### PR TITLE
A few code cleanups in RCX as a first OpenROAD PR.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.rej
 *.orig
 *.vscode
+*.swp
 TAGS
 *~
 \#*#

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 *.rej
 *.orig
 *.vscode
-*.swp
+*.sw[opqr]
 TAGS
 *~
 \#*#

--- a/src/rcx/include/rcx/ext.h
+++ b/src/rcx/include/rcx/ext.h
@@ -32,9 +32,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include <tcl.h>
+
+#include <memory>
 
 #include "extRCap.h"
 #include "exttree.h"

--- a/src/rcx/include/rcx/ext.h
+++ b/src/rcx/include/rcx/ext.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <tcl.h>
 
 #include "extRCap.h"
@@ -53,7 +55,7 @@ class Ext
 {
  public:
   Ext();
-  ~Ext();
+  ~Ext() = default;
 
   void init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger);
   void setLogger(Logger* logger);
@@ -307,10 +309,10 @@ class Ext
                  const std::string& branch_len);
 
  private:
-  odb::dbDatabase* _db;
-  extMain* _ext;
-  extRcTree* _tree;
-  Logger* logger_;
+  odb::dbDatabase* _db = nullptr;
+  std::unique_ptr<extMain> _ext;
+  std::unique_ptr<extRcTree> _tree;
+  Logger* logger_ = nullptr;
 };  // namespace rcx
 
 }  // namespace rcx

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1601,7 +1601,6 @@ class extMain
   Ath__array1D<int>* _btermTable;
   Ath__array1D<int>* _itermTable;
 
-  uint _menuId;
   uint _dbPowerId;
   uint _dbSignalId;
   uint _RsegId;
@@ -1805,7 +1804,7 @@ class extMain
     ISPEF_ORIGINAL_PLUS_HALO,
     ISPEF_NEW_PLUS_HALO,
   };
