### PR TITLE
ppl: update check for available slots

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1438,6 +1438,15 @@ void IOPlacer::run(bool random_mode)
   initIOLists();
   defineSlots();
 
+  if (netlist_io_pins_->getIOPins().size() > slots_.size()) {
+    logger_->error(PPL,
+                   24,
+                   "Number of IO pins ({}) exceeds maximum number of available "
+                   "positions ({}).",
+                   netlist_io_pins_->getIOPins().size(),
+                   slots_.size());
+  }
+
   initMirroredPins();
   initConstraints();
 

--- a/src/ppl/src/IOPlacer.tcl
+++ b/src/ppl/src/IOPlacer.tcl
@@ -496,10 +496,6 @@ proc place_pins { args } {
 
   set num_slots [expr (2*$num_tracks_x + 2*$num_tracks_y)/$min_dist]
 
-  if { ($bterms_cnt > $num_slots) } {
-    utl::error PPL 24 "Number of pins $bterms_cnt exceeds max possible $num_slots."
-  }
-
   if { $regions != {} } {
     set lef_units [$dbTech getLefUnits]
 


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/3149

Previously, the check for available slots against the number of IO pins wasn't considering already placed pins and the calculation of the number of slots needed to be more accurate. Moved it to cpp code to get the correct number of pins and slots.