### PR TITLE
dft: misc refactors

### DIFF
--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -137,16 +137,10 @@ std::vector<std::unique_ptr<ScanChain>> Dft::replaceAndArchitect()
   std::vector<std::unique_ptr<ScanCell>> scan_cells
       = CollectScanCells(db_, sta_, logger_);
 
-  std::vector<std::shared_ptr<ScanCell>> shared_scan_cells;
-  std::move(scan_cells.begin(),
-            scan_cells.end(),
-            std::back_inserter(shared_scan_cells));
-
   // Scan Architect
   std::unique_ptr<ScanCellsBucket> scan_cells_bucket
       = std::make_unique<ScanCellsBucket>(logger_);
-  scan_cells_bucket->init(dft_config_->getScanArchitectConfig(),
-                          shared_scan_cells);
+  scan_cells_bucket->init(dft_config_->getScanArchitectConfig(), scan_cells);
 
   std::unique_ptr<ScanArchitect> scan_architect
       = ScanArchitect::ConstructScanScanArchitect(

--- a/src/dft/src/architect/ScanArchitect.hh
+++ b/src/dft/src/architect/ScanArchitect.hh
@@ -53,11 +53,11 @@ class ScanCellsBucket
   ScanCellsBucket& operator=(const ScanCellsBucket&) = delete;
 
   // Gets the next scan cell of the given hash domain
-  std::shared_ptr<ScanCell> pop(size_t hash_domain);
+  std::unique_ptr<ScanCell> pop(size_t hash_domain);
 
   // Init the scan cell bucket with with the given config and scan cells
   void init(const ScanArchitectConfig& config,
-            const std::vector<std::shared_ptr<ScanCell>>& scan_cells);
+            std::vector<std::unique_ptr<ScanCell>>& scan_cells);
 
   // Returns the number of bits we need to include in each hash domain
   std::unordered_map<size_t, uint64_t> getTotalBitsPerHashDomain() const;
@@ -66,7 +66,7 @@ class ScanCellsBucket
   uint64_t numberOfCells(size_t hash_domain) const;
 
  private:
-  std::unordered_map<size_t, std::vector<std::shared_ptr<ScanCell>>> buckets_;
+  std::unordered_map<size_t, std::vector<std::unique_ptr<ScanCell>>> buckets_;
   utl::Logger* logger_;
 };
 

--- a/src/dft/src/architect/ScanArchitectHeuristic.cpp
+++ b/src/dft/src/architect/ScanArchitectHeuristic.cpp
@@ -35,6 +35,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "ClockDomain.hh"
 #include "ScanArchitect.hh"
 
 namespace dft {
@@ -55,9 +56,9 @@ void ScanArchitectHeuristic::architect()
           = hash_domain_to_limits_.find(hash_domain)->second.max_length;
       while (current_chain->getBits() < max_length
              && scan_cells_bucket_->numberOfCells(hash_domain)) {
-        std::shared_ptr<ScanCell> scan_cell
+        std::unique_ptr<ScanCell> scan_cell
             = scan_cells_bucket_->pop(hash_domain);
-        current_chain->add(scan_cell);
+        current_chain->add(std::move(scan_cell));
       }
     }
   }

--- a/src/dft/src/architect/ScanArchitectHeuristic.cpp
+++ b/src/dft/src/architect/ScanArchitectHeuristic.cpp
@@ -66,6 +66,7 @@ void ScanArchitectHeuristic::architect()
           [](std::vector<std::unique_ptr<ScanCell>>& falling,
              std::vector<std::unique_ptr<ScanCell>>& rising,
              std::vector<std::unique_ptr<ScanCell>>& sorted) {
+            sorted.reserve(falling.size() + rising.size());
             // Falling edge first
             std::move(
                 falling.begin(), falling.end(), std::back_inserter(sorted));

--- a/src/dft/src/architect/ScanArchitectHeuristic.cpp
+++ b/src/dft/src/architect/ScanArchitectHeuristic.cpp
@@ -60,6 +60,17 @@ void ScanArchitectHeuristic::architect()
             = scan_cells_bucket_->pop(hash_domain);
         current_chain->add(std::move(scan_cell));
       }
