### PR TITLE
grt: estimate parasitics over corners based on rsz corner values if available

### DIFF
--- a/src/grt/CMakeLists.txt
+++ b/src/grt/CMakeLists.txt
@@ -70,6 +70,7 @@ target_link_libraries(grt
     dbSta
     gui
     stt
+    rsz
     OpenSTA
     Boost::boost
 )

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -77,6 +77,10 @@ namespace dpl {
 class Opendp;
 }
 
+namespace rsz {
+class Resizer;
+}
+
 namespace sta {
 class dbSta;
 class dbNetwork;
@@ -142,6 +146,7 @@ class GlobalRouter
             stt::SteinerTreeBuilder* stt_builder,
             odb::dbDatabase* db,
             sta::dbSta* sta,
+            rsz::Resizer* resizer,
             ant::AntennaChecker* antenna_checker,
             dpl::Opendp* opendp);
   void clear();
@@ -371,6 +376,7 @@ class GlobalRouter
   stt::SteinerTreeBuilder* stt_builder_;
   ant::AntennaChecker* antenna_checker_;
   dpl::Opendp* opendp_;
+  rsz::Resizer* resizer_;
   // Objects variables
   FastRouteCore* fastroute_;
   odb::Point grid_origin_;

--- a/src/grt/src/MakeGlobalRouter.cpp
+++ b/src/grt/src/MakeGlobalRouter.cpp
@@ -71,6 +71,7 @@ void initGlobalRouter(OpenRoad* openroad)
                                     openroad->getSteinerTreeBuilder(),
                                     openroad->getDb(),
                                     openroad->getSta(),
+                                    openroad->getResizer(),
                                     openroad->getAntennaChecker(),
                                     openroad->getOpendp());
 }

--- a/src/grt/src/MakeWireParasitics.h
+++ b/src/grt/src/MakeWireParasitics.h
@@ -62,12 +62,17 @@ namespace utl {
 class Logger;
 }
 
+namespace rsz {
+class Resizer;
+}
+
 namespace grt {
 
 class MakeWireParasitics
 {
  public:
   MakeWireParasitics(utl::Logger* logger,
+                     rsz::Resizer* resizer,
                      sta::dbSta* sta,
                      odb::dbTech* tech,
                      GlobalRouter* grouter);
@@ -92,27 +97,28 @@ class MakeWireParasitics
                // Return values.
                float& res,
                float& cap);
-  float getCutLayerRes(unsigned below_layer_id);
+  float getCutLayerRes(odb::dbTechLayer* cut_layer, int num_cuts = 1) const;
   double dbuToMeters(int dbu);
 
   // Variables common to all nets.
   GlobalRouter* grouter_;
   odb::dbTech* tech_;
   utl::Logger* logger_;
+  rsz::Resizer* resizer_;
   sta::dbSta* sta_;
   sta::dbNetwork* network_;
   sta::Parasitics* parasitics_;
-  sta::Corner* corner_;
   sta::MinMax* min_max_;
-  sta::ParasiticAnalysisPt* analysis_point_;
 
   // Net variables
   sta::Net* sta_net_;
-  sta::Parasitic* parasitic_;
+  sta::Corner* net_corner_;
+  sta::ParasiticAnalysisPt* net_analysis_point_;
+  sta::Parasitic* net_parasitic_;
   // Counter for internal parasitic node IDs.
   int node_id_;
   // x/y/layer -> parasitic node
-  NodeRoutePtMap node_map_;
+  std::map<sta::Corner*, NodeRoutePtMap> node_map_;
 };
 
 }  // namespace grt

--- a/src/grt/src/MakeWireParasitics.h
+++ b/src/grt/src/MakeWireParasitics.h
@@ -78,27 +78,48 @@ class MakeWireParasitics
                      GlobalRouter* grouter);
   void estimateParasitcs(odb::dbNet* net,
                          std::vector<Pin>& pins,
-                         GRoute& route);
+                         GRoute& route) const;
   // Return GRT layer lengths in dbu's for db_net's route indexed by routing
   // layer.
