### PR TITLE
dbsta: enable file redirects

### DIFF
--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -331,6 +331,11 @@ void dbStaReport::printLine(const char* line, size_t length)
     redirectStringPrint("\n", 1);
     return;
   }
+  if (redirect_stream_) {
+    fwrite(line, sizeof(char), length, redirect_stream_);
+    fwrite("\n", sizeof(char), 1, redirect_stream_);
+    return;
+  }
 
   logger_->report("{}", line);
 }
@@ -341,6 +346,10 @@ size_t dbStaReport::printString(const char* buffer, size_t length)
   if (redirect_to_string_) {
     redirectStringPrint(buffer, length);
     return length;
+  }
+  if (redirect_stream_) {
+    size_t ret = fwrite(buffer, sizeof(char), length, redirect_stream_);
+    return std::min(ret, length);
   }
 
   // prepend saved buffer


### PR DESCRIPTION
This enables the file redirects that are available to some commands like `report_checks`, this will be helpful to write out specific timing reports to a file instead of only having the log available