### PR TITLE
Separate the creation of dbSta from initialization.

### DIFF
--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -755,7 +755,7 @@ void TechChar::createStaInstance()
 {
   // Creates a new OpenSTA instance that is used only for the characterization.
   // Creates the new instance based on the charcterization block.
-  openStaChar_ = sta::makeBlockSta(openroad_, charBlock_);
+  openStaChar_ = openSta_->makeBlockSta(charBlock_);
   // Gets the corner and other analysis attributes from the new instance.
   charCorner_ = openStaChar_->cmdCorner();
   sta::PathAPIndex path_ap_index
@@ -1178,8 +1178,7 @@ void TechChar::create()
         buffersUpdate--;
       } while (buffersUpdate != 0);
     }
-    delete openStaChar_;
-    openStaChar_ = nullptr;
+    openStaChar_.reset(nullptr);
   }
   logger_->info(CTS, 39, "Number of created patterns = {}.", topologiesCreated);
   // Post-processing of the results.
@@ -1197,8 +1196,7 @@ void TechChar::create()
   // super confused -cherry
   if (openStaChar_ != nullptr) {
     openStaChar_->clear();
-    delete openStaChar_;
-    openStaChar_ = nullptr;
+    openStaChar_.reset(nullptr);
   }
 }
 

--- a/src/cts/src/TechChar.h
+++ b/src/cts/src/TechChar.h
@@ -294,7 +294,7 @@ class TechChar
   odb::dbDatabase* db_;
   rsz::Resizer* resizer_;
   sta::dbSta* openSta_;
-  sta::dbSta* openStaChar_;
+  std::unique_ptr<sta::dbSta> openStaChar_;
   sta::dbNetwork* db_network_;
   Logger* logger_;
   sta::PathAnalysisPt* charPathAnalysis_ = nullptr;

--- a/src/dbSta/include/db_sta/MakeDbSta.hh
+++ b/src/dbSta/include/db_sta/MakeDbSta.hh
@@ -33,10 +33,6 @@
 
 #pragma once
 
-namespace odb {
-class dbDatabase;
-}
-
 namespace sta {
 class dbSta;
 }
@@ -47,6 +43,5 @@ class OpenRoad;
 
 sta::dbSta* makeDbSta();
 void deleteDbSta(sta::dbSta* sta);
-void initDbSta(OpenRoad* openroad);
 
 }  // namespace ord

--- a/src/dbSta/include/db_sta/MakeDbSta.hh
+++ b/src/dbSta/include/db_sta/MakeDbSta.hh
@@ -43,5 +43,6 @@ class OpenRoad;
 
 sta::dbSta* makeDbSta();
 void deleteDbSta(sta::dbSta* sta);
+void initDbSta(OpenRoad* openroad);
 
 }  // namespace ord

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -48,6 +48,7 @@ class Gui;
 
 namespace ord {
 class OpenRoad;
+void initDbSta(OpenRoad*);
 }
 
 namespace utl {
@@ -63,7 +64,6 @@ class dbStaCbk;
 class PathRenderer;
 class PowerDensityDataSource;
 
-using ord::OpenRoad;
 using utl::Logger;
 
 using odb::dbBlock;
@@ -82,15 +82,15 @@ class dbSta : public Sta, public ord::OpenRoad::Observer
  public:
   dbSta();
   virtual ~dbSta();
-  void init(Tcl_Interp* tcl_interp,
-            dbDatabase* db,
-            gui::Gui* gui,
-            Logger* logger);
-  // for makeBlockSta
+
   void initVars(Tcl_Interp* tcl_interp,
-                dbDatabase* db,
+                odb::dbDatabase* db,
                 gui::Gui* gui,
-                Logger* logger);
+                utl::Logger* logger);
+
+  // Creates a dbSta instance for the given dbBlock using the same context as
+  // this dbSta instance (e.g. TCL interpreter, units, etc.)
+  std::unique_ptr<dbSta> makeBlockSta(odb::dbBlock* block);
 
   dbDatabase* db() { return db_; }
   dbNetwork* getDbNetwork() { return db_network_; }
@@ -118,7 +118,12 @@ class dbSta : public Sta, public ord::OpenRoad::Observer
   using Sta::netSlack;
   using Sta::replaceCell;
 
- protected:
+ private:
+  friend void ::ord::initDbSta(::ord::OpenRoad*);
+
+  // Creates the power density heatmap object (for GUI rendering).
+  void initPowerDensityHeatmap();
+
   virtual void makeReport() override;
   virtual void makeNetwork() override;
   virtual void makeSdcNetwork() override;
