### PR TITLE
ppl: place groups in fallback mode in the middle of the constraint region

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -384,7 +384,7 @@ int IOPlacer::placeFallbackPins(bool random)
             logger_->error(PPL,
                            93,
                            "Pin group of size {} does not fit in the "
-                           "constrained region {}-{} at {} edge. "
+                           "constrained region {:.2f}-{:.2f} at {} edge. "
                            "First pin of the group is {}.",
                            group.first.size(),
                            dbuToMicrons(interval.getBegin()),

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -362,8 +362,36 @@ int IOPlacer::placeFallbackPins(bool random)
                 group.first.size());
           }
 
+          int mid_slot = (last_slot - first_slot) / 2 - group.first.size() / 2
+                         + first_slot;
+
+          // try to place fallback group in the middle of the edge
           int place_slot = getFirstSlotToPlaceGroup(
-              first_slot, last_slot, group.first.size(), have_mirrored, io_pin);
+              mid_slot, last_slot, group.first.size(), have_mirrored, io_pin);
+
+          // if the previous fails, try to place the fallback group from the
+          // beginning of the edge
+          if (place_slot == -1) {
+            place_slot = getFirstSlotToPlaceGroup(first_slot,
+                                                  last_slot,
+                                                  group.first.size(),
+                                                  have_mirrored,
+                                                  io_pin);
+          }
+
+          if (place_slot == -1) {
+            Interval& interval = constraint.interval;
+            logger_->error(PPL,
+                           93,
+                           "Pin group of size {} does not fit in the "
+                           "constrained region {}-{} at {} edge. "
+                           "First pin of the group is {}.",
+                           group.first.size(),
+                           dbuToMicrons(interval.getBegin()),
+                           dbuToMicrons(interval.getEnd()),
+                           getEdgeString(interval.getEdge()),
+                           io_pin.getName());
+          }
 
           placeFallbackGroup(group, place_slot);
           break;
@@ -488,14 +516,13 @@ int IOPlacer::getFirstSlotToPlaceGroup(int first_slot,
   }
 
   if (max_contiguous_slots < group_size) {
-    logger_->error(PPL,
-                   93,
-                   "Pin group of size {} does not fit in the die boundaries. "
-                   "First pin of the group is {}."
-                   "The max contiguous slots is {}.",
-                   group_size,
-                   first_pin.getName(),
-                   max_contiguous_slots);
+    logger_->warn(
+        PPL,
+        97,
+        "The max contiguous slots ({}) is smaller than the group size ({}).",
+        max_contiguous_slots,
+        group_size);
+    return -1;
   }
 
   return place_slot;
@@ -1066,6 +1093,7 @@ int IOPlacer::assignGroupToSection(const std::vector<int>& io_group,
                     group_size);
     }
     if (!group_assigned) {
+      addGroupToFallback(io_group, order);
       logger_->warn(PPL, 42, "Unsuccessfully assigned I/O groups.");
     }
   }
@@ -1800,6 +1828,7 @@ void IOPlacer::run(bool random_mode)
         mirrored_pins_cnt = 0;
       }
     }
+    constrained_pins_cnt += placeFallbackPins(false);
 
     setupSections(constrained_pins_cnt);
     findPinAssignment(sections_, false);

--- a/src/ppl/test/large_groups3.ok
+++ b/src/ppl/test/large_groups3.ok
@@ -17,5 +17,5 @@ Found 0 macro blocks.
 [WARNING PPL-0042] Unsuccessfully assigned I/O groups.
 [WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
 [WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
-[ERROR PPL-0093] Pin group of size 71 does not fit in the constrained region 0-100.13 at TOP edge. First pin of the group is pin300.
+[ERROR PPL-0093] Pin group of size 71 does not fit in the constrained region 0.00-100.13 at TOP edge. First pin of the group is pin300.
 PPL-0093

--- a/src/ppl/test/large_groups4.defok
+++ b/src/ppl/test/large_groups4.defok
@@ -31,1215 +31,1215 @@ PINS 400 ;
     - pin0 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 56810 201530 ) N ;
+        + PLACED ( 43510 201530 ) N ;
     - pin1 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 57190 201530 ) N ;
+        + PLACED ( 43890 201530 ) N ;
     - pin10 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 60610 201530 ) N ;
+        + PLACED ( 47310 201530 ) N ;
     - pin100 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 94810 201530 ) N ;
+        + PLACED ( 81510 201530 ) N ;
     - pin101 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 95190 201530 ) N ;
+        + PLACED ( 81890 201530 ) N ;
     - pin102 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 95570 201530 ) N ;
+        + PLACED ( 82270 201530 ) N ;
     - pin103 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 95950 201530 ) N ;
+        + PLACED ( 82650 201530 ) N ;
     - pin104 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 96330 201530 ) N ;
+        + PLACED ( 83030 201530 ) N ;
     - pin105 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 96710 201530 ) N ;
+        + PLACED ( 83410 201530 ) N ;
     - pin106 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 97090 201530 ) N ;
+        + PLACED ( 83790 201530 ) N ;
     - pin107 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 97470 201530 ) N ;
+        + PLACED ( 84170 201530 ) N ;
     - pin108 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 97850 201530 ) N ;
+        + PLACED ( 84550 201530 ) N ;
     - pin109 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 98230 201530 ) N ;
+        + PLACED ( 84930 201530 ) N ;
     - pin11 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 60990 201530 ) N ;
+        + PLACED ( 47690 201530 ) N ;
     - pin110 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 98610 201530 ) N ;
+        + PLACED ( 85310 201530 ) N ;
     - pin111 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 98990 201530 ) N ;
+        + PLACED ( 85690 201530 ) N ;
     - pin112 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 99370 201530 ) N ;
+        + PLACED ( 86070 201530 ) N ;
     - pin113 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 99750 201530 ) N ;
