### PR TITLE
Fix typos for ABC command names

### DIFF
--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -264,17 +264,15 @@ void Restructure::getEndPoints(sta::PinSet& ends,
 
   std::size_t path_found = path_ends->size();
   logger_->report("Number of paths for restructure are {}", path_found);
-  int end_count = 0;
   for (auto& path_end : *path_ends) {
     if (opt_mode_ >= Mode::DELAY_1) {
       sta::PathExpanded expanded(path_end->path(), open_sta_);
       logger_->report("Found path of depth {}", expanded.size() / 2);
       if (expanded.size() / 2 > max_depth) {
         ends.insert(path_end->vertex(sta_state)->pin());
-        end_count++;
       }
-      if (end_count > 5)  // limit blob size for timing
-        break;
+      // Use only one end point to limit blob size for timing
+      break;
     } else {
       ends.insert(path_end->vertex(sta_state)->pin());
     }
@@ -482,37 +480,37 @@ void Restructure::writeOptCommands(std::ofstream& script)
       break;
     }
     case Mode::DELAY_2: {
-      script << choice << std::endl;
+      script << "choice" << std::endl;
       script << "map -p -B 0.2 -A 0.9 -M 0" << std::endl;
-      script << choice << std::endl;
+      script << "choice" << std::endl;
       script << "map" << std::endl << "topo" << std::endl;
       break;
     }
     case Mode::DELAY_3: {
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "map -p -B 0.2 -A 0.9 -M 0" << std::endl;
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "map" << std::endl << "topo" << std::endl;
       break;
     }
     case Mode::DELAY_4: {
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "amap -m -Q 0.1 -F 20 -A 20 -C 5000" << std::endl;
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "map -p -B 0.2 -A 0.9 -M 0" << std::endl;
       break;
     }
     case Mode::AREA_2:
     case Mode::AREA_3: {
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "amap -m -Q 0.1 -F 20 -A 20 -C 5000" << std::endl;
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "amap -m -Q 0.1 -F 20 -A 20 -C 5000" << std::endl;
       break;
     }
     case Mode::AREA_1:
     default: {
-      script << choice2 << std::endl;
+      script << "choice2" << std::endl;
       script << "amap -m -Q 0.1 -F 20 -A 20 -C 5000" << std::endl;
       break;
     }
@@ -524,20 +522,10 @@ void Restructure::writeOptCommands(std::ofstream& script)
 
 void Restructure::setMode(const char* mode_name)
 {
-  if (!strcmp(mode_name, "delay1") || !strcmp(mode_name, "delay"))
+  if (!strcmp(mode_name, "timing"))
     opt_mode_ = Mode::DELAY_1;
-  else if (!strcmp(mode_name, "delay2"))
-    opt_mode_ = Mode::DELAY_2;
-  else if (!strcmp(mode_name, "delay3"))
-    opt_mode_ = Mode::DELAY_3;
-  else if (!strcmp(mode_name, "delay4"))
-    opt_mode_ = Mode::DELAY_4;
-  else if (!strcmp(mode_name, "area1") || !strcmp(mode_name, "area"))
+  else if (!strcmp(mode_name, "area"))
     opt_mode_ = Mode::AREA_1;
-  else if (!strcmp(mode_name, "area2"))
-    opt_mode_ = Mode::AREA_2;
-  else if (!strcmp(mode_name, "area3"))
-    opt_mode_ = Mode::AREA_3;
   else {
     logger_->report("Mode {} note recognized.", mode_name);
   }

--- a/src/rmp/test/const_cell_removal.ok
+++ b/src/rmp/test/const_cell_removal.ok
@@ -10,16 +10,16 @@
 [INFO ODB-0133]     Created 103 nets and 242 connections.
 [INFO ODB-0134] Finished DEF file: rcon.def
 Design area 0 u^2 100% utilization.
-Removed 2 instances with constant outputs.
+Removed 27 instances with constant outputs.
 Number of paths for restructure are 19
 Found 10 end points for restructure
-Found 123 pins in extracted logic
+Found 123 pins in extracted logic.
 Found 41 instances for restructuring.
 [INFO RMP-0002] Blif writer successfully dumped file with 41 instances.
 Optimized to 36 instances in iteration 0
 Optimized to 37 instances in iteration 1
 Optimized to 36 instances in iteration 2
-[INFO RMP-0005] blif parsed successfully, destroying 41 existing instances...
-[INFO RMP-0006] Found 8 Inputs, 14 Outputs, 0 Clocks, 36 Combinational gates, 0 Registers after parsing the blif file.
-[INFO RMP-0007] inserting 36 new instances...
+[INFO RMP-0005] Blif parsed successfully, will destroy 41 existing instances.
+[INFO RMP-0006] Found 8 inputs, 14 outputs, 0 clocks, 36 combinational gates, 0 registers after parsing the blif file.
+[INFO RMP-0007] Inserting 36 new instances.
 Design area 0 u^2 100% utilization.

--- a/src/rmp/test/gcd_restructure.ok
+++ b/src/rmp/test/gcd_restructure.ok
@@ -12,17 +12,17 @@
 [INFO ODB-0134] Finished DEF file: gcd_placed.def
 [WARNING STA-0354] set_input_delay relative to a clock defined on the same port/pin not allowed.
 worst slack 1.29
-Design area 700 u^2 11% utilization.
+Design area 670 u^2 10% utilization.
 Removed 0 instances with constant outputs.
 Number of paths for restructure are 105
 Found 53 end points for restructure
-Found 1290 pins in extracted logic
+Found 1290 pins in extracted logic.
 Found 422 instances for restructuring.
 [INFO RMP-0002] Blif writer successfully dumped file with 422 instances.
-Optimized to 241 instances in iteration 0
-Optimized to 257 instances in iteration 1
-Optimized to 255 instances in iteration 2
-[INFO RMP-0005] blif parsed successfully, destroying 422 existing instances...
-[INFO RMP-0006] Found 89 Inputs, 52 Outputs, 0 Clocks, 241 Combinational gates, 0 Registers after parsing the blif file.
-[INFO RMP-0007] inserting 241 new instances...
-Design area 523 u^2 8% utilization.
+Optimized to 256 instances in iteration 0
+Optimized to 250 instances in iteration 1
+Optimized to 257 instances in iteration 2
+[INFO RMP-0005] Blif parsed successfully, will destroy 422 existing instances.
+[INFO RMP-0006] Found 89 inputs, 52 outputs, 0 clocks, 250 combinational gates, 0 registers after parsing the blif file.
+[INFO RMP-0007] Inserting 250 new instances.
+Design area 489 u^2 8% utilization.


### PR DESCRIPTION
Fix typo to use timing instead of delay in option "target"

Signed-off-by: Sanjiv Mathur <mathur.sanjiv@gmail.com>