@@ -138,8 +143,5 @@ class dbSta : public Sta, public ord::OpenRoad::Observer
 
   std::unique_ptr<PowerDensityDataSource> power_density_heatmap_;
 };
-
-// Make a stand-alone (scratchpad) sta for block.
-dbSta* makeBlockSta(OpenRoad* openroad, dbBlock* block);
 
 }  // namespace sta

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -48,7 +48,6 @@ class Gui;
 
 namespace ord {
 class OpenRoad;
-void initDbSta(OpenRoad*);
 }
 
 namespace utl {
@@ -88,6 +87,9 @@ class dbSta : public Sta, public ord::OpenRoad::Observer
                 gui::Gui* gui,
                 utl::Logger* logger);
 
+  // Creates the power density heatmap object (for GUI rendering).
+  void initPowerDensityHeatmap();
+
   // Creates a dbSta instance for the given dbBlock using the same context as
   // this dbSta instance (e.g. TCL interpreter, units, etc.)
   std::unique_ptr<dbSta> makeBlockSta(odb::dbBlock* block);
@@ -119,11 +121,6 @@ class dbSta : public Sta, public ord::OpenRoad::Observer
   using Sta::replaceCell;
 
  private:
-  friend void ::ord::initDbSta(::ord::OpenRoad*);
-
-  // Creates the power density heatmap object (for GUI rendering).
-  void initPowerDensityHeatmap();
-
   virtual void makeReport() override;
   virtual void makeNetwork() override;
   virtual void makeSdcNetwork() override;

--- a/src/dbSta/src/CMakeLists.txt
+++ b/src/dbSta/src/CMakeLists.txt
@@ -85,6 +85,7 @@ swig_lib(NAME          dbSta
 
 target_sources(dbSta
   PRIVATE
+    MakeDbSta.cc
     dbSta.cc
     heatMap.cpp
 )

--- a/src/dbSta/src/MakeDbSta.cc
+++ b/src/dbSta/src/MakeDbSta.cc
@@ -1,0 +1,63 @@
+// Copyright 2023 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "db_sta/MakeDbSta.hh"
+
+#include <tcl.h>
+
+#include "db_sta/dbNetwork.hh"
+#include "db_sta/dbSta.hh"
+#include "gui/gui.h"
+#include "heatMap.h"
+#include "odb/db.h"
+#include "ord/OpenRoad.hh"
+#include "sta/StaMain.hh"
+
+extern "C" {
+extern int Dbsta_Init(Tcl_Interp* interp);
+}
+
+namespace sta {
+extern const char* dbSta_tcl_inits[];
+}
+
+namespace ord {
+
+using sta::dbSta;
+
+dbSta* makeDbSta()
+{
+  return new dbSta;
+}
+
+void deleteDbSta(sta::dbSta* sta)
+{
+  delete sta;
+  sta::Sta::setSta(nullptr);
+}
+
+void initDbSta(OpenRoad* openroad)
+{
+  dbSta* sta = openroad->getSta();
+  sta::initSta();
+
+  utl::Logger* logger = openroad->getLogger();
+  sta->initVars(
+      openroad->tclInterp(), openroad->getDb(), gui::Gui::get(), logger);
+
+  Tcl_Interp* tcl_interp = openroad->tclInterp();
+
+  // Define swig TCL commands.
+  Dbsta_Init(tcl_interp);
+  // Eval encoded sta TCL sources.
+  sta::evalTclInit(tcl_interp, sta::dbSta_tcl_inits);
+
+  sta->initPowerDensityHeatmap();
+
+  openroad->addObserver(sta);
+}
+
+}  // namespace ord

--- a/src/dbSta/src/MakeDbSta.cc
+++ b/src/dbSta/src/MakeDbSta.cc
@@ -47,6 +47,7 @@ void initDbSta(OpenRoad* openroad)
   utl::Logger* logger = openroad->getLogger();
   sta->initVars(
       openroad->tclInterp(), openroad->getDb(), gui::Gui::get(), logger);
+  Sta::setSta(sta);
 
   Tcl_Interp* tcl_interp = openroad->tclInterp();
 

--- a/src/dbSta/src/MakeDbSta.cc
+++ b/src/dbSta/src/MakeDbSta.cc
@@ -47,7 +47,7 @@ void initDbSta(OpenRoad* openroad)
   utl::Logger* logger = openroad->getLogger();
   sta->initVars(
       openroad->tclInterp(), openroad->getDb(), gui::Gui::get(), logger);
-  Sta::setSta(sta);
+  sta::Sta::setSta(sta);
 
   Tcl_Interp* tcl_interp = openroad->tclInterp();
 

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -187,10 +187,9 @@ void dbSta::initVars(Tcl_Interp* tcl_interp,
   logger_ = logger;
   makeComponents();
   setTclInterp(tcl_interp);
-  db_network_->init(db, logger);
   db_report_->setLogger(logger);
+  db_network_->init(db, logger);
   db_cbk_ = new dbStaCbk(this, logger);
-  Sta::setSta(this);
 }
 
 void dbSta::initPowerDensityHeatmap()

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -64,39 +64,6 @@
 #include "sta/StaMain.hh"
 #include "utl/Logger.h"
 
-namespace ord {
-
-using sta::dbSta;
-using sta::PathExpanded;
-using sta::PathRef;
-
-sta::dbSta*
-makeDbSta()
-{
-  return new sta::dbSta;
-}
-
-void
-initDbSta(OpenRoad* openroad)
-{
-  dbSta* sta = openroad->getSta();
-  sta->init(openroad->tclInterp(),
-            openroad->getDb(),
-            // Broken gui api missing openroad accessor.
-            gui::Gui::get(),
-            openroad->getLogger());
-  openroad->addObserver(sta);
-}
-
-void
-deleteDbSta(sta::dbSta* sta)
-{
-  delete sta;
-  sta::Sta::setSta(nullptr);
-}
-
-}  // namespace ord
-
 ////////////////////////////////////////////////////////////////
 
 namespace sta {
@@ -193,28 +160,6 @@ private:
   static gui::Painter::Color clock_color;
 };
 
-dbSta*
-makeBlockSta(ord::OpenRoad* openroad, dbBlock* block)
-{
-  dbSta* sta = openroad->getSta();
-  dbSta* sta2 = new dbSta;
-  sta2->makeComponents();
-  sta2->initVars(sta->tclInterp(),
-                 openroad->getDb(),
-                 gui::Gui::get(),
-                 openroad->getLogger());
-  sta2->getDbNetwork()->setBlock(block);
-  sta2->copyUnits(sta->units());
-  return sta2;
-}
-
-extern "C" {
-extern int
-Dbsta_Init(Tcl_Interp* interp);
-}
-
-extern const char* dbSta_tcl_inits[];
-
 dbSta::dbSta() :
   Sta(),
   db_(nullptr),
@@ -232,38 +177,37 @@ dbSta::~dbSta()
   delete path_renderer_;
 }
 
