### PR TITLE
layoutviewer: add more gui timers

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1787,6 +1787,7 @@ void LayoutViewer::drawRows(QPainter* painter, const Rect& bounds)
     return;
   }
 
+  painter->setBrush(Qt::NoBrush);
   for (const auto& [row, row_site] : getRowRects(bounds)) {
     odb::dbSite* site = nullptr;
     if (row->getObjectType() == odb::dbObjectType::dbSiteObj) {
@@ -1798,7 +1799,6 @@ void LayoutViewer::drawRows(QPainter* painter, const Rect& bounds)
       QPen pen(options_->siteColor(site));
       pen.setCosmetic(true);
       painter->setPen(pen);
-      painter->setBrush(Qt::NoBrush);
       painter->drawRect(
           row_site.xMin(), row_site.yMin(), row_site.dx(), row_site.dy());
     }

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2488,31 +2488,46 @@ void LayoutViewer::drawBlock(QPainter* painter, const Rect& bounds, int depth)
                layer->getName(),
                layer_timer);
   }
-  utl::Timer inst_various;
-  // draw instance names
-  drawInstanceNames(painter, insts);
 
+  utl::Timer inst_names;
+  drawInstanceNames(painter, insts);
+  debugPrint(logger_, GUI, "draw", 1, "instance names {}", inst_names);
+
+  utl::Timer inst_rows;
   drawRows(painter, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "rows {}", inst_rows);
+
+  utl::Timer inst_access_points;
   if (options_->areAccessPointsVisible()) {
     drawAccessPoints(gui_painter, insts);
   }
+  debugPrint(logger_, GUI, "draw", 1, "access points {}", inst_access_points);
 
+  utl::Timer inst_module_view;
   drawModuleView(painter, insts);
+  debugPrint(logger_, GUI, "draw", 1, "module view {}", inst_module_view);
 
+  utl::Timer inst_regions;
   drawRegions(painter);
+  debugPrint(logger_, GUI, "draw", 1, "regions {}", inst_regions);
 
+  utl::Timer inst_pin_markers;
   if (options_->arePinMarkersVisible()) {
     drawPinMarkers(gui_painter, bounds);
   }
+  debugPrint(logger_, GUI, "draw", 1, "pin markers {}", inst_pin_markers);
 
+  utl::Timer inst_cell_grid;
   drawGCellGrid(painter, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "save cell grid {}", inst_cell_grid);
 
+  utl::Timer inst_save_restore;
   for (auto* renderer : renderers) {
     gui_painter.saveState();
     renderer->drawObjects(gui_painter);
     gui_painter.restoreState();
   }
-  debugPrint(logger_, GUI, "draw", 1, "various {}", inst_various);
+  debugPrint(logger_, GUI, "draw", 1, "save restore {}", inst_save_restore);
 
   debugPrint(logger_, GUI, "draw", 1, "total render {}", timer);
 }

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1796,11 +1796,12 @@ void LayoutViewer::drawRows(QPainter* painter, const Rect& bounds)
       site = static_cast<odb::dbRow*>(row)->getSite();
     }
     if (options_->isSiteVisible(site)) {
-      QPen pen(options_->siteColor(site));
-      pen.setCosmetic(true);
-      painter->setPen(pen);
-      painter->drawRect(
-          row_site.xMin(), row_site.yMin(), row_site.dx(), row_site.dy());
+      // Disable everything but rendering
+      // QPen pen(options_->siteColor(site));
+      // pen.setCosmetic(true);
+      // painter->setPen(pen);
+      // painter->drawRect(
+      //     row_site.xMin(), row_site.yMin(), row_site.dx(), row_site.dy());
     }
   }
 }


### PR DESCRIPTION
The discrepancy is quite small locally, I suspect that the logging statements take some time, so they would have to be moved out to reduce the discrepancy between total and actual rendering time.

Hmm.... to reduce the discrepancy, we could include the logging statements in the rendering time. Or... we could sum up the logging time and print it out as a separate line so that the total should include logging time.