### PR TITLE
drt: Modifying param file fstream to ifstream

### DIFF
--- a/src/TritonRoute/src/TritonRoute.cpp
+++ b/src/TritonRoute/src/TritonRoute.cpp
@@ -204,7 +204,7 @@ int TritonRoute::main() {
 void TritonRoute::readParams(const string &fileName)
 {
   int readParamCnt = 0;
-  fstream fin(fileName.c_str());
+  ifstream fin(fileName.c_str());
   string line;
   if (fin.is_open()){
     while (fin.good()){


### PR DESCRIPTION
fstream opens a file with both read and write permissions since this file is only reading ifstream should be used instead.