### PR TITLE
FastRoute: write guide using the LEF units

### DIFF
--- a/src/FastRoute/include/fastroute/GlobalRouter.h
+++ b/src/FastRoute/include/fastroute/GlobalRouter.h
@@ -316,6 +316,9 @@ protected:
   // Variables for PADs obstacles handling
   std::map<Net*, std::vector<FastRoute::GSegment>> _padPinsConnections;
 
+  //  For guides output: factor between DB and lef.
+  int lef_factor;
+  
   // db variables
   sta::dbSta* _openSta;
   int selectedMetal = 3;

--- a/src/FastRoute/src/GlobalRouter.cpp
+++ b/src/FastRoute/src/GlobalRouter.cpp
@@ -1258,6 +1258,14 @@ void GlobalRouter::writeGuides(const char* fileName)
   std::cout << "[INFO] Num routed nets: " << _routes.size() << "\n";
   int finalLayer;
 
+  // In general, DBu is the same as LEF units, but not always.
+  odb::dbTech* tech = _db->getTech();
+  lef_factor = tech->getDbUnitsPerMicron() / tech->getLefUnits();
+  assert(lef_factor >= 1);
+
+  offsetX /= lef_factor;
+  offsetY /= lef_factor;
+
   // Sort nets so guide file net order is consistent.
   std::vector<odb::dbNet*> sorted_nets;
   for (odb::dbNet* net : _block->getNets())
@@ -1640,6 +1648,14 @@ Box GlobalRouter::globalRoutingToBox(const GSegment& route)
     urY = dieBounds.getUpperBound().getY();
   }
 
+  //  Convert to LEF units
+  if (lef_factor != 1) {
+    llX /= lef_factor;
+    llY /= lef_factor;
+    urX /= lef_factor;
+    urY /= lef_factor;
+  }
+  
   Coordinate lowerLeft = Coordinate(llX, llY);
   Coordinate upperRight = Coordinate(urX, urY);
 


### PR DESCRIPTION
The guide values were the raw DB units, which often correspond
to the LEF units.  But not always.  According to lefin::units,
the DB unit is at least 1 nm.  If the LEF unit was less than 1000,
the guide values were in nm, which is not what TritonRoute expects.

Another possible fix is to always use LEF units for DB units.