### PR TITLE
gitignore: ignore Scala .metals/ folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ debug/
 
 coverage-output
 messages.txt
+.metals/


### PR DESCRIPTION
used by e.g. Chisel