### PR TITLE
Fix disabling readline use in abc.

### DIFF
--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -42,10 +42,10 @@ if (NOT USE_SYSTEM_ABC)
      set(ABC_USE_STDINT_H 1)
   endif()
 
+  # make sure not to include readline headers to avoid extra dependencies
+  # readline is not needed since we call abc from c++
+  set(READLINE_FOUND FALSE)
+
   add_subdirectory(abc)
 
 endif()
-
-# make sure not to include readline headers to avoid extra dependencies
-# readline is not needed since we call abc from c++
-set(ABC_USE_NO_READLINE 1)


### PR DESCRIPTION
ABC_USE_NO_READLINE is not read in abc's CMakeLists.txt but instead generated depending on READLINE_FOUND.
It's not clear who's supposed to set this variable but it tells if the readline header is present or not. So just pretend the header is not present as we don't need it.