### PR TITLE
Break Observer OpenRoad coupling

### DIFF
--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -39,6 +39,8 @@
 #include <string>
 #include <vector>
 
+#include "OpenRoadObserver.hh"
+
 extern "C" {
 struct Tcl_Interp;
 }
@@ -235,24 +237,8 @@ class OpenRoad
   void setThreadCount(const char* threads, bool printInfo = true);
   int getThreadCount();
 
-  // Observer interface
-  class Observer
-  {
-   public:
-    virtual ~Observer();
-
-    // Either pointer could be null
-    virtual void postReadLef(odb::dbTech* tech, odb::dbLib* library) = 0;
-    virtual void postReadDef(odb::dbBlock* block) = 0;
-    virtual void postReadDb(odb::dbDatabase* db) = 0;
-
-   private:
-    OpenRoad* owner_ = nullptr;
-    friend class OpenRoad;
-  };
-
-  void addObserver(Observer* observer);
-  void removeObserver(Observer* observer);
+  void addObserver(OpenRoadObserver* observer);
+  void removeObserver(OpenRoadObserver* observer);
 
  protected:
   ~OpenRoad();
@@ -288,7 +274,7 @@ class OpenRoad
   stt::SteinerTreeBuilder* stt_builder_ = nullptr;
   dft::Dft* dft_ = nullptr;
 
-  std::set<Observer*> observers_;
+  std::set<OpenRoadObserver*> observers_;
 
   int threads_ = 1;
 };

--- a/include/ord/OpenRoadObserver.hh
+++ b/include/ord/OpenRoadObserver.hh
@@ -1,0 +1,49 @@
+// Copyright 2019-2023 The Regents of the University of California, Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#pragma once
+
+#include <functional>
+
+namespace odb {
+
+class dbBlock;
+class dbDatabase;
+class dbLib;
+class dbTech;
+
+}  // namespace odb
+
+namespace ord {
+
+class OpenRoad;
+
+// Observer interface
+class OpenRoadObserver
+{
+ public:
+  virtual ~OpenRoadObserver()
+  {
+    if (unregister_observer_ != nullptr) {
+      unregister_observer_();
+    }
+  }
+
+  // Either pointer could be null
+  virtual void postReadLef(odb::dbTech* tech, odb::dbLib* library) = 0;
+  virtual void postReadDef(odb::dbBlock* block) = 0;
+  virtual void postReadDb(odb::dbDatabase* db) = 0;
+
+  void set_unregister_observer(std::function<void()> unregister_observer)
+  {
+    unregister_observer_ = std::move(unregister_observer);
+  }
+
+ private:
+  std::function<void()> unregister_observer_;
+};
+
+}  // namespace ord