+        + PLACED ( 86450 201530 ) N ;
     - pin114 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 100130 201530 ) N ;
+        + PLACED ( 86830 201530 ) N ;
     - pin115 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 100510 201530 ) N ;
+        + PLACED ( 87210 201530 ) N ;
     - pin116 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 100890 201530 ) N ;
+        + PLACED ( 87590 201530 ) N ;
     - pin117 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 101270 201530 ) N ;
+        + PLACED ( 87970 201530 ) N ;
     - pin118 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 101650 201530 ) N ;
+        + PLACED ( 88350 201530 ) N ;
     - pin119 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 102030 201530 ) N ;
+        + PLACED ( 88730 201530 ) N ;
     - pin12 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 61370 201530 ) N ;
+        + PLACED ( 48070 201530 ) N ;
     - pin120 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 102410 201530 ) N ;
+        + PLACED ( 89110 201530 ) N ;
     - pin121 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 102790 201530 ) N ;
+        + PLACED ( 89490 201530 ) N ;
     - pin122 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 103170 201530 ) N ;
+        + PLACED ( 89870 201530 ) N ;
     - pin123 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 103550 201530 ) N ;
+        + PLACED ( 90250 201530 ) N ;
     - pin124 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 103930 201530 ) N ;
+        + PLACED ( 90630 201530 ) N ;
     - pin125 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 104310 201530 ) N ;
+        + PLACED ( 91010 201530 ) N ;
     - pin126 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 104690 201530 ) N ;
+        + PLACED ( 91390 201530 ) N ;
     - pin127 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 105070 201530 ) N ;
+        + PLACED ( 91770 201530 ) N ;
     - pin128 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 105450 201530 ) N ;
+        + PLACED ( 92150 201530 ) N ;
     - pin129 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 105830 201530 ) N ;
+        + PLACED ( 92530 201530 ) N ;
     - pin13 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 61750 201530 ) N ;
+        + PLACED ( 48450 201530 ) N ;
     - pin130 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 106210 201530 ) N ;
+        + PLACED ( 92910 201530 ) N ;
     - pin131 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 106590 201530 ) N ;
+        + PLACED ( 93290 201530 ) N ;
     - pin132 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 106970 201530 ) N ;
+        + PLACED ( 93670 201530 ) N ;
     - pin133 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 107350 201530 ) N ;
+        + PLACED ( 94050 201530 ) N ;
     - pin134 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 107730 201530 ) N ;
+        + PLACED ( 94430 201530 ) N ;
     - pin135 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 108110 201530 ) N ;
+        + PLACED ( 94810 201530 ) N ;
     - pin136 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 108490 201530 ) N ;
+        + PLACED ( 95190 201530 ) N ;
     - pin137 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 108870 201530 ) N ;
+        + PLACED ( 95570 201530 ) N ;
     - pin138 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 109250 201530 ) N ;
+        + PLACED ( 95950 201530 ) N ;
     - pin139 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 109630 201530 ) N ;
+        + PLACED ( 96330 201530 ) N ;
     - pin14 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 62130 201530 ) N ;
+        + PLACED ( 48830 201530 ) N ;
     - pin140 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 110010 201530 ) N ;
+        + PLACED ( 96710 201530 ) N ;
     - pin141 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 110390 201530 ) N ;
+        + PLACED ( 97090 201530 ) N ;
     - pin142 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 110770 201530 ) N ;
+        + PLACED ( 97470 201530 ) N ;
     - pin143 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 111150 201530 ) N ;
+        + PLACED ( 97850 201530 ) N ;
     - pin144 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 111530 201530 ) N ;
+        + PLACED ( 98230 201530 ) N ;
     - pin145 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 111910 201530 ) N ;
+        + PLACED ( 98610 201530 ) N ;
     - pin146 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 112290 201530 ) N ;
+        + PLACED ( 98990 201530 ) N ;
     - pin147 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 112670 201530 ) N ;
+        + PLACED ( 99370 201530 ) N ;
     - pin148 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 113050 201530 ) N ;
+        + PLACED ( 99750 201530 ) N ;
     - pin149 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 113430 201530 ) N ;
+        + PLACED ( 100130 201530 ) N ;
     - pin15 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 62510 201530 ) N ;
+        + PLACED ( 49210 201530 ) N ;
     - pin150 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 113810 201530 ) N ;
+        + PLACED ( 100510 201530 ) N ;
     - pin151 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 114190 201530 ) N ;
+        + PLACED ( 100890 201530 ) N ;
     - pin152 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 114570 201530 ) N ;
+        + PLACED ( 101270 201530 ) N ;
     - pin153 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 114950 201530 ) N ;
+        + PLACED ( 101650 201530 ) N ;
     - pin154 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 115330 201530 ) N ;
+        + PLACED ( 102030 201530 ) N ;
     - pin155 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 115710 201530 ) N ;
+        + PLACED ( 102410 201530 ) N ;
     - pin156 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 116090 201530 ) N ;
+        + PLACED ( 102790 201530 ) N ;
     - pin157 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 116470 201530 ) N ;
+        + PLACED ( 103170 201530 ) N ;
     - pin158 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 116850 201530 ) N ;
+        + PLACED ( 103550 201530 ) N ;
     - pin159 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 117230 201530 ) N ;
+        + PLACED ( 103930 201530 ) N ;
     - pin16 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 62890 201530 ) N ;
+        + PLACED ( 49590 201530 ) N ;
     - pin160 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 117610 201530 ) N ;
+        + PLACED ( 104310 201530 ) N ;
     - pin161 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 117990 201530 ) N ;
+        + PLACED ( 104690 201530 ) N ;
     - pin162 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 118370 201530 ) N ;
+        + PLACED ( 105070 201530 ) N ;
     - pin163 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 118750 201530 ) N ;
