### PR TITLE
Format the max_merge_res value for RCX message 436 to account

### DIFF
--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -2626,7 +2626,7 @@ uint extMain::makeBlockRCsegs(bool btermThresholdFlag, const char* cmp_file,
     getResCapTable(true);
   }
 
-  logger_->info(RCX, 436, "RC segment generation {} (max_merge_res {}) ...",
+  logger_->info(RCX, 436, "RC segment generation {} (max_merge_res {:.1f}) ...",
                 getBlock()->getName().c_str(), _mergeResBound);
   uint itermCntEst = 3 * bnets.size();
   setupMapping(itermCntEst);


### PR DESCRIPTION
for platform differences. Seen 0 (versus 0.0) appear which can cause regression to fail

Fix for issue #911 