### PR TITLE
[TritonCTS] Interface, New command, and Error Handling Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ clock_tree_synthesis -lut_file <lut_file> \
                      [-wire_unit <wire_unit>] \
                      [-clk_nets <list_of_clk_nets>] 
 ```
+
 - ```lut_file``` (mandatory) is the file containing delay, power and other metrics for each segment.
 - ``sol_list`` (mandatory) is the file containing the information on the topology of each segment (wirelengths and buffer masters).
 - ``sqr_res`` (mandatory) is the resistance (in ohm) per database units to be used in the wire segments. 
@@ -523,6 +524,29 @@ If this parameter is omitted, you can use the ```buf_list``` argument, using the
 If this parameter is omitted, the code gets the value from the header of the ```lut_file```. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
 - ``clk_nets`` (optional) is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
+
+Another command available from TritonCTS is ``report_cts``. It is used to extract metrics after a successful ``clock_tree_synthesis`` run. These are: Number of Clock Roots, Number of Buffers Inserted, Number of Clock Subnets, and Number of Sinks.
+
+```
+read_lef "mylef.lef"
+read_liberty "myliberty.lib"
+read_def "mydef.def"
+read_verilog "myverilog.v"
+read_sdc "mysdc.sdc"
+
+report_checks
+
+clock_tree_synthesis -lut_file "lut.txt" \
+                     -sol_list "sol_list.txt" \
+                     -root_buf "BUF_X4" \
+                     -wire_unit 20 
+
+report_cts [-out_file "file.txt"]
+```
+
+- ```out_file``` (optional) is the file containing the TritonCTS reports.
+If this parameter is omitted, the metrics are shown on the standard output.
+
 
 #### Global Routing
 

--- a/README.md
+++ b/README.md
@@ -482,28 +482,28 @@ clock_tree_synthesis -buf_list <list_of_buffers> \
                      [-wire_unit <wire_unit>] \
                      [-clk_nets <list_of_clk_nets>] \
                      [-out_path <lut_path>] \
-                     [-only_characterization <enable>]
+                     [-characterization_only]
 ```
 
-- ```buf_list``` (mandatory) are the master cells (buffers) that will be considered when making the wire segments.
-- ``sqr_cap`` (mandatory) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``root_buffer`` (optional) is the master cell of the buffer that serves as root for the clock tree. 
-If this parameter is omitted, the first master cell from ```buf_list``` is taken.
-- ``max_slew`` (optional) is the max slew value (in seconds) that the characterization will test. 
+- ``-buf_list`` are the master cells (buffers) that will be considered when making the wire segments.
+- ``-sqr_cap`` is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``-sqr_res`` is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``root_buffer`` is the master cell of the buffer that serves as root for the clock tree. 
+If this parameter is omitted, the first master cell from ``-buf_list`` is taken.
+- ``-max_slew`` is the max slew value (in seconds) that the characterization will test. 
 If this parameter is omitted, the code tries to obtain the value from the liberty file.
-- ``max_cap`` (optional) is the max capacitance value (in farad) that the characterization will test. 
+- ``-max_cap`` is the max capacitance value (in farad) that the characterization will test. 
 If this parameter is omitted, the code tries to obtain the value from the liberty file.
-- ``slew_inter`` (optional) is the time value (in seconds) that the characterization will consider for results. 
+- ``-slew_inter`` is the time value (in seconds) that the characterization will consider for results. 
 If this parameter is omitted, the code gets the default value (5.0e-12). Be careful that this value can be quite low for bigger technologies (>65nm).
-- ``cap_inter`` (optional) is the capacitance value (in farad) that the characterization will consider for results. 
+- ``-cap_inter`` is the capacitance value (in farad) that the characterization will consider for results. 
 If this parameter is omitted, the code gets the default value (5.0e-15). Be careful that this value can be quite low for bigger technologies (>65nm).
-- ``wire_unit`` (optional) is the minimum unit distance between buffers for a specific wire. 
-If this parameter is omitted, the code gets the value from ten times the height of ``root_buffer``.
-- ``clk_nets`` (optional) is a string containing the names of the clock roots. 
+- ``-wire_unit`` is the minimum unit distance between buffers for a specific wire. 
+If this parameter is omitted, the code gets the value from ten times the height of ``-root_buffer``.
+- ``-clk_nets`` is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
-- ``out_path`` (optional) is the output path (full) that the lut.txt and sol_list.txt files will be saved. This is used to load an existing characterization, without creating one from scratch.
-- ``only_characterization`` (optional), if true, makes so that the code exits after running the characterization.
+- ``-out_path`` is the output path (full) that the lut.txt and sol_list.txt files will be saved. This is used to load an existing characterization, without creating one from scratch.
+- ``-only_characterization`` is a flag that, when specified, makes so that only the library characterization step is run and no clock tree is inserted in the design.
 
 Instead of creating a characterization, you can use use the following parameters to load a characterization file.
 
@@ -515,14 +515,14 @@ clock_tree_synthesis -lut_file <lut_file> \
                      [-clk_nets <list_of_clk_nets>] 
 ```
 
-- ```lut_file``` (mandatory) is the file containing delay, power and other metrics for each segment.
-- ``sol_list`` (mandatory) is the file containing the information on the topology of each segment (wirelengths and buffer masters).
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per database units to be used in the wire segments. 
-- ``root_buffer`` (mandatory) is the master cell of the buffer that serves as root for the clock tree. 
-If this parameter is omitted, you can use the ```buf_list``` argument, using the first master cell. If both arguments are omitted, an error is raised.
-- ``wire_unit`` (optional) is the minimum unit distance between buffers for a specific wire, based on your ```lut_file```. 
-If this parameter is omitted, the code gets the value from the header of the ```lut_file```. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
-- ``clk_nets`` (optional) is a string containing the names of the clock roots. 
+- ``-lut_file`` (mandatory) is the file containing delay, power and other metrics for each segment.
+- ``-sol_list`` (mandatory) is the file containing the information on the topology of each segment (wirelengths and buffer masters).
+- ``-sqr_res`` (mandatory) is the resistance (in ohm) per database units to be used in the wire segments. 
+- ``-root_buffer`` (mandatory) is the master cell of the buffer that serves as root for the clock tree. 
+If this parameter is omitted, you can use the ``-buf_list`` argument, using the first master cell. If both arguments are omitted, an error is raised.
+- ``-wire_unit`` (optional) is the minimum unit distance between buffers for a specific wire, based on your ``-lut_file``. 
+If this parameter is omitted, the code gets the value from the header of the ``-lut_file``. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
+- ``-clk_nets`` (optional) is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
 
 Another command available from TritonCTS is ``report_cts``. It is used to extract metrics after a successful ``clock_tree_synthesis`` run. These are: Number of Clock Roots, Number of Buffers Inserted, Number of Clock Subnets, and Number of Sinks.
@@ -544,7 +544,7 @@ clock_tree_synthesis -lut_file "lut.txt" \
 report_cts [-out_file "file.txt"]
 ```
 
