### PR TITLE
[cts] Fix base case handling for HTreeBuilder.

### DIFF
--- a/src/cts/src/CtsOptions.h
+++ b/src/cts/src/CtsOptions.h
@@ -106,8 +106,6 @@ class CtsOptions
   int getSlewSteps() const { return slewSteps_; }
   void setClockTreeMaxDepth(unsigned depth) { clockTreeMaxDepth_ = depth; }
   unsigned getClockTreeMaxDepth() const { return clockTreeMaxDepth_; }
-  void setEnableFakeLutEntries(bool enable) { enableFakeLutEntries_ = enable; }
-  unsigned isFakeLutEntriesEnabled() const { return enableFakeLutEntries_; }
   void setForceBuffersOnLeafLevel(bool force)
   {
     forceBuffersOnLeafLevel_ = force;
@@ -208,7 +206,6 @@ class CtsOptions
   int slewSteps_ = 12;
   unsigned charWirelengthIterations_ = 4;
   unsigned clockTreeMaxDepth_ = 100;
-  bool enableFakeLutEntries_ = true;
   bool forceBuffersOnLeafLevel_ = true;
   double bufDistRatio_ = 0.1;
   long int clockRoots_ = 0;

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -248,7 +248,6 @@ void HTreeBuilder::run()
   clockTreeMaxDepth_ = options_->getClockTreeMaxDepth();
   minInputCap_ = techChar_->getActualMinInputCap();
   numMaxLeafSinks_ = options_->getNumMaxLeafSinks();
-  minLengthSinkRegion_ = techChar_->getMinSegmentLength() * 2;
 
   initSinkRegion();
 
@@ -259,18 +258,8 @@ void HTreeBuilder::run()
     computeSubRegionSize(level, regionWidth, regionHeight);
 
     if (isSubRegionTooSmall(regionWidth, regionHeight)) {
-      if (options_->isFakeLutEntriesEnabled()) {
-        unsigned minIndex = 1;
-        techChar_->createFakeEntries(minLengthSinkRegion_, minIndex);
-        minLengthSinkRegion_ = 1;
-      } else {
-        logger_->info(
-            CTS,
-            31,
-            " Stop criterion found. Min length of sink region is ({}).",
-            minLengthSinkRegion_);
-        break;
-      }
+      unsigned minIndex = 1;
+      techChar_->createFakeEntries(getMinLengthSinkRegion(), minIndex);
     }
 
     computeLevelTopology(level, regionWidth, regionHeight);
@@ -346,7 +335,7 @@ void HTreeBuilder::computeLevelTopology(unsigned level,
   logger_->report("    Sinks per sub-region: {}", numSinksPerSubRegion);
   logger_->report("    Sub-region size: {:.4f} X {:.4f}", width, height);
 
-  const unsigned minLength = minLengthSinkRegion_ / 2;
+  const unsigned minLength = techChar_->getMinSegmentLength();
   unsigned segmentLength = std::round(width / (2.0 * minLength)) * minLength;
   if (isVertical(level)) {
     segmentLength = std::round(height / (2.0 * minLength)) * minLength;

--- a/src/cts/src/HTreeBuilder.h
+++ b/src/cts/src/HTreeBuilder.h
@@ -280,9 +280,13 @@ class HTreeBuilder : public TreeBuilder
       const std::vector<unsigned>& mapSinkToPoint,
       const std::vector<std::vector<unsigned>>& clusters);
 
+  unsigned getMinLengthSinkRegion() const {
+    return techChar_->getMinSegmentLength() * 2;
+  }
+
   bool isSubRegionTooSmall(double width, double height) const
   {
-    return width < minLengthSinkRegion_ || height < minLengthSinkRegion_;
+    return width < getMinLengthSinkRegion() || height < getMinLengthSinkRegion();
   }
 
   bool isNumberOfSinksTooSmall(unsigned numSinksPerSubRegion) const
@@ -301,7 +305,6 @@ class HTreeBuilder : public TreeBuilder
   int wireSegmentUnit_ = 0;
   unsigned minInputCap_ = 0;
   unsigned numMaxLeafSinks_ = 0;
-  unsigned minLengthSinkRegion_ = 0;
   unsigned clockTreeMaxDepth_ = 0;
   static constexpr int min_clustering_sinks_ = 200;
 };

--- a/src/cts/src/HTreeBuilder.h
+++ b/src/cts/src/HTreeBuilder.h
@@ -280,13 +280,15 @@ class HTreeBuilder : public TreeBuilder
       const std::vector<unsigned>& mapSinkToPoint,
       const std::vector<std::vector<unsigned>>& clusters);
 
