### PR TITLE
write_verilog flips the indices of lsb first bus ports

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -242,6 +242,7 @@ protected:
   virtual void visitConnectedPins(const Net *net,
                                   PinVisitor &visitor,
                                   ConstNetSet &visited_nets) const;
+  bool portIsBigEndian(const char *port_name);
 
   dbDatabase *db_;
   Logger *logger_;

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -242,7 +242,7 @@ protected:
   virtual void visitConnectedPins(const Net *net,
                                   PinVisitor &visitor,
                                   ConstNetSet &visited_nets) const;
-  bool portIsBigEndian(const char *port_name);
+  bool portMsbFirst(const char *port_name);
 
   dbDatabase *db_;
   Logger *logger_;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -944,6 +944,11 @@ dbNetwork::readDbNetlistAfter()
 void
 dbNetwork::makeTopCell()
 {
+  if (top_cell_) {
+    // Reading DEF or linking when a network already exists; remove previous top cell.
+    Library *top_lib = library(top_cell_);
+    deleteLibrary(top_lib);
+  }
   const char *design_name = block_->getConstName();
   Library *top_lib = makeLibrary(design_name, nullptr);
   top_cell_ = makeCell(top_lib, design_name, false, nullptr);
@@ -975,6 +980,7 @@ dbNetwork::portMsbFirst(const char *port_name)
 void
 dbNetwork::findConstantNets()
 {
+  clearConstantNets();
   for (dbNet *dnet : block_->getNets()) {
     if (dnet->getSigType() == dbSigType::GROUND)
       addConstantNet(dbToSta(dnet), LogicValue::zero);

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -911,7 +911,7 @@ dbNetwork::makeCell(Library *library,
 		      port_name);
     }
   }
-  // Assume big endian busses because LEF has no clue about busses.
+  // Assume msb first busses because LEF has no clue about busses.
   groupBusPorts(cell, [](const char*) { return true; });
 
   // Fill in liberty to db/LEF master correspondence for libraries not used
@@ -955,15 +955,15 @@ dbNetwork::makeTopCell()
     
   }
   groupBusPorts(top_cell_,
-                [=](const char *port_name) { return portIsBigEndian(port_name); } );
+                [=](const char *port_name) { return portMsbFirst(port_name); } );
 }
 
 // read_verilog / Verilog2db::makeDbPins leaves a cookie to know if a bus port
-// is big endian.
+// is msb first or lsb first.
 bool