-- ```out_file``` (optional) is the file containing the TritonCTS reports.
+- ``-out_file`` (optional) is the file containing the TritonCTS reports.
 If this parameter is omitted, the metrics are shown on the standard output.
 
 

--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ clock_tree_synthesis -buf_list <list_of_buffers> \
 - ``-buf_list`` are the master cells (buffers) that will be considered when making the wire segments.
 - ``-sqr_cap`` is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
 - ``-sqr_res`` is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``root_buffer`` is the master cell of the buffer that serves as root for the clock tree. 
+- ``-root_buffer`` is the master cell of the buffer that serves as root for the clock tree. 
 If this parameter is omitted, the first master cell from ``-buf_list`` is taken.
 - ``-max_slew`` is the max slew value (in seconds) that the characterization will test. 
 If this parameter is omitted, the code tries to obtain the value from the liberty file.

--- a/src/TritonCTS/CMakeLists.txt
+++ b/src/TritonCTS/CMakeLists.txt
@@ -17,6 +17,7 @@ add_custom_command(OUTPUT ${TRITONCTS_WRAP}
         DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/src/TritonCTSKernelTcl.i
         ${CMAKE_CURRENT_SOURCE_DIR}/src/TritonCTSKernel.h
+        ${OPENROAD_HOME}/src/Exception.i
 )
 
 set(TRITONCTS_TCL_INIT ${CMAKE_CURRENT_BINARY_DIR}/TritonCtsTclInitVar.cc)

--- a/src/TritonCTS/README.md
+++ b/src/TritonCTS/README.md
@@ -26,7 +26,7 @@ clock_tree_synthesis -buf_list "BUF_X1 BUF_X2" \
                      -wire_unit 20 \
                      -clk_nets "clk" \
                      -out_path "/home/myfolder/" \
-                     -only_characterization 0
+                     -characterization_only 1
 
 write_def "final.def"
 ```
@@ -49,7 +49,7 @@ If this parameter is omitted, the code gets the value from ten times the height 
 - ``clk_nets`` (optional) is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
 - ``out_path`` (optional) is the output path (full) that the lut.txt and sol_list.txt files will be saved. This is used to load an existing characterization, without creating one from scratch.
-- ``only_characterization`` (optional), if true, makes so that the code exits after running the characterization.
+- ``characterization_only`` (optional), if true, makes so that the code exits after running and checking the characterization.
 
 Instead of creating a characterization, you can use the following tcl snippet to call TritonCTS and load the characterization file..
 
@@ -80,6 +80,30 @@ If this parameter is omitted, you can use the ```buf_list``` argument, using the
 If this parameter is omitted, the code gets the value from the header of the ```lut_file```. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
 - ``clk_nets`` (optional) is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
+
+Another command available from TritonCTS is ``report_cts``. It is used to extract metrics after a successful ``clock_tree_synthesis`` run. These are: Number of Clock Roots, Number of Buffers Inserted, Number of Clock Subnets, and Number of Sinks.
+The following tcl snippet shows how to call ``report_cts``.
+
+```
+read_lef "mylef.lef"
+read_liberty "myliberty.lib"
+read_def "mydef.def"
+read_verilog "myverilog.v"
+read_sdc "mysdc.sdc"
+
+report_checks
+
+clock_tree_synthesis -lut_file "lut.txt" \
+                     -sol_list "sol_list.txt" \
+                     -root_buf "BUF_X4" \
+                     -wire_unit 20 
+
+report_cts -out_file "file.txt"
+```
+
+Argument description:
+- ```out_file``` (optional) is the file containing the TritonCTS reports.
+If this parameter is omitted, the metrics are shown on the standard output.
 
 ### Third party packages
 [LEMON](https://lemon.cs.elte.hu/trac/lemon) - **L**ibrary for **E**fficient **M**odeling and **O**ptimization in **N**etworks

--- a/src/TritonCTS/README.md
+++ b/src/TritonCTS/README.md
@@ -15,41 +15,41 @@ read_sdc "mysdc.sdc"
 
 report_checks
 
-clock_tree_synthesis -buf_list "BUF_X1 BUF_X2" \
-                     -sqr_cap 3.5e-20 \
-                     -sqr_res 2.0e-4 \
-                     -root_buf "BUF_X4" \
-                     -max_slew 50.0e-12 \
-                     -max_cap 150.0e-15 \
-                     -slew_inter 1.0e-12 \
-                     -cap_inter 1.0e-15 \
-                     -wire_unit 20 \
-                     -clk_nets "clk" \
-                     -out_path "/home/myfolder/" \
-                     -characterization_only 1
+clock_tree_synthesis -buf_list <list_of_buffers> \
+                     -sqr_cap <cap_per_sqr> \
+                     -sqr_res <res_per_sqr> \
+                     [-root_buf <root_buf>] \
+                     [-max_slew <max_slew>] \
+                     [-max_cap <max_cap>] \
+                     [-slew_inter <slew_inter>] \
+                     [-cap_inter <cap_inter>] \
+                     [-wire_unit <wire_unit>] \
+                     [-clk_nets <list_of_clk_nets>] \
+                     [-out_path <lut_path>] \
+                     [-characterization_only]
 
 write_def "final.def"
 ```
 Argument description:
-- ```buf_list``` (mandatory) are the master cells (buffers) that will be considered when making the wire segments.
-- ``sqr_cap`` (mandatory) is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
-- ``root_buffer`` (optional) is the master cell of the buffer that serves as root for the clock tree. 
-If this parameter is omitted, the first master cell from ```buf_list``` is taken.
-- ``max_slew`` (optional) is the max slew value (in seconds) that the characterization will test. 
+- ``-buf_list`` are the master cells (buffers) that will be considered when making the wire segments.
+- ``-sqr_cap`` is the capacitance (in picofarad) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``-sqr_res`` is the resistance (in ohm) per micrometer (thus, the same unit that is used in the LEF syntax) to be used in the wire segments. 
+- ``-root_buffer`` is the master cell of the buffer that serves as root for the clock tree. 
+If this parameter is omitted, the first master cell from ``-buf_list`` is taken.
+- ``-max_slew`` is the max slew value (in seconds) that the characterization will test. 
 If this parameter is omitted, the code tries to obtain the value from the liberty file.
