### PR TITLE
Discussion: allow different placement margin per instance also in global placement

### DIFF
--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -44,6 +44,10 @@ namespace sta {
 class dbSta;
 }
 
+namespace dpl {
+class Opendp;
+};
+
 namespace grt {
 class GlobalRouter;
 }
@@ -76,6 +80,7 @@ class Replace
   ~Replace();
 
   void init(odb::dbDatabase* odb,
+            dpl::Opendp* dp,
             rsz::Resizer* resizer,
             grt::GlobalRouter* router,
             utl::Logger* logger);
@@ -145,6 +150,7 @@ class Replace
   bool initNesterovPlace();
 
   odb::dbDatabase* db_;
+  dpl::Opendp* dp_;
   rsz::Resizer* rs_;
   grt::GlobalRouter* fr_;
   utl::Logger* log_;

--- a/src/gpl/src/MakeReplace.cpp
+++ b/src/gpl/src/MakeReplace.cpp
@@ -60,6 +60,7 @@ void initReplace(OpenRoad* openroad)
   Gpl_Init(tcl_interp);
   sta::evalTclInit(tcl_interp, sta::gpl_tcl_inits);
   openroad->getReplace()->init(openroad->getDb(),
+                               openroad->getOpendp(),
                                openroad->getResizer(),
                                openroad->getGlobalRouter(),
                                openroad->getLogger());

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -34,6 +34,7 @@
 #include "placerBase.h"
 
 #include <odb/db.h>
+#include <dpl/Opendp.h>
 
 #include <iostream>
 #include <utility>
@@ -794,11 +795,13 @@ PlacerBaseCommon::PlacerBaseCommon()
 }
 
 PlacerBaseCommon::PlacerBaseCommon(odb::dbDatabase* db,
+                                   dpl::Opendp* dp,
                                    PlacerBaseVars pbVars,
                                    utl::Logger* log)
     : PlacerBaseCommon()
 {
   db_ = db;
+  dp_ = dp;
   log_ = log;
   pbVars_ = pbVars;
   init();
@@ -853,9 +856,18 @@ void PlacerBaseCommon::init()
     if (!type.isCore() && !type.isBlock()) {
       continue;
     }
+    // Get Padding from Detailed Placer
+    int padLeft = dp_->padLeft(inst);
+    int padRight = dp_->padRight(inst);
+    if (padLeft == 0) {
+      padLeft = pbVars_.padLeft;
+    }
+    if (padRight == 0) {
+      padRight = pbVars_.padRight;
+    }
     Instance myInst(inst,
-                    pbVars_.padLeft * siteSizeX_,
-                    pbVars_.padRight * siteSizeX_,
+                    padLeft * siteSizeX_,
+                    padRight * siteSizeX_,
                     siteSizeY_,
                     log_);
 

--- a/src/gpl/src/placerBase.h
+++ b/src/gpl/src/placerBase.h
@@ -56,6 +56,10 @@ class Point;
 
 }  // namespace odb
 
+namespace dpl {
+class Opendp; 
+}
+
 namespace utl {
 class Logger;
 }
@@ -309,6 +313,7 @@ class PlacerBaseCommon
   PlacerBaseCommon();
   // temp padLeft/Right before OpenDB supporting...
   PlacerBaseCommon(odb::dbDatabase* db,
+                   dpl::Opendp* dp, 
                    PlacerBaseVars pbVars,
                    utl::Logger* log);
   ~PlacerBaseCommon();
@@ -343,6 +348,7 @@ class PlacerBaseCommon
 
  private:
   odb::dbDatabase* db_;
+  dpl::Opendp* dp_;
   utl::Logger* log_;
 
   PlacerBaseVars pbVars_;

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -39,6 +39,7 @@
 #include "nesterovBase.h"
 #include "nesterovPlace.h"
 #include "odb/db.h"
+#include "dpl/Opendp.h"
 #include "placerBase.h"
 #include "routeBase.h"
 #include "rsz/Resizer.hh"
