### PR TITLE
Builds new library structure for OpenROAD modules

### DIFF
--- a/src/rcx/include/rcx/ext.h
+++ b/src/rcx/include/rcx/ext.h
@@ -32,8 +32,7 @@
 
 #pragma once
 
-#include <tcl.h>
-
+#include <functional>
 #include <memory>
 
 #include "extRCap.h"
@@ -56,7 +55,10 @@ class Ext
   Ext();
   ~Ext() = default;
 
-  void init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger);
+  void init(
+      odb::dbDatabase* db,
+      Logger* logger,
+      std::function<void()> rcx_init = []() {});
   void setLogger(Logger* logger);
 
   void write_rules(const std::string& name,

--- a/src/rcx/src/CMakeLists.txt
+++ b/src/rcx/src/CMakeLists.txt
@@ -145,7 +145,7 @@ if (Python3_FOUND AND BUILD_PYTHON)
 
   target_link_libraries(rcx_py
     PUBLIC
-      rcx
+      rcx_lib
   )
 
 endif()

--- a/src/rcx/src/CMakeLists.txt
+++ b/src/rcx/src/CMakeLists.txt
@@ -33,34 +33,47 @@
 
 include("openroad")
 
+add_library(rcx_lib
+  ext.cpp
+  extBench.cpp
+  extBenchDB.cpp
+  extCC.cpp
+  extCoords.cpp
+  extFlow.cpp
+  extRCmodel.cpp
+  extSpef.cpp
+  extSpefIn.cpp
+  extmain.cpp
+  extmeasure.cpp
+  extDebugPrint.cpp
+  extplanes.cpp
+  extstats.cpp
+  extprocess.cpp
+  ext2dBox.cpp
+  netRC.cpp
+  extmeasure_res.cpp
+)
+
+target_include_directories(rcx_lib
+  PUBLIC
+    ../include
+)
+
+target_link_libraries(rcx_lib
+  PUBLIC
+    odb
+    utl
+)
+
 swig_lib(NAME      rcx
          NAMESPACE rcx
          I_FILE    ext.i
          SCRIPTS   OpenRCX.tcl
 )
 
-
 target_sources(rcx
   PRIVATE
-    ext.cpp
-    extBench.cpp
-    extBenchDB.cpp
-    extCC.cpp
-    extCoords.cpp
-    extFlow.cpp
-    extRCmodel.cpp
-    extSpef.cpp
-    extSpefIn.cpp
-    extmain.cpp
-    extmeasure.cpp
-    extDebugPrint.cpp
-    extplanes.cpp
-    extstats.cpp
-    extprocess.cpp
-    ext2dBox.cpp
-    netRC.cpp
     MakeOpenRCX.cpp
-    extmeasure_res.cpp
 )
 
 target_include_directories(rcx
@@ -70,7 +83,7 @@ target_include_directories(rcx
 
 target_link_libraries(rcx
   PUBLIC
-    odb
+    rcx_lib
     utl
   PRIVATE
     OpenSTA
@@ -97,7 +110,7 @@ target_include_directories(rcxUnitTest
 )
 
 target_link_libraries(rcxUnitTest
-  rcx
+  rcx_lib
 )
 
 # Use the shared library if found.  We need to pass this info to

--- a/src/rcx/src/MakeOpenRCX.cpp
+++ b/src/rcx/src/MakeOpenRCX.cpp
@@ -35,6 +35,18 @@
 
 #include "ord/OpenRoad.hh"
 #include "rcx/ext.h"
+#include "sta/StaMain.hh"
+
+namespace sta {
+// Tcl files encoded into strings.
+extern const char* rcx_tcl_inits[];
+}  // namespace sta
+
+namespace rcx {
+extern "C" {
+extern int Rcx_Init(Tcl_Interp* interp);
+}
+}  // namespace rcx
 
 namespace ord {
 
@@ -51,7 +63,10 @@ void deleteOpenRCX(rcx::Ext* extractor)
 void initOpenRCX(OpenRoad* openroad)
 {
   openroad->getOpenRCX()->init(
-      openroad->tclInterp(), openroad->getDb(), openroad->getLogger());
+      openroad->getDb(), openroad->getLogger(), [openroad] {
+        rcx::Rcx_Init(openroad->tclInterp());
+        sta::evalTclInit(openroad->tclInterp(), sta::rcx_tcl_inits);
+      });
 }
 
 }  // namespace ord

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -34,36 +34,27 @@
 #include <errno.h>
 
 #include "odb/wOrder.h"
-#include "sta/StaMain.hh"
 #include "utl/Logger.h"
-
-namespace sta {
-// Tcl files encoded into strings.
-extern const char* rcx_tcl_inits[];
-}  // namespace sta
 
 namespace rcx {
 
 using utl::Logger;
 using utl::RCX;
 
-extern "C" {
-extern int Rcx_Init(Tcl_Interp* interp);
-}
-
 Ext::Ext() : odb::ZInterface(), _ext(std::make_unique<extMain>())
 {
 }
 
-void Ext::init(Tcl_Interp* tcl_interp, odb::dbDatabase* db, Logger* logger)
+void Ext::init(odb::dbDatabase* db,
+               Logger* logger,
+               std::function<void()> rcx_init)
 {
   _db = db;
   logger_ = logger;
   _ext->init(db, logger);
 
   // Define swig TCL commands.
-  Rcx_Init(tcl_interp);
-  sta::evalTclInit(tcl_interp, sta::rcx_tcl_inits);
+  rcx_init();
 }
 
 void Ext::setLogger(Logger* logger)


### PR DESCRIPTION
The new library ordering of modules decouples the TCL/Wrapper code from the underlying module code. This allows us to create unit tests for each module without having to link the entire application and swig layers.

It should lead to a more ~~compostable~~ composable environment.

And now a poem, because I like being extra.

```
The path is dark and cold,
The trees are gnarled and old,
The sun is hidden from my sight,
And I am lost in endless night.

I stumble on, I know not where,
My only guide is my despair.
The path is hard and the journey long,
And I am weak, I cannot go on.

But then I see a light,
A glimmer of hope in the night.
I run towards it, I must find it,
It is my only chance to be free.

I stumble out into the light,
And I see that I have died.
I am in a new world,
A world of peace and light.

I am free.
```

Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>