### PR TITLE
Add missing boost header from new PDN module.

### DIFF
--- a/src/pdn/src/via.h
+++ b/src/pdn/src/via.h
@@ -35,6 +35,7 @@
 #include <array>
 #include <boost/geometry.hpp>
 #include <boost/geometry/index/rtree.hpp>
+#include <boost/geometry/geometries/point_xy.hpp>
 #include <map>
 #include <memory>
 


### PR DESCRIPTION
A small fix for failing centos8 build.

* The mentioned header is [required](https://www.boost.org/doc/libs/1_66_0/libs/geometry/doc/html/geometry/reference/models/model_d2_point_xy.html) for boost's 2d point cartesians (centos8 have boost 1.66).
* The new PDN was introduced a week ago [#1749] done by @arlpetergadfort .

The patch pass [all builds](https://copr.fedorainfracloud.org/coprs/rezso/VLSI/build/4114356/) including centos8.


Cc: @maliberty 

Thank you,
~Cristian.