### PR TITLE
dpl: Move Grid from pointers to vectors

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -357,6 +357,7 @@ class Opendp
   int rectDist(const Cell* cell, const Rect* rect) const;
   bool havePadding() const;
   void checkOneSiteDbMaster();
+  void deleteGrid();
   Pixel* gridPixel(int grid_idx, int x, int y) const;
   // Cell initial location wrt core origin.
   int getRowHeight(const Cell* cell) const;

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -87,7 +87,7 @@ class DplObserver;
 // multi-height cells. Each unique row height creates a new grid that is used in
 // legalization. The first index is the grid index (corresponding to row
 // height), second index is the row index, and third index is the site index.
-using Grid = Pixel***;
+using Grid = std::vector<std::vector<std::vector<Pixel>>>;
 using dbMasterSeq = vector<dbMaster*>;
 // gap -> sequence of masters to fill the gap
 using GapFillers = vector<dbMasterSeq>;
@@ -357,7 +357,6 @@ class Opendp
   int rectDist(const Cell* cell, const Rect* rect) const;
   bool havePadding() const;
   void checkOneSiteDbMaster();
-  void deleteGrid();
   Pixel* gridPixel(int grid_idx, int x, int y) const;
   // Cell initial location wrt core origin.
   int getRowHeight(const Cell* cell) const;
@@ -459,7 +458,7 @@ class Opendp
   vector<dbInst*> placement_failures_;
 
   // 3D pixel grid
-  Grid grid_ = nullptr;
+  Grid grid_;
   Cell dummy_cell_;
 
   // Filler placement.

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -191,6 +191,10 @@ void Opendp::initGrid()
   }
 }
 
+void Opendp::deleteGrid() {
+  grid_.clear();
+}
+
 Pixel* Opendp::gridPixel(int grid_idx, int grid_x, int grid_y) const
 {
   if (grid_idx < 0 || grid_idx >= grid_info_vector_.size()) {
@@ -199,7 +203,7 @@ Pixel* Opendp::gridPixel(int grid_idx, int grid_x, int grid_y) const
   GridInfo* grid_info = grid_info_vector_[grid_idx];
   if (grid_x >= 0 && grid_x < grid_info->site_count && grid_y >= 0
       && grid_y < grid_info->row_count) {
-    return const_cast<Pixel*>(&grid_[grid_idx][grid_y].data()[grid_x]);
+    return const_cast<Pixel*>(&grid_[grid_idx][grid_y][grid_x]);
   }
   return nullptr;
 }

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -191,7 +191,8 @@ void Opendp::initGrid()
   }
 }
 
-void Opendp::deleteGrid() {
+void Opendp::deleteGrid()
+{
   grid_.clear();
 }
 

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -92,13 +92,13 @@ void Opendp::initGrid()
   }
 
   // Make pixel grid
-  if (grid_ == nullptr) {
-    grid_ = new Pixel**[grid_info_map_.size()];
+  if (grid_.empty()) {
+    grid_.resize(grid_info_map_.size());
 
     for (auto& [row_height, grid_info] : grid_info_map_) {
       int layer_row_count = grid_info.row_count;
       int index = grid_info.grid_index;
-      grid_[index] = new Pixel*[layer_row_count];
+      grid_[index].resize(layer_row_count);
     }
   }
 
@@ -106,9 +106,9 @@ void Opendp::initGrid()
     const int layer_row_count = grid_info.row_count;
     const int layer_row_site_count = grid_info.site_count;
     const int index = grid_info.grid_index;
-    grid_[index] = new Pixel*[layer_row_count];
+    grid_[index].resize(layer_row_count);
     for (int j = 0; j < layer_row_count; j++) {
-      grid_[index][j] = new Pixel[layer_row_site_count];
+      grid_[index][j].resize(layer_row_site_count);
       for (int k = 0; k < layer_row_site_count; k++) {
         Pixel& pixel = grid_[index][j][k];
         pixel.cell = nullptr;
@@ -183,28 +183,12 @@ void Opendp::initGrid()
     for (const auto& rect : rects) {
       for (int y = gtl::yl(rect); y < gtl::yh(rect); y++) {
         for (int x = gtl::xl(rect); x < gtl::xh(rect); x++) {
-          grid_[h_index][y][x].is_hopeless = true;
+          Pixel& pixel = grid_[h_index][y][x];
+          pixel.is_hopeless = true;
         }
       }
     }
   }
-}
-
-void Opendp::deleteGrid()
-{
-  if (grid_) {
-    int i = 0;
-    for (auto [row_height, grid_info] : grid_info_map_) {
-      int N = grid_info.row_count;
-      for (int j = 0; j < N; j++) {
-        delete[] grid_[i][j];
-      }
-      delete[] grid_[i];
-      i++;
-    }
-    delete[] grid_;
-  }
-  grid_ = nullptr;
 }
 
 Pixel* Opendp::gridPixel(int grid_idx, int grid_x, int grid_y) const
@@ -215,7 +199,7 @@ Pixel* Opendp::gridPixel(int grid_idx, int grid_x, int grid_y) const
   GridInfo* grid_info = grid_info_vector_[grid_idx];
   if (grid_x >= 0 && grid_x < grid_info->site_count && grid_y >= 0
       && grid_y < grid_info->row_count) {
-    return &grid_[grid_idx][grid_y][grid_x];
+    return const_cast<Pixel*>(&grid_[grid_idx][grid_y].data()[grid_x]);
   }
   return nullptr;
 }

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -90,11 +90,7 @@ Opendp::Opendp()
   dummy_cell_.is_placed_ = true;
 }
 
-Opendp::~Opendp()
-{
-  deleteGrid();
-}
-
+Opendp::~Opendp() = default;
 void Opendp::init(dbDatabase* db, Logger* logger)
 {
   db_ = db;

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -91,6 +91,7 @@ Opendp::Opendp()
 }
 
 Opendp::~Opendp() = default;
+
 void Opendp::init(dbDatabase* db, Logger* logger)
 {
   db_ = db;

--- a/src/dpl/src/dbToOpendp.cpp
+++ b/src/dpl/src/dbToOpendp.cpp
@@ -77,7 +77,6 @@ void Opendp::importClear()
   cells_.clear();
   groups_.clear();
   db_inst_map_.clear();
-  deleteGrid();
   have_multi_row_cells_ = false;
 }
 

--- a/src/dpl/src/dbToOpendp.cpp
+++ b/src/dpl/src/dbToOpendp.cpp
@@ -77,6 +77,7 @@ void Opendp::importClear()
   cells_.clear();
   groups_.clear();
   db_inst_map_.clear();
+  deleteGrid();
   have_multi_row_cells_ = false;
 }
 


### PR DESCRIPTION
I found a destructor related bug in one of Google's test cases. Rather than debug it I figured I'd just move it to vector, and not worry about it.