### PR TITLE
More aggressive setup timing repair

### DIFF
--- a/src/resizer/include/rsz/Resizer.hh
+++ b/src/resizer/include/rsz/Resizer.hh
@@ -566,6 +566,9 @@ protected:
   // Journal to roll back changes (OpenDB not up to the task).
   Map<Instance*, LibertyCell*> resized_inst_map_;
   InstanceSet inserted_buffers_;
+
+  // During setup repair, allow this many passes where slack doesn't improve.
+  static constexpr int max_non_decreasing_slack_passes_ = 5;
 };
 
 } // namespace


### PR DESCRIPTION
In Resizer::repairSetup() we might end up in a local minimum, and adding
buffers makes our wns worse. While decreasing_slack_passes is supposed
to allow this, we compare against zero which means it doesn't work as
intended.

We might also encounter a point in which our wns is unchanged, and we
should allow a few iterations to give us a chance to break out of it.

Both of these issues were found when testing the openlane y_dct test
case. Before the patch our wns was -4 ns, and with the patch applied we
make timing.