### PR TITLE
[TritonCTS] Updated the clock_tree_synthesis command

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,8 @@ The first is if the user does not have a characterization file. Thus, the wire s
 
 ```
 clock_tree_synthesis -buf_list <list_of_buffers> \
-                     -sqr_cap <cap_per_sqr> \
-                     -sqr_res <res_per_sqr> \
+                     [-sqr_cap <cap_per_sqr>] \
+                     [-sqr_res <res_per_sqr>] \
                      [-root_buf <root_buf>] \
                      [-max_slew <max_slew>] \
                      [-max_cap <max_cap>] \
@@ -427,8 +427,10 @@ clock_tree_synthesis -buf_list <list_of_buffers> \
 ```
 
 - ```buf_list``` (mandatory) are the master cells (buffers) that will be considered when making the wire segments.
-- ``sqr_cap`` (mandatory) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``sqr_cap`` (optional) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+If this parameter is omitted, the code tries to get the parasitic values from the DB.
+- ``sqr_res`` (optional) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+If this parameter is omitted, the code tries to get the parasitic values from the DB.
 - ``root_buffer`` (optional) is the master cell of the buffer that serves as root for the clock tree. 
 If this parameter is omitted, the first master cell from ```buf_list``` is taken.
 - ``max_slew`` (optional) is the max slew value (in seconds) that the characterization will test. 

--- a/src/TritonCTS/README.md
+++ b/src/TritonCTS/README.md
@@ -32,8 +32,10 @@ write_def "final.def"
 ```
 Argument description:
 - ```buf_list``` (mandatory) are the master cells (buffers) that will be considered when making the wire segments.
-- ``sqr_cap`` (mandatory) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``sqr_cap`` (optional) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+If this parameter is omitted, the code tries to get the parasitic values from the DB.
+- ``sqr_res`` (optional) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+If this parameter is omitted, the code tries to get the parasitic values from the DB.
 - ``root_buffer`` (optional) is the master cell of the buffer that serves as root for the clock tree. 
 If this parameter is omitted, the first master cell from ```buf_list``` is taken.
 - ``max_slew`` (optional) is the max slew value (in seconds) that the characterization will test. 

--- a/src/TritonCTS/src/tritoncts.tcl
+++ b/src/TritonCTS/src/tritoncts.tcl
@@ -65,7 +65,7 @@ proc clock_tree_synthesis { args } {
   #Clock Tree Synthesis TCL -> Required commands:
   #                               -lut_file , -sol_list , -root-buf, -wire_unit
   #                                               or
-  #                               -buf_list , -sqr_cap , -sqr_res
+  #                               -buf_list
   #                         -> Other commands can be used as extra parameters or in conjunction with each other:
   #                               ex: clock_tree_synthesis -buf_list "BUFX1 BUFX2" -wire_unit 20 -sqr_cap 1 -sqr_res 2 -clk_nets clk1
 
@@ -151,10 +151,6 @@ proc clock_tree_synthesis { args } {
       $cts set_cap_per_sqr $sqr_cap
       set sqr_res $keys(-sqr_res)
       $cts set_res_per_sqr $sqr_res
-    } else {
-      #User must enter capacitance and resistance per square (um²) when creating a new characterization.
-      puts "Missing argument -sqr_cap and/or -sqr_res"
-      exit
     }
   }
 


### PR DESCRIPTION
Now works without supplying res_sqr or cap_sqr. It uses the values from the DB instead. Also sets a default max_cap and max_slew based on the slew_inter and cap_inter.