### PR TITLE
Fixes GF180MCU antenna violations

### DIFF
--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -1997,7 +1997,7 @@ bool AntennaChecker::antennaRatioDiffDependent(dbTechLayer* layer)
     const dbTechLayerAntennaRule* antenna_rule = layer->getDefaultAntennaRule();
     dbTechLayerAntennaRule::pwl_pair diffPAR = antenna_rule->getDiffPAR();
     dbTechLayerAntennaRule::pwl_pair diffPSR = antenna_rule->getDiffPSR();
-    return diffPAR.indices.size() > 1 || diffPSR.indices.size() > 1;
+    return diffPAR.indices.size() >= 1 || diffPSR.indices.size() >= 1;
   }
   return false;
 }

--- a/src/grt/test/repair_antennas4.ok
+++ b/src/grt/test/repair_antennas4.ok
@@ -10,6 +10,14 @@
 [INFO ODB-0131]     Created 1360 components and 6650 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 411 nets and 1210 connections.
+[WARNING ANT-0009] Net clk requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[11] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[13] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[14] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[1] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[3] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net resp_msg[7] requires more than 10 diodes per gate to repair violations.
+[WARNING ANT-0009] Net _229_ requires more than 10 diodes per gate to repair violations.
 [INFO GRT-0012] Found 8 antenna violations.
-[WARNING GRT-0243] Unable to repair antennas on net with diodes.
-[INFO GRT-0015] Inserted 0 diodes.
+[INFO GRT-0015] Inserted 165 diodes.
+[INFO GRT-0054] Using detailed placer to place 65 diodes.


### PR DESCRIPTION
The issue looks to be down to GF180MCU being simpler than we expect.

Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/2516

In SKY130 we have antenna rules that look like this.
```
  ANTENNAMODEL OXIDE1 ;
  ANTENNADIFFSIDEAREARATIO PWL ( ( 0 400 ) ( 0.0125 400 ) ( 0.0225 2609 ) ( 22.5 11600 ) ) ;

```

However, in GF180MCU we have rules that look like.
```
    ANTENNAMODEL OXIDE1 ;
    ANTENNADIFFSIDEAREARATIO 400 ;
    ANTENNAGATEPLUSDIFF 2 ;
```

There is only a single value instead of a linearly interpolated list of values.

```c++
bool AntennaChecker::antennaRatioDiffDependent(dbTechLayer* layer)
{
  if (layer->hasDefaultAntennaRule()) {
    const dbTechLayerAntennaRule* antenna_rule = layer->getDefaultAntennaRule();
    dbTechLayerAntennaRule::pwl_pair diffPAR = antenna_rule->getDiffPAR();
    dbTechLayerAntennaRule::pwl_pair diffPSR = antenna_rule->getDiffPSR();
    return diffPAR.indices.size() > 1 || diffPSR.indices.size() > 1;
  }
  return false;
}
```

The following code asserts that there must be at least two values for the rule to be diff dependent which is incorrect. When I changed the code to

```c++
bool AntennaChecker::antennaRatioDiffDependent(dbTechLayer* layer)
{
  if (layer->hasDefaultAntennaRule()) {
    const dbTechLayerAntennaRule* antenna_rule = layer->getDefaultAntennaRule();
    dbTechLayerAntennaRule::pwl_pair diffPAR = antenna_rule->getDiffPAR();
    dbTechLayerAntennaRule::pwl_pair diffPSR = antenna_rule->getDiffPSR();
    return diffPAR.indices.size() >= 1 || diffPSR.indices.size() >= 1;
  }
  return false;
}
```

OpenROAD fixed nearly all of the antennas in this design.