-  extMain(uint menuId);
+  extMain();
 
   void set_debug_nets(const char* nets)
   {

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -51,10 +51,9 @@ extern "C" {
 extern int Rcx_Init(Tcl_Interp* interp);
 }
 
-Ext::Ext()
-  : odb::ZInterface(),
-    _ext(std::make_unique<extMain>())
-{}
+Ext::Ext() : odb::ZInterface(), _ext(std::make_unique<extMain>())
+{
+}
 
 void Ext::init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger)
 {

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -51,17 +51,10 @@ extern "C" {
 extern int Rcx_Init(Tcl_Interp* interp);
 }
 
-Ext::Ext() : odb::ZInterface()
-{
-  _ext = new extMain(5);
-  _tree = NULL;
-  logger_ = nullptr;
-}
-
-Ext::~Ext()
-{
-  delete _ext;
-}
+Ext::Ext()
+  : odb::ZInterface(),
+    _ext(std::make_unique<extMain>(5))
+{}
 
 void Ext::init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger)
 {
@@ -687,8 +680,8 @@ bool Ext::rc_tree(float max_cap,
 
   odb::dbBlock* block = _ext->getBlock();
 
-  if (_tree == NULL)
-    _tree = new extRcTree(block, logger_);
+  if (_tree == nullptr)
+    _tree = std::make_unique<extRcTree>(block, logger_);
 
   uint cnt;
   if (netId > 0)

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -53,7 +53,7 @@ extern int Rcx_Init(Tcl_Interp* interp);
 
 Ext::Ext()
   : odb::ZInterface(),
-    _ext(std::make_unique<extMain>(5))
+    _ext(std::make_unique<extMain>())
 {}
 
 void Ext::init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger)

--- a/src/rcx/src/extBenchDB.cpp
+++ b/src/rcx/src/extBenchDB.cpp
@@ -630,7 +630,6 @@ int extRCModel::writeBenchWires_DB(extMeasure* measure)
   uint WW2 = measure->_w2_nm;
   uint SS2 = measure->_s2_nm;
 
-  uint base;
   if (n > 1) {
     cnt++;
     measure->createNetSingleWire(_wireDirName, idCnt, WW, s_layout);
@@ -639,7 +638,6 @@ int extRCModel::writeBenchWires_DB(extMeasure* measure)
     cnt++;
     if (!measure->_diag) {
       measure->createNetSingleWire(_wireDirName, idCnt, WW, SS1);
-      base = measure->_ll[measure->_dir] + WW / 2;
       idCnt++;
       cnt++;
       measure->createNetSingleWire(_wireDirName, idCnt, WW2, SS2);
@@ -665,7 +663,6 @@ int extRCModel::writeBenchWires_DB(extMeasure* measure)
       idCnt++;
     }
   } else {
-    base = measure->_ll[measure->_dir] + WW / 2;
     cnt++;
     measure->createNetSingleWire(_wireDirName, 3, w_layout, s_layout);
     idCnt++;

--- a/src/rcx/src/extBenchDB.cpp
+++ b/src/rcx/src/extBenchDB.cpp
@@ -431,22 +431,6 @@ uint extRCModel::benchDB_WS(extMainOptions* opt, extMeasure* measure)
     }
   } else if (opt->_nondefault_lef_rules) {
     return 0;
-    wTable->resetCnt();
-    sTable->resetCnt();
-    dbSet<dbTechNonDefaultRule> nd_rules = opt->_tech->getNonDefaultRules();
-    dbSet<dbTechNonDefaultRule>::iterator nditr;
-    dbTechLayerRule* tst_rule;
-
-    for (nditr = nd_rules.begin(); nditr != nd_rules.end(); ++nditr) {
-      tst_rule = (*nditr)->getLayerRule(layer);
-      if (tst_rule == NULL)
-        continue;
-
-      double w = tst_rule->getWidth();
-      double s = tst_rule->getSpacing();
-      wTable->add(w);
-      sTable->add(s);
-    }
   } else {
     if (measure->_diag)
       spaceTable->add(0.0);
@@ -688,32 +672,6 @@ int extRCModel::writeBenchWires_DB(extMeasure* measure)
   }
 
   if (measure->_diag) {
-    return cnt;
-
-    int met;
-    if (measure->_overMet > 0)
-      met = measure->_overMet;
-    else if (measure->_underMet > 0)
-      met = measure->_underMet;
-
-    double minWidth = measure->_minWidth;
-    double minSpace = measure->_minSpace;
-    double min_pitch = minWidth + minSpace;
-    measure->clean2dBoxTable(met, false);
-    int i;
-    uint begin = base - Ath__double2int(measure->_seff * 1000)
-                 + Ath__double2int(minWidth * 1000) / 2;
-    for (i = 0; i < n + 1; i++) {
-      measure->createDiagNetSingleWire(_wireDirName,
-                                       idCnt,
-                                       begin,
-                                       Ath__double2int(1000 * minWidth),
-                                       Ath__double2int(1000 * minSpace),
-                                       measure->_dir);
-      begin -= Ath__double2int(min_pitch * 1000);
-      idCnt++;
-    }
-    measure->_ur[measure->_dir] += grid_gap_cnt * (w_layout + s_layout);
     return cnt;
   }
   bool grid_context = true;

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1259,12 +1259,6 @@ uint extSpef::writeRes(uint netId, odb::dbSet<odb::dbRSeg>& rSet)
   }
   return cnt;
 }
-void getjxy(odb::dbNet* net, uint jid, Logger* logger)
-{
-  int jx, jy;
-  net->getWire()->getCoord((int) jid, jx, jy);
-  logger->info(RCX, 174, "{}:{} {} {}", net->getId(), jid, jx, jy);
-}
 uint extSpef::writeNet(odb::dbNet* net, double resBound, uint debug)
 {
   _d_net = net;

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -395,7 +395,7 @@ void extMain::setupMapping(uint itermCnt)
   _itermTable = new Ath__array1D<int>(itermCnt);
   _nodeTable = new Ath__array1D<int>(16000);
 }
-extMain::extMain(uint menuId)
+extMain::extMain()
     : _db(nullptr),
       _tech(nullptr),
       _block(nullptr),
@@ -476,7 +476,6 @@ extMain::extMain(uint menuId)
   _gndcFactor = 1.0;
   _gndcModify = false;
 
-  _menuId = menuId;
   _dbPowerId = 1;
   _dbSignalId = 2;
   _CCsegId = 3;

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -1226,15 +1226,6 @@ void extMain::printNet(dbNet* net, uint netId)
   if (netId == net->getId())
     net->printNetName(stdout);
 }
