### PR TITLE
[TritonCTS] Sink Clustering Update

### DIFF
--- a/src/TritonCTS/src/Clock.cpp
+++ b/src/TritonCTS/src/Clock.cpp
@@ -86,6 +86,26 @@ Box<DBU> Clock::computeSinkRegion() {
         return Box<DBU>(xMin, yMin, xMax, yMax);
 }
 
+Box<double> Clock::computeSinkRegionClustered(std::vector<std::pair<float, float>> sinks) {
+        std::vector<double> allPositionsX;                
+        std::vector<double> allPositionsY;   
+        for (std::pair<float, float> sinkLocation : sinks){
+                allPositionsX.push_back(sinkLocation.first);
+                allPositionsY.push_back(sinkLocation.second);
+        }     
+
+        std::sort(allPositionsX.begin(), allPositionsX.end());
+        std::sort(allPositionsY.begin(), allPositionsY.end());
+
+        unsigned numSinks = allPositionsX.size();
+        double xMin = allPositionsX[0];
+        double xMax = allPositionsX[(allPositionsX.size() - 1)]; 
+        double yMin = allPositionsY[0];
+        double yMax = allPositionsY[(allPositionsY.size() - 1)]; 
+        
+        return Box<double>(xMin, yMin, xMax, yMax);
+}
+
 Box<double> Clock::computeNormalizedSinkRegion(double factor) {
         Box<DBU> sinkRegion = computeSinkRegion();
         return sinkRegion.normalize(factor);
@@ -105,6 +125,12 @@ void Clock::forEachSink(const std::function<void(ClockInst&)>& func) {
 
 void Clock::forEachClockBuffer(const std::function<void(const ClockInst&)>& func) const {
         for (const ClockInst& clockBuffer: _clockBuffers) {
+                func(clockBuffer);
+        }
+}
+
+void Clock::forEachClockBuffer(const std::function<void(ClockInst&)>& func) {
+        for (ClockInst& clockBuffer: _clockBuffers) {
                 func(clockBuffer);
         }
 }

--- a/src/TritonCTS/src/CtsOptions.h
+++ b/src/TritonCTS/src/CtsOptions.h
@@ -75,6 +75,10 @@ public:
         bool runAutoLut() const { return _autoLutEnable; }
         void setOnlyCharacterization(bool enable) { _onlyCharacterization = enable; } 
         bool getOnlyCharacterization() const { return _onlyCharacterization; }
+        void setSimpleCts(bool enable) { _simpleCts = enable; } 
+        bool getSimpleCts() const { return _simpleCts; }
+        void setSinkClustering(bool enable) { _sinkClusteringEnable = enable; } 
+        bool getSinkClustering() const { return _sinkClusteringEnable; }
         void setNumMaxLeafSinks(unsigned numSinks) { _numMaxLeafSinks = numSinks; }
         unsigned getNumMaxLeafSinks() const { return _numMaxLeafSinks; }        
         void setMaxSlew(unsigned slew) { _maxSlew = slew; }
@@ -135,7 +139,16 @@ public:
         void setVertexBuffersEnabled(bool enable) { _vertexBuffersEnable = enable; }
         bool isSimpleSegmentEnabled()  const { return _simpleSegmentsEnable; }
         void setSimpleSegmentsEnabled(bool enable) { _simpleSegmentsEnable = enable; }
-
+        void setGeoMatchingThreshold(unsigned threshold) { _geoMatchingThreshold = threshold; }
+        unsigned getGeoMatchingThreshold() { return _geoMatchingThreshold; }
+        double getMaxDiameter()  const { return _maxDiameter; }
+        void setMaxDiameter(double distance) { _maxDiameter = distance; }
+        unsigned getSizeSinkClustering()  const { return _sinkClustersSize; }
+        void setSizeSinkClustering(unsigned size) { _sinkClustersSize = size; }
+        unsigned getNumStaticLayers()  const { return _numStaticLayers; }
+        void setNumStaticLayers(unsigned num) { _numStaticLayers = num; }
+        void setSinkBuffer(const std::string& buffer) { _sinkBuffer = buffer; }
+        std::string getSinkBuffer() const { return  _sinkBuffer; }
 private:
         std::string _blockName                  = "";
         std::string _lutFile                    = "";
@@ -143,12 +156,15 @@ private:
         std::string _outputPath                 = "";
         std::string _clockNets                  = "";
         std::string _rootBuffer                 = "";
+        std::string _sinkBuffer                 = "";
         std::string _metricFile                 = "";
         DBU         _dbUnits                    = -1;
         unsigned    _wireSegmentUnit            = 0;
         unsigned    _dbId                       = 0;
         bool        _plotSolution               = false;
         bool        _onlyCharacterization       = false;
+        bool        _simpleCts                  = false;
+        bool        _sinkClusteringEnable       = false;
         bool        _autoLutEnable              = true;
         bool        _simpleSegmentsEnable       = false;
         bool        _vertexBuffersEnable        = false;
@@ -177,6 +193,10 @@ private:
         long int    _clockSubnets               = 0;
         long int    _buffersInserted            = 0;
         long int    _sinks                      = 0;
+        unsigned    _geoMatchingThreshold       = 100000;
+        double      _maxDiameter                = 50;
+        unsigned    _sinkClustersSize           = 20;
+        unsigned    _numStaticLayers            = 0;
         std::vector<std::string> _bufferList;
         std::vector<odb::dbNet*> _clockNetsObjs;
 };

--- a/src/TritonCTS/src/DbWrapper.cpp
+++ b/src/TritonCTS/src/DbWrapper.cpp
@@ -152,7 +152,7 @@ void DbWrapper::initClock(odb::dbNet* net) {
                                    std::string(mterm->getConstName());
                 DBU x, y;
                 computeITermPosition(iterm, x, y);
-                clockNet.addSink(name, x, y);
+                clockNet.addSink(name, x, y, iterm);
         }
         
         if (clockNet.getNumSinks() < 2) {
@@ -234,54 +234,71 @@ void DbWrapper::writeClockNetsToDb(Clock& clockNet) {
         std::map<int,uint> fanoutcount;
 
         // create subNets
-        unsigned numClkNets = 0; 
+        _numClkNets = 0; 
+        _numFixedNets = 0;
         const Clock::SubNet* rootSubNet = nullptr;
         clockNet.forEachSubNet( [&] (const Clock::SubNet& subNet) {
                         bool outputPinFound = true;
                         bool inputPinFound = true;
+                        bool leafLevelNet = subNet.isLeafLevel();
                         //std::cout << "    SubNet: " << subNet.getName() << "\n";
                         if (("clknet_0_" + clockNet.getName()) == subNet.getName()){
                                 rootSubNet = &subNet;
                         }
                         odb::dbNet* clkSubNet = odb::dbNet::create(_block, subNet.getName().c_str());
-                        ++numClkNets;
+                        ++_numClkNets;
                         clkSubNet->setSigType(odb::dbSigType::CLOCK);
                         
                         //std::cout << "      Driver: " << subNet.getDriver()->getName() << "\n";
                        
-                        odb::dbInst* driver = _block->findInst(subNet.getDriver()->getName().c_str());
+                        odb::dbInst* driver = subNet.getDriver()->getDbInst();
+                        odb::dbITerm* driverInputPin = getFirstInput(driver);
+                        odb::dbNet* inputNet = driverInputPin->getNet();
                         odb::dbITerm* outputPin = driver->getFirstOutput();
                         if (outputPin == nullptr) {
                                 outputPinFound = false;
                         }
                         odb::dbITerm::connect(outputPin, clkSubNet); 
 
-                        if ( fanoutcount.find(subNet.getNumSinks()) == fanoutcount.end() ) {
-                                fanoutcount[subNet.getNumSinks()] = 0;
+                        if (subNet.getNumSinks() == 0){
+                                inputPinFound = false;
                         }
-
-                        fanoutcount[subNet.getNumSinks()] = fanoutcount[subNet.getNumSinks()] + 1;
 
                         subNet.forEachSink( [&] (ClockInst *inst) {
                                 //std::cout << "      " << inst->getName() << "\n";
                                 odb::dbITerm* inputPin = nullptr;
                                 if (inst->isClockBuffer()) { 
-                                        odb::dbInst* sink = _block->findInst(inst->getName().c_str());
+                                        odb::dbInst* sink = inst->getDbInst();
                                         inputPin = getFirstInput(sink);
                                 } else {
-                                        inputPin = _block->findITerm(inst->getName().c_str());
+                                        inputPin = inst->getDbInputPin();
                                 }
                                 if (inputPin == nullptr) {
                                         inputPinFound = false;
+                                } else {
+                                        if (!inputPin->getInst()->isPlaced()){
+                                                inputPinFound = false;
+                                        }
                                 }
                                 odb::dbITerm::connect(inputPin, clkSubNet); 
                         });
 
+                        if (leafLevelNet){
+                                //Report fanout values only for sink nets
+                                if ( fanoutcount.find(subNet.getNumSinks()) == fanoutcount.end() ) {
+                                        fanoutcount[subNet.getNumSinks()] = 0;
+                                }
+                                fanoutcount[subNet.getNumSinks()] = fanoutcount[subNet.getNumSinks()] + 1;
+                        }
+
                         if (inputPinFound == false || outputPinFound == false){
-                                std::cout << subNet.getName() << " not fully connected. Removing it.\n";
+                                // Net not fully connected. Removing it.
                                 disconnectAllPinsFromNet(clkSubNet);
                                 odb::dbNet::destroy(clkSubNet);
-                                --numClkNets;
+                                _numFixedNets++;
+                                --_numClkNets;
+                                odb::dbInst::destroy(driver);
+                                checkUpstreamConnections(inputNet);
                         }
                 });       
         
@@ -312,11 +329,15 @@ void DbWrapper::writeClockNetsToDb(Clock& clockNet) {
                 }
         });
 
-        std::cout << " Minimum number of buffers in the clock path: " << minPath << ".\n";
-        std::cout << " Maximum number of buffers in the clock path: " << maxPath << ".\n";
+        std::cout << "    Minimum number of buffers in the clock path: " << minPath << ".\n";
+        std::cout << "    Maximum number of buffers in the clock path: " << maxPath << ".\n";
 
-        std::cout << "    Created " << numClkNets << " clock nets.\n";
-        long int currentTotalNets = _options->getNumClockSubnets() + numClkNets;
+        if (_numFixedNets > 0){
+                std::cout << "    " << _numFixedNets << " clock nets were removed/fixed.\n";
+        }
+
+        std::cout << "    Created " << _numClkNets << " clock nets.\n";
+        long int currentTotalNets = _options->getNumClockSubnets() + _numClkNets;
         _options->setNumClockSubnets(currentTotalNets);
         
         std::cout << fanoutDistString << std::endl;
@@ -324,7 +345,7 @@ void DbWrapper::writeClockNetsToDb(Clock& clockNet) {
 }
 
 std::pair<int,int> DbWrapper::branchBufferCount(ClockInst *inst, int bufCounter, Clock& clockNet){
-        odb::dbInst* sink = _block->findInst(inst->getName().c_str());
+        odb::dbInst* sink = inst->getDbInst();
         odb::dbITerm* outITerm = sink->getFirstOutput();
         int minPath = std::numeric_limits<int>::max();
         int maxPath = std::numeric_limits<int>::min();
@@ -375,11 +396,36 @@ void DbWrapper::disconnectAllPinsFromNet(odb::dbNet* net) {
         }
 }
 
-void DbWrapper::createClockBuffers(const Clock& clockNet) {
+void DbWrapper::checkUpstreamConnections(odb::dbNet* net) {
+        odb::dbNet* currentNet = net;
+        while (currentNet->getITermCount() <= 1){
+                //Net is incomplete, only 1 pin.
+                odb::dbITerm* firstITerm = currentNet->get1stITerm();
+                if (firstITerm == nullptr) {
+                        disconnectAllPinsFromNet(currentNet);
+                        odb::dbNet::destroy(currentNet);
+                        break;
+                } else {
+                        odb::dbInst* bufferInst = firstITerm->getInst();
+                        odb::dbITerm* driverInputPin = getFirstInput(bufferInst);
+                        disconnectAllPinsFromNet(currentNet);
+                        odb::dbNet::destroy(currentNet);
+                        currentNet = driverInputPin->getNet();
+                        ++_numFixedNets;
+                        --_numClkNets;
+                        odb::dbInst::destroy(bufferInst);
+                }
+        }
+
+}
+
+void DbWrapper::createClockBuffers(Clock& clockNet) {
         unsigned numBuffers = 0;
-        clockNet.forEachClockBuffer([&] (const ClockInst& inst) {
+        clockNet.forEachClockBuffer([&] (ClockInst& inst) {
                 odb::dbMaster* master = _db->findMaster(inst.getMaster().c_str());
                 odb::dbInst* newInst = odb::dbInst::create(_block, master, inst.getName().c_str());
+                inst.setInstObj(newInst);
+                inst.setInputPinObj(getFirstInput(newInst));
                 newInst->setLocation(inst.getX(), inst.getY());        
                 newInst->setPlacementStatus(odb::dbPlacementStatus::PLACED);
                 ++numBuffers;

--- a/src/TritonCTS/src/DbWrapper.h
+++ b/src/TritonCTS/src/DbWrapper.h
@@ -78,6 +78,8 @@ private:
         CtsOptions*       _options              = nullptr;
         TritonCTSKernel*  _kernel               = nullptr;  
         unsigned          _numberOfClocks       = 0;       
+        unsigned          _numClkNets           = 0;   
+        unsigned          _numFixedNets         = 0;
 
         void parseClockNames(std::vector<std::string>& clockNetNames) const;
 
@@ -87,7 +89,8 @@ private:
         
         void disconnectAllSinksFromNet(odb::dbNet* net);
         void disconnectAllPinsFromNet(odb::dbNet* net);
-        void createClockBuffers(const Clock& clk);
+        void checkUpstreamConnections(odb::dbNet* net);
+        void createClockBuffers(Clock& clk);
         void removeNonClockNets();
         void computeITermPosition(odb::dbITerm* term, DBU &x, DBU &y) const;
         std::pair<int,int> branchBufferCount(ClockInst *inst, int bufCounter, Clock& clockNet);

--- a/src/TritonCTS/src/HTreeBuilder.h
+++ b/src/TritonCTS/src/HTreeBuilder.h
@@ -197,7 +197,7 @@ private:
         void computeBranchSinks(LevelTopology& topology, unsigned branchIdx,
                                 std::vector<std::pair<float,float>>& sinkLocations) const;
         
-        bool isVertical(unsigned level) const { return level % 2 == 0; }
+        bool isVertical(unsigned level) const { return level % 2 == (_sinkRegion.getHeight() >= _sinkRegion.getWidth()); }
         bool isHorizontal(unsigned level) const { return !isVertical(level); }
 
         unsigned computeGridSizeX(unsigned level) const { return std::pow(2, (level + 1) / 2); }
@@ -209,8 +209,20 @@ private:
                                                  unsigned branchPtIdx1,
                                                  unsigned branchPtIdx2, 
                                                  const Point<double>& rootLocation,
-                                                 const std::vector<std::pair<float, float>>& topLevelSinks );
-        
+                                                 const std::vector<std::pair<float, float>>& sinks);
+        void preClusteringOpt(const std::vector<std::pair<float, float>>& sinks,
+                              std::vector<std::pair<float, float>>& points,
+                              std::vector<unsigned>& mapSinkToPoint);
+        void preSinkClustering(std::vector<std::pair<float, float>>& sinks,
+                                    float maxDiameter, unsigned clusterSize);
+        void assignSinksToBranches(LevelTopology& topology,
+                                   unsigned branchPtIdx1,
+                                   unsigned branchPtIdx2,
+                                   const std::vector<std::pair<float, float>>& sinks,
+                                   const std::vector<std::pair<float, float>>& points,
+                                   const std::vector<unsigned>& mapSinkToPoint,
+                                   const std::vector<std::vector<unsigned>>& clusters);        
+
         bool isSubRegionTooSmall(double width, double height) const {
                 if (width < _minLengthSinkRegion || height < _minLengthSinkRegion ) {
                         return true;
@@ -228,6 +240,8 @@ private:
 protected:
         Box<double>                _sinkRegion;
         std::vector<LevelTopology> _topologyForEachLevel;
+        std::map<Point<double>, ClockInst*> _mapLocationToSink;
+        std::vector<std::pair<float, float>> _topLevelSinksClustered;
         
         DBU      _wireSegmentUnit     = -1;
         unsigned _minInputCap         =  1;

--- a/src/TritonCTS/src/SinkClustering.cpp
+++ b/src/TritonCTS/src/SinkClustering.cpp
@@ -1,0 +1,320 @@
+#include "SinkClustering.h"
+#include <tuple>
+#include <iostream>
+#include <cmath> 
+#include <algorithm>
+#include <fstream>
+#include <map>
+#include <string>
+
+namespace TritonCTS {
+
+void SinkClustering::normalizePoints(float maxDiameter) {
+        double xMax = -std::numeric_limits<double>::infinity();
+        double xMin =  std::numeric_limits<double>::infinity();
+        double yMax = -std::numeric_limits<double>::infinity();
+        double yMin =  std::numeric_limits<double>::infinity();
+        for (const Point<double>& p : _points) {         
+                xMax = std::max(p.getX(), xMax);        
+                yMax = std::max(p.getY(), yMax);        
+                xMin = std::min(p.getX(), xMin);        
+                yMin = std::min(p.getY(), yMin);        
+        }
+
+        double xSpan = xMax - xMin;
+        double ySpan = yMax - yMin;
+        for (Point<double>& p : _points) {
+                double x = p.getX();
+                double xNorm = (x - xMin) / xSpan; 
+                double y = p.getY();
+                double yNorm = (y - yMin)/ ySpan; 
+                p = Point<double>(xNorm, yNorm);
+        }
+        _maxInternalDiameter = maxDiameter / std::min(xSpan, ySpan);
+}
+
+void SinkClustering::computeAllThetas() {
+        for (unsigned idx = 0; idx < _points.size(); ++idx) {
+                const Point<double>& p = _points[idx];
+                double theta = computeTheta(p.getX(), p.getY());
+                _thetaIndexVector.emplace_back(theta, idx);
+        }
+}
+
+void SinkClustering::sortPoints() {
+        std::sort(_thetaIndexVector.begin(), _thetaIndexVector.end());
+}
+
+double SinkClustering::computeTheta(double x, double y) const {
+        if (isOne(x) && isOne(y)) {
+                return 0.5;        
+        }
+        
+        unsigned quad = numVertex(std::min(unsigned(2.0 * x), (unsigned) 1), 
+                                  std::min(unsigned(2.0 * y), (unsigned) 1));
+
+        double t = computeTheta(2 * std::fabs(x - 0.5),
+                                2 * std::fabs(y - 0.5)); 
+
+        if (quad % 2 == 1) {
+                t = 1 - t;
+        }
+
+        double integral;
+        double fractal = std::modf((quad + t) / 4.0 + 7.0 / 8.0, &integral);
+        return fractal;
+}
+
+unsigned SinkClustering::numVertex(unsigned x, unsigned y) const {
+        if ((x == 0) && (y == 0)) {
+                return 0;
+        } else if ((x == 0) && (y == 1)) {
+                return 1;
+        } else if ((x == 1) && (y == 1)) {
+                return 2; 
+        } else if ((x == 1) && (y == 0)) {
+                return 3;
+        }
+        
+        std::cout << "[ERROR] Invalid parameters in " << __func__ << "\n";
+        std::exit(1);
+}
+
+void SinkClustering::findBestMatching() {
+        std::vector<Matching> matching0;
+        std::vector<Matching> matching1;
+        double matchingCost0 = 0.0;
+        double matchingCost1 = 0.0;
+
+        for (unsigned i = 0; i < _thetaIndexVector.size() - 1; ++i) {
+                unsigned idx0 = _thetaIndexVector[i].second;
+                unsigned idx1 = _thetaIndexVector[i + 1].second;
+                Point<double>& p0 = _points[idx0];
+                Point<double>& p1 = _points[idx1];
+                
+                double cost = p0.computeDist(p1);
+                if (i % 2 == 0) {
+                        matching0.emplace_back(idx0, idx1);
+                        matchingCost0 += cost;
+                } else {
+                        matching1.emplace_back(idx0, idx1);
+                        matchingCost1 += cost;
+                }
+        }
+        
+        // Cost 1 needs to sum the distance from first to last
+        // element
+        unsigned idx0 = _thetaIndexVector.front().second;
+        unsigned idx1 = _thetaIndexVector.back().second; 
+        matching1.emplace_back(idx0, idx1);
+        Point<double>& p0 = _points[idx0];
+        Point<double>& p1 = _points[idx1];
+        matchingCost1 += p0.computeDist(p1);
+        
+        std::cout << "Matching0 size: " << matching0.size() << "\n";
+        std::cout << "Matching1 size: " << matching1.size() << "\n";
+        if (matchingCost0 < matchingCost1) {
+                _matchings = matching0;
+        } else {
+                _matchings = matching1;
+        }
+}
+
+void SinkClustering::run() {
+        normalizePoints();
+        computeAllThetas();
+        sortPoints();
+        findBestMatching();        
+        //writePlotFile();
+}
+
+void SinkClustering::run(unsigned groupSize, float maxDiameter) {
+        normalizePoints(maxDiameter);
+        computeAllThetas();
+        sortPoints();
+        findBestMatching(groupSize);        
+        //writePlotFile(groupSize);
+}
+
+void SinkClustering::writePlotFile() {
+        std::ofstream file("plot.py");
+        file << "import numpy as np\n"; 
+        file << "import matplotlib.pyplot as plt\n";
+        file << "import matplotlib.path as mpath\n";
+        file << "import matplotlib.lines as mlines\n";
+        file << "import matplotlib.patches as mpatches\n";
+        file << "from matplotlib.collections import PatchCollection\n\n";
+
+        for (unsigned idx = 0; idx < _thetaIndexVector.size() - 1; idx += 2) {
+                unsigned idx0 = _thetaIndexVector[idx].second;
+                unsigned idx1 = _thetaIndexVector[idx+1].second;
+                Point<double>& p0 = _points[idx0];
+                Point<double>& p1 = _points[idx1];
+                file << "plt.scatter(" << p0.getX() << ", " << p0.getY() << ")\n";
+                file << "plt.scatter(" << p1.getX() << ", " << p1.getY() << ")\n";
+                file << "plt.plot([" << p0.getX() << ", " << p1.getX() << "], ["
+                     << p0.getY() << ", " << p1.getY() << "])\n";
+        }
+
+        file << "plt.show()\n"; 
+        file.close();
+}
+
+void SinkClustering::findBestMatching(unsigned groupSize) {
+        //Counts how many clusters are in each solution.
+        std::vector<unsigned> clusters (groupSize, 0);
+        //Keeps track of the total cost of each solution.
+        std::vector<double> costs (groupSize, 0);
+        std::vector<double> previousCosts (groupSize, 0);
+        //Has the points for each cluster of each solution.
+        std::vector<std::vector<std::vector<Point<double>>>> solutionPoints;
+        //Has the sink indexes for each cluster of each solution.
+        std::vector<std::vector<std::vector<unsigned>>> solutions;
+
+        //Iterates over the theta vector.
+        for (unsigned i = 0; i < _thetaIndexVector.size(); ++i) {
+                //The - groupSize is because each solution will start on a different index. There is groupSize solutions.
+                for (unsigned j = 0; j < groupSize; ++j){
+                        if ((i + j) >= _thetaIndexVector.size()){
+                                continue;
+                        }
+                        //Add vectors in case they are no allocated yet.
+                        if (solutions.size() < (j + 1)){
+                                std::vector<std::vector<unsigned>> clusterIndexes;
+                                solutions.push_back(clusterIndexes);
+                                std::vector<std::vector<Point<double>>> clusterPoints;
+                                solutionPoints.push_back(clusterPoints);
+                        }
+                        if (solutions[j].size() < (clusters[j] + 1)) {
+                                std::vector<unsigned> indexesVector;
+                                solutions[j].push_back(indexesVector);
+                                std::vector<Point<double>> pointsVector;
+                                solutionPoints[j].push_back(pointsVector);
+                        }
+                        //Get the current point
+                        unsigned idx = _thetaIndexVector[i + j].second;
+                        Point<double>& p = _points[idx];
+                        double distanceCost = 0;
+                        //Check the distance from the current point to others in the cluster, if there are any.
+                        for (Point<double> comparisonPoint : solutionPoints[j][clusters[j]]){
+                                double cost = p.computeDist(comparisonPoint);
+                                if (cost > distanceCost){
+                                        distanceCost = cost;
+                                }
+                        }
+                        //If the cluster size is higher than groupSize, or the distance is higher than _maxInternalDiameter -> start another cluster and save the cost of the current one.
+                        if (solutionPoints[j][clusters[j]].size() >= groupSize || distanceCost > _maxInternalDiameter){
+                                //The cost is computed as the highest cost found on the current cluster
+                                if (previousCosts[j] == 0){
+                                        previousCosts[j] = _maxInternalDiameter;
+                                }
+                                costs[j] += previousCosts[j];
+                                //A new cluster is defined
+                                clusters[j] = clusters[j] + 1;
+                                //The cost was already saved, so the same structure can be used for the next cluster.
+                                previousCosts[j] = 0;
+                        } else {
+                                //Node will be a part of the current cluster, thus, save the highest cost.
+                                if (distanceCost > previousCosts[j]){
+                                        previousCosts[j] = distanceCost;
+                                }
+                        }
+                        //Add vectors in case they are no allocated yet. (Depends if a new cluster was defined above)
+                        if (solutions[j].size() < (clusters[j] + 1)) {
+                                std::vector<unsigned> indexesVector;
+                                solutions[j].push_back(indexesVector);
+                                std::vector<Point<double>> pointsVector;
+                                solutionPoints[j].push_back(pointsVector);
+                        }
+                        //Save the current Point in it's respective cluster. (Depends if a new cluster was defined above)
+                        solutionPoints[j][clusters[j]].push_back(p);   
+                        solutions[j][clusters[j]].push_back(idx);
+                }
+        }
+
+        //Same computation as above, however, only for the first groupSize Points.
+        for (unsigned i = 0; i < groupSize; ++i) {
+                //This is because every solution after the first one skips a Point (starts one late).
+                for (unsigned j = (i+1); j < groupSize; ++j){
+                        if (solutions[j].size() < (clusters[j] + 1)) {
+                                std::vector<unsigned> indexesVector;
+                                solutions[j].push_back(indexesVector);
+                                std::vector<Point<double>> pointsVector;
+                                solutionPoints[j].push_back(pointsVector);
+                        }
+                        //Thus here we will assign the Points missing from those solutions.
+                        unsigned idx = _thetaIndexVector[i].second;
+                        Point<double>& p = _points[idx];
+                        double distanceCost = 0;
+                        for (Point<double> comparisonPoint : solutionPoints[j][clusters[j]]){
+                                double cost = p.computeDist(comparisonPoint);
+                                if (cost > distanceCost){
+                                        distanceCost = cost;
+                                }
+                        }
+                        if (solutionPoints[j][clusters[j]].size() >= groupSize || distanceCost > _maxInternalDiameter){
+                                if (previousCosts[j] == 0){
+                                        previousCosts[j] = _maxInternalDiameter;
+                                }
+                                costs[j] += previousCosts[j];
+                                clusters[j] = clusters[j] + 1;
+                                previousCosts[j] = 0;
+                        } else {
+                                if (distanceCost > previousCosts[j]){
+                                        previousCosts[j] = distanceCost;
+                                }
+                        }
+                        if (solutions[j].size() < (clusters[j] + 1)) {
+                                std::vector<unsigned> indexesVector;
+                                solutions[j].push_back(indexesVector);
+                                std::vector<Point<double>> pointsVector;
+                                solutionPoints[j].push_back(pointsVector);
+                        }
+                        solutionPoints[j][clusters[j]].push_back(p);   
+                        solutions[j][clusters[j]].push_back(idx);   
+                }
+        }
+
+        unsigned bestSolution = 0;
+        double bestSolutionCost = costs[0];
+        
+        //Find the solution with minimum cost.
+        for (unsigned j = 1; j < groupSize; ++j){
+                if (costs[j] < bestSolutionCost){
+                        bestSolution = j;
+                        bestSolutionCost = costs[j];
+                }
+        }
+
+        //Save the solution for the Tree Builder.
+        _bestSolution = solutions[bestSolution];
+}
+
+void SinkClustering::writePlotFile(unsigned groupSize) {
+        std::ofstream file("plot_clustering.py");
+        file << "import numpy as np\n"; 
+        file << "import matplotlib.pyplot as plt\n";
+        file << "import matplotlib.path as mpath\n";
+        file << "import matplotlib.lines as mlines\n";
+        file << "import matplotlib.patches as mpatches\n";
+        file << "from matplotlib.collections import PatchCollection\n\n";
+        std::vector<std::string> colors;
+        colors.push_back("tab:blue"); colors.push_back("tab:orange"); colors.push_back("tab:green"); colors.push_back("tab:red");
+        colors.push_back("tab:purple"); colors.push_back("tab:brown"); colors.push_back("tab:pink"); colors.push_back("tab:gray");
+        colors.push_back("tab:olive"); colors.push_back("tab:cyan");
+
+        unsigned clusterCounter = 0;
+        for (std::vector<unsigned> clusters : _bestSolution) {
+                unsigned currentColor = clusterCounter % colors.size();
+                for (unsigned idx : clusters){
+                        Point<double>& currentPoint = _points[idx];
+                        file << "plt.scatter(" << currentPoint.getX() << ", " << currentPoint.getY() << ", c=\"" << colors[currentColor] << "\")\n";
+                }
+                clusterCounter++;
+        }
+
+        file << "plt.show()\n"; 
+        file.close();
+}
+
+}

--- a/src/TritonCTS/src/SinkClustering.h
+++ b/src/TritonCTS/src/SinkClustering.h
@@ -1,0 +1,62 @@
+#ifndef GEO_MATCHING
+#define GEO_MATCHING
+
+#include "Util.h"
+
+#include <vector>
+#include <limits>
+#include <map>
+#include <string>
+
+namespace TritonCTS {
+
+class Matching {
+public:
+        Matching(unsigned p0, unsigned p1) : _p0(p0), _p1(p1) {}
+
+        unsigned getP0() const { return _p0; }
+        unsigned getP1() const { return _p1; }
+private:
+        unsigned _p0;
+        unsigned _p1;
+};
+
+class SinkClustering {
+public:
+        SinkClustering() = default;
+
+        void addPoint(double x, double y) {  _points.emplace_back(x, y); }
+        void run();
+        void run(unsigned groupSize, float maxDiameter);
+        unsigned getNumPoints() const { return _points.size(); }
+        
+        const std::vector<Matching>& allMatchings() const { return _matchings; } 
+
+        std::vector<std::vector<unsigned>> sinkClusteringSolution() { return _bestSolution; } 
+
+private:
+        void normalizePoints(float maxDiameter = 10);
+        void computeAllThetas();
+        void sortPoints();
+        void findBestMatching();
+        void writePlotFile();
+        void findBestMatching(unsigned groupSize);
+        void writePlotFile(unsigned groupSize);
+        
+        double computeTheta(double x, double y) const;
+        unsigned numVertex(unsigned x, unsigned y) const;
+        
+        bool isOne(double pos) const { return (1 - pos) < std::numeric_limits<double>::epsilon(); }
+        bool isZero(double pos) const { return pos < std::numeric_limits<double>::epsilon(); }
+        
+        std::vector<Point<double>> _points;
+        std::vector<std::pair<double, unsigned>> _thetaIndexVector;
+        std::vector<Matching> _matchings;
+        std::map<unsigned, std::vector<Point<double>>> _sinkClusters;
+        std::vector<std::vector<unsigned>> _bestSolution;
+        float _maxInternalDiameter = 10;
+};
+
+}
+
+#endif 

--- a/src/TritonCTS/src/TritonCTSKernel.h
+++ b/src/TritonCTS/src/TritonCTSKernel.h
@@ -83,11 +83,14 @@ private:
 // TCL commands
 public:
         void set_only_characterization(bool enable);
+        void set_simple_cts(bool enable);
+        void set_sink_clustering(bool enable);
         void set_auto_lut(bool enable);
         void set_lut_file(const char* file);
         void set_sol_list_file(const char* file);
         void export_characterization(const char* file);
         void set_root_buffer(const char* buffer);
+        void set_sink_buffer(const char* buffer);
         void set_buffer_list(const char* buffers);
         int set_clock_nets(const char* names);
         void set_wire_segment_distance_unit(unsigned unit);
@@ -108,6 +111,10 @@ public:
         void set_disable_post_cts(bool disable);
         void set_clustering_exponent(unsigned power);
         void set_clustering_unbalance_ratio(double ratio);
+	void set_geo_matching_threshold(unsigned threshold);
+        void set_sink_clustering_size(unsigned size);
+        void set_clustering_diameter(double distance);
+        void set_num_static_layers(unsigned num);
 };
 
 }

--- a/src/TritonCTS/src/TritonCTSKernelTcl.cpp
+++ b/src/TritonCTS/src/TritonCTSKernelTcl.cpp
@@ -50,6 +50,14 @@ void TritonCTSKernel::set_only_characterization(bool enable) {
         _options.setOnlyCharacterization(enable);
 }
 
+void TritonCTSKernel::set_simple_cts(bool enable) {
+        _options.setSimpleCts(enable);
+}
+
+void TritonCTSKernel::set_sink_clustering(bool enable) {
+        _options.setSinkClustering(enable);
+}
+
 void TritonCTSKernel::set_auto_lut(bool enable) {
         _options.setAutoLut(enable);
 }
@@ -188,8 +196,29 @@ void TritonCTSKernel::set_disable_post_cts(bool disable) {
 void TritonCTSKernel::set_clustering_exponent(unsigned power){
         _options.setClusteringPower(power);
 }
+
 void TritonCTSKernel::set_clustering_unbalance_ratio(double ratio){
         _options.setClusteringCapacity(ratio);
+}
+
+void TritonCTSKernel::set_geo_matching_threshold(unsigned threshold) {
+	_options.setGeoMatchingThreshold(threshold);
+}
+
+void TritonCTSKernel::set_sink_clustering_size(unsigned size){
+        _options.setSizeSinkClustering(size);
+}
+
+void TritonCTSKernel::set_clustering_diameter(double distance){
+        _options.setMaxDiameter(distance);
+}
+
+void TritonCTSKernel::set_num_static_layers(unsigned num){
+        _options.setNumStaticLayers(num);
+}
+
+void TritonCTSKernel::set_sink_buffer(const char* buffer) {
+        _options.setSinkBuffer(buffer);
 }
 
 }

--- a/src/TritonCTS/src/third_party/CKMeans/clustering.cpp
+++ b/src/TritonCTS/src/third_party/CKMeans/clustering.cpp
@@ -68,10 +68,10 @@ int myrandom (int i) {
 clustering::clustering(const vector<std::pair<float, float>>& sinks, 
                        float xBranch, float yBranch) {
 	for (unsigned i = 0; i < sinks.size(); ++i) {
-        	flops.push_back(new flop(sinks[i].first, sinks[i].second, i));
-		flops.back()->dists.resize(1);	
-		flops.back()->match_idx.resize(1);	
-		flops.back()->silhs.resize(1);	
+        	flops.push_back(flop(sinks[i].first, sinks[i].second, i));
+		flops.back().dists.resize(1);	
+		flops.back().match_idx.resize(1);	
+		flops.back().silhs.resize(1);	
 	}
 	srand(56);
 	
@@ -79,9 +79,6 @@ clustering::clustering(const vector<std::pair<float, float>>& sinks,
 }
 
 clustering::~clustering() {
-	for (unsigned i = 0; i < flops.size(); ++i) {
-		delete flops[i];
-	}
 }
 
 /*** Capacitated K means **************************************************/
@@ -111,7 +108,7 @@ void clustering::iterKmeans(unsigned ITER, unsigned N, unsigned CAP, unsigned ID
         if (silh > max_silh) {
             max_silh = silh;
             for (unsigned j = 0; j < flops.size(); ++j)
-                sol[j] = flops[j]->match_idx[IDX];
+                sol[j] = flops[j].match_idx[IDX];
             _means.resize(means.size());
             for (unsigned j = 0; j < means.size(); ++j)
                 _means[j] = means[j];
@@ -119,7 +116,7 @@ void clustering::iterKmeans(unsigned ITER, unsigned N, unsigned CAP, unsigned ID
     }
 
     for (unsigned i = 0; i < flops.size(); ++i) 
-        flops[i]->match_idx[IDX] = sol[i];
+        flops[i].match_idx[IDX] = sol[i];
 
     // print clustering solution
     if (TEST_LAYOUT == 1) {
@@ -129,7 +126,7 @@ void clustering::iterKmeans(unsigned ITER, unsigned N, unsigned CAP, unsigned ID
             outFile << "TRAY " << i << " " << _means[i].first << " " << _means[i].second << endl;
         }
         for (unsigned i = 0; i < flops.size(); ++i) {
-            flop * f = flops[i];
+            flop * f = &flops[i];
             //outFile << "FLOP " << f->name << " " << flops[i]->match_idx[IDX].first << endl;
         }
         outFile.close();
@@ -207,17 +204,17 @@ float clustering::Kmeans (unsigned N, unsigned CAP, unsigned IDX, vector<pair<fl
 	vector<vector<flop*>> clusters;    
 
 	for (unsigned i = 0; i < flops.size(); ++i) {
-		flops[i]->dists[IDX] = 0;
+		flops[i].dists[IDX] = 0;
 		for (unsigned j = 0; j < N; ++j)
 		{
-			flops[i]->dists[IDX] += 
-				calcDist(make_pair(means[j].first, means[j].second), flops[i]);
+			flops[i].dists[IDX] += 
+				calcDist(make_pair(means[j].first, means[j].second), &flops[i]);
 		}
 	}
 	
     // initialize matching indexes for flops
     for (unsigned i = 0; i < flops.size(); ++i) {
-        flop * f = flops[i];
+        flop * f = &flops[i];
         f->match_idx[IDX] = make_pair(-1, -1);
     }
 
@@ -255,13 +252,17 @@ float clustering::Kmeans (unsigned N, unsigned CAP, unsigned IDX, vector<pair<fl
         clusters.clear();
         clusters.resize(N);
         for (unsigned i = 0; i < flops.size(); ++i) {
-            flop * f = flops[i];
+            flop * f = &flops[i];
             int position = 0;
             if (f->match_idx[IDX].first >= 0 && f->match_idx[IDX].first < N){
                 position = f->match_idx[IDX].first;
+            } else {
+                if (clusters[0].size() >= CAP){
+                    position = 1;
+                }
             }
             clusters[position].push_back(f);
-        }
+        } 
 
         // always use mode 1
         unsigned update_mode = 1;
@@ -290,8 +291,8 @@ float clustering::Kmeans (unsigned N, unsigned CAP, unsigned IDX, vector<pair<fl
 					means[i] = make_pair(sum_x/clusters[i].size(), sum_y/clusters[i].size());
 					delta += abs(pre_x - means[i].first) + abs(pre_y - means[i].second);
 				} else {
-					cout << "WARNING: Empty cluster [" << i << "] " <<
-						"in a level with " << clusters.size() << " clusters.\n";
+					//cout << "WARNING: Empty cluster [" << i << "] " <<
+					//	"in a level with " << clusters.size() << " clusters.\n";
 				}
             }
         }
@@ -341,7 +342,7 @@ float clustering::Kmeans (unsigned N, unsigned CAP, unsigned IDX, vector<pair<fl
 float clustering::calcSilh(const vector<pair<float, float>>& means, unsigned CAP, unsigned IDX) {
     float sum_silh = 0;
     for (unsigned i = 0; i < flops.size(); ++i) {
-        flop * f = flops[i];
+        flop * f = &flops[i];
         float in_d = 0, out_d = INT_MAX;
         for (unsigned j = 0; j < means.size(); ++j) {
             float _x = means[j].first;
@@ -352,10 +353,9 @@ float clustering::calcSilh(const vector<pair<float, float>>& means, unsigned CAP
                 in_d = calcDist(make_pair(_x, _y), f);
             } else {
                 // outside of the cluster
-                for (unsigned k = 0; k < CAP; ++k) {
-                    float d = calcDist(make_pair(_x, _y), f);
-                    if (d < out_d)
-                        out_d = d;
+                float d = calcDist(make_pair(_x, _y), f);
+                if (d < out_d) { 
+                    out_d = d;
                 }
             }
         }
@@ -428,7 +428,7 @@ void clustering::minCostFlow (const vector<pair<float, float>>& means, unsigned 
 //                    slot_loc = make_pair(_x, _y);
 //                }
                 //float d = calcDist(slot_loc, flops[i]);
-				float d = calcDist(make_pair(_x, _y), flops[i]);
+				float d = calcDist(make_pair(_x, _y), &flops[i]);
                 if (d > DIST){
                     continue;
                 }
@@ -519,7 +519,7 @@ void clustering::minCostFlow (const vector<pair<float, float>>& means, unsigned 
                 cout << " slot_" << node_map[g.target(it)].second.second;
                 cout << " flow = " << f_sol[it] << endl;
                 }
-                flops[node_map[g.source(it)].first]->match_idx[IDX] = node_map[g.target(it)].second;
+                flops[node_map[g.source(it)].first].match_idx[IDX] = node_map[g.target(it)].second;
             }
         }
     }

--- a/src/TritonCTS/src/third_party/CKMeans/clustering.h
+++ b/src/TritonCTS/src/third_party/CKMeans/clustering.h
@@ -55,7 +55,7 @@ public:
 
 
 class clustering {
-	vector<flop*> flops;
+	vector<flop> flops;
 	vector<vector<flop*>> clusters;
 	
 	//map<unsigned, vector<pair<float, float>>> shifts;  // relative x- and y-shifts of slots w.r.t tray 

--- a/src/TritonCTS/src/tritoncts.tcl
+++ b/src/TritonCTS/src/tritoncts.tcl
@@ -53,13 +53,19 @@ sta::define_cmd_args "clock_tree_synthesis" {[-lut_file lut] \
                                              [-branching_point_buffers_distance] \
                                              [-clustering_exponent] \
                                              [-clustering_unbalance_ratio] \
+					                                   [-geo_matching_threshold] \
+                                             [-sink_clustering_size] \
+                                             [-sink_clustering_max_diameter] \
+                                             [-sink_clustering_enable] \
+                                             [-num_static_layers] \
+                                             [-sink_clustering_buffer] \
                                             } 
 
 proc clock_tree_synthesis { args } {
   sta::parse_key_args "clock_tree_synthesis" args \
-    keys {-lut_file -sol_list -root_buf -buf_list -wire_unit -max_cap -max_slew -clk_nets -out_path -sqr_cap -sqr_res -slew_inter \
-    -cap_inter -distance_between_buffers -branching_point_buffers_distance -clustering_exponent -clustering_unbalance_ratio} \
-    flags {-characterization_only -post_cts_disable}
+    keys {-lut_file -sol_list -root_buf -buf_list -wire_unit -max_cap -max_slew -clk_nets -out_path -sqr_cap -sqr_res -slew_inter -sink_clustering_size -num_static_layers -sink_clustering_buffer\
+    -cap_inter -distance_between_buffers -branching_point_buffers_distance -clustering_exponent -clustering_unbalance_ratio -geo_matching_threshold -sink_clustering_max_diameter} \
+    flags {-characterization_only -post_cts_disable -sink_clustering_enable}
 
   set cts [get_triton_cts]
 
@@ -74,6 +80,23 @@ proc clock_tree_synthesis { args } {
   $cts set_only_characterization [info exists flags(-characterization_only)]
 
   $cts set_disable_post_cts [info exists flags(-post_cts_disable)]
+
+  $cts set_sink_clustering [info exists flags(-sink_clustering_enable)]
+
+  if { [info exists keys(-sink_clustering_size)] } {
+    set size $keys(-sink_clustering_size)
+    $cts set_sink_clustering_size $size
+  } 
+
+  if { [info exists keys(-sink_clustering_max_diameter)] } {
+    set distance $keys(-sink_clustering_max_diameter)
+    $cts set_clustering_diameter $distance
+  } 
+
+  if { [info exists keys(-num_static_layers)] } {
+    set num $keys(-num_static_layers)
+    $cts set_num_static_layers $num
+  } 
 
   if { [info exists keys(-distance_between_buffers)] } {
     set distance $keys(-distance_between_buffers)
@@ -158,15 +181,29 @@ proc clock_tree_synthesis { args } {
 
   if { [info exists keys(-root_buf)] } {
     set root_buf $keys(-root_buf)
+    if { [llength $root_buf] > 1} {
+      set root_buf [lindex $root_buf 0]
+    }
     $cts set_root_buffer $root_buf
   } else {
     if { [info exists keys(-buf_list)] } {
       #If using -buf_list, the first buffer can become the root buffer.
-      $cts set_root_buffer [lindex $buf_list 0]
+      set root_buf [lindex $buf_list 0]
+      $cts set_root_buffer $root_buf
     } else {
       #User must enter at least one of -root_buf or -buf_list.
       ord::error "Missing argument -root_buf"
     }
+  }
+
+  if { [info exists keys(-sink_clustering_buffer)] } {
+    set sink_buf $keys(-sink_clustering_buffer)
+    if { [llength $sink_buf] > 1} {
+      set sink_buf [lindex $sink_buf 0]
+    }
+    $cts set_sink_buffer $sink_buf
+  } else {
+    $cts set_sink_buffer $root_buf
   }
 
   if { [info exists keys(-out_path)] && (![info exists keys(-lut_file)] || ![info exists keys(-sol_list)]) } {
@@ -184,6 +221,12 @@ proc clock_tree_synthesis { args } {
       #User must enter capacitance and resistance per square (um²) when creating a new characterization.
       ord::error "Missing argument -sqr_cap and/or -sqr_res"
     }
+  }
+
+  if { [info exists keys(-geo_matching_threshold)] } {
+        set threshold $keys(-geo_matching_threshold)
+	      puts $threshold
+        $cts set_geo_matching_threshold $threshold
   }
 
   if {[catch {$cts run_triton_cts} error_msg options]} {


### PR DESCRIPTION
This includes the following changes in the behavior of TritonCTS:

- Branches are now automatically oriented based on the aspect ratio of the sink region.
- The number of CKMeans optimation iterations is now 20.

The following are possible with new parameters, but are not set as default:

- Sink Clustering with Space-Filling Curves.
- Sink Clustering Diameter (um) and Size.
- Distance between buffers (um).
- Distance in a branch to force a branching point buffer (um).
- Post-CTS (buffer insertion for outlier sinks) disable flag.
- Setting the master used to drive the sinks.
- A number of static H-Tree layers.
