### PR TITLE
Rcx python

### DIFF
--- a/include/ord/Design.h
+++ b/include/ord/Design.h
@@ -97,6 +97,10 @@ namespace par {
 class PartitionMgr;
 }
 
+namespace rcx {
+class Ext;
+}
+
 namespace ord {
 
 class Tech;
@@ -140,6 +144,7 @@ class Design
   dpo::Optdp* getOptdp();
   fin::Finale* getFinale();
   par::PartitionMgr* getPartitionMgr();
+  rcx::Ext* getOpenRCX();
 
  private:
   Tech* tech_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -395,6 +395,7 @@ if (Python3_FOUND AND BUILD_PYTHON)
     dpo_py
     fin_py
     par_py
+    rcx_py
   )
 else()
   message(STATUS "Python3 disabled")

--- a/src/Design.cc
+++ b/src/Design.cc
@@ -216,4 +216,10 @@ par::PartitionMgr* Design::getPartitionMgr()
   return app->getPartitionMgr();
 }
 
+rcx::Ext* Design::getOpenRCX()
+{
+  auto app = OpenRoad::openRoad();
+  return app->getOpenRCX();
+}
+
 }  // namespace ord

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -94,6 +94,7 @@ using std::string;
   X(dpo)                                 \
   X(fin)                                 \
   X(par)                                 \
+  X(rcx)                                 \
   X(odb)
 
 #define FOREACH_TOOL(X)            \

--- a/src/rcx/src/CMakeLists.txt
+++ b/src/rcx/src/CMakeLists.txt
@@ -84,3 +84,24 @@ messages(
   TARGET rcx
   OUTPUT_DIR ..
 )
+
+if (Python3_FOUND AND BUILD_PYTHON)
+  swig_lib(NAME          rcx_py
+           NAMESPACE     rcx
+           LANGUAGE      python
+           I_FILE        ext-py.i
+           SWIG_INCLUDES ${PROJECT_SOURCE_DIR}/../include
+           SCRIPTS       ${CMAKE_CURRENT_BINARY_DIR}/rcx_py.py
+  )
+
+  target_include_directories(rcx_py
+    PUBLIC
+      ../include
+  )
+
+  target_link_libraries(rcx_py
+    PUBLIC
+      rcx
+  )
+
+endif()

--- a/src/rcx/src/ext-py.i
+++ b/src/rcx/src/ext-py.i
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2022, The Regents of the University of California
+// All rights reserved.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+///////////////////////////////////////////////////////////////////////////////
+
+%{
+#include "ord/OpenRoad.hh"
+#include "rcx/ext.h"
+
+using namespace odb;
+using rcx::Ext;
+%}
+
+%include "../../Exception-py.i"
+
+// Swig can't seem to find this on its own
+namespace odb {
+typedef int uint;
+} 
+
+%include "rcx/ext.h"

--- a/src/rcx/src/ext-py.i
+++ b/src/rcx/src/ext-py.i
@@ -42,9 +42,58 @@ using rcx::Ext;
 
 %include "../../Exception-py.i"
 
-// Swig can't seem to find this on its own
-namespace odb {
-typedef int uint;
-} 
+// Just reuse the api defined in ext.i
+%inline %{
 
-%include "rcx/ext.h"
+void define_process_corner(int ext_model_index, const char* file);
+
+void extract(const char* ext_model_file,
+             int corner_cnt,
+             double max_res,
+             float coupling_threshold,
+             int signal_table,
+             int cc_model,
+             int context_depth,
+             const char* debug_net_id,
+             bool lef_res,
+             bool no_merge_via_res);
+
+void write_spef(const char* file, const char* nets, int net_id);
+
+void adjust_rc(double res_factor,
+               double cc_factor,
+               double gndc_factor);
+
+void diff_spef(const char* file,
+               bool r_conn,
+               bool r_res,
+               bool r_cap,
+               bool r_cc_cap);
+
+void bench_wires(bool db_only,
+                 bool over,
+                 bool diag,
+                 bool all,
+                 int met_cnt,
+                 int cnt,
+                 int len,
+                 int under_met,
+                 const char* w_list,
+                 const char* s_list,
+                 int over_dist,
+                 int under_dist);
+
+void bench_verilog(const char* file);
+
+void write_rules(const char* file,
+                 const char* dir,
+                 const char* name,
+                 int pattern,
+                 bool read_from_db,
+                 bool read_from_solver);
+
+void read_spef(const char* file);
+
+%}
+
+

