### PR TITLE
odb: Modifies abstract LEF writer to work on ostreams 

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -390,10 +390,16 @@ void OpenRoad::writeLef(const char* filename)
       if (cnt > 0) {
         name += "_" + std::to_string(cnt);
         std::ofstream os(name);
+        if (!os.is_open()) {
+          logger_->error(utl::ODB, 2001, "Cannot open LEF file {}\n", name);
+        }
         odb::lefout lef_writer(logger_, os);
         lef_writer.writeLib(lib);
       } else {
         std::ofstream os(name);
+        if (!os.is_open()) {
+          logger_->error(utl::ODB, 2002, "Cannot open LEF file {}\n", name);
+        }
         odb::lefout lef_writer(logger_, os);
         lef_writer.writeTechAndLib(lib);
       }
@@ -401,6 +407,9 @@ void OpenRoad::writeLef(const char* filename)
     }
   } else if (db_->getTech()) {
     std::ofstream os(filename);
+    if (!os.is_open()) {
+      logger_->error(utl::ODB, 2003, "Cannot open LEF file {}\n", filename);
+    }
     odb::lefout lef_writer(logger_, os);
     lef_writer.writeTech(db_->getTech());
   }

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -378,7 +378,6 @@ void OpenRoad::writeLef(const char* filename)
 {
   auto libs = db_->getLibs();
   int num_libs = libs.size();
-  odb::lefout lef_writer(logger_);
   if (num_libs > 0) {
     if (num_libs > 1) {
       logger_->info(
@@ -390,14 +389,20 @@ void OpenRoad::writeLef(const char* filename)
       std::string name(filename);
       if (cnt > 0) {
         name += "_" + std::to_string(cnt);
-        lef_writer.writeLib(lib, name.c_str());
+        std::ofstream os(name);
+        odb::lefout lef_writer(logger_, os);
+        lef_writer.writeLib(lib);
       } else {
-        lef_writer.writeTechAndLib(lib, name.c_str());
+        std::ofstream os(name);
+        odb::lefout lef_writer(logger_, os);
+        lef_writer.writeTechAndLib(lib);
       }
       ++cnt;
     }
   } else if (db_->getTech()) {
-    lef_writer.writeTech(db_->getTech(), filename);
+    std::ofstream os(filename);
+    odb::lefout lef_writer(logger_, os);
+    lef_writer.writeTech(db_->getTech());
   }
 }
 

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -389,27 +389,24 @@ void OpenRoad::writeLef(const char* filename)
       std::string name(filename);
       if (cnt > 0) {
         name += "_" + std::to_string(cnt);
-        std::ofstream os(name);
-        if (!os.is_open()) {
-          logger_->error(utl::ODB, 2001, "Cannot open LEF file {}\n", name);
-        }
+        std::ofstream os;
+        os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+        os.open(name);
         odb::lefout lef_writer(logger_, os);
         lef_writer.writeLib(lib);
       } else {
-        std::ofstream os(name);
-        if (!os.is_open()) {
-          logger_->error(utl::ODB, 2002, "Cannot open LEF file {}\n", name);
-        }
+        std::ofstream os;
+        os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+        os.open(name);
         odb::lefout lef_writer(logger_, os);
         lef_writer.writeTechAndLib(lib);
       }
       ++cnt;
     }
   } else if (db_->getTech()) {
-    std::ofstream os(filename);
-    if (!os.is_open()) {
-      logger_->error(utl::ODB, 2003, "Cannot open LEF file {}\n", filename);
-    }
+    std::ofstream os;
+    os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+    os.open(filename);
     odb::lefout lef_writer(logger_, os);
     lef_writer.writeTech(db_->getTech());
   }

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -199,8 +199,8 @@ class dbProperty : public dbObject
   static dbSet<dbProperty> getProperties(dbObject* object);
   static dbSet<dbProperty>::iterator destroy(dbSet<dbProperty>::iterator itr);
   // 5.8
-  static void writeProperties(dbObject* object, FILE* out);
-  static void writePropValue(dbProperty* prop, FILE* out);
+  static std::string writeProperties(dbObject* object);
+  static std::string writePropValue(dbProperty* prop);
 };
 
 ///

--- a/src/odb/include/odb/lefout.h
+++ b/src/odb/include/odb/lefout.h
@@ -33,6 +33,8 @@
 #pragma once
 
 #include <boost/polygon/polygon.hpp>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -60,7 +62,6 @@ class dbProperty;
 
 class lefout
 {
-  FILE* _out;
   bool _use_master_ids;
   bool _use_alias;
   bool _write_marked_masters;
@@ -76,12 +77,12 @@ class lefout
   using ObstructionMap
       = std::map<dbTechLayer*, boost::polygon::polygon_90_set_data<int>>;
 
-  void writeTech(dbTech* tech);
+  void writeTechBody(dbTech* tech);
   void writeLayer(dbTechLayer* layer);
   void writeVia(dbTechVia* via);
   void writeHeader(dbLib* lib);
   void writeHeader(dbBlock* db_block);
-  void writeLib(dbLib* lib);
+  void writeLibBody(dbLib* lib);
   void writeMaster(dbMaster* master);
   void writeMTerm(dbMTerm* mterm);
   void writeSite(dbSite* site);
@@ -130,9 +131,8 @@ class lefout
 
   double lefarea(int value) { return ((double) value * _area_factor); }
 
-  lefout(utl::Logger* logger)
+  lefout(utl::Logger* logger, std::ostream& out) : _out(out)
   {
-    _out = nullptr;
     _write_marked_masters = _use_alias = _use_master_ids = false;
     _dist_factor = 0.001;
     _area_factor = 0.000001;
@@ -149,11 +149,14 @@ class lefout
   void setBloatFactor(int value) { bloat_factor_ = value; }
   void setBloatOccupiedLayers(bool value) { bloat_occupied_layers_ = value; }
 
-  bool writeTech(dbTech* tech, const char* lef_file);
-  bool writeLib(dbLib* lib, const char* lef_file);
-  bool writeTechAndLib(dbLib* lib, const char* lef_file);
-  bool writeAbstractLef(dbBlock* db_block, const char* lef_file);
+  void writeTech(dbTech* tech);
+  void writeLib(dbLib* lib);
+  void writeTechAndLib(dbLib* lib);
+  void writeAbstractLef(dbBlock* db_block);
 
-  FILE* out() { return _out; }
+  std::ostream& out() { return _out; }
+
+ protected:
+  std::ostream& _out;
 };
 }  // namespace odb

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -3462,10 +3462,11 @@ void dbBlock::saveLef(char* filename,
                       int bloat_factor,
                       bool bloat_occupied_layers)
 {
-  lefout writer(getImpl()->getLogger());
+  std::ofstream os(filename);
+  lefout writer(getImpl()->getLogger(), os);
   writer.setBloatFactor(bloat_factor);
   writer.setBloatOccupiedLayers(bloat_occupied_layers);
-  writer.writeAbstractLef(this, filename);
+  writer.writeAbstractLef(this);
 }
 
 //

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -3462,11 +3462,9 @@ void dbBlock::saveLef(char* filename,
                       int bloat_factor,
                       bool bloat_occupied_layers)
 {
-  std::ofstream os(filename);
-  if (!os.is_open()) {
-    getImpl()->getLogger()->error(
-        utl::ODB, 2004, "Cannot open LEF file {}\n", filename);
-  }
+  std::ofstream os;
+  os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+  os.open(filename);
   lefout writer(getImpl()->getLogger(), os);
   writer.setBloatFactor(bloat_factor);
   writer.setBloatOccupiedLayers(bloat_occupied_layers);

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -3463,6 +3463,10 @@ void dbBlock::saveLef(char* filename,
                       bool bloat_occupied_layers)
 {
   std::ofstream os(filename);
+  if (!os.is_open()) {
+    getImpl()->getLogger()->error(
+        utl::ODB, 2004, "Cannot open LEF file {}\n", filename);
+  }
   lefout writer(getImpl()->getLogger(), os);
   writer.setBloatFactor(bloat_factor);
   writer.setBloatOccupiedLayers(bloat_occupied_layers);

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -32,6 +32,8 @@
 
 #include "dbMTerm.h"
 
+#include <spdlog/fmt/ostr.h>
+
 #include "db.h"
 #include "dbDatabase.h"
 #include "dbLib.h"
@@ -521,7 +523,7 @@ void dbMTerm::writeAntennaLef(lefout& writer) const
     getDefaultAntennaModel()->writeLef(tech, writer);
 
   if (hasOxide2AntennaModel()) {
-    fprintf(writer.out(), "        ANTENNAMODEL OXIDE2 ;\n");
+    fmt::print(writer.out(), "        ANTENNAMODEL OXIDE2 ;\n");
     getOxide2AntennaModel()->writeLef(tech, writer);
   }
 }

--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -671,9 +671,7 @@ std::string dbProperty::writeProperties(dbObject* object)
   for (itr = props.begin(); itr != props.end(); ++itr) {
     dbProperty* prop = *itr;
     std::string name = prop->getName();
-    fmt::print(out, "    PROPERTY {} ", name);
-    fmt::print(out, "{}", writePropValue(prop));
-    fmt::print(out, ";\n");
+    fmt::print(out, "    PROPERTY {} {};\n", name, writePropValue(prop));
   }
 
   return out.str();

--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -32,6 +32,9 @@
 
 #include "dbProperty.h"
 
+#include <spdlog/fmt/ostr.h>
+#include <sstream>
+
 #include "db.h"
 #include "dbBlock.h"
 #include "dbChip.h"
@@ -633,46 +636,46 @@ dbDoubleProperty* dbDoubleProperty::find(dbObject* object, const char* name)
       object, name, dbProperty::DOUBLE_PROP);
 }
 
-void dbProperty::writePropValue(dbProperty* prop, FILE* out)
+std::string dbProperty::writePropValue(dbProperty* prop)
 {
   switch (prop->getType()) {
     case dbProperty::STRING_PROP: {
       dbStringProperty* p = (dbStringProperty*) prop;
       std::string v = p->getValue();
-      fprintf(out, "\"%s\" ", v.c_str());
-      break;
+      return fmt::format("\"{}\" ", v);
     }
 
     case dbProperty::INT_PROP: {
       dbIntProperty* p = (dbIntProperty*) prop;
       int v = p->getValue();
-      fprintf(out, "%d ", v);
-      break;
+      return fmt::format("{} ", v);
     }
 
     case dbProperty::DOUBLE_PROP: {
       dbDoubleProperty* p = (dbDoubleProperty*) prop;
       double v = p->getValue();
-      fprintf(out, "%G ", v);
+      return fmt::format("{:G} ", v);
     }
-
     default:
-      break;
+      return "";
   }
 }
 
