### PR TITLE
gui: Add iterm labels to layout viewer

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -439,6 +439,9 @@ DisplayControls::DisplayControls(QWidget* parent)
   instance_name_font_ = QApplication::font();  // use default font
   instance_name_color_ = Qt::yellow;
 
+  iterm_label_font_ = QApplication::font();  // use default font
+  iterm_label_color_ = Qt::yellow;
+
   auto instance_shape
       = makeParentItem(misc_.instances, "Instances", misc, Qt::Checked);
   makeLeafItem(instance_shapes_.names,
@@ -453,13 +456,17 @@ DisplayControls::DisplayControls(QWidget* parent)
                instance_shape,
                Qt::Unchecked,
                false,
-               instance_name_color_);
+               iterm_label_color_);
   makeLeafItem(
       instance_shapes_.blockages, "Blockages", instance_shape, Qt::Checked);
   toggleParent(misc_.instances);
   setNameItemDoubleClickAction(instance_shapes_.names, [this]() {
     instance_name_font_ = QFontDialog::getFont(
         nullptr, instance_name_font_, this, "Instance name font");
+  });
+  setNameItemDoubleClickAction(instance_shapes_.iterm_labels, [this]() {
+    iterm_label_font_ = QFontDialog::getFont(
+        nullptr, iterm_label_font_, this, "Instance ITerm name font");
   });
 
   region_color_ = QColor(0x70, 0x70, 0x70, 0x70);  // semi-transparent mid-gray
@@ -657,6 +664,7 @@ void DisplayControls::readSettings(QSettings* settings)
       blockages_.blockages, placement_blockage_color_, "blockages_placement");
   getColor(rulers_, ruler_color_, "ruler");
   getColor(instance_shapes_.names, instance_name_color_, "instance_name");
+  getColor(instance_shapes_.iterm_labels, iterm_label_color_, "iterm_label");
   getColor(misc_.regions, region_color_, "region");
   settings->endGroup();
   settings->beginGroup("pattern");
@@ -667,6 +675,7 @@ void DisplayControls::readSettings(QSettings* settings)
   getFont(pin_markers_font_, "pin_markers");
   getFont(ruler_font_, "ruler");
   getFont(instance_name_font_, "instance_name");
+  getFont(iterm_label_font_, "iterm_label");
   settings->endGroup();
   settings->endGroup();
 
@@ -727,6 +736,7 @@ void DisplayControls::writeSettings(QSettings* settings)
   settings->setValue("blockages_placement", placement_blockage_color_);
   settings->setValue("ruler", ruler_color_);
   settings->setValue("instance_name", instance_name_color_);
+  settings->setValue("iterm_label", iterm_label_color_);
   settings->setValue("region", region_color_);
   settings->endGroup();
   settings->beginGroup("pattern");
@@ -739,6 +749,7 @@ void DisplayControls::writeSettings(QSettings* settings)
   settings->setValue("pin_markers", pin_markers_font_);
   settings->setValue("ruler", ruler_font_);
   settings->setValue("instance_name", instance_name_font_);
+  settings->setValue("iterm_label", iterm_label_font_);
   settings->endGroup();
   settings->endGroup();
 
@@ -974,7 +985,9 @@ void DisplayControls::displayItemDblClicked(const QModelIndex& index)
       item_color = &region_color_;
       item_pattern = &region_pattern_;
     } else if (color_item == instance_shapes_.names.swatch) {
-      item_color = &instance_name_color_;
+      item_color = &instance_name_color_; 
+    } else if (color_item == instance_shapes_.iterm_labels.swatch) {
+      item_color = &iterm_label_color_; 
     } else if (color_item == rulers_.swatch) {
       item_color = &ruler_color_;
     } else {
@@ -1345,6 +1358,16 @@ QFont DisplayControls::instanceNameFont()
   return instance_name_font_;
 }
 
