### PR TITLE
odb: use logger error instead of exit(2) in definReader

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1840,9 +1840,10 @@ bool definReader::createBlock(const char* file)
   }
 
   if (res != 0 || errors() != 0) {
-    _logger->warn(utl::ODB, 149, "DEF parser returns an error!");
     if (!_continue_on_errors) {
-      exit(2);
+      _logger->error(utl::ODB, 421, "DEF parser returns an error!");
+    } else {
+      _logger->warn(utl::ODB, 149, "DEF parser returns an error!");
     }
   }
 
@@ -1875,9 +1876,10 @@ bool definReader::replaceWires(const char* file)
 
   int res = defrRead(f, file, (defiUserData) this, /* case sensitive */ 1);
   if (res != 0) {
-    _logger->warn(utl::ODB, 151, "DEF parser returns an error!");
     if (!_continue_on_errors) {
-      exit(2);
+      _logger->error(utl::ODB, 422, "DEF parser returns an error!");
+    } else {
+      _logger->warn(utl::ODB, 151, "DEF parser returns an error!");
     }
   }
 


### PR DESCRIPTION
Removes exit call from defin which makes debugging impossible, replaced with an error 