### PR TITLE
tapcells offset value fix

### DIFF
--- a/src/tap/src/tapcell.tcl
+++ b/src/tap/src/tapcell.tcl
@@ -572,7 +572,6 @@ proc insert_tapcells {db rows tapcell_master dist prefix} {
 
       if {$row_idx == 0 || $row_idx == [expr [llength $rows]-1] || $gaps_above_below} {
         set pitch $dist1
-        set offset $dist1
       } else {
         set pitch $dist2
       }


### PR DESCRIPTION
 offset was set to 1*distance on both the first and last rows causing them to have 2 * n number of tapcells, which in turn causes a DRC violation down the line (sometimes it does not manifest, depends really on the design)

![tapcell_issue_3](https://user-images.githubusercontent.com/23408673/116545891-44376d80-a8f1-11eb-9ef9-26501309b62f.png)

This is also demonstrable in another design

![tapcell_issue](https://user-images.githubusercontent.com/23408673/116545127-506efb00-a8f0-11eb-97b5-134e7baf31dc.png)

![tapcell_issue_2](https://user-images.githubusercontent.com/23408673/116545456-be1b2700-a8f0-11eb-8dc5-ccf13400da85.png)



