### PR TITLE
Minor defout fixes for the PINS section

### DIFF
--- a/src/OpenDB/src/defin/definPin.cpp
+++ b/src/OpenDB/src/defin/definPin.cpp
@@ -259,6 +259,7 @@ void definPin::pinSupplyPin(const char* supplyPin)
 
 void definPin::pinEnd()
 {
+  dbBPin* pin = dbBPin::create(_cur_bterm);
   if (!_rects.empty()) {
     if (_has_placement == false) {
       _status = dbPlacementStatus::NONE;
@@ -270,7 +271,7 @@ void definPin::pinEnd()
     std::vector<PinRect>::iterator itr;
 
     for (itr = _rects.begin(); itr != _rects.end(); ++itr)
-      addRect(*itr);
+      addRect(*itr, pin);
   }
 
   if (!_polygons.empty()) {
@@ -284,15 +285,17 @@ void definPin::pinEnd()
     std::vector<Polygon>::iterator itr;
 
     for (itr = _polygons.begin(); itr != _polygons.end(); ++itr)
-      addPolygon(*itr);
+      addPolygon(*itr, pin);
   }
 
   _cur_bterm = NULL;
 }
 
-void definPin::addRect(PinRect& r)
+void definPin::addRect(PinRect& r, dbBPin* pin)
 {
-  dbBPin* pin = dbBPin::create(_cur_bterm);
+  if (pin == NULL)
+    pin = dbBPin::create(_cur_bterm);
+
   pin->setPlacementStatus(_status);
 
   Point     origin(0, 0);
@@ -308,7 +311,7 @@ void definPin::addRect(PinRect& r)
   dbBox::create(pin, r._layer, xmin, ymin, xmax, ymax);
 }
 
-void definPin::addPolygon(Polygon& p)
+void definPin::addPolygon(Polygon& p, dbBPin* pin)
 {
   std::vector<Rect> R;
 
@@ -319,7 +322,7 @@ void definPin::addPolygon(Polygon& p)
   for (itr = R.begin(); itr != R.end(); ++itr) {
     Rect& r = *itr;
     PinRect R(p._layer, r);
-    addRect(R);
+    addRect(R, pin);
   }
 }
 

--- a/src/OpenDB/src/defin/definPin.h
+++ b/src/OpenDB/src/defin/definPin.h
@@ -43,6 +43,7 @@
 namespace odb {
 
 class dbBTerm;
+class dbBPin;
 class dbTechLayer;
 
 class definPin : public definBase
@@ -98,8 +99,8 @@ class definPin : public definBase
   std::vector<Pin>         _ground_pins;
   std::vector<Pin>         _supply_pins;
 
-  void addRect(PinRect& r);
-  void addPolygon(Polygon& p);
+  void addRect(PinRect& r, dbBPin* pin);
+  void addPolygon(Polygon& p, dbBPin* pin);
 
  public:
   // Pin interface methods

--- a/src/OpenDB/src/defout/defout_impl.cpp
+++ b/src/OpenDB/src/defout/defout_impl.cpp
@@ -954,7 +954,7 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
 
   for (dbBox* box : bpin->getBoxes())
   {
-      
+
       int dw = defdist(int(box->getDX() / 2));
       int dh = defdist(int(box->getDY() / 2));
       int x  = defdist(box->xMin()) + dw;
@@ -968,7 +968,10 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
       else
         lname = layer->getName();
 
-      fprintf(_out, "\n      + PORT");
+      fprintf(_out, "\n      ");
+      /* if (_version > defout::DEF_5_6) */
+	      /* fprintf(_out, "+ PORT"); */
+
       if (_version == defout::DEF_5_5)
         fprintf(_out,
                 " + LAYER %s ( %d %d ) ( %d %d )",
@@ -1006,7 +1009,7 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
                   -dh,
                   dw,
                   dh);
-        } 
+        }
       }
 
       dbPlacementStatus status = bpin->getPlacementStatus();
@@ -1036,9 +1039,9 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
 
   }
   fprintf(_out, " ;\n");
-  
 
-  
+
+
 }
 
 void defout_impl::writeBlockages(dbBlock* block)