+
+      // TODO: Perform an actual sorting to reduce the wire length
+      current_chain->sortScanCells(
+          [](std::vector<std::unique_ptr<ScanCell>>& falling,
+             std::vector<std::unique_ptr<ScanCell>>& rising,
+             std::vector<std::unique_ptr<ScanCell>>& sorted) {
+            // Falling edge first
+            std::move(
+                falling.begin(), falling.end(), std::back_inserter(sorted));
+            std::move(rising.begin(), rising.end(), std::back_inserter(sorted));
+          });
     }
   }
 }

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -63,9 +63,10 @@ uint64_t ScanChain::getBits() const
   return bits_;
 }
 
-void ScanChain::sortScanCells(const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
-                                                       std::vector<std::unique_ptr<ScanCell>>&,
-                                                       std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn)
+void ScanChain::sortScanCells(
+    const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
+                             std::vector<std::unique_ptr<ScanCell>>&,
+                             std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn)
 {
   sort_fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
   // At this point, falling_edge_scan_cells_ and rising_edge_scan_cells_ will be

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -63,9 +63,11 @@ uint64_t ScanChain::getBits() const
   return bits_;
 }
 
-void ScanChain::sortScanCells(SortFn fn)
+void ScanChain::sortScanCells(const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
+                                                       std::vector<std::unique_ptr<ScanCell>>&,
+                                                       std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn)
 {
-  fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
+  sort_fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
   // At this point, falling_edge_scan_cells_ and rising_edge_scan_cells_ will be
   // with just null, we clear and reduce the memory of the vectors
 

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -92,18 +92,18 @@ void ScanChain::report(utl::Logger* logger, bool verbose) const
     return;
   }
 
