### PR TITLE
gui: Add remaining properties to Tech and Block inspection

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2015,7 +2015,7 @@ Descriptor::Properties DbViaDescriptor::getProperties(std::any object) const
 
   Properties props({{"Block", gui->makeSelected(via->getBlock())}});
 
-  if (via->getPattern() != "") {
+  if (via->getPattern().empty()) {
     props.push_back({"Pattern", via->getPattern()});
   }
 

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2019,49 +2019,61 @@ Descriptor::Properties DbViaDescriptor::getProperties(std::any object) const
     props.push_back({"Pattern", via->getPattern()});
   }
 
-  props.push_back({"Tech Via Generate Rule", gui->makeSelected(via->getViaGenerateRule())});
+  props.push_back(
+      {"Tech Via Generate Rule", gui->makeSelected(via->getViaGenerateRule())});
 
   if (via->hasParams()) {
     odb::dbViaParams via_params;
     via->getViaParams(via_params);
 
-    props.push_back({"Cut Size",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXCutSize(), true),
-                                 Property::convert_dbu(via_params.getYCutSize(), true))});
+    props.push_back(
+        {"Cut Size",
+         fmt::format("X={}, Y={}",
+                     Property::convert_dbu(via_params.getXCutSize(), true),
+                     Property::convert_dbu(via_params.getYCutSize(), true))});
 
-    props.push_back({"Cut Spacing",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXCutSpacing(), true),
-                                 Property::convert_dbu(via_params.getYCutSpacing(), true))});    
+    props.push_back(
+        {"Cut Spacing",
+         fmt::format(
+             "X={}, Y={}",
+             Property::convert_dbu(via_params.getXCutSpacing(), true),
+             Property::convert_dbu(via_params.getYCutSpacing(), true))});
 
-    props.push_back({"Top Enclosure",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXTopEnclosure(), true),
-                                 Property::convert_dbu(via_params.getYTopEnclosure(), true))}); 
+    props.push_back(
+        {"Top Enclosure",
+         fmt::format(
+             "X={}, Y={}",
+             Property::convert_dbu(via_params.getXTopEnclosure(), true),
+             Property::convert_dbu(via_params.getYTopEnclosure(), true))});
 
-    props.push_back({"Bottom Enclosure",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXBottomEnclosure(), true),
-                                 Property::convert_dbu(via_params.getYBottomEnclosure(), true))});
+    props.push_back(
+        {"Bottom Enclosure",
+         fmt::format(
+             "X={}, Y={}",
+             Property::convert_dbu(via_params.getXBottomEnclosure(), true),
+             Property::convert_dbu(via_params.getYBottomEnclosure(), true))});
 
     props.push_back({"Number of Cut Rows", via_params.getNumCutRows()});
     props.push_back({"Number of Cut Columns", via_params.getNumCutCols()});
 
-    props.push_back({"Origin",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXOrigin(), true),
-                                 Property::convert_dbu(via_params.getYOrigin(), true))});    
+    props.push_back(
+        {"Origin",
+         fmt::format("X={}, Y={}",
+                     Property::convert_dbu(via_params.getXOrigin(), true),
+                     Property::convert_dbu(via_params.getYOrigin(), true))});
 
-    props.push_back({"Top Offset",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXTopOffset(), true),
-                                 Property::convert_dbu(via_params.getYTopOffset(), true))});
+    props.push_back(
+        {"Top Offset",
+         fmt::format("X={}, Y={}",
+                     Property::convert_dbu(via_params.getXTopOffset(), true),
+                     Property::convert_dbu(via_params.getYTopOffset(), true))});
 
