### PR TITLE
Use gridPaddedEndX in erasePixel

### DIFF
--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -275,7 +275,7 @@ void
 Opendp::erasePixel(Cell *cell)
 {
   if (!(isFixed(cell) || !cell->is_placed_)) {
-    int x_end = gridEndX(cell);
+    int x_end = gridPaddedEndX(cell);
     int y_end = gridEndY(cell);
     for (int x = gridPaddedX(cell); x < x_end; x++) {
       for (int y = gridY(cell); y < y_end; y++) {


### PR DESCRIPTION
erasePixel() should remove the cell and all surrounding padding.
We currently remove the left padding but not the right padding.