-  std::vector<int> routeLayerLengths(odb::dbNet* db_net);
+  std::vector<int> routeLayerLengths(odb::dbNet* db_net) const;
 
  private:
   typedef std::map<RoutePt, sta::ParasiticNode*> NodeRoutePtMap;
 
-  sta::Pin* staPin(Pin& pin);
-  void makeRouteParasitics(odb::dbNet* net, GRoute& route);
-  sta::ParasiticNode* ensureParasiticNode(int x, int y, int layer);
-  void makeParasiticsToPins(std::vector<Pin>& pins);
-  void makeParasiticsToPin(Pin& pin);
-  void reduceParasiticNetwork();
+  sta::Pin* staPin(Pin& pin) const;
+  void makeRouteParasitics(odb::dbNet* net,
+                           GRoute& route,
+                           sta::Net* sta_net,
+                           sta::Corner* corner,
+                           sta::ParasiticAnalysisPt* analysis_point,
+                           sta::Parasitic* parasitic,
+                           NodeRoutePtMap& node_map) const;
+  sta::ParasiticNode* ensureParasiticNode(int x,
+                                          int y,
+                                          int layer,
+                                          NodeRoutePtMap& node_map,
+                                          sta::Parasitic* parasitic,
+                                          sta::Net* net) const;
+  void makeParasiticsToPins(std::vector<Pin>& pins,
+                            NodeRoutePtMap& node_map,
+                            sta::Corner* corner,
+                            sta::ParasiticAnalysisPt* analysis_point,
+                            sta::Parasitic* parasitic) const;
+  void makeParasiticsToPin(Pin& pin,
+                           NodeRoutePtMap& node_map,
+                           sta::Corner* corner,
+                           sta::ParasiticAnalysisPt* analysis_point,
+                           sta::Parasitic* parasitic) const;
   void layerRC(int wire_length_dbu,
                int layer,
+               sta::Corner* corner,
                // Return values.
                float& res,
-               float& cap);
-  float getCutLayerRes(odb::dbTechLayer* cut_layer, int num_cuts = 1) const;
-  double dbuToMeters(int dbu);
+               float& cap) const;
+  float getCutLayerRes(odb::dbTechLayer* cut_layer,
+                       sta::Corner* corner,
+                       int num_cuts = 1) const;
+  double dbuToMeters(int dbu) const;
 
   // Variables common to all nets.
   GlobalRouter* grouter_;
@@ -109,16 +130,6 @@ class MakeWireParasitics
   sta::dbNetwork* network_;
   sta::Parasitics* parasitics_;
   sta::MinMax* min_max_;
-
-  // Net variables
-  sta::Net* sta_net_;
-  sta::Corner* net_corner_;
-  sta::ParasiticAnalysisPt* net_analysis_point_;
-  sta::Parasitic* net_parasitic_;
-  // Counter for internal parasitic node IDs.
-  int node_id_;
-  // x/y/layer -> parasitic node
-  std::map<sta::Corner*, NodeRoutePtMap> node_map_;
 };
 
 }  // namespace grt

