### PR TITLE
Fix undefined behavior with sprintf.

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -56,7 +56,7 @@ static int getMetIndexOverUnder(int met, int mUnder, int mOver,
   int n = layerCnt - met - 1;
   n *= mUnder - 1;
   n += mOver - met - 1;
-  
+
   if ((n < 0) || (n >= maxCnt)) {
     return -1;
   }
@@ -2292,13 +2292,12 @@ FILE* extRCModel::openFile(const char* topDir, const char* name,
                            const char* suffix, const char* permissions) {
   char filename[2048];
 
+  filename[0] = '\0';
   if (topDir != NULL)
-    sprintf(filename, "%s", topDir);
-
-  if (suffix == NULL)
-    sprintf(filename, "%s/%s", filename, name);
-  else
-    sprintf(filename, "%s/%s%s", filename, name, suffix);
+    sprintf(filename, "%s/", topDir);
+  strcat(filename, name);
+  if (suffix != NULL)
+    strcat(filename, suffix);
 
   FILE* fp = fopen(filename, permissions);
   if (fp == NULL) {


### PR DESCRIPTION
This bug cropped up in the rcx regression tests when running as an unprivileged user. In `openFile()` in `src/rcx/src/extRCmodel.cpp`, a call to `sprintf()` uses one of its sources as a destination buffer which is [a known source of undefined behavior](https://gms.tf/on-sprintf-fails.html). The result was that `openroad` kept trying to write a log file to the root directory of my file system in regression tests since the log path was malformed. I believe this should fix it.