### PR TITLE
metrics: avoid double formatting metrics and adding core_area and die_area metrics

### DIFF
--- a/src/Metrics.tcl
+++ b/src/Metrics.tcl
@@ -138,7 +138,7 @@ proc report_units_metric { args } {
 define_cmd_args "report_design_area_metrics" {}
 proc report_design_area_metrics {args} {
   set db [::ord::get_db]
-  set dbu_per_uu [[$db getTech] getDbUnitsPerMicron]
+  set dbu_per_uu [expr double([[$db getTech] getDbUnitsPerMicron])]
   set block [[$db getChip] getBlock]
   set die_bbox [$block getDieArea]
   set die_area [expr [$die_bbox dx] * [$die_bbox dy]]

--- a/src/Metrics.tcl
+++ b/src/Metrics.tcl
@@ -37,7 +37,6 @@ namespace eval sta {
 
 define_cmd_args "report_clock_skew_metric" {[-setup]|[-hold]}
 proc report_clock_skew_metric { args } {
-  global sta_report_default_digits
   parse_key_args "report_clock_skew_metric" args keys {} flags {-setup -hold}
 
   set min_max "-setup"
@@ -54,7 +53,6 @@ proc report_clock_skew_metric { args } {
 
 define_cmd_args "report_tns_metric" {[-setup]|[-hold]}
 proc report_tns_metric { args } {
-  global sta_report_default_digits
   parse_key_args "report_tns_metric" args keys {} flags {-setup -hold}
 
   set min_max "max"
@@ -66,7 +64,7 @@ proc report_tns_metric { args } {
     utl::error ORD 18 "both -setup and -hold specified."
   }
 
-  utl::metric_float $metric_name "[format_time [total_negative_slack_cmd  $min_max] $sta_report_default_digits]"
+  utl::metric_float $metric_name [total_negative_slack_cmd $min_max]
 }
 
 define_cmd_args "report_worst_slack_metric" {[-setup]|[-hold]}
@@ -83,7 +81,7 @@ proc report_worst_slack_metric { args } {
     utl::error ORD 17 "both -steup and -hold specified."
   }
 
-  utl::metric_float $metric_name "[format_time [worst_slack_cmd $min_max] $sta_report_default_digits]"
+  utl::metric_float $metric_name [worst_slack_cmd $min_max]
 }
 
 define_cmd_args "report_erc_metrics" {}
@@ -142,6 +140,8 @@ proc report_design_area_metrics {args} {
   set db [::ord::get_db]
   set dbu_per_uu [[$db getTech] getDbUnitsPerMicron]
   set block [[$db getChip] getBlock]
+  set die_bbox [$block getDieArea]
+  set die_area [expr [$die_bbox dx] * [$die_bbox dy]]
   set core_bbox [$block getCoreArea]
   set core_area [expr [$core_bbox dx] * [$core_bbox dy]]
 
@@ -185,6 +185,7 @@ proc report_design_area_metrics {args} {
     }
   }
 
+  set die_area [expr $die_area / [expr $dbu_per_uu * $dbu_per_uu]]
   set core_area [expr $core_area / [expr $dbu_per_uu * $dbu_per_uu]]
   set total_area [expr $total_area / [expr $dbu_per_uu * $dbu_per_uu]]
   set stdcell_area [expr $stdcell_area / [expr $dbu_per_uu * $dbu_per_uu]]
@@ -198,6 +199,8 @@ proc report_design_area_metrics {args} {
   set stdcell_util [expr $stdcell_area / [expr $core_area - $macro_area]]
 
   utl::metric_int "design__io" $num_ios
+  utl::metric_float "design__die__area" $die_area
+  utl::metric_float "design__core__area" $core_area
   utl::metric_int "design__instance__count" $num_insts
   utl::metric_float "design__instance__area" $total_active_area
   utl::metric_int "design__instance__count__stdcell" $num_stdcells


### PR DESCRIPTION
Fixes:
- by calling `format_time` and recording floats, the value "inf" appears in the json format, which is not supported.
```
	"sc__metric__timing__setup__ws": inf,
```
- This fixes this to record the value and letting the metrics logger format the information.

Adds:
- Core and die area metrics