### PR TITLE
cmake: dont attempt to include system gtest

### DIFF
--- a/third-party/gtest/CMakeLists.txt
+++ b/third-party/gtest/CMakeLists.txt
@@ -1,11 +1,8 @@
-find_package(GTest)
-if(NOT GTest_FOUND)
-  include(FetchContent)
-  FetchContent_Declare(
-    googletest
-    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
-    # Specify the commit you depend on and update it regularly.
-    URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"
-  )
-  FetchContent_MakeAvailable(googletest)
-endif()
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+  # Specify the commit you depend on and update it regularly.
+  URL "https://github.com/google/googletest/archive/refs/tags/v1.13.0.zip"
+)
+FetchContent_MakeAvailable(googletest)


### PR DESCRIPTION
attempt to fix the builds on systems with googletest packages that are incomplete.
Closes #3520 