### PR TITLE
[rcx] ext2dBox translation unit: encapsulate/test

### DIFF
--- a/src/drt/test/gc_test.tcl
+++ b/src/drt/test/gc_test.tcl
@@ -1,31 +1,3 @@
 source "helpers.tcl"
 
-set test_dir [pwd]
-set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
-set test_path [file join $openroad_dir "build" "src" "drt" "trTest"]
-
-set test_status [catch { exec sh -c "BASE_DIR=$test_dir $test_path" } output option]
-
-puts $test_status 
-puts $output 
-if { $test_status != 0 } {
-  set test_err_info [lassign [dict get $option -errorcode] err_type]
-  switch -exact -- $err_type {
-    NONE {
-      #passed
-    }
-    CHILDSTATUS {
-      # non-zero exit status
-      set exit_status [lindex $test_err_info 1]
-      puts "ERROR: test returned exit code $exit_status"
-      exit 1
-
-    }
-    default {
-      puts "ERROR: $option"
-      exit 1
-    }
-  }
-}
-puts "pass"
-exit 0
+run_unit_test_and_exit [list "build" "src" "drt" "trTest"]

--- a/src/odb/include/odb/util.h
+++ b/src/odb/include/odb/util.h
@@ -229,6 +229,9 @@ class AthArray
 };
 
 // A simple pool allocation function
+//
+// Note: T must be default-constructible, as `new` is used to construct T when
+// memory debugging is enabled.
 template <class T>
 class AthPool
 {

--- a/src/rcx/include/rcx/ext2dBox.h
+++ b/src/rcx/include/rcx/ext2dBox.h
@@ -54,7 +54,6 @@ class ext2dBox  // assume cross-section on the z-direction
            bool dir);
 
   void rotate();
