### PR TITLE
dpl: filler masters use string match instead of regexp to avoid matching everything

### DIFF
--- a/src/dpl/src/Opendp.tcl
+++ b/src/dpl/src/Opendp.tcl
@@ -184,11 +184,11 @@ proc detailed_placement_debug { args } {
 }
 
 proc get_masters_arg { arg_name arg } {
-  set matched 0
   set masters {}
   # Expand master name regexps
   set db [ord::get_db]
   foreach name $arg {
+    set matched 0
     foreach lib [$db getLibs] {
       foreach master [$lib getMasters] {
         set master_name [$master getConstName]
@@ -198,9 +198,13 @@ proc get_masters_arg { arg_name arg } {
         }
       }
     }
+    if { !$matched } {
+      utl::warn "DPL" 28 "$name did not match any masters."
+    }
   }
-  if { !$matched } {
-    utl::warn "DPL" 28 "$name did not match any masters."
+  if { [llength $arg] > 0 && [llength $masters] == 0 } {
+    utl::error "DPL" 39 "\"$arg\" did not match any masters.
+This could be due to a change from using regex to glob to search for cell masters. https://github.com/The-OpenROAD-Project/OpenROAD/pull/3210"
   }
   return $masters
 }

--- a/src/dpl/src/Opendp.tcl
+++ b/src/dpl/src/Opendp.tcl
@@ -192,7 +192,7 @@ proc get_masters_arg { arg_name arg } {
     foreach lib [$db getLibs] {
       foreach master [$lib getMasters] {
         set master_name [$master getConstName]
-        if { [regexp $name $master_name] } {
+        if { [string match $name $master_name] } {
           lappend masters $master
           set matched 1
         }

--- a/src/dpl/test/fillers3.ok
+++ b/src/dpl/test/fillers3.ok
@@ -17,4 +17,4 @@ original HPWL               2.3 u
 legalized HPWL              9.1 u
 delta HPWL                  299 %
 
-[INFO DPL-0001] Placed 12 filler instances.
+[INFO DPL-0001] Placed 61 filler instances.

--- a/src/dpl/test/fillers3.py
+++ b/src/dpl/test/fillers3.py
@@ -8,8 +8,6 @@ design = Design(tech)
 design.readDef("simple01.def")
 
 dpl_aux.detailed_placement(design)
-# In the tcl version, the regex "FILLCELL_X1" matches both "FILLCELL_X1" and 
-# "FILLCELL_X16" but here we must specify both
-masters=["FILLCELL_X1", "FILLCELL_X16", "FILLCELL_X2"]
+masters=["FILLCELL_X1", "FILLCELL_X2"]
 dpl_aux.filler_placement(design, masters=masters)
 design.getOpendp().checkPlacement(False)

--- a/src/dpl/test/fillers4.ok
+++ b/src/dpl/test/fillers4.ok
@@ -20,4 +20,4 @@ original HPWL               8.6 u
 legalized HPWL              8.7 u
 delta HPWL                    2 %
 
-[INFO DPL-0001] Placed 10 filler instances.
+[INFO DPL-0001] Placed 19 filler instances.

--- a/src/dpl/test/fillers4.py
+++ b/src/dpl/test/fillers4.py
@@ -9,6 +9,6 @@ design = Design(tech)
 design.readDef("fillers4.def")
 
 dpl_aux.detailed_placement(design, disallow_one_site_gaps=True)
-masters=["FILLCELL_X1", "FILLCELL_X16", "FILLCELL_X2", "FILLCELL_X3", "FILLCELL_X4", "FILLCELL_X8"]
+masters=["FILLCELL_X2", "FILLCELL_X3", "FILLCELL_X4", "FILLCELL_X8"]
 dpl_aux.filler_placement(design, masters=masters)
 design.getOpendp().checkPlacement(False)


### PR DESCRIPTION
This is a different solution to #2839 

This preserves the matching without requiring the -regexp flag.
