### PR TITLE
ppl: check min width during place_pin command

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1202,13 +1202,13 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
   Point ub = die_boundary.ur();
 
   odb::dbTechLayer* tech_layer = tech_->findRoutingLayer(layer);
-  if (width < tech_layer->getWidth() ||
-      height < tech_layer->getWidth()) {
+  float pin_width = std::min(width, height);
+  if (pin_width < tech_layer->getWidth()) {
     logger_->error(PPL,
                    34,
                    "Pin {} has dimension {}u which is less than the min width {}u of layer {}.",
                    bterm->getName(),
-                   dbuToMicrons(std::min(width, height)),
+                   dbuToMicrons(pin_width),
                    dbuToMicrons(tech_layer->getWidth()),
                    tech_layer->getName());
   }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1206,8 +1206,9 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
       height < tech_layer->getWidth()) {
     logger_->error(PPL,
                    34,
-                   "Pin {} do not respect the min width {}u of layer {}",
+                   "Pin {} has dimension {}u which is less than the min width {}u of layer {}.",
                    bterm->getName(),
+                   dbuToMicrons(std::min(width, height)),
                    dbuToMicrons(tech_layer->getWidth()),
                    tech_layer->getName());
   }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1201,10 +1201,20 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
   Point lb = die_boundary.ll();
   Point ub = die_boundary.ur();
 
+  odb::dbTechLayer* tech_layer = tech_->findRoutingLayer(layer);
+  if (width < tech_layer->getWidth() ||
+      height < tech_layer->getWidth()) {
+    logger_->error(PPL,
+                   34,
+                   "Pin {} do not respect the min width {}u of layer {}",
+                   bterm->getName(),
+                   dbuToMicrons(tech_layer->getWidth()),
+                   tech_layer->getName());
+  }
+
   if (force_to_die_bound) {
     movePinToTrack(pos, layer, width, height, die_boundary);
     Edge edge;
-    odb::dbTechLayer* tech_layer = tech_->findRoutingLayer(layer);
     odb::dbTrackGrid* track_grid = block_->findTrackGrid(tech_layer);
     int min_spacing, init_track, num_track;
     bool horizontal = tech_layer->getDirection() == odb::dbTechLayerDir::HORIZONTAL;

--- a/src/ppl/test/place_pin_error3.ok
+++ b/src/ppl/test/place_pin_error3.ok
@@ -1,0 +1,13 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 134 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0127] Reading DEF file: gcd.def
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO ODB-0134] Finished DEF file: gcd.def
+[ERROR PPL-0034] Pin clk do not respect the min width 0.4u of layer metal7
+PPL-0034

--- a/src/ppl/test/place_pin_error3.ok
+++ b/src/ppl/test/place_pin_error3.ok
@@ -9,5 +9,5 @@
 [INFO ODB-0131]     Created 88 components and 422 component-terminals.
 [INFO ODB-0133]     Created 54 nets and 88 connections.
 [INFO ODB-0134] Finished DEF file: gcd.def
-[ERROR PPL-0034] Pin clk do not respect the min width 0.4u of layer metal7
+[ERROR PPL-0034] Pin clk has dimension 0.35u which is less than the min width 0.4u of layer metal7.
 PPL-0034

--- a/src/ppl/test/place_pin_error3.tcl
+++ b/src/ppl/test/place_pin_error3.tcl
@@ -1,0 +1,7 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+catch {place_pin -pin_name clk -layer metal7 -location {40 30} -pin_size {1.6 0.35}} error
+puts $error

--- a/src/ppl/test/regression_tests.tcl
+++ b/src/ppl/test/regression_tests.tcl
@@ -56,4 +56,5 @@ record_tests {
   place_pin5
   place_pin_error1
   place_pin_error2
+  place_pin_error3
 }


### PR DESCRIPTION
This PR adds a check for the `place_pin` command for the min width of the layer. When a pin is placed violating the min width, drt can fail when computing the APs.

Issue detected from a user testcase.