### PR TITLE
pdn: fix repeated creation of rtrees in Shape::cut

### DIFF
--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -94,6 +94,7 @@ void PdnGen::resetShapes()
 
 void PdnGen::buildGrids(bool trim)
 {
+  debugPrint(logger_, utl::PDN, "Make", 1, "Build - begin");
   auto* block = db_->getChip()->getBlock();
 
   resetShapes();
@@ -108,18 +109,12 @@ void PdnGen::buildGrids(bool trim)
   }
 
   ShapeTreeMap block_obs;
-  Grid::makeInitialObstructions(block, block_obs, insts_in_grids);
+  Grid::makeInitialObstructions(block, block_obs, insts_in_grids, logger_);
 
   ShapeTreeMap all_shapes;
 
   // get special shapes
-  std::set<odb::dbNet*> nets;
-  for (auto* domain : getDomains()) {
-    for (auto* net : domain->getNets()) {
-      nets.insert(net);
-    }
-  }
-  Grid::makeInitialShapes(block, all_shapes);
+  Grid::makeInitialShapes(block, all_shapes, logger_);
   for (const auto& [layer, layer_shapes] : all_shapes) {
     auto& layer_obs = block_obs[layer];
     for (const auto& [box, shape] : layer_shapes) {
@@ -128,6 +123,8 @@ void PdnGen::buildGrids(bool trim)
   }
 
   for (auto* grid : grids) {
+    debugPrint(
+        logger_, utl::PDN, "Make", 2, "Build start grid - {}", grid->getName());
     ShapeTreeMap obs_local = block_obs;
     for (auto* grid_other : grids) {
       if (grid != grid_other) {
@@ -142,6 +139,8 @@ void PdnGen::buildGrids(bool trim)
         all_shapes_layer.insert(shape);
       }
     }
+    debugPrint(
+        logger_, utl::PDN, "Make", 2, "Build end grid - {}", grid->getName());
   }
 
   if (trim) {
@@ -151,6 +150,7 @@ void PdnGen::buildGrids(bool trim)
   }
 
   updateRenderer();
+  debugPrint(logger_, utl::PDN, "Make", 1, "Build - end");
 }
 
 void PdnGen::cleanupVias()

