### PR TITLE
Add select all buffer trees #3290

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -569,7 +569,7 @@ class Gui
                                     bool output,
                                     bool input,
                                     int highlight_group = 0);
-
+  void selectHighlightConnectedBufferTrees(bool select_flag, int highlight_group = 0);
   void addInstToHighlightSet(const char* name, int highlight_group = 0);
   void addNetToHighlightSet(const char* name, int highlight_group = 0);
 

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -569,7 +569,8 @@ class Gui
                                     bool output,
                                     bool input,
                                     int highlight_group = 0);
-  void selectHighlightConnectedBufferTrees(bool select_flag, int highlight_group = 0);
+  void selectHighlightConnectedBufferTrees(bool select_flag,
+                                           int highlight_group = 0);
   void addInstToHighlightSet(const char* name, int highlight_group = 0);
   void addNetToHighlightSet(const char* name, int highlight_group = 0);
 

--- a/src/gui/src/bufferTreeDescriptor.h
+++ b/src/gui/src/bufferTreeDescriptor.h
@@ -51,11 +51,11 @@ namespace gui {
 class BufferTree
 {
  public:
-  BufferTree(odb::dbNet* net);
+  BufferTree(odb::dbNet* net, bool timingSource = true);
 
   static void setSTA(sta::dbSta* sta) { sta_ = sta; }
-  static bool isAggregate(odb::dbNet* net);
-  static bool isAggregate(odb::dbInst* inst);
+  static bool isAggregate(odb::dbNet* net, bool timingSource = true);
+  static bool isAggregate(odb::dbInst* inst, bool timingSource = true);
 
   const std::string& getName() const { return name_; }
   const std::vector<odb::dbNet*>& getNets() const { return nets_; }
@@ -73,7 +73,7 @@ class BufferTree
 
   static sta::dbSta* sta_;
 
-  void populate(odb::dbNet* net);
+  void populate(odb::dbNet* net, bool timingSource = true);
 };
 
 class BufferTreeDescriptor : public Descriptor

--- a/src/gui/src/bufferTreeDescriptor.h
+++ b/src/gui/src/bufferTreeDescriptor.h
@@ -51,11 +51,11 @@ namespace gui {
 class BufferTree
 {
  public:
-  BufferTree(odb::dbNet* net, bool timingSource = true);
+  explicit BufferTree(odb::dbNet* net);
 
   static void setSTA(sta::dbSta* sta) { sta_ = sta; }
-  static bool isAggregate(odb::dbNet* net, bool timingSource = true);
-  static bool isAggregate(odb::dbInst* inst, bool timingSource = true);
+  static bool isAggregate(odb::dbNet* net);
+  static bool isAggregate(odb::dbInst* inst);
 
   const std::string& getName() const { return name_; }
   const std::vector<odb::dbNet*>& getNets() const { return nets_; }
@@ -73,7 +73,7 @@ class BufferTree
 
   static sta::dbSta* sta_;
 
-  void populate(odb::dbNet* net, bool timingSource = true);
+  void populate(odb::dbNet* net);
 };
 
 class BufferTreeDescriptor : public Descriptor

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -353,6 +353,13 @@ void Gui::selectHighlightConnectedNets(bool select_flag,
       select_flag, output, input, highlight_group);
 }
 
+void Gui::selectHighlightConnectedBufferTrees(bool select_flag,
+                                              int highlight_group)
+{
+  return main_window->selectHighlightConnectedBufferTrees(select_flag,
+                                                          highlight_group);
+}
+
 void Gui::addInstToHighlightSet(const char* name, int highlight_group)
 {
   auto block = getBlock(main_window->getDb());

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -3263,6 +3263,17 @@ void LayoutViewer::selectHighlightConnectedNets(bool select_flag,
       select_flag, output, input, highlight_group);
 }
 
+void LayoutViewer::selectHighlightConnectedBufferTrees(bool select_flag)
+{
+  int highlight_group = 0;
+  if (!select_flag) {
+    HighlightGroupDialog dlg;
+    dlg.exec();
+    highlight_group = dlg.getSelectedHighlightGroup();
+  }
+  Gui::get()->selectHighlightConnectedBufferTrees(select_flag, highlight_group);
+}
+
 void LayoutViewer::updateContextMenuItems()
 {
   if (Gui::get()->anyObjectInSet(true /*selection set*/, odb::dbInstObj)
@@ -3271,18 +3282,22 @@ void LayoutViewer::updateContextMenuItems()
     menu_actions_[SELECT_OUTPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[SELECT_INPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[SELECT_ALL_NETS_ACT]->setDisabled(true);
+    menu_actions_[SELECT_ALL_BUFFER_TREES_ACT]->setDisabled(true);
 
     menu_actions_[HIGHLIGHT_OUTPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[HIGHLIGHT_INPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[HIGHLIGHT_ALL_NETS_ACT]->setDisabled(true);
+    menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]->setDisabled(true);
   } else {
     menu_actions_[SELECT_OUTPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[SELECT_INPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[SELECT_ALL_NETS_ACT]->setDisabled(false);
+    menu_actions_[SELECT_ALL_BUFFER_TREES_ACT]->setDisabled(false);
 
     menu_actions_[HIGHLIGHT_OUTPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[HIGHLIGHT_INPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[HIGHLIGHT_ALL_NETS_ACT]->setDisabled(false);
+    menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]->setDisabled(false);
   }
 
   if (Gui::get()->anyObjectInSet(true, odb::dbNetObj)
@@ -3416,6 +3431,8 @@ void LayoutViewer::addMenuAndActions()
   menu_actions_[SELECT_INPUT_NETS_ACT]
       = select_menu->addAction(tr("Input Nets"));
   menu_actions_[SELECT_ALL_NETS_ACT] = select_menu->addAction(tr("All Nets"));
+  menu_actions_[SELECT_ALL_BUFFER_TREES_ACT]
+      = select_menu->addAction(tr("All buffer trees"));
 
   // Highlight Actions
   menu_actions_[HIGHLIGHT_CONNECTED_INST_ACT]
@@ -3426,6 +3443,8 @@ void LayoutViewer::addMenuAndActions()
       = highlight_menu->addAction(tr("Input Nets"));
   menu_actions_[HIGHLIGHT_ALL_NETS_ACT]
       = highlight_menu->addAction(tr("All Nets"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]
+      = highlight_menu->addAction(tr("All buffer trees"));
 
   // View Actions
   menu_actions_[VIEW_ZOOMIN_ACT] = view_menu->addAction(tr("Zoom In"));
@@ -3464,6 +3483,10 @@ void LayoutViewer::addMenuAndActions()
       menu_actions_[SELECT_ALL_NETS_ACT], &QAction::triggered, this, [this]() {
         selectHighlightConnectedNets(true, true, true);
       });
+  connect(menu_actions_[SELECT_ALL_BUFFER_TREES_ACT],
+          &QAction::triggered,
+          this,
+          [this]() { selectHighlightConnectedBufferTrees(true); });
 
   connect(menu_actions_[HIGHLIGHT_CONNECTED_INST_ACT],
           &QAction::triggered,
@@ -3481,6 +3504,10 @@ void LayoutViewer::addMenuAndActions()
           &QAction::triggered,
           this,
           [this]() { selectHighlightConnectedNets(false, true, true); });
+  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT],
+          &QAction::triggered,
+          this,
+          [this]() { selectHighlightConnectedBufferTrees(false); });
 
   connect(menu_actions_[VIEW_ZOOMIN_ACT], &QAction::triggered, this, [this]() {
     zoomIn();

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -3263,14 +3263,9 @@ void LayoutViewer::selectHighlightConnectedNets(bool select_flag,
       select_flag, output, input, highlight_group);
 }
 
-void LayoutViewer::selectHighlightConnectedBufferTrees(bool select_flag)
+void LayoutViewer::selectHighlightConnectedBufferTrees(bool select_flag,
+                                                       int highlight_group)
 {
-  int highlight_group = 0;
-  if (!select_flag) {
-    HighlightGroupDialog dlg;
-    dlg.exec();
-    highlight_group = dlg.getSelectedHighlightGroup();
-  }
   Gui::get()->selectHighlightConnectedBufferTrees(select_flag, highlight_group);
 }
 
@@ -3287,7 +3282,7 @@ void LayoutViewer::updateContextMenuItems()
     menu_actions_[HIGHLIGHT_OUTPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[HIGHLIGHT_INPUT_NETS_ACT]->setDisabled(true);
     menu_actions_[HIGHLIGHT_ALL_NETS_ACT]->setDisabled(true);
-    menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]->setDisabled(true);
+    highlight_color_menu->setDisabled(true);
   } else {
     menu_actions_[SELECT_OUTPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[SELECT_INPUT_NETS_ACT]->setDisabled(false);
@@ -3297,7 +3292,7 @@ void LayoutViewer::updateContextMenuItems()
     menu_actions_[HIGHLIGHT_OUTPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[HIGHLIGHT_INPUT_NETS_ACT]->setDisabled(false);
     menu_actions_[HIGHLIGHT_ALL_NETS_ACT]->setDisabled(false);
-    menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]->setDisabled(false);
+    highlight_color_menu->setDisabled(false);
   }
 
   if (Gui::get()->anyObjectInSet(true, odb::dbNetObj)
@@ -3443,8 +3438,29 @@ void LayoutViewer::addMenuAndActions()
       = highlight_menu->addAction(tr("Input Nets"));
   menu_actions_[HIGHLIGHT_ALL_NETS_ACT]
       = highlight_menu->addAction(tr("All Nets"));
-  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT]
-      = highlight_menu->addAction(tr("All buffer trees"));
+
+  highlight_color_menu = highlight_menu->addMenu(tr("All buffer trees"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_0]
+      = highlight_color_menu->addAction(tr("green"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_1]
+      = highlight_color_menu->addAction(tr("yellow"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_2]
+      = highlight_color_menu->addAction(tr("cyan"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_3]
+      = highlight_color_menu->addAction(tr("magenta"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_4]
+      = highlight_color_menu->addAction(tr("red"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_5]
+      = highlight_color_menu->addAction(tr("dark_green"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_6]
+      = highlight_color_menu->addAction(tr("dark_magenta"));
+  menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_7]
+      = highlight_color_menu->addAction(tr("blue"));
+
+  // for { highlightColor : Painter::highlightColors[highlight_group]} {
+  //   menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_7]
+  //       = highlight_color_menu->addAction(tr("blue"));
+  // }
 
   // View Actions
   menu_actions_[VIEW_ZOOMIN_ACT] = view_menu->addAction(tr("Zoom In"));
@@ -3504,10 +3520,22 @@ void LayoutViewer::addMenuAndActions()
           &QAction::triggered,
           this,
           [this]() { selectHighlightConnectedNets(false, true, true); });
-  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT],
+  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_0],
           &QAction::triggered,
           this,
-          [this]() { selectHighlightConnectedBufferTrees(false); });
+          [this]() { selectHighlightConnectedBufferTrees(false, 0); });
+  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_1],
+          &QAction::triggered,
+          this,
+          [this]() { selectHighlightConnectedBufferTrees(false, 1); });
+  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_2],
+          &QAction::triggered,
+          this,
+          [this]() { selectHighlightConnectedBufferTrees(false, 2); });
+  connect(menu_actions_[HIGHLIGHT_ALL_BUFFER_TREES_ACT_3],
+          &QAction::triggered,
+          this,
+          [this]() { selectHighlightConnectedBufferTrees(false, 3); });
 
   connect(menu_actions_[VIEW_ZOOMIN_ACT], &QAction::triggered, this, [this]() {
     zoomIn();

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -89,11 +89,13 @@ class LayoutViewer : public QWidget
     SELECT_OUTPUT_NETS_ACT,
     SELECT_INPUT_NETS_ACT,
     SELECT_ALL_NETS_ACT,
+    SELECT_ALL_BUFFER_TREES_ACT,
 
     HIGHLIGHT_CONNECTED_INST_ACT,
     HIGHLIGHT_OUTPUT_NETS_ACT,
     HIGHLIGHT_INPUT_NETS_ACT,
     HIGHLIGHT_ALL_NETS_ACT,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT,
 
     VIEW_ZOOMIN_ACT,
     VIEW_ZOOMOUT_ACT,
@@ -235,6 +237,7 @@ class LayoutViewer : public QWidget
 
   void selectHighlightConnectedInst(bool select_flag);
   void selectHighlightConnectedNets(bool select_flag, bool output, bool input);
+  void selectHighlightConnectedBufferTrees(bool selectFlag);
 
   void updateContextMenuItems();
   void showLayoutCustomMenu(QPoint pos);

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -95,7 +95,14 @@ class LayoutViewer : public QWidget
     HIGHLIGHT_OUTPUT_NETS_ACT,
     HIGHLIGHT_INPUT_NETS_ACT,
     HIGHLIGHT_ALL_NETS_ACT,
-    HIGHLIGHT_ALL_BUFFER_TREES_ACT,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_0,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_1,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_2,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_3,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_4,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_5,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_6,
+    HIGHLIGHT_ALL_BUFFER_TREES_ACT_7,
 
     VIEW_ZOOMIN_ACT,
     VIEW_ZOOMOUT_ACT,
@@ -237,7 +244,8 @@ class LayoutViewer : public QWidget
 
   void selectHighlightConnectedInst(bool select_flag);
   void selectHighlightConnectedNets(bool select_flag, bool output, bool input);
-  void selectHighlightConnectedBufferTrees(bool selectFlag);
+  void selectHighlightConnectedBufferTrees(bool select_flag,
+                                           int highlight_group = 0);
 
   void updateContextMenuItems();
   void showLayoutCustomMenu(QPoint pos);
@@ -440,6 +448,7 @@ class LayoutViewer : public QWidget
   utl::Logger* logger_;
 
   QMenu* layout_context_menu_;
+  QMenu* highlight_color_menu;
   QMap<CONTEXT_MENU_ACTIONS, QAction*> menu_actions_;
 
   // shift required when drawing the layout to center the layout in the window

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1244,6 +1244,45 @@ void MainWindow::selectHighlightConnectedNets(bool select_flag,
   }
 }
 
+void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
+                                                     int highlight_group)
+{
+  SelectionSet connected_objects;
+  for (auto& sel_obj : selected_) {
+    if (sel_obj.isInst()) {
+      auto inst_obj = std::any_cast<odb::dbInst*>(sel_obj.getObject());
+      for (auto inst_term : inst_obj->getITerms()) {
+        auto inst_term_dir = inst_term->getIoType();
+        if (!inst_term->getSigType().isSupply()
+            && (inst_term_dir == odb::dbIoType::OUTPUT
+                || inst_term_dir == odb::dbIoType::INOUT)) {
+          auto net_obj = inst_term->getNet();
+          gui::BufferTree buffer_tree_obj = gui::BufferTree(net_obj, false);
+
+          for (auto Bterm : buffer_tree_obj.getBTerms()) {
+            connected_objects.insert(Gui::get()->makeSelected(Bterm));
+          }
+
+          for (auto net : buffer_tree_obj.getNets()) {
+            connected_objects.insert(Gui::get()->makeSelected(net));
+          }
+
+          for (auto inst : buffer_tree_obj.getInsts()) {
+            connected_objects.insert(Gui::get()->makeSelected(inst));
+          }
+        }
+      }
+    }
+  }
+
+  if (connected_objects.empty())
+    return;
+  if (select_flag)
+    addSelected(connected_objects);
+  else
+    addHighlighted(connected_objects, highlight_group);
+}
+
 void MainWindow::saveSettings()
 {
   QSettings settings("OpenRoad Project", "openroad");

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1257,7 +1257,7 @@ void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
             && (inst_term_dir == odb::dbIoType::OUTPUT
                 || inst_term_dir == odb::dbIoType::INOUT)) {
           auto net_obj = inst_term->getNet();
-          gui::BufferTree buffer_tree_obj = gui::BufferTree(net_obj, false);
+          gui::BufferTree buffer_tree_obj = gui::BufferTree(net_obj);
 
           for (auto Bterm : buffer_tree_obj.getBTerms()) {
             connected_objects.insert(Gui::get()->makeSelected(Bterm));
@@ -1275,12 +1275,14 @@ void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
     }
   }
 
-  if (connected_objects.empty())
+  if (connected_objects.empty()) {
     return;
-  if (select_flag)
+  }
+  if (select_flag) {
     addSelected(connected_objects);
-  else
+  } else {
     addHighlighted(connected_objects, highlight_group);
+  }
 }
 
 void MainWindow::saveSettings()

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1259,7 +1259,7 @@ void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
                 || inst_term_dir == odb::dbIoType::INOUT)) {
           auto net_obj = inst_term->getNet();
           if (net_obj == nullptr
-            || net_obj->getSigType() != odb::dbSigType::SIGNAL) {
+              || net_obj->getSigType() != odb::dbSigType::SIGNAL) {
             continue;
           }
           connected_objects.insert(

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1257,19 +1257,11 @@ void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
             && (inst_term_dir == odb::dbIoType::OUTPUT
                 || inst_term_dir == odb::dbIoType::INOUT)) {
           auto net_obj = inst_term->getNet();
-          gui::BufferTree buffer_tree_obj = gui::BufferTree(net_obj);
-
-          for (auto Bterm : buffer_tree_obj.getBTerms()) {
-            connected_objects.insert(Gui::get()->makeSelected(Bterm));
+          if (!net_obj) {
+            continue;
           }
-
-          for (auto net : buffer_tree_obj.getNets()) {
-            connected_objects.insert(Gui::get()->makeSelected(net));
-          }
-
-          for (auto inst : buffer_tree_obj.getInsts()) {
-            connected_objects.insert(Gui::get()->makeSelected(inst));
-          }
+          connected_objects.insert(
+              Gui::get()->makeSelected(gui::BufferTree(net_obj)));
         }
       }
     }

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1254,10 +1254,12 @@ void MainWindow::selectHighlightConnectedBufferTrees(bool select_flag,
       for (auto inst_term : inst_obj->getITerms()) {
         auto inst_term_dir = inst_term->getIoType();
         if (!inst_term->getSigType().isSupply()
-            && (inst_term_dir == odb::dbIoType::OUTPUT
+            && (inst_term_dir == odb::dbIoType::INPUT
+                || inst_term_dir == odb::dbIoType::OUTPUT
                 || inst_term_dir == odb::dbIoType::INOUT)) {
           auto net_obj = inst_term->getNet();
-          if (!net_obj) {
+          if (net_obj == nullptr
+            || net_obj->getSigType() != odb::dbSigType::SIGNAL) {
             continue;
           }
           connected_objects.insert(

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -231,6 +231,8 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
                                     bool output,
                                     bool input,
                                     int highlight_group = 0);
+  void selectHighlightConnectedBufferTrees(bool select_flag,
+                                           int highlight_group = 0);
 
   void timingCone(Gui::odbTerm term, bool fanin, bool fanout);
   void timingPathsThrough(const std::set<Gui::odbTerm>& terms);


### PR DESCRIPTION
Hi,
I added the option to select/highlight all buffer trees in the gui menu.

I didn't find very great case to test is, so I manually added to gcd test multiple buffer and connect them to random FF ( if you got better test case please let me know), the result looks like that:
![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/61157132/6a639ac3-8096-4138-ba3c-60ee5ee369d1)


Few notes:

- To get all the buffers I used the existing class of BufferTrees. In that class there is condition that only if the timing source of the inst is equal to TIMING it consider buffer, I'm not fully understood that condition so for now I added another option to work around it and create bufferTree even if the timing source don't defined.
-  When selected all buffer tree all the inst/nets/Bterms in of the buffer trees are selected, I can change it easily I just wasn't sure  if that was the original propose.
-  Right now it supporting only when select inst, I can add other object if you think it is needed too.

