### PR TITLE
def parser: fix new coverity defects 

### DIFF
--- a/src/odb/src/def/def/defiNet.cpp
+++ b/src/odb/src/def/def/defiNet.cpp
@@ -768,7 +768,7 @@ const defiPath* defiShield::path(int index) const
 ////////////////////////////////////////////////////
 ////////////////////////////////////////////////////
 
-defiWire::defiWire(defrData* data) : defData(data)
+defiWire::defiWire(defrData* data) : defData(data), paths_(nullptr)
 {
 }
 

--- a/src/odb/src/def/def/defiNet.hpp
+++ b/src/odb/src/def/def/defiNet.hpp
@@ -72,13 +72,12 @@ class defiWire
   void bumpPaths(long long size);
 
  protected:
+  defrData* defData;
+  defiPath** paths_;
   char* type_;
   char* wireShieldName_;  // It only set from specialnet SHIELD, 5.4
   int numPaths_;
   long long pathsAllocated_;
-  defiPath** paths_;
-
-  defrData* defData;
 };
 
 class defiSubnet

--- a/src/odb/src/def/def/defrReader.cpp
+++ b/src/odb/src/def/def/defrReader.cpp
@@ -33,6 +33,8 @@
 #include <string.h>
 #include <sys/stat.h>
 
+#include <sstream>
+
 #include "defiDebug.hpp"
 #include "defiMisc.hpp"
 #include "defiProp.hpp"
@@ -2134,27 +2136,18 @@ void defrSetCaseSensitivity(int caseSense)
   }
 }
 
-void defrAddAlias(const char* key, const char* value, int marked)
+void defrAddAlias(std::string_view key, std::string_view value, int marked)
 {
   // Since the alias data is stored in the hash table, the hash table
   // only takes the key and the data, the marked data will be stored
   // at the end of the value data
 
-  defrData* defData = defContext.data;
-
-  char* k1;
-  char* v1;
-  int len = strlen(key) + 1;
-  k1 = (char*) malloc(len);
-  strcpy(k1, key);
-  len = strlen(value) + 1 + 1;  // 1 for the marked
-  v1 = (char*) malloc(len);
-  // strcpy(v1, value);
-  if (marked != 0)
+  if (marked != 0) {
     marked = 1;  // make sure only 1 digit
-  sprintf(v1, "%d%s", marked, value);
-
-  defData->def_alias_set[k1] = v1;
+  }
+  std::stringstream concated_value;
+  concated_value << marked << value;
+  defContext.data->def_alias_set[std::string(key)] = concated_value.str();
 }
 
 void defrSetOpenLogFileAppend()

--- a/src/odb/src/def/def/defrReader.hpp
+++ b/src/odb/src/def/def/defrReader.hpp
@@ -32,6 +32,8 @@
 
 #include <stdarg.h>
 
+#include <string_view>
+
 #include "defiDefs.hpp"
 #include "defiKRDefs.hpp"
 #include "defiUser.hpp"
@@ -747,7 +749,9 @@ extern void defrSetLimitPerMsg(int msgId, int numMsg);
 #define PARSE_ERROR 2  // stop parsing, print an error message
 
 // Add this alias to the list for the parser
-extern void defrAddAlias(const char* key, const char* value, int marked);
+extern void defrAddAlias(std::string_view key,
+                         std::string_view value,
+                         int marked);
 
 END_LEFDEF_PARSER_NAMESPACE
 


### PR DESCRIPTION
This PR should fix the 3 defects.

```
** CID 1513255:  Resource leaks  (RESOURCE_LEAK)
/src/odb/src/def/def/defrReader.cpp: 2158 in LefDefParser::defrAddAlias(const char *, const char *, int)()


________________________________________________________________________________________________________
*** CID 1513255:  Resource leaks  (RESOURCE_LEAK)
/src/odb/src/def/def/defrReader.cpp: 2158 in LefDefParser::defrAddAlias(const char *, const char *, int)()
2152       // strcpy(v1, value);
2153       if (marked != 0)
2154         marked = 1;  // make sure only 1 digit
2155       sprintf(v1, "%d%s", marked, value);
2156     
2157       defData->def_alias_set[k1] = v1;
>>>     CID 1513255:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "k1" going out of scope leaks the storage it points to.
2158     }
2159     
2160     void defrSetOpenLogFileAppend()
2161     {
2162       DEF_INIT;
2163       defContext.settings->LogFileAppend = TRUE;

** CID 1513254:  Uninitialized members  (UNINIT_CTOR)
/src/odb/src/def/def/defiNet.cpp: 773 in LefDefParser::defiWire::defiWire(LefDefParser::defrData *)()


________________________________________________________________________________________________________
*** CID 1513254:  Uninitialized members  (UNINIT_CTOR)
/src/odb/src/def/def/defiNet.cpp: 773 in LefDefParser::defiWire::defiWire(LefDefParser::defrData *)()
767     //
768     ////////////////////////////////////////////////////
769     ////////////////////////////////////////////////////
770     
771     defiWire::defiWire(defrData* data) : defData(data)
772     {
>>>     CID 1513254:  Uninitialized members  (UNINIT_CTOR)
>>>     Non-static class member "paths_" is not initialized in this constructor nor in any functions that it calls.
773     }
774     
775     void defiWire::Init(const char* type, const char* wireShieldName)
776     {
777       int len = strlen(type) + 1;
778       type_ = (char*) malloc(len);

** CID 1513253:  Resource leaks  (RESOURCE_LEAK)
/src/odb/src/def/def/defrReader.cpp: 2158 in LefDefParser::defrAddAlias(const char *, const char *, int)()


________________________________________________________________________________________________________
*** CID 1513253:  Resource leaks  (RESOURCE_LEAK)
/src/odb/src/def/def/defrReader.cpp: 2158 in LefDefParser::defrAddAlias(const char *, const char *, int)()
2152       // strcpy(v1, value);
2153       if (marked != 0)
2154         marked = 1;  // make sure only 1 digit
2155       sprintf(v1, "%d%s", marked, value);
2156     
2157       defData->def_alias_set[k1] = v1;
>>>     CID 1513253:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "v1" going out of scope leaks the storage it points to.
2158     }
2159     
2160     void defrSetOpenLogFileAppend()
2161     {
2162       DEF_INIT;
2163       defContext.settings->LogFileAppend = TRUE;
```
