### PR TITLE
Avoid evaluating floating point divide-by-zero in CTS

### DIFF
--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -348,17 +348,7 @@ void HTreeBuilder::computeLevelTopology(unsigned level,
 
   const unsigned minLength = minLengthSinkRegion_ / 2;
 
-  // Implementation note: this must be non-zero for the algorithm to work, or
-  // we end up dividing by a zero minLength.
-  if (minLength == 0) {
-    logger_->error(
-        CTS,
-        542,
-        "Minimum length must be non-zero; min length sink region: {}",
-        minLengthSinkRegion_);
-  }
-
-  unsigned segmentLength = std::round(width / (2.0 * minLength)) * minLength;
+  unsigned segmentLength = minLength == 0 ? 0 : std::round(width / (2.0 * minLength)) * minLength;
   if (isVertical(level)) {
     segmentLength = std::round(height / (2.0 * minLength)) * minLength;
   }

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -347,6 +347,17 @@ void HTreeBuilder::computeLevelTopology(unsigned level,
   logger_->report("    Sub-region size: {:.4f} X {:.4f}", width, height);
 
   const unsigned minLength = minLengthSinkRegion_ / 2;
+
+  // Implementation note: this must be non-zero for the algorithm to work, or
+  // we end up dividing by a zero minLength.
+  if (minLength == 0) {
+    logger_->error(
+        CTS,
+        542,
+        "Minimum length must be non-zero; min length sink region: {}",
+        minLengthSinkRegion_);
+  }
+
   unsigned segmentLength = std::round(width / (2.0 * minLength)) * minLength;
   if (isVertical(level)) {
     segmentLength = std::round(height / (2.0 * minLength)) * minLength;

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -348,7 +348,8 @@ void HTreeBuilder::computeLevelTopology(unsigned level,
 
   const unsigned minLength = minLengthSinkRegion_ / 2;
 
-  unsigned segmentLength = minLength == 0 ? 0 : std::round(width / (2.0 * minLength)) * minLength;
+  unsigned segmentLength
+      = minLength == 0 ? 0 : std::round(width / (2.0 * minLength)) * minLength;
   if (isVertical(level)) {
     segmentLength = std::round(height / (2.0 * minLength)) * minLength;
   }


### PR DESCRIPTION
We observed there was a floating point divide by zero when running in a build with sanitizers on.

Signed-off-by: Christopher D. Leary <cdleary@gmail.com>