### PR TITLE
lef parser: Fix new defect reported by Coverity Scan

### DIFF
--- a/src/odb/src/lef/lef/lefiMacro.cpp
+++ b/src/odb/src/lef/lef/lefiMacro.cpp
@@ -2038,7 +2038,6 @@ void lefiPin::addAntennaModel(int oxide)
       // just initialize it first
     }
     antennaModelAllocated_ = lefMaxOxides;
-    amo = pinAntennaModel_[0];
     curAntennaModelIndex_ = 0;
   }
 


### PR DESCRIPTION
Assigning amo to a value has no effect as it is assigned again inside the for loop or after the for loop. 

```
2040         antennaModelAllocated_ = lefMaxOxides;
>>>     CID 1513198:  Code maintainability issues  (UNUSED_VALUE)
>>>     Assigning value from "this->pinAntennaModel_[0]" to "amo" here, but that stored value is overwritten before it can be used.
2041         amo = pinAntennaModel_[0];
```