+QColor DisplayControls::itermLabelColor()
+{
+  return iterm_label_color_;
+}
+
+QFont DisplayControls::itermLabelFont()
+{
+  return iterm_label_font_;
+}
+
 bool DisplayControls::isModelRowVisible(
     const DisplayControls::ModelRow* row) const
 {
@@ -1511,7 +1534,7 @@ bool DisplayControls::areInstancePinsVisible()
   return isModelRowVisible(&instance_shapes_.pins);
 }
 
-bool DisplayControls::areInstanceItermsVisible()
+bool DisplayControls::areInstanceITermsVisible()
 {
   return isModelRowVisible(&instance_shapes_.iterm_labels);
 }

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -985,9 +985,9 @@ void DisplayControls::displayItemDblClicked(const QModelIndex& index)
       item_color = &region_color_;
       item_pattern = &region_pattern_;
     } else if (color_item == instance_shapes_.names.swatch) {
-      item_color = &instance_name_color_; 
+      item_color = &instance_name_color_;
     } else if (color_item == instance_shapes_.iterm_labels.swatch) {
-      item_color = &iterm_label_color_; 
+      item_color = &iterm_label_color_;
     } else if (color_item == rulers_.swatch) {
       item_color = &ruler_color_;
     } else {

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -448,6 +448,12 @@ DisplayControls::DisplayControls(QWidget* parent)
                false,
                instance_name_color_);
   makeLeafItem(instance_shapes_.pins, "Pins", instance_shape, Qt::Checked);
+  makeLeafItem(instance_shapes_.iterm_labels,
+               "Iterm Labels",
+               instance_shape,
+               Qt::Unchecked,
+               false,
+               instance_name_color_);
   makeLeafItem(
       instance_shapes_.blockages, "Blockages", instance_shape, Qt::Checked);
   toggleParent(misc_.instances);
@@ -1503,6 +1509,11 @@ bool DisplayControls::areInstanceNamesVisible()
 bool DisplayControls::areInstancePinsVisible()
 {
   return isModelRowVisible(&instance_shapes_.pins);
+}
+
+bool DisplayControls::areInstanceItermsVisible()
+{
+  return isModelRowVisible(&instance_shapes_.iterm_labels);
 }
 
 bool DisplayControls::areInstanceBlockagesVisible()

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -533,7 +533,6 @@ class DisplayControls : public QDockWidget,
   QColor iterm_label_color_;
   QFont iterm_label_font_;
 
-
   QColor ruler_color_;
   QFont ruler_font_;
 

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -203,6 +203,8 @@ class DisplayControls : public QDockWidget,
   Qt::BrushStyle regionPattern() override;
   QColor instanceNameColor() override;
   QFont instanceNameFont() override;
+  QColor itermLabelColor() override;
+  QFont itermLabelFont() override;
   QColor siteColor(odb::dbSite* site) override;
   bool isVisible(const odb::dbTechLayer* layer) override;
   bool isSelectable(const odb::dbTechLayer* layer) override;
@@ -528,6 +530,9 @@ class DisplayControls : public QDockWidget,
 
   QColor instance_name_color_;
   QFont instance_name_font_;
+  QColor iterm_label_color_;
+  QFont iterm_label_font_;
+
 
   QColor ruler_color_;
   QFont ruler_font_;

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -155,7 +155,7 @@ class DisplayControlModel : public QStandardItemModel
 
 // This class shows the user the set of layers & objects that
 // they can control the visibility and selectablity of.  The
-// controls are show in a tree view to provide grouping of
+// controls are shown in a tree view to provide grouping of
 // related options.
 //
 // It also implements the Options interface so that other clients can

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -212,7 +212,7 @@ class DisplayControls : public QDockWidget,
   bool isInstanceSelectable(odb::dbInst* inst) override;
   bool areInstanceNamesVisible() override;
   bool areInstancePinsVisible() override;
-  bool areInstanceItermsVisible() override;
+  bool areInstanceITermsVisible() override;
   bool areInstanceBlockagesVisible() override;
   bool areFillsVisible() override;
   bool areBlockagesVisible() override;

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -212,6 +212,7 @@ class DisplayControls : public QDockWidget,
   bool isInstanceSelectable(odb::dbInst* inst) override;
   bool areInstanceNamesVisible() override;
   bool areInstancePinsVisible() override;