-bool IsDebugNets(dbNet* srcNet, dbNet* tgtNet, uint debugNetId)
-{
-  if (srcNet != NULL && srcNet->getId() == debugNetId)
-    return true;
-  if (tgtNet != NULL && tgtNet->getId() == debugNetId)
-    return true;
-
-  return false;
-}
 void extMain::measureRC(CoupleOptions& options)
 {
   _totSegCnt++;
@@ -1392,11 +1383,6 @@ void extMain::measureRC(CoupleOptions& options)
     }
   }
   ccReportProgress();
-}
-void extCompute(CoupleOptions& options, void* computePtr)
-{
-  extMain* mmm = (extMain*) computePtr;
-  mmm->measureRC(options);
 }
 extern CoupleOptions coupleOptionsNull;
 

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -63,7 +63,7 @@ void extMain::initExtractedCorners(dbBlock* block)
 {
   extMain* tmiExt = (extMain*) block->getExtmi();
   if (tmiExt == NULL) {
-    tmiExt = new extMain(0);
+    tmiExt = new extMain;
     tmiExt->init((dbDatabase*) block->getDataBase(), logger_);
   }
   if (tmiExt->_processCornerTable)
@@ -76,7 +76,7 @@ int extMain::getExtCornerIndex(dbBlock* block, const char* cornerName)
 {
   extMain* tmiExt = (extMain*) block->getExtmi();
   if (tmiExt == NULL) {
-    tmiExt = new extMain(0);
+    tmiExt = new extMain;
     tmiExt->init((dbDatabase*) block->getDataBase(), logger_);
   }
   int idx = tmiExt->getDbCornerIndex(cornerName);
@@ -165,7 +165,7 @@ void extMain::writeIncrementalSpef(std::vector<dbNet*>& buf_nets,
 {
   extMain* tmiExt = (extMain*) block->getExtmi();
   if (tmiExt == NULL) {
-    tmiExt = new extMain(0);
+    tmiExt = new extMain;
     tmiExt->init((dbDatabase*) block->getDataBase(), logger_);
   }
   tmiExt->writeIncrementalSpef(buf_nets,

--- a/src/rcx/src/extprocess.cpp
+++ b/src/rcx/src/extprocess.cpp
@@ -816,19 +816,6 @@ double extMasterConductor::writeRaphaelBox(FILE* fp,
                                            double volt)
 {
   return writeRaphaelPoly(fp, wireNum, width, X, volt);
-
-  fprintf(fp, "BOX NAME=");
-  writeBoxName(fp, wireNum);
-
-  fprintf(fp,
-          " CX=%g; CY=%g; W=%g; H=%g; VOLT=%g\n",
-          X,
-          _loLeft[2],
-          width,
-          _hiLeft[2] - _loLeft[2],
-          volt);
-
-  return X + width;
 }
 void extMasterConductor::writeRaphaelPointXY(FILE* fp, double X, double Y)
 {

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1116,13 +1116,6 @@ void extMain::removeExt()
   }
   removeExt(rnets);
 }
-void v_printWireNeighbor(void* ip,
-                         uint met,
-                         void* v_swire,
-                         void* v_topNeighbor,
-                         void* v_botNeighbor)
-{
-}
 void extCompute(CoupleOptions& inputTable, void* extModel);
 void extCompute1(CoupleOptions& inputTable, void* extModel);
 
@@ -1881,9 +1874,11 @@ bool extMain::setCorners(const char* rulesFileName, const char* cmp_file)
     logger_->info(
         RCX, 435, "Reading extraction model file {} ...", rulesFileName);
 
-    if (!fopen(rulesFileName, "r"))
+    FILE* rules_file = fopen(rulesFileName, "r");
+    if (rules_file == nullptr)
       logger_->error(
           RCX, 468, "Can't open extraction model file {}", rulesFileName);
+    fclose(rules_file);
 
     if (!(m->readRules((char*) rulesFileName,
                        false,


### PR DESCRIPTION
- Use unique_ptr in two spots where unique lifetime ownership was immediately clear.
- Delete some unreachable code flagged by static analysis tooling.
- Add Vim swp files to the ignored file extension list in .gitignore (similar to the existing ignorance of vscode files).

Signed-off-by: Christopher D. Leary <cdleary@gmail.com>