### PR TITLE
drt: Integer overflow results in tracks outside die area

### DIFF
--- a/src/TritonRoute/src/dr/FlexDR_maze.cpp
+++ b/src/TritonRoute/src/dr/FlexDR_maze.cpp
@@ -3601,7 +3601,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
   auto minAreaConstraint
       = getDesign()->getTech()->getLayer(layerNum)->getAreaConstraint();
 
-  frCoord currArea = 0;
+  frArea currArea = 0;
   if (ENABLE_BOUNDARY_MAR_FIX) {
     if (areaMap.find(points[0]) != areaMap.end()) {
       currArea = areaMap.find(points[0])->second;
@@ -3628,7 +3628,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
       layerNum = gridGraph_.getLayerNum(prevIdx.z());
       minAreaConstraint
           = getDesign()->getTech()->getLayer(layerNum)->getAreaConstraint();
-      frCoord reqArea
+      frArea reqArea
           = (minAreaConstraint) ? minAreaConstraint->getMinArea() : 0;
       // add next via enclosure
       if (currIdx.z() < prevIdx.z()) {
@@ -3645,7 +3645,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
         //   <<", " <<i - 1 <<endl;
         // }
         FlexMazeIdx bp, ep;
-        frCoord gapArea = reqArea
+        frArea gapArea = reqArea
                           - (currArea - startViaHalfEncArea - endViaHalfEncArea)
                           - std::min(startViaHalfEncArea, endViaHalfEncArea);
         // new
@@ -3737,7 +3737,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
       layerNum = gridGraph_.getLayerNum(prevIdx.z());
       minAreaConstraint
           = getDesign()->getTech()->getLayer(layerNum)->getAreaConstraint();
-      frCoord reqArea
+      frArea reqArea
           = (minAreaConstraint) ? minAreaConstraint->getMinArea() : 0;
       auto pathWidth = getDesign()->getTech()->getLayer(layerNum)->getWidth();
       frPoint bp, ep;
@@ -3759,7 +3759,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
     layerNum = gridGraph_.getLayerNum(prevIdx.z());
     minAreaConstraint
         = getDesign()->getTech()->getLayer(layerNum)->getAreaConstraint();
-    frCoord reqArea = (minAreaConstraint) ? minAreaConstraint->getMinArea() : 0;
+    frArea reqArea = (minAreaConstraint) ? minAreaConstraint->getMinArea() : 0;
     if (areaMap.find(prevIdx) != areaMap.end()) {
       currArea += areaMap.find(prevIdx)->second;
     }
@@ -3770,7 +3770,7 @@ void FlexDRWorker::routeNet_postAstarPatchMinAreaVio(
       //   <<endl;
       // }
       FlexMazeIdx bp, ep;
-      frCoord gapArea = reqArea
+      frArea gapArea = reqArea
                         - (currArea - startViaHalfEncArea - endViaHalfEncArea)
                         - std::min(startViaHalfEncArea, endViaHalfEncArea);
       // new


### PR DESCRIPTION
Integer overflow in routeNet_postAstarPatchMinAreaVio causes tracks to
be created that are much longer than they should be. I've noticed this
on a few larger sky130hd designs on the metal 5 layer.