### PR TITLE
Add CMake variable for building with Address Sanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,9 @@ option(USE_SYSTEM_ABC "Use system shared ABC library" OFF)
 # Allow disabling tests
 option(ENABLE_TESTS "Enable OpenROAD tests" ON)
 
+# Allow enabling address sanitizer
+option(ASAN "Enable Address Sanitizer" OFF)
+
 project(OpenROAD VERSION 1
   LANGUAGES CXX
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,7 +185,16 @@ add_compile_options(
   $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>
   # Apple clang 14.0.0 deprecates sprintf, which generates 900 warnings.
   $<$<CXX_COMPILER_ID:AppleClang>:-Wno-deprecated-declarations>
+  $<$<BOOL:${ASAN}>:-fsanitize=address>
+  $<$<BOOL:${ASAN}>:-fno-omit-frame-pointer>
+  $<$<BOOL:${ASAN}>:-g>
 )
+
+if (ASAN)
+  add_link_options(
+    -fsanitize=address
+  )
+endif()
 
 ################################################################
 
@@ -273,7 +282,16 @@ add_executable(openroad
 target_compile_options(openroad
   PRIVATE
     -Wextra -pedantic -Wcast-qual
+  $<$<BOOL:${ASAN}>:-fsanitize=address>
+  $<$<BOOL:${ASAN}>:-fno-omit-frame-pointer>
+  $<$<BOOL:${ASAN}>:-g>
 )
+if (ASAN)
+  target_link_options(openroad
+    PRIVATE
+    -fsanitize=address
+  )
+endif()
 
 # Needed for boost stacktrace
 if(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,9 +191,7 @@ add_compile_options(
 )
 
 if (ASAN)
-  add_link_options(
-    -fsanitize=address
-  )
+  add_link_options(-fsanitize=address)
 endif()
 
 ################################################################
@@ -287,10 +285,7 @@ target_compile_options(openroad
   $<$<BOOL:${ASAN}>:-g>
 )
 if (ASAN)
-  target_link_options(openroad
-    PRIVATE
-    -fsanitize=address
-  )
+  target_link_options(openroad PRIVATE -fsanitize=address)
 endif()
 
 # Needed for boost stacktrace

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -280,13 +280,7 @@ add_executable(openroad
 target_compile_options(openroad
   PRIVATE
     -Wextra -pedantic -Wcast-qual
-  $<$<BOOL:${ASAN}>:-fsanitize=address>
-  $<$<BOOL:${ASAN}>:-fno-omit-frame-pointer>
-  $<$<BOOL:${ASAN}>:-g>
 )
-if (ASAN)
-  target_link_options(openroad PRIVATE -fsanitize=address)
-endif()
 
 # Needed for boost stacktrace
 if(APPLE)


### PR DESCRIPTION
Created a new variable "ASAN" in the top-level CMakeLists.txt. This variable is OFF by default. To enable building with Address Sanitizer, set the ASAN variable to ON by passing the argument to CMake "-DASAN=ON".

When ASAN is ON, the src/CMakeLists.txt file adds compile and link options for using Address Sanitizer to the directory properties and also to the target properties. These compile and link options will be applied to all tools in the src directory and to openroad itself.

Fixes #2738