### PR TITLE
Update version number to  .9 to align with v1.0 being the end of phase 1b

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
 cmake_policy(SET CMP0077 NEW)
 endif()
 
-project(OpenROAD VERSION 1.1.0
+project(OpenROAD VERSION 0.9.0
   LANGUAGES CXX
 )
 


### PR DESCRIPTION
Modify openroad app version number to be .9 since 1.0 will be the phase1b deliverable name.