+        + PLACED ( 105450 201530 ) N ;
     - pin164 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 119130 201530 ) N ;
+        + PLACED ( 105830 201530 ) N ;
     - pin165 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 119510 201530 ) N ;
+        + PLACED ( 106210 201530 ) N ;
     - pin166 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 119890 201530 ) N ;
+        + PLACED ( 106590 201530 ) N ;
     - pin167 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 120270 201530 ) N ;
+        + PLACED ( 106970 201530 ) N ;
     - pin168 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 120650 201530 ) N ;
+        + PLACED ( 107350 201530 ) N ;
     - pin169 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 121030 201530 ) N ;
+        + PLACED ( 107730 201530 ) N ;
     - pin17 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 63270 201530 ) N ;
+        + PLACED ( 49970 201530 ) N ;
     - pin170 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 121410 201530 ) N ;
+        + PLACED ( 108110 201530 ) N ;
     - pin171 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 121790 201530 ) N ;
+        + PLACED ( 108490 201530 ) N ;
     - pin172 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 122170 201530 ) N ;
+        + PLACED ( 108870 201530 ) N ;
     - pin173 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 122550 201530 ) N ;
+        + PLACED ( 109250 201530 ) N ;
     - pin174 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 122930 201530 ) N ;
+        + PLACED ( 109630 201530 ) N ;
     - pin175 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 123310 201530 ) N ;
+        + PLACED ( 110010 201530 ) N ;
     - pin176 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 123690 201530 ) N ;
+        + PLACED ( 110390 201530 ) N ;
     - pin177 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 124070 201530 ) N ;
+        + PLACED ( 110770 201530 ) N ;
     - pin178 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 124450 201530 ) N ;
+        + PLACED ( 111150 201530 ) N ;
     - pin179 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 124830 201530 ) N ;
+        + PLACED ( 111530 201530 ) N ;
     - pin18 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 63650 201530 ) N ;
+        + PLACED ( 50350 201530 ) N ;
     - pin180 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 125210 201530 ) N ;
+        + PLACED ( 111910 201530 ) N ;
     - pin181 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 125590 201530 ) N ;
+        + PLACED ( 112290 201530 ) N ;
     - pin182 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 125970 201530 ) N ;
+        + PLACED ( 112670 201530 ) N ;
     - pin183 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 126350 201530 ) N ;
+        + PLACED ( 113050 201530 ) N ;
     - pin184 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 126730 201530 ) N ;
+        + PLACED ( 113430 201530 ) N ;
     - pin185 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 127110 201530 ) N ;
+        + PLACED ( 113810 201530 ) N ;
     - pin186 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 127490 201530 ) N ;
+        + PLACED ( 114190 201530 ) N ;
     - pin187 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 127870 201530 ) N ;
+        + PLACED ( 114570 201530 ) N ;
     - pin188 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 128250 201530 ) N ;
+        + PLACED ( 114950 201530 ) N ;
     - pin189 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 128630 201530 ) N ;
+        + PLACED ( 115330 201530 ) N ;
     - pin19 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 64030 201530 ) N ;
+        + PLACED ( 50730 201530 ) N ;
     - pin190 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 129010 201530 ) N ;
+        + PLACED ( 115710 201530 ) N ;
     - pin191 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 129390 201530 ) N ;
+        + PLACED ( 116090 201530 ) N ;
     - pin192 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 129770 201530 ) N ;
+        + PLACED ( 116470 201530 ) N ;
     - pin193 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 130150 201530 ) N ;
+        + PLACED ( 116850 201530 ) N ;
     - pin194 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 130530 201530 ) N ;
+        + PLACED ( 117230 201530 ) N ;
     - pin195 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 130910 201530 ) N ;
+        + PLACED ( 117610 201530 ) N ;
     - pin196 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 131290 201530 ) N ;
+        + PLACED ( 117990 201530 ) N ;
     - pin197 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 131670 201530 ) N ;
+        + PLACED ( 118370 201530 ) N ;
     - pin198 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 132050 201530 ) N ;
+        + PLACED ( 118750 201530 ) N ;
     - pin199 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 132430 201530 ) N ;
+        + PLACED ( 119130 201530 ) N ;
     - pin2 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 57570 201530 ) N ;
+        + PLACED ( 44270 201530 ) N ;
     - pin20 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 64410 201530 ) N ;
+        + PLACED ( 51110 201530 ) N ;
     - pin200 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 132810 201530 ) N ;
+        + PLACED ( 119510 201530 ) N ;
     - pin201 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 133190 201530 ) N ;
+        + PLACED ( 119890 201530 ) N ;
     - pin202 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 133570 201530 ) N ;
+        + PLACED ( 120270 201530 ) N ;
     - pin203 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 133950 201530 ) N ;
+        + PLACED ( 120650 201530 ) N ;
     - pin204 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 134330 201530 ) N ;
+        + PLACED ( 121030 201530 ) N ;
     - pin205 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 134710 201530 ) N ;
+        + PLACED ( 121410 201530 ) N ;
     - pin206 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 135090 201530 ) N ;
+        + PLACED ( 121790 201530 ) N ;
     - pin207 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 135470 201530 ) N ;
+        + PLACED ( 122170 201530 ) N ;
     - pin208 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 135850 201530 ) N ;
+        + PLACED ( 122550 201530 ) N ;
     - pin209 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 136230 201530 ) N ;
+        + PLACED ( 122930 201530 ) N ;
     - pin21 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 64790 201530 ) N ;
+        + PLACED ( 51490 201530 ) N ;
     - pin210 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 136610 201530 ) N ;
+        + PLACED ( 123310 201530 ) N ;
     - pin211 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 136990 201530 ) N ;
+        + PLACED ( 123690 201530 ) N ;
     - pin212 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 137370 201530 ) N ;
