### PR TITLE
grt: Error mentions wrong LEF property

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -307,7 +307,7 @@ void GlobalRouter::repairAntennas(odb::dbMTerm* diode_mterm, int iterations)
   if (repair_antennas_->diffArea(diode_mterm) == 0.0)
     logger_->error(GRT,
                    244,
-                   "Diode {}/{} ANTENNADIFFSIDEAREARATIO is zero.",
+                   "Diode {}/{} ANTENNADIFFAREA is zero.",
                    diode_mterm->getMaster()->getConstName(),
                    diode_mterm->getConstName());
 


### PR DESCRIPTION
We are looking for the diode ANTENNADIFFAREA property but the error
mentions the layer ANTENNADIFFSIDEAREARATIO property.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>