### PR TITLE
Blockages section in pdn macro grid specification

### DIFF
--- a/src/pdngen/src/PdnGen.tcl
+++ b/src/pdngen/src/PdnGen.tcl
@@ -1882,10 +1882,10 @@ proc get_macro_blockage_layers {instance} {
   variable metal_layers
   
   set specification [select_instance_specification $instance]
-  if {[dict exists $specification blockage]} {
-    return [dict get $specification blockage]
+  if {[dict exists $specification blockages]} {
+    return [dict get $specification blockages]
   }
-  return [lrange $metal_layers 0 3]
+  return $metal_layers
 }
 
 proc print_layer_details {layer_name layer indent} {


### PR DESCRIPTION
Hello,

I assume that the intended section name in the specification is "blockages" since it's on all of the test cases. I have also changed the default behavior when the section isn't specified to block all layers instead of arbitrarily blocking the first 4 layers, which I find more logical.
I have done these changes on master initially since I was using it, but I thought it would be more useful to issue the PR against this branch; please let me know if I was wrong.

Thanks!