### PR TITLE
Add support for C++20 Compilation

### DIFF
--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -15,11 +15,6 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16
-      - name: Install Ninja
-        run: |
-          sudo wget -qO /usr/local/bin/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
-          sudo gunzip /usr/local/bin/ninja.gz
-          sudo chmod a+x /usr/local/bin/ninja
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
@@ -42,4 +37,4 @@ jobs:
           cd ../..
       - name: Build OpenROAD
         run: |
-          ./etc/Build.sh -compiler='clang-16' -cmake='-GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20'
+          ./etc/Build.sh -compiler='clang-16' -cmake='-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20'

--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -1,0 +1,27 @@
+name: Test C++20 Compile
+on:
+  # Triggers the workflow on push or pull request events
+  push:
+  pull_request:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install clang
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 16
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: Install dependencies
+        run: |
+          sudo ./etc/DependencyInstaller.sh
+      - name: Build OpenROAD
+        run: |
+          ./etc/Build.sh -compiler='clang-16' -cmake='-DCMAKE_CXX_STANDARD=20'

--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -15,6 +15,12 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16
+      - name: Install Ninja
+        run: |
+          sudo wget -qO /usr/local/bin/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
+          sudo gunzip /usr/local/bin/ninja.gz
+          sudo chmod a+x /usr/local/bin/ninja
+          sudo rm /usr/local/bin/ninja.gz
       - name: Check out repository code
         uses: actions/checkout@v3
         with:
@@ -37,4 +43,4 @@ jobs:
           cd ../..
       - name: Build OpenROAD
         run: |
-          ./etc/Build.sh -compiler='clang-16' -cmake='-DCMAKE_CXX_STANDARD=20'
+          ./etc/Build.sh -compiler='clang-16' -cmake='-GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_STANDARD=20'

--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get install mercurial
           hg clone http://lemon.cs.elte.hu/hg/lemon
           cd lemon
-          hg co ed2c21cb
+          hg co a278d16bd2d082aa3c52ff4a9b0e2224ddc0549a
           hg import ../third-party/lemon/patches/allocator-patch.patch
           mkdir build
           cd build

--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -20,7 +20,6 @@ jobs:
           sudo wget -qO /usr/local/bin/ninja.gz https://github.com/ninja-build/ninja/releases/latest/download/ninja-linux.zip
           sudo gunzip /usr/local/bin/ninja.gz
           sudo chmod a+x /usr/local/bin/ninja
-          sudo rm /usr/local/bin/ninja.gz
       - name: Check out repository code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/github-actions-c++.yml
+++ b/.github/workflows/github-actions-c++.yml
@@ -22,6 +22,19 @@ jobs:
       - name: Install dependencies
         run: |
           sudo ./etc/DependencyInstaller.sh
+      - name: Install Patched LEMON # Current LEMON does not compile with C++20 https://lemon.cs.elte.hu/trac/lemon/ticket/631#no1
+        run: |
+          sudo apt-get install mercurial
+          hg clone http://lemon.cs.elte.hu/hg/lemon
+          cd lemon
+          hg co ed2c21cb
+          hg import ../third-party/lemon/patches/allocator-patch.patch
+          mkdir build
+          cd build
+          cmake ..
+          make
+          sudo make install
+          cd ../..
       - name: Build OpenROAD
         run: |
           ./etc/Build.sh -compiler='clang-16' -cmake='-DCMAKE_CXX_STANDARD=20'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ set(OPENROAD_HOME ${PROJECT_SOURCE_DIR})
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 # Default c++ standard used unless otherwise specified in target_compile_features.
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "the C++ standard to use for this project")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Disable compiler specific extensions like gnu++11.
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/docs/contrib/Logger.md
+++ b/docs/contrib/Logger.md
@@ -33,6 +33,27 @@ critical, error, warning, information and debug. These are supported by
 automatic calls to the logger which will then prefix the appropriate
 severity type to the message.
 
+## C++20 Requirements
+
+In C++20 the logger messages are checked during compile time which introduces
+restrictions around rutime format strings. See [docs](https://fmt.dev/latest/api.html#compile-time-format-string-checks)
+
+OpenROAD uses SPDLog which usues fmt_lib under the hood below is an example of
+what is no longer allowed.
+
+In order to make use of runtime format strings we have introduced a 
+`FMT_RUNTIME` macro in Logger.h. You should use this any time that you are 
+passing a dynamic string as the format string 
+
+```c++
+logger_->info("{} {}", a, b); // OK
+
+void blah(std::string template& a) {
+  logger_->info(a, c); // Illegal
+  logger_->info(FMT_RUNTIME(a), c); // Ok
+}
+```
+
 ## Messaging Guidelines
 
 In addition to the proper use of message types, follow the guidelines
@@ -419,7 +440,7 @@ target_link_libraries(<library_target>
 ```
 
 | Tool             | message/namespace |
-|------------------|-------------------|
+| ---------------- | ----------------- |
 | antenna_checker  | ant               |
 | dbSta            | sta               |
 | FastRoute        | grt               |

--- a/docs/contrib/Logger.md
+++ b/docs/contrib/Logger.md
@@ -41,7 +41,7 @@ restrictions around rutime format strings. See [docs](https://fmt.dev/latest/api
 OpenROAD uses `spdlog` which uses `fmt_lib` under the hood. Below is an example of
 what is no longer allowed.
 
-In order to make use of runtime format strings we have introduced a 
+In order to make use of runtime format strings, we have introduced a 
 `FMT_RUNTIME` macro in Logger.h. You should use this macro any time you
 pass a dynamic string as the format string 
 

--- a/docs/contrib/Logger.md
+++ b/docs/contrib/Logger.md
@@ -42,8 +42,8 @@ OpenROAD uses `spdlog` which uses `fmt_lib` under the hood. Below is an example 
 what is no longer allowed.
 
 In order to make use of runtime format strings we have introduced a 
-`FMT_RUNTIME` macro in Logger.h. You should use this any time that you are 
-passing a dynamic string as the format string 
+`FMT_RUNTIME` macro in Logger.h. You should use this macro any time you
+pass a dynamic string as the format string 
 
 ```c++
 logger_->info("{} {}", a, b); // OK

--- a/docs/contrib/Logger.md
+++ b/docs/contrib/Logger.md
@@ -38,7 +38,7 @@ severity type to the message.
 In C++20 the logger messages are checked during compile time which introduces
 restrictions around rutime format strings. See [docs](https://fmt.dev/latest/api.html#compile-time-format-string-checks)
 
-OpenROAD uses SPDLog which usues fmt_lib under the hood below is an example of
+OpenROAD uses `spdlog` which uses `fmt_lib` under the hood. Below is an example of
 what is no longer allowed.
 
 In order to make use of runtime format strings we have introduced a 

--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -103,17 +103,7 @@ case "${compiler}" in
         export CC="$(command -v gcc)"
         export CXX="$(command -v g++)"
         ;;
-    "clang" )
-        if [[ -f "/opt/rh/llvm-toolset-7.0/enable" ]]; then
-            # the scl script has unbound variables
-            set +u
-            source /opt/rh/llvm-toolset-7.0/enable
-            set -u
-        fi
-        export CC="$(command -v clang)"
-        export CXX="$(command -v clang++)"
-        ;;
-    clang-* )
+    clang* )
         if [[ -f "/opt/rh/llvm-toolset-7.0/enable" ]]; then
             # the scl script has unbound variables
             set +u

