### PR TITLE
grt: Restore draw_route_guides documentation

### DIFF
--- a/src/grt/README.md
+++ b/src/grt/README.md
@@ -142,6 +142,14 @@ option of the `estimate_parasitics` command.
 ```
 estimate_parasitics -global_routing
 ```
+
+```
+draw_route_guides net_names
+```
+The `draw_route_guides` command plots the route guides for a set of nets.
+To erase the route guides from the GUI, pass an empty list to this command:
+`draw_route_guides {}`.
+
 ## Debug Mode
 
 ```


### PR DESCRIPTION
Commit dd6b529f0d6a ("Review") dropped the documentation for
draw_route_guides. Restore it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>