### PR TITLE
dependencyinstaller: fix error message

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -569,7 +569,6 @@ EOF
         ;;
     *)
         echo "unsupported system: ${os}" >&2
-        echo "supported systems are CentOS 7 and Ubuntu 20.04" >&2
         _help
         ;;
 esac


### PR DESCRIPTION
this error message is out of date, more systems are supported, easiest is to remove it

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>