### PR TITLE
grt: add option to inform macro halos for repair_antennas

### DIFF
--- a/src/grt/README.md
+++ b/src/grt/README.md
@@ -116,6 +116,8 @@ Example: `set_global_routing_random -seed 42 -capacities_perturbation_percentage
 
 ```
 repair_antennas diodeCellName/diodePinName [-iterations iterations]
+                                           [-macro_halo_x halo_x]
+                                           [-macro_halo_y halo_y]
 ```
 
 The repair_antenna command evaluates the global routing results to find
@@ -126,6 +128,12 @@ iterations. By default, the command runs only one iteration to repair
 antennas.  It uses the  `antennachecker` tool to identify any nets with antenna
 violations and, for each such net, the exact number of diodes necessary to fix the
 antenna violation.
+
+Options description:
+
+- `-macro_halo_x`. Specify the horizontal halo size (in microns) around macros.
+- `-macro_halo_y`. Specify the vertical halo size (in microns) around macros.
+Both options above should be the same defined during the floorplanning.
 
 Example: `repair_antenna sky130_fd_sc_hs__diode_2/DIODE`
 

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -182,7 +182,10 @@ class GlobalRouter
   int getTileSize() const;
 
   // repair antenna public functions
-  void repairAntennas(sta::LibertyPort* diode_port, int iterations);
+  void repairAntennas(sta::LibertyPort* diode_port,
+                      int iterations,
+                      int macro_halo_x,
+                      int macro_halo_y);
 
   // Incremental global routing functions.
   // See class IncrementalGRoute.

--- a/src/grt/src/AntennaRepair.h
+++ b/src/grt/src/AntennaRepair.h
@@ -76,7 +76,9 @@ class AntennaRepair
                 ant::AntennaChecker* arc,
                 dpl::Opendp* opendp,
                 odb::dbDatabase* db,
-                utl::Logger* logger);
+                utl::Logger* logger,
+                int macro_halo_x,
+                int macro_halo_y);
 
   int checkAntennaViolations(NetRouteMap& routing,
                              int max_routing_layer,
@@ -119,6 +121,8 @@ class AntennaRepair
   odb::dbBlock* block_;
   std::vector<odb::dbInst*> diode_insts_;
   AntennaViolations antenna_violations_;
+  int macro_halo_x_;
+  int macro_halo_y_;
 };
 
 }  // namespace grt

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -230,13 +230,18 @@ void GlobalRouter::updateDbCongestion()
   heatmap_->update();
 }
 
-void GlobalRouter::repairAntennas(sta::LibertyPort* diode_port, int iterations)
+void GlobalRouter::repairAntennas(sta::LibertyPort* diode_port,
+                                  int iterations,
+                                  int macro_halo_x,
+                                  int macro_halo_y)
 {
   AntennaRepair antenna_repair = AntennaRepair(this,
                                                openroad_->getAntennaChecker(),
                                                openroad_->getOpendp(),
                                                db_,
-                                               logger_);
+                                               logger_,
+                                               macro_halo_x,
+                                               macro_halo_y);
 
   odb::dbMTerm* diode_mterm = sta_->getDbNetwork()->staToDb(diode_port);
 

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -180,9 +180,9 @@ route_layer_lengths(odb::dbNet* db_net)
 }
 
 void
-repair_antennas(LibertyPort* diodePort, int iterations)
+repair_antennas(LibertyPort* diodePort, int iterations, int macro_halo_x, int macro_halo_y)
 {
-  getGlobalRouter()->repairAntennas(diodePort, iterations);
+  getGlobalRouter()->repairAntennas(diodePort, iterations, macro_halo_x, macro_halo_y);
 }
 
 void

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -258,11 +258,13 @@ proc global_route { args } {
 }
 
 sta::define_cmd_args "repair_antennas" { lib_port \
-                                         [-iterations iterations]}
+                                         [-iterations iterations] \
+                                         [-macro_halo_x halo_x] \
+                                         [-macro_halo_y halo_y]}
 
 proc repair_antennas { args } {
   sta::parse_key_args "repair_antennas" args \
-                 keys {-iterations}
+                 keys {-iterations -macro_halo_x -macro_halo_y}
   if { [grt::have_routes] } {
     sta::check_argc_eq1 "repair_antennas" $args
     set lib_port [lindex $args 0]
@@ -277,8 +279,25 @@ proc repair_antennas { args } {
       set iterations 1
     }
 
+    if { [info exists keys(-macro_halo_x)] } {
+      set macro_halo_x $keys(-macro_halo_x)
+      sta::check_positive_integer "-repair_antennas_macro_halo_x" $macro_halo_x
+    } else {
+      set macro_halo_x 0
+    }
+
+    if { [info exists keys(-macro_halo_y)] } {
+      set macro_halo_y $keys(-macro_halo_y)
+      sta::check_positive_integer "-repair_antennas_macro_halo_y" $macro_halo_y
+    } else {
+      set macro_halo_y 0
+    }
+
+    set macro_halo_x [ord::microns_to_dbu $macro_halo_x]
+    set macro_halo_y [ord::microns_to_dbu $macro_halo_y]
+
     if { $lib_port != "" } {
-      grt::repair_antennas $lib_port $iterations
+      grt::repair_antennas $lib_port $iterations $macro_halo_x $macro_halo_y
     } else {
       utl::error GRT 69 "Diode not found."
     }


### PR DESCRIPTION
In the latest reply on https://github.com/The-OpenROAD-Project/OpenROAD/issues/1646, there was detected an issue with `repair_antennas`, where it cannot detect diodes placed on the macro halos (i.e., out of rows).

This update adds an option to inform the macro halos, so `repair_antennas` can detect diodes placed out of rows and allow `detail_placement` to legalize these diodes.