### PR TITLE
Enable metal4-pitch snapping on TritonMP / Minor bug fixes on RePlAce

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,9 +18,6 @@
 	path = src/opendp
 	url = https://github.com/The-OpenROAD-Project/OpenDP.git
 	branch = openroad
-[submodule "src/OpenPhySyn"]
-	path = src/OpenPhySyn
-	url = https://github.com/The-OpenROAD-Project/OpenPhySyn
 [submodule "src/FastRoute"]
 	path = src/FastRoute
 	url = https://github.com/The-OpenROAD-Project/FastRoute.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/The-OpenROAD-Project/OpenDB.git
 [submodule "flute3"]
 	path = src/flute3
-	url = https://github.com/The-OpenROAD-Project/flute3
+	url = https://github.com/The-OpenROAD-Project/flute3.git
 [submodule "src/replace"]
 	path = src/replace
 	url = https://github.com/The-OpenROAD-Project/RePlAce.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 
 cmake_minimum_required (VERSION 3.9)
 
-project(OpenROAD VERSION 1.0.0)
+project(OpenROAD VERSION 1.0.1)
 
 set(OPENROAD_HOME ${PROJECT_SOURCE_DIR})
 

--- a/README.md
+++ b/README.md
@@ -316,13 +316,3 @@ Options description:
 
 ###### NOTE 1: if you set unidirectionalRoute as "true", the minimum routing layer will be assigned as "2" automatically
 ###### NOTE 2: the first routing layer of the design have index equal to 1
-
-#### Physical Synthesis Optimization [optional]
-
-You can optionally run OpenPhySyn timing optimization commands (currently only performs load driven gate-cloning and pin-swapping).
-
-```
-psn::set_wire_rc 0.0020 0.00020
-optimize_design [-no_gate_clone] [-no_pin_swap] [-clone_max_cap_factor factor] [-clone_non_largest_cells]
-optimize_fanout -buffer_cell buffer_cell_name -max_fanout max_fanout # Adds buffer cells based on sink pin count
-```

--- a/README.md
+++ b/README.md
@@ -265,9 +265,8 @@ global_placement
     [-timing_driven]
     [-bin_grid_count grid_count]
 ```
-
--timing_driven Enable timing-driven mode
-grid_count [64,128,256,512,..., int]. Default: Defined by internal algorithm.
+- **timing_driven**: Enable timing-driven mode
+- **grid_count**: [64,128,256,512,..., int]. Default: Defined by internal algorithm.
 
 Use the `set_wire_rc` command to set resistance and capacitance of
 estimated wires used for timing.

--- a/include/openroad/OpenRoad.hh
+++ b/include/openroad/OpenRoad.hh
@@ -114,7 +114,6 @@ private:
   MacroPlace::TritonMacroPlace *tritonMp_;
   pdngen::PdnGen *pdngen_;
   FastRoute::FastRouteKernel *fastRoute_;
-  psn::Psn *psn_;
   TritonCTS::TritonCTSKernel *tritonCts_;
   tapcell::Tapcell *tapcell_;
 

--- a/jenkins/test.sh
+++ b/jenkins/test.sh
@@ -8,5 +8,4 @@ docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/ope
 docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/openroad bash -c "/OpenROAD/src/TritonMacroPlace/test/regression fast"
 docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/openroad bash -c "cd /OpenROAD/src/replace/test && python3 regression.py run openroad"
 docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/openroad bash -c "cd /OpenROAD && cp etc/PO* . && tclsh ./src/FastRoute/tests/run_all.tcl"
-docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/openroad bash -c "cd /OpenROAD/src/OpenPhySyn/tests && PSN_TRANSFORM_PATH=../../../build/transforms ../../../build/src/OpenPhySyn/unit_tests"
 docker run -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd):/OpenROAD openroad/openroad bash -c "cd /OpenROAD && ./src/ioPlacer/tests/run_all.sh ./build/src/openroad ./src/ioPlacer/tests/"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,8 +33,6 @@ set(TAPCELL_HOME ${OPENROAD_HOME}/src/tapcell)
 
 set(MPLACE_HOME ${PROJECT_SOURCE_DIR}/src/TritonMacroPlace)
 
-set(OPENPHYSYN_HOME ${PROJECT_SOURCE_DIR}/src/OpenPhySyn)
-
 set(OPENROAD_WRAP ${CMAKE_CURRENT_BINARY_DIR}/OpenRoad_wrap.cc)
 set(OPENROAD_TCL_INIT ${CMAKE_CURRENT_BINARY_DIR}/OpenRoadTclInitVar.cc)
 
@@ -132,7 +130,6 @@ add_subdirectory(ioPlacer)
 add_subdirectory(pdngen)
 add_subdirectory(TritonCTS)
 add_subdirectory(FastRoute)
-add_subdirectory(OpenPhySyn)
 add_subdirectory(tapcell)
 add_subdirectory(TritonMacroPlace)
 
@@ -150,7 +147,6 @@ target_include_directories(openroad
   ${OPENDP_HOME}/include
   ${MPLACE_HOME}/include
   ${FASTROUTE_HOME}/include
-  ${OPENPHYSYN_HOME}/include
   flute3
   ${PDNGEN_HOME}/include
   ${TAPCELL_HOME}/include
@@ -174,8 +170,6 @@ target_link_libraries(openroad
   TritonMacroPlace 
   ParquetFP
   ABKCommon 
-  OpenPhySyn
-  zutil 
   zlib 
   tm
   defin

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -28,18 +28,13 @@
 #include "openroad/InitOpenRoad.hh"
 #include "InitFlute.hh"
 
-
 #include "ioPlacer/src/MakeIoplacer.h"
 #include "resizer/MakeResizer.hh"
 #include "opendp/MakeOpendp.h"
 #include "tritonmp/MakeTritonMp.h"
 #include "replace/src/MakeReplace.h"
 #include "pdngen/MakePdnGen.hh"
-
 #include "FastRoute/src/MakeFastRoute.h"
-
-#include "OpenPhySyn/OpenROAD/MakeOpenPhySyn.hpp"
-
 #include "TritonCTS/src/MakeTritoncts.h"
 #include "tapcell/MakeTapcell.h"
 
@@ -75,7 +70,6 @@ OpenRoad::~OpenRoad()
   deleteDbSta(sta_);
   deleteResizer(resizer_);
   deleteOpendp(opendp_);
-  deletePsn(psn_);
   odb::dbDatabase::destroy(db_);
 }
 
@@ -110,7 +104,6 @@ OpenRoad::init(Tcl_Interp *tcl_interp,
   opendp_ = makeOpendp();
   pdngen_ = makePdnGen();
   fastRoute_ = (FastRoute::FastRouteKernel*) makeFastRoute();
-  psn_ = makePsn();
 
   tritonCts_ = makeTritonCts();
   tapcell_ = makeTapcell();
@@ -131,7 +124,6 @@ OpenRoad::init(Tcl_Interp *tcl_interp,
   initOpendp(this);
   initPdnGen(this);
   initFastRoute(this);
-  initPsn(this);
   initTritonCts(this);
   initTapcell(this);
   initTritonMp(this);


### PR DESCRIPTION
1) Enable macroPlace snapping on Metal4 pitch
2) Fix Negative HPWL errors
3) Fix bugs on regression scripts.