### PR TITLE
setup: remove possibly harmful advice

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -640,8 +640,6 @@ EOF
 To install or run openroad, update your path with:
     export PATH="\$(brew --prefix bison)/bin:\$(brew --prefix flex)/bin:\$(brew --prefix tcl-tk)/bin:\${PATH}"
     export CMAKE_PREFIX_PATH=\$(brew --prefix or-tools)
-
-You may wish to add these lines to your .bashrc file.
 EOF
         ;;
     "openSUSE Leap" )
@@ -677,13 +675,3 @@ EOF
         _help
         ;;
 esac
-
-if [[ ! -z "${PREFIX}" ]]; then
-            cat <<EOF
-To use cmake, set cmake as an alias:
-    alias cmake='${PREFIX}/bin/cmake'
-    or  run
-    echo export PATH=${PREFIX}/bin:\${PATH} >> ~/.bash_profile
-    source ~/.bash_profile
-EOF
-fi


### PR DESCRIPTION
if the user knows about the pros and cons
of using bashrc, then they don't need
the tip.

The documentation now encourages a harmless way to set up dependencies and environment that is not persisted across bash sessions/restart/logout, which means that a user can safely get back to "square one" by rebooting his computer.

Modifying the default cmake of the system can cause very subtle and hard to track down problems.