### PR TITLE
drt: Move FIXEDSHAPECOST and MARKERDECAY into SearchRepairArgs 

### DIFF
--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -136,6 +136,8 @@ class TritonRoute
   void setDebugWorkerParams(int mazeEndIter,
                             int drcCost,
                             int markerCost,
+                            int fixedShapeCost,
+                            float markerDecay,
                             int ripupMode,
                             int followGuide);
   void setDistributed(bool on = true);

--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -116,6 +116,8 @@ class TritonRoute
               int mazeEndIter,
               unsigned int workerDRCCost,
               unsigned int workerMarkerCost,
+              unsigned int workerFixedShapeCost,
+              float workerMarkerDecay,
               int ripupMode,
               bool followGuide);
 

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -174,12 +174,16 @@ void TritonRoute::setDebugPaCommit(bool on)
 void TritonRoute::setDebugWorkerParams(int mazeEndIter,
                                        int drcCost,
                                        int markerCost,
+                                       int fixedShapeCost,
+                                       float markerDecay,
                                        int ripupMode,
                                        int followGuide)
 {
   debug_->mazeEndIter = mazeEndIter;
   debug_->drcCost = drcCost;
   debug_->markerCost = markerCost;
+  debug_->fixedShapeCost = fixedShapeCost;
+  debug_->markerDecay = markerDecay;
   debug_->ripupMode = ripupMode;
   debug_->followGuide = followGuide;
 }
@@ -238,6 +242,10 @@ void TritonRoute::debugSingleWorker(const std::string& dumpDir,
     worker->setMarkerCost(debug_->markerCost);
   if (debug_->drcCost != -1)
     worker->setDrcCost(debug_->drcCost);
+  if (debug_->fixedShapeCost != -1)
+    worker->setFixedShapeCost(debug_->fixedShapeCost);
+  if (debug_->markerDecay != -1)
+    worker->setMarkerDecay(debug_->markerDecay);
   if (debug_->ripupMode != -1)
     worker->setRipupMode(debug_->ripupMode);
   if (debug_->followGuide != -1)

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -609,6 +609,8 @@ void TritonRoute::stepDR(int size,
                          int mazeEndIter,
                          frUInt4 workerDRCCost,
                          frUInt4 workerMarkerCost,
+                         frUInt4 workerFixedShapeCost,
+                         float workerMarkerDecay,
                          int ripupMode,
                          bool followGuide)
 {
@@ -617,6 +619,8 @@ void TritonRoute::stepDR(int size,
                      mazeEndIter,
                      workerDRCCost,
                      workerMarkerCost,
+                     workerFixedShapeCost,
+                     workerMarkerDecay,
                      ripupMode,
                      followGuide});
   num_drvs_ = design_->getTopBlock()->getNumMarkers();

--- a/src/drt/src/TritonRoute.i
+++ b/src/drt/src/TritonRoute.i
@@ -211,12 +211,15 @@ void detailed_route_step_drt(int size,
                              int mazeEndIter,
                              int workerDRCCost,
                              int workerMarkerCost,
+                             int workerFixedShapeCost,
+                             float workerMarkerDecay,
                              int ripupMode,
                              bool followGuide)
 {
   auto* router = ord::OpenRoad::openRoad()->getTritonRoute();
   router->stepDR(size, offset, mazeEndIter, workerDRCCost,
-                 workerMarkerCost, ripupMode, followGuide);
+                 workerMarkerCost, workerFixedShapeCost,
+                 workerMarkerDecay, ripupMode, followGuide);
 }
 
 void step_end()

