### PR TITLE
drt: Add comment explaining multi patterning limitation

### DIFF
--- a/src/drt/src/db/tech/frLayer.h
+++ b/src/drt/src/db/tech/frLayer.h
@@ -190,7 +190,7 @@ class frLayer
   }
   bool isUnidirectional() const
   {
-    // We don't handle coloring so any double/triple patterned
+    // We don't handle coloring so any multiple patterned
     // layer is treated as unidirectional.
     // RectOnly could allow for a purely wrong-way rect but
     // we ignore that rare case and treat it as unidirectional.

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1234,6 +1234,8 @@ void io::Parser::setRoutingLayerProperties(odb::dbTechLayer* layer,
     tmpLayer->setLef58RectOnlyConstraint(rectOnlyConstraint.get());
     tech_->addUConstraint(std::move(rectOnlyConstraint));
   }
+  // We don't handle coloring so tracks on any multiple patterned
+  // layer are forced to be on grid.
   if (layer->isRightWayOnGridOnly() || layer->getNumMasks() > 1) {
     auto rightWayOnGridOnlyConstraint
         = make_unique<frLef58RightWayOnGridOnlyConstraint>(


### PR DESCRIPTION
On multiple patterned layers we force tracks to be both unidirectional and on grid. Add a comment (and update the other).