### PR TITLE
Fix bug when trying to reference pwr/gnd pads to connect to core rings

### DIFF
--- a/src/pdngen/src/PdnGen.tcl
+++ b/src/pdngen/src/PdnGen.tcl
@@ -2613,7 +2613,7 @@ proc get_quadrant {x y} {
     }
   } else {
     # Bottom or right
-    if {)$dw * $test_y) + ($dh * $test_x) > ($dw * $dh)} {
+    if {($dw * $test_y) + ($dh * $test_x) > ($dw * $dh)} {
       # Top or right
       return "r"
     } else {

--- a/src/pdngen/test/regression_vars.tcl
+++ b/src/pdngen/test/regression_vars.tcl
@@ -132,7 +132,6 @@ soc_bsg_black_parrot_nangate45
 # Medium speed tests.
 # run time <15s with optimized compile
 define_test_group med {
-soc_bsg_black_parrot_nangate45
 }
 
 define_test_group slow {

--- a/src/pdngen/test/soc_bsg_black_parrot_nangate45/PDN.cfg
+++ b/src/pdngen/test/soc_bsg_black_parrot_nangate45/PDN.cfg
@@ -17,13 +17,17 @@ set ::ground_nets "VSS"
 
 pdngen::specify_grid stdcell {
   name grid
-  rails {
-    metal1 {width 0.17 pitch  2.4 offset 0}
-  }
+
+  pwr_pads {PADCELL_VDD_V PADCELL_VDD_H}
+  gnd_pads {PADCELL_VSS_V PADCELL_VSS_H}
+
   core_ring {
     metal9  {width 5.0 spacing 2.0 core_offset 4.5}
     metal10 {width 5.0 spacing 2.0 core_offset 4.5}
   }                                           
+  rails {
+    metal1 {width 0.17 pitch  2.4 offset 0}
+  }
   straps {
     metal4 {width 0.48 pitch 56.0 offset 2}
     metal7 {width 1.40 pitch 40.0 offset 2}


### PR DESCRIPTION
Fixed issue when trying to connect power pads into the core rings
Ensure that the soc level unit test is always run.