### PR TITLE
Add pdnsim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,7 @@
 [submodule "src/OpenRCX"]
 	path = src/OpenRCX
 	url = https://github.com/The-OpenROAD-Project/OpenRCX.git
+[submodule "src/PDNSim"]
+	path = src/PDNSim
+	url = https://github.com/The-OpenROAD-Project/PDNSim.git
+	branch = openroad

--- a/include/openroad/OpenRoad.hh
+++ b/include/openroad/OpenRoad.hh
@@ -64,6 +64,10 @@ namespace OpenRCX {
 class Ext;
 }
 
+namespace pdnsim {
+class PDNSim;
+}
+
 namespace ord {
 
 using std::string;
@@ -92,6 +96,7 @@ public:
   MacroPlace::TritonMacroPlace *getTritonMp() { return tritonMp_; }
   OpenRCX::Ext *getOpenRCX() { return extractor_; }
   replace::Replace* getReplace() { return replace_; }
+  pdnsim::PDNSim* getPDNSim() { return pdnsim_; }
   // Return the bounding box of the db rows.
   odb::adsRect getCore();
   // Return true if the command units have been initialized.
@@ -131,6 +136,7 @@ private:
   tapcell::Tapcell *tapcell_;
   OpenRCX::Ext *extractor_;
   replace::Replace *replace_;
+  pdnsim::PDNSim *pdnsim_; 
 
   // Singleton used by tcl command interpreter.
   static OpenRoad *openroad_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,7 @@ set(FASTROUTE_HOME ${PROJECT_SOURCE_DIR}/src/FastRoute)
 set(TAPCELL_HOME ${OPENROAD_HOME}/src/tapcell)
 set(OPENRCX_HOME ${OPENROAD_HOME}/src/OpenRCX)
 set(MPLACE_HOME ${PROJECT_SOURCE_DIR}/src/TritonMacroPlace)
+set(PDNSIM_HOME ${PROJECT_SOURCE_DIR}/src/PDNSim)
 
 set(OPENROAD_TCL_INIT ${CMAKE_CURRENT_BINARY_DIR}/OpenRoadTclInitVar.cc)
 
@@ -210,6 +211,7 @@ add_subdirectory(FastRoute)
 add_subdirectory(tapcell)
 add_subdirectory(TritonMacroPlace)
 add_subdirectory(OpenRCX)
+add_subdirectory(PDNSim)
 
 ################################################################
 
@@ -238,6 +240,7 @@ target_include_directories(openroad
   ${PDNGEN_HOME}/include
   ${TAPCELL_HOME}/include
   ${OPENRCX_HOME}/include
+  ${PDNSIM_HOME}/include
   ${TCL_INCLUDE_PATH}
   ${Boost_INCLUDE_DIRS}
   )
@@ -261,6 +264,7 @@ target_link_libraries(openroad
   TritonMacroPlace
   ParquetFP
   ABKCommon
+  pdnsim
   zlib
   tm
   defin

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -40,6 +40,7 @@
 #include "TritonCTS/src/MakeTritoncts.h"
 #include "tapcell/MakeTapcell.h"
 #include "OpenRCX/MakeOpenRCX.h"
+#include "pdnsim/MakePDNSim.hh"
 
 namespace sta {
 extern const char *openroad_tcl_inits[];
@@ -112,6 +113,7 @@ OpenRoad::init(Tcl_Interp *tcl_interp)
   tritonMp_ = makeTritonMp();
   extractor_ = makeOpenRCX();
   replace_ = makeReplace();
+  pdnsim_ = makePDNSim();
 
   // Init components.
   Openroad_Init(tcl_interp);
@@ -132,6 +134,7 @@ OpenRoad::init(Tcl_Interp *tcl_interp)
   initTapcell(this);
   initTritonMp(this);
   initOpenRCX(this);
+  initPDNSim(this);
   
   // Import exported commands to global namespace.
   Tcl_Eval(tcl_interp, "sta::define_sta_cmds");

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -121,6 +121,13 @@ getOpenRCX()
   return openroad->getOpenRCX();
 }
 
+pdnsim::PDNSim*
+getPDNSim()
+{
+  OpenRoad *openroad = getOpenRoad();
+  return openroad->getPDNSim();
+}
+
 } // namespace
 
 using ord::OpenRoad;

--- a/test/regression
+++ b/test/regression
@@ -37,6 +37,7 @@ set tool_scripts {"InitFloorplan" "src/init_fp/test/regression" \
 		    "OpenDP" "src/opendp/test/regression" \
 		    "FastRoute" "src/FastRoute/test/regression" \
 		    "TapCell" "src/tapcell/test/regression" \
+		    "PDNSim" "src/PDNSim/test/regression" \
 		  }
 
 foreach tool $argv {


### PR DESCRIPTION
This adds an analyze_power_grid facility to OpenROAD. External dependency on a voltage source location file and a default resistance configuration file for via resistance and per-unit R.
