### PR TITLE
Gate cloning off by default

### DIFF
--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -115,7 +115,7 @@ RepairSetup::repairSetup(float setup_slack_margin,
                          double repair_tns_end_percent,
                          int max_passes,
                          bool skip_pin_swap,
-                         bool skip_gate_cloning)
+                         bool enable_gate_cloning)
 {
   init();
   constexpr int digits = 3;
@@ -185,7 +185,7 @@ RepairSetup::repairSetup(float setup_slack_margin,
       int cloned_gate_begin, cloned_gate_end;
       cloned_gate_begin = cloned_gate_count_ ;//+ split_load_buffer_count_;
       bool changed = repairSetup(end_path, end_slack, skip_pin_swap,
-                                 skip_gate_cloning);
+                                 enable_gate_cloning);
       cloned_gate_end = cloned_gate_count_ ;//+ split_load_buffer_count_;
       if (!changed) {
         debugPrint(logger_, RSZ, "repair_setup", 2,
@@ -332,7 +332,7 @@ RepairSetup::repairSetup(const Pin *end_pin)
 bool
 RepairSetup::repairSetup(PathRef &path,
                          Slack path_slack,
-                         bool skip_pin_swap, bool skip_gate_cloning)
+                         bool skip_pin_swap, bool enable_gate_cloning)
 {
   PathExpanded expanded(&path, sta_);
   bool changed = false;
@@ -417,7 +417,7 @@ RepairSetup::repairSetup(PathRef &path,
       }
 
       // Gate cloning
-      if (!skip_gate_cloning && fanout > split_load_min_fanout_ &&
+      if (enable_gate_cloning && fanout > split_load_min_fanout_ &&
           !tristate_drvr &&
           !resizer_->dontTouch(net)) {
         rsz::GateCloner cloner(resizer_);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2425,14 +2425,14 @@ Resizer::repairSetup(double setup_margin,
                      double repair_tns_end_percent,
                      int max_passes,
                      bool skip_pin_swap,
-                     bool skip_gate_cloning)
+                     bool enable_gate_cloning)
 {
   resizePreamble();
   if (parasitics_src_ == ParasiticsSrc::global_routing) {
     opendp_->initMacrosAndGrid();
   }
   repair_setup_->repairSetup(setup_margin, repair_tns_end_percent,
-                             max_passes, skip_pin_swap, skip_gate_cloning);
+                             max_passes, skip_pin_swap, enable_gate_cloning);
 }
 
 void

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -478,12 +478,12 @@ void
 repair_setup(double setup_margin,
              double repair_tns_end_percent,
              int max_passes,
-             bool skip_pin_swap, bool skip_gate_cloning)
+             bool skip_pin_swap, bool enable_gate_cloning)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
   resizer->repairSetup(setup_margin, repair_tns_end_percent,
-                       max_passes, skip_pin_swap, skip_gate_cloning);
+                       max_passes, skip_pin_swap, enable_gate_cloning);
 }
 
 void

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -391,7 +391,7 @@ sta::define_cmd_args "repair_timing" {[-setup] [-hold]\
                                         [-hold_margin hold_margin]\
                                         [-allow_setup_violations]\
 					[-skip_pin_swap]\
-					[-skip_gate_cloning)]\
+					[-enable_gate_cloning)]\
                                         [-repair_tns tns_end_percent]\
                                         [-max_buffer_percent buffer_percent]\
                                         [-max_utilization util]}
@@ -401,7 +401,7 @@ proc repair_timing { args } {
     keys {-setup_margin -hold_margin -slack_margin \
             -libraries -max_utilization -max_buffer_percent \
             -repair_tns -max_passes} \
-    flags {-setup -hold -allow_setup_violations -skip_pin_swap -skip_gate_cloning}
+    flags {-setup -hold -allow_setup_violations -skip_pin_swap -enable_gate_cloning}
   
   set setup [info exists flags(-setup)]
   set hold [info exists flags(-hold)]
@@ -426,7 +426,7 @@ proc repair_timing { args } {
 
   set allow_setup_violations [info exists flags(-allow_setup_violations)]
   set skip_pin_swap [info exists flags(-skip_pin_swap)]
-  set skip_gate_cloning [info exists flags(-skip_gate_cloning)]
+  set enable_gate_cloning [info exists flags(-enable_gate_cloning)]
   rsz::set_max_utilization [rsz::parse_max_util keys]
   
   set max_buffer_percent 20
@@ -450,7 +450,7 @@ proc repair_timing { args } {
   sta::check_argc_eq0 "repair_timing" $args
   rsz::check_parasitics
   if { $setup } {
-    rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes $skip_pin_swap $skip_gate_cloning
+    rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes $skip_pin_swap $enable_gate_cloning
   }
   if { $hold } {
     rsz::repair_hold $setup_margin $hold_margin \

--- a/src/rsz/test/repair_fanout7.tcl
+++ b/src/rsz/test/repair_fanout7.tcl
@@ -33,5 +33,5 @@ estimate_parasitics -placement
 # Repair the high fanout net hopefully with gate cloning code. 
 report_worst_slack -max
 #set ::env(TEST_GATE_CLONING) 1
-repair_timing -setup -repair_tns 100
+repair_timing -setup -repair_tns 100 -enable_gate_cloning
 report_worst_slack -max

--- a/src/rsz/test/repair_fanout8.tcl
+++ b/src/rsz/test/repair_fanout8.tcl
@@ -32,5 +32,5 @@ estimate_parasitics -placement
 
 report_worst_slack -max
 #set ::env(TEST_GATE_CLONING) 1
-repair_timing -setup -repair_tns 100 -skip_gate_cloning
+repair_timing -setup -repair_tns 100
 report_worst_slack -max


### PR DESCRIPTION
@maliberty @tspyrou : Here is the PR to turn off gate cloning by default. It also changes the option in the TCL command to:

-enable_gate_cloning so we can evaulate the ORFS tests and enable as needed. The two regressions have also been updated. 
