### PR TITLE
psm: analysis across corners

### DIFF
--- a/src/psm/README.md
+++ b/src/psm/README.md
@@ -29,6 +29,7 @@ analyze_power_grid -vsrc <voltage_source_location_file> \
                    [-em_outfile <filename>]
                    [-node_density <node_pitch>]
                    [-node_density_factor <factor>]
+                   [-corner corner]
 write_pg_spice -vsrc <voltage_source_location_file> -outfile <netlist.sp> -net <net_name>
 ```
 
@@ -42,6 +43,7 @@ Options description:
 - ``voltage``: (optional) Sets the voltage on a specific net. If this command is not run, the voltage value is obtained from operating conditions in the liberty.
 - ``node_density``: (optional)  This value can be specfied by the user in um to determine the node density on the std. cell rails. Cannot be used together with node_density_factor.
 - ``node_density_factor``: (optional) Integer value factor which is multiplied by standard cell height to determine the node density on the std. cell rails. Cannot be used together with node_density. Default value is 5.
+- ``corner``: (optional) Corner to use for analysis.
 
 ## Example scripts
 

--- a/src/psm/include/psm/pdnsim.h
+++ b/src/psm/include/psm/pdnsim.h
@@ -49,6 +49,9 @@ class dbSta;
 namespace utl {
 class Logger;
 }
+namespace rsz {
+class Resizer;
+}
 
 namespace psm {
 class IRDropDataSource;
@@ -63,7 +66,10 @@ class PDNSim
   PDNSim();
   ~PDNSim();
 
-  void init(utl::Logger* logger, odb::dbDatabase* db, sta::dbSta* sta);
+  void init(utl::Logger* logger,
+            odb::dbDatabase* db,
+            sta::dbSta* sta,
+            rsz::Resizer* resizer);
 
   void import_vsrc_cfg(const std::string& vsrc);
   void import_out_file(const std::string& out_file);
@@ -88,6 +94,7 @@ class PDNSim
  private:
   odb::dbDatabase* db_ = nullptr;
   sta::dbSta* sta_ = nullptr;
+  rsz::Resizer* resizer_ = nullptr;
   utl::Logger* logger_ = nullptr;
   std::string vsrc_loc_;
   std::string out_file_;

--- a/src/psm/include/psm/pdnsim.h
+++ b/src/psm/include/psm/pdnsim.h
@@ -45,7 +45,8 @@ class dbTechLayer;
 
 namespace sta {
 class dbSta;
-}
+class Corner;
+}  // namespace sta
 namespace utl {
 class Logger;
 }
@@ -91,6 +92,8 @@ class PDNSim
   bool check_connectivity();
   void setDebugGui();
 
+  void setCorner(sta::Corner* corner);
+
  private:
   odb::dbDatabase* db_ = nullptr;
   sta::dbSta* sta_ = nullptr;
@@ -105,6 +108,7 @@ class PDNSim
   int bump_pitch_y_ = 0;
   std::string spice_out_file_;
   std::string power_net_;
+  sta::Corner* corner_;
   std::map<std::string, float> net_voltage_map_;
   IRDropByLayer ir_drop_;
   float node_density_ = -1;

--- a/src/psm/src/CMakeLists.txt
+++ b/src/psm/src/CMakeLists.txt
@@ -63,6 +63,7 @@ target_link_libraries(psm
     odb
     OpenSTA
     dbSta
+    rsz_lib
     Eigen3::Eigen
     gui
 )

--- a/src/psm/src/MakePDNSim.cpp
+++ b/src/psm/src/MakePDNSim.cpp
@@ -59,8 +59,10 @@ void initPDNSim(OpenRoad* openroad)
   Tcl_Interp* tcl_interp = openroad->tclInterp();
   Psm_Init(tcl_interp);
   sta::evalTclInit(tcl_interp, sta::psm_tcl_inits);
-  openroad->getPDNSim()->init(
-      openroad->getLogger(), openroad->getDb(), openroad->getSta());
+  openroad->getPDNSim()->init(openroad->getLogger(),
+                              openroad->getDb(),
+                              openroad->getSta(),
+                              openroad->getResizer());
 }
 
 void deletePDNSim(psm::PDNSim* pdnsim)

--- a/src/psm/src/get_power.cpp
+++ b/src/psm/src/get_power.cpp
@@ -52,22 +52,12 @@ using std::vector;
 //! Function for power per instance calculation
 vector<pair<odb::dbInst*, double>> PowerInst::executePowerPerInst(
     sta::dbSta* sta,
-    utl::Logger* logger)
+    utl::Logger* logger,
+    sta::Corner* corner)
 {
   // STA object create
   sta_ = sta;
   logger_ = logger;
-  // environment settings
-  string cornerName = "wst";
-  // string cornerNameFF="bst";
-
-  //  StringSet cornerNameSet;
-  //  cornerNameSet.insert(cornerName.c_str());
-  //
-  //  // define_corners
-  //  _sta->makeCorners(&cornerNameSet);
-  //  Corner* corner = _sta->findCorner(cornerName.c_str());
-  Corner* corner = sta_->cmdCorner();
 
   vector<pair<odb::dbInst*, double>> power_report;
   dbNetwork* network = sta_->getDbNetwork();

--- a/src/psm/src/get_power.h
+++ b/src/psm/src/get_power.h
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace sta {
 class dbSta;
+class Corner;
 }  // namespace sta
 
 namespace odb {
@@ -57,7 +58,8 @@ class PowerInst
   //! Function for power per instance calculation
   std::vector<std::pair<odb::dbInst*, double>> executePowerPerInst(
       sta::dbSta* sta,
-      utl::Logger* logger);
+      utl::Logger* logger,
+      sta::Corner* corner);
 
  private:
   //! Instance to OpenSTA object.

--- a/src/psm/src/get_voltage.cpp
+++ b/src/psm/src/get_voltage.cpp
@@ -44,11 +44,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace psm {
 std::pair<double, double> SupplyVoltage::getSupplyVoltage(sta::dbSta* sta,
-                                                          utl::Logger* logger)
+                                                          utl::Logger* logger,
+                                                          sta::Corner* corner)
 {
   std::pair<double, double> supply_voltage;
   sta::dbNetwork* network = sta->getDbNetwork();
-  sta::Corner* corner = sta->cmdCorner();
   sta::MinMax* mm = sta::MinMax::max();
   const sta::DcalcAnalysisPt* dcalc_ap = corner->findDcalcAnalysisPt(mm);
   float power_voltage;

--- a/src/psm/src/get_voltage.h
+++ b/src/psm/src/get_voltage.h
@@ -36,6 +36,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 namespace sta {
 class dbSta;
+class Corner;
 }  // namespace sta
 
 namespace utl {
@@ -54,7 +55,8 @@ class SupplyVoltage
  public:
   //! Function for power per instance calculation
   std::pair<double, double> getSupplyVoltage(sta::dbSta* sta,
-                                             utl::Logger* logger);
+                                             utl::Logger* logger,
+                                             sta::Corner* corner);
 };
 
 }  // namespace psm

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -128,7 +128,7 @@ IRSolver::IRSolver(odb::dbDatabase* db,
   net_voltage_map_ = net_voltage_map;
 
   if (corner == nullptr) {
-    logger_->error(utl::PSM, 84, "A valid corner is required.");
+    corner = sta_->cmdCorner();
   }
   corner_ = corner;
 }

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "gmat.h"
 #include "node.h"
 #include "odb/db.h"
+#include "rsz/Resizer.hh"
 
 namespace psm {
 using odb::dbBlock;
@@ -93,6 +94,7 @@ using Eigen::VectorXd;
 
 IRSolver::IRSolver(odb::dbDatabase* db,
                    sta::dbSta* sta,
+                   rsz::Resizer* resizer,
                    utl::Logger* logger,
                    const std::string& vsrc_loc,
                    const std::string& power_net,
@@ -105,10 +107,12 @@ IRSolver::IRSolver(odb::dbDatabase* db,
                    int bump_pitch_y,
                    float node_density_um,
                    int node_density_factor_user,
-                   const std::map<std::string, float>& net_voltage_map)
+                   const std::map<std::string, float>& net_voltage_map,
+                   sta::Corner* corner)
 {
   db_ = db;
   sta_ = sta;
+  resizer_ = resizer;
   logger_ = logger;
   vsrc_file_ = vsrc_loc;
   power_net_ = power_net;
@@ -122,6 +126,11 @@ IRSolver::IRSolver(odb::dbDatabase* db,
   node_density_um_ = node_density_um;
   node_density_factor_user_ = node_density_factor_user;
   net_voltage_map_ = net_voltage_map;
+
+  if (corner == nullptr) {
+    logger_->error(utl::PSM, 84, "A valid corner is required.");
+  }
+  corner_ = corner;
 }
 
 IRSolver::~IRSolver() = default;
@@ -946,7 +955,7 @@ void IRSolver::createGmatConnections(const vector<dbSBox*>& power_wires,
           = getViaCuts(loc, via_boxes, bot_l, top_l, has_params, params);
 
       // Find the resistance of each via cut
-      const double R = via_bottom_layer->getUpperLayer()->getResistance()
+      const double R = getResistance(via_bottom_layer->getUpperLayer())
                        * via_cuts.size() / (num_via_rows * num_via_cols);
       if (!checkValidR(R) && !connection_only) {
         logger_->error(utl::PSM,
@@ -1000,7 +1009,7 @@ void IRSolver::createGmatConnections(const vector<dbSBox*>& power_wires,
       const auto bot_layer_dir = via_bottom_layer->getDirection();
       // The bottom layer must be connected by a rail and not by the enclosure.
       if (bot_l != bottom_layer_) {
-        const double rho = via_bottom_layer->getResistance();
+        const double rho = getResistance(via_bottom_layer);
         if (!checkValidR(rho) && !connection_only) {
           logger_->error(utl::PSM,
                          36,
@@ -1021,7 +1030,7 @@ void IRSolver::createGmatConnections(const vector<dbSBox*>& power_wires,
       }
       // Create the connections in the top enclosure
       const auto top_layer_dir = via_top_layer->getDirection();
-      const double rho = via_top_layer->getResistance();
+      const double rho = getResistance(via_top_layer);
       if (!checkValidR(rho) && !connection_only) {
         logger_->error(utl::PSM,
                        37,
@@ -1044,7 +1053,7 @@ void IRSolver::createGmatConnections(const vector<dbSBox*>& power_wires,
       // stripe
       dbTechLayer* wire_layer = curWire->getTechLayer();
       int l = wire_layer->getRoutingLevel();
-      double rho = wire_layer->getResistance();
+      double rho = getResistance(wire_layer);
       if (!checkValidR(rho) && !connection_only) {
         logger_->error(utl::PSM,
                        66,
@@ -1347,12 +1356,12 @@ vector<pair<odb::dbInst*, double>> IRSolver::getPower()
 {
   debugPrint(
       logger_, utl::PSM, "IR Solver", 1, "Executing STA for power calculation");
-  return PowerInst().executePowerPerInst(sta_, logger_);
+  return PowerInst().executePowerPerInst(sta_, logger_, corner_);
 }
 
 pair<double, double> IRSolver::getSupplyVoltage()
 {
-  return SupplyVoltage().getSupplyVoltage(sta_, logger_);
+  return SupplyVoltage().getSupplyVoltage(sta_, logger_, corner_);
 }
 
 bool IRSolver::getResult()
@@ -1504,4 +1513,30 @@ bool IRSolver::buildConnection()
   result_ = res;
   return result_;
 }
+
+double IRSolver::getResistance(odb::dbTechLayer* layer) const
+{
+  double res;
+
+  if (layer->getRoutingLevel() == 0) {
+    double cap;
+    resizer_->layerRC(layer, corner_, res, cap);
+  } else {
+    double r_per_meter, cap_per_meter;
+    resizer_->layerRC(layer, corner_, r_per_meter, cap_per_meter);
+
+    const double width_meter = static_cast<double>(layer->getWidth())
+                               / layer->getTech()->getLefUnits() * 1e-6;
+
+    res = r_per_meter * width_meter;
+  }
+
+  if (res == 0.0) {
+    // Get database resistance
+    res = layer->getResistance();
+  }
+
+  return res;
+}
+
 }  // namespace psm

--- a/src/psm/src/ir_solver.h
+++ b/src/psm/src/ir_solver.h
@@ -38,6 +38,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace sta {
 class dbSta;
+class Corner;
+}  // namespace sta
+
+namespace rsz {
+class Resizer;
 }
 
 namespace psm {
@@ -72,6 +77,7 @@ class IRSolver
    */
   IRSolver(odb::dbDatabase* db,
            sta::dbSta* sta,
+           rsz::Resizer* resizer,
            utl::Logger* logger,
            const std::string& vsrc_loc,
            const std::string& power_net,
@@ -84,7 +90,8 @@ class IRSolver
            int bump_pitch_y,
            float node_density_um,
            int node_density_factor_user,
-           const std::map<std::string, float>& net_voltage_map);
+           const std::map<std::string, float>& net_voltage_map,
+           sta::Corner* corner);
   //! IRSolver destructor
   ~IRSolver();
   //! Returns the created G matrix for the design
@@ -155,6 +162,8 @@ class IRSolver
   bool checkValidR(double R);
   bool getResult();
 
+  double getResistance(odb::dbTechLayer* layer) const;
+
   float supply_voltage_src{0};
   //! Worst case voltage at the lowest layer nodes
   double wc_voltage{0};
@@ -172,6 +181,8 @@ class IRSolver
   odb::dbDatabase* db_;
   //! Pointer to STA
   sta::dbSta* sta_;
+  //! Pointer to Resizer for parastics
+  rsz::Resizer* resizer_;
   //! Pointer to Logger
   utl::Logger* logger_;
   //! Voltage source file
@@ -201,6 +212,8 @@ class IRSolver
 
   bool result_{false};
   bool connection_{false};
+
+  sta::Corner* corner_;
 
   odb::dbSigType power_net_type_;
   std::map<std::string, float> net_voltage_map_;

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -48,8 +48,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ir_solver.h"
 #include "node.h"
 #include "odb/db.h"
-#include "utl/Logger.h"
 #include "sta/Corner.hh"
+#include "utl/Logger.h"
 
 namespace psm {
 
@@ -204,7 +204,8 @@ void PDNSim::analyze_power_grid()
   gmat_obj = irsolve_h->getGMat();
   irsolve_h->solveIR();
   logger_->report("########## IR report #################");
-  logger_->report("Corner: {}", corner_ != nullptr ? corner_->name() : "default");
+  logger_->report("Corner: {}",
+                  corner_ != nullptr ? corner_->name() : "default");
   logger_->report("Worstcase voltage: {:3.2e} V",
                   irsolve_h->getWorstCaseVoltage());
   logger_->report(

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "node.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
+#include "sta/Corner.hh"
 
 namespace psm {
 
@@ -203,6 +204,7 @@ void PDNSim::analyze_power_grid()
   gmat_obj = irsolve_h->getGMat();
   irsolve_h->solveIR();
   logger_->report("########## IR report #################");
+  logger_->report("Corner: {}", corner_ != nullptr ? corner_->name() : "default");
   logger_->report("Worstcase voltage: {:3.2e} V",
                   irsolve_h->getWorstCaseVoltage());
   logger_->report(

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -161,7 +161,7 @@ void PDNSim::write_pg_spice()
                                               node_density_,
                                               node_density_factor_,
                                               net_voltage_map_,
-                                              sta_->cmdCorner());
+                                              corner_);
 
   if (irsolve_h->build()) {
     int check_spice = irsolve_h->printSpice();
@@ -194,7 +194,7 @@ void PDNSim::analyze_power_grid()
                                               node_density_,
                                               node_density_factor_,
                                               net_voltage_map_,
-                                              sta_->cmdCorner());
+                                              corner_);
 
   if (!irsolve_h->build()) {
     logger_->error(
@@ -264,7 +264,7 @@ bool PDNSim::check_connectivity()
                                               node_density_,
                                               node_density_factor_,
                                               net_voltage_map_,
-                                              sta_->cmdCorner());
+                                              corner_);
   if (!irsolve_h->buildConnection()) {
     return false;
   }
@@ -296,6 +296,11 @@ int PDNSim::getMinimumResolution()
         "Minimum resolution not set. Please run analyze_power_grid first.");
   }
   return min_resolution_;
+}
+
+void PDNSim::setCorner(sta::Corner* corner)
+{
+  corner_ = corner;
 }
 
 }  // namespace psm

--- a/src/psm/src/pdnsim.i
+++ b/src/psm/src/pdnsim.i
@@ -35,6 +35,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 %{
 #include "ord/OpenRoad.hh"
 #include "psm/pdnsim.h"
+#include "sta/Corner.hh"
 
 namespace ord {
 psm::PDNSim*
@@ -43,6 +44,7 @@ getPDNSim();
 
 using ord::getPDNSim;
 using psm::PDNSim;
+using sta::Corner;
 %}
 
 %inline %{
@@ -162,6 +164,12 @@ void set_debug_gui_cmd()
 {
   PDNSim* pdnsim = getPDNSim();
   pdnsim->setDebugGui();
+}
+
+void set_corner(Corner* corner)
+{
+  PDNSim* pdnsim = getPDNSim();
+  pdnsim->setCorner(corner);
 }
 
 %} // inline

--- a/src/psm/src/pdnsim.tcl
+++ b/src/psm/src/pdnsim.tcl
@@ -44,11 +44,12 @@ sta::define_cmd_args "analyze_power_grid" {
   [-dy bump_pitch_y]
   [-node_density val_node_density]
   [-node_density_factor val_node_density_factor]
+  [-corner corner]
   }
 
 proc analyze_power_grid { args } {
   sta::parse_key_args "analyze_power_grid" args \
-    keys {-vsrc -outfile -error_file -em_outfile -net -dx -dy -node_density -node_density_factor} flags {-enable_em}
+    keys {-vsrc -outfile -error_file -em_outfile -net -dx -dy -node_density -node_density_factor -corner} flags {-enable_em}
   if { [info exists keys(-vsrc)] } {
     set vsrc_file $keys(-vsrc)
     if { [file readable $vsrc_file] } {
@@ -71,6 +72,8 @@ proc analyze_power_grid { args } {
     set bump_pitch_y $keys(-dy)
     psm::set_bump_pitch_y $bump_pitch_y
   }
+
+  psm::set_corner [sta::parse_corner_or_default keys]
 
   if { [info exists keys(-node_density)] && [info exists keys(-node_density_factor)] } {
     utl::error PSM 77 "Cannot use both node_density and node_density_factor together. Use any one argument"
@@ -138,11 +141,12 @@ sta::define_cmd_args "write_pg_spice" {
   [-net net_name]
   [-dx bump_pitch_x]
   [-dy bump_pitch_y]
+  [-corner corner]
   }
 
 proc write_pg_spice { args } {
   sta::parse_key_args "write_pg_spice" args \
-    keys {-vsrc -outfile -net -dx -dy} flags {}
+    keys {-vsrc -outfile -net -dx -dy -corner} flags {}
   if { [info exists keys(-vsrc)] } {
     set vsrc_file $keys(-vsrc)
     if { [file readable $vsrc_file] } {
@@ -169,6 +173,8 @@ proc write_pg_spice { args } {
     set bump_pitch_y $keys(-dy)
     psm::set_bump_pitch_y $bump_pitch_y
   }
+
+  psm::set_corner [sta::parse_corner_or_default keys]
 
   if { [ord::db_has_rows] } {
     psm::write_pg_spice_cmd

--- a/src/psm/test/Nangate45_data/Nangate45_corners.rc
+++ b/src/psm/test/Nangate45_data/Nangate45_corners.rc
@@ -1,0 +1,41 @@
+set_layer_rc -corner min -layer metal1 -resistance 5.432e-03 -capacitance 8.494e-02
+set_layer_rc -corner min -layer metal2 -resistance 3.574e-03 -capacitance 8.081e-02
+set_layer_rc -corner min -layer metal3 -resistance 3.574e-03 -capacitance 7.516e-02
+set_layer_rc -corner min -layer metal4 -resistance 1.502e-03 -capacitance 9.663e-02
+set_layer_rc -corner min -layer metal5 -resistance 1.502e-03 -capacitance 8.394e-02
+set_layer_rc -corner min -layer metal6 -resistance 1.502e-03 -capacitance 7.298e-02
+set_layer_rc -corner min -layer metal7 -resistance 1.883e-04 -capacitance 1.112e-01
+set_layer_rc -corner min -layer metal8 -resistance 1.883e-04 -capacitance 8.528e-02
+set_layer_rc -corner min -layer metal9 -resistance 3.780e-05 -capacitance 9.063e-02
+set_layer_rc -corner min -layer metal10 -resistance 3.780e-05 -capacitance 6.635e-02
+
+set_layer_rc -corner min -via via1 -resistance 10
+set_layer_rc -corner min -via via2 -resistance 10
+set_layer_rc -corner min -via via3 -resistance 10
+set_layer_rc -corner min -via via4 -resistance 10
+set_layer_rc -corner min -via via5 -resistance 10
+set_layer_rc -corner min -via via6 -resistance 10
+set_layer_rc -corner min -via via7 -resistance 10
+set_layer_rc -corner min -via via8 -resistance 10
+set_layer_rc -corner min -via via9 -resistance 10
+
+set_layer_rc -corner max -layer metal1 -resistance 10.432e-03 -capacitance 8.494e-02
+set_layer_rc -corner max -layer metal2 -resistance 6.574e-03 -capacitance 8.081e-02
+set_layer_rc -corner max -layer metal3 -resistance 6.574e-03 -capacitance 7.516e-02
+set_layer_rc -corner max -layer metal4 -resistance 2.502e-03 -capacitance 9.663e-02
+set_layer_rc -corner max -layer metal5 -resistance 2.502e-03 -capacitance 8.394e-02
+set_layer_rc -corner max -layer metal6 -resistance 2.502e-03 -capacitance 7.298e-02
+set_layer_rc -corner max -layer metal7 -resistance 2.883e-04 -capacitance 1.112e-01
+set_layer_rc -corner max -layer metal8 -resistance 2.883e-04 -capacitance 8.528e-02
+set_layer_rc -corner max -layer metal9 -resistance 6.780e-05 -capacitance 9.063e-02
+set_layer_rc -corner max -layer metal10 -resistance 6.780e-05 -capacitance 6.635e-02
+
+set_layer_rc -corner max -via via1 -resistance 20
+set_layer_rc -corner max -via via2 -resistance 20
+set_layer_rc -corner max -via via3 -resistance 20
+set_layer_rc -corner max -via via4 -resistance 20
+set_layer_rc -corner max -via via5 -resistance 20
+set_layer_rc -corner max -via via6 -resistance 20
+set_layer_rc -corner max -via via7 -resistance 20
+set_layer_rc -corner max -via via8 -resistance 20
+set_layer_rc -corner max -via via9 -resistance 20

--- a/src/psm/test/aes_asap7_vdd.ok
+++ b/src/psm/test/aes_asap7_vdd.ok
@@ -32,6 +32,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 7.00e-01 V
 Average IR drop  : 1.81e-05 V
 Worstcase IR drop: 2.14e-05 V

--- a/src/psm/test/aes_test_vdd.ok
+++ b/src/psm/test/aes_test_vdd.ok
@@ -18,6 +18,7 @@
 [INFO PSM-0064] Number of voltage sources = 4.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.05e+00 V
 Average IR drop  : 1.71e-02 V
 Worstcase IR drop: 4.78e-02 V

--- a/src/psm/test/aes_test_vdd_set_node_density.ok
+++ b/src/psm/test/aes_test_vdd_set_node_density.ok
@@ -18,6 +18,7 @@
 [INFO PSM-0064] Number of voltage sources = 4.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.05e+00 V
 Average IR drop  : 1.71e-02 V
 Worstcase IR drop: 4.78e-02 V

--- a/src/psm/test/aes_test_vdd_set_node_density_fact.ok
+++ b/src/psm/test/aes_test_vdd_set_node_density_fact.ok
@@ -18,6 +18,7 @@
 [INFO PSM-0064] Number of voltage sources = 4.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.05e+00 V
 Average IR drop  : 1.71e-02 V
 Worstcase IR drop: 4.86e-02 V

--- a/src/psm/test/aes_test_vss.ok
+++ b/src/psm/test/aes_test_vss.ok
@@ -17,6 +17,7 @@
 [INFO PSM-0064] Number of voltage sources = 2.
 [INFO PSM-0040] All PDN stripes on net VSS are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 8.56e-02 V
 Average IR drop  : 5.29e-02 V
 Worstcase IR drop: 8.56e-02 V

--- a/src/psm/test/corners.ok
+++ b/src/psm/test/corners.ok
@@ -16,6 +16,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: min
 Worstcase voltage: 6.12e-01 V
 Average IR drop  : 4.42e-01 V
 Worstcase IR drop: 4.88e-01 V
@@ -28,6 +29,7 @@ Worstcase IR drop: 4.88e-01 V
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: max
 Worstcase voltage: 6.71e-01 V
 Average IR drop  : 3.89e-01 V
 Worstcase IR drop: 4.29e-01 V

--- a/src/psm/test/corners.ok
+++ b/src/psm/test/corners.ok
@@ -1,0 +1,34 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 624 components and 2752 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 1248 connections.
+[INFO ODB-0133]     Created 581 nets and 1504 connections.
+[INFO PSM-0001] Reading voltage source file: Vsrc_gcd_vdd.loc.
+[INFO PSM-0015] Reading location of VDD and VSS sources from Vsrc_gcd_vdd.loc.
+[INFO PSM-0076] Setting metal node density to be standard cell height times 5.
+[WARNING PSM-0030] VSRC location at (50.000um, 50.000um) and size 20.000um, is not located on an existing power stripe node. Moving to closest node at (68.070um, 53.115um).
+[INFO PSM-0031] Number of PDN nodes on net VDD = 604.
+[INFO PSM-0064] Number of voltage sources = 1.
+[INFO PSM-0040] All PDN stripes on net VDD are connected.
+########## IR report #################
+Worstcase voltage: 6.12e-01 V
+Average IR drop  : 4.42e-01 V
+Worstcase IR drop: 4.88e-01 V
+######################################
+[INFO PSM-0001] Reading voltage source file: Vsrc_gcd_vdd.loc.
+[INFO PSM-0015] Reading location of VDD and VSS sources from Vsrc_gcd_vdd.loc.
+[INFO PSM-0076] Setting metal node density to be standard cell height times 5.
+[WARNING PSM-0030] VSRC location at (50.000um, 50.000um) and size 20.000um, is not located on an existing power stripe node. Moving to closest node at (68.070um, 53.115um).
+[INFO PSM-0031] Number of PDN nodes on net VDD = 604.
+[INFO PSM-0064] Number of voltage sources = 1.
+[INFO PSM-0040] All PDN stripes on net VDD are connected.
+########## IR report #################
+Worstcase voltage: 6.71e-01 V
+Average IR drop  : 3.89e-01 V
+Worstcase IR drop: 4.29e-01 V
+######################################

--- a/src/psm/test/corners.tcl
+++ b/src/psm/test/corners.tcl
@@ -1,0 +1,14 @@
+source helpers.tcl
+
+read_lef  Nangate45/Nangate45.lef
+read_def Nangate45_data/gcd.def
+define_corners "min" "max"
+read_liberty -corner max Nangate45/Nangate45_slow.lib
+read_liberty -corner min Nangate45/Nangate45_fast.lib
+read_sdc Nangate45_data/gcd.sdc
+
+source Nangate45_data/Nangate45_corners.rc
+
+analyze_power_grid -corner min -vsrc Vsrc_gcd_vdd.loc -net VDD
+
+analyze_power_grid -corner max -vsrc Vsrc_gcd_vdd.loc -net VDD

--- a/src/psm/test/gcd_all_vss.ok
+++ b/src/psm/test/gcd_all_vss.ok
@@ -26,6 +26,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VSS are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 9.92e-04 V
 Average IR drop  : 6.34e-04 V
 Worstcase IR drop: 9.92e-04 V

--- a/src/psm/test/gcd_em_test_vdd.ok
+++ b/src/psm/test/gcd_em_test_vdd.ok
@@ -27,6 +27,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.10e+00 V
 Average IR drop  : 2.91e-04 V
 Worstcase IR drop: 5.13e-04 V

--- a/src/psm/test/gcd_no_vsrc.ok
+++ b/src/psm/test/gcd_no_vsrc.ok
@@ -19,6 +19,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.10e+00 V
 Average IR drop  : 2.91e-04 V
 Worstcase IR drop: 5.13e-04 V

--- a/src/psm/test/gcd_test_vdd.ok
+++ b/src/psm/test/gcd_test_vdd.ok
@@ -26,6 +26,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VDD are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 1.10e+00 V
 Average IR drop  : 2.91e-04 V
 Worstcase IR drop: 5.13e-04 V

--- a/src/psm/test/gcd_vss_no_vsrc.ok
+++ b/src/psm/test/gcd_vss_no_vsrc.ok
@@ -21,6 +21,7 @@
 [INFO PSM-0064] Number of voltage sources = 1.
 [INFO PSM-0040] All PDN stripes on net VSS are connected.
 ########## IR report #################
+Corner: default
 Worstcase voltage: 9.92e-04 V
 Average IR drop  : 6.34e-04 V
 Worstcase IR drop: 9.92e-04 V

--- a/src/psm/test/pdnsim_aux.py
+++ b/src/psm/test/pdnsim_aux.py
@@ -45,7 +45,8 @@ def analyze_power_grid(design, *,
                        dx=None,
                        dy=None,
                        node_density=None,
-                       node_density_factor=None):
+                       node_density_factor=None,
+                       corner=None):
     pdnsim = design.getPDNSim()
     if bool(vsrc):
         if isfile(vsrc):
@@ -82,6 +83,8 @@ def analyze_power_grid(design, *,
 
     pdnsim.import_enable_em(enable_em)
     
+    _set_corner(design, corner)
+
     if bool(em_outfile):
         if enable_em:
             pdnsim.import_em_out_file(em_outfile)
@@ -118,7 +121,8 @@ def write_pg_spice(design, *,
                    outfile=None,
                    net=None,
                    dx=None,
-                   dy=None):
+                   dy=None,
+                   corner=None):
     pdnsim = design.getPDNSim()
 
     if bool(vsrc):
@@ -141,6 +145,8 @@ def write_pg_spice(design, *,
     if bool(dy):
         pdnsim.set_bump_pitch_y(dy)
 
+    _set_corner(design, corner)
+
     if len(design.getBlock().getRows()) > 0:  # db_has_rows
         pdnsim.write_pg_spice()
     else:
@@ -155,3 +161,10 @@ def set_pdnsim_net_voltage(design, *, net=None, voltage=None):
     else:
         utl.error(utl.PSM, 162, "Argument -net or -voltage not specified. " +
                   "Please specify both -net and -voltage arguments.")
+
+
+def _set_corner(design, corner):
+    if corner:
+        design.evalTclString(f"psm::set_corner [sta::find_corner {corner}]")
+    else:
+        design.evalTclString(f"psm::set_corner [sta::cmd_corner]")

--- a/src/psm/test/regression_tests.tcl
+++ b/src/psm/test/regression_tests.tcl
@@ -13,4 +13,5 @@ record_tests {
   aes_asap7_vdd
   check_power_grid
   check_power_grid_disconnected
+  corners
 }


### PR DESCRIPTION
Changes:
- adds a `-corner` flag to `analyze_power_grid` and `write_pg_spice` to allow PSM to get power numbers for a specific corner and parasitic values from resizer.
- If `-corner` is not used, there are no changes in behavior.
