### PR TITLE
DependencyInstaller.sh Fixes

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -132,6 +132,15 @@ _installCommonDev() {
 
     cd "${lastDir}"
     rm -rf "${baseDir}"
+
+    if [[ ! -z ${PREFIX} ]]; then
+      # Emit an environment setup script
+      cat > ${PREFIX}/env.sh <<EOF
+depRoot="\$(dirname \$(readlink -f "\${BASH_SOURCE[0]}"))"
+PATH=\${depRoot}/bin:\${PATH}
+LD_LIBRARY_PATH=\${depRoot}/lib64:\${depRoot}/lib:\${LD_LIBRARY_PATH}
+EOF
+    fi
 }
 
 _installOrTools() {

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -56,6 +56,7 @@ _installCommonDev() {
         if [[ -z $(pcre2-config --version) ]]; then
           tarName="pcre2-${pcreVersion}.tar.gz"
           wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/${tarName}
+          md5sum -c <(echo "${pcreChecksum} ${tarName}") || exit 1
           ./Tools/pcre-build.sh
         fi
         ./autogen.sh

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -30,7 +30,8 @@ _installCommonDev() {
 
     # CMake
     cmakePrefix=${PREFIX:-"/usr/local"}
-    if [[ -z $(${cmakePrefix}/bin/cmake --version | grep ${cmakeVersionBig}) ]]; then
+    cmakeBin=${cmakePrefix}/bin/cmake
+    if [[ ! -f ${cmakeBin} || -z $(${cmakeBin} --version | grep ${cmakeVersionBig}) ]]; then
         cd "${baseDir}"
         wget https://cmake.org/files/v${cmakeVersionBig}/cmake-${cmakeVersionSmall}-${osName}-x86_64.sh
         md5sum -c <(echo "${cmakeChecksum}  cmake-${cmakeVersionSmall}-${osName}-x86_64.sh") || exit 1
@@ -41,8 +42,9 @@ _installCommonDev() {
     fi
 
     # SWIG
-    swigPrefix=${PREFIX:-"/usr"}
-    if [[ -z $(${swigPrefix}/bin/swig -version | grep ${swigVersion}) ]]; then
+    swigPrefix=${PREFIX:-"/usr/local"}
+    swigBin=${swigPrefix}/bin/swig
+    if [[ ! -f ${swigBin} || -z $(${swigBin} -version | grep ${swigVersion}) ]]; then
         cd "${baseDir}"
         tarName="v${swigVersion}.tar.gz"
         wget https://github.com/swig/swig/archive/${tarName}

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -34,7 +34,7 @@ _installCommonDev() {
     if [[ ! -f ${cmakeBin} || -z $(${cmakeBin} --version | grep ${cmakeVersionBig}) ]]; then
         cd "${baseDir}"
         wget https://cmake.org/files/v${cmakeVersionBig}/cmake-${cmakeVersionSmall}-${osName}-x86_64.sh
-        md5sum -c <(echo "${cmakeChecksum}  cmake-${cmakeVersionSmall}-${osName}-x86_64.sh") || exit 1
+        md5sum -c <(echo "${cmakeChecksum} cmake-${cmakeVersionSmall}-${osName}-x86_64.sh") || exit 1
         chmod +x cmake-${cmakeVersionSmall}-${osName}-x86_64.sh
         ./cmake-${cmakeVersionSmall}-${osName}-x86_64.sh --skip-license --prefix=${cmakePrefix}
     else
@@ -48,7 +48,7 @@ _installCommonDev() {
         cd "${baseDir}"
         tarName="v${swigVersion}.tar.gz"
         wget https://github.com/swig/swig/archive/${tarName}
-        md5sum -c <(echo "${swigChecksum}  ${tarName}") || exit 1
+        md5sum -c <(echo "${swigChecksum} ${tarName}") || exit 1
         tar xfz ${tarName}
         cd swig-${tarName%%.tar*} || cd swig-${swigVersion}
 
@@ -591,7 +591,7 @@ case "${platform}" in
         ;;
     "Darwin" )
         if [[ $(id -u) == 0 ]]; then>&2
-            echo "ERROR: cannot install on macOS if you are root or using sudo  (not recommended for brew)." >&2
+            echo "ERROR: cannot install on macOS if you are root or using sudo (not recommended for brew)." >&2
             exit 1
         fi
         os="Darwin"

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -568,7 +568,7 @@ while [ "$#" -gt 0 ]; do
                 echo "WARNING: previous argument -local will be overwritten with -prefix"
                 export isLocal="false"
             fi
-            export PREFIX="$(echo $1 | sed -e 's/^[^=]*=//g')"
+            export PREFIX="$(realpath $(echo $1 | sed -e 's/^[^=]*=//g'))"
             ;;
         *)
             echo "unknown option: ${1}" >&2

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -285,8 +285,7 @@ _installRHELPackages() {
 
     yum install -y \
         http://repo.okay.com.mx/centos/8/x86_64/release/bison-3.0.4-10.el8.x86_64.rpm \
-        https://forensics.cert.org/centos/cert/7/x86_64/flex-2.6.1-9.el7.x86_64.rpm \
-        https://vault.centos.org/centos/8/BaseOS/x86_64/os/Packages/tcl-devel-8.6.8-2.el8.i686.rpm
+        https://forensics.cert.org/centos/cert/7/x86_64/flex-2.6.1-9.el7.x86_64.rpm
 
     if [[ $(yum repolist | egrep -c "rhel-8-for-x86_64-appstream-rpms") -eq 0 ]]; then
         yum -y install http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-6.el8.noarch.rpm
@@ -294,9 +293,10 @@ _installRHELPackages() {
     	rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
     fi
 
-    yum -y install  \
+    yum -y install \
         qt5-qtbase-devel \
-        qt5-qtimageformats
+        qt5-qtimageformats \
+        tcl-devel
         
 }
 

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -9,6 +9,8 @@ _installCommonDev() {
     cmakeChecksum="b8d86f8c5ee990ae03c486c3631cee05"
     cmakeVersionBig=3.24
     cmakeVersionSmall=${cmakeVersionBig}.2
+    pcreVersion=10.42
+    pcreChecksum="37d2f77cfd411a3ddf1c64e1d72e43f7"
     swigVersion=4.1.0
     swigChecksum="794433378154eb61270a3ac127d9c5f3"
     boostVersionBig=1.80
@@ -47,6 +49,13 @@ _installCommonDev() {
         md5sum -c <(echo "${swigChecksum}  ${tarName}") || exit 1
         tar xfz ${tarName}
         cd swig-${tarName%%.tar*} || cd swig-${swigVersion}
+
+        # Check if pcre2 is installed
+        if [[ -z $(pcre2-config --version | grep ${pcreVersion}) ]]; then
+          tarName="pcre2-${pcreVersion}.tar.gz"
+          wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/${tarName}
+          ./Tools/pcre-build.sh
+        fi
         ./autogen.sh
         ./configure --prefix=${swigPrefix}
         make -j $(nproc)

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -53,7 +53,7 @@ _installCommonDev() {
         cd swig-${tarName%%.tar*} || cd swig-${swigVersion}
 
         # Check if pcre2 is installed
-        if [[ -z $(pcre2-config --version | grep ${pcreVersion}) ]]; then
+        if [[ -z $(pcre2-config --version) ]]; then
           tarName="pcre2-${pcreVersion}.tar.gz"
           wget https://github.com/PCRE2Project/pcre2/releases/download/pcre2-${pcreVersion}/${tarName}
           ./Tools/pcre-build.sh


### PR DESCRIPTION
Some small fixes and cleanups of the dependency installer script

* Check for and install pcre2 as a swig dependency (not all systems may have a suitable version)
* Eliminate some spurious warnings about "file not found" when grepping files that don't exist
* Formatting
* If installing to a non-default location, emit a sourceable script to set up the environment
* Convert relative paths to absolute when passing to installers