### PR TITLE
grt: fixing incremental grt bugs

### DIFF
--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -968,7 +968,7 @@ NetRouteMap FastRouteCore::run()
   // debug mode Rectilinear Steiner Tree before overflow iterations
   if (debug_->isOn_ && debug_->rectilinearSTree_) {
     for (int netID = 0; netID < netCount(); netID++) {
-      if (nets_[netID]->db_net == debug_->net_) {
+      if (nets_[netID]->db_net == debug_->net_ && !nets_[netID]->is_routed) {
         StTreeVisualization(sttrees_[netID], nets_[netID], false);
       }
     }
@@ -1219,7 +1219,7 @@ NetRouteMap FastRouteCore::run()
   // Debug mode Tree 2D after overflow iterations
   if (debug_->isOn_ && debug_->tree2D_) {
     for (int netID = 0; netID < netCount(); netID++) {
-      if (nets_[netID]->db_net == debug_->net_) {
+      if (nets_[netID]->db_net == debug_->net_ && !nets_[netID]->is_routed) {
         StTreeVisualization(sttrees_[netID], nets_[netID], false);
       }
     }
@@ -1261,7 +1261,7 @@ NetRouteMap FastRouteCore::run()
   // Debug mode Tree 3D after layer assignament
   if (debug_->isOn_ && debug_->tree3D_) {
     for (int netID = 0; netID < netCount(); netID++) {
-      if (nets_[netID]->db_net == debug_->net_) {
+      if (nets_[netID]->db_net == debug_->net_ && !nets_[netID]->is_routed) {
         StTreeVisualization(sttrees_[netID], nets_[netID], true);
       }
     }

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -1114,11 +1114,16 @@ void FastRouteCore::StNetOrder()
   tree_order_cong_.resize(netCount());
 
   i = 0;
-  for (j = 0; j < netCount(); j++) {
+  for (j = 0; j < netCount(); j++) { 
+
     stree = &(sttrees_[j]);
     d = stree->deg;
     tree_order_cong_[j].xmin = 0;
     tree_order_cong_[j].treeIndex = j;
+
+    // if the net is routed
+    if (nets_[j]->is_routed) continue;
+
     for (ind = 0; ind < 2 * d - 3; ind++) {
       treeedges = stree->edges;
       treeedge = &(treeedges[ind]);
@@ -1218,11 +1223,13 @@ void FastRouteCore::recoverEdge(int netID, int edgeID)
       if (gridsX[i] == gridsX[i + 1])  // a vertical edge
       {
         ymin = std::min(gridsY[i], gridsY[i + 1]);
+        v_edges_[ymin][gridsX[i]].usage += net->edgeCost;
         v_edges_3D_[gridsL[i]][ymin][gridsX[i]].usage
           += net->layerEdgeCost(gridsL[i]);
       } else if (gridsY[i] == gridsY[i + 1])  // a horizontal edge
       {
         xmin = std::min(gridsX[i], gridsX[i + 1]);
+        h_edges_[gridsY[i]][xmin].usage += net->edgeCost;
         h_edges_3D_[gridsL[i]][gridsY[i]][xmin].usage
           += net->layerEdgeCost(gridsL[i]);
       }


### PR DESCRIPTION
Fixing wrong values in 2D usage and bug in `FastRouterCore::StNetOrder` function.
Modifying debug mode to only show net when its routing is changed.

Signed-off-by: luis201420 <tauro_luisito_20@hotmail.com>