### PR TITLE
grt: Use pin access in parasitic estimates

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -243,6 +243,9 @@ class GlobalRouter
   void createWLReportFile(const char* file_name, bool verbose);
   std::vector<PinGridLocation> getPinGridPositions(odb::dbNet* db_net);
 
+  bool pinAccessPointPositions(const Pin& pin,
+                               std::vector<std::pair<odb::Point, odb::Point>>& ap_positions);
+
  private:
   // Net functions
   Net* addNet(odb::dbNet* db_net);


### PR DESCRIPTION
This is a first attempt at fixing https://github.com/The-OpenROAD-Project/OpenROAD/issues/2377

`pinAccessPointPositions()` creates pairs of `{ap_position, ap_position_on_grid}`, does that look reasonable?