+  bool areInstanceItermsVisible() override;
   bool areInstanceBlockagesVisible() override;
   bool areFillsVisible() override;
   bool areBlockagesVisible() override;
@@ -383,6 +384,7 @@ class DisplayControls : public QDockWidget,
   {
     ModelRow names;
     ModelRow pins;
+    ModelRow iterm_labels;
     ModelRow blockages;
   };
 

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -67,6 +67,7 @@ class Options
   virtual bool isInstanceSelectable(odb::dbInst* inst) = 0;
   virtual bool areInstanceNamesVisible() = 0;
   virtual bool areInstancePinsVisible() = 0;
+  virtual bool areInstanceItermsVisible() = 0;
   virtual bool areInstanceBlockagesVisible() = 0;
   virtual bool areFillsVisible() = 0;
   virtual bool areBlockagesVisible() = 0;

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -67,7 +67,7 @@ class Options
   virtual bool isInstanceSelectable(odb::dbInst* inst) = 0;
   virtual bool areInstanceNamesVisible() = 0;
   virtual bool areInstancePinsVisible() = 0;
-  virtual bool areInstanceItermsVisible() = 0;
+  virtual bool areInstanceITermsVisible() = 0;
   virtual bool areInstanceBlockagesVisible() = 0;
   virtual bool areFillsVisible() = 0;
   virtual bool areBlockagesVisible() = 0;

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -58,6 +58,8 @@ class Options
   virtual Qt::BrushStyle regionPattern() = 0;
   virtual QColor instanceNameColor() = 0;
   virtual QFont instanceNameFont() = 0;
