### PR TITLE
drt: Shrink frInstBlockage and frInstTerm

### DIFF
--- a/src/drt/src/db/obj/frInstBlockage.h
+++ b/src/drt/src/db/obj/frInstBlockage.h
@@ -41,7 +41,7 @@ class frInstBlockage : public frBlockObject
  public:
   // constructors
   frInstBlockage(frInst* inst, frBlockage* blockage)
-      : inst_(inst), blockage_(blockage), index_in_owner_(0)
+      : inst_(inst), blockage_(blockage)
   {
   }
   // getters
@@ -54,8 +54,10 @@ class frInstBlockage : public frBlockObject
   int getIndexInOwner() const { return index_in_owner_; }
 
  private:
+  // Place this first so it is adjacent to "int id_" inherited from
+  // frBlockObject, saving 8 bytes.
+  int index_in_owner_{0};
   frInst* inst_;
   frBlockage* blockage_;
-  int index_in_owner_;
 };
 }  // namespace fr

--- a/src/drt/src/db/obj/frInstTerm.h
+++ b/src/drt/src/db/obj/frInstTerm.h
@@ -46,16 +46,11 @@ class frInstTerm : public frBlockObject
  public:
   // constructors
   frInstTerm(frInst* inst, frMTerm* term)
-      : inst_(inst), term_(term), net_(nullptr), ap_(), index_in_owner_(0)
+      : inst_(inst), term_(term), net_(nullptr), ap_()
   {
   }
   frInstTerm(const frInstTerm& in)
-      : frBlockObject(),
-        inst_(in.inst_),
-        term_(in.term_),
-        net_(in.net_),
-        ap_(),
-        index_in_owner_(0)
+      : frBlockObject(), inst_(in.inst_), term_(in.term_), net_(in.net_), ap_()
   {
   }
   // getters
@@ -81,11 +76,13 @@ class frInstTerm : public frBlockObject
   int getIndexInOwner() const { return index_in_owner_; }
 
  private:
+  // Place this first so it is adjacent to "int id_" inherited from
+  // frBlockObject, saving 8 bytes.
+  int index_in_owner_{0};
   frInst* inst_;
   frMTerm* term_;
   frNet* net_;
   std::vector<frAccessPoint*> ap_;  // follows pin index
-  int index_in_owner_;
 };
 
 }  // namespace fr


### PR DESCRIPTION
Rearrange the memory layout such that the 4 byte id_ (from frBlockObject) and 4 byte index_in_owner_ are adjacent, saving 8 bytes.

This reduces memory consumption by 300MB on ispd2019 test10.