### PR TITLE
rsz: print progress

### DIFF
--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -168,6 +168,7 @@ repair_timing [-setup]
               [-repair_tns tns_end_percent]
               [-max_utilization util]
               [-max_buffer_percent buffer_percent]
+              [-verbose]
 ```
 
 The `repair_timing` command repairs setup and hold violations.  It
@@ -175,8 +176,10 @@ should be run after clock tree synthesis with propagated clocks.
 Setup repair is done before hold repair so that hold repair does not
 cause setup checks to fail. While repairing hold violations buffers
 are not inserted that will cause setup violations unless
-'-allow_setup_violations' is specified.
+`-allow_setup_violations` is specified.
 Use `-setup_margin/-hold_margin` to add additional slack margin.
+Use `-verbose` to print more information about the progress of the
+repair.
 
 The worst setup path is always repaired.  Next, violating paths to
 endpoints are repaired to reduced the total negative slack.  The

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -228,6 +228,7 @@ public:
   void repairSetup(double setup_margin,
                    double repair_tns_end_percent,
                    int max_passes,
+                   bool verbose,
                    bool skip_pin_swap,
                    bool skip_gate_cloning);
   // For testing.
@@ -243,7 +244,8 @@ public:
                   bool allow_setup_violations,
                   // Max buffer count as percent of design instance count.
                   float max_buffer_percent,
-                  int max_passes);
+                  int max_passes,
+                  bool verbose);
   void repairHold(const Pin *end_pin,
                   double setup_margin,
                   double hold_margin,

--- a/src/rsz/src/RepairHold.hh
+++ b/src/rsz/src/RepairHold.hh
@@ -73,7 +73,8 @@ public:
                   bool allow_setup_violations,
                   // Max buffer count as percent of design instance count.
                   float max_buffer_percent,
-                  int max_passes);
+                  int max_passes,
+                  bool verbose);
   void repairHold(const Pin *end_pin,
                   double setup_margin,
                   double hold_margin,
@@ -100,7 +101,8 @@ private:
                   double hold_margin,
                   bool allow_setup_violations,
                   int max_buffer_count,
-                  int max_passes);
+                  int max_passes,
+                  bool verbose);
   void repairHoldPass(VertexSeq &ends,
                       LibertyCell *buffer_cell,
                       double setup_margin,
@@ -123,6 +125,8 @@ private:
   void mergeInto(Slacks &slacks,
                  Slacks &result);
 
+  void printProgress(int iteration, bool force, bool end) const;
+
   Logger *logger_;
   dbSta *sta_;
   dbNetwork *db_network_;
@@ -139,6 +143,7 @@ private:
   const int fall_index_;
 
   static constexpr float hold_slack_limit_ratio_max_ = 0.2;
+  static constexpr int print_interval_ = 10;
 };
 
 } // namespace

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -142,6 +142,11 @@ RepairSetup::repairSetup(float setup_slack_margin,
              endpoints->size(),
              int(violating_ends.size() / double(endpoints->size()) * 100));
 
+  if (!violating_ends.empty()) {
+    logger_->info(RSZ, 94, "Found {} endpoints with setup violations.",
+                  violating_ends.size());
+  }
+
   int end_index = 0;
   int max_end_count = violating_ends.size() * repair_tns_end_percent;
   // Always repair the worst endpoint, even if tns percent is zero.

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -111,6 +111,7 @@ void
 RepairSetup::repairSetup(float setup_slack_margin,
                          double repair_tns_end_percent,
                          int max_passes,
+                         bool verbose,
                          bool skip_pin_swap,
                          bool enable_gate_cloning)
 {
@@ -153,6 +154,10 @@ RepairSetup::repairSetup(float setup_slack_margin,
   max_end_count = max(max_end_count, 1);
   swap_pin_inst_map_.clear(); // Make sure we do not swap the same pin twice.
   resizer_->incrementalParasiticsBegin();
+  int print_iteration = 0;
+  if (verbose) {
+    printProgress(print_iteration, false, false);
+  }
   for (Vertex *end : violating_ends) {
     resizer_->updateParasitics();
     sta_->findRequireds();
@@ -174,6 +179,11 @@ RepairSetup::repairSetup(float setup_slack_margin,
     int decreasing_slack_passes = 0;
     resizer_->journalBegin();
     while (pass <= max_passes) {
+      print_iteration++;
+      if (verbose) {
+        printProgress(print_iteration, false, false);
+      }
+
       if (end_slack > setup_slack_margin) {
         debugPrint(logger_, RSZ, "repair_setup", 2,
                    "Restoring best slack end slack {} worst slack {}",
@@ -245,6 +255,12 @@ RepairSetup::repairSetup(float setup_slack_margin,
         end = worst_vertex;
       pass++;
     }
+    if (verbose) {
+      printProgress(print_iteration, true, false);
+    }
+  }
+  if (verbose) {
+    printProgress(print_iteration, true, true);
   }
   // Leave the parasitics up to date.
   resizer_->updateParasitics();
@@ -963,4 +979,42 @@ RepairSetup::equivCellPins(const LibertyCell *cell, sta::LibertyPortSet &ports)
         }
     }
 }
+
+void
+RepairSetup::printProgress(int iteration, bool force, bool end) const
+{
+  const bool start = iteration == 0;
+
+  if (start) {
+    logger_->report("Iteration | Resized | Buffers | Cloned Gates | Pin Swaps |   WNS   |   TNS   | Endpoint");
+    logger_->report("---------------------------------------------------------------------------------------");
+  }
+
+  if (iteration % print_interval_ == 0 || force || end) {
+    Slack wns;
+    Vertex* worst_vertex;
+    sta_->worstSlack(max_, wns, worst_vertex);
+    const Slack tns = sta_->totalNegativeSlack(max_);
+
+    std::string itr_field = fmt::format("{}", iteration);
+    if (end) {
+      itr_field = "final";
+    }
+
+    logger_->report("{: >9s} | {: >7d} | {: >7d} | {: >12d} | {: >9d} | {: >7s} | {: >7s} | {}",
+                    itr_field,
+                    resize_count_,
+                    inserted_buffer_count_ + split_load_buffer_count_ + rebuffer_net_count_,
+                    cloned_gate_count_,
+                    swap_pin_count_,
+                    delayAsString(wns, sta_, 3),
+                    delayAsString(tns, sta_, 3),
+                    worst_vertex->name(network_));
+  }
+
+  if (end) {
+    logger_->report("---------------------------------------------------------------------------------------");
+  }
+}
+
 }  // namespace rsz

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -84,6 +84,7 @@ public:
                    // reduce tns (0.0-1.0).
                    double repair_tns_end_percent,
                    int max_passes,
+                   bool verbose,
                    bool skip_pin_swap,
                    bool enable_gate_cloning);
   // For testing.
@@ -144,6 +145,8 @@ private:
   Slack slackPenalized(BufferedNetPtr bnet,
                        int index);
 
+  void printProgress(int iteration, bool force, bool end) const;
+
   Logger *logger_;
   dbSta *sta_;
   dbNetwork *db_network_;
@@ -170,6 +173,7 @@ private:
   static constexpr int rebuffer_max_fanout_ = 20;
   static constexpr int split_load_min_fanout_ = 8;
   static constexpr double rebuffer_buffer_penalty_ = .01;
+  static constexpr int print_interval_ = 10;
 };
 
 } // namespace

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2564,6 +2564,7 @@ void
 Resizer::repairSetup(double setup_margin,
                      double repair_tns_end_percent,
                      int max_passes,
+                     bool verbose,
                      bool skip_pin_swap,
                      bool enable_gate_cloning)
 {
@@ -2572,7 +2573,8 @@ Resizer::repairSetup(double setup_margin,
     opendp_->initMacrosAndGrid();
   }
   repair_setup_->repairSetup(setup_margin, repair_tns_end_percent,
-                             max_passes, skip_pin_swap, enable_gate_cloning);
+                             max_passes, verbose,
+                             skip_pin_swap, enable_gate_cloning);
 }
 
 void
@@ -2597,7 +2599,8 @@ Resizer::repairHold(double setup_margin,
                     bool allow_setup_violations,
                     // Max buffer count as percent of design instance count.
                     float max_buffer_percent,
-                    int max_passes)
+                    int max_passes,
+                    bool verbose)
 {
   resizePreamble();
   if (parasitics_src_ == ParasiticsSrc::global_routing) {
@@ -2605,7 +2608,8 @@ Resizer::repairHold(double setup_margin,
   }
   repair_hold_->repairHold(setup_margin, hold_margin,
                            allow_setup_violations,
-                           max_buffer_percent, max_passes);
+                           max_buffer_percent, max_passes,
+                           verbose);
 }
 
 void

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -478,12 +478,14 @@ void
 repair_setup(double setup_margin,
              double repair_tns_end_percent,
              int max_passes,
+             bool verbose,
              bool skip_pin_swap, bool enable_gate_cloning)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
   resizer->repairSetup(setup_margin, repair_tns_end_percent,
-                       max_passes, skip_pin_swap, enable_gate_cloning);
+                       max_passes, verbose,
+                       skip_pin_swap, enable_gate_cloning);
 }
 
 void
@@ -499,13 +501,15 @@ repair_hold(double setup_margin,
             double hold_margin,
             bool allow_setup_violations,
             float max_buffer_percent,
-            int max_passes)
+            int max_passes,
+            bool verbose)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
   resizer->repairHold(setup_margin, hold_margin,
                       allow_setup_violations,
-                      max_buffer_percent, max_passes);
+                      max_buffer_percent, max_passes,
+                      verbose);
 }
 
 void

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -394,14 +394,15 @@ sta::define_cmd_args "repair_timing" {[-setup] [-hold]\
                                         [-enable_gate_cloning)]\
                                         [-repair_tns tns_end_percent]\
                                         [-max_buffer_percent buffer_percent]\
-                                        [-max_utilization util]}
+                                        [-max_utilization util] \
+                                        [-verbose]}
 
 proc repair_timing { args } {
   sta::parse_key_args "repair_timing" args \
     keys {-setup_margin -hold_margin -slack_margin \
             -libraries -max_utilization -max_buffer_percent \
             -repair_tns -max_passes} \
-    flags {-setup -hold -allow_setup_violations -skip_pin_swap -enable_gate_cloning}
+    flags {-setup -hold -allow_setup_violations -skip_pin_swap -enable_gate_cloning -verbose}
 
   set setup [info exists flags(-setup)]
   set hold [info exists flags(-hold)]
@@ -443,6 +444,11 @@ proc repair_timing { args } {
     set repair_tns_end_percent [expr $repair_tns_end_percent / 100.0]
   }
 
+  set verbose 0
+  if { [info exists flags(-verbose)] } {
+    set verbose 1
+  }
+
   set max_passes 10000
   if { [info exists keys(-max_passes)] } {
     set max_passes $keys(-max_passes)
@@ -450,11 +456,14 @@ proc repair_timing { args } {
   sta::check_argc_eq0 "repair_timing" $args
   rsz::check_parasitics
   if { $setup } {
-    rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes $skip_pin_swap $enable_gate_cloning
+    rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes \
+      $verbose \
+      $skip_pin_swap $enable_gate_cloning
   }
   if { $hold } {
     rsz::repair_hold $setup_margin $hold_margin \
-      $allow_setup_violations $max_buffer_percent $max_passes
+      $allow_setup_violations $max_buffer_percent $max_passes \
+      $verbose
   }
 }
 

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -98,4 +98,6 @@ record_tests {
   repair_wire10
   repair_wire11
   gcd_resize
+  repair_setup4_verbose
+  repair_hold9_verbose
 }

--- a/src/rsz/test/repair_fanout6.ok
+++ b/src/rsz/test/repair_fanout6.ok
@@ -19,6 +19,7 @@ Pin                                   Limit Fanout  Slack
 ---------------------------------------------------------
 fanout1/X                                20     20      0 (MET)
 
+[INFO RSZ-0094] Found 6400 endpoints with setup violations.
 [INFO RSZ-0045] Inserted 17 buffers, 1 to split loads.
 [INFO RSZ-0041] Resized 67 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.

--- a/src/rsz/test/repair_fanout7.ok
+++ b/src/rsz/test/repair_fanout7.ok
@@ -11,6 +11,7 @@ load DFF_X1 CK D 300000 metal3 1000
 [INFO ODB-0132]     Created 2 special nets and 306 connections.
 [INFO ODB-0133]     Created 4 nets and 307 connections.
 worst slack -23.63
+[INFO RSZ-0094] Found 150 endpoints with setup violations.
 [INFO RSZ-0040] Inserted 81 buffers.
 [INFO RSZ-0041] Resized 326 instances.
 [INFO RSZ-0049] Cloned 7 instances.

--- a/src/rsz/test/repair_fanout8.ok
+++ b/src/rsz/test/repair_fanout8.ok
@@ -11,6 +11,7 @@ load DFF_X1 CK D 300000 metal3 1000
 [INFO ODB-0132]     Created 2 special nets and 306 connections.
 [INFO ODB-0133]     Created 4 nets and 307 connections.
 worst slack -23.63
+[INFO RSZ-0094] Found 150 endpoints with setup violations.
 [INFO RSZ-0045] Inserted 37 buffers, 1 to split loads.
 [INFO RSZ-0041] Resized 22 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.

--- a/src/rsz/test/repair_hold9_verbose.ok
+++ b/src/rsz/test/repair_hold9_verbose.ok
@@ -1,0 +1,22 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 571 components and 2554 component-terminals.
+[INFO ODB-0132]     Created 5 special nets and 1142 connections.
+[INFO ODB-0133]     Created 528 nets and 1412 connections.
+Design area 670 u^2 10% utilization.
+[INFO RSZ-0046] Found 35 endpoints with hold violations.
+Iteration | Resized | Buffers | Cloned Gates |   WNS   |   TNS   | Endpoint
+---------------------------------------------------------------------------
+        0 |       0 |       0 |            0 |   0.145 |   0.000 | _863_/D
+    final |       0 |     163 |            0 |   0.214 |   0.000 | _880_/D
+---------------------------------------------------------------------------
+[WARNING RSZ-0064] Unable to repair all hold checks within margin.
+[INFO RSZ-0032] Inserted 163 hold buffers.
+[ERROR RSZ-0060] Max buffer count reached.
+RSZ-0060
+Design area 800 u^2 13% utilization.

--- a/src/rsz/test/repair_hold9_verbose.tcl
+++ b/src/rsz/test/repair_hold9_verbose.tcl
@@ -1,0 +1,15 @@
+# repair_timing -hold -max_buffer_percent
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def gcd_nangate45_placed.def
+create_clock [get_ports clk] -name core_clock -period 2
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+report_design_area
+catch {repair_timing -verbose -hold -hold_margin .4 -max_buffer_percent 2} error
+puts $error
+report_design_area

--- a/src/rsz/test/repair_setup1.ok
+++ b/src/rsz/test/repair_setup1.ok
@@ -45,6 +45,7 @@ Path Type: max
            -0.333   slack (VIOLATED)
 
 
+[INFO RSZ-0094] Found 4 endpoints with setup violations.
 [INFO RSZ-0040] Inserted 3 buffers.
 [INFO RSZ-0041] Resized 18 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.

--- a/src/rsz/test/repair_setup2.ok
+++ b/src/rsz/test/repair_setup2.ok
@@ -13,6 +13,7 @@ worst slack -0.28
 [INFO RSZ-0037] Found 3 long wires.
 [INFO RSZ-0038] Inserted 3 buffers in 3 nets.
 [INFO RSZ-0039] Resized 2 instances.
+[INFO RSZ-0094] Found 2 endpoints with setup violations.
 [INFO RSZ-0041] Resized 2 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.
 worst slack -0.12

--- a/src/rsz/test/repair_setup3.ok
+++ b/src/rsz/test/repair_setup3.ok
@@ -10,5 +10,6 @@
 [INFO ODB-0131]     Created 6 components and 29 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 6 nets and 13 connections.
+[INFO RSZ-0094] Found 2 endpoints with setup violations.
 [INFO RSZ-0041] Resized 2 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.

--- a/src/rsz/test/repair_setup4.ok
+++ b/src/rsz/test/repair_setup4.ok
@@ -9,6 +9,7 @@
 [INFO ODB-0132]     Created 2 special nets and 34 connections.
 [INFO ODB-0133]     Created 7 nets and 30 connections.
 worst slack -1.95
+[INFO RSZ-0094] Found 6 endpoints with setup violations.
 [INFO RSZ-0040] Inserted 2 buffers.
 [INFO RSZ-0041] Resized 17 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.

--- a/src/rsz/test/repair_setup4_verbose.ok
+++ b/src/rsz/test/repair_setup4_verbose.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: reg1
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 17 components and 92 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 34 connections.
+[INFO ODB-0133]     Created 7 nets and 30 connections.
+worst slack -1.95
+[INFO RSZ-0094] Found 6 endpoints with setup violations.
+Iteration | Resized | Buffers | Cloned Gates | Pin Swaps |   WNS   |   TNS   | Endpoint
+---------------------------------------------------------------------------------------
+        0 |       0 |       0 |            0 |         0 |  -1.954 |  -6.294 | r2/D
+       10 |       8 |       3 |            0 |         0 |  -0.865 |  -3.085 | r2/D
+       19 |      17 |       3 |            0 |        -2 |  -0.654 |  -2.908 | r2/D
+    final |      17 |       3 |            0 |        -2 |  -0.654 |  -2.908 | r2/D
+---------------------------------------------------------------------------------------
+[INFO RSZ-0040] Inserted 2 buffers.
+[INFO RSZ-0041] Resized 17 instances.
+[WARNING RSZ-0062] Unable to repair all setup violations.
+worst slack -0.65

--- a/src/rsz/test/repair_setup4_verbose.tcl
+++ b/src/rsz/test/repair_setup4_verbose.tcl
@@ -1,0 +1,16 @@
+# repair_timing -setup 2 corners
+source "helpers.tcl"
+define_corners fast slow
+read_liberty -corner slow Nangate45/Nangate45_slow.lib
+read_liberty -corner fast Nangate45/Nangate45_fast.lib
+read_lef Nangate45/Nangate45.lef
+read_def repair_setup1.def
+create_clock -period 0.3 clk
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+report_worst_slack -max
+repair_timing -verbose -setup
+report_worst_slack -max

--- a/src/rsz/test/repair_setup5.ok
+++ b/src/rsz/test/repair_setup5.ok
@@ -11,5 +11,6 @@
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 6 nets and 10 connections.
 worst slack -1.88
+[INFO RSZ-0094] Found 1 endpoints with setup violations.
 [INFO RSZ-0041] Resized 15 instances.
 worst slack 0.09

--- a/src/rsz/test/repair_setup6.ok
+++ b/src/rsz/test/repair_setup6.ok
@@ -19,6 +19,7 @@ legalized HPWL           2533.0 u
 delta HPWL                    0 %
 
 worst slack -0.39
+[INFO RSZ-0094] Found 4 endpoints with setup violations.
 [INFO RSZ-0040] Inserted 2 buffers.
 [INFO RSZ-0041] Resized 18 instances.
 [WARNING RSZ-0062] Unable to repair all setup violations.


### PR DESCRIPTION
Adds:
- adds number of violating endpoints to setup repair (to mirror the behavior of the repair hold).
- adds a `-verbose` to `repair_timing` to print the status of the repair.

Motivation:
repair_timing can run for a very long time on some designs and it would be helpful to be able to see what progress if any is actually being made.

Current format:
```
Iteration | Resized | Buffers | Cloned Gates | Pin Swaps |   WNS   |   TNS   | Endpoint
```
printed every 10 repairs (could increase of decrease that). It doesn't seem to impact the runtime (atleast from what I could tell).
If there are suggestions for alternative headings or phrasing I think that would be helpful, since I just grabbed the first set that came to mind.

@maliberty @openroadie I noticed that the pin swap goes negative (this seems counter intuitive to me, I assume that is not correct).