### PR TITLE
grt: Call updateDbCongestion before exiting global routing

### DIFF
--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -1219,6 +1219,8 @@ NetRouteMap FastRouteCore::run()
 
   net_eo_.clear();
 
+  updateDbCongestion();
+
   if (has_2D_overflow && !allow_overflow_) {
     logger_->error(GRT, 118, "Routing congestion too high.");
   }


### PR DESCRIPTION
The global routing congestion heat map stopped working recently
because we no longer call updateDbCongestion().