### PR TITLE
Fixes #618 swig type check error.

### DIFF
--- a/src/OpenDB/src/swig/python/dbtypes.i
+++ b/src/OpenDB/src/swig/python/dbtypes.i
@@ -5,11 +5,14 @@
 
 %template(vector_str) std::vector<std::string>;
 
+%typemap(typecheck,precedence=SWIG_TYPECHECK_INTEGER) uint {
+   $1 = PyInt_Check($input) ? 1 : 0;
+}
 
 // DB specital types
 %typemap(out) odb::dbStringProperty {
     PyObject *obj = PyString_FromString($1.getValue().c_str());
-    $result = obj; 
+    $result = obj;
 }
 
 %typemap(out) odb::Point, Point {
@@ -22,7 +25,7 @@
 }
 
 // Wrapper for dbSet, dbVector...etc
-%define WRAP_DB_CONTAINER(T) 
+%define WRAP_DB_CONTAINER(T)
 %typemap(out) dbSet< T >, dbVector< T > {
     PyObject *list = PyList_New(0);
     swig_type_info *tf = SWIG_TypeQuery("T" "*");
@@ -36,7 +39,7 @@
 
 %typemap(in) std::vector< T* >* (std::vector< T* > *v, std::vector< T* > w),
              std::vector< T* >& (std::vector< T* > *v, std::vector< T* > w) {
-        
+
         int nitems;
         int i;
         T*        temp;


### PR DESCRIPTION
This commit addresses a regression in the python test suite related to
the python int to uint conversion. In these cases swig needs a
customized type checking routine to check the type of our python ints.

This check was removed in the OpenDB refactor adding it back to fix the
regressions

Closes #618 