### PR TITLE
Process blockages on -initialize_floorplan

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1785,6 +1785,7 @@ bool definReader::createBlock(const char* file)
     defrSetNetCbk(netCallback);
     defrSetSNetCbk(specialNetCallback);
     defrSetViaCbk(viaCallback);
+    defrSetBlockageCbk(blockageCallback);
 
     defrSetAddPathToNet();
   }
@@ -1793,7 +1794,6 @@ bool definReader::createBlock(const char* file)
     defrSetPropCbk(propCallback);
     defrSetPropDefEndCbk(propEndCallback);
     defrSetPropDefStartCbk(propStartCallback);
-    defrSetBlockageCbk(blockageCallback);
 
     defrSetExtensionCbk(extensionCallback);
     defrSetFillStartCbk(fillsCallback);


### PR DESCRIPTION
Similarly to PR #987, I'd like to be able to initialize a floorplan based on a provided DEF file that includes placement or routing blockages and not have them e stripped away. This PR adjusts the definReader configuration to enable this.

Thanks!