### PR TITLE
database: switch to ifstream, less code, more idiomatic C++

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -413,13 +413,12 @@ void OpenRoad::readDb(const char* filename)
         ORD, 47, "You can't load a new db file as the db is already populated");
   }
 
-  FILE* stream = fopen(filename, "r");
-  if (stream == nullptr) {
-    return;
-  }
+  std::ifstream stream;
+  stream.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                    | std::ios::eofbit);
+  stream.open(filename, std::ios::binary);
 
   db_->read(stream);
-  fclose(stream);
 
   for (OpenRoadObserver* observer : observers_) {
     observer->postReadDb(db_);
@@ -439,15 +438,15 @@ void OpenRoad::diffDbs(const char* filename1,
                        const char* filename2,
                        const char* diffs)
 {
-  FILE* stream1 = fopen(filename1, "r");
-  if (stream1 == nullptr) {
-    logger_->error(ORD, 103, "Can't open {}", filename1);
-  }
+  std::ifstream stream1;
+  stream1.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                     | std::ios::eofbit);
+  stream1.open(filename1, std::ios::binary);
 
-  FILE* stream2 = fopen(filename2, "r");
-  if (stream2 == nullptr) {
-    logger_->error(ORD, 104, "Can't open {}", filename1);
-  }
+  std::ifstream stream2;
+  stream2.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                     | std::ios::eofbit);
+  stream2.open(filename2, std::ios::binary);
 
   FILE* out = fopen(diffs, "w");
   if (out == nullptr) {
@@ -462,8 +461,6 @@ void OpenRoad::diffDbs(const char* filename1,
 
   odb::dbDatabase::diff(db1, db2, out, 2);
 
-  fclose(stream1);
-  fclose(stream2);
   fclose(out);
 }
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -354,7 +354,7 @@ class dbDatabase : public dbObject
   /// WARNING: This function destroys the data currently in the database.
   /// Throws ZIOError..
   ///
-  void read(FILE* file);
+  void read(std::ifstream& f);
 
   ///
   /// Write a database to this stream.
@@ -371,14 +371,14 @@ class dbDatabase : public dbObject
   void writeWires(FILE* file, dbBlock* block);
   void writeNets(FILE* file, dbBlock* block);
   void writeParasitics(FILE* file, dbBlock* block);
-  void readTech(FILE* file);
-  void readLib(FILE* file, dbLib*);
-  void readLibs(FILE* file);
-  void readBlock(FILE* file, dbBlock* block);
-  void readWires(FILE* file, dbBlock* block);
-  void readNets(FILE* file, dbBlock* block);
-  void readParasitics(FILE* file, dbBlock* block);
-  void readChip(FILE* file);
+  void readTech(std::ifstream& f);
+  void readLib(std::ifstream& f, dbLib*);
+  void readLibs(std::ifstream& f);
+  void readBlock(std::ifstream& f, dbBlock* block);
+  void readWires(std::ifstream& f, dbBlock* block);
+  void readNets(std::ifstream& f, dbBlock* block);
+  void readParasitics(std::ifstream& f, dbBlock* block);
+  void readChip(std::ifstream& f);
 
   ///
   /// ECO - The following methods implement a simple ECO mechanism for capturing

--- a/src/odb/include/odb/dbStream.h
+++ b/src/odb/include/odb/dbStream.h
@@ -35,6 +35,7 @@
 #include <string.h>
 
 #include <array>
+#include <fstream>
 #include <string>
 
 #include "ZException.h"
@@ -237,23 +238,13 @@ class dbOStream
 
 class dbIStream
 {
-  FILE* _f;
+  std::ifstream& _f;
   _dbDatabase* _db;
   double _lef_area_factor;
   double _lef_dist_factor;
 
-  void read_error()
-  {
-    if (feof(_f))
-      throw ZException(
-          "read failed on database stream (unexpected end-of-file encounted).");
-    else
-      throw ZException("read failed on database stream; system io error: (%s)",
-                       strerror(ferror(_f)));
-  }
-
  public:
-  dbIStream(_dbDatabase* db, FILE* f);
+  dbIStream(_dbDatabase* db, std::ifstream& f);
 
   _dbDatabase* getDatabase() { return _db; }
 
@@ -267,89 +258,67 @@ class dbIStream
 
   dbIStream& operator>>(char& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(unsigned char& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(short& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(unsigned short& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(int& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(uint64_t& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(unsigned int& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(int8_t& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(float& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(double& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
   dbIStream& operator>>(long double& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 
@@ -362,12 +331,7 @@ class dbIStream
       c = NULL;
     else {
       c = (char*) malloc(l);
-      if (!c) {
-        read_error();
-      }
-      int n = fread(c, l, 1, _f);
-      if (n != 1)
-        read_error();
+      _f.read(reinterpret_cast<char*>(c), l);
     }
 
     return *this;
@@ -375,9 +339,7 @@ class dbIStream
 
   dbIStream& operator>>(dbObjectType& c)
   {
-    int n = fread(&c, sizeof(c), 1, _f);
-    if (n != 1)
-      read_error();
+    _f.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;
   }
 

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -411,14 +411,14 @@ dbTech* dbDatabase::getTech()
   return (dbTech*) db->_tech_tbl->getPtr(db->_tech);
 }
 
-void dbDatabase::read(FILE* file)
+void dbDatabase::read(std::ifstream& file)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   dbIStream stream(db, file);
   stream >> *db;
 }
 
-void dbDatabase::readTech(FILE* file)
+void dbDatabase::readTech(std::ifstream& file)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   _dbTech* tech = (_dbTech*) getTech();
@@ -434,7 +434,7 @@ void dbDatabase::readTech(FILE* file)
   stream >> *tech;
 }
 
-void dbDatabase::readLib(FILE* file, dbLib* lib)
+void dbDatabase::readLib(std::ifstream& file, dbLib* lib)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   _dbLib* l = (_dbLib*) lib;
@@ -446,14 +446,14 @@ void dbDatabase::readLib(FILE* file, dbLib* lib)
   stream >> *l;
 }
 
-void dbDatabase::readLibs(FILE* file)
+void dbDatabase::readLibs(std::ifstream& file)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   dbIStream stream(db, file);
   stream >> *db->_lib_tbl;
 }
 
-void dbDatabase::readBlock(FILE* file, dbBlock* block)
+void dbDatabase::readBlock(std::ifstream& file, dbBlock* block)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   _dbBlock* b = (_dbBlock*) block;
@@ -463,7 +463,7 @@ void dbDatabase::readBlock(FILE* file, dbBlock* block)
   stream >> *b;
 }
 
-void dbDatabase::readNets(FILE* file, dbBlock* block)
+void dbDatabase::readNets(std::ifstream& file, dbBlock* block)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   dbIStream stream(db, file);
@@ -477,14 +477,14 @@ void dbDatabase::readNets(FILE* file, dbBlock* block)
   stream >> *((_dbBlock*) block)->_net_tbl;
 }
 
-void dbDatabase::readWires(FILE* file, dbBlock* block)
+void dbDatabase::readWires(std::ifstream& file, dbBlock* block)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   dbIStream stream(db, file);
   stream >> *((_dbBlock*) block)->_wire_tbl;
 }
 
-void dbDatabase::readParasitics(FILE* file, dbBlock* block)
+void dbDatabase::readParasitics(std::ifstream& file, dbBlock* block)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   dbIStream stream(db, file);
@@ -502,7 +502,7 @@ void dbDatabase::readParasitics(FILE* file, dbBlock* block)
       = ((_dbBlock*) block)->_num_ext_corners;
 }
 
-void dbDatabase::readChip(FILE* file)
+void dbDatabase::readChip(std::ifstream& file)
 {
   _dbDatabase* db = (_dbDatabase*) this;
   _dbChip* chip = (_dbChip*) getChip();
@@ -646,13 +646,10 @@ void dbDatabase::readEco(dbBlock* block_, const char* filename)
 {
   _dbBlock* block = (_dbBlock*) block_;
 
-  FILE* file = fopen(filename, "r");
-  if (!file) {
-    int errnum = errno;
-    block->getImpl()->getLogger()->error(
-        utl::ODB, 1, "Error opening file {}", strerror(errnum));
-    return;
-  }
+  std::ifstream file;
+  file.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                  | std::ios::eofbit);
+  file.open(filename, std::ios::binary);
 
   dbIStream stream(block->getDatabase(), file);
   dbJournal* eco = new dbJournal(block_);
@@ -663,8 +660,6 @@ void dbDatabase::readEco(dbBlock* block_, const char* filename)
     delete block->_journal_pending;
 
   block->_journal_pending = eco;
-
-  fclose(file);
 }
 
 void dbDatabase::writeEco(dbBlock* block_, const char* filename)

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -32,6 +32,8 @@
 
 #pragma once
 
+#include <iostream>
+
 #include "dbCore.h"
 #include "odb.h"
 

--- a/src/odb/src/db/dbStream.cpp
+++ b/src/odb/src/db/dbStream.cpp
@@ -101,10 +101,9 @@ dbOStream::dbOStream(_dbDatabase* db, FILE* f)
   }
 }
 
-dbIStream::dbIStream(_dbDatabase* db, FILE* f)
+dbIStream::dbIStream(_dbDatabase* db, std::ifstream& f) : _f(f)
 {
   _db = db;
-  _f = f;
 
   _lef_dist_factor = 0.001;
   _lef_area_factor = 0.000001;

--- a/src/odb/src/swig/common/swig_common.cpp
+++ b/src/odb/src/swig/common/swig_common.cpp
@@ -150,15 +150,14 @@ odb::dbDatabase* read_db(odb::dbDatabase* db, const char* db_path)
   if (db == NULL) {
     db = odb::dbDatabase::create();
   }
-  FILE* fp = fopen(db_path, "rb");
-  if (!fp) {
-    int errnum = errno;
-    fprintf(stderr, "Error opening file: %s\n", strerror(errnum));
-    fprintf(stderr, "Errno: %d\n", errno);
-    return NULL;
-  }
-  db->read(fp);
-  fclose(fp);
+
+  std::ifstream file;
+  file.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                  | std::ios::eofbit);
+  file.open(db_path, std::ios::binary);
+
+  db->read(file);
+
   return db;
 }
 

--- a/src/odb/test/cpp/TestAccessPoint.cpp
+++ b/src/odb/test/cpp/TestAccessPoint.cpp
@@ -1,5 +1,6 @@
 #define BOOST_TEST_MODULE TestAccessPoint
 #include <boost/test/included/unit_test.hpp>
+#include <fstream>
 
 #include "db.h"
 #include "helper.cpp"
@@ -27,7 +28,7 @@ BOOST_AUTO_TEST_CASE(test_default)
   ap->setHighType(dbAccessType::HalfGrid);
   ap->setAccess(true, dbDirection::DOWN);
   iterm->setAccessPoint(pin, ap);
-  FILE *write, *read;
+  FILE* write;
   std::string path
       = std::string(std::getenv("BASE_DIR")) + "/results/TestAccessPointDbRW";
   write = fopen(path.c_str(), "w");
@@ -35,7 +36,10 @@ BOOST_AUTO_TEST_CASE(test_default)
   dbDatabase::destroy(db);
 
   dbDatabase* db2 = dbDatabase::create();
-  read = fopen(path.c_str(), "r");
+  std::ifstream read;
+  read.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                  | std::ios::eofbit);
+  read.open(path.c_str(), std::ios::binary);
   db2->read(read);
   auto aps = db2->getChip()
                  ->getBlock()