--- a/src/drt/src/TritonRoute.i
+++ b/src/drt/src/TritonRoute.i
@@ -186,11 +186,14 @@ void
 set_worker_debug_params(int maze_end_iter,
                         int drc_cost,
                         int marker_cost,
+                        int fixed_shape_cost,
+                        int marker_decay,
                         int ripup_mode,
                         int follow_guide)
 {
   auto* router = ord::OpenRoad::openRoad()->getTritonRoute();
-  router->setDebugWorkerParams(maze_end_iter, drc_cost, marker_cost, ripup_mode, follow_guide);
+  router->setDebugWorkerParams(maze_end_iter, drc_cost, marker_cost, fixed_shape_cost,
+                               marker_decay, ripup_mode, follow_guide);
 }
 
 void

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -403,8 +403,8 @@ namespace eval drt {
 
 proc step_dr { args } {
   # args match FlexDR::SearchRepairArgs
-  if { [llength $args] != 7 } {
-    utl::error DRT 308 "step_dr requires seven positional arguments."
+  if { [llength $args] != 9 } {
+    utl::error DRT 308 "step_dr requires nine positional arguments."
   }
 
   drt::detailed_route_step_drt {*}$args

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -349,13 +349,15 @@ sta::define_cmd_args "detailed_route_worker_debug" {
     [-maze_end_iter iter]
     [-drc_cost d_cost]
     [-marker_cost m_cost]
+    [-fixed_shape_cost f_cost]
+    [-marker_decay m_decay]
     [-ripup_mode mode]
     [-follow_guide f_guide]
 }
 
 proc detailed_route_worker_debug { args } {
   sta::parse_key_args "detailed_route_worker_debug" args \
-      keys {-maze_end_iter -drc_cost -marker_cost -ripup_mode -follow_guide} \
+      keys {-maze_end_iter -drc_cost -marker_cost -fixed_shape_cost -marker_decay -ripup_mode -follow_guide} \
       flags {}
   if [info exists keys(-maze_end_iter)] {
     set maze_end_iter $keys(-maze_end_iter)
@@ -375,6 +377,18 @@ proc detailed_route_worker_debug { args } {
     set marker_cost -1
   }
 
+  if [info exists keys(-fixed_shape_cost)] {
+    set fixed_shape_cost $keys(-fixed_shape_cost)
+  } else {
+    set fixed_shape_cost -1
+  }
+
+  if [info exists keys(-marker_decay)] {
+    set marker_decay $keys(-marker_decay)
+  } else {
+    set marker_decay -1
+  }
+
   if [info exists keys(-ripup_mode)] {
     set ripup_mode $keys(-ripup_mode)
   } else {
@@ -386,7 +400,7 @@ proc detailed_route_worker_debug { args } {
   } else {
     set follow_guide -1
   }
-  drt::set_worker_debug_params $maze_end_iter $drc_cost $marker_cost $ripup_mode $follow_guide
+  drt::set_worker_debug_params $maze_end_iter $drc_cost $marker_cost $fixed_shape_cost $marker_decay $ripup_mode $follow_guide
 }
 
 proc detailed_route_set_default_via { args } {

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -1972,473 +1972,75 @@ static std::vector<FlexDR::SearchRepairArgs> strategy()
 {
   const fr::frUInt4 shapeCost = ROUTESHAPECOST;
 
+  // clang-format off
   return {
-      /*  0 */ {
-          7, 0, 3, shapeCost, 0 /*MARKERCOST*/, ROUTESHAPECOST, 0.95, 1, true},
-      /*  1 */
-      {7,
-       -2,
-       3,
-       shapeCost,
-       shapeCost /*MARKERCOST*/,
-       ROUTESHAPECOST,
-       0.95,
-       1,
-       true},
-      /*  2 */
-      {7,
-       -5,
-       3,
-       shapeCost,
-       shapeCost /*MAARKERCOST*/,
-       ROUTESHAPECOST,
-       0.95,
-       1,
-       true},
-      /*  3 */
-      {7, 0, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  4 */
-      {7, -1, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  5 */
-      {7, -2, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  6 */
-      {7, -3, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  7 */
-      {7, -4, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  8 */
-      {7, -5, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /*  9 */
-      {7, -6, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 10 */
-      {7, 0, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 11 */
-      {7, -1, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 12 */
-      {7, -2, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 13 */
-      {7, -3, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 14 */
-      {7, -4, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 15 */
-      {7, -5, 8, shapeCost * 2, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 16 */
-      {7, -6, 8, shapeCost * 2, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 17 */
-      {7, -3, 8, shapeCost, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 1, false},
-      /* 18 */
-      {7, 0, 8, shapeCost * 4, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 19 */
-      {7, -1, 8, shapeCost * 4, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
-      /* 20 */
-      {7,
-       -2,
-       8,
-       shapeCost * 4,
-       MARKERCOST,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 21 */
-      {7,
-       -3,
-       8,
-       shapeCost * 4,
-       MARKERCOST,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 22 */
-      {7,
-       -4,
-       8,
-       shapeCost * 4,
-       MARKERCOST,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 23 */
-      {7,
-       -5,
-       8,
-       shapeCost * 4,
-       MARKERCOST,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 24 */
-      {7,
-       -6,
-       8,
-       shapeCost * 4,
-       MARKERCOST,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 25 */
-      {5, -2, 8, shapeCost, MARKERCOST, 10 * ROUTESHAPECOST, 0.95, 1, false},
-      /* 26 */
-      {7,
-       0,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 27 */
-      {7,
-       -1,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 28 */
-      {7,
-       -2,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 29 */
-      {7,
-       -3,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       10 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 30 */
-      {7,
-       -4,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 31 */
-      {7,
-       -5,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 32 */
-      {7,
-       -6,
-       8,
-       shapeCost * 8,
-       MARKERCOST * 2,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 33 */
-      {3, -1, 8, shapeCost, MARKERCOST, 50 * ROUTESHAPECOST, 0.95, 1, false},
-      /* 34 */
-      {7,
-       0,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 35 */
-      {7,
-       -1,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 36 */
-      {7,
-       -2,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 37 */
-      {7,
-       -3,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 38 */
-      {7,
-       -4,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 39 */
-      {7,
-       -5,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       50 * ROUTESHAPECOST,
-       0.95,
-       0,
-       false},
-      /* 40 */
-      {7,
-       -6,
-       8,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 41 */
-      {3, -2, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.99, 1, false},
-      /* 42 */
-      {7,
-       0,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 43 */
-      {7,
-       -1,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 44 */
-      {7,
-       -2,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 45 */
-      {7,
-       -3,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 46 */
-      {7,
-       -4,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 47 */
-      {7,
-       -5,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 48 */
-      {7,
-       -6,
-       16,
-       shapeCost * 16,
-       MARKERCOST * 4,
-       100 * ROUTESHAPECOST,
-       0.99,
-       0,
-       false},
-      /* 49 */
-      {3, -0, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.99, 1, false},
-      /* 50 */
-      {7,
-       0,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 51 */
-      {7,
-       -1,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 52 */
-      {7,
-       -2,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 53 */
-      {7,
-       -3,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 54 */
-      {7,
-       -4,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 55 */
-      {7,
-       -5,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 56 */
-      {7,
-       -6,
-       32,
-       shapeCost * 32,
-       MARKERCOST * 8,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 57 */
-      {3, -1, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.999, 1, false},
-      /* 58 */
-      {7,
-       0,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 59 */
-      {7,
-       -1,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 60 */
-      {7,
-       -2,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 61 */
-      {7,
-       -3,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 62 */
-      {7,
-       -4,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 63 */
-      {7,
-       -5,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false},
-      /* 64 */
-      {7,
-       -6,
-       64,
-       shapeCost * 64,
-       MARKERCOST * 16,
-       100 * ROUTESHAPECOST,
-       0.999,
-       0,
-       false}};
+    {7,  0,  3,      shapeCost,               0,       shapeCost, 0.950, 1,  true}, //  0
+    {7, -2,  3,      shapeCost,       shapeCost,       shapeCost, 0.950, 1,  true}, //  1
+    {7, -5,  3,      shapeCost,       shapeCost,       shapeCost, 0.950, 1,  true}, //  2
+    {7,  0,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  3
+    {7, -1,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  4
+    {7, -2,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  5
+    {7, -3,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  6
+    {7, -4,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  7
+    {7, -5,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  8
+    {7, -6,  8,      shapeCost,      MARKERCOST,   2 * shapeCost, 0.950, 0, false}, //  9
+    {7,  0,  8,  2 * shapeCost,      MARKERCOST,   3 * shapeCost, 0.950, 0, false}, // 10
+    {7, -1,  8,  2 * shapeCost,      MARKERCOST,   3 * shapeCost, 0.950, 0, false}, // 11
+    {7, -2,  8,  2 * shapeCost,      MARKERCOST,   3 * shapeCost, 0.950, 0, false}, // 12
+    {7, -3,  8,  2 * shapeCost,      MARKERCOST,   3 * shapeCost, 0.950, 0, false}, // 13
+    {7, -4,  8,  2 * shapeCost,      MARKERCOST,   3 * shapeCost, 0.950, 0, false}, // 14
+    {7, -5,  8,  2 * shapeCost,      MARKERCOST,   4 * shapeCost, 0.950, 0, false}, // 15
+    {7, -6,  8,  2 * shapeCost,      MARKERCOST,   4 * shapeCost, 0.950, 0, false}, // 16
+    {7, -3,  8,      shapeCost,      MARKERCOST,   4 * shapeCost, 0.950, 1, false}, // 17
+    {7,  0,  8,  4 * shapeCost,      MARKERCOST,   4 * shapeCost, 0.950, 0, false}, // 18
+    {7, -1,  8,  4 * shapeCost,      MARKERCOST,   4 * shapeCost, 0.950, 0, false}, // 19
+    {7, -2,  8,  4 * shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 20
+    {7, -3,  8,  4 * shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 21
+    {7, -4,  8,  4 * shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 22
+    {7, -5,  8,  4 * shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 23
+    {7, -6,  8,  4 * shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 24
+    {5, -2,  8,      shapeCost,      MARKERCOST,  10 * shapeCost, 0.950, 1, false}, // 25
+    {7,  0,  8,  8 * shapeCost,  2 * MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 26
+    {7, -1,  8,  8 * shapeCost,  2 * MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 27
+    {7, -2,  8,  8 * shapeCost,  2 * MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 28
+    {7, -3,  8,  8 * shapeCost,  2 * MARKERCOST,  10 * shapeCost, 0.950, 0, false}, // 29
+    {7, -4,  8,  8 * shapeCost,  2 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 30
+    {7, -5,  8,  8 * shapeCost,  2 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 31
+    {7, -6,  8,  8 * shapeCost,  2 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 32
+    {3, -1,  8,      shapeCost,      MARKERCOST,  50 * shapeCost, 0.950, 1, false}, // 33
+    {7,  0,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 34
+    {7, -1,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 35
+    {7, -2,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 36
+    {7, -3,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 37
+    {7, -4,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 38
+    {7, -5,  8, 16 * shapeCost,  4 * MARKERCOST,  50 * shapeCost, 0.950, 0, false}, // 39
+    {7, -6,  8, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 40
+    {3, -2,  8,      shapeCost,      MARKERCOST, 100 * shapeCost, 0.990, 1, false}, // 41
+    {7,  0, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 42
+    {7, -1, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 43
+    {7, -2, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 44
+    {7, -3, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 45
+    {7, -4, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 46
+    {7, -5, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 47
+    {7, -6, 16, 16 * shapeCost,  4 * MARKERCOST, 100 * shapeCost, 0.990, 0, false}, // 48
+    {3, -0,  8,      shapeCost,      MARKERCOST, 100 * shapeCost, 0.990, 1, false}, // 49
+    {7,  0, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 50
+    {7, -1, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 51
+    {7, -2, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 52
+    {7, -3, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 53
+    {7, -4, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 54
+    {7, -5, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 55
+    {7, -6, 32, 32 * shapeCost,  8 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 56
+    {3, -1,  8,      shapeCost,      MARKERCOST, 100 * shapeCost, 0.999, 1, false}, // 57
+    {7,  0, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 58
+    {7, -1, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 59
+    {7, -2, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 60
+    {7, -3, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 61
+    {7, -4, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 62
+    {7, -5, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}, // 63
+    {7, -6, 64, 64 * shapeCost, 16 * MARKERCOST, 100 * shapeCost, 0.999, 0, false}  // 64
+  };
+  // clang-format on
 }
 
 void addRectToPolySet(gtl::polygon_90_set_data<frCoord>& polySet, Rect rect)

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -1520,6 +1520,8 @@ void FlexDR::searchRepair(const SearchRepairArgs& args)
   const int mazeEndIter = args.mazeEndIter;
   const frUInt4 workerDRCCost = args.workerDRCCost;
   const frUInt4 workerMarkerCost = args.workerMarkerCost;
+  const frUInt4 workerFixedShapeCost = args.workerFixedShapeCost;
+  const float workerMarkerDecay = args.workerMarkerDecay;
   const int ripupMode = args.ripupMode;
   const bool followGuide = args.followGuide;
 
@@ -1607,7 +1609,10 @@ void FlexDR::searchRepair(const SearchRepairArgs& args)
       worker->setFollowGuide(followGuide);
       // TODO: only pass to relevant workers
       worker->setGraphics(graphics_.get());
-      worker->setCost(workerDRCCost, workerMarkerCost);
+      worker->setCost(workerDRCCost,
+                      workerMarkerCost,
+                      workerFixedShapeCost,
+                      workerMarkerDecay);
 
       int batchIdx = (xIdx % batchStepX) * batchStepY + yIdx % batchStepY;
       if (workers[batchIdx].empty()
@@ -1967,71 +1972,473 @@ static std::vector<FlexDR::SearchRepairArgs> strategy()
 {
   const fr::frUInt4 shapeCost = ROUTESHAPECOST;
 
-  return {/*  0 */ {7, 0, 3, shapeCost, 0 /*MARKERCOST*/, 1, true},
-          /*  1 */ {7, -2, 3, shapeCost, shapeCost /*MARKERCOST*/, 1, true},
-          /*  2 */ {7, -5, 3, shapeCost, shapeCost /*MAARKERCOST*/, 1, true},
-          /*  3 */ {7, 0, 8, shapeCost, MARKERCOST, 0, false},
-          /*  4 */ {7, -1, 8, shapeCost, MARKERCOST, 0, false},
-          /*  5 */ {7, -2, 8, shapeCost, MARKERCOST, 0, false},
-          /*  6 */ {7, -3, 8, shapeCost, MARKERCOST, 0, false},
-          /*  7 */ {7, -4, 8, shapeCost, MARKERCOST, 0, false},
-          /*  8 */ {7, -5, 8, shapeCost, MARKERCOST, 0, false},
-          /*  9 */ {7, -6, 8, shapeCost, MARKERCOST, 0, false},
-          /* 10 */ {7, 0, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 11 */ {7, -1, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 12 */ {7, -2, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 13 */ {7, -3, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 14 */ {7, -4, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 15 */ {7, -5, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 16 */ {7, -6, 8, shapeCost * 2, MARKERCOST, 0, false},
-          /* 17 */ {7, -3, 8, shapeCost, MARKERCOST, 1, false},
-          /* 18 */ {7, 0, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 19 */ {7, -1, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 20 */ {7, -2, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 21 */ {7, -3, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 22 */ {7, -4, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 23 */ {7, -5, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 24 */ {7, -6, 8, shapeCost * 4, MARKERCOST, 0, false},
-          /* 25 */ {5, -2, 8, shapeCost, MARKERCOST, 1, false},
-          /* 26 */ {7, 0, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 27 */ {7, -1, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 28 */ {7, -2, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 29 */ {7, -3, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 30 */ {7, -4, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 31 */ {7, -5, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 32 */ {7, -6, 8, shapeCost * 8, MARKERCOST * 2, 0, false},
-          /* 33 */ {3, -1, 8, shapeCost, MARKERCOST, 1, false},
-          /* 34 */ {7, 0, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 35 */ {7, -1, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 36 */ {7, -2, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 37 */ {7, -3, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 38 */ {7, -4, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 39 */ {7, -5, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 40 */ {7, -6, 8, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 41 */ {3, -2, 8, shapeCost, MARKERCOST, 1, false},
-          /* 42 */ {7, 0, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 43 */ {7, -1, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 44 */ {7, -2, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 45 */ {7, -3, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 46 */ {7, -4, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 47 */ {7, -5, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 48 */ {7, -6, 16, shapeCost * 16, MARKERCOST * 4, 0, false},
-          /* 49 */ {3, -0, 8, shapeCost, MARKERCOST, 1, false},
-          /* 50 */ {7, 0, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 51 */ {7, -1, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 52 */ {7, -2, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 53 */ {7, -3, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 54 */ {7, -4, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 55 */ {7, -5, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 56 */ {7, -6, 32, shapeCost * 32, MARKERCOST * 8, 0, false},
-          /* 57 */ {3, -1, 8, shapeCost, MARKERCOST, 1, false},
-          /* 58 */ {7, 0, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 59 */ {7, -1, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 60 */ {7, -2, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 61 */ {7, -3, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 62 */ {7, -4, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 63 */ {7, -5, 64, shapeCost * 64, MARKERCOST * 16, 0, false},
-          /* 64 */ {7, -6, 64, shapeCost * 64, MARKERCOST * 16, 0, false}};
+  return {
+      /*  0 */ {
+          7, 0, 3, shapeCost, 0 /*MARKERCOST*/, ROUTESHAPECOST, 0.95, 1, true},
+      /*  1 */
+      {7,
+       -2,
+       3,
+       shapeCost,
+       shapeCost /*MARKERCOST*/,
+       ROUTESHAPECOST,
+       0.95,
+       1,
+       true},
+      /*  2 */
+      {7,
+       -5,
+       3,
+       shapeCost,
+       shapeCost /*MAARKERCOST*/,
+       ROUTESHAPECOST,
+       0.95,
+       1,
+       true},
+      /*  3 */
+      {7, 0, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  4 */
+      {7, -1, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  5 */
+      {7, -2, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  6 */
+      {7, -3, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  7 */
+      {7, -4, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  8 */
+      {7, -5, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /*  9 */
+      {7, -6, 8, shapeCost, MARKERCOST, 2 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 10 */
+      {7, 0, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 11 */
+      {7, -1, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 12 */
+      {7, -2, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 13 */
+      {7, -3, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 14 */
+      {7, -4, 8, shapeCost * 2, MARKERCOST, 3 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 15 */
+      {7, -5, 8, shapeCost * 2, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 16 */
+      {7, -6, 8, shapeCost * 2, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 17 */
+      {7, -3, 8, shapeCost, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 1, false},
+      /* 18 */
+      {7, 0, 8, shapeCost * 4, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 19 */
+      {7, -1, 8, shapeCost * 4, MARKERCOST, 4 * ROUTESHAPECOST, 0.95, 0, false},
+      /* 20 */
+      {7,
+       -2,
+       8,
+       shapeCost * 4,
+       MARKERCOST,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 21 */
+      {7,
+       -3,
+       8,
+       shapeCost * 4,
+       MARKERCOST,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 22 */
+      {7,
+       -4,
+       8,
+       shapeCost * 4,
+       MARKERCOST,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 23 */
+      {7,
+       -5,
+       8,
+       shapeCost * 4,
+       MARKERCOST,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 24 */
+      {7,
+       -6,
+       8,
+       shapeCost * 4,
+       MARKERCOST,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 25 */
+      {5, -2, 8, shapeCost, MARKERCOST, 10 * ROUTESHAPECOST, 0.95, 1, false},
+      /* 26 */
+      {7,
+       0,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 27 */
+      {7,
+       -1,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 28 */
+      {7,
+       -2,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 29 */
+      {7,
+       -3,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       10 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 30 */
+      {7,
+       -4,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 31 */
+      {7,
+       -5,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 32 */
+      {7,
+       -6,
+       8,
+       shapeCost * 8,
+       MARKERCOST * 2,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 33 */
+      {3, -1, 8, shapeCost, MARKERCOST, 50 * ROUTESHAPECOST, 0.95, 1, false},
+      /* 34 */
+      {7,
+       0,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 35 */
+      {7,
+       -1,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 36 */
+      {7,
+       -2,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 37 */
+      {7,
+       -3,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 38 */
+      {7,
+       -4,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 39 */
+      {7,
+       -5,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       50 * ROUTESHAPECOST,
+       0.95,
+       0,
+       false},
+      /* 40 */
+      {7,
+       -6,
+       8,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 41 */
+      {3, -2, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.99, 1, false},
+      /* 42 */
+      {7,
+       0,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 43 */
+      {7,
+       -1,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 44 */
+      {7,
+       -2,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 45 */
+      {7,
+       -3,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 46 */
+      {7,
+       -4,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 47 */
+      {7,
+       -5,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 48 */
+      {7,
+       -6,
+       16,
+       shapeCost * 16,
+       MARKERCOST * 4,
+       100 * ROUTESHAPECOST,
+       0.99,
+       0,
+       false},
+      /* 49 */
+      {3, -0, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.99, 1, false},
+      /* 50 */
+      {7,
+       0,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 51 */
+      {7,
+       -1,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 52 */
+      {7,
+       -2,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 53 */
+      {7,
+       -3,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 54 */
+      {7,
+       -4,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 55 */
+      {7,
+       -5,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 56 */
+      {7,
+       -6,
+       32,
+       shapeCost * 32,
+       MARKERCOST * 8,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 57 */
+      {3, -1, 8, shapeCost, MARKERCOST, 100 * ROUTESHAPECOST, 0.999, 1, false},
+      /* 58 */
+      {7,
+       0,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 59 */
+      {7,
+       -1,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 60 */
+      {7,
+       -2,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 61 */
+      {7,
+       -3,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 62 */
+      {7,
+       -4,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 63 */
+      {7,
+       -5,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false},
+      /* 64 */
+      {7,
+       -6,
+       64,
+       shapeCost * 64,
+       MARKERCOST * 16,
+       100 * ROUTESHAPECOST,
+       0.999,
+       0,
+       false}};
 }
 
 void addRectToPolySet(gtl::polygon_90_set_data<frCoord>& polySet, Rect rect)
@@ -2167,26 +2574,6 @@ int FlexDR::main()
   frTime t;
 
   for (auto& args : strategy()) {
-    if (iter_ < 3)
-      FIXEDSHAPECOST = ROUTESHAPECOST;
-    else if (iter_ < 10)
-      FIXEDSHAPECOST = 2 * ROUTESHAPECOST;
-    else if (iter_ < 15)
-      FIXEDSHAPECOST = 3 * ROUTESHAPECOST;
-    else if (iter_ < 20)
-      FIXEDSHAPECOST = 4 * ROUTESHAPECOST;
-    else if (iter_ < 30)
-      FIXEDSHAPECOST = 10 * ROUTESHAPECOST;
-    else if (iter_ < 40)
-      FIXEDSHAPECOST = 50 * ROUTESHAPECOST;
-    else
-      FIXEDSHAPECOST = 100 * ROUTESHAPECOST;
-
-    if (iter_ == 40)
-      MARKERDECAY = 0.99;
-    if (iter_ == 50)
-      MARKERDECAY = 0.999;
-
     int clipSize = args.size;
     if (args.ripupMode != 1) {
       if (increaseClipsize_) {
@@ -2307,6 +2694,8 @@ void FlexDRWorker::serialize(Archive& ar, const unsigned int version)
   (ar) & ripupMode_;
   (ar) & workerDRCCost_;
   (ar) & workerMarkerCost_;
+  (ar) & workerFixedShapeCost_;
+  (ar) & workerMarkerDecay_;
   (ar) & pinCnt_;
   (ar) & initNumMarkers_;
   (ar) & apSVia_;

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -400,6 +400,14 @@ class FlexDRWorker
   }
   void setMarkerCost(frUInt4 markerCostIn) { workerMarkerCost_ = markerCostIn; }
   void setDrcCost(frUInt4 drcCostIn) { workerDRCCost_ = drcCostIn; }
+  void setFixedShapeCost(frUInt4 fixedShapeCostIn)
+  {
+    workerFixedShapeCost_ = fixedShapeCostIn;
+  }
+  void setMarkerDecay(float markerDecayIn)
+  {
+    workerMarkerDecay_ = markerDecayIn;
+  }
   void setMarkers(std::vector<frMarker>& in)
   {
     markers_.clear();

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -110,6 +110,8 @@ class FlexDR
     int mazeEndIter;
     frUInt4 workerDRCCost;
     frUInt4 workerMarkerCost;
+    frUInt4 workerFixedShapeCost;
+    float workerMarkerDecay;
     int ripupMode;
     bool followGuide;
   };
@@ -307,6 +309,8 @@ class FlexDRWorker
         ripupMode_(1),
         workerDRCCost_(ROUTESHAPECOST),
         workerMarkerCost_(MARKERCOST),
+        workerFixedShapeCost_(0),
+        workerMarkerDecay_(0),
         boundaryPin_(),
         pinCnt_(0),
         initNumMarkers_(0),
@@ -342,6 +346,8 @@ class FlexDRWorker
         ripupMode_(0),
         workerDRCCost_(0),
         workerMarkerCost_(0),
+        workerFixedShapeCost_(0),
+        workerMarkerDecay_(0),
         boundaryPin_(),
         pinCnt_(0),
         initNumMarkers_(0),
@@ -382,10 +388,15 @@ class FlexDRWorker
   void setMazeEndIter(int in) { mazeEndIter_ = in; }
   void setRipupMode(int in) { ripupMode_ = in; }
   void setFollowGuide(bool in) { followGuide_ = in; }
-  void setCost(frUInt4 drcCostIn, frUInt4 markerCostIn)
+  void setCost(frUInt4 drcCostIn,
+               frUInt4 markerCostIn,
+               frUInt4 workerFixedShapeCostIn,
+               float workerMarkerDecayIn)
   {
     workerDRCCost_ = drcCostIn;
     workerMarkerCost_ = markerCostIn;
+    workerFixedShapeCost_ = workerFixedShapeCostIn;
+    workerMarkerDecay_ = workerMarkerDecayIn;
   }
   void setMarkerCost(frUInt4 markerCostIn) { workerMarkerCost_ = markerCostIn; }
   void setDrcCost(frUInt4 drcCostIn) { workerDRCCost_ = drcCostIn; }
@@ -538,7 +549,8 @@ class FlexDRWorker
   bool skipRouting_;
   int ripupMode_;
   // drNetOrderingEnum netOrderingMode;
-  frUInt4 workerDRCCost_, workerMarkerCost_;
+  frUInt4 workerDRCCost_, workerMarkerCost_, workerFixedShapeCost_;
+  float workerMarkerDecay_;
   // used in init route as gr boundary pin
   std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
       boundaryPin_;

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -1990,7 +1990,7 @@ void FlexDRWorker::initGridGraph(const frDesign* design)
   map<frCoord, map<frLayerNum, frTrackPattern*>> xMap;
   map<frCoord, map<frLayerNum, frTrackPattern*>> yMap;
   initTrackCoords(xMap, yMap);
-  gridGraph_.setCost(workerDRCCost_, workerMarkerCost_);
+  gridGraph_.setCost(workerDRCCost_, workerMarkerCost_, workerFixedShapeCost_);
   gridGraph_.init(design,
                   getRouteBox(),
                   getExtBox(),
@@ -2552,7 +2552,8 @@ void FlexDRWorker::route_queue_markerCostDecay()
     auto currIt = it;
     auto& mi = *currIt;
     ++it;
-    if (gridGraph_.decayMarkerCostPlanar(mi.x(), mi.y(), mi.z(), MARKERDECAY)) {
+    if (gridGraph_.decayMarkerCostPlanar(
+            mi.x(), mi.y(), mi.z(), workerMarkerDecay_)) {
       planarHistoryMarkers_.erase(currIt);
     }
   }
@@ -2560,7 +2561,8 @@ void FlexDRWorker::route_queue_markerCostDecay()
     auto currIt = it;
     auto& mi = *currIt;
     ++it;
-    if (gridGraph_.decayMarkerCostVia(mi.x(), mi.y(), mi.z(), MARKERDECAY)) {
+    if (gridGraph_.decayMarkerCostVia(
+            mi.x(), mi.y(), mi.z(), workerMarkerDecay_)) {
       viaHistoryMarkers_.erase(currIt);
     }
   }

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -3256,7 +3256,7 @@ int FlexDRWorker::routeNet_postAstarAddPathMetal_isClean(
                 xIdx, bpIdx.y(), bpIdx.z(), frDirEnum::E)) {
           cost += gridGraph_.getEdgeLength(
                       xIdx, bpIdx.y(), bpIdx.z(), frDirEnum::E)
-                  * FIXEDSHAPECOST;
+                  * workerFixedShapeCost_;
         }
         if (gridGraph_.hasMarkerCostAdj(
                 xIdx, bpIdx.y(), bpIdx.z(), frDirEnum::E)) {
@@ -3278,7 +3278,7 @@ int FlexDRWorker::routeNet_postAstarAddPathMetal_isClean(
                 bpIdx.x(), yIdx, bpIdx.z(), frDirEnum::N)) {
           cost += gridGraph_.getEdgeLength(
                       bpIdx.x(), yIdx, bpIdx.z(), frDirEnum::N)
-                  * FIXEDSHAPECOST;
+                  * workerFixedShapeCost_;
         }
         if (gridGraph_.hasMarkerCostAdj(
                 bpIdx.x(), yIdx, bpIdx.z(), frDirEnum::N)) {

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -56,6 +56,7 @@ class FlexGridGraph
         zHeights_(),
         ggDRCCost_(0),
         ggMarkerCost_(0),
+        ggFixedShapeCost_(0),
         halfViaEncArea_(nullptr),
         via2viaMinLen_(nullptr),
         via2viaMinLenNew_(nullptr),
@@ -863,10 +864,13 @@ class FlexGridGraph
               FlexMazeIdx& ccMazeIdx2,
               const Point& centerPt,
               std::map<FlexMazeIdx, frBox3D*>& mazeIdx2TaperBox);
-  void setCost(frUInt4 drcCostIn, frUInt4 markerCostIn)
+  void setCost(frUInt4 drcCostIn,
+               frUInt4 markerCostIn,
+               frUInt4 FixedShapeCostIn)
   {
     ggDRCCost_ = drcCostIn;
     ggMarkerCost_ = markerCostIn;
+    ggFixedShapeCost_ = FixedShapeCostIn;
   }
   frCoord getHalfViaEncArea(frMIdx z, bool isLayer1) const
   {
@@ -1008,6 +1012,7 @@ class FlexGridGraph
   Rect dieBox_;
   frUInt4 ggDRCCost_;
   frUInt4 ggMarkerCost_;
+  frUInt4 ggFixedShapeCost_;
   // temporary variables
   FlexWavefront wavefront_;
   const std::vector<std::pair<frCoord, frCoord>>*

--- a/src/drt/src/dr/FlexGridGraph_maze.cpp
+++ b/src/drt/src/dr/FlexGridGraph_maze.cpp
@@ -556,8 +556,8 @@ frCoord FlexGridGraph::getCostsNDR(frMIdx gridX,
   // get costs
   for (frMIdx x = startX; x <= endX; x++) {
     for (frMIdx y = startY; y <= endY; y++) {
-      cost
-          += (hasFixedShapeCostAdj(x, y, gridZ, dir) ? FIXEDSHAPECOST * el : 0);
+      cost += (hasFixedShapeCostAdj(x, y, gridZ, dir) ? ggFixedShapeCost_ * el
+                                                      : 0);
       cost += (hasRouteShapeCostAdj(x, y, gridZ, dir) ? ggDRCCost_ * el : 0);
       cost += (hasMarkerCostAdj(x, y, gridZ, dir) ? ggMarkerCost_ * el : 0);
       cost += (isBlocked(x, y, gridZ, dir)
@@ -593,8 +593,9 @@ frCoord FlexGridGraph::getViaCostsNDR(frMIdx gridX,
   endX = getUpperBoundIndex(xCoords_, x2 = (xCoords_[gridX] + r));
   startY = getLowerBoundIndex(yCoords_, y1 = (yCoords_[gridY] - r));
   endY = getUpperBoundIndex(yCoords_, y2 = (yCoords_[gridY] + r));
-  cost += (hasFixedShapeCostAdj(gridX, gridY, gridZ, dir) ? FIXEDSHAPECOST * el
-                                                          : 0);
+  cost += (hasFixedShapeCostAdj(gridX, gridY, gridZ, dir)
+               ? ggFixedShapeCost_ * el
+               : 0);
   cost
       += (hasRouteShapeCostAdj(gridX, gridY, gridZ, dir) ? ggDRCCost_ * el : 0);
   cost += (hasMarkerCostAdj(gridX, gridY, gridZ, dir) ? ggMarkerCost_ * el : 0);
@@ -630,8 +631,8 @@ frCoord FlexGridGraph::getViaCostsNDR(frMIdx gridX,
   // get costs
   for (frMIdx x = startX; x <= endX; x++) {
     for (frMIdx y = startY; y <= endY; y++) {
-      cost
-          += (hasFixedShapeCostAdj(x, y, gridZ, dir) ? FIXEDSHAPECOST * el : 0);
+      cost += (hasFixedShapeCostAdj(x, y, gridZ, dir) ? ggFixedShapeCost_ * el
+                                                      : 0);
       cost += (hasRouteShapeCostAdj(x, y, gridZ, dir) ? ggDRCCost_ * el : 0);
       cost += (hasMarkerCostAdj(x, y, gridZ, dir) ? ggMarkerCost_ * el : 0);
     }
@@ -658,7 +659,7 @@ frCost FlexGridGraph::getCosts(frMIdx gridX,
          + (gridCost ? GRIDCOST * edgeLength : 0)
          + (drcCost ? ggDRCCost_ * edgeLength : 0)
          + (markerCost ? ggMarkerCost_ * edgeLength : 0)
-         + (shapeCost ? FIXEDSHAPECOST * edgeLength : 0)
+         + (shapeCost ? ggFixedShapeCost_ * edgeLength : 0)
          + (blockCost ? BLOCKCOST * layer->getMinWidth() * 20 : 0)
          + (!guideCost ? GUIDECOST * edgeLength : 0);
 }

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -305,6 +305,8 @@ struct frDebugSettings
         mazeEndIter(-1),
         drcCost(-1),
         markerCost(-1),
+        fixedShapeCost(-1),
+        markerDecay(-1),
         ripupMode(-1),
         followGuide(-1)
 
@@ -333,6 +335,8 @@ struct frDebugSettings
   int mazeEndIter;
   int drcCost;
   int markerCost;
+  int fixedShapeCost;
+  float markerDecay;
   int ripupMode;
   int followGuide;
 };

--- a/src/drt/src/global.cpp
+++ b/src/drt/src/global.cpp
@@ -102,13 +102,11 @@ float TASHAPEBLOATWIDTH = 1.5;
 frUInt4 VIACOST = 4;
 // new cost used
 frUInt4 GRIDCOST = 2;
-frUInt4 FIXEDSHAPECOST = 30;
 frUInt4 ROUTESHAPECOST = 8;
 frUInt4 MARKERCOST = 32;
 frUInt4 MARKERBLOATWIDTH = 1;
 frUInt4 BLOCKCOST = 32;
 frUInt4 GUIDECOST = 1;  // disabled change getNextPathCost to enable
-float MARKERDECAY = 0.95;
 float SHAPEBLOATWIDTH = 3;
 int MISALIGNMENTCOST = 8;
 

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -97,13 +97,11 @@ extern float TASHAPEBLOATWIDTH;
 extern fr::frUInt4 VIACOST;
 
 extern fr::frUInt4 GRIDCOST;
-extern fr::frUInt4 FIXEDSHAPECOST;
 extern fr::frUInt4 ROUTESHAPECOST;
 extern fr::frUInt4 MARKERCOST;
 extern fr::frUInt4 MARKERBLOATWIDTH;
 extern fr::frUInt4 BLOCKCOST;
 extern fr::frUInt4 GUIDECOST;
-extern float MARKERDECAY;
 extern float SHAPEBLOATWIDTH;
 extern int MISALIGNMENTCOST;
 

--- a/src/drt/src/serialization.h
+++ b/src/drt/src/serialization.h
@@ -659,13 +659,11 @@ void serializeGlobals(Archive& ar)
   (ar) & TASHAPEBLOATWIDTH;
   (ar) & VIACOST;
   (ar) & GRIDCOST;
-  (ar) & FIXEDSHAPECOST;
   (ar) & ROUTESHAPECOST;
   (ar) & MARKERCOST;
   (ar) & MARKERBLOATWIDTH;
   (ar) & BLOCKCOST;
   (ar) & GUIDECOST;
-  (ar) & MARKERDECAY;
   (ar) & SHAPEBLOATWIDTH;
   (ar) & MISALIGNMENTCOST;
   (ar) & HISTCOST;

--- a/src/drt/test/drt_aux.py
+++ b/src/drt/test/drt_aux.py
@@ -57,10 +57,12 @@ def detailed_route(design, *,
 
 
 def step_dr(design, size, offset, mazeEndIter, workerDRCCost, 
-            workerMarkerCost, ripupMode, followGuide):
+            workerMarkerCost, workerFixedShapeCost,
+            workerMarkerDecay, ripupMode, followGuide):
     router = design.getTritonRoute()
     router.stepDR(size, offset, mazeEndIter, workerDRCCost,
-                  workerMarkerCost, ripupMode, followGuide)
+                  workerMarkerCost, workerFixedShapeCost,
+                  workerMarkerDecay, ripupMode, followGuide)
 
 
 def step_end(design):

--- a/src/drt/test/single_step.py
+++ b/src/drt/test/single_step.py
@@ -16,9 +16,9 @@ drt_aux.detailed_route(design,
                        verbose=0,
                        single_step_dr=True)
 
-drt_aux.step_dr(design, 7,  0, 3, 8, 0, 1, True)
-drt_aux.step_dr(design, 7, -2, 3, 8, 8, 1, True)
-drt_aux.step_dr(design, 7, -5, 3, 8, 8, 1, True)
+drt_aux.step_dr(design, 7,  0, 3, 8, 0, 8, 0.95, 1, True)
+drt_aux.step_dr(design, 7, -2, 3, 8, 8, 8, 0.95, 1, True)
+drt_aux.step_dr(design, 7, -5, 3, 8, 8, 8, 0.95, 1, True)
 drt_aux.step_end(design)
 
 def_file = helpers.make_result_file("single_step.def")

--- a/src/drt/test/single_step.tcl
+++ b/src/drt/test/single_step.tcl
@@ -9,9 +9,9 @@ detailed_route -output_drc results/single_step.output.drc.rpt \
                -verbose 0 \
                -single_step_dr
 
-drt::step_dr 7  0 3 8 0 1 true 
-drt::step_dr 7 -2 3 8 8 1 true
-drt::step_dr 7 -5 3 8 8 1 true
+drt::step_dr 7  0 3 8 0 8 0.95 1 true
+drt::step_dr 7 -2 3 8 8 8 0.95 1 true
+drt::step_dr 7 -5 3 8 8 8 0.95 1 true
 drt::step_end
 
 set def_file [make_result_file single_step.def]


### PR DESCRIPTION
FIXEDSHAPECOST and MARKERDECAY change based on the iteration, so move
them into SearchRepairArgs where all other per iteration variables are
set.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>
