### PR TITLE
drt: Avoid negative sqrt in modMinSpacingCostPlanar()

### DIFF
--- a/src/TritonRoute/src/ta/FlexTA_assign.cpp
+++ b/src/TritonRoute/src/ta/FlexTA_assign.cpp
@@ -114,6 +114,9 @@ void FlexTAWorker::modMinSpacingCostPlanar(const frBox& box,
     xform.set(frPoint(boxLeft, trackLoc));
     box2.transform(xform);
     box2boxDistSquare(box1, box2, dx, dy);
+    if (dy >= bloatDist) {
+      continue;
+    }
     frCoord maxX = (frCoord) (sqrt(1.0 * bloatDistSquare - 1.0 * dy * dy));
     if (maxX * maxX + dy * dy == bloatDistSquare) {
       maxX = max(0, maxX - 1);


### PR DESCRIPTION
The LLVM undefined behaviour sanitizer highlighted issues in
modMinSpacingCostPlanar(). We are trying to calculate the cost even when
the spacing to the nearest object is greater than our minimum spacing
rules. Just skip over it in this case, simliar to how
modMinSpacingCostVia() handles it.