### PR TITLE
Updates CMake GTest fetch rule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,9 +143,9 @@ if(NOT GTest_FOUND)
   include(FetchContent)
   FetchContent_Declare(
     googletest
-    # Specify the commit you depend on and update it regularly.
-    URL https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    # Specify the commit you depend on and update it regularly.
+    URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"
   )
   FetchContent_MakeAvailable(googletest)
 endif()


### PR DESCRIPTION
Fixes problem described here https://stackoverflow.com/questions/74996365/cmake-error-at-least-one-entry-of-url-is-a-path-invalid-in-a-list

Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>