### PR TITLE
Don't recreate via rule if either layer is square

### DIFF
--- a/src/TritonRoute/src/io/io_parser_helper.cpp
+++ b/src/TritonRoute/src/io/io_parser_helper.cpp
@@ -89,6 +89,10 @@ void io::Parser::initDefaultVias()
       via.getLayer2BBox(layer2Box);
       layer1Num = techDefautlViaDef->getLayer1Num();
       layer2Num = techDefautlViaDef->getLayer2Num();
+      bool isLayer1Square = (layer1Box.right() - layer1Box.left())
+	                     == (layer1Box.top() - layer1Box.bottom());
+      bool isLayer2Square = (layer2Box.right() - layer2Box.left())
+	                     == (layer2Box.top() - layer2Box.bottom());
       bool isLayer1EncHorz = (layer1Box.right() - layer1Box.left())
                              > (layer1Box.top() - layer1Box.bottom());
       bool isLayer2EncHorz = (layer2Box.right() - layer2Box.left())
@@ -98,7 +102,8 @@ void io::Parser::initDefaultVias()
       bool isLayer2Horz
           = (tech->getLayer(layer2Num)->getDir() == frcHorzPrefRoutingDir);
       bool needViaGen = false;
-      if (isLayer1EncHorz != isLayer1Horz || isLayer2EncHorz != isLayer2Horz) {
+      if ((!isLayer1Square && (isLayer1EncHorz != isLayer1Horz)) ||
+          (!isLayer2Square && (isLayer2EncHorz != isLayer2Horz))) {
         needViaGen = true;
       }
 


### PR DESCRIPTION
There are a couple of warnings when using the sky130 hd tech:

[WARNING DRT-0160] Warning: met2 does not have viaDef aligned with layer direction, generating new viaDef via2_FR.
[WARNING DRT-0160] Warning: met4 does not have viaDef aligned with layer direction, generating new viaDef via4_FR.

In both cases the layer is square, so the warning is harmless, but we
may as well catch this case and avoid the warning altogether.