### PR TITLE
Fix "out" typemaps to work with SWIG 4.1.0+ (given use of >=C++11 in OpenROAD)

### DIFF
--- a/src/odb/src/swig/tcl/dbtypes.i
+++ b/src/odb/src/swig/tcl/dbtypes.i
@@ -45,14 +45,16 @@
     Tcl_SetObjResult(interp, list);
 }
 %typemap(out) std::vector< T > {
-    for (unsigned int i=0; i<$1.size(); i++) {
-        T* ptr = new T((($1_type &)$1)[i]);
+    std::vector<T>& v = *&($1);
+    for (size_t i = 0; i< v.size(); i++) {
+        T* ptr = new T(v[i]);
         Tcl_ListObjAppendElement(interp, $result,  SWIG_NewInstanceObj(ptr, $descriptor(T *), 0));
     }
 }
 %typemap(out) std::vector< T* > {
-    for (unsigned int i = 0; i < $1.size(); i++) {
-        T* ptr = ((($1_type &)$1)[i]);
+    std::vector<T*>& v = *&($1);
+    for (size_t i = 0; i < v.size(); i++) {
+        T* ptr = v[i];
         Tcl_ListObjAppendElement(interp, $result,  SWIG_NewInstanceObj(ptr, $descriptor(T *), 0));
     }
 }


### PR DESCRIPTION
Fixes issue #2777 -- see that issue for more details.

Before snippet from generated file `build/src/dbSta/src/CMakeFiles/dbSta.dir/dbStaTCL_wrap.cxx`

```c++
SWIGINTERN int
_wrap_find_all_clk_nets(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
  SwigValueWrapper< std::vector< odb::dbNet * > > result;

  if (SWIG_GetArgs(interp, objc, objv,":sta::find_all_clk_nets ") == TCL_ERROR) SWIG_fail;
  {
    try {
      result = find_all_clk_nets();
    }
    catch (std::bad_alloc &) {
      fprintf(stderr, "Error: out of memory.");
      exit(0);
    }
    // This catches std::runtime_error (utl::error) and sta::Exception.
    catch (std::exception &excp) {
      Tcl_ResetResult(interp);
      Tcl_AppendResult(interp, excp.what(), nullptr);
      return TCL_ERROR;
    }
  }
  {
    for (unsigned int i = 0; i < (&result)->size(); i++) {
      odb::dbNet* ptr = (((std::vector< odb::dbNet * > &)result)[i]);
      Tcl_ListObjAppendElement(interp, (Tcl_GetObjResult(interp)),  SWIG_NewInstanceObj(ptr, SWIGTYPE_p_odb__dbNet, 0));
    }
  }
  return TCL_OK;
fail:
  return TCL_ERROR;
}
```

After fix -- this is compatible with the new `SwigValueWrapper` definition supplied by 4.1.0, which **does not** have an lvalue reference cast operator overload:

```c++
SWIGINTERN int
_wrap_find_all_clk_nets(ClientData clientData SWIGUNUSED, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]) {
  SwigValueWrapper< std::vector< odb::dbNet * > > result;

  if (SWIG_GetArgs(interp, objc, objv,":sta::find_all_clk_nets ") == TCL_ERROR) SWIG_fail;
  {
    try {
      result = find_all_clk_nets();
    }
    catch (std::bad_alloc &) {
      fprintf(stderr, "Error: out of memory.");
      exit(0);
    }
    // This catches std::runtime_error (utl::error) and sta::Exception.
    catch (std::exception &excp) {
      Tcl_ResetResult(interp);
      Tcl_AppendResult(interp, excp.what(), nullptr);
      return TCL_ERROR;
    }
  }
  {
    std::vector<odb::dbNet*>& v = *&(result);
    for (size_t i = 0; i < v.size(); i++) {
      odb::dbNet* ptr = v[i];
      Tcl_ListObjAppendElement(interp, (Tcl_GetObjResult(interp)),  SWIG_NewInstanceObj(ptr, SWIGTYPE_p_odb__dbNet, 0));
    }
  }
  return TCL_OK;
fail:
  return TCL_ERROR;
}
```

Signed-off-by: Christopher D. Leary <cdleary@gmail.com>