### PR TITLE
Undo change to dbtypes.i and add %clear directive to PdnGen-py.i

### DIFF
--- a/src/odb/src/swig/python/dbtypes.i
+++ b/src/odb/src/swig/python/dbtypes.i
@@ -217,6 +217,7 @@
 
 // Handle return by ref.
 %apply int &OUTPUT { int & overhang1, int & overhang2 };
+%apply int &OUTPUT { int & x, int & y };
 %apply int &OUTPUT { int & x_spacing, int & y_spacing };
 WRAP_OBJECT_RETURN_REF(odb::Rect, r)
 WRAP_OBJECT_RETURN_REF(odb::Rect, rect)

--- a/src/pdn/src/PdnGen-py.i
+++ b/src/pdn/src/PdnGen-py.i
@@ -66,7 +66,7 @@ using namespace pdn;
 %apply unsigned long { ExtensionMode };
 
 %import "odb.i"
-%import "dbtypes.i"
+%clear int & x, int & y; // defined in dbtypes.i, must be cleared here.
 %include <std_string.i>
 
 // These are needed to coax swig into sending or returning Python 


### PR DESCRIPTION
Signed-off-by: Don MacMillen <don@macmillen.net>
So this got through the regression tests because I completely forgot that the odb Python regressions do not run with the standard OR regression system. We have to fix that.