### PR TITLE
dbSta: enable string redirection in openroad to function with with_output_to_variable

### DIFF
--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -428,6 +428,12 @@ dbStaReport::setLogger(Logger* logger)
 void
 dbStaReport::printLine(const char* buffer, size_t length)
 {
+  if (redirect_to_string_) {
+    redirectStringPrint(buffer, length);
+    redirectStringPrint("\n", 1);
+    return;
+  }
+
   logger_->report(buffer);
 }
 
@@ -435,6 +441,11 @@ dbStaReport::printLine(const char* buffer, size_t length)
 size_t
 dbStaReport::printString(const char* buffer, size_t length)
 {
+  if (redirect_to_string_) {
+    redirectStringPrint(buffer, length);
+    return length;
+  }
+
   // prepend saved buffer
   string buf = tcl_buffer_ + string(buffer);
   tcl_buffer_.clear();  // clear buffer


### PR DESCRIPTION
Fixes:
- `with_output_to_variable` does not work in OpenROAD like it does in OpenSTA because the functions that enable this behavior is overridden for the logger. This enables this redirection to have the same behavior as OpenSTA.