-    props.push_back({"Bottom Offset",
-                     fmt::format(" X={}, Y={}",
-                                 Property::convert_dbu(via_params.getXBottomOffset(), true),
-                                 Property::convert_dbu(via_params.getYBottomOffset(), true))});     
+    props.push_back(
+        {"Bottom Offset",
+         fmt::format(
+             "X={}, Y={}",
+             Property::convert_dbu(via_params.getXBottomOffset(), true),
+             Property::convert_dbu(via_params.getYBottomOffset(), true))});
 
     PropertyList shapes;
     for (auto box : via->getBoxes()) {
@@ -2076,8 +2088,8 @@ Descriptor::Properties DbViaDescriptor::getProperties(std::any object) const
       auto layer = box->getTechLayer();
       auto rect = box->getBox();
       shapes.push_back({gui->makeSelected(layer), rect});
-    }    
-    props.push_back({"Shapes", shapes});  
+    }
+    props.push_back({"Shapes", shapes});
   }
 
   props.push_back({"Is Rotated", via->isViaRotated()});
@@ -2114,7 +2126,7 @@ bool DbViaDescriptor::getAllObjects(SelectionSet& objects) const
   if (chip == nullptr) {
     return false;
   }
-  
+
   auto block = chip->getBlock();
   if (block == nullptr) {
     return false;
@@ -3271,8 +3283,7 @@ bool DbTechViaDescriptor::getAllObjects(SelectionSet& objects) const
 }
 //////////////////////////////////////////////////
 
-DbTechViaRuleDescriptor::DbTechViaRuleDescriptor(odb::dbDatabase* db)
-    : db_(db)
+DbTechViaRuleDescriptor::DbTechViaRuleDescriptor(odb::dbDatabase* db) : db_(db)
 {
 }
 
@@ -3296,7 +3307,8 @@ void DbTechViaRuleDescriptor::highlight(std::any object, Painter& painter) const
 {
 }
 
-Descriptor::Properties DbTechViaRuleDescriptor::getProperties(std::any object) const
+Descriptor::Properties DbTechViaRuleDescriptor::getProperties(
+    std::any object) const
 {
   auto via_rule = std::any_cast<odb::dbTechViaRule*>(object);
   auto gui = Gui::get();
@@ -3310,21 +3322,23 @@ Descriptor::Properties DbTechViaRuleDescriptor::getProperties(std::any object) c
   props.push_back({"Tech Vias", vias});
 
   SelectionSet layer_rules;
-  for (uint rule_index = 0; rule_index < via_rule->getViaLayerRuleCount(); rule_index++) {
-    layer_rules.insert(gui->makeSelected(via_rule->getViaLayerRule(rule_index)));
+  for (uint rule_index = 0; rule_index < via_rule->getViaLayerRuleCount();
+       rule_index++) {
+    layer_rules.insert(
+        gui->makeSelected(via_rule->getViaLayerRule(rule_index)));
   }
   props.push_back({"Tech Via-Layer Rules", layer_rules});
 
   return props;
 }
-    
+
 Selected DbTechViaRuleDescriptor::makeSelected(std::any object) const
 {
- if(auto via_rule = std::any_cast<odb::dbTechViaRule*>(&object)) {
-  return Selected(*via_rule, this);
- }
+  if (auto via_rule = std::any_cast<odb::dbTechViaRule*>(&object)) {
+    return Selected(*via_rule, this);
+  }
 
- return Selected();
+  return Selected();
 }
 
 bool DbTechViaRuleDescriptor::lessThan(std::any l, std::any r) const
@@ -3364,16 +3378,19 @@ std::string DbTechViaLayerRuleDescriptor::getTypeName() const
   return "Tech Via-Layer Rule";
 }
 
