### PR TITLE
dpl,dst: find tcl package

### DIFF
--- a/src/dpl/CMakeLists.txt
+++ b/src/dpl/CMakeLists.txt
@@ -37,7 +37,7 @@
 ###########################################################################
 
 include("openroad")
-
+find_package(TCL)
 
 add_library(dpl_lib
   src/Opendp.cpp
@@ -84,7 +84,7 @@ target_include_directories(dpl
 
 target_link_libraries(dpl
   PRIVATE
-    tcl
+    ${TCL_LIBRARY}
     odb
     dpl_lib
     OpenSTA

--- a/src/dst/CMakeLists.txt
+++ b/src/dst/CMakeLists.txt
@@ -34,6 +34,7 @@
 ###############################################################################
 include("openroad")
 include(FindZLIB)
+find_package(TCL)
 
 project(dst
   LANGUAGES CXX
@@ -64,7 +65,7 @@ target_link_libraries(dst
   PUBLIC
     utl
     OpenSTA
-    tcl
+    ${TCL_LIBRARY}
     ${ZLIB_LIBRARIES}
     Boost::serialization
     Boost::system


### PR DESCRIPTION
Seems like `find_package` directive were missing for those two modules.

Note: this is one of the patches used by the packages here to ensure we build against the version of TCL packaged in conda:
https://github.com/hdl/conda-eda/tree/master/pnr/openroad

Related: https://github.com/hdl/conda-eda/pull/334

/cc @QuantamHD 
