### PR TITLE
Add external system libraries options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,15 @@ if (LINK_TIME_OPTIMIZATION)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
+# Allow to use external shared boost libraries
+option(USE_SYSTEM_BOOST "Use system shared Boost libraries" OFF)
+
+# Allow to use external shared opensta libraries
+option(USE_SYSTEM_OPENSTA "Use system shared OpenSTA library" OFF)
+
+# Allow to use external shared abc libraries
+option(USE_SYSTEM_ABC "Use system shared ABC library" OFF)
+
 project(OpenROAD VERSION 1
   LANGUAGES CXX
 )
@@ -68,13 +77,16 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 # Get version string in OPENROAD_VERSION
-include(GetGitRevisionDescription)
-git_describe(OPENROAD_VERSION)
-string(FIND ${OPENROAD_VERSION} "NOTFOUND" GIT_DESCRIBE_NOTFOUND)
-if(${GIT_DESCRIBE_NOTFOUND} GREATER -1)
-  message(WARNING "OpenROAD git describe failed, using sha1 instead")
-  get_git_head_revision(GIT_REFSPEC OPENROAD_VERSION)
+if(NOT OPENROAD_VERSION)
+  include(GetGitRevisionDescription)
+  git_describe(OPENROAD_VERSION)
+  string(FIND ${OPENROAD_VERSION} "NOTFOUND" GIT_DESCRIBE_NOTFOUND)
+  if(${GIT_DESCRIBE_NOTFOUND} GREATER -1)
+    message(WARNING "OpenROAD git describe failed, using sha1 instead")
+    get_git_head_revision(GIT_REFSPEC OPENROAD_VERSION)
+  endif()
 endif()
+
 message(STATUS "OpenROAD version: ${OPENROAD_VERSION}")
 
 # Default to bulding optimnized/release executable.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/src/cmake")
 
 include("openroad")
 
-set(OPENSTA_HOME ${PROJECT_SOURCE_DIR}/src/sta)
+if(USE_SYSTEM_OPENSTA)
+  if(NOT OPENSTA_HOME)
+    message(FATAL_ERROR "Please set external OPENSTA_HOME path.")
+  endif()
+else()
+  set(OPENSTA_HOME ${PROJECT_SOURCE_DIR}/src/sta)
+endif()
+
 set(ODB_HOME ${PROJECT_SOURCE_DIR}/src/odb)
 set(DBSTA_HOME ${PROJECT_SOURCE_DIR}/src/dbSta)
 set(RESIZER_HOME ${PROJECT_SOURCE_DIR}/src/rsz)
@@ -28,7 +35,62 @@ set(OPENROAD_SOURCE
   Main.cc
   )
 
-set(Boost_USE_STATIC_LIBS ON)
+if(USE_SYSTEM_BOOST)
+  set(Boost_USE_STATIC_LIBS OFF)
+else()
+  set(Boost_USE_STATIC_LIBS ON)
+endif()
+
+if(USE_SYSTEM_OPENSTA)
+  if(NOT OPENSTA_LIBRARY)
+    find_library(OPENSTA_LIBRARY NAMES OpenSTA
+                 PATHS
+                 /usr/lib
+                 /usr/lib64
+                 /usr/local/lib
+                 /usr/local/lib64)
+    if(OPENSTA_LIBRARY)
+      message(STATUS "Found OpenSTA: ${OPENSTA_LIBRARY}")
+    else()
+      message(FATAL_ERROR "OpenSTA not found, set the OPENSTA_LIBRARY manually.")
+    endif()
+  endif()
+  if(NOT OPENSTA_INCLUDE_DIR)
+    set(OPENSTA_INCLUDE_DIR "/usr/include/sta")
+  endif()
+  include_directories(${OPENSTA_INCLUDE_DIR})
+  message(STATUS "Using OPENSTA_INCLUDE_DIR=${OPENSTA_INCLUDE_DIR}")
+else()
+  # local build of opensta
+  set(OPENSTA_LIBRARY "sta_swig")
+endif()
+
+if(USE_SYSTEM_ABC)
+  if(NOT ABC_LIBRARY)
+    find_library(ABC_LIBRARY NAMES abc
+                 PATHS
+                 /usr/lib
+                 /usr/lib64
+                 /usr/local/lib
+                 /usr/local/lib64)
+    if(ABC_LIBRARY)
+      message(STATUS "Found ABC: ${ABC_LIBRARY}")
+      # make sure link dl symbols
+      list(APPEND ABC_LIBRARY "dl")
+    else()
+      message(FATAL_ERROR "ABC not found, set the ABC_LIBRARY manually.")
+    endif()
+  endif()
+  if(NOT ABC_INCLUDE_DIR)
+    set(ABC_INCLUDE_DIR "/usr/include/abc")
+  endif()
+  add_definitions(-DABC_USE_STDINT_H=1)
+  include_directories(${ABC_INCLUDE_DIR})
+  message(STATUS "Using ABC_INCLUDE_DIR=${ABC_INCLUDE_DIR}")
+else()
+  # local build of abc
+  set(ABC_LIBRARY "libabc")
+endif()
 
 ################################################################
 
