### PR TITLE
ppl: -force_to_die_boundary fails on vertical layers

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1428,7 +1428,7 @@ void IOPlacer::movePinToTrack(odb::Point& pos,
                + init_track);
       int dist_lb = abs(pos.y() - lb_y);
       int dist_ub = abs(pos.y() - ub_y);
-      int new_y = (dist_lb < dist_ub) ? lb_y + (width / 2) : ub_y - (width / 2);
+      int new_y = (dist_lb < dist_ub) ? lb_y + (height / 2) : ub_y - (height / 2);
       pos.setY(new_y);
     }
   }


### PR DESCRIPTION
Pins on vertical layers are placed partially outside the die area.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>