### PR TITLE
global router: this warning seems almost like an error

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1986,13 +1986,14 @@ void GlobalRouter::checkPinPlacement()
     } else {
       for (odb::Point& pos : layer_positions_map[layer]) {
         if (pos == port->getPosition()) {
-          if (verbose_)
-            logger_->warn(GRT,
-                          31,
-                          "At least 2 pins in position ({}, {}), layer {}.",
-                          pos.x(),
-                          pos.y(),
-                          tech_layer->getName());
+          logger_->warn(
+              GRT,
+              31,
+              "At least 2 pins in position ({}, {}), layer {}, port {}.",
+              pos.x(),
+              pos.y(),
+              tech_layer->getName(),
+              port->getName().c_str());
           invalid = true;
         }
       }


### PR DESCRIPTION
too useful to omit when verbose is disabled?

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>