+        + PLACED ( 124070 201530 ) N ;
     - pin213 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 137750 201530 ) N ;
+        + PLACED ( 124450 201530 ) N ;
     - pin214 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 138130 201530 ) N ;
+        + PLACED ( 124830 201530 ) N ;
     - pin215 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 138510 201530 ) N ;
+        + PLACED ( 125210 201530 ) N ;
     - pin216 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 138890 201530 ) N ;
+        + PLACED ( 125590 201530 ) N ;
     - pin217 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 139270 201530 ) N ;
+        + PLACED ( 125970 201530 ) N ;
     - pin218 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 139650 201530 ) N ;
+        + PLACED ( 126350 201530 ) N ;
     - pin219 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 140030 201530 ) N ;
+        + PLACED ( 126730 201530 ) N ;
     - pin22 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 65170 201530 ) N ;
+        + PLACED ( 51870 201530 ) N ;
     - pin220 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 140410 201530 ) N ;
+        + PLACED ( 127110 201530 ) N ;
     - pin221 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 140790 201530 ) N ;
+        + PLACED ( 127490 201530 ) N ;
     - pin222 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 141170 201530 ) N ;
+        + PLACED ( 127870 201530 ) N ;
     - pin223 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 141550 201530 ) N ;
+        + PLACED ( 128250 201530 ) N ;
     - pin224 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 141930 201530 ) N ;
+        + PLACED ( 128630 201530 ) N ;
     - pin225 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 142310 201530 ) N ;
+        + PLACED ( 129010 201530 ) N ;
     - pin226 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 142690 201530 ) N ;
+        + PLACED ( 129390 201530 ) N ;
     - pin227 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 143070 201530 ) N ;
+        + PLACED ( 129770 201530 ) N ;
     - pin228 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 143450 201530 ) N ;
+        + PLACED ( 130150 201530 ) N ;
     - pin229 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 143830 201530 ) N ;
+        + PLACED ( 130530 201530 ) N ;
     - pin23 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 65550 201530 ) N ;
+        + PLACED ( 52250 201530 ) N ;
     - pin230 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 144210 201530 ) N ;
+        + PLACED ( 130910 201530 ) N ;
     - pin231 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 144590 201530 ) N ;
+        + PLACED ( 131290 201530 ) N ;
     - pin232 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 144970 201530 ) N ;
+        + PLACED ( 131670 201530 ) N ;
     - pin233 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 145350 201530 ) N ;
+        + PLACED ( 132050 201530 ) N ;
     - pin234 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 145730 201530 ) N ;
+        + PLACED ( 132430 201530 ) N ;
     - pin235 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 146110 201530 ) N ;
+        + PLACED ( 132810 201530 ) N ;
     - pin236 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 146490 201530 ) N ;
+        + PLACED ( 133190 201530 ) N ;
     - pin237 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 146870 201530 ) N ;
+        + PLACED ( 133570 201530 ) N ;
     - pin238 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 147250 201530 ) N ;
+        + PLACED ( 133950 201530 ) N ;
     - pin239 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 147630 201530 ) N ;
+        + PLACED ( 134330 201530 ) N ;
     - pin24 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 65930 201530 ) N ;
+        + PLACED ( 52630 201530 ) N ;
     - pin240 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 148010 201530 ) N ;
+        + PLACED ( 134710 201530 ) N ;
     - pin241 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 148390 201530 ) N ;
+        + PLACED ( 135090 201530 ) N ;
     - pin242 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 148770 201530 ) N ;
+        + PLACED ( 135470 201530 ) N ;
     - pin243 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 149150 201530 ) N ;
+        + PLACED ( 135850 201530 ) N ;
     - pin244 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 149530 201530 ) N ;
+        + PLACED ( 136230 201530 ) N ;
     - pin245 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 149910 201530 ) N ;
+        + PLACED ( 136610 201530 ) N ;
     - pin246 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 150290 201530 ) N ;
+        + PLACED ( 136990 201530 ) N ;
     - pin247 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 150670 201530 ) N ;
+        + PLACED ( 137370 201530 ) N ;
     - pin248 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 151050 201530 ) N ;
+        + PLACED ( 137750 201530 ) N ;
     - pin249 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 151430 201530 ) N ;
+        + PLACED ( 138130 201530 ) N ;
     - pin25 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 66310 201530 ) N ;
+        + PLACED ( 53010 201530 ) N ;
     - pin250 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 151810 201530 ) N ;
+        + PLACED ( 138510 201530 ) N ;
     - pin251 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 152190 201530 ) N ;
+        + PLACED ( 138890 201530 ) N ;
     - pin252 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 152570 201530 ) N ;
+        + PLACED ( 139270 201530 ) N ;
     - pin253 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 152950 201530 ) N ;
+        + PLACED ( 139650 201530 ) N ;
     - pin254 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 153330 201530 ) N ;
+        + PLACED ( 140030 201530 ) N ;
     - pin255 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 153710 201530 ) N ;
+        + PLACED ( 140410 201530 ) N ;
     - pin256 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 154090 201530 ) N ;
+        + PLACED ( 140790 201530 ) N ;
     - pin257 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 154470 201530 ) N ;
+        + PLACED ( 141170 201530 ) N ;
     - pin258 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 154850 201530 ) N ;
+        + PLACED ( 141550 201530 ) N ;
     - pin259 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 155230 201530 ) N ;
+        + PLACED ( 141930 201530 ) N ;
     - pin26 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 66690 201530 ) N ;
+        + PLACED ( 53390 201530 ) N ;
     - pin260 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 155610 201530 ) N ;
+        + PLACED ( 142310 201530 ) N ;
     - pin261 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 155990 201530 ) N ;
+        + PLACED ( 142690 201530 ) N ;
     - pin262 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 156370 201530 ) N ;
