### PR TITLE
drt/gc: Fix memory leak in checkMetalSpacing_short_obs()

### DIFF
--- a/src/drt/src/gc/FlexGC_eol.cpp
+++ b/src/drt/src/gc/FlexGC_eol.cpp
@@ -933,9 +933,9 @@ void FlexGCWorker::Impl::checkMetalEOLkeepout_main(
                                            ptr->getLowCorner()->y(),
                                            ptr->getHighCorner()->x(),
                                            ptr->getHighCorner()->y());
-      gcRect* rect = new gcRect(
+      gcRect rect(
           segrect, layerNum, ptr->getPin(), ptr->getNet(), ptr->isFixed());
-      checkMetalEOLkeepout_helper(edge, rect, queryRect, constraint);
+      checkMetalEOLkeepout_helper(edge, &rect, queryRect, constraint);
     }
   } else {
     vector<rq_box_value_t<gcRect*>> results;

--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -638,11 +638,11 @@ void FlexGCWorker::Impl::checkMetalSpacing_short_obs(
     std::list<gtl::rectangle_data<frCoord>> res;
     gtl::get_max_rectangles(res, bg2gtl(poly));
     for (const auto& rect : res) {
-      gcRect* rect3 = new gcRect(*rect2);
-      rect3->setRect(rect);
+      gcRect rect3 = *rect2;
+      rect3.setRect(rect);
       gtl::rectangle_data<frCoord> newMarkerRect(markerRect);
-      gtl::intersect(newMarkerRect, *rect3);
-      checkMetalSpacing_short(rect1, rect3, newMarkerRect);
+      gtl::intersect(newMarkerRect, rect3);
+      checkMetalSpacing_short(rect1, &rect3, newMarkerRect);
     }
   }
 }


### PR DESCRIPTION
We are leaking memory in checkMetalSpacing_short_obs() via gcRect rect3. There doesn't seem to be a reason for dynamically allocating this, so just move it to the stack.