-void dbProperty::writeProperties(dbObject* object, FILE* out)
+std::string dbProperty::writeProperties(dbObject* object)
 {
   dbSet<dbProperty> props = dbProperty::getProperties(object);
   dbSet<dbProperty>::iterator itr;
+  std::ostringstream out;
 
   for (itr = props.begin(); itr != props.end(); ++itr) {
     dbProperty* prop = *itr;
     std::string name = prop->getName();
-    fprintf(out, "    PROPERTY %s ", name.c_str());
-    writePropValue(prop, out);
-    fprintf(out, ";\n");
+    fmt::print(out, "    PROPERTY {} ", name);
+    fmt::print(out, "{}", writePropValue(prop));
+    fmt::print(out, ";\n");
   }
+
+  return out.str();
 }
 
 /* Sample Code to access dbTechLayer properties

--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -33,6 +33,7 @@
 #include "dbProperty.h"
 
 #include <spdlog/fmt/ostr.h>
+
 #include <sstream>
 
 #include "db.h"

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -56,6 +56,8 @@
 #include "dbTechLayerSpacingTablePrlRule.h"
 #include "dbTechLayerWidthTableRule.h"
 // User Code Begin Includes
+#include <spdlog/fmt/ostr.h>
+
 #include "dbHashTable.hpp"
 #include "dbTech.h"
 #include "dbTechLayerAntennaRule.h"
@@ -63,7 +65,6 @@
 #include "dbTechMinCutOrAreaRule.h"
 #include "lefout.h"
 #include "utl/Logger.h"
-#include <spdlog/fmt/ostr.h>
 // User Code End Includes
 namespace odb {
 
@@ -1506,8 +1507,8 @@ void dbTechLayer::printV55SpacingRules(lefout& writer) const
     fmt::print(writer.out(), "  WIDTH {:.3f}\t", writer.lefdist(*v55_itr));
     for (lndx = 0; lndx < layer->_v55sp_spacing.numCols(); lndx++)
       fmt::print(writer.out(),
-              " {:.3f}",
-              writer.lefdist(layer->_v55sp_spacing(wddx, lndx)));
+                 " {:.3f}",
+                 writer.lefdist(layer->_v55sp_spacing(wddx, lndx)));
   }
 
   fmt::print(writer.out(), " ;\n");
@@ -1603,8 +1604,8 @@ void dbTechLayer::printTwoWidthsSpacingRules(lefout& writer) const
     fmt::print(writer.out(), "\n  WIDTH {:.3f}\t", writer.lefdist(*itr));
     for (lndx = 0; lndx < layer->_two_widths_sp_spacing.numCols(); lndx++)
       fmt::print(writer.out(),
-              " {:.3f}",
-              writer.lefdist(layer->_two_widths_sp_spacing(wddx, lndx)));
+                 " {:.3f}",
+                 writer.lefdist(layer->_two_widths_sp_spacing(wddx, lndx)));
   }
 
   fmt::print(writer.out(), " ;\n");

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -63,6 +63,7 @@
 #include "dbTechMinCutOrAreaRule.h"
 #include "lefout.h"
 #include "utl/Logger.h"
+#include <spdlog/fmt/ostr.h>
 // User Code End Includes
 namespace odb {
 
@@ -1488,28 +1489,28 @@ void dbTechLayer::printV55SpacingRules(lefout& writer) const
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
 
-  fprintf(writer.out(), "SPACINGTABLE\n");
-  fprintf(writer.out(), "  PARALLELRUNLENGTH");
+  fmt::print(writer.out(), "SPACINGTABLE\n");
+  fmt::print(writer.out(), "  PARALLELRUNLENGTH");
   dbVector<uint>::const_iterator v55_itr;
   uint wddx, lndx;
 
   for (v55_itr = layer->_v55sp_length_idx.begin();
        v55_itr != layer->_v55sp_length_idx.end();
        v55_itr++)
-    fprintf(writer.out(), " %.3f", writer.lefdist(*v55_itr));
+    fmt::print(writer.out(), " {:.3f}", writer.lefdist(*v55_itr));
 
   for (wddx = 0, v55_itr = layer->_v55sp_width_idx.begin();
        v55_itr != layer->_v55sp_width_idx.end();
        wddx++, v55_itr++) {
-    fprintf(writer.out(), "\n");
-    fprintf(writer.out(), "  WIDTH %.3f\t", writer.lefdist(*v55_itr));
+    fmt::print(writer.out(), "\n");
+    fmt::print(writer.out(), "  WIDTH {:.3f}\t", writer.lefdist(*v55_itr));
     for (lndx = 0; lndx < layer->_v55sp_spacing.numCols(); lndx++)
-      fprintf(writer.out(),
-              " %.3f",
+      fmt::print(writer.out(),
+              " {:.3f}",
               writer.lefdist(layer->_v55sp_spacing(wddx, lndx)));
   }
 
-  fprintf(writer.out(), " ;\n");
+  fmt::print(writer.out(), " ;\n");
 }
 
 bool dbTechLayer::getV55SpacingTable(
@@ -1592,21 +1593,21 @@ void dbTechLayer::printTwoWidthsSpacingRules(lefout& writer) const
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
 
-  fprintf(writer.out(), "SPACINGTABLE TWOWIDTHS");
+  fmt::print(writer.out(), "SPACINGTABLE TWOWIDTHS");
   dbVector<uint>::const_iterator itr;
   uint wddx, lndx;
 
   for (wddx = 0, itr = layer->_two_widths_sp_idx.begin();
        itr != layer->_two_widths_sp_idx.end();
        wddx++, itr++) {
-    fprintf(writer.out(), "\n  WIDTH %.3f\t", writer.lefdist(*itr));
+    fmt::print(writer.out(), "\n  WIDTH {:.3f}\t", writer.lefdist(*itr));
     for (lndx = 0; lndx < layer->_two_widths_sp_spacing.numCols(); lndx++)
-      fprintf(writer.out(),
-              " %.3f",
+      fmt::print(writer.out(),
+              " {:.3f}",
               writer.lefdist(layer->_two_widths_sp_spacing(wddx, lndx)));
   }
 
-  fprintf(writer.out(), " ;\n");
+  fmt::print(writer.out(), " ;\n");
 }
 
 uint dbTechLayer::getTwoWidthsSpacingTableEntry(uint row, uint col) const
@@ -1836,12 +1837,12 @@ void dbTechLayer::writeAntennaRulesLef(lefout& writer) const
   bool prt_model = (hasDefaultAntennaRule() && hasOxide2AntennaRule());
 
   if (prt_model)
-    fprintf(writer.out(), "    ANTENNAMODEL OXIDE1 ;\n");
+    fmt::print(writer.out(), "    ANTENNAMODEL OXIDE1 ;\n");
   if (hasDefaultAntennaRule())
     getDefaultAntennaRule()->writeLef(writer);
 
   if (prt_model)
-    fprintf(writer.out(), "    ANTENNAMODEL OXIDE2 ;\n");
+    fmt::print(writer.out(), "    ANTENNAMODEL OXIDE2 ;\n");
   if (hasOxide2AntennaRule())
     getOxide2AntennaRule()->writeLef(writer);
 }

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -32,6 +32,8 @@
 
 #include "dbTechLayerAntennaRule.h"
 
+#include <spdlog/fmt/ostr.h>
+
 #include "db.h"
 #include "dbDatabase.h"
 #include "dbMaster.h"
@@ -438,31 +440,31 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
   _dbTechLayerAntennaRule* ant_rule = (_dbTechLayerAntennaRule*) this;
 
   if (ant_rule->_area_mult._explicit) {
-    fprintf(writer.out(),
-            "    ANTENNAAREAFACTOR %g %s;\n",
+    fmt::print(writer.out(),
+            "    ANTENNAAREAFACTOR {:g} {};\n",
             ant_rule->_area_mult._factor,
             ant_rule->_area_mult._diff_use_only ? "DIFFUSEONLY " : "");
   }
 
   if (ant_rule->_has_antenna_cumroutingpluscut) {
-    fprintf(writer.out(), "    ANTENNACUMROUTINGPLUSCUT ;\n");
+    fmt::print(writer.out(), "    ANTENNACUMROUTINGPLUSCUT ;\n");
   }
 
   if (ant_rule->_gate_plus_diff_factor > 0.0) {
-    fprintf(writer.out(),
-            "    ANTENNAGATEPLUSDIFF %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNAGATEPLUSDIFF {:g} ;\n",
             ant_rule->_gate_plus_diff_factor);
   }
 
   if (ant_rule->_area_minus_diff_factor > 0.0) {
-    fprintf(writer.out(),
-            "    ANTENNAAREAMINUSDIFF %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNAAREAMINUSDIFF {:g} ;\n",
             ant_rule->_area_minus_diff_factor);
   }
 
   if (ant_rule->_sidearea_mult._explicit) {
-    fprintf(writer.out(),
-            "    ANTENNASIDEAREAFACTOR %g %s;\n",
+    fmt::print(writer.out(),
+            "    ANTENNASIDEAREAFACTOR {:g} {};\n",
             ant_rule->_sidearea_mult._factor,
             ant_rule->_sidearea_mult._diff_use_only ? "DIFFUSEONLY" : "");
   }
@@ -471,102 +473,102 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
   dbVector<double>::const_iterator ratio_itr;
 
   if (ant_rule->_par_area_val._ratio > 0)
-    fprintf(writer.out(),
-            "    ANTENNAAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNAAREARATIO {:g} ;\n",
             ant_rule->_par_area_val._ratio);
 
   if ((ant_rule->_par_area_val._diff_ratio.size() == 1)
       && (ant_rule->_par_area_val._diff_ratio[0] > 0))
-    fprintf(writer.out(),
-            "    ANTENNADIFFAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNADIFFAREARATIO {:g} ;\n",
             ant_rule->_par_area_val._diff_ratio[0]);
 
   if (ant_rule->_par_area_val._diff_ratio.size() > 1) {
-    fprintf(writer.out(), "    ANTENNADIFFAREARATIO  PWL ( ");
+    fmt::print(writer.out(), "    ANTENNADIFFAREARATIO  PWL ( ");
     for (diffdx_itr = ant_rule->_par_area_val._diff_idx.begin(),
         ratio_itr = ant_rule->_par_area_val._diff_ratio.begin();
          diffdx_itr != ant_rule->_par_area_val._diff_idx.end()
          && ratio_itr != ant_rule->_par_area_val._diff_ratio.end();
          diffdx_itr++, ratio_itr++)
-      fprintf(writer.out(), "( %g %g ) ", *diffdx_itr, *ratio_itr);
-    fprintf(writer.out(), ") ;\n");
+      fmt::print(writer.out(), "( {:g} {:g} ) ", *diffdx_itr, *ratio_itr);
+    fmt::print(writer.out(), ") ;\n");
   }
 
   if (ant_rule->_cum_area_val._ratio > 0)
-    fprintf(writer.out(),
-            "    ANTENNACUMAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNACUMAREARATIO {:g} ;\n",
             ant_rule->_cum_area_val._ratio);
 
   if ((ant_rule->_cum_area_val._diff_ratio.size() == 1)
       && (ant_rule->_cum_area_val._diff_ratio[0] > 0))
-    fprintf(writer.out(),
-            "    ANTENNACUMDIFFAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNACUMDIFFAREARATIO {:g} ;\n",
             ant_rule->_cum_area_val._diff_ratio[0]);
 
   if (ant_rule->_cum_area_val._diff_ratio.size() > 1) {
-    fprintf(writer.out(), "    ANTENNACUMDIFFAREARATIO  PWL ( ");
+    fmt::print(writer.out(), "    ANTENNACUMDIFFAREARATIO  PWL ( ");
     for (diffdx_itr = ant_rule->_cum_area_val._diff_idx.begin(),
         ratio_itr = ant_rule->_cum_area_val._diff_ratio.begin();
          diffdx_itr != ant_rule->_cum_area_val._diff_idx.end()
          && ratio_itr != ant_rule->_cum_area_val._diff_ratio.end();
          diffdx_itr++, ratio_itr++)
-      fprintf(writer.out(), "( %g %g ) ", *diffdx_itr, *ratio_itr);
-    fprintf(writer.out(), ") ;\n");
+      fmt::print(writer.out(), "( {:g} {:g} ) ", *diffdx_itr, *ratio_itr);
+    fmt::print(writer.out(), ") ;\n");
   }
 
   if (ant_rule->_par_sidearea_val._ratio > 0)
-    fprintf(writer.out(),
-            "    ANTENNASIDEAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNASIDEAREARATIO {:g} ;\n",
             ant_rule->_par_sidearea_val._ratio);
 
   if ((ant_rule->_par_sidearea_val._diff_ratio.size() == 1)
       && (ant_rule->_par_sidearea_val._diff_ratio[0] > 0))
-    fprintf(writer.out(),
-            "    ANTENNADIFFSIDEAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNADIFFSIDEAREARATIO {:g} ;\n",
             ant_rule->_par_sidearea_val._diff_ratio[0]);
 
   if (ant_rule->_par_sidearea_val._diff_ratio.size() > 1) {
-    fprintf(writer.out(), "    ANTENNADIFFSIDEAREARATIO  PWL ( ");
+    fmt::print(writer.out(), "    ANTENNADIFFSIDEAREARATIO  PWL ( ");
     for (diffdx_itr = ant_rule->_par_sidearea_val._diff_idx.begin(),
         ratio_itr = ant_rule->_par_sidearea_val._diff_ratio.begin();
          diffdx_itr != ant_rule->_par_sidearea_val._diff_idx.end()
          && ratio_itr != ant_rule->_par_sidearea_val._diff_ratio.end();
          diffdx_itr++, ratio_itr++)
-      fprintf(writer.out(), "( %g %g ) ", *diffdx_itr, *ratio_itr);
-    fprintf(writer.out(), ") ;\n");
+      fmt::print(writer.out(), "( {:g} {:g} ) ", *diffdx_itr, *ratio_itr);
+    fmt::print(writer.out(), ") ;\n");
   }
 
   if (ant_rule->_cum_sidearea_val._ratio > 0)
-    fprintf(writer.out(),
-            "    ANTENNACUMSIDEAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNACUMSIDEAREARATIO {:g} ;\n",
             ant_rule->_cum_sidearea_val._ratio);
 
   if ((ant_rule->_cum_sidearea_val._diff_ratio.size() == 1)
       && (ant_rule->_cum_sidearea_val._diff_ratio[0] > 0))
-    fprintf(writer.out(),
-            "    ANTENNACUMDIFFSIDEAREARATIO %g ;\n",
+    fmt::print(writer.out(),
+            "    ANTENNACUMDIFFSIDEAREARATIO {:g} ;\n",
             ant_rule->_cum_sidearea_val._diff_ratio[0]);
 
   if (ant_rule->_cum_sidearea_val._diff_ratio.size() > 1) {
-    fprintf(writer.out(), "    ANTENNACUMDIFFSIDEAREARATIO  PWL ( ");
+    fmt::print(writer.out(), "    ANTENNACUMDIFFSIDEAREARATIO  PWL ( ");
     for (diffdx_itr = ant_rule->_cum_sidearea_val._diff_idx.begin(),
         ratio_itr = ant_rule->_cum_sidearea_val._diff_ratio.begin();
          diffdx_itr != ant_rule->_cum_sidearea_val._diff_idx.end()
          && ratio_itr != ant_rule->_cum_sidearea_val._diff_ratio.end();
          diffdx_itr++, ratio_itr++)
-      fprintf(writer.out(), "( %g %g ) ", *diffdx_itr, *ratio_itr);
-    fprintf(writer.out(), ") ;\n");
+      fmt::print(writer.out(), "( {:g} {:g} ) ", *diffdx_itr, *ratio_itr);
+    fmt::print(writer.out(), ") ;\n");
   }
 
   if (ant_rule->_area_diff_reduce_val._diff_ratio.size() > 1) {
-    fprintf(writer.out(), "    ANTENNAAREADIFFREDUCEPWL ( ");
+    fmt::print(writer.out(), "    ANTENNAAREADIFFREDUCEPWL ( ");
     for (diffdx_itr = ant_rule->_area_diff_reduce_val._diff_idx.begin(),
         ratio_itr = ant_rule->_area_diff_reduce_val._diff_ratio.begin();
          diffdx_itr != ant_rule->_area_diff_reduce_val._diff_idx.end()
          && ratio_itr != ant_rule->_area_diff_reduce_val._diff_ratio.end();
          diffdx_itr++, ratio_itr++)
-      fprintf(writer.out(), "( %g %g ) ", *diffdx_itr, *ratio_itr);
-    fprintf(writer.out(), ") ;\n");
+      fmt::print(writer.out(), "( {:g} {:g} ) ", *diffdx_itr, *ratio_itr);
+    fmt::print(writer.out(), ") ;\n");
   }
 }
 
@@ -872,12 +874,12 @@ void _dbTechAntennaAreaElement::writeLef(const char* header,
                                          dbTech* tech,
                                          lefout& writer) const
 {
-  fprintf(writer.out(), "        %s %g ", header, _area);
+  fmt::print(writer.out(), "        {} {:g} ", header, _area);
   if (_lyidx != dbIdValidation::invalidId())
-    fprintf(writer.out(),
-            "LAYER %s ",
+    fmt::print(writer.out(),
+            "LAYER {} ",
             dbTechLayer::getTechLayer(tech, _lyidx)->getName().c_str());
-  fprintf(writer.out(), ";\n");
+  fmt::print(writer.out(), ";\n");
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -441,9 +441,9 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_area_mult._explicit) {
     fmt::print(writer.out(),
-            "    ANTENNAAREAFACTOR {:g} {};\n",
-            ant_rule->_area_mult._factor,
-            ant_rule->_area_mult._diff_use_only ? "DIFFUSEONLY " : "");
+               "    ANTENNAAREAFACTOR {:g} {};\n",
+               ant_rule->_area_mult._factor,
+               ant_rule->_area_mult._diff_use_only ? "DIFFUSEONLY " : "");
   }
 
   if (ant_rule->_has_antenna_cumroutingpluscut) {
@@ -452,21 +452,21 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_gate_plus_diff_factor > 0.0) {
     fmt::print(writer.out(),
-            "    ANTENNAGATEPLUSDIFF {:g} ;\n",
-            ant_rule->_gate_plus_diff_factor);
+               "    ANTENNAGATEPLUSDIFF {:g} ;\n",
+               ant_rule->_gate_plus_diff_factor);
   }
 
   if (ant_rule->_area_minus_diff_factor > 0.0) {
     fmt::print(writer.out(),
-            "    ANTENNAAREAMINUSDIFF {:g} ;\n",
-            ant_rule->_area_minus_diff_factor);
+               "    ANTENNAAREAMINUSDIFF {:g} ;\n",
+               ant_rule->_area_minus_diff_factor);
   }
 
   if (ant_rule->_sidearea_mult._explicit) {
     fmt::print(writer.out(),
-            "    ANTENNASIDEAREAFACTOR {:g} {};\n",
-            ant_rule->_sidearea_mult._factor,
-            ant_rule->_sidearea_mult._diff_use_only ? "DIFFUSEONLY" : "");
+               "    ANTENNASIDEAREAFACTOR {:g} {};\n",
+               ant_rule->_sidearea_mult._factor,
+               ant_rule->_sidearea_mult._diff_use_only ? "DIFFUSEONLY" : "");
   }
 
   dbVector<double>::const_iterator diffdx_itr;
@@ -474,14 +474,14 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_par_area_val._ratio > 0)
     fmt::print(writer.out(),
-            "    ANTENNAAREARATIO {:g} ;\n",
-            ant_rule->_par_area_val._ratio);
+               "    ANTENNAAREARATIO {:g} ;\n",
+               ant_rule->_par_area_val._ratio);
 
   if ((ant_rule->_par_area_val._diff_ratio.size() == 1)
       && (ant_rule->_par_area_val._diff_ratio[0] > 0))
     fmt::print(writer.out(),
-            "    ANTENNADIFFAREARATIO {:g} ;\n",
-            ant_rule->_par_area_val._diff_ratio[0]);
+               "    ANTENNADIFFAREARATIO {:g} ;\n",
+               ant_rule->_par_area_val._diff_ratio[0]);
 
   if (ant_rule->_par_area_val._diff_ratio.size() > 1) {
     fmt::print(writer.out(), "    ANTENNADIFFAREARATIO  PWL ( ");
@@ -496,14 +496,14 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_cum_area_val._ratio > 0)
     fmt::print(writer.out(),
-            "    ANTENNACUMAREARATIO {:g} ;\n",
-            ant_rule->_cum_area_val._ratio);
+               "    ANTENNACUMAREARATIO {:g} ;\n",
+               ant_rule->_cum_area_val._ratio);
 
   if ((ant_rule->_cum_area_val._diff_ratio.size() == 1)
       && (ant_rule->_cum_area_val._diff_ratio[0] > 0))
     fmt::print(writer.out(),
-            "    ANTENNACUMDIFFAREARATIO {:g} ;\n",
-            ant_rule->_cum_area_val._diff_ratio[0]);
+               "    ANTENNACUMDIFFAREARATIO {:g} ;\n",
+               ant_rule->_cum_area_val._diff_ratio[0]);
 
   if (ant_rule->_cum_area_val._diff_ratio.size() > 1) {
     fmt::print(writer.out(), "    ANTENNACUMDIFFAREARATIO  PWL ( ");
@@ -518,14 +518,14 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_par_sidearea_val._ratio > 0)
     fmt::print(writer.out(),
-            "    ANTENNASIDEAREARATIO {:g} ;\n",
-            ant_rule->_par_sidearea_val._ratio);
+               "    ANTENNASIDEAREARATIO {:g} ;\n",
+               ant_rule->_par_sidearea_val._ratio);
 
   if ((ant_rule->_par_sidearea_val._diff_ratio.size() == 1)
       && (ant_rule->_par_sidearea_val._diff_ratio[0] > 0))
     fmt::print(writer.out(),
-            "    ANTENNADIFFSIDEAREARATIO {:g} ;\n",
-            ant_rule->_par_sidearea_val._diff_ratio[0]);
+               "    ANTENNADIFFSIDEAREARATIO {:g} ;\n",
+               ant_rule->_par_sidearea_val._diff_ratio[0]);
 
   if (ant_rule->_par_sidearea_val._diff_ratio.size() > 1) {
     fmt::print(writer.out(), "    ANTENNADIFFSIDEAREARATIO  PWL ( ");
@@ -540,14 +540,14 @@ void dbTechLayerAntennaRule::writeLef(lefout& writer) const
 
   if (ant_rule->_cum_sidearea_val._ratio > 0)
     fmt::print(writer.out(),
-            "    ANTENNACUMSIDEAREARATIO {:g} ;\n",
-            ant_rule->_cum_sidearea_val._ratio);
+               "    ANTENNACUMSIDEAREARATIO {:g} ;\n",
+               ant_rule->_cum_sidearea_val._ratio);
 
   if ((ant_rule->_cum_sidearea_val._diff_ratio.size() == 1)
       && (ant_rule->_cum_sidearea_val._diff_ratio[0] > 0))
     fmt::print(writer.out(),
-            "    ANTENNACUMDIFFSIDEAREARATIO {:g} ;\n",
-            ant_rule->_cum_sidearea_val._diff_ratio[0]);
+               "    ANTENNACUMDIFFSIDEAREARATIO {:g} ;\n",
+               ant_rule->_cum_sidearea_val._diff_ratio[0]);
 
   if (ant_rule->_cum_sidearea_val._diff_ratio.size() > 1) {
     fmt::print(writer.out(), "    ANTENNACUMDIFFSIDEAREARATIO  PWL ( ");
@@ -877,8 +877,8 @@ void _dbTechAntennaAreaElement::writeLef(const char* header,
   fmt::print(writer.out(), "        {} {:g} ", header, _area);
   if (_lyidx != dbIdValidation::invalidId())
     fmt::print(writer.out(),
-            "LAYER {} ",
-            dbTechLayer::getTechLayer(tech, _lyidx)->getName().c_str());
+               "LAYER {} ",
+               dbTechLayer::getTechLayer(tech, _lyidx)->getName().c_str());
   fmt::print(writer.out(), ";\n");
 }
 

--- a/src/odb/src/db/dbTechLayerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingRule.cpp
@@ -739,9 +739,9 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
 
   if (getRange(rmin, rmax)) {
     fmt::print(writer.out(),
-            "RANGE {:g} {:g} ",
-            writer.lefdist(rmin),
-            writer.lefdist(rmax));
+               "RANGE {:g} {:g} ",
+               writer.lefdist(rmin),
+               writer.lefdist(rmax));
     if (hasUseLengthThreshold())
       fmt::print(writer.out(), "USELENGTHTHRESHOLD ");
     else if (getInfluence(length_or_influence)) {
@@ -749,24 +749,24 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
           writer.out(), "INFLUENCE {:g} ", writer.lefdist(length_or_influence));
       if (getInfluenceRange(rmin, rmax))
         fmt::print(writer.out(),
-                "RANGE {:g} {:g} ",
-                writer.lefdist(rmin),
-                writer.lefdist(rmax));
+                   "RANGE {:g} {:g} ",
+                   writer.lefdist(rmin),
+                   writer.lefdist(rmax));
     } else if (getRangeRange(rmin, rmax)) {
       fmt::print(writer.out(),
-              "RANGE {:g} {:g} ",
-              writer.lefdist(rmin),
-              writer.lefdist(rmax));
+                 "RANGE {:g} {:g} ",
+                 writer.lefdist(rmin),
+                 writer.lefdist(rmax));
     }
   } else if (getLengthThreshold(length_or_influence)) {
     fmt::print(writer.out(),
-            "_dbTechLayerSpacingRule::LENGTHTHRESHOLD {:g} ",
-            writer.lefdist(length_or_influence));
+               "_dbTechLayerSpacingRule::LENGTHTHRESHOLD {:g} ",
+               writer.lefdist(length_or_influence));
     if (getLengthThresholdRange(rmin, rmax))
       fmt::print(writer.out(),
-              "RANGE {:g} {:g} ",
-              writer.lefdist(rmin),
-              writer.lefdist(rmax));
+                 "RANGE {:g} {:g} ",
+                 writer.lefdist(rmin),
+                 writer.lefdist(rmax));
   } else if (getCutLayer4Spacing(rulely)) {
     fmt::print(writer.out(), "LAYER {} ", rulely->getName().c_str());
   } else if (getAdjacentCuts(numcuts,
@@ -774,9 +774,9 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
                              cut_spacing,
                              except_same_pgnet)) {
     fmt::print(writer.out(),
-            "ADJACENTCUTS {} WITHIN {:g} ",
-            numcuts,
-            writer.lefdist(length_or_influence));
+               "ADJACENTCUTS {} WITHIN {:g} ",
+               numcuts,
+               writer.lefdist(length_or_influence));
     if (except_same_pgnet) {
       fmt::print(writer.out(), "EXCEPTSAMEPGNET ");
     }
@@ -790,14 +790,14 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
                parallelWithin,
                twoEdges)) {
       fmt::print(writer.out(),
-              "ENDOFLINE {:g} WITHIN {:g} ",
-              writer.lefdist(width),
-              writer.lefdist(within));
+                 "ENDOFLINE {:g} WITHIN {:g} ",
+                 writer.lefdist(width),
+                 writer.lefdist(within));
       if (parallelEdge) {
         fmt::print(writer.out(),
-                "PARALLELEDGE {:g} WITHIN {:g} ",
-                writer.lefdist(parallelSpace),
-                writer.lefdist(parallelWithin));
+                   "PARALLELEDGE {:g} WITHIN {:g} ",
+                   writer.lefdist(parallelSpace),
+                   writer.lefdist(parallelWithin));
         if (twoEdges)
           fmt::print(writer.out(), " TWOEDGES ");
       }
@@ -839,10 +839,10 @@ void dbTechV55InfluenceEntry::writeLef(lefout& writer) const
 
   getV55InfluenceEntry(inf_width, inf_within, inf_spacing);
   fmt::print(writer.out(),
-          "\n   WIDTH {:g} WITHIN {:g} SPACING {:g}",
-          writer.lefdist(inf_width),
-          writer.lefdist(inf_within),
-          writer.lefdist(inf_spacing));
+             "\n   WIDTH {:g} WITHIN {:g} SPACING {:g}",
+             writer.lefdist(inf_width),
+             writer.lefdist(inf_within),
+             writer.lefdist(inf_spacing));
 }
 
 dbTechV55InfluenceEntry* dbTechV55InfluenceEntry::create(dbTechLayer* inly)

--- a/src/odb/src/db/dbTechLayerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingRule.cpp
@@ -32,6 +32,8 @@
 
 #include "dbTechLayerSpacingRule.h"
 
+#include <spdlog/fmt/ostr.h>
+
 #include "db.h"
 #include "dbDatabase.h"
 #include "dbTable.h"
@@ -717,66 +719,66 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
   bool except_same_pgnet;
   dbTechLayer* rulely;
 
-  fprintf(writer.out(), "    SPACING %g ", writer.lefdist(getSpacing()));
+  fmt::print(writer.out(), "    SPACING {:g} ", writer.lefdist(getSpacing()));
 
   if (getCutCenterToCenter()) {
-    fprintf(writer.out(), "    CENTERTOCENTER ");
+    fmt::print(writer.out(), "    CENTERTOCENTER ");
   }
 
   if (getCutSameNet()) {
-    fprintf(writer.out(), "    SAMENET ");
+    fmt::print(writer.out(), "    SAMENET ");
   }
 
   if (getCutParallelOverlap()) {
-    fprintf(writer.out(), "    PARALLELOVERLAP ");
+    fmt::print(writer.out(), "    PARALLELOVERLAP ");
   }
 
   if (getCutArea() > 0) {
-    fprintf(writer.out(), "    AREA %g ", writer.lefdist(getCutArea()));
+    fmt::print(writer.out(), "    AREA {:g} ", writer.lefdist(getCutArea()));
   }
 
   if (getRange(rmin, rmax)) {
-    fprintf(writer.out(),
-            "RANGE %g %g ",
+    fmt::print(writer.out(),
+            "RANGE {:g} {:g} ",
             writer.lefdist(rmin),
             writer.lefdist(rmax));
     if (hasUseLengthThreshold())
-      fprintf(writer.out(), "USELENGTHTHRESHOLD ");
+      fmt::print(writer.out(), "USELENGTHTHRESHOLD ");
     else if (getInfluence(length_or_influence)) {
-      fprintf(
-          writer.out(), "INFLUENCE %g ", writer.lefdist(length_or_influence));
+      fmt::print(
+          writer.out(), "INFLUENCE {:g} ", writer.lefdist(length_or_influence));
       if (getInfluenceRange(rmin, rmax))
-        fprintf(writer.out(),
-                "RANGE %g %g ",
+        fmt::print(writer.out(),
+                "RANGE {:g} {:g} ",
                 writer.lefdist(rmin),
                 writer.lefdist(rmax));
     } else if (getRangeRange(rmin, rmax)) {
-      fprintf(writer.out(),
-              "RANGE %g %g ",
+      fmt::print(writer.out(),
+              "RANGE {:g} {:g} ",
               writer.lefdist(rmin),
               writer.lefdist(rmax));
     }
   } else if (getLengthThreshold(length_or_influence)) {
-    fprintf(writer.out(),
-            "_dbTechLayerSpacingRule::LENGTHTHRESHOLD %g ",
+    fmt::print(writer.out(),
+            "_dbTechLayerSpacingRule::LENGTHTHRESHOLD {:g} ",
             writer.lefdist(length_or_influence));
     if (getLengthThresholdRange(rmin, rmax))
-      fprintf(writer.out(),
-              "RANGE %g %g ",
+      fmt::print(writer.out(),
+              "RANGE {:g} {:g} ",
               writer.lefdist(rmin),
               writer.lefdist(rmax));
   } else if (getCutLayer4Spacing(rulely)) {
-    fprintf(writer.out(), "LAYER %s ", rulely->getName().c_str());
+    fmt::print(writer.out(), "LAYER {} ", rulely->getName().c_str());
   } else if (getAdjacentCuts(numcuts,
                              length_or_influence,
                              cut_spacing,
                              except_same_pgnet)) {
-    fprintf(writer.out(),
-            "ADJACENTCUTS %d WITHIN %g ",
+    fmt::print(writer.out(),
+            "ADJACENTCUTS {} WITHIN {:g} ",
             numcuts,
             writer.lefdist(length_or_influence));
     if (except_same_pgnet) {
-      fprintf(writer.out(), "EXCEPTSAMEPGNET ");
+      fmt::print(writer.out(), "EXCEPTSAMEPGNET ");
     }
   } else {
     uint width, within, parallelSpace, parallelWithin;
@@ -787,21 +789,21 @@ void dbTechLayerSpacingRule::writeLef(lefout& writer) const
                parallelSpace,
                parallelWithin,
                twoEdges)) {
-      fprintf(writer.out(),
-              "ENDOFLINE %g WITHIN %g ",
+      fmt::print(writer.out(),
+              "ENDOFLINE {:g} WITHIN {:g} ",
               writer.lefdist(width),
               writer.lefdist(within));
       if (parallelEdge) {
-        fprintf(writer.out(),
-                "PARALLELEDGE %g WITHIN %g ",
+        fmt::print(writer.out(),
+                "PARALLELEDGE {:g} WITHIN {:g} ",
                 writer.lefdist(parallelSpace),
                 writer.lefdist(parallelWithin));
         if (twoEdges)
-          fprintf(writer.out(), " TWOEDGES ");
+          fmt::print(writer.out(), " TWOEDGES ");
       }
     }
   }
-  fprintf(writer.out(), " ;\n");
+  fmt::print(writer.out(), " ;\n");
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -836,8 +838,8 @@ void dbTechV55InfluenceEntry::writeLef(lefout& writer) const
   uint inf_width, inf_within, inf_spacing;
 
   getV55InfluenceEntry(inf_width, inf_within, inf_spacing);
-  fprintf(writer.out(),
-          "\n   WIDTH %g WITHIN %g SPACING %g",
+  fmt::print(writer.out(),
+          "\n   WIDTH {:g} WITHIN {:g} SPACING {:g}",
           writer.lefdist(inf_width),
           writer.lefdist(inf_within),
           writer.lefdist(inf_spacing));

--- a/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
+++ b/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
@@ -292,28 +292,28 @@ void dbTechMinCutRule::writeLef(lefout& writer) const
   uint numcuts = 0;
   uint cut_width = 0;
   getMinimumCuts(numcuts, cut_width);
-  fprintf(writer.out(),
-          "    MINIMUMCUT %d  WIDTH %g ",
+  fmt::print(writer.out(),
+          "    MINIMUMCUT {}  WIDTH {:g} ",
           numcuts,
           writer.lefdist(cut_width));
 
   uint cut_distance;
   if (getCutDistance(cut_distance)) {
-    fprintf(writer.out(), "WITHIN %g ", writer.lefdist(cut_distance));
+    fmt::print(writer.out(), "WITHIN {:g} ", writer.lefdist(cut_distance));
   }
 
   if (isAboveOnly())
-    fprintf(writer.out(), "FROMABOVE ");
+    fmt::print(writer.out(), "{}", "FROMABOVE ");
   else if (isBelowOnly())
-    fprintf(writer.out(), "FROMBELOW ");
+    fmt::print(writer.out(), "{}",  "FROMBELOW ");
 
   uint length, distance;
   if (getLengthForCuts(length, distance))
-    fprintf(writer.out(),
-            "LENGTH %g  WITHIN %g ",
+    fmt::print(writer.out(),
+            "LENGTH {:g}  WITHIN {:g} ",
             writer.lefdist(length),
             writer.lefdist(distance));
-  fprintf(writer.out(), ";\n");
+  fmt::print(writer.out(), ";\n");
 }
 
 dbTechMinCutRule* dbTechMinCutRule::create(dbTechLayer* inly)
@@ -373,10 +373,10 @@ void dbTechMinEncRule::writeLef(lefout& writer) const
 {
   uint enc_area, enc_width;
   getEnclosure(enc_area);
-  fprintf(writer.out(), "    MINENCLOSEDAREA %g ", writer.lefarea(enc_area));
+  fmt::print(writer.out(), "    MINENCLOSEDAREA {:g} ", writer.lefarea(enc_area));
   if (getEnclosureWidth(enc_width))
-    fprintf(writer.out(), "WIDTH %g ", writer.lefdist(enc_width));
-  fprintf(writer.out(), ";\n");
+    fmt::print(writer.out(), "WIDTH {:g} ", writer.lefdist(enc_width));
+  fmt::print(writer.out(), "{}", ";\n");
 }
 
 dbTechMinEncRule* dbTechMinEncRule::create(dbTechLayer* inly)

--- a/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
+++ b/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
@@ -293,9 +293,9 @@ void dbTechMinCutRule::writeLef(lefout& writer) const
   uint cut_width = 0;
   getMinimumCuts(numcuts, cut_width);
   fmt::print(writer.out(),
-          "    MINIMUMCUT {}  WIDTH {:g} ",
-          numcuts,
-          writer.lefdist(cut_width));
+             "    MINIMUMCUT {}  WIDTH {:g} ",
+             numcuts,
+             writer.lefdist(cut_width));
 
   uint cut_distance;
   if (getCutDistance(cut_distance)) {
@@ -305,14 +305,14 @@ void dbTechMinCutRule::writeLef(lefout& writer) const
   if (isAboveOnly())
     fmt::print(writer.out(), "{}", "FROMABOVE ");
   else if (isBelowOnly())
-    fmt::print(writer.out(), "{}",  "FROMBELOW ");
+    fmt::print(writer.out(), "{}", "FROMBELOW ");
 
   uint length, distance;
   if (getLengthForCuts(length, distance))
     fmt::print(writer.out(),
-            "LENGTH {:g}  WITHIN {:g} ",
-            writer.lefdist(length),
-            writer.lefdist(distance));
+               "LENGTH {:g}  WITHIN {:g} ",
+               writer.lefdist(length),
+               writer.lefdist(distance));
   fmt::print(writer.out(), ";\n");
 }
 
@@ -373,7 +373,8 @@ void dbTechMinEncRule::writeLef(lefout& writer) const
 {
   uint enc_area, enc_width;
   getEnclosure(enc_area);
-  fmt::print(writer.out(), "    MINENCLOSEDAREA {:g} ", writer.lefarea(enc_area));
+  fmt::print(
+      writer.out(), "    MINENCLOSEDAREA {:g} ", writer.lefarea(enc_area));
   if (getEnclosureWidth(enc_width))
     fmt::print(writer.out(), "WIDTH {:g} ", writer.lefdist(enc_width));
   fmt::print(writer.out(), "{}", ";\n");

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -32,6 +32,7 @@
 
 #include "odb/lefout.h"
 
+#include <spdlog/fmt/ostr.h>
 #include <stdio.h>
 
 #include <algorithm>
@@ -79,7 +80,7 @@ void lefout::insertObstruction(dbTechLayer* layer,
 
 void lefout::writeVersion(const char* version)
 {
-  fprintf(_out, "VERSION %s ;\n", version);
+  fmt::print(_out, "VERSION {} ;\n", version);
 }
 
 template <typename GenericBox>
@@ -107,12 +108,12 @@ void lefout::writeBoxes(dbSet<GenericBox>& boxes, const char* indent)
 
       int x, y;
       box->getViaXY(x, y);
-      fprintf(_out,
-              "%sVIA %.11g %.11g %s ;\n",
-              indent,
-              lefdist(x),
-              lefdist(y),
-              via_name.c_str());
+      fmt::print(_out,
+                 "{}VIA {:.11g} {:.11g} {} ;\n",
+                 indent,
+                 lefdist(x),
+                 lefdist(y),
+                 via_name.c_str());
       cur_layer = NULL;
     } else {
       std::string layer_name;
@@ -122,7 +123,7 @@ void lefout::writeBoxes(dbSet<GenericBox>& boxes, const char* indent)
         layer_name = layer->getName();
 
       if (cur_layer != layer) {
-        fprintf(_out, "%sLAYER %s ;\n", indent, layer_name.c_str());
+        fmt::print(_out, "{}LAYER {} ;\n", indent, layer_name.c_str());
         cur_layer = layer;
       }
 
@@ -138,13 +139,13 @@ void lefout::writeBox(const std::string& indent, dbBox* box)
   int x2 = box->xMax();
   int y2 = box->yMax();
 
-  fprintf(_out,
-          "%s  RECT  %.11g %.11g %.11g %.11g ;\n",
-          indent.c_str(),
-          lefdist(x1),
-          lefdist(y1),
-          lefdist(x2),
-          lefdist(y2));
+  fmt::print(_out,
+             "{}  RECT  {:.11g} {:.11g} {:.11g} {:.11g} ;\n",
+             indent.c_str(),
+             lefdist(x1),
+             lefdist(y1),
+             lefdist(x2),
+             lefdist(y2));
 }
 
 void lefout::writeRect(const std::string& indent,
@@ -155,13 +156,13 @@ void lefout::writeRect(const std::string& indent,
   int x2 = boost::polygon::xh(rect);
   int y2 = boost::polygon::yh(rect);
 
-  fprintf(_out,
-          "%s  RECT  %.11g %.11g %.11g %.11g ;\n",
-          indent.c_str(),
-          lefdist(x1),
-          lefdist(y1),
-          lefdist(x2),
-          lefdist(y2));
+  fmt::print(_out,
+             "{}  RECT  {:.11g} {:.11g} {:.11g} {:.11g} ;\n",
+             indent.c_str(),
+             lefdist(x1),
+             lefdist(y1),
+             lefdist(x2),
+             lefdist(y2));
 }
 
 void lefout::writeHeader(dbBlock* db_block)
@@ -192,10 +193,10 @@ void lefout::writeObstructions(dbBlock* db_block)
   ObstructionMap obstructions;
   getObstructions(db_block, obstructions);
 
-  fprintf(_out, "  OBS\n");
+  fmt::print(_out, "{}", "  OBS\n");
   dbBox* block_bounding_box = db_block->getBBox();
   for (const auto& [tech_layer, polySet] : obstructions) {
-    fprintf(_out, "    LAYER %s ;\n", tech_layer->getName().c_str());
+    fmt::print(_out, "    LAYER {} ;\n", tech_layer->getName().c_str());
 
     if (bloat_occupied_layers_) {
       writeBox("   ", block_bounding_box);
@@ -219,7 +220,7 @@ void lefout::writeObstructions(dbBlock* db_block)
       }
     }
   }
-  fprintf(_out, "  END\n");
+  fmt::print(_out, "  END\n");
 }
 
 void lefout::getObstructions(dbBlock* db_block,
@@ -348,27 +349,27 @@ void lefout::writeHeader(dbLib* lib)
 
 void lefout::writeDividerChar(char hier_delimeter)
 {
-  fprintf(_out, "DIVIDERCHAR \"%c\" ;\n", hier_delimeter);
+  fmt::print(_out, "DIVIDERCHAR \"{}\" ;\n", hier_delimeter);
 }
 
 void lefout::writeUnits(int database_units)
 {
-  fprintf(_out, "UNITS\n");
-  fprintf(_out, "    DATABASE MICRONS %d ;\n", database_units);
-  fprintf(_out, "END UNITS\n");
+  fmt::print(_out, "{}", "UNITS\n");
+  fmt::print(_out, "    DATABASE MICRONS {} ;\n", database_units);
+  fmt::print(_out, "{}", "END UNITS\n");
 }
 
 void lefout::writeBusBitChars(char left_bus_delimeter, char right_bus_delimeter)
 {
-  fprintf(_out,
-          "BUSBITCHARS \"%c%c\" ;\n",
-          left_bus_delimeter,
-          right_bus_delimeter);
+  fmt::print(_out,
+             "BUSBITCHARS \"{}{}\" ;\n",
+             left_bus_delimeter,
+             right_bus_delimeter);
 }
 
 void lefout::writeNameCaseSensitive(const dbOnOffType on_off_type)
 {
-  fprintf(_out, "NAMESCASESENSITIVE %s ;\n", on_off_type.getString());
+  fmt::print(_out, "NAMESCASESENSITIVE {} ;\n", on_off_type.getString());
 }
 
 void lefout::writeBlock(dbBlock* db_block)
@@ -377,13 +378,13 @@ void lefout::writeBlock(dbBlock* db_block)
   double size_x = lefdist(bounding_box->xMax());
   double size_y = lefdist(bounding_box->yMax());
 
-  fprintf(_out, "MACRO %s\n", db_block->getName().c_str());
-  fprintf(_out, "  FOREIGN %s 0 0 ;\n", db_block->getName().c_str());
-  fprintf(_out, "  CLASS BLOCK ;\n");
-  fprintf(_out, "  SIZE %.11g BY %.11g ;\n", size_x, size_y);
+  fmt::print(_out, "MACRO {}\n", db_block->getName().c_str());
+  fmt::print(_out, "  FOREIGN {} 0 0 ;\n", db_block->getName().c_str());
+  fmt::print(_out, "  CLASS BLOCK ;\n");
+  fmt::print(_out, "  SIZE {:.11g} BY {:.11g} ;\n", size_x, size_y);
   writePins(db_block);
   writeObstructions(db_block);
-  fprintf(_out, "END %s\n", db_block->getName().c_str());
+  fmt::print(_out, "END {}\n", db_block->getName().c_str());
 }
 
 void lefout::writePins(dbBlock* db_block)
@@ -395,16 +396,16 @@ void lefout::writePins(dbBlock* db_block)
 void lefout::writeBlockTerms(dbBlock* db_block)
 {
   for (dbBTerm* b_term : db_block->getBTerms()) {
-    fprintf(_out, "  PIN %s\n", b_term->getName().c_str());
-    fprintf(_out, "    DIRECTION %s ;\n", b_term->getIoType().getString());
-    fprintf(_out, "    USE %s ;\n", b_term->getSigType().getString());
+    fmt::print(_out, "  PIN {}\n", b_term->getName().c_str());
+    fmt::print(_out, "    DIRECTION {} ;\n", b_term->getIoType().getString());
+    fmt::print(_out, "    USE {} ;\n", b_term->getSigType().getString());
     for (dbBPin* db_b_pin : b_term->getBPins()) {
-      fprintf(_out, "    PORT\n");
+      fmt::print(_out, "{}", "    PORT\n");
       dbSet<dbBox> term_pins = db_b_pin->getBoxes();
       writeBoxes(term_pins, "      ");
-      fprintf(_out, "    END\n");
+      fmt::print(_out, "{}", "    END\n");
     }
-    fprintf(_out, "  END %s\n", b_term->getName().c_str());
+    fmt::print(_out, "  END {}\n", b_term->getName().c_str());
   }
 }
 
@@ -418,48 +419,48 @@ void lefout::writePowerPins(dbBlock* db_block)
       // net already has pins that will be added
       continue;
     }
-    fprintf(_out, "  PIN %s\n", net->getName().c_str());
-    fprintf(_out, "    USE %s ;\n", net->getSigType().getString());
-    fprintf(
-        _out, "    DIRECTION %s ;\n", dbIoType(dbIoType::INOUT).getString());
+    fmt::print(_out, "  PIN {}\n", net->getName().c_str());
+    fmt::print(_out, "    USE {} ;\n", net->getSigType().getString());
+    fmt::print(
+        _out, "    DIRECTION {} ;\n", dbIoType(dbIoType::INOUT).getString());
     for (dbSWire* special_wire : net->getSWires()) {
-      fprintf(_out, "    PORT\n");
+      fmt::print(_out, "    PORT\n");
       dbSet<dbSBox> wires = special_wire->getWires();
       writeBoxes(wires, /*indent=*/"      ");
