### PR TITLE
Process vias and snet paths on init floorplan

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1784,6 +1784,9 @@ bool definReader::createBlock(const char* file)
     defrSetRowCbk(rowCallback);
     defrSetNetCbk(netCallback);
     defrSetSNetCbk(specialNetCallback);
+    defrSetViaCbk(viaCallback);
+
+    defrSetAddPathToNet();
   }
 
   if (_mode == defin::DEFAULT) {
@@ -1810,10 +1813,6 @@ bool definReader::createBlock(const char* file)
     defrSetStartPinsCbk(pinsStartCallback);
     defrSetStylesStartCbk(stylesCallback);
     defrSetTechnologyCbk(technologyCallback);
-
-    defrSetViaCbk(viaCallback);
-
-    defrSetAddPathToNet();
   }
 
   bool isZipped = hasSuffix(file, ".gz");


### PR DESCRIPTION
I want to be able to initialize a floorplan based on a provided DEF that includes special net paths and via declarations, but I noticed that when `read_def` has the `-floorplan_initialize` flag passed in, it strips these away. If there's no particular reason for this, I think it would be helpful for this information to be processed and included even on floorplan initialization reads. 

This PR accomplishes this by adjusting the definReader configuration to process this information for both the default and floorplan reader modes.