### PR TITLE
Fixing metrics float handling

### DIFF
--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -38,6 +38,7 @@
 #include <array>
 #include <cstdlib>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <stack>
@@ -46,7 +47,6 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
-#include <limits>
 
 #include "Metrics.h"
 #include "spdlog/fmt/fmt.h"
@@ -84,7 +84,8 @@ namespace utl {
   X(STA)                \
   X(STT)                \
   X(TAP)                \
-  X(UKN)
+  X(UKN)                \
+  X(UTL)
 
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
@@ -215,6 +216,7 @@ class Logger
   void addSink(spdlog::sink_ptr sink);
   void removeSink(spdlog::sink_ptr sink);
   void addMetricsSink(const char* metrics_filename);
+  void removeMetricsSink(const char* metrics_filename);
 
   void setMetricsStage(std::string_view format);
   void clearMetricsStage();
@@ -268,6 +270,7 @@ class Logger
     metrics_entries_.push_back({key, value});
   }
 
+  void flushMetrics();
   void finalizeMetrics();
 
   // Allows for lookup by a compatible key (ie string_view)

--- a/src/utl/src/LoggerCommon.cpp
+++ b/src/utl/src/LoggerCommon.cpp
@@ -82,6 +82,12 @@ void open_metrics(const char* metrics_filename)
   logger->addMetricsSink(metrics_filename);
 }
 
+void close_metrics(const char* metrics_filename)
+{
+  Logger* logger = getLogger();
+  logger->removeMetricsSink(metrics_filename);
+}
+
 void metric(const char* metric, const char* value)
 {
   Logger* logger = getLogger();

--- a/src/utl/src/LoggerCommon.cpp
+++ b/src/utl/src/LoggerCommon.cpp
@@ -94,7 +94,7 @@ void metric_integer(const char* metric, const int value)
   logger->metric(metric, value);
 }
 
-void metric_float(const char* metric, const float value)
+void metric_float(const char* metric, const double value)
 {
   Logger* logger = getLogger();
   logger->metric(metric, value);

--- a/src/utl/src/LoggerCommon.h
+++ b/src/utl/src/LoggerCommon.h
@@ -45,7 +45,7 @@ void critical(utl::ToolId tool, int id, const char* msg);
 void open_metrics(const char* metrics_filename);
 void metric(const char* metric, const char* value);
 void metric_integer(const char* metric, const int value);
-void metric_float(const char* metric, const float value);
+void metric_float(const char* metric, const double value);
 void set_metrics_stage(const char* fmt);
 void clear_metrics_stage();
 void push_metrics_stage(const char* fmt);

--- a/src/utl/src/LoggerCommon.h
+++ b/src/utl/src/LoggerCommon.h
@@ -43,6 +43,7 @@ void warn(utl::ToolId tool, int id, const char* msg);
 void error(utl::ToolId tool, int id, const char* msg);
 void critical(utl::ToolId tool, int id, const char* msg);
 void open_metrics(const char* metrics_filename);
+void close_metrics(const char* metrics_filename);
 void metric(const char* metric, const char* value);
 void metric_integer(const char* metric, const int value);
 void metric_float(const char* metric, const double value);

--- a/src/utl/test/helpers.py
+++ b/src/utl/test/helpers.py
@@ -1,0 +1,1 @@
+../../../test/helpers.py

--- a/src/utl/test/helpers.tcl
+++ b/src/utl/test/helpers.tcl
@@ -1,0 +1,1 @@
+../../../test/helpers.tcl

--- a/src/utl/test/metrics-py.jsonok
+++ b/src/utl/test/metrics-py.jsonok
@@ -1,0 +1,13 @@
+{
+	"integer0": -1,
+	"integer1": 0,
+	"integer2": 1,
+	"float0": 0,
+	"float1": 1000,
+	"float2": 1e+39,
+	"float3": "nan",
+	"float4": "inf",
+	"float5": "-inf",
+	"string0": "",
+	"string1": "(one"
+}

--- a/src/utl/test/metrics-tcl.jsonok
+++ b/src/utl/test/metrics-tcl.jsonok
@@ -1,0 +1,12 @@
+{
+	"integer0": -1,
+	"integer1": 0,
+	"integer2": 1,
+	"float0": 0,
+	"float1": 1000,
+	"float2": 1e+39,
+	"float4": "inf",
+	"float5": "-inf",
+	"string0": "",
+	"string1": "one"
+}

--- a/src/utl/test/regression_tests.tcl
+++ b/src/utl/test/regression_tests.tcl
@@ -2,6 +2,7 @@ record_tests {
     test_info
     test_error
     test_suppress_message
+    test_metrics
     #test_error_exception
 }
 

--- a/src/utl/test/test_metrics.ok
+++ b/src/utl/test/test_metrics.ok
@@ -1,0 +1,1 @@
+No differences found.

--- a/src/utl/test/test_metrics.py
+++ b/src/utl/test/test_metrics.py
@@ -1,0 +1,20 @@
+import utl
+import helpers
+
+metrics_file = helpers.make_result_file("metrics.json")
+
+utl.open_metrics(metrics_file)
+
+utl.metric_integer("integer0", -1)
+utl.metric_integer("integer1", 0)
+utl.metric_integer("integer2", 1)
+
+utl.metric_float("float0", 0)
+utl.metric_float("float1", 1e3)
+utl.metric_float("float2", 1e39)
+utl.metric_float("float3", float("nan"))
+utl.metric_float("float4", float("inf"))
+utl.metric_float("float5", float("-inf"))
+
+utl.metric("string0", "")
+utl.metric("string1", "(one")

--- a/src/utl/test/test_metrics.py
+++ b/src/utl/test/test_metrics.py
@@ -18,3 +18,9 @@ utl.metric_float("float5", float("-inf"))
 
 utl.metric("string0", "")
 utl.metric("string1", "(one")
+
+utl.close_metrics(metrics_file)
+helpers.diff_files("metrics-py.jsonok", metrics_file)
+
+
+utl.metric_float("float6", float("-inf"))

--- a/src/utl/test/test_metrics.tcl
+++ b/src/utl/test/test_metrics.tcl
@@ -18,3 +18,6 @@ utl::metric_float "float5" -INF
 
 utl::metric "string0" ""
 utl::metric "string1" "one"
+
+utl::close_metrics $metrics_file
+diff_files "metrics-tcl.jsonok" $metrics_file

--- a/src/utl/test/test_metrics.tcl
+++ b/src/utl/test/test_metrics.tcl
@@ -1,0 +1,20 @@
+source "helpers.tcl"
+
+set metrics_file [make_result_file "metrics.json"]
+
+utl::open_metrics $metrics_file
+
+utl::metric_integer "integer0" -1
+utl::metric_integer "integer1" 0
+utl::metric_integer "integer2" 1
+
+utl::metric_float "float0" 0
+utl::metric_float "float1" 1e3
+utl::metric_float "float2" 1e39
+# TCL cannot convert NaN
+#utl::metric_float "float3" nan
+utl::metric_float "float4" INF
+utl::metric_float "float5" -INF
+
+utl::metric "string0" ""
+utl::metric "string1" "one"


### PR DESCRIPTION
We ran into a new problem with the metrics handler and it was easier to fix the handling of `inf` and `nan` by converting them to a string metric and recording them so.
Additionally, Tcl doesn't really have floats they are all doubles, so large values that are legal in tcl will cause a SWIG error if `metric_float` takes a float.

Fixes:
- Change float to double in SWIG interface
- Add checking of values for `inf` and `nan` to ensure the metrics are recorded.
- Adds units tests to the metrics (along with ability to close the metrics file), so these issues can be tested for.