### PR TITLE
gui: scale heatmap with gui scaling

### DIFF
--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -218,7 +218,9 @@ void Graphics::drawNesterov(gui::Painter& painter)
     float efMax = 0;
     int max_len = std::numeric_limits<int>::max();
     for (Bin& bin : nb_->bins()) {
-      efMax = std::max(efMax, hypot(bin.electroForceX(), bin.electroForceY()));
+      efMax = std::max(
+          efMax,
+          static_cast<float>(hypot(bin.electroForceX(), bin.electroForceY())));
       max_len = std::min({max_len, bin.dx(), bin.dy()});
     }
 

--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -215,7 +215,7 @@ void Graphics::drawNesterov(gui::Painter& painter)
 
   // Draw force direction lines
   if (draw_bins_) {
-    float efMax = 0;
+    double efMax = 0;
     int max_len = std::numeric_limits<int>::max();
     for (Bin& bin : nb_->bins()) {
       efMax = std::max(efMax, hypot(bin.electroForceX(), bin.electroForceY()));

--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -34,6 +34,7 @@
 #include "graphics.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <limits>
 
@@ -218,9 +219,8 @@ void Graphics::drawNesterov(gui::Painter& painter)
     float efMax = 0;
     int max_len = std::numeric_limits<int>::max();
     for (Bin& bin : nb_->bins()) {
-      efMax = std::max(
-          efMax,
-          static_cast<float>(hypot(bin.electroForceX(), bin.electroForceY())));
+      efMax = std::max(efMax,
+                       std::hypot(bin.electroForceX(), bin.electroForceY()));
       max_len = std::min({max_len, bin.dx(), bin.dy()});
     }
 

--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -215,7 +215,7 @@ void Graphics::drawNesterov(gui::Painter& painter)
 
   // Draw force direction lines
   if (draw_bins_) {
-    double efMax = 0;
+    float efMax = 0;
     int max_len = std::numeric_limits<int>::max();
     for (Bin& bin : nb_->bins()) {
       efMax = std::max(efMax, hypot(bin.electroForceX(), bin.electroForceY()));

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -273,16 +273,20 @@ void RoutingCongestionDataSource::correctMapScale(HeatMapDataSource::Map& map)
   }
 
   max_ = 0.0;
-  for (auto& [bbox, map_pt] : map) {
-    max_ = std::max(map_pt->value, max_);
+  for (const auto& map_col : map) {
+    for (const auto& map_pt : map_col) {
+      max_ = std::max(map_pt->value, max_);
+    }
   }
 
   if (max_ == 0.0) {
     return;
   }
 
-  for (auto& [bbox, map_pt] : map) {
-    map_pt->value = map_pt->value * 100 / max_;
+  for (const auto& map_col : map) {
+    for (const auto& map_pt : map_col) {
+      map_pt->value = map_pt->value * 100 / max_;
+    }
   }
 }
 

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -159,6 +159,7 @@ class HeatMapDataSource
   virtual double getGridSizeMaximumValue() const { return 100.0; }
   // The default implementation uses the block's bounds
   virtual odb::Rect getBounds() const;
+  odb::dbBlock* getBlock() const { return block_; }
 
   // map controls
   void update() { destroyMap(); }
@@ -191,8 +192,6 @@ class HeatMapDataSource
       const std::function<std::vector<std::string>(void)>& choices,
       const std::function<std::string(void)>& getter,
       const std::function<void(std::string)>& setter);
-
-  odb::dbBlock* getBlock() const { return block_; }
 
   void setupMap();
   void clearMap();

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -33,9 +33,7 @@
 #pragma once
 
 #include <array>
-#include <boost/geometry.hpp>
-#include <boost/geometry/geometries/point_xy.hpp>
-#include <boost/geometry/index/rtree.hpp>
+#include <boost/multi_array.hpp>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -57,9 +55,6 @@ class Logger;
 namespace gui {
 class HeatMapRenderer;
 class HeatMapSetup;
-
-namespace bg = boost::geometry;
-namespace bgi = boost::geometry::index;
 
 class HeatMapDataSource
 {
@@ -87,11 +82,9 @@ class HeatMapDataSource
     double value;
     Painter::Color color;
   };
-  using Point = bg::model::d2::point_xy<int, bg::cs::cartesian>;
-  using Box = bg::model::box<Point>;
-  using Map = bgi::rtree<std::pair<Box, std::shared_ptr<MapColor>>,
-                         bgi::quadratic<16>>;
 
+  using Map = boost::multi_array<std::shared_ptr<MapColor>, 2>;
+  using MapView = Map::array_view<2>::type;
   using MapSetting = std::variant<MapSettingBoolean, MapSettingMultiChoice>;
 
   HeatMapDataSource(utl::Logger* logger,
@@ -172,6 +165,7 @@ class HeatMapDataSource
   void ensureMap();
   void destroyMap();
   const Map& getMap() const { return map_; }
+  const MapView getMapView(const odb::Rect& bounds);
   bool isPopulated() const { return populated_; }
 
   const std::vector<std::pair<int, double>> getLegendValues() const;
@@ -201,6 +195,7 @@ class HeatMapDataSource
   odb::dbBlock* getBlock() const { return block_; }
 
   void setupMap();
+  void clearMap();
   virtual bool populateMap() = 0;
   void addToMap(const odb::Rect& region, double value);
   virtual void combineMapData(bool base_has_value,

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -198,10 +198,10 @@ void PDNSim::analyze_power_grid()
                   irsolve_h->getWorstCaseVoltage());
   logger_->report(
       "Average IR drop  : {:3.2e} V",
-      abs(irsolve_h->getSupplyVoltageSrc() - irsolve_h->getAvgVoltage()));
-  logger_->report(
-      "Worstcase IR drop: {:3.2e} V",
-      abs(irsolve_h->getSupplyVoltageSrc() - irsolve_h->getWorstCaseVoltage()));
+      std::abs(irsolve_h->getSupplyVoltageSrc() - irsolve_h->getAvgVoltage()));
+  logger_->report("Worstcase IR drop: {:3.2e} V",
+                  std::abs(irsolve_h->getSupplyVoltageSrc()
+                           - irsolve_h->getWorstCaseVoltage()));
   logger_->report("######################################");
   if (enable_em_) {
     logger_->report("########## EM analysis ###############");
@@ -226,7 +226,7 @@ void PDNSim::analyze_power_grid()
     // Absolute is needed for GND nets. In case of GND net voltage is higher
     // than supply.
     ir_drop[node_layer][point]
-        = abs(irsolve_h->getSupplyVoltageSrc() - voltage);
+        = std::abs(irsolve_h->getSupplyVoltageSrc() - voltage);
   }
   ir_drop_ = ir_drop;
   min_resolution_ = irsolve_h->getMinimumResolution();


### PR DESCRIPTION
This is an attempt to speed up handling of heatmaps in the gui.
1. change the underlying data type from an rtree to a 2d array.
2. only draw the portion of the heatmap that is currently visible
3. when zoomed out merges multiple bins together to avoid drawing boxes that are less an than a pixel.
