### PR TITLE
grt: fix net min layer calculation

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -846,9 +846,9 @@ bool GlobalRouter::makeFastrouteNet(Net* net)
     int min_pin_layer = std::numeric_limits<int>::max();
     for (RoutePt& pin_pos : pins_on_grid) {
       fr_net->addPin(pin_pos.x(), pin_pos.y(), pin_pos.layer() - 1);
-      min_pin_layer = std::min(min_pin_layer, pin_pos.layer()) - 1;
+      min_pin_layer = std::min(min_pin_layer, pin_pos.layer());
     }
-    fr_net->setMinLayer(std::max(min_pin_layer, min_layer - 1));
+    fr_net->setMinLayer(std::max(min_pin_layer - 1, min_layer - 1));
     // Save stt input on debug file
     if (fastroute_->hasSaveSttInput()
         && net->getDbNet() == fastroute_->getDebugNet()) {


### PR DESCRIPTION
This fix is related to a bug in mock-array-big, where nets that only have pins in M4 were routed in lower layers (M2). The root cause of the issue was using the macro extensions, making FastRoute detect congestion in M4. Removing the macro extensions fixed the issue.

But while debugging the code, I found this minor bug where the min routing layer calculated from the pins layer wasn't correct. This fix ensure the `min_pin_layer` will have the correct value.