### PR TITLE
Fix some threading data races

### DIFF
--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -1690,6 +1690,7 @@ void FlexDRWorker::route_queue_main(queue<RouteQueueEntry>& rerouteQueue)
       // init
       net->setModified(true);
       if (net->getFrNet()) {
+#pragma omp critical
         net->getFrNet()->setModified(true);
       }
       net->setNumMarkers(0);

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -44,8 +44,6 @@ using namespace fr;
 
 using utl::ThreadException;
 
-int gcCallCnt = 0;
-
 template <typename T>
 void FlexPA::prepPoint_pin_mergePinShapes(
     vector<gtl::polygon_90_set_data<frCoord>>& pinShapes,
@@ -2250,7 +2248,6 @@ bool FlexPA::genPatterns_gc(std::set<frBlockObject*> targetObjs,
                             const PatternType patternType,
                             std::set<frBlockObject*>* owners)
 {
-  gcCallCnt++;
   if (objs.empty()) {
     if (VERBOSE > 1) {
       logger_->warn(DRT, 89, "genPattern_gc objs empty.");


### PR DESCRIPTION
These were found with the clang thread sanitizer. The concurrent update of getFrNet()->setModified(true) is probably OK, but it really should be protected.