### PR TITLE
[db_sta]: Fixes initialization without gui

### DIFF
--- a/src/dbSta/src/MakeDbSta.cc
+++ b/src/dbSta/src/MakeDbSta.cc
@@ -49,9 +49,11 @@ void initDbSta(OpenRoad* openroad)
   sta->initVars(openroad->tclInterp(), openroad->getDb(), logger);
   sta::Sta::setSta(sta);
 
-  sta->setPathRenderer(std::make_unique<sta::PathRenderer>(sta));
-  sta->setPowerDensityDataSource(
-      std::make_unique<sta::PowerDensityDataSource>(sta, logger));
+  if (gui::Gui::enabled()) {
+    sta->setPathRenderer(std::make_unique<sta::PathRenderer>(sta));
+    sta->setPowerDensityDataSource(
+        std::make_unique<sta::PowerDensityDataSource>(sta, logger));
+  }
 
   Tcl_Interp* tcl_interp = openroad->tclInterp();
 

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -403,7 +403,7 @@ dbStaReport::printString(const char* buffer, size_t length)
 
   // if gui enabled, keep tcl_buffer_ until a newline appears
   // otherwise proceed to print directly to console
-  if (gui_is_on_) {
+  if (!gui_is_on_) {
     // puts without a trailing \n in the string.
     // Tcl command prompts get here.
     // puts "xyz" makes a separate call for the '\n '.


### PR DESCRIPTION
* In Google build gui::Gui::get()->registerRenderer call fails when built without gui support, the added `if` statement protects against that.
* gui_is_on check was inadvertently flipped.