--- a/src/OpenDB/src/defout/defout_impl.cpp
+++ b/src/OpenDB/src/defout/defout_impl.cpp
@@ -960,31 +960,6 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
       int x  = defdist(box->xMin()) + dw;
       int y  = defdist(box->yMin()) + dh;
 
-      dbPlacementStatus status = bpin->getPlacementStatus();
-
-      switch (status.getValue()) {
-        case dbPlacementStatus::NONE:
-        case dbPlacementStatus::UNPLACED:
-          break;
-
-        case dbPlacementStatus::SUGGESTED:
-        case dbPlacementStatus::PLACED: {
-          fprintf(_out, " + PLACED ( %d %d ) N", x, y);
-          break;
-        }
-
-        case dbPlacementStatus::LOCKED:
-        case dbPlacementStatus::FIRM: {
-          fprintf(_out, " + FIXED ( %d %d ) N", x, y);
-          break;
-        }
-
-        case dbPlacementStatus::COVER: {
-          fprintf(_out, " + COVER ( %d %d ) N", x, y);
-          break;
-        }
-      }
-
       dbTechLayer* layer = box->getTechLayer();
       std::string  lname;
 
@@ -993,6 +968,7 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
       else
         lname = layer->getName();
 
+      fprintf(_out, "\n      + PORT");
       if (_version == defout::DEF_5_5)
         fprintf(_out,
                 " + LAYER %s ( %d %d ) ( %d %d )",
@@ -1031,10 +1007,35 @@ void defout_impl::writeBPin(dbBPin* bpin, int cnt)
                   dw,
                   dh);
         } 
-    }
-    
-    fprintf(_out, " ;\n");
+      }
+
+      dbPlacementStatus status = bpin->getPlacementStatus();
+
+      switch (status.getValue()) {
+        case dbPlacementStatus::NONE:
+        case dbPlacementStatus::UNPLACED:
+          break;
+
+        case dbPlacementStatus::SUGGESTED:
+        case dbPlacementStatus::PLACED: {
+          fprintf(_out, " + PLACED ( %d %d ) N", x, y);
+          break;
+        }
+
+        case dbPlacementStatus::LOCKED:
+        case dbPlacementStatus::FIRM: {
+          fprintf(_out, " + FIXED ( %d %d ) N", x, y);
+          break;
+        }
+
+        case dbPlacementStatus::COVER: {
+          fprintf(_out, " + COVER ( %d %d ) N", x, y);
+          break;
+        }
+      }
+
   }
+  fprintf(_out, " ;\n");
   
 
   


### PR DESCRIPTION
- multiple ';' removed

When multiple dbBoxes exist on a dbBPin, the DEF output contains extra incorrect semi-colons.
See lines 1389 and 1390 in [bug.def.gz](https://github.com/The-OpenROAD-Project/OpenROAD/files/5735746/bug.def.gz).

-------------------

- printing the LAYER statement before placement status (same order as in
  p. 272 in the LEF/DEF Ref. version 5.7). Some parsers assume that
  order as well (e.g., Magic's).

---------------------

- added "PORT" statements (see p. 278); without those, all LAYER
  statements are assumed to be under *one* implicit port. Some parsers
  adhere to this as well (e.g., KLayout's).

See attached LEF/DEF files: [port_no_port.tar.gz](https://github.com/The-OpenROAD-Project/OpenROAD/files/5735752/port_no_port.tar.gz)

Without "+ PORT" (`no_port.def`):
![screenshot_20201223_00-24-13](https://user-images.githubusercontent.com/19731159/103007560-4a30d280-453c-11eb-8b30-21eeb2943903.png)

With "+ PORT" (intended) (`port.def`):
![screenshot_20201223_16-31-35](https://user-images.githubusercontent.com/19731159/103007584-5452d100-453c-11eb-814f-37afe53359fd.png)

------------------------------------------------

Let me know if any further information is needed. Also, many of the CI tests will currently obviously fail since many of the `.defok` files need to be regenerated. Could you let me know what you think of the above changes before I start doing that?


EDIT: fixing a couple of things related to different LEF/DEF versions and the fact that defin doesn't like reading PORTs back....