### PR TITLE
Enabling Link Time Optimization (LTO) for OpenROAD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,12 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.10)
 cmake_policy(SET CMP0071 NEW)
 endif()
 
+option(LINK_TIME_OPTIMIZATION "Flag to control link time optimization: on by default" ON)
+
+if (LINK_TIME_OPTIMIZATION)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
 project(OpenROAD VERSION 1
   LANGUAGES CXX
 )

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ To install in a different directory use:
 ./etc/Build.sh -cmake="-DCMAKE_INSTALL_PREFIX=<prefix_path>"
 ```
 
+### LTO Options
+By default, OpenROAD is built with link time optimizations enabled. This adds 
+about 1 minute to compile times and improves the runtime by about 11%. If
+you would like to disable LTO pass `-DLINK_TIME_OPTIMIZATION=OFF` when
+generating a build.
+
 ## Regression Tests
 
 There are a set of regression tests in `test/`.


### PR DESCRIPTION
Link Time Optimization allows the compiler to make optimizations across link boundaries. 
https://en.wikipedia.org/wiki/Interprocedural_optimization

Current CI runtime is measured at about 23-37 minutes. We should see if this reduces that time.