### PR TITLE
Fix LEMON library detection

### DIFF
--- a/src/cts/src/CMakeLists.txt
+++ b/src/cts/src/CMakeLists.txt
@@ -35,7 +35,8 @@
 
 include("openroad")
 
-find_package(LEMON REQUIRED)
+# https://github.com/The-OpenROAD-Project/OpenROAD/issues/1186
+find_package(LEMON NAMES LEMON lemon REQUIRED)
 
 swig_lib(NAME      cts
          NAMESPACE cts

--- a/src/dpo/CMakeLists.txt
+++ b/src/dpo/CMakeLists.txt
@@ -38,7 +38,8 @@ swig_lib(NAME         dpo
          SCRIPTS      src/Optdp.tcl
 )
 
-find_package(LEMON REQUIRED)
+# https://github.com/The-OpenROAD-Project/OpenROAD/issues/1186
+find_package(LEMON NAMES LEMON lemon REQUIRED)
 
 target_sources(dpo
   PRIVATE


### PR DESCRIPTION
Debian/Ubuntu installs LEMONConfig.cmake as lemonConfig.cmake, which breaks detection of the system library.

Use the NAME syntax to list both.

Fixes: https://github.com/The-OpenROAD-Project/OpenROAD/issues/1186
Signed-off-by: Joel Stanley <joel@jms.id.au>