### PR TITLE
drt: set VIA_ACCESS_LAYERNUM when adding the first routing level 

### DIFF
--- a/src/drt/src/db/tech/frTechObject.h
+++ b/src/drt/src/db/tech/frTechObject.h
@@ -38,7 +38,9 @@
 #include "db/tech/frLayer.h"
 #include "db/tech/frViaRuleGenerate.h"
 #include "frBaseTypes.h"
+#include "global.h"
 #include "utl/Logger.h"
+
 namespace odb {
 class dbTechLayer;
 }
@@ -257,7 +259,7 @@ class frTechObject
     logger->info(DRT, 167, "List of default vias:");
     for (auto& layer : layers) {
       if (layer->getType() == dbTechLayerType::CUT
-          && layer->getLayerNum() >= 2 /* BOTTOM_ROUTING_LAYER */) {
+          && layer->getLayerNum() >= BOTTOM_ROUTING_LAYER) {
         logger->report("  Layer {}", layer->getName());
         if (layer->getDefaultViaDef() != nullptr) {
           logger->report("    default via: {}",

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1742,11 +1742,6 @@ void io::Parser::addRoutingLayer(odb::dbTechLayer* layer)
     addDefaultMasterSliceLayer();
     addDefaultCutLayer();
   }
-
-  if (layer->getRoutingLevel() == 1) {
-    VIA_ACCESS_LAYERNUM = readLayerCnt_;
-  }
-
   unique_ptr<frLayer> uLayer = make_unique<frLayer>();
   auto tmpLayer = uLayer.get();
   tmpLayer->setDbLayer(layer);

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1742,6 +1742,11 @@ void io::Parser::addRoutingLayer(odb::dbTechLayer* layer)
     addDefaultMasterSliceLayer();
     addDefaultCutLayer();
   }
+
+  if (layer->getRoutingLevel() == 1) {
+    VIA_ACCESS_LAYERNUM = readLayerCnt_;
+  }
+
   unique_ptr<frLayer> uLayer = make_unique<frLayer>();
   auto tmpLayer = uLayer.get();
   tmpLayer->setDbLayer(layer);
@@ -2632,14 +2637,16 @@ bool io::Parser::readGuide()
                        155,
                        "Guide in net {} uses layer {} ({})"
                        " that is outside the allowed routing range "
-                       "[{} ({}), ({})].",
+                       "[{} ({}), {} ({})] with via access on [{} ({})].",
                        net->getName(),
                        layer->getName(),
                        layerNum,
                        tech_->getLayer(BOTTOM_ROUTING_LAYER)->getName(),
                        BOTTOM_ROUTING_LAYER,
                        tech_->getLayer(TOP_ROUTING_LAYER)->getName(),
-                       TOP_ROUTING_LAYER);
+                       TOP_ROUTING_LAYER,
+                       tech_->getLayer(VIA_ACCESS_LAYERNUM)->getName(),
+                       VIA_ACCESS_LAYERNUM);
       }
 
       frRect rect;

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -2072,8 +2072,9 @@ void io::Parser::addCutLayer(odb::dbTechLayer* layer)
     addDefaultMasterSliceLayer();
   auto* lowerlayer = layer->getLowerLayer();
   if (lowerlayer != nullptr
-      && lowerlayer->getType() == odb::dbTechLayerType::CUT)
+      && lowerlayer->getType() == odb::dbTechLayerType::CUT) {
     return;
+  }
 
   unique_ptr<frLayer> uLayer = make_unique<frLayer>();
   auto tmpLayer = uLayer.get();

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -2075,6 +2075,10 @@ void io::Parser::addCutLayer(odb::dbTechLayer* layer)
     return;
   if (readLayerCnt_ == 0)
     addDefaultMasterSliceLayer();
+  auto* lowerlayer = layer->getLowerLayer();
+  if (lowerlayer != nullptr
+      && lowerlayer->getType() == odb::dbTechLayerType::CUT)
+    return;
 
   unique_ptr<frLayer> uLayer = make_unique<frLayer>();
   auto tmpLayer = uLayer.get();

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -902,21 +902,20 @@ void io::Parser::buildGCellPatterns(odb::dbDatabase* db)
 
   design_->getTopBlock()->setGCellPatterns({xgp, ygp});
 