-  std::string current_clock_name;
-
+  size_t current_clock_domain_id = 0;
   // First negative triggered cells
   for (const auto& scan_cell : scan_cells_) {
-    if (current_clock_name != scan_cell->getClockDomain().getClockName()) {
+    if (current_clock_domain_id
+        != scan_cell->getClockDomain().getClockDomainId()) {
       const ClockDomain& clock_domain = scan_cell->getClockDomain();
       // Change of clock domain, show the clock
       logger->report("  {:s} ({:s}, {:s})",
                      scan_cell->getName(),
                      clock_domain.getClockName(),
                      clock_domain.getClockEdgeName());
-      current_clock_name = scan_cell->getClockDomain().getClockName();
+      current_clock_domain_id = scan_cell->getClockDomain().getClockDomainId();
     } else {
       logger->report("  {:s}", scan_cell->getName());
     }

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -55,7 +55,7 @@ void ScanChain::add(std::unique_ptr<ScanCell> scan_cell)
 
 bool ScanChain::empty() const
 {
-  return rising_edge_scan_cells_.empty() && falling_edge_scan_cells_.empty();
+  return scan_cells_.empty();
 }
 
 uint64_t ScanChain::getBits() const
@@ -63,25 +63,29 @@ uint64_t ScanChain::getBits() const
   return bits_;
 }
 
-const std::vector<std::unique_ptr<ScanCell>>&
-ScanChain::getRisingEdgeScanCells() const
+void ScanChain::sortScanCells(SortFn fn)
 {
-  return rising_edge_scan_cells_;
+  fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
+  // At this point, falling_edge_scan_cells_ and rising_edge_scan_cells_ will be
+  // with just null, we clear and reduce the memory of the vectors
+
+  falling_edge_scan_cells_.clear();
+  rising_edge_scan_cells_.clear();
+
+  falling_edge_scan_cells_.shrink_to_fit();
+  rising_edge_scan_cells_.shrink_to_fit();
 }
 
-const std::vector<std::unique_ptr<ScanCell>>&
-ScanChain::getFallingEdgeScanCells() const
+const std::vector<std::unique_ptr<ScanCell>>& ScanChain::getScanCells() const
 {
-  return falling_edge_scan_cells_;
+  return scan_cells_;
 }
 
 void ScanChain::report(utl::Logger* logger, bool verbose) const
 {
-  const size_t total_cells
-      = falling_edge_scan_cells_.size() + rising_edge_scan_cells_.size();
   logger->report("Scan chain '{:s}' has {:d} cells ({:d} bits)\n",
                  name_,
-                 total_cells,
+                 scan_cells_.size(),
                  bits_);
 
   if (!verbose) {
@@ -91,25 +95,14 @@ void ScanChain::report(utl::Logger* logger, bool verbose) const
   std::string current_clock_name;
 
   // First negative triggered cells
-  for (const auto& scan_cell : falling_edge_scan_cells_) {
+  for (const auto& scan_cell : scan_cells_) {
     if (current_clock_name != scan_cell->getClockDomain().getClockName()) {
+      const ClockDomain& clock_domain = scan_cell->getClockDomain();
       // Change of clock domain, show the clock
-      logger->report("  {:s} ({:s}, falling)",
+      logger->report("  {:s} ({:s}, {:s})",
                      scan_cell->getName(),
-                     scan_cell->getClockDomain().getClockName());
-      current_clock_name = scan_cell->getClockDomain().getClockName();
-    } else {
-      logger->report("  {:s}", scan_cell->getName());
-    }
-  }
-
-  // Then positive edge cells
-  for (const auto& scan_cell : rising_edge_scan_cells_) {
-    if (current_clock_name != scan_cell->getClockDomain().getClockName()) {
-      // Change of clock domain, show the clock
-      logger->report("  {:s} ({:s}, rising)",
-                     scan_cell->getName(),
-                     scan_cell->getClockDomain().getClockName());
+                     clock_domain.getClockName(),
+                     clock_domain.getClockEdgeName());
       current_clock_name = scan_cell->getClockDomain().getClockName();
     } else {
       logger->report("  {:s}", scan_cell->getName());

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -40,17 +40,17 @@ ScanChain::ScanChain(const std::string& name) : name_(name), bits_(0)
 {
 }
 
-void ScanChain::add(const std::shared_ptr<ScanCell>& scan_cell)
+void ScanChain::add(std::unique_ptr<ScanCell> scan_cell)
 {
+  bits_ += scan_cell->getBits();
   switch (scan_cell->getClockDomain().getClockEdge()) {
     case ClockEdge::Rising:
-      rising_edge_scan_cells_.push_back(scan_cell);
+      rising_edge_scan_cells_.push_back(std::move(scan_cell));
       break;
     case ClockEdge::Falling:
-      falling_edge_scan_cells_.push_back(scan_cell);
+      falling_edge_scan_cells_.push_back(std::move(scan_cell));
       break;
   }
-  bits_ += scan_cell->getBits();
 }
 
 bool ScanChain::empty() const
@@ -63,13 +63,13 @@ uint64_t ScanChain::getBits() const
   return bits_;
 }
 
-const std::vector<std::shared_ptr<ScanCell>>&
+const std::vector<std::unique_ptr<ScanCell>>&
 ScanChain::getRisingEdgeScanCells() const
 {
   return rising_edge_scan_cells_;
 }
 
-const std::vector<std::shared_ptr<ScanCell>>&
+const std::vector<std::unique_ptr<ScanCell>>&
 ScanChain::getFallingEdgeScanCells() const
 {
   return falling_edge_scan_cells_;

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -50,7 +50,13 @@ namespace dft {
 //  - Find the scan enable of the chain
 class ScanChain
 {
+ private:
+  using ScanCells = std::vector<std::unique_ptr<ScanCell>>;
+
  public:
+  // Function to sort the scan cells. (falling, rising, output vector)
+  using SortFn = const std::function<void(ScanCells&, ScanCells&, ScanCells&)>&;
+
   explicit ScanChain(const std::string& name);
   // Not copyable or movable
   ScanChain(const ScanChain&) = delete;
@@ -67,11 +73,11 @@ class ScanChain
   // we update every time we add a scan cell
   uint64_t getBits() const;
 
-  // Returns a reference to a vector containing only rising edge scan cells
-  const std::vector<std::unique_ptr<ScanCell>>& getRisingEdgeScanCells() const;
+  // Sorts the scan cells of this chain
+  void sortScanCells(SortFn sort_fn);
 
-  // Returns a reference to a vector containing only falling edge scan cells
-  const std::vector<std::unique_ptr<ScanCell>>& getFallingEdgeScanCells() const;
+  // Returns a reference to a vector containing all the scan cells of the chain
+  const std::vector<std::unique_ptr<ScanCell>>& getScanCells() const;
 
   // Reports this scan chain contents. If verbose is true, the cells of the
   // chains are also going to be printed
@@ -84,6 +90,8 @@ class ScanChain
   std::string name_;
   std::vector<std::unique_ptr<ScanCell>> rising_edge_scan_cells_;
   std::vector<std::unique_ptr<ScanCell>> falling_edge_scan_cells_;
+  // The final container of the scan cells once sorted by Scan Architect
+  std::vector<std::unique_ptr<ScanCell>> scan_cells_;
 
   // The total bits in this scan chain. Scan cells can contain more than one
   // bit, that's why this is different from the number of cells.

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -58,7 +58,7 @@ class ScanChain
 
   // Adds a scan cell to the chain. Depending on the edge of the cell, we will
   // move the cell to rising or falling vectors.
-  void add(const std::shared_ptr<ScanCell>& scan_cell);
+  void add(std::unique_ptr<ScanCell> scan_cell);
 
   // Returns true if the scan chain is empty
   bool empty() const;
@@ -68,10 +68,10 @@ class ScanChain
   uint64_t getBits() const;
 
   // Returns a reference to a vector containing only rising edge scan cells
-  const std::vector<std::shared_ptr<ScanCell>>& getRisingEdgeScanCells() const;
+  const std::vector<std::unique_ptr<ScanCell>>& getRisingEdgeScanCells() const;
 
   // Returns a reference to a vector containing only falling edge scan cells
-  const std::vector<std::shared_ptr<ScanCell>>& getFallingEdgeScanCells() const;
+  const std::vector<std::unique_ptr<ScanCell>>& getFallingEdgeScanCells() const;
 
   // Reports this scan chain contents. If verbose is true, the cells of the
   // chains are also going to be printed
@@ -82,8 +82,8 @@ class ScanChain
 
  private:
   std::string name_;
-  std::vector<std::shared_ptr<ScanCell>> rising_edge_scan_cells_;
-  std::vector<std::shared_ptr<ScanCell>> falling_edge_scan_cells_;
+  std::vector<std::unique_ptr<ScanCell>> rising_edge_scan_cells_;
+  std::vector<std::unique_ptr<ScanCell>> falling_edge_scan_cells_;
 
   // The total bits in this scan chain. Scan cells can contain more than one
   // bit, that's why this is different from the number of cells.

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -50,13 +50,7 @@ namespace dft {
 //  - Find the scan enable of the chain
 class ScanChain
 {
- private:
-  using ScanCells = std::vector<std::unique_ptr<ScanCell>>;
-
  public:
-  // Function to sort the scan cells. (falling, rising, output vector)
-  using SortFn = const std::function<void(ScanCells&, ScanCells&, ScanCells&)>&;
-
   explicit ScanChain(const std::string& name);
   // Not copyable or movable
   ScanChain(const ScanChain&) = delete;
@@ -73,8 +67,11 @@ class ScanChain
   // we update every time we add a scan cell
   uint64_t getBits() const;
 
-  // Sorts the scan cells of this chain
-  void sortScanCells(SortFn sort_fn);
+  // Sorts the scan cells of this chain.  This function has 3 arguments: falling
+  // cells, rising cells and the output vector with the sorted cells
+  void sortScanCells(const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
+                                              std::vector<std::unique_ptr<ScanCell>>&,
+                                              std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn);
 
   // Returns a reference to a vector containing all the scan cells of the chain
   const std::vector<std::unique_ptr<ScanCell>>& getScanCells() const;

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -69,9 +69,11 @@ class ScanChain
 
   // Sorts the scan cells of this chain.  This function has 3 arguments: falling
   // cells, rising cells and the output vector with the sorted cells
-  void sortScanCells(const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
-                                              std::vector<std::unique_ptr<ScanCell>>&,
-                                              std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn);
+  void sortScanCells(
+      const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
+                               std::vector<std::unique_ptr<ScanCell>>&,
+                               std::vector<std::unique_ptr<ScanCell>>&)>&
+          sort_fn);
 
   // Returns a reference to a vector containing all the scan cells of the chain
   const std::vector<std::unique_ptr<ScanCell>>& getScanCells() const;

--- a/src/dft/src/cells/ScanCell.cpp
+++ b/src/dft/src/cells/ScanCell.cpp
@@ -43,7 +43,7 @@ ScanCell::ScanCell(const std::string& name,
 {
 }
 
-const std::string& ScanCell::getName() const
+std::string_view ScanCell::getName() const
 {
   return name_;
 }

--- a/src/dft/src/cells/ScanCell.hh
+++ b/src/dft/src/cells/ScanCell.hh
@@ -67,7 +67,7 @@ class ScanCell
   virtual ScanDriver getScanOut() const = 0;
 
   const ClockDomain& getClockDomain() const;
-  const std::string& getName() const;
+  std::string_view getName() const;
 
  private:
   std::string name_;

--- a/src/dft/src/clock_domain/ClockDomain.cpp
+++ b/src/dft/src/clock_domain/ClockDomain.cpp
@@ -42,7 +42,7 @@ std::function<size_t(const ClockDomain&)> GetClockDomainHashFn(
     // For NoMix, every clock domain is different
     case ScanArchitectConfig::ClockMixing::NoMix:
       return [](const ClockDomain& clock_domain) {
-        return std::hash<std::string>{}(clock_domain.getClockName())
+        return std::hash<std::string_view>{}(clock_domain.getClockName())
                ^ std::hash<ClockEdge>{}(clock_domain.getClockEdge());
       };
     case ScanArchitectConfig::ClockMixing::ClockMix:
@@ -58,7 +58,7 @@ ClockDomain::ClockDomain(const std::string& clock_name, ClockEdge clock_edge)
 {
 }
 
-const std::string& ClockDomain::getClockName() const
+std::string_view ClockDomain::getClockName() const
 {
   return clock_name_;
 }
@@ -66,6 +66,22 @@ const std::string& ClockDomain::getClockName() const
 ClockEdge ClockDomain::getClockEdge() const
 {
   return clock_edge_;
+}
+
+std::string_view ClockDomain::getClockEdgeName() const
+{
+  switch (clock_edge_) {
+    case ClockEdge::Rising:
+      return "rising";
+      break;
+    case ClockEdge::Falling:
+      return "falling";
+      break;
+    default:
+      // TODO replace with std::unreachable() once we reach c++23
+      return "";
+      break;
+  }
 }
 
 }  // namespace dft

--- a/src/dft/src/clock_domain/ClockDomain.cpp
+++ b/src/dft/src/clock_domain/ClockDomain.cpp
@@ -84,4 +84,10 @@ std::string_view ClockDomain::getClockEdgeName() const
   }
 }
 
+size_t ClockDomain::getClockDomainId() const
+{
+  return std::hash<std::string_view>{}(clock_name_)
+         ^ std::hash<ClockEdge>{}(clock_edge_);
+}
+
 }  // namespace dft

--- a/src/dft/src/clock_domain/ClockDomain.cpp
+++ b/src/dft/src/clock_domain/ClockDomain.cpp
@@ -77,11 +77,9 @@ std::string_view ClockDomain::getClockEdgeName() const
     case ClockEdge::Falling:
       return "falling";
       break;
-    default:
-      // TODO replace with std::unreachable() once we reach c++23
-      return "";
-      break;
   }
+  // TODO replace with std::unreachable() once we reach c++23
+  return "Unknown clock edge";
 }
 
 size_t ClockDomain::getClockDomainId() const

--- a/src/dft/src/clock_domain/ClockDomain.hh
+++ b/src/dft/src/clock_domain/ClockDomain.hh
@@ -55,8 +55,9 @@ class ClockDomain
   ClockDomain(ClockDomain&& other) = default;
   ClockDomain& operator=(ClockDomain&& other) = default;
 
-  const std::string& getClockName() const;
+  std::string_view getClockName() const;
   ClockEdge getClockEdge() const;
+  std::string_view getClockEdgeName() const;
 
  private:
   std::string clock_name_;

--- a/src/dft/src/clock_domain/ClockDomain.hh
+++ b/src/dft/src/clock_domain/ClockDomain.hh
@@ -59,6 +59,9 @@ class ClockDomain
   ClockEdge getClockEdge() const;
   std::string_view getClockEdgeName() const;
 
+  // Returns a unique id that can be use to identify a particular clock domain
+  size_t getClockDomainId() const;
+
  private:
   std::string clock_name_;
   ClockEdge clock_edge_;

--- a/src/dft/src/stitch/ScanStitch.cpp
+++ b/src/dft/src/stitch/ScanStitch.cpp
@@ -50,16 +50,12 @@ void ScanStitch::Stitch(odb::dbBlock* block,
   std::deque<std::reference_wrapper<const std::unique_ptr<ScanCell>>>
       scan_cells;
 
-  const std::vector<std::unique_ptr<ScanCell>>& falling_edge
-      = scan_chain.getFallingEdgeScanCells();
-  const std::vector<std::unique_ptr<ScanCell>>& rising_edge
-      = scan_chain.getRisingEdgeScanCells();
+  const std::vector<std::unique_ptr<ScanCell>>& original_scan_cells
+      = scan_chain.getScanCells();
 
-  // Falling edge first
-  std::copy(
-      falling_edge.begin(), falling_edge.end(), std::back_inserter(scan_cells));
-  std::copy(
-      rising_edge.begin(), rising_edge.end(), std::back_inserter(scan_cells));
+  std::copy(original_scan_cells.cbegin(),
+            original_scan_cells.cend(),
+            std::back_inserter(scan_cells));
 
   // All the cells in the scan chain are controlled by the same scan enable
   for (const std::unique_ptr<ScanCell>& scan_cell : scan_cells) {

--- a/src/dft/src/stitch/ScanStitch.cpp
+++ b/src/dft/src/stitch/ScanStitch.cpp
@@ -47,11 +47,12 @@ void ScanStitch::Stitch(odb::dbBlock* block,
   ScanDriver scan_in_port = FindOrCreateScanIn(block);
 
   // We need fast pop for front and back
-  std::deque<std::shared_ptr<ScanCell>> scan_cells;
+  std::deque<std::reference_wrapper<const std::unique_ptr<ScanCell>>>
+      scan_cells;
 
-  const std::vector<std::shared_ptr<ScanCell>>& falling_edge
+  const std::vector<std::unique_ptr<ScanCell>>& falling_edge
       = scan_chain.getFallingEdgeScanCells();
-  const std::vector<std::shared_ptr<ScanCell>>& rising_edge
+  const std::vector<std::unique_ptr<ScanCell>>& rising_edge
       = scan_chain.getRisingEdgeScanCells();
 
   // Falling edge first
@@ -61,13 +62,13 @@ void ScanStitch::Stitch(odb::dbBlock* block,
       rising_edge.begin(), rising_edge.end(), std::back_inserter(scan_cells));
 
   // All the cells in the scan chain are controlled by the same scan enable
-  for (const auto& scan_cell : scan_cells) {
+  for (const std::unique_ptr<ScanCell>& scan_cell : scan_cells) {
     scan_cell->connectScanEnable(scan_enable);
   }
 
   // Lets get the first and last cell
-  const std::shared_ptr<ScanCell>& first_scan_cell = *scan_cells.begin();
-  const std::shared_ptr<ScanCell>& last_scan_cell = *(scan_cells.end() - 1);
+  const std::unique_ptr<ScanCell>& first_scan_cell = *scan_cells.begin();
+  const std::unique_ptr<ScanCell>& last_scan_cell = *(scan_cells.end() - 1);
 
   if (!scan_cells.empty()) {
     scan_cells.pop_front();
@@ -77,11 +78,11 @@ void ScanStitch::Stitch(odb::dbBlock* block,
     scan_cells.pop_back();
   }
 
-  for (auto current = scan_cells.begin(); current != scan_cells.end();
-       ++current) {
-    auto next = current + 1;
+  for (auto it = scan_cells.begin(); it != scan_cells.end(); ++it) {
+    const std::unique_ptr<ScanCell>& current = *it;
+    const std::unique_ptr<ScanCell>& next = *(it + 1);
     // Connects current cell scan out to next cell scan in
-    (*next)->connectScanIn((*current)->getScanOut());
+    next->connectScanIn(current->getScanOut());
   }
 
   // Let's connect the first cell
@@ -89,7 +90,7 @@ void ScanStitch::Stitch(odb::dbBlock* block,
   first_scan_cell->connectScanIn(scan_in_port);
 
   if (!scan_cells.empty()) {
-    (*scan_cells.begin())->connectScanIn(first_scan_cell->getScanOut());
+    scan_cells.begin()->get()->connectScanIn(first_scan_cell->getScanOut());
   } else {
     // If last_scan_cell == first_scan_cell, then scan in was already connected
     if (last_scan_cell != first_scan_cell) {

--- a/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
+++ b/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
@@ -22,14 +22,14 @@ BOOST_AUTO_TEST_CASE(test_one_clock_domain_no_mix)
   ScanArchitectConfig config;
   config.setClockMixing(ScanArchitectConfig::ClockMixing::NoMix);
   config.setMaxLength(10);
-  std::vector<std::shared_ptr<ScanCell>> scan_cells;
+  std::vector<std::unique_ptr<ScanCell>> scan_cells;
   std::vector<std::string> scan_cell_names;
 
   for (uint64_t i = 0; i < 20; ++i) {
     std::stringstream ss;
     ss << "scan_cell" << i;
     scan_cell_names.push_back(ss.str());
-    scan_cells.push_back(std::make_shared<ScanCellMock>(
+    scan_cells.push_back(std::make_unique<ScanCellMock>(
         ss.str(),
         std::make_unique<ClockDomain>("clk1", ClockEdge::Rising),
         logger));
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(test_two_clock_domain_no_mix)
   ScanArchitectConfig config;
   config.setClockMixing(ScanArchitectConfig::ClockMixing::NoMix);
   config.setMaxLength(10);
-  std::vector<std::shared_ptr<ScanCell>> scan_cells;
+  std::vector<std::unique_ptr<ScanCell>> scan_cells;
   std::vector<std::string> scan_cell_names;
 
   uint64_t name_number = 0;
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(test_two_clock_domain_no_mix)
     ss << "scan_cell" << name_number;
     ++name_number;
     scan_cell_names.push_back(ss.str());
-    scan_cells.push_back(std::make_shared<ScanCellMock>(
+    scan_cells.push_back(std::make_unique<ScanCellMock>(
         ss.str(),
         std::make_unique<ClockDomain>("clk1", ClockEdge::Rising),
         logger));
@@ -95,7 +95,7 @@ BOOST_AUTO_TEST_CASE(test_two_clock_domain_no_mix)
     ss << "scan_cell" << name_number;
     ++name_number;
     scan_cell_names.push_back(ss.str());
-    scan_cells.push_back(std::make_shared<ScanCellMock>(
+    scan_cells.push_back(std::make_unique<ScanCellMock>(
         ss.str(),
         std::make_unique<ClockDomain>("clk2", ClockEdge::Rising),
         logger));
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(test_two_edges_no_mix)
   ScanArchitectConfig config;
   config.setClockMixing(ScanArchitectConfig::ClockMixing::NoMix);
   config.setMaxLength(10);
-  std::vector<std::shared_ptr<ScanCell>> scan_cells;
+  std::vector<std::unique_ptr<ScanCell>> scan_cells;
   std::vector<std::string> scan_cell_names;
 
   uint64_t name_number = 0;
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(test_two_edges_no_mix)
     ss << "scan_cell" << name_number;
     ++name_number;
     scan_cell_names.push_back(ss.str());
-    scan_cells.push_back(std::make_shared<ScanCellMock>(
+    scan_cells.push_back(std::make_unique<ScanCellMock>(
         ss.str(),
         std::make_unique<ClockDomain>("clk1", ClockEdge::Rising),
         logger));
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(test_two_edges_no_mix)
     ss << "scan_cell" << name_number;
     ++name_number;
     scan_cell_names.push_back(ss.str());
-    scan_cells.push_back(std::make_shared<ScanCellMock>(
+    scan_cells.push_back(std::make_unique<ScanCellMock>(
         ss.str(),
         std::make_unique<ClockDomain>("clk1", ClockEdge::Falling),
         logger));

--- a/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
+++ b/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
@@ -51,10 +51,10 @@ BOOST_AUTO_TEST_CASE(test_one_clock_domain_no_mix)
   BOOST_TEST(scan_chains.size() == 2);
 
   // All the scan cells should be in the chains
-  std::unordered_set<std::string> scan_cells_in_chains_names;
+  std::unordered_set<std::string_view> scan_cells_in_chains_names;
   for (const std::unique_ptr<ScanChain>& scan_chain : scan_chains) {
-    BOOST_TEST(!scan_chain->empty());  // All the cells should have cells
-    for (const auto& scan_cell : scan_chain->getRisingEdgeScanCells()) {
+    BOOST_TEST(!scan_chain->empty());  // All the chains should have cells
+    for (const auto& scan_cell : scan_chain->getScanCells()) {
       scan_cells_in_chains_names.insert(scan_cell->getName());
     }
   }
@@ -118,10 +118,9 @@ BOOST_AUTO_TEST_CASE(test_two_clock_domain_no_mix)
 
   uint64_t total_bits = 0;
   for (const auto& scan_chain : scan_chains) {
-    for (const auto& scan_cell : scan_chain->getRisingEdgeScanCells()) {
+    for (const auto& scan_cell : scan_chain->getScanCells()) {
       total_bits += scan_cell->getBits();
     }
-    BOOST_TEST(scan_chain->getFallingEdgeScanCells().empty());
   }
   BOOST_TEST(total_bits == 20 + 15);
 }
@@ -179,11 +178,15 @@ BOOST_AUTO_TEST_CASE(test_two_edges_no_mix)
   uint64_t total_bits_rising = 0;
   uint64_t total_bits_falling = 0;
   for (const auto& scan_chain : scan_chains) {
-    for (const auto& scan_cell : scan_chain->getRisingEdgeScanCells()) {
-      total_bits_rising += scan_cell->getBits();
-    }
-    for (const auto& scan_cell : scan_chain->getFallingEdgeScanCells()) {
-      total_bits_falling += scan_cell->getBits();
+    for (const auto& scan_cell : scan_chain->getScanCells()) {
+      switch (scan_cell->getClockDomain().getClockEdge()) {
+        case ClockEdge::Falling:
+          total_bits_falling += scan_cell->getBits();
+          break;
+        case ClockEdge::Rising:
+          total_bits_rising += scan_cell->getBits();
+          break;
+      }
     }
   }
   BOOST_TEST(total_bits_rising == 20);

--- a/src/dft/test/scan_architect_clock_mix_sky130.ok
+++ b/src/dft/test/scan_architect_clock_mix_sky130.ok
@@ -22,7 +22,7 @@ Scan chain 'chain_1' has 3 cells (3 bits)
 
   ff10_clk2_falling (clock2, falling)
   ff4_clk2_falling
-  ff10_clk2_rising
+  ff10_clk2_rising (clock2, rising)
 
 Scan chain 'chain_2' has 3 cells (3 bits)
 


### PR DESCRIPTION
Several refactors:

* changing shared_ptrs to unique_ptr in dft code. The owner should be the scan chains
* Changing the responsibility of sorting the scan cells inside the scan chains to architect instead of stitch. Stitch should only create the connectivity and not decide the order of the scan cells.
* Fix a small bug where we didn't show  the change of clock if we were changing clock edges.