### PR TITLE
grt:change testing moment for error GRT183 heap underflow to prevent crashing

### DIFF
--- a/src/grt/src/fastroute/src/maze3D.cpp
+++ b/src/grt/src/fastroute/src/maze3D.cpp
@@ -971,7 +971,6 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
         const int remd = ind1 % (grid_hv_);
         const int curX = remd % x_range_;
         const int curY = remd / x_range_;
-        
         removeMin3D(src_heap_3D);
 
         const bool Horizontal = (((curL % 2) - layerOrientation) == 0);

--- a/src/grt/src/fastroute/src/maze3D.cpp
+++ b/src/grt/src/fastroute/src/maze3D.cpp
@@ -971,7 +971,6 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
         const int remd = ind1 % (grid_hv_);
         const int curX = remd % x_range_;
         const int curY = remd / x_range_;
-
         
         removeMin3D(src_heap_3D);
 

--- a/src/grt/src/fastroute/src/maze3D.cpp
+++ b/src/grt/src/fastroute/src/maze3D.cpp
@@ -972,12 +972,7 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
         const int curX = remd % x_range_;
         const int curY = remd / x_range_;
 
-        if (src_heap_3D.empty()) {
-          logger_->error(GRT,
-                         183,
-                         "Net {}: heap underflow during 3D maze routing.",
-                         nets_[netID]->getName());
-        }
+        
         removeMin3D(src_heap_3D);
 
         const bool Horizontal = (((curL % 2) - layerOrientation) == 0);
@@ -1194,6 +1189,12 @@ void FastRouteCore::mazeRouteMSMDOrder3D(int expand,
           }
         }
 
+        if (src_heap_3D.empty()) {
+          logger_->error(GRT,
+                         183,
+                         "Net {}: heap underflow during 3D maze routing.",
+                         nets_[netID]->getName());
+        }
         // update ind1 for next loop
         ind1 = (src_heap_3D[0] - &d1_3D[0][0][0]);
       }  // while loop


### PR DESCRIPTION
Signed-off-by: Arthur <arthurjolo@gmail.com>

In the previous code, if the src_heap_3D becomes empty after "removeMin3D(src_heap_3D);" and nothing was added to the heap at the end of the while the code crashed when trying to access "src_heap_3D[0]".

With this changes, the test for an empty heap is made before this access to prevent the code from crashing