### PR TITLE
Add `or-tools` to cmake and remove hard coded paths

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -122,18 +122,6 @@ _installCommonDev() {
     rm -rf "${baseDir}"
 }
 
-_installOrTools() {
-    os=$1
-    version=$2
-    arch=$3
-    orToolsVersionBig=9.4
-    orToolsVersionSmall=${orToolsVersionBig}.1874
-    orToolsFile=or-tools_${arch}_${os}-${version}_cpp_v${orToolsVersionSmall}.tar.gz
-    wget https://github.com/google/or-tools/releases/download/v${orToolsVersionBig}/${orToolsFile}
-    mkdir -p /opt/or-tools
-    tar --strip 1 --dir /opt/or-tools -xf ${orToolsFile}
-}
-
 _installUbuntuCleanUp() {
     apt-get autoclean -y
     apt-get autoremove -y
@@ -481,7 +469,6 @@ case "${os}" in
             _installCentosDev
             _installCommonDev
         fi
-        _installOrTools "centos" "7" "amd64"
         _installCentosCleanUp
         cat <<EOF
 To enable GCC-8 or Clang-7 you need to run:
@@ -498,7 +485,6 @@ EOF
             _installUbuntuDev
             _installCommonDev
         fi
-        _installOrTools "ubuntu" "${version}" "amd64"
         _installUbuntuCleanUp
         ;;
     "Red Hat Enterprise Linux")
@@ -509,12 +495,10 @@ EOF
             _installRHELDev
             _installCommonDev
         fi
-        _installOrTools "centos" "8" "amd64"
         _installRHELCleanUp
         ;;
     "Darwin" )
         _installDarwin
-        _installOrTools "MacOsX" "12.5" $(uname -m)
         cat <<EOF
 
 To install or run openroad, update your path with:
@@ -532,7 +516,6 @@ EOF
             _installDebianDev
             _installCommonDev
         fi
-        _installOrTools "debian" "${version}" "amd64"
         _installDebianCleanUp
         ;;
     *)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,33 @@ list(APPEND CMAKE_INSTALL_RPATH
   "/opt/or-tools/lib"
 )
 
+################
+##  OR_TOOLS  ##
+################
+message(STATUS "Installing OR-Tools...")
+# Download and install or-tools at configure time
+configure_file(
+	${CMAKE_CURRENT_SOURCE_DIR}/cmake/ortools.CMakeLists.txt
+	${CMAKE_BINARY_DIR}/ortools-download/CMakeLists.txt)
+# CMake configure
+execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" . -DCMAKE_BUILD_TYPE=Release
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/ortools-download)
+if(result)
+  message(FATAL_ERROR "CMake step for ortools failed: ${result}")
+endif()
+# CMake Build/Install
+execute_process(COMMAND ${CMAKE_COMMAND} --build . --config Release
+  RESULT_VARIABLE result
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/ortools-download)
+if(result)
+  message(FATAL_ERROR "Build step for ortools failed: ${result}")
+endif()
+message(STATUS "Installing OR-Tools...DONE")
+
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR}/deps)
+find_package(ortools REQUIRED)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/src/cmake")
 
 include("openroad")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,13 +33,6 @@
 ##
 ###############################################################################
 
-# The location used by etc/DependencyInstaller.sh
-# lib64 is used for CentOS and openSUSE
-# lib is used for Ubuntu and MacOS
-list(APPEND CMAKE_INSTALL_RPATH
-  "/opt/or-tools/lib64"
-  "/opt/or-tools/lib"
-)
 
 ################
 ##  OR_TOOLS  ##

--- a/src/cmake/ortools.CMakeLists.txt
+++ b/src/cmake/ortools.CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(ortools-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(ortools_project
+  GIT_REPOSITORY https://github.com/google/or-tools.git
+  GIT_TAG "92eab40155d5566039c92662632f196174f8da47"
+  GIT_SHALLOW TRUE
+  GIT_PROGRESS TRUE
+  CMAKE_ARGS
+    "-G@CMAKE_GENERATOR@"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-DBUILD_DEPS=ON"
+    "-DBUILD_SAMPLES=OFF"
+    "-DBUILD_EXAMPLES=OFF"
+    "-DBUILD_TESTING=OFF"
+    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/deps"
+)

--- a/src/mpl2/CMakeLists.txt
+++ b/src/mpl2/CMakeLists.txt
@@ -33,12 +33,6 @@
 
 include("openroad")
 
-# The location used by etc/DependencyInstaller.sh
-list(APPEND CMAKE_PREFIX_PATH
-  "/opt/or-tools/lib64/cmake"
-  "/opt/or-tools/lib/cmake"
-)
-
 find_package(ortools REQUIRED)
 
 swig_lib(NAME      mpl2


### PR DESCRIPTION
This fixes the non-docker build. It includes `or-tools` as described by the devs here: https://github.com/or-tools/cmake_or-tools/tree/main/LocalInstall

I tried to get the `local` build running due to not having access to docker (not my decision), and it always crashed because of the hard-coded paths in `cmake`.

Here:
https://github.com/The-OpenROAD-Project/OpenROAD/blob/df19865e51b0c192caf4e8ee7ecf7b88ee593194/src/mpl2/CMakeLists.txt#L37-L40

And here:

https://github.com/The-OpenROAD-Project/OpenROAD/blob/df19865e51b0c192caf4e8ee7ecf7b88ee593194/src/CMakeLists.txt#L39-L42

This works nicely in a docker env, and I tried to bypass it by setting `CMAKE_INSTALL_RPATH` and `CMAKE_INSTALL_PREFIX`, but I still had some linking issues.

I know my proposed solution will lead to longer build times, but I think it will mitigate issues in the future. 

I tagged the latest release here:

https://github.com/joennlae/OpenROAD/blob/7c3c5cdef94cb29434b418999434fc5f62db2e4c/src/cmake/ortools.CMakeLists.txt#L8

Tell me what you think about this solution.

It could maybe also fix the macOS problem:
https://github.com/The-OpenROAD-Project/OpenROAD/blob/df19865e51b0c192caf4e8ee7ecf7b88ee593194/src/CMakeLists.txt#L328-L331
but I did not run any tests.