### PR TITLE
Python wrapper and regression tests for rmp

### DIFF
--- a/include/ord/Design.h
+++ b/include/ord/Design.h
@@ -101,6 +101,10 @@ namespace rcx {
 class Ext;
 }
 
+namespace rmp {
+class Restructure;
+}
+
 namespace ord {
 
 class Tech;
@@ -145,6 +149,7 @@ class Design
   fin::Finale* getFinale();
   par::PartitionMgr* getPartitionMgr();
   rcx::Ext* getOpenRCX();
+  rmp::Restructure* getRestructure();
 
  private:
   Tech* tech_;

--- a/include/ord/Tech.h
+++ b/include/ord/Tech.h
@@ -45,6 +45,13 @@ namespace utl {
 class Logger;
 }
 
+namespace sta {
+class dbSta;
+class dbNetwork;
+class Resizer;
+class LibertyCell;
+}  // namespace sta
+
 namespace ord {
 
 class Tech
@@ -54,6 +61,7 @@ class Tech
   void readLef(const std::string& file_name);
   void readLiberty(const std::string& file_name);
   odb::dbDatabase* getDB();
+  sta::dbSta* getSta();
 
  private:
   odb::dbDatabase* db_;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -396,6 +396,7 @@ if (Python3_FOUND AND BUILD_PYTHON)
     fin_py
     par_py
     rcx_py
+    rmp_py
   )
 else()
   message(STATUS "Python3 disabled")

--- a/src/Design.cc
+++ b/src/Design.cc
@@ -222,4 +222,10 @@ rcx::Ext* Design::getOpenRCX()
   return app->getOpenRCX();
 }
 
+rmp::Restructure* Design::getRestructure()
+{
+  auto app = OpenRoad::openRoad();
+  return app->getRestructure();
+}
+
 }  // namespace ord

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -95,6 +95,7 @@ using std::string;
   X(fin)                                 \
   X(par)                                 \
   X(rcx)                                 \
+  X(rmp)                                 \
   X(odb)
 
 #define FOREACH_TOOL(X)            \

--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -72,3 +72,30 @@ target_link_libraries(rmp
     utl
     ${ABC_LIBRARY}
  )
+
+if (Python3_FOUND AND BUILD_PYTHON)
+  swig_lib(NAME          rmp_py
+           NAMESPACE     rmp
+           LANGUAGE      python
+           I_FILE        rmp-py.i
+           SWIG_INCLUDES ${PROJECT_SOURCE_DIR}/../include
+                         ${ODB_HOME}/src/swig/common
+                         ${ODB_HOME}/src/swig/python
+           SCRIPTS       ${CMAKE_CURRENT_BINARY_DIR}/rmp_py.py
+  )
+
+  target_include_directories(rmp_py
+    PUBLIC
+      ../include
+  )
+
+  target_link_libraries(rmp_py
+    PUBLIC
+      rmp
+      odb
+      dbSta
+      OpenSTA
+      rsz
+  )
+
+endif()

--- a/src/rmp/src/blif.cpp
+++ b/src/rmp/src/blif.cpp
@@ -96,6 +96,11 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
 
   std::ofstream f(file_name);
 