-      fprintf(_out, "    END\n");
+      fmt::print(_out, "    END\n");
     }
-    fprintf(_out, "  END %s\n", net->getName().c_str());
+    fmt::print(_out, "  END {}\n", net->getName().c_str());
   }
 }
 
-void lefout::writeTech(dbTech* tech)
+void lefout::writeTechBody(dbTech* tech)
 {
   assert(tech);
 
   if (tech->hasNoWireExtAtPin())
-    fprintf(_out,
-            "NOWIREEXTENSIONATPIN %s ;\n",
-            tech->getNoWireExtAtPin().getString());
+    fmt::print(_out,
+               "NOWIREEXTENSIONATPIN {} ;\n",
+               tech->getNoWireExtAtPin().getString());
 
   if (tech->hasClearanceMeasure())
-    fprintf(_out,
-            "CLEARANCEMEASURE %s ;\n",
-            tech->getClearanceMeasure().getString());
+    fmt::print(_out,
+               "CLEARANCEMEASURE {} ;\n",
+               tech->getClearanceMeasure().getString());
 
   if (tech->hasUseMinSpacingObs())
-    fprintf(_out,
-            "USEMINSPACING OBS %s ;\n",
-            tech->getUseMinSpacingObs().getString());
+    fmt::print(_out,
+               "USEMINSPACING OBS {} ;\n",
+               tech->getUseMinSpacingObs().getString());
 
   if (tech->hasUseMinSpacingPin())
-    fprintf(_out,
-            "USEMINSPACING PIN %s ;\n",
-            tech->getUseMinSpacingPin().getString());
+    fmt::print(_out,
+               "USEMINSPACING PIN {} ;\n",
+               tech->getUseMinSpacingPin().getString());
 
   if (tech->hasManufacturingGrid())
-    fprintf(_out,
-            "MANUFACTURINGGRID %.11g ;\n",
-            lefdist(tech->getManufacturingGrid()));
+    fmt::print(_out,
+               "MANUFACTURINGGRID {:.11g} ;\n",
+               lefdist(tech->getManufacturingGrid()));
 
   dbSet<dbTechLayer> layers = tech->getLayers();
   dbSet<dbTechLayer>::iterator litr;
@@ -513,13 +514,13 @@ void lefout::writeTech(dbTech* tech)
   tech->getSameNetRules(srules);
 
   if (srules.begin() != srules.end()) {
-    fprintf(_out, "\nSPACING\n");
+    fmt::print(_out, "\nSPACING\n");
 
     std::vector<dbTechSameNetRule*>::iterator sritr;
     for (sritr = srules.begin(); sritr != srules.end(); ++sritr)
       writeSameNetRule(*sritr);
 
-    fprintf(_out, "\nEND SPACING\n");
+    fmt::print(_out, "\nEND SPACING\n");
   }
 
   dbSet<dbTechNonDefaultRule> rules = tech->getNonDefaultRules();
@@ -534,10 +535,10 @@ void lefout::writeTech(dbTech* tech)
 void lefout::writeNonDefaultRule(dbTech* tech, dbTechNonDefaultRule* rule)
 {
   std::string name = rule->getName();
-  fprintf(_out, "\nNONDEFAULTRULE %s\n", name.c_str());
+  fmt::print(_out, "\nNONDEFAULTRULE {}\n", name.c_str());
 
   if (rule->getHardSpacing())
-    fprintf(_out, "HARDSPACING ;\n");
+    fmt::print(_out, "{}", "HARDSPACING ;\n");
 
   std::vector<dbTechLayerRule*> layer_rules;
   rule->getLayerRules(layer_rules);
@@ -557,13 +558,13 @@ void lefout::writeNonDefaultRule(dbTech* tech, dbTechNonDefaultRule* rule)
   rule->getSameNetRules(srules);
 
   if (srules.begin() != srules.end()) {
-    fprintf(_out, "\nSPACING\n");
+    fmt::print(_out, "\nSPACING\n");
 
     std::vector<dbTechSameNetRule*>::iterator sritr;
     for (sritr = srules.begin(); sritr != srules.end(); ++sritr)
       writeSameNetRule(*sritr);
 
-    fprintf(_out, "\nEND SPACING\n");
+    fmt::print(_out, "\nEND SPACING\n");
   }
 
   std::vector<dbTechVia*> use_vias;
@@ -573,7 +574,7 @@ void lefout::writeNonDefaultRule(dbTech* tech, dbTechNonDefaultRule* rule)
   for (uvitr = use_vias.begin(); uvitr != use_vias.end(); ++uvitr) {
     dbTechVia* via = *uvitr;
     std::string vname = via->getName();
-    fprintf(_out, "USEVIA %s ;\n", vname.c_str());
+    fmt::print(_out, "USEVIA {} ;\n", vname.c_str());
   }
 
   std::vector<dbTechViaGenerateRule*> use_rules;
@@ -583,7 +584,7 @@ void lefout::writeNonDefaultRule(dbTech* tech, dbTechNonDefaultRule* rule)
   for (uvritr = use_rules.begin(); uvritr != use_rules.end(); ++uvritr) {
     dbTechViaGenerateRule* rule = *uvritr;
     std::string rname = rule->getName();
-    fprintf(_out, "USEVIARULE %s ;\n", rname.c_str());
+    fmt::print(_out, "USEVIARULE {} ;\n", rname.c_str());
   }
 
   dbSet<dbTechLayer> layers = tech->getLayers();
@@ -595,11 +596,11 @@ void lefout::writeNonDefaultRule(dbTech* tech, dbTechNonDefaultRule* rule)
 
     if (rule->getMinCuts(layer, count)) {
       std::string lname = layer->getName();
-      fprintf(_out, "MINCUTS %s %d ;\n", lname.c_str(), count);
+      fmt::print(_out, "MINCUTS {} {} ;\n", lname.c_str(), count);
     }
   }
 
-  fprintf(_out, "\nEND %s\n", name.c_str());
+  fmt::print(_out, "\nEND {}\n", name.c_str());
 }
 
 void lefout::writeLayerRule(dbTechLayerRule* rule)
