### PR TITLE
grt: fix APs for pins connected to macros or pads

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -579,13 +579,14 @@ std::vector<odb::Point> GlobalRouter::findOnGridPositions(
       access_points.insert(
           access_points.begin(), bpin_pas.begin(), bpin_pas.end());
     }
-  } else if (pin.isConnectedToPad()) {
-    // get APs for macro pins and pins connected to pads
-    for (const auto& [mpin, aps] : pin.getITerm()->getAccessPoints()) {
-      access_points.insert(access_points.end(), aps.begin(), aps.end());
-    }
   } else {
     access_points = pin.getITerm()->getPrefAccessPoints();
+    if (access_points.empty()) {
+      // get all APs if there are no preferred access points
+      for (const auto& [mpin, aps] : pin.getITerm()->getAccessPoints()) {
+        access_points.insert(access_points.end(), aps.begin(), aps.end());
+      }
+    }
   }
 
   std::vector<odb::Point> positions_on_grid;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -571,13 +571,18 @@ std::vector<odb::Point> GlobalRouter::findOnGridPositions(
     odb::Point& pos_on_grid)
 {
   std::vector<odb::dbAccessPoint*> access_points;
-  // get PAs from odb
+  // get APs from odb
   if (pin.isPort()) {
     for (const odb::dbBPin* bpin : pin.getBTerm()->getBPins()) {
       const std::vector<odb::dbAccessPoint*>& bpin_pas
           = bpin->getAccessPoints();
       access_points.insert(
           access_points.begin(), bpin_pas.begin(), bpin_pas.end());
+    }
+  } else if (pin.isConnectedToPad()) {
+    // get APs for macro pins and pins connected to pads
+    for (const auto& [mpin, aps] : pin.getITerm()->getAccessPoints()) {
+      access_points.insert(access_points.end(), aps.begin(), aps.end());
     }
   } else {
     access_points = pin.getITerm()->getPrefAccessPoints();


### PR DESCRIPTION
Fix https://github.com/The-OpenROAD-Project/OpenROAD/issues/1360

It seems that `pin.getITerm()->getPrefAccessPoints()` doesn't work for pins connected to macros or pads. This PR updates grt code to get the APs for these pins with `pin.getITerm()->getAccessPoints()`;

Signed-off-by: Eder Monteiro <eder.matheus.monteiro@gmail.com>