--- a/src/odb/test/cpp/TestLef58Properties.cpp
+++ b/src/odb/test/cpp/TestLef58Properties.cpp
@@ -2,6 +2,7 @@
 #include <libgen.h>
 
 #include <boost/test/included/unit_test.hpp>
+#include <fstream>
 #include <iostream>
 
 #include "db.h"
@@ -53,12 +54,17 @@ BOOST_AUTO_TEST_CASE(test_default)
 
   lefParser.createTechAndLib(libname, path.c_str());
 
-  FILE *write, *read;
+  FILE* write;
   path = std::string(std::getenv("BASE_DIR"))
          + "/results/TestLef58PropertiesDbRW";
   write = fopen(path.c_str(), "w");
   db1->write(write);
-  read = fopen(path.c_str(), "r");
+
+  std::ifstream read;
+  read.exceptions(std::ifstream::failbit | std::ifstream::badbit
+                  | std::ios::eofbit);
+  read.open(path.c_str(), std::ios::binary);
+
   db2->read(read);
 
   auto dbTech = db2->getTech();


### PR DESCRIPTION
More idiomatic C++ means less manually written error handling and more reliance on exceptions.

This was inspired by seing fread() turning up and I think ifstream should be faster because as it is inlined and we're reading gigabytes.

I suspect, but don't have a way to measure precisely and accurately enough a 10% improvement: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1001#issuecomment-1517339354

10% might not seem like much, but if the performance problems in the GUI can be addressed, 10% grows to become a substantial part of the load time. Let's say the rest of the load is made 5x faster, then 20% today becomes 50% of the load time.