### PR TITLE
[TritonCTS] Stability fixes

### DIFF
--- a/src/TritonCTS/src/Clock.cpp
+++ b/src/TritonCTS/src/Clock.cpp
@@ -109,4 +109,10 @@ void Clock::forEachClockBuffer(const std::function<void(const ClockInst&)>& func
         }
 }
 
+void Clock::forEachClockBuffer(const std::function<void(ClockInst&)>& func) {
+        for (ClockInst& clockBuffer: _clockBuffers) {
+                func(clockBuffer);
+        }
+}
+
 }

--- a/src/TritonCTS/src/Clock.h
+++ b/src/TritonCTS/src/Clock.h
@@ -60,17 +60,23 @@ public:
         ClockInst(const std::string& name,
                   const std::string& master,
                   InstType type,
-                  DBU x, DBU y) : 
+                  DBU x, DBU y, odb::dbITerm* pinObj = nullptr) : 
                   _name(name), 
                   _master(master),
                   _type(type),
-                  _location(x, y) {}
+                  _location(x, y), 
+                  _inputPinObj(pinObj) {}
 
         std::string getName() const { return _name; }
         std::string getMaster() const { return _master; }
         DBU getX() const { return _location.getX(); }
         DBU getY() const { return _location.getY(); }
         Point<DBU> getLocation() const { return _location; }
+
+        void setInstObj(odb::dbInst* inst) { _instObj = inst; }
+        odb::dbInst* getDbInst() const { return _instObj; }
+        void setInputPinObj(odb::dbITerm* pin) { _inputPinObj = pin; }
+        odb::dbITerm* getDbInputPin() const { return _inputPinObj; }
 
         bool isClockBuffer() const { return _type == CLOCK_BUFFER; }
 
@@ -79,6 +85,8 @@ protected:
         std::string _master;
         InstType    _type;
         Point<DBU>  _location;
+        odb::dbInst* _instObj = nullptr;
+        odb::dbITerm* _inputPinObj = nullptr;
 };
 
 //-----------------------------------------------------------------------------
@@ -165,6 +173,10 @@ public:
                 _sinks.emplace_back(name, "", CLOCK_SINK, x, y);
         }
 
+        void addSink(const std::string& name, DBU x, DBU y, odb::dbITerm* pinObj) {
+                _sinks.emplace_back(name, "", CLOCK_SINK, x, y, pinObj);
+        }
+
         std::string getName() const { return _netName; }
         unsigned getNumSinks() const { return _sinks.size(); }
 
@@ -176,6 +188,7 @@ public:
         void forEachSink(const std::function<void(const ClockInst&)>& func) const;
         void forEachSink(const std::function<void(ClockInst&)>& func);
         void forEachClockBuffer(const std::function<void(const ClockInst&)>& func) const;
