### PR TITLE
pad: fix special net handling

### DIFF
--- a/src/pad/src/ICeWall.cpp
+++ b/src/pad/src/ICeWall.cpp
@@ -166,6 +166,7 @@ void ICeWall::makeBTerm(odb::dbNet* net,
   odb::dbBox::create(
       pin, layer, shape.xMin(), shape.yMin(), shape.xMax(), shape.yMax());
   pin->setPlacementStatus(odb::dbPlacementStatus::FIRM);
+  Utilities::makeSpecial(net);
 }
 
 void ICeWall::assignBump(odb::dbInst* inst, odb::dbNet* net)

--- a/src/pad/src/Utilities.cpp
+++ b/src/pad/src/Utilities.cpp
@@ -42,12 +42,21 @@ namespace pad {
 void Utilities::makeSpecial(odb::dbNet* net)
 {
   net->setSpecial();
+  odb::dbSigType sigtype = net->getSigType();
+  for (auto* iterm : net->getITerms()) {
+    if (iterm->getSigType().isSupply()) {
+      sigtype = iterm->getSigType();
+    }
+  }
+
   for (auto* iterm : net->getITerms()) {
     iterm->setSpecial();
   }
   for (auto* bterm : net->getBTerms()) {
     bterm->setSpecial();
+    bterm->setSigType(sigtype);
   }
+  net->setSigType(sigtype);
 }
 
 }  // namespace pad

--- a/src/pad/test/assign_bumps.defok
+++ b/src/pad/test/assign_bumps.defok
@@ -1521,7 +1521,7 @@ COMPONENTS 1486 ;
     - u_vzz_9 PADCELL_VSSIO_H + FIXED ( 5650000 1250000 ) W ;
 END COMPONENTS
 PINS 139 ;
-    - DVDD + NET DVDD + DIRECTION INPUT + USE POWER
+    - DVDD + NET DVDD + SPECIAL + DIRECTION INPUT + USE POWER
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 1435000 ) N
@@ -1624,7 +1624,7 @@ PINS 139 ;
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 795000 ) N ;
-    - DVSS + NET DVSS + DIRECTION INPUT + USE GROUND
+    - DVSS + NET DVSS + SPECIAL + DIRECTION INPUT + USE GROUND
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 5595000 ) N
@@ -1730,7 +1730,7 @@ PINS 139 ;
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 475000 ) N ;
-    - VDD + NET VDD + DIRECTION INPUT + USE POWER
+    - VDD + NET VDD + SPECIAL + DIRECTION INPUT + USE POWER
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 475000 ) N
@@ -1797,7 +1797,7 @@ PINS 139 ;
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 1115000 ) N ;
-    - VSS + NET VSS + DIRECTION INPUT + USE GROUND
+    - VSS + NET VSS + SPECIAL + DIRECTION INPUT + USE GROUND
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 1435000 ) N
@@ -1849,852 +1849,860 @@ PINS 139 ;
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 1435000 ) N ;
-    - p_bsg_tag_clk_i + NET p_bsg_tag_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_clk_i + NET p_bsg_tag_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 3035000 ) N ;
-    - p_bsg_tag_clk_o + NET p_bsg_tag_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_bsg_tag_clk_o + NET p_bsg_tag_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 3675000 ) N ;
-    - p_bsg_tag_data_i + NET p_bsg_tag_data_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_data_i + NET p_bsg_tag_data_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 3035000 ) N ;
-    - p_bsg_tag_data_o + NET p_bsg_tag_data_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_bsg_tag_data_o + NET p_bsg_tag_data_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 3675000 ) N ;
-    - p_bsg_tag_en_i + NET p_bsg_tag_en_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_en_i + NET p_bsg_tag_en_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 3355000 ) N ;
-    - p_ci2_0_o + NET p_ci2_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_0_o + NET p_ci2_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 5595000 ) N ;
-    - p_ci2_1_o + NET p_ci2_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_1_o + NET p_ci2_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 5275000 ) N ;
-    - p_ci2_2_o + NET p_ci2_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_2_o + NET p_ci2_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 4955000 ) N ;
-    - p_ci2_3_o + NET p_ci2_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_3_o + NET p_ci2_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 5595000 ) N ;
-    - p_ci2_4_o + NET p_ci2_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_4_o + NET p_ci2_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 5275000 ) N ;
-    - p_ci2_5_o + NET p_ci2_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_5_o + NET p_ci2_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 5275000 ) N ;
-    - p_ci2_6_o + NET p_ci2_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_6_o + NET p_ci2_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 5595000 ) N ;
-    - p_ci2_7_o + NET p_ci2_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_7_o + NET p_ci2_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 5275000 ) N ;
-    - p_ci2_8_o + NET p_ci2_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_8_o + NET p_ci2_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 4955000 ) N ;
-    - p_ci2_clk_o + NET p_ci2_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_clk_o + NET p_ci2_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 4635000 ) N ;
-    - p_ci2_tkn_i + NET p_ci2_tkn_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci2_tkn_i + NET p_ci2_tkn_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 5275000 ) N ;
-    - p_ci2_v_o + NET p_ci2_v_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_v_o + NET p_ci2_v_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 4635000 ) N ;
-    - p_ci_0_i + NET p_ci_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_0_i + NET p_ci_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 4955000 ) N ;
-    - p_ci_1_i + NET p_ci_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_1_i + NET p_ci_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 4635000 ) N ;
-    - p_ci_2_i + NET p_ci_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_2_i + NET p_ci_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 4315000 ) N ;
-    - p_ci_3_i + NET p_ci_3_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_3_i + NET p_ci_3_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 4315000 ) N ;
-    - p_ci_4_i + NET p_ci_4_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_4_i + NET p_ci_4_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 3995000 ) N ;
-    - p_ci_5_i + NET p_ci_5_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_5_i + NET p_ci_5_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 3675000 ) N ;
-    - p_ci_6_i + NET p_ci_6_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_6_i + NET p_ci_6_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 3675000 ) N ;
-    - p_ci_7_i + NET p_ci_7_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_7_i + NET p_ci_7_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 3355000 ) N ;
-    - p_ci_8_i + NET p_ci_8_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_8_i + NET p_ci_8_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 3355000 ) N ;
-    - p_ci_clk_i + NET p_ci_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_clk_i + NET p_ci_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 3995000 ) N ;
-    - p_ci_tkn_o + NET p_ci_tkn_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci_tkn_o + NET p_ci_tkn_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 3995000 ) N ;
-    - p_ci_v_i + NET p_ci_v_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_v_i + NET p_ci_v_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 3675000 ) N ;
-    - p_clk_A_i + NET p_clk_A_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_A_i + NET p_clk_A_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2705000 4635000 ) N ;
-    - p_clk_B_i + NET p_clk_B_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_B_i + NET p_clk_B_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 4315000 ) N ;
-    - p_clk_C_i + NET p_clk_C_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_C_i + NET p_clk_C_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 5595000 ) N ;
-    - p_clk_async_reset_i + NET p_clk_async_reset_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_async_reset_i + NET p_clk_async_reset_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3345000 4955000 ) N ;
-    - p_clk_o + NET p_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_clk_o + NET p_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 4635000 ) N ;
-    - p_co2_0_o + NET p_co2_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_0_o + NET p_co2_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 3995000 ) N ;
-    - p_co2_1_o + NET p_co2_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_1_o + NET p_co2_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 3995000 ) N ;
-    - p_co2_2_o + NET p_co2_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_2_o + NET p_co2_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 3995000 ) N ;
-    - p_co2_3_o + NET p_co2_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_3_o + NET p_co2_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 4315000 ) N ;
-    - p_co2_4_o + NET p_co2_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_4_o + NET p_co2_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 4315000 ) N ;
-    - p_co2_5_o + NET p_co2_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_5_o + NET p_co2_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 4955000 ) N ;
-    - p_co2_6_o + NET p_co2_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_6_o + NET p_co2_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 5275000 ) N ;
-    - p_co2_7_o + NET p_co2_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_7_o + NET p_co2_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 5275000 ) N ;
-    - p_co2_8_o + NET p_co2_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_8_o + NET p_co2_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 5595000 ) N ;
-    - p_co2_clk_o + NET p_co2_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_clk_o + NET p_co2_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 4315000 ) N ;
-    - p_co2_tkn_i + NET p_co2_tkn_i + DIRECTION INPUT + USE SIGNAL
+    - p_co2_tkn_i + NET p_co2_tkn_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 4635000 ) N ;
-    - p_co2_v_o + NET p_co2_v_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_v_o + NET p_co2_v_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 4635000 ) N ;
-    - p_co_0_i + NET p_co_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_0_i + NET p_co_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 5275000 ) N ;
-    - p_co_1_i + NET p_co_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_1_i + NET p_co_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 4955000 ) N ;
-    - p_co_2_i + NET p_co_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_2_i + NET p_co_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 5595000 ) N ;
-    - p_co_3_i + NET p_co_3_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_3_i + NET p_co_3_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 5595000 ) N ;
-    - p_co_4_i + NET p_co_4_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_4_i + NET p_co_4_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 4315000 ) N ;
-    - p_co_5_i + NET p_co_5_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_5_i + NET p_co_5_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 4955000 ) N ;
-    - p_co_6_i + NET p_co_6_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_6_i + NET p_co_6_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 5595000 ) N ;
-    - p_co_7_i + NET p_co_7_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_7_i + NET p_co_7_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 5275000 ) N ;
-    - p_co_8_i + NET p_co_8_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_8_i + NET p_co_8_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 4635000 ) N ;
-    - p_co_clk_i + NET p_co_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_clk_i + NET p_co_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 4955000 ) N ;
-    - p_co_tkn_o + NET p_co_tkn_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co_tkn_o + NET p_co_tkn_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 5595000 ) N ;
-    - p_co_v_i + NET p_co_v_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_v_i + NET p_co_v_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 5275000 ) N ;
-    - p_core_async_reset_i + NET p_core_async_reset_i + DIRECTION INPUT + USE SIGNAL
+    - p_core_async_reset_i + NET p_core_async_reset_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 4955000 ) N ;
-    - p_ddr_addr_0_o + NET p_ddr_addr_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_0_o + NET p_ddr_addr_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3345000 475000 ) N ;
-    - p_ddr_addr_10_o + NET p_ddr_addr_10_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_10_o + NET p_ddr_addr_10_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 1755000 ) N ;
-    - p_ddr_addr_11_o + NET p_ddr_addr_11_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_11_o + NET p_ddr_addr_11_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 1115000 ) N ;
-    - p_ddr_addr_12_o + NET p_ddr_addr_12_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_12_o + NET p_ddr_addr_12_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2065000 1435000 ) N ;
-    - p_ddr_addr_13_o + NET p_ddr_addr_13_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_13_o + NET p_ddr_addr_13_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 1755000 ) N ;
-    - p_ddr_addr_14_o + NET p_ddr_addr_14_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_14_o + NET p_ddr_addr_14_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 1115000 ) N ;
-    - p_ddr_addr_15_o + NET p_ddr_addr_15_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_15_o + NET p_ddr_addr_15_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 475000 ) N ;
-    - p_ddr_addr_1_o + NET p_ddr_addr_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_1_o + NET p_ddr_addr_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 1755000 ) N ;
-    - p_ddr_addr_2_o + NET p_ddr_addr_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_2_o + NET p_ddr_addr_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 1115000 ) N ;
-    - p_ddr_addr_3_o + NET p_ddr_addr_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_3_o + NET p_ddr_addr_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3025000 475000 ) N ;
-    - p_ddr_addr_4_o + NET p_ddr_addr_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_4_o + NET p_ddr_addr_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2705000 1755000 ) N ;
-    - p_ddr_addr_5_o + NET p_ddr_addr_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_5_o + NET p_ddr_addr_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2705000 1115000 ) N ;
-    - p_ddr_addr_6_o + NET p_ddr_addr_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_6_o + NET p_ddr_addr_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2705000 475000 ) N ;
-    - p_ddr_addr_7_o + NET p_ddr_addr_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_7_o + NET p_ddr_addr_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2705000 795000 ) N ;
-    - p_ddr_addr_8_o + NET p_ddr_addr_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_8_o + NET p_ddr_addr_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 1115000 ) N ;
-    - p_ddr_addr_9_o + NET p_ddr_addr_9_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_9_o + NET p_ddr_addr_9_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 2385000 475000 ) N ;
-    - p_ddr_ba_0_o + NET p_ddr_ba_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_0_o + NET p_ddr_ba_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 1115000 ) N ;
-    - p_ddr_ba_1_o + NET p_ddr_ba_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_1_o + NET p_ddr_ba_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 475000 ) N ;
-    - p_ddr_ba_2_o + NET p_ddr_ba_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_2_o + NET p_ddr_ba_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 795000 ) N ;
-    - p_ddr_cas_n_o + NET p_ddr_cas_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cas_n_o + NET p_ddr_cas_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 1115000 ) N ;
-    - p_ddr_ck_n_o + NET p_ddr_ck_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ck_n_o + NET p_ddr_ck_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 1755000 ) N ;
-    - p_ddr_ck_p_o + NET p_ddr_ck_p_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ck_p_o + NET p_ddr_ck_p_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 795000 ) N ;
-    - p_ddr_cke_o + NET p_ddr_cke_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cke_o + NET p_ddr_cke_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 1115000 ) N ;
-    - p_ddr_cs_n_o + NET p_ddr_cs_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cs_n_o + NET p_ddr_cs_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 475000 ) N ;
-    - p_ddr_dm_0_o + NET p_ddr_dm_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_0_o + NET p_ddr_dm_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 2715000 ) N ;
-    - p_ddr_dm_1_o + NET p_ddr_dm_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_1_o + NET p_ddr_dm_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 475000 ) N ;
-    - p_ddr_dm_2_o + NET p_ddr_dm_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_2_o + NET p_ddr_dm_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 795000 ) N ;
-    - p_ddr_dm_3_o + NET p_ddr_dm_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_3_o + NET p_ddr_dm_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 3035000 ) N ;
-    - p_ddr_dq_0_io + NET p_ddr_dq_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_0_io + NET p_ddr_dq_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 2715000 ) N ;
-    - p_ddr_dq_10_io + NET p_ddr_dq_10_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_10_io + NET p_ddr_dq_10_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 1755000 ) N ;
-    - p_ddr_dq_11_io + NET p_ddr_dq_11_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_11_io + NET p_ddr_dq_11_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 2075000 ) N ;
-    - p_ddr_dq_12_io + NET p_ddr_dq_12_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_12_io + NET p_ddr_dq_12_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 2075000 ) N ;
-    - p_ddr_dq_13_io + NET p_ddr_dq_13_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_13_io + NET p_ddr_dq_13_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 2075000 ) N ;
-    - p_ddr_dq_14_io + NET p_ddr_dq_14_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_14_io + NET p_ddr_dq_14_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 2395000 ) N ;
-    - p_ddr_dq_15_io + NET p_ddr_dq_15_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_15_io + NET p_ddr_dq_15_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 2395000 ) N ;
-    - p_ddr_dq_16_io + NET p_ddr_dq_16_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_16_io + NET p_ddr_dq_16_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 1755000 ) N ;
-    - p_ddr_dq_17_io + NET p_ddr_dq_17_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_17_io + NET p_ddr_dq_17_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 1755000 ) N ;
-    - p_ddr_dq_18_io + NET p_ddr_dq_18_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_18_io + NET p_ddr_dq_18_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 1435000 ) N ;
-    - p_ddr_dq_19_io + NET p_ddr_dq_19_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_19_io + NET p_ddr_dq_19_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 1435000 ) N ;
-    - p_ddr_dq_1_io + NET p_ddr_dq_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_1_io + NET p_ddr_dq_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 3035000 ) N ;
-    - p_ddr_dq_20_io + NET p_ddr_dq_20_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_20_io + NET p_ddr_dq_20_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 1115000 ) N ;
-    - p_ddr_dq_21_io + NET p_ddr_dq_21_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_21_io + NET p_ddr_dq_21_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 795000 ) N ;
-    - p_ddr_dq_22_io + NET p_ddr_dq_22_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_22_io + NET p_ddr_dq_22_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 795000 ) N ;
-    - p_ddr_dq_23_io + NET p_ddr_dq_23_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_23_io + NET p_ddr_dq_23_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 475000 ) N ;
-    - p_ddr_dq_24_io + NET p_ddr_dq_24_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_24_io + NET p_ddr_dq_24_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 2715000 ) N ;
-    - p_ddr_dq_25_io + NET p_ddr_dq_25_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_25_io + NET p_ddr_dq_25_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 2395000 ) N ;
-    - p_ddr_dq_26_io + NET p_ddr_dq_26_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_26_io + NET p_ddr_dq_26_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 2395000 ) N ;
-    - p_ddr_dq_27_io + NET p_ddr_dq_27_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_27_io + NET p_ddr_dq_27_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 2395000 ) N ;
-    - p_ddr_dq_28_io + NET p_ddr_dq_28_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_28_io + NET p_ddr_dq_28_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5585000 2075000 ) N ;
-    - p_ddr_dq_29_io + NET p_ddr_dq_29_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_29_io + NET p_ddr_dq_29_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 5265000 2075000 ) N ;
-    - p_ddr_dq_2_io + NET p_ddr_dq_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_2_io + NET p_ddr_dq_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 3035000 ) N ;
-    - p_ddr_dq_30_io + NET p_ddr_dq_30_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_30_io + NET p_ddr_dq_30_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 2075000 ) N ;
-    - p_ddr_dq_31_io + NET p_ddr_dq_31_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_31_io + NET p_ddr_dq_31_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 1755000 ) N ;
-    - p_ddr_dq_3_io + NET p_ddr_dq_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_3_io + NET p_ddr_dq_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 3035000 ) N ;
-    - p_ddr_dq_4_io + NET p_ddr_dq_4_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_4_io + NET p_ddr_dq_4_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 3355000 ) N ;
-    - p_ddr_dq_5_io + NET p_ddr_dq_5_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_5_io + NET p_ddr_dq_5_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 3355000 ) N ;
-    - p_ddr_dq_6_io + NET p_ddr_dq_6_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_6_io + NET p_ddr_dq_6_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1425000 3355000 ) N ;
-    - p_ddr_dq_7_io + NET p_ddr_dq_7_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_7_io + NET p_ddr_dq_7_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 3675000 ) N ;
-    - p_ddr_dq_8_io + NET p_ddr_dq_8_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_8_io + NET p_ddr_dq_8_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 1755000 ) N ;
-    - p_ddr_dq_9_io + NET p_ddr_dq_9_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_9_io + NET p_ddr_dq_9_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 1755000 ) N ;
-    - p_ddr_dqs_n_0_io + NET p_ddr_dqs_n_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_0_io + NET p_ddr_dqs_n_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1745000 2715000 ) N ;
-    - p_ddr_dqs_n_1_io + NET p_ddr_dqs_n_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_1_io + NET p_ddr_dqs_n_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 785000 795000 ) N ;
-    - p_ddr_dqs_n_2_io + NET p_ddr_dqs_n_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_2_io + NET p_ddr_dqs_n_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 475000 ) N ;
-    - p_ddr_dqs_n_3_io + NET p_ddr_dqs_n_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_3_io + NET p_ddr_dqs_n_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4945000 2715000 ) N ;
-    - p_ddr_dqs_p_0_io + NET p_ddr_dqs_p_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_0_io + NET p_ddr_dqs_p_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 465000 2395000 ) N ;
-    - p_ddr_dqs_p_1_io + NET p_ddr_dqs_p_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_1_io + NET p_ddr_dqs_p_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 1105000 475000 ) N ;
-    - p_ddr_dqs_p_2_io + NET p_ddr_dqs_p_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_2_io + NET p_ddr_dqs_p_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4625000 1115000 ) N ;
-    - p_ddr_dqs_p_3_io + NET p_ddr_dqs_p_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_3_io + NET p_ddr_dqs_p_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 4305000 2715000 ) N ;
-    - p_ddr_odt_o + NET p_ddr_odt_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_odt_o + NET p_ddr_odt_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 1435000 ) N ;
-    - p_ddr_ras_n_o + NET p_ddr_ras_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ras_n_o + NET p_ddr_ras_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3985000 795000 ) N ;
-    - p_ddr_reset_n_o + NET p_ddr_reset_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_reset_n_o + NET p_ddr_reset_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 795000 ) N ;
-    - p_ddr_we_n_o + NET p_ddr_we_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_we_n_o + NET p_ddr_we_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 475000 ) N ;
-    - p_misc_o + NET p_misc_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_misc_o + NET p_misc_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3345000 5275000 ) N ;
-    - p_sel_0_i + NET p_sel_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_0_i + NET p_sel_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3345000 4635000 ) N ;
-    - p_sel_1_i + NET p_sel_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_1_i + NET p_sel_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 4315000 ) N ;
-    - p_sel_2_i + NET p_sel_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_2_i + NET p_sel_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -45000 -45000 ) ( 45000 45000 )
         + FIXED ( 3665000 5275000 ) N ;
 END PINS
-SPECIALNETS 6 ;
-    - DVDD ( PIN DVDD ) ( IO_FILL_IO_WEST_0_485 DVDD ) ( IO_FILL_IO_WEST_0_480 DVDD ) ( IO_FILL_IO_WEST_0_475 DVDD ) ( IO_FILL_IO_WEST_0_470 DVDD ) ( IO_FILL_IO_WEST_0_465 DVDD ) ( IO_FILL_IO_WEST_0_460 DVDD )
-      ( IO_FILL_IO_WEST_0_455 DVDD ) ( IO_FILL_IO_WEST_0_450 DVDD ) ( IO_FILL_IO_WEST_0_445 DVDD ) ( IO_FILL_IO_WEST_0_440 DVDD ) ( IO_FILL_IO_WEST_0_435 DVDD ) ( IO_FILL_IO_WEST_0_430 DVDD ) ( IO_FILL_IO_WEST_0_425 DVDD ) ( IO_FILL_IO_WEST_0_420 DVDD )
-      ( IO_FILL_IO_WEST_0_415 DVDD ) ( IO_FILL_IO_WEST_0_410 DVDD ) ( IO_FILL_IO_WEST_0_405 DVDD ) ( IO_FILL_IO_WEST_0_400 DVDD ) ( IO_FILL_IO_WEST_0_395 DVDD ) ( IO_FILL_IO_WEST_0_390 DVDD ) ( IO_FILL_IO_WEST_0_385 DVDD ) ( IO_FILL_IO_WEST_0_380 DVDD )
-      ( IO_FILL_IO_WEST_0_375 DVDD ) ( IO_FILL_IO_WEST_0_370 DVDD ) ( IO_FILL_IO_WEST_0_365 DVDD ) ( IO_FILL_IO_WEST_0_360 DVDD ) ( IO_FILL_IO_WEST_0_355 DVDD ) ( IO_FILL_IO_WEST_0_350 DVDD ) ( IO_FILL_IO_WEST_0_345 DVDD ) ( IO_FILL_IO_WEST_0_340 DVDD )
-      ( IO_FILL_IO_WEST_0_335 DVDD ) ( IO_FILL_IO_WEST_0_330 DVDD ) ( IO_FILL_IO_WEST_0_325 DVDD ) ( IO_FILL_IO_WEST_0_320 DVDD ) ( IO_FILL_IO_WEST_0_315 DVDD ) ( IO_FILL_IO_WEST_0_310 DVDD ) ( IO_FILL_IO_WEST_0_305 DVDD ) ( IO_FILL_IO_WEST_0_300 DVDD )
-      ( IO_FILL_IO_WEST_0_295 DVDD ) ( IO_FILL_IO_WEST_0_290 DVDD ) ( IO_FILL_IO_WEST_0_285 DVDD ) ( IO_FILL_IO_WEST_0_280 DVDD ) ( IO_FILL_IO_WEST_0_275 DVDD ) ( IO_FILL_IO_WEST_0_270 DVDD ) ( IO_FILL_IO_WEST_0_265 DVDD ) ( IO_FILL_IO_WEST_0_260 DVDD )
-      ( IO_FILL_IO_WEST_0_255 DVDD ) ( IO_FILL_IO_WEST_0_250 DVDD ) ( IO_FILL_IO_WEST_0_245 DVDD ) ( IO_FILL_IO_WEST_0_240 DVDD ) ( IO_FILL_IO_WEST_0_235 DVDD ) ( IO_FILL_IO_WEST_0_230 DVDD ) ( IO_FILL_IO_WEST_0_225 DVDD ) ( IO_FILL_IO_WEST_0_220 DVDD )
-      ( IO_FILL_IO_WEST_0_215 DVDD ) ( IO_FILL_IO_WEST_0_210 DVDD ) ( IO_FILL_IO_WEST_0_205 DVDD ) ( IO_FILL_IO_WEST_0_200 DVDD ) ( IO_FILL_IO_WEST_0_195 DVDD ) ( IO_FILL_IO_WEST_0_190 DVDD ) ( IO_FILL_IO_WEST_0_185 DVDD ) ( IO_FILL_IO_WEST_0_180 DVDD )
-      ( IO_FILL_IO_WEST_0_175 DVDD ) ( IO_FILL_IO_WEST_0_170 DVDD ) ( IO_FILL_IO_WEST_0_165 DVDD ) ( IO_FILL_IO_WEST_0_160 DVDD ) ( IO_FILL_IO_WEST_0_155 DVDD ) ( IO_FILL_IO_WEST_0_150 DVDD ) ( IO_FILL_IO_WEST_0_145 DVDD ) ( IO_FILL_IO_WEST_0_140 DVDD )
-      ( IO_FILL_IO_WEST_0_135 DVDD ) ( IO_FILL_IO_WEST_0_130 DVDD ) ( IO_FILL_IO_WEST_0_125 DVDD ) ( IO_FILL_IO_WEST_0_120 DVDD ) ( IO_FILL_IO_WEST_0_115 DVDD ) ( IO_FILL_IO_WEST_0_110 DVDD ) ( IO_FILL_IO_WEST_0_105 DVDD ) ( IO_FILL_IO_WEST_0_100 DVDD )
-      ( IO_FILL_IO_WEST_0_95 DVDD ) ( IO_FILL_IO_WEST_0_90 DVDD ) ( IO_FILL_IO_WEST_0_85 DVDD ) ( IO_FILL_IO_WEST_0_80 DVDD ) ( IO_FILL_IO_WEST_0_75 DVDD ) ( IO_FILL_IO_WEST_0_70 DVDD ) ( IO_FILL_IO_WEST_0_65 DVDD ) ( IO_FILL_IO_WEST_0_60 DVDD )
-      ( IO_FILL_IO_WEST_0_55 DVDD ) ( IO_FILL_IO_WEST_0_50 DVDD ) ( IO_FILL_IO_WEST_0_45 DVDD ) ( IO_FILL_IO_WEST_0_40 DVDD ) ( IO_FILL_IO_WEST_0_35 DVDD ) ( IO_FILL_IO_WEST_0_30 DVDD ) ( IO_FILL_IO_WEST_0_25 DVDD ) ( IO_FILL_IO_WEST_0_20 DVDD )
-      ( IO_FILL_IO_WEST_0_15 DVDD ) ( IO_FILL_IO_WEST_0_10 DVDD ) ( IO_FILL_IO_WEST_0_5 DVDD ) ( IO_FILL_IO_WEST_0_0 DVDD ) ( IO_CORNER_SOUTH_WEST_INST DVDD ) ( IO_FILL_IO_SOUTH_0_0 DVDD ) ( IO_FILL_IO_SOUTH_0_5 DVDD ) ( IO_FILL_IO_WEST_0_490 DVDD )
-      ( IO_FILL_IO_SOUTH_0_10 DVDD ) ( IO_FILL_IO_WEST_0_495 DVDD ) ( IO_FILL_IO_SOUTH_0_15 DVDD ) ( IO_FILL_IO_EAST_0_15 DVDD ) ( IO_FILL_IO_EAST_0_10 DVDD ) ( IO_FILL_IO_EAST_0_5 DVDD ) ( IO_FILL_IO_EAST_0_0 DVDD ) ( IO_CORNER_SOUTH_EAST_INST DVDD )
-      ( IO_FILL_IO_WEST_56_90 DVDD ) ( IO_FILL_IO_WEST_56_85 DVDD ) ( IO_FILL_IO_WEST_56_80 DVDD ) ( IO_FILL_IO_WEST_56_75 DVDD ) ( IO_FILL_IO_WEST_56_70 DVDD ) ( IO_FILL_IO_WEST_56_65 DVDD ) ( IO_FILL_IO_WEST_56_60 DVDD ) ( IO_FILL_IO_WEST_56_55 DVDD )
-      ( IO_FILL_IO_WEST_56_50 DVDD ) ( IO_FILL_IO_WEST_56_45 DVDD ) ( IO_FILL_IO_WEST_56_40 DVDD ) ( IO_FILL_IO_WEST_56_35 DVDD ) ( IO_FILL_IO_WEST_56_30 DVDD ) ( IO_FILL_IO_WEST_56_25 DVDD ) ( IO_FILL_IO_WEST_56_20 DVDD ) ( IO_FILL_IO_WEST_56_15 DVDD )
-      ( IO_FILL_IO_WEST_56_10 DVDD ) ( IO_FILL_IO_WEST_56_5 DVDD ) ( IO_FILL_IO_WEST_54_95 DVDD ) ( IO_FILL_IO_WEST_54_90 DVDD ) ( IO_FILL_IO_WEST_54_85 DVDD ) ( IO_FILL_IO_WEST_54_80 DVDD ) ( IO_FILL_IO_WEST_54_75 DVDD ) ( IO_FILL_IO_WEST_54_70 DVDD )
-      ( IO_FILL_IO_WEST_54_65 DVDD ) ( IO_FILL_IO_WEST_54_60 DVDD ) ( IO_FILL_IO_WEST_54_55 DVDD ) ( IO_FILL_IO_WEST_54_50 DVDD ) ( IO_FILL_IO_WEST_54_45 DVDD ) ( IO_FILL_IO_WEST_54_40 DVDD ) ( IO_FILL_IO_WEST_54_35 DVDD ) ( IO_FILL_IO_WEST_54_30 DVDD )
-      ( IO_FILL_IO_WEST_54_25 DVDD ) ( IO_FILL_IO_WEST_54_20 DVDD ) ( IO_FILL_IO_WEST_54_15 DVDD ) ( IO_FILL_IO_WEST_54_10 DVDD ) ( IO_FILL_IO_WEST_54_5 DVDD ) ( IO_FILL_IO_WEST_51_25 DVDD ) ( IO_FILL_IO_WEST_51_20 DVDD ) ( IO_FILL_IO_WEST_51_15 DVDD )
-      ( IO_FILL_IO_WEST_51_10 DVDD ) ( IO_FILL_IO_WEST_51_5 DVDD ) ( IO_FILL_IO_WEST_47_45 DVDD ) ( IO_FILL_IO_WEST_47_40 DVDD ) ( IO_FILL_IO_WEST_47_35 DVDD ) ( IO_FILL_IO_WEST_47_30 DVDD ) ( IO_FILL_IO_WEST_47_25 DVDD ) ( IO_FILL_IO_WEST_47_20 DVDD )
-      ( IO_FILL_IO_WEST_47_15 DVDD ) ( IO_FILL_IO_WEST_47_10 DVDD ) ( IO_FILL_IO_WEST_47_5 DVDD ) ( IO_FILL_IO_WEST_32_5 DVDD ) ( IO_FILL_IO_WEST_27_5 DVDD ) ( IO_FILL_IO_WEST_12_5 DVDD ) ( IO_FILL_IO_WEST_7_5 DVDD ) ( IO_FILL_IO_WEST_3_65 DVDD )
-      ( IO_FILL_IO_WEST_3_60 DVDD ) ( IO_FILL_IO_WEST_3_55 DVDD ) ( IO_FILL_IO_WEST_3_50 DVDD ) ( IO_FILL_IO_WEST_3_45 DVDD ) ( IO_FILL_IO_WEST_3_40 DVDD ) ( IO_FILL_IO_WEST_3_35 DVDD ) ( IO_FILL_IO_WEST_3_30 DVDD ) ( IO_FILL_IO_WEST_3_25 DVDD )
-      ( IO_FILL_IO_WEST_3_20 DVDD ) ( IO_FILL_IO_WEST_3_15 DVDD ) ( IO_FILL_IO_WEST_3_10 DVDD ) ( IO_FILL_IO_WEST_3_5 DVDD ) ( IO_FILL_IO_WEST_0_500 DVDD ) ( IO_FILL_IO_WEST_0_505 DVDD ) ( IO_FILL_IO_WEST_1_0 DVDD ) ( IO_FILL_IO_WEST_17_0 DVDD )
-      ( IO_FILL_IO_WEST_51_0 DVDD ) ( IO_FILL_IO_WEST_3_0 DVDD ) ( IO_FILL_IO_WEST_2_0 DVDD ) ( IO_FILL_IO_WEST_19_5 DVDD ) ( IO_FILL_IO_WEST_51_30 DVDD ) ( IO_FILL_IO_WEST_3_70 DVDD ) ( IO_FILL_IO_WEST_20_0 DVDD ) ( IO_FILL_IO_WEST_35_0 DVDD )
-      ( IO_FILL_IO_WEST_52_0 DVDD ) ( IO_FILL_IO_WEST_10_0 DVDD ) ( IO_FILL_IO_WEST_16_0 DVDD ) ( IO_FILL_IO_WEST_24_0 DVDD ) ( IO_FILL_IO_WEST_30_0 DVDD ) ( IO_FILL_IO_WEST_38_0 DVDD ) ( IO_FILL_IO_WEST_37_5 DVDD ) ( IO_FILL_IO_WEST_44_0 DVDD )
-      ( IO_FILL_IO_WEST_50_0 DVDD ) ( IO_FILL_IO_WEST_15_0 DVDD ) ( IO_FILL_IO_WEST_17_5 DVDD ) ( IO_FILL_IO_WEST_5_0 DVDD ) ( IO_FILL_IO_WEST_4_0 DVDD ) ( IO_FILL_IO_WEST_33_0 DVDD ) ( IO_FILL_IO_WEST_32_10 DVDD ) ( IO_FILL_IO_WEST_32_0 DVDD )
-      ( IO_FILL_IO_WEST_31_0 DVDD ) ( IO_FILL_IO_WEST_29_0 DVDD ) ( IO_FILL_IO_WEST_28_0 DVDD ) ( IO_FILL_IO_WEST_27_10 DVDD ) ( IO_FILL_IO_WEST_27_0 DVDD ) ( IO_FILL_IO_WEST_26_0 DVDD ) ( IO_FILL_IO_WEST_25_0 DVDD ) ( IO_FILL_IO_WEST_23_0 DVDD )
-      ( IO_FILL_IO_WEST_22_5 DVDD ) ( IO_FILL_IO_WEST_14_0 DVDD ) ( IO_FILL_IO_WEST_13_5 DVDD ) ( IO_FILL_IO_WEST_13_0 DVDD ) ( IO_FILL_IO_WEST_12_10 DVDD ) ( IO_FILL_IO_WEST_12_0 DVDD ) ( IO_FILL_IO_WEST_11_0 DVDD ) ( IO_FILL_IO_WEST_9_0 DVDD )
-      ( IO_FILL_IO_WEST_8_0 DVDD ) ( IO_FILL_IO_WEST_7_10 DVDD ) ( IO_FILL_IO_WEST_7_0 DVDD ) ( IO_FILL_IO_WEST_6_0 DVDD ) ( IO_FILL_IO_WEST_22_0 DVDD ) ( IO_FILL_IO_WEST_21_0 DVDD ) ( IO_FILL_IO_WEST_19_0 DVDD ) ( IO_FILL_IO_WEST_18_0 DVDD )
-      ( IO_FILL_IO_WEST_49_0 DVDD ) ( IO_FILL_IO_WEST_48_0 DVDD ) ( IO_FILL_IO_WEST_47_50 DVDD ) ( IO_FILL_IO_WEST_47_0 DVDD ) ( IO_FILL_IO_WEST_56_95 DVDD ) ( IO_FILL_IO_WEST_56_0 DVDD ) ( IO_FILL_IO_WEST_55_5 DVDD ) ( IO_FILL_IO_WEST_55_0 DVDD )
-      ( IO_FILL_IO_WEST_54_100 DVDD ) ( IO_FILL_IO_WEST_54_0 DVDD ) ( IO_FILL_IO_WEST_53_0 DVDD ) ( IO_FILL_IO_WEST_46_0 DVDD ) ( IO_FILL_IO_WEST_45_0 DVDD ) ( IO_FILL_IO_WEST_43_0 DVDD ) ( IO_FILL_IO_WEST_42_5 DVDD ) ( IO_FILL_IO_WEST_42_0 DVDD )
-      ( IO_FILL_IO_WEST_41_5 DVDD ) ( IO_FILL_IO_WEST_41_0 DVDD ) ( IO_FILL_IO_WEST_40_0 DVDD ) ( IO_FILL_IO_WEST_39_0 DVDD ) ( IO_FILL_IO_WEST_34_0 DVDD ) ( IO_FILL_IO_WEST_33_5 DVDD ) ( IO_FILL_IO_WEST_37_0 DVDD ) ( IO_FILL_IO_WEST_36_0 DVDD )
-      ( IO_FILL_IO_SOUTH_60_190 DVDD ) ( IO_FILL_IO_SOUTH_60_185 DVDD ) ( IO_FILL_IO_SOUTH_60_180 DVDD ) ( IO_FILL_IO_SOUTH_60_175 DVDD ) ( IO_FILL_IO_SOUTH_60_170 DVDD ) ( IO_FILL_IO_SOUTH_60_165 DVDD ) ( IO_FILL_IO_SOUTH_60_160 DVDD ) ( IO_FILL_IO_SOUTH_60_155 DVDD )
-      ( IO_FILL_IO_SOUTH_60_150 DVDD ) ( IO_FILL_IO_SOUTH_60_145 DVDD ) ( IO_FILL_IO_SOUTH_60_140 DVDD ) ( IO_FILL_IO_SOUTH_60_135 DVDD ) ( IO_FILL_IO_SOUTH_60_130 DVDD ) ( IO_FILL_IO_SOUTH_60_125 DVDD ) ( IO_FILL_IO_SOUTH_60_120 DVDD ) ( IO_FILL_IO_SOUTH_60_115 DVDD )
-      ( IO_FILL_IO_SOUTH_60_110 DVDD ) ( IO_FILL_IO_SOUTH_60_105 DVDD ) ( IO_FILL_IO_SOUTH_60_100 DVDD ) ( IO_FILL_IO_SOUTH_60_95 DVDD ) ( IO_FILL_IO_SOUTH_60_90 DVDD ) ( IO_FILL_IO_SOUTH_60_85 DVDD ) ( IO_FILL_IO_SOUTH_60_80 DVDD ) ( IO_FILL_IO_SOUTH_60_75 DVDD )
-      ( IO_FILL_IO_SOUTH_60_70 DVDD ) ( IO_FILL_IO_SOUTH_60_65 DVDD ) ( IO_FILL_IO_SOUTH_60_60 DVDD ) ( IO_FILL_IO_SOUTH_60_55 DVDD ) ( IO_FILL_IO_SOUTH_60_50 DVDD ) ( IO_FILL_IO_SOUTH_60_45 DVDD ) ( IO_FILL_IO_SOUTH_60_40 DVDD ) ( IO_FILL_IO_SOUTH_60_35 DVDD )
-      ( IO_FILL_IO_SOUTH_60_30 DVDD ) ( IO_FILL_IO_SOUTH_60_25 DVDD ) ( IO_FILL_IO_SOUTH_60_20 DVDD ) ( IO_FILL_IO_SOUTH_60_15 DVDD ) ( IO_FILL_IO_SOUTH_60_10 DVDD ) ( IO_FILL_IO_SOUTH_60_5 DVDD ) ( IO_FILL_IO_SOUTH_59_125 DVDD ) ( IO_FILL_IO_SOUTH_59_120 DVDD )
-      ( IO_FILL_IO_SOUTH_59_115 DVDD ) ( IO_FILL_IO_SOUTH_59_110 DVDD ) ( IO_FILL_IO_SOUTH_59_105 DVDD ) ( IO_FILL_IO_SOUTH_59_100 DVDD ) ( IO_FILL_IO_SOUTH_59_95 DVDD ) ( IO_FILL_IO_SOUTH_59_90 DVDD ) ( IO_FILL_IO_SOUTH_59_85 DVDD ) ( IO_FILL_IO_SOUTH_59_80 DVDD )
-      ( IO_FILL_IO_SOUTH_59_75 DVDD ) ( IO_FILL_IO_SOUTH_59_70 DVDD ) ( IO_FILL_IO_SOUTH_59_65 DVDD ) ( IO_FILL_IO_SOUTH_59_60 DVDD ) ( IO_FILL_IO_SOUTH_59_55 DVDD ) ( IO_FILL_IO_SOUTH_59_50 DVDD ) ( IO_FILL_IO_SOUTH_59_45 DVDD ) ( IO_FILL_IO_SOUTH_59_40 DVDD )
-      ( IO_FILL_IO_SOUTH_59_35 DVDD ) ( IO_FILL_IO_SOUTH_59_30 DVDD ) ( IO_FILL_IO_SOUTH_59_25 DVDD ) ( IO_FILL_IO_SOUTH_59_20 DVDD ) ( IO_FILL_IO_SOUTH_59_15 DVDD ) ( IO_FILL_IO_SOUTH_59_10 DVDD ) ( IO_FILL_IO_SOUTH_59_5 DVDD ) ( IO_FILL_IO_SOUTH_57_60 DVDD )
-      ( IO_FILL_IO_SOUTH_57_55 DVDD ) ( IO_FILL_IO_SOUTH_57_50 DVDD ) ( IO_FILL_IO_SOUTH_57_45 DVDD ) ( IO_FILL_IO_SOUTH_57_40 DVDD ) ( IO_FILL_IO_SOUTH_57_35 DVDD ) ( IO_FILL_IO_SOUTH_57_30 DVDD ) ( IO_FILL_IO_SOUTH_57_25 DVDD ) ( IO_FILL_IO_SOUTH_57_20 DVDD )
-      ( IO_FILL_IO_SOUTH_57_15 DVDD ) ( IO_FILL_IO_SOUTH_57_10 DVDD ) ( IO_FILL_IO_SOUTH_57_5 DVDD ) ( IO_FILL_IO_SOUTH_54_65 DVDD ) ( IO_FILL_IO_SOUTH_54_60 DVDD ) ( IO_FILL_IO_SOUTH_54_55 DVDD ) ( IO_FILL_IO_SOUTH_54_50 DVDD ) ( IO_FILL_IO_SOUTH_54_45 DVDD )
-      ( IO_FILL_IO_SOUTH_54_40 DVDD ) ( IO_FILL_IO_SOUTH_54_35 DVDD ) ( IO_FILL_IO_SOUTH_54_30 DVDD ) ( IO_FILL_IO_SOUTH_54_25 DVDD ) ( IO_FILL_IO_SOUTH_54_20 DVDD ) ( IO_FILL_IO_SOUTH_54_15 DVDD ) ( IO_FILL_IO_SOUTH_54_10 DVDD ) ( IO_FILL_IO_SOUTH_54_5 DVDD )
-      ( IO_FILL_IO_SOUTH_40_5 DVDD ) ( IO_FILL_IO_SOUTH_20_5 DVDD ) ( IO_FILL_IO_SOUTH_10_30 DVDD ) ( IO_FILL_IO_SOUTH_10_25 DVDD ) ( IO_FILL_IO_SOUTH_10_20 DVDD ) ( IO_FILL_IO_SOUTH_10_15 DVDD ) ( IO_FILL_IO_SOUTH_10_10 DVDD ) ( IO_FILL_IO_SOUTH_10_5 DVDD )
-      ( IO_FILL_IO_SOUTH_6_35 DVDD ) ( IO_FILL_IO_SOUTH_6_30 DVDD ) ( IO_FILL_IO_SOUTH_6_25 DVDD ) ( IO_FILL_IO_SOUTH_6_20 DVDD ) ( IO_FILL_IO_SOUTH_6_15 DVDD ) ( IO_FILL_IO_SOUTH_6_10 DVDD ) ( IO_FILL_IO_SOUTH_6_5 DVDD ) ( IO_FILL_IO_SOUTH_3_95 DVDD )
-      ( IO_FILL_IO_SOUTH_3_90 DVDD ) ( IO_FILL_IO_SOUTH_3_85 DVDD ) ( IO_FILL_IO_SOUTH_3_80 DVDD ) ( IO_FILL_IO_SOUTH_3_75 DVDD ) ( IO_FILL_IO_SOUTH_3_70 DVDD ) ( IO_FILL_IO_SOUTH_3_65 DVDD ) ( IO_FILL_IO_SOUTH_3_60 DVDD ) ( IO_FILL_IO_SOUTH_3_55 DVDD )
-      ( IO_FILL_IO_SOUTH_3_50 DVDD ) ( IO_FILL_IO_SOUTH_3_45 DVDD ) ( IO_FILL_IO_SOUTH_3_40 DVDD ) ( IO_FILL_IO_SOUTH_3_35 DVDD ) ( IO_FILL_IO_SOUTH_3_30 DVDD ) ( IO_FILL_IO_SOUTH_3_25 DVDD ) ( IO_FILL_IO_SOUTH_3_20 DVDD ) ( IO_FILL_IO_SOUTH_3_15 DVDD )
-      ( IO_FILL_IO_SOUTH_3_10 DVDD ) ( IO_FILL_IO_SOUTH_3_5 DVDD ) ( IO_FILL_IO_SOUTH_1_95 DVDD ) ( IO_FILL_IO_SOUTH_1_90 DVDD ) ( IO_FILL_IO_SOUTH_1_85 DVDD ) ( IO_FILL_IO_SOUTH_1_80 DVDD ) ( IO_FILL_IO_SOUTH_1_75 DVDD ) ( IO_FILL_IO_SOUTH_1_70 DVDD )
-      ( IO_FILL_IO_SOUTH_1_65 DVDD ) ( IO_FILL_IO_SOUTH_1_60 DVDD ) ( IO_FILL_IO_SOUTH_1_55 DVDD ) ( IO_FILL_IO_SOUTH_1_50 DVDD ) ( IO_FILL_IO_SOUTH_1_45 DVDD ) ( IO_FILL_IO_SOUTH_1_40 DVDD ) ( IO_FILL_IO_SOUTH_1_35 DVDD ) ( IO_FILL_IO_SOUTH_1_30 DVDD )
-      ( IO_FILL_IO_SOUTH_1_25 DVDD ) ( IO_FILL_IO_SOUTH_1_20 DVDD ) ( IO_FILL_IO_SOUTH_1_15 DVDD ) ( IO_FILL_IO_SOUTH_1_10 DVDD ) ( IO_FILL_IO_SOUTH_1_5 DVDD ) ( IO_FILL_IO_SOUTH_0_20 DVDD ) ( IO_FILL_IO_SOUTH_6_0 DVDD ) ( IO_FILL_IO_SOUTH_3_100 DVDD )
-      ( IO_FILL_IO_SOUTH_59_0 DVDD ) ( IO_FILL_IO_SOUTH_50_5 DVDD ) ( IO_FILL_IO_SOUTH_45_0 DVDD ) ( IO_FILL_IO_SOUTH_30_5 DVDD ) ( IO_FILL_IO_SOUTH_25_0 DVDD ) ( IO_FILL_IO_SOUTH_10_35 DVDD ) ( IO_FILL_IO_SOUTH_3_0 DVDD ) ( IO_FILL_IO_SOUTH_54_0 DVDD )
-      ( IO_FILL_IO_SOUTH_22_0 DVDD ) ( IO_FILL_IO_SOUTH_6_40 DVDD ) ( IO_FILL_IO_SOUTH_53_0 DVDD ) ( IO_FILL_IO_SOUTH_36_0 DVDD ) ( IO_FILL_IO_SOUTH_35_5 DVDD ) ( IO_FILL_IO_SOUTH_21_0 DVDD ) ( IO_FILL_IO_SOUTH_20_10 DVDD ) ( IO_FILL_IO_SOUTH_60_0 DVDD )
-      ( IO_FILL_IO_SOUTH_59_130 DVDD ) ( IO_FILL_IO_SOUTH_52_0 DVDD ) ( IO_FILL_IO_SOUTH_51_0 DVDD ) ( IO_FILL_IO_SOUTH_45_5 DVDD ) ( IO_FILL_IO_SOUTH_40_0 DVDD ) ( IO_FILL_IO_SOUTH_39_0 DVDD ) ( IO_FILL_IO_SOUTH_31_0 DVDD ) ( IO_FILL_IO_SOUTH_25_5 DVDD )
-      ( IO_FILL_IO_SOUTH_17_0 DVDD ) ( IO_FILL_IO_SOUTH_11_0 DVDD ) ( IO_FILL_IO_SOUTH_42_5 DVDD ) ( IO_FILL_IO_SOUTH_42_0 DVDD ) ( IO_FILL_IO_SOUTH_46_0 DVDD ) ( IO_FILL_IO_SOUTH_41_0 DVDD ) ( IO_FILL_IO_SOUTH_40_10 DVDD ) ( IO_FILL_IO_SOUTH_57_0 DVDD )
-      ( IO_FILL_IO_SOUTH_56_5 DVDD ) ( IO_FILL_IO_SOUTH_5_0 DVDD ) ( IO_FILL_IO_SOUTH_4_0 DVDD ) ( IO_FILL_IO_SOUTH_56_0 DVDD ) ( IO_FILL_IO_SOUTH_2_0 DVDD ) ( IO_FILL_IO_SOUTH_1_100 DVDD ) ( IO_FILL_IO_SOUTH_58_0 DVDD ) ( IO_FILL_IO_SOUTH_57_65 DVDD )
-      ( IO_FILL_IO_SOUTH_1_0 DVDD ) ( IO_FILL_IO_SOUTH_0_25 DVDD ) ( IO_FILL_IO_SOUTH_48_0 DVDD ) ( IO_FILL_IO_SOUTH_47_0 DVDD ) ( IO_FILL_IO_SOUTH_48_5 DVDD ) ( IO_FILL_IO_SOUTH_55_0 DVDD ) ( IO_FILL_IO_SOUTH_54_70 DVDD ) ( IO_FILL_IO_SOUTH_50_0 DVDD )
-      ( IO_FILL_IO_SOUTH_49_0 DVDD ) ( IO_FILL_IO_SOUTH_44_0 DVDD ) ( IO_FILL_IO_SOUTH_43_0 DVDD ) ( IO_FILL_IO_SOUTH_8_0 DVDD ) ( IO_FILL_IO_SOUTH_7_0 DVDD ) ( IO_FILL_IO_SOUTH_8_5 DVDD ) ( IO_FILL_IO_SOUTH_10_0 DVDD ) ( IO_FILL_IO_SOUTH_9_0 DVDD )
-      ( IO_FILL_IO_SOUTH_22_5 DVDD ) ( IO_FILL_IO_SOUTH_24_0 DVDD ) ( IO_FILL_IO_SOUTH_23_0 DVDD ) ( IO_FILL_IO_SOUTH_26_0 DVDD ) ( IO_FILL_IO_SOUTH_28_0 DVDD ) ( IO_FILL_IO_SOUTH_27_0 DVDD ) ( IO_FILL_IO_SOUTH_28_5 DVDD ) ( IO_FILL_IO_SOUTH_30_0 DVDD )
-      ( IO_FILL_IO_SOUTH_29_0 DVDD ) ( IO_FILL_IO_SOUTH_32_0 DVDD ) ( IO_FILL_IO_SOUTH_34_0 DVDD ) ( IO_FILL_IO_SOUTH_33_0 DVDD ) ( IO_FILL_IO_SOUTH_35_0 DVDD ) ( IO_FILL_IO_SOUTH_34_5 DVDD ) ( IO_FILL_IO_SOUTH_12_0 DVDD ) ( IO_FILL_IO_SOUTH_14_0 DVDD )
-      ( IO_FILL_IO_SOUTH_13_0 DVDD ) ( IO_FILL_IO_SOUTH_15_0 DVDD ) ( IO_FILL_IO_SOUTH_14_5 DVDD ) ( IO_FILL_IO_SOUTH_16_0 DVDD ) ( IO_FILL_IO_SOUTH_15_5 DVDD ) ( IO_FILL_IO_SOUTH_18_0 DVDD ) ( IO_FILL_IO_SOUTH_20_0 DVDD ) ( IO_FILL_IO_SOUTH_19_0 DVDD )
-      ( IO_FILL_IO_SOUTH_38_0 DVDD ) ( IO_FILL_IO_SOUTH_37_0 DVDD ) ( IO_FILL_IO_EAST_60_180 DVDD ) ( IO_FILL_IO_EAST_60_175 DVDD ) ( IO_FILL_IO_EAST_60_170 DVDD ) ( IO_FILL_IO_EAST_60_165 DVDD ) ( IO_FILL_IO_EAST_60_160 DVDD ) ( IO_FILL_IO_EAST_60_155 DVDD )
-      ( IO_FILL_IO_EAST_60_150 DVDD ) ( IO_FILL_IO_EAST_60_145 DVDD ) ( IO_FILL_IO_EAST_60_140 DVDD ) ( IO_FILL_IO_EAST_60_135 DVDD ) ( IO_FILL_IO_EAST_60_130 DVDD ) ( IO_FILL_IO_EAST_60_125 DVDD ) ( IO_FILL_IO_EAST_60_120 DVDD ) ( IO_FILL_IO_EAST_60_115 DVDD )
-      ( IO_FILL_IO_EAST_60_110 DVDD ) ( IO_FILL_IO_EAST_60_105 DVDD ) ( IO_FILL_IO_EAST_60_100 DVDD ) ( IO_FILL_IO_EAST_60_95 DVDD ) ( IO_FILL_IO_EAST_60_90 DVDD ) ( IO_FILL_IO_EAST_60_85 DVDD ) ( IO_FILL_IO_EAST_60_80 DVDD ) ( IO_FILL_IO_EAST_60_75 DVDD )
-      ( IO_FILL_IO_EAST_60_70 DVDD ) ( IO_FILL_IO_EAST_60_65 DVDD ) ( IO_FILL_IO_EAST_60_60 DVDD ) ( IO_FILL_IO_EAST_60_55 DVDD ) ( IO_FILL_IO_EAST_60_50 DVDD ) ( IO_FILL_IO_EAST_60_45 DVDD ) ( IO_FILL_IO_EAST_60_40 DVDD ) ( IO_FILL_IO_EAST_60_35 DVDD )
-      ( IO_FILL_IO_EAST_60_30 DVDD ) ( IO_FILL_IO_EAST_60_25 DVDD ) ( IO_FILL_IO_EAST_60_20 DVDD ) ( IO_FILL_IO_EAST_60_15 DVDD ) ( IO_FILL_IO_EAST_60_10 DVDD ) ( IO_FILL_IO_EAST_60_5 DVDD ) ( IO_FILL_IO_EAST_59_120 DVDD ) ( IO_FILL_IO_EAST_59_115 DVDD )
-      ( IO_FILL_IO_EAST_59_110 DVDD ) ( IO_FILL_IO_EAST_59_105 DVDD ) ( IO_FILL_IO_EAST_59_100 DVDD ) ( IO_FILL_IO_EAST_59_95 DVDD ) ( IO_FILL_IO_EAST_59_90 DVDD ) ( IO_FILL_IO_EAST_59_85 DVDD ) ( IO_FILL_IO_EAST_59_80 DVDD ) ( IO_FILL_IO_EAST_59_75 DVDD )
-      ( IO_FILL_IO_EAST_59_70 DVDD ) ( IO_FILL_IO_EAST_59_65 DVDD ) ( IO_FILL_IO_EAST_59_60 DVDD ) ( IO_FILL_IO_EAST_59_55 DVDD ) ( IO_FILL_IO_EAST_59_50 DVDD ) ( IO_FILL_IO_EAST_59_45 DVDD ) ( IO_FILL_IO_EAST_59_40 DVDD ) ( IO_FILL_IO_EAST_59_35 DVDD )
-      ( IO_FILL_IO_EAST_59_30 DVDD ) ( IO_FILL_IO_EAST_59_25 DVDD ) ( IO_FILL_IO_EAST_59_20 DVDD ) ( IO_FILL_IO_EAST_59_15 DVDD ) ( IO_FILL_IO_EAST_59_10 DVDD ) ( IO_FILL_IO_EAST_59_5 DVDD ) ( IO_FILL_IO_EAST_57_65 DVDD ) ( IO_FILL_IO_EAST_57_60 DVDD )
-      ( IO_FILL_IO_EAST_57_55 DVDD ) ( IO_FILL_IO_EAST_57_50 DVDD ) ( IO_FILL_IO_EAST_57_45 DVDD ) ( IO_FILL_IO_EAST_57_40 DVDD ) ( IO_FILL_IO_EAST_57_35 DVDD ) ( IO_FILL_IO_EAST_57_30 DVDD ) ( IO_FILL_IO_EAST_57_25 DVDD ) ( IO_FILL_IO_EAST_57_20 DVDD )
-      ( IO_FILL_IO_EAST_57_15 DVDD ) ( IO_FILL_IO_EAST_57_10 DVDD ) ( IO_FILL_IO_EAST_57_5 DVDD ) ( IO_FILL_IO_EAST_54_65 DVDD ) ( IO_FILL_IO_EAST_54_60 DVDD ) ( IO_FILL_IO_EAST_54_55 DVDD ) ( IO_FILL_IO_EAST_54_50 DVDD ) ( IO_FILL_IO_EAST_54_45 DVDD )
-      ( IO_FILL_IO_EAST_54_40 DVDD ) ( IO_FILL_IO_EAST_54_35 DVDD ) ( IO_FILL_IO_EAST_54_30 DVDD ) ( IO_FILL_IO_EAST_54_25 DVDD ) ( IO_FILL_IO_EAST_54_20 DVDD ) ( IO_FILL_IO_EAST_54_15 DVDD ) ( IO_FILL_IO_EAST_54_10 DVDD ) ( IO_FILL_IO_EAST_54_5 DVDD )
-      ( IO_FILL_IO_EAST_50_5 DVDD ) ( IO_FILL_IO_EAST_35_5 DVDD ) ( IO_FILL_IO_EAST_30_5 DVDD ) ( IO_FILL_IO_EAST_15_5 DVDD ) ( IO_FILL_IO_EAST_10_35 DVDD ) ( IO_FILL_IO_EAST_10_30 DVDD ) ( IO_FILL_IO_EAST_10_25 DVDD ) ( IO_FILL_IO_EAST_10_20 DVDD )
-      ( IO_FILL_IO_EAST_10_15 DVDD ) ( IO_FILL_IO_EAST_10_10 DVDD ) ( IO_FILL_IO_EAST_10_5 DVDD ) ( IO_FILL_IO_EAST_6_35 DVDD ) ( IO_FILL_IO_EAST_6_30 DVDD ) ( IO_FILL_IO_EAST_6_25 DVDD ) ( IO_FILL_IO_EAST_6_20 DVDD ) ( IO_FILL_IO_EAST_6_15 DVDD )
-      ( IO_FILL_IO_EAST_6_10 DVDD ) ( IO_FILL_IO_EAST_6_5 DVDD ) ( IO_FILL_IO_EAST_3_90 DVDD ) ( IO_FILL_IO_EAST_3_85 DVDD ) ( IO_FILL_IO_EAST_3_80 DVDD ) ( IO_FILL_IO_EAST_3_75 DVDD ) ( IO_FILL_IO_EAST_3_70 DVDD ) ( IO_FILL_IO_EAST_3_65 DVDD )
-      ( IO_FILL_IO_EAST_3_60 DVDD ) ( IO_FILL_IO_EAST_3_55 DVDD ) ( IO_FILL_IO_EAST_3_50 DVDD ) ( IO_FILL_IO_EAST_3_45 DVDD ) ( IO_FILL_IO_EAST_3_40 DVDD ) ( IO_FILL_IO_EAST_3_35 DVDD ) ( IO_FILL_IO_EAST_3_30 DVDD ) ( IO_FILL_IO_EAST_3_25 DVDD )
-      ( IO_FILL_IO_EAST_3_20 DVDD ) ( IO_FILL_IO_EAST_3_15 DVDD ) ( IO_FILL_IO_EAST_3_10 DVDD ) ( IO_FILL_IO_EAST_3_5 DVDD ) ( IO_FILL_IO_EAST_1_95 DVDD ) ( IO_FILL_IO_EAST_1_90 DVDD ) ( IO_FILL_IO_EAST_1_85 DVDD ) ( IO_FILL_IO_EAST_1_80 DVDD )
-      ( IO_FILL_IO_EAST_1_75 DVDD ) ( IO_FILL_IO_EAST_1_70 DVDD ) ( IO_FILL_IO_EAST_1_65 DVDD ) ( IO_FILL_IO_EAST_1_60 DVDD ) ( IO_FILL_IO_EAST_1_55 DVDD ) ( IO_FILL_IO_EAST_1_50 DVDD ) ( IO_FILL_IO_EAST_1_45 DVDD ) ( IO_FILL_IO_EAST_1_40 DVDD )
-      ( IO_FILL_IO_EAST_1_35 DVDD ) ( IO_FILL_IO_EAST_1_30 DVDD ) ( IO_FILL_IO_EAST_1_25 DVDD ) ( IO_FILL_IO_EAST_1_20 DVDD ) ( IO_FILL_IO_EAST_1_15 DVDD ) ( IO_FILL_IO_EAST_1_10 DVDD ) ( IO_FILL_IO_EAST_1_5 DVDD ) ( IO_FILL_IO_EAST_0_20 DVDD )
-      ( IO_FILL_IO_EAST_6_40 DVDD ) ( IO_FILL_IO_EAST_40_5 DVDD ) ( IO_FILL_IO_EAST_57_0 DVDD ) ( IO_FILL_IO_EAST_56_0 DVDD ) ( IO_FILL_IO_EAST_38_0 DVDD ) ( IO_FILL_IO_EAST_22_0 DVDD ) ( IO_FILL_IO_EAST_4_0 DVDD ) ( IO_FILL_IO_EAST_3_95 DVDD )
-      ( IO_FILL_IO_EAST_7_0 DVDD ) ( IO_FILL_IO_EAST_54_0 DVDD ) ( IO_FILL_IO_EAST_53_0 DVDD ) ( IO_FILL_IO_EAST_47_0 DVDD ) ( IO_FILL_IO_EAST_41_0 DVDD ) ( IO_FILL_IO_EAST_33_0 DVDD ) ( IO_FILL_IO_EAST_27_0 DVDD ) ( IO_FILL_IO_EAST_20_0 DVDD )
-      ( IO_FILL_IO_EAST_19_0 DVDD ) ( IO_FILL_IO_EAST_13_0 DVDD ) ( IO_FILL_IO_EAST_30_0 DVDD ) ( IO_FILL_IO_EAST_29_0 DVDD ) ( IO_FILL_IO_EAST_28_0 DVDD ) ( IO_FILL_IO_EAST_15_0 DVDD ) ( IO_FILL_IO_EAST_14_0 DVDD ) ( IO_FILL_IO_EAST_16_0 DVDD )
-      ( IO_FILL_IO_EAST_15_10 DVDD ) ( IO_FILL_IO_EAST_16_5 DVDD ) ( IO_FILL_IO_EAST_18_0 DVDD ) ( IO_FILL_IO_EAST_17_0 DVDD ) ( IO_FILL_IO_EAST_21_0 DVDD ) ( IO_FILL_IO_EAST_20_5 DVDD ) ( IO_FILL_IO_EAST_24_0 DVDD ) ( IO_FILL_IO_EAST_23_0 DVDD )
-      ( IO_FILL_IO_EAST_25_0 DVDD ) ( IO_FILL_IO_EAST_24_5 DVDD ) ( IO_FILL_IO_EAST_26_0 DVDD ) ( IO_FILL_IO_EAST_25_5 DVDD ) ( IO_FILL_IO_EAST_1_0 DVDD ) ( IO_FILL_IO_EAST_0_25 DVDD ) ( IO_FILL_IO_EAST_2_0 DVDD ) ( IO_FILL_IO_EAST_1_100 DVDD )
-      ( IO_FILL_IO_EAST_3_0 DVDD ) ( IO_FILL_IO_EAST_2_5 DVDD ) ( IO_FILL_IO_EAST_6_0 DVDD ) ( IO_FILL_IO_EAST_5_0 DVDD ) ( IO_FILL_IO_EAST_8_0 DVDD ) ( IO_FILL_IO_EAST_10_0 DVDD ) ( IO_FILL_IO_EAST_9_0 DVDD ) ( IO_FILL_IO_EAST_10_40 DVDD )
-      ( IO_FILL_IO_EAST_12_0 DVDD ) ( IO_FILL_IO_EAST_11_0 DVDD ) ( IO_FILL_IO_EAST_30_10 DVDD ) ( IO_FILL_IO_EAST_45_0 DVDD ) ( IO_FILL_IO_EAST_44_5 DVDD ) ( IO_FILL_IO_EAST_46_0 DVDD ) ( IO_FILL_IO_EAST_45_5 DVDD ) ( IO_FILL_IO_EAST_48_0 DVDD )
-      ( IO_FILL_IO_EAST_37_0 DVDD ) ( IO_FILL_IO_EAST_36_5 DVDD ) ( IO_FILL_IO_EAST_40_0 DVDD ) ( IO_FILL_IO_EAST_39_0 DVDD ) ( IO_FILL_IO_EAST_42_0 DVDD ) ( IO_FILL_IO_EAST_44_0 DVDD ) ( IO_FILL_IO_EAST_43_0 DVDD ) ( IO_FILL_IO_EAST_50_0 DVDD )
-      ( IO_FILL_IO_EAST_49_0 DVDD ) ( IO_FILL_IO_EAST_50_10 DVDD ) ( IO_FILL_IO_EAST_52_0 DVDD ) ( IO_FILL_IO_EAST_51_0 DVDD ) ( IO_FILL_IO_EAST_55_0 DVDD ) ( IO_FILL_IO_EAST_54_70 DVDD ) ( IO_FILL_IO_EAST_58_0 DVDD ) ( IO_FILL_IO_EAST_57_70 DVDD )
-      ( IO_FILL_IO_EAST_59_0 DVDD ) ( IO_FILL_IO_EAST_58_5 DVDD ) ( IO_FILL_IO_EAST_60_0 DVDD ) ( IO_FILL_IO_EAST_59_125 DVDD ) ( IO_FILL_IO_EAST_36_0 DVDD ) ( IO_FILL_IO_EAST_35_10 DVDD ) ( IO_FILL_IO_EAST_35_0 DVDD ) ( IO_FILL_IO_EAST_34_0 DVDD )
-      ( IO_FILL_IO_EAST_32_0 DVDD ) ( IO_FILL_IO_EAST_31_0 DVDD ) ( IO_FILL_IO_NORTH_53_95 DVDD ) ( IO_FILL_IO_NORTH_53_90 DVDD ) ( IO_FILL_IO_NORTH_53_85 DVDD ) ( IO_FILL_IO_NORTH_53_80 DVDD ) ( IO_FILL_IO_NORTH_53_75 DVDD ) ( IO_FILL_IO_NORTH_53_70 DVDD )
-      ( IO_FILL_IO_NORTH_53_65 DVDD ) ( IO_FILL_IO_NORTH_53_60 DVDD ) ( IO_FILL_IO_NORTH_53_55 DVDD ) ( IO_FILL_IO_NORTH_53_50 DVDD ) ( IO_FILL_IO_NORTH_53_45 DVDD ) ( IO_FILL_IO_NORTH_53_40 DVDD ) ( IO_FILL_IO_NORTH_53_35 DVDD ) ( IO_FILL_IO_NORTH_53_30 DVDD )
-      ( IO_FILL_IO_NORTH_53_25 DVDD ) ( IO_FILL_IO_NORTH_53_20 DVDD ) ( IO_FILL_IO_NORTH_53_15 DVDD ) ( IO_FILL_IO_NORTH_53_10 DVDD ) ( IO_FILL_IO_NORTH_53_5 DVDD ) ( IO_FILL_IO_NORTH_51_95 DVDD ) ( IO_FILL_IO_NORTH_51_90 DVDD ) ( IO_FILL_IO_NORTH_51_85 DVDD )
-      ( IO_FILL_IO_NORTH_51_80 DVDD ) ( IO_FILL_IO_NORTH_51_75 DVDD ) ( IO_FILL_IO_NORTH_51_70 DVDD ) ( IO_FILL_IO_NORTH_51_65 DVDD ) ( IO_FILL_IO_NORTH_51_60 DVDD ) ( IO_FILL_IO_NORTH_51_55 DVDD ) ( IO_FILL_IO_NORTH_51_50 DVDD ) ( IO_FILL_IO_NORTH_51_45 DVDD )
-      ( IO_FILL_IO_NORTH_51_40 DVDD ) ( IO_FILL_IO_NORTH_51_35 DVDD ) ( IO_FILL_IO_NORTH_51_30 DVDD ) ( IO_FILL_IO_NORTH_51_25 DVDD ) ( IO_FILL_IO_NORTH_51_20 DVDD ) ( IO_FILL_IO_NORTH_51_15 DVDD ) ( IO_FILL_IO_NORTH_51_10 DVDD ) ( IO_FILL_IO_NORTH_51_5 DVDD )
-      ( IO_FILL_IO_NORTH_48_35 DVDD ) ( IO_FILL_IO_NORTH_48_30 DVDD ) ( IO_FILL_IO_NORTH_48_25 DVDD ) ( IO_FILL_IO_NORTH_48_20 DVDD ) ( IO_FILL_IO_NORTH_48_15 DVDD ) ( IO_FILL_IO_NORTH_48_10 DVDD ) ( IO_FILL_IO_NORTH_48_5 DVDD ) ( IO_FILL_IO_NORTH_44_30 DVDD )
-      ( IO_FILL_IO_NORTH_44_25 DVDD ) ( IO_FILL_IO_NORTH_44_20 DVDD ) ( IO_FILL_IO_NORTH_44_15 DVDD ) ( IO_FILL_IO_NORTH_44_10 DVDD ) ( IO_FILL_IO_NORTH_44_5 DVDD ) ( IO_FILL_IO_NORTH_42_20 DVDD ) ( IO_FILL_IO_NORTH_42_15 DVDD ) ( IO_FILL_IO_NORTH_42_10 DVDD )
-      ( IO_FILL_IO_NORTH_42_5 DVDD ) ( IO_FILL_IO_NORTH_30_15 DVDD ) ( IO_FILL_IO_NORTH_30_10 DVDD ) ( IO_FILL_IO_NORTH_30_5 DVDD ) ( IO_FILL_IO_NORTH_25_5 DVDD ) ( IO_FILL_IO_NORTH_10_5 DVDD ) ( IO_FILL_IO_NORTH_6_60 DVDD ) ( IO_FILL_IO_NORTH_6_55 DVDD )
-      ( IO_FILL_IO_NORTH_6_50 DVDD ) ( IO_FILL_IO_NORTH_6_45 DVDD ) ( IO_FILL_IO_NORTH_6_40 DVDD ) ( IO_FILL_IO_NORTH_6_35 DVDD ) ( IO_FILL_IO_NORTH_6_30 DVDD ) ( IO_FILL_IO_NORTH_6_25 DVDD ) ( IO_FILL_IO_NORTH_6_20 DVDD ) ( IO_FILL_IO_NORTH_6_15 DVDD )
-      ( IO_FILL_IO_NORTH_6_10 DVDD ) ( IO_FILL_IO_NORTH_6_5 DVDD ) ( IO_FILL_IO_NORTH_3_65 DVDD ) ( IO_FILL_IO_NORTH_3_60 DVDD ) ( IO_FILL_IO_NORTH_3_55 DVDD ) ( IO_FILL_IO_NORTH_3_50 DVDD ) ( IO_FILL_IO_NORTH_3_45 DVDD ) ( IO_FILL_IO_NORTH_3_40 DVDD )
-      ( IO_FILL_IO_NORTH_3_35 DVDD ) ( IO_FILL_IO_NORTH_3_30 DVDD ) ( IO_FILL_IO_NORTH_3_25 DVDD ) ( IO_FILL_IO_NORTH_3_20 DVDD ) ( IO_FILL_IO_NORTH_3_15 DVDD ) ( IO_FILL_IO_NORTH_3_10 DVDD ) ( IO_FILL_IO_NORTH_3_5 DVDD ) ( IO_FILL_IO_NORTH_1_125 DVDD )
-      ( IO_FILL_IO_NORTH_1_120 DVDD ) ( IO_FILL_IO_NORTH_1_115 DVDD ) ( IO_FILL_IO_NORTH_1_110 DVDD ) ( IO_FILL_IO_NORTH_1_105 DVDD ) ( IO_FILL_IO_NORTH_1_100 DVDD ) ( IO_FILL_IO_NORTH_1_95 DVDD ) ( IO_FILL_IO_NORTH_1_90 DVDD ) ( IO_FILL_IO_NORTH_1_85 DVDD )
-      ( IO_FILL_IO_NORTH_1_80 DVDD ) ( IO_FILL_IO_NORTH_1_75 DVDD ) ( IO_FILL_IO_NORTH_1_70 DVDD ) ( IO_FILL_IO_NORTH_1_65 DVDD ) ( IO_FILL_IO_NORTH_1_60 DVDD ) ( IO_FILL_IO_NORTH_1_55 DVDD ) ( IO_FILL_IO_NORTH_1_50 DVDD ) ( IO_FILL_IO_NORTH_1_45 DVDD )
-      ( IO_FILL_IO_NORTH_1_40 DVDD ) ( IO_FILL_IO_NORTH_1_35 DVDD ) ( IO_FILL_IO_NORTH_1_30 DVDD ) ( IO_FILL_IO_NORTH_1_25 DVDD ) ( IO_FILL_IO_NORTH_1_20 DVDD ) ( IO_FILL_IO_NORTH_1_15 DVDD ) ( IO_FILL_IO_NORTH_1_10 DVDD ) ( IO_FILL_IO_NORTH_1_5 DVDD )
-      ( IO_FILL_IO_NORTH_0_210 DVDD ) ( IO_FILL_IO_NORTH_0_205 DVDD ) ( IO_FILL_IO_NORTH_0_200 DVDD ) ( IO_FILL_IO_NORTH_0_195 DVDD ) ( IO_FILL_IO_NORTH_0_190 DVDD ) ( IO_FILL_IO_NORTH_0_185 DVDD ) ( IO_FILL_IO_NORTH_0_180 DVDD ) ( IO_FILL_IO_NORTH_0_175 DVDD )
-      ( IO_FILL_IO_NORTH_0_170 DVDD ) ( IO_FILL_IO_NORTH_0_165 DVDD ) ( IO_FILL_IO_NORTH_0_160 DVDD ) ( IO_FILL_IO_NORTH_0_155 DVDD ) ( IO_FILL_IO_NORTH_0_150 DVDD ) ( IO_FILL_IO_NORTH_0_145 DVDD ) ( IO_FILL_IO_NORTH_0_140 DVDD ) ( IO_FILL_IO_NORTH_0_135 DVDD )
-      ( IO_FILL_IO_NORTH_0_130 DVDD ) ( IO_FILL_IO_NORTH_0_125 DVDD ) ( IO_FILL_IO_NORTH_0_120 DVDD ) ( IO_FILL_IO_NORTH_0_115 DVDD ) ( IO_FILL_IO_NORTH_0_110 DVDD ) ( IO_FILL_IO_NORTH_0_105 DVDD ) ( IO_FILL_IO_NORTH_0_100 DVDD ) ( IO_FILL_IO_NORTH_0_95 DVDD )
-      ( IO_FILL_IO_NORTH_0_90 DVDD ) ( IO_FILL_IO_NORTH_0_85 DVDD ) ( IO_FILL_IO_NORTH_0_80 DVDD ) ( IO_FILL_IO_NORTH_0_75 DVDD ) ( IO_FILL_IO_NORTH_0_70 DVDD ) ( IO_FILL_IO_NORTH_0_65 DVDD ) ( IO_FILL_IO_NORTH_0_60 DVDD ) ( IO_FILL_IO_NORTH_0_55 DVDD )
-      ( IO_FILL_IO_NORTH_0_50 DVDD ) ( IO_FILL_IO_NORTH_0_45 DVDD ) ( IO_FILL_IO_NORTH_0_40 DVDD ) ( IO_FILL_IO_NORTH_0_35 DVDD ) ( IO_FILL_IO_NORTH_0_30 DVDD ) ( IO_FILL_IO_NORTH_0_25 DVDD ) ( IO_FILL_IO_NORTH_0_20 DVDD ) ( IO_FILL_IO_NORTH_0_15 DVDD )
-      ( IO_FILL_IO_NORTH_0_10 DVDD ) ( IO_FILL_IO_NORTH_0_5 DVDD ) ( IO_FILL_IO_NORTH_0_0 DVDD ) ( u_brk0 DVDDA ) ( IO_FILL_IO_NORTH_1_130 DVDD ) ( IO_FILL_IO_NORTH_10_0 DVDD ) ( IO_FILL_IO_NORTH_15_5 DVDD ) ( IO_FILL_IO_NORTH_53_100 DVDD )
-      ( IO_FILL_IO_NORTH_37_0 DVDD ) ( IO_FILL_IO_NORTH_48_40 DVDD ) ( IO_FILL_IO_NORTH_6_0 DVDD ) ( IO_FILL_IO_NORTH_22_0 DVDD ) ( IO_FILL_IO_NORTH_30_20 DVDD ) ( IO_FILL_IO_NORTH_37_5 DVDD ) ( IO_FILL_IO_NORTH_49_0 DVDD ) ( IO_FILL_IO_NORTH_6_65 DVDD )
-      ( IO_FILL_IO_NORTH_23_0 DVDD ) ( IO_FILL_IO_NORTH_1_0 DVDD ) ( IO_FILL_IO_NORTH_0_215 DVDD ) ( IO_FILL_IO_NORTH_9_0 DVDD ) ( IO_FILL_IO_NORTH_15_0 DVDD ) ( IO_FILL_IO_NORTH_21_0 DVDD ) ( IO_FILL_IO_NORTH_20_5 DVDD ) ( IO_FILL_IO_NORTH_26_5 DVDD )
-      ( IO_FILL_IO_NORTH_35_0 DVDD ) ( IO_FILL_IO_NORTH_34_0 DVDD ) ( IO_FILL_IO_NORTH_45_0 DVDD ) ( IO_FILL_IO_NORTH_44_35 DVDD ) ( IO_FILL_IO_NORTH_53_0 DVDD ) ( IO_FILL_IO_NORTH_36_0 DVDD ) ( IO_FILL_IO_NORTH_35_5 DVDD ) ( IO_FILL_IO_NORTH_33_0 DVDD )
-      ( IO_FILL_IO_NORTH_32_5 DVDD ) ( IO_FILL_IO_NORTH_32_0 DVDD ) ( u_brk0 DVDDB ) ( IO_FILL_IO_NORTH_31_0 DVDD ) ( IO_FILL_IO_NORTH_39_0 DVDD ) ( IO_FILL_IO_NORTH_38_0 DVDD ) ( IO_FILL_IO_NORTH_14_0 DVDD ) ( IO_FILL_IO_NORTH_13_0 DVDD )
-      ( IO_FILL_IO_NORTH_12_5 DVDD ) ( IO_FILL_IO_NORTH_12_0 DVDD ) ( IO_FILL_IO_NORTH_20_0 DVDD ) ( IO_FILL_IO_NORTH_19_0 DVDD ) ( IO_FILL_IO_NORTH_18_5 DVDD ) ( IO_FILL_IO_NORTH_18_0 DVDD ) ( IO_FILL_IO_NORTH_17_0 DVDD ) ( IO_FILL_IO_NORTH_16_0 DVDD )
-      ( IO_FILL_IO_NORTH_11_0 DVDD ) ( IO_FILL_IO_NORTH_10_10 DVDD ) ( IO_FILL_IO_NORTH_8_0 DVDD ) ( IO_FILL_IO_NORTH_7_0 DVDD ) ( IO_FILL_IO_NORTH_5_0 DVDD ) ( IO_FILL_IO_NORTH_4_5 DVDD ) ( IO_FILL_IO_NORTH_4_0 DVDD ) ( IO_FILL_IO_NORTH_3_70 DVDD )
-      ( IO_FILL_IO_NORTH_3_0 DVDD ) ( IO_FILL_IO_NORTH_2_0 DVDD ) ( IO_FILL_IO_NORTH_30_0 DVDD ) ( IO_FILL_IO_NORTH_29_0 DVDD ) ( IO_FILL_IO_NORTH_28_0 DVDD ) ( IO_FILL_IO_NORTH_27_0 DVDD ) ( IO_FILL_IO_NORTH_26_0 DVDD ) ( IO_FILL_IO_NORTH_25_10 DVDD )
-      ( IO_FILL_IO_NORTH_25_0 DVDD ) ( IO_FILL_IO_NORTH_24_0 DVDD ) ( IO_FILL_IO_NORTH_48_0 DVDD ) ( IO_FILL_IO_NORTH_47_0 DVDD ) ( IO_FILL_IO_NORTH_46_0 DVDD ) ( IO_FILL_IO_NORTH_44_0 DVDD ) ( IO_FILL_IO_NORTH_52_0 DVDD ) ( IO_FILL_IO_NORTH_51_100 DVDD )
-      ( IO_FILL_IO_NORTH_51_0 DVDD ) ( IO_FILL_IO_NORTH_50_0 DVDD ) ( IO_FILL_IO_NORTH_43_0 DVDD ) ( IO_FILL_IO_NORTH_42_25 DVDD ) ( IO_FILL_IO_NORTH_42_0 DVDD ) ( IO_FILL_IO_NORTH_41_0 DVDD ) ( IO_FILL_IO_NORTH_40_0 DVDD ) ( IO_FILL_IO_NORTH_39_5 DVDD )
-      ( IO_FILL_IO_EAST_60_185 DVDD ) ( IO_FILL_IO_EAST_60_190 DVDD ) ( IO_CORNER_NORTH_EAST_INST DVDD ) ( IO_FILL_IO_NORTH_54_0 DVDD ) ( IO_CORNER_NORTH_WEST_INST DVDD ) ( IO_FILL_IO_WEST_57_0 DVDD ) ( u_v18_33 DVDD ) ( u_vzz_33 DVDD )
-      ( u_vdd_0 DVDD ) ( u_v18_0 DVDD ) ( u_vzz_9 DVDD ) ( u_vzz_8 DVDD ) ( u_vzz_7 DVDD ) ( u_vzz_6 DVDD ) ( u_vzz_5 DVDD ) ( u_vzz_4 DVDD )
-      ( u_vzz_32 DVDD ) ( u_vzz_31 DVDD ) ( u_vzz_30 DVDD ) ( u_vzz_3 DVDD ) ( u_vzz_29 DVDD ) ( u_vzz_28 DVDD ) ( u_vzz_27 DVDD ) ( u_vzz_26 DVDD )
-      ( u_vzz_25 DVDD ) ( u_vzz_24 DVDD ) ( u_vzz_23 DVDD ) ( u_vzz_22 DVDD ) ( u_vzz_21 DVDD ) ( u_vzz_20 DVDD ) ( u_vzz_2 DVDD ) ( u_vzz_19 DVDD )
-      ( u_vzz_18 DVDD ) ( u_vzz_17 DVDD ) ( u_vzz_16 DVDD ) ( u_vzz_15 DVDD ) ( u_vzz_14 DVDD ) ( u_vzz_13 DVDD ) ( u_vzz_12 DVDD ) ( u_vzz_11 DVDD )
-      ( u_vzz_10 DVDD ) ( u_vzz_1 DVDD ) ( u_vzz_0 DVDD ) ( u_vss_pll DVDD ) ( u_vss_9 DVDD ) ( u_vss_8 DVDD ) ( u_vss_7 DVDD ) ( u_vss_6 DVDD )
-      ( u_vss_5 DVDD ) ( u_vss_4 DVDD ) ( u_vss_32 DVDD ) ( u_vss_31 DVDD ) ( u_vss_30 DVDD ) ( u_vss_3 DVDD ) ( u_vss_29 DVDD ) ( u_vss_28 DVDD )
-      ( u_vss_27 DVDD ) ( u_vss_26 DVDD ) ( u_vss_25 DVDD ) ( u_vss_24 DVDD ) ( u_vss_23 DVDD ) ( u_vss_22 DVDD ) ( u_vss_21 DVDD ) ( u_vss_20 DVDD )
-      ( u_vss_2 DVDD ) ( u_vss_19 DVDD ) ( u_vss_18 DVDD ) ( u_vss_17 DVDD ) ( u_vss_16 DVDD ) ( u_vss_15 DVDD ) ( u_vss_14 DVDD ) ( u_vss_13 DVDD )
-      ( u_vss_12 DVDD ) ( u_vss_11 DVDD ) ( u_vss_10 DVDD ) ( u_vss_1 DVDD ) ( u_vss_0 DVDD ) ( u_vdd_pll DVDD ) ( u_vdd_9 DVDD ) ( u_vdd_8 DVDD )
-      ( u_vdd_7 DVDD ) ( u_vdd_6 DVDD ) ( u_vdd_5 DVDD ) ( u_vdd_4 DVDD ) ( u_vdd_32 DVDD ) ( u_vdd_31 DVDD ) ( u_vdd_30 DVDD ) ( u_vdd_3 DVDD )
-      ( u_vdd_29 DVDD ) ( u_vdd_28 DVDD ) ( u_vdd_27 DVDD ) ( u_vdd_26 DVDD ) ( u_vdd_25 DVDD ) ( u_vdd_24 DVDD ) ( u_vdd_23 DVDD ) ( u_vdd_22 DVDD )
-      ( u_vdd_21 DVDD ) ( u_vdd_20 DVDD ) ( u_vdd_2 DVDD ) ( u_vdd_19 DVDD ) ( u_vdd_18 DVDD ) ( u_vdd_17 DVDD ) ( u_vdd_16 DVDD ) ( u_vdd_15 DVDD )
-      ( u_vdd_14 DVDD ) ( u_vdd_13 DVDD ) ( u_vdd_12 DVDD ) ( u_vdd_11 DVDD ) ( u_vdd_10 DVDD ) ( u_vdd_1 DVDD ) ( u_v18_9 DVDD ) ( u_v18_8 DVDD )
-      ( u_v18_7 DVDD ) ( u_v18_6 DVDD ) ( u_v18_5 DVDD ) ( u_v18_4 DVDD ) ( u_v18_32 DVDD ) ( u_v18_31 DVDD ) ( u_v18_30 DVDD ) ( u_v18_3 DVDD )
-      ( u_v18_29 DVDD ) ( u_v18_28 DVDD ) ( u_v18_27 DVDD ) ( u_v18_26 DVDD ) ( u_v18_25 DVDD ) ( u_v18_24 DVDD ) ( u_v18_23 DVDD ) ( u_v18_22 DVDD )
-      ( u_v18_21 DVDD ) ( u_v18_20 DVDD ) ( u_v18_2 DVDD ) ( u_v18_19 DVDD ) ( u_v18_18 DVDD ) ( u_v18_17 DVDD ) ( u_v18_16 DVDD ) ( u_v18_15 DVDD )
-      ( u_v18_14 DVDD ) ( u_v18_13 DVDD ) ( u_v18_12 DVDD ) ( u_v18_11 DVDD ) ( u_v18_10 DVDD ) ( u_v18_1 DVDD ) ( u_sel_2_i DVDD ) ( u_sel_1_i DVDD )
-      ( u_sel_0_i DVDD ) ( u_misc_o DVDD ) ( u_ddr_we_n_o DVDD ) ( u_ddr_reset_n_o DVDD ) ( u_ddr_ras_n_o DVDD ) ( u_ddr_odt_o DVDD ) ( u_ddr_dqs_p_3_io DVDD ) ( u_ddr_dqs_p_2_io DVDD )
-      ( u_ddr_dqs_p_1_io DVDD ) ( u_ddr_dqs_p_0_io DVDD ) ( u_ddr_dqs_n_3_io DVDD ) ( u_ddr_dqs_n_2_io DVDD ) ( u_ddr_dqs_n_1_io DVDD ) ( u_ddr_dqs_n_0_io DVDD ) ( u_ddr_dq_9_io DVDD ) ( u_ddr_dq_8_io DVDD )
-      ( u_ddr_dq_7_io DVDD ) ( u_ddr_dq_6_io DVDD ) ( u_ddr_dq_5_io DVDD ) ( u_ddr_dq_4_io DVDD ) ( u_ddr_dq_3_io DVDD ) ( u_ddr_dq_31_io DVDD ) ( u_ddr_dq_30_io DVDD ) ( u_ddr_dq_2_io DVDD )
-      ( u_ddr_dq_29_io DVDD ) ( u_ddr_dq_28_io DVDD ) ( u_ddr_dq_27_io DVDD ) ( u_ddr_dq_26_io DVDD ) ( u_ddr_dq_25_io DVDD ) ( u_ddr_dq_24_io DVDD ) ( u_ddr_dq_23_io DVDD ) ( u_ddr_dq_22_io DVDD )
-      ( u_ddr_dq_21_io DVDD ) ( u_ddr_dq_20_io DVDD ) ( u_ddr_dq_1_io DVDD ) ( u_ddr_dq_19_io DVDD ) ( u_ddr_dq_18_io DVDD ) ( u_ddr_dq_17_io DVDD ) ( u_ddr_dq_16_io DVDD ) ( u_ddr_dq_15_io DVDD )
-      ( u_ddr_dq_14_io DVDD ) ( u_ddr_dq_13_io DVDD ) ( u_ddr_dq_12_io DVDD ) ( u_ddr_dq_11_io DVDD ) ( u_ddr_dq_10_io DVDD ) ( u_ddr_dq_0_io DVDD ) ( u_ddr_dm_3_o DVDD ) ( u_ddr_dm_2_o DVDD )
-      ( u_ddr_dm_1_o DVDD ) ( u_ddr_dm_0_o DVDD ) ( u_ddr_cs_n_o DVDD ) ( u_ddr_cke_o DVDD ) ( u_ddr_ck_p_o DVDD ) ( u_ddr_ck_n_o DVDD ) ( u_ddr_cas_n_o DVDD ) ( u_ddr_ba_2_o DVDD )
-      ( u_ddr_ba_1_o DVDD ) ( u_ddr_ba_0_o DVDD ) ( u_ddr_addr_9_o DVDD ) ( u_ddr_addr_8_o DVDD ) ( u_ddr_addr_7_o DVDD ) ( u_ddr_addr_6_o DVDD ) ( u_ddr_addr_5_o DVDD ) ( u_ddr_addr_4_o DVDD )
-      ( u_ddr_addr_3_o DVDD ) ( u_ddr_addr_2_o DVDD ) ( u_ddr_addr_1_o DVDD ) ( u_ddr_addr_15_o DVDD ) ( u_ddr_addr_14_o DVDD ) ( u_ddr_addr_13_o DVDD ) ( u_ddr_addr_12_o DVDD ) ( u_ddr_addr_11_o DVDD )
-      ( u_ddr_addr_10_o DVDD ) ( u_ddr_addr_0_o DVDD ) ( u_core_async_reset_i DVDD ) ( u_co_v_i DVDD ) ( u_co_tkn_o DVDD ) ( u_co_clk_i DVDD ) ( u_co_8_i DVDD ) ( u_co_7_i DVDD )
-      ( u_co_6_i DVDD ) ( u_co_5_i DVDD ) ( u_co_4_i DVDD ) ( u_co_3_i DVDD ) ( u_co_2_i DVDD ) ( u_co_1_i DVDD ) ( u_co_0_i DVDD ) ( u_co2_v_o DVDD )
-      ( u_co2_tkn_i DVDD ) ( u_co2_clk_o DVDD ) ( u_co2_8_o DVDD ) ( u_co2_7_o DVDD ) ( u_co2_6_o DVDD ) ( u_co2_5_o DVDD ) ( u_co2_4_o DVDD ) ( u_co2_3_o DVDD )
-      ( u_co2_2_o DVDD ) ( u_co2_1_o DVDD ) ( u_co2_0_o DVDD ) ( u_clk_o DVDD ) ( u_clk_async_reset_i DVDD ) ( u_clk_C_i DVDD ) ( u_clk_B_i DVDD ) ( u_clk_A_i DVDD )
-      ( u_ci_v_i DVDD ) ( u_ci_tkn_o DVDD ) ( u_ci_clk_i DVDD ) ( u_ci_8_i DVDD ) ( u_ci_7_i DVDD ) ( u_ci_6_i DVDD ) ( u_ci_5_i DVDD ) ( u_ci_4_i DVDD )
-      ( u_ci_3_i DVDD ) ( u_ci_2_i DVDD ) ( u_ci_1_i DVDD ) ( u_ci_0_i DVDD ) ( u_ci2_v_o DVDD ) ( u_ci2_tkn_i DVDD ) ( u_ci2_clk_o DVDD ) ( u_ci2_8_o DVDD )
-      ( u_ci2_7_o DVDD ) ( u_ci2_6_o DVDD ) ( u_ci2_5_o DVDD ) ( u_ci2_4_o DVDD ) ( u_ci2_3_o DVDD ) ( u_ci2_2_o DVDD ) ( u_ci2_1_o DVDD ) ( u_ci2_0_o DVDD )
-      ( u_bsg_tag_en_i DVDD ) ( u_bsg_tag_data_o DVDD ) ( u_bsg_tag_data_i DVDD ) ( u_bsg_tag_clk_o DVDD ) ( u_bsg_tag_clk_i DVDD ) + USE POWER ;
-    - DVSS ( PIN DVSS ) ( IO_FILL_IO_WEST_0_485 DVSS ) ( IO_FILL_IO_WEST_0_480 DVSS ) ( IO_FILL_IO_WEST_0_475 DVSS ) ( IO_FILL_IO_WEST_0_470 DVSS ) ( IO_FILL_IO_WEST_0_465 DVSS ) ( IO_FILL_IO_WEST_0_460 DVSS )
-      ( IO_FILL_IO_WEST_0_455 DVSS ) ( IO_FILL_IO_WEST_0_450 DVSS ) ( IO_FILL_IO_WEST_0_445 DVSS ) ( IO_FILL_IO_WEST_0_440 DVSS ) ( IO_FILL_IO_WEST_0_435 DVSS ) ( IO_FILL_IO_WEST_0_430 DVSS ) ( IO_FILL_IO_WEST_0_425 DVSS ) ( IO_FILL_IO_WEST_0_420 DVSS )
-      ( IO_FILL_IO_WEST_0_415 DVSS ) ( IO_FILL_IO_WEST_0_410 DVSS ) ( IO_FILL_IO_WEST_0_405 DVSS ) ( IO_FILL_IO_WEST_0_400 DVSS ) ( IO_FILL_IO_WEST_0_395 DVSS ) ( IO_FILL_IO_WEST_0_390 DVSS ) ( IO_FILL_IO_WEST_0_385 DVSS ) ( IO_FILL_IO_WEST_0_380 DVSS )
-      ( IO_FILL_IO_WEST_0_375 DVSS ) ( IO_FILL_IO_WEST_0_370 DVSS ) ( IO_FILL_IO_WEST_0_365 DVSS ) ( IO_FILL_IO_WEST_0_360 DVSS ) ( IO_FILL_IO_WEST_0_355 DVSS ) ( IO_FILL_IO_WEST_0_350 DVSS ) ( IO_FILL_IO_WEST_0_345 DVSS ) ( IO_FILL_IO_WEST_0_340 DVSS )
-      ( IO_FILL_IO_WEST_0_335 DVSS ) ( IO_FILL_IO_WEST_0_330 DVSS ) ( IO_FILL_IO_WEST_0_325 DVSS ) ( IO_FILL_IO_WEST_0_320 DVSS ) ( IO_FILL_IO_WEST_0_315 DVSS ) ( IO_FILL_IO_WEST_0_310 DVSS ) ( IO_FILL_IO_WEST_0_305 DVSS ) ( IO_FILL_IO_WEST_0_300 DVSS )
-      ( IO_FILL_IO_WEST_0_295 DVSS ) ( IO_FILL_IO_WEST_0_290 DVSS ) ( IO_FILL_IO_WEST_0_285 DVSS ) ( IO_FILL_IO_WEST_0_280 DVSS ) ( IO_FILL_IO_WEST_0_275 DVSS ) ( IO_FILL_IO_WEST_0_270 DVSS ) ( IO_FILL_IO_WEST_0_265 DVSS ) ( IO_FILL_IO_WEST_0_260 DVSS )
-      ( IO_FILL_IO_WEST_0_255 DVSS ) ( IO_FILL_IO_WEST_0_250 DVSS ) ( IO_FILL_IO_WEST_0_245 DVSS ) ( IO_FILL_IO_WEST_0_240 DVSS ) ( IO_FILL_IO_WEST_0_235 DVSS ) ( IO_FILL_IO_WEST_0_230 DVSS ) ( IO_FILL_IO_WEST_0_225 DVSS ) ( IO_FILL_IO_WEST_0_220 DVSS )
-      ( IO_FILL_IO_WEST_0_215 DVSS ) ( IO_FILL_IO_WEST_0_210 DVSS ) ( IO_FILL_IO_WEST_0_205 DVSS ) ( IO_FILL_IO_WEST_0_200 DVSS ) ( IO_FILL_IO_WEST_0_195 DVSS ) ( IO_FILL_IO_WEST_0_190 DVSS ) ( IO_FILL_IO_WEST_0_185 DVSS ) ( IO_FILL_IO_WEST_0_180 DVSS )
-      ( IO_FILL_IO_WEST_0_175 DVSS ) ( IO_FILL_IO_WEST_0_170 DVSS ) ( IO_FILL_IO_WEST_0_165 DVSS ) ( IO_FILL_IO_WEST_0_160 DVSS ) ( IO_FILL_IO_WEST_0_155 DVSS ) ( IO_FILL_IO_WEST_0_150 DVSS ) ( IO_FILL_IO_WEST_0_145 DVSS ) ( IO_FILL_IO_WEST_0_140 DVSS )
-      ( IO_FILL_IO_WEST_0_135 DVSS ) ( IO_FILL_IO_WEST_0_130 DVSS ) ( IO_FILL_IO_WEST_0_125 DVSS ) ( IO_FILL_IO_WEST_0_120 DVSS ) ( IO_FILL_IO_WEST_0_115 DVSS ) ( IO_FILL_IO_WEST_0_110 DVSS ) ( IO_FILL_IO_WEST_0_105 DVSS ) ( IO_FILL_IO_WEST_0_100 DVSS )
-      ( IO_FILL_IO_WEST_0_95 DVSS ) ( IO_FILL_IO_WEST_0_90 DVSS ) ( IO_FILL_IO_WEST_0_85 DVSS ) ( IO_FILL_IO_WEST_0_80 DVSS ) ( IO_FILL_IO_WEST_0_75 DVSS ) ( IO_FILL_IO_WEST_0_70 DVSS ) ( IO_FILL_IO_WEST_0_65 DVSS ) ( IO_FILL_IO_WEST_0_60 DVSS )
-      ( IO_FILL_IO_WEST_0_55 DVSS ) ( IO_FILL_IO_WEST_0_50 DVSS ) ( IO_FILL_IO_WEST_0_45 DVSS ) ( IO_FILL_IO_WEST_0_40 DVSS ) ( IO_FILL_IO_WEST_0_35 DVSS ) ( IO_FILL_IO_WEST_0_30 DVSS ) ( IO_FILL_IO_WEST_0_25 DVSS ) ( IO_FILL_IO_WEST_0_20 DVSS )
-      ( IO_FILL_IO_WEST_0_15 DVSS ) ( IO_FILL_IO_WEST_0_10 DVSS ) ( IO_FILL_IO_WEST_0_5 DVSS ) ( IO_FILL_IO_WEST_0_0 DVSS ) ( IO_CORNER_SOUTH_WEST_INST DVSS ) ( IO_FILL_IO_SOUTH_0_0 DVSS ) ( IO_FILL_IO_SOUTH_0_5 DVSS ) ( IO_FILL_IO_WEST_0_490 DVSS )
-      ( IO_FILL_IO_SOUTH_0_10 DVSS ) ( IO_FILL_IO_WEST_0_495 DVSS ) ( IO_FILL_IO_SOUTH_0_15 DVSS ) ( IO_FILL_IO_EAST_0_15 DVSS ) ( IO_FILL_IO_EAST_0_10 DVSS ) ( IO_FILL_IO_EAST_0_5 DVSS ) ( IO_FILL_IO_EAST_0_0 DVSS ) ( IO_CORNER_SOUTH_EAST_INST DVSS )
-      ( IO_FILL_IO_WEST_56_90 DVSS ) ( IO_FILL_IO_WEST_56_85 DVSS ) ( IO_FILL_IO_WEST_56_80 DVSS ) ( IO_FILL_IO_WEST_56_75 DVSS ) ( IO_FILL_IO_WEST_56_70 DVSS ) ( IO_FILL_IO_WEST_56_65 DVSS ) ( IO_FILL_IO_WEST_56_60 DVSS ) ( IO_FILL_IO_WEST_56_55 DVSS )
-      ( IO_FILL_IO_WEST_56_50 DVSS ) ( IO_FILL_IO_WEST_56_45 DVSS ) ( IO_FILL_IO_WEST_56_40 DVSS ) ( IO_FILL_IO_WEST_56_35 DVSS ) ( IO_FILL_IO_WEST_56_30 DVSS ) ( IO_FILL_IO_WEST_56_25 DVSS ) ( IO_FILL_IO_WEST_56_20 DVSS ) ( IO_FILL_IO_WEST_56_15 DVSS )
-      ( IO_FILL_IO_WEST_56_10 DVSS ) ( IO_FILL_IO_WEST_56_5 DVSS ) ( IO_FILL_IO_WEST_54_95 DVSS ) ( IO_FILL_IO_WEST_54_90 DVSS ) ( IO_FILL_IO_WEST_54_85 DVSS ) ( IO_FILL_IO_WEST_54_80 DVSS ) ( IO_FILL_IO_WEST_54_75 DVSS ) ( IO_FILL_IO_WEST_54_70 DVSS )
-      ( IO_FILL_IO_WEST_54_65 DVSS ) ( IO_FILL_IO_WEST_54_60 DVSS ) ( IO_FILL_IO_WEST_54_55 DVSS ) ( IO_FILL_IO_WEST_54_50 DVSS ) ( IO_FILL_IO_WEST_54_45 DVSS ) ( IO_FILL_IO_WEST_54_40 DVSS ) ( IO_FILL_IO_WEST_54_35 DVSS ) ( IO_FILL_IO_WEST_54_30 DVSS )
-      ( IO_FILL_IO_WEST_54_25 DVSS ) ( IO_FILL_IO_WEST_54_20 DVSS ) ( IO_FILL_IO_WEST_54_15 DVSS ) ( IO_FILL_IO_WEST_54_10 DVSS ) ( IO_FILL_IO_WEST_54_5 DVSS ) ( IO_FILL_IO_WEST_51_25 DVSS ) ( IO_FILL_IO_WEST_51_20 DVSS ) ( IO_FILL_IO_WEST_51_15 DVSS )
-      ( IO_FILL_IO_WEST_51_10 DVSS ) ( IO_FILL_IO_WEST_51_5 DVSS ) ( IO_FILL_IO_WEST_47_45 DVSS ) ( IO_FILL_IO_WEST_47_40 DVSS ) ( IO_FILL_IO_WEST_47_35 DVSS ) ( IO_FILL_IO_WEST_47_30 DVSS ) ( IO_FILL_IO_WEST_47_25 DVSS ) ( IO_FILL_IO_WEST_47_20 DVSS )
-      ( IO_FILL_IO_WEST_47_15 DVSS ) ( IO_FILL_IO_WEST_47_10 DVSS ) ( IO_FILL_IO_WEST_47_5 DVSS ) ( IO_FILL_IO_WEST_32_5 DVSS ) ( IO_FILL_IO_WEST_27_5 DVSS ) ( IO_FILL_IO_WEST_12_5 DVSS ) ( IO_FILL_IO_WEST_7_5 DVSS ) ( IO_FILL_IO_WEST_3_65 DVSS )
-      ( IO_FILL_IO_WEST_3_60 DVSS ) ( IO_FILL_IO_WEST_3_55 DVSS ) ( IO_FILL_IO_WEST_3_50 DVSS ) ( IO_FILL_IO_WEST_3_45 DVSS ) ( IO_FILL_IO_WEST_3_40 DVSS ) ( IO_FILL_IO_WEST_3_35 DVSS ) ( IO_FILL_IO_WEST_3_30 DVSS ) ( IO_FILL_IO_WEST_3_25 DVSS )
-      ( IO_FILL_IO_WEST_3_20 DVSS ) ( IO_FILL_IO_WEST_3_15 DVSS ) ( IO_FILL_IO_WEST_3_10 DVSS ) ( IO_FILL_IO_WEST_3_5 DVSS ) ( IO_FILL_IO_WEST_0_500 DVSS ) ( IO_FILL_IO_WEST_0_505 DVSS ) ( IO_FILL_IO_WEST_1_0 DVSS ) ( IO_FILL_IO_WEST_17_0 DVSS )
-      ( IO_FILL_IO_WEST_51_0 DVSS ) ( IO_FILL_IO_WEST_3_0 DVSS ) ( IO_FILL_IO_WEST_2_0 DVSS ) ( IO_FILL_IO_WEST_19_5 DVSS ) ( IO_FILL_IO_WEST_51_30 DVSS ) ( IO_FILL_IO_WEST_3_70 DVSS ) ( IO_FILL_IO_WEST_20_0 DVSS ) ( IO_FILL_IO_WEST_35_0 DVSS )
-      ( IO_FILL_IO_WEST_52_0 DVSS ) ( IO_FILL_IO_WEST_10_0 DVSS ) ( IO_FILL_IO_WEST_16_0 DVSS ) ( IO_FILL_IO_WEST_24_0 DVSS ) ( IO_FILL_IO_WEST_30_0 DVSS ) ( IO_FILL_IO_WEST_38_0 DVSS ) ( IO_FILL_IO_WEST_37_5 DVSS ) ( IO_FILL_IO_WEST_44_0 DVSS )
-      ( IO_FILL_IO_WEST_50_0 DVSS ) ( IO_FILL_IO_WEST_15_0 DVSS ) ( IO_FILL_IO_WEST_17_5 DVSS ) ( IO_FILL_IO_WEST_5_0 DVSS ) ( IO_FILL_IO_WEST_4_0 DVSS ) ( IO_FILL_IO_WEST_33_0 DVSS ) ( IO_FILL_IO_WEST_32_10 DVSS ) ( IO_FILL_IO_WEST_32_0 DVSS )
-      ( IO_FILL_IO_WEST_31_0 DVSS ) ( IO_FILL_IO_WEST_29_0 DVSS ) ( IO_FILL_IO_WEST_28_0 DVSS ) ( IO_FILL_IO_WEST_27_10 DVSS ) ( IO_FILL_IO_WEST_27_0 DVSS ) ( IO_FILL_IO_WEST_26_0 DVSS ) ( IO_FILL_IO_WEST_25_0 DVSS ) ( IO_FILL_IO_WEST_23_0 DVSS )
-      ( IO_FILL_IO_WEST_22_5 DVSS ) ( IO_FILL_IO_WEST_14_0 DVSS ) ( IO_FILL_IO_WEST_13_5 DVSS ) ( IO_FILL_IO_WEST_13_0 DVSS ) ( IO_FILL_IO_WEST_12_10 DVSS ) ( IO_FILL_IO_WEST_12_0 DVSS ) ( IO_FILL_IO_WEST_11_0 DVSS ) ( IO_FILL_IO_WEST_9_0 DVSS )
-      ( IO_FILL_IO_WEST_8_0 DVSS ) ( IO_FILL_IO_WEST_7_10 DVSS ) ( IO_FILL_IO_WEST_7_0 DVSS ) ( IO_FILL_IO_WEST_6_0 DVSS ) ( IO_FILL_IO_WEST_22_0 DVSS ) ( IO_FILL_IO_WEST_21_0 DVSS ) ( IO_FILL_IO_WEST_19_0 DVSS ) ( IO_FILL_IO_WEST_18_0 DVSS )
-      ( IO_FILL_IO_WEST_49_0 DVSS ) ( IO_FILL_IO_WEST_48_0 DVSS ) ( IO_FILL_IO_WEST_47_50 DVSS ) ( IO_FILL_IO_WEST_47_0 DVSS ) ( IO_FILL_IO_WEST_56_95 DVSS ) ( IO_FILL_IO_WEST_56_0 DVSS ) ( IO_FILL_IO_WEST_55_5 DVSS ) ( IO_FILL_IO_WEST_55_0 DVSS )
-      ( IO_FILL_IO_WEST_54_100 DVSS ) ( IO_FILL_IO_WEST_54_0 DVSS ) ( IO_FILL_IO_WEST_53_0 DVSS ) ( IO_FILL_IO_WEST_46_0 DVSS ) ( IO_FILL_IO_WEST_45_0 DVSS ) ( IO_FILL_IO_WEST_43_0 DVSS ) ( IO_FILL_IO_WEST_42_5 DVSS ) ( IO_FILL_IO_WEST_42_0 DVSS )
-      ( IO_FILL_IO_WEST_41_5 DVSS ) ( IO_FILL_IO_WEST_41_0 DVSS ) ( IO_FILL_IO_WEST_40_0 DVSS ) ( IO_FILL_IO_WEST_39_0 DVSS ) ( IO_FILL_IO_WEST_34_0 DVSS ) ( IO_FILL_IO_WEST_33_5 DVSS ) ( IO_FILL_IO_WEST_37_0 DVSS ) ( IO_FILL_IO_WEST_36_0 DVSS )
-      ( IO_FILL_IO_SOUTH_60_190 DVSS ) ( IO_FILL_IO_SOUTH_60_185 DVSS ) ( IO_FILL_IO_SOUTH_60_180 DVSS ) ( IO_FILL_IO_SOUTH_60_175 DVSS ) ( IO_FILL_IO_SOUTH_60_170 DVSS ) ( IO_FILL_IO_SOUTH_60_165 DVSS ) ( IO_FILL_IO_SOUTH_60_160 DVSS ) ( IO_FILL_IO_SOUTH_60_155 DVSS )
-      ( IO_FILL_IO_SOUTH_60_150 DVSS ) ( IO_FILL_IO_SOUTH_60_145 DVSS ) ( IO_FILL_IO_SOUTH_60_140 DVSS ) ( IO_FILL_IO_SOUTH_60_135 DVSS ) ( IO_FILL_IO_SOUTH_60_130 DVSS ) ( IO_FILL_IO_SOUTH_60_125 DVSS ) ( IO_FILL_IO_SOUTH_60_120 DVSS ) ( IO_FILL_IO_SOUTH_60_115 DVSS )
-      ( IO_FILL_IO_SOUTH_60_110 DVSS ) ( IO_FILL_IO_SOUTH_60_105 DVSS ) ( IO_FILL_IO_SOUTH_60_100 DVSS ) ( IO_FILL_IO_SOUTH_60_95 DVSS ) ( IO_FILL_IO_SOUTH_60_90 DVSS ) ( IO_FILL_IO_SOUTH_60_85 DVSS ) ( IO_FILL_IO_SOUTH_60_80 DVSS ) ( IO_FILL_IO_SOUTH_60_75 DVSS )
-      ( IO_FILL_IO_SOUTH_60_70 DVSS ) ( IO_FILL_IO_SOUTH_60_65 DVSS ) ( IO_FILL_IO_SOUTH_60_60 DVSS ) ( IO_FILL_IO_SOUTH_60_55 DVSS ) ( IO_FILL_IO_SOUTH_60_50 DVSS ) ( IO_FILL_IO_SOUTH_60_45 DVSS ) ( IO_FILL_IO_SOUTH_60_40 DVSS ) ( IO_FILL_IO_SOUTH_60_35 DVSS )
-      ( IO_FILL_IO_SOUTH_60_30 DVSS ) ( IO_FILL_IO_SOUTH_60_25 DVSS ) ( IO_FILL_IO_SOUTH_60_20 DVSS ) ( IO_FILL_IO_SOUTH_60_15 DVSS ) ( IO_FILL_IO_SOUTH_60_10 DVSS ) ( IO_FILL_IO_SOUTH_60_5 DVSS ) ( IO_FILL_IO_SOUTH_59_125 DVSS ) ( IO_FILL_IO_SOUTH_59_120 DVSS )
-      ( IO_FILL_IO_SOUTH_59_115 DVSS ) ( IO_FILL_IO_SOUTH_59_110 DVSS ) ( IO_FILL_IO_SOUTH_59_105 DVSS ) ( IO_FILL_IO_SOUTH_59_100 DVSS ) ( IO_FILL_IO_SOUTH_59_95 DVSS ) ( IO_FILL_IO_SOUTH_59_90 DVSS ) ( IO_FILL_IO_SOUTH_59_85 DVSS ) ( IO_FILL_IO_SOUTH_59_80 DVSS )
-      ( IO_FILL_IO_SOUTH_59_75 DVSS ) ( IO_FILL_IO_SOUTH_59_70 DVSS ) ( IO_FILL_IO_SOUTH_59_65 DVSS ) ( IO_FILL_IO_SOUTH_59_60 DVSS ) ( IO_FILL_IO_SOUTH_59_55 DVSS ) ( IO_FILL_IO_SOUTH_59_50 DVSS ) ( IO_FILL_IO_SOUTH_59_45 DVSS ) ( IO_FILL_IO_SOUTH_59_40 DVSS )
-      ( IO_FILL_IO_SOUTH_59_35 DVSS ) ( IO_FILL_IO_SOUTH_59_30 DVSS ) ( IO_FILL_IO_SOUTH_59_25 DVSS ) ( IO_FILL_IO_SOUTH_59_20 DVSS ) ( IO_FILL_IO_SOUTH_59_15 DVSS ) ( IO_FILL_IO_SOUTH_59_10 DVSS ) ( IO_FILL_IO_SOUTH_59_5 DVSS ) ( IO_FILL_IO_SOUTH_57_60 DVSS )
-      ( IO_FILL_IO_SOUTH_57_55 DVSS ) ( IO_FILL_IO_SOUTH_57_50 DVSS ) ( IO_FILL_IO_SOUTH_57_45 DVSS ) ( IO_FILL_IO_SOUTH_57_40 DVSS ) ( IO_FILL_IO_SOUTH_57_35 DVSS ) ( IO_FILL_IO_SOUTH_57_30 DVSS ) ( IO_FILL_IO_SOUTH_57_25 DVSS ) ( IO_FILL_IO_SOUTH_57_20 DVSS )
-      ( IO_FILL_IO_SOUTH_57_15 DVSS ) ( IO_FILL_IO_SOUTH_57_10 DVSS ) ( IO_FILL_IO_SOUTH_57_5 DVSS ) ( IO_FILL_IO_SOUTH_54_65 DVSS ) ( IO_FILL_IO_SOUTH_54_60 DVSS ) ( IO_FILL_IO_SOUTH_54_55 DVSS ) ( IO_FILL_IO_SOUTH_54_50 DVSS ) ( IO_FILL_IO_SOUTH_54_45 DVSS )
-      ( IO_FILL_IO_SOUTH_54_40 DVSS ) ( IO_FILL_IO_SOUTH_54_35 DVSS ) ( IO_FILL_IO_SOUTH_54_30 DVSS ) ( IO_FILL_IO_SOUTH_54_25 DVSS ) ( IO_FILL_IO_SOUTH_54_20 DVSS ) ( IO_FILL_IO_SOUTH_54_15 DVSS ) ( IO_FILL_IO_SOUTH_54_10 DVSS ) ( IO_FILL_IO_SOUTH_54_5 DVSS )
-      ( IO_FILL_IO_SOUTH_40_5 DVSS ) ( IO_FILL_IO_SOUTH_20_5 DVSS ) ( IO_FILL_IO_SOUTH_10_30 DVSS ) ( IO_FILL_IO_SOUTH_10_25 DVSS ) ( IO_FILL_IO_SOUTH_10_20 DVSS ) ( IO_FILL_IO_SOUTH_10_15 DVSS ) ( IO_FILL_IO_SOUTH_10_10 DVSS ) ( IO_FILL_IO_SOUTH_10_5 DVSS )
-      ( IO_FILL_IO_SOUTH_6_35 DVSS ) ( IO_FILL_IO_SOUTH_6_30 DVSS ) ( IO_FILL_IO_SOUTH_6_25 DVSS ) ( IO_FILL_IO_SOUTH_6_20 DVSS ) ( IO_FILL_IO_SOUTH_6_15 DVSS ) ( IO_FILL_IO_SOUTH_6_10 DVSS ) ( IO_FILL_IO_SOUTH_6_5 DVSS ) ( IO_FILL_IO_SOUTH_3_95 DVSS )
-      ( IO_FILL_IO_SOUTH_3_90 DVSS ) ( IO_FILL_IO_SOUTH_3_85 DVSS ) ( IO_FILL_IO_SOUTH_3_80 DVSS ) ( IO_FILL_IO_SOUTH_3_75 DVSS ) ( IO_FILL_IO_SOUTH_3_70 DVSS ) ( IO_FILL_IO_SOUTH_3_65 DVSS ) ( IO_FILL_IO_SOUTH_3_60 DVSS ) ( IO_FILL_IO_SOUTH_3_55 DVSS )
-      ( IO_FILL_IO_SOUTH_3_50 DVSS ) ( IO_FILL_IO_SOUTH_3_45 DVSS ) ( IO_FILL_IO_SOUTH_3_40 DVSS ) ( IO_FILL_IO_SOUTH_3_35 DVSS ) ( IO_FILL_IO_SOUTH_3_30 DVSS ) ( IO_FILL_IO_SOUTH_3_25 DVSS ) ( IO_FILL_IO_SOUTH_3_20 DVSS ) ( IO_FILL_IO_SOUTH_3_15 DVSS )
-      ( IO_FILL_IO_SOUTH_3_10 DVSS ) ( IO_FILL_IO_SOUTH_3_5 DVSS ) ( IO_FILL_IO_SOUTH_1_95 DVSS ) ( IO_FILL_IO_SOUTH_1_90 DVSS ) ( IO_FILL_IO_SOUTH_1_85 DVSS ) ( IO_FILL_IO_SOUTH_1_80 DVSS ) ( IO_FILL_IO_SOUTH_1_75 DVSS ) ( IO_FILL_IO_SOUTH_1_70 DVSS )
-      ( IO_FILL_IO_SOUTH_1_65 DVSS ) ( IO_FILL_IO_SOUTH_1_60 DVSS ) ( IO_FILL_IO_SOUTH_1_55 DVSS ) ( IO_FILL_IO_SOUTH_1_50 DVSS ) ( IO_FILL_IO_SOUTH_1_45 DVSS ) ( IO_FILL_IO_SOUTH_1_40 DVSS ) ( IO_FILL_IO_SOUTH_1_35 DVSS ) ( IO_FILL_IO_SOUTH_1_30 DVSS )
-      ( IO_FILL_IO_SOUTH_1_25 DVSS ) ( IO_FILL_IO_SOUTH_1_20 DVSS ) ( IO_FILL_IO_SOUTH_1_15 DVSS ) ( IO_FILL_IO_SOUTH_1_10 DVSS ) ( IO_FILL_IO_SOUTH_1_5 DVSS ) ( IO_FILL_IO_SOUTH_0_20 DVSS ) ( IO_FILL_IO_SOUTH_6_0 DVSS ) ( IO_FILL_IO_SOUTH_3_100 DVSS )
-      ( IO_FILL_IO_SOUTH_59_0 DVSS ) ( IO_FILL_IO_SOUTH_50_5 DVSS ) ( IO_FILL_IO_SOUTH_45_0 DVSS ) ( IO_FILL_IO_SOUTH_30_5 DVSS ) ( IO_FILL_IO_SOUTH_25_0 DVSS ) ( IO_FILL_IO_SOUTH_10_35 DVSS ) ( IO_FILL_IO_SOUTH_3_0 DVSS ) ( IO_FILL_IO_SOUTH_54_0 DVSS )
-      ( IO_FILL_IO_SOUTH_22_0 DVSS ) ( IO_FILL_IO_SOUTH_6_40 DVSS ) ( IO_FILL_IO_SOUTH_53_0 DVSS ) ( IO_FILL_IO_SOUTH_36_0 DVSS ) ( IO_FILL_IO_SOUTH_35_5 DVSS ) ( IO_FILL_IO_SOUTH_21_0 DVSS ) ( IO_FILL_IO_SOUTH_20_10 DVSS ) ( IO_FILL_IO_SOUTH_60_0 DVSS )
-      ( IO_FILL_IO_SOUTH_59_130 DVSS ) ( IO_FILL_IO_SOUTH_52_0 DVSS ) ( IO_FILL_IO_SOUTH_51_0 DVSS ) ( IO_FILL_IO_SOUTH_45_5 DVSS ) ( IO_FILL_IO_SOUTH_40_0 DVSS ) ( IO_FILL_IO_SOUTH_39_0 DVSS ) ( IO_FILL_IO_SOUTH_31_0 DVSS ) ( IO_FILL_IO_SOUTH_25_5 DVSS )
-      ( IO_FILL_IO_SOUTH_17_0 DVSS ) ( IO_FILL_IO_SOUTH_11_0 DVSS ) ( IO_FILL_IO_SOUTH_42_5 DVSS ) ( IO_FILL_IO_SOUTH_42_0 DVSS ) ( IO_FILL_IO_SOUTH_46_0 DVSS ) ( IO_FILL_IO_SOUTH_41_0 DVSS ) ( IO_FILL_IO_SOUTH_40_10 DVSS ) ( IO_FILL_IO_SOUTH_57_0 DVSS )
-      ( IO_FILL_IO_SOUTH_56_5 DVSS ) ( IO_FILL_IO_SOUTH_5_0 DVSS ) ( IO_FILL_IO_SOUTH_4_0 DVSS ) ( IO_FILL_IO_SOUTH_56_0 DVSS ) ( IO_FILL_IO_SOUTH_2_0 DVSS ) ( IO_FILL_IO_SOUTH_1_100 DVSS ) ( IO_FILL_IO_SOUTH_58_0 DVSS ) ( IO_FILL_IO_SOUTH_57_65 DVSS )
-      ( IO_FILL_IO_SOUTH_1_0 DVSS ) ( IO_FILL_IO_SOUTH_0_25 DVSS ) ( IO_FILL_IO_SOUTH_48_0 DVSS ) ( IO_FILL_IO_SOUTH_47_0 DVSS ) ( IO_FILL_IO_SOUTH_48_5 DVSS ) ( IO_FILL_IO_SOUTH_55_0 DVSS ) ( IO_FILL_IO_SOUTH_54_70 DVSS ) ( IO_FILL_IO_SOUTH_50_0 DVSS )
-      ( IO_FILL_IO_SOUTH_49_0 DVSS ) ( IO_FILL_IO_SOUTH_44_0 DVSS ) ( IO_FILL_IO_SOUTH_43_0 DVSS ) ( IO_FILL_IO_SOUTH_8_0 DVSS ) ( IO_FILL_IO_SOUTH_7_0 DVSS ) ( IO_FILL_IO_SOUTH_8_5 DVSS ) ( IO_FILL_IO_SOUTH_10_0 DVSS ) ( IO_FILL_IO_SOUTH_9_0 DVSS )
-      ( IO_FILL_IO_SOUTH_22_5 DVSS ) ( IO_FILL_IO_SOUTH_24_0 DVSS ) ( IO_FILL_IO_SOUTH_23_0 DVSS ) ( IO_FILL_IO_SOUTH_26_0 DVSS ) ( IO_FILL_IO_SOUTH_28_0 DVSS ) ( IO_FILL_IO_SOUTH_27_0 DVSS ) ( IO_FILL_IO_SOUTH_28_5 DVSS ) ( IO_FILL_IO_SOUTH_30_0 DVSS )
-      ( IO_FILL_IO_SOUTH_29_0 DVSS ) ( IO_FILL_IO_SOUTH_32_0 DVSS ) ( IO_FILL_IO_SOUTH_34_0 DVSS ) ( IO_FILL_IO_SOUTH_33_0 DVSS ) ( IO_FILL_IO_SOUTH_35_0 DVSS ) ( IO_FILL_IO_SOUTH_34_5 DVSS ) ( IO_FILL_IO_SOUTH_12_0 DVSS ) ( IO_FILL_IO_SOUTH_14_0 DVSS )
-      ( IO_FILL_IO_SOUTH_13_0 DVSS ) ( IO_FILL_IO_SOUTH_15_0 DVSS ) ( IO_FILL_IO_SOUTH_14_5 DVSS ) ( IO_FILL_IO_SOUTH_16_0 DVSS ) ( IO_FILL_IO_SOUTH_15_5 DVSS ) ( IO_FILL_IO_SOUTH_18_0 DVSS ) ( IO_FILL_IO_SOUTH_20_0 DVSS ) ( IO_FILL_IO_SOUTH_19_0 DVSS )
-      ( IO_FILL_IO_SOUTH_38_0 DVSS ) ( IO_FILL_IO_SOUTH_37_0 DVSS ) ( IO_FILL_IO_EAST_60_180 DVSS ) ( IO_FILL_IO_EAST_60_175 DVSS ) ( IO_FILL_IO_EAST_60_170 DVSS ) ( IO_FILL_IO_EAST_60_165 DVSS ) ( IO_FILL_IO_EAST_60_160 DVSS ) ( IO_FILL_IO_EAST_60_155 DVSS )
-      ( IO_FILL_IO_EAST_60_150 DVSS ) ( IO_FILL_IO_EAST_60_145 DVSS ) ( IO_FILL_IO_EAST_60_140 DVSS ) ( IO_FILL_IO_EAST_60_135 DVSS ) ( IO_FILL_IO_EAST_60_130 DVSS ) ( IO_FILL_IO_EAST_60_125 DVSS ) ( IO_FILL_IO_EAST_60_120 DVSS ) ( IO_FILL_IO_EAST_60_115 DVSS )
-      ( IO_FILL_IO_EAST_60_110 DVSS ) ( IO_FILL_IO_EAST_60_105 DVSS ) ( IO_FILL_IO_EAST_60_100 DVSS ) ( IO_FILL_IO_EAST_60_95 DVSS ) ( IO_FILL_IO_EAST_60_90 DVSS ) ( IO_FILL_IO_EAST_60_85 DVSS ) ( IO_FILL_IO_EAST_60_80 DVSS ) ( IO_FILL_IO_EAST_60_75 DVSS )
-      ( IO_FILL_IO_EAST_60_70 DVSS ) ( IO_FILL_IO_EAST_60_65 DVSS ) ( IO_FILL_IO_EAST_60_60 DVSS ) ( IO_FILL_IO_EAST_60_55 DVSS ) ( IO_FILL_IO_EAST_60_50 DVSS ) ( IO_FILL_IO_EAST_60_45 DVSS ) ( IO_FILL_IO_EAST_60_40 DVSS ) ( IO_FILL_IO_EAST_60_35 DVSS )
-      ( IO_FILL_IO_EAST_60_30 DVSS ) ( IO_FILL_IO_EAST_60_25 DVSS ) ( IO_FILL_IO_EAST_60_20 DVSS ) ( IO_FILL_IO_EAST_60_15 DVSS ) ( IO_FILL_IO_EAST_60_10 DVSS ) ( IO_FILL_IO_EAST_60_5 DVSS ) ( IO_FILL_IO_EAST_59_120 DVSS ) ( IO_FILL_IO_EAST_59_115 DVSS )
-      ( IO_FILL_IO_EAST_59_110 DVSS ) ( IO_FILL_IO_EAST_59_105 DVSS ) ( IO_FILL_IO_EAST_59_100 DVSS ) ( IO_FILL_IO_EAST_59_95 DVSS ) ( IO_FILL_IO_EAST_59_90 DVSS ) ( IO_FILL_IO_EAST_59_85 DVSS ) ( IO_FILL_IO_EAST_59_80 DVSS ) ( IO_FILL_IO_EAST_59_75 DVSS )
-      ( IO_FILL_IO_EAST_59_70 DVSS ) ( IO_FILL_IO_EAST_59_65 DVSS ) ( IO_FILL_IO_EAST_59_60 DVSS ) ( IO_FILL_IO_EAST_59_55 DVSS ) ( IO_FILL_IO_EAST_59_50 DVSS ) ( IO_FILL_IO_EAST_59_45 DVSS ) ( IO_FILL_IO_EAST_59_40 DVSS ) ( IO_FILL_IO_EAST_59_35 DVSS )
-      ( IO_FILL_IO_EAST_59_30 DVSS ) ( IO_FILL_IO_EAST_59_25 DVSS ) ( IO_FILL_IO_EAST_59_20 DVSS ) ( IO_FILL_IO_EAST_59_15 DVSS ) ( IO_FILL_IO_EAST_59_10 DVSS ) ( IO_FILL_IO_EAST_59_5 DVSS ) ( IO_FILL_IO_EAST_57_65 DVSS ) ( IO_FILL_IO_EAST_57_60 DVSS )
-      ( IO_FILL_IO_EAST_57_55 DVSS ) ( IO_FILL_IO_EAST_57_50 DVSS ) ( IO_FILL_IO_EAST_57_45 DVSS ) ( IO_FILL_IO_EAST_57_40 DVSS ) ( IO_FILL_IO_EAST_57_35 DVSS ) ( IO_FILL_IO_EAST_57_30 DVSS ) ( IO_FILL_IO_EAST_57_25 DVSS ) ( IO_FILL_IO_EAST_57_20 DVSS )
-      ( IO_FILL_IO_EAST_57_15 DVSS ) ( IO_FILL_IO_EAST_57_10 DVSS ) ( IO_FILL_IO_EAST_57_5 DVSS ) ( IO_FILL_IO_EAST_54_65 DVSS ) ( IO_FILL_IO_EAST_54_60 DVSS ) ( IO_FILL_IO_EAST_54_55 DVSS ) ( IO_FILL_IO_EAST_54_50 DVSS ) ( IO_FILL_IO_EAST_54_45 DVSS )
-      ( IO_FILL_IO_EAST_54_40 DVSS ) ( IO_FILL_IO_EAST_54_35 DVSS ) ( IO_FILL_IO_EAST_54_30 DVSS ) ( IO_FILL_IO_EAST_54_25 DVSS ) ( IO_FILL_IO_EAST_54_20 DVSS ) ( IO_FILL_IO_EAST_54_15 DVSS ) ( IO_FILL_IO_EAST_54_10 DVSS ) ( IO_FILL_IO_EAST_54_5 DVSS )
-      ( IO_FILL_IO_EAST_50_5 DVSS ) ( IO_FILL_IO_EAST_35_5 DVSS ) ( IO_FILL_IO_EAST_30_5 DVSS ) ( IO_FILL_IO_EAST_15_5 DVSS ) ( IO_FILL_IO_EAST_10_35 DVSS ) ( IO_FILL_IO_EAST_10_30 DVSS ) ( IO_FILL_IO_EAST_10_25 DVSS ) ( IO_FILL_IO_EAST_10_20 DVSS )
-      ( IO_FILL_IO_EAST_10_15 DVSS ) ( IO_FILL_IO_EAST_10_10 DVSS ) ( IO_FILL_IO_EAST_10_5 DVSS ) ( IO_FILL_IO_EAST_6_35 DVSS ) ( IO_FILL_IO_EAST_6_30 DVSS ) ( IO_FILL_IO_EAST_6_25 DVSS ) ( IO_FILL_IO_EAST_6_20 DVSS ) ( IO_FILL_IO_EAST_6_15 DVSS )
-      ( IO_FILL_IO_EAST_6_10 DVSS ) ( IO_FILL_IO_EAST_6_5 DVSS ) ( IO_FILL_IO_EAST_3_90 DVSS ) ( IO_FILL_IO_EAST_3_85 DVSS ) ( IO_FILL_IO_EAST_3_80 DVSS ) ( IO_FILL_IO_EAST_3_75 DVSS ) ( IO_FILL_IO_EAST_3_70 DVSS ) ( IO_FILL_IO_EAST_3_65 DVSS )
-      ( IO_FILL_IO_EAST_3_60 DVSS ) ( IO_FILL_IO_EAST_3_55 DVSS ) ( IO_FILL_IO_EAST_3_50 DVSS ) ( IO_FILL_IO_EAST_3_45 DVSS ) ( IO_FILL_IO_EAST_3_40 DVSS ) ( IO_FILL_IO_EAST_3_35 DVSS ) ( IO_FILL_IO_EAST_3_30 DVSS ) ( IO_FILL_IO_EAST_3_25 DVSS )
-      ( IO_FILL_IO_EAST_3_20 DVSS ) ( IO_FILL_IO_EAST_3_15 DVSS ) ( IO_FILL_IO_EAST_3_10 DVSS ) ( IO_FILL_IO_EAST_3_5 DVSS ) ( IO_FILL_IO_EAST_1_95 DVSS ) ( IO_FILL_IO_EAST_1_90 DVSS ) ( IO_FILL_IO_EAST_1_85 DVSS ) ( IO_FILL_IO_EAST_1_80 DVSS )
-      ( IO_FILL_IO_EAST_1_75 DVSS ) ( IO_FILL_IO_EAST_1_70 DVSS ) ( IO_FILL_IO_EAST_1_65 DVSS ) ( IO_FILL_IO_EAST_1_60 DVSS ) ( IO_FILL_IO_EAST_1_55 DVSS ) ( IO_FILL_IO_EAST_1_50 DVSS ) ( IO_FILL_IO_EAST_1_45 DVSS ) ( IO_FILL_IO_EAST_1_40 DVSS )
-      ( IO_FILL_IO_EAST_1_35 DVSS ) ( IO_FILL_IO_EAST_1_30 DVSS ) ( IO_FILL_IO_EAST_1_25 DVSS ) ( IO_FILL_IO_EAST_1_20 DVSS ) ( IO_FILL_IO_EAST_1_15 DVSS ) ( IO_FILL_IO_EAST_1_10 DVSS ) ( IO_FILL_IO_EAST_1_5 DVSS ) ( IO_FILL_IO_EAST_0_20 DVSS )
-      ( IO_FILL_IO_EAST_6_40 DVSS ) ( IO_FILL_IO_EAST_40_5 DVSS ) ( IO_FILL_IO_EAST_57_0 DVSS ) ( IO_FILL_IO_EAST_56_0 DVSS ) ( IO_FILL_IO_EAST_38_0 DVSS ) ( IO_FILL_IO_EAST_22_0 DVSS ) ( IO_FILL_IO_EAST_4_0 DVSS ) ( IO_FILL_IO_EAST_3_95 DVSS )
-      ( IO_FILL_IO_EAST_7_0 DVSS ) ( IO_FILL_IO_EAST_54_0 DVSS ) ( IO_FILL_IO_EAST_53_0 DVSS ) ( IO_FILL_IO_EAST_47_0 DVSS ) ( IO_FILL_IO_EAST_41_0 DVSS ) ( IO_FILL_IO_EAST_33_0 DVSS ) ( IO_FILL_IO_EAST_27_0 DVSS ) ( IO_FILL_IO_EAST_20_0 DVSS )
-      ( IO_FILL_IO_EAST_19_0 DVSS ) ( IO_FILL_IO_EAST_13_0 DVSS ) ( IO_FILL_IO_EAST_30_0 DVSS ) ( IO_FILL_IO_EAST_29_0 DVSS ) ( IO_FILL_IO_EAST_28_0 DVSS ) ( IO_FILL_IO_EAST_15_0 DVSS ) ( IO_FILL_IO_EAST_14_0 DVSS ) ( IO_FILL_IO_EAST_16_0 DVSS )
-      ( IO_FILL_IO_EAST_15_10 DVSS ) ( IO_FILL_IO_EAST_16_5 DVSS ) ( IO_FILL_IO_EAST_18_0 DVSS ) ( IO_FILL_IO_EAST_17_0 DVSS ) ( IO_FILL_IO_EAST_21_0 DVSS ) ( IO_FILL_IO_EAST_20_5 DVSS ) ( IO_FILL_IO_EAST_24_0 DVSS ) ( IO_FILL_IO_EAST_23_0 DVSS )
-      ( IO_FILL_IO_EAST_25_0 DVSS ) ( IO_FILL_IO_EAST_24_5 DVSS ) ( IO_FILL_IO_EAST_26_0 DVSS ) ( IO_FILL_IO_EAST_25_5 DVSS ) ( IO_FILL_IO_EAST_1_0 DVSS ) ( IO_FILL_IO_EAST_0_25 DVSS ) ( IO_FILL_IO_EAST_2_0 DVSS ) ( IO_FILL_IO_EAST_1_100 DVSS )
-      ( IO_FILL_IO_EAST_3_0 DVSS ) ( IO_FILL_IO_EAST_2_5 DVSS ) ( IO_FILL_IO_EAST_6_0 DVSS ) ( IO_FILL_IO_EAST_5_0 DVSS ) ( IO_FILL_IO_EAST_8_0 DVSS ) ( IO_FILL_IO_EAST_10_0 DVSS ) ( IO_FILL_IO_EAST_9_0 DVSS ) ( IO_FILL_IO_EAST_10_40 DVSS )
-      ( IO_FILL_IO_EAST_12_0 DVSS ) ( IO_FILL_IO_EAST_11_0 DVSS ) ( IO_FILL_IO_EAST_30_10 DVSS ) ( IO_FILL_IO_EAST_45_0 DVSS ) ( IO_FILL_IO_EAST_44_5 DVSS ) ( IO_FILL_IO_EAST_46_0 DVSS ) ( IO_FILL_IO_EAST_45_5 DVSS ) ( IO_FILL_IO_EAST_48_0 DVSS )
-      ( IO_FILL_IO_EAST_37_0 DVSS ) ( IO_FILL_IO_EAST_36_5 DVSS ) ( IO_FILL_IO_EAST_40_0 DVSS ) ( IO_FILL_IO_EAST_39_0 DVSS ) ( IO_FILL_IO_EAST_42_0 DVSS ) ( IO_FILL_IO_EAST_44_0 DVSS ) ( IO_FILL_IO_EAST_43_0 DVSS ) ( IO_FILL_IO_EAST_50_0 DVSS )
-      ( IO_FILL_IO_EAST_49_0 DVSS ) ( IO_FILL_IO_EAST_50_10 DVSS ) ( IO_FILL_IO_EAST_52_0 DVSS ) ( IO_FILL_IO_EAST_51_0 DVSS ) ( IO_FILL_IO_EAST_55_0 DVSS ) ( IO_FILL_IO_EAST_54_70 DVSS ) ( IO_FILL_IO_EAST_58_0 DVSS ) ( IO_FILL_IO_EAST_57_70 DVSS )
-      ( IO_FILL_IO_EAST_59_0 DVSS ) ( IO_FILL_IO_EAST_58_5 DVSS ) ( IO_FILL_IO_EAST_60_0 DVSS ) ( IO_FILL_IO_EAST_59_125 DVSS ) ( IO_FILL_IO_EAST_36_0 DVSS ) ( IO_FILL_IO_EAST_35_10 DVSS ) ( IO_FILL_IO_EAST_35_0 DVSS ) ( IO_FILL_IO_EAST_34_0 DVSS )
-      ( IO_FILL_IO_EAST_32_0 DVSS ) ( IO_FILL_IO_EAST_31_0 DVSS ) ( IO_FILL_IO_NORTH_53_95 DVSS ) ( IO_FILL_IO_NORTH_53_90 DVSS ) ( IO_FILL_IO_NORTH_53_85 DVSS ) ( IO_FILL_IO_NORTH_53_80 DVSS ) ( IO_FILL_IO_NORTH_53_75 DVSS ) ( IO_FILL_IO_NORTH_53_70 DVSS )
-      ( IO_FILL_IO_NORTH_53_65 DVSS ) ( IO_FILL_IO_NORTH_53_60 DVSS ) ( IO_FILL_IO_NORTH_53_55 DVSS ) ( IO_FILL_IO_NORTH_53_50 DVSS ) ( IO_FILL_IO_NORTH_53_45 DVSS ) ( IO_FILL_IO_NORTH_53_40 DVSS ) ( IO_FILL_IO_NORTH_53_35 DVSS ) ( IO_FILL_IO_NORTH_53_30 DVSS )
-      ( IO_FILL_IO_NORTH_53_25 DVSS ) ( IO_FILL_IO_NORTH_53_20 DVSS ) ( IO_FILL_IO_NORTH_53_15 DVSS ) ( IO_FILL_IO_NORTH_53_10 DVSS ) ( IO_FILL_IO_NORTH_53_5 DVSS ) ( IO_FILL_IO_NORTH_51_95 DVSS ) ( IO_FILL_IO_NORTH_51_90 DVSS ) ( IO_FILL_IO_NORTH_51_85 DVSS )
-      ( IO_FILL_IO_NORTH_51_80 DVSS ) ( IO_FILL_IO_NORTH_51_75 DVSS ) ( IO_FILL_IO_NORTH_51_70 DVSS ) ( IO_FILL_IO_NORTH_51_65 DVSS ) ( IO_FILL_IO_NORTH_51_60 DVSS ) ( IO_FILL_IO_NORTH_51_55 DVSS ) ( IO_FILL_IO_NORTH_51_50 DVSS ) ( IO_FILL_IO_NORTH_51_45 DVSS )
-      ( IO_FILL_IO_NORTH_51_40 DVSS ) ( IO_FILL_IO_NORTH_51_35 DVSS ) ( IO_FILL_IO_NORTH_51_30 DVSS ) ( IO_FILL_IO_NORTH_51_25 DVSS ) ( IO_FILL_IO_NORTH_51_20 DVSS ) ( IO_FILL_IO_NORTH_51_15 DVSS ) ( IO_FILL_IO_NORTH_51_10 DVSS ) ( IO_FILL_IO_NORTH_51_5 DVSS )
-      ( IO_FILL_IO_NORTH_48_35 DVSS ) ( IO_FILL_IO_NORTH_48_30 DVSS ) ( IO_FILL_IO_NORTH_48_25 DVSS ) ( IO_FILL_IO_NORTH_48_20 DVSS ) ( IO_FILL_IO_NORTH_48_15 DVSS ) ( IO_FILL_IO_NORTH_48_10 DVSS ) ( IO_FILL_IO_NORTH_48_5 DVSS ) ( IO_FILL_IO_NORTH_44_30 DVSS )
-      ( IO_FILL_IO_NORTH_44_25 DVSS ) ( IO_FILL_IO_NORTH_44_20 DVSS ) ( IO_FILL_IO_NORTH_44_15 DVSS ) ( IO_FILL_IO_NORTH_44_10 DVSS ) ( IO_FILL_IO_NORTH_44_5 DVSS ) ( IO_FILL_IO_NORTH_42_20 DVSS ) ( IO_FILL_IO_NORTH_42_15 DVSS ) ( IO_FILL_IO_NORTH_42_10 DVSS )
-      ( IO_FILL_IO_NORTH_42_5 DVSS ) ( IO_FILL_IO_NORTH_30_15 DVSS ) ( IO_FILL_IO_NORTH_30_10 DVSS ) ( IO_FILL_IO_NORTH_30_5 DVSS ) ( IO_FILL_IO_NORTH_25_5 DVSS ) ( IO_FILL_IO_NORTH_10_5 DVSS ) ( IO_FILL_IO_NORTH_6_60 DVSS ) ( IO_FILL_IO_NORTH_6_55 DVSS )
-      ( IO_FILL_IO_NORTH_6_50 DVSS ) ( IO_FILL_IO_NORTH_6_45 DVSS ) ( IO_FILL_IO_NORTH_6_40 DVSS ) ( IO_FILL_IO_NORTH_6_35 DVSS ) ( IO_FILL_IO_NORTH_6_30 DVSS ) ( IO_FILL_IO_NORTH_6_25 DVSS ) ( IO_FILL_IO_NORTH_6_20 DVSS ) ( IO_FILL_IO_NORTH_6_15 DVSS )
-      ( IO_FILL_IO_NORTH_6_10 DVSS ) ( IO_FILL_IO_NORTH_6_5 DVSS ) ( IO_FILL_IO_NORTH_3_65 DVSS ) ( IO_FILL_IO_NORTH_3_60 DVSS ) ( IO_FILL_IO_NORTH_3_55 DVSS ) ( IO_FILL_IO_NORTH_3_50 DVSS ) ( IO_FILL_IO_NORTH_3_45 DVSS ) ( IO_FILL_IO_NORTH_3_40 DVSS )
-      ( IO_FILL_IO_NORTH_3_35 DVSS ) ( IO_FILL_IO_NORTH_3_30 DVSS ) ( IO_FILL_IO_NORTH_3_25 DVSS ) ( IO_FILL_IO_NORTH_3_20 DVSS ) ( IO_FILL_IO_NORTH_3_15 DVSS ) ( IO_FILL_IO_NORTH_3_10 DVSS ) ( IO_FILL_IO_NORTH_3_5 DVSS ) ( IO_FILL_IO_NORTH_1_125 DVSS )
-      ( IO_FILL_IO_NORTH_1_120 DVSS ) ( IO_FILL_IO_NORTH_1_115 DVSS ) ( IO_FILL_IO_NORTH_1_110 DVSS ) ( IO_FILL_IO_NORTH_1_105 DVSS ) ( IO_FILL_IO_NORTH_1_100 DVSS ) ( IO_FILL_IO_NORTH_1_95 DVSS ) ( IO_FILL_IO_NORTH_1_90 DVSS ) ( IO_FILL_IO_NORTH_1_85 DVSS )
-      ( IO_FILL_IO_NORTH_1_80 DVSS ) ( IO_FILL_IO_NORTH_1_75 DVSS ) ( IO_FILL_IO_NORTH_1_70 DVSS ) ( IO_FILL_IO_NORTH_1_65 DVSS ) ( IO_FILL_IO_NORTH_1_60 DVSS ) ( IO_FILL_IO_NORTH_1_55 DVSS ) ( IO_FILL_IO_NORTH_1_50 DVSS ) ( IO_FILL_IO_NORTH_1_45 DVSS )
-      ( IO_FILL_IO_NORTH_1_40 DVSS ) ( IO_FILL_IO_NORTH_1_35 DVSS ) ( IO_FILL_IO_NORTH_1_30 DVSS ) ( IO_FILL_IO_NORTH_1_25 DVSS ) ( IO_FILL_IO_NORTH_1_20 DVSS ) ( IO_FILL_IO_NORTH_1_15 DVSS ) ( IO_FILL_IO_NORTH_1_10 DVSS ) ( IO_FILL_IO_NORTH_1_5 DVSS )
-      ( IO_FILL_IO_NORTH_0_210 DVSS ) ( IO_FILL_IO_NORTH_0_205 DVSS ) ( IO_FILL_IO_NORTH_0_200 DVSS ) ( IO_FILL_IO_NORTH_0_195 DVSS ) ( IO_FILL_IO_NORTH_0_190 DVSS ) ( IO_FILL_IO_NORTH_0_185 DVSS ) ( IO_FILL_IO_NORTH_0_180 DVSS ) ( IO_FILL_IO_NORTH_0_175 DVSS )
-      ( IO_FILL_IO_NORTH_0_170 DVSS ) ( IO_FILL_IO_NORTH_0_165 DVSS ) ( IO_FILL_IO_NORTH_0_160 DVSS ) ( IO_FILL_IO_NORTH_0_155 DVSS ) ( IO_FILL_IO_NORTH_0_150 DVSS ) ( IO_FILL_IO_NORTH_0_145 DVSS ) ( IO_FILL_IO_NORTH_0_140 DVSS ) ( IO_FILL_IO_NORTH_0_135 DVSS )
-      ( IO_FILL_IO_NORTH_0_130 DVSS ) ( IO_FILL_IO_NORTH_0_125 DVSS ) ( IO_FILL_IO_NORTH_0_120 DVSS ) ( IO_FILL_IO_NORTH_0_115 DVSS ) ( IO_FILL_IO_NORTH_0_110 DVSS ) ( IO_FILL_IO_NORTH_0_105 DVSS ) ( IO_FILL_IO_NORTH_0_100 DVSS ) ( IO_FILL_IO_NORTH_0_95 DVSS )
-      ( IO_FILL_IO_NORTH_0_90 DVSS ) ( IO_FILL_IO_NORTH_0_85 DVSS ) ( IO_FILL_IO_NORTH_0_80 DVSS ) ( IO_FILL_IO_NORTH_0_75 DVSS ) ( IO_FILL_IO_NORTH_0_70 DVSS ) ( IO_FILL_IO_NORTH_0_65 DVSS ) ( IO_FILL_IO_NORTH_0_60 DVSS ) ( IO_FILL_IO_NORTH_0_55 DVSS )
-      ( IO_FILL_IO_NORTH_0_50 DVSS ) ( IO_FILL_IO_NORTH_0_45 DVSS ) ( IO_FILL_IO_NORTH_0_40 DVSS ) ( IO_FILL_IO_NORTH_0_35 DVSS ) ( IO_FILL_IO_NORTH_0_30 DVSS ) ( IO_FILL_IO_NORTH_0_25 DVSS ) ( IO_FILL_IO_NORTH_0_20 DVSS ) ( IO_FILL_IO_NORTH_0_15 DVSS )
-      ( IO_FILL_IO_NORTH_0_10 DVSS ) ( IO_FILL_IO_NORTH_0_5 DVSS ) ( IO_FILL_IO_NORTH_0_0 DVSS ) ( u_brk0 DVSSA ) ( IO_FILL_IO_NORTH_1_130 DVSS ) ( IO_FILL_IO_NORTH_10_0 DVSS ) ( IO_FILL_IO_NORTH_15_5 DVSS ) ( IO_FILL_IO_NORTH_53_100 DVSS )
-      ( IO_FILL_IO_NORTH_37_0 DVSS ) ( IO_FILL_IO_NORTH_48_40 DVSS ) ( IO_FILL_IO_NORTH_6_0 DVSS ) ( IO_FILL_IO_NORTH_22_0 DVSS ) ( IO_FILL_IO_NORTH_30_20 DVSS ) ( IO_FILL_IO_NORTH_37_5 DVSS ) ( IO_FILL_IO_NORTH_49_0 DVSS ) ( IO_FILL_IO_NORTH_6_65 DVSS )
-      ( IO_FILL_IO_NORTH_23_0 DVSS ) ( IO_FILL_IO_NORTH_1_0 DVSS ) ( IO_FILL_IO_NORTH_0_215 DVSS ) ( IO_FILL_IO_NORTH_9_0 DVSS ) ( IO_FILL_IO_NORTH_15_0 DVSS ) ( IO_FILL_IO_NORTH_21_0 DVSS ) ( IO_FILL_IO_NORTH_20_5 DVSS ) ( IO_FILL_IO_NORTH_26_5 DVSS )
-      ( IO_FILL_IO_NORTH_35_0 DVSS ) ( IO_FILL_IO_NORTH_34_0 DVSS ) ( IO_FILL_IO_NORTH_45_0 DVSS ) ( IO_FILL_IO_NORTH_44_35 DVSS ) ( IO_FILL_IO_NORTH_53_0 DVSS ) ( IO_FILL_IO_NORTH_36_0 DVSS ) ( IO_FILL_IO_NORTH_35_5 DVSS ) ( IO_FILL_IO_NORTH_33_0 DVSS )
-      ( IO_FILL_IO_NORTH_32_5 DVSS ) ( IO_FILL_IO_NORTH_32_0 DVSS ) ( u_brk0 DVSSB ) ( IO_FILL_IO_NORTH_31_0 DVSS ) ( IO_FILL_IO_NORTH_39_0 DVSS ) ( IO_FILL_IO_NORTH_38_0 DVSS ) ( IO_FILL_IO_NORTH_14_0 DVSS ) ( IO_FILL_IO_NORTH_13_0 DVSS )
-      ( IO_FILL_IO_NORTH_12_5 DVSS ) ( IO_FILL_IO_NORTH_12_0 DVSS ) ( IO_FILL_IO_NORTH_20_0 DVSS ) ( IO_FILL_IO_NORTH_19_0 DVSS ) ( IO_FILL_IO_NORTH_18_5 DVSS ) ( IO_FILL_IO_NORTH_18_0 DVSS ) ( IO_FILL_IO_NORTH_17_0 DVSS ) ( IO_FILL_IO_NORTH_16_0 DVSS )
-      ( IO_FILL_IO_NORTH_11_0 DVSS ) ( IO_FILL_IO_NORTH_10_10 DVSS ) ( IO_FILL_IO_NORTH_8_0 DVSS ) ( IO_FILL_IO_NORTH_7_0 DVSS ) ( IO_FILL_IO_NORTH_5_0 DVSS ) ( IO_FILL_IO_NORTH_4_5 DVSS ) ( IO_FILL_IO_NORTH_4_0 DVSS ) ( IO_FILL_IO_NORTH_3_70 DVSS )
-      ( IO_FILL_IO_NORTH_3_0 DVSS ) ( IO_FILL_IO_NORTH_2_0 DVSS ) ( IO_FILL_IO_NORTH_30_0 DVSS ) ( IO_FILL_IO_NORTH_29_0 DVSS ) ( IO_FILL_IO_NORTH_28_0 DVSS ) ( IO_FILL_IO_NORTH_27_0 DVSS ) ( IO_FILL_IO_NORTH_26_0 DVSS ) ( IO_FILL_IO_NORTH_25_10 DVSS )
-      ( IO_FILL_IO_NORTH_25_0 DVSS ) ( IO_FILL_IO_NORTH_24_0 DVSS ) ( IO_FILL_IO_NORTH_48_0 DVSS ) ( IO_FILL_IO_NORTH_47_0 DVSS ) ( IO_FILL_IO_NORTH_46_0 DVSS ) ( IO_FILL_IO_NORTH_44_0 DVSS ) ( IO_FILL_IO_NORTH_52_0 DVSS ) ( IO_FILL_IO_NORTH_51_100 DVSS )
-      ( IO_FILL_IO_NORTH_51_0 DVSS ) ( IO_FILL_IO_NORTH_50_0 DVSS ) ( IO_FILL_IO_NORTH_43_0 DVSS ) ( IO_FILL_IO_NORTH_42_25 DVSS ) ( IO_FILL_IO_NORTH_42_0 DVSS ) ( IO_FILL_IO_NORTH_41_0 DVSS ) ( IO_FILL_IO_NORTH_40_0 DVSS ) ( IO_FILL_IO_NORTH_39_5 DVSS )
-      ( IO_FILL_IO_EAST_60_185 DVSS ) ( IO_FILL_IO_EAST_60_190 DVSS ) ( IO_CORNER_NORTH_EAST_INST DVSS ) ( IO_FILL_IO_NORTH_54_0 DVSS ) ( IO_CORNER_NORTH_WEST_INST DVSS ) ( IO_FILL_IO_WEST_57_0 DVSS ) ( u_v18_33 DVSS ) ( u_vzz_33 DVSS )
-      ( u_vdd_0 DVSS ) ( u_v18_0 DVSS ) ( u_vzz_9 DVSS ) ( u_vzz_8 DVSS ) ( u_vzz_7 DVSS ) ( u_vzz_6 DVSS ) ( u_vzz_5 DVSS ) ( u_vzz_4 DVSS )
-      ( u_vzz_32 DVSS ) ( u_vzz_31 DVSS ) ( u_vzz_30 DVSS ) ( u_vzz_3 DVSS ) ( u_vzz_29 DVSS ) ( u_vzz_28 DVSS ) ( u_vzz_27 DVSS ) ( u_vzz_26 DVSS )
-      ( u_vzz_25 DVSS ) ( u_vzz_24 DVSS ) ( u_vzz_23 DVSS ) ( u_vzz_22 DVSS ) ( u_vzz_21 DVSS ) ( u_vzz_20 DVSS ) ( u_vzz_2 DVSS ) ( u_vzz_19 DVSS )
-      ( u_vzz_18 DVSS ) ( u_vzz_17 DVSS ) ( u_vzz_16 DVSS ) ( u_vzz_15 DVSS ) ( u_vzz_14 DVSS ) ( u_vzz_13 DVSS ) ( u_vzz_12 DVSS ) ( u_vzz_11 DVSS )
-      ( u_vzz_10 DVSS ) ( u_vzz_1 DVSS ) ( u_vzz_0 DVSS ) ( u_vss_pll DVSS ) ( u_vss_9 DVSS ) ( u_vss_8 DVSS ) ( u_vss_7 DVSS ) ( u_vss_6 DVSS )
-      ( u_vss_5 DVSS ) ( u_vss_4 DVSS ) ( u_vss_32 DVSS ) ( u_vss_31 DVSS ) ( u_vss_30 DVSS ) ( u_vss_3 DVSS ) ( u_vss_29 DVSS ) ( u_vss_28 DVSS )
-      ( u_vss_27 DVSS ) ( u_vss_26 DVSS ) ( u_vss_25 DVSS ) ( u_vss_24 DVSS ) ( u_vss_23 DVSS ) ( u_vss_22 DVSS ) ( u_vss_21 DVSS ) ( u_vss_20 DVSS )
-      ( u_vss_2 DVSS ) ( u_vss_19 DVSS ) ( u_vss_18 DVSS ) ( u_vss_17 DVSS ) ( u_vss_16 DVSS ) ( u_vss_15 DVSS ) ( u_vss_14 DVSS ) ( u_vss_13 DVSS )
-      ( u_vss_12 DVSS ) ( u_vss_11 DVSS ) ( u_vss_10 DVSS ) ( u_vss_1 DVSS ) ( u_vss_0 DVSS ) ( u_vdd_pll DVSS ) ( u_vdd_9 DVSS ) ( u_vdd_8 DVSS )
-      ( u_vdd_7 DVSS ) ( u_vdd_6 DVSS ) ( u_vdd_5 DVSS ) ( u_vdd_4 DVSS ) ( u_vdd_32 DVSS ) ( u_vdd_31 DVSS ) ( u_vdd_30 DVSS ) ( u_vdd_3 DVSS )
-      ( u_vdd_29 DVSS ) ( u_vdd_28 DVSS ) ( u_vdd_27 DVSS ) ( u_vdd_26 DVSS ) ( u_vdd_25 DVSS ) ( u_vdd_24 DVSS ) ( u_vdd_23 DVSS ) ( u_vdd_22 DVSS )
-      ( u_vdd_21 DVSS ) ( u_vdd_20 DVSS ) ( u_vdd_2 DVSS ) ( u_vdd_19 DVSS ) ( u_vdd_18 DVSS ) ( u_vdd_17 DVSS ) ( u_vdd_16 DVSS ) ( u_vdd_15 DVSS )
-      ( u_vdd_14 DVSS ) ( u_vdd_13 DVSS ) ( u_vdd_12 DVSS ) ( u_vdd_11 DVSS ) ( u_vdd_10 DVSS ) ( u_vdd_1 DVSS ) ( u_v18_9 DVSS ) ( u_v18_8 DVSS )
-      ( u_v18_7 DVSS ) ( u_v18_6 DVSS ) ( u_v18_5 DVSS ) ( u_v18_4 DVSS ) ( u_v18_32 DVSS ) ( u_v18_31 DVSS ) ( u_v18_30 DVSS ) ( u_v18_3 DVSS )
-      ( u_v18_29 DVSS ) ( u_v18_28 DVSS ) ( u_v18_27 DVSS ) ( u_v18_26 DVSS ) ( u_v18_25 DVSS ) ( u_v18_24 DVSS ) ( u_v18_23 DVSS ) ( u_v18_22 DVSS )
-      ( u_v18_21 DVSS ) ( u_v18_20 DVSS ) ( u_v18_2 DVSS ) ( u_v18_19 DVSS ) ( u_v18_18 DVSS ) ( u_v18_17 DVSS ) ( u_v18_16 DVSS ) ( u_v18_15 DVSS )
-      ( u_v18_14 DVSS ) ( u_v18_13 DVSS ) ( u_v18_12 DVSS ) ( u_v18_11 DVSS ) ( u_v18_10 DVSS ) ( u_v18_1 DVSS ) ( u_sel_2_i DVSS ) ( u_sel_1_i DVSS )
-      ( u_sel_0_i DVSS ) ( u_misc_o DVSS ) ( u_ddr_we_n_o DVSS ) ( u_ddr_reset_n_o DVSS ) ( u_ddr_ras_n_o DVSS ) ( u_ddr_odt_o DVSS ) ( u_ddr_dqs_p_3_io DVSS ) ( u_ddr_dqs_p_2_io DVSS )
-      ( u_ddr_dqs_p_1_io DVSS ) ( u_ddr_dqs_p_0_io DVSS ) ( u_ddr_dqs_n_3_io DVSS ) ( u_ddr_dqs_n_2_io DVSS ) ( u_ddr_dqs_n_1_io DVSS ) ( u_ddr_dqs_n_0_io DVSS ) ( u_ddr_dq_9_io DVSS ) ( u_ddr_dq_8_io DVSS )
-      ( u_ddr_dq_7_io DVSS ) ( u_ddr_dq_6_io DVSS ) ( u_ddr_dq_5_io DVSS ) ( u_ddr_dq_4_io DVSS ) ( u_ddr_dq_3_io DVSS ) ( u_ddr_dq_31_io DVSS ) ( u_ddr_dq_30_io DVSS ) ( u_ddr_dq_2_io DVSS )
-      ( u_ddr_dq_29_io DVSS ) ( u_ddr_dq_28_io DVSS ) ( u_ddr_dq_27_io DVSS ) ( u_ddr_dq_26_io DVSS ) ( u_ddr_dq_25_io DVSS ) ( u_ddr_dq_24_io DVSS ) ( u_ddr_dq_23_io DVSS ) ( u_ddr_dq_22_io DVSS )
-      ( u_ddr_dq_21_io DVSS ) ( u_ddr_dq_20_io DVSS ) ( u_ddr_dq_1_io DVSS ) ( u_ddr_dq_19_io DVSS ) ( u_ddr_dq_18_io DVSS ) ( u_ddr_dq_17_io DVSS ) ( u_ddr_dq_16_io DVSS ) ( u_ddr_dq_15_io DVSS )
-      ( u_ddr_dq_14_io DVSS ) ( u_ddr_dq_13_io DVSS ) ( u_ddr_dq_12_io DVSS ) ( u_ddr_dq_11_io DVSS ) ( u_ddr_dq_10_io DVSS ) ( u_ddr_dq_0_io DVSS ) ( u_ddr_dm_3_o DVSS ) ( u_ddr_dm_2_o DVSS )
-      ( u_ddr_dm_1_o DVSS ) ( u_ddr_dm_0_o DVSS ) ( u_ddr_cs_n_o DVSS ) ( u_ddr_cke_o DVSS ) ( u_ddr_ck_p_o DVSS ) ( u_ddr_ck_n_o DVSS ) ( u_ddr_cas_n_o DVSS ) ( u_ddr_ba_2_o DVSS )
-      ( u_ddr_ba_1_o DVSS ) ( u_ddr_ba_0_o DVSS ) ( u_ddr_addr_9_o DVSS ) ( u_ddr_addr_8_o DVSS ) ( u_ddr_addr_7_o DVSS ) ( u_ddr_addr_6_o DVSS ) ( u_ddr_addr_5_o DVSS ) ( u_ddr_addr_4_o DVSS )
-      ( u_ddr_addr_3_o DVSS ) ( u_ddr_addr_2_o DVSS ) ( u_ddr_addr_1_o DVSS ) ( u_ddr_addr_15_o DVSS ) ( u_ddr_addr_14_o DVSS ) ( u_ddr_addr_13_o DVSS ) ( u_ddr_addr_12_o DVSS ) ( u_ddr_addr_11_o DVSS )
-      ( u_ddr_addr_10_o DVSS ) ( u_ddr_addr_0_o DVSS ) ( u_core_async_reset_i DVSS ) ( u_co_v_i DVSS ) ( u_co_tkn_o DVSS ) ( u_co_clk_i DVSS ) ( u_co_8_i DVSS ) ( u_co_7_i DVSS )
-      ( u_co_6_i DVSS ) ( u_co_5_i DVSS ) ( u_co_4_i DVSS ) ( u_co_3_i DVSS ) ( u_co_2_i DVSS ) ( u_co_1_i DVSS ) ( u_co_0_i DVSS ) ( u_co2_v_o DVSS )
-      ( u_co2_tkn_i DVSS ) ( u_co2_clk_o DVSS ) ( u_co2_8_o DVSS ) ( u_co2_7_o DVSS ) ( u_co2_6_o DVSS ) ( u_co2_5_o DVSS ) ( u_co2_4_o DVSS ) ( u_co2_3_o DVSS )
-      ( u_co2_2_o DVSS ) ( u_co2_1_o DVSS ) ( u_co2_0_o DVSS ) ( u_clk_o DVSS ) ( u_clk_async_reset_i DVSS ) ( u_clk_C_i DVSS ) ( u_clk_B_i DVSS ) ( u_clk_A_i DVSS )
-      ( u_ci_v_i DVSS ) ( u_ci_tkn_o DVSS ) ( u_ci_clk_i DVSS ) ( u_ci_8_i DVSS ) ( u_ci_7_i DVSS ) ( u_ci_6_i DVSS ) ( u_ci_5_i DVSS ) ( u_ci_4_i DVSS )
-      ( u_ci_3_i DVSS ) ( u_ci_2_i DVSS ) ( u_ci_1_i DVSS ) ( u_ci_0_i DVSS ) ( u_ci2_v_o DVSS ) ( u_ci2_tkn_i DVSS ) ( u_ci2_clk_o DVSS ) ( u_ci2_8_o DVSS )
-      ( u_ci2_7_o DVSS ) ( u_ci2_6_o DVSS ) ( u_ci2_5_o DVSS ) ( u_ci2_4_o DVSS ) ( u_ci2_3_o DVSS ) ( u_ci2_2_o DVSS ) ( u_ci2_1_o DVSS ) ( u_ci2_0_o DVSS )
-      ( u_bsg_tag_en_i DVSS ) ( u_bsg_tag_data_o DVSS ) ( u_bsg_tag_data_i DVSS ) ( u_bsg_tag_clk_o DVSS ) ( u_bsg_tag_clk_i DVSS ) + USE GROUND ;
+SPECIALNETS 141 ;
+    - DVDD ( PIN DVDD ) ( BUMP_2_3 PAD ) ( BUMP_0_5 PAD ) ( BUMP_1_6 PAD ) ( BUMP_2_8 PAD ) ( BUMP_0_9 PAD ) ( BUMP_4_11 PAD )
+      ( BUMP_2_12 PAD ) ( BUMP_1_13 PAD ) ( BUMP_1_16 PAD ) ( BUMP_4_15 PAD ) ( BUMP_5_13 PAD ) ( BUMP_7_12 PAD ) ( BUMP_8_14 PAD ) ( BUMP_10_16 PAD )
+      ( BUMP_11_13 PAD ) ( BUMP_13_14 PAD ) ( BUMP_15_15 PAD ) ( BUMP_14_12 PAD ) ( BUMP_16_11 PAD ) ( BUMP_15_10 PAD ) ( BUMP_14_8 PAD ) ( BUMP_16_7 PAD )
+      ( BUMP_12_5 PAD ) ( BUMP_14_4 PAD ) ( BUMP_15_3 PAD ) ( BUMP_15_0 PAD ) ( BUMP_12_1 PAD ) ( BUMP_11_3 PAD ) ( BUMP_9_4 PAD ) ( BUMP_8_1 PAD )
+      ( BUMP_7_3 PAD ) ( BUMP_5_0 PAD ) ( BUMP_4_1 PAD ) ( BUMP_2_1 PAD ) ( IO_FILL_IO_WEST_0_485 DVDD ) ( IO_FILL_IO_WEST_0_480 DVDD ) ( IO_FILL_IO_WEST_0_475 DVDD ) ( IO_FILL_IO_WEST_0_470 DVDD )
+      ( IO_FILL_IO_WEST_0_465 DVDD ) ( IO_FILL_IO_WEST_0_460 DVDD ) ( IO_FILL_IO_WEST_0_455 DVDD ) ( IO_FILL_IO_WEST_0_450 DVDD ) ( IO_FILL_IO_WEST_0_445 DVDD ) ( IO_FILL_IO_WEST_0_440 DVDD ) ( IO_FILL_IO_WEST_0_435 DVDD ) ( IO_FILL_IO_WEST_0_430 DVDD )
+      ( IO_FILL_IO_WEST_0_425 DVDD ) ( IO_FILL_IO_WEST_0_420 DVDD ) ( IO_FILL_IO_WEST_0_415 DVDD ) ( IO_FILL_IO_WEST_0_410 DVDD ) ( IO_FILL_IO_WEST_0_405 DVDD ) ( IO_FILL_IO_WEST_0_400 DVDD ) ( IO_FILL_IO_WEST_0_395 DVDD ) ( IO_FILL_IO_WEST_0_390 DVDD )
+      ( IO_FILL_IO_WEST_0_385 DVDD ) ( IO_FILL_IO_WEST_0_380 DVDD ) ( IO_FILL_IO_WEST_0_375 DVDD ) ( IO_FILL_IO_WEST_0_370 DVDD ) ( IO_FILL_IO_WEST_0_365 DVDD ) ( IO_FILL_IO_WEST_0_360 DVDD ) ( IO_FILL_IO_WEST_0_355 DVDD ) ( IO_FILL_IO_WEST_0_350 DVDD )
+      ( IO_FILL_IO_WEST_0_345 DVDD ) ( IO_FILL_IO_WEST_0_340 DVDD ) ( IO_FILL_IO_WEST_0_335 DVDD ) ( IO_FILL_IO_WEST_0_330 DVDD ) ( IO_FILL_IO_WEST_0_325 DVDD ) ( IO_FILL_IO_WEST_0_320 DVDD ) ( IO_FILL_IO_WEST_0_315 DVDD ) ( IO_FILL_IO_WEST_0_310 DVDD )
+      ( IO_FILL_IO_WEST_0_305 DVDD ) ( IO_FILL_IO_WEST_0_300 DVDD ) ( IO_FILL_IO_WEST_0_295 DVDD ) ( IO_FILL_IO_WEST_0_290 DVDD ) ( IO_FILL_IO_WEST_0_285 DVDD ) ( IO_FILL_IO_WEST_0_280 DVDD ) ( IO_FILL_IO_WEST_0_275 DVDD ) ( IO_FILL_IO_WEST_0_270 DVDD )
+      ( IO_FILL_IO_WEST_0_265 DVDD ) ( IO_FILL_IO_WEST_0_260 DVDD ) ( IO_FILL_IO_WEST_0_255 DVDD ) ( IO_FILL_IO_WEST_0_250 DVDD ) ( IO_FILL_IO_WEST_0_245 DVDD ) ( IO_FILL_IO_WEST_0_240 DVDD ) ( IO_FILL_IO_WEST_0_235 DVDD ) ( IO_FILL_IO_WEST_0_230 DVDD )
+      ( IO_FILL_IO_WEST_0_225 DVDD ) ( IO_FILL_IO_WEST_0_220 DVDD ) ( IO_FILL_IO_WEST_0_215 DVDD ) ( IO_FILL_IO_WEST_0_210 DVDD ) ( IO_FILL_IO_WEST_0_205 DVDD ) ( IO_FILL_IO_WEST_0_200 DVDD ) ( IO_FILL_IO_WEST_0_195 DVDD ) ( IO_FILL_IO_WEST_0_190 DVDD )
+      ( IO_FILL_IO_WEST_0_185 DVDD ) ( IO_FILL_IO_WEST_0_180 DVDD ) ( IO_FILL_IO_WEST_0_175 DVDD ) ( IO_FILL_IO_WEST_0_170 DVDD ) ( IO_FILL_IO_WEST_0_165 DVDD ) ( IO_FILL_IO_WEST_0_160 DVDD ) ( IO_FILL_IO_WEST_0_155 DVDD ) ( IO_FILL_IO_WEST_0_150 DVDD )
+      ( IO_FILL_IO_WEST_0_145 DVDD ) ( IO_FILL_IO_WEST_0_140 DVDD ) ( IO_FILL_IO_WEST_0_135 DVDD ) ( IO_FILL_IO_WEST_0_130 DVDD ) ( IO_FILL_IO_WEST_0_125 DVDD ) ( IO_FILL_IO_WEST_0_120 DVDD ) ( IO_FILL_IO_WEST_0_115 DVDD ) ( IO_FILL_IO_WEST_0_110 DVDD )
+      ( IO_FILL_IO_WEST_0_105 DVDD ) ( IO_FILL_IO_WEST_0_100 DVDD ) ( IO_FILL_IO_WEST_0_95 DVDD ) ( IO_FILL_IO_WEST_0_90 DVDD ) ( IO_FILL_IO_WEST_0_85 DVDD ) ( IO_FILL_IO_WEST_0_80 DVDD ) ( IO_FILL_IO_WEST_0_75 DVDD ) ( IO_FILL_IO_WEST_0_70 DVDD )
+      ( IO_FILL_IO_WEST_0_65 DVDD ) ( IO_FILL_IO_WEST_0_60 DVDD ) ( IO_FILL_IO_WEST_0_55 DVDD ) ( IO_FILL_IO_WEST_0_50 DVDD ) ( IO_FILL_IO_WEST_0_45 DVDD ) ( IO_FILL_IO_WEST_0_40 DVDD ) ( IO_FILL_IO_WEST_0_35 DVDD ) ( IO_FILL_IO_WEST_0_30 DVDD )
+      ( IO_FILL_IO_WEST_0_25 DVDD ) ( IO_FILL_IO_WEST_0_20 DVDD ) ( IO_FILL_IO_WEST_0_15 DVDD ) ( IO_FILL_IO_WEST_0_10 DVDD ) ( IO_FILL_IO_WEST_0_5 DVDD ) ( IO_FILL_IO_WEST_0_0 DVDD ) ( IO_CORNER_SOUTH_WEST_INST DVDD ) ( IO_FILL_IO_SOUTH_0_0 DVDD )
+      ( IO_FILL_IO_SOUTH_0_5 DVDD ) ( IO_FILL_IO_WEST_0_490 DVDD ) ( IO_FILL_IO_SOUTH_0_10 DVDD ) ( IO_FILL_IO_WEST_0_495 DVDD ) ( IO_FILL_IO_SOUTH_0_15 DVDD ) ( IO_FILL_IO_EAST_0_15 DVDD ) ( IO_FILL_IO_EAST_0_10 DVDD ) ( IO_FILL_IO_EAST_0_5 DVDD )
+      ( IO_FILL_IO_EAST_0_0 DVDD ) ( IO_CORNER_SOUTH_EAST_INST DVDD ) ( IO_FILL_IO_WEST_56_90 DVDD ) ( IO_FILL_IO_WEST_56_85 DVDD ) ( IO_FILL_IO_WEST_56_80 DVDD ) ( IO_FILL_IO_WEST_56_75 DVDD ) ( IO_FILL_IO_WEST_56_70 DVDD ) ( IO_FILL_IO_WEST_56_65 DVDD )
+      ( IO_FILL_IO_WEST_56_60 DVDD ) ( IO_FILL_IO_WEST_56_55 DVDD ) ( IO_FILL_IO_WEST_56_50 DVDD ) ( IO_FILL_IO_WEST_56_45 DVDD ) ( IO_FILL_IO_WEST_56_40 DVDD ) ( IO_FILL_IO_WEST_56_35 DVDD ) ( IO_FILL_IO_WEST_56_30 DVDD ) ( IO_FILL_IO_WEST_56_25 DVDD )
+      ( IO_FILL_IO_WEST_56_20 DVDD ) ( IO_FILL_IO_WEST_56_15 DVDD ) ( IO_FILL_IO_WEST_56_10 DVDD ) ( IO_FILL_IO_WEST_56_5 DVDD ) ( IO_FILL_IO_WEST_54_95 DVDD ) ( IO_FILL_IO_WEST_54_90 DVDD ) ( IO_FILL_IO_WEST_54_85 DVDD ) ( IO_FILL_IO_WEST_54_80 DVDD )
+      ( IO_FILL_IO_WEST_54_75 DVDD ) ( IO_FILL_IO_WEST_54_70 DVDD ) ( IO_FILL_IO_WEST_54_65 DVDD ) ( IO_FILL_IO_WEST_54_60 DVDD ) ( IO_FILL_IO_WEST_54_55 DVDD ) ( IO_FILL_IO_WEST_54_50 DVDD ) ( IO_FILL_IO_WEST_54_45 DVDD ) ( IO_FILL_IO_WEST_54_40 DVDD )
+      ( IO_FILL_IO_WEST_54_35 DVDD ) ( IO_FILL_IO_WEST_54_30 DVDD ) ( IO_FILL_IO_WEST_54_25 DVDD ) ( IO_FILL_IO_WEST_54_20 DVDD ) ( IO_FILL_IO_WEST_54_15 DVDD ) ( IO_FILL_IO_WEST_54_10 DVDD ) ( IO_FILL_IO_WEST_54_5 DVDD ) ( IO_FILL_IO_WEST_51_25 DVDD )
+      ( IO_FILL_IO_WEST_51_20 DVDD ) ( IO_FILL_IO_WEST_51_15 DVDD ) ( IO_FILL_IO_WEST_51_10 DVDD ) ( IO_FILL_IO_WEST_51_5 DVDD ) ( IO_FILL_IO_WEST_47_45 DVDD ) ( IO_FILL_IO_WEST_47_40 DVDD ) ( IO_FILL_IO_WEST_47_35 DVDD ) ( IO_FILL_IO_WEST_47_30 DVDD )
+      ( IO_FILL_IO_WEST_47_25 DVDD ) ( IO_FILL_IO_WEST_47_20 DVDD ) ( IO_FILL_IO_WEST_47_15 DVDD ) ( IO_FILL_IO_WEST_47_10 DVDD ) ( IO_FILL_IO_WEST_47_5 DVDD ) ( IO_FILL_IO_WEST_32_5 DVDD ) ( IO_FILL_IO_WEST_27_5 DVDD ) ( IO_FILL_IO_WEST_12_5 DVDD )
+      ( IO_FILL_IO_WEST_7_5 DVDD ) ( IO_FILL_IO_WEST_3_65 DVDD ) ( IO_FILL_IO_WEST_3_60 DVDD ) ( IO_FILL_IO_WEST_3_55 DVDD ) ( IO_FILL_IO_WEST_3_50 DVDD ) ( IO_FILL_IO_WEST_3_45 DVDD ) ( IO_FILL_IO_WEST_3_40 DVDD ) ( IO_FILL_IO_WEST_3_35 DVDD )
+      ( IO_FILL_IO_WEST_3_30 DVDD ) ( IO_FILL_IO_WEST_3_25 DVDD ) ( IO_FILL_IO_WEST_3_20 DVDD ) ( IO_FILL_IO_WEST_3_15 DVDD ) ( IO_FILL_IO_WEST_3_10 DVDD ) ( IO_FILL_IO_WEST_3_5 DVDD ) ( IO_FILL_IO_WEST_0_500 DVDD ) ( IO_FILL_IO_WEST_0_505 DVDD )
+      ( IO_FILL_IO_WEST_1_0 DVDD ) ( IO_FILL_IO_WEST_17_0 DVDD ) ( IO_FILL_IO_WEST_51_0 DVDD ) ( IO_FILL_IO_WEST_3_0 DVDD ) ( IO_FILL_IO_WEST_2_0 DVDD ) ( IO_FILL_IO_WEST_19_5 DVDD ) ( IO_FILL_IO_WEST_51_30 DVDD ) ( IO_FILL_IO_WEST_3_70 DVDD )
+      ( IO_FILL_IO_WEST_20_0 DVDD ) ( IO_FILL_IO_WEST_35_0 DVDD ) ( IO_FILL_IO_WEST_52_0 DVDD ) ( IO_FILL_IO_WEST_10_0 DVDD ) ( IO_FILL_IO_WEST_16_0 DVDD ) ( IO_FILL_IO_WEST_24_0 DVDD ) ( IO_FILL_IO_WEST_30_0 DVDD ) ( IO_FILL_IO_WEST_38_0 DVDD )
+      ( IO_FILL_IO_WEST_37_5 DVDD ) ( IO_FILL_IO_WEST_44_0 DVDD ) ( IO_FILL_IO_WEST_50_0 DVDD ) ( IO_FILL_IO_WEST_15_0 DVDD ) ( IO_FILL_IO_WEST_17_5 DVDD ) ( IO_FILL_IO_WEST_5_0 DVDD ) ( IO_FILL_IO_WEST_4_0 DVDD ) ( IO_FILL_IO_WEST_33_0 DVDD )
+      ( IO_FILL_IO_WEST_32_10 DVDD ) ( IO_FILL_IO_WEST_32_0 DVDD ) ( IO_FILL_IO_WEST_31_0 DVDD ) ( IO_FILL_IO_WEST_29_0 DVDD ) ( IO_FILL_IO_WEST_28_0 DVDD ) ( IO_FILL_IO_WEST_27_10 DVDD ) ( IO_FILL_IO_WEST_27_0 DVDD ) ( IO_FILL_IO_WEST_26_0 DVDD )
+      ( IO_FILL_IO_WEST_25_0 DVDD ) ( IO_FILL_IO_WEST_23_0 DVDD ) ( IO_FILL_IO_WEST_22_5 DVDD ) ( IO_FILL_IO_WEST_14_0 DVDD ) ( IO_FILL_IO_WEST_13_5 DVDD ) ( IO_FILL_IO_WEST_13_0 DVDD ) ( IO_FILL_IO_WEST_12_10 DVDD ) ( IO_FILL_IO_WEST_12_0 DVDD )
+      ( IO_FILL_IO_WEST_11_0 DVDD ) ( IO_FILL_IO_WEST_9_0 DVDD ) ( IO_FILL_IO_WEST_8_0 DVDD ) ( IO_FILL_IO_WEST_7_10 DVDD ) ( IO_FILL_IO_WEST_7_0 DVDD ) ( IO_FILL_IO_WEST_6_0 DVDD ) ( IO_FILL_IO_WEST_22_0 DVDD ) ( IO_FILL_IO_WEST_21_0 DVDD )
+      ( IO_FILL_IO_WEST_19_0 DVDD ) ( IO_FILL_IO_WEST_18_0 DVDD ) ( IO_FILL_IO_WEST_49_0 DVDD ) ( IO_FILL_IO_WEST_48_0 DVDD ) ( IO_FILL_IO_WEST_47_50 DVDD ) ( IO_FILL_IO_WEST_47_0 DVDD ) ( IO_FILL_IO_WEST_56_95 DVDD ) ( IO_FILL_IO_WEST_56_0 DVDD )
+      ( IO_FILL_IO_WEST_55_5 DVDD ) ( IO_FILL_IO_WEST_55_0 DVDD ) ( IO_FILL_IO_WEST_54_100 DVDD ) ( IO_FILL_IO_WEST_54_0 DVDD ) ( IO_FILL_IO_WEST_53_0 DVDD ) ( IO_FILL_IO_WEST_46_0 DVDD ) ( IO_FILL_IO_WEST_45_0 DVDD ) ( IO_FILL_IO_WEST_43_0 DVDD )
+      ( IO_FILL_IO_WEST_42_5 DVDD ) ( IO_FILL_IO_WEST_42_0 DVDD ) ( IO_FILL_IO_WEST_41_5 DVDD ) ( IO_FILL_IO_WEST_41_0 DVDD ) ( IO_FILL_IO_WEST_40_0 DVDD ) ( IO_FILL_IO_WEST_39_0 DVDD ) ( IO_FILL_IO_WEST_34_0 DVDD ) ( IO_FILL_IO_WEST_33_5 DVDD )
+      ( IO_FILL_IO_WEST_37_0 DVDD ) ( IO_FILL_IO_WEST_36_0 DVDD ) ( IO_FILL_IO_SOUTH_60_190 DVDD ) ( IO_FILL_IO_SOUTH_60_185 DVDD ) ( IO_FILL_IO_SOUTH_60_180 DVDD ) ( IO_FILL_IO_SOUTH_60_175 DVDD ) ( IO_FILL_IO_SOUTH_60_170 DVDD ) ( IO_FILL_IO_SOUTH_60_165 DVDD )
+      ( IO_FILL_IO_SOUTH_60_160 DVDD ) ( IO_FILL_IO_SOUTH_60_155 DVDD ) ( IO_FILL_IO_SOUTH_60_150 DVDD ) ( IO_FILL_IO_SOUTH_60_145 DVDD ) ( IO_FILL_IO_SOUTH_60_140 DVDD ) ( IO_FILL_IO_SOUTH_60_135 DVDD ) ( IO_FILL_IO_SOUTH_60_130 DVDD ) ( IO_FILL_IO_SOUTH_60_125 DVDD )
+      ( IO_FILL_IO_SOUTH_60_120 DVDD ) ( IO_FILL_IO_SOUTH_60_115 DVDD ) ( IO_FILL_IO_SOUTH_60_110 DVDD ) ( IO_FILL_IO_SOUTH_60_105 DVDD ) ( IO_FILL_IO_SOUTH_60_100 DVDD ) ( IO_FILL_IO_SOUTH_60_95 DVDD ) ( IO_FILL_IO_SOUTH_60_90 DVDD ) ( IO_FILL_IO_SOUTH_60_85 DVDD )
+      ( IO_FILL_IO_SOUTH_60_80 DVDD ) ( IO_FILL_IO_SOUTH_60_75 DVDD ) ( IO_FILL_IO_SOUTH_60_70 DVDD ) ( IO_FILL_IO_SOUTH_60_65 DVDD ) ( IO_FILL_IO_SOUTH_60_60 DVDD ) ( IO_FILL_IO_SOUTH_60_55 DVDD ) ( IO_FILL_IO_SOUTH_60_50 DVDD ) ( IO_FILL_IO_SOUTH_60_45 DVDD )
+      ( IO_FILL_IO_SOUTH_60_40 DVDD ) ( IO_FILL_IO_SOUTH_60_35 DVDD ) ( IO_FILL_IO_SOUTH_60_30 DVDD ) ( IO_FILL_IO_SOUTH_60_25 DVDD ) ( IO_FILL_IO_SOUTH_60_20 DVDD ) ( IO_FILL_IO_SOUTH_60_15 DVDD ) ( IO_FILL_IO_SOUTH_60_10 DVDD ) ( IO_FILL_IO_SOUTH_60_5 DVDD )
+      ( IO_FILL_IO_SOUTH_59_125 DVDD ) ( IO_FILL_IO_SOUTH_59_120 DVDD ) ( IO_FILL_IO_SOUTH_59_115 DVDD ) ( IO_FILL_IO_SOUTH_59_110 DVDD ) ( IO_FILL_IO_SOUTH_59_105 DVDD ) ( IO_FILL_IO_SOUTH_59_100 DVDD ) ( IO_FILL_IO_SOUTH_59_95 DVDD ) ( IO_FILL_IO_SOUTH_59_90 DVDD )
+      ( IO_FILL_IO_SOUTH_59_85 DVDD ) ( IO_FILL_IO_SOUTH_59_80 DVDD ) ( IO_FILL_IO_SOUTH_59_75 DVDD ) ( IO_FILL_IO_SOUTH_59_70 DVDD ) ( IO_FILL_IO_SOUTH_59_65 DVDD ) ( IO_FILL_IO_SOUTH_59_60 DVDD ) ( IO_FILL_IO_SOUTH_59_55 DVDD ) ( IO_FILL_IO_SOUTH_59_50 DVDD )
+      ( IO_FILL_IO_SOUTH_59_45 DVDD ) ( IO_FILL_IO_SOUTH_59_40 DVDD ) ( IO_FILL_IO_SOUTH_59_35 DVDD ) ( IO_FILL_IO_SOUTH_59_30 DVDD ) ( IO_FILL_IO_SOUTH_59_25 DVDD ) ( IO_FILL_IO_SOUTH_59_20 DVDD ) ( IO_FILL_IO_SOUTH_59_15 DVDD ) ( IO_FILL_IO_SOUTH_59_10 DVDD )
+      ( IO_FILL_IO_SOUTH_59_5 DVDD ) ( IO_FILL_IO_SOUTH_57_60 DVDD ) ( IO_FILL_IO_SOUTH_57_55 DVDD ) ( IO_FILL_IO_SOUTH_57_50 DVDD ) ( IO_FILL_IO_SOUTH_57_45 DVDD ) ( IO_FILL_IO_SOUTH_57_40 DVDD ) ( IO_FILL_IO_SOUTH_57_35 DVDD ) ( IO_FILL_IO_SOUTH_57_30 DVDD )
+      ( IO_FILL_IO_SOUTH_57_25 DVDD ) ( IO_FILL_IO_SOUTH_57_20 DVDD ) ( IO_FILL_IO_SOUTH_57_15 DVDD ) ( IO_FILL_IO_SOUTH_57_10 DVDD ) ( IO_FILL_IO_SOUTH_57_5 DVDD ) ( IO_FILL_IO_SOUTH_54_65 DVDD ) ( IO_FILL_IO_SOUTH_54_60 DVDD ) ( IO_FILL_IO_SOUTH_54_55 DVDD )
+      ( IO_FILL_IO_SOUTH_54_50 DVDD ) ( IO_FILL_IO_SOUTH_54_45 DVDD ) ( IO_FILL_IO_SOUTH_54_40 DVDD ) ( IO_FILL_IO_SOUTH_54_35 DVDD ) ( IO_FILL_IO_SOUTH_54_30 DVDD ) ( IO_FILL_IO_SOUTH_54_25 DVDD ) ( IO_FILL_IO_SOUTH_54_20 DVDD ) ( IO_FILL_IO_SOUTH_54_15 DVDD )
+      ( IO_FILL_IO_SOUTH_54_10 DVDD ) ( IO_FILL_IO_SOUTH_54_5 DVDD ) ( IO_FILL_IO_SOUTH_40_5 DVDD ) ( IO_FILL_IO_SOUTH_20_5 DVDD ) ( IO_FILL_IO_SOUTH_10_30 DVDD ) ( IO_FILL_IO_SOUTH_10_25 DVDD ) ( IO_FILL_IO_SOUTH_10_20 DVDD ) ( IO_FILL_IO_SOUTH_10_15 DVDD )
+      ( IO_FILL_IO_SOUTH_10_10 DVDD ) ( IO_FILL_IO_SOUTH_10_5 DVDD ) ( IO_FILL_IO_SOUTH_6_35 DVDD ) ( IO_FILL_IO_SOUTH_6_30 DVDD ) ( IO_FILL_IO_SOUTH_6_25 DVDD ) ( IO_FILL_IO_SOUTH_6_20 DVDD ) ( IO_FILL_IO_SOUTH_6_15 DVDD ) ( IO_FILL_IO_SOUTH_6_10 DVDD )
+      ( IO_FILL_IO_SOUTH_6_5 DVDD ) ( IO_FILL_IO_SOUTH_3_95 DVDD ) ( IO_FILL_IO_SOUTH_3_90 DVDD ) ( IO_FILL_IO_SOUTH_3_85 DVDD ) ( IO_FILL_IO_SOUTH_3_80 DVDD ) ( IO_FILL_IO_SOUTH_3_75 DVDD ) ( IO_FILL_IO_SOUTH_3_70 DVDD ) ( IO_FILL_IO_SOUTH_3_65 DVDD )
+      ( IO_FILL_IO_SOUTH_3_60 DVDD ) ( IO_FILL_IO_SOUTH_3_55 DVDD ) ( IO_FILL_IO_SOUTH_3_50 DVDD ) ( IO_FILL_IO_SOUTH_3_45 DVDD ) ( IO_FILL_IO_SOUTH_3_40 DVDD ) ( IO_FILL_IO_SOUTH_3_35 DVDD ) ( IO_FILL_IO_SOUTH_3_30 DVDD ) ( IO_FILL_IO_SOUTH_3_25 DVDD )
+      ( IO_FILL_IO_SOUTH_3_20 DVDD ) ( IO_FILL_IO_SOUTH_3_15 DVDD ) ( IO_FILL_IO_SOUTH_3_10 DVDD ) ( IO_FILL_IO_SOUTH_3_5 DVDD ) ( IO_FILL_IO_SOUTH_1_95 DVDD ) ( IO_FILL_IO_SOUTH_1_90 DVDD ) ( IO_FILL_IO_SOUTH_1_85 DVDD ) ( IO_FILL_IO_SOUTH_1_80 DVDD )
+      ( IO_FILL_IO_SOUTH_1_75 DVDD ) ( IO_FILL_IO_SOUTH_1_70 DVDD ) ( IO_FILL_IO_SOUTH_1_65 DVDD ) ( IO_FILL_IO_SOUTH_1_60 DVDD ) ( IO_FILL_IO_SOUTH_1_55 DVDD ) ( IO_FILL_IO_SOUTH_1_50 DVDD ) ( IO_FILL_IO_SOUTH_1_45 DVDD ) ( IO_FILL_IO_SOUTH_1_40 DVDD )
+      ( IO_FILL_IO_SOUTH_1_35 DVDD ) ( IO_FILL_IO_SOUTH_1_30 DVDD ) ( IO_FILL_IO_SOUTH_1_25 DVDD ) ( IO_FILL_IO_SOUTH_1_20 DVDD ) ( IO_FILL_IO_SOUTH_1_15 DVDD ) ( IO_FILL_IO_SOUTH_1_10 DVDD ) ( IO_FILL_IO_SOUTH_1_5 DVDD ) ( IO_FILL_IO_SOUTH_0_20 DVDD )
+      ( IO_FILL_IO_SOUTH_6_0 DVDD ) ( IO_FILL_IO_SOUTH_3_100 DVDD ) ( IO_FILL_IO_SOUTH_59_0 DVDD ) ( IO_FILL_IO_SOUTH_50_5 DVDD ) ( IO_FILL_IO_SOUTH_45_0 DVDD ) ( IO_FILL_IO_SOUTH_30_5 DVDD ) ( IO_FILL_IO_SOUTH_25_0 DVDD ) ( IO_FILL_IO_SOUTH_10_35 DVDD )
+      ( IO_FILL_IO_SOUTH_3_0 DVDD ) ( IO_FILL_IO_SOUTH_54_0 DVDD ) ( IO_FILL_IO_SOUTH_22_0 DVDD ) ( IO_FILL_IO_SOUTH_6_40 DVDD ) ( IO_FILL_IO_SOUTH_53_0 DVDD ) ( IO_FILL_IO_SOUTH_36_0 DVDD ) ( IO_FILL_IO_SOUTH_35_5 DVDD ) ( IO_FILL_IO_SOUTH_21_0 DVDD )
+      ( IO_FILL_IO_SOUTH_20_10 DVDD ) ( IO_FILL_IO_SOUTH_60_0 DVDD ) ( IO_FILL_IO_SOUTH_59_130 DVDD ) ( IO_FILL_IO_SOUTH_52_0 DVDD ) ( IO_FILL_IO_SOUTH_51_0 DVDD ) ( IO_FILL_IO_SOUTH_45_5 DVDD ) ( IO_FILL_IO_SOUTH_40_0 DVDD ) ( IO_FILL_IO_SOUTH_39_0 DVDD )
+      ( IO_FILL_IO_SOUTH_31_0 DVDD ) ( IO_FILL_IO_SOUTH_25_5 DVDD ) ( IO_FILL_IO_SOUTH_17_0 DVDD ) ( IO_FILL_IO_SOUTH_11_0 DVDD ) ( IO_FILL_IO_SOUTH_42_5 DVDD ) ( IO_FILL_IO_SOUTH_42_0 DVDD ) ( IO_FILL_IO_SOUTH_46_0 DVDD ) ( IO_FILL_IO_SOUTH_41_0 DVDD )
+      ( IO_FILL_IO_SOUTH_40_10 DVDD ) ( IO_FILL_IO_SOUTH_57_0 DVDD ) ( IO_FILL_IO_SOUTH_56_5 DVDD ) ( IO_FILL_IO_SOUTH_5_0 DVDD ) ( IO_FILL_IO_SOUTH_4_0 DVDD ) ( IO_FILL_IO_SOUTH_56_0 DVDD ) ( IO_FILL_IO_SOUTH_2_0 DVDD ) ( IO_FILL_IO_SOUTH_1_100 DVDD )
+      ( IO_FILL_IO_SOUTH_58_0 DVDD ) ( IO_FILL_IO_SOUTH_57_65 DVDD ) ( IO_FILL_IO_SOUTH_1_0 DVDD ) ( IO_FILL_IO_SOUTH_0_25 DVDD ) ( IO_FILL_IO_SOUTH_48_0 DVDD ) ( IO_FILL_IO_SOUTH_47_0 DVDD ) ( IO_FILL_IO_SOUTH_48_5 DVDD ) ( IO_FILL_IO_SOUTH_55_0 DVDD )
+      ( IO_FILL_IO_SOUTH_54_70 DVDD ) ( IO_FILL_IO_SOUTH_50_0 DVDD ) ( IO_FILL_IO_SOUTH_49_0 DVDD ) ( IO_FILL_IO_SOUTH_44_0 DVDD ) ( IO_FILL_IO_SOUTH_43_0 DVDD ) ( IO_FILL_IO_SOUTH_8_0 DVDD ) ( IO_FILL_IO_SOUTH_7_0 DVDD ) ( IO_FILL_IO_SOUTH_8_5 DVDD )
+      ( IO_FILL_IO_SOUTH_10_0 DVDD ) ( IO_FILL_IO_SOUTH_9_0 DVDD ) ( IO_FILL_IO_SOUTH_22_5 DVDD ) ( IO_FILL_IO_SOUTH_24_0 DVDD ) ( IO_FILL_IO_SOUTH_23_0 DVDD ) ( IO_FILL_IO_SOUTH_26_0 DVDD ) ( IO_FILL_IO_SOUTH_28_0 DVDD ) ( IO_FILL_IO_SOUTH_27_0 DVDD )
+      ( IO_FILL_IO_SOUTH_28_5 DVDD ) ( IO_FILL_IO_SOUTH_30_0 DVDD ) ( IO_FILL_IO_SOUTH_29_0 DVDD ) ( IO_FILL_IO_SOUTH_32_0 DVDD ) ( IO_FILL_IO_SOUTH_34_0 DVDD ) ( IO_FILL_IO_SOUTH_33_0 DVDD ) ( IO_FILL_IO_SOUTH_35_0 DVDD ) ( IO_FILL_IO_SOUTH_34_5 DVDD )
+      ( IO_FILL_IO_SOUTH_12_0 DVDD ) ( IO_FILL_IO_SOUTH_14_0 DVDD ) ( IO_FILL_IO_SOUTH_13_0 DVDD ) ( IO_FILL_IO_SOUTH_15_0 DVDD ) ( IO_FILL_IO_SOUTH_14_5 DVDD ) ( IO_FILL_IO_SOUTH_16_0 DVDD ) ( IO_FILL_IO_SOUTH_15_5 DVDD ) ( IO_FILL_IO_SOUTH_18_0 DVDD )
+      ( IO_FILL_IO_SOUTH_20_0 DVDD ) ( IO_FILL_IO_SOUTH_19_0 DVDD ) ( IO_FILL_IO_SOUTH_38_0 DVDD ) ( IO_FILL_IO_SOUTH_37_0 DVDD ) ( IO_FILL_IO_EAST_60_180 DVDD ) ( IO_FILL_IO_EAST_60_175 DVDD ) ( IO_FILL_IO_EAST_60_170 DVDD ) ( IO_FILL_IO_EAST_60_165 DVDD )
+      ( IO_FILL_IO_EAST_60_160 DVDD ) ( IO_FILL_IO_EAST_60_155 DVDD ) ( IO_FILL_IO_EAST_60_150 DVDD ) ( IO_FILL_IO_EAST_60_145 DVDD ) ( IO_FILL_IO_EAST_60_140 DVDD ) ( IO_FILL_IO_EAST_60_135 DVDD ) ( IO_FILL_IO_EAST_60_130 DVDD ) ( IO_FILL_IO_EAST_60_125 DVDD )
+      ( IO_FILL_IO_EAST_60_120 DVDD ) ( IO_FILL_IO_EAST_60_115 DVDD ) ( IO_FILL_IO_EAST_60_110 DVDD ) ( IO_FILL_IO_EAST_60_105 DVDD ) ( IO_FILL_IO_EAST_60_100 DVDD ) ( IO_FILL_IO_EAST_60_95 DVDD ) ( IO_FILL_IO_EAST_60_90 DVDD ) ( IO_FILL_IO_EAST_60_85 DVDD )
+      ( IO_FILL_IO_EAST_60_80 DVDD ) ( IO_FILL_IO_EAST_60_75 DVDD ) ( IO_FILL_IO_EAST_60_70 DVDD ) ( IO_FILL_IO_EAST_60_65 DVDD ) ( IO_FILL_IO_EAST_60_60 DVDD ) ( IO_FILL_IO_EAST_60_55 DVDD ) ( IO_FILL_IO_EAST_60_50 DVDD ) ( IO_FILL_IO_EAST_60_45 DVDD )
+      ( IO_FILL_IO_EAST_60_40 DVDD ) ( IO_FILL_IO_EAST_60_35 DVDD ) ( IO_FILL_IO_EAST_60_30 DVDD ) ( IO_FILL_IO_EAST_60_25 DVDD ) ( IO_FILL_IO_EAST_60_20 DVDD ) ( IO_FILL_IO_EAST_60_15 DVDD ) ( IO_FILL_IO_EAST_60_10 DVDD ) ( IO_FILL_IO_EAST_60_5 DVDD )
+      ( IO_FILL_IO_EAST_59_120 DVDD ) ( IO_FILL_IO_EAST_59_115 DVDD ) ( IO_FILL_IO_EAST_59_110 DVDD ) ( IO_FILL_IO_EAST_59_105 DVDD ) ( IO_FILL_IO_EAST_59_100 DVDD ) ( IO_FILL_IO_EAST_59_95 DVDD ) ( IO_FILL_IO_EAST_59_90 DVDD ) ( IO_FILL_IO_EAST_59_85 DVDD )
+      ( IO_FILL_IO_EAST_59_80 DVDD ) ( IO_FILL_IO_EAST_59_75 DVDD ) ( IO_FILL_IO_EAST_59_70 DVDD ) ( IO_FILL_IO_EAST_59_65 DVDD ) ( IO_FILL_IO_EAST_59_60 DVDD ) ( IO_FILL_IO_EAST_59_55 DVDD ) ( IO_FILL_IO_EAST_59_50 DVDD ) ( IO_FILL_IO_EAST_59_45 DVDD )
+      ( IO_FILL_IO_EAST_59_40 DVDD ) ( IO_FILL_IO_EAST_59_35 DVDD ) ( IO_FILL_IO_EAST_59_30 DVDD ) ( IO_FILL_IO_EAST_59_25 DVDD ) ( IO_FILL_IO_EAST_59_20 DVDD ) ( IO_FILL_IO_EAST_59_15 DVDD ) ( IO_FILL_IO_EAST_59_10 DVDD ) ( IO_FILL_IO_EAST_59_5 DVDD )
+      ( IO_FILL_IO_EAST_57_65 DVDD ) ( IO_FILL_IO_EAST_57_60 DVDD ) ( IO_FILL_IO_EAST_57_55 DVDD ) ( IO_FILL_IO_EAST_57_50 DVDD ) ( IO_FILL_IO_EAST_57_45 DVDD ) ( IO_FILL_IO_EAST_57_40 DVDD ) ( IO_FILL_IO_EAST_57_35 DVDD ) ( IO_FILL_IO_EAST_57_30 DVDD )
+      ( IO_FILL_IO_EAST_57_25 DVDD ) ( IO_FILL_IO_EAST_57_20 DVDD ) ( IO_FILL_IO_EAST_57_15 DVDD ) ( IO_FILL_IO_EAST_57_10 DVDD ) ( IO_FILL_IO_EAST_57_5 DVDD ) ( IO_FILL_IO_EAST_54_65 DVDD ) ( IO_FILL_IO_EAST_54_60 DVDD ) ( IO_FILL_IO_EAST_54_55 DVDD )
+      ( IO_FILL_IO_EAST_54_50 DVDD ) ( IO_FILL_IO_EAST_54_45 DVDD ) ( IO_FILL_IO_EAST_54_40 DVDD ) ( IO_FILL_IO_EAST_54_35 DVDD ) ( IO_FILL_IO_EAST_54_30 DVDD ) ( IO_FILL_IO_EAST_54_25 DVDD ) ( IO_FILL_IO_EAST_54_20 DVDD ) ( IO_FILL_IO_EAST_54_15 DVDD )
+      ( IO_FILL_IO_EAST_54_10 DVDD ) ( IO_FILL_IO_EAST_54_5 DVDD ) ( IO_FILL_IO_EAST_50_5 DVDD ) ( IO_FILL_IO_EAST_35_5 DVDD ) ( IO_FILL_IO_EAST_30_5 DVDD ) ( IO_FILL_IO_EAST_15_5 DVDD ) ( IO_FILL_IO_EAST_10_35 DVDD ) ( IO_FILL_IO_EAST_10_30 DVDD )
+      ( IO_FILL_IO_EAST_10_25 DVDD ) ( IO_FILL_IO_EAST_10_20 DVDD ) ( IO_FILL_IO_EAST_10_15 DVDD ) ( IO_FILL_IO_EAST_10_10 DVDD ) ( IO_FILL_IO_EAST_10_5 DVDD ) ( IO_FILL_IO_EAST_6_35 DVDD ) ( IO_FILL_IO_EAST_6_30 DVDD ) ( IO_FILL_IO_EAST_6_25 DVDD )
+      ( IO_FILL_IO_EAST_6_20 DVDD ) ( IO_FILL_IO_EAST_6_15 DVDD ) ( IO_FILL_IO_EAST_6_10 DVDD ) ( IO_FILL_IO_EAST_6_5 DVDD ) ( IO_FILL_IO_EAST_3_90 DVDD ) ( IO_FILL_IO_EAST_3_85 DVDD ) ( IO_FILL_IO_EAST_3_80 DVDD ) ( IO_FILL_IO_EAST_3_75 DVDD )
+      ( IO_FILL_IO_EAST_3_70 DVDD ) ( IO_FILL_IO_EAST_3_65 DVDD ) ( IO_FILL_IO_EAST_3_60 DVDD ) ( IO_FILL_IO_EAST_3_55 DVDD ) ( IO_FILL_IO_EAST_3_50 DVDD ) ( IO_FILL_IO_EAST_3_45 DVDD ) ( IO_FILL_IO_EAST_3_40 DVDD ) ( IO_FILL_IO_EAST_3_35 DVDD )
+      ( IO_FILL_IO_EAST_3_30 DVDD ) ( IO_FILL_IO_EAST_3_25 DVDD ) ( IO_FILL_IO_EAST_3_20 DVDD ) ( IO_FILL_IO_EAST_3_15 DVDD ) ( IO_FILL_IO_EAST_3_10 DVDD ) ( IO_FILL_IO_EAST_3_5 DVDD ) ( IO_FILL_IO_EAST_1_95 DVDD ) ( IO_FILL_IO_EAST_1_90 DVDD )
+      ( IO_FILL_IO_EAST_1_85 DVDD ) ( IO_FILL_IO_EAST_1_80 DVDD ) ( IO_FILL_IO_EAST_1_75 DVDD ) ( IO_FILL_IO_EAST_1_70 DVDD ) ( IO_FILL_IO_EAST_1_65 DVDD ) ( IO_FILL_IO_EAST_1_60 DVDD ) ( IO_FILL_IO_EAST_1_55 DVDD ) ( IO_FILL_IO_EAST_1_50 DVDD )
+      ( IO_FILL_IO_EAST_1_45 DVDD ) ( IO_FILL_IO_EAST_1_40 DVDD ) ( IO_FILL_IO_EAST_1_35 DVDD ) ( IO_FILL_IO_EAST_1_30 DVDD ) ( IO_FILL_IO_EAST_1_25 DVDD ) ( IO_FILL_IO_EAST_1_20 DVDD ) ( IO_FILL_IO_EAST_1_15 DVDD ) ( IO_FILL_IO_EAST_1_10 DVDD )
+      ( IO_FILL_IO_EAST_1_5 DVDD ) ( IO_FILL_IO_EAST_0_20 DVDD ) ( IO_FILL_IO_EAST_6_40 DVDD ) ( IO_FILL_IO_EAST_40_5 DVDD ) ( IO_FILL_IO_EAST_57_0 DVDD ) ( IO_FILL_IO_EAST_56_0 DVDD ) ( IO_FILL_IO_EAST_38_0 DVDD ) ( IO_FILL_IO_EAST_22_0 DVDD )
+      ( IO_FILL_IO_EAST_4_0 DVDD ) ( IO_FILL_IO_EAST_3_95 DVDD ) ( IO_FILL_IO_EAST_7_0 DVDD ) ( IO_FILL_IO_EAST_54_0 DVDD ) ( IO_FILL_IO_EAST_53_0 DVDD ) ( IO_FILL_IO_EAST_47_0 DVDD ) ( IO_FILL_IO_EAST_41_0 DVDD ) ( IO_FILL_IO_EAST_33_0 DVDD )
+      ( IO_FILL_IO_EAST_27_0 DVDD ) ( IO_FILL_IO_EAST_20_0 DVDD ) ( IO_FILL_IO_EAST_19_0 DVDD ) ( IO_FILL_IO_EAST_13_0 DVDD ) ( IO_FILL_IO_EAST_30_0 DVDD ) ( IO_FILL_IO_EAST_29_0 DVDD ) ( IO_FILL_IO_EAST_28_0 DVDD ) ( IO_FILL_IO_EAST_15_0 DVDD )
+      ( IO_FILL_IO_EAST_14_0 DVDD ) ( IO_FILL_IO_EAST_16_0 DVDD ) ( IO_FILL_IO_EAST_15_10 DVDD ) ( IO_FILL_IO_EAST_16_5 DVDD ) ( IO_FILL_IO_EAST_18_0 DVDD ) ( IO_FILL_IO_EAST_17_0 DVDD ) ( IO_FILL_IO_EAST_21_0 DVDD ) ( IO_FILL_IO_EAST_20_5 DVDD )
+      ( IO_FILL_IO_EAST_24_0 DVDD ) ( IO_FILL_IO_EAST_23_0 DVDD ) ( IO_FILL_IO_EAST_25_0 DVDD ) ( IO_FILL_IO_EAST_24_5 DVDD ) ( IO_FILL_IO_EAST_26_0 DVDD ) ( IO_FILL_IO_EAST_25_5 DVDD ) ( IO_FILL_IO_EAST_1_0 DVDD ) ( IO_FILL_IO_EAST_0_25 DVDD )
+      ( IO_FILL_IO_EAST_2_0 DVDD ) ( IO_FILL_IO_EAST_1_100 DVDD ) ( IO_FILL_IO_EAST_3_0 DVDD ) ( IO_FILL_IO_EAST_2_5 DVDD ) ( IO_FILL_IO_EAST_6_0 DVDD ) ( IO_FILL_IO_EAST_5_0 DVDD ) ( IO_FILL_IO_EAST_8_0 DVDD ) ( IO_FILL_IO_EAST_10_0 DVDD )
+      ( IO_FILL_IO_EAST_9_0 DVDD ) ( IO_FILL_IO_EAST_10_40 DVDD ) ( IO_FILL_IO_EAST_12_0 DVDD ) ( IO_FILL_IO_EAST_11_0 DVDD ) ( IO_FILL_IO_EAST_30_10 DVDD ) ( IO_FILL_IO_EAST_45_0 DVDD ) ( IO_FILL_IO_EAST_44_5 DVDD ) ( IO_FILL_IO_EAST_46_0 DVDD )
+      ( IO_FILL_IO_EAST_45_5 DVDD ) ( IO_FILL_IO_EAST_48_0 DVDD ) ( IO_FILL_IO_EAST_37_0 DVDD ) ( IO_FILL_IO_EAST_36_5 DVDD ) ( IO_FILL_IO_EAST_40_0 DVDD ) ( IO_FILL_IO_EAST_39_0 DVDD ) ( IO_FILL_IO_EAST_42_0 DVDD ) ( IO_FILL_IO_EAST_44_0 DVDD )
+      ( IO_FILL_IO_EAST_43_0 DVDD ) ( IO_FILL_IO_EAST_50_0 DVDD ) ( IO_FILL_IO_EAST_49_0 DVDD ) ( IO_FILL_IO_EAST_50_10 DVDD ) ( IO_FILL_IO_EAST_52_0 DVDD ) ( IO_FILL_IO_EAST_51_0 DVDD ) ( IO_FILL_IO_EAST_55_0 DVDD ) ( IO_FILL_IO_EAST_54_70 DVDD )
+      ( IO_FILL_IO_EAST_58_0 DVDD ) ( IO_FILL_IO_EAST_57_70 DVDD ) ( IO_FILL_IO_EAST_59_0 DVDD ) ( IO_FILL_IO_EAST_58_5 DVDD ) ( IO_FILL_IO_EAST_60_0 DVDD ) ( IO_FILL_IO_EAST_59_125 DVDD ) ( IO_FILL_IO_EAST_36_0 DVDD ) ( IO_FILL_IO_EAST_35_10 DVDD )
+      ( IO_FILL_IO_EAST_35_0 DVDD ) ( IO_FILL_IO_EAST_34_0 DVDD ) ( IO_FILL_IO_EAST_32_0 DVDD ) ( IO_FILL_IO_EAST_31_0 DVDD ) ( IO_FILL_IO_NORTH_53_95 DVDD ) ( IO_FILL_IO_NORTH_53_90 DVDD ) ( IO_FILL_IO_NORTH_53_85 DVDD ) ( IO_FILL_IO_NORTH_53_80 DVDD )
+      ( IO_FILL_IO_NORTH_53_75 DVDD ) ( IO_FILL_IO_NORTH_53_70 DVDD ) ( IO_FILL_IO_NORTH_53_65 DVDD ) ( IO_FILL_IO_NORTH_53_60 DVDD ) ( IO_FILL_IO_NORTH_53_55 DVDD ) ( IO_FILL_IO_NORTH_53_50 DVDD ) ( IO_FILL_IO_NORTH_53_45 DVDD ) ( IO_FILL_IO_NORTH_53_40 DVDD )
+      ( IO_FILL_IO_NORTH_53_35 DVDD ) ( IO_FILL_IO_NORTH_53_30 DVDD ) ( IO_FILL_IO_NORTH_53_25 DVDD ) ( IO_FILL_IO_NORTH_53_20 DVDD ) ( IO_FILL_IO_NORTH_53_15 DVDD ) ( IO_FILL_IO_NORTH_53_10 DVDD ) ( IO_FILL_IO_NORTH_53_5 DVDD ) ( IO_FILL_IO_NORTH_51_95 DVDD )
+      ( IO_FILL_IO_NORTH_51_90 DVDD ) ( IO_FILL_IO_NORTH_51_85 DVDD ) ( IO_FILL_IO_NORTH_51_80 DVDD ) ( IO_FILL_IO_NORTH_51_75 DVDD ) ( IO_FILL_IO_NORTH_51_70 DVDD ) ( IO_FILL_IO_NORTH_51_65 DVDD ) ( IO_FILL_IO_NORTH_51_60 DVDD ) ( IO_FILL_IO_NORTH_51_55 DVDD )
+      ( IO_FILL_IO_NORTH_51_50 DVDD ) ( IO_FILL_IO_NORTH_51_45 DVDD ) ( IO_FILL_IO_NORTH_51_40 DVDD ) ( IO_FILL_IO_NORTH_51_35 DVDD ) ( IO_FILL_IO_NORTH_51_30 DVDD ) ( IO_FILL_IO_NORTH_51_25 DVDD ) ( IO_FILL_IO_NORTH_51_20 DVDD ) ( IO_FILL_IO_NORTH_51_15 DVDD )
+      ( IO_FILL_IO_NORTH_51_10 DVDD ) ( IO_FILL_IO_NORTH_51_5 DVDD ) ( IO_FILL_IO_NORTH_48_35 DVDD ) ( IO_FILL_IO_NORTH_48_30 DVDD ) ( IO_FILL_IO_NORTH_48_25 DVDD ) ( IO_FILL_IO_NORTH_48_20 DVDD ) ( IO_FILL_IO_NORTH_48_15 DVDD ) ( IO_FILL_IO_NORTH_48_10 DVDD )
+      ( IO_FILL_IO_NORTH_48_5 DVDD ) ( IO_FILL_IO_NORTH_44_30 DVDD ) ( IO_FILL_IO_NORTH_44_25 DVDD ) ( IO_FILL_IO_NORTH_44_20 DVDD ) ( IO_FILL_IO_NORTH_44_15 DVDD ) ( IO_FILL_IO_NORTH_44_10 DVDD ) ( IO_FILL_IO_NORTH_44_5 DVDD ) ( IO_FILL_IO_NORTH_42_20 DVDD )
+      ( IO_FILL_IO_NORTH_42_15 DVDD ) ( IO_FILL_IO_NORTH_42_10 DVDD ) ( IO_FILL_IO_NORTH_42_5 DVDD ) ( IO_FILL_IO_NORTH_30_15 DVDD ) ( IO_FILL_IO_NORTH_30_10 DVDD ) ( IO_FILL_IO_NORTH_30_5 DVDD ) ( IO_FILL_IO_NORTH_25_5 DVDD ) ( IO_FILL_IO_NORTH_10_5 DVDD )
+      ( IO_FILL_IO_NORTH_6_60 DVDD ) ( IO_FILL_IO_NORTH_6_55 DVDD ) ( IO_FILL_IO_NORTH_6_50 DVDD ) ( IO_FILL_IO_NORTH_6_45 DVDD ) ( IO_FILL_IO_NORTH_6_40 DVDD ) ( IO_FILL_IO_NORTH_6_35 DVDD ) ( IO_FILL_IO_NORTH_6_30 DVDD ) ( IO_FILL_IO_NORTH_6_25 DVDD )
+      ( IO_FILL_IO_NORTH_6_20 DVDD ) ( IO_FILL_IO_NORTH_6_15 DVDD ) ( IO_FILL_IO_NORTH_6_10 DVDD ) ( IO_FILL_IO_NORTH_6_5 DVDD ) ( IO_FILL_IO_NORTH_3_65 DVDD ) ( IO_FILL_IO_NORTH_3_60 DVDD ) ( IO_FILL_IO_NORTH_3_55 DVDD ) ( IO_FILL_IO_NORTH_3_50 DVDD )
+      ( IO_FILL_IO_NORTH_3_45 DVDD ) ( IO_FILL_IO_NORTH_3_40 DVDD ) ( IO_FILL_IO_NORTH_3_35 DVDD ) ( IO_FILL_IO_NORTH_3_30 DVDD ) ( IO_FILL_IO_NORTH_3_25 DVDD ) ( IO_FILL_IO_NORTH_3_20 DVDD ) ( IO_FILL_IO_NORTH_3_15 DVDD ) ( IO_FILL_IO_NORTH_3_10 DVDD )
+      ( IO_FILL_IO_NORTH_3_5 DVDD ) ( IO_FILL_IO_NORTH_1_125 DVDD ) ( IO_FILL_IO_NORTH_1_120 DVDD ) ( IO_FILL_IO_NORTH_1_115 DVDD ) ( IO_FILL_IO_NORTH_1_110 DVDD ) ( IO_FILL_IO_NORTH_1_105 DVDD ) ( IO_FILL_IO_NORTH_1_100 DVDD ) ( IO_FILL_IO_NORTH_1_95 DVDD )
+      ( IO_FILL_IO_NORTH_1_90 DVDD ) ( IO_FILL_IO_NORTH_1_85 DVDD ) ( IO_FILL_IO_NORTH_1_80 DVDD ) ( IO_FILL_IO_NORTH_1_75 DVDD ) ( IO_FILL_IO_NORTH_1_70 DVDD ) ( IO_FILL_IO_NORTH_1_65 DVDD ) ( IO_FILL_IO_NORTH_1_60 DVDD ) ( IO_FILL_IO_NORTH_1_55 DVDD )
+      ( IO_FILL_IO_NORTH_1_50 DVDD ) ( IO_FILL_IO_NORTH_1_45 DVDD ) ( IO_FILL_IO_NORTH_1_40 DVDD ) ( IO_FILL_IO_NORTH_1_35 DVDD ) ( IO_FILL_IO_NORTH_1_30 DVDD ) ( IO_FILL_IO_NORTH_1_25 DVDD ) ( IO_FILL_IO_NORTH_1_20 DVDD ) ( IO_FILL_IO_NORTH_1_15 DVDD )
+      ( IO_FILL_IO_NORTH_1_10 DVDD ) ( IO_FILL_IO_NORTH_1_5 DVDD ) ( IO_FILL_IO_NORTH_0_210 DVDD ) ( IO_FILL_IO_NORTH_0_205 DVDD ) ( IO_FILL_IO_NORTH_0_200 DVDD ) ( IO_FILL_IO_NORTH_0_195 DVDD ) ( IO_FILL_IO_NORTH_0_190 DVDD ) ( IO_FILL_IO_NORTH_0_185 DVDD )
+      ( IO_FILL_IO_NORTH_0_180 DVDD ) ( IO_FILL_IO_NORTH_0_175 DVDD ) ( IO_FILL_IO_NORTH_0_170 DVDD ) ( IO_FILL_IO_NORTH_0_165 DVDD ) ( IO_FILL_IO_NORTH_0_160 DVDD ) ( IO_FILL_IO_NORTH_0_155 DVDD ) ( IO_FILL_IO_NORTH_0_150 DVDD ) ( IO_FILL_IO_NORTH_0_145 DVDD )
+      ( IO_FILL_IO_NORTH_0_140 DVDD ) ( IO_FILL_IO_NORTH_0_135 DVDD ) ( IO_FILL_IO_NORTH_0_130 DVDD ) ( IO_FILL_IO_NORTH_0_125 DVDD ) ( IO_FILL_IO_NORTH_0_120 DVDD ) ( IO_FILL_IO_NORTH_0_115 DVDD ) ( IO_FILL_IO_NORTH_0_110 DVDD ) ( IO_FILL_IO_NORTH_0_105 DVDD )
+      ( IO_FILL_IO_NORTH_0_100 DVDD ) ( IO_FILL_IO_NORTH_0_95 DVDD ) ( IO_FILL_IO_NORTH_0_90 DVDD ) ( IO_FILL_IO_NORTH_0_85 DVDD ) ( IO_FILL_IO_NORTH_0_80 DVDD ) ( IO_FILL_IO_NORTH_0_75 DVDD ) ( IO_FILL_IO_NORTH_0_70 DVDD ) ( IO_FILL_IO_NORTH_0_65 DVDD )
+      ( IO_FILL_IO_NORTH_0_60 DVDD ) ( IO_FILL_IO_NORTH_0_55 DVDD ) ( IO_FILL_IO_NORTH_0_50 DVDD ) ( IO_FILL_IO_NORTH_0_45 DVDD ) ( IO_FILL_IO_NORTH_0_40 DVDD ) ( IO_FILL_IO_NORTH_0_35 DVDD ) ( IO_FILL_IO_NORTH_0_30 DVDD ) ( IO_FILL_IO_NORTH_0_25 DVDD )
+      ( IO_FILL_IO_NORTH_0_20 DVDD ) ( IO_FILL_IO_NORTH_0_15 DVDD ) ( IO_FILL_IO_NORTH_0_10 DVDD ) ( IO_FILL_IO_NORTH_0_5 DVDD ) ( IO_FILL_IO_NORTH_0_0 DVDD ) ( u_brk0 DVDDA ) ( IO_FILL_IO_NORTH_1_130 DVDD ) ( IO_FILL_IO_NORTH_10_0 DVDD )
+      ( IO_FILL_IO_NORTH_15_5 DVDD ) ( IO_FILL_IO_NORTH_53_100 DVDD ) ( IO_FILL_IO_NORTH_37_0 DVDD ) ( IO_FILL_IO_NORTH_48_40 DVDD ) ( IO_FILL_IO_NORTH_6_0 DVDD ) ( IO_FILL_IO_NORTH_22_0 DVDD ) ( IO_FILL_IO_NORTH_30_20 DVDD ) ( IO_FILL_IO_NORTH_37_5 DVDD )
+      ( IO_FILL_IO_NORTH_49_0 DVDD ) ( IO_FILL_IO_NORTH_6_65 DVDD ) ( IO_FILL_IO_NORTH_23_0 DVDD ) ( IO_FILL_IO_NORTH_1_0 DVDD ) ( IO_FILL_IO_NORTH_0_215 DVDD ) ( IO_FILL_IO_NORTH_9_0 DVDD ) ( IO_FILL_IO_NORTH_15_0 DVDD ) ( IO_FILL_IO_NORTH_21_0 DVDD )
+      ( IO_FILL_IO_NORTH_20_5 DVDD ) ( IO_FILL_IO_NORTH_26_5 DVDD ) ( IO_FILL_IO_NORTH_35_0 DVDD ) ( IO_FILL_IO_NORTH_34_0 DVDD ) ( IO_FILL_IO_NORTH_45_0 DVDD ) ( IO_FILL_IO_NORTH_44_35 DVDD ) ( IO_FILL_IO_NORTH_53_0 DVDD ) ( IO_FILL_IO_NORTH_36_0 DVDD )
+      ( IO_FILL_IO_NORTH_35_5 DVDD ) ( IO_FILL_IO_NORTH_33_0 DVDD ) ( IO_FILL_IO_NORTH_32_5 DVDD ) ( IO_FILL_IO_NORTH_32_0 DVDD ) ( u_brk0 DVDDB ) ( IO_FILL_IO_NORTH_31_0 DVDD ) ( IO_FILL_IO_NORTH_39_0 DVDD ) ( IO_FILL_IO_NORTH_38_0 DVDD )
+      ( IO_FILL_IO_NORTH_14_0 DVDD ) ( IO_FILL_IO_NORTH_13_0 DVDD ) ( IO_FILL_IO_NORTH_12_5 DVDD ) ( IO_FILL_IO_NORTH_12_0 DVDD ) ( IO_FILL_IO_NORTH_20_0 DVDD ) ( IO_FILL_IO_NORTH_19_0 DVDD ) ( IO_FILL_IO_NORTH_18_5 DVDD ) ( IO_FILL_IO_NORTH_18_0 DVDD )
+      ( IO_FILL_IO_NORTH_17_0 DVDD ) ( IO_FILL_IO_NORTH_16_0 DVDD ) ( IO_FILL_IO_NORTH_11_0 DVDD ) ( IO_FILL_IO_NORTH_10_10 DVDD ) ( IO_FILL_IO_NORTH_8_0 DVDD ) ( IO_FILL_IO_NORTH_7_0 DVDD ) ( IO_FILL_IO_NORTH_5_0 DVDD ) ( IO_FILL_IO_NORTH_4_5 DVDD )
+      ( IO_FILL_IO_NORTH_4_0 DVDD ) ( IO_FILL_IO_NORTH_3_70 DVDD ) ( IO_FILL_IO_NORTH_3_0 DVDD ) ( IO_FILL_IO_NORTH_2_0 DVDD ) ( IO_FILL_IO_NORTH_30_0 DVDD ) ( IO_FILL_IO_NORTH_29_0 DVDD ) ( IO_FILL_IO_NORTH_28_0 DVDD ) ( IO_FILL_IO_NORTH_27_0 DVDD )
+      ( IO_FILL_IO_NORTH_26_0 DVDD ) ( IO_FILL_IO_NORTH_25_10 DVDD ) ( IO_FILL_IO_NORTH_25_0 DVDD ) ( IO_FILL_IO_NORTH_24_0 DVDD ) ( IO_FILL_IO_NORTH_48_0 DVDD ) ( IO_FILL_IO_NORTH_47_0 DVDD ) ( IO_FILL_IO_NORTH_46_0 DVDD ) ( IO_FILL_IO_NORTH_44_0 DVDD )
+      ( IO_FILL_IO_NORTH_52_0 DVDD ) ( IO_FILL_IO_NORTH_51_100 DVDD ) ( IO_FILL_IO_NORTH_51_0 DVDD ) ( IO_FILL_IO_NORTH_50_0 DVDD ) ( IO_FILL_IO_NORTH_43_0 DVDD ) ( IO_FILL_IO_NORTH_42_25 DVDD ) ( IO_FILL_IO_NORTH_42_0 DVDD ) ( IO_FILL_IO_NORTH_41_0 DVDD )
+      ( IO_FILL_IO_NORTH_40_0 DVDD ) ( IO_FILL_IO_NORTH_39_5 DVDD ) ( IO_FILL_IO_EAST_60_185 DVDD ) ( IO_FILL_IO_EAST_60_190 DVDD ) ( IO_CORNER_NORTH_EAST_INST DVDD ) ( IO_FILL_IO_NORTH_54_0 DVDD ) ( IO_CORNER_NORTH_WEST_INST DVDD ) ( IO_FILL_IO_WEST_57_0 DVDD )
+      ( u_v18_33 DVDD ) ( u_vzz_33 DVDD ) ( u_vdd_0 DVDD ) ( u_v18_0 DVDD ) ( u_vzz_9 DVDD ) ( u_vzz_8 DVDD ) ( u_vzz_7 DVDD ) ( u_vzz_6 DVDD )
+      ( u_vzz_5 DVDD ) ( u_vzz_4 DVDD ) ( u_vzz_32 DVDD ) ( u_vzz_31 DVDD ) ( u_vzz_30 DVDD ) ( u_vzz_3 DVDD ) ( u_vzz_29 DVDD ) ( u_vzz_28 DVDD )
+      ( u_vzz_27 DVDD ) ( u_vzz_26 DVDD ) ( u_vzz_25 DVDD ) ( u_vzz_24 DVDD ) ( u_vzz_23 DVDD ) ( u_vzz_22 DVDD ) ( u_vzz_21 DVDD ) ( u_vzz_20 DVDD )
+      ( u_vzz_2 DVDD ) ( u_vzz_19 DVDD ) ( u_vzz_18 DVDD ) ( u_vzz_17 DVDD ) ( u_vzz_16 DVDD ) ( u_vzz_15 DVDD ) ( u_vzz_14 DVDD ) ( u_vzz_13 DVDD )
+      ( u_vzz_12 DVDD ) ( u_vzz_11 DVDD ) ( u_vzz_10 DVDD ) ( u_vzz_1 DVDD ) ( u_vzz_0 DVDD ) ( u_vss_pll DVDD ) ( u_vss_9 DVDD ) ( u_vss_8 DVDD )
+      ( u_vss_7 DVDD ) ( u_vss_6 DVDD ) ( u_vss_5 DVDD ) ( u_vss_4 DVDD ) ( u_vss_32 DVDD ) ( u_vss_31 DVDD ) ( u_vss_30 DVDD ) ( u_vss_3 DVDD )
+      ( u_vss_29 DVDD ) ( u_vss_28 DVDD ) ( u_vss_27 DVDD ) ( u_vss_26 DVDD ) ( u_vss_25 DVDD ) ( u_vss_24 DVDD ) ( u_vss_23 DVDD ) ( u_vss_22 DVDD )
+      ( u_vss_21 DVDD ) ( u_vss_20 DVDD ) ( u_vss_2 DVDD ) ( u_vss_19 DVDD ) ( u_vss_18 DVDD ) ( u_vss_17 DVDD ) ( u_vss_16 DVDD ) ( u_vss_15 DVDD )
+      ( u_vss_14 DVDD ) ( u_vss_13 DVDD ) ( u_vss_12 DVDD ) ( u_vss_11 DVDD ) ( u_vss_10 DVDD ) ( u_vss_1 DVDD ) ( u_vss_0 DVDD ) ( u_vdd_pll DVDD )
+      ( u_vdd_9 DVDD ) ( u_vdd_8 DVDD ) ( u_vdd_7 DVDD ) ( u_vdd_6 DVDD ) ( u_vdd_5 DVDD ) ( u_vdd_4 DVDD ) ( u_vdd_32 DVDD ) ( u_vdd_31 DVDD )
+      ( u_vdd_30 DVDD ) ( u_vdd_3 DVDD ) ( u_vdd_29 DVDD ) ( u_vdd_28 DVDD ) ( u_vdd_27 DVDD ) ( u_vdd_26 DVDD ) ( u_vdd_25 DVDD ) ( u_vdd_24 DVDD )
+      ( u_vdd_23 DVDD ) ( u_vdd_22 DVDD ) ( u_vdd_21 DVDD ) ( u_vdd_20 DVDD ) ( u_vdd_2 DVDD ) ( u_vdd_19 DVDD ) ( u_vdd_18 DVDD ) ( u_vdd_17 DVDD )
+      ( u_vdd_16 DVDD ) ( u_vdd_15 DVDD ) ( u_vdd_14 DVDD ) ( u_vdd_13 DVDD ) ( u_vdd_12 DVDD ) ( u_vdd_11 DVDD ) ( u_vdd_10 DVDD ) ( u_vdd_1 DVDD )
+      ( u_v18_9 DVDD ) ( u_v18_8 DVDD ) ( u_v18_7 DVDD ) ( u_v18_6 DVDD ) ( u_v18_5 DVDD ) ( u_v18_4 DVDD ) ( u_v18_32 DVDD ) ( u_v18_31 DVDD )
+      ( u_v18_30 DVDD ) ( u_v18_3 DVDD ) ( u_v18_29 DVDD ) ( u_v18_28 DVDD ) ( u_v18_27 DVDD ) ( u_v18_26 DVDD ) ( u_v18_25 DVDD ) ( u_v18_24 DVDD )
+      ( u_v18_23 DVDD ) ( u_v18_22 DVDD ) ( u_v18_21 DVDD ) ( u_v18_20 DVDD ) ( u_v18_2 DVDD ) ( u_v18_19 DVDD ) ( u_v18_18 DVDD ) ( u_v18_17 DVDD )
+      ( u_v18_16 DVDD ) ( u_v18_15 DVDD ) ( u_v18_14 DVDD ) ( u_v18_13 DVDD ) ( u_v18_12 DVDD ) ( u_v18_11 DVDD ) ( u_v18_10 DVDD ) ( u_v18_1 DVDD )
+      ( u_sel_2_i DVDD ) ( u_sel_1_i DVDD ) ( u_sel_0_i DVDD ) ( u_misc_o DVDD ) ( u_ddr_we_n_o DVDD ) ( u_ddr_reset_n_o DVDD ) ( u_ddr_ras_n_o DVDD ) ( u_ddr_odt_o DVDD )
+      ( u_ddr_dqs_p_3_io DVDD ) ( u_ddr_dqs_p_2_io DVDD ) ( u_ddr_dqs_p_1_io DVDD ) ( u_ddr_dqs_p_0_io DVDD ) ( u_ddr_dqs_n_3_io DVDD ) ( u_ddr_dqs_n_2_io DVDD ) ( u_ddr_dqs_n_1_io DVDD ) ( u_ddr_dqs_n_0_io DVDD )
+      ( u_ddr_dq_9_io DVDD ) ( u_ddr_dq_8_io DVDD ) ( u_ddr_dq_7_io DVDD ) ( u_ddr_dq_6_io DVDD ) ( u_ddr_dq_5_io DVDD ) ( u_ddr_dq_4_io DVDD ) ( u_ddr_dq_3_io DVDD ) ( u_ddr_dq_31_io DVDD )
+      ( u_ddr_dq_30_io DVDD ) ( u_ddr_dq_2_io DVDD ) ( u_ddr_dq_29_io DVDD ) ( u_ddr_dq_28_io DVDD ) ( u_ddr_dq_27_io DVDD ) ( u_ddr_dq_26_io DVDD ) ( u_ddr_dq_25_io DVDD ) ( u_ddr_dq_24_io DVDD )
+      ( u_ddr_dq_23_io DVDD ) ( u_ddr_dq_22_io DVDD ) ( u_ddr_dq_21_io DVDD ) ( u_ddr_dq_20_io DVDD ) ( u_ddr_dq_1_io DVDD ) ( u_ddr_dq_19_io DVDD ) ( u_ddr_dq_18_io DVDD ) ( u_ddr_dq_17_io DVDD )
+      ( u_ddr_dq_16_io DVDD ) ( u_ddr_dq_15_io DVDD ) ( u_ddr_dq_14_io DVDD ) ( u_ddr_dq_13_io DVDD ) ( u_ddr_dq_12_io DVDD ) ( u_ddr_dq_11_io DVDD ) ( u_ddr_dq_10_io DVDD ) ( u_ddr_dq_0_io DVDD )
+      ( u_ddr_dm_3_o DVDD ) ( u_ddr_dm_2_o DVDD ) ( u_ddr_dm_1_o DVDD ) ( u_ddr_dm_0_o DVDD ) ( u_ddr_cs_n_o DVDD ) ( u_ddr_cke_o DVDD ) ( u_ddr_ck_p_o DVDD ) ( u_ddr_ck_n_o DVDD )
+      ( u_ddr_cas_n_o DVDD ) ( u_ddr_ba_2_o DVDD ) ( u_ddr_ba_1_o DVDD ) ( u_ddr_ba_0_o DVDD ) ( u_ddr_addr_9_o DVDD ) ( u_ddr_addr_8_o DVDD ) ( u_ddr_addr_7_o DVDD ) ( u_ddr_addr_6_o DVDD )
+      ( u_ddr_addr_5_o DVDD ) ( u_ddr_addr_4_o DVDD ) ( u_ddr_addr_3_o DVDD ) ( u_ddr_addr_2_o DVDD ) ( u_ddr_addr_1_o DVDD ) ( u_ddr_addr_15_o DVDD ) ( u_ddr_addr_14_o DVDD ) ( u_ddr_addr_13_o DVDD )
+      ( u_ddr_addr_12_o DVDD ) ( u_ddr_addr_11_o DVDD ) ( u_ddr_addr_10_o DVDD ) ( u_ddr_addr_0_o DVDD ) ( u_core_async_reset_i DVDD ) ( u_co_v_i DVDD ) ( u_co_tkn_o DVDD ) ( u_co_clk_i DVDD )
+      ( u_co_8_i DVDD ) ( u_co_7_i DVDD ) ( u_co_6_i DVDD ) ( u_co_5_i DVDD ) ( u_co_4_i DVDD ) ( u_co_3_i DVDD ) ( u_co_2_i DVDD ) ( u_co_1_i DVDD )
+      ( u_co_0_i DVDD ) ( u_co2_v_o DVDD ) ( u_co2_tkn_i DVDD ) ( u_co2_clk_o DVDD ) ( u_co2_8_o DVDD ) ( u_co2_7_o DVDD ) ( u_co2_6_o DVDD ) ( u_co2_5_o DVDD )
+      ( u_co2_4_o DVDD ) ( u_co2_3_o DVDD ) ( u_co2_2_o DVDD ) ( u_co2_1_o DVDD ) ( u_co2_0_o DVDD ) ( u_clk_o DVDD ) ( u_clk_async_reset_i DVDD ) ( u_clk_C_i DVDD )
+      ( u_clk_B_i DVDD ) ( u_clk_A_i DVDD ) ( u_ci_v_i DVDD ) ( u_ci_tkn_o DVDD ) ( u_ci_clk_i DVDD ) ( u_ci_8_i DVDD ) ( u_ci_7_i DVDD ) ( u_ci_6_i DVDD )
+      ( u_ci_5_i DVDD ) ( u_ci_4_i DVDD ) ( u_ci_3_i DVDD ) ( u_ci_2_i DVDD ) ( u_ci_1_i DVDD ) ( u_ci_0_i DVDD ) ( u_ci2_v_o DVDD ) ( u_ci2_tkn_i DVDD )
+      ( u_ci2_clk_o DVDD ) ( u_ci2_8_o DVDD ) ( u_ci2_7_o DVDD ) ( u_ci2_6_o DVDD ) ( u_ci2_5_o DVDD ) ( u_ci2_4_o DVDD ) ( u_ci2_3_o DVDD ) ( u_ci2_2_o DVDD )
+      ( u_ci2_1_o DVDD ) ( u_ci2_0_o DVDD ) ( u_bsg_tag_en_i DVDD ) ( u_bsg_tag_data_o DVDD ) ( u_bsg_tag_data_i DVDD ) ( u_bsg_tag_clk_o DVDD ) ( u_bsg_tag_clk_i DVDD ) + USE POWER ;
+    - DVSS ( PIN DVSS ) ( BUMP_0_3 PAD ) ( BUMP_1_5 PAD ) ( BUMP_3_6 PAD ) ( BUMP_0_8 PAD ) ( BUMP_1_9 PAD ) ( BUMP_2_11 PAD )
+      ( BUMP_0_12 PAD ) ( BUMP_3_13 PAD ) ( BUMP_2_16 PAD ) ( BUMP_4_13 PAD ) ( BUMP_6_12 PAD ) ( BUMP_7_14 PAD ) ( BUMP_8_15 PAD ) ( BUMP_10_14 PAD )
+      ( BUMP_12_12 PAD ) ( BUMP_13_16 PAD ) ( BUMP_16_16 PAD ) ( BUMP_16_12 PAD ) ( BUMP_15_11 PAD ) ( BUMP_13_10 PAD ) ( BUMP_16_8 PAD ) ( BUMP_15_7 PAD )
+      ( BUMP_14_5 PAD ) ( BUMP_16_4 PAD ) ( BUMP_13_3 PAD ) ( BUMP_14_0 PAD ) ( BUMP_12_3 PAD ) ( BUMP_10_4 PAD ) ( BUMP_9_2 PAD ) ( BUMP_8_3 PAD )
+      ( BUMP_6_4 PAD ) ( BUMP_5_1 PAD ) ( BUMP_4_3 PAD ) ( BUMP_1_0 PAD ) ( IO_FILL_IO_WEST_0_485 DVSS ) ( IO_FILL_IO_WEST_0_480 DVSS ) ( IO_FILL_IO_WEST_0_475 DVSS ) ( IO_FILL_IO_WEST_0_470 DVSS )
+      ( IO_FILL_IO_WEST_0_465 DVSS ) ( IO_FILL_IO_WEST_0_460 DVSS ) ( IO_FILL_IO_WEST_0_455 DVSS ) ( IO_FILL_IO_WEST_0_450 DVSS ) ( IO_FILL_IO_WEST_0_445 DVSS ) ( IO_FILL_IO_WEST_0_440 DVSS ) ( IO_FILL_IO_WEST_0_435 DVSS ) ( IO_FILL_IO_WEST_0_430 DVSS )
+      ( IO_FILL_IO_WEST_0_425 DVSS ) ( IO_FILL_IO_WEST_0_420 DVSS ) ( IO_FILL_IO_WEST_0_415 DVSS ) ( IO_FILL_IO_WEST_0_410 DVSS ) ( IO_FILL_IO_WEST_0_405 DVSS ) ( IO_FILL_IO_WEST_0_400 DVSS ) ( IO_FILL_IO_WEST_0_395 DVSS ) ( IO_FILL_IO_WEST_0_390 DVSS )
+      ( IO_FILL_IO_WEST_0_385 DVSS ) ( IO_FILL_IO_WEST_0_380 DVSS ) ( IO_FILL_IO_WEST_0_375 DVSS ) ( IO_FILL_IO_WEST_0_370 DVSS ) ( IO_FILL_IO_WEST_0_365 DVSS ) ( IO_FILL_IO_WEST_0_360 DVSS ) ( IO_FILL_IO_WEST_0_355 DVSS ) ( IO_FILL_IO_WEST_0_350 DVSS )
+      ( IO_FILL_IO_WEST_0_345 DVSS ) ( IO_FILL_IO_WEST_0_340 DVSS ) ( IO_FILL_IO_WEST_0_335 DVSS ) ( IO_FILL_IO_WEST_0_330 DVSS ) ( IO_FILL_IO_WEST_0_325 DVSS ) ( IO_FILL_IO_WEST_0_320 DVSS ) ( IO_FILL_IO_WEST_0_315 DVSS ) ( IO_FILL_IO_WEST_0_310 DVSS )
+      ( IO_FILL_IO_WEST_0_305 DVSS ) ( IO_FILL_IO_WEST_0_300 DVSS ) ( IO_FILL_IO_WEST_0_295 DVSS ) ( IO_FILL_IO_WEST_0_290 DVSS ) ( IO_FILL_IO_WEST_0_285 DVSS ) ( IO_FILL_IO_WEST_0_280 DVSS ) ( IO_FILL_IO_WEST_0_275 DVSS ) ( IO_FILL_IO_WEST_0_270 DVSS )
+      ( IO_FILL_IO_WEST_0_265 DVSS ) ( IO_FILL_IO_WEST_0_260 DVSS ) ( IO_FILL_IO_WEST_0_255 DVSS ) ( IO_FILL_IO_WEST_0_250 DVSS ) ( IO_FILL_IO_WEST_0_245 DVSS ) ( IO_FILL_IO_WEST_0_240 DVSS ) ( IO_FILL_IO_WEST_0_235 DVSS ) ( IO_FILL_IO_WEST_0_230 DVSS )
+      ( IO_FILL_IO_WEST_0_225 DVSS ) ( IO_FILL_IO_WEST_0_220 DVSS ) ( IO_FILL_IO_WEST_0_215 DVSS ) ( IO_FILL_IO_WEST_0_210 DVSS ) ( IO_FILL_IO_WEST_0_205 DVSS ) ( IO_FILL_IO_WEST_0_200 DVSS ) ( IO_FILL_IO_WEST_0_195 DVSS ) ( IO_FILL_IO_WEST_0_190 DVSS )
+      ( IO_FILL_IO_WEST_0_185 DVSS ) ( IO_FILL_IO_WEST_0_180 DVSS ) ( IO_FILL_IO_WEST_0_175 DVSS ) ( IO_FILL_IO_WEST_0_170 DVSS ) ( IO_FILL_IO_WEST_0_165 DVSS ) ( IO_FILL_IO_WEST_0_160 DVSS ) ( IO_FILL_IO_WEST_0_155 DVSS ) ( IO_FILL_IO_WEST_0_150 DVSS )
+      ( IO_FILL_IO_WEST_0_145 DVSS ) ( IO_FILL_IO_WEST_0_140 DVSS ) ( IO_FILL_IO_WEST_0_135 DVSS ) ( IO_FILL_IO_WEST_0_130 DVSS ) ( IO_FILL_IO_WEST_0_125 DVSS ) ( IO_FILL_IO_WEST_0_120 DVSS ) ( IO_FILL_IO_WEST_0_115 DVSS ) ( IO_FILL_IO_WEST_0_110 DVSS )
+      ( IO_FILL_IO_WEST_0_105 DVSS ) ( IO_FILL_IO_WEST_0_100 DVSS ) ( IO_FILL_IO_WEST_0_95 DVSS ) ( IO_FILL_IO_WEST_0_90 DVSS ) ( IO_FILL_IO_WEST_0_85 DVSS ) ( IO_FILL_IO_WEST_0_80 DVSS ) ( IO_FILL_IO_WEST_0_75 DVSS ) ( IO_FILL_IO_WEST_0_70 DVSS )
+      ( IO_FILL_IO_WEST_0_65 DVSS ) ( IO_FILL_IO_WEST_0_60 DVSS ) ( IO_FILL_IO_WEST_0_55 DVSS ) ( IO_FILL_IO_WEST_0_50 DVSS ) ( IO_FILL_IO_WEST_0_45 DVSS ) ( IO_FILL_IO_WEST_0_40 DVSS ) ( IO_FILL_IO_WEST_0_35 DVSS ) ( IO_FILL_IO_WEST_0_30 DVSS )
+      ( IO_FILL_IO_WEST_0_25 DVSS ) ( IO_FILL_IO_WEST_0_20 DVSS ) ( IO_FILL_IO_WEST_0_15 DVSS ) ( IO_FILL_IO_WEST_0_10 DVSS ) ( IO_FILL_IO_WEST_0_5 DVSS ) ( IO_FILL_IO_WEST_0_0 DVSS ) ( IO_CORNER_SOUTH_WEST_INST DVSS ) ( IO_FILL_IO_SOUTH_0_0 DVSS )
+      ( IO_FILL_IO_SOUTH_0_5 DVSS ) ( IO_FILL_IO_WEST_0_490 DVSS ) ( IO_FILL_IO_SOUTH_0_10 DVSS ) ( IO_FILL_IO_WEST_0_495 DVSS ) ( IO_FILL_IO_SOUTH_0_15 DVSS ) ( IO_FILL_IO_EAST_0_15 DVSS ) ( IO_FILL_IO_EAST_0_10 DVSS ) ( IO_FILL_IO_EAST_0_5 DVSS )
+      ( IO_FILL_IO_EAST_0_0 DVSS ) ( IO_CORNER_SOUTH_EAST_INST DVSS ) ( IO_FILL_IO_WEST_56_90 DVSS ) ( IO_FILL_IO_WEST_56_85 DVSS ) ( IO_FILL_IO_WEST_56_80 DVSS ) ( IO_FILL_IO_WEST_56_75 DVSS ) ( IO_FILL_IO_WEST_56_70 DVSS ) ( IO_FILL_IO_WEST_56_65 DVSS )
+      ( IO_FILL_IO_WEST_56_60 DVSS ) ( IO_FILL_IO_WEST_56_55 DVSS ) ( IO_FILL_IO_WEST_56_50 DVSS ) ( IO_FILL_IO_WEST_56_45 DVSS ) ( IO_FILL_IO_WEST_56_40 DVSS ) ( IO_FILL_IO_WEST_56_35 DVSS ) ( IO_FILL_IO_WEST_56_30 DVSS ) ( IO_FILL_IO_WEST_56_25 DVSS )
+      ( IO_FILL_IO_WEST_56_20 DVSS ) ( IO_FILL_IO_WEST_56_15 DVSS ) ( IO_FILL_IO_WEST_56_10 DVSS ) ( IO_FILL_IO_WEST_56_5 DVSS ) ( IO_FILL_IO_WEST_54_95 DVSS ) ( IO_FILL_IO_WEST_54_90 DVSS ) ( IO_FILL_IO_WEST_54_85 DVSS ) ( IO_FILL_IO_WEST_54_80 DVSS )
+      ( IO_FILL_IO_WEST_54_75 DVSS ) ( IO_FILL_IO_WEST_54_70 DVSS ) ( IO_FILL_IO_WEST_54_65 DVSS ) ( IO_FILL_IO_WEST_54_60 DVSS ) ( IO_FILL_IO_WEST_54_55 DVSS ) ( IO_FILL_IO_WEST_54_50 DVSS ) ( IO_FILL_IO_WEST_54_45 DVSS ) ( IO_FILL_IO_WEST_54_40 DVSS )
+      ( IO_FILL_IO_WEST_54_35 DVSS ) ( IO_FILL_IO_WEST_54_30 DVSS ) ( IO_FILL_IO_WEST_54_25 DVSS ) ( IO_FILL_IO_WEST_54_20 DVSS ) ( IO_FILL_IO_WEST_54_15 DVSS ) ( IO_FILL_IO_WEST_54_10 DVSS ) ( IO_FILL_IO_WEST_54_5 DVSS ) ( IO_FILL_IO_WEST_51_25 DVSS )
+      ( IO_FILL_IO_WEST_51_20 DVSS ) ( IO_FILL_IO_WEST_51_15 DVSS ) ( IO_FILL_IO_WEST_51_10 DVSS ) ( IO_FILL_IO_WEST_51_5 DVSS ) ( IO_FILL_IO_WEST_47_45 DVSS ) ( IO_FILL_IO_WEST_47_40 DVSS ) ( IO_FILL_IO_WEST_47_35 DVSS ) ( IO_FILL_IO_WEST_47_30 DVSS )
+      ( IO_FILL_IO_WEST_47_25 DVSS ) ( IO_FILL_IO_WEST_47_20 DVSS ) ( IO_FILL_IO_WEST_47_15 DVSS ) ( IO_FILL_IO_WEST_47_10 DVSS ) ( IO_FILL_IO_WEST_47_5 DVSS ) ( IO_FILL_IO_WEST_32_5 DVSS ) ( IO_FILL_IO_WEST_27_5 DVSS ) ( IO_FILL_IO_WEST_12_5 DVSS )
+      ( IO_FILL_IO_WEST_7_5 DVSS ) ( IO_FILL_IO_WEST_3_65 DVSS ) ( IO_FILL_IO_WEST_3_60 DVSS ) ( IO_FILL_IO_WEST_3_55 DVSS ) ( IO_FILL_IO_WEST_3_50 DVSS ) ( IO_FILL_IO_WEST_3_45 DVSS ) ( IO_FILL_IO_WEST_3_40 DVSS ) ( IO_FILL_IO_WEST_3_35 DVSS )
+      ( IO_FILL_IO_WEST_3_30 DVSS ) ( IO_FILL_IO_WEST_3_25 DVSS ) ( IO_FILL_IO_WEST_3_20 DVSS ) ( IO_FILL_IO_WEST_3_15 DVSS ) ( IO_FILL_IO_WEST_3_10 DVSS ) ( IO_FILL_IO_WEST_3_5 DVSS ) ( IO_FILL_IO_WEST_0_500 DVSS ) ( IO_FILL_IO_WEST_0_505 DVSS )
+      ( IO_FILL_IO_WEST_1_0 DVSS ) ( IO_FILL_IO_WEST_17_0 DVSS ) ( IO_FILL_IO_WEST_51_0 DVSS ) ( IO_FILL_IO_WEST_3_0 DVSS ) ( IO_FILL_IO_WEST_2_0 DVSS ) ( IO_FILL_IO_WEST_19_5 DVSS ) ( IO_FILL_IO_WEST_51_30 DVSS ) ( IO_FILL_IO_WEST_3_70 DVSS )
+      ( IO_FILL_IO_WEST_20_0 DVSS ) ( IO_FILL_IO_WEST_35_0 DVSS ) ( IO_FILL_IO_WEST_52_0 DVSS ) ( IO_FILL_IO_WEST_10_0 DVSS ) ( IO_FILL_IO_WEST_16_0 DVSS ) ( IO_FILL_IO_WEST_24_0 DVSS ) ( IO_FILL_IO_WEST_30_0 DVSS ) ( IO_FILL_IO_WEST_38_0 DVSS )
+      ( IO_FILL_IO_WEST_37_5 DVSS ) ( IO_FILL_IO_WEST_44_0 DVSS ) ( IO_FILL_IO_WEST_50_0 DVSS ) ( IO_FILL_IO_WEST_15_0 DVSS ) ( IO_FILL_IO_WEST_17_5 DVSS ) ( IO_FILL_IO_WEST_5_0 DVSS ) ( IO_FILL_IO_WEST_4_0 DVSS ) ( IO_FILL_IO_WEST_33_0 DVSS )
+      ( IO_FILL_IO_WEST_32_10 DVSS ) ( IO_FILL_IO_WEST_32_0 DVSS ) ( IO_FILL_IO_WEST_31_0 DVSS ) ( IO_FILL_IO_WEST_29_0 DVSS ) ( IO_FILL_IO_WEST_28_0 DVSS ) ( IO_FILL_IO_WEST_27_10 DVSS ) ( IO_FILL_IO_WEST_27_0 DVSS ) ( IO_FILL_IO_WEST_26_0 DVSS )
+      ( IO_FILL_IO_WEST_25_0 DVSS ) ( IO_FILL_IO_WEST_23_0 DVSS ) ( IO_FILL_IO_WEST_22_5 DVSS ) ( IO_FILL_IO_WEST_14_0 DVSS ) ( IO_FILL_IO_WEST_13_5 DVSS ) ( IO_FILL_IO_WEST_13_0 DVSS ) ( IO_FILL_IO_WEST_12_10 DVSS ) ( IO_FILL_IO_WEST_12_0 DVSS )
+      ( IO_FILL_IO_WEST_11_0 DVSS ) ( IO_FILL_IO_WEST_9_0 DVSS ) ( IO_FILL_IO_WEST_8_0 DVSS ) ( IO_FILL_IO_WEST_7_10 DVSS ) ( IO_FILL_IO_WEST_7_0 DVSS ) ( IO_FILL_IO_WEST_6_0 DVSS ) ( IO_FILL_IO_WEST_22_0 DVSS ) ( IO_FILL_IO_WEST_21_0 DVSS )
+      ( IO_FILL_IO_WEST_19_0 DVSS ) ( IO_FILL_IO_WEST_18_0 DVSS ) ( IO_FILL_IO_WEST_49_0 DVSS ) ( IO_FILL_IO_WEST_48_0 DVSS ) ( IO_FILL_IO_WEST_47_50 DVSS ) ( IO_FILL_IO_WEST_47_0 DVSS ) ( IO_FILL_IO_WEST_56_95 DVSS ) ( IO_FILL_IO_WEST_56_0 DVSS )
+      ( IO_FILL_IO_WEST_55_5 DVSS ) ( IO_FILL_IO_WEST_55_0 DVSS ) ( IO_FILL_IO_WEST_54_100 DVSS ) ( IO_FILL_IO_WEST_54_0 DVSS ) ( IO_FILL_IO_WEST_53_0 DVSS ) ( IO_FILL_IO_WEST_46_0 DVSS ) ( IO_FILL_IO_WEST_45_0 DVSS ) ( IO_FILL_IO_WEST_43_0 DVSS )
+      ( IO_FILL_IO_WEST_42_5 DVSS ) ( IO_FILL_IO_WEST_42_0 DVSS ) ( IO_FILL_IO_WEST_41_5 DVSS ) ( IO_FILL_IO_WEST_41_0 DVSS ) ( IO_FILL_IO_WEST_40_0 DVSS ) ( IO_FILL_IO_WEST_39_0 DVSS ) ( IO_FILL_IO_WEST_34_0 DVSS ) ( IO_FILL_IO_WEST_33_5 DVSS )
+      ( IO_FILL_IO_WEST_37_0 DVSS ) ( IO_FILL_IO_WEST_36_0 DVSS ) ( IO_FILL_IO_SOUTH_60_190 DVSS ) ( IO_FILL_IO_SOUTH_60_185 DVSS ) ( IO_FILL_IO_SOUTH_60_180 DVSS ) ( IO_FILL_IO_SOUTH_60_175 DVSS ) ( IO_FILL_IO_SOUTH_60_170 DVSS ) ( IO_FILL_IO_SOUTH_60_165 DVSS )
+      ( IO_FILL_IO_SOUTH_60_160 DVSS ) ( IO_FILL_IO_SOUTH_60_155 DVSS ) ( IO_FILL_IO_SOUTH_60_150 DVSS ) ( IO_FILL_IO_SOUTH_60_145 DVSS ) ( IO_FILL_IO_SOUTH_60_140 DVSS ) ( IO_FILL_IO_SOUTH_60_135 DVSS ) ( IO_FILL_IO_SOUTH_60_130 DVSS ) ( IO_FILL_IO_SOUTH_60_125 DVSS )
+      ( IO_FILL_IO_SOUTH_60_120 DVSS ) ( IO_FILL_IO_SOUTH_60_115 DVSS ) ( IO_FILL_IO_SOUTH_60_110 DVSS ) ( IO_FILL_IO_SOUTH_60_105 DVSS ) ( IO_FILL_IO_SOUTH_60_100 DVSS ) ( IO_FILL_IO_SOUTH_60_95 DVSS ) ( IO_FILL_IO_SOUTH_60_90 DVSS ) ( IO_FILL_IO_SOUTH_60_85 DVSS )
+      ( IO_FILL_IO_SOUTH_60_80 DVSS ) ( IO_FILL_IO_SOUTH_60_75 DVSS ) ( IO_FILL_IO_SOUTH_60_70 DVSS ) ( IO_FILL_IO_SOUTH_60_65 DVSS ) ( IO_FILL_IO_SOUTH_60_60 DVSS ) ( IO_FILL_IO_SOUTH_60_55 DVSS ) ( IO_FILL_IO_SOUTH_60_50 DVSS ) ( IO_FILL_IO_SOUTH_60_45 DVSS )
+      ( IO_FILL_IO_SOUTH_60_40 DVSS ) ( IO_FILL_IO_SOUTH_60_35 DVSS ) ( IO_FILL_IO_SOUTH_60_30 DVSS ) ( IO_FILL_IO_SOUTH_60_25 DVSS ) ( IO_FILL_IO_SOUTH_60_20 DVSS ) ( IO_FILL_IO_SOUTH_60_15 DVSS ) ( IO_FILL_IO_SOUTH_60_10 DVSS ) ( IO_FILL_IO_SOUTH_60_5 DVSS )
+      ( IO_FILL_IO_SOUTH_59_125 DVSS ) ( IO_FILL_IO_SOUTH_59_120 DVSS ) ( IO_FILL_IO_SOUTH_59_115 DVSS ) ( IO_FILL_IO_SOUTH_59_110 DVSS ) ( IO_FILL_IO_SOUTH_59_105 DVSS ) ( IO_FILL_IO_SOUTH_59_100 DVSS ) ( IO_FILL_IO_SOUTH_59_95 DVSS ) ( IO_FILL_IO_SOUTH_59_90 DVSS )
+      ( IO_FILL_IO_SOUTH_59_85 DVSS ) ( IO_FILL_IO_SOUTH_59_80 DVSS ) ( IO_FILL_IO_SOUTH_59_75 DVSS ) ( IO_FILL_IO_SOUTH_59_70 DVSS ) ( IO_FILL_IO_SOUTH_59_65 DVSS ) ( IO_FILL_IO_SOUTH_59_60 DVSS ) ( IO_FILL_IO_SOUTH_59_55 DVSS ) ( IO_FILL_IO_SOUTH_59_50 DVSS )
+      ( IO_FILL_IO_SOUTH_59_45 DVSS ) ( IO_FILL_IO_SOUTH_59_40 DVSS ) ( IO_FILL_IO_SOUTH_59_35 DVSS ) ( IO_FILL_IO_SOUTH_59_30 DVSS ) ( IO_FILL_IO_SOUTH_59_25 DVSS ) ( IO_FILL_IO_SOUTH_59_20 DVSS ) ( IO_FILL_IO_SOUTH_59_15 DVSS ) ( IO_FILL_IO_SOUTH_59_10 DVSS )
+      ( IO_FILL_IO_SOUTH_59_5 DVSS ) ( IO_FILL_IO_SOUTH_57_60 DVSS ) ( IO_FILL_IO_SOUTH_57_55 DVSS ) ( IO_FILL_IO_SOUTH_57_50 DVSS ) ( IO_FILL_IO_SOUTH_57_45 DVSS ) ( IO_FILL_IO_SOUTH_57_40 DVSS ) ( IO_FILL_IO_SOUTH_57_35 DVSS ) ( IO_FILL_IO_SOUTH_57_30 DVSS )
+      ( IO_FILL_IO_SOUTH_57_25 DVSS ) ( IO_FILL_IO_SOUTH_57_20 DVSS ) ( IO_FILL_IO_SOUTH_57_15 DVSS ) ( IO_FILL_IO_SOUTH_57_10 DVSS ) ( IO_FILL_IO_SOUTH_57_5 DVSS ) ( IO_FILL_IO_SOUTH_54_65 DVSS ) ( IO_FILL_IO_SOUTH_54_60 DVSS ) ( IO_FILL_IO_SOUTH_54_55 DVSS )
+      ( IO_FILL_IO_SOUTH_54_50 DVSS ) ( IO_FILL_IO_SOUTH_54_45 DVSS ) ( IO_FILL_IO_SOUTH_54_40 DVSS ) ( IO_FILL_IO_SOUTH_54_35 DVSS ) ( IO_FILL_IO_SOUTH_54_30 DVSS ) ( IO_FILL_IO_SOUTH_54_25 DVSS ) ( IO_FILL_IO_SOUTH_54_20 DVSS ) ( IO_FILL_IO_SOUTH_54_15 DVSS )
+      ( IO_FILL_IO_SOUTH_54_10 DVSS ) ( IO_FILL_IO_SOUTH_54_5 DVSS ) ( IO_FILL_IO_SOUTH_40_5 DVSS ) ( IO_FILL_IO_SOUTH_20_5 DVSS ) ( IO_FILL_IO_SOUTH_10_30 DVSS ) ( IO_FILL_IO_SOUTH_10_25 DVSS ) ( IO_FILL_IO_SOUTH_10_20 DVSS ) ( IO_FILL_IO_SOUTH_10_15 DVSS )
+      ( IO_FILL_IO_SOUTH_10_10 DVSS ) ( IO_FILL_IO_SOUTH_10_5 DVSS ) ( IO_FILL_IO_SOUTH_6_35 DVSS ) ( IO_FILL_IO_SOUTH_6_30 DVSS ) ( IO_FILL_IO_SOUTH_6_25 DVSS ) ( IO_FILL_IO_SOUTH_6_20 DVSS ) ( IO_FILL_IO_SOUTH_6_15 DVSS ) ( IO_FILL_IO_SOUTH_6_10 DVSS )
+      ( IO_FILL_IO_SOUTH_6_5 DVSS ) ( IO_FILL_IO_SOUTH_3_95 DVSS ) ( IO_FILL_IO_SOUTH_3_90 DVSS ) ( IO_FILL_IO_SOUTH_3_85 DVSS ) ( IO_FILL_IO_SOUTH_3_80 DVSS ) ( IO_FILL_IO_SOUTH_3_75 DVSS ) ( IO_FILL_IO_SOUTH_3_70 DVSS ) ( IO_FILL_IO_SOUTH_3_65 DVSS )
+      ( IO_FILL_IO_SOUTH_3_60 DVSS ) ( IO_FILL_IO_SOUTH_3_55 DVSS ) ( IO_FILL_IO_SOUTH_3_50 DVSS ) ( IO_FILL_IO_SOUTH_3_45 DVSS ) ( IO_FILL_IO_SOUTH_3_40 DVSS ) ( IO_FILL_IO_SOUTH_3_35 DVSS ) ( IO_FILL_IO_SOUTH_3_30 DVSS ) ( IO_FILL_IO_SOUTH_3_25 DVSS )
+      ( IO_FILL_IO_SOUTH_3_20 DVSS ) ( IO_FILL_IO_SOUTH_3_15 DVSS ) ( IO_FILL_IO_SOUTH_3_10 DVSS ) ( IO_FILL_IO_SOUTH_3_5 DVSS ) ( IO_FILL_IO_SOUTH_1_95 DVSS ) ( IO_FILL_IO_SOUTH_1_90 DVSS ) ( IO_FILL_IO_SOUTH_1_85 DVSS ) ( IO_FILL_IO_SOUTH_1_80 DVSS )
+      ( IO_FILL_IO_SOUTH_1_75 DVSS ) ( IO_FILL_IO_SOUTH_1_70 DVSS ) ( IO_FILL_IO_SOUTH_1_65 DVSS ) ( IO_FILL_IO_SOUTH_1_60 DVSS ) ( IO_FILL_IO_SOUTH_1_55 DVSS ) ( IO_FILL_IO_SOUTH_1_50 DVSS ) ( IO_FILL_IO_SOUTH_1_45 DVSS ) ( IO_FILL_IO_SOUTH_1_40 DVSS )
+      ( IO_FILL_IO_SOUTH_1_35 DVSS ) ( IO_FILL_IO_SOUTH_1_30 DVSS ) ( IO_FILL_IO_SOUTH_1_25 DVSS ) ( IO_FILL_IO_SOUTH_1_20 DVSS ) ( IO_FILL_IO_SOUTH_1_15 DVSS ) ( IO_FILL_IO_SOUTH_1_10 DVSS ) ( IO_FILL_IO_SOUTH_1_5 DVSS ) ( IO_FILL_IO_SOUTH_0_20 DVSS )
+      ( IO_FILL_IO_SOUTH_6_0 DVSS ) ( IO_FILL_IO_SOUTH_3_100 DVSS ) ( IO_FILL_IO_SOUTH_59_0 DVSS ) ( IO_FILL_IO_SOUTH_50_5 DVSS ) ( IO_FILL_IO_SOUTH_45_0 DVSS ) ( IO_FILL_IO_SOUTH_30_5 DVSS ) ( IO_FILL_IO_SOUTH_25_0 DVSS ) ( IO_FILL_IO_SOUTH_10_35 DVSS )
+      ( IO_FILL_IO_SOUTH_3_0 DVSS ) ( IO_FILL_IO_SOUTH_54_0 DVSS ) ( IO_FILL_IO_SOUTH_22_0 DVSS ) ( IO_FILL_IO_SOUTH_6_40 DVSS ) ( IO_FILL_IO_SOUTH_53_0 DVSS ) ( IO_FILL_IO_SOUTH_36_0 DVSS ) ( IO_FILL_IO_SOUTH_35_5 DVSS ) ( IO_FILL_IO_SOUTH_21_0 DVSS )
+      ( IO_FILL_IO_SOUTH_20_10 DVSS ) ( IO_FILL_IO_SOUTH_60_0 DVSS ) ( IO_FILL_IO_SOUTH_59_130 DVSS ) ( IO_FILL_IO_SOUTH_52_0 DVSS ) ( IO_FILL_IO_SOUTH_51_0 DVSS ) ( IO_FILL_IO_SOUTH_45_5 DVSS ) ( IO_FILL_IO_SOUTH_40_0 DVSS ) ( IO_FILL_IO_SOUTH_39_0 DVSS )
+      ( IO_FILL_IO_SOUTH_31_0 DVSS ) ( IO_FILL_IO_SOUTH_25_5 DVSS ) ( IO_FILL_IO_SOUTH_17_0 DVSS ) ( IO_FILL_IO_SOUTH_11_0 DVSS ) ( IO_FILL_IO_SOUTH_42_5 DVSS ) ( IO_FILL_IO_SOUTH_42_0 DVSS ) ( IO_FILL_IO_SOUTH_46_0 DVSS ) ( IO_FILL_IO_SOUTH_41_0 DVSS )
+      ( IO_FILL_IO_SOUTH_40_10 DVSS ) ( IO_FILL_IO_SOUTH_57_0 DVSS ) ( IO_FILL_IO_SOUTH_56_5 DVSS ) ( IO_FILL_IO_SOUTH_5_0 DVSS ) ( IO_FILL_IO_SOUTH_4_0 DVSS ) ( IO_FILL_IO_SOUTH_56_0 DVSS ) ( IO_FILL_IO_SOUTH_2_0 DVSS ) ( IO_FILL_IO_SOUTH_1_100 DVSS )
+      ( IO_FILL_IO_SOUTH_58_0 DVSS ) ( IO_FILL_IO_SOUTH_57_65 DVSS ) ( IO_FILL_IO_SOUTH_1_0 DVSS ) ( IO_FILL_IO_SOUTH_0_25 DVSS ) ( IO_FILL_IO_SOUTH_48_0 DVSS ) ( IO_FILL_IO_SOUTH_47_0 DVSS ) ( IO_FILL_IO_SOUTH_48_5 DVSS ) ( IO_FILL_IO_SOUTH_55_0 DVSS )
+      ( IO_FILL_IO_SOUTH_54_70 DVSS ) ( IO_FILL_IO_SOUTH_50_0 DVSS ) ( IO_FILL_IO_SOUTH_49_0 DVSS ) ( IO_FILL_IO_SOUTH_44_0 DVSS ) ( IO_FILL_IO_SOUTH_43_0 DVSS ) ( IO_FILL_IO_SOUTH_8_0 DVSS ) ( IO_FILL_IO_SOUTH_7_0 DVSS ) ( IO_FILL_IO_SOUTH_8_5 DVSS )
+      ( IO_FILL_IO_SOUTH_10_0 DVSS ) ( IO_FILL_IO_SOUTH_9_0 DVSS ) ( IO_FILL_IO_SOUTH_22_5 DVSS ) ( IO_FILL_IO_SOUTH_24_0 DVSS ) ( IO_FILL_IO_SOUTH_23_0 DVSS ) ( IO_FILL_IO_SOUTH_26_0 DVSS ) ( IO_FILL_IO_SOUTH_28_0 DVSS ) ( IO_FILL_IO_SOUTH_27_0 DVSS )
+      ( IO_FILL_IO_SOUTH_28_5 DVSS ) ( IO_FILL_IO_SOUTH_30_0 DVSS ) ( IO_FILL_IO_SOUTH_29_0 DVSS ) ( IO_FILL_IO_SOUTH_32_0 DVSS ) ( IO_FILL_IO_SOUTH_34_0 DVSS ) ( IO_FILL_IO_SOUTH_33_0 DVSS ) ( IO_FILL_IO_SOUTH_35_0 DVSS ) ( IO_FILL_IO_SOUTH_34_5 DVSS )
+      ( IO_FILL_IO_SOUTH_12_0 DVSS ) ( IO_FILL_IO_SOUTH_14_0 DVSS ) ( IO_FILL_IO_SOUTH_13_0 DVSS ) ( IO_FILL_IO_SOUTH_15_0 DVSS ) ( IO_FILL_IO_SOUTH_14_5 DVSS ) ( IO_FILL_IO_SOUTH_16_0 DVSS ) ( IO_FILL_IO_SOUTH_15_5 DVSS ) ( IO_FILL_IO_SOUTH_18_0 DVSS )
+      ( IO_FILL_IO_SOUTH_20_0 DVSS ) ( IO_FILL_IO_SOUTH_19_0 DVSS ) ( IO_FILL_IO_SOUTH_38_0 DVSS ) ( IO_FILL_IO_SOUTH_37_0 DVSS ) ( IO_FILL_IO_EAST_60_180 DVSS ) ( IO_FILL_IO_EAST_60_175 DVSS ) ( IO_FILL_IO_EAST_60_170 DVSS ) ( IO_FILL_IO_EAST_60_165 DVSS )
+      ( IO_FILL_IO_EAST_60_160 DVSS ) ( IO_FILL_IO_EAST_60_155 DVSS ) ( IO_FILL_IO_EAST_60_150 DVSS ) ( IO_FILL_IO_EAST_60_145 DVSS ) ( IO_FILL_IO_EAST_60_140 DVSS ) ( IO_FILL_IO_EAST_60_135 DVSS ) ( IO_FILL_IO_EAST_60_130 DVSS ) ( IO_FILL_IO_EAST_60_125 DVSS )
+      ( IO_FILL_IO_EAST_60_120 DVSS ) ( IO_FILL_IO_EAST_60_115 DVSS ) ( IO_FILL_IO_EAST_60_110 DVSS ) ( IO_FILL_IO_EAST_60_105 DVSS ) ( IO_FILL_IO_EAST_60_100 DVSS ) ( IO_FILL_IO_EAST_60_95 DVSS ) ( IO_FILL_IO_EAST_60_90 DVSS ) ( IO_FILL_IO_EAST_60_85 DVSS )
+      ( IO_FILL_IO_EAST_60_80 DVSS ) ( IO_FILL_IO_EAST_60_75 DVSS ) ( IO_FILL_IO_EAST_60_70 DVSS ) ( IO_FILL_IO_EAST_60_65 DVSS ) ( IO_FILL_IO_EAST_60_60 DVSS ) ( IO_FILL_IO_EAST_60_55 DVSS ) ( IO_FILL_IO_EAST_60_50 DVSS ) ( IO_FILL_IO_EAST_60_45 DVSS )
+      ( IO_FILL_IO_EAST_60_40 DVSS ) ( IO_FILL_IO_EAST_60_35 DVSS ) ( IO_FILL_IO_EAST_60_30 DVSS ) ( IO_FILL_IO_EAST_60_25 DVSS ) ( IO_FILL_IO_EAST_60_20 DVSS ) ( IO_FILL_IO_EAST_60_15 DVSS ) ( IO_FILL_IO_EAST_60_10 DVSS ) ( IO_FILL_IO_EAST_60_5 DVSS )
+      ( IO_FILL_IO_EAST_59_120 DVSS ) ( IO_FILL_IO_EAST_59_115 DVSS ) ( IO_FILL_IO_EAST_59_110 DVSS ) ( IO_FILL_IO_EAST_59_105 DVSS ) ( IO_FILL_IO_EAST_59_100 DVSS ) ( IO_FILL_IO_EAST_59_95 DVSS ) ( IO_FILL_IO_EAST_59_90 DVSS ) ( IO_FILL_IO_EAST_59_85 DVSS )
+      ( IO_FILL_IO_EAST_59_80 DVSS ) ( IO_FILL_IO_EAST_59_75 DVSS ) ( IO_FILL_IO_EAST_59_70 DVSS ) ( IO_FILL_IO_EAST_59_65 DVSS ) ( IO_FILL_IO_EAST_59_60 DVSS ) ( IO_FILL_IO_EAST_59_55 DVSS ) ( IO_FILL_IO_EAST_59_50 DVSS ) ( IO_FILL_IO_EAST_59_45 DVSS )
+      ( IO_FILL_IO_EAST_59_40 DVSS ) ( IO_FILL_IO_EAST_59_35 DVSS ) ( IO_FILL_IO_EAST_59_30 DVSS ) ( IO_FILL_IO_EAST_59_25 DVSS ) ( IO_FILL_IO_EAST_59_20 DVSS ) ( IO_FILL_IO_EAST_59_15 DVSS ) ( IO_FILL_IO_EAST_59_10 DVSS ) ( IO_FILL_IO_EAST_59_5 DVSS )
+      ( IO_FILL_IO_EAST_57_65 DVSS ) ( IO_FILL_IO_EAST_57_60 DVSS ) ( IO_FILL_IO_EAST_57_55 DVSS ) ( IO_FILL_IO_EAST_57_50 DVSS ) ( IO_FILL_IO_EAST_57_45 DVSS ) ( IO_FILL_IO_EAST_57_40 DVSS ) ( IO_FILL_IO_EAST_57_35 DVSS ) ( IO_FILL_IO_EAST_57_30 DVSS )
+      ( IO_FILL_IO_EAST_57_25 DVSS ) ( IO_FILL_IO_EAST_57_20 DVSS ) ( IO_FILL_IO_EAST_57_15 DVSS ) ( IO_FILL_IO_EAST_57_10 DVSS ) ( IO_FILL_IO_EAST_57_5 DVSS ) ( IO_FILL_IO_EAST_54_65 DVSS ) ( IO_FILL_IO_EAST_54_60 DVSS ) ( IO_FILL_IO_EAST_54_55 DVSS )
+      ( IO_FILL_IO_EAST_54_50 DVSS ) ( IO_FILL_IO_EAST_54_45 DVSS ) ( IO_FILL_IO_EAST_54_40 DVSS ) ( IO_FILL_IO_EAST_54_35 DVSS ) ( IO_FILL_IO_EAST_54_30 DVSS ) ( IO_FILL_IO_EAST_54_25 DVSS ) ( IO_FILL_IO_EAST_54_20 DVSS ) ( IO_FILL_IO_EAST_54_15 DVSS )
+      ( IO_FILL_IO_EAST_54_10 DVSS ) ( IO_FILL_IO_EAST_54_5 DVSS ) ( IO_FILL_IO_EAST_50_5 DVSS ) ( IO_FILL_IO_EAST_35_5 DVSS ) ( IO_FILL_IO_EAST_30_5 DVSS ) ( IO_FILL_IO_EAST_15_5 DVSS ) ( IO_FILL_IO_EAST_10_35 DVSS ) ( IO_FILL_IO_EAST_10_30 DVSS )
+      ( IO_FILL_IO_EAST_10_25 DVSS ) ( IO_FILL_IO_EAST_10_20 DVSS ) ( IO_FILL_IO_EAST_10_15 DVSS ) ( IO_FILL_IO_EAST_10_10 DVSS ) ( IO_FILL_IO_EAST_10_5 DVSS ) ( IO_FILL_IO_EAST_6_35 DVSS ) ( IO_FILL_IO_EAST_6_30 DVSS ) ( IO_FILL_IO_EAST_6_25 DVSS )
+      ( IO_FILL_IO_EAST_6_20 DVSS ) ( IO_FILL_IO_EAST_6_15 DVSS ) ( IO_FILL_IO_EAST_6_10 DVSS ) ( IO_FILL_IO_EAST_6_5 DVSS ) ( IO_FILL_IO_EAST_3_90 DVSS ) ( IO_FILL_IO_EAST_3_85 DVSS ) ( IO_FILL_IO_EAST_3_80 DVSS ) ( IO_FILL_IO_EAST_3_75 DVSS )
+      ( IO_FILL_IO_EAST_3_70 DVSS ) ( IO_FILL_IO_EAST_3_65 DVSS ) ( IO_FILL_IO_EAST_3_60 DVSS ) ( IO_FILL_IO_EAST_3_55 DVSS ) ( IO_FILL_IO_EAST_3_50 DVSS ) ( IO_FILL_IO_EAST_3_45 DVSS ) ( IO_FILL_IO_EAST_3_40 DVSS ) ( IO_FILL_IO_EAST_3_35 DVSS )
+      ( IO_FILL_IO_EAST_3_30 DVSS ) ( IO_FILL_IO_EAST_3_25 DVSS ) ( IO_FILL_IO_EAST_3_20 DVSS ) ( IO_FILL_IO_EAST_3_15 DVSS ) ( IO_FILL_IO_EAST_3_10 DVSS ) ( IO_FILL_IO_EAST_3_5 DVSS ) ( IO_FILL_IO_EAST_1_95 DVSS ) ( IO_FILL_IO_EAST_1_90 DVSS )
+      ( IO_FILL_IO_EAST_1_85 DVSS ) ( IO_FILL_IO_EAST_1_80 DVSS ) ( IO_FILL_IO_EAST_1_75 DVSS ) ( IO_FILL_IO_EAST_1_70 DVSS ) ( IO_FILL_IO_EAST_1_65 DVSS ) ( IO_FILL_IO_EAST_1_60 DVSS ) ( IO_FILL_IO_EAST_1_55 DVSS ) ( IO_FILL_IO_EAST_1_50 DVSS )
+      ( IO_FILL_IO_EAST_1_45 DVSS ) ( IO_FILL_IO_EAST_1_40 DVSS ) ( IO_FILL_IO_EAST_1_35 DVSS ) ( IO_FILL_IO_EAST_1_30 DVSS ) ( IO_FILL_IO_EAST_1_25 DVSS ) ( IO_FILL_IO_EAST_1_20 DVSS ) ( IO_FILL_IO_EAST_1_15 DVSS ) ( IO_FILL_IO_EAST_1_10 DVSS )
+      ( IO_FILL_IO_EAST_1_5 DVSS ) ( IO_FILL_IO_EAST_0_20 DVSS ) ( IO_FILL_IO_EAST_6_40 DVSS ) ( IO_FILL_IO_EAST_40_5 DVSS ) ( IO_FILL_IO_EAST_57_0 DVSS ) ( IO_FILL_IO_EAST_56_0 DVSS ) ( IO_FILL_IO_EAST_38_0 DVSS ) ( IO_FILL_IO_EAST_22_0 DVSS )
+      ( IO_FILL_IO_EAST_4_0 DVSS ) ( IO_FILL_IO_EAST_3_95 DVSS ) ( IO_FILL_IO_EAST_7_0 DVSS ) ( IO_FILL_IO_EAST_54_0 DVSS ) ( IO_FILL_IO_EAST_53_0 DVSS ) ( IO_FILL_IO_EAST_47_0 DVSS ) ( IO_FILL_IO_EAST_41_0 DVSS ) ( IO_FILL_IO_EAST_33_0 DVSS )
+      ( IO_FILL_IO_EAST_27_0 DVSS ) ( IO_FILL_IO_EAST_20_0 DVSS ) ( IO_FILL_IO_EAST_19_0 DVSS ) ( IO_FILL_IO_EAST_13_0 DVSS ) ( IO_FILL_IO_EAST_30_0 DVSS ) ( IO_FILL_IO_EAST_29_0 DVSS ) ( IO_FILL_IO_EAST_28_0 DVSS ) ( IO_FILL_IO_EAST_15_0 DVSS )
+      ( IO_FILL_IO_EAST_14_0 DVSS ) ( IO_FILL_IO_EAST_16_0 DVSS ) ( IO_FILL_IO_EAST_15_10 DVSS ) ( IO_FILL_IO_EAST_16_5 DVSS ) ( IO_FILL_IO_EAST_18_0 DVSS ) ( IO_FILL_IO_EAST_17_0 DVSS ) ( IO_FILL_IO_EAST_21_0 DVSS ) ( IO_FILL_IO_EAST_20_5 DVSS )
+      ( IO_FILL_IO_EAST_24_0 DVSS ) ( IO_FILL_IO_EAST_23_0 DVSS ) ( IO_FILL_IO_EAST_25_0 DVSS ) ( IO_FILL_IO_EAST_24_5 DVSS ) ( IO_FILL_IO_EAST_26_0 DVSS ) ( IO_FILL_IO_EAST_25_5 DVSS ) ( IO_FILL_IO_EAST_1_0 DVSS ) ( IO_FILL_IO_EAST_0_25 DVSS )
+      ( IO_FILL_IO_EAST_2_0 DVSS ) ( IO_FILL_IO_EAST_1_100 DVSS ) ( IO_FILL_IO_EAST_3_0 DVSS ) ( IO_FILL_IO_EAST_2_5 DVSS ) ( IO_FILL_IO_EAST_6_0 DVSS ) ( IO_FILL_IO_EAST_5_0 DVSS ) ( IO_FILL_IO_EAST_8_0 DVSS ) ( IO_FILL_IO_EAST_10_0 DVSS )
+      ( IO_FILL_IO_EAST_9_0 DVSS ) ( IO_FILL_IO_EAST_10_40 DVSS ) ( IO_FILL_IO_EAST_12_0 DVSS ) ( IO_FILL_IO_EAST_11_0 DVSS ) ( IO_FILL_IO_EAST_30_10 DVSS ) ( IO_FILL_IO_EAST_45_0 DVSS ) ( IO_FILL_IO_EAST_44_5 DVSS ) ( IO_FILL_IO_EAST_46_0 DVSS )
+      ( IO_FILL_IO_EAST_45_5 DVSS ) ( IO_FILL_IO_EAST_48_0 DVSS ) ( IO_FILL_IO_EAST_37_0 DVSS ) ( IO_FILL_IO_EAST_36_5 DVSS ) ( IO_FILL_IO_EAST_40_0 DVSS ) ( IO_FILL_IO_EAST_39_0 DVSS ) ( IO_FILL_IO_EAST_42_0 DVSS ) ( IO_FILL_IO_EAST_44_0 DVSS )
+      ( IO_FILL_IO_EAST_43_0 DVSS ) ( IO_FILL_IO_EAST_50_0 DVSS ) ( IO_FILL_IO_EAST_49_0 DVSS ) ( IO_FILL_IO_EAST_50_10 DVSS ) ( IO_FILL_IO_EAST_52_0 DVSS ) ( IO_FILL_IO_EAST_51_0 DVSS ) ( IO_FILL_IO_EAST_55_0 DVSS ) ( IO_FILL_IO_EAST_54_70 DVSS )
+      ( IO_FILL_IO_EAST_58_0 DVSS ) ( IO_FILL_IO_EAST_57_70 DVSS ) ( IO_FILL_IO_EAST_59_0 DVSS ) ( IO_FILL_IO_EAST_58_5 DVSS ) ( IO_FILL_IO_EAST_60_0 DVSS ) ( IO_FILL_IO_EAST_59_125 DVSS ) ( IO_FILL_IO_EAST_36_0 DVSS ) ( IO_FILL_IO_EAST_35_10 DVSS )
+      ( IO_FILL_IO_EAST_35_0 DVSS ) ( IO_FILL_IO_EAST_34_0 DVSS ) ( IO_FILL_IO_EAST_32_0 DVSS ) ( IO_FILL_IO_EAST_31_0 DVSS ) ( IO_FILL_IO_NORTH_53_95 DVSS ) ( IO_FILL_IO_NORTH_53_90 DVSS ) ( IO_FILL_IO_NORTH_53_85 DVSS ) ( IO_FILL_IO_NORTH_53_80 DVSS )
+      ( IO_FILL_IO_NORTH_53_75 DVSS ) ( IO_FILL_IO_NORTH_53_70 DVSS ) ( IO_FILL_IO_NORTH_53_65 DVSS ) ( IO_FILL_IO_NORTH_53_60 DVSS ) ( IO_FILL_IO_NORTH_53_55 DVSS ) ( IO_FILL_IO_NORTH_53_50 DVSS ) ( IO_FILL_IO_NORTH_53_45 DVSS ) ( IO_FILL_IO_NORTH_53_40 DVSS )
+      ( IO_FILL_IO_NORTH_53_35 DVSS ) ( IO_FILL_IO_NORTH_53_30 DVSS ) ( IO_FILL_IO_NORTH_53_25 DVSS ) ( IO_FILL_IO_NORTH_53_20 DVSS ) ( IO_FILL_IO_NORTH_53_15 DVSS ) ( IO_FILL_IO_NORTH_53_10 DVSS ) ( IO_FILL_IO_NORTH_53_5 DVSS ) ( IO_FILL_IO_NORTH_51_95 DVSS )
+      ( IO_FILL_IO_NORTH_51_90 DVSS ) ( IO_FILL_IO_NORTH_51_85 DVSS ) ( IO_FILL_IO_NORTH_51_80 DVSS ) ( IO_FILL_IO_NORTH_51_75 DVSS ) ( IO_FILL_IO_NORTH_51_70 DVSS ) ( IO_FILL_IO_NORTH_51_65 DVSS ) ( IO_FILL_IO_NORTH_51_60 DVSS ) ( IO_FILL_IO_NORTH_51_55 DVSS )
+      ( IO_FILL_IO_NORTH_51_50 DVSS ) ( IO_FILL_IO_NORTH_51_45 DVSS ) ( IO_FILL_IO_NORTH_51_40 DVSS ) ( IO_FILL_IO_NORTH_51_35 DVSS ) ( IO_FILL_IO_NORTH_51_30 DVSS ) ( IO_FILL_IO_NORTH_51_25 DVSS ) ( IO_FILL_IO_NORTH_51_20 DVSS ) ( IO_FILL_IO_NORTH_51_15 DVSS )
+      ( IO_FILL_IO_NORTH_51_10 DVSS ) ( IO_FILL_IO_NORTH_51_5 DVSS ) ( IO_FILL_IO_NORTH_48_35 DVSS ) ( IO_FILL_IO_NORTH_48_30 DVSS ) ( IO_FILL_IO_NORTH_48_25 DVSS ) ( IO_FILL_IO_NORTH_48_20 DVSS ) ( IO_FILL_IO_NORTH_48_15 DVSS ) ( IO_FILL_IO_NORTH_48_10 DVSS )
+      ( IO_FILL_IO_NORTH_48_5 DVSS ) ( IO_FILL_IO_NORTH_44_30 DVSS ) ( IO_FILL_IO_NORTH_44_25 DVSS ) ( IO_FILL_IO_NORTH_44_20 DVSS ) ( IO_FILL_IO_NORTH_44_15 DVSS ) ( IO_FILL_IO_NORTH_44_10 DVSS ) ( IO_FILL_IO_NORTH_44_5 DVSS ) ( IO_FILL_IO_NORTH_42_20 DVSS )
+      ( IO_FILL_IO_NORTH_42_15 DVSS ) ( IO_FILL_IO_NORTH_42_10 DVSS ) ( IO_FILL_IO_NORTH_42_5 DVSS ) ( IO_FILL_IO_NORTH_30_15 DVSS ) ( IO_FILL_IO_NORTH_30_10 DVSS ) ( IO_FILL_IO_NORTH_30_5 DVSS ) ( IO_FILL_IO_NORTH_25_5 DVSS ) ( IO_FILL_IO_NORTH_10_5 DVSS )
+      ( IO_FILL_IO_NORTH_6_60 DVSS ) ( IO_FILL_IO_NORTH_6_55 DVSS ) ( IO_FILL_IO_NORTH_6_50 DVSS ) ( IO_FILL_IO_NORTH_6_45 DVSS ) ( IO_FILL_IO_NORTH_6_40 DVSS ) ( IO_FILL_IO_NORTH_6_35 DVSS ) ( IO_FILL_IO_NORTH_6_30 DVSS ) ( IO_FILL_IO_NORTH_6_25 DVSS )
+      ( IO_FILL_IO_NORTH_6_20 DVSS ) ( IO_FILL_IO_NORTH_6_15 DVSS ) ( IO_FILL_IO_NORTH_6_10 DVSS ) ( IO_FILL_IO_NORTH_6_5 DVSS ) ( IO_FILL_IO_NORTH_3_65 DVSS ) ( IO_FILL_IO_NORTH_3_60 DVSS ) ( IO_FILL_IO_NORTH_3_55 DVSS ) ( IO_FILL_IO_NORTH_3_50 DVSS )
+      ( IO_FILL_IO_NORTH_3_45 DVSS ) ( IO_FILL_IO_NORTH_3_40 DVSS ) ( IO_FILL_IO_NORTH_3_35 DVSS ) ( IO_FILL_IO_NORTH_3_30 DVSS ) ( IO_FILL_IO_NORTH_3_25 DVSS ) ( IO_FILL_IO_NORTH_3_20 DVSS ) ( IO_FILL_IO_NORTH_3_15 DVSS ) ( IO_FILL_IO_NORTH_3_10 DVSS )
+      ( IO_FILL_IO_NORTH_3_5 DVSS ) ( IO_FILL_IO_NORTH_1_125 DVSS ) ( IO_FILL_IO_NORTH_1_120 DVSS ) ( IO_FILL_IO_NORTH_1_115 DVSS ) ( IO_FILL_IO_NORTH_1_110 DVSS ) ( IO_FILL_IO_NORTH_1_105 DVSS ) ( IO_FILL_IO_NORTH_1_100 DVSS ) ( IO_FILL_IO_NORTH_1_95 DVSS )
+      ( IO_FILL_IO_NORTH_1_90 DVSS ) ( IO_FILL_IO_NORTH_1_85 DVSS ) ( IO_FILL_IO_NORTH_1_80 DVSS ) ( IO_FILL_IO_NORTH_1_75 DVSS ) ( IO_FILL_IO_NORTH_1_70 DVSS ) ( IO_FILL_IO_NORTH_1_65 DVSS ) ( IO_FILL_IO_NORTH_1_60 DVSS ) ( IO_FILL_IO_NORTH_1_55 DVSS )
+      ( IO_FILL_IO_NORTH_1_50 DVSS ) ( IO_FILL_IO_NORTH_1_45 DVSS ) ( IO_FILL_IO_NORTH_1_40 DVSS ) ( IO_FILL_IO_NORTH_1_35 DVSS ) ( IO_FILL_IO_NORTH_1_30 DVSS ) ( IO_FILL_IO_NORTH_1_25 DVSS ) ( IO_FILL_IO_NORTH_1_20 DVSS ) ( IO_FILL_IO_NORTH_1_15 DVSS )
+      ( IO_FILL_IO_NORTH_1_10 DVSS ) ( IO_FILL_IO_NORTH_1_5 DVSS ) ( IO_FILL_IO_NORTH_0_210 DVSS ) ( IO_FILL_IO_NORTH_0_205 DVSS ) ( IO_FILL_IO_NORTH_0_200 DVSS ) ( IO_FILL_IO_NORTH_0_195 DVSS ) ( IO_FILL_IO_NORTH_0_190 DVSS ) ( IO_FILL_IO_NORTH_0_185 DVSS )
+      ( IO_FILL_IO_NORTH_0_180 DVSS ) ( IO_FILL_IO_NORTH_0_175 DVSS ) ( IO_FILL_IO_NORTH_0_170 DVSS ) ( IO_FILL_IO_NORTH_0_165 DVSS ) ( IO_FILL_IO_NORTH_0_160 DVSS ) ( IO_FILL_IO_NORTH_0_155 DVSS ) ( IO_FILL_IO_NORTH_0_150 DVSS ) ( IO_FILL_IO_NORTH_0_145 DVSS )
+      ( IO_FILL_IO_NORTH_0_140 DVSS ) ( IO_FILL_IO_NORTH_0_135 DVSS ) ( IO_FILL_IO_NORTH_0_130 DVSS ) ( IO_FILL_IO_NORTH_0_125 DVSS ) ( IO_FILL_IO_NORTH_0_120 DVSS ) ( IO_FILL_IO_NORTH_0_115 DVSS ) ( IO_FILL_IO_NORTH_0_110 DVSS ) ( IO_FILL_IO_NORTH_0_105 DVSS )
+      ( IO_FILL_IO_NORTH_0_100 DVSS ) ( IO_FILL_IO_NORTH_0_95 DVSS ) ( IO_FILL_IO_NORTH_0_90 DVSS ) ( IO_FILL_IO_NORTH_0_85 DVSS ) ( IO_FILL_IO_NORTH_0_80 DVSS ) ( IO_FILL_IO_NORTH_0_75 DVSS ) ( IO_FILL_IO_NORTH_0_70 DVSS ) ( IO_FILL_IO_NORTH_0_65 DVSS )
+      ( IO_FILL_IO_NORTH_0_60 DVSS ) ( IO_FILL_IO_NORTH_0_55 DVSS ) ( IO_FILL_IO_NORTH_0_50 DVSS ) ( IO_FILL_IO_NORTH_0_45 DVSS ) ( IO_FILL_IO_NORTH_0_40 DVSS ) ( IO_FILL_IO_NORTH_0_35 DVSS ) ( IO_FILL_IO_NORTH_0_30 DVSS ) ( IO_FILL_IO_NORTH_0_25 DVSS )
+      ( IO_FILL_IO_NORTH_0_20 DVSS ) ( IO_FILL_IO_NORTH_0_15 DVSS ) ( IO_FILL_IO_NORTH_0_10 DVSS ) ( IO_FILL_IO_NORTH_0_5 DVSS ) ( IO_FILL_IO_NORTH_0_0 DVSS ) ( u_brk0 DVSSA ) ( IO_FILL_IO_NORTH_1_130 DVSS ) ( IO_FILL_IO_NORTH_10_0 DVSS )
+      ( IO_FILL_IO_NORTH_15_5 DVSS ) ( IO_FILL_IO_NORTH_53_100 DVSS ) ( IO_FILL_IO_NORTH_37_0 DVSS ) ( IO_FILL_IO_NORTH_48_40 DVSS ) ( IO_FILL_IO_NORTH_6_0 DVSS ) ( IO_FILL_IO_NORTH_22_0 DVSS ) ( IO_FILL_IO_NORTH_30_20 DVSS ) ( IO_FILL_IO_NORTH_37_5 DVSS )
+      ( IO_FILL_IO_NORTH_49_0 DVSS ) ( IO_FILL_IO_NORTH_6_65 DVSS ) ( IO_FILL_IO_NORTH_23_0 DVSS ) ( IO_FILL_IO_NORTH_1_0 DVSS ) ( IO_FILL_IO_NORTH_0_215 DVSS ) ( IO_FILL_IO_NORTH_9_0 DVSS ) ( IO_FILL_IO_NORTH_15_0 DVSS ) ( IO_FILL_IO_NORTH_21_0 DVSS )
+      ( IO_FILL_IO_NORTH_20_5 DVSS ) ( IO_FILL_IO_NORTH_26_5 DVSS ) ( IO_FILL_IO_NORTH_35_0 DVSS ) ( IO_FILL_IO_NORTH_34_0 DVSS ) ( IO_FILL_IO_NORTH_45_0 DVSS ) ( IO_FILL_IO_NORTH_44_35 DVSS ) ( IO_FILL_IO_NORTH_53_0 DVSS ) ( IO_FILL_IO_NORTH_36_0 DVSS )
+      ( IO_FILL_IO_NORTH_35_5 DVSS ) ( IO_FILL_IO_NORTH_33_0 DVSS ) ( IO_FILL_IO_NORTH_32_5 DVSS ) ( IO_FILL_IO_NORTH_32_0 DVSS ) ( u_brk0 DVSSB ) ( IO_FILL_IO_NORTH_31_0 DVSS ) ( IO_FILL_IO_NORTH_39_0 DVSS ) ( IO_FILL_IO_NORTH_38_0 DVSS )
+      ( IO_FILL_IO_NORTH_14_0 DVSS ) ( IO_FILL_IO_NORTH_13_0 DVSS ) ( IO_FILL_IO_NORTH_12_5 DVSS ) ( IO_FILL_IO_NORTH_12_0 DVSS ) ( IO_FILL_IO_NORTH_20_0 DVSS ) ( IO_FILL_IO_NORTH_19_0 DVSS ) ( IO_FILL_IO_NORTH_18_5 DVSS ) ( IO_FILL_IO_NORTH_18_0 DVSS )
+      ( IO_FILL_IO_NORTH_17_0 DVSS ) ( IO_FILL_IO_NORTH_16_0 DVSS ) ( IO_FILL_IO_NORTH_11_0 DVSS ) ( IO_FILL_IO_NORTH_10_10 DVSS ) ( IO_FILL_IO_NORTH_8_0 DVSS ) ( IO_FILL_IO_NORTH_7_0 DVSS ) ( IO_FILL_IO_NORTH_5_0 DVSS ) ( IO_FILL_IO_NORTH_4_5 DVSS )
+      ( IO_FILL_IO_NORTH_4_0 DVSS ) ( IO_FILL_IO_NORTH_3_70 DVSS ) ( IO_FILL_IO_NORTH_3_0 DVSS ) ( IO_FILL_IO_NORTH_2_0 DVSS ) ( IO_FILL_IO_NORTH_30_0 DVSS ) ( IO_FILL_IO_NORTH_29_0 DVSS ) ( IO_FILL_IO_NORTH_28_0 DVSS ) ( IO_FILL_IO_NORTH_27_0 DVSS )
+      ( IO_FILL_IO_NORTH_26_0 DVSS ) ( IO_FILL_IO_NORTH_25_10 DVSS ) ( IO_FILL_IO_NORTH_25_0 DVSS ) ( IO_FILL_IO_NORTH_24_0 DVSS ) ( IO_FILL_IO_NORTH_48_0 DVSS ) ( IO_FILL_IO_NORTH_47_0 DVSS ) ( IO_FILL_IO_NORTH_46_0 DVSS ) ( IO_FILL_IO_NORTH_44_0 DVSS )
+      ( IO_FILL_IO_NORTH_52_0 DVSS ) ( IO_FILL_IO_NORTH_51_100 DVSS ) ( IO_FILL_IO_NORTH_51_0 DVSS ) ( IO_FILL_IO_NORTH_50_0 DVSS ) ( IO_FILL_IO_NORTH_43_0 DVSS ) ( IO_FILL_IO_NORTH_42_25 DVSS ) ( IO_FILL_IO_NORTH_42_0 DVSS ) ( IO_FILL_IO_NORTH_41_0 DVSS )
+      ( IO_FILL_IO_NORTH_40_0 DVSS ) ( IO_FILL_IO_NORTH_39_5 DVSS ) ( IO_FILL_IO_EAST_60_185 DVSS ) ( IO_FILL_IO_EAST_60_190 DVSS ) ( IO_CORNER_NORTH_EAST_INST DVSS ) ( IO_FILL_IO_NORTH_54_0 DVSS ) ( IO_CORNER_NORTH_WEST_INST DVSS ) ( IO_FILL_IO_WEST_57_0 DVSS )
+      ( u_v18_33 DVSS ) ( u_vzz_33 DVSS ) ( u_vdd_0 DVSS ) ( u_v18_0 DVSS ) ( u_vzz_9 DVSS ) ( u_vzz_8 DVSS ) ( u_vzz_7 DVSS ) ( u_vzz_6 DVSS )
+      ( u_vzz_5 DVSS ) ( u_vzz_4 DVSS ) ( u_vzz_32 DVSS ) ( u_vzz_31 DVSS ) ( u_vzz_30 DVSS ) ( u_vzz_3 DVSS ) ( u_vzz_29 DVSS ) ( u_vzz_28 DVSS )
+      ( u_vzz_27 DVSS ) ( u_vzz_26 DVSS ) ( u_vzz_25 DVSS ) ( u_vzz_24 DVSS ) ( u_vzz_23 DVSS ) ( u_vzz_22 DVSS ) ( u_vzz_21 DVSS ) ( u_vzz_20 DVSS )
+      ( u_vzz_2 DVSS ) ( u_vzz_19 DVSS ) ( u_vzz_18 DVSS ) ( u_vzz_17 DVSS ) ( u_vzz_16 DVSS ) ( u_vzz_15 DVSS ) ( u_vzz_14 DVSS ) ( u_vzz_13 DVSS )
+      ( u_vzz_12 DVSS ) ( u_vzz_11 DVSS ) ( u_vzz_10 DVSS ) ( u_vzz_1 DVSS ) ( u_vzz_0 DVSS ) ( u_vss_pll DVSS ) ( u_vss_9 DVSS ) ( u_vss_8 DVSS )
+      ( u_vss_7 DVSS ) ( u_vss_6 DVSS ) ( u_vss_5 DVSS ) ( u_vss_4 DVSS ) ( u_vss_32 DVSS ) ( u_vss_31 DVSS ) ( u_vss_30 DVSS ) ( u_vss_3 DVSS )
+      ( u_vss_29 DVSS ) ( u_vss_28 DVSS ) ( u_vss_27 DVSS ) ( u_vss_26 DVSS ) ( u_vss_25 DVSS ) ( u_vss_24 DVSS ) ( u_vss_23 DVSS ) ( u_vss_22 DVSS )
+      ( u_vss_21 DVSS ) ( u_vss_20 DVSS ) ( u_vss_2 DVSS ) ( u_vss_19 DVSS ) ( u_vss_18 DVSS ) ( u_vss_17 DVSS ) ( u_vss_16 DVSS ) ( u_vss_15 DVSS )
+      ( u_vss_14 DVSS ) ( u_vss_13 DVSS ) ( u_vss_12 DVSS ) ( u_vss_11 DVSS ) ( u_vss_10 DVSS ) ( u_vss_1 DVSS ) ( u_vss_0 DVSS ) ( u_vdd_pll DVSS )
+      ( u_vdd_9 DVSS ) ( u_vdd_8 DVSS ) ( u_vdd_7 DVSS ) ( u_vdd_6 DVSS ) ( u_vdd_5 DVSS ) ( u_vdd_4 DVSS ) ( u_vdd_32 DVSS ) ( u_vdd_31 DVSS )
+      ( u_vdd_30 DVSS ) ( u_vdd_3 DVSS ) ( u_vdd_29 DVSS ) ( u_vdd_28 DVSS ) ( u_vdd_27 DVSS ) ( u_vdd_26 DVSS ) ( u_vdd_25 DVSS ) ( u_vdd_24 DVSS )
+      ( u_vdd_23 DVSS ) ( u_vdd_22 DVSS ) ( u_vdd_21 DVSS ) ( u_vdd_20 DVSS ) ( u_vdd_2 DVSS ) ( u_vdd_19 DVSS ) ( u_vdd_18 DVSS ) ( u_vdd_17 DVSS )
+      ( u_vdd_16 DVSS ) ( u_vdd_15 DVSS ) ( u_vdd_14 DVSS ) ( u_vdd_13 DVSS ) ( u_vdd_12 DVSS ) ( u_vdd_11 DVSS ) ( u_vdd_10 DVSS ) ( u_vdd_1 DVSS )
+      ( u_v18_9 DVSS ) ( u_v18_8 DVSS ) ( u_v18_7 DVSS ) ( u_v18_6 DVSS ) ( u_v18_5 DVSS ) ( u_v18_4 DVSS ) ( u_v18_32 DVSS ) ( u_v18_31 DVSS )
+      ( u_v18_30 DVSS ) ( u_v18_3 DVSS ) ( u_v18_29 DVSS ) ( u_v18_28 DVSS ) ( u_v18_27 DVSS ) ( u_v18_26 DVSS ) ( u_v18_25 DVSS ) ( u_v18_24 DVSS )
+      ( u_v18_23 DVSS ) ( u_v18_22 DVSS ) ( u_v18_21 DVSS ) ( u_v18_20 DVSS ) ( u_v18_2 DVSS ) ( u_v18_19 DVSS ) ( u_v18_18 DVSS ) ( u_v18_17 DVSS )
+      ( u_v18_16 DVSS ) ( u_v18_15 DVSS ) ( u_v18_14 DVSS ) ( u_v18_13 DVSS ) ( u_v18_12 DVSS ) ( u_v18_11 DVSS ) ( u_v18_10 DVSS ) ( u_v18_1 DVSS )
+      ( u_sel_2_i DVSS ) ( u_sel_1_i DVSS ) ( u_sel_0_i DVSS ) ( u_misc_o DVSS ) ( u_ddr_we_n_o DVSS ) ( u_ddr_reset_n_o DVSS ) ( u_ddr_ras_n_o DVSS ) ( u_ddr_odt_o DVSS )
+      ( u_ddr_dqs_p_3_io DVSS ) ( u_ddr_dqs_p_2_io DVSS ) ( u_ddr_dqs_p_1_io DVSS ) ( u_ddr_dqs_p_0_io DVSS ) ( u_ddr_dqs_n_3_io DVSS ) ( u_ddr_dqs_n_2_io DVSS ) ( u_ddr_dqs_n_1_io DVSS ) ( u_ddr_dqs_n_0_io DVSS )
+      ( u_ddr_dq_9_io DVSS ) ( u_ddr_dq_8_io DVSS ) ( u_ddr_dq_7_io DVSS ) ( u_ddr_dq_6_io DVSS ) ( u_ddr_dq_5_io DVSS ) ( u_ddr_dq_4_io DVSS ) ( u_ddr_dq_3_io DVSS ) ( u_ddr_dq_31_io DVSS )
+      ( u_ddr_dq_30_io DVSS ) ( u_ddr_dq_2_io DVSS ) ( u_ddr_dq_29_io DVSS ) ( u_ddr_dq_28_io DVSS ) ( u_ddr_dq_27_io DVSS ) ( u_ddr_dq_26_io DVSS ) ( u_ddr_dq_25_io DVSS ) ( u_ddr_dq_24_io DVSS )
+      ( u_ddr_dq_23_io DVSS ) ( u_ddr_dq_22_io DVSS ) ( u_ddr_dq_21_io DVSS ) ( u_ddr_dq_20_io DVSS ) ( u_ddr_dq_1_io DVSS ) ( u_ddr_dq_19_io DVSS ) ( u_ddr_dq_18_io DVSS ) ( u_ddr_dq_17_io DVSS )
+      ( u_ddr_dq_16_io DVSS ) ( u_ddr_dq_15_io DVSS ) ( u_ddr_dq_14_io DVSS ) ( u_ddr_dq_13_io DVSS ) ( u_ddr_dq_12_io DVSS ) ( u_ddr_dq_11_io DVSS ) ( u_ddr_dq_10_io DVSS ) ( u_ddr_dq_0_io DVSS )
+      ( u_ddr_dm_3_o DVSS ) ( u_ddr_dm_2_o DVSS ) ( u_ddr_dm_1_o DVSS ) ( u_ddr_dm_0_o DVSS ) ( u_ddr_cs_n_o DVSS ) ( u_ddr_cke_o DVSS ) ( u_ddr_ck_p_o DVSS ) ( u_ddr_ck_n_o DVSS )
+      ( u_ddr_cas_n_o DVSS ) ( u_ddr_ba_2_o DVSS ) ( u_ddr_ba_1_o DVSS ) ( u_ddr_ba_0_o DVSS ) ( u_ddr_addr_9_o DVSS ) ( u_ddr_addr_8_o DVSS ) ( u_ddr_addr_7_o DVSS ) ( u_ddr_addr_6_o DVSS )
+      ( u_ddr_addr_5_o DVSS ) ( u_ddr_addr_4_o DVSS ) ( u_ddr_addr_3_o DVSS ) ( u_ddr_addr_2_o DVSS ) ( u_ddr_addr_1_o DVSS ) ( u_ddr_addr_15_o DVSS ) ( u_ddr_addr_14_o DVSS ) ( u_ddr_addr_13_o DVSS )
+      ( u_ddr_addr_12_o DVSS ) ( u_ddr_addr_11_o DVSS ) ( u_ddr_addr_10_o DVSS ) ( u_ddr_addr_0_o DVSS ) ( u_core_async_reset_i DVSS ) ( u_co_v_i DVSS ) ( u_co_tkn_o DVSS ) ( u_co_clk_i DVSS )
+      ( u_co_8_i DVSS ) ( u_co_7_i DVSS ) ( u_co_6_i DVSS ) ( u_co_5_i DVSS ) ( u_co_4_i DVSS ) ( u_co_3_i DVSS ) ( u_co_2_i DVSS ) ( u_co_1_i DVSS )
+      ( u_co_0_i DVSS ) ( u_co2_v_o DVSS ) ( u_co2_tkn_i DVSS ) ( u_co2_clk_o DVSS ) ( u_co2_8_o DVSS ) ( u_co2_7_o DVSS ) ( u_co2_6_o DVSS ) ( u_co2_5_o DVSS )
+      ( u_co2_4_o DVSS ) ( u_co2_3_o DVSS ) ( u_co2_2_o DVSS ) ( u_co2_1_o DVSS ) ( u_co2_0_o DVSS ) ( u_clk_o DVSS ) ( u_clk_async_reset_i DVSS ) ( u_clk_C_i DVSS )
+      ( u_clk_B_i DVSS ) ( u_clk_A_i DVSS ) ( u_ci_v_i DVSS ) ( u_ci_tkn_o DVSS ) ( u_ci_clk_i DVSS ) ( u_ci_8_i DVSS ) ( u_ci_7_i DVSS ) ( u_ci_6_i DVSS )
+      ( u_ci_5_i DVSS ) ( u_ci_4_i DVSS ) ( u_ci_3_i DVSS ) ( u_ci_2_i DVSS ) ( u_ci_1_i DVSS ) ( u_ci_0_i DVSS ) ( u_ci2_v_o DVSS ) ( u_ci2_tkn_i DVSS )
+      ( u_ci2_clk_o DVSS ) ( u_ci2_8_o DVSS ) ( u_ci2_7_o DVSS ) ( u_ci2_6_o DVSS ) ( u_ci2_5_o DVSS ) ( u_ci2_4_o DVSS ) ( u_ci2_3_o DVSS ) ( u_ci2_2_o DVSS )
+      ( u_ci2_1_o DVSS ) ( u_ci2_0_o DVSS ) ( u_bsg_tag_en_i DVSS ) ( u_bsg_tag_data_o DVSS ) ( u_bsg_tag_data_i DVSS ) ( u_bsg_tag_clk_o DVSS ) ( u_bsg_tag_clk_i DVSS ) + USE GROUND ;
     - IO_CORNER_NORTH_WEST_INST.RETN_RING ( u_brk0 RETNB ) ( u_sel_0_i RETN ) ( IO_FILL_IO_NORTH_32_0 RETN ) ( IO_FILL_IO_NORTH_32_5 RETN ) ( u_sel_1_i RETN ) ( IO_FILL_IO_NORTH_33_0 RETN ) ( u_vzz_20 RETN )
       ( IO_FILL_IO_NORTH_34_0 RETN ) ( u_v18_20 RETN ) ( IO_FILL_IO_NORTH_35_0 RETN ) ( IO_FILL_IO_NORTH_35_5 RETN ) ( u_sel_2_i RETN ) ( IO_FILL_IO_NORTH_36_0 RETN ) ( u_vss_9 RETN ) ( IO_FILL_IO_NORTH_37_0 RETN )
       ( IO_FILL_IO_NORTH_37_5 RETN ) ( u_vdd_9 RETN ) ( IO_FILL_IO_NORTH_38_0 RETN ) ( u_core_async_reset_i RETN ) ( IO_FILL_IO_NORTH_39_0 RETN ) ( IO_FILL_IO_NORTH_39_5 RETN ) ( u_ci2_0_o RETN ) ( IO_FILL_IO_NORTH_40_0 RETN )
@@ -2991,328 +2999,451 @@ SPECIALNETS 6 ;
       ( IO_FILL_IO_NORTH_0_70 SNS ) ( IO_FILL_IO_NORTH_0_65 SNS ) ( IO_FILL_IO_NORTH_0_60 SNS ) ( IO_FILL_IO_NORTH_0_55 SNS ) ( IO_FILL_IO_NORTH_0_50 SNS ) ( IO_FILL_IO_NORTH_0_45 SNS ) ( IO_FILL_IO_NORTH_0_40 SNS ) ( IO_FILL_IO_NORTH_0_35 SNS )
       ( IO_FILL_IO_NORTH_0_30 SNS ) ( IO_FILL_IO_NORTH_0_25 SNS ) ( IO_FILL_IO_NORTH_0_20 SNS ) ( IO_FILL_IO_NORTH_0_15 SNS ) ( IO_FILL_IO_NORTH_0_10 SNS ) ( u_co2_8_o SNS ) ( IO_FILL_IO_NORTH_0_5 SNS ) ( IO_FILL_IO_WEST_57_0 SNS )
       ( IO_FILL_IO_NORTH_0_0 SNS ) ( IO_CORNER_NORTH_WEST_INST SNS ) + USE SIGNAL ;
-    - VDD ( PIN VDD ) ( IO_FILL_IO_WEST_0_485 VDD ) ( IO_FILL_IO_WEST_0_480 VDD ) ( IO_FILL_IO_WEST_0_475 VDD ) ( IO_FILL_IO_WEST_0_470 VDD ) ( IO_FILL_IO_WEST_0_465 VDD ) ( IO_FILL_IO_WEST_0_460 VDD )
-      ( IO_FILL_IO_WEST_0_455 VDD ) ( IO_FILL_IO_WEST_0_450 VDD ) ( IO_FILL_IO_WEST_0_445 VDD ) ( IO_FILL_IO_WEST_0_440 VDD ) ( IO_FILL_IO_WEST_0_435 VDD ) ( IO_FILL_IO_WEST_0_430 VDD ) ( IO_FILL_IO_WEST_0_425 VDD ) ( IO_FILL_IO_WEST_0_420 VDD )
-      ( IO_FILL_IO_WEST_0_415 VDD ) ( IO_FILL_IO_WEST_0_410 VDD ) ( IO_FILL_IO_WEST_0_405 VDD ) ( IO_FILL_IO_WEST_0_400 VDD ) ( IO_FILL_IO_WEST_0_395 VDD ) ( IO_FILL_IO_WEST_0_390 VDD ) ( IO_FILL_IO_WEST_0_385 VDD ) ( IO_FILL_IO_WEST_0_380 VDD )
-      ( IO_FILL_IO_WEST_0_375 VDD ) ( IO_FILL_IO_WEST_0_370 VDD ) ( IO_FILL_IO_WEST_0_365 VDD ) ( IO_FILL_IO_WEST_0_360 VDD ) ( IO_FILL_IO_WEST_0_355 VDD ) ( IO_FILL_IO_WEST_0_350 VDD ) ( IO_FILL_IO_WEST_0_345 VDD ) ( IO_FILL_IO_WEST_0_340 VDD )
-      ( IO_FILL_IO_WEST_0_335 VDD ) ( IO_FILL_IO_WEST_0_330 VDD ) ( IO_FILL_IO_WEST_0_325 VDD ) ( IO_FILL_IO_WEST_0_320 VDD ) ( IO_FILL_IO_WEST_0_315 VDD ) ( IO_FILL_IO_WEST_0_310 VDD ) ( IO_FILL_IO_WEST_0_305 VDD ) ( IO_FILL_IO_WEST_0_300 VDD )
-      ( IO_FILL_IO_WEST_0_295 VDD ) ( IO_FILL_IO_WEST_0_290 VDD ) ( IO_FILL_IO_WEST_0_285 VDD ) ( IO_FILL_IO_WEST_0_280 VDD ) ( IO_FILL_IO_WEST_0_275 VDD ) ( IO_FILL_IO_WEST_0_270 VDD ) ( IO_FILL_IO_WEST_0_265 VDD ) ( IO_FILL_IO_WEST_0_260 VDD )
-      ( IO_FILL_IO_WEST_0_255 VDD ) ( IO_FILL_IO_WEST_0_250 VDD ) ( IO_FILL_IO_WEST_0_245 VDD ) ( IO_FILL_IO_WEST_0_240 VDD ) ( IO_FILL_IO_WEST_0_235 VDD ) ( IO_FILL_IO_WEST_0_230 VDD ) ( IO_FILL_IO_WEST_0_225 VDD ) ( IO_FILL_IO_WEST_0_220 VDD )
-      ( IO_FILL_IO_WEST_0_215 VDD ) ( IO_FILL_IO_WEST_0_210 VDD ) ( IO_FILL_IO_WEST_0_205 VDD ) ( IO_FILL_IO_WEST_0_200 VDD ) ( IO_FILL_IO_WEST_0_195 VDD ) ( IO_FILL_IO_WEST_0_190 VDD ) ( IO_FILL_IO_WEST_0_185 VDD ) ( IO_FILL_IO_WEST_0_180 VDD )
-      ( IO_FILL_IO_WEST_0_175 VDD ) ( IO_FILL_IO_WEST_0_170 VDD ) ( IO_FILL_IO_WEST_0_165 VDD ) ( IO_FILL_IO_WEST_0_160 VDD ) ( IO_FILL_IO_WEST_0_155 VDD ) ( IO_FILL_IO_WEST_0_150 VDD ) ( IO_FILL_IO_WEST_0_145 VDD ) ( IO_FILL_IO_WEST_0_140 VDD )
-      ( IO_FILL_IO_WEST_0_135 VDD ) ( IO_FILL_IO_WEST_0_130 VDD ) ( IO_FILL_IO_WEST_0_125 VDD ) ( IO_FILL_IO_WEST_0_120 VDD ) ( IO_FILL_IO_WEST_0_115 VDD ) ( IO_FILL_IO_WEST_0_110 VDD ) ( IO_FILL_IO_WEST_0_105 VDD ) ( IO_FILL_IO_WEST_0_100 VDD )
-      ( IO_FILL_IO_WEST_0_95 VDD ) ( IO_FILL_IO_WEST_0_90 VDD ) ( IO_FILL_IO_WEST_0_85 VDD ) ( IO_FILL_IO_WEST_0_80 VDD ) ( IO_FILL_IO_WEST_0_75 VDD ) ( IO_FILL_IO_WEST_0_70 VDD ) ( IO_FILL_IO_WEST_0_65 VDD ) ( IO_FILL_IO_WEST_0_60 VDD )
-      ( IO_FILL_IO_WEST_0_55 VDD ) ( IO_FILL_IO_WEST_0_50 VDD ) ( IO_FILL_IO_WEST_0_45 VDD ) ( IO_FILL_IO_WEST_0_40 VDD ) ( IO_FILL_IO_WEST_0_35 VDD ) ( IO_FILL_IO_WEST_0_30 VDD ) ( IO_FILL_IO_WEST_0_25 VDD ) ( IO_FILL_IO_WEST_0_20 VDD )
-      ( IO_FILL_IO_WEST_0_15 VDD ) ( IO_FILL_IO_WEST_0_10 VDD ) ( IO_FILL_IO_WEST_0_5 VDD ) ( IO_FILL_IO_WEST_0_0 VDD ) ( IO_CORNER_SOUTH_WEST_INST VDD ) ( IO_FILL_IO_SOUTH_0_0 VDD ) ( IO_FILL_IO_SOUTH_0_5 VDD ) ( IO_FILL_IO_WEST_0_490 VDD )
-      ( IO_FILL_IO_SOUTH_0_10 VDD ) ( IO_FILL_IO_WEST_0_495 VDD ) ( IO_FILL_IO_SOUTH_0_15 VDD ) ( IO_FILL_IO_EAST_0_15 VDD ) ( IO_FILL_IO_EAST_0_10 VDD ) ( IO_FILL_IO_EAST_0_5 VDD ) ( IO_FILL_IO_EAST_0_0 VDD ) ( IO_CORNER_SOUTH_EAST_INST VDD )
-      ( IO_FILL_IO_WEST_56_90 VDD ) ( IO_FILL_IO_WEST_56_85 VDD ) ( IO_FILL_IO_WEST_56_80 VDD ) ( IO_FILL_IO_WEST_56_75 VDD ) ( IO_FILL_IO_WEST_56_70 VDD ) ( IO_FILL_IO_WEST_56_65 VDD ) ( IO_FILL_IO_WEST_56_60 VDD ) ( IO_FILL_IO_WEST_56_55 VDD )
-      ( IO_FILL_IO_WEST_56_50 VDD ) ( IO_FILL_IO_WEST_56_45 VDD ) ( IO_FILL_IO_WEST_56_40 VDD ) ( IO_FILL_IO_WEST_56_35 VDD ) ( IO_FILL_IO_WEST_56_30 VDD ) ( IO_FILL_IO_WEST_56_25 VDD ) ( IO_FILL_IO_WEST_56_20 VDD ) ( IO_FILL_IO_WEST_56_15 VDD )
-      ( IO_FILL_IO_WEST_56_10 VDD ) ( IO_FILL_IO_WEST_56_5 VDD ) ( IO_FILL_IO_WEST_54_95 VDD ) ( IO_FILL_IO_WEST_54_90 VDD ) ( IO_FILL_IO_WEST_54_85 VDD ) ( IO_FILL_IO_WEST_54_80 VDD ) ( IO_FILL_IO_WEST_54_75 VDD ) ( IO_FILL_IO_WEST_54_70 VDD )
-      ( IO_FILL_IO_WEST_54_65 VDD ) ( IO_FILL_IO_WEST_54_60 VDD ) ( IO_FILL_IO_WEST_54_55 VDD ) ( IO_FILL_IO_WEST_54_50 VDD ) ( IO_FILL_IO_WEST_54_45 VDD ) ( IO_FILL_IO_WEST_54_40 VDD ) ( IO_FILL_IO_WEST_54_35 VDD ) ( IO_FILL_IO_WEST_54_30 VDD )
-      ( IO_FILL_IO_WEST_54_25 VDD ) ( IO_FILL_IO_WEST_54_20 VDD ) ( IO_FILL_IO_WEST_54_15 VDD ) ( IO_FILL_IO_WEST_54_10 VDD ) ( IO_FILL_IO_WEST_54_5 VDD ) ( IO_FILL_IO_WEST_51_25 VDD ) ( IO_FILL_IO_WEST_51_20 VDD ) ( IO_FILL_IO_WEST_51_15 VDD )
-      ( IO_FILL_IO_WEST_51_10 VDD ) ( IO_FILL_IO_WEST_51_5 VDD ) ( IO_FILL_IO_WEST_47_45 VDD ) ( IO_FILL_IO_WEST_47_40 VDD ) ( IO_FILL_IO_WEST_47_35 VDD ) ( IO_FILL_IO_WEST_47_30 VDD ) ( IO_FILL_IO_WEST_47_25 VDD ) ( IO_FILL_IO_WEST_47_20 VDD )
-      ( IO_FILL_IO_WEST_47_15 VDD ) ( IO_FILL_IO_WEST_47_10 VDD ) ( IO_FILL_IO_WEST_47_5 VDD ) ( IO_FILL_IO_WEST_32_5 VDD ) ( IO_FILL_IO_WEST_27_5 VDD ) ( IO_FILL_IO_WEST_12_5 VDD ) ( IO_FILL_IO_WEST_7_5 VDD ) ( IO_FILL_IO_WEST_3_65 VDD )
-      ( IO_FILL_IO_WEST_3_60 VDD ) ( IO_FILL_IO_WEST_3_55 VDD ) ( IO_FILL_IO_WEST_3_50 VDD ) ( IO_FILL_IO_WEST_3_45 VDD ) ( IO_FILL_IO_WEST_3_40 VDD ) ( IO_FILL_IO_WEST_3_35 VDD ) ( IO_FILL_IO_WEST_3_30 VDD ) ( IO_FILL_IO_WEST_3_25 VDD )
-      ( IO_FILL_IO_WEST_3_20 VDD ) ( IO_FILL_IO_WEST_3_15 VDD ) ( IO_FILL_IO_WEST_3_10 VDD ) ( IO_FILL_IO_WEST_3_5 VDD ) ( IO_FILL_IO_WEST_0_500 VDD ) ( IO_FILL_IO_WEST_0_505 VDD ) ( IO_FILL_IO_WEST_1_0 VDD ) ( IO_FILL_IO_WEST_17_0 VDD )
-      ( IO_FILL_IO_WEST_51_0 VDD ) ( IO_FILL_IO_WEST_3_0 VDD ) ( IO_FILL_IO_WEST_2_0 VDD ) ( IO_FILL_IO_WEST_19_5 VDD ) ( IO_FILL_IO_WEST_51_30 VDD ) ( IO_FILL_IO_WEST_3_70 VDD ) ( IO_FILL_IO_WEST_20_0 VDD ) ( IO_FILL_IO_WEST_35_0 VDD )
-      ( IO_FILL_IO_WEST_52_0 VDD ) ( IO_FILL_IO_WEST_10_0 VDD ) ( IO_FILL_IO_WEST_16_0 VDD ) ( IO_FILL_IO_WEST_24_0 VDD ) ( IO_FILL_IO_WEST_30_0 VDD ) ( IO_FILL_IO_WEST_38_0 VDD ) ( IO_FILL_IO_WEST_37_5 VDD ) ( IO_FILL_IO_WEST_44_0 VDD )
-      ( IO_FILL_IO_WEST_50_0 VDD ) ( IO_FILL_IO_WEST_15_0 VDD ) ( IO_FILL_IO_WEST_17_5 VDD ) ( IO_FILL_IO_WEST_5_0 VDD ) ( IO_FILL_IO_WEST_4_0 VDD ) ( IO_FILL_IO_WEST_33_0 VDD ) ( IO_FILL_IO_WEST_32_10 VDD ) ( IO_FILL_IO_WEST_32_0 VDD )
-      ( IO_FILL_IO_WEST_31_0 VDD ) ( IO_FILL_IO_WEST_29_0 VDD ) ( IO_FILL_IO_WEST_28_0 VDD ) ( IO_FILL_IO_WEST_27_10 VDD ) ( IO_FILL_IO_WEST_27_0 VDD ) ( IO_FILL_IO_WEST_26_0 VDD ) ( IO_FILL_IO_WEST_25_0 VDD ) ( IO_FILL_IO_WEST_23_0 VDD )
-      ( IO_FILL_IO_WEST_22_5 VDD ) ( IO_FILL_IO_WEST_14_0 VDD ) ( IO_FILL_IO_WEST_13_5 VDD ) ( IO_FILL_IO_WEST_13_0 VDD ) ( IO_FILL_IO_WEST_12_10 VDD ) ( IO_FILL_IO_WEST_12_0 VDD ) ( IO_FILL_IO_WEST_11_0 VDD ) ( IO_FILL_IO_WEST_9_0 VDD )
-      ( IO_FILL_IO_WEST_8_0 VDD ) ( IO_FILL_IO_WEST_7_10 VDD ) ( IO_FILL_IO_WEST_7_0 VDD ) ( IO_FILL_IO_WEST_6_0 VDD ) ( IO_FILL_IO_WEST_22_0 VDD ) ( IO_FILL_IO_WEST_21_0 VDD ) ( IO_FILL_IO_WEST_19_0 VDD ) ( IO_FILL_IO_WEST_18_0 VDD )
-      ( IO_FILL_IO_WEST_49_0 VDD ) ( IO_FILL_IO_WEST_48_0 VDD ) ( IO_FILL_IO_WEST_47_50 VDD ) ( IO_FILL_IO_WEST_47_0 VDD ) ( IO_FILL_IO_WEST_56_95 VDD ) ( IO_FILL_IO_WEST_56_0 VDD ) ( IO_FILL_IO_WEST_55_5 VDD ) ( IO_FILL_IO_WEST_55_0 VDD )
-      ( IO_FILL_IO_WEST_54_100 VDD ) ( IO_FILL_IO_WEST_54_0 VDD ) ( IO_FILL_IO_WEST_53_0 VDD ) ( IO_FILL_IO_WEST_46_0 VDD ) ( IO_FILL_IO_WEST_45_0 VDD ) ( IO_FILL_IO_WEST_43_0 VDD ) ( IO_FILL_IO_WEST_42_5 VDD ) ( IO_FILL_IO_WEST_42_0 VDD )
-      ( IO_FILL_IO_WEST_41_5 VDD ) ( IO_FILL_IO_WEST_41_0 VDD ) ( IO_FILL_IO_WEST_40_0 VDD ) ( IO_FILL_IO_WEST_39_0 VDD ) ( IO_FILL_IO_WEST_34_0 VDD ) ( IO_FILL_IO_WEST_33_5 VDD ) ( IO_FILL_IO_WEST_37_0 VDD ) ( IO_FILL_IO_WEST_36_0 VDD )
-      ( IO_FILL_IO_SOUTH_60_190 VDD ) ( IO_FILL_IO_SOUTH_60_185 VDD ) ( IO_FILL_IO_SOUTH_60_180 VDD ) ( IO_FILL_IO_SOUTH_60_175 VDD ) ( IO_FILL_IO_SOUTH_60_170 VDD ) ( IO_FILL_IO_SOUTH_60_165 VDD ) ( IO_FILL_IO_SOUTH_60_160 VDD ) ( IO_FILL_IO_SOUTH_60_155 VDD )
-      ( IO_FILL_IO_SOUTH_60_150 VDD ) ( IO_FILL_IO_SOUTH_60_145 VDD ) ( IO_FILL_IO_SOUTH_60_140 VDD ) ( IO_FILL_IO_SOUTH_60_135 VDD ) ( IO_FILL_IO_SOUTH_60_130 VDD ) ( IO_FILL_IO_SOUTH_60_125 VDD ) ( IO_FILL_IO_SOUTH_60_120 VDD ) ( IO_FILL_IO_SOUTH_60_115 VDD )
-      ( IO_FILL_IO_SOUTH_60_110 VDD ) ( IO_FILL_IO_SOUTH_60_105 VDD ) ( IO_FILL_IO_SOUTH_60_100 VDD ) ( IO_FILL_IO_SOUTH_60_95 VDD ) ( IO_FILL_IO_SOUTH_60_90 VDD ) ( IO_FILL_IO_SOUTH_60_85 VDD ) ( IO_FILL_IO_SOUTH_60_80 VDD ) ( IO_FILL_IO_SOUTH_60_75 VDD )
-      ( IO_FILL_IO_SOUTH_60_70 VDD ) ( IO_FILL_IO_SOUTH_60_65 VDD ) ( IO_FILL_IO_SOUTH_60_60 VDD ) ( IO_FILL_IO_SOUTH_60_55 VDD ) ( IO_FILL_IO_SOUTH_60_50 VDD ) ( IO_FILL_IO_SOUTH_60_45 VDD ) ( IO_FILL_IO_SOUTH_60_40 VDD ) ( IO_FILL_IO_SOUTH_60_35 VDD )
-      ( IO_FILL_IO_SOUTH_60_30 VDD ) ( IO_FILL_IO_SOUTH_60_25 VDD ) ( IO_FILL_IO_SOUTH_60_20 VDD ) ( IO_FILL_IO_SOUTH_60_15 VDD ) ( IO_FILL_IO_SOUTH_60_10 VDD ) ( IO_FILL_IO_SOUTH_60_5 VDD ) ( IO_FILL_IO_SOUTH_59_125 VDD ) ( IO_FILL_IO_SOUTH_59_120 VDD )
-      ( IO_FILL_IO_SOUTH_59_115 VDD ) ( IO_FILL_IO_SOUTH_59_110 VDD ) ( IO_FILL_IO_SOUTH_59_105 VDD ) ( IO_FILL_IO_SOUTH_59_100 VDD ) ( IO_FILL_IO_SOUTH_59_95 VDD ) ( IO_FILL_IO_SOUTH_59_90 VDD ) ( IO_FILL_IO_SOUTH_59_85 VDD ) ( IO_FILL_IO_SOUTH_59_80 VDD )
-      ( IO_FILL_IO_SOUTH_59_75 VDD ) ( IO_FILL_IO_SOUTH_59_70 VDD ) ( IO_FILL_IO_SOUTH_59_65 VDD ) ( IO_FILL_IO_SOUTH_59_60 VDD ) ( IO_FILL_IO_SOUTH_59_55 VDD ) ( IO_FILL_IO_SOUTH_59_50 VDD ) ( IO_FILL_IO_SOUTH_59_45 VDD ) ( IO_FILL_IO_SOUTH_59_40 VDD )
-      ( IO_FILL_IO_SOUTH_59_35 VDD ) ( IO_FILL_IO_SOUTH_59_30 VDD ) ( IO_FILL_IO_SOUTH_59_25 VDD ) ( IO_FILL_IO_SOUTH_59_20 VDD ) ( IO_FILL_IO_SOUTH_59_15 VDD ) ( IO_FILL_IO_SOUTH_59_10 VDD ) ( IO_FILL_IO_SOUTH_59_5 VDD ) ( IO_FILL_IO_SOUTH_57_60 VDD )
-      ( IO_FILL_IO_SOUTH_57_55 VDD ) ( IO_FILL_IO_SOUTH_57_50 VDD ) ( IO_FILL_IO_SOUTH_57_45 VDD ) ( IO_FILL_IO_SOUTH_57_40 VDD ) ( IO_FILL_IO_SOUTH_57_35 VDD ) ( IO_FILL_IO_SOUTH_57_30 VDD ) ( IO_FILL_IO_SOUTH_57_25 VDD ) ( IO_FILL_IO_SOUTH_57_20 VDD )
-      ( IO_FILL_IO_SOUTH_57_15 VDD ) ( IO_FILL_IO_SOUTH_57_10 VDD ) ( IO_FILL_IO_SOUTH_57_5 VDD ) ( IO_FILL_IO_SOUTH_54_65 VDD ) ( IO_FILL_IO_SOUTH_54_60 VDD ) ( IO_FILL_IO_SOUTH_54_55 VDD ) ( IO_FILL_IO_SOUTH_54_50 VDD ) ( IO_FILL_IO_SOUTH_54_45 VDD )
-      ( IO_FILL_IO_SOUTH_54_40 VDD ) ( IO_FILL_IO_SOUTH_54_35 VDD ) ( IO_FILL_IO_SOUTH_54_30 VDD ) ( IO_FILL_IO_SOUTH_54_25 VDD ) ( IO_FILL_IO_SOUTH_54_20 VDD ) ( IO_FILL_IO_SOUTH_54_15 VDD ) ( IO_FILL_IO_SOUTH_54_10 VDD ) ( IO_FILL_IO_SOUTH_54_5 VDD )
-      ( IO_FILL_IO_SOUTH_40_5 VDD ) ( IO_FILL_IO_SOUTH_20_5 VDD ) ( IO_FILL_IO_SOUTH_10_30 VDD ) ( IO_FILL_IO_SOUTH_10_25 VDD ) ( IO_FILL_IO_SOUTH_10_20 VDD ) ( IO_FILL_IO_SOUTH_10_15 VDD ) ( IO_FILL_IO_SOUTH_10_10 VDD ) ( IO_FILL_IO_SOUTH_10_5 VDD )
-      ( IO_FILL_IO_SOUTH_6_35 VDD ) ( IO_FILL_IO_SOUTH_6_30 VDD ) ( IO_FILL_IO_SOUTH_6_25 VDD ) ( IO_FILL_IO_SOUTH_6_20 VDD ) ( IO_FILL_IO_SOUTH_6_15 VDD ) ( IO_FILL_IO_SOUTH_6_10 VDD ) ( IO_FILL_IO_SOUTH_6_5 VDD ) ( IO_FILL_IO_SOUTH_3_95 VDD )
-      ( IO_FILL_IO_SOUTH_3_90 VDD ) ( IO_FILL_IO_SOUTH_3_85 VDD ) ( IO_FILL_IO_SOUTH_3_80 VDD ) ( IO_FILL_IO_SOUTH_3_75 VDD ) ( IO_FILL_IO_SOUTH_3_70 VDD ) ( IO_FILL_IO_SOUTH_3_65 VDD ) ( IO_FILL_IO_SOUTH_3_60 VDD ) ( IO_FILL_IO_SOUTH_3_55 VDD )
-      ( IO_FILL_IO_SOUTH_3_50 VDD ) ( IO_FILL_IO_SOUTH_3_45 VDD ) ( IO_FILL_IO_SOUTH_3_40 VDD ) ( IO_FILL_IO_SOUTH_3_35 VDD ) ( IO_FILL_IO_SOUTH_3_30 VDD ) ( IO_FILL_IO_SOUTH_3_25 VDD ) ( IO_FILL_IO_SOUTH_3_20 VDD ) ( IO_FILL_IO_SOUTH_3_15 VDD )
-      ( IO_FILL_IO_SOUTH_3_10 VDD ) ( IO_FILL_IO_SOUTH_3_5 VDD ) ( IO_FILL_IO_SOUTH_1_95 VDD ) ( IO_FILL_IO_SOUTH_1_90 VDD ) ( IO_FILL_IO_SOUTH_1_85 VDD ) ( IO_FILL_IO_SOUTH_1_80 VDD ) ( IO_FILL_IO_SOUTH_1_75 VDD ) ( IO_FILL_IO_SOUTH_1_70 VDD )
-      ( IO_FILL_IO_SOUTH_1_65 VDD ) ( IO_FILL_IO_SOUTH_1_60 VDD ) ( IO_FILL_IO_SOUTH_1_55 VDD ) ( IO_FILL_IO_SOUTH_1_50 VDD ) ( IO_FILL_IO_SOUTH_1_45 VDD ) ( IO_FILL_IO_SOUTH_1_40 VDD ) ( IO_FILL_IO_SOUTH_1_35 VDD ) ( IO_FILL_IO_SOUTH_1_30 VDD )
-      ( IO_FILL_IO_SOUTH_1_25 VDD ) ( IO_FILL_IO_SOUTH_1_20 VDD ) ( IO_FILL_IO_SOUTH_1_15 VDD ) ( IO_FILL_IO_SOUTH_1_10 VDD ) ( IO_FILL_IO_SOUTH_1_5 VDD ) ( IO_FILL_IO_SOUTH_0_20 VDD ) ( IO_FILL_IO_SOUTH_6_0 VDD ) ( IO_FILL_IO_SOUTH_3_100 VDD )
-      ( IO_FILL_IO_SOUTH_59_0 VDD ) ( IO_FILL_IO_SOUTH_50_5 VDD ) ( IO_FILL_IO_SOUTH_45_0 VDD ) ( IO_FILL_IO_SOUTH_30_5 VDD ) ( IO_FILL_IO_SOUTH_25_0 VDD ) ( IO_FILL_IO_SOUTH_10_35 VDD ) ( IO_FILL_IO_SOUTH_3_0 VDD ) ( IO_FILL_IO_SOUTH_54_0 VDD )
-      ( IO_FILL_IO_SOUTH_22_0 VDD ) ( IO_FILL_IO_SOUTH_6_40 VDD ) ( IO_FILL_IO_SOUTH_53_0 VDD ) ( IO_FILL_IO_SOUTH_36_0 VDD ) ( IO_FILL_IO_SOUTH_35_5 VDD ) ( IO_FILL_IO_SOUTH_21_0 VDD ) ( IO_FILL_IO_SOUTH_20_10 VDD ) ( IO_FILL_IO_SOUTH_60_0 VDD )
-      ( IO_FILL_IO_SOUTH_59_130 VDD ) ( IO_FILL_IO_SOUTH_52_0 VDD ) ( IO_FILL_IO_SOUTH_51_0 VDD ) ( IO_FILL_IO_SOUTH_45_5 VDD ) ( IO_FILL_IO_SOUTH_40_0 VDD ) ( IO_FILL_IO_SOUTH_39_0 VDD ) ( IO_FILL_IO_SOUTH_31_0 VDD ) ( IO_FILL_IO_SOUTH_25_5 VDD )
-      ( IO_FILL_IO_SOUTH_17_0 VDD ) ( IO_FILL_IO_SOUTH_11_0 VDD ) ( IO_FILL_IO_SOUTH_42_5 VDD ) ( IO_FILL_IO_SOUTH_42_0 VDD ) ( IO_FILL_IO_SOUTH_46_0 VDD ) ( IO_FILL_IO_SOUTH_41_0 VDD ) ( IO_FILL_IO_SOUTH_40_10 VDD ) ( IO_FILL_IO_SOUTH_57_0 VDD )
-      ( IO_FILL_IO_SOUTH_56_5 VDD ) ( IO_FILL_IO_SOUTH_5_0 VDD ) ( IO_FILL_IO_SOUTH_4_0 VDD ) ( IO_FILL_IO_SOUTH_56_0 VDD ) ( IO_FILL_IO_SOUTH_2_0 VDD ) ( IO_FILL_IO_SOUTH_1_100 VDD ) ( IO_FILL_IO_SOUTH_58_0 VDD ) ( IO_FILL_IO_SOUTH_57_65 VDD )
-      ( IO_FILL_IO_SOUTH_1_0 VDD ) ( IO_FILL_IO_SOUTH_0_25 VDD ) ( IO_FILL_IO_SOUTH_48_0 VDD ) ( IO_FILL_IO_SOUTH_47_0 VDD ) ( IO_FILL_IO_SOUTH_48_5 VDD ) ( IO_FILL_IO_SOUTH_55_0 VDD ) ( IO_FILL_IO_SOUTH_54_70 VDD ) ( IO_FILL_IO_SOUTH_50_0 VDD )
-      ( IO_FILL_IO_SOUTH_49_0 VDD ) ( IO_FILL_IO_SOUTH_44_0 VDD ) ( IO_FILL_IO_SOUTH_43_0 VDD ) ( IO_FILL_IO_SOUTH_8_0 VDD ) ( IO_FILL_IO_SOUTH_7_0 VDD ) ( IO_FILL_IO_SOUTH_8_5 VDD ) ( IO_FILL_IO_SOUTH_10_0 VDD ) ( IO_FILL_IO_SOUTH_9_0 VDD )
-      ( IO_FILL_IO_SOUTH_22_5 VDD ) ( IO_FILL_IO_SOUTH_24_0 VDD ) ( IO_FILL_IO_SOUTH_23_0 VDD ) ( IO_FILL_IO_SOUTH_26_0 VDD ) ( IO_FILL_IO_SOUTH_28_0 VDD ) ( IO_FILL_IO_SOUTH_27_0 VDD ) ( IO_FILL_IO_SOUTH_28_5 VDD ) ( IO_FILL_IO_SOUTH_30_0 VDD )
-      ( IO_FILL_IO_SOUTH_29_0 VDD ) ( IO_FILL_IO_SOUTH_32_0 VDD ) ( IO_FILL_IO_SOUTH_34_0 VDD ) ( IO_FILL_IO_SOUTH_33_0 VDD ) ( IO_FILL_IO_SOUTH_35_0 VDD ) ( IO_FILL_IO_SOUTH_34_5 VDD ) ( IO_FILL_IO_SOUTH_12_0 VDD ) ( IO_FILL_IO_SOUTH_14_0 VDD )
-      ( IO_FILL_IO_SOUTH_13_0 VDD ) ( IO_FILL_IO_SOUTH_15_0 VDD ) ( IO_FILL_IO_SOUTH_14_5 VDD ) ( IO_FILL_IO_SOUTH_16_0 VDD ) ( IO_FILL_IO_SOUTH_15_5 VDD ) ( IO_FILL_IO_SOUTH_18_0 VDD ) ( IO_FILL_IO_SOUTH_20_0 VDD ) ( IO_FILL_IO_SOUTH_19_0 VDD )
-      ( IO_FILL_IO_SOUTH_38_0 VDD ) ( IO_FILL_IO_SOUTH_37_0 VDD ) ( IO_FILL_IO_EAST_60_180 VDD ) ( IO_FILL_IO_EAST_60_175 VDD ) ( IO_FILL_IO_EAST_60_170 VDD ) ( IO_FILL_IO_EAST_60_165 VDD ) ( IO_FILL_IO_EAST_60_160 VDD ) ( IO_FILL_IO_EAST_60_155 VDD )
-      ( IO_FILL_IO_EAST_60_150 VDD ) ( IO_FILL_IO_EAST_60_145 VDD ) ( IO_FILL_IO_EAST_60_140 VDD ) ( IO_FILL_IO_EAST_60_135 VDD ) ( IO_FILL_IO_EAST_60_130 VDD ) ( IO_FILL_IO_EAST_60_125 VDD ) ( IO_FILL_IO_EAST_60_120 VDD ) ( IO_FILL_IO_EAST_60_115 VDD )
-      ( IO_FILL_IO_EAST_60_110 VDD ) ( IO_FILL_IO_EAST_60_105 VDD ) ( IO_FILL_IO_EAST_60_100 VDD ) ( IO_FILL_IO_EAST_60_95 VDD ) ( IO_FILL_IO_EAST_60_90 VDD ) ( IO_FILL_IO_EAST_60_85 VDD ) ( IO_FILL_IO_EAST_60_80 VDD ) ( IO_FILL_IO_EAST_60_75 VDD )
-      ( IO_FILL_IO_EAST_60_70 VDD ) ( IO_FILL_IO_EAST_60_65 VDD ) ( IO_FILL_IO_EAST_60_60 VDD ) ( IO_FILL_IO_EAST_60_55 VDD ) ( IO_FILL_IO_EAST_60_50 VDD ) ( IO_FILL_IO_EAST_60_45 VDD ) ( IO_FILL_IO_EAST_60_40 VDD ) ( IO_FILL_IO_EAST_60_35 VDD )
-      ( IO_FILL_IO_EAST_60_30 VDD ) ( IO_FILL_IO_EAST_60_25 VDD ) ( IO_FILL_IO_EAST_60_20 VDD ) ( IO_FILL_IO_EAST_60_15 VDD ) ( IO_FILL_IO_EAST_60_10 VDD ) ( IO_FILL_IO_EAST_60_5 VDD ) ( IO_FILL_IO_EAST_59_120 VDD ) ( IO_FILL_IO_EAST_59_115 VDD )
-      ( IO_FILL_IO_EAST_59_110 VDD ) ( IO_FILL_IO_EAST_59_105 VDD ) ( IO_FILL_IO_EAST_59_100 VDD ) ( IO_FILL_IO_EAST_59_95 VDD ) ( IO_FILL_IO_EAST_59_90 VDD ) ( IO_FILL_IO_EAST_59_85 VDD ) ( IO_FILL_IO_EAST_59_80 VDD ) ( IO_FILL_IO_EAST_59_75 VDD )
-      ( IO_FILL_IO_EAST_59_70 VDD ) ( IO_FILL_IO_EAST_59_65 VDD ) ( IO_FILL_IO_EAST_59_60 VDD ) ( IO_FILL_IO_EAST_59_55 VDD ) ( IO_FILL_IO_EAST_59_50 VDD ) ( IO_FILL_IO_EAST_59_45 VDD ) ( IO_FILL_IO_EAST_59_40 VDD ) ( IO_FILL_IO_EAST_59_35 VDD )
-      ( IO_FILL_IO_EAST_59_30 VDD ) ( IO_FILL_IO_EAST_59_25 VDD ) ( IO_FILL_IO_EAST_59_20 VDD ) ( IO_FILL_IO_EAST_59_15 VDD ) ( IO_FILL_IO_EAST_59_10 VDD ) ( IO_FILL_IO_EAST_59_5 VDD ) ( IO_FILL_IO_EAST_57_65 VDD ) ( IO_FILL_IO_EAST_57_60 VDD )
-      ( IO_FILL_IO_EAST_57_55 VDD ) ( IO_FILL_IO_EAST_57_50 VDD ) ( IO_FILL_IO_EAST_57_45 VDD ) ( IO_FILL_IO_EAST_57_40 VDD ) ( IO_FILL_IO_EAST_57_35 VDD ) ( IO_FILL_IO_EAST_57_30 VDD ) ( IO_FILL_IO_EAST_57_25 VDD ) ( IO_FILL_IO_EAST_57_20 VDD )
-      ( IO_FILL_IO_EAST_57_15 VDD ) ( IO_FILL_IO_EAST_57_10 VDD ) ( IO_FILL_IO_EAST_57_5 VDD ) ( IO_FILL_IO_EAST_54_65 VDD ) ( IO_FILL_IO_EAST_54_60 VDD ) ( IO_FILL_IO_EAST_54_55 VDD ) ( IO_FILL_IO_EAST_54_50 VDD ) ( IO_FILL_IO_EAST_54_45 VDD )
-      ( IO_FILL_IO_EAST_54_40 VDD ) ( IO_FILL_IO_EAST_54_35 VDD ) ( IO_FILL_IO_EAST_54_30 VDD ) ( IO_FILL_IO_EAST_54_25 VDD ) ( IO_FILL_IO_EAST_54_20 VDD ) ( IO_FILL_IO_EAST_54_15 VDD ) ( IO_FILL_IO_EAST_54_10 VDD ) ( IO_FILL_IO_EAST_54_5 VDD )
-      ( IO_FILL_IO_EAST_50_5 VDD ) ( IO_FILL_IO_EAST_35_5 VDD ) ( IO_FILL_IO_EAST_30_5 VDD ) ( IO_FILL_IO_EAST_15_5 VDD ) ( IO_FILL_IO_EAST_10_35 VDD ) ( IO_FILL_IO_EAST_10_30 VDD ) ( IO_FILL_IO_EAST_10_25 VDD ) ( IO_FILL_IO_EAST_10_20 VDD )
-      ( IO_FILL_IO_EAST_10_15 VDD ) ( IO_FILL_IO_EAST_10_10 VDD ) ( IO_FILL_IO_EAST_10_5 VDD ) ( IO_FILL_IO_EAST_6_35 VDD ) ( IO_FILL_IO_EAST_6_30 VDD ) ( IO_FILL_IO_EAST_6_25 VDD ) ( IO_FILL_IO_EAST_6_20 VDD ) ( IO_FILL_IO_EAST_6_15 VDD )
-      ( IO_FILL_IO_EAST_6_10 VDD ) ( IO_FILL_IO_EAST_6_5 VDD ) ( IO_FILL_IO_EAST_3_90 VDD ) ( IO_FILL_IO_EAST_3_85 VDD ) ( IO_FILL_IO_EAST_3_80 VDD ) ( IO_FILL_IO_EAST_3_75 VDD ) ( IO_FILL_IO_EAST_3_70 VDD ) ( IO_FILL_IO_EAST_3_65 VDD )
-      ( IO_FILL_IO_EAST_3_60 VDD ) ( IO_FILL_IO_EAST_3_55 VDD ) ( IO_FILL_IO_EAST_3_50 VDD ) ( IO_FILL_IO_EAST_3_45 VDD ) ( IO_FILL_IO_EAST_3_40 VDD ) ( IO_FILL_IO_EAST_3_35 VDD ) ( IO_FILL_IO_EAST_3_30 VDD ) ( IO_FILL_IO_EAST_3_25 VDD )
-      ( IO_FILL_IO_EAST_3_20 VDD ) ( IO_FILL_IO_EAST_3_15 VDD ) ( IO_FILL_IO_EAST_3_10 VDD ) ( IO_FILL_IO_EAST_3_5 VDD ) ( IO_FILL_IO_EAST_1_95 VDD ) ( IO_FILL_IO_EAST_1_90 VDD ) ( IO_FILL_IO_EAST_1_85 VDD ) ( IO_FILL_IO_EAST_1_80 VDD )
-      ( IO_FILL_IO_EAST_1_75 VDD ) ( IO_FILL_IO_EAST_1_70 VDD ) ( IO_FILL_IO_EAST_1_65 VDD ) ( IO_FILL_IO_EAST_1_60 VDD ) ( IO_FILL_IO_EAST_1_55 VDD ) ( IO_FILL_IO_EAST_1_50 VDD ) ( IO_FILL_IO_EAST_1_45 VDD ) ( IO_FILL_IO_EAST_1_40 VDD )
-      ( IO_FILL_IO_EAST_1_35 VDD ) ( IO_FILL_IO_EAST_1_30 VDD ) ( IO_FILL_IO_EAST_1_25 VDD ) ( IO_FILL_IO_EAST_1_20 VDD ) ( IO_FILL_IO_EAST_1_15 VDD ) ( IO_FILL_IO_EAST_1_10 VDD ) ( IO_FILL_IO_EAST_1_5 VDD ) ( IO_FILL_IO_EAST_0_20 VDD )
-      ( IO_FILL_IO_EAST_6_40 VDD ) ( IO_FILL_IO_EAST_40_5 VDD ) ( IO_FILL_IO_EAST_57_0 VDD ) ( IO_FILL_IO_EAST_56_0 VDD ) ( IO_FILL_IO_EAST_38_0 VDD ) ( IO_FILL_IO_EAST_22_0 VDD ) ( IO_FILL_IO_EAST_4_0 VDD ) ( IO_FILL_IO_EAST_3_95 VDD )
-      ( IO_FILL_IO_EAST_7_0 VDD ) ( IO_FILL_IO_EAST_54_0 VDD ) ( IO_FILL_IO_EAST_53_0 VDD ) ( IO_FILL_IO_EAST_47_0 VDD ) ( IO_FILL_IO_EAST_41_0 VDD ) ( IO_FILL_IO_EAST_33_0 VDD ) ( IO_FILL_IO_EAST_27_0 VDD ) ( IO_FILL_IO_EAST_20_0 VDD )
-      ( IO_FILL_IO_EAST_19_0 VDD ) ( IO_FILL_IO_EAST_13_0 VDD ) ( IO_FILL_IO_EAST_30_0 VDD ) ( IO_FILL_IO_EAST_29_0 VDD ) ( IO_FILL_IO_EAST_28_0 VDD ) ( IO_FILL_IO_EAST_15_0 VDD ) ( IO_FILL_IO_EAST_14_0 VDD ) ( IO_FILL_IO_EAST_16_0 VDD )
-      ( IO_FILL_IO_EAST_15_10 VDD ) ( IO_FILL_IO_EAST_16_5 VDD ) ( IO_FILL_IO_EAST_18_0 VDD ) ( IO_FILL_IO_EAST_17_0 VDD ) ( IO_FILL_IO_EAST_21_0 VDD ) ( IO_FILL_IO_EAST_20_5 VDD ) ( IO_FILL_IO_EAST_24_0 VDD ) ( IO_FILL_IO_EAST_23_0 VDD )
-      ( IO_FILL_IO_EAST_25_0 VDD ) ( IO_FILL_IO_EAST_24_5 VDD ) ( IO_FILL_IO_EAST_26_0 VDD ) ( IO_FILL_IO_EAST_25_5 VDD ) ( IO_FILL_IO_EAST_1_0 VDD ) ( IO_FILL_IO_EAST_0_25 VDD ) ( IO_FILL_IO_EAST_2_0 VDD ) ( IO_FILL_IO_EAST_1_100 VDD )
-      ( IO_FILL_IO_EAST_3_0 VDD ) ( IO_FILL_IO_EAST_2_5 VDD ) ( IO_FILL_IO_EAST_6_0 VDD ) ( IO_FILL_IO_EAST_5_0 VDD ) ( IO_FILL_IO_EAST_8_0 VDD ) ( IO_FILL_IO_EAST_10_0 VDD ) ( IO_FILL_IO_EAST_9_0 VDD ) ( IO_FILL_IO_EAST_10_40 VDD )
-      ( IO_FILL_IO_EAST_12_0 VDD ) ( IO_FILL_IO_EAST_11_0 VDD ) ( IO_FILL_IO_EAST_30_10 VDD ) ( IO_FILL_IO_EAST_45_0 VDD ) ( IO_FILL_IO_EAST_44_5 VDD ) ( IO_FILL_IO_EAST_46_0 VDD ) ( IO_FILL_IO_EAST_45_5 VDD ) ( IO_FILL_IO_EAST_48_0 VDD )
-      ( IO_FILL_IO_EAST_37_0 VDD ) ( IO_FILL_IO_EAST_36_5 VDD ) ( IO_FILL_IO_EAST_40_0 VDD ) ( IO_FILL_IO_EAST_39_0 VDD ) ( IO_FILL_IO_EAST_42_0 VDD ) ( IO_FILL_IO_EAST_44_0 VDD ) ( IO_FILL_IO_EAST_43_0 VDD ) ( IO_FILL_IO_EAST_50_0 VDD )
-      ( IO_FILL_IO_EAST_49_0 VDD ) ( IO_FILL_IO_EAST_50_10 VDD ) ( IO_FILL_IO_EAST_52_0 VDD ) ( IO_FILL_IO_EAST_51_0 VDD ) ( IO_FILL_IO_EAST_55_0 VDD ) ( IO_FILL_IO_EAST_54_70 VDD ) ( IO_FILL_IO_EAST_58_0 VDD ) ( IO_FILL_IO_EAST_57_70 VDD )
-      ( IO_FILL_IO_EAST_59_0 VDD ) ( IO_FILL_IO_EAST_58_5 VDD ) ( IO_FILL_IO_EAST_60_0 VDD ) ( IO_FILL_IO_EAST_59_125 VDD ) ( IO_FILL_IO_EAST_36_0 VDD ) ( IO_FILL_IO_EAST_35_10 VDD ) ( IO_FILL_IO_EAST_35_0 VDD ) ( IO_FILL_IO_EAST_34_0 VDD )
-      ( IO_FILL_IO_EAST_32_0 VDD ) ( IO_FILL_IO_EAST_31_0 VDD ) ( IO_FILL_IO_NORTH_53_95 VDD ) ( IO_FILL_IO_NORTH_53_90 VDD ) ( IO_FILL_IO_NORTH_53_85 VDD ) ( IO_FILL_IO_NORTH_53_80 VDD ) ( IO_FILL_IO_NORTH_53_75 VDD ) ( IO_FILL_IO_NORTH_53_70 VDD )
-      ( IO_FILL_IO_NORTH_53_65 VDD ) ( IO_FILL_IO_NORTH_53_60 VDD ) ( IO_FILL_IO_NORTH_53_55 VDD ) ( IO_FILL_IO_NORTH_53_50 VDD ) ( IO_FILL_IO_NORTH_53_45 VDD ) ( IO_FILL_IO_NORTH_53_40 VDD ) ( IO_FILL_IO_NORTH_53_35 VDD ) ( IO_FILL_IO_NORTH_53_30 VDD )
-      ( IO_FILL_IO_NORTH_53_25 VDD ) ( IO_FILL_IO_NORTH_53_20 VDD ) ( IO_FILL_IO_NORTH_53_15 VDD ) ( IO_FILL_IO_NORTH_53_10 VDD ) ( IO_FILL_IO_NORTH_53_5 VDD ) ( IO_FILL_IO_NORTH_51_95 VDD ) ( IO_FILL_IO_NORTH_51_90 VDD ) ( IO_FILL_IO_NORTH_51_85 VDD )
-      ( IO_FILL_IO_NORTH_51_80 VDD ) ( IO_FILL_IO_NORTH_51_75 VDD ) ( IO_FILL_IO_NORTH_51_70 VDD ) ( IO_FILL_IO_NORTH_51_65 VDD ) ( IO_FILL_IO_NORTH_51_60 VDD ) ( IO_FILL_IO_NORTH_51_55 VDD ) ( IO_FILL_IO_NORTH_51_50 VDD ) ( IO_FILL_IO_NORTH_51_45 VDD )
-      ( IO_FILL_IO_NORTH_51_40 VDD ) ( IO_FILL_IO_NORTH_51_35 VDD ) ( IO_FILL_IO_NORTH_51_30 VDD ) ( IO_FILL_IO_NORTH_51_25 VDD ) ( IO_FILL_IO_NORTH_51_20 VDD ) ( IO_FILL_IO_NORTH_51_15 VDD ) ( IO_FILL_IO_NORTH_51_10 VDD ) ( IO_FILL_IO_NORTH_51_5 VDD )
-      ( IO_FILL_IO_NORTH_48_35 VDD ) ( IO_FILL_IO_NORTH_48_30 VDD ) ( IO_FILL_IO_NORTH_48_25 VDD ) ( IO_FILL_IO_NORTH_48_20 VDD ) ( IO_FILL_IO_NORTH_48_15 VDD ) ( IO_FILL_IO_NORTH_48_10 VDD ) ( IO_FILL_IO_NORTH_48_5 VDD ) ( IO_FILL_IO_NORTH_44_30 VDD )
-      ( IO_FILL_IO_NORTH_44_25 VDD ) ( IO_FILL_IO_NORTH_44_20 VDD ) ( IO_FILL_IO_NORTH_44_15 VDD ) ( IO_FILL_IO_NORTH_44_10 VDD ) ( IO_FILL_IO_NORTH_44_5 VDD ) ( IO_FILL_IO_NORTH_42_20 VDD ) ( IO_FILL_IO_NORTH_42_15 VDD ) ( IO_FILL_IO_NORTH_42_10 VDD )
-      ( IO_FILL_IO_NORTH_42_5 VDD ) ( IO_FILL_IO_NORTH_30_15 VDD ) ( IO_FILL_IO_NORTH_30_10 VDD ) ( IO_FILL_IO_NORTH_30_5 VDD ) ( IO_FILL_IO_NORTH_25_5 VDD ) ( IO_FILL_IO_NORTH_10_5 VDD ) ( IO_FILL_IO_NORTH_6_60 VDD ) ( IO_FILL_IO_NORTH_6_55 VDD )
-      ( IO_FILL_IO_NORTH_6_50 VDD ) ( IO_FILL_IO_NORTH_6_45 VDD ) ( IO_FILL_IO_NORTH_6_40 VDD ) ( IO_FILL_IO_NORTH_6_35 VDD ) ( IO_FILL_IO_NORTH_6_30 VDD ) ( IO_FILL_IO_NORTH_6_25 VDD ) ( IO_FILL_IO_NORTH_6_20 VDD ) ( IO_FILL_IO_NORTH_6_15 VDD )
-      ( IO_FILL_IO_NORTH_6_10 VDD ) ( IO_FILL_IO_NORTH_6_5 VDD ) ( IO_FILL_IO_NORTH_3_65 VDD ) ( IO_FILL_IO_NORTH_3_60 VDD ) ( IO_FILL_IO_NORTH_3_55 VDD ) ( IO_FILL_IO_NORTH_3_50 VDD ) ( IO_FILL_IO_NORTH_3_45 VDD ) ( IO_FILL_IO_NORTH_3_40 VDD )
-      ( IO_FILL_IO_NORTH_3_35 VDD ) ( IO_FILL_IO_NORTH_3_30 VDD ) ( IO_FILL_IO_NORTH_3_25 VDD ) ( IO_FILL_IO_NORTH_3_20 VDD ) ( IO_FILL_IO_NORTH_3_15 VDD ) ( IO_FILL_IO_NORTH_3_10 VDD ) ( IO_FILL_IO_NORTH_3_5 VDD ) ( IO_FILL_IO_NORTH_1_125 VDD )
-      ( IO_FILL_IO_NORTH_1_120 VDD ) ( IO_FILL_IO_NORTH_1_115 VDD ) ( IO_FILL_IO_NORTH_1_110 VDD ) ( IO_FILL_IO_NORTH_1_105 VDD ) ( IO_FILL_IO_NORTH_1_100 VDD ) ( IO_FILL_IO_NORTH_1_95 VDD ) ( IO_FILL_IO_NORTH_1_90 VDD ) ( IO_FILL_IO_NORTH_1_85 VDD )
-      ( IO_FILL_IO_NORTH_1_80 VDD ) ( IO_FILL_IO_NORTH_1_75 VDD ) ( IO_FILL_IO_NORTH_1_70 VDD ) ( IO_FILL_IO_NORTH_1_65 VDD ) ( IO_FILL_IO_NORTH_1_60 VDD ) ( IO_FILL_IO_NORTH_1_55 VDD ) ( IO_FILL_IO_NORTH_1_50 VDD ) ( IO_FILL_IO_NORTH_1_45 VDD )
-      ( IO_FILL_IO_NORTH_1_40 VDD ) ( IO_FILL_IO_NORTH_1_35 VDD ) ( IO_FILL_IO_NORTH_1_30 VDD ) ( IO_FILL_IO_NORTH_1_25 VDD ) ( IO_FILL_IO_NORTH_1_20 VDD ) ( IO_FILL_IO_NORTH_1_15 VDD ) ( IO_FILL_IO_NORTH_1_10 VDD ) ( IO_FILL_IO_NORTH_1_5 VDD )
-      ( IO_FILL_IO_NORTH_0_210 VDD ) ( IO_FILL_IO_NORTH_0_205 VDD ) ( IO_FILL_IO_NORTH_0_200 VDD ) ( IO_FILL_IO_NORTH_0_195 VDD ) ( IO_FILL_IO_NORTH_0_190 VDD ) ( IO_FILL_IO_NORTH_0_185 VDD ) ( IO_FILL_IO_NORTH_0_180 VDD ) ( IO_FILL_IO_NORTH_0_175 VDD )
-      ( IO_FILL_IO_NORTH_0_170 VDD ) ( IO_FILL_IO_NORTH_0_165 VDD ) ( IO_FILL_IO_NORTH_0_160 VDD ) ( IO_FILL_IO_NORTH_0_155 VDD ) ( IO_FILL_IO_NORTH_0_150 VDD ) ( IO_FILL_IO_NORTH_0_145 VDD ) ( IO_FILL_IO_NORTH_0_140 VDD ) ( IO_FILL_IO_NORTH_0_135 VDD )
-      ( IO_FILL_IO_NORTH_0_130 VDD ) ( IO_FILL_IO_NORTH_0_125 VDD ) ( IO_FILL_IO_NORTH_0_120 VDD ) ( IO_FILL_IO_NORTH_0_115 VDD ) ( IO_FILL_IO_NORTH_0_110 VDD ) ( IO_FILL_IO_NORTH_0_105 VDD ) ( IO_FILL_IO_NORTH_0_100 VDD ) ( IO_FILL_IO_NORTH_0_95 VDD )
-      ( IO_FILL_IO_NORTH_0_90 VDD ) ( IO_FILL_IO_NORTH_0_85 VDD ) ( IO_FILL_IO_NORTH_0_80 VDD ) ( IO_FILL_IO_NORTH_0_75 VDD ) ( IO_FILL_IO_NORTH_0_70 VDD ) ( IO_FILL_IO_NORTH_0_65 VDD ) ( IO_FILL_IO_NORTH_0_60 VDD ) ( IO_FILL_IO_NORTH_0_55 VDD )
-      ( IO_FILL_IO_NORTH_0_50 VDD ) ( IO_FILL_IO_NORTH_0_45 VDD ) ( IO_FILL_IO_NORTH_0_40 VDD ) ( IO_FILL_IO_NORTH_0_35 VDD ) ( IO_FILL_IO_NORTH_0_30 VDD ) ( IO_FILL_IO_NORTH_0_25 VDD ) ( IO_FILL_IO_NORTH_0_20 VDD ) ( IO_FILL_IO_NORTH_0_15 VDD )
-      ( IO_FILL_IO_NORTH_0_10 VDD ) ( IO_FILL_IO_NORTH_0_5 VDD ) ( IO_FILL_IO_NORTH_0_0 VDD ) ( IO_FILL_IO_NORTH_1_130 VDD ) ( IO_FILL_IO_NORTH_10_0 VDD ) ( IO_FILL_IO_NORTH_15_5 VDD ) ( IO_FILL_IO_NORTH_53_100 VDD ) ( IO_FILL_IO_NORTH_37_0 VDD )
-      ( IO_FILL_IO_NORTH_48_40 VDD ) ( IO_FILL_IO_NORTH_6_0 VDD ) ( IO_FILL_IO_NORTH_22_0 VDD ) ( IO_FILL_IO_NORTH_30_20 VDD ) ( IO_FILL_IO_NORTH_37_5 VDD ) ( IO_FILL_IO_NORTH_49_0 VDD ) ( IO_FILL_IO_NORTH_6_65 VDD ) ( IO_FILL_IO_NORTH_23_0 VDD )
-      ( IO_FILL_IO_NORTH_1_0 VDD ) ( IO_FILL_IO_NORTH_0_215 VDD ) ( IO_FILL_IO_NORTH_9_0 VDD ) ( IO_FILL_IO_NORTH_15_0 VDD ) ( IO_FILL_IO_NORTH_21_0 VDD ) ( IO_FILL_IO_NORTH_20_5 VDD ) ( IO_FILL_IO_NORTH_26_5 VDD ) ( IO_FILL_IO_NORTH_35_0 VDD )
-      ( IO_FILL_IO_NORTH_34_0 VDD ) ( IO_FILL_IO_NORTH_45_0 VDD ) ( IO_FILL_IO_NORTH_44_35 VDD ) ( IO_FILL_IO_NORTH_53_0 VDD ) ( IO_FILL_IO_NORTH_36_0 VDD ) ( IO_FILL_IO_NORTH_35_5 VDD ) ( IO_FILL_IO_NORTH_33_0 VDD ) ( IO_FILL_IO_NORTH_32_5 VDD )
-      ( IO_FILL_IO_NORTH_32_0 VDD ) ( IO_FILL_IO_NORTH_31_0 VDD ) ( IO_FILL_IO_NORTH_39_0 VDD ) ( IO_FILL_IO_NORTH_38_0 VDD ) ( IO_FILL_IO_NORTH_14_0 VDD ) ( IO_FILL_IO_NORTH_13_0 VDD ) ( IO_FILL_IO_NORTH_12_5 VDD ) ( IO_FILL_IO_NORTH_12_0 VDD )
-      ( IO_FILL_IO_NORTH_20_0 VDD ) ( IO_FILL_IO_NORTH_19_0 VDD ) ( IO_FILL_IO_NORTH_18_5 VDD ) ( IO_FILL_IO_NORTH_18_0 VDD ) ( IO_FILL_IO_NORTH_17_0 VDD ) ( IO_FILL_IO_NORTH_16_0 VDD ) ( IO_FILL_IO_NORTH_11_0 VDD ) ( IO_FILL_IO_NORTH_10_10 VDD )
-      ( IO_FILL_IO_NORTH_8_0 VDD ) ( IO_FILL_IO_NORTH_7_0 VDD ) ( IO_FILL_IO_NORTH_5_0 VDD ) ( IO_FILL_IO_NORTH_4_5 VDD ) ( IO_FILL_IO_NORTH_4_0 VDD ) ( IO_FILL_IO_NORTH_3_70 VDD ) ( IO_FILL_IO_NORTH_3_0 VDD ) ( IO_FILL_IO_NORTH_2_0 VDD )
-      ( IO_FILL_IO_NORTH_30_0 VDD ) ( IO_FILL_IO_NORTH_29_0 VDD ) ( IO_FILL_IO_NORTH_28_0 VDD ) ( IO_FILL_IO_NORTH_27_0 VDD ) ( IO_FILL_IO_NORTH_26_0 VDD ) ( IO_FILL_IO_NORTH_25_10 VDD ) ( IO_FILL_IO_NORTH_25_0 VDD ) ( IO_FILL_IO_NORTH_24_0 VDD )
-      ( IO_FILL_IO_NORTH_48_0 VDD ) ( IO_FILL_IO_NORTH_47_0 VDD ) ( IO_FILL_IO_NORTH_46_0 VDD ) ( IO_FILL_IO_NORTH_44_0 VDD ) ( IO_FILL_IO_NORTH_52_0 VDD ) ( IO_FILL_IO_NORTH_51_100 VDD ) ( IO_FILL_IO_NORTH_51_0 VDD ) ( IO_FILL_IO_NORTH_50_0 VDD )
-      ( IO_FILL_IO_NORTH_43_0 VDD ) ( IO_FILL_IO_NORTH_42_25 VDD ) ( IO_FILL_IO_NORTH_42_0 VDD ) ( IO_FILL_IO_NORTH_41_0 VDD ) ( IO_FILL_IO_NORTH_40_0 VDD ) ( IO_FILL_IO_NORTH_39_5 VDD ) ( IO_FILL_IO_EAST_60_185 VDD ) ( IO_FILL_IO_EAST_60_190 VDD )
-      ( IO_CORNER_NORTH_EAST_INST VDD ) ( IO_FILL_IO_NORTH_54_0 VDD ) ( IO_CORNER_NORTH_WEST_INST VDD ) ( IO_FILL_IO_WEST_57_0 VDD ) ( u_v18_33 VDD ) ( u_vzz_33 VDD ) ( u_brk0 VDD ) ( u_vdd_0 VDD )
-      ( u_v18_0 VDD ) ( u_vzz_9 VDD ) ( u_vzz_8 VDD ) ( u_vzz_7 VDD ) ( u_vzz_6 VDD ) ( u_vzz_5 VDD ) ( u_vzz_4 VDD ) ( u_vzz_32 VDD )
-      ( u_vzz_31 VDD ) ( u_vzz_30 VDD ) ( u_vzz_3 VDD ) ( u_vzz_29 VDD ) ( u_vzz_28 VDD ) ( u_vzz_27 VDD ) ( u_vzz_26 VDD ) ( u_vzz_25 VDD )
-      ( u_vzz_24 VDD ) ( u_vzz_23 VDD ) ( u_vzz_22 VDD ) ( u_vzz_21 VDD ) ( u_vzz_20 VDD ) ( u_vzz_2 VDD ) ( u_vzz_19 VDD ) ( u_vzz_18 VDD )
-      ( u_vzz_17 VDD ) ( u_vzz_16 VDD ) ( u_vzz_15 VDD ) ( u_vzz_14 VDD ) ( u_vzz_13 VDD ) ( u_vzz_12 VDD ) ( u_vzz_11 VDD ) ( u_vzz_10 VDD )
-      ( u_vzz_1 VDD ) ( u_vzz_0 VDD ) ( u_vss_pll VDD ) ( u_vss_9 VDD ) ( u_vss_8 VDD ) ( u_vss_7 VDD ) ( u_vss_6 VDD ) ( u_vss_5 VDD )
-      ( u_vss_4 VDD ) ( u_vss_32 VDD ) ( u_vss_31 VDD ) ( u_vss_30 VDD ) ( u_vss_3 VDD ) ( u_vss_29 VDD ) ( u_vss_28 VDD ) ( u_vss_27 VDD )
-      ( u_vss_26 VDD ) ( u_vss_25 VDD ) ( u_vss_24 VDD ) ( u_vss_23 VDD ) ( u_vss_22 VDD ) ( u_vss_21 VDD ) ( u_vss_20 VDD ) ( u_vss_2 VDD )
-      ( u_vss_19 VDD ) ( u_vss_18 VDD ) ( u_vss_17 VDD ) ( u_vss_16 VDD ) ( u_vss_15 VDD ) ( u_vss_14 VDD ) ( u_vss_13 VDD ) ( u_vss_12 VDD )
-      ( u_vss_11 VDD ) ( u_vss_10 VDD ) ( u_vss_1 VDD ) ( u_vss_0 VDD ) ( u_vdd_pll VDD ) ( u_vdd_9 VDD ) ( u_vdd_8 VDD ) ( u_vdd_7 VDD )
-      ( u_vdd_6 VDD ) ( u_vdd_5 VDD ) ( u_vdd_4 VDD ) ( u_vdd_32 VDD ) ( u_vdd_31 VDD ) ( u_vdd_30 VDD ) ( u_vdd_3 VDD ) ( u_vdd_29 VDD )
-      ( u_vdd_28 VDD ) ( u_vdd_27 VDD ) ( u_vdd_26 VDD ) ( u_vdd_25 VDD ) ( u_vdd_24 VDD ) ( u_vdd_23 VDD ) ( u_vdd_22 VDD ) ( u_vdd_21 VDD )
-      ( u_vdd_20 VDD ) ( u_vdd_2 VDD ) ( u_vdd_19 VDD ) ( u_vdd_18 VDD ) ( u_vdd_17 VDD ) ( u_vdd_16 VDD ) ( u_vdd_15 VDD ) ( u_vdd_14 VDD )
-      ( u_vdd_13 VDD ) ( u_vdd_12 VDD ) ( u_vdd_11 VDD ) ( u_vdd_10 VDD ) ( u_vdd_1 VDD ) ( u_v18_9 VDD ) ( u_v18_8 VDD ) ( u_v18_7 VDD )
-      ( u_v18_6 VDD ) ( u_v18_5 VDD ) ( u_v18_4 VDD ) ( u_v18_32 VDD ) ( u_v18_31 VDD ) ( u_v18_30 VDD ) ( u_v18_3 VDD ) ( u_v18_29 VDD )
-      ( u_v18_28 VDD ) ( u_v18_27 VDD ) ( u_v18_26 VDD ) ( u_v18_25 VDD ) ( u_v18_24 VDD ) ( u_v18_23 VDD ) ( u_v18_22 VDD ) ( u_v18_21 VDD )
-      ( u_v18_20 VDD ) ( u_v18_2 VDD ) ( u_v18_19 VDD ) ( u_v18_18 VDD ) ( u_v18_17 VDD ) ( u_v18_16 VDD ) ( u_v18_15 VDD ) ( u_v18_14 VDD )
-      ( u_v18_13 VDD ) ( u_v18_12 VDD ) ( u_v18_11 VDD ) ( u_v18_10 VDD ) ( u_v18_1 VDD ) ( u_sel_2_i VDD ) ( u_sel_1_i VDD ) ( u_sel_0_i VDD )
-      ( u_misc_o VDD ) ( u_ddr_we_n_o VDD ) ( u_ddr_reset_n_o VDD ) ( u_ddr_ras_n_o VDD ) ( u_ddr_odt_o VDD ) ( u_ddr_dqs_p_3_io VDD ) ( u_ddr_dqs_p_2_io VDD ) ( u_ddr_dqs_p_1_io VDD )
-      ( u_ddr_dqs_p_0_io VDD ) ( u_ddr_dqs_n_3_io VDD ) ( u_ddr_dqs_n_2_io VDD ) ( u_ddr_dqs_n_1_io VDD ) ( u_ddr_dqs_n_0_io VDD ) ( u_ddr_dq_9_io VDD ) ( u_ddr_dq_8_io VDD ) ( u_ddr_dq_7_io VDD )
-      ( u_ddr_dq_6_io VDD ) ( u_ddr_dq_5_io VDD ) ( u_ddr_dq_4_io VDD ) ( u_ddr_dq_3_io VDD ) ( u_ddr_dq_31_io VDD ) ( u_ddr_dq_30_io VDD ) ( u_ddr_dq_2_io VDD ) ( u_ddr_dq_29_io VDD )
-      ( u_ddr_dq_28_io VDD ) ( u_ddr_dq_27_io VDD ) ( u_ddr_dq_26_io VDD ) ( u_ddr_dq_25_io VDD ) ( u_ddr_dq_24_io VDD ) ( u_ddr_dq_23_io VDD ) ( u_ddr_dq_22_io VDD ) ( u_ddr_dq_21_io VDD )
-      ( u_ddr_dq_20_io VDD ) ( u_ddr_dq_1_io VDD ) ( u_ddr_dq_19_io VDD ) ( u_ddr_dq_18_io VDD ) ( u_ddr_dq_17_io VDD ) ( u_ddr_dq_16_io VDD ) ( u_ddr_dq_15_io VDD ) ( u_ddr_dq_14_io VDD )
-      ( u_ddr_dq_13_io VDD ) ( u_ddr_dq_12_io VDD ) ( u_ddr_dq_11_io VDD ) ( u_ddr_dq_10_io VDD ) ( u_ddr_dq_0_io VDD ) ( u_ddr_dm_3_o VDD ) ( u_ddr_dm_2_o VDD ) ( u_ddr_dm_1_o VDD )
-      ( u_ddr_dm_0_o VDD ) ( u_ddr_cs_n_o VDD ) ( u_ddr_cke_o VDD ) ( u_ddr_ck_p_o VDD ) ( u_ddr_ck_n_o VDD ) ( u_ddr_cas_n_o VDD ) ( u_ddr_ba_2_o VDD ) ( u_ddr_ba_1_o VDD )
-      ( u_ddr_ba_0_o VDD ) ( u_ddr_addr_9_o VDD ) ( u_ddr_addr_8_o VDD ) ( u_ddr_addr_7_o VDD ) ( u_ddr_addr_6_o VDD ) ( u_ddr_addr_5_o VDD ) ( u_ddr_addr_4_o VDD ) ( u_ddr_addr_3_o VDD )
-      ( u_ddr_addr_2_o VDD ) ( u_ddr_addr_1_o VDD ) ( u_ddr_addr_15_o VDD ) ( u_ddr_addr_14_o VDD ) ( u_ddr_addr_13_o VDD ) ( u_ddr_addr_12_o VDD ) ( u_ddr_addr_11_o VDD ) ( u_ddr_addr_10_o VDD )
-      ( u_ddr_addr_0_o VDD ) ( u_core_async_reset_i VDD ) ( u_co_v_i VDD ) ( u_co_tkn_o VDD ) ( u_co_clk_i VDD ) ( u_co_8_i VDD ) ( u_co_7_i VDD ) ( u_co_6_i VDD )
-      ( u_co_5_i VDD ) ( u_co_4_i VDD ) ( u_co_3_i VDD ) ( u_co_2_i VDD ) ( u_co_1_i VDD ) ( u_co_0_i VDD ) ( u_co2_v_o VDD ) ( u_co2_tkn_i VDD )
-      ( u_co2_clk_o VDD ) ( u_co2_8_o VDD ) ( u_co2_7_o VDD ) ( u_co2_6_o VDD ) ( u_co2_5_o VDD ) ( u_co2_4_o VDD ) ( u_co2_3_o VDD ) ( u_co2_2_o VDD )
-      ( u_co2_1_o VDD ) ( u_co2_0_o VDD ) ( u_clk_o VDD ) ( u_clk_async_reset_i VDD ) ( u_clk_C_i VDD ) ( u_clk_B_i VDD ) ( u_clk_A_i VDD ) ( u_ci_v_i VDD )
-      ( u_ci_tkn_o VDD ) ( u_ci_clk_i VDD ) ( u_ci_8_i VDD ) ( u_ci_7_i VDD ) ( u_ci_6_i VDD ) ( u_ci_5_i VDD ) ( u_ci_4_i VDD ) ( u_ci_3_i VDD )
-      ( u_ci_2_i VDD ) ( u_ci_1_i VDD ) ( u_ci_0_i VDD ) ( u_ci2_v_o VDD ) ( u_ci2_tkn_i VDD ) ( u_ci2_clk_o VDD ) ( u_ci2_8_o VDD ) ( u_ci2_7_o VDD )
-      ( u_ci2_6_o VDD ) ( u_ci2_5_o VDD ) ( u_ci2_4_o VDD ) ( u_ci2_3_o VDD ) ( u_ci2_2_o VDD ) ( u_ci2_1_o VDD ) ( u_ci2_0_o VDD ) ( u_bsg_tag_en_i VDD )
-      ( u_bsg_tag_data_o VDD ) ( u_bsg_tag_data_i VDD ) ( u_bsg_tag_clk_o VDD ) ( u_bsg_tag_clk_i VDD ) + USE POWER ;
-    - VSS ( PIN VSS ) ( IO_FILL_IO_WEST_0_485 VSS ) ( IO_FILL_IO_WEST_0_480 VSS ) ( IO_FILL_IO_WEST_0_475 VSS ) ( IO_FILL_IO_WEST_0_470 VSS ) ( IO_FILL_IO_WEST_0_465 VSS ) ( IO_FILL_IO_WEST_0_460 VSS )
-      ( IO_FILL_IO_WEST_0_455 VSS ) ( IO_FILL_IO_WEST_0_450 VSS ) ( IO_FILL_IO_WEST_0_445 VSS ) ( IO_FILL_IO_WEST_0_440 VSS ) ( IO_FILL_IO_WEST_0_435 VSS ) ( IO_FILL_IO_WEST_0_430 VSS ) ( IO_FILL_IO_WEST_0_425 VSS ) ( IO_FILL_IO_WEST_0_420 VSS )
-      ( IO_FILL_IO_WEST_0_415 VSS ) ( IO_FILL_IO_WEST_0_410 VSS ) ( IO_FILL_IO_WEST_0_405 VSS ) ( IO_FILL_IO_WEST_0_400 VSS ) ( IO_FILL_IO_WEST_0_395 VSS ) ( IO_FILL_IO_WEST_0_390 VSS ) ( IO_FILL_IO_WEST_0_385 VSS ) ( IO_FILL_IO_WEST_0_380 VSS )
-      ( IO_FILL_IO_WEST_0_375 VSS ) ( IO_FILL_IO_WEST_0_370 VSS ) ( IO_FILL_IO_WEST_0_365 VSS ) ( IO_FILL_IO_WEST_0_360 VSS ) ( IO_FILL_IO_WEST_0_355 VSS ) ( IO_FILL_IO_WEST_0_350 VSS ) ( IO_FILL_IO_WEST_0_345 VSS ) ( IO_FILL_IO_WEST_0_340 VSS )
-      ( IO_FILL_IO_WEST_0_335 VSS ) ( IO_FILL_IO_WEST_0_330 VSS ) ( IO_FILL_IO_WEST_0_325 VSS ) ( IO_FILL_IO_WEST_0_320 VSS ) ( IO_FILL_IO_WEST_0_315 VSS ) ( IO_FILL_IO_WEST_0_310 VSS ) ( IO_FILL_IO_WEST_0_305 VSS ) ( IO_FILL_IO_WEST_0_300 VSS )
-      ( IO_FILL_IO_WEST_0_295 VSS ) ( IO_FILL_IO_WEST_0_290 VSS ) ( IO_FILL_IO_WEST_0_285 VSS ) ( IO_FILL_IO_WEST_0_280 VSS ) ( IO_FILL_IO_WEST_0_275 VSS ) ( IO_FILL_IO_WEST_0_270 VSS ) ( IO_FILL_IO_WEST_0_265 VSS ) ( IO_FILL_IO_WEST_0_260 VSS )
-      ( IO_FILL_IO_WEST_0_255 VSS ) ( IO_FILL_IO_WEST_0_250 VSS ) ( IO_FILL_IO_WEST_0_245 VSS ) ( IO_FILL_IO_WEST_0_240 VSS ) ( IO_FILL_IO_WEST_0_235 VSS ) ( IO_FILL_IO_WEST_0_230 VSS ) ( IO_FILL_IO_WEST_0_225 VSS ) ( IO_FILL_IO_WEST_0_220 VSS )
-      ( IO_FILL_IO_WEST_0_215 VSS ) ( IO_FILL_IO_WEST_0_210 VSS ) ( IO_FILL_IO_WEST_0_205 VSS ) ( IO_FILL_IO_WEST_0_200 VSS ) ( IO_FILL_IO_WEST_0_195 VSS ) ( IO_FILL_IO_WEST_0_190 VSS ) ( IO_FILL_IO_WEST_0_185 VSS ) ( IO_FILL_IO_WEST_0_180 VSS )
-      ( IO_FILL_IO_WEST_0_175 VSS ) ( IO_FILL_IO_WEST_0_170 VSS ) ( IO_FILL_IO_WEST_0_165 VSS ) ( IO_FILL_IO_WEST_0_160 VSS ) ( IO_FILL_IO_WEST_0_155 VSS ) ( IO_FILL_IO_WEST_0_150 VSS ) ( IO_FILL_IO_WEST_0_145 VSS ) ( IO_FILL_IO_WEST_0_140 VSS )
-      ( IO_FILL_IO_WEST_0_135 VSS ) ( IO_FILL_IO_WEST_0_130 VSS ) ( IO_FILL_IO_WEST_0_125 VSS ) ( IO_FILL_IO_WEST_0_120 VSS ) ( IO_FILL_IO_WEST_0_115 VSS ) ( IO_FILL_IO_WEST_0_110 VSS ) ( IO_FILL_IO_WEST_0_105 VSS ) ( IO_FILL_IO_WEST_0_100 VSS )
-      ( IO_FILL_IO_WEST_0_95 VSS ) ( IO_FILL_IO_WEST_0_90 VSS ) ( IO_FILL_IO_WEST_0_85 VSS ) ( IO_FILL_IO_WEST_0_80 VSS ) ( IO_FILL_IO_WEST_0_75 VSS ) ( IO_FILL_IO_WEST_0_70 VSS ) ( IO_FILL_IO_WEST_0_65 VSS ) ( IO_FILL_IO_WEST_0_60 VSS )
-      ( IO_FILL_IO_WEST_0_55 VSS ) ( IO_FILL_IO_WEST_0_50 VSS ) ( IO_FILL_IO_WEST_0_45 VSS ) ( IO_FILL_IO_WEST_0_40 VSS ) ( IO_FILL_IO_WEST_0_35 VSS ) ( IO_FILL_IO_WEST_0_30 VSS ) ( IO_FILL_IO_WEST_0_25 VSS ) ( IO_FILL_IO_WEST_0_20 VSS )
-      ( IO_FILL_IO_WEST_0_15 VSS ) ( IO_FILL_IO_WEST_0_10 VSS ) ( IO_FILL_IO_WEST_0_5 VSS ) ( IO_FILL_IO_WEST_0_0 VSS ) ( IO_CORNER_SOUTH_WEST_INST VSS ) ( IO_FILL_IO_SOUTH_0_0 VSS ) ( IO_FILL_IO_SOUTH_0_5 VSS ) ( IO_FILL_IO_WEST_0_490 VSS )
-      ( IO_FILL_IO_SOUTH_0_10 VSS ) ( IO_FILL_IO_WEST_0_495 VSS ) ( IO_FILL_IO_SOUTH_0_15 VSS ) ( IO_FILL_IO_EAST_0_15 VSS ) ( IO_FILL_IO_EAST_0_10 VSS ) ( IO_FILL_IO_EAST_0_5 VSS ) ( IO_FILL_IO_EAST_0_0 VSS ) ( IO_CORNER_SOUTH_EAST_INST VSS )
-      ( IO_FILL_IO_WEST_56_90 VSS ) ( IO_FILL_IO_WEST_56_85 VSS ) ( IO_FILL_IO_WEST_56_80 VSS ) ( IO_FILL_IO_WEST_56_75 VSS ) ( IO_FILL_IO_WEST_56_70 VSS ) ( IO_FILL_IO_WEST_56_65 VSS ) ( IO_FILL_IO_WEST_56_60 VSS ) ( IO_FILL_IO_WEST_56_55 VSS )
-      ( IO_FILL_IO_WEST_56_50 VSS ) ( IO_FILL_IO_WEST_56_45 VSS ) ( IO_FILL_IO_WEST_56_40 VSS ) ( IO_FILL_IO_WEST_56_35 VSS ) ( IO_FILL_IO_WEST_56_30 VSS ) ( IO_FILL_IO_WEST_56_25 VSS ) ( IO_FILL_IO_WEST_56_20 VSS ) ( IO_FILL_IO_WEST_56_15 VSS )
-      ( IO_FILL_IO_WEST_56_10 VSS ) ( IO_FILL_IO_WEST_56_5 VSS ) ( IO_FILL_IO_WEST_54_95 VSS ) ( IO_FILL_IO_WEST_54_90 VSS ) ( IO_FILL_IO_WEST_54_85 VSS ) ( IO_FILL_IO_WEST_54_80 VSS ) ( IO_FILL_IO_WEST_54_75 VSS ) ( IO_FILL_IO_WEST_54_70 VSS )
-      ( IO_FILL_IO_WEST_54_65 VSS ) ( IO_FILL_IO_WEST_54_60 VSS ) ( IO_FILL_IO_WEST_54_55 VSS ) ( IO_FILL_IO_WEST_54_50 VSS ) ( IO_FILL_IO_WEST_54_45 VSS ) ( IO_FILL_IO_WEST_54_40 VSS ) ( IO_FILL_IO_WEST_54_35 VSS ) ( IO_FILL_IO_WEST_54_30 VSS )
-      ( IO_FILL_IO_WEST_54_25 VSS ) ( IO_FILL_IO_WEST_54_20 VSS ) ( IO_FILL_IO_WEST_54_15 VSS ) ( IO_FILL_IO_WEST_54_10 VSS ) ( IO_FILL_IO_WEST_54_5 VSS ) ( IO_FILL_IO_WEST_51_25 VSS ) ( IO_FILL_IO_WEST_51_20 VSS ) ( IO_FILL_IO_WEST_51_15 VSS )
-      ( IO_FILL_IO_WEST_51_10 VSS ) ( IO_FILL_IO_WEST_51_5 VSS ) ( IO_FILL_IO_WEST_47_45 VSS ) ( IO_FILL_IO_WEST_47_40 VSS ) ( IO_FILL_IO_WEST_47_35 VSS ) ( IO_FILL_IO_WEST_47_30 VSS ) ( IO_FILL_IO_WEST_47_25 VSS ) ( IO_FILL_IO_WEST_47_20 VSS )
-      ( IO_FILL_IO_WEST_47_15 VSS ) ( IO_FILL_IO_WEST_47_10 VSS ) ( IO_FILL_IO_WEST_47_5 VSS ) ( IO_FILL_IO_WEST_32_5 VSS ) ( IO_FILL_IO_WEST_27_5 VSS ) ( IO_FILL_IO_WEST_12_5 VSS ) ( IO_FILL_IO_WEST_7_5 VSS ) ( IO_FILL_IO_WEST_3_65 VSS )
-      ( IO_FILL_IO_WEST_3_60 VSS ) ( IO_FILL_IO_WEST_3_55 VSS ) ( IO_FILL_IO_WEST_3_50 VSS ) ( IO_FILL_IO_WEST_3_45 VSS ) ( IO_FILL_IO_WEST_3_40 VSS ) ( IO_FILL_IO_WEST_3_35 VSS ) ( IO_FILL_IO_WEST_3_30 VSS ) ( IO_FILL_IO_WEST_3_25 VSS )
-      ( IO_FILL_IO_WEST_3_20 VSS ) ( IO_FILL_IO_WEST_3_15 VSS ) ( IO_FILL_IO_WEST_3_10 VSS ) ( IO_FILL_IO_WEST_3_5 VSS ) ( IO_FILL_IO_WEST_0_500 VSS ) ( IO_FILL_IO_WEST_0_505 VSS ) ( IO_FILL_IO_WEST_1_0 VSS ) ( IO_FILL_IO_WEST_17_0 VSS )
-      ( IO_FILL_IO_WEST_51_0 VSS ) ( IO_FILL_IO_WEST_3_0 VSS ) ( IO_FILL_IO_WEST_2_0 VSS ) ( IO_FILL_IO_WEST_19_5 VSS ) ( IO_FILL_IO_WEST_51_30 VSS ) ( IO_FILL_IO_WEST_3_70 VSS ) ( IO_FILL_IO_WEST_20_0 VSS ) ( IO_FILL_IO_WEST_35_0 VSS )
-      ( IO_FILL_IO_WEST_52_0 VSS ) ( IO_FILL_IO_WEST_10_0 VSS ) ( IO_FILL_IO_WEST_16_0 VSS ) ( IO_FILL_IO_WEST_24_0 VSS ) ( IO_FILL_IO_WEST_30_0 VSS ) ( IO_FILL_IO_WEST_38_0 VSS ) ( IO_FILL_IO_WEST_37_5 VSS ) ( IO_FILL_IO_WEST_44_0 VSS )
-      ( IO_FILL_IO_WEST_50_0 VSS ) ( IO_FILL_IO_WEST_15_0 VSS ) ( IO_FILL_IO_WEST_17_5 VSS ) ( IO_FILL_IO_WEST_5_0 VSS ) ( IO_FILL_IO_WEST_4_0 VSS ) ( IO_FILL_IO_WEST_33_0 VSS ) ( IO_FILL_IO_WEST_32_10 VSS ) ( IO_FILL_IO_WEST_32_0 VSS )
-      ( IO_FILL_IO_WEST_31_0 VSS ) ( IO_FILL_IO_WEST_29_0 VSS ) ( IO_FILL_IO_WEST_28_0 VSS ) ( IO_FILL_IO_WEST_27_10 VSS ) ( IO_FILL_IO_WEST_27_0 VSS ) ( IO_FILL_IO_WEST_26_0 VSS ) ( IO_FILL_IO_WEST_25_0 VSS ) ( IO_FILL_IO_WEST_23_0 VSS )
-      ( IO_FILL_IO_WEST_22_5 VSS ) ( IO_FILL_IO_WEST_14_0 VSS ) ( IO_FILL_IO_WEST_13_5 VSS ) ( IO_FILL_IO_WEST_13_0 VSS ) ( IO_FILL_IO_WEST_12_10 VSS ) ( IO_FILL_IO_WEST_12_0 VSS ) ( IO_FILL_IO_WEST_11_0 VSS ) ( IO_FILL_IO_WEST_9_0 VSS )
-      ( IO_FILL_IO_WEST_8_0 VSS ) ( IO_FILL_IO_WEST_7_10 VSS ) ( IO_FILL_IO_WEST_7_0 VSS ) ( IO_FILL_IO_WEST_6_0 VSS ) ( IO_FILL_IO_WEST_22_0 VSS ) ( IO_FILL_IO_WEST_21_0 VSS ) ( IO_FILL_IO_WEST_19_0 VSS ) ( IO_FILL_IO_WEST_18_0 VSS )
-      ( IO_FILL_IO_WEST_49_0 VSS ) ( IO_FILL_IO_WEST_48_0 VSS ) ( IO_FILL_IO_WEST_47_50 VSS ) ( IO_FILL_IO_WEST_47_0 VSS ) ( IO_FILL_IO_WEST_56_95 VSS ) ( IO_FILL_IO_WEST_56_0 VSS ) ( IO_FILL_IO_WEST_55_5 VSS ) ( IO_FILL_IO_WEST_55_0 VSS )
-      ( IO_FILL_IO_WEST_54_100 VSS ) ( IO_FILL_IO_WEST_54_0 VSS ) ( IO_FILL_IO_WEST_53_0 VSS ) ( IO_FILL_IO_WEST_46_0 VSS ) ( IO_FILL_IO_WEST_45_0 VSS ) ( IO_FILL_IO_WEST_43_0 VSS ) ( IO_FILL_IO_WEST_42_5 VSS ) ( IO_FILL_IO_WEST_42_0 VSS )
-      ( IO_FILL_IO_WEST_41_5 VSS ) ( IO_FILL_IO_WEST_41_0 VSS ) ( IO_FILL_IO_WEST_40_0 VSS ) ( IO_FILL_IO_WEST_39_0 VSS ) ( IO_FILL_IO_WEST_34_0 VSS ) ( IO_FILL_IO_WEST_33_5 VSS ) ( IO_FILL_IO_WEST_37_0 VSS ) ( IO_FILL_IO_WEST_36_0 VSS )
-      ( IO_FILL_IO_SOUTH_60_190 VSS ) ( IO_FILL_IO_SOUTH_60_185 VSS ) ( IO_FILL_IO_SOUTH_60_180 VSS ) ( IO_FILL_IO_SOUTH_60_175 VSS ) ( IO_FILL_IO_SOUTH_60_170 VSS ) ( IO_FILL_IO_SOUTH_60_165 VSS ) ( IO_FILL_IO_SOUTH_60_160 VSS ) ( IO_FILL_IO_SOUTH_60_155 VSS )
-      ( IO_FILL_IO_SOUTH_60_150 VSS ) ( IO_FILL_IO_SOUTH_60_145 VSS ) ( IO_FILL_IO_SOUTH_60_140 VSS ) ( IO_FILL_IO_SOUTH_60_135 VSS ) ( IO_FILL_IO_SOUTH_60_130 VSS ) ( IO_FILL_IO_SOUTH_60_125 VSS ) ( IO_FILL_IO_SOUTH_60_120 VSS ) ( IO_FILL_IO_SOUTH_60_115 VSS )
-      ( IO_FILL_IO_SOUTH_60_110 VSS ) ( IO_FILL_IO_SOUTH_60_105 VSS ) ( IO_FILL_IO_SOUTH_60_100 VSS ) ( IO_FILL_IO_SOUTH_60_95 VSS ) ( IO_FILL_IO_SOUTH_60_90 VSS ) ( IO_FILL_IO_SOUTH_60_85 VSS ) ( IO_FILL_IO_SOUTH_60_80 VSS ) ( IO_FILL_IO_SOUTH_60_75 VSS )
-      ( IO_FILL_IO_SOUTH_60_70 VSS ) ( IO_FILL_IO_SOUTH_60_65 VSS ) ( IO_FILL_IO_SOUTH_60_60 VSS ) ( IO_FILL_IO_SOUTH_60_55 VSS ) ( IO_FILL_IO_SOUTH_60_50 VSS ) ( IO_FILL_IO_SOUTH_60_45 VSS ) ( IO_FILL_IO_SOUTH_60_40 VSS ) ( IO_FILL_IO_SOUTH_60_35 VSS )
-      ( IO_FILL_IO_SOUTH_60_30 VSS ) ( IO_FILL_IO_SOUTH_60_25 VSS ) ( IO_FILL_IO_SOUTH_60_20 VSS ) ( IO_FILL_IO_SOUTH_60_15 VSS ) ( IO_FILL_IO_SOUTH_60_10 VSS ) ( IO_FILL_IO_SOUTH_60_5 VSS ) ( IO_FILL_IO_SOUTH_59_125 VSS ) ( IO_FILL_IO_SOUTH_59_120 VSS )
-      ( IO_FILL_IO_SOUTH_59_115 VSS ) ( IO_FILL_IO_SOUTH_59_110 VSS ) ( IO_FILL_IO_SOUTH_59_105 VSS ) ( IO_FILL_IO_SOUTH_59_100 VSS ) ( IO_FILL_IO_SOUTH_59_95 VSS ) ( IO_FILL_IO_SOUTH_59_90 VSS ) ( IO_FILL_IO_SOUTH_59_85 VSS ) ( IO_FILL_IO_SOUTH_59_80 VSS )
-      ( IO_FILL_IO_SOUTH_59_75 VSS ) ( IO_FILL_IO_SOUTH_59_70 VSS ) ( IO_FILL_IO_SOUTH_59_65 VSS ) ( IO_FILL_IO_SOUTH_59_60 VSS ) ( IO_FILL_IO_SOUTH_59_55 VSS ) ( IO_FILL_IO_SOUTH_59_50 VSS ) ( IO_FILL_IO_SOUTH_59_45 VSS ) ( IO_FILL_IO_SOUTH_59_40 VSS )
-      ( IO_FILL_IO_SOUTH_59_35 VSS ) ( IO_FILL_IO_SOUTH_59_30 VSS ) ( IO_FILL_IO_SOUTH_59_25 VSS ) ( IO_FILL_IO_SOUTH_59_20 VSS ) ( IO_FILL_IO_SOUTH_59_15 VSS ) ( IO_FILL_IO_SOUTH_59_10 VSS ) ( IO_FILL_IO_SOUTH_59_5 VSS ) ( IO_FILL_IO_SOUTH_57_60 VSS )
-      ( IO_FILL_IO_SOUTH_57_55 VSS ) ( IO_FILL_IO_SOUTH_57_50 VSS ) ( IO_FILL_IO_SOUTH_57_45 VSS ) ( IO_FILL_IO_SOUTH_57_40 VSS ) ( IO_FILL_IO_SOUTH_57_35 VSS ) ( IO_FILL_IO_SOUTH_57_30 VSS ) ( IO_FILL_IO_SOUTH_57_25 VSS ) ( IO_FILL_IO_SOUTH_57_20 VSS )
-      ( IO_FILL_IO_SOUTH_57_15 VSS ) ( IO_FILL_IO_SOUTH_57_10 VSS ) ( IO_FILL_IO_SOUTH_57_5 VSS ) ( IO_FILL_IO_SOUTH_54_65 VSS ) ( IO_FILL_IO_SOUTH_54_60 VSS ) ( IO_FILL_IO_SOUTH_54_55 VSS ) ( IO_FILL_IO_SOUTH_54_50 VSS ) ( IO_FILL_IO_SOUTH_54_45 VSS )
-      ( IO_FILL_IO_SOUTH_54_40 VSS ) ( IO_FILL_IO_SOUTH_54_35 VSS ) ( IO_FILL_IO_SOUTH_54_30 VSS ) ( IO_FILL_IO_SOUTH_54_25 VSS ) ( IO_FILL_IO_SOUTH_54_20 VSS ) ( IO_FILL_IO_SOUTH_54_15 VSS ) ( IO_FILL_IO_SOUTH_54_10 VSS ) ( IO_FILL_IO_SOUTH_54_5 VSS )
-      ( IO_FILL_IO_SOUTH_40_5 VSS ) ( IO_FILL_IO_SOUTH_20_5 VSS ) ( IO_FILL_IO_SOUTH_10_30 VSS ) ( IO_FILL_IO_SOUTH_10_25 VSS ) ( IO_FILL_IO_SOUTH_10_20 VSS ) ( IO_FILL_IO_SOUTH_10_15 VSS ) ( IO_FILL_IO_SOUTH_10_10 VSS ) ( IO_FILL_IO_SOUTH_10_5 VSS )
-      ( IO_FILL_IO_SOUTH_6_35 VSS ) ( IO_FILL_IO_SOUTH_6_30 VSS ) ( IO_FILL_IO_SOUTH_6_25 VSS ) ( IO_FILL_IO_SOUTH_6_20 VSS ) ( IO_FILL_IO_SOUTH_6_15 VSS ) ( IO_FILL_IO_SOUTH_6_10 VSS ) ( IO_FILL_IO_SOUTH_6_5 VSS ) ( IO_FILL_IO_SOUTH_3_95 VSS )
-      ( IO_FILL_IO_SOUTH_3_90 VSS ) ( IO_FILL_IO_SOUTH_3_85 VSS ) ( IO_FILL_IO_SOUTH_3_80 VSS ) ( IO_FILL_IO_SOUTH_3_75 VSS ) ( IO_FILL_IO_SOUTH_3_70 VSS ) ( IO_FILL_IO_SOUTH_3_65 VSS ) ( IO_FILL_IO_SOUTH_3_60 VSS ) ( IO_FILL_IO_SOUTH_3_55 VSS )
-      ( IO_FILL_IO_SOUTH_3_50 VSS ) ( IO_FILL_IO_SOUTH_3_45 VSS ) ( IO_FILL_IO_SOUTH_3_40 VSS ) ( IO_FILL_IO_SOUTH_3_35 VSS ) ( IO_FILL_IO_SOUTH_3_30 VSS ) ( IO_FILL_IO_SOUTH_3_25 VSS ) ( IO_FILL_IO_SOUTH_3_20 VSS ) ( IO_FILL_IO_SOUTH_3_15 VSS )
-      ( IO_FILL_IO_SOUTH_3_10 VSS ) ( IO_FILL_IO_SOUTH_3_5 VSS ) ( IO_FILL_IO_SOUTH_1_95 VSS ) ( IO_FILL_IO_SOUTH_1_90 VSS ) ( IO_FILL_IO_SOUTH_1_85 VSS ) ( IO_FILL_IO_SOUTH_1_80 VSS ) ( IO_FILL_IO_SOUTH_1_75 VSS ) ( IO_FILL_IO_SOUTH_1_70 VSS )
-      ( IO_FILL_IO_SOUTH_1_65 VSS ) ( IO_FILL_IO_SOUTH_1_60 VSS ) ( IO_FILL_IO_SOUTH_1_55 VSS ) ( IO_FILL_IO_SOUTH_1_50 VSS ) ( IO_FILL_IO_SOUTH_1_45 VSS ) ( IO_FILL_IO_SOUTH_1_40 VSS ) ( IO_FILL_IO_SOUTH_1_35 VSS ) ( IO_FILL_IO_SOUTH_1_30 VSS )
-      ( IO_FILL_IO_SOUTH_1_25 VSS ) ( IO_FILL_IO_SOUTH_1_20 VSS ) ( IO_FILL_IO_SOUTH_1_15 VSS ) ( IO_FILL_IO_SOUTH_1_10 VSS ) ( IO_FILL_IO_SOUTH_1_5 VSS ) ( IO_FILL_IO_SOUTH_0_20 VSS ) ( IO_FILL_IO_SOUTH_6_0 VSS ) ( IO_FILL_IO_SOUTH_3_100 VSS )
-      ( IO_FILL_IO_SOUTH_59_0 VSS ) ( IO_FILL_IO_SOUTH_50_5 VSS ) ( IO_FILL_IO_SOUTH_45_0 VSS ) ( IO_FILL_IO_SOUTH_30_5 VSS ) ( IO_FILL_IO_SOUTH_25_0 VSS ) ( IO_FILL_IO_SOUTH_10_35 VSS ) ( IO_FILL_IO_SOUTH_3_0 VSS ) ( IO_FILL_IO_SOUTH_54_0 VSS )
-      ( IO_FILL_IO_SOUTH_22_0 VSS ) ( IO_FILL_IO_SOUTH_6_40 VSS ) ( IO_FILL_IO_SOUTH_53_0 VSS ) ( IO_FILL_IO_SOUTH_36_0 VSS ) ( IO_FILL_IO_SOUTH_35_5 VSS ) ( IO_FILL_IO_SOUTH_21_0 VSS ) ( IO_FILL_IO_SOUTH_20_10 VSS ) ( IO_FILL_IO_SOUTH_60_0 VSS )
-      ( IO_FILL_IO_SOUTH_59_130 VSS ) ( IO_FILL_IO_SOUTH_52_0 VSS ) ( IO_FILL_IO_SOUTH_51_0 VSS ) ( IO_FILL_IO_SOUTH_45_5 VSS ) ( IO_FILL_IO_SOUTH_40_0 VSS ) ( IO_FILL_IO_SOUTH_39_0 VSS ) ( IO_FILL_IO_SOUTH_31_0 VSS ) ( IO_FILL_IO_SOUTH_25_5 VSS )
-      ( IO_FILL_IO_SOUTH_17_0 VSS ) ( IO_FILL_IO_SOUTH_11_0 VSS ) ( IO_FILL_IO_SOUTH_42_5 VSS ) ( IO_FILL_IO_SOUTH_42_0 VSS ) ( IO_FILL_IO_SOUTH_46_0 VSS ) ( IO_FILL_IO_SOUTH_41_0 VSS ) ( IO_FILL_IO_SOUTH_40_10 VSS ) ( IO_FILL_IO_SOUTH_57_0 VSS )
-      ( IO_FILL_IO_SOUTH_56_5 VSS ) ( IO_FILL_IO_SOUTH_5_0 VSS ) ( IO_FILL_IO_SOUTH_4_0 VSS ) ( IO_FILL_IO_SOUTH_56_0 VSS ) ( IO_FILL_IO_SOUTH_2_0 VSS ) ( IO_FILL_IO_SOUTH_1_100 VSS ) ( IO_FILL_IO_SOUTH_58_0 VSS ) ( IO_FILL_IO_SOUTH_57_65 VSS )
-      ( IO_FILL_IO_SOUTH_1_0 VSS ) ( IO_FILL_IO_SOUTH_0_25 VSS ) ( IO_FILL_IO_SOUTH_48_0 VSS ) ( IO_FILL_IO_SOUTH_47_0 VSS ) ( IO_FILL_IO_SOUTH_48_5 VSS ) ( IO_FILL_IO_SOUTH_55_0 VSS ) ( IO_FILL_IO_SOUTH_54_70 VSS ) ( IO_FILL_IO_SOUTH_50_0 VSS )
-      ( IO_FILL_IO_SOUTH_49_0 VSS ) ( IO_FILL_IO_SOUTH_44_0 VSS ) ( IO_FILL_IO_SOUTH_43_0 VSS ) ( IO_FILL_IO_SOUTH_8_0 VSS ) ( IO_FILL_IO_SOUTH_7_0 VSS ) ( IO_FILL_IO_SOUTH_8_5 VSS ) ( IO_FILL_IO_SOUTH_10_0 VSS ) ( IO_FILL_IO_SOUTH_9_0 VSS )
-      ( IO_FILL_IO_SOUTH_22_5 VSS ) ( IO_FILL_IO_SOUTH_24_0 VSS ) ( IO_FILL_IO_SOUTH_23_0 VSS ) ( IO_FILL_IO_SOUTH_26_0 VSS ) ( IO_FILL_IO_SOUTH_28_0 VSS ) ( IO_FILL_IO_SOUTH_27_0 VSS ) ( IO_FILL_IO_SOUTH_28_5 VSS ) ( IO_FILL_IO_SOUTH_30_0 VSS )
-      ( IO_FILL_IO_SOUTH_29_0 VSS ) ( IO_FILL_IO_SOUTH_32_0 VSS ) ( IO_FILL_IO_SOUTH_34_0 VSS ) ( IO_FILL_IO_SOUTH_33_0 VSS ) ( IO_FILL_IO_SOUTH_35_0 VSS ) ( IO_FILL_IO_SOUTH_34_5 VSS ) ( IO_FILL_IO_SOUTH_12_0 VSS ) ( IO_FILL_IO_SOUTH_14_0 VSS )
-      ( IO_FILL_IO_SOUTH_13_0 VSS ) ( IO_FILL_IO_SOUTH_15_0 VSS ) ( IO_FILL_IO_SOUTH_14_5 VSS ) ( IO_FILL_IO_SOUTH_16_0 VSS ) ( IO_FILL_IO_SOUTH_15_5 VSS ) ( IO_FILL_IO_SOUTH_18_0 VSS ) ( IO_FILL_IO_SOUTH_20_0 VSS ) ( IO_FILL_IO_SOUTH_19_0 VSS )
-      ( IO_FILL_IO_SOUTH_38_0 VSS ) ( IO_FILL_IO_SOUTH_37_0 VSS ) ( IO_FILL_IO_EAST_60_180 VSS ) ( IO_FILL_IO_EAST_60_175 VSS ) ( IO_FILL_IO_EAST_60_170 VSS ) ( IO_FILL_IO_EAST_60_165 VSS ) ( IO_FILL_IO_EAST_60_160 VSS ) ( IO_FILL_IO_EAST_60_155 VSS )
-      ( IO_FILL_IO_EAST_60_150 VSS ) ( IO_FILL_IO_EAST_60_145 VSS ) ( IO_FILL_IO_EAST_60_140 VSS ) ( IO_FILL_IO_EAST_60_135 VSS ) ( IO_FILL_IO_EAST_60_130 VSS ) ( IO_FILL_IO_EAST_60_125 VSS ) ( IO_FILL_IO_EAST_60_120 VSS ) ( IO_FILL_IO_EAST_60_115 VSS )
-      ( IO_FILL_IO_EAST_60_110 VSS ) ( IO_FILL_IO_EAST_60_105 VSS ) ( IO_FILL_IO_EAST_60_100 VSS ) ( IO_FILL_IO_EAST_60_95 VSS ) ( IO_FILL_IO_EAST_60_90 VSS ) ( IO_FILL_IO_EAST_60_85 VSS ) ( IO_FILL_IO_EAST_60_80 VSS ) ( IO_FILL_IO_EAST_60_75 VSS )
-      ( IO_FILL_IO_EAST_60_70 VSS ) ( IO_FILL_IO_EAST_60_65 VSS ) ( IO_FILL_IO_EAST_60_60 VSS ) ( IO_FILL_IO_EAST_60_55 VSS ) ( IO_FILL_IO_EAST_60_50 VSS ) ( IO_FILL_IO_EAST_60_45 VSS ) ( IO_FILL_IO_EAST_60_40 VSS ) ( IO_FILL_IO_EAST_60_35 VSS )
-      ( IO_FILL_IO_EAST_60_30 VSS ) ( IO_FILL_IO_EAST_60_25 VSS ) ( IO_FILL_IO_EAST_60_20 VSS ) ( IO_FILL_IO_EAST_60_15 VSS ) ( IO_FILL_IO_EAST_60_10 VSS ) ( IO_FILL_IO_EAST_60_5 VSS ) ( IO_FILL_IO_EAST_59_120 VSS ) ( IO_FILL_IO_EAST_59_115 VSS )
-      ( IO_FILL_IO_EAST_59_110 VSS ) ( IO_FILL_IO_EAST_59_105 VSS ) ( IO_FILL_IO_EAST_59_100 VSS ) ( IO_FILL_IO_EAST_59_95 VSS ) ( IO_FILL_IO_EAST_59_90 VSS ) ( IO_FILL_IO_EAST_59_85 VSS ) ( IO_FILL_IO_EAST_59_80 VSS ) ( IO_FILL_IO_EAST_59_75 VSS )
-      ( IO_FILL_IO_EAST_59_70 VSS ) ( IO_FILL_IO_EAST_59_65 VSS ) ( IO_FILL_IO_EAST_59_60 VSS ) ( IO_FILL_IO_EAST_59_55 VSS ) ( IO_FILL_IO_EAST_59_50 VSS ) ( IO_FILL_IO_EAST_59_45 VSS ) ( IO_FILL_IO_EAST_59_40 VSS ) ( IO_FILL_IO_EAST_59_35 VSS )
-      ( IO_FILL_IO_EAST_59_30 VSS ) ( IO_FILL_IO_EAST_59_25 VSS ) ( IO_FILL_IO_EAST_59_20 VSS ) ( IO_FILL_IO_EAST_59_15 VSS ) ( IO_FILL_IO_EAST_59_10 VSS ) ( IO_FILL_IO_EAST_59_5 VSS ) ( IO_FILL_IO_EAST_57_65 VSS ) ( IO_FILL_IO_EAST_57_60 VSS )
-      ( IO_FILL_IO_EAST_57_55 VSS ) ( IO_FILL_IO_EAST_57_50 VSS ) ( IO_FILL_IO_EAST_57_45 VSS ) ( IO_FILL_IO_EAST_57_40 VSS ) ( IO_FILL_IO_EAST_57_35 VSS ) ( IO_FILL_IO_EAST_57_30 VSS ) ( IO_FILL_IO_EAST_57_25 VSS ) ( IO_FILL_IO_EAST_57_20 VSS )
-      ( IO_FILL_IO_EAST_57_15 VSS ) ( IO_FILL_IO_EAST_57_10 VSS ) ( IO_FILL_IO_EAST_57_5 VSS ) ( IO_FILL_IO_EAST_54_65 VSS ) ( IO_FILL_IO_EAST_54_60 VSS ) ( IO_FILL_IO_EAST_54_55 VSS ) ( IO_FILL_IO_EAST_54_50 VSS ) ( IO_FILL_IO_EAST_54_45 VSS )
-      ( IO_FILL_IO_EAST_54_40 VSS ) ( IO_FILL_IO_EAST_54_35 VSS ) ( IO_FILL_IO_EAST_54_30 VSS ) ( IO_FILL_IO_EAST_54_25 VSS ) ( IO_FILL_IO_EAST_54_20 VSS ) ( IO_FILL_IO_EAST_54_15 VSS ) ( IO_FILL_IO_EAST_54_10 VSS ) ( IO_FILL_IO_EAST_54_5 VSS )
-      ( IO_FILL_IO_EAST_50_5 VSS ) ( IO_FILL_IO_EAST_35_5 VSS ) ( IO_FILL_IO_EAST_30_5 VSS ) ( IO_FILL_IO_EAST_15_5 VSS ) ( IO_FILL_IO_EAST_10_35 VSS ) ( IO_FILL_IO_EAST_10_30 VSS ) ( IO_FILL_IO_EAST_10_25 VSS ) ( IO_FILL_IO_EAST_10_20 VSS )
-      ( IO_FILL_IO_EAST_10_15 VSS ) ( IO_FILL_IO_EAST_10_10 VSS ) ( IO_FILL_IO_EAST_10_5 VSS ) ( IO_FILL_IO_EAST_6_35 VSS ) ( IO_FILL_IO_EAST_6_30 VSS ) ( IO_FILL_IO_EAST_6_25 VSS ) ( IO_FILL_IO_EAST_6_20 VSS ) ( IO_FILL_IO_EAST_6_15 VSS )
-      ( IO_FILL_IO_EAST_6_10 VSS ) ( IO_FILL_IO_EAST_6_5 VSS ) ( IO_FILL_IO_EAST_3_90 VSS ) ( IO_FILL_IO_EAST_3_85 VSS ) ( IO_FILL_IO_EAST_3_80 VSS ) ( IO_FILL_IO_EAST_3_75 VSS ) ( IO_FILL_IO_EAST_3_70 VSS ) ( IO_FILL_IO_EAST_3_65 VSS )
-      ( IO_FILL_IO_EAST_3_60 VSS ) ( IO_FILL_IO_EAST_3_55 VSS ) ( IO_FILL_IO_EAST_3_50 VSS ) ( IO_FILL_IO_EAST_3_45 VSS ) ( IO_FILL_IO_EAST_3_40 VSS ) ( IO_FILL_IO_EAST_3_35 VSS ) ( IO_FILL_IO_EAST_3_30 VSS ) ( IO_FILL_IO_EAST_3_25 VSS )
-      ( IO_FILL_IO_EAST_3_20 VSS ) ( IO_FILL_IO_EAST_3_15 VSS ) ( IO_FILL_IO_EAST_3_10 VSS ) ( IO_FILL_IO_EAST_3_5 VSS ) ( IO_FILL_IO_EAST_1_95 VSS ) ( IO_FILL_IO_EAST_1_90 VSS ) ( IO_FILL_IO_EAST_1_85 VSS ) ( IO_FILL_IO_EAST_1_80 VSS )
-      ( IO_FILL_IO_EAST_1_75 VSS ) ( IO_FILL_IO_EAST_1_70 VSS ) ( IO_FILL_IO_EAST_1_65 VSS ) ( IO_FILL_IO_EAST_1_60 VSS ) ( IO_FILL_IO_EAST_1_55 VSS ) ( IO_FILL_IO_EAST_1_50 VSS ) ( IO_FILL_IO_EAST_1_45 VSS ) ( IO_FILL_IO_EAST_1_40 VSS )
-      ( IO_FILL_IO_EAST_1_35 VSS ) ( IO_FILL_IO_EAST_1_30 VSS ) ( IO_FILL_IO_EAST_1_25 VSS ) ( IO_FILL_IO_EAST_1_20 VSS ) ( IO_FILL_IO_EAST_1_15 VSS ) ( IO_FILL_IO_EAST_1_10 VSS ) ( IO_FILL_IO_EAST_1_5 VSS ) ( IO_FILL_IO_EAST_0_20 VSS )
-      ( IO_FILL_IO_EAST_6_40 VSS ) ( IO_FILL_IO_EAST_40_5 VSS ) ( IO_FILL_IO_EAST_57_0 VSS ) ( IO_FILL_IO_EAST_56_0 VSS ) ( IO_FILL_IO_EAST_38_0 VSS ) ( IO_FILL_IO_EAST_22_0 VSS ) ( IO_FILL_IO_EAST_4_0 VSS ) ( IO_FILL_IO_EAST_3_95 VSS )
-      ( IO_FILL_IO_EAST_7_0 VSS ) ( IO_FILL_IO_EAST_54_0 VSS ) ( IO_FILL_IO_EAST_53_0 VSS ) ( IO_FILL_IO_EAST_47_0 VSS ) ( IO_FILL_IO_EAST_41_0 VSS ) ( IO_FILL_IO_EAST_33_0 VSS ) ( IO_FILL_IO_EAST_27_0 VSS ) ( IO_FILL_IO_EAST_20_0 VSS )
-      ( IO_FILL_IO_EAST_19_0 VSS ) ( IO_FILL_IO_EAST_13_0 VSS ) ( IO_FILL_IO_EAST_30_0 VSS ) ( IO_FILL_IO_EAST_29_0 VSS ) ( IO_FILL_IO_EAST_28_0 VSS ) ( IO_FILL_IO_EAST_15_0 VSS ) ( IO_FILL_IO_EAST_14_0 VSS ) ( IO_FILL_IO_EAST_16_0 VSS )
-      ( IO_FILL_IO_EAST_15_10 VSS ) ( IO_FILL_IO_EAST_16_5 VSS ) ( IO_FILL_IO_EAST_18_0 VSS ) ( IO_FILL_IO_EAST_17_0 VSS ) ( IO_FILL_IO_EAST_21_0 VSS ) ( IO_FILL_IO_EAST_20_5 VSS ) ( IO_FILL_IO_EAST_24_0 VSS ) ( IO_FILL_IO_EAST_23_0 VSS )
-      ( IO_FILL_IO_EAST_25_0 VSS ) ( IO_FILL_IO_EAST_24_5 VSS ) ( IO_FILL_IO_EAST_26_0 VSS ) ( IO_FILL_IO_EAST_25_5 VSS ) ( IO_FILL_IO_EAST_1_0 VSS ) ( IO_FILL_IO_EAST_0_25 VSS ) ( IO_FILL_IO_EAST_2_0 VSS ) ( IO_FILL_IO_EAST_1_100 VSS )
-      ( IO_FILL_IO_EAST_3_0 VSS ) ( IO_FILL_IO_EAST_2_5 VSS ) ( IO_FILL_IO_EAST_6_0 VSS ) ( IO_FILL_IO_EAST_5_0 VSS ) ( IO_FILL_IO_EAST_8_0 VSS ) ( IO_FILL_IO_EAST_10_0 VSS ) ( IO_FILL_IO_EAST_9_0 VSS ) ( IO_FILL_IO_EAST_10_40 VSS )
-      ( IO_FILL_IO_EAST_12_0 VSS ) ( IO_FILL_IO_EAST_11_0 VSS ) ( IO_FILL_IO_EAST_30_10 VSS ) ( IO_FILL_IO_EAST_45_0 VSS ) ( IO_FILL_IO_EAST_44_5 VSS ) ( IO_FILL_IO_EAST_46_0 VSS ) ( IO_FILL_IO_EAST_45_5 VSS ) ( IO_FILL_IO_EAST_48_0 VSS )
-      ( IO_FILL_IO_EAST_37_0 VSS ) ( IO_FILL_IO_EAST_36_5 VSS ) ( IO_FILL_IO_EAST_40_0 VSS ) ( IO_FILL_IO_EAST_39_0 VSS ) ( IO_FILL_IO_EAST_42_0 VSS ) ( IO_FILL_IO_EAST_44_0 VSS ) ( IO_FILL_IO_EAST_43_0 VSS ) ( IO_FILL_IO_EAST_50_0 VSS )
-      ( IO_FILL_IO_EAST_49_0 VSS ) ( IO_FILL_IO_EAST_50_10 VSS ) ( IO_FILL_IO_EAST_52_0 VSS ) ( IO_FILL_IO_EAST_51_0 VSS ) ( IO_FILL_IO_EAST_55_0 VSS ) ( IO_FILL_IO_EAST_54_70 VSS ) ( IO_FILL_IO_EAST_58_0 VSS ) ( IO_FILL_IO_EAST_57_70 VSS )
-      ( IO_FILL_IO_EAST_59_0 VSS ) ( IO_FILL_IO_EAST_58_5 VSS ) ( IO_FILL_IO_EAST_60_0 VSS ) ( IO_FILL_IO_EAST_59_125 VSS ) ( IO_FILL_IO_EAST_36_0 VSS ) ( IO_FILL_IO_EAST_35_10 VSS ) ( IO_FILL_IO_EAST_35_0 VSS ) ( IO_FILL_IO_EAST_34_0 VSS )
-      ( IO_FILL_IO_EAST_32_0 VSS ) ( IO_FILL_IO_EAST_31_0 VSS ) ( IO_FILL_IO_NORTH_53_95 VSS ) ( IO_FILL_IO_NORTH_53_90 VSS ) ( IO_FILL_IO_NORTH_53_85 VSS ) ( IO_FILL_IO_NORTH_53_80 VSS ) ( IO_FILL_IO_NORTH_53_75 VSS ) ( IO_FILL_IO_NORTH_53_70 VSS )
-      ( IO_FILL_IO_NORTH_53_65 VSS ) ( IO_FILL_IO_NORTH_53_60 VSS ) ( IO_FILL_IO_NORTH_53_55 VSS ) ( IO_FILL_IO_NORTH_53_50 VSS ) ( IO_FILL_IO_NORTH_53_45 VSS ) ( IO_FILL_IO_NORTH_53_40 VSS ) ( IO_FILL_IO_NORTH_53_35 VSS ) ( IO_FILL_IO_NORTH_53_30 VSS )
-      ( IO_FILL_IO_NORTH_53_25 VSS ) ( IO_FILL_IO_NORTH_53_20 VSS ) ( IO_FILL_IO_NORTH_53_15 VSS ) ( IO_FILL_IO_NORTH_53_10 VSS ) ( IO_FILL_IO_NORTH_53_5 VSS ) ( IO_FILL_IO_NORTH_51_95 VSS ) ( IO_FILL_IO_NORTH_51_90 VSS ) ( IO_FILL_IO_NORTH_51_85 VSS )
-      ( IO_FILL_IO_NORTH_51_80 VSS ) ( IO_FILL_IO_NORTH_51_75 VSS ) ( IO_FILL_IO_NORTH_51_70 VSS ) ( IO_FILL_IO_NORTH_51_65 VSS ) ( IO_FILL_IO_NORTH_51_60 VSS ) ( IO_FILL_IO_NORTH_51_55 VSS ) ( IO_FILL_IO_NORTH_51_50 VSS ) ( IO_FILL_IO_NORTH_51_45 VSS )
-      ( IO_FILL_IO_NORTH_51_40 VSS ) ( IO_FILL_IO_NORTH_51_35 VSS ) ( IO_FILL_IO_NORTH_51_30 VSS ) ( IO_FILL_IO_NORTH_51_25 VSS ) ( IO_FILL_IO_NORTH_51_20 VSS ) ( IO_FILL_IO_NORTH_51_15 VSS ) ( IO_FILL_IO_NORTH_51_10 VSS ) ( IO_FILL_IO_NORTH_51_5 VSS )
-      ( IO_FILL_IO_NORTH_48_35 VSS ) ( IO_FILL_IO_NORTH_48_30 VSS ) ( IO_FILL_IO_NORTH_48_25 VSS ) ( IO_FILL_IO_NORTH_48_20 VSS ) ( IO_FILL_IO_NORTH_48_15 VSS ) ( IO_FILL_IO_NORTH_48_10 VSS ) ( IO_FILL_IO_NORTH_48_5 VSS ) ( IO_FILL_IO_NORTH_44_30 VSS )
-      ( IO_FILL_IO_NORTH_44_25 VSS ) ( IO_FILL_IO_NORTH_44_20 VSS ) ( IO_FILL_IO_NORTH_44_15 VSS ) ( IO_FILL_IO_NORTH_44_10 VSS ) ( IO_FILL_IO_NORTH_44_5 VSS ) ( IO_FILL_IO_NORTH_42_20 VSS ) ( IO_FILL_IO_NORTH_42_15 VSS ) ( IO_FILL_IO_NORTH_42_10 VSS )
-      ( IO_FILL_IO_NORTH_42_5 VSS ) ( IO_FILL_IO_NORTH_30_15 VSS ) ( IO_FILL_IO_NORTH_30_10 VSS ) ( IO_FILL_IO_NORTH_30_5 VSS ) ( IO_FILL_IO_NORTH_25_5 VSS ) ( IO_FILL_IO_NORTH_10_5 VSS ) ( IO_FILL_IO_NORTH_6_60 VSS ) ( IO_FILL_IO_NORTH_6_55 VSS )
-      ( IO_FILL_IO_NORTH_6_50 VSS ) ( IO_FILL_IO_NORTH_6_45 VSS ) ( IO_FILL_IO_NORTH_6_40 VSS ) ( IO_FILL_IO_NORTH_6_35 VSS ) ( IO_FILL_IO_NORTH_6_30 VSS ) ( IO_FILL_IO_NORTH_6_25 VSS ) ( IO_FILL_IO_NORTH_6_20 VSS ) ( IO_FILL_IO_NORTH_6_15 VSS )
-      ( IO_FILL_IO_NORTH_6_10 VSS ) ( IO_FILL_IO_NORTH_6_5 VSS ) ( IO_FILL_IO_NORTH_3_65 VSS ) ( IO_FILL_IO_NORTH_3_60 VSS ) ( IO_FILL_IO_NORTH_3_55 VSS ) ( IO_FILL_IO_NORTH_3_50 VSS ) ( IO_FILL_IO_NORTH_3_45 VSS ) ( IO_FILL_IO_NORTH_3_40 VSS )
-      ( IO_FILL_IO_NORTH_3_35 VSS ) ( IO_FILL_IO_NORTH_3_30 VSS ) ( IO_FILL_IO_NORTH_3_25 VSS ) ( IO_FILL_IO_NORTH_3_20 VSS ) ( IO_FILL_IO_NORTH_3_15 VSS ) ( IO_FILL_IO_NORTH_3_10 VSS ) ( IO_FILL_IO_NORTH_3_5 VSS ) ( IO_FILL_IO_NORTH_1_125 VSS )
-      ( IO_FILL_IO_NORTH_1_120 VSS ) ( IO_FILL_IO_NORTH_1_115 VSS ) ( IO_FILL_IO_NORTH_1_110 VSS ) ( IO_FILL_IO_NORTH_1_105 VSS ) ( IO_FILL_IO_NORTH_1_100 VSS ) ( IO_FILL_IO_NORTH_1_95 VSS ) ( IO_FILL_IO_NORTH_1_90 VSS ) ( IO_FILL_IO_NORTH_1_85 VSS )
-      ( IO_FILL_IO_NORTH_1_80 VSS ) ( IO_FILL_IO_NORTH_1_75 VSS ) ( IO_FILL_IO_NORTH_1_70 VSS ) ( IO_FILL_IO_NORTH_1_65 VSS ) ( IO_FILL_IO_NORTH_1_60 VSS ) ( IO_FILL_IO_NORTH_1_55 VSS ) ( IO_FILL_IO_NORTH_1_50 VSS ) ( IO_FILL_IO_NORTH_1_45 VSS )
-      ( IO_FILL_IO_NORTH_1_40 VSS ) ( IO_FILL_IO_NORTH_1_35 VSS ) ( IO_FILL_IO_NORTH_1_30 VSS ) ( IO_FILL_IO_NORTH_1_25 VSS ) ( IO_FILL_IO_NORTH_1_20 VSS ) ( IO_FILL_IO_NORTH_1_15 VSS ) ( IO_FILL_IO_NORTH_1_10 VSS ) ( IO_FILL_IO_NORTH_1_5 VSS )
-      ( IO_FILL_IO_NORTH_0_210 VSS ) ( IO_FILL_IO_NORTH_0_205 VSS ) ( IO_FILL_IO_NORTH_0_200 VSS ) ( IO_FILL_IO_NORTH_0_195 VSS ) ( IO_FILL_IO_NORTH_0_190 VSS ) ( IO_FILL_IO_NORTH_0_185 VSS ) ( IO_FILL_IO_NORTH_0_180 VSS ) ( IO_FILL_IO_NORTH_0_175 VSS )
-      ( IO_FILL_IO_NORTH_0_170 VSS ) ( IO_FILL_IO_NORTH_0_165 VSS ) ( IO_FILL_IO_NORTH_0_160 VSS ) ( IO_FILL_IO_NORTH_0_155 VSS ) ( IO_FILL_IO_NORTH_0_150 VSS ) ( IO_FILL_IO_NORTH_0_145 VSS ) ( IO_FILL_IO_NORTH_0_140 VSS ) ( IO_FILL_IO_NORTH_0_135 VSS )
-      ( IO_FILL_IO_NORTH_0_130 VSS ) ( IO_FILL_IO_NORTH_0_125 VSS ) ( IO_FILL_IO_NORTH_0_120 VSS ) ( IO_FILL_IO_NORTH_0_115 VSS ) ( IO_FILL_IO_NORTH_0_110 VSS ) ( IO_FILL_IO_NORTH_0_105 VSS ) ( IO_FILL_IO_NORTH_0_100 VSS ) ( IO_FILL_IO_NORTH_0_95 VSS )
-      ( IO_FILL_IO_NORTH_0_90 VSS ) ( IO_FILL_IO_NORTH_0_85 VSS ) ( IO_FILL_IO_NORTH_0_80 VSS ) ( IO_FILL_IO_NORTH_0_75 VSS ) ( IO_FILL_IO_NORTH_0_70 VSS ) ( IO_FILL_IO_NORTH_0_65 VSS ) ( IO_FILL_IO_NORTH_0_60 VSS ) ( IO_FILL_IO_NORTH_0_55 VSS )
-      ( IO_FILL_IO_NORTH_0_50 VSS ) ( IO_FILL_IO_NORTH_0_45 VSS ) ( IO_FILL_IO_NORTH_0_40 VSS ) ( IO_FILL_IO_NORTH_0_35 VSS ) ( IO_FILL_IO_NORTH_0_30 VSS ) ( IO_FILL_IO_NORTH_0_25 VSS ) ( IO_FILL_IO_NORTH_0_20 VSS ) ( IO_FILL_IO_NORTH_0_15 VSS )
-      ( IO_FILL_IO_NORTH_0_10 VSS ) ( IO_FILL_IO_NORTH_0_5 VSS ) ( IO_FILL_IO_NORTH_0_0 VSS ) ( IO_FILL_IO_NORTH_1_130 VSS ) ( IO_FILL_IO_NORTH_10_0 VSS ) ( IO_FILL_IO_NORTH_15_5 VSS ) ( IO_FILL_IO_NORTH_53_100 VSS ) ( IO_FILL_IO_NORTH_37_0 VSS )
-      ( IO_FILL_IO_NORTH_48_40 VSS ) ( IO_FILL_IO_NORTH_6_0 VSS ) ( IO_FILL_IO_NORTH_22_0 VSS ) ( IO_FILL_IO_NORTH_30_20 VSS ) ( IO_FILL_IO_NORTH_37_5 VSS ) ( IO_FILL_IO_NORTH_49_0 VSS ) ( IO_FILL_IO_NORTH_6_65 VSS ) ( IO_FILL_IO_NORTH_23_0 VSS )
-      ( IO_FILL_IO_NORTH_1_0 VSS ) ( IO_FILL_IO_NORTH_0_215 VSS ) ( IO_FILL_IO_NORTH_9_0 VSS ) ( IO_FILL_IO_NORTH_15_0 VSS ) ( IO_FILL_IO_NORTH_21_0 VSS ) ( IO_FILL_IO_NORTH_20_5 VSS ) ( IO_FILL_IO_NORTH_26_5 VSS ) ( IO_FILL_IO_NORTH_35_0 VSS )
-      ( IO_FILL_IO_NORTH_34_0 VSS ) ( IO_FILL_IO_NORTH_45_0 VSS ) ( IO_FILL_IO_NORTH_44_35 VSS ) ( IO_FILL_IO_NORTH_53_0 VSS ) ( IO_FILL_IO_NORTH_36_0 VSS ) ( IO_FILL_IO_NORTH_35_5 VSS ) ( IO_FILL_IO_NORTH_33_0 VSS ) ( IO_FILL_IO_NORTH_32_5 VSS )
-      ( IO_FILL_IO_NORTH_32_0 VSS ) ( IO_FILL_IO_NORTH_31_0 VSS ) ( IO_FILL_IO_NORTH_39_0 VSS ) ( IO_FILL_IO_NORTH_38_0 VSS ) ( IO_FILL_IO_NORTH_14_0 VSS ) ( IO_FILL_IO_NORTH_13_0 VSS ) ( IO_FILL_IO_NORTH_12_5 VSS ) ( IO_FILL_IO_NORTH_12_0 VSS )
-      ( IO_FILL_IO_NORTH_20_0 VSS ) ( IO_FILL_IO_NORTH_19_0 VSS ) ( IO_FILL_IO_NORTH_18_5 VSS ) ( IO_FILL_IO_NORTH_18_0 VSS ) ( IO_FILL_IO_NORTH_17_0 VSS ) ( IO_FILL_IO_NORTH_16_0 VSS ) ( IO_FILL_IO_NORTH_11_0 VSS ) ( IO_FILL_IO_NORTH_10_10 VSS )
-      ( IO_FILL_IO_NORTH_8_0 VSS ) ( IO_FILL_IO_NORTH_7_0 VSS ) ( IO_FILL_IO_NORTH_5_0 VSS ) ( IO_FILL_IO_NORTH_4_5 VSS ) ( IO_FILL_IO_NORTH_4_0 VSS ) ( IO_FILL_IO_NORTH_3_70 VSS ) ( IO_FILL_IO_NORTH_3_0 VSS ) ( IO_FILL_IO_NORTH_2_0 VSS )
-      ( IO_FILL_IO_NORTH_30_0 VSS ) ( IO_FILL_IO_NORTH_29_0 VSS ) ( IO_FILL_IO_NORTH_28_0 VSS ) ( IO_FILL_IO_NORTH_27_0 VSS ) ( IO_FILL_IO_NORTH_26_0 VSS ) ( IO_FILL_IO_NORTH_25_10 VSS ) ( IO_FILL_IO_NORTH_25_0 VSS ) ( IO_FILL_IO_NORTH_24_0 VSS )
-      ( IO_FILL_IO_NORTH_48_0 VSS ) ( IO_FILL_IO_NORTH_47_0 VSS ) ( IO_FILL_IO_NORTH_46_0 VSS ) ( IO_FILL_IO_NORTH_44_0 VSS ) ( IO_FILL_IO_NORTH_52_0 VSS ) ( IO_FILL_IO_NORTH_51_100 VSS ) ( IO_FILL_IO_NORTH_51_0 VSS ) ( IO_FILL_IO_NORTH_50_0 VSS )
-      ( IO_FILL_IO_NORTH_43_0 VSS ) ( IO_FILL_IO_NORTH_42_25 VSS ) ( IO_FILL_IO_NORTH_42_0 VSS ) ( IO_FILL_IO_NORTH_41_0 VSS ) ( IO_FILL_IO_NORTH_40_0 VSS ) ( IO_FILL_IO_NORTH_39_5 VSS ) ( IO_FILL_IO_EAST_60_185 VSS ) ( IO_FILL_IO_EAST_60_190 VSS )
-      ( IO_CORNER_NORTH_EAST_INST VSS ) ( IO_FILL_IO_NORTH_54_0 VSS ) ( IO_CORNER_NORTH_WEST_INST VSS ) ( IO_FILL_IO_WEST_57_0 VSS ) ( u_v18_33 VSS ) ( u_vzz_33 VSS ) ( u_brk0 VSS ) ( u_vdd_0 VSS )
-      ( u_v18_0 VSS ) ( u_vzz_9 VSS ) ( u_vzz_8 VSS ) ( u_vzz_7 VSS ) ( u_vzz_6 VSS ) ( u_vzz_5 VSS ) ( u_vzz_4 VSS ) ( u_vzz_32 VSS )
-      ( u_vzz_31 VSS ) ( u_vzz_30 VSS ) ( u_vzz_3 VSS ) ( u_vzz_29 VSS ) ( u_vzz_28 VSS ) ( u_vzz_27 VSS ) ( u_vzz_26 VSS ) ( u_vzz_25 VSS )
-      ( u_vzz_24 VSS ) ( u_vzz_23 VSS ) ( u_vzz_22 VSS ) ( u_vzz_21 VSS ) ( u_vzz_20 VSS ) ( u_vzz_2 VSS ) ( u_vzz_19 VSS ) ( u_vzz_18 VSS )
-      ( u_vzz_17 VSS ) ( u_vzz_16 VSS ) ( u_vzz_15 VSS ) ( u_vzz_14 VSS ) ( u_vzz_13 VSS ) ( u_vzz_12 VSS ) ( u_vzz_11 VSS ) ( u_vzz_10 VSS )
-      ( u_vzz_1 VSS ) ( u_vzz_0 VSS ) ( u_vss_pll VSS ) ( u_vss_9 VSS ) ( u_vss_8 VSS ) ( u_vss_7 VSS ) ( u_vss_6 VSS ) ( u_vss_5 VSS )
-      ( u_vss_4 VSS ) ( u_vss_32 VSS ) ( u_vss_31 VSS ) ( u_vss_30 VSS ) ( u_vss_3 VSS ) ( u_vss_29 VSS ) ( u_vss_28 VSS ) ( u_vss_27 VSS )
-      ( u_vss_26 VSS ) ( u_vss_25 VSS ) ( u_vss_24 VSS ) ( u_vss_23 VSS ) ( u_vss_22 VSS ) ( u_vss_21 VSS ) ( u_vss_20 VSS ) ( u_vss_2 VSS )
-      ( u_vss_19 VSS ) ( u_vss_18 VSS ) ( u_vss_17 VSS ) ( u_vss_16 VSS ) ( u_vss_15 VSS ) ( u_vss_14 VSS ) ( u_vss_13 VSS ) ( u_vss_12 VSS )
-      ( u_vss_11 VSS ) ( u_vss_10 VSS ) ( u_vss_1 VSS ) ( u_vss_0 VSS ) ( u_vdd_pll VSS ) ( u_vdd_9 VSS ) ( u_vdd_8 VSS ) ( u_vdd_7 VSS )
-      ( u_vdd_6 VSS ) ( u_vdd_5 VSS ) ( u_vdd_4 VSS ) ( u_vdd_32 VSS ) ( u_vdd_31 VSS ) ( u_vdd_30 VSS ) ( u_vdd_3 VSS ) ( u_vdd_29 VSS )
-      ( u_vdd_28 VSS ) ( u_vdd_27 VSS ) ( u_vdd_26 VSS ) ( u_vdd_25 VSS ) ( u_vdd_24 VSS ) ( u_vdd_23 VSS ) ( u_vdd_22 VSS ) ( u_vdd_21 VSS )
-      ( u_vdd_20 VSS ) ( u_vdd_2 VSS ) ( u_vdd_19 VSS ) ( u_vdd_18 VSS ) ( u_vdd_17 VSS ) ( u_vdd_16 VSS ) ( u_vdd_15 VSS ) ( u_vdd_14 VSS )
-      ( u_vdd_13 VSS ) ( u_vdd_12 VSS ) ( u_vdd_11 VSS ) ( u_vdd_10 VSS ) ( u_vdd_1 VSS ) ( u_v18_9 VSS ) ( u_v18_8 VSS ) ( u_v18_7 VSS )
-      ( u_v18_6 VSS ) ( u_v18_5 VSS ) ( u_v18_4 VSS ) ( u_v18_32 VSS ) ( u_v18_31 VSS ) ( u_v18_30 VSS ) ( u_v18_3 VSS ) ( u_v18_29 VSS )
-      ( u_v18_28 VSS ) ( u_v18_27 VSS ) ( u_v18_26 VSS ) ( u_v18_25 VSS ) ( u_v18_24 VSS ) ( u_v18_23 VSS ) ( u_v18_22 VSS ) ( u_v18_21 VSS )
-      ( u_v18_20 VSS ) ( u_v18_2 VSS ) ( u_v18_19 VSS ) ( u_v18_18 VSS ) ( u_v18_17 VSS ) ( u_v18_16 VSS ) ( u_v18_15 VSS ) ( u_v18_14 VSS )
-      ( u_v18_13 VSS ) ( u_v18_12 VSS ) ( u_v18_11 VSS ) ( u_v18_10 VSS ) ( u_v18_1 VSS ) ( u_sel_2_i VSS ) ( u_sel_1_i VSS ) ( u_sel_0_i VSS )
-      ( u_misc_o VSS ) ( u_ddr_we_n_o VSS ) ( u_ddr_reset_n_o VSS ) ( u_ddr_ras_n_o VSS ) ( u_ddr_odt_o VSS ) ( u_ddr_dqs_p_3_io VSS ) ( u_ddr_dqs_p_2_io VSS ) ( u_ddr_dqs_p_1_io VSS )
-      ( u_ddr_dqs_p_0_io VSS ) ( u_ddr_dqs_n_3_io VSS ) ( u_ddr_dqs_n_2_io VSS ) ( u_ddr_dqs_n_1_io VSS ) ( u_ddr_dqs_n_0_io VSS ) ( u_ddr_dq_9_io VSS ) ( u_ddr_dq_8_io VSS ) ( u_ddr_dq_7_io VSS )
-      ( u_ddr_dq_6_io VSS ) ( u_ddr_dq_5_io VSS ) ( u_ddr_dq_4_io VSS ) ( u_ddr_dq_3_io VSS ) ( u_ddr_dq_31_io VSS ) ( u_ddr_dq_30_io VSS ) ( u_ddr_dq_2_io VSS ) ( u_ddr_dq_29_io VSS )
-      ( u_ddr_dq_28_io VSS ) ( u_ddr_dq_27_io VSS ) ( u_ddr_dq_26_io VSS ) ( u_ddr_dq_25_io VSS ) ( u_ddr_dq_24_io VSS ) ( u_ddr_dq_23_io VSS ) ( u_ddr_dq_22_io VSS ) ( u_ddr_dq_21_io VSS )
-      ( u_ddr_dq_20_io VSS ) ( u_ddr_dq_1_io VSS ) ( u_ddr_dq_19_io VSS ) ( u_ddr_dq_18_io VSS ) ( u_ddr_dq_17_io VSS ) ( u_ddr_dq_16_io VSS ) ( u_ddr_dq_15_io VSS ) ( u_ddr_dq_14_io VSS )
-      ( u_ddr_dq_13_io VSS ) ( u_ddr_dq_12_io VSS ) ( u_ddr_dq_11_io VSS ) ( u_ddr_dq_10_io VSS ) ( u_ddr_dq_0_io VSS ) ( u_ddr_dm_3_o VSS ) ( u_ddr_dm_2_o VSS ) ( u_ddr_dm_1_o VSS )
-      ( u_ddr_dm_0_o VSS ) ( u_ddr_cs_n_o VSS ) ( u_ddr_cke_o VSS ) ( u_ddr_ck_p_o VSS ) ( u_ddr_ck_n_o VSS ) ( u_ddr_cas_n_o VSS ) ( u_ddr_ba_2_o VSS ) ( u_ddr_ba_1_o VSS )
-      ( u_ddr_ba_0_o VSS ) ( u_ddr_addr_9_o VSS ) ( u_ddr_addr_8_o VSS ) ( u_ddr_addr_7_o VSS ) ( u_ddr_addr_6_o VSS ) ( u_ddr_addr_5_o VSS ) ( u_ddr_addr_4_o VSS ) ( u_ddr_addr_3_o VSS )
-      ( u_ddr_addr_2_o VSS ) ( u_ddr_addr_1_o VSS ) ( u_ddr_addr_15_o VSS ) ( u_ddr_addr_14_o VSS ) ( u_ddr_addr_13_o VSS ) ( u_ddr_addr_12_o VSS ) ( u_ddr_addr_11_o VSS ) ( u_ddr_addr_10_o VSS )
-      ( u_ddr_addr_0_o VSS ) ( u_core_async_reset_i VSS ) ( u_co_v_i VSS ) ( u_co_tkn_o VSS ) ( u_co_clk_i VSS ) ( u_co_8_i VSS ) ( u_co_7_i VSS ) ( u_co_6_i VSS )
-      ( u_co_5_i VSS ) ( u_co_4_i VSS ) ( u_co_3_i VSS ) ( u_co_2_i VSS ) ( u_co_1_i VSS ) ( u_co_0_i VSS ) ( u_co2_v_o VSS ) ( u_co2_tkn_i VSS )
-      ( u_co2_clk_o VSS ) ( u_co2_8_o VSS ) ( u_co2_7_o VSS ) ( u_co2_6_o VSS ) ( u_co2_5_o VSS ) ( u_co2_4_o VSS ) ( u_co2_3_o VSS ) ( u_co2_2_o VSS )
-      ( u_co2_1_o VSS ) ( u_co2_0_o VSS ) ( u_clk_o VSS ) ( u_clk_async_reset_i VSS ) ( u_clk_C_i VSS ) ( u_clk_B_i VSS ) ( u_clk_A_i VSS ) ( u_ci_v_i VSS )
-      ( u_ci_tkn_o VSS ) ( u_ci_clk_i VSS ) ( u_ci_8_i VSS ) ( u_ci_7_i VSS ) ( u_ci_6_i VSS ) ( u_ci_5_i VSS ) ( u_ci_4_i VSS ) ( u_ci_3_i VSS )
-      ( u_ci_2_i VSS ) ( u_ci_1_i VSS ) ( u_ci_0_i VSS ) ( u_ci2_v_o VSS ) ( u_ci2_tkn_i VSS ) ( u_ci2_clk_o VSS ) ( u_ci2_8_o VSS ) ( u_ci2_7_o VSS )
-      ( u_ci2_6_o VSS ) ( u_ci2_5_o VSS ) ( u_ci2_4_o VSS ) ( u_ci2_3_o VSS ) ( u_ci2_2_o VSS ) ( u_ci2_1_o VSS ) ( u_ci2_0_o VSS ) ( u_bsg_tag_en_i VSS )
-      ( u_bsg_tag_data_o VSS ) ( u_bsg_tag_data_i VSS ) ( u_bsg_tag_clk_o VSS ) ( u_bsg_tag_clk_i VSS ) + USE GROUND ;
-END SPECIALNETS
-NETS 354 ;
-    - DVDD ( PIN DVDD ) ( BUMP_2_3 PAD ) ( BUMP_0_5 PAD ) ( BUMP_1_6 PAD ) ( BUMP_2_8 PAD ) ( BUMP_0_9 PAD ) ( BUMP_4_11 PAD )
-      ( BUMP_2_12 PAD ) ( BUMP_1_13 PAD ) ( BUMP_1_16 PAD ) ( BUMP_4_15 PAD ) ( BUMP_5_13 PAD ) ( BUMP_7_12 PAD ) ( BUMP_8_14 PAD ) ( BUMP_10_16 PAD )
-      ( BUMP_11_13 PAD ) ( BUMP_13_14 PAD ) ( BUMP_15_15 PAD ) ( BUMP_14_12 PAD ) ( BUMP_16_11 PAD ) ( BUMP_15_10 PAD ) ( BUMP_14_8 PAD ) ( BUMP_16_7 PAD )
-      ( BUMP_12_5 PAD ) ( BUMP_14_4 PAD ) ( BUMP_15_3 PAD ) ( BUMP_15_0 PAD ) ( BUMP_12_1 PAD ) ( BUMP_11_3 PAD ) ( BUMP_9_4 PAD ) ( BUMP_8_1 PAD )
-      ( BUMP_7_3 PAD ) ( BUMP_5_0 PAD ) ( BUMP_4_1 PAD ) ( BUMP_2_1 PAD ) + USE POWER ;
-    - DVSS ( PIN DVSS ) ( BUMP_0_3 PAD ) ( BUMP_1_5 PAD ) ( BUMP_3_6 PAD ) ( BUMP_0_8 PAD ) ( BUMP_1_9 PAD ) ( BUMP_2_11 PAD )
-      ( BUMP_0_12 PAD ) ( BUMP_3_13 PAD ) ( BUMP_2_16 PAD ) ( BUMP_4_13 PAD ) ( BUMP_6_12 PAD ) ( BUMP_7_14 PAD ) ( BUMP_8_15 PAD ) ( BUMP_10_14 PAD )
-      ( BUMP_12_12 PAD ) ( BUMP_13_16 PAD ) ( BUMP_16_16 PAD ) ( BUMP_16_12 PAD ) ( BUMP_15_11 PAD ) ( BUMP_13_10 PAD ) ( BUMP_16_8 PAD ) ( BUMP_15_7 PAD )
-      ( BUMP_14_5 PAD ) ( BUMP_16_4 PAD ) ( BUMP_13_3 PAD ) ( BUMP_14_0 PAD ) ( BUMP_12_3 PAD ) ( BUMP_10_4 PAD ) ( BUMP_9_2 PAD ) ( BUMP_8_3 PAD )
-      ( BUMP_6_4 PAD ) ( BUMP_5_1 PAD ) ( BUMP_4_3 PAD ) ( BUMP_1_0 PAD ) + USE GROUND ;
     - VDD ( PIN VDD ) ( BUMP_2_4 PAD ) ( BUMP_1_7 PAD ) ( BUMP_1_10 PAD ) ( BUMP_0_14 PAD ) ( BUMP_4_14 PAD ) ( BUMP_7_15 PAD )
       ( BUMP_9_12 PAD ) ( BUMP_11_12 PAD ) ( BUMP_14_16 PAD ) ( BUMP_16_13 PAD ) ( BUMP_16_9 PAD ) ( BUMP_15_6 PAD ) ( BUMP_15_2 PAD ) ( BUMP_12_0 PAD )
-      ( BUMP_9_3 PAD ) ( BUMP_6_3 PAD ) ( BUMP_2_2 PAD ) + USE POWER ;
+      ( BUMP_9_3 PAD ) ( BUMP_6_3 PAD ) ( BUMP_2_2 PAD ) ( IO_FILL_IO_WEST_0_485 VDD ) ( IO_FILL_IO_WEST_0_480 VDD ) ( IO_FILL_IO_WEST_0_475 VDD ) ( IO_FILL_IO_WEST_0_470 VDD ) ( IO_FILL_IO_WEST_0_465 VDD )
+      ( IO_FILL_IO_WEST_0_460 VDD ) ( IO_FILL_IO_WEST_0_455 VDD ) ( IO_FILL_IO_WEST_0_450 VDD ) ( IO_FILL_IO_WEST_0_445 VDD ) ( IO_FILL_IO_WEST_0_440 VDD ) ( IO_FILL_IO_WEST_0_435 VDD ) ( IO_FILL_IO_WEST_0_430 VDD ) ( IO_FILL_IO_WEST_0_425 VDD )
+      ( IO_FILL_IO_WEST_0_420 VDD ) ( IO_FILL_IO_WEST_0_415 VDD ) ( IO_FILL_IO_WEST_0_410 VDD ) ( IO_FILL_IO_WEST_0_405 VDD ) ( IO_FILL_IO_WEST_0_400 VDD ) ( IO_FILL_IO_WEST_0_395 VDD ) ( IO_FILL_IO_WEST_0_390 VDD ) ( IO_FILL_IO_WEST_0_385 VDD )
+      ( IO_FILL_IO_WEST_0_380 VDD ) ( IO_FILL_IO_WEST_0_375 VDD ) ( IO_FILL_IO_WEST_0_370 VDD ) ( IO_FILL_IO_WEST_0_365 VDD ) ( IO_FILL_IO_WEST_0_360 VDD ) ( IO_FILL_IO_WEST_0_355 VDD ) ( IO_FILL_IO_WEST_0_350 VDD ) ( IO_FILL_IO_WEST_0_345 VDD )
+      ( IO_FILL_IO_WEST_0_340 VDD ) ( IO_FILL_IO_WEST_0_335 VDD ) ( IO_FILL_IO_WEST_0_330 VDD ) ( IO_FILL_IO_WEST_0_325 VDD ) ( IO_FILL_IO_WEST_0_320 VDD ) ( IO_FILL_IO_WEST_0_315 VDD ) ( IO_FILL_IO_WEST_0_310 VDD ) ( IO_FILL_IO_WEST_0_305 VDD )
+      ( IO_FILL_IO_WEST_0_300 VDD ) ( IO_FILL_IO_WEST_0_295 VDD ) ( IO_FILL_IO_WEST_0_290 VDD ) ( IO_FILL_IO_WEST_0_285 VDD ) ( IO_FILL_IO_WEST_0_280 VDD ) ( IO_FILL_IO_WEST_0_275 VDD ) ( IO_FILL_IO_WEST_0_270 VDD ) ( IO_FILL_IO_WEST_0_265 VDD )
+      ( IO_FILL_IO_WEST_0_260 VDD ) ( IO_FILL_IO_WEST_0_255 VDD ) ( IO_FILL_IO_WEST_0_250 VDD ) ( IO_FILL_IO_WEST_0_245 VDD ) ( IO_FILL_IO_WEST_0_240 VDD ) ( IO_FILL_IO_WEST_0_235 VDD ) ( IO_FILL_IO_WEST_0_230 VDD ) ( IO_FILL_IO_WEST_0_225 VDD )
+      ( IO_FILL_IO_WEST_0_220 VDD ) ( IO_FILL_IO_WEST_0_215 VDD ) ( IO_FILL_IO_WEST_0_210 VDD ) ( IO_FILL_IO_WEST_0_205 VDD ) ( IO_FILL_IO_WEST_0_200 VDD ) ( IO_FILL_IO_WEST_0_195 VDD ) ( IO_FILL_IO_WEST_0_190 VDD ) ( IO_FILL_IO_WEST_0_185 VDD )
+      ( IO_FILL_IO_WEST_0_180 VDD ) ( IO_FILL_IO_WEST_0_175 VDD ) ( IO_FILL_IO_WEST_0_170 VDD ) ( IO_FILL_IO_WEST_0_165 VDD ) ( IO_FILL_IO_WEST_0_160 VDD ) ( IO_FILL_IO_WEST_0_155 VDD ) ( IO_FILL_IO_WEST_0_150 VDD ) ( IO_FILL_IO_WEST_0_145 VDD )
+      ( IO_FILL_IO_WEST_0_140 VDD ) ( IO_FILL_IO_WEST_0_135 VDD ) ( IO_FILL_IO_WEST_0_130 VDD ) ( IO_FILL_IO_WEST_0_125 VDD ) ( IO_FILL_IO_WEST_0_120 VDD ) ( IO_FILL_IO_WEST_0_115 VDD ) ( IO_FILL_IO_WEST_0_110 VDD ) ( IO_FILL_IO_WEST_0_105 VDD )
+      ( IO_FILL_IO_WEST_0_100 VDD ) ( IO_FILL_IO_WEST_0_95 VDD ) ( IO_FILL_IO_WEST_0_90 VDD ) ( IO_FILL_IO_WEST_0_85 VDD ) ( IO_FILL_IO_WEST_0_80 VDD ) ( IO_FILL_IO_WEST_0_75 VDD ) ( IO_FILL_IO_WEST_0_70 VDD ) ( IO_FILL_IO_WEST_0_65 VDD )
+      ( IO_FILL_IO_WEST_0_60 VDD ) ( IO_FILL_IO_WEST_0_55 VDD ) ( IO_FILL_IO_WEST_0_50 VDD ) ( IO_FILL_IO_WEST_0_45 VDD ) ( IO_FILL_IO_WEST_0_40 VDD ) ( IO_FILL_IO_WEST_0_35 VDD ) ( IO_FILL_IO_WEST_0_30 VDD ) ( IO_FILL_IO_WEST_0_25 VDD )
+      ( IO_FILL_IO_WEST_0_20 VDD ) ( IO_FILL_IO_WEST_0_15 VDD ) ( IO_FILL_IO_WEST_0_10 VDD ) ( IO_FILL_IO_WEST_0_5 VDD ) ( IO_FILL_IO_WEST_0_0 VDD ) ( IO_CORNER_SOUTH_WEST_INST VDD ) ( IO_FILL_IO_SOUTH_0_0 VDD ) ( IO_FILL_IO_SOUTH_0_5 VDD )
+      ( IO_FILL_IO_WEST_0_490 VDD ) ( IO_FILL_IO_SOUTH_0_10 VDD ) ( IO_FILL_IO_WEST_0_495 VDD ) ( IO_FILL_IO_SOUTH_0_15 VDD ) ( IO_FILL_IO_EAST_0_15 VDD ) ( IO_FILL_IO_EAST_0_10 VDD ) ( IO_FILL_IO_EAST_0_5 VDD ) ( IO_FILL_IO_EAST_0_0 VDD )
+      ( IO_CORNER_SOUTH_EAST_INST VDD ) ( IO_FILL_IO_WEST_56_90 VDD ) ( IO_FILL_IO_WEST_56_85 VDD ) ( IO_FILL_IO_WEST_56_80 VDD ) ( IO_FILL_IO_WEST_56_75 VDD ) ( IO_FILL_IO_WEST_56_70 VDD ) ( IO_FILL_IO_WEST_56_65 VDD ) ( IO_FILL_IO_WEST_56_60 VDD )
+      ( IO_FILL_IO_WEST_56_55 VDD ) ( IO_FILL_IO_WEST_56_50 VDD ) ( IO_FILL_IO_WEST_56_45 VDD ) ( IO_FILL_IO_WEST_56_40 VDD ) ( IO_FILL_IO_WEST_56_35 VDD ) ( IO_FILL_IO_WEST_56_30 VDD ) ( IO_FILL_IO_WEST_56_25 VDD ) ( IO_FILL_IO_WEST_56_20 VDD )
+      ( IO_FILL_IO_WEST_56_15 VDD ) ( IO_FILL_IO_WEST_56_10 VDD ) ( IO_FILL_IO_WEST_56_5 VDD ) ( IO_FILL_IO_WEST_54_95 VDD ) ( IO_FILL_IO_WEST_54_90 VDD ) ( IO_FILL_IO_WEST_54_85 VDD ) ( IO_FILL_IO_WEST_54_80 VDD ) ( IO_FILL_IO_WEST_54_75 VDD )
+      ( IO_FILL_IO_WEST_54_70 VDD ) ( IO_FILL_IO_WEST_54_65 VDD ) ( IO_FILL_IO_WEST_54_60 VDD ) ( IO_FILL_IO_WEST_54_55 VDD ) ( IO_FILL_IO_WEST_54_50 VDD ) ( IO_FILL_IO_WEST_54_45 VDD ) ( IO_FILL_IO_WEST_54_40 VDD ) ( IO_FILL_IO_WEST_54_35 VDD )
+      ( IO_FILL_IO_WEST_54_30 VDD ) ( IO_FILL_IO_WEST_54_25 VDD ) ( IO_FILL_IO_WEST_54_20 VDD ) ( IO_FILL_IO_WEST_54_15 VDD ) ( IO_FILL_IO_WEST_54_10 VDD ) ( IO_FILL_IO_WEST_54_5 VDD ) ( IO_FILL_IO_WEST_51_25 VDD ) ( IO_FILL_IO_WEST_51_20 VDD )
+      ( IO_FILL_IO_WEST_51_15 VDD ) ( IO_FILL_IO_WEST_51_10 VDD ) ( IO_FILL_IO_WEST_51_5 VDD ) ( IO_FILL_IO_WEST_47_45 VDD ) ( IO_FILL_IO_WEST_47_40 VDD ) ( IO_FILL_IO_WEST_47_35 VDD ) ( IO_FILL_IO_WEST_47_30 VDD ) ( IO_FILL_IO_WEST_47_25 VDD )
+      ( IO_FILL_IO_WEST_47_20 VDD ) ( IO_FILL_IO_WEST_47_15 VDD ) ( IO_FILL_IO_WEST_47_10 VDD ) ( IO_FILL_IO_WEST_47_5 VDD ) ( IO_FILL_IO_WEST_32_5 VDD ) ( IO_FILL_IO_WEST_27_5 VDD ) ( IO_FILL_IO_WEST_12_5 VDD ) ( IO_FILL_IO_WEST_7_5 VDD )
+      ( IO_FILL_IO_WEST_3_65 VDD ) ( IO_FILL_IO_WEST_3_60 VDD ) ( IO_FILL_IO_WEST_3_55 VDD ) ( IO_FILL_IO_WEST_3_50 VDD ) ( IO_FILL_IO_WEST_3_45 VDD ) ( IO_FILL_IO_WEST_3_40 VDD ) ( IO_FILL_IO_WEST_3_35 VDD ) ( IO_FILL_IO_WEST_3_30 VDD )
+      ( IO_FILL_IO_WEST_3_25 VDD ) ( IO_FILL_IO_WEST_3_20 VDD ) ( IO_FILL_IO_WEST_3_15 VDD ) ( IO_FILL_IO_WEST_3_10 VDD ) ( IO_FILL_IO_WEST_3_5 VDD ) ( IO_FILL_IO_WEST_0_500 VDD ) ( IO_FILL_IO_WEST_0_505 VDD ) ( IO_FILL_IO_WEST_1_0 VDD )
+      ( IO_FILL_IO_WEST_17_0 VDD ) ( IO_FILL_IO_WEST_51_0 VDD ) ( IO_FILL_IO_WEST_3_0 VDD ) ( IO_FILL_IO_WEST_2_0 VDD ) ( IO_FILL_IO_WEST_19_5 VDD ) ( IO_FILL_IO_WEST_51_30 VDD ) ( IO_FILL_IO_WEST_3_70 VDD ) ( IO_FILL_IO_WEST_20_0 VDD )
+      ( IO_FILL_IO_WEST_35_0 VDD ) ( IO_FILL_IO_WEST_52_0 VDD ) ( IO_FILL_IO_WEST_10_0 VDD ) ( IO_FILL_IO_WEST_16_0 VDD ) ( IO_FILL_IO_WEST_24_0 VDD ) ( IO_FILL_IO_WEST_30_0 VDD ) ( IO_FILL_IO_WEST_38_0 VDD ) ( IO_FILL_IO_WEST_37_5 VDD )
+      ( IO_FILL_IO_WEST_44_0 VDD ) ( IO_FILL_IO_WEST_50_0 VDD ) ( IO_FILL_IO_WEST_15_0 VDD ) ( IO_FILL_IO_WEST_17_5 VDD ) ( IO_FILL_IO_WEST_5_0 VDD ) ( IO_FILL_IO_WEST_4_0 VDD ) ( IO_FILL_IO_WEST_33_0 VDD ) ( IO_FILL_IO_WEST_32_10 VDD )
+      ( IO_FILL_IO_WEST_32_0 VDD ) ( IO_FILL_IO_WEST_31_0 VDD ) ( IO_FILL_IO_WEST_29_0 VDD ) ( IO_FILL_IO_WEST_28_0 VDD ) ( IO_FILL_IO_WEST_27_10 VDD ) ( IO_FILL_IO_WEST_27_0 VDD ) ( IO_FILL_IO_WEST_26_0 VDD ) ( IO_FILL_IO_WEST_25_0 VDD )
+      ( IO_FILL_IO_WEST_23_0 VDD ) ( IO_FILL_IO_WEST_22_5 VDD ) ( IO_FILL_IO_WEST_14_0 VDD ) ( IO_FILL_IO_WEST_13_5 VDD ) ( IO_FILL_IO_WEST_13_0 VDD ) ( IO_FILL_IO_WEST_12_10 VDD ) ( IO_FILL_IO_WEST_12_0 VDD ) ( IO_FILL_IO_WEST_11_0 VDD )
+      ( IO_FILL_IO_WEST_9_0 VDD ) ( IO_FILL_IO_WEST_8_0 VDD ) ( IO_FILL_IO_WEST_7_10 VDD ) ( IO_FILL_IO_WEST_7_0 VDD ) ( IO_FILL_IO_WEST_6_0 VDD ) ( IO_FILL_IO_WEST_22_0 VDD ) ( IO_FILL_IO_WEST_21_0 VDD ) ( IO_FILL_IO_WEST_19_0 VDD )
+      ( IO_FILL_IO_WEST_18_0 VDD ) ( IO_FILL_IO_WEST_49_0 VDD ) ( IO_FILL_IO_WEST_48_0 VDD ) ( IO_FILL_IO_WEST_47_50 VDD ) ( IO_FILL_IO_WEST_47_0 VDD ) ( IO_FILL_IO_WEST_56_95 VDD ) ( IO_FILL_IO_WEST_56_0 VDD ) ( IO_FILL_IO_WEST_55_5 VDD )
+      ( IO_FILL_IO_WEST_55_0 VDD ) ( IO_FILL_IO_WEST_54_100 VDD ) ( IO_FILL_IO_WEST_54_0 VDD ) ( IO_FILL_IO_WEST_53_0 VDD ) ( IO_FILL_IO_WEST_46_0 VDD ) ( IO_FILL_IO_WEST_45_0 VDD ) ( IO_FILL_IO_WEST_43_0 VDD ) ( IO_FILL_IO_WEST_42_5 VDD )
+      ( IO_FILL_IO_WEST_42_0 VDD ) ( IO_FILL_IO_WEST_41_5 VDD ) ( IO_FILL_IO_WEST_41_0 VDD ) ( IO_FILL_IO_WEST_40_0 VDD ) ( IO_FILL_IO_WEST_39_0 VDD ) ( IO_FILL_IO_WEST_34_0 VDD ) ( IO_FILL_IO_WEST_33_5 VDD ) ( IO_FILL_IO_WEST_37_0 VDD )
+      ( IO_FILL_IO_WEST_36_0 VDD ) ( IO_FILL_IO_SOUTH_60_190 VDD ) ( IO_FILL_IO_SOUTH_60_185 VDD ) ( IO_FILL_IO_SOUTH_60_180 VDD ) ( IO_FILL_IO_SOUTH_60_175 VDD ) ( IO_FILL_IO_SOUTH_60_170 VDD ) ( IO_FILL_IO_SOUTH_60_165 VDD ) ( IO_FILL_IO_SOUTH_60_160 VDD )
+      ( IO_FILL_IO_SOUTH_60_155 VDD ) ( IO_FILL_IO_SOUTH_60_150 VDD ) ( IO_FILL_IO_SOUTH_60_145 VDD ) ( IO_FILL_IO_SOUTH_60_140 VDD ) ( IO_FILL_IO_SOUTH_60_135 VDD ) ( IO_FILL_IO_SOUTH_60_130 VDD ) ( IO_FILL_IO_SOUTH_60_125 VDD ) ( IO_FILL_IO_SOUTH_60_120 VDD )
+      ( IO_FILL_IO_SOUTH_60_115 VDD ) ( IO_FILL_IO_SOUTH_60_110 VDD ) ( IO_FILL_IO_SOUTH_60_105 VDD ) ( IO_FILL_IO_SOUTH_60_100 VDD ) ( IO_FILL_IO_SOUTH_60_95 VDD ) ( IO_FILL_IO_SOUTH_60_90 VDD ) ( IO_FILL_IO_SOUTH_60_85 VDD ) ( IO_FILL_IO_SOUTH_60_80 VDD )
+      ( IO_FILL_IO_SOUTH_60_75 VDD ) ( IO_FILL_IO_SOUTH_60_70 VDD ) ( IO_FILL_IO_SOUTH_60_65 VDD ) ( IO_FILL_IO_SOUTH_60_60 VDD ) ( IO_FILL_IO_SOUTH_60_55 VDD ) ( IO_FILL_IO_SOUTH_60_50 VDD ) ( IO_FILL_IO_SOUTH_60_45 VDD ) ( IO_FILL_IO_SOUTH_60_40 VDD )
+      ( IO_FILL_IO_SOUTH_60_35 VDD ) ( IO_FILL_IO_SOUTH_60_30 VDD ) ( IO_FILL_IO_SOUTH_60_25 VDD ) ( IO_FILL_IO_SOUTH_60_20 VDD ) ( IO_FILL_IO_SOUTH_60_15 VDD ) ( IO_FILL_IO_SOUTH_60_10 VDD ) ( IO_FILL_IO_SOUTH_60_5 VDD ) ( IO_FILL_IO_SOUTH_59_125 VDD )
+      ( IO_FILL_IO_SOUTH_59_120 VDD ) ( IO_FILL_IO_SOUTH_59_115 VDD ) ( IO_FILL_IO_SOUTH_59_110 VDD ) ( IO_FILL_IO_SOUTH_59_105 VDD ) ( IO_FILL_IO_SOUTH_59_100 VDD ) ( IO_FILL_IO_SOUTH_59_95 VDD ) ( IO_FILL_IO_SOUTH_59_90 VDD ) ( IO_FILL_IO_SOUTH_59_85 VDD )
+      ( IO_FILL_IO_SOUTH_59_80 VDD ) ( IO_FILL_IO_SOUTH_59_75 VDD ) ( IO_FILL_IO_SOUTH_59_70 VDD ) ( IO_FILL_IO_SOUTH_59_65 VDD ) ( IO_FILL_IO_SOUTH_59_60 VDD ) ( IO_FILL_IO_SOUTH_59_55 VDD ) ( IO_FILL_IO_SOUTH_59_50 VDD ) ( IO_FILL_IO_SOUTH_59_45 VDD )
+      ( IO_FILL_IO_SOUTH_59_40 VDD ) ( IO_FILL_IO_SOUTH_59_35 VDD ) ( IO_FILL_IO_SOUTH_59_30 VDD ) ( IO_FILL_IO_SOUTH_59_25 VDD ) ( IO_FILL_IO_SOUTH_59_20 VDD ) ( IO_FILL_IO_SOUTH_59_15 VDD ) ( IO_FILL_IO_SOUTH_59_10 VDD ) ( IO_FILL_IO_SOUTH_59_5 VDD )
+      ( IO_FILL_IO_SOUTH_57_60 VDD ) ( IO_FILL_IO_SOUTH_57_55 VDD ) ( IO_FILL_IO_SOUTH_57_50 VDD ) ( IO_FILL_IO_SOUTH_57_45 VDD ) ( IO_FILL_IO_SOUTH_57_40 VDD ) ( IO_FILL_IO_SOUTH_57_35 VDD ) ( IO_FILL_IO_SOUTH_57_30 VDD ) ( IO_FILL_IO_SOUTH_57_25 VDD )
+      ( IO_FILL_IO_SOUTH_57_20 VDD ) ( IO_FILL_IO_SOUTH_57_15 VDD ) ( IO_FILL_IO_SOUTH_57_10 VDD ) ( IO_FILL_IO_SOUTH_57_5 VDD ) ( IO_FILL_IO_SOUTH_54_65 VDD ) ( IO_FILL_IO_SOUTH_54_60 VDD ) ( IO_FILL_IO_SOUTH_54_55 VDD ) ( IO_FILL_IO_SOUTH_54_50 VDD )
+      ( IO_FILL_IO_SOUTH_54_45 VDD ) ( IO_FILL_IO_SOUTH_54_40 VDD ) ( IO_FILL_IO_SOUTH_54_35 VDD ) ( IO_FILL_IO_SOUTH_54_30 VDD ) ( IO_FILL_IO_SOUTH_54_25 VDD ) ( IO_FILL_IO_SOUTH_54_20 VDD ) ( IO_FILL_IO_SOUTH_54_15 VDD ) ( IO_FILL_IO_SOUTH_54_10 VDD )
+      ( IO_FILL_IO_SOUTH_54_5 VDD ) ( IO_FILL_IO_SOUTH_40_5 VDD ) ( IO_FILL_IO_SOUTH_20_5 VDD ) ( IO_FILL_IO_SOUTH_10_30 VDD ) ( IO_FILL_IO_SOUTH_10_25 VDD ) ( IO_FILL_IO_SOUTH_10_20 VDD ) ( IO_FILL_IO_SOUTH_10_15 VDD ) ( IO_FILL_IO_SOUTH_10_10 VDD )
+      ( IO_FILL_IO_SOUTH_10_5 VDD ) ( IO_FILL_IO_SOUTH_6_35 VDD ) ( IO_FILL_IO_SOUTH_6_30 VDD ) ( IO_FILL_IO_SOUTH_6_25 VDD ) ( IO_FILL_IO_SOUTH_6_20 VDD ) ( IO_FILL_IO_SOUTH_6_15 VDD ) ( IO_FILL_IO_SOUTH_6_10 VDD ) ( IO_FILL_IO_SOUTH_6_5 VDD )
+      ( IO_FILL_IO_SOUTH_3_95 VDD ) ( IO_FILL_IO_SOUTH_3_90 VDD ) ( IO_FILL_IO_SOUTH_3_85 VDD ) ( IO_FILL_IO_SOUTH_3_80 VDD ) ( IO_FILL_IO_SOUTH_3_75 VDD ) ( IO_FILL_IO_SOUTH_3_70 VDD ) ( IO_FILL_IO_SOUTH_3_65 VDD ) ( IO_FILL_IO_SOUTH_3_60 VDD )
+      ( IO_FILL_IO_SOUTH_3_55 VDD ) ( IO_FILL_IO_SOUTH_3_50 VDD ) ( IO_FILL_IO_SOUTH_3_45 VDD ) ( IO_FILL_IO_SOUTH_3_40 VDD ) ( IO_FILL_IO_SOUTH_3_35 VDD ) ( IO_FILL_IO_SOUTH_3_30 VDD ) ( IO_FILL_IO_SOUTH_3_25 VDD ) ( IO_FILL_IO_SOUTH_3_20 VDD )
+      ( IO_FILL_IO_SOUTH_3_15 VDD ) ( IO_FILL_IO_SOUTH_3_10 VDD ) ( IO_FILL_IO_SOUTH_3_5 VDD ) ( IO_FILL_IO_SOUTH_1_95 VDD ) ( IO_FILL_IO_SOUTH_1_90 VDD ) ( IO_FILL_IO_SOUTH_1_85 VDD ) ( IO_FILL_IO_SOUTH_1_80 VDD ) ( IO_FILL_IO_SOUTH_1_75 VDD )
+      ( IO_FILL_IO_SOUTH_1_70 VDD ) ( IO_FILL_IO_SOUTH_1_65 VDD ) ( IO_FILL_IO_SOUTH_1_60 VDD ) ( IO_FILL_IO_SOUTH_1_55 VDD ) ( IO_FILL_IO_SOUTH_1_50 VDD ) ( IO_FILL_IO_SOUTH_1_45 VDD ) ( IO_FILL_IO_SOUTH_1_40 VDD ) ( IO_FILL_IO_SOUTH_1_35 VDD )
+      ( IO_FILL_IO_SOUTH_1_30 VDD ) ( IO_FILL_IO_SOUTH_1_25 VDD ) ( IO_FILL_IO_SOUTH_1_20 VDD ) ( IO_FILL_IO_SOUTH_1_15 VDD ) ( IO_FILL_IO_SOUTH_1_10 VDD ) ( IO_FILL_IO_SOUTH_1_5 VDD ) ( IO_FILL_IO_SOUTH_0_20 VDD ) ( IO_FILL_IO_SOUTH_6_0 VDD )
+      ( IO_FILL_IO_SOUTH_3_100 VDD ) ( IO_FILL_IO_SOUTH_59_0 VDD ) ( IO_FILL_IO_SOUTH_50_5 VDD ) ( IO_FILL_IO_SOUTH_45_0 VDD ) ( IO_FILL_IO_SOUTH_30_5 VDD ) ( IO_FILL_IO_SOUTH_25_0 VDD ) ( IO_FILL_IO_SOUTH_10_35 VDD ) ( IO_FILL_IO_SOUTH_3_0 VDD )
+      ( IO_FILL_IO_SOUTH_54_0 VDD ) ( IO_FILL_IO_SOUTH_22_0 VDD ) ( IO_FILL_IO_SOUTH_6_40 VDD ) ( IO_FILL_IO_SOUTH_53_0 VDD ) ( IO_FILL_IO_SOUTH_36_0 VDD ) ( IO_FILL_IO_SOUTH_35_5 VDD ) ( IO_FILL_IO_SOUTH_21_0 VDD ) ( IO_FILL_IO_SOUTH_20_10 VDD )
+      ( IO_FILL_IO_SOUTH_60_0 VDD ) ( IO_FILL_IO_SOUTH_59_130 VDD ) ( IO_FILL_IO_SOUTH_52_0 VDD ) ( IO_FILL_IO_SOUTH_51_0 VDD ) ( IO_FILL_IO_SOUTH_45_5 VDD ) ( IO_FILL_IO_SOUTH_40_0 VDD ) ( IO_FILL_IO_SOUTH_39_0 VDD ) ( IO_FILL_IO_SOUTH_31_0 VDD )
+      ( IO_FILL_IO_SOUTH_25_5 VDD ) ( IO_FILL_IO_SOUTH_17_0 VDD ) ( IO_FILL_IO_SOUTH_11_0 VDD ) ( IO_FILL_IO_SOUTH_42_5 VDD ) ( IO_FILL_IO_SOUTH_42_0 VDD ) ( IO_FILL_IO_SOUTH_46_0 VDD ) ( IO_FILL_IO_SOUTH_41_0 VDD ) ( IO_FILL_IO_SOUTH_40_10 VDD )
+      ( IO_FILL_IO_SOUTH_57_0 VDD ) ( IO_FILL_IO_SOUTH_56_5 VDD ) ( IO_FILL_IO_SOUTH_5_0 VDD ) ( IO_FILL_IO_SOUTH_4_0 VDD ) ( IO_FILL_IO_SOUTH_56_0 VDD ) ( IO_FILL_IO_SOUTH_2_0 VDD ) ( IO_FILL_IO_SOUTH_1_100 VDD ) ( IO_FILL_IO_SOUTH_58_0 VDD )
+      ( IO_FILL_IO_SOUTH_57_65 VDD ) ( IO_FILL_IO_SOUTH_1_0 VDD ) ( IO_FILL_IO_SOUTH_0_25 VDD ) ( IO_FILL_IO_SOUTH_48_0 VDD ) ( IO_FILL_IO_SOUTH_47_0 VDD ) ( IO_FILL_IO_SOUTH_48_5 VDD ) ( IO_FILL_IO_SOUTH_55_0 VDD ) ( IO_FILL_IO_SOUTH_54_70 VDD )
+      ( IO_FILL_IO_SOUTH_50_0 VDD ) ( IO_FILL_IO_SOUTH_49_0 VDD ) ( IO_FILL_IO_SOUTH_44_0 VDD ) ( IO_FILL_IO_SOUTH_43_0 VDD ) ( IO_FILL_IO_SOUTH_8_0 VDD ) ( IO_FILL_IO_SOUTH_7_0 VDD ) ( IO_FILL_IO_SOUTH_8_5 VDD ) ( IO_FILL_IO_SOUTH_10_0 VDD )
+      ( IO_FILL_IO_SOUTH_9_0 VDD ) ( IO_FILL_IO_SOUTH_22_5 VDD ) ( IO_FILL_IO_SOUTH_24_0 VDD ) ( IO_FILL_IO_SOUTH_23_0 VDD ) ( IO_FILL_IO_SOUTH_26_0 VDD ) ( IO_FILL_IO_SOUTH_28_0 VDD ) ( IO_FILL_IO_SOUTH_27_0 VDD ) ( IO_FILL_IO_SOUTH_28_5 VDD )
+      ( IO_FILL_IO_SOUTH_30_0 VDD ) ( IO_FILL_IO_SOUTH_29_0 VDD ) ( IO_FILL_IO_SOUTH_32_0 VDD ) ( IO_FILL_IO_SOUTH_34_0 VDD ) ( IO_FILL_IO_SOUTH_33_0 VDD ) ( IO_FILL_IO_SOUTH_35_0 VDD ) ( IO_FILL_IO_SOUTH_34_5 VDD ) ( IO_FILL_IO_SOUTH_12_0 VDD )
+      ( IO_FILL_IO_SOUTH_14_0 VDD ) ( IO_FILL_IO_SOUTH_13_0 VDD ) ( IO_FILL_IO_SOUTH_15_0 VDD ) ( IO_FILL_IO_SOUTH_14_5 VDD ) ( IO_FILL_IO_SOUTH_16_0 VDD ) ( IO_FILL_IO_SOUTH_15_5 VDD ) ( IO_FILL_IO_SOUTH_18_0 VDD ) ( IO_FILL_IO_SOUTH_20_0 VDD )
+      ( IO_FILL_IO_SOUTH_19_0 VDD ) ( IO_FILL_IO_SOUTH_38_0 VDD ) ( IO_FILL_IO_SOUTH_37_0 VDD ) ( IO_FILL_IO_EAST_60_180 VDD ) ( IO_FILL_IO_EAST_60_175 VDD ) ( IO_FILL_IO_EAST_60_170 VDD ) ( IO_FILL_IO_EAST_60_165 VDD ) ( IO_FILL_IO_EAST_60_160 VDD )
+      ( IO_FILL_IO_EAST_60_155 VDD ) ( IO_FILL_IO_EAST_60_150 VDD ) ( IO_FILL_IO_EAST_60_145 VDD ) ( IO_FILL_IO_EAST_60_140 VDD ) ( IO_FILL_IO_EAST_60_135 VDD ) ( IO_FILL_IO_EAST_60_130 VDD ) ( IO_FILL_IO_EAST_60_125 VDD ) ( IO_FILL_IO_EAST_60_120 VDD )
+      ( IO_FILL_IO_EAST_60_115 VDD ) ( IO_FILL_IO_EAST_60_110 VDD ) ( IO_FILL_IO_EAST_60_105 VDD ) ( IO_FILL_IO_EAST_60_100 VDD ) ( IO_FILL_IO_EAST_60_95 VDD ) ( IO_FILL_IO_EAST_60_90 VDD ) ( IO_FILL_IO_EAST_60_85 VDD ) ( IO_FILL_IO_EAST_60_80 VDD )
+      ( IO_FILL_IO_EAST_60_75 VDD ) ( IO_FILL_IO_EAST_60_70 VDD ) ( IO_FILL_IO_EAST_60_65 VDD ) ( IO_FILL_IO_EAST_60_60 VDD ) ( IO_FILL_IO_EAST_60_55 VDD ) ( IO_FILL_IO_EAST_60_50 VDD ) ( IO_FILL_IO_EAST_60_45 VDD ) ( IO_FILL_IO_EAST_60_40 VDD )
+      ( IO_FILL_IO_EAST_60_35 VDD ) ( IO_FILL_IO_EAST_60_30 VDD ) ( IO_FILL_IO_EAST_60_25 VDD ) ( IO_FILL_IO_EAST_60_20 VDD ) ( IO_FILL_IO_EAST_60_15 VDD ) ( IO_FILL_IO_EAST_60_10 VDD ) ( IO_FILL_IO_EAST_60_5 VDD ) ( IO_FILL_IO_EAST_59_120 VDD )
+      ( IO_FILL_IO_EAST_59_115 VDD ) ( IO_FILL_IO_EAST_59_110 VDD ) ( IO_FILL_IO_EAST_59_105 VDD ) ( IO_FILL_IO_EAST_59_100 VDD ) ( IO_FILL_IO_EAST_59_95 VDD ) ( IO_FILL_IO_EAST_59_90 VDD ) ( IO_FILL_IO_EAST_59_85 VDD ) ( IO_FILL_IO_EAST_59_80 VDD )
+      ( IO_FILL_IO_EAST_59_75 VDD ) ( IO_FILL_IO_EAST_59_70 VDD ) ( IO_FILL_IO_EAST_59_65 VDD ) ( IO_FILL_IO_EAST_59_60 VDD ) ( IO_FILL_IO_EAST_59_55 VDD ) ( IO_FILL_IO_EAST_59_50 VDD ) ( IO_FILL_IO_EAST_59_45 VDD ) ( IO_FILL_IO_EAST_59_40 VDD )
+      ( IO_FILL_IO_EAST_59_35 VDD ) ( IO_FILL_IO_EAST_59_30 VDD ) ( IO_FILL_IO_EAST_59_25 VDD ) ( IO_FILL_IO_EAST_59_20 VDD ) ( IO_FILL_IO_EAST_59_15 VDD ) ( IO_FILL_IO_EAST_59_10 VDD ) ( IO_FILL_IO_EAST_59_5 VDD ) ( IO_FILL_IO_EAST_57_65 VDD )
+      ( IO_FILL_IO_EAST_57_60 VDD ) ( IO_FILL_IO_EAST_57_55 VDD ) ( IO_FILL_IO_EAST_57_50 VDD ) ( IO_FILL_IO_EAST_57_45 VDD ) ( IO_FILL_IO_EAST_57_40 VDD ) ( IO_FILL_IO_EAST_57_35 VDD ) ( IO_FILL_IO_EAST_57_30 VDD ) ( IO_FILL_IO_EAST_57_25 VDD )
+      ( IO_FILL_IO_EAST_57_20 VDD ) ( IO_FILL_IO_EAST_57_15 VDD ) ( IO_FILL_IO_EAST_57_10 VDD ) ( IO_FILL_IO_EAST_57_5 VDD ) ( IO_FILL_IO_EAST_54_65 VDD ) ( IO_FILL_IO_EAST_54_60 VDD ) ( IO_FILL_IO_EAST_54_55 VDD ) ( IO_FILL_IO_EAST_54_50 VDD )
+      ( IO_FILL_IO_EAST_54_45 VDD ) ( IO_FILL_IO_EAST_54_40 VDD ) ( IO_FILL_IO_EAST_54_35 VDD ) ( IO_FILL_IO_EAST_54_30 VDD ) ( IO_FILL_IO_EAST_54_25 VDD ) ( IO_FILL_IO_EAST_54_20 VDD ) ( IO_FILL_IO_EAST_54_15 VDD ) ( IO_FILL_IO_EAST_54_10 VDD )
+      ( IO_FILL_IO_EAST_54_5 VDD ) ( IO_FILL_IO_EAST_50_5 VDD ) ( IO_FILL_IO_EAST_35_5 VDD ) ( IO_FILL_IO_EAST_30_5 VDD ) ( IO_FILL_IO_EAST_15_5 VDD ) ( IO_FILL_IO_EAST_10_35 VDD ) ( IO_FILL_IO_EAST_10_30 VDD ) ( IO_FILL_IO_EAST_10_25 VDD )
+      ( IO_FILL_IO_EAST_10_20 VDD ) ( IO_FILL_IO_EAST_10_15 VDD ) ( IO_FILL_IO_EAST_10_10 VDD ) ( IO_FILL_IO_EAST_10_5 VDD ) ( IO_FILL_IO_EAST_6_35 VDD ) ( IO_FILL_IO_EAST_6_30 VDD ) ( IO_FILL_IO_EAST_6_25 VDD ) ( IO_FILL_IO_EAST_6_20 VDD )
+      ( IO_FILL_IO_EAST_6_15 VDD ) ( IO_FILL_IO_EAST_6_10 VDD ) ( IO_FILL_IO_EAST_6_5 VDD ) ( IO_FILL_IO_EAST_3_90 VDD ) ( IO_FILL_IO_EAST_3_85 VDD ) ( IO_FILL_IO_EAST_3_80 VDD ) ( IO_FILL_IO_EAST_3_75 VDD ) ( IO_FILL_IO_EAST_3_70 VDD )
+      ( IO_FILL_IO_EAST_3_65 VDD ) ( IO_FILL_IO_EAST_3_60 VDD ) ( IO_FILL_IO_EAST_3_55 VDD ) ( IO_FILL_IO_EAST_3_50 VDD ) ( IO_FILL_IO_EAST_3_45 VDD ) ( IO_FILL_IO_EAST_3_40 VDD ) ( IO_FILL_IO_EAST_3_35 VDD ) ( IO_FILL_IO_EAST_3_30 VDD )
+      ( IO_FILL_IO_EAST_3_25 VDD ) ( IO_FILL_IO_EAST_3_20 VDD ) ( IO_FILL_IO_EAST_3_15 VDD ) ( IO_FILL_IO_EAST_3_10 VDD ) ( IO_FILL_IO_EAST_3_5 VDD ) ( IO_FILL_IO_EAST_1_95 VDD ) ( IO_FILL_IO_EAST_1_90 VDD ) ( IO_FILL_IO_EAST_1_85 VDD )
+      ( IO_FILL_IO_EAST_1_80 VDD ) ( IO_FILL_IO_EAST_1_75 VDD ) ( IO_FILL_IO_EAST_1_70 VDD ) ( IO_FILL_IO_EAST_1_65 VDD ) ( IO_FILL_IO_EAST_1_60 VDD ) ( IO_FILL_IO_EAST_1_55 VDD ) ( IO_FILL_IO_EAST_1_50 VDD ) ( IO_FILL_IO_EAST_1_45 VDD )
+      ( IO_FILL_IO_EAST_1_40 VDD ) ( IO_FILL_IO_EAST_1_35 VDD ) ( IO_FILL_IO_EAST_1_30 VDD ) ( IO_FILL_IO_EAST_1_25 VDD ) ( IO_FILL_IO_EAST_1_20 VDD ) ( IO_FILL_IO_EAST_1_15 VDD ) ( IO_FILL_IO_EAST_1_10 VDD ) ( IO_FILL_IO_EAST_1_5 VDD )
+      ( IO_FILL_IO_EAST_0_20 VDD ) ( IO_FILL_IO_EAST_6_40 VDD ) ( IO_FILL_IO_EAST_40_5 VDD ) ( IO_FILL_IO_EAST_57_0 VDD ) ( IO_FILL_IO_EAST_56_0 VDD ) ( IO_FILL_IO_EAST_38_0 VDD ) ( IO_FILL_IO_EAST_22_0 VDD ) ( IO_FILL_IO_EAST_4_0 VDD )
+      ( IO_FILL_IO_EAST_3_95 VDD ) ( IO_FILL_IO_EAST_7_0 VDD ) ( IO_FILL_IO_EAST_54_0 VDD ) ( IO_FILL_IO_EAST_53_0 VDD ) ( IO_FILL_IO_EAST_47_0 VDD ) ( IO_FILL_IO_EAST_41_0 VDD ) ( IO_FILL_IO_EAST_33_0 VDD ) ( IO_FILL_IO_EAST_27_0 VDD )
+      ( IO_FILL_IO_EAST_20_0 VDD ) ( IO_FILL_IO_EAST_19_0 VDD ) ( IO_FILL_IO_EAST_13_0 VDD ) ( IO_FILL_IO_EAST_30_0 VDD ) ( IO_FILL_IO_EAST_29_0 VDD ) ( IO_FILL_IO_EAST_28_0 VDD ) ( IO_FILL_IO_EAST_15_0 VDD ) ( IO_FILL_IO_EAST_14_0 VDD )
+      ( IO_FILL_IO_EAST_16_0 VDD ) ( IO_FILL_IO_EAST_15_10 VDD ) ( IO_FILL_IO_EAST_16_5 VDD ) ( IO_FILL_IO_EAST_18_0 VDD ) ( IO_FILL_IO_EAST_17_0 VDD ) ( IO_FILL_IO_EAST_21_0 VDD ) ( IO_FILL_IO_EAST_20_5 VDD ) ( IO_FILL_IO_EAST_24_0 VDD )
+      ( IO_FILL_IO_EAST_23_0 VDD ) ( IO_FILL_IO_EAST_25_0 VDD ) ( IO_FILL_IO_EAST_24_5 VDD ) ( IO_FILL_IO_EAST_26_0 VDD ) ( IO_FILL_IO_EAST_25_5 VDD ) ( IO_FILL_IO_EAST_1_0 VDD ) ( IO_FILL_IO_EAST_0_25 VDD ) ( IO_FILL_IO_EAST_2_0 VDD )
+      ( IO_FILL_IO_EAST_1_100 VDD ) ( IO_FILL_IO_EAST_3_0 VDD ) ( IO_FILL_IO_EAST_2_5 VDD ) ( IO_FILL_IO_EAST_6_0 VDD ) ( IO_FILL_IO_EAST_5_0 VDD ) ( IO_FILL_IO_EAST_8_0 VDD ) ( IO_FILL_IO_EAST_10_0 VDD ) ( IO_FILL_IO_EAST_9_0 VDD )
+      ( IO_FILL_IO_EAST_10_40 VDD ) ( IO_FILL_IO_EAST_12_0 VDD ) ( IO_FILL_IO_EAST_11_0 VDD ) ( IO_FILL_IO_EAST_30_10 VDD ) ( IO_FILL_IO_EAST_45_0 VDD ) ( IO_FILL_IO_EAST_44_5 VDD ) ( IO_FILL_IO_EAST_46_0 VDD ) ( IO_FILL_IO_EAST_45_5 VDD )
+      ( IO_FILL_IO_EAST_48_0 VDD ) ( IO_FILL_IO_EAST_37_0 VDD ) ( IO_FILL_IO_EAST_36_5 VDD ) ( IO_FILL_IO_EAST_40_0 VDD ) ( IO_FILL_IO_EAST_39_0 VDD ) ( IO_FILL_IO_EAST_42_0 VDD ) ( IO_FILL_IO_EAST_44_0 VDD ) ( IO_FILL_IO_EAST_43_0 VDD )
+      ( IO_FILL_IO_EAST_50_0 VDD ) ( IO_FILL_IO_EAST_49_0 VDD ) ( IO_FILL_IO_EAST_50_10 VDD ) ( IO_FILL_IO_EAST_52_0 VDD ) ( IO_FILL_IO_EAST_51_0 VDD ) ( IO_FILL_IO_EAST_55_0 VDD ) ( IO_FILL_IO_EAST_54_70 VDD ) ( IO_FILL_IO_EAST_58_0 VDD )
+      ( IO_FILL_IO_EAST_57_70 VDD ) ( IO_FILL_IO_EAST_59_0 VDD ) ( IO_FILL_IO_EAST_58_5 VDD ) ( IO_FILL_IO_EAST_60_0 VDD ) ( IO_FILL_IO_EAST_59_125 VDD ) ( IO_FILL_IO_EAST_36_0 VDD ) ( IO_FILL_IO_EAST_35_10 VDD ) ( IO_FILL_IO_EAST_35_0 VDD )
+      ( IO_FILL_IO_EAST_34_0 VDD ) ( IO_FILL_IO_EAST_32_0 VDD ) ( IO_FILL_IO_EAST_31_0 VDD ) ( IO_FILL_IO_NORTH_53_95 VDD ) ( IO_FILL_IO_NORTH_53_90 VDD ) ( IO_FILL_IO_NORTH_53_85 VDD ) ( IO_FILL_IO_NORTH_53_80 VDD ) ( IO_FILL_IO_NORTH_53_75 VDD )
+      ( IO_FILL_IO_NORTH_53_70 VDD ) ( IO_FILL_IO_NORTH_53_65 VDD ) ( IO_FILL_IO_NORTH_53_60 VDD ) ( IO_FILL_IO_NORTH_53_55 VDD ) ( IO_FILL_IO_NORTH_53_50 VDD ) ( IO_FILL_IO_NORTH_53_45 VDD ) ( IO_FILL_IO_NORTH_53_40 VDD ) ( IO_FILL_IO_NORTH_53_35 VDD )
+      ( IO_FILL_IO_NORTH_53_30 VDD ) ( IO_FILL_IO_NORTH_53_25 VDD ) ( IO_FILL_IO_NORTH_53_20 VDD ) ( IO_FILL_IO_NORTH_53_15 VDD ) ( IO_FILL_IO_NORTH_53_10 VDD ) ( IO_FILL_IO_NORTH_53_5 VDD ) ( IO_FILL_IO_NORTH_51_95 VDD ) ( IO_FILL_IO_NORTH_51_90 VDD )
+      ( IO_FILL_IO_NORTH_51_85 VDD ) ( IO_FILL_IO_NORTH_51_80 VDD ) ( IO_FILL_IO_NORTH_51_75 VDD ) ( IO_FILL_IO_NORTH_51_70 VDD ) ( IO_FILL_IO_NORTH_51_65 VDD ) ( IO_FILL_IO_NORTH_51_60 VDD ) ( IO_FILL_IO_NORTH_51_55 VDD ) ( IO_FILL_IO_NORTH_51_50 VDD )
+      ( IO_FILL_IO_NORTH_51_45 VDD ) ( IO_FILL_IO_NORTH_51_40 VDD ) ( IO_FILL_IO_NORTH_51_35 VDD ) ( IO_FILL_IO_NORTH_51_30 VDD ) ( IO_FILL_IO_NORTH_51_25 VDD ) ( IO_FILL_IO_NORTH_51_20 VDD ) ( IO_FILL_IO_NORTH_51_15 VDD ) ( IO_FILL_IO_NORTH_51_10 VDD )
+      ( IO_FILL_IO_NORTH_51_5 VDD ) ( IO_FILL_IO_NORTH_48_35 VDD ) ( IO_FILL_IO_NORTH_48_30 VDD ) ( IO_FILL_IO_NORTH_48_25 VDD ) ( IO_FILL_IO_NORTH_48_20 VDD ) ( IO_FILL_IO_NORTH_48_15 VDD ) ( IO_FILL_IO_NORTH_48_10 VDD ) ( IO_FILL_IO_NORTH_48_5 VDD )
+      ( IO_FILL_IO_NORTH_44_30 VDD ) ( IO_FILL_IO_NORTH_44_25 VDD ) ( IO_FILL_IO_NORTH_44_20 VDD ) ( IO_FILL_IO_NORTH_44_15 VDD ) ( IO_FILL_IO_NORTH_44_10 VDD ) ( IO_FILL_IO_NORTH_44_5 VDD ) ( IO_FILL_IO_NORTH_42_20 VDD ) ( IO_FILL_IO_NORTH_42_15 VDD )
+      ( IO_FILL_IO_NORTH_42_10 VDD ) ( IO_FILL_IO_NORTH_42_5 VDD ) ( IO_FILL_IO_NORTH_30_15 VDD ) ( IO_FILL_IO_NORTH_30_10 VDD ) ( IO_FILL_IO_NORTH_30_5 VDD ) ( IO_FILL_IO_NORTH_25_5 VDD ) ( IO_FILL_IO_NORTH_10_5 VDD ) ( IO_FILL_IO_NORTH_6_60 VDD )
+      ( IO_FILL_IO_NORTH_6_55 VDD ) ( IO_FILL_IO_NORTH_6_50 VDD ) ( IO_FILL_IO_NORTH_6_45 VDD ) ( IO_FILL_IO_NORTH_6_40 VDD ) ( IO_FILL_IO_NORTH_6_35 VDD ) ( IO_FILL_IO_NORTH_6_30 VDD ) ( IO_FILL_IO_NORTH_6_25 VDD ) ( IO_FILL_IO_NORTH_6_20 VDD )
+      ( IO_FILL_IO_NORTH_6_15 VDD ) ( IO_FILL_IO_NORTH_6_10 VDD ) ( IO_FILL_IO_NORTH_6_5 VDD ) ( IO_FILL_IO_NORTH_3_65 VDD ) ( IO_FILL_IO_NORTH_3_60 VDD ) ( IO_FILL_IO_NORTH_3_55 VDD ) ( IO_FILL_IO_NORTH_3_50 VDD ) ( IO_FILL_IO_NORTH_3_45 VDD )
+      ( IO_FILL_IO_NORTH_3_40 VDD ) ( IO_FILL_IO_NORTH_3_35 VDD ) ( IO_FILL_IO_NORTH_3_30 VDD ) ( IO_FILL_IO_NORTH_3_25 VDD ) ( IO_FILL_IO_NORTH_3_20 VDD ) ( IO_FILL_IO_NORTH_3_15 VDD ) ( IO_FILL_IO_NORTH_3_10 VDD ) ( IO_FILL_IO_NORTH_3_5 VDD )
+      ( IO_FILL_IO_NORTH_1_125 VDD ) ( IO_FILL_IO_NORTH_1_120 VDD ) ( IO_FILL_IO_NORTH_1_115 VDD ) ( IO_FILL_IO_NORTH_1_110 VDD ) ( IO_FILL_IO_NORTH_1_105 VDD ) ( IO_FILL_IO_NORTH_1_100 VDD ) ( IO_FILL_IO_NORTH_1_95 VDD ) ( IO_FILL_IO_NORTH_1_90 VDD )
+      ( IO_FILL_IO_NORTH_1_85 VDD ) ( IO_FILL_IO_NORTH_1_80 VDD ) ( IO_FILL_IO_NORTH_1_75 VDD ) ( IO_FILL_IO_NORTH_1_70 VDD ) ( IO_FILL_IO_NORTH_1_65 VDD ) ( IO_FILL_IO_NORTH_1_60 VDD ) ( IO_FILL_IO_NORTH_1_55 VDD ) ( IO_FILL_IO_NORTH_1_50 VDD )
+      ( IO_FILL_IO_NORTH_1_45 VDD ) ( IO_FILL_IO_NORTH_1_40 VDD ) ( IO_FILL_IO_NORTH_1_35 VDD ) ( IO_FILL_IO_NORTH_1_30 VDD ) ( IO_FILL_IO_NORTH_1_25 VDD ) ( IO_FILL_IO_NORTH_1_20 VDD ) ( IO_FILL_IO_NORTH_1_15 VDD ) ( IO_FILL_IO_NORTH_1_10 VDD )
+      ( IO_FILL_IO_NORTH_1_5 VDD ) ( IO_FILL_IO_NORTH_0_210 VDD ) ( IO_FILL_IO_NORTH_0_205 VDD ) ( IO_FILL_IO_NORTH_0_200 VDD ) ( IO_FILL_IO_NORTH_0_195 VDD ) ( IO_FILL_IO_NORTH_0_190 VDD ) ( IO_FILL_IO_NORTH_0_185 VDD ) ( IO_FILL_IO_NORTH_0_180 VDD )
+      ( IO_FILL_IO_NORTH_0_175 VDD ) ( IO_FILL_IO_NORTH_0_170 VDD ) ( IO_FILL_IO_NORTH_0_165 VDD ) ( IO_FILL_IO_NORTH_0_160 VDD ) ( IO_FILL_IO_NORTH_0_155 VDD ) ( IO_FILL_IO_NORTH_0_150 VDD ) ( IO_FILL_IO_NORTH_0_145 VDD ) ( IO_FILL_IO_NORTH_0_140 VDD )
+      ( IO_FILL_IO_NORTH_0_135 VDD ) ( IO_FILL_IO_NORTH_0_130 VDD ) ( IO_FILL_IO_NORTH_0_125 VDD ) ( IO_FILL_IO_NORTH_0_120 VDD ) ( IO_FILL_IO_NORTH_0_115 VDD ) ( IO_FILL_IO_NORTH_0_110 VDD ) ( IO_FILL_IO_NORTH_0_105 VDD ) ( IO_FILL_IO_NORTH_0_100 VDD )
+      ( IO_FILL_IO_NORTH_0_95 VDD ) ( IO_FILL_IO_NORTH_0_90 VDD ) ( IO_FILL_IO_NORTH_0_85 VDD ) ( IO_FILL_IO_NORTH_0_80 VDD ) ( IO_FILL_IO_NORTH_0_75 VDD ) ( IO_FILL_IO_NORTH_0_70 VDD ) ( IO_FILL_IO_NORTH_0_65 VDD ) ( IO_FILL_IO_NORTH_0_60 VDD )
+      ( IO_FILL_IO_NORTH_0_55 VDD ) ( IO_FILL_IO_NORTH_0_50 VDD ) ( IO_FILL_IO_NORTH_0_45 VDD ) ( IO_FILL_IO_NORTH_0_40 VDD ) ( IO_FILL_IO_NORTH_0_35 VDD ) ( IO_FILL_IO_NORTH_0_30 VDD ) ( IO_FILL_IO_NORTH_0_25 VDD ) ( IO_FILL_IO_NORTH_0_20 VDD )
+      ( IO_FILL_IO_NORTH_0_15 VDD ) ( IO_FILL_IO_NORTH_0_10 VDD ) ( IO_FILL_IO_NORTH_0_5 VDD ) ( IO_FILL_IO_NORTH_0_0 VDD ) ( IO_FILL_IO_NORTH_1_130 VDD ) ( IO_FILL_IO_NORTH_10_0 VDD ) ( IO_FILL_IO_NORTH_15_5 VDD ) ( IO_FILL_IO_NORTH_53_100 VDD )
+      ( IO_FILL_IO_NORTH_37_0 VDD ) ( IO_FILL_IO_NORTH_48_40 VDD ) ( IO_FILL_IO_NORTH_6_0 VDD ) ( IO_FILL_IO_NORTH_22_0 VDD ) ( IO_FILL_IO_NORTH_30_20 VDD ) ( IO_FILL_IO_NORTH_37_5 VDD ) ( IO_FILL_IO_NORTH_49_0 VDD ) ( IO_FILL_IO_NORTH_6_65 VDD )
+      ( IO_FILL_IO_NORTH_23_0 VDD ) ( IO_FILL_IO_NORTH_1_0 VDD ) ( IO_FILL_IO_NORTH_0_215 VDD ) ( IO_FILL_IO_NORTH_9_0 VDD ) ( IO_FILL_IO_NORTH_15_0 VDD ) ( IO_FILL_IO_NORTH_21_0 VDD ) ( IO_FILL_IO_NORTH_20_5 VDD ) ( IO_FILL_IO_NORTH_26_5 VDD )
+      ( IO_FILL_IO_NORTH_35_0 VDD ) ( IO_FILL_IO_NORTH_34_0 VDD ) ( IO_FILL_IO_NORTH_45_0 VDD ) ( IO_FILL_IO_NORTH_44_35 VDD ) ( IO_FILL_IO_NORTH_53_0 VDD ) ( IO_FILL_IO_NORTH_36_0 VDD ) ( IO_FILL_IO_NORTH_35_5 VDD ) ( IO_FILL_IO_NORTH_33_0 VDD )
+      ( IO_FILL_IO_NORTH_32_5 VDD ) ( IO_FILL_IO_NORTH_32_0 VDD ) ( IO_FILL_IO_NORTH_31_0 VDD ) ( IO_FILL_IO_NORTH_39_0 VDD ) ( IO_FILL_IO_NORTH_38_0 VDD ) ( IO_FILL_IO_NORTH_14_0 VDD ) ( IO_FILL_IO_NORTH_13_0 VDD ) ( IO_FILL_IO_NORTH_12_5 VDD )
+      ( IO_FILL_IO_NORTH_12_0 VDD ) ( IO_FILL_IO_NORTH_20_0 VDD ) ( IO_FILL_IO_NORTH_19_0 VDD ) ( IO_FILL_IO_NORTH_18_5 VDD ) ( IO_FILL_IO_NORTH_18_0 VDD ) ( IO_FILL_IO_NORTH_17_0 VDD ) ( IO_FILL_IO_NORTH_16_0 VDD ) ( IO_FILL_IO_NORTH_11_0 VDD )
+      ( IO_FILL_IO_NORTH_10_10 VDD ) ( IO_FILL_IO_NORTH_8_0 VDD ) ( IO_FILL_IO_NORTH_7_0 VDD ) ( IO_FILL_IO_NORTH_5_0 VDD ) ( IO_FILL_IO_NORTH_4_5 VDD ) ( IO_FILL_IO_NORTH_4_0 VDD ) ( IO_FILL_IO_NORTH_3_70 VDD ) ( IO_FILL_IO_NORTH_3_0 VDD )
+      ( IO_FILL_IO_NORTH_2_0 VDD ) ( IO_FILL_IO_NORTH_30_0 VDD ) ( IO_FILL_IO_NORTH_29_0 VDD ) ( IO_FILL_IO_NORTH_28_0 VDD ) ( IO_FILL_IO_NORTH_27_0 VDD ) ( IO_FILL_IO_NORTH_26_0 VDD ) ( IO_FILL_IO_NORTH_25_10 VDD ) ( IO_FILL_IO_NORTH_25_0 VDD )
+      ( IO_FILL_IO_NORTH_24_0 VDD ) ( IO_FILL_IO_NORTH_48_0 VDD ) ( IO_FILL_IO_NORTH_47_0 VDD ) ( IO_FILL_IO_NORTH_46_0 VDD ) ( IO_FILL_IO_NORTH_44_0 VDD ) ( IO_FILL_IO_NORTH_52_0 VDD ) ( IO_FILL_IO_NORTH_51_100 VDD ) ( IO_FILL_IO_NORTH_51_0 VDD )
+      ( IO_FILL_IO_NORTH_50_0 VDD ) ( IO_FILL_IO_NORTH_43_0 VDD ) ( IO_FILL_IO_NORTH_42_25 VDD ) ( IO_FILL_IO_NORTH_42_0 VDD ) ( IO_FILL_IO_NORTH_41_0 VDD ) ( IO_FILL_IO_NORTH_40_0 VDD ) ( IO_FILL_IO_NORTH_39_5 VDD ) ( IO_FILL_IO_EAST_60_185 VDD )
+      ( IO_FILL_IO_EAST_60_190 VDD ) ( IO_CORNER_NORTH_EAST_INST VDD ) ( IO_FILL_IO_NORTH_54_0 VDD ) ( IO_CORNER_NORTH_WEST_INST VDD ) ( IO_FILL_IO_WEST_57_0 VDD ) ( u_v18_33 VDD ) ( u_vzz_33 VDD ) ( u_brk0 VDD )
+      ( u_vdd_0 VDD ) ( u_v18_0 VDD ) ( u_vzz_9 VDD ) ( u_vzz_8 VDD ) ( u_vzz_7 VDD ) ( u_vzz_6 VDD ) ( u_vzz_5 VDD ) ( u_vzz_4 VDD )
+      ( u_vzz_32 VDD ) ( u_vzz_31 VDD ) ( u_vzz_30 VDD ) ( u_vzz_3 VDD ) ( u_vzz_29 VDD ) ( u_vzz_28 VDD ) ( u_vzz_27 VDD ) ( u_vzz_26 VDD )
+      ( u_vzz_25 VDD ) ( u_vzz_24 VDD ) ( u_vzz_23 VDD ) ( u_vzz_22 VDD ) ( u_vzz_21 VDD ) ( u_vzz_20 VDD ) ( u_vzz_2 VDD ) ( u_vzz_19 VDD )
+      ( u_vzz_18 VDD ) ( u_vzz_17 VDD ) ( u_vzz_16 VDD ) ( u_vzz_15 VDD ) ( u_vzz_14 VDD ) ( u_vzz_13 VDD ) ( u_vzz_12 VDD ) ( u_vzz_11 VDD )
+      ( u_vzz_10 VDD ) ( u_vzz_1 VDD ) ( u_vzz_0 VDD ) ( u_vss_pll VDD ) ( u_vss_9 VDD ) ( u_vss_8 VDD ) ( u_vss_7 VDD ) ( u_vss_6 VDD )
+      ( u_vss_5 VDD ) ( u_vss_4 VDD ) ( u_vss_32 VDD ) ( u_vss_31 VDD ) ( u_vss_30 VDD ) ( u_vss_3 VDD ) ( u_vss_29 VDD ) ( u_vss_28 VDD )
+      ( u_vss_27 VDD ) ( u_vss_26 VDD ) ( u_vss_25 VDD ) ( u_vss_24 VDD ) ( u_vss_23 VDD ) ( u_vss_22 VDD ) ( u_vss_21 VDD ) ( u_vss_20 VDD )
+      ( u_vss_2 VDD ) ( u_vss_19 VDD ) ( u_vss_18 VDD ) ( u_vss_17 VDD ) ( u_vss_16 VDD ) ( u_vss_15 VDD ) ( u_vss_14 VDD ) ( u_vss_13 VDD )
+      ( u_vss_12 VDD ) ( u_vss_11 VDD ) ( u_vss_10 VDD ) ( u_vss_1 VDD ) ( u_vss_0 VDD ) ( u_vdd_pll VDD ) ( u_vdd_9 VDD ) ( u_vdd_8 VDD )
+      ( u_vdd_7 VDD ) ( u_vdd_6 VDD ) ( u_vdd_5 VDD ) ( u_vdd_4 VDD ) ( u_vdd_32 VDD ) ( u_vdd_31 VDD ) ( u_vdd_30 VDD ) ( u_vdd_3 VDD )
+      ( u_vdd_29 VDD ) ( u_vdd_28 VDD ) ( u_vdd_27 VDD ) ( u_vdd_26 VDD ) ( u_vdd_25 VDD ) ( u_vdd_24 VDD ) ( u_vdd_23 VDD ) ( u_vdd_22 VDD )
+      ( u_vdd_21 VDD ) ( u_vdd_20 VDD ) ( u_vdd_2 VDD ) ( u_vdd_19 VDD ) ( u_vdd_18 VDD ) ( u_vdd_17 VDD ) ( u_vdd_16 VDD ) ( u_vdd_15 VDD )
+      ( u_vdd_14 VDD ) ( u_vdd_13 VDD ) ( u_vdd_12 VDD ) ( u_vdd_11 VDD ) ( u_vdd_10 VDD ) ( u_vdd_1 VDD ) ( u_v18_9 VDD ) ( u_v18_8 VDD )
+      ( u_v18_7 VDD ) ( u_v18_6 VDD ) ( u_v18_5 VDD ) ( u_v18_4 VDD ) ( u_v18_32 VDD ) ( u_v18_31 VDD ) ( u_v18_30 VDD ) ( u_v18_3 VDD )
+      ( u_v18_29 VDD ) ( u_v18_28 VDD ) ( u_v18_27 VDD ) ( u_v18_26 VDD ) ( u_v18_25 VDD ) ( u_v18_24 VDD ) ( u_v18_23 VDD ) ( u_v18_22 VDD )
+      ( u_v18_21 VDD ) ( u_v18_20 VDD ) ( u_v18_2 VDD ) ( u_v18_19 VDD ) ( u_v18_18 VDD ) ( u_v18_17 VDD ) ( u_v18_16 VDD ) ( u_v18_15 VDD )
+      ( u_v18_14 VDD ) ( u_v18_13 VDD ) ( u_v18_12 VDD ) ( u_v18_11 VDD ) ( u_v18_10 VDD ) ( u_v18_1 VDD ) ( u_sel_2_i VDD ) ( u_sel_1_i VDD )
+      ( u_sel_0_i VDD ) ( u_misc_o VDD ) ( u_ddr_we_n_o VDD ) ( u_ddr_reset_n_o VDD ) ( u_ddr_ras_n_o VDD ) ( u_ddr_odt_o VDD ) ( u_ddr_dqs_p_3_io VDD ) ( u_ddr_dqs_p_2_io VDD )
+      ( u_ddr_dqs_p_1_io VDD ) ( u_ddr_dqs_p_0_io VDD ) ( u_ddr_dqs_n_3_io VDD ) ( u_ddr_dqs_n_2_io VDD ) ( u_ddr_dqs_n_1_io VDD ) ( u_ddr_dqs_n_0_io VDD ) ( u_ddr_dq_9_io VDD ) ( u_ddr_dq_8_io VDD )
+      ( u_ddr_dq_7_io VDD ) ( u_ddr_dq_6_io VDD ) ( u_ddr_dq_5_io VDD ) ( u_ddr_dq_4_io VDD ) ( u_ddr_dq_3_io VDD ) ( u_ddr_dq_31_io VDD ) ( u_ddr_dq_30_io VDD ) ( u_ddr_dq_2_io VDD )
+      ( u_ddr_dq_29_io VDD ) ( u_ddr_dq_28_io VDD ) ( u_ddr_dq_27_io VDD ) ( u_ddr_dq_26_io VDD ) ( u_ddr_dq_25_io VDD ) ( u_ddr_dq_24_io VDD ) ( u_ddr_dq_23_io VDD ) ( u_ddr_dq_22_io VDD )
+      ( u_ddr_dq_21_io VDD ) ( u_ddr_dq_20_io VDD ) ( u_ddr_dq_1_io VDD ) ( u_ddr_dq_19_io VDD ) ( u_ddr_dq_18_io VDD ) ( u_ddr_dq_17_io VDD ) ( u_ddr_dq_16_io VDD ) ( u_ddr_dq_15_io VDD )
+      ( u_ddr_dq_14_io VDD ) ( u_ddr_dq_13_io VDD ) ( u_ddr_dq_12_io VDD ) ( u_ddr_dq_11_io VDD ) ( u_ddr_dq_10_io VDD ) ( u_ddr_dq_0_io VDD ) ( u_ddr_dm_3_o VDD ) ( u_ddr_dm_2_o VDD )
+      ( u_ddr_dm_1_o VDD ) ( u_ddr_dm_0_o VDD ) ( u_ddr_cs_n_o VDD ) ( u_ddr_cke_o VDD ) ( u_ddr_ck_p_o VDD ) ( u_ddr_ck_n_o VDD ) ( u_ddr_cas_n_o VDD ) ( u_ddr_ba_2_o VDD )
+      ( u_ddr_ba_1_o VDD ) ( u_ddr_ba_0_o VDD ) ( u_ddr_addr_9_o VDD ) ( u_ddr_addr_8_o VDD ) ( u_ddr_addr_7_o VDD ) ( u_ddr_addr_6_o VDD ) ( u_ddr_addr_5_o VDD ) ( u_ddr_addr_4_o VDD )
+      ( u_ddr_addr_3_o VDD ) ( u_ddr_addr_2_o VDD ) ( u_ddr_addr_1_o VDD ) ( u_ddr_addr_15_o VDD ) ( u_ddr_addr_14_o VDD ) ( u_ddr_addr_13_o VDD ) ( u_ddr_addr_12_o VDD ) ( u_ddr_addr_11_o VDD )
+      ( u_ddr_addr_10_o VDD ) ( u_ddr_addr_0_o VDD ) ( u_core_async_reset_i VDD ) ( u_co_v_i VDD ) ( u_co_tkn_o VDD ) ( u_co_clk_i VDD ) ( u_co_8_i VDD ) ( u_co_7_i VDD )
+      ( u_co_6_i VDD ) ( u_co_5_i VDD ) ( u_co_4_i VDD ) ( u_co_3_i VDD ) ( u_co_2_i VDD ) ( u_co_1_i VDD ) ( u_co_0_i VDD ) ( u_co2_v_o VDD )
+      ( u_co2_tkn_i VDD ) ( u_co2_clk_o VDD ) ( u_co2_8_o VDD ) ( u_co2_7_o VDD ) ( u_co2_6_o VDD ) ( u_co2_5_o VDD ) ( u_co2_4_o VDD ) ( u_co2_3_o VDD )
+      ( u_co2_2_o VDD ) ( u_co2_1_o VDD ) ( u_co2_0_o VDD ) ( u_clk_o VDD ) ( u_clk_async_reset_i VDD ) ( u_clk_C_i VDD ) ( u_clk_B_i VDD ) ( u_clk_A_i VDD )
+      ( u_ci_v_i VDD ) ( u_ci_tkn_o VDD ) ( u_ci_clk_i VDD ) ( u_ci_8_i VDD ) ( u_ci_7_i VDD ) ( u_ci_6_i VDD ) ( u_ci_5_i VDD ) ( u_ci_4_i VDD )
+      ( u_ci_3_i VDD ) ( u_ci_2_i VDD ) ( u_ci_1_i VDD ) ( u_ci_0_i VDD ) ( u_ci2_v_o VDD ) ( u_ci2_tkn_i VDD ) ( u_ci2_clk_o VDD ) ( u_ci2_8_o VDD )
+      ( u_ci2_7_o VDD ) ( u_ci2_6_o VDD ) ( u_ci2_5_o VDD ) ( u_ci2_4_o VDD ) ( u_ci2_3_o VDD ) ( u_ci2_2_o VDD ) ( u_ci2_1_o VDD ) ( u_ci2_0_o VDD )
+      ( u_bsg_tag_en_i VDD ) ( u_bsg_tag_data_o VDD ) ( u_bsg_tag_data_i VDD ) ( u_bsg_tag_clk_o VDD ) ( u_bsg_tag_clk_i VDD ) + USE POWER ;
     - VSS ( PIN VSS ) ( BUMP_1_3 PAD ) ( BUMP_0_7 PAD ) ( BUMP_0_10 PAD ) ( BUMP_2_14 PAD ) ( BUMP_3_15 PAD ) ( BUMP_7_16 PAD )
       ( BUMP_9_16 PAD ) ( BUMP_10_13 PAD ) ( BUMP_14_14 PAD ) ( BUMP_14_13 PAD ) ( BUMP_14_9 PAD ) ( BUMP_16_6 PAD ) ( BUMP_16_2 PAD ) ( BUMP_12_2 PAD )
-      ( BUMP_9_1 PAD ) ( BUMP_6_1 PAD ) ( BUMP_3_3 PAD ) + USE GROUND ;
+      ( BUMP_9_1 PAD ) ( BUMP_6_1 PAD ) ( BUMP_3_3 PAD ) ( IO_FILL_IO_WEST_0_485 VSS ) ( IO_FILL_IO_WEST_0_480 VSS ) ( IO_FILL_IO_WEST_0_475 VSS ) ( IO_FILL_IO_WEST_0_470 VSS ) ( IO_FILL_IO_WEST_0_465 VSS )
+      ( IO_FILL_IO_WEST_0_460 VSS ) ( IO_FILL_IO_WEST_0_455 VSS ) ( IO_FILL_IO_WEST_0_450 VSS ) ( IO_FILL_IO_WEST_0_445 VSS ) ( IO_FILL_IO_WEST_0_440 VSS ) ( IO_FILL_IO_WEST_0_435 VSS ) ( IO_FILL_IO_WEST_0_430 VSS ) ( IO_FILL_IO_WEST_0_425 VSS )
+      ( IO_FILL_IO_WEST_0_420 VSS ) ( IO_FILL_IO_WEST_0_415 VSS ) ( IO_FILL_IO_WEST_0_410 VSS ) ( IO_FILL_IO_WEST_0_405 VSS ) ( IO_FILL_IO_WEST_0_400 VSS ) ( IO_FILL_IO_WEST_0_395 VSS ) ( IO_FILL_IO_WEST_0_390 VSS ) ( IO_FILL_IO_WEST_0_385 VSS )
+      ( IO_FILL_IO_WEST_0_380 VSS ) ( IO_FILL_IO_WEST_0_375 VSS ) ( IO_FILL_IO_WEST_0_370 VSS ) ( IO_FILL_IO_WEST_0_365 VSS ) ( IO_FILL_IO_WEST_0_360 VSS ) ( IO_FILL_IO_WEST_0_355 VSS ) ( IO_FILL_IO_WEST_0_350 VSS ) ( IO_FILL_IO_WEST_0_345 VSS )
+      ( IO_FILL_IO_WEST_0_340 VSS ) ( IO_FILL_IO_WEST_0_335 VSS ) ( IO_FILL_IO_WEST_0_330 VSS ) ( IO_FILL_IO_WEST_0_325 VSS ) ( IO_FILL_IO_WEST_0_320 VSS ) ( IO_FILL_IO_WEST_0_315 VSS ) ( IO_FILL_IO_WEST_0_310 VSS ) ( IO_FILL_IO_WEST_0_305 VSS )
+      ( IO_FILL_IO_WEST_0_300 VSS ) ( IO_FILL_IO_WEST_0_295 VSS ) ( IO_FILL_IO_WEST_0_290 VSS ) ( IO_FILL_IO_WEST_0_285 VSS ) ( IO_FILL_IO_WEST_0_280 VSS ) ( IO_FILL_IO_WEST_0_275 VSS ) ( IO_FILL_IO_WEST_0_270 VSS ) ( IO_FILL_IO_WEST_0_265 VSS )
+      ( IO_FILL_IO_WEST_0_260 VSS ) ( IO_FILL_IO_WEST_0_255 VSS ) ( IO_FILL_IO_WEST_0_250 VSS ) ( IO_FILL_IO_WEST_0_245 VSS ) ( IO_FILL_IO_WEST_0_240 VSS ) ( IO_FILL_IO_WEST_0_235 VSS ) ( IO_FILL_IO_WEST_0_230 VSS ) ( IO_FILL_IO_WEST_0_225 VSS )
+      ( IO_FILL_IO_WEST_0_220 VSS ) ( IO_FILL_IO_WEST_0_215 VSS ) ( IO_FILL_IO_WEST_0_210 VSS ) ( IO_FILL_IO_WEST_0_205 VSS ) ( IO_FILL_IO_WEST_0_200 VSS ) ( IO_FILL_IO_WEST_0_195 VSS ) ( IO_FILL_IO_WEST_0_190 VSS ) ( IO_FILL_IO_WEST_0_185 VSS )
+      ( IO_FILL_IO_WEST_0_180 VSS ) ( IO_FILL_IO_WEST_0_175 VSS ) ( IO_FILL_IO_WEST_0_170 VSS ) ( IO_FILL_IO_WEST_0_165 VSS ) ( IO_FILL_IO_WEST_0_160 VSS ) ( IO_FILL_IO_WEST_0_155 VSS ) ( IO_FILL_IO_WEST_0_150 VSS ) ( IO_FILL_IO_WEST_0_145 VSS )
+      ( IO_FILL_IO_WEST_0_140 VSS ) ( IO_FILL_IO_WEST_0_135 VSS ) ( IO_FILL_IO_WEST_0_130 VSS ) ( IO_FILL_IO_WEST_0_125 VSS ) ( IO_FILL_IO_WEST_0_120 VSS ) ( IO_FILL_IO_WEST_0_115 VSS ) ( IO_FILL_IO_WEST_0_110 VSS ) ( IO_FILL_IO_WEST_0_105 VSS )
+      ( IO_FILL_IO_WEST_0_100 VSS ) ( IO_FILL_IO_WEST_0_95 VSS ) ( IO_FILL_IO_WEST_0_90 VSS ) ( IO_FILL_IO_WEST_0_85 VSS ) ( IO_FILL_IO_WEST_0_80 VSS ) ( IO_FILL_IO_WEST_0_75 VSS ) ( IO_FILL_IO_WEST_0_70 VSS ) ( IO_FILL_IO_WEST_0_65 VSS )
+      ( IO_FILL_IO_WEST_0_60 VSS ) ( IO_FILL_IO_WEST_0_55 VSS ) ( IO_FILL_IO_WEST_0_50 VSS ) ( IO_FILL_IO_WEST_0_45 VSS ) ( IO_FILL_IO_WEST_0_40 VSS ) ( IO_FILL_IO_WEST_0_35 VSS ) ( IO_FILL_IO_WEST_0_30 VSS ) ( IO_FILL_IO_WEST_0_25 VSS )
+      ( IO_FILL_IO_WEST_0_20 VSS ) ( IO_FILL_IO_WEST_0_15 VSS ) ( IO_FILL_IO_WEST_0_10 VSS ) ( IO_FILL_IO_WEST_0_5 VSS ) ( IO_FILL_IO_WEST_0_0 VSS ) ( IO_CORNER_SOUTH_WEST_INST VSS ) ( IO_FILL_IO_SOUTH_0_0 VSS ) ( IO_FILL_IO_SOUTH_0_5 VSS )
+      ( IO_FILL_IO_WEST_0_490 VSS ) ( IO_FILL_IO_SOUTH_0_10 VSS ) ( IO_FILL_IO_WEST_0_495 VSS ) ( IO_FILL_IO_SOUTH_0_15 VSS ) ( IO_FILL_IO_EAST_0_15 VSS ) ( IO_FILL_IO_EAST_0_10 VSS ) ( IO_FILL_IO_EAST_0_5 VSS ) ( IO_FILL_IO_EAST_0_0 VSS )
+      ( IO_CORNER_SOUTH_EAST_INST VSS ) ( IO_FILL_IO_WEST_56_90 VSS ) ( IO_FILL_IO_WEST_56_85 VSS ) ( IO_FILL_IO_WEST_56_80 VSS ) ( IO_FILL_IO_WEST_56_75 VSS ) ( IO_FILL_IO_WEST_56_70 VSS ) ( IO_FILL_IO_WEST_56_65 VSS ) ( IO_FILL_IO_WEST_56_60 VSS )
+      ( IO_FILL_IO_WEST_56_55 VSS ) ( IO_FILL_IO_WEST_56_50 VSS ) ( IO_FILL_IO_WEST_56_45 VSS ) ( IO_FILL_IO_WEST_56_40 VSS ) ( IO_FILL_IO_WEST_56_35 VSS ) ( IO_FILL_IO_WEST_56_30 VSS ) ( IO_FILL_IO_WEST_56_25 VSS ) ( IO_FILL_IO_WEST_56_20 VSS )
+      ( IO_FILL_IO_WEST_56_15 VSS ) ( IO_FILL_IO_WEST_56_10 VSS ) ( IO_FILL_IO_WEST_56_5 VSS ) ( IO_FILL_IO_WEST_54_95 VSS ) ( IO_FILL_IO_WEST_54_90 VSS ) ( IO_FILL_IO_WEST_54_85 VSS ) ( IO_FILL_IO_WEST_54_80 VSS ) ( IO_FILL_IO_WEST_54_75 VSS )
+      ( IO_FILL_IO_WEST_54_70 VSS ) ( IO_FILL_IO_WEST_54_65 VSS ) ( IO_FILL_IO_WEST_54_60 VSS ) ( IO_FILL_IO_WEST_54_55 VSS ) ( IO_FILL_IO_WEST_54_50 VSS ) ( IO_FILL_IO_WEST_54_45 VSS ) ( IO_FILL_IO_WEST_54_40 VSS ) ( IO_FILL_IO_WEST_54_35 VSS )
+      ( IO_FILL_IO_WEST_54_30 VSS ) ( IO_FILL_IO_WEST_54_25 VSS ) ( IO_FILL_IO_WEST_54_20 VSS ) ( IO_FILL_IO_WEST_54_15 VSS ) ( IO_FILL_IO_WEST_54_10 VSS ) ( IO_FILL_IO_WEST_54_5 VSS ) ( IO_FILL_IO_WEST_51_25 VSS ) ( IO_FILL_IO_WEST_51_20 VSS )
+      ( IO_FILL_IO_WEST_51_15 VSS ) ( IO_FILL_IO_WEST_51_10 VSS ) ( IO_FILL_IO_WEST_51_5 VSS ) ( IO_FILL_IO_WEST_47_45 VSS ) ( IO_FILL_IO_WEST_47_40 VSS ) ( IO_FILL_IO_WEST_47_35 VSS ) ( IO_FILL_IO_WEST_47_30 VSS ) ( IO_FILL_IO_WEST_47_25 VSS )
+      ( IO_FILL_IO_WEST_47_20 VSS ) ( IO_FILL_IO_WEST_47_15 VSS ) ( IO_FILL_IO_WEST_47_10 VSS ) ( IO_FILL_IO_WEST_47_5 VSS ) ( IO_FILL_IO_WEST_32_5 VSS ) ( IO_FILL_IO_WEST_27_5 VSS ) ( IO_FILL_IO_WEST_12_5 VSS ) ( IO_FILL_IO_WEST_7_5 VSS )
+      ( IO_FILL_IO_WEST_3_65 VSS ) ( IO_FILL_IO_WEST_3_60 VSS ) ( IO_FILL_IO_WEST_3_55 VSS ) ( IO_FILL_IO_WEST_3_50 VSS ) ( IO_FILL_IO_WEST_3_45 VSS ) ( IO_FILL_IO_WEST_3_40 VSS ) ( IO_FILL_IO_WEST_3_35 VSS ) ( IO_FILL_IO_WEST_3_30 VSS )
+      ( IO_FILL_IO_WEST_3_25 VSS ) ( IO_FILL_IO_WEST_3_20 VSS ) ( IO_FILL_IO_WEST_3_15 VSS ) ( IO_FILL_IO_WEST_3_10 VSS ) ( IO_FILL_IO_WEST_3_5 VSS ) ( IO_FILL_IO_WEST_0_500 VSS ) ( IO_FILL_IO_WEST_0_505 VSS ) ( IO_FILL_IO_WEST_1_0 VSS )
+      ( IO_FILL_IO_WEST_17_0 VSS ) ( IO_FILL_IO_WEST_51_0 VSS ) ( IO_FILL_IO_WEST_3_0 VSS ) ( IO_FILL_IO_WEST_2_0 VSS ) ( IO_FILL_IO_WEST_19_5 VSS ) ( IO_FILL_IO_WEST_51_30 VSS ) ( IO_FILL_IO_WEST_3_70 VSS ) ( IO_FILL_IO_WEST_20_0 VSS )
+      ( IO_FILL_IO_WEST_35_0 VSS ) ( IO_FILL_IO_WEST_52_0 VSS ) ( IO_FILL_IO_WEST_10_0 VSS ) ( IO_FILL_IO_WEST_16_0 VSS ) ( IO_FILL_IO_WEST_24_0 VSS ) ( IO_FILL_IO_WEST_30_0 VSS ) ( IO_FILL_IO_WEST_38_0 VSS ) ( IO_FILL_IO_WEST_37_5 VSS )
+      ( IO_FILL_IO_WEST_44_0 VSS ) ( IO_FILL_IO_WEST_50_0 VSS ) ( IO_FILL_IO_WEST_15_0 VSS ) ( IO_FILL_IO_WEST_17_5 VSS ) ( IO_FILL_IO_WEST_5_0 VSS ) ( IO_FILL_IO_WEST_4_0 VSS ) ( IO_FILL_IO_WEST_33_0 VSS ) ( IO_FILL_IO_WEST_32_10 VSS )
+      ( IO_FILL_IO_WEST_32_0 VSS ) ( IO_FILL_IO_WEST_31_0 VSS ) ( IO_FILL_IO_WEST_29_0 VSS ) ( IO_FILL_IO_WEST_28_0 VSS ) ( IO_FILL_IO_WEST_27_10 VSS ) ( IO_FILL_IO_WEST_27_0 VSS ) ( IO_FILL_IO_WEST_26_0 VSS ) ( IO_FILL_IO_WEST_25_0 VSS )
+      ( IO_FILL_IO_WEST_23_0 VSS ) ( IO_FILL_IO_WEST_22_5 VSS ) ( IO_FILL_IO_WEST_14_0 VSS ) ( IO_FILL_IO_WEST_13_5 VSS ) ( IO_FILL_IO_WEST_13_0 VSS ) ( IO_FILL_IO_WEST_12_10 VSS ) ( IO_FILL_IO_WEST_12_0 VSS ) ( IO_FILL_IO_WEST_11_0 VSS )
+      ( IO_FILL_IO_WEST_9_0 VSS ) ( IO_FILL_IO_WEST_8_0 VSS ) ( IO_FILL_IO_WEST_7_10 VSS ) ( IO_FILL_IO_WEST_7_0 VSS ) ( IO_FILL_IO_WEST_6_0 VSS ) ( IO_FILL_IO_WEST_22_0 VSS ) ( IO_FILL_IO_WEST_21_0 VSS ) ( IO_FILL_IO_WEST_19_0 VSS )
+      ( IO_FILL_IO_WEST_18_0 VSS ) ( IO_FILL_IO_WEST_49_0 VSS ) ( IO_FILL_IO_WEST_48_0 VSS ) ( IO_FILL_IO_WEST_47_50 VSS ) ( IO_FILL_IO_WEST_47_0 VSS ) ( IO_FILL_IO_WEST_56_95 VSS ) ( IO_FILL_IO_WEST_56_0 VSS ) ( IO_FILL_IO_WEST_55_5 VSS )
+      ( IO_FILL_IO_WEST_55_0 VSS ) ( IO_FILL_IO_WEST_54_100 VSS ) ( IO_FILL_IO_WEST_54_0 VSS ) ( IO_FILL_IO_WEST_53_0 VSS ) ( IO_FILL_IO_WEST_46_0 VSS ) ( IO_FILL_IO_WEST_45_0 VSS ) ( IO_FILL_IO_WEST_43_0 VSS ) ( IO_FILL_IO_WEST_42_5 VSS )
+      ( IO_FILL_IO_WEST_42_0 VSS ) ( IO_FILL_IO_WEST_41_5 VSS ) ( IO_FILL_IO_WEST_41_0 VSS ) ( IO_FILL_IO_WEST_40_0 VSS ) ( IO_FILL_IO_WEST_39_0 VSS ) ( IO_FILL_IO_WEST_34_0 VSS ) ( IO_FILL_IO_WEST_33_5 VSS ) ( IO_FILL_IO_WEST_37_0 VSS )
+      ( IO_FILL_IO_WEST_36_0 VSS ) ( IO_FILL_IO_SOUTH_60_190 VSS ) ( IO_FILL_IO_SOUTH_60_185 VSS ) ( IO_FILL_IO_SOUTH_60_180 VSS ) ( IO_FILL_IO_SOUTH_60_175 VSS ) ( IO_FILL_IO_SOUTH_60_170 VSS ) ( IO_FILL_IO_SOUTH_60_165 VSS ) ( IO_FILL_IO_SOUTH_60_160 VSS )
+      ( IO_FILL_IO_SOUTH_60_155 VSS ) ( IO_FILL_IO_SOUTH_60_150 VSS ) ( IO_FILL_IO_SOUTH_60_145 VSS ) ( IO_FILL_IO_SOUTH_60_140 VSS ) ( IO_FILL_IO_SOUTH_60_135 VSS ) ( IO_FILL_IO_SOUTH_60_130 VSS ) ( IO_FILL_IO_SOUTH_60_125 VSS ) ( IO_FILL_IO_SOUTH_60_120 VSS )
+      ( IO_FILL_IO_SOUTH_60_115 VSS ) ( IO_FILL_IO_SOUTH_60_110 VSS ) ( IO_FILL_IO_SOUTH_60_105 VSS ) ( IO_FILL_IO_SOUTH_60_100 VSS ) ( IO_FILL_IO_SOUTH_60_95 VSS ) ( IO_FILL_IO_SOUTH_60_90 VSS ) ( IO_FILL_IO_SOUTH_60_85 VSS ) ( IO_FILL_IO_SOUTH_60_80 VSS )
+      ( IO_FILL_IO_SOUTH_60_75 VSS ) ( IO_FILL_IO_SOUTH_60_70 VSS ) ( IO_FILL_IO_SOUTH_60_65 VSS ) ( IO_FILL_IO_SOUTH_60_60 VSS ) ( IO_FILL_IO_SOUTH_60_55 VSS ) ( IO_FILL_IO_SOUTH_60_50 VSS ) ( IO_FILL_IO_SOUTH_60_45 VSS ) ( IO_FILL_IO_SOUTH_60_40 VSS )
+      ( IO_FILL_IO_SOUTH_60_35 VSS ) ( IO_FILL_IO_SOUTH_60_30 VSS ) ( IO_FILL_IO_SOUTH_60_25 VSS ) ( IO_FILL_IO_SOUTH_60_20 VSS ) ( IO_FILL_IO_SOUTH_60_15 VSS ) ( IO_FILL_IO_SOUTH_60_10 VSS ) ( IO_FILL_IO_SOUTH_60_5 VSS ) ( IO_FILL_IO_SOUTH_59_125 VSS )
+      ( IO_FILL_IO_SOUTH_59_120 VSS ) ( IO_FILL_IO_SOUTH_59_115 VSS ) ( IO_FILL_IO_SOUTH_59_110 VSS ) ( IO_FILL_IO_SOUTH_59_105 VSS ) ( IO_FILL_IO_SOUTH_59_100 VSS ) ( IO_FILL_IO_SOUTH_59_95 VSS ) ( IO_FILL_IO_SOUTH_59_90 VSS ) ( IO_FILL_IO_SOUTH_59_85 VSS )
+      ( IO_FILL_IO_SOUTH_59_80 VSS ) ( IO_FILL_IO_SOUTH_59_75 VSS ) ( IO_FILL_IO_SOUTH_59_70 VSS ) ( IO_FILL_IO_SOUTH_59_65 VSS ) ( IO_FILL_IO_SOUTH_59_60 VSS ) ( IO_FILL_IO_SOUTH_59_55 VSS ) ( IO_FILL_IO_SOUTH_59_50 VSS ) ( IO_FILL_IO_SOUTH_59_45 VSS )
+      ( IO_FILL_IO_SOUTH_59_40 VSS ) ( IO_FILL_IO_SOUTH_59_35 VSS ) ( IO_FILL_IO_SOUTH_59_30 VSS ) ( IO_FILL_IO_SOUTH_59_25 VSS ) ( IO_FILL_IO_SOUTH_59_20 VSS ) ( IO_FILL_IO_SOUTH_59_15 VSS ) ( IO_FILL_IO_SOUTH_59_10 VSS ) ( IO_FILL_IO_SOUTH_59_5 VSS )
+      ( IO_FILL_IO_SOUTH_57_60 VSS ) ( IO_FILL_IO_SOUTH_57_55 VSS ) ( IO_FILL_IO_SOUTH_57_50 VSS ) ( IO_FILL_IO_SOUTH_57_45 VSS ) ( IO_FILL_IO_SOUTH_57_40 VSS ) ( IO_FILL_IO_SOUTH_57_35 VSS ) ( IO_FILL_IO_SOUTH_57_30 VSS ) ( IO_FILL_IO_SOUTH_57_25 VSS )
+      ( IO_FILL_IO_SOUTH_57_20 VSS ) ( IO_FILL_IO_SOUTH_57_15 VSS ) ( IO_FILL_IO_SOUTH_57_10 VSS ) ( IO_FILL_IO_SOUTH_57_5 VSS ) ( IO_FILL_IO_SOUTH_54_65 VSS ) ( IO_FILL_IO_SOUTH_54_60 VSS ) ( IO_FILL_IO_SOUTH_54_55 VSS ) ( IO_FILL_IO_SOUTH_54_50 VSS )
+      ( IO_FILL_IO_SOUTH_54_45 VSS ) ( IO_FILL_IO_SOUTH_54_40 VSS ) ( IO_FILL_IO_SOUTH_54_35 VSS ) ( IO_FILL_IO_SOUTH_54_30 VSS ) ( IO_FILL_IO_SOUTH_54_25 VSS ) ( IO_FILL_IO_SOUTH_54_20 VSS ) ( IO_FILL_IO_SOUTH_54_15 VSS ) ( IO_FILL_IO_SOUTH_54_10 VSS )
+      ( IO_FILL_IO_SOUTH_54_5 VSS ) ( IO_FILL_IO_SOUTH_40_5 VSS ) ( IO_FILL_IO_SOUTH_20_5 VSS ) ( IO_FILL_IO_SOUTH_10_30 VSS ) ( IO_FILL_IO_SOUTH_10_25 VSS ) ( IO_FILL_IO_SOUTH_10_20 VSS ) ( IO_FILL_IO_SOUTH_10_15 VSS ) ( IO_FILL_IO_SOUTH_10_10 VSS )
+      ( IO_FILL_IO_SOUTH_10_5 VSS ) ( IO_FILL_IO_SOUTH_6_35 VSS ) ( IO_FILL_IO_SOUTH_6_30 VSS ) ( IO_FILL_IO_SOUTH_6_25 VSS ) ( IO_FILL_IO_SOUTH_6_20 VSS ) ( IO_FILL_IO_SOUTH_6_15 VSS ) ( IO_FILL_IO_SOUTH_6_10 VSS ) ( IO_FILL_IO_SOUTH_6_5 VSS )
+      ( IO_FILL_IO_SOUTH_3_95 VSS ) ( IO_FILL_IO_SOUTH_3_90 VSS ) ( IO_FILL_IO_SOUTH_3_85 VSS ) ( IO_FILL_IO_SOUTH_3_80 VSS ) ( IO_FILL_IO_SOUTH_3_75 VSS ) ( IO_FILL_IO_SOUTH_3_70 VSS ) ( IO_FILL_IO_SOUTH_3_65 VSS ) ( IO_FILL_IO_SOUTH_3_60 VSS )
+      ( IO_FILL_IO_SOUTH_3_55 VSS ) ( IO_FILL_IO_SOUTH_3_50 VSS ) ( IO_FILL_IO_SOUTH_3_45 VSS ) ( IO_FILL_IO_SOUTH_3_40 VSS ) ( IO_FILL_IO_SOUTH_3_35 VSS ) ( IO_FILL_IO_SOUTH_3_30 VSS ) ( IO_FILL_IO_SOUTH_3_25 VSS ) ( IO_FILL_IO_SOUTH_3_20 VSS )
+      ( IO_FILL_IO_SOUTH_3_15 VSS ) ( IO_FILL_IO_SOUTH_3_10 VSS ) ( IO_FILL_IO_SOUTH_3_5 VSS ) ( IO_FILL_IO_SOUTH_1_95 VSS ) ( IO_FILL_IO_SOUTH_1_90 VSS ) ( IO_FILL_IO_SOUTH_1_85 VSS ) ( IO_FILL_IO_SOUTH_1_80 VSS ) ( IO_FILL_IO_SOUTH_1_75 VSS )
+      ( IO_FILL_IO_SOUTH_1_70 VSS ) ( IO_FILL_IO_SOUTH_1_65 VSS ) ( IO_FILL_IO_SOUTH_1_60 VSS ) ( IO_FILL_IO_SOUTH_1_55 VSS ) ( IO_FILL_IO_SOUTH_1_50 VSS ) ( IO_FILL_IO_SOUTH_1_45 VSS ) ( IO_FILL_IO_SOUTH_1_40 VSS ) ( IO_FILL_IO_SOUTH_1_35 VSS )
+      ( IO_FILL_IO_SOUTH_1_30 VSS ) ( IO_FILL_IO_SOUTH_1_25 VSS ) ( IO_FILL_IO_SOUTH_1_20 VSS ) ( IO_FILL_IO_SOUTH_1_15 VSS ) ( IO_FILL_IO_SOUTH_1_10 VSS ) ( IO_FILL_IO_SOUTH_1_5 VSS ) ( IO_FILL_IO_SOUTH_0_20 VSS ) ( IO_FILL_IO_SOUTH_6_0 VSS )
+      ( IO_FILL_IO_SOUTH_3_100 VSS ) ( IO_FILL_IO_SOUTH_59_0 VSS ) ( IO_FILL_IO_SOUTH_50_5 VSS ) ( IO_FILL_IO_SOUTH_45_0 VSS ) ( IO_FILL_IO_SOUTH_30_5 VSS ) ( IO_FILL_IO_SOUTH_25_0 VSS ) ( IO_FILL_IO_SOUTH_10_35 VSS ) ( IO_FILL_IO_SOUTH_3_0 VSS )
+      ( IO_FILL_IO_SOUTH_54_0 VSS ) ( IO_FILL_IO_SOUTH_22_0 VSS ) ( IO_FILL_IO_SOUTH_6_40 VSS ) ( IO_FILL_IO_SOUTH_53_0 VSS ) ( IO_FILL_IO_SOUTH_36_0 VSS ) ( IO_FILL_IO_SOUTH_35_5 VSS ) ( IO_FILL_IO_SOUTH_21_0 VSS ) ( IO_FILL_IO_SOUTH_20_10 VSS )
+      ( IO_FILL_IO_SOUTH_60_0 VSS ) ( IO_FILL_IO_SOUTH_59_130 VSS ) ( IO_FILL_IO_SOUTH_52_0 VSS ) ( IO_FILL_IO_SOUTH_51_0 VSS ) ( IO_FILL_IO_SOUTH_45_5 VSS ) ( IO_FILL_IO_SOUTH_40_0 VSS ) ( IO_FILL_IO_SOUTH_39_0 VSS ) ( IO_FILL_IO_SOUTH_31_0 VSS )
+      ( IO_FILL_IO_SOUTH_25_5 VSS ) ( IO_FILL_IO_SOUTH_17_0 VSS ) ( IO_FILL_IO_SOUTH_11_0 VSS ) ( IO_FILL_IO_SOUTH_42_5 VSS ) ( IO_FILL_IO_SOUTH_42_0 VSS ) ( IO_FILL_IO_SOUTH_46_0 VSS ) ( IO_FILL_IO_SOUTH_41_0 VSS ) ( IO_FILL_IO_SOUTH_40_10 VSS )
+      ( IO_FILL_IO_SOUTH_57_0 VSS ) ( IO_FILL_IO_SOUTH_56_5 VSS ) ( IO_FILL_IO_SOUTH_5_0 VSS ) ( IO_FILL_IO_SOUTH_4_0 VSS ) ( IO_FILL_IO_SOUTH_56_0 VSS ) ( IO_FILL_IO_SOUTH_2_0 VSS ) ( IO_FILL_IO_SOUTH_1_100 VSS ) ( IO_FILL_IO_SOUTH_58_0 VSS )
+      ( IO_FILL_IO_SOUTH_57_65 VSS ) ( IO_FILL_IO_SOUTH_1_0 VSS ) ( IO_FILL_IO_SOUTH_0_25 VSS ) ( IO_FILL_IO_SOUTH_48_0 VSS ) ( IO_FILL_IO_SOUTH_47_0 VSS ) ( IO_FILL_IO_SOUTH_48_5 VSS ) ( IO_FILL_IO_SOUTH_55_0 VSS ) ( IO_FILL_IO_SOUTH_54_70 VSS )
+      ( IO_FILL_IO_SOUTH_50_0 VSS ) ( IO_FILL_IO_SOUTH_49_0 VSS ) ( IO_FILL_IO_SOUTH_44_0 VSS ) ( IO_FILL_IO_SOUTH_43_0 VSS ) ( IO_FILL_IO_SOUTH_8_0 VSS ) ( IO_FILL_IO_SOUTH_7_0 VSS ) ( IO_FILL_IO_SOUTH_8_5 VSS ) ( IO_FILL_IO_SOUTH_10_0 VSS )
+      ( IO_FILL_IO_SOUTH_9_0 VSS ) ( IO_FILL_IO_SOUTH_22_5 VSS ) ( IO_FILL_IO_SOUTH_24_0 VSS ) ( IO_FILL_IO_SOUTH_23_0 VSS ) ( IO_FILL_IO_SOUTH_26_0 VSS ) ( IO_FILL_IO_SOUTH_28_0 VSS ) ( IO_FILL_IO_SOUTH_27_0 VSS ) ( IO_FILL_IO_SOUTH_28_5 VSS )
+      ( IO_FILL_IO_SOUTH_30_0 VSS ) ( IO_FILL_IO_SOUTH_29_0 VSS ) ( IO_FILL_IO_SOUTH_32_0 VSS ) ( IO_FILL_IO_SOUTH_34_0 VSS ) ( IO_FILL_IO_SOUTH_33_0 VSS ) ( IO_FILL_IO_SOUTH_35_0 VSS ) ( IO_FILL_IO_SOUTH_34_5 VSS ) ( IO_FILL_IO_SOUTH_12_0 VSS )
+      ( IO_FILL_IO_SOUTH_14_0 VSS ) ( IO_FILL_IO_SOUTH_13_0 VSS ) ( IO_FILL_IO_SOUTH_15_0 VSS ) ( IO_FILL_IO_SOUTH_14_5 VSS ) ( IO_FILL_IO_SOUTH_16_0 VSS ) ( IO_FILL_IO_SOUTH_15_5 VSS ) ( IO_FILL_IO_SOUTH_18_0 VSS ) ( IO_FILL_IO_SOUTH_20_0 VSS )
+      ( IO_FILL_IO_SOUTH_19_0 VSS ) ( IO_FILL_IO_SOUTH_38_0 VSS ) ( IO_FILL_IO_SOUTH_37_0 VSS ) ( IO_FILL_IO_EAST_60_180 VSS ) ( IO_FILL_IO_EAST_60_175 VSS ) ( IO_FILL_IO_EAST_60_170 VSS ) ( IO_FILL_IO_EAST_60_165 VSS ) ( IO_FILL_IO_EAST_60_160 VSS )
+      ( IO_FILL_IO_EAST_60_155 VSS ) ( IO_FILL_IO_EAST_60_150 VSS ) ( IO_FILL_IO_EAST_60_145 VSS ) ( IO_FILL_IO_EAST_60_140 VSS ) ( IO_FILL_IO_EAST_60_135 VSS ) ( IO_FILL_IO_EAST_60_130 VSS ) ( IO_FILL_IO_EAST_60_125 VSS ) ( IO_FILL_IO_EAST_60_120 VSS )
+      ( IO_FILL_IO_EAST_60_115 VSS ) ( IO_FILL_IO_EAST_60_110 VSS ) ( IO_FILL_IO_EAST_60_105 VSS ) ( IO_FILL_IO_EAST_60_100 VSS ) ( IO_FILL_IO_EAST_60_95 VSS ) ( IO_FILL_IO_EAST_60_90 VSS ) ( IO_FILL_IO_EAST_60_85 VSS ) ( IO_FILL_IO_EAST_60_80 VSS )
+      ( IO_FILL_IO_EAST_60_75 VSS ) ( IO_FILL_IO_EAST_60_70 VSS ) ( IO_FILL_IO_EAST_60_65 VSS ) ( IO_FILL_IO_EAST_60_60 VSS ) ( IO_FILL_IO_EAST_60_55 VSS ) ( IO_FILL_IO_EAST_60_50 VSS ) ( IO_FILL_IO_EAST_60_45 VSS ) ( IO_FILL_IO_EAST_60_40 VSS )
+      ( IO_FILL_IO_EAST_60_35 VSS ) ( IO_FILL_IO_EAST_60_30 VSS ) ( IO_FILL_IO_EAST_60_25 VSS ) ( IO_FILL_IO_EAST_60_20 VSS ) ( IO_FILL_IO_EAST_60_15 VSS ) ( IO_FILL_IO_EAST_60_10 VSS ) ( IO_FILL_IO_EAST_60_5 VSS ) ( IO_FILL_IO_EAST_59_120 VSS )
+      ( IO_FILL_IO_EAST_59_115 VSS ) ( IO_FILL_IO_EAST_59_110 VSS ) ( IO_FILL_IO_EAST_59_105 VSS ) ( IO_FILL_IO_EAST_59_100 VSS ) ( IO_FILL_IO_EAST_59_95 VSS ) ( IO_FILL_IO_EAST_59_90 VSS ) ( IO_FILL_IO_EAST_59_85 VSS ) ( IO_FILL_IO_EAST_59_80 VSS )
+      ( IO_FILL_IO_EAST_59_75 VSS ) ( IO_FILL_IO_EAST_59_70 VSS ) ( IO_FILL_IO_EAST_59_65 VSS ) ( IO_FILL_IO_EAST_59_60 VSS ) ( IO_FILL_IO_EAST_59_55 VSS ) ( IO_FILL_IO_EAST_59_50 VSS ) ( IO_FILL_IO_EAST_59_45 VSS ) ( IO_FILL_IO_EAST_59_40 VSS )
+      ( IO_FILL_IO_EAST_59_35 VSS ) ( IO_FILL_IO_EAST_59_30 VSS ) ( IO_FILL_IO_EAST_59_25 VSS ) ( IO_FILL_IO_EAST_59_20 VSS ) ( IO_FILL_IO_EAST_59_15 VSS ) ( IO_FILL_IO_EAST_59_10 VSS ) ( IO_FILL_IO_EAST_59_5 VSS ) ( IO_FILL_IO_EAST_57_65 VSS )
+      ( IO_FILL_IO_EAST_57_60 VSS ) ( IO_FILL_IO_EAST_57_55 VSS ) ( IO_FILL_IO_EAST_57_50 VSS ) ( IO_FILL_IO_EAST_57_45 VSS ) ( IO_FILL_IO_EAST_57_40 VSS ) ( IO_FILL_IO_EAST_57_35 VSS ) ( IO_FILL_IO_EAST_57_30 VSS ) ( IO_FILL_IO_EAST_57_25 VSS )
+      ( IO_FILL_IO_EAST_57_20 VSS ) ( IO_FILL_IO_EAST_57_15 VSS ) ( IO_FILL_IO_EAST_57_10 VSS ) ( IO_FILL_IO_EAST_57_5 VSS ) ( IO_FILL_IO_EAST_54_65 VSS ) ( IO_FILL_IO_EAST_54_60 VSS ) ( IO_FILL_IO_EAST_54_55 VSS ) ( IO_FILL_IO_EAST_54_50 VSS )
+      ( IO_FILL_IO_EAST_54_45 VSS ) ( IO_FILL_IO_EAST_54_40 VSS ) ( IO_FILL_IO_EAST_54_35 VSS ) ( IO_FILL_IO_EAST_54_30 VSS ) ( IO_FILL_IO_EAST_54_25 VSS ) ( IO_FILL_IO_EAST_54_20 VSS ) ( IO_FILL_IO_EAST_54_15 VSS ) ( IO_FILL_IO_EAST_54_10 VSS )
+      ( IO_FILL_IO_EAST_54_5 VSS ) ( IO_FILL_IO_EAST_50_5 VSS ) ( IO_FILL_IO_EAST_35_5 VSS ) ( IO_FILL_IO_EAST_30_5 VSS ) ( IO_FILL_IO_EAST_15_5 VSS ) ( IO_FILL_IO_EAST_10_35 VSS ) ( IO_FILL_IO_EAST_10_30 VSS ) ( IO_FILL_IO_EAST_10_25 VSS )
+      ( IO_FILL_IO_EAST_10_20 VSS ) ( IO_FILL_IO_EAST_10_15 VSS ) ( IO_FILL_IO_EAST_10_10 VSS ) ( IO_FILL_IO_EAST_10_5 VSS ) ( IO_FILL_IO_EAST_6_35 VSS ) ( IO_FILL_IO_EAST_6_30 VSS ) ( IO_FILL_IO_EAST_6_25 VSS ) ( IO_FILL_IO_EAST_6_20 VSS )
+      ( IO_FILL_IO_EAST_6_15 VSS ) ( IO_FILL_IO_EAST_6_10 VSS ) ( IO_FILL_IO_EAST_6_5 VSS ) ( IO_FILL_IO_EAST_3_90 VSS ) ( IO_FILL_IO_EAST_3_85 VSS ) ( IO_FILL_IO_EAST_3_80 VSS ) ( IO_FILL_IO_EAST_3_75 VSS ) ( IO_FILL_IO_EAST_3_70 VSS )
+      ( IO_FILL_IO_EAST_3_65 VSS ) ( IO_FILL_IO_EAST_3_60 VSS ) ( IO_FILL_IO_EAST_3_55 VSS ) ( IO_FILL_IO_EAST_3_50 VSS ) ( IO_FILL_IO_EAST_3_45 VSS ) ( IO_FILL_IO_EAST_3_40 VSS ) ( IO_FILL_IO_EAST_3_35 VSS ) ( IO_FILL_IO_EAST_3_30 VSS )
+      ( IO_FILL_IO_EAST_3_25 VSS ) ( IO_FILL_IO_EAST_3_20 VSS ) ( IO_FILL_IO_EAST_3_15 VSS ) ( IO_FILL_IO_EAST_3_10 VSS ) ( IO_FILL_IO_EAST_3_5 VSS ) ( IO_FILL_IO_EAST_1_95 VSS ) ( IO_FILL_IO_EAST_1_90 VSS ) ( IO_FILL_IO_EAST_1_85 VSS )
+      ( IO_FILL_IO_EAST_1_80 VSS ) ( IO_FILL_IO_EAST_1_75 VSS ) ( IO_FILL_IO_EAST_1_70 VSS ) ( IO_FILL_IO_EAST_1_65 VSS ) ( IO_FILL_IO_EAST_1_60 VSS ) ( IO_FILL_IO_EAST_1_55 VSS ) ( IO_FILL_IO_EAST_1_50 VSS ) ( IO_FILL_IO_EAST_1_45 VSS )
+      ( IO_FILL_IO_EAST_1_40 VSS ) ( IO_FILL_IO_EAST_1_35 VSS ) ( IO_FILL_IO_EAST_1_30 VSS ) ( IO_FILL_IO_EAST_1_25 VSS ) ( IO_FILL_IO_EAST_1_20 VSS ) ( IO_FILL_IO_EAST_1_15 VSS ) ( IO_FILL_IO_EAST_1_10 VSS ) ( IO_FILL_IO_EAST_1_5 VSS )
+      ( IO_FILL_IO_EAST_0_20 VSS ) ( IO_FILL_IO_EAST_6_40 VSS ) ( IO_FILL_IO_EAST_40_5 VSS ) ( IO_FILL_IO_EAST_57_0 VSS ) ( IO_FILL_IO_EAST_56_0 VSS ) ( IO_FILL_IO_EAST_38_0 VSS ) ( IO_FILL_IO_EAST_22_0 VSS ) ( IO_FILL_IO_EAST_4_0 VSS )
+      ( IO_FILL_IO_EAST_3_95 VSS ) ( IO_FILL_IO_EAST_7_0 VSS ) ( IO_FILL_IO_EAST_54_0 VSS ) ( IO_FILL_IO_EAST_53_0 VSS ) ( IO_FILL_IO_EAST_47_0 VSS ) ( IO_FILL_IO_EAST_41_0 VSS ) ( IO_FILL_IO_EAST_33_0 VSS ) ( IO_FILL_IO_EAST_27_0 VSS )
+      ( IO_FILL_IO_EAST_20_0 VSS ) ( IO_FILL_IO_EAST_19_0 VSS ) ( IO_FILL_IO_EAST_13_0 VSS ) ( IO_FILL_IO_EAST_30_0 VSS ) ( IO_FILL_IO_EAST_29_0 VSS ) ( IO_FILL_IO_EAST_28_0 VSS ) ( IO_FILL_IO_EAST_15_0 VSS ) ( IO_FILL_IO_EAST_14_0 VSS )
+      ( IO_FILL_IO_EAST_16_0 VSS ) ( IO_FILL_IO_EAST_15_10 VSS ) ( IO_FILL_IO_EAST_16_5 VSS ) ( IO_FILL_IO_EAST_18_0 VSS ) ( IO_FILL_IO_EAST_17_0 VSS ) ( IO_FILL_IO_EAST_21_0 VSS ) ( IO_FILL_IO_EAST_20_5 VSS ) ( IO_FILL_IO_EAST_24_0 VSS )
+      ( IO_FILL_IO_EAST_23_0 VSS ) ( IO_FILL_IO_EAST_25_0 VSS ) ( IO_FILL_IO_EAST_24_5 VSS ) ( IO_FILL_IO_EAST_26_0 VSS ) ( IO_FILL_IO_EAST_25_5 VSS ) ( IO_FILL_IO_EAST_1_0 VSS ) ( IO_FILL_IO_EAST_0_25 VSS ) ( IO_FILL_IO_EAST_2_0 VSS )
+      ( IO_FILL_IO_EAST_1_100 VSS ) ( IO_FILL_IO_EAST_3_0 VSS ) ( IO_FILL_IO_EAST_2_5 VSS ) ( IO_FILL_IO_EAST_6_0 VSS ) ( IO_FILL_IO_EAST_5_0 VSS ) ( IO_FILL_IO_EAST_8_0 VSS ) ( IO_FILL_IO_EAST_10_0 VSS ) ( IO_FILL_IO_EAST_9_0 VSS )
+      ( IO_FILL_IO_EAST_10_40 VSS ) ( IO_FILL_IO_EAST_12_0 VSS ) ( IO_FILL_IO_EAST_11_0 VSS ) ( IO_FILL_IO_EAST_30_10 VSS ) ( IO_FILL_IO_EAST_45_0 VSS ) ( IO_FILL_IO_EAST_44_5 VSS ) ( IO_FILL_IO_EAST_46_0 VSS ) ( IO_FILL_IO_EAST_45_5 VSS )
+      ( IO_FILL_IO_EAST_48_0 VSS ) ( IO_FILL_IO_EAST_37_0 VSS ) ( IO_FILL_IO_EAST_36_5 VSS ) ( IO_FILL_IO_EAST_40_0 VSS ) ( IO_FILL_IO_EAST_39_0 VSS ) ( IO_FILL_IO_EAST_42_0 VSS ) ( IO_FILL_IO_EAST_44_0 VSS ) ( IO_FILL_IO_EAST_43_0 VSS )
+      ( IO_FILL_IO_EAST_50_0 VSS ) ( IO_FILL_IO_EAST_49_0 VSS ) ( IO_FILL_IO_EAST_50_10 VSS ) ( IO_FILL_IO_EAST_52_0 VSS ) ( IO_FILL_IO_EAST_51_0 VSS ) ( IO_FILL_IO_EAST_55_0 VSS ) ( IO_FILL_IO_EAST_54_70 VSS ) ( IO_FILL_IO_EAST_58_0 VSS )
+      ( IO_FILL_IO_EAST_57_70 VSS ) ( IO_FILL_IO_EAST_59_0 VSS ) ( IO_FILL_IO_EAST_58_5 VSS ) ( IO_FILL_IO_EAST_60_0 VSS ) ( IO_FILL_IO_EAST_59_125 VSS ) ( IO_FILL_IO_EAST_36_0 VSS ) ( IO_FILL_IO_EAST_35_10 VSS ) ( IO_FILL_IO_EAST_35_0 VSS )
+      ( IO_FILL_IO_EAST_34_0 VSS ) ( IO_FILL_IO_EAST_32_0 VSS ) ( IO_FILL_IO_EAST_31_0 VSS ) ( IO_FILL_IO_NORTH_53_95 VSS ) ( IO_FILL_IO_NORTH_53_90 VSS ) ( IO_FILL_IO_NORTH_53_85 VSS ) ( IO_FILL_IO_NORTH_53_80 VSS ) ( IO_FILL_IO_NORTH_53_75 VSS )
+      ( IO_FILL_IO_NORTH_53_70 VSS ) ( IO_FILL_IO_NORTH_53_65 VSS ) ( IO_FILL_IO_NORTH_53_60 VSS ) ( IO_FILL_IO_NORTH_53_55 VSS ) ( IO_FILL_IO_NORTH_53_50 VSS ) ( IO_FILL_IO_NORTH_53_45 VSS ) ( IO_FILL_IO_NORTH_53_40 VSS ) ( IO_FILL_IO_NORTH_53_35 VSS )
+      ( IO_FILL_IO_NORTH_53_30 VSS ) ( IO_FILL_IO_NORTH_53_25 VSS ) ( IO_FILL_IO_NORTH_53_20 VSS ) ( IO_FILL_IO_NORTH_53_15 VSS ) ( IO_FILL_IO_NORTH_53_10 VSS ) ( IO_FILL_IO_NORTH_53_5 VSS ) ( IO_FILL_IO_NORTH_51_95 VSS ) ( IO_FILL_IO_NORTH_51_90 VSS )
+      ( IO_FILL_IO_NORTH_51_85 VSS ) ( IO_FILL_IO_NORTH_51_80 VSS ) ( IO_FILL_IO_NORTH_51_75 VSS ) ( IO_FILL_IO_NORTH_51_70 VSS ) ( IO_FILL_IO_NORTH_51_65 VSS ) ( IO_FILL_IO_NORTH_51_60 VSS ) ( IO_FILL_IO_NORTH_51_55 VSS ) ( IO_FILL_IO_NORTH_51_50 VSS )
+      ( IO_FILL_IO_NORTH_51_45 VSS ) ( IO_FILL_IO_NORTH_51_40 VSS ) ( IO_FILL_IO_NORTH_51_35 VSS ) ( IO_FILL_IO_NORTH_51_30 VSS ) ( IO_FILL_IO_NORTH_51_25 VSS ) ( IO_FILL_IO_NORTH_51_20 VSS ) ( IO_FILL_IO_NORTH_51_15 VSS ) ( IO_FILL_IO_NORTH_51_10 VSS )
+      ( IO_FILL_IO_NORTH_51_5 VSS ) ( IO_FILL_IO_NORTH_48_35 VSS ) ( IO_FILL_IO_NORTH_48_30 VSS ) ( IO_FILL_IO_NORTH_48_25 VSS ) ( IO_FILL_IO_NORTH_48_20 VSS ) ( IO_FILL_IO_NORTH_48_15 VSS ) ( IO_FILL_IO_NORTH_48_10 VSS ) ( IO_FILL_IO_NORTH_48_5 VSS )
+      ( IO_FILL_IO_NORTH_44_30 VSS ) ( IO_FILL_IO_NORTH_44_25 VSS ) ( IO_FILL_IO_NORTH_44_20 VSS ) ( IO_FILL_IO_NORTH_44_15 VSS ) ( IO_FILL_IO_NORTH_44_10 VSS ) ( IO_FILL_IO_NORTH_44_5 VSS ) ( IO_FILL_IO_NORTH_42_20 VSS ) ( IO_FILL_IO_NORTH_42_15 VSS )
+      ( IO_FILL_IO_NORTH_42_10 VSS ) ( IO_FILL_IO_NORTH_42_5 VSS ) ( IO_FILL_IO_NORTH_30_15 VSS ) ( IO_FILL_IO_NORTH_30_10 VSS ) ( IO_FILL_IO_NORTH_30_5 VSS ) ( IO_FILL_IO_NORTH_25_5 VSS ) ( IO_FILL_IO_NORTH_10_5 VSS ) ( IO_FILL_IO_NORTH_6_60 VSS )
+      ( IO_FILL_IO_NORTH_6_55 VSS ) ( IO_FILL_IO_NORTH_6_50 VSS ) ( IO_FILL_IO_NORTH_6_45 VSS ) ( IO_FILL_IO_NORTH_6_40 VSS ) ( IO_FILL_IO_NORTH_6_35 VSS ) ( IO_FILL_IO_NORTH_6_30 VSS ) ( IO_FILL_IO_NORTH_6_25 VSS ) ( IO_FILL_IO_NORTH_6_20 VSS )
+      ( IO_FILL_IO_NORTH_6_15 VSS ) ( IO_FILL_IO_NORTH_6_10 VSS ) ( IO_FILL_IO_NORTH_6_5 VSS ) ( IO_FILL_IO_NORTH_3_65 VSS ) ( IO_FILL_IO_NORTH_3_60 VSS ) ( IO_FILL_IO_NORTH_3_55 VSS ) ( IO_FILL_IO_NORTH_3_50 VSS ) ( IO_FILL_IO_NORTH_3_45 VSS )
+      ( IO_FILL_IO_NORTH_3_40 VSS ) ( IO_FILL_IO_NORTH_3_35 VSS ) ( IO_FILL_IO_NORTH_3_30 VSS ) ( IO_FILL_IO_NORTH_3_25 VSS ) ( IO_FILL_IO_NORTH_3_20 VSS ) ( IO_FILL_IO_NORTH_3_15 VSS ) ( IO_FILL_IO_NORTH_3_10 VSS ) ( IO_FILL_IO_NORTH_3_5 VSS )
+      ( IO_FILL_IO_NORTH_1_125 VSS ) ( IO_FILL_IO_NORTH_1_120 VSS ) ( IO_FILL_IO_NORTH_1_115 VSS ) ( IO_FILL_IO_NORTH_1_110 VSS ) ( IO_FILL_IO_NORTH_1_105 VSS ) ( IO_FILL_IO_NORTH_1_100 VSS ) ( IO_FILL_IO_NORTH_1_95 VSS ) ( IO_FILL_IO_NORTH_1_90 VSS )
+      ( IO_FILL_IO_NORTH_1_85 VSS ) ( IO_FILL_IO_NORTH_1_80 VSS ) ( IO_FILL_IO_NORTH_1_75 VSS ) ( IO_FILL_IO_NORTH_1_70 VSS ) ( IO_FILL_IO_NORTH_1_65 VSS ) ( IO_FILL_IO_NORTH_1_60 VSS ) ( IO_FILL_IO_NORTH_1_55 VSS ) ( IO_FILL_IO_NORTH_1_50 VSS )
+      ( IO_FILL_IO_NORTH_1_45 VSS ) ( IO_FILL_IO_NORTH_1_40 VSS ) ( IO_FILL_IO_NORTH_1_35 VSS ) ( IO_FILL_IO_NORTH_1_30 VSS ) ( IO_FILL_IO_NORTH_1_25 VSS ) ( IO_FILL_IO_NORTH_1_20 VSS ) ( IO_FILL_IO_NORTH_1_15 VSS ) ( IO_FILL_IO_NORTH_1_10 VSS )
+      ( IO_FILL_IO_NORTH_1_5 VSS ) ( IO_FILL_IO_NORTH_0_210 VSS ) ( IO_FILL_IO_NORTH_0_205 VSS ) ( IO_FILL_IO_NORTH_0_200 VSS ) ( IO_FILL_IO_NORTH_0_195 VSS ) ( IO_FILL_IO_NORTH_0_190 VSS ) ( IO_FILL_IO_NORTH_0_185 VSS ) ( IO_FILL_IO_NORTH_0_180 VSS )
+      ( IO_FILL_IO_NORTH_0_175 VSS ) ( IO_FILL_IO_NORTH_0_170 VSS ) ( IO_FILL_IO_NORTH_0_165 VSS ) ( IO_FILL_IO_NORTH_0_160 VSS ) ( IO_FILL_IO_NORTH_0_155 VSS ) ( IO_FILL_IO_NORTH_0_150 VSS ) ( IO_FILL_IO_NORTH_0_145 VSS ) ( IO_FILL_IO_NORTH_0_140 VSS )
+      ( IO_FILL_IO_NORTH_0_135 VSS ) ( IO_FILL_IO_NORTH_0_130 VSS ) ( IO_FILL_IO_NORTH_0_125 VSS ) ( IO_FILL_IO_NORTH_0_120 VSS ) ( IO_FILL_IO_NORTH_0_115 VSS ) ( IO_FILL_IO_NORTH_0_110 VSS ) ( IO_FILL_IO_NORTH_0_105 VSS ) ( IO_FILL_IO_NORTH_0_100 VSS )
+      ( IO_FILL_IO_NORTH_0_95 VSS ) ( IO_FILL_IO_NORTH_0_90 VSS ) ( IO_FILL_IO_NORTH_0_85 VSS ) ( IO_FILL_IO_NORTH_0_80 VSS ) ( IO_FILL_IO_NORTH_0_75 VSS ) ( IO_FILL_IO_NORTH_0_70 VSS ) ( IO_FILL_IO_NORTH_0_65 VSS ) ( IO_FILL_IO_NORTH_0_60 VSS )
+      ( IO_FILL_IO_NORTH_0_55 VSS ) ( IO_FILL_IO_NORTH_0_50 VSS ) ( IO_FILL_IO_NORTH_0_45 VSS ) ( IO_FILL_IO_NORTH_0_40 VSS ) ( IO_FILL_IO_NORTH_0_35 VSS ) ( IO_FILL_IO_NORTH_0_30 VSS ) ( IO_FILL_IO_NORTH_0_25 VSS ) ( IO_FILL_IO_NORTH_0_20 VSS )
+      ( IO_FILL_IO_NORTH_0_15 VSS ) ( IO_FILL_IO_NORTH_0_10 VSS ) ( IO_FILL_IO_NORTH_0_5 VSS ) ( IO_FILL_IO_NORTH_0_0 VSS ) ( IO_FILL_IO_NORTH_1_130 VSS ) ( IO_FILL_IO_NORTH_10_0 VSS ) ( IO_FILL_IO_NORTH_15_5 VSS ) ( IO_FILL_IO_NORTH_53_100 VSS )
+      ( IO_FILL_IO_NORTH_37_0 VSS ) ( IO_FILL_IO_NORTH_48_40 VSS ) ( IO_FILL_IO_NORTH_6_0 VSS ) ( IO_FILL_IO_NORTH_22_0 VSS ) ( IO_FILL_IO_NORTH_30_20 VSS ) ( IO_FILL_IO_NORTH_37_5 VSS ) ( IO_FILL_IO_NORTH_49_0 VSS ) ( IO_FILL_IO_NORTH_6_65 VSS )
+      ( IO_FILL_IO_NORTH_23_0 VSS ) ( IO_FILL_IO_NORTH_1_0 VSS ) ( IO_FILL_IO_NORTH_0_215 VSS ) ( IO_FILL_IO_NORTH_9_0 VSS ) ( IO_FILL_IO_NORTH_15_0 VSS ) ( IO_FILL_IO_NORTH_21_0 VSS ) ( IO_FILL_IO_NORTH_20_5 VSS ) ( IO_FILL_IO_NORTH_26_5 VSS )
+      ( IO_FILL_IO_NORTH_35_0 VSS ) ( IO_FILL_IO_NORTH_34_0 VSS ) ( IO_FILL_IO_NORTH_45_0 VSS ) ( IO_FILL_IO_NORTH_44_35 VSS ) ( IO_FILL_IO_NORTH_53_0 VSS ) ( IO_FILL_IO_NORTH_36_0 VSS ) ( IO_FILL_IO_NORTH_35_5 VSS ) ( IO_FILL_IO_NORTH_33_0 VSS )
+      ( IO_FILL_IO_NORTH_32_5 VSS ) ( IO_FILL_IO_NORTH_32_0 VSS ) ( IO_FILL_IO_NORTH_31_0 VSS ) ( IO_FILL_IO_NORTH_39_0 VSS ) ( IO_FILL_IO_NORTH_38_0 VSS ) ( IO_FILL_IO_NORTH_14_0 VSS ) ( IO_FILL_IO_NORTH_13_0 VSS ) ( IO_FILL_IO_NORTH_12_5 VSS )
+      ( IO_FILL_IO_NORTH_12_0 VSS ) ( IO_FILL_IO_NORTH_20_0 VSS ) ( IO_FILL_IO_NORTH_19_0 VSS ) ( IO_FILL_IO_NORTH_18_5 VSS ) ( IO_FILL_IO_NORTH_18_0 VSS ) ( IO_FILL_IO_NORTH_17_0 VSS ) ( IO_FILL_IO_NORTH_16_0 VSS ) ( IO_FILL_IO_NORTH_11_0 VSS )
+      ( IO_FILL_IO_NORTH_10_10 VSS ) ( IO_FILL_IO_NORTH_8_0 VSS ) ( IO_FILL_IO_NORTH_7_0 VSS ) ( IO_FILL_IO_NORTH_5_0 VSS ) ( IO_FILL_IO_NORTH_4_5 VSS ) ( IO_FILL_IO_NORTH_4_0 VSS ) ( IO_FILL_IO_NORTH_3_70 VSS ) ( IO_FILL_IO_NORTH_3_0 VSS )
+      ( IO_FILL_IO_NORTH_2_0 VSS ) ( IO_FILL_IO_NORTH_30_0 VSS ) ( IO_FILL_IO_NORTH_29_0 VSS ) ( IO_FILL_IO_NORTH_28_0 VSS ) ( IO_FILL_IO_NORTH_27_0 VSS ) ( IO_FILL_IO_NORTH_26_0 VSS ) ( IO_FILL_IO_NORTH_25_10 VSS ) ( IO_FILL_IO_NORTH_25_0 VSS )
+      ( IO_FILL_IO_NORTH_24_0 VSS ) ( IO_FILL_IO_NORTH_48_0 VSS ) ( IO_FILL_IO_NORTH_47_0 VSS ) ( IO_FILL_IO_NORTH_46_0 VSS ) ( IO_FILL_IO_NORTH_44_0 VSS ) ( IO_FILL_IO_NORTH_52_0 VSS ) ( IO_FILL_IO_NORTH_51_100 VSS ) ( IO_FILL_IO_NORTH_51_0 VSS )
+      ( IO_FILL_IO_NORTH_50_0 VSS ) ( IO_FILL_IO_NORTH_43_0 VSS ) ( IO_FILL_IO_NORTH_42_25 VSS ) ( IO_FILL_IO_NORTH_42_0 VSS ) ( IO_FILL_IO_NORTH_41_0 VSS ) ( IO_FILL_IO_NORTH_40_0 VSS ) ( IO_FILL_IO_NORTH_39_5 VSS ) ( IO_FILL_IO_EAST_60_185 VSS )
+      ( IO_FILL_IO_EAST_60_190 VSS ) ( IO_CORNER_NORTH_EAST_INST VSS ) ( IO_FILL_IO_NORTH_54_0 VSS ) ( IO_CORNER_NORTH_WEST_INST VSS ) ( IO_FILL_IO_WEST_57_0 VSS ) ( u_v18_33 VSS ) ( u_vzz_33 VSS ) ( u_brk0 VSS )
+      ( u_vdd_0 VSS ) ( u_v18_0 VSS ) ( u_vzz_9 VSS ) ( u_vzz_8 VSS ) ( u_vzz_7 VSS ) ( u_vzz_6 VSS ) ( u_vzz_5 VSS ) ( u_vzz_4 VSS )
+      ( u_vzz_32 VSS ) ( u_vzz_31 VSS ) ( u_vzz_30 VSS ) ( u_vzz_3 VSS ) ( u_vzz_29 VSS ) ( u_vzz_28 VSS ) ( u_vzz_27 VSS ) ( u_vzz_26 VSS )
+      ( u_vzz_25 VSS ) ( u_vzz_24 VSS ) ( u_vzz_23 VSS ) ( u_vzz_22 VSS ) ( u_vzz_21 VSS ) ( u_vzz_20 VSS ) ( u_vzz_2 VSS ) ( u_vzz_19 VSS )
+      ( u_vzz_18 VSS ) ( u_vzz_17 VSS ) ( u_vzz_16 VSS ) ( u_vzz_15 VSS ) ( u_vzz_14 VSS ) ( u_vzz_13 VSS ) ( u_vzz_12 VSS ) ( u_vzz_11 VSS )
+      ( u_vzz_10 VSS ) ( u_vzz_1 VSS ) ( u_vzz_0 VSS ) ( u_vss_pll VSS ) ( u_vss_9 VSS ) ( u_vss_8 VSS ) ( u_vss_7 VSS ) ( u_vss_6 VSS )
+      ( u_vss_5 VSS ) ( u_vss_4 VSS ) ( u_vss_32 VSS ) ( u_vss_31 VSS ) ( u_vss_30 VSS ) ( u_vss_3 VSS ) ( u_vss_29 VSS ) ( u_vss_28 VSS )
+      ( u_vss_27 VSS ) ( u_vss_26 VSS ) ( u_vss_25 VSS ) ( u_vss_24 VSS ) ( u_vss_23 VSS ) ( u_vss_22 VSS ) ( u_vss_21 VSS ) ( u_vss_20 VSS )
+      ( u_vss_2 VSS ) ( u_vss_19 VSS ) ( u_vss_18 VSS ) ( u_vss_17 VSS ) ( u_vss_16 VSS ) ( u_vss_15 VSS ) ( u_vss_14 VSS ) ( u_vss_13 VSS )
+      ( u_vss_12 VSS ) ( u_vss_11 VSS ) ( u_vss_10 VSS ) ( u_vss_1 VSS ) ( u_vss_0 VSS ) ( u_vdd_pll VSS ) ( u_vdd_9 VSS ) ( u_vdd_8 VSS )
+      ( u_vdd_7 VSS ) ( u_vdd_6 VSS ) ( u_vdd_5 VSS ) ( u_vdd_4 VSS ) ( u_vdd_32 VSS ) ( u_vdd_31 VSS ) ( u_vdd_30 VSS ) ( u_vdd_3 VSS )
+      ( u_vdd_29 VSS ) ( u_vdd_28 VSS ) ( u_vdd_27 VSS ) ( u_vdd_26 VSS ) ( u_vdd_25 VSS ) ( u_vdd_24 VSS ) ( u_vdd_23 VSS ) ( u_vdd_22 VSS )
+      ( u_vdd_21 VSS ) ( u_vdd_20 VSS ) ( u_vdd_2 VSS ) ( u_vdd_19 VSS ) ( u_vdd_18 VSS ) ( u_vdd_17 VSS ) ( u_vdd_16 VSS ) ( u_vdd_15 VSS )
+      ( u_vdd_14 VSS ) ( u_vdd_13 VSS ) ( u_vdd_12 VSS ) ( u_vdd_11 VSS ) ( u_vdd_10 VSS ) ( u_vdd_1 VSS ) ( u_v18_9 VSS ) ( u_v18_8 VSS )
+      ( u_v18_7 VSS ) ( u_v18_6 VSS ) ( u_v18_5 VSS ) ( u_v18_4 VSS ) ( u_v18_32 VSS ) ( u_v18_31 VSS ) ( u_v18_30 VSS ) ( u_v18_3 VSS )
+      ( u_v18_29 VSS ) ( u_v18_28 VSS ) ( u_v18_27 VSS ) ( u_v18_26 VSS ) ( u_v18_25 VSS ) ( u_v18_24 VSS ) ( u_v18_23 VSS ) ( u_v18_22 VSS )
+      ( u_v18_21 VSS ) ( u_v18_20 VSS ) ( u_v18_2 VSS ) ( u_v18_19 VSS ) ( u_v18_18 VSS ) ( u_v18_17 VSS ) ( u_v18_16 VSS ) ( u_v18_15 VSS )
+      ( u_v18_14 VSS ) ( u_v18_13 VSS ) ( u_v18_12 VSS ) ( u_v18_11 VSS ) ( u_v18_10 VSS ) ( u_v18_1 VSS ) ( u_sel_2_i VSS ) ( u_sel_1_i VSS )
+      ( u_sel_0_i VSS ) ( u_misc_o VSS ) ( u_ddr_we_n_o VSS ) ( u_ddr_reset_n_o VSS ) ( u_ddr_ras_n_o VSS ) ( u_ddr_odt_o VSS ) ( u_ddr_dqs_p_3_io VSS ) ( u_ddr_dqs_p_2_io VSS )
+      ( u_ddr_dqs_p_1_io VSS ) ( u_ddr_dqs_p_0_io VSS ) ( u_ddr_dqs_n_3_io VSS ) ( u_ddr_dqs_n_2_io VSS ) ( u_ddr_dqs_n_1_io VSS ) ( u_ddr_dqs_n_0_io VSS ) ( u_ddr_dq_9_io VSS ) ( u_ddr_dq_8_io VSS )
+      ( u_ddr_dq_7_io VSS ) ( u_ddr_dq_6_io VSS ) ( u_ddr_dq_5_io VSS ) ( u_ddr_dq_4_io VSS ) ( u_ddr_dq_3_io VSS ) ( u_ddr_dq_31_io VSS ) ( u_ddr_dq_30_io VSS ) ( u_ddr_dq_2_io VSS )
+      ( u_ddr_dq_29_io VSS ) ( u_ddr_dq_28_io VSS ) ( u_ddr_dq_27_io VSS ) ( u_ddr_dq_26_io VSS ) ( u_ddr_dq_25_io VSS ) ( u_ddr_dq_24_io VSS ) ( u_ddr_dq_23_io VSS ) ( u_ddr_dq_22_io VSS )
+      ( u_ddr_dq_21_io VSS ) ( u_ddr_dq_20_io VSS ) ( u_ddr_dq_1_io VSS ) ( u_ddr_dq_19_io VSS ) ( u_ddr_dq_18_io VSS ) ( u_ddr_dq_17_io VSS ) ( u_ddr_dq_16_io VSS ) ( u_ddr_dq_15_io VSS )
+      ( u_ddr_dq_14_io VSS ) ( u_ddr_dq_13_io VSS ) ( u_ddr_dq_12_io VSS ) ( u_ddr_dq_11_io VSS ) ( u_ddr_dq_10_io VSS ) ( u_ddr_dq_0_io VSS ) ( u_ddr_dm_3_o VSS ) ( u_ddr_dm_2_o VSS )
+      ( u_ddr_dm_1_o VSS ) ( u_ddr_dm_0_o VSS ) ( u_ddr_cs_n_o VSS ) ( u_ddr_cke_o VSS ) ( u_ddr_ck_p_o VSS ) ( u_ddr_ck_n_o VSS ) ( u_ddr_cas_n_o VSS ) ( u_ddr_ba_2_o VSS )
+      ( u_ddr_ba_1_o VSS ) ( u_ddr_ba_0_o VSS ) ( u_ddr_addr_9_o VSS ) ( u_ddr_addr_8_o VSS ) ( u_ddr_addr_7_o VSS ) ( u_ddr_addr_6_o VSS ) ( u_ddr_addr_5_o VSS ) ( u_ddr_addr_4_o VSS )
+      ( u_ddr_addr_3_o VSS ) ( u_ddr_addr_2_o VSS ) ( u_ddr_addr_1_o VSS ) ( u_ddr_addr_15_o VSS ) ( u_ddr_addr_14_o VSS ) ( u_ddr_addr_13_o VSS ) ( u_ddr_addr_12_o VSS ) ( u_ddr_addr_11_o VSS )
+      ( u_ddr_addr_10_o VSS ) ( u_ddr_addr_0_o VSS ) ( u_core_async_reset_i VSS ) ( u_co_v_i VSS ) ( u_co_tkn_o VSS ) ( u_co_clk_i VSS ) ( u_co_8_i VSS ) ( u_co_7_i VSS )
+      ( u_co_6_i VSS ) ( u_co_5_i VSS ) ( u_co_4_i VSS ) ( u_co_3_i VSS ) ( u_co_2_i VSS ) ( u_co_1_i VSS ) ( u_co_0_i VSS ) ( u_co2_v_o VSS )
+      ( u_co2_tkn_i VSS ) ( u_co2_clk_o VSS ) ( u_co2_8_o VSS ) ( u_co2_7_o VSS ) ( u_co2_6_o VSS ) ( u_co2_5_o VSS ) ( u_co2_4_o VSS ) ( u_co2_3_o VSS )
+      ( u_co2_2_o VSS ) ( u_co2_1_o VSS ) ( u_co2_0_o VSS ) ( u_clk_o VSS ) ( u_clk_async_reset_i VSS ) ( u_clk_C_i VSS ) ( u_clk_B_i VSS ) ( u_clk_A_i VSS )
+      ( u_ci_v_i VSS ) ( u_ci_tkn_o VSS ) ( u_ci_clk_i VSS ) ( u_ci_8_i VSS ) ( u_ci_7_i VSS ) ( u_ci_6_i VSS ) ( u_ci_5_i VSS ) ( u_ci_4_i VSS )
+      ( u_ci_3_i VSS ) ( u_ci_2_i VSS ) ( u_ci_1_i VSS ) ( u_ci_0_i VSS ) ( u_ci2_v_o VSS ) ( u_ci2_tkn_i VSS ) ( u_ci2_clk_o VSS ) ( u_ci2_8_o VSS )
+      ( u_ci2_7_o VSS ) ( u_ci2_6_o VSS ) ( u_ci2_5_o VSS ) ( u_ci2_4_o VSS ) ( u_ci2_3_o VSS ) ( u_ci2_2_o VSS ) ( u_ci2_1_o VSS ) ( u_ci2_0_o VSS )
+      ( u_bsg_tag_en_i VSS ) ( u_bsg_tag_data_o VSS ) ( u_bsg_tag_data_i VSS ) ( u_bsg_tag_clk_o VSS ) ( u_bsg_tag_clk_i VSS ) + USE GROUND ;
+    - p_bsg_tag_clk_i ( PIN p_bsg_tag_clk_i ) ( BUMP_15_8 PAD ) ( u_bsg_tag_clk_i PAD ) + USE SIGNAL ;
+    - p_bsg_tag_clk_o ( PIN p_bsg_tag_clk_o ) ( BUMP_3_10 PAD ) ( u_bsg_tag_clk_o PAD ) + USE SIGNAL ;
+    - p_bsg_tag_data_i ( PIN p_bsg_tag_data_i ) ( BUMP_12_8 PAD ) ( u_bsg_tag_data_i PAD ) + USE SIGNAL ;
+    - p_bsg_tag_data_o ( PIN p_bsg_tag_data_o ) ( BUMP_2_10 PAD ) ( u_bsg_tag_data_o PAD ) + USE SIGNAL ;
+    - p_bsg_tag_en_i ( PIN p_bsg_tag_en_i ) ( BUMP_13_9 PAD ) ( u_bsg_tag_en_i PAD ) + USE SIGNAL ;
+    - p_ci2_0_o ( PIN p_ci2_0_o ) ( BUMP_11_16 PAD ) ( u_ci2_0_o PAD ) + USE SIGNAL ;
+    - p_ci2_1_o ( PIN p_ci2_1_o ) ( BUMP_11_15 PAD ) ( u_ci2_1_o PAD ) + USE SIGNAL ;
+    - p_ci2_2_o ( PIN p_ci2_2_o ) ( BUMP_12_14 PAD ) ( u_ci2_2_o PAD ) + USE SIGNAL ;
+    - p_ci2_3_o ( PIN p_ci2_3_o ) ( BUMP_12_16 PAD ) ( u_ci2_3_o PAD ) + USE SIGNAL ;
+    - p_ci2_4_o ( PIN p_ci2_4_o ) ( BUMP_12_15 PAD ) ( u_ci2_4_o PAD ) + USE SIGNAL ;
+    - p_ci2_5_o ( PIN p_ci2_5_o ) ( BUMP_14_15 PAD ) ( u_ci2_5_o PAD ) + USE SIGNAL ;
+    - p_ci2_6_o ( PIN p_ci2_6_o ) ( BUMP_15_16 PAD ) ( u_ci2_6_o PAD ) + USE SIGNAL ;
+    - p_ci2_7_o ( PIN p_ci2_7_o ) ( BUMP_16_15 PAD ) ( u_ci2_7_o PAD ) + USE SIGNAL ;
+    - p_ci2_8_o ( PIN p_ci2_8_o ) ( BUMP_16_14 PAD ) ( u_ci2_8_o PAD ) + USE SIGNAL ;
+    - p_ci2_clk_o ( PIN p_ci2_clk_o ) ( BUMP_12_13 PAD ) ( u_ci2_clk_o PAD ) + USE SIGNAL ;
+    - p_ci2_tkn_i ( PIN p_ci2_tkn_i ) ( BUMP_13_15 PAD ) ( u_ci2_tkn_i PAD ) + USE SIGNAL ;
+    - p_ci2_v_o ( PIN p_ci2_v_o ) ( BUMP_13_13 PAD ) ( u_ci2_v_o PAD ) + USE SIGNAL ;
+    - p_ci_0_i ( PIN p_ci_0_i ) ( BUMP_15_14 PAD ) ( u_ci_0_i PAD ) + USE SIGNAL ;
+    - p_ci_1_i ( PIN p_ci_1_i ) ( BUMP_15_13 PAD ) ( u_ci_1_i PAD ) + USE SIGNAL ;
+    - p_ci_2_i ( PIN p_ci_2_i ) ( BUMP_15_12 PAD ) ( u_ci_2_i PAD ) + USE SIGNAL ;
+    - p_ci_3_i ( PIN p_ci_3_i ) ( BUMP_13_12 PAD ) ( u_ci_3_i PAD ) + USE SIGNAL ;
+    - p_ci_4_i ( PIN p_ci_4_i ) ( BUMP_12_11 PAD ) ( u_ci_4_i PAD ) + USE SIGNAL ;
+    - p_ci_5_i ( PIN p_ci_5_i ) ( BUMP_14_10 PAD ) ( u_ci_5_i PAD ) + USE SIGNAL ;
+    - p_ci_6_i ( PIN p_ci_6_i ) ( BUMP_16_10 PAD ) ( u_ci_6_i PAD ) + USE SIGNAL ;
+    - p_ci_7_i ( PIN p_ci_7_i ) ( BUMP_12_9 PAD ) ( u_ci_7_i PAD ) + USE SIGNAL ;
+    - p_ci_8_i ( PIN p_ci_8_i ) ( BUMP_15_9 PAD ) ( u_ci_8_i PAD ) + USE SIGNAL ;
+    - p_ci_clk_i ( PIN p_ci_clk_i ) ( BUMP_14_11 PAD ) ( u_ci_clk_i PAD ) + USE SIGNAL ;
+    - p_ci_tkn_o ( PIN p_ci_tkn_o ) ( BUMP_13_11 PAD ) ( u_ci_tkn_o PAD ) + USE SIGNAL ;
+    - p_ci_v_i ( PIN p_ci_v_i ) ( BUMP_12_10 PAD ) ( u_ci_v_i PAD ) + USE SIGNAL ;
+    - p_clk_A_i ( PIN p_clk_A_i ) ( BUMP_7_13 PAD ) ( u_clk_A_i PAD ) + USE SIGNAL ;
+    - p_clk_B_i ( PIN p_clk_B_i ) ( BUMP_8_12 PAD ) ( u_clk_B_i PAD ) + USE SIGNAL ;
+    - p_clk_C_i ( PIN p_clk_C_i ) ( BUMP_8_16 PAD ) ( u_clk_C_i PAD ) + USE SIGNAL ;
+    - p_clk_async_reset_i ( PIN p_clk_async_reset_i ) ( BUMP_9_14 PAD ) ( u_clk_async_reset_i PAD ) + USE SIGNAL ;
+    - p_clk_o ( PIN p_clk_o ) ( BUMP_8_13 PAD ) ( u_clk_o PAD ) + USE SIGNAL ;
+    - p_co2_0_o ( PIN p_co2_0_o ) ( BUMP_0_11 PAD ) ( u_co2_0_o PAD ) + USE SIGNAL ;
+    - p_co2_1_o ( PIN p_co2_1_o ) ( BUMP_1_11 PAD ) ( u_co2_1_o PAD ) + USE SIGNAL ;
+    - p_co2_2_o ( PIN p_co2_2_o ) ( BUMP_3_11 PAD ) ( u_co2_2_o PAD ) + USE SIGNAL ;
+    - p_co2_3_o ( PIN p_co2_3_o ) ( BUMP_4_12 PAD ) ( u_co2_3_o PAD ) + USE SIGNAL ;
+    - p_co2_4_o ( PIN p_co2_4_o ) ( BUMP_1_12 PAD ) ( u_co2_4_o PAD ) + USE SIGNAL ;
+    - p_co2_5_o ( PIN p_co2_5_o ) ( BUMP_1_14 PAD ) ( u_co2_5_o PAD ) + USE SIGNAL ;
+    - p_co2_6_o ( PIN p_co2_6_o ) ( BUMP_0_15 PAD ) ( u_co2_6_o PAD ) + USE SIGNAL ;
+    - p_co2_7_o ( PIN p_co2_7_o ) ( BUMP_1_15 PAD ) ( u_co2_7_o PAD ) + USE SIGNAL ;
+    - p_co2_8_o ( PIN p_co2_8_o ) ( BUMP_0_16 PAD ) ( u_co2_8_o PAD ) + USE SIGNAL ;
+    - p_co2_clk_o ( PIN p_co2_clk_o ) ( BUMP_3_12 PAD ) ( u_co2_clk_o PAD ) + USE SIGNAL ;
+    - p_co2_tkn_i ( PIN p_co2_tkn_i ) ( BUMP_2_13 PAD ) ( u_co2_tkn_i PAD ) + USE SIGNAL ;
+    - p_co2_v_o ( PIN p_co2_v_o ) ( BUMP_0_13 PAD ) ( u_co2_v_o PAD ) + USE SIGNAL ;
+    - p_co_0_i ( PIN p_co_0_i ) ( BUMP_2_15 PAD ) ( u_co_0_i PAD ) + USE SIGNAL ;
+    - p_co_1_i ( PIN p_co_1_i ) ( BUMP_3_14 PAD ) ( u_co_1_i PAD ) + USE SIGNAL ;
+    - p_co_2_i ( PIN p_co_2_i ) ( BUMP_3_16 PAD ) ( u_co_2_i PAD ) + USE SIGNAL ;
+    - p_co_3_i ( PIN p_co_3_i ) ( BUMP_4_16 PAD ) ( u_co_3_i PAD ) + USE SIGNAL ;
+    - p_co_4_i ( PIN p_co_4_i ) ( BUMP_5_12 PAD ) ( u_co_4_i PAD ) + USE SIGNAL ;
+    - p_co_5_i ( PIN p_co_5_i ) ( BUMP_6_14 PAD ) ( u_co_5_i PAD ) + USE SIGNAL ;
+    - p_co_6_i ( PIN p_co_6_i ) ( BUMP_6_16 PAD ) ( u_co_6_i PAD ) + USE SIGNAL ;
+    - p_co_7_i ( PIN p_co_7_i ) ( BUMP_6_15 PAD ) ( u_co_7_i PAD ) + USE SIGNAL ;
+    - p_co_8_i ( PIN p_co_8_i ) ( BUMP_6_13 PAD ) ( u_co_8_i PAD ) + USE SIGNAL ;
+    - p_co_clk_i ( PIN p_co_clk_i ) ( BUMP_5_14 PAD ) ( u_co_clk_i PAD ) + USE SIGNAL ;
+    - p_co_tkn_o ( PIN p_co_tkn_o ) ( BUMP_5_16 PAD ) ( u_co_tkn_o PAD ) + USE SIGNAL ;
+    - p_co_v_i ( PIN p_co_v_i ) ( BUMP_5_15 PAD ) ( u_co_v_i PAD ) + USE SIGNAL ;
+    - p_core_async_reset_i ( PIN p_core_async_reset_i ) ( BUMP_11_14 PAD ) ( u_core_async_reset_i PAD ) + USE SIGNAL ;
+    - p_ddr_addr_0_o ( PIN p_ddr_addr_0_o ) ( BUMP_9_0 PAD ) ( u_ddr_addr_0_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_10_o ( PIN p_ddr_addr_10_o ) ( BUMP_5_4 PAD ) ( u_ddr_addr_10_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_11_o ( PIN p_ddr_addr_11_o ) ( BUMP_5_2 PAD ) ( u_ddr_addr_11_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_12_o ( PIN p_ddr_addr_12_o ) ( BUMP_5_3 PAD ) ( u_ddr_addr_12_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_13_o ( PIN p_ddr_addr_13_o ) ( BUMP_4_4 PAD ) ( u_ddr_addr_13_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_14_o ( PIN p_ddr_addr_14_o ) ( BUMP_4_2 PAD ) ( u_ddr_addr_14_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_15_o ( PIN p_ddr_addr_15_o ) ( BUMP_4_0 PAD ) ( u_ddr_addr_15_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_1_o ( PIN p_ddr_addr_1_o ) ( BUMP_8_4 PAD ) ( u_ddr_addr_1_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_2_o ( PIN p_ddr_addr_2_o ) ( BUMP_8_2 PAD ) ( u_ddr_addr_2_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_3_o ( PIN p_ddr_addr_3_o ) ( BUMP_8_0 PAD ) ( u_ddr_addr_3_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_4_o ( PIN p_ddr_addr_4_o ) ( BUMP_7_4 PAD ) ( u_ddr_addr_4_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_5_o ( PIN p_ddr_addr_5_o ) ( BUMP_7_2 PAD ) ( u_ddr_addr_5_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_6_o ( PIN p_ddr_addr_6_o ) ( BUMP_7_0 PAD ) ( u_ddr_addr_6_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_7_o ( PIN p_ddr_addr_7_o ) ( BUMP_7_1 PAD ) ( u_ddr_addr_7_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_8_o ( PIN p_ddr_addr_8_o ) ( BUMP_6_2 PAD ) ( u_ddr_addr_8_o PAD ) + USE SIGNAL ;
+    - p_ddr_addr_9_o ( PIN p_ddr_addr_9_o ) ( BUMP_6_0 PAD ) ( u_ddr_addr_9_o PAD ) + USE SIGNAL ;
+    - p_ddr_ba_0_o ( PIN p_ddr_ba_0_o ) ( BUMP_3_2 PAD ) ( u_ddr_ba_0_o PAD ) + USE SIGNAL ;
+    - p_ddr_ba_1_o ( PIN p_ddr_ba_1_o ) ( BUMP_3_0 PAD ) ( u_ddr_ba_1_o PAD ) + USE SIGNAL ;
+    - p_ddr_ba_2_o ( PIN p_ddr_ba_2_o ) ( BUMP_3_1 PAD ) ( u_ddr_ba_2_o PAD ) + USE SIGNAL ;
+    - p_ddr_cas_n_o ( PIN p_ddr_cas_n_o ) ( BUMP_10_2 PAD ) ( u_ddr_cas_n_o PAD ) + USE SIGNAL ;
+    - p_ddr_ck_n_o ( PIN p_ddr_ck_n_o ) ( BUMP_11_4 PAD ) ( u_ddr_ck_n_o PAD ) + USE SIGNAL ;
+    - p_ddr_ck_p_o ( PIN p_ddr_ck_p_o ) ( BUMP_13_1 PAD ) ( u_ddr_ck_p_o PAD ) + USE SIGNAL ;
+    - p_ddr_cke_o ( PIN p_ddr_cke_o ) ( BUMP_11_2 PAD ) ( u_ddr_cke_o PAD ) + USE SIGNAL ;
+    - p_ddr_cs_n_o ( PIN p_ddr_cs_n_o ) ( BUMP_11_0 PAD ) ( u_ddr_cs_n_o PAD ) + USE SIGNAL ;
+    - p_ddr_dm_0_o ( PIN p_ddr_dm_0_o ) ( BUMP_2_7 PAD ) ( u_ddr_dm_0_o PAD ) + USE SIGNAL ;
+    - p_ddr_dm_1_o ( PIN p_ddr_dm_1_o ) ( BUMP_0_0 PAD ) ( u_ddr_dm_1_o PAD ) + USE SIGNAL ;
+    - p_ddr_dm_2_o ( PIN p_ddr_dm_2_o ) ( BUMP_14_1 PAD ) ( u_ddr_dm_2_o PAD ) + USE SIGNAL ;
+    - p_ddr_dm_3_o ( PIN p_ddr_dm_3_o ) ( BUMP_13_8 PAD ) ( u_ddr_dm_3_o PAD ) + USE SIGNAL ;
+    - p_ddr_dq_0_io ( PIN p_ddr_dq_0_io ) ( BUMP_3_7 PAD ) ( u_ddr_dq_0_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_10_io ( PIN p_ddr_dq_10_io ) ( BUMP_3_4 PAD ) ( u_ddr_dq_10_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_11_io ( PIN p_ddr_dq_11_io ) ( BUMP_4_5 PAD ) ( u_ddr_dq_11_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_12_io ( PIN p_ddr_dq_12_io ) ( BUMP_2_5 PAD ) ( u_ddr_dq_12_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_13_io ( PIN p_ddr_dq_13_io ) ( BUMP_3_5 PAD ) ( u_ddr_dq_13_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_14_io ( PIN p_ddr_dq_14_io ) ( BUMP_4_6 PAD ) ( u_ddr_dq_14_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_15_io ( PIN p_ddr_dq_15_io ) ( BUMP_2_6 PAD ) ( u_ddr_dq_15_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_16_io ( PIN p_ddr_dq_16_io ) ( BUMP_15_4 PAD ) ( u_ddr_dq_16_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_17_io ( PIN p_ddr_dq_17_io ) ( BUMP_13_4 PAD ) ( u_ddr_dq_17_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_18_io ( PIN p_ddr_dq_18_io ) ( BUMP_14_3 PAD ) ( u_ddr_dq_18_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_19_io ( PIN p_ddr_dq_19_io ) ( BUMP_16_3 PAD ) ( u_ddr_dq_19_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_1_io ( PIN p_ddr_dq_1_io ) ( BUMP_4_8 PAD ) ( u_ddr_dq_1_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_20_io ( PIN p_ddr_dq_20_io ) ( BUMP_14_2 PAD ) ( u_ddr_dq_20_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_21_io ( PIN p_ddr_dq_21_io ) ( BUMP_16_1 PAD ) ( u_ddr_dq_21_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_22_io ( PIN p_ddr_dq_22_io ) ( BUMP_15_1 PAD ) ( u_ddr_dq_22_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_23_io ( PIN p_ddr_dq_23_io ) ( BUMP_16_0 PAD ) ( u_ddr_dq_23_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_24_io ( PIN p_ddr_dq_24_io ) ( BUMP_13_7 PAD ) ( u_ddr_dq_24_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_25_io ( PIN p_ddr_dq_25_io ) ( BUMP_12_6 PAD ) ( u_ddr_dq_25_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_26_io ( PIN p_ddr_dq_26_io ) ( BUMP_14_6 PAD ) ( u_ddr_dq_26_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_27_io ( PIN p_ddr_dq_27_io ) ( BUMP_13_6 PAD ) ( u_ddr_dq_27_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_28_io ( PIN p_ddr_dq_28_io ) ( BUMP_16_5 PAD ) ( u_ddr_dq_28_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_29_io ( PIN p_ddr_dq_29_io ) ( BUMP_15_5 PAD ) ( u_ddr_dq_29_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_2_io ( PIN p_ddr_dq_2_io ) ( BUMP_1_8 PAD ) ( u_ddr_dq_2_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_30_io ( PIN p_ddr_dq_30_io ) ( BUMP_13_5 PAD ) ( u_ddr_dq_30_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_31_io ( PIN p_ddr_dq_31_io ) ( BUMP_12_4 PAD ) ( u_ddr_dq_31_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_3_io ( PIN p_ddr_dq_3_io ) ( BUMP_3_8 PAD ) ( u_ddr_dq_3_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_4_io ( PIN p_ddr_dq_4_io ) ( BUMP_4_9 PAD ) ( u_ddr_dq_4_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_5_io ( PIN p_ddr_dq_5_io ) ( BUMP_2_9 PAD ) ( u_ddr_dq_5_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_6_io ( PIN p_ddr_dq_6_io ) ( BUMP_3_9 PAD ) ( u_ddr_dq_6_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_7_io ( PIN p_ddr_dq_7_io ) ( BUMP_4_10 PAD ) ( u_ddr_dq_7_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_8_io ( PIN p_ddr_dq_8_io ) ( BUMP_0_4 PAD ) ( u_ddr_dq_8_io PAD ) + USE SIGNAL ;
+    - p_ddr_dq_9_io ( PIN p_ddr_dq_9_io ) ( BUMP_1_4 PAD ) ( u_ddr_dq_9_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_0_io ( PIN p_ddr_dqs_n_0_io ) ( BUMP_4_7 PAD ) ( u_ddr_dqs_n_0_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_1_io ( PIN p_ddr_dqs_n_1_io ) ( BUMP_1_1 PAD ) ( u_ddr_dqs_n_1_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_2_io ( PIN p_ddr_dqs_n_2_io ) ( BUMP_13_0 PAD ) ( u_ddr_dqs_n_2_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_3_io ( PIN p_ddr_dqs_n_3_io ) ( BUMP_14_7 PAD ) ( u_ddr_dqs_n_3_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_0_io ( PIN p_ddr_dqs_p_0_io ) ( BUMP_0_6 PAD ) ( u_ddr_dqs_p_0_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_1_io ( PIN p_ddr_dqs_p_1_io ) ( BUMP_2_0 PAD ) ( u_ddr_dqs_p_1_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_2_io ( PIN p_ddr_dqs_p_2_io ) ( BUMP_13_2 PAD ) ( u_ddr_dqs_p_2_io PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_3_io ( PIN p_ddr_dqs_p_3_io ) ( BUMP_12_7 PAD ) ( u_ddr_dqs_p_3_io PAD ) + USE SIGNAL ;
+    - p_ddr_odt_o ( PIN p_ddr_odt_o ) ( BUMP_10_3 PAD ) ( u_ddr_odt_o PAD ) + USE SIGNAL ;
+    - p_ddr_ras_n_o ( PIN p_ddr_ras_n_o ) ( BUMP_11_1 PAD ) ( u_ddr_ras_n_o PAD ) + USE SIGNAL ;
+    - p_ddr_reset_n_o ( PIN p_ddr_reset_n_o ) ( BUMP_10_1 PAD ) ( u_ddr_reset_n_o PAD ) + USE SIGNAL ;
+    - p_ddr_we_n_o ( PIN p_ddr_we_n_o ) ( BUMP_10_0 PAD ) ( u_ddr_we_n_o PAD ) + USE SIGNAL ;
+    - p_misc_o ( PIN p_misc_o ) ( BUMP_9_15 PAD ) ( u_misc_o PAD ) + USE SIGNAL ;
+    - p_sel_0_i ( PIN p_sel_0_i ) ( BUMP_9_13 PAD ) ( u_sel_0_i PAD ) + USE SIGNAL ;
+    - p_sel_1_i ( PIN p_sel_1_i ) ( BUMP_10_12 PAD ) ( u_sel_1_i PAD ) + USE SIGNAL ;
+    - p_sel_2_i ( PIN p_sel_2_i ) ( BUMP_10_15 PAD ) ( u_sel_2_i PAD ) + USE SIGNAL ;
+END SPECIALNETS
+NETS 215 ;
     - core_bsg_tag_clk_i ( u_bsg_tag_clk_i Y ) + USE SIGNAL ;
     - core_bsg_tag_clk_o ( u_bsg_tag_clk_o A ) + USE SIGNAL ;
     - core_bsg_tag_data_i ( u_bsg_tag_data_i Y ) + USE SIGNAL ;
@@ -3528,140 +3659,5 @@ NETS 354 ;
     - core_sel_0_i ( u_sel_0_i Y ) + USE SIGNAL ;
     - core_sel_1_i ( u_sel_1_i Y ) + USE SIGNAL ;
     - core_sel_2_i ( u_sel_2_i Y ) + USE SIGNAL ;
-    - p_bsg_tag_clk_i ( PIN p_bsg_tag_clk_i ) ( BUMP_15_8 PAD ) ( u_bsg_tag_clk_i PAD ) + USE SIGNAL ;
-    - p_bsg_tag_clk_o ( PIN p_bsg_tag_clk_o ) ( BUMP_3_10 PAD ) ( u_bsg_tag_clk_o PAD ) + USE SIGNAL ;
-    - p_bsg_tag_data_i ( PIN p_bsg_tag_data_i ) ( BUMP_12_8 PAD ) ( u_bsg_tag_data_i PAD ) + USE SIGNAL ;
-    - p_bsg_tag_data_o ( PIN p_bsg_tag_data_o ) ( BUMP_2_10 PAD ) ( u_bsg_tag_data_o PAD ) + USE SIGNAL ;
-    - p_bsg_tag_en_i ( PIN p_bsg_tag_en_i ) ( BUMP_13_9 PAD ) ( u_bsg_tag_en_i PAD ) + USE SIGNAL ;
-    - p_ci2_0_o ( PIN p_ci2_0_o ) ( BUMP_11_16 PAD ) ( u_ci2_0_o PAD ) + USE SIGNAL ;
-    - p_ci2_1_o ( PIN p_ci2_1_o ) ( BUMP_11_15 PAD ) ( u_ci2_1_o PAD ) + USE SIGNAL ;
-    - p_ci2_2_o ( PIN p_ci2_2_o ) ( BUMP_12_14 PAD ) ( u_ci2_2_o PAD ) + USE SIGNAL ;
-    - p_ci2_3_o ( PIN p_ci2_3_o ) ( BUMP_12_16 PAD ) ( u_ci2_3_o PAD ) + USE SIGNAL ;
-    - p_ci2_4_o ( PIN p_ci2_4_o ) ( BUMP_12_15 PAD ) ( u_ci2_4_o PAD ) + USE SIGNAL ;
-    - p_ci2_5_o ( PIN p_ci2_5_o ) ( BUMP_14_15 PAD ) ( u_ci2_5_o PAD ) + USE SIGNAL ;
-    - p_ci2_6_o ( PIN p_ci2_6_o ) ( BUMP_15_16 PAD ) ( u_ci2_6_o PAD ) + USE SIGNAL ;
-    - p_ci2_7_o ( PIN p_ci2_7_o ) ( BUMP_16_15 PAD ) ( u_ci2_7_o PAD ) + USE SIGNAL ;
-    - p_ci2_8_o ( PIN p_ci2_8_o ) ( BUMP_16_14 PAD ) ( u_ci2_8_o PAD ) + USE SIGNAL ;
-    - p_ci2_clk_o ( PIN p_ci2_clk_o ) ( BUMP_12_13 PAD ) ( u_ci2_clk_o PAD ) + USE SIGNAL ;
-    - p_ci2_tkn_i ( PIN p_ci2_tkn_i ) ( BUMP_13_15 PAD ) ( u_ci2_tkn_i PAD ) + USE SIGNAL ;
-    - p_ci2_v_o ( PIN p_ci2_v_o ) ( BUMP_13_13 PAD ) ( u_ci2_v_o PAD ) + USE SIGNAL ;
-    - p_ci_0_i ( PIN p_ci_0_i ) ( BUMP_15_14 PAD ) ( u_ci_0_i PAD ) + USE SIGNAL ;
-    - p_ci_1_i ( PIN p_ci_1_i ) ( BUMP_15_13 PAD ) ( u_ci_1_i PAD ) + USE SIGNAL ;
-    - p_ci_2_i ( PIN p_ci_2_i ) ( BUMP_15_12 PAD ) ( u_ci_2_i PAD ) + USE SIGNAL ;
-    - p_ci_3_i ( PIN p_ci_3_i ) ( BUMP_13_12 PAD ) ( u_ci_3_i PAD ) + USE SIGNAL ;
-    - p_ci_4_i ( PIN p_ci_4_i ) ( BUMP_12_11 PAD ) ( u_ci_4_i PAD ) + USE SIGNAL ;
-    - p_ci_5_i ( PIN p_ci_5_i ) ( BUMP_14_10 PAD ) ( u_ci_5_i PAD ) + USE SIGNAL ;
-    - p_ci_6_i ( PIN p_ci_6_i ) ( BUMP_16_10 PAD ) ( u_ci_6_i PAD ) + USE SIGNAL ;
-    - p_ci_7_i ( PIN p_ci_7_i ) ( BUMP_12_9 PAD ) ( u_ci_7_i PAD ) + USE SIGNAL ;
-    - p_ci_8_i ( PIN p_ci_8_i ) ( BUMP_15_9 PAD ) ( u_ci_8_i PAD ) + USE SIGNAL ;
-    - p_ci_clk_i ( PIN p_ci_clk_i ) ( BUMP_14_11 PAD ) ( u_ci_clk_i PAD ) + USE SIGNAL ;
-    - p_ci_tkn_o ( PIN p_ci_tkn_o ) ( BUMP_13_11 PAD ) ( u_ci_tkn_o PAD ) + USE SIGNAL ;
-    - p_ci_v_i ( PIN p_ci_v_i ) ( BUMP_12_10 PAD ) ( u_ci_v_i PAD ) + USE SIGNAL ;
-    - p_clk_A_i ( PIN p_clk_A_i ) ( BUMP_7_13 PAD ) ( u_clk_A_i PAD ) + USE SIGNAL ;
-    - p_clk_B_i ( PIN p_clk_B_i ) ( BUMP_8_12 PAD ) ( u_clk_B_i PAD ) + USE SIGNAL ;
-    - p_clk_C_i ( PIN p_clk_C_i ) ( BUMP_8_16 PAD ) ( u_clk_C_i PAD ) + USE SIGNAL ;
-    - p_clk_async_reset_i ( PIN p_clk_async_reset_i ) ( BUMP_9_14 PAD ) ( u_clk_async_reset_i PAD ) + USE SIGNAL ;
-    - p_clk_o ( PIN p_clk_o ) ( BUMP_8_13 PAD ) ( u_clk_o PAD ) + USE SIGNAL ;
-    - p_co2_0_o ( PIN p_co2_0_o ) ( BUMP_0_11 PAD ) ( u_co2_0_o PAD ) + USE SIGNAL ;
-    - p_co2_1_o ( PIN p_co2_1_o ) ( BUMP_1_11 PAD ) ( u_co2_1_o PAD ) + USE SIGNAL ;
-    - p_co2_2_o ( PIN p_co2_2_o ) ( BUMP_3_11 PAD ) ( u_co2_2_o PAD ) + USE SIGNAL ;
-    - p_co2_3_o ( PIN p_co2_3_o ) ( BUMP_4_12 PAD ) ( u_co2_3_o PAD ) + USE SIGNAL ;
-    - p_co2_4_o ( PIN p_co2_4_o ) ( BUMP_1_12 PAD ) ( u_co2_4_o PAD ) + USE SIGNAL ;
-    - p_co2_5_o ( PIN p_co2_5_o ) ( BUMP_1_14 PAD ) ( u_co2_5_o PAD ) + USE SIGNAL ;
-    - p_co2_6_o ( PIN p_co2_6_o ) ( BUMP_0_15 PAD ) ( u_co2_6_o PAD ) + USE SIGNAL ;
-    - p_co2_7_o ( PIN p_co2_7_o ) ( BUMP_1_15 PAD ) ( u_co2_7_o PAD ) + USE SIGNAL ;
-    - p_co2_8_o ( PIN p_co2_8_o ) ( BUMP_0_16 PAD ) ( u_co2_8_o PAD ) + USE SIGNAL ;
-    - p_co2_clk_o ( PIN p_co2_clk_o ) ( BUMP_3_12 PAD ) ( u_co2_clk_o PAD ) + USE SIGNAL ;
-    - p_co2_tkn_i ( PIN p_co2_tkn_i ) ( BUMP_2_13 PAD ) ( u_co2_tkn_i PAD ) + USE SIGNAL ;
-    - p_co2_v_o ( PIN p_co2_v_o ) ( BUMP_0_13 PAD ) ( u_co2_v_o PAD ) + USE SIGNAL ;
-    - p_co_0_i ( PIN p_co_0_i ) ( BUMP_2_15 PAD ) ( u_co_0_i PAD ) + USE SIGNAL ;
-    - p_co_1_i ( PIN p_co_1_i ) ( BUMP_3_14 PAD ) ( u_co_1_i PAD ) + USE SIGNAL ;
-    - p_co_2_i ( PIN p_co_2_i ) ( BUMP_3_16 PAD ) ( u_co_2_i PAD ) + USE SIGNAL ;
-    - p_co_3_i ( PIN p_co_3_i ) ( BUMP_4_16 PAD ) ( u_co_3_i PAD ) + USE SIGNAL ;
-    - p_co_4_i ( PIN p_co_4_i ) ( BUMP_5_12 PAD ) ( u_co_4_i PAD ) + USE SIGNAL ;
-    - p_co_5_i ( PIN p_co_5_i ) ( BUMP_6_14 PAD ) ( u_co_5_i PAD ) + USE SIGNAL ;
-    - p_co_6_i ( PIN p_co_6_i ) ( BUMP_6_16 PAD ) ( u_co_6_i PAD ) + USE SIGNAL ;
-    - p_co_7_i ( PIN p_co_7_i ) ( BUMP_6_15 PAD ) ( u_co_7_i PAD ) + USE SIGNAL ;
-    - p_co_8_i ( PIN p_co_8_i ) ( BUMP_6_13 PAD ) ( u_co_8_i PAD ) + USE SIGNAL ;
-    - p_co_clk_i ( PIN p_co_clk_i ) ( BUMP_5_14 PAD ) ( u_co_clk_i PAD ) + USE SIGNAL ;
-    - p_co_tkn_o ( PIN p_co_tkn_o ) ( BUMP_5_16 PAD ) ( u_co_tkn_o PAD ) + USE SIGNAL ;
-    - p_co_v_i ( PIN p_co_v_i ) ( BUMP_5_15 PAD ) ( u_co_v_i PAD ) + USE SIGNAL ;
-    - p_core_async_reset_i ( PIN p_core_async_reset_i ) ( BUMP_11_14 PAD ) ( u_core_async_reset_i PAD ) + USE SIGNAL ;
-    - p_ddr_addr_0_o ( PIN p_ddr_addr_0_o ) ( BUMP_9_0 PAD ) ( u_ddr_addr_0_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_10_o ( PIN p_ddr_addr_10_o ) ( BUMP_5_4 PAD ) ( u_ddr_addr_10_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_11_o ( PIN p_ddr_addr_11_o ) ( BUMP_5_2 PAD ) ( u_ddr_addr_11_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_12_o ( PIN p_ddr_addr_12_o ) ( BUMP_5_3 PAD ) ( u_ddr_addr_12_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_13_o ( PIN p_ddr_addr_13_o ) ( BUMP_4_4 PAD ) ( u_ddr_addr_13_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_14_o ( PIN p_ddr_addr_14_o ) ( BUMP_4_2 PAD ) ( u_ddr_addr_14_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_15_o ( PIN p_ddr_addr_15_o ) ( BUMP_4_0 PAD ) ( u_ddr_addr_15_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_1_o ( PIN p_ddr_addr_1_o ) ( BUMP_8_4 PAD ) ( u_ddr_addr_1_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_2_o ( PIN p_ddr_addr_2_o ) ( BUMP_8_2 PAD ) ( u_ddr_addr_2_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_3_o ( PIN p_ddr_addr_3_o ) ( BUMP_8_0 PAD ) ( u_ddr_addr_3_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_4_o ( PIN p_ddr_addr_4_o ) ( BUMP_7_4 PAD ) ( u_ddr_addr_4_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_5_o ( PIN p_ddr_addr_5_o ) ( BUMP_7_2 PAD ) ( u_ddr_addr_5_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_6_o ( PIN p_ddr_addr_6_o ) ( BUMP_7_0 PAD ) ( u_ddr_addr_6_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_7_o ( PIN p_ddr_addr_7_o ) ( BUMP_7_1 PAD ) ( u_ddr_addr_7_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_8_o ( PIN p_ddr_addr_8_o ) ( BUMP_6_2 PAD ) ( u_ddr_addr_8_o PAD ) + USE SIGNAL ;
-    - p_ddr_addr_9_o ( PIN p_ddr_addr_9_o ) ( BUMP_6_0 PAD ) ( u_ddr_addr_9_o PAD ) + USE SIGNAL ;
-    - p_ddr_ba_0_o ( PIN p_ddr_ba_0_o ) ( BUMP_3_2 PAD ) ( u_ddr_ba_0_o PAD ) + USE SIGNAL ;
-    - p_ddr_ba_1_o ( PIN p_ddr_ba_1_o ) ( BUMP_3_0 PAD ) ( u_ddr_ba_1_o PAD ) + USE SIGNAL ;
-    - p_ddr_ba_2_o ( PIN p_ddr_ba_2_o ) ( BUMP_3_1 PAD ) ( u_ddr_ba_2_o PAD ) + USE SIGNAL ;
-    - p_ddr_cas_n_o ( PIN p_ddr_cas_n_o ) ( BUMP_10_2 PAD ) ( u_ddr_cas_n_o PAD ) + USE SIGNAL ;
-    - p_ddr_ck_n_o ( PIN p_ddr_ck_n_o ) ( BUMP_11_4 PAD ) ( u_ddr_ck_n_o PAD ) + USE SIGNAL ;
-    - p_ddr_ck_p_o ( PIN p_ddr_ck_p_o ) ( BUMP_13_1 PAD ) ( u_ddr_ck_p_o PAD ) + USE SIGNAL ;
-    - p_ddr_cke_o ( PIN p_ddr_cke_o ) ( BUMP_11_2 PAD ) ( u_ddr_cke_o PAD ) + USE SIGNAL ;
-    - p_ddr_cs_n_o ( PIN p_ddr_cs_n_o ) ( BUMP_11_0 PAD ) ( u_ddr_cs_n_o PAD ) + USE SIGNAL ;
-    - p_ddr_dm_0_o ( PIN p_ddr_dm_0_o ) ( BUMP_2_7 PAD ) ( u_ddr_dm_0_o PAD ) + USE SIGNAL ;
-    - p_ddr_dm_1_o ( PIN p_ddr_dm_1_o ) ( BUMP_0_0 PAD ) ( u_ddr_dm_1_o PAD ) + USE SIGNAL ;
-    - p_ddr_dm_2_o ( PIN p_ddr_dm_2_o ) ( BUMP_14_1 PAD ) ( u_ddr_dm_2_o PAD ) + USE SIGNAL ;
-    - p_ddr_dm_3_o ( PIN p_ddr_dm_3_o ) ( BUMP_13_8 PAD ) ( u_ddr_dm_3_o PAD ) + USE SIGNAL ;
-    - p_ddr_dq_0_io ( PIN p_ddr_dq_0_io ) ( BUMP_3_7 PAD ) ( u_ddr_dq_0_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_10_io ( PIN p_ddr_dq_10_io ) ( BUMP_3_4 PAD ) ( u_ddr_dq_10_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_11_io ( PIN p_ddr_dq_11_io ) ( BUMP_4_5 PAD ) ( u_ddr_dq_11_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_12_io ( PIN p_ddr_dq_12_io ) ( BUMP_2_5 PAD ) ( u_ddr_dq_12_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_13_io ( PIN p_ddr_dq_13_io ) ( BUMP_3_5 PAD ) ( u_ddr_dq_13_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_14_io ( PIN p_ddr_dq_14_io ) ( BUMP_4_6 PAD ) ( u_ddr_dq_14_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_15_io ( PIN p_ddr_dq_15_io ) ( BUMP_2_6 PAD ) ( u_ddr_dq_15_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_16_io ( PIN p_ddr_dq_16_io ) ( BUMP_15_4 PAD ) ( u_ddr_dq_16_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_17_io ( PIN p_ddr_dq_17_io ) ( BUMP_13_4 PAD ) ( u_ddr_dq_17_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_18_io ( PIN p_ddr_dq_18_io ) ( BUMP_14_3 PAD ) ( u_ddr_dq_18_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_19_io ( PIN p_ddr_dq_19_io ) ( BUMP_16_3 PAD ) ( u_ddr_dq_19_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_1_io ( PIN p_ddr_dq_1_io ) ( BUMP_4_8 PAD ) ( u_ddr_dq_1_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_20_io ( PIN p_ddr_dq_20_io ) ( BUMP_14_2 PAD ) ( u_ddr_dq_20_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_21_io ( PIN p_ddr_dq_21_io ) ( BUMP_16_1 PAD ) ( u_ddr_dq_21_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_22_io ( PIN p_ddr_dq_22_io ) ( BUMP_15_1 PAD ) ( u_ddr_dq_22_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_23_io ( PIN p_ddr_dq_23_io ) ( BUMP_16_0 PAD ) ( u_ddr_dq_23_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_24_io ( PIN p_ddr_dq_24_io ) ( BUMP_13_7 PAD ) ( u_ddr_dq_24_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_25_io ( PIN p_ddr_dq_25_io ) ( BUMP_12_6 PAD ) ( u_ddr_dq_25_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_26_io ( PIN p_ddr_dq_26_io ) ( BUMP_14_6 PAD ) ( u_ddr_dq_26_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_27_io ( PIN p_ddr_dq_27_io ) ( BUMP_13_6 PAD ) ( u_ddr_dq_27_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_28_io ( PIN p_ddr_dq_28_io ) ( BUMP_16_5 PAD ) ( u_ddr_dq_28_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_29_io ( PIN p_ddr_dq_29_io ) ( BUMP_15_5 PAD ) ( u_ddr_dq_29_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_2_io ( PIN p_ddr_dq_2_io ) ( BUMP_1_8 PAD ) ( u_ddr_dq_2_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_30_io ( PIN p_ddr_dq_30_io ) ( BUMP_13_5 PAD ) ( u_ddr_dq_30_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_31_io ( PIN p_ddr_dq_31_io ) ( BUMP_12_4 PAD ) ( u_ddr_dq_31_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_3_io ( PIN p_ddr_dq_3_io ) ( BUMP_3_8 PAD ) ( u_ddr_dq_3_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_4_io ( PIN p_ddr_dq_4_io ) ( BUMP_4_9 PAD ) ( u_ddr_dq_4_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_5_io ( PIN p_ddr_dq_5_io ) ( BUMP_2_9 PAD ) ( u_ddr_dq_5_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_6_io ( PIN p_ddr_dq_6_io ) ( BUMP_3_9 PAD ) ( u_ddr_dq_6_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_7_io ( PIN p_ddr_dq_7_io ) ( BUMP_4_10 PAD ) ( u_ddr_dq_7_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_8_io ( PIN p_ddr_dq_8_io ) ( BUMP_0_4 PAD ) ( u_ddr_dq_8_io PAD ) + USE SIGNAL ;
-    - p_ddr_dq_9_io ( PIN p_ddr_dq_9_io ) ( BUMP_1_4 PAD ) ( u_ddr_dq_9_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_0_io ( PIN p_ddr_dqs_n_0_io ) ( BUMP_4_7 PAD ) ( u_ddr_dqs_n_0_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_1_io ( PIN p_ddr_dqs_n_1_io ) ( BUMP_1_1 PAD ) ( u_ddr_dqs_n_1_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_2_io ( PIN p_ddr_dqs_n_2_io ) ( BUMP_13_0 PAD ) ( u_ddr_dqs_n_2_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_3_io ( PIN p_ddr_dqs_n_3_io ) ( BUMP_14_7 PAD ) ( u_ddr_dqs_n_3_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_0_io ( PIN p_ddr_dqs_p_0_io ) ( BUMP_0_6 PAD ) ( u_ddr_dqs_p_0_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_1_io ( PIN p_ddr_dqs_p_1_io ) ( BUMP_2_0 PAD ) ( u_ddr_dqs_p_1_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_2_io ( PIN p_ddr_dqs_p_2_io ) ( BUMP_13_2 PAD ) ( u_ddr_dqs_p_2_io PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_3_io ( PIN p_ddr_dqs_p_3_io ) ( BUMP_12_7 PAD ) ( u_ddr_dqs_p_3_io PAD ) + USE SIGNAL ;
-    - p_ddr_odt_o ( PIN p_ddr_odt_o ) ( BUMP_10_3 PAD ) ( u_ddr_odt_o PAD ) + USE SIGNAL ;
-    - p_ddr_ras_n_o ( PIN p_ddr_ras_n_o ) ( BUMP_11_1 PAD ) ( u_ddr_ras_n_o PAD ) + USE SIGNAL ;
-    - p_ddr_reset_n_o ( PIN p_ddr_reset_n_o ) ( BUMP_10_1 PAD ) ( u_ddr_reset_n_o PAD ) + USE SIGNAL ;
-    - p_ddr_we_n_o ( PIN p_ddr_we_n_o ) ( BUMP_10_0 PAD ) ( u_ddr_we_n_o PAD ) + USE SIGNAL ;
-    - p_misc_o ( PIN p_misc_o ) ( BUMP_9_15 PAD ) ( u_misc_o PAD ) + USE SIGNAL ;
-    - p_sel_0_i ( PIN p_sel_0_i ) ( BUMP_9_13 PAD ) ( u_sel_0_i PAD ) + USE SIGNAL ;
-    - p_sel_1_i ( PIN p_sel_1_i ) ( BUMP_10_12 PAD ) ( u_sel_1_i PAD ) + USE SIGNAL ;
-    - p_sel_2_i ( PIN p_sel_2_i ) ( BUMP_10_15 PAD ) ( u_sel_2_i PAD ) + USE SIGNAL ;
 END NETS
 END DESIGN

--- a/src/pad/test/place_bondpad_stagger.defok
+++ b/src/pad/test/place_bondpad_stagger.defok
@@ -1441,548 +1441,685 @@ COMPONENTS 1414 ;
     - u_vzz_9_inner PADCELL_VSSIO_H + FIXED ( 5650000 1250000 ) W ;
 END COMPONENTS
 PINS 135 ;
-    - p_bsg_tag_clk_i + NET p_bsg_tag_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_clk_i + NET p_bsg_tag_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 2935000 ) N ;
-    - p_bsg_tag_clk_o + NET p_bsg_tag_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_bsg_tag_clk_o + NET p_bsg_tag_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 3825000 ) N ;
-    - p_bsg_tag_data_i + NET p_bsg_tag_data_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_data_i + NET p_bsg_tag_data_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 3115000 ) N ;
-    - p_bsg_tag_data_o + NET p_bsg_tag_data_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_bsg_tag_data_o + NET p_bsg_tag_data_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 3645000 ) N ;
-    - p_bsg_tag_en_i + NET p_bsg_tag_en_i + DIRECTION INPUT + USE SIGNAL
+    - p_bsg_tag_en_i + NET p_bsg_tag_en_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 3195000 ) N ;
-    - p_ci2_0_o + NET p_ci2_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_0_o + NET p_ci2_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4025000 5870000 ) N ;
-    - p_ci2_1_o + NET p_ci2_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_1_o + NET p_ci2_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4085000 5710000 ) N ;
-    - p_ci2_2_o + NET p_ci2_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_2_o + NET p_ci2_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4245000 5870000 ) N ;
-    - p_ci2_3_o + NET p_ci2_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_3_o + NET p_ci2_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4295000 5710000 ) N ;
-    - p_ci2_4_o + NET p_ci2_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_4_o + NET p_ci2_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4405000 5870000 ) N ;
-    - p_ci2_5_o + NET p_ci2_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_5_o + NET p_ci2_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 5035000 5870000 ) N ;
-    - p_ci2_6_o + NET p_ci2_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_6_o + NET p_ci2_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 5295000 5710000 ) N ;
-    - p_ci2_7_o + NET p_ci2_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_7_o + NET p_ci2_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 5235000 ) N ;
-    - p_ci2_8_o + NET p_ci2_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_8_o + NET p_ci2_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 4925000 ) N ;
-    - p_ci2_clk_o + NET p_ci2_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_clk_o + NET p_ci2_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4465000 5710000 ) N ;
-    - p_ci2_tkn_i + NET p_ci2_tkn_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci2_tkn_i + NET p_ci2_tkn_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4715000 5870000 ) N ;
-    - p_ci2_v_o + NET p_ci2_v_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci2_v_o + NET p_ci2_v_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4775000 5710000 ) N ;
-    - p_ci_0_i + NET p_ci_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_0_i + NET p_ci_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 4855000 ) N ;
-    - p_ci_1_i + NET p_ci_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_1_i + NET p_ci_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 4535000 ) N ;
-    - p_ci_2_i + NET p_ci_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_2_i + NET p_ci_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 4215000 ) N ;
-    - p_ci_3_i + NET p_ci_3_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_3_i + NET p_ci_3_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 4155000 ) N ;
-    - p_ci_4_i + NET p_ci_4_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_4_i + NET p_ci_4_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 4075000 ) N ;
-    - p_ci_5_i + NET p_ci_5_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_5_i + NET p_ci_5_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 3695000 ) N ;
-    - p_ci_6_i + NET p_ci_6_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_6_i + NET p_ci_6_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 3635000 ) N ;
-    - p_ci_7_i + NET p_ci_7_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_7_i + NET p_ci_7_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 3445000 ) N ;
-    - p_ci_8_i + NET p_ci_8_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_8_i + NET p_ci_8_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 3265000 ) N ;
-    - p_ci_clk_i + NET p_ci_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_clk_i + NET p_ci_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 4015000 ) N ;
-    - p_ci_tkn_o + NET p_ci_tkn_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ci_tkn_o + NET p_ci_tkn_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 3835000 ) N ;
-    - p_ci_v_i + NET p_ci_v_i + DIRECTION INPUT + USE SIGNAL
+    - p_ci_v_i + NET p_ci_v_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 3765000 ) N ;
-    - p_clk_A_i + NET p_clk_A_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_A_i + NET p_clk_A_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2855000 5710000 ) N ;
-    - p_clk_B_i + NET p_clk_B_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_B_i + NET p_clk_B_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2935000 5870000 ) N ;
-    - p_clk_C_i + NET p_clk_C_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_C_i + NET p_clk_C_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3065000 5870000 ) N ;
-    - p_clk_async_reset_i + NET p_clk_async_reset_i + DIRECTION INPUT + USE SIGNAL
+    - p_clk_async_reset_i + NET p_clk_async_reset_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3335000 5870000 ) N ;
-    - p_clk_o + NET p_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_clk_o + NET p_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3185000 5870000 ) N ;
-    - p_co2_0_o + NET p_co2_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_0_o + NET p_co2_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 4015000 ) N ;
-    - p_co2_1_o + NET p_co2_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_1_o + NET p_co2_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 4075000 ) N ;
-    - p_co2_2_o + NET p_co2_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_2_o + NET p_co2_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 4145000 ) N ;
-    - p_co2_3_o + NET p_co2_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_3_o + NET p_co2_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 4215000 ) N ;
-    - p_co2_4_o + NET p_co2_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_4_o + NET p_co2_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 4395000 ) N ;
-    - p_co2_5_o + NET p_co2_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_5_o + NET p_co2_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 5035000 ) N ;
-    - p_co2_6_o + NET p_co2_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_6_o + NET p_co2_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 5295000 ) N ;
-    - p_co2_7_o + NET p_co2_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_7_o + NET p_co2_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 5365000 ) N ;
-    - p_co2_8_o + NET p_co2_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_8_o + NET p_co2_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 5615000 ) N ;
-    - p_co2_clk_o + NET p_co2_clk_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_clk_o + NET p_co2_clk_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 4455000 ) N ;
-    - p_co2_tkn_i + NET p_co2_tkn_i + DIRECTION INPUT + USE SIGNAL
+    - p_co2_tkn_i + NET p_co2_tkn_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 4615000 ) N ;
-    - p_co2_v_o + NET p_co2_v_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co2_v_o + NET p_co2_v_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 4675000 ) N ;
-    - p_co_0_i + NET p_co_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_0_i + NET p_co_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1195000 5710000 ) N ;
-    - p_co_1_i + NET p_co_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_1_i + NET p_co_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1395000 5870000 ) N ;
-    - p_co_2_i + NET p_co_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_2_i + NET p_co_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1465000 5710000 ) N ;
-    - p_co_3_i + NET p_co_3_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_3_i + NET p_co_3_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1775000 5870000 ) N ;
-    - p_co_4_i + NET p_co_4_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_4_i + NET p_co_4_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1975000 5710000 ) N ;
-    - p_co_5_i + NET p_co_5_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_5_i + NET p_co_5_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2355000 5710000 ) N ;
-    - p_co_6_i + NET p_co_6_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_6_i + NET p_co_6_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2415000 5870000 ) N ;
-    - p_co_7_i + NET p_co_7_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_7_i + NET p_co_7_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2485000 5710000 ) N ;
-    - p_co_8_i + NET p_co_8_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_8_i + NET p_co_8_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2545000 5870000 ) N ;
-    - p_co_clk_i + NET p_co_clk_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_clk_i + NET p_co_clk_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2035000 5870000 ) N ;
-    - p_co_tkn_o + NET p_co_tkn_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_co_tkn_o + NET p_co_tkn_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2105000 5710000 ) N ;
-    - p_co_v_i + NET p_co_v_i + DIRECTION INPUT + USE SIGNAL
+    - p_co_v_i + NET p_co_v_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2165000 5870000 ) N ;
-    - p_core_async_reset_i + NET p_core_async_reset_i + DIRECTION INPUT + USE SIGNAL
+    - p_core_async_reset_i + NET p_core_async_reset_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3955000 5710000 ) N ;
-    - p_ddr_addr_0_o + NET p_ddr_addr_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_0_o + NET p_ddr_addr_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3315000 130000 ) N ;
-    - p_ddr_addr_10_o + NET p_ddr_addr_10_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_10_o + NET p_ddr_addr_10_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2155000 130000 ) N ;
-    - p_ddr_addr_11_o + NET p_ddr_addr_11_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_11_o + NET p_ddr_addr_11_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2095000 290000 ) N ;
-    - p_ddr_addr_12_o + NET p_ddr_addr_12_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_12_o + NET p_ddr_addr_12_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1915000 130000 ) N ;
-    - p_ddr_addr_13_o + NET p_ddr_addr_13_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_13_o + NET p_ddr_addr_13_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1845000 290000 ) N ;
-    - p_ddr_addr_14_o + NET p_ddr_addr_14_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_14_o + NET p_ddr_addr_14_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1775000 130000 ) N ;
-    - p_ddr_addr_15_o + NET p_ddr_addr_15_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_15_o + NET p_ddr_addr_15_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1715000 290000 ) N ;
-    - p_ddr_addr_1_o + NET p_ddr_addr_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_1_o + NET p_ddr_addr_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3125000 290000 ) N ;
-    - p_ddr_addr_2_o + NET p_ddr_addr_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_2_o + NET p_ddr_addr_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3055000 130000 ) N ;
-    - p_ddr_addr_3_o + NET p_ddr_addr_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_3_o + NET p_ddr_addr_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2995000 290000 ) N ;
-    - p_ddr_addr_4_o + NET p_ddr_addr_4_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_4_o + NET p_ddr_addr_4_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2805000 130000 ) N ;
-    - p_ddr_addr_5_o + NET p_ddr_addr_5_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_5_o + NET p_ddr_addr_5_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2745000 290000 ) N ;
-    - p_ddr_addr_6_o + NET p_ddr_addr_6_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_6_o + NET p_ddr_addr_6_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2675000 130000 ) N ;
-    - p_ddr_addr_7_o + NET p_ddr_addr_7_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_7_o + NET p_ddr_addr_7_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2615000 290000 ) N ;
-    - p_ddr_addr_8_o + NET p_ddr_addr_8_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_8_o + NET p_ddr_addr_8_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2425000 130000 ) N ;
-    - p_ddr_addr_9_o + NET p_ddr_addr_9_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_addr_9_o + NET p_ddr_addr_9_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 2365000 290000 ) N ;
-    - p_ddr_ba_0_o + NET p_ddr_ba_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_0_o + NET p_ddr_ba_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1465000 130000 ) N ;
-    - p_ddr_ba_1_o + NET p_ddr_ba_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_1_o + NET p_ddr_ba_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1405000 290000 ) N ;
-    - p_ddr_ba_2_o + NET p_ddr_ba_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ba_2_o + NET p_ddr_ba_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1335000 130000 ) N ;
-    - p_ddr_cas_n_o + NET p_ddr_cas_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cas_n_o + NET p_ddr_cas_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3705000 130000 ) N ;
-    - p_ddr_ck_n_o + NET p_ddr_ck_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ck_n_o + NET p_ddr_ck_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4085000 130000 ) N ;
-    - p_ddr_ck_p_o + NET p_ddr_ck_p_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ck_p_o + NET p_ddr_ck_p_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4535000 290000 ) N ;
-    - p_ddr_cke_o + NET p_ddr_cke_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cke_o + NET p_ddr_cke_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4025000 290000 ) N ;
-    - p_ddr_cs_n_o + NET p_ddr_cs_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_cs_n_o + NET p_ddr_cs_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3955000 130000 ) N ;
-    - p_ddr_dm_0_o + NET p_ddr_dm_0_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_0_o + NET p_ddr_dm_0_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 2675000 ) N ;
-    - p_ddr_dm_1_o + NET p_ddr_dm_1_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_1_o + NET p_ddr_dm_1_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 435000 290000 ) N ;
-    - p_ddr_dm_2_o + NET p_ddr_dm_2_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_2_o + NET p_ddr_dm_2_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4855000 130000 ) N ;
-    - p_ddr_dm_3_o + NET p_ddr_dm_3_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_dm_3_o + NET p_ddr_dm_3_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 2875000 ) N ;
-    - p_ddr_dq_0_io + NET p_ddr_dq_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_0_io + NET p_ddr_dq_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 2865000 ) N ;
-    - p_ddr_dq_10_io + NET p_ddr_dq_10_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_10_io + NET p_ddr_dq_10_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 1895000 ) N ;
-    - p_ddr_dq_11_io + NET p_ddr_dq_11_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_11_io + NET p_ddr_dq_11_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 1975000 ) N ;
-    - p_ddr_dq_12_io + NET p_ddr_dq_12_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_12_io + NET p_ddr_dq_12_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 2035000 ) N ;
-    - p_ddr_dq_13_io + NET p_ddr_dq_13_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_13_io + NET p_ddr_dq_13_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 2215000 ) N ;
-    - p_ddr_dq_14_io + NET p_ddr_dq_14_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_14_io + NET p_ddr_dq_14_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 2295000 ) N ;
-    - p_ddr_dq_15_io + NET p_ddr_dq_15_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_15_io + NET p_ddr_dq_15_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 2365000 ) N ;
-    - p_ddr_dq_16_io + NET p_ddr_dq_16_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_16_io + NET p_ddr_dq_16_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 1655000 ) N ;
-    - p_ddr_dq_17_io + NET p_ddr_dq_17_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_17_io + NET p_ddr_dq_17_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 1595000 ) N ;
-    - p_ddr_dq_18_io + NET p_ddr_dq_18_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_18_io + NET p_ddr_dq_18_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 1455000 ) N ;
-    - p_ddr_dq_19_io + NET p_ddr_dq_19_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_19_io + NET p_ddr_dq_19_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 1395000 ) N ;
-    - p_ddr_dq_1_io + NET p_ddr_dq_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_1_io + NET p_ddr_dq_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 2935000 ) N ;
-    - p_ddr_dq_20_io + NET p_ddr_dq_20_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_20_io + NET p_ddr_dq_20_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 1135000 ) N ;
-    - p_ddr_dq_21_io + NET p_ddr_dq_21_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_21_io + NET p_ddr_dq_21_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 765000 ) N ;
-    - p_ddr_dq_22_io + NET p_ddr_dq_22_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_22_io + NET p_ddr_dq_22_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 695000 ) N ;
-    - p_ddr_dq_23_io + NET p_ddr_dq_23_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_23_io + NET p_ddr_dq_23_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 435000 ) N ;
-    - p_ddr_dq_24_io + NET p_ddr_dq_24_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_24_io + NET p_ddr_dq_24_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 2555000 ) N ;
-    - p_ddr_dq_25_io + NET p_ddr_dq_25_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_25_io + NET p_ddr_dq_25_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 2485000 ) N ;
-    - p_ddr_dq_26_io + NET p_ddr_dq_26_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_26_io + NET p_ddr_dq_26_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 2415000 ) N ;
-    - p_ddr_dq_27_io + NET p_ddr_dq_27_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_27_io + NET p_ddr_dq_27_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 2235000 ) N ;
-    - p_ddr_dq_28_io + NET p_ddr_dq_28_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_28_io + NET p_ddr_dq_28_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 2045000 ) N ;
-    - p_ddr_dq_29_io + NET p_ddr_dq_29_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_29_io + NET p_ddr_dq_29_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 1985000 ) N ;
-    - p_ddr_dq_2_io + NET p_ddr_dq_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_2_io + NET p_ddr_dq_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 3115000 ) N ;
-    - p_ddr_dq_30_io + NET p_ddr_dq_30_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_30_io + NET p_ddr_dq_30_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 1915000 ) N ;
-    - p_ddr_dq_31_io + NET p_ddr_dq_31_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_31_io + NET p_ddr_dq_31_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 1835000 ) N ;
-    - p_ddr_dq_3_io + NET p_ddr_dq_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_3_io + NET p_ddr_dq_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 3175000 ) N ;
-    - p_ddr_dq_4_io + NET p_ddr_dq_4_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_4_io + NET p_ddr_dq_4_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 3255000 ) N ;
-    - p_ddr_dq_5_io + NET p_ddr_dq_5_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_5_io + NET p_ddr_dq_5_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 3315000 ) N ;
-    - p_ddr_dq_6_io + NET p_ddr_dq_6_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_6_io + NET p_ddr_dq_6_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 3495000 ) N ;
-    - p_ddr_dq_7_io + NET p_ddr_dq_7_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_7_io + NET p_ddr_dq_7_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 3575000 ) N ;
-    - p_ddr_dq_8_io + NET p_ddr_dq_8_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_8_io + NET p_ddr_dq_8_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 1775000 ) N ;
-    - p_ddr_dq_9_io + NET p_ddr_dq_9_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dq_9_io + NET p_ddr_dq_9_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 1835000 ) N ;
-    - p_ddr_dqs_n_0_io + NET p_ddr_dqs_n_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_0_io + NET p_ddr_dqs_n_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 130000 2615000 ) N ;
-    - p_ddr_dqs_n_1_io + NET p_ddr_dqs_n_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_1_io + NET p_ddr_dqs_n_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 695000 130000 ) N ;
-    - p_ddr_dqs_n_2_io + NET p_ddr_dqs_n_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_2_io + NET p_ddr_dqs_n_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4595000 130000 ) N ;
-    - p_ddr_dqs_n_3_io + NET p_ddr_dqs_n_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_n_3_io + NET p_ddr_dqs_n_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5710000 2735000 ) N ;
-    - p_ddr_dqs_p_0_io + NET p_ddr_dqs_p_0_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_0_io + NET p_ddr_dqs_p_0_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 290000 2425000 ) N ;
-    - p_ddr_dqs_p_1_io + NET p_ddr_dqs_p_1_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_1_io + NET p_ddr_dqs_p_1_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 1075000 290000 ) N ;
-    - p_ddr_dqs_p_2_io + NET p_ddr_dqs_p_2_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_2_io + NET p_ddr_dqs_p_2_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 4665000 290000 ) N ;
-    - p_ddr_dqs_p_3_io + NET p_ddr_dqs_p_3_io + DIRECTION INOUT + USE SIGNAL
+    - p_ddr_dqs_p_3_io + NET p_ddr_dqs_p_3_io + SPECIAL + DIRECTION INOUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -70000 -35000 ) ( 70000 35000 )
         + FIXED ( 5870000 2795000 ) N ;
-    - p_ddr_odt_o + NET p_ddr_odt_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_odt_o + NET p_ddr_odt_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3515000 290000 ) N ;
-    - p_ddr_ras_n_o + NET p_ddr_ras_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_ras_n_o + NET p_ddr_ras_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3895000 290000 ) N ;
-    - p_ddr_reset_n_o + NET p_ddr_reset_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_reset_n_o + NET p_ddr_reset_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3575000 130000 ) N ;
-    - p_ddr_we_n_o + NET p_ddr_we_n_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_ddr_we_n_o + NET p_ddr_we_n_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3645000 290000 ) N ;
-    - p_misc_o + NET p_misc_o + DIRECTION OUTPUT + USE SIGNAL
+    - p_misc_o + NET p_misc_o + SPECIAL + DIRECTION OUTPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3435000 5870000 ) N ;
-    - p_sel_0_i + NET p_sel_0_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_0_i + NET p_sel_0_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3505000 5870000 ) N ;
-    - p_sel_1_i + NET p_sel_1_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_1_i + NET p_sel_1_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3575000 5710000 ) N ;
-    - p_sel_2_i + NET p_sel_2_i + DIRECTION INPUT + USE SIGNAL
+    - p_sel_2_i + NET p_sel_2_i + SPECIAL + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal10 ( -35000 -70000 ) ( 35000 70000 )
         + FIXED ( 3765000 5870000 ) N ;
 END PINS
-NETS 350 ;
+SPECIALNETS 135 ;
+    - p_bsg_tag_clk_i ( PIN p_bsg_tag_clk_i ) ( IO_BOND_u_bsg_tag_clk_i_outer PAD ) ( u_bsg_tag_clk_i_outer PAD ) + USE SIGNAL ;
+    - p_bsg_tag_clk_o ( PIN p_bsg_tag_clk_o ) ( IO_BOND_u_bsg_tag_clk_o_inner PAD ) ( u_bsg_tag_clk_o_inner PAD ) + USE SIGNAL ;
+    - p_bsg_tag_data_i ( PIN p_bsg_tag_data_i ) ( IO_BOND_u_bsg_tag_data_i_inner PAD ) ( u_bsg_tag_data_i_inner PAD ) + USE SIGNAL ;
+    - p_bsg_tag_data_o ( PIN p_bsg_tag_data_o ) ( IO_BOND_u_bsg_tag_data_o_outer PAD ) ( u_bsg_tag_data_o_outer PAD ) + USE SIGNAL ;
+    - p_bsg_tag_en_i ( PIN p_bsg_tag_en_i ) ( IO_BOND_u_bsg_tag_en_i_outer PAD ) ( u_bsg_tag_en_i_outer PAD ) + USE SIGNAL ;
+    - p_ci2_0_o ( PIN p_ci2_0_o ) ( IO_BOND_u_ci2_0_o_outer PAD ) ( u_ci2_0_o_outer PAD ) + USE SIGNAL ;
+    - p_ci2_1_o ( PIN p_ci2_1_o ) ( IO_BOND_u_ci2_1_o_inner PAD ) ( u_ci2_1_o_inner PAD ) + USE SIGNAL ;
+    - p_ci2_2_o ( PIN p_ci2_2_o ) ( IO_BOND_u_ci2_2_o_outer PAD ) ( u_ci2_2_o_outer PAD ) + USE SIGNAL ;
+    - p_ci2_3_o ( PIN p_ci2_3_o ) ( IO_BOND_u_ci2_3_o_inner PAD ) ( u_ci2_3_o_inner PAD ) + USE SIGNAL ;
+    - p_ci2_4_o ( PIN p_ci2_4_o ) ( IO_BOND_u_ci2_4_o_outer PAD ) ( u_ci2_4_o_outer PAD ) + USE SIGNAL ;
+    - p_ci2_5_o ( PIN p_ci2_5_o ) ( IO_BOND_u_ci2_5_o_outer PAD ) ( u_ci2_5_o_outer PAD ) + USE SIGNAL ;
+    - p_ci2_6_o ( PIN p_ci2_6_o ) ( IO_BOND_u_ci2_6_o_inner PAD ) ( u_ci2_6_o_inner PAD ) + USE SIGNAL ;
+    - p_ci2_7_o ( PIN p_ci2_7_o ) ( IO_BOND_u_ci2_7_o_outer PAD ) ( u_ci2_7_o_outer PAD ) + USE SIGNAL ;
+    - p_ci2_8_o ( PIN p_ci2_8_o ) ( IO_BOND_u_ci2_8_o_inner PAD ) ( u_ci2_8_o_inner PAD ) + USE SIGNAL ;
+    - p_ci2_clk_o ( PIN p_ci2_clk_o ) ( IO_BOND_u_ci2_clk_o_inner PAD ) ( u_ci2_clk_o_inner PAD ) + USE SIGNAL ;
+    - p_ci2_tkn_i ( PIN p_ci2_tkn_i ) ( IO_BOND_u_ci2_tkn_i_outer PAD ) ( u_ci2_tkn_i_outer PAD ) + USE SIGNAL ;
+    - p_ci2_v_o ( PIN p_ci2_v_o ) ( IO_BOND_u_ci2_v_o_inner PAD ) ( u_ci2_v_o_inner PAD ) + USE SIGNAL ;
+    - p_ci_0_i ( PIN p_ci_0_i ) ( IO_BOND_u_ci_0_i_outer PAD ) ( u_ci_0_i_outer PAD ) + USE SIGNAL ;
+    - p_ci_1_i ( PIN p_ci_1_i ) ( IO_BOND_u_ci_1_i_inner PAD ) ( u_ci_1_i_inner PAD ) + USE SIGNAL ;
+    - p_ci_2_i ( PIN p_ci_2_i ) ( IO_BOND_u_ci_2_i_outer PAD ) ( u_ci_2_i_outer PAD ) + USE SIGNAL ;
+    - p_ci_3_i ( PIN p_ci_3_i ) ( IO_BOND_u_ci_3_i_inner PAD ) ( u_ci_3_i_inner PAD ) + USE SIGNAL ;
+    - p_ci_4_i ( PIN p_ci_4_i ) ( IO_BOND_u_ci_4_i_outer PAD ) ( u_ci_4_i_outer PAD ) + USE SIGNAL ;
+    - p_ci_5_i ( PIN p_ci_5_i ) ( IO_BOND_u_ci_5_i_outer PAD ) ( u_ci_5_i_outer PAD ) + USE SIGNAL ;
+    - p_ci_6_i ( PIN p_ci_6_i ) ( IO_BOND_u_ci_6_i_inner PAD ) ( u_ci_6_i_inner PAD ) + USE SIGNAL ;
+    - p_ci_7_i ( PIN p_ci_7_i ) ( IO_BOND_u_ci_7_i_outer PAD ) ( u_ci_7_i_outer PAD ) + USE SIGNAL ;
+    - p_ci_8_i ( PIN p_ci_8_i ) ( IO_BOND_u_ci_8_i_inner PAD ) ( u_ci_8_i_inner PAD ) + USE SIGNAL ;
+    - p_ci_clk_i ( PIN p_ci_clk_i ) ( IO_BOND_u_ci_clk_i_inner PAD ) ( u_ci_clk_i_inner PAD ) + USE SIGNAL ;
+    - p_ci_tkn_o ( PIN p_ci_tkn_o ) ( IO_BOND_u_ci_tkn_o_outer PAD ) ( u_ci_tkn_o_outer PAD ) + USE SIGNAL ;
+    - p_ci_v_i ( PIN p_ci_v_i ) ( IO_BOND_u_ci_v_i_inner PAD ) ( u_ci_v_i_inner PAD ) + USE SIGNAL ;
+    - p_clk_A_i ( PIN p_clk_A_i ) ( IO_BOND_u_clk_A_i_inner PAD ) ( u_clk_A_i_inner PAD ) + USE SIGNAL ;
+    - p_clk_B_i ( PIN p_clk_B_i ) ( IO_BOND_u_clk_B_i_outer PAD ) ( u_clk_B_i_outer PAD ) + USE SIGNAL ;
+    - p_clk_C_i ( PIN p_clk_C_i ) ( IO_BOND_u_clk_C_i_outer PAD ) ( u_clk_C_i_outer PAD ) + USE SIGNAL ;
+    - p_clk_async_reset_i ( PIN p_clk_async_reset_i ) ( IO_BOND_u_clk_async_reset_i_outer PAD ) ( u_clk_async_reset_i_outer PAD ) + USE SIGNAL ;
+    - p_clk_o ( PIN p_clk_o ) ( IO_BOND_u_clk_o_outer PAD ) ( u_clk_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_0_o ( PIN p_co2_0_o ) ( IO_BOND_u_co2_0_o_outer PAD ) ( u_co2_0_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_1_o ( PIN p_co2_1_o ) ( IO_BOND_u_co2_1_o_inner PAD ) ( u_co2_1_o_inner PAD ) + USE SIGNAL ;
+    - p_co2_2_o ( PIN p_co2_2_o ) ( IO_BOND_u_co2_2_o_outer PAD ) ( u_co2_2_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_3_o ( PIN p_co2_3_o ) ( IO_BOND_u_co2_3_o_inner PAD ) ( u_co2_3_o_inner PAD ) + USE SIGNAL ;
+    - p_co2_4_o ( PIN p_co2_4_o ) ( IO_BOND_u_co2_4_o_outer PAD ) ( u_co2_4_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_5_o ( PIN p_co2_5_o ) ( IO_BOND_u_co2_5_o_outer PAD ) ( u_co2_5_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_6_o ( PIN p_co2_6_o ) ( IO_BOND_u_co2_6_o_inner PAD ) ( u_co2_6_o_inner PAD ) + USE SIGNAL ;
+    - p_co2_7_o ( PIN p_co2_7_o ) ( IO_BOND_u_co2_7_o_outer PAD ) ( u_co2_7_o_outer PAD ) + USE SIGNAL ;
+    - p_co2_8_o ( PIN p_co2_8_o ) ( IO_BOND_u_co2_8_o_inner PAD ) ( u_co2_8_o_inner PAD ) + USE SIGNAL ;
+    - p_co2_clk_o ( PIN p_co2_clk_o ) ( IO_BOND_u_co2_clk_o_inner PAD ) ( u_co2_clk_o_inner PAD ) + USE SIGNAL ;
+    - p_co2_tkn_i ( PIN p_co2_tkn_i ) ( IO_BOND_u_co2_tkn_i_outer PAD ) ( u_co2_tkn_i_outer PAD ) + USE SIGNAL ;
+    - p_co2_v_o ( PIN p_co2_v_o ) ( IO_BOND_u_co2_v_o_inner PAD ) ( u_co2_v_o_inner PAD ) + USE SIGNAL ;
+    - p_co_0_i ( PIN p_co_0_i ) ( IO_BOND_u_co_0_i_inner PAD ) ( u_co_0_i_inner PAD ) + USE SIGNAL ;
+    - p_co_1_i ( PIN p_co_1_i ) ( IO_BOND_u_co_1_i_outer PAD ) ( u_co_1_i_outer PAD ) + USE SIGNAL ;
+    - p_co_2_i ( PIN p_co_2_i ) ( IO_BOND_u_co_2_i_inner PAD ) ( u_co_2_i_inner PAD ) + USE SIGNAL ;
+    - p_co_3_i ( PIN p_co_3_i ) ( IO_BOND_u_co_3_i_outer PAD ) ( u_co_3_i_outer PAD ) + USE SIGNAL ;
+    - p_co_4_i ( PIN p_co_4_i ) ( IO_BOND_u_co_4_i_inner PAD ) ( u_co_4_i_inner PAD ) + USE SIGNAL ;
+    - p_co_5_i ( PIN p_co_5_i ) ( IO_BOND_u_co_5_i_inner PAD ) ( u_co_5_i_inner PAD ) + USE SIGNAL ;
+    - p_co_6_i ( PIN p_co_6_i ) ( IO_BOND_u_co_6_i_outer PAD ) ( u_co_6_i_outer PAD ) + USE SIGNAL ;
+    - p_co_7_i ( PIN p_co_7_i ) ( IO_BOND_u_co_7_i_inner PAD ) ( u_co_7_i_inner PAD ) + USE SIGNAL ;
+    - p_co_8_i ( PIN p_co_8_i ) ( IO_BOND_u_co_8_i_outer PAD ) ( u_co_8_i_outer PAD ) + USE SIGNAL ;
+    - p_co_clk_i ( PIN p_co_clk_i ) ( IO_BOND_u_co_clk_i_outer PAD ) ( u_co_clk_i_outer PAD ) + USE SIGNAL ;
+    - p_co_tkn_o ( PIN p_co_tkn_o ) ( IO_BOND_u_co_tkn_o_inner PAD ) ( u_co_tkn_o_inner PAD ) + USE SIGNAL ;
+    - p_co_v_i ( PIN p_co_v_i ) ( IO_BOND_u_co_v_i_outer PAD ) ( u_co_v_i_outer PAD ) + USE SIGNAL ;
+    - p_core_async_reset_i ( PIN p_core_async_reset_i ) ( IO_BOND_u_core_async_reset_i_inner PAD ) ( u_core_async_reset_i_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_0_o ( PIN p_ddr_addr_0_o ) ( IO_BOND_u_ddr_addr_0_o_outer PAD ) ( u_ddr_addr_0_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_10_o ( PIN p_ddr_addr_10_o ) ( IO_BOND_u_ddr_addr_10_o_outer PAD ) ( u_ddr_addr_10_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_11_o ( PIN p_ddr_addr_11_o ) ( IO_BOND_u_ddr_addr_11_o_inner PAD ) ( u_ddr_addr_11_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_12_o ( PIN p_ddr_addr_12_o ) ( IO_BOND_u_ddr_addr_12_o_outer PAD ) ( u_ddr_addr_12_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_13_o ( PIN p_ddr_addr_13_o ) ( IO_BOND_u_ddr_addr_13_o_inner PAD ) ( u_ddr_addr_13_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_14_o ( PIN p_ddr_addr_14_o ) ( IO_BOND_u_ddr_addr_14_o_outer PAD ) ( u_ddr_addr_14_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_15_o ( PIN p_ddr_addr_15_o ) ( IO_BOND_u_ddr_addr_15_o_inner PAD ) ( u_ddr_addr_15_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_1_o ( PIN p_ddr_addr_1_o ) ( IO_BOND_u_ddr_addr_1_o_inner PAD ) ( u_ddr_addr_1_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_2_o ( PIN p_ddr_addr_2_o ) ( IO_BOND_u_ddr_addr_2_o_outer PAD ) ( u_ddr_addr_2_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_3_o ( PIN p_ddr_addr_3_o ) ( IO_BOND_u_ddr_addr_3_o_inner PAD ) ( u_ddr_addr_3_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_4_o ( PIN p_ddr_addr_4_o ) ( IO_BOND_u_ddr_addr_4_o_outer PAD ) ( u_ddr_addr_4_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_5_o ( PIN p_ddr_addr_5_o ) ( IO_BOND_u_ddr_addr_5_o_inner PAD ) ( u_ddr_addr_5_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_6_o ( PIN p_ddr_addr_6_o ) ( IO_BOND_u_ddr_addr_6_o_outer PAD ) ( u_ddr_addr_6_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_7_o ( PIN p_ddr_addr_7_o ) ( IO_BOND_u_ddr_addr_7_o_inner PAD ) ( u_ddr_addr_7_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_addr_8_o ( PIN p_ddr_addr_8_o ) ( IO_BOND_u_ddr_addr_8_o_outer PAD ) ( u_ddr_addr_8_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_addr_9_o ( PIN p_ddr_addr_9_o ) ( IO_BOND_u_ddr_addr_9_o_inner PAD ) ( u_ddr_addr_9_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_ba_0_o ( PIN p_ddr_ba_0_o ) ( IO_BOND_u_ddr_ba_0_o_outer PAD ) ( u_ddr_ba_0_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_ba_1_o ( PIN p_ddr_ba_1_o ) ( IO_BOND_u_ddr_ba_1_o_inner PAD ) ( u_ddr_ba_1_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_ba_2_o ( PIN p_ddr_ba_2_o ) ( IO_BOND_u_ddr_ba_2_o_outer PAD ) ( u_ddr_ba_2_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_cas_n_o ( PIN p_ddr_cas_n_o ) ( IO_BOND_u_ddr_cas_n_o_outer PAD ) ( u_ddr_cas_n_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_ck_n_o ( PIN p_ddr_ck_n_o ) ( IO_BOND_u_ddr_ck_n_o_outer PAD ) ( u_ddr_ck_n_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_ck_p_o ( PIN p_ddr_ck_p_o ) ( IO_BOND_u_ddr_ck_p_o_inner PAD ) ( u_ddr_ck_p_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_cke_o ( PIN p_ddr_cke_o ) ( IO_BOND_u_ddr_cke_o_inner PAD ) ( u_ddr_cke_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_cs_n_o ( PIN p_ddr_cs_n_o ) ( IO_BOND_u_ddr_cs_n_o_outer PAD ) ( u_ddr_cs_n_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dm_0_o ( PIN p_ddr_dm_0_o ) ( IO_BOND_u_ddr_dm_0_o_inner PAD ) ( u_ddr_dm_0_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dm_1_o ( PIN p_ddr_dm_1_o ) ( IO_BOND_u_ddr_dm_1_o_inner PAD ) ( u_ddr_dm_1_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dm_2_o ( PIN p_ddr_dm_2_o ) ( IO_BOND_u_ddr_dm_2_o_outer PAD ) ( u_ddr_dm_2_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dm_3_o ( PIN p_ddr_dm_3_o ) ( IO_BOND_u_ddr_dm_3_o_inner PAD ) ( u_ddr_dm_3_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_0_io ( PIN p_ddr_dq_0_io ) ( IO_BOND_u_ddr_dq_0_io_outer PAD ) ( u_ddr_dq_0_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_10_io ( PIN p_ddr_dq_10_io ) ( IO_BOND_u_ddr_dq_10_io_inner PAD ) ( u_ddr_dq_10_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_11_io ( PIN p_ddr_dq_11_io ) ( IO_BOND_u_ddr_dq_11_io_outer PAD ) ( u_ddr_dq_11_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_12_io ( PIN p_ddr_dq_12_io ) ( IO_BOND_u_ddr_dq_12_io_inner PAD ) ( u_ddr_dq_12_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_13_io ( PIN p_ddr_dq_13_io ) ( IO_BOND_u_ddr_dq_13_io_outer PAD ) ( u_ddr_dq_13_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_14_io ( PIN p_ddr_dq_14_io ) ( IO_BOND_u_ddr_dq_14_io_inner PAD ) ( u_ddr_dq_14_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_15_io ( PIN p_ddr_dq_15_io ) ( IO_BOND_u_ddr_dq_15_io_outer PAD ) ( u_ddr_dq_15_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_16_io ( PIN p_ddr_dq_16_io ) ( IO_BOND_u_ddr_dq_16_io_outer PAD ) ( u_ddr_dq_16_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_17_io ( PIN p_ddr_dq_17_io ) ( IO_BOND_u_ddr_dq_17_io_inner PAD ) ( u_ddr_dq_17_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_18_io ( PIN p_ddr_dq_18_io ) ( IO_BOND_u_ddr_dq_18_io_outer PAD ) ( u_ddr_dq_18_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_19_io ( PIN p_ddr_dq_19_io ) ( IO_BOND_u_ddr_dq_19_io_inner PAD ) ( u_ddr_dq_19_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_1_io ( PIN p_ddr_dq_1_io ) ( IO_BOND_u_ddr_dq_1_io_inner PAD ) ( u_ddr_dq_1_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_20_io ( PIN p_ddr_dq_20_io ) ( IO_BOND_u_ddr_dq_20_io_outer PAD ) ( u_ddr_dq_20_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_21_io ( PIN p_ddr_dq_21_io ) ( IO_BOND_u_ddr_dq_21_io_inner PAD ) ( u_ddr_dq_21_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_22_io ( PIN p_ddr_dq_22_io ) ( IO_BOND_u_ddr_dq_22_io_outer PAD ) ( u_ddr_dq_22_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_23_io ( PIN p_ddr_dq_23_io ) ( IO_BOND_u_ddr_dq_23_io_inner PAD ) ( u_ddr_dq_23_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_24_io ( PIN p_ddr_dq_24_io ) ( IO_BOND_u_ddr_dq_24_io_outer PAD ) ( u_ddr_dq_24_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_25_io ( PIN p_ddr_dq_25_io ) ( IO_BOND_u_ddr_dq_25_io_inner PAD ) ( u_ddr_dq_25_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_26_io ( PIN p_ddr_dq_26_io ) ( IO_BOND_u_ddr_dq_26_io_outer PAD ) ( u_ddr_dq_26_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_27_io ( PIN p_ddr_dq_27_io ) ( IO_BOND_u_ddr_dq_27_io_inner PAD ) ( u_ddr_dq_27_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_28_io ( PIN p_ddr_dq_28_io ) ( IO_BOND_u_ddr_dq_28_io_outer PAD ) ( u_ddr_dq_28_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_29_io ( PIN p_ddr_dq_29_io ) ( IO_BOND_u_ddr_dq_29_io_inner PAD ) ( u_ddr_dq_29_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_2_io ( PIN p_ddr_dq_2_io ) ( IO_BOND_u_ddr_dq_2_io_outer PAD ) ( u_ddr_dq_2_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_30_io ( PIN p_ddr_dq_30_io ) ( IO_BOND_u_ddr_dq_30_io_outer PAD ) ( u_ddr_dq_30_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_31_io ( PIN p_ddr_dq_31_io ) ( IO_BOND_u_ddr_dq_31_io_inner PAD ) ( u_ddr_dq_31_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_3_io ( PIN p_ddr_dq_3_io ) ( IO_BOND_u_ddr_dq_3_io_inner PAD ) ( u_ddr_dq_3_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_4_io ( PIN p_ddr_dq_4_io ) ( IO_BOND_u_ddr_dq_4_io_outer PAD ) ( u_ddr_dq_4_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_5_io ( PIN p_ddr_dq_5_io ) ( IO_BOND_u_ddr_dq_5_io_inner PAD ) ( u_ddr_dq_5_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_6_io ( PIN p_ddr_dq_6_io ) ( IO_BOND_u_ddr_dq_6_io_outer PAD ) ( u_ddr_dq_6_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dq_7_io ( PIN p_ddr_dq_7_io ) ( IO_BOND_u_ddr_dq_7_io_inner PAD ) ( u_ddr_dq_7_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_8_io ( PIN p_ddr_dq_8_io ) ( IO_BOND_u_ddr_dq_8_io_inner PAD ) ( u_ddr_dq_8_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dq_9_io ( PIN p_ddr_dq_9_io ) ( IO_BOND_u_ddr_dq_9_io_outer PAD ) ( u_ddr_dq_9_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_0_io ( PIN p_ddr_dqs_n_0_io ) ( IO_BOND_u_ddr_dqs_n_0_io_outer PAD ) ( u_ddr_dqs_n_0_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_1_io ( PIN p_ddr_dqs_n_1_io ) ( IO_BOND_u_ddr_dqs_n_1_io_outer PAD ) ( u_ddr_dqs_n_1_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_2_io ( PIN p_ddr_dqs_n_2_io ) ( IO_BOND_u_ddr_dqs_n_2_io_outer PAD ) ( u_ddr_dqs_n_2_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_n_3_io ( PIN p_ddr_dqs_n_3_io ) ( IO_BOND_u_ddr_dqs_n_3_io_inner PAD ) ( u_ddr_dqs_n_3_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_0_io ( PIN p_ddr_dqs_p_0_io ) ( IO_BOND_u_ddr_dqs_p_0_io_inner PAD ) ( u_ddr_dqs_p_0_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_1_io ( PIN p_ddr_dqs_p_1_io ) ( IO_BOND_u_ddr_dqs_p_1_io_inner PAD ) ( u_ddr_dqs_p_1_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_2_io ( PIN p_ddr_dqs_p_2_io ) ( IO_BOND_u_ddr_dqs_p_2_io_inner PAD ) ( u_ddr_dqs_p_2_io_inner PAD ) + USE SIGNAL ;
+    - p_ddr_dqs_p_3_io ( PIN p_ddr_dqs_p_3_io ) ( IO_BOND_u_ddr_dqs_p_3_io_outer PAD ) ( u_ddr_dqs_p_3_io_outer PAD ) + USE SIGNAL ;
+    - p_ddr_odt_o ( PIN p_ddr_odt_o ) ( IO_BOND_u_ddr_odt_o_inner PAD ) ( u_ddr_odt_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_ras_n_o ( PIN p_ddr_ras_n_o ) ( IO_BOND_u_ddr_ras_n_o_inner PAD ) ( u_ddr_ras_n_o_inner PAD ) + USE SIGNAL ;
+    - p_ddr_reset_n_o ( PIN p_ddr_reset_n_o ) ( IO_BOND_u_ddr_reset_n_o_outer PAD ) ( u_ddr_reset_n_o_outer PAD ) + USE SIGNAL ;
+    - p_ddr_we_n_o ( PIN p_ddr_we_n_o ) ( IO_BOND_u_ddr_we_n_o_inner PAD ) ( u_ddr_we_n_o_inner PAD ) + USE SIGNAL ;
+    - p_misc_o ( PIN p_misc_o ) ( IO_BOND_u_misc_o_outer PAD ) ( u_misc_o_outer PAD ) + USE SIGNAL ;
+    - p_sel_0_i ( PIN p_sel_0_i ) ( IO_BOND_u_sel_0_i_outer PAD ) ( u_sel_0_i_outer PAD ) + USE SIGNAL ;
+    - p_sel_1_i ( PIN p_sel_1_i ) ( IO_BOND_u_sel_1_i_inner PAD ) ( u_sel_1_i_inner PAD ) + USE SIGNAL ;
+    - p_sel_2_i ( PIN p_sel_2_i ) ( IO_BOND_u_sel_2_i_outer PAD ) ( u_sel_2_i_outer PAD ) + USE SIGNAL ;
+END SPECIALNETS
+NETS 215 ;
     - core_bsg_tag_clk_i ( u_bsg_tag_clk_i_outer Y ) + USE SIGNAL ;
     - core_bsg_tag_clk_o ( u_bsg_tag_clk_o_inner A ) + USE SIGNAL ;
     - core_bsg_tag_data_i ( u_bsg_tag_data_i_inner Y ) + USE SIGNAL ;
@@ -2198,140 +2335,5 @@ NETS 350 ;
     - core_sel_0_i ( u_sel_0_i_outer Y ) + USE SIGNAL ;
     - core_sel_1_i ( u_sel_1_i_inner Y ) + USE SIGNAL ;
     - core_sel_2_i ( u_sel_2_i_outer Y ) + USE SIGNAL ;
-    - p_bsg_tag_clk_i ( PIN p_bsg_tag_clk_i ) ( IO_BOND_u_bsg_tag_clk_i_outer PAD ) ( u_bsg_tag_clk_i_outer PAD ) + USE SIGNAL ;
-    - p_bsg_tag_clk_o ( PIN p_bsg_tag_clk_o ) ( IO_BOND_u_bsg_tag_clk_o_inner PAD ) ( u_bsg_tag_clk_o_inner PAD ) + USE SIGNAL ;
-    - p_bsg_tag_data_i ( PIN p_bsg_tag_data_i ) ( IO_BOND_u_bsg_tag_data_i_inner PAD ) ( u_bsg_tag_data_i_inner PAD ) + USE SIGNAL ;
-    - p_bsg_tag_data_o ( PIN p_bsg_tag_data_o ) ( IO_BOND_u_bsg_tag_data_o_outer PAD ) ( u_bsg_tag_data_o_outer PAD ) + USE SIGNAL ;
-    - p_bsg_tag_en_i ( PIN p_bsg_tag_en_i ) ( IO_BOND_u_bsg_tag_en_i_outer PAD ) ( u_bsg_tag_en_i_outer PAD ) + USE SIGNAL ;
-    - p_ci2_0_o ( PIN p_ci2_0_o ) ( IO_BOND_u_ci2_0_o_outer PAD ) ( u_ci2_0_o_outer PAD ) + USE SIGNAL ;
-    - p_ci2_1_o ( PIN p_ci2_1_o ) ( IO_BOND_u_ci2_1_o_inner PAD ) ( u_ci2_1_o_inner PAD ) + USE SIGNAL ;
-    - p_ci2_2_o ( PIN p_ci2_2_o ) ( IO_BOND_u_ci2_2_o_outer PAD ) ( u_ci2_2_o_outer PAD ) + USE SIGNAL ;
-    - p_ci2_3_o ( PIN p_ci2_3_o ) ( IO_BOND_u_ci2_3_o_inner PAD ) ( u_ci2_3_o_inner PAD ) + USE SIGNAL ;
-    - p_ci2_4_o ( PIN p_ci2_4_o ) ( IO_BOND_u_ci2_4_o_outer PAD ) ( u_ci2_4_o_outer PAD ) + USE SIGNAL ;
-    - p_ci2_5_o ( PIN p_ci2_5_o ) ( IO_BOND_u_ci2_5_o_outer PAD ) ( u_ci2_5_o_outer PAD ) + USE SIGNAL ;
-    - p_ci2_6_o ( PIN p_ci2_6_o ) ( IO_BOND_u_ci2_6_o_inner PAD ) ( u_ci2_6_o_inner PAD ) + USE SIGNAL ;
-    - p_ci2_7_o ( PIN p_ci2_7_o ) ( IO_BOND_u_ci2_7_o_outer PAD ) ( u_ci2_7_o_outer PAD ) + USE SIGNAL ;
-    - p_ci2_8_o ( PIN p_ci2_8_o ) ( IO_BOND_u_ci2_8_o_inner PAD ) ( u_ci2_8_o_inner PAD ) + USE SIGNAL ;
-    - p_ci2_clk_o ( PIN p_ci2_clk_o ) ( IO_BOND_u_ci2_clk_o_inner PAD ) ( u_ci2_clk_o_inner PAD ) + USE SIGNAL ;
-    - p_ci2_tkn_i ( PIN p_ci2_tkn_i ) ( IO_BOND_u_ci2_tkn_i_outer PAD ) ( u_ci2_tkn_i_outer PAD ) + USE SIGNAL ;
-    - p_ci2_v_o ( PIN p_ci2_v_o ) ( IO_BOND_u_ci2_v_o_inner PAD ) ( u_ci2_v_o_inner PAD ) + USE SIGNAL ;
-    - p_ci_0_i ( PIN p_ci_0_i ) ( IO_BOND_u_ci_0_i_outer PAD ) ( u_ci_0_i_outer PAD ) + USE SIGNAL ;
-    - p_ci_1_i ( PIN p_ci_1_i ) ( IO_BOND_u_ci_1_i_inner PAD ) ( u_ci_1_i_inner PAD ) + USE SIGNAL ;
-    - p_ci_2_i ( PIN p_ci_2_i ) ( IO_BOND_u_ci_2_i_outer PAD ) ( u_ci_2_i_outer PAD ) + USE SIGNAL ;
-    - p_ci_3_i ( PIN p_ci_3_i ) ( IO_BOND_u_ci_3_i_inner PAD ) ( u_ci_3_i_inner PAD ) + USE SIGNAL ;
-    - p_ci_4_i ( PIN p_ci_4_i ) ( IO_BOND_u_ci_4_i_outer PAD ) ( u_ci_4_i_outer PAD ) + USE SIGNAL ;
-    - p_ci_5_i ( PIN p_ci_5_i ) ( IO_BOND_u_ci_5_i_outer PAD ) ( u_ci_5_i_outer PAD ) + USE SIGNAL ;
-    - p_ci_6_i ( PIN p_ci_6_i ) ( IO_BOND_u_ci_6_i_inner PAD ) ( u_ci_6_i_inner PAD ) + USE SIGNAL ;
-    - p_ci_7_i ( PIN p_ci_7_i ) ( IO_BOND_u_ci_7_i_outer PAD ) ( u_ci_7_i_outer PAD ) + USE SIGNAL ;
-    - p_ci_8_i ( PIN p_ci_8_i ) ( IO_BOND_u_ci_8_i_inner PAD ) ( u_ci_8_i_inner PAD ) + USE SIGNAL ;
-    - p_ci_clk_i ( PIN p_ci_clk_i ) ( IO_BOND_u_ci_clk_i_inner PAD ) ( u_ci_clk_i_inner PAD ) + USE SIGNAL ;
-    - p_ci_tkn_o ( PIN p_ci_tkn_o ) ( IO_BOND_u_ci_tkn_o_outer PAD ) ( u_ci_tkn_o_outer PAD ) + USE SIGNAL ;
-    - p_ci_v_i ( PIN p_ci_v_i ) ( IO_BOND_u_ci_v_i_inner PAD ) ( u_ci_v_i_inner PAD ) + USE SIGNAL ;
-    - p_clk_A_i ( PIN p_clk_A_i ) ( IO_BOND_u_clk_A_i_inner PAD ) ( u_clk_A_i_inner PAD ) + USE SIGNAL ;
-    - p_clk_B_i ( PIN p_clk_B_i ) ( IO_BOND_u_clk_B_i_outer PAD ) ( u_clk_B_i_outer PAD ) + USE SIGNAL ;
-    - p_clk_C_i ( PIN p_clk_C_i ) ( IO_BOND_u_clk_C_i_outer PAD ) ( u_clk_C_i_outer PAD ) + USE SIGNAL ;
-    - p_clk_async_reset_i ( PIN p_clk_async_reset_i ) ( IO_BOND_u_clk_async_reset_i_outer PAD ) ( u_clk_async_reset_i_outer PAD ) + USE SIGNAL ;
-    - p_clk_o ( PIN p_clk_o ) ( IO_BOND_u_clk_o_outer PAD ) ( u_clk_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_0_o ( PIN p_co2_0_o ) ( IO_BOND_u_co2_0_o_outer PAD ) ( u_co2_0_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_1_o ( PIN p_co2_1_o ) ( IO_BOND_u_co2_1_o_inner PAD ) ( u_co2_1_o_inner PAD ) + USE SIGNAL ;
-    - p_co2_2_o ( PIN p_co2_2_o ) ( IO_BOND_u_co2_2_o_outer PAD ) ( u_co2_2_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_3_o ( PIN p_co2_3_o ) ( IO_BOND_u_co2_3_o_inner PAD ) ( u_co2_3_o_inner PAD ) + USE SIGNAL ;
-    - p_co2_4_o ( PIN p_co2_4_o ) ( IO_BOND_u_co2_4_o_outer PAD ) ( u_co2_4_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_5_o ( PIN p_co2_5_o ) ( IO_BOND_u_co2_5_o_outer PAD ) ( u_co2_5_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_6_o ( PIN p_co2_6_o ) ( IO_BOND_u_co2_6_o_inner PAD ) ( u_co2_6_o_inner PAD ) + USE SIGNAL ;
-    - p_co2_7_o ( PIN p_co2_7_o ) ( IO_BOND_u_co2_7_o_outer PAD ) ( u_co2_7_o_outer PAD ) + USE SIGNAL ;
-    - p_co2_8_o ( PIN p_co2_8_o ) ( IO_BOND_u_co2_8_o_inner PAD ) ( u_co2_8_o_inner PAD ) + USE SIGNAL ;
-    - p_co2_clk_o ( PIN p_co2_clk_o ) ( IO_BOND_u_co2_clk_o_inner PAD ) ( u_co2_clk_o_inner PAD ) + USE SIGNAL ;
-    - p_co2_tkn_i ( PIN p_co2_tkn_i ) ( IO_BOND_u_co2_tkn_i_outer PAD ) ( u_co2_tkn_i_outer PAD ) + USE SIGNAL ;
-    - p_co2_v_o ( PIN p_co2_v_o ) ( IO_BOND_u_co2_v_o_inner PAD ) ( u_co2_v_o_inner PAD ) + USE SIGNAL ;
-    - p_co_0_i ( PIN p_co_0_i ) ( IO_BOND_u_co_0_i_inner PAD ) ( u_co_0_i_inner PAD ) + USE SIGNAL ;
-    - p_co_1_i ( PIN p_co_1_i ) ( IO_BOND_u_co_1_i_outer PAD ) ( u_co_1_i_outer PAD ) + USE SIGNAL ;
-    - p_co_2_i ( PIN p_co_2_i ) ( IO_BOND_u_co_2_i_inner PAD ) ( u_co_2_i_inner PAD ) + USE SIGNAL ;
-    - p_co_3_i ( PIN p_co_3_i ) ( IO_BOND_u_co_3_i_outer PAD ) ( u_co_3_i_outer PAD ) + USE SIGNAL ;
-    - p_co_4_i ( PIN p_co_4_i ) ( IO_BOND_u_co_4_i_inner PAD ) ( u_co_4_i_inner PAD ) + USE SIGNAL ;
-    - p_co_5_i ( PIN p_co_5_i ) ( IO_BOND_u_co_5_i_inner PAD ) ( u_co_5_i_inner PAD ) + USE SIGNAL ;
-    - p_co_6_i ( PIN p_co_6_i ) ( IO_BOND_u_co_6_i_outer PAD ) ( u_co_6_i_outer PAD ) + USE SIGNAL ;
-    - p_co_7_i ( PIN p_co_7_i ) ( IO_BOND_u_co_7_i_inner PAD ) ( u_co_7_i_inner PAD ) + USE SIGNAL ;
-    - p_co_8_i ( PIN p_co_8_i ) ( IO_BOND_u_co_8_i_outer PAD ) ( u_co_8_i_outer PAD ) + USE SIGNAL ;
-    - p_co_clk_i ( PIN p_co_clk_i ) ( IO_BOND_u_co_clk_i_outer PAD ) ( u_co_clk_i_outer PAD ) + USE SIGNAL ;
-    - p_co_tkn_o ( PIN p_co_tkn_o ) ( IO_BOND_u_co_tkn_o_inner PAD ) ( u_co_tkn_o_inner PAD ) + USE SIGNAL ;
-    - p_co_v_i ( PIN p_co_v_i ) ( IO_BOND_u_co_v_i_outer PAD ) ( u_co_v_i_outer PAD ) + USE SIGNAL ;
-    - p_core_async_reset_i ( PIN p_core_async_reset_i ) ( IO_BOND_u_core_async_reset_i_inner PAD ) ( u_core_async_reset_i_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_0_o ( PIN p_ddr_addr_0_o ) ( IO_BOND_u_ddr_addr_0_o_outer PAD ) ( u_ddr_addr_0_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_10_o ( PIN p_ddr_addr_10_o ) ( IO_BOND_u_ddr_addr_10_o_outer PAD ) ( u_ddr_addr_10_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_11_o ( PIN p_ddr_addr_11_o ) ( IO_BOND_u_ddr_addr_11_o_inner PAD ) ( u_ddr_addr_11_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_12_o ( PIN p_ddr_addr_12_o ) ( IO_BOND_u_ddr_addr_12_o_outer PAD ) ( u_ddr_addr_12_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_13_o ( PIN p_ddr_addr_13_o ) ( IO_BOND_u_ddr_addr_13_o_inner PAD ) ( u_ddr_addr_13_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_14_o ( PIN p_ddr_addr_14_o ) ( IO_BOND_u_ddr_addr_14_o_outer PAD ) ( u_ddr_addr_14_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_15_o ( PIN p_ddr_addr_15_o ) ( IO_BOND_u_ddr_addr_15_o_inner PAD ) ( u_ddr_addr_15_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_1_o ( PIN p_ddr_addr_1_o ) ( IO_BOND_u_ddr_addr_1_o_inner PAD ) ( u_ddr_addr_1_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_2_o ( PIN p_ddr_addr_2_o ) ( IO_BOND_u_ddr_addr_2_o_outer PAD ) ( u_ddr_addr_2_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_3_o ( PIN p_ddr_addr_3_o ) ( IO_BOND_u_ddr_addr_3_o_inner PAD ) ( u_ddr_addr_3_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_4_o ( PIN p_ddr_addr_4_o ) ( IO_BOND_u_ddr_addr_4_o_outer PAD ) ( u_ddr_addr_4_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_5_o ( PIN p_ddr_addr_5_o ) ( IO_BOND_u_ddr_addr_5_o_inner PAD ) ( u_ddr_addr_5_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_6_o ( PIN p_ddr_addr_6_o ) ( IO_BOND_u_ddr_addr_6_o_outer PAD ) ( u_ddr_addr_6_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_7_o ( PIN p_ddr_addr_7_o ) ( IO_BOND_u_ddr_addr_7_o_inner PAD ) ( u_ddr_addr_7_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_addr_8_o ( PIN p_ddr_addr_8_o ) ( IO_BOND_u_ddr_addr_8_o_outer PAD ) ( u_ddr_addr_8_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_addr_9_o ( PIN p_ddr_addr_9_o ) ( IO_BOND_u_ddr_addr_9_o_inner PAD ) ( u_ddr_addr_9_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_ba_0_o ( PIN p_ddr_ba_0_o ) ( IO_BOND_u_ddr_ba_0_o_outer PAD ) ( u_ddr_ba_0_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_ba_1_o ( PIN p_ddr_ba_1_o ) ( IO_BOND_u_ddr_ba_1_o_inner PAD ) ( u_ddr_ba_1_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_ba_2_o ( PIN p_ddr_ba_2_o ) ( IO_BOND_u_ddr_ba_2_o_outer PAD ) ( u_ddr_ba_2_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_cas_n_o ( PIN p_ddr_cas_n_o ) ( IO_BOND_u_ddr_cas_n_o_outer PAD ) ( u_ddr_cas_n_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_ck_n_o ( PIN p_ddr_ck_n_o ) ( IO_BOND_u_ddr_ck_n_o_outer PAD ) ( u_ddr_ck_n_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_ck_p_o ( PIN p_ddr_ck_p_o ) ( IO_BOND_u_ddr_ck_p_o_inner PAD ) ( u_ddr_ck_p_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_cke_o ( PIN p_ddr_cke_o ) ( IO_BOND_u_ddr_cke_o_inner PAD ) ( u_ddr_cke_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_cs_n_o ( PIN p_ddr_cs_n_o ) ( IO_BOND_u_ddr_cs_n_o_outer PAD ) ( u_ddr_cs_n_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dm_0_o ( PIN p_ddr_dm_0_o ) ( IO_BOND_u_ddr_dm_0_o_inner PAD ) ( u_ddr_dm_0_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dm_1_o ( PIN p_ddr_dm_1_o ) ( IO_BOND_u_ddr_dm_1_o_inner PAD ) ( u_ddr_dm_1_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dm_2_o ( PIN p_ddr_dm_2_o ) ( IO_BOND_u_ddr_dm_2_o_outer PAD ) ( u_ddr_dm_2_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dm_3_o ( PIN p_ddr_dm_3_o ) ( IO_BOND_u_ddr_dm_3_o_inner PAD ) ( u_ddr_dm_3_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_0_io ( PIN p_ddr_dq_0_io ) ( IO_BOND_u_ddr_dq_0_io_outer PAD ) ( u_ddr_dq_0_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_10_io ( PIN p_ddr_dq_10_io ) ( IO_BOND_u_ddr_dq_10_io_inner PAD ) ( u_ddr_dq_10_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_11_io ( PIN p_ddr_dq_11_io ) ( IO_BOND_u_ddr_dq_11_io_outer PAD ) ( u_ddr_dq_11_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_12_io ( PIN p_ddr_dq_12_io ) ( IO_BOND_u_ddr_dq_12_io_inner PAD ) ( u_ddr_dq_12_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_13_io ( PIN p_ddr_dq_13_io ) ( IO_BOND_u_ddr_dq_13_io_outer PAD ) ( u_ddr_dq_13_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_14_io ( PIN p_ddr_dq_14_io ) ( IO_BOND_u_ddr_dq_14_io_inner PAD ) ( u_ddr_dq_14_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_15_io ( PIN p_ddr_dq_15_io ) ( IO_BOND_u_ddr_dq_15_io_outer PAD ) ( u_ddr_dq_15_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_16_io ( PIN p_ddr_dq_16_io ) ( IO_BOND_u_ddr_dq_16_io_outer PAD ) ( u_ddr_dq_16_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_17_io ( PIN p_ddr_dq_17_io ) ( IO_BOND_u_ddr_dq_17_io_inner PAD ) ( u_ddr_dq_17_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_18_io ( PIN p_ddr_dq_18_io ) ( IO_BOND_u_ddr_dq_18_io_outer PAD ) ( u_ddr_dq_18_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_19_io ( PIN p_ddr_dq_19_io ) ( IO_BOND_u_ddr_dq_19_io_inner PAD ) ( u_ddr_dq_19_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_1_io ( PIN p_ddr_dq_1_io ) ( IO_BOND_u_ddr_dq_1_io_inner PAD ) ( u_ddr_dq_1_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_20_io ( PIN p_ddr_dq_20_io ) ( IO_BOND_u_ddr_dq_20_io_outer PAD ) ( u_ddr_dq_20_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_21_io ( PIN p_ddr_dq_21_io ) ( IO_BOND_u_ddr_dq_21_io_inner PAD ) ( u_ddr_dq_21_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_22_io ( PIN p_ddr_dq_22_io ) ( IO_BOND_u_ddr_dq_22_io_outer PAD ) ( u_ddr_dq_22_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_23_io ( PIN p_ddr_dq_23_io ) ( IO_BOND_u_ddr_dq_23_io_inner PAD ) ( u_ddr_dq_23_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_24_io ( PIN p_ddr_dq_24_io ) ( IO_BOND_u_ddr_dq_24_io_outer PAD ) ( u_ddr_dq_24_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_25_io ( PIN p_ddr_dq_25_io ) ( IO_BOND_u_ddr_dq_25_io_inner PAD ) ( u_ddr_dq_25_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_26_io ( PIN p_ddr_dq_26_io ) ( IO_BOND_u_ddr_dq_26_io_outer PAD ) ( u_ddr_dq_26_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_27_io ( PIN p_ddr_dq_27_io ) ( IO_BOND_u_ddr_dq_27_io_inner PAD ) ( u_ddr_dq_27_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_28_io ( PIN p_ddr_dq_28_io ) ( IO_BOND_u_ddr_dq_28_io_outer PAD ) ( u_ddr_dq_28_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_29_io ( PIN p_ddr_dq_29_io ) ( IO_BOND_u_ddr_dq_29_io_inner PAD ) ( u_ddr_dq_29_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_2_io ( PIN p_ddr_dq_2_io ) ( IO_BOND_u_ddr_dq_2_io_outer PAD ) ( u_ddr_dq_2_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_30_io ( PIN p_ddr_dq_30_io ) ( IO_BOND_u_ddr_dq_30_io_outer PAD ) ( u_ddr_dq_30_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_31_io ( PIN p_ddr_dq_31_io ) ( IO_BOND_u_ddr_dq_31_io_inner PAD ) ( u_ddr_dq_31_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_3_io ( PIN p_ddr_dq_3_io ) ( IO_BOND_u_ddr_dq_3_io_inner PAD ) ( u_ddr_dq_3_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_4_io ( PIN p_ddr_dq_4_io ) ( IO_BOND_u_ddr_dq_4_io_outer PAD ) ( u_ddr_dq_4_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_5_io ( PIN p_ddr_dq_5_io ) ( IO_BOND_u_ddr_dq_5_io_inner PAD ) ( u_ddr_dq_5_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_6_io ( PIN p_ddr_dq_6_io ) ( IO_BOND_u_ddr_dq_6_io_outer PAD ) ( u_ddr_dq_6_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dq_7_io ( PIN p_ddr_dq_7_io ) ( IO_BOND_u_ddr_dq_7_io_inner PAD ) ( u_ddr_dq_7_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_8_io ( PIN p_ddr_dq_8_io ) ( IO_BOND_u_ddr_dq_8_io_inner PAD ) ( u_ddr_dq_8_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dq_9_io ( PIN p_ddr_dq_9_io ) ( IO_BOND_u_ddr_dq_9_io_outer PAD ) ( u_ddr_dq_9_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_0_io ( PIN p_ddr_dqs_n_0_io ) ( IO_BOND_u_ddr_dqs_n_0_io_outer PAD ) ( u_ddr_dqs_n_0_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_1_io ( PIN p_ddr_dqs_n_1_io ) ( IO_BOND_u_ddr_dqs_n_1_io_outer PAD ) ( u_ddr_dqs_n_1_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_2_io ( PIN p_ddr_dqs_n_2_io ) ( IO_BOND_u_ddr_dqs_n_2_io_outer PAD ) ( u_ddr_dqs_n_2_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_n_3_io ( PIN p_ddr_dqs_n_3_io ) ( IO_BOND_u_ddr_dqs_n_3_io_inner PAD ) ( u_ddr_dqs_n_3_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_0_io ( PIN p_ddr_dqs_p_0_io ) ( IO_BOND_u_ddr_dqs_p_0_io_inner PAD ) ( u_ddr_dqs_p_0_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_1_io ( PIN p_ddr_dqs_p_1_io ) ( IO_BOND_u_ddr_dqs_p_1_io_inner PAD ) ( u_ddr_dqs_p_1_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_2_io ( PIN p_ddr_dqs_p_2_io ) ( IO_BOND_u_ddr_dqs_p_2_io_inner PAD ) ( u_ddr_dqs_p_2_io_inner PAD ) + USE SIGNAL ;
-    - p_ddr_dqs_p_3_io ( PIN p_ddr_dqs_p_3_io ) ( IO_BOND_u_ddr_dqs_p_3_io_outer PAD ) ( u_ddr_dqs_p_3_io_outer PAD ) + USE SIGNAL ;
-    - p_ddr_odt_o ( PIN p_ddr_odt_o ) ( IO_BOND_u_ddr_odt_o_inner PAD ) ( u_ddr_odt_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_ras_n_o ( PIN p_ddr_ras_n_o ) ( IO_BOND_u_ddr_ras_n_o_inner PAD ) ( u_ddr_ras_n_o_inner PAD ) + USE SIGNAL ;
-    - p_ddr_reset_n_o ( PIN p_ddr_reset_n_o ) ( IO_BOND_u_ddr_reset_n_o_outer PAD ) ( u_ddr_reset_n_o_outer PAD ) + USE SIGNAL ;
-    - p_ddr_we_n_o ( PIN p_ddr_we_n_o ) ( IO_BOND_u_ddr_we_n_o_inner PAD ) ( u_ddr_we_n_o_inner PAD ) + USE SIGNAL ;
-    - p_misc_o ( PIN p_misc_o ) ( IO_BOND_u_misc_o_outer PAD ) ( u_misc_o_outer PAD ) + USE SIGNAL ;
-    - p_sel_0_i ( PIN p_sel_0_i ) ( IO_BOND_u_sel_0_i_outer PAD ) ( u_sel_0_i_outer PAD ) + USE SIGNAL ;
-    - p_sel_1_i ( PIN p_sel_1_i ) ( IO_BOND_u_sel_1_i_inner PAD ) ( u_sel_1_i_inner PAD ) + USE SIGNAL ;
-    - p_sel_2_i ( PIN p_sel_2_i ) ( IO_BOND_u_sel_2_i_outer PAD ) ( u_sel_2_i_outer PAD ) + USE SIGNAL ;
 END NETS
 END DESIGN

--- a/src/pad/test/skywater130_caravel.defok
+++ b/src/pad/test/skywater130_caravel.defok
@@ -3257,20 +3257,20 @@ PINS 722 ;
     - porb_h + NET porb_h + DIRECTION INPUT + USE SIGNAL ;
     - resetb + NET resetb + DIRECTION INPUT + USE SIGNAL ;
     - resetb_core_h + NET resetb_core_h + DIRECTION OUTPUT + USE SIGNAL ;
-    - vccd + NET vccd + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vccd1 + NET vccd1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vccd2 + NET vccd2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda + NET vdda + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda1 + NET vdda1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda2 + NET vdda2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vddio + NET vddio + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa + NET vssa + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa1 + NET vssa1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa2 + NET vssa2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd + NET vssd + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd1 + NET vssd1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd2 + NET vssd2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssio + NET vssio + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
+    - vccd + NET vccd + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vccd1 + NET vccd1 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vccd2 + NET vccd2 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda + NET vdda + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda1 + NET vdda1 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda2 + NET vdda2 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vddio + NET vddio + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vssa + NET vssa + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssa1 + NET vssa1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssa2 + NET vssa2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd + NET vssd + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd1 + NET vssd1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd2 + NET vssd2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssio + NET vssio + SPECIAL + DIRECTION INOUT + USE GROUND ;
 END PINS
 SPECIALNETS 18 ;
     - mprj_pads.analog_a ( connect_0 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_56 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_55 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_50 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_40 AMUXBUS_A ) ( connect_1 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_20 AMUXBUS_A )
@@ -3572,7 +3572,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[7\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[6\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[5\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[4\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[3\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[2\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[1\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[17\] VDDIO_Q )
       ( mprj_pads.area1_io_pad\[16\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[15\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[14\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[13\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[12\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[11\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[10\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[0\] VDDIO_Q )
       ( mgmt_vssio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vssd_lvclmap_pad VDDIO_Q ) ( mgmt_vssa_hvclamp_pad VDDIO_Q ) ( mgmt_vddio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vdda_hvclamp_pad VDDIO_Q ) ( mgmt_vccd_lvclamp_pad VDDIO_Q )
-      ( mgmt_corner\[1\] VDDIO_Q ) ( mgmt_corner\[0\] VDDIO_Q ) ( gpio_pad VDDIO_Q ) ( flash_io1_pad VDDIO_Q ) ( flash_io0_pad VDDIO_Q ) ( flash_csb_pad VDDIO_Q ) ( flash_clk_pad VDDIO_Q ) ( clock_pad VDDIO_Q ) + USE SIGNAL ;
+      ( mgmt_corner\[1\] VDDIO_Q ) ( mgmt_corner\[0\] VDDIO_Q ) ( gpio_pad VDDIO_Q ) ( flash_io1_pad VDDIO_Q ) ( flash_io0_pad VDDIO_Q ) ( flash_csb_pad VDDIO_Q ) ( flash_clk_pad VDDIO_Q ) ( clock_pad VDDIO_Q ) + USE POWER ;
     - mprj_pads.vssio_q ( connect_0 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_56 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_55 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_50 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_40 VSSIO_Q ) ( connect_1 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_20 VSSIO_Q )
       ( IO_FILL_IO_SOUTH_0_0 VSSIO_Q ) ( IO_CORNER_SOUTH_WEST_INST VSSIO_Q ) ( connect_2 VSSIO_Q ) ( IO_FILL_IO_WEST_0_0 VSSIO_Q ) ( IO_FILL_IO_WEST_0_20 VSSIO_Q ) ( connect_3 VSSIO_Q ) ( IO_FILL_IO_WEST_0_40 VSSIO_Q ) ( connect_4 VSSIO_Q )
       ( IO_FILL_IO_EAST_1_80 VSSIO_Q ) ( IO_FILL_IO_EAST_1_60 VSSIO_Q ) ( IO_FILL_IO_EAST_1_40 VSSIO_Q ) ( IO_FILL_IO_EAST_1_20 VSSIO_Q ) ( IO_FILL_IO_EAST_1_0 VSSIO_Q ) ( brk_vccd_0 VSSIO_Q ) ( IO_FILL_IO_WEST_0_60 VSSIO_Q ) ( connect_5 VSSIO_Q )
@@ -3672,7 +3672,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[7\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[6\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[5\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[4\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[3\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[2\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[1\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[17\] VSSIO_Q )
       ( mprj_pads.area1_io_pad\[16\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[15\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[14\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[13\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[12\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[11\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[10\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[0\] VSSIO_Q )
       ( mgmt_vssio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vssd_lvclmap_pad VSSIO_Q ) ( mgmt_vssa_hvclamp_pad VSSIO_Q ) ( mgmt_vddio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vdda_hvclamp_pad VSSIO_Q ) ( mgmt_vccd_lvclamp_pad VSSIO_Q )
-      ( mgmt_corner\[1\] VSSIO_Q ) ( mgmt_corner\[0\] VSSIO_Q ) ( gpio_pad VSSIO_Q ) ( flash_io1_pad VSSIO_Q ) ( flash_io0_pad VSSIO_Q ) ( flash_csb_pad VSSIO_Q ) ( flash_clk_pad VSSIO_Q ) ( clock_pad VSSIO_Q ) + USE SIGNAL ;
+      ( mgmt_corner\[1\] VSSIO_Q ) ( mgmt_corner\[0\] VSSIO_Q ) ( gpio_pad VSSIO_Q ) ( flash_io1_pad VSSIO_Q ) ( flash_io0_pad VSSIO_Q ) ( flash_csb_pad VSSIO_Q ) ( flash_clk_pad VSSIO_Q ) ( clock_pad VSSIO_Q ) + USE GROUND ;
     - vccd ( PIN vccd ) ( connect_0 VCCD ) ( connect_0 VCCHIB ) ( IO_FILL_IO_SOUTH_0_56 VCCD ) ( IO_FILL_IO_SOUTH_0_56 VCCHIB ) ( IO_FILL_IO_SOUTH_0_55 VCCD ) ( IO_FILL_IO_SOUTH_0_55 VCCHIB )
       ( IO_FILL_IO_SOUTH_0_50 VCCD ) ( IO_FILL_IO_SOUTH_0_50 VCCHIB ) ( IO_FILL_IO_SOUTH_0_40 VCCD ) ( IO_FILL_IO_SOUTH_0_40 VCCHIB ) ( connect_1 VCCD ) ( connect_1 VCCHIB ) ( IO_FILL_IO_SOUTH_0_20 VCCD ) ( IO_FILL_IO_SOUTH_0_20 VCCHIB )
       ( IO_FILL_IO_SOUTH_0_0 VCCD ) ( IO_FILL_IO_SOUTH_0_0 VCCHIB ) ( IO_CORNER_SOUTH_WEST_INST VCCD ) ( IO_CORNER_SOUTH_WEST_INST VCCHIB ) ( connect_2 VCCD ) ( connect_2 VCCHIB ) ( IO_FILL_IO_WEST_0_0 VCCD ) ( IO_FILL_IO_WEST_0_0 VCCHIB )
@@ -3808,7 +3808,7 @@ SPECIALNETS 18 ;
       ( mgmt_vccd_lvclamp_pad DRN_LVC2 ) ( mgmt_vccd_lvclamp_pad DRN_LVC1 ) ( mgmt_corner\[1\] VCCHIB ) ( mgmt_corner\[1\] VCCD ) ( mgmt_corner\[0\] VCCHIB ) ( mgmt_corner\[0\] VCCD ) ( gpio_pad VCCHIB ) ( gpio_pad VCCD )
       ( gpio_pad ENABLE_VDDIO ) ( flash_io1_pad VCCHIB ) ( flash_io1_pad VCCD ) ( flash_io1_pad ENABLE_VDDIO ) ( flash_io0_pad VCCHIB ) ( flash_io0_pad VCCD ) ( flash_io0_pad ENABLE_VDDIO ) ( flash_csb_pad VCCHIB )
       ( flash_csb_pad VCCD ) ( flash_csb_pad ENABLE_VDDIO ) ( flash_csb_pad DM[2] ) ( flash_csb_pad DM[1] ) ( flash_clk_pad VCCHIB ) ( flash_clk_pad VCCD ) ( flash_clk_pad ENABLE_VDDIO ) ( flash_clk_pad DM[2] )
-      ( flash_clk_pad DM[1] ) ( clock_pad VCCHIB ) ( clock_pad VCCD ) ( clock_pad OE_N ) ( clock_pad ENABLE_VDDIO ) ( clock_pad DM[0] ) + USE SIGNAL ;
+      ( flash_clk_pad DM[1] ) ( clock_pad VCCHIB ) ( clock_pad VCCD ) ( clock_pad OE_N ) ( clock_pad ENABLE_VDDIO ) ( clock_pad DM[0] ) + USE POWER ;
     - vccd1 ( PIN vccd1 ) ( IO_FILL_IO_NORTH_8_0 VCCD ) ( IO_FILL_IO_NORTH_8_20 VCCD ) ( IO_FILL_IO_EAST_1_0 VCCD ) ( IO_FILL_IO_NORTH_8_40 VCCD ) ( IO_FILL_IO_EAST_1_20 VCCD ) ( IO_FILL_IO_NORTH_8_60 VCCD )
       ( IO_FILL_IO_EAST_1_40 VCCD ) ( IO_FILL_IO_NORTH_8_80 VCCD ) ( IO_FILL_IO_EAST_1_60 VCCD ) ( IO_FILL_IO_NORTH_8_100 VCCD ) ( IO_FILL_IO_EAST_1_80 VCCD ) ( IO_FILL_IO_NORTH_8_120 VCCD ) ( IO_FILL_IO_EAST_1_100 VCCD ) ( IO_FILL_IO_NORTH_8_140 VCCD )
       ( IO_FILL_IO_EAST_1_120 VCCD ) ( IO_FILL_IO_NORTH_8_160 VCCD ) ( IO_FILL_IO_EAST_1_140 VCCD ) ( IO_FILL_IO_NORTH_8_170 VCCD ) ( IO_FILL_IO_EAST_1_160 VCCD ) ( IO_FILL_IO_NORTH_8_175 VCCD ) ( IO_FILL_IO_EAST_21_60 VCCD ) ( IO_FILL_IO_EAST_21_40 VCCD )
@@ -3842,7 +3842,7 @@ SPECIALNETS 18 ;
       ( user1_vssd_lvclmap_pad DRN_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VCCD ) ( user1_vssa_hvclamp_pad\[0\] VCCD ) ( user1_vdda_hvclamp_pad\[1\] VCCD ) ( user1_vdda_hvclamp_pad\[0\] VCCD ) ( user1_vccd_lvclamp_pad VCCD ) ( user1_vccd_lvclamp_pad DRN_LVC2 ) ( user1_vccd_lvclamp_pad DRN_LVC1 )
       ( user1_corner VCCD ) ( mprj_pads.area1_io_pad\[9\] VCCD ) ( mprj_pads.area1_io_pad\[8\] VCCD ) ( mprj_pads.area1_io_pad\[7\] VCCD ) ( mprj_pads.area1_io_pad\[6\] VCCD ) ( mprj_pads.area1_io_pad\[5\] VCCD ) ( mprj_pads.area1_io_pad\[4\] VCCD ) ( mprj_pads.area1_io_pad\[3\] VCCD )
       ( mprj_pads.area1_io_pad\[2\] VCCD ) ( mprj_pads.area1_io_pad\[1\] VCCD ) ( mprj_pads.area1_io_pad\[17\] VCCD ) ( mprj_pads.area1_io_pad\[16\] VCCD ) ( mprj_pads.area1_io_pad\[15\] VCCD ) ( mprj_pads.area1_io_pad\[14\] VCCD ) ( mprj_pads.area1_io_pad\[13\] VCCD ) ( mprj_pads.area1_io_pad\[12\] VCCD )
-      ( mprj_pads.area1_io_pad\[11\] VCCD ) ( mprj_pads.area1_io_pad\[10\] VCCD ) ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[11\] VCCD ) ( mprj_pads.area1_io_pad\[10\] VCCD ) ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE POWER ;
     - vccd2 ( PIN vccd2 ) ( IO_FILL_IO_WEST_3_0 VCCD ) ( IO_FILL_IO_WEST_3_20 VCCD ) ( IO_FILL_IO_WEST_3_40 VCCD ) ( IO_FILL_IO_WEST_3_60 VCCD ) ( IO_FILL_IO_WEST_3_80 VCCD ) ( IO_FILL_IO_WEST_3_100 VCCD )
       ( IO_FILL_IO_WEST_3_120 VCCD ) ( IO_FILL_IO_NORTH_0_140 VCCD ) ( IO_FILL_IO_NORTH_0_120 VCCD ) ( IO_FILL_IO_NORTH_0_100 VCCD ) ( IO_FILL_IO_NORTH_0_80 VCCD ) ( IO_FILL_IO_NORTH_0_60 VCCD ) ( IO_FILL_IO_NORTH_0_40 VCCD ) ( brk_vdda_1 VCCD )
       ( IO_FILL_IO_NORTH_0_20 VCCD ) ( IO_FILL_IO_NORTH_0_0 VCCD ) ( IO_CORNER_NORTH_WEST_INST VCCD ) ( IO_FILL_IO_WEST_22_132 VCCD ) ( IO_FILL_IO_WEST_22_131 VCCD ) ( IO_FILL_IO_WEST_22_130 VCCD ) ( IO_FILL_IO_WEST_22_120 VCCD ) ( IO_FILL_IO_WEST_22_100 VCCD )
@@ -3881,7 +3881,7 @@ SPECIALNETS 18 ;
       ( user2_vssd_lvclmap_pad VCCD ) ( user2_vssd_lvclmap_pad DRN_LVC2 ) ( user2_vssd_lvclmap_pad DRN_LVC1 ) ( user2_vssa_hvclamp_pad VCCD ) ( user2_vdda_hvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad DRN_LVC2 ) ( user2_vccd_lvclamp_pad DRN_LVC1 )
       ( user2_corner VCCD ) ( mprj_pads.area2_io_pad\[9\] VCCD ) ( mprj_pads.area2_io_pad\[8\] VCCD ) ( mprj_pads.area2_io_pad\[7\] VCCD ) ( mprj_pads.area2_io_pad\[6\] VCCD ) ( mprj_pads.area2_io_pad\[5\] VCCD ) ( mprj_pads.area2_io_pad\[4\] VCCD ) ( mprj_pads.area2_io_pad\[3\] VCCD )
       ( mprj_pads.area2_io_pad\[2\] VCCD ) ( mprj_pads.area2_io_pad\[1\] VCCD ) ( mprj_pads.area2_io_pad\[19\] VCCD ) ( mprj_pads.area2_io_pad\[18\] VCCD ) ( mprj_pads.area2_io_pad\[17\] VCCD ) ( mprj_pads.area2_io_pad\[16\] VCCD ) ( mprj_pads.area2_io_pad\[15\] VCCD ) ( mprj_pads.area2_io_pad\[14\] VCCD )
-      ( mprj_pads.area2_io_pad\[13\] VCCD ) ( mprj_pads.area2_io_pad\[12\] VCCD ) ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[13\] VCCD ) ( mprj_pads.area2_io_pad\[12\] VCCD ) ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE POWER ;
     - vdda ( PIN vdda ) ( connect_0 VDDA ) ( IO_FILL_IO_SOUTH_0_56 VDDA ) ( IO_FILL_IO_SOUTH_0_55 VDDA ) ( IO_FILL_IO_SOUTH_0_50 VDDA ) ( IO_FILL_IO_SOUTH_0_40 VDDA ) ( connect_1 VDDA )
       ( IO_FILL_IO_SOUTH_0_20 VDDA ) ( IO_FILL_IO_SOUTH_0_0 VDDA ) ( IO_CORNER_SOUTH_WEST_INST VDDA ) ( connect_2 VDDA ) ( IO_FILL_IO_WEST_0_0 VDDA ) ( IO_FILL_IO_WEST_0_20 VDDA ) ( connect_3 VDDA ) ( IO_FILL_IO_WEST_0_40 VDDA )
       ( connect_4 VDDA ) ( IO_FILL_IO_WEST_0_60 VDDA ) ( connect_5 VDDA ) ( IO_FILL_IO_WEST_0_80 VDDA ) ( IO_FILL_IO_SOUTH_1_0 VDDA ) ( IO_FILL_IO_EAST_0_145 VDDA ) ( IO_FILL_IO_EAST_0_140 VDDA ) ( IO_FILL_IO_EAST_0_120 VDDA )
@@ -3910,7 +3910,7 @@ SPECIALNETS 18 ;
       ( IO_FILL_IO_SOUTH_1_61 VDDA ) ( IO_FILL_IO_SOUTH_22_0 VDDA ) ( IO_FILL_IO_SOUTH_21_61 VDDA ) ( IO_FILL_IO_SOUTH_18_0 VDDA ) ( IO_FILL_IO_SOUTH_17_66 VDDA ) ( IO_FILL_IO_SOUTH_16_0 VDDA ) ( IO_FILL_IO_SOUTH_15_66 VDDA ) ( IO_FILL_IO_SOUTH_14_0 VDDA )
       ( IO_FILL_IO_SOUTH_13_66 VDDA ) ( IO_FILL_IO_SOUTH_10_0 VDDA ) ( IO_FILL_IO_SOUTH_9_66 VDDA ) ( IO_FILL_IO_SOUTH_12_0 VDDA ) ( IO_FILL_IO_SOUTH_11_66 VDDA ) ( IO_FILL_IO_SOUTH_6_0 VDDA ) ( IO_FILL_IO_SOUTH_5_66 VDDA ) ( resetb_pad VDDA )
       ( mgmt_vssio_hvclamp_pad\[0\] VDDA ) ( mgmt_vssd_lvclmap_pad VDDA ) ( mgmt_vssa_hvclamp_pad VDDA ) ( mgmt_vssa_hvclamp_pad DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VDDA ) ( mgmt_vdda_hvclamp_pad VDDA ) ( mgmt_vdda_hvclamp_pad DRN_HVC ) ( mgmt_vccd_lvclamp_pad VDDA )
-      ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA ) ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE SIGNAL ;
+      ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA ) ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE POWER ;
     - vdda1 ( PIN vdda1 ) ( brk_vccd_1 VDDA ) ( IO_FILL_IO_NORTH_8_0 VDDA ) ( brk_vccd_0 VDDA ) ( IO_FILL_IO_NORTH_8_20 VDDA ) ( IO_FILL_IO_EAST_1_0 VDDA ) ( IO_FILL_IO_NORTH_8_40 VDDA )
       ( IO_FILL_IO_EAST_1_20 VDDA ) ( IO_FILL_IO_NORTH_8_60 VDDA ) ( IO_FILL_IO_EAST_1_40 VDDA ) ( IO_FILL_IO_NORTH_8_80 VDDA ) ( IO_FILL_IO_EAST_1_60 VDDA ) ( IO_FILL_IO_NORTH_8_100 VDDA ) ( IO_FILL_IO_EAST_1_80 VDDA ) ( IO_FILL_IO_NORTH_8_120 VDDA )
       ( IO_FILL_IO_EAST_1_100 VDDA ) ( IO_FILL_IO_NORTH_8_140 VDDA ) ( IO_FILL_IO_EAST_1_120 VDDA ) ( IO_FILL_IO_NORTH_8_160 VDDA ) ( IO_FILL_IO_EAST_1_140 VDDA ) ( IO_FILL_IO_NORTH_8_170 VDDA ) ( IO_FILL_IO_EAST_1_160 VDDA ) ( IO_FILL_IO_NORTH_8_175 VDDA )
@@ -3944,7 +3944,7 @@ SPECIALNETS 18 ;
       ( user1_vssd_lvclmap_pad VDDA ) ( user1_vssa_hvclamp_pad\[1\] VDDA ) ( user1_vssa_hvclamp_pad\[1\] DRN_HVC ) ( user1_vssa_hvclamp_pad\[0\] VDDA ) ( user1_vssa_hvclamp_pad\[0\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[1\] VDDA ) ( user1_vdda_hvclamp_pad\[1\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[0\] VDDA )
       ( user1_vdda_hvclamp_pad\[0\] DRN_HVC ) ( user1_vccd_lvclamp_pad VDDA ) ( user1_corner VDDA ) ( mprj_pads.area1_io_pad\[9\] VDDA ) ( mprj_pads.area1_io_pad\[8\] VDDA ) ( mprj_pads.area1_io_pad\[7\] VDDA ) ( mprj_pads.area1_io_pad\[6\] VDDA ) ( mprj_pads.area1_io_pad\[5\] VDDA )
       ( mprj_pads.area1_io_pad\[4\] VDDA ) ( mprj_pads.area1_io_pad\[3\] VDDA ) ( mprj_pads.area1_io_pad\[2\] VDDA ) ( mprj_pads.area1_io_pad\[1\] VDDA ) ( mprj_pads.area1_io_pad\[17\] VDDA ) ( mprj_pads.area1_io_pad\[16\] VDDA ) ( mprj_pads.area1_io_pad\[15\] VDDA ) ( mprj_pads.area1_io_pad\[14\] VDDA )
-      ( mprj_pads.area1_io_pad\[13\] VDDA ) ( mprj_pads.area1_io_pad\[12\] VDDA ) ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[13\] VDDA ) ( mprj_pads.area1_io_pad\[12\] VDDA ) ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE POWER ;
     - vdda2 ( PIN vdda2 ) ( brk_vccd_2 VDDA ) ( IO_FILL_IO_WEST_3_0 VDDA ) ( IO_FILL_IO_WEST_3_20 VDDA ) ( IO_FILL_IO_WEST_3_40 VDDA ) ( IO_FILL_IO_WEST_3_60 VDDA ) ( IO_FILL_IO_WEST_3_80 VDDA )
       ( IO_FILL_IO_WEST_3_100 VDDA ) ( IO_FILL_IO_WEST_3_120 VDDA ) ( IO_FILL_IO_NORTH_0_140 VDDA ) ( IO_FILL_IO_NORTH_0_120 VDDA ) ( IO_FILL_IO_NORTH_0_100 VDDA ) ( IO_FILL_IO_NORTH_0_80 VDDA ) ( IO_FILL_IO_NORTH_0_60 VDDA ) ( IO_FILL_IO_NORTH_0_40 VDDA )
       ( IO_FILL_IO_NORTH_0_20 VDDA ) ( IO_FILL_IO_NORTH_0_0 VDDA ) ( IO_CORNER_NORTH_WEST_INST VDDA ) ( IO_FILL_IO_WEST_22_132 VDDA ) ( IO_FILL_IO_WEST_22_131 VDDA ) ( IO_FILL_IO_WEST_22_130 VDDA ) ( IO_FILL_IO_WEST_22_120 VDDA ) ( IO_FILL_IO_WEST_22_100 VDDA )
@@ -3983,7 +3983,7 @@ SPECIALNETS 18 ;
       ( user2_vssd_lvclmap_pad VDDA ) ( user2_vssa_hvclamp_pad VDDA ) ( user2_vssa_hvclamp_pad DRN_HVC ) ( user2_vdda_hvclamp_pad VDDA ) ( user2_vdda_hvclamp_pad DRN_HVC ) ( user2_vccd_lvclamp_pad VDDA ) ( user2_corner VDDA ) ( mprj_pads.area2_io_pad\[9\] VDDA )
       ( mprj_pads.area2_io_pad\[8\] VDDA ) ( mprj_pads.area2_io_pad\[7\] VDDA ) ( mprj_pads.area2_io_pad\[6\] VDDA ) ( mprj_pads.area2_io_pad\[5\] VDDA ) ( mprj_pads.area2_io_pad\[4\] VDDA ) ( mprj_pads.area2_io_pad\[3\] VDDA ) ( mprj_pads.area2_io_pad\[2\] VDDA ) ( mprj_pads.area2_io_pad\[1\] VDDA )
       ( mprj_pads.area2_io_pad\[19\] VDDA ) ( mprj_pads.area2_io_pad\[18\] VDDA ) ( mprj_pads.area2_io_pad\[17\] VDDA ) ( mprj_pads.area2_io_pad\[16\] VDDA ) ( mprj_pads.area2_io_pad\[15\] VDDA ) ( mprj_pads.area2_io_pad\[14\] VDDA ) ( mprj_pads.area2_io_pad\[13\] VDDA ) ( mprj_pads.area2_io_pad\[12\] VDDA )
-      ( mprj_pads.area2_io_pad\[11\] VDDA ) ( mprj_pads.area2_io_pad\[10\] VDDA ) ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[11\] VDDA ) ( mprj_pads.area2_io_pad\[10\] VDDA ) ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE POWER ;
     - vddio ( PIN vddio ) ( connect_0 VDDIO ) ( connect_0 VSWITCH ) ( IO_FILL_IO_SOUTH_0_56 VDDIO ) ( IO_FILL_IO_SOUTH_0_56 VSWITCH ) ( IO_FILL_IO_SOUTH_0_55 VDDIO ) ( IO_FILL_IO_SOUTH_0_55 VSWITCH )
       ( IO_FILL_IO_SOUTH_0_50 VDDIO ) ( IO_FILL_IO_SOUTH_0_50 VSWITCH ) ( IO_FILL_IO_SOUTH_0_40 VDDIO ) ( IO_FILL_IO_SOUTH_0_40 VSWITCH ) ( connect_1 VDDIO ) ( connect_1 VSWITCH ) ( IO_FILL_IO_SOUTH_0_20 VDDIO ) ( IO_FILL_IO_SOUTH_0_20 VSWITCH )
       ( IO_FILL_IO_SOUTH_0_0 VDDIO ) ( IO_FILL_IO_SOUTH_0_0 VSWITCH ) ( IO_CORNER_SOUTH_WEST_INST VDDIO ) ( IO_CORNER_SOUTH_WEST_INST VSWITCH ) ( connect_2 VDDIO ) ( connect_2 VSWITCH ) ( IO_FILL_IO_WEST_0_0 VDDIO ) ( IO_FILL_IO_WEST_0_0 VSWITCH )
@@ -4185,7 +4185,7 @@ SPECIALNETS 18 ;
       ( mgmt_vdda_hvclamp_pad VSWITCH ) ( mgmt_vdda_hvclamp_pad VDDIO ) ( mgmt_vccd_lvclamp_pad VSWITCH ) ( mgmt_vccd_lvclamp_pad VDDIO ) ( mgmt_corner\[1\] VSWITCH ) ( mgmt_corner\[1\] VDDIO ) ( mgmt_corner\[0\] VSWITCH ) ( mgmt_corner\[0\] VDDIO )
       ( gpio_pad VSWITCH ) ( gpio_pad VDDIO ) ( gpio_pad HLD_H_N ) ( flash_io1_pad VSWITCH ) ( flash_io1_pad VDDIO ) ( flash_io1_pad HLD_H_N ) ( flash_io0_pad VSWITCH ) ( flash_io0_pad VDDIO )
       ( flash_io0_pad HLD_H_N ) ( flash_csb_pad VSWITCH ) ( flash_csb_pad VDDIO ) ( flash_csb_pad HLD_H_N ) ( flash_clk_pad VSWITCH ) ( flash_clk_pad VDDIO ) ( flash_clk_pad HLD_H_N ) ( clock_pad VSWITCH )
-      ( clock_pad VDDIO ) ( clock_pad HLD_H_N ) + USE SIGNAL ;
+      ( clock_pad VDDIO ) ( clock_pad HLD_H_N ) + USE POWER ;
     - vssa ( PIN vssa ) ( connect_0 VSSA ) ( IO_FILL_IO_SOUTH_0_56 VSSA ) ( IO_FILL_IO_SOUTH_0_55 VSSA ) ( IO_FILL_IO_SOUTH_0_50 VSSA ) ( IO_FILL_IO_SOUTH_0_40 VSSA ) ( connect_1 VSSA )
       ( IO_FILL_IO_SOUTH_0_20 VSSA ) ( IO_FILL_IO_SOUTH_0_0 VSSA ) ( IO_CORNER_SOUTH_WEST_INST VSSA ) ( connect_2 VSSA ) ( IO_FILL_IO_WEST_0_0 VSSA ) ( IO_FILL_IO_WEST_0_20 VSSA ) ( connect_3 VSSA ) ( IO_FILL_IO_WEST_0_40 VSSA )
       ( connect_4 VSSA ) ( IO_FILL_IO_WEST_0_60 VSSA ) ( connect_5 VSSA ) ( IO_FILL_IO_WEST_0_80 VSSA ) ( IO_FILL_IO_SOUTH_1_0 VSSA ) ( IO_FILL_IO_EAST_0_145 VSSA ) ( IO_FILL_IO_EAST_0_140 VSSA ) ( IO_FILL_IO_EAST_0_120 VSSA )
@@ -4215,7 +4215,7 @@ SPECIALNETS 18 ;
       ( IO_FILL_IO_SOUTH_13_66 VSSA ) ( IO_FILL_IO_SOUTH_10_0 VSSA ) ( IO_FILL_IO_SOUTH_9_66 VSSA ) ( IO_FILL_IO_SOUTH_12_0 VSSA ) ( IO_FILL_IO_SOUTH_11_66 VSSA ) ( IO_FILL_IO_SOUTH_6_0 VSSA ) ( IO_FILL_IO_SOUTH_5_66 VSSA ) ( resetb_pad VSSA )
       ( mgmt_vssio_hvclamp_pad\[0\] VSSA ) ( mgmt_vssd_lvclmap_pad VSSA ) ( mgmt_vssd_lvclmap_pad BDY2_B2B ) ( mgmt_vssa_hvclamp_pad VSSA ) ( mgmt_vssa_hvclamp_pad SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSA ) ( mgmt_vdda_hvclamp_pad VSSA ) ( mgmt_vdda_hvclamp_pad SRC_BDY_HVC )
       ( mgmt_vccd_lvclamp_pad VSSA ) ( mgmt_vccd_lvclamp_pad BDY2_B2B ) ( mgmt_corner\[1\] VSSA ) ( mgmt_corner\[0\] VSSA ) ( gpio_pad VSSA ) ( gpio_pad ENABLE_VSWITCH_H ) ( flash_io1_pad VSSA ) ( flash_io1_pad ENABLE_VSWITCH_H )
-      ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA ) ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE SIGNAL ;
+      ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA ) ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE GROUND ;
     - vssa1 ( PIN vssa1 ) ( brk_vccd_1 VSSA ) ( IO_FILL_IO_NORTH_8_0 VSSA ) ( brk_vccd_0 VSSA ) ( IO_FILL_IO_NORTH_8_20 VSSA ) ( IO_FILL_IO_EAST_1_0 VSSA ) ( IO_FILL_IO_NORTH_8_40 VSSA )
       ( IO_FILL_IO_EAST_1_20 VSSA ) ( IO_FILL_IO_NORTH_8_60 VSSA ) ( IO_FILL_IO_EAST_1_40 VSSA ) ( IO_FILL_IO_NORTH_8_80 VSSA ) ( IO_FILL_IO_EAST_1_60 VSSA ) ( IO_FILL_IO_NORTH_8_100 VSSA ) ( IO_FILL_IO_EAST_1_80 VSSA ) ( IO_FILL_IO_NORTH_8_120 VSSA )
       ( IO_FILL_IO_EAST_1_100 VSSA ) ( IO_FILL_IO_NORTH_8_140 VSSA ) ( IO_FILL_IO_EAST_1_120 VSSA ) ( IO_FILL_IO_NORTH_8_160 VSSA ) ( IO_FILL_IO_EAST_1_140 VSSA ) ( IO_FILL_IO_NORTH_8_170 VSSA ) ( IO_FILL_IO_EAST_1_160 VSSA ) ( IO_FILL_IO_NORTH_8_175 VSSA )
@@ -4249,7 +4249,7 @@ SPECIALNETS 18 ;
       ( user1_vssd_lvclmap_pad VSSA ) ( user1_vssa_hvclamp_pad\[1\] VSSA ) ( user1_vssa_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vssa_hvclamp_pad\[0\] VSSA ) ( user1_vssa_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[1\] VSSA ) ( user1_vdda_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[0\] VSSA )
       ( user1_vdda_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vccd_lvclamp_pad VSSA ) ( user1_corner VSSA ) ( mprj_pads.area1_io_pad\[9\] VSSA ) ( mprj_pads.area1_io_pad\[8\] VSSA ) ( mprj_pads.area1_io_pad\[7\] VSSA ) ( mprj_pads.area1_io_pad\[6\] VSSA ) ( mprj_pads.area1_io_pad\[5\] VSSA )
       ( mprj_pads.area1_io_pad\[4\] VSSA ) ( mprj_pads.area1_io_pad\[3\] VSSA ) ( mprj_pads.area1_io_pad\[2\] VSSA ) ( mprj_pads.area1_io_pad\[1\] VSSA ) ( mprj_pads.area1_io_pad\[17\] VSSA ) ( mprj_pads.area1_io_pad\[16\] VSSA ) ( mprj_pads.area1_io_pad\[15\] VSSA ) ( mprj_pads.area1_io_pad\[14\] VSSA )
-      ( mprj_pads.area1_io_pad\[13\] VSSA ) ( mprj_pads.area1_io_pad\[12\] VSSA ) ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[13\] VSSA ) ( mprj_pads.area1_io_pad\[12\] VSSA ) ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE GROUND ;
     - vssa2 ( PIN vssa2 ) ( brk_vccd_2 VSSA ) ( IO_FILL_IO_WEST_3_0 VSSA ) ( IO_FILL_IO_WEST_3_20 VSSA ) ( IO_FILL_IO_WEST_3_40 VSSA ) ( IO_FILL_IO_WEST_3_60 VSSA ) ( IO_FILL_IO_WEST_3_80 VSSA )
       ( IO_FILL_IO_WEST_3_100 VSSA ) ( IO_FILL_IO_WEST_3_120 VSSA ) ( IO_FILL_IO_NORTH_0_140 VSSA ) ( IO_FILL_IO_NORTH_0_120 VSSA ) ( IO_FILL_IO_NORTH_0_100 VSSA ) ( IO_FILL_IO_NORTH_0_80 VSSA ) ( IO_FILL_IO_NORTH_0_60 VSSA ) ( IO_FILL_IO_NORTH_0_40 VSSA )
       ( IO_FILL_IO_NORTH_0_20 VSSA ) ( IO_FILL_IO_NORTH_0_0 VSSA ) ( IO_CORNER_NORTH_WEST_INST VSSA ) ( IO_FILL_IO_WEST_22_132 VSSA ) ( IO_FILL_IO_WEST_22_131 VSSA ) ( IO_FILL_IO_WEST_22_130 VSSA ) ( IO_FILL_IO_WEST_22_120 VSSA ) ( IO_FILL_IO_WEST_22_100 VSSA )
@@ -4288,7 +4288,7 @@ SPECIALNETS 18 ;
       ( user2_vssd_lvclmap_pad VSSA ) ( user2_vssa_hvclamp_pad VSSA ) ( user2_vssa_hvclamp_pad SRC_BDY_HVC ) ( user2_vdda_hvclamp_pad VSSA ) ( user2_vdda_hvclamp_pad SRC_BDY_HVC ) ( user2_vccd_lvclamp_pad VSSA ) ( user2_corner VSSA ) ( mprj_pads.area2_io_pad\[9\] VSSA )
       ( mprj_pads.area2_io_pad\[8\] VSSA ) ( mprj_pads.area2_io_pad\[7\] VSSA ) ( mprj_pads.area2_io_pad\[6\] VSSA ) ( mprj_pads.area2_io_pad\[5\] VSSA ) ( mprj_pads.area2_io_pad\[4\] VSSA ) ( mprj_pads.area2_io_pad\[3\] VSSA ) ( mprj_pads.area2_io_pad\[2\] VSSA ) ( mprj_pads.area2_io_pad\[1\] VSSA )
       ( mprj_pads.area2_io_pad\[19\] VSSA ) ( mprj_pads.area2_io_pad\[18\] VSSA ) ( mprj_pads.area2_io_pad\[17\] VSSA ) ( mprj_pads.area2_io_pad\[16\] VSSA ) ( mprj_pads.area2_io_pad\[15\] VSSA ) ( mprj_pads.area2_io_pad\[14\] VSSA ) ( mprj_pads.area2_io_pad\[13\] VSSA ) ( mprj_pads.area2_io_pad\[12\] VSSA )
-      ( mprj_pads.area2_io_pad\[11\] VSSA ) ( mprj_pads.area2_io_pad\[10\] VSSA ) ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[11\] VSSA ) ( mprj_pads.area2_io_pad\[10\] VSSA ) ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE GROUND ;
     - vssd ( PIN vssd ) ( connect_0 VSSD ) ( IO_FILL_IO_SOUTH_0_56 VSSD ) ( IO_FILL_IO_SOUTH_0_55 VSSD ) ( IO_FILL_IO_SOUTH_0_50 VSSD ) ( IO_FILL_IO_SOUTH_0_40 VSSD ) ( connect_1 VSSD )
       ( IO_FILL_IO_SOUTH_0_20 VSSD ) ( IO_FILL_IO_SOUTH_0_0 VSSD ) ( IO_CORNER_SOUTH_WEST_INST VSSD ) ( connect_2 VSSD ) ( IO_FILL_IO_WEST_0_0 VSSD ) ( IO_FILL_IO_WEST_0_20 VSSD ) ( connect_3 VSSD ) ( IO_FILL_IO_WEST_0_40 VSSD )
       ( connect_4 VSSD ) ( IO_FILL_IO_WEST_0_60 VSSD ) ( connect_5 VSSD ) ( brk_vdda_0 VSSD ) ( IO_FILL_IO_WEST_0_80 VSSD ) ( IO_FILL_IO_SOUTH_1_0 VSSD ) ( IO_FILL_IO_EAST_0_145 VSSD ) ( IO_FILL_IO_EAST_0_140 VSSD )
@@ -4324,7 +4324,7 @@ SPECIALNETS 18 ;
       ( flash_csb_pad VTRIP_SEL ) ( flash_csb_pad VSSD ) ( flash_csb_pad SLOW ) ( flash_csb_pad IB_MODE_SEL ) ( flash_csb_pad HLD_OVR ) ( flash_csb_pad DM[0] ) ( flash_csb_pad ANALOG_SEL ) ( flash_csb_pad ANALOG_POL )
       ( flash_csb_pad ANALOG_EN ) ( flash_clk_pad VTRIP_SEL ) ( flash_clk_pad VSSD ) ( flash_clk_pad SLOW ) ( flash_clk_pad IB_MODE_SEL ) ( flash_clk_pad HLD_OVR ) ( flash_clk_pad DM[0] ) ( flash_clk_pad ANALOG_SEL )
       ( flash_clk_pad ANALOG_POL ) ( flash_clk_pad ANALOG_EN ) ( clock_pad VTRIP_SEL ) ( clock_pad VSSD ) ( clock_pad SLOW ) ( clock_pad OUT ) ( clock_pad IB_MODE_SEL ) ( clock_pad HLD_OVR )
-      ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE SIGNAL ;
+      ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE GROUND ;
     - vssd1 ( PIN vssd1 ) ( IO_FILL_IO_NORTH_8_0 VSSD ) ( IO_FILL_IO_NORTH_8_20 VSSD ) ( IO_FILL_IO_EAST_1_0 VSSD ) ( IO_FILL_IO_NORTH_8_40 VSSD ) ( IO_FILL_IO_EAST_1_20 VSSD ) ( IO_FILL_IO_NORTH_8_60 VSSD )
       ( IO_FILL_IO_EAST_1_40 VSSD ) ( IO_FILL_IO_NORTH_8_80 VSSD ) ( IO_FILL_IO_EAST_1_60 VSSD ) ( IO_FILL_IO_NORTH_8_100 VSSD ) ( IO_FILL_IO_EAST_1_80 VSSD ) ( IO_FILL_IO_NORTH_8_120 VSSD ) ( IO_FILL_IO_EAST_1_100 VSSD ) ( IO_FILL_IO_NORTH_8_140 VSSD )
       ( IO_FILL_IO_EAST_1_120 VSSD ) ( IO_FILL_IO_NORTH_8_160 VSSD ) ( IO_FILL_IO_EAST_1_140 VSSD ) ( IO_FILL_IO_NORTH_8_170 VSSD ) ( IO_FILL_IO_EAST_1_160 VSSD ) ( IO_FILL_IO_NORTH_8_175 VSSD ) ( IO_FILL_IO_EAST_21_60 VSSD ) ( IO_FILL_IO_EAST_21_40 VSSD )
@@ -4358,7 +4358,7 @@ SPECIALNETS 18 ;
       ( user1_vssa_hvclamp_pad\[1\] VSSD ) ( user1_vssa_hvclamp_pad\[0\] VSSD ) ( user1_vdda_hvclamp_pad\[1\] VSSD ) ( user1_vdda_hvclamp_pad\[0\] VSSD ) ( user1_vccd_lvclamp_pad VSSD ) ( user1_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user1_corner VSSD ) ( mprj_pads.area1_io_pad\[9\] VSSD )
       ( mprj_pads.area1_io_pad\[8\] VSSD ) ( mprj_pads.area1_io_pad\[7\] VSSD ) ( mprj_pads.area1_io_pad\[6\] VSSD ) ( mprj_pads.area1_io_pad\[5\] VSSD ) ( mprj_pads.area1_io_pad\[4\] VSSD ) ( mprj_pads.area1_io_pad\[3\] VSSD ) ( mprj_pads.area1_io_pad\[2\] VSSD ) ( mprj_pads.area1_io_pad\[1\] VSSD )
       ( mprj_pads.area1_io_pad\[17\] VSSD ) ( mprj_pads.area1_io_pad\[16\] VSSD ) ( mprj_pads.area1_io_pad\[15\] VSSD ) ( mprj_pads.area1_io_pad\[14\] VSSD ) ( mprj_pads.area1_io_pad\[13\] VSSD ) ( mprj_pads.area1_io_pad\[12\] VSSD ) ( mprj_pads.area1_io_pad\[11\] VSSD ) ( mprj_pads.area1_io_pad\[10\] VSSD )
-      ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE GROUND ;
     - vssd2 ( PIN vssd2 ) ( IO_FILL_IO_WEST_3_0 VSSD ) ( IO_FILL_IO_WEST_3_20 VSSD ) ( IO_FILL_IO_WEST_3_40 VSSD ) ( IO_FILL_IO_WEST_3_60 VSSD ) ( IO_FILL_IO_WEST_3_80 VSSD ) ( IO_FILL_IO_WEST_3_100 VSSD )
       ( IO_FILL_IO_WEST_3_120 VSSD ) ( IO_FILL_IO_NORTH_0_140 VSSD ) ( IO_FILL_IO_NORTH_0_120 VSSD ) ( IO_FILL_IO_NORTH_0_100 VSSD ) ( IO_FILL_IO_NORTH_0_80 VSSD ) ( IO_FILL_IO_NORTH_0_60 VSSD ) ( IO_FILL_IO_NORTH_0_40 VSSD ) ( brk_vdda_1 VSSD )
       ( IO_FILL_IO_NORTH_0_20 VSSD ) ( IO_FILL_IO_NORTH_0_0 VSSD ) ( IO_CORNER_NORTH_WEST_INST VSSD ) ( IO_FILL_IO_WEST_22_132 VSSD ) ( IO_FILL_IO_WEST_22_131 VSSD ) ( IO_FILL_IO_WEST_22_130 VSSD ) ( IO_FILL_IO_WEST_22_120 VSSD ) ( IO_FILL_IO_WEST_22_100 VSSD )
@@ -4397,7 +4397,7 @@ SPECIALNETS 18 ;
       ( user2_vssd_lvclmap_pad VSSD ) ( user2_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( user2_vssa_hvclamp_pad VSSD ) ( user2_vdda_hvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user2_corner VSSD ) ( mprj_pads.area2_io_pad\[9\] VSSD )
       ( mprj_pads.area2_io_pad\[8\] VSSD ) ( mprj_pads.area2_io_pad\[7\] VSSD ) ( mprj_pads.area2_io_pad\[6\] VSSD ) ( mprj_pads.area2_io_pad\[5\] VSSD ) ( mprj_pads.area2_io_pad\[4\] VSSD ) ( mprj_pads.area2_io_pad\[3\] VSSD ) ( mprj_pads.area2_io_pad\[2\] VSSD ) ( mprj_pads.area2_io_pad\[1\] VSSD )
       ( mprj_pads.area2_io_pad\[19\] VSSD ) ( mprj_pads.area2_io_pad\[18\] VSSD ) ( mprj_pads.area2_io_pad\[17\] VSSD ) ( mprj_pads.area2_io_pad\[16\] VSSD ) ( mprj_pads.area2_io_pad\[15\] VSSD ) ( mprj_pads.area2_io_pad\[14\] VSSD ) ( mprj_pads.area2_io_pad\[13\] VSSD ) ( mprj_pads.area2_io_pad\[12\] VSSD )
-      ( mprj_pads.area2_io_pad\[11\] VSSD ) ( mprj_pads.area2_io_pad\[10\] VSSD ) ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[11\] VSSD ) ( mprj_pads.area2_io_pad\[10\] VSSD ) ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE GROUND ;
     - vssio ( PIN vssio ) ( connect_0 VSSIO ) ( IO_FILL_IO_SOUTH_0_56 VSSIO ) ( IO_FILL_IO_SOUTH_0_55 VSSIO ) ( IO_FILL_IO_SOUTH_0_50 VSSIO ) ( IO_FILL_IO_SOUTH_0_40 VSSIO ) ( connect_1 VSSIO )
       ( IO_FILL_IO_SOUTH_0_20 VSSIO ) ( IO_FILL_IO_SOUTH_0_0 VSSIO ) ( IO_CORNER_SOUTH_WEST_INST VSSIO ) ( connect_2 VSSIO ) ( IO_FILL_IO_WEST_0_0 VSSIO ) ( IO_FILL_IO_WEST_0_20 VSSIO ) ( connect_3 VSSIO ) ( IO_FILL_IO_WEST_0_40 VSSIO )
       ( connect_4 VSSIO ) ( IO_FILL_IO_EAST_1_80 VSSIO ) ( IO_FILL_IO_EAST_1_60 VSSIO ) ( IO_FILL_IO_EAST_1_40 VSSIO ) ( IO_FILL_IO_EAST_1_20 VSSIO ) ( IO_FILL_IO_EAST_1_0 VSSIO ) ( brk_vccd_0 VSSIO ) ( IO_FILL_IO_WEST_0_60 VSSIO )
@@ -4504,7 +4504,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[12\] VSSIO ) ( mprj_pads.area1_io_pad\[12\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[11\] VSSIO ) ( mprj_pads.area1_io_pad\[11\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[10\] VSSIO ) ( mprj_pads.area1_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[0\] VSSIO ) ( mprj_pads.area1_io_pad\[0\] ENABLE_VSWITCH_H )
       ( mgmt_vssio_hvclamp_pad\[1\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vssd_lvclmap_pad VSSIO ) ( mgmt_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( mgmt_vssa_hvclamp_pad VSSIO ) ( mgmt_vddio_hvclamp_pad\[1\] VSSIO )
       ( mgmt_vddio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vddio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vdda_hvclamp_pad VSSIO ) ( mgmt_vccd_lvclamp_pad VSSIO ) ( mgmt_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( mgmt_corner\[1\] VSSIO ) ( mgmt_corner\[0\] VSSIO )
-      ( gpio_pad VSSIO ) ( flash_io1_pad VSSIO ) ( flash_io0_pad VSSIO ) ( flash_csb_pad VSSIO ) ( flash_clk_pad VSSIO ) ( clock_pad VSSIO ) + USE SIGNAL ;
+      ( gpio_pad VSSIO ) ( flash_io1_pad VSSIO ) ( flash_io0_pad VSSIO ) ( flash_csb_pad VSSIO ) ( flash_clk_pad VSSIO ) ( clock_pad VSSIO ) + USE GROUND ;
 END SPECIALNETS
 NETS 760 ;
     - clock ( PIN clock ) ( clock_pad PAD ) + USE SIGNAL ;

--- a/src/pad/test/skywater130_coyote_tc.defok
+++ b/src/pad/test/skywater130_coyote_tc.defok
@@ -3309,366 +3309,366 @@ SPECIALNETS 242 ;
       ( u_fsb_node_ready.u_io AMUXBUS_B ) ( u_fsb_node_data_o_7_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_6_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_5_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_4_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_3_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_2_.u_io AMUXBUS_B ) ( u_fsb_node_data_o_1_.u_io AMUXBUS_B )
       ( u_fsb_node_data_o_0_.u_io AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[7\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[6\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[5\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[4\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[3\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[2\].u_in AMUXBUS_B ) ( u_fsb_node_data_i.u_io\[1\].u_in AMUXBUS_B )
       ( u_fsb_node_data_i.u_io\[0\].u_in AMUXBUS_B ) ( u_clk.u_in AMUXBUS_B ) + USE SIGNAL ;
-    - u_clk.u_in.VCCD_RING ( u_vzz_0 VCCD ) ( u_reset.u_in VCCD ) ( u_clk.u_in VCCD ) + USE SIGNAL ;
-    - u_clk.u_in.VCCHIB_RING ( u_vzz_0 VCCHIB ) ( u_reset.u_in VCCHIB ) ( u_clk.u_in VCCHIB ) + USE SIGNAL ;
-    - u_clk.u_in.VDDA_RING ( u_vzz_0 VDDA ) ( u_reset.u_in VDDA ) ( u_clk.u_in VDDA ) + USE SIGNAL ;
-    - u_clk.u_in.VDDIO_Q_RING ( u_vzz_0 VDDIO_Q ) ( u_reset.u_in VDDIO_Q ) ( u_clk.u_in VDDIO_Q ) + USE SIGNAL ;
-    - u_clk.u_in.VDDIO_RING ( u_vzz_0 VDDIO ) ( u_reset.u_in VDDIO ) ( u_clk.u_in VDDIO ) + USE SIGNAL ;
-    - u_clk.u_in.VSSA_RING ( u_vzz_0 VSSA ) ( u_reset.u_in VSSA ) ( u_clk.u_in VSSA ) + USE SIGNAL ;
-    - u_clk.u_in.VSSD_RING ( u_vzz_0 VSSD ) ( u_reset.u_in VSSD ) ( u_clk.u_in VSSD ) + USE SIGNAL ;
-    - u_clk.u_in.VSSIO_Q_RING ( u_vzz_0 VSSIO_Q ) ( u_reset.u_in VSSIO_Q ) ( u_clk.u_in VSSIO_Q ) + USE SIGNAL ;
-    - u_clk.u_in.VSSIO_RING ( u_vzz_0 VSSIO ) ( u_reset.u_in VSSIO ) ( u_clk.u_in VSSIO ) + USE SIGNAL ;
-    - u_clk.u_in.VSWITCH_RING ( u_vzz_0 VSWITCH ) ( u_reset.u_in VSWITCH ) ( u_clk.u_in VSWITCH ) + USE SIGNAL ;
+    - u_clk.u_in.VCCD_RING ( u_vzz_0 VCCD ) ( u_reset.u_in VCCD ) ( u_clk.u_in VCCD ) + USE POWER ;
+    - u_clk.u_in.VCCHIB_RING ( u_vzz_0 VCCHIB ) ( u_reset.u_in VCCHIB ) ( u_clk.u_in VCCHIB ) + USE POWER ;
+    - u_clk.u_in.VDDA_RING ( u_vzz_0 VDDA ) ( u_reset.u_in VDDA ) ( u_clk.u_in VDDA ) + USE POWER ;
+    - u_clk.u_in.VDDIO_Q_RING ( u_vzz_0 VDDIO_Q ) ( u_reset.u_in VDDIO_Q ) ( u_clk.u_in VDDIO_Q ) + USE POWER ;
+    - u_clk.u_in.VDDIO_RING ( u_vzz_0 VDDIO ) ( u_reset.u_in VDDIO ) ( u_clk.u_in VDDIO ) + USE POWER ;
+    - u_clk.u_in.VSSA_RING ( u_vzz_0 VSSA ) ( u_reset.u_in VSSA ) ( u_clk.u_in VSSA ) + USE GROUND ;
+    - u_clk.u_in.VSSD_RING ( u_vzz_0 VSSD ) ( u_reset.u_in VSSD ) ( u_clk.u_in VSSD ) + USE GROUND ;
+    - u_clk.u_in.VSSIO_Q_RING ( u_vzz_0 VSSIO_Q ) ( u_reset.u_in VSSIO_Q ) ( u_clk.u_in VSSIO_Q ) + USE GROUND ;
+    - u_clk.u_in.VSSIO_RING ( u_vzz_0 VSSIO ) ( u_reset.u_in VSSIO ) ( u_clk.u_in VSSIO ) + USE GROUND ;
+    - u_clk.u_in.VSWITCH_RING ( u_vzz_0 VSWITCH ) ( u_reset.u_in VSWITCH ) ( u_clk.u_in VSWITCH ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VCCD_RING ( u_rocc_mem_resp_data_o_62_.u_io VCCD ) ( u_rocc_mem_resp_data_o_63_.u_io VCCD ) ( u_fsb_node_data_i.u_io\[4\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[3\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[2\].u_in VCCD ) ( u_fsb_node_v_i.u_in VCCD ) ( u_fsb_node_data_i.u_io\[1\].u_in VCCD )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VCCD ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VCCD ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VCCHIB_RING ( u_rocc_mem_resp_data_o_62_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_63_.u_io VCCHIB ) ( u_fsb_node_data_i.u_io\[4\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[3\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[2\].u_in VCCHIB ) ( u_fsb_node_v_i.u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[1\].u_in VCCHIB )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VCCHIB ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VCCHIB ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VDDA_RING ( u_rocc_mem_resp_data_o_62_.u_io VDDA ) ( u_rocc_mem_resp_data_o_63_.u_io VDDA ) ( u_fsb_node_data_i.u_io\[4\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[3\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[2\].u_in VDDA ) ( u_fsb_node_v_i.u_in VDDA ) ( u_fsb_node_data_i.u_io\[1\].u_in VDDA )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VDDA ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VDDA ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_62_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_63_.u_io VDDIO_Q ) ( u_fsb_node_data_i.u_io\[4\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[3\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[2\].u_in VDDIO_Q ) ( u_fsb_node_v_i.u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[1\].u_in VDDIO_Q )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VDDIO_Q ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VDDIO_Q ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VDDIO_RING ( u_rocc_mem_resp_data_o_62_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_63_.u_io VDDIO ) ( u_fsb_node_data_i.u_io\[4\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[3\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[2\].u_in VDDIO ) ( u_fsb_node_v_i.u_in VDDIO ) ( u_fsb_node_data_i.u_io\[1\].u_in VDDIO )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VDDIO ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VDDIO ) + USE POWER ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VSSA_RING ( u_rocc_mem_resp_data_o_62_.u_io VSSA ) ( u_rocc_mem_resp_data_o_63_.u_io VSSA ) ( u_fsb_node_data_i.u_io\[4\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[3\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[2\].u_in VSSA ) ( u_fsb_node_v_i.u_in VSSA ) ( u_fsb_node_data_i.u_io\[1\].u_in VSSA )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VSSA ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VSSA ) + USE GROUND ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VSSD_RING ( u_rocc_mem_resp_data_o_62_.u_io VSSD ) ( u_rocc_mem_resp_data_o_63_.u_io VSSD ) ( u_fsb_node_data_i.u_io\[4\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[3\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[2\].u_in VSSD ) ( u_fsb_node_v_i.u_in VSSD ) ( u_fsb_node_data_i.u_io\[1\].u_in VSSD )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VSSD ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VSSD ) + USE GROUND ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_62_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_63_.u_io VSSIO_Q ) ( u_fsb_node_data_i.u_io\[4\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[3\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[2\].u_in VSSIO_Q ) ( u_fsb_node_v_i.u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[1\].u_in VSSIO_Q )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VSSIO_Q ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VSSIO_Q ) + USE GROUND ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VSSIO_RING ( u_rocc_mem_resp_data_o_62_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_63_.u_io VSSIO ) ( u_fsb_node_data_i.u_io\[4\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[3\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[2\].u_in VSSIO ) ( u_fsb_node_v_i.u_in VSSIO ) ( u_fsb_node_data_i.u_io\[1\].u_in VSSIO )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VSSIO ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VSSIO ) + USE GROUND ;
     - u_fsb_node_data_i.u_io\[0\].u_in.VSWITCH_RING ( u_rocc_mem_resp_data_o_62_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_63_.u_io VSWITCH ) ( u_fsb_node_data_i.u_io\[4\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[3\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[2\].u_in VSWITCH ) ( u_fsb_node_v_i.u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[1\].u_in VSWITCH )
-      ( u_fsb_node_data_i.u_io\[0\].u_in VSWITCH ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VCCD_RING ( u_fsb_node_data_o_0_.u_io VCCD ) ( u_fsb_node_v_o.u_io VCCD ) ( u_fsb_node_ready.u_io VCCD ) ( u_fsb_node_data_i.u_io\[7\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[6\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[5\].u_in VCCD ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VCCHIB_RING ( u_fsb_node_data_o_0_.u_io VCCHIB ) ( u_fsb_node_v_o.u_io VCCHIB ) ( u_fsb_node_ready.u_io VCCHIB ) ( u_fsb_node_data_i.u_io\[7\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[6\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[5\].u_in VCCHIB ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VDDA_RING ( u_fsb_node_data_o_0_.u_io VDDA ) ( u_fsb_node_v_o.u_io VDDA ) ( u_fsb_node_ready.u_io VDDA ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDA ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VDDIO_Q_RING ( u_fsb_node_data_o_0_.u_io VDDIO_Q ) ( u_fsb_node_v_o.u_io VDDIO_Q ) ( u_fsb_node_ready.u_io VDDIO_Q ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDIO_Q ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VDDIO_RING ( u_fsb_node_data_o_0_.u_io VDDIO ) ( u_fsb_node_v_o.u_io VDDIO ) ( u_fsb_node_ready.u_io VDDIO ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDIO ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VSSA_RING ( u_fsb_node_data_o_0_.u_io VSSA ) ( u_fsb_node_v_o.u_io VSSA ) ( u_fsb_node_ready.u_io VSSA ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSA ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VSSD_RING ( u_fsb_node_data_o_0_.u_io VSSD ) ( u_fsb_node_v_o.u_io VSSD ) ( u_fsb_node_ready.u_io VSSD ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSD ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VSSIO_Q_RING ( u_fsb_node_data_o_0_.u_io VSSIO_Q ) ( u_fsb_node_v_o.u_io VSSIO_Q ) ( u_fsb_node_ready.u_io VSSIO_Q ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSIO_Q ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VSSIO_RING ( u_fsb_node_data_o_0_.u_io VSSIO ) ( u_fsb_node_v_o.u_io VSSIO ) ( u_fsb_node_ready.u_io VSSIO ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSIO ) + USE SIGNAL ;
-    - u_fsb_node_data_i.u_io\[5\].u_in.VSWITCH_RING ( u_fsb_node_data_o_0_.u_io VSWITCH ) ( u_fsb_node_v_o.u_io VSWITCH ) ( u_fsb_node_ready.u_io VSWITCH ) ( u_fsb_node_data_i.u_io\[7\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[6\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[5\].u_in VSWITCH ) + USE SIGNAL ;
+      ( u_fsb_node_data_i.u_io\[0\].u_in VSWITCH ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VCCD_RING ( u_fsb_node_data_o_0_.u_io VCCD ) ( u_fsb_node_v_o.u_io VCCD ) ( u_fsb_node_ready.u_io VCCD ) ( u_fsb_node_data_i.u_io\[7\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[6\].u_in VCCD ) ( u_fsb_node_data_i.u_io\[5\].u_in VCCD ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VCCHIB_RING ( u_fsb_node_data_o_0_.u_io VCCHIB ) ( u_fsb_node_v_o.u_io VCCHIB ) ( u_fsb_node_ready.u_io VCCHIB ) ( u_fsb_node_data_i.u_io\[7\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[6\].u_in VCCHIB ) ( u_fsb_node_data_i.u_io\[5\].u_in VCCHIB ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VDDA_RING ( u_fsb_node_data_o_0_.u_io VDDA ) ( u_fsb_node_v_o.u_io VDDA ) ( u_fsb_node_ready.u_io VDDA ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDA ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDA ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VDDIO_Q_RING ( u_fsb_node_data_o_0_.u_io VDDIO_Q ) ( u_fsb_node_v_o.u_io VDDIO_Q ) ( u_fsb_node_ready.u_io VDDIO_Q ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDIO_Q ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDIO_Q ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VDDIO_RING ( u_fsb_node_data_o_0_.u_io VDDIO ) ( u_fsb_node_v_o.u_io VDDIO ) ( u_fsb_node_ready.u_io VDDIO ) ( u_fsb_node_data_i.u_io\[7\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[6\].u_in VDDIO ) ( u_fsb_node_data_i.u_io\[5\].u_in VDDIO ) + USE POWER ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VSSA_RING ( u_fsb_node_data_o_0_.u_io VSSA ) ( u_fsb_node_v_o.u_io VSSA ) ( u_fsb_node_ready.u_io VSSA ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSA ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSA ) + USE GROUND ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VSSD_RING ( u_fsb_node_data_o_0_.u_io VSSD ) ( u_fsb_node_v_o.u_io VSSD ) ( u_fsb_node_ready.u_io VSSD ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSD ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSD ) + USE GROUND ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VSSIO_Q_RING ( u_fsb_node_data_o_0_.u_io VSSIO_Q ) ( u_fsb_node_v_o.u_io VSSIO_Q ) ( u_fsb_node_ready.u_io VSSIO_Q ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSIO_Q ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSIO_Q ) + USE GROUND ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VSSIO_RING ( u_fsb_node_data_o_0_.u_io VSSIO ) ( u_fsb_node_v_o.u_io VSSIO ) ( u_fsb_node_ready.u_io VSSIO ) ( u_fsb_node_data_i.u_io\[7\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[6\].u_in VSSIO ) ( u_fsb_node_data_i.u_io\[5\].u_in VSSIO ) + USE GROUND ;
+    - u_fsb_node_data_i.u_io\[5\].u_in.VSWITCH_RING ( u_fsb_node_data_o_0_.u_io VSWITCH ) ( u_fsb_node_v_o.u_io VSWITCH ) ( u_fsb_node_ready.u_io VSWITCH ) ( u_fsb_node_data_i.u_io\[7\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[6\].u_in VSWITCH ) ( u_fsb_node_data_i.u_io\[5\].u_in VSWITCH ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VCCD_RING ( u_rocc_ctrl_i_interrupt.u_in VCCD ) ( u_rocc_ctrl_i_busy.u_in VCCD ) ( u_fsb_node_yumi.u_in VCCD ) ( u_fsb_node_data_o_7_.u_io VCCD ) ( u_fsb_node_data_o_6_.u_io VCCD ) ( u_fsb_node_data_o_5_.u_io VCCD ) ( u_fsb_node_data_o_4_.u_io VCCD )
-      ( u_fsb_node_data_o_3_.u_io VCCD ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VCCD ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VCCHIB_RING ( u_rocc_ctrl_i_interrupt.u_in VCCHIB ) ( u_rocc_ctrl_i_busy.u_in VCCHIB ) ( u_fsb_node_yumi.u_in VCCHIB ) ( u_fsb_node_data_o_7_.u_io VCCHIB ) ( u_fsb_node_data_o_6_.u_io VCCHIB ) ( u_fsb_node_data_o_5_.u_io VCCHIB ) ( u_fsb_node_data_o_4_.u_io VCCHIB )
-      ( u_fsb_node_data_o_3_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VCCHIB ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VDDA_RING ( u_rocc_ctrl_i_interrupt.u_in VDDA ) ( u_rocc_ctrl_i_busy.u_in VDDA ) ( u_fsb_node_yumi.u_in VDDA ) ( u_fsb_node_data_o_7_.u_io VDDA ) ( u_fsb_node_data_o_6_.u_io VDDA ) ( u_fsb_node_data_o_5_.u_io VDDA ) ( u_fsb_node_data_o_4_.u_io VDDA )
-      ( u_fsb_node_data_o_3_.u_io VDDA ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VDDA ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VDDIO_Q_RING ( u_rocc_ctrl_i_interrupt.u_in VDDIO_Q ) ( u_rocc_ctrl_i_busy.u_in VDDIO_Q ) ( u_fsb_node_yumi.u_in VDDIO_Q ) ( u_fsb_node_data_o_7_.u_io VDDIO_Q ) ( u_fsb_node_data_o_6_.u_io VDDIO_Q ) ( u_fsb_node_data_o_5_.u_io VDDIO_Q ) ( u_fsb_node_data_o_4_.u_io VDDIO_Q )
-      ( u_fsb_node_data_o_3_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VDDIO_Q ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VDDIO_RING ( u_rocc_ctrl_i_interrupt.u_in VDDIO ) ( u_rocc_ctrl_i_busy.u_in VDDIO ) ( u_fsb_node_yumi.u_in VDDIO ) ( u_fsb_node_data_o_7_.u_io VDDIO ) ( u_fsb_node_data_o_6_.u_io VDDIO ) ( u_fsb_node_data_o_5_.u_io VDDIO ) ( u_fsb_node_data_o_4_.u_io VDDIO )
-      ( u_fsb_node_data_o_3_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VDDIO ) + USE POWER ;
     - u_fsb_node_data_o_3_.u_io.VSSA_RING ( u_rocc_ctrl_i_interrupt.u_in VSSA ) ( u_rocc_ctrl_i_busy.u_in VSSA ) ( u_fsb_node_yumi.u_in VSSA ) ( u_fsb_node_data_o_7_.u_io VSSA ) ( u_fsb_node_data_o_6_.u_io VSSA ) ( u_fsb_node_data_o_5_.u_io VSSA ) ( u_fsb_node_data_o_4_.u_io VSSA )
-      ( u_fsb_node_data_o_3_.u_io VSSA ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VSSA ) + USE GROUND ;
     - u_fsb_node_data_o_3_.u_io.VSSD_RING ( u_rocc_ctrl_i_interrupt.u_in VSSD ) ( u_rocc_ctrl_i_busy.u_in VSSD ) ( u_fsb_node_yumi.u_in VSSD ) ( u_fsb_node_data_o_7_.u_io VSSD ) ( u_fsb_node_data_o_6_.u_io VSSD ) ( u_fsb_node_data_o_5_.u_io VSSD ) ( u_fsb_node_data_o_4_.u_io VSSD )
-      ( u_fsb_node_data_o_3_.u_io VSSD ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VSSD ) + USE GROUND ;
     - u_fsb_node_data_o_3_.u_io.VSSIO_Q_RING ( u_rocc_ctrl_i_interrupt.u_in VSSIO_Q ) ( u_rocc_ctrl_i_busy.u_in VSSIO_Q ) ( u_fsb_node_yumi.u_in VSSIO_Q ) ( u_fsb_node_data_o_7_.u_io VSSIO_Q ) ( u_fsb_node_data_o_6_.u_io VSSIO_Q ) ( u_fsb_node_data_o_5_.u_io VSSIO_Q ) ( u_fsb_node_data_o_4_.u_io VSSIO_Q )
-      ( u_fsb_node_data_o_3_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VSSIO_Q ) + USE GROUND ;
     - u_fsb_node_data_o_3_.u_io.VSSIO_RING ( u_rocc_ctrl_i_interrupt.u_in VSSIO ) ( u_rocc_ctrl_i_busy.u_in VSSIO ) ( u_fsb_node_yumi.u_in VSSIO ) ( u_fsb_node_data_o_7_.u_io VSSIO ) ( u_fsb_node_data_o_6_.u_io VSSIO ) ( u_fsb_node_data_o_5_.u_io VSSIO ) ( u_fsb_node_data_o_4_.u_io VSSIO )
-      ( u_fsb_node_data_o_3_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VSSIO ) + USE GROUND ;
     - u_fsb_node_data_o_3_.u_io.VSWITCH_RING ( u_rocc_ctrl_i_interrupt.u_in VSWITCH ) ( u_rocc_ctrl_i_busy.u_in VSWITCH ) ( u_fsb_node_yumi.u_in VSWITCH ) ( u_fsb_node_data_o_7_.u_io VSWITCH ) ( u_fsb_node_data_o_6_.u_io VSWITCH ) ( u_fsb_node_data_o_5_.u_io VSWITCH ) ( u_fsb_node_data_o_4_.u_io VSWITCH )
-      ( u_fsb_node_data_o_3_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_fsb_node_data_o_3_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VCCD_RING ( u_vzz_1 VCCD ) ( u_rocc_cmd_data_o_5_.u_io VCCD ) ( u_rocc_cmd_data_o_4_.u_io VCCD ) ( u_rocc_cmd_data_o_3_.u_io VCCD ) ( u_rocc_cmd_data_o_2_.u_io VCCD ) ( u_rocc_cmd_v.u_io VCCD ) ( u_rocc_cmd_data_o_1_.u_io VCCD )
-      ( u_rocc_cmd_data_o_0_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VCCD ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VCCHIB_RING ( u_vzz_1 VCCHIB ) ( u_rocc_cmd_data_o_5_.u_io VCCHIB ) ( u_rocc_cmd_data_o_4_.u_io VCCHIB ) ( u_rocc_cmd_data_o_3_.u_io VCCHIB ) ( u_rocc_cmd_data_o_2_.u_io VCCHIB ) ( u_rocc_cmd_v.u_io VCCHIB ) ( u_rocc_cmd_data_o_1_.u_io VCCHIB )
-      ( u_rocc_cmd_data_o_0_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VDDA_RING ( u_vzz_1 VDDA ) ( u_rocc_cmd_data_o_5_.u_io VDDA ) ( u_rocc_cmd_data_o_4_.u_io VDDA ) ( u_rocc_cmd_data_o_3_.u_io VDDA ) ( u_rocc_cmd_data_o_2_.u_io VDDA ) ( u_rocc_cmd_v.u_io VDDA ) ( u_rocc_cmd_data_o_1_.u_io VDDA )
-      ( u_rocc_cmd_data_o_0_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VDDA ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VDDIO_Q_RING ( u_vzz_1 VDDIO_Q ) ( u_rocc_cmd_data_o_5_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_4_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_3_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_2_.u_io VDDIO_Q ) ( u_rocc_cmd_v.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_1_.u_io VDDIO_Q )
-      ( u_rocc_cmd_data_o_0_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VDDIO_RING ( u_vzz_1 VDDIO ) ( u_rocc_cmd_data_o_5_.u_io VDDIO ) ( u_rocc_cmd_data_o_4_.u_io VDDIO ) ( u_rocc_cmd_data_o_3_.u_io VDDIO ) ( u_rocc_cmd_data_o_2_.u_io VDDIO ) ( u_rocc_cmd_v.u_io VDDIO ) ( u_rocc_cmd_data_o_1_.u_io VDDIO )
-      ( u_rocc_cmd_data_o_0_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VDDIO ) + USE POWER ;
     - u_rocc_cmd_data_o_0_.u_io.VSSA_RING ( u_vzz_1 VSSA ) ( u_rocc_cmd_data_o_5_.u_io VSSA ) ( u_rocc_cmd_data_o_4_.u_io VSSA ) ( u_rocc_cmd_data_o_3_.u_io VSSA ) ( u_rocc_cmd_data_o_2_.u_io VSSA ) ( u_rocc_cmd_v.u_io VSSA ) ( u_rocc_cmd_data_o_1_.u_io VSSA )
-      ( u_rocc_cmd_data_o_0_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VSSA ) + USE GROUND ;
     - u_rocc_cmd_data_o_0_.u_io.VSSD_RING ( u_vzz_1 VSSD ) ( u_rocc_cmd_data_o_5_.u_io VSSD ) ( u_rocc_cmd_data_o_4_.u_io VSSD ) ( u_rocc_cmd_data_o_3_.u_io VSSD ) ( u_rocc_cmd_data_o_2_.u_io VSSD ) ( u_rocc_cmd_v.u_io VSSD ) ( u_rocc_cmd_data_o_1_.u_io VSSD )
-      ( u_rocc_cmd_data_o_0_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VSSD ) + USE GROUND ;
     - u_rocc_cmd_data_o_0_.u_io.VSSIO_Q_RING ( u_vzz_1 VSSIO_Q ) ( u_rocc_cmd_data_o_5_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_4_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_3_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_2_.u_io VSSIO_Q ) ( u_rocc_cmd_v.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_1_.u_io VSSIO_Q )
-      ( u_rocc_cmd_data_o_0_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_cmd_data_o_0_.u_io.VSSIO_RING ( u_vzz_1 VSSIO ) ( u_rocc_cmd_data_o_5_.u_io VSSIO ) ( u_rocc_cmd_data_o_4_.u_io VSSIO ) ( u_rocc_cmd_data_o_3_.u_io VSSIO ) ( u_rocc_cmd_data_o_2_.u_io VSSIO ) ( u_rocc_cmd_v.u_io VSSIO ) ( u_rocc_cmd_data_o_1_.u_io VSSIO )
-      ( u_rocc_cmd_data_o_0_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_cmd_data_o_0_.u_io.VSWITCH_RING ( u_vzz_1 VSWITCH ) ( u_rocc_cmd_data_o_5_.u_io VSWITCH ) ( u_rocc_cmd_data_o_4_.u_io VSWITCH ) ( u_rocc_cmd_data_o_3_.u_io VSWITCH ) ( u_rocc_cmd_data_o_2_.u_io VSWITCH ) ( u_rocc_cmd_v.u_io VSWITCH ) ( u_rocc_cmd_data_o_1_.u_io VSWITCH )
-      ( u_rocc_cmd_data_o_0_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VCCD_RING ( u_vzz_2 VCCD ) ( u_rocc_cmd_data_o_13_.u_io VCCD ) ( u_rocc_cmd_data_o_12_.u_io VCCD ) ( u_rocc_cmd_data_o_9_.u_io VCCD ) ( u_rocc_cmd_data_o_11_.u_io VCCD ) ( u_rocc_cmd_data_o_10_.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VCCHIB_RING ( u_vzz_2 VCCHIB ) ( u_rocc_cmd_data_o_13_.u_io VCCHIB ) ( u_rocc_cmd_data_o_12_.u_io VCCHIB ) ( u_rocc_cmd_data_o_9_.u_io VCCHIB ) ( u_rocc_cmd_data_o_11_.u_io VCCHIB ) ( u_rocc_cmd_data_o_10_.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VDDA_RING ( u_vzz_2 VDDA ) ( u_rocc_cmd_data_o_13_.u_io VDDA ) ( u_rocc_cmd_data_o_12_.u_io VDDA ) ( u_rocc_cmd_data_o_9_.u_io VDDA ) ( u_rocc_cmd_data_o_11_.u_io VDDA ) ( u_rocc_cmd_data_o_10_.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VDDIO_Q_RING ( u_vzz_2 VDDIO_Q ) ( u_rocc_cmd_data_o_13_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_12_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_9_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_11_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_10_.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VDDIO_RING ( u_vzz_2 VDDIO ) ( u_rocc_cmd_data_o_13_.u_io VDDIO ) ( u_rocc_cmd_data_o_12_.u_io VDDIO ) ( u_rocc_cmd_data_o_9_.u_io VDDIO ) ( u_rocc_cmd_data_o_11_.u_io VDDIO ) ( u_rocc_cmd_data_o_10_.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VSSA_RING ( u_vzz_2 VSSA ) ( u_rocc_cmd_data_o_13_.u_io VSSA ) ( u_rocc_cmd_data_o_12_.u_io VSSA ) ( u_rocc_cmd_data_o_9_.u_io VSSA ) ( u_rocc_cmd_data_o_11_.u_io VSSA ) ( u_rocc_cmd_data_o_10_.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VSSD_RING ( u_vzz_2 VSSD ) ( u_rocc_cmd_data_o_13_.u_io VSSD ) ( u_rocc_cmd_data_o_12_.u_io VSSD ) ( u_rocc_cmd_data_o_9_.u_io VSSD ) ( u_rocc_cmd_data_o_11_.u_io VSSD ) ( u_rocc_cmd_data_o_10_.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VSSIO_Q_RING ( u_vzz_2 VSSIO_Q ) ( u_rocc_cmd_data_o_13_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_12_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_9_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_11_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_10_.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VSSIO_RING ( u_vzz_2 VSSIO ) ( u_rocc_cmd_data_o_13_.u_io VSSIO ) ( u_rocc_cmd_data_o_12_.u_io VSSIO ) ( u_rocc_cmd_data_o_9_.u_io VSSIO ) ( u_rocc_cmd_data_o_11_.u_io VSSIO ) ( u_rocc_cmd_data_o_10_.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_10_.u_io.VSWITCH_RING ( u_vzz_2 VSWITCH ) ( u_rocc_cmd_data_o_13_.u_io VSWITCH ) ( u_rocc_cmd_data_o_12_.u_io VSWITCH ) ( u_rocc_cmd_data_o_9_.u_io VSWITCH ) ( u_rocc_cmd_data_o_11_.u_io VSWITCH ) ( u_rocc_cmd_data_o_10_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_0_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VCCD_RING ( u_vzz_2 VCCD ) ( u_rocc_cmd_data_o_13_.u_io VCCD ) ( u_rocc_cmd_data_o_12_.u_io VCCD ) ( u_rocc_cmd_data_o_9_.u_io VCCD ) ( u_rocc_cmd_data_o_11_.u_io VCCD ) ( u_rocc_cmd_data_o_10_.u_io VCCD ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VCCHIB_RING ( u_vzz_2 VCCHIB ) ( u_rocc_cmd_data_o_13_.u_io VCCHIB ) ( u_rocc_cmd_data_o_12_.u_io VCCHIB ) ( u_rocc_cmd_data_o_9_.u_io VCCHIB ) ( u_rocc_cmd_data_o_11_.u_io VCCHIB ) ( u_rocc_cmd_data_o_10_.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VDDA_RING ( u_vzz_2 VDDA ) ( u_rocc_cmd_data_o_13_.u_io VDDA ) ( u_rocc_cmd_data_o_12_.u_io VDDA ) ( u_rocc_cmd_data_o_9_.u_io VDDA ) ( u_rocc_cmd_data_o_11_.u_io VDDA ) ( u_rocc_cmd_data_o_10_.u_io VDDA ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VDDIO_Q_RING ( u_vzz_2 VDDIO_Q ) ( u_rocc_cmd_data_o_13_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_12_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_9_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_11_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_10_.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VDDIO_RING ( u_vzz_2 VDDIO ) ( u_rocc_cmd_data_o_13_.u_io VDDIO ) ( u_rocc_cmd_data_o_12_.u_io VDDIO ) ( u_rocc_cmd_data_o_9_.u_io VDDIO ) ( u_rocc_cmd_data_o_11_.u_io VDDIO ) ( u_rocc_cmd_data_o_10_.u_io VDDIO ) + USE POWER ;
+    - u_rocc_cmd_data_o_10_.u_io.VSSA_RING ( u_vzz_2 VSSA ) ( u_rocc_cmd_data_o_13_.u_io VSSA ) ( u_rocc_cmd_data_o_12_.u_io VSSA ) ( u_rocc_cmd_data_o_9_.u_io VSSA ) ( u_rocc_cmd_data_o_11_.u_io VSSA ) ( u_rocc_cmd_data_o_10_.u_io VSSA ) + USE GROUND ;
+    - u_rocc_cmd_data_o_10_.u_io.VSSD_RING ( u_vzz_2 VSSD ) ( u_rocc_cmd_data_o_13_.u_io VSSD ) ( u_rocc_cmd_data_o_12_.u_io VSSD ) ( u_rocc_cmd_data_o_9_.u_io VSSD ) ( u_rocc_cmd_data_o_11_.u_io VSSD ) ( u_rocc_cmd_data_o_10_.u_io VSSD ) + USE GROUND ;
+    - u_rocc_cmd_data_o_10_.u_io.VSSIO_Q_RING ( u_vzz_2 VSSIO_Q ) ( u_rocc_cmd_data_o_13_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_12_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_9_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_11_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_10_.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_cmd_data_o_10_.u_io.VSSIO_RING ( u_vzz_2 VSSIO ) ( u_rocc_cmd_data_o_13_.u_io VSSIO ) ( u_rocc_cmd_data_o_12_.u_io VSSIO ) ( u_rocc_cmd_data_o_9_.u_io VSSIO ) ( u_rocc_cmd_data_o_11_.u_io VSSIO ) ( u_rocc_cmd_data_o_10_.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_cmd_data_o_10_.u_io.VSWITCH_RING ( u_vzz_2 VSWITCH ) ( u_rocc_cmd_data_o_13_.u_io VSWITCH ) ( u_rocc_cmd_data_o_12_.u_io VSWITCH ) ( u_rocc_cmd_data_o_9_.u_io VSWITCH ) ( u_rocc_cmd_data_o_11_.u_io VSWITCH ) ( u_rocc_cmd_data_o_10_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VCCD_RING ( u_vzz_3 VCCD ) ( u_rocc_resp_data_i.u_io\[3\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[2\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[1\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[0\].u_in VCCD ) ( u_rocc_resp_v.u_in VCCD ) ( u_rocc_cmd_ready.u_in VCCD )
-      ( u_rocc_cmd_data_o_15_.u_io VCCD ) ( u_rocc_cmd_data_o_14_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VCCD ) ( u_rocc_cmd_data_o_14_.u_io VCCD ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VCCHIB_RING ( u_vzz_3 VCCHIB ) ( u_rocc_resp_data_i.u_io\[3\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[2\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[1\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[0\].u_in VCCHIB ) ( u_rocc_resp_v.u_in VCCHIB ) ( u_rocc_cmd_ready.u_in VCCHIB )
-      ( u_rocc_cmd_data_o_15_.u_io VCCHIB ) ( u_rocc_cmd_data_o_14_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VCCHIB ) ( u_rocc_cmd_data_o_14_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VDDA_RING ( u_vzz_3 VDDA ) ( u_rocc_resp_data_i.u_io\[3\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[2\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[1\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[0\].u_in VDDA ) ( u_rocc_resp_v.u_in VDDA ) ( u_rocc_cmd_ready.u_in VDDA )
-      ( u_rocc_cmd_data_o_15_.u_io VDDA ) ( u_rocc_cmd_data_o_14_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VDDA ) ( u_rocc_cmd_data_o_14_.u_io VDDA ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VDDIO_Q_RING ( u_vzz_3 VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[3\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[2\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[1\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[0\].u_in VDDIO_Q ) ( u_rocc_resp_v.u_in VDDIO_Q ) ( u_rocc_cmd_ready.u_in VDDIO_Q )
-      ( u_rocc_cmd_data_o_15_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_14_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_14_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VDDIO_RING ( u_vzz_3 VDDIO ) ( u_rocc_resp_data_i.u_io\[3\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[2\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[1\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[0\].u_in VDDIO ) ( u_rocc_resp_v.u_in VDDIO ) ( u_rocc_cmd_ready.u_in VDDIO )
-      ( u_rocc_cmd_data_o_15_.u_io VDDIO ) ( u_rocc_cmd_data_o_14_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VDDIO ) ( u_rocc_cmd_data_o_14_.u_io VDDIO ) + USE POWER ;
     - u_rocc_cmd_data_o_14_.u_io.VSSA_RING ( u_vzz_3 VSSA ) ( u_rocc_resp_data_i.u_io\[3\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[2\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[1\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[0\].u_in VSSA ) ( u_rocc_resp_v.u_in VSSA ) ( u_rocc_cmd_ready.u_in VSSA )
-      ( u_rocc_cmd_data_o_15_.u_io VSSA ) ( u_rocc_cmd_data_o_14_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VSSA ) ( u_rocc_cmd_data_o_14_.u_io VSSA ) + USE GROUND ;
     - u_rocc_cmd_data_o_14_.u_io.VSSD_RING ( u_vzz_3 VSSD ) ( u_rocc_resp_data_i.u_io\[3\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[2\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[1\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[0\].u_in VSSD ) ( u_rocc_resp_v.u_in VSSD ) ( u_rocc_cmd_ready.u_in VSSD )
-      ( u_rocc_cmd_data_o_15_.u_io VSSD ) ( u_rocc_cmd_data_o_14_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VSSD ) ( u_rocc_cmd_data_o_14_.u_io VSSD ) + USE GROUND ;
     - u_rocc_cmd_data_o_14_.u_io.VSSIO_Q_RING ( u_vzz_3 VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[3\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[2\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[1\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[0\].u_in VSSIO_Q ) ( u_rocc_resp_v.u_in VSSIO_Q ) ( u_rocc_cmd_ready.u_in VSSIO_Q )
-      ( u_rocc_cmd_data_o_15_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_14_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_14_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_cmd_data_o_14_.u_io.VSSIO_RING ( u_vzz_3 VSSIO ) ( u_rocc_resp_data_i.u_io\[3\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[2\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[1\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[0\].u_in VSSIO ) ( u_rocc_resp_v.u_in VSSIO ) ( u_rocc_cmd_ready.u_in VSSIO )
-      ( u_rocc_cmd_data_o_15_.u_io VSSIO ) ( u_rocc_cmd_data_o_14_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VSSIO ) ( u_rocc_cmd_data_o_14_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_cmd_data_o_14_.u_io.VSWITCH_RING ( u_vzz_3 VSWITCH ) ( u_rocc_resp_data_i.u_io\[3\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[2\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[1\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[0\].u_in VSWITCH ) ( u_rocc_resp_v.u_in VSWITCH ) ( u_rocc_cmd_ready.u_in VSWITCH )
-      ( u_rocc_cmd_data_o_15_.u_io VSWITCH ) ( u_rocc_cmd_data_o_14_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VCCD_RING ( u_vss_0 VCCD ) ( u_rocc_cmd_data_o_8_.u_io VCCD ) ( u_rocc_cmd_data_o_7_.u_io VCCD ) ( u_rocc_cmd_data_o_6_.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VCCHIB_RING ( u_vss_0 VCCHIB ) ( u_rocc_cmd_data_o_8_.u_io VCCHIB ) ( u_rocc_cmd_data_o_7_.u_io VCCHIB ) ( u_rocc_cmd_data_o_6_.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VDDA_RING ( u_vss_0 VDDA ) ( u_rocc_cmd_data_o_8_.u_io VDDA ) ( u_rocc_cmd_data_o_7_.u_io VDDA ) ( u_rocc_cmd_data_o_6_.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VDDIO_Q_RING ( u_vss_0 VDDIO_Q ) ( u_rocc_cmd_data_o_8_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_7_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_6_.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VDDIO_RING ( u_vss_0 VDDIO ) ( u_rocc_cmd_data_o_8_.u_io VDDIO ) ( u_rocc_cmd_data_o_7_.u_io VDDIO ) ( u_rocc_cmd_data_o_6_.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VSSA_RING ( u_vss_0 VSSA ) ( u_rocc_cmd_data_o_8_.u_io VSSA ) ( u_rocc_cmd_data_o_7_.u_io VSSA ) ( u_rocc_cmd_data_o_6_.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VSSD_RING ( u_vss_0 VSSD ) ( u_rocc_cmd_data_o_8_.u_io VSSD ) ( u_rocc_cmd_data_o_7_.u_io VSSD ) ( u_rocc_cmd_data_o_6_.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VSSIO_Q_RING ( u_vss_0 VSSIO_Q ) ( u_rocc_cmd_data_o_8_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_7_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_6_.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VSSIO_RING ( u_vss_0 VSSIO ) ( u_rocc_cmd_data_o_8_.u_io VSSIO ) ( u_rocc_cmd_data_o_7_.u_io VSSIO ) ( u_rocc_cmd_data_o_6_.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_cmd_data_o_6_.u_io.VSWITCH_RING ( u_vss_0 VSWITCH ) ( u_rocc_cmd_data_o_8_.u_io VSWITCH ) ( u_rocc_cmd_data_o_7_.u_io VSWITCH ) ( u_rocc_cmd_data_o_6_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VCCD_RING ( u_rocc_ctrl_o_s.u_io VCCD ) ( u_rocc_ctrl_o_host_id.u_io VCCD ) ( u_rocc_ctrl_o_exception.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VCCHIB_RING ( u_rocc_ctrl_o_s.u_io VCCHIB ) ( u_rocc_ctrl_o_host_id.u_io VCCHIB ) ( u_rocc_ctrl_o_exception.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VDDA_RING ( u_rocc_ctrl_o_s.u_io VDDA ) ( u_rocc_ctrl_o_host_id.u_io VDDA ) ( u_rocc_ctrl_o_exception.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VDDIO_Q_RING ( u_rocc_ctrl_o_s.u_io VDDIO_Q ) ( u_rocc_ctrl_o_host_id.u_io VDDIO_Q ) ( u_rocc_ctrl_o_exception.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VDDIO_RING ( u_rocc_ctrl_o_s.u_io VDDIO ) ( u_rocc_ctrl_o_host_id.u_io VDDIO ) ( u_rocc_ctrl_o_exception.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VSSA_RING ( u_rocc_ctrl_o_s.u_io VSSA ) ( u_rocc_ctrl_o_host_id.u_io VSSA ) ( u_rocc_ctrl_o_exception.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VSSD_RING ( u_rocc_ctrl_o_s.u_io VSSD ) ( u_rocc_ctrl_o_host_id.u_io VSSD ) ( u_rocc_ctrl_o_exception.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VSSIO_Q_RING ( u_rocc_ctrl_o_s.u_io VSSIO_Q ) ( u_rocc_ctrl_o_host_id.u_io VSSIO_Q ) ( u_rocc_ctrl_o_exception.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VSSIO_RING ( u_rocc_ctrl_o_s.u_io VSSIO ) ( u_rocc_ctrl_o_host_id.u_io VSSIO ) ( u_rocc_ctrl_o_exception.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_ctrl_o_exception.u_io.VSWITCH_RING ( u_rocc_ctrl_o_s.u_io VSWITCH ) ( u_rocc_ctrl_o_host_id.u_io VSWITCH ) ( u_rocc_ctrl_o_exception.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VCCD_RING ( u_vzz_4 VCCD ) ( u_rocc_mem_req_v.u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VCCHIB_RING ( u_vzz_4 VCCHIB ) ( u_rocc_mem_req_v.u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDA_RING ( u_vzz_4 VDDA ) ( u_rocc_mem_req_v.u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDIO_Q_RING ( u_vzz_4 VDDIO_Q ) ( u_rocc_mem_req_v.u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDIO_RING ( u_vzz_4 VDDIO ) ( u_rocc_mem_req_v.u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSA_RING ( u_vzz_4 VSSA ) ( u_rocc_mem_req_v.u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSD_RING ( u_vzz_4 VSSD ) ( u_rocc_mem_req_v.u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSIO_Q_RING ( u_vzz_4 VSSIO_Q ) ( u_rocc_mem_req_v.u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSIO_RING ( u_vzz_4 VSSIO ) ( u_rocc_mem_req_v.u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSWITCH_RING ( u_vzz_4 VSWITCH ) ( u_rocc_mem_req_v.u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VCCD_RING ( u_vzz_6 VCCD ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VCCHIB_RING ( u_vzz_6 VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDA_RING ( u_vzz_6 VDDA ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDIO_Q_RING ( u_vzz_6 VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDIO_RING ( u_vzz_6 VDDIO ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSA_RING ( u_vzz_6 VSSA ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSD_RING ( u_vzz_6 VSSD ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSIO_Q_RING ( u_vzz_6 VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSIO_RING ( u_vzz_6 VSSIO ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSWITCH_RING ( u_vzz_6 VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_cmd_data_o_15_.u_io VSWITCH ) ( u_rocc_cmd_data_o_14_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VCCD_RING ( u_vss_0 VCCD ) ( u_rocc_cmd_data_o_8_.u_io VCCD ) ( u_rocc_cmd_data_o_7_.u_io VCCD ) ( u_rocc_cmd_data_o_6_.u_io VCCD ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VCCHIB_RING ( u_vss_0 VCCHIB ) ( u_rocc_cmd_data_o_8_.u_io VCCHIB ) ( u_rocc_cmd_data_o_7_.u_io VCCHIB ) ( u_rocc_cmd_data_o_6_.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VDDA_RING ( u_vss_0 VDDA ) ( u_rocc_cmd_data_o_8_.u_io VDDA ) ( u_rocc_cmd_data_o_7_.u_io VDDA ) ( u_rocc_cmd_data_o_6_.u_io VDDA ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VDDIO_Q_RING ( u_vss_0 VDDIO_Q ) ( u_rocc_cmd_data_o_8_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_7_.u_io VDDIO_Q ) ( u_rocc_cmd_data_o_6_.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VDDIO_RING ( u_vss_0 VDDIO ) ( u_rocc_cmd_data_o_8_.u_io VDDIO ) ( u_rocc_cmd_data_o_7_.u_io VDDIO ) ( u_rocc_cmd_data_o_6_.u_io VDDIO ) + USE POWER ;
+    - u_rocc_cmd_data_o_6_.u_io.VSSA_RING ( u_vss_0 VSSA ) ( u_rocc_cmd_data_o_8_.u_io VSSA ) ( u_rocc_cmd_data_o_7_.u_io VSSA ) ( u_rocc_cmd_data_o_6_.u_io VSSA ) + USE GROUND ;
+    - u_rocc_cmd_data_o_6_.u_io.VSSD_RING ( u_vss_0 VSSD ) ( u_rocc_cmd_data_o_8_.u_io VSSD ) ( u_rocc_cmd_data_o_7_.u_io VSSD ) ( u_rocc_cmd_data_o_6_.u_io VSSD ) + USE GROUND ;
+    - u_rocc_cmd_data_o_6_.u_io.VSSIO_Q_RING ( u_vss_0 VSSIO_Q ) ( u_rocc_cmd_data_o_8_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_7_.u_io VSSIO_Q ) ( u_rocc_cmd_data_o_6_.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_cmd_data_o_6_.u_io.VSSIO_RING ( u_vss_0 VSSIO ) ( u_rocc_cmd_data_o_8_.u_io VSSIO ) ( u_rocc_cmd_data_o_7_.u_io VSSIO ) ( u_rocc_cmd_data_o_6_.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_cmd_data_o_6_.u_io.VSWITCH_RING ( u_vss_0 VSWITCH ) ( u_rocc_cmd_data_o_8_.u_io VSWITCH ) ( u_rocc_cmd_data_o_7_.u_io VSWITCH ) ( u_rocc_cmd_data_o_6_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VCCD_RING ( u_rocc_ctrl_o_s.u_io VCCD ) ( u_rocc_ctrl_o_host_id.u_io VCCD ) ( u_rocc_ctrl_o_exception.u_io VCCD ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VCCHIB_RING ( u_rocc_ctrl_o_s.u_io VCCHIB ) ( u_rocc_ctrl_o_host_id.u_io VCCHIB ) ( u_rocc_ctrl_o_exception.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VDDA_RING ( u_rocc_ctrl_o_s.u_io VDDA ) ( u_rocc_ctrl_o_host_id.u_io VDDA ) ( u_rocc_ctrl_o_exception.u_io VDDA ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VDDIO_Q_RING ( u_rocc_ctrl_o_s.u_io VDDIO_Q ) ( u_rocc_ctrl_o_host_id.u_io VDDIO_Q ) ( u_rocc_ctrl_o_exception.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VDDIO_RING ( u_rocc_ctrl_o_s.u_io VDDIO ) ( u_rocc_ctrl_o_host_id.u_io VDDIO ) ( u_rocc_ctrl_o_exception.u_io VDDIO ) + USE POWER ;
+    - u_rocc_ctrl_o_exception.u_io.VSSA_RING ( u_rocc_ctrl_o_s.u_io VSSA ) ( u_rocc_ctrl_o_host_id.u_io VSSA ) ( u_rocc_ctrl_o_exception.u_io VSSA ) + USE GROUND ;
+    - u_rocc_ctrl_o_exception.u_io.VSSD_RING ( u_rocc_ctrl_o_s.u_io VSSD ) ( u_rocc_ctrl_o_host_id.u_io VSSD ) ( u_rocc_ctrl_o_exception.u_io VSSD ) + USE GROUND ;
+    - u_rocc_ctrl_o_exception.u_io.VSSIO_Q_RING ( u_rocc_ctrl_o_s.u_io VSSIO_Q ) ( u_rocc_ctrl_o_host_id.u_io VSSIO_Q ) ( u_rocc_ctrl_o_exception.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_ctrl_o_exception.u_io.VSSIO_RING ( u_rocc_ctrl_o_s.u_io VSSIO ) ( u_rocc_ctrl_o_host_id.u_io VSSIO ) ( u_rocc_ctrl_o_exception.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_ctrl_o_exception.u_io.VSWITCH_RING ( u_rocc_ctrl_o_s.u_io VSWITCH ) ( u_rocc_ctrl_o_host_id.u_io VSWITCH ) ( u_rocc_ctrl_o_exception.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VCCD_RING ( u_vzz_4 VCCD ) ( u_rocc_mem_req_v.u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VCCD ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VCCHIB_RING ( u_vzz_4 VCCHIB ) ( u_rocc_mem_req_v.u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VCCHIB ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDA_RING ( u_vzz_4 VDDA ) ( u_rocc_mem_req_v.u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDA ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDIO_Q_RING ( u_vzz_4 VDDIO_Q ) ( u_rocc_mem_req_v.u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VDDIO_RING ( u_vzz_4 VDDIO ) ( u_rocc_mem_req_v.u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VDDIO ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSA_RING ( u_vzz_4 VSSA ) ( u_rocc_mem_req_v.u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSA ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSD_RING ( u_vzz_4 VSSD ) ( u_rocc_mem_req_v.u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSD ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSIO_Q_RING ( u_vzz_4 VSSIO_Q ) ( u_rocc_mem_req_v.u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSSIO_RING ( u_vzz_4 VSSIO ) ( u_rocc_mem_req_v.u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSSIO ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[0\].u_in.VSWITCH_RING ( u_vzz_4 VSWITCH ) ( u_rocc_mem_req_v.u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[1\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[0\].u_in VSWITCH ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VCCD_RING ( u_vzz_6 VCCD ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VCCD ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VCCHIB_RING ( u_vzz_6 VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VCCHIB ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDA_RING ( u_vzz_6 VDDA ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDA ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDIO_Q_RING ( u_vzz_6 VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VDDIO_RING ( u_vzz_6 VDDIO ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VDDIO ) + USE POWER ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSA_RING ( u_vzz_6 VSSA ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSA ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSD_RING ( u_vzz_6 VSSD ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSD ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSIO_Q_RING ( u_vzz_6 VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSSIO_RING ( u_vzz_6 VSSIO ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSSIO ) + USE GROUND ;
+    - u_rocc_mem_req_data_i.u_io\[12\].u_in.VSWITCH_RING ( u_vzz_6 VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[15\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[14\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[13\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[12\].u_in VSWITCH ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VCCD_RING ( u_vzz_7 VCCD ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VCCD )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VCCD ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VCCHIB_RING ( u_vzz_7 VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VCCHIB )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VCCHIB ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VDDA_RING ( u_vzz_7 VDDA ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VDDA )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDA ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VDDIO_Q_RING ( u_vzz_7 VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VDDIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VDDIO_RING ( u_vzz_7 VDDIO ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VDDIO )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VDDIO ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VSSA_RING ( u_vzz_7 VSSA ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VSSA )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSA ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VSSD_RING ( u_vzz_7 VSSD ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VSSD )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSD ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VSSIO_Q_RING ( u_vzz_7 VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VSSIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VSSIO_RING ( u_vzz_7 VSSIO ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VSSIO )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSSIO ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[16\].u_in.VSWITCH_RING ( u_vzz_7 VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[23\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[22\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[21\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[20\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[19\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[18\].u_in VSWITCH )
-      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[17\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[16\].u_in VSWITCH ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VCCD_RING ( u_vzz_8 VCCD ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VCCD )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VCCD ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VCCHIB_RING ( u_vzz_8 VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VCCHIB )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VCCHIB ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VDDA_RING ( u_vzz_8 VDDA ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VDDA )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDA ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VDDIO_Q_RING ( u_vzz_8 VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VDDIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VDDIO_RING ( u_vzz_8 VDDIO ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VDDIO )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VDDIO ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VSSA_RING ( u_vzz_8 VSSA ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VSSA )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSA ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VSSD_RING ( u_vzz_8 VSSD ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VSSD )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSD ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VSSIO_Q_RING ( u_vzz_8 VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VSSIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VSSIO_RING ( u_vzz_8 VSSIO ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VSSIO )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSSIO ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[24\].u_in.VSWITCH_RING ( u_vzz_8 VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[31\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[30\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[29\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[28\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[27\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[26\].u_in VSWITCH )
-      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[25\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[24\].u_in VSWITCH ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VCCD_RING ( u_vzz_5 VCCD ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VCCD )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VCCD ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VCCD ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VCCHIB_RING ( u_vzz_5 VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VCCHIB )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VCCHIB ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VCCHIB ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VDDA_RING ( u_vzz_5 VDDA ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VDDA )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDA ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDA ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VDDIO_Q_RING ( u_vzz_5 VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VDDIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDIO_Q ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VDDIO_RING ( u_vzz_5 VDDIO ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VDDIO )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VDDIO ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VDDIO ) + USE POWER ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VSSA_RING ( u_vzz_5 VSSA ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VSSA )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSA ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSA ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VSSD_RING ( u_vzz_5 VSSD ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VSSD )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSD ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSD ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VSSIO_Q_RING ( u_vzz_5 VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VSSIO_Q )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSIO_Q ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VSSIO_RING ( u_vzz_5 VSSIO ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VSSIO )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSSIO ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSSIO ) + USE GROUND ;
     - u_rocc_mem_req_data_i.u_io\[2\].u_in.VSWITCH_RING ( u_vzz_5 VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[9\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[8\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[7\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[6\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[5\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[4\].u_in VSWITCH )
-      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VCCD_RING ( u_vss_3 VCCD ) ( u_rocc_mem_resp_data_o_0_.u_io VCCD ) ( u_rocc_mem_resp_v.u_io VCCD ) ( u_rocc_mem_req_ready.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VCCHIB_RING ( u_vss_3 VCCHIB ) ( u_rocc_mem_resp_data_o_0_.u_io VCCHIB ) ( u_rocc_mem_resp_v.u_io VCCHIB ) ( u_rocc_mem_req_ready.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VDDA_RING ( u_vss_3 VDDA ) ( u_rocc_mem_resp_data_o_0_.u_io VDDA ) ( u_rocc_mem_resp_v.u_io VDDA ) ( u_rocc_mem_req_ready.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VDDIO_Q_RING ( u_vss_3 VDDIO_Q ) ( u_rocc_mem_resp_data_o_0_.u_io VDDIO_Q ) ( u_rocc_mem_resp_v.u_io VDDIO_Q ) ( u_rocc_mem_req_ready.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VDDIO_RING ( u_vss_3 VDDIO ) ( u_rocc_mem_resp_data_o_0_.u_io VDDIO ) ( u_rocc_mem_resp_v.u_io VDDIO ) ( u_rocc_mem_req_ready.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VSSA_RING ( u_vss_3 VSSA ) ( u_rocc_mem_resp_data_o_0_.u_io VSSA ) ( u_rocc_mem_resp_v.u_io VSSA ) ( u_rocc_mem_req_ready.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VSSD_RING ( u_vss_3 VSSD ) ( u_rocc_mem_resp_data_o_0_.u_io VSSD ) ( u_rocc_mem_resp_v.u_io VSSD ) ( u_rocc_mem_req_ready.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VSSIO_Q_RING ( u_vss_3 VSSIO_Q ) ( u_rocc_mem_resp_data_o_0_.u_io VSSIO_Q ) ( u_rocc_mem_resp_v.u_io VSSIO_Q ) ( u_rocc_mem_req_ready.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VSSIO_RING ( u_vss_3 VSSIO ) ( u_rocc_mem_resp_data_o_0_.u_io VSSIO ) ( u_rocc_mem_resp_v.u_io VSSIO ) ( u_rocc_mem_req_ready.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_req_ready.u_io.VSWITCH_RING ( u_vss_3 VSWITCH ) ( u_rocc_mem_resp_data_o_0_.u_io VSWITCH ) ( u_rocc_mem_resp_v.u_io VSWITCH ) ( u_rocc_mem_req_ready.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_req_data_i.u_io\[3\].u_in VSWITCH ) ( u_rocc_mem_req_data_i.u_io\[2\].u_in VSWITCH ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VCCD_RING ( u_vss_3 VCCD ) ( u_rocc_mem_resp_data_o_0_.u_io VCCD ) ( u_rocc_mem_resp_v.u_io VCCD ) ( u_rocc_mem_req_ready.u_io VCCD ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VCCHIB_RING ( u_vss_3 VCCHIB ) ( u_rocc_mem_resp_data_o_0_.u_io VCCHIB ) ( u_rocc_mem_resp_v.u_io VCCHIB ) ( u_rocc_mem_req_ready.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VDDA_RING ( u_vss_3 VDDA ) ( u_rocc_mem_resp_data_o_0_.u_io VDDA ) ( u_rocc_mem_resp_v.u_io VDDA ) ( u_rocc_mem_req_ready.u_io VDDA ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VDDIO_Q_RING ( u_vss_3 VDDIO_Q ) ( u_rocc_mem_resp_data_o_0_.u_io VDDIO_Q ) ( u_rocc_mem_resp_v.u_io VDDIO_Q ) ( u_rocc_mem_req_ready.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VDDIO_RING ( u_vss_3 VDDIO ) ( u_rocc_mem_resp_data_o_0_.u_io VDDIO ) ( u_rocc_mem_resp_v.u_io VDDIO ) ( u_rocc_mem_req_ready.u_io VDDIO ) + USE POWER ;
+    - u_rocc_mem_req_ready.u_io.VSSA_RING ( u_vss_3 VSSA ) ( u_rocc_mem_resp_data_o_0_.u_io VSSA ) ( u_rocc_mem_resp_v.u_io VSSA ) ( u_rocc_mem_req_ready.u_io VSSA ) + USE GROUND ;
+    - u_rocc_mem_req_ready.u_io.VSSD_RING ( u_vss_3 VSSD ) ( u_rocc_mem_resp_data_o_0_.u_io VSSD ) ( u_rocc_mem_resp_v.u_io VSSD ) ( u_rocc_mem_req_ready.u_io VSSD ) + USE GROUND ;
+    - u_rocc_mem_req_ready.u_io.VSSIO_Q_RING ( u_vss_3 VSSIO_Q ) ( u_rocc_mem_resp_data_o_0_.u_io VSSIO_Q ) ( u_rocc_mem_resp_v.u_io VSSIO_Q ) ( u_rocc_mem_req_ready.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_req_ready.u_io.VSSIO_RING ( u_vss_3 VSSIO ) ( u_rocc_mem_resp_data_o_0_.u_io VSSIO ) ( u_rocc_mem_resp_v.u_io VSSIO ) ( u_rocc_mem_req_ready.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_mem_req_ready.u_io.VSWITCH_RING ( u_vss_3 VSWITCH ) ( u_rocc_mem_resp_data_o_0_.u_io VSWITCH ) ( u_rocc_mem_resp_v.u_io VSWITCH ) ( u_rocc_mem_req_ready.u_io VSWITCH ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_6_.u_io VCCD ) ( u_rocc_mem_resp_data_o_7_.u_io VCCD ) ( u_rocc_mem_resp_data_o_8_.u_io VCCD ) ( u_vzz_10 VCCD ) ( u_rocc_mem_resp_data_o_13_.u_io VCCD ) ( u_rocc_mem_resp_data_o_12_.u_io VCCD ) ( u_rocc_mem_resp_data_o_9_.u_io VCCD )
-      ( u_rocc_mem_resp_data_o_11_.u_io VCCD ) ( u_rocc_mem_resp_data_o_10_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VCCD ) ( u_rocc_mem_resp_data_o_10_.u_io VCCD ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_6_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_7_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_8_.u_io VCCHIB ) ( u_vzz_10 VCCHIB ) ( u_rocc_mem_resp_data_o_13_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_12_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_9_.u_io VCCHIB )
-      ( u_rocc_mem_resp_data_o_11_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_10_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_10_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_6_.u_io VDDA ) ( u_rocc_mem_resp_data_o_7_.u_io VDDA ) ( u_rocc_mem_resp_data_o_8_.u_io VDDA ) ( u_vzz_10 VDDA ) ( u_rocc_mem_resp_data_o_13_.u_io VDDA ) ( u_rocc_mem_resp_data_o_12_.u_io VDDA ) ( u_rocc_mem_resp_data_o_9_.u_io VDDA )
-      ( u_rocc_mem_resp_data_o_11_.u_io VDDA ) ( u_rocc_mem_resp_data_o_10_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VDDA ) ( u_rocc_mem_resp_data_o_10_.u_io VDDA ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_6_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_7_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_8_.u_io VDDIO_Q ) ( u_vzz_10 VDDIO_Q ) ( u_rocc_mem_resp_data_o_13_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_12_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_9_.u_io VDDIO_Q )
-      ( u_rocc_mem_resp_data_o_11_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_10_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_10_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_6_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_7_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_8_.u_io VDDIO ) ( u_vzz_10 VDDIO ) ( u_rocc_mem_resp_data_o_13_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_12_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_9_.u_io VDDIO )
-      ( u_rocc_mem_resp_data_o_11_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_10_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_10_.u_io VDDIO ) + USE POWER ;
     - u_rocc_mem_resp_data_o_10_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_6_.u_io VSSA ) ( u_rocc_mem_resp_data_o_7_.u_io VSSA ) ( u_rocc_mem_resp_data_o_8_.u_io VSSA ) ( u_vzz_10 VSSA ) ( u_rocc_mem_resp_data_o_13_.u_io VSSA ) ( u_rocc_mem_resp_data_o_12_.u_io VSSA ) ( u_rocc_mem_resp_data_o_9_.u_io VSSA )
-      ( u_rocc_mem_resp_data_o_11_.u_io VSSA ) ( u_rocc_mem_resp_data_o_10_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VSSA ) ( u_rocc_mem_resp_data_o_10_.u_io VSSA ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_10_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_6_.u_io VSSD ) ( u_rocc_mem_resp_data_o_7_.u_io VSSD ) ( u_rocc_mem_resp_data_o_8_.u_io VSSD ) ( u_vzz_10 VSSD ) ( u_rocc_mem_resp_data_o_13_.u_io VSSD ) ( u_rocc_mem_resp_data_o_12_.u_io VSSD ) ( u_rocc_mem_resp_data_o_9_.u_io VSSD )
-      ( u_rocc_mem_resp_data_o_11_.u_io VSSD ) ( u_rocc_mem_resp_data_o_10_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VSSD ) ( u_rocc_mem_resp_data_o_10_.u_io VSSD ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_10_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_6_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_7_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_8_.u_io VSSIO_Q ) ( u_vzz_10 VSSIO_Q ) ( u_rocc_mem_resp_data_o_13_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_12_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_9_.u_io VSSIO_Q )
-      ( u_rocc_mem_resp_data_o_11_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_10_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_10_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_10_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_6_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_7_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_8_.u_io VSSIO ) ( u_vzz_10 VSSIO ) ( u_rocc_mem_resp_data_o_13_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_12_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_9_.u_io VSSIO )
-      ( u_rocc_mem_resp_data_o_11_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_10_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_10_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_10_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_6_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_7_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_8_.u_io VSWITCH ) ( u_vzz_10 VSWITCH ) ( u_rocc_mem_resp_data_o_13_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_12_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_9_.u_io VSWITCH )
-      ( u_rocc_mem_resp_data_o_11_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_10_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_19_.u_io VCCD ) ( u_rocc_mem_resp_data_o_18_.u_io VCCD ) ( u_rocc_mem_resp_data_o_17_.u_io VCCD ) ( u_rocc_mem_resp_data_o_16_.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_19_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_18_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_17_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_16_.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDA ) ( u_rocc_mem_resp_data_o_18_.u_io VDDA ) ( u_rocc_mem_resp_data_o_17_.u_io VDDA ) ( u_rocc_mem_resp_data_o_16_.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_18_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_17_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_16_.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_18_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_17_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_16_.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSA ) ( u_rocc_mem_resp_data_o_18_.u_io VSSA ) ( u_rocc_mem_resp_data_o_17_.u_io VSSA ) ( u_rocc_mem_resp_data_o_16_.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSD ) ( u_rocc_mem_resp_data_o_18_.u_io VSSD ) ( u_rocc_mem_resp_data_o_17_.u_io VSSD ) ( u_rocc_mem_resp_data_o_16_.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_18_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_17_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_16_.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_18_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_17_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_16_.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_16_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_19_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_18_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_17_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_16_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VCCD_RING ( u_vzz_9 VCCD ) ( u_rocc_mem_resp_data_o_5_.u_io VCCD ) ( u_rocc_mem_resp_data_o_4_.u_io VCCD ) ( u_rocc_mem_resp_data_o_3_.u_io VCCD ) ( u_rocc_mem_resp_data_o_2_.u_io VCCD ) ( u_rocc_mem_resp_data_o_1_.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VCCHIB_RING ( u_vzz_9 VCCHIB ) ( u_rocc_mem_resp_data_o_5_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_4_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_3_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_2_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_1_.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VDDA_RING ( u_vzz_9 VDDA ) ( u_rocc_mem_resp_data_o_5_.u_io VDDA ) ( u_rocc_mem_resp_data_o_4_.u_io VDDA ) ( u_rocc_mem_resp_data_o_3_.u_io VDDA ) ( u_rocc_mem_resp_data_o_2_.u_io VDDA ) ( u_rocc_mem_resp_data_o_1_.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VDDIO_Q_RING ( u_vzz_9 VDDIO_Q ) ( u_rocc_mem_resp_data_o_5_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_4_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_3_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_2_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_1_.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VDDIO_RING ( u_vzz_9 VDDIO ) ( u_rocc_mem_resp_data_o_5_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_4_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_3_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_2_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_1_.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VSSA_RING ( u_vzz_9 VSSA ) ( u_rocc_mem_resp_data_o_5_.u_io VSSA ) ( u_rocc_mem_resp_data_o_4_.u_io VSSA ) ( u_rocc_mem_resp_data_o_3_.u_io VSSA ) ( u_rocc_mem_resp_data_o_2_.u_io VSSA ) ( u_rocc_mem_resp_data_o_1_.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VSSD_RING ( u_vzz_9 VSSD ) ( u_rocc_mem_resp_data_o_5_.u_io VSSD ) ( u_rocc_mem_resp_data_o_4_.u_io VSSD ) ( u_rocc_mem_resp_data_o_3_.u_io VSSD ) ( u_rocc_mem_resp_data_o_2_.u_io VSSD ) ( u_rocc_mem_resp_data_o_1_.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VSSIO_Q_RING ( u_vzz_9 VSSIO_Q ) ( u_rocc_mem_resp_data_o_5_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_4_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_3_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_2_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_1_.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VSSIO_RING ( u_vzz_9 VSSIO ) ( u_rocc_mem_resp_data_o_5_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_4_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_3_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_2_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_1_.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_1_.u_io.VSWITCH_RING ( u_vzz_9 VSWITCH ) ( u_rocc_mem_resp_data_o_5_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_4_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_3_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_2_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_1_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_11_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_10_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_19_.u_io VCCD ) ( u_rocc_mem_resp_data_o_18_.u_io VCCD ) ( u_rocc_mem_resp_data_o_17_.u_io VCCD ) ( u_rocc_mem_resp_data_o_16_.u_io VCCD ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_19_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_18_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_17_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_16_.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDA ) ( u_rocc_mem_resp_data_o_18_.u_io VDDA ) ( u_rocc_mem_resp_data_o_17_.u_io VDDA ) ( u_rocc_mem_resp_data_o_16_.u_io VDDA ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_18_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_17_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_16_.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_19_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_18_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_17_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_16_.u_io VDDIO ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSA ) ( u_rocc_mem_resp_data_o_18_.u_io VSSA ) ( u_rocc_mem_resp_data_o_17_.u_io VSSA ) ( u_rocc_mem_resp_data_o_16_.u_io VSSA ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSD ) ( u_rocc_mem_resp_data_o_18_.u_io VSSD ) ( u_rocc_mem_resp_data_o_17_.u_io VSSD ) ( u_rocc_mem_resp_data_o_16_.u_io VSSD ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_18_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_17_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_16_.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_19_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_18_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_17_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_16_.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_16_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_19_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_18_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_17_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_16_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VCCD_RING ( u_vzz_9 VCCD ) ( u_rocc_mem_resp_data_o_5_.u_io VCCD ) ( u_rocc_mem_resp_data_o_4_.u_io VCCD ) ( u_rocc_mem_resp_data_o_3_.u_io VCCD ) ( u_rocc_mem_resp_data_o_2_.u_io VCCD ) ( u_rocc_mem_resp_data_o_1_.u_io VCCD ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VCCHIB_RING ( u_vzz_9 VCCHIB ) ( u_rocc_mem_resp_data_o_5_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_4_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_3_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_2_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_1_.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VDDA_RING ( u_vzz_9 VDDA ) ( u_rocc_mem_resp_data_o_5_.u_io VDDA ) ( u_rocc_mem_resp_data_o_4_.u_io VDDA ) ( u_rocc_mem_resp_data_o_3_.u_io VDDA ) ( u_rocc_mem_resp_data_o_2_.u_io VDDA ) ( u_rocc_mem_resp_data_o_1_.u_io VDDA ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VDDIO_Q_RING ( u_vzz_9 VDDIO_Q ) ( u_rocc_mem_resp_data_o_5_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_4_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_3_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_2_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_1_.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VDDIO_RING ( u_vzz_9 VDDIO ) ( u_rocc_mem_resp_data_o_5_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_4_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_3_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_2_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_1_.u_io VDDIO ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VSSA_RING ( u_vzz_9 VSSA ) ( u_rocc_mem_resp_data_o_5_.u_io VSSA ) ( u_rocc_mem_resp_data_o_4_.u_io VSSA ) ( u_rocc_mem_resp_data_o_3_.u_io VSSA ) ( u_rocc_mem_resp_data_o_2_.u_io VSSA ) ( u_rocc_mem_resp_data_o_1_.u_io VSSA ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VSSD_RING ( u_vzz_9 VSSD ) ( u_rocc_mem_resp_data_o_5_.u_io VSSD ) ( u_rocc_mem_resp_data_o_4_.u_io VSSD ) ( u_rocc_mem_resp_data_o_3_.u_io VSSD ) ( u_rocc_mem_resp_data_o_2_.u_io VSSD ) ( u_rocc_mem_resp_data_o_1_.u_io VSSD ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VSSIO_Q_RING ( u_vzz_9 VSSIO_Q ) ( u_rocc_mem_resp_data_o_5_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_4_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_3_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_2_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_1_.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VSSIO_RING ( u_vzz_9 VSSIO ) ( u_rocc_mem_resp_data_o_5_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_4_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_3_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_2_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_1_.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_1_.u_io.VSWITCH_RING ( u_vzz_9 VSWITCH ) ( u_rocc_mem_resp_data_o_5_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_4_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_3_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_2_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_1_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_29_.u_io VCCD ) ( u_rocc_mem_resp_data_o_28_.u_io VCCD ) ( u_rocc_mem_resp_data_o_27_.u_io VCCD ) ( u_rocc_mem_resp_data_o_26_.u_io VCCD ) ( u_rocc_mem_resp_data_o_25_.u_io VCCD ) ( u_rocc_mem_resp_data_o_24_.u_io VCCD ) ( u_rocc_mem_resp_data_o_23_.u_io VCCD )
-      ( u_rocc_mem_resp_data_o_22_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VCCD ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_29_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_28_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_27_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_26_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_25_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_24_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_23_.u_io VCCHIB )
-      ( u_rocc_mem_resp_data_o_22_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_29_.u_io VDDA ) ( u_rocc_mem_resp_data_o_28_.u_io VDDA ) ( u_rocc_mem_resp_data_o_27_.u_io VDDA ) ( u_rocc_mem_resp_data_o_26_.u_io VDDA ) ( u_rocc_mem_resp_data_o_25_.u_io VDDA ) ( u_rocc_mem_resp_data_o_24_.u_io VDDA ) ( u_rocc_mem_resp_data_o_23_.u_io VDDA )
-      ( u_rocc_mem_resp_data_o_22_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VDDA ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_29_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_28_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_27_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_26_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_25_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_24_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_23_.u_io VDDIO_Q )
-      ( u_rocc_mem_resp_data_o_22_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_29_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_28_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_27_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_26_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_25_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_24_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_23_.u_io VDDIO )
-      ( u_rocc_mem_resp_data_o_22_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VDDIO ) + USE POWER ;
     - u_rocc_mem_resp_data_o_22_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_29_.u_io VSSA ) ( u_rocc_mem_resp_data_o_28_.u_io VSSA ) ( u_rocc_mem_resp_data_o_27_.u_io VSSA ) ( u_rocc_mem_resp_data_o_26_.u_io VSSA ) ( u_rocc_mem_resp_data_o_25_.u_io VSSA ) ( u_rocc_mem_resp_data_o_24_.u_io VSSA ) ( u_rocc_mem_resp_data_o_23_.u_io VSSA )
-      ( u_rocc_mem_resp_data_o_22_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VSSA ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_22_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_29_.u_io VSSD ) ( u_rocc_mem_resp_data_o_28_.u_io VSSD ) ( u_rocc_mem_resp_data_o_27_.u_io VSSD ) ( u_rocc_mem_resp_data_o_26_.u_io VSSD ) ( u_rocc_mem_resp_data_o_25_.u_io VSSD ) ( u_rocc_mem_resp_data_o_24_.u_io VSSD ) ( u_rocc_mem_resp_data_o_23_.u_io VSSD )
-      ( u_rocc_mem_resp_data_o_22_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VSSD ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_22_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_29_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_28_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_27_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_26_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_25_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_24_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_23_.u_io VSSIO_Q )
-      ( u_rocc_mem_resp_data_o_22_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_22_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_29_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_28_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_27_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_26_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_25_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_24_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_23_.u_io VSSIO )
-      ( u_rocc_mem_resp_data_o_22_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_22_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_29_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_28_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_27_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_26_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_25_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_24_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_23_.u_io VSWITCH )
-      ( u_rocc_mem_resp_data_o_22_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_22_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_37_.u_io VCCD ) ( u_rocc_mem_resp_data_o_36_.u_io VCCD ) ( u_rocc_mem_resp_data_o_35_.u_io VCCD ) ( u_rocc_mem_resp_data_o_34_.u_io VCCD ) ( u_rocc_mem_resp_data_o_33_.u_io VCCD ) ( u_rocc_mem_resp_data_o_32_.u_io VCCD ) ( u_rocc_mem_resp_data_o_31_.u_io VCCD )
-      ( u_rocc_mem_resp_data_o_30_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VCCD ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_37_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_36_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_35_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_34_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_33_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_32_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_31_.u_io VCCHIB )
-      ( u_rocc_mem_resp_data_o_30_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_37_.u_io VDDA ) ( u_rocc_mem_resp_data_o_36_.u_io VDDA ) ( u_rocc_mem_resp_data_o_35_.u_io VDDA ) ( u_rocc_mem_resp_data_o_34_.u_io VDDA ) ( u_rocc_mem_resp_data_o_33_.u_io VDDA ) ( u_rocc_mem_resp_data_o_32_.u_io VDDA ) ( u_rocc_mem_resp_data_o_31_.u_io VDDA )
-      ( u_rocc_mem_resp_data_o_30_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VDDA ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_37_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_36_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_35_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_34_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_33_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_32_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_31_.u_io VDDIO_Q )
-      ( u_rocc_mem_resp_data_o_30_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_37_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_36_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_35_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_34_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_33_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_32_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_31_.u_io VDDIO )
-      ( u_rocc_mem_resp_data_o_30_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VDDIO ) + USE POWER ;
     - u_rocc_mem_resp_data_o_30_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_37_.u_io VSSA ) ( u_rocc_mem_resp_data_o_36_.u_io VSSA ) ( u_rocc_mem_resp_data_o_35_.u_io VSSA ) ( u_rocc_mem_resp_data_o_34_.u_io VSSA ) ( u_rocc_mem_resp_data_o_33_.u_io VSSA ) ( u_rocc_mem_resp_data_o_32_.u_io VSSA ) ( u_rocc_mem_resp_data_o_31_.u_io VSSA )
-      ( u_rocc_mem_resp_data_o_30_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VSSA ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_30_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_37_.u_io VSSD ) ( u_rocc_mem_resp_data_o_36_.u_io VSSD ) ( u_rocc_mem_resp_data_o_35_.u_io VSSD ) ( u_rocc_mem_resp_data_o_34_.u_io VSSD ) ( u_rocc_mem_resp_data_o_33_.u_io VSSD ) ( u_rocc_mem_resp_data_o_32_.u_io VSSD ) ( u_rocc_mem_resp_data_o_31_.u_io VSSD )
-      ( u_rocc_mem_resp_data_o_30_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VSSD ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_30_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_37_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_36_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_35_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_34_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_33_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_32_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_31_.u_io VSSIO_Q )
-      ( u_rocc_mem_resp_data_o_30_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_30_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_37_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_36_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_35_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_34_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_33_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_32_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_31_.u_io VSSIO )
-      ( u_rocc_mem_resp_data_o_30_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_30_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_37_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_36_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_35_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_34_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_33_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_32_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_31_.u_io VSWITCH )
-      ( u_rocc_mem_resp_data_o_30_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_30_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_45_.u_io VCCD ) ( u_rocc_mem_resp_data_o_44_.u_io VCCD ) ( u_rocc_mem_resp_data_o_43_.u_io VCCD ) ( u_rocc_mem_resp_data_o_42_.u_io VCCD ) ( u_rocc_mem_resp_data_o_41_.u_io VCCD ) ( u_rocc_mem_resp_data_o_40_.u_io VCCD ) ( u_rocc_mem_resp_data_o_39_.u_io VCCD )
-      ( u_rocc_mem_resp_data_o_38_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VCCD ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_45_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_44_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_43_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_42_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_41_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_40_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_39_.u_io VCCHIB )
-      ( u_rocc_mem_resp_data_o_38_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_45_.u_io VDDA ) ( u_rocc_mem_resp_data_o_44_.u_io VDDA ) ( u_rocc_mem_resp_data_o_43_.u_io VDDA ) ( u_rocc_mem_resp_data_o_42_.u_io VDDA ) ( u_rocc_mem_resp_data_o_41_.u_io VDDA ) ( u_rocc_mem_resp_data_o_40_.u_io VDDA ) ( u_rocc_mem_resp_data_o_39_.u_io VDDA )
-      ( u_rocc_mem_resp_data_o_38_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VDDA ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_45_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_44_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_43_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_42_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_41_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_40_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_39_.u_io VDDIO_Q )
-      ( u_rocc_mem_resp_data_o_38_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_45_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_44_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_43_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_42_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_41_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_40_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_39_.u_io VDDIO )
-      ( u_rocc_mem_resp_data_o_38_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VDDIO ) + USE POWER ;
     - u_rocc_mem_resp_data_o_38_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_45_.u_io VSSA ) ( u_rocc_mem_resp_data_o_44_.u_io VSSA ) ( u_rocc_mem_resp_data_o_43_.u_io VSSA ) ( u_rocc_mem_resp_data_o_42_.u_io VSSA ) ( u_rocc_mem_resp_data_o_41_.u_io VSSA ) ( u_rocc_mem_resp_data_o_40_.u_io VSSA ) ( u_rocc_mem_resp_data_o_39_.u_io VSSA )
-      ( u_rocc_mem_resp_data_o_38_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VSSA ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_38_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_45_.u_io VSSD ) ( u_rocc_mem_resp_data_o_44_.u_io VSSD ) ( u_rocc_mem_resp_data_o_43_.u_io VSSD ) ( u_rocc_mem_resp_data_o_42_.u_io VSSD ) ( u_rocc_mem_resp_data_o_41_.u_io VSSD ) ( u_rocc_mem_resp_data_o_40_.u_io VSSD ) ( u_rocc_mem_resp_data_o_39_.u_io VSSD )
-      ( u_rocc_mem_resp_data_o_38_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VSSD ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_38_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_45_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_44_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_43_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_42_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_41_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_40_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_39_.u_io VSSIO_Q )
-      ( u_rocc_mem_resp_data_o_38_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_38_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_45_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_44_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_43_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_42_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_41_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_40_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_39_.u_io VSSIO )
-      ( u_rocc_mem_resp_data_o_38_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_38_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_45_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_44_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_43_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_42_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_41_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_40_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_39_.u_io VSWITCH )
-      ( u_rocc_mem_resp_data_o_38_.u_io VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_38_.u_io VSWITCH ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_53_.u_io VCCD ) ( u_rocc_mem_resp_data_o_52_.u_io VCCD ) ( u_rocc_mem_resp_data_o_51_.u_io VCCD ) ( u_rocc_mem_resp_data_o_50_.u_io VCCD ) ( u_rocc_mem_resp_data_o_49_.u_io VCCD ) ( u_rocc_mem_resp_data_o_48_.u_io VCCD ) ( u_rocc_mem_resp_data_o_47_.u_io VCCD )
-      ( u_rocc_mem_resp_data_o_46_.u_io VCCD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VCCD ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_53_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_52_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_51_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_50_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_49_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_48_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_47_.u_io VCCHIB )
-      ( u_rocc_mem_resp_data_o_46_.u_io VCCHIB ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VCCHIB ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_53_.u_io VDDA ) ( u_rocc_mem_resp_data_o_52_.u_io VDDA ) ( u_rocc_mem_resp_data_o_51_.u_io VDDA ) ( u_rocc_mem_resp_data_o_50_.u_io VDDA ) ( u_rocc_mem_resp_data_o_49_.u_io VDDA ) ( u_rocc_mem_resp_data_o_48_.u_io VDDA ) ( u_rocc_mem_resp_data_o_47_.u_io VDDA )
-      ( u_rocc_mem_resp_data_o_46_.u_io VDDA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VDDA ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_53_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_52_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_51_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_50_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_49_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_48_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_47_.u_io VDDIO_Q )
-      ( u_rocc_mem_resp_data_o_46_.u_io VDDIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VDDIO_Q ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_53_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_52_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_51_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_50_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_49_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_48_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_47_.u_io VDDIO )
-      ( u_rocc_mem_resp_data_o_46_.u_io VDDIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VDDIO ) + USE POWER ;
     - u_rocc_mem_resp_data_o_46_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_53_.u_io VSSA ) ( u_rocc_mem_resp_data_o_52_.u_io VSSA ) ( u_rocc_mem_resp_data_o_51_.u_io VSSA ) ( u_rocc_mem_resp_data_o_50_.u_io VSSA ) ( u_rocc_mem_resp_data_o_49_.u_io VSSA ) ( u_rocc_mem_resp_data_o_48_.u_io VSSA ) ( u_rocc_mem_resp_data_o_47_.u_io VSSA )
-      ( u_rocc_mem_resp_data_o_46_.u_io VSSA ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VSSA ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_46_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_53_.u_io VSSD ) ( u_rocc_mem_resp_data_o_52_.u_io VSSD ) ( u_rocc_mem_resp_data_o_51_.u_io VSSD ) ( u_rocc_mem_resp_data_o_50_.u_io VSSD ) ( u_rocc_mem_resp_data_o_49_.u_io VSSD ) ( u_rocc_mem_resp_data_o_48_.u_io VSSD ) ( u_rocc_mem_resp_data_o_47_.u_io VSSD )
-      ( u_rocc_mem_resp_data_o_46_.u_io VSSD ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VSSD ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_46_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_53_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_52_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_51_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_50_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_49_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_48_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_47_.u_io VSSIO_Q )
-      ( u_rocc_mem_resp_data_o_46_.u_io VSSIO_Q ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VSSIO_Q ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_46_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_53_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_52_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_51_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_50_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_49_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_48_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_47_.u_io VSSIO )
-      ( u_rocc_mem_resp_data_o_46_.u_io VSSIO ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VSSIO ) + USE GROUND ;
     - u_rocc_mem_resp_data_o_46_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_53_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_52_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_51_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_50_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_49_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_48_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_47_.u_io VSWITCH )
-      ( u_rocc_mem_resp_data_o_46_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_56_.u_io VCCD ) ( u_rocc_mem_resp_data_o_57_.u_io VCCD ) ( u_rocc_mem_resp_data_o_58_.u_io VCCD ) ( IO_CORNER_NORTH_WEST_INST VCCD ) ( u_rocc_mem_resp_data_o_59_.u_io VCCD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_56_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_57_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_58_.u_io VCCHIB ) ( IO_CORNER_NORTH_WEST_INST VCCHIB ) ( u_rocc_mem_resp_data_o_59_.u_io VCCHIB ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDA ) ( u_rocc_mem_resp_data_o_57_.u_io VDDA ) ( u_rocc_mem_resp_data_o_58_.u_io VDDA ) ( IO_CORNER_NORTH_WEST_INST VDDA ) ( u_rocc_mem_resp_data_o_59_.u_io VDDA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_57_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_58_.u_io VDDIO_Q ) ( IO_CORNER_NORTH_WEST_INST VDDIO_Q ) ( u_rocc_mem_resp_data_o_59_.u_io VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_57_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_58_.u_io VDDIO ) ( IO_CORNER_NORTH_WEST_INST VDDIO ) ( u_rocc_mem_resp_data_o_59_.u_io VDDIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSA ) ( u_rocc_mem_resp_data_o_57_.u_io VSSA ) ( u_rocc_mem_resp_data_o_58_.u_io VSSA ) ( IO_CORNER_NORTH_WEST_INST VSSA ) ( u_rocc_mem_resp_data_o_59_.u_io VSSA ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSD ) ( u_rocc_mem_resp_data_o_57_.u_io VSSD ) ( u_rocc_mem_resp_data_o_58_.u_io VSSD ) ( IO_CORNER_NORTH_WEST_INST VSSD ) ( u_rocc_mem_resp_data_o_59_.u_io VSSD ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_57_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_58_.u_io VSSIO_Q ) ( IO_CORNER_NORTH_WEST_INST VSSIO_Q ) ( u_rocc_mem_resp_data_o_59_.u_io VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_57_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_58_.u_io VSSIO ) ( IO_CORNER_NORTH_WEST_INST VSSIO ) ( u_rocc_mem_resp_data_o_59_.u_io VSSIO ) + USE SIGNAL ;
-    - u_rocc_mem_resp_data_o_59_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_56_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_57_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_58_.u_io VSWITCH ) ( IO_CORNER_NORTH_WEST_INST VSWITCH ) ( u_rocc_mem_resp_data_o_59_.u_io VSWITCH ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VCCD_RING ( u_vss_1 VCCD ) ( u_rocc_resp_ready.u_io VCCD ) ( u_rocc_resp_data_i.u_io\[7\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[6\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[5\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[4\].u_in VCCD ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VCCHIB_RING ( u_vss_1 VCCHIB ) ( u_rocc_resp_ready.u_io VCCHIB ) ( u_rocc_resp_data_i.u_io\[7\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[6\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[5\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[4\].u_in VCCHIB ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDA_RING ( u_vss_1 VDDA ) ( u_rocc_resp_ready.u_io VDDA ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDA ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDIO_Q_RING ( u_vss_1 VDDIO_Q ) ( u_rocc_resp_ready.u_io VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDIO_Q ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDIO_RING ( u_vss_1 VDDIO ) ( u_rocc_resp_ready.u_io VDDIO ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDIO ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSA_RING ( u_vss_1 VSSA ) ( u_rocc_resp_ready.u_io VSSA ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSA ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSD_RING ( u_vss_1 VSSD ) ( u_rocc_resp_ready.u_io VSSD ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSD ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSIO_Q_RING ( u_vss_1 VSSIO_Q ) ( u_rocc_resp_ready.u_io VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSIO_Q ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSIO_RING ( u_vss_1 VSSIO ) ( u_rocc_resp_ready.u_io VSSIO ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSIO ) + USE SIGNAL ;
-    - u_rocc_resp_data_i.u_io\[4\].u_in.VSWITCH_RING ( u_vss_1 VSWITCH ) ( u_rocc_resp_ready.u_io VSWITCH ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSWITCH ) + USE SIGNAL ;
+      ( u_rocc_mem_resp_data_o_46_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VCCD_RING ( u_rocc_mem_resp_data_o_56_.u_io VCCD ) ( u_rocc_mem_resp_data_o_57_.u_io VCCD ) ( u_rocc_mem_resp_data_o_58_.u_io VCCD ) ( IO_CORNER_NORTH_WEST_INST VCCD ) ( u_rocc_mem_resp_data_o_59_.u_io VCCD ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VCCHIB_RING ( u_rocc_mem_resp_data_o_56_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_57_.u_io VCCHIB ) ( u_rocc_mem_resp_data_o_58_.u_io VCCHIB ) ( IO_CORNER_NORTH_WEST_INST VCCHIB ) ( u_rocc_mem_resp_data_o_59_.u_io VCCHIB ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VDDA_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDA ) ( u_rocc_mem_resp_data_o_57_.u_io VDDA ) ( u_rocc_mem_resp_data_o_58_.u_io VDDA ) ( IO_CORNER_NORTH_WEST_INST VDDA ) ( u_rocc_mem_resp_data_o_59_.u_io VDDA ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VDDIO_Q_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_57_.u_io VDDIO_Q ) ( u_rocc_mem_resp_data_o_58_.u_io VDDIO_Q ) ( IO_CORNER_NORTH_WEST_INST VDDIO_Q ) ( u_rocc_mem_resp_data_o_59_.u_io VDDIO_Q ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VDDIO_RING ( u_rocc_mem_resp_data_o_56_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_57_.u_io VDDIO ) ( u_rocc_mem_resp_data_o_58_.u_io VDDIO ) ( IO_CORNER_NORTH_WEST_INST VDDIO ) ( u_rocc_mem_resp_data_o_59_.u_io VDDIO ) + USE POWER ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VSSA_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSA ) ( u_rocc_mem_resp_data_o_57_.u_io VSSA ) ( u_rocc_mem_resp_data_o_58_.u_io VSSA ) ( IO_CORNER_NORTH_WEST_INST VSSA ) ( u_rocc_mem_resp_data_o_59_.u_io VSSA ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VSSD_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSD ) ( u_rocc_mem_resp_data_o_57_.u_io VSSD ) ( u_rocc_mem_resp_data_o_58_.u_io VSSD ) ( IO_CORNER_NORTH_WEST_INST VSSD ) ( u_rocc_mem_resp_data_o_59_.u_io VSSD ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VSSIO_Q_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_57_.u_io VSSIO_Q ) ( u_rocc_mem_resp_data_o_58_.u_io VSSIO_Q ) ( IO_CORNER_NORTH_WEST_INST VSSIO_Q ) ( u_rocc_mem_resp_data_o_59_.u_io VSSIO_Q ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VSSIO_RING ( u_rocc_mem_resp_data_o_56_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_57_.u_io VSSIO ) ( u_rocc_mem_resp_data_o_58_.u_io VSSIO ) ( IO_CORNER_NORTH_WEST_INST VSSIO ) ( u_rocc_mem_resp_data_o_59_.u_io VSSIO ) + USE GROUND ;
+    - u_rocc_mem_resp_data_o_59_.u_io.VSWITCH_RING ( u_rocc_mem_resp_data_o_56_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_57_.u_io VSWITCH ) ( u_rocc_mem_resp_data_o_58_.u_io VSWITCH ) ( IO_CORNER_NORTH_WEST_INST VSWITCH ) ( u_rocc_mem_resp_data_o_59_.u_io VSWITCH ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VCCD_RING ( u_vss_1 VCCD ) ( u_rocc_resp_ready.u_io VCCD ) ( u_rocc_resp_data_i.u_io\[7\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[6\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[5\].u_in VCCD ) ( u_rocc_resp_data_i.u_io\[4\].u_in VCCD ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VCCHIB_RING ( u_vss_1 VCCHIB ) ( u_rocc_resp_ready.u_io VCCHIB ) ( u_rocc_resp_data_i.u_io\[7\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[6\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[5\].u_in VCCHIB ) ( u_rocc_resp_data_i.u_io\[4\].u_in VCCHIB ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDA_RING ( u_vss_1 VDDA ) ( u_rocc_resp_ready.u_io VDDA ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDA ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDA ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDIO_Q_RING ( u_vss_1 VDDIO_Q ) ( u_rocc_resp_ready.u_io VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDIO_Q ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDIO_Q ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VDDIO_RING ( u_vss_1 VDDIO ) ( u_rocc_resp_ready.u_io VDDIO ) ( u_rocc_resp_data_i.u_io\[7\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[6\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[5\].u_in VDDIO ) ( u_rocc_resp_data_i.u_io\[4\].u_in VDDIO ) + USE POWER ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSA_RING ( u_vss_1 VSSA ) ( u_rocc_resp_ready.u_io VSSA ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSA ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSA ) + USE GROUND ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSD_RING ( u_vss_1 VSSD ) ( u_rocc_resp_ready.u_io VSSD ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSD ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSD ) + USE GROUND ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSIO_Q_RING ( u_vss_1 VSSIO_Q ) ( u_rocc_resp_ready.u_io VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSIO_Q ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSIO_Q ) + USE GROUND ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VSSIO_RING ( u_vss_1 VSSIO ) ( u_rocc_resp_ready.u_io VSSIO ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSSIO ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSSIO ) + USE GROUND ;
+    - u_rocc_resp_data_i.u_io\[4\].u_in.VSWITCH_RING ( u_vss_1 VSWITCH ) ( u_rocc_resp_ready.u_io VSWITCH ) ( u_rocc_resp_data_i.u_io\[7\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[6\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[5\].u_in VSWITCH ) ( u_rocc_resp_data_i.u_io\[4\].u_in VSWITCH ) + USE POWER ;
 END SPECIALNETS
 NETS 631 ;
     - IO_CORNER_NORTH_EAST_INST.AMUXBUS_A_RING ( IO_CORNER_NORTH_EAST_INST AMUXBUS_A ) + USE SIGNAL ;

--- a/src/pad/test/skywater130_overlapping_filler.defok
+++ b/src/pad/test/skywater130_overlapping_filler.defok
@@ -3221,20 +3221,20 @@ PINS 722 ;
     - porb_h + NET porb_h + DIRECTION INPUT + USE SIGNAL ;
     - resetb + NET resetb + DIRECTION INPUT + USE SIGNAL ;
     - resetb_core_h + NET resetb_core_h + DIRECTION OUTPUT + USE SIGNAL ;
-    - vccd + NET vccd + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vccd1 + NET vccd1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vccd2 + NET vccd2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda + NET vdda + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda1 + NET vdda1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vdda2 + NET vdda2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vddio + NET vddio + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa + NET vssa + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa1 + NET vssa1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssa2 + NET vssa2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd + NET vssd + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd1 + NET vssd1 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssd2 + NET vssd2 + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
-    - vssio + NET vssio + SPECIAL + DIRECTION INOUT + USE SIGNAL ;
+    - vccd + NET vccd + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vccd1 + NET vccd1 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vccd2 + NET vccd2 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda + NET vdda + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda1 + NET vdda1 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vdda2 + NET vdda2 + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vddio + NET vddio + SPECIAL + DIRECTION INOUT + USE POWER ;
+    - vssa + NET vssa + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssa1 + NET vssa1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssa2 + NET vssa2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd + NET vssd + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd1 + NET vssd1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssd2 + NET vssd2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vssio + NET vssio + SPECIAL + DIRECTION INOUT + USE GROUND ;
 END PINS
 SPECIALNETS 18 ;
     - mprj_pads.analog_a ( IO_FILL_IO_SOUTH_0_50 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_40 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_55 AMUXBUS_A ) ( connect_0 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_20 AMUXBUS_A ) ( IO_FILL_IO_SOUTH_0_0 AMUXBUS_A ) ( IO_CORNER_SOUTH_WEST_INST AMUXBUS_A )
@@ -3524,7 +3524,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[3\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[2\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[1\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[17\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[16\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[15\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[14\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[13\] VDDIO_Q )
       ( mprj_pads.area1_io_pad\[12\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[11\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[10\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[0\] VDDIO_Q ) ( mgmt_vssio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vssd_lvclmap_pad VDDIO_Q ) ( mgmt_vssa_hvclamp_pad VDDIO_Q )
       ( mgmt_vddio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vdda_hvclamp_pad VDDIO_Q ) ( mgmt_vccd_lvclamp_pad VDDIO_Q ) ( mgmt_corner\[1\] VDDIO_Q ) ( mgmt_corner\[0\] VDDIO_Q ) ( gpio_pad VDDIO_Q ) ( flash_io1_pad VDDIO_Q )
-      ( flash_io0_pad VDDIO_Q ) ( flash_csb_pad VDDIO_Q ) ( flash_clk_pad VDDIO_Q ) ( clock_pad VDDIO_Q ) + USE SIGNAL ;
+      ( flash_io0_pad VDDIO_Q ) ( flash_csb_pad VDDIO_Q ) ( flash_clk_pad VDDIO_Q ) ( clock_pad VDDIO_Q ) + USE POWER ;
     - mprj_pads.vssio_q ( IO_FILL_IO_SOUTH_0_50 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_40 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_55 VSSIO_Q ) ( connect_0 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_20 VSSIO_Q ) ( IO_FILL_IO_SOUTH_0_0 VSSIO_Q ) ( IO_CORNER_SOUTH_WEST_INST VSSIO_Q )
       ( connect_1 VSSIO_Q ) ( IO_FILL_IO_WEST_0_0 VSSIO_Q ) ( IO_FILL_IO_WEST_0_20 VSSIO_Q ) ( connect_2 VSSIO_Q ) ( IO_FILL_IO_WEST_0_40 VSSIO_Q ) ( connect_3 VSSIO_Q ) ( IO_FILL_IO_EAST_1_80 VSSIO_Q ) ( IO_FILL_IO_EAST_1_60 VSSIO_Q )
       ( IO_FILL_IO_EAST_1_40 VSSIO_Q ) ( IO_FILL_IO_EAST_1_20 VSSIO_Q ) ( IO_FILL_IO_EAST_1_0 VSSIO_Q ) ( brk_vccd_0 VSSIO_Q ) ( IO_FILL_IO_WEST_0_60 VSSIO_Q ) ( connect_4 VSSIO_Q ) ( IO_FILL_IO_EAST_1_100 VSSIO_Q ) ( brk_vdda_0 VSSIO_Q )
@@ -3620,7 +3620,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[3\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[2\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[1\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[17\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[16\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[15\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[14\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[13\] VSSIO_Q )
       ( mprj_pads.area1_io_pad\[12\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[11\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[10\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[0\] VSSIO_Q ) ( mgmt_vssio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vssd_lvclmap_pad VSSIO_Q ) ( mgmt_vssa_hvclamp_pad VSSIO_Q )
       ( mgmt_vddio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vdda_hvclamp_pad VSSIO_Q ) ( mgmt_vccd_lvclamp_pad VSSIO_Q ) ( mgmt_corner\[1\] VSSIO_Q ) ( mgmt_corner\[0\] VSSIO_Q ) ( gpio_pad VSSIO_Q ) ( flash_io1_pad VSSIO_Q )
-      ( flash_io0_pad VSSIO_Q ) ( flash_csb_pad VSSIO_Q ) ( flash_clk_pad VSSIO_Q ) ( clock_pad VSSIO_Q ) + USE SIGNAL ;
+      ( flash_io0_pad VSSIO_Q ) ( flash_csb_pad VSSIO_Q ) ( flash_clk_pad VSSIO_Q ) ( clock_pad VSSIO_Q ) + USE GROUND ;
     - vccd ( PIN vccd ) ( IO_FILL_IO_SOUTH_0_50 VCCD ) ( IO_FILL_IO_SOUTH_0_50 VCCHIB ) ( IO_FILL_IO_SOUTH_0_40 VCCD ) ( IO_FILL_IO_SOUTH_0_40 VCCHIB ) ( IO_FILL_IO_SOUTH_0_55 VCCD ) ( IO_FILL_IO_SOUTH_0_55 VCCHIB )
       ( connect_0 VCCD ) ( connect_0 VCCHIB ) ( IO_FILL_IO_SOUTH_0_20 VCCD ) ( IO_FILL_IO_SOUTH_0_20 VCCHIB ) ( IO_FILL_IO_SOUTH_0_0 VCCD ) ( IO_FILL_IO_SOUTH_0_0 VCCHIB ) ( IO_CORNER_SOUTH_WEST_INST VCCD ) ( IO_CORNER_SOUTH_WEST_INST VCCHIB )
       ( connect_1 VCCD ) ( connect_1 VCCHIB ) ( IO_FILL_IO_WEST_0_0 VCCD ) ( IO_FILL_IO_WEST_0_0 VCCHIB ) ( IO_FILL_IO_WEST_0_20 VCCD ) ( IO_FILL_IO_WEST_0_20 VCCHIB ) ( connect_2 VCCD ) ( connect_2 VCCHIB )
@@ -3749,7 +3749,7 @@ SPECIALNETS 18 ;
       ( mgmt_corner\[0\] VCCHIB ) ( mgmt_corner\[0\] VCCD ) ( gpio_pad VCCHIB ) ( gpio_pad VCCD ) ( gpio_pad ENABLE_VDDIO ) ( flash_io1_pad VCCHIB ) ( flash_io1_pad VCCD ) ( flash_io1_pad ENABLE_VDDIO )
       ( flash_io0_pad VCCHIB ) ( flash_io0_pad VCCD ) ( flash_io0_pad ENABLE_VDDIO ) ( flash_csb_pad VCCHIB ) ( flash_csb_pad VCCD ) ( flash_csb_pad ENABLE_VDDIO ) ( flash_csb_pad DM[2] ) ( flash_csb_pad DM[1] )
       ( flash_clk_pad VCCHIB ) ( flash_clk_pad VCCD ) ( flash_clk_pad ENABLE_VDDIO ) ( flash_clk_pad DM[2] ) ( flash_clk_pad DM[1] ) ( clock_pad VCCHIB ) ( clock_pad VCCD ) ( clock_pad OE_N )
-      ( clock_pad ENABLE_VDDIO ) ( clock_pad DM[0] ) + USE SIGNAL ;
+      ( clock_pad ENABLE_VDDIO ) ( clock_pad DM[0] ) + USE POWER ;
     - vccd1 ( PIN vccd1 ) ( IO_FILL_IO_EAST_1_0 VCCD ) ( IO_FILL_IO_NORTH_8_0 VCCD ) ( IO_FILL_IO_EAST_1_20 VCCD ) ( IO_FILL_IO_NORTH_8_20 VCCD ) ( IO_FILL_IO_EAST_1_40 VCCD ) ( IO_FILL_IO_NORTH_8_40 VCCD )
       ( IO_FILL_IO_EAST_1_60 VCCD ) ( IO_FILL_IO_NORTH_8_60 VCCD ) ( IO_FILL_IO_EAST_1_80 VCCD ) ( IO_FILL_IO_NORTH_8_80 VCCD ) ( IO_FILL_IO_EAST_1_100 VCCD ) ( IO_FILL_IO_NORTH_8_100 VCCD ) ( IO_FILL_IO_EAST_1_120 VCCD ) ( IO_FILL_IO_NORTH_8_120 VCCD )
       ( IO_FILL_IO_EAST_1_140 VCCD ) ( IO_FILL_IO_NORTH_8_140 VCCD ) ( IO_FILL_IO_EAST_1_160 VCCD ) ( IO_FILL_IO_NORTH_8_160 VCCD ) ( IO_FILL_IO_EAST_21_60 VCCD ) ( IO_FILL_IO_EAST_21_40 VCCD ) ( IO_FILL_IO_EAST_21_20 VCCD ) ( IO_FILL_IO_EAST_20_120 VCCD )
@@ -3783,7 +3783,7 @@ SPECIALNETS 18 ;
       ( user1_vssa_hvclamp_pad\[0\] VCCD ) ( user1_vdda_hvclamp_pad\[1\] VCCD ) ( user1_vdda_hvclamp_pad\[0\] VCCD ) ( user1_vccd_lvclamp_pad VCCD ) ( user1_vccd_lvclamp_pad DRN_LVC2 ) ( user1_vccd_lvclamp_pad DRN_LVC1 ) ( user1_corner VCCD ) ( mprj_pads.area1_io_pad\[9\] VCCD )
       ( mprj_pads.area1_io_pad\[8\] VCCD ) ( mprj_pads.area1_io_pad\[7\] VCCD ) ( mprj_pads.area1_io_pad\[6\] VCCD ) ( mprj_pads.area1_io_pad\[5\] VCCD ) ( mprj_pads.area1_io_pad\[4\] VCCD ) ( mprj_pads.area1_io_pad\[3\] VCCD ) ( mprj_pads.area1_io_pad\[2\] VCCD ) ( mprj_pads.area1_io_pad\[1\] VCCD )
       ( mprj_pads.area1_io_pad\[17\] VCCD ) ( mprj_pads.area1_io_pad\[16\] VCCD ) ( mprj_pads.area1_io_pad\[15\] VCCD ) ( mprj_pads.area1_io_pad\[14\] VCCD ) ( mprj_pads.area1_io_pad\[13\] VCCD ) ( mprj_pads.area1_io_pad\[12\] VCCD ) ( mprj_pads.area1_io_pad\[11\] VCCD ) ( mprj_pads.area1_io_pad\[10\] VCCD )
-      ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE POWER ;
     - vccd2 ( PIN vccd2 ) ( IO_FILL_IO_WEST_3_0 VCCD ) ( IO_FILL_IO_WEST_3_20 VCCD ) ( IO_FILL_IO_WEST_3_40 VCCD ) ( IO_FILL_IO_WEST_3_60 VCCD ) ( IO_FILL_IO_WEST_3_80 VCCD ) ( IO_FILL_IO_WEST_3_100 VCCD )
       ( IO_FILL_IO_WEST_3_120 VCCD ) ( IO_FILL_IO_NORTH_0_140 VCCD ) ( IO_FILL_IO_NORTH_0_120 VCCD ) ( IO_FILL_IO_NORTH_0_100 VCCD ) ( IO_FILL_IO_NORTH_0_80 VCCD ) ( IO_FILL_IO_NORTH_0_60 VCCD ) ( IO_FILL_IO_NORTH_0_40 VCCD ) ( brk_vdda_1 VCCD )
       ( IO_FILL_IO_NORTH_0_20 VCCD ) ( IO_FILL_IO_NORTH_0_0 VCCD ) ( IO_CORNER_NORTH_WEST_INST VCCD ) ( IO_FILL_IO_WEST_22_130 VCCD ) ( IO_FILL_IO_WEST_22_120 VCCD ) ( IO_FILL_IO_WEST_22_100 VCCD ) ( IO_FILL_IO_WEST_22_80 VCCD ) ( IO_FILL_IO_WEST_22_60 VCCD )
@@ -3821,7 +3821,7 @@ SPECIALNETS 18 ;
       ( user2_vssd_lvclmap_pad DRN_LVC1 ) ( user2_vssa_hvclamp_pad VCCD ) ( user2_vdda_hvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad DRN_LVC2 ) ( user2_vccd_lvclamp_pad DRN_LVC1 ) ( user2_corner VCCD ) ( mprj_pads.area2_io_pad\[9\] VCCD )
       ( mprj_pads.area2_io_pad\[8\] VCCD ) ( mprj_pads.area2_io_pad\[7\] VCCD ) ( mprj_pads.area2_io_pad\[6\] VCCD ) ( mprj_pads.area2_io_pad\[5\] VCCD ) ( mprj_pads.area2_io_pad\[4\] VCCD ) ( mprj_pads.area2_io_pad\[3\] VCCD ) ( mprj_pads.area2_io_pad\[2\] VCCD ) ( mprj_pads.area2_io_pad\[1\] VCCD )
       ( mprj_pads.area2_io_pad\[19\] VCCD ) ( mprj_pads.area2_io_pad\[18\] VCCD ) ( mprj_pads.area2_io_pad\[17\] VCCD ) ( mprj_pads.area2_io_pad\[16\] VCCD ) ( mprj_pads.area2_io_pad\[15\] VCCD ) ( mprj_pads.area2_io_pad\[14\] VCCD ) ( mprj_pads.area2_io_pad\[13\] VCCD ) ( mprj_pads.area2_io_pad\[12\] VCCD )
-      ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE POWER ;
     - vdda ( PIN vdda ) ( IO_FILL_IO_SOUTH_0_50 VDDA ) ( IO_FILL_IO_SOUTH_0_40 VDDA ) ( IO_FILL_IO_SOUTH_0_55 VDDA ) ( connect_0 VDDA ) ( IO_FILL_IO_SOUTH_0_20 VDDA ) ( IO_FILL_IO_SOUTH_0_0 VDDA )
       ( IO_CORNER_SOUTH_WEST_INST VDDA ) ( connect_1 VDDA ) ( IO_FILL_IO_WEST_0_0 VDDA ) ( IO_FILL_IO_WEST_0_20 VDDA ) ( connect_2 VDDA ) ( IO_FILL_IO_WEST_0_40 VDDA ) ( connect_3 VDDA ) ( IO_FILL_IO_WEST_0_60 VDDA )
       ( connect_4 VDDA ) ( IO_FILL_IO_WEST_0_80 VDDA ) ( connect_5 VDDA ) ( IO_FILL_IO_EAST_0_145 VDDA ) ( IO_FILL_IO_EAST_0_140 VDDA ) ( IO_FILL_IO_EAST_0_120 VDDA ) ( IO_FILL_IO_EAST_0_100 VDDA ) ( IO_FILL_IO_EAST_0_80 VDDA )
@@ -3847,7 +3847,7 @@ SPECIALNETS 18 ;
       ( IO_FILL_IO_SOUTH_1_60 VDDA ) ( IO_FILL_IO_SOUTH_22_0 VDDA ) ( IO_FILL_IO_SOUTH_21_60 VDDA ) ( IO_FILL_IO_SOUTH_18_0 VDDA ) ( IO_FILL_IO_SOUTH_17_65 VDDA ) ( IO_FILL_IO_SOUTH_16_0 VDDA ) ( IO_FILL_IO_SOUTH_15_65 VDDA ) ( IO_FILL_IO_SOUTH_14_0 VDDA )
       ( IO_FILL_IO_SOUTH_13_65 VDDA ) ( IO_FILL_IO_SOUTH_10_0 VDDA ) ( IO_FILL_IO_SOUTH_9_65 VDDA ) ( IO_FILL_IO_SOUTH_12_0 VDDA ) ( IO_FILL_IO_SOUTH_11_65 VDDA ) ( IO_FILL_IO_SOUTH_6_0 VDDA ) ( IO_FILL_IO_SOUTH_5_65 VDDA ) ( resetb_pad VDDA )
       ( mgmt_vssio_hvclamp_pad\[0\] VDDA ) ( mgmt_vssd_lvclmap_pad VDDA ) ( mgmt_vssa_hvclamp_pad VDDA ) ( mgmt_vssa_hvclamp_pad DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VDDA ) ( mgmt_vdda_hvclamp_pad VDDA ) ( mgmt_vdda_hvclamp_pad DRN_HVC ) ( mgmt_vccd_lvclamp_pad VDDA )
-      ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA ) ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE SIGNAL ;
+      ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA ) ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE POWER ;
     - vdda1 ( PIN vdda1 ) ( brk_vccd_0 VDDA ) ( brk_vccd_1 VDDA ) ( IO_FILL_IO_EAST_1_0 VDDA ) ( IO_FILL_IO_NORTH_8_0 VDDA ) ( IO_FILL_IO_EAST_1_20 VDDA ) ( IO_FILL_IO_NORTH_8_20 VDDA )
       ( IO_FILL_IO_EAST_1_40 VDDA ) ( IO_FILL_IO_NORTH_8_40 VDDA ) ( IO_FILL_IO_EAST_1_60 VDDA ) ( IO_FILL_IO_NORTH_8_60 VDDA ) ( IO_FILL_IO_EAST_1_80 VDDA ) ( IO_FILL_IO_NORTH_8_80 VDDA ) ( IO_FILL_IO_EAST_1_100 VDDA ) ( IO_FILL_IO_NORTH_8_100 VDDA )
       ( IO_FILL_IO_EAST_1_120 VDDA ) ( IO_FILL_IO_NORTH_8_120 VDDA ) ( IO_FILL_IO_EAST_1_140 VDDA ) ( IO_FILL_IO_NORTH_8_140 VDDA ) ( IO_FILL_IO_EAST_1_160 VDDA ) ( IO_FILL_IO_NORTH_8_160 VDDA ) ( IO_FILL_IO_EAST_21_60 VDDA ) ( IO_FILL_IO_EAST_21_40 VDDA )
@@ -3881,7 +3881,7 @@ SPECIALNETS 18 ;
       ( user1_vssa_hvclamp_pad\[1\] DRN_HVC ) ( user1_vssa_hvclamp_pad\[0\] VDDA ) ( user1_vssa_hvclamp_pad\[0\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[1\] VDDA ) ( user1_vdda_hvclamp_pad\[1\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[0\] VDDA ) ( user1_vdda_hvclamp_pad\[0\] DRN_HVC ) ( user1_vccd_lvclamp_pad VDDA )
       ( user1_corner VDDA ) ( mprj_pads.area1_io_pad\[9\] VDDA ) ( mprj_pads.area1_io_pad\[8\] VDDA ) ( mprj_pads.area1_io_pad\[7\] VDDA ) ( mprj_pads.area1_io_pad\[6\] VDDA ) ( mprj_pads.area1_io_pad\[5\] VDDA ) ( mprj_pads.area1_io_pad\[4\] VDDA ) ( mprj_pads.area1_io_pad\[3\] VDDA )
       ( mprj_pads.area1_io_pad\[2\] VDDA ) ( mprj_pads.area1_io_pad\[1\] VDDA ) ( mprj_pads.area1_io_pad\[17\] VDDA ) ( mprj_pads.area1_io_pad\[16\] VDDA ) ( mprj_pads.area1_io_pad\[15\] VDDA ) ( mprj_pads.area1_io_pad\[14\] VDDA ) ( mprj_pads.area1_io_pad\[13\] VDDA ) ( mprj_pads.area1_io_pad\[12\] VDDA )
-      ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE POWER ;
     - vdda2 ( PIN vdda2 ) ( brk_vccd_2 VDDA ) ( IO_FILL_IO_WEST_3_0 VDDA ) ( IO_FILL_IO_WEST_3_20 VDDA ) ( IO_FILL_IO_WEST_3_40 VDDA ) ( IO_FILL_IO_WEST_3_60 VDDA ) ( IO_FILL_IO_WEST_3_80 VDDA )
       ( IO_FILL_IO_WEST_3_100 VDDA ) ( IO_FILL_IO_WEST_3_120 VDDA ) ( IO_FILL_IO_NORTH_0_140 VDDA ) ( IO_FILL_IO_NORTH_0_120 VDDA ) ( IO_FILL_IO_NORTH_0_100 VDDA ) ( IO_FILL_IO_NORTH_0_80 VDDA ) ( IO_FILL_IO_NORTH_0_60 VDDA ) ( IO_FILL_IO_NORTH_0_40 VDDA )
       ( IO_FILL_IO_NORTH_0_20 VDDA ) ( IO_FILL_IO_NORTH_0_0 VDDA ) ( IO_CORNER_NORTH_WEST_INST VDDA ) ( IO_FILL_IO_WEST_22_130 VDDA ) ( IO_FILL_IO_WEST_22_120 VDDA ) ( IO_FILL_IO_WEST_22_100 VDDA ) ( IO_FILL_IO_WEST_22_80 VDDA ) ( IO_FILL_IO_WEST_22_60 VDDA )
@@ -3919,7 +3919,7 @@ SPECIALNETS 18 ;
       ( user2_vssa_hvclamp_pad DRN_HVC ) ( user2_vdda_hvclamp_pad VDDA ) ( user2_vdda_hvclamp_pad DRN_HVC ) ( user2_vccd_lvclamp_pad VDDA ) ( user2_corner VDDA ) ( mprj_pads.area2_io_pad\[9\] VDDA ) ( mprj_pads.area2_io_pad\[8\] VDDA ) ( mprj_pads.area2_io_pad\[7\] VDDA )
       ( mprj_pads.area2_io_pad\[6\] VDDA ) ( mprj_pads.area2_io_pad\[5\] VDDA ) ( mprj_pads.area2_io_pad\[4\] VDDA ) ( mprj_pads.area2_io_pad\[3\] VDDA ) ( mprj_pads.area2_io_pad\[2\] VDDA ) ( mprj_pads.area2_io_pad\[1\] VDDA ) ( mprj_pads.area2_io_pad\[19\] VDDA ) ( mprj_pads.area2_io_pad\[18\] VDDA )
       ( mprj_pads.area2_io_pad\[17\] VDDA ) ( mprj_pads.area2_io_pad\[16\] VDDA ) ( mprj_pads.area2_io_pad\[15\] VDDA ) ( mprj_pads.area2_io_pad\[14\] VDDA ) ( mprj_pads.area2_io_pad\[13\] VDDA ) ( mprj_pads.area2_io_pad\[12\] VDDA ) ( mprj_pads.area2_io_pad\[11\] VDDA ) ( mprj_pads.area2_io_pad\[10\] VDDA )
-      ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE POWER ;
     - vddio ( PIN vddio ) ( IO_FILL_IO_SOUTH_0_50 VDDIO ) ( IO_FILL_IO_SOUTH_0_50 VSWITCH ) ( IO_FILL_IO_SOUTH_0_40 VDDIO ) ( IO_FILL_IO_SOUTH_0_40 VSWITCH ) ( IO_FILL_IO_SOUTH_0_55 VDDIO ) ( IO_FILL_IO_SOUTH_0_55 VSWITCH )
       ( connect_0 VDDIO ) ( connect_0 VSWITCH ) ( IO_FILL_IO_SOUTH_0_20 VDDIO ) ( IO_FILL_IO_SOUTH_0_20 VSWITCH ) ( IO_FILL_IO_SOUTH_0_0 VDDIO ) ( IO_FILL_IO_SOUTH_0_0 VSWITCH ) ( IO_CORNER_SOUTH_WEST_INST VDDIO ) ( IO_CORNER_SOUTH_WEST_INST VSWITCH )
       ( connect_1 VDDIO ) ( connect_1 VSWITCH ) ( IO_FILL_IO_WEST_0_0 VDDIO ) ( IO_FILL_IO_WEST_0_0 VSWITCH ) ( IO_FILL_IO_WEST_0_20 VDDIO ) ( IO_FILL_IO_WEST_0_20 VSWITCH ) ( connect_2 VDDIO ) ( connect_2 VSWITCH )
@@ -4112,7 +4112,7 @@ SPECIALNETS 18 ;
       ( mgmt_vdda_hvclamp_pad VSWITCH ) ( mgmt_vdda_hvclamp_pad VDDIO ) ( mgmt_vccd_lvclamp_pad VSWITCH ) ( mgmt_vccd_lvclamp_pad VDDIO ) ( mgmt_corner\[1\] VSWITCH ) ( mgmt_corner\[1\] VDDIO ) ( mgmt_corner\[0\] VSWITCH ) ( mgmt_corner\[0\] VDDIO )
       ( gpio_pad VSWITCH ) ( gpio_pad VDDIO ) ( gpio_pad HLD_H_N ) ( flash_io1_pad VSWITCH ) ( flash_io1_pad VDDIO ) ( flash_io1_pad HLD_H_N ) ( flash_io0_pad VSWITCH ) ( flash_io0_pad VDDIO )
       ( flash_io0_pad HLD_H_N ) ( flash_csb_pad VSWITCH ) ( flash_csb_pad VDDIO ) ( flash_csb_pad HLD_H_N ) ( flash_clk_pad VSWITCH ) ( flash_clk_pad VDDIO ) ( flash_clk_pad HLD_H_N ) ( clock_pad VSWITCH )
-      ( clock_pad VDDIO ) ( clock_pad HLD_H_N ) + USE SIGNAL ;
+      ( clock_pad VDDIO ) ( clock_pad HLD_H_N ) + USE POWER ;
     - vssa ( PIN vssa ) ( IO_FILL_IO_SOUTH_0_50 VSSA ) ( IO_FILL_IO_SOUTH_0_40 VSSA ) ( IO_FILL_IO_SOUTH_0_55 VSSA ) ( connect_0 VSSA ) ( IO_FILL_IO_SOUTH_0_20 VSSA ) ( IO_FILL_IO_SOUTH_0_0 VSSA )
       ( IO_CORNER_SOUTH_WEST_INST VSSA ) ( connect_1 VSSA ) ( IO_FILL_IO_WEST_0_0 VSSA ) ( IO_FILL_IO_WEST_0_20 VSSA ) ( connect_2 VSSA ) ( IO_FILL_IO_WEST_0_40 VSSA ) ( connect_3 VSSA ) ( IO_FILL_IO_WEST_0_60 VSSA )
       ( connect_4 VSSA ) ( IO_FILL_IO_WEST_0_80 VSSA ) ( connect_5 VSSA ) ( IO_FILL_IO_EAST_0_145 VSSA ) ( IO_FILL_IO_EAST_0_140 VSSA ) ( IO_FILL_IO_EAST_0_120 VSSA ) ( IO_FILL_IO_EAST_0_100 VSSA ) ( IO_FILL_IO_EAST_0_80 VSSA )
@@ -4139,7 +4139,7 @@ SPECIALNETS 18 ;
       ( IO_FILL_IO_SOUTH_13_65 VSSA ) ( IO_FILL_IO_SOUTH_10_0 VSSA ) ( IO_FILL_IO_SOUTH_9_65 VSSA ) ( IO_FILL_IO_SOUTH_12_0 VSSA ) ( IO_FILL_IO_SOUTH_11_65 VSSA ) ( IO_FILL_IO_SOUTH_6_0 VSSA ) ( IO_FILL_IO_SOUTH_5_65 VSSA ) ( resetb_pad VSSA )
       ( mgmt_vssio_hvclamp_pad\[0\] VSSA ) ( mgmt_vssd_lvclmap_pad VSSA ) ( mgmt_vssd_lvclmap_pad BDY2_B2B ) ( mgmt_vssa_hvclamp_pad VSSA ) ( mgmt_vssa_hvclamp_pad SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSA ) ( mgmt_vdda_hvclamp_pad VSSA ) ( mgmt_vdda_hvclamp_pad SRC_BDY_HVC )
       ( mgmt_vccd_lvclamp_pad VSSA ) ( mgmt_vccd_lvclamp_pad BDY2_B2B ) ( mgmt_corner\[1\] VSSA ) ( mgmt_corner\[0\] VSSA ) ( gpio_pad VSSA ) ( gpio_pad ENABLE_VSWITCH_H ) ( flash_io1_pad VSSA ) ( flash_io1_pad ENABLE_VSWITCH_H )
-      ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA ) ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE SIGNAL ;
+      ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA ) ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE GROUND ;
     - vssa1 ( PIN vssa1 ) ( brk_vccd_0 VSSA ) ( brk_vccd_1 VSSA ) ( IO_FILL_IO_EAST_1_0 VSSA ) ( IO_FILL_IO_NORTH_8_0 VSSA ) ( IO_FILL_IO_EAST_1_20 VSSA ) ( IO_FILL_IO_NORTH_8_20 VSSA )
       ( IO_FILL_IO_EAST_1_40 VSSA ) ( IO_FILL_IO_NORTH_8_40 VSSA ) ( IO_FILL_IO_EAST_1_60 VSSA ) ( IO_FILL_IO_NORTH_8_60 VSSA ) ( IO_FILL_IO_EAST_1_80 VSSA ) ( IO_FILL_IO_NORTH_8_80 VSSA ) ( IO_FILL_IO_EAST_1_100 VSSA ) ( IO_FILL_IO_NORTH_8_100 VSSA )
       ( IO_FILL_IO_EAST_1_120 VSSA ) ( IO_FILL_IO_NORTH_8_120 VSSA ) ( IO_FILL_IO_EAST_1_140 VSSA ) ( IO_FILL_IO_NORTH_8_140 VSSA ) ( IO_FILL_IO_EAST_1_160 VSSA ) ( IO_FILL_IO_NORTH_8_160 VSSA ) ( IO_FILL_IO_EAST_21_60 VSSA ) ( IO_FILL_IO_EAST_21_40 VSSA )
@@ -4173,7 +4173,7 @@ SPECIALNETS 18 ;
       ( user1_vssa_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vssa_hvclamp_pad\[0\] VSSA ) ( user1_vssa_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[1\] VSSA ) ( user1_vdda_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[0\] VSSA ) ( user1_vdda_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vccd_lvclamp_pad VSSA )
       ( user1_corner VSSA ) ( mprj_pads.area1_io_pad\[9\] VSSA ) ( mprj_pads.area1_io_pad\[8\] VSSA ) ( mprj_pads.area1_io_pad\[7\] VSSA ) ( mprj_pads.area1_io_pad\[6\] VSSA ) ( mprj_pads.area1_io_pad\[5\] VSSA ) ( mprj_pads.area1_io_pad\[4\] VSSA ) ( mprj_pads.area1_io_pad\[3\] VSSA )
       ( mprj_pads.area1_io_pad\[2\] VSSA ) ( mprj_pads.area1_io_pad\[1\] VSSA ) ( mprj_pads.area1_io_pad\[17\] VSSA ) ( mprj_pads.area1_io_pad\[16\] VSSA ) ( mprj_pads.area1_io_pad\[15\] VSSA ) ( mprj_pads.area1_io_pad\[14\] VSSA ) ( mprj_pads.area1_io_pad\[13\] VSSA ) ( mprj_pads.area1_io_pad\[12\] VSSA )
-      ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE GROUND ;
     - vssa2 ( PIN vssa2 ) ( brk_vccd_2 VSSA ) ( IO_FILL_IO_WEST_3_0 VSSA ) ( IO_FILL_IO_WEST_3_20 VSSA ) ( IO_FILL_IO_WEST_3_40 VSSA ) ( IO_FILL_IO_WEST_3_60 VSSA ) ( IO_FILL_IO_WEST_3_80 VSSA )
       ( IO_FILL_IO_WEST_3_100 VSSA ) ( IO_FILL_IO_WEST_3_120 VSSA ) ( IO_FILL_IO_NORTH_0_140 VSSA ) ( IO_FILL_IO_NORTH_0_120 VSSA ) ( IO_FILL_IO_NORTH_0_100 VSSA ) ( IO_FILL_IO_NORTH_0_80 VSSA ) ( IO_FILL_IO_NORTH_0_60 VSSA ) ( IO_FILL_IO_NORTH_0_40 VSSA )
       ( IO_FILL_IO_NORTH_0_20 VSSA ) ( IO_FILL_IO_NORTH_0_0 VSSA ) ( IO_CORNER_NORTH_WEST_INST VSSA ) ( IO_FILL_IO_WEST_22_130 VSSA ) ( IO_FILL_IO_WEST_22_120 VSSA ) ( IO_FILL_IO_WEST_22_100 VSSA ) ( IO_FILL_IO_WEST_22_80 VSSA ) ( IO_FILL_IO_WEST_22_60 VSSA )
@@ -4211,7 +4211,7 @@ SPECIALNETS 18 ;
       ( user2_vssa_hvclamp_pad SRC_BDY_HVC ) ( user2_vdda_hvclamp_pad VSSA ) ( user2_vdda_hvclamp_pad SRC_BDY_HVC ) ( user2_vccd_lvclamp_pad VSSA ) ( user2_corner VSSA ) ( mprj_pads.area2_io_pad\[9\] VSSA ) ( mprj_pads.area2_io_pad\[8\] VSSA ) ( mprj_pads.area2_io_pad\[7\] VSSA )
       ( mprj_pads.area2_io_pad\[6\] VSSA ) ( mprj_pads.area2_io_pad\[5\] VSSA ) ( mprj_pads.area2_io_pad\[4\] VSSA ) ( mprj_pads.area2_io_pad\[3\] VSSA ) ( mprj_pads.area2_io_pad\[2\] VSSA ) ( mprj_pads.area2_io_pad\[1\] VSSA ) ( mprj_pads.area2_io_pad\[19\] VSSA ) ( mprj_pads.area2_io_pad\[18\] VSSA )
       ( mprj_pads.area2_io_pad\[17\] VSSA ) ( mprj_pads.area2_io_pad\[16\] VSSA ) ( mprj_pads.area2_io_pad\[15\] VSSA ) ( mprj_pads.area2_io_pad\[14\] VSSA ) ( mprj_pads.area2_io_pad\[13\] VSSA ) ( mprj_pads.area2_io_pad\[12\] VSSA ) ( mprj_pads.area2_io_pad\[11\] VSSA ) ( mprj_pads.area2_io_pad\[10\] VSSA )
-      ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE GROUND ;
     - vssd ( PIN vssd ) ( IO_FILL_IO_SOUTH_0_50 VSSD ) ( IO_FILL_IO_SOUTH_0_40 VSSD ) ( IO_FILL_IO_SOUTH_0_55 VSSD ) ( connect_0 VSSD ) ( IO_FILL_IO_SOUTH_0_20 VSSD ) ( IO_FILL_IO_SOUTH_0_0 VSSD )
       ( IO_CORNER_SOUTH_WEST_INST VSSD ) ( connect_1 VSSD ) ( IO_FILL_IO_WEST_0_0 VSSD ) ( IO_FILL_IO_WEST_0_20 VSSD ) ( connect_2 VSSD ) ( IO_FILL_IO_WEST_0_40 VSSD ) ( connect_3 VSSD ) ( IO_FILL_IO_WEST_0_60 VSSD )
       ( connect_4 VSSD ) ( brk_vdda_0 VSSD ) ( IO_FILL_IO_WEST_0_80 VSSD ) ( connect_5 VSSD ) ( IO_FILL_IO_EAST_0_145 VSSD ) ( IO_FILL_IO_EAST_0_140 VSSD ) ( IO_FILL_IO_EAST_0_120 VSSD ) ( IO_FILL_IO_EAST_0_100 VSSD )
@@ -4244,7 +4244,7 @@ SPECIALNETS 18 ;
       ( flash_csb_pad VTRIP_SEL ) ( flash_csb_pad VSSD ) ( flash_csb_pad SLOW ) ( flash_csb_pad IB_MODE_SEL ) ( flash_csb_pad HLD_OVR ) ( flash_csb_pad DM[0] ) ( flash_csb_pad ANALOG_SEL ) ( flash_csb_pad ANALOG_POL )
       ( flash_csb_pad ANALOG_EN ) ( flash_clk_pad VTRIP_SEL ) ( flash_clk_pad VSSD ) ( flash_clk_pad SLOW ) ( flash_clk_pad IB_MODE_SEL ) ( flash_clk_pad HLD_OVR ) ( flash_clk_pad DM[0] ) ( flash_clk_pad ANALOG_SEL )
       ( flash_clk_pad ANALOG_POL ) ( flash_clk_pad ANALOG_EN ) ( clock_pad VTRIP_SEL ) ( clock_pad VSSD ) ( clock_pad SLOW ) ( clock_pad OUT ) ( clock_pad IB_MODE_SEL ) ( clock_pad HLD_OVR )
-      ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE SIGNAL ;
+      ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE GROUND ;
     - vssd1 ( PIN vssd1 ) ( IO_FILL_IO_EAST_1_0 VSSD ) ( IO_FILL_IO_NORTH_8_0 VSSD ) ( IO_FILL_IO_EAST_1_20 VSSD ) ( IO_FILL_IO_NORTH_8_20 VSSD ) ( IO_FILL_IO_EAST_1_40 VSSD ) ( IO_FILL_IO_NORTH_8_40 VSSD )
       ( IO_FILL_IO_EAST_1_60 VSSD ) ( IO_FILL_IO_NORTH_8_60 VSSD ) ( IO_FILL_IO_EAST_1_80 VSSD ) ( IO_FILL_IO_NORTH_8_80 VSSD ) ( IO_FILL_IO_EAST_1_100 VSSD ) ( IO_FILL_IO_NORTH_8_100 VSSD ) ( IO_FILL_IO_EAST_1_120 VSSD ) ( IO_FILL_IO_NORTH_8_120 VSSD )
       ( IO_FILL_IO_EAST_1_140 VSSD ) ( IO_FILL_IO_NORTH_8_140 VSSD ) ( IO_FILL_IO_EAST_1_160 VSSD ) ( IO_FILL_IO_NORTH_8_160 VSSD ) ( IO_FILL_IO_EAST_21_60 VSSD ) ( IO_FILL_IO_EAST_21_40 VSSD ) ( IO_FILL_IO_EAST_21_20 VSSD ) ( IO_FILL_IO_EAST_20_120 VSSD )
@@ -4277,7 +4277,7 @@ SPECIALNETS 18 ;
       ( IO_FILL_IO_NORTH_10_0 VSSD ) ( IO_FILL_IO_NORTH_9_175 VSSD ) ( IO_FILL_IO_NORTH_12_0 VSSD ) ( IO_FILL_IO_NORTH_11_175 VSSD ) ( user1_vssd_lvclmap_pad VSSD ) ( user1_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VSSD ) ( user1_vssa_hvclamp_pad\[0\] VSSD )
       ( user1_vdda_hvclamp_pad\[1\] VSSD ) ( user1_vdda_hvclamp_pad\[0\] VSSD ) ( user1_vccd_lvclamp_pad VSSD ) ( user1_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user1_corner VSSD ) ( mprj_pads.area1_io_pad\[9\] VSSD ) ( mprj_pads.area1_io_pad\[8\] VSSD ) ( mprj_pads.area1_io_pad\[7\] VSSD )
       ( mprj_pads.area1_io_pad\[6\] VSSD ) ( mprj_pads.area1_io_pad\[5\] VSSD ) ( mprj_pads.area1_io_pad\[4\] VSSD ) ( mprj_pads.area1_io_pad\[3\] VSSD ) ( mprj_pads.area1_io_pad\[2\] VSSD ) ( mprj_pads.area1_io_pad\[1\] VSSD ) ( mprj_pads.area1_io_pad\[17\] VSSD ) ( mprj_pads.area1_io_pad\[16\] VSSD )
-      ( mprj_pads.area1_io_pad\[15\] VSSD ) ( mprj_pads.area1_io_pad\[14\] VSSD ) ( mprj_pads.area1_io_pad\[13\] VSSD ) ( mprj_pads.area1_io_pad\[12\] VSSD ) ( mprj_pads.area1_io_pad\[11\] VSSD ) ( mprj_pads.area1_io_pad\[10\] VSSD ) ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE SIGNAL ;
+      ( mprj_pads.area1_io_pad\[15\] VSSD ) ( mprj_pads.area1_io_pad\[14\] VSSD ) ( mprj_pads.area1_io_pad\[13\] VSSD ) ( mprj_pads.area1_io_pad\[12\] VSSD ) ( mprj_pads.area1_io_pad\[11\] VSSD ) ( mprj_pads.area1_io_pad\[10\] VSSD ) ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE GROUND ;
     - vssd2 ( PIN vssd2 ) ( IO_FILL_IO_WEST_3_0 VSSD ) ( IO_FILL_IO_WEST_3_20 VSSD ) ( IO_FILL_IO_WEST_3_40 VSSD ) ( IO_FILL_IO_WEST_3_60 VSSD ) ( IO_FILL_IO_WEST_3_80 VSSD ) ( IO_FILL_IO_WEST_3_100 VSSD )
       ( IO_FILL_IO_WEST_3_120 VSSD ) ( IO_FILL_IO_NORTH_0_140 VSSD ) ( IO_FILL_IO_NORTH_0_120 VSSD ) ( IO_FILL_IO_NORTH_0_100 VSSD ) ( IO_FILL_IO_NORTH_0_80 VSSD ) ( IO_FILL_IO_NORTH_0_60 VSSD ) ( IO_FILL_IO_NORTH_0_40 VSSD ) ( brk_vdda_1 VSSD )
       ( IO_FILL_IO_NORTH_0_20 VSSD ) ( IO_FILL_IO_NORTH_0_0 VSSD ) ( IO_CORNER_NORTH_WEST_INST VSSD ) ( IO_FILL_IO_WEST_22_130 VSSD ) ( IO_FILL_IO_WEST_22_120 VSSD ) ( IO_FILL_IO_WEST_22_100 VSSD ) ( IO_FILL_IO_WEST_22_80 VSSD ) ( IO_FILL_IO_WEST_22_60 VSSD )
@@ -4315,7 +4315,7 @@ SPECIALNETS 18 ;
       ( user2_vssa_hvclamp_pad VSSD ) ( user2_vdda_hvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user2_corner VSSD ) ( mprj_pads.area2_io_pad\[9\] VSSD ) ( mprj_pads.area2_io_pad\[8\] VSSD ) ( mprj_pads.area2_io_pad\[7\] VSSD )
       ( mprj_pads.area2_io_pad\[6\] VSSD ) ( mprj_pads.area2_io_pad\[5\] VSSD ) ( mprj_pads.area2_io_pad\[4\] VSSD ) ( mprj_pads.area2_io_pad\[3\] VSSD ) ( mprj_pads.area2_io_pad\[2\] VSSD ) ( mprj_pads.area2_io_pad\[1\] VSSD ) ( mprj_pads.area2_io_pad\[19\] VSSD ) ( mprj_pads.area2_io_pad\[18\] VSSD )
       ( mprj_pads.area2_io_pad\[17\] VSSD ) ( mprj_pads.area2_io_pad\[16\] VSSD ) ( mprj_pads.area2_io_pad\[15\] VSSD ) ( mprj_pads.area2_io_pad\[14\] VSSD ) ( mprj_pads.area2_io_pad\[13\] VSSD ) ( mprj_pads.area2_io_pad\[12\] VSSD ) ( mprj_pads.area2_io_pad\[11\] VSSD ) ( mprj_pads.area2_io_pad\[10\] VSSD )
-      ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE SIGNAL ;
+      ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE GROUND ;
     - vssio ( PIN vssio ) ( IO_FILL_IO_SOUTH_0_50 VSSIO ) ( IO_FILL_IO_SOUTH_0_40 VSSIO ) ( IO_FILL_IO_SOUTH_0_55 VSSIO ) ( connect_0 VSSIO ) ( IO_FILL_IO_SOUTH_0_20 VSSIO ) ( IO_FILL_IO_SOUTH_0_0 VSSIO )
       ( IO_CORNER_SOUTH_WEST_INST VSSIO ) ( connect_1 VSSIO ) ( IO_FILL_IO_WEST_0_0 VSSIO ) ( IO_FILL_IO_WEST_0_20 VSSIO ) ( connect_2 VSSIO ) ( IO_FILL_IO_WEST_0_40 VSSIO ) ( connect_3 VSSIO ) ( IO_FILL_IO_EAST_1_80 VSSIO )
       ( IO_FILL_IO_EAST_1_60 VSSIO ) ( IO_FILL_IO_EAST_1_40 VSSIO ) ( IO_FILL_IO_EAST_1_20 VSSIO ) ( IO_FILL_IO_EAST_1_0 VSSIO ) ( brk_vccd_0 VSSIO ) ( IO_FILL_IO_WEST_0_60 VSSIO ) ( connect_4 VSSIO ) ( IO_FILL_IO_EAST_1_100 VSSIO )
@@ -4418,7 +4418,7 @@ SPECIALNETS 18 ;
       ( mprj_pads.area1_io_pad\[10\] VSSIO ) ( mprj_pads.area1_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[0\] VSSIO ) ( mprj_pads.area1_io_pad\[0\] ENABLE_VSWITCH_H ) ( mgmt_vssio_hvclamp_pad\[1\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[0\] SRC_BDY_HVC )
       ( mgmt_vssd_lvclmap_pad VSSIO ) ( mgmt_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( mgmt_vssa_hvclamp_pad VSSIO ) ( mgmt_vddio_hvclamp_pad\[1\] VSSIO ) ( mgmt_vddio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vddio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vdda_hvclamp_pad VSSIO )
       ( mgmt_vccd_lvclamp_pad VSSIO ) ( mgmt_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( mgmt_corner\[1\] VSSIO ) ( mgmt_corner\[0\] VSSIO ) ( gpio_pad VSSIO ) ( flash_io1_pad VSSIO ) ( flash_io0_pad VSSIO ) ( flash_csb_pad VSSIO )
-      ( flash_clk_pad VSSIO ) ( clock_pad VSSIO ) + USE SIGNAL ;
+      ( flash_clk_pad VSSIO ) ( clock_pad VSSIO ) + USE GROUND ;
 END SPECIALNETS
 NETS 760 ;
     - clock ( PIN clock ) ( clock_pad PAD ) + USE SIGNAL ;


### PR DESCRIPTION
Fixes:
- missing special net marking and ensuring nets match their iterms if the iterms are supply