### PR TITLE
Reduce data transferred in distributed detailed routing

### DIFF
--- a/src/drt/src/db/drObj/drNet.cpp
+++ b/src/drt/src/db/drObj/drNet.cpp
@@ -49,9 +49,6 @@ template <class Archive>
 void drNet::serialize(Archive& ar, const unsigned int version)
 {
   (ar) & boost::serialization::base_object<drBlockObject>(*this);
-  // (ar) & pins_;
-  // (ar) & extConnFigs_;
-  // (ar) & routeConnFigs_;
   (ar) & bestRouteConnFigs_;
   (ar) & modified_;
   (ar) & numMarkers_;
@@ -65,26 +62,13 @@ void drNet::serialize(Archive& ar, const unsigned int version)
   (ar) & maxRipupAvoids_;
   (ar) & inQueue_;
   (ar) & routed_;
-  // (ar) & origGuides_;
   if (is_loading(ar)) {
     frBlockObject* obj;
     serializeBlockObject(ar, obj);
     fNet_ = (frNet*) obj;
-    // int terms_sz = 0;
-    // (ar) & terms_sz;
-    // while (terms_sz--) {
-    //   serializeBlockObject(ar, obj);
-    //   fNetTerms_.insert(obj);
-    // }
   } else {
     frBlockObject* obj = (frBlockObject*) fNet_;
     serializeBlockObject(ar, obj);
-    // int terms_sz = fNetTerms_.size();
-    // (ar) & terms_sz;
-    // for (auto fNetTerm : fNetTerms_) {
-    //   obj = (frBlockObject*) fNetTerm;
-    //   serializeBlockObject(ar, obj);
-    // }
   }
 }
 

--- a/src/drt/src/db/drObj/drNet.cpp
+++ b/src/drt/src/db/drObj/drNet.cpp
@@ -49,9 +49,9 @@ template <class Archive>
 void drNet::serialize(Archive& ar, const unsigned int version)
 {
   (ar) & boost::serialization::base_object<drBlockObject>(*this);
-  (ar) & pins_;
-  (ar) & extConnFigs_;
-  (ar) & routeConnFigs_;
+  // (ar) & pins_;
+  // (ar) & extConnFigs_;
+  // (ar) & routeConnFigs_;
   (ar) & bestRouteConnFigs_;
   (ar) & modified_;
   (ar) & numMarkers_;
@@ -65,26 +65,26 @@ void drNet::serialize(Archive& ar, const unsigned int version)
   (ar) & maxRipupAvoids_;
   (ar) & inQueue_;
   (ar) & routed_;
-  (ar) & origGuides_;
+  // (ar) & origGuides_;
   if (is_loading(ar)) {
     frBlockObject* obj;
     serializeBlockObject(ar, obj);
     fNet_ = (frNet*) obj;
-    int terms_sz = 0;
-    (ar) & terms_sz;
-    while (terms_sz--) {
-      serializeBlockObject(ar, obj);
-      fNetTerms_.insert(obj);
-    }
+    // int terms_sz = 0;
+    // (ar) & terms_sz;
+    // while (terms_sz--) {
+    //   serializeBlockObject(ar, obj);
+    //   fNetTerms_.insert(obj);
+    // }
   } else {
     frBlockObject* obj = (frBlockObject*) fNet_;
     serializeBlockObject(ar, obj);
-    int terms_sz = fNetTerms_.size();
-    (ar) & terms_sz;
-    for (auto fNetTerm : fNetTerms_) {
-      obj = (frBlockObject*) fNetTerm;
-      serializeBlockObject(ar, obj);
-    }
+    // int terms_sz = fNetTerms_.size();
+    // (ar) & terms_sz;
+    // for (auto fNetTerm : fNetTerms_) {
+    //   obj = (frBlockObject*) fNetTerm;
+    //   serializeBlockObject(ar, obj);
+    // }
   }
 }
 

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -1236,14 +1236,8 @@ void FlexDRWorker::serialize(Archive& ar, const unsigned int version)
   (ar) & workerMarkerCost_;
   (ar) & workerFixedShapeCost_;
   (ar) & workerMarkerDecay_;
-  // (ar) & pinCnt_;
   (ar) & initNumMarkers_;
-  // (ar) & apSVia_;
-  // (ar) & planarHistoryMarkers_;
-  // (ar) & viaHistoryMarkers_;
-  // (ar) & historyMarkers_;
   (ar) & nets_;
