### PR TITLE
Prevent warnings about unneeded copy in for loops

### DIFF
--- a/src/cts/src/Clock.cpp
+++ b/src/cts/src/Clock.cpp
@@ -95,7 +95,7 @@ Box<double> Clock::computeSinkRegionClustered(
   auto yMin = std::numeric_limits<float>::max();
   auto yMax = std::numeric_limits<float>::lowest();
 
-  for (const auto [sinkX, sinkY] : sinks) {
+  for (const auto& [sinkX, sinkY] : sinks) {
     xMin = std::min(xMin, sinkX);
     xMax = std::max(xMax, sinkX);
     yMin = std::min(yMin, sinkY);

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3034,7 +3034,7 @@ void HierRTLMP::multiLevelMacroPlacement(Cluster* parent)
   }
   // add the virtual connections (the weight related to IOs and macros belong to
   // the same cluster)
-  for (const auto [cluster1, cluster2] : parent->getVirtualConnections()) {
+  for (const auto& [cluster1, cluster2] : parent->getVirtualConnections()) {
     BundledNet net(soft_macro_id_map[cluster_map_[cluster1]->getName()],
                    soft_macro_id_map[cluster_map_[cluster2]->getName()],
                    virtual_weight_);


### PR DESCRIPTION
Just two small changes to prevent copy of std::pair in for loops