### PR TITLE
Docker CI

### DIFF
--- a/.github/workflows/github-actions-on-push.yml
+++ b/.github/workflows/github-actions-on-push.yml
@@ -1,4 +1,4 @@
-name: Scan Code with pre commit trigger
+name: Push Actions
 on:
   # Triggers the workflow on push or pull request events
   push:
@@ -8,12 +8,64 @@ on:
 
 jobs:
   scan:
+    name: Scan Code With Pre-Commit Trigger
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
       - name: run security_scan_on_push
         uses: The-OpenROAD-Project/actions/security_scan_on_push@main
-
-
-        
+  build-docker:
+    name: Build Docker Container
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: ["centos7"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Write Image Base name
+        run: |
+          echo "IMAGE_NAME_BASE=$(printf "ghcr.io/${{ github.repository }}-${{ matrix.os }}" | perl -ne "print lc")" >> $GITHUB_ENV
+      - name: "Phase 1: Dev Image"
+        env:
+          IMAGE_NAME_OVERRIDE: ${{ env.IMAGE_NAME_BASE }}-dev
+        run: |
+          bash ./etc/DockerHelper.sh create -target=dev -compiler=gcc -os=${{ matrix.os }}
+      - name: "Phase 2: Build"
+        env:
+          IMAGE_NAME_OVERRIDE: ${{ env.IMAGE_NAME_BASE }}-builder
+          FROM_IMAGE_OVERRIDE: ${{ env.IMAGE_NAME_BASE }}-dev
+        run: |
+          bash ./etc/DockerHelper.sh create -target=builder -compiler=gcc -os=${{ matrix.os }}
+      - name: "Phase 3: Runtime"
+        env:
+          IMAGE_NAME_OVERRIDE: ${{ env.IMAGE_NAME_BASE }}
+          COPY_IMAGE_OVERRIDE: ${{ env.IMAGE_NAME_BASE }}-builder
+        run: |
+          bash ./etc/DockerHelper.sh create -target=runtime -compiler=gcc -os=${{ matrix.os }}
+      - name: Write Upload Data
+        shell: bash # sh does not support complex conditionals
+        run: |
+          if [[ "${{ secrets.UPLOAD_IMAGE }}" == "yes" && ${{ github.event_name }} != "pull_request" ]]; then
+            export TAG_NAME=${GITHUB_REF##*/}
+            if [[ "$TAG_NAME" == "main" || "$TAG_NAME" == "master" ]]; then
+                export TAG_NAME="latest"
+            fi
+            echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+          else
+            echo "TAG_NAME=" >> $GITHUB_ENV
+          fi
+      - name: Login to GitHub Container Registry
+        if: ${{ env.TAG_NAME != '' }}
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+      - name: Push Image To GitHub Container Registry
+        if: ${{ env.TAG_NAME != '' }}
+        run: |
+          docker push ${{ env.IMAGE_NAME_BASE }}:${{ env.TAG_NAME }}

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -3,15 +3,16 @@
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
 
+# https://github.com/moby/moby/issues/38379#issuecomment-448445652
 ARG copyImage=openroad/centos7-builder:latest
+ARG fromImage=centos:centos7
+
 # need to use the line below as the "COPY --from" does not accept an ARG
 FROM $copyImage AS copyfrom
+FROM $fromImage AS runtime
 
-ARG fromImage=centos:centos7
-FROM $fromImage
-
-COPY Installer.sh /tmp/.
-RUN /tmp/Installer.sh -runtime && rm -f /tmp/Installer.sh
+COPY DependencyInstaller.sh /tmp/.
+RUN /tmp/DependencyInstaller.sh -runtime && rm -f /tmp/DependencyInstaller.sh
 
 COPY --from=copyfrom /OpenROAD/build/src/openroad /usr/bin/.
 ENTRYPOINT [ "openroad" ]

--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -58,7 +58,7 @@ _setup() {
             _help
             ;;
     esac
-    imageName="${org}/${os}-${target}"
+    imageName="${IMAGE_NAME_OVERRIDE:-"${org}/${os}-${target}"}"
     if [[ "${useCommitSha}" == "yes" ]]; then
         imageTag="${commitSha}"
     else
@@ -66,21 +66,21 @@ _setup() {
     fi
     case "${target}" in
         "builder" )
-            fromImage="${org}/${os}-dev:${imageTag}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-"${org}/${os}-dev"}:${imageTag}"
             context="."
             buildArgs="--build-arg compiler=${compiler}"
             buildArgs="${buildArgs} --build-arg numThreads=${numThreads}"
-            imageName="${imageName}-${compiler}"
+            imageName="${IMAGE_NAME_OVERRIDE:-"${imageName}-${compiler}"}"
             ;;
         "dev" )
-            fromImage="${osBaseImage}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
             context="etc"
             buildArgs=""
             ;;
         "runtime" )
-            fromImage="${osBaseImage}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
             context="etc"
-            copyImage="${org}/${os}-builder-${compiler}:${imageTag}"
+            copyImage="${COPY_IMAGE_OVERRIDE:-"${org}/${os}-builder-${compiler}"}:${imageTag}"
             buildArgs="--build-arg copyImage=${copyImage}"
             ;;
         *)


### PR DESCRIPTION
This adds building a docker container to GitHub Actions. Every push or PR will attempt a Docker image build.

If the repository secret `UPLOAD_IMAGE` is set to `yes`, a docker image will be pushed to the GitHub Container Repository called openroad-\<os\>, with the tag "latest" for branches named "master" or "main" or with a tag named after the branch for other branches.

This requires "improved container support": see https://docs.github.com/en/packages/working-with-a-github-packages-registry/enabling-improved-container-support-with-the-container-registry

All changes are strictly additive and do not break any existing APIs for any modified scripts or files.