### PR TITLE
gui: decouple script widget and tcl input widget

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -31,6 +31,7 @@ if (Qt5_FOUND AND BUILD_GUI)
     src/layoutViewer.cpp
     src/mainWindow.cpp
     src/scriptWidget.cpp
+    src/cmdInputWidget.cpp
     src/tclCmdInputWidget.cpp
     src/tclCmdHighlighter.cpp
     src/displayControls.cpp

--- a/src/gui/src/cmdInputWidget.cpp
+++ b/src/gui/src/cmdInputWidget.cpp
@@ -68,9 +68,9 @@ CmdInputWidget::~CmdInputWidget()
 {
 }
 
-void CmdInputWidget::setFont(const QFont& font)
+void CmdInputWidget::setWidgetFont(const QFont& font)
 {
-  QPlainTextEdit::setFont(font);
+  setFont(font);
 
   determineLineHeight();
 }
@@ -201,7 +201,7 @@ void CmdInputWidget::setText(const QString& text)
   emit textChanged();
 }
 
-void CmdInputWidget::setMaximumHeight(int height)
+void CmdInputWidget::setMaxHeight(int height)
 {
   const int min_height = line_height_ + document_margins_;  // atleast one line
   if (height < min_height) {
@@ -210,7 +210,7 @@ void CmdInputWidget::setMaximumHeight(int height)
 
   // save max height, since it's overwritten by setFixedHeight
   max_height_ = height;
-  QPlainTextEdit::setMaximumHeight(height);
+  setMaximumHeight(height);
 
   updateSize();
 }

--- a/src/gui/src/cmdInputWidget.cpp
+++ b/src/gui/src/cmdInputWidget.cpp
@@ -1,0 +1,250 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, The Regents of the University of California
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "cmdInputWidget.h"
+
+#include <QMimeData>
+#include <QTextStream>
+
+namespace gui {
+
+CmdInputWidget::CmdInputWidget(const QString& interp_name, QWidget* parent)
+    : QPlainTextEdit(parent),
+      line_height_(0),
+      document_margins_(0),
+      max_height_(QWIDGETSIZE_MAX),
+      history_(),
+      history_buffer_last_(),
+      historyPosition_(0)
+{
+  setObjectName("interperter_scripting");  // for settings
+  setPlaceholderText(interp_name + " commands");
+  setAcceptDrops(true);
+
+  determineLineHeight();
+
+  // precompute size for updating text box size
+  document_margins_ = 2 * (document()->documentMargin() + 3);
+
+  connect(this, SIGNAL(textChanged()), this, SLOT(updateSize()));
+  updateSize();
+
+  connect(this,
+          SIGNAL(commandFinishedExecuting(bool)),
+          this,
+          SLOT(commandFinished(bool)));
+}
+
+CmdInputWidget::~CmdInputWidget()
+{
+}
+
+void CmdInputWidget::setFont(const QFont& font)
+{
+  QPlainTextEdit::setFont(font);
+
+  determineLineHeight();
+}
+
+void CmdInputWidget::determineLineHeight()
+{
+  const QFontMetrics font_metrics = fontMetrics();
+  line_height_ = font_metrics.lineSpacing();
+
+  double tab_indent_width = 2 * font_metrics.averageCharWidth();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+  // setTabStopWidth deprecated in 5.10
+  setTabStopDistance(tab_indent_width);
+#else
+  setTabStopWidth(tab_indent_width);
+#endif
+}
+
+bool CmdInputWidget::handleHistoryKeyPress(QKeyEvent* event)
+{
+  const int key = event->key();
+
+  // handle regular command typing
+  const bool has_control = event->modifiers().testFlag(Qt::ControlModifier);
+
+  if (key == Qt::Key_Down) {
+    // Handle down through history
+    // control+down immediate
+    if ((!textCursor().hasSelection()
+         && !textCursor().movePosition(QTextCursor::Down))
+        || has_control) {
+      goForwardHistory();
+      return true;
+    }
+  } else if (key == Qt::Key_Up) {
+    // Handle up through history
+    // control+up immediate
+    if ((!textCursor().hasSelection()
+         && !textCursor().movePosition(QTextCursor::Up))
+        || has_control) {
+      goBackHistory();
+      return true;
+    }
+  }
+
+  return false;
+}
+
+// Update the size of the widget to match text
+void CmdInputWidget::updateSize()
+{
+  int height = document()->size().toSize().height();
+  if (height < 1) {
+    height = 1;  // ensure minimum is 1 line
+  }
+
+  // in px
+  int desired_height = height * line_height_ + document_margins_;
+
+  if (desired_height > max_height_) {
+    desired_height = max_height_;  // ensure maximum from Qt suggestion
+  }
+
+  setFixedHeight(desired_height);
+
+  ensureCursorVisible();
+}
+
+// Handle dragged and drop script files
+void CmdInputWidget::dragEnterEvent(QDragEnterEvent* event)
+{
+  if (event->mimeData()->text().startsWith("file://")) {
+    event->accept();
+  }
+}
+
+void CmdInputWidget::dropEvent(QDropEvent* event)
+{
+  if (event->mimeData()->text().startsWith("file://")) {
+    event->accept();
+
+    // replace the content in the text area with the file
+    QFile drop_file(event->mimeData()->text().remove(0, 7).simplified());
+    if (drop_file.open(QIODevice::ReadOnly)) {
+      QTextStream file_data(&drop_file);
+      setText(file_data.readAll());
+      drop_file.close();
+    }
+  }
+}
+
+// replicate QLineEdit function
+QString CmdInputWidget::text() const
+{
+  return toPlainText();
+}
+
+// replicate QLineEdit function
+void CmdInputWidget::setText(const QString& text)
+{
+  setPlainText(text);
+  emit textChanged();
+}
+
+void CmdInputWidget::setMaximumHeight(int height)
+{
+  const int min_height = line_height_ + document_margins_;  // atleast one line
+  if (height < min_height) {
+    height = min_height;
+  }
+
+  // save max height, since it's overwritten by setFixedHeight
+  max_height_ = height;
+  QPlainTextEdit::setMaximumHeight(height);
+
+  updateSize();
+}
+
+void CmdInputWidget::readSettings(QSettings* settings)
+{
+  settings->beginGroup(objectName());
+  history_ = settings->value("history").toStringList();
+  historyPosition_ = history_.size();
+  settings->endGroup();
+}
+
+void CmdInputWidget::writeSettings(QSettings* settings)
+{
+  settings->beginGroup(objectName());
+  settings->setValue("history", history_);
+  settings->endGroup();
+}
+
+void CmdInputWidget::goForwardHistory()
+{
+  if (historyPosition_ < history_.size() - 1) {
+    ++historyPosition_;
+    setText(history_[historyPosition_]);
+  } else if (historyPosition_ == history_.size() - 1) {
+    ++historyPosition_;
+    setText(history_buffer_last_);
+  }
+}
+
+void CmdInputWidget::goBackHistory()
+{
+  if (historyPosition_ > 0) {
+    if (historyPosition_ == history_.size()) {
+      // whats in the buffer is the last thing the user was editing
+      history_buffer_last_ = text();
+    }
+    --historyPosition_;
+    setText(history_[historyPosition_]);
+  }
+}
+
+void CmdInputWidget::addCommandToHistory(const QString& command)
+{
+  // Update history; ignore repeated commands and keep last 100
+  const int history_limit = 100;
+  if (history_.empty() || command != history_.last()) {
+    if (history_.size() == history_limit) {
+      history_.pop_front();
+    }
+    history_.append(command);
+  }
+  historyPosition_ = history_.size();
+}
+
+void CmdInputWidget::commandFinished(bool is_ok)
+{
+  if (is_ok) {
+    clear();
+  }
+}
+
+}  // namespace gui

--- a/src/gui/src/cmdInputWidget.cpp
+++ b/src/gui/src/cmdInputWidget.cpp
@@ -119,6 +119,32 @@ bool CmdInputWidget::handleHistoryKeyPress(QKeyEvent* event)
   return false;
 }
 