--- a/include/ord/OpenRoadObserver.hh
+++ b/include/ord/OpenRoadObserver.hh
@@ -27,7 +27,7 @@ class OpenRoadObserver
  public:
   virtual ~OpenRoadObserver()
   {
-    if (unregister_observer_ != nullptr) {
+    if (unregister_observer_) {
       unregister_observer_();
     }
   }

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -287,7 +287,7 @@ void OpenRoad::readLef(const char* filename,
 
   // both are null on parser failure
   if (lib != nullptr || tech != nullptr) {
-    for (Observer* observer : observers_) {
+    for (OpenRoadObserver* observer : observers_) {
       observer->postReadLef(tech, lib);
     }
   }
@@ -323,7 +323,7 @@ void OpenRoad::readDef(const char* filename,
   dbChip* chip = def_reader.createChip(search_libs, filename);
   if (chip) {
     dbBlock* block = chip->getBlock();
-    for (Observer* observer : observers_) {
+    for (OpenRoadObserver* observer : observers_) {
       observer->postReadDef(block);
     }
   }
@@ -421,7 +421,7 @@ void OpenRoad::readDb(const char* filename)
   db_->read(stream);
   fclose(stream);
 
-  for (Observer* observer : observers_) {
+  for (OpenRoadObserver* observer : observers_) {
     observer->postReadDb(db_);
   }
 }
@@ -477,14 +477,14 @@ void OpenRoad::linkDesign(const char* design_name)
 
 {
   dbLinkDesign(design_name, verilog_network_, db_, logger_);
-  for (Observer* observer : observers_) {
+  for (OpenRoadObserver* observer : observers_) {
     observer->postReadDb(db_);
   }
 }
 
 void OpenRoad::designCreated()
 {
-  for (Observer* observer : observers_) {
+  for (OpenRoadObserver* observer : observers_) {
     observer->postReadDb(db_);
   }
 }
@@ -500,25 +500,19 @@ odb::Rect OpenRoad::getCore()
   return db_->getChip()->getBlock()->getCoreArea();
 }
 
-void OpenRoad::addObserver(Observer* observer)
+void OpenRoad::addObserver(OpenRoadObserver* observer)
 {
-  assert(observer->owner_ == nullptr);
-  observer->owner_ = this;
+  observer->set_unregister_observer(
+      [this, observer] { removeObserver(observer); });
   observers_.insert(observer);
 }
 
-void OpenRoad::removeObserver(Observer* observer)
+void OpenRoad::removeObserver(OpenRoadObserver* observer)
 {
-  observer->owner_ = nullptr;
+  observer->set_unregister_observer(nullptr);
   observers_.erase(observer);
 }
 
-OpenRoad::Observer::~Observer()
-{
-  if (owner_) {
-    owner_->removeObserver(this);
-  }
-}
 void OpenRoad::setThreadCount(int threads, bool printInfo)
 {
   int max_threads = std::thread::hardware_concurrency();

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -39,7 +39,7 @@
 
 #include "odb/db.h"
 #include "odb/dbBlockCallBackObj.h"
-#include "ord/OpenRoad.hh"
+#include "ord/OpenRoadObserver.hh"
 #include "sta/Sta.hh"
 
 namespace ord {
@@ -72,7 +72,7 @@ using odb::dbMaster;
 using odb::dbNet;
 using odb::dbTech;
 
-class dbSta : public Sta, public ord::OpenRoad::Observer
+class dbSta : public Sta, public ord::OpenRoadObserver
 {
  public:
   dbSta();

--- a/src/dbSta/src/CMakeLists.txt
+++ b/src/dbSta/src/CMakeLists.txt
@@ -36,6 +36,7 @@
 include("openroad")
 
 add_library(dbSta_lib
+  dbSta.cc
   dbNetwork.cc
   dbSdcNetwork.cc
   dbReadVerilog.cc
@@ -86,7 +87,6 @@ swig_lib(NAME          dbSta
 target_sources(dbSta
   PRIVATE
     MakeDbSta.cc
-    dbSta.cc
     heatMap.cpp
     PathRenderer.cc
 )

--- a/src/drt/test/stubs.cpp
+++ b/src/drt/test/stubs.cpp
@@ -77,21 +77,17 @@ void OpenRoad::readDb(const char*)
 {
 }
 
-void OpenRoad::addObserver(Observer* observer)
+void OpenRoad::addObserver(OpenRoadObserver* observer)
 {
 }
 
-void OpenRoad::removeObserver(Observer* observer)
+void OpenRoad::removeObserver(OpenRoadObserver* observer)
 {
 }
 
 int OpenRoad::getThreadCount()
 {
   return 0;
-}
-
-OpenRoad::Observer::~Observer()
-{
 }
 
 }  // namespace ord

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -67,7 +67,7 @@ class BrowserWidget;
 
 // This is the main window for the GUI.  Currently we use a single
 // instance of this class.
-class MainWindow : public QMainWindow, public ord::OpenRoad::Observer
+class MainWindow : public QMainWindow, public ord::OpenRoadObserver
 {
   Q_OBJECT
 

--- a/src/ifp/src/InitFloorplan.i
+++ b/src/ifp/src/InitFloorplan.i
@@ -37,6 +37,7 @@
 
 #include "db_sta/dbSta.hh"
 #include "ifp/InitFloorplan.hh"
+#include "ord/OpenRoad.hh"
 #include "utl/Logger.h"
 
 // Defined by OpenRoad.i

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -41,6 +41,7 @@
 
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "ord/OpenRoad.hh"
 #include "sta/FuncExpr.hh"
 #include "sta/Liberty.hh"
 #include "utl/Logger.h"


### PR DESCRIPTION
This makes the OpenRoadObserver not depend on the concrete
implementation of the OpenRoad object itself, so that the dbSta.cc file
can be moved to the non-application target dbSta_lib.