### PR TITLE
openroad: add more GUI timers

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -2042,7 +2042,6 @@ void LayoutViewer::drawRulers(Painter& painter)
 void LayoutViewer::drawInstanceOutlines(QPainter* painter,
                                         const std::vector<odb::dbInst*>& insts)
 {
-  utl::Timer timer;
   int minimum_height_for_tag = nominalViewableResolution();
   int minimum_size = fineViewableResolution();
   const QTransform initial_xfm = painter->transform();
@@ -2089,7 +2088,6 @@ void LayoutViewer::drawInstanceOutlines(QPainter* painter,
     }
   }
   painter->setTransform(initial_xfm);
-  debugPrint(logger_, GUI, "draw", 1, "inst outline render {}", timer);
 }
 
 // Draw the instances' shapes
@@ -2511,6 +2509,7 @@ void LayoutViewer::drawBlock(QPainter* painter,
 {
   utl::Timer timer;
 
+  utl::Timer manufacturing_grid_timer;
   const int instance_limit = instanceSizeLimit();
 
   LayerBoxes boxes;
@@ -2527,6 +2526,12 @@ void LayoutViewer::drawBlock(QPainter* painter,
   }
 
   drawManufacturingGrid(painter, bounds);
+  debugPrint(logger_,
+             GUI,
+             "draw",
+             1,
+             "manufacturing grid {}",
+             manufacturing_grid_timer);
 
   utl::Timer inst_timer;
   auto inst_range = search_.searchInsts(block,
@@ -2547,38 +2552,59 @@ void LayoutViewer::drawBlock(QPainter* painter,
   }
   debugPrint(logger_, GUI, "draw", 1, "inst search {}", inst_timer);
 
+  utl::Timer insts_outline;
   drawInstanceOutlines(painter, insts);
+  debugPrint(logger_, GUI, "draw", 1, "inst outline render {}", insts_outline);
 
   // draw blockages
+  utl::Timer inst_blockages;
   drawBlockages(painter, block, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "blockages {}", inst_blockages);
 
   dbTech* tech = block->getDataBase()->getTech();
   for (dbTechLayer* layer : tech->getLayers()) {
     drawLayer(painter, block, layer, insts, bounds, gui_painter);
   }
-  // draw instance names
-  drawInstanceNames(painter, insts);
 
+  utl::Timer inst_names;
+  drawInstanceNames(painter, insts);
+  debugPrint(logger_, GUI, "draw", 1, "instance names {}", inst_names);
+
+  utl::Timer inst_rows;
   drawRows(painter, block, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "rows {}", inst_rows);
+
+  utl::Timer inst_access_points;
   if (options_->areAccessPointsVisible()) {
     drawAccessPoints(gui_painter, insts);
   }
+  debugPrint(logger_, GUI, "draw", 1, "access points {}", inst_access_points);
 
+  utl::Timer inst_module_view;
   drawModuleView(painter, insts);
+  debugPrint(logger_, GUI, "draw", 1, "module view {}", inst_module_view);
 
+  utl::Timer inst_regions;
   drawRegions(painter, block);
+  debugPrint(logger_, GUI, "draw", 1, "regions {}", inst_regions);
 
+  utl::Timer inst_pin_markers;
   if (options_->arePinMarkersVisible()) {
     drawPinMarkers(gui_painter, block, bounds);
   }
+  debugPrint(logger_, GUI, "draw", 1, "pin markers {}", inst_pin_markers);
 
+  utl::Timer inst_cell_grid;
   drawGCellGrid(painter, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "save cell grid {}", inst_cell_grid);
 
+  utl::Timer inst_save_restore;
   for (auto* renderer : Gui::get()->renderers()) {
     gui_painter.saveState();
     renderer->drawObjects(gui_painter);
     gui_painter.restoreState();
   }
+  debugPrint(logger_, GUI, "draw", 1, "renderers {}", inst_save_restore);
 
   debugPrint(logger_, GUI, "draw", 1, "total render {}", timer);
 }


### PR DESCRIPTION
With this change, all rendering time is pretty much accounted for, previously there could be significant discrepancies between what was logged and the total rendering time.

<!DOCTYPE html>

<html>
<head>
	
	
	
</head>

<body>


[DEBUG | GUI-draw] | manufacturing | grid |   | 2.62222E-04 | sec
-- | -- | -- | -- | -- | -- | --
[DEBUG | GUI-draw] | inst | search |   | 4.86770E-01 | sec
[DEBUG | GUI-draw] | inst | outline | render | 1.13920E+00 | sec
[DEBUG | GUI-draw] | blockages |   |   | 9.15498E-04 | sec
[DEBUG | GUI-draw] | layer | V0 | render | 9.15700E-06 | sec
[DEBUG | GUI-draw] | layer | M1 | render | 2.43998E-01 | sec
[DEBUG | GUI-draw] | layer | V1 | render | 6.62100E-06 | sec
[DEBUG | GUI-draw] | layer | M2 | render | 3.04803E-01 | sec
[DEBUG | GUI-draw] | layer | V2 | render | 7.07200E-06 | sec
[DEBUG | GUI-draw] | layer | M3 | render | 2.07964E-01 | sec
[DEBUG | GUI-draw] | layer | V3 | render | 6.77800E-06 | sec
[DEBUG | GUI-draw] | layer | M4 | render | 1.61031E-01 | sec
[DEBUG | GUI-draw] | layer | V4 | render | 6.84600E-06 | sec
[DEBUG | GUI-draw] | layer | M5 | render | 1.41925E-01 | sec
[DEBUG | GUI-draw] | layer | V5 | render | 4.94600E-06 | sec
[DEBUG | GUI-draw] | layer | M6 | render | 1.36262E-01 | sec
[DEBUG | GUI-draw] | layer | V6 | render | 5.25500E-06 | sec
[DEBUG | GUI-draw] | layer | M7 | render | 1.28346E-01 | sec
[DEBUG | GUI-draw] | layer | V7 | render | 4.66900E-06 | sec
[DEBUG | GUI-draw] | layer | M8 | render | 1.28116E-01 | sec
[DEBUG | GUI-draw] | layer | V8 | render | 5.02000E-06 | sec
[DEBUG | GUI-draw] | layer | M9 | render | 1.28121E-01 | sec
[DEBUG | GUI-draw] | layer | V9 | render | 4.80500E-06 | sec
[DEBUG | GUI-draw] | layer | Pad | render | 1.28144E-01 | sec
[DEBUG | GUI-draw] | instance | names |   | 1.25108E-01 | sec
[DEBUG | GUI-draw] | rows |   |   | 1.93254E-01 | sec
[DEBUG | GUI-draw] | access | points |   | 1.93248E-01 | sec
[DEBUG | GUI-draw] | module | view |   | 9.38482E-02 | sec
[DEBUG | GUI-draw] | regions |   |   | 4.55800E-06 | sec
[DEBUG | GUI-draw] | pin | markers |   | 3.72047E-03 | sec
[DEBUG | GUI-draw] | save | cell | grid | 5.39687E-02 | sec
[DEBUG | GUI-draw] | save | restore |   | 1.53866E-04 | sec
  |   | Measured total |   |   | 3.99922E+00 |  
  |   |   |   |   |   |  
[DEBUG | GUI-draw] | total | render |   | 4.00425E+00 | sec


</body>

</html>