+bool CmdInputWidget::handleEnterKeyPress(QKeyEvent* event)
+{
+  const int key = event->key();
+
+  // handle regular command typing
+  const bool has_control = event->modifiers().testFlag(Qt::ControlModifier);
+  if (key == Qt::Key_Enter || key == Qt::Key_Return) {
+    // Handle enter
+    if (has_control) {
+      // don't execute just insert the newline
+      // does not get inserted by Qt, so manually inserting
+      insertPlainText("\n");
+      return true;
+    } else {
+      // Check if command complete and attempt to execute, otherwise do nothing
+      if (isCommandComplete(toPlainText().simplified().toStdString())) {
+        // execute command
+        executeCommand(text());
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 // Update the size of the widget to match text
 void CmdInputWidget::updateSize()
 {

--- a/src/gui/src/cmdInputWidget.h
+++ b/src/gui/src/cmdInputWidget.h
@@ -79,8 +79,11 @@ class CmdInputWidget : public QPlainTextEdit
   void dragEnterEvent(QDragEnterEvent* event) override;
   void dropEvent(QDropEvent* event) override;
   bool handleHistoryKeyPress(QKeyEvent* event);
+  bool handleEnterKeyPress(QKeyEvent* event);
 
   void addCommandToHistory(const QString& command);
+
+  virtual bool isCommandComplete(const std::string& cmd) const = 0;
 
  private:
   // back in history

--- a/src/gui/src/cmdInputWidget.h
+++ b/src/gui/src/cmdInputWidget.h
@@ -46,12 +46,12 @@ class CmdInputWidget : public QPlainTextEdit
   CmdInputWidget(const QString& interp_name, QWidget* parent = nullptr);
   virtual ~CmdInputWidget();
 
-  void setFont(const QFont& font);
+  void setWidgetFont(const QFont& font);
 
   QString text() const;
   void setText(const QString& text);
 
-  void setMaximumHeight(int height);
+  void setMaxHeight(int height);
 
   void readSettings(QSettings* settings);
   void writeSettings(QSettings* settings);

--- a/src/gui/src/cmdInputWidget.h
+++ b/src/gui/src/cmdInputWidget.h
@@ -1,0 +1,103 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2022, The Regents of the University of California
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <QPlainTextEdit>
+#include <QSettings>
+#include <QStringList>
+
+namespace gui {
+
+class CmdInputWidget : public QPlainTextEdit
+{
+  Q_OBJECT
+
+ public:
+  CmdInputWidget(const QString& interp_name, QWidget* parent = nullptr);
+  virtual ~CmdInputWidget();
+
+  void setFont(const QFont& font);
+
+  QString text() const;
+  void setText(const QString& text);
+
+  void setMaximumHeight(int height);
+
+  void readSettings(QSettings* settings);
+  void writeSettings(QSettings* settings);
+
+ signals:
+  void exiting();
+
+  void commandAboutToExecute();
+  void commandFinishedExecuting(bool is_ok);
+
+  void addResultToOutput(const QString& result, bool is_ok);
+  void addCommandToOutput(const QString& cmd);
+
+ public slots:
+  virtual void executeCommand(const QString& cmd,
+                              bool echo = true,
+                              bool silent = false)
+      = 0;
+
+ private slots:
+  void updateSize();
+  void commandFinished(bool is_ok);
+
+ protected:
+  void dragEnterEvent(QDragEnterEvent* event) override;
+  void dropEvent(QDropEvent* event) override;
+  bool handleHistoryKeyPress(QKeyEvent* event);
+
+  void addCommandToHistory(const QString& command);
+
+ private:
+  // back in history
+  void goBackHistory();
+  // forward in history
+  void goForwardHistory();
+
+  void determineLineHeight();
+
+  int line_height_;
+  int document_margins_;
+
+  int max_height_;
+
+  QStringList history_;
+  QString history_buffer_last_;
+  int historyPosition_;
+};
+
+}  // namespace gui

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -515,7 +515,7 @@ LayoutViewer::LayoutViewer(Options* options,
           SLOT(setBlock(odb::dbBlock*)));
 
   connect(output_widget_,
-          SIGNAL(commandExecuted(int)),
+          SIGNAL(commandExecuted(bool)),
           this,
           SLOT(setResetRepaintInterval()));
   connect(output_widget_,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -132,7 +132,7 @@ MainWindow::MainWindow(QWidget* parent)
 
   // Hook up all the signals/slots
   connect(script_, SIGNAL(exiting()), this, SIGNAL(exit()));
-  connect(script_, SIGNAL(commandExecuted(int)), viewer_, SLOT(update()));
+  connect(script_, SIGNAL(commandExecuted(bool)), viewer_, SLOT(update()));
   connect(this,
           SIGNAL(designLoaded(odb::dbBlock*)),
           viewer_,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -131,7 +131,7 @@ MainWindow::MainWindow(QWidget* parent)
   clock_viewer_->hide();
 
   // Hook up all the signals/slots
-  connect(script_, SIGNAL(tclExiting()), this, SIGNAL(exit()));
+  connect(script_, SIGNAL(exiting()), this, SIGNAL(exit()));
   connect(script_, SIGNAL(commandExecuted(int)), viewer_, SLOT(update()));
   connect(this,
           SIGNAL(designLoaded(odb::dbBlock*)),

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -108,7 +108,7 @@ MainWindow::MainWindow(QWidget* parent)
 
   QFont font("Monospace");
   font.setStyleHint(QFont::Monospace);
-  script_->setFont(font);
+  script_->setWidgetFont(font);
 
   setCentralWidget(scroll_);
   addDockWidget(Qt::BottomDockWidgetArea, script_);

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -259,14 +259,14 @@ void ScriptWidget::addTextToOutput(const QString& text, const QColor& color)
 
 void ScriptWidget::readSettings(QSettings* settings)
 {
-  settings->beginGroup("scripting");
+  settings->beginGroup(objectName());
   input_->readSettings(settings);
   settings->endGroup();
 }
 
 void ScriptWidget::writeSettings(QSettings* settings)
 {
-  settings->beginGroup("scripting");
+  settings->beginGroup(objectName());
   input_->writeSettings(settings);
   settings->endGroup();
 }

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -80,17 +80,28 @@ ScriptWidget::ScriptWidget(QWidget* parent)
   container->setLayout(layout);
 
   connect(input_, SIGNAL(textChanged()), this, SLOT(outputChanged()));
-  connect(input_, SIGNAL(tclExiting()), this, SIGNAL(exiting()));
+
+  connect(input_, SIGNAL(exiting()), this, SIGNAL(exiting()));
+  connect(input_,
+          SIGNAL(commandAboutToExecute()),
+          this,
+          SIGNAL(commandAboutToExecute()));
   connect(input_,
           SIGNAL(commandAboutToExecute()),
           this,
           SLOT(setPauserToRunning()));
-  connect(
-      input_, SIGNAL(commandFinishedExecuting(int)), this, SLOT(resetPauser()));
   connect(input_,
-          SIGNAL(commandFinishedExecuting(int)),
+          SIGNAL(addCommandToOutput(const QString&)),
           this,
-          SIGNAL(commandExecuted(int)));
+          SLOT(addCommandToOutput(const QString&)));
+  connect(input_,
+          SIGNAL(commandFinishedExecuting(bool)),
+          this,
+          SLOT(resetPauser()));
+  connect(input_,
+          SIGNAL(commandFinishedExecuting(bool)),
+          this,
+          SIGNAL(commandExecuted(bool)));
   connect(output_, SIGNAL(textChanged()), this, SLOT(outputChanged()));
   connect(pauser_, SIGNAL(pressed()), this, SLOT(pauserClicked()));
   connect(pause_timer_.get(), SIGNAL(timeout()), this, SLOT(unpause()));

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -330,16 +330,15 @@ void ScriptWidget::bufferOutputs(bool state)
 
 void ScriptWidget::resizeEvent(QResizeEvent* event)
 {
-  input_->setMaximumHeight(event->size().height()
-                           - output_->sizeHint().height());
+  input_->setMaxHeight(event->size().height() - output_->sizeHint().height());
   QDockWidget::resizeEvent(event);
 }
 
-void ScriptWidget::setFont(const QFont& font)
+void ScriptWidget::setWidgetFont(const QFont& font)
 {
   QDockWidget::setFont(font);
   output_->setFont(font);
-  input_->setFont(font);
+  input_->setWidgetFont(font);
 }
 
 // This class is an spdlog sink that writes the messages into the output

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -122,11 +122,6 @@ class ScriptWidget : public QDockWidget
   void addReportToOutput(const QString& text);
   void addLogToOutput(const QString& text, const QColor& color);
 
-  static int tclExitHandler(ClientData instance_data,
-                            Tcl_Interp* interp,
-                            int argc,
-                            const char** argv);
-
   QPlainTextEdit* output_;
   TclCmdInputWidget* input_;
   QPushButton* pauser_;

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -79,7 +79,7 @@ class ScriptWidget : public QDockWidget
  signals:
   // Commands might have effects that others need to know
   // (eg change placement of an instance requires a redraw)
-  void commandExecuted(int return_code);
+  void commandExecuted(bool is_ok);
   void commandAboutToExecute();
   void executionPaused();
 

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -32,21 +32,21 @@
 
 #pragma once
 
-#include <tcl.h>
-
 #include <QDockWidget>
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSettings>
 
-#include "tclCmdInputWidget.h"
 #include "utl/Logger.h"
 
 namespace odb {
 class dbDatabase;
 }  // namespace odb
 
+class Tcl_Interp;
+
 namespace gui {
+class TclCmdInputWidget;
 
 // This shows a line edit to enter tcl commands and a
 // text area that is used to show the commands and their
@@ -85,7 +85,7 @@ class ScriptWidget : public QDockWidget
 
   // tcl exit has been initiated, want the gui to handle
   // shutdown
-  void tclExiting();
+  void exiting();
 
   void addToOutput(const QString& text, const QColor& color);
 
@@ -95,6 +95,9 @@ class ScriptWidget : public QDockWidget
 
   // Use to execute a command silently, ie. without echo or return.
   void executeSilentCommand(const QString& command);
+
+  void addResultToOutput(const QString& result, bool is_ok);
+  void addCommandToOutput(const QString& cmd);
 
  private slots:
   void outputChanged();
@@ -108,17 +111,16 @@ class ScriptWidget : public QDockWidget
 
   void addTextToOutput(const QString& text, const QColor& color);
 
+  void setPauserToRunning();
+  void resetPauser();
+
  protected:
   // required to ensure input command space it set to correct height
   void resizeEvent(QResizeEvent* event) override;
 
  private:
-  int executeTclCommand(const QString& command);
-
   void triggerPauseCountDown(int timeout);
 
-  void addCommandToOutput(const QString& cmd);
-  void addTclResultToOutput(int return_code);
   void addReportToOutput(const QString& text);
   void addLogToOutput(const QString& text, const QColor& color);
 
@@ -126,7 +128,6 @@ class ScriptWidget : public QDockWidget
   TclCmdInputWidget* input_;
   QPushButton* pauser_;
   std::unique_ptr<QTimer> pause_timer_;
-  Tcl_Interp* interp_;
   bool paused_;
   utl::Logger* logger_;
 
@@ -142,8 +143,8 @@ class ScriptWidget : public QDockWidget
   const int max_output_line_length_ = 1000;
 
   const QColor cmd_msg_ = Qt::black;
-  const QColor tcl_error_msg_ = Qt::red;
-  const QColor tcl_ok_msg_ = Qt::blue;
+  const QColor error_msg_ = Qt::red;
+  const QColor ok_msg_ = Qt::blue;
   const QColor buffer_msg_ = QColor(0x30, 0x30, 0x30);
 };
 

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -38,7 +38,6 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QSettings>
-#include <QStringList>
 
 #include "tclCmdInputWidget.h"
 #include "utl/Logger.h"
@@ -105,9 +104,6 @@ class ScriptWidget : public QDockWidget
 
   void pauserClicked();
 
-  void goBackHistory();
-  void goForwardHistory();
-
   void updatePauseTimeout();
 
   void addTextToOutput(const QString& text, const QColor& color);
@@ -136,9 +132,6 @@ class ScriptWidget : public QDockWidget
   QPushButton* pauser_;
   std::unique_ptr<QTimer> pause_timer_;
   Tcl_Interp* interp_;
-  QStringList history_;
-  QString history_buffer_last_;
-  int historyPosition_;
   bool paused_;
   utl::Logger* logger_;
 

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -72,7 +72,7 @@ class ScriptWidget : public QDockWidget
                 bool do_init_openroad,
                 const std::function<void(void)>& post_or_init);
 
-  void setFont(const QFont& font);
+  void setWidgetFont(const QFont& font);
 
   void bufferOutputs(bool state);
 

--- a/src/gui/src/tclCmdInputWidget.cpp
+++ b/src/gui/src/tclCmdInputWidget.cpp
@@ -414,7 +414,7 @@ void TclCmdInputWidget::init()
 }
 
 // replicate QLineEdit function
-QString TclCmdInputWidget::text()
+QString TclCmdInputWidget::text() const
 {
   return toPlainText();
 }

--- a/src/gui/src/tclCmdInputWidget.cpp
+++ b/src/gui/src/tclCmdInputWidget.cpp
@@ -154,24 +154,11 @@ void TclCmdInputWidget::keyPressEvent(QKeyEvent* e)
     return;
   }
 
-  // handle regular command typing
-  bool has_control = e->modifiers().testFlag(Qt::ControlModifier);
-  if (key == Qt::Key_Enter || key == Qt::Key_Return) {
-    // Handle enter
-    if (has_control) {
-      // don't execute just insert the newline
-      // does not get inserted by Qt, so manually inserting
-      insertPlainText("\n");
-      return;
-    } else {
-      // Check if command complete and attempt to execute, otherwise do nothing
-      if (isCommandComplete(toPlainText().simplified().toStdString())) {
-        // execute command
-        executeCommand(text());
-        return;
-      }
-    }
+  if (handleEnterKeyPress(e)) {
+    return;
   }
+
+  const bool has_control = e->modifiers().testFlag(Qt::ControlModifier);
 
   // handle completer
   if (completer_ == nullptr) {
@@ -258,10 +245,10 @@ void TclCmdInputWidget::keyReleaseEvent(QKeyEvent* e)
     emit textChanged();
   }
 
-  QPlainTextEdit::keyReleaseEvent(e);
+  CmdInputWidget::keyReleaseEvent(e);
 }
 
-bool TclCmdInputWidget::isCommandComplete(const std::string& cmd)
+bool TclCmdInputWidget::isCommandComplete(const std::string& cmd) const
 {
   if (cmd.empty()) {
     return false;

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -58,8 +58,9 @@ class TclCmdInputWidget : public QPlainTextEdit
   TclCmdInputWidget(QWidget* parent = nullptr);
   ~TclCmdInputWidget();
 
-  void setTclInterp(Tcl_Interp* interp);
-  void init();
+  void setTclInterp(Tcl_Interp* interp,
+                    bool do_init_openroad,
+                    const std::function<void(void)>& post_or_init);
 
   void setFont(const QFont& font);
 
@@ -71,16 +72,21 @@ class TclCmdInputWidget : public QPlainTextEdit
   void readSettings(QSettings* settings);
   void writeSettings(QSettings* settings);
 
- public slots:
-  void commandExecuted(int return_code);
-
  signals:
-  // complete TCL command available
-  void completeCommand(const QString& command);
-
   // tcl exit has been initiated, want the gui to handle
   // shutdown
   void tclExiting();
+
+  void commandAboutToExecute();
+  void commandFinishedExecuting(int code);
+
+  void addResultToOutput(const QString& result, int code);
+  void addCommandToOutput(const QString& cmd);
+
+ public slots:
+  void executeCommand(const QString& cmd,
+                      bool echo = true,
+                      bool silent = false);
 
  private slots:
   void updateSize();
@@ -103,7 +109,9 @@ class TclCmdInputWidget : public QPlainTextEdit
   // forward in history
   void goForwardHistory();
 
-  void setupTclHandler();
+  void init();
+  void processTclResult(int result_code);
+
   static int tclExitHandler(ClientData instance_data,
                             Tcl_Interp* interp,
                             int argc,

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -58,7 +58,8 @@ class TclCmdInputWidget : public QPlainTextEdit
   TclCmdInputWidget(QWidget* parent = nullptr);
   ~TclCmdInputWidget();
 
-  void init(Tcl_Interp* interp);
+  void setTclInterp(Tcl_Interp* interp);
+  void init();
 
   void setFont(const QFont& font);
 
@@ -76,6 +77,10 @@ class TclCmdInputWidget : public QPlainTextEdit
  signals:
   // complete TCL command available
   void completeCommand(const QString& command);
+
+  // tcl exit has been initiated, want the gui to handle
+  // shutdown
+  void tclExiting();
 
  private slots:
   void updateSize();
@@ -97,6 +102,12 @@ class TclCmdInputWidget : public QPlainTextEdit
   void goBackHistory();
   // forward in history
   void goForwardHistory();
+
+  void setupTclHandler();
+  static int tclExitHandler(ClientData instance_data,
+                            Tcl_Interp* interp,
+                            int argc,
+                            const char** argv);
 
   bool isCommandComplete(const std::string& cmd);
 
@@ -144,6 +155,7 @@ class TclCmdInputWidget : public QPlainTextEdit
   static constexpr const char* enable_highlighting_keyword_ = "highlighting";
   static constexpr const char* enable_completion_keyword_ = "completion";
   static const int completer_mimimum_length_ = 2;
+  static constexpr const char* command_rename_prefix_ = "::tcl::openroad::";
 };
 
 }  // namespace gui

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -63,7 +63,7 @@ class TclCmdInputWidget : public QPlainTextEdit
 
   void setFont(const QFont& font);
 
-  QString text();
+  QString text() const;
   void setText(const QString& text);
 
   void setMaximumHeight(int height);

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -82,6 +82,8 @@ class TclCmdInputWidget : public CmdInputWidget
   void keyPressEvent(QKeyEvent* e) override;
   void keyReleaseEvent(QKeyEvent* e) override;
 
+  virtual bool isCommandComplete(const std::string& cmd) const override;
+
  private:
   void init();
   void processTclResult(int result_code);
@@ -90,8 +92,6 @@ class TclCmdInputWidget : public CmdInputWidget
                             Tcl_Interp* interp,
                             int argc,
                             const char** argv);
-
-  bool isCommandComplete(const std::string& cmd);
 
   void initOpenRoadCommands();
   void parseOpenRoadArguments(const char* or_args, std::set<std::string>& args);

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -77,12 +77,6 @@ class TclCmdInputWidget : public QPlainTextEdit
   // complete TCL command available
   void completeCommand(const QString& command);
 
-  // back in history
-  void historyGoBack();
-
-  // forward in history
-  void historyGoForward();
-
  private slots:
   void updateSize();
 
@@ -95,10 +89,14 @@ class TclCmdInputWidget : public QPlainTextEdit
   void dragEnterEvent(QDragEnterEvent* event) override;
   void dropEvent(QDropEvent* event) override;
   void contextMenuEvent(QContextMenuEvent* event) override;
-
- private:
   void keyPressEvent(QKeyEvent* e) override;
   void keyReleaseEvent(QKeyEvent* e) override;
+
+ private:
+  // back in history
+  void goBackHistory();
+  // forward in history
+  void goForwardHistory();
 
   bool isCommandComplete(const std::string& cmd);
 
@@ -123,6 +121,9 @@ class TclCmdInputWidget : public QPlainTextEdit
   int max_height_;
 
   Tcl_Interp* interp_;
+  QStringList history_;
+  QString history_buffer_last_;
+  int historyPosition_;
 
   std::unique_ptr<QMenu> context_menu_;
   std::unique_ptr<QAction> enable_highlighting_;

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -45,12 +45,13 @@
 #include <set>
 #include <string>
 
+#include "cmdInputWidget.h"
 #include "tclCmdHighlighter.h"
 #include "tclSwig.h"  // generated header
 
 namespace gui {
 
-class TclCmdInputWidget : public QPlainTextEdit
+class TclCmdInputWidget : public CmdInputWidget
 {
   Q_OBJECT
 
@@ -62,53 +63,26 @@ class TclCmdInputWidget : public QPlainTextEdit
                     bool do_init_openroad,
                     const std::function<void(void)>& post_or_init);
 
-  void setFont(const QFont& font);
-
-  QString text() const;
-  void setText(const QString& text);
-
-  void setMaximumHeight(int height);
-
   void readSettings(QSettings* settings);
   void writeSettings(QSettings* settings);
 
- signals:
-  // tcl exit has been initiated, want the gui to handle
-  // shutdown
-  void tclExiting();
-
-  void commandAboutToExecute();
-  void commandFinishedExecuting(int code);
-
-  void addResultToOutput(const QString& result, int code);
-  void addCommandToOutput(const QString& cmd);
-
  public slots:
-  void executeCommand(const QString& cmd,
-                      bool echo = true,
-                      bool silent = false);
+  virtual void executeCommand(const QString& cmd,
+                              bool echo = true,
+                              bool silent = false) override;
 
  private slots:
-  void updateSize();
-
   void updateHighlighting();
   void updateCompletion();
 
   void insertCompletion(const QString& text);
 
  protected:
-  void dragEnterEvent(QDragEnterEvent* event) override;
-  void dropEvent(QDropEvent* event) override;
   void contextMenuEvent(QContextMenuEvent* event) override;
   void keyPressEvent(QKeyEvent* e) override;
   void keyReleaseEvent(QKeyEvent* e) override;
 
  private:
-  // back in history
-  void goBackHistory();
-  // forward in history
-  void goForwardHistory();
-
   void init();
   void processTclResult(int result_code);
 
@@ -118,8 +92,6 @@ class TclCmdInputWidget : public QPlainTextEdit
                             const char** argv);
 
   bool isCommandComplete(const std::string& cmd);
-
-  void determineLineHeight();
 
   void initOpenRoadCommands();
   void parseOpenRoadArguments(const char* or_args, std::set<std::string>& args);
@@ -134,15 +106,7 @@ class TclCmdInputWidget : public QPlainTextEdit
   void setCompleterArguments(const std::set<int>& cmds);
   void setCompleterVariables();
 
-  int line_height_;
-  int document_margins_;
-
-  int max_height_;
-
   Tcl_Interp* interp_;
-  QStringList history_;
-  QString history_buffer_last_;
-  int historyPosition_;
 
   std::unique_ptr<QMenu> context_menu_;
   std::unique_ptr<QAction> enable_highlighting_;


### PR DESCRIPTION
Changes:
- Removes all command execution from script widget and moves them to tcl command widget

Adds:
- Adds base class to help with eventual python input