### PR TITLE
metrics: use defaultfloat and 6 point precision to avoid truncating small numbers, such as leakage power

### DIFF
--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -177,7 +177,7 @@ class Logger
   inline void metric(const std::string_view metric, T value)
   {
     std::ostringstream oss;
-    oss << std::fixed << std::setprecision(4) << value;
+    oss << std::defaultfloat << std::setprecision(6) << value;
     log_metric(std::string(metric), oss.str());
   }
 


### PR DESCRIPTION
Changes:
- Current metrics get truncated by the `std::fixed` which leads to loss of information. This changes the behavior to use `std::defaultfloat` with slightly higher precision.

Current:
```
"power__internal__total": 0.0016,
"power__switching__total": 0.0005,
"power__leakage__total": 0.0000,
```

Changed to:
```
"power__internal__total": 0.00159408,
"power__switching__total": 0.00054661,
"power__leakage__total": 9.91616e-06,
```