### PR TITLE
fixes #3573: GUI designs with origin not at ( 0 , 0 )

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -247,7 +247,9 @@ Rect LayoutViewer::getBounds() const
 
   Rect die = block_->getDieArea();
 
-  bbox.merge(die);
+  Rect visible(0, 0, die.xMax(), die.yMax());
+
+  bbox.merge(visible);
 
   return bbox;
 }


### PR DESCRIPTION
Fixes #3573.

The die was actually being painted, but outside the scope of the layoutviewer’s viewport.