-  bool matchCoords(int* ll, int* ur) const;
   void printGeoms3D(FILE* fp,
                     double h,
                     double t,

--- a/src/rcx/include/rcx/ext2dBox.h
+++ b/src/rcx/include/rcx/ext2dBox.h
@@ -1,0 +1,86 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Nefelus Inc
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <array>
+#include <cstdio>
+
+namespace rcx {
+
+class ext2dBox  // assume cross-section on the z-direction
+{
+ public:
+  // Implementation note: a default constructor is necessary because these are
+  // AthPool allocated, and it requires the type to be default constructible.
+  // We use placement new (with the full constructor below) for initialization
+  // after pool allocation.
+  ext2dBox() = default;
+
+  ext2dBox(std::array<int, 2> ll,
+           std::array<int, 2> ur,
+           unsigned int met,
+           unsigned int id,
+           unsigned int map,
+           bool dir);
+
+  void rotate();
+  bool matchCoords(int* ll, int* ur) const;
+  void printGeoms3D(FILE* fp,
+                    double h,
+                    double t,
+                    const std::array<int, 2>& orig) const;
+  unsigned int length() const;
+  unsigned int width() const;
+  int loX() const;
+  int loY() const;
+  unsigned int id() const;
+
+  unsigned int met() const { return _met; }
+  unsigned int map() const { return _map; }
+  bool dir() const { return _dir; }
+
+  int ur0() const { return _ur[0]; }
+  int ur1() const { return _ur[1]; }
+  int ll0() const { return _ll[0]; }
+  int ll1() const { return _ll[1]; }
+
+ private:
+  std::array<int, 2> _ll;
+  std::array<int, 2> _ur;
+  unsigned int _met;
+  unsigned int _id;
+  unsigned int _map;
+  bool _dir;
+};
+
+}  // namespace rcx

--- a/src/rcx/include/rcx/ext2dBox.h
+++ b/src/rcx/include/rcx/ext2dBox.h
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Nefelus Inc
+// Copyright (c) 2019-2023, Nefelus Inc, Google LLC
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -43,6 +43,7 @@
 
 #include "ZObject.h"
 #include "db.h"
+#include "ext2dBox.h"
 #include "extprocess.h"
 #include "gseq.h"
 #include "odb.h"
@@ -63,27 +64,6 @@ using odb::Darr;
 using odb::uint;
 using utl::Logger;
 
-class ext2dBox  // assume cross-section on the z-direction
-{
-  int _ll[2];
-  int _ur[2];
-  uint _met;
-  uint _dir;
-  uint _id;
-  uint _map;
-
-  void rotate();
-  bool matchCoords(int* ll, int* ur);
-  void printGeoms3D(FILE* fp, double h, double t, int* orig);
-  uint length();
-  uint width();
-  int loX();
-  int loY();
-  uint id();
-
-  friend class extMeasure;
-  friend class extRCModel;
-};
 class extGeoVarTable
 {
   int _x;

--- a/src/rcx/src/CMakeLists.txt
+++ b/src/rcx/src/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(rcx
     extstats.cpp
     extprocess.cpp
     exttree.cpp
+    ext2dBox.cpp
     hierSpef.cpp
     netRC.cpp
     powerConn.cpp
@@ -83,6 +84,41 @@ messages(
   TARGET rcx
   OUTPUT_DIR ..
 )
+
+############################################################
+# Unit testing
+############################################################
+enable_testing()
+
+add_executable(rcxUnitTest
+  ${PROJECT_SOURCE_DIR}/test/ext2dBoxTest.cpp
+)
+
+target_include_directories(rcxUnitTest
+  PRIVATE
+  ${PROJECT_SOURCE_DIR}/src
+  ${OPENROAD_HOME}/include
+)
+
+target_link_libraries(rcxUnitTest
+  rcx
+)
+
+# Use the shared library if found.  We need to pass this info to
+# the code to select the corresponding include.  Using the shared
+# library speeds up compilation.
+if (Boost_unit_test_framework_FOUND)
+  message(STATUS "Boost unit_test_framework library found")
+  target_link_libraries(trTest
+    Boost::unit_test_framework
+  )
+  target_compile_definitions(trTest
+    PRIVATE
+    HAS_BOOST_UNIT_TEST_LIBRARY
+  )
+endif()
+
+add_test(NAME trTest COMMAND trTest)
 
 if (Python3_FOUND AND BUILD_PYTHON)
   swig_lib(NAME          rcx_py

--- a/src/rcx/src/ext2dBox.cpp
+++ b/src/rcx/src/ext2dBox.cpp
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Nefelus Inc
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "rcx/ext2dBox.h"
 
 #include <utility>

--- a/src/rcx/src/ext2dBox.cpp
+++ b/src/rcx/src/ext2dBox.cpp
@@ -45,14 +45,6 @@ ext2dBox::ext2dBox(std::array<int, 2> ll,
     : _ll(ll), _ur(ur), _met(met), _id(id), _map(map), _dir(dir)
 {
 }
-bool ext2dBox::matchCoords(int* ll, int* ur) const
-{
-  if ((ur[0] < _ll[0]) || (ll[0] > _ur[0]) || (ur[1] < _ll[1])
-      || (ll[1] > _ur[1]))
-    return false;
-
-  return true;
-}
 
 void ext2dBox::rotate()
 {

--- a/src/rcx/src/ext2dBox.cpp
+++ b/src/rcx/src/ext2dBox.cpp
@@ -1,0 +1,75 @@
+#include "rcx/ext2dBox.h"
+
+#include <utility>
+
+namespace rcx {
+
+ext2dBox::ext2dBox(std::array<int, 2> ll,
+                   std::array<int, 2> ur,
+                   unsigned int met,
+                   unsigned int id,
+                   unsigned int map,
+                   bool dir)
+    : _ll(ll), _ur(ur), _met(met), _id(id), _map(map), _dir(dir)
+{
+}
+bool ext2dBox::matchCoords(int* ll, int* ur) const
+{
+  if ((ur[0] < _ll[0]) || (ll[0] > _ur[0]) || (ur[1] < _ll[1])
+      || (ll[1] > _ur[1]))
+    return false;
+
+  return true;
+}
+
+void ext2dBox::rotate()
+{
+  std::swap(_ur[0], _ur[1]);
+  std::swap(_ll[0], _ll[1]);
+  _dir = !_dir;
+}
+unsigned int ext2dBox::length() const
+{
+  return _ur[_dir] - _ll[_dir];
+}
+unsigned int ext2dBox::width() const
+{
+  return _ur[!_dir] - _ll[!_dir];
+}
+int ext2dBox::loX() const
+{
+  return _ll[0];
+}
+int ext2dBox::loY() const
+{
+  return _ll[1];
+}
+unsigned int ext2dBox::id() const
+{
+  return _id;
+}
+void ext2dBox::printGeoms3D(FILE* fp,
+                            double h,
+                            double t,
+                            const std::array<int, 2>& orig) const
+{
+  fprintf(fp,
+          "%3d %8d -- M%d D%d  %g %g  %g %g  L= %g W= %g  H= %g  TH= %g ORIG "
+          "%g %g\n",
+          _id,
+          _map,
+          _met,
+          _dir,
+          0.001 * _ll[0],
+          0.001 * _ll[1],
+          0.001 * _ur[0],
+          0.001 * _ur[1],
+          0.001 * length(),
+          0.001 * width(),
+          h,
+          t,
+          0.001 * (_ll[0] - orig[0]),
+          0.001 * (_ll[1] - orig[1]));
+}
+
+}  // namespace rcx

--- a/src/rcx/src/ext2dBox.cpp
+++ b/src/rcx/src/ext2dBox.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Nefelus Inc
+// Copyright (c) 2019-2023, Nefelus Inc, Google LLC
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/rcx/src/extBench.cpp
+++ b/src/rcx/src/extBench.cpp
@@ -587,13 +587,14 @@ uint extRCModel::writePatternGeoms(extMeasure* m,
           0.001 * m->_ur[0],
           0.001 * m->_ur[1]);
 
+  const std::array<int, 2> orig = {m->_ll[0], m->_ll[1]};
   for (uint ii = 0; ii < boxArray->getCnt(); ii++) {
     ext2dBox* bb = boxArray->get(ii);
-    uint met = bb->_met;
+    uint met = bb->met();
 
     double h = _process->getConductor(met)->_height;
     double t = _process->getConductor(met)->_thickness;
-    bb->printGeoms3D(fp, h, t, m->_ll);
+    bb->printGeoms3D(fp, h, t, orig);
   }
   fclose(fp);
   return boxArray->getCnt();
@@ -621,7 +622,7 @@ bool extRCModel::makePatternNet3D(extMeasure* measure,
   double th = _process->getConductor(measure->_met)->_thickness;
 
   ext2dBox* bb1 = boxArray->get(0);
-  uint mainDir = bb1->_dir;
+  uint mainDir = bb1->dir();
   if (mainDir == 0) {
     int x = measure->_ll[0];
     measure->_ll[0] = measure->_ll[1];
@@ -643,7 +644,7 @@ bool extRCModel::makePatternNet3D(extMeasure* measure,
     if (mainDir == 0) {
       bb->rotate();
     }
-    uint met = bb->_met;
+    uint met = bb->met();
 
     double h = _process->getConductor(met)->_height;
     double t = _process->getConductor(met)->_thickness;
@@ -682,14 +683,6 @@ uint extMeasure::getRSeg(dbNet* net, uint shapeId)
     return rsegId;
   else
     return 0;
-}
-bool ext2dBox::matchCoords(int* ll, int* ur)
-{
-  if ((ur[0] < _ll[0]) || (ll[0] > _ur[0]) || (ur[1] < _ll[1])
-      || (ll[1] > _ur[1]))
-    return false;
-
-  return true;
 }
 
 uint extRCModel::runWiresSolver(uint netId, int shapeId)

--- a/src/rcx/src/extmeasure.cpp
+++ b/src/rcx/src/extmeasure.cpp
@@ -260,7 +260,9 @@ ext2dBox* extMeasure::addNew2dBox(dbNet* net,
     bb_ur = {ur[0], ur[1]};
   }
 
-  assert(d == 0 || d == 1);
+  if (d != 0 && d != 1)
+    logger_->error(RCX, 498, "Direction value is out of range.");
+
   new (bb) ext2dBox(bb_ll, bb_ur, /*met=*/m, id, /*map=*/0, /*dir=*/d);
 
   if (cntx)  // context net

--- a/src/rcx/test/ext2dBoxTest.cpp
+++ b/src/rcx/test/ext2dBoxTest.cpp
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Nefelus Inc
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #define BOOST_TEST_MODULE ext2dBox
 
 #ifdef HAS_BOOST_UNIT_TEST_LIBRARY

--- a/src/rcx/test/ext2dBoxTest.cpp
+++ b/src/rcx/test/ext2dBoxTest.cpp
@@ -1,0 +1,67 @@
+#define BOOST_TEST_MODULE ext2dBox
+
+#ifdef HAS_BOOST_UNIT_TEST_LIBRARY
+// Shared library version
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+#else
+// Header only version
+#include <boost/test/included/unit_test.hpp>
+#endif
+
+#include "rcx/ext2dBox.h"
+
+namespace rcx {
+
+BOOST_AUTO_TEST_CASE(simple_instantiate_accessors)
+{
+  ext2dBox box({0, 1}, {2, 4}, 1, 0, 0, /*dir=*/false);
+
+  BOOST_TEST(box.dir() == false);
+  BOOST_TEST(box.ll0() == 0);
+  BOOST_TEST(box.ll1() == 1);
+  BOOST_TEST(box.ur0() == 2);
+  BOOST_TEST(box.ur1() == 4);
+
+  BOOST_TEST(box.length() == 2);
+  BOOST_TEST(box.width() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(simple_rotate)
+{
+  ext2dBox box(/*ll=*/{0, 1}, /*ur=*/{2, 4}, 1, 0, 0, /*dir=*/false);
+
+  box.rotate();
+
+  BOOST_TEST(box.dir() == true);
+  BOOST_TEST(box.ll0() == 1);
+  BOOST_TEST(box.ll1() == 0);
+  BOOST_TEST(box.ur0() == 4);
+  BOOST_TEST(box.ur1() == 2);
+
+  BOOST_TEST(box.length() == 2);
+  BOOST_TEST(box.width() == 3);
+}
+
+BOOST_AUTO_TEST_CASE(simple_print_geoms_3d)
+{
+  ext2dBox box(/*ll=*/{0, 1}, /*ur=*/{2, 4}, 1, 0, 0, /*dir=*/false);
+
+  FILE* tmp = tmpfile();
+  const std::array<int, 2> orig = {0, 0};
+  box.printGeoms3D(tmp, .5, .25, orig);
+  BOOST_TEST(fseek(tmp, 0, SEEK_SET) == 0);
+
+  constexpr size_t kBufSize = 1024;
+  std::array<uint8_t, kBufSize> buf = {0};
+  size_t total_read = 0;
+  while (!feof(tmp)) {
+    size_t read = fread(buf.data() + total_read, 1, kBufSize - total_read, tmp);
+    total_read += read;
+  }
+  BOOST_TEST(total_read != 0);
+  std::string_view s(reinterpret_cast<char*>(buf.data()));
+  BOOST_TEST(s == "  0        0 -- M1 D0  0 0.001  0.002 0.004  L= 0.002 W= 0.003  H= 0.5  TH= 0.25 ORIG 0 0.001\n");
+}
+
+}  // namespace rcx

--- a/src/rcx/test/ext2dBoxTest.cpp
+++ b/src/rcx/test/ext2dBoxTest.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Nefelus Inc
+// Copyright (c) 2023, Google LLC
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/rcx/test/rcx_unit_test.tcl
+++ b/src/rcx/test/rcx_unit_test.tcl
@@ -1,0 +1,3 @@
+source "helpers.tcl"
+
+run_unit_test_and_exit [list "build" "src" "rcx" "src" "rcxUnitTest"]

--- a/src/rcx/test/regression_tests.tcl
+++ b/src/rcx/test/regression_tests.tcl
@@ -6,3 +6,6 @@ record_tests {
   45_gcd
   names
 }
+record_pass_fail_tests {
+  rcx_unit_test
+}

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -54,6 +54,38 @@ proc diff_files { file1 file2 } {
   }
 }
 
+proc run_unit_test_and_exit { relative_path } {
+  set test_dir [pwd]
+  set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
+  set test_path [file join $openroad_dir {*}$relative_path]
+
+  set test_status [catch { exec sh -c "BASE_DIR=$test_dir $test_path" } output option]
+
+  puts $test_status
+  puts $output
+  if { $test_status != 0 } {
+    set test_err_info [lassign [dict get $option -errorcode] err_type]
+    switch -exact -- $err_type {
+      NONE {
+        #passed
+      }
+      CHILDSTATUS {
+        # non-zero exit status
+        set exit_status [lindex $test_err_info 1]
+        puts "ERROR: test returned exit code $exit_status"
+        exit 1
+
+      }
+      default {
+        puts "ERROR: $option"
+        exit 1
+      }
+    }
+  }
+  puts "pass"
+  exit 0
+}
+
 # Output voltage file is specified as ...
 suppress_message PSM 2
 # Output current file specified ...


### PR DESCRIPTION
- Put a note on `AthPool` that the type parameter has to be default-constructible.
- Break `ext2dBox` into its own translation unit, remove friend access to members in favor of it being immutable-after-construction. We use placement-`new` since it needs to be default constructible to use `AthPool`.
- Use `std::array`s to indicate safe bounds instead of raw pointers / C arrays that degenerate to raw pointers.
- Make `dir` a boolean since it was always boolean-valued.
- Make a unit test (boost based).
- Factor out unit test running harness TCL code and put into common `helpers.tcl`

Signed-off-by: Christopher D. Leary <cdleary@gmail.com>