### PR TITLE
Fixes nullptr segfault when building without GUI support.

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -1383,7 +1383,10 @@ FanoutRender::FanoutRender(RepairDesign *repair) :
   repair_(repair),
   pins_(nullptr)
 {
-  gui::Gui::get()->registerRenderer(this);
+  const bool gui_enabled = gui::Gui::enabled();
+  if (gui_enabled) {
+    gui::Gui::get()->registerRenderer(this);
+  }
 }
 
 void


### PR DESCRIPTION
I should note that gui::Gui::get() would be safer if it was
wrapped in std::optional<>...