### PR TITLE
drt/pa: Fix bounding box calculation in genPatterns_gc

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -2270,9 +2270,9 @@ bool FlexPA::genPatterns_gc(std::set<frBlockObject*> targetObjs,
   for (auto& [connFig, owner] : objs) {
     Rect bbox = connFig->getBBox();
     llx = std::min(llx, bbox.xMin());
-    lly = std::min(llx, bbox.yMin());
-    urx = std::max(llx, bbox.xMax());
-    ury = std::max(llx, bbox.yMax());
+    lly = std::min(lly, bbox.yMin());
+    urx = std::max(urx, bbox.xMax());
+    ury = std::max(ury, bbox.yMax());
   }
   Rect extBox(llx - 3000, lly - 3000, urx + 3000, ury + 3000);
   // Rect extBox(llx - 1000, lly - 1000, urx + 1000, ury + 1000);


### PR DESCRIPTION
genPatterns_gc miscalculates the bounding box used for gc, applying the lower x coordinate to all other coordinates. If we are unlucky this bounding box is huge and could contain over 100,000 objects. As a result gc wastes a lot of time initialising all the objects within the bounding box.

Fixing this significantly improves the start up time for the ispd19_test10 test case.