+        + PLACED ( 143070 201530 ) N ;
     - pin263 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 156750 201530 ) N ;
+        + PLACED ( 143450 201530 ) N ;
     - pin264 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 157130 201530 ) N ;
+        + PLACED ( 143830 201530 ) N ;
     - pin265 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 157510 201530 ) N ;
+        + PLACED ( 144210 201530 ) N ;
     - pin266 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 157890 201530 ) N ;
+        + PLACED ( 144590 201530 ) N ;
     - pin267 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 158270 201530 ) N ;
+        + PLACED ( 144970 201530 ) N ;
     - pin268 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 158650 201530 ) N ;
+        + PLACED ( 145350 201530 ) N ;
     - pin269 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 159030 201530 ) N ;
+        + PLACED ( 145730 201530 ) N ;
     - pin27 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 67070 201530 ) N ;
+        + PLACED ( 53770 201530 ) N ;
     - pin270 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 159410 201530 ) N ;
+        + PLACED ( 146110 201530 ) N ;
     - pin271 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 159790 201530 ) N ;
+        + PLACED ( 146490 201530 ) N ;
     - pin272 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 160170 201530 ) N ;
+        + PLACED ( 146870 201530 ) N ;
     - pin273 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 160550 201530 ) N ;
+        + PLACED ( 147250 201530 ) N ;
     - pin274 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 160930 201530 ) N ;
+        + PLACED ( 147630 201530 ) N ;
     - pin275 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 161310 201530 ) N ;
+        + PLACED ( 148010 201530 ) N ;
     - pin276 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 161690 201530 ) N ;
+        + PLACED ( 148390 201530 ) N ;
     - pin277 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 162070 201530 ) N ;
+        + PLACED ( 148770 201530 ) N ;
     - pin278 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 162450 201530 ) N ;
+        + PLACED ( 149150 201530 ) N ;
     - pin279 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 162830 201530 ) N ;
+        + PLACED ( 149530 201530 ) N ;
     - pin28 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 67450 201530 ) N ;
+        + PLACED ( 54150 201530 ) N ;
     - pin280 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 163210 201530 ) N ;
+        + PLACED ( 149910 201530 ) N ;
     - pin281 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 163590 201530 ) N ;
+        + PLACED ( 150290 201530 ) N ;
     - pin282 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 163970 201530 ) N ;
+        + PLACED ( 150670 201530 ) N ;
     - pin283 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 164350 201530 ) N ;
+        + PLACED ( 151050 201530 ) N ;
     - pin284 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 164730 201530 ) N ;
+        + PLACED ( 151430 201530 ) N ;
     - pin285 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 165110 201530 ) N ;
+        + PLACED ( 151810 201530 ) N ;
     - pin286 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 165490 201530 ) N ;
+        + PLACED ( 152190 201530 ) N ;
     - pin287 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 165870 201530 ) N ;
+        + PLACED ( 152570 201530 ) N ;
     - pin288 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 166250 201530 ) N ;
+        + PLACED ( 152950 201530 ) N ;
     - pin289 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 166630 201530 ) N ;
+        + PLACED ( 153330 201530 ) N ;
     - pin29 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 67830 201530 ) N ;
+        + PLACED ( 54530 201530 ) N ;
     - pin290 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 167010 201530 ) N ;
+        + PLACED ( 153710 201530 ) N ;
     - pin291 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 167390 201530 ) N ;
+        + PLACED ( 154090 201530 ) N ;
     - pin292 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 167770 201530 ) N ;
+        + PLACED ( 154470 201530 ) N ;
     - pin293 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 168150 201530 ) N ;
+        + PLACED ( 154850 201530 ) N ;
     - pin294 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 168530 201530 ) N ;
+        + PLACED ( 155230 201530 ) N ;
     - pin295 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 168910 201530 ) N ;
+        + PLACED ( 155610 201530 ) N ;
     - pin296 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 169290 201530 ) N ;
+        + PLACED ( 155990 201530 ) N ;
     - pin297 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 169670 201530 ) N ;
+        + PLACED ( 156370 201530 ) N ;
     - pin298 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 170050 201530 ) N ;
+        + PLACED ( 156750 201530 ) N ;
     - pin299 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 170430 201530 ) N ;
+        + PLACED ( 157130 201530 ) N ;
     - pin3 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 57950 201530 ) N ;
+        + PLACED ( 44650 201530 ) N ;
     - pin30 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 68210 201530 ) N ;
+        + PLACED ( 54910 201530 ) N ;
     - pin300 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 29830 201530 ) N ;
+        + PLACED ( 56810 70 ) N ;
     - pin301 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 30210 201530 ) N ;
+        + PLACED ( 57190 70 ) N ;
     - pin302 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 30590 201530 ) N ;
+        + PLACED ( 57570 70 ) N ;
     - pin303 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 30970 201530 ) N ;
+        + PLACED ( 57950 70 ) N ;
     - pin304 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 31350 201530 ) N ;
+        + PLACED ( 58330 70 ) N ;
     - pin305 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 31730 201530 ) N ;
+        + PLACED ( 58710 70 ) N ;
     - pin306 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 32110 201530 ) N ;
+        + PLACED ( 59090 70 ) N ;
     - pin307 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 32490 201530 ) N ;
+        + PLACED ( 59470 70 ) N ;
     - pin308 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 32870 201530 ) N ;
+        + PLACED ( 59850 70 ) N ;
     - pin309 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 33250 201530 ) N ;
+        + PLACED ( 60230 70 ) N ;
     - pin31 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 68590 201530 ) N ;
+        + PLACED ( 55290 201530 ) N ;
     - pin310 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 33630 201530 ) N ;
+        + PLACED ( 60610 70 ) N ;
     - pin311 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 34010 201530 ) N ;