-bool DbTechViaLayerRuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechViaLayerRuleDescriptor::getBBox(std::any object,
+                                           odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechViaLayerRuleDescriptor::highlight(std::any object, Painter& painter) const
+void DbTechViaLayerRuleDescriptor::highlight(std::any object,
+                                             Painter& painter) const
 {
 }
 
-Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any object) const
+Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(
+    std::any object) const
 {
   auto via_layer_rule = std::any_cast<odb::dbTechViaLayerRule*>(object);
   auto gui = Gui::get();
@@ -3383,16 +3400,17 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
   if (via_layer_rule->hasWidth()) {
     int minWidth = 0;
-    int maxWidth =  0;
+    int maxWidth = 0;
 
     via_layer_rule->getWidth(minWidth, maxWidth);
 
-    std::string width_range = fmt::format("{} to {}",
-                              Property::convert_dbu(minWidth, true),
-                              Property::convert_dbu(maxWidth, true));
+    std::string width_range
+        = fmt::format("{} to {}",
+                      Property::convert_dbu(minWidth, true),
+                      Property::convert_dbu(maxWidth, true));
 
     props.push_back({"Width", width_range});
-  }        
+  }
 
   if (via_layer_rule->hasEnclosure()) {
     int overhang_1 = 0;
@@ -3400,19 +3418,24 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
     via_layer_rule->getEnclosure(overhang_1, overhang_2);
 
-    std::string enclosure_rule = fmt::format("{} x {}",
-                                             Property::convert_dbu(overhang_1, true),
-                                             Property::convert_dbu(overhang_2, true));
+    std::string enclosure_rule
+        = fmt::format("{} x {}",
+                      Property::convert_dbu(overhang_1, true),
+                      Property::convert_dbu(overhang_2, true));
 
     props.push_back({"Enclosure", enclosure_rule});
   }
 
   if (via_layer_rule->hasOverhang()) {
-    props.push_back({"Overhang", Property::convert_dbu(via_layer_rule->getOverhang(), true)});
+    props.push_back(
+        {"Overhang",
+         Property::convert_dbu(via_layer_rule->getOverhang(), true)});
   }
 
   if (via_layer_rule->hasMetalOverhang()) {
-    props.push_back({"Metal Overhang", Property::convert_dbu(via_layer_rule->getMetalOverhang(), true)});
+    props.push_back(
+        {"Metal Overhang",
+         Property::convert_dbu(via_layer_rule->getMetalOverhang(), true)});
   }
 
   if (via_layer_rule->hasRect()) {
@@ -3428,14 +3451,16 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
     via_layer_rule->getSpacing(x_spacing, y_spacing);
 
-    props.push_back({"Spacing", fmt::format("{} x {}",
-                                            Property::convert_dbu(x_spacing, true),
-                                            Property::convert_dbu(y_spacing, true))});
+    props.push_back({"Spacing",
+                     fmt::format("{} x {}",
+                                 Property::convert_dbu(x_spacing, true),
+                                 Property::convert_dbu(y_spacing, true))});
   }
 
   if (via_layer_rule->hasResistance()) {
     props.push_back({"Resistance",
-                     convertUnits(via_layer_rule->getResistance()) + "\u03A9/sq"}); // ohm/sq
+                     convertUnits(via_layer_rule->getResistance())
+                         + "\u03A9/sq"});  // ohm/sq
   }
 
   return props;
@@ -3450,7 +3475,7 @@ Selected DbTechViaLayerRuleDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool DbTechViaLayerRuleDescriptor::lessThan(std::any l, std::any r) const 
+bool DbTechViaLayerRuleDescriptor::lessThan(std::any l, std::any r) const
 {
   auto l_via_layer_rule = std::any_cast<odb::dbTechViaLayerRule*>(l);
   auto r_via_layer_rule = std::any_cast<odb::dbTechViaLayerRule*>(r);
@@ -3463,10 +3488,12 @@ bool DbTechViaLayerRuleDescriptor::getAllObjects(SelectionSet& objects) const
   auto tech = db_->getTech();
 
   for (auto via_rule : tech->getViaRules()) {
-    for (uint via_layer_index = 0; via_layer_index < via_rule->getViaLayerRuleCount(); via_layer_index++) {
+    for (uint via_layer_index = 0;
+         via_layer_index < via_rule->getViaLayerRuleCount();
+         via_layer_index++) {
       objects.insert(makeSelected(via_rule->getViaLayerRule(via_layer_index)));
     }
-  } 
+  }
 
   return true;
 }

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -286,6 +286,12 @@ Descriptor::Properties DbTechDescriptor::getProperties(std::any object) const
   }
   props.push_back({"Tech Via Rules", via_rules});
 
