### PR TITLE
rsz: fix layerRC for vias

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -161,7 +161,7 @@ public:
                // Return values.
                double &res,
                double &cap) const;
-  void layerRC(int routing_level,
+  void layerRC(int layer_level,
                const Corner *corner,
                // Return values.
                double &res,

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -161,11 +161,6 @@ public:
                // Return values.
                double &res,
                double &cap) const;
-  void layerRC(int layer_level,
-               const Corner *corner,
-               // Return values.
-               double &res,
-               double &cap) const;
   // Set the resistance and capacitance used for parasitics on signal nets.
   void setWireSignalRC(const Corner *corner,
                        double res, // ohms/meter

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -342,8 +342,10 @@ BufferedNet::wireRC(const Corner *corner,
     resizer->logger()->critical(RSZ, 82, "wireRC called for non-wire");
   if (layer_ == BufferedNet::null_layer)
     resizer->wireSignalRC(corner, res, cap);
-  else
-    resizer->layerRC(layer_, corner, res, cap);
+  else {
+    odb::dbTech* tech = resizer->db_->getTech();
+    resizer->layerRC(tech->findRoutingLayer(layer_), corner, res, cap);
+  }
 }
 
 static const char *

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -81,8 +81,8 @@ Resizer::setLayerRC(dbTechLayer *layer,
     }
   }
 
-  layer_res_[layer->getRoutingLevel()][corner->index()] = res;
-  layer_cap_[layer->getRoutingLevel()][corner->index()] = cap;
+  layer_res_[layer->getNumber()][corner->index()] = res;
+  layer_cap_[layer->getNumber()][corner->index()] = cap;
 }
 
 void
@@ -92,11 +92,11 @@ Resizer::layerRC(dbTechLayer *layer,
                  double &res,
                  double &cap) const
 {
-  layerRC(layer->getRoutingLevel(), corner, res, cap);
+  layerRC(layer->getNumber(), corner, res, cap);
 }
 
 void
-Resizer::layerRC(int routing_level,
+Resizer::layerRC(int layer_level,
                  const Corner *corner,
                  // Return values.
                  double &res,
@@ -107,8 +107,8 @@ Resizer::layerRC(int routing_level,
     cap = 0.0;
   }
   else {
-    res = layer_res_[routing_level][corner->index()];
-    cap = layer_cap_[routing_level][corner->index()];
+    res = layer_res_[layer_level][corner->index()];
+    cap = layer_cap_[layer_level][corner->index()];
   }
 }
 

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -92,21 +92,12 @@ Resizer::layerRC(dbTechLayer *layer,
                  double &res,
                  double &cap) const
 {
-  layerRC(layer->getNumber(), corner, res, cap);
-}
-
-void
-Resizer::layerRC(int layer_level,
-                 const Corner *corner,
-                 // Return values.
-                 double &res,
-                 double &cap) const
-{
   if (layer_res_.empty()) {
     res = 0.0;
     cap = 0.0;
   }
   else {
+    const int layer_level = layer->getNumber();
     res = layer_res_[layer_level][corner->index()];
     cap = layer_cap_[layer_level][corner->index()];
   }

--- a/src/rsz/test/repair_hold10.ok
+++ b/src/rsz/test/repair_hold10.ok
@@ -9,10 +9,10 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 15 components and 68 component-terminals.
 [INFO ODB-0133]     Created 13 nets and 29 connections.
-worst slack -3.23
+worst slack -3.24
 [INFO RSZ-0046] Found 2 endpoints with hold violations.
 [INFO RSZ-0032] Inserted 6 hold buffers.
-worst slack 0.22
+worst slack 0.21
 Placement Analysis
 ---------------------------------
 total displacement          9.6 u


### PR DESCRIPTION
Issue:
- `set_layer_rc` is using the routing level to store the layer RCs, this causes the vias to be stored and overwrite eachother.

Changes:
- use `getNumber` instead of `getRoutingLevel` to store and recover the layer RCs so vias are recorded correctly.