--- a/src/rcx/test/45_gcd.py
+++ b/src/rcx/test/45_gcd.py
@@ -1,0 +1,26 @@
+from openroad import Design, Tech
+import rcx_aux
+import helpers
+import via_45_resistance as via_45
+
+test_nets = ""
+
+tech = Tech()
+tech.readLef("Nangate45/Nangate45.lef")
+tech.readLiberty("Nangate45/Nangate45_typ.lib")
+
+design = Design(tech)
+design.readDef("45_gcd.def")
+
+# Load via resistance info
+via_45.set_resistance(tech)
+
+rcx_aux.define_process_corner(ext_model_index=0, filename="X")
+
+rcx_aux.extract_parasitics(ext_model_file="45_patterns.rules",
+                           max_res=0, coupling_threshold=0.1)
+
+spef_file = helpers.make_result_file("45_gcd.spef")
+rcx_aux.write_spef(filename=spef_file, nets=test_nets)
+
+helpers.diff_files("45_gcd.spefok", spef_file)

--- a/src/rcx/test/ext_pattern.py
+++ b/src/rcx/test/ext_pattern.py
@@ -1,0 +1,20 @@
+from openroad import Design, Tech
+import helpers
+import rcx_aux
+
+test_nets = "3 48 92 193 200 243 400 521 671"
+
+tech = Tech()
+tech.readLef("sky130hs/sky130hs.tlef")
+design = Design(tech)
+design.readDef("generate_pattern.defok")
+
+rcx_aux.define_process_corner(ext_model_index=0, filename="X")
+
+rcx_aux.extract_parasitics(ext_model_file="ext_pattern.rules",
+                           cc_model=12, max_res=0, context_depth=10,
+                           coupling_threshold=0.1)
+
+spef_file = helpers.make_result_file("ext_pattern.spef")
+rcx_aux.write_spef(filename=spef_file, nets=test_nets)
+helpers.diff_files("ext_pattern.spefok", spef_file)

--- a/src/rcx/test/gcd.py
+++ b/src/rcx/test/gcd.py
@@ -1,0 +1,26 @@
+from openroad import Design, Tech
+import helpers
+import rcx_aux
+
+tech = Tech()
+tech.readLef("sky130hs/sky130hs.tlef")
+tech.readLef("sky130hs/sky130hs_std_cell.lef")
+tech.readLiberty("sky130hs/sky130hs_tt.lib")
+
+test_nets = ""
+
+design = Design(tech)
+design.readDef("gcd.def")
+
+# This uses 'set_layer_rc' which is in rsz which has not yet been
+# Python wrapped. Remove when rsz has been wrapped
+design.evalTclString("source sky130hs/sky130hs.rc")
+
+rcx_aux.define_process_corner(ext_model_index=0, filename="X")
+
+rcx_aux.extract_parasitics(ext_model_file="ext_pattern.rules", max_res=0,
+                           coupling_threshold=0.1)
+
+spef_file = helpers.make_result_file("gcd.spef")
+rcx_aux.write_spef(filename=spef_file, nets=test_nets)
+helpers.diff_files("gcd.spefok", spef_file)

--- a/src/rcx/test/generate_pattern.py
+++ b/src/rcx/test/generate_pattern.py
@@ -1,0 +1,20 @@
+from openroad import Design, Tech
+import helpers
+import rcx_aux
+
+tech = Tech()
+tech.readLef("sky130hs/sky130hs.tlef")
+design = Design(tech)
+
+rcx_aux.bench_wires(len=100, all=True)
+
+def_file = helpers.make_result_file("generate_pattern.def")
+
+verilog_file = helpers.make_result_file("generate_pattern.v")
+
+rcx_aux.bench_verilog(filename=verilog_file)
+
+design.writeDef(def_file)
+
+helpers.diff_files("generate_pattern.defok", def_file)
+helpers.diff_files("generate_pattern.vok", verilog_file)