+  SelectionSet generate_vias;
+  for (auto via : tech->getViaGenerateRules()) {
+    generate_vias.insert(gui->makeSelected(via));
+  }
+  props.push_back({"Tech Via Generate Rules", generate_vias});
+
   SelectionSet via_maps;
   for (auto map : tech->getMetalWidthViaMap()) {
     via_maps.insert(gui->makeSelected(map));
@@ -305,12 +311,6 @@ Descriptor::Properties DbTechDescriptor::getProperties(std::any object) const
     nondefault_rules.insert(gui->makeSelected(nondefault));
   }
   props.push_back({"Non-Default Rules", nondefault_rules});
-
-  SelectionSet generate_vias;
-  for (auto via : tech->getViaGenerateRules()) {
-    generate_vias.insert(gui->makeSelected(via));
-  }
-  props.push_back({"Via Generate Rules", generate_vias});
 
   return props;
 }
@@ -3355,7 +3355,7 @@ DbTechViaLayerRuleDescriptor::DbTechViaLayerRuleDescriptor(odb::dbDatabase* db)
 std::string DbTechViaLayerRuleDescriptor::getName(std::any object) const
 {
   auto via_layer_rule = std::any_cast<odb::dbTechViaLayerRule*>(object);
-  std::string rule_name = via_layer_rule->getLayer()->getName() + "_via_layer";
+  std::string rule_name = via_layer_rule->getLayer()->getName() + "_rule";
   return rule_name;
 }
 
@@ -3428,10 +3428,9 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
     via_layer_rule->getSpacing(x_spacing, y_spacing);
 