@@ -133,7 +195,9 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 # Build flow tools
 add_subdirectory(ifp)
 add_subdirectory(odb)
-add_subdirectory(sta)
+if (NOT USE_SYSTEM_OPENSTA)
+  add_subdirectory(sta)
+endif()
 add_subdirectory(dbSta)
 add_subdirectory(rsz)
 add_subdirectory(stt)
@@ -217,7 +281,7 @@ target_link_libraries(openroad
   par
   utl
   pdn
-  libabc
+  ${ABC_LIBRARY}
   ${TCL_LIBRARY}
   ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/src/dst/CMakeLists.txt
+++ b/src/dst/CMakeLists.txt
@@ -61,7 +61,7 @@ target_include_directories(dst
 target_link_libraries(dst
   PUBLIC
     utl
-    sta_swig
+    ${OPENSTA_LIBRARY}
     ${Boost_LIBRARIES}
 )
 

--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -70,5 +70,5 @@ target_link_libraries(rmp
     OpenSTA
     rsz
     utl
-    libabc
+    ${ABC_LIBRARY}
  )

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -33,11 +33,15 @@
 ##
 ###############################################################################
 
-# abc does not have "platform" support for macos so force it to use stdint.h
-if (CMAKE_OSX_SYSROOT)
-   set(ABC_USE_STDINT_H 1)
+if (NOT USE_SYSTEM_ABC)
+
+  set(ABC_USE_NAMESPACE "abc")
+
+  # abc does not have "platform" support for macos so force it to use stdint.h
+  if (CMAKE_OSX_SYSROOT)
+     set(ABC_USE_STDINT_H 1)
+  endif()
+
+  add_subdirectory(abc)
+
 endif()
-
-set(ABC_USE_NAMESPACE "abc")
-
-add_subdirectory(abc)


### PR DESCRIPTION
This PR enables **optional** possibilities to pick **external system libraries** during build time.

* This pass latest weekly [copr instance](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/3209030/) on a range of builds.
* For full completion a small batch of code related fixes will be sent after this PR.

The goal is to enable more portability that can be further polished.

Thank You !
~cristian.

----

(1) Introduced **optional** cmake knobs:
  - ```USE_SYSTEM_BOOST```  picks **shared** system wide **boost** related libraries.
  - ```USE_SYSTEM_ABC``` picks **shared**/**static** system wide **abc** related libraries.
  - ```USE_SYSTEM_OPENSTA```  picks **shared**/**static** pre-builds and **require** to set ```OPENSTA_HOME``` path.

(2) Variable additions to the knobs:
  - ```OPENROAD_VERSION``` can be customised for releng version override.
  - ```ABC_INCLUDE_DIR``` may set include headers (default: /usr/include/abc)
  - ```OPENSTA_INCLUDE_DIR``` may set include headers (default: /usr/include/sta)

~~(3) Removed strict version enforcement over ```SWIG```~~

By **default** all knobs are ```OFF``` and **keeps the actual behaviour** untouched.

---

Invoke:
```
cmake .. -Wno-dev \
       -DCMAKE_SKIP_RPATH=ON \
       -DCMAKE_VERBOSE_MAKEFILE=OFF \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DBUILD_SHARED_LIBS:BOOL=OFF \
       [...]
       -DUSE_SYSTEM_ABC=ON \
       -DUSE_SYSTEM_BOOST=ON \
       -DUSE_SYSTEM_OPENSTA=ON \
       -DOPENSTA_HOME=/usr/share/opensta \
       [...]
```

Output:
```
[...]
-- OpenROAD version: 2.0-20220119.git34180dda.fc36
-- System name: Linux
-- Compiler: GNU 12.0.1
-- Build type: RelWithDebInfo
-- Install prefix: /usr
-- Found OpenSTA: /usr/lib64/libOpenSTA.so
-- Using OPENSTA_INCLUDE_DIR=/usr/include/sta
-- Found ABC: /usr/lib64/libabc.so
-- Using ABC_INCLUDE_DIR=/usr/include/abc
-- Found Boost: /usr/include (found version "1.76.0") found components: serialization
[...]
```