### PR TITLE
turn off tests in mpl2 when ENABLE_TESTS is off

### DIFF
--- a/src/mpl2/CMakeLists.txt
+++ b/src/mpl2/CMakeLists.txt
@@ -93,4 +93,6 @@ target_link_libraries(mpl2
     gui
 )
 
-add_subdirectory(test/cpp)
+if(ENABLE_TESTS)
+  add_subdirectory(test/cpp)
+endif()


### PR DESCRIPTION
Fixes:
- cmake will fail because GoogleTest is not included when ENABLE_TESTS is off, this mirrors the behavior of drt and openroad