-    PropertyList spacing_rule;
-    spacing_rule.push_back({"X", Property::convert_dbu(x_spacing, true)});
-    spacing_rule.push_back({"Y", Property::convert_dbu(y_spacing, true)});
-    props.push_back({"Spacing", spacing_rule});
+    props.push_back({"Spacing", fmt::format("{} x {}",
+                                            Property::convert_dbu(x_spacing, true),
+                                            Property::convert_dbu(y_spacing, true))});
   }
 
   if (via_layer_rule->hasResistance()) {

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2015,7 +2015,7 @@ Descriptor::Properties DbViaDescriptor::getProperties(std::any object) const
 
   Properties props({{"Block", gui->makeSelected(via->getBlock())}});
 
-  if (via->getPattern().empty()) {
+  if (!via->getPattern().empty()) {
     props.push_back({"Pattern", via->getPattern()});
   }
 

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3145,13 +3145,13 @@ Descriptor::Properties DbTechViaRuleDescriptor::getProperties(std::any object) c
   Properties props;
 
   SelectionSet vias;
-  for (int via_index = 0; via_index < via_rule->getViaCount(); via_index++) {
+  for (uint via_index = 0; via_index < via_rule->getViaCount(); via_index++) {
     vias.insert(gui->makeSelected(via_rule->getVia(via_index)));
   }
   props.push_back({"Vias", vias});
 
   SelectionSet layer_rules;
-  for (int rule_index = 0; rule_index < via_rule->getViaLayerRuleCount(); rule_index++) {
+  for (uint rule_index = 0; rule_index < via_rule->getViaLayerRuleCount(); rule_index++) {
     layer_rules.insert(gui->makeSelected(via_rule->getViaLayerRule(rule_index)));
   }
   props.push_back({"Via-Layer Rules", layer_rules});
@@ -3304,11 +3304,11 @@ bool DbTechViaLayerRuleDescriptor::getAllObjects(SelectionSet& objects) const
 {
   auto tech = db_->getTech();
 
-  int index = 0;
   for (auto via_rule : tech->getViaRules()) {
-    objects.insert(makeSelected(via_rule->getViaLayerRule(index)));
-    index++;
-  }
+    for (uint via_layer_index = 0; via_layer_index < via_rule->getViaLayerRuleCount(); via_layer_index++) {
+      objects.insert(makeSelected(via_rule->getViaLayerRule(via_layer_index)));
+    }
+  } 
 
   return true;
 }

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3582,6 +3582,7 @@ Descriptor::Properties DbGenerateViaDescriptor::getProperties(
 
   Properties props;
 
+  SelectionSet via_layer_rules;
   PropertyList layers;
   for (uint l = 0; l < via->getViaLayerRuleCount(); l++) {
     auto* rule = via->getViaLayerRule(l);
@@ -3603,7 +3604,9 @@ Descriptor::Properties DbGenerateViaDescriptor::getProperties(
                                Property::convert_dbu(enc1, true));
     }
     layers.push_back({gui->makeSelected(layer), shape_text});
+    via_layer_rules.insert(gui->makeSelected(rule));
   }
+  props.push_back({"Tech Via-Layer Rules", via_layer_rules});
   props.push_back({"Layers", layers});
 
   props.push_back({"Is default", via->isDefault()});

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -284,7 +284,7 @@ Descriptor::Properties DbTechDescriptor::getProperties(std::any object) const
   for (auto via_rule : tech->getViaRules()) {
     via_rules.insert(gui->makeSelected(via_rule));
   }
-  props.push_back({"Via Rules", via_rules});
+  props.push_back({"Tech Via Rules", via_rules});
 
   SelectionSet via_maps;
   for (auto map : tech->getMetalWidthViaMap()) {
@@ -3307,13 +3307,13 @@ Descriptor::Properties DbTechViaRuleDescriptor::getProperties(std::any object) c
   for (uint via_index = 0; via_index < via_rule->getViaCount(); via_index++) {
     vias.insert(gui->makeSelected(via_rule->getVia(via_index)));
   }
-  props.push_back({"Vias", vias});
+  props.push_back({"Tech Vias", vias});
 
   SelectionSet layer_rules;
   for (uint rule_index = 0; rule_index < via_rule->getViaLayerRuleCount(); rule_index++) {
     layer_rules.insert(gui->makeSelected(via_rule->getViaLayerRule(rule_index)));
   }
-  props.push_back({"Via-Layer Rules", layer_rules});
+  props.push_back({"Tech Via-Layer Rules", layer_rules});
 
   return props;
 }

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3228,11 +3228,10 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
     via_layer_rule->getWidth(minWidth, maxWidth);
 
-    std::string width_range;
-
-    width_range = fmt::format("{} to {}",
+    std::string width_range = fmt::format("{} to {}",
                               Property::convert_dbu(minWidth, true),
                               Property::convert_dbu(maxWidth, true));
+
     props.push_back({"Width", width_range});
   }        
 
@@ -3242,25 +3241,26 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
 
     via_layer_rule->getEnclosure(overhang_1, overhang_2);
 
-    PropertyList enclosure;
-    enclosure.push_back({"Overhang 1", Property::convert_dbu(overhang_1, true)});
-    enclosure.push_back({"Overhang 2", Property::convert_dbu(overhang_2, true)});
-    props.push_back({"Enclosure Rule", enclosure});
+    std::string enclosure_rule = fmt::format("{} x {}",
+                                             Property::convert_dbu(overhang_1, true),
+                                             Property::convert_dbu(overhang_2, true));
+
+    props.push_back({"Enclosure", enclosure_rule});
   }
 
   if (via_layer_rule->hasOverhang()) {
-    props.push_back({"Overhang Rule", Property::convert_dbu(via_layer_rule->getOverhang(), true)});
+    props.push_back({"Overhang", Property::convert_dbu(via_layer_rule->getOverhang(), true)});
   }
 
   if (via_layer_rule->hasMetalOverhang()) {
-    props.push_back({"Metal Overhang Rule", Property::convert_dbu(via_layer_rule->getMetalOverhang(), true)});
+    props.push_back({"Metal Overhang", Property::convert_dbu(via_layer_rule->getMetalOverhang(), true)});
   }
 
   if (via_layer_rule->hasRect()) {
     odb::Rect rect_rule;
     via_layer_rule->getRect(rect_rule);
 
-    props.push_back({"Rectangle Rule", rect_rule});
+    props.push_back({"Rectangle", rect_rule});
   }
 
   if (via_layer_rule->hasSpacing()) {
@@ -3272,11 +3272,12 @@ Descriptor::Properties DbTechViaLayerRuleDescriptor::getProperties(std::any obje
     PropertyList spacing_rule;
     spacing_rule.push_back({"X", Property::convert_dbu(x_spacing, true)});
     spacing_rule.push_back({"Y", Property::convert_dbu(y_spacing, true)});
-    props.push_back({"Spacing Rule", spacing_rule});
+    props.push_back({"Spacing", spacing_rule});
   }
 
   if (via_layer_rule->hasResistance()) {
-    props.push_back({"Resistance Rule", convertUnits(via_layer_rule->getResistance()) + "\u03A9/sq"}); // ohm/sq
+    props.push_back({"Resistance",
+                     convertUnits(via_layer_rule->getResistance()) + "\u03A9/sq"}); // ohm/sq
   }
 
   return props;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2063,19 +2063,22 @@ Descriptor::Properties DbViaDescriptor::getProperties(std::any object) const
                                  Property::convert_dbu(via_params.getXBottomOffset(), true),
                                  Property::convert_dbu(via_params.getYBottomOffset(), true))});     
 
