### PR TITLE
grt: Add -scenic_routes_report_file option

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -168,6 +168,7 @@ class GlobalRouter
   void setVerbose(const bool v);
   void setOverflowIterations(int iterations);
   void setCongestionReportFile(const char* file_name);
+  void setScenicRoutesReportFile(const char* file_name);
   void setGridOrigin(int x, int y);
   void setAllowCongestion(bool allow_congestion);
   void setMacroExtension(int macro_extension);
@@ -189,6 +190,7 @@ class GlobalRouter
   std::vector<int> routeLayerLengths(odb::dbNet* db_net);
   void globalRoute(bool save_guides = false);
   void saveCongestion();
+  void saveScenicRoutes();
   NetRouteMap& getRoutes() { return routes_; }
   bool haveRoutes();
   Net* getNet(odb::dbNet* db_net);
@@ -435,6 +437,9 @@ class GlobalRouter
 
   // variables congestion report file
   const char* congestion_file_name_;
+
+  // variables scenic routes report file
+  const char* scenic_routes_file_name_;
 
   friend class IncrementalGRoute;
   friend class GRouteDbCbk;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4078,7 +4078,7 @@ void GlobalRouter::saveScenicRoutes()
     const auto grtLength = computeNetWirelength(db_net);
     const int extraLength = dbuToMicrons(grtLength-sttLength);
 
-    lengths.push_back({extraLength, db_net});
+    lengths.emplace_back(extraLength, db_net);
   }
 
   std::sort(lengths.rbegin(), lengths.rend());

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4076,7 +4076,7 @@ void GlobalRouter::saveScenicRoutes()
   for (odb::dbNet* db_net : block_->getNets()) {
     const auto sttLength = fastroute_->getSTTLength(db_net);
     const auto grtLength = computeNetWirelength(db_net);
-    const int extraLength = dbuToMicrons(grtLength-sttLength);
+    const int extraLength = dbuToMicrons(grtLength - sttLength);
 
     lengths.emplace_back(extraLength, db_net);
   }
@@ -4099,12 +4099,13 @@ void GlobalRouter::saveScenicRoutes()
         bbox.merge(globalRoutingToBox(seg));
       }
 
-      out << "  violation type: GRT scenic route " << length << " um longer than RSMT" << std::endl;
+      out << "  violation type: GRT scenic route " << length
+          << " um longer than RSMT" << std::endl;
       out << "    srcs: ";
       out << "net:" << db_net->getName() << std::endl;
       out << "    bbox = ( " << dbuToMicrons(bbox.xMin()) << ", "
-          << dbuToMicrons(bbox.yMin()) << " ) - ( " << dbuToMicrons(bbox.xMax()) << ", "
-          << dbuToMicrons(bbox.yMax()) << " ) on Layer ";
+          << dbuToMicrons(bbox.yMin()) << " ) - ( " << dbuToMicrons(bbox.xMax())
+          << ", " << dbuToMicrons(bbox.yMax()) << " ) on Layer ";
       // We don't need the layer, but the format requires it
       out << routing_layers_[1]->getName() << std::endl;
     }

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -117,6 +117,11 @@ void set_congestion_report_file (const char * file_name)
   getGlobalRouter()->setCongestionReportFile(file_name);
 }
 
