### PR TITLE
add more macro orientation options

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -515,8 +515,45 @@ void Pin::updateCoordi(odb::dbITerm* iTerm)
     offsetCy_ = (offsetLy + offsetUy) / 2 - instCenterY;
   }
 
-  cx_ = lx + instCenterX + offsetCx_;
-  cy_ = ly + instCenterY + offsetCy_;
+  // Rotate and Mirror depending on instance orientation
+  switch (iTerm->getInst()->getOrient()) {
+    case dbOrientType::R0:
+      cx_ = lx + instCenterX + offsetCx_;
+      cy_ = ly + instCenterY + offsetCy_;
+      break;
+    case dbOrientType::R90:
+      cx_ = lx + instCenterY - offsetCy_;
+      cy_ = ly + instCenterX - offsetCx_;
+      break;
+    case dbOrientType::R180:
+      cx_ = lx + instCenterX - offsetCx_;
+      cy_ = ly + instCenterY - offsetCy_;
+      break;
+    case dbOrientType::R270:
+      cx_ = lx + instCenterY + offsetCy_;
+      cy_ = ly + instCenterX + offsetCx_;
+      break;
+    case dbOrientType::MX:
+      cx_ = lx + instCenterX + offsetCx_;
+      cy_ = ly + instCenterY - offsetCy_;
+      break;
+    case dbOrientType::MY:
+      cx_ = lx + instCenterX - offsetCx_;
+      cy_ = ly + instCenterY + offsetCy_;
+      break;
+    case dbOrientType::MXR90:
+      cx_ = lx + instCenterY + offsetCy_;
+      cy_ = ly + instCenterX - offsetCx_;
+      break;
+    case dbOrientType::MYR90:
+      cx_ = lx + instCenterY - offsetCy_;
+      cy_ = ly + instCenterX + offsetCx_;
+      break;
+    default:
+      cx_ = lx + instCenterX;
+      cy_ = ly + instCenterY;
+      break;
+  }
 }
 
 //


### PR DESCRIPTION
This PR adds more macro orientation options.

Especially the placer needed to be made aware of the macro orientation, which for more extensive memory macros, was a problem. We tested this with the IHP13 srams: https://github.com/IHP-GmbH/IHP-Open-PDK/tree/main/ihp-sg13g2/libs.ref/sg13g2_sram

Thank you to the OpenROAD team for this amazing project 💯 