### PR TITLE
drt/pa: Better sizing of gc bounding box

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -858,7 +858,11 @@ void FlexPA::prepPoint_pin_checkPoint_planar(
   FlexGCWorker gcWorker(getTech(), logger_);
   gcWorker.setIgnoreMinArea();
   gcWorker.setIgnoreCornerSpacing();
-  Rect extBox(bp.x() - 3000, bp.y() - 3000, bp.x() + 3000, bp.y() + 3000);
+  const auto pitch = layer->getPitch();
+  const auto extension = 5 * pitch;
+  Rect tmpBox(bp, bp);
+  Rect extBox;
+  tmpBox.bloat(extension, extBox);
   gcWorker.setExtBox(extBox);
   gcWorker.setDrcBox(extBox);
   if (instTerm) {
@@ -1087,7 +1091,11 @@ bool FlexPA::prepPoint_pin_checkPoint_via_helper(frAccessPoint* ap,
   gcWorker.setIgnoreMinArea();
   gcWorker.setIgnoreLongSideEOL();
   gcWorker.setIgnoreCornerSpacing();
-  Rect extBox(bp.x() - 3000, bp.y() - 3000, bp.x() + 3000, bp.y() + 3000);
+  const auto pitch = getTech()->getLayer(ap->getLayerNum())->getPitch();
+  const auto extension = 5 * pitch;
+  Rect tmpBox(bp, bp);
+  Rect extBox;
+  tmpBox.bloat(extension, extBox);
   gcWorker.setExtBox(extBox);
   gcWorker.setDrcBox(extBox);
   if (instTerm) {


### PR DESCRIPTION
During pin access, we currently hard wire the size of the gc bounding box. Depending on the technology, 3000 could be too big or too small.

Change this to be 5 wire pitches of the metal layer of the pin, which should be enough area to determine if we can safely access the pin.