### PR TITLE
gpl: improve error message upon too big die area

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1002,8 +1002,8 @@ void PlacerBase::initInstsForUnusableSites()
 {
   dbSet<dbRow> rows = db_->getChip()->getBlock()->getRows();
 
-  int siteCountX = (die_.coreUx() - die_.coreLx()) / siteSizeX_;
-  int siteCountY = (die_.coreUy() - die_.coreLy()) / siteSizeY_;
+  int64 siteCountX = (die_.coreUx() - die_.coreLx()) / siteSizeX_;
+  int64 siteCountY = (die_.coreUy() - die_.coreLy()) / siteSizeY_;
 
   enum PlaceInfo
   {

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1002,8 +1002,8 @@ void PlacerBase::initInstsForUnusableSites()
 {
   dbSet<dbRow> rows = db_->getChip()->getBlock()->getRows();
 
-  int64 siteCountX = (die_.coreUx() - die_.coreLx()) / siteSizeX_;
-  int64 siteCountY = (die_.coreUy() - die_.coreLy()) / siteSizeY_;
+  int64_t siteCountX = (die_.coreUx() - die_.coreLx()) / siteSizeX_;
+  int64_t siteCountY = (die_.coreUy() - die_.coreLy()) / siteSizeY_;
 
   enum PlaceInfo
   {


### PR DESCRIPTION
if the die area is too big, an out of error message is printed, rather than a std::vector() max_size() message.

out of memory is a hair better than the more internal error message from std::vector().