### PR TITLE
gui: Enable coalescing of mouse scroll events

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1129,6 +1129,9 @@ int startGui(int& argc,
   font.setPointSize(12);
   QApplication::setFont(font);
 
+  // Enable coalescing of high-frequency events
+  QCoreApplication::setAttribute(Qt::AA_CompressHighFrequencyEvents);
+
   auto* open_road = ord::OpenRoad::openRoad();
 
   // create new MainWindow

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -725,9 +725,9 @@ void LayoutViewer::zoomIn()
   zoomIn(getVisibleCenter(), false);
 }
 
-void LayoutViewer::zoomIn(const odb::Point& focus, bool do_delta_focus)
+void LayoutViewer::zoomIn(const odb::Point& focus, int angleDelta, bool do_delta_focus)
 {
-  zoom(focus, 1 * zoom_scale_factor_, do_delta_focus);
+  zoom(focus, (angleDelta / 120.0) * zoom_scale_factor_, do_delta_focus);
 }
 
 void LayoutViewer::zoomOut()
@@ -735,9 +735,9 @@ void LayoutViewer::zoomOut()
   zoomOut(getVisibleCenter(), false);
 }
 
-void LayoutViewer::zoomOut(const odb::Point& focus, bool do_delta_focus)
+void LayoutViewer::zoomOut(const odb::Point& focus, int angleDelta, bool do_delta_focus)
 {
-  zoom(focus, 1 / zoom_scale_factor_, do_delta_focus);
+  zoom(focus, (angleDelta / 120.0) / zoom_scale_factor_, do_delta_focus);
 }
 
 void LayoutViewer::zoom(const odb::Point& focus,
@@ -3793,10 +3793,11 @@ void LayoutScroll::wheelEvent(QWheelEvent* event)
 
   const odb::Point mouse_pos
       = viewer_->screenToDBU(viewer_->mapFromGlobal(QCursor::pos()));
-  if (event->angleDelta().y() > 0) {
-    viewer_->zoomIn(mouse_pos, true);
+  auto angleDeltaY = event->angleDelta().y();
+  if (angleDeltaY > 0) {
+    viewer_->zoomIn(mouse_pos, angleDeltaY, true);
   } else {
-    viewer_->zoomOut(mouse_pos, true);
+    viewer_->zoomOut(mouse_pos, -angleDeltaY, true);
   }
   // ensure changes are processed before the next wheel event to prevent
   // zoomIn and Out from jumping around on the ScrollBars

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -725,7 +725,9 @@ void LayoutViewer::zoomIn()
   zoomIn(getVisibleCenter(), false);
 }
 
-void LayoutViewer::zoomIn(const odb::Point& focus, int angleDelta, bool do_delta_focus)
+void LayoutViewer::zoomIn(const odb::Point& focus,
+                          int angleDelta,
+                          bool do_delta_focus)
 {
   zoom(focus, (angleDelta / 120.0) * zoom_scale_factor_, do_delta_focus);
 }
@@ -735,7 +737,9 @@ void LayoutViewer::zoomOut()
   zoomOut(getVisibleCenter(), false);
 }
 
-void LayoutViewer::zoomOut(const odb::Point& focus, int angleDelta, bool do_delta_focus)
+void LayoutViewer::zoomOut(const odb::Point& focus,
+                           int angleDelta,
+                           bool do_delta_focus)
 {
   zoom(focus, (angleDelta / 120.0) / zoom_scale_factor_, do_delta_focus);
 }

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -199,7 +199,9 @@ class LayoutViewer : public QWidget
   // do_delta_focus indicates (if true) that the center of the layout should
   // zoom in around the focus instead of making it the new center. This is used
   // when scrolling with the mouse to keep the mouse point steady in the layout
-  void zoomIn(const odb::Point& focus, int angleDelta = 120, bool do_delta_focus = false);
+  void zoomIn(const odb::Point& focus,
+              int angleDelta = 120,
+              bool do_delta_focus = false);
 
   // zoom out the layout, keeping the current center_
   void zoomOut();
@@ -208,7 +210,9 @@ class LayoutViewer : public QWidget
   // do_delta_focus indicates (if true) that the center of the layout should
   // zoom in around the focus instead of making it the new center. This is used
   // when scrolling with the mouse to keep the mouse point steady in the layout
-  void zoomOut(const odb::Point& focus, int angleDelta = 120, bool do_delta_focus = false);
+  void zoomOut(const odb::Point& focus,
+               int angleDelta = 120,
+               bool do_delta_focus = false);
 
   // zoom to the specified rect
   void zoomTo(const odb::Rect& rect_dbu);

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -199,7 +199,7 @@ class LayoutViewer : public QWidget
   // do_delta_focus indicates (if true) that the center of the layout should
   // zoom in around the focus instead of making it the new center. This is used
   // when scrolling with the mouse to keep the mouse point steady in the layout
-  void zoomIn(const odb::Point& focus, bool do_delta_focus = false);
+  void zoomIn(const odb::Point& focus, int angleDelta = 120, bool do_delta_focus = false);
 
   // zoom out the layout, keeping the current center_
   void zoomOut();
@@ -208,7 +208,7 @@ class LayoutViewer : public QWidget
   // do_delta_focus indicates (if true) that the center of the layout should
   // zoom in around the focus instead of making it the new center. This is used
   // when scrolling with the mouse to keep the mouse point steady in the layout
-  void zoomOut(const odb::Point& focus, bool do_delta_focus = false);
+  void zoomOut(const odb::Point& focus, int angleDelta = 120, bool do_delta_focus = false);
 
   // zoom to the specified rect
   void zoomTo(const odb::Rect& rect_dbu);


### PR DESCRIPTION
Attempt to enable coalescing of mouse scroll events when the render time is very long. This should hopefully stop the event queue from backing up.