### PR TITLE
Remove RCX hard-coded define for debug net.

### DIFF
--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -42,8 +42,6 @@
 #define MAXINT 0x7FFFFFFF;
 //#define HI_ACC_10312011
 
-#define DEBUG_NET_ID 228157
-
 namespace rcx {
 
 #ifdef DEBUG_NET_ID


### PR DESCRIPTION
This is generating a file in ORFS for some design.

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>