### PR TITLE
Fix string formatting in tests

### DIFF
--- a/src/par/test/partition_gcd.ok
+++ b/src/par/test/partition_gcd.ok
@@ -9,7 +9,7 @@
 ========================================
 [INFO] Partitioning parameters**** 
 [PARAM] Number of partitions = 2
-[PARAM] UBfactor = 1.0
+[PARAM] UBfactor = 1
 [PARAM] Vertex dimensions = 1
 [PARAM] Hyperedge dimensions = 1
 ========================================
@@ -118,7 +118,7 @@ After Hyperedge Reduction :  num_vertices = 137, num_hyperedges = 251
 [V-Refine] Level 2 :: 207, 301, 154.65254
 [V-Refine] Level 3 :: 312, 370, 154.65254
 [V-Refine] Level 4 :: 469, 451, 154.65254
-[INFO] V-cycle refinement 1 delta cost 0.0
+[INFO] V-cycle refinement 1 delta cost 0
 =========================================
 [STATUS] Running FC multilevel coarsening 
 =========================================
@@ -133,7 +133,7 @@ After Hyperedge Reduction :  num_vertices = 137, num_hyperedges = 251
 [V-Refine] Level 2 :: 207, 301, 154.65254
 [V-Refine] Level 3 :: 312, 370, 154.65254
 [V-Refine] Level 4 :: 469, 451, 154.65254
-[INFO] V-cycle refinement 2 delta cost 0.0
+[INFO] V-cycle refinement 2 delta cost 0
 [Cutcost of partition : 154.65254]
 [Vertex balance of block_0 : 0.59249  ( 327.17993 )    
 [Vertex balance of block_1 : 0.40751  ( 225.03609 )    

--- a/src/pdn/test/design_width.ok
+++ b/src/pdn/test/design_width.ok
@@ -9,5 +9,5 @@
 [INFO ODB-0130]     Created 54 pins.
 [INFO ODB-0131]     Created 406 components and 1816 component-terminals.
 [INFO ODB-0133]     Created 361 nets and 1004 connections.
-[ERROR PDN-0185] Insufficient width (14.04 um) to add straps on layer M8 in grid "Core" with total strap width 6.0 um and offset 10.0 um.
+[ERROR PDN-0185] Insufficient width (14.04 um) to add straps on layer M8 in grid "Core" with total strap width 6 um and offset 10 um.
 PDN-0185


### PR DESCRIPTION
Hide the decimal point and digits after the decimal point when they are not needed.

This patch is necessary for building and packaging OpenROAD on [NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/blob/c59f6c75b60b31d2349b35ddb2777d230d02cabe/pkgs/applications/science/electronics/openroad/default.nix), which currently uses fmt 9.1.0. IIRC, fmt changed the default for printing floating point numbers to not show any decimal point and following digits, if they would be zero: https://fmt.dev/9.1.0/syntax.html

> The '#' option causes the “alternate form” to be used for the conversion. [...] For floating-point numbers the alternate form causes the result of the conversion to always contain a decimal-point character, even if no digits follow it. Normally, a decimal-point character appears in the result of these conversions only if a digit follows it.

Maybe this does not (yet) happen in your tests, because you use an older fmt. You may consider applying this patch when you update fmt, or format using the alternate form to make the decimal point and following digits explicit.