### PR TITLE
drt: Fix a number of integer overflow issues

### DIFF
--- a/src/TritonRoute/src/dr/FlexDR.h
+++ b/src/TritonRoute/src/dr/FlexDR.h
@@ -715,9 +715,10 @@ namespace fr {
     void modMinSpacingCost(drNet* net, const frBox &box, frMIdx z, int type, bool isCurrPs);
     void modMinSpacingCostPlanar(const frBox &box, frMIdx z, int type, bool isBlockage = false, frNonDefaultRule* ndr = nullptr);
     void modMinSpacingCostVia(const frBox &box, frMIdx z, int type, bool isUpperVia, bool isCurrPs, bool isBlockage = false, frNonDefaultRule* ndr = nullptr);
-    frCoord pt2boxDistSquare(const frPoint &pt, const frBox &box);
-    frCoord box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
-    frCoord box2boxDistSquareNew(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
+    frSquaredDistance pt2boxDistSquare(const frPoint &pt, const frBox &box);
+    frSquaredDistance pt2ptDistSquare(const frPoint &pt1, const frPoint &pt2);
+    frSquaredDistance box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
+    frSquaredDistance box2boxDistSquareNew(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
     void modMinSpacingCostVia_eol(const frBox &box, const frBox &tmpBx, int type, bool isUpperVia, frMIdx i, frMIdx j, frMIdx z);
     void modMinSpacingCostVia_eol_helper(const frBox &box, const frBox &testBox, int type, bool isUpperVia, frMIdx i, frMIdx j, frMIdx z);
     // eolSpc

--- a/src/TritonRoute/src/frBaseTypes.h
+++ b/src/TritonRoute/src/frBaseTypes.h
@@ -46,6 +46,7 @@ namespace fr {
   using frLayerNum = int;
   using frCoord = int;
   using frArea = uint64_t;
+  using frSquaredDistance = uint64_t;
   using frUInt4 = unsigned int;
   using frDist  = double;
   using frString = std::string;

--- a/src/TritonRoute/src/gc/FlexGC_main.cpp
+++ b/src/TritonRoute/src/gc/FlexGC_main.cpp
@@ -2546,13 +2546,13 @@ void FlexGCWorker::Impl::checkCutSpacing_spc(gcRect* rect1, gcRect* rect2, const
   }
 
   // no violation if spacing satisfied
-  auto reqSpcValSquare = checkCutSpacing_spc_getReqSpcVal(rect1, rect2, con);
+  frSquaredDistance reqSpcValSquare = checkCutSpacing_spc_getReqSpcVal(rect1, rect2, con);
   reqSpcValSquare *= reqSpcValSquare;
 
   gtl::point_data<frCoord> center1, center2;
   gtl::center(center1, *rect1);
   gtl::center(center2, *rect2);
-  frCoord distSquare = 0;
+  frSquaredDistance distSquare = 0;
   if (con->hasCenterToCenter()) {
     distSquare = gtl::distance_squared(center1, center2);
   } else {
@@ -2649,13 +2649,13 @@ void FlexGCWorker::Impl::checkCutSpacing_spc_diff_layer(gcRect* rect1, gcRect* r
   }
 
   // no violation if spacing satisfied
-  auto reqSpcValSquare = checkCutSpacing_spc_getReqSpcVal(rect1, rect2, con);
+  frSquaredDistance reqSpcValSquare = checkCutSpacing_spc_getReqSpcVal(rect1, rect2, con);
   reqSpcValSquare *= reqSpcValSquare;
 
   gtl::point_data<frCoord> center1, center2;
   gtl::center(center1, *rect1);
   gtl::center(center2, *rect2);
-  frCoord distSquare = 0;
+  frSquaredDistance distSquare = 0;
 
   if (con->hasCenterToCenter()) {
     distSquare = gtl::distance_squared(center1, center2);
@@ -2765,7 +2765,7 @@ bool FlexGCWorker::Impl::checkLef58CutSpacing_spc_hasAdjCuts(gcRect* rect, frLef
 
   auto conCutClassIdx = con->getCutClassIdx();
 
-  auto cutWithinSquare = con->getCutWithin();
+  frSquaredDistance cutWithinSquare = con->getCutWithin();
   box_t queryBox;
   myBloat(*rect, cutWithinSquare, queryBox);
   cutWithinSquare *= cutWithinSquare;
@@ -2778,7 +2778,7 @@ bool FlexGCWorker::Impl::checkLef58CutSpacing_spc_hasAdjCuts(gcRect* rect, frLef
   gtl::center(center1, *rect);
   // count adj cuts
   for (auto &[objBox, ptr]: result) {
-    frCoord distSquare = 0;
+    frSquaredDistance distSquare = 0;
     if (con->isCenterToCenter()) {
       gtl::center(center2, *ptr);
       distSquare = gtl::distance_squared(center1, center2);
@@ -2818,7 +2818,7 @@ bool FlexGCWorker::Impl::checkLef58CutSpacing_spc_hasTwoCuts_helper(gcRect* rect
 
   auto conCutClassIdx = con->getCutClassIdx();
 
-  auto cutWithinSquare = con->getCutWithin();
+  frSquaredDistance cutWithinSquare = con->getCutWithin();
   box_t queryBox;
   myBloat(*rect, cutWithinSquare, queryBox);
   cutWithinSquare *= cutWithinSquare;
@@ -2831,7 +2831,7 @@ bool FlexGCWorker::Impl::checkLef58CutSpacing_spc_hasTwoCuts_helper(gcRect* rect
   gtl::center(center1, *rect);
   // count adj cuts
   for (auto &[objBox, ptr]: result) {
-    frCoord distSquare = 0;
+    frSquaredDistance distSquare = 0;
     if (con->isCenterToCenter()) {
       gtl::center(center2, *ptr);
       distSquare = gtl::distance_squared(center1, center2);
@@ -2954,13 +2954,13 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_adjCut(gcRect* rect1,
     ;
   }
 
-  auto reqSpcValSquare = checkLef58CutSpacing_spc_getReqSpcVal(rect1, rect2, con);
+  frSquaredDistance reqSpcValSquare = checkLef58CutSpacing_spc_getReqSpcVal(rect1, rect2, con);
   reqSpcValSquare *= reqSpcValSquare;
 
   gtl::point_data<frCoord> center1, center2;
   gtl::center(center1, *rect1);
   gtl::center(center2, *rect2);
-  frCoord distSquare = 0;
+  frSquaredDistance distSquare = 0;
   if (con->isCenterToCenter()) {
     distSquare = gtl::distance_squared(center1, center2);
   } else {
@@ -3051,7 +3051,8 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(gcRect* rect1,
   auto net1 = rect1->getNet();
   auto net2 = rect2->getNet();
   auto reqSpcVal = con->getCutSpacing();
-  auto reqSpcValSquare = reqSpcVal * reqSpcVal;
+  frSquaredDistance reqSpcValSquare = reqSpcVal;
+  reqSpcVal *= reqSpcVal;
 
   // skip unsupported rule branch
   if (con->isStack()) {
@@ -3124,7 +3125,7 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(gcRect* rect1,
         gtl::rectangle_data<frCoord> markerRect(corner->x(), corner->y(), corner->x(), corner->y());
         gtl::generalized_intersect(markerRect, *rect1);
         
-        frCoord distSquare = 0;
+        frSquaredDistance distSquare = 0;
         if (con->isCenterToCenter()) {
           gtl::point_data<frCoord> center1;
           gtl::center(center1, *rect1);
@@ -3432,7 +3433,7 @@ bool FlexGCWorker::Impl::checkCutSpacing_main_hasAdjCuts(gcRect* rect, frCutSpac
     return true;
   }
   
-  auto cutWithinSquare = con->getCutWithin();
+  frSquaredDistance cutWithinSquare = con->getCutWithin();
   box_t queryBox;
   myBloat(*rect, cutWithinSquare, queryBox);
   cutWithinSquare *= cutWithinSquare;
@@ -3445,7 +3446,7 @@ bool FlexGCWorker::Impl::checkCutSpacing_main_hasAdjCuts(gcRect* rect, frCutSpac
   gtl::center(center1, *rect);
   // count adj cuts
   for (auto &[objBox, ptr]: result) {
-    frCoord distSquare = 0;
+    frSquaredDistance distSquare = 0;
     if (con->hasCenterToCenter()) {
       gtl::center(center2, *ptr);
       distSquare = gtl::distance_squared(center1, center2);

--- a/src/TritonRoute/src/ta/FlexTA.h
+++ b/src/TritonRoute/src/ta/FlexTA.h
@@ -215,7 +215,7 @@ namespace fr {
     void sortIroutes();
 
     // quick drc
-    inline frCoord box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
+    inline frSquaredDistance box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy);
     void addCost(taPinFig* fig, std::set<taPin*, frBlockObjectComp> *pinS = nullptr);
     void subCost(taPinFig* fig, std::set<taPin*, frBlockObjectComp> *pinS = nullptr);
     void modCost(taPinFig* fig, bool isAddCost, std::set<taPin*, frBlockObjectComp> *pinS = nullptr);

--- a/src/TritonRoute/src/ta/FlexTA_assign.cpp
+++ b/src/TritonRoute/src/ta/FlexTA_assign.cpp
@@ -32,10 +32,10 @@
 using namespace std;
 using namespace fr;
 
-inline frCoord FlexTAWorker::box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy) {
+inline frSquaredDistance FlexTAWorker::box2boxDistSquare(const frBox &box1, const frBox &box2, frCoord &dx, frCoord &dy) {
   dx = max(max(box1.left(), box2.left())     - min(box1.right(), box2.right()), 0);
   dy = max(max(box1.bottom(), box2.bottom()) - min(box1.top(), box2.top()),     0);
-  return dx * dx + dy * dy;
+  return (frSquaredDistance)dx * dx + (frSquaredDistance)dy * dy;
 }
 
 // must be current TA layer
@@ -70,7 +70,7 @@ void FlexTAWorker::modMinSpacingCostPlanar(const frBox &box, frLayerNum lNum, ta
   }
   if (fig->getNet()->getNondefaultRule())
       bloatDist = max(bloatDist, fig->getNet()->getNondefaultRule()->getSpacing(lNum/2 -1));
-  frCoord bloatDistSquare = bloatDist * bloatDist;
+  frSquaredDistance bloatDistSquare = (frSquaredDistance)bloatDist * bloatDist;
 
   bool isH = (getDir() == frPrefRoutingDirEnum::frcHorzPrefRoutingDir);
 
@@ -94,8 +94,8 @@ void FlexTAWorker::modMinSpacingCostPlanar(const frBox &box, frLayerNum lNum, ta
     xform.set(frPoint(boxLeft, trackLoc));
     box2.transform(xform);
     box2boxDistSquare(box1, box2, dx, dy);
-    frCoord maxX = (frCoord)(sqrt(1.0 * bloatDistSquare - 1.0 * dy * dy));
-    if (maxX * maxX + dy * dy == bloatDistSquare) {
+    frCoord maxX = (frCoord)(sqrt(1.0 * bloatDistSquare - 1.0 * (frSquaredDistance)dy * dy));
+    if ((frSquaredDistance)maxX * maxX + (frSquaredDistance)dy * dy == bloatDistSquare) {
       maxX = max(0, maxX - 1);
     }
     frCoord blockLeft  = boxLeft  - maxX - halfwidth2;
@@ -380,7 +380,7 @@ void FlexTAWorker::modCutSpacingCost(const frBox &box, frLayerNum lNum, taPinFig
   frBox tmpBx;
   frTransform xform;
   frCoord dx, dy, c2ctrackdist;
-  //frCoord distSquare;
+  //frSquaredDistance distSquare;
   frCoord reqDist = 0;
   frCoord maxX, blockLeft, blockRight;
   frBox blockBox;


### PR DESCRIPTION
There are a number of places we compute distance squared, and on
larger designs this can overflow an frCoord which is a signed 32
bit integer.  Create a uint64_t datatype called frSquaredDistance
to store these values without overflow.

Also create pt2ptDistSquare() to square the distance between
two points safely.