### PR TITLE
Adds Precompiled headers to build

### DIFF
--- a/src/drt/CMakeLists.txt
+++ b/src/drt/CMakeLists.txt
@@ -138,6 +138,15 @@ target_include_directories(drt
     src
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0") 
+  target_precompile_headers(drt
+    PRIVATE
+      src/serialization.h
+      src/io/io.h
+      src/dr/FlexDR.h
+  )
+endif()
+
 target_link_libraries(drt
   PUBLIC
     gui

--- a/src/dst/CMakeLists.txt
+++ b/src/dst/CMakeLists.txt
@@ -58,6 +58,13 @@ target_include_directories(dst
     include
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0") 
+  target_precompile_headers(dst
+    PUBLIC
+      include/dst/Distributed.h
+  )
+endif()
+
 target_link_libraries(dst
   PUBLIC
     utl

--- a/src/odb/src/db/CMakeLists.txt
+++ b/src/odb/src/db/CMakeLists.txt
@@ -135,6 +135,13 @@ target_include_directories(db
         ${TCL_INCLUDE_PATH}
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0") 
+  target_precompile_headers(db
+    PUBLIC
+      ${PROJECT_SOURCE_DIR}/include/odb/db.h
+  )
+endif()
+
 set_target_properties(db
   PROPERTIES
     # python requirement

--- a/src/utl/CMakeLists.txt
+++ b/src/utl/CMakeLists.txt
@@ -77,6 +77,14 @@ target_include_directories(utl
     src
 )
 
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.16.0")
+  target_precompile_headers(utl
+    PUBLIC
+      include/utl/Logger.h
+  )
+endif()
+
+
 target_link_libraries(utl
   PUBLIC
     spdlog::spdlog


### PR DESCRIPTION
This PR adds some commonly included headers as pre-compiled headers (PCH) it speeds up the build time pretty considerably on my laptop.

It only works on CMake 3.16 so added a few ifdef guards.