### PR TITLE
Removing ambiguity with new glibc

### DIFF
--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -420,7 +420,7 @@ const std::string input_dialog(const char* title, const char* question)
   return gui->requestUserInput(title, question);
 }
 
-void pause(int timeout = 0)
+void pause(int timeout)
 {
   if (!check_gui("pause")) {
     return;


### PR DESCRIPTION
pause() is now included in glibc and having a default parameter causes a linker ambiguity. We should either remove the default or rename this particular function.  This PR is meant to start a discussion.