### PR TITLE
odb: version checking fixes

### DIFF
--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -306,12 +306,12 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& db)
   stream >> db._schema_major;
 
   if (db._schema_major != db_schema_major)
-    throw ZException("Incompatible database schema revision");
+    throw ZException("incompatible database schema major revision (OpenROAD requires %d but database is %d)", db_schema_major, db._schema_major);
 
   stream >> db._schema_minor;
 
   if (db._schema_minor < db_schema_initial)
-    throw ZException("incompatible database schema revision");
+    throw ZException("incompatible database schema minor revision (database requires %d or greater but OpenROAD is %d)", db._schema_minor, db_schema_initial);
 
   stream >> db._master_id;
 

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -310,7 +310,7 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& db)
 
   stream >> db._schema_minor;
 
-  if (db._schema_minor < db_schema_initial)
+  if (db_schema_initial < db._schema_minor)
     throw ZException("incompatible database schema minor revision (database requires %d or greater but OpenROAD is %d)", db._schema_minor, db_schema_initial);
 
   stream >> db._master_id;


### PR DESCRIPTION
It looks like the minor revision check is reversed, because before I added the second patch I was getting:

```
incompatible database schema minor revision (database requires 56 or greater but OpenROAD is 57)
```

I presume the idea of a minor revision is an update that retains compatibility with older minor revisions (is that correct?). After making the fix I tested that database (minor rev 56, OpenROAD minor rev 57) and it promptly used all of my memory and crashed. That suggests we are misusing the minor rev number.