### PR TITLE
gui: fix handling of TCL commands and results in GUI

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -95,6 +95,10 @@ ScriptWidget::ScriptWidget(QWidget* parent)
           this,
           SLOT(addCommandToOutput(const QString&)));
   connect(input_,
+          SIGNAL(addResultToOutput(const QString&, bool)),
+          this,
+          SLOT(addResultToOutput(const QString&, bool)));
+  connect(input_,
           SIGNAL(commandFinishedExecuting(bool)),
           this,
           SLOT(resetPauser()));

--- a/src/gui/src/tclCmdInputWidget.cpp
+++ b/src/gui/src/tclCmdInputWidget.cpp
@@ -699,27 +699,26 @@ void TclCmdInputWidget::executeCommand(const QString& cmd,
 
   const std::string command = cmd.toStdString();
 
-  int return_code = Tcl_Eval(interp_, command.c_str());
+  const int return_code = Tcl_Eval(interp_, command.c_str());
+  const bool is_ok = return_code == TCL_OK;
 
   if (!silent) {
     // Show its output
-    processTclResult(return_code);
+    processTclResult(is_ok);
 
-    if (return_code == TCL_OK && echo) {
+    if (is_ok) {
       // record the successful command to tcl history command
       Tcl_RecordAndEval(interp_, command.c_str(), TCL_NO_EVAL);
+      addCommandToHistory(QString::fromStdString(command));
     }
-
-    addCommandToHistory(QString::fromStdString(command));
   }
 
-  emit commandFinishedExecuting(return_code == TCL_OK);
+  emit commandFinishedExecuting(is_ok);
 }
 
-void TclCmdInputWidget::processTclResult(int return_code)
+void TclCmdInputWidget::processTclResult(bool is_ok)
 {
-  emit addResultToOutput(Tcl_GetString(Tcl_GetObjResult(interp_)),
-                         return_code == TCL_OK);
+  emit addResultToOutput(Tcl_GetString(Tcl_GetObjResult(interp_)), is_ok);
 }
 
 }  // namespace gui

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -86,7 +86,7 @@ class TclCmdInputWidget : public CmdInputWidget
 
  private:
   void init();
-  void processTclResult(int result_code);
+  void processTclResult(bool is_ok);
 
   static int tclExitHandler(ClientData instance_data,
                             Tcl_Interp* interp,


### PR DESCRIPTION
Fixes:
- result handling was mistakenly turned off, this should re-enable it in the GUI