### PR TITLE
gpl: Fix for trivial designs (RePlAce diverged at initial iteration)

### DIFF
--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -842,7 +842,10 @@ NesterovPlace::getStepLength(
   debugPrint(log_, GPL, "replace", 3, "getStepLength:  CoordinateDistance: {:g}", coordiDistance);
   debugPrint(log_, GPL, "replace", 3, "getStepLength:  GradientDistance: {:g}", gradDistance);
 
-  return coordiDistance / gradDistance;
+  if (gradDistance == 0.0)
+    return 0;
+  else
+    return coordiDistance / gradDistance;
 }
 
 float


### PR DESCRIPTION
I have a trivial design (a few wires between input and output ports) that fails in gpl with the following error:

[ERROR GPL-0304] RePlAce diverged at initial iteration. Re-run with a smaller init_density_penalty value.

The issue is gradDistance is 0, and getStepLength divides by 0. Catch this and return 0 instead.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>