### PR TITLE
Changing dbSigType and dbIoType from enum to enum class

### DIFF
--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -383,14 +383,14 @@ std::pair<double, double> AntennaChecker::calculateWireArea(
   vector<std::pair<dbWireGraph::Edge*, dbIoType>> edge_vec;
   if (node->in_edge() != nullptr
       && nv.find(node->in_edge()->source()) == nv.end()) {
-    edge_vec.emplace_back(node->in_edge(), dbIoType::INPUT);
+    edge_vec.emplace_back(node->in_edge(), dbIoType::Value::INPUT);
   }
 
   dbWireGraph::Node::edge_iterator edge_it;
 
   for (edge_it = node->begin(); edge_it != node->end(); edge_it++) {
     if (nv.find((*edge_it)->source()) == nv.end()) {
-      edge_vec.emplace_back(*edge_it, dbIoType::OUTPUT);
+      edge_vec.emplace_back(*edge_it, dbIoType::Value::OUTPUT);
     }
   }
 
@@ -401,7 +401,7 @@ std::pair<double, double> AntennaChecker::calculateWireArea(
     dbIoType edge_io_type = edge_info.second;
     if (edge->type() == dbWireGraph::Edge::Type::VIA
         || edge->type() == dbWireGraph::Edge::Type::TECH_VIA) {
-      if (edge_io_type == dbIoType::INPUT) {
+      if (edge_io_type == dbIoType::Value::INPUT) {
         if (edge->source()->layer()->getRoutingLevel() <= wire_level) {
           std::pair<double, double> areas
               = calculateWireArea(edge->source(), wire_level, nv, level_nodes);
@@ -410,7 +410,7 @@ std::pair<double, double> AntennaChecker::calculateWireArea(
         }
       }
 
-      if (edge_io_type == dbIoType::OUTPUT) {
+      if (edge_io_type == dbIoType::Value::OUTPUT) {
         if (edge->target()->layer()->getRoutingLevel() <= wire_level) {
           std::pair<double, double> areas
               = calculateWireArea(edge->target(), wire_level, nv, level_nodes);
@@ -422,7 +422,7 @@ std::pair<double, double> AntennaChecker::calculateWireArea(
 
     if (edge->type() == dbWireGraph::Edge::Type::SEGMENT
         || edge->type() == dbWireGraph::Edge::Type::SHORT) {
-      if (edge_io_type == dbIoType::INPUT) {
+      if (edge_io_type == dbIoType::Value::INPUT) {
         if (node->layer()->getRoutingLevel() == wire_level) {
           level_nodes.insert(node);
           edge->source()->xy(end_x, end_y);
@@ -445,7 +445,7 @@ std::pair<double, double> AntennaChecker::calculateWireArea(
         side_wire_area += areas.second;
       }
 
-      if (edge_io_type == dbIoType::OUTPUT) {
+      if (edge_io_type == dbIoType::Value::OUTPUT) {
         if (node->layer()->getRoutingLevel() == wire_level) {
           level_nodes.insert(node);
           edge->target()->xy(end_x, end_y);
@@ -1543,7 +1543,7 @@ void AntennaChecker::findWireRoots(dbWire* wire,
     if (node->object() && node->object()->getObjectType() == dbITermObj) {
       dbITerm* iterm = dbITerm::getITerm(block_, node->object()->getId());
       dbMTerm* mterm = iterm->getMTerm();
-      if (mterm->getIoType() == dbIoType::INPUT && gateArea(mterm) > 0.0) {
+      if (mterm->getIoType() == dbIoType::Value::INPUT && gateArea(mterm) > 0.0) {
         gate_iterms.push_back(node);
       }
     }

--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -1543,7 +1543,8 @@ void AntennaChecker::findWireRoots(dbWire* wire,
     if (node->object() && node->object()->getObjectType() == dbITermObj) {
       dbITerm* iterm = dbITerm::getITerm(block_, node->object()->getId());
       dbMTerm* mterm = iterm->getMTerm();
-      if (mterm->getIoType() == dbIoType::Value::INPUT && gateArea(mterm) > 0.0) {
+      if (mterm->getIoType() == dbIoType::Value::INPUT
+          && gateArea(mterm) > 0.0) {
         gate_iterms.push_back(node);
       }
     }

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -510,12 +510,12 @@ void TechChar::initCharacterization()
       = db_->findMaster(options_->getSinkBuffer().c_str());
 
   for (odb::dbMTerm* masterTerminal : charBuf_->getMTerms()) {
-    if (masterTerminal->getIoType() == odb::dbIoType::INPUT
-        && (masterTerminal->getSigType() == odb::dbSigType::SIGNAL
-            || masterTerminal->getSigType() == odb::dbSigType::CLOCK)) {
+    if (masterTerminal->getIoType() == odb::dbIoType::Value::INPUT
+        && (masterTerminal->getSigType() == odb::dbSigType::Value::SIGNAL
+            || masterTerminal->getSigType() == odb::dbSigType::Value::CLOCK)) {
       charBufIn_ = masterTerminal;
-    } else if (masterTerminal->getIoType() == odb::dbIoType::OUTPUT
-               && masterTerminal->getSigType() == odb::dbSigType::SIGNAL) {
+    } else if (masterTerminal->getIoType() == odb::dbIoType::Value::OUTPUT
+               && masterTerminal->getSigType() == odb::dbSigType::Value::SIGNAL) {
       charBufOut_ = masterTerminal;
     }
   }
@@ -671,13 +671,13 @@ std::vector<TechChar::SolutionData> TechChar::createPatterns(
                                 + std::to_string(wireCounter);
     net = odb::dbNet::create(charBlock_, netName.c_str());
     odb::dbWire::create(net);
-    net->setSigType(odb::dbSigType::SIGNAL);
+    net->setSigType(odb::dbSigType::Value::SIGNAL);
     // Creates the input port.
     const std::string inPortName
         = "in_" + std::to_string(setupWirelength) + solutionCounter.to_string();
     odb::dbBTerm* inPort = odb::dbBTerm::create(
         net, inPortName.c_str());  // sig type is signal by default
-    inPort->setIoType(odb::dbIoType::INPUT);
+    inPort->setIoType(odb::dbIoType::Value::INPUT);
     odb::dbBPin* inPortPin = odb::dbBPin::create(inPort);
     // Updates the topology with the new port.
     topology.inPort = inPortPin;
@@ -712,7 +712,7 @@ std::vector<TechChar::SolutionData> TechChar::createPatterns(
         net = odb::dbNet::create(charBlock_, netName.c_str());
         odb::dbWire::create(net);
         bufInstanceOutPin->connect(net);
-        net->setSigType(odb::dbSigType::SIGNAL);
+        net->setSigType(odb::dbSigType::Value::SIGNAL);
         // Updates the topology wih the new instance and the current topology
         // (as a vector of strings).
         topology.instVector.push_back(bufInstance);
@@ -728,7 +728,7 @@ std::vector<TechChar::SolutionData> TechChar::createPatterns(
                                     + solutionCounter.to_string();
     odb::dbBTerm* outPort = odb::dbBTerm::create(
         net, outPortName.c_str());  // sig type is signal by default
-    outPort->setIoType(odb::dbIoType::OUTPUT);
+    outPort->setIoType(odb::dbIoType::Value::OUTPUT);
     odb::dbBPin* outPortPin = odb::dbBPin::create(outPort);
     // Updates the topology with the output port, old new, possible instances
     // and other attributes.
@@ -802,11 +802,11 @@ void TechChar::setParasitics(
                 // iterate over the net ITerms.
         for (odb::dbITerm* iterm : netITerms) {
           if (iterm != nullptr) {
-            if (iterm->getIoType() == odb::dbIoType::INPUT) {
+            if (iterm->getIoType() == odb::dbIoType::Value::INPUT) {
               lastPin = db_network_->dbToSta(iterm);
             }
 
-            if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+            if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
               firstPin = db_network_->dbToSta(iterm);
             }
 

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -515,7 +515,8 @@ void TechChar::initCharacterization()
             || masterTerminal->getSigType() == odb::dbSigType::Value::CLOCK)) {
       charBufIn_ = masterTerminal;
     } else if (masterTerminal->getIoType() == odb::dbIoType::Value::OUTPUT
-               && masterTerminal->getSigType() == odb::dbSigType::Value::SIGNAL) {
+               && masterTerminal->getSigType()
+                      == odb::dbSigType::Value::SIGNAL) {
       charBufOut_ = masterTerminal;
     }
   }

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -207,14 +207,14 @@ void TritonCTS::countSinksPostDbWrite(TreeBuilder* builder,
   int driverX = 0;
   int driverY = 0;
   for (odb::dbITerm* iterm : iterms) {
-    if (iterm->getIoType() != odb::dbIoType::INPUT) {
+    if (iterm->getIoType() != odb::dbIoType::Value::INPUT) {
       iterm->getAvgXY(&driverX, &driverY);
       break;
     }
   }
   odb::dbSet<odb::dbBTerm> bterms = net->getBTerms();
   for (odb::dbBTerm* bterm : bterms) {
-    if (bterm->getIoType() == odb::dbIoType::INPUT) {
+    if (bterm->getIoType() == odb::dbIoType::Value::INPUT) {
       for (odb::dbBPin* pin : bterm->getBPins()) {
         odb::dbPlacementStatus status = pin->getPlacementStatus();
         if (status == odb::dbPlacementStatus::NONE
@@ -233,7 +233,7 @@ void TritonCTS::countSinksPostDbWrite(TreeBuilder* builder,
     }
   }
   for (odb::dbITerm* iterm : iterms) {
-    if (iterm->getIoType() == odb::dbIoType::INPUT) {
+    if (iterm->getIoType() == odb::dbIoType::Value::INPUT) {
       std::string name = iterm->getInst()->getName();
       int receiverX, receiverY;
       iterm->getAvgXY(&receiverX, &receiverY);
@@ -626,7 +626,7 @@ void TritonCTS::writeClockNetsToDb(Clock& clockNet)
   odb::dbInst* topClockInst = block_->findInst(topClockInstName.c_str());
   odb::dbITerm* topClockInstInputPin = getFirstInput(topClockInst);
   topClockInstInputPin->connect(topClockNet);
-  topClockNet->setSigType(odb::dbSigType::CLOCK);
+  topClockNet->setSigType(odb::dbSigType::Value::CLOCK);
 
   std::map<int, uint> fanoutcount;
 
@@ -644,7 +644,7 @@ void TritonCTS::writeClockNetsToDb(Clock& clockNet)
     odb::dbNet* clkSubNet
         = odb::dbNet::create(block_, subNet.getName().c_str());
     ++numClkNets_;
-    clkSubNet->setSigType(odb::dbSigType::CLOCK);
+    clkSubNet->setSigType(odb::dbSigType::Value::CLOCK);
 
     odb::dbInst* driver = subNet.getDriver()->getDbInst();
     odb::dbITerm* driverInputPin = getFirstInput(driver);
@@ -787,7 +787,7 @@ void TritonCTS::disconnectAllSinksFromNet(odb::dbNet* net)
 {
   odb::dbSet<odb::dbITerm> iterms = net->getITerms();
   for (odb::dbITerm* iterm : iterms) {
-    if (iterm->getIoType() == odb::dbIoType::INPUT) {
+    if (iterm->getIoType() == odb::dbIoType::Value::INPUT) {
       iterm->disconnect();
     }
   }

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -829,14 +829,14 @@ bool
 dbNetwork::isPower(const Net* net) const
 {
   dbNet* dnet = staToDb(net);
-  return (dnet->getSigType() == dbSigType::POWER);
+  return (dnet->getSigType() == dbSigType::Value::POWER);
 }
 
 bool
 dbNetwork::isGround(const Net* net) const
 {
   dbNet* dnet = staToDb(net);
-  return (dnet->getSigType() == dbSigType::GROUND);
+  return (dnet->getSigType() == dbSigType::Value::GROUND);
 }
 
 NetPinIterator*
@@ -1076,9 +1076,9 @@ dbNetwork::findConstantNets()
 {
   clearConstantNets();
   for (dbNet* dnet : block_->getNets()) {
-    if (dnet->getSigType() == dbSigType::GROUND)
+    if (dnet->getSigType() == dbSigType::Value::GROUND)
       addConstantNet(dbToSta(dnet), LogicValue::zero);
-    else if (dnet->getSigType() == dbSigType::POWER)
+    else if (dnet->getSigType() == dbSigType::Value::POWER)
       addConstantNet(dbToSta(dnet), LogicValue::one);
   }
 }
@@ -1451,24 +1451,24 @@ dbNetwork::staToDb(PortDirection* dir,
                    dbIoType& io_type) const
 {
   if (dir == PortDirection::input()) {
-    sig_type = dbSigType::SIGNAL;
-    io_type = dbIoType::INPUT;
+    sig_type = dbSigType::Value::SIGNAL;
+    io_type = dbIoType::Value::INPUT;
   }
   else if (dir == PortDirection::output()) {
-    sig_type = dbSigType::SIGNAL;
-    io_type = dbIoType::OUTPUT;
+    sig_type = dbSigType::Value::SIGNAL;
+    io_type = dbIoType::Value::OUTPUT;
   }
   else if (dir == PortDirection::bidirect()) {
-    sig_type = dbSigType::SIGNAL;
-    io_type = dbIoType::INOUT;
+    sig_type = dbSigType::Value::SIGNAL;
+    io_type = dbIoType::Value::INOUT;
   }
   else if (dir == PortDirection::power()) {
-    sig_type = dbSigType::POWER;
-    io_type = dbIoType::INOUT;
+    sig_type = dbSigType::Value::POWER;
+    io_type = dbIoType::Value::INOUT;
   }
   else if (dir == PortDirection::ground()) {
-    sig_type = dbSigType::GROUND;
-    io_type = dbIoType::INOUT;
+    sig_type = dbSigType::Value::GROUND;
+    io_type = dbIoType::Value::INOUT;
   }
   else
     logger_->critical(ORD, 1007, "unhandled port direction");
@@ -1533,17 +1533,17 @@ dbNetwork::dbToSta(dbMaster* master) const
 PortDirection*
 dbNetwork::dbToSta(dbSigType sig_type, dbIoType io_type) const
 {
-  if (sig_type == dbSigType::POWER)
+  if (sig_type == dbSigType::Value::POWER)
     return PortDirection::power();
-  else if (sig_type == dbSigType::GROUND)
+  else if (sig_type == dbSigType::Value::GROUND)
     return PortDirection::ground();
-  else if (io_type == dbIoType::INPUT)
+  else if (io_type == dbIoType::Value::INPUT)
     return PortDirection::input();
-  else if (io_type == dbIoType::OUTPUT)
+  else if (io_type == dbIoType::Value::OUTPUT)
     return PortDirection::output();
-  else if (io_type == dbIoType::INOUT)
+  else if (io_type == dbIoType::Value::INOUT)
     return PortDirection::bidirect();
-  else if (io_type == dbIoType::FEEDTHRU)
+  else if (io_type == dbIoType::Value::FEEDTHRU)
     return PortDirection::bidirect();
   else {
     logger_->critical(ORD, 1008, "unknown master term type");

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -72,8 +72,7 @@ using odb::dbSet;
 using odb::dbSigType;
 
 // TODO: move to StringUtil
-char*
-tmpStringCopy(const char* str)
+char* tmpStringCopy(const char* str)
 {
   char* tmp = makeTmpString(strlen(str) + 1);
   strcpy(tmp, str);
@@ -82,18 +81,18 @@ tmpStringCopy(const char* str)
 
 class DbLibraryIterator1 : public Iterator<Library*>
 {
-public:
+ public:
   DbLibraryIterator1(ConcreteLibraryIterator* iter);
   ~DbLibraryIterator1();
   virtual bool hasNext();
   virtual Library* next();
 
-private:
+ private:
   ConcreteLibraryIterator* iter_;
 };
 
-DbLibraryIterator1::DbLibraryIterator1(ConcreteLibraryIterator* iter) :
-  iter_(iter)
+DbLibraryIterator1::DbLibraryIterator1(ConcreteLibraryIterator* iter)
+    : iter_(iter)
 {
 }
 
@@ -102,14 +101,12 @@ DbLibraryIterator1::~DbLibraryIterator1()
   delete iter_;
 }
 
-bool
-DbLibraryIterator1::hasNext()
+bool DbLibraryIterator1::hasNext()
 {
   return iter_->hasNext();
 }
 
-Library*
-DbLibraryIterator1::next()
+Library* DbLibraryIterator1::next()
 {
   return reinterpret_cast<Library*>(iter_->next());
 }
@@ -118,12 +115,12 @@ DbLibraryIterator1::next()
 
 class DbInstanceChildIterator : public InstanceChildIterator
 {
-public:
+ public:
   DbInstanceChildIterator(const Instance* instance, const dbNetwork* network);
   bool hasNext();
   Instance* next();
 
-private:
+ private:
   const dbNetwork* network_;
   bool top_;
   dbSet<dbInst>::iterator iter_;
@@ -131,8 +128,8 @@ private:
 };
 
 DbInstanceChildIterator::DbInstanceChildIterator(const Instance* instance,
-                                                 const dbNetwork* network) :
-  network_(network)
+                                                 const dbNetwork* network)
+    : network_(network)
 {
   dbBlock* block = network->block();
   if (instance == network->topInstance() && block) {
@@ -140,19 +137,16 @@ DbInstanceChildIterator::DbInstanceChildIterator(const Instance* instance,
     top_ = true;
     iter_ = insts.begin();
     end_ = insts.end();
-  }
-  else
+  } else
     top_ = false;
 }
 
-bool
-DbInstanceChildIterator::hasNext()
+bool DbInstanceChildIterator::hasNext()
 {
   return top_ && iter_ != end_;
 }
 
-Instance*
-DbInstanceChildIterator::next()
+Instance* DbInstanceChildIterator::next()
 {
   dbInst* child = *iter_;
   iter_++;
@@ -161,12 +155,12 @@ DbInstanceChildIterator::next()
 
 class DbInstanceNetIterator : public InstanceNetIterator
 {
-public:
+ public:
   DbInstanceNetIterator(const Instance* instance, const dbNetwork* network);
   bool hasNext();
   Net* next();
 
-private:
+ private:
   const dbNetwork* network_;
   dbSet<dbNet>::iterator iter_;
   dbSet<dbNet>::iterator end_;
@@ -174,9 +168,8 @@ private:
 };
 
 DbInstanceNetIterator::DbInstanceNetIterator(const Instance* instance,
-                                             const dbNetwork* network) :
-  network_(network),
-  next_(nullptr)
+                                             const dbNetwork* network)
+    : network_(network), next_(nullptr)
 {
   if (instance == network->topInstance()) {
     dbSet<dbNet> nets = network->block()->getNets();
@@ -185,8 +178,7 @@ DbInstanceNetIterator::DbInstanceNetIterator(const Instance* instance,
   }
 }
 
-bool
-DbInstanceNetIterator::hasNext()
+bool DbInstanceNetIterator::hasNext()
 {
   while (iter_ != end_) {
     dbNet* net = *iter_;
@@ -200,8 +192,7 @@ DbInstanceNetIterator::hasNext()
   return false;
 }
 
-Net*
-DbInstanceNetIterator::next()
+Net* DbInstanceNetIterator::next()
 {
   return next_;
 }
@@ -210,12 +201,12 @@ DbInstanceNetIterator::next()
 
 class DbInstancePinIterator : public InstancePinIterator
 {
-public:
+ public:
   DbInstancePinIterator(const Instance* inst, const dbNetwork* network);
   bool hasNext();
   Pin* next();
 
-private:
+ private:
   const dbNetwork* network_;
   bool top_;
   dbSet<dbITerm>::iterator iitr_;
@@ -226,16 +217,15 @@ private:
 };
 
 DbInstancePinIterator::DbInstancePinIterator(const Instance* inst,
-                                             const dbNetwork* network) :
-  network_(network)
+                                             const dbNetwork* network)
+    : network_(network)
 {
   top_ = (inst == network->topInstance());
   if (top_) {
     dbBlock* block = network->block();
     bitr_ = block->getBTerms().begin();
     bitr_end_ = block->getBTerms().end();
-  }
-  else {
+  } else {
     dbInst* db_inst;
     dbModInst* mod_inst;  // has no inst pins in odb
     network_->staToDb(inst, db_inst, mod_inst);
@@ -246,8 +236,7 @@ DbInstancePinIterator::DbInstancePinIterator(const Instance* inst,
   }
 }
 
-bool
-DbInstancePinIterator::hasNext()
+bool DbInstancePinIterator::hasNext()
 {
   if (top_) {
     if (bitr_ == bitr_end_) {
@@ -258,8 +247,7 @@ DbInstancePinIterator::hasNext()
       bitr_++;
       return true;
     }
-  }
-  else {
+  } else {
     while (iitr_ != iitr_end_) {
       dbITerm* iterm = *iitr_;
       if (!iterm->getSigType().isSupply()) {
@@ -273,8 +261,7 @@ DbInstancePinIterator::hasNext()
   }
 }
 
-Pin*
-DbInstancePinIterator::next()
+Pin* DbInstancePinIterator::next()
 {
   return next_;
 }
@@ -283,12 +270,12 @@ DbInstancePinIterator::next()
 
 class DbNetPinIterator : public NetPinIterator
 {
-public:
+ public:
   DbNetPinIterator(const Net* net, const dbNetwork* network);
   bool hasNext();
   Pin* next();
 
-private:
+ private:
   dbSet<dbITerm>::iterator iitr_;
   dbSet<dbITerm>::iterator iitr_end_;
   Pin* next_;
@@ -303,8 +290,7 @@ DbNetPinIterator::DbNetPinIterator(const Net* net,
   next_ = nullptr;
 }
 
-bool
-DbNetPinIterator::hasNext()
+bool DbNetPinIterator::hasNext()
 {
   while (iitr_ != iitr_end_) {
     dbITerm* iterm = *iitr_;
@@ -318,8 +304,7 @@ DbNetPinIterator::hasNext()
   return false;
 }
 
-Pin*
-DbNetPinIterator::next()
+Pin* DbNetPinIterator::next()
 {
   return next_;
 }
@@ -328,19 +313,19 @@ DbNetPinIterator::next()
 
 class DbNetTermIterator : public NetTermIterator
 {
-public:
+ public:
   DbNetTermIterator(const Net* net, const dbNetwork* network);
   bool hasNext();
   Term* next();
 
-private:
+ private:
   const dbNetwork* network_;
   dbSet<dbBTerm>::iterator iter_;
   dbSet<dbBTerm>::iterator end_;
 };
 
-DbNetTermIterator::DbNetTermIterator(const Net* net, const dbNetwork* network) :
-  network_(network)
+DbNetTermIterator::DbNetTermIterator(const Net* net, const dbNetwork* network)
+    : network_(network)
 {
   dbNet* dnet = network_->staToDb(net);
   dbSet<dbBTerm> terms = dnet->getBTerms();
@@ -348,14 +333,12 @@ DbNetTermIterator::DbNetTermIterator(const Net* net, const dbNetwork* network) :
   end_ = terms.end();
 }
 
-bool
-DbNetTermIterator::hasNext()
+bool DbNetTermIterator::hasNext()
 {
   return iter_ != end_;
 }
 
-Term*
-DbNetTermIterator::next()
+Term* DbNetTermIterator::next()
 {
   dbBTerm* bterm = *iter_;
   iter_++;
@@ -364,13 +347,13 @@ DbNetTermIterator::next()
 
 ////////////////////////////////////////////////////////////////
 
-dbNetwork::dbNetwork() :
-  ConcreteNetwork(),
-  db_(nullptr),
-  logger_(nullptr),
-  block_(nullptr),
-  top_instance_(reinterpret_cast<Instance*>(1)),
-  top_cell_(nullptr)
+dbNetwork::dbNetwork()
+    : ConcreteNetwork(),
+      db_(nullptr),
+      logger_(nullptr),
+      block_(nullptr),
+      top_instance_(reinterpret_cast<Instance*>(1)),
+      top_cell_(nullptr)
 {
 }
 
@@ -378,29 +361,25 @@ dbNetwork::~dbNetwork()
 {
 }
 
-void
-dbNetwork::init(dbDatabase* db, Logger* logger)
+void dbNetwork::init(dbDatabase* db, Logger* logger)
 {
   db_ = db;
   logger_ = logger;
 }
 
-void
-dbNetwork::setBlock(dbBlock* block)
+void dbNetwork::setBlock(dbBlock* block)
 {
   block_ = block;
   readDbNetlistAfter();
 }
 
-void
-dbNetwork::clear()
+void dbNetwork::clear()
 {
   ConcreteNetwork::clear();
   db_ = nullptr;
 }
 
-Instance*
-dbNetwork::topInstance() const
+Instance* dbNetwork::topInstance() const
 {
   if (top_cell_)
     return top_instance_;
@@ -408,21 +387,19 @@ dbNetwork::topInstance() const
     return nullptr;
 }
 
-double
-dbNetwork::dbuToMeters(int dist) const
+double dbNetwork::dbuToMeters(int dist) const
 {
   int dbu = db_->getTech()->getDbUnitsPerMicron();
   return dist / (dbu * 1e+6);
 }
 
-int
-dbNetwork::metersToDbu(double dist) const
+int dbNetwork::metersToDbu(double dist) const
 {
   int dbu = db_->getTech()->getDbUnitsPerMicron();
   return dist * dbu * 1e+6;
 }
 
-ObjectId dbNetwork::id(const Port *port) const
+ObjectId dbNetwork::id(const Port* port) const
 {
   if (!port) {
     // should not match anything else
@@ -441,8 +418,7 @@ ObjectId dbNetwork::id(const Instance* instance) const
   return staToDb(instance)->getId();
 }
 
-const char*
-dbNetwork::name(const Instance* instance) const
+const char* dbNetwork::name(const Instance* instance) const
 {
   if (instance == top_instance_)
     return tmpStringCopy(block_->getConstName());
@@ -457,8 +433,7 @@ dbNetwork::name(const Instance* instance) const
   }
 }
 
-Cell*
-dbNetwork::cell(const Instance* instance) const
+Cell* dbNetwork::cell(const Instance* instance) const
 {
   if (instance == top_instance_)
     return reinterpret_cast<Cell*>(top_cell_);
@@ -477,8 +452,7 @@ dbNetwork::cell(const Instance* instance) const
   }
 }
 
-Instance*
-dbNetwork::parent(const Instance* instance) const
+Instance* dbNetwork::parent(const Instance* instance) const
 {
   if (instance == top_instance_)
     return nullptr;
@@ -496,23 +470,20 @@ dbNetwork::parent(const Instance* instance) const
   return top_instance_;
 }
 
-bool
-dbNetwork::isLeaf(const Instance* instance) const
+bool dbNetwork::isLeaf(const Instance* instance) const
 {
   if (instance == top_instance_)
     return false;
   return true;
 }
 
-Instance*
-dbNetwork::findInstance(const char* path_name) const
+Instance* dbNetwork::findInstance(const char* path_name) const
 {
   dbInst* inst = block_->findInst(path_name);
   return dbToSta(inst);
 }
 
-Instance*
-dbNetwork::findChild(const Instance* parent, const char* name) const
+Instance* dbNetwork::findChild(const Instance* parent, const char* name) const
 {
   if (parent == top_instance_) {
     dbInst* inst = block_->findInst(name);
@@ -542,14 +513,12 @@ dbNetwork::findChild(const Instance* parent, const char* name) const
   return dbToSta(inst);
 }
 
-Pin*
-dbNetwork::findPin(const Instance* instance, const char* port_name) const
+Pin* dbNetwork::findPin(const Instance* instance, const char* port_name) const
 {
   if (instance == top_instance_) {
     dbBTerm* bterm = block_->findBTerm(port_name);
     return dbToSta(bterm);
-  }
-  else {
+  } else {
     dbInst* db_inst;
     dbModInst* mod_inst;
     staToDb(instance, db_inst, mod_inst);
@@ -561,15 +530,13 @@ dbNetwork::findPin(const Instance* instance, const char* port_name) const
   }
 }
 
-Pin*
-dbNetwork::findPin(const Instance* instance, const Port* port) const
+Pin* dbNetwork::findPin(const Instance* instance, const Port* port) const
 {
   const char* port_name = this->name(port);
   return findPin(instance, port_name);
 }
 
-Net*
-dbNetwork::findNet(const Instance* instance, const char* net_name) const
+Net* dbNetwork::findNet(const Instance* instance, const char* net_name) const
 {
   if (instance == top_instance_) {
     dbNet* dnet = block_->findNet(net_name);
@@ -592,8 +559,7 @@ void dbNetwork::findInstNetsMatching(const Instance* instance,
         if (pattern->match(net_name))
           nets.push_back(dbToSta(dnet));
       }
-    }
-    else {
+    } else {
       dbNet* dnet = block_->findNet(pattern->pattern());
       if (dnet)
         nets.push_back(dbToSta(dnet));
@@ -601,20 +567,17 @@ void dbNetwork::findInstNetsMatching(const Instance* instance,
   }
 }
 
-InstanceChildIterator*
-dbNetwork::childIterator(const Instance* instance) const
+InstanceChildIterator* dbNetwork::childIterator(const Instance* instance) const
 {
   return new DbInstanceChildIterator(instance, this);
 }
 
-InstancePinIterator*
-dbNetwork::pinIterator(const Instance* instance) const
+InstancePinIterator* dbNetwork::pinIterator(const Instance* instance) const
 {
   return new DbInstancePinIterator(instance, this);
 }
 
-InstanceNetIterator*
-dbNetwork::netIterator(const Instance* instance) const
+InstanceNetIterator* dbNetwork::netIterator(const Instance* instance) const
 {
   return new DbInstanceNetIterator(instance, this);
 }
@@ -633,8 +596,7 @@ ObjectId dbNetwork::id(const Pin* pin) const
   return bterm->getId();
 }
 
-Instance*
-dbNetwork::instance(const Pin* pin) const
+Instance* dbNetwork::instance(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -642,15 +604,13 @@ dbNetwork::instance(const Pin* pin) const
   if (iterm) {
     dbInst* dinst = iterm->getInst();
     return dbToSta(dinst);
-  }
-  else if (bterm)
+  } else if (bterm)
     return top_instance_;
   else
     return nullptr;
 }
 
-Net*
-dbNetwork::net(const Pin* pin) const
+Net* dbNetwork::net(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -658,13 +618,11 @@ dbNetwork::net(const Pin* pin) const
   if (iterm) {
     dbNet* dnet = iterm->getNet();
     return dbToSta(dnet);
-  }
-  else
+  } else
     return nullptr;
 }
 
-Term*
-dbNetwork::term(const Pin* pin) const
+Term* dbNetwork::term(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -677,8 +635,7 @@ dbNetwork::term(const Pin* pin) const
     return nullptr;
 }
 
-Port*
-dbNetwork::port(const Pin* pin) const
+Port* dbNetwork::port(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -686,20 +643,18 @@ dbNetwork::port(const Pin* pin) const
   if (iterm) {
     dbMTerm* mterm = iterm->getMTerm();
     return dbToSta(mterm);
-  }
-  else if (bterm) {
+  } else if (bterm) {
     const char* port_name = bterm->getConstName();
     return findPort(top_cell_, port_name);
-  }
-  else
+  } else
     return nullptr;
 }
 
-PortDirection*
-dbNetwork::direction(const Pin* pin) const
+PortDirection* dbNetwork::direction(const Pin* pin) const
 {
-  // ODB does not undestand tristates so look to liberty before ODB for port direction.
-  LibertyPort *lib_port = libertyPort(pin);
+  // ODB does not undestand tristates so look to liberty before ODB for port
+  // direction.
+  LibertyPort* lib_port = libertyPort(pin);
   if (lib_port)
     return lib_port->direction();
   else {
@@ -709,8 +664,7 @@ dbNetwork::direction(const Pin* pin) const
     if (iterm) {
       PortDirection* dir = dbToSta(iterm->getSigType(), iterm->getIoType());
       return dir;
-    }
-    else if (bterm) {
+    } else if (bterm) {
       PortDirection* dir = dbToSta(bterm->getSigType(), bterm->getIoType());
       return dir;
     }
@@ -718,8 +672,7 @@ dbNetwork::direction(const Pin* pin) const
   return PortDirection::unknown();
 }
 
-VertexId
-dbNetwork::vertexId(const Pin* pin) const
+VertexId dbNetwork::vertexId(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -731,8 +684,7 @@ dbNetwork::vertexId(const Pin* pin) const
   return object_id_null;
 }
 
-void
-dbNetwork::setVertexId(Pin* pin, VertexId id)
+void dbNetwork::setVertexId(Pin* pin, VertexId id)
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -743,28 +695,25 @@ dbNetwork::setVertexId(Pin* pin, VertexId id)
     return bterm->staSetVertexId(id);
 }
 
-void
-dbNetwork::location(const Pin* pin,
-                    // Return values.
-                    double& x,
-                    double& y,
-                    bool& exists) const
+void dbNetwork::location(const Pin* pin,
+                         // Return values.
+                         double& x,
+                         double& y,
+                         bool& exists) const
 {
   if (isPlaced(pin)) {
     Point pt = location(pin);
     x = dbuToMeters(pt.getX());
     y = dbuToMeters(pt.getY());
     exists = true;
-  }
-  else {
+  } else {
     x = 0;
     y = 0;
     exists = false;
   }
 }
 
-Point
-dbNetwork::location(const Pin* pin) const
+Point dbNetwork::location(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -788,8 +737,7 @@ dbNetwork::location(const Pin* pin) const
   return Point(0, 0);
 }
 
-bool
-dbNetwork::isPlaced(const Pin* pin) const
+bool dbNetwork::isPlaced(const Pin* pin) const
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -811,42 +759,36 @@ ObjectId dbNetwork::id(const Net* net) const
   return staToDb(net)->getId();
 }
 
-const char*
-dbNetwork::name(const Net* net) const
+const char* dbNetwork::name(const Net* net) const
 {
   dbNet* dnet = staToDb(net);
   const char* name = dnet->getConstName();
   return tmpStringCopy(name);
 }
 
-Instance*
-dbNetwork::instance(const Net*) const
+Instance* dbNetwork::instance(const Net*) const
 {
   return top_instance_;
 }
 
-bool
-dbNetwork::isPower(const Net* net) const
+bool dbNetwork::isPower(const Net* net) const
 {
   dbNet* dnet = staToDb(net);
   return (dnet->getSigType() == dbSigType::Value::POWER);
 }
 
-bool
-dbNetwork::isGround(const Net* net) const
+bool dbNetwork::isGround(const Net* net) const
 {
   dbNet* dnet = staToDb(net);
   return (dnet->getSigType() == dbSigType::Value::GROUND);
 }
 
-NetPinIterator*
-dbNetwork::pinIterator(const Net* net) const
+NetPinIterator* dbNetwork::pinIterator(const Net* net) const
 {
   return new DbNetPinIterator(net, this);
 }
 
-NetTermIterator*
-dbNetwork::termIterator(const Net* net) const
+NetTermIterator* dbNetwork::termIterator(const Net* net) const
 {
   return new DbNetTermIterator(net, this);
 }
@@ -879,15 +821,13 @@ ObjectId dbNetwork::id(const Term* term) const
   return staToDb(term)->getId();
 }
 
-Pin*
-dbNetwork::pin(const Term* term) const
+Pin* dbNetwork::pin(const Term* term) const
 {
   // Only terms are for top level instance pins, which are also BTerms.
   return reinterpret_cast<Pin*>(const_cast<Term*>(term));
 }
 
-Net*
-dbNetwork::net(const Term* term) const
+Net* dbNetwork::net(const Term* term) const
 {
   dbBTerm* bterm = staToDb(term);
   dbNet* dnet = bterm->getNet();
@@ -896,27 +836,23 @@ dbNetwork::net(const Term* term) const
 
 ////////////////////////////////////////////////////////////////
 
-bool
-dbNetwork::isLinked() const
+bool dbNetwork::isLinked() const
 {
   return top_cell_ != nullptr;
 }
 
-bool
-dbNetwork::linkNetwork(const char*, bool, Report*)
+bool dbNetwork::linkNetwork(const char*, bool, Report*)
 {
   // Not called.
   return true;
 }
 
-void
-dbNetwork::readLefAfter(dbLib* lib)
+void dbNetwork::readLefAfter(dbLib* lib)
 {
   makeLibrary(lib);
 }
 
-void
-dbNetwork::readDefAfter(dbBlock* block)
+void dbNetwork::readDefAfter(dbBlock* block)
 {
   db_ = block->getDataBase();
   block_ = block;
@@ -925,8 +861,7 @@ dbNetwork::readDefAfter(dbBlock* block)
 
 // Make ConcreteLibrary/Cell/Port objects for the
 // db library/master/MTerm objects.
-void
-dbNetwork::readDbAfter(odb::dbDatabase* db)
+void dbNetwork::readDbAfter(odb::dbDatabase* db)
 {
   db_ = db;
   dbChip* chip = db_->getChip();
@@ -942,8 +877,7 @@ dbNetwork::readDbAfter(odb::dbDatabase* db)
   }
 }
 
-void
-dbNetwork::makeLibrary(dbLib* lib)
+void dbNetwork::makeLibrary(dbLib* lib)
 {
   const char* lib_name = lib->getConstName();
   Library* library = makeLibrary(lib_name, nullptr);
@@ -951,8 +885,7 @@ dbNetwork::makeLibrary(dbLib* lib)
     makeCell(library, master);
 }
 
-void
-dbNetwork::makeCell(Library* library, dbMaster* master)
+void dbNetwork::makeCell(Library* library, dbMaster* master)
 {
   const char* cell_name = master->getConstName();
   Cell* cell = makeCell(library, cell_name, true, nullptr);
@@ -981,8 +914,7 @@ dbNetwork::makeCell(Library* library, dbMaster* master)
       if (lib_port) {
         cport->setLibertyPort(lib_port);
         lib_port->setExtPort(mterm);
-      }
-      else if (!dir->isPowerGround() && !lib_cell->findPgPort(port_name))
+      } else if (!dir->isPowerGround() && !lib_cell->findPgPort(port_name))
         logger_->warn(ORD,
                       1001,
                       "LEF macro {} pin {} missing from liberty cell.",
@@ -1013,16 +945,14 @@ dbNetwork::makeCell(Library* library, dbMaster* master)
   delete lib_iter;
 }
 
-void
-dbNetwork::readDbNetlistAfter()
+void dbNetwork::readDbNetlistAfter()
 {
   makeTopCell();
   findConstantNets();
   checkLibertyCorners();
 }
 
-void
-dbNetwork::makeTopCell()
+void dbNetwork::makeTopCell()
 {
   if (top_cell_) {
     // Reading DEF or linking when a network already exists; remove previous top
@@ -1039,8 +969,7 @@ dbNetwork::makeTopCell()
                 [=](const char* port_name) { return portMsbFirst(port_name); });
 }
 
-void
-dbNetwork::makeTopPort(dbBTerm* bterm)
+void dbNetwork::makeTopPort(dbBTerm* bterm)
 {
   const char* port_name = bterm->getConstName();
   Port* port = makePort(top_cell_, port_name);
@@ -1048,8 +977,7 @@ dbNetwork::makeTopPort(dbBTerm* bterm)
   setDirection(port, dir);
 }
 
-void
-dbNetwork::setTopPortDirection(dbBTerm* bterm, const dbIoType& io_type)
+void dbNetwork::setTopPortDirection(dbBTerm* bterm, const dbIoType& io_type)
 {
   Port* port = findPort(top_cell_, bterm->getConstName());
   PortDirection* dir = dbToSta(bterm->getSigType(), bterm->getIoType());
@@ -1058,8 +986,7 @@ dbNetwork::setTopPortDirection(dbBTerm* bterm, const dbIoType& io_type)
 
 // read_verilog / Verilog2db::makeDbPins leaves a cookie to know if a bus port
 // is msb first or lsb first.
-bool
-dbNetwork::portMsbFirst(const char* port_name)
+bool dbNetwork::portMsbFirst(const char* port_name)
 {
   string key = "bus_msb_first ";
   key += port_name;
@@ -1071,8 +998,7 @@ dbNetwork::portMsbFirst(const char* port_name)
     return true;
 }
 
-void
-dbNetwork::findConstantNets()
+void dbNetwork::findConstantNets()
 {
   clearConstantNets();
   for (dbNet* dnet : block_->getNets()) {
@@ -1084,8 +1010,7 @@ dbNetwork::findConstantNets()
 }
 
 // Setup mapping from Cell/Port to LibertyCell/LibertyPort.
-void
-dbNetwork::readLibertyAfter(LibertyLibrary* lib)
+void dbNetwork::readLibertyAfter(LibertyLibrary* lib)
 {
   for (ConcreteLibrary* clib : library_seq_) {
     if (!clib->isLiberty()) {
@@ -1106,8 +1031,8 @@ dbNetwork::readLibertyAfter(LibertyLibrary* lib)
               if (lport) {
                 cport->setLibertyPort(lport);
                 lport->setExtPort(cport->extPort());
-              }
-              else if (!cport->direction()->isPowerGround() && !lcell->findPgPort(port_name))
+              } else if (!cport->direction()->isPowerGround()
+                         && !lcell->findPgPort(port_name))
                 logger_->warn(ORD,
                               1002,
                               "Liberty cell {} pin {} missing from LEF macro.",
@@ -1131,10 +1056,9 @@ dbNetwork::readLibertyAfter(LibertyLibrary* lib)
 
 // Edit functions
 
-Instance*
-dbNetwork::makeInstance(LibertyCell* cell,
-                        const char* name,
-                        Instance* parent)
+Instance* dbNetwork::makeInstance(LibertyCell* cell,
+                                  const char* name,
+                                  Instance* parent)
 {
   if (parent == top_instance_) {
     const char* cell_name = cell->name();
@@ -1147,14 +1071,12 @@ dbNetwork::makeInstance(LibertyCell* cell,
   return nullptr;
 }
 
-void
-dbNetwork::makePins(Instance*)
+void dbNetwork::makePins(Instance*)
 {
   // This space intentionally left blank.
 }
 
-void
-dbNetwork::replaceCell(Instance* inst, Cell* cell)
+void dbNetwork::replaceCell(Instance* inst, Cell* cell)
 {
   dbMaster* master = staToDb(cell);
   dbInst* db_inst;
@@ -1165,22 +1087,19 @@ dbNetwork::replaceCell(Instance* inst, Cell* cell)
   }
 }
 
-void
-dbNetwork::deleteInstance(Instance* inst)
+void dbNetwork::deleteInstance(Instance* inst)
 {
   dbInst* db_inst;
   dbModInst* mod_inst;
   staToDb(inst, db_inst, mod_inst);
   if (db_inst) {
     dbInst::destroy(db_inst);
-  }
-  else {
+  } else {
     dbModInst::destroy(mod_inst);
   }
 }
 
-Pin*
-dbNetwork::connect(Instance* inst, Port* port, Net* net)
+Pin* dbNetwork::connect(Instance* inst, Port* port, Net* net)
 {
   Pin* pin = nullptr;
   dbNet* dnet = staToDb(net);
@@ -1199,8 +1118,7 @@ dbNetwork::connect(Instance* inst, Port* port, Net* net)
       bterm->setIoType(io_type);
     }
     pin = dbToSta(bterm);
-  }
-  else {
+  } else {
     dbInst* db_inst;
     dbModInst* mod_inst;
     staToDb(inst, db_inst, mod_inst);
@@ -1216,8 +1134,7 @@ dbNetwork::connect(Instance* inst, Port* port, Net* net)
 
 // Used by dbStaCbk
 // Incrementally update drivers.
-void
-dbNetwork::connectPinAfter(Pin* pin)
+void dbNetwork::connectPinAfter(Pin* pin)
 {
   if (isDriver(pin)) {
     Net* net = this->net(pin);
@@ -1227,8 +1144,7 @@ dbNetwork::connectPinAfter(Pin* pin)
   }
 }
 
-Pin*
-dbNetwork::connect(Instance* inst, LibertyPort* port, Net* net)
+Pin* dbNetwork::connect(Instance* inst, LibertyPort* port, Net* net)
 {
   dbNet* dnet = staToDb(net);
   const char* port_name = port->name();
@@ -1246,8 +1162,7 @@ dbNetwork::connect(Instance* inst, LibertyPort* port, Net* net)
     bterm->setSigType(sig_type);
     bterm->setIoType(io_type);
     pin = dbToSta(bterm);
-  }
-  else {
+  } else {
     dbInst* db_inst;
     dbModInst* mod_inst;
     staToDb(inst, db_inst, mod_inst);
@@ -1262,8 +1177,7 @@ dbNetwork::connect(Instance* inst, LibertyPort* port, Net* net)
   return pin;
 }
 
-void
-dbNetwork::disconnectPin(Pin* pin)
+void dbNetwork::disconnectPin(Pin* pin)
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -1285,8 +1199,7 @@ void dbNetwork::disconnectPinBefore(const Pin* pin)
   }
 }
 
-void
-dbNetwork::deletePin(Pin* pin)
+void dbNetwork::deletePin(Pin* pin)
 {
   dbITerm* iterm;
   dbBTerm* bterm;
@@ -1297,8 +1210,7 @@ dbNetwork::deletePin(Pin* pin)
     dbBTerm::destroy(bterm);
 }
 
-Net*
-dbNetwork::makeNet(const char* name, Instance* parent)
+Net* dbNetwork::makeNet(const char* name, Instance* parent)
 {
   if (parent == top_instance_) {
     dbNet* dnet = dbNet::create(block_, name, false);
@@ -1307,8 +1219,7 @@ dbNetwork::makeNet(const char* name, Instance* parent)
   return nullptr;
 }
 
-void
-dbNetwork::deleteNet(Net* net)
+void dbNetwork::deleteNet(Net* net)
 {
   deleteNetBefore(net);
   dbNet* dnet = staToDb(net);
@@ -1322,21 +1233,18 @@ void dbNetwork::deleteNetBefore(const Net* net)
   net_drvr_pin_map_.erase(net);
 }
 
-void
-dbNetwork::mergeInto(Net*, Net*)
+void dbNetwork::mergeInto(Net*, Net*)
 {
   logger_->critical(ORD, 1004, "unimplemented network function mergeInto");
 }
 
-Net*
-dbNetwork::mergedInto(Net*)
+Net* dbNetwork::mergedInto(Net*)
 {
   logger_->critical(ORD, 1005, "unimplemented network function mergeInto");
   return nullptr;
 }
 
-bool
-dbNetwork::isSpecial(Net* net)
+bool dbNetwork::isSpecial(Net* net)
 {
   dbNet* db_net = staToDb(net);
   return db_net->isSpecial();
@@ -1344,8 +1252,7 @@ dbNetwork::isSpecial(Net* net)
 
 ////////////////////////////////////////////////////////////////
 
-dbInst*
-dbNetwork::staToDb(const Instance* instance) const
+dbInst* dbNetwork::staToDb(const Instance* instance) const
 {
   dbInst* db_inst;
   dbModInst* mod_inst;
@@ -1353,43 +1260,38 @@ dbNetwork::staToDb(const Instance* instance) const
   return db_inst;
 }
 
-void
-dbNetwork::staToDb(const Instance* instance,
-                   // Return values.
-                   dbInst*& db_inst,
-                   dbModInst*& mod_inst) const
+void dbNetwork::staToDb(const Instance* instance,
+                        // Return values.
+                        dbInst*& db_inst,
+                        dbModInst*& mod_inst) const
 {
   if (instance) {
-    dbObject* obj = reinterpret_cast<dbObject*>(const_cast<Instance*>(instance));
+    dbObject* obj
+        = reinterpret_cast<dbObject*>(const_cast<Instance*>(instance));
     dbObjectType type = obj->getObjectType();
     if (type == dbInstObj) {
       db_inst = static_cast<dbInst*>(obj);
       mod_inst = nullptr;
-    }
-    else if (type == dbModInstObj) {
+    } else if (type == dbModInstObj) {
       db_inst = nullptr;
       mod_inst = static_cast<dbModInst*>(obj);
-    }
-    else
+    } else
       logger_->critical(ORD, 1016, "instance is not Inst or ModInst");
-  }
-  else {
+  } else {
     db_inst = nullptr;
     mod_inst = nullptr;
   }
 }
 
-dbNet*
-dbNetwork::staToDb(const Net* net) const
+dbNet* dbNetwork::staToDb(const Net* net) const
 {
   return reinterpret_cast<dbNet*>(const_cast<Net*>(net));
 }
 
-void
-dbNetwork::staToDb(const Pin* pin,
-                   // Return values.
-                   dbITerm*& iterm,
-                   dbBTerm*& bterm) const
+void dbNetwork::staToDb(const Pin* pin,
+                        // Return values.
+                        dbITerm*& iterm,
+                        dbBTerm*& bterm) const
 {
   if (pin) {
     dbObject* obj = reinterpret_cast<dbObject*>(const_cast<Pin*>(pin));
@@ -1397,141 +1299,117 @@ dbNetwork::staToDb(const Pin* pin,
     if (type == dbITermObj) {
       iterm = static_cast<dbITerm*>(obj);
       bterm = nullptr;
-    }
-    else if (type == dbBTermObj) {
+    } else if (type == dbBTermObj) {
       iterm = nullptr;
       bterm = static_cast<dbBTerm*>(obj);
-    }
-    else
+    } else
       logger_->critical(ORD, 1006, "pin is not ITerm or BTerm");
-  }
-  else {
+  } else {
     iterm = nullptr;
     bterm = nullptr;
   }
 }
 
-dbBTerm*
-dbNetwork::staToDb(const Term* term) const
+dbBTerm* dbNetwork::staToDb(const Term* term) const
 {
   return reinterpret_cast<dbBTerm*>(const_cast<Term*>(term));
 }
 
-dbMaster*
-dbNetwork::staToDb(const Cell* cell) const
+dbMaster* dbNetwork::staToDb(const Cell* cell) const
 {
   const ConcreteCell* ccell = reinterpret_cast<const ConcreteCell*>(cell);
   return reinterpret_cast<dbMaster*>(ccell->extCell());
 }
 
-dbMaster*
-dbNetwork::staToDb(const LibertyCell* cell) const
+dbMaster* dbNetwork::staToDb(const LibertyCell* cell) const
 {
   const ConcreteCell* ccell = cell;
   return reinterpret_cast<dbMaster*>(ccell->extCell());
 }
 
-dbMTerm*
-dbNetwork::staToDb(const Port* port) const
+dbMTerm* dbNetwork::staToDb(const Port* port) const
 {
   const ConcretePort* cport = reinterpret_cast<const ConcretePort*>(port);
   return reinterpret_cast<dbMTerm*>(cport->extPort());
 }
 
-dbMTerm*
-dbNetwork::staToDb(const LibertyPort* port) const
+dbMTerm* dbNetwork::staToDb(const LibertyPort* port) const
 {
   return reinterpret_cast<dbMTerm*>(port->extPort());
 }
 
-void
-dbNetwork::staToDb(PortDirection* dir,
-                   // Return values.
-                   dbSigType& sig_type,
-                   dbIoType& io_type) const
+void dbNetwork::staToDb(PortDirection* dir,
+                        // Return values.
+                        dbSigType& sig_type,
+                        dbIoType& io_type) const
 {
   if (dir == PortDirection::input()) {
     sig_type = dbSigType::Value::SIGNAL;
     io_type = dbIoType::Value::INPUT;
-  }
-  else if (dir == PortDirection::output()) {
+  } else if (dir == PortDirection::output()) {
     sig_type = dbSigType::Value::SIGNAL;
     io_type = dbIoType::Value::OUTPUT;
-  }
-  else if (dir == PortDirection::bidirect()) {
+  } else if (dir == PortDirection::bidirect()) {
     sig_type = dbSigType::Value::SIGNAL;
     io_type = dbIoType::Value::INOUT;
-  }
-  else if (dir == PortDirection::power()) {
+  } else if (dir == PortDirection::power()) {
     sig_type = dbSigType::Value::POWER;
     io_type = dbIoType::Value::INOUT;
-  }
-  else if (dir == PortDirection::ground()) {
+  } else if (dir == PortDirection::ground()) {
     sig_type = dbSigType::Value::GROUND;
     io_type = dbIoType::Value::INOUT;
-  }
-  else
+  } else
     logger_->critical(ORD, 1007, "unhandled port direction");
 }
 
 ////////////////////////////////////////////////////////////////
 
-Instance*
-dbNetwork::dbToSta(dbInst* inst) const
+Instance* dbNetwork::dbToSta(dbInst* inst) const
 {
   return reinterpret_cast<Instance*>(inst);
 }
 
-Instance*
-dbNetwork::dbToSta(dbModInst* inst) const
+Instance* dbNetwork::dbToSta(dbModInst* inst) const
 {
   return reinterpret_cast<Instance*>(inst);
 }
 
-Net*
-dbNetwork::dbToSta(dbNet* net) const
+Net* dbNetwork::dbToSta(dbNet* net) const
 {
   return reinterpret_cast<Net*>(net);
 }
 
-const Net*
-dbNetwork::dbToSta(const dbNet* net) const
+const Net* dbNetwork::dbToSta(const dbNet* net) const
 {
   return reinterpret_cast<const Net*>(net);
 }
 
-Pin*
-dbNetwork::dbToSta(dbBTerm* bterm) const
+Pin* dbNetwork::dbToSta(dbBTerm* bterm) const
 {
   return reinterpret_cast<Pin*>(bterm);
 }
 
-Pin*
-dbNetwork::dbToSta(dbITerm* iterm) const
+Pin* dbNetwork::dbToSta(dbITerm* iterm) const
 {
   return reinterpret_cast<Pin*>(iterm);
 }
 
-Term*
-dbNetwork::dbToStaTerm(dbBTerm* bterm) const
+Term* dbNetwork::dbToStaTerm(dbBTerm* bterm) const
 {
   return reinterpret_cast<Term*>(bterm);
 }
 
-Port*
-dbNetwork::dbToSta(dbMTerm* mterm) const
+Port* dbNetwork::dbToSta(dbMTerm* mterm) const
 {
   return reinterpret_cast<Port*>(mterm->staPort());
 }
 
-Cell*
-dbNetwork::dbToSta(dbMaster* master) const
+Cell* dbNetwork::dbToSta(dbMaster* master) const
 {
   return reinterpret_cast<Cell*>(master->staCell());
 }
 
-PortDirection*
-dbNetwork::dbToSta(dbSigType sig_type, dbIoType io_type) const
+PortDirection* dbNetwork::dbToSta(dbSigType sig_type, dbIoType io_type) const
 {
   if (sig_type == dbSigType::Value::POWER)
     return PortDirection::power();
@@ -1553,8 +1431,7 @@ dbNetwork::dbToSta(dbSigType sig_type, dbIoType io_type) const
 
 ////////////////////////////////////////////////////////////////
 
-LibertyCell*
-dbNetwork::libertyCell(dbInst* inst)
+LibertyCell* dbNetwork::libertyCell(dbInst* inst)
 {
   return libertyCell(dbToSta(inst));
 }
@@ -1562,15 +1439,13 @@ dbNetwork::libertyCell(dbInst* inst)
 ////////////////////////////////////////////////////////////////
 // Observer
 
-void
-dbNetwork::addObserver(dbNetworkObserver* observer)
+void dbNetwork::addObserver(dbNetworkObserver* observer)
 {
   observer->owner_ = this;
   observers_.insert(observer);
 }
 
-void
-dbNetwork::removeObserver(dbNetworkObserver* observer)
+void dbNetwork::removeObserver(dbNetworkObserver* observer)
 {
   observer->owner_ = nullptr;
   observers_.erase(observer);

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -342,17 +342,17 @@ dbIoType
 Verilog2db::staToDb(PortDirection* dir)
 {
   if (dir == PortDirection::input())
-    return dbIoType::INPUT;
+    return dbIoType::Value::INPUT;
   else if (dir == PortDirection::output())
-    return dbIoType::OUTPUT;
+    return dbIoType::Value::OUTPUT;
   else if (dir == PortDirection::bidirect())
-    return dbIoType::INOUT;
+    return dbIoType::Value::INOUT;
   else if (dir == PortDirection::tristate())
-    return dbIoType::OUTPUT;
+    return dbIoType::Value::OUTPUT;
   else if (dir == PortDirection::unknown())
-    return dbIoType::INPUT;
+    return dbIoType::Value::INPUT;
   else
-    return dbIoType::INOUT;
+    return dbIoType::Value::INOUT;
 }
 
 void
@@ -367,9 +367,9 @@ Verilog2db::makeDbNets(const Instance* inst)
       dbNet* db_net = dbNet::create(block_, net_name);
 
       if (network_->isPower(net))
-        db_net->setSigType(odb::dbSigType::POWER);
+        db_net->setSigType(odb::dbSigType::Value::POWER);
       if (network_->isGround(net))
-        db_net->setSigType(odb::dbSigType::GROUND);
+        db_net->setSigType(odb::dbSigType::Value::GROUND);
 
       // Sort connected pins for regression stability.
       PinSeq net_pins;

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -95,42 +95,36 @@ using sta::PortDirection;
 using utl::Logger;
 using utl::STA;
 
-dbVerilogNetwork::dbVerilogNetwork() :
-  ConcreteNetwork(), db_network_(nullptr)
+dbVerilogNetwork::dbVerilogNetwork() : ConcreteNetwork(), db_network_(nullptr)
 {
   report_ = nullptr;
   debug_ = nullptr;
 }
 
-void
-dbVerilogNetwork::init(dbNetwork* db_network)
+void dbVerilogNetwork::init(dbNetwork* db_network)
 {
   db_network_ = db_network;
   copyState(db_network_);
 }
 
-dbVerilogNetwork*
-makeDbVerilogNetwork()
+dbVerilogNetwork* makeDbVerilogNetwork()
 {
   return new dbVerilogNetwork;
 }
 
-void
-initDbVerilogNetwork(ord::OpenRoad* openroad)
+void initDbVerilogNetwork(ord::OpenRoad* openroad)
 {
   openroad->getVerilogNetwork()->init(openroad->getDbNetwork());
 }
 
-void
-deleteDbVerilogNetwork(dbVerilogNetwork* verilog_network)
+void deleteDbVerilogNetwork(dbVerilogNetwork* verilog_network)
 {
   delete verilog_network;
 }
 
 // Facade that looks in the db network for a liberty cell if
 // there isn't one in the verilog network.
-Cell*
-dbVerilogNetwork::findAnyCell(const char* name)
+Cell* dbVerilogNetwork::findAnyCell(const char* name)
 {
   Cell* cell = ConcreteNetwork::findAnyCell(name);
   if (cell == nullptr)
@@ -138,8 +132,7 @@ dbVerilogNetwork::findAnyCell(const char* name)
   return cell;
 }
 
-void
-dbReadVerilog(const char* filename, dbVerilogNetwork* verilog_network)
+void dbReadVerilog(const char* filename, dbVerilogNetwork* verilog_network)
 {
   sta::readVerilogFile(filename, verilog_network);
 }
@@ -148,12 +141,12 @@ dbReadVerilog(const char* filename, dbVerilogNetwork* verilog_network)
 
 class Verilog2db
 {
-public:
+ public:
   Verilog2db(Network* verilog_network, dbDatabase* db, Logger* logger);
   void makeBlock();
   void makeDbNetlist();
 
-protected:
+ protected:
   void makeDbModule(Instance* inst, dbModule* parent);
   dbIoType staToDb(PortDirection* dir);
   void recordBusPortsOrder();
@@ -170,17 +163,14 @@ protected:
   std::map<std::string, int> uniquify_id_;  // key: module name
 };
 
-void
-dbLinkDesign(const char* top_cell_name,
-             dbVerilogNetwork* verilog_network,
-             dbDatabase* db,
-             Logger* logger)
+void dbLinkDesign(const char* top_cell_name,
+                  dbVerilogNetwork* verilog_network,
+                  dbDatabase* db,
+                  Logger* logger)
 {
   bool link_make_black_boxes = true;
   bool success = verilog_network->linkNetwork(
-      top_cell_name,
-      link_make_black_boxes,
-      verilog_network->report());
+      top_cell_name, link_make_black_boxes, verilog_network->report());
   if (success) {
     Verilog2db v2db(verilog_network, db, logger);
     v2db.makeBlock();
@@ -189,13 +179,12 @@ dbLinkDesign(const char* top_cell_name,
   }
 }
 
-Verilog2db::Verilog2db(Network* network, dbDatabase* db, Logger* logger) :
-  network_(network), db_(db), block_(nullptr), logger_(logger)
+Verilog2db::Verilog2db(Network* network, dbDatabase* db, Logger* logger)
+    : network_(network), db_(db), block_(nullptr), logger_(logger)
 {
 }
 
-void
-Verilog2db::makeBlock()
+void Verilog2db::makeBlock()
 {
   dbChip* chip = db_->getChip();
   if (chip == nullptr)
@@ -219,9 +208,9 @@ Verilog2db::makeBlock()
     for (auto iter = mod_insts.begin(); iter != mod_insts.end();) {
       iter = dbModInst::destroy(iter);
     }
-  }
-  else {
-    const char* design = network_->name(network_->cell(network_->topInstance()));
+  } else {
+    const char* design
+        = network_->name(network_->cell(network_->topInstance()));
     block_ = dbBlock::create(chip, design, network_->pathDivider());
   }
   dbTech* tech = db_->getTech();
@@ -229,16 +218,14 @@ Verilog2db::makeBlock()
   block_->setBusDelimeters('[', ']');
 }
 
-void
-Verilog2db::makeDbNetlist()
+void Verilog2db::makeDbNetlist()
 {
   recordBusPortsOrder();
   makeDbModule(network_->topInstance(), /* parent */ nullptr);
   makeDbNets(network_->topInstance());
 }
 
-void
-Verilog2db::recordBusPortsOrder()
+void Verilog2db::recordBusPortsOrder()
 {
   // OpenDB does not have any concept of bus ports.
   // Use a property to annotate the bus names as msb or lsb first for writing
@@ -259,8 +246,7 @@ Verilog2db::recordBusPortsOrder()
   delete bus_iter;
 }
 
-dbModule*
-Verilog2db::makeUniqueDbModule(const char* name)
+dbModule* Verilog2db::makeUniqueDbModule(const char* name)
 {
   dbModule* module;
   do {
@@ -279,18 +265,17 @@ Verilog2db::makeUniqueDbModule(const char* name)
 // to the sta network rooted at inst.  parent is the dbModule to build
 // the hierarchy under. If null the top module is used.
 
-void
-Verilog2db::makeDbModule(Instance* inst, dbModule* parent)
+void Verilog2db::makeDbModule(Instance* inst, dbModule* parent)
 {
   Cell* cell = network_->cell(inst);
 
   dbModule* module;
   if (parent == nullptr) {
     module = block_->getTopModule();
-  }
-  else {
+  } else {
     module = makeUniqueDbModule(network_->name(cell));
-    dbModInst* modinst = dbModInst::create(parent, module, network_->name(inst));
+    dbModInst* modinst
+        = dbModInst::create(parent, module, network_->name(inst));
     if (modinst == nullptr) {
       logger_->warn(ORD,
                     1014,
@@ -305,8 +290,7 @@ Verilog2db::makeDbModule(Instance* inst, dbModule* parent)
     Instance* child = child_iter->next();
     if (network_->isHierarchical(child)) {
       makeDbModule(child, module);
-    }
-    else {
+    } else {
       const char* child_name = network_->pathName(child);
       Cell* cell = network_->cell(child);
       dbMaster* master = getMaster(cell);
@@ -332,14 +316,14 @@ Verilog2db::makeDbModule(Instance* inst, dbModule* parent)
   }
   delete child_iter;
 
-  if (module->getChildren().reversible() && module->getChildren().orderReversed())
+  if (module->getChildren().reversible()
+      && module->getChildren().orderReversed())
     module->getChildren().reverse();
   if (module->getInsts().reversible() && module->getInsts().orderReversed())
     module->getInsts().reverse();
 }
 
-dbIoType
-Verilog2db::staToDb(PortDirection* dir)
+dbIoType Verilog2db::staToDb(PortDirection* dir)
 {
   if (dir == PortDirection::input())
     return dbIoType::Value::INPUT;
@@ -355,8 +339,7 @@ Verilog2db::staToDb(PortDirection* dir)
     return dbIoType::Value::INOUT;
 }
 
-void
-Verilog2db::makeDbNets(const Instance* inst)
+void Verilog2db::makeDbNets(const Instance* inst)
 {
   bool is_top = (inst == network_->topInstance());
   NetIterator* net_iter = network_->netIterator(inst);
@@ -389,8 +372,7 @@ Verilog2db::makeDbNets(const Instance* inst)
             dbIoType io_type = staToDb(network_->direction(pin));
             bterm->setIoType(io_type);
           }
-        }
-        else if (network_->isLeaf(pin)) {
+        } else if (network_->isLeaf(pin)) {
           const char* port_name = network_->portName(pin);
           Instance* inst = network_->instance(pin);
           const char* inst_name = network_->pathName(inst);
@@ -415,8 +397,7 @@ Verilog2db::makeDbNets(const Instance* inst)
   delete child_iter;
 }
 
-bool
-Verilog2db::hasTerminals(Net* net) const
+bool Verilog2db::hasTerminals(Net* net) const
 {
   NetTermIterator* term_iter = network_->termIterator(net);
   bool has_terms = term_iter->hasNext();
@@ -424,8 +405,7 @@ Verilog2db::hasTerminals(Net* net) const
   return has_terms;
 }
 
-dbMaster*
-Verilog2db::getMaster(Cell* cell)
+dbMaster* Verilog2db::getMaster(Cell* cell)
 {
   auto miter = master_map_.find(cell);
   if (miter != master_map_.end())
@@ -439,20 +419,13 @@ Verilog2db::getMaster(Cell* cell)
       LibertyCell* lib_cell = network_->libertyCell(cell);
       if (lib_cell == nullptr)
         logger_->warn(
-            ORD,
-            1011,
-            "LEF master {} has no liberty cell.",
-            cell_name);
+            ORD, 1011, "LEF master {} has no liberty cell.", cell_name);
       return master;
-    }
-    else {
+    } else {
       LibertyCell* lib_cell = network_->libertyCell(cell);
       if (lib_cell)
         logger_->warn(
-            ORD,
-            1012,
-            "Liberty cell {} has no LEF master.",
-            cell_name);
+            ORD, 1012, "Liberty cell {} has no LEF master.", cell_name);
       // OpenSTA read_verilog warns about missing cells.
       master_map_[cell] = nullptr;
       return nullptr;

--- a/src/dft/src/utils/Utils.cpp
+++ b/src/dft/src/utils/Utils.cpp
@@ -104,7 +104,7 @@ std::vector<odb::dbITerm*> GetClockPin(odb::dbInst* inst)
 {
   std::vector<odb::dbITerm*> clocks;
   for (odb::dbITerm* iterm : inst->getITerms()) {
-    if (iterm->getSigType() == odb::dbSigType::CLOCK) {
+    if (iterm->getSigType() == odb::dbSigType::Value::CLOCK) {
       clocks.push_back(iterm);
     }
   }

--- a/src/dpo/src/Optdp.cpp
+++ b/src/dpo/src/Optdp.cpp
@@ -325,7 +325,7 @@ void Optdp::setupMasterPowers()
     bool isVdd = false;
     bool isGnd = false;
     for (dbMTerm* mterm : master->getMTerms()) {
-      if (mterm->getSigType() == dbSigType::POWER) {
+      if (mterm->getSigType() == dbSigType::Value::POWER) {
         isVdd = true;
         for (dbMPin* mpin : mterm->getMPins()) {
           // Geometry or box?
@@ -338,7 +338,7 @@ void Optdp::setupMasterPowers()
             pwrLayers_.insert(layer);
           }
         }
-      } else if (mterm->getSigType() == dbSigType::GROUND) {
+      } else if (mterm->getSigType() == dbSigType::Value::GROUND) {
         isGnd = true;
         for (dbMPin* mpin : mterm->getMPins()) {
           // Geometry or box?
@@ -777,11 +777,11 @@ void Optdp::createArchitecture()
     if (!net->isSpecial()) {
       continue;
     }
-    if (!(net->getSigType() == dbSigType::POWER
-          || net->getSigType() == dbSigType::GROUND)) {
+    if (!(net->getSigType() == dbSigType::Value::POWER
+          || net->getSigType() == dbSigType::Value::GROUND)) {
       continue;
     }
-    int pwr = (net->getSigType() == dbSigType::POWER)
+    int pwr = (net->getSigType() == dbSigType::Value::POWER)
                   ? Architecture::Row::Power_VDD
                   : Architecture::Row::Power_VSS;
     for (dbSWire* swire : net->getSWires()) {

--- a/src/drt/src/db/obj/frNet.h
+++ b/src/drt/src/db/obj/frNet.h
@@ -65,7 +65,7 @@ class frNet : public frBlockObject
         firstNonRPinNode_(nullptr),
         rpins_(),
         guides_(),
-        type_(dbSigType::SIGNAL),
+        type_(dbSigType::Value::SIGNAL),
         modified_(false),
         isFakeNet_(false),
         ndr_(nullptr),

--- a/src/drt/src/db/obj/frTerm.h
+++ b/src/drt/src/db/obj/frTerm.h
@@ -72,8 +72,8 @@ class frTerm : public frBlockObject
       : frBlockObject(),
         name_(name),
         net_(nullptr),
-        type_(dbSigType::SIGNAL),
-        direction_(dbIoType::INPUT),
+        type_(dbSigType::Value::SIGNAL),
+        direction_(dbIoType::Value::INPUT),
         index_in_owner_(0),
         bbox_()
   {

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -48,8 +48,8 @@ gcNet* FlexGCWorker::Impl::getNet(frBlockObject* obj)
         owner = bterm->getNet();
       } else {
         dbSigType sigType = bterm->getType();
-        isFloatingVDD = (sigType == dbSigType::POWER);
-        isFloatingVSS = (sigType == dbSigType::GROUND);
+        isFloatingVDD = (sigType == dbSigType::Value::POWER);
+        isFloatingVSS = (sigType == dbSigType::Value::GROUND);
         owner = obj;
       }
       break;
@@ -60,8 +60,8 @@ gcNet* FlexGCWorker::Impl::getNet(frBlockObject* obj)
         owner = instTerm->getNet();
       } else {
         dbSigType sigType = instTerm->getTerm()->getType();
-        isFloatingVDD = (sigType == dbSigType::POWER);
-        isFloatingVSS = (sigType == dbSigType::GROUND);
+        isFloatingVDD = (sigType == dbSigType::Value::POWER);
+        isFloatingVSS = (sigType == dbSigType::Value::GROUND);
         owner = obj;
       }
       break;

--- a/src/drt/src/gr/FlexGR.cpp
+++ b/src/drt/src/gr/FlexGR.cpp
@@ -1534,7 +1534,7 @@ void FlexGR::initGR_genTopology_net(frNet* net)
                           ->getTerm()
                           ->getDirection();
         // for instTerm, direction OUTPUT is driver
-        if (ioType == dbIoType::OUTPUT && nodes[0] == nullptr) {
+        if (ioType == dbIoType::Value::OUTPUT && nodes[0] == nullptr) {
           nodes[0] = node.get();
         } else {
           if (sinkIdx >= nodes.size()) {
@@ -1548,7 +1548,7 @@ void FlexGR::initGR_genTopology_net(frNet* net)
                  || node->getPin()->typeId() == frcMTerm) {
         auto ioType = static_cast<frTerm*>(node->getPin())->getDirection();
         // for IO term, direction INPUT is driver
-        if (ioType == dbIoType::INPUT && nodes[0] == nullptr) {
+        if (ioType == dbIoType::Value::INPUT && nodes[0] == nullptr) {
           nodes[0] = node.get();
         } else {
           if (sinkIdx >= nodes.size()) {

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -514,7 +514,7 @@ void io::Parser::setNets(odb::dbBlock* block)
     if (net->getNonDefaultRule())
       uNetIn->updateNondefaultRule(design_->getTech()->getNondefaultRule(
           net->getNonDefaultRule()->getName()));
-    if (net->getSigType() == dbSigType::CLOCK)
+    if (net->getSigType() == dbSigType::Value::CLOCK)
       uNetIn->updateIsClock(true);
     if (is_special)
       uNetIn->setIsSpecial(true);
@@ -870,16 +870,16 @@ void io::Parser::setBTerms(odb::dbBlock* block)
 {
   for (auto term : block->getBTerms()) {
     switch (term->getSigType()) {
-      case odb::dbSigType::POWER:
-      case odb::dbSigType::GROUND:
+      case odb::dbSigType::Value::POWER:
+      case odb::dbSigType::Value::GROUND:
         // We allow for multiple pins
         break;
-      case odb::dbSigType::TIEOFF:
-      case odb::dbSigType::SIGNAL:
-      case odb::dbSigType::CLOCK:
-      case odb::dbSigType::ANALOG:
-      case odb::dbSigType::RESET:
-      case odb::dbSigType::SCAN:
+      case odb::dbSigType::Value::TIEOFF:
+      case odb::dbSigType::Value::SIGNAL:
+      case odb::dbSigType::Value::CLOCK:
+      case odb::dbSigType::Value::ANALOG:
+      case odb::dbSigType::Value::RESET:
+      case odb::dbSigType::Value::SCAN:
         if (term->getBPins().size() > 1)
           logger_->error(utl::DRT,
                          302,
@@ -1126,12 +1126,12 @@ void io::Parser::addFakeNets()
 {
   // add VSS fake net
   auto vssFakeNet = make_unique<frNet>(string("frFakeVSS"));
-  vssFakeNet->setType(dbSigType::GROUND);
+  vssFakeNet->setType(dbSigType::Value::GROUND);
   vssFakeNet->setIsFake(true);
   design_->getTopBlock()->addFakeSNet(std::move(vssFakeNet));
   // add VDD fake net
   auto vddFakeNet = make_unique<frNet>(string("frFakeVDD"));
-  vddFakeNet->setType(dbSigType::POWER);
+  vddFakeNet->setType(dbSigType::Value::POWER);
   vddFakeNet->setIsFake(true);
   design_->getTopBlock()->addFakeSNet(std::move(vddFakeNet));
 }
@@ -3198,8 +3198,8 @@ void io::Writer::updateDbAccessPoints(odb::dbBlock* block, odb::dbTech* db_tech)
     auto db_term = block->findBTerm(term->getName().c_str());
     if (db_term == nullptr)
       logger_->error(DRT, 301, "bterm {} not found in db", term->getName());
-    if (db_term->getSigType() == odb::dbSigType::POWER
-        || db_term->getSigType() == odb::dbSigType::GROUND)
+    if (db_term->getSigType() == odb::dbSigType::Value::POWER
+        || db_term->getSigType() == odb::dbSigType::Value::GROUND)
       continue;
     auto db_pins = db_term->getBPins();
     auto& pins = term->getPins();

--- a/src/drt/src/serialization.h
+++ b/src/drt/src/serialization.h
@@ -318,7 +318,7 @@ void serialize(Archive& ar, odb::Point& p, const unsigned int version)
 template <class Archive>
 void serialize(Archive& ar, odb::dbSigType& type, const unsigned int version)
 {
-  odb::dbSigType::Value v = odb::dbSigType::SIGNAL;
+  odb::dbSigType::Value v = odb::dbSigType::Value::SIGNAL;
   if (fr::is_loading(ar)) {
     (ar) & v;
     type = odb::dbSigType(v);
@@ -331,7 +331,7 @@ void serialize(Archive& ar, odb::dbSigType& type, const unsigned int version)
 template <class Archive>
 void serialize(Archive& ar, odb::dbIoType& type, const unsigned int version)
 {
-  odb::dbIoType::Value v = odb::dbIoType::INOUT;
+  odb::dbIoType::Value v = odb::dbIoType::Value::INOUT;
   if (fr::is_loading(ar)) {
     (ar) & v;
     type = odb::dbIoType(v);
@@ -549,7 +549,7 @@ void serializeBlockObject(Archive& ar, frBlockObject*& obj)
         (ar) & fake;
         (ar) & special;
         if (fake) {
-          if (((frNet*) obj)->getType() == odb::dbSigType::GROUND)
+          if (((frNet*) obj)->getType() == odb::dbSigType::Value::GROUND)
             id = 0;
           else
             id = 1;

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -158,9 +158,9 @@ frTerm* Fixture::makeMacroPin(frMaster* master,
   auto term = uTerm.get();
   term->setId(id);
   master->addTerm(std::move(uTerm));
-  dbSigType termType = dbSigType::SIGNAL;
+  dbSigType termType = dbSigType::Value::SIGNAL;
   term->setType(termType);
-  dbIoType termDirection = dbIoType::INPUT;
+  dbIoType termDirection = dbIoType::Value::INPUT;
   term->setDirection(termDirection);
   auto pinIn = make_unique<frMPin>();
   pinIn->setId(0);
@@ -212,12 +212,12 @@ void Fixture::makeDesign()
 
   // GC assumes these fake nets exist
   auto vssFakeNet = std::make_unique<frNet>("frFakeVSS");
-  vssFakeNet->setType(dbSigType::GROUND);
+  vssFakeNet->setType(dbSigType::Value::GROUND);
   vssFakeNet->setIsFake(true);
   block->addFakeSNet(std::move(vssFakeNet));
 
   auto vddFakeNet = std::make_unique<frNet>("frFakeVDD");
-  vddFakeNet->setType(dbSigType::POWER);
+  vddFakeNet->setType(dbSigType::Value::POWER);
   vddFakeNet->setIsFake(true);
   block->addFakeSNet(std::move(vddFakeNet));
 

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -923,7 +923,7 @@ void PlacerBase::init()
     dbSigType netType = net->getSigType();
 
     // escape nets with VDD/VSS/reset nets
-    if (netType == dbSigType::SIGNAL || netType == dbSigType::CLOCK) {
+    if (netType == dbSigType::Value::SIGNAL || netType == dbSigType::Value::CLOCK) {
       Net myNet(net, pbVars_.skipIoMode);
       netStor_.push_back(myNet);
 

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -923,7 +923,8 @@ void PlacerBase::init()
     dbSigType netType = net->getSigType();
 
     // escape nets with VDD/VSS/reset nets
-    if (netType == dbSigType::Value::SIGNAL || netType == dbSigType::Value::CLOCK) {
+    if (netType == dbSigType::Value::SIGNAL
+        || netType == dbSigType::Value::CLOCK) {
       Net myNet(net, pbVars_.skipIoMode);
       netStor_.push_back(myNet);
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -652,7 +652,7 @@ void GlobalRouter::findPins(Net* net)
 
 int GlobalRouter::getNetMaxRoutingLayer(const Net* net)
 {
-  return net->getSignalType() == odb::dbSigType::CLOCK
+  return net->getSignalType() == odb::dbSigType::Value::CLOCK
                  && max_layer_for_clock_ > 0
              ? max_layer_for_clock_
              : max_routing_layer_;
@@ -820,7 +820,7 @@ bool GlobalRouter::makeFastrouteNet(Net* net)
   }
 
   if (!on_grid_local) {
-    bool is_clock = (net->getSignalType() == odb::dbSigType::CLOCK);
+    bool is_clock = (net->getSignalType() == odb::dbSigType::Value::CLOCK);
     std::vector<int>* edge_cost_per_layer;
     int edge_cost_for_net;
     computeTrackConsumption(net, edge_cost_for_net, edge_cost_per_layer);
@@ -2772,7 +2772,7 @@ void GlobalRouter::initClockNets()
     logger_->info(GRT, 19, "Found {} clock nets.", clock_nets.size());
 
   for (odb::dbNet* net : clock_nets) {
-    net->setSigType(odb::dbSigType::CLOCK);
+    net->setSigType(odb::dbSigType::Value::CLOCK);
   }
 }
 
@@ -2792,7 +2792,7 @@ bool GlobalRouter::isClkTerm(odb::dbITerm* iterm, sta::dbNetwork* network)
 bool GlobalRouter::isNonLeafClock(odb::dbNet* db_net)
 {
   sta::dbNetwork* network = sta_->getDbNetwork();
-  if (db_net->getSigType() != odb::dbSigType::CLOCK) {
+  if (db_net->getSigType() != odb::dbSigType::Value::CLOCK) {
     return false;
   }
 
@@ -2808,7 +2808,7 @@ void GlobalRouter::makeItermPins(Net* net,
                                  odb::dbNet* db_net,
                                  const odb::Rect& die_area)
 {
-  bool is_clock = (net->getSignalType() == odb::dbSigType::CLOCK);
+  bool is_clock = (net->getSignalType() == odb::dbSigType::Value::CLOCK);
   int max_routing_layer = (is_clock && max_layer_for_clock_ > 0)
                               ? max_layer_for_clock_
                               : max_routing_layer_;

--- a/src/grt/src/Pin.cpp
+++ b/src/grt/src/Pin.cpp
@@ -186,7 +186,8 @@ bool Pin::isDriver()
   } else {
     odb::dbMTerm* mterm = iterm_->getMTerm();
     odb::dbIoType type = mterm->getIoType();
-    return type == odb::dbIoType::Value::OUTPUT || type == odb::dbIoType::Value::INOUT;
+    return type == odb::dbIoType::Value::OUTPUT
+           || type == odb::dbIoType::Value::INOUT;
   }
 }
 

--- a/src/grt/src/Pin.cpp
+++ b/src/grt/src/Pin.cpp
@@ -182,11 +182,11 @@ std::string Pin::getName() const
 bool Pin::isDriver()
 {
   if (is_port_) {
-    return (bterm_->getIoType() == odb::dbIoType::INPUT);
+    return (bterm_->getIoType() == odb::dbIoType::Value::INPUT);
   } else {
     odb::dbMTerm* mterm = iterm_->getMTerm();
     odb::dbIoType type = mterm->getIoType();
-    return type == odb::dbIoType::OUTPUT || type == odb::dbIoType::INOUT;
+    return type == odb::dbIoType::Value::OUTPUT || type == odb::dbIoType::Value::INOUT;
   }
 }
 

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -610,7 +610,7 @@ DbInstDescriptor::Type DbInstDescriptor::getInstanceType(
         if (net == nullptr) {
           continue;
         }
-        if (net->getSigType() == odb::dbSigType::CLOCK) {
+        if (net->getSigType() == odb::dbSigType::Value::CLOCK) {
           return STD_BUFINV_CLK_TREE;
         }
       }
@@ -908,7 +908,7 @@ void DbNetDescriptor::findSourcesAndSinks(odb::dbNet* net,
     }
 
     auto iotype = iterm->getIoType();
-    if (iotype == odb::dbIoType::OUTPUT || iotype == odb::dbIoType::INOUT) {
+    if (iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT) {
       odb::dbTransform transform;
       iterm->getInst()->getTransform(transform);
       get_graph_iterm_targets(iterm->getMTerm(), transform, sources);
@@ -921,8 +921,8 @@ void DbNetDescriptor::findSourcesAndSinks(odb::dbNet* net,
     }
 
     auto iotype = bterm->getIoType();
-    if (iotype == odb::dbIoType::INPUT || iotype == odb::dbIoType::INOUT
-        || iotype == odb::dbIoType::FEEDTHRU) {
+    if (iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT
+        || iotype == odb::dbIoType::Value::FEEDTHRU) {
       get_graph_bterm_targets(bterm, sources);
     }
   }
@@ -1167,22 +1167,22 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
 
   auto is_source_iterm = [](odb::dbITerm* iterm) -> bool {
     const auto iotype = iterm->getIoType();
-    return iotype == odb::dbIoType::OUTPUT || iotype == odb::dbIoType::INOUT;
+    return iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT;
   };
   auto is_sink_iterm = [](odb::dbITerm* iterm) -> bool {
     const auto iotype = iterm->getIoType();
-    return iotype == odb::dbIoType::INPUT || iotype == odb::dbIoType::INOUT;
+    return iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT;
   };
 
   auto is_source_bterm = [](odb::dbBTerm* bterm) -> bool {
     const auto iotype = bterm->getIoType();
-    return iotype == odb::dbIoType::INPUT || iotype == odb::dbIoType::INOUT
-           || iotype == odb::dbIoType::FEEDTHRU;
+    return iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT
+           || iotype == odb::dbIoType::Value::FEEDTHRU;
   };
   auto is_sink_bterm = [](odb::dbBTerm* bterm) -> bool {
     const auto iotype = bterm->getIoType();
-    return iotype == odb::dbIoType::OUTPUT || iotype == odb::dbIoType::INOUT
-           || iotype == odb::dbIoType::FEEDTHRU;
+    return iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT
+           || iotype == odb::dbIoType::Value::FEEDTHRU;
   };
 
   // Draw regular routing

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -908,7 +908,8 @@ void DbNetDescriptor::findSourcesAndSinks(odb::dbNet* net,
     }
 
     auto iotype = iterm->getIoType();
-    if (iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT) {
+    if (iotype == odb::dbIoType::Value::OUTPUT
+        || iotype == odb::dbIoType::Value::INOUT) {
       odb::dbTransform transform;
       iterm->getInst()->getTransform(transform);
       get_graph_iterm_targets(iterm->getMTerm(), transform, sources);
@@ -921,7 +922,8 @@ void DbNetDescriptor::findSourcesAndSinks(odb::dbNet* net,
     }
 
     auto iotype = bterm->getIoType();
-    if (iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT
+    if (iotype == odb::dbIoType::Value::INPUT
+        || iotype == odb::dbIoType::Value::INOUT
         || iotype == odb::dbIoType::Value::FEEDTHRU) {
       get_graph_bterm_targets(bterm, sources);
     }
@@ -1167,21 +1169,25 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
 
   auto is_source_iterm = [](odb::dbITerm* iterm) -> bool {
     const auto iotype = iterm->getIoType();
-    return iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT;
+    return iotype == odb::dbIoType::Value::OUTPUT
+           || iotype == odb::dbIoType::Value::INOUT;
   };
   auto is_sink_iterm = [](odb::dbITerm* iterm) -> bool {
     const auto iotype = iterm->getIoType();
-    return iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT;
+    return iotype == odb::dbIoType::Value::INPUT
+           || iotype == odb::dbIoType::Value::INOUT;
   };
 
   auto is_source_bterm = [](odb::dbBTerm* bterm) -> bool {
     const auto iotype = bterm->getIoType();
-    return iotype == odb::dbIoType::Value::INPUT || iotype == odb::dbIoType::Value::INOUT
+    return iotype == odb::dbIoType::Value::INPUT
+           || iotype == odb::dbIoType::Value::INOUT
            || iotype == odb::dbIoType::Value::FEEDTHRU;
   };
   auto is_sink_bterm = [](odb::dbBTerm* bterm) -> bool {
     const auto iotype = bterm->getIoType();
-    return iotype == odb::dbIoType::Value::OUTPUT || iotype == odb::dbIoType::Value::INOUT
+    return iotype == odb::dbIoType::Value::OUTPUT
+           || iotype == odb::dbIoType::Value::INOUT
            || iotype == odb::dbIoType::Value::FEEDTHRU;
   };
 

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1457,13 +1457,13 @@ const DisplayControls::ModelRow* DisplayControls::getNetRow(
     odb::dbNet* net) const
 {
   switch (net->getSigType()) {
-    case dbSigType::SIGNAL:
+    case dbSigType::Value::SIGNAL:
       return &nets_.signal;
-    case dbSigType::POWER:
+    case dbSigType::Value::POWER:
       return &nets_.power;
-    case dbSigType::GROUND:
+    case dbSigType::Value::GROUND:
       return &nets_.ground;
-    case dbSigType::CLOCK:
+    case dbSigType::Value::CLOCK:
       return &nets_.clock;
     default:
       return nullptr;

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2655,9 +2655,9 @@ void LayoutViewer::drawPinMarkers(Painter& painter, const odb::Rect& bounds)
 
         // select marker
         const std::vector<Point>* template_points = &bi_marker;
-        if (pin_dir == odb::dbIoType::INPUT) {
+        if (pin_dir == odb::dbIoType::Value::INPUT) {
           template_points = &in_marker;
-        } else if (pin_dir == odb::dbIoType::OUTPUT) {
+        } else if (pin_dir == odb::dbIoType::Value::OUTPUT) {
           template_points = &out_marker;
         }
 

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1202,7 +1202,8 @@ void MainWindow::selectHighlightConnectedNets(bool select_flag,
       auto inst_obj = std::any_cast<odb::dbInst*>(sel_obj.getObject());
       for (auto inst_term : inst_obj->getITerms()) {
         if (inst_term->getNet() == nullptr
-            || inst_term->getNet()->getSigType() != odb::dbSigType::Value::SIGNAL)
+            || inst_term->getNet()->getSigType()
+                   != odb::dbSigType::Value::SIGNAL)
           continue;
         auto inst_term_dir = inst_term->getIoType();
 

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1202,17 +1202,17 @@ void MainWindow::selectHighlightConnectedNets(bool select_flag,
       auto inst_obj = std::any_cast<odb::dbInst*>(sel_obj.getObject());
       for (auto inst_term : inst_obj->getITerms()) {
         if (inst_term->getNet() == nullptr
-            || inst_term->getNet()->getSigType() != odb::dbSigType::SIGNAL)
+            || inst_term->getNet()->getSigType() != odb::dbSigType::Value::SIGNAL)
           continue;
         auto inst_term_dir = inst_term->getIoType();
 
         if (output
-            && (inst_term_dir == odb::dbIoType::OUTPUT
-                || inst_term_dir == odb::dbIoType::INOUT))
+            && (inst_term_dir == odb::dbIoType::Value::OUTPUT
+                || inst_term_dir == odb::dbIoType::Value::INOUT))
           connected_nets.insert(Gui::get()->makeSelected(inst_term->getNet()));
         if (input
-            && (inst_term_dir == odb::dbIoType::INPUT
-                || inst_term_dir == odb::dbIoType::INOUT))
+            && (inst_term_dir == odb::dbIoType::Value::INPUT
+                || inst_term_dir == odb::dbIoType::Value::INOUT))
           connected_nets.insert(Gui::get()->makeSelected(
               DbNetDescriptor::NetWithSink{inst_term->getNet(), inst_term}));
       }

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -538,9 +538,9 @@ void InitFloorplan::insertTiecells(odb::dbMTerm* tie_term,
 
   odb::dbSigType look_for;
   if (is_zero) {
-    look_for = odb::dbSigType::GROUND;
+    look_for = odb::dbSigType::Value::GROUND;
   } else if (is_one) {
-    look_for = odb::dbSigType::POWER;
+    look_for = odb::dbSigType::Value::POWER;
   } else {
     logger_->error(utl::IFP,
                    29,
@@ -563,7 +563,7 @@ void InitFloorplan::insertTiecells(odb::dbMTerm* tie_term,
     auto* inst = odb::dbInst::create(block_, master, inst_name.c_str());
     auto* iterm = inst->findITerm(tie_term->getConstName());
     iterm->connect(net);
-    net->setSigType(odb::dbSigType::SIGNAL);
+    net->setSigType(odb::dbSigType::Value::SIGNAL);
     count++;
   }
 

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -217,7 +217,7 @@ void HierRTLMP::setDefaultThresholds()
   for (auto& macro : hard_macro_map_) {
     odb::dbMaster* master = macro.first->getMaster();
     for (odb::dbMTerm* mterm : master->getMTerms()) {
-      if (mterm->getSigType() == odb::dbSigType::SIGNAL) {
+      if (mterm->getSigType() == odb::dbSigType::Value::SIGNAL) {
         for (odb::dbMPin* mpin : mterm->getMPins()) {
           for (odb::dbBox* box : mpin->getGeometry()) {
             odb::dbTechLayer* layer = box->getTechLayer();
@@ -1327,7 +1327,7 @@ void HierRTLMP::calculateConnection()
       }
       const int cluster_id
           = odb::dbIntProperty::find(inst, "cluster_id")->getValue();
-      if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+      if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
         driver_id = cluster_id;
       } else {
         loads_id.push_back(cluster_id);
@@ -1342,7 +1342,7 @@ void HierRTLMP::calculateConnection()
       const int cluster_id
           = odb::dbIntProperty::find(bterm, "cluster_id")->getValue();
       io_flag = true;
-      if (bterm->getIoType() == odb::dbIoType::INPUT) {
+      if (bterm->getIoType() == odb::dbIoType::Value::INPUT) {
         driver_id = cluster_id;
       } else {
         loads_id.push_back(cluster_id);
@@ -1409,7 +1409,7 @@ void HierRTLMP::createDataFlow()
   // all macro pins are flagged as sequential stopping pt
   for (auto& [macro, hard_macro] : hard_macro_map_) {
     for (odb::dbITerm* pin : macro->getITerms()) {
-      if (pin->getSigType() != odb::dbSigType::SIGNAL) {
+      if (pin->getSigType() != odb::dbSigType::Value::SIGNAL) {
         continue;
       }
       odb::dbIntProperty::create(pin, "vertex_id", stop_flag_vec.size());
@@ -1461,7 +1461,7 @@ void HierRTLMP::createDataFlow()
       } else {
         vertex_id = odb::dbIntProperty::find(inst, "vertex_id")->getValue();
       }
-      if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+      if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
         driver_id = vertex_id;
       } else {
         loads_id.insert(vertex_id);
@@ -1475,7 +1475,7 @@ void HierRTLMP::createDataFlow()
     for (odb::dbBTerm* bterm : net->getBTerms()) {
       const int vertex_id
           = odb::dbIntProperty::find(bterm, "vertex_id")->getValue();
-      if (bterm->getIoType() == odb::dbIoType::INPUT) {
+      if (bterm->getIoType() == odb::dbIoType::Value::INPUT) {
         driver_id = vertex_id;
       } else {
         loads_id.insert(vertex_id);
@@ -1926,7 +1926,7 @@ void HierRTLMP::breakLargeFlatCluster(Cluster* parent)
       int vertex_id = (cluster_id != parent_cluster_id)
                           ? cluster_vertex_id_map[cluster_id]
                           : inst_vertex_id_map[inst];
-      if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+      if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
         driver_id = vertex_id;
       } else {
         loads_id.insert(vertex_id);
@@ -1940,7 +1940,7 @@ void HierRTLMP::breakLargeFlatCluster(Cluster* parent)
     for (odb::dbBTerm* bterm : net->getBTerms()) {
       const int cluster_id
           = odb::dbIntProperty::find(bterm, "cluster_id")->getValue();
-      if (bterm->getIoType() == odb::dbIoType::INPUT) {
+      if (bterm->getIoType() == odb::dbIoType::Value::INPUT) {
         driver_id = cluster_vertex_id_map[cluster_id];
       } else {
         loads_id.insert(cluster_vertex_id_map[cluster_id]);

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -759,7 +759,7 @@ HardMacro::HardMacro(odb::dbInst* inst, float dbu, float halo_width)
   odb::Rect bbox;
   bbox.mergeInit();
   for (odb::dbMTerm* mterm : master->getMTerms()) {
-    if (mterm->getSigType() == odb::dbSigType::SIGNAL) {
+    if (mterm->getSigType() == odb::dbSigType::Value::SIGNAL) {
       for (odb::dbMPin* mpin : mterm->getMPins()) {
         for (odb::dbBox* box : mpin->getGeometry()) {
           odb::Rect rect = box->getBox();

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -3086,10 +3086,10 @@ class dbInst : public dbObject
   ///
   /// Get the all the instances connected to the net of each iterm of this
   /// instance. Only traverse nets of the specified SigType. Default is
-  /// dbSigType::SIGNAL.
+  /// dbSigType::Value::SIGNAL.
   ///
   void getConnectivity(std::vector<dbInst*>& neighbors,
-                       dbSigType::Value value = dbSigType::SIGNAL);
+                       dbSigType::Value value = dbSigType::Value::SIGNAL);
 
   ///
   /// Bind the hierarchical (child) block to this instance.

--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -173,7 +173,7 @@ class dbGroupType
 class dbSigType
 {
  public:
-  enum Value
+  enum class Value
   {
     SIGNAL, /** */
     POWER,  /** */
@@ -237,7 +237,7 @@ class dbSigType
 class dbIoType
 {
  public:
-  enum Value
+  enum class Value
   {
     INPUT,
     OUTPUT,

--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -173,7 +173,7 @@ class dbGroupType
 class dbSigType
 {
  public:
-  enum class Value: uint
+  enum class Value : uint
   {
     SIGNAL, /** */
     POWER,  /** */
@@ -237,7 +237,7 @@ class dbSigType
 class dbIoType
 {
  public:
-  enum class Value: uint
+  enum class Value : uint
   {
     INPUT,
     OUTPUT,

--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -173,7 +173,7 @@ class dbGroupType
 class dbSigType
 {
  public:
-  enum class Value
+  enum class Value: uint
   {
     SIGNAL, /** */
     POWER,  /** */
@@ -237,7 +237,7 @@ class dbSigType
 class dbIoType
 {
  public:
-  enum class Value
+  enum class Value: uint
   {
     INPUT,
     OUTPUT,

--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -59,8 +59,8 @@ template class dbTable<_dbBTerm>;
 
 _dbBTerm::_dbBTerm(_dbDatabase*)
 {
-  _flags._io_type = dbIoType::INPUT;
-  _flags._sig_type = dbSigType::SIGNAL;
+  _flags._io_type = dbIoType::Value::INPUT;
+  _flags._sig_type = dbSigType::Value::SIGNAL;
   _flags._orient = 0;
   _flags._status = 0;
   _flags._spef = 0;

--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -311,7 +311,7 @@ void dbBTerm::setSigType(dbSigType type)
                "DB_ECO",
                1,
                "ECO: setSigType {}",
-               type.getValue());
+               type.getString());
     block->_journal->updateField(
         this, _dbBTerm::FLAGS, prev_flags, flagsToUInt(bterm));
   }
@@ -337,7 +337,7 @@ void dbBTerm::setIoType(dbIoType type)
                "DB_ECO",
                1,
                "ECO: setIoType {}",
-               type.getValue());
+               type.getString());
     block->_journal->updateField(
         this, _dbBTerm::FLAGS, prev_flags, flagsToUInt(bterm));
   }

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2554,7 +2554,7 @@ dbBlock* dbBlock::createExtCornerBlock(uint corner)
                                    net->getId(),
                                    net->getConstName());
     dbSigType ty = net->getSigType();
-    if ((ty == dbSigType::POWER) && (ty == dbSigType::GROUND))
+    if ((ty == dbSigType::Value::POWER) && (ty == dbSigType::Value::GROUND))
       xnet->setSpecial();
 
     xnet->setSigType(ty);
@@ -3281,7 +3281,7 @@ dbBlock::createNetSingleSWire(const char *innm, int x1, int y1, int x2, int y2, 
   if (!nwnet)
     return NULL;
 
-  nwnet->setSigType(dbSigType::SIGNAL);
+  nwnet->setSigType(dbSigType::Value::SIGNAL);
 
   dbSWire *nwsw = dbSWire::create(nwnet, dbWireType::ROUTED);
   if (!nwsw)
@@ -3324,7 +3324,7 @@ dbBlock::createNetSingleWire(const char *innm, int x1, int y1, int x2, int y2, u
 	if (!nwnet)
 		return NULL;
 	
-	nwnet->setSigType(dbSigType::SIGNAL);
+	nwnet->setSigType(dbSigType::Value::SIGNAL);
 
 	std::pair<dbBTerm *, dbBTerm *> blutrms;
 	if (! skipBterms ) {
@@ -3602,12 +3602,12 @@ uint dbBlock::levelize(std::vector<dbInst*>& startingInsts,
     dbSet<dbITerm>::iterator iitr;
     for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
       dbITerm* iterm = *iitr;
-      if ((iterm->getSigType() == dbSigType::GROUND)
-          || (iterm->getSigType() == dbSigType::POWER))
+      if ((iterm->getSigType() == dbSigType::Value::GROUND)
+          || (iterm->getSigType() == dbSigType::Value::POWER))
         continue;
 
-      if ((iterm->getIoType() == dbIoType::INPUT)
-          || (iterm->getIoType() == dbIoType::INOUT))
+      if ((iterm->getIoType() == dbIoType::Value::INPUT)
+          || (iterm->getIoType() == dbIoType::Value::INOUT))
         continue;
 
       dbNet* net = iterm->getNet();
@@ -3632,8 +3632,8 @@ uint dbBlock::levelizeFromPrimaryInputs()
     dbNet* net = bterm->getNet();
 
     if (net != NULL) {
-      if ((net->getSigType() == dbSigType::GROUND)
-          || (net->getSigType() == dbSigType::POWER))
+      if ((net->getSigType() == dbSigType::Value::GROUND)
+          || (net->getSigType() == dbSigType::Value::POWER))
         continue;
 
       net->setLevelAtFanout(level, true, instsToBeLeveled);
@@ -3739,8 +3739,8 @@ resultTable)
                 for (iitr= iterms.begin(); iitr != iterms.end(); ++iitr)
                 {
                         dbITerm *iterm= *iitr;
-                        if ((iterm->getSigType() == dbSigType::GROUND)||
-(iterm->getSigType() == dbSigType::POWER)) continue; if
+                        if ((iterm->getSigType() == dbSigType::Value::GROUND)||
+(iterm->getSigType() == dbSigType::Value::POWER)) continue; if
 (!iterm->isInputSignal()) continue; if (iterm->isClocked()) continue;
 
                         dbNet *inputNet= iterm->getNet();
@@ -3748,8 +3748,8 @@ resultTable)
                         if (inputNet==NULL)
                                 continue;
 
-                        if ((inputNet->getSigType()==dbSigType::GROUND)||
-(inputNet->getSigType()==dbSigType::POWER)) continue;
+                        if ((inputNet->getSigType()==dbSigType::Value::GROUND)||
+(inputNet->getSigType()==dbSigType::Value::POWER)) continue;
 
                         dbITerm* out= inputNet->getFirstOutput();
 
@@ -3818,8 +3818,8 @@ int dbBlock::markBackwardsUser2(std::vector<dbInst*>& startingInsts,
       if (inputNet == NULL)
         continue;
 
-      if ((inputNet->getSigType() == dbSigType::GROUND)
-          || (inputNet->getSigType() == dbSigType::POWER))
+      if ((inputNet->getSigType() == dbSigType::Value::GROUND)
+          || (inputNet->getSigType() == dbSigType::Value::POWER))
         continue;
 
       dbITerm* out = inputNet->getFirstOutput();
@@ -3921,8 +3921,8 @@ void dbBlock::setDrivingItermsforNets()
 
   for (nitr = nets.begin(); nitr != nets.end(); ++nitr) {
     dbNet* net = *nitr;
-    if ((net->getSigType() == dbSigType::GROUND)
-        || (net->getSigType() == dbSigType::POWER))
+    if ((net->getSigType() == dbSigType::Value::GROUND)
+        || (net->getSigType() == dbSigType::Value::POWER))
       continue;
 
     net->setDrivingITerm(0);
@@ -3932,7 +3932,7 @@ void dbBlock::setDrivingItermsforNets()
     for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
       dbITerm* tr = *iitr;
 
-      if (tr->getIoType() == dbIoType::OUTPUT) {
+      if (tr->getIoType() == dbIoType::Value::OUTPUT) {
         net->setDrivingITerm(tr->getId());
         break;
       }

--- a/src/odb/src/db/dbCapNode.cpp
+++ b/src/odb/src/db/dbCapNode.cpp
@@ -510,14 +510,14 @@ bool dbCapNode::isSourceTerm(dbBlock* mblock)
   if (seg->_flags._iterm) {
     dbITerm* iterm = dbITerm::getITerm(block, seg->_node_num);
     iotype = iterm->getIoType();
-    if (iterm->getIoType() == dbIoType::OUTPUT)
+    if (iterm->getIoType() == dbIoType::Value::OUTPUT)
       return true;
     else
       return false;
   } else if (seg->_flags._bterm) {
     dbBTerm* bterm = dbBTerm::getBTerm(block, seg->_node_num);
     iotype = bterm->getIoType();
-    if (bterm->getIoType() == dbIoType::INPUT)
+    if (bterm->getIoType() == dbIoType::Value::INPUT)
       return true;
     else
       return false;
@@ -530,13 +530,13 @@ bool dbCapNode::isInoutTerm(dbBlock* mblock)
   dbBlock* block = mblock ? mblock : (dbBlock*) seg->getOwner();
   if (seg->_flags._iterm) {
     dbITerm* iterm = dbITerm::getITerm(block, seg->_node_num);
-    if (iterm->getIoType() == dbIoType::INOUT)
+    if (iterm->getIoType() == dbIoType::Value::INOUT)
       return true;
     else
       return false;
   } else if (seg->_flags._bterm) {
     dbBTerm* bterm = dbBTerm::getBTerm(block, seg->_node_num);
-    if (bterm->getIoType() == dbIoType::INOUT)
+    if (bterm->getIoType() == dbIoType::Value::INOUT)
       return true;
     else
       return false;

--- a/src/odb/src/db/dbHierInstShapeItr.cpp
+++ b/src/odb/src/db/dbHierInstShapeItr.cpp
@@ -282,10 +282,10 @@ bool dbHierInstShapeItr::drawNet(unsigned filter,
   draw_segment = false;
 
   switch (type) {
-    case dbSigType::SCAN:
-    case dbSigType::ANALOG:
-    case dbSigType::TIEOFF:
-    case dbSigType::SIGNAL: {
+    case dbSigType::Value::SCAN:
+    case dbSigType::Value::ANALOG:
+    case dbSigType::Value::TIEOFF:
+    case dbSigType::Value::SIGNAL: {
       if (isFiltered(filter, SIGNAL_WIRE | SIGNAL_VIA))
         return false;
 
@@ -298,8 +298,8 @@ bool dbHierInstShapeItr::drawNet(unsigned filter,
       return true;
     }
 
-    case dbSigType::POWER:
-    case dbSigType::GROUND: {
+    case dbSigType::Value::POWER:
+    case dbSigType::Value::GROUND: {
       if (isFiltered(filter, POWER_WIRE | POWER_VIA))
         return false;
 
@@ -312,7 +312,7 @@ bool dbHierInstShapeItr::drawNet(unsigned filter,
       return true;
     }
 
-    case dbSigType::CLOCK: {
+    case dbSigType::Value::CLOCK: {
       if (isFiltered(filter, CLOCK_WIRE | CLOCK_VIA))
         return false;
 
@@ -325,7 +325,7 @@ bool dbHierInstShapeItr::drawNet(unsigned filter,
       return true;
     }
 
-    case dbSigType::RESET: {
+    case dbSigType::Value::RESET: {
       if (isFiltered(filter, RESET_WIRE | RESET_VIA))
         return false;
 

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -281,7 +281,8 @@ void dbITerm::setClocked(bool v)
 }
 bool dbITerm::isClocked()
 {
-  bool masterFlag = getMTerm()->getSigType() == dbSigType::Value::CLOCK ? true : false;
+  bool masterFlag
+      = getMTerm()->getSigType() == dbSigType::Value::CLOCK ? true : false;
   _dbITerm* iterm = (_dbITerm*) this;
   return iterm->_flags._clocked > 0 || masterFlag ? true : false;
 }

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -281,7 +281,7 @@ void dbITerm::setClocked(bool v)
 }
 bool dbITerm::isClocked()
 {
-  bool masterFlag = getMTerm()->getSigType() == dbSigType::CLOCK ? true : false;
+  bool masterFlag = getMTerm()->getSigType() == dbSigType::Value::CLOCK ? true : false;
   _dbITerm* iterm = (_dbITerm*) this;
   return iterm->_flags._clocked > 0 || masterFlag ? true : false;
 }
@@ -601,13 +601,13 @@ bool dbITerm::isOutputSignal(bool io)
   dbSigType sType = dbSigType(mterm->_flags._sig_type);
   dbIoType ioType = dbIoType(mterm->_flags._io_type);
 
-  if ((sType == dbSigType::GROUND) || (sType == dbSigType::POWER))
+  if ((sType == dbSigType::Value::GROUND) || (sType == dbSigType::Value::POWER))
     return false;
 
-  if (ioType == dbIoType::OUTPUT)
+  if (ioType == dbIoType::Value::OUTPUT)
     return true;
 
-  if (io && (ioType == dbIoType::INOUT))
+  if (io && (ioType == dbIoType::Value::INOUT))
     return true;
 
   return false;
@@ -618,13 +618,13 @@ bool dbITerm::isInputSignal(bool io)
   dbSigType sType = dbSigType(mterm->_flags._sig_type);
   dbIoType ioType = dbIoType(mterm->_flags._io_type);
 
-  if ((sType == dbSigType::GROUND) || (sType == dbSigType::POWER))
+  if ((sType == dbSigType::Value::GROUND) || (sType == dbSigType::Value::POWER))
     return false;
 
-  if (ioType == dbIoType::INPUT)
+  if (ioType == dbIoType::Value::INPUT)
     return true;
 
-  if (io && (ioType == dbIoType::INOUT))
+  if (io && (ioType == dbIoType::Value::INOUT))
     return true;
 
   return false;

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -1540,11 +1540,11 @@ dbITerm* dbInst::getFirstOutput()
   for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
     dbITerm* tr = *iitr;
 
-    if ((tr->getSigType() == dbSigType::GROUND)
-        || (tr->getSigType() == dbSigType::POWER))
+    if ((tr->getSigType() == dbSigType::Value::GROUND)
+        || (tr->getSigType() == dbSigType::Value::POWER))
       continue;
 
-    if (tr->getIoType() != dbIoType::OUTPUT)
+    if (tr->getIoType() != dbIoType::Value::OUTPUT)
       continue;
 
     return tr;

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -543,7 +543,7 @@ dbMTerm* dbMTerm::create(dbMaster* master_,
   mterm->_flags._io_type = io_type_;
   mterm->_flags._sig_type = sig_type_;
   mterm->_flags._shape_type = shape_type_;
-  if (sig_type_ == dbSigType::CLOCK)
+  if (sig_type_ == dbSigType::Value::CLOCK)
     master_->setSequential(1);
   master->_mterm_hash.insert(mterm);
   master->_mterm_cnt++;

--- a/src/odb/src/db/dbMTerm.h
+++ b/src/odb/src/db/dbMTerm.h
@@ -94,8 +94,8 @@ class _dbMTerm : public _dbObject
 
 inline _dbMTerm::_dbMTerm(_dbDatabase*)
 {
-  _flags._io_type = dbIoType::INPUT;
-  _flags._sig_type = dbSigType::SIGNAL;
+  _flags._io_type = dbIoType::Value::INPUT;
+  _flags._sig_type = dbSigType::Value::SIGNAL;
   _flags._shape_type = dbMTermShapeType::NONE;
   _flags._mark = 0;
   _flags._spare_bits = 0;

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -816,7 +816,7 @@ void dbNet::setSigType(dbSigType sig_type)
                1,
                "ECO: net {}, setSigType: {}",
                getId(),
-               sig_type.getValue());
+               sig_type.getString());
     block->_journal->updateField(
         this, _dbNet::FLAGS, prev_flags, flagsToUInt(net));
   }

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -2820,7 +2820,8 @@ void dbNet::getPowerWireCount(uint& wireCnt, uint& viaCnt)
 
 void dbNet::getWireCount(uint& wireCnt, uint& viaCnt)
 {
-  if (getSigType() == dbSigType::Value::POWER || getSigType() == dbSigType::Value::GROUND)
+  if (getSigType() == dbSigType::Value::POWER
+      || getSigType() == dbSigType::Value::GROUND)
     getPowerWireCount(wireCnt, viaCnt);
   else
     getSignalWireCount(wireCnt, viaCnt);

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -110,7 +110,7 @@ _dbNet::_dbNet(_dbDatabase* db, const _dbNet& n)
 
 _dbNet::_dbNet(_dbDatabase* db)
 {
-  _flags._sig_type = dbSigType::SIGNAL;
+  _flags._sig_type = dbSigType::Value::SIGNAL;
   _flags._wire_type = dbWireType::ROUTED;
   _flags._special = 0;
   _flags._wild_connect = 0;
@@ -1608,14 +1608,14 @@ dbITerm* dbNet::getFirstOutput()
   for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
     dbITerm* tr = *iitr;
 
-    if ((tr->getSigType() == dbSigType::GROUND)
-        || (tr->getSigType() == dbSigType::POWER))
+    if ((tr->getSigType() == dbSigType::Value::GROUND)
+        || (tr->getSigType() == dbSigType::Value::POWER))
       continue;
 
     if (tr->isClocked())
       continue;
 
-    if (tr->getIoType() != dbIoType::OUTPUT)
+    if (tr->getIoType() != dbIoType::Value::OUTPUT)
       continue;
 
     return tr;
@@ -1631,14 +1631,14 @@ dbITerm* dbNet::get1stSignalInput(bool io)
   for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
     dbITerm* tr = *iitr;
 
-    if ((tr->getSigType() == dbSigType::GROUND)
-        || (tr->getSigType() == dbSigType::POWER))
+    if ((tr->getSigType() == dbSigType::Value::GROUND)
+        || (tr->getSigType() == dbSigType::Value::POWER))
       continue;
 
-    if (tr->getIoType() != dbIoType::INPUT)
+    if (tr->getIoType() != dbIoType::Value::INPUT)
       continue;
 
-    if (io && (tr->getIoType() != dbIoType::INOUT))
+    if (io && (tr->getIoType() != dbIoType::Value::INOUT))
       continue;
 
     return tr;
@@ -2534,7 +2534,7 @@ void dbNet::getCouplingNets(uint corner,
 void dbNet::getGndTotalCap(double* gndcap, double* totalcap, double mcf)
 {
   dbSigType type = getSigType();
-  if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+  if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
     return;
   dbSet<dbRSeg> rSet = getRSegs();
   if (rSet.begin() == rSet.end()) {
@@ -2580,7 +2580,7 @@ void dbNet::preExttreeMergeRC(double max_cap, uint corner)
   dbCapNode* tgtNode;
   std::vector<dbRSeg*> mrsegs;
   dbSigType type = getSigType();
-  if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+  if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
     return;
   dbSet<dbRSeg> rSet = getRSegs();
   if (rSet.begin() == rSet.end()) {
@@ -2820,7 +2820,7 @@ void dbNet::getPowerWireCount(uint& wireCnt, uint& viaCnt)
 
 void dbNet::getWireCount(uint& wireCnt, uint& viaCnt)
 {
-  if (getSigType() == dbSigType::POWER || getSigType() == dbSigType::GROUND)
+  if (getSigType() == dbSigType::Value::POWER || getSigType() == dbSigType::Value::GROUND)
     getPowerWireCount(wireCnt, viaCnt);
   else
     getSignalWireCount(wireCnt, viaCnt);
@@ -3053,8 +3053,8 @@ uint dbNet::setLevelAtFanout(uint level,
   dbSet<dbITerm>::iterator iitr;
   for (iitr = iterms.begin(); iitr != iterms.end(); ++iitr) {
     dbITerm* iterm = *iitr;
-    if (!((iterm->getIoType() == dbIoType::INPUT)
-          || (iterm->getIoType() == dbIoType::INOUT)))
+    if (!((iterm->getIoType() == dbIoType::Value::INPUT)
+          || (iterm->getIoType() == dbIoType::Value::INOUT)))
       continue;
 
     dbInst* inst = iterm->getInst();
@@ -3164,10 +3164,10 @@ dbNet::createTerms4SingleNet(int x1, int y1, int x2, int y2, dbTechLayer *inly)
       dbBox::create(bupin, inly, -hwidth+x2, -hwidth+y, hwidth+x2, hwidth+y);
   }
 
-  blterm->setSigType(dbSigType::SIGNAL);
-  buterm->setSigType(dbSigType::SIGNAL);
-  blterm->setIoType(dbIoType::INPUT);
-  buterm->setIoType(dbIoType::OUTPUT);
+  blterm->setSigType(dbSigType::Value::SIGNAL);
+  buterm->setSigType(dbSigType::Value::SIGNAL);
+  blterm->setIoType(dbIoType::Value::INPUT);
+  buterm->setIoType(dbIoType::Value::OUTPUT);
   blpin->setPlacementStatus(dbPlacementStatus::PLACED);
   bupin->setPlacementStatus(dbPlacementStatus::PLACED);
 

--- a/src/odb/src/db/dbSearch.cpp
+++ b/src/odb/src/db/dbSearch.cpp
@@ -1598,7 +1598,7 @@ void dbBlockSearch::selectIterm2Net(uint itermId)
   // add context markers
 
   dbSigType type = net->getSigType();
-  if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+  if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
     addNetSBoxesOnSearch(net, false);
   else
     getNetConnectivity(net, false, 0, false, false, false);
@@ -1930,7 +1930,7 @@ uint dbBlockSearch::getConnectivityWires(dbInst* inst, bool ignoreZuiFlags)
       continue;
 
     dbSigType type = net->getSigType();
-    if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+    if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
       continue;
 
     cnt += getNetFromDb(net, ignoreZuiFlags, true);
@@ -2059,7 +2059,7 @@ bool dbBlockSearch::isSignalNet(dbNet* net)
 {
   dbSigType type = net->getSigType();
 
-  return ((type == dbSigType::POWER) || (type == dbSigType::GROUND)) ? false
+  return ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND)) ? false
                                                                      : true;
 }
 uint dbBlockSearch::selectNet()
@@ -2161,7 +2161,7 @@ void dbBlockSearch::selectBterm2Net(uint btermId)
 
   dbSigType type = net->getSigType();
 
-  if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+  if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
     addNetSBoxesOnSearch(net, false);
   else
     getNetConnectivity(net, false, 0, false, false, false);

--- a/src/odb/src/db/dbSearch.cpp
+++ b/src/odb/src/db/dbSearch.cpp
@@ -41,7 +41,7 @@
 #include "dbTypes.h"
 #include "utl/Logger.h"
 
-//#define NEW_TRACKS
+// #define NEW_TRACKS
 
 #include "dbShape.h"
 namespace odb {
@@ -2059,8 +2059,10 @@ bool dbBlockSearch::isSignalNet(dbNet* net)
 {
   dbSigType type = net->getSigType();
 
-  return ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND)) ? false
-                                                                     : true;
+  return ((type == dbSigType::Value::POWER)
+          || (type == dbSigType::Value::GROUND))
+             ? false
+             : true;
 }
 uint dbBlockSearch::selectNet()
 {

--- a/src/odb/src/db/dbTypes.cpp
+++ b/src/odb/src/db/dbTypes.cpp
@@ -238,34 +238,34 @@ const char* dbGroupType::getString() const
 dbSigType::dbSigType(const char* value)
 {
   if (strcasecmp(value, "SIGNAL") == 0)
-    _value = SIGNAL;
+    _value = Value::SIGNAL;
 
   else if (strcasecmp(value, "POWER") == 0)
-    _value = POWER;
+    _value = Value::POWER;
 
   else if (strcasecmp(value, "GROUND") == 0)
-    _value = GROUND;
+    _value = Value::GROUND;
 
   else if (strcasecmp(value, "CLOCK") == 0)
-    _value = CLOCK;
+    _value = Value::CLOCK;
 
   else if (strcasecmp(value, "ANALOG") == 0)
-    _value = ANALOG;
+    _value = Value::ANALOG;
 
   else if (strcasecmp(value, "ANALOG") == 0)
-    _value = ANALOG;
+    _value = Value::ANALOG;
 
   else if (strcasecmp(value, "RESET") == 0)
-    _value = RESET;
+    _value = Value::RESET;
 
   else if (strcasecmp(value, "SCAN") == 0)
-    _value = SCAN;
+    _value = Value::SCAN;
 
   else if (strcasecmp(value, "TIEOFF") == 0)
-    _value = TIEOFF;
+    _value = Value::TIEOFF;
 
   else
-    _value = SIGNAL;
+    _value = Value::SIGNAL;
 }
 
 dbSigType::dbSigType(Value value)
@@ -275,7 +275,7 @@ dbSigType::dbSigType(Value value)
 
 dbSigType::dbSigType()
 {
-  _value = SIGNAL;
+  _value = Value::SIGNAL;
 }
 
 dbSigType::dbSigType(const dbSigType& value)
@@ -286,15 +286,15 @@ dbSigType::dbSigType(const dbSigType& value)
 bool dbSigType::isSupply() const
 {
   switch (_value) {
-    case POWER:
-    case GROUND:
+    case Value::POWER:
+    case Value::GROUND:
       return true;
-    case SIGNAL:
-    case CLOCK:
-    case ANALOG:
-    case RESET:
-    case SCAN:
-    case TIEOFF:
+    case Value::SIGNAL:
+    case Value::CLOCK:
+    case Value::ANALOG:
+    case Value::RESET:
+    case Value::SCAN:
+    case Value::TIEOFF:
       return false;
   }
   assert(false);
@@ -306,35 +306,35 @@ const char* dbSigType::getString() const
   const char* value = "";
 
   switch (_value) {
-    case SIGNAL:
+    case Value::SIGNAL:
       value = "SIGNAL";
       break;
 
-    case POWER:
+    case Value::POWER:
       value = "POWER";
       break;
 
-    case GROUND:
+    case Value::GROUND:
       value = "GROUND";
       break;
 
-    case CLOCK:
+    case Value::CLOCK:
       value = "CLOCK";
       break;
 
-    case ANALOG:
+    case Value::ANALOG:
       value = "ANALOG";
       break;
 
-    case RESET:
+    case Value::RESET:
       value = "RESET";
       break;
 
-    case SCAN:
+    case Value::SCAN:
       value = "SCAN";
       break;
 
-    case TIEOFF:
+    case Value::TIEOFF:
       value = "TIEOFF";
       break;
   }
@@ -345,19 +345,19 @@ const char* dbSigType::getString() const
 dbIoType::dbIoType(const char* value)
 {
   if (strcasecmp(value, "INPUT") == 0)
-    _value = INPUT;
+    _value = Value::INPUT;
 
   else if (strcasecmp(value, "OUTPUT") == 0)
-    _value = OUTPUT;
+    _value = Value::OUTPUT;
 
   else if (strcasecmp(value, "INOUT") == 0)
-    _value = INOUT;
+    _value = Value::INOUT;
 
   else if (strcasecmp(value, "FEEDTHRU") == 0)
-    _value = FEEDTHRU;
+    _value = Value::FEEDTHRU;
 
   else
-    _value = INPUT;
+    _value = Value::INPUT;
 }
 
 dbIoType::dbIoType(Value value)
@@ -367,7 +367,7 @@ dbIoType::dbIoType(Value value)
 
 dbIoType::dbIoType()
 {
-  _value = INPUT;
+  _value = Value::INPUT;
 }
 
 dbIoType::dbIoType(const dbIoType& value)
@@ -380,19 +380,19 @@ const char* dbIoType::getString() const
   const char* value = "";
 
   switch (_value) {
-    case INPUT:
+    case Value::INPUT:
       value = "INPUT";
       break;
 
-    case OUTPUT:
+    case Value::OUTPUT:
       value = "OUTPUT";
       break;
 
-    case INOUT:
+    case Value::INOUT:
       value = "INOUT";
       break;
 
-    case FEEDTHRU:
+    case Value::FEEDTHRU:
       value = "FEEDTHRU";
       break;
   }

--- a/src/odb/src/db/dbUtil.cpp
+++ b/src/odb/src/db/dbUtil.cpp
@@ -661,7 +661,7 @@ uint dbCreateNetUtil::printModifiedNets(dbBlock* ecoBlock,
 
     if (_skipPowerNets) {
       dbSigType ty = net->getSigType();
-      if ((ty == dbSigType::POWER) || (ty == dbSigType::GROUND))
+      if ((ty == dbSigType::Value::POWER) || (ty == dbSigType::Value::GROUND))
         continue;
     }
 
@@ -680,7 +680,7 @@ dbNet* dbCreateNetUtil::createNet(dbNet* nn, bool create, bool destroy)
   dbNet* net = dbNet::create(_block, nn->getConstName());
 
   dbSigType ty = nn->getSigType();
-  if ((ty == dbSigType::POWER) && (ty == dbSigType::GROUND))
+  if ((ty == dbSigType::Value::POWER) && (ty == dbSigType::Value::GROUND))
     net->setSpecial();
 
   net->setSigType(ty);
@@ -1085,7 +1085,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
   if (net == NULL)
     return NULL;
 
-  net->setSigType(dbSigType::SIGNAL);
+  net->setSigType(dbSigType::Value::SIGNAL);
 
   std::pair<dbBTerm*, dbBTerm*> blutrms;
 
@@ -1167,11 +1167,11 @@ dbNet* dbCreateNetUtil::createSpecialNet(dbNet* origNet, const char* name)
   if (net == NULL) {
     net = dbNet::create(_block, netName);
     if ((origNet != NULL)
-        && ((origNet->getSigType() == dbSigType::POWER)
-            || (origNet->getSigType() == dbSigType::GROUND)))
+        && ((origNet->getSigType() == dbSigType::Value::POWER)
+            || (origNet->getSigType() == dbSigType::Value::GROUND)))
       net->setSigType(origNet->getSigType());
     else
-      net->setSigType(dbSigType::POWER);
+      net->setSigType(dbSigType::Value::POWER);
 
     dbSWire::create(net, dbWireType::NONE, NULL);
 
@@ -1194,11 +1194,11 @@ dbNet* dbCreateNetUtil::createSpecialNetSingleWire(Rect& r,
   dbNet* net = _block->findNet(netName);
   if (net == NULL) {
     net = dbNet::create(_block, netName);
-    if ((origNet->getSigType() == dbSigType::POWER)
-        || (origNet->getSigType() == dbSigType::GROUND))
+    if ((origNet->getSigType() == dbSigType::Value::POWER)
+        || (origNet->getSigType() == dbSigType::Value::GROUND))
       net->setSigType(origNet->getSigType());
     else
-      net->setSigType(dbSigType::POWER);
+      net->setSigType(dbSigType::Value::POWER);
 
     swire = dbSWire::create(net, dbWireType::NONE, NULL);
   } else {
@@ -1408,7 +1408,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
     return NULL;
   }
 
-  net->setSigType(dbSigType::SIGNAL);
+  net->setSigType(dbSigType::Value::SIGNAL);
 
   std::pair<dbBTerm*, dbBTerm*> blutrms;
 
@@ -1508,10 +1508,10 @@ std::pair<dbBTerm*, dbBTerm*> dbCreateNetUtil::createTerms4SingleNet(
         bupin, inly, -hwidth + x2, -hwidth + y, hwidth + x2, hwidth + y);
   }
 
-  blterm->setSigType(dbSigType::SIGNAL);
-  buterm->setSigType(dbSigType::SIGNAL);
-  blterm->setIoType(dbIoType::INPUT);
-  buterm->setIoType(dbIoType::OUTPUT);
+  blterm->setSigType(dbSigType::Value::SIGNAL);
+  buterm->setSigType(dbSigType::Value::SIGNAL);
+  blterm->setIoType(dbIoType::Value::INPUT);
+  buterm->setIoType(dbIoType::Value::OUTPUT);
   blpin->setPlacementStatus(dbPlacementStatus::PLACED);
   bupin->setPlacementStatus(dbPlacementStatus::PLACED);
 
@@ -1540,7 +1540,7 @@ dbNet* dbCreateNetUtil::createNetSingleVia(const char* netName,
     return NULL;
   }
 
-  net->setSigType(dbSigType::SIGNAL);
+  net->setSigType(dbSigType::Value::SIGNAL);
 
   if (!createSingleVia(net, x1, y1, x2, y2, lay1, lay2)) {
     dbNet::destroy(net);

--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -71,11 +71,11 @@ static void tmg_getDriveTerm(dbNet* net, dbITerm** iterm, dbBTerm** bterm)
   dbITerm* it_inout = NULL;
   for (iterm_itr = iterms.begin(); iterm_itr != iterms.end(); ++iterm_itr) {
     it = *iterm_itr;
-    if (it->getIoType() == dbIoType::OUTPUT) {
+    if (it->getIoType() == dbIoType::Value::OUTPUT) {
       *iterm = it;
       return;
     }
-    if (it->getIoType() == dbIoType::INOUT && !it_inout)
+    if (it->getIoType() == dbIoType::Value::INOUT && !it_inout)
       it_inout = it;
   }
   dbSet<dbBTerm> bterms = net->getBTerms();
@@ -84,11 +84,11 @@ static void tmg_getDriveTerm(dbNet* net, dbITerm** iterm, dbBTerm** bterm)
   dbBTerm* bt_inout = NULL;
   for (bterm_itr = bterms.begin(); bterm_itr != bterms.end(); ++bterm_itr) {
     bt = *bterm_itr;
-    if (bt->getIoType() == dbIoType::INPUT) {
+    if (bt->getIoType() == dbIoType::Value::INPUT) {
       *bterm = bt;
       return;
     }
-    if (bt->getIoType() == dbIoType::INOUT && !bt_inout)
+    if (bt->getIoType() == dbIoType::Value::INOUT && !bt_inout)
       bt_inout = bt;
   }
   if (bt_inout) {

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -1433,7 +1433,7 @@ void lefin::pin(lefiPin* pin)
 
   if (pin->hasDirection()) {
     if (strcasecmp(pin->direction(), "OUTPUT TRISTATE") == 0)
-      io_type = dbIoType(dbIoType::OUTPUT);
+      io_type = dbIoType(dbIoType::Value::OUTPUT);
     else
       io_type = dbIoType(pin->direction());
   }

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -420,8 +420,9 @@ void lefout::writePowerPins(dbBlock* db_block)
     }
     fprintf(_out, "  PIN %s\n", net->getName().c_str());
     fprintf(_out, "    USE %s ;\n", net->getSigType().getString());
-    fprintf(
-        _out, "    DIRECTION %s ;\n", dbIoType(dbIoType::Value::INOUT).getString());
+    fprintf(_out,
+            "    DIRECTION %s ;\n",
+            dbIoType(dbIoType::Value::INOUT).getString());
     for (dbSWire* special_wire : net->getSWires()) {
       fprintf(_out, "    PORT\n");
       dbSet<dbSBox> wires = special_wire->getWires();

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -421,7 +421,7 @@ void lefout::writePowerPins(dbBlock* db_block)
     fprintf(_out, "  PIN %s\n", net->getName().c_str());
     fprintf(_out, "    USE %s ;\n", net->getSigType().getString());
     fprintf(
-        _out, "    DIRECTION %s ;\n", dbIoType(dbIoType::INOUT).getString());
+        _out, "    DIRECTION %s ;\n", dbIoType(dbIoType::Value::INOUT).getString());
     for (dbSWire* special_wire : net->getSWires()) {
       fprintf(_out, "    PORT\n");
       dbSet<dbSBox> wires = special_wire->getWires();

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(test_bterm)
   cb->addOwner(block);
   auto n1 = block->findNet("n1");
   dbBTerm* IN1 = dbBTerm::create(n1, "IN1");
-  IN1->setIoType(dbIoType::INPUT);
+  IN1->setIoType(dbIoType::Value::INPUT);
   BOOST_TEST(cb->events.size() == 3);
   BOOST_TEST(cb->events[0] == "Create IN1");
   BOOST_TEST(cb->events[1] == "Preconnect IN1 to n1");

--- a/src/odb/test/cpp/helper.cpp
+++ b/src/odb/test/cpp/helper.cpp
@@ -17,9 +17,12 @@ dbMaster* createMaster2X1(dbLib* lib,
   master->setWidth(width);
   master->setHeight(height);
   master->setType(dbMasterType::CORE);
-  dbMTerm::create(master, in1, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
-  dbMTerm::create(master, in2, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
-  dbMTerm::create(master, out, dbIoType::Value::OUTPUT, dbSigType::Value::SIGNAL);
+  dbMTerm::create(
+      master, in1, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
+  dbMTerm::create(
+      master, in2, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
+  dbMTerm::create(
+      master, out, dbIoType::Value::OUTPUT, dbSigType::Value::SIGNAL);
   master->setFrozen();
   return master;
 }

--- a/src/odb/test/cpp/helper.cpp
+++ b/src/odb/test/cpp/helper.cpp
@@ -17,9 +17,9 @@ dbMaster* createMaster2X1(dbLib* lib,
   master->setWidth(width);
   master->setHeight(height);
   master->setType(dbMasterType::CORE);
-  dbMTerm::create(master, in1, dbIoType::INPUT, dbSigType::SIGNAL);
-  dbMTerm::create(master, in2, dbIoType::INPUT, dbSigType::SIGNAL);
-  dbMTerm::create(master, out, dbIoType::OUTPUT, dbSigType::SIGNAL);
+  dbMTerm::create(master, in1, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
+  dbMTerm::create(master, in2, dbIoType::Value::INPUT, dbSigType::Value::SIGNAL);
+  dbMTerm::create(master, out, dbIoType::Value::OUTPUT, dbSigType::Value::SIGNAL);
   master->setFrozen();
   return master;
 }
@@ -87,10 +87,10 @@ dbDatabase* create2LevetDbWithBTerms()
   auto n2 = block->findNet("n2");
   auto n7 = block->findNet("n7");
   dbBTerm* IN1 = dbBTerm::create(n1, "IN1");
-  IN1->setIoType(dbIoType::INPUT);
+  IN1->setIoType(dbIoType::Value::INPUT);
   dbBTerm* IN2 = dbBTerm::create(n2, "IN2");
-  IN2->setIoType(dbIoType::INPUT);
+  IN2->setIoType(dbIoType::Value::INPUT);
   dbBTerm* OUT = dbBTerm::create(n7, "IN3");
-  OUT->setIoType(dbIoType::OUTPUT);
+  OUT->setIoType(dbIoType::Value::OUTPUT);
   return db;
 }

--- a/src/par/src/TritonPart.cpp
+++ b/src/par/src/TritonPart.cpp
@@ -240,7 +240,7 @@ void TritonPart::ReadNetlist()
       odb::dbInst* inst = iterm->getInst();
       const int vertex_id
           = odb::dbIntProperty::find(inst, "vertex_id")->getValue();
-      if (iterm->getIoType() == odb::dbIoType::OUTPUT)
+      if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT)
         driver_id = vertex_id;
       else
         loads_id.insert(vertex_id);
@@ -249,7 +249,7 @@ void TritonPart::ReadNetlist()
     for (odb::dbBTerm* bterm : net->getBTerms()) {
       const int vertex_id
           = odb::dbIntProperty::find(bterm, "vertex_id")->getValue();
-      if (bterm->getIoType() == odb::dbIoType::INPUT)
+      if (bterm->getIoType() == odb::dbIoType::Value::INPUT)
         driver_id = vertex_id;
       else
         loads_id.insert(vertex_id);

--- a/src/pdn/src/domain.cpp
+++ b/src/pdn/src/domain.cpp
@@ -278,7 +278,7 @@ void VoltageDomain::determinePowerGroundNets()
 {
   // look for power
   if (power_ == nullptr) {
-    power_ = findDomainNet(odb::dbSigType::POWER);
+    power_ = findDomainNet(odb::dbSigType::Value::POWER);
     logger_->info(utl::PDN,
                   101,
                   "Using {} as power net for {} domain.",
@@ -287,7 +287,7 @@ void VoltageDomain::determinePowerGroundNets()
   }
   // look for ground
   if (ground_ == nullptr) {
-    ground_ = findDomainNet(odb::dbSigType::GROUND);
+    ground_ = findDomainNet(odb::dbSigType::Value::GROUND);
     logger_->info(utl::PDN,
                   102,
                   "Using {} as ground net for {} domain.",

--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -1471,12 +1471,12 @@ ExistingGrid::ExistingGrid(
   // find a power and ground net for the domain
   for (auto* net : nets) {
     if (power == nullptr) {
-      if (net->getSigType() == odb::dbSigType::POWER) {
+      if (net->getSigType() == odb::dbSigType::Value::POWER) {
         power = net;
       }
     }
     if (ground == nullptr) {
-      if (net->getSigType() == odb::dbSigType::GROUND) {
+      if (net->getSigType() == odb::dbSigType::Value::GROUND) {
         ground = net;
       }
     }

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -388,7 +388,7 @@ void Shape::addBPinToDb(const odb::Rect& rect) const
   if (net_->getBTermCount() == 0) {
     bterm = odb::dbBTerm::create(net_, net_->getConstName());
     bterm->setSigType(net_->getSigType());
-    bterm->setIoType(odb::dbIoType::INOUT);
+    bterm->setIoType(odb::dbIoType::Value::INOUT);
     bterm->setSpecial();
   } else {
     bterm = net_->get1stBTerm();

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1991,10 +1991,10 @@ void IOPlacer::initNetlist()
 
     Direction dir = Direction::inout;
     switch (b_term->getIoType()) {
-      case odb::dbIoType::INPUT:
+      case odb::dbIoType::Value::INPUT:
         dir = Direction::input;
         break;
-      case odb::dbIoType::OUTPUT:
+      case odb::dbIoType::Value::OUTPUT:
         dir = Direction::output;
         break;
       default:

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -206,7 +206,7 @@ void IRSolver::solveIR()
     Node* node = Gmat_->getNode(node_num);
     const double volt = x(node_num);
     sum_volt = sum_volt + volt;
-    if (power_net_type_ == dbSigType::POWER) {
+    if (power_net_type_ == dbSigType::Value::POWER) {
       if (volt < wc_voltage) {
         wc_voltage = volt;
       }
@@ -395,7 +395,7 @@ void IRSolver::readC4Data()
                        power_net_);
       }
       power_net_type_ = power_net->getSigType();
-      if (power_net_type_ == dbSigType::GROUND) {
+      if (power_net_type_ == dbSigType::Value::GROUND) {
         supply_voltage_src = supply_voltages.second;
         logger_->warn(utl::PSM,
                       21,
@@ -584,7 +584,7 @@ bool IRSolver::createJ()
   // Creating the J matrix
   for (int i = 0; i < num_nodes; ++i) {
     const Node* node_J = Gmat_->getNode(i);
-    if (power_net_type_ == dbSigType::GROUND) {
+    if (power_net_type_ == dbSigType::Value::GROUND) {
       J_[i] = (node_J->getCurrent());
     } else {
       J_[i] = -1 * (node_J->getCurrent());

--- a/src/rcx/src/extBenchDB.cpp
+++ b/src/rcx/src/extBenchDB.cpp
@@ -317,17 +317,17 @@ double extMain::getTotalCouplingCap(dbNet* net,
 uint extMain::benchVerilog(FILE* fp)
 {
   fprintf(fp, "module %s (\n", _block->getConstName());
-  benchVerilog_bterms(fp, dbIoType::OUTPUT, "  ", ",");
-  benchVerilog_bterms(fp, dbIoType::INPUT, "  ", ",", true);
+  benchVerilog_bterms(fp, dbIoType::Value::OUTPUT, "  ", ",");
+  benchVerilog_bterms(fp, dbIoType::Value::INPUT, "  ", ",", true);
   fprintf(fp, ");\n\n");
-  benchVerilog_bterms(fp, dbIoType::OUTPUT, "  output ", " ;");
+  benchVerilog_bterms(fp, dbIoType::Value::OUTPUT, "  output ", " ;");
   fprintf(fp, "\n");
-  benchVerilog_bterms(fp, dbIoType::INPUT, "  input ", " ;");
+  benchVerilog_bterms(fp, dbIoType::Value::INPUT, "  input ", " ;");
   fprintf(fp, "\n");
 
-  benchVerilog_bterms(fp, dbIoType::OUTPUT, "  wire ", " ;");
+  benchVerilog_bterms(fp, dbIoType::Value::OUTPUT, "  wire ", " ;");
   fprintf(fp, "\n");
-  benchVerilog_bterms(fp, dbIoType::INPUT, "  wire ", " ;");
+  benchVerilog_bterms(fp, dbIoType::Value::INPUT, "  wire ", " ;");
   fprintf(fp, "\n");
 
   benchVerilog_assign(fp);
@@ -370,13 +370,13 @@ uint extMain::benchVerilog_assign(FILE* fp)
     const char* bterm2 = NULL;
     dbSet<dbBTerm> bterms = net->getBTerms();
     for (dbBTerm* bterm : bterms) {
-      if (bterm->getIoType() == dbIoType::OUTPUT) {
+      if (bterm->getIoType() == dbIoType::Value::OUTPUT) {
         bterm1 = bterm->getConstName();
         break;
       }
     }
     for (dbBTerm* bterm : bterms) {
-      if (bterm->getIoType() == dbIoType::INPUT) {
+      if (bterm->getIoType() == dbIoType::Value::INPUT) {
         bterm2 = bterm->getConstName();
         break;
       }

--- a/src/rcx/src/extFlow.cpp
+++ b/src/rcx/src/extFlow.cpp
@@ -954,7 +954,7 @@ uint extMain::addNetShapesGs(dbNet* net,
     return 0;
 
   bool plane = false;
-  if (net->getSigType() == dbSigType::ANALOG)
+  if (net->getSigType() == dbSigType::Value::ANALOG)
     plane = true;
 
   dbWireShapeItr shapes;

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1435,9 +1435,9 @@ uint extSpef::writeBlockPorts()
   odb::dbSet<odb::dbBTerm>::iterator itr;
   for (itr = bterms.begin(); itr != bterms.end(); ++itr) {
     odb::dbBTerm* bterm = *itr;
-    if (bterm->getSigType() == odb::dbSigType::POWER)
+    if (bterm->getSigType() == odb::dbSigType::Value::POWER)
       continue;
-    if (bterm->getSigType() == odb::dbSigType::GROUND)
+    if (bterm->getSigType() == odb::dbSigType::Value::GROUND)
       continue;
     if (_partial && !bterm->isSetMark())
       continue;
@@ -1518,7 +1518,7 @@ uint extSpef::writeNetMap(odb::dbSet<odb::dbNet>& nets)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::POWER) || (type == odb::dbSigType::GROUND))
+    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (!_partial || !net->isMarked())
       continue;
@@ -1558,7 +1558,7 @@ uint extSpef::writeNetMap(odb::dbSet<odb::dbNet>& nets)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::POWER) || (type == odb::dbSigType::GROUND))
+    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (_partial && !net->isMark_1ed())
       continue;
@@ -1751,9 +1751,9 @@ uint extSpef::writeBlock(char* nodeCoord,
         continue;
     }
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::POWER) || (type == odb::dbSigType::GROUND))
+    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
       continue;
-    if (_wOnlyClock && type != odb::dbSigType::CLOCK)
+    if (_wOnlyClock && type != odb::dbSigType::Value::CLOCK)
       continue;
 
     cnt += writeNet(net, 0.0, 0);
@@ -1787,9 +1787,9 @@ uint extSpef::write_spef_nets(bool flatten, bool parallel)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::POWER) || (type == odb::dbSigType::GROUND))
+    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
       continue;
-    if (_wOnlyClock && type != odb::dbSigType::CLOCK)
+    if (_wOnlyClock && type != odb::dbSigType::Value::CLOCK)
       continue;
 
     odb::dbSet<odb::dbRSeg> rSet = net->getRSegs();

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1518,7 +1518,8 @@ uint extSpef::writeNetMap(odb::dbSet<odb::dbNet>& nets)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
+    if ((type == odb::dbSigType::Value::POWER)
+        || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (!_partial || !net->isMarked())
       continue;
@@ -1558,7 +1559,8 @@ uint extSpef::writeNetMap(odb::dbSet<odb::dbNet>& nets)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
+    if ((type == odb::dbSigType::Value::POWER)
+        || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (_partial && !net->isMark_1ed())
       continue;
@@ -1751,7 +1753,8 @@ uint extSpef::writeBlock(char* nodeCoord,
         continue;
     }
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
+    if ((type == odb::dbSigType::Value::POWER)
+        || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (_wOnlyClock && type != odb::dbSigType::Value::CLOCK)
       continue;
@@ -1787,7 +1790,8 @@ uint extSpef::write_spef_nets(bool flatten, bool parallel)
     odb::dbNet* net = *net_itr;
 
     odb::dbSigType type = net->getSigType();
-    if ((type == odb::dbSigType::Value::POWER) || (type == odb::dbSigType::Value::GROUND))
+    if ((type == odb::dbSigType::Value::POWER)
+        || (type == odb::dbSigType::Value::GROUND))
       continue;
     if (_wOnlyClock && type != odb::dbSigType::Value::CLOCK)
       continue;

--- a/src/rcx/src/extSpefIn.cpp
+++ b/src/rcx/src/extSpefIn.cpp
@@ -729,7 +729,7 @@ void extSpef::setSpefFlag(bool v)
     dbNet* net = *net_itr;
 
     dbSigType type = net->getSigType();
-    if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+    if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
       continue;
     net->setSpef(v);
   }
@@ -2144,7 +2144,7 @@ void extSpef::buildNodeHashTable()
   for (net_itr = nets.begin(); net_itr != nets.end(); ++net_itr) {
     dbNet* net = *net_itr;
     dbSigType type = net->getSigType();
-    if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+    if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
       continue;
     addNetNodeHash(net);
   }
@@ -2551,7 +2551,7 @@ uint extSpef::readBlock(uint debug,
     for (net_itr = bnets.begin(); net_itr != bnets.end(); ++net_itr) {
       net = *net_itr;
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
         continue;
       net->calibrateCouplingCap(_db_ext_corner);
     }
@@ -2583,7 +2583,7 @@ uint extSpef::readBlock(uint debug,
     for (net_itr = bnets.begin(); net_itr != bnets.end(); ++net_itr) {
       net = *net_itr;
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
         continue;
       cornerNet = dbNet::getNet(_cornerBlock, net->getId());
       if (!cornerNet->isSpef()) {

--- a/src/rcx/src/extSpefIn.cpp
+++ b/src/rcx/src/extSpefIn.cpp
@@ -2551,7 +2551,8 @@ uint extSpef::readBlock(uint debug,
     for (net_itr = bnets.begin(); net_itr != bnets.end(); ++net_itr) {
       net = *net_itr;
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
+      if ((type == dbSigType::Value::POWER)
+          || (type == dbSigType::Value::GROUND))
         continue;
       net->calibrateCouplingCap(_db_ext_corner);
     }
@@ -2583,7 +2584,8 @@ uint extSpef::readBlock(uint debug,
     for (net_itr = bnets.begin(); net_itr != bnets.end(); ++net_itr) {
       net = *net_itr;
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
+      if ((type == dbSigType::Value::POWER)
+          || (type == dbSigType::Value::GROUND))
         continue;
       cornerNet = dbNet::getNet(_cornerBlock, net->getId());
       if (!cornerNet->isSpef()) {

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1816,7 +1816,7 @@ uint extMain::makeBlockRCsegs(const char* netNames,
     net = *net_itr;
 
     dbSigType type = net->getSigType();
-    if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+    if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
       continue;
     if (!_allNet && !net->isMarked())
       continue;
@@ -1947,7 +1947,7 @@ uint extMain::makeBlockRCsegs(const char* netNames,
       net = *net_itr;
 
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::POWER) || (type == dbSigType::GROUND))
+      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
         continue;
       net->setWireAltered(false);
     }

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -1947,7 +1947,8 @@ uint extMain::makeBlockRCsegs(const char* netNames,
       net = *net_itr;
 
       dbSigType type = net->getSigType();
-      if ((type == dbSigType::Value::POWER) || (type == dbSigType::Value::GROUND))
+      if ((type == dbSigType::Value::POWER)
+          || (type == dbSigType::Value::GROUND))
         continue;
       net->setWireAltered(false);
     }

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -416,11 +416,11 @@ void Restructure::removeConstCells()
       continue;
 
     for (auto&& iterm : inst->getITerms()) {
-      if (iterm->getSigType() == odb::dbSigType::POWER
-          || iterm->getSigType() == odb::dbSigType::GROUND)
+      if (iterm->getSigType() == odb::dbSigType::Value::POWER
+          || iterm->getSigType() == odb::dbSigType::Value::GROUND)
         continue;
 
-      if (iterm->getIoType() != odb::dbIoType::OUTPUT)
+      if (iterm->getIoType() != odb::dbIoType::Value::OUTPUT)
         continue;
       outputs++;
       auto pin = open_sta_->getDbNetwork()->dbToSta(iterm);

--- a/src/rmp/src/blif.cpp
+++ b/src/rmp/src/blif.cpp
@@ -135,8 +135,8 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
       auto mterm = iterm->getMTerm();
       auto net = iterm->getNet();
 
-      if (iterm->getSigType() == odb::dbSigType::POWER
-          || iterm->getSigType() == odb::dbSigType::GROUND)
+      if (iterm->getSigType() == odb::dbSigType::Value::POWER
+          || iterm->getSigType() == odb::dbSigType::Value::GROUND)
         continue;
 
       sta::Vertex *vertex, *bidirect_drvr_vertex;
@@ -168,10 +168,10 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
       auto connectedIterms = net->getITerms();
 
       if (connectedIterms.size() == 1) {
-        if (iterm->getIoType() == odb::dbIoType::INPUT) {
+        if (iterm->getIoType() == odb::dbIoType::Value::INPUT) {
           inputs.insert(netName);
           addArrival(pin_, netName);
-        } else if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+        } else if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
           outputs.insert(netName);
           addRequired(pin_, netName);
         }
@@ -184,7 +184,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
           if (instMap.find(connectedInstId) == instMap.end()) {
             // Net is connected to an instance outside the cut out region
             // Check whether it's input or output
-            if (iterm->getIoType() == odb::dbIoType::INPUT) {
+            if (iterm->getIoType() == odb::dbIoType::Value::INPUT) {
               // Net is connected to a pin outside the bubble and should be
               // treated as an input If the driving pin is contant then we'll
               // add a constant gate in blif otherwise just add the net as input
@@ -220,7 +220,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
                 addAsInput = true;
               }
 
-            } else if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
+            } else if (iterm->getIoType() == odb::dbIoType::Value::OUTPUT) {
               outputs.insert(netName);
               addRequired(pin_, netName);
             }
@@ -240,7 +240,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
           && const1.find(netName) == const1.end()) {
         auto connectedPorts = net->getBTerms();
         for (auto connectedPort : connectedPorts) {
-          if (connectedPort->getIoType() == odb::dbIoType::INPUT) {
+          if (connectedPort->getIoType() == odb::dbIoType::Value::INPUT) {
             auto pin_ = open_sta_->getDbNetwork()->dbToSta(connectedPort);
             auto network_ = open_sta_->network();
             auto port_ = network_->libertyPort(pin_);
@@ -265,7 +265,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
               inputs.insert(netName);
               addArrival(pin_, netName);
             }
-          } else if (connectedPort->getIoType() == odb::dbIoType::OUTPUT) {
+          } else if (connectedPort->getIoType() == odb::dbIoType::Value::OUTPUT) {
             outputs.insert(netName);
             addRequired(pin_, netName);
           }

--- a/src/rmp/src/blif.cpp
+++ b/src/rmp/src/blif.cpp
@@ -265,7 +265,8 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
               inputs.insert(netName);
               addArrival(pin_, netName);
             }
-          } else if (connectedPort->getIoType() == odb::dbIoType::Value::OUTPUT) {
+          } else if (connectedPort->getIoType()
+                     == odb::dbIoType::Value::OUTPUT) {
             outputs.insert(netName);
             addRequired(pin_, netName);
           }

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -589,7 +589,7 @@ bool find_smallest_isolation(utl::Logger* logger,
       enable_lib_port = lib_port;
     }
 
-    if (term->getIoType() == odb::dbIoType::OUTPUT) {
+    if (term->getIoType() == odb::dbIoType::Value::OUTPUT) {
       output_term = term;
       out_lib_port = lib_port;
     }
@@ -924,7 +924,7 @@ bool eval_upf(utl::Logger* logger, odb::dbBlock* block)
     for (auto&& inst : insts) {
       auto iterms = inst->getITerms();
       for (auto&& iterm : iterms) {
-        if (iterm->getIoType() != odb::dbIoType::OUTPUT) {
+        if (iterm->getIoType() != odb::dbIoType::Value::OUTPUT) {
           continue;
         }
 


### PR DESCRIPTION
Making dbSigType and dbIoType more type safe to prevent mixing up both classes.

I have been bitten by this in the past by mixing dbSigType and dbIoType.

If this is approved I will do the same for other types in odb/dbTypes.h