-    PropertyList layers({{"Top", gui->makeSelected(via_params.getTopLayer())},
-                         {"Cut", gui->makeSelected(via_params.getCutLayer())},
-                         {"Bottom", gui->makeSelected(via_params.getBottomLayer())}});
-    props.push_back({"Layers", layers});
+    PropertyList shapes;
+    for (auto box : via->getBoxes()) {
+      auto layer = box->getTechLayer();
+      auto rect = box->getBox();
+      shapes.push_back({gui->makeSelected(layer), rect});
+    }
+    props.push_back({"Shapes", shapes});
   } else {
-    props.push_back({"Top Layer", gui->makeSelected(via->getTopLayer())});
-    props.push_back({"Bottom Layer", gui->makeSelected(via->getBottomLayer())});    
+    PropertyList shapes;
+    for (auto box : via->getBoxes()) {
+      auto layer = box->getTechLayer();
+      auto rect = box->getBox();
+      shapes.push_back({gui->makeSelected(layer), rect});
+    }    
+    props.push_back({"Shapes", shapes});  
   }
-
-  std::cout << "++++++++++++++++++++++++++" << std::endl;
-  std::cout << "Número de boxes no set:" << via->getBoxes().size() << std::endl;
-  std::cout << "++++++++++++++++++++++++++" << std::endl;
-  //getBoxes???
 
   props.push_back({"Is Rotated", via->isViaRotated()});
 

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -596,7 +596,7 @@ class DbNonDefaultRuleDescriptor : public Descriptor
 };
 
 class DbTechLayerRuleDescriptor : public Descriptor
-{ 
+{
  public:
   std::string getName(std::any object) const override;
   std::string getTypeName() const override;

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -547,7 +547,7 @@ class DbTechViaLayerRuleDescriptor : public Descriptor
   bool getAllObjects(SelectionSet& objects) const override;
 
  private:
-  odb::dbDatabase* db_;  
+  odb::dbDatabase* db_;
 };
 
 class DbMetalWidthViaMapDescriptor : public Descriptor

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -303,6 +303,27 @@ class DbBTermDescriptor : public Descriptor
   odb::dbDatabase* db_;
 };
 
+class DbViaDescriptor : public Descriptor
+{
+ public:
+  DbViaDescriptor(odb::dbDatabase* db);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+};
+
 class DbBlockageDescriptor : public Descriptor
 {
  public:

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -485,6 +485,28 @@ class DbTechViaDescriptor : public Descriptor
   odb::dbDatabase* db_;
 };
 
+class DbTechViaRuleDescriptor : public Descriptor
+{
+ public:
+  DbTechViaRuleDescriptor(odb::dbDatabase* db);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+};
+
 class DbMetalWidthViaMapDescriptor : public Descriptor
 {
  public:

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -507,6 +507,28 @@ class DbTechViaRuleDescriptor : public Descriptor
   odb::dbDatabase* db_;
 };
 
