### PR TITLE
drt: Remove layerPathArea from FlexWavefront

### DIFF
--- a/src/drt/src/dr/FlexGridGraph_maze.cpp
+++ b/src/drt/src/dr/FlexGridGraph_maze.cpp
@@ -51,8 +51,6 @@ void FlexGridGraph::expand(FlexWavefrontGrid& currGrid,
   // get cost
   nextEstCost = getEstCost(nextIdx, dstMazeIdx1, dstMazeIdx2, dir);
   nextPathCost = getNextPathCost(currGrid, dir);
-  auto lNum = getLayerNum(currGrid.z());
-  auto pathWidth = getTech()->getLayer(lNum)->getWidth();
   Point currPt;
   getPoint(currPt, gridX, gridY);
   frCoord currDist = Point::manhattanDistance(currPt, centerPt);
@@ -99,32 +97,24 @@ void FlexGridGraph::expand(FlexWavefrontGrid& currGrid,
     nextTLength = std::numeric_limits<frCoord>::max();
   }
 
-  FlexWavefrontGrid nextWavefrontGrid(
-      gridX,
-      gridY,
-      gridZ,
-      currGrid.getLayerPathArea()
-          + getEdgeLength(currGrid.x(), currGrid.y(), currGrid.z(), dir)
-                * pathWidth,
-      nextVLengthX,
-      nextVLengthY,
-      nextIsPrevViaUp,
-      nextTLength,
-      currDist,
-      nextPathCost,
-      nextPathCost + nextEstCost,
-      currGrid.getBackTraceBuffer());
+  FlexWavefrontGrid nextWavefrontGrid(gridX,
+                                      gridY,
+                                      gridZ,
+                                      nextVLengthX,
+                                      nextVLengthY,
+                                      nextIsPrevViaUp,
+                                      nextTLength,
+                                      currDist,
+                                      nextPathCost,
+                                      nextPathCost + nextEstCost,
+                                      currGrid.getBackTraceBuffer());
   if (dir == frDirEnum::U || dir == frDirEnum::D) {
-    nextWavefrontGrid.resetLayerPathArea();
     nextWavefrontGrid.resetLength();
     if (dir == frDirEnum::U) {
       nextWavefrontGrid.setPrevViaUp(false);
     } else {
       nextWavefrontGrid.setPrevViaUp(true);
     }
-    nextWavefrontGrid.addLayerPathArea(
-        (dir == frDirEnum::U) ? getHalfViaEncArea(currGrid.z(), false)
-                              : getHalfViaEncArea(gridZ, true));
   }
   if (currGrid.getSrcTaperBox()
       && currGrid.getSrcTaperBox()->contains(
@@ -845,17 +835,12 @@ bool FlexGridGraph::search(vector<FlexMazeIdx>& connComps,
       path.push_back(FlexMazeIdx(idx.x(), idx.y(), idx.z()));
       return true;
     }
-    // get min area min length
-    auto lNum = getLayerNum(idx.z());
-    auto minAreaConstraint = getTech()->getLayer(lNum)->getAreaConstraint();
-    frCoord fakeArea = minAreaConstraint ? minAreaConstraint->getMinArea() : 0;
     getPoint(currPt, idx.x(), idx.y());
     frCoord currDist = Point::manhattanDistance(currPt, centerPt);
     FlexWavefrontGrid currGrid(
         idx.x(),
         idx.y(),
         idx.z(),
-        fakeArea,
         std::numeric_limits<frCoord>::max(),
         std::numeric_limits<frCoord>::max(),
         true,

--- a/src/drt/src/dr/FlexWavefront.h
+++ b/src/drt/src/dr/FlexWavefront.h
@@ -36,7 +36,7 @@
 #include "dr/FlexMazeTypes.h"
 #include "frBaseTypes.h"
 #include "global.h"
-//#include <boost/pool/pool_alloc.hpp>
+// #include <boost/pool/pool_alloc.hpp>
 
 namespace fr {
 class FlexWavefrontGrid
@@ -48,7 +48,6 @@ class FlexWavefrontGrid
         zIdx_(-1),
         pathCost_(0),
         cost_(0),
-        layerPathArea_(0),
         vLengthX_(std::numeric_limits<frCoord>::max()),
         vLengthY_(std::numeric_limits<frCoord>::max()),
         dist_(0),
@@ -60,7 +59,6 @@ class FlexWavefrontGrid
   FlexWavefrontGrid(int xIn,
                     int yIn,
                     int zIn,
-                    frCoord layerPathAreaIn,
                     frCoord vLengthXIn,
                     frCoord vLengthYIn,
                     bool prevViaUpIn,
@@ -73,7 +71,6 @@ class FlexWavefrontGrid
         zIdx_(zIn),
         pathCost_(pathCostIn),
         cost_(costIn),
-        layerPathArea_(layerPathAreaIn),
         vLengthX_(vLengthXIn),
         vLengthY_(vLengthYIn),
         dist_(distIn),
@@ -85,7 +82,6 @@ class FlexWavefrontGrid
   FlexWavefrontGrid(int xIn,
                     int yIn,
                     int zIn,
-                    frCoord layerPathAreaIn,
                     frCoord vLengthXIn,
                     frCoord vLengthYIn,
                     bool prevViaUpIn,
@@ -99,7 +95,6 @@ class FlexWavefrontGrid
         zIdx_(zIn),
         pathCost_(pathCostIn),
         cost_(costIn),
-        layerPathArea_(layerPathAreaIn),
         vLengthX_(vLengthXIn),
         vLengthY_(vLengthYIn),
         dist_(distIn),
@@ -135,7 +130,6 @@ class FlexWavefrontGrid
   {
     return backTraceBuffer_;
   }
-  frCoord getLayerPathArea() const { return layerPathArea_; }
   frCoord getLength() const { return vLengthX_; }
   void getVLength(frCoord& vLengthXIn, frCoord& vLengthYIn) const
   {
@@ -145,8 +139,6 @@ class FlexWavefrontGrid
   bool isPrevViaUp() const { return prevViaUp_; }
   frCoord getTLength() const { return tLength_; }
   // setters
-  void addLayerPathArea(frCoord in) { layerPathArea_ += in; }
-  void resetLayerPathArea() { layerPathArea_ = 0; }
 
   void resetLength()
   {
@@ -180,7 +172,6 @@ class FlexWavefrontGrid
   frMIdx xIdx_, yIdx_, zIdx_;
   frCost pathCost_;  // path cost
   frCost cost_;      // path + est cost
-  frCoord layerPathArea_;
   frCoord vLengthX_;
   frCoord vLengthY_;
   frCoord dist_;  // to maze center


### PR DESCRIPTION
Based on a patch from Austin Rovinski

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>