-  for (const auto& layer : tech_->getLayers()) {
-    if (layer->getType() != odb::dbTechLayerType::ROUTING) {
-      continue;
-    }
+  for (int layerNum = 0; layerNum < (int) tech_->getLayers().size();
+       layerNum += 2) {
     for (int i = 0; i < (int) xgp.getCount(); i++) {
       for (int j = 0; j < (int) ygp.getCount(); j++) {
         Rect gcellBox = design_->getTopBlock()->getGCellBox(Point(i, j));
-        bool isH = layer->getDir() == dbTechLayerDir::HORIZONTAL;
+        bool isH = (tech_->getLayers().at(layerNum)->getDir()
+                    == dbTechLayerDir::HORIZONTAL);
         frCoord gcLow = isH ? gcellBox.yMin() : gcellBox.xMax();
         frCoord gcHigh = isH ? gcellBox.yMax() : gcellBox.xMin();
-        for (auto& tp :
-             design_->getTopBlock()->getTrackPatterns(layer->getLayerNum())) {
-          if ((layer->getDir() == dbTechLayerDir::HORIZONTAL
+        for (auto& tp : design_->getTopBlock()->getTrackPatterns(layerNum)) {
+          if ((tech_->getLayer(layerNum)->getDir() == dbTechLayerDir::HORIZONTAL
                && tp->isHorizontal() == false)
-              || (layer->getDir() == dbTechLayerDir::VERTICAL
+              || (tech_->getLayer(layerNum)->getDir()
+                      == dbTechLayerDir::VERTICAL
                   && tp->isHorizontal() == true)) {
             int trackNum
                 = (gcLow - tp->getStartCoord()) / (int) tp->getTrackSpacing();

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -902,20 +902,21 @@ void io::Parser::buildGCellPatterns(odb::dbDatabase* db)
 
   design_->getTopBlock()->setGCellPatterns({xgp, ygp});
 
-  for (int layerNum = 0; layerNum < (int) tech_->getLayers().size();
-       layerNum += 2) {
+  for (const auto& layer : tech_->getLayers()) {
+    if (layer->getType() != odb::dbTechLayerType::ROUTING) {
+      continue;
+    }
     for (int i = 0; i < (int) xgp.getCount(); i++) {
       for (int j = 0; j < (int) ygp.getCount(); j++) {
         Rect gcellBox = design_->getTopBlock()->getGCellBox(Point(i, j));
-        bool isH = (tech_->getLayers().at(layerNum)->getDir()
-                    == dbTechLayerDir::HORIZONTAL);
+        bool isH = layer->getDir() == dbTechLayerDir::HORIZONTAL;
         frCoord gcLow = isH ? gcellBox.yMin() : gcellBox.xMax();
         frCoord gcHigh = isH ? gcellBox.yMax() : gcellBox.xMin();
-        for (auto& tp : design_->getTopBlock()->getTrackPatterns(layerNum)) {
-          if ((tech_->getLayer(layerNum)->getDir() == dbTechLayerDir::HORIZONTAL
+        for (auto& tp :
+             design_->getTopBlock()->getTrackPatterns(layer->getLayerNum())) {
+          if ((layer->getDir() == dbTechLayerDir::HORIZONTAL
                && tp->isHorizontal() == false)
-              || (tech_->getLayer(layerNum)->getDir()
-                      == dbTechLayerDir::VERTICAL
+              || (layer->getDir() == dbTechLayerDir::VERTICAL
                   && tp->isHorizontal() == true)) {
             int trackNum
                 = (gcLow - tp->getStartCoord()) / (int) tp->getTrackSpacing();

--- a/src/drt/test/ndr_vias1.ok
+++ b/src/drt/test/ndr_vias1.ok
@@ -10,8 +10,6 @@
 [INFO ODB-0131]     Created 66 components and 347 component-terminals.
 [INFO ODB-0133]     Created 8 nets and 54 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2

--- a/src/drt/test/ndr_vias2.ok
+++ b/src/drt/test/ndr_vias2.ok
@@ -10,8 +10,6 @@
 [INFO ODB-0131]     Created 66 components and 347 component-terminals.
 [INFO ODB-0133]     Created 8 nets and 54 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2

--- a/src/drt/test/top_level_term.ok
+++ b/src/drt/test/top_level_term.ok
@@ -10,8 +10,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2

--- a/src/drt/test/top_level_term2.ok
+++ b/src/drt/test/top_level_term2.ok
@@ -10,8 +10,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2

--- a/src/grt/test/pin_access1.ok
+++ b/src/grt/test/pin_access1.ok
@@ -10,8 +10,6 @@
 [INFO ODB-0131]     Created 170 components and 1258 component-terminals.
 [INFO ODB-0133]     Created 15 nets and 72 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2

--- a/src/grt/test/pin_access2.ok
+++ b/src/grt/test/pin_access2.ok
@@ -11,8 +11,6 @@
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 411 nets and 1210 connections.
 [INFO DRT-0167] List of default vias:
-  Layer mcon
-    default via: L1M1_PR
   Layer via
     default via: M1M2_PR
   Layer via2


### PR DESCRIPTION
Issue:
if multiple vias are defined before the first routing level, the `VIA_ACCESS_LAYERNUM` will be pointing to a via instead of the first routing level.

Changes:
- set VIA_ACCESS_LAYERNUM when adding the first routing level to ensure it matches the layer stack
- just loop over layers to init gcells to avoid assumptions about the start of the layer stack
- minor changes to error message for guideIN to make it clear what the via access is.