### PR TITLE
drt/ta: Reduce memory usage

### DIFF
--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -577,7 +577,7 @@ void TritonRoute::gr()
 
 void TritonRoute::ta()
 {
-  FlexTA ta(getDesign(), logger_);
+  FlexTA ta(getDesign(), logger_, distributed_);
   ta.setDebug(debug_.get(), db_);
   ta.main();
 }

--- a/src/drt/src/ta/FlexTA.cpp
+++ b/src/drt/src/ta/FlexTA.cpp
@@ -99,8 +99,11 @@ int FlexTAWorker::main_mt()
   return 0;
 }
 
-FlexTA::FlexTA(frDesign* in, Logger* logger)
-    : tech_(in->getTech()), design_(in), logger_(logger)
+FlexTA::FlexTA(frDesign* in, Logger* logger, bool save_updates)
+    : tech_(in->getTech()),
+      design_(in),
+      logger_(logger),
+      save_updates_(save_updates)
 {
 }
 
@@ -120,7 +123,8 @@ int FlexTA::initTA_helper(int iter,
   vector<vector<unique_ptr<FlexTAWorker>>> workers;
   if (isH) {
     for (int i = offset; i < (int) ygp.getCount(); i += size) {
-      auto uworker = make_unique<FlexTAWorker>(getDesign(), logger_);
+      auto uworker
+          = make_unique<FlexTAWorker>(getDesign(), logger_, save_updates_);
       auto& worker = *(uworker.get());
       Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(0, i));
       Rect endBox = getDesign()->getTopBlock()->getGCellBox(
@@ -141,7 +145,8 @@ int FlexTA::initTA_helper(int iter,
     }
   } else {
     for (int i = offset; i < (int) xgp.getCount(); i += size) {
-      auto uworker = make_unique<FlexTAWorker>(getDesign(), logger_);
+      auto uworker
+          = make_unique<FlexTAWorker>(getDesign(), logger_, save_updates_);
       auto& worker = *(uworker.get());
       Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(i, 0));
       Rect endBox = getDesign()->getTopBlock()->getGCellBox(

--- a/src/drt/src/ta/FlexTA.h
+++ b/src/drt/src/ta/FlexTA.h
@@ -42,7 +42,7 @@ class FlexTA
 {
  public:
   // constructors
-  FlexTA(frDesign* in, Logger* logger);
+  FlexTA(frDesign* in, Logger* logger, bool save_updates_);
   ~FlexTA();
   // getters
   frTechObject* getTech() const { return tech_; }
@@ -55,6 +55,7 @@ class FlexTA
   frTechObject* tech_;
   frDesign* design_;
   Logger* logger_;
+  bool save_updates_;
   std::unique_ptr<FlexTAGraphics> graphics_;
   // others
   void main_helper(frLayerNum lNum, int maxOffsetIter, int panelWidth);
@@ -103,9 +104,10 @@ class FlexTAWorker
 {
  public:
   // constructors
-  FlexTAWorker(frDesign* designIn, Logger* logger)
+  FlexTAWorker(frDesign* designIn, Logger* logger, bool save_updates)
       : design_(designIn),
         logger_(logger),
+        save_updates_(save_updates),
         dir_(dbTechLayerDir::NONE),
         taIter_(0),
         rq_(this),
@@ -181,6 +183,7 @@ class FlexTAWorker
  private:
   frDesign* design_;
   Logger* logger_;
+  bool save_updates_;
   Rect routeBox_;
   Rect extBox_;
   dbTechLayerDir dir_;

--- a/src/drt/src/ta/FlexTA_end.cpp
+++ b/src/drt/src/ta/FlexTA_end.cpp
@@ -38,12 +38,13 @@ void FlexTAWorker::saveToGuides()
       if (uPinFig->typeId() == tacPathSeg) {
         unique_ptr<frPathSeg> pathSeg
             = make_unique<frPathSeg>(*static_cast<taPathSeg*>(uPinFig.get()));
-        drUpdate update(drUpdate::ADD_GUIDE);
-        update.setPathSeg(*pathSeg.get());
-        update.setIndexInOwner(iroute->getGuide()->getIndexInOwner());
-        update.setNet(iroute->getGuide()->getNet());
-        design_->addUpdate(update);
-
+        if (save_updates_) {
+          drUpdate update(drUpdate::ADD_GUIDE);
+          update.setPathSeg(*pathSeg.get());
+          update.setIndexInOwner(iroute->getGuide()->getIndexInOwner());
+          update.setNet(iroute->getGuide()->getNet());
+          design_->addUpdate(update);
+        }
         pathSeg->addToNet(iroute->getGuide()->getNet());
         auto guide = iroute->getGuide();
         vector<unique_ptr<frConnFig>> tmp;

--- a/src/drt/src/ta/FlexTA_end.cpp
+++ b/src/drt/src/ta/FlexTA_end.cpp
@@ -40,7 +40,7 @@ void FlexTAWorker::saveToGuides()
             = make_unique<frPathSeg>(*static_cast<taPathSeg*>(uPinFig.get()));
         if (save_updates_) {
           drUpdate update(drUpdate::ADD_GUIDE);
-          update.setPathSeg(*pathSeg.get());
+          update.setPathSeg(*pathSeg);
           update.setIndexInOwner(iroute->getGuide()->getIndexInOwner());
           update.setNet(iroute->getGuide()->getNet());
           design_->addUpdate(update);


### PR DESCRIPTION
Only save updates in TA when distributed mode is on. On my machine this reduces the peak memory usage on ispd2019 test10 from 44 GB to 37 GB.