### PR TITLE
ppl: add option to allow min dist in tracks

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ place_pins [-hor_layers h_layers]
            [-group_pins pins]
            [-corner_avoidance length]
            [-min_distance distance]
+           [-min_distance_in_tracks]
 ```
 - ``-hor_layers`` (mandatory). Specify the layers to create the metal shapes 
 of pins placed in horizontal tracks. Can be a single layer or a list of layer names.
@@ -319,7 +320,9 @@ where pins cannot be placed. Can be used multiple times.
 random.
 - ``-group_pins``. Specify a list of pins to be placed together on the die boundary.
 - ``-corner_avoidance distance``. Specify the distance (in micron) from each corner to avoid placing pins.
-- ``-min_distance distance``. Specify the minimum distance (in micron) between pins in the die boundary.
+- ``-min_distance distance``. Specify the minimum distance between pins in the die boundary.
+It can be in microns (default) or in number of tracks between each pin.
+- ``-min_distance_in_tracks``. Flag that allows set the min distance in number of tracks instead of microns.
 
 The `exclude` option syntax is `-exclude edge:interval`. The `edge` values are
 (top|bottom|left|right). The `interval` can be the whole edge, with the `*` value,

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -337,12 +337,17 @@ void IOPlacer::findSlots(const std::set<int>& layers, Edge edge)
   int offset = parms_->getCornerAvoidance();
 
   int i = 0;
+  bool dist_in_tracks = parms_->getMinDistanceInTracks();
   for (int layer : layers) {
     int curr_x, curr_y, start_idx, end_idx;
     // get the on grid min distance
-    int min_dst_ver = core_.getMinDstPinsX()[i]*
+    int min_dst_ver = dist_in_tracks ?
+                      core_.getMinDstPinsX()[i]*parms_->getMinDistance() :
+                      core_.getMinDstPinsX()[i]*
                       std::ceil(static_cast<float>(parms_->getMinDistance())/core_.getMinDstPinsX()[i]);
-    int min_dst_hor = core_.getMinDstPinsY()[i]*
+    int min_dst_hor = dist_in_tracks ?
+                      core_.getMinDstPinsY()[i]*parms_->getMinDistance() :
+                      core_.getMinDstPinsY()[i]*
                       std::ceil(static_cast<float>(parms_->getMinDistance())/core_.getMinDstPinsY()[i]);
 
     min_dst_ver = (min_dst_ver == 0) ? default_min_dist*core_.getMinDstPinsX()[i] : min_dst_ver;

--- a/src/ppl/src/IOPlacer.i
+++ b/src/ppl/src/IOPlacer.i
@@ -274,6 +274,12 @@ set_min_distance(int minDist)
 }
 
 void
+set_min_distance_in_tracks(bool in_tracks)
+{
+  getIOPlacer()->getParameters()->setMinDistanceInTracks(in_tracks);
+}
+
+void
 create_pin_shape_pattern(int layer, int x_step, int y_step,
                          int llx, int lly, int urx, int ury,
                          int width, int height, int keepout)

--- a/src/ppl/src/IOPlacer.tcl
+++ b/src/ppl/src/IOPlacer.tcl
@@ -252,6 +252,7 @@ sta::define_cmd_args "place_pins" {[-hor_layers h_layers]\
                        	          [-random]\
                                   [-corner_avoidance distance]\
                                   [-min_distance min_dist]\
+                                  [-min_distance_in_tracks]\
                                   [-exclude region]\
                                   [-group_pins pin_list]
                                  }
@@ -260,8 +261,9 @@ proc place_pins { args } {
   set regions [ppl::parse_excludes_arg $args]
   set pin_groups [ppl::parse_group_pins_arg $args]
   sta::parse_key_args "place_pins" args \
-  keys {-hor_layers -ver_layers -random_seed -corner_avoidance -min_distance -exclude -group_pins} \
-  flags {-random}
+  keys {-hor_layers -ver_layers -random_seed -corner_avoidance \
+        -min_distance -exclude -group_pins} \
+  flags {-random -min_distance_in_tracks}
 
   set dbTech [ord::get_db_tech]
   if { $dbTech == "NULL" } {
@@ -318,14 +320,20 @@ proc place_pins { args } {
   }
 
   set min_dist 2
+  set dist_in_tracks [info exists flags(-min_distance_in_tracks)]
   if [info exists keys(-min_distance)] {
     set min_dist $keys(-min_distance)
-    ppl::set_min_distance [ord::microns_to_dbu $min_dist]
+    if {$dist_in_tracks} {
+      ppl::set_min_distance $min_dist
+    } else {
+      ppl::set_min_distance [ord::microns_to_dbu $min_dist]
+    }
   } else {
     utl::report "Using $min_dist tracks default min distance between IO pins."
     # setting min distance as 0u leads to the default min distance
     ppl::set_min_distance 0
   }
+  ppl::set_min_distance_in_tracks $dist_in_tracks
 
   set bterms_cnt [llength [$dbBlock getBTerms]]
 

--- a/src/ppl/src/Parameters.h
+++ b/src/ppl/src/Parameters.h
@@ -104,6 +104,9 @@ class Parameters
   void setMinDistance(int min_dist) { min_dist_ = min_dist; }
   int getMinDistance() const { return min_dist_; }
 
+  void setMinDistanceInTracks(bool in_tracks) { distance_in_tracks_ = in_tracks; }
+  bool getMinDistanceInTracks() const { return distance_in_tracks_; }
+
  private:
   bool report_hpwl_ = false;
   bool force_spread_ = true;
@@ -120,6 +123,7 @@ class Parameters
   double rand_seed_ = 42.0;
   int corner_avoidance_;
   int min_dist_ = 0;
+  bool distance_in_tracks_ = false;
 };
 
 }  // namespace ppl

--- a/src/ppl/test/min_dist_in_tracks1.defok
+++ b/src/ppl/test/min_dist_in_tracks1.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76190 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 141540 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 125590 201530 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 104310 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 172060 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 152190 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 43890 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 25650 201530 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 155990 201530 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 82460 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 66310 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 140030 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 74290 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 30590 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 127260 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 80750 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 96740 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48070 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 111150 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 29540 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 88730 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 151050 201530 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 35910 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165490 201530 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 175140 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 113540 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 29540 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 60060 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 158340 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 30590 201530 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 74340 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 23660 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104860 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 163940 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 91140 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 68740 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 26460 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176890 70 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 135090 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26460 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 149660 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 135940 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165110 70 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 23940 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 37660 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 46340 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 177660 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 119140 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 120270 70 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 177660 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 54460 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/min_dist_in_tracks1.ok
+++ b/src/ppl/test/min_dist_in_tracks1.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 134 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0127] Reading DEF file: gcd.def
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO ODB-0134] Finished DEF file: gcd.def
+Found 0 macro blocks.
+[INFO PPL-0010] Tentative 0 to set up sections
+[INFO PPL-0001] Number of slots          2494
+[INFO PPL-0002] Number of I/O            54
+[INFO PPL-0003] Number of I/O w/sink     54
+[INFO PPL-0004] Number of I/O w/o sink   0
+[INFO PPL-0005] Slots per section        200
+[INFO PPL-0006] Slots increase factor    0.01
+[INFO PPL-0008] Usage increase factor    0.01
+[INFO PPL-0009] Force pin spread         true
+Successfully assigned I/O pins
+No differences found.

--- a/src/ppl/test/min_dist_in_tracks1.tcl
+++ b/src/ppl/test/min_dist_in_tracks1.tcl
@@ -1,0 +1,12 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 1 -min_distance_in_tracks
+
+set def_file [make_result_file min_dist_in_tracks1.def]
+
+write_def $def_file
+
+diff_file min_dist_in_tracks1.defok $def_file

--- a/src/ppl/test/min_dist_in_tracks2.defok
+++ b/src/ppl/test/min_dist_in_tracks2.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 53770 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 168140 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 125590 201530 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 103930 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 172340 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 148390 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 24500 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 176540 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 177380 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 82460 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 66310 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 140410 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 74290 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 25340 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 126980 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 24500 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 81130 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 96740 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 51490 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 110770 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 29540 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 89110 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 176540 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 35530 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 175700 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 174860 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 113540 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 29540 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 32060 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 168980 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 177380 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 74060 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 22820 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 178220 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 105140 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 163940 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 90860 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 69020 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 26180 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 23660 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 134710 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26180 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 149660 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 136220 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165490 70 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 23660 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 37940 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 32900 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 179060 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 119420 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 119890 70 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 178220 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 54740 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/min_dist_in_tracks2.ok
+++ b/src/ppl/test/min_dist_in_tracks2.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 134 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0127] Reading DEF file: gcd.def
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO ODB-0134] Finished DEF file: gcd.def
+Found 0 macro blocks.
+[INFO PPL-0010] Tentative 0 to set up sections
+[INFO PPL-0001] Number of slots          832
+[INFO PPL-0002] Number of I/O            54
+[INFO PPL-0003] Number of I/O w/sink     54
+[INFO PPL-0004] Number of I/O w/o sink   0
+[INFO PPL-0005] Slots per section        200
+[INFO PPL-0006] Slots increase factor    0.01
+[INFO PPL-0008] Usage increase factor    0.01
+[INFO PPL-0009] Force pin spread         true
+Successfully assigned I/O pins
+No differences found.

--- a/src/ppl/test/min_dist_in_tracks2.tcl
+++ b/src/ppl/test/min_dist_in_tracks2.tcl
@@ -1,0 +1,12 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 3 -min_distance_in_tracks
+
+set def_file [make_result_file min_dist_in_tracks2.def]
+
+write_def $def_file
+
+diff_file min_dist_in_tracks2.defok $def_file

--- a/src/ppl/test/regression_tests.tcl
+++ b/src/ppl/test/regression_tests.tcl
@@ -3,6 +3,8 @@ record_tests {
   multi_layers
   multiple_calls
   invalid_layer
+  min_dist_in_tracks1
+  min_dist_in_tracks2
   no_instance_pins
   no_pins
   no_tracks


### PR DESCRIPTION
This PR covers a request from Ravi. It adds an option to allow the min distance units to be in number of tracks. By default, the min distance is in microns, but with the `-min_distance_in_tracks` flag, it changes to number of tracks.