--- a/src/grt/test/est_rc4.ok
+++ b/src/grt/test/est_rc4.ok
@@ -1,0 +1,106 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[WARNING STA-0053] Nangate45/Nangate45_typ.lib line 37, library NangateOpenCellLibrary already exists.
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 676 components and 2850 component-terminals.
+[INFO ODB-0133]     Created 579 nets and 1498 connections.
+Net clk
+ Pin capacitance: 29.975-33.238
+ Wire capacitance: 330.569
+ Total capacitance: 360.545-363.807
+ Number of drivers: 1
+ Number of loads: 35
+ Number of pins: 36
+
+Driver pins
+ clk input port (48, 101)
+
+Load pins
+ _858_/CK input (DFF_X1) 0.856-0.950 (29, 54)
+ _859_/CK input (DFF_X1) 0.856-0.950 (29, 60)
+ _860_/CK input (DFF_X1) 0.856-0.950 (39, 57)
+ _861_/CK input (DFF_X1) 0.856-0.950 (76, 66)
+ _862_/CK input (DFF_X1) 0.856-0.950 (44, 66)
+ _863_/CK input (DFF_X1) 0.856-0.950 (52, 75)
+ _864_/CK input (DFF_X1) 0.856-0.950 (66, 74)
+ _865_/CK input (DFF_X1) 0.856-0.950 (76, 38)
+ _866_/CK input (DFF_X1) 0.856-0.950 (78, 60)
+ _867_/CK input (DFF_X1) 0.856-0.950 (68, 36)
+ _868_/CK input (DFF_X1) 0.856-0.950 (67, 62)
+ _869_/CK input (DFF_X1) 0.856-0.950 (27, 47)
+ _870_/CK input (DFF_X1) 0.856-0.950 (29, 37)
+ _871_/CK input (DFF_X1) 0.856-0.950 (31, 33)
+ _872_/CK input (DFF_X1) 0.856-0.950 (61, 33)
+ _873_/CK input (DFF_X1) 0.856-0.950 (59, 23)
+ _874_/CK input (DFF_X1) 0.856-0.950 (45, 16)
+ _875_/CK input (DFF_X1) 0.856-0.950 (38, 19)
+ _876_/CK input (DFF_X1) 0.856-0.950 (55, 46)
+ _877_/CK input (DFF_X1) 0.856-0.950 (69, 66)
+ _878_/CK input (DFF_X1) 0.856-0.950 (44, 62)
+ _879_/CK input (DFF_X1) 0.856-0.950 (54, 72)
+ _880_/CK input (DFF_X1) 0.856-0.950 (61, 69)
+ _881_/CK input (DFF_X1) 0.856-0.950 (77, 43)
+ _882_/CK input (DFF_X1) 0.856-0.950 (79, 54)
+ _883_/CK input (DFF_X1) 0.856-0.950 (64, 43)
+ _884_/CK input (DFF_X1) 0.856-0.950 (69, 58)
+ _885_/CK input (DFF_X1) 0.856-0.950 (33, 50)
+ _886_/CK input (DFF_X1) 0.856-0.950 (27, 43)
+ _887_/CK input (DFF_X1) 0.856-0.950 (37, 30)
+ _888_/CK input (DFF_X1) 0.856-0.950 (56, 36)
+ _889_/CK input (DFF_X1) 0.856-0.950 (58, 27)
+ _890_/CK input (DFF_X1) 0.856-0.950 (52, 16)
+ _891_/CK input (DFF_X1) 0.856-0.950 (36, 26)
+ _892_/CK input (DFF_X1) 0.856-0.950 (53, 38)
+
+Net clk
+ Pin capacitance: 29.975-33.238
+ Wire capacitance: 660.869
+ Total capacitance: 690.845-694.107
+ Number of drivers: 1
+ Number of loads: 35
+ Number of pins: 36
+
+Driver pins
+ clk input port (48, 101)
+
+Load pins
+ _858_/CK input (DFF_X1) 0.856-0.950 (29, 54)
+ _859_/CK input (DFF_X1) 0.856-0.950 (29, 60)
+ _860_/CK input (DFF_X1) 0.856-0.950 (39, 57)
+ _861_/CK input (DFF_X1) 0.856-0.950 (76, 66)
+ _862_/CK input (DFF_X1) 0.856-0.950 (44, 66)
+ _863_/CK input (DFF_X1) 0.856-0.950 (52, 75)
+ _864_/CK input (DFF_X1) 0.856-0.950 (66, 74)
+ _865_/CK input (DFF_X1) 0.856-0.950 (76, 38)
+ _866_/CK input (DFF_X1) 0.856-0.950 (78, 60)
+ _867_/CK input (DFF_X1) 0.856-0.950 (68, 36)
+ _868_/CK input (DFF_X1) 0.856-0.950 (67, 62)
+ _869_/CK input (DFF_X1) 0.856-0.950 (27, 47)
+ _870_/CK input (DFF_X1) 0.856-0.950 (29, 37)
+ _871_/CK input (DFF_X1) 0.856-0.950 (31, 33)
+ _872_/CK input (DFF_X1) 0.856-0.950 (61, 33)
+ _873_/CK input (DFF_X1) 0.856-0.950 (59, 23)
+ _874_/CK input (DFF_X1) 0.856-0.950 (45, 16)
+ _875_/CK input (DFF_X1) 0.856-0.950 (38, 19)
+ _876_/CK input (DFF_X1) 0.856-0.950 (55, 46)
+ _877_/CK input (DFF_X1) 0.856-0.950 (69, 66)
+ _878_/CK input (DFF_X1) 0.856-0.950 (44, 62)
+ _879_/CK input (DFF_X1) 0.856-0.950 (54, 72)
+ _880_/CK input (DFF_X1) 0.856-0.950 (61, 69)
+ _881_/CK input (DFF_X1) 0.856-0.950 (77, 43)
+ _882_/CK input (DFF_X1) 0.856-0.950 (79, 54)
+ _883_/CK input (DFF_X1) 0.856-0.950 (64, 43)
+ _884_/CK input (DFF_X1) 0.856-0.950 (69, 58)
+ _885_/CK input (DFF_X1) 0.856-0.950 (33, 50)
+ _886_/CK input (DFF_X1) 0.856-0.950 (27, 43)
+ _887_/CK input (DFF_X1) 0.856-0.950 (37, 30)
+ _888_/CK input (DFF_X1) 0.856-0.950 (56, 36)
+ _889_/CK input (DFF_X1) 0.856-0.950 (58, 27)
+ _890_/CK input (DFF_X1) 0.856-0.950 (52, 16)
+ _891_/CK input (DFF_X1) 0.856-0.950 (36, 26)
+ _892_/CK input (DFF_X1) 0.856-0.950 (53, 38)
+