+class DbTechViaLayerRuleDescriptor : public Descriptor
+{
+ public:
+  DbTechViaLayerRuleDescriptor(odb::dbDatabase*);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;  
+};
+
 class DbMetalWidthViaMapDescriptor : public Descriptor
 {
  public:
@@ -574,7 +596,7 @@ class DbNonDefaultRuleDescriptor : public Descriptor
 };
 
 class DbTechLayerRuleDescriptor : public Descriptor
-{
+{ 
  public:
   std::string getName(std::any object) const override;
   std::string getTypeName() const override;

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -498,6 +498,7 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbTech*>(new DbTechDescriptor(db_));
   gui->registerDescriptor<odb::dbMetalWidthViaMap*>(
       new DbMetalWidthViaMapDescriptor(db_));
+  gui->registerDescriptor<odb::dbTechViaRule*>(new DbTechViaRuleDescriptor(db_));
 
   gui->registerDescriptor<BufferTree>(
       new BufferTreeDescriptor(db_,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -471,6 +471,7 @@ void MainWindow::init(sta::dbSta* sta)
                           viewer_->getNetTracks()));
   gui->registerDescriptor<odb::dbITerm*>(new DbITermDescriptor(db_));
   gui->registerDescriptor<odb::dbBTerm*>(new DbBTermDescriptor(db_));
+  gui->registerDescriptor<odb::dbVia*>(new DbViaDescriptor(db_));
   gui->registerDescriptor<odb::dbBlockage*>(new DbBlockageDescriptor(db_));
   gui->registerDescriptor<odb::dbObstruction*>(
       new DbObstructionDescriptor(db_));

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -481,6 +481,8 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbRegion*>(new DbRegionDescriptor(db_));
   gui->registerDescriptor<odb::dbModule*>(new DbModuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechVia*>(new DbTechViaDescriptor(db_));
+  gui->registerDescriptor<odb::dbTechViaRule*>(new DbTechViaRuleDescriptor(db_));
+  gui->registerDescriptor<odb::dbTechViaLayerRule*>(new DbTechViaLayerRuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechViaGenerateRule*>(
       new DbGenerateViaDescriptor(db_));
   gui->registerDescriptor<odb::dbTechNonDefaultRule*>(
@@ -498,7 +500,6 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbTech*>(new DbTechDescriptor(db_));
   gui->registerDescriptor<odb::dbMetalWidthViaMap*>(
       new DbMetalWidthViaMapDescriptor(db_));
-  gui->registerDescriptor<odb::dbTechViaRule*>(new DbTechViaRuleDescriptor(db_));
 
   gui->registerDescriptor<BufferTree>(
       new BufferTreeDescriptor(db_,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -482,8 +482,10 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbRegion*>(new DbRegionDescriptor(db_));
   gui->registerDescriptor<odb::dbModule*>(new DbModuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechVia*>(new DbTechViaDescriptor(db_));
-  gui->registerDescriptor<odb::dbTechViaRule*>(new DbTechViaRuleDescriptor(db_));
-  gui->registerDescriptor<odb::dbTechViaLayerRule*>(new DbTechViaLayerRuleDescriptor(db_));
+  gui->registerDescriptor<odb::dbTechViaRule*>(
+      new DbTechViaRuleDescriptor(db_));
+  gui->registerDescriptor<odb::dbTechViaLayerRule*>(
+      new DbTechViaLayerRuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechViaGenerateRule*>(
       new DbGenerateViaDescriptor(db_));
   gui->registerDescriptor<odb::dbTechNonDefaultRule*>(


### PR DESCRIPTION
This PR is to be linked with the Issue #3404.

With these changes I'm adding the remaining properties in the Technology and Block inspection which were requested by @gadfort and listed in #3477.

Some important considerations:
In the dbVia, I created a property list Shapes, because a dbVia may have more than 3 geometries as the cut layer may have more than one. As the layers can be inspected through this new property, I thought there was no need to create a "Layers" property of its own.

The way the DbTechViaLayerRuleDescriptor is currently implemented, there will be inevitably via-layer rules with the same name. I couldn't find a solution to that, because there is neither a getName() method nor a way to access the ViaRule through the dbTechViaLayerRule object (The latter would make possible to create a name such as: via_rule_name + layer_name).