### PR TITLE
grt: fix usage from underflow after removing loops

### DIFF
--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -174,6 +174,30 @@ void FastRouteCore::fixOverlappingEdge(
     routeLShape(
         startpoint, endpoint, blocked_positions, new_route_x, new_route_y);
 
+    // Updates the usage of the altered edge
+    const int edgeCost = nets_[net_id]->getEdgeCost();
+    for (int k = 0; k < treeedge->route.routelen; k++) { // Remove the usages of the old edges
+      if (treeedge->route.gridsX[k] == treeedge->route.gridsX[k + 1]) {
+        if (treeedge->route.gridsY[k] != treeedge->route.gridsY[k + 1]) {
+          const int min_y = std::min(treeedge->route.gridsY[k], treeedge->route.gridsY[k + 1]);
+          v_edges_[min_y][treeedge->route.gridsX[k]].usage -= edgeCost;
+        }
+      } else {
+        const int min_x = std::min(treeedge->route.gridsX[k], treeedge->route.gridsX[k + 1]);
+        h_edges_[treeedge->route.gridsY[k]][min_x].usage -= edgeCost;
+      }
+    }
+    for (int k = 0; k < new_route_x.size() - 1; k++) { // Update the usage for the new edges
+      if (new_route_x[k] == new_route_x[k + 1]) {
+        if (new_route_y[k] != new_route_y[k + 1]) {
+          const int min_y = std::min(new_route_y[k], new_route_y[k + 1]);
+          v_edges_[min_y][new_route_x[k]].usage += edgeCost;
+        }
+      } else {
+        const int min_x = std::min(new_route_x[k], new_route_x[k + 1]);
+        h_edges_[new_route_y[k]][min_x].usage += edgeCost;
+      }
+    }
     treeedge->route.gridsX = new_route_x;
     treeedge->route.gridsY = new_route_y;
     treeedge->route.routelen = new_route_x.size() - 1;

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -176,18 +176,22 @@ void FastRouteCore::fixOverlappingEdge(
 
     // Updates the usage of the altered edge
     const int edgeCost = nets_[net_id]->getEdgeCost();
-    for (int k = 0; k < treeedge->route.routelen; k++) { // Remove the usages of the old edges
+    for (int k = 0; k < treeedge->route.routelen;
+         k++) {  // remove the usages of the old edges
       if (treeedge->route.gridsX[k] == treeedge->route.gridsX[k + 1]) {
         if (treeedge->route.gridsY[k] != treeedge->route.gridsY[k + 1]) {
-          const int min_y = std::min(treeedge->route.gridsY[k], treeedge->route.gridsY[k + 1]);
+          const int min_y = std::min(treeedge->route.gridsY[k],
+                                     treeedge->route.gridsY[k + 1]);
           v_edges_[min_y][treeedge->route.gridsX[k]].usage -= edgeCost;
         }
       } else {
-        const int min_x = std::min(treeedge->route.gridsX[k], treeedge->route.gridsX[k + 1]);
+        const int min_x = std::min(treeedge->route.gridsX[k],
+                                   treeedge->route.gridsX[k + 1]);
         h_edges_[treeedge->route.gridsY[k]][min_x].usage -= edgeCost;
       }
     }
-    for (int k = 0; k < new_route_x.size() - 1; k++) { // Update the usage for the new edges
+    for (int k = 0; k < new_route_x.size() - 1;
+         k++) {  // update the usage for the new edges
       if (new_route_x[k] == new_route_x[k + 1]) {
         if (new_route_y[k] != new_route_y[k + 1]) {
           const int min_y = std::min(new_route_y[k], new_route_y[k + 1]);

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -1228,10 +1228,12 @@ void FastRouteCore::removeLoops()
             for (int k = j; k < i; k++) {
               if (gridsX[k] == gridsX[k + 1]) {
                 if (gridsY[k] != gridsY[k + 1]) {
-                  v_edges_[gridsY[k]][gridsX[k]].usage -= edgeCost;
+                  const int min_y = std::min(gridsY[k], gridsY[k + 1]);
+                  v_edges_[min_y][gridsX[k]].usage -= edgeCost;
                 }
               } else {
-                h_edges_[gridsY[k]][gridsX[k]].usage -= edgeCost;
+                const int min_x = std::min(gridsX[k], gridsX[k + 1]);
+                h_edges_[gridsY[k]][min_x].usage -= edgeCost;
               }
             }
 

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -1228,12 +1228,10 @@ void FastRouteCore::removeLoops()
             for (int k = j; k < i; k++) {
               if (gridsX[k] == gridsX[k + 1]) {
                 if (gridsY[k] != gridsY[k + 1]) {
-                  const int min_y = std::min(gridsY[k], gridsY[k + 1]);
-                  v_edges_[min_y][gridsX[k]].usage -= edgeCost;
+                  v_edges_[gridsY[k]][gridsX[k]].usage -= edgeCost;
                 }
               } else {
-                const int min_x = std::min(gridsX[k], gridsX[k + 1]);
-                h_edges_[gridsY[k]][min_x].usage -= edgeCost;
+                h_edges_[gridsY[k]][gridsX[k]].usage -= edgeCost;
               }
             }
 


### PR DESCRIPTION
Signed-off-by: Arthur <arthurjolo@gmail.com>

The method FastCore::removeLoops() was choosing the wrong edges to decrease the usage, this fix changes it to choose the correct edge to decrease the usage.
Before the method was choosing the one with the minimum coordinates, and in some cases the same edge was decreased 2 times in a row, making the usage be updated to wrong value, some times that generated an underflow.
With the change the method chooses every edge on the loop one at a time, updating the usage only once for each edge.