### PR TITLE
[ARC] Fix CMake TCL error

### DIFF
--- a/src/antennachecker/src/CMakeLists.txt
+++ b/src/antennachecker/src/CMakeLists.txt
@@ -59,4 +59,5 @@ target_include_directories(antennachecker
   ${OPENDB_HOME}/include
   ${OPENSTA_HOME}/include
   ${OPENSTA_HOME}/app
+  ${TCL_INCLUDE_PATH}
   )


### PR DESCRIPTION
This fixes an error with tcl.h that happens in some Linux distributions. 

> OpenROAD/build/src/antennachecker/src/AntennaChecker_wrap.cc:195:10: fatal error: tcl.h: No such file or directory
>  #include <tcl.h>

Some newer versions of TCL have the tcl.h inside another folder, which makes the build fail. Adding the TCL_INCLUDE_PATH to the CMakeLists file of ARC solves this problem.