@@ -610,36 +611,38 @@ void lefout::writeLayerRule(dbTechLayerRule* rule)
     name = layer->getAlias();
   else
     name = layer->getName();
-  fprintf(_out, "\nLAYER %s\n", name.c_str());
+  fmt::print(_out, "\nLAYER {}\n", name.c_str());
 
   if (rule->getWidth())
-    fprintf(_out, "    WIDTH %.11g ;\n", lefdist(rule->getWidth()));
+    fmt::print(_out, "    WIDTH {:.11g} ;\n", lefdist(rule->getWidth()));
 
   if (rule->getSpacing())
-    fprintf(_out, "    SPACING %.11g ;\n", lefdist(rule->getSpacing()));
+    fmt::print(_out, "    SPACING {:.11g} ;\n", lefdist(rule->getSpacing()));
 
   if (rule->getWireExtension() != 0.0)
-    fprintf(
-        _out, "    WIREEXTENSION %.11g ;\n", lefdist(rule->getWireExtension()));
+    fmt::print(_out,
+               "    WIREEXTENSION {:.11g} ;\n",
+               lefdist(rule->getWireExtension()));
 
   if (rule->getResistance() != 0.0)
-    fprintf(_out, "    RESISTANCE RPERSQ %.11g ;\n", rule->getResistance());
+    fmt::print(
+        _out, "    RESISTANCE RPERSQ {:.11g} ;\n", rule->getResistance());
 
   if (rule->getCapacitance() != 0.0)
