### PR TITLE
drt: Re-enable non preferred direction routing on GF14

### DIFF
--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -490,8 +490,6 @@ void TritonRoute::init(Tcl_Interp* tcl_interp,
 
 bool TritonRoute::initGuide()
 {
-  if (DBPROCESSNODE == "GF14_13M_3Mx_2Cx_4Kx_2Hx_2Gx_LB")
-    USENONPREFTRACKS = false;
   io::Parser parser(db_, getDesign(), logger_);
   bool guideOk = parser.readGuide();
   parser.postProcessGuide();


### PR DESCRIPTION
With support for WRONGDIRECTION width routing added recently, remove the GF14 workaround.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>