### PR TITLE
odb: Don't leak memory in MACRO PORT statements

### DIFF
--- a/src/odb/src/lef/lef/lefiMacro.cpp
+++ b/src/odb/src/lef/lef/lefiMacro.cpp
@@ -1129,12 +1129,11 @@ void lefiPin::clear()
   int i;
   lefiPinAntennaModel* aModel;
 
-  //    This destructiong is automatically done in Vector's destructor
-  //    for (i = 0; i < numPorts_; i++) {
-  //        g = ports_[i];
-  //        g->Destroy();
-  //        lefFree((char*) g);
-  //    }
+  for (i = 0; i < numPorts_; i++) {
+    auto g = ports_[i];
+    g->Destroy();
+    lefFree(g);
+  }
   numPorts_ = 0;
   portsAllocated_ = 0;
 


### PR DESCRIPTION
The comment suggests the memory will be automatically recovered because it uses a vector, however it is not using a vector and the memory is getting leaked.