--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -113,6 +113,16 @@ case "${compiler}" in
         export CC="$(command -v clang)"
         export CXX="$(command -v clang++)"
         ;;
+    clang-* )
+        if [[ -f "/opt/rh/llvm-toolset-7.0/enable" ]]; then
+            # the scl script has unbound variables
+            set +u
+            source /opt/rh/llvm-toolset-7.0/enable
+            set -u
+        fi
+        export CC="$(command -v ${compiler})"
+        export CXX="$(command -v ${compiler}++)"
+        ;;
     *)
         echo "Compiler $compiler is not supported" >&2
         _help 1

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -112,7 +112,7 @@ _installCommonDev() {
         cd "${baseDir}"
         git clone -b "v${spdlogVersion}" https://github.com/gabime/spdlog.git
         cd spdlog
-        ${cmakePrefix}/bin/cmake -B build .
+        ${cmakePrefix}/bin/cmake -DSPDLOG_BUILD_EXAMPLE=OFF -B build .
         ${cmakePrefix}/bin/cmake --build build -j $(nproc) --target install
     else
         echo "spdlog already installed."

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -18,7 +18,7 @@ _installCommonDev() {
     eigenVersion=3.4
     lemonVersion=1.3.1
     lemonChecksum="e89f887559113b68657eca67cf3329b5"
-    spdlogVersion=1.8.1
+    spdlogVersion=1.10.0
 
     # temp dir to download and compile
     baseDir=/tmp/installers

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -374,7 +374,7 @@ static int tclAppInit(int& argc,
           // need to delay loading of file until after GUI is completed
           // initialized
           gui::Gui::get()->addRestoreStateCommand(
-              fmt::format(fmt::runtime(restore_state_cmd), init.string()));
+              fmt::format(FMT_RUNTIME(restore_state_cmd), init.string()));
         }
       }
 #else
@@ -388,7 +388,7 @@ static int tclAppInit(int& argc,
           // need to delay loading of file until after GUI is completed
           // initialized
           gui::Gui::get()->addRestoreStateCommand(
-              fmt::format(fmt::runtime(restore_state_cmd), init_path));
+              fmt::format(FMT_RUNTIME(restore_state_cmd), init_path));
         }
       }
 #endif

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -374,7 +374,7 @@ static int tclAppInit(int& argc,
           // need to delay loading of file until after GUI is completed
           // initialized
           gui::Gui::get()->addRestoreStateCommand(
-              fmt::format(restore_state_cmd, init.string()));
+              fmt::format(fmt::runtime(restore_state_cmd), init.string()));
         }
       }
 #else
@@ -388,7 +388,7 @@ static int tclAppInit(int& argc,
           // need to delay loading of file until after GUI is completed
           // initialized
           gui::Gui::get()->addRestoreStateCommand(
-              fmt::format(restore_state_cmd, init_path));
+              fmt::format(fmt::runtime(restore_state_cmd), init_path));
         }
       }
 #endif
@@ -409,9 +409,8 @@ static int tclAppInit(int& argc,
           } else {
             // need to delay loading of file until after GUI is completed
             // initialized
-            const char* restore_state_cmd = "source {{{}}}";
             gui::Gui::get()->addRestoreStateCommand(
-                fmt::format(restore_state_cmd, cmd_file));
+                fmt::format("source {{{}}}", cmd_file));
             if (exit_after_cmd_file) {
               gui::Gui::get()->addRestoreStateCommand("exit");
             }

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1814,11 +1814,11 @@ void DisplayControls::buildRestoreTclCommands(std::vector<std::string>& cmds,
       buildRestoreTclCommands(cmds, item, name + "/");
     } else {
       bool visible = parent->child(r, Visible)->checkState() == Qt::Checked;
-      cmds.push_back(fmt::format(fmt::runtime(visible_restore), name, visible));
+      cmds.push_back(fmt::format(FMT_RUNTIME(visible_restore), name, visible));
       auto* selectable = parent->child(r, Selectable);
       if (selectable != nullptr) {
         bool select = selectable->checkState() == Qt::Checked;
-        cmds.push_back(fmt::format(fmt::runtime(selectable_restore), name, select));
+        cmds.push_back(fmt::format(FMT_RUNTIME(selectable_restore), name, select));
       }
     }
   }

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1818,7 +1818,8 @@ void DisplayControls::buildRestoreTclCommands(std::vector<std::string>& cmds,
       auto* selectable = parent->child(r, Selectable);
       if (selectable != nullptr) {
         bool select = selectable->checkState() == Qt::Checked;
-        cmds.push_back(fmt::format(FMT_RUNTIME(selectable_restore), name, select));
+        cmds.push_back(
+            fmt::format(FMT_RUNTIME(selectable_restore), name, select));
       }
     }
   }

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1814,11 +1814,11 @@ void DisplayControls::buildRestoreTclCommands(std::vector<std::string>& cmds,
       buildRestoreTclCommands(cmds, item, name + "/");
     } else {
       bool visible = parent->child(r, Visible)->checkState() == Qt::Checked;
-      cmds.push_back(fmt::format(visible_restore, name, visible));
+      cmds.push_back(fmt::format(fmt::runtime(visible_restore), name, visible));
       auto* selectable = parent->child(r, Selectable);
       if (selectable != nullptr) {
         bool select = selectable->checkState() == Qt::Checked;
-        cmds.push_back(fmt::format(selectable_restore, name, select));
+        cmds.push_back(fmt::format(fmt::runtime(selectable_restore), name, select));
       }
     }
   }

--- a/src/par/src/MLPart/mlpart/ABKCommon/abkrand.h
+++ b/src/par/src/MLPart/mlpart/ABKCommon/abkrand.h
@@ -76,11 +76,12 @@ CHANGES
 #ifndef _ABKRAND_H_
 #define _ABKRAND_H_
 
-#include "abkseed.h"
-#include "abkassert.h"
-#include "verbosity.h"
-#include <iostream>
 #include <cmath>
+#include <iostream>
+
+#include "abkassert.h"
+#include "abkseed.h"
+#include "verbosity.h"
 
 /* These classes are actually typedefed in the bottom of this class;
  statements are rather verbose, therefore not included here  -ILM
@@ -97,34 +98,41 @@ typedef RandomNumberGenerator RNG;
 */
 
 //: All random "kernel" classes MUST be derived from RandomRoot
