### PR TITLE
utility: Adds ability to quiet and silece stdout logging.

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -56,7 +56,7 @@
 #include "openroad/Version.hh"
 #include "openroad/InitOpenRoad.hh"
 #include "openroad/OpenRoad.hh"
-#include "utility/Logger.h" 
+#include "utility/Logger.h"
 #include "gui/gui.h"
 
 using std::string;
@@ -71,6 +71,8 @@ static char **cmd_argv;
 bool gui_mode = false;
 const char* log_filename = nullptr;
 const char* metrics_filename = nullptr;
+bool quiet_logs = false;
+bool silent_logs = false;
 
 static const char *init_filename = ".openroad";
 
@@ -100,6 +102,14 @@ main(int argc,
   metrics_filename = findCmdLineKey(argc, argv, "-metrics");
   if (metrics_filename)
     remove(metrics_filename);
+
+  if (findCmdLineFlag(argc, argv, "-quiet")) {
+    quiet_logs = true;
+  }
+
+  if (findCmdLineFlag(argc, argv, "-silent")) {
+    silent_logs = true;
+  }
 
   cmd_argc = argc;
   cmd_argv = argv;
@@ -216,7 +226,7 @@ static void
 showUsage(const char *prog,
 	  const char *init_filename)
 {
-  printf("Usage: %s [-help] [-version] [-no_init] [-exit] [-gui] [-log file_name] cmd_file\n", prog);
+  printf("Usage: %s [-help] [-version] [-no_init] [-exit] [-gui] [-log file_name] [-silent] [-quiet] cmd_file\n", prog);
   printf("  -help              show help and exit\n");
   printf("  -version           show version and exit\n");
   printf("  -no_init           do not read %s init file\n", init_filename);
@@ -225,6 +235,8 @@ showUsage(const char *prog,
   printf("  -exit              exit after reading cmd_file\n");
   printf("  -gui               start in gui mode\n");
   printf("  -log <file_name>   write a log in <file_name>\n");
+  printf("  -quiet             only emit warnings and above to the console\n");
+  printf("  -silent            do not emit logs to console.\n");
   printf("  cmd_file           source cmd_file\n");
 }
 

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -89,6 +89,8 @@ extern int Opendbtcl_Init(Tcl_Interp *interp);
 // Main.cc set by main()
 extern const char* log_filename;
 extern const char* metrics_filename;
+extern const bool quiet_logs;
+extern const bool silent_logs;
 
 namespace ord {
 
@@ -189,7 +191,7 @@ OpenRoad::init(Tcl_Interp *tcl_interp)
   tcl_interp_ = tcl_interp;
 
   // Make components.
-  logger_ = makeLogger(log_filename, metrics_filename);
+  logger_ = makeLogger(log_filename, metrics_filename, quiet_logs, silent_logs);
   db_->setLogger(logger_);
   sta_ = makeDbSta();
   verilog_network_ = makeDbVerilogNetwork();

--- a/src/utility/include/utility/MakeLogger.h
+++ b/src/utility/include/utility/MakeLogger.h
@@ -45,9 +45,8 @@ struct Tcl_Interp;
 
 namespace ord {
 
-utl::Logger *
-makeLogger(const char *log_filename,
-           const char *metrics_filename);
+utl::Logger *makeLogger(const char *log_filename, const char *metrics_filename,
+                        const bool quiet_logs, const bool silent_logs);
 void
 initLogger(utl::Logger *logger,
            Tcl_Interp *tcl_interp);

--- a/src/utility/src/MakeLogger.cpp
+++ b/src/utility/src/MakeLogger.cpp
@@ -46,10 +46,9 @@ namespace ord {
 
 using utl::Logger;
 
-Logger *
-makeLogger(const char *log_filename, const char *metrics_filename)
-{
-  return new Logger(log_filename, metrics_filename);
+Logger *makeLogger(const char *log_filename, const char *metrics_filename,
+                   const bool quiet_logs, const bool silent_logs) {
+  return new Logger(log_filename, metrics_filename, quiet_logs, silent_logs);
 }
 
 void


### PR DESCRIPTION
This change introduces two command line flags -quiet an -silent.

-quiet limits the log level to warning and above on stdout.
-silent turns off logging to stdout

For many CI tools it is undersirable to log to stdout or stderr.
Many tools do not allow for redirection so this must be implemented
at the tool level.