### PR TITLE
[odb]: Fixed memory leak in dbProperty

### DIFF
--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -49,8 +49,13 @@ namespace odb {
 template class dbTable<_dbProperty>;
 
 _dbProperty::_dbProperty(_dbDatabase*, const _dbProperty& n)
-    : _flags(n._flags), _name(n._name), _next(n._next), _owner(n._owner), _value(n._value)
-{}
+    : _flags(n._flags),
+      _name(n._name),
+      _next(n._next),
+      _owner(n._owner),
+      _value(n._value)
+{
+}
 
 _dbProperty::_dbProperty(_dbDatabase*)
 {
@@ -156,10 +161,10 @@ dbIStream& operator>>(dbIStream& stream, _dbProperty& prop)
   stream >> prop._name;
   stream >> prop._next;
   stream >> prop._owner;
-  
+
   uint boolean;
   int integer;
-  char* char_string; 
+  char* char_string;
   std::string string_property;
   double double_property;
 

--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -181,8 +181,11 @@ dbIStream& operator>>(dbIStream& stream, _dbProperty& prop)
 
     case DB_STRING_PROP:
       stream >> char_string;
-      prop._value = std::string(char_string);
-      free(char_string);
+      prop._value = "";
+      if (char_string != nullptr) {
+        prop._value = std::string(char_string);
+        free(char_string);
+      }
       break;
 
     case DB_DOUBLE_PROP:
@@ -501,7 +504,7 @@ bool dbBoolProperty::getValue()
 void dbBoolProperty::setValue(bool value)
 {
   _dbProperty* prop = (_dbProperty*) this;
-  prop->_value = value;
+  prop->_value = static_cast<uint>(value);
 }
 
 dbBoolProperty* dbBoolProperty::create(dbObject* object,
@@ -512,7 +515,7 @@ dbBoolProperty* dbBoolProperty::create(dbObject* object,
     return NULL;
 
   _dbProperty* prop = _dbProperty::createProperty(object, name, DB_BOOL_PROP);
-  prop->_value = value;
+  prop->_value = static_cast<uint>(value);
   return (dbBoolProperty*) prop;
 }
 

--- a/src/odb/src/db/dbProperty.h
+++ b/src/odb/src/db/dbProperty.h
@@ -32,8 +32,8 @@
 
 #pragma once
 
-#include <variant>
 #include <string>
+#include <variant>
 
 #include "dbCore.h"
 #include "dbId.h"

--- a/src/odb/src/db/dbProperty.h
+++ b/src/odb/src/db/dbProperty.h
@@ -76,7 +76,7 @@ class _dbProperty : public _dbObject
   dbId<_dbProperty> _next;
   uint _owner;
 
-  std::variant<std::string, uint, int, double> _value;
+  std::variant<std::string, bool, int, double> _value;
 
   _dbProperty(_dbDatabase*);
   _dbProperty(_dbDatabase*, const _dbProperty& n);

--- a/src/odb/src/db/dbProperty.h
+++ b/src/odb/src/db/dbProperty.h
@@ -32,6 +32,9 @@
 
 #pragma once
 
+#include <variant>
+#include <string>
+
 #include "dbCore.h"
 #include "dbId.h"
 #include "dbTypes.h"
@@ -73,13 +76,7 @@ class _dbProperty : public _dbObject
   dbId<_dbProperty> _next;
   uint _owner;
 
-  union
-  {
-    char* _str_val;
-    uint _bool_val;
-    int _int_val;
-    double _double_val;
-  } _value;
+  std::variant<std::string, uint, int, double> _value;
 
   _dbProperty(_dbDatabase*);
   _dbProperty(_dbDatabase*, const _dbProperty& n);


### PR DESCRIPTION
I decided to modernize the class with std::variant. The source of the leak was not freeing char* on replace. This new system relies on std::string which makes things simpler.