### PR TITLE
Fixes QT 5.12.9 compile issues

### DIFF
--- a/src/gui/src/browserWidget.cpp
+++ b/src/gui/src/browserWidget.cpp
@@ -41,6 +41,7 @@
 #include <QEvent>
 #include <QLocale>
 #include <QMouseEvent>
+#include <QString>
 
 #include "utl/Logger.h"
 #include "db_sta/dbSta.hh"
@@ -482,7 +483,7 @@ void BrowserWidget::makeRowItems(QStandardItem* item,
     units = "m";
   }
 
-  auto text = locale.toString(disp_area, 'f', 3) + " " + units + "m\u00B2"; // m2
+  QString text = locale.toString(disp_area, 'f', 3) + " " + units + "m\u00B2"; // m2
 
   auto makeDataItem = [item](const QString& text, bool right_align = true) -> QStandardItem* {
     QStandardItem* data_item = new QStandardItem(text);

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -177,7 +177,9 @@ QStandardItem* SelectedItemModel::makeList(QStandardItem* name_item, const Itera
     name_item->appendRow({index_item, selected_item});
   }
 
-  return makeItem(QString::number(index) + " items");
+  QString items = QString::number(index) + " items";
+
+  return makeItem(items);
 }
 
 template<typename Iterator>
@@ -188,7 +190,9 @@ QStandardItem* SelectedItemModel::makePropertyList(QStandardItem* name_item, con
     name_item->appendRow({makeItem(name, true), makeItem(value)});
   }
 
-  return makeItem(QString::number(name_item->rowCount()) + " items");
+  QString items = QString::number(name_item->rowCount()) + " items";
+
+  return makeItem(items);
 }
 
 void SelectedItemModel::makeItemEditor(const std::string& name,

--- a/src/gui/src/selectHighlightWindow.cpp
+++ b/src/gui/src/selectHighlightWindow.cpp
@@ -177,8 +177,8 @@ QVariant HighlightModel::data(const QModelIndex& index, int role) const
     bool valid = table_data_[row_index].second->getBBox(bbox);
     return valid ? QString::fromStdString(Descriptor::Property::toString(bbox)) : "<none>";
   } else if (index.column() == 3) {
-    return QString("Group ")
-           + QString::number(table_data_[row_index].first + 1);
+    QString group_string = QString("Group ") + QString::number(table_data_[row_index].first + 1);
+    return group_string;
   }
   return QVariant();
 }


### PR DESCRIPTION
In Google's QT installation the following lines create ambiguity with
the QTStringStringBuilder. These changes allow the compiler to correctly
figure out what method to call.

Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>