### PR TITLE
Don't call atexit() functions from signal handler

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -260,11 +260,22 @@ static void initPython()
 }
 #endif
 
-static void handler(int)
+static volatile sig_atomic_t fatal_error_in_progress = 0;
+
+static void handler(int sig)
 {
+  if (fatal_error_in_progress) {
+    raise(sig);
+  }
+  fatal_error_in_progress = 1;
+
+  std::cerr << "Signal " << sig << " received\n";
+
   std::cerr << "Stack trace:\n";
   std::cerr << boost::stacktrace::stacktrace();
-  exit(1);
+
+  signal(sig, SIG_DFL);
+  raise(sig);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
I hit a SEGV:

  Stack trace:
   0# sta::ClkInfo::refsFilter(sta::StaState const*) const in openroad
   1# sta::TagGroupBldr::setMatchArrival(sta::Tag*, sta::Tag*, float const&, int, sta::PathVertexRep*) in openroad

Which then proceeded to abort and dump the stack a second time:

  terminate called after throwing an instance of 'std::system_error'
    what():  Resource deadlock avoided
  Stack trace:
   0# raise in /lib64/libc.so.6
   1# abort in /lib64/libc.so.6
  ...
  16# sta::Sta::~Sta() in openroad
  17# ord::deleteDbSta(sta::dbSta*) in openroad
  18# ord::OpenRoad::~OpenRoad() in openroad
  20# on_exit in /lib64/libc.so.6

The issue is we are calling exit() which is not async safe and so cannot be used in a signal handler. Considering the application is in a bad state, it also doesn't make sense to try and gracefully shutdown.

Call _exit() instead.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>