### PR TITLE
[opendp] expose diamond_search_height to be configurable by the user

### DIFF
--- a/src/opendp/include/opendp/Opendp.h
+++ b/src/opendp/include/opendp/Opendp.h
@@ -170,7 +170,7 @@ public:
             Logger *logger);
   // legalize/report
   // max_displacment is in rows, 0 for unconstrained
-  void detailedPlacement(int max_displacment);
+  void detailedPlacement(int max_displacment, int diamond_search_height=100);
   void setPaddingGlobal(int left, int right);
   void setPadding(dbMaster *inst,
                   int left,

--- a/src/opendp/src/Opendp.cpp
+++ b/src/opendp/src/Opendp.cpp
@@ -186,8 +186,10 @@ Opendp::havePadding() const
 }
 
 void
-Opendp::detailedPlacement(int max_displacment)
+Opendp::detailedPlacement(int max_displacment, int diamond_search_height)
 {
+  diamond_search_height_ = diamond_search_height;
+  diamond_search_width_ = diamond_search_height_ * 5;
   importDb();
   reportImportWarnings();
   findDesignStats();

--- a/src/opendp/src/opendp.i
+++ b/src/opendp/src/opendp.i
@@ -114,10 +114,10 @@ tclListSetdbMaster(Tcl_Obj *const source,
 namespace dpl {
 
 void
-detailed_placement_cmd(int max_displacment)
+detailed_placement_cmd(int max_displacment, int diamond_search_height)
 {
   dpl::Opendp *opendp = ord::OpenRoad::openRoad()->getOpendp();
-  opendp->detailedPlacement(max_displacment);
+  opendp->detailedPlacement(max_displacment,diamond_search_height);
 }
 
 bool

--- a/src/opendp/src/opendp.tcl
+++ b/src/opendp/src/opendp.tcl
@@ -33,11 +33,11 @@
 #############################################################################
 
 # -constraints is an undocumented option for worthless academic contests
-sta::define_cmd_args "detailed_placement" {[-constraints constraints_file]}
+sta::define_cmd_args "detailed_placement" {[-max_displacement max_displacement_val] [-diamond_search_height diamond_search_height_val]}
 
 proc detailed_placement { args } {
   sta::parse_key_args "detailed_placement" args \
-    keys {-constraints} flags {}
+    keys {-max_displacement -diamond_search_height} flags {}
 
   if { [info exists keys(-max_displacment)] } {
     set max_displacment $keys(-max_displacment)
@@ -45,10 +45,15 @@ proc detailed_placement { args } {
   } else {
     set max_displacment 0
   }
+  set diamond_search_height 100
+  if { [info exists keys(-diamond_search_height)] } {
+    set diamond_search_height $keys(-diamond_search_height)
+    sta::check_positive_integer "-diamond_search_height" $diamond_search_height
+  }
 
   sta::check_argc_eq0 "detailed_placement" $args
   if { [ord::db_has_rows] } {
-    dpl::detailed_placement_cmd $max_displacment
+    dpl::detailed_placement_cmd $max_displacment $diamond_search_height
   } else {
     ord::error "no rows defined in design. Use initialize_floorplan to add rows."
   }


### PR DESCRIPTION
A somewhat better solution for the problem described in  #549 by exposing the parameter to be configurable by the user, if needed, while maintaining the current "magic number" as the default value. Tested on a couple of designs (one of them had the issue mentioned in #549 ).