### PR TITLE
rm mpl2 until it works on macos

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -182,7 +182,8 @@ add_compile_options(
   -Wno-sign-compare
   -Wp,-D_GLIBCXX_ASSERTIONS
   $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>
-  $<$<CXX_COMPILER_ID:AppleClang>:-Wno-gnu-zero-variadic-macro-arguments>
+  # Apple clang 14.0.0 deprecates sprintf, which generates 900 warnings.
+  $<$<CXX_COMPILER_ID:AppleClang>:-Wno-deprecated-declarations>
 )
 
 ################################################################
@@ -314,7 +315,6 @@ target_link_libraries(openroad
   drt
   dst
   mpl
-  mpl2
   psm
   ant
   par
@@ -324,6 +324,13 @@ target_link_libraries(openroad
   ${TCL_LIBRARY}
   ${CMAKE_THREAD_LIBS_INIT}
 )
+
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  # mpl2 aborts with link error on darwin so do not link it.
+  target_link_libraries(openroad mpl2)
+else()
+  message(STATUS "Removing MPL2 to avoid run time fatal error.")
+endif()
 
 # tclReadline
 if (TCL_READLINE_LIBRARY AND TCL_READLINE_H)

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -164,7 +164,7 @@ OpenRoad::~OpenRoad()
   deleteTapcell(tapcell_);
   deleteMacroPlacer(macro_placer_);
 #if (CMAKE_SYSTEM_NAME != Darwin)
-   deleteMacroPlacer2(macro_placer2_);
+  deleteMacroPlacer2(macro_placer2_);
 #endif
   deleteOpenRCX(extractor_);
   deleteTritonRoute(detailed_router_);

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -57,7 +57,10 @@
 #include "gui/MakeGui.h"
 #include "ifp//MakeInitFloorplan.hh"
 #include "mpl/MakeMacroPlacer.h"
+#if (CMAKE_SYSTEM_NAME != Darwin)
+// mpl2 aborts with link error on darwin
 #include "mpl2/MakeMacroPlacer.h"
+#endif
 #include "odb/cdl.h"
 #include "odb/db.h"
 #include "odb/defin.h"
@@ -160,7 +163,9 @@ OpenRoad::~OpenRoad()
   deleteTritonCts(tritonCts_);
   deleteTapcell(tapcell_);
   deleteMacroPlacer(macro_placer_);
-  deleteMacroPlacer2(macro_placer2_);
+#if (CMAKE_SYSTEM_NAME != Darwin)
+   deleteMacroPlacer2(macro_placer2_);
+#endif
   deleteOpenRCX(extractor_);
   deleteTritonRoute(detailed_router_);
   deleteReplace(replace_);
@@ -213,7 +218,9 @@ void OpenRoad::init(Tcl_Interp* tcl_interp)
   tritonCts_ = makeTritonCts();
   tapcell_ = makeTapcell();
   macro_placer_ = makeMacroPlacer();
+#if (CMAKE_SYSTEM_NAME != Darwin)
   macro_placer2_ = makeMacroPlacer2();
+#endif
   extractor_ = makeOpenRCX();
   detailed_router_ = makeTritonRoute();
   replace_ = makeReplace();
@@ -247,7 +254,9 @@ void OpenRoad::init(Tcl_Interp* tcl_interp)
   initTritonCts(this);
   initTapcell(this);
   initMacroPlacer(this);
+#if (CMAKE_SYSTEM_NAME != Darwin)
   initMacroPlacer2(this);
+#endif
   initOpenRCX(this);
   initPad(this);
   initRestructure(this);

--- a/third-party/CMakeLists.txt
+++ b/third-party/CMakeLists.txt
@@ -46,6 +46,10 @@ if (NOT USE_SYSTEM_ABC)
   # readline is not needed since we call abc from c++
   set(READLINE_FOUND FALSE)
 
+# apple clang 14.0.0 seg faults on abc without -g
+add_compile_options(
+  $<$<CXX_COMPILER_ID:AppleClang>:-g>
+)
   add_subdirectory(abc)
 
 endif()


### PR DESCRIPTION
remove mpl2 on macos until it does not cause a link related startup error
disable optimization for abc until apple clang does not seg fault compiling it
Signed-off-by: James Cherry <cherry@parallaxsw.com>r