### PR TITLE
Bump OpenSTA Version

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -159,8 +159,9 @@ OpenRoad::OpenRoad()
 OpenRoad::~OpenRoad()
 {
   deleteDbVerilogNetwork(verilog_network_);
-  deleteDbSta(sta_);
-  sta::deleteAllMemory();
+  // Temporarily removed until a crash can be resolved
+  // deleteDbSta(sta_);
+  // sta::deleteAllMemory();
   deleteIoplacer(ioPlacer_);
   deleteResizer(resizer_);
   deleteOpendp(opendp_);

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -859,7 +859,7 @@ TechChar::ResultData TechChar::computeTopologyResults(
     // buffer.
     for (odb::dbInst* bufferInst : solution.instVector) {
       sta::Instance* bufferInstSta = db_network_->dbToSta(bufferInst);
-      sta::PowerResult instResults 
+      sta::PowerResult instResults
           = openStaChar_->power(bufferInstSta, charCorner_);
       totalPower = totalPower + instResults.total();
     }

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -859,8 +859,7 @@ TechChar::ResultData TechChar::computeTopologyResults(
     // buffer.
     for (odb::dbInst* bufferInst : solution.instVector) {
       sta::Instance* bufferInstSta = db_network_->dbToSta(bufferInst);
-      sta::PowerResult instResults;
-      openStaChar_->power(bufferInstSta, charCorner_, instResults);
+      sta::PowerResult instResults = openStaChar_->power(bufferInstSta, charCorner_);
       totalPower = totalPower + instResults.total();
     }
   }

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -859,7 +859,8 @@ TechChar::ResultData TechChar::computeTopologyResults(
     // buffer.
     for (odb::dbInst* bufferInst : solution.instVector) {
       sta::Instance* bufferInstSta = db_network_->dbToSta(bufferInst);
-      sta::PowerResult instResults = openStaChar_->power(bufferInstSta, charCorner_);
+      sta::PowerResult instResults 
+          = openStaChar_->power(bufferInstSta, charCorner_);
       totalPower = totalPower + instResults.total();
     }
   }

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -867,7 +867,7 @@ bool TritonCTS::masterExists(const std::string& master) const
 void TritonCTS::findClockRoots(sta::Clock* clk,
                                std::set<odb::dbNet*>& clockNets)
 {
-  for (sta::Pin* pin : clk->leafPins()) {
+  for (const sta::Pin* pin : clk->leafPins()) {
     odb::dbITerm* instTerm;
     odb::dbBTerm* port;
     network_->staToDb(pin, instTerm, port);

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -197,14 +197,14 @@ class dbNetwork : public ConcreteNetwork
   void findInstNetsMatching(const Instance* instance,
                             const PatternMatch* pattern,
                             // Return value.
-                            NetSeq* nets) const override;
+                            NetSeq& nets) const override;
   const char* name(const Net* net) const override;
   Instance* instance(const Net* net) const override;
   bool isPower(const Net* net) const override;
   bool isGround(const Net* net) const override;
   NetPinIterator* pinIterator(const Net* net) const override;
   NetTermIterator* termIterator(const Net* net) const override;
-  Net* highestConnectedNet(Net* net) const override;
+  const Net* highestConnectedNet(Net *net) const override;
   bool isSpecial(Net* net);
 
   ////////////////////////////////////////////////////////////////
@@ -221,11 +221,11 @@ class dbNetwork : public ConcreteNetwork
   Pin* connect(Instance* inst, LibertyPort* port, Net* net) override;
   void connectPinAfter(Pin* pin);
   void disconnectPin(Pin* pin) override;
-  void disconnectPinBefore(Pin* pin);
+  void disconnectPinBefore(const Pin* pin);
   void deletePin(Pin* pin) override;
   Net* makeNet(const char* name, Instance* parent) override;
   void deleteNet(Net* net) override;
-  void deleteNetBefore(Net* net);
+  void deleteNetBefore(const Net* net);
   void mergeInto(Net* net, Net* into_net) override;
   Net* mergedInto(Net* net) override;
   double dbuToMeters(int dist) const;
@@ -253,7 +253,7 @@ class dbNetwork : public ConcreteNetwork
   void findConstantNets();
   void visitConnectedPins(const Net* net,
                           PinVisitor& visitor,
-                          ConstNetSet& visited_nets) const override;
+                          NetSet& visited_nets) const override;
   bool portMsbFirst(const char* port_name);
 
   dbDatabase* db_;

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -165,6 +165,7 @@ class dbNetwork : public ConcreteNetwork
   Instance* topInstance() const override;
   // Name local to containing cell/instance.
   const char* name(const Instance* instance) const override;
+  ObjectId id(const Instance *instance) const override;
   Cell* cell(const Instance* instance) const override;
   Instance* parent(const Instance* instance) const override;
   bool isLeaf(const Instance* instance) const override;
@@ -176,6 +177,7 @@ class dbNetwork : public ConcreteNetwork
   
   ////////////////////////////////////////////////////////////////
   // Pin functions
+  ObjectId id(const Pin *pin) const override;
   Pin* findPin(const Instance* instance, const char* port_name) const override;
   Pin* findPin(const Instance* instance, const Port* port) const override;
   Port* port(const Pin* pin) const override;
@@ -190,9 +192,11 @@ class dbNetwork : public ConcreteNetwork
   // Terminal functions
   Net* net(const Term* term) const override;
   Pin* pin(const Term* term) const override;
+  ObjectId id(const Term *term) const override;
 
   ////////////////////////////////////////////////////////////////
   // Net functions
+  ObjectId id(const Net *net) const override;
   Net* findNet(const Instance* instance, const char* net_name) const override;
   void findInstNetsMatching(const Instance* instance,
                             const PatternMatch* pattern,
@@ -246,7 +250,7 @@ class dbNetwork : public ConcreteNetwork
   using Network::netIterator;
   using NetworkReader::makeCell;
   using NetworkReader::makeLibrary;
-
+ 
  protected:
   void readDbNetlistAfter();
   void makeTopCell();

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -147,6 +147,7 @@ class dbNetwork : public ConcreteNetwork
   PortDirection* dbToSta(dbSigType sig_type, dbIoType io_type) const;
   // dbStaCbk::inDbBTermCreate
   void makeTopPort(dbBTerm* bterm);
+  ObjectId id(const Port *port) const override;
 
   ////////////////////////////////////////////////////////////////
   //

--- a/src/dbSta/src/CMakeLists.txt
+++ b/src/dbSta/src/CMakeLists.txt
@@ -44,11 +44,14 @@ swig_lib(NAME          dbSta
                        ${ODB_HOME}/include
          SCRIPTS       ${OPENSTA_HOME}/tcl/Graph.tcl
                        ${OPENSTA_HOME}/tcl/Liberty.tcl
+                       ${OPENSTA_HOME}/tcl/CmdArgs.tcl
+                       ${OPENSTA_HOME}/tcl/CmdUtil.tcl
+                       ${OPENSTA_HOME}/tcl/Property.tcl
+                       ${OPENSTA_HOME}/tcl/WritePathSpice.tcl
                        ${OPENSTA_HOME}/tcl/Network.tcl
                        ${OPENSTA_HOME}/tcl/NetworkEdit.tcl
                        ${OPENSTA_HOME}/tcl/Sdc.tcl
                        ${OPENSTA_HOME}/tcl/Search.tcl
-                       ${OPENSTA_HOME}/tcl/Cmds.tcl
                        ${OPENSTA_HOME}/tcl/Variables.tcl
                        ${OPENSTA_HOME}/tcl/Sta.tcl
                        ${OPENSTA_HOME}/tcl/Splash.tcl

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -424,6 +424,14 @@ dbNetwork::metersToDbu(double dist) const
 
 ////////////////////////////////////////////////////////////////
 
+ObjectId dbNetwork::id(const Instance* instance) const
+{
+  if (instance == top_instance_) {
+    return 0;
+  }
+  return staToDb(instance)->getId();
+}
+
 const char*
 dbNetwork::name(const Instance* instance) const
 {
@@ -604,6 +612,18 @@ dbNetwork::netIterator(const Instance* instance) const
 
 ////////////////////////////////////////////////////////////////
 
+ObjectId dbNetwork::id(const Pin* pin) const
+{
+  dbITerm* iterm;
+  dbBTerm* bterm;
+  staToDb(pin, iterm, bterm);
+
+  if (iterm) {
+    return iterm->getId() + iterm->getBlock()->getBTerms().size();
+  }
+  return bterm->getId();
+}
+
 Instance*
 dbNetwork::instance(const Pin* pin) const
 {
@@ -777,6 +797,11 @@ dbNetwork::isPlaced(const Pin* pin) const
 
 ////////////////////////////////////////////////////////////////
 
+ObjectId dbNetwork::id(const Net* net) const
+{
+  return staToDb(net)->getId();
+}
+
 const char*
 dbNetwork::name(const Net* net) const
 {
@@ -839,6 +864,11 @@ const Net* dbNetwork::highestConnectedNet(Net* net) const
 }
 
 ////////////////////////////////////////////////////////////////
+
+ObjectId dbNetwork::id(const Term* term) const
+{
+  return staToDb(term)->getId();
+}
 
 Pin*
 dbNetwork::pin(const Term* term) const

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -835,7 +835,7 @@ dbNetwork::visitConnectedPins(const Net* net,
   }
 }
 
-const Net*
+const Net* 
 dbNetwork::highestConnectedNet(Net* net) const
 {
   return net;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -422,6 +422,15 @@ dbNetwork::metersToDbu(double dist) const
   return dist * dbu * 1e+6;
 }
 
+ObjectId dbNetwork::id(const Port *port) const
+{
+  if (!port) {
+    // should not match anything else
+    return std::numeric_limits<ObjectId>::max();
+  }
+  return ConcreteNetwork::id(port);
+}
+
 ////////////////////////////////////////////////////////////////
 
 ObjectId dbNetwork::id(const Instance* instance) const

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -823,7 +823,7 @@ dbNetwork::termIterator(const Net* net) const
 void
 dbNetwork::visitConnectedPins(const Net* net,
                               PinVisitor& visitor,
-                              ConstNetSet& visited_nets) const
+                              NetSet& visited_nets) const
 {
   dbNet* db_net = staToDb(net);
   for (dbITerm* iterm : db_net->getITerms()) {

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -564,10 +564,9 @@ dbNetwork::findNet(const Instance* instance, const char* net_name) const
   return dbToSta(dnet);
 }
 
-void
-dbNetwork::findInstNetsMatching(const Instance* instance,
-                                const PatternMatch* pattern,
-                                NetSeq& nets) const
+void dbNetwork::findInstNetsMatching(const Instance* instance,
+                                     const PatternMatch* pattern,
+                                     NetSeq& nets) const
 {
   if (instance == top_instance_) {
     if (pattern->hasWildcards()) {
@@ -819,10 +818,9 @@ dbNetwork::termIterator(const Net* net) const
 }
 
 // override ConcreteNetwork::visitConnectedPins
-void
-dbNetwork::visitConnectedPins(const Net* net,
-                              PinVisitor& visitor,
-                              NetSet& visited_nets) const
+void dbNetwork::visitConnectedPins(const Net* net,
+                                   PinVisitor& visitor,
+                                   NetSet& visited_nets) const
 {
   dbNet* db_net = staToDb(net);
   for (dbITerm* iterm : db_net->getITerms()) {
@@ -835,8 +833,7 @@ dbNetwork::visitConnectedPins(const Net* net,
   }
 }
 
-const Net* 
-dbNetwork::highestConnectedNet(Net* net) const
+const Net* dbNetwork::highestConnectedNet(Net* net) const
 {
   return net;
 }
@@ -1230,8 +1227,7 @@ dbNetwork::disconnectPin(Pin* pin)
     bterm->disconnect();
 }
 
-void
-dbNetwork::disconnectPinBefore(const Pin* pin)
+void dbNetwork::disconnectPinBefore(const Pin* pin)
 {
   Net* net = this->net(pin);
   // Incrementally update drivers.
@@ -1272,8 +1268,7 @@ dbNetwork::deleteNet(Net* net)
   dbNet::destroy(dnet);
 }
 
-void
-dbNetwork::deleteNetBefore(const Net* net)
+void dbNetwork::deleteNetBefore(const Net* net)
 {
   PinSet* drvrs = net_drvr_pin_map_.findKey(net);
   delete drvrs;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -567,21 +567,20 @@ dbNetwork::findNet(const Instance* instance, const char* net_name) const
 void
 dbNetwork::findInstNetsMatching(const Instance* instance,
                                 const PatternMatch* pattern,
-                                // Return value.
-                                NetSeq* nets) const
+                                NetSeq& nets) const
 {
   if (instance == top_instance_) {
     if (pattern->hasWildcards()) {
       for (dbNet* dnet : block_->getNets()) {
         const char* net_name = dnet->getConstName();
         if (pattern->match(net_name))
-          nets->push_back(dbToSta(dnet));
+          nets.push_back(dbToSta(dnet));
       }
     }
     else {
       dbNet* dnet = block_->findNet(pattern->pattern());
       if (dnet)
-        nets->push_back(dbToSta(dnet));
+        nets.push_back(dbToSta(dnet));
     }
   }
 }
@@ -836,7 +835,7 @@ dbNetwork::visitConnectedPins(const Net* net,
   }
 }
 
-Net*
+const Net*
 dbNetwork::highestConnectedNet(Net* net) const
 {
   return net;
@@ -1232,7 +1231,7 @@ dbNetwork::disconnectPin(Pin* pin)
 }
 
 void
-dbNetwork::disconnectPinBefore(Pin* pin)
+dbNetwork::disconnectPinBefore(const Pin* pin)
 {
   Net* net = this->net(pin);
   // Incrementally update drivers.
@@ -1274,7 +1273,7 @@ dbNetwork::deleteNet(Net* net)
 }
 
 void
-dbNetwork::deleteNetBefore(Net* net)
+dbNetwork::deleteNetBefore(const Net* net)
 {
   PinSet* drvrs = net_drvr_pin_map_.findKey(net);
   delete drvrs;

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -375,13 +375,13 @@ Verilog2db::makeDbNets(const Instance* inst)
       PinSeq net_pins;
       NetConnectedPinIterator* pin_iter = network_->connectedPinIterator(net);
       while (pin_iter->hasNext()) {
-        Pin* pin = pin_iter->next();
+        const Pin* pin = pin_iter->next();
         net_pins.push_back(pin);
       }
       delete pin_iter;
       sort(net_pins, PinPathNameLess(network_));
 
-      for (Pin* pin : net_pins) {
+      for (const Pin* pin : net_pins) {
         if (network_->isTopLevelPort(pin)) {
           const char* port_name = network_->portName(pin);
           if (block_->findBTerm(port_name) == nullptr) {

--- a/src/dbSta/src/dbSdcNetwork.hh
+++ b/src/dbSta/src/dbSdcNetwork.hh
@@ -44,23 +44,20 @@ class dbSdcNetwork : public SdcNetwork
 public:
   dbSdcNetwork(Network* network);
   virtual Instance* findInstance(const char* path_name) const;
-  virtual void findInstancesMatching(const Instance* contex,
-                                     const PatternMatch* pattern,
-                                     InstanceSeq* insts) const;
-  virtual void findNetsMatching(const Instance*,
-                                const PatternMatch* pattern,
-                                NetSeq* nets) const;
-  virtual void findPinsMatching(const Instance* instance,
-                                const PatternMatch* pattern,
-                                PinSeq* pins) const;
+  virtual InstanceSeq findInstancesMatching(const Instance* contex,
+                                     const PatternMatch* pattern) const;
+  virtual NetSeq findNetsMatching(const Instance*,
+                                const PatternMatch* pattern) const;
+  virtual PinSeq findPinsMatching(const Instance* instance,
+                                  const PatternMatch* pattern) const;
 
 protected:
   void findInstancesMatching1(const PatternMatch* pattern,
-                              InstanceSeq* insts) const;
-  void findNetsMatching1(const PatternMatch* pattern, NetSeq* nets) const;
+                              InstanceSeq& insts) const;
+  void findNetsMatching1(const PatternMatch* pattern, NetSeq& nets) const;
   void findMatchingPins(const Instance* instance,
                         const PatternMatch* port_pattern,
-                        PinSeq* pins) const;
+                        PinSeq& pins) const;
   Pin* findPin(const char* path_name) const;
 
   using SdcNetwork::findPin;

--- a/src/dbSta/src/dbSdcNetwork.hh
+++ b/src/dbSta/src/dbSdcNetwork.hh
@@ -45,9 +45,9 @@ public:
   dbSdcNetwork(Network* network);
   virtual Instance* findInstance(const char* path_name) const;
   virtual InstanceSeq findInstancesMatching(const Instance* contex,
-                                     const PatternMatch* pattern) const;
+                                            const PatternMatch* pattern) const;
   virtual NetSeq findNetsMatching(const Instance*,
-                                const PatternMatch* pattern) const;
+                                  const PatternMatch* pattern) const;
   virtual PinSeq findPinsMatching(const Instance* instance,
                                   const PatternMatch* pattern) const;
 

--- a/src/dbSta/src/dbSdcNetwork.hh
+++ b/src/dbSta/src/dbSdcNetwork.hh
@@ -46,10 +46,10 @@ public:
   Instance* findInstance(const char* path_name) const override;
   InstanceSeq findInstancesMatching(const Instance* contex,
                                             const PatternMatch* pattern) const override;
-  virtual NetSeq findNetsMatching(const Instance*,
-                                  const PatternMatch* pattern) const override;
-  virtual PinSeq findPinsMatching(const Instance* instance,
-                                  const PatternMatch* pattern) const override;
+  NetSeq findNetsMatching(const Instance*,
+                          const PatternMatch* pattern) const override;
+  PinSeq findPinsMatching(const Instance* instance,
+                          const PatternMatch* pattern) const override;
 
 protected:
   void findInstancesMatching1(const PatternMatch* pattern,

--- a/src/dbSta/src/dbSdcNetwork.hh
+++ b/src/dbSta/src/dbSdcNetwork.hh
@@ -43,13 +43,13 @@ class dbSdcNetwork : public SdcNetwork
 {
 public:
   dbSdcNetwork(Network* network);
-  virtual Instance* findInstance(const char* path_name) const;
-  virtual InstanceSeq findInstancesMatching(const Instance* contex,
-                                            const PatternMatch* pattern) const;
+  Instance* findInstance(const char* path_name) const override;
+  InstanceSeq findInstancesMatching(const Instance* contex,
+                                            const PatternMatch* pattern) const override;
   virtual NetSeq findNetsMatching(const Instance*,
-                                  const PatternMatch* pattern) const;
+                                  const PatternMatch* pattern) const override;
   virtual PinSeq findPinsMatching(const Instance* instance,
-                                  const PatternMatch* pattern) const;
+                                  const PatternMatch* pattern) const override;
 
 protected:
   void findInstancesMatching1(const PatternMatch* pattern,
@@ -58,8 +58,7 @@ protected:
   void findMatchingPins(const Instance* instance,
                         const PatternMatch* port_pattern,
                         PinSeq& pins) const;
-  Pin* findPin(const char* path_name) const;
-
+  Pin* findPin(const char* path_name) const override;
   using SdcNetwork::findPin;
 };
 

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -694,7 +694,7 @@ dbStaCbk::inDbBTermCreate(dbBTerm* bterm)
 void
 dbStaCbk::inDbBTermDestroy(dbBTerm* bterm)
 {
-  sta_->deletePinBefore(network_->dbToSta(bterm));
+  sta_->disconnectPin(network_->dbToSta(bterm));
   // sta::NetworkEdit does not support port removal.
 }
 

--- a/src/dbSta/src/heatMap.cpp
+++ b/src/dbSta/src/heatMap.cpp
@@ -113,8 +113,7 @@ bool PowerDensityDataSource::populateMap()
       continue;
     }
 
-    sta::PowerResult power;
-    sta_->power(network->dbToSta(inst), corner_, power);
+    sta::PowerResult power = sta_->power(network->dbToSta(inst), corner_);
 
     float pwr = 0.0;
     if (include_all) {

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -48,6 +48,7 @@
 #include "utl/Logger.h"
 
 namespace gpl {
+using namespace std;
 
 using namespace std;
 using utl::GPL;

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -1161,7 +1161,7 @@ ClockNodeGraphicsViewItem* ClockTreeView::addCellToScene(
     const PinArrival& output_pin,
     sta::dbNetwork* network)
 {
-  auto convert_pin = [&network](sta::Pin* pin) -> odb::dbITerm* {
+  auto convert_pin = [&network](const sta::Pin* pin) -> odb::dbITerm* {
     odb::dbITerm* iterm;
     odb::dbBTerm* bterm;
     network->staToDb(pin, iterm, bterm);

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -410,7 +410,7 @@ class ClockTreeView : public QGraphicsView
 
   struct PinArrival
   {
-    sta::Pin* pin = nullptr;
+    const sta::Pin* pin = nullptr;
     sta::Delay delay = 0.0;
   };
   ClockNodeGraphicsViewItem* addCellToScene(qreal x,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1419,7 +1419,7 @@ void MainWindow::timingPathsThrough(const std::set<Gui::odbTerm>& terms)
 {
   auto* settings = timing_widget_->getSettings();
   settings->setFromPin({});
-  std::set<sta::Pin*> pins;
+  std::set<const sta::Pin*> pins;
   for (const auto& term : terms) {
     pins.insert(settings->convertTerm(term));
   }

--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -230,9 +230,9 @@ void TimingPathsModel::sort(int col_index, Qt::SortOrder sort_order)
 }
 
 void TimingPathsModel::populateModel(
-    const std::set<sta::Pin*>& from,
-    const std::vector<std::set<sta::Pin*>>& thru,
-    const std::set<sta::Pin*>& to)
+    const std::set<const sta::Pin*>& from,
+    const std::vector<std::set<const sta::Pin*>>& thru,
+    const std::set<const sta::Pin*>& to)
 {
   beginResetModel();
   timing_paths_.clear();
@@ -241,9 +241,9 @@ void TimingPathsModel::populateModel(
 }
 
 bool TimingPathsModel::populatePaths(
-    const std::set<sta::Pin*>& from,
-    const std::vector<std::set<sta::Pin*>>& thru,
-    const std::set<sta::Pin*>& to)
+    const std::set<const sta::Pin*>& from,
+    const std::vector<std::set<const sta::Pin*>>& thru,
+    const std::set<const sta::Pin*>& to)
 {
   // On lines of DataBaseHandler
   QApplication::setOverrideCursor(Qt::WaitCursor);
@@ -615,7 +615,7 @@ void TimingConeRenderer::setBTerm(odb::dbBTerm* term, bool fanin, bool fanout)
   setPin(network->dbToSta(term), fanin, fanout);
 }
 
-void TimingConeRenderer::setPin(sta::Pin* pin, bool fanin, bool fanout)
+void TimingConeRenderer::setPin(const sta::Pin* pin, bool fanin, bool fanout)
 {
   if (sta_ == nullptr) {
     return;
@@ -688,7 +688,7 @@ void TimingConeRenderer::setPin(sta::Pin* pin, bool fanin, bool fanout)
   redraw();
 }
 
-bool TimingConeRenderer::isSupplyPin(sta::Pin* pin) const
+bool TimingConeRenderer::isSupplyPin(const sta::Pin* pin) const
 {
   auto* network = sta_->getDbNetwork();
   odb::dbITerm* iterm;
@@ -937,20 +937,20 @@ void PinSetWidget::updatePins()
   }
 }
 
-void PinSetWidget::setPins(const std::set<sta::Pin*>& pins)
+void PinSetWidget::setPins(const std::set<const sta::Pin*>& pins)
 {
   pins_.clear();
   pins_.insert(pins_.end(), pins.begin(), pins.end());
   updatePins();
 }
 
-const std::set<sta::Pin*> PinSetWidget::getPins() const
+const std::set<const sta::Pin*> PinSetWidget::getPins() const
 {
-  std::set<sta::Pin*> pins(pins_.begin(), pins_.end());
+  std::set<const sta::Pin*> pins(pins_.begin(), pins_.end());
   return pins;
 }
 
-void PinSetWidget::addPin(sta::Pin* pin)
+void PinSetWidget::addPin(const sta::Pin* pin)
 {
   if (pin == nullptr) {
     return;
@@ -963,7 +963,7 @@ void PinSetWidget::addPin(sta::Pin* pin)
   pins_.push_back(pin);
 }
 
-void PinSetWidget::removePin(sta::Pin* pin)
+void PinSetWidget::removePin(const sta::Pin* pin)
 {
   pins_.erase(std::find(pins_.begin(), pins_.end(), pin));
 }
@@ -972,7 +972,7 @@ void PinSetWidget::removeSelectedPins()
 {
   for (auto* selection : box_->selectedItems()) {
     void* pin_data = selection->data(Qt::UserRole).value<void*>();
-    removePin((sta::Pin*) pin_data);
+    removePin((const sta::Pin*) pin_data);
   }
   updatePins();
 }
@@ -997,16 +997,14 @@ void PinSetWidget::findPin()
     sta::PatternMatch matcher(name.constData());
 
     // search pins
-    sta::PinSeq found_pins;
-    network->findPinsHierMatching(top_inst, &matcher, &found_pins);
+    sta::PinSeq found_pins = network->findPinsHierMatching(top_inst, &matcher);
 
-    for (auto* pin : found_pins) {
+    for (const sta::Pin* pin : found_pins) {
       addPin(pin);
     }
 
     // search ports
-    sta::PortSeq found_ports;
-    network->findPortsMatching(network->cell(top_inst), &matcher, &found_ports);
+    sta::PortSeq found_ports = network->findPortsMatching(network->cell(top_inst), &matcher);
 
     for (auto* port : found_ports) {
       if (network->isBus(port) || network->isBundle(port)) {
@@ -1035,7 +1033,7 @@ void PinSetWidget::showMenu(const QPoint& point)
     return;
   }
 
-  sta::Pin* pin = (sta::Pin*) pin_item->data(Qt::UserRole).value<void*>();
+  const sta::Pin* pin = (const sta::Pin*) pin_item->data(Qt::UserRole).value<void*>();
 
   // Create menu and insert some actions
   QMenu pin_menu;
@@ -1217,7 +1215,7 @@ void TimingControlsDialog::setPinSelections()
   to_->updatePins();
 }
 
-sta::Pin* TimingControlsDialog::convertTerm(Gui::odbTerm term) const
+const sta::Pin* TimingControlsDialog::convertTerm(Gui::odbTerm term) const
 {
   sta::dbNetwork* network = sta_->getNetwork();
 
@@ -1229,7 +1227,7 @@ sta::Pin* TimingControlsDialog::convertTerm(Gui::odbTerm term) const
 }
 
 void TimingControlsDialog::setThruPin(
-    const std::vector<std::set<sta::Pin*>>& pins)
+    const std::vector<std::set<const sta::Pin*>>& pins)
 {
   for (size_t i = 0; i < thru_.size(); i++) {
     layout_->removeRow(thru_start_row_);
@@ -1247,7 +1245,7 @@ void TimingControlsDialog::setThruPin(
   }
 }
 
-void TimingControlsDialog::addThruRow(const std::set<sta::Pin*>& pins)
+void TimingControlsDialog::addThruRow(const std::set<const sta::Pin*>& pins)
 {
   auto* row = new PinSetWidget(true, this);
 
@@ -1280,9 +1278,9 @@ void TimingControlsDialog::addRemoveThru(PinSetWidget* row)
   }
 }
 
-const std::vector<std::set<sta::Pin*>> TimingControlsDialog::getThruPins() const
+const std::vector<std::set<const sta::Pin*>> TimingControlsDialog::getThruPins() const
 {
-  std::vector<std::set<sta::Pin*>> pins;
+  std::vector<std::set<const sta::Pin*>> pins;
   for (auto* row : thru_) {
     pins.push_back(row->getPins());
   }

--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -1004,7 +1004,8 @@ void PinSetWidget::findPin()
     }
 
     // search ports
-    sta::PortSeq found_ports = network->findPortsMatching(network->cell(top_inst), &matcher);
+    sta::PortSeq found_ports
+        = network->findPortsMatching(network->cell(top_inst), &matcher);
 
     for (auto* port : found_ports) {
       if (network->isBus(port) || network->isBundle(port)) {
@@ -1033,7 +1034,8 @@ void PinSetWidget::showMenu(const QPoint& point)
     return;
   }
 
-  const sta::Pin* pin = (const sta::Pin*) pin_item->data(Qt::UserRole).value<void*>();
+  const sta::Pin* pin
+      = (const sta::Pin*) pin_item->data(Qt::UserRole).value<void*>();
 
   // Create menu and insert some actions
   QMenu pin_menu;
@@ -1278,7 +1280,8 @@ void TimingControlsDialog::addRemoveThru(PinSetWidget* row)
   }
 }
 
-const std::vector<std::set<const sta::Pin*>> TimingControlsDialog::getThruPins() const
+const std::vector<std::set<const sta::Pin*>> TimingControlsDialog::getThruPins()
+    const
 {
   std::vector<std::set<const sta::Pin*>> pins;
   for (auto* row : thru_) {

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -383,11 +383,17 @@ class TimingControlsDialog : public QDialog
   void setExpandClock(bool expand);
   bool getExpandClock() const;
 
-  void setFromPin(const std::set<const sta::Pin*>& pins) { from_->setPins(pins); }
+  void setFromPin(const std::set<const sta::Pin*>& pins)
+  {
+    from_->setPins(pins);
+  }
   void setThruPin(const std::vector<std::set<const sta::Pin*>>& pins);
   void setToPin(const std::set<const sta::Pin*>& pins) { to_->setPins(pins); }
 
-  const std::set<const sta::Pin*> getFromPins() const { return from_->getPins(); }
+  const std::set<const sta::Pin*> getFromPins() const
+  {
+    return from_->getPins();
+  }
   const std::vector<std::set<const sta::Pin*>> getThruPins() const;
   const std::set<const sta::Pin*> getToPins() const { return to_->getPins(); }
 

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -88,17 +88,17 @@ class TimingPathsModel : public QAbstractTableModel
   TimingPath* getPathAt(const QModelIndex& index) const;
 
   void resetModel();
-  void populateModel(const std::set<sta::Pin*>& from,
-                     const std::vector<std::set<sta::Pin*>>& thru,
-                     const std::set<sta::Pin*>& to);
+  void populateModel(const std::set<const sta::Pin*>& from,
+                     const std::vector<std::set<const sta::Pin*>>& thru,
+                     const std::set<const sta::Pin*>& to);
 
  public slots:
   void sort(int col_index, Qt::SortOrder sort_order) override;
 
  private:
-  bool populatePaths(const std::set<sta::Pin*>& from,
-                     const std::vector<std::set<sta::Pin*>>& thru,
-                     const std::set<sta::Pin*>& to);
+  bool populatePaths(const std::set<const sta::Pin*>& from,
+                     const std::vector<std::set<const sta::Pin*>>& thru,
+                     const std::set<const sta::Pin*>& to);
 
   STAGuiInterface* sta_;
   bool is_setup_;
@@ -239,13 +239,13 @@ class TimingConeRenderer : public gui::Renderer
   void setSTA(sta::dbSta* sta) { sta_ = sta; }
   void setITerm(odb::dbITerm* term, bool fanin, bool fanout);
   void setBTerm(odb::dbBTerm* term, bool fanin, bool fanout);
-  void setPin(sta::Pin* pin, bool fanin, bool fanout);
+  void setPin(const sta::Pin* pin, bool fanin, bool fanout);
 
   virtual void drawObjects(gui::Painter& painter) override;
 
  private:
   sta::dbSta* sta_;
-  sta::Pin* term_;
+  const sta::Pin* term_;
   bool fanin_;
   bool fanout_;
   ConeDepthMap map_;
@@ -253,7 +253,7 @@ class TimingConeRenderer : public gui::Renderer
   float max_timing_;
   SpectrumGenerator color_generator_;
 
-  bool isSupplyPin(sta::Pin* pin) const;
+  bool isSupplyPin(const sta::Pin* pin) const;
 };
 
 class GuiDBChangeListener : public QObject, public odb::dbBlockCallBackObj
@@ -323,9 +323,9 @@ class PinSetWidget : public QWidget
 
   void updatePins();
 
-  void setPins(const std::set<sta::Pin*>& pins);
+  void setPins(const std::set<const sta::Pin*>& pins);
 
-  const std::set<sta::Pin*> getPins() const;
+  const std::set<const sta::Pin*> getPins() const;
 
   bool isAddMode() const { return add_mode_; }
   bool isRemoveMode() const { return !isAddMode(); }
@@ -348,7 +348,7 @@ class PinSetWidget : public QWidget
 
  private:
   sta::dbSta* sta_;
-  std::vector<sta::Pin*> pins_;
+  std::vector<const sta::Pin*> pins_;
 
   QListWidget* box_;
   QLineEdit* find_pin_;
@@ -357,8 +357,8 @@ class PinSetWidget : public QWidget
 
   bool add_mode_;
 
-  void addPin(sta::Pin* pin);
-  void removePin(sta::Pin* pin);
+  void addPin(const sta::Pin* pin);
+  void removePin(const sta::Pin* pin);
   void removeSelectedPins();
 };
 
@@ -383,15 +383,15 @@ class TimingControlsDialog : public QDialog
   void setExpandClock(bool expand);
   bool getExpandClock() const;
 
-  void setFromPin(const std::set<sta::Pin*>& pins) { from_->setPins(pins); }
-  void setThruPin(const std::vector<std::set<sta::Pin*>>& pins);
-  void setToPin(const std::set<sta::Pin*>& pins) { to_->setPins(pins); }
+  void setFromPin(const std::set<const sta::Pin*>& pins) { from_->setPins(pins); }
+  void setThruPin(const std::vector<std::set<const sta::Pin*>>& pins);
+  void setToPin(const std::set<const sta::Pin*>& pins) { to_->setPins(pins); }
 
-  const std::set<sta::Pin*> getFromPins() const { return from_->getPins(); }
-  const std::vector<std::set<sta::Pin*>> getThruPins() const;
-  const std::set<sta::Pin*> getToPins() const { return to_->getPins(); }
+  const std::set<const sta::Pin*> getFromPins() const { return from_->getPins(); }
+  const std::vector<std::set<const sta::Pin*>> getThruPins() const;
+  const std::set<const sta::Pin*> getToPins() const { return to_->getPins(); }
 
-  sta::Pin* convertTerm(Gui::odbTerm term) const;
+  const sta::Pin* convertTerm(Gui::odbTerm term) const;
 
   sta::Corner* getCorner() const { return sta_->getCorner(); }
   void setCorner(sta::Corner* corner) { sta_->setCorner(corner); }
@@ -426,7 +426,7 @@ class TimingControlsDialog : public QDialog
 
   void setPinSelections();
 
-  void addThruRow(const std::set<sta::Pin*>& pins);
+  void addThruRow(const std::set<const sta::Pin*>& pins);
   void setupPinRow(const QString& label, PinSetWidget* row, int row_index = -1);
 };
 

--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -219,7 +219,9 @@ void TimingPath::populateNodeList(sta::Path* path,
         if (network->isTopLevelPort(pin)) {
           // Output port counts as a fanout.
           sta::Port* port = network->port(pin);
-          fanout += sdc->portExtFanout(port, dcalc_ap->corner(), sta::MinMax::max()) + 1;
+          fanout += sdc->portExtFanout(
+                        port, dcalc_ap->corner(), sta::MinMax::max())
+                    + 1;
         } else {
           fanout++;
         }
@@ -658,7 +660,8 @@ std::vector<std::pair<const sta::Pin*, const sta::Pin*>> ClockTree::findPathTo(
   return path;
 }
 
-std::map<const sta::Pin*, std::set<const sta::Pin*>> ClockTree::getPinMapping() const
+std::map<const sta::Pin*, std::set<const sta::Pin*>> ClockTree::getPinMapping()
+    const
 {
   std::map<const sta::Pin*, std::set<const sta::Pin*>> pins;
 
@@ -771,8 +774,8 @@ TimingPathList STAGuiInterface::getTimingPaths(
 
   sta::Search* search = sta_->search();
 
-  sta::PathEndSeq path_ends =
-      search->findPathEnds(  // from, thrus, to, unconstrained
+  sta::PathEndSeq path_ends
+      = search->findPathEnds(  // from, thrus, to, unconstrained
           e_from,
           e_thrus,
           e_to,
@@ -858,12 +861,12 @@ ConeDepthMapPinSet STAGuiInterface::getFaninCone(const sta::Pin* pin) const
   pins_to.push_back(pin);
 
   auto pins = sta_->findFaninPins(&pins_to,
-                                   true,   // flat
-                                   false,  // startpoints_only
-                                   0,
-                                   0,
-                                   true,   // thru_disabled
-                                   true);  // thru_constants
+                                  true,   // flat
+                                  false,  // startpoints_only
+                                  0,
+                                  0,
+                                  true,   // thru_disabled
+                                  true);  // thru_constants
 
   ConeDepthMapPinSet depth_map;
   for (auto& [level, pin_list] : getCone(pin, pins, true)) {
@@ -879,12 +882,12 @@ ConeDepthMapPinSet STAGuiInterface::getFanoutCone(const sta::Pin* pin) const
   pins_from.push_back(pin);
 
   sta::PinSet pins = sta_->findFanoutPins(&pins_from,
-                                    true,   // flat
-                                    false,  // startpoints_only
-                                    0,
-                                    0,
-                                    true,   // thru_disabled
-                                    true);  // thru_constants
+                                          true,   // flat
+                                          false,  // startpoints_only
+                                          0,
+                                          0,
+                                          true,   // thru_disabled
+                                          true);  // thru_constants
   return getCone(pin, pins, false);
 }
 

--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -215,11 +215,11 @@ void TimingPath::populateNodeList(sta::Path* path,
     while (iter.hasNext()) {
       sta::Edge* edge = iter.next();
       if (edge->isWire()) {
-        sta::Pin* pin = edge->to(graph)->pin();
+        const sta::Pin* pin = edge->to(graph)->pin();
         if (network->isTopLevelPort(pin)) {
           // Output port counts as a fanout.
           sta::Port* port = network->port(pin);
-          fanout += sdc->portExtFanout(port, sta::MinMax::max()) + 1;
+          fanout += sdc->portExtFanout(port, dcalc_ap->corner(), sta::MinMax::max()) + 1;
         } else {
           fanout++;
         }
@@ -368,18 +368,18 @@ ClockTree::ClockTree(sta::Clock* clock, sta::dbNetwork* network)
   net_ = getNet(*clock_->pins().begin());
 }
 
-std::set<sta::Pin*> ClockTree::getDrivers() const
+std::set<const sta::Pin*> ClockTree::getDrivers() const
 {
-  std::set<sta::Pin*> drivers;
+  std::set<const sta::Pin*> drivers;
   for (const auto& [driver, arrival] : drivers_) {
     drivers.insert(driver);
   }
   return drivers;
 }
 
-std::set<sta::Pin*> ClockTree::getLeaves() const
+std::set<const sta::Pin*> ClockTree::getLeaves() const
 {
-  std::set<sta::Pin*> leaves;
+  std::set<const sta::Pin*> leaves;
   for (auto& [leaf, arrival] : leaves_) {
     leaves.insert(leaf);
   }
@@ -580,7 +580,7 @@ void ClockTree::addPath(sta::PathExpanded& path, const sta::StaState* sta)
   addPath(path, 0, sta);
 }
 
-sta::Net* ClockTree::getNet(sta::Pin* pin) const
+sta::Net* ClockTree::getNet(const sta::Pin* pin) const
 {
   sta::Term* term = network_->term(pin);
   if (term != nullptr) {
@@ -590,14 +590,14 @@ sta::Net* ClockTree::getNet(sta::Pin* pin) const
   }
 }
 
-bool ClockTree::isLeaf(sta::Pin* pin) const
+bool ClockTree::isLeaf(const sta::Pin* pin) const
 {
   return network_->isRegClkPin(pin) || network_->isLatchData(pin);
 }
 
 bool ClockTree::addVertex(sta::Vertex* vertex, sta::Delay delay)
 {
-  sta::Pin* pin = vertex->pin();
+  const sta::Pin* pin = vertex->pin();
 
   if (isLeaf(pin)) {
     leaves_[pin] = delay;
@@ -612,8 +612,8 @@ bool ClockTree::addVertex(sta::Vertex* vertex, sta::Delay delay)
   }
 }
 
-std::pair<sta::Pin*, sta::Delay> ClockTree::getPairedSink(
-    sta::Pin* paired_pin) const
+std::pair<const sta::Pin*, sta::Delay> ClockTree::getPairedSink(
+    const sta::Pin* paired_pin) const
 {
   sta::Instance* inst = network_->instance(paired_pin);
 
@@ -630,21 +630,21 @@ std::pair<sta::Pin*, sta::Delay> ClockTree::getPairedSink(
   return {nullptr, 0.0};
 }
 
-std::vector<std::pair<sta::Pin*, sta::Pin*>> ClockTree::findPathTo(
-    sta::Pin* pin) const
+std::vector<std::pair<const sta::Pin*, const sta::Pin*>> ClockTree::findPathTo(
+    const sta::Pin* pin) const
 {
   auto pin_map = getPinMapping();
 
-  std::vector<std::pair<sta::Pin*, sta::Pin*>> path;
+  std::vector<std::pair<const sta::Pin*, const sta::Pin*>> path;
 
   // looking for path to root
-  sta::Pin* root = drivers_.begin()->first;
+  const sta::Pin* root = drivers_.begin()->first;
 
-  sta::Pin* search_pin = pin;
+  const sta::Pin* search_pin = pin;
   while (search_pin != root) {
     const auto connections = pin_map[search_pin];
 
-    for (sta::Pin* connect : connections) {
+    for (const sta::Pin* connect : connections) {
       path.emplace_back(connect, search_pin);
     }
 
@@ -658,9 +658,9 @@ std::vector<std::pair<sta::Pin*, sta::Pin*>> ClockTree::findPathTo(
   return path;
 }
 
-std::map<sta::Pin*, std::set<sta::Pin*>> ClockTree::getPinMapping() const
+std::map<const sta::Pin*, std::set<const sta::Pin*>> ClockTree::getPinMapping() const
 {
-  std::map<sta::Pin*, std::set<sta::Pin*>> pins;
+  std::map<const sta::Pin*, std::set<const sta::Pin*>> pins;
 
   const auto drivers = getDrivers();
   for (const auto& [leaf, arrival] : leaves_) {
@@ -672,7 +672,7 @@ std::map<sta::Pin*, std::set<sta::Pin*>> ClockTree::getPinMapping() const
   }
 
   if (parent_ != nullptr) {
-    for (sta::Pin* driver : drivers) {
+    for (const sta::Pin* driver : drivers) {
       const auto& [parent_sink, time] = parent_->getPairedSink(driver);
       pins[driver].insert(parent_sink);
     }
@@ -706,7 +706,7 @@ int STAGuiInterface::getEndPointCount() const
 }
 
 std::unique_ptr<TimingPathNode> STAGuiInterface::getTimingNode(
-    sta::Pin* pin) const
+    const sta::Pin* pin) const
 {
   for (const auto& path : getTimingPaths(pin)) {
     for (const auto& node : path->getPathNodes()) {
@@ -722,7 +722,7 @@ std::unique_ptr<TimingPathNode> STAGuiInterface::getTimingNode(
   return nullptr;
 }
 
-TimingPathList STAGuiInterface::getTimingPaths(sta::Pin* thru) const
+TimingPathList STAGuiInterface::getTimingPaths(const sta::Pin* thru) const
 {
   return getTimingPaths({}, {{thru}}, {});
 }
@@ -771,7 +771,7 @@ TimingPathList STAGuiInterface::getTimingPaths(
 
   sta::Search* search = sta_->search();
 
-  std::unique_ptr<sta::PathEndSeq> path_ends(
+  sta::PathEndSeq path_ends =
       search->findPathEnds(  // from, thrus, to, unconstrained
           e_from,
           e_thrus,
@@ -795,9 +795,9 @@ TimingPathList STAGuiInterface::getTimingPaths(
           false,
           // clk_gating_setup, clk_gating_hold
           false,
-          false));
+          false);
 
-  for (auto& path_end : *path_ends) {
+  for (auto& path_end : path_ends) {
     TimingPath* timing_path = new TimingPath();
     sta::Path* path = path_end->path();
 
@@ -852,12 +852,12 @@ TimingPathList STAGuiInterface::getTimingPaths(
   return paths;
 }
 
-ConeDepthMapPinSet STAGuiInterface::getFaninCone(sta::Pin* pin) const
+ConeDepthMapPinSet STAGuiInterface::getFaninCone(const sta::Pin* pin) const
 {
   sta::PinSeq pins_to;
   pins_to.push_back(pin);
 
-  auto* pins = sta_->findFaninPins(&pins_to,
+  auto pins = sta_->findFaninPins(&pins_to,
                                    true,   // flat
                                    false,  // startpoints_only
                                    0,
@@ -873,12 +873,12 @@ ConeDepthMapPinSet STAGuiInterface::getFaninCone(sta::Pin* pin) const
   return depth_map;
 }
 
-ConeDepthMapPinSet STAGuiInterface::getFanoutCone(sta::Pin* pin) const
+ConeDepthMapPinSet STAGuiInterface::getFanoutCone(const sta::Pin* pin) const
 {
   sta::PinSeq pins_from;
   pins_from.push_back(pin);
 
-  auto* pins = sta_->findFanoutPins(&pins_from,
+  sta::PinSet pins = sta_->findFanoutPins(&pins_from,
                                     true,   // flat
                                     false,  // startpoints_only
                                     0,
@@ -888,8 +888,8 @@ ConeDepthMapPinSet STAGuiInterface::getFanoutCone(sta::Pin* pin) const
   return getCone(pin, pins, false);
 }
 
-ConeDepthMapPinSet STAGuiInterface::getCone(sta::Pin* source_pin,
-                                            sta::PinSet* pins,
+ConeDepthMapPinSet STAGuiInterface::getCone(const sta::Pin* source_pin,
+                                            sta::PinSet pins,
                                             bool is_fanin) const
 {
   initSTA();
@@ -897,16 +897,16 @@ ConeDepthMapPinSet STAGuiInterface::getCone(sta::Pin* source_pin,
   auto* graph = sta_->graph();
 
   auto filter_pins
-      = [network](sta::Pin* pin) { return network->isRegClkPin(pin); };
+      = [network](const sta::Pin* pin) { return network->isRegClkPin(pin); };
 
-  pins->erase(source_pin);
+  pins.erase(source_pin);
 
   int level = 0;
-  std::map<int, std::set<sta::Pin*>> mapped_pins;
+  std::map<int, std::set<const sta::Pin*>> mapped_pins;
   mapped_pins[level].insert(source_pin);
   int pins_size = -1;
-  while (!pins->empty() && pins_size != pins->size()) {
-    pins_size = pins->size();
+  while (!pins.empty() && pins_size != pins.size()) {
+    pins_size = pins.size();
     int next_level = level + 1;
 
     auto& source_pins = mapped_pins[level];
@@ -929,13 +929,13 @@ ConeDepthMapPinSet STAGuiInterface::getCone(sta::Pin* source_pin,
           next_vertex = next_edge->from(graph);
         }
         auto* next_pin = next_vertex->pin();
-        auto pin_find = pins->find(next_pin);
-        if (pin_find != pins->end()) {
+        auto pin_find = pins.find(next_pin);
+        if (pin_find != pins.end()) {
           if (!filter_pins(next_pin)) {
             next_pins.insert(next_pin);
           }
 
-          pins->erase(pin_find);
+          pins.erase(pin_find);
         }
       }
 
@@ -944,7 +944,6 @@ ConeDepthMapPinSet STAGuiInterface::getCone(sta::Pin* source_pin,
 
     level = next_level;
   }
-  delete pins;
 
   ConeDepthMapPinSet depth_map;
 
@@ -959,7 +958,7 @@ ConeDepthMapPinSet STAGuiInterface::getCone(sta::Pin* source_pin,
 }
 
 ConeDepthMap STAGuiInterface::buildConeConnectivity(
-    sta::Pin* stapin,
+    const sta::Pin* stapin,
     ConeDepthMapPinSet& depth_map) const
 {
   auto* network = sta_->getDbNetwork();
@@ -1023,7 +1022,7 @@ ConeDepthMap STAGuiInterface::buildConeConnectivity(
   return map;
 }
 
-void STAGuiInterface::annotateConeTiming(sta::Pin* source_pin,
+void STAGuiInterface::annotateConeTiming(const sta::Pin* source_pin,
                                          ConeDepthMap& map) const
 {
   int min_map_index = std::numeric_limits<int>::max();
@@ -1094,7 +1093,7 @@ std::vector<std::unique_ptr<ClockTree>> STAGuiInterface::getClockTrees() const
   sta_->ensureClkArrivals();
 
   std::vector<std::unique_ptr<ClockTree>> trees;
-  std::map<sta::Clock*, ClockTree*> roots;
+  std::map<const sta::Clock*, ClockTree*> roots;
   for (sta::Clock* clk : *sta_->sdc()->clocks()) {
     ClockTree* root = new ClockTree(clk, getNetwork());
     roots[clk] = root;
@@ -1113,7 +1112,7 @@ std::vector<std::unique_ptr<ClockTree>> STAGuiInterface::getClockTrees() const
 
       sta::PathExpanded expand(path, sta_);
 
-      sta::Clock* clock = path->clock(sta_);
+      const sta::Clock* clock = path->clock(sta_);
       if (clock) {
         roots[clock]->addPath(expand, sta_);
       }

--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -741,7 +741,7 @@ TimingPathList STAGuiInterface::getTimingPaths(
 
   sta::ExceptionFrom* e_from = nullptr;
   if (!from.empty()) {
-    sta::PinSet* pins = new sta::PinSet;
+    sta::PinSet* pins = new sta::PinSet(getNetwork());
     pins->insert(from.begin(), from.end());
     e_from = sta_->makeExceptionFrom(
         pins, nullptr, nullptr, sta::RiseFallBoth::riseFall());
@@ -755,7 +755,7 @@ TimingPathList STAGuiInterface::getTimingPaths(
       if (e_thrus == nullptr) {
         e_thrus = new sta::ExceptionThruSeq;
       }
-      sta::PinSet* pins = new sta::PinSet;
+      sta::PinSet* pins = new sta::PinSet(getNetwork());
       pins->insert(thru_set.begin(), thru_set.end());
       e_thrus->push_back(sta_->makeExceptionThru(
           pins, nullptr, nullptr, sta::RiseFallBoth::riseFall()));
@@ -763,7 +763,7 @@ TimingPathList STAGuiInterface::getTimingPaths(
   }
   sta::ExceptionTo* e_to = nullptr;
   if (!to.empty()) {
-    sta::PinSet* pins = new sta::PinSet;
+    sta::PinSet* pins = new sta::PinSet(getNetwork());
     pins->insert(to.begin(), to.end());
     e_to = sta_->makeExceptionTo(pins,
                                  nullptr,

--- a/src/gui/src/staGuiInterface.h
+++ b/src/gui/src/staGuiInterface.h
@@ -257,7 +257,8 @@ class ClockTree
   const PinDelays& getChildSinkDelays() const { return child_sinks_; }
   const PinDelays& getLeavesDelays() const { return leaves_; }
 
-  std::pair<const sta::Pin*, sta::Delay> getPairedSink(const sta::Pin* paired_pin) const;
+  std::pair<const sta::Pin*, sta::Delay> getPairedSink(
+      const sta::Pin* paired_pin) const;
 
   int getTotalFanout() const;
   int getTotalLeaves() const;
@@ -271,7 +272,8 @@ class ClockTree
 
   void addPath(sta::PathExpanded& path, const sta::StaState* sta);
 
-  std::vector<std::pair<const sta::Pin*, const sta::Pin*>> findPathTo(const sta::Pin* pin) const;
+  std::vector<std::pair<const sta::Pin*, const sta::Pin*>> findPathTo(
+      const sta::Pin* pin) const;
   ClockTree* findTree(odb::dbNet* net, bool include_children = true);
   ClockTree* findTree(sta::Net* net, bool include_children = true);
 

--- a/src/gui/src/staGuiInterface.h
+++ b/src/gui/src/staGuiInterface.h
@@ -59,7 +59,7 @@ class STAGuiInterface;
 
 using TimingPathList = std::vector<std::unique_ptr<TimingPath>>;
 using TimingNodeList = std::vector<std::unique_ptr<TimingPathNode>>;
-using StaPins = std::set<sta::Pin*>;
+using StaPins = std::set<const sta::Pin*>;
 using ConeDepthMapPinSet = std::map<int, StaPins>;
 using ConeDepthMap = std::map<int, TimingNodeList>;
 
@@ -67,7 +67,7 @@ class TimingPathNode
 {
  public:
   TimingPathNode(odb::dbObject* pin,
-                 sta::Pin* stapin,
+                 const sta::Pin* stapin,
                  bool is_clock = false,
                  bool is_rising = false,
                  bool is_sink = false,
@@ -111,7 +111,7 @@ class TimingPathNode
   }
 
   odb::dbObject* getPin() const { return pin_; }
-  sta::Pin* getPinAsSTA() const { return stapin_; }
+  const sta::Pin* getPinAsSTA() const { return stapin_; }
   odb::dbITerm* getPinAsITerm() const;
   odb::dbBTerm* getPinAsBTerm() const;
   const odb::Rect getPinBBox() const;
@@ -148,7 +148,7 @@ class TimingPathNode
 
  private:
   odb::dbObject* pin_;
-  sta::Pin* stapin_;
+  const sta::Pin* stapin_;
   bool is_clock_;
   bool is_rising_;
   bool is_sink_;
@@ -230,7 +230,7 @@ class TimingPath
 class ClockTree
 {
  public:
-  using PinDelays = std::map<sta::Pin*, sta::Delay>;
+  using PinDelays = std::map<const sta::Pin*, sta::Delay>;
 
   ClockTree(ClockTree* parent, sta::Net* net);
   ClockTree(sta::Clock* clock, sta::dbNetwork* network);
@@ -243,8 +243,8 @@ class ClockTree
   int getLevel() const { return level_; }
   bool isRoot() const { return level_ == 0; }
 
-  std::set<sta::Pin*> getDrivers() const;
-  std::set<sta::Pin*> getLeaves() const;
+  std::set<const sta::Pin*> getDrivers() const;
+  std::set<const sta::Pin*> getLeaves() const;
 
   const std::vector<std::unique_ptr<ClockTree>>& getFanout() const
   {
@@ -257,7 +257,7 @@ class ClockTree
   const PinDelays& getChildSinkDelays() const { return child_sinks_; }
   const PinDelays& getLeavesDelays() const { return leaves_; }
 
-  std::pair<sta::Pin*, sta::Delay> getPairedSink(sta::Pin* paired_pin) const;
+  std::pair<const sta::Pin*, sta::Delay> getPairedSink(const sta::Pin* paired_pin) const;
 
   int getTotalFanout() const;
   int getTotalLeaves() const;
@@ -271,7 +271,7 @@ class ClockTree
 
   void addPath(sta::PathExpanded& path, const sta::StaState* sta);
 
-  std::vector<std::pair<sta::Pin*, sta::Pin*>> findPathTo(sta::Pin* pin) const;
+  std::vector<std::pair<const sta::Pin*, const sta::Pin*>> findPathTo(const sta::Pin* pin) const;
   ClockTree* findTree(odb::dbNet* net, bool include_children = true);
   ClockTree* findTree(sta::Net* net, bool include_children = true);
 
@@ -292,11 +292,11 @@ class ClockTree
 
   void addPath(sta::PathExpanded& path, int idx, const sta::StaState* sta);
   ClockTree* getTree(sta::Net* net);
-  bool isLeaf(sta::Pin* pin) const;
+  bool isLeaf(const sta::Pin* pin) const;
   bool addVertex(sta::Vertex* vertex, sta::Delay delay);
-  sta::Net* getNet(sta::Pin* pin) const;
+  sta::Net* getNet(const sta::Pin* pin) const;
 
-  std::map<sta::Pin*, std::set<sta::Pin*>> getPinMapping() const;
+  std::map<const sta::Pin*, std::set<const sta::Pin*>> getPinMapping() const;
 };
 
 class STAGuiInterface
@@ -333,13 +333,13 @@ class STAGuiInterface
   TimingPathList getTimingPaths(const StaPins& from,
                                 const std::vector<StaPins>& thrus,
                                 const StaPins& to) const;
-  TimingPathList getTimingPaths(sta::Pin* thru) const;
+  TimingPathList getTimingPaths(const sta::Pin* thru) const;
 
-  std::unique_ptr<TimingPathNode> getTimingNode(sta::Pin* pin) const;
+  std::unique_ptr<TimingPathNode> getTimingNode(const sta::Pin* pin) const;
 
-  ConeDepthMapPinSet getFaninCone(sta::Pin* pin) const;
-  ConeDepthMapPinSet getFanoutCone(sta::Pin* pin) const;
-  ConeDepthMap buildConeConnectivity(sta::Pin* pin,
+  ConeDepthMapPinSet getFaninCone(const sta::Pin* pin) const;
+  ConeDepthMapPinSet getFanoutCone(const sta::Pin* pin) const;
+  ConeDepthMap buildConeConnectivity(const sta::Pin* pin,
                                      ConeDepthMapPinSet& depth_map) const;
 
   std::vector<std::unique_ptr<ClockTree>> getClockTrees() const;
@@ -357,10 +357,10 @@ class STAGuiInterface
   bool include_unconstrained_;
   bool include_capture_path_;
 
-  ConeDepthMapPinSet getCone(sta::Pin* pin,
-                             sta::PinSet* pin_set,
+  ConeDepthMapPinSet getCone(const sta::Pin* pin,
+                             sta::PinSet pin_set,
                              bool is_fanin) const;
-  void annotateConeTiming(sta::Pin* pin, ConeDepthMap& map) const;
+  void annotateConeTiming(const sta::Pin* pin, ConeDepthMap& map) const;
 
   void initSTA() const;
 };

--- a/src/par/src/TritonPart.cpp
+++ b/src/par/src/TritonPart.cpp
@@ -324,7 +324,7 @@ void TritonPart::BuildTimingPaths()
   //              bool clk_gating_hold);
   // PathEnds represent search endpoints that are either unconstrained or
   // constrained by a timing check, output delay, data check, or path delay.
-  sta::PathEndSeq* path_ends
+  sta::PathEndSeq path_ends
       = sta_->search()->findPathEnds(  // from, thrus, to, unconstrained
           e_from,                      // return paths from a list of
                    // clocks/instances/ports/register clock pins or latch data
@@ -357,7 +357,7 @@ void TritonPart::BuildTimingPaths()
                   sta_->units()->timeUnit()->scale());
 
   // check all the timing paths
-  for (auto& path_end : *path_ends) {
+  for (auto& path_end : path_ends) {
     // Printing timing paths to logger
     // sta_->reportPathEnd(path_end);
     auto* path = path_end->path();
@@ -419,8 +419,6 @@ void TritonPart::BuildTimingPaths()
     timing_attr_.push_back(slack);
   }
 
-  // release memory
-  delete path_ends;
 }
 
 void TritonPart::GenerateTimingReport(std::vector<int>& partition, bool design)

--- a/src/par/src/TritonPart.cpp
+++ b/src/par/src/TritonPart.cpp
@@ -418,7 +418,6 @@ void TritonPart::BuildTimingPaths()
     timing_paths_.push_back(timing_path);
     timing_attr_.push_back(slack);
   }
-
 }
 
 void TritonPart::GenerateTimingReport(std::vector<int>& partition, bool design)

--- a/src/psm/src/get_power.cpp
+++ b/src/psm/src/get_power.cpp
@@ -78,8 +78,7 @@ vector<pair<odb::dbInst*, double>> PowerInst::executePowerPerInst(
     Instance* inst = inst_iter->next();
     LibertyCell* cell = network->libertyCell(inst);
     if (cell) {
-      PowerResult inst_power;
-      sta_->power(inst, corner, inst_power);
+      PowerResult inst_power = sta_->power(inst, corner);
       total_calc.incr(inst_power);
       power_report.push_back({network->staToDb(inst), inst_power.total()});
       debugPrint(logger_,

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -131,7 +131,7 @@ void Restructure::getBlob(unsigned max_depth)
   open_sta_->ensureLevelized();
   open_sta_->searchPreamble();
 
-  sta::PinSet ends;
+  sta::PinSet ends(open_sta_->getDbNetwork());
 
   getEndPoints(ends, is_area_mode_, max_depth);
   if (ends.size()) {

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -136,12 +136,12 @@ void Restructure::getBlob(unsigned max_depth)
   getEndPoints(ends, is_area_mode_, max_depth);
   if (ends.size()) {
     sta::PinSet boundary_points = !is_area_mode_
-                                      ? resizer_->findFanins(&ends)
-                                      : resizer_->findFaninFanouts(&ends);
+                                      ? resizer_->findFanins(ends)
+                                      : resizer_->findFaninFanouts(ends);
     // fanin_fanouts.insert(ends.begin(), ends.end()); // Add seq cells
     logger_->report("Found {} pins in extracted logic.",
                     boundary_points.size());
-    for (sta::Pin* pin : boundary_points) {
+    for (const sta::Pin* pin : boundary_points) {
       odb::dbITerm* term = nullptr;
       odb::dbBTerm* port = nullptr;
       open_sta_->getDbNetwork()->staToDb(pin, term, port);

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -233,7 +233,7 @@ public:
                    double repair_tns_end_percent,
                    int max_passes);
   // For testing.
-  void repairSetup(Pin *drvr_pin);
+  void repairSetup(const Pin *drvr_pin);
   // Rebuffer one net (for testing).
   // resizerPreamble() required.
   void rebufferNet(const Pin *drvr_pin);
@@ -246,7 +246,7 @@ public:
                   // Max buffer count as percent of design instance count.
                   float max_buffer_percent,
                   int max_passes);
-  void repairHold(Pin *end_pin,
+  void repairHold(const Pin *end_pin,
                   double setup_margin,
                   double hold_margin,
                   bool allow_setup_violations,
@@ -329,8 +329,8 @@ public:
 
   ////////////////////////////////////////////////////////////////
   // API for logic resynthesis
-  PinSet findFaninFanouts(PinSet *end_pins);
-  PinSet findFanins(PinSet *end_pins);
+  PinSet findFaninFanouts(PinSet& end_pins);
+  PinSet findFanins(PinSet& end_pins);
 
   ////////////////////////////////////////////////////////////////
   void highlightSteiner(const Pin *drvr);
@@ -346,7 +346,7 @@ protected:
   void ensureLevelDrvrVertices();
   Instance *bufferInput(const Pin *top_pin,
                         LibertyCell *buffer_cell);
-  void bufferOutput(Pin *top_pin,
+  void bufferOutput(const Pin *top_pin,
                     LibertyCell *buffer_cell);
   bool hasTristateOrDontTouchDriver(const Net *net);
   bool isTristateDriver(const Pin *pin);
@@ -454,7 +454,7 @@ protected:
                  PinSeq &loads);
   bool isFuncOneZero(const Pin *drvr_pin);
   bool hasPins(Net *net);
-  Point tieLocation(Pin *load,
+  Point tieLocation(const Pin *load,
                     int separation);
   bool hasFanout(Vertex *drvr);
   InstanceSeq findClkInverters();

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -233,7 +233,7 @@ public:
                    double repair_tns_end_percent,
                    int max_passes);
   // For testing.
-  void repairSetup(const Pin *drvr_pin);
+  void repairSetup(const Pin *end_pin);
   // Rebuffer one net (for testing).
   // resizerPreamble() required.
   void rebufferNet(const Pin *drvr_pin);

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -75,7 +75,7 @@ to_string(BufferedNetType type);
 // load
 BufferedNet::BufferedNet(const BufferedNetType type,
                          const Point location,
-                         Pin *load_pin,
+                         const Pin *load_pin,
                          const Corner *corner,
                          const Resizer *resizer)
 {
@@ -401,7 +401,7 @@ makeBufferedNetFromTree(const SteinerTree *tree,
   // add the pins repeatedly.  The first node wins and the rest are skipped.
   if (pins && pins_visited.find(to_loc) == pins_visited.end()) {
     pins_visited.insert(to_loc);
-    for (Pin *pin : *pins) {
+    for (const Pin *pin : *pins) {
       if (network->isLoad(pin)) {
         BufferedNetPtr bnet1 = make_shared<BufferedNet>(BufferedNetType::load,
                                                         tree->location(to), pin,
@@ -540,7 +540,7 @@ makeBufferedNet(RoutePt &from,
   const PinSeq &pins = loc_pin_map[to_pt];
   Point from_pt(from.x(), from.y());
   BufferedNetPtr bnet = nullptr;
-  for (Pin *pin : pins) {
+  for (const Pin *pin : pins) {
     if (db_network->isLoad(pin)) {
       auto load_bnet = make_shared<BufferedNet>(BufferedNetType::load,
                                                 to_pt, pin, corner, resizer);

--- a/src/rsz/src/BufferedNet.hh
+++ b/src/rsz/src/BufferedNet.hh
@@ -86,7 +86,7 @@ public:
   // load
   BufferedNet(const BufferedNetType type,
               const Point location,
-              Pin *load_pin,
+              const Pin *load_pin,
               const Corner *corner,
               const Resizer *resizer);
   // wire
@@ -126,7 +126,7 @@ public:
   float maxLoadSlew() const { return max_load_slew_; }
   void setMaxLoadSlew(float max_slew);
   // load
-  Pin *loadPin() const { return load_pin_; }
+  const Pin *loadPin() const { return load_pin_; }
   // wire
   int length() const;
   // routing level
@@ -163,7 +163,7 @@ private:
   BufferedNetType type_;
   Point location_;
   // only used by load type
-  Pin *load_pin_;
+  const Pin *load_pin_;
   // only used by buffer type
   LibertyCell *buffer_cell_;
   // only used by wire type

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -345,7 +345,7 @@ Resizer::estimateWireParasitic(const Net *net)
   PinSet *drivers = network_->drivers(net);
   if (drivers && !drivers->empty()) {
     PinSet::Iterator drvr_iter(drivers);
-    Pin *drvr_pin = drvr_iter.next();
+    const Pin *drvr_pin = drvr_iter.next();
     estimateWireParasitic(drvr_pin, net);
   }
 }
@@ -468,7 +468,7 @@ Resizer::parasiticNodeConnectPins(Parasitic *parasitic,
 {
   const PinSeq *pins = tree->pins(pt);
   if (pins) {
-    for (Pin *pin : *pins) {
+    for (const Pin *pin : *pins) {
       ParasiticNode *pin_node = parasitics_->ensureParasiticNode(parasitic, pin);
       // Use a small resistor to keep the connectivity intact.
       parasitics_->makeResistor(nullptr, node, pin_node, 1.0e-3, parasitics_ap);

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -197,7 +197,7 @@ RepairSetup::hasTopLevelOutputPort(Net *net)
 {
   NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     if (network_->isTopLevelPort(pin)
         && network_->direction(pin)->isOutput()) {
       delete pin_iter;
@@ -270,7 +270,7 @@ RepairSetup::rebufferBottomUp(BufferedNetPtr bnet,
     return Z;
   }
   case BufferedNetType::load: {
-    Pin *load_pin = bnet->loadPin();
+    const Pin *load_pin = bnet->loadPin();
     Vertex *vertex = graph_->pinLoadVertex(load_pin);
     PathRef req_path = sta_->vertexWorstSlackPath(vertex, max_);
     const DcalcAnalysisPt *dcalc_ap = req_path.isNull()
@@ -460,7 +460,7 @@ RepairSetup::rebufferTopDown(BufferedNetPtr choice,
       + rebufferTopDown(choice->ref2(), net, level + 1);
   }
   case BufferedNetType::load: {
-    Pin *load_pin = choice->loadPin();
+    const Pin *load_pin = choice->loadPin();
     Net *load_net = network_->net(load_pin);
     if (load_net != net) {
       Instance *load_inst = db_network_->instance(load_pin);
@@ -469,7 +469,7 @@ RepairSetup::rebufferTopDown(BufferedNetPtr choice,
                "", level,
                sdc_network_->pathName(load_pin),
                sdc_network_->pathName(net));
-      sta_->disconnectPin(load_pin);
+      sta_->disconnectPin(const_cast<Pin*>(load_pin));
       sta_->connectPin(load_inst, load_port, net);
       resizer_->parasiticsInvalid(load_net);
     }

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -1128,7 +1128,7 @@ RepairDesign::findLoads(const Pin *drvr_pin)
   PinSeq loads;
   Pin *drvr_pin1 = const_cast<Pin*>(drvr_pin);
   PinSeq drvrs;
-  PinSet visited_drvrs;
+  PinSet visited_drvrs(db_network_);
   sta::FindNetDrvrLoads visitor(drvr_pin1, visited_drvrs, loads, drvrs, network_);
   network_->visitConnectedPins(drvr_pin1, visitor);
   return loads;
@@ -1264,7 +1264,7 @@ RepairDesign::makeRepeater(const char *reason,
     in_net_db->setSigType(out_net_db->getSigType());
 
     // Move non-repeater load pins to in_net.
-    PinSet load_pins1;
+    PinSet load_pins1(db_network_);
     for (const Pin *pin : load_pins)
       load_pins1.insert(pin);
 

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -75,10 +75,10 @@ class LoadRegion
 {
 public:
   LoadRegion();
-  LoadRegion(Vector<Pin*> &pins,
+  LoadRegion(PinSeq& pins,
        Rect &bbox);
 
-  Vector<Pin*> pins_;
+  PinSeq pins_;
   Rect bbox_; // dbu
   vector<LoadRegion> regions_;
 };

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -143,7 +143,7 @@ RepairHold::repairHold(double setup_margin,
 
 // For testing/debug.
 void
-RepairHold::repairHold(Pin *end_pin,
+RepairHold::repairHold(const Pin *end_pin,
                        double setup_margin,
                        double hold_margin,
                        bool allow_setup_violations,
@@ -535,14 +535,14 @@ RepairHold::makeHoldDelay(Vertex *drvr,
   sta_->connectPin(buffer, output, out_net);
   resizer_->parasiticsInvalid(out_net);
 
-  for (Pin *load_pin : load_pins) {
+  for (const Pin *load_pin : load_pins) {
     Net *load_net = network_->isTopLevelPort(load_pin)
       ? network_->net(network_->term(load_pin))
       : network_->net(load_pin);
     if (load_net != out_net) {
       Instance *load = db_network_->instance(load_pin);
       Port *load_port = db_network_->port(load_pin);
-      sta_->disconnectPin(load_pin);
+      sta_->disconnectPin(const_cast<Pin*>(load_pin));
       sta_->connectPin(load, load_port, out_net);
     }
   }

--- a/src/rsz/src/RepairHold.hh
+++ b/src/rsz/src/RepairHold.hh
@@ -74,7 +74,7 @@ public:
                   // Max buffer count as percent of design instance count.
                   float max_buffer_percent,
                   int max_passes);
-  void repairHold(Pin *end_pin,
+  void repairHold(const Pin *end_pin,
                   double setup_margin,
                   double hold_margin,
                   bool allow_setup_violations,

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -244,7 +244,7 @@ RepairSetup::repairSetup(float setup_slack_margin,
 
 // For testing.
 void
-RepairSetup::repairSetup(Pin *end_pin)
+RepairSetup::repairSetup(const Pin *end_pin)
 {
   init();
   inserted_buffer_count_ = 0;
@@ -286,7 +286,7 @@ RepairSetup::repairSetup(PathRef &path,
           && network_->isDriver(path_pin)
           && !network_->isTopLevelPort(path_pin)) {
         TimingArc *prev_arc = expanded.prevArc(i);
-        TimingArc *corner_arc = prev_arc->cornerArc(lib_ap);
+        const TimingArc *corner_arc = prev_arc->cornerArc(lib_ap);
         Edge *prev_edge = path->prevEdge(prev_arc, sta_);
         Delay load_delay = graph_->arcDelay(prev_edge, prev_arc, dcalc_ap->index())
           // Remove intrinsic delay to find load dependent delay.

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -84,7 +84,7 @@ public:
                    double repair_tns_end_percent,
                    int max_passes);
   // For testing.
-  void repairSetup(Pin *drvr_pin);
+  void repairSetup(const Pin *drvr_pin);
   // Rebuffer one net (for testing).
   // resizerPreamble() required.
   void rebufferNet(const Pin *drvr_pin);

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -84,7 +84,7 @@ public:
                    double repair_tns_end_percent,
                    int max_passes);
   // For testing.
-  void repairSetup(const Pin *drvr_pin);
+  void repairSetup(const Pin *end_pin);
   // Rebuffer one net (for testing).
   // resizerPreamble() required.
   void rebufferNet(const Pin *drvr_pin);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2007,6 +2007,7 @@ Resizer::cellWireDelay(LibertyPort *drvr_port,
   ArcDelayCalc *arc_delay_calc = sta->arcDelayCalc();
   Corners *corners = sta->corners();
   corners->copy(sta_->corners());
+  sta->sdc()->makeCornersAfter(corners);
 
   Instance *top_inst = network->topInstance();
   // Tmp net for parasitics to live on.

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1026,7 +1026,7 @@ Resizer::findFaninFanouts(PinSet &end_pins)
     Vertex *end = graph_->pinLoadVertex(pin);
     ends.insert(end);
   }
-  PinSet fanin_fanout_pins;
+  PinSet fanin_fanout_pins(db_network_);
   VertexSet fanin_fanouts = findFaninFanouts(ends);
   for (Vertex *vertex : fanin_fanouts)
     fanin_fanout_pins.insert(vertex->pin());
@@ -1062,7 +1062,7 @@ Resizer::findFanins(PinSet &end_pins)
   for (Vertex *vertex : ends)
     iter.enqueueAdjacentVertices(vertex);
 
-  PinSet fanins;
+  PinSet fanins(db_network_);
   while (iter.hasNext()) {
     Vertex *vertex = iter.next();
     if (isRegOutput(vertex)
@@ -1723,7 +1723,7 @@ Resizer::findFloatingNets()
     Net *net = net_iter->next();
     PinSeq loads;
     PinSeq drvrs;
-    PinSet visited_drvrs;
+    PinSet visited_drvrs(db_network_);
     FindNetDrvrLoads visitor(nullptr, visited_drvrs, loads, drvrs, network_);
     network_->visitConnectedPins(net, visitor);
     if (drvrs.size() == 0 && loads.size() > 0)

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -34,149 +34,151 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "rsz/Resizer.hh"
+
+#include <type_traits>
+
 #include "BufferedNet.hh"
 #include "RepairDesign.hh"
-#include "RepairSetup.hh"
 #include "RepairHold.hh"
-
-#include "utl/Logger.h"
+#include "RepairSetup.hh"
 #include "db_sta/dbNetwork.hh"
-
-#include "sta/FuncExpr.hh"
-#include "sta/PortDirection.hh"
-#include "sta/Units.hh"
-#include "sta/Liberty.hh"
-#include "sta/TimingArc.hh"
-#include "sta/TimingModel.hh"
-#include "sta/Network.hh"
-#include "sta/Graph.hh"
 #include "sta/ArcDelayCalc.hh"
-#include "sta/GraphDelayCalc.hh"
-#include "sta/Parasitics.hh"
-#include "sta/Sdc.hh"
-#include "sta/InputDrive.hh"
-#include "sta/Corner.hh"
 #include "sta/Bfs.hh"
+#include "sta/Corner.hh"
+#include "sta/FuncExpr.hh"
+#include "sta/Fuzzy.hh"
+#include "sta/Graph.hh"
+#include "sta/GraphDelayCalc.hh"
+#include "sta/InputDrive.hh"
+#include "sta/Liberty.hh"
+#include "sta/Network.hh"
+#include "sta/Parasitics.hh"
+#include "sta/PortDirection.hh"
+#include "sta/Sdc.hh"
 #include "sta/Search.hh"
 #include "sta/StaMain.hh"
-#include "sta/Fuzzy.hh"
+#include "sta/TimingArc.hh"
+#include "sta/TimingModel.hh"
+#include "sta/Units.hh"
+#include "utl/Logger.h"
 
 // http://vlsicad.eecs.umich.edu/BK/Slots/cache/dropzone.tamu.edu/~zhuoli/GSRC/fast_buffer_insertion.html
 
 namespace sta {
-extern const char *rsz_tcl_inits[];
+extern const char* rsz_tcl_inits[];
 }
 
 namespace rsz {
 
 using std::abs;
-using std::min;
-using std::max;
-using std::string;
-using std::vector;
 using std::map;
+using std::max;
+using std::min;
 using std::pair;
 using std::sqrt;
+using std::string;
+using std::vector;
 
 using utl::RSZ;
 
+using odb::dbBox;
 using odb::dbInst;
+using odb::dbMaster;
 using odb::dbModule;
+using odb::dbMPin;
+using odb::dbOrientType;
 using odb::dbPlacementStatus;
 using odb::Rect;
-using odb::dbOrientType;
-using odb::dbMPin;
-using odb::dbBox;
-using odb::dbMaster;
 
 using sta::evalTclInit;
-using sta::makeBlockSta;
-using sta::Level;
-using sta::stringLess;
-using sta::NetworkEdit;
-using sta::NetPinIterator;
-using sta::NetConnectedPinIterator;
+using sta::FindNetDrvrLoads;
+using sta::FuncExpr;
 using sta::InstancePinIterator;
 using sta::LeafInstanceIterator;
-using sta::LibertyLibraryIterator;
+using sta::Level;
 using sta::LibertyCellIterator;
+using sta::LibertyLibraryIterator;
+using sta::makeBlockSta;
+using sta::NetConnectedPinIterator;
+using sta::NetIterator;
+using sta::NetPinIterator;
+using sta::NetworkEdit;
+using sta::Port;
+using sta::stringLess;
+using sta::Term;
 using sta::TimingArcSet;
 using sta::TimingArcSetSeq;
 using sta::TimingRole;
-using sta::FuncExpr;
-using sta::Term;
-using sta::Port;
-using sta::NetIterator;
-using sta::FindNetDrvrLoads;;
-using sta::VertexIterator;
-using sta::VertexOutEdgeIterator;
-using sta::Edge;
-using sta::SearchPredNonReg2;
-using sta::ClkArrivalSearchPred;
+;
+using sta::ArcDelayCalc;
 using sta::BfsBkwdIterator;
 using sta::BfsFwdIterator;
 using sta::BfsIndex;
+using sta::ClkArrivalSearchPred;
 using sta::Clock;
-using sta::PathExpanded;
-using sta::INF;
+using sta::Corners;
+using sta::delayInf;
+using sta::Edge;
 using sta::fuzzyEqual;
-using sta::fuzzyLess;
-using sta::fuzzyLessEqual;
 using sta::fuzzyGreater;
 using sta::fuzzyGreaterEqual;
-using sta::delayInf;
+using sta::fuzzyLess;
+using sta::fuzzyLessEqual;
+using sta::INF;
+using sta::InputDrive;
+using sta::PathExpanded;
+using sta::PinConnectedPinIterator;
+using sta::SearchPredNonReg2;
 using sta::stringPrint;
 using sta::Unit;
-using sta::ArcDelayCalc;
-using sta::Corners;
-using sta::InputDrive;
-using sta::PinConnectedPinIterator;
+using sta::VertexIterator;
+using sta::VertexOutEdgeIterator;
 
 extern "C" {
-extern int Rsz_Init(Tcl_Interp *interp);
+extern int Rsz_Init(Tcl_Interp* interp);
 }
 
-Resizer::Resizer() :
-  StaState(),
-  repair_design_(new RepairDesign(this)),
-  repair_setup_(new RepairSetup(this)),
-  repair_hold_(new RepairHold(this)),
-  steiner_renderer_(nullptr),
-  wire_signal_res_(0.0),
-  wire_signal_cap_(0.0),
-  wire_clk_res_(0.0),
-  wire_clk_cap_(0.0),
-  max_area_(0.0),
-  openroad_(nullptr),
-  logger_(nullptr),
-  stt_builder_(nullptr),
-  global_router_(nullptr),
-  incr_groute_(nullptr),
-  gui_(nullptr),
-  sta_(nullptr),
-  db_network_(nullptr),
-  db_(nullptr),
-  block_(nullptr),
-  dbu_(0),
-  debug_pin_(nullptr),
-  core_exists_(false),
-  parasitics_src_(ParasiticsSrc::none),
-  design_area_(0.0),
-  min_(MinMax::min()),
-  max_(MinMax::max()),
-  buffer_lowest_drive_(nullptr),
-  target_load_map_(nullptr),
-  level_drvr_vertices_valid_(false),
-  tgt_slews_{0.0, 0.0},
-  tgt_slew_corner_(nullptr),
-  tgt_slew_dcalc_ap_(nullptr),
-  unique_net_index_(1),
-  unique_inst_index_(1),
-  resize_count_(0),
-  inserted_buffer_count_(0),
-  buffer_moved_into_core_(false),
-  max_wire_length_(0),
-  worst_slack_nets_percent_(10)
+Resizer::Resizer()
+    : StaState(),
+      repair_design_(new RepairDesign(this)),
+      repair_setup_(new RepairSetup(this)),
+      repair_hold_(new RepairHold(this)),
+      steiner_renderer_(nullptr),
+      wire_signal_res_(0.0),
+      wire_signal_cap_(0.0),
+      wire_clk_res_(0.0),
+      wire_clk_cap_(0.0),
+      max_area_(0.0),
+      openroad_(nullptr),
+      logger_(nullptr),
+      stt_builder_(nullptr),
+      global_router_(nullptr),
+      incr_groute_(nullptr),
+      gui_(nullptr),
+      sta_(nullptr),
+      db_network_(nullptr),
+      db_(nullptr),
+      block_(nullptr),
+      dbu_(0),
+      debug_pin_(nullptr),
+      core_exists_(false),
+      parasitics_src_(ParasiticsSrc::none),
+      design_area_(0.0),
+      min_(MinMax::min()),
+      max_(MinMax::max()),
+      buffer_lowest_drive_(nullptr),
+      target_load_map_(nullptr),
+      level_drvr_vertices_valid_(false),
+      tgt_slews_{0.0, 0.0},
+      tgt_slew_corner_(nullptr),
+      tgt_slew_dcalc_ap_(nullptr),
+      unique_net_index_(1),
+      unique_inst_index_(1),
+      resize_count_(0),
+      inserted_buffer_count_(0),
+      buffer_moved_into_core_(false),
+      max_wire_length_(0),
+      worst_slack_nets_percent_(10)
 {
 }
 
@@ -187,15 +189,14 @@ Resizer::~Resizer()
   delete repair_hold_;
 }
 
-void
-Resizer::init(OpenRoad *openroad,
-              Tcl_Interp *interp,
-              Logger *logger,
-              Gui *gui,
-              dbDatabase *db,
-              dbSta *sta,
-              SteinerTreeBuilder *stt_builder,
-              GlobalRouter *global_router)
+void Resizer::init(OpenRoad* openroad,
+                   Tcl_Interp* interp,
+                   Logger* logger,
+                   Gui* gui,
+                   dbDatabase* db,
+                   dbSta* sta,
+                   SteinerTreeBuilder* stt_builder,
+                   GlobalRouter* global_router)
 {
   openroad_ = openroad;
   logger_ = logger;
@@ -216,14 +217,12 @@ Resizer::init(OpenRoad *openroad,
 
 ////////////////////////////////////////////////////////////////
 
-double
-Resizer::coreArea() const
+double Resizer::coreArea() const
 {
   return dbuToMeters(core_.dx()) * dbuToMeters(core_.dy());
 }
 
-double
-Resizer::utilization()
+double Resizer::utilization()
 {
   initBlock();
   initDesignArea();
@@ -234,8 +233,7 @@ Resizer::utilization()
     return 1.0;
 }
 
-double
-Resizer::maxArea() const
+double Resizer::maxArea() const
 {
   return max_area_;
 }
@@ -244,51 +242,43 @@ Resizer::maxArea() const
 
 class VertexLevelLess
 {
-public:
-  VertexLevelLess(const Network *network);
-  bool operator()(const Vertex *vertex1,
-                  const Vertex *vertex2) const;
+ public:
+  VertexLevelLess(const Network* network);
+  bool operator()(const Vertex* vertex1, const Vertex* vertex2) const;
 
-protected:
-  const Network *network_;
+ protected:
+  const Network* network_;
 };
 
-VertexLevelLess::VertexLevelLess(const Network *network) :
-  network_(network)
+VertexLevelLess::VertexLevelLess(const Network* network) : network_(network)
 {
 }
 
-bool
-VertexLevelLess::operator()(const Vertex *vertex1,
-                            const Vertex *vertex2) const
+bool VertexLevelLess::operator()(const Vertex* vertex1,
+                                 const Vertex* vertex2) const
 {
   Level level1 = vertex1->level();
   Level level2 = vertex2->level();
   return (level1 < level2)
-    || (level1 == level2
-        // Break ties for stable results.
-        && stringLess(network_->pathName(vertex1->pin()),
-                      network_->pathName(vertex2->pin())));
+         || (level1 == level2
+             // Break ties for stable results.
+             && stringLess(network_->pathName(vertex1->pin()),
+                           network_->pathName(vertex2->pin())));
 }
-
 
 ////////////////////////////////////////////////////////////////
 
 // block_ indicates core_, design_area_, db_network_ etc valid.
-void
-Resizer::initBlock()
+void Resizer::initBlock()
 {
   block_ = db_->getChip()->getBlock();
   core_ = block_->getCoreArea();
-  core_exists_ = !(core_.xMin() == 0
-                   && core_.xMax() == 0
-                   && core_.yMin() == 0
+  core_exists_ = !(core_.xMin() == 0 && core_.xMax() == 0 && core_.yMin() == 0
                    && core_.yMax() == 0);
   dbu_ = db_->getTech()->getDbUnitsPerMicron();
 }
 
-void
-Resizer::init()
+void Resizer::init()
 {
   initBlock();
   sta_->ensureLevelized();
@@ -296,8 +286,7 @@ Resizer::init()
   initDesignArea();
 }
 
-void
-Resizer::removeBuffers()
+void Resizer::removeBuffers()
 {
   initBlock();
   // Disable incremental timing.
@@ -305,11 +294,10 @@ Resizer::removeBuffers()
   search_->arrivalsInvalid();
 
   int remove_count = 0;
-  for (dbInst *db_inst : block_->getInsts()) {
-    LibertyCell *lib_cell = db_network_->libertyCell(db_inst);
-    Instance *buffer = db_network_->dbToSta(db_inst);
-    if (!db_inst->isDoNotTouch()
-        && lib_cell
+  for (dbInst* db_inst : block_->getInsts()) {
+    LibertyCell* lib_cell = db_network_->libertyCell(db_inst);
+    Instance* buffer = db_network_->dbToSta(db_inst);
+    if (!db_inst->isDoNotTouch() && lib_cell
         && lib_cell->isBuffer()
         // Do not remove buffers connected to input/output ports
         // because verilog netlists use the net name for the port.
@@ -322,38 +310,35 @@ Resizer::removeBuffers()
   logger_->info(RSZ, 26, "Removed {} buffers.", remove_count);
 }
 
-bool
-Resizer::bufferBetweenPorts(Instance *buffer)
+bool Resizer::bufferBetweenPorts(Instance* buffer)
 {
-  LibertyCell *lib_cell = network_->libertyCell(buffer);
+  LibertyCell* lib_cell = network_->libertyCell(buffer);
   LibertyPort *in_port, *out_port;
   lib_cell->bufferPorts(in_port, out_port);
-  Pin *in_pin = db_network_->findPin(buffer, in_port);
-  Pin *out_pin = db_network_->findPin(buffer, out_port);
-  Net *in_net = db_network_->net(in_pin);
-  Net *out_net = db_network_->net(out_pin);
+  const Pin* in_pin = db_network_->findPin(buffer, in_port);
+  const Pin* out_pin = db_network_->findPin(buffer, out_port);
+  Net* in_net = db_network_->net(in_pin);
+  Net* out_net = db_network_->net(out_pin);
   bool in_net_ports = hasPort(in_net);
   bool out_net_ports = hasPort(out_net);
   return in_net_ports && out_net_ports;
 }
 
-void
-Resizer::removeBuffer(Instance *buffer)
+void Resizer::removeBuffer(Instance* buffer)
 {
-  LibertyCell *lib_cell = network_->libertyCell(buffer);
+  LibertyCell* lib_cell = network_->libertyCell(buffer);
   LibertyPort *in_port, *out_port;
   lib_cell->bufferPorts(in_port, out_port);
-  Pin *in_pin = db_network_->findPin(buffer, in_port);
-  Pin *out_pin = db_network_->findPin(buffer, out_port);
-  Net *in_net = db_network_->net(in_pin);
-  Net *out_net = db_network_->net(out_pin);
+  Pin* in_pin = db_network_->findPin(buffer, in_port);
+  Pin* out_pin = db_network_->findPin(buffer, out_port);
+  Net* in_net = db_network_->net(in_pin);
+  Net* out_net = db_network_->net(out_pin);
   bool out_net_ports = hasPort(out_net);
   Net *survivor, *removed;
   if (out_net_ports) {
     survivor = out_net;
     removed = in_net;
-  }
-  else {
+  } else {
     // default or out_net_ports
     // Default to in_net surviving so drivers (cached in dbNetwork)
     // do not change.
@@ -361,21 +346,19 @@ Resizer::removeBuffer(Instance *buffer)
     removed = out_net;
   }
 
-  if (!sdc_->isConstrained(in_pin)
-      && !sdc_->isConstrained(out_pin)
-      && !sdc_->isConstrained(removed)
-      && !sdc_->isConstrained(buffer)) {
+  if (!sdc_->isConstrained(in_pin) && !sdc_->isConstrained(out_pin)
+      && !sdc_->isConstrained(removed) && !sdc_->isConstrained(buffer)) {
     sta_->disconnectPin(in_pin);
     sta_->disconnectPin(out_pin);
     sta_->deleteInstance(buffer);
 
-    NetPinIterator *pin_iter = db_network_->pinIterator(removed);
+    NetPinIterator* pin_iter = db_network_->pinIterator(removed);
     while (pin_iter->hasNext()) {
-      Pin *pin = pin_iter->next();
-      Instance *pin_inst = db_network_->instance(pin);
+      const Pin* pin = pin_iter->next();
+      Instance* pin_inst = db_network_->instance(pin);
       if (pin_inst != buffer) {
-        Port *pin_port = db_network_->port(pin);
-        sta_->disconnectPin(pin);
+        Port* pin_port = db_network_->port(pin);
+        sta_->disconnectPin(const_cast<Pin*>(pin));
         sta_->connectPin(pin_inst, pin_port, survivor);
       }
     }
@@ -386,14 +369,13 @@ Resizer::removeBuffer(Instance *buffer)
   }
 }
 
-void
-Resizer::ensureLevelDrvrVertices()
+void Resizer::ensureLevelDrvrVertices()
 {
   if (!level_drvr_vertices_valid_) {
     level_drvr_vertices_.clear();
     VertexIterator vertex_iter(graph_);
     while (vertex_iter.hasNext()) {
-      Vertex *vertex = vertex_iter.next();
+      Vertex* vertex = vertex_iter.next();
       if (vertex->isDriver(network_))
         level_drvr_vertices_.push_back(vertex);
     }
@@ -404,16 +386,14 @@ Resizer::ensureLevelDrvrVertices()
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::findBuffers()
+void Resizer::findBuffers()
 {
   if (buffer_cells_.empty()) {
-    LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
+    LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
     while (lib_iter->hasNext()) {
-      LibertyLibrary *lib = lib_iter->next();
-      for (LibertyCell *buffer : *lib->buffers()) {
-        if (!dontUse(buffer)
-            && isLinkCell(buffer)) {
+      LibertyLibrary* lib = lib_iter->next();
+      for (LibertyCell* buffer : *lib->buffers()) {
+        if (!dontUse(buffer) && isLinkCell(buffer)) {
           buffer_cells_.push_back(buffer);
         }
       }
@@ -423,26 +403,24 @@ Resizer::findBuffers()
     if (buffer_cells_.empty())
       logger_->error(RSZ, 22, "no buffers found.");
     else {
-      sort(buffer_cells_, [this] (const LibertyCell *buffer1,
-                                  const LibertyCell *buffer2) {
-        return bufferDriveResistance(buffer1)
-          > bufferDriveResistance(buffer2);
-      });
+      sort(buffer_cells_,
+           [this](const LibertyCell* buffer1, const LibertyCell* buffer2) {
+             return bufferDriveResistance(buffer1)
+                    > bufferDriveResistance(buffer2);
+           });
       buffer_lowest_drive_ = buffer_cells_[0];
     }
   }
 }
 
-bool
-Resizer::isLinkCell(LibertyCell *cell)
+bool Resizer::isLinkCell(LibertyCell* cell)
 {
   return network_->findLibertyCell(cell->name()) == cell;
 }
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::bufferInputs()
+void Resizer::bufferInputs()
 {
   init();
   findBuffers();
@@ -451,18 +429,17 @@ Resizer::bufferInputs()
   buffer_moved_into_core_ = false;
 
   incrementalParasiticsBegin();
-  InstancePinIterator *port_iter = network_->pinIterator(network_->topInstance());
+  InstancePinIterator* port_iter
+      = network_->pinIterator(network_->topInstance());
   while (port_iter->hasNext()) {
-    Pin *pin = port_iter->next();
-    Vertex *vertex = graph_->pinDrvrVertex(pin);
-    Net *net = network_->net(network_->term(pin));
-    if (network_->direction(pin)->isInput()
-        && !dontTouch(net)
+    const Pin* pin = port_iter->next();
+    Vertex* vertex = graph_->pinDrvrVertex(pin);
+    Net* net = network_->net(network_->term(pin));
+    if (network_->direction(pin)->isInput() && !dontTouch(net)
         && !vertex->isConstant()
         && !sta_->isClock(pin)
         // Hands off special nets.
-        && !db_network_->isSpecial(net)
-        && hasPins(net))
+        && !db_network_->isSpecial(net) && hasPins(net))
       // repair_design will resize to target slew.
       bufferInput(pin, buffer_lowest_drive_);
   }
@@ -471,33 +448,31 @@ Resizer::bufferInputs()
   incrementalParasiticsEnd();
 
   if (inserted_buffer_count_ > 0) {
-    logger_->info(RSZ, 27, "Inserted {} input buffers.", inserted_buffer_count_);
+    logger_->info(
+        RSZ, 27, "Inserted {} input buffers.", inserted_buffer_count_);
     level_drvr_vertices_valid_ = false;
   }
 }
-   
-bool
-Resizer::hasPins(Net *net)
+
+bool Resizer::hasPins(Net* net)
 {
-  NetPinIterator *pin_iter = db_network_->pinIterator(net);
+  NetPinIterator* pin_iter = db_network_->pinIterator(net);
   bool has_pins = pin_iter->hasNext();
   delete pin_iter;
   return has_pins;
 }
 
-Instance *
-Resizer::bufferInput(const Pin *top_pin,
-                     LibertyCell *buffer_cell)
+Instance* Resizer::bufferInput(const Pin* top_pin, LibertyCell* buffer_cell)
 {
-  Term *term = db_network_->term(top_pin);
-  Net *input_net = db_network_->net(term);
+  Term* term = db_network_->term(top_pin);
+  Net* input_net = db_network_->net(term);
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
 
   bool has_dont_touch = false;
-  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(input_net);
+  NetConnectedPinIterator* pin_iter = network_->connectedPinIterator(input_net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     // Leave input port pin connected to input_net.
     if (pin != top_pin && dontTouch(network_->instance(pin))) {
       has_dont_touch = true;
@@ -516,21 +491,20 @@ Resizer::bufferInput(const Pin *top_pin,
   }
 
   string buffer_name = makeUniqueInstName("input");
-  Instance *parent = db_network_->topInstance();
-  Net *buffer_out = makeUniqueNet();
+  Instance* parent = db_network_->topInstance();
+  Net* buffer_out = makeUniqueNet();
   Point pin_loc = db_network_->location(top_pin);
-  Instance *buffer = makeBuffer(buffer_cell,
-                                buffer_name.c_str(),
-                                parent, pin_loc);
+  Instance* buffer
+      = makeBuffer(buffer_cell, buffer_name.c_str(), parent, pin_loc);
   inserted_buffer_count_++;
 
   pin_iter = network_->connectedPinIterator(input_net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     // Leave input port pin connected to input_net.
     if (pin != top_pin) {
-      sta_->disconnectPin(pin);
-      Port *pin_port = db_network_->port(pin);
+      sta_->disconnectPin(const_cast<Pin*>(pin));
+      Port* pin_port = db_network_->port(pin);
       sta_->connectPin(db_network_->instance(pin), pin_port, buffer_out);
     }
   }
@@ -543,8 +517,7 @@ Resizer::bufferInput(const Pin *top_pin,
   return buffer;
 }
 
-void
-Resizer::bufferOutputs()
+void Resizer::bufferOutputs()
 {
   init();
   findBuffers();
@@ -552,19 +525,19 @@ Resizer::bufferOutputs()
   buffer_moved_into_core_ = false;
 
   incrementalParasiticsBegin();
-  InstancePinIterator *port_iter = network_->pinIterator(network_->topInstance());
+  InstancePinIterator* port_iter
+      = network_->pinIterator(network_->topInstance());
   while (port_iter->hasNext()) {
-    Pin *pin = port_iter->next();
-    Vertex *vertex = graph_->pinLoadVertex(pin);
-    Net *net = network_->net(network_->term(pin));
-    if (network_->direction(pin)->isOutput()
-        && net
+    const Pin* pin = port_iter->next();
+    Vertex* vertex = graph_->pinLoadVertex(pin);
+    Net* net = network_->net(network_->term(pin));
+    if (network_->direction(pin)->isOutput() && net
         && !dontTouch(net)
         // Hands off special nets.
         && !db_network_->isSpecial(net)
-        // DEF does not have tristate output types so we have look at the drivers.
-        && !hasTristateOrDontTouchDriver(net)
-        && !vertex->isConstant()
+        // DEF does not have tristate output types so we have look at the
+        // drivers.
+        && !hasTristateOrDontTouchDriver(net) && !vertex->isConstant()
         && hasPins(net)) {
       bufferOutput(pin, buffer_lowest_drive_);
     }
@@ -574,17 +547,17 @@ Resizer::bufferOutputs()
   incrementalParasiticsEnd();
 
   if (inserted_buffer_count_ > 0) {
-    logger_->info(RSZ, 28, "Inserted {} output buffers.", inserted_buffer_count_);
+    logger_->info(
+        RSZ, 28, "Inserted {} output buffers.", inserted_buffer_count_);
     level_drvr_vertices_valid_ = false;
   }
 }
 
-bool
-Resizer::hasTristateOrDontTouchDriver(const Net *net)
+bool Resizer::hasTristateOrDontTouchDriver(const Net* net)
 {
-  PinSet *drivers = network_->drivers(net);
+  PinSet* drivers = network_->drivers(net);
   if (drivers) {
-    for (Pin *pin : *drivers) {
+    for (const Pin* pin : *drivers) {
       if (isTristateDriver(pin)) {
         return true;
       }
@@ -604,39 +577,36 @@ Resizer::hasTristateOrDontTouchDriver(const Net *net)
   return false;
 }
 
-bool
-Resizer::isTristateDriver(const Pin *pin)
+bool Resizer::isTristateDriver(const Pin* pin)
 {
   // Note LEF macro PINs do not have a clue about tristates.
-  LibertyPort *port = network_->libertyPort(pin);
+  LibertyPort* port = network_->libertyPort(pin);
   return port && port->direction()->isAnyTristate();
 }
 
-void
-Resizer::bufferOutput(Pin *top_pin,
-                      LibertyCell *buffer_cell)
+void Resizer::bufferOutput(const Pin* top_pin, LibertyCell* buffer_cell)
 {
-  NetworkEdit *network = networkEdit();
-  Term *term = network_->term(top_pin);
-  Net *output_net = network_->net(term);
+  NetworkEdit* network = networkEdit();
+  Term* term = network_->term(top_pin);
+  Net* output_net = network_->net(term);
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
   string buffer_name = makeUniqueInstName("output");
-  Instance *parent = network->topInstance();
-  Net *buffer_in = makeUniqueNet();
+  Instance* parent = network->topInstance();
+  Net* buffer_in = makeUniqueNet();
   Point pin_loc = db_network_->location(top_pin);
-  Instance *buffer = makeBuffer(buffer_cell,
-                                buffer_name.c_str(),
-                                parent, pin_loc);
+  Instance* buffer
+      = makeBuffer(buffer_cell, buffer_name.c_str(), parent, pin_loc);
   inserted_buffer_count_++;
 
-  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(output_net);
+  NetConnectedPinIterator* pin_iter
+      = network_->connectedPinIterator(output_net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     if (pin != top_pin) {
       // Leave output port pin connected to output_net.
-      sta_->disconnectPin(pin);
-      Port *pin_port = network->port(pin);
+      sta_->disconnectPin(const_cast<Pin*>(pin));
+      Port* pin_port = network->port(pin);
       sta_->connectPin(network->instance(pin), pin_port, buffer_in);
     }
   }
@@ -650,13 +620,12 @@ Resizer::bufferOutput(Pin *top_pin,
 
 ////////////////////////////////////////////////////////////////
 
-bool
-Resizer::hasPort(const Net *net)
+bool Resizer::hasPort(const Net* net)
 {
   bool has_top_level_port = false;
-  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(net);
+  NetConnectedPinIterator* pin_iter = network_->connectedPinIterator(net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     if (network_->isTopLevelPort(pin)) {
       has_top_level_port = true;
       break;
@@ -666,19 +635,18 @@ Resizer::hasPort(const Net *net)
   return has_top_level_port;
 }
 
-float
-Resizer::driveResistance(const Pin *drvr_pin)
+float Resizer::driveResistance(const Pin* drvr_pin)
 {
   if (network_->isTopLevelPort(drvr_pin)) {
-    InputDrive *drive = sdc_->findInputDrive(network_->port(drvr_pin));
+    InputDrive* drive = sdc_->findInputDrive(network_->port(drvr_pin));
     if (drive) {
       float max_res = 0;
       for (auto min_max : MinMax::range()) {
         for (auto rf : RiseFall::range()) {
-          LibertyCell *cell;
-          LibertyPort *from_port;
-          float *from_slews;
-          LibertyPort *to_port;
+          const LibertyCell* cell;
+          const LibertyPort* from_port;
+          float* from_slews;
+          const LibertyPort* to_port;
           drive->driveCell(rf, min_max, cell, from_port, from_slews, to_port);
           if (to_port)
             max_res = max(max_res, to_port->driveResistance());
@@ -693,17 +661,15 @@ Resizer::driveResistance(const Pin *drvr_pin)
       }
       return max_res;
     }
-  }
-  else {
-    LibertyPort *drvr_port = network_->libertyPort(drvr_pin);
+  } else {
+    LibertyPort* drvr_port = network_->libertyPort(drvr_pin);
     if (drvr_port)
       return drvr_port->driveResistance();
   }
   return 0.0;
 }
 
-float
-Resizer::bufferDriveResistance(const LibertyCell *buffer) const
+float Resizer::bufferDriveResistance(const LibertyCell* buffer) const
 {
   LibertyPort *input, *output;
   buffer->bufferPorts(input, output);
@@ -712,31 +678,26 @@ Resizer::bufferDriveResistance(const LibertyCell *buffer) const
 
 ////////////////////////////////////////////////////////////////
 
-bool
-Resizer::hasFanout(Vertex *drvr)
+bool Resizer::hasFanout(Vertex* drvr)
 {
   VertexOutEdgeIterator edge_iter(drvr, graph_);
   return edge_iter.hasNext();
 }
 
-static float
-targetLoadDist(float load_cap,
-               float target_load)
+static float targetLoadDist(float load_cap, float target_load)
 {
   return abs(load_cap - target_load);
 }
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::resizeDrvrToTargetSlew(const Pin *drvr_pin)
+void Resizer::resizeDrvrToTargetSlew(const Pin* drvr_pin)
 {
   resizePreamble();
   resizeToTargetSlew(drvr_pin);
 }
 
-void
-Resizer::resizePreamble()
+void Resizer::resizePreamble()
 {
   init();
   ensureLevelDrvrVertices();
@@ -746,17 +707,16 @@ Resizer::resizePreamble()
   findTargetLoads();
 }
 
-void
-Resizer::makeEquivCells()
+void Resizer::makeEquivCells()
 {
   LibertyLibrarySeq libs;
-  LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
+  LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
   while (lib_iter->hasNext()) {
-    LibertyLibrary *lib = lib_iter->next();
+    LibertyLibrary* lib = lib_iter->next();
     // massive kludge until makeEquivCells is fixed to only incldue link cells
     LibertyCellIterator cell_iter(lib);
     if (cell_iter.hasNext()) {
-      LibertyCell *cell = cell_iter.next();
+      LibertyCell* cell = cell_iter.next();
       if (isLinkCell(cell))
         libs.push_back(lib);
     }
@@ -765,19 +725,20 @@ Resizer::makeEquivCells()
   sta_->makeEquivCells(&libs, nullptr);
 }
 
-int
-Resizer::resizeToTargetSlew(const Pin *drvr_pin)
+int Resizer::resizeToTargetSlew(const Pin* drvr_pin)
 {
-  Instance *inst = network_->instance(drvr_pin);
-  LibertyCell *cell = network_->libertyCell(inst);
-  if (!network_->isTopLevelPort(drvr_pin)
-      && !dontTouch(inst)
-      && cell
+  Instance* inst = network_->instance(drvr_pin);
+  LibertyCell* cell = network_->libertyCell(inst);
+  if (!network_->isTopLevelPort(drvr_pin) && !dontTouch(inst) && cell
       && isLogicStdCell(inst)) {
     bool revisiting_inst = false;
     if (hasMultipleOutputs(inst)) {
       revisiting_inst = resized_multi_output_insts_.hasKey(inst);
-      debugPrint(logger_, RSZ, "resize", 2, "multiple outputs{}",
+      debugPrint(logger_,
+                 RSZ,
+                 "resize",
+                 2,
+                 "multiple outputs{}",
                  revisiting_inst ? " - revisit" : "");
       resized_multi_output_insts_.insert(inst);
     }
@@ -785,14 +746,18 @@ Resizer::resizeToTargetSlew(const Pin *drvr_pin)
     // Includes net parasitic capacitance.
     float load_cap = graph_delay_calc_->loadCap(drvr_pin, tgt_slew_dcalc_ap_);
     if (load_cap > 0.0) {
-      LibertyCell *target_cell = findTargetCell(cell, load_cap, revisiting_inst);
+      LibertyCell* target_cell
+          = findTargetCell(cell, load_cap, revisiting_inst);
       if (target_cell != cell) {
-        debugPrint(logger_, RSZ, "resize", 2, "{} {} -> {}",
+        debugPrint(logger_,
+                   RSZ,
+                   "resize",
+                   2,
+                   "{} {} -> {}",
                    sdc_network_->pathName(drvr_pin),
                    cell->name(),
                    target_cell->name());
-        if (replaceCell(inst, target_cell, true)
-            && !revisiting_inst)
+        if (replaceCell(inst, target_cell, true) && !revisiting_inst)
           return 1;
       }
     }
@@ -800,59 +765,62 @@ Resizer::resizeToTargetSlew(const Pin *drvr_pin)
   return 0;
 }
 
-bool
-Resizer::isLogicStdCell(const Instance *inst)
+bool Resizer::isLogicStdCell(const Instance* inst)
 {
   return !db_network_->isTopInstance(inst)
-    && db_network_->staToDb(inst)->getMaster()->getType() == odb::dbMasterType::CORE;
+         && db_network_->staToDb(inst)->getMaster()->getType()
+                == odb::dbMasterType::CORE;
 }
 
-LibertyCell *
-Resizer::findTargetCell(LibertyCell *cell,
-                        float load_cap,
-                        bool revisiting_inst)
+LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
+                                     float load_cap,
+                                     bool revisiting_inst)
 {
-  LibertyCell *best_cell = cell;
-  LibertyCellSeq *equiv_cells = sta_->equivCells(cell);
+  LibertyCell* best_cell = cell;
+  LibertyCellSeq* equiv_cells = sta_->equivCells(cell);
   if (equiv_cells) {
     bool is_buf_inv = cell->isBuffer() || cell->isInverter();
     float target_load = (*target_load_map_)[cell];
     float best_load = target_load;
     float best_dist = targetLoadDist(load_cap, target_load);
-    float best_delay = is_buf_inv
-      ? bufferDelay(cell, load_cap, tgt_slew_dcalc_ap_)
-      : 0.0;
-    debugPrint(logger_, RSZ, "resize", 3, "{} load cap {} dist={:.2e} delay={}",
+    float best_delay
+        = is_buf_inv ? bufferDelay(cell, load_cap, tgt_slew_dcalc_ap_) : 0.0;
+    debugPrint(logger_,
+               RSZ,
+               "resize",
+               3,
+               "{} load cap {} dist={:.2e} delay={}",
                cell->name(),
                units_->capacitanceUnit()->asString(load_cap),
                best_dist,
                delayAsString(best_delay, sta_, 3));
-    for (LibertyCell *target_cell : *equiv_cells) {
-      if (!dontUse(target_cell)
-          && isLinkCell(target_cell)) {
+    for (LibertyCell* target_cell : *equiv_cells) {
+      if (!dontUse(target_cell) && isLinkCell(target_cell)) {
         float target_load = (*target_load_map_)[target_cell];
-        float delay = is_buf_inv
-          ? bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_)
-          : 0.0;
+        float delay = is_buf_inv ? bufferDelay(
+                          target_cell, load_cap, tgt_slew_dcalc_ap_)
+                                 : 0.0;
         float dist = targetLoadDist(load_cap, target_load);
-        debugPrint(logger_, RSZ, "resize", 3, " {} dist={:.2e} delay={}",
+        debugPrint(logger_,
+                   RSZ,
+                   "resize",
+                   3,
+                   " {} dist={:.2e} delay={}",
                    target_cell->name(),
                    dist,
                    delayAsString(delay, sta_, 3));
         if (is_buf_inv
-            // Library may have "delay" buffers/inverters that are
-            // functionally buffers/inverters but have additional
-            // intrinsic delay. Accept worse target load matching if
-            // delay is reduced to avoid using them.
-            ? ((delay < best_delay
-                && dist < best_dist * 1.1)
-               || (dist < best_dist
-                   && delay < best_delay * 1.1))
-            : dist < best_dist
-            // If the instance has multiple outputs (generally a register Q/QN)
-            // only allow upsizing after the first pin is visited.
-            && (!revisiting_inst
-                || target_load > best_load)) {
+                // Library may have "delay" buffers/inverters that are
+                // functionally buffers/inverters but have additional
+                // intrinsic delay. Accept worse target load matching if
+                // delay is reduced to avoid using them.
+                ? ((delay < best_delay && dist < best_dist * 1.1)
+                   || (dist < best_dist && delay < best_delay * 1.1))
+                : dist < best_dist
+                      // If the instance has multiple outputs (generally a
+                      // register Q/QN) only allow upsizing after the first pin
+                      // is visited.
+                      && (!revisiting_inst || target_load > best_load)) {
           best_cell = target_cell;
           best_dist = dist;
           best_load = target_load;
@@ -865,30 +833,29 @@ Resizer::findTargetCell(LibertyCell *cell,
 }
 
 // Replace LEF with LEF so ports stay aligned in instance.
-bool
-Resizer::replaceCell(Instance *inst,
-                     LibertyCell *replacement,
-                     bool journal)
+bool Resizer::replaceCell(Instance* inst,
+                          LibertyCell* replacement,
+                          bool journal)
 {
-  const char *replacement_name = replacement->name();
-  dbMaster *replacement_master = db_->findMaster(replacement_name);
+  const char* replacement_name = replacement->name();
+  dbMaster* replacement_master = db_->findMaster(replacement_name);
   if (replacement_master) {
-    dbInst *dinst = db_network_->staToDb(inst);
-    dbMaster *master = dinst->getMaster();
+    dbInst* dinst = db_network_->staToDb(inst);
+    dbMaster* master = dinst->getMaster();
     designAreaIncr(-area(master));
-    Cell *replacement_cell1 = db_network_->dbToSta(replacement_master);
+    Cell* replacement_cell1 = db_network_->dbToSta(replacement_master);
     if (journal)
       journalInstReplaceCellBefore(inst);
     sta_->replaceCell(inst, replacement_cell1);
     designAreaIncr(area(replacement_master));
 
     if (haveEstimatedParasitics()) {
-      InstancePinIterator *pin_iter = network_->pinIterator(inst);
+      InstancePinIterator* pin_iter = network_->pinIterator(inst);
       while (pin_iter->hasNext()) {
-        const Pin *pin = pin_iter->next();
-        const Net *net = network_->net(pin);
+        const Pin* pin = pin_iter->next();
+        const Net* net = network_->net(pin);
         // ODB is clueless about tristates so go to liberty for reality.
-        const LibertyPort *port = network_->libertyPort(pin);
+        const LibertyPort* port = network_->libertyPort(pin);
         // Invalidate estimated parasitics on all instance input pins.
         // Tristate nets have multiple drivers and this is drivers^2 if
         // the parasitics are updated for each resize.
@@ -902,15 +869,13 @@ Resizer::replaceCell(Instance *inst,
   return false;
 }
 
-bool
-Resizer::hasMultipleOutputs(const Instance *inst)
+bool Resizer::hasMultipleOutputs(const Instance* inst)
 {
   int output_count = 0;
-  InstancePinIterator *pin_iter = network_->pinIterator(inst);
+  InstancePinIterator* pin_iter = network_->pinIterator(inst);
   while (pin_iter->hasNext()) {
-    const Pin *pin = pin_iter->next();
-    if (network_->direction(pin)->isAnyOutput()
-        && network_->net(pin)) {
+    const Pin* pin = pin_iter->next();
+    if (network_->direction(pin)->isAnyOutput() && network_->net(pin)) {
       output_count++;
       if (output_count > 1)
         return true;
@@ -923,8 +888,7 @@ Resizer::hasMultipleOutputs(const Instance *inst)
 
 // API for timing driven placement.
 
-void
-Resizer::resizeSlackPreamble()
+void Resizer::resizeSlackPreamble()
 {
   resizePreamble();
   // Save max_wire_length for multiple repairDesign calls.
@@ -933,38 +897,40 @@ Resizer::resizeSlackPreamble()
 
 // Run repair_design to repair long wires and max slew, capacitance and fanout
 // violations. Find the slacks, and then undo all changes to the netlist.
-void
-Resizer::findResizeSlacks()
+void Resizer::findResizeSlacks()
 {
   journalBegin();
   estimateWireParasitics();
   int repaired_net_count, slew_violations, cap_violations;
   int fanout_violations, length_violations;
-  repair_design_->repairDesign(max_wire_length_, 0.0, 0.0,
-                               repaired_net_count, slew_violations, cap_violations,
-                               fanout_violations, length_violations);
+  repair_design_->repairDesign(max_wire_length_,
+                               0.0,
+                               0.0,
+                               repaired_net_count,
+                               slew_violations,
+                               cap_violations,
+                               fanout_violations,
+                               length_violations);
   findResizeSlacks1();
   journalRestore(resize_count_, inserted_buffer_count_);
 }
-  
-void
-Resizer::findResizeSlacks1()
+
+void Resizer::findResizeSlacks1()
 {
   // Use driver pin slacks rather than Sta::netSlack to save visiting
   // the net pins and min'ing the slack.
   net_slack_map_.clear();
   NetSeq nets;
   for (int i = level_drvr_vertices_.size() - 1; i >= 0; i--) {
-    Vertex *drvr = level_drvr_vertices_[i];
-    Pin *drvr_pin = drvr->pin();
-    Net *net = network_->isTopLevelPort(drvr_pin)
-      ? network_->net(network_->term(drvr_pin))
-      : network_->net(drvr_pin);
+    Vertex* drvr = level_drvr_vertices_[i];
+    Pin* drvr_pin = drvr->pin();
+    Net* net = network_->isTopLevelPort(drvr_pin)
+                   ? network_->net(network_->term(drvr_pin))
+                   : network_->net(drvr_pin);
     if (net
         && !drvr->isConstant()
         // Hands off special nets.
-        && !db_network_->isSpecial(net)
-        && !sta_->isClock(drvr_pin)) {
+        && !db_network_->isSpecial(net) && !sta_->isClock(drvr_pin)) {
       net_slack_map_[net] = sta_->vertexSlack(drvr, max_);
       nets.push_back(net);
     }
@@ -973,66 +939,60 @@ Resizer::findResizeSlacks1()
   // Find the nets with the worst slack.
 
   //  sort(nets.begin(), nets.end(). [&](const Net *net1,
-  sort(nets, [this](const Net *net1,
-                 const Net *net2)
-             { return resizeNetSlack(net1) < resizeNetSlack(net2); });
+  sort(nets, [this](const Net* net1, const Net* net2) {
+    return resizeNetSlack(net1) < resizeNetSlack(net2);
+  });
   worst_slack_nets_.clear();
   for (int i = 0; i < nets.size() * worst_slack_nets_percent_ / 100.0; i++)
     worst_slack_nets_.push_back(nets[i]);
 }
 
-NetSeq &
-Resizer::resizeWorstSlackNets()
+NetSeq& Resizer::resizeWorstSlackNets()
 {
   return worst_slack_nets_;
 }
 
-vector<dbNet*>
-Resizer::resizeWorstSlackDbNets()
+vector<dbNet*> Resizer::resizeWorstSlackDbNets()
 {
   vector<dbNet*> nets;
-  for (Net* net : worst_slack_nets_)
+  for (const Net* net : worst_slack_nets_)
     nets.push_back(db_network_->staToDb(net));
   return nets;
 }
 
-Slack
-Resizer::resizeNetSlack(const Net *net)
+Slack Resizer::resizeNetSlack(const Net* net)
 {
   return net_slack_map_[net];
 }
 
-Slack
-Resizer::resizeNetSlack(const dbNet *db_net)
+Slack Resizer::resizeNetSlack(const dbNet* db_net)
 {
-  const Net *net = db_network_->dbToSta(db_net);
+  const Net* net = db_network_->dbToSta(db_net);
   return net_slack_map_[net];
 }
 
 ////////////////////////////////////////////////////////////////
 
 // API for logic resynthesis
-PinSet
-Resizer::findFaninFanouts(PinSet *end_pins)
+PinSet Resizer::findFaninFanouts(PinSet& end_pins)
 {
   // Abbreviated copyState
   sta_->ensureLevelized();
   graph_ = sta_->graph();
 
   VertexSet ends(graph_);
-  for (Pin *pin : *end_pins) {
-    Vertex *end = graph_->pinLoadVertex(pin);
+  for (const Pin* pin : end_pins) {
+    Vertex* end = graph_->pinLoadVertex(pin);
     ends.insert(end);
   }
   PinSet fanin_fanout_pins;
   VertexSet fanin_fanouts = findFaninFanouts(ends);
-  for (Vertex *vertex : fanin_fanouts)
+  for (Vertex* vertex : fanin_fanouts)
     fanin_fanout_pins.insert(vertex->pin());
   return fanin_fanout_pins;
 }
 
-VertexSet
-Resizer::findFaninFanouts(VertexSet &ends)
+VertexSet Resizer::findFaninFanouts(VertexSet& ends)
 {
   // Search backwards from ends to fanin register outputs and input ports.
   VertexSet fanin_roots = findFaninRoots(ends);
@@ -1042,29 +1002,27 @@ Resizer::findFaninFanouts(VertexSet &ends)
 }
 
 // Find source pins for logic fanin of ends.
-PinSet
-Resizer::findFanins(PinSet *end_pins)
+PinSet Resizer::findFanins(PinSet& end_pins)
 {
   // Abbreviated copyState
   sta_->ensureLevelized();
   graph_ = sta_->graph();
 
   VertexSet ends(graph_);
-  for (Pin *pin : *end_pins) {
-    Vertex *end = graph_->pinLoadVertex(pin);
+  for (const Pin* pin : end_pins) {
+    Vertex* end = graph_->pinLoadVertex(pin);
     ends.insert(end);
   }
 
   SearchPredNonReg2 pred(sta_);
   BfsBkwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex *vertex : ends)
+  for (Vertex* vertex : ends)
     iter.enqueueAdjacentVertices(vertex);
 
   PinSet fanins;
   while (iter.hasNext()) {
-    Vertex *vertex = iter.next();
-    if (isRegOutput(vertex)
-        || network_->isTopLevelPort(vertex->pin()))
+    Vertex* vertex = iter.next();
+    if (isRegOutput(vertex) || network_->isTopLevelPort(vertex->pin()))
       continue;
     else {
       iter.enqueueAdjacentVertices(vertex);
@@ -1075,19 +1033,17 @@ Resizer::findFanins(PinSet *end_pins)
 }
 
 // Find roots for logic fanin of ends.
-VertexSet
-Resizer::findFaninRoots(VertexSet &ends)
+VertexSet Resizer::findFaninRoots(VertexSet& ends)
 {
   SearchPredNonReg2 pred(sta_);
   BfsBkwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex *vertex : ends)
+  for (Vertex* vertex : ends)
     iter.enqueueAdjacentVertices(vertex);
 
   VertexSet roots(graph_);
   while (iter.hasNext()) {
-    Vertex *vertex = iter.next();
-    if (isRegOutput(vertex)
-        || network_->isTopLevelPort(vertex->pin()))
+    Vertex* vertex = iter.next();
+    if (isRegOutput(vertex) || network_->isTopLevelPort(vertex->pin()))
       roots.insert(vertex);
     else
       iter.enqueueAdjacentVertices(vertex);
@@ -1095,13 +1051,12 @@ Resizer::findFaninRoots(VertexSet &ends)
   return roots;
 }
 
-bool
-Resizer::isRegOutput(Vertex *vertex)
+bool Resizer::isRegOutput(Vertex* vertex)
 {
-  LibertyPort *port = network_->libertyPort(vertex->pin());
+  LibertyPort* port = network_->libertyPort(vertex->pin());
   if (port) {
-    LibertyCell *cell = port->libertyCell();
-    for (TimingArcSet *arc_set : cell->timingArcSets(nullptr, port)) {
+    LibertyCell* cell = port->libertyCell();
+    for (TimingArcSet* arc_set : cell->timingArcSets(nullptr, port)) {
       if (arc_set->role()->genericRole() == TimingRole::regClkToQ())
         return true;
     }
@@ -1109,17 +1064,16 @@ Resizer::isRegOutput(Vertex *vertex)
   return false;
 }
 
-VertexSet
-Resizer::findFanouts(VertexSet &reg_outs)
+VertexSet Resizer::findFanouts(VertexSet& reg_outs)
 {
   VertexSet fanouts(graph_);
   sta::SearchPredNonLatch2 pred(sta_);
   BfsFwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex *reg_out : reg_outs)
+  for (Vertex* reg_out : reg_outs)
     iter.enqueueAdjacentVertices(reg_out);
 
   while (iter.hasNext()) {
-    Vertex *vertex = iter.next();
+    Vertex* vertex = iter.next();
     if (!isRegister(vertex)) {
       fanouts.insert(vertex);
       iter.enqueueAdjacentVertices(vertex);
@@ -1128,12 +1082,11 @@ Resizer::findFanouts(VertexSet &reg_outs)
   return fanouts;
 }
 
-bool
-Resizer::isRegister(Vertex *vertex)
+bool Resizer::isRegister(Vertex* vertex)
 {
-  LibertyPort *port = network_->libertyPort(vertex->pin());
+  LibertyPort* port = network_->libertyPort(vertex->pin());
   if (port) {
-    LibertyCell *cell = port->libertyCell();
+    LibertyCell* cell = port->libertyCell();
     return cell && cell->hasSequentials();
   }
   return false;
@@ -1141,14 +1094,12 @@ Resizer::isRegister(Vertex *vertex)
 
 ////////////////////////////////////////////////////////////////
 
-double
-Resizer::area(Cell *cell)
+double Resizer::area(Cell* cell)
 {
   return area(db_network_->staToDb(cell));
 }
 
-double
-Resizer::area(dbMaster *master)
+double Resizer::area(dbMaster* master)
 {
   if (!master->isCoreAutoPlaceable()) {
     return 0;
@@ -1156,34 +1107,27 @@ Resizer::area(dbMaster *master)
   return dbuToMeters(master->getWidth()) * dbuToMeters(master->getHeight());
 }
 
-double
-Resizer::dbuToMeters(int dist) const
+double Resizer::dbuToMeters(int dist) const
 {
   return dist / (dbu_ * 1e+6);
 }
 
-int
-Resizer::metersToDbu(double dist) const
+int Resizer::metersToDbu(double dist) const
 {
   return dist * dbu_ * 1e+6;
 }
 
-void
-Resizer::setMaxUtilization(double max_utilization)
+void Resizer::setMaxUtilization(double max_utilization)
 {
   max_area_ = coreArea() * max_utilization;
 }
 
-bool
-Resizer::overMaxArea()
+bool Resizer::overMaxArea()
 {
-  return max_area_
-    && fuzzyGreaterEqual(design_area_, max_area_);
+  return max_area_ && fuzzyGreaterEqual(design_area_, max_area_);
 }
 
-void
-Resizer::setDontUse(LibertyCell *cell,
-                    bool dont_use)
+void Resizer::setDontUse(LibertyCell* cell, bool dont_use)
 {
   if (dont_use)
     dont_use_.insert(cell);
@@ -1191,43 +1135,35 @@ Resizer::setDontUse(LibertyCell *cell,
     dont_use_.erase(cell);
 }
 
-bool
-Resizer::dontUse(LibertyCell *cell)
+bool Resizer::dontUse(LibertyCell* cell)
 {
-  return cell->dontUse()
-    || dont_use_.hasKey(cell);
+  return cell->dontUse() || dont_use_.hasKey(cell);
 }
 
-void
-Resizer::setDontTouch(const Instance *inst,
-                      bool dont_touch)
+void Resizer::setDontTouch(const Instance* inst, bool dont_touch)
 {
-  dbInst *db_inst = db_network_->staToDb(inst);
+  dbInst* db_inst = db_network_->staToDb(inst);
   db_inst->setDoNotTouch(dont_touch);
 }
 
-bool
-Resizer::dontTouch(const Instance *inst)
+bool Resizer::dontTouch(const Instance* inst)
 {
-  dbInst *db_inst = db_network_->staToDb(inst);
+  dbInst* db_inst = db_network_->staToDb(inst);
   if (!db_inst) {
     return false;
   }
   return db_inst->isDoNotTouch();
 }
 
-void
-Resizer::setDontTouch(const Net *net,
-                      bool dont_touch)
+void Resizer::setDontTouch(const Net* net, bool dont_touch)
 {
-  dbNet *db_net = db_network_->staToDb(net);
+  dbNet* db_net = db_network_->staToDb(net);
   db_net->setDoNotTouch(dont_touch);
 }
 
-bool
-Resizer::dontTouch(const Net *net)
+bool Resizer::dontTouch(const Net* net)
 {
-  dbNet *db_net = db_network_->staToDb(net);
+  dbNet* db_net = db_network_->staToDb(net);
   return db_net->isDoNotTouch();
 }
 
@@ -1235,8 +1171,7 @@ Resizer::dontTouch(const Net *net)
 
 // Find a target slew for the libraries and then
 // a target load for each cell that gives the target slew.
-void
-Resizer::findTargetLoads()
+void Resizer::findTargetLoads()
 {
   if (target_load_map_ == nullptr) {
     // Find target slew across all buffers in the libraries.
@@ -1245,14 +1180,14 @@ Resizer::findTargetLoads()
     target_load_map_ = new CellTargetLoadMap;
     // Find target loads at the tgt_slew_corner.
     int lib_ap_index = tgt_slew_corner_->libertyIndex(max_);
-    LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
+    LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
     while (lib_iter->hasNext()) {
-      LibertyLibrary *lib = lib_iter->next();
+      LibertyLibrary* lib = lib_iter->next();
       LibertyCellIterator cell_iter(lib);
       while (cell_iter.hasNext()) {
-        LibertyCell *cell = cell_iter.next();
+        LibertyCell* cell = cell_iter.next();
         if (isLinkCell(cell)) {
-          LibertyCell *corner_cell = cell->cornerCell(lib_ap_index);
+          LibertyCell* corner_cell = cell->cornerCell(lib_ap_index);
           float tgt_load;
           bool exists;
           target_load_map_->findKey(corner_cell, tgt_load, exists);
@@ -1270,8 +1205,7 @@ Resizer::findTargetLoads()
   }
 }
 
-float
-Resizer::targetLoadCap(LibertyCell *cell)
+float Resizer::targetLoadCap(LibertyCell* cell)
 {
   float load_cap = 0.0;
   bool exists;
@@ -1281,23 +1215,24 @@ Resizer::targetLoadCap(LibertyCell *cell)
   return load_cap;
 }
 
-float
-Resizer::findTargetLoad(LibertyCell *cell)
+float Resizer::findTargetLoad(LibertyCell* cell)
 {
   float target_load_sum = 0.0;
   int arc_count = 0;
-  for (TimingArcSet *arc_set : cell->timingArcSets()) {
-    TimingRole *role = arc_set->role();
-    if (!role->isTimingCheck()
-        && role != TimingRole::tristateDisable()
+  for (TimingArcSet* arc_set : cell->timingArcSets()) {
+    TimingRole* role = arc_set->role();
+    if (!role->isTimingCheck() && role != TimingRole::tristateDisable()
         && role != TimingRole::tristateEnable()) {
-      for (TimingArc *arc : arc_set->arcs()) {
+      for (TimingArc* arc : arc_set->arcs()) {
         int in_rf_index = arc->fromEdge()->asRiseFall()->index();
         int out_rf_index = arc->toEdge()->asRiseFall()->index();
-        float arc_target_load = findTargetLoad(cell, arc, 
-                                               tgt_slews_[in_rf_index],
-                                               tgt_slews_[out_rf_index]);
-        debugPrint(logger_, RSZ, "target_load", 3, "{} {} -> {} {} target_load = {:.2e}",
+        float arc_target_load = findTargetLoad(
+            cell, arc, tgt_slews_[in_rf_index], tgt_slews_[out_rf_index]);
+        debugPrint(logger_,
+                   RSZ,
+                   "target_load",
+                   3,
+                   "{} {} -> {} {} target_load = {:.2e}",
                    cell->name(),
                    arc->from()->name(),
                    arc->to()->name(),
@@ -1309,7 +1244,11 @@ Resizer::findTargetLoad(LibertyCell *cell)
     }
   }
   float target_load = arc_count ? target_load_sum / arc_count : 0.0;
-  debugPrint(logger_, RSZ, "target_load", 2, "{} target_load = {:.2e}",
+  debugPrint(logger_,
+             RSZ,
+             "target_load",
+             2,
+             "{} target_load = {:.2e}",
              cell->name(),
              target_load);
   return target_load;
@@ -1317,19 +1256,18 @@ Resizer::findTargetLoad(LibertyCell *cell)
 
 // Find the load capacitance that will cause the output slew
 // to be equal to out_slew.
-float
-Resizer::findTargetLoad(LibertyCell *cell,
-                        TimingArc *arc,
-                        Slew in_slew,
-                        Slew out_slew)
+float Resizer::findTargetLoad(LibertyCell* cell,
+                              TimingArc* arc,
+                              Slew in_slew,
+                              Slew out_slew)
 {
-  GateTimingModel *model = dynamic_cast<GateTimingModel*>(arc->model());
+  GateTimingModel* model = dynamic_cast<GateTimingModel*>(arc->model());
   if (model) {
     // load_cap1 lower bound
     // load_cap2 upper bound
     double load_cap1 = 0.0;
     double load_cap2 = 1.0e-12;  // 1pF
-    double tol = .01; // 1%
+    double tol = .01;            // 1%
     double diff1 = gateSlewDiff(cell, arc, model, in_slew, load_cap1, out_slew);
     if (diff1 > 0.0)
       // Zero load cap out_slew is higher than the target.
@@ -1341,14 +1279,13 @@ Resizer::findTargetLoad(LibertyCell *cell,
         load_cap1 = load_cap2;
         load_cap2 *= 2;
         diff2 = gateSlewDiff(cell, arc, model, in_slew, load_cap2, out_slew);
-      }
-      else {
+      } else {
         double load_cap3 = (load_cap1 + load_cap2) / 2.0;
-        const double diff3 = gateSlewDiff(cell, arc, model, in_slew, load_cap3, out_slew);
+        const double diff3
+            = gateSlewDiff(cell, arc, model, in_slew, load_cap3, out_slew);
         if (diff3 < 0.0) {
           load_cap1 = load_cap3;
-        }
-        else {
+        } else {
           load_cap2 = load_cap3;
           diff2 = diff3;
         }
@@ -1360,51 +1297,50 @@ Resizer::findTargetLoad(LibertyCell *cell,
 }
 
 // objective function
-Slew
-Resizer::gateSlewDiff(LibertyCell *cell,
-                      TimingArc *arc,
-                      GateTimingModel *model,
-                      Slew in_slew,
-                      float load_cap,
-                      Slew out_slew)
+Slew Resizer::gateSlewDiff(LibertyCell* cell,
+                           TimingArc* arc,
+                           GateTimingModel* model,
+                           Slew in_slew,
+                           float load_cap,
+                           Slew out_slew)
 
 {
-  const Pvt *pvt = tgt_slew_dcalc_ap_->operatingConditions();
+  const Pvt* pvt = tgt_slew_dcalc_ap_->operatingConditions();
   ArcDelay arc_delay;
   Slew arc_slew;
-  model->gateDelay(cell, pvt, in_slew, load_cap, 0.0, false,
-                   arc_delay, arc_slew);
+  model->gateDelay(
+      cell, pvt, in_slew, load_cap, 0.0, false, arc_delay, arc_slew);
   return arc_slew - out_slew;
 }
 
 ////////////////////////////////////////////////////////////////
 
-Slew
-Resizer::targetSlew(const RiseFall *rf)
+Slew Resizer::targetSlew(const RiseFall* rf)
 {
   return tgt_slews_[rf->index()];
 }
 
 // Find target slew across all buffers in the libraries.
-void
-Resizer::findBufferTargetSlews()
+void Resizer::findBufferTargetSlews()
 {
   tgt_slews_ = {0.0};
   tgt_slew_corner_ = nullptr;
-  
-  for (Corner *corner : *sta_->corners()) {
+
+  for (Corner* corner : *sta_->corners()) {
     int lib_ap_index = corner->libertyIndex(max_);
-    const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
-    const Pvt *pvt = dcalc_ap->operatingConditions();
+    const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
+    const Pvt* pvt = dcalc_ap->operatingConditions();
     // Average slews across buffers at corner.
     Slew slews[RiseFall::index_count]{0.0};
     int counts[RiseFall::index_count]{0};
-    for (LibertyCell *buffer : buffer_cells_) {
-      LibertyCell *corner_buffer = buffer->cornerCell(lib_ap_index);
+    for (LibertyCell* buffer : buffer_cells_) {
+      LibertyCell* corner_buffer = buffer->cornerCell(lib_ap_index);
       findBufferTargetSlews(corner_buffer, pvt, slews, counts);
     }
-    Slew slew_rise = slews[RiseFall::riseIndex()] / counts[RiseFall::riseIndex()];
-    Slew slew_fall = slews[RiseFall::fallIndex()] / counts[RiseFall::fallIndex()];
+    Slew slew_rise
+        = slews[RiseFall::riseIndex()] / counts[RiseFall::riseIndex()];
+    Slew slew_fall
+        = slews[RiseFall::fallIndex()] / counts[RiseFall::fallIndex()];
     // Use the target slews from the slowest corner,
     // and resize using that corner.
     if (slew_rise > tgt_slews_[RiseFall::riseIndex()]) {
@@ -1415,34 +1351,37 @@ Resizer::findBufferTargetSlews()
     }
   }
 
-  debugPrint(logger_, RSZ, "target_load", 1, "target slew corner {} = {}/{}",
+  debugPrint(logger_,
+             RSZ,
+             "target_load",
+             1,
+             "target slew corner {} = {}/{}",
              tgt_slew_corner_->name(),
              delayAsString(tgt_slews_[RiseFall::riseIndex()], sta_, 3),
              delayAsString(tgt_slews_[RiseFall::fallIndex()], sta_, 3));
 }
 
-void
-Resizer::findBufferTargetSlews(LibertyCell *buffer,
-                               const Pvt *pvt,
-                               // Return values.
-                               Slew slews[],
-                               int counts[])
+void Resizer::findBufferTargetSlews(LibertyCell* buffer,
+                                    const Pvt* pvt,
+                                    // Return values.
+                                    Slew slews[],
+                                    int counts[])
 {
   LibertyPort *input, *output;
   buffer->bufferPorts(input, output);
-  for (TimingArcSet *arc_set : buffer->timingArcSets(input, output)) {
-    for (TimingArc *arc : arc_set->arcs()) {
-      GateTimingModel *model = dynamic_cast<GateTimingModel*>(arc->model());
-      RiseFall *in_rf = arc->fromEdge()->asRiseFall();
-      RiseFall *out_rf = arc->toEdge()->asRiseFall();
+  for (TimingArcSet* arc_set : buffer->timingArcSets(input, output)) {
+    for (TimingArc* arc : arc_set->arcs()) {
+      GateTimingModel* model = dynamic_cast<GateTimingModel*>(arc->model());
+      RiseFall* in_rf = arc->fromEdge()->asRiseFall();
+      RiseFall* out_rf = arc->toEdge()->asRiseFall();
       float in_cap = input->capacitance(in_rf, max_);
       float load_cap = in_cap * tgt_slew_load_cap_factor;
       ArcDelay arc_delay;
       Slew arc_slew;
-      model->gateDelay(buffer, pvt, 0.0, load_cap, 0.0, false,
-                       arc_delay, arc_slew);
-      model->gateDelay(buffer, pvt, arc_slew, load_cap, 0.0, false,
-                       arc_delay, arc_slew);
+      model->gateDelay(
+          buffer, pvt, 0.0, load_cap, 0.0, false, arc_delay, arc_slew);
+      model->gateDelay(
+          buffer, pvt, arc_slew, load_cap, 0.0, false, arc_delay, arc_slew);
       slews[out_rf->index()] += arc_slew;
       counts[out_rf->index()]++;
     }
@@ -1453,37 +1392,36 @@ Resizer::findBufferTargetSlews(LibertyCell *buffer,
 
 // Repair tie hi/low net driver fanout by duplicating the
 // tie hi/low instances for every pin connected to tie hi/low instances.
-void
-Resizer::repairTieFanout(LibertyPort *tie_port,
-                         double separation, // meters
-                         bool verbose)
+void Resizer::repairTieFanout(LibertyPort* tie_port,
+                              double separation,  // meters
+                              bool verbose)
 {
   initBlock();
   initDesignArea();
-  Instance *top_inst = network_->topInstance();
-  LibertyCell *tie_cell = tie_port->libertyCell();
+  Instance* top_inst = network_->topInstance();
+  LibertyCell* tie_cell = tie_port->libertyCell();
   InstanceSeq insts;
   findCellInstances(tie_cell, insts);
   int tie_count = 0;
   int separation_dbu = metersToDbu(separation);
-  for (Instance *inst : insts) {
+  for (const Instance* inst : insts) {
     if (!dontTouch(inst)) {
-      Pin *drvr_pin = network_->findPin(inst, tie_port);
+      Pin* drvr_pin = network_->findPin(inst, tie_port);
       if (drvr_pin) {
-        Net *net = network_->net(drvr_pin);
-        if (net
-            && !dontTouch(net)) {
-          NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(net);
+        Net* net = network_->net(drvr_pin);
+        if (net && !dontTouch(net)) {
+          NetConnectedPinIterator* pin_iter
+              = network_->connectedPinIterator(net);
           while (pin_iter->hasNext()) {
-            Pin *load = pin_iter->next();
+            const Pin* load = pin_iter->next();
             if (load != drvr_pin) {
               // Make tie inst.
               Point tie_loc = tieLocation(load, separation_dbu);
-              Instance *load_inst = network_->instance(load);
-              const char *inst_name = network_->name(load_inst);
+              Instance* load_inst = network_->instance(load);
+              const char* inst_name = network_->name(load_inst);
               string tie_name = makeUniqueInstName(inst_name, true);
-              Instance *tie = makeInstance(tie_cell, tie_name.c_str(),
-                                           top_inst, tie_loc);
+              Instance* tie
+                  = makeInstance(tie_cell, tie_name.c_str(), top_inst, tie_loc);
 
               // Put the tie cell instance in the same module with the load
               // it drives.
@@ -1494,14 +1432,14 @@ Resizer::repairTieFanout(LibertyPort *tie_port,
               }
 
               // Make tie output net.
-              Net *load_net = makeUniqueNet();
+              Net* load_net = makeUniqueNet();
 
               // Connect tie inst output.
               sta_->connectPin(tie, tie_port, load_net);
 
               // Connect load to tie output net.
-              sta_->disconnectPin(load);
-              Port *load_port = network_->port(load);
+              sta_->disconnectPin(const_cast<Pin*>(load));
+              Port* load_port = network_->port(load);
               sta_->connectPin(load_inst, load_port, load_net);
 
               designAreaIncr(area(db_network_->cell(tie_cell)));
@@ -1511,8 +1449,8 @@ Resizer::repairTieFanout(LibertyPort *tie_port,
           delete pin_iter;
 
           // Delete inst output net.
-          Pin *tie_pin = network_->findPin(inst, tie_port);
-          Net *tie_net = network_->net(tie_pin);
+          Pin* tie_pin = network_->findPin(inst, tie_port);
+          Net* tie_net = network_->net(tie_pin);
           sta_->deleteNet(tie_net);
           parasitics_invalid_.erase(tie_net);
           // Delete the tie instance if no other ports are in use.
@@ -1521,7 +1459,7 @@ Resizer::repairTieFanout(LibertyPort *tie_port,
           std::unique_ptr<InstancePinIterator> inst_pin_iter{
               network_->pinIterator(inst)};
           while (inst_pin_iter->hasNext()) {
-            Pin *pin = inst_pin_iter->next();
+            Pin* pin = inst_pin_iter->next();
             if (pin != drvr_pin) {
               Net* net = network_->net(pin);
               if (net && !network_->isPower(net) && !network_->isGround(net)) {
@@ -1531,7 +1469,7 @@ Resizer::repairTieFanout(LibertyPort *tie_port,
             }
           }
           if (!has_other_fanout) {
-            sta_->deleteInstance(inst);
+            sta_->deleteInstance(const_cast<Instance*>(inst));
           }
         }
       }
@@ -1539,21 +1477,19 @@ Resizer::repairTieFanout(LibertyPort *tie_port,
   }
 
   if (tie_count > 0) {
-    logger_->info(RSZ, 42, "Inserted {} tie {} instances.",
-                  tie_count,
-                  tie_cell->name());
+    logger_->info(
+        RSZ, 42, "Inserted {} tie {} instances.", tie_count, tie_cell->name());
     level_drvr_vertices_valid_ = false;
   }
 }
 
-void
-Resizer::findCellInstances(LibertyCell *cell,
-                           // Return value.
-                           InstanceSeq &insts)
+void Resizer::findCellInstances(LibertyCell* cell,
+                                // Return value.
+                                InstanceSeq& insts)
 {
-  LeafInstanceIterator *inst_iter = network_->leafInstanceIterator();
+  LeafInstanceIterator* inst_iter = network_->leafInstanceIterator();
   while (inst_iter->hasNext()) {
-    Instance *inst = inst_iter->next();
+    Instance* inst = inst_iter->next();
     if (network_->libertyCell(inst) == cell)
       insts.push_back(inst);
   }
@@ -1561,9 +1497,7 @@ Resizer::findCellInstances(LibertyCell *cell,
 }
 
 // Place the tie instance on the side of the load pin.
-Point
-Resizer::tieLocation(Pin *load,
-                     int separation)
+Point Resizer::tieLocation(const Pin* load, int separation)
 {
   Point load_loc = db_network_->location(load);
   int load_x = load_loc.getX();
@@ -1571,30 +1505,23 @@ Resizer::tieLocation(Pin *load,
   int tie_x = load_x;
   int tie_y = load_y;
   if (!network_->isTopLevelPort(load)) {
-    dbInst *db_inst = db_network_->staToDb(network_->instance(load));
-    dbBox *bbox = db_inst->getBBox();
+    dbInst* db_inst = db_network_->staToDb(network_->instance(load));
+    dbBox* bbox = db_inst->getBBox();
     int left_dist = abs(load_x - bbox->xMin());
     int right_dist = abs(load_x - bbox->xMax());
     int bot_dist = abs(load_y - bbox->yMin());
     int top_dist = abs(load_y - bbox->yMax());
-    if (left_dist < right_dist
-        && left_dist < bot_dist
-        && left_dist < top_dist)
+    if (left_dist < right_dist && left_dist < bot_dist && left_dist < top_dist)
       // left
       tie_x -= separation;
-    if (right_dist < left_dist
-        && right_dist < bot_dist
+    if (right_dist < left_dist && right_dist < bot_dist
         && right_dist < top_dist)
       // right
       tie_x += separation;
-    if (bot_dist < left_dist
-        && bot_dist < right_dist
-        && bot_dist < top_dist)
+    if (bot_dist < left_dist && bot_dist < right_dist && bot_dist < top_dist)
       // bot
       tie_y -= separation;
-    if (top_dist < left_dist
-        && top_dist < right_dist
-        && top_dist < bot_dist)
+    if (top_dist < left_dist && top_dist < right_dist && top_dist < bot_dist)
       // top
       tie_y += separation;
   }
@@ -1603,9 +1530,7 @@ Resizer::tieLocation(Pin *load,
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::reportLongWires(int count,
-                         int digits)
+void Resizer::reportLongWires(int count, int digits)
 {
   initBlock();
   graph_ = sta_->ensureGraph();
@@ -1613,12 +1538,12 @@ Resizer::reportLongWires(int count,
   VertexSeq drvrs;
   findLongWires(drvrs);
   logger_->report("Driver    length delay");
-  const Corner *corner = sta_->cmdCorner();
+  const Corner* corner = sta_->cmdCorner();
   double wire_res = wireSignalResistance(corner);
   double wire_cap = wireSignalCapacitance(corner);
   int i = 0;
-  for (Vertex *drvr : drvrs) {
-    Pin *drvr_pin = drvr->pin();
+  for (Vertex* drvr : drvrs) {
+    Pin* drvr_pin = drvr->pin();
     double wire_length = dbuToMeters(maxLoadManhattenDistance(drvr));
     double steiner_length = dbuToMeters(findMaxSteinerDist(drvr, corner));
     double delay = (wire_length * wire_res) * (wire_length * wire_cap) * 0.5;
@@ -1635,39 +1560,35 @@ Resizer::reportLongWires(int count,
 
 typedef std::pair<Vertex*, int> DrvrDist;
 
-void
-Resizer::findLongWires(VertexSeq &drvrs)
+void Resizer::findLongWires(VertexSeq& drvrs)
 {
   Vector<DrvrDist> drvr_dists;
   VertexIterator vertex_iter(graph_);
   while (vertex_iter.hasNext()) {
-    Vertex *vertex = vertex_iter.next();
+    Vertex* vertex = vertex_iter.next();
     if (vertex->isDriver(network_)) {
-      Pin *pin = vertex->pin();
+      Pin* pin = vertex->pin();
       // Hands off the clock nets.
-      if (!sta_->isClock(pin)
-          && !vertex->isConstant()
+      if (!sta_->isClock(pin) && !vertex->isConstant()
           && !vertex->isDisabledConstraint())
-        drvr_dists.push_back(DrvrDist(vertex, maxLoadManhattenDistance(vertex)));
+        drvr_dists.push_back(
+            DrvrDist(vertex, maxLoadManhattenDistance(vertex)));
     }
   }
-  sort(drvr_dists, [](const DrvrDist &drvr_dist1,
-                          const DrvrDist &drvr_dist2) {
-                    return drvr_dist1.second > drvr_dist2.second;
-                  });
+  sort(drvr_dists, [](const DrvrDist& drvr_dist1, const DrvrDist& drvr_dist2) {
+    return drvr_dist1.second > drvr_dist2.second;
+  });
   drvrs.reserve(drvr_dists.size());
-  for (DrvrDist &drvr_dist : drvr_dists)
+  for (DrvrDist& drvr_dist : drvr_dists)
     drvrs.push_back(drvr_dist.first);
 }
 
 // Find the maximum distance along steiner tree branches from
 // the driver to loads (in dbu).
-int
-Resizer::findMaxSteinerDist(Vertex *drvr,
-                            const Corner *corner)
+int Resizer::findMaxSteinerDist(Vertex* drvr, const Corner* corner)
 
 {
-  Pin *drvr_pin = drvr->pin();
+  Pin* drvr_pin = drvr->pin();
   BufferedNetPtr bnet = makeBufferedNetSteiner(drvr_pin, corner);
   if (bnet)
     return bnet->maxLoadWireLength();
@@ -1675,15 +1596,14 @@ Resizer::findMaxSteinerDist(Vertex *drvr,
     return 0;
 }
 
-double
-Resizer::maxLoadManhattenDistance(const Net *net)
+double Resizer::maxLoadManhattenDistance(const Net* net)
 {
-  NetPinIterator *pin_iter = network_->pinIterator(net);
+  NetPinIterator* pin_iter = network_->pinIterator(net);
   int max_dist = 0;
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     if (network_->isDriver(pin)) {
-      Vertex *drvr = graph_->pinDrvrVertex(pin);
+      Vertex* drvr = graph_->pinDrvrVertex(pin);
       if (drvr) {
         int dist = maxLoadManhattenDistance(drvr);
         max_dist = max(max_dist, dist);
@@ -1694,15 +1614,14 @@ Resizer::maxLoadManhattenDistance(const Net *net)
   return dbuToMeters(max_dist);
 }
 
-int
-Resizer::maxLoadManhattenDistance(Vertex *drvr)
+int Resizer::maxLoadManhattenDistance(Vertex* drvr)
 {
   int max_dist = 0;
   Point drvr_loc = db_network_->location(drvr->pin());
   VertexOutEdgeIterator edge_iter(drvr, graph_);
   while (edge_iter.hasNext()) {
-    Edge *edge = edge_iter.next();
-    Vertex *load = edge->to(graph_);
+    Edge* edge = edge_iter.next();
+    Vertex* load = edge->to(graph_);
     Point load_loc = db_network_->location(load->pin());
     int dist = Point::manhattanDistance(drvr_loc, load_loc);
     max_dist = max(max_dist, dist);
@@ -1712,13 +1631,12 @@ Resizer::maxLoadManhattenDistance(Vertex *drvr)
 
 ////////////////////////////////////////////////////////////////
 
-NetSeq *
-Resizer::findFloatingNets()
+NetSeq* Resizer::findFloatingNets()
 {
-  NetSeq *floating_nets = new NetSeq;
-  NetIterator *net_iter = network_->netIterator(network_->topInstance());
+  NetSeq* floating_nets = new NetSeq;
+  NetIterator* net_iter = network_->netIterator(network_->topInstance());
   while (net_iter->hasNext()) {
-    Net *net = net_iter->next();
+    Net* net = net_iter->next();
     PinSeq loads;
     PinSeq drvrs;
     PinSet visited_drvrs;
@@ -1734,51 +1652,47 @@ Resizer::findFloatingNets()
 
 ////////////////////////////////////////////////////////////////
 
-string
-Resizer::makeUniqueNetName()
+string Resizer::makeUniqueNetName()
 {
   string node_name;
-  Instance *top_inst = network_->topInstance();
+  Instance* top_inst = network_->topInstance();
   do {
     stringPrint(node_name, "net%d", unique_net_index_++);
   } while (network_->findNet(top_inst, node_name.c_str()));
   return node_name;
 }
 
-Net *
-Resizer::makeUniqueNet()
+Net* Resizer::makeUniqueNet()
 {
   string net_name = makeUniqueNetName();
-  Instance *parent = db_network_->topInstance();
+  Instance* parent = db_network_->topInstance();
   return db_network_->makeNet(net_name.c_str(), parent);
 }
 
-string
-Resizer::makeUniqueInstName(const char *base_name)
+string Resizer::makeUniqueInstName(const char* base_name)
 {
   return makeUniqueInstName(base_name, false);
 }
 
-string
-Resizer::makeUniqueInstName(const char *base_name,
-                            bool underscore)
+string Resizer::makeUniqueInstName(const char* base_name, bool underscore)
 {
   string inst_name;
   do {
-    stringPrint(inst_name, underscore ? "%s_%d" : "%s%d",
-                base_name, unique_inst_index_++);
+    stringPrint(inst_name,
+                underscore ? "%s_%d" : "%s%d",
+                base_name,
+                unique_inst_index_++);
   } while (network_->findInstance(inst_name.c_str()));
   return inst_name;
 }
 
-float
-Resizer::portFanoutLoad(LibertyPort *port) const
+float Resizer::portFanoutLoad(LibertyPort* port) const
 {
   float fanout_load;
   bool exists;
   port->fanoutLoad(fanout_load, exists);
   if (!exists) {
-    LibertyLibrary *lib = port->libertyLibrary();
+    LibertyLibrary* lib = port->libertyLibrary();
     lib->defaultFanoutLoad(fanout_load, exists);
   }
   if (exists)
@@ -1787,11 +1701,10 @@ Resizer::portFanoutLoad(LibertyPort *port) const
     return 0.0;
 }
 
-float
-Resizer::bufferDelay(LibertyCell *buffer_cell,
-                     const RiseFall *rf,
-                     float load_cap,
-                     const DcalcAnalysisPt *dcalc_ap)
+float Resizer::bufferDelay(LibertyCell* buffer_cell,
+                           const RiseFall* rf,
+                           float load_cap,
+                           const DcalcAnalysisPt* dcalc_ap)
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1801,10 +1714,9 @@ Resizer::bufferDelay(LibertyCell *buffer_cell,
   return gate_delays[rf->index()];
 }
 
-float
-Resizer::bufferDelay(LibertyCell *buffer_cell,
-                     float load_cap,
-                     const DcalcAnalysisPt *dcalc_ap)
+float Resizer::bufferDelay(LibertyCell* buffer_cell,
+                           float load_cap,
+                           const DcalcAnalysisPt* dcalc_ap)
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1815,13 +1727,12 @@ Resizer::bufferDelay(LibertyCell *buffer_cell,
              gate_delays[RiseFall::fallIndex()]);
 }
 
-void
-Resizer::bufferDelays(LibertyCell *buffer_cell,
-                      float load_cap,
-                      const DcalcAnalysisPt *dcalc_ap,
-                      // Return values.
-                      ArcDelay delays[RiseFall::index_count],
-                      Slew slews[RiseFall::index_count])
+void Resizer::bufferDelays(LibertyCell* buffer_cell,
+                           float load_cap,
+                           const DcalcAnalysisPt* dcalc_ap,
+                           // Return values.
+                           ArcDelay delays[RiseFall::index_count],
+                           Slew slews[RiseFall::index_count])
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1830,31 +1741,35 @@ Resizer::bufferDelays(LibertyCell *buffer_cell,
 
 // Rise/fall delays across all timing arcs into drvr_port.
 // Uses target slew for input slew.
-void
-Resizer::gateDelays(LibertyPort *drvr_port,
-                    float load_cap,
-                    const DcalcAnalysisPt *dcalc_ap,
-                    // Return values.
-                    ArcDelay delays[RiseFall::index_count],
-                    Slew slews[RiseFall::index_count])
+void Resizer::gateDelays(LibertyPort* drvr_port,
+                         float load_cap,
+                         const DcalcAnalysisPt* dcalc_ap,
+                         // Return values.
+                         ArcDelay delays[RiseFall::index_count],
+                         Slew slews[RiseFall::index_count])
 {
   for (int rf_index : RiseFall::rangeIndex()) {
     delays[rf_index] = -INF;
     slews[rf_index] = -INF;
   }
-  const Pvt *pvt = dcalc_ap->operatingConditions();
-  LibertyCell *cell = drvr_port->libertyCell();
-  for (TimingArcSet *arc_set : cell->timingArcSets()) {
-    if (arc_set->to() == drvr_port
-        && !arc_set->role()->isTimingCheck()) {
-      for (TimingArc *arc : arc_set->arcs()) {
-        RiseFall *in_rf = arc->fromEdge()->asRiseFall();
+  const Pvt* pvt = dcalc_ap->operatingConditions();
+  LibertyCell* cell = drvr_port->libertyCell();
+  for (TimingArcSet* arc_set : cell->timingArcSets()) {
+    if (arc_set->to() == drvr_port && !arc_set->role()->isTimingCheck()) {
+      for (TimingArc* arc : arc_set->arcs()) {
+        RiseFall* in_rf = arc->fromEdge()->asRiseFall();
         int out_rf_index = arc->toEdge()->asRiseFall()->index();
         float in_slew = tgt_slews_[in_rf->index()];
         ArcDelay gate_delay;
         Slew drvr_slew;
-        arc_delay_calc_->gateDelay(cell, arc, in_slew, load_cap,
-                                   nullptr, 0.0, pvt, dcalc_ap,
+        arc_delay_calc_->gateDelay(cell,
+                                   arc,
+                                   in_slew,
+                                   load_cap,
+                                   nullptr,
+                                   0.0,
+                                   pvt,
+                                   dcalc_ap,
                                    gate_delay,
                                    drvr_slew);
         delays[out_rf_index] = max(delays[out_rf_index], gate_delay);
@@ -1864,11 +1779,10 @@ Resizer::gateDelays(LibertyPort *drvr_port,
   }
 }
 
-ArcDelay
-Resizer::gateDelay(LibertyPort *drvr_port,
-                   const RiseFall *rf,
-                   float load_cap,
-                   const DcalcAnalysisPt *dcalc_ap)
+ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
+                            const RiseFall* rf,
+                            float load_cap,
+                            const DcalcAnalysisPt* dcalc_ap)
 {
   ArcDelay delays[RiseFall::index_count];
   Slew slews[RiseFall::index_count];
@@ -1876,10 +1790,9 @@ Resizer::gateDelay(LibertyPort *drvr_port,
   return delays[rf->index()];
 }
 
-ArcDelay
-Resizer::gateDelay(LibertyPort *drvr_port,
-                   float load_cap,
-                   const DcalcAnalysisPt *dcalc_ap)
+ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
+                            float load_cap,
+                            const DcalcAnalysisPt* dcalc_ap)
 {
   ArcDelay delays[RiseFall::index_count];
   Slew slews[RiseFall::index_count];
@@ -1889,8 +1802,7 @@ Resizer::gateDelay(LibertyPort *drvr_port,
 
 ////////////////////////////////////////////////////////////////
 
-double
-Resizer::findMaxWireLength()
+double Resizer::findMaxWireLength()
 {
   init();
   findBuffers();
@@ -1898,13 +1810,12 @@ Resizer::findMaxWireLength()
   return findMaxWireLength1();
 }
 
-double
-Resizer::findMaxWireLength1()
+double Resizer::findMaxWireLength1()
 {
   double max_length = INF;
-  for (const Corner *corner : *sta_->corners()) {
+  for (const Corner* corner : *sta_->corners()) {
     if (wireSignalResistance(corner) > 0.0) {
-      for (LibertyCell *buffer_cell : buffer_cells_) {
+      for (LibertyCell* buffer_cell : buffer_cells_) {
         double buffer_length = findMaxWireLength(buffer_cell, corner);
         max_length = min(max_length, buffer_length);
       }
@@ -1915,9 +1826,8 @@ Resizer::findMaxWireLength1()
 
 // Find the max wire length before it is faster to split the wire
 // in half with a buffer (in meters).
-double
-Resizer::findMaxWireLength(LibertyCell *buffer_cell,
-                           const Corner *corner)
+double Resizer::findMaxWireLength(LibertyCell* buffer_cell,
+                                  const Corner* corner)
 {
   initBlock();
   LibertyPort *load_port, *drvr_port;
@@ -1925,11 +1835,9 @@ Resizer::findMaxWireLength(LibertyCell *buffer_cell,
   return findMaxWireLength(drvr_port, corner);
 }
 
-double
-Resizer::findMaxWireLength(LibertyPort *drvr_port,
-                           const Corner *corner)
+double Resizer::findMaxWireLength(LibertyPort* drvr_port, const Corner* corner)
 {
-  LibertyCell *cell = drvr_port->libertyCell();
+  LibertyCell* cell = drvr_port->libertyCell();
   if (db_network_->staToDb(cell) == nullptr)
     logger_->error(RSZ, 70, "no LEF cell for {}.", cell->name());
   double drvr_r = drvr_port->driveResistance();
@@ -1938,22 +1846,21 @@ Resizer::findMaxWireLength(LibertyPort *drvr_port,
   double wire_length1 = 0.0;
   // Initial guess with wire resistance same as driver resistance.
   double wire_length2 = drvr_r / wireSignalResistance(corner);
-  double tol = .01; // 1%
+  double tol = .01;  // 1%
   double diff1 = splitWireDelayDiff(wire_length2, cell);
   // binary search for diff = 0.
-  while (abs(wire_length1 - wire_length2) > max(wire_length1, wire_length2) * tol) {
+  while (abs(wire_length1 - wire_length2)
+         > max(wire_length1, wire_length2) * tol) {
     if (diff1 < 0.0) {
       wire_length1 = wire_length2;
       wire_length2 *= 2;
       diff1 = splitWireDelayDiff(wire_length2, cell);
-    }
-    else {
+    } else {
       double wire_length3 = (wire_length1 + wire_length2) / 2.0;
       double diff2 = splitWireDelayDiff(wire_length3, cell);
       if (diff2 < 0.0) {
         wire_length1 = wire_length3;
-      }
-      else {
+      } else {
         wire_length2 = wire_length3;
         diff1 = diff2;
       }
@@ -1963,9 +1870,7 @@ Resizer::findMaxWireLength(LibertyPort *drvr_port,
 }
 
 // objective function
-double
-Resizer::splitWireDelayDiff(double wire_length,
-                            LibertyCell *buffer_cell)
+double Resizer::splitWireDelayDiff(double wire_length, LibertyCell* buffer_cell)
 {
   Delay delay1, delay2;
   Slew slew1, slew2;
@@ -1974,12 +1879,11 @@ Resizer::splitWireDelayDiff(double wire_length,
   return delay1 - delay2 * 2;
 }
 
-void
-Resizer::bufferWireDelay(LibertyCell *buffer_cell,
-                         double wire_length, // meters
-                         // Return values.
-                         Delay &delay,
-                         Slew &slew)
+void Resizer::bufferWireDelay(LibertyCell* buffer_cell,
+                              double wire_length,  // meters
+                              // Return values.
+                              Delay& delay,
+                              Slew& slew)
 {
   LibertyPort *load_port, *drvr_port;
   buffer_cell->bufferPorts(load_port, drvr_port);
@@ -1989,57 +1893,61 @@ Resizer::bufferWireDelay(LibertyCell *buffer_cell,
 // Cell delay plus wire delay.
 // Use target slew for input slew.
 // drvr_port and load_port do not have to be the same liberty cell.
-void
-Resizer::cellWireDelay(LibertyPort *drvr_port,
-                       LibertyPort *load_port,
-                       double wire_length, // meters
-                       // Return values.
-                       Delay &delay,
-                       Slew &slew)
+void Resizer::cellWireDelay(LibertyPort* drvr_port,
+                            LibertyPort* load_port,
+                            double wire_length,  // meters
+                            // Return values.
+                            Delay& delay,
+                            Slew& slew)
 {
   // Make a (hierarchical) block to use as a scratchpad.
-  dbBlock *block = dbBlock::create(block_, "wire_delay", '/');
-  dbSta *sta = makeBlockSta(openroad_, block);
-  Parasitics *parasitics = sta->parasitics();
-  Network *network = sta->network();
-  ArcDelayCalc *arc_delay_calc = sta->arcDelayCalc();
-  Corners *corners = sta->corners();
+  dbBlock* block = dbBlock::create(block_, "wire_delay", '/');
+  dbSta* sta = makeBlockSta(openroad_, block);
+  Parasitics* parasitics = sta->parasitics();
+  Network* network = sta->network();
+  ArcDelayCalc* arc_delay_calc = sta->arcDelayCalc();
+  Corners* corners = sta->corners();
   corners->copy(sta_->corners());
 
-  Instance *top_inst = network->topInstance();
+  Instance* top_inst = network->topInstance();
   // Tmp net for parasitics to live on.
-  Net *net = sta->makeNet("wire", top_inst);
-  LibertyCell *drvr_cell = drvr_port->libertyCell();
-  LibertyCell *load_cell = load_port->libertyCell();
-  Instance *drvr = sta->makeInstance("drvr", drvr_cell, top_inst);
-  Instance *load = sta->makeInstance("load", load_cell, top_inst);
+  Net* net = sta->makeNet("wire", top_inst);
+  LibertyCell* drvr_cell = drvr_port->libertyCell();
+  LibertyCell* load_cell = load_port->libertyCell();
+  Instance* drvr = sta->makeInstance("drvr", drvr_cell, top_inst);
+  Instance* load = sta->makeInstance("load", load_cell, top_inst);
   sta->connectPin(drvr, drvr_port, net);
   sta->connectPin(load, load_port, net);
-  Pin *drvr_pin = network->findPin(drvr, drvr_port);
-  Pin *load_pin = network->findPin(load, load_port);
+  Pin* drvr_pin = network->findPin(drvr, drvr_port);
+  Pin* load_pin = network->findPin(load, load_port);
 
   // Max rise/fall delays.
   delay = -INF;
   slew = -INF;
 
-  for (Corner *corner : *corners) {
-    const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
-    const Pvt *pvt = dcalc_ap->operatingConditions();
+  for (Corner* corner : *corners) {
+    const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
+    const Pvt* pvt = dcalc_ap->operatingConditions();
 
     makeWireParasitic(net, drvr_pin, load_pin, wire_length, corner, parasitics);
     // Let delay calc reduce parasitic network as it sees fit.
-    Parasitic *drvr_parasitic = arc_delay_calc->findParasitic(drvr_pin,
-                                                              RiseFall::rise(),
-                                                              dcalc_ap);
-    for (TimingArcSet *arc_set : drvr_cell->timingArcSets()) {
+    Parasitic* drvr_parasitic
+        = arc_delay_calc->findParasitic(drvr_pin, RiseFall::rise(), dcalc_ap);
+    for (TimingArcSet* arc_set : drvr_cell->timingArcSets()) {
       if (arc_set->to() == drvr_port) {
-        for (TimingArc *arc : arc_set->arcs()) {
-          RiseFall *in_rf = arc->fromEdge()->asRiseFall();
+        for (TimingArc* arc : arc_set->arcs()) {
+          RiseFall* in_rf = arc->fromEdge()->asRiseFall();
           double in_slew = tgt_slews_[in_rf->index()];
           ArcDelay gate_delay;
           Slew drvr_slew;
-          arc_delay_calc->gateDelay(drvr_cell, arc, in_slew, 0.0,
-                                    drvr_parasitic, 0.0, pvt, dcalc_ap,
+          arc_delay_calc->gateDelay(drvr_cell,
+                                    arc,
+                                    in_slew,
+                                    0.0,
+                                    drvr_parasitic,
+                                    0.0,
+                                    pvt,
+                                    dcalc_ap,
                                     gate_delay,
                                     drvr_slew);
           ArcDelay wire_delay;
@@ -2062,20 +1970,19 @@ Resizer::cellWireDelay(LibertyPort *drvr_port,
   dbBlock::destroy(block);
 }
 
-void
-Resizer::makeWireParasitic(Net *net,
-                           Pin *drvr_pin,
-                           Pin *load_pin,
-                           double wire_length, // meters
-                           const Corner *corner,
-                           Parasitics *parasitics)
+void Resizer::makeWireParasitic(Net* net,
+                                Pin* drvr_pin,
+                                Pin* load_pin,
+                                double wire_length,  // meters
+                                const Corner* corner,
+                                Parasitics* parasitics)
 {
-  const ParasiticAnalysisPt *parasitics_ap =
-    corner->findParasiticAnalysisPt(max_);
-  Parasitic *parasitic = parasitics->makeParasiticNetwork(net, false,
-                                                          parasitics_ap);
-  ParasiticNode *n1 = parasitics->ensureParasiticNode(parasitic, drvr_pin);
-  ParasiticNode *n2 = parasitics->ensureParasiticNode(parasitic, load_pin);
+  const ParasiticAnalysisPt* parasitics_ap
+      = corner->findParasiticAnalysisPt(max_);
+  Parasitic* parasitic
+      = parasitics->makeParasiticNetwork(net, false, parasitics_ap);
+  ParasiticNode* n1 = parasitics->ensureParasiticNode(parasitic, drvr_pin);
+  ParasiticNode* n2 = parasitics->ensureParasiticNode(parasitic, load_pin);
   double wire_cap = wire_length * wireSignalCapacitance(corner);
   double wire_res = wire_length * wireSignalResistance(corner);
   parasitics->incrCap(n1, wire_cap / 2.0, parasitics_ap);
@@ -2085,25 +1992,22 @@ Resizer::makeWireParasitic(Net *net,
 
 ////////////////////////////////////////////////////////////////
 
-double
-Resizer::designArea()
+double Resizer::designArea()
 {
   initDesignArea();
   return design_area_;
 }
 
-void
-Resizer::designAreaIncr(float delta)
+void Resizer::designAreaIncr(float delta)
 {
   design_area_ += delta;
 }
 
-void
-Resizer::initDesignArea()
+void Resizer::initDesignArea()
 {
   design_area_ = 0.0;
-  for (dbInst *inst : block_->getInsts()) {
-    dbMaster *master = inst->getMaster();
+  for (dbInst* inst : block_->getInsts()) {
+    dbMaster* master = inst->getMaster();
     // Don't count fillers otherwise you'll always get 100% utilization
     if (!master->isFiller()) {
       design_area_ += area(master);
@@ -2111,47 +2015,43 @@ Resizer::initDesignArea()
   }
 }
 
-bool
-Resizer::isFuncOneZero(const Pin *drvr_pin)
+bool Resizer::isFuncOneZero(const Pin* drvr_pin)
 {
-  LibertyPort *port = network_->libertyPort(drvr_pin);
+  LibertyPort* port = network_->libertyPort(drvr_pin);
   if (port) {
-    FuncExpr *func = port->function();
-    return func && (func->op() == FuncExpr::op_zero
-                    || func->op() == FuncExpr::op_one);
+    FuncExpr* func = port->function();
+    return func
+           && (func->op() == FuncExpr::op_zero
+               || func->op() == FuncExpr::op_one);
   }
   return false;
 }
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::repairDesign(double max_wire_length,
-                      double slew_margin,
-                      double cap_margin)
+void Resizer::repairDesign(double max_wire_length,
+                           double slew_margin,
+                           double cap_margin)
 {
   resizePreamble();
   repair_design_->repairDesign(max_wire_length, slew_margin, cap_margin);
 }
 
-int
-Resizer::repairDesignBufferCount() const
+int Resizer::repairDesignBufferCount() const
 {
   return repair_design_->insertedBufferCount();
 }
 
-void
-Resizer::repairNet(Net *net,
-                   double max_wire_length,
-                   double slew_margin,
-                   double cap_margin)
+void Resizer::repairNet(Net* net,
+                        double max_wire_length,
+                        double slew_margin,
+                        double cap_margin)
 {
   resizePreamble();
   repair_design_->repairNet(net, max_wire_length, slew_margin, cap_margin);
 }
 
-void
-Resizer::repairClkNets(double max_wire_length)
+void Resizer::repairClkNets(double max_wire_length)
 {
   resizePreamble();
   repair_design_->repairClkNets(max_wire_length);
@@ -2161,41 +2061,41 @@ Resizer::repairClkNets(double max_wire_length)
 
 // Find inverters in the clock network and clone them next to the
 // each register they drive.
-void
-Resizer::repairClkInverters()
+void Resizer::repairClkInverters()
 {
   initBlock();
   initDesignArea();
   sta_->ensureLevelized();
   graph_ = sta_->graph();
-  for (Instance *inv : findClkInverters()) {
+  for (const Instance* inv : findClkInverters()) {
     if (!dontTouch(inv))
-      cloneClkInverter(inv);
+      cloneClkInverter(const_cast<Instance*>(inv));
   }
 }
 
-InstanceSeq
-Resizer::findClkInverters()
+InstanceSeq Resizer::findClkInverters()
 {
   InstanceSeq clk_inverters;
   ClkArrivalSearchPred srch_pred(this);
   BfsFwdIterator bfs(BfsIndex::other, &srch_pred, this);
-  for (Clock *clk : sdc_->clks()) {
-    for (Pin *pin : clk->leafPins()) {
-      Vertex *vertex = graph_->pinDrvrVertex(pin);
+  for (Clock* clk : sdc_->clks()) {
+    for (const Pin* pin : clk->leafPins()) {
+      Vertex* vertex = graph_->pinDrvrVertex(pin);
       bfs.enqueue(vertex);
     }
   }
   while (bfs.hasNext()) {
-    Vertex *vertex = bfs.next();
-    const Pin *pin = vertex->pin();
-    Instance *inst = network_->instance(pin);
-    LibertyCell *lib_cell = network_->libertyCell(inst);
-    if (vertex->isDriver(network_)
-        && lib_cell
-        && lib_cell->isInverter()) {
+    Vertex* vertex = bfs.next();
+    const Pin* pin = vertex->pin();
+    Instance* inst = network_->instance(pin);
+    LibertyCell* lib_cell = network_->libertyCell(inst);
+    if (vertex->isDriver(network_) && lib_cell && lib_cell->isInverter()) {
       clk_inverters.push_back(inst);
-      debugPrint(logger_, RSZ, "repair_clk_inverters", 2, "inverter {}",
+      debugPrint(logger_,
+                 RSZ,
+                 "repair_clk_inverters",
+                 2,
+                 "inverter {}",
                  network_->pathName(inst));
     }
     if (!vertex->isRegClk())
@@ -2204,43 +2104,42 @@ Resizer::findClkInverters()
   return clk_inverters;
 }
 
-void
-Resizer::cloneClkInverter(Instance *inv)
+void Resizer::cloneClkInverter(Instance* inv)
 {
-  LibertyCell *inv_cell = network_->libertyCell(inv);
+  LibertyCell* inv_cell = network_->libertyCell(inv);
   LibertyPort *in_port, *out_port;
   inv_cell->bufferPorts(in_port, out_port);
-  Pin *in_pin = network_->findPin(inv, in_port);
-  Pin *out_pin = network_->findPin(inv, out_port);
-  Net *in_net = network_->net(in_pin);
-  dbNet *in_net_db = db_network_->staToDb(in_net);
-  Net *out_net = network_->isTopLevelPort(out_pin)
-    ? network_->net(network_->term(out_pin))
-    : network_->net(out_pin);
+  Pin* in_pin = network_->findPin(inv, in_port);
+  Pin* out_pin = network_->findPin(inv, out_port);
+  Net* in_net = network_->net(in_pin);
+  dbNet* in_net_db = db_network_->staToDb(in_net);
+  Net* out_net = network_->isTopLevelPort(out_pin)
+                     ? network_->net(network_->term(out_pin))
+                     : network_->net(out_pin);
   if (out_net) {
-    const char *inv_name = network_->name(inv);
-    Instance *top_inst = network_->topInstance();
-    NetConnectedPinIterator *load_iter = network_->pinIterator(out_net);
+    const char* inv_name = network_->name(inv);
+    Instance* top_inst = network_->topInstance();
+    NetConnectedPinIterator* load_iter = network_->pinIterator(out_net);
     while (load_iter->hasNext()) {
-      Pin *load_pin = load_iter->next();
+      const Pin* load_pin = load_iter->next();
       if (load_pin != out_pin) {
         string clone_name = makeUniqueInstName(inv_name, true);
         Point clone_loc = db_network_->location(load_pin);
-        Instance *clone = makeInstance(inv_cell, clone_name.c_str(),
-                                       top_inst, clone_loc);
+        Instance* clone
+            = makeInstance(inv_cell, clone_name.c_str(), top_inst, clone_loc);
         journalMakeBuffer(clone);
 
-        Net *clone_out_net = makeUniqueNet();
-        dbNet *clone_out_net_db = db_network_->staToDb(clone_out_net);
+        Net* clone_out_net = makeUniqueNet();
+        dbNet* clone_out_net_db = db_network_->staToDb(clone_out_net);
         clone_out_net_db->setSigType(in_net_db->getSigType());
 
-        Instance *load = network_->instance(load_pin);
+        Instance* load = network_->instance(load_pin);
         sta_->connectPin(clone, in_port, in_net);
         sta_->connectPin(clone, out_port, clone_out_net);
 
         // Connect load to clone
-        sta_->disconnectPin(load_pin);
-        Port *load_port = network_->port(load_pin);
+        sta_->disconnectPin(const_cast<Pin*>(load_pin));
+        Port* load_port = network_->port(load_pin);
         sta_->connectPin(load, load_port, clone_out_net);
       }
     }
@@ -2257,24 +2156,21 @@ Resizer::cloneClkInverter(Instance *inv)
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::repairSetup(double setup_margin,
-                     double repair_tns_end_percent,
-                     int max_passes)
+void Resizer::repairSetup(double setup_margin,
+                          double repair_tns_end_percent,
+                          int max_passes)
 {
   resizePreamble();
   repair_setup_->repairSetup(setup_margin, repair_tns_end_percent, max_passes);
 }
 
-void
-Resizer::repairSetup(Pin *end_pin)
+void Resizer::repairSetup(const Pin* end_pin)
 {
   resizePreamble();
   repair_setup_->repairSetup(end_pin);
 }
 
-void
-Resizer::rebufferNet(const Pin *drvr_pin)
+void Resizer::rebufferNet(const Pin* drvr_pin)
 {
   resizePreamble();
   repair_setup_->rebufferNet(drvr_pin);
@@ -2282,36 +2178,39 @@ Resizer::rebufferNet(const Pin *drvr_pin)
 
 ////////////////////////////////////////////////////////////////
 
-void
-Resizer::repairHold(double setup_margin,
-                    double hold_margin,
-                    bool allow_setup_violations,
-                    // Max buffer count as percent of design instance count.
-                    float max_buffer_percent,
-                    int max_passes)
+void Resizer::repairHold(
+    double setup_margin,
+    double hold_margin,
+    bool allow_setup_violations,
+    // Max buffer count as percent of design instance count.
+    float max_buffer_percent,
+    int max_passes)
 {
   resizePreamble();
-  repair_hold_->repairHold(setup_margin, hold_margin,
+  repair_hold_->repairHold(setup_margin,
+                           hold_margin,
                            allow_setup_violations,
-                           max_buffer_percent, max_passes);
+                           max_buffer_percent,
+                           max_passes);
 }
 
-void
-Resizer::repairHold(Pin *end_pin,
-                    double setup_margin,
-                    double hold_margin,
-                    bool allow_setup_violations,
-                    float max_buffer_percent,
-                    int max_passes)
+void Resizer::repairHold(const Pin* end_pin,
+                         double setup_margin,
+                         double hold_margin,
+                         bool allow_setup_violations,
+                         float max_buffer_percent,
+                         int max_passes)
 {
   resizePreamble();
-  repair_hold_->repairHold(end_pin, setup_margin, hold_margin,
+  repair_hold_->repairHold(end_pin,
+                           setup_margin,
+                           hold_margin,
                            allow_setup_violations,
-                           max_buffer_percent, max_passes);
+                           max_buffer_percent,
+                           max_passes);
 }
 
-int
-Resizer::holdBufferCount() const
+int Resizer::holdBufferCount() const
 {
   return repair_hold_->holdBufferCount();
 }
@@ -2319,27 +2218,28 @@ Resizer::holdBufferCount() const
 ////////////////////////////////////////////////////////////////
 
 // Journal to roll back changes (OpenDB not up to the task).
-void
-Resizer::journalBegin()
+void Resizer::journalBegin()
 {
   debugPrint(logger_, RSZ, "journal", 1, "journal begin");
   resized_inst_map_.clear();
   inserted_buffers_.clear();
 }
 
-void
-Resizer::journalEnd()
+void Resizer::journalEnd()
 {
   debugPrint(logger_, RSZ, "journal", 1, "journal end");
   resized_inst_map_.clear();
   inserted_buffers_.clear();
 }
 
-void
-Resizer::journalInstReplaceCellBefore(Instance *inst)
+void Resizer::journalInstReplaceCellBefore(Instance* inst)
 {
-  LibertyCell *lib_cell = network_->libertyCell(inst);
-  debugPrint(logger_, RSZ, "journal", 1, "journal replace {} ({})",
+  LibertyCell* lib_cell = network_->libertyCell(inst);
+  debugPrint(logger_,
+             RSZ,
+             "journal",
+             1,
+             "journal replace {} ({})",
              network_->pathName(inst),
              lib_cell->name());
   // Do not clobber an existing checkpoint cell.
@@ -2347,22 +2247,27 @@ Resizer::journalInstReplaceCellBefore(Instance *inst)
     resized_inst_map_[inst] = lib_cell;
 }
 
-void
-Resizer::journalMakeBuffer(Instance *buffer)
+void Resizer::journalMakeBuffer(Instance* buffer)
 {
-  debugPrint(logger_, RSZ, "journal", 1, "journal make_buffer {}",
+  debugPrint(logger_,
+             RSZ,
+             "journal",
+             1,
+             "journal make_buffer {}",
              network_->pathName(buffer));
   inserted_buffers_.push_back(buffer);
   inserted_buffer_set_.insert(buffer);
 }
 
-void
-Resizer::journalRestore(int &resize_count,
-                        int &inserted_buffer_count)
+void Resizer::journalRestore(int& resize_count, int& inserted_buffer_count)
 {
   for (auto [inst, lib_cell] : resized_inst_map_) {
     if (!inserted_buffer_set_.hasKey(inst)) {
-      debugPrint(logger_, RSZ, "journal", 1, "journal restore {} ({})",
+      debugPrint(logger_,
+                 RSZ,
+                 "journal",
+                 1,
+                 "journal restore {} ({})",
                  network_->pathName(inst),
                  lib_cell->name());
       replaceCell(inst, lib_cell, false);
@@ -2370,10 +2275,14 @@ Resizer::journalRestore(int &resize_count,
     }
   }
   while (!inserted_buffers_.empty()) {
-  Instance *buffer = inserted_buffers_.back();
-    debugPrint(logger_, RSZ, "journal", 1, "journal remove {}",
+    const Instance* buffer = inserted_buffers_.back();
+    debugPrint(logger_,
+               RSZ,
+               "journal",
+               1,
+               "journal remove {}",
                network_->pathName(buffer));
-    removeBuffer(buffer);
+    removeBuffer(const_cast<Instance*>(buffer));
     inserted_buffers_.pop_back();
     inserted_buffer_count--;
   }
@@ -2382,47 +2291,42 @@ Resizer::journalRestore(int &resize_count,
 
 ////////////////////////////////////////////////////////////////
 
-Instance *
-Resizer::makeBuffer(LibertyCell *cell,
-                    const char *name,
-                    Instance *parent,
-                    Point loc)
+Instance* Resizer::makeBuffer(LibertyCell* cell,
+                              const char* name,
+                              Instance* parent,
+                              Point loc)
 {
-  Instance *inst = makeInstance(cell, name, parent, loc);
+  Instance* inst = makeInstance(cell, name, parent, loc);
   journalMakeBuffer(inst);
   return inst;
 }
 
-Instance *
-Resizer::makeInstance(LibertyCell *cell,
-                      const char *name,
-                      Instance *parent,
-                      Point loc)
+Instance* Resizer::makeInstance(LibertyCell* cell,
+                                const char* name,
+                                Instance* parent,
+                                Point loc)
 {
   debugPrint(logger_, RSZ, "make_instance", 1, "make instance {}", name);
-  Instance *inst = db_network_->makeInstance(cell, name, parent);
-  dbInst *db_inst = db_network_->staToDb(inst);
+  Instance* inst = db_network_->makeInstance(cell, name, parent);
+  dbInst* db_inst = db_network_->staToDb(inst);
   db_inst->setSourceType(odb::dbSourceType::TIMING);
   setLocation(db_inst, loc);
   designAreaIncr(area(db_inst->getMaster()));
   return inst;
 }
 
-void
-Resizer::setLocation(dbInst *db_inst,
-                     Point pt)
+void Resizer::setLocation(dbInst* db_inst, Point pt)
 {
   int x = pt.x();
   int y = pt.y();
   // Stay inside the lines.
   if (core_exists_) {
-    dbMaster *master = db_inst->getMaster();
+    dbMaster* master = db_inst->getMaster();
     int width = master->getWidth();
     if (x < core_.xMin()) {
       x = core_.xMin();
       buffer_moved_into_core_ = true;
-    }
-    else if (x > core_.xMax() - width) {
+    } else if (x > core_.xMax() - width) {
       // Make sure the instance is entirely inside core.
       x = core_.xMax() - width;
       buffer_moved_into_core_ = true;
@@ -2432,8 +2336,7 @@ Resizer::setLocation(dbInst *db_inst,
     if (y < core_.yMin()) {
       y = core_.yMin();
       buffer_moved_into_core_ = true;
-    }
-    else if (y > core_.yMax() - height) {
+    } else if (y > core_.yMax() - height) {
       y = core_.yMax() - height;
       buffer_moved_into_core_ = true;
     }
@@ -2443,19 +2346,16 @@ Resizer::setLocation(dbInst *db_inst,
   db_inst->setLocation(x, y);
 }
 
-float
-Resizer::portCapacitance(LibertyPort *input,
-                         const Corner *corner) const
+float Resizer::portCapacitance(LibertyPort* input, const Corner* corner) const
 {
-  const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
+  const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
   int lib_ap = dcalc_ap->libertyIndex();
-  LibertyPort *corner_input = input->cornerPort(lib_ap);
+  LibertyPort* corner_input = input->cornerPort(lib_ap);
   return corner_input->capacitance();
 }
 
-float
-Resizer::maxInputSlew(const LibertyPort *input,
-                      const Corner *corner) const
+float Resizer::maxInputSlew(const LibertyPort* input,
+                            const Corner* corner) const
 {
   float limit;
   bool exists;
@@ -2466,27 +2366,26 @@ Resizer::maxInputSlew(const LibertyPort *input,
   return limit;
 }
 
-void
-Resizer::checkLoadSlews(const Pin *drvr_pin,
-                        double slew_margin,
-                        // Return values.
-                        Slew &slew,
-                        float &limit,
-                        float &slack,
-                        const Corner *&corner)
+void Resizer::checkLoadSlews(const Pin* drvr_pin,
+                             double slew_margin,
+                             // Return values.
+                             Slew& slew,
+                             float& limit,
+                             float& slack,
+                             const Corner*& corner)
 {
   slack = INF;
   limit = INF;
-  PinConnectedPinIterator *pin_iter = network_->connectedPinIterator(drvr_pin);
+  PinConnectedPinIterator* pin_iter = network_->connectedPinIterator(drvr_pin);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin* pin = pin_iter->next();
     if (pin != drvr_pin) {
-      const Corner *corner1;
-      const RiseFall *tr1;
+      const Corner* corner1;
+      const RiseFall* tr1;
       Slew slew1;
       float limit1, slack1;
-      sta_->checkSlew(pin, nullptr, max_, false,
-                      corner1, tr1, slew1, limit1, slack1);
+      sta_->checkSlew(
+          pin, nullptr, max_, false, corner1, tr1, slew1, limit1, slack1);
       if (corner1) {
         limit1 *= (1.0 - slew_margin / 100.0);
         limit = min(limit, limit1);
@@ -2502,23 +2401,20 @@ Resizer::checkLoadSlews(const Pin *drvr_pin,
   delete pin_iter;
 }
 
-void
-Resizer::warnBufferMovedIntoCore()
+void Resizer::warnBufferMovedIntoCore()
 {
   if (buffer_moved_into_core_)
     logger_->warn(RSZ, 77, "some buffers were moved inside the core.");
 }
 
-void
-Resizer::setDebugPin(const Pin *pin)
+void Resizer::setDebugPin(const Pin* pin)
 {
   debug_pin_ = pin;
 }
 
-void
-Resizer::setWorstSlackNetsPercent(float percent)
+void Resizer::setWorstSlackNetsPercent(float percent)
 {
   worst_slack_nets_percent_ = percent;
 }
 
-} // namespace
+}  // namespace rsz

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -207,6 +207,8 @@ Resizer::init(OpenRoad *openroad,
   global_router_ = global_router;
   incr_groute_ = nullptr;
   db_network_ = sta->getDbNetwork();
+  resized_multi_output_insts_ = InstanceSet(db_network_);
+  inserted_buffer_set_ = InstanceSet(db_network_);
   copyState(sta);
   // Define swig TCL commands.
   Rsz_Init(interp);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -34,151 +34,149 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "rsz/Resizer.hh"
-
-#include <type_traits>
-
 #include "BufferedNet.hh"
 #include "RepairDesign.hh"
-#include "RepairHold.hh"
 #include "RepairSetup.hh"
+#include "RepairHold.hh"
+
+#include "utl/Logger.h"
 #include "db_sta/dbNetwork.hh"
-#include "sta/ArcDelayCalc.hh"
-#include "sta/Bfs.hh"
-#include "sta/Corner.hh"
+
 #include "sta/FuncExpr.hh"
-#include "sta/Fuzzy.hh"
-#include "sta/Graph.hh"
-#include "sta/GraphDelayCalc.hh"
-#include "sta/InputDrive.hh"
-#include "sta/Liberty.hh"
-#include "sta/Network.hh"
-#include "sta/Parasitics.hh"
 #include "sta/PortDirection.hh"
-#include "sta/Sdc.hh"
-#include "sta/Search.hh"
-#include "sta/StaMain.hh"
+#include "sta/Units.hh"
+#include "sta/Liberty.hh"
 #include "sta/TimingArc.hh"
 #include "sta/TimingModel.hh"
-#include "sta/Units.hh"
-#include "utl/Logger.h"
+#include "sta/Network.hh"
+#include "sta/Graph.hh"
+#include "sta/ArcDelayCalc.hh"
+#include "sta/GraphDelayCalc.hh"
+#include "sta/Parasitics.hh"
+#include "sta/Sdc.hh"
+#include "sta/InputDrive.hh"
+#include "sta/Corner.hh"
+#include "sta/Bfs.hh"
+#include "sta/Search.hh"
+#include "sta/StaMain.hh"
+#include "sta/Fuzzy.hh"
 
 // http://vlsicad.eecs.umich.edu/BK/Slots/cache/dropzone.tamu.edu/~zhuoli/GSRC/fast_buffer_insertion.html
 
 namespace sta {
-extern const char* rsz_tcl_inits[];
+extern const char *rsz_tcl_inits[];
 }
 
 namespace rsz {
 
 using std::abs;
-using std::map;
-using std::max;
 using std::min;
-using std::pair;
-using std::sqrt;
+using std::max;
 using std::string;
 using std::vector;
+using std::map;
+using std::pair;
+using std::sqrt;
 
 using utl::RSZ;
 
-using odb::dbBox;
 using odb::dbInst;
-using odb::dbMaster;
 using odb::dbModule;
-using odb::dbMPin;
-using odb::dbOrientType;
 using odb::dbPlacementStatus;
 using odb::Rect;
+using odb::dbOrientType;
+using odb::dbMPin;
+using odb::dbBox;
+using odb::dbMaster;
 
 using sta::evalTclInit;
-using sta::FindNetDrvrLoads;
-using sta::FuncExpr;
+using sta::makeBlockSta;
+using sta::Level;
+using sta::stringLess;
+using sta::NetworkEdit;
+using sta::NetPinIterator;
+using sta::NetConnectedPinIterator;
 using sta::InstancePinIterator;
 using sta::LeafInstanceIterator;
-using sta::Level;
-using sta::LibertyCellIterator;
 using sta::LibertyLibraryIterator;
-using sta::makeBlockSta;
-using sta::NetConnectedPinIterator;
-using sta::NetIterator;
-using sta::NetPinIterator;
-using sta::NetworkEdit;
-using sta::Port;
-using sta::stringLess;
-using sta::Term;
+using sta::LibertyCellIterator;
 using sta::TimingArcSet;
 using sta::TimingArcSetSeq;
 using sta::TimingRole;
-;
-using sta::ArcDelayCalc;
+using sta::FuncExpr;
+using sta::Term;
+using sta::Port;
+using sta::NetIterator;
+using sta::FindNetDrvrLoads;;
+using sta::VertexIterator;
+using sta::VertexOutEdgeIterator;
+using sta::Edge;
+using sta::SearchPredNonReg2;
+using sta::ClkArrivalSearchPred;
 using sta::BfsBkwdIterator;
 using sta::BfsFwdIterator;
 using sta::BfsIndex;
-using sta::ClkArrivalSearchPred;
 using sta::Clock;
-using sta::Corners;
-using sta::delayInf;
-using sta::Edge;
+using sta::PathExpanded;
+using sta::INF;
 using sta::fuzzyEqual;
-using sta::fuzzyGreater;
-using sta::fuzzyGreaterEqual;
 using sta::fuzzyLess;
 using sta::fuzzyLessEqual;
-using sta::INF;
-using sta::InputDrive;
-using sta::PathExpanded;
-using sta::PinConnectedPinIterator;
-using sta::SearchPredNonReg2;
+using sta::fuzzyGreater;
+using sta::fuzzyGreaterEqual;
+using sta::delayInf;
 using sta::stringPrint;
 using sta::Unit;
-using sta::VertexIterator;
-using sta::VertexOutEdgeIterator;
+using sta::ArcDelayCalc;
+using sta::Corners;
+using sta::InputDrive;
+using sta::PinConnectedPinIterator;
 
 extern "C" {
-extern int Rsz_Init(Tcl_Interp* interp);
+extern int Rsz_Init(Tcl_Interp *interp);
 }
 
-Resizer::Resizer()
-    : StaState(),
-      repair_design_(new RepairDesign(this)),
-      repair_setup_(new RepairSetup(this)),
-      repair_hold_(new RepairHold(this)),
-      steiner_renderer_(nullptr),
-      wire_signal_res_(0.0),
-      wire_signal_cap_(0.0),
-      wire_clk_res_(0.0),
-      wire_clk_cap_(0.0),
-      max_area_(0.0),
-      openroad_(nullptr),
-      logger_(nullptr),
-      stt_builder_(nullptr),
-      global_router_(nullptr),
-      incr_groute_(nullptr),
-      gui_(nullptr),
-      sta_(nullptr),
-      db_network_(nullptr),
-      db_(nullptr),
-      block_(nullptr),
-      dbu_(0),
-      debug_pin_(nullptr),
-      core_exists_(false),
-      parasitics_src_(ParasiticsSrc::none),
-      design_area_(0.0),
-      min_(MinMax::min()),
-      max_(MinMax::max()),
-      buffer_lowest_drive_(nullptr),
-      target_load_map_(nullptr),
-      level_drvr_vertices_valid_(false),
-      tgt_slews_{0.0, 0.0},
-      tgt_slew_corner_(nullptr),
-      tgt_slew_dcalc_ap_(nullptr),
-      unique_net_index_(1),
-      unique_inst_index_(1),
-      resize_count_(0),
-      inserted_buffer_count_(0),
-      buffer_moved_into_core_(false),
-      max_wire_length_(0),
-      worst_slack_nets_percent_(10)
+Resizer::Resizer() :
+  StaState(),
+  repair_design_(new RepairDesign(this)),
+  repair_setup_(new RepairSetup(this)),
+  repair_hold_(new RepairHold(this)),
+  steiner_renderer_(nullptr),
+  wire_signal_res_(0.0),
+  wire_signal_cap_(0.0),
+  wire_clk_res_(0.0),
+  wire_clk_cap_(0.0),
+  max_area_(0.0),
+  openroad_(nullptr),
+  logger_(nullptr),
+  stt_builder_(nullptr),
+  global_router_(nullptr),
+  incr_groute_(nullptr),
+  gui_(nullptr),
+  sta_(nullptr),
+  db_network_(nullptr),
+  db_(nullptr),
+  block_(nullptr),
+  dbu_(0),
+  debug_pin_(nullptr),
+  core_exists_(false),
+  parasitics_src_(ParasiticsSrc::none),
+  design_area_(0.0),
+  min_(MinMax::min()),
+  max_(MinMax::max()),
+  buffer_lowest_drive_(nullptr),
+  target_load_map_(nullptr),
+  level_drvr_vertices_valid_(false),
+  tgt_slews_{0.0, 0.0},
+  tgt_slew_corner_(nullptr),
+  tgt_slew_dcalc_ap_(nullptr),
+  unique_net_index_(1),
+  unique_inst_index_(1),
+  resize_count_(0),
+  inserted_buffer_count_(0),
+  buffer_moved_into_core_(false),
+  max_wire_length_(0),
+  worst_slack_nets_percent_(10)
 {
 }
 
@@ -189,14 +187,15 @@ Resizer::~Resizer()
   delete repair_hold_;
 }
 
-void Resizer::init(OpenRoad* openroad,
-                   Tcl_Interp* interp,
-                   Logger* logger,
-                   Gui* gui,
-                   dbDatabase* db,
-                   dbSta* sta,
-                   SteinerTreeBuilder* stt_builder,
-                   GlobalRouter* global_router)
+void
+Resizer::init(OpenRoad *openroad,
+              Tcl_Interp *interp,
+              Logger *logger,
+              Gui *gui,
+              dbDatabase *db,
+              dbSta *sta,
+              SteinerTreeBuilder *stt_builder,
+              GlobalRouter *global_router)
 {
   openroad_ = openroad;
   logger_ = logger;
@@ -208,7 +207,6 @@ void Resizer::init(OpenRoad* openroad,
   global_router_ = global_router;
   incr_groute_ = nullptr;
   db_network_ = sta->getDbNetwork();
-  inserted_buffer_set_ = InstanceSet(db_network_);
   copyState(sta);
   // Define swig TCL commands.
   Rsz_Init(interp);
@@ -218,12 +216,14 @@ void Resizer::init(OpenRoad* openroad,
 
 ////////////////////////////////////////////////////////////////
 
-double Resizer::coreArea() const
+double
+Resizer::coreArea() const
 {
   return dbuToMeters(core_.dx()) * dbuToMeters(core_.dy());
 }
 
-double Resizer::utilization()
+double
+Resizer::utilization()
 {
   initBlock();
   initDesignArea();
@@ -234,7 +234,8 @@ double Resizer::utilization()
     return 1.0;
 }
 
-double Resizer::maxArea() const
+double
+Resizer::maxArea() const
 {
   return max_area_;
 }
@@ -243,43 +244,51 @@ double Resizer::maxArea() const
 
 class VertexLevelLess
 {
- public:
-  VertexLevelLess(const Network* network);
-  bool operator()(const Vertex* vertex1, const Vertex* vertex2) const;
+public:
+  VertexLevelLess(const Network *network);
+  bool operator()(const Vertex *vertex1,
+                  const Vertex *vertex2) const;
 
- protected:
-  const Network* network_;
+protected:
+  const Network *network_;
 };
 
-VertexLevelLess::VertexLevelLess(const Network* network) : network_(network)
+VertexLevelLess::VertexLevelLess(const Network *network) :
+  network_(network)
 {
 }
 
-bool VertexLevelLess::operator()(const Vertex* vertex1,
-                                 const Vertex* vertex2) const
+bool
+VertexLevelLess::operator()(const Vertex *vertex1,
+                            const Vertex *vertex2) const
 {
   Level level1 = vertex1->level();
   Level level2 = vertex2->level();
   return (level1 < level2)
-         || (level1 == level2
-             // Break ties for stable results.
-             && stringLess(network_->pathName(vertex1->pin()),
-                           network_->pathName(vertex2->pin())));
+    || (level1 == level2
+        // Break ties for stable results.
+        && stringLess(network_->pathName(vertex1->pin()),
+                      network_->pathName(vertex2->pin())));
 }
+
 
 ////////////////////////////////////////////////////////////////
 
 // block_ indicates core_, design_area_, db_network_ etc valid.
-void Resizer::initBlock()
+void
+Resizer::initBlock()
 {
   block_ = db_->getChip()->getBlock();
   core_ = block_->getCoreArea();
-  core_exists_ = !(core_.xMin() == 0 && core_.xMax() == 0 && core_.yMin() == 0
+  core_exists_ = !(core_.xMin() == 0
+                   && core_.xMax() == 0
+                   && core_.yMin() == 0
                    && core_.yMax() == 0);
   dbu_ = db_->getTech()->getDbUnitsPerMicron();
 }
 
-void Resizer::init()
+void
+Resizer::init()
 {
   initBlock();
   sta_->ensureLevelized();
@@ -287,7 +296,8 @@ void Resizer::init()
   initDesignArea();
 }
 
-void Resizer::removeBuffers()
+void
+Resizer::removeBuffers()
 {
   initBlock();
   // Disable incremental timing.
@@ -295,10 +305,11 @@ void Resizer::removeBuffers()
   search_->arrivalsInvalid();
 
   int remove_count = 0;
-  for (dbInst* db_inst : block_->getInsts()) {
-    LibertyCell* lib_cell = db_network_->libertyCell(db_inst);
-    Instance* buffer = db_network_->dbToSta(db_inst);
-    if (!db_inst->isDoNotTouch() && lib_cell
+  for (dbInst *db_inst : block_->getInsts()) {
+    LibertyCell *lib_cell = db_network_->libertyCell(db_inst);
+    Instance *buffer = db_network_->dbToSta(db_inst);
+    if (!db_inst->isDoNotTouch()
+        && lib_cell
         && lib_cell->isBuffer()
         // Do not remove buffers connected to input/output ports
         // because verilog netlists use the net name for the port.
@@ -311,35 +322,38 @@ void Resizer::removeBuffers()
   logger_->info(RSZ, 26, "Removed {} buffers.", remove_count);
 }
 
-bool Resizer::bufferBetweenPorts(Instance* buffer)
+bool
+Resizer::bufferBetweenPorts(Instance *buffer)
 {
-  LibertyCell* lib_cell = network_->libertyCell(buffer);
+  LibertyCell *lib_cell = network_->libertyCell(buffer);
   LibertyPort *in_port, *out_port;
   lib_cell->bufferPorts(in_port, out_port);
-  const Pin* in_pin = db_network_->findPin(buffer, in_port);
-  const Pin* out_pin = db_network_->findPin(buffer, out_port);
-  Net* in_net = db_network_->net(in_pin);
-  Net* out_net = db_network_->net(out_pin);
+  Pin *in_pin = db_network_->findPin(buffer, in_port);
+  Pin *out_pin = db_network_->findPin(buffer, out_port);
+  Net *in_net = db_network_->net(in_pin);
+  Net *out_net = db_network_->net(out_pin);
   bool in_net_ports = hasPort(in_net);
   bool out_net_ports = hasPort(out_net);
   return in_net_ports && out_net_ports;
 }
 
-void Resizer::removeBuffer(Instance* buffer)
+void
+Resizer::removeBuffer(Instance *buffer)
 {
-  LibertyCell* lib_cell = network_->libertyCell(buffer);
+  LibertyCell *lib_cell = network_->libertyCell(buffer);
   LibertyPort *in_port, *out_port;
   lib_cell->bufferPorts(in_port, out_port);
-  Pin* in_pin = db_network_->findPin(buffer, in_port);
-  Pin* out_pin = db_network_->findPin(buffer, out_port);
-  Net* in_net = db_network_->net(in_pin);
-  Net* out_net = db_network_->net(out_pin);
+  Pin *in_pin = db_network_->findPin(buffer, in_port);
+  Pin *out_pin = db_network_->findPin(buffer, out_port);
+  Net *in_net = db_network_->net(in_pin);
+  Net *out_net = db_network_->net(out_pin);
   bool out_net_ports = hasPort(out_net);
   Net *survivor, *removed;
   if (out_net_ports) {
     survivor = out_net;
     removed = in_net;
-  } else {
+  }
+  else {
     // default or out_net_ports
     // Default to in_net surviving so drivers (cached in dbNetwork)
     // do not change.
@@ -347,18 +361,20 @@ void Resizer::removeBuffer(Instance* buffer)
     removed = out_net;
   }
 
-  if (!sdc_->isConstrained(in_pin) && !sdc_->isConstrained(out_pin)
-      && !sdc_->isConstrained(removed) && !sdc_->isConstrained(buffer)) {
+  if (!sdc_->isConstrained(in_pin)
+      && !sdc_->isConstrained(out_pin)
+      && !sdc_->isConstrained(removed)
+      && !sdc_->isConstrained(buffer)) {
     sta_->disconnectPin(in_pin);
     sta_->disconnectPin(out_pin);
     sta_->deleteInstance(buffer);
 
-    NetPinIterator* pin_iter = db_network_->pinIterator(removed);
+    NetPinIterator *pin_iter = db_network_->pinIterator(removed);
     while (pin_iter->hasNext()) {
-      const Pin* pin = pin_iter->next();
-      Instance* pin_inst = db_network_->instance(pin);
+      const Pin *pin = pin_iter->next();
+      Instance *pin_inst = db_network_->instance(pin);
       if (pin_inst != buffer) {
-        Port* pin_port = db_network_->port(pin);
+        Port *pin_port = db_network_->port(pin);
         sta_->disconnectPin(const_cast<Pin*>(pin));
         sta_->connectPin(pin_inst, pin_port, survivor);
       }
@@ -370,13 +386,14 @@ void Resizer::removeBuffer(Instance* buffer)
   }
 }
 
-void Resizer::ensureLevelDrvrVertices()
+void
+Resizer::ensureLevelDrvrVertices()
 {
   if (!level_drvr_vertices_valid_) {
     level_drvr_vertices_.clear();
     VertexIterator vertex_iter(graph_);
     while (vertex_iter.hasNext()) {
-      Vertex* vertex = vertex_iter.next();
+      Vertex *vertex = vertex_iter.next();
       if (vertex->isDriver(network_))
         level_drvr_vertices_.push_back(vertex);
     }
@@ -387,14 +404,16 @@ void Resizer::ensureLevelDrvrVertices()
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::findBuffers()
+void
+Resizer::findBuffers()
 {
   if (buffer_cells_.empty()) {
-    LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
+    LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
     while (lib_iter->hasNext()) {
-      LibertyLibrary* lib = lib_iter->next();
-      for (LibertyCell* buffer : *lib->buffers()) {
-        if (!dontUse(buffer) && isLinkCell(buffer)) {
+      LibertyLibrary *lib = lib_iter->next();
+      for (LibertyCell *buffer : *lib->buffers()) {
+        if (!dontUse(buffer)
+            && isLinkCell(buffer)) {
           buffer_cells_.push_back(buffer);
         }
       }
@@ -404,24 +423,26 @@ void Resizer::findBuffers()
     if (buffer_cells_.empty())
       logger_->error(RSZ, 22, "no buffers found.");
     else {
-      sort(buffer_cells_,
-           [this](const LibertyCell* buffer1, const LibertyCell* buffer2) {
-             return bufferDriveResistance(buffer1)
-                    > bufferDriveResistance(buffer2);
-           });
+      sort(buffer_cells_, [this] (const LibertyCell *buffer1,
+                                  const LibertyCell *buffer2) {
+        return bufferDriveResistance(buffer1)
+          > bufferDriveResistance(buffer2);
+      });
       buffer_lowest_drive_ = buffer_cells_[0];
     }
   }
 }
 
-bool Resizer::isLinkCell(LibertyCell* cell)
+bool
+Resizer::isLinkCell(LibertyCell *cell)
 {
   return network_->findLibertyCell(cell->name()) == cell;
 }
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::bufferInputs()
+void
+Resizer::bufferInputs()
 {
   init();
   findBuffers();
@@ -430,17 +451,18 @@ void Resizer::bufferInputs()
   buffer_moved_into_core_ = false;
 
   incrementalParasiticsBegin();
-  InstancePinIterator* port_iter
-      = network_->pinIterator(network_->topInstance());
+  InstancePinIterator *port_iter = network_->pinIterator(network_->topInstance());
   while (port_iter->hasNext()) {
-    const Pin* pin = port_iter->next();
-    Vertex* vertex = graph_->pinDrvrVertex(pin);
-    Net* net = network_->net(network_->term(pin));
-    if (network_->direction(pin)->isInput() && !dontTouch(net)
+    Pin *pin = port_iter->next();
+    Vertex *vertex = graph_->pinDrvrVertex(pin);
+    Net *net = network_->net(network_->term(pin));
+    if (network_->direction(pin)->isInput()
+        && !dontTouch(net)
         && !vertex->isConstant()
         && !sta_->isClock(pin)
         // Hands off special nets.
-        && !db_network_->isSpecial(net) && hasPins(net))
+        && !db_network_->isSpecial(net)
+        && hasPins(net))
       // repair_design will resize to target slew.
       bufferInput(pin, buffer_lowest_drive_);
   }
@@ -449,31 +471,33 @@ void Resizer::bufferInputs()
   incrementalParasiticsEnd();
 
   if (inserted_buffer_count_ > 0) {
-    logger_->info(
-        RSZ, 27, "Inserted {} input buffers.", inserted_buffer_count_);
+    logger_->info(RSZ, 27, "Inserted {} input buffers.", inserted_buffer_count_);
     level_drvr_vertices_valid_ = false;
   }
 }
-
-bool Resizer::hasPins(Net* net)
+   
+bool
+Resizer::hasPins(Net *net)
 {
-  NetPinIterator* pin_iter = db_network_->pinIterator(net);
+  NetPinIterator *pin_iter = db_network_->pinIterator(net);
   bool has_pins = pin_iter->hasNext();
   delete pin_iter;
   return has_pins;
 }
 
-Instance* Resizer::bufferInput(const Pin* top_pin, LibertyCell* buffer_cell)
+Instance *
+Resizer::bufferInput(const Pin *top_pin,
+                     LibertyCell *buffer_cell)
 {
-  Term* term = db_network_->term(top_pin);
-  Net* input_net = db_network_->net(term);
+  Term *term = db_network_->term(top_pin);
+  Net *input_net = db_network_->net(term);
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
 
   bool has_dont_touch = false;
-  NetConnectedPinIterator* pin_iter = network_->connectedPinIterator(input_net);
+  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(input_net);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     // Leave input port pin connected to input_net.
     if (pin != top_pin && dontTouch(network_->instance(pin))) {
       has_dont_touch = true;
@@ -492,20 +516,21 @@ Instance* Resizer::bufferInput(const Pin* top_pin, LibertyCell* buffer_cell)
   }
 
   string buffer_name = makeUniqueInstName("input");
-  Instance* parent = db_network_->topInstance();
-  Net* buffer_out = makeUniqueNet();
+  Instance *parent = db_network_->topInstance();
+  Net *buffer_out = makeUniqueNet();
   Point pin_loc = db_network_->location(top_pin);
-  Instance* buffer
-      = makeBuffer(buffer_cell, buffer_name.c_str(), parent, pin_loc);
+  Instance *buffer = makeBuffer(buffer_cell,
+                                buffer_name.c_str(),
+                                parent, pin_loc);
   inserted_buffer_count_++;
 
   pin_iter = network_->connectedPinIterator(input_net);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     // Leave input port pin connected to input_net.
     if (pin != top_pin) {
       sta_->disconnectPin(const_cast<Pin*>(pin));
-      Port* pin_port = db_network_->port(pin);
+      Port *pin_port = db_network_->port(pin);
       sta_->connectPin(db_network_->instance(pin), pin_port, buffer_out);
     }
   }
@@ -518,7 +543,8 @@ Instance* Resizer::bufferInput(const Pin* top_pin, LibertyCell* buffer_cell)
   return buffer;
 }
 
-void Resizer::bufferOutputs()
+void
+Resizer::bufferOutputs()
 {
   init();
   findBuffers();
@@ -526,19 +552,19 @@ void Resizer::bufferOutputs()
   buffer_moved_into_core_ = false;
 
   incrementalParasiticsBegin();
-  InstancePinIterator* port_iter
-      = network_->pinIterator(network_->topInstance());
+  InstancePinIterator *port_iter = network_->pinIterator(network_->topInstance());
   while (port_iter->hasNext()) {
-    const Pin* pin = port_iter->next();
-    Vertex* vertex = graph_->pinLoadVertex(pin);
-    Net* net = network_->net(network_->term(pin));
-    if (network_->direction(pin)->isOutput() && net
+    Pin *pin = port_iter->next();
+    Vertex *vertex = graph_->pinLoadVertex(pin);
+    Net *net = network_->net(network_->term(pin));
+    if (network_->direction(pin)->isOutput()
+        && net
         && !dontTouch(net)
         // Hands off special nets.
         && !db_network_->isSpecial(net)
-        // DEF does not have tristate output types so we have look at the
-        // drivers.
-        && !hasTristateOrDontTouchDriver(net) && !vertex->isConstant()
+        // DEF does not have tristate output types so we have look at the drivers.
+        && !hasTristateOrDontTouchDriver(net)
+        && !vertex->isConstant()
         && hasPins(net)) {
       bufferOutput(pin, buffer_lowest_drive_);
     }
@@ -548,17 +574,17 @@ void Resizer::bufferOutputs()
   incrementalParasiticsEnd();
 
   if (inserted_buffer_count_ > 0) {
-    logger_->info(
-        RSZ, 28, "Inserted {} output buffers.", inserted_buffer_count_);
+    logger_->info(RSZ, 28, "Inserted {} output buffers.", inserted_buffer_count_);
     level_drvr_vertices_valid_ = false;
   }
 }
 
-bool Resizer::hasTristateOrDontTouchDriver(const Net* net)
+bool
+Resizer::hasTristateOrDontTouchDriver(const Net *net)
 {
-  PinSet* drivers = network_->drivers(net);
+  PinSet *drivers = network_->drivers(net);
   if (drivers) {
-    for (const Pin* pin : *drivers) {
+    for (const Pin *pin : *drivers) {
       if (isTristateDriver(pin)) {
         return true;
       }
@@ -578,36 +604,39 @@ bool Resizer::hasTristateOrDontTouchDriver(const Net* net)
   return false;
 }
 
-bool Resizer::isTristateDriver(const Pin* pin)
+bool
+Resizer::isTristateDriver(const Pin *pin)
 {
   // Note LEF macro PINs do not have a clue about tristates.
-  LibertyPort* port = network_->libertyPort(pin);
+  LibertyPort *port = network_->libertyPort(pin);
   return port && port->direction()->isAnyTristate();
 }
 
-void Resizer::bufferOutput(const Pin* top_pin, LibertyCell* buffer_cell)
+void
+Resizer::bufferOutput(const Pin *top_pin,
+                      LibertyCell *buffer_cell)
 {
-  NetworkEdit* network = networkEdit();
-  Term* term = network_->term(top_pin);
-  Net* output_net = network_->net(term);
+  NetworkEdit *network = networkEdit();
+  Term *term = network_->term(top_pin);
+  Net *output_net = network_->net(term);
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
   string buffer_name = makeUniqueInstName("output");
-  Instance* parent = network->topInstance();
-  Net* buffer_in = makeUniqueNet();
+  Instance *parent = network->topInstance();
+  Net *buffer_in = makeUniqueNet();
   Point pin_loc = db_network_->location(top_pin);
-  Instance* buffer
-      = makeBuffer(buffer_cell, buffer_name.c_str(), parent, pin_loc);
+  Instance *buffer = makeBuffer(buffer_cell,
+                                buffer_name.c_str(),
+                                parent, pin_loc);
   inserted_buffer_count_++;
 
-  NetConnectedPinIterator* pin_iter
-      = network_->connectedPinIterator(output_net);
+  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(output_net);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     if (pin != top_pin) {
       // Leave output port pin connected to output_net.
       sta_->disconnectPin(const_cast<Pin*>(pin));
-      Port* pin_port = network->port(pin);
+      Port *pin_port = network->port(pin);
       sta_->connectPin(network->instance(pin), pin_port, buffer_in);
     }
   }
@@ -621,12 +650,13 @@ void Resizer::bufferOutput(const Pin* top_pin, LibertyCell* buffer_cell)
 
 ////////////////////////////////////////////////////////////////
 
-bool Resizer::hasPort(const Net* net)
+bool
+Resizer::hasPort(const Net *net)
 {
   bool has_top_level_port = false;
-  NetConnectedPinIterator* pin_iter = network_->connectedPinIterator(net);
+  NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(net);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     if (network_->isTopLevelPort(pin)) {
       has_top_level_port = true;
       break;
@@ -636,18 +666,19 @@ bool Resizer::hasPort(const Net* net)
   return has_top_level_port;
 }
 
-float Resizer::driveResistance(const Pin* drvr_pin)
+float
+Resizer::driveResistance(const Pin *drvr_pin)
 {
   if (network_->isTopLevelPort(drvr_pin)) {
-    InputDrive* drive = sdc_->findInputDrive(network_->port(drvr_pin));
+    InputDrive *drive = sdc_->findInputDrive(network_->port(drvr_pin));
     if (drive) {
       float max_res = 0;
       for (auto min_max : MinMax::range()) {
         for (auto rf : RiseFall::range()) {
-          const LibertyCell* cell;
-          const LibertyPort* from_port;
-          float* from_slews;
-          const LibertyPort* to_port;
+          const LibertyCell *cell;
+          const LibertyPort *from_port;
+          float *from_slews;
+          const LibertyPort *to_port;
           drive->driveCell(rf, min_max, cell, from_port, from_slews, to_port);
           if (to_port)
             max_res = max(max_res, to_port->driveResistance());
@@ -662,15 +693,17 @@ float Resizer::driveResistance(const Pin* drvr_pin)
       }
       return max_res;
     }
-  } else {
-    LibertyPort* drvr_port = network_->libertyPort(drvr_pin);
+  }
+  else {
+    LibertyPort *drvr_port = network_->libertyPort(drvr_pin);
     if (drvr_port)
       return drvr_port->driveResistance();
   }
   return 0.0;
 }
 
-float Resizer::bufferDriveResistance(const LibertyCell* buffer) const
+float
+Resizer::bufferDriveResistance(const LibertyCell *buffer) const
 {
   LibertyPort *input, *output;
   buffer->bufferPorts(input, output);
@@ -679,26 +712,31 @@ float Resizer::bufferDriveResistance(const LibertyCell* buffer) const
 
 ////////////////////////////////////////////////////////////////
 
-bool Resizer::hasFanout(Vertex* drvr)
+bool
+Resizer::hasFanout(Vertex *drvr)
 {
   VertexOutEdgeIterator edge_iter(drvr, graph_);
   return edge_iter.hasNext();
 }
 
-static float targetLoadDist(float load_cap, float target_load)
+static float
+targetLoadDist(float load_cap,
+               float target_load)
 {
   return abs(load_cap - target_load);
 }
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::resizeDrvrToTargetSlew(const Pin* drvr_pin)
+void
+Resizer::resizeDrvrToTargetSlew(const Pin *drvr_pin)
 {
   resizePreamble();
   resizeToTargetSlew(drvr_pin);
 }
 
-void Resizer::resizePreamble()
+void
+Resizer::resizePreamble()
 {
   init();
   ensureLevelDrvrVertices();
@@ -708,16 +746,17 @@ void Resizer::resizePreamble()
   findTargetLoads();
 }
 
-void Resizer::makeEquivCells()
+void
+Resizer::makeEquivCells()
 {
   LibertyLibrarySeq libs;
-  LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
+  LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
   while (lib_iter->hasNext()) {
-    LibertyLibrary* lib = lib_iter->next();
+    LibertyLibrary *lib = lib_iter->next();
     // massive kludge until makeEquivCells is fixed to only incldue link cells
     LibertyCellIterator cell_iter(lib);
     if (cell_iter.hasNext()) {
-      LibertyCell* cell = cell_iter.next();
+      LibertyCell *cell = cell_iter.next();
       if (isLinkCell(cell))
         libs.push_back(lib);
     }
@@ -726,20 +765,19 @@ void Resizer::makeEquivCells()
   sta_->makeEquivCells(&libs, nullptr);
 }
 
-int Resizer::resizeToTargetSlew(const Pin* drvr_pin)
+int
+Resizer::resizeToTargetSlew(const Pin *drvr_pin)
 {
-  Instance* inst = network_->instance(drvr_pin);
-  LibertyCell* cell = network_->libertyCell(inst);
-  if (!network_->isTopLevelPort(drvr_pin) && !dontTouch(inst) && cell
+  Instance *inst = network_->instance(drvr_pin);
+  LibertyCell *cell = network_->libertyCell(inst);
+  if (!network_->isTopLevelPort(drvr_pin)
+      && !dontTouch(inst)
+      && cell
       && isLogicStdCell(inst)) {
     bool revisiting_inst = false;
     if (hasMultipleOutputs(inst)) {
       revisiting_inst = resized_multi_output_insts_.hasKey(inst);
-      debugPrint(logger_,
-                 RSZ,
-                 "resize",
-                 2,
-                 "multiple outputs{}",
+      debugPrint(logger_, RSZ, "resize", 2, "multiple outputs{}",
                  revisiting_inst ? " - revisit" : "");
       resized_multi_output_insts_.insert(inst);
     }
@@ -747,18 +785,14 @@ int Resizer::resizeToTargetSlew(const Pin* drvr_pin)
     // Includes net parasitic capacitance.
     float load_cap = graph_delay_calc_->loadCap(drvr_pin, tgt_slew_dcalc_ap_);
     if (load_cap > 0.0) {
-      LibertyCell* target_cell
-          = findTargetCell(cell, load_cap, revisiting_inst);
+      LibertyCell *target_cell = findTargetCell(cell, load_cap, revisiting_inst);
       if (target_cell != cell) {
-        debugPrint(logger_,
-                   RSZ,
-                   "resize",
-                   2,
-                   "{} {} -> {}",
+        debugPrint(logger_, RSZ, "resize", 2, "{} {} -> {}",
                    sdc_network_->pathName(drvr_pin),
                    cell->name(),
                    target_cell->name());
-        if (replaceCell(inst, target_cell, true) && !revisiting_inst)
+        if (replaceCell(inst, target_cell, true)
+            && !revisiting_inst)
           return 1;
       }
     }
@@ -766,62 +800,59 @@ int Resizer::resizeToTargetSlew(const Pin* drvr_pin)
   return 0;
 }
 
-bool Resizer::isLogicStdCell(const Instance* inst)
+bool
+Resizer::isLogicStdCell(const Instance *inst)
 {
   return !db_network_->isTopInstance(inst)
-         && db_network_->staToDb(inst)->getMaster()->getType()
-                == odb::dbMasterType::CORE;
+    && db_network_->staToDb(inst)->getMaster()->getType() == odb::dbMasterType::CORE;
 }
 
-LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
-                                     float load_cap,
-                                     bool revisiting_inst)
+LibertyCell *
+Resizer::findTargetCell(LibertyCell *cell,
+                        float load_cap,
+                        bool revisiting_inst)
 {
-  LibertyCell* best_cell = cell;
-  LibertyCellSeq* equiv_cells = sta_->equivCells(cell);
+  LibertyCell *best_cell = cell;
+  LibertyCellSeq *equiv_cells = sta_->equivCells(cell);
   if (equiv_cells) {
     bool is_buf_inv = cell->isBuffer() || cell->isInverter();
     float target_load = (*target_load_map_)[cell];
     float best_load = target_load;
     float best_dist = targetLoadDist(load_cap, target_load);
-    float best_delay
-        = is_buf_inv ? bufferDelay(cell, load_cap, tgt_slew_dcalc_ap_) : 0.0;
-    debugPrint(logger_,
-               RSZ,
-               "resize",
-               3,
-               "{} load cap {} dist={:.2e} delay={}",
+    float best_delay = is_buf_inv
+      ? bufferDelay(cell, load_cap, tgt_slew_dcalc_ap_)
+      : 0.0;
+    debugPrint(logger_, RSZ, "resize", 3, "{} load cap {} dist={:.2e} delay={}",
                cell->name(),
                units_->capacitanceUnit()->asString(load_cap),
                best_dist,
                delayAsString(best_delay, sta_, 3));
-    for (LibertyCell* target_cell : *equiv_cells) {
-      if (!dontUse(target_cell) && isLinkCell(target_cell)) {
+    for (LibertyCell *target_cell : *equiv_cells) {
+      if (!dontUse(target_cell)
+          && isLinkCell(target_cell)) {
         float target_load = (*target_load_map_)[target_cell];
-        float delay = is_buf_inv ? bufferDelay(
-                          target_cell, load_cap, tgt_slew_dcalc_ap_)
-                                 : 0.0;
+        float delay = is_buf_inv
+          ? bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_)
+          : 0.0;
         float dist = targetLoadDist(load_cap, target_load);
-        debugPrint(logger_,
-                   RSZ,
-                   "resize",
-                   3,
-                   " {} dist={:.2e} delay={}",
+        debugPrint(logger_, RSZ, "resize", 3, " {} dist={:.2e} delay={}",
                    target_cell->name(),
                    dist,
                    delayAsString(delay, sta_, 3));
         if (is_buf_inv
-                // Library may have "delay" buffers/inverters that are
-                // functionally buffers/inverters but have additional
-                // intrinsic delay. Accept worse target load matching if
-                // delay is reduced to avoid using them.
-                ? ((delay < best_delay && dist < best_dist * 1.1)
-                   || (dist < best_dist && delay < best_delay * 1.1))
-                : dist < best_dist
-                      // If the instance has multiple outputs (generally a
-                      // register Q/QN) only allow upsizing after the first pin
-                      // is visited.
-                      && (!revisiting_inst || target_load > best_load)) {
+            // Library may have "delay" buffers/inverters that are
+            // functionally buffers/inverters but have additional
+            // intrinsic delay. Accept worse target load matching if
+            // delay is reduced to avoid using them.
+            ? ((delay < best_delay
+                && dist < best_dist * 1.1)
+               || (dist < best_dist
+                   && delay < best_delay * 1.1))
+            : dist < best_dist
+            // If the instance has multiple outputs (generally a register Q/QN)
+            // only allow upsizing after the first pin is visited.
+            && (!revisiting_inst
+                || target_load > best_load)) {
           best_cell = target_cell;
           best_dist = dist;
           best_load = target_load;
@@ -834,29 +865,30 @@ LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
 }
 
 // Replace LEF with LEF so ports stay aligned in instance.
-bool Resizer::replaceCell(Instance* inst,
-                          LibertyCell* replacement,
-                          bool journal)
+bool
+Resizer::replaceCell(Instance *inst,
+                     LibertyCell *replacement,
+                     bool journal)
 {
-  const char* replacement_name = replacement->name();
-  dbMaster* replacement_master = db_->findMaster(replacement_name);
+  const char *replacement_name = replacement->name();
+  dbMaster *replacement_master = db_->findMaster(replacement_name);
   if (replacement_master) {
-    dbInst* dinst = db_network_->staToDb(inst);
-    dbMaster* master = dinst->getMaster();
+    dbInst *dinst = db_network_->staToDb(inst);
+    dbMaster *master = dinst->getMaster();
     designAreaIncr(-area(master));
-    Cell* replacement_cell1 = db_network_->dbToSta(replacement_master);
+    Cell *replacement_cell1 = db_network_->dbToSta(replacement_master);
     if (journal)
       journalInstReplaceCellBefore(inst);
     sta_->replaceCell(inst, replacement_cell1);
     designAreaIncr(area(replacement_master));
 
     if (haveEstimatedParasitics()) {
-      InstancePinIterator* pin_iter = network_->pinIterator(inst);
+      InstancePinIterator *pin_iter = network_->pinIterator(inst);
       while (pin_iter->hasNext()) {
-        const Pin* pin = pin_iter->next();
-        const Net* net = network_->net(pin);
+        const Pin *pin = pin_iter->next();
+        const Net *net = network_->net(pin);
         // ODB is clueless about tristates so go to liberty for reality.
-        const LibertyPort* port = network_->libertyPort(pin);
+        const LibertyPort *port = network_->libertyPort(pin);
         // Invalidate estimated parasitics on all instance input pins.
         // Tristate nets have multiple drivers and this is drivers^2 if
         // the parasitics are updated for each resize.
@@ -870,13 +902,15 @@ bool Resizer::replaceCell(Instance* inst,
   return false;
 }
 
-bool Resizer::hasMultipleOutputs(const Instance* inst)
+bool
+Resizer::hasMultipleOutputs(const Instance *inst)
 {
   int output_count = 0;
-  InstancePinIterator* pin_iter = network_->pinIterator(inst);
+  InstancePinIterator *pin_iter = network_->pinIterator(inst);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
-    if (network_->direction(pin)->isAnyOutput() && network_->net(pin)) {
+    const Pin *pin = pin_iter->next();
+    if (network_->direction(pin)->isAnyOutput()
+        && network_->net(pin)) {
       output_count++;
       if (output_count > 1)
         return true;
@@ -889,7 +923,8 @@ bool Resizer::hasMultipleOutputs(const Instance* inst)
 
 // API for timing driven placement.
 
-void Resizer::resizeSlackPreamble()
+void
+Resizer::resizeSlackPreamble()
 {
   resizePreamble();
   // Save max_wire_length for multiple repairDesign calls.
@@ -898,40 +933,38 @@ void Resizer::resizeSlackPreamble()
 
 // Run repair_design to repair long wires and max slew, capacitance and fanout
 // violations. Find the slacks, and then undo all changes to the netlist.
-void Resizer::findResizeSlacks()
+void
+Resizer::findResizeSlacks()
 {
   journalBegin();
   estimateWireParasitics();
   int repaired_net_count, slew_violations, cap_violations;
   int fanout_violations, length_violations;
-  repair_design_->repairDesign(max_wire_length_,
-                               0.0,
-                               0.0,
-                               repaired_net_count,
-                               slew_violations,
-                               cap_violations,
-                               fanout_violations,
-                               length_violations);
+  repair_design_->repairDesign(max_wire_length_, 0.0, 0.0,
+                               repaired_net_count, slew_violations, cap_violations,
+                               fanout_violations, length_violations);
   findResizeSlacks1();
   journalRestore(resize_count_, inserted_buffer_count_);
 }
-
-void Resizer::findResizeSlacks1()
+  
+void
+Resizer::findResizeSlacks1()
 {
   // Use driver pin slacks rather than Sta::netSlack to save visiting
   // the net pins and min'ing the slack.
   net_slack_map_.clear();
   NetSeq nets;
   for (int i = level_drvr_vertices_.size() - 1; i >= 0; i--) {
-    Vertex* drvr = level_drvr_vertices_[i];
-    Pin* drvr_pin = drvr->pin();
-    Net* net = network_->isTopLevelPort(drvr_pin)
-                   ? network_->net(network_->term(drvr_pin))
-                   : network_->net(drvr_pin);
+    Vertex *drvr = level_drvr_vertices_[i];
+    Pin *drvr_pin = drvr->pin();
+    Net *net = network_->isTopLevelPort(drvr_pin)
+      ? network_->net(network_->term(drvr_pin))
+      : network_->net(drvr_pin);
     if (net
         && !drvr->isConstant()
         // Hands off special nets.
-        && !db_network_->isSpecial(net) && !sta_->isClock(drvr_pin)) {
+        && !db_network_->isSpecial(net)
+        && !sta_->isClock(drvr_pin)) {
       net_slack_map_[net] = sta_->vertexSlack(drvr, max_);
       nets.push_back(net);
     }
@@ -940,20 +973,22 @@ void Resizer::findResizeSlacks1()
   // Find the nets with the worst slack.
 
   //  sort(nets.begin(), nets.end(). [&](const Net *net1,
-  sort(nets, [this](const Net* net1, const Net* net2) {
-    return resizeNetSlack(net1) < resizeNetSlack(net2);
-  });
+  sort(nets, [this](const Net *net1,
+                 const Net *net2)
+             { return resizeNetSlack(net1) < resizeNetSlack(net2); });
   worst_slack_nets_.clear();
   for (int i = 0; i < nets.size() * worst_slack_nets_percent_ / 100.0; i++)
     worst_slack_nets_.push_back(nets[i]);
 }
 
-NetSeq& Resizer::resizeWorstSlackNets()
+NetSeq &
+Resizer::resizeWorstSlackNets()
 {
   return worst_slack_nets_;
 }
 
-vector<dbNet*> Resizer::resizeWorstSlackDbNets()
+vector<dbNet*>
+Resizer::resizeWorstSlackDbNets()
 {
   vector<dbNet*> nets;
   for (const Net* net : worst_slack_nets_)
@@ -961,39 +996,43 @@ vector<dbNet*> Resizer::resizeWorstSlackDbNets()
   return nets;
 }
 
-Slack Resizer::resizeNetSlack(const Net* net)
+Slack
+Resizer::resizeNetSlack(const Net *net)
 {
   return net_slack_map_[net];
 }
 
-Slack Resizer::resizeNetSlack(const dbNet* db_net)
+Slack
+Resizer::resizeNetSlack(const dbNet *db_net)
 {
-  const Net* net = db_network_->dbToSta(db_net);
+  const Net *net = db_network_->dbToSta(db_net);
   return net_slack_map_[net];
 }
 
 ////////////////////////////////////////////////////////////////
 
 // API for logic resynthesis
-PinSet Resizer::findFaninFanouts(PinSet& end_pins)
+PinSet
+Resizer::findFaninFanouts(PinSet &end_pins)
 {
   // Abbreviated copyState
   sta_->ensureLevelized();
   graph_ = sta_->graph();
 
   VertexSet ends(graph_);
-  for (const Pin* pin : end_pins) {
-    Vertex* end = graph_->pinLoadVertex(pin);
+  for (const Pin *pin : end_pins) {
+    Vertex *end = graph_->pinLoadVertex(pin);
     ends.insert(end);
   }
   PinSet fanin_fanout_pins;
   VertexSet fanin_fanouts = findFaninFanouts(ends);
-  for (Vertex* vertex : fanin_fanouts)
+  for (Vertex *vertex : fanin_fanouts)
     fanin_fanout_pins.insert(vertex->pin());
   return fanin_fanout_pins;
 }
 
-VertexSet Resizer::findFaninFanouts(VertexSet& ends)
+VertexSet
+Resizer::findFaninFanouts(VertexSet &ends)
 {
   // Search backwards from ends to fanin register outputs and input ports.
   VertexSet fanin_roots = findFaninRoots(ends);
@@ -1003,27 +1042,29 @@ VertexSet Resizer::findFaninFanouts(VertexSet& ends)
 }
 
 // Find source pins for logic fanin of ends.
-PinSet Resizer::findFanins(PinSet& end_pins)
+PinSet
+Resizer::findFanins(PinSet &end_pins)
 {
   // Abbreviated copyState
   sta_->ensureLevelized();
   graph_ = sta_->graph();
 
   VertexSet ends(graph_);
-  for (const Pin* pin : end_pins) {
-    Vertex* end = graph_->pinLoadVertex(pin);
+  for (const Pin *pin : end_pins) {
+    Vertex *end = graph_->pinLoadVertex(pin);
     ends.insert(end);
   }
 
   SearchPredNonReg2 pred(sta_);
   BfsBkwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex* vertex : ends)
+  for (Vertex *vertex : ends)
     iter.enqueueAdjacentVertices(vertex);
 
   PinSet fanins;
   while (iter.hasNext()) {
-    Vertex* vertex = iter.next();
-    if (isRegOutput(vertex) || network_->isTopLevelPort(vertex->pin()))
+    Vertex *vertex = iter.next();
+    if (isRegOutput(vertex)
+        || network_->isTopLevelPort(vertex->pin()))
       continue;
     else {
       iter.enqueueAdjacentVertices(vertex);
@@ -1034,17 +1075,19 @@ PinSet Resizer::findFanins(PinSet& end_pins)
 }
 
 // Find roots for logic fanin of ends.
-VertexSet Resizer::findFaninRoots(VertexSet& ends)
+VertexSet
+Resizer::findFaninRoots(VertexSet &ends)
 {
   SearchPredNonReg2 pred(sta_);
   BfsBkwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex* vertex : ends)
+  for (Vertex *vertex : ends)
     iter.enqueueAdjacentVertices(vertex);
 
   VertexSet roots(graph_);
   while (iter.hasNext()) {
-    Vertex* vertex = iter.next();
-    if (isRegOutput(vertex) || network_->isTopLevelPort(vertex->pin()))
+    Vertex *vertex = iter.next();
+    if (isRegOutput(vertex)
+        || network_->isTopLevelPort(vertex->pin()))
       roots.insert(vertex);
     else
       iter.enqueueAdjacentVertices(vertex);
@@ -1052,12 +1095,13 @@ VertexSet Resizer::findFaninRoots(VertexSet& ends)
   return roots;
 }
 
-bool Resizer::isRegOutput(Vertex* vertex)
+bool
+Resizer::isRegOutput(Vertex *vertex)
 {
-  LibertyPort* port = network_->libertyPort(vertex->pin());
+  LibertyPort *port = network_->libertyPort(vertex->pin());
   if (port) {
-    LibertyCell* cell = port->libertyCell();
-    for (TimingArcSet* arc_set : cell->timingArcSets(nullptr, port)) {
+    LibertyCell *cell = port->libertyCell();
+    for (TimingArcSet *arc_set : cell->timingArcSets(nullptr, port)) {
       if (arc_set->role()->genericRole() == TimingRole::regClkToQ())
         return true;
     }
@@ -1065,16 +1109,17 @@ bool Resizer::isRegOutput(Vertex* vertex)
   return false;
 }
 
-VertexSet Resizer::findFanouts(VertexSet& reg_outs)
+VertexSet
+Resizer::findFanouts(VertexSet &reg_outs)
 {
   VertexSet fanouts(graph_);
   sta::SearchPredNonLatch2 pred(sta_);
   BfsFwdIterator iter(BfsIndex::other, &pred, this);
-  for (Vertex* reg_out : reg_outs)
+  for (Vertex *reg_out : reg_outs)
     iter.enqueueAdjacentVertices(reg_out);
 
   while (iter.hasNext()) {
-    Vertex* vertex = iter.next();
+    Vertex *vertex = iter.next();
     if (!isRegister(vertex)) {
       fanouts.insert(vertex);
       iter.enqueueAdjacentVertices(vertex);
@@ -1083,11 +1128,12 @@ VertexSet Resizer::findFanouts(VertexSet& reg_outs)
   return fanouts;
 }
 
-bool Resizer::isRegister(Vertex* vertex)
+bool
+Resizer::isRegister(Vertex *vertex)
 {
-  LibertyPort* port = network_->libertyPort(vertex->pin());
+  LibertyPort *port = network_->libertyPort(vertex->pin());
   if (port) {
-    LibertyCell* cell = port->libertyCell();
+    LibertyCell *cell = port->libertyCell();
     return cell && cell->hasSequentials();
   }
   return false;
@@ -1095,12 +1141,14 @@ bool Resizer::isRegister(Vertex* vertex)
 
 ////////////////////////////////////////////////////////////////
 
-double Resizer::area(Cell* cell)
+double
+Resizer::area(Cell *cell)
 {
   return area(db_network_->staToDb(cell));
 }
 
-double Resizer::area(dbMaster* master)
+double
+Resizer::area(dbMaster *master)
 {
   if (!master->isCoreAutoPlaceable()) {
     return 0;
@@ -1108,27 +1156,34 @@ double Resizer::area(dbMaster* master)
   return dbuToMeters(master->getWidth()) * dbuToMeters(master->getHeight());
 }
 
-double Resizer::dbuToMeters(int dist) const
+double
+Resizer::dbuToMeters(int dist) const
 {
   return dist / (dbu_ * 1e+6);
 }
 
-int Resizer::metersToDbu(double dist) const
+int
+Resizer::metersToDbu(double dist) const
 {
   return dist * dbu_ * 1e+6;
 }
 
-void Resizer::setMaxUtilization(double max_utilization)
+void
+Resizer::setMaxUtilization(double max_utilization)
 {
   max_area_ = coreArea() * max_utilization;
 }
 
-bool Resizer::overMaxArea()
+bool
+Resizer::overMaxArea()
 {
-  return max_area_ && fuzzyGreaterEqual(design_area_, max_area_);
+  return max_area_
+    && fuzzyGreaterEqual(design_area_, max_area_);
 }
 
-void Resizer::setDontUse(LibertyCell* cell, bool dont_use)
+void
+Resizer::setDontUse(LibertyCell *cell,
+                    bool dont_use)
 {
   if (dont_use)
     dont_use_.insert(cell);
@@ -1136,35 +1191,43 @@ void Resizer::setDontUse(LibertyCell* cell, bool dont_use)
     dont_use_.erase(cell);
 }
 
-bool Resizer::dontUse(LibertyCell* cell)
+bool
+Resizer::dontUse(LibertyCell *cell)
 {
-  return cell->dontUse() || dont_use_.hasKey(cell);
+  return cell->dontUse()
+    || dont_use_.hasKey(cell);
 }
 
-void Resizer::setDontTouch(const Instance* inst, bool dont_touch)
+void
+Resizer::setDontTouch(const Instance *inst,
+                      bool dont_touch)
 {
-  dbInst* db_inst = db_network_->staToDb(inst);
+  dbInst *db_inst = db_network_->staToDb(inst);
   db_inst->setDoNotTouch(dont_touch);
 }
 
-bool Resizer::dontTouch(const Instance* inst)
+bool
+Resizer::dontTouch(const Instance *inst)
 {
-  dbInst* db_inst = db_network_->staToDb(inst);
+  dbInst *db_inst = db_network_->staToDb(inst);
   if (!db_inst) {
     return false;
   }
   return db_inst->isDoNotTouch();
 }
 
-void Resizer::setDontTouch(const Net* net, bool dont_touch)
+void
+Resizer::setDontTouch(const Net *net,
+                      bool dont_touch)
 {
-  dbNet* db_net = db_network_->staToDb(net);
+  dbNet *db_net = db_network_->staToDb(net);
   db_net->setDoNotTouch(dont_touch);
 }
 
-bool Resizer::dontTouch(const Net* net)
+bool
+Resizer::dontTouch(const Net *net)
 {
-  dbNet* db_net = db_network_->staToDb(net);
+  dbNet *db_net = db_network_->staToDb(net);
   return db_net->isDoNotTouch();
 }
 
@@ -1172,7 +1235,8 @@ bool Resizer::dontTouch(const Net* net)
 
 // Find a target slew for the libraries and then
 // a target load for each cell that gives the target slew.
-void Resizer::findTargetLoads()
+void
+Resizer::findTargetLoads()
 {
   if (target_load_map_ == nullptr) {
     // Find target slew across all buffers in the libraries.
@@ -1181,14 +1245,14 @@ void Resizer::findTargetLoads()
     target_load_map_ = new CellTargetLoadMap;
     // Find target loads at the tgt_slew_corner.
     int lib_ap_index = tgt_slew_corner_->libertyIndex(max_);
-    LibertyLibraryIterator* lib_iter = network_->libertyLibraryIterator();
+    LibertyLibraryIterator *lib_iter = network_->libertyLibraryIterator();
     while (lib_iter->hasNext()) {
-      LibertyLibrary* lib = lib_iter->next();
+      LibertyLibrary *lib = lib_iter->next();
       LibertyCellIterator cell_iter(lib);
       while (cell_iter.hasNext()) {
-        LibertyCell* cell = cell_iter.next();
+        LibertyCell *cell = cell_iter.next();
         if (isLinkCell(cell)) {
-          LibertyCell* corner_cell = cell->cornerCell(lib_ap_index);
+          LibertyCell *corner_cell = cell->cornerCell(lib_ap_index);
           float tgt_load;
           bool exists;
           target_load_map_->findKey(corner_cell, tgt_load, exists);
@@ -1206,7 +1270,8 @@ void Resizer::findTargetLoads()
   }
 }
 
-float Resizer::targetLoadCap(LibertyCell* cell)
+float
+Resizer::targetLoadCap(LibertyCell *cell)
 {
   float load_cap = 0.0;
   bool exists;
@@ -1216,24 +1281,23 @@ float Resizer::targetLoadCap(LibertyCell* cell)
   return load_cap;
 }
 
-float Resizer::findTargetLoad(LibertyCell* cell)
+float
+Resizer::findTargetLoad(LibertyCell *cell)
 {
   float target_load_sum = 0.0;
   int arc_count = 0;
-  for (TimingArcSet* arc_set : cell->timingArcSets()) {
-    TimingRole* role = arc_set->role();
-    if (!role->isTimingCheck() && role != TimingRole::tristateDisable()
+  for (TimingArcSet *arc_set : cell->timingArcSets()) {
+    TimingRole *role = arc_set->role();
+    if (!role->isTimingCheck()
+        && role != TimingRole::tristateDisable()
         && role != TimingRole::tristateEnable()) {
-      for (TimingArc* arc : arc_set->arcs()) {
+      for (TimingArc *arc : arc_set->arcs()) {
         int in_rf_index = arc->fromEdge()->asRiseFall()->index();
         int out_rf_index = arc->toEdge()->asRiseFall()->index();
-        float arc_target_load = findTargetLoad(
-            cell, arc, tgt_slews_[in_rf_index], tgt_slews_[out_rf_index]);
-        debugPrint(logger_,
-                   RSZ,
-                   "target_load",
-                   3,
-                   "{} {} -> {} {} target_load = {:.2e}",
+        float arc_target_load = findTargetLoad(cell, arc, 
+                                               tgt_slews_[in_rf_index],
+                                               tgt_slews_[out_rf_index]);
+        debugPrint(logger_, RSZ, "target_load", 3, "{} {} -> {} {} target_load = {:.2e}",
                    cell->name(),
                    arc->from()->name(),
                    arc->to()->name(),
@@ -1245,11 +1309,7 @@ float Resizer::findTargetLoad(LibertyCell* cell)
     }
   }
   float target_load = arc_count ? target_load_sum / arc_count : 0.0;
-  debugPrint(logger_,
-             RSZ,
-             "target_load",
-             2,
-             "{} target_load = {:.2e}",
+  debugPrint(logger_, RSZ, "target_load", 2, "{} target_load = {:.2e}",
              cell->name(),
              target_load);
   return target_load;
@@ -1257,18 +1317,19 @@ float Resizer::findTargetLoad(LibertyCell* cell)
 
 // Find the load capacitance that will cause the output slew
 // to be equal to out_slew.
-float Resizer::findTargetLoad(LibertyCell* cell,
-                              TimingArc* arc,
-                              Slew in_slew,
-                              Slew out_slew)
+float
+Resizer::findTargetLoad(LibertyCell *cell,
+                        TimingArc *arc,
+                        Slew in_slew,
+                        Slew out_slew)
 {
-  GateTimingModel* model = dynamic_cast<GateTimingModel*>(arc->model());
+  GateTimingModel *model = dynamic_cast<GateTimingModel*>(arc->model());
   if (model) {
     // load_cap1 lower bound
     // load_cap2 upper bound
     double load_cap1 = 0.0;
     double load_cap2 = 1.0e-12;  // 1pF
-    double tol = .01;            // 1%
+    double tol = .01; // 1%
     double diff1 = gateSlewDiff(cell, arc, model, in_slew, load_cap1, out_slew);
     if (diff1 > 0.0)
       // Zero load cap out_slew is higher than the target.
@@ -1280,13 +1341,14 @@ float Resizer::findTargetLoad(LibertyCell* cell,
         load_cap1 = load_cap2;
         load_cap2 *= 2;
         diff2 = gateSlewDiff(cell, arc, model, in_slew, load_cap2, out_slew);
-      } else {
+      }
+      else {
         double load_cap3 = (load_cap1 + load_cap2) / 2.0;
-        const double diff3
-            = gateSlewDiff(cell, arc, model, in_slew, load_cap3, out_slew);
+        const double diff3 = gateSlewDiff(cell, arc, model, in_slew, load_cap3, out_slew);
         if (diff3 < 0.0) {
           load_cap1 = load_cap3;
-        } else {
+        }
+        else {
           load_cap2 = load_cap3;
           diff2 = diff3;
         }
@@ -1298,50 +1360,51 @@ float Resizer::findTargetLoad(LibertyCell* cell,
 }
 
 // objective function
-Slew Resizer::gateSlewDiff(LibertyCell* cell,
-                           TimingArc* arc,
-                           GateTimingModel* model,
-                           Slew in_slew,
-                           float load_cap,
-                           Slew out_slew)
+Slew
+Resizer::gateSlewDiff(LibertyCell *cell,
+                      TimingArc *arc,
+                      GateTimingModel *model,
+                      Slew in_slew,
+                      float load_cap,
+                      Slew out_slew)
 
 {
-  const Pvt* pvt = tgt_slew_dcalc_ap_->operatingConditions();
+  const Pvt *pvt = tgt_slew_dcalc_ap_->operatingConditions();
   ArcDelay arc_delay;
   Slew arc_slew;
-  model->gateDelay(
-      cell, pvt, in_slew, load_cap, 0.0, false, arc_delay, arc_slew);
+  model->gateDelay(cell, pvt, in_slew, load_cap, 0.0, false,
+                   arc_delay, arc_slew);
   return arc_slew - out_slew;
 }
 
 ////////////////////////////////////////////////////////////////
 
-Slew Resizer::targetSlew(const RiseFall* rf)
+Slew
+Resizer::targetSlew(const RiseFall *rf)
 {
   return tgt_slews_[rf->index()];
 }
 
 // Find target slew across all buffers in the libraries.
-void Resizer::findBufferTargetSlews()
+void
+Resizer::findBufferTargetSlews()
 {
   tgt_slews_ = {0.0};
   tgt_slew_corner_ = nullptr;
-
-  for (Corner* corner : *sta_->corners()) {
+  
+  for (Corner *corner : *sta_->corners()) {
     int lib_ap_index = corner->libertyIndex(max_);
-    const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
-    const Pvt* pvt = dcalc_ap->operatingConditions();
+    const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
+    const Pvt *pvt = dcalc_ap->operatingConditions();
     // Average slews across buffers at corner.
     Slew slews[RiseFall::index_count]{0.0};
     int counts[RiseFall::index_count]{0};
-    for (LibertyCell* buffer : buffer_cells_) {
-      LibertyCell* corner_buffer = buffer->cornerCell(lib_ap_index);
+    for (LibertyCell *buffer : buffer_cells_) {
+      LibertyCell *corner_buffer = buffer->cornerCell(lib_ap_index);
       findBufferTargetSlews(corner_buffer, pvt, slews, counts);
     }
-    Slew slew_rise
-        = slews[RiseFall::riseIndex()] / counts[RiseFall::riseIndex()];
-    Slew slew_fall
-        = slews[RiseFall::fallIndex()] / counts[RiseFall::fallIndex()];
+    Slew slew_rise = slews[RiseFall::riseIndex()] / counts[RiseFall::riseIndex()];
+    Slew slew_fall = slews[RiseFall::fallIndex()] / counts[RiseFall::fallIndex()];
     // Use the target slews from the slowest corner,
     // and resize using that corner.
     if (slew_rise > tgt_slews_[RiseFall::riseIndex()]) {
@@ -1352,37 +1415,34 @@ void Resizer::findBufferTargetSlews()
     }
   }
 
-  debugPrint(logger_,
-             RSZ,
-             "target_load",
-             1,
-             "target slew corner {} = {}/{}",
+  debugPrint(logger_, RSZ, "target_load", 1, "target slew corner {} = {}/{}",
              tgt_slew_corner_->name(),
              delayAsString(tgt_slews_[RiseFall::riseIndex()], sta_, 3),
              delayAsString(tgt_slews_[RiseFall::fallIndex()], sta_, 3));
 }
 
-void Resizer::findBufferTargetSlews(LibertyCell* buffer,
-                                    const Pvt* pvt,
-                                    // Return values.
-                                    Slew slews[],
-                                    int counts[])
+void
+Resizer::findBufferTargetSlews(LibertyCell *buffer,
+                               const Pvt *pvt,
+                               // Return values.
+                               Slew slews[],
+                               int counts[])
 {
   LibertyPort *input, *output;
   buffer->bufferPorts(input, output);
-  for (TimingArcSet* arc_set : buffer->timingArcSets(input, output)) {
-    for (TimingArc* arc : arc_set->arcs()) {
-      GateTimingModel* model = dynamic_cast<GateTimingModel*>(arc->model());
-      RiseFall* in_rf = arc->fromEdge()->asRiseFall();
-      RiseFall* out_rf = arc->toEdge()->asRiseFall();
+  for (TimingArcSet *arc_set : buffer->timingArcSets(input, output)) {
+    for (TimingArc *arc : arc_set->arcs()) {
+      GateTimingModel *model = dynamic_cast<GateTimingModel*>(arc->model());
+      RiseFall *in_rf = arc->fromEdge()->asRiseFall();
+      RiseFall *out_rf = arc->toEdge()->asRiseFall();
       float in_cap = input->capacitance(in_rf, max_);
       float load_cap = in_cap * tgt_slew_load_cap_factor;
       ArcDelay arc_delay;
       Slew arc_slew;
-      model->gateDelay(
-          buffer, pvt, 0.0, load_cap, 0.0, false, arc_delay, arc_slew);
-      model->gateDelay(
-          buffer, pvt, arc_slew, load_cap, 0.0, false, arc_delay, arc_slew);
+      model->gateDelay(buffer, pvt, 0.0, load_cap, 0.0, false,
+                       arc_delay, arc_slew);
+      model->gateDelay(buffer, pvt, arc_slew, load_cap, 0.0, false,
+                       arc_delay, arc_slew);
       slews[out_rf->index()] += arc_slew;
       counts[out_rf->index()]++;
     }
@@ -1393,36 +1453,37 @@ void Resizer::findBufferTargetSlews(LibertyCell* buffer,
 
 // Repair tie hi/low net driver fanout by duplicating the
 // tie hi/low instances for every pin connected to tie hi/low instances.
-void Resizer::repairTieFanout(LibertyPort* tie_port,
-                              double separation,  // meters
-                              bool verbose)
+void
+Resizer::repairTieFanout(LibertyPort *tie_port,
+                         double separation, // meters
+                         bool verbose)
 {
   initBlock();
   initDesignArea();
-  Instance* top_inst = network_->topInstance();
-  LibertyCell* tie_cell = tie_port->libertyCell();
+  Instance *top_inst = network_->topInstance();
+  LibertyCell *tie_cell = tie_port->libertyCell();
   InstanceSeq insts;
   findCellInstances(tie_cell, insts);
   int tie_count = 0;
   int separation_dbu = metersToDbu(separation);
-  for (const Instance* inst : insts) {
+  for (const Instance *inst : insts) {
     if (!dontTouch(inst)) {
-      Pin* drvr_pin = network_->findPin(inst, tie_port);
+      Pin *drvr_pin = network_->findPin(inst, tie_port);
       if (drvr_pin) {
-        Net* net = network_->net(drvr_pin);
-        if (net && !dontTouch(net)) {
-          NetConnectedPinIterator* pin_iter
-              = network_->connectedPinIterator(net);
+        Net *net = network_->net(drvr_pin);
+        if (net
+            && !dontTouch(net)) {
+          NetConnectedPinIterator *pin_iter = network_->connectedPinIterator(net);
           while (pin_iter->hasNext()) {
-            const Pin* load = pin_iter->next();
+            const Pin *load = pin_iter->next();
             if (load != drvr_pin) {
               // Make tie inst.
               Point tie_loc = tieLocation(load, separation_dbu);
-              Instance* load_inst = network_->instance(load);
-              const char* inst_name = network_->name(load_inst);
+              Instance *load_inst = network_->instance(load);
+              const char *inst_name = network_->name(load_inst);
               string tie_name = makeUniqueInstName(inst_name, true);
-              Instance* tie
-                  = makeInstance(tie_cell, tie_name.c_str(), top_inst, tie_loc);
+              Instance *tie = makeInstance(tie_cell, tie_name.c_str(),
+                                           top_inst, tie_loc);
 
               // Put the tie cell instance in the same module with the load
               // it drives.
@@ -1433,14 +1494,14 @@ void Resizer::repairTieFanout(LibertyPort* tie_port,
               }
 
               // Make tie output net.
-              Net* load_net = makeUniqueNet();
+              Net *load_net = makeUniqueNet();
 
               // Connect tie inst output.
               sta_->connectPin(tie, tie_port, load_net);
 
               // Connect load to tie output net.
               sta_->disconnectPin(const_cast<Pin*>(load));
-              Port* load_port = network_->port(load);
+              Port *load_port = network_->port(load);
               sta_->connectPin(load_inst, load_port, load_net);
 
               designAreaIncr(area(db_network_->cell(tie_cell)));
@@ -1450,8 +1511,8 @@ void Resizer::repairTieFanout(LibertyPort* tie_port,
           delete pin_iter;
 
           // Delete inst output net.
-          Pin* tie_pin = network_->findPin(inst, tie_port);
-          Net* tie_net = network_->net(tie_pin);
+          Pin *tie_pin = network_->findPin(inst, tie_port);
+          Net *tie_net = network_->net(tie_pin);
           sta_->deleteNet(tie_net);
           parasitics_invalid_.erase(tie_net);
           // Delete the tie instance if no other ports are in use.
@@ -1460,7 +1521,7 @@ void Resizer::repairTieFanout(LibertyPort* tie_port,
           std::unique_ptr<InstancePinIterator> inst_pin_iter{
               network_->pinIterator(inst)};
           while (inst_pin_iter->hasNext()) {
-            Pin* pin = inst_pin_iter->next();
+            Pin *pin = inst_pin_iter->next();
             if (pin != drvr_pin) {
               Net* net = network_->net(pin);
               if (net && !network_->isPower(net) && !network_->isGround(net)) {
@@ -1478,19 +1539,21 @@ void Resizer::repairTieFanout(LibertyPort* tie_port,
   }
 
   if (tie_count > 0) {
-    logger_->info(
-        RSZ, 42, "Inserted {} tie {} instances.", tie_count, tie_cell->name());
+    logger_->info(RSZ, 42, "Inserted {} tie {} instances.",
+                  tie_count,
+                  tie_cell->name());
     level_drvr_vertices_valid_ = false;
   }
 }
 
-void Resizer::findCellInstances(LibertyCell* cell,
-                                // Return value.
-                                InstanceSeq& insts)
+void
+Resizer::findCellInstances(LibertyCell *cell,
+                           // Return value.
+                           InstanceSeq &insts)
 {
-  LeafInstanceIterator* inst_iter = network_->leafInstanceIterator();
+  LeafInstanceIterator *inst_iter = network_->leafInstanceIterator();
   while (inst_iter->hasNext()) {
-    Instance* inst = inst_iter->next();
+    Instance *inst = inst_iter->next();
     if (network_->libertyCell(inst) == cell)
       insts.push_back(inst);
   }
@@ -1498,7 +1561,9 @@ void Resizer::findCellInstances(LibertyCell* cell,
 }
 
 // Place the tie instance on the side of the load pin.
-Point Resizer::tieLocation(const Pin* load, int separation)
+Point
+Resizer::tieLocation(const Pin *load,
+                     int separation)
 {
   Point load_loc = db_network_->location(load);
   int load_x = load_loc.getX();
@@ -1506,23 +1571,30 @@ Point Resizer::tieLocation(const Pin* load, int separation)
   int tie_x = load_x;
   int tie_y = load_y;
   if (!network_->isTopLevelPort(load)) {
-    dbInst* db_inst = db_network_->staToDb(network_->instance(load));
-    dbBox* bbox = db_inst->getBBox();
+    dbInst *db_inst = db_network_->staToDb(network_->instance(load));
+    dbBox *bbox = db_inst->getBBox();
     int left_dist = abs(load_x - bbox->xMin());
     int right_dist = abs(load_x - bbox->xMax());
     int bot_dist = abs(load_y - bbox->yMin());
     int top_dist = abs(load_y - bbox->yMax());
-    if (left_dist < right_dist && left_dist < bot_dist && left_dist < top_dist)
+    if (left_dist < right_dist
+        && left_dist < bot_dist
+        && left_dist < top_dist)
       // left
       tie_x -= separation;
-    if (right_dist < left_dist && right_dist < bot_dist
+    if (right_dist < left_dist
+        && right_dist < bot_dist
         && right_dist < top_dist)
       // right
       tie_x += separation;
-    if (bot_dist < left_dist && bot_dist < right_dist && bot_dist < top_dist)
+    if (bot_dist < left_dist
+        && bot_dist < right_dist
+        && bot_dist < top_dist)
       // bot
       tie_y -= separation;
-    if (top_dist < left_dist && top_dist < right_dist && top_dist < bot_dist)
+    if (top_dist < left_dist
+        && top_dist < right_dist
+        && top_dist < bot_dist)
       // top
       tie_y += separation;
   }
@@ -1531,7 +1603,9 @@ Point Resizer::tieLocation(const Pin* load, int separation)
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::reportLongWires(int count, int digits)
+void
+Resizer::reportLongWires(int count,
+                         int digits)
 {
   initBlock();
   graph_ = sta_->ensureGraph();
@@ -1539,12 +1613,12 @@ void Resizer::reportLongWires(int count, int digits)
   VertexSeq drvrs;
   findLongWires(drvrs);
   logger_->report("Driver    length delay");
-  const Corner* corner = sta_->cmdCorner();
+  const Corner *corner = sta_->cmdCorner();
   double wire_res = wireSignalResistance(corner);
   double wire_cap = wireSignalCapacitance(corner);
   int i = 0;
-  for (Vertex* drvr : drvrs) {
-    Pin* drvr_pin = drvr->pin();
+  for (Vertex *drvr : drvrs) {
+    Pin *drvr_pin = drvr->pin();
     double wire_length = dbuToMeters(maxLoadManhattenDistance(drvr));
     double steiner_length = dbuToMeters(findMaxSteinerDist(drvr, corner));
     double delay = (wire_length * wire_res) * (wire_length * wire_cap) * 0.5;
@@ -1561,35 +1635,39 @@ void Resizer::reportLongWires(int count, int digits)
 
 typedef std::pair<Vertex*, int> DrvrDist;
 
-void Resizer::findLongWires(VertexSeq& drvrs)
+void
+Resizer::findLongWires(VertexSeq &drvrs)
 {
   Vector<DrvrDist> drvr_dists;
   VertexIterator vertex_iter(graph_);
   while (vertex_iter.hasNext()) {
-    Vertex* vertex = vertex_iter.next();
+    Vertex *vertex = vertex_iter.next();
     if (vertex->isDriver(network_)) {
-      Pin* pin = vertex->pin();
+      Pin *pin = vertex->pin();
       // Hands off the clock nets.
-      if (!sta_->isClock(pin) && !vertex->isConstant()
+      if (!sta_->isClock(pin)
+          && !vertex->isConstant()
           && !vertex->isDisabledConstraint())
-        drvr_dists.push_back(
-            DrvrDist(vertex, maxLoadManhattenDistance(vertex)));
+        drvr_dists.push_back(DrvrDist(vertex, maxLoadManhattenDistance(vertex)));
     }
   }
-  sort(drvr_dists, [](const DrvrDist& drvr_dist1, const DrvrDist& drvr_dist2) {
-    return drvr_dist1.second > drvr_dist2.second;
-  });
+  sort(drvr_dists, [](const DrvrDist &drvr_dist1,
+                          const DrvrDist &drvr_dist2) {
+                    return drvr_dist1.second > drvr_dist2.second;
+                  });
   drvrs.reserve(drvr_dists.size());
-  for (DrvrDist& drvr_dist : drvr_dists)
+  for (DrvrDist &drvr_dist : drvr_dists)
     drvrs.push_back(drvr_dist.first);
 }
 
 // Find the maximum distance along steiner tree branches from
 // the driver to loads (in dbu).
-int Resizer::findMaxSteinerDist(Vertex* drvr, const Corner* corner)
+int
+Resizer::findMaxSteinerDist(Vertex *drvr,
+                            const Corner *corner)
 
 {
-  Pin* drvr_pin = drvr->pin();
+  Pin *drvr_pin = drvr->pin();
   BufferedNetPtr bnet = makeBufferedNetSteiner(drvr_pin, corner);
   if (bnet)
     return bnet->maxLoadWireLength();
@@ -1597,14 +1675,15 @@ int Resizer::findMaxSteinerDist(Vertex* drvr, const Corner* corner)
     return 0;
 }
 
-double Resizer::maxLoadManhattenDistance(const Net* net)
+double
+Resizer::maxLoadManhattenDistance(const Net *net)
 {
-  NetPinIterator* pin_iter = network_->pinIterator(net);
+  NetPinIterator *pin_iter = network_->pinIterator(net);
   int max_dist = 0;
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     if (network_->isDriver(pin)) {
-      Vertex* drvr = graph_->pinDrvrVertex(pin);
+      Vertex *drvr = graph_->pinDrvrVertex(pin);
       if (drvr) {
         int dist = maxLoadManhattenDistance(drvr);
         max_dist = max(max_dist, dist);
@@ -1615,14 +1694,15 @@ double Resizer::maxLoadManhattenDistance(const Net* net)
   return dbuToMeters(max_dist);
 }
 
-int Resizer::maxLoadManhattenDistance(Vertex* drvr)
+int
+Resizer::maxLoadManhattenDistance(Vertex *drvr)
 {
   int max_dist = 0;
   Point drvr_loc = db_network_->location(drvr->pin());
   VertexOutEdgeIterator edge_iter(drvr, graph_);
   while (edge_iter.hasNext()) {
-    Edge* edge = edge_iter.next();
-    Vertex* load = edge->to(graph_);
+    Edge *edge = edge_iter.next();
+    Vertex *load = edge->to(graph_);
     Point load_loc = db_network_->location(load->pin());
     int dist = Point::manhattanDistance(drvr_loc, load_loc);
     max_dist = max(max_dist, dist);
@@ -1632,12 +1712,13 @@ int Resizer::maxLoadManhattenDistance(Vertex* drvr)
 
 ////////////////////////////////////////////////////////////////
 
-NetSeq* Resizer::findFloatingNets()
+NetSeq *
+Resizer::findFloatingNets()
 {
-  NetSeq* floating_nets = new NetSeq;
-  NetIterator* net_iter = network_->netIterator(network_->topInstance());
+  NetSeq *floating_nets = new NetSeq;
+  NetIterator *net_iter = network_->netIterator(network_->topInstance());
   while (net_iter->hasNext()) {
-    Net* net = net_iter->next();
+    Net *net = net_iter->next();
     PinSeq loads;
     PinSeq drvrs;
     PinSet visited_drvrs;
@@ -1653,47 +1734,51 @@ NetSeq* Resizer::findFloatingNets()
 
 ////////////////////////////////////////////////////////////////
 
-string Resizer::makeUniqueNetName()
+string
+Resizer::makeUniqueNetName()
 {
   string node_name;
-  Instance* top_inst = network_->topInstance();
+  Instance *top_inst = network_->topInstance();
   do {
     stringPrint(node_name, "net%d", unique_net_index_++);
   } while (network_->findNet(top_inst, node_name.c_str()));
   return node_name;
 }
 
-Net* Resizer::makeUniqueNet()
+Net *
+Resizer::makeUniqueNet()
 {
   string net_name = makeUniqueNetName();
-  Instance* parent = db_network_->topInstance();
+  Instance *parent = db_network_->topInstance();
   return db_network_->makeNet(net_name.c_str(), parent);
 }
 
-string Resizer::makeUniqueInstName(const char* base_name)
+string
+Resizer::makeUniqueInstName(const char *base_name)
 {
   return makeUniqueInstName(base_name, false);
 }
 
-string Resizer::makeUniqueInstName(const char* base_name, bool underscore)
+string
+Resizer::makeUniqueInstName(const char *base_name,
+                            bool underscore)
 {
   string inst_name;
   do {
-    stringPrint(inst_name,
-                underscore ? "%s_%d" : "%s%d",
-                base_name,
-                unique_inst_index_++);
+    stringPrint(inst_name, underscore ? "%s_%d" : "%s%d",
+                base_name, unique_inst_index_++);
   } while (network_->findInstance(inst_name.c_str()));
   return inst_name;
 }
 
-float Resizer::portFanoutLoad(LibertyPort* port) const
+float
+Resizer::portFanoutLoad(LibertyPort *port) const
 {
   float fanout_load;
   bool exists;
   port->fanoutLoad(fanout_load, exists);
   if (!exists) {
-    LibertyLibrary* lib = port->libertyLibrary();
+    LibertyLibrary *lib = port->libertyLibrary();
     lib->defaultFanoutLoad(fanout_load, exists);
   }
   if (exists)
@@ -1702,10 +1787,11 @@ float Resizer::portFanoutLoad(LibertyPort* port) const
     return 0.0;
 }
 
-float Resizer::bufferDelay(LibertyCell* buffer_cell,
-                           const RiseFall* rf,
-                           float load_cap,
-                           const DcalcAnalysisPt* dcalc_ap)
+float
+Resizer::bufferDelay(LibertyCell *buffer_cell,
+                     const RiseFall *rf,
+                     float load_cap,
+                     const DcalcAnalysisPt *dcalc_ap)
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1715,9 +1801,10 @@ float Resizer::bufferDelay(LibertyCell* buffer_cell,
   return gate_delays[rf->index()];
 }
 
-float Resizer::bufferDelay(LibertyCell* buffer_cell,
-                           float load_cap,
-                           const DcalcAnalysisPt* dcalc_ap)
+float
+Resizer::bufferDelay(LibertyCell *buffer_cell,
+                     float load_cap,
+                     const DcalcAnalysisPt *dcalc_ap)
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1728,12 +1815,13 @@ float Resizer::bufferDelay(LibertyCell* buffer_cell,
              gate_delays[RiseFall::fallIndex()]);
 }
 
-void Resizer::bufferDelays(LibertyCell* buffer_cell,
-                           float load_cap,
-                           const DcalcAnalysisPt* dcalc_ap,
-                           // Return values.
-                           ArcDelay delays[RiseFall::index_count],
-                           Slew slews[RiseFall::index_count])
+void
+Resizer::bufferDelays(LibertyCell *buffer_cell,
+                      float load_cap,
+                      const DcalcAnalysisPt *dcalc_ap,
+                      // Return values.
+                      ArcDelay delays[RiseFall::index_count],
+                      Slew slews[RiseFall::index_count])
 {
   LibertyPort *input, *output;
   buffer_cell->bufferPorts(input, output);
@@ -1742,35 +1830,31 @@ void Resizer::bufferDelays(LibertyCell* buffer_cell,
 
 // Rise/fall delays across all timing arcs into drvr_port.
 // Uses target slew for input slew.
-void Resizer::gateDelays(LibertyPort* drvr_port,
-                         float load_cap,
-                         const DcalcAnalysisPt* dcalc_ap,
-                         // Return values.
-                         ArcDelay delays[RiseFall::index_count],
-                         Slew slews[RiseFall::index_count])
+void
+Resizer::gateDelays(LibertyPort *drvr_port,
+                    float load_cap,
+                    const DcalcAnalysisPt *dcalc_ap,
+                    // Return values.
+                    ArcDelay delays[RiseFall::index_count],
+                    Slew slews[RiseFall::index_count])
 {
   for (int rf_index : RiseFall::rangeIndex()) {
     delays[rf_index] = -INF;
     slews[rf_index] = -INF;
   }
-  const Pvt* pvt = dcalc_ap->operatingConditions();
-  LibertyCell* cell = drvr_port->libertyCell();
-  for (TimingArcSet* arc_set : cell->timingArcSets()) {
-    if (arc_set->to() == drvr_port && !arc_set->role()->isTimingCheck()) {
-      for (TimingArc* arc : arc_set->arcs()) {
-        RiseFall* in_rf = arc->fromEdge()->asRiseFall();
+  const Pvt *pvt = dcalc_ap->operatingConditions();
+  LibertyCell *cell = drvr_port->libertyCell();
+  for (TimingArcSet *arc_set : cell->timingArcSets()) {
+    if (arc_set->to() == drvr_port
+        && !arc_set->role()->isTimingCheck()) {
+      for (TimingArc *arc : arc_set->arcs()) {
+        RiseFall *in_rf = arc->fromEdge()->asRiseFall();
         int out_rf_index = arc->toEdge()->asRiseFall()->index();
         float in_slew = tgt_slews_[in_rf->index()];
         ArcDelay gate_delay;
         Slew drvr_slew;
-        arc_delay_calc_->gateDelay(cell,
-                                   arc,
-                                   in_slew,
-                                   load_cap,
-                                   nullptr,
-                                   0.0,
-                                   pvt,
-                                   dcalc_ap,
+        arc_delay_calc_->gateDelay(cell, arc, in_slew, load_cap,
+                                   nullptr, 0.0, pvt, dcalc_ap,
                                    gate_delay,
                                    drvr_slew);
         delays[out_rf_index] = max(delays[out_rf_index], gate_delay);
@@ -1780,10 +1864,11 @@ void Resizer::gateDelays(LibertyPort* drvr_port,
   }
 }
 
-ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
-                            const RiseFall* rf,
-                            float load_cap,
-                            const DcalcAnalysisPt* dcalc_ap)
+ArcDelay
+Resizer::gateDelay(LibertyPort *drvr_port,
+                   const RiseFall *rf,
+                   float load_cap,
+                   const DcalcAnalysisPt *dcalc_ap)
 {
   ArcDelay delays[RiseFall::index_count];
   Slew slews[RiseFall::index_count];
@@ -1791,9 +1876,10 @@ ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
   return delays[rf->index()];
 }
 
-ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
-                            float load_cap,
-                            const DcalcAnalysisPt* dcalc_ap)
+ArcDelay
+Resizer::gateDelay(LibertyPort *drvr_port,
+                   float load_cap,
+                   const DcalcAnalysisPt *dcalc_ap)
 {
   ArcDelay delays[RiseFall::index_count];
   Slew slews[RiseFall::index_count];
@@ -1803,7 +1889,8 @@ ArcDelay Resizer::gateDelay(LibertyPort* drvr_port,
 
 ////////////////////////////////////////////////////////////////
 
-double Resizer::findMaxWireLength()
+double
+Resizer::findMaxWireLength()
 {
   init();
   findBuffers();
@@ -1811,12 +1898,13 @@ double Resizer::findMaxWireLength()
   return findMaxWireLength1();
 }
 
-double Resizer::findMaxWireLength1()
+double
+Resizer::findMaxWireLength1()
 {
   double max_length = INF;
-  for (const Corner* corner : *sta_->corners()) {
+  for (const Corner *corner : *sta_->corners()) {
     if (wireSignalResistance(corner) > 0.0) {
-      for (LibertyCell* buffer_cell : buffer_cells_) {
+      for (LibertyCell *buffer_cell : buffer_cells_) {
         double buffer_length = findMaxWireLength(buffer_cell, corner);
         max_length = min(max_length, buffer_length);
       }
@@ -1827,8 +1915,9 @@ double Resizer::findMaxWireLength1()
 
 // Find the max wire length before it is faster to split the wire
 // in half with a buffer (in meters).
-double Resizer::findMaxWireLength(LibertyCell* buffer_cell,
-                                  const Corner* corner)
+double
+Resizer::findMaxWireLength(LibertyCell *buffer_cell,
+                           const Corner *corner)
 {
   initBlock();
   LibertyPort *load_port, *drvr_port;
@@ -1836,9 +1925,11 @@ double Resizer::findMaxWireLength(LibertyCell* buffer_cell,
   return findMaxWireLength(drvr_port, corner);
 }
 
-double Resizer::findMaxWireLength(LibertyPort* drvr_port, const Corner* corner)
+double
+Resizer::findMaxWireLength(LibertyPort *drvr_port,
+                           const Corner *corner)
 {
-  LibertyCell* cell = drvr_port->libertyCell();
+  LibertyCell *cell = drvr_port->libertyCell();
   if (db_network_->staToDb(cell) == nullptr)
     logger_->error(RSZ, 70, "no LEF cell for {}.", cell->name());
   double drvr_r = drvr_port->driveResistance();
@@ -1847,21 +1938,22 @@ double Resizer::findMaxWireLength(LibertyPort* drvr_port, const Corner* corner)
   double wire_length1 = 0.0;
   // Initial guess with wire resistance same as driver resistance.
   double wire_length2 = drvr_r / wireSignalResistance(corner);
-  double tol = .01;  // 1%
+  double tol = .01; // 1%
   double diff1 = splitWireDelayDiff(wire_length2, cell);
   // binary search for diff = 0.
-  while (abs(wire_length1 - wire_length2)
-         > max(wire_length1, wire_length2) * tol) {
+  while (abs(wire_length1 - wire_length2) > max(wire_length1, wire_length2) * tol) {
     if (diff1 < 0.0) {
       wire_length1 = wire_length2;
       wire_length2 *= 2;
       diff1 = splitWireDelayDiff(wire_length2, cell);
-    } else {
+    }
+    else {
       double wire_length3 = (wire_length1 + wire_length2) / 2.0;
       double diff2 = splitWireDelayDiff(wire_length3, cell);
       if (diff2 < 0.0) {
         wire_length1 = wire_length3;
-      } else {
+      }
+      else {
         wire_length2 = wire_length3;
         diff1 = diff2;
       }
@@ -1871,7 +1963,9 @@ double Resizer::findMaxWireLength(LibertyPort* drvr_port, const Corner* corner)
 }
 
 // objective function
-double Resizer::splitWireDelayDiff(double wire_length, LibertyCell* buffer_cell)
+double
+Resizer::splitWireDelayDiff(double wire_length,
+                            LibertyCell *buffer_cell)
 {
   Delay delay1, delay2;
   Slew slew1, slew2;
@@ -1880,11 +1974,12 @@ double Resizer::splitWireDelayDiff(double wire_length, LibertyCell* buffer_cell)
   return delay1 - delay2 * 2;
 }
 
-void Resizer::bufferWireDelay(LibertyCell* buffer_cell,
-                              double wire_length,  // meters
-                              // Return values.
-                              Delay& delay,
-                              Slew& slew)
+void
+Resizer::bufferWireDelay(LibertyCell *buffer_cell,
+                         double wire_length, // meters
+                         // Return values.
+                         Delay &delay,
+                         Slew &slew)
 {
   LibertyPort *load_port, *drvr_port;
   buffer_cell->bufferPorts(load_port, drvr_port);
@@ -1894,61 +1989,57 @@ void Resizer::bufferWireDelay(LibertyCell* buffer_cell,
 // Cell delay plus wire delay.
 // Use target slew for input slew.
 // drvr_port and load_port do not have to be the same liberty cell.
-void Resizer::cellWireDelay(LibertyPort* drvr_port,
-                            LibertyPort* load_port,
-                            double wire_length,  // meters
-                            // Return values.
-                            Delay& delay,
-                            Slew& slew)
+void
+Resizer::cellWireDelay(LibertyPort *drvr_port,
+                       LibertyPort *load_port,
+                       double wire_length, // meters
+                       // Return values.
+                       Delay &delay,
+                       Slew &slew)
 {
   // Make a (hierarchical) block to use as a scratchpad.
-  dbBlock* block = dbBlock::create(block_, "wire_delay", '/');
-  dbSta* sta = makeBlockSta(openroad_, block);
-  Parasitics* parasitics = sta->parasitics();
-  Network* network = sta->network();
-  ArcDelayCalc* arc_delay_calc = sta->arcDelayCalc();
-  Corners* corners = sta->corners();
+  dbBlock *block = dbBlock::create(block_, "wire_delay", '/');
+  dbSta *sta = makeBlockSta(openroad_, block);
+  Parasitics *parasitics = sta->parasitics();
+  Network *network = sta->network();
+  ArcDelayCalc *arc_delay_calc = sta->arcDelayCalc();
+  Corners *corners = sta->corners();
   corners->copy(sta_->corners());
 
-  Instance* top_inst = network->topInstance();
+  Instance *top_inst = network->topInstance();
   // Tmp net for parasitics to live on.
-  Net* net = sta->makeNet("wire", top_inst);
-  LibertyCell* drvr_cell = drvr_port->libertyCell();
-  LibertyCell* load_cell = load_port->libertyCell();
-  Instance* drvr = sta->makeInstance("drvr", drvr_cell, top_inst);
-  Instance* load = sta->makeInstance("load", load_cell, top_inst);
+  Net *net = sta->makeNet("wire", top_inst);
+  LibertyCell *drvr_cell = drvr_port->libertyCell();
+  LibertyCell *load_cell = load_port->libertyCell();
+  Instance *drvr = sta->makeInstance("drvr", drvr_cell, top_inst);
+  Instance *load = sta->makeInstance("load", load_cell, top_inst);
   sta->connectPin(drvr, drvr_port, net);
   sta->connectPin(load, load_port, net);
-  Pin* drvr_pin = network->findPin(drvr, drvr_port);
-  Pin* load_pin = network->findPin(load, load_port);
+  Pin *drvr_pin = network->findPin(drvr, drvr_port);
+  Pin *load_pin = network->findPin(load, load_port);
 
   // Max rise/fall delays.
   delay = -INF;
   slew = -INF;
 
-  for (Corner* corner : *corners) {
-    const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
-    const Pvt* pvt = dcalc_ap->operatingConditions();
+  for (Corner *corner : *corners) {
+    const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
+    const Pvt *pvt = dcalc_ap->operatingConditions();
 
     makeWireParasitic(net, drvr_pin, load_pin, wire_length, corner, parasitics);
     // Let delay calc reduce parasitic network as it sees fit.
-    Parasitic* drvr_parasitic
-        = arc_delay_calc->findParasitic(drvr_pin, RiseFall::rise(), dcalc_ap);
-    for (TimingArcSet* arc_set : drvr_cell->timingArcSets()) {
+    Parasitic *drvr_parasitic = arc_delay_calc->findParasitic(drvr_pin,
+                                                              RiseFall::rise(),
+                                                              dcalc_ap);
+    for (TimingArcSet *arc_set : drvr_cell->timingArcSets()) {
       if (arc_set->to() == drvr_port) {
-        for (TimingArc* arc : arc_set->arcs()) {
-          RiseFall* in_rf = arc->fromEdge()->asRiseFall();
+        for (TimingArc *arc : arc_set->arcs()) {
+          RiseFall *in_rf = arc->fromEdge()->asRiseFall();
           double in_slew = tgt_slews_[in_rf->index()];
           ArcDelay gate_delay;
           Slew drvr_slew;
-          arc_delay_calc->gateDelay(drvr_cell,
-                                    arc,
-                                    in_slew,
-                                    0.0,
-                                    drvr_parasitic,
-                                    0.0,
-                                    pvt,
-                                    dcalc_ap,
+          arc_delay_calc->gateDelay(drvr_cell, arc, in_slew, 0.0,
+                                    drvr_parasitic, 0.0, pvt, dcalc_ap,
                                     gate_delay,
                                     drvr_slew);
           ArcDelay wire_delay;
@@ -1971,19 +2062,20 @@ void Resizer::cellWireDelay(LibertyPort* drvr_port,
   dbBlock::destroy(block);
 }
 
-void Resizer::makeWireParasitic(Net* net,
-                                Pin* drvr_pin,
-                                Pin* load_pin,
-                                double wire_length,  // meters
-                                const Corner* corner,
-                                Parasitics* parasitics)
+void
+Resizer::makeWireParasitic(Net *net,
+                           Pin *drvr_pin,
+                           Pin *load_pin,
+                           double wire_length, // meters
+                           const Corner *corner,
+                           Parasitics *parasitics)
 {
-  const ParasiticAnalysisPt* parasitics_ap
-      = corner->findParasiticAnalysisPt(max_);
-  Parasitic* parasitic
-      = parasitics->makeParasiticNetwork(net, false, parasitics_ap);
-  ParasiticNode* n1 = parasitics->ensureParasiticNode(parasitic, drvr_pin);
-  ParasiticNode* n2 = parasitics->ensureParasiticNode(parasitic, load_pin);
+  const ParasiticAnalysisPt *parasitics_ap =
+    corner->findParasiticAnalysisPt(max_);
+  Parasitic *parasitic = parasitics->makeParasiticNetwork(net, false,
+                                                          parasitics_ap);
+  ParasiticNode *n1 = parasitics->ensureParasiticNode(parasitic, drvr_pin);
+  ParasiticNode *n2 = parasitics->ensureParasiticNode(parasitic, load_pin);
   double wire_cap = wire_length * wireSignalCapacitance(corner);
   double wire_res = wire_length * wireSignalResistance(corner);
   parasitics->incrCap(n1, wire_cap / 2.0, parasitics_ap);
@@ -1993,22 +2085,25 @@ void Resizer::makeWireParasitic(Net* net,
 
 ////////////////////////////////////////////////////////////////
 
-double Resizer::designArea()
+double
+Resizer::designArea()
 {
   initDesignArea();
   return design_area_;
 }
 
-void Resizer::designAreaIncr(float delta)
+void
+Resizer::designAreaIncr(float delta)
 {
   design_area_ += delta;
 }
 
-void Resizer::initDesignArea()
+void
+Resizer::initDesignArea()
 {
   design_area_ = 0.0;
-  for (dbInst* inst : block_->getInsts()) {
-    dbMaster* master = inst->getMaster();
+  for (dbInst *inst : block_->getInsts()) {
+    dbMaster *master = inst->getMaster();
     // Don't count fillers otherwise you'll always get 100% utilization
     if (!master->isFiller()) {
       design_area_ += area(master);
@@ -2016,43 +2111,47 @@ void Resizer::initDesignArea()
   }
 }
 
-bool Resizer::isFuncOneZero(const Pin* drvr_pin)
+bool
+Resizer::isFuncOneZero(const Pin *drvr_pin)
 {
-  LibertyPort* port = network_->libertyPort(drvr_pin);
+  LibertyPort *port = network_->libertyPort(drvr_pin);
   if (port) {
-    FuncExpr* func = port->function();
-    return func
-           && (func->op() == FuncExpr::op_zero
-               || func->op() == FuncExpr::op_one);
+    FuncExpr *func = port->function();
+    return func && (func->op() == FuncExpr::op_zero
+                    || func->op() == FuncExpr::op_one);
   }
   return false;
 }
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::repairDesign(double max_wire_length,
-                           double slew_margin,
-                           double cap_margin)
+void
+Resizer::repairDesign(double max_wire_length,
+                      double slew_margin,
+                      double cap_margin)
 {
   resizePreamble();
   repair_design_->repairDesign(max_wire_length, slew_margin, cap_margin);
 }
 
-int Resizer::repairDesignBufferCount() const
+int
+Resizer::repairDesignBufferCount() const
 {
   return repair_design_->insertedBufferCount();
 }
 
-void Resizer::repairNet(Net* net,
-                        double max_wire_length,
-                        double slew_margin,
-                        double cap_margin)
+void
+Resizer::repairNet(Net *net,
+                   double max_wire_length,
+                   double slew_margin,
+                   double cap_margin)
 {
   resizePreamble();
   repair_design_->repairNet(net, max_wire_length, slew_margin, cap_margin);
 }
 
-void Resizer::repairClkNets(double max_wire_length)
+void
+Resizer::repairClkNets(double max_wire_length)
 {
   resizePreamble();
   repair_design_->repairClkNets(max_wire_length);
@@ -2062,41 +2161,41 @@ void Resizer::repairClkNets(double max_wire_length)
 
 // Find inverters in the clock network and clone them next to the
 // each register they drive.
-void Resizer::repairClkInverters()
+void
+Resizer::repairClkInverters()
 {
   initBlock();
   initDesignArea();
   sta_->ensureLevelized();
   graph_ = sta_->graph();
-  for (const Instance* inv : findClkInverters()) {
+  for (const Instance *inv : findClkInverters()) {
     if (!dontTouch(inv))
       cloneClkInverter(const_cast<Instance*>(inv));
   }
 }
 
-InstanceSeq Resizer::findClkInverters()
+InstanceSeq
+Resizer::findClkInverters()
 {
   InstanceSeq clk_inverters;
   ClkArrivalSearchPred srch_pred(this);
   BfsFwdIterator bfs(BfsIndex::other, &srch_pred, this);
-  for (Clock* clk : sdc_->clks()) {
-    for (const Pin* pin : clk->leafPins()) {
-      Vertex* vertex = graph_->pinDrvrVertex(pin);
+  for (Clock *clk : sdc_->clks()) {
+    for (const Pin *pin : clk->leafPins()) {
+      Vertex *vertex = graph_->pinDrvrVertex(pin);
       bfs.enqueue(vertex);
     }
   }
   while (bfs.hasNext()) {
-    Vertex* vertex = bfs.next();
-    const Pin* pin = vertex->pin();
-    Instance* inst = network_->instance(pin);
-    LibertyCell* lib_cell = network_->libertyCell(inst);
-    if (vertex->isDriver(network_) && lib_cell && lib_cell->isInverter()) {
+    Vertex *vertex = bfs.next();
+    const Pin *pin = vertex->pin();
+    Instance *inst = network_->instance(pin);
+    LibertyCell *lib_cell = network_->libertyCell(inst);
+    if (vertex->isDriver(network_)
+        && lib_cell
+        && lib_cell->isInverter()) {
       clk_inverters.push_back(inst);
-      debugPrint(logger_,
-                 RSZ,
-                 "repair_clk_inverters",
-                 2,
-                 "inverter {}",
+      debugPrint(logger_, RSZ, "repair_clk_inverters", 2, "inverter {}",
                  network_->pathName(inst));
     }
     if (!vertex->isRegClk())
@@ -2105,42 +2204,43 @@ InstanceSeq Resizer::findClkInverters()
   return clk_inverters;
 }
 
-void Resizer::cloneClkInverter(Instance* inv)
+void
+Resizer::cloneClkInverter(Instance *inv)
 {
-  LibertyCell* inv_cell = network_->libertyCell(inv);
+  LibertyCell *inv_cell = network_->libertyCell(inv);
   LibertyPort *in_port, *out_port;
   inv_cell->bufferPorts(in_port, out_port);
-  Pin* in_pin = network_->findPin(inv, in_port);
-  Pin* out_pin = network_->findPin(inv, out_port);
-  Net* in_net = network_->net(in_pin);
-  dbNet* in_net_db = db_network_->staToDb(in_net);
-  Net* out_net = network_->isTopLevelPort(out_pin)
-                     ? network_->net(network_->term(out_pin))
-                     : network_->net(out_pin);
+  Pin *in_pin = network_->findPin(inv, in_port);
+  Pin *out_pin = network_->findPin(inv, out_port);
+  Net *in_net = network_->net(in_pin);
+  dbNet *in_net_db = db_network_->staToDb(in_net);
+  Net *out_net = network_->isTopLevelPort(out_pin)
+    ? network_->net(network_->term(out_pin))
+    : network_->net(out_pin);
   if (out_net) {
-    const char* inv_name = network_->name(inv);
-    Instance* top_inst = network_->topInstance();
-    NetConnectedPinIterator* load_iter = network_->pinIterator(out_net);
+    const char *inv_name = network_->name(inv);
+    Instance *top_inst = network_->topInstance();
+    NetConnectedPinIterator *load_iter = network_->pinIterator(out_net);
     while (load_iter->hasNext()) {
-      const Pin* load_pin = load_iter->next();
+      const Pin *load_pin = load_iter->next();
       if (load_pin != out_pin) {
         string clone_name = makeUniqueInstName(inv_name, true);
         Point clone_loc = db_network_->location(load_pin);
-        Instance* clone
-            = makeInstance(inv_cell, clone_name.c_str(), top_inst, clone_loc);
+        Instance *clone = makeInstance(inv_cell, clone_name.c_str(),
+                                       top_inst, clone_loc);
         journalMakeBuffer(clone);
 
-        Net* clone_out_net = makeUniqueNet();
-        dbNet* clone_out_net_db = db_network_->staToDb(clone_out_net);
+        Net *clone_out_net = makeUniqueNet();
+        dbNet *clone_out_net_db = db_network_->staToDb(clone_out_net);
         clone_out_net_db->setSigType(in_net_db->getSigType());
 
-        Instance* load = network_->instance(load_pin);
+        Instance *load = network_->instance(load_pin);
         sta_->connectPin(clone, in_port, in_net);
         sta_->connectPin(clone, out_port, clone_out_net);
 
         // Connect load to clone
         sta_->disconnectPin(const_cast<Pin*>(load_pin));
-        Port* load_port = network_->port(load_pin);
+        Port *load_port = network_->port(load_pin);
         sta_->connectPin(load, load_port, clone_out_net);
       }
     }
@@ -2157,21 +2257,24 @@ void Resizer::cloneClkInverter(Instance* inv)
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::repairSetup(double setup_margin,
-                          double repair_tns_end_percent,
-                          int max_passes)
+void
+Resizer::repairSetup(double setup_margin,
+                     double repair_tns_end_percent,
+                     int max_passes)
 {
   resizePreamble();
   repair_setup_->repairSetup(setup_margin, repair_tns_end_percent, max_passes);
 }
 
-void Resizer::repairSetup(const Pin* end_pin)
+void
+Resizer::repairSetup(const Pin *end_pin)
 {
   resizePreamble();
   repair_setup_->repairSetup(end_pin);
 }
 
-void Resizer::rebufferNet(const Pin* drvr_pin)
+void
+Resizer::rebufferNet(const Pin *drvr_pin)
 {
   resizePreamble();
   repair_setup_->rebufferNet(drvr_pin);
@@ -2179,39 +2282,36 @@ void Resizer::rebufferNet(const Pin* drvr_pin)
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::repairHold(
-    double setup_margin,
-    double hold_margin,
-    bool allow_setup_violations,
-    // Max buffer count as percent of design instance count.
-    float max_buffer_percent,
-    int max_passes)
+void
+Resizer::repairHold(double setup_margin,
+                    double hold_margin,
+                    bool allow_setup_violations,
+                    // Max buffer count as percent of design instance count.
+                    float max_buffer_percent,
+                    int max_passes)
 {
   resizePreamble();
-  repair_hold_->repairHold(setup_margin,
-                           hold_margin,
+  repair_hold_->repairHold(setup_margin, hold_margin,
                            allow_setup_violations,
-                           max_buffer_percent,
-                           max_passes);
+                           max_buffer_percent, max_passes);
 }
 
-void Resizer::repairHold(const Pin* end_pin,
-                         double setup_margin,
-                         double hold_margin,
-                         bool allow_setup_violations,
-                         float max_buffer_percent,
-                         int max_passes)
+void
+Resizer::repairHold(const Pin *end_pin,
+                    double setup_margin,
+                    double hold_margin,
+                    bool allow_setup_violations,
+                    float max_buffer_percent,
+                    int max_passes)
 {
   resizePreamble();
-  repair_hold_->repairHold(end_pin,
-                           setup_margin,
-                           hold_margin,
+  repair_hold_->repairHold(end_pin, setup_margin, hold_margin,
                            allow_setup_violations,
-                           max_buffer_percent,
-                           max_passes);
+                           max_buffer_percent, max_passes);
 }
 
-int Resizer::holdBufferCount() const
+int
+Resizer::holdBufferCount() const
 {
   return repair_hold_->holdBufferCount();
 }
@@ -2219,28 +2319,27 @@ int Resizer::holdBufferCount() const
 ////////////////////////////////////////////////////////////////
 
 // Journal to roll back changes (OpenDB not up to the task).
-void Resizer::journalBegin()
+void
+Resizer::journalBegin()
 {
   debugPrint(logger_, RSZ, "journal", 1, "journal begin");
   resized_inst_map_.clear();
   inserted_buffers_.clear();
 }
 
-void Resizer::journalEnd()
+void
+Resizer::journalEnd()
 {
   debugPrint(logger_, RSZ, "journal", 1, "journal end");
   resized_inst_map_.clear();
   inserted_buffers_.clear();
 }
 
-void Resizer::journalInstReplaceCellBefore(Instance* inst)
+void
+Resizer::journalInstReplaceCellBefore(Instance *inst)
 {
-  LibertyCell* lib_cell = network_->libertyCell(inst);
-  debugPrint(logger_,
-             RSZ,
-             "journal",
-             1,
-             "journal replace {} ({})",
+  LibertyCell *lib_cell = network_->libertyCell(inst);
+  debugPrint(logger_, RSZ, "journal", 1, "journal replace {} ({})",
              network_->pathName(inst),
              lib_cell->name());
   // Do not clobber an existing checkpoint cell.
@@ -2248,27 +2347,22 @@ void Resizer::journalInstReplaceCellBefore(Instance* inst)
     resized_inst_map_[inst] = lib_cell;
 }
 
-void Resizer::journalMakeBuffer(Instance* buffer)
+void
+Resizer::journalMakeBuffer(Instance *buffer)
 {
-  debugPrint(logger_,
-             RSZ,
-             "journal",
-             1,
-             "journal make_buffer {}",
+  debugPrint(logger_, RSZ, "journal", 1, "journal make_buffer {}",
              network_->pathName(buffer));
   inserted_buffers_.push_back(buffer);
   inserted_buffer_set_.insert(buffer);
 }
 
-void Resizer::journalRestore(int& resize_count, int& inserted_buffer_count)
+void
+Resizer::journalRestore(int &resize_count,
+                        int &inserted_buffer_count)
 {
   for (auto [inst, lib_cell] : resized_inst_map_) {
     if (!inserted_buffer_set_.hasKey(inst)) {
-      debugPrint(logger_,
-                 RSZ,
-                 "journal",
-                 1,
-                 "journal restore {} ({})",
+      debugPrint(logger_, RSZ, "journal", 1, "journal restore {} ({})",
                  network_->pathName(inst),
                  lib_cell->name());
       replaceCell(inst, lib_cell, false);
@@ -2276,12 +2370,8 @@ void Resizer::journalRestore(int& resize_count, int& inserted_buffer_count)
     }
   }
   while (!inserted_buffers_.empty()) {
-    const Instance* buffer = inserted_buffers_.back();
-    debugPrint(logger_,
-               RSZ,
-               "journal",
-               1,
-               "journal remove {}",
+  const Instance *buffer = inserted_buffers_.back();
+    debugPrint(logger_, RSZ, "journal", 1, "journal remove {}",
                network_->pathName(buffer));
     removeBuffer(const_cast<Instance*>(buffer));
     inserted_buffers_.pop_back();
@@ -2292,42 +2382,47 @@ void Resizer::journalRestore(int& resize_count, int& inserted_buffer_count)
 
 ////////////////////////////////////////////////////////////////
 
-Instance* Resizer::makeBuffer(LibertyCell* cell,
-                              const char* name,
-                              Instance* parent,
-                              Point loc)
+Instance *
+Resizer::makeBuffer(LibertyCell *cell,
+                    const char *name,
+                    Instance *parent,
+                    Point loc)
 {
-  Instance* inst = makeInstance(cell, name, parent, loc);
+  Instance *inst = makeInstance(cell, name, parent, loc);
   journalMakeBuffer(inst);
   return inst;
 }
 
-Instance* Resizer::makeInstance(LibertyCell* cell,
-                                const char* name,
-                                Instance* parent,
-                                Point loc)
+Instance *
+Resizer::makeInstance(LibertyCell *cell,
+                      const char *name,
+                      Instance *parent,
+                      Point loc)
 {
   debugPrint(logger_, RSZ, "make_instance", 1, "make instance {}", name);
-  Instance* inst = db_network_->makeInstance(cell, name, parent);
-  dbInst* db_inst = db_network_->staToDb(inst);
+  Instance *inst = db_network_->makeInstance(cell, name, parent);
+  dbInst *db_inst = db_network_->staToDb(inst);
   db_inst->setSourceType(odb::dbSourceType::TIMING);
   setLocation(db_inst, loc);
   designAreaIncr(area(db_inst->getMaster()));
   return inst;
 }
 
-void Resizer::setLocation(dbInst* db_inst, Point pt)
+void
+Resizer::setLocation(dbInst *db_inst,
+                     Point pt)
 {
   int x = pt.x();
   int y = pt.y();
   // Stay inside the lines.
   if (core_exists_) {
-    dbMaster* master = db_inst->getMaster();
+    dbMaster *master = db_inst->getMaster();
     int width = master->getWidth();
     if (x < core_.xMin()) {
       x = core_.xMin();
       buffer_moved_into_core_ = true;
-    } else if (x > core_.xMax() - width) {
+    }
+    else if (x > core_.xMax() - width) {
       // Make sure the instance is entirely inside core.
       x = core_.xMax() - width;
       buffer_moved_into_core_ = true;
@@ -2337,7 +2432,8 @@ void Resizer::setLocation(dbInst* db_inst, Point pt)
     if (y < core_.yMin()) {
       y = core_.yMin();
       buffer_moved_into_core_ = true;
-    } else if (y > core_.yMax() - height) {
+    }
+    else if (y > core_.yMax() - height) {
       y = core_.yMax() - height;
       buffer_moved_into_core_ = true;
     }
@@ -2347,16 +2443,19 @@ void Resizer::setLocation(dbInst* db_inst, Point pt)
   db_inst->setLocation(x, y);
 }
 
-float Resizer::portCapacitance(LibertyPort* input, const Corner* corner) const
+float
+Resizer::portCapacitance(LibertyPort *input,
+                         const Corner *corner) const
 {
-  const DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(max_);
+  const DcalcAnalysisPt *dcalc_ap = corner->findDcalcAnalysisPt(max_);
   int lib_ap = dcalc_ap->libertyIndex();
-  LibertyPort* corner_input = input->cornerPort(lib_ap);
+  LibertyPort *corner_input = input->cornerPort(lib_ap);
   return corner_input->capacitance();
 }
 
-float Resizer::maxInputSlew(const LibertyPort* input,
-                            const Corner* corner) const
+float
+Resizer::maxInputSlew(const LibertyPort *input,
+                      const Corner *corner) const
 {
   float limit;
   bool exists;
@@ -2367,26 +2466,27 @@ float Resizer::maxInputSlew(const LibertyPort* input,
   return limit;
 }
 
-void Resizer::checkLoadSlews(const Pin* drvr_pin,
-                             double slew_margin,
-                             // Return values.
-                             Slew& slew,
-                             float& limit,
-                             float& slack,
-                             const Corner*& corner)
+void
+Resizer::checkLoadSlews(const Pin *drvr_pin,
+                        double slew_margin,
+                        // Return values.
+                        Slew &slew,
+                        float &limit,
+                        float &slack,
+                        const Corner *&corner)
 {
   slack = INF;
   limit = INF;
-  PinConnectedPinIterator* pin_iter = network_->connectedPinIterator(drvr_pin);
+  PinConnectedPinIterator *pin_iter = network_->connectedPinIterator(drvr_pin);
   while (pin_iter->hasNext()) {
-    const Pin* pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     if (pin != drvr_pin) {
-      const Corner* corner1;
-      const RiseFall* tr1;
+      const Corner *corner1;
+      const RiseFall *tr1;
       Slew slew1;
       float limit1, slack1;
-      sta_->checkSlew(
-          pin, nullptr, max_, false, corner1, tr1, slew1, limit1, slack1);
+      sta_->checkSlew(pin, nullptr, max_, false,
+                      corner1, tr1, slew1, limit1, slack1);
       if (corner1) {
         limit1 *= (1.0 - slew_margin / 100.0);
         limit = min(limit, limit1);
@@ -2402,20 +2502,23 @@ void Resizer::checkLoadSlews(const Pin* drvr_pin,
   delete pin_iter;
 }
 
-void Resizer::warnBufferMovedIntoCore()
+void
+Resizer::warnBufferMovedIntoCore()
 {
   if (buffer_moved_into_core_)
     logger_->warn(RSZ, 77, "some buffers were moved inside the core.");
 }
 
-void Resizer::setDebugPin(const Pin* pin)
+void
+Resizer::setDebugPin(const Pin *pin)
 {
   debug_pin_ = pin;
 }
 
-void Resizer::setWorstSlackNetsPercent(float percent)
+void
+Resizer::setWorstSlackNetsPercent(float percent)
 {
   worst_slack_nets_percent_ = percent;
 }
 
-}  // namespace rsz
+} // namespace

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -208,6 +208,7 @@ void Resizer::init(OpenRoad* openroad,
   global_router_ = global_router;
   incr_groute_ = nullptr;
   db_network_ = sta->getDbNetwork();
+  inserted_buffer_set_ = InstanceSet(db_network_);
   copyState(sta);
   // Define swig TCL commands.
   Rsz_Init(interp);

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -122,8 +122,8 @@ using rsz::ParasiticsSrc;
   NetSeq *nets = $1;
   NetSeq::Iterator net_iter(nets);
   while (net_iter.hasNext()) {
-    Net *net = net_iter.next();
-    Tcl_Obj *obj = SWIG_NewInstanceObj(net, SWIGTYPE_p_Net, false);
+    const Net *net = net_iter.next();
+    Tcl_Obj *obj = SWIG_NewInstanceObj(const_cast<Net*>(net), SWIGTYPE_p_Net, false);
     Tcl_ListObjAppendElement(interp, list, obj);
   }
   delete nets;
@@ -135,8 +135,8 @@ using rsz::ParasiticsSrc;
   NetSeq *nets = $1;
   NetSeq::Iterator net_iter(nets);
   while (net_iter.hasNext()) {
-    Net *net = net_iter.next();
-    Tcl_Obj *obj = SWIG_NewInstanceObj(net, SWIGTYPE_p_Net, false);
+    const Net *net = net_iter.next();
+    Tcl_Obj *obj = SWIG_NewInstanceObj(const_cast<Net*>(net), SWIGTYPE_p_Net, false);
     Tcl_ListObjAppendElement(interp, list, obj);
   }
   Tcl_SetObjResult(interp, list);
@@ -147,16 +147,12 @@ using rsz::ParasiticsSrc;
   Tcl_SetObjResult(interp, obj);
 }
 
-%typemap(in) PinSet* {
-  $1 = tclListSetPin($input, interp);
-}
-
 %typemap(out) PinSet {
   Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
   PinSet::Iterator pin_iter($1);
   while (pin_iter.hasNext()) {
-    Pin *pin = pin_iter.next();
-    Tcl_Obj *obj = SWIG_NewInstanceObj(pin, SWIGTYPE_p_Pin, false);
+    const Pin *pin = pin_iter.next();
+    Tcl_Obj *obj = SWIG_NewInstanceObj(const_cast<Pin*>(pin), SWIGTYPE_p_Pin, false);
     Tcl_ListObjAppendElement(interp, list, obj);
   }
   Tcl_SetObjResult(interp, list);
@@ -626,7 +622,7 @@ highlight_steiner_tree(const Pin *drvr_pin)
 }
 
 PinSet
-find_fanin_fanouts(PinSet *pins)
+find_fanin_fanouts(PinSet& pins)
 {
   Resizer *resizer = getResizer();
   return resizer->findFaninFanouts(pins);

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -42,6 +42,7 @@
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
 #include "sta/Liberty.hh"
+#include "db_sta/dbNetwork.hh"
 
 namespace ord {
 // Defined in OpenRoad.i
@@ -92,6 +93,29 @@ using sta::stringEq;
 using rsz::Resizer;
 using rsz::ParasiticsSrc;
 
+template <class SET_TYPE, class OBJECT_TYPE>
+SET_TYPE *
+tclListNetworkSet(Tcl_Obj *const source,
+                  swig_type_info *swig_type,
+                  Tcl_Interp *interp,
+                  const Network *network)
+{
+  int argc;
+  Tcl_Obj **argv;
+  if (Tcl_ListObjGetElements(interp, source, &argc, &argv) == TCL_OK
+      && argc > 0) {
+    SET_TYPE *set = new SET_TYPE(network);
+    for (int i = 0; i < argc; i++) {
+      void *obj;
+      // Ignore returned TCL_ERROR because can't get swig_type_info.
+      SWIG_ConvertPtr(argv[i], &obj, swig_type, false);
+      set->insert(reinterpret_cast<OBJECT_TYPE*>(obj));
+    }
+    return set;
+  }
+  else
+    return nullptr;
+}
 %}
 
 ////////////////////////////////////////////////////////////////
@@ -145,6 +169,12 @@ using rsz::ParasiticsSrc;
 %typemap(out) LibertyPort* {
   Tcl_Obj *obj = SWIG_NewInstanceObj($1, $1_descriptor, false);
   Tcl_SetObjResult(interp, obj);
+}
+
+%typemap(in) PinSet* {
+  Resizer *resizer = getResizer();
+  dbNetwork *network = resizer->getDbNetwork();
+  $1 = tclListNetworkSet<PinSet, Pin>($input, SWIGTYPE_p_Pin, interp, network);
 }
 
 %typemap(out) PinSet {
@@ -622,10 +652,10 @@ highlight_steiner_tree(const Pin *drvr_pin)
 }
 
 PinSet
-find_fanin_fanouts(PinSet& pins)
+find_fanin_fanouts(PinSet* pins)
 {
   Resizer *resizer = getResizer();
-  return resizer->findFaninFanouts(pins);
+  return resizer->findFaninFanouts(*pins);
 }
 
 void

--- a/src/rsz/src/SteinerTree.cc
+++ b/src/rsz/src/SteinerTree.cc
@@ -94,7 +94,7 @@ Resizer::makeSteinerTree(const Pin *drvr_pin)
     vector<int> x, y;
     int drvr_idx = 0;
     for (int i = 0; i < pin_count; i++) {
-      Pin *pin = pins[i];
+      const Pin *pin = pins[i];
       if (pin == drvr_pin)
         drvr_idx = i;
       Point loc = db_network_->location(pin);
@@ -130,7 +130,7 @@ connectedPins(const Net *net,
 {
   NetConnectedPinIterator *pin_iter = network->connectedPinIterator(net);
   while (pin_iter->hasNext()) {
-    Pin *pin = pin_iter->next();
+    const Pin *pin = pin_iter->next();
     pins.push_back(pin);
   }
   delete pin_iter;
@@ -172,7 +172,7 @@ SteinerTree::branchCount() const
 
 void
 SteinerTree::locAddPin(Point &loc,
-                       Pin *pin)
+                       const Pin *pin)
 {
   PinSeq &pins = loc_pin_map_[loc];
   pins.push_back(pin);

--- a/src/rsz/src/SteinerTree.hh
+++ b/src/rsz/src/SteinerTree.hh
@@ -124,7 +124,7 @@ public:
 
 protected:
   void locAddPin(Point &loc,
-                 Pin *pin);
+                 const Pin *pin);
 
   stt::Tree tree_;
   const Pin *drvr_pin_;

--- a/src/rsz/test/make_parasitics4.ok
+++ b/src/rsz/test/make_parasitics4.ok
@@ -43,7 +43,7 @@ Load pins
 
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
   Delay    Time   Description

--- a/src/rsz/test/remove_buffers1.ok
+++ b/src/rsz/test/remove_buffers1.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 5 nets and 8 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
   Delay    Time   Description
@@ -30,7 +30,7 @@ Path Type: max
 [INFO RSZ-0026] Removed 3 buffers.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
   Delay    Time   Description

--- a/src/rsz/test/remove_buffers2.ok
+++ b/src/rsz/test/remove_buffers2.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 4 nets and 6 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
   Delay    Time   Description
@@ -28,7 +28,7 @@ Path Type: max
 [INFO RSZ-0026] Removed 1 buffers.
 Startpoint: in1 (input port)
 Endpoint: out2 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
   Delay    Time   Description

--- a/src/rsz/test/repair_clk_nets1.ok
+++ b/src/rsz/test/repair_clk_nets1.ok
@@ -15,7 +15,7 @@ CLOCK
 Driver    length delay
 Startpoint: in1 (clock source 'in1')
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
     Cap    Slew   Delay    Time   Description

--- a/src/rsz/test/repair_slew7.ok
+++ b/src/rsz/test/repair_slew7.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 10 nets and 22 connections.
 Startpoint: u1/A4 (internal pin)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 Corner: slow
 
@@ -42,7 +42,7 @@ u1/ZN                                  10.47   15.05   -4.58 (VIOLATED)
 [INFO RSZ-0039] Resized 3 instances.
 Startpoint: u1/A4 (internal pin)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 Corner: slow
 

--- a/src/rsz/test/repair_wire1.ok
+++ b/src/rsz/test/repair_wire1.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 4 nets and 6 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -44,7 +44,7 @@ u3/Z manhtn 1.3 steiner 1.3 0.00
 in1 manhtn 0.7 steiner 0.7 0.00
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description

--- a/src/rsz/test/repair_wire10.ok
+++ b/src/rsz/test/repair_wire10.ok
@@ -20,7 +20,7 @@ delta HPWL                    0 %
 
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
     Cap    Slew   Delay    Time   Description
@@ -48,7 +48,7 @@ in1 manhtn 0.7 steiner 0.7 0.00
 [INFO RSZ-0039] Resized 2 instances.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
     Cap    Slew   Delay    Time   Description

--- a/src/rsz/test/repair_wire2.ok
+++ b/src/rsz/test/repair_wire2.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 5 nets and 8 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -31,7 +31,7 @@ Path Type: max
 
 Startpoint: in1 (input port)
 Endpoint: out2 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -69,7 +69,7 @@ u1/Z manhtn 0.8 steiner 0.8 0.00
 in1 manhtn 0.7 steiner 0.7 0.00
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -92,7 +92,7 @@ Path Type: max
 
 Startpoint: in1 (input port)
 Endpoint: out2 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description

--- a/src/rsz/test/repair_wire6.ok
+++ b/src/rsz/test/repair_wire6.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 3 nets and 4 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -42,7 +42,7 @@ u2/Z manhtn 357.8 steiner 357.8 0.02
 in1 manhtn 0.7 steiner 0.7 0.00
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description

--- a/src/rsz/test/repair_wire7.ok
+++ b/src/rsz/test/repair_wire7.ok
@@ -10,7 +10,7 @@
 [INFO ODB-0133]     Created 4 nets and 6 connections.
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description
@@ -44,7 +44,7 @@ wire1/Z manhtn 566.9 steiner 566.9 0.04
 in1 manhtn 291.4 steiner 291.4 0.01
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 
      Cap     Slew    Delay     Time   Description

--- a/src/rsz/test/repair_wire8.ok
+++ b/src/rsz/test/repair_wire8.ok
@@ -26,7 +26,7 @@ u3/Z                                   60.63    0.00   60.63 (MET)
 
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
-Path Group: (none)
+Path Group: unconstrained
 Path Type: max
 Corner: slow
 


### PR DESCRIPTION
@jjcherry56 @maliberty I have a couple of issues with this PR that I could use some help with. I got the app building, but many of the tests fail either with correctness or segfaulting issues. I need some help to fix, or need someone to take this as a base, and fix the remaining issues.

1. The dbNetwork creates an invalid top_instance_ that causes segfaults in some of the tests

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/3784748/221113882-a364eb1c-66ea-4134-ae53-5b5ffa256575.png">

```c++
// dbNetwork.cc

dbNetwork::dbNetwork() :
  ConcreteNetwork(),
  db_(nullptr),
  logger_(nullptr),
  block_(nullptr),
  top_instance_(reinterpret_cast<Instance*>(1)),
  top_cell_(nullptr)
{
}
```

Seems like this is caused by dbNetwork returning this 0x1 cast Instance * that gets cast to a ConcreteInstance in the visitMatches function. Any thoughts on this @jjcherry56?

```c++
NetSeq
SdcNetwork::findNetsMatching(const Instance *parent,
			     const PatternMatch *pattern) const
{
  NetSeq matches;
  visitMatches(parent, pattern,
	       [&](const Instance *instance,
		   const PatternMatch *tail)
	       {
		 size_t match_count = matches.size();
		 network_->findInstNetsMatching(instance, tail, matches);
		 return matches.size() != match_count;
	       });
  return matches;
}
```

2.  @jjcherry56 There's a number of areas where PinSeq is integrated and then the pin is deleted. These require `const_cast<T*>`'s is this how you intended users to use this API? If not what's the right approach?

<img width="590" alt="image" src="https://user-images.githubusercontent.com/3784748/221114567-74957dd8-19bf-4be8-9ba6-c7fe2c668b8a.png">


