### PR TITLE
Boost header fix and external abc having no namespace.

### DIFF
--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -34,6 +34,7 @@
 
 #include <boost/geometry.hpp>
 #include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
 
 #include <array>
 #include <functional>

--- a/src/mpl/src/ParquetFP/src/SolveMulti.cxx
+++ b/src/mpl/src/ParquetFP/src/SolveMulti.cxx
@@ -30,6 +30,8 @@
 ***
 ***************************************************************************/
 
+#include <memory>
+
 #include "SolveMulti.h"
 
 #include "Annealer.h"

--- a/src/rmp/include/rmp/Restructure.h
+++ b/src/rmp/include/rmp/Restructure.h
@@ -41,6 +41,9 @@
 #include "db_sta/dbSta.hh"
 #include "rsz/Resizer.hh"
 
+namespace abc {
+}  // namespace abc
+
 namespace ord {
 class OpenRoad;
 }  // namespace ord

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -65,10 +65,11 @@
 #include "utl/Logger.h"
 
 using utl::RMP;
+using namespace abc;
 
 namespace rmp {
 
-  
+
 
 void Restructure::init(ord::OpenRoad* openroad)
 {
@@ -211,8 +212,8 @@ void Restructure::runABC()
 
     if (writeAbcScript(abc_script_file)) {
       // call linked abc
-      abc::Abc_Start();
-      abc::Abc_Frame_t * abc_frame = abc::Abc_FrameGetGlobalFrame();
+      Abc_Start();
+      Abc_Frame_t * abc_frame = Abc_FrameGetGlobalFrame();
       const std::string command = "source " + abc_script_file;
       child_proc[curr_mode_idx] = Cmd_CommandExecute( abc_frame, command.c_str() );
       if ( child_proc[curr_mode_idx] )
@@ -220,7 +221,7 @@ void Restructure::runABC()
 	  logger_->error(RMP, 26, "Error executing ABC command {}.", command);
 	  return;
 	}
-      abc::Abc_Stop();
+      Abc_Stop();
       // exit linked abc
       files_to_remove.emplace_back(abc_script_file);
     }


### PR DESCRIPTION
Fix a ```boost``` header inclusion and allow pick ```abc``` (external) having no namespace.

----

* One ```boost``` header must be included for >= .fc36
* External```abc``` picked from distros have no namespace

----

The PR pass vanilla OpenROAD for [range of builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/3260074) on fedora copr public build system.

Thank You !

