### PR TITLE
Verbose SPDLOG_FMT_EXTERNAL during cmake detection.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,6 +188,9 @@ endif()
 
 find_package(spdlog REQUIRED)
 message(STATUS "spdlog: ${spdlog_VERSION}")
+if (${SPDLOG_FMT_EXTERNAL})
+  message(WARNING "spdlog: SPDLOG_FMT_EXTERNAL=${SPDLOG_FMT_EXTERNAL}")
+endif()
 
 find_package(Threads REQUIRED)
 set(THREADS_PREFER_PTHREAD_FLAG ON)


### PR DESCRIPTION
Small PR to ~~fix~~ avoid ```fmt``` errors like below.

```
/usr/include/fmt/core.h:1733:7: error: static assertion failed: Cannot format an argument. 
To make type T formattable provide a formatter<T> specialization: 
https://fmt.dev/latest/api.html#udt
```

Output now signals SPDLOG mode:

```
{...}
-- OpenROAD version: 2.0-20220728.gitbd841a8c.fc37
-- System name: Linux
-- Compiler: GNU 12.1.1
{...}
-- spdlog: 1.10.0
-- spdlog: SPDLOG_FMT_EXTERNAL=OFF
{...}
```
----

More system details:

```
$ rpm -q fmt-devel
fmt-devel-9.0.0-2.fc37.x86_64
$ rpm -q spdlog-devel
spdlog-devel-1.10.0-3.fc37.x86_64
```
