### PR TITLE
[Docs] drt documentation

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -68,7 +68,7 @@ entries:
   - file: main/src/ant/README
     title: Antenna Checker
   - file: main/src/drt/README
-    title: Detail Routing
+    title: Detailed Routing
   - file: main/src/fin/README
     title: Metal Fill
   - file: main/src/stt/src/flt/README

--- a/src/drt/LICENSE
+++ b/src/drt/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018-2023, The Regents of the University of California
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1.  Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+
+2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+
+3.  Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software
+    without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -80,7 +80,7 @@ detailed_route
 | `-save_guide_updates` | Flag to save guides updates. |
 | `-repair_pdn_vias` | This option is used for PDKs where M1 and M2 power rails run in parallel. |
 
-### Developer arguments
+#### Developer arguments
 
 Some arguments that are helpful for developers are listed here. 
 

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -58,9 +58,9 @@ detailed_route
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-output_maze` | Path to output maze log file (e.g. `.output.maze.log`). |
-| `-output_drc` | Path to output DRC report file (e.g. `.output.drc.rpt`). |
-| `-output_cmap` | Path to output congestion map file (e.g. `.output.cmap`). |
+| `-output_maze` | Path to output maze log file (e.g. `output_maze.log`). |
+| `-output_drc` | Path to output DRC report file (e.g. `output_drc.rpt`). |
+| `-output_cmap` | Path to output congestion map file (e.g. `output.cmap`). |
 | `-output_guide_coverage` | Path to output guide coverage file (e.g. `sample_coverage.csv`). |
 | `-drc_report_iter_step` | Report DRC on each iteration which is a multiple of this step. The default value is `0`, and the allowed values are integers `[0, MAX_INT]`. |
 | `-db_process_node` | Specify the process node. |

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -1,9 +1,10 @@
 # Detailed Routing
 
-TritonRoute is an open-source detailed router for modern industrial
-designs. The router consists of several main building blocks, including
-pin access analysis, track assignment, initial detailed routing,
-search and repair, and a DRC engine. The initial development of the
+The Detailed Routing (`drt`) module in OpenROAD is based on the open-source
+detailed router, TritonRoute. TritonRoute consists of several main 
+building blocks, including pin access analysis, track assignment,
+initial detailed routing,  search and repair, and a DRC engine.
+The initial development of the
 [router](https://vlsicad.ucsd.edu/Publications/Conferences/363/c363.pdf)
 is inspired by the [ISPD-2018 initial detailed routing
 contest](http://www.ispd.cc/contests/18/).  However, the current framework
@@ -58,32 +59,35 @@ detailed_route
 | Switch Name | Description |
 | ----- | ----- |
 | `-output_maze` | Path to output maze log file (e.g. `.output.maze.log`). |
-| `-output_drc` | Path to output drc report file (e.g. `.output.drc.rpt`). |
+| `-output_drc` | Path to output DRC report file (e.g. `.output.drc.rpt`). |
 | `-output_cmap` | Path to output congestion map file (e.g. `.output.cmap`). |
-| `-output_guide_coverage` | Path to output guide coverage file (e.g. `_sample_coverage.csv`). |
-| `-drc_report_iter_step` | Report drc on each iteration which is a multiple of this step (default 0, integer). |
+| `-output_guide_coverage` | Path to output guide coverage file (e.g. `sample_coverage.csv`). |
+| `-drc_report_iter_step` | Report DRC on each iteration which is a multiple of this step (default 0, integer). |
 | `-db_process_node` | Specify the process node. |
 | `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. (default not set) | 
 | `-droute_end_iter` | Number of detailed routing iterations (must be a positive integer <= 64). |
 | `-via_in_pin_bottom_layer` | Via-in pin bottom layer name. |
 | `-via_in_pin_top_layer` | Via-in pin top layer name. |
