### PR TITLE
drt: write preferred aps back to database in debug mode

### DIFF
--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -844,7 +844,7 @@ int TritonRoute::main()
     FlexPA pa(getDesign(), logger_);
     pa.setDebug(debug_.get(), db_);
     pa.main();
-    if (distributed_ || debug_->debugDumpDR) {
+    if (distributed_ || debug_->debugDR || debug_->debugDumpDR) {
       io::Writer writer(getDesign(), logger_);
       writer.updateDb(db_, true);
       if (distributed_)


### PR DESCRIPTION
It's useful to see preferred access points when using detailed routing debug.