### PR TITLE
setup: a safe, no choices to be made setup that safely installs dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ cmake-build-debug/
 
 coverage-output
 messages.txt
+dependencies/

--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+function setpaths() {
+    local DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+    export PATH=$DIR/dependencies/bin:$PATH
+}
+
+setpaths

--- a/etc/setup.sh
+++ b/etc/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# allow this script to be invoked from any folder
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ $EUID -ne 0 ]; then
+  echo "This script must be run with sudo"
+  exit 1
+fi
+
+$DIR/DependencyInstaller.sh -base
+
+sudo -u $SUDO_USER $DIR/DependencyInstaller.sh -common -prefix=$DIR/../dependencies
+
+echo "To set up paths to dependencies, run:"
+echo ""
+echo ". env.sh"


### PR DESCRIPTION
@yupferris The idea is to remove choices and sharp edges from install process.

Just run:

`sudo etc/setup.sh`

Then, to set up environment variables, run:

`. env.sh`

From ORFS, a local build is then made by running:

`./build_openroad.sh --local`

Then, after https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/928 merged, you can run the commands to set up env vars to yosys and OpenROAD binaries:

```
. env.sh
```
