### PR TITLE
cts: Rename graphics class to disambiguate header files

### DIFF
--- a/src/cts/src/CMakeLists.txt
+++ b/src/cts/src/CMakeLists.txt
@@ -57,7 +57,7 @@ swig_lib(NAME      cts
 target_sources(cts
   PRIVATE
     MakeTritoncts.cpp
-    Graphics.cpp
+    CtsGraphics.cpp
 )
 
 target_include_directories(cts_lib

--- a/src/cts/src/CtsGraphics.cpp
+++ b/src/cts/src/CtsGraphics.cpp
@@ -43,7 +43,8 @@
 
 namespace cts {
 
-void CtsGraphics::initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock)
+void CtsGraphics::initializeWithClock(HTreeBuilder* h_tree_builder,
+                                      Clock& clock)
 {
   clock_ = &clock;
   h_tree_builder_ = h_tree_builder;
@@ -55,7 +56,7 @@ void CtsGraphics::initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock
 }
 
 void CtsGraphics::initializeWithPoints(SinkClustering* SinkClustering,
-                                    const std::vector<Point<double>>& points)
+                                       const std::vector<Point<double>>& points)
 {
   clock_ = nullptr;
   h_tree_builder_ = nullptr;

--- a/src/cts/src/CtsGraphics.cpp
+++ b/src/cts/src/CtsGraphics.cpp
@@ -33,7 +33,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "Graphics.h"
+#include "CtsGraphics.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -43,7 +43,7 @@
 
 namespace cts {
 
-void Graphics::initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock)
+void CtsGraphics::initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock)
 {
   clock_ = &clock;
   h_tree_builder_ = h_tree_builder;
@@ -54,7 +54,7 @@ void Graphics::initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock)
   }
 }
 
-void Graphics::initializeWithPoints(SinkClustering* SinkClustering,
+void CtsGraphics::initializeWithPoints(SinkClustering* SinkClustering,
                                     const std::vector<Point<double>>& points)
 {
   clock_ = nullptr;
@@ -67,7 +67,7 @@ void Graphics::initializeWithPoints(SinkClustering* SinkClustering,
   }
 }
 
-void Graphics::drawCluster(gui::Painter& painter)
+void CtsGraphics::drawCluster(gui::Painter& painter)
 {
   std::vector<gui::Painter::Color> colors{gui::Painter::red,
                                           gui::Painter::yellow,
@@ -119,7 +119,7 @@ void Graphics::drawCluster(gui::Painter& painter)
   }
 }
 
-void Graphics::drawHTree(gui::Painter& painter)
+void CtsGraphics::drawHTree(gui::Painter& painter)
 {
   auto color = gui::Painter::red;
   color.a = 180;
@@ -169,7 +169,7 @@ void Graphics::drawHTree(gui::Painter& painter)
   }
 }
 
-void Graphics::drawObjects(gui::Painter& painter)
+void CtsGraphics::drawObjects(gui::Painter& painter)
 {
   if (clock_) {
     drawHTree(painter);
@@ -180,7 +180,7 @@ void Graphics::drawObjects(gui::Painter& painter)
   }
 }
 
-void Graphics::clockPlot(bool pause)
+void CtsGraphics::clockPlot(bool pause)
 {
   gui::Gui::get()->redraw();
   if (pause) {
@@ -188,13 +188,13 @@ void Graphics::clockPlot(bool pause)
   }
 }
 
-void Graphics::status(const std::string& message)
+void CtsGraphics::status(const std::string& message)
 {
   gui::Gui::get()->status(message);
 }
 
 /* static */
-bool Graphics::guiActive()
+bool CtsGraphics::guiActive()
 {
   return gui::Gui::enabled();
 }

--- a/src/cts/src/CtsGraphics.h
+++ b/src/cts/src/CtsGraphics.h
@@ -53,7 +53,7 @@ class HTreeBuilder;
 class SinkClustering;
 
 // This class draws debugging graphics on the layout
-class Graphics : public gui::Renderer, public CtsObserver
+class CtsGraphics : public gui::Renderer, public CtsObserver
 {
  public:
   void initializeWithClock(HTreeBuilder* h_tree_builder, Clock& clock) override;

--- a/src/cts/src/TritonCTS.i
+++ b/src/cts/src/TritonCTS.i
@@ -37,7 +37,7 @@
 #include "cts/TritonCTS.h"
 #include "CtsOptions.h"
 #include "TechChar.h"
-#include "Graphics.h"
+#include "CtsGraphics.h"
 #include "ord/OpenRoad.hh"
 
 namespace ord {
@@ -120,7 +120,7 @@ set_metric_output(const char* file)
 void
 set_debug_cmd()
 {
-  getTritonCts()->getParms()->setObserver(std::make_unique<Graphics>());
+  getTritonCts()->getParms()->setObserver(std::make_unique<CtsGraphics>());
 }
 
 void


### PR DESCRIPTION
Some header files are named similarly which presents a problem in Google's version of the build. I could fix it other ways, but this would be helpful for us.