### PR TITLE
Remove requirement to link with swig-3.0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,7 @@ if (BUILD_TCLX AND TCLX_H)
   message(STATUS "TclX header: ${TCLX_H}")
 endif()
 
-find_package(SWIG 3.0 REQUIRED)
+find_package(SWIG REQUIRED)
 include(UseSWIG)
 
 find_package(Boost REQUIRED)


### PR DESCRIPTION
The latest version of swig is swig-4.0.2 and OpenROAD builds fine with it.