### PR TITLE
FastRoute enhancements and tapcell fix

### DIFF
--- a/src/tapcell/test/src/check_cells_inserted/run.sh
+++ b/src/tapcell/test/src/check_cells_inserted/run.sh
@@ -46,7 +46,7 @@ fi
 binary=$1
 testdir=$2
 
-$binary -no-init < run.tcl > test.log 2>&1
+$binary -no_init < run.tcl > test.log 2>&1
 
 obs_report0=$(grep -e '---- #Endcaps inserted:' ./test.log)
 obs_report1=$(grep -e '---- #Endcaps inserted:' ./test.log)

--- a/src/tapcell/test/src/check_cut_rows/run.sh
+++ b/src/tapcell/test/src/check_cut_rows/run.sh
@@ -46,7 +46,7 @@ fi
 binary=$1
 testdir=$2
 
-$binary -no-init < run.tcl > test.log 2>&1
+$binary -no_init < run.tcl > test.log 2>&1
 
 obs_report=$(grep -e '---- #Cut rows:' ./test.log)
 

--- a/src/tapcell/test/src/check_macros/run.sh
+++ b/src/tapcell/test/src/check_macros/run.sh
@@ -46,7 +46,7 @@ fi
 binary=$1
 testdir=$2
 
-$binary -no-init < run.tcl > test.log 2>&1
+$binary -no_init < run.tcl > test.log 2>&1
 
 obs_report=$(grep -e '---- Macro blocks found:' ./test.log)
 


### PR DESCRIPTION
Updates:
- FastRoute reads wires from nets and special nets when computing obstacles
- FastRoute creates global routing grid considering die area
- tapcell unit tests use "-no_init" option when they call openroad