### PR TITLE
Fix for `Dockerfile.runtime`, Docker helper script

### DIFF
--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -3,15 +3,16 @@
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
 
+# https://github.com/moby/moby/issues/38379#issuecomment-448445652
 ARG copyImage=openroad/centos7-builder:latest
+ARG fromImage=centos:centos7
+
 # need to use the line below as the "COPY --from" does not accept an ARG
 FROM $copyImage AS copyfrom
+FROM $fromImage AS runtime
 
-ARG fromImage=centos:centos7
-FROM $fromImage
-
-COPY Installer.sh /tmp/.
-RUN /tmp/Installer.sh -runtime && rm -f /tmp/Installer.sh
+COPY DependencyInstaller.sh /tmp/.
+RUN /tmp/DependencyInstaller.sh -runtime && rm -f /tmp/DependencyInstaller.sh
 
 COPY --from=copyfrom /OpenROAD/build/src/openroad /usr/bin/.
 ENTRYPOINT [ "openroad" ]

--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -58,7 +58,7 @@ _setup() {
             _help
             ;;
     esac
-    imageName="${org}/${os}-${target}"
+    imageName="${IMAGE_NAME_OVERRIDE:-"${org}/${os}-${target}"}"
     if [[ "${useCommitSha}" == "yes" ]]; then
         imageTag="${commitSha}"
     else
@@ -66,21 +66,21 @@ _setup() {
     fi
     case "${target}" in
         "builder" )
-            fromImage="${org}/${os}-dev:${imageTag}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-"${org}/${os}-dev"}:${imageTag}"
             context="."
             buildArgs="--build-arg compiler=${compiler}"
             buildArgs="${buildArgs} --build-arg numThreads=${numThreads}"
-            imageName="${imageName}-${compiler}"
+            imageName="${IMAGE_NAME_OVERRIDE:-"${imageName}-${compiler}"}"
             ;;
         "dev" )
-            fromImage="${osBaseImage}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
             context="etc"
             buildArgs=""
             ;;
         "runtime" )
-            fromImage="${osBaseImage}"
+            fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
             context="etc"
-            copyImage="${org}/${os}-builder-${compiler}:${imageTag}"
+            copyImage="${COPY_IMAGE_OVERRIDE:-"${org}/${os}-builder-${compiler}"}:${imageTag}"
             buildArgs="--build-arg copyImage=${copyImage}"
             ;;
         *)


### PR DESCRIPTION
This makes `Dockerfile.runtime` work.

Additionally, the Docker helper script has been updated so environment variables can override the image names (useful if you're building the images as part of a more controlled flow.) This is a strictly additive change that will not interrupt any existing flows.