### PR TITLE
add missing ostream formatters

### DIFF
--- a/src/cts/src/Util.h
+++ b/src/cts/src/Util.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <ostream>
+#include <fmt/ostream.h>
 
 namespace cts {
 
@@ -140,3 +141,5 @@ class Box
 };
 
 }  // namespace cts
+
+template <typename T> struct fmt::formatter<cts::Box<T>> : fmt::ostream_formatter {};

--- a/src/cts/src/Util.h
+++ b/src/cts/src/Util.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include <ostream>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 namespace cts {
 
@@ -142,4 +142,7 @@ class Box
 
 }  // namespace cts
 
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <typename T> struct fmt::formatter<cts::Box<T>> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000

--- a/src/drt/src/db/infra/frTime.h
+++ b/src/drt/src/db/infra/frTime.h
@@ -32,6 +32,7 @@
 #include <chrono>
 #include <ctime>
 #include <iostream>
+#include <fmt/ostream.h>
 
 #include "frBaseTypes.h"
 
@@ -60,5 +61,7 @@ class frTime
 
 std::ostream& operator<<(std::ostream& os, const frTime& t);
 }  // namespace fr
+
+template <> struct fmt::formatter<fr::frTime> : fmt::ostream_formatter {};
 
 #endif

--- a/src/drt/src/db/infra/frTime.h
+++ b/src/drt/src/db/infra/frTime.h
@@ -32,7 +32,7 @@
 #include <chrono>
 #include <ctime>
 #include <iostream>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "frBaseTypes.h"
 
@@ -62,6 +62,9 @@ class frTime
 std::ostream& operator<<(std::ostream& os, const frTime& t);
 }  // namespace fr
 
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <> struct fmt::formatter<fr::frTime> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000
 
 #endif

--- a/src/drt/src/dr/FlexDR_conn.cpp
+++ b/src/drt/src/dr/FlexDR_conn.cpp
@@ -34,6 +34,7 @@
 #include "frProfileTask.h"
 #include "io/io.h"
 #include "utl/exception.h"
+#include "utl/exception.h"
 
 using namespace std;
 using namespace fr;

--- a/src/drt/src/dr/FlexDR_conn.cpp
+++ b/src/drt/src/dr/FlexDR_conn.cpp
@@ -34,7 +34,6 @@
 #include "frProfileTask.h"
 #include "io/io.h"
 #include "utl/exception.h"
-#include "utl/exception.h"
 
 using namespace std;
 using namespace fr;

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -40,6 +40,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <fmt/ostream.h>
 
 #include "odb/dbTypes.h"
 #include "utl/Logger.h"
@@ -347,5 +348,13 @@ inline bool is_loading(const Archive& ar)
 }
 
 }  // namespace fr
+
+template <> struct fmt::formatter<fr::frConstraintTypeEnum> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frCornerTypeEnum> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frMinimumcutConnectionEnum> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frMinstepTypeEnum> : fmt::ostream_formatter {};
 
 #endif

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -40,7 +40,7 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "odb/dbTypes.h"
 #include "utl/Logger.h"
@@ -349,12 +349,12 @@ inline bool is_loading(const Archive& ar)
 
 }  // namespace fr
 
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <> struct fmt::formatter<fr::frConstraintTypeEnum> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frCornerTypeEnum> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frMinimumcutConnectionEnum> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frMinstepTypeEnum> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000
 
 #endif

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -32,6 +32,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <fmt/ostream.h>
 
 #include "db/obj/frMarker.h"
 #include "frBaseTypes.h"
@@ -145,6 +146,7 @@ class frInstTerm;
 class frTerm;
 class frBTerm;
 class frMTerm;
+class frMPin;
 class frPin;
 class frBPin;
 class frRect;
@@ -179,4 +181,34 @@ std::ostream& operator<<(std::ostream& os, const drNet& n);
 std::ostream& operator<<(std::ostream& os, const frMarker& m);
 // namespace fr
 }  // namespace fr
+
+// formatters
+template <> struct fmt::formatter<fr::frRect> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frPolygon> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frMPin> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frBTerm> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frInstTerm> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frBlock> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frViaDef> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::drConnFig> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frPathSeg> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frGuide> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frConnFig> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frNet> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::drNet> : fmt::ostream_formatter {};
+
+template <> struct fmt::formatter<fr::frMarker> : fmt::ostream_formatter {};
+
 #endif

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -32,7 +32,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "db/obj/frMarker.h"
 #include "frBaseTypes.h"
@@ -182,33 +182,22 @@ std::ostream& operator<<(std::ostream& os, const frMarker& m);
 // namespace fr
 }  // namespace fr
 
-// formatters
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <> struct fmt::formatter<fr::frRect> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frPolygon> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frMPin> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frBTerm> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frInstTerm> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frBlock> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frViaDef> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::drConnFig> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frPathSeg> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frGuide> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frConnFig> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frNet> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::drNet> : fmt::ostream_formatter {};
-
 template <> struct fmt::formatter<fr::frMarker> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000
 
 #endif

--- a/src/dst/src/LoadBalancer.h
+++ b/src/dst/src/LoadBalancer.h
@@ -33,7 +33,7 @@
 #include <mutex>
 #include <queue>
 #include <vector>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 #include "BalancerConnection.h"
 
@@ -106,4 +106,7 @@ class LoadBalancer
 };
 }  // namespace dst
 
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <> struct fmt::formatter<boost::asio::ip::address> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000

--- a/src/dst/src/LoadBalancer.h
+++ b/src/dst/src/LoadBalancer.h
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <queue>
 #include <vector>
+#include <fmt/ostream.h>
 
 #include "BalancerConnection.h"
 
@@ -104,3 +105,5 @@ class LoadBalancer
   friend class dst::BalancerConnection;
 };
 }  // namespace dst
+
+template <> struct fmt::formatter<boost::asio::ip::address> : fmt::ostream_formatter {};

--- a/src/grt/src/fastroute/include/DataType.h
+++ b/src/grt/src/fastroute/include/DataType.h
@@ -35,7 +35,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <fmt/ostream.h>
+#include <spdlog/fmt/fmt.h>
 
 namespace odb {
 class dbNet;
@@ -243,4 +243,7 @@ struct OrderNetEdge
 
 }  // namespace grt
 
+#if defined(FMT_VERSION) && FMT_VERSION >= 90000
+#include <fmt/ostream.h>
 template <> struct fmt::formatter<grt::RouteType> : fmt::ostream_formatter {};
+#endif // FMT_VERSION >= 90000

--- a/src/grt/src/fastroute/include/DataType.h
+++ b/src/grt/src/fastroute/include/DataType.h
@@ -35,6 +35,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <fmt/ostream.h>
 
 namespace odb {
 class dbNet;
@@ -241,3 +242,5 @@ struct OrderNetEdge
 };
 
 }  // namespace grt
+
+template <> struct fmt::formatter<grt::RouteType> : fmt::ostream_formatter {};


### PR DESCRIPTION
Fixes compile on [at least] the following platforms:
- Fedora 37 (spdlog:1.10.0, fmt:9.1.0)
- macOS Ventura (homebrew spdlog:1.11.0 fmt:9.1.0)

https://fmt.dev/latest/api.html#format-api
https://fmt.dev/latest/api.html#ostream-api