### PR TITLE
Docker: separate runtime into two.

### DIFF
--- a/docker/Dockerfile.binary
+++ b/docker/Dockerfile.binary
@@ -1,0 +1,17 @@
+# create image with runtime dependencies and a copy of the binary from a
+# builder image
+# NOTE: don't use this file directly unless you know what you are doing,
+# instead use etc/DockerHelper.sh
+
+# https://github.com/moby/moby/issues/38379#issuecomment-448445652
+ARG copyImage=openroad/centos7-builder:latest
+ARG fromImage=openroad/centos7-runtime:latest
+
+# need to use the line below as the "COPY --from" does not accept an ARG
+FROM $copyImage AS copyfrom
+
+FROM $fromImage
+
+COPY --from=copyfrom /OpenROAD/build/src/openroad /usr/bin/.
+
+ENTRYPOINT [ "openroad" ]

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -2,12 +2,16 @@
 # copy source code to the docker image and compile the app
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
+
+# https://github.com/moby/moby/issues/38379#issuecomment-448445652
 ARG fromImage=openroad/centos7-dev:latest
+
 FROM $fromImage
+
+ARG compiler=gcc
+ARG numThreads=$(nproc)
 
 COPY . /OpenROAD
 WORKDIR /OpenROAD
 
-ARG compiler=gcc
-ARG numThreads=$(nproc)
 RUN ./etc/Build.sh -compiler=${compiler} -threads=${numThreads}

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,10 @@
 # create image with dependencies needed to compile openroad app
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
+
+# https://github.com/moby/moby/issues/38379#issuecomment-448445652
 ARG fromImage=centos:centos7
+
 FROM $fromImage
 
 COPY DependencyInstaller.sh /tmp/.

--- a/docker/Dockerfile.runtime
+++ b/docker/Dockerfile.runtime
@@ -1,18 +1,11 @@
 # create image only with runtime dependencies
-# copies binary from a builder image
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
 
 # https://github.com/moby/moby/issues/38379#issuecomment-448445652
-ARG copyImage=openroad/centos7-builder:latest
 ARG fromImage=centos:centos7
 
-# need to use the line below as the "COPY --from" does not accept an ARG
-FROM $copyImage AS copyfrom
-FROM $fromImage AS runtime
+FROM $fromImage
 
 COPY DependencyInstaller.sh /tmp/.
 RUN /tmp/DependencyInstaller.sh -runtime && rm -f /tmp/DependencyInstaller.sh
-
-COPY --from=copyfrom /OpenROAD/build/src/openroad /usr/bin/.
-ENTRYPOINT [ "openroad" ]

--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -26,6 +26,8 @@ usage: $0 [CMD] [OPTIONS]
                                   'builder': os + packages to compile app +
                                              copy source code and build app
                                   'runtime': os + packages to run a compiled app
+                                  'binary': os + packages to run a compiled
+                                            app + binary set as entrypoint
   -threads                      Max number of threads to use if compiling.
                                   Default = \$(nproc)
   -sha                          Use git commit sha as the tag image. Default is
@@ -79,6 +81,12 @@ _setup() {
             ;;
         "runtime" )
             fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
+            context="etc"
+            copyImage="${COPY_IMAGE_OVERRIDE:-"${org}/${os}-builder-${compiler}"}:${imageTag}"
+            buildArgs="--build-arg copyImage=${copyImage}"
+            ;;
+        "binary" )
+            fromImage="${FROM_IMAGE_OVERRIDE:-${org}/${os}-runtime}:${imageTag}"
             context="etc"
             copyImage="${COPY_IMAGE_OVERRIDE:-"${org}/${os}-builder-${compiler}"}:${imageTag}"
             buildArgs="--build-arg copyImage=${copyImage}"


### PR DESCRIPTION
With the separation between runtime and binary we can deploy the runtime image to hub.docker.com without a binary.

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>