--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -883,8 +883,10 @@ void Grid::getGridLevelObstructions(ShapeTreeMap& obstructions) const
 
 void Grid::makeInitialObstructions(odb::dbBlock* block,
                                    ShapeTreeMap& obs,
-                                   const std::set<odb::dbInst*>& skip_insts)
+                                   const std::set<odb::dbInst*>& skip_insts,
+                                   utl::Logger* logger)
 {
+  debugPrint(logger, utl::PDN, "Make", 2, "Get initial obstructions - begin");
   // routing obs
   for (auto* ob : block->getObstructions()) {
     if (ob->isSlotObstruction() || ob->isFillObstruction()) {
@@ -924,18 +926,30 @@ void Grid::makeInitialObstructions(odb::dbBlock* block,
       continue;
     }
 
+    debugPrint(logger,
+               utl::PDN,
+               "Make",
+               3,
+               "Get instance {} obstructions",
+               inst->getName());
+
     for (const auto& [layer, shapes] :
          InstanceGrid::getInstanceObstructions(inst)) {
       obs[layer].insert(shapes.begin(), shapes.end());
     }
   }
+  debugPrint(logger, utl::PDN, "Make", 2, "Get initial obstructions - end");
 }
 
-void Grid::makeInitialShapes(odb::dbBlock* block, ShapeTreeMap& shapes)
+void Grid::makeInitialShapes(odb::dbBlock* block,
+                             ShapeTreeMap& shapes,
+                             utl::Logger* logger)
 {
+  debugPrint(logger, utl::PDN, "Make", 2, "Get initial shapes - start");
   for (auto* net : block->getNets()) {
     Shape::populateMapFromDb(net, shapes);
   }
+  debugPrint(logger, utl::PDN, "Make", 2, "Get initial shapes - end");
 }
 
 std::set<odb::dbTechLayer*> Grid::connectableLayers(
@@ -1413,7 +1427,7 @@ ExistingGrid::ExistingGrid(
 
 void ExistingGrid::populate()
 {
-  Grid::makeInitialShapes(domain_->getBlock(), shapes_);
+  Grid::makeInitialShapes(domain_->getBlock(), shapes_, getLogger());
 
   for (auto* inst : getBlock()->getInsts()) {
     if (inst->getPlacementStatus().isFixed()) {

--- a/src/pdn/src/grid.h
+++ b/src/pdn/src/grid.h
@@ -181,8 +181,11 @@ class Grid
 
   static void makeInitialObstructions(odb::dbBlock* block,
                                       ShapeTreeMap& obs,
-                                      const std::set<odb::dbInst*>& skip_insts);
-  static void makeInitialShapes(odb::dbBlock* block, ShapeTreeMap& shapes);
+                                      const std::set<odb::dbInst*>& skip_insts,
+                                      utl::Logger* logger);
+  static void makeInitialShapes(odb::dbBlock* block,
+                                ShapeTreeMap& shapes,
+                                utl::Logger* logger);
 
   virtual bool isReplaceable() const { return false; }
 

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -639,6 +639,9 @@ bool FollowPinShape::cut(const ShapeTree& obstructions,
   return Shape::cut(
       obstructions, replacements, [](const ShapeValue& other) -> bool {
         // followpins can ignore grid level obstructions
+        // grid level obstructions represent the other grids defined
+        // followpins should only get cut from real obstructions and
+        // not estimated obstructions
         return other.second->shapeType() != GRID_OBS;
       });
 }

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -218,6 +218,14 @@ const odb::Rect Shape::getMinimumRect() const
 bool Shape::cut(const ShapeTree& obstructions,
                 std::vector<Shape*>& replacements) const
 {
+  return cut(
+      obstructions, replacements, [](const ShapeValue&) { return true; });
+}
+
+bool Shape::cut(const ShapeTree& obstructions,
+                std::vector<Shape*>& replacements,
+                const std::function<bool(const ShapeValue&)>& obs_filter) const
+{
   using namespace boost::polygon::operators;
   using Rectangle = boost::polygon::rectangle_data<int>;
   using Polygon90 = boost::polygon::polygon_90_with_holes_data<int>;
@@ -233,7 +241,8 @@ bool Shape::cut(const ShapeTree& obstructions,
                                   const auto& other_shape = other.second;
                                   return layer_ == other_shape->getLayer()
                                          || other_shape->getLayer() == nullptr;
-                                }));
+                                })
+                             && bgi::satisfies(obs_filter));
        it != obstructions.qend();
        it++) {
     auto other_shape = it->second;
@@ -627,17 +636,11 @@ const odb::Rect FollowPinShape::getMinimumRect() const
 bool FollowPinShape::cut(const ShapeTree& obstructions,
                          std::vector<Shape*>& replacements) const
 {
-  ShapeTree filtered_obstructions;
-
-  for (const auto& [box, shape] : obstructions) {
-    if (shape->shapeType() == GRID_OBS) {
-      // followpins can ignore grid level obstructions
-      continue;
-    }
-    filtered_obstructions.insert({box, shape});
-  }
-
-  return Shape::cut(filtered_obstructions, replacements);
+  return Shape::cut(
+      obstructions, replacements, [](const ShapeValue& other) -> bool {
+        // followpins can ignore grid level obstructions
+        return other.second->shapeType() != GRID_OBS;
+      });
 }
 
 }  // namespace pdn

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -219,6 +219,11 @@ class Shape
     allow_non_preferred_change_ = true;
   }
 
+ protected:
+  bool cut(const ShapeTree& obstructions,
+           std::vector<Shape*>& replacements,
+           const std::function<bool(const ShapeValue&)>& obs_filter) const;
+
  private:
   odb::dbTechLayer* layer_;
   odb::dbNet* net_;


### PR DESCRIPTION
Fixes:
- Filtering method to use boost filtering instead and leaving the obs rtree alone. This will likely be possible in several other places to help speed things up.

Replaces: #2795