### PR TITLE
Removes AstarCosts from TritonRoute.

### DIFF
--- a/src/TritonRoute/src/dr/FlexDR_maze.cpp
+++ b/src/TritonRoute/src/dr/FlexDR_maze.cpp
@@ -2644,7 +2644,6 @@ drPin* FlexDRWorker::routeNet_getNextDst(FlexMazeIdx &ccMazeIdx1, FlexMazeIdx &c
 }
 
 void FlexDRWorker::mazePinInit() {
-  gridGraph_.resetAStarCosts();
   gridGraph_.resetPrevNodeDir();
 }
 

--- a/src/TritonRoute/src/dr/FlexGridGraph.cpp
+++ b/src/TritonRoute/src/dr/FlexGridGraph.cpp
@@ -67,11 +67,9 @@ void FlexGridGraph::initGrids(const map<frCoord, map<frLayerNum, frTrackPattern*
   nodes_.clear();
   nodes_.resize(xDim*yDim*zDim, Node());
   // new
-  astarCosts_.clear();
   prevDirs_.clear();
   srcs_.clear();
   dsts_.clear();
-  astarCosts_.resize(xDim*yDim*zDim, UINT_MAX);
   prevDirs_.resize(xDim*yDim*zDim*3, 0);
   srcs_.resize(xDim*yDim*zDim, 0);
   dsts_.resize(xDim*yDim*zDim, 0);
@@ -402,7 +400,6 @@ void FlexGridGraph::initTracks(map<frCoord, map<frLayerNum, frTrackPattern* > > 
 void FlexGridGraph::resetStatus() {
   resetSrc();
   resetDst();
-  resetAStarCosts();
   resetPrevNodeDir();
 }
 
@@ -412,10 +409,6 @@ void FlexGridGraph::resetSrc() {
 
 void FlexGridGraph::resetDst() {
   dsts_.assign(dsts_.size(), 0);
-}
-
-void FlexGridGraph::resetAStarCosts() {
-  astarCosts_.assign(astarCosts_.size(), UINT_MAX);
 }
 
 void FlexGridGraph::resetPrevNodeDir() {

--- a/src/TritonRoute/src/dr/FlexGridGraph.h
+++ b/src/TritonRoute/src/dr/FlexGridGraph.h
@@ -65,13 +65,6 @@ namespace fr {
     }
     // getters
     // unsafe access, no check
-    bool hasAStarCost(frMIdx x, frMIdx y, frMIdx z) const {
-      return (getAStarCost(x, y, z) != UINT_MAX);
-    }
-    frCost getAStarCost(frMIdx x, frMIdx y, frMIdx z) const {
-      return astarCosts_[getIdx(x, y, z)];
-    }
-    // unsafe access, no check
     bool isAstarVisited(frMIdx x, frMIdx y, frMIdx z) const {
       return (getPrevAstarNodeDir(x, y, z) == frDirEnum::UNKNOWN);
     }
@@ -569,9 +562,6 @@ namespace fr {
       }
     }
 
-    void setAStarCost(frMIdx x, frMIdx y, frMIdx z, frCost cost) {
-      astarCosts_[getIdx(x, y, z)] = cost;
-    }
     // unsafe access, no idx check
     void setPrevAstarNodeDir(frMIdx x, frMIdx y, frMIdx z, frDirEnum dir) {
       auto baseIdx = 3 * getIdx(x, y, z);
@@ -752,7 +742,6 @@ namespace fr {
               bool initDR, bool followGuide);
     void print() const;
     void resetStatus();
-    void resetAStarCosts();
     void resetPrevNodeDir();
     void resetSrc();
     void resetDst();
@@ -782,8 +771,6 @@ namespace fr {
     void cleanup() {
       nodes_.clear();
       nodes_.shrink_to_fit();
-      astarCosts_.clear();
-      astarCosts_.shrink_to_fit();
       srcs_.clear();
       srcs_.shrink_to_fit();
       dsts_.clear();
@@ -845,7 +832,6 @@ namespace fr {
     };
     static_assert(sizeof(Node) == 8);
     frVector<Node>                             nodes_;
-    std::vector<unsigned int>                  astarCosts_; // astar cost
     std::vector<bool>                          prevDirs_;
     std::vector<bool>                          srcs_;
     std::vector<bool>                          dsts_;


### PR DESCRIPTION
This vector is unused in the current tritonroute implementation, but
consists of 7% of the total runtime because it is still sized and
cleared.