### PR TITLE
gpl: Add -timing_driven_nets_percentage

### DIFF
--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -44,6 +44,7 @@ global_placement
     [-routability_rc_coefficients routability_rc_coefficients]
     [-timing_driven_net_reweight_overflow]
     [-timing_driven_net_weight_max]
+    [-timing_driven_nets_percentage]
     [-pad_left pad_left]
     [-pad_right pad_right]
     [-verbose_level level]
@@ -67,16 +68,18 @@ global_placement
 - `-initial_place_max_fanout`: set net escape condition in initial place when 'fanout >= initial_place_max_fanout'. Default value is 200. Allowed values are `[1-MAX_INT, int]`.
 - `-timing_driven_net_reweight_overflow`: set overflow threshold for timing-driven net reweighting. Allowed values are `tcl list of [0-100, int]`.
 - `-timing_driven_net_weight_max`: Set the multiplier for the most timing critical nets. Default value is 1.9.
+- `-timing_driven_nets_percentage`: Set the percentage of nets that are reweighted in timing-driven mode. Default value is 10. Allowed values are `[0-100, float]`
 - `-verbose_level`: set verbose level for RePlAce. Default value is 1. Allowed values are `[0-5, int]`.
 - `-force_cpu`: Force to use the CPU solver even if the GPU is available.
 
 
 `-timing_driven` does a virtual `repair_design` to find slacks and
-weight nets with low slack. It adjusts the 10% worst slacks using
-a multiplier (1.9 by default, modified with `-timing_driven_net_weight_max`).
-The multiplier is scaled from the full value for the worst slack, to 1.0 for
-the 10% worst slack. Use the `set_wire_rc` command to set resistance and
-capacitance of estimated wires used for timing.
+weight nets with low slack. It adjusts the worst slacks (10% by default,
+modified with -timing_driven_nets_percentage) using a multiplier (1.9 by
+default, modified with `-timing_driven_net_weight_max`). The multiplier
+is scaled from the full value for the worst slack, to 1.0 at the
+timing_driven_nets_percentage point. Use the `set_wire_rc` command to set
+resistance and capacitance of estimated wires used for timing.
 
 ## Example scripts
 

--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -23,8 +23,6 @@ global_placement
     [-timing_driven]
     [-routability_driven]
     [-skip_initial_place]
-    [-disable_timing_driven]
-    [-disable_routability_driven]
     [-incremental]
     [-bin_grid_count grid_count]
     [-density target_density]
@@ -55,6 +53,7 @@ global_placement
 ### Tuning Parameters
 
 - `-timing_driven`: Enable timing-driven mode
+- `-routability_driven`: Enable routability-driven mode
 - `-skip_initial_place` : Skip the initial placement (BiCGSTAB solving) before Nesterov placement. IP improves HPWL by ~5% on large designs. Equal to '-initial_place_max_iter 0'
 - `-incremental` : Enable the incremental global placement. Users would need to tune other parameters (e.g., init_density_penalty) with pre-placed solutions.
 - `-bin_grid_count`: set bin grid's counts. Default value is defined by internal heuristic. Allowed values are  `[64,128,256,512,..., int]`.

--- a/src/gpl/src/replace.tcl
+++ b/src/gpl/src/replace.tcl
@@ -61,6 +61,7 @@ sta::define_cmd_args "global_placement" {\
     [-routability_rc_coefficients routability_rc_coefficients]\
     [-timing_driven_net_reweight_overflow timing_driven_net_reweight_overflow]\
     [-timing_driven_net_weight_max timing_driven_net_weight_max]\
+    [-timing_driven_nets_percentage timing_driven_nets_percentage]\
     [-pad_left pad_left]\
     [-pad_right pad_right]\
 }
