### PR TITLE
Fix some compile warnings and errors on an up-to-date system

### DIFF
--- a/src/cts/src/Util.h
+++ b/src/cts/src/Util.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <ostream>
+#include "spdlog/fmt/ostr.h"
 
 namespace cts {
 
@@ -137,3 +138,6 @@ class Box
 };
 
 }  // namespace cts
+
+template <typename T> struct fmt::formatter<cts::Box<T>> : ostream_formatter {};
+template <typename T> struct fmt::formatter<cts::Point<T>> : ostream_formatter {};

--- a/src/drt/src/db/infra/frTime.h
+++ b/src/drt/src/db/infra/frTime.h
@@ -34,6 +34,7 @@
 #include <iostream>
 
 #include "frBaseTypes.h"
+#include "spdlog/fmt/ostr.h"
 
 extern size_t getPeakRSS();
 extern size_t getCurrentRSS();
@@ -60,5 +61,7 @@ class frTime
 
 std::ostream& operator<<(std::ostream& os, const frTime& t);
 }  // namespace fr
+
+template <> struct fmt::formatter<fr::frTime> : ostream_formatter {};
 
 #endif

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -43,6 +43,7 @@
 
 #include "odb/dbTypes.h"
 #include "utl/Logger.h"
+#include "spdlog/fmt/ostr.h"
 
 namespace odb {
   class Rect;
@@ -344,5 +345,11 @@ inline bool is_loading(const Archive& ar)
 }
 
 }  // namespace fr
+
+template <> struct fmt::formatter<fr::frBlockObjectEnum> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frConstraintTypeEnum> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frCornerTypeEnum> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frMinimumcutConnectionEnum> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frMinstepTypeEnum> : ostream_formatter {};
 
 #endif

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -35,6 +35,7 @@
 
 #include "frBaseTypes.h"
 #include "db/obj/frMarker.h"
+#include "spdlog/fmt/ostr.h"
 
 extern std::string DBPROCESSNODE;
 extern std::string OUT_MAZE_FILE;
@@ -176,4 +177,21 @@ std::ostream& operator<<(std::ostream& os, const drNet& n);
 std::ostream& operator<<(std::ostream& os, const frMarker& m);
 // namespace fr
 }  // namespace fr
+
+template <> struct fmt::formatter<fr::frViaDef> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frBlock> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frInst> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frInstTerm> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frBTerm> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frRect> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frPolygon> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frShape> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frConnFig> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frPathSeg> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frGuide> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frBlockObject> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frNet> : ostream_formatter {};
+template <> struct fmt::formatter<fr::drNet> : ostream_formatter {};
+template <> struct fmt::formatter<fr::frMarker> : ostream_formatter {};
+
 #endif

--- a/src/dst/src/BalancerConnection.cc
+++ b/src/dst/src/BalancerConnection.cc
@@ -136,7 +136,7 @@ void BalancerConnection::handle_read(boost::system::error_code const& err,
                               "Exception thrown: {}. worker with ip \"{}\" and "
                               "port \"{}\" will be pushed back the queue.",
                               ex.what(),
-                              workerAddress,
+                              workerAddress.to_string(),
                               port);
                 owner_->punishWorker(workerAddress, port);
                 failed_workers_trials++;

--- a/src/dst/src/LoadBalancer.cc
+++ b/src/dst/src/LoadBalancer.cc
@@ -45,7 +45,7 @@ void LoadBalancer::start_accept()
     while (!copy.empty()) {
       auto worker = copy.top();
       logger_->report("Worker {}/{} handled {} jobs",
-                      worker.ip,
+                      worker.ip.to_string(),
                       worker.port,
                       worker.priority);
       copy.pop();

--- a/src/grt/src/fastroute/CMakeLists.txt
+++ b/src/grt/src/fastroute/CMakeLists.txt
@@ -60,3 +60,9 @@ target_link_libraries(FastRoute4.1
     odb
     Boost::boost
 )
+
+# False positive? inside Boost
+# error: ‘void* __builtin_memset(void*, int, long unsigned int)’ offset 0 is out of the bounds [0, 0] [-Werror=array-bounds]
+target_compile_options(FastRoute4.1
+  PRIVATE $<$<CXX_COMPILER_ID:GNU>:-Wno-array-bounds>
+)

--- a/src/grt/src/fastroute/include/DataType.h
+++ b/src/grt/src/fastroute/include/DataType.h
@@ -35,6 +35,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "spdlog/fmt/ostr.h"
 
 namespace odb {
 class dbNet;
@@ -238,3 +239,5 @@ struct OrderNetEdge
 };
 
 }  // namespace grt
+
+template <> struct fmt::formatter<grt::RouteType> : ostream_formatter {};

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -185,10 +185,9 @@ class GuiPainter : public Painter
   void drawRect(const odb::Rect& rect, int roundX = 0, int roundY = 0) override
   {
     if (roundX > 0 || roundY > 0)
-      painter_->drawRoundRect(
-          QRect(rect.xMin(), rect.yMin(), rect.dx(), rect.dy()),
-          roundX,
-          roundY);
+      painter_->drawRoundedRect(QRect(rect.xMin(), rect.yMin(), rect.dx(), rect.dy()),
+                              rect.dx() * (roundX / 200.0f), // convert roundX and roundY from percent to radius
+                              rect.dy() * (roundY / 200.0f));
     else
       painter_->drawRect(QRect(rect.xMin(), rect.yMin(), rect.dx(), rect.dy()));
   }