-class RandomRoot {
-       private:
-        SeedHandler _handler;
+class RandomRoot
+{
+ private:
+  SeedHandler _handler;
 
-       protected:
-        unsigned _seed;
-        Verbosity _verb;
-        RandomRoot(unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : _handler(seed), _verb(verb) {
-                _seed = _handler._seed;
-                if (verb.getForMajStats()) std::cout << "_seed = " << _seed << std::endl;
-        }
+ protected:
+  unsigned _seed;
+  Verbosity _verb;
+  RandomRoot(unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent"))
+      : _handler(seed), _verb(verb)
+  {
+    _seed = _handler._seed;
+    if (verb.getForMajStats())
+      std::cout << "_seed = " << _seed << std::endl;
+  }
 
-        RandomRoot(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent"));
+  RandomRoot(const char* locIdent,
+             unsigned counterOverride = UINT_MAX,
+             Verbosity verb = Verbosity("silent"));
 
-       public:
-        static const double randTick;  //    = 1/(0xffffffff + 1.0); // 2^-32
-        unsigned getSeed() const {
-                abkfatal(!_handler._isSeedMultipartite,
-                         "can't use getSeed() "
-                         "with multipartite seed");
-                return _seed;
-        }
+ public:
+  static const double randTick;  //    = 1/(0xffffffff + 1.0); // 2^-32
+  unsigned getSeed() const
+  {
+    abkfatal(!_handler._isSeedMultipartite,
+             "can't use getSeed() "
+             "with multipartite seed");
+    return _seed;
+  }
 
-        static unsigned getExternalSeed();
-        const char *getLocIdent() const;
-        unsigned getCounter() const;
+  static unsigned getExternalSeed();
+  const char* getLocIdent() const;
+  unsigned getCounter() const;
 
-        const Verbosity &getVerbosity() const { return _verb; }
+  const Verbosity& getVerbosity() const { return _verb; }
 };
 
 //:  Currently implemented are based on the r250 (or r1279)
@@ -134,103 +142,160 @@ class RandomRoot {
 //   because you have a significant chance that the sequences produced
 //   by two different seeds will overlap in the global sequence of
 //   the RNG, and therefore not be independent.
-class Tausworthe : public RandomRoot {
-       private:
-        unsigned _encryptWithSeed(unsigned clear);
-        // the reason for the function is to be able
-        // to "encrypt" a buffer value in a way dependent on
-        // the seed, so that the initial state of the buffer
-        // depends very chaotically on the seed.
-        // returns (clear XOR _seed)^17 mod cryptMod
-        void _encryptBufWithSeed();
+class Tausworthe : public RandomRoot
+{
+ private:
+  unsigned _encryptWithSeed(unsigned clear);
+  // the reason for the function is to be able
+  // to "encrypt" a buffer value in a way dependent on
+  // the seed, so that the initial state of the buffer
+  // depends very chaotically on the seed.
+  // returns (clear XOR _seed)^17 mod cryptMod
+  void _encryptBufWithSeed();
 
-        void _encryptBufMultipartiteSeed();
+  void _encryptBufMultipartiteSeed();
 
-        unsigned _multmod(unsigned x, unsigned y);
-        // returns x*y mod cryptMod
-        unsigned _bufferSize;
-        unsigned _tauswortheQ;
-        mutable unsigned *_buffer;
-        mutable unsigned _cursor;
+  unsigned _multmod(unsigned x, unsigned y);
+  // returns x*y mod cryptMod
+  unsigned _bufferSize;
+  unsigned _tauswortheQ;
+  mutable unsigned* _buffer;
+  mutable unsigned _cursor;
 
-       protected:
-        Tausworthe(unsigned bufSize, unsigned Q, unsigned *preloads, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomRoot(seed, verb), _bufferSize(bufSize), _tauswortheQ(Q), _preloads(preloads) {
-                _buffer = new unsigned[bufSize];
-                for (unsigned i = 0; i != bufSize; i++) _buffer[i] = 0;
-                _encryptBufWithSeed();
-        }
+ protected:
+  Tausworthe(unsigned bufSize,
+             unsigned Q,
+             unsigned* preloads,
+             unsigned seed = UINT_MAX,
+             Verbosity verb = Verbosity("silent"))
+      : RandomRoot(seed, verb),
+        _bufferSize(bufSize),
+        _tauswortheQ(Q),
+        _preloads(preloads)
+  {
+    _buffer = new unsigned[bufSize];
+    for (unsigned i = 0; i != bufSize; i++)
+      _buffer[i] = 0;
+    _encryptBufWithSeed();
+  }
 
-        Tausworthe(unsigned bufSize, unsigned Q, unsigned *preloads, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomRoot(locIdent, counterOverride, verb), _bufferSize(bufSize), _tauswortheQ(Q), _preloads(preloads) {
-                _buffer = new unsigned[bufSize];
-                for (unsigned i = 0; i != bufSize; i++) _buffer[i] = 0;
-                _encryptBufMultipartiteSeed();
-        }
+  Tausworthe(unsigned bufSize,
+             unsigned Q,
+             unsigned* preloads,
+             const char* locIdent,
+             unsigned counterOverride = UINT_MAX,
+             Verbosity verb = Verbosity("silent"))
+      : RandomRoot(locIdent, counterOverride, verb),
+        _bufferSize(bufSize),
+        _tauswortheQ(Q),
+        _preloads(preloads)
+  {
+    _buffer = new unsigned[bufSize];
+    for (unsigned i = 0; i != bufSize; i++)
+      _buffer[i] = 0;
+    _encryptBufMultipartiteSeed();
+  }
 
-        ~Tausworthe() { delete[] _buffer; }
-        inline unsigned _getRawUnsigned() {
-                // the function is the genuine "raw" engine for the RNG
-                {
-                        unsigned retval;
-                        int otherPoint = _cursor - _tauswortheQ;
-                        if (otherPoint < 0) otherPoint += _bufferSize;
+  ~Tausworthe() { delete[] _buffer; }
+  inline unsigned _getRawUnsigned()
+  {
+    // the function is the genuine "raw" engine for the RNG
+    {
+      unsigned retval;
+      int otherPoint = _cursor - _tauswortheQ;
+      if (otherPoint < 0)
+        otherPoint += _bufferSize;
 
-                        retval = _buffer[_cursor] ^= _buffer[otherPoint];
-                        if (++_cursor >= _bufferSize) _cursor = 0;
+      retval = _buffer[_cursor] ^= _buffer[otherPoint];
+      if (++_cursor >= _bufferSize)
+        _cursor = 0;
 
-                        return retval;
-                }
-        }
-        double _getRawDouble() { return randTick * _getRawUnsigned(); }
-        unsigned *_preloads;
+      return retval;
+    }
+  }
+  double _getRawDouble() { return randTick * _getRawUnsigned(); }
+  unsigned* _preloads;
 };
 
 //: Existing engine classes: RandomKernel250 is derived from Tausworthe.
 //    This is not necessary for future engine classes, and indeed
 //    if your generator is not Tausworthe-style then please
 //    don't derive it from Tausworthe as that would be confusing.
-class RandomKernel250 : public Tausworthe {
+class RandomKernel250 : public Tausworthe
+{
+ protected:
+  RandomKernel250(unsigned seed = UINT_MAX,
+                  Verbosity verb = Verbosity("silent"));
 
-       protected:
-        RandomKernel250(unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent"));
-
-        RandomKernel250(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent"));
+  RandomKernel250(const char* locIdent,
+                  unsigned counterOverride = UINT_MAX,
+                  Verbosity verb = Verbosity("silent"));
 };
 //: The other existing engine class derived form Tausworthe.
-class RandomKernel1279 : public Tausworthe {
+class RandomKernel1279 : public Tausworthe
+{
+ protected:
+  RandomKernel1279(unsigned seed = UINT_MAX,
+                   Verbosity verb = Verbosity("silent"));
 
-       protected:
-        RandomKernel1279(unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent"));
-
-        RandomKernel1279(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent"));
+  RandomKernel1279(const char* locIdent,
+                   unsigned counterOverride = UINT_MAX,
+                   Verbosity verb = Verbosity("silent"));
 };
 
 //: Base template class of RandomUnsignT, RandomDoubleT, RandomRawUnsignT
 //  RandomRawDoubleT and so on
 template <class RK>
-class RandomNumberGeneratorT : public RK {
-       protected:
-        double _dLowerB, _dUpperB, _dDelta;
-        unsigned _lowerB, _upperB, _delta;
+class RandomNumberGeneratorT : public RK
+{
+ protected:
+  double _dLowerB, _dUpperB, _dDelta;
+  unsigned _lowerB, _upperB, _delta;
 
-        unsigned _getUnsignedRand();
-        double _getDoubleRand();
+  unsigned _getUnsignedRand();
+  double _getDoubleRand();
 
-       public:
-        RandomNumberGeneratorT(double _lowerBdry, double _upperBdry, unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seedN, verb), _dLowerB(_lowerBdry), _dUpperB(_upperBdry), _dDelta(_upperBdry - _lowerBdry), _lowerB(unsigned(_lowerBdry)), _upperB(unsigned(_upperBdry)) {
-                abkfatal(_lowerBdry < _upperBdry, " Invalid range for random number generator");
-                abkfatal(_dDelta > 1e-4, " Range too small for random number generator ");
-                _delta = unsigned(_dDelta);
-                if (_dDelta < 1) _delta = 1;
-        }
+ public:
+  RandomNumberGeneratorT(double _lowerBdry,
+                         double _upperBdry,
+                         unsigned seedN = UINT_MAX,
+                         Verbosity verb = Verbosity("silent"))
+      : RK(seedN, verb),
+        _dLowerB(_lowerBdry),
+        _dUpperB(_upperBdry),
+        _dDelta(_upperBdry - _lowerBdry),
+        _lowerB(unsigned(_lowerBdry)),
+        _upperB(unsigned(_upperBdry))
+  {
+    abkfatal(_lowerBdry < _upperBdry,
+             " Invalid range for random number generator");
+    abkfatal(_dDelta > 1e-4, " Range too small for random number generator ");
+    _delta = unsigned(_dDelta);
+    if (_dDelta < 1)
+      _delta = 1;
+  }
 
-        RandomNumberGeneratorT(double _lowerBdry, double _upperBdry, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb), _dLowerB(_lowerBdry), _dUpperB(_upperBdry), _dDelta(_upperBdry - _lowerBdry), _lowerB(unsigned(_lowerBdry)), _upperB(unsigned(_upperBdry)) {
-                abkfatal(_lowerBdry < _upperBdry, " Invalid range for random number generator");
-                abkfatal(_dDelta > 1e-4, " Range too small for random number generator ");
-                _delta = unsigned(_dDelta);
-                if (_dDelta < 1) _delta = 1;
-        }
+  RandomNumberGeneratorT(double _lowerBdry,
+                         double _upperBdry,
+                         const char* locIdent,
+                         unsigned counterOverride = UINT_MAX,
+                         Verbosity verb = Verbosity("silent"))
+      : RK(locIdent, counterOverride, verb),
+        _dLowerB(_lowerBdry),
+        _dUpperB(_upperBdry),
+        _dDelta(_upperBdry - _lowerBdry),
+        _lowerB(unsigned(_lowerBdry)),
+        _upperB(unsigned(_upperBdry))
+  {
+    abkfatal(_lowerBdry < _upperBdry,
+             " Invalid range for random number generator");
+    abkfatal(_dDelta > 1e-4, " Range too small for random number generator ");
+    _delta = unsigned(_dDelta);
+    if (_dDelta < 1)
+      _delta = 1;
+  }
 
-        unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
+  unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
 };
 
 //: To override the seed , do something like RandomUnsigned ru(0,19,257);
@@ -253,18 +318,41 @@ class RandomNumberGeneratorT : public RK {
 //    This may be useful for debugging if you need to reproduce exactly
 //    what happened in a particular segment of code.
 template <class RK>
-class RandomUnsignedT : public RandomNumberGeneratorT<RK> {
-       public:
-        RandomUnsignedT(double _lowerBdry, double _upperBdry, unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, seedN, verb) {}
+class RandomUnsignedT : public RandomNumberGeneratorT<RK>
+{
+ public:
+  RandomUnsignedT(double _lowerBdry,
+                  double _upperBdry,
+                  unsigned seedN = UINT_MAX,
+                  Verbosity verb = Verbosity("silent"))
+      : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, seedN, verb)
+  {
+  }
 
-        RandomUnsignedT(double _lowerBdry, double _upperBdry, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, locIdent, counterOverride, verb) {}
-        operator unsigned() { return RandomNumberGeneratorT<RK>::_getUnsignedRand(); }
+  RandomUnsignedT(double _lowerBdry,
+                  double _upperBdry,
+                  const char* locIdent,
+                  unsigned counterOverride = UINT_MAX,
+                  Verbosity verb = Verbosity("silent"))
+      : RandomNumberGeneratorT<RK>(_lowerBdry,
+                                   _upperBdry,
+                                   locIdent,
+                                   counterOverride,
+                                   verb)
+  {
+  }
+  operator unsigned() { return RandomNumberGeneratorT<RK>::_getUnsignedRand(); }
 
-        using result_type = unsigned;
-        static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
-        static constexpr result_type min() { return std::numeric_limits<result_type>::min(); }
-        result_type operator()() { return static_cast<unsigned>(*this); }
-  
+  using result_type = unsigned;
+  static constexpr result_type max()
+  {
+    return std::numeric_limits<result_type>::max();
+  }
+  static constexpr result_type min()
+  {
+    return std::numeric_limits<result_type>::min();
+  }
+  result_type operator()() { return static_cast<unsigned>(*this); }
 };
 
 //: Everything is exactly analogous to RandomUnsigned as above,
@@ -272,12 +360,26 @@ class RandomUnsignedT : public RandomNumberGeneratorT<RK> {
 //    to the constructor, and in that you cast to double to get
 //    the random value.
 template <class RK>
-class RandomDoubleT : public RandomNumberGeneratorT<RK> {
-       public:
-        RandomDoubleT(double _lowerBdry, double _upperBdry, unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, seedN, verb) {};
+class RandomDoubleT : public RandomNumberGeneratorT<RK>
+{
+ public:
+  RandomDoubleT(double _lowerBdry,
+                double _upperBdry,
+                unsigned seedN = UINT_MAX,
+                Verbosity verb = Verbosity("silent"))
+      : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, seedN, verb){};
 
-        RandomDoubleT(double _lowerBdry, double _upperBdry, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RandomNumberGeneratorT<RK>(_lowerBdry, _upperBdry, locIdent, counterOverride, verb) {};
-        operator double() { return RandomNumberGeneratorT<RK>::_getDoubleRand(); }
+  RandomDoubleT(double _lowerBdry,
+                double _upperBdry,
+                const char* locIdent,
+                unsigned counterOverride = UINT_MAX,
+                Verbosity verb = Verbosity("silent"))
+      : RandomNumberGeneratorT<RK>(_lowerBdry,
+                                   _upperBdry,
+                                   locIdent,
+                                   counterOverride,
+                                   verb){};
+  operator double() { return RandomNumberGeneratorT<RK>::_getDoubleRand(); }
 };
 
 /*
@@ -289,70 +391,109 @@ should
 // adjust for ranges.
 */
 template <class RK>
-class RandomRawUnsignedT_impl : public RK {
-       public:
-        RandomRawUnsignedT_impl(unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seedN, verb) {};
+class RandomRawUnsignedT_impl : public RK
+{
+ public:
+  RandomRawUnsignedT_impl(unsigned seedN = UINT_MAX,
+                          Verbosity verb = Verbosity("silent"))
+      : RK(seedN, verb){};
 
-        RandomRawUnsignedT_impl(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb) {};
+  RandomRawUnsignedT_impl(const char* locIdent,
+                          unsigned counterOverride = UINT_MAX,
+                          Verbosity verb = Verbosity("silent"))
+      : RK(locIdent, counterOverride, verb){};
 
-        operator unsigned() { return RK::_getRawUnsigned(); }
-        unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
+  operator unsigned() { return RK::_getRawUnsigned(); }
+  unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
 };
 
 template <class RK>
-class RandomRawUnsignedT {
+class RandomRawUnsignedT
+{
+  RandomRawUnsignedT_impl<RK>* _impl;
+  std::string _locIdent;
+  unsigned _seedN, _counterOverride;
+  Verbosity _verb;
+  bool _haveLoc;
 
-        RandomRawUnsignedT_impl<RK> *_impl;
-        std::string _locIdent;
-        unsigned _seedN, _counterOverride;
-        Verbosity _verb;
-        bool _haveLoc;
+  void create(void)
+  {
+    if (_haveLoc)
+      _impl = new RandomRawUnsignedT_impl<RK>(
+          _locIdent.c_str(), _counterOverride, _verb);
+    else
+      _impl = new RandomRawUnsignedT_impl<RK>(_seedN, _verb);
+  }
 
-        void create(void) {
-                if (_haveLoc)
-                        _impl = new RandomRawUnsignedT_impl<RK>(_locIdent.c_str(), _counterOverride, _verb);
-                else
-                        _impl = new RandomRawUnsignedT_impl<RK>(_seedN, _verb);
-        }
+ public:
+  using result_type = unsigned;
+  static constexpr result_type max()
+  {
+    return std::numeric_limits<result_type>::max();
+  }
+  static constexpr result_type min()
+  {
+    return std::numeric_limits<result_type>::min();
+  }
+  result_type operator()() { return static_cast<unsigned>(*this); }
 
-       public:
-        using result_type = unsigned;
-        static constexpr result_type max() { return std::numeric_limits<result_type>::max(); }
-        static constexpr result_type min() { return std::numeric_limits<result_type>::min(); }
-        result_type operator()() { return static_cast<unsigned>(*this); }
-  
-        RandomRawUnsignedT(unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : _impl(NULL), _seedN(seedN), _verb(verb), _haveLoc(false) {}
+  RandomRawUnsignedT(unsigned seedN = UINT_MAX,
+                     Verbosity verb = Verbosity("silent"))
+      : _impl(NULL), _seedN(seedN), _verb(verb), _haveLoc(false)
+  {
+  }
 
-        RandomRawUnsignedT(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : _impl(NULL), _locIdent(locIdent), _counterOverride(counterOverride), _verb(verb), _haveLoc(true) {}
+  RandomRawUnsignedT(const char* locIdent,
+                     unsigned counterOverride = UINT_MAX,
+                     Verbosity verb = Verbosity("silent"))
+      : _impl(NULL),
+        _locIdent(locIdent),
+        _counterOverride(counterOverride),
+        _verb(verb),
+        _haveLoc(true)
+  {
+  }
 
-        ~RandomRawUnsignedT() { delete _impl; }
+  ~RandomRawUnsignedT() { delete _impl; }
 
-        operator unsigned() {
-                if (_impl == NULL) create();
-                return static_cast<unsigned>(*_impl);
-        }
+  operator unsigned()
+  {
+    if (_impl == NULL)
+      create();
+    return static_cast<unsigned>(*_impl);
+  }
 
-        unsigned operator()(unsigned N) {
-                if (_impl == NULL) create();
-                return _impl->operator()(N);
-        }
+  unsigned operator()(unsigned N)
+  {
+    if (_impl == NULL)
+      create();
+    return _impl->operator()(N);
+  }
 
-        unsigned getSeed() {
-                if (_impl == NULL) create();
-                return _impl->getSeed();
-        }
+  unsigned getSeed()
+  {
+    if (_impl == NULL)
+      create();
+    return _impl->getSeed();
+  }
 };
 
 //:
 template <class RK>
-class RandomRawDoubleT : public RK {
-       public:
-        RandomRawDoubleT(unsigned seedN = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seedN, verb) {};
+class RandomRawDoubleT : public RK
+{
+ public:
+  RandomRawDoubleT(unsigned seedN = UINT_MAX,
+                   Verbosity verb = Verbosity("silent"))
+      : RK(seedN, verb){};
 
-        RandomRawDoubleT(const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb) {};
+  RandomRawDoubleT(const char* locIdent,
+                   unsigned counterOverride = UINT_MAX,
+                   Verbosity verb = Verbosity("silent"))
+      : RK(locIdent, counterOverride, verb){};
 
-        operator double() { return RK::_getRawDouble(); }
-        unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
+  operator double() { return RK::_getRawDouble(); }
+  unsigned operator()(unsigned N) { return RK::_getRawUnsigned() % N; }
 };
 
 //:
@@ -365,19 +506,41 @@ class RandomRawDoubleT : public RK {
 //    The values of rn will be normally distributed (Gaussian, bell curve)
 //    with mean 4.0 and standard deviation 2.0.
 template <class RK>
-class RandomNormalT : public RK {
-       private:
-        double _mu;
-        double _sigma;
-        mutable bool _cacheFull;
-        mutable double _cachedValue;
+class RandomNormalT : public RK
+{
+ private:
+  double _mu;
+  double _sigma;
+  mutable bool _cacheFull;
+  mutable double _cachedValue;
 
-       public:
-        RandomNormalT(double mean, double stdDev, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seed, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
+ public:
+  RandomNormalT(double mean,
+                double stdDev,
+                unsigned seed = UINT_MAX,
+                Verbosity verb = Verbosity("silent"))
+      : RK(seed, verb),
+        _mu(mean),
+        _sigma(stdDev),
+        _cacheFull(false),
+        _cachedValue(0.0)
+  {
+  }
 
-        RandomNormalT(double mean, double stdDev, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
+  RandomNormalT(double mean,
+                double stdDev,
+                const char* locIdent,
+                unsigned counterOverride = UINT_MAX,
+                Verbosity verb = Verbosity("silent"))
+      : RK(locIdent, counterOverride, verb),
+        _mu(mean),
+        _sigma(stdDev),
+        _cacheFull(false),
+        _cachedValue(0.0)
+  {
+  }
 
-        operator double();
+  operator double();
 };
 
 // This class generates pairs of binormal deviates
@@ -390,59 +553,105 @@ class RandomNormalT : public RK {
 // element.
 
 template <class RK>
-class RandomNormCorrPairsT {
-       private:
-        RandomNormalT<RK> _norm;
-        const double _mu1, _mu2;
-        const double _sigma1, _sigma2;
-        const double _rho;
-        const double _c;  // we'll use x1+_c*x2 and x1-_c*x2,
-                          // where x1, x2 are indep. unit normal deviates
+class RandomNormCorrPairsT
+{
+ private:
+  RandomNormalT<RK> _norm;
+  const double _mu1, _mu2;
+  const double _sigma1, _sigma2;
+  const double _rho;
+  const double _c;  // we'll use x1+_c*x2 and x1-_c*x2,
+                    // where x1, x2 are indep. unit normal deviates
 
-        const double _a1, _a2, _b1, _b2;  // intermed values useful to precalc
+  const double _a1, _a2, _b1, _b2;  // intermed values useful to precalc
 
-       public:
-        RandomNormCorrPairsT(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, seed, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
+ public:
+  RandomNormCorrPairsT(double mean1,
+                       double stdDev1,
+                       double mean2,
+                       double stdDev2,
+                       double correlation,
+                       unsigned seed = UINT_MAX,
+                       Verbosity verb = Verbosity("silent"))
+      : _norm(0, 1, seed, verb),
+        _mu1(mean1),
+        _mu2(mean2),
+        _sigma1(stdDev1),
+        _sigma2(stdDev2),
+        _rho(correlation),
+        _c(sqrt((1 - _rho) / (1 + _rho))),
+        _a1(_sigma1 / sqrt(1 + _c * _c)),
+        _a2(_sigma2 / sqrt(1 + _c * _c)),
+        _b1(_sigma1 * _c / sqrt(1 + _c * _c)),
+        _b2(_sigma2 * _c / sqrt(1 + _c * _c))
+  {
+  }
 
-        RandomNormCorrPairsT(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, locIdent, counterOverride, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
+  RandomNormCorrPairsT(double mean1,
+                       double stdDev1,
+                       double mean2,
+                       double stdDev2,
+                       double correlation,
+                       const char* locIdent,
+                       unsigned counterOverride = UINT_MAX,
+                       Verbosity verb = Verbosity("silent"))
+      : _norm(0, 1, locIdent, counterOverride, verb),
+        _mu1(mean1),
+        _mu2(mean2),
+        _sigma1(stdDev1),
+        _sigma2(stdDev2),
+        _rho(correlation),
+        _c(sqrt((1 - _rho) / (1 + _rho))),
+        _a1(_sigma1 / sqrt(1 + _c * _c)),
+        _a2(_sigma2 / sqrt(1 + _c * _c)),
+        _b1(_sigma1 * _c / sqrt(1 + _c * _c)),
+        _b2(_sigma2 * _c / sqrt(1 + _c * _c))
+  {
+  }
 
-        std::pair<double, double> getPair();
+  std::pair<double, double> getPair();
 };
 
 // This RNG gives multinormally-distributed X_0, X_1,...,X_{n-1}
 // with specified pairwise correlations.
 template <class RK>
-class RandomNormCorrTuplesT {
-       private:
-        // helper function; _rho_ij includes only upper-triangular elements
-        // i.e. _rho_ij[i][j] is not really rho_ij but
-        // rather rho_{i,i+j+1}
-        // return value is success
-        bool _findBasis(const std::vector<std::vector<double> > &_rho_ij, std::vector<std::vector<double> > &_v_ij);
+class RandomNormCorrTuplesT
+{
+ private:
+  // helper function; _rho_ij includes only upper-triangular elements
+  // i.e. _rho_ij[i][j] is not really rho_ij but
+  // rather rho_{i,i+j+1}
+  // return value is success
+  bool _findBasis(const std::vector<std::vector<double>>& _rho_ij,
+                  std::vector<std::vector<double>>& _v_ij);
 
-        const unsigned _n;  // number of variates
-        std::vector<RandomNormalT<RK> *> _norm_j;
-        std::vector<double> _y_j;  // scratch space; fill with normal values
-        // then transform with _v_ij
-        const std::vector<double> _mu_i;
-        const std::vector<double> _sigma_i;
-        std::vector<std::vector<double> > _v_ij;
+  const unsigned _n;  // number of variates
+  std::vector<RandomNormalT<RK>*> _norm_j;
+  std::vector<double> _y_j;  // scratch space; fill with normal values
+  // then transform with _v_ij
+  const std::vector<double> _mu_i;
+  const std::vector<double> _sigma_i;
+  std::vector<std::vector<double>> _v_ij;
 
-        bool _bad;  // will be set if _findBasis() fails
+  bool _bad;  // will be set if _findBasis() fails
 
-       public:
-        RandomNormCorrTuplesT(const std::vector<double> &means, const std::vector<double> &stdDevs,
+ public:
+  RandomNormCorrTuplesT(const std::vector<double>& means,
+                        const std::vector<double>& stdDevs,
 
-                                  // Note:  corrs[i][j] is the desired
-                                  // correlation between X_i and
-                                  // X_{i+j+1} (i.e. only upper-triangular
-                                  // elements are included
-                                  const std::vector<std::vector<double> > &corrs, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent"));
+                        // Note:  corrs[i][j] is the desired
+                        // correlation between X_i and
+                        // X_{i+j+1} (i.e. only upper-triangular
+                        // elements are included
+                        const std::vector<std::vector<double>>& corrs,
+                        const char* locIdent,
+                        unsigned counterOverride = UINT_MAX,
+                        Verbosity verb = Verbosity("silent"));
 
-        ~RandomNormCorrTuplesT();
+  ~RandomNormCorrTuplesT();
 
-        void getTuple(std::vector<double> &tuple);
-        bool bad() const { return _bad; }
+  void getTuple(std::vector<double>& tuple);
+  bool bad() const { return _bad; }
 };
 /* -------------------------   IMPLEMENTATIONS  ----------------------- */
 // I don't seem to be able to get any compiler to instantiate these

--- a/src/par/src/MLPart/mlpart/ABKCommon/abkrand.h
+++ b/src/par/src/MLPart/mlpart/ABKCommon/abkrand.h
@@ -373,9 +373,9 @@ class RandomNormalT : public RK {
         mutable double _cachedValue;
 
        public:
-        RandomNormalT<RK>(double mean, double stdDev, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seed, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
+        RandomNormalT(double mean, double stdDev, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(seed, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
 
-        RandomNormalT<RK>(double mean, double stdDev, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
+        RandomNormalT(double mean, double stdDev, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : RK(locIdent, counterOverride, verb), _mu(mean), _sigma(stdDev), _cacheFull(false), _cachedValue(0.0) {}
 
         operator double();
 };
@@ -402,9 +402,9 @@ class RandomNormCorrPairsT {
         const double _a1, _a2, _b1, _b2;  // intermed values useful to precalc
 
        public:
-        RandomNormCorrPairsT<RK>(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, seed, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
+        RandomNormCorrPairsT(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, unsigned seed = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, seed, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
 
-        RandomNormCorrPairsT<RK>(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, locIdent, counterOverride, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
+        RandomNormCorrPairsT(double mean1, double stdDev1, double mean2, double stdDev2, double correlation, const char *locIdent, unsigned counterOverride = UINT_MAX, Verbosity verb = Verbosity("silent")) : _norm(0, 1, locIdent, counterOverride, verb), _mu1(mean1), _mu2(mean2), _sigma1(stdDev1), _sigma2(stdDev2), _rho(correlation), _c(sqrt((1 - _rho) / (1 + _rho))), _a1(_sigma1 / sqrt(1 + _c * _c)), _a2(_sigma2 / sqrt(1 + _c * _c)), _b1(_sigma1 * _c / sqrt(1 + _c * _c)), _b2(_sigma2 * _c / sqrt(1 + _c * _c)) {}
 
         std::pair<double, double> getPair();
 };
@@ -431,7 +431,7 @@ class RandomNormCorrTuplesT {
         bool _bad;  // will be set if _findBasis() fails
 
        public:
-        RandomNormCorrTuplesT<RK>(const std::vector<double> &means, const std::vector<double> &stdDevs,
+        RandomNormCorrTuplesT(const std::vector<double> &means, const std::vector<double> &stdDevs,
 
                                   // Note:  corrs[i][j] is the desired
                                   // correlation between X_i and

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -88,6 +88,13 @@ namespace utl {
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
 
+#if FMT_VERSION >= 80000 // backward compatibility with fmt versions older than 8
+# define FMT_RUNTIME(format_string) fmt::runtime(format_string)
+#else
+# define FMT_RUNTIME(format_string) format_string
+#endif
+
+
 enum ToolId
 {
   FOREACH_TOOL(GENERATE_ENUM)
@@ -106,7 +113,7 @@ class Logger
   template <typename... Args>
   inline void report(const std::string& message, const Args&... args)
   {
-    logger_->log(spdlog::level::level_enum::off, fmt::runtime(message), args...);
+    logger_->log(spdlog::level::level_enum::off, FMT_RUNTIME(message), args...);
   }
 
   // Do NOT call this directly, use the debugPrint macro  instead (defined
@@ -119,7 +126,7 @@ class Logger
   {
     // Message counters do NOT apply to debug messages.
     logger_->log(spdlog::level::level_enum::debug,
-                 fmt::runtime("[{} {}-{:04d}] " + message),
+                 FMT_RUNTIME("[{} {}-{:04d}] " + message),
                  level_names[spdlog::level::level_enum::debug],
                  tool_names_[tool],
                  level,
@@ -226,7 +233,7 @@ class Logger
     auto count = counter++;
     if (count < max_message_print) {
       logger_->log(level,
-                   fmt::runtime("[{} {}-{:04d}] " + message),
+                   FMT_RUNTIME("[{} {}-{:04d}] " + message),
                    level_names[level],
                    tool_names_[tool],
                    id,
@@ -252,7 +259,7 @@ class Logger
     if (metrics_stages_.empty())
       key = metric;
     else
-      key = fmt::format(fmt::runtime(metrics_stages_.top()), metric);
+      key = fmt::format(FMT_RUNTIME(metrics_stages_.top()), metric);
     metrics_entries_.push_back({key, value});
   }
 

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -106,7 +106,7 @@ class Logger
   template <typename... Args>
   inline void report(const std::string& message, const Args&... args)
   {
-    logger_->log(spdlog::level::level_enum::off, message, args...);
+    logger_->log(spdlog::level::level_enum::off, fmt::runtime(message), args...);
   }
 
   // Do NOT call this directly, use the debugPrint macro  instead (defined
@@ -119,7 +119,7 @@ class Logger
   {
     // Message counters do NOT apply to debug messages.
     logger_->log(spdlog::level::level_enum::debug,
-                 "[{} {}-{:04d}] " + message,
+                 fmt::runtime("[{} {}-{:04d}] " + message),
                  level_names[spdlog::level::level_enum::debug],
                  tool_names_[tool],
                  level,
@@ -226,7 +226,7 @@ class Logger
     auto count = counter++;
     if (count < max_message_print) {
       logger_->log(level,
-                   "[{} {}-{:04d}] " + message,
+                   fmt::runtime("[{} {}-{:04d}] " + message),
                    level_names[level],
                    tool_names_[tool],
                    id,
@@ -252,7 +252,7 @@ class Logger
     if (metrics_stages_.empty())
       key = metric;
     else
-      key = fmt::format(metrics_stages_.top(), metric);
+      key = fmt::format(fmt::runtime(metrics_stages_.top()), metric);
     metrics_entries_.push_back({key, value});
   }
 

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -88,12 +88,12 @@ namespace utl {
 #define GENERATE_ENUM(ENUM) ENUM,
 #define GENERATE_STRING(STRING) #STRING,
 
-#if FMT_VERSION >= 80000 // backward compatibility with fmt versions older than 8
-# define FMT_RUNTIME(format_string) fmt::runtime(format_string)
+// backward compatibility with fmt versions older than 8
+#if FMT_VERSION >= 80000
+#define FMT_RUNTIME(format_string) fmt::runtime(format_string)
 #else
-# define FMT_RUNTIME(format_string) format_string
+#define FMT_RUNTIME(format_string) format_string
 #endif
-
 
 enum ToolId
 {

--- a/third-party/lemon/patches/allocator-patch.patch
+++ b/third-party/lemon/patches/allocator-patch.patch
@@ -1,0 +1,298 @@
+# HG changeset patch
+# User David Torres Sanchez <d.torressanchez@lancaster.ac.uk>
+# Date 1637826358 -3600
+#      Thu Nov 25 08:45:58 2021 +0100
+# Node ID 93c983122692826b48d3a40bc40100c8a4ea7650
+# Parent  a278d16bd2d082aa3c52ff4a9b0e2224ddc0549a
+Fix C++20 compatibility issue (#631)
+
+diff --git a/lemon/bits/array_map.h b/lemon/bits/array_map.h
+--- a/lemon/bits/array_map.h
++++ b/lemon/bits/array_map.h
+@@ -75,6 +75,7 @@
+     typedef typename Notifier::ObserverBase Parent;
+ 
+     typedef std::allocator<Value> Allocator;
++    typedef std::allocator_traits<std::allocator<Value>> AllocatorTraits;
+ 
+   public:
+ 
+@@ -87,8 +88,8 @@
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -101,8 +102,8 @@
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), value);
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), value);
+       }
+     }
+ 
+@@ -120,8 +121,8 @@
+       Notifier* nf = Parent::notifier();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), copy.values[id]);
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), copy.values[id]);
+       }
+     }
+ 
+@@ -216,17 +217,17 @@
+         Value* new_values = allocator.allocate(new_capacity);
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+-          int jd = nf->id(it);;
++          int jd = nf->id(it);
+           if (id != jd) {
+-            allocator.construct(&(new_values[jd]), values[jd]);
+-            allocator.destroy(&(values[jd]));
++            AllocatorTraits::construct(allocator, &(new_values[jd]), values[jd]);
++            AllocatorTraits::destroy(allocator, &(values[jd]));
+           }
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+         capacity = new_capacity;
+       }
+-      allocator.construct(&(values[id]), Value());
++      AllocatorTraits::construct(allocator, &(values[id]), Value());
+     }
+ 
+     // \brief Adds more new keys to the map.
+@@ -260,8 +261,8 @@
+             }
+           }
+           if (found) continue;
+-          allocator.construct(&(new_values[id]), values[id]);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::construct(allocator, &(new_values[id]), values[id]);
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         if (capacity != 0) allocator.deallocate(values, capacity);
+         values = new_values;
+@@ -269,7 +270,7 @@
+       }
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = nf->id(keys[i]);
+-        allocator.construct(&(values[id]), Value());
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -279,7 +280,7 @@
+     // and it overrides the erase() member function of the observer base.
+     virtual void erase(const Key& key) {
+       int id = Parent::notifier()->id(key);
+-      allocator.destroy(&(values[id]));
++      AllocatorTraits::destroy(allocator, &(values[id]));
+     }
+ 
+     // \brief Erase more keys from the map.
+@@ -289,7 +290,7 @@
+     virtual void erase(const std::vector<Key>& keys) {
+       for (int i = 0; i < int(keys.size()); ++i) {
+         int id = Parent::notifier()->id(keys[i]);
+-        allocator.destroy(&(values[id]));
++        AllocatorTraits::destroy(allocator, &(values[id]));
+       }
+     }
+ 
+@@ -302,8 +303,8 @@
+       allocate_memory();
+       Item it;
+       for (nf->first(it); it != INVALID; nf->next(it)) {
+-        int id = nf->id(it);;
+-        allocator.construct(&(values[id]), Value());
++        int id = nf->id(it);
++        AllocatorTraits::construct(allocator, &(values[id]), Value());
+       }
+     }
+ 
+@@ -317,7 +318,7 @@
+         Item it;
+         for (nf->first(it); it != INVALID; nf->next(it)) {
+           int id = nf->id(it);
+-          allocator.destroy(&(values[id]));
++          AllocatorTraits::destroy(allocator, &(values[id]));
+         }
+         allocator.deallocate(values, capacity);
+         capacity = 0;
+diff --git a/lemon/path.h b/lemon/path.h
+--- a/lemon/path.h
++++ b/lemon/path.h
+@@ -448,7 +448,7 @@
+       data.resize(len);
+       int index = 0;
+       for (typename CPath::ArcIt it(path); it != INVALID; ++it) {
+-        data[index] = it;;
++        data[index] = it;
+         ++index;
+       }
+     }
+@@ -460,7 +460,7 @@
+       int index = len;
+       for (typename CPath::RevArcIt it(path); it != INVALID; ++it) {
+         --index;
+-        data[index] = it;;
++        data[index] = it;
+       }
+     }
+ 
+@@ -503,7 +503,9 @@
+ 
+     Node *first, *last;
+ 
+-    std::allocator<Node> alloc;
++  private:
++    typedef std::allocator<Node> Allocator;
++    typedef std::allocator_traits<std::allocator<Node>> AllocatorTraits;
+ 
+   public:
+ 
+@@ -663,8 +665,8 @@
+     void clear() {
+       while (first != 0) {
+         last = first->next;
+-        alloc.destroy(first);
+-        alloc.deallocate(first, 1);
++        AllocatorTraits::destroy(_allocator, first);
++        _allocator.deallocate(first, 1);
+         first = last;
+       }
+     }
+@@ -676,8 +678,8 @@
+ 
+     /// \brief Add a new arc before the current path
+     void addFront(const Arc& arc) {
+-      Node *node = alloc.allocate(1);
+-      alloc.construct(node, Node());
++      Node *node = _allocator.allocate(1);
++      AllocatorTraits::construct(_allocator, node, Node());
+       node->prev = 0;
+       node->next = first;
+       node->arc = arc;
+@@ -698,8 +700,8 @@
+       } else {
+         last = 0;
+       }
+-      alloc.destroy(node);
+-      alloc.deallocate(node, 1);
++      AllocatorTraits::destroy(_allocator, node);
++      _allocator.deallocate(node, 1);
+     }
+ 
+     /// \brief The last arc of the path.
+@@ -709,8 +711,8 @@
+ 
+     /// \brief Add a new arc behind the current path.
+     void addBack(const Arc& arc) {
+-      Node *node = alloc.allocate(1);
+-      alloc.construct(node, Node());
++      Node *node = _allocator.allocate(1);
++      AllocatorTraits::construct(_allocator, node, Node());
+       node->next = 0;
+       node->prev = last;
+       node->arc = arc;
+@@ -731,8 +733,8 @@
+       } else {
+         first = 0;
+       }
+-      alloc.destroy(node);
+-      alloc.deallocate(node, 1);
++      AllocatorTraits::destroy(_allocator, node);
++      _allocator.deallocate(node, 1);
+     }
+ 
+     /// \brief Splice a path to the back of the current path.
+@@ -847,6 +849,9 @@
+       }
+     }
+ 
++  private:
++    Allocator _allocator;
++
+   };
+ 
+   /// \brief A structure for representing directed paths in a digraph.
+@@ -875,7 +880,7 @@
+     /// \brief Default constructor
+     ///
+     /// Default constructor
+-    StaticPath() : len(0), _arcs(0) {}
++    StaticPath() : _len(0), _arcs(0) {}
+ 
+     /// \brief Copy constructor
+     ///
+@@ -1003,14 +1008,14 @@
+     }
+ 
+     /// \brief The length of the path.
+-    int length() const { return len; }
++    int length() const { return _len; }
+ 
+     /// \brief Return true when the path is empty.
+-    int empty() const { return len == 0; }
++    int empty() const { return _len == 0; }
+ 
+     /// \brief Reset the path to an empty one.
+     void clear() {
+-      len = 0;
++      _len = 0;
+       if (_arcs) delete[] _arcs;
+       _arcs = 0;
+     }
+@@ -1022,7 +1027,7 @@
+ 
+     /// \brief The last arc of the path.
+     const Arc& back() const {
+-      return _arcs[len - 1];
++      return _arcs[_len - 1];
+     }
+ 
+ 
+@@ -1030,8 +1035,8 @@
+ 
+     template <typename CPath>
+     void build(const CPath& path) {
+-      len = path.length();
+-      _arcs = new Arc[len];
++      _len = path.length();
++      _arcs = new Arc[_len];
+       int index = 0;
+       for (typename CPath::ArcIt it(path); it != INVALID; ++it) {
+         _arcs[index] = it;
+@@ -1041,9 +1046,9 @@
+ 
+     template <typename CPath>
+     void buildRev(const CPath& path) {
+-      len = path.length();
+-      _arcs = new Arc[len];
+-      int index = len;
++      _len = path.length();
++      _arcs = new Arc[_len];
++      int index = _len;
+       for (typename CPath::RevArcIt it(path); it != INVALID; ++it) {
+         --index;
+         _arcs[index] = it;
+@@ -1051,7 +1056,7 @@
+     }
+ 
+   private:
+-    int len;
++    int _len;
+     Arc* _arcs;
+   };
+ 


### PR DESCRIPTION
Couple of notes on C++20

* LEMON 1.3.1 has an issue that needs to be resolved related to allocators. (Included a patch from https://lemon.cs.elte.hu/trac/lemon/ticket/631#no1)
* fmt in versions greater than 8 added the ability to constexpr compile format lines. The downside is runtime strings need to be wrapped in fmt::runtime. Added FMT_RUNTIME macro to support both versions. The current version of spd_log is on version 7 of FMT
* template ids on constructors and destructors have been removed. Removed usage in abk libs.

Introduced a github action to build openroad on c++20. Should prevent any usage of non-supported c++20 features, but this does not mean the project is moving to c++20 yet.

**OpenROAD will stay on C++17**