+  // These always need to be done before writing blif
+  open_sta_->ensureGraph();
+  open_sta_->ensureLevelized();
+  open_sta_->searchPreamble();
+
   if (f.bad()) {
     logger_->error(RMP, 1, "Cannot open file {}.", file_name);
     return false;

--- a/src/rmp/src/rmp-py.i
+++ b/src/rmp/src/rmp-py.i
@@ -1,9 +1,9 @@
 /////////////////////////////////////////////////////////////////////////////
 //
+// BSD 3-Clause License
+//
 // Copyright (c) 2022, The Regents of the University of California
 // All rights reserved.
-//
-// BSD 3-Clause License
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -33,60 +33,33 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "ord/Tech.h"
-
-#include "db_sta/dbSta.hh"
-#include "odb/db.h"
-#include "odb/lefin.h"
+%{
+#include "rmp/Restructure.h"
+#include "rmp/blif.h"
 #include "ord/OpenRoad.hh"
+#include "odb/db.h"
+#include "sta/Liberty.hh"
+#include <string>
 
 namespace ord {
+// Defined in OpenRoad.i
+rmp::Restructure *
+getRestructure();
 
-Tech::Tech()
-{
-  auto app = OpenRoad::openRoad();
-  db_ = app->getDb();
+OpenRoad *
+getOpenRoad();
 }
 
-odb::dbDatabase* Tech::getDB()
-{
-  return db_;
-}
+using namespace rmp;
+using ord::getRestructure;
+using ord::getOpenRoad;
+using odb::dbInst;
+using sta::LibertyPort;
+%}
 
-void Tech::readLef(const std::string& file_name)
-{
-  auto app = OpenRoad::openRoad();
-  const bool make_tech = db_->getTech() == nullptr;
-  const bool make_library = true;
-  std::string lib_name = file_name;
+%include "../../Exception-py.i"
 
-  // Hacky but easier than dealing with stdc++fs linking
-  auto slash_pos = lib_name.find_last_of('/');
-  if (slash_pos != std::string::npos) {
-    lib_name.erase(0, slash_pos + 1);
-  }
-  auto dot_pos = lib_name.find_last_of('.');
-  if (dot_pos != std::string::npos) {
-    lib_name.erase(lib_name.begin() + dot_pos, lib_name.end());
-  }
-
-  app->readLef(file_name.c_str(), lib_name.c_str(), make_tech, make_library);
-}
-
-void Tech::readLiberty(const std::string& file_name)
-{
-  auto sta = OpenRoad::openRoad()->getSta();
-  // TODO: take corner & min/max args
-  sta->readLiberty(file_name.c_str(),
-                   sta->cmdCorner(),
-                   sta::MinMaxAll::all(),
-                   true /* infer_latches */);
-}
-
-sta::dbSta* Tech::getSta()
-{
-  auto sta = OpenRoad::openRoad()->getSta();
-  return sta;
-}
-
-}  // namespace ord
+%include <typemaps.i>
+%include <std_string.i>
+%include "rmp/blif.h"
+%include "rmp/Restructure.h"

--- a/src/rmp/src/rmp.i
+++ b/src/rmp/src/rmp.i
@@ -91,9 +91,6 @@ void blif_add_instance(Blif* blif_, const char* inst_){
 }
 
 void blif_dump(Blif* blif_, const char* file_name){
-  getOpenRoad()->getSta()->ensureGraph();
-  getOpenRoad()->getSta()->ensureLevelized();
-  getOpenRoad()->getSta()->searchPreamble();
   blif_->writeBlif(file_name);
 }
 

--- a/src/rmp/test/blif_reader.py
+++ b/src/rmp/test/blif_reader.py
@@ -1,0 +1,34 @@
+from openroad import Design, Tech
+import helpers
+import rmp_aux
+import rmp
+
+tech = Tech()
+design = Design(tech)
+
+blif = rmp_aux.create_blif(design,
+                           hicell="LOGIC1_X1",
+                           hiport="Z",
+                           locell="LOGIC0_X1",
+                           loport="Z")
+
+tech.readLef("./Nangate45/Nangate45.lef")
+tech.readLiberty("./Nangate45/Nangate45_typ.lib")
+design.readDef("design_in_out.def")
+
+block = design.getBlock()
+
+blif.addReplaceableInstance(block.findInst("_i1_"))
+blif.addReplaceableInstance(block.findInst("_i2_"))
+blif.addReplaceableInstance(block.findInst("_i3_"))
+blif.addReplaceableInstance(block.findInst("_i4_"))
+blif.addReplaceableInstance(block.findInst("_i5_"))
+blif.addReplaceableInstance(block.findInst("_i6_"))
+blif.addReplaceableInstance(block.findInst("_i7_"))
+blif.addReplaceableInstance(block.findInst("_i8_"))
+
+blif.readBlif("./blif_reader.blif", block)
+
+def_file = helpers.make_result_file("blif_reader.def")
+design.writeDef(def_file)
+helpers.diff_files(def_file, "blif_reader.def.ok")

--- a/src/rmp/test/blif_writer.py
+++ b/src/rmp/test/blif_writer.py
@@ -1,0 +1,22 @@
+from openroad import Design, Tech
+import helpers
+import rmp_aux
+import rmp
+
+tech = Tech()
+tech.readLef("./Nangate45/Nangate45.lef")
+tech.readLiberty("./Nangate45/Nangate45_typ.lib")
+design = Design(tech)
+design.readDef("./design.def")
+
+blif = rmp_aux.create_blif(design)
+
+blif.addReplaceableInstance(design.getBlock().findInst("_i1_"))
+blif.addReplaceableInstance(design.getBlock().findInst("_i2_"))
+blif.addReplaceableInstance(design.getBlock().findInst("_i3_"))
+
+blif_file = helpers.make_result_file("blif_writer.blif")
+
+blif.writeBlif(blif_file)
+
+helpers.diff_files(blif_file, "blif_writer.blif.ok")

--- a/src/rmp/test/const_cell_removal.py
+++ b/src/rmp/test/const_cell_removal.py
@@ -1,0 +1,20 @@
+from openroad import Design, Tech, set_thread_count
+import helpers
+import rmp_aux
+
+tech = Tech()
+tech.readLiberty("Nangate45/Nangate45_typ.lib")
+tech.readLef("Nangate45/Nangate45.lef")
+
+design = Design(tech)
+design.readDef("rcon.def")
+design.evalTclString("read_sdc rcon.sdc")
+design.evalTclString("report_design_area")
+
+tiehi = "LOGIC1_X1/Z"
+tielo = "LOGIC0_X1/Z"
+
+rmp_aux.restructure(design, liberty_file_name="Nangate45/Nangate45_typ.lib", target="area",
+                    abc_logfile="results/abc_rcon.log",  tielo_port=tielo, tiehi_port=tiehi)
+
+design.evalTclString("report_design_area")

--- a/src/rmp/test/gcd_restructure.py
+++ b/src/rmp/test/gcd_restructure.py
@@ -1,0 +1,30 @@
+from openroad import Design, Tech, set_thread_count
+import helpers
+import rmp_aux
+
+tech = Tech()
+tech.readLiberty("Nangate45/Nangate45_typ.lib")
+tech.readLef("Nangate45/Nangate45.lef")
+
+design = Design(tech)
+design.readDef("gcd_placed.def")
+
+# read_sdc is defined in sta/tcl/Sdc.tcl (not yet wrapped)
+design.evalTclString("read_sdc gcd.sdc")
+
+# set_wire_rc and estimate_parasitics are both defined in rsz (not yet wrapped)
+design.evalTclString("set_wire_rc -layer metal3")
+design.evalTclString("estimate_parasitics -placement")
+design.evalTclString("report_worst_slack")
+design.evalTclString("report_design_area")
+
+tiehi = "LOGIC1_X1/Z"
+tielo = "LOGIC0_X1/Z"
+
+set_thread_count(3)
+
+rmp_aux.restructure(design, liberty_file_name="Nangate45/Nangate45_typ.lib", target="area",
+                    abc_logfile="results/abc_rcon.log", tielo_port=tielo, tiehi_port=tiehi,
+                    workdir_name="./results")
+
+design.evalTclString("report_design_area")

--- a/src/rmp/test/helpers.py
+++ b/src/rmp/test/helpers.py
@@ -1,0 +1,1 @@
+../../../test/helpers.py

--- a/src/rmp/test/rmp_aux.py
+++ b/src/rmp/test/rmp_aux.py
@@ -1,0 +1,68 @@
+import utl
+from string import Template
+import rmp
+
+# So, getting back objects from evalTclString is not supported and we
+# end up with this... These lib pins appear to be Liberty lib pins,
+# and it doesn't look like I can use odb to get these objects. 
+# Must wait until sta is wrapped?
+#
+# To be used with this substition dict, where portname is a string
+# {'tielohi_port': portname, 'tie' : 'hi'} or
+# {'tielohi_port': portname, 'tie' : 'lo'}
+lohitemp = Template('''set lohiport $tielohi_port
+      if { ![sta::is_object $$lohiport] } {
+        set lohiport [sta::get_lib_pins $tielohi_port]
+        if { [llength $$lohiport] > 1 } {
+          # multiple libraries match the lib port arg; use any
+          set lohiport [lindex $$lohiport 0]
+        }
+      }
+      if { $$lohiport != "" } {
+        rmp::set_tie${tie}_port_cmd $$lohiport
+      }
+    ''')
+
+
+def set_tiehi(design, tiehi_port):
+    if tiehi_port == None:
+        utl.error(utl.RMP, 301, "Must specify a tiehi_port")
+    tieHiport = design.evalTclString(
+        lohitemp.substitute({'tielohi_port' : tiehi_port, 'tie': 'hi'}))
+
+
+def set_tielo(design, tielo_port):
+    if tielo_port == None:
+        utl.error(utl.RMP, 302, "Must specify a tielo_port")
+    tieLoport = design.evalTclString(
+        lohitemp.substitute({'tielohi_port' : tielo_port,'tie': 'lo'}))
+
+
+def restructure(design, *,
+                liberty_file_name="",
+                target="area",
+                slack_threshold=0.0,
+                depth_threshold=16,
+                workdir_name=".",
+                tielo_port=None,
+                tiehi_port=None,
+                abc_logfile=""):
+    rst = design.getRestructure()
+    set_tielo(design, tielo_port)
+    set_tiehi(design, tiehi_port)
+    rst.setMode(target)
+    rst.run(liberty_file_name,
+            slack_threshold,
+            depth_threshold,
+            workdir_name,
+            abc_logfile)
+
+
+def create_blif(design, *, hicell="", hiport="", locell="", loport=""):
+    logger = design.getLogger()
+    sta = design.getTech().getSta()
+    return rmp.Blif(logger, sta, locell, loport, hicell, hiport)
+
+
+def blif_read(design, blif, filename):
+    return blif.readBlif(filename, design.getBlock())


### PR DESCRIPTION
Signed-off-by: Don MacMillen <don@macmillen.net>
rmp makes significant use of sta, so there was some things to address that. The constructor for Blif needs the pointer to a sta object, so getSta() was added to the Tech object (seemed better here than on the Design Object).  For the time being, this is an opaque pointer that is only passed to the Blif constructor. Also, there were some graph consistency checking / repair that needs to happen before writeBlif. Moved them from C++ code in an interface file into the body of the C++ method writeBlif (where they belong). Finally, since we needed sta::get_lib_pins (which gets pins from a Liberty library) and there was no obvious way to use odb for that, had to do some moderately ugly Python string Template hacking in order to use evalTclString 