### PR TITLE
Improve drt performance by inlining dbTechLayerDir constructors

### DIFF
--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -504,17 +504,17 @@ class dbTechLayerType
   ///
   /// Create a dbTechLayerType instance with an explicit value.
   ///
-  dbTechLayerType(Value value);
+  dbTechLayerType(Value value) { _value = value; }
 
   ///
   /// Create a dbTechLayerType instance with value = "none".
   ///
-  dbTechLayerType();
+  dbTechLayerType() { _value = ROUTING; }
 
   ///
   /// Copy constructor.
   ///
-  dbTechLayerType(const dbTechLayerType& value);
+  dbTechLayerType(const dbTechLayerType& value) { _value = value._value; }
 
   ///
   /// Returns the layer-value.
@@ -558,17 +558,17 @@ class dbTechLayerDir
   ///
   /// Create a dbTechLayerDir instance with an explicit direction.
   ///
-  dbTechLayerDir(Value value);
+  dbTechLayerDir(Value value) { _value = value; }
 
   ///
   /// Create a dbTechLayerDir instance with direction = "none".
   ///
-  dbTechLayerDir();
+  dbTechLayerDir() { _value = NONE; }
 
   ///
   /// Copy constructor.
   ///
-  dbTechLayerDir(const dbTechLayerDir& value);
+  dbTechLayerDir(const dbTechLayerDir& value) { _value = value._value; }
 
   ///
   /// Returns the layer-direction.

--- a/src/odb/src/db/dbTypes.cpp
+++ b/src/odb/src/db/dbTypes.cpp
@@ -1088,21 +1088,6 @@ dbTechLayerType::dbTechLayerType(const char* value)
     _value = NONE;
 }
 
-dbTechLayerType::dbTechLayerType(Value value)
-{
-  _value = value;
-}
-
-dbTechLayerType::dbTechLayerType()
-{
-  _value = ROUTING;
-}
-
-dbTechLayerType::dbTechLayerType(const dbTechLayerType& value)
-{
-  _value = value._value;
-}
-
 const char* dbTechLayerType::getString() const
 {
   const char* value = "";
@@ -1149,21 +1134,6 @@ dbTechLayerDir::dbTechLayerDir(const char* value)
 
   else
     _value = NONE;
-}
-
-dbTechLayerDir::dbTechLayerDir(Value value)
-{
-  _value = value;
-}
-
-dbTechLayerDir::dbTechLayerDir()
-{
-  _value = NONE;
-}
-
-dbTechLayerDir::dbTechLayerDir(const dbTechLayerDir& value)
-{
-  _value = value._value;
 }
 
 const char* dbTechLayerDir::getString() const


### PR DESCRIPTION
getIdx() continually calls into odb code to determine the layer direction.
Create a helper isZDirHorizontal() which caches this.

Detailed routing of the Microwatt register file is 8.5% faster with this
applied.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>