### PR TITLE
metrics: add group_count to setup/hold violation metrics to return more than 1 or 0 for a more accurate result

### DIFF
--- a/src/Metrics.tcl
+++ b/src/Metrics.tcl
@@ -87,7 +87,7 @@ proc report_worst_slack_metric { args } {
 }
 
 define_cmd_args "report_erc_metrics" {}
-proc report_erc_metrics { args } {
+proc report_erc_metrics { } {
 
     set max_slew_limit [sta::max_slew_check_slack_limit]
     set max_cap_limit [sta::max_capacitance_check_slack_limit]
@@ -95,8 +95,8 @@ proc report_erc_metrics { args } {
     set max_slew_violation [sta::max_slew_violation_count]
     set max_cap_violation [sta::max_capacitance_violation_count]
     set max_fanout_violation [sta::max_fanout_violation_count]
-    set setup_violation [llength [find_timing_paths -path_delay max -slack_max 0]]
-    set hold_violation [llength [find_timing_paths -path_delay min -slack_max 0]]
+    set setup_violation [sta::endpoint_violation_count max]
+    set hold_violation [sta::endpoint_violation_count min]
 
     utl::metric_float "timing__drv__max_slew_limit" $max_slew_limit
     utl::metric_int "timing__drv__max_slew" $max_slew_violation


### PR DESCRIPTION
I noticed that the metrics for hold and setup violation count is basically binary since `find_timing_paths` returns just one by default. By adding `group_count` the result will include more than 1 and will default to `sta::endpoint_count`.