### PR TITLE
Add if statement to skip tapcell insertion for HVL cells (OpenFASOC)

### DIFF
--- a/src/tap/src/tapcell.tcl
+++ b/src/tap/src/tapcell.tcl
@@ -191,11 +191,13 @@ proc tapcell { args } {
     }
   }
 
+
+  if { [info exists keys(-tapcell_master)] } {
   tap::clear
   tap::set_tap_prefix $tap_prefix
   tap::set_endcap_prefix $endcap_prefix
   tap::run $endcap_master $halo_x $halo_y $cnrcap_nwin_master $cnrcap_nwout_master $add_boundary_cell $tap_nwintie_master $tap_nwin2_master $tap_nwin3_master $tap_nwouttie_master $tap_nwout2_master $tap_nwout3_master $incnrcap_nwin_master $incnrcap_nwout_master $tapcell_master $dist
-
+  }
 }
 
 sta::define_cmd_args "tapcell_ripup" {[-tap_prefix tap_prefix]\

--- a/src/tap/src/tapcell.tcl
+++ b/src/tap/src/tapcell.tcl
@@ -191,7 +191,6 @@ proc tapcell { args } {
     }
   }
 
-
   if { [info exists keys(-tapcell_master)] } {
   tap::clear
   tap::set_tap_prefix $tap_prefix


### PR DESCRIPTION
 need to use the high voltage library for OpenFASOC's LDO. And since the sky130hvl technology already contains tapcells in its standard cells, I added an if statement to skip inserting tapcells. 