### PR TITLE
gui: add trigger action command to swig to allow for easier debugging

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -644,6 +644,9 @@ class Gui
   // show/hide widgets
   void showWidget(const std::string& name, bool show);
 
+  // trigger actions in the GUI
+  void triggerAction(const std::string& name);
+
   // adding custom buttons to toolbar
   std::string addToolbarButton(const std::string& name,
                                const std::string& text,

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -637,5 +637,14 @@ void clear_focus_nets()
   gui->clearFocusNets();
 }
 
+void trigger_action(const std::string& name)
+{
+  if (!check_gui("trigger_action")) {
+    return;
+  }
+  auto gui = gui::Gui::get();
+  gui->triggerAction(name);
+}
+
 %} // inline
 

--- a/src/gui/src/stub.cpp
+++ b/src/gui/src/stub.cpp
@@ -99,6 +99,10 @@ void Gui::status(const std::string& /* message */)
 {
 }
 
+void Gui::triggerAction(const std::string& /* action */)
+{
+}
+
 void Renderer::redraw()
 {
 }


### PR DESCRIPTION
This should add a swig command `gui::trigger_action`, which should not be for general use, but only debugging.

FYI @maliberty 

For https://github.com/The-OpenROAD-Project/OpenROAD/issues/3609 you would just need to do `gui::trigger_action "timing_report.Update"`