-dbNetwork::portIsBigEndian(const char *port_name)
+dbNetwork::portMsbFirst(const char *port_name)
 {
-  string key = "bus_big_endian ";
+  string key = "bus_msb_first ";
   key += port_name;
   dbBoolProperty *property = odb::dbBoolProperty::find(block_, key.c_str());
   if (property)

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -952,7 +952,6 @@ dbNetwork::makeTopCell()
     Port *port = makePort(top_cell_, port_name);
     PortDirection *dir = dbToSta(bterm->getSigType(), bterm->getIoType());
     setDirection(port, dir);
-    
   }
   groupBusPorts(top_cell_,
                 [=](const char *port_name) { return portMsbFirst(port_name); } );

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -310,6 +310,7 @@ Verilog2db::makeDbNets(const Instance *inst)
     const char *net_name = network_->pathName(net);
     if (is_top || !hasTerminals(net)) {
       dbNet *db_net = block_->findNet(net_name);
+      // Net may already exist from makeDbPins().
       if (db_net == nullptr)
         db_net = dbNet::create(block_, net_name);
 
@@ -329,18 +330,8 @@ Verilog2db::makeDbNets(const Instance *inst)
       sort(net_pins, PinPathNameLess(network_));
 
       for (Pin *pin : net_pins) {
-#if 0
-	if (network_->isTopLevelPort(pin)) {
-	  const char *port_name = network_->portName(pin);
-	  if (block_->findBTerm(port_name) == nullptr) {
-	    dbBTerm *bterm = dbBTerm::create(db_net, port_name);
-	    dbIoType io_type = staToDb(network_->direction(pin));
-	    bterm->setIoType(io_type);
-	  }
-	}
-	else 
-#endif
-if (network_->isLeaf(pin)) {
+        // Note bterms are made in makeDbPins().
+        if (network_->isLeaf(pin)) {
 	  const char *port_name = network_->portName(pin);
 	  Instance *inst = network_->instance(pin);
 	  const char *inst_name = network_->pathName(inst);

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -250,7 +250,7 @@ Verilog2db::makeDbPins()
   delete port_iter;
 
   // OpenDB does not have any concept of bus ports.
-  // Use a property to annotate the bus names endian-ness for writing verilog.
+  // Use a property to annotate the bus names as msb or lsb first for writing verilog.
   CellPortIterator *bus_iter = network_->portIterator(top_cell);
   while (bus_iter->hasNext()) {
     Port *port = port_iter->next();
@@ -258,7 +258,7 @@ Verilog2db::makeDbPins()
       const char *port_name = network_->name(port);
       int from = network_->fromIndex(port);
       int to = network_->toIndex(port);
-      string key = "bus_big_endian ";
+      string key = "bus_msb_first ";
       key += port_name;
       odb::dbBoolProperty::create(block_, key.c_str(), from > to);
     }

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -253,7 +253,7 @@ Verilog2db::makeDbPins()
   // Use a property to annotate the bus names as msb or lsb first for writing verilog.
   CellPortIterator *bus_iter = network_->portIterator(top_cell);
   while (bus_iter->hasNext()) {
-    Port *port = port_iter->next();
+    Port *port = bus_iter->next();
     if (network_->isBus(port)) {
       const char *port_name = network_->name(port);
       int from = network_->fromIndex(port);

--- a/src/dbSta/test/read_verilog1.tcl
+++ b/src/dbSta/test/read_verilog1.tcl
@@ -8,4 +8,3 @@ link_design top
 set def_file [make_result_file read_verilog1.def]
 write_def $def_file
 diff_files $def_file read_verilog1.defok
-

--- a/src/dbSta/test/read_verilog4.ok
+++ b/src/dbSta/test/read_verilog4.ok
@@ -2,6 +2,6 @@
 [INFO ODB-0223]     Created 2 technology layers
 [INFO ODB-0225]     Created 6 library cells
 [INFO ODB-0226] Finished LEF file:  liberty1.lef
-[WARNING STA-0198] read_verilog4.v line 6, module xxx not found.  Creating black box for r1.
+[WARNING STA-0198] read_verilog4.v line 6, module xxx not found. Creating black box for r1.
 [WARNING ORD-1013] instance r1 LEF master xxx not found.
 No differences found.

--- a/src/dbSta/test/read_verilog6.ok
+++ b/src/dbSta/test/read_verilog6.ok
@@ -6,6 +6,6 @@
 [INFO ODB-0222] Reading LEF file: read_verilog6.lef
 [INFO ODB-0225]     Created 1 library cells
 [INFO ODB-0226] Finished LEF file:  read_verilog6.lef
-[WARNING STA-0198] read_verilog6.v line 11, module AND2_X10 not found.  Creating black box for u2.
+[WARNING STA-0198] read_verilog6.v line 11, module AND2_X10 not found. Creating black box for u2.
 [WARNING ORD-1011] LEF master BUF_X10 has no liberty cell.
 [WARNING ORD-1013] instance u2 LEF master AND2_X10 not found.

--- a/src/dbSta/test/read_verilog8.tcl
+++ b/src/dbSta/test/read_verilog8.tcl
@@ -1,0 +1,10 @@
+# port assigned to net (port with alias)
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_verilog read_verilog8.v
+link_design top
+
+set def_file [make_result_file read_verilog8.def]
+write_def $def_file
+diff_files $def_file read_verilog8.defok

--- a/src/dbSta/test/read_verilog8.v
+++ b/src/dbSta/test/read_verilog8.v
@@ -1,0 +1,8 @@
+module top (in1, out1);
+   input in1;
+   output out1;
+   wire out1_alias;
+
+   BUF_X1 u1 (.A(in1), .Z(out1_alias));
+   assign out1 = out1_alias;
+endmodule // top

--- a/src/dbSta/test/regression_tests.tcl
+++ b/src/dbSta/test/regression_tests.tcl
@@ -22,6 +22,7 @@ record_tests {
   read_verilog5
   read_verilog6
   read_verilog7
+  read_verilog8
 
   write_verilog1
   write_verilog2

--- a/src/dbSta/test/write_verilog8.ok
+++ b/src/dbSta/test/write_verilog8.ok
@@ -7,7 +7,7 @@ module reg5 (out,
     in);
  output out;
  input [2:0] clk;
- input [1:0] in;
+ input [0:1] in;
 
  wire r1q;
  wire r2q;

--- a/src/ifp/test/auto_place_pins1.ok
+++ b/src/ifp/test/auto_place_pins1.ok
@@ -4,6 +4,4 @@
 [INFO ODB-0225]     Created 134 library cells
 [INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
 [INFO IFP-0001] Added 570 rows of 4209 sites.
-Differences found at line 588.
-        + FIXED ( 200260 201600 ) N ;
-        + FIXED ( 1799680 732460 ) N ;
+No differences found.

--- a/src/ifp/test/auto_place_pins1.ok
+++ b/src/ifp/test/auto_place_pins1.ok
@@ -4,4 +4,6 @@
 [INFO ODB-0225]     Created 134 library cells
 [INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
 [INFO IFP-0001] Added 570 rows of 4209 sites.
-No differences found.
+Differences found at line 588.
+        + FIXED ( 200260 201600 ) N ;
+        + FIXED ( 1799680 732460 ) N ;

--- a/src/par/src/PartitionNetwork.cpp
+++ b/src/par/src/PartitionNetwork.cpp
@@ -310,7 +310,7 @@ PartitionMgr::buildPartitionedInstance(
       }
     }
   }
-  network->groupBusPorts(cell);
+  network->groupBusPorts(cell, [](const char*) { return true; });
 
   // build instance
   std::string instname = name;


### PR DESCRIPTION
 write_verilog flips the indices of lsb first bus ports #578 
Signed-off-by: James Cherry <cherry@parallaxsw.com>