+        void forEachClockBuffer(const std::function<void(ClockInst&)>& func);
         void forEachSubNet(const std::function<void(const SubNet&)>& func) const {
                 for (const SubNet& subNet: _subNets) {
                         func(subNet);

--- a/src/TritonCTS/src/DbWrapper.h
+++ b/src/TritonCTS/src/DbWrapper.h
@@ -78,6 +78,7 @@ private:
         CtsOptions*       _options              = nullptr;
         TritonCTSKernel*  _kernel               = nullptr;  
         unsigned          _numberOfClocks       = 0;       
+        unsigned          _numClkNets           = 0;   
 
         void parseClockNames(std::vector<std::string>& clockNetNames) const;
 
@@ -87,6 +88,7 @@ private:
         
         void disconnectAllSinksFromNet(odb::dbNet* net);
         void disconnectAllPinsFromNet(odb::dbNet* net);
+        void checkUpstreamConnections(odb::dbNet* net);
         void createClockBuffers(const Clock& clk);
         void removeNonClockNets();
         void computeITermPosition(odb::dbITerm* term, DBU &x, DBU &y) const;

--- a/src/TritonCTS/src/DbWrapper.h
+++ b/src/TritonCTS/src/DbWrapper.h
@@ -89,7 +89,7 @@ private:
         void disconnectAllSinksFromNet(odb::dbNet* net);
         void disconnectAllPinsFromNet(odb::dbNet* net);
         void checkUpstreamConnections(odb::dbNet* net);
-        void createClockBuffers(const Clock& clk);
+        void createClockBuffers(Clock& clk);
         void removeNonClockNets();
         void computeITermPosition(odb::dbITerm* term, DBU &x, DBU &y) const;
         std::pair<int,int> branchBufferCount(ClockInst *inst, int bufCounter, Clock& clockNet);

--- a/src/TritonCTS/src/DbWrapper.h
+++ b/src/TritonCTS/src/DbWrapper.h
@@ -79,6 +79,7 @@ private:
         TritonCTSKernel*  _kernel               = nullptr;  
         unsigned          _numberOfClocks       = 0;       
         unsigned          _numClkNets           = 0;   
+        unsigned          _numFixedNets         = 0;
 
         void parseClockNames(std::vector<std::string>& clockNetNames) const;
 

--- a/src/TritonCTS/src/tritoncts.tcl
+++ b/src/TritonCTS/src/tritoncts.tcl
@@ -158,6 +158,9 @@ proc clock_tree_synthesis { args } {
 
   if { [info exists keys(-root_buf)] } {
     set root_buf $keys(-root_buf)
+    if { [llength $root_buf] > 1} {
+      set root_buf [lindex $root_buf 0]
+    }
     $cts set_root_buffer $root_buf
   } else {
     if { [info exists keys(-buf_list)] } {

--- a/src/antennachecker/test/antenna.rpt
+++ b/src/antennachecker/test/antenna.rpt
@@ -1,0 +1,223 @@
+
+Net - clk
+
+Net - req_msg[0]
+
+Net - req_msg[10]
+
+Net - req_msg[11]
+
+Net - req_msg[12]
+
+Net - req_msg[13]
+
+Net - req_msg[14]
+
+Net - req_msg[15]
+
+Net - req_msg[16]
+
+Net - req_msg[17]
+
+Net - req_msg[18]
+
+Net - req_msg[19]
+
+Net - req_msg[1]
+
+Net - req_msg[20]
+
+Net - req_msg[21]
+
+Net - req_msg[22]
+
+Net - req_msg[23]
+
+Net - req_msg[24]
+
+Net - req_msg[25]
+
+Net - req_msg[26]
+
+Net - req_msg[27]
+
+Net - req_msg[28]
+
+Net - req_msg[29]
+
+Net - req_msg[2]
+
+Net - req_msg[30]
+
+Net - req_msg[31]
+
+Net - req_msg[3]
+
+Net - req_msg[4]
+
+Net - req_msg[5]
+
+Net - req_msg[6]
+
+Net - req_msg[7]
+
+Net - req_msg[8]
+
+Net - req_msg[9]
+
+Net - req_rdy
+
+Net - req_val
+
+Net - reset
+
+Net - resp_msg[0]
+
+Net - resp_msg[10]
+
+Net - resp_msg[11]
+
+Net - resp_msg[12]
+
+Net - resp_msg[13]
+
+Net - resp_msg[14]
+
+Net - resp_msg[15]
+
+Net - resp_msg[1]
+
+Net - resp_msg[2]
+
+Net - resp_msg[3]
+
+Net - resp_msg[4]
+
+Net - resp_msg[5]
+
+Net - resp_msg[6]
+
+Net - resp_msg[7]
+
+Net - resp_msg[8]
+
+Net - resp_msg[9]
+
+Net - resp_rdy
+
+Net - resp_val
+
+Net - net50
+  _264_  (sky130_fd_sc_ms__a222oi_1)  B2
+[1]  met3:
+  PAR:   40.63  Ratio:    0.00       (Area)
+  PAR:  218.43  Ratio: 2878.88       (S.Area)
+  CAR:  138.03  Ratio:    0.00       (C.Area)
+  CAR:  707.18  Ratio:    0.00       (C.S.Area)
+
+[1]  met2:
+  PAR:   13.57  Ratio:    0.00       (Area)
+  PAR:   68.63  Ratio:  400.00       (S.Area)
+  CAR:   13.71  Ratio:    0.00       (C.Area)
+  CAR:   69.10  Ratio:    0.00       (C.S.Area)
+
+[1]  met1:
+  PAR:    0.08  Ratio:    0.00       (Area)
+  PAR:    0.40  Ratio:  400.00       (S.Area)
+  CAR:    0.14  Ratio:    0.00       (C.Area)
+  CAR:    0.47  Ratio:    0.00       (C.S.Area)
+
+[1]  li1:
+  PAR:    0.06  Ratio:    0.00       (Area)
+  PAR:    0.07  Ratio:   75.00       (S.Area)
+  CAR:    0.06  Ratio:    0.00       (C.Area)
+  CAR:    0.07  Ratio:    0.00       (C.S.Area)
+
+[1]  M2M3_PR_M:
+  PAR:    0.16  Ratio:    6.00       (Area)
+  CAR:    0.37  Ratio:    0.00       (C.Area)
+
+[1]  M1M2_PR:
+  PAR:    0.09  Ratio:    6.00       (Area)
+  CAR:    0.21  Ratio:    0.00       (C.Area)
+
+[1]  L1M1_PR_MR:
+  PAR:    0.12  Ratio:    3.00       (Area)
+  CAR:    0.12  Ratio:    0.00       (C.Area)
+
+  output50  (sky130_fd_sc_ms__buf_1)  A
+[1]  met3:
+  PAR:   40.63  Ratio:    0.00       (Area)
+  PAR:  218.43  Ratio: 2878.88       (S.Area)
+  CAR:  179.21  Ratio:    0.00       (C.Area)
+  CAR:  912.89  Ratio:    0.00       (C.S.Area)
+
+[1]  met2:
+  PAR:   83.70  Ratio:    0.00       (Area)
+  PAR:  419.64*  Ratio:  400.00       (S.Area)
+  CAR:  138.58  Ratio:    0.00       (C.Area)
+  CAR:  694.46  Ratio:    0.00       (C.S.Area)
+
+[1]  met1:
+  PAR:   54.81  Ratio:    0.00       (Area)
+  PAR:  274.73  Ratio:  400.00       (S.Area)
+  CAR:   54.88  Ratio:    0.00       (C.Area)
+  CAR:  274.81  Ratio:    0.00       (C.S.Area)
+
+[1]  li1:
+  PAR:    0.07  Ratio:    0.00       (Area)
+  PAR:    0.08  Ratio:   75.00       (S.Area)
+  CAR:    0.07  Ratio:    0.00       (C.Area)
+  CAR:    0.08  Ratio:    0.00       (C.S.Area)
+
+[1]  M2M3_PR_M:
+  PAR:    0.38  Ratio:    6.00       (Area)
+  CAR:    0.63  Ratio:    0.00       (C.Area)
+
+[1]  M1M2_PR:
+  PAR:    0.11  Ratio:    6.00       (Area)
+  CAR:    0.25  Ratio:    0.00       (C.Area)
+
+[1]  L1M1_PR_MR:
+  PAR:    0.14  Ratio:    3.00       (Area)
+  CAR:    0.14  Ratio:    0.00       (C.Area)
+
+
+Net - net51
+  _270_  (sky130_fd_sc_ms__a222oi_1)  B2
+[1]  met1:
+  PAR:   39.02  Ratio:    0.00       (Area)
+  PAR:  195.67  Ratio: 2879.92       (S.Area)
+  CAR:   39.07  Ratio:    0.00       (C.Area)
+  CAR:  195.74  Ratio:    0.00       (C.S.Area)
+
+[1]  li1:
+  PAR:    0.06  Ratio:    0.00       (Area)
+  PAR:    0.07  Ratio:   75.00       (S.Area)
+  CAR:    0.06  Ratio:    0.00       (C.Area)
+  CAR:    0.07  Ratio:    0.00       (C.S.Area)
+
+[1]  L1M1_PR_MR:
+  PAR:    0.12  Ratio:    3.00       (Area)
+  CAR:    0.12  Ratio:    0.00       (C.Area)
+
+  output51  (sky130_fd_sc_ms__buf_1)  A
+[1]  met1:
+  PAR:   39.02  Ratio:    0.00       (Area)
+  PAR:  195.67  Ratio: 2879.92       (S.Area)
+  CAR:   39.09  Ratio:    0.00       (C.Area)
+  CAR:  195.75  Ratio:    0.00       (C.S.Area)
+
+[1]  li1:
+  PAR:    0.07  Ratio:    0.00       (Area)
+  PAR:    0.08  Ratio:   75.00       (S.Area)
+  CAR:    0.07  Ratio:    0.00       (C.Area)
+  CAR:    0.08  Ratio:    0.00       (C.S.Area)
+
+[1]  L1M1_PR_MR:
+  PAR:    0.14  Ratio:    3.00       (Area)
+  CAR:    0.14  Ratio:    0.00       (C.Area)
+
+Number of pins violated: 1
+Number of nets violated: 1
+Total number of unspecial nets: 56

--- a/src/antennachecker/test/results/sw130_random.log
+++ b/src/antennachecker/test/results/sw130_random.log
@@ -1554,8 +1554,6 @@ Notice 0:     Created 54 pins.
 Notice 0:     Created 6 components and 48 component-terminals.
 Notice 0:     Created 2 nets and 6 connections.
 Notice 0: Finished DEF file: sw130_random.def
-Notice 0: 
-disconnected net 55  net50
 Notice 0: Split top of 1 T shapes.
 Number of pins violated: 1
 Number of nets violated: 1


### PR DESCRIPTION
This PR has no effect on the current OpenROAD-flow. It only fixes segFaults and unconnected buffers/nets that happen in some combinations of input parameters.

This includes fixes for Issue #389 and for when TritonCTS was inserting unconnected buffers (no global placement) and nets (no sink found).