### PR TITLE
remove par and par_py until they work on apple silicon.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,7 +319,6 @@ target_link_libraries(openroad
   mpl
   psm
   ant
-  par
   upf
   utl
   pdn
@@ -330,11 +329,12 @@ target_link_libraries(openroad
 )
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  # mpl2 aborts with link error on darwin so do not link it.
-  target_link_libraries(openroad mpl2)
+  # mpl2 aborts with link error on darwin and par causes abseil link error at startup on apple silicon so do not link it.
+  target_link_libraries(openroad mpl2 par)
   target_compile_definitions(openroad PRIVATE ENABLE_MPL2)
+  target_compile_definitions(openroad PRIVATE ENABLE_PAR)
 else()
-  message(STATUS "Removing MPL2 to avoid run time fatal error.")
+  message(STATUS "Removing MPL2 and PAR to avoid run time fatal error.")
 endif()
 
 # tclReadline
@@ -398,7 +398,6 @@ if (Python3_FOUND AND BUILD_PYTHON)
     drt_py
     dpo_py
     fin_py
-    par_py
     rcx_py
     rmp_py
     stt_py
@@ -406,6 +405,13 @@ if (Python3_FOUND AND BUILD_PYTHON)
     pdn_py
     dft_py
   )
+
+  if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # par_py causes abseil link error at startup on apple silicon so do not link it.
+    target_link_libraries(openroad par_py)
+  else()
+    message(STATUS "Removing PAR_PY to avoid run time fatal error.")
+  endif()
 else()
   message(STATUS "Python3 disabled")
 endif()

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -79,6 +79,13 @@ using sta::stringEq;
 using std::string;
 
 #ifdef ENABLE_PYTHON3
+// par causes abseil link error at startup on apple silicon
+#ifdef ENABLE_PAR
+#define TOOL_PAR X(par)
+#else
+#define TOOL_PAR
+#endif
+
 #define FOREACH_TOOL_WITHOUT_OPENROAD(X) \
   X(ifp)                                 \
   X(utl)                                 \
@@ -93,7 +100,7 @@ using std::string;
   X(drt)                                 \
   X(dpo)                                 \
   X(fin)                                 \
-  X(par)                                 \
+  TOOL_PAR                               \
   X(rcx)                                 \
   X(rmp)                                 \
   X(stt)                                 \

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -70,7 +70,10 @@
 #include "odb/lefout.h"
 #include "ord/InitOpenRoad.hh"
 #include "pad/MakeICeWall.h"
+#ifdef ENABLE_PAR
+// par causes abseil link error at startup on apple silicon
 #include "par/MakePartitionMgr.h"
+#endif
 #include "pdn/MakePdnGen.hh"
 #include "ppl/MakeIoplacer.h"
 #include "psm/MakePDNSim.hh"
@@ -176,7 +179,9 @@ OpenRoad::~OpenRoad()
   deleteFinale(finale_);
   deleteAntennaChecker(antenna_checker_);
   odb::dbDatabase::destroy(db_);
+#ifdef ENABLE_PAR
   deletePartitionMgr(partitionMgr_);
+#endif
   deletePdnGen(pdngen_);
   deleteICeWall(icewall_);
   deleteDistributed(distributer_);
@@ -232,7 +237,9 @@ void OpenRoad::init(Tcl_Interp* tcl_interp)
   replace_ = makeReplace();
   pdnsim_ = makePDNSim();
   antenna_checker_ = makeAntennaChecker();
+#ifdef ENABLE_PAR
   partitionMgr_ = makePartitionMgr();
+#endif
   pdngen_ = makePdnGen();
   icewall_ = makeICeWall();
   distributer_ = makeDistributed();
@@ -271,7 +278,9 @@ void OpenRoad::init(Tcl_Interp* tcl_interp)
   initTritonRoute(this);
   initPDNSim(this);
   initAntennaChecker(this);
+#ifdef ENABLE_PAR
   initPartitionMgr(this);
+#endif
   initPdnGen(this);
   initDistributed(this);
   initSteinerTreeBuilder(this);


### PR DESCRIPTION
par and pay_py will cause `ERROR: Something is wrong with flag 'flagfile' in file 'Users/corentinl/work/main/build_make/_deps/absl-src/absl/flags/parse.cc'. One possibility: file 'Users/corentinl/work/main/build_make/_deps/absl-src/absl/flags/parse.cc' is being linked both statically and dynamically into this executable. e.g. some files listed as srcs to a test and also listed as srcs of some shared lib deps of the same test.` on apple silicon when launches executable, so temporarily remove until or-tools fix this problem.