### PR TITLE
Don't restrict boost version.

### DIFF
--- a/src/drt/CMakeLists.txt
+++ b/src/drt/CMakeLists.txt
@@ -44,7 +44,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 include(CheckIPOSupported)
 check_ipo_supported(RESULT ipo_supported OUTPUT error)
 
-find_package(Boost 1.68.0 REQUIRED COMPONENTS serialization)
+find_package(Boost REQUIRED COMPONENTS serialization)
 find_package(OpenMP REQUIRED)
 find_package(VTune)
 

--- a/src/dst/CMakeLists.txt
+++ b/src/dst/CMakeLists.txt
@@ -36,7 +36,7 @@ include("openroad")
 project(dst
   LANGUAGES CXX
 )
-find_package(Boost 1.76.0 REQUIRED COMPONENTS serialization system thread)
+find_package(Boost REQUIRED COMPONENTS serialization system thread)
 swig_lib(NAME      dst
          NAMESPACE dst
          I_FILE    src/Distributed.i

--- a/src/dst/include/dst/Distributed.h
+++ b/src/dst/include/dst/Distributed.h
@@ -34,24 +34,21 @@
 #include <string>
 #include <vector>
 
+#include <boost/asio.hpp>
+
 namespace utl {
 class Logger;
 }
-
-namespace boost::asio {
-class any_io_executor;
-template <typename Protocol, typename Executor>
-class basic_stream_socket;
-namespace ip {
-class tcp;
-}
-}  // namespace boost::asio
 
 namespace asio = boost::asio;
 using asio::ip::tcp;
 
 namespace dst {
+#if BOOST_VERSION >= 107000
 typedef asio::basic_stream_socket<tcp, asio::any_io_executor> socket;
+#else
+typedef asio::basic_stream_socket<tcp> socket;
+#endif
 class JobMessage;
 class JobCallBack;
 


### PR DESCRIPTION
This PR allows to build using any boost version.

  * Distro's **cannot guarantee** a specific **pinned version**.
  * As example on RHEL-8/CentOS-8 **cannot be compiled**.

For the involved `basic_stream_socket` see the major changes [1.69.0](https://www.boost.org/doc/libs/1_69_0/doc/html/boost_asio/reference/basic_stream_socket.html) vs [1.70.0](https://www.boost.org/doc/libs/1_70_0/doc/html/boost_asio/reference/basic_stream_socket.html)
```
- template< typename Protocol >
+ template< typename Protocol, typename Executor >
 class basic_stream_socket :
-  public basic_socket< Protocol >
+  public basic_socket< Protocol, Executor >
```
---

This now pass compilation on following [latest builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/3077214)
For your interest there are Fedora/EPEL ***weekly*** releases of OpenROAD & OpenSTA in this **[VLSI](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/)** package repo


Thank You !
~cristian.