### PR TITLE
Fix array out of bounds access in FlexGridGraph::getEdgeLength()

### DIFF
--- a/src/TritonRoute/src/dr/FlexGridGraph.h
+++ b/src/TritonRoute/src/dr/FlexGridGraph.h
@@ -276,7 +276,7 @@ namespace fr {
     frCoord getEdgeLength(frMIdx x, frMIdx y, frMIdx z, frDirEnum dir) const {
       frCoord sol = 0;
       correct(x, y, z, dir);
-      //if (isValid(x, y, z, dir)) {
+      if (isValid(x, y, z, dir)) {
         switch (dir) {
           case frDirEnum::E:
             sol = xCoords_[x+1] - xCoords_[x];
@@ -290,7 +290,7 @@ namespace fr {
           default:
             ;
         }
-      //}
+      }
       return sol;
     }
     bool isEdgeInBox(frMIdx x, frMIdx y, frMIdx z, frDirEnum dir, const frBox &box, bool initDR) const {


### PR DESCRIPTION
LLVM address sanitizer hits an array out of bounds access:

    #0 in fr::FlexGridGraph::getEdgeLength(int, int, int, fr::frDirEnum) const src/TritonRoute/src/dr/FlexGridGraph.h
    #1 in fr::FlexDRWorker::initMazeCost_ap_planarGrid_helper(fr::FlexMazeIdx const&, fr::frDirEnum const&, int, bool) src/TritonRoute/src/dr/FlexDR_init.cpp
    #2 in fr::FlexDRWorker::initMazeCost_ap_helper(fr::drNet*, bool) src/TritonRoute/src/dr/FlexDR_init.cpp:2314:11
    #3 in fr::FlexDRWorker::mazeNetInit(fr::drNet*) src/TritonRoute/src/dr/FlexDR_maze.cpp:1767:3

There is already a call to isValid() to check the array indexes are
valid, but it is commented out. Add it back in.