-- ``max_cap`` (optional) is the max capacitance value (in farad) that the characterization will test. 
+- ``-max_cap`` is the max capacitance value (in farad) that the characterization will test. 
 If this parameter is omitted, the code tries to obtain the value from the liberty file.
-- ``slew_inter`` (optional) is the time value (in seconds) that the characterization will consider for results. 
+- ``-slew_inter`` is the time value (in seconds) that the characterization will consider for results. 
 If this parameter is omitted, the code gets the default value (5.0e-12). Be careful that this value can be quite low for bigger technologies (>65nm).
-- ``cap_inter`` (optional) is the capacitance value (in farad) that the characterization will consider for results. 
+- ``-cap_inter`` is the capacitance value (in farad) that the characterization will consider for results. 
 If this parameter is omitted, the code gets the default value (5.0e-15). Be careful that this value can be quite low for bigger technologies (>65nm).
-- ``wire_unit`` (optional) is the minimum unit distance between buffers for a specific wire. 
-If this parameter is omitted, the code gets the value from ten times the height of ``root_buffer``.
-- ``clk_nets`` (optional) is a string containing the names of the clock roots. 
+- ``-wire_unit`` is the minimum unit distance between buffers for a specific wire. 
+If this parameter is omitted, the code gets the value from ten times the height of ``-root_buffer``.
+- ``-clk_nets`` is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
-- ``out_path`` (optional) is the output path (full) that the lut.txt and sol_list.txt files will be saved. This is used to load an existing characterization, without creating one from scratch.
-- ``characterization_only`` (optional), if true, makes so that the code exits after running and checking the characterization.
+- ``-out_path`` is the output path (full) that the lut.txt and sol_list.txt files will be saved. This is used to load an existing characterization, without creating one from scratch.
+- ``-characterization_only`` is a flag that, when specified, makes so that only the library characterization step is run and no clock tree is inserted in the design.
 
 Instead of creating a characterization, you can use the following tcl snippet to call TritonCTS and load the characterization file..
 
@@ -62,23 +62,23 @@ read_sdc "mysdc.sdc"
 
 report_checks
 
-clock_tree_synthesis -lut_file "lut.txt" \
-                     -sol_list "sol_list.txt" \
-                     -root_buf "BUF_X4" \
-                     -wire_unit 20 \
-                     -clk_nets "clk" 
+clock_tree_synthesis -lut_file <lut_file> \
+                     -sol_list <sol_list_file> \
+                     -root_buf <root_buf> \
+                     [-wire_unit <wire_unit>] \
+                     [-clk_nets <list_of_clk_nets>] 
 
 write_def "final.def"
 ```
 Argument description:
-- ```lut_file``` (mandatory) is the file containing delay, power and other metrics for each segment.
-- ``sol_list`` (mandatory) is the file containing the information on the topology of each segment (wirelengths and buffer masters).
-- ``sqr_res`` (mandatory) is the resistance (in ohm) per database units to be used in the wire segments. 
-- ``root_buffer`` (mandatory) is the master cell of the buffer that serves as root for the clock tree. 
-If this parameter is omitted, you can use the ```buf_list``` argument, using the first master cell. If both arguments are omitted, an error is raised.
-- ``wire_unit`` (optional) is the minimum unit distance between buffers for a specific wire, based on your ```lut_file```. 
-If this parameter is omitted, the code gets the value from the header of the ```lut_file```. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
-- ``clk_nets`` (optional) is a string containing the names of the clock roots. 
+- ``-lut_file`` is the file containing delay, power and other metrics for each segment.
+- ``-sol_list`` is the file containing the information on the topology of each segment (wirelengths and buffer masters).
+- ``-sqr_res`` is the resistance (in ohm) per database units to be used in the wire segments. 
+- ``-root_buffer`` is the master cell of the buffer that serves as root for the clock tree. 
+If this parameter is omitted, you can use the ``-buf_list`` argument, using the first master cell. If both arguments are omitted, an error is raised.
+- ``-wire_unit`` is the minimum unit distance between buffers for a specific wire, based on your ``-lut_file``. 
+If this parameter is omitted, the code gets the value from the header of the ``-lut_file``. For the old technology characterization, described [here](https://github.com/The-OpenROAD-Project/TritonCTS/blob/master/doc/Technology_characterization.md), this argument is mandatory, and omitting it raises an error.
+- ``-clk_nets`` is a string containing the names of the clock roots. 
 If this parameter is omitted, TritonCTS looks for the clock roots automatically.
 
 Another command available from TritonCTS is ``report_cts``. It is used to extract metrics after a successful ``clock_tree_synthesis`` run. These are: Number of Clock Roots, Number of Buffers Inserted, Number of Clock Subnets, and Number of Sinks.
@@ -98,11 +98,11 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -root_buf "BUF_X4" \
                      -wire_unit 20 
 
-report_cts -out_file "file.txt"
+report_cts [-out_file "file.txt"]
 ```
 
 Argument description:
-- ```out_file``` (optional) is the file containing the TritonCTS reports.
+- ``-out_file`` is the file containing the TritonCTS reports.
 If this parameter is omitted, the metrics are shown on the standard output.
 
 ### Third party packages

--- a/src/TritonCTS/src/CtsOptions.h
+++ b/src/TritonCTS/src/CtsOptions.h
@@ -120,13 +120,13 @@ public:
         void setMetricsFile(const std::string& metricFile) { _metricFile = metricFile; }
         std::string getMetricsFile() const { return _metricFile; } 
         void setNumClockRoots(unsigned roots) { _clockRoots = roots; }
-        unsigned getNumClockRoots() const { return _clockRoots; }
-        void setNumClockSubnets(unsigned nets) { _clockSubnets = nets; }
-        unsigned getNumClockSubnets() const { return _clockSubnets; }
-        void setNumBuffersInserted(unsigned buffers) { _buffersInserted = buffers; }
-        unsigned getNumBuffersInserted() const { return _buffersInserted; }
-        void setNumSinks(unsigned sinks) { _sinks = sinks; }
-        unsigned getNumSinks() const { return _sinks; }
+        long int getNumClockRoots() const { return _clockRoots; }
+        void setNumClockSubnets(long int nets) { _clockSubnets = nets; }
+        long int getNumClockSubnets() const { return _clockSubnets; }
+        void setNumBuffersInserted(long int buffers) { _buffersInserted = buffers; }
+        long int getNumBuffersInserted() const { return _buffersInserted; }
+        void setNumSinks(long int sinks) { _sinks = sinks; }
+        long int getNumSinks() const { return _sinks; }
                 
 private:
         std::string _blockName                  = "";
