### PR TITLE
odb: add missing call to setViaParams in lefin::via

### DIFF
--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -1918,6 +1918,8 @@ void lefin::via(lefiVia* via, dbTechNonDefaultRule* rule)
       P.setYTopEnclosure(dbdist(via->yTopOffset()));
     }
 
+    v->setViaParams(P);
+
     if (via->hasCutPattern())
       v->setPattern(via->cutPattern());
   }


### PR DESCRIPTION
Signed-off-by: Matt Liberty <mliberty@eng.ucsd.edu>