### PR TITLE
src/Main: simplify python flag handling

### DIFF
--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -227,10 +227,6 @@ class OpenRoad
   void setThreadCount(const char* threads, bool printInfo = true);
   int getThreadCount();
 
-#ifdef ENABLE_PYTHON3
-  void pythonCommand(const char* py_command);
-#endif
-
   // Observer interface
   class Observer
   {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -115,9 +115,8 @@ FOREACH_TOOL(X)
 #undef X
 }  // namespace sta
 
-static void initPython(int argc, char *const *argv, int inspect)
+static void initPython(int argc, char* argv[], int inspect)
 {
-
 #define X(name)                                                             \
   if (PyImport_AppendInittab("_" #name "_py", PyInit__##name##_py) == -1) { \
     fprintf(stderr, "Error: could not add module _" #name "_py\n");         \
@@ -128,7 +127,7 @@ static void initPython(int argc, char *const *argv, int inspect)
 
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
-  PyConfig_SetBytesArgv(&config, argc, argv); 
+  PyConfig_SetBytesArgv(&config, argc, argv);
   config.inspect = inspect;
   Py_InitializeFromConfig(&config);
   PyConfig_Clear(&config);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -256,14 +256,14 @@ int main(int argc, char* argv[])
     std::vector<wchar_t*> args;
     args.push_back(Py_DecodeLocale(cmd_argv[0], nullptr));
     if (!exit) {
-        args.push_back(Py_DecodeLocale("-i", nullptr));
+      args.push_back(Py_DecodeLocale("-i", nullptr));
     }
     for (int i = 1; i < cmd_argc; i++) {
       args.push_back(Py_DecodeLocale(cmd_argv[i], nullptr));
     }
     return Py_Main(args.size(), args.data());
   }
-#endif // ENABLE_PYTHON3
+#endif  // ENABLE_PYTHON3
 
   // Set argc to 1 so Tcl_Main doesn't source any files.
   // Tcl_Main never returns.

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -482,14 +482,6 @@ OpenRoad::Observer::~Observer()
     owner_->removeObserver(this);
   }
 }
-
-#ifdef ENABLE_PYTHON3
-void OpenRoad::pythonCommand(const char* py_command)
-{
-  PyRun_SimpleString(py_command);
-}
-#endif
-
 void OpenRoad::setThreadCount(int threads, bool printInfo)
 {
   int max_threads = std::thread::hardware_concurrency();

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -516,15 +516,6 @@ units_initialized()
   return openroad->unitsInitialized();
 }
 
-#ifdef ENABLE_PYTHON3
-void
-python_cmd(const char* py_command)
-{
-  OpenRoad *openroad = getOpenRoad();
-  return openroad->pythonCommand(py_command);
-}
-#endif
-
 namespace ord {
 
 void

--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -229,11 +229,6 @@ proc suppress_message {args} {
   utl::suppress_message $tool $id
 }
 
-sta::define_cmd_args "python" { args }
-proc python {args} {
-  ord::python_cmd $args
-}
-
 proc set_thread_count { count } {
   ord::set_thread_count $count
 }


### PR DESCRIPTION
redo of #2438

- set interpreter config according to command line flags
- forward arguments to python interpreter
- only init python when flag is passed (remove signal save/restore)

Fixes #2419

# Tests

I'd love to add something to the test suite, but https://wiki.tcl-lang.org/page/Expect doesn't seems to be supported by the `test/regression` (and would be needed in order to test proper interaction with the REPL).

```
OpenROAD 🍡 cat foo.py 
import odb
print(odb)
import sys
a = sys.argv
print(a)
```

```
OpenROAD 🍧 build/src/openroad -python foo.py 
OpenROAD v2.0-5434-gb348ed433 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
<module 'odb' from '/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/odb_py.py'>
['foo.py']
>>> print(a)
['foo.py']
>>> 
```

```
OpenROAD 🍉 build/src/openroad -python -m foo 
OpenROAD v2.0-5434-gb348ed433 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
<module 'odb' from '/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/odb_py.py'>
['/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/foo.py']
>>> print(a)
['/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/foo.py']
>>> 
```

```
OpenROAD 🍫 build/src/openroad -python -exit foo.py 
OpenROAD v2.0-5434-gb348ed433 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
<module 'odb' from '/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/odb_py.py'>
['foo.py']
OpenROAD 🍫 build/src/openroad -exit -python foo.py 
OpenROAD v2.0-5434-gb348ed433 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
<module 'odb' from '/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/odb_py.py'>
['foo.py']
```

```
OpenROAD 💀 build/src/openroad -python -exit -m foo a b c 
OpenROAD v2.0-5434-gb348ed433 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
<module 'odb' from '/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/odb_py.py'>
['/usr/local/google/home/proppy/src/github.com/The-OpenROAD-Project/OpenROAD/foo.py', 'a', 'b', 'c']
```