+        + PLACED ( 60990 70 ) N ;
     - pin312 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 34390 201530 ) N ;
+        + PLACED ( 61370 70 ) N ;
     - pin313 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 34770 201530 ) N ;
+        + PLACED ( 61750 70 ) N ;
     - pin314 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 35150 201530 ) N ;
+        + PLACED ( 62130 70 ) N ;
     - pin315 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 35530 201530 ) N ;
+        + PLACED ( 62510 70 ) N ;
     - pin316 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 35910 201530 ) N ;
+        + PLACED ( 62890 70 ) N ;
     - pin317 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 36290 201530 ) N ;
+        + PLACED ( 63270 70 ) N ;
     - pin318 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 36670 201530 ) N ;
+        + PLACED ( 63650 70 ) N ;
     - pin319 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 37050 201530 ) N ;
+        + PLACED ( 64030 70 ) N ;
     - pin32 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 68970 201530 ) N ;
+        + PLACED ( 55670 201530 ) N ;
     - pin320 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 37430 201530 ) N ;
+        + PLACED ( 64410 70 ) N ;
     - pin321 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 37810 201530 ) N ;
+        + PLACED ( 64790 70 ) N ;
     - pin322 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 38190 201530 ) N ;
+        + PLACED ( 65170 70 ) N ;
     - pin323 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 38570 201530 ) N ;
+        + PLACED ( 65550 70 ) N ;
     - pin324 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 38950 201530 ) N ;
+        + PLACED ( 65930 70 ) N ;
     - pin325 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 39330 201530 ) N ;
+        + PLACED ( 66310 70 ) N ;
     - pin326 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 39710 201530 ) N ;
+        + PLACED ( 66690 70 ) N ;
     - pin327 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 40090 201530 ) N ;
+        + PLACED ( 67070 70 ) N ;
     - pin328 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 40470 201530 ) N ;
+        + PLACED ( 67450 70 ) N ;
     - pin329 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 40850 201530 ) N ;
+        + PLACED ( 67830 70 ) N ;
     - pin33 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 69350 201530 ) N ;
+        + PLACED ( 56050 201530 ) N ;
     - pin330 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 41230 201530 ) N ;
+        + PLACED ( 68210 70 ) N ;
     - pin331 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 41610 201530 ) N ;
+        + PLACED ( 68590 70 ) N ;
     - pin332 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 41990 201530 ) N ;
+        + PLACED ( 68970 70 ) N ;
     - pin333 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 42370 201530 ) N ;
+        + PLACED ( 69350 70 ) N ;
     - pin334 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 42750 201530 ) N ;
+        + PLACED ( 69730 70 ) N ;
     - pin335 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 43130 201530 ) N ;
+        + PLACED ( 70110 70 ) N ;
     - pin336 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 43510 201530 ) N ;
+        + PLACED ( 70490 70 ) N ;
     - pin337 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 43890 201530 ) N ;
+        + PLACED ( 70870 70 ) N ;
     - pin338 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 44270 201530 ) N ;
+        + PLACED ( 71250 70 ) N ;
     - pin339 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 44650 201530 ) N ;
+        + PLACED ( 71630 70 ) N ;
     - pin34 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 69730 201530 ) N ;
+        + PLACED ( 56430 201530 ) N ;
     - pin340 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 45030 201530 ) N ;
+        + PLACED ( 72010 70 ) N ;
     - pin341 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 45410 201530 ) N ;
+        + PLACED ( 72390 70 ) N ;
     - pin342 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 45790 201530 ) N ;
+        + PLACED ( 72770 70 ) N ;
     - pin343 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 46170 201530 ) N ;
+        + PLACED ( 73150 70 ) N ;
     - pin344 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 46550 201530 ) N ;
+        + PLACED ( 73530 70 ) N ;
     - pin345 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 46930 201530 ) N ;
+        + PLACED ( 73910 70 ) N ;
     - pin346 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 47310 201530 ) N ;
+        + PLACED ( 74290 70 ) N ;
     - pin347 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 47690 201530 ) N ;
+        + PLACED ( 74670 70 ) N ;
     - pin348 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 48070 201530 ) N ;
+        + PLACED ( 75050 70 ) N ;
     - pin349 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 48450 201530 ) N ;
+        + PLACED ( 75430 70 ) N ;
     - pin35 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 70110 201530 ) N ;
+        + PLACED ( 56810 201530 ) N ;
     - pin350 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 48830 201530 ) N ;
+        + PLACED ( 75810 70 ) N ;
     - pin351 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 49210 201530 ) N ;
+        + PLACED ( 76190 70 ) N ;
     - pin352 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 49590 201530 ) N ;
+        + PLACED ( 76570 70 ) N ;
     - pin353 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 49970 201530 ) N ;
+        + PLACED ( 76950 70 ) N ;
     - pin354 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 50350 201530 ) N ;
+        + PLACED ( 77330 70 ) N ;
     - pin355 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 50730 201530 ) N ;
+        + PLACED ( 77710 70 ) N ;
     - pin356 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 51110 201530 ) N ;
+        + PLACED ( 78090 70 ) N ;
     - pin357 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 51490 201530 ) N ;
+        + PLACED ( 78470 70 ) N ;
     - pin358 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 51870 201530 ) N ;
+        + PLACED ( 78850 70 ) N ;
     - pin359 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 52250 201530 ) N ;
+        + PLACED ( 79230 70 ) N ;
     - pin36 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 70490 201530 ) N ;
+        + PLACED ( 57190 201530 ) N ;
     - pin360 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 52630 201530 ) N ;
+        + PLACED ( 79610 70 ) N ;
     - pin361 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 53010 201530 ) N ;
+        + PLACED ( 79990 70 ) N ;
     - pin362 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 53390 201530 ) N ;