@@ -80,6 +81,7 @@ proc global_placement { args } {
       -routability_rc_coefficients \
       -timing_driven_net_reweight_overflow \
       -timing_driven_net_weight_max \
+      -timing_driven_nets_percentage \
       -pad_left -pad_right} \
     flags {-skip_initial_place \
       -skip_nesterov_place \
@@ -133,6 +135,10 @@ proc global_placement { args } {
 
     if { [info exists keys(-timing_driven_net_weight_max)] } {
       gpl::set_timing_driven_net_weight_max_cmd $keys(-timing_driven_net_weight_max)
+    }
+
+    if { [info exists keys(-timing_driven_nets_percentage)] } {
+      rsz::set_worst_slack_nets_percent $keys(-timing_driven_nets_percentage)
     }
   }
 

--- a/src/gpl/src/timingBase.cpp
+++ b/src/gpl/src/timingBase.cpp
@@ -153,7 +153,7 @@ bool
 TimingBase::updateGNetWeights(float overflow) {
   rs_->findResizeSlacks();
 
-  // get Top 10% worst resize nets
+  // get worst resize nets
   sta::NetSeq &worst_slack_nets = rs_->resizeWorstSlackNets();
 
   if( worst_slack_nets.empty()) {
@@ -161,7 +161,7 @@ TimingBase::updateGNetWeights(float overflow) {
     return false;
   }
   
-  // min/max slack for worst 10% nets
+  // min/max slack for worst nets
   sta::Slack slack_min = rs_->resizeNetSlack(worst_slack_nets[0]);
   sta::Slack slack_max = rs_->resizeNetSlack(worst_slack_nets[worst_slack_nets.size()-1]);
 

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -266,6 +266,7 @@ public:
                        Delay &delay,
                        Slew &slew);
   void setDebugPin(const Pin *pin);
+  void setWorstSlackNetsPercent(float);
 
   ////////////////////////////////////////////////////////////////
 
@@ -314,7 +315,7 @@ public:
   // resizeSlackPreamble must be called before the first findResizeSlacks.
   void resizeSlackPreamble();
   void findResizeSlacks();
-  // Return 10% of nets with worst slack.
+  // Return nets with worst slack.
   NetSeq &resizeWorstSlackNets();
   // Return net slack.
   Slack resizeNetSlack(const Net *net);
@@ -595,6 +596,7 @@ protected:
   bool buffer_moved_into_core_;
   // Slack map variables.
   float max_wire_length_;
+  float worst_slack_nets_percent_;
   Map<const Net*, Slack> net_slack_map_;
   NetSeq worst_slack_nets_;
 

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -175,7 +175,8 @@ Resizer::Resizer() :
   resize_count_(0),
   inserted_buffer_count_(0),
   buffer_moved_into_core_(false),
-  max_wire_length_(0)
+  max_wire_length_(0),
+  worst_slack_nets_percent_(10)
 {
 }
 
@@ -934,13 +935,13 @@ Resizer::findResizeSlacks1()
   }
 
   // Find the nets with the worst slack.
-  double worst_percent = .1;
+
   //  sort(nets.begin(), nets.end(). [&](const Net *net1,
   sort(nets, [this](const Net *net1,
                  const Net *net2)
              { return resizeNetSlack(net1) < resizeNetSlack(net2); });
   worst_slack_nets_.clear();
-  for (int i = 0; i < nets.size() * worst_percent; i++)
+  for (int i = 0; i < nets.size() * worst_slack_nets_percent_ / 100.0; i++)
     worst_slack_nets_.push_back(nets[i]);
 }
 
@@ -2458,6 +2459,12 @@ void
 Resizer::setDebugPin(const Pin *pin)
 {
   debug_pin_ = pin;
+}
+
+void
+Resizer::setWorstSlackNetsPercent(float percent)
+{
+  worst_slack_nets_percent_ = percent;
 }
 
 } // namespace

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -638,6 +638,13 @@ set_debug_pin(const Pin *pin)
   resizer->setDebugPin(pin);
 }
 
+void
+set_worst_slack_nets_percent(float percent)
+{
+  Resizer *resizer = getResizer();
+  resizer->setWorstSlackNetsPercent(percent);
+}
+
 } // namespace
 
 %} // inline


### PR DESCRIPTION
This allows us to tune the percentage of nets that are reweighted
in timing driven placement.