@@ -52,6 +53,7 @@ using utl::GPL;
 
 Replace::Replace()
     : db_(nullptr),
+      dp_(nullptr),
       rs_(nullptr),
       fr_(nullptr),
       log_(nullptr),
@@ -107,11 +109,13 @@ Replace::~Replace()
 }
 
 void Replace::init(odb::dbDatabase* odb,
+                   dpl::Opendp* dp,
                    rsz::Resizer* resizer,
                    grt::GlobalRouter* router,
                    utl::Logger* logger)
 {
   db_ = odb;
+  dp_ = dp;
   rs_ = resizer;
   fr_ = router;
   log_ = logger;
@@ -186,7 +190,7 @@ void Replace::doIncrementalPlace()
     pbVars.padRight = padRight_;
     pbVars.skipIoMode = skipIoMode_;
 
-    pbc_ = std::make_shared<PlacerBaseCommon>(db_, pbVars, log_);
+    pbc_ = std::make_shared<PlacerBaseCommon>(db_, dp_, pbVars, log_);
 
     pbVec_.push_back(std::make_shared<PlacerBase>(db_, pbc_, log_));
 
@@ -210,8 +214,13 @@ void Replace::doIncrementalPlace()
   for (auto inst : block->getInsts()) {
     auto status = inst->getPlacementStatus();
     if (status == odb::dbPlacementStatus::PLACED) {
-      pbc_->dbToPb(inst)->lock();
-      ++locked_cnt;
+      auto inst_ptr = pbc_->dbToPb(inst);
+      if (inst_ptr != nullptr) {
+        pbc_->dbToPb(inst)->lock();
+        ++locked_cnt;
+      } else {
+        log_->info(GPL, 2345, "Failed to lock {}", inst->getName());
+      }
     } else if (!status.isPlaced()) {
       ++unplaced_cnt;
     }
@@ -264,7 +273,7 @@ void Replace::doInitialPlace()
     pbVars.padRight = padRight_;
     pbVars.skipIoMode = skipIoMode_;
 
-    pbc_ = std::make_shared<PlacerBaseCommon>(db_, pbVars, log_);
+    pbc_ = std::make_shared<PlacerBaseCommon>(db_, dp_, pbVars, log_);
 
     pbVec_.push_back(std::make_shared<PlacerBase>(db_, pbc_, log_));
 
@@ -304,7 +313,7 @@ bool Replace::initNesterovPlace()
     pbVars.padRight = padRight_;
     pbVars.skipIoMode = skipIoMode_;
 
-    pbc_ = std::make_shared<PlacerBaseCommon>(db_, pbVars, log_);
+    pbc_ = std::make_shared<PlacerBaseCommon>(db_, dp_, pbVars, log_);
 
     pbVec_.push_back(std::make_shared<PlacerBase>(db_, pbc_, log_));
 


### PR DESCRIPTION
There are better solutions than this here... But it is the fastest fix we saw atm.

We had the issue that we could not place our design when using `set_placement_density -instances` in detailed placement.

We used the way shown in this PR to get the information from the detailed placement command to the global placer, as the global placer supports per-instance padding.

Examples of our hotspots:

```tcl
set_placement_padding -global -left 2 -right 2
set_placement_padding -instances [get_cells *i_bootrom*] -right 5 -left 5
set_placement_padding -instances [get_cells *gen_asic_regfile_i_ariane_regfile*] -right 7 -left 7
set_placement_padding -instances [get_cells *gen_asic_fp_regfile_i_ariane_fp_regfile*] -right 7 -left 7
set_placement_padding -instances [get_cells *i_scoreboard*] -right 5 -left 5
set_placement_padding -instances [get_cells *i_multiplier*] -right 5 -left 5
```

As mentioned above, this is not a nice solution as it mixes global placer and detailed placer. But we believe that having the per instance placement information in the global placer should help with the overall backend flow.

We are happy to discuss any other ideas or also if we have missed something :-).