--- a/src/odb/src/def/def/def_keywords.cpp
+++ b/src/odb/src/def/def/def_keywords.cpp
@@ -1026,7 +1026,7 @@ defrData::defInfo(int msgNum, const char *s) {
       if (!hasOpenedDefLogFile) {
          if ((defrLog = fopen("defRWarning.log", "w")) == 0) {
             printf("WARNING(DEFPARS-8500): Unable to open the file defRWarning.log in %s.\n",
-            getcwd(NULL, 64));
+            getcwd(NULL, 0));
             printf("Info messages will not be printed.\n");
          } else {
             hasOpenedDefLogFile = 1;
@@ -1037,7 +1037,7 @@ defrData::defInfo(int msgNum, const char *s) {
       } else {
          if ((defrLog = fopen("defRWarning.log", "a")) == 0) {
             printf("WARNING (DEFPARS-8500): Unable to open the file defRWarning.log in %s.\n",
-            getcwd(NULL, 64));
+            getcwd(NULL, 0));
             printf("Info messages will not be printed.\n");
          } else {
             hasOpenedDefLogFile = 1;
@@ -1081,7 +1081,7 @@ defrData::defWarning(int msgNum, const char *s) {
       if (!hasOpenedDefLogFile) {
          if ((defrLog = fopen("defRWarning.log", "w")) == 0) {
             printf("WARNING (DEFPARS-7500): Unable to open the file defRWarning.log in %s.\n",
-            getcwd(NULL, 64));
+            getcwd(NULL, 0));
             printf("Warning messages will not be printed.\n");
          } else {
             hasOpenedDefLogFile = 1;
@@ -1092,7 +1092,7 @@ defrData::defWarning(int msgNum, const char *s) {
       } else {
          if ((defrLog = fopen("defRWarning.log", "a")) == 0) {
             printf("WARNING (DEFAPRS-7501): Unable to open the file defRWarning.log in %s.\n",
-            getcwd(NULL, 64));
+            getcwd(NULL, 0));
             printf("Warning messages will not be printed.\n");
          } else {
             hasOpenedDefLogFile = 1;

--- a/src/odb/src/lef/lef/lef_keywords.cpp
+++ b/src/odb/src/lef/lef/lef_keywords.cpp
@@ -1130,7 +1130,7 @@ lefInfo(int         msgNum,
         if (!lefData->hasOpenedLogFile) {
             if ((lefData->lefrLog = fopen("lefRWarning.log", "w")) == 0) {
                 printf("WARNING (LEFPARS-3500): Unable to open the file lefRWarning.log in %s.\n",
-                       getcwd(NULL, 64));
+                       getcwd(NULL, 0));
                 printf("Info messages will not be printed.\n");
             } else {
                 lefData->hasOpenedLogFile = 1;
@@ -1141,7 +1141,7 @@ lefInfo(int         msgNum,
         } else {
             if ((lefData->lefrLog = fopen("lefRWarning.log", "a")) == 0) {
                 printf("WARNING (LEFPARS-3500): Unable to open the file lefRWarning.log in %s.\n",
-                       getcwd(NULL, 64));
+                       getcwd(NULL, 0));
                 printf("Info messages will not be printed.\n");
             } else {
                 fprintf(lefData->lefrLog, "\nInfo from file: %s\n\n", lefData->lefrFileName);
@@ -1206,7 +1206,7 @@ lefWarning(int          msgNum,
         if (!lefData->hasOpenedLogFile) {
             if ((lefData->lefrLog = fopen("lefRWarning.log", "w")) == 0) {
                 printf("WARNING (LEFPARS-2500): Unable to open the file lefRWarning.log in %s.\n",
-                       getcwd(NULL, 64));
+                       getcwd(NULL, 0));
                 printf("Warning messages will not be printed.\n");
             } else {
                 lefData->hasOpenedLogFile = 1;
@@ -1217,7 +1217,7 @@ lefWarning(int          msgNum,
         } else {
             if ((lefData->lefrLog = fopen("lefRWarning.log", "a")) == 0) {
                 printf("WARNING (LEFPARS-2501): Unable to open the file lefRWarning.log in %s.\n",
-                       getcwd(NULL, 64));
+                       getcwd(NULL, 0));
                 printf("Warning messages will not be printed.\n");
             } else {
                 fprintf(lefData->lefrLog, "\nWarnings from file: %s\n\n", lefData->lefrFileName);

--- a/src/stt/src/pdr/src/edge.h
+++ b/src/stt/src/pdr/src/edge.h
@@ -39,6 +39,8 @@
 #include "node.h"
 #include "pdrevII.h"
 
+#include "spdlog/fmt/ostr.h"
+
 namespace pdr {
 
 using std::ostream;
@@ -68,3 +70,5 @@ class Edge
 };
 
 }  // namespace pdr
+
+template <> struct fmt::formatter<pdr::Edge> : ostream_formatter {};

--- a/src/stt/src/pdr/src/node.h
+++ b/src/stt/src/pdr/src/node.h
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "pdrevII.h"
+#include "spdlog/fmt/ostr.h"
 
 namespace pdr {
 
@@ -98,3 +99,5 @@ class Node1
 };
 
 }  // namespace pdr
+
+template <> struct fmt::formatter<pdr::Node> : ostream_formatter {};


### PR DESCRIPTION
This enables OpenROAD to build with a recent compiler; without hitting warnings that become errors due to -Werror (the first commit, the `free` on a class member, is a particularly concerning issue...)

Not sure if all of these will be of interest as-is but hopefully at least some of this is useful!