### PR TITLE
Remove libgtest-dev from DependencyInstaller

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -188,7 +188,6 @@ _installUbuntuPackages() {
         libpcre3-dev \
         python3-dev \
         libreadline-dev \
-        libgtest-dev \
         tcl-dev \
         tcllib \
         wget \

--- a/third-party/gtest/CMakeLists.txt
+++ b/third-party/gtest/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(GTest)
 if(NOT GTest_FOUND)
   include(FetchContent)
   FetchContent_Declare(

--- a/third-party/gtest/CMakeLists.txt
+++ b/third-party/gtest/CMakeLists.txt
@@ -1,10 +1,8 @@
-if(NOT GTest_FOUND)
-  include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    # Specify the commit you depend on and update it regularly.
-    URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"
-  )
-  FetchContent_MakeAvailable(googletest)
-endif()
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  # Specify the commit you depend on and update it regularly.
+  URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"
+)
+FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
This is installed from ./third-party/gtest/CMakeLists.txt