@@ -158,12 +158,10 @@ private:
         bool        _writeOnlyClockNets         = false;
         bool        _runPostCtsOpt              = true;
         double      _bufDistRatio               = 0.1;
-
-        unsigned    _clockRoots                 = 0;
-        unsigned    _clockSubnets               = 0;
-        unsigned    _buffersInserted            = 0;
-        unsigned    _sinks                      = 0;
-        
+        long int    _clockRoots                 = 0;
+        long int    _clockSubnets               = 0;
+        long int    _buffersInserted            = 0;
+        long int    _sinks                      = 0;
         std::vector<std::string> _bufferList;
         std::vector<odb::dbNet*> _clockNetsObjs;
 };

--- a/src/TritonCTS/src/CtsOptions.h
+++ b/src/TritonCTS/src/CtsOptions.h
@@ -117,6 +117,16 @@ public:
         double getBufDistRatio() { return _bufDistRatio; }
         void setClockNetsObjs(std::vector<odb::dbNet*> nets) { _clockNetsObjs = nets; }
         std::vector<odb::dbNet*> getClockNetsObjs() const { return  _clockNetsObjs; }
+        void setMetricsFile(const std::string& metricFile) { _metricFile = metricFile; }
+        std::string getMetricsFile() const { return _metricFile; } 
+        void setNumClockRoots(unsigned roots) { _clockRoots = roots; }
+        unsigned getNumClockRoots() const { return _clockRoots; }
+        void setNumClockSubnets(unsigned nets) { _clockSubnets = nets; }
+        unsigned getNumClockSubnets() const { return _clockSubnets; }
+        void setNumBuffersInserted(unsigned buffers) { _buffersInserted = buffers; }
+        unsigned getNumBuffersInserted() const { return _buffersInserted; }
+        void setNumSinks(unsigned sinks) { _sinks = sinks; }
+        unsigned getNumSinks() const { return _sinks; }
                 
 private:
         std::string _blockName                  = "";
@@ -125,6 +135,7 @@ private:
         std::string _outputPath                 = "";
         std::string _clockNets                  = "";
         std::string _rootBuffer                 = "";
+        std::string _metricFile                 = "";
         DBU         _dbUnits                    = -1;
         unsigned    _wireSegmentUnit            = 0;
         unsigned    _dbId                       = 0;
@@ -147,6 +158,11 @@ private:
         bool        _writeOnlyClockNets         = false;
         bool        _runPostCtsOpt              = true;
         double      _bufDistRatio               = 0.1;
+
+        unsigned    _clockRoots                 = 0;
+        unsigned    _clockSubnets               = 0;
+        unsigned    _buffersInserted            = 0;
+        unsigned    _sinks                      = 0;
         
         std::vector<std::string> _bufferList;
         std::vector<odb::dbNet*> _clockNetsObjs;

--- a/src/TritonCTS/src/DbWrapper.cpp
+++ b/src/TritonCTS/src/DbWrapper.cpp
@@ -110,9 +110,8 @@ void DbWrapper::initAllClocks() {
                 }
         }
 
-        if (getNumClocks() <= 0) {
-                std::string errorMsg = "No clock nets have been found.\n";
-                error(errorMsg.c_str());
+        if (getNumClocks() == 0) {
+                error("No clock nets have been found.\n");
         }
 
         std::cout << " TritonCTS found " << getNumClocks() << " clock nets." << std::endl;
@@ -168,7 +167,7 @@ void DbWrapper::initClock(odb::dbNet* net) {
 
         std::cout << " Clock net \"" << net->getConstName() << "\" has " << clockNet.getNumSinks() << " sinks" << std::endl;
 
-        unsigned currentTotalSinks = _options->getNumSinks() + clockNet.getNumSinks();
+        long int currentTotalSinks = _options->getNumSinks() + clockNet.getNumSinks();
         _options->setNumSinks(currentTotalSinks);
 
         incrementNumClocks();
@@ -265,7 +264,7 @@ void DbWrapper::writeClockNetsToDb(const Clock& clockNet) {
         }
 
         std::cout << "    Created " << numClkNets << " clock nets.\n";
-        unsigned currentTotalNets = _options->getNumClockSubnets() + numClkNets;
+        long int currentTotalNets = _options->getNumClockSubnets() + numClkNets;
         _options->setNumClockSubnets(currentTotalNets);
 }
 
@@ -292,7 +291,7 @@ void DbWrapper::createClockBuffers(const Clock& clockNet) {
                 ++numBuffers;
         });
         std::cout << "    Created " << numBuffers << " clock buffers.\n";
-        unsigned currentTotalBuffers = _options->getNumBuffersInserted() + numBuffers;
+        long int currentTotalBuffers = _options->getNumBuffersInserted() + numBuffers;
         _options->setNumBuffersInserted(currentTotalBuffers);
 }
 

