### PR TITLE
Fix finding the clocks of the cells after scan replace and rollback

### DIFF
--- a/src/dft/src/replace/ScanReplace.cpp
+++ b/src/dft/src/replace/ScanReplace.cpp
@@ -331,6 +331,7 @@ void ScanReplace::scanReplace()
 {
   odb::dbChip* chip = db_->getChip();
   scanReplace(chip->getBlock());
+  sta_->networkChanged();
 }
 
 // Recursive function that iterates over a block (and the blocks inside this
@@ -424,6 +425,7 @@ void ScanReplace::rollbackScanReplace()
 {
   odb::dbChip* chip = db_->getChip();
   rollbackScanReplace(chip->getBlock());
+  sta_->networkChanged();
 }
 
 void ScanReplace::rollbackScanReplace(odb::dbBlock* block)


### PR DESCRIPTION
I found this bug while implementing scan stitching. The unit tests for this part will in the PR for scan stitching