-    fprintf(
-        _out, "    CAPACITANCE CPERSQDIST %.11g ;\n", rule->getCapacitance());
+    fmt::print(
+        _out, "    CAPACITANCE CPERSQDIST {:.11g} ;\n", rule->getCapacitance());
 
   if (rule->getEdgeCapacitance() != 0.0)
-    fprintf(
-        _out, "      EDGECAPACITANCE %.11g ;\n", rule->getEdgeCapacitance());
+    fmt::print(
+        _out, "      EDGECAPACITANCE {:.11g} ;\n", rule->getEdgeCapacitance());
 
-  fprintf(_out, "END %s\n", name.c_str());
+  fmt::print(_out, "END {}\n", name.c_str());
 }
 
 void lefout::writeTechViaRule(dbTechViaRule* rule)
 {
   std::string name = rule->getName();
-  fprintf(_out, "\nVIARULE %s\n", name.c_str());
+  fmt::print(_out, "\nVIARULE {}\n", name.c_str());
 
   uint idx;
 
@@ -647,28 +650,30 @@ void lefout::writeTechViaRule(dbTechViaRule* rule)
     dbTechViaLayerRule* layrule = rule->getViaLayerRule(idx);
     dbTechLayer* layer = layrule->getLayer();
     std::string lname = layer->getName();
-    fprintf(_out, "    LAYER %s ;\n", lname.c_str());
+    fmt::print(_out, "    LAYER {} ;\n", lname.c_str());
 
     if (layrule->getDirection() == dbTechLayerDir::VERTICAL)
-      fprintf(_out, "      DIRECTION VERTICAL ;\n");
+      fmt::print(_out, "      DIRECTION VERTICAL ;\n");
     else if (layrule->getDirection() == dbTechLayerDir::HORIZONTAL)
-      fprintf(_out, "      DIRECTION HORIZONTAL ;\n");
+      fmt::print(_out, "      DIRECTION HORIZONTAL ;\n");
 
     if (layrule->hasWidth()) {
       int minW, maxW;
       layrule->getWidth(minW, maxW);
-      fprintf(
-          _out, "      WIDTH %.11g TO %.11g ;\n", lefdist(minW), lefdist(maxW));
+      fmt::print(_out,
+                 "      WIDTH {:.11g} TO {:.11g} ;\n",
+                 lefdist(minW),
+                 lefdist(maxW));
     }
   }
 
   for (idx = 0; idx < rule->getViaCount(); ++idx) {
     dbTechVia* via = rule->getVia(idx);
     std::string vname = via->getName();
-    fprintf(_out, "    VIA %s ;\n", vname.c_str());
+    fmt::print(_out, "    VIA {} ;\n", vname.c_str());
   }
 
