### PR TITLE
gui: README: add example of how to read files

### DIFF
--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -2,6 +2,18 @@
 
 The graphical user interface can be access by launching OpenROAD with ``-gui`` or by opening it from the command-line with ``gui::show``.
 
+## Reading files
+
+The GUI is used to inspect files generated at various stages of design flow. Once the gui is running, you can use the ``read_db`` command to read a ``.odb`` file for inspection:
+
+```
+read_db results/placement/project.odb
+```
+
+The GUI can be used to inspect the following files:
+- ``.odb``: OpenROAD database files, loaded with ``read_db``
+- ``.def``: Design Exchange Format files, loaded with ``read_def``
+
 ## Commands
 
 ### Add buttons to the toolbar


### PR DESCRIPTION
The GUI is very powerful, and is shown off a lot. However, the documentation of the GUI itself never actually spells out how to open files, nor specifies what sorts of files it reads. This is compounded by the lack of an "Open" dialogue box.

Add a note to the top of the GUI documentation to explicitly state how to open files.