### PR TITLE
Fix undefined behaviour in OpenDB hash_int()

### DIFF
--- a/src/OpenDB/src/db/dbIntHashTable.hpp
+++ b/src/OpenDB/src/db/dbIntHashTable.hpp
@@ -39,14 +39,14 @@ namespace odb {
 
 inline uint hash_int(uint id)
 {
-  int key = (int) id;
+  uint key = id;
   key += ~(key << 15);
   key ^= (key >> 10);
   key += (key << 3);
   key ^= (key >> 6);
   key += ~(key << 11);
   key ^= (key >> 16);
-  return (uint) key;
+  return key;
 }
 
 template <class T>


### PR DESCRIPTION
The LLVM undefined behaviour sanitizer is complaining about hash_int():

../src/OpenDB/src/db/dbIntHashTable.hpp:47:16: runtime error: left shift of 37304127 by 11 places cannot be represented in type 'int'

We can simplify hash_int() and fix this issue by defining key as an
unsigned int.