### PR TITLE
Optimizes LayoutViewer performance

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -40,6 +40,7 @@
 #include <QGridLayout>
 #include <QHBoxLayout>
 #include <QImageWriter>
+#include <QtGlobal>
 #include <QLabel>
 #include <QLineEdit>
 #include <QPaintEvent>
@@ -226,7 +227,7 @@ class GuiPainter : public Painter
     painter_->drawLine(x - o, y + o, x + o, y - o);
   }
 
-  const odb::Point determineStringOrigin(int x, int y, Anchor anchor, const QString& text, bool rotate_90 = false, QRect *bounding_rect = nullptr)
+  const odb::Point determineStringOrigin(int x, int y, Anchor anchor, const QString& text, bool rotate_90 = false, const QRect *bounding_rect = nullptr)
   {
     
     QRect text_bbox;
@@ -310,7 +311,7 @@ class GuiPainter : public Painter
   {
     const QString text = QString::fromStdString(s);
     const QRect text_bbox = painter_->fontMetrics().boundingRect(text);
-    const odb::Point origin = determineStringOrigin(x, y, anchor, text, &text_bbox);
+    const odb::Point origin = determineStringOrigin(x, y, anchor, text, false, &text_bbox);
 
     const qreal scale_adjust = 1.0 / getPixelsPerDBU();
 
@@ -2247,7 +2248,11 @@ void LayoutViewer::drawPinMarkers(Painter& painter,
   QPainter* qpainter = static_cast<GuiPainter&>(painter).getPainter();
   const QFont initial_font = qpainter->font();
   QFont marker_font = options_->pinMarkersFont();
+  
+  #if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
   marker_font.setStyleStrategy(QFont::StyleStrategy::PreferNoShaping);
+  #endif
+
   qpainter->setFont(marker_font);
 
   const QFontMetrics font_metrics(marker_font);

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -43,6 +43,7 @@
 #include <QShortcut>
 #include <QTimer>
 #include <chrono>
+#include <QImage>
 #include <map>
 #include <memory>
 #include <vector>
@@ -126,6 +127,7 @@ class LayoutViewer : public QWidget
                const std::vector<std::unique_ptr<Ruler>>& rulers,
                std::function<Selected(const std::any&)> makeSelected,
                std::function<bool(void)> usingDBU,
+               std::function<bool(void)> showFps,
                QWidget* parent = nullptr);
 
   void setLogger(utl::Logger* logger);
@@ -376,6 +378,7 @@ class LayoutViewer : public QWidget
   bool rubber_band_showing_;
   std::function<Selected(const std::any&)> makeSelected_;
   std::function<bool(void)> usingDBU_;
+  std::function<bool(void)> showFps_;
 
   std::map<odb::dbModule*, ModuleSettings> modules_;
 
@@ -399,7 +402,7 @@ class LayoutViewer : public QWidget
   std::unique_ptr<AnimatedSelected> animate_selection_;
 
   // Hold the last painted drawing of the layout
-  std::unique_ptr<QPixmap> block_drawing_;
+  std::unique_ptr<QImage> block_drawing_;
   bool repaint_requested_;
   std::chrono::time_point<std::chrono::system_clock> last_paint_time_;
   int repaint_interval_; // milliseconds

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -88,6 +88,7 @@ MainWindow::MainWindow(QWidget* parent)
           rulers_,
           [](const std::any& object) { return Gui::get()->makeSelected(object); },
           [this]() -> bool { return show_dbu_->isChecked(); },
+          [this]() -> bool { return show_fps_->isChecked(); },
           this)),
       selection_browser_(
           new SelectHighlightWindow(selected_, highlighted_, this)),
@@ -347,6 +348,7 @@ MainWindow::MainWindow(QWidget* parent)
   QApplication::setFont(settings.value("font", QApplication::font()).value<QFont>());
   hide_option_->setChecked(settings.value("check_exit", hide_option_->isChecked()).toBool());
   show_dbu_->setChecked(settings.value("use_dbu", show_dbu_->isChecked()).toBool());
+  show_fps_->setChecked(settings.value("use_fps", show_fps_->isChecked()).toBool());
   script_->readSettings(&settings);
   controls_->readSettings(&settings);
   timing_widget_->readSettings(&settings);
@@ -478,6 +480,10 @@ void MainWindow::createActions()
   show_dbu_->setCheckable(true);
   show_dbu_->setChecked(false);
 
+  show_fps_ = new QAction("Show FPS", this);
+  show_fps_->setCheckable(true);
+  show_fps_->setChecked(false);
+
   font_ = new QAction("Application font", this);
 
   connect(hide_, SIGNAL(triggered()), this, SIGNAL(hide()));
@@ -497,6 +503,8 @@ void MainWindow::createActions()
   connect(show_dbu_, SIGNAL(toggled(bool)), selection_browser_, SLOT(updateModels()));
   connect(show_dbu_, SIGNAL(toggled(bool)), this, SLOT(setUseDBU(bool)));
   connect(show_dbu_, SIGNAL(toggled(bool)), this, SLOT(setClearLocation()));
+
+  connect(show_fps_, SIGNAL(toggled(bool)), viewer_, SLOT(fullRepaint()));
 
   connect(font_, SIGNAL(triggered()), this, SLOT(showApplicationFont()));
 }
@@ -552,6 +560,7 @@ void MainWindow::createMenus()
   auto option_menu = menuBar()->addMenu("&Options");
   option_menu->addAction(hide_option_);
   option_menu->addAction(show_dbu_);
+  option_menu->addAction(show_fps_);
   option_menu->addAction(font_);
 
   menuBar()->addAction(help_);
@@ -1132,6 +1141,7 @@ void MainWindow::saveSettings()
   settings.setValue("font", QApplication::font());
   settings.setValue("check_exit", hide_option_->isChecked());
   settings.setValue("use_dbu", show_dbu_->isChecked());
+  settings.setValue("use_fps", show_fps_->isChecked());
   script_->writeSettings(&settings);
   controls_->writeSettings(&settings);
   timing_widget_->writeSettings(&settings);

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -298,6 +298,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoad::Observer
   QAction* help_;
   QAction* build_ruler_;
   QAction* show_dbu_;
+  QAction* show_fps_;
   QAction* font_;
 
   QLabel* location_;


### PR DESCRIPTION
This PR optimizes the LayoutViewer performance by
removing anti aliasing routines from axis aligned boxes and
replaces our Pixmap target with a QImage instead.

I experimented with threaded rendering, but found the code
unsavory in its current iteration. We should explore using
an OpenGL paint device instead since a lot of the rendering
we're doing is very suboptimal.

Potential Areas of Improvement
* 50% of render loop is spend in drawing the PinLabels. This is being
  eaten up by both the layout code and all the calls to getBoundingBox
  for the text. We should make sure that we are caching these layouts
  and not rendering text if it falls off screen.

* Using OpenGL instead of our own custom rasterizer. A lot of time is
  spent drawing rectangles that are occuluded by other rectangles. On a
  CPU renderer this is killing our performance. Filling pixels is the
  single most expensive thing we could be doing. By moving to OpenGL
  (even a software implementation) we would benefit from its occlusion
  culling algorithms which would be faster than our implementation.

* Distance based culling, possibly with QuadTree. When rendering the
  power grid at low resolution our framerate dips significantly. We
  should try to throw away geometry if it's not going to visibile. I can
  think of a few methods to doing this, but it's not exactly a simple
  optimization.

* MipMapping/Caching different tile based renders of the layout. As a
  opposed to dynamically rendering them.