--- a/src/grt/test/est_rc4.tcl
+++ b/src/grt/test/est_rc4.tcl
@@ -1,0 +1,22 @@
+# estimate parasitics based on gr results over corners
+source "helpers.tcl"
+read_lef "Nangate45/Nangate45.lef"
+define_corners corner1 corner0
+read_liberty -corner corner0 Nangate45/Nangate45_typ.lib
+read_liberty -corner corner1 Nangate45/Nangate45_typ.lib
+read_def "gcd.def"
+read_guides "est_rc3.guide"
+
+set_layer_rc -corner corner0 -layer metal2 -resistance 2 -capacitance 1
+set_layer_rc -corner corner0 -layer metal3 -resistance 2 -capacitance 1
+set_layer_rc -corner corner0 -layer metal4 -resistance 2 -capacitance 1
+
+set_layer_rc -corner corner1 -layer metal2 -resistance 4 -capacitance 2
+set_layer_rc -corner corner1 -layer metal3 -resistance 4 -capacitance 2
+set_layer_rc -corner corner1 -layer metal4 -resistance 4 -capacitance 2
+
+set_routing_layers -signal metal2-metal10
+estimate_parasitics -global_routing
+
+report_net -corner corner0 -connections -verbose -digits 3 clk
+report_net -corner corner1 -connections -verbose -digits 3 clk

--- a/src/grt/test/regression_tests.tcl
+++ b/src/grt/test/regression_tests.tcl
@@ -12,6 +12,7 @@ record_tests {
   est_rc1
   est_rc2
   est_rc3
+  est_rc4
   gcd
   gcd_flute
   inst_pin_out_of_die

--- a/src/rsz/test/repair_hold10.ok
+++ b/src/rsz/test/repair_hold10.ok
@@ -9,10 +9,10 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 15 components and 68 component-terminals.
 [INFO ODB-0133]     Created 13 nets and 29 connections.
-worst slack -3.24
+worst slack -3.23
 [INFO RSZ-0046] Found 2 endpoints with hold violations.
 [INFO RSZ-0032] Inserted 6 hold buffers.
-worst slack 0.21
+worst slack 0.22
 Placement Analysis
 ---------------------------------
 total displacement         14.0 u


### PR DESCRIPTION
I noticed that the post routing parasitics didn't generate anything across for corners and didn't honor the rsz values when set for corners.
 
Changes:
- Generate parasitics across corners like resizer does (if only one corner is defined there shouldn't be any changes)
- Use the resizer parasitics values for corners, overwise default back to LEF

Notes:
If rsz values are not set and only one corner is defined, there should be no functional changes