-  unsigned getMinLengthSinkRegion() const {
+  unsigned getMinLengthSinkRegion() const
+  {
     return techChar_->getMinSegmentLength() * 2;
   }
 
   bool isSubRegionTooSmall(double width, double height) const
   {
-    return width < getMinLengthSinkRegion() || height < getMinLengthSinkRegion();
+    return width < getMinLengthSinkRegion()
+           || height < getMinLengthSinkRegion();
   }
 
   bool isNumberOfSinksTooSmall(unsigned numSinksPerSubRegion) const

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -556,9 +556,7 @@ void TechChar::initCharacterization()
 
   // Required to make sure that the fake entry for minLengthSinkRegion
   // exists (see HTreeBuilder::run())
-  if (options_->isFakeLutEntriesEnabled()) {
-    maxWirelength = std::max(maxWirelength, 2 * options_->getWireSegmentUnit());
-  }
+  maxWirelength = std::max(maxWirelength, 2 * options_->getWireSegmentUnit());
 
   for (unsigned wirelengthInter = options_->getWireSegmentUnit();
        (wirelengthInter <= maxWirelength)

--- a/src/cts/test/balance_levels.ok
+++ b/src/cts/test/balance_levels.ok
@@ -39,24 +39,22 @@ TritonCTS forced slew degradation on these wires.
     Direction: Vertical
     Sinks per sub-region: 38
     Sub-region size: 6.7460 X 3.1746
-[INFO CTS-0034]     Segment length (rounded): 1.
-    Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
+[INFO CTS-0034]     Segment length (rounded): 2.
+    Key: 12 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 2 delay: 1
+[WARNING CTS-0045] Creating fake entries in the LUT.
  Level 3
     Direction: Horizontal
     Sinks per sub-region: 19
     Sub-region size: 3.3730 X 3.1746
-[INFO CTS-0034]     Segment length (rounded): 1.
-    Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
+[INFO CTS-0034]     Segment length (rounded): 2.
+    Key: 12 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 2 delay: 1
+[WARNING CTS-0045] Creating fake entries in the LUT.
  Level 4
     Direction: Vertical
     Sinks per sub-region: 10
     Sub-region size: 3.3730 X 1.5873
 [INFO CTS-0034]     Segment length (rounded): 1.
     Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
- Out of 20 sinks, 2 sinks closer to other cluster.
- Out of 20 sinks, 2 sinks closer to other cluster.
- Out of 20 sinks, 1 sinks closer to other cluster.
- Out of 16 sinks, 1 sinks closer to other cluster.
 [INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
 [INFO CTS-0035]  Number of sinks covered: 151.
 [INFO CTS-0027] Generating H-Tree topology for net clk2.
@@ -80,25 +78,22 @@ TritonCTS forced slew degradation on these wires.
     Direction: Vertical
     Sinks per sub-region: 38
     Sub-region size: 6.7460 X 3.1746
-[INFO CTS-0034]     Segment length (rounded): 1.
-    Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
+[INFO CTS-0034]     Segment length (rounded): 2.
+    Key: 12 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 2 delay: 1
+[WARNING CTS-0045] Creating fake entries in the LUT.
  Level 3
     Direction: Horizontal
     Sinks per sub-region: 19
     Sub-region size: 3.3730 X 3.1746
-[INFO CTS-0034]     Segment length (rounded): 1.
-    Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
- Out of 36 sinks, 1 sinks closer to other cluster.
+[INFO CTS-0034]     Segment length (rounded): 2.
+    Key: 12 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 2 delay: 1
+[WARNING CTS-0045] Creating fake entries in the LUT.
  Level 4
     Direction: Vertical
     Sinks per sub-region: 10
     Sub-region size: 3.3730 X 1.5873
 [INFO CTS-0034]     Segment length (rounded): 1.
     Key: 2484 inSlew: 1 inCap: 1 outSlew: 2 load: 1 length: 1 delay: 1
- Out of 19 sinks, 1 sinks closer to other cluster.
- Out of 20 sinks, 2 sinks closer to other cluster.
- Out of 20 sinks, 2 sinks closer to other cluster.
- Out of 16 sinks, 1 sinks closer to other cluster.
 [INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
 [INFO CTS-0035]  Number of sinks covered: 150.
 [INFO CTS-0093] Fixing tree levels for max depth 5
@@ -107,21 +102,21 @@ Fixing from level 2 (parent=0 + current=2) to max 5 for driver clk
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
 [INFO CTS-0013]     Maximum number of buffers in the clock path: 5.
 [INFO CTS-0015]     Created 65 clock nets.
-[INFO CTS-0016]     Fanout distribution for the current clock = 2:1, 7:3, 8:3, 9:4, 10:1, 11:1, 12:4..
+[INFO CTS-0016]     Fanout distribution for the current clock = 2:1, 8:5, 9:1, 10:9, 11:1..
 [INFO CTS-0017]     Max level of the clock tree: 4.
 [INFO CTS-0018]     Created 17 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
 [INFO CTS-0013]     Maximum number of buffers in the clock path: 2.
 [INFO CTS-0015]     Created 17 clock nets.
-[INFO CTS-0016]     Fanout distribution for the current clock = 6:1, 7:2, 8:3, 9:4, 10:1, 11:1, 12:3, 13:1..
+[INFO CTS-0016]     Fanout distribution for the current clock = 8:7, 10:6, 11:2, 12:1..
 [INFO CTS-0017]     Max level of the clock tree: 4.
 [INFO CTS-0098] Clock net "clk"
 [INFO CTS-0099]  Sinks 300
 [INFO CTS-0100]  Leaf buffers 0
-[INFO CTS-0101]  Average sink wire length 169.48 um
+[INFO CTS-0101]  Average sink wire length 163.20 um
 [INFO CTS-0102]  Path depth 5 - 5
 [INFO CTS-0098] Clock net "clk2"
 [INFO CTS-0099]  Sinks 150
 [INFO CTS-0100]  Leaf buffers 0
-[INFO CTS-0101]  Average sink wire length 67.41 um
+[INFO CTS-0101]  Average sink wire length 67.94 um
 [INFO CTS-0102]  Path depth 2 - 2


### PR DESCRIPTION
Previously when the region was too small for CTS HTree building we would set the minimum segment length to be `1` independent of the tech lef. This value of `1` would get divided in half when computing minimum length which would result in a value of `0`, which would become a divisor.

The correct fix seems to be to say that the minimum length comes directly from the characterization. This also simplifies the control flow -- we rip out the `enableFakeLutEntries` which was universally true and obfuscated the control flow.

Co-authored-by: Ethan Mahintorabi <ethanmoon@google.com>
Signed-off-by: Christopher D. Leary <cdleary@gmail.com>