### PR TITLE
Tiny cleanup: Remove unused using odb::dbSigType declaration

### DIFF
--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -63,7 +63,6 @@ using odb::dbMPin;
 using odb::dbMTerm;
 using odb::dbNet;
 using odb::dbPlacementStatus;
-using odb::dbSigType;
 using odb::Rect;
 
 Cell::Cell()


### PR DESCRIPTION
(https://clang.llvm.org/extra/clang-tidy/checks/misc/unused-using-decls.html)

Signed-off-by: Henner Zeller <hzeller@google.com>