### PR TITLE
Update DependencyInstaller.sh to support MacOS

### DIFF
--- a/cmake/FindTCL.cmake
+++ b/cmake/FindTCL.cmake
@@ -33,7 +33,10 @@ set(TCL_POSSIBLE_NAMES tcl87 tcl8.7
 # tcl lib path guesses.
 if (NOT TCL_LIB_PATHS)
   if (CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(TCL_LIB_PATHS /usr/local/lib /opt/homebrew/opt/tcl-tk/lib)
+    set(TCL_LIB_PATHS /usr/local/lib
+      /opt/homebrew/opt/tcl-tk/lib
+      /usr/local/opt/tcl-tk/lib
+      )
     set(TCL_NO_DEFAULT_PATH TRUE)
   elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(TCL_LIB_PATHS /usr/lib /usr/local/lib)

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -200,6 +200,57 @@ _installCentosRuntime() {
     yum update -y
 }
 
+_installHomebrewPackage() {
+    package=$1
+    commit=$2
+    url=https://raw.githubusercontent.com/Homebrew/homebrew-core/${commit}/Formula/${package}.rb
+    curl -L ${url} > ${package}.rb
+
+    if brew list $package &> /dev/null
+        then
+        # Homebrew is awful at letting you use the version you want if a newer
+        # version is installed. The package must be completely removed to ensure
+        # only the correct version is installed
+        brew remove --force --ignore-dependencies $package
+    fi
+
+    # Must ignore dependencies to avoid automatic upgrade
+    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+    brew install --ignore-dependencies --formula ./${package}.rb
+    brew pin ${package}
+
+    # Cleanup
+    rm ./${package}.rb
+}
+
+_installDarwin() {
+    if ! command -v brew &> /dev/null
+      then
+      echo "Homebrew is not found. Please install homebrew before continuing."
+      exit 1
+      fi
+    if ! xcode-select -p &> /dev/null
+      then
+      # xcode-select does not pause execution, so the user must handle it
+      cat <<EOF
+Xcode command line tools not installed.
+Run the following command to install them:
+  xcode-select --install
+Then, rerun this script.
+EOF
+      exit 1
+    fi
+    brew install bison boost cmake eigen flex libomp pyqt5 python swig tcl-tk zlib
+
+    # Lemon is not in the homebrew-core repo
+    brew install The-OpenROAD-Project/lemon-graph/lemon-graph
+
+    # Install fmt 8.1.1 because fmt 9 causes compile errors
+    _installHomebrewPackage "fmt" "8643c850826702923f02d289e0f93a3b4433741b"
+    # Install spdlog 1.9.2
+    _installHomebrewPackage "spdlog" "0974b8721f2f349ed4a47a403323237e46f95ca0"
+}
+
 _help() {
     cat <<EOF
 
@@ -242,6 +293,9 @@ case "${platform}" in
             os="Unidentified OS, could not find /etc/os-release."
         fi
         ;;
+    "Darwin" )
+        os="Darwin"
+        ;;
     *)
         echo "${platform} is not supported" >&2
         echo "We only officially support Linux at the moment." >&2
@@ -274,6 +328,16 @@ EOF
             _installCommonDev
         fi
         _installUbuntuCleanUp
+        ;;
+    "Darwin" )
+        _installDarwin
+        cat <<EOF
+
+To install or run openroad, update your path with:
+    export PATH="\$(brew --prefix bison)/bin:\$(brew --prefix flex)/bin:\$(brew --prefix tcl-tk)/bin:\$PATH"
+
+You may wish to add this line to your .bashrc file
+EOF
         ;;
     *)
         echo "unsupported system: ${os}" >&2


### PR DESCRIPTION
Draft PR to support MacOS. Closes #2173.

This isn't a perfect solution to the problem, but I think it's a good start. There are several issues I worked around while making this.

* Problem: Homebrew's `spdlog` does not work out of the box as of right now.
* Cause: This has been mentioned a few times in issues such as #2173, #2220, and #2097, but the main issue seems to be that `spdlog` is dependent on `fmt`. While `fmt 8` works with OpenROAD's code, `fmt 9` has more strict standards for conversions of objects into strings for logging, thus resulting in several compiler errors.
* Solution: I think that longer term, we simply have to fix all the object to string conversions so that we can upgrade to `spdlog 1.10` which depends on `fmt 9`. This is what Homebrew wants to do, and it makes installing old package versions as difficult as possible. This PR works around this by forcibly installing `fmt 8.1.1_1` and `spdlog 1.9.2`, which I have found to work.

---

* Problem: Some dependencies don't take precedence in the `PATH` over system-installed libraries, which can cause compilation errors (such as bison)
* ~~Cause: `/usr/bin` tends to be in front of `/usr/local`~~ Homebrew refuses to link libs which are already provided by MacOS
* Solution: For right now, I just have the script print commands for the user to copy+paste to update the `PATH`. This is a dependency script, so it's not expected to build `openroad` for the user.

---

* Problem: Xcode Command Line Tools and the Xcode app seem to conflict on my system when both are installed.
* Cause: Not sure. I have consistently found that openroad has std lib reference issues *if* the Command Line Tools are installed (e.g. `xcode-select --install`), regardless of whether the Xcode app is installed. I can only compile if *only* the Xcode app is installed. I have checked `CMakeCache.txt` and cmake appears to be pointing to all the right directories (no mixing between the CLT and the app), so I don't know why this fails. Annoyingly, homebrew refuses to install Python if it doesn't detect CLT (even if the app is installed).
* My current workaround is to install CLT to install the dependencies, then remove CLT and install the Xcode app to actually build openroad. I sincerely hope this is just a problem on my side and not typical.

The script was tested on an x86_64 macbook running `Monterey 12.5.1` with `Apple clang version 13.1.6 (clang-1316.0.21.2.5)`

TODO items
- [x] Separate packages into runtime and development
- [x] See if someone can replicate my issues
- [ ] Add package(s) to enable GUI