--- a/src/rcx/test/helpers.py
+++ b/src/rcx/test/helpers.py
@@ -1,0 +1,1 @@
+../../../test/helpers.py

--- a/src/rcx/test/rcx_aux.py
+++ b/src/rcx/test/rcx_aux.py
@@ -1,0 +1,88 @@
+import utl
+import rcx
+
+# Thin wrapper over api defined in ext.i (and reused by ext-py.i)
+# Ensure keywords only and provide defaults when appropriate
+
+
+def define_process_corner(*, ext_model_index=0, filename=""):
+    rcx.define_process_corner(ext_model_index, filename)
+
+
+def extract_parasitics(*, ext_model_file=None,
+                       corner_cnt=1,
+                       max_res=50.0,
+                       coupling_threshold=0.1,
+                       signal_table=3,
+                       debug_net_id="",
+                       lef_res=False,
+                       cc_model=10,
+                       context_depth=5,
+                       no_merge_via_res=False
+                       ):
+    # NOTE: This is position dependent
+    rcx.extract(ext_model_file,
+                corner_cnt,
+                max_res,
+                coupling_threshold,
+                signal_table,
+                cc_model,                
+                context_depth,
+                debug_net_id,
+                lef_res,
+                no_merge_via_res)
+
+
+def write_spef(*, filename="", nets="", net_id=0):
+    rcx.write_spef(filename, nets, net_id)
+
+
+def bench_verilog(*, filename=""):
+    rcx.bench_verilog(filename)
+
+
+def bench_wires(*,
+                met_cnt=1000,
+                cnt=5,
+                len=100,
+                over=False,
+                diag=False,
+                all=False,
+                db_only=False,
+                under_met=-1,
+                w_list="1",
+                s_list="1 2 2.5 3 3.5 4 4.5 5 6 8 10 12",
+                over_dist=100,
+                under_dist=100):
+    rcx.bench_wires(db_only, over, diag, all, met_cnt, cnt, len, under_met,
+                    w_list, s_list, over_dist, under_dist)
+
+
+def adjust_rc(*, res_factor=1.0,
+              cc_factor=1.0,
+              gndc_factor=1.0):
+    rcx.adjust_rc(res_factor, cc_factor, gndc_factor)
+
+
+def diff_spef(*, filename="",
+              r_conn=False,
+              r_res=False,
+              r_cap=False,
+              r_cc_cap=False):
+    rcx.diff_spef(filename, r_conn, r_res, r_cap, r_cc_cap)    
+
+
+def write_rules(*,
+                filename="extRules",
+                dir="./",
+                name="TYP",
+                pattern=0,
+                read_from_db=False,
+                read_from_solver=False):
+    rcx.write_rules(filename, dir, name, pattern,
+                    read_from_db, read_from_solver)
+
+
+def read_spef(*, filename):
+    rcx.read_spef(filename)
+

--- a/src/rcx/test/via_45_resistance.py
+++ b/src/rcx/test/via_45_resistance.py
@@ -1,0 +1,13 @@
+import helpers  # only for setting logging
+
+def set_resistance(tech):
+    layer = tech.getDB().getTech().findLayer
+    layer("via1").setResistance(5)
+    layer("via2").setResistance(5)
+    layer("via3").setResistance(5)
+    layer("via4").setResistance(3)
+    layer("via5").setResistance(3)
+    layer("via6").setResistance(3)
+    layer("via7").setResistance(1)
+    layer("via8").setResistance(1)
+    layer("via9").setResistance(0.5)


### PR DESCRIPTION
Python wrapper for rcx. A slightly different approach was used here. The ext.h header file makes heavy use of various Options structures. But these are defined inside of the Ext class and SWIG will not wrap them there. We can try to think about duplicating them in global scope by .i file hacking, but then we run afoul of "const char *" declarations.  So the easier path is to just use the api that is defined in ext.i