+void set_scenic_routes_report_file (const char * file_name)
+{
+  getGlobalRouter()->setScenicRoutesReportFile(file_name);
+}
+
 void
 set_grid_origin(int x, int y)
 {

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -196,6 +196,7 @@ sta::define_cmd_args "global_route" {[-guide_file out_file] \
                                   [-grid_origin origin] \
                                   [-overflow_iterations iterations] \
                                   [-critical_nets_percentage percent] \
+                                  [-scenic_routes_report_file file_name] \
                                   [-allow_congestion] \
                                   [-allow_overflow] \
                                   [-verbose]
@@ -204,7 +205,8 @@ sta::define_cmd_args "global_route" {[-guide_file out_file] \
 proc global_route { args } {
   sta::parse_key_args "global_route" args \
     keys {-guide_file -congestion_iterations -congestion_report_file \
-          -overflow_iterations -grid_origin -critical_nets_percentage
+          -overflow_iterations -grid_origin -critical_nets_percentage \
+          -scenic_routes_report_file
          } \
     flags {-allow_congestion -allow_overflow -verbose}
 
@@ -243,6 +245,11 @@ proc global_route { args } {
   if { [info exists keys(-congestion_report_file) ] } {
     set file_name $keys(-congestion_report_file)
     grt::set_congestion_report_file $file_name
+  }
+
+  if { [info exists keys(-scenic_routes_report_file) ] } {
+    set file_name $keys(-scenic_routes_report_file)
+    grt::set_scenic_routes_report_file $file_name
   }
 
   if { [info exists keys(-overflow_iterations)] } {

--- a/src/grt/src/fastroute/include/DataType.h
+++ b/src/grt/src/fastroute/include/DataType.h
@@ -112,6 +112,9 @@ struct FrNet  // A Net is a set of connected MazePoints
   void setMaxLayer(int max_layer) { max_layer_ = max_layer; }
   void setMinLayer(int min_layer) { min_layer_ = min_layer; }
 
+  int getSTTLength() const { return stt_length_; }
+  void setSTTLength(int length) { stt_length_ = length; }
+
  private:
   odb::dbNet* db_net_;
   std::vector<int> pin_x_;  // x coordinates of pins
@@ -126,6 +129,7 @@ struct FrNet  // A Net is a set of connected MazePoints
   // Non-null when an NDR has been applied to the net.
   std::unique_ptr<std::vector<int>> edge_cost_per_layer_;
   bool is_routed_ = false;
+  int stt_length_;
 };
 
 struct Edge  // An Edge is the routing track holder between two adjacent

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -186,7 +186,7 @@ class FastRouteCore
   }
   const std::vector<int>& getMaxVerticalOverflows() { return max_v_overflow_; }
 
-  const int getSTTLength(odb::dbNet* net)
+  int getSTTLength(odb::dbNet* net)
   {
     auto netid = db_net_id_map_[net];
     auto fr_net = nets_[netid];

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -186,6 +186,13 @@ class FastRouteCore
   }
   const std::vector<int>& getMaxVerticalOverflows() { return max_v_overflow_; }
 
+  const int getSTTLength(odb::dbNet* net)
+  {
+    auto netid = db_net_id_map_[net];
+    auto fr_net = nets_[netid];
+    return fr_net->getSTTLength();
+  }
+
   // debug mode functions
   void setDebugOn(bool isOn);
   void setDebugNet(const odb::dbNet* net);

--- a/src/grt/src/fastroute/src/RSMT.cpp
+++ b/src/grt/src/fastroute/src/RSMT.cpp
@@ -749,7 +749,7 @@ void FastRouteCore::gen_brk_RSMT(const bool congestionDriven,
       const int x2 = rsmt.branch[n].x;
       const int y2 = rsmt.branch[n].y;
 
-      thisWl  += abs(x1 - x2) + abs(y1 - y2);
+      thisWl += abs(x1 - x2) + abs(y1 - y2);
 
       if (x1 != x2 || y1 != y2) {  // the branch is not degraded (a point)
         // the position of this segment in seglist

--- a/src/grt/src/fastroute/src/RSMT.cpp
+++ b/src/grt/src/fastroute/src/RSMT.cpp
@@ -740,6 +740,8 @@ void FastRouteCore::gen_brk_RSMT(const bool congestionDriven,
         wl1 += sttrees_[i].edges[j].len;
     }
 
+    int thisWl = 0;
+
     for (int j = 0; j < rsmt.branchCount(); j++) {
       const int x1 = rsmt.branch[j].x;
       const int y1 = rsmt.branch[j].y;
@@ -747,7 +749,7 @@ void FastRouteCore::gen_brk_RSMT(const bool congestionDriven,
       const int x2 = rsmt.branch[n].x;
       const int y2 = rsmt.branch[n].y;
 
-      wl += abs(x1 - x2) + abs(y1 - y2);
+      thisWl  += abs(x1 - x2) + abs(y1 - y2);
 
       if (x1 != x2 || y1 != y2) {  // the branch is not degraded (a point)
         // the position of this segment in seglist
@@ -768,6 +770,9 @@ void FastRouteCore::gen_brk_RSMT(const bool congestionDriven,
         seg.netID = i;
       }
     }  // loop j
+
+    net->setSTTLength(thisWl);
+    wl += thisWl;
 
     totalNumSeg += seglist_[i].size();
 


### PR DESCRIPTION
Add an option to create a report of the most scenic routes in global routing.

This is a first pass and needs work, but it allows me to quickly see where grt had congestion issues and had to route specific tracks all over the die. Some issues:

- Is "scenic route" a common enough name for this?
- Should we reuse the TritonRoute format, or use JSON?
- How should we format these reports? Right now each has their own top level entry, and unfortunately they get reverse sorted (shortest to longest). We also end up with a mess of DRC boxes making it impossible to see the design.
- What metrics do we want for flagging these routes? Below I flag any routes that are 1000 dbu larger than the Steiner tree, which is pretty arbitrary.