+  virtual QColor itermLabelColor() = 0;
+  virtual QFont itermLabelFont() = 0;
   virtual QColor siteColor(odb::dbSite* site) = 0;
   virtual bool isVisible(const odb::dbTechLayer* layer) = 0;
   virtual bool isSelectable(const odb::dbTechLayer* layer) = 0;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -640,7 +640,7 @@ void RenderThread::drawInstanceNames(QPainter* painter,
 
 // Draw the instances ITerm names
 void RenderThread::drawITermLabels(QPainter* painter,
-                                     const std::vector<odb::dbInst*>& insts)
+                                   const std::vector<odb::dbInst*>& insts)
 {
   if (!viewer_->options_->areInstanceITermsVisible()) {
     return;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -227,6 +227,23 @@ void RenderThread::addInstTransform(QTransform& xfm,
   }
 }
 
+bool RenderThread::instanceBelowMinSize(dbInst* inst)
+{
+  dbMaster* master = inst->getMaster();
+  int master_height = master->getHeight();
+  int master_width = master->getHeight();
+  const int minimum_size = viewer_->coarseViewableResolution();
+
+  if (master_height < minimum_size) {
+    return true;
+  }
+  if (!inst->getMaster()->isCore() && master_width < minimum_size) {
+    // if core cell, just check master height
+    return true;
+  }
+  return false;
+}
+
 void RenderThread::drawTracks(dbTechLayer* layer,
                               QPainter* painter,
                               const Rect& bounds)
@@ -540,7 +557,6 @@ void RenderThread::drawInstanceNames(QPainter* painter,
     return;
   }
 
-  const int minimum_size = viewer_->coarseViewableResolution();
   const QTransform initial_xfm = painter->transform();
 
   const QColor text_color = viewer_->options_->instanceNameColor();
@@ -572,15 +588,8 @@ void RenderThread::drawInstanceNames(QPainter* painter,
     if (restart_) {
       break;
     }
-    dbMaster* master = inst->getMaster();
-    int master_height = master->getHeight();
-    int master_width = master->getHeight();
 
-    if (master_height < minimum_size) {
-      continue;
-    }
-    if (!inst->getMaster()->isCore() && master_width < minimum_size) {
-      // if core cell, just check master height
+    if (instanceBelowMinSize(inst)) {
       continue;
     }
 
@@ -646,7 +655,6 @@ void RenderThread::drawITermLabels(QPainter* painter,
     return;
   }
 
-  const int minimum_size = viewer_->coarseViewableResolution();
   const QTransform initial_xfm = painter->transform();
 
   const QColor text_color = viewer_->options_->itermLabelColor();
@@ -678,15 +686,8 @@ void RenderThread::drawITermLabels(QPainter* painter,
     if (restart_) {
       break;
     }
-    dbMaster* master = inst->getMaster();
-    int master_height = master->getHeight();
-    int master_width = master->getHeight();
 
-    if (master_height < minimum_size) {
-      continue;
-    }
-    if (!inst->getMaster()->isCore() && master_width < minimum_size) {
-      // if core cell, just check master height
+    if (instanceBelowMinSize(inst)) {
       continue;
     }
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -649,12 +649,12 @@ void RenderThread::drawITermLabels(QPainter* painter,
   const int minimum_size = viewer_->coarseViewableResolution();
   const QTransform initial_xfm = painter->transform();
 
-  const QColor text_color = viewer_->options_->instanceNameColor();
+  const QColor text_color = viewer_->options_->itermLabelColor();
   painter->setPen(QPen(text_color, 0));
   painter->setBrush(QBrush(text_color));
 
   const QFont initial_font = painter->font();
-  const QFont text_font = viewer_->options_->instanceNameFont();
+  const QFont text_font = viewer_->options_->itermLabelFont();
   const QFontMetricsF font_metrics(text_font);
 
   // minimum pixel height for text (10px)

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -590,7 +590,7 @@ void RenderThread::drawInstanceNames(QPainter* painter,
     QRectF instance_bbox_in_px = viewer_->dbuToScreen(instance_box);
 
     QRectF text_bounding_box = font_metrics.boundingRect(name);
-    
+
     bool do_rotate = false;
     if (text_bounding_box.width()
         > rotation_limit * instance_bbox_in_px.width()) {
@@ -692,10 +692,10 @@ void RenderThread::drawITermLabels(QPainter* painter,
 
     for (auto inst_iterm : inst->getITerms()) {
       Rect iterm_box = inst_iterm->getBBox();
-      
+
       QString name = inst_iterm->getMTerm()->getConstName();
       QRectF iterm_bbox_in_px = viewer_->dbuToScreen(iterm_box);
-      
+
       QRectF text_bounding_box = font_metrics.boundingRect(name);
 
       bool do_rotate = false;
@@ -708,7 +708,8 @@ void RenderThread::drawITermLabels(QPainter* painter,
         }
       }
 
-      qreal text_height_check = non_core_scale_limit * text_bounding_box.height();
+      qreal text_height_check
+          = non_core_scale_limit * text_bounding_box.height();
       // don't show text if it's more than "non_core_scale_limit" of cell
       // height/width this keeps text from dominating the cell size
       if (!do_rotate && text_height_check > iterm_bbox_in_px.height()) {
@@ -717,7 +718,7 @@ void RenderThread::drawITermLabels(QPainter* painter,
       if (do_rotate && text_height_check > iterm_bbox_in_px.width()) {
         continue;
       }
-      
+
       if (do_rotate) {
         name = font_metrics.elidedText(
             name, Qt::ElideLeft, size_limit * iterm_bbox_in_px.height());

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -638,6 +638,112 @@ void RenderThread::drawInstanceNames(QPainter* painter,
   painter->setFont(initial_font);
 }
 
+// Draw the instances' names
+void RenderThread::drawItermLabels(QPainter* painter,
+                                     const std::vector<odb::dbInst*>& insts)
+{
+  if (!viewer_->options_->areInstanceItermsVisible()) {
+    return;
+  }
+
+  const int minimum_size = viewer_->coarseViewableResolution();
+  const QTransform initial_xfm = painter->transform();
+
+  const QColor text_color = viewer_->options_->instanceNameColor();
+  painter->setPen(QPen(text_color, 0));
+  painter->setBrush(QBrush(text_color));
+
+  const QFont initial_font = painter->font();
+  const QFont text_font = viewer_->options_->instanceNameFont();
+  const QFontMetricsF font_metrics(text_font);
+
+  // minimum pixel height for text (10px)
+  if (font_metrics.ascent() < 10) {
+    // text is too small
+    return;
+  }
+
+  // text should not fill more than 90% of the instance height or width
+  static const float size_limit = 0.9;
+  static const float rotation_limit
+      = 0.85;  // slightly lower to prevent oscillating rotations when zooming
+
+  // limit non-core text to 1/2.0 (50%) of cell height or width
+  static const float non_core_scale_limit = 2.0;
+
+  const qreal scale_adjust = 1.0 / viewer_->pixels_per_dbu_;
+
+  painter->setFont(text_font);
+  for (auto inst : insts) {
+    if (restart_) {
+      break;
+    }
+    dbMaster* master = inst->getMaster();
+    int master_height = master->getHeight();
+    int master_width = master->getHeight();
+
+    if (master_height < minimum_size) {
+      continue;
+    }
+    if (!inst->getMaster()->isCore() && master_width < minimum_size) {
+      // if core cell, just check master height
+      continue;
+    }
+
+    Rect instance_box = inst->getBBox()->getBox();
+
+    QString name = inst->getName().c_str();
+    QRectF instance_bbox_in_px = viewer_->dbuToScreen(instance_box);
+
+    QRectF text_bounding_box = font_metrics.boundingRect(name);
+
+    bool do_rotate = false;
+    if (text_bounding_box.width()
+        > rotation_limit * instance_bbox_in_px.width()) {
+      // non-rotated text will not fit without elide
+      if (instance_bbox_in_px.height() > instance_bbox_in_px.width()) {
+        // check if more text will fit if rotated
+        do_rotate = true;
+      }
+    }
+
+    qreal text_height_check = non_core_scale_limit * text_bounding_box.height();
+    // don't show text if it's more than "non_core_scale_limit" of cell
+    // height/width this keeps text from dominating the cell size
+    if (!do_rotate && text_height_check > instance_bbox_in_px.height()) {
+      continue;
+    }
+    if (do_rotate && text_height_check > instance_bbox_in_px.width()) {
+      continue;
+    }
+
+    if (do_rotate) {
+      name = font_metrics.elidedText(
+          name, Qt::ElideLeft, size_limit * instance_bbox_in_px.height());
+    } else {
+      name = font_metrics.elidedText(
+          name, Qt::ElideLeft, size_limit * instance_bbox_in_px.width());
+    }
+
+    painter->translate(instance_box.xMin(), instance_box.yMin());
+    painter->scale(scale_adjust, -scale_adjust);
+    if (do_rotate) {
+      text_bounding_box = font_metrics.boundingRect(name);
+      painter->rotate(90);
+      painter->translate(-text_bounding_box.width(), 0);
+      // account for descent of font
+      painter->translate(-font_metrics.descent(), 0);
+    } else {
+      // account for descent of font
+      painter->translate(font_metrics.descent(), 0);
+    }
+    painter->drawText(0, 0, name);
+
+    painter->setTransform(initial_xfm);
+  }
+  painter->setFont(initial_font);
+}
+
 void RenderThread::drawBlockages(QPainter* painter,
                                  odb::dbBlock* block,
                                  const Rect& bounds)

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -38,8 +38,6 @@
 #include "painter.h"
 #include "utl/timer.h"
 
-#include <iostream>
-
 namespace gui {
 
 using odb::dbBlock;
@@ -641,10 +639,10 @@ void RenderThread::drawInstanceNames(QPainter* painter,
 }
 
 // Draw the instances ITerm names
-void RenderThread::drawItermLabels(QPainter* painter,
+void RenderThread::drawITermLabels(QPainter* painter,
                                      const std::vector<odb::dbInst*>& insts)
 {
-  if (!viewer_->options_->areInstanceItermsVisible()) {
+  if (!viewer_->options_->areInstanceITermsVisible()) {
     return;
   }
 
@@ -1066,7 +1064,7 @@ void RenderThread::drawBlock(QPainter* painter,
   debugPrint(logger_, GUI, "draw", 1, "instance names {}", inst_names);
 
   utl::Timer inst_iterms;
-  drawItermLabels(painter, insts);
+  drawITermLabels(painter, insts);
   debugPrint(logger_, GUI, "draw", 1, "instance iterms {}", inst_iterms);
 
   utl::Timer inst_rows;

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -102,7 +102,7 @@ class RenderThread : public QThread
                           GuiPainter& gui_painter);
   void drawInstanceNames(QPainter* painter,
                          const std::vector<odb::dbInst*>& insts);
-  void drawItermLabels(QPainter* painter,
+  void drawITermLabels(QPainter* painter,
                          const std::vector<odb::dbInst*>& insts);
   void drawBlockages(QPainter* painter,
                      odb::dbBlock* block,

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -103,7 +103,7 @@ class RenderThread : public QThread
   void drawInstanceNames(QPainter* painter,
                          const std::vector<odb::dbInst*>& insts);
   void drawItermLabels(QPainter* painter,
-                         const std::vector<odb::dbInst*>& insts)
+                         const std::vector<odb::dbInst*>& insts);
   void drawBlockages(QPainter* painter,
                      odb::dbBlock* block,
                      const odb::Rect& bounds);

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -102,6 +102,8 @@ class RenderThread : public QThread
                           GuiPainter& gui_painter);
   void drawInstanceNames(QPainter* painter,
                          const std::vector<odb::dbInst*>& insts);
+  void drawItermLabels(QPainter* painter,
+                         const std::vector<odb::dbInst*>& insts)
   void drawBlockages(QPainter* painter,
                      odb::dbBlock* block,
                      const odb::Rect& bounds);

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -135,6 +135,8 @@ class RenderThread : public QThread
                       const std::vector<odb::dbInst*>& insts);
   void drawRulers(Painter& painter, const Rulers& rulers);
 
+  bool instanceBelowMinSize(odb::dbInst* inst);
+
   void addInstTransform(QTransform& xfm, const odb::dbTransform& inst_xfm);
   QColor getColor(odb::dbTechLayer* layer);
   Qt::BrushStyle getPattern(odb::dbTechLayer* layer);

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -103,7 +103,7 @@ class RenderThread : public QThread
   void drawInstanceNames(QPainter* painter,
                          const std::vector<odb::dbInst*>& insts);
   void drawITermLabels(QPainter* painter,
-                         const std::vector<odb::dbInst*>& insts);
+                       const std::vector<odb::dbInst*>& insts);
   void drawBlockages(QPainter* painter,
                      odb::dbBlock* block,
                      const odb::Rect& bounds);


### PR DESCRIPTION
Fixes #3410 

I added a function to renderThread.cpp called drawItermLabels(), which gets called in exactly the same way as drawInstanceNames().

I replaced the variable Rect instance_box = inst->getBBox()->getBox(); with Rect iterm_box = inst_iterm->getBBox();. I also obtain the name of an iterm through its corresponding mterm, since dbMTerm has a getName() funciton but dbITerm does not.

I left in the same checks as drawInstanceNames() to prevent printing the names when text_height_check > ..bbox_in_px.height(). This caused the iterm labels to not be drawn at any zoom level.

I then commented out those checks, so I expected the labels to always be drawn. The labels are then drawn even when fully zoomed out, and in the correct locations it seems. However as I zoom in, the labels become truncated with ellipses and then disappear entirely. Whereas the instance names are still visible when fully zoomed in.

Any ideas what could cause this problem? Besides the text_height_check I mentioned, what could be preventing the names from being drawn when zoomed in?

I will keep reading the code to figure this out.