-void
-dbSta::init(Tcl_Interp* tcl_interp,
-            dbDatabase* db,
-            gui::Gui* gui,
-            Logger* logger)
-{
-  initSta();
-  initVars(tcl_interp, db, gui, logger);
-  Sta::setSta(this);
-  // Define swig TCL commands.
-  Dbsta_Init(tcl_interp);
-  // Eval encoded sta TCL sources.
-  evalTclInit(tcl_interp, dbSta_tcl_inits);
-
-  power_density_heatmap_ = std::make_unique<PowerDensityDataSource>(this, logger);
-  power_density_heatmap_->registerHeatMap();
-}
-
-void
-dbSta::initVars(Tcl_Interp* tcl_interp,
-                dbDatabase* db,
-                gui::Gui* gui,
-                Logger* logger)
+void dbSta::initVars(Tcl_Interp* tcl_interp,
+                     odb::dbDatabase* db,
+                     gui::Gui* gui,
+                     utl::Logger* logger)
 {
   db_ = db;
   gui_ = gui;
   logger_ = logger;
   makeComponents();
   setTclInterp(tcl_interp);
-  db_report_->setLogger(logger);
   db_network_->init(db, logger);
+  db_report_->setLogger(logger);
   db_cbk_ = new dbStaCbk(this, logger);
+  Sta::setSta(this);
+}
+
+void dbSta::initPowerDensityHeatmap()
+{
+  power_density_heatmap_
+      = std::make_unique<PowerDensityDataSource>(this, logger_);
+  power_density_heatmap_->registerHeatMap();
+}
+
+std::unique_ptr<dbSta> dbSta::makeBlockSta(odb::dbBlock* block)
+{
+  auto clone = std::make_unique<dbSta>();
+  clone->makeComponents();
+  clone->initVars(tclInterp(), db_, gui_, logger_);
+  clone->getDbNetwork()->setBlock(block);
+  clone->copyUnits(units());
+  return clone;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -3,6 +3,7 @@
 #include "odb/db.h"
 #include "db_sta/dbSta.hh"
 #include "db_sta/dbNetwork.hh"
+#include "db_sta/MakeDbSta.hh"
 #include "ord/OpenRoad.hh"
 #include "sta/VerilogWriter.hh"
 
@@ -31,7 +32,7 @@ sta::Sta *
 make_block_sta(odb::dbBlock *block)
 {
   ord::OpenRoad *openroad = ord::getOpenRoad();
-  return sta::makeBlockSta(openroad, block);
+  return openroad->getSta()->makeBlockSta(block).release();
 }
 
 // For testing

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -58,7 +58,6 @@ using std::array;
 using std::string;
 using std::vector;
 
-using ord::OpenRoad;
 using utl::Logger;
 using gui::Gui;
 
@@ -145,14 +144,13 @@ class Resizer : public StaState
 public:
   Resizer();
   ~Resizer();
-  void init(OpenRoad *openroad,
-            Tcl_Interp *interp,
-            Logger *logger,
-            Gui *gui,
-            dbDatabase *db,
-            dbSta *sta,
-            SteinerTreeBuilder *stt_builder,
-            GlobalRouter *global_router);
+  void init(Tcl_Interp* interp,
+            Logger* logger,
+            Gui* gui,
+            dbDatabase* db,
+            dbSta* sta,
+            SteinerTreeBuilder* stt_builder,
+            GlobalRouter* global_router);
   void setLayerRC(dbTechLayer *layer,
                   const Corner *corner,
                   double res,
@@ -560,7 +558,6 @@ protected:
   LibertyCellSet dont_use_;
   double max_area_;
 
-  OpenRoad *openroad_;
   Logger *logger_;
   SteinerTreeBuilder *stt_builder_;
   GlobalRouter *global_router_;

--- a/src/rsz/src/MakeResizer.cc
+++ b/src/rsz/src/MakeResizer.cc
@@ -56,8 +56,7 @@ deleteResizer(rsz::Resizer *resizer)
 void
 initResizer(OpenRoad *openroad)
 {
-  openroad->getResizer()->init(openroad,
-                               openroad->tclInterp(),
+  openroad->getResizer()->init(openroad->tclInterp(),
                                openroad->getLogger(),
                                // Broken gui api missing openroad accessor.
                                gui::Gui::get(),

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -90,7 +90,6 @@ using odb::dbBox;
 using odb::dbMaster;
 
 using sta::evalTclInit;
-using sta::makeBlockSta;
 using sta::Level;
 using sta::stringLess;
 using sta::NetworkEdit;
@@ -148,7 +147,6 @@ Resizer::Resizer() :
   wire_clk_res_(0.0),
   wire_clk_cap_(0.0),
   max_area_(0.0),
-  openroad_(nullptr),
   logger_(nullptr),
   stt_builder_(nullptr),
   global_router_(nullptr),
@@ -188,17 +186,14 @@ Resizer::~Resizer()
   delete repair_hold_;
 }
 
-void
-Resizer::init(OpenRoad *openroad,
-              Tcl_Interp *interp,
-              Logger *logger,
-              Gui *gui,
-              dbDatabase *db,
-              dbSta *sta,
-              SteinerTreeBuilder *stt_builder,
-              GlobalRouter *global_router)
+void Resizer::init(Tcl_Interp* interp,
+                   Logger* logger,
+                   Gui* gui,
+                   dbDatabase* db,
+                   dbSta* sta,
+                   SteinerTreeBuilder* stt_builder,
+                   GlobalRouter* global_router)
 {
-  openroad_ = openroad;
   logger_ = logger;
   gui_ = gui;
   db_ = db;
@@ -2002,7 +1997,7 @@ Resizer::cellWireDelay(LibertyPort *drvr_port,
 {
   // Make a (hierarchical) block to use as a scratchpad.
   dbBlock *block = dbBlock::create(block_, "wire_delay", '/');
-  dbSta *sta = makeBlockSta(openroad_, block);
+  std::unique_ptr<dbSta> sta = sta_->makeBlockSta(block);
   Parasitics *parasitics = sta->parasitics();
   Network *network = sta->network();
   ArcDelayCalc *arc_delay_calc = sta->arcDelayCalc();
@@ -2062,7 +2057,6 @@ Resizer::cellWireDelay(LibertyPort *drvr_port,
   sta->deleteInstance(drvr);
   sta->deleteInstance(load);
   sta->deleteNet(net);
-  delete sta;
   dbBlock::destroy(block);
 }
 


### PR DESCRIPTION
Avoids dependency on OpenRoad object for creation of block-level dbSta instances.

Remove openroad object dependency from resizer.

Additional development context: we should be able to move dbSta.cc to dbSta_lib once we've abstracted the GUI dependency (and somehow addressed the OpenRoad observer). Those two things still couple it to the OpenRoad object after this change. This is an intermediate step that we felt was pretty self-contained and smaller / easier to review vs needing to "go for broke" of doing the full separation in this PR + GUI changes + OpenRoad observer changes.