### PR TITLE
Fix apparent typos in `InitFloorplan.tcl`

### DIFF
--- a/src/ifp/src/InitFloorplan.tcl
+++ b/src/ifp/src/InitFloorplan.tcl
@@ -221,12 +221,12 @@ proc insert_tiecells { args } {
     }
   }
   if { $master == "NULL" } {
-    utl::logger "IFP" 31 "Unable to find master: $tie_cell"
+    utl::error "IFP" 31 "Unable to find master: $tie_cell"
   }
 
   set mterm [$master findMTerm $port]
   if { $master == "NULL" } {
-    utl::logger "IFP" 32 "Unable to find master pin: $args"
+    utl::error "IFP" 32 "Unable to find master pin: $args"
   }
 
   ifp::insert_tiecells_cmd $mterm $prefix


### PR DESCRIPTION
I could be wrong, but it looks like the `utl::logger` calls in `InitFloorplan.tcl` cause syntax errors if they are ever reached. Were these lines supposed to be `utl::error`?

Signed-off-by: WRansohoff <5217539+WRansohoff@users.noreply.github.com>