### PR TITLE
Ignore warning on stderr

### DIFF
--- a/src/dst/test/cpp_tests.tcl
+++ b/src/dst/test/cpp_tests.tcl
@@ -4,7 +4,7 @@ set test_dir [pwd]
 set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
 set tests_path [file join $openroad_dir "build" "src" "dst" "test" "cpp"]
 
-set tests_list [split [exec sh -c "find $tests_path -maxdepth 1 -name 'Test*'"] \n]
+set tests_list [split [exec -ignorestderr sh -c "find $tests_path -maxdepth 1 -name 'Test*'"] \n]
 
 foreach test $tests_list {
     set test_name [file tail $test]

--- a/src/odb/test/cpp_tests.tcl
+++ b/src/odb/test/cpp_tests.tcl
@@ -4,7 +4,7 @@ set test_dir [pwd]
 set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
 set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp"]
 
-set tests_list [split [exec sh -c "find $tests_path -maxdepth 1 -name 'Test*' ! -name '*.cmake'"] \n]
+set tests_list [split [exec -ignorestderr sh -c "find $tests_path -maxdepth 1 -name 'Test*' ! -name '*.cmake'"] \n]
 
 foreach test $tests_list {
     set test_name [file tail $test]


### PR DESCRIPTION
If the right locale is not available, the warning `sh: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)` is written to stderr. Since tcl's `exec` by default [treats output to stderr as failure](https://www.tcl-lang.org/man/tcl/TclCmd/exec.htm), the tcl script fails before any unit tests are executed.