--- a/src/TritonCTS/src/HTreeBuilder.cpp
+++ b/src/TritonCTS/src/HTreeBuilder.cpp
@@ -488,8 +488,7 @@ void HTreeBuilder::createClockSubNets() {
                 const std::vector<Point<double>>& sinkLocs = leafTopology.getBranchSinksLocations(idx);
                 for (const Point<double>& loc : sinkLocs) {
                         if (mapLocationToSink.find(loc) == mapLocationToSink.end()) {
-                                std::string errorMsg = "Sink not found!\n";
-                                error(errorMsg.c_str());
+                                error("Sink not found.\n");
                         }
                         
                         subNet->addInst(*mapLocationToSink[loc]);

--- a/src/TritonCTS/src/HTreeBuilder.cpp
+++ b/src/TritonCTS/src/HTreeBuilder.cpp
@@ -42,6 +42,7 @@
 
 #include "HTreeBuilder.h"
 #include "third_party/CKMeans/clustering.h"
+#include "openroad/Error.hh"
 
 #include <iostream>
 #include <iomanip>
@@ -49,6 +50,8 @@
 #include <map>
 
 namespace TritonCTS {
+
+using ord::error;
 
 void HTreeBuilder::initSinkRegion() {
         unsigned wireSegmentUnitInMicron = _techChar->getLengthUnit(); 
@@ -485,8 +488,8 @@ void HTreeBuilder::createClockSubNets() {
                 const std::vector<Point<double>>& sinkLocs = leafTopology.getBranchSinksLocations(idx);
                 for (const Point<double>& loc : sinkLocs) {
                         if (mapLocationToSink.find(loc) == mapLocationToSink.end()) {
-                                std::cout << "Sink not found!\n";
-                                std::exit(1);
+                                std::string errorMsg = "Sink not found!\n";
+                                error(errorMsg.c_str());
                         }
                         
                         subNet->addInst(*mapLocationToSink[loc]);
@@ -642,8 +645,6 @@ void SegmentBuilder::buildHorizontalConnection() {
 }
 
 void SegmentBuilder::buildLShapeConnection() {
-        //std::cout << "L shape connection. Exiting...\n";
-        //std::exit(1);
         double lengthX = std::abs(_root.getX() - _target.getX());
         double lengthY = std::abs(_root.getY() - _target.getY());
         bool isLowToHiX = _root.getX() < _target.getX();

--- a/src/TritonCTS/src/TechChar.cpp
+++ b/src/TritonCTS/src/TechChar.cpp
@@ -131,26 +131,22 @@ void TechChar::parseLut(const std::string& file) {
         std::ifstream lutFile(file.c_str());
         
         if (!lutFile.is_open()) {
-                std::string errorMsg = "Could not find LUT file.\n";
-                error(errorMsg.c_str());
+                error("Could not find LUT file.\n");
         }
 
         // First line of the LUT is a header with normalization values
         if (!(lutFile >> _minSegmentLength >> _maxSegmentLength >> _minCapacitance 
                       >> _maxCapacitance >> _minSlew >> _maxSlew)) {
-                std::string errorMsg = "Problem reading the LUT file.\n";
-                error(errorMsg.c_str());
+                error("Problem reading the LUT file.\n");
         }
         
         if (_options->getWireSegmentUnit() == 0){
                 unsigned presetWireUnit = 0;
                 if (!(lutFile >> presetWireUnit)) {
-                        std::string errorMsg = "Problem reading the LUT file.\n";
-                        error(errorMsg.c_str());
+                        error("Problem reading the LUT file.\n");
                 }
                 if (presetWireUnit == 0) {
-                        std::string errorMsg = "Problem reading the LUT file.\n";
-                        error(errorMsg.c_str());
+                        error("Problem reading the LUT file.\n");
                 }
                 _options->setWireSegmentUnit(presetWireUnit);
                 setLenghthUnit(static_cast<unsigned> (presetWireUnit)/2);
@@ -240,11 +236,10 @@ void TechChar::checkCharacterizationBounds() const {
         if (_minSegmentLength > MAX_NORMALIZED_VAL || _maxSegmentLength > MAX_NORMALIZED_VAL ||
             _minCapacitance > MAX_NORMALIZED_VAL || _maxCapacitance > MAX_NORMALIZED_VAL ||
             _minSlew > MAX_NORMALIZED_VAL || _maxSlew > MAX_NORMALIZED_VAL) {
-               std::string errorMsg = "Normalized values in the LUT should be in the range [1, " +
-                                      std::to_string(MAX_NORMALIZED_VAL) + "\n Check the table " +
-                                      "above to see the normalization ranges and check " +
-                                      "your characterization configuration.\n";
-               error(errorMsg.c_str());
+               error(("Normalized values in the LUT should be in the range [1, " +
+                      std::to_string(MAX_NORMALIZED_VAL) + "\n Check the table " +
+                      "above to see the normalization ranges and check " +
+                      "your characterization configuration.\n").c_str());
         } 
 }
 
@@ -287,9 +282,8 @@ void TechChar::parseSolList(const std::string& file) {
                 
                 // Sanity check
                 if (_wireSegments[solIdx].getNumBuffers() != numBuffers) {
-                        std::string errorMsg = "Number of buffers does not match on solution.\n" +
-                                                std::to_string(solIdx) + " " + std::to_string(numBuffers) + ".\n";
-                        error(errorMsg.c_str());
+                        error(("Number of buffers does not match on solution.\n" +
+                               std::to_string(solIdx) + " " + std::to_string(numBuffers) + ".\n").c_str());
                 }
                ++solIdx; 
         }
@@ -522,29 +516,24 @@ void TechChar::initCharacterization() {
         ord::OpenRoad* openRoad = ord::OpenRoad::openRoad();
         _dbNetworkChar = openRoad->getDbNetwork();
         if (_dbNetworkChar == nullptr){
-                std::string errorMsg = "Network not found! Check your lef/def/verilog file.\n";
-                error(errorMsg.c_str());
+                error("Network not found. Check your lef/def/verilog file.\n");
         }
         _db = odb::dbDatabase::getDatabase(_options->getDbId());
         if (_db == nullptr){
-                std::string errorMsg = "Database not found! Check your lef/def/verilog file.\n";
-                error(errorMsg.c_str());
+                error("Database not found. Check your lef/def/verilog file.\n");
         }
         odb::dbChip* chip  = _db->getChip();
         if (chip == nullptr){
-                std::string errorMsg = "Chip not found! Check your lef/def/verilog file.\n";
-                error(errorMsg.c_str());
+                error("Chip not found. Check your lef/def/verilog file.\n");
         }
         odb::dbBlock* block = chip->getBlock();
         if (block == nullptr){
-                std::string errorMsg = "Block not found! Check your lef/def/verilog file.\n";
-                error(errorMsg.c_str());
+                error("Block not found. Check your lef/def/verilog file.\n");
         }
         _openSta = openRoad->getSta();
         sta::Network* networkChar = _openSta->network();
         if (networkChar == nullptr){
-                std::string errorMsg = "Network not found! Check your lef/def/verilog file.\n";
-                error(errorMsg.c_str());
+                error("Network not found. Check your lef/def/verilog file.\n");
         }
         float dbUnitsPerMicron = static_cast<float> (block->getDbUnitsPerMicron());
 
@@ -565,15 +554,13 @@ void TechChar::initCharacterization() {
         //Gets the buffer masters and its in/out pins.
         std::vector<std::string> masterVector = _options->getBufferList();
         if (masterVector.size() < 1){
-                std::string errorMsg = "Buffer not found! Check your -buf_list input.\n";
-                error(errorMsg.c_str());
+                error("Buffer not found. Check your -buf_list input.\n");
         }
         odb::dbMaster* testBuf = nullptr;
         for (std::string masterString : masterVector) {
                 testBuf = _db->findMaster(masterString.c_str());
                 if (testBuf == NULL){
-                        std::string errorMsg = "Buffer not found! Check your -buf_list input.\n";
-                        error(errorMsg.c_str());
+                        error("Buffer not found. Check your -buf_list input.\n");
                 }
                 _masterNames.insert(masterString);
         }
@@ -618,8 +605,7 @@ void TechChar::initCharacterization() {
         }
 
         if (_wirelengthsToTest.size() < 1) {
-                std::string errorMsg = "Error generating the wirelenghts to test. Check your -wire_unit parameter or technology files.\n";
-                error(errorMsg.c_str());
+                error("Error generating the wirelengths to test. Check your -wire_unit parameter or technology files.\n");
         }
 
         setLenghthUnit(static_cast<unsigned> ( ((_charBuf->getHeight() * 10)/2) / dbUnitsPerMicron));
@@ -635,8 +621,7 @@ void TechChar::initCharacterization() {
                 staLib->defaultMaxSlew(maxSlew, maxSlewExist);
                 staLib->defaultMaxCapacitance(maxCap, maxCapExist);
                 if ( !maxSlewExist || !maxCapExist ){
-                        std::string errorMsg = "Liberty Library does not have Max Slew or Max Cap values.\n";
-                        error(errorMsg.c_str());
+                        error("Liberty Library does not have Max Slew or Max Cap values.\n");
                 } else {
                         _charMaxSlew = maxSlew;
                         _charMaxCap = maxCap;
@@ -661,8 +646,7 @@ void TechChar::initCharacterization() {
         }
 
         if ((_loadsToTest.size() < 1) || (_slewsToTest.size() < 1)) {
-                std::string errorMsg = "Error generating the wirelenghts to test. Check your -max_cap / -max_slew / -cap_inter / -slew_inter parameter or technology files.\n";
-                error(errorMsg.c_str());
+                error("Error generating the wirelengths to test. Check your -max_cap / -max_slew / -cap_inter / -slew_inter parameter or technology files.\n");
         }
 }
 

--- a/src/TritonCTS/src/TechChar.cpp
+++ b/src/TritonCTS/src/TechChar.cpp
@@ -41,6 +41,7 @@
 ////////////////////////////////////////////////////////////////////////////////////
 
 #include "TechChar.h"
+#include "openroad/Error.hh"
 
 #include "sta/Sdc.hh"
 #include "sta/Liberty.hh"
@@ -58,6 +59,8 @@
 #include <algorithm>
 
 namespace TritonCTS {
+
+using ord::error;
 
 void TechChar::compileLut(std::vector<TechChar::ResultData> lutSols) {
         std::cout << " Compiling LUT\n";
@@ -128,26 +131,26 @@ void TechChar::parseLut(const std::string& file) {
         std::ifstream lutFile(file.c_str());
         
         if (!lutFile.is_open()) {
-                std::cout << "    [ERROR] Could not find LUT file. Exiting...\n";
-                std::exit(1);
+                std::string errorMsg = "Could not find LUT file.\n";
+                error(errorMsg.c_str());
         }
 
         // First line of the LUT is a header with normalization values
         if (!(lutFile >> _minSegmentLength >> _maxSegmentLength >> _minCapacitance 
                       >> _maxCapacitance >> _minSlew >> _maxSlew)) {
-                std::cout << "    [ERROR] Problem reading the LUT file\n";     
-                std::exit(1);            
+                std::string errorMsg = "Problem reading the LUT file.\n";
+                error(errorMsg.c_str());
         }
         
         if (_options->getWireSegmentUnit() == 0){
                 unsigned presetWireUnit = 0;
                 if (!(lutFile >> presetWireUnit)) {
-                        std::cout << "    [ERROR] Problem reading the LUT file\n"; 
-                        std::exit(1);            
+                        std::string errorMsg = "Problem reading the LUT file.\n";
+                        error(errorMsg.c_str());
                 }
                 if (presetWireUnit == 0) {
-                        std::cout << "    [ERROR] Problem reading the LUT file\n";
-                        std::exit(1);   
+                        std::string errorMsg = "Problem reading the LUT file.\n";
+                        error(errorMsg.c_str());
                 }
                 _options->setWireSegmentUnit(presetWireUnit);
                 setLenghthUnit(static_cast<unsigned> (presetWireUnit)/2);
@@ -237,11 +240,11 @@ void TechChar::checkCharacterizationBounds() const {
         if (_minSegmentLength > MAX_NORMALIZED_VAL || _maxSegmentLength > MAX_NORMALIZED_VAL ||
             _minCapacitance > MAX_NORMALIZED_VAL || _maxCapacitance > MAX_NORMALIZED_VAL ||
             _minSlew > MAX_NORMALIZED_VAL || _maxSlew > MAX_NORMALIZED_VAL) {
-               std::cout << "    [ERROR] Normalized values in the LUT should be in the range ";
-               std::cout << "[1, " << MAX_NORMALIZED_VAL << "]\n";
-               std::cout << "    Check the table above to see the normalization ranges and check ";
-               std::cout << "your characterization configuration.\n";
-               std::exit(1);
+               std::string errorMsg = "Normalized values in the LUT should be in the range [1, " +
+                                      std::to_string(MAX_NORMALIZED_VAL) + "\n Check the table " +
+                                      "above to see the normalization ranges and check " +
+                                      "your characterization configuration.\n";
+               error(errorMsg.c_str());
         } 
 }
 
@@ -284,10 +287,9 @@ void TechChar::parseSolList(const std::string& file) {
                 
                 // Sanity check
                 if (_wireSegments[solIdx].getNumBuffers() != numBuffers) {
-                        std::cout << "    [ERROR] Number of buffers does not match on solution " 
-                                  << solIdx << "\n";
-                        std::cout << numBuffers << "\n";
-                        std::exit(1);
+                        std::string errorMsg = "Number of buffers does not match on solution.\n" +
+                                                std::to_string(solIdx) + " " + std::to_string(numBuffers) + ".\n";
+                        error(errorMsg.c_str());
                 }
                ++solIdx; 
         }
@@ -520,29 +522,29 @@ void TechChar::initCharacterization() {
         ord::OpenRoad* openRoad = ord::OpenRoad::openRoad();
         _dbNetworkChar = openRoad->getDbNetwork();
         if (_dbNetworkChar == nullptr){
-                std::cout << "Network not found! Check your lef/def/verilog file.\n";
-                std::exit(1);
+                std::string errorMsg = "Network not found! Check your lef/def/verilog file.\n";
+                error(errorMsg.c_str());
         }
         _db = odb::dbDatabase::getDatabase(_options->getDbId());
         if (_db == nullptr){
-                std::cout << "Database not found! Check your lef/def/verilog file.\n";
-                std::exit(1);
+                std::string errorMsg = "Database not found! Check your lef/def/verilog file.\n";
+                error(errorMsg.c_str());
         }
         odb::dbChip* chip  = _db->getChip();
         if (chip == nullptr){
-                std::cout << "Chip not found! Check your lef/def/verilog file.\n";
-                std::exit(1);
+                std::string errorMsg = "Chip not found! Check your lef/def/verilog file.\n";
+                error(errorMsg.c_str());
         }
         odb::dbBlock* block = chip->getBlock();
         if (block == nullptr){
-                std::cout << "Block not found! Check your lef/def/verilog file.\n";
-                std::exit(1);
+                std::string errorMsg = "Block not found! Check your lef/def/verilog file.\n";
+                error(errorMsg.c_str());
         }
         _openSta = openRoad->getSta();
         sta::Network* networkChar = _openSta->network();
         if (networkChar == nullptr){
-                std::cout << "Network not found! Check your lef/def/verilog file.\n";
-                std::exit(1);
+                std::string errorMsg = "Network not found! Check your lef/def/verilog file.\n";
+                error(errorMsg.c_str());
         }
         float dbUnitsPerMicron = static_cast<float> (block->getDbUnitsPerMicron());
 
@@ -563,15 +565,15 @@ void TechChar::initCharacterization() {
         //Gets the buffer masters and its in/out pins.
         std::vector<std::string> masterVector = _options->getBufferList();
         if (masterVector.size() < 1){
-                std::cout << "Buffer not found! Check your -buf_list input.\n";
-                std::exit(1);
+                std::string errorMsg = "Buffer not found! Check your -buf_list input.\n";
+                error(errorMsg.c_str());
         }
         odb::dbMaster* testBuf = nullptr;
         for (std::string masterString : masterVector) {
                 testBuf = _db->findMaster(masterString.c_str());
                 if (testBuf == NULL){
-                        std::cout << "Buffer not found! Check your -buf_list input.\n";
-                        std::exit(1);
+                        std::string errorMsg = "Buffer not found! Check your -buf_list input.\n";
+                        error(errorMsg.c_str());
                 }
                 _masterNames.insert(masterString);
         }
@@ -616,8 +618,8 @@ void TechChar::initCharacterization() {
         }
 
         if (_wirelengthsToTest.size() < 1) {
-                std::cout << "Error generating the wirelenghts to test. Check your -wire_unit parameter or technology files.\n";
-                std::exit(1);
+                std::string errorMsg = "Error generating the wirelenghts to test. Check your -wire_unit parameter or technology files.\n";
+                error(errorMsg.c_str());
         }
 
         setLenghthUnit(static_cast<unsigned> ( ((_charBuf->getHeight() * 10)/2) / dbUnitsPerMicron));
@@ -633,8 +635,8 @@ void TechChar::initCharacterization() {
                 staLib->defaultMaxSlew(maxSlew, maxSlewExist);
                 staLib->defaultMaxCapacitance(maxCap, maxCapExist);
                 if ( !maxSlewExist || !maxCapExist ){
-                        std::cout << "Liberty Library does not have Max Slew or Max Cap values.\n";
-                        std::exit(1);
+                        std::string errorMsg = "Liberty Library does not have Max Slew or Max Cap values.\n";
+                        error(errorMsg.c_str());
                 } else {
                         _charMaxSlew = maxSlew;
                         _charMaxCap = maxCap;
@@ -659,8 +661,8 @@ void TechChar::initCharacterization() {
         }
 
         if ((_loadsToTest.size() < 1) || (_slewsToTest.size() < 1)) {
-                std::cout << "Error generating the wirelenghts to test. Check your -max_cap / -max_slew / -cap_inter / -slew_inter parameter or technology files.\n";
-                std::exit(1);
+                std::string errorMsg = "Error generating the wirelenghts to test. Check your -max_cap / -max_slew / -cap_inter / -slew_inter parameter or technology files.\n";
+                error(errorMsg.c_str());
         }
 }
 

--- a/src/TritonCTS/src/TritonCTSKernel.cpp
+++ b/src/TritonCTS/src/TritonCTSKernel.cpp
@@ -82,6 +82,11 @@ void TritonCTSKernel::setupCharacterization() {
                 //LUT files exists. Import the characterization results.
                 importCharacterization();
         }
+        //Also resets metrics everytime the setup is done
+        _options.setNumSinks(0);
+        _options.setNumBuffersInserted(0);
+        _options.setNumClockRoots(0);
+        _options.setNumClockSubnets(0);
 }
 
 void TritonCTSKernel::importCharacterization() {
@@ -116,9 +121,7 @@ void TritonCTSKernel::checkCharacterization() {
                         if (_dbWrapper.masterExists(master)) {
                                 visitedMasters.insert(master);
                         } else {
-                                std::string errorMsg = "Buffer " + master + 
-                                                       " is not in the loaded DB.\n";
-                                error(errorMsg.c_str());
+                                error(("Buffer " + master + " is not in the loaded DB.\n").c_str());
                         }           
                 }
         });
@@ -150,8 +153,7 @@ void TritonCTSKernel::populateTritonCts() {
         _dbWrapper.populateTritonCTS();
 
         if (_builders.size() < 1) {
-                std::string errorMsg = "No valid clock nets in the design.\n";
-                error(errorMsg.c_str());
+                error("No valid clock nets in the design.\n");
         }
 }
 

--- a/src/TritonCTS/src/TritonCTSKernel.h
+++ b/src/TritonCTS/src/TritonCTSKernel.h
@@ -60,6 +60,7 @@ public:
                             _staEngine(_options) {}
 
         void runTritonCts();
+        void reportCtsMetrics();
         CtsOptions& getParms() { return _options; }
         void addBuilder(TreeBuilder* builder) { _builders.push_back(builder); }
         void forEachBuilder(const std::function<void(const TreeBuilder*)> func) const;
@@ -105,6 +106,8 @@ public:
         void run_triton_cts();
         void report_characterization();
         void report_wire_segments(unsigned length, unsigned load, unsigned outputSlew); 
+        void set_metric_output(const char* file);
+        void report_cts_metrics();
 };
 
 }

--- a/src/TritonCTS/src/TritonCTSKernelTcl.cpp
+++ b/src/TritonCTS/src/TritonCTSKernelTcl.cpp
@@ -165,4 +165,12 @@ void TritonCTSKernel::set_cap_inter(double cap){
         _options.setCapInter(cap);
 }
 
+void TritonCTSKernel::set_metric_output(const char* file){
+        _options.setMetricsFile(file);
+}
+
+void TritonCTSKernel::report_cts_metrics(){
+        reportCtsMetrics();
+};
+
 }

--- a/src/TritonCTS/src/TritonCTSKernelTcl.i
+++ b/src/TritonCTS/src/TritonCTSKernelTcl.i
@@ -62,5 +62,7 @@ TritonCTSKernel* get_triton_cts() {
 
 %} //inline
 
+%include "../../Exception.i"
+
 %include "TritonCTSKernel.h"
 using namespace TritonCTS;

--- a/src/TritonCTS/src/tritoncts.tcl
+++ b/src/TritonCTS/src/tritoncts.tcl
@@ -51,14 +51,14 @@ sta::define_cmd_args "clock_tree_synthesis" {[-lut_file lut] \
                                              [-out_path path] \
                                              [-sqr_cap capvalue] \
                                              [-sqr_res resvalue] \
-                                             [-only_characterization enable] \
                                              [-slew_inter slewvalue] \
                                              [-cap_inter capvalue] \
+                                             [-characterization_only] \
                                             } 
 
 proc clock_tree_synthesis { args } {
   sta::parse_key_args "clock_tree_synthesis" args \
-    keys {-lut_file -sol_list -root_buf -buf_list -wire_unit -max_cap -max_slew -clk_nets -out_path -sqr_cap -sqr_res -only_characterization -slew_inter -cap_inter} flags {}
+    keys {-lut_file -sol_list -root_buf -buf_list -wire_unit -max_cap -max_slew -clk_nets -out_path -sqr_cap -sqr_res -slew_inter -cap_inter} flags {-characterization_only}
 
   set cts [get_triton_cts]
 
@@ -70,10 +70,7 @@ proc clock_tree_synthesis { args } {
   #                               ex: clock_tree_synthesis -buf_list "BUFX1 BUFX2" -wire_unit 20 -sqr_cap 1 -sqr_res 2 -clk_nets clk1
 
 
-  if { [info exists keys(-only_characterization)] } {
-	  set enable $keys(-only_characterization)
-    $cts set_only_characterization $enable 
-  } 
+  $cts set_only_characterization [info exists flags(-characterization_only)]
 
   if { [info exists keys(-lut_file)] } {
 	  set lut $keys(-lut_file)
@@ -158,7 +155,27 @@ proc clock_tree_synthesis { args } {
     }
   }
 
-  $cts run_triton_cts
+  if {[catch {$cts run_triton_cts} error_msg options]} {
+    puts $error_msg
+  }
+
   # CTS changed the network behind the STA's back.
   sta::network_changed
+}
+
+sta::define_cmd_args "report_cts" {[-out_file file] \
+                                  } 
+
+proc report_cts { args } {
+  sta::parse_key_args "report_cts" args \
+    keys {-out_file} flags {}
+
+  set cts [get_triton_cts]
+
+  if { [info exists keys(-out_file)] } {
+	  set outFile $keys(-lut_file)
+    $cts set_metric_output $outFile 
+  } 
+
+  $cts report_cts_metrics
 }

--- a/src/TritonCTS/src/tritoncts.tcl
+++ b/src/TritonCTS/src/tritoncts.tcl
@@ -173,7 +173,7 @@ proc report_cts { args } {
   set cts [get_triton_cts]
 
   if { [info exists keys(-out_file)] } {
-	  set outFile $keys(-lut_file)
+	  set outFile $keys(-out_file)
     $cts set_metric_output $outFile 
   } 
 

--- a/src/TritonCTS/test/src/check_lut/run.tcl
+++ b/src/TritonCTS/test/src/check_lut/run.tcl
@@ -9,3 +9,4 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -root_buf CLKBUF_X3 \
                      -wire_unit 20 
 
+exit

--- a/src/TritonCTS/test/src/create_lut/run.tcl
+++ b/src/TritonCTS/test/src/create_lut/run.tcl
@@ -5,7 +5,7 @@ read_verilog "aes.v"
 read_sdc "aes.sdc"
 
 clock_tree_synthesis -buf_list "BUF_X1" \
-                     -characterization_only 1 \
+                     -characterization_only \
                      -max_slew 10.0e-12 \
                      -max_cap 30.0e-15 \
                      -sqr_cap 7.7161e-5 \

--- a/src/TritonCTS/test/src/create_lut/run.tcl
+++ b/src/TritonCTS/test/src/create_lut/run.tcl
@@ -5,9 +5,10 @@ read_verilog "aes.v"
 read_sdc "aes.sdc"
 
 clock_tree_synthesis -buf_list "BUF_X1" \
-                     -only_characterization 1 \
+                     -characterization_only 1 \
                      -max_slew 10.0e-12 \
                      -max_cap 30.0e-15 \
                      -sqr_cap 7.7161e-5 \
                      -sqr_res 3.8e-1
 
+exit

--- a/src/TritonCTS/test/src/find_clock/run.tcl
+++ b/src/TritonCTS/test/src/find_clock/run.tcl
@@ -9,3 +9,4 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -root_buf CLKBUF_X3 \
                      -wire_unit 20 
 
+exit

--- a/src/TritonCTS/test/src/find_clock_pad/run.tcl
+++ b/src/TritonCTS/test/src/find_clock_pad/run.tcl
@@ -17,5 +17,6 @@ clock_tree_synthesis -buf_list "BUF_X1" \
                      -max_cap 30.0e-15 \
                      -sqr_cap 7.7161e-5 \
                      -sqr_res 3.8e-1 \
-                     -only_characterization 1
+                     -characterization_only 1
 
+exit

--- a/src/TritonCTS/test/src/find_clock_pad/run.tcl
+++ b/src/TritonCTS/test/src/find_clock_pad/run.tcl
@@ -17,6 +17,6 @@ clock_tree_synthesis -buf_list "BUF_X1" \
                      -max_cap 30.0e-15 \
                      -sqr_cap 7.7161e-5 \
                      -sqr_res 3.8e-1 \
-                     -characterization_only 1
+                     -characterization_only
 
 exit

--- a/src/TritonCTS/test/src/no_clocks/run.tcl
+++ b/src/TritonCTS/test/src/no_clocks/run.tcl
@@ -9,3 +9,4 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -root_buf CLKBUF_X3 \
                      -wire_unit 20 
 
+exit

--- a/src/TritonCTS/test/src/no_sinks/run.tcl
+++ b/src/TritonCTS/test/src/no_sinks/run.tcl
@@ -10,3 +10,4 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -wire_unit 20 \
                      -clk_nets "clk" 
 
+exit

--- a/src/TritonCTS/test/src/simple_test/run.tcl
+++ b/src/TritonCTS/test/src/simple_test/run.tcl
@@ -9,3 +9,4 @@ clock_tree_synthesis -lut_file "lut.txt" \
                      -root_buf CLKBUF_X3 \
                      -wire_unit 20 
 
+exit


### PR DESCRIPTION
This PR fixes/updates various things for TritonCTS:
1. Flags are now used on TCL.
2. Errors stop the execution of TritonCTS and return to TCL, not to the terminal/cmd... This fixes issue #299.
3. Added the report_cts command.
4. Errors raised during execution do not std::exit() and instead uses ord::error.