-| `-or_seed` | Random seed for the order of nets to reroute (default -1, integer). | 
-| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0, integer). |
+| `-or_seed` | Refer to developer arguments [here](#useful-developer-arguments). |
+| `-or_k` | Refer to developer arguments [here](#useful-developer-arguments). |
 | `-bottom_routing_layer` | Bottommost routing layer name. |
 | `-top_routing_layer` | Topmost routing layer name. |
 | `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
-| `-distributed` | Enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
-| `-remote_host` | The host IP. |
-| `-remote_port` | The value of the port to access from. |
-| `-shared_volume` | The mount path of the nfs shared folder. |
-| `-cloud_size` | The number of workers. |
+| `-distributed` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-remote_host` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-remote_port` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-shared_volume` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-cloud_size` | Refer to distributed arguments [here](#distributed-arguments). |
 | `-clean_patches` | Clean unneeded patches during detailed routing. | 
 | `-no_pin_access` | Disables pin access for routing. |
 | `-min_access_points` | Minimum access points for standard cell and macro cell pins. | 
 | `-save_guide_updates` | Flag to save guides updates. |
 | `-repair_pdn_vias` | This option is used for some PDKs which have M1 and M2 layers that run in parallel. |
 
-### Detailed Route debugging
+### Detailed Route Debugging
+
+The following command and arguments are useful when debugging error
+messages from `drt` and to understand its behavior.
 
 ```tcl
 detailed_route_debug 
@@ -122,7 +126,7 @@ detailed_route_debug
 | `-pa_commit` | Enable visibility of pin access commits. |
 | `-write_net_tracks` | Enable writing of net track assigments. |
 
-### Check Pin access 
+### Check Pin Access 
 
 ```tcl
 pin_access
@@ -147,7 +151,23 @@ pin_access
 | `-top_routing_layer` | Topmost routing layer. |
 | `-min_access_points` | Minimum number of access points per pin. |
 | `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
-| `-distributed` | Enable distributed pin access algorithm. |
+| `-distributed` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-remote_host` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-remote_port` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-shared_volume` | Refer to distributed arguments [here](#distributed-arguments). |
+| `-cloud_size` | Refer to distributed arguments [here](#distributed-arguments). |
+
+### Distributed arguments
+
+We have compiled all distributed arguments in this section.
+
+```{note}
+Additional setup is required. Please refer to this [guide](./doc/Distributed.md).
+```
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-distributed` | Enable distributed mode with Kubernetes and Google Cloud. |
 | `-remote_host` | The host IP. |
 | `-remote_port` | The value of the port to access from. |
 | `-shared_volume` | The mount path of the nfs shared folder. |
@@ -155,14 +175,24 @@ pin_access
 
 ### Useful developer functions
 
-If you are a developer, you might find these useful. More details can be found in the [source file](https://github.com/The-OpenROAD-Project/OpenROAD/tree/master/src/drt/src/TritonRoute.cpp) or the [swig file](https://github.com/The-OpenROAD-Project/OpenROAD/tree/master/src/drt/src/TritonRoute.i).
+If you are a developer, you might find these useful. More details can be found in the [source file](./src/TritonRoute.cpp) or the [swig file](./src/TritonRoute.i).
 
-```
-detailed_route_set_default_via [-via]   # set default via 
-detailed_route_set_unidirectional_layer [-layer] # set unidirectional layer
-step_dr # refer to function detailed_route_step_drt
-check_drc   # refer to function check_drc_cmd 
-```
+| Function Name | Description |
+| ----- | ----- |
+| `detailed_route_set_default_via` | Set default via. |
+| `detailed_route_set_unidirectional_layer` | Set unidirectional layer. |
+| `step_dr` | Refer to function `detailed_route_step_drt`. | 
+| `check_drc` | Refer to function `check_drc_cmd`. |
+
+### Useful developer arguments
+
+Some arguments that are helpful for developers are listed here. 
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-or_seed` | Random seed for the order of nets to reroute (default -1, integer). | 
+| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0, integer). |
+
 
 ## Example scripts
 
@@ -170,8 +200,11 @@ Example script demonstrating how to run TritonRoute on a sample design of `gcd`
 in the Nangate45 technology node.
 
 ```shell
-./test/gcd_nangate45.tcl    # single machine example
-./test/gcd_nangate45_distributed.tcl    # distributed example
+# single machine example 
+./test/gcd_nangate45.tcl
+
+# distributed example
+./test/gcd_nangate45_distributed.tcl
 ```
 
 ## Regression tests

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -62,27 +62,32 @@ detailed_route
 | `-output_drc` | Path to output DRC report file (e.g. `.output.drc.rpt`). |
 | `-output_cmap` | Path to output congestion map file (e.g. `.output.cmap`). |
 | `-output_guide_coverage` | Path to output guide coverage file (e.g. `sample_coverage.csv`). |
-| `-drc_report_iter_step` | Report DRC on each iteration which is a multiple of this step (default 0, integer). |
+| `-drc_report_iter_step` | Report DRC on each iteration which is a multiple of this step. The default value is `0`, and the allowed values are integers `[0, MAX_INT]`. |
 | `-db_process_node` | Specify the process node. |
-| `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. (default not set) | 
-| `-droute_end_iter` | Number of detailed routing iterations (must be a positive integer <= 64). |
+| `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. The default value is disabled. | 
+| `-droute_end_iter` | Number of detailed routing iterations. The default value is `-1`, and the allowed values are integers `[1, 64]`. |
 | `-via_in_pin_bottom_layer` | Via-in pin bottom layer name. |
 | `-via_in_pin_top_layer` | Via-in pin top layer name. |
-| `-or_seed` | Refer to developer arguments [here](#useful-developer-arguments). |
-| `-or_k` | Refer to developer arguments [here](#useful-developer-arguments). |
+| `-or_seed` | Refer to developer arguments [here](#developer-arguments). |
+| `-or_k` | Refer to developer arguments [here](#developer-arguments). |
 | `-bottom_routing_layer` | Bottommost routing layer name. |
 | `-top_routing_layer` | Topmost routing layer name. |
 | `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
 | `-distributed` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-remote_host` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-remote_port` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-shared_volume` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-cloud_size` | Refer to distributed arguments [here](#distributed-arguments). |
 | `-clean_patches` | Clean unneeded patches during detailed routing. | 
 | `-no_pin_access` | Disables pin access for routing. |
 | `-min_access_points` | Minimum access points for standard cell and macro cell pins. | 
 | `-save_guide_updates` | Flag to save guides updates. |
-| `-repair_pdn_vias` | This option is used for some PDKs which have M1 and M2 layers that run in parallel. |
+| `-repair_pdn_vias` | This option is used for PDKs where M1 and M2 power rails run in parallel. |
+
+### Developer arguments
+
+Some arguments that are helpful for developers are listed here. 
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-or_seed` | Random seed for the order of nets to reroute. The default value is `-1`, and the allowed values are integers `[0, MAX_INT]`. | 
+| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$. The default value is `0`, and the allowed values are integers `[0, MAX_INT]`. |
 
 ### Detailed Route Debugging
 
@@ -118,7 +123,7 @@ detailed_route_debug
 | `-net` | Enable debug for net name. |
 | `-pin` | Enable debug for pin name. |
 | `-worker` | Debugs routes that pass through the point `{x, y}`. |
-| `-iter` | Specifies the number of debug iterations. (default 0, integer) |
+| `-iter` | Specifies the number of debug iterations. The default value is `0`, and the accepted values are integers `[0, MAX_INT`. |
 | `-pa_markers` | Enable pin access markers. |
 | `-dump_dr` | Filename for detailed routing dump. |
 | `-dump_dir` | Directory for detailed routing dump. |
@@ -152,10 +157,6 @@ pin_access
 | `-min_access_points` | Minimum number of access points per pin. |
 | `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
 | `-distributed` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-remote_host` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-remote_port` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-shared_volume` | Refer to distributed arguments [here](#distributed-arguments). |
-| `-cloud_size` | Refer to distributed arguments [here](#distributed-arguments). |
 
 ### Distributed arguments
 
@@ -184,14 +185,6 @@ If you are a developer, you might find these useful. More details can be found i
 | `step_dr` | Refer to function `detailed_route_step_drt`. | 
 | `check_drc` | Refer to function `check_drc_cmd`. |
 
-### Useful developer arguments
-
-Some arguments that are helpful for developers are listed here. 
-
-| Switch Name | Description |
-| ----- | ----- |
-| `-or_seed` | Random seed for the order of nets to reroute (default -1, integer). | 
-| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0, integer). |
 
 
 ## Example scripts

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -155,7 +155,7 @@ pin_access
 
 ### Useful developer functions
 
-If you are a developer, you might find these useful. More details can be found in the [source file](./src/TritonRoute.cpp) or the [swig file](./src/TritonRoute.i).
+If you are a developer, you might find these useful. More details can be found in the [source file](https://github.com/The-OpenROAD-Project/OpenROAD/tree/master/src/drt/src/TritonRoute.cpp) or the [swig file](https://github.com/The-OpenROAD-Project/OpenROAD/tree/master/src/drt/src/TritonRoute.i).
 
 ```
 detailed_route_set_default_via [-via]   # set default via 
@@ -176,7 +176,7 @@ in the Nangate45 technology node.
 
 ## Regression tests
 
-There are a set of regression tests in `/test`. For more information, refer to this [section](../../README.md#regression-tests). 
+There are a set of regression tests in `./test`. For more information, refer to this [section](../../README.md#regression-tests). 
 
 Simply run the following script: 
 
@@ -195,12 +195,12 @@ about this tool.
 
 Please cite the following paper(s) for publication:
 
--   A. B. Kahng, L. Wang and B. Xu, "TritonRoute: The Open Source Detailed
+1.   A. B. Kahng, L. Wang and B. Xu, "TritonRoute: The Open Source Detailed
     Router", IEEE Transactions on Computer-Aided Design of Integrated Circuits
-    and Systems (2020), doi:10.1109/TCAD.2020.3003234.
--   A. B. Kahng, L. Wang and B. Xu, "The Tao of PAO: Anatomy of a Pin Access
+    and Systems (2020), doi:10.1109/TCAD.2020.3003234. [(.pdf)](https://ieeexplore.ieee.org/ielaam/43/9358030/9120211-aam.pdf)
+1.   A. B. Kahng, L. Wang and B. Xu, "The Tao of PAO: Anatomy of a Pin Access
     Oracle for Detailed Routing", Proc. ACM/IEEE Design Automation Conf., 2020,
-    pp. 1-6.
+    pp. 1-6. [(.pdf)](https://vlsicad.ucsd.edu/Publications/Conferences/377/c377.pdf)
 
 ## Authors
 

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -17,9 +17,14 @@ guide format.
 
 ## Commands
 
+```{note}
+- Parameters in square brackets `[-param param]` are optional.
+- Parameters without square brackets `-param2 param2` are required.
+```
+
 ### Detailed Route
 
-```
+```tcl
 detailed_route 
     [-output_maze filename]
     [-output_drc filename]
@@ -56,17 +61,17 @@ detailed_route
 | `-output_drc` | output drc report filename |
 | `-output_cmap` | output congestion map file |
 | `-output_guide_coverage` | output guide coverage filename |
-| `-drc_report_iter_step` | report drc on each iteration which is a multiple of this step |
-| `-db_process_node` | specify the process node (optional) |
-| `-disable_via_gen` | option to diable via generation with bottom and top routing layer |
-| `-droute_end_iter` | number of detailed routing iterations |
+| `-drc_report_iter_step` | report drc on each iteration which is a multiple of this step (default 0) |
+| `-db_process_node` | specify the process node |
+| `-disable_via_gen` | option to diable via generation with bottom and top routing layer | 
+| `-droute_end_iter` | number of detailed routing iterations, must be a positive integer <= 64 |
 | `-via_in_pin_bottom_layer` | via-in pin bottom layer name |
 | `-via_in_pin_top_layer` | via-in pin top layer name |
-| `-or_seed` | random seed for the order of nets to reroute | 
-| `-or_k` | number of swaps is given by $k * sizeof(rerouteNets)$ |
+| `-or_seed` | random seed for the order of nets to reroute (default -1) | 
+| `-or_k` | number of swaps is given by $k * sizeof(rerouteNets)$ (default 0) |
 | `-bottom_routing_layer` | bottommost routing layer name |
 | `-top_routing_layer` | topmost routing layer name |
-| `-verbose` | set verbose if value is greater than 0. |
+| `-verbose` | set verbose if value is greater than 0 |
 | `-distributed` | enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
 | `-remote_host` | the host IP |
 | `-remote_port` | the value of the port to access from |
@@ -80,7 +85,7 @@ detailed_route
 
 ### Detailed Route debugging
 
-```
+```tcl
 detailed_route_debug 
     [-pa]
     [-ta]
@@ -119,7 +124,7 @@ detailed_route_debug
 
 ### Check Pin access 
 
-```
+```tcl
 pin_access
     [-db_process_node name]
     [-bottom_routing_layer layer]
@@ -137,7 +142,7 @@ pin_access
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-db_process_node` | specify for process node (optional) |
+| `-db_process_node` | specify for process node | 
 | `-bottom_routing_layer` | bottommost routing layer |
 | `-top_routing_layer` | topmost routing layer |
 | `-min_access_points` | minimum number of access points per pin |
@@ -164,7 +169,7 @@ check_drc   # refer to function check_drc_cmd
 Example script demonstrating how to run TritonRoute on a sample design of `gcd`
 in the Nangate45 technology node.
 
-```
+```shell
 ./test/gcd_nangate45.tcl    # single machine example
 ./test/gcd_nangate45_distributed.tcl    # distributed example
 ```

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -57,31 +57,31 @@ detailed_route
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-output_maze` | output maze log filename |
-| `-output_drc` | output drc report filename |
-| `-output_cmap` | output congestion map file |
-| `-output_guide_coverage` | output guide coverage filename |
-| `-drc_report_iter_step` | report drc on each iteration which is a multiple of this step (default 0) |
-| `-db_process_node` | specify the process node |
-| `-disable_via_gen` | option to diable via generation with bottom and top routing layer | 
-| `-droute_end_iter` | number of detailed routing iterations, must be a positive integer <= 64 |
-| `-via_in_pin_bottom_layer` | via-in pin bottom layer name |
-| `-via_in_pin_top_layer` | via-in pin top layer name |
-| `-or_seed` | random seed for the order of nets to reroute (default -1) | 
-| `-or_k` | number of swaps is given by $k * sizeof(rerouteNets)$ (default 0) |
-| `-bottom_routing_layer` | bottommost routing layer name |
-| `-top_routing_layer` | topmost routing layer name |
-| `-verbose` | set verbose if value is greater than 0 |
-| `-distributed` | enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
-| `-remote_host` | the host IP |
-| `-remote_port` | the value of the port to access from |
-| `-shared_volume` | the mount path of the nfs shared folder |
-| `-cloud_size` | the number of workers |
-| `-clean_patches` | clean unneeded patches during detailed routing. | 
-| `-no_pin_access` | disables pin access for routing |
-| `-min_access_points` | minimum access points for standard cell and macro cell pins. | 
-| `-save_guide_updates` | save guides updates |
-| `-repair_pdn_vias` | this option is used for some PDKs which have M1 and M2 layers that run in parallel. |
+| `-output_maze` | Path to output maze log file (e.g. `.output.maze.log`). |
+| `-output_drc` | Path to output drc report file (e.g. `.output.drc.rpt`). |
+| `-output_cmap` | Path to output congestion map file (e.g. `.output.cmap`). |
+| `-output_guide_coverage` | Path to output guide coverage file (e.g. `_sample_coverage.csv`). |
+| `-drc_report_iter_step` | Report drc on each iteration which is a multiple of this step (default 0). |
+| `-db_process_node` | Specify the process node. |
+| `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. | 
+| `-droute_end_iter` | Number of detailed routing iterations (must be a positive integer <= 64). |
+| `-via_in_pin_bottom_layer` | Via-in pin bottom layer name. |
+| `-via_in_pin_top_layer` | Via-in pin top layer name. |
+| `-or_seed` | Random seed for the order of nets to reroute (default -1). | 
+| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0). |
+| `-bottom_routing_layer` | Bottommost routing layer name. |
+| `-top_routing_layer` | Topmost routing layer name. |
+| `-verbose` | Set verbose if value is greater than 0. |
+| `-distributed` | Enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
+| `-remote_host` | The host IP. |
+| `-remote_port` | The value of the port to access from. |
+| `-shared_volume` | The mount path of the nfs shared folder. |
+| `-cloud_size` | The number of workers. |
+| `-clean_patches` | Clean unneeded patches during detailed routing. | 
+| `-no_pin_access` | Disables pin access for routing. |
+| `-min_access_points` | Minimum access points for standard cell and macro cell pins. | 
+| `-save_guide_updates` | Flag to save guides updates. |
+| `-repair_pdn_vias` | This option is used for some PDKs which have M1 and M2 layers that run in parallel. |
 
 ### Detailed Route debugging
 
@@ -107,20 +107,20 @@ detailed_route_debug
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-pa` | enable debug for pin access |
-| `-ta` | enable debug for track assignment |
-| `-dr` | enable debug for detailed routing |
-| `-maze` | enable debug for maze routing | 
-| `-net` | enable debug for net name |
-| `-pin` | enable debug for pin name |
-| `-worker` | debugs routes that pass through the point `{x, y}` |
-| `-iter` | debug iterations |
-| `-pa_markers` | enable pin access markers |
-| `-dump_dr` | dump detailed routing filename |
-| `-dump_dir` | dump detailed routing directory |
-| `-pa_edge` | visibility of pin access edges |
-| `-pa_commit` | visibility of pin access commits |
-| `-write_net_tracks` | enable writing of net track assigments |
+| `-pa` | Enable debug for pin access. |
+| `-ta` | Enable debug for track assignment. |
+| `-dr` | Enable debug for detailed routing. |
+| `-maze` | Enable debug for maze routing. | 
+| `-net` | Enable debug for net name. |
+| `-pin` | Enable debug for pin name. |
+| `-worker` | Debugs routes that pass through the point `{x, y}`. |
+| `-iter` | Specifies the number of debug iterations. |
+| `-pa_markers` | Enable pin access markers. |
+| `-dump_dr` | Dump detailed routing filename. |
+| `-dump_dir` | Dump detailed routing directory. |
+| `-pa_edge` | Visibility of pin access edges. |
+| `-pa_commit` | Visibility of pin access commits. |
+| `-write_net_tracks` | Enable writing of net track assigments. |
 
 ### Check Pin access 
 
@@ -142,16 +142,16 @@ pin_access
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-db_process_node` | specify for process node | 
-| `-bottom_routing_layer` | bottommost routing layer |
-| `-top_routing_layer` | topmost routing layer |
-| `-min_access_points` | minimum number of access points per pin |
-| `-verbose` | set verbose if the value is greater than 0 |
-| `-distributed` | enable distributed pin access algorithm |
-| `-remote_host` | the host IP |
-| `-remote_port` | the value of the port to access from |
-| `-shared_volume` | the mount path of the nfs shared folder |
-| `-cloud_size` | the number of workers |
+| `-db_process_node` | Specify process node. |
+| `-bottom_routing_layer` | Bottommost routing layer. |
+| `-top_routing_layer` | Topmost routing layer. |
+| `-min_access_points` | Minimum number of access points per pin. |
+| `-verbose` | Set verbose if the value is greater than 0. |
+| `-distributed` | Enable distributed pin access algorithm. |
+| `-remote_host` | The host IP. |
+| `-remote_port` | The value of the port to access from. |
+| `-shared_volume` | The mount path of the nfs shared folder. |
+| `-cloud_size` | The number of workers. |
 
 ### Useful developer functions
 

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -17,14 +17,157 @@ guide format.
 
 ## Commands
 
-## Report wire length
+### Detailed Route
 
-Check the [global router README](https://github.com/The-OpenROAD-Project/OpenROAD/blob/master/src/grt/README.md)
-file for the full description of the `report_wire_length` command.
+```
+detailed_route 
+    [-output_maze filename]
+    [-output_drc filename]
+    [-output_cmap filename]
+    [-output_guide_coverage filename]
+    [-drc_report_iter_step step]
+    [-db_process_node name]
+    [-disable_via_gen]
+    [-droute_end_iter iter]
+    [-via_in_pin_bottom_layer layer]
+    [-via_in_pin_top_layer layer]
+    [-or_seed seed]
+    [-or_k_ k]
+    [-bottom_routing_layer layer]
+    [-top_routing_layer layer]
+    [-verbose level]
+    [-param filename]
+    [-distributed]
+    [-remote_host rhost]
+    [-remote_port rport]
+    [-shared_volume vol]
+    [-cloud_size sz]
+    [-clean_patches]
+    [-no_pin_access]
+    [-min_access_points count]
+    [-save_guide_updates]
+    [-repair_pdn_vias layer]
+```
+
+- `-output_maze` output maze log filename
+- `-output_drc` output drc report filename
+- `-output_cmap` output congestion map file file
+- `-output_guide_coverage` output guide coverage filename
+- `-drc_report_iter_step` report drc on each iteration which is a multiple of this step
+- `-db_process_node` specify the process node (optional)
+- `-disable_via_gen` option to diable via generation with bottom and top routing layer
+- `-droute_end_iter` number of detailed routing iterations
+- `-via_in_pin_bottom_layer` via-in pin bottom layer name  
+- `-via_in_pin_top_layer` via-in pin top layer name
+- `-or_seed` random seed
+- `-or_k` number of swaps is given by $k * sizeof(rerouteNets)$
+- `-bottom_routing_layer` bottommost routing layer name 
+- `-top_routing_layer` topmost routing layer name
+- `-verbose` set verbose if value is greater than 0. 
+- `-param` you may set parameters in this argument using a file. note that `-param` may not be used
+with other keyword arguments. (deprecated)
+- `-distributed` enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md).
+- `-remote_host` the host IP 
+- `-remote_port` the value of the port to access from 
+- `-shared_volume` the mount path of the nfs shared folder
+- `-cloud_size` the number of workers 
+- `-clean_patches` clean unneeded patches during detailed routing. 
+- `-min_access_points` minimum access points for standard cell and macro cell pins. 
+- `-save_guide_updates` save guides updates 
+
+### Detailed Route debugging
+
+```
+detailed_route_debug 
+    [-pa]
+    [-ta]
+    [-dr]
+    [-maze]
+    [-net name]
+    [-pin name]
+    [-worker x y]
+    [-iter iter]
+    [-pa_markers]
+    [-dump_dr]
+    [-dump_dir dir]
+    [-pa_edge]
+    [-pa_commit]
+    [-write_net_tracks]
+```
+
+- `-pa` enable debug for pin access
+- `-ta` enable debug for track assignment
+- `-dr` enable debug for detailed routing
+- `-maze` enable debug for maze routing 
+- `-net` enable debug for net name
+- `-pin` enable debug for pin name
+- `-worker` debugs routes that pass through the point `{x, y}`
+- `-iter` debug iterations
+- `-pa_markers` enable pin access markers
+- `-dump_dr` dump detailed routing filename
+- `-dump_dir dir` dump detailed routing directory
+- `-pa_edge` visibility of pin access edges
+- `-pa_commit` visibility of pin access commits
+- `-write_net_tracks` enable writing of net track assigments
+
+### Check Pin access 
+
+```
+pin_access
+    [-db_process_node name]
+    [-bottom_routing_layer layer]
+    [-top_routing_layer layer]
+    [-min_access_points count]
+    [-verbose level]
+    [-distributed]
+    [-remote_host rhost]
+    [-remote_port rport]
+    [-shared_volume vol]
+    [-cloud_size sz]
+```
+
+- `-db_process_node` specify for process node (optional) 
+- `-bottom_routing_layer` bottommost routing layer
+- `-top_routing_layer` topmost routing layer
+- `-min_access_points` minimum number of access points per pin
+- `-verbose` set verbose if the value is greater than 0
+- `-distributed` enable distributed pin access algorithm
+- `-remote_host` the host IP 
+- `-remote_port` the value of the port to access from 
+- `-shared_volume` the mount path of the nfs shared folder
+- `-cloud_size` the number of workers 
+
+### Other functions
+
+```
+    detailed_route_set_default_via [-via]   # set default via 
+    detailed_route_set_unidirectional_layer [-layer] # set unidirectional layer
+```
+
+### Undocumented functions (coming soon!)
+
+```
+    step_dr
+    check_drc
+```
 
 ## Example scripts
 
+Example script demonstrating how to run TritonRoute on a sample design of `gcd`
+in the Nangate45 technology node.
+
+```
+./test/gcd_nangate45.tcl    # single machine example
+./test/gcd_nangate45_distributed.tcl    # distributed example
+```
+
 ## Regression tests
+
+There is a set of regression tests in `/test`.
+
+```shell
+./test/regression
+```
 
 ## Limitations
 

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -176,7 +176,9 @@ in the Nangate45 technology node.
 
 ## Regression tests
 
-There is a set of regression tests in `/test`.
+There are a set of regression tests in `/test`. For more information, refer to this [section](../../README.md#regression-tests). 
+
+Simply run the following script: 
 
 ```shell
 ./test/regression

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -61,17 +61,17 @@ detailed_route
 | `-output_drc` | Path to output drc report file (e.g. `.output.drc.rpt`). |
 | `-output_cmap` | Path to output congestion map file (e.g. `.output.cmap`). |
 | `-output_guide_coverage` | Path to output guide coverage file (e.g. `_sample_coverage.csv`). |
-| `-drc_report_iter_step` | Report drc on each iteration which is a multiple of this step (default 0). |
+| `-drc_report_iter_step` | Report drc on each iteration which is a multiple of this step (default 0, integer). |
 | `-db_process_node` | Specify the process node. |
-| `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. | 
+| `-disable_via_gen` | Option to diable via generation with bottom and top routing layer. (default not set) | 
 | `-droute_end_iter` | Number of detailed routing iterations (must be a positive integer <= 64). |
 | `-via_in_pin_bottom_layer` | Via-in pin bottom layer name. |
 | `-via_in_pin_top_layer` | Via-in pin top layer name. |
-| `-or_seed` | Random seed for the order of nets to reroute (default -1). | 
-| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0). |
+| `-or_seed` | Random seed for the order of nets to reroute (default -1, integer). | 
+| `-or_k` | Number of swaps is given by $k * sizeof(rerouteNets)$ (default 0, integer). |
 | `-bottom_routing_layer` | Bottommost routing layer name. |
 | `-top_routing_layer` | Topmost routing layer name. |
-| `-verbose` | Set verbose if value is greater than 0. |
+| `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
 | `-distributed` | Enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
 | `-remote_host` | The host IP. |
 | `-remote_port` | The value of the port to access from. |
@@ -114,12 +114,12 @@ detailed_route_debug
 | `-net` | Enable debug for net name. |
 | `-pin` | Enable debug for pin name. |
 | `-worker` | Debugs routes that pass through the point `{x, y}`. |
-| `-iter` | Specifies the number of debug iterations. |
+| `-iter` | Specifies the number of debug iterations. (default 0, integer) |
 | `-pa_markers` | Enable pin access markers. |
-| `-dump_dr` | Dump detailed routing filename. |
-| `-dump_dir` | Dump detailed routing directory. |
-| `-pa_edge` | Visibility of pin access edges. |
-| `-pa_commit` | Visibility of pin access commits. |
+| `-dump_dr` | Filename for detailed routing dump. |
+| `-dump_dir` | Directory for detailed routing dump. |
+| `-pa_edge` | Enable visibility of pin access edges. |
+| `-pa_commit` | Enable visibility of pin access commits. |
 | `-write_net_tracks` | Enable writing of net track assigments. |
 
 ### Check Pin access 
@@ -146,7 +146,7 @@ pin_access
 | `-bottom_routing_layer` | Bottommost routing layer. |
 | `-top_routing_layer` | Topmost routing layer. |
 | `-min_access_points` | Minimum number of access points per pin. |
-| `-verbose` | Set verbose if the value is greater than 0. |
+| `-verbose` | Sets verbose mode if the value is greater than 1, else non-verbose mode (must be integer, or error will be triggered.) |
 | `-distributed` | Enable distributed pin access algorithm. |
 | `-remote_host` | The host IP. |
 | `-remote_port` | The value of the port to access from. |

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -36,7 +36,6 @@ detailed_route
     [-bottom_routing_layer layer]
     [-top_routing_layer layer]
     [-verbose level]
-    [-param filename]
     [-distributed]
     [-remote_host rhost]
     [-remote_port rport]
@@ -68,7 +67,6 @@ detailed_route
 | `-bottom_routing_layer` | bottommost routing layer name |
 | `-top_routing_layer` | topmost routing layer name |
 | `-verbose` | set verbose if value is greater than 0. |
-| `-param` | you may set parameters in this argument using a file.  **note that `-param` may not be used with other keyword arguments. (deprecated)** |
 | `-distributed` | enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
 | `-remote_host` | the host IP |
 | `-remote_port` | the value of the port to access from |

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -49,34 +49,36 @@ detailed_route
     [-repair_pdn_vias layer]
 ```
 
-- `-output_maze` output maze log filename
-- `-output_drc` output drc report filename
-- `-output_cmap` output congestion map file file
-- `-output_guide_coverage` output guide coverage filename
-- `-drc_report_iter_step` report drc on each iteration which is a multiple of this step
-- `-db_process_node` specify the process node (optional)
-- `-disable_via_gen` option to diable via generation with bottom and top routing layer
-- `-droute_end_iter` number of detailed routing iterations
-- `-via_in_pin_bottom_layer` via-in pin bottom layer name  
-- `-via_in_pin_top_layer` via-in pin top layer name
-- `-or_seed` random seed for the order of nets to reroute. 
-- `-or_k` number of swaps is given by $k * sizeof(rerouteNets)$
-- `-bottom_routing_layer` bottommost routing layer name 
-- `-top_routing_layer` topmost routing layer name
-- `-verbose` set verbose if value is greater than 0. 
-- `-param` you may set parameters in this argument using a file. 
-**note that `-param` may not be used with other keyword arguments.
-(deprecated)**
-- `-distributed` enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md).
-- `-remote_host` the host IP 
-- `-remote_port` the value of the port to access from 
-- `-shared_volume` the mount path of the nfs shared folder
-- `-cloud_size` the number of workers 
-- `-clean_patches` clean unneeded patches during detailed routing. 
-- `-no_pin_access` disables pin access for routing
-- `-min_access_points` minimum access points for standard cell and macro cell pins. 
-- `-save_guide_updates` save guides updates 
-- `-repair_pdn_vias` this option is used for some PDKs which have M1 and M2 layers that run in parallel. 
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-output_maze` | output maze log filename |
+| `-output_drc` | output drc report filename |
+| `-output_cmap` | output congestion map file |
+| `-output_guide_coverage` | output guide coverage filename |
+| `-drc_report_iter_step` | report drc on each iteration which is a multiple of this step |
+| `-db_process_node` | specify the process node (optional) |
+| `-disable_via_gen` | option to diable via generation with bottom and top routing layer |
+| `-droute_end_iter` | number of detailed routing iterations |
+| `-via_in_pin_bottom_layer` | via-in pin bottom layer name |
+| `-via_in_pin_top_layer` | via-in pin top layer name |
+| `-or_seed` | random seed for the order of nets to reroute | 
+| `-or_k` | number of swaps is given by $k * sizeof(rerouteNets)$ |
+| `-bottom_routing_layer` | bottommost routing layer name |
+| `-top_routing_layer` | topmost routing layer name |
+| `-verbose` | set verbose if value is greater than 0. |
+| `-param` | you may set parameters in this argument using a file.  **note that `-param` may not be used with other keyword arguments. (deprecated)** |
+| `-distributed` | enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md). |
+| `-remote_host` | the host IP |
+| `-remote_port` | the value of the port to access from |
+| `-shared_volume` | the mount path of the nfs shared folder |
+| `-cloud_size` | the number of workers |
+| `-clean_patches` | clean unneeded patches during detailed routing. | 
+| `-no_pin_access` | disables pin access for routing |
+| `-min_access_points` | minimum access points for standard cell and macro cell pins. | 
+| `-save_guide_updates` | save guides updates |
+| `-repair_pdn_vias` | this option is used for some PDKs which have M1 and M2 layers that run in parallel. |
 
 ### Detailed Route debugging
 
@@ -98,20 +100,24 @@ detailed_route_debug
     [-write_net_tracks]
 ```
 
-- `-pa` enable debug for pin access
-- `-ta` enable debug for track assignment
-- `-dr` enable debug for detailed routing
-- `-maze` enable debug for maze routing 
-- `-net` enable debug for net name
-- `-pin` enable debug for pin name
-- `-worker` debugs routes that pass through the point `{x, y}`
-- `-iter` debug iterations
-- `-pa_markers` enable pin access markers
-- `-dump_dr` dump detailed routing filename
-- `-dump_dir` dump detailed routing directory
-- `-pa_edge` visibility of pin access edges
-- `-pa_commit` visibility of pin access commits
-- `-write_net_tracks` enable writing of net track assigments
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-pa` | enable debug for pin access |
+| `-ta` | enable debug for track assignment |
+| `-dr` | enable debug for detailed routing |
+| `-maze` | enable debug for maze routing | 
+| `-net` | enable debug for net name |
+| `-pin` | enable debug for pin name |
+| `-worker` | debugs routes that pass through the point `{x, y}` |
+| `-iter` | debug iterations |
+| `-pa_markers` | enable pin access markers |
+| `-dump_dr` | dump detailed routing filename |
+| `-dump_dir` | dump detailed routing directory |
+| `-pa_edge` | visibility of pin access edges |
+| `-pa_commit` | visibility of pin access commits |
+| `-write_net_tracks` | enable writing of net track assigments |
 
 ### Check Pin access 
 
@@ -129,16 +135,20 @@ pin_access
     [-cloud_size sz]
 ```
 
-- `-db_process_node` specify for process node (optional) 
-- `-bottom_routing_layer` bottommost routing layer
-- `-top_routing_layer` topmost routing layer
-- `-min_access_points` minimum number of access points per pin
-- `-verbose` set verbose if the value is greater than 0
-- `-distributed` enable distributed pin access algorithm
-- `-remote_host` the host IP 
-- `-remote_port` the value of the port to access from 
-- `-shared_volume` the mount path of the nfs shared folder
-- `-cloud_size` the number of workers 
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-db_process_node` | specify for process node (optional) |
+| `-bottom_routing_layer` | bottommost routing layer |
+| `-top_routing_layer` | topmost routing layer |
+| `-min_access_points` | minimum number of access points per pin |
+| `-verbose` | set verbose if the value is greater than 0 |
+| `-distributed` | enable distributed pin access algorithm |
+| `-remote_host` | the host IP |
+| `-remote_port` | the value of the port to access from |
+| `-shared_volume` | the mount path of the nfs shared folder |
+| `-cloud_size` | the number of workers |
 
 ### Useful developer functions
 

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -59,21 +59,24 @@ detailed_route
 - `-droute_end_iter` number of detailed routing iterations
 - `-via_in_pin_bottom_layer` via-in pin bottom layer name  
 - `-via_in_pin_top_layer` via-in pin top layer name
-- `-or_seed` random seed
+- `-or_seed` random seed for the order of nets to reroute. 
 - `-or_k` number of swaps is given by $k * sizeof(rerouteNets)$
 - `-bottom_routing_layer` bottommost routing layer name 
 - `-top_routing_layer` topmost routing layer name
 - `-verbose` set verbose if value is greater than 0. 
-- `-param` you may set parameters in this argument using a file. note that `-param` may not be used
-with other keyword arguments. (deprecated)
+- `-param` you may set parameters in this argument using a file. 
+**note that `-param` may not be used with other keyword arguments.
+(deprecated)**
 - `-distributed` enable distributed mode with Kubernetes and Google Cloud, [guide](./doc/Distributed.md).
 - `-remote_host` the host IP 
 - `-remote_port` the value of the port to access from 
 - `-shared_volume` the mount path of the nfs shared folder
 - `-cloud_size` the number of workers 
 - `-clean_patches` clean unneeded patches during detailed routing. 
+- `-no_pin_access` disables pin access for routing
 - `-min_access_points` minimum access points for standard cell and macro cell pins. 
 - `-save_guide_updates` save guides updates 
+- `-repair_pdn_vias` this option is used for some PDKs which have M1 and M2 layers that run in parallel. 
 
 ### Detailed Route debugging
 
@@ -105,7 +108,7 @@ detailed_route_debug
 - `-iter` debug iterations
 - `-pa_markers` enable pin access markers
 - `-dump_dr` dump detailed routing filename
-- `-dump_dir dir` dump detailed routing directory
+- `-dump_dir` dump detailed routing directory
 - `-pa_edge` visibility of pin access edges
 - `-pa_commit` visibility of pin access commits
 - `-write_net_tracks` enable writing of net track assigments
@@ -137,18 +140,15 @@ pin_access
 - `-shared_volume` the mount path of the nfs shared folder
 - `-cloud_size` the number of workers 
 
-### Other functions
+### Useful developer functions
+
+If you are a developer, you might find these useful. More details can be found in the [source file](./src/TritonRoute.cpp) or the [swig file](./src/TritonRoute.i).
 
 ```
-    detailed_route_set_default_via [-via]   # set default via 
-    detailed_route_set_unidirectional_layer [-layer] # set unidirectional layer
-```
-
-### Undocumented functions (coming soon!)
-
-```
-    step_dr
-    check_drc
+detailed_route_set_default_via [-via]   # set default via 
+detailed_route_set_unidirectional_layer [-layer] # set unidirectional layer
+step_dr # refer to function detailed_route_step_drt
+check_drc   # refer to function check_drc_cmd 
 ```
 
 ## Example scripts

--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -1,4 +1,4 @@
-# TritonRoute
+# Detailed Routing
 
 TritonRoute is an open-source detailed router for modern industrial
 designs. The router consists of several main building blocks, including


### PR DESCRIPTION
Todos
- Clarify if these parameters are still needed `OR_seed`, `OR_k`, `no_pin_access`,  `repair_pdn_vias`
- Missing keyword argument specification for these tcl procs: `step_dr`, `check_drc`
[should i use sta namespace or drt?]