-  // (ar) & gridGraph_;
   (ar) & markers_;
   (ar) & bestMarkers_;
   (ar) & isCongested_;
@@ -1288,7 +1282,6 @@ std::unique_ptr<FlexDRWorker> FlexDRWorker::load(const std::string& workerStr,
   // We need to fix up the fields we want from the current run rather
   // than the stored ones.
   worker->setLogger(logger);
-  // worker->getGridGraph().setLogger(logger);
   worker->setGraphics(graphics);
 
   return worker;

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -1236,18 +1236,20 @@ void FlexDRWorker::serialize(Archive& ar, const unsigned int version)
   (ar) & workerMarkerCost_;
   (ar) & workerFixedShapeCost_;
   (ar) & workerMarkerDecay_;
-  (ar) & pinCnt_;
+  // (ar) & pinCnt_;
   (ar) & initNumMarkers_;
-  (ar) & apSVia_;
-  (ar) & planarHistoryMarkers_;
-  (ar) & viaHistoryMarkers_;
-  (ar) & historyMarkers_;
+  // (ar) & apSVia_;
+  // (ar) & planarHistoryMarkers_;
+  // (ar) & viaHistoryMarkers_;
+  // (ar) & historyMarkers_;
   (ar) & nets_;
-  (ar) & gridGraph_;
+  // (ar) & gridGraph_;
   (ar) & markers_;
   (ar) & bestMarkers_;
   (ar) & isCongested_;
   if (is_loading(ar)) {
+    gridGraph_.setTech(design_->getTech());
+    gridGraph_.setWorker(this);
     // boundaryPin_
     int sz = 0;
     (ar) & sz;
@@ -1286,6 +1288,7 @@ std::unique_ptr<FlexDRWorker> FlexDRWorker::load(const std::string& workerStr,
   // We need to fix up the fields we want from the current run rather
   // than the stored ones.
   worker->setLogger(logger);
+  // worker->getGridGraph().setLogger(logger);
   worker->setGraphics(graphics);
 
   return worker;

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -141,7 +141,9 @@ std::string FlexDRWorker::reloadedMain()
              1,
              "Init number of markers {}",
              getInitNumMarkers());
-  route_queue();
+  if (!skipRouting_) {
+    route_queue();
+  }
   setGCWorker(nullptr);
   cleanup();
   std::string workerStr;

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -445,7 +445,11 @@ class FlexDRWorker
   bool end(frDesign* design);
 
   Logger* getLogger() { return logger_; }
-  void setLogger(Logger* logger) { logger_ = logger; }
+  void setLogger(Logger* logger)
+  {
+    logger_ = logger;
+    gridGraph_.setLogger(logger);
+  }
 
   static std::unique_ptr<FlexDRWorker> load(const std::string& file_name,
                                             utl::Logger* logger,

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -372,6 +372,9 @@ class FlexGridGraph
     return sol;
   }
   // setters
+  void setTech(frTechObject* techIn) { tech_ = techIn; }
+  void setLogger(Logger* loggerIn) { logger_ = loggerIn; }
+  void setWorker(FlexDRWorker* workerIn) { drWorker_ = workerIn; }
   bool addEdge(frMIdx x,
                frMIdx y,
                frMIdx z,

--- a/src/drt/test/gcd_nangate45_distributed.tcl
+++ b/src/drt/test/gcd_nangate45_distributed.tcl
@@ -5,7 +5,7 @@ set server1 [exec $OR server1.tcl > results/server1.log &]
 set server2 [exec $OR server2.tcl > results/server2.log &]
 set balancer [exec $OR balancer.tcl > results/balancer.log &]
 set base [exec $OR -exit gcd_nangate45.tcl > results/base.log &]
-
+exec sleep 3
 read_lef Nangate45/Nangate45_tech.lef
 read_lef Nangate45/Nangate45_stdcell.lef
 read_def gcd_nangate45_preroute.def


### PR DESCRIPTION
In this PR, I am reducing the data sent to servers and received by leaders to the minimal needed form. I studied the data needed by both ends. The server only needs the initial data of worker including the routebox, extBox, costs and markers. The leader only needs the nets and the bestMarkers. The nets don't need to include the initial segments, it only needs the final segments to be committed to the design.
The main part that has beed reduced here is the gridGraph. The server doesn't need the gridGraph since it initializes it. and the leader doesn't need the gridGraph back. This minimization showed noticeable speedup and memory recduction in distributed detailed routing.