### PR TITLE
gpl: Fix routability_max_density option

### DIFF
--- a/src/gpl/src/replace.tcl
+++ b/src/gpl/src/replace.tcl
@@ -137,7 +137,7 @@ proc global_placement { args } {
   if { [info exists keys(-routability_max_density)] } {
     set routability_max_density $keys(-routability_max_density)
     sta::check_positive_float "-routability_max_density" $routability_max_density
-    set_routability_max_density_cmd $routability_max_density
+    gpl::set_routability_max_density_cmd $routability_max_density
   }
 
 


### PR DESCRIPTION
When using the routability_max_density option, openroad died with:

invalid command name "set_routability_max_density_cmd"