+        + PLACED ( 80370 70 ) N ;
     - pin363 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 53770 201530 ) N ;
+        + PLACED ( 80750 70 ) N ;
     - pin364 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 54150 201530 ) N ;
+        + PLACED ( 81130 70 ) N ;
     - pin365 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 54530 201530 ) N ;
+        + PLACED ( 81510 70 ) N ;
     - pin366 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 54910 201530 ) N ;
+        + PLACED ( 81890 70 ) N ;
     - pin367 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 55290 201530 ) N ;
+        + PLACED ( 82270 70 ) N ;
     - pin368 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 55670 201530 ) N ;
+        + PLACED ( 82650 70 ) N ;
     - pin369 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 56050 201530 ) N ;
+        + PLACED ( 83030 70 ) N ;
     - pin37 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 70870 201530 ) N ;
+        + PLACED ( 57570 201530 ) N ;
     - pin370 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 56430 201530 ) N ;
+        + PLACED ( 83410 70 ) N ;
     - pin371 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal3 ( -70 -70 ) ( 70 70 )
@@ -1279,7 +1279,7 @@ PINS 400 ;
     - pin38 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 71250 201530 ) N ;
+        + PLACED ( 57950 201530 ) N ;
     - pin380 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal3 ( -70 -70 ) ( 70 70 )
@@ -1323,7 +1323,7 @@ PINS 400 ;
     - pin39 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 71630 201530 ) N ;
+        + PLACED ( 58330 201530 ) N ;
     - pin390 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal3 ( -70 -70 ) ( 70 70 )
@@ -1367,267 +1367,267 @@ PINS 400 ;
     - pin4 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 58330 201530 ) N ;
+        + PLACED ( 45030 201530 ) N ;
     - pin40 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 72010 201530 ) N ;
+        + PLACED ( 58710 201530 ) N ;
     - pin41 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 72390 201530 ) N ;
+        + PLACED ( 59090 201530 ) N ;
     - pin42 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 72770 201530 ) N ;
+        + PLACED ( 59470 201530 ) N ;
     - pin43 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 73150 201530 ) N ;
+        + PLACED ( 59850 201530 ) N ;
     - pin44 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 73530 201530 ) N ;
+        + PLACED ( 60230 201530 ) N ;
     - pin45 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 73910 201530 ) N ;
+        + PLACED ( 60610 201530 ) N ;
     - pin46 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 74290 201530 ) N ;
+        + PLACED ( 60990 201530 ) N ;
     - pin47 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 74670 201530 ) N ;
+        + PLACED ( 61370 201530 ) N ;
     - pin48 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 75050 201530 ) N ;
+        + PLACED ( 61750 201530 ) N ;
     - pin49 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 75430 201530 ) N ;
+        + PLACED ( 62130 201530 ) N ;
     - pin5 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 58710 201530 ) N ;
+        + PLACED ( 45410 201530 ) N ;
     - pin50 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 75810 201530 ) N ;
+        + PLACED ( 62510 201530 ) N ;
     - pin51 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 76190 201530 ) N ;
+        + PLACED ( 62890 201530 ) N ;
     - pin52 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 76570 201530 ) N ;
+        + PLACED ( 63270 201530 ) N ;
     - pin53 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 76950 201530 ) N ;
+        + PLACED ( 63650 201530 ) N ;
     - pin54 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 77330 201530 ) N ;
+        + PLACED ( 64030 201530 ) N ;
     - pin55 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 77710 201530 ) N ;
+        + PLACED ( 64410 201530 ) N ;
     - pin56 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 78090 201530 ) N ;
+        + PLACED ( 64790 201530 ) N ;
     - pin57 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 78470 201530 ) N ;
+        + PLACED ( 65170 201530 ) N ;
     - pin58 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 78850 201530 ) N ;
+        + PLACED ( 65550 201530 ) N ;
     - pin59 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 79230 201530 ) N ;
+        + PLACED ( 65930 201530 ) N ;
     - pin6 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 59090 201530 ) N ;
+        + PLACED ( 45790 201530 ) N ;
     - pin60 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 79610 201530 ) N ;
+        + PLACED ( 66310 201530 ) N ;
     - pin61 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 79990 201530 ) N ;
+        + PLACED ( 66690 201530 ) N ;
     - pin62 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 80370 201530 ) N ;
+        + PLACED ( 67070 201530 ) N ;
     - pin63 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 80750 201530 ) N ;
+        + PLACED ( 67450 201530 ) N ;
     - pin64 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 81130 201530 ) N ;
+        + PLACED ( 67830 201530 ) N ;
     - pin65 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 81510 201530 ) N ;
+        + PLACED ( 68210 201530 ) N ;
     - pin66 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 81890 201530 ) N ;
+        + PLACED ( 68590 201530 ) N ;
     - pin67 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 82270 201530 ) N ;
+        + PLACED ( 68970 201530 ) N ;
     - pin68 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 82650 201530 ) N ;
+        + PLACED ( 69350 201530 ) N ;
     - pin69 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 83030 201530 ) N ;
+        + PLACED ( 69730 201530 ) N ;
     - pin7 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 59470 201530 ) N ;
+        + PLACED ( 46170 201530 ) N ;
     - pin70 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 83410 201530 ) N ;
+        + PLACED ( 70110 201530 ) N ;
     - pin71 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 83790 201530 ) N ;
+        + PLACED ( 70490 201530 ) N ;
     - pin72 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 84170 201530 ) N ;
+        + PLACED ( 70870 201530 ) N ;
     - pin73 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 84550 201530 ) N ;
+        + PLACED ( 71250 201530 ) N ;
     - pin74 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 84930 201530 ) N ;
+        + PLACED ( 71630 201530 ) N ;
     - pin75 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 85310 201530 ) N ;
+        + PLACED ( 72010 201530 ) N ;
     - pin76 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 85690 201530 ) N ;
+        + PLACED ( 72390 201530 ) N ;
     - pin77 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 86070 201530 ) N ;
+        + PLACED ( 72770 201530 ) N ;
     - pin78 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 86450 201530 ) N ;
+        + PLACED ( 73150 201530 ) N ;
     - pin79 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 86830 201530 ) N ;
+        + PLACED ( 73530 201530 ) N ;
     - pin8 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 59850 201530 ) N ;
+        + PLACED ( 46550 201530 ) N ;
     - pin80 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 87210 201530 ) N ;
+        + PLACED ( 73910 201530 ) N ;
     - pin81 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 87590 201530 ) N ;
+        + PLACED ( 74290 201530 ) N ;
     - pin82 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 87970 201530 ) N ;
+        + PLACED ( 74670 201530 ) N ;
     - pin83 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 88350 201530 ) N ;
+        + PLACED ( 75050 201530 ) N ;
     - pin84 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 88730 201530 ) N ;
+        + PLACED ( 75430 201530 ) N ;
     - pin85 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 89110 201530 ) N ;
+        + PLACED ( 75810 201530 ) N ;
     - pin86 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 89490 201530 ) N ;
+        + PLACED ( 76190 201530 ) N ;
     - pin87 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 89870 201530 ) N ;
+        + PLACED ( 76570 201530 ) N ;
     - pin88 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 90250 201530 ) N ;
+        + PLACED ( 76950 201530 ) N ;
     - pin89 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 90630 201530 ) N ;
+        + PLACED ( 77330 201530 ) N ;
     - pin9 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 60230 201530 ) N ;
+        + PLACED ( 46930 201530 ) N ;
     - pin90 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 91010 201530 ) N ;
+        + PLACED ( 77710 201530 ) N ;
     - pin91 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 91390 201530 ) N ;
+        + PLACED ( 78090 201530 ) N ;
     - pin92 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 91770 201530 ) N ;
+        + PLACED ( 78470 201530 ) N ;
     - pin93 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 92150 201530 ) N ;
+        + PLACED ( 78850 201530 ) N ;
     - pin94 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 92530 201530 ) N ;
+        + PLACED ( 79230 201530 ) N ;
     - pin95 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 92910 201530 ) N ;
+        + PLACED ( 79610 201530 ) N ;
     - pin96 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 93290 201530 ) N ;
+        + PLACED ( 79990 201530 ) N ;
     - pin97 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 93670 201530 ) N ;
+        + PLACED ( 80370 201530 ) N ;
     - pin98 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 94050 201530 ) N ;
+        + PLACED ( 80750 201530 ) N ;
     - pin99 + NET net + DIRECTION INPUT + USE SIGNAL
       + PORT
         + LAYER metal2 ( -70 -70 ) ( 70 70 )
-        + PLACED ( 94430 201530 ) N ;
+        + PLACED ( 81130 201530 ) N ;
 END PINS
 NETS 1 ;
     - net ( PIN pin99 ) ( PIN pin98 ) ( PIN pin97 ) ( PIN pin96 ) ( PIN pin95 ) ( PIN pin94 ) ( PIN pin93 )

--- a/src/ppl/test/large_groups4.ok
+++ b/src/ppl/test/large_groups4.ok
@@ -12,10 +12,13 @@
 Found 0 macro blocks.
 [WARNING PPL-0092] Pin group of size 300 does not fit any section. Adding to fallback mode.
 [INFO PPL-0100] Group of size 300 placed during fallback mode.
-[WARNING PPL-0078] Not enough available positions (36) in section (47.215, 100.8)-(14.915, 100.8) at edge TOP to place the pin group of size 71.
-[WARNING PPL-0078] Not enough available positions (35) in section (85.215, 100.8)-(47.405, 100.8) at edge TOP to place the pin group of size 71.
-[WARNING PPL-0042] Unsuccessfully assigned I/O groups.
-[WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
-[WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
-[ERROR PPL-0093] Pin group of size 71 does not fit in the constrained region 0-100.13 at TOP edge. First pin of the group is pin300.
-PPL-0093
+[INFO PPL-0010] Tentative 0 to set up sections.
+[INFO PPL-0001] Number of slots          1754
+[INFO PPL-0002] Number of I/O            400
+[INFO PPL-0003] Number of I/O w/sink     400
+[INFO PPL-0004] Number of I/O w/o sink   0
+[INFO PPL-0005] Slots per section        200
+[INFO PPL-0006] Slots increase factor    0.01
+[INFO PPL-0008] Successfully assigned pins to sections.
+[INFO PPL-0012] I/O nets HPWL: 25867.56 um.
+No differences found.

--- a/src/ppl/test/large_groups4.tcl
+++ b/src/ppl/test/large_groups4.tcl
@@ -15,7 +15,12 @@ for {set i 300} {$i < 371} {incr i} {
 
 set_io_pin_constraint -region top:* -group -order -pin_names $group1
 
-set_io_pin_constraint -region top:* -group -order -pin_names $group2
+set_io_pin_constraint -region bottom:* -group -order -pin_names $group2
 
-catch {place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 15 -min_distance 0.12} error
-puts $error
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 15 -min_distance 0.12
+
+set def_file [make_result_file large_groups4.def]
+
+write_def $def_file
+
+diff_file large_groups4.defok $def_file

--- a/src/ppl/test/regression_tests.tcl
+++ b/src/ppl/test/regression_tests.tcl
@@ -42,6 +42,7 @@ record_tests {
   large_groups1
   large_groups2
   large_groups3
+  large_groups4
   min_dist_in_tracks1
   min_dist_in_tracks2
   multi_layers


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/3338

Only constrained groups placed during fallback mode are placed in the middle of the constrained region.