### PR TITLE
[FR] Ignore OBSes completely outside the die area

### DIFF
--- a/src/FastRoute/src/GlobalRouter.cpp
+++ b/src/FastRoute/src/GlobalRouter.cpp
@@ -1086,6 +1086,9 @@ void GlobalRouter::computeObstaclesAdjustments()
       for (odb::Rect& obs : layerObstacles) {
         if (obs.xMax() <= _grid->getLowerLeftX() || obs.xMin() >= _grid->getUpperRightX() ||
 	    obs.yMax() <= _grid->getLowerLeftY() || obs.yMin() >= _grid->getUpperRightY()) {
+		std::cout << "[WARNING] Ignoring an obstruction on "
+			  << routingLayer.getName()
+			  <<" outside the die area.\n";
 		continue;
 	}
 

--- a/src/FastRoute/src/GlobalRouter.cpp
+++ b/src/FastRoute/src/GlobalRouter.cpp
@@ -1084,6 +1084,11 @@ void GlobalRouter::computeObstaclesAdjustments()
       int trackSpace = _grid->getMinWidths()[layer - 1];
 
       for (odb::Rect& obs : layerObstacles) {
+        if (obs.xMax() <= _grid->getLowerLeftX() || obs.xMin() >= _grid->getUpperRightX() ||
+	    obs.yMax() <= _grid->getLowerLeftY() || obs.yMin() >= _grid->getUpperRightY()) {
+		continue;
+	}
+
         odb::Rect firstTileBox;
         odb::Rect lastTileBox;
 


### PR DESCRIPTION
This lets FastRoute ignore obstructions that lie completely outside the die area, where no tracks exist anyway. I attached a test case of a design that contains a core ring that is placed outside the die area.  Running the included script produces a segfault on the current version of FastRoute. This commit is one possible way to fix it.

[fastroute_ring_crash.tar.gz](https://github.com/The-OpenROAD-Project/OpenROAD/files/5735625/fastroute_ring_crash.tar.gz)
