### PR TITLE
pdn: use RTree filter to avoid rebuilding rtrees for obstructions

### DIFF
--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -110,6 +110,9 @@ void PdnGen::buildGrids(bool trim)
 
   ShapeTreeMap block_obs;
   Grid::makeInitialObstructions(block, block_obs, insts_in_grids, logger_);
+  for (auto* grid : grids) {
+    grid->getGridLevelObstructions(block_obs);
+  }
 
   ShapeTreeMap all_shapes;
 
@@ -125,20 +128,14 @@ void PdnGen::buildGrids(bool trim)
   for (auto* grid : grids) {
     debugPrint(
         logger_, utl::PDN, "Make", 2, "Build start grid - {}", grid->getName());
-    ShapeTreeMap obs_local = block_obs;
-    for (auto* grid_other : grids) {
-      if (grid != grid_other) {
-        grid_other->getGridLevelObstructions(obs_local);
-        grid_other->getObstructions(obs_local);
-      }
-    }
-    grid->makeShapes(all_shapes, obs_local);
+    grid->makeShapes(all_shapes, block_obs);
     for (const auto& [layer, shapes] : grid->getShapes()) {
       auto& all_shapes_layer = all_shapes[layer];
       for (auto& shape : shapes) {
         all_shapes_layer.insert(shape);
       }
     }
+    grid->getObstructions(block_obs);
     debugPrint(
         logger_, utl::PDN, "Make", 2, "Build end grid - {}", grid->getName());
   }

--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -891,7 +891,7 @@ void Grid::getGridLevelObstructions(ShapeTreeMap& obstructions) const
   }
 
   for (auto* layer : layers) {
-    auto obs = std::make_shared<Shape>(layer, core, Shape::GRID_OBS);
+    auto obs = std::make_shared<GridObsShape>(layer, core, this);
     debugPrint(getLogger(),
                utl::PDN,
                "Obs",
@@ -912,7 +912,7 @@ void Grid::getGridLevelObstructions(ShapeTreeMap& obstructions) const
                               core.xMax() + ver_size + offset[2],
                               core.yMax() + hor_size + offset[3]);
     for (auto* layer : ring->getLayers()) {
-      auto obs = std::make_shared<Shape>(layer, ring_rect, Shape::GRID_OBS);
+      auto obs = std::make_shared<GridObsShape>(layer, ring_rect, this);
       obs->generateObstruction();
       debugPrint(
           getLogger(),
@@ -1312,13 +1312,16 @@ void InstanceGrid::getGridLevelObstructions(ShapeTreeMap& obstructions) const
 
   // copy layer obs
   for (const auto& [layer, shapes] : local_obs) {
-    auto obs = std::make_shared<Shape>(layer, inst_box, Shape::GRID_OBS);
+    auto obs = std::make_shared<GridObsShape>(layer, inst_box, this);
     local_obs[layer].insert({obs->getObstructionBox(), obs});
   }
 
   // copy instance obstructions
   for (const auto& [layer, shapes] : getInstanceObstructions(inst_, halos_)) {
-    local_obs[layer].insert(shapes.begin(), shapes.end());
+    for (const auto& [box, shape] : shapes) {
+      auto obs = std::make_shared<GridObsShape>(layer, shape->getRect(), this);
+      local_obs[layer].insert({box, obs});
+    }
   }
 
   // merge local and global obs

--- a/src/pdn/src/grid_component.cpp
+++ b/src/pdn/src/grid_component.cpp
@@ -299,7 +299,7 @@ void GridComponent::cutShapes(const ShapeTreeMap& obstructions)
     std::map<Shape*, std::vector<Shape*>> replacement_shapes;
     for (const auto& [box, shape] : shapes) {
       std::vector<Shape*> replacements;
-      if (!shape->cut(obs, replacements)) {
+      if (!shape->cut(obs, getGrid(), replacements)) {
         continue;
       }
 

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -651,4 +651,13 @@ bool FollowPinShape::cut(const ShapeTree& obstructions,
       });
 }
 
+/////////////////////////////////////
+
+GridObsShape::GridObsShape(odb::dbTechLayer* layer, const odb::Rect& rect, const Grid* grid) :
+  Shape(layer, rect, Shape::GRID_OBS),
+  grid_(grid)
+{
+  setObstruction(rect);
+}
+
 }  // namespace pdn

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -179,9 +179,14 @@ class Shape
   int getNumberOfConnectionsBelow() const;
   int getNumberOfConnectionsAbove() const;
 
-  Shape* extendTo(const odb::Rect& rect, const ShapeTree& obstructions) const;
+  Shape* extendTo(
+      const odb::Rect& rect,
+      const ShapeTree& obstructions,
+      const std::function<bool(const ShapeValue&)>& obs_filter
+      = [](const ShapeValue&) { return true; }) const;
 
   virtual bool cut(const ShapeTree& obstructions,
+                   const Grid* ignore_grid,
                    std::vector<Shape*>& replacements) const;
 
   // return a copy of the shape
@@ -267,6 +272,7 @@ class FollowPinShape : public Shape
   virtual void setAllowsNonPreferredDirectionChange() override {}
 
   virtual bool cut(const ShapeTree& obstructions,
+                   const Grid* ignore_grid,
                    std::vector<Shape*>& replacements) const override;
 
  private:
@@ -276,7 +282,9 @@ class FollowPinShape : public Shape
 class GridObsShape : public Shape
 {
  public:
-  GridObsShape(odb::dbTechLayer* layer, const odb::Rect& rect, const Grid* grid);
+  GridObsShape(odb::dbTechLayer* layer,
+               const odb::Rect& rect,
+               const Grid* grid);
   ~GridObsShape() {}
 
   bool belongsTo(const Grid* grid) const { return grid == grid_; }

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -285,7 +285,7 @@ class GridObsShape : public Shape
   GridObsShape(odb::dbTechLayer* layer,
                const odb::Rect& rect,
                const Grid* grid);
-  ~GridObsShape() {}
+  ~GridObsShape() override = default;
 
   bool belongsTo(const Grid* grid) const { return grid == grid_; }
   const Grid* getGrid() const { return grid_; }

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -273,4 +273,17 @@ class FollowPinShape : public Shape
   std::set<odb::dbRow*> rows_;
 };
 
+class GridObsShape : public Shape
+{
+ public:
+  GridObsShape(odb::dbTechLayer* layer, const odb::Rect& rect, const Grid* grid);
+  ~GridObsShape() {}
+
+  bool belongsTo(const Grid* grid) const { return grid == grid_; }
+  const Grid* getGrid() const { return grid_; }
+
+ private:
+  const Grid* grid_;
+};
+
 }  // namespace pdn


### PR DESCRIPTION
This should help speed up: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/940
Changes:
- Stops rebuilding the obs rtrees and just use a filter to ignore the shapes