### PR TITLE
drt: check layers 

### DIFF
--- a/src/drt/src/db/tech/frTechObject.h
+++ b/src/drt/src/db/tech/frTechObject.h
@@ -257,7 +257,7 @@ class frTechObject
     logger->info(DRT, 167, "List of default vias:");
     for (auto& layer : layers) {
       if (layer->getType() == dbTechLayerType::CUT
-          && layer->getLayerNum() >= BOTTOM_ROUTING_LAYER) {
+          && layer->getLayerNum() >= 2 /* BOTTOM_ROUTING_LAYER */) {
         logger->report("  Layer {}", layer->getName());
         if (layer->getDefaultViaDef() != nullptr) {
           logger->report("    default via: {}",

--- a/src/drt/src/db/tech/frTechObject.h
+++ b/src/drt/src/db/tech/frTechObject.h
@@ -257,10 +257,14 @@ class frTechObject
     logger->info(DRT, 167, "List of default vias:");
     for (auto& layer : layers) {
       if (layer->getType() == dbTechLayerType::CUT
-          && layer->getLayerNum() >= 2 /*BOTTOM_ROUTING_LAYER*/) {
+          && layer->getLayerNum() >= BOTTOM_ROUTING_LAYER) {
         logger->report("  Layer {}", layer->getName());
-        logger->report("    default via: {}",
-                       layer->getDefaultViaDef()->getName());
+        if (layer->getDefaultViaDef() != nullptr) {
+          logger->report("    default via: {}",
+                         layer->getDefaultViaDef()->getName());
+        } else {
+          logger->report("    default via: none");
+        }
       }
     }
   }

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -902,7 +902,7 @@ void io::Parser::buildGCellPatterns(odb::dbDatabase* db)
 
   design_->getTopBlock()->setGCellPatterns({xgp, ygp});
 
-  for (int layerNum = 0; layerNum <= (int) tech_->getLayers().size();
+  for (int layerNum = 0; layerNum < (int) tech_->getLayers().size();
        layerNum += 2) {
     for (int i = 0; i < (int) xgp.getCount(); i++) {
       for (int j = 0; j < (int) ygp.getCount(); j++) {


### PR DESCRIPTION
Changes:
- avoids segfault when default via is empty (closes #3654)
- ensures drt doesnt go beyond the layer list when iterating over it in `buildGCellPatterns`