### PR TITLE
odb/lefout: fix segfault on no layer for insertObstruction()

### DIFF
--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -67,7 +67,7 @@ void lefout::insertObstruction(dbTechLayer* layer,
                                const Rect& rect,
                                ObstructionMap& obstructions) const
 {
-  if (layer->getType() == odb::dbTechLayerType::CUT) {
+  if (!layer || layer->getType() == odb::dbTechLayerType::CUT) {
     return;
   }
 


### PR DESCRIPTION
fixes #3649

it is tricky to run `deltaDebug.py` on segfaults, so I wasn't able to provide an example.

Shot in the dark to fix the segfault... I can run `make generate_abstract` on the testcase I couldn't share.