### PR TITLE
Rework the automatically sync branch github action.

### DIFF
--- a/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
+++ b/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
@@ -1,30 +1,46 @@
-name: GitHub Actions Cron sync this fork from upstream
-# on push can specify branch
+name: Automatically sync branch from upstream.
+
 on:
   schedule:
-  - cron: "0/30 * * * *"
+  - cron: "*/5 * * * *"
+
   workflow_dispatch:
+    inputs:
+      force:
+        description: Use GitHub --force push.
+        default:
+
   repository_dispatch:
 
-jobs:
-  Sync-Fork-From-Upstream:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
-      - run: echo "This job is now running on a ${{ runner.os }} server hosted by GitHub!"
-      - run: echo "The name of your branch is ${{ github.ref }} and your repository is ${{ github.repository }}."
-      
-      - name: Check out repository code
-        uses: actions/checkout@v2
-        with:
-          ref: master
-          token: ${{ secrets.GITHUBPUBLICREPOTOKEN }}
 
-      
-      - name: Pull Upstream
-        uses: The-OpenROAD-Project/actions/upstream_sync@main
-        with:
-          upstreamRepoUrl: https://github.com/The-OpenROAD-Project/OpenROAD.git
-          upstreamBranch: master
-                
+jobs:
+  Sync-Branch-From-Upstream:
+    name: Automatic sync 'master' from The-OpenROAD-Project/OpenROAD
+    runs-on: ubuntu-latest
+
+    # Only allow one action to run at a time.
+    concurrency: sync-branch-from-upstream
+
+    # Action needs no permissions, as push is granted via adding a deploy key
+    # with write access to the $DEPLOY_KEY secret.
+    permissions:
+      contents: read
+
+    # Don't run on the upstream repository and only run on the right branch.
+    if: ${{ (github.repository != 'The-OpenROAD-Project/OpenROAD') && endsWith(github.ref, '/master') }}
+
+    steps:
+
+    - uses: The-OpenROAD-Project/actions/upstream_sync@main
+      env:
+        HAS_DEPLOY_KEY: ${{ !!(secrets.DEPLOY_KEY) }}
+      if: ${{ env.HAS_DEPLOY_KEY == 'true' }}
+      with:
+        upstreamRepo: The-OpenROAD-Project/OpenROAD
+        upstreamBranch: master
+        # To always overwrite master branch, set UPSTREAM_SYNC to the exact
+        # string 'always overwrite master branch'.
+        # You can also manually trigger a workflow dispatch with the force
+        # value equal to 'true'.
+        force: ${{ github.event.inputs.force || (secrets.UPSTREAM_SYNC == 'always overwrite master branch') }}
+        deployKey: ${{ secrets.DEPLOY_KEY }}


### PR DESCRIPTION
This needs https://github.com/The-OpenROAD-Project/actions/pull/3 to be merged first.

Changes;
 * Action will run only if a `DEPLOY_KEY` secret is set.
 * Use significantly faster push method (takes like 4 seconds) allowing much increased frequency.
 * Only use overwrite the master branch if the `UPSTREAM_SYNC` GitHub Action secret is set to **exactly** `always overwrite master branch`. *Otherwise* the workflow can be manually triggered with the force value set to `true`.

Steps for setting up the `DEPLOY_KEY`;
 * Generate a new deploy key with `ssh-keygen -t ed25519 -f openroad-push`.
 * Add the private key output (in file `openroad-push`) to the [repositories GitHub Actions secrets](../settings/secrets/actions) named `DEPLOY_KEY`.
 * Add the public key output (in file `openroad-push.pub`) to the [repositories Deploy Keys](../settings/keys) **making sure** to give the key write access.