### PR TITLE
lef: check if windows compile in lef.y and avoid referencing the lef_parser.hpp as it fails to compile

### DIFF
--- a/src/odb/src/lef/lef/lef.y
+++ b/src/odb/src/lef/lef/lef.y
@@ -63,7 +63,10 @@
 #include "lefrCallBacks.hpp"
 #include "lefrSettings.hpp"
 
-#include "lef_parser.hpp"
+#ifndef WIN32
+  // Only include this on non-Windows platforms
+  #include "lef_parser.hpp"
+#endif
 
 BEGIN_LEFDEF_PARSER_NAMESPACE
 


### PR DESCRIPTION
Fixes:
- Compiles for LEF parser only on windows.