### PR TITLE
Implements CORE_SPACER auto-detection

### DIFF
--- a/src/odb/include/odb/lefin.h
+++ b/src/odb/include/odb/lefin.h
@@ -124,7 +124,7 @@ class lefin
     else
       return (int) (value + 0.5);
   }
-
+  bool isSpacer(dbMaster* _master);
   bool readLef(const char* lef_file);
   bool addGeoms(dbObject* object, bool is_pin, lefiGeometries* geometry);
   void createLibrary();


### PR DESCRIPTION
LEF5.8 page 116 specifies

```
SPACER—Sometimes called a filler cell, this cell is used to fill in space
between regular core cells. The SPACER sub-class needs to be cells with
no logic-pins. Thus even with the sub-class defined, a cell will not be
considered SPACER (also called FILLER) unless it has no logic/signal
pins. A filler can only have Power and Ground pins. The instances of
these cells will be marked by the insertion command to be of type
'Physical'.
```

This went unimplemented in OpenROAD. This PR implements the the
detection algorithm.