-  fprintf(_out, "END %s\n", name.c_str());
+  fmt::print(_out, "END {}\n", name.c_str());
 }
 
 void lefout::writeTechViaGenerateRule(dbTechViaGenerateRule* rule)
@@ -676,9 +681,9 @@ void lefout::writeTechViaGenerateRule(dbTechViaGenerateRule* rule)
   std::string name = rule->getName();
 
   if (rule->isDefault())
-    fprintf(_out, "\nVIARULE %s GENERATE DEFAULT\n", name.c_str());
+    fmt::print(_out, "\nVIARULE {} GENERATE DEFAULT\n", name.c_str());
   else
-    fprintf(_out, "\nVIARULE %s GENERATE \n", name.c_str());
+    fmt::print(_out, "\nVIARULE {} GENERATE \n", name.c_str());
 
   uint idx;
 
@@ -686,63 +691,66 @@ void lefout::writeTechViaGenerateRule(dbTechViaGenerateRule* rule)
     dbTechViaLayerRule* layrule = rule->getViaLayerRule(idx);
     dbTechLayer* layer = layrule->getLayer();
     std::string lname = layer->getName();
-    fprintf(_out, "    LAYER %s ;\n", lname.c_str());
+    fmt::print(_out, "    LAYER {} ;\n", lname.c_str());
 
     if (layrule->getDirection() == dbTechLayerDir::VERTICAL)
-      fprintf(_out, "      DIRECTION VERTICAL ;\n");
+      fmt::print(_out, "      DIRECTION VERTICAL ;\n");
     else if (layrule->getDirection() == dbTechLayerDir::HORIZONTAL)
-      fprintf(_out, "      DIRECTION HORIZONTAL ;\n");
+      fmt::print(_out, "      DIRECTION HORIZONTAL ;\n");
 
     if (layrule->hasOverhang())
-      fprintf(
-          _out, "      OVERHANG %.11g ;\n", lefdist(layrule->getOverhang()));
+      fmt::print(
+          _out, "      OVERHANG {:.11g} ;\n", lefdist(layrule->getOverhang()));
 
     if (layrule->hasMetalOverhang())
-      fprintf(_out,
-              "      METALOVERHANG %.11g ;\n",
-              lefdist(layrule->getMetalOverhang()));
+      fmt::print(_out,
+                 "      METALOVERHANG {:.11g} ;\n",
+                 lefdist(layrule->getMetalOverhang()));
 
     if (layrule->hasEnclosure()) {
       int overhang1, overhang2;
       layrule->getEnclosure(overhang1, overhang2);
-      fprintf(_out,
-              "      ENCLOSURE %.11g %.11g ;\n",
-              lefdist(overhang1),
-              lefdist(overhang2));
+      fmt::print(_out,
+                 "      ENCLOSURE {:.11g} {:.11g} ;\n",
+                 lefdist(overhang1),
+                 lefdist(overhang2));
     }
 
     if (layrule->hasWidth()) {
       int minW, maxW;
       layrule->getWidth(minW, maxW);
-      fprintf(
-          _out, "      WIDTH %.11g TO %.11g ;\n", lefdist(minW), lefdist(maxW));
+      fmt::print(_out,
+                 "      WIDTH {:.11g} TO {:.11g} ;\n",
+                 lefdist(minW),
+                 lefdist(maxW));
     }
 
     if (layrule->hasRect()) {
       Rect r;
       layrule->getRect(r);
-      fprintf(_out,
-              "      RECT  %.11g %.11g  %.11g %.11g  ;\n",
-              lefdist(r.xMin()),
-              lefdist(r.yMin()),
-              lefdist(r.xMax()),
-              lefdist(r.yMax()));
+      fmt::print(_out,
+                 "      RECT  {:.11g} {:.11g}  {:.11g} {:.11g}  ;\n",
+                 lefdist(r.xMin()),
+                 lefdist(r.yMin()),
+                 lefdist(r.xMax()),
+                 lefdist(r.yMax()));
     }
 
     if (layrule->hasSpacing()) {
       int spacing_x, spacing_y;
       layrule->getSpacing(spacing_x, spacing_y);
-      fprintf(_out,
-              "      SPACING %.11g BY %.11g ;\n",
-              lefdist(spacing_x),
-              lefdist(spacing_y));
+      fmt::print(_out,
+                 "      SPACING {:.11g} BY {:.11g} ;\n",
+                 lefdist(spacing_x),
+                 lefdist(spacing_y));
     }
 
     if (layrule->hasResistance())
-      fprintf(_out, "      RESISTANCE %.11g ;\n", layrule->getResistance());
+      fmt::print(
+          _out, "      RESISTANCE {:.11g} ;\n", layrule->getResistance());
   }
 
-  fprintf(_out, "END %s\n", name.c_str());
+  fmt::print(_out, "END {}\n", name.c_str());
 }
 
 void lefout::writeSameNetRule(dbTechSameNetRule* rule)
@@ -763,17 +771,17 @@ void lefout::writeSameNetRule(dbTechSameNetRule* rule)
     n2 = l2->getName();
 
   if (rule->getAllowStackedVias())
-    fprintf(_out,
-            "  SAMENET %s %s %.11g STACK ;\n",
-            n1.c_str(),
-            n2.c_str(),
-            lefdist(rule->getSpacing()));
+    fmt::print(_out,
+               "  SAMENET {} {} {:.11g} STACK ;\n",
+               n1.c_str(),
+               n2.c_str(),
+               lefdist(rule->getSpacing()));
   else
-    fprintf(_out,
-            "  SAMENET %s %s %.11g ;\n",
-            n1.c_str(),
-            n2.c_str(),
-            lefdist(rule->getSpacing()));
+    fmt::print(_out,
+               "  SAMENET {} {} {:.11g} ;\n",
+               n1.c_str(),
+               n2.c_str(),
+               lefdist(rule->getSpacing()));
 }
 
 void lefout::writeLayer(dbTechLayer* layer)
@@ -784,42 +792,42 @@ void lefout::writeLayer(dbTechLayer* layer)
   else
     name = layer->getName();
 
-  fprintf(_out, "\nLAYER %s\n", name.c_str());
-  fprintf(_out, "    TYPE %s ;\n", layer->getType().getString());
+  fmt::print(_out, "\nLAYER {}\n", name.c_str());
+  fmt::print(_out, "    TYPE {} ;\n", layer->getType().getString());
 
   if (layer->getNumMasks() > 1)
-    fprintf(_out, "    MASK %u ;\n", layer->getNumMasks());
+    fmt::print(_out, "    MASK {} ;\n", layer->getNumMasks());
 
   if (layer->getPitch())
-    fprintf(_out, "    PITCH %.11g ;\n", lefdist(layer->getPitch()));
+    fmt::print(_out, "    PITCH {:.11g} ;\n", lefdist(layer->getPitch()));
 
   if (layer->getWidth())
-    fprintf(_out, "    WIDTH %.11g ;\n", lefdist(layer->getWidth()));
+    fmt::print(_out, "    WIDTH {:.11g} ;\n", lefdist(layer->getWidth()));
 
   if (layer->getWireExtension() != 0.0)
-    fprintf(_out,
-            "    WIREEXTENSION %.11g ;\n",
-            lefdist(layer->getWireExtension()));
+    fmt::print(_out,
+               "    WIREEXTENSION {:.11g} ;\n",
+               lefdist(layer->getWireExtension()));
 
   if (layer->hasArea())
-    fprintf(_out, "    AREA %.11g ;\n", layer->getArea());
+    fmt::print(_out, "    AREA {:.11g} ;\n", layer->getArea());
 
   uint thickness;
   if (layer->getThickness(thickness))
-    fprintf(_out, "    THICKNESS %.11g ;\n", lefdist(thickness));
+    fmt::print(_out, "    THICKNESS {:.11g} ;\n", lefdist(thickness));
 
   if (layer->hasMaxWidth())
-    fprintf(_out, "    MAXWIDTH %.11g ;\n", lefdist(layer->getMaxWidth()));
+    fmt::print(_out, "    MAXWIDTH {:.11g} ;\n", lefdist(layer->getMaxWidth()));
 
   if (layer->hasMinStep())
-    fprintf(_out, "    MINSTEP %.11g ;\n", lefdist(layer->getMinStep()));
+    fmt::print(_out, "    MINSTEP {:.11g} ;\n", lefdist(layer->getMinStep()));
 
   if (layer->hasProtrusion())
-    fprintf(_out,
-            "    PROTRUSIONWIDTH %.11g  LENGTH %.11g  WIDTH %.11g ;\n",
-            lefdist(layer->getProtrusionWidth()),
-            lefdist(layer->getProtrusionLength()),
-            lefdist(layer->getProtrusionFromWidth()));
+    fmt::print(_out,
+               "    PROTRUSIONWIDTH {:.11g}  LENGTH {:.11g}  WIDTH {:.11g} ;\n",
+               lefdist(layer->getProtrusionWidth()),
+               lefdist(layer->getProtrusionLength()),
+               lefdist(layer->getProtrusionFromWidth()));
 
   for (auto rule : layer->getV54SpacingRules()) {
     rule->writeLef(*this);
@@ -829,10 +837,10 @@ void lefout::writeLayer(dbTechLayer* layer)
     layer->printV55SpacingRules(*this);
     auto inf_rules = layer->getV55InfluenceRules();
     if (!inf_rules.empty()) {
-      fprintf(_out, "SPACINGTABLE INFLUENCE");
+      fmt::print(_out, "SPACINGTABLE INFLUENCE");
       for (auto rule : inf_rules)
         rule->writeLef(*this);
-      fprintf(_out, " ;\n");
+      fmt::print(_out, " ;\n");
     }
   }
 
@@ -853,26 +861,29 @@ void lefout::writeLayer(dbTechLayer* layer)
   layer->writeAntennaRulesLef(*this);
 
   if (layer->getDirection() != dbTechLayerDir::NONE)
-    fprintf(_out, "    DIRECTION %s ;\n", layer->getDirection().getString());
+    fmt::print(_out, "    DIRECTION {} ;\n", layer->getDirection().getString());
 
   if (layer->getResistance() != 0.0) {
     if (layer->getType() == dbTechLayerType::CUT) {
-      fprintf(_out, "    RESISTANCE %.11g ;\n", layer->getResistance());
+      fmt::print(_out, "    RESISTANCE {:.11g} ;\n", layer->getResistance());
     } else {
-      fprintf(_out, "    RESISTANCE RPERSQ %.11g ;\n", layer->getResistance());
+      fmt::print(
+          _out, "    RESISTANCE RPERSQ {:.11g} ;\n", layer->getResistance());
     }
   }
 
   if (layer->getCapacitance() != 0.0)
-    fprintf(
-        _out, "    CAPACITANCE CPERSQDIST %.11g ;\n", layer->getCapacitance());
+    fmt::print(_out,
+               "    CAPACITANCE CPERSQDIST {:.11g} ;\n",
+               layer->getCapacitance());
 
   if (layer->getEdgeCapacitance() != 0.0)
-    fprintf(_out, "    EDGECAPACITANCE %.11g ;\n", layer->getEdgeCapacitance());
+    fmt::print(
+        _out, "    EDGECAPACITANCE {:.11g} ;\n", layer->getEdgeCapacitance());
 
-  dbProperty::writeProperties(layer, _out);
+  fmt::print(_out, "{}", dbProperty::writeProperties(layer));
 
-  fprintf(_out, "END %s\n", name.c_str());
+  fmt::print(_out, "END {}\n", name.c_str());
 }
 
 void lefout::writeVia(dbTechVia* via)
@@ -880,15 +891,15 @@ void lefout::writeVia(dbTechVia* via)
   std::string name = via->getName();
 
   if (via->isDefault())
-    fprintf(_out, "\nVIA %s DEFAULT\n", name.c_str());
+    fmt::print(_out, "\nVIA {} DEFAULT\n", name.c_str());
   else
-    fprintf(_out, "\nVIA %s\n", name.c_str());
+    fmt::print(_out, "\nVIA {}\n", name.c_str());
 
   if (via->isTopOfStack())
-    fprintf(_out, "    TOPOFSTACKONLY\n");
+    fmt::print(_out, "    TOPOFSTACKONLY\n");
 
   if (via->getResistance() != 0.0)
-    fprintf(_out, "    RESISTANCE %.11g ;\n", via->getResistance());
+    fmt::print(_out, "    RESISTANCE {:.11g} ;\n", via->getResistance());
 
   dbTechViaGenerateRule* rule = via->getViaGenerateRule();
 
@@ -897,57 +908,59 @@ void lefout::writeVia(dbTechVia* via)
     writeBoxes(boxes, "    ");
   } else {
     std::string rname = rule->getName();
-    fprintf(_out, "\n    VIARULE %s \n", rname.c_str());
+    fmt::print(_out, "\n    VIARULE {} \n", rname.c_str());
 
     dbViaParams P;
     via->getViaParams(P);
 
-    fprintf(_out,
-            " + CUTSIZE %.11g %.11g ",
-            lefdist(P.getXCutSize()),
-            lefdist(P.getYCutSize()));
+    fmt::print(_out,
+               " + CUTSIZE {:.11g} {:.11g} ",
+               lefdist(P.getXCutSize()),
+               lefdist(P.getYCutSize()));
     std::string top = P.getTopLayer()->getName();
     std::string bot = P.getBottomLayer()->getName();
     std::string cut = P.getCutLayer()->getName();
-    fprintf(_out, " + LAYERS %s %s %s ", bot.c_str(), cut.c_str(), top.c_str());
-    fprintf(_out,
-            " + CUTSPACING %.11g %.11g ",
-            lefdist(P.getXCutSpacing()),
-            lefdist(P.getYCutSpacing()));
-    fprintf(_out,
-            " + ENCLOSURE %.11g %.11g %.11g %.11g ",
-            lefdist(P.getXBottomEnclosure()),
-            lefdist(P.getYBottomEnclosure()),
-            lefdist(P.getXTopEnclosure()),
-            lefdist(P.getYTopEnclosure()));
+    fmt::print(
+        _out, " + LAYERS {} {} {} ", bot.c_str(), cut.c_str(), top.c_str());
+    fmt::print(_out,
+               " + CUTSPACING {:.11g} {:.11g} ",
+               lefdist(P.getXCutSpacing()),
+               lefdist(P.getYCutSpacing()));
+    fmt::print(_out,
+               " + ENCLOSURE {:.11g} {:.11g} {:.11g} {:.11g} ",
+               lefdist(P.getXBottomEnclosure()),
+               lefdist(P.getYBottomEnclosure()),
+               lefdist(P.getXTopEnclosure()),
+               lefdist(P.getYTopEnclosure()));
 
     if ((P.getNumCutRows() != 1) || (P.getNumCutCols() != 1))
-      fprintf(_out, " + ROWCOL %d %d ", P.getNumCutRows(), P.getNumCutCols());
+      fmt::print(
+          _out, " + ROWCOL {} {} ", P.getNumCutRows(), P.getNumCutCols());
 
     if ((P.getXOrigin() != 0) || (P.getYOrigin() != 0))
-      fprintf(_out,
-              " + ORIGIN %.11g %.11g ",
-              lefdist(P.getXOrigin()),
-              lefdist(P.getYOrigin()));
+      fmt::print(_out,
+                 " + ORIGIN {:.11g} {:.11g} ",
+                 lefdist(P.getXOrigin()),
+                 lefdist(P.getYOrigin()));
 
     if ((P.getXTopOffset() != 0) || (P.getYTopOffset() != 0)
         || (P.getXBottomOffset() != 0) || (P.getYBottomOffset() != 0))
-      fprintf(_out,
-              " + OFFSET %.11g %.11g %.11g %.11g ",
-              lefdist(P.getXBottomOffset()),
-              lefdist(P.getYBottomOffset()),
-              lefdist(P.getXTopOffset()),
-              lefdist(P.getYTopOffset()));
+      fmt::print(_out,
+                 " + OFFSET {:.11g} {:.11g} {:.11g} {:.11g} ",
+                 lefdist(P.getXBottomOffset()),
+                 lefdist(P.getYBottomOffset()),
+                 lefdist(P.getXTopOffset()),
+                 lefdist(P.getYTopOffset()));
 
     std::string pname = via->getPattern();
     if (strcmp(pname.c_str(), "") != 0)
-      fprintf(_out, " + PATTERNNAME %s", pname.c_str());
+      fmt::print(_out, " + PATTERNNAME {}", pname.c_str());
   }
 
-  fprintf(_out, "END %s\n", name.c_str());
+  fmt::print(_out, "END {}\n", name.c_str());
 }
 
-void lefout::writeLib(dbLib* lib)
+void lefout::writeLibBody(dbLib* lib)
 {
   dbSet<dbSite> sites = lib->getSites();
   dbSet<dbSite>::iterator site_itr;
@@ -973,32 +986,32 @@ void lefout::writeSite(dbSite* site)
 {
   std::string n = site->getName();
 
-  fprintf(_out, "SITE %s\n", n.c_str());
+  fmt::print(_out, "SITE {}\n", n.c_str());
   dbSiteClass sclass = site->getClass();
-  fprintf(_out, "    CLASS %s ;\n", sclass.getString());
+  fmt::print(_out, "    CLASS {} ;\n", sclass.getString());
 
   if (site->getSymmetryX() || site->getSymmetryY() || site->getSymmetryR90()) {
-    fprintf(_out, "    SYMMETRY");
+    fmt::print(_out, "{}", "    SYMMETRY");
 
     if (site->getSymmetryX())
-      fprintf(_out, " X");
+      fmt::print(_out, "{}", " X");
 
     if (site->getSymmetryY())
-      fprintf(_out, " Y");
+      fmt::print(_out, "{}", " Y");
 
     if (site->getSymmetryR90())
-      fprintf(_out, " R90");
+      fmt::print(_out, "{}", " R90");
 
-    fprintf(_out, " ;\n");
+    fmt::print(_out, "{}", " ;\n");
   }
 
   if (site->getWidth() || site->getHeight())
-    fprintf(_out,
-            "    SIZE %.11g BY %.11g ;\n",
-            lefdist(site->getWidth()),
-            lefdist(site->getHeight()));
+    fmt::print(_out,
+               "    SIZE {:.11g} BY {:.11g} ;\n",
+               lefdist(site->getWidth()),
+               lefdist(site->getHeight()));
 
-  fprintf(_out, "END %s\n", n.c_str());
+  fmt::print(_out, "END {}\n", n.c_str());
 }
 
 void lefout::writeMaster(dbMaster* master)
@@ -1006,55 +1019,61 @@ void lefout::writeMaster(dbMaster* master)
   std::string name = master->getName();
 
   if (_use_master_ids)
-    fprintf(_out, "\nMACRO M%u\n", master->getMasterId());
+    fmt::print(_out,
+               "\nMACRO M{}\n",
+               static_cast<std::uint32_t>(master->getMasterId()));
   else
-    fprintf(_out, "\nMACRO %s\n", name.c_str());
+    fmt::print(_out, "\nMACRO {}\n", name.c_str());
 
   if (master->getType() != dbMasterType::NONE)
-    fprintf(_out, "    CLASS %s ;\n", master->getType().getString());
+    fmt::print(_out, "    CLASS {} ;\n", master->getType().getString());
 
   int x, y;
   master->getOrigin(x, y);
 
   if ((x != 0) || (y != 0))
-    fprintf(_out, "    ORIGIN %.11g %.11g ;\n", lefdist(x), lefdist(y));
+    fmt::print(_out, "    ORIGIN {:.11g} {:.11g} ;\n", lefdist(x), lefdist(y));
 
   if (master->getEEQ()) {
     std::string eeq = master->getEEQ()->getName();
     if (_use_master_ids)
-      fprintf(_out, "    EEQ M%u ;\n", master->getEEQ()->getMasterId());
+      fmt::print(_out,
+                 "    EEQ M{} ;\n",
+                 static_cast<std::uint32_t>(master->getEEQ()->getMasterId()));
     else
-      fprintf(_out, "    EEQ %s ;\n", eeq.c_str());
+      fmt::print(_out, "    EEQ {} ;\n", eeq.c_str());
   }
 
   if (master->getLEQ()) {
     std::string leq = master->getLEQ()->getName();
     if (_use_master_ids)
-      fprintf(_out, "    LEQ M%u ;\n", master->getLEQ()->getMasterId());
+      fmt::print(_out,
+                 "    LEQ M{} ;\n",
+                 static_cast<std::uint32_t>(master->getLEQ()->getMasterId()));
     else
-      fprintf(_out, "    LEQ %s ;\n", leq.c_str());
+      fmt::print(_out, "    LEQ {} ;\n", leq.c_str());
   }
 
   int w = master->getWidth();
   int h = master->getHeight();
 
   if ((w != 0) || (h != 0))
-    fprintf(_out, "    SIZE %.11g BY %.11g ;\n", lefdist(w), lefdist(h));
+    fmt::print(_out, "    SIZE {:.11g} BY {:.11g} ;\n", lefdist(w), lefdist(h));
 
   if (master->getSymmetryX() || master->getSymmetryY()
       || master->getSymmetryR90()) {
-    fprintf(_out, "    SYMMETRY");
+    fmt::print(_out, "{}", "    SYMMETRY");
 
     if (master->getSymmetryX())
-      fprintf(_out, " X");
+      fmt::print(_out, "{}", " X");
 
     if (master->getSymmetryY())
-      fprintf(_out, " Y");
+      fmt::print(_out, "{}", " Y");
 
     if (master->getSymmetryR90())
-      fprintf(_out, " R90");
+      fmt::print(_out, "{}", " R90");
 
-    fprintf(_out, " ;\n");
+    fmt::print(_out, "{}", " ;\n");
   }
 
   if ((x != 0) || (y != 0)) {
@@ -1064,7 +1083,7 @@ void lefout::writeMaster(dbMaster* master)
 
   if (master->getSite()) {
     std::string site = master->getSite()->getName();
-    fprintf(_out, "    SITE %s ;\n", site.c_str());
+    fmt::print(_out, "    SITE {} ;\n", site.c_str());
   }
 
   dbSet<dbMTerm> mterms = master->getMTerms();
@@ -1078,9 +1097,9 @@ void lefout::writeMaster(dbMaster* master)
   dbSet<dbBox> obs = master->getObstructions();
 
   if (obs.begin() != obs.end()) {
-    fprintf(_out, "    OBS\n");
+    fmt::print(_out, "{}", "    OBS\n");
     writeBoxes(obs, "      ");
-    fprintf(_out, "    END\n");
+    fmt::print(_out, "{}", "    END\n");
   }
 
   if ((x != 0) || (y != 0)) {
@@ -1089,18 +1108,19 @@ void lefout::writeMaster(dbMaster* master)
   }
 
   if (_use_master_ids)
-    fprintf(_out, "END M%u\n", master->getMasterId());
+    fmt::print(
+        _out, "END M{}\n", static_cast<std::uint32_t>(master->getMasterId()));
   else
-    fprintf(_out, "END %s\n", name.c_str());
+    fmt::print(_out, "END {}\n", name.c_str());
 }
 
 void lefout::writeMTerm(dbMTerm* mterm)
 {
   std::string name = mterm->getName();
 
-  fprintf(_out, "    PIN %s\n", name.c_str());
-  fprintf(_out, "        DIRECTION %s ; \n", mterm->getIoType().getString());
-  fprintf(_out, "        USE %s ; \n", mterm->getSigType().getString());
+  fmt::print(_out, "    PIN {}\n", name.c_str());
+  fmt::print(_out, "        DIRECTION {} ; \n", mterm->getIoType().getString());
+  fmt::print(_out, "        USE {} ; \n", mterm->getSigType().getString());
 
   mterm->writeAntennaLef(*this);
   dbSet<dbMPin> pins = mterm->getMPins();
@@ -1112,13 +1132,13 @@ void lefout::writeMTerm(dbMTerm* mterm)
     dbSet<dbBox> geoms = pin->getGeometry();
 
     if (geoms.begin() != geoms.end()) {
-      fprintf(_out, "        PORT\n");
+      fmt::print(_out, "        PORT\n");
       writeBoxes(geoms, "            ");
-      fprintf(_out, "        END\n");
+      fmt::print(_out, "        END\n");
     }
   }
 
-  fprintf(_out, "    END %s\n", name.c_str());
+  fmt::print(_out, "    END {}\n", name.c_str());
 }
 
 void lefout::writePropertyDefinition(dbProperty* prop)
@@ -1167,18 +1187,18 @@ void lefout::writePropertyDefinition(dbProperty* prop)
     default:
       return;
   }
-  fprintf(_out,
-          "    %s %s %s ",
-          objectType.c_str(),
-          propName.c_str(),
-          propType.c_str());
+  fmt::print(_out,
+             "    {} {} {} ",
+             objectType.c_str(),
+             propName.c_str(),
+             propType.c_str());
   if (owner_type == dbLibObj) {
-    fprintf(_out, "\n        ");
-    prop->writePropValue(prop, _out);
-    fprintf(_out, "\n    ");
+    fmt::print(_out, "{}", "\n        ");
+    fmt::print(_out, "{}", dbProperty::writePropValue(prop));
+    fmt::print(_out, "{}", "\n    ");
   }
 
-  fprintf(_out, ";\n");
+  fmt::print(_out, "{}", ";\n");
 }
 
 inline void lefout::writeObjectPropertyDefinitions(
@@ -1227,7 +1247,7 @@ void lefout::writePropertyDefinitions(dbLib* lib)
   std::unordered_map<std::string, short> propertiesMap;
   dbTech* tech = lib->getDb()->getTech();
 
-  fprintf(_out, "\nPROPERTYDEFINITIONS\n");
+  fmt::print(_out, "{}", "\nPROPERTYDEFINITIONS\n");
 
   // writing property definitions of objectType LAYER
   for (dbTechLayer* layer : tech->getLayers())
@@ -1256,84 +1276,48 @@ void lefout::writePropertyDefinitions(dbLib* lib)
   for (dbTechNonDefaultRule* nrule : tech->getNonDefaultRules())
     writeObjectPropertyDefinitions(nrule, propertiesMap);
 
-  fprintf(_out, "END PROPERTYDEFINITIONS\n\n");
+  fmt::print(_out, "{}", "END PROPERTYDEFINITIONS\n\n");
 }
 
-bool lefout::writeTech(dbTech* tech, const char* lef_file)
+void lefout::writeTech(dbTech* tech)
 {
-  _out = fopen(lef_file, "w");
-
-  if (_out == NULL) {
-    logger_->error(utl::ODB, 1015, "Cannot open LEF file %s\n", lef_file);
-    return false;
-  }
-
   _dist_factor = 1.0 / (double) tech->getDbUnitsPerMicron();
   _area_factor = _dist_factor * _dist_factor;
-  writeTech(tech);
+  writeTechBody(tech);
 
-  fprintf(_out, "END LIBRARY\n");
-  fclose(_out);
-  return true;
+  fmt::print(_out, "END LIBRARY\n");
 }
 
-bool lefout::writeLib(dbLib* lib, const char* lef_file)
+void lefout::writeLib(dbLib* lib)
 {
-  _out = fopen(lef_file, "w");
-
-  if (_out == NULL) {
-    logger_->error(utl::ODB, 1033, "Cannot open LEF file %s\n", lef_file);
-    return false;
-  }
-
   _dist_factor = 1.0 / (double) lib->getDbUnitsPerMicron();
   _area_factor = _dist_factor * _dist_factor;
   writeHeader(lib);
-  writeLib(lib);
-  fprintf(_out, "END LIBRARY\n");
-  fclose(_out);
-  return true;
+  writeLibBody(lib);
+  fmt::print(_out, "END LIBRARY\n");
 }
 
-bool lefout::writeTechAndLib(dbLib* lib, const char* lef_file)
+void lefout::writeTechAndLib(dbLib* lib)
 {
-  _out = fopen(lef_file, "w");
-
-  if (_out == NULL) {
-    logger_->error(utl::ODB, 1051, "Cannot open LEF file %s\n", lef_file);
-    return false;
-  }
-
   _dist_factor = 1.0 / (double) lib->getDbUnitsPerMicron();
   _area_factor = _dist_factor * _dist_factor;
   dbTech* tech = lib->getDb()->getTech();
   writeHeader(lib);
-  writeTech(tech);
-  writeLib(lib);
-  fprintf(_out, "END LIBRARY\n");
-  fclose(_out);
-
-  return true;
+  writeTechBody(tech);
+  writeLibBody(lib);
+  fmt::print(_out, "END LIBRARY\n");
 }
 
-bool lefout::writeAbstractLef(dbBlock* db_block, const char* lef_file)
+void lefout::writeAbstractLef(dbBlock* db_block)
 {
-  _out = fopen(lef_file, "w");
-  if (_out == nullptr) {
-    logger_->error(utl::ODB, 1072, "Cannot open LEF file %s\n", lef_file);
-  }
-
   double temporary_dist_factor = _dist_factor;
   _dist_factor = 1.0L / db_block->getDbUnitsPerMicron();
   _area_factor = _dist_factor * _dist_factor;
 
   writeHeader(db_block);
   writeBlock(db_block);
-  fprintf(_out, "END LIBRARY\n");
-  fclose(_out);
+  fmt::print(_out, "END LIBRARY\n");
 
   _dist_factor = temporary_dist_factor;
   _area_factor = _dist_factor * _dist_factor;
-
-  return true;
 }

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -914,20 +914,20 @@ void lefout::writeVia(dbTechVia* via)
     via->getViaParams(P);
 
     fmt::print(_out,
-               " + CUTSIZE {:.11g} {:.11g} ",
+               " + CUTSIZE {:.11g} {:.11g}\n",
                lefdist(P.getXCutSize()),
                lefdist(P.getYCutSize()));
     std::string top = P.getTopLayer()->getName();
     std::string bot = P.getBottomLayer()->getName();
     std::string cut = P.getCutLayer()->getName();
     fmt::print(
-        _out, " + LAYERS {} {} {} ", bot.c_str(), cut.c_str(), top.c_str());
+        _out, " + LAYERS {} {} {}\n", bot.c_str(), cut.c_str(), top.c_str());
     fmt::print(_out,
-               " + CUTSPACING {:.11g} {:.11g} ",
+               " + CUTSPACING {:.11g} {:.11g}\n",
                lefdist(P.getXCutSpacing()),
                lefdist(P.getYCutSpacing()));
     fmt::print(_out,
-               " + ENCLOSURE {:.11g} {:.11g} {:.11g} {:.11g} ",
+               " + ENCLOSURE {:.11g} {:.11g} {:.11g} {:.11g}\n",
                lefdist(P.getXBottomEnclosure()),
                lefdist(P.getYBottomEnclosure()),
                lefdist(P.getXTopEnclosure()),
@@ -935,18 +935,18 @@ void lefout::writeVia(dbTechVia* via)
 
     if ((P.getNumCutRows() != 1) || (P.getNumCutCols() != 1))
       fmt::print(
-          _out, " + ROWCOL {} {} ", P.getNumCutRows(), P.getNumCutCols());
+          _out, " + ROWCOL {} {}\n", P.getNumCutRows(), P.getNumCutCols());
 
     if ((P.getXOrigin() != 0) || (P.getYOrigin() != 0))
       fmt::print(_out,
-                 " + ORIGIN {:.11g} {:.11g} ",
+                 " + ORIGIN {:.11g} {:.11g}\n",
                  lefdist(P.getXOrigin()),
                  lefdist(P.getYOrigin()));
 
     if ((P.getXTopOffset() != 0) || (P.getYTopOffset() != 0)
         || (P.getXBottomOffset() != 0) || (P.getYBottomOffset() != 0))
       fmt::print(_out,
-                 " + OFFSET {:.11g} {:.11g} {:.11g} {:.11g} ",
+                 " + OFFSET {:.11g} {:.11g} {:.11g} {:.11g}\n",
                  lefdist(P.getXBottomOffset()),
                  lefdist(P.getYBottomOffset()),
                  lefdist(P.getXTopOffset()),
@@ -954,7 +954,7 @@ void lefout::writeVia(dbTechVia* via)
 
     std::string pname = via->getPattern();
     if (strcmp(pname.c_str(), "") != 0)
-      fmt::print(_out, " + PATTERNNAME {}", pname.c_str());
+      fmt::print(_out, " + PATTERNNAME {}\n", pname.c_str());
   }
 
   fmt::print(_out, "END {}\n", name.c_str());

--- a/src/odb/src/swig/common/swig_common.cpp
+++ b/src/odb/src/swig/common/swig_common.cpp
@@ -128,10 +128,9 @@ int write_def(odb::dbBlock* block,
 int write_lef(odb::dbLib* lib, const char* path)
 {
   utl::Logger* logger = new utl::Logger(NULL);
-  std::ofstream os(path);
-  if (!os.is_open()) {
-    logger->error(utl::ODB, 2005, "Cannot open LEF file {}\n", path);
-  }
+  std::ofstream os;
+  os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+  os.open(path);
   odb::lefout writer(logger, os);
   writer.writeTechAndLib(lib);
   return true;
@@ -140,10 +139,9 @@ int write_lef(odb::dbLib* lib, const char* path)
 int write_tech_lef(odb::dbTech* tech, const char* path)
 {
   utl::Logger* logger = new utl::Logger(NULL);
-  std::ofstream os(path);
-  if (!os.is_open()) {
-    logger->error(utl::ODB, 2006, "Cannot open LEF file {}\n", path);
-  }
+  std::ofstream os;
+  os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+  os.open(path);
   odb::lefout writer(logger, os);
   writer.writeTech(tech);
   return true;
@@ -151,10 +149,9 @@ int write_tech_lef(odb::dbTech* tech, const char* path)
 int write_macro_lef(odb::dbLib* lib, const char* path)
 {
   utl::Logger* logger = new utl::Logger(NULL);
-  std::ofstream os(path);
-  if (!os.is_open()) {
-    logger->error(utl::ODB, 1072, "Cannot open LEF file {}\n", path);
-  }
+  std::ofstream os;
+  os.exceptions(std::ofstream::badbit | std::ofstream::failbit);
+  os.open(path);
   odb::lefout writer(logger, os);
   writer.writeLib(lib);
   return true;

--- a/src/odb/src/swig/common/swig_common.cpp
+++ b/src/odb/src/swig/common/swig_common.cpp
@@ -127,22 +127,28 @@ int write_def(odb::dbBlock* block,
 
 int write_lef(odb::dbLib* lib, const char* path)
 {
+  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
-  odb::lefout writer(logger);
-  return writer.writeTechAndLib(lib, path);
+  odb::lefout writer(logger, os);
+  writer.writeTechAndLib(lib);
+  return true;
 }
 
 int write_tech_lef(odb::dbTech* tech, const char* path)
 {
+  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
-  odb::lefout writer(logger);
-  return writer.writeTech(tech, path);
+  odb::lefout writer(logger, os);
+  writer.writeTech(tech);
+  return true;
 }
 int write_macro_lef(odb::dbLib* lib, const char* path)
 {
+  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
-  odb::lefout writer(logger);
-  return writer.writeLib(lib, path);
+  odb::lefout writer(logger, os);
+  writer.writeLib(lib);
+  return true;
 }
 
 odb::dbDatabase* read_db(odb::dbDatabase* db, const char* db_path)

--- a/src/odb/src/swig/common/swig_common.cpp
+++ b/src/odb/src/swig/common/swig_common.cpp
@@ -127,8 +127,11 @@ int write_def(odb::dbBlock* block,
 
 int write_lef(odb::dbLib* lib, const char* path)
 {
-  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
+  std::ofstream os(path);
+  if (!os.is_open()) {
+    logger->error(utl::ODB, 2005, "Cannot open LEF file {}\n", path);
+  }
   odb::lefout writer(logger, os);
   writer.writeTechAndLib(lib);
   return true;
@@ -136,16 +139,22 @@ int write_lef(odb::dbLib* lib, const char* path)
 
 int write_tech_lef(odb::dbTech* tech, const char* path)
 {
-  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
+  std::ofstream os(path);
+  if (!os.is_open()) {
+    logger->error(utl::ODB, 2006, "Cannot open LEF file {}\n", path);
+  }
   odb::lefout writer(logger, os);
   writer.writeTech(tech);
   return true;
 }
 int write_macro_lef(odb::dbLib* lib, const char* path)
 {
-  std::ofstream os(path);
   utl::Logger* logger = new utl::Logger(NULL);
+  std::ofstream os(path);
+  if (!os.is_open()) {
+    logger->error(utl::ODB, 1072, "Cannot open LEF file {}\n", path);
+  }
   odb::lefout writer(logger, os);
   writer.writeLib(lib);
   return true;


### PR DESCRIPTION
Moves file output mechanism to ostreams instead of FILE*. I want an ostream so I can run unit tests without having to rely on the filesystem. Also it's just nice to modernize this interface
