### PR TITLE
Proposal: percentage progress indication

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -159,7 +159,13 @@ RepairDesign::repairDesign(double max_wire_length, // zero for none (meters)
 
   resizer_->incrementalParasiticsBegin();
   int max_length = resizer_->metersToDbu(max_wire_length);
+  int previous_progress = 0;
   for (int i = resizer_->level_drvr_vertices_.size() - 1; i >= 0; i--) {
+    int progress = (int)(100.0F * (1.0F - ((float)i / (float)resizer_->level_drvr_vertices_.size())));
+    if (progress > previous_progress) {
+      logger_->info(RSZ, 1234, "Repaired: {}%", progress);
+      previous_progress = progress;
+    }
     Vertex *drvr = resizer_->level_drvr_vertices_[i];
     Pin *drvr_pin = drvr->pin();
     Net *net = network_->isTopLevelPort(drvr_pin)

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -159,7 +159,7 @@ RepairDesign::repairDesign(double max_wire_length, // zero for none (meters)
 
   resizer_->incrementalParasiticsBegin();
   int max_length = resizer_->metersToDbu(max_wire_length);
-  int previous_progress = 0;
+  int previous_progress = -1;
   for (int i = resizer_->level_drvr_vertices_.size() - 1; i >= 0; i--) {
     int progress = (int)(100.0F * (1.0F - ((float)i / (float)resizer_->level_drvr_vertices_.size())));
     if (progress > previous_progress) {

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -299,6 +299,10 @@ RepairHold::repairHold(VertexSeq &ends,
       sta_->findRequireds();
       findHoldViolations(ends, hold_margin, worst_slack, hold_failures);
       pass++;
+      logger_->info(RSZ, 46, "Hold fixing progress: {} worst slack {}, pass {}, max_passes {}, setup_slack {}",
+                    inserted_buffer_count_,
+                    delayAsString(worst_slack, sta_, 3),
+                    pass, max_passes, delayAsString(sta_->worstSlack(max_), sta_, 3));
       progress = inserted_buffer_count_ > hold_buffer_count_before;
     }
     if (verbose) {

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -299,7 +299,7 @@ RepairHold::repairHold(VertexSeq &ends,
       sta_->findRequireds();
       findHoldViolations(ends, hold_margin, worst_slack, hold_failures);
       pass++;
-      logger_->info(RSZ, 46, "Hold fixing progress: {} worst slack {}, pass {}, max_passes {}, setup_slack {}",
+      logger_->info(RSZ, 1236, "Hold fixing progress: {} worst slack {}, pass {}, max_passes {}, setup_slack {}",
                     inserted_buffer_count_,
                     delayAsString(worst_slack, sta_, 3),
                     pass, max_passes, delayAsString(sta_->worstSlack(max_), sta_, 3));

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -161,7 +161,13 @@ RepairSetup::repairSetup(float setup_slack_margin,
   if (verbose) {
     printProgress(print_iteration, false, false);
   }
+  int previous_progress = -1;
   for (Vertex *end : violating_ends) {
+    int progress = (int)(100.0F * ((float)end_index / (float)max_end_count));
+    if (progress > previous_progress) {
+      logger_->info(RSZ, 1235, "Repaired setup: {}%", progress);
+      previous_progress = progress;
+    }
     resizer_->updateParasitics();
     sta_->findRequireds();
     Slack end_slack = sta_->vertexSlack(end, max_);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -303,7 +303,7 @@ Resizer::removeBuffers()
   for (dbInst *db_inst : block_->getInsts()) {
     int progress = (int)(100.0F * ((float)i++ / (float)num_insts));
     if (progress > previous_progress) {
-      logger_->info(RSZ, 1236, "Checked: {}%", progress);
+      logger_->info(RSZ, 29, "Checked: {}%", progress);
       previous_progress = progress;
     }
     LibertyCell *lib_cell = db_network_->libertyCell(db_inst);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -296,8 +296,16 @@ Resizer::removeBuffers()
   graph_delay_calc_->delaysInvalid();
   search_->arrivalsInvalid();
 
+  int num_insts = block_->getInsts().size();
   int remove_count = 0;
+  int previous_progress = -1;
+  int i = 0;
   for (dbInst *db_inst : block_->getInsts()) {
+    int progress = (int)(100.0F * ((float)i++ / (float)num_insts));
+    if (progress > previous_progress) {
+      logger_->info(RSZ, 1236, "Checked: {}%", progress);
+      previous_progress = progress;
+    }
     LibertyCell *lib_cell = db_network_->libertyCell(db_inst);
     Instance *buffer = db_network_->dbToSta(db_inst);
     if (!db_inst->isDoNotTouch()


### PR DESCRIPTION
This PR introduces percentage indications for `repairDesign`, `repairHold`, and `repairSetup`. I know that there is a debug logging option. 

We found this helpful for larger designs that can spend multiple hours in these stages. We wanted to propose this, but we also understand if there is an effort to keep terminal output to a minimum.

Thank you again for this fantastic piece of software 💯 