### PR TITLE
logging: fix lockup when resizing window in Docker

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -380,7 +380,11 @@ class ScriptWidget::GuiSink : public spdlog::sinks::base_sink<Mutex>
     // process widget event queue, if main thread will process new text,
     // otherwise there is nothing to process from this thread.
     if (QThread::currentThread() == widget_->thread()) {
-      QCoreApplication::sendPostedEvents(widget_);
+      if (!formatted_msg.contains("XcbConnection")) {
+        // there is a slim chance of a deadlock if we update the GUI
+        // from within a Qt error handler.
+        QCoreApplication::sendPostedEvents(widget_);
+      }
     }
   }
 

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -376,6 +376,12 @@ class ScriptWidget::GuiSink : public spdlog::sinks::base_sink<Mutex>
 
       widget_->addLogToOutput(formatted_msg, msg_color);
     }
+
+    // process widget event queue, if main thread will process new text,
+    // otherwise there is nothing to process from this thread.
+    if (QThread::currentThread() == widget_->thread()) {
+      QCoreApplication::sendPostedEvents(widget_);
+    }
   }
 
   void flush_() override {}

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -376,12 +376,6 @@ class ScriptWidget::GuiSink : public spdlog::sinks::base_sink<Mutex>
 
       widget_->addLogToOutput(formatted_msg, msg_color);
     }
-
-    // process widget event queue, if main thread will process new text,
-    // otherwise there is nothing to process from this thread.
-    if (QThread::currentThread() == widget_->thread()) {
-      QCoreApplication::sendPostedEvents(widget_);
-    }
   }
 
   void flush_() override {}


### PR DESCRIPTION
fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/2675

logging tried to render the log message synchronously, which
caused a lockup as the main event loop was processed during
the reporting of an Xcb error.

With the upcoming https://github.com/The-OpenROAD-Project/OpenROAD/pull/3370 fix to rendering where rendering is
cancelled and restarted when it takes to long, it's not
too bad to wait until the GUI is idle before updating the
log message in the GUI.