### PR TITLE
drt: sort insts and nets to ensure stable results

### DIFF
--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -26,6 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "io/io.h"
+
 #include <exception>
 #include <fstream>
 #include <iostream>
@@ -35,7 +37,6 @@
 #include "frProfileTask.h"
 #include "frRTree.h"
 #include "global.h"
-#include "io/io.h"
 #include "odb/db.h"
 #include "odb/dbWireCodec.h"
 #include "utl/Logger.h"

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -122,9 +122,21 @@ void io::Parser::setTracks(odb::dbBlock* block)
   }
 }
 
+template <typename T>
+static std::vector<T*> sortedSet(odb::dbSet<T>& to_sort)
+{
+  std::vector<T*> sorted(to_sort.begin(), to_sort.end());
+  std::sort(sorted.begin(), sorted.end(), [](T* a, T* b) {
+    return a->getName() < b->getName();
+  });
+  return sorted;
+}
+
 void io::Parser::setInsts(odb::dbBlock* block)
 {
-  for (auto inst : block->getInsts()) {
+  odb::dbSet<odb::dbInst> insts = block->getInsts();
+
+  for (odb::dbInst* inst : sortedSet(insts)) {
     if (design_->name2master_.find(inst->getMaster()->getName())
         == design_->name2master_.end())
       logger_->error(
@@ -497,7 +509,9 @@ void io::Parser::getSBoxCoords(odb::dbSBox* box,
 
 void io::Parser::setNets(odb::dbBlock* block)
 {
-  for (auto net : block->getNets()) {
+  odb::dbSet<odb::dbNet> nets = block->getNets();
+
+  for (odb::dbNet* net : sortedSet(nets)) {
     bool is_special = net->isSpecial();
     if (!is_special && net->getSigType().isSupply()) {
       logger_->error(DRT,


### PR DESCRIPTION
I have a test case for global and detailed routing where the results of detailed routing are different if an odb or def is used. Both the odb and def are created at the same time (before global routing), and there should be nothing in the odb at that stage that cannot be represented by the def.

One difference (pointed out by Matt) is that write_def sorts insts and nets, so we iterate through them in a different order. Sorting them before using them in drt fixes the issue.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>