### PR TITLE
Support future swig >= 4.1.0 changes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -150,6 +150,9 @@ if (BUILD_TCLX AND TCLX_H)
 endif()
 
 find_package(SWIG 3.0 REQUIRED)
+if (SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
+  message(WARNING "Using SWIG >= ${SWIG_VERSION} -flatstaticmethod flag for python")
+endif()
 include(UseSWIG)
 
 find_package(Boost REQUIRED)

--- a/src/cmake/swig_lib.cmake
+++ b/src/cmake/swig_lib.cmake
@@ -102,6 +102,9 @@ function(swig_lib)
       PRIVATE
         ${Python3_INCLUDE_DIRS}
     )
+    if (SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
+      set_property(TARGET ${ARG_NAME} PROPERTY SWIG_COMPILE_OPTIONS -flatstaticmethod)
+    endif()
 
     swig_link_libraries(${ARG_NAME}
       PUBLIC


### PR DESCRIPTION
This PR fix support for future ```swig >= 4.10```, requiring a compatible ```-flatstaticmethod``` for python exports.

* Upstream explanations: https://github.com/swig/swig/pull/2137
* Exposed ```openlane``` behaviour in such case: https://github.com/The-OpenROAD-Project/OpenLane/pull/1471

---

For swig >= 4.1.0 there will be a WARNING during initial detection phase. 
In some future, there might be a desire to switch to swig 4.1.0 ```nonflatstatic``` new behaviour.

Thanks,
~Cristian.