### PR TITLE
ppl: support for mirrored pins inside annealing

### DIFF
--- a/src/ppl/README.md
+++ b/src/ppl/README.md
@@ -23,6 +23,7 @@ place_pins [-hor_layers <h_layers>]
            [-corner_avoidance <length>]
            [-min_distance <distance>]
            [-min_distance_in_tracks]
+           [-annealing]
 ```
 
 -   `-hor_layers` (mandatory). Specify the layers to create the metal shapes
@@ -45,6 +46,8 @@ place_pins [-hor_layers <h_layers>]
     between each pin.
 -   `-min_distance_in_tracks`. Flag that allows setting the min distance in
     number of tracks instead of microns.
+-   `-annealing`. Flag that enables the Simulated Annealing solver to perform
+    the pin placement.
 
 The `exclude` option syntax is `-exclude edge:interval`. The `edge` values are
 (top|bottom|left|right). The `interval` can be the whole edge, with the `*`
@@ -216,6 +219,23 @@ set_pin_thick_multiplier [-hor_multiplier h_mult]
 
 -   The `-hor_multiplier` option defines the thickness multiplier for the horizontal pins.
 -   The `-ver_multiplier` option defines the thickness multiplier for the vertical pins.
+
+#### Configure Simulated Annealing Solver
+
+The `set_simulated_annealing` command defines the parameters of the Simulated Annealing
+solver.
+
+```
+set_simulated_annealing [-temperature temperature]
+                        [-max_iterations iters]
+                        [-perturb_per_iter perturbs]
+                        [-alpha alpha]
+```
+
+- The `-temperature` sets the initial temperature of the Simulated Annealing solver.
+- The `-max_iterations` sets the number of iterations performed by the Simulated Annealing solver.
+- The `-perturb_per_iter` sets the number of perturbations performed at each iteration.
+- The `-alpha` sets the reduction factor of the temperature at each iteration.
 
 ## Example scripts
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -123,7 +123,7 @@ class IOPlacer
   void clear();
   void clearConstraints();
   void run(bool random_mode);
-  void runAnnealing();
+  void runAnnealing(bool random);
   void reportHPWL();
   void printConfig();
   Parameters* getParameters() { return parms_.get(); }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1918,7 +1918,7 @@ void IOPlacer::setAnnealingConfig(float temperature,
   alpha_ = alpha;
 }
 
-void IOPlacer::runAnnealing()
+void IOPlacer::runAnnealing(bool random)
 {
   initParms();
 
@@ -1932,8 +1932,8 @@ void IOPlacer::runAnnealing()
   initConstraints(true);
 
   ppl::SimulatedAnnealing annealing(
-      netlist_io_pins_.get(), slots_, constraints_, logger_, db_);
-  annealing.run(init_temperature_, max_iterations_, perturb_per_iter_, alpha_);
+      netlist_io_pins_.get(), core_.get(), slots_, constraints_, logger_, db_);
+  annealing.run(init_temperature_, max_iterations_, perturb_per_iter_, alpha_, random);
   annealing.getAssignment(assignment_);
 
   for (auto& pin : assignment_) {

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1570,19 +1570,16 @@ std::vector<int> IOPlacer::findPinsForConstraint(const Constraint& constraint,
 
 void IOPlacer::initMirroredPins(bool annealing)
 {
-  if (annealing && !mirrored_pins_.empty()) {
-    logger_->error(PPL,
-                   102,
-                   "Mirrored pins not supported during pin placement with "
-                   "Simulated Annealing");
-  }
   for (IOPin& io_pin : netlist_io_pins_->getIOPins()) {
     if (mirrored_pins_.find(io_pin.getBTerm()) != mirrored_pins_.end()) {
+      int pin_idx = netlist_io_pins_->getIoPinIdx(io_pin.getBTerm());
       io_pin.setMirrored();
       odb::dbBTerm* mirrored_term = mirrored_pins_[io_pin.getBTerm()];
       int mirrored_pin_idx = netlist_io_pins_->getIoPinIdx(mirrored_term);
       IOPin& mirrored_pin = netlist_io_pins_->getIoPin(mirrored_pin_idx);
       mirrored_pin.setMirrored();
+      io_pin.setMirrorPinIdx(mirrored_pin_idx);
+      mirrored_pin.setMirrorPinIdx(pin_idx);
     }
   }
 }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1933,7 +1933,8 @@ void IOPlacer::runAnnealing(bool random)
 
   ppl::SimulatedAnnealing annealing(
       netlist_io_pins_.get(), core_.get(), slots_, constraints_, logger_, db_);
-  annealing.run(init_temperature_, max_iterations_, perturb_per_iter_, alpha_, random);
+  annealing.run(
+      init_temperature_, max_iterations_, perturb_per_iter_, alpha_, random);
   annealing.getAssignment(assignment_);
 
   for (auto& pin : assignment_) {

--- a/src/ppl/src/IOPlacer.i
+++ b/src/ppl/src/IOPlacer.i
@@ -323,9 +323,9 @@ set_simulated_annealing(float temperature,
 }
 
 void
-run_annealing()
+run_annealing(bool random)
 {
-  getIOPlacer()->runAnnealing();
+  getIOPlacer()->runAnnealing(random);
 }
 
 } // namespace

--- a/src/ppl/src/IOPlacer.tcl
+++ b/src/ppl/src/IOPlacer.tcl
@@ -586,7 +586,7 @@ proc place_pins { args } {
   }
 
   if { [info exists flags(-annealing)] } {
-    ppl::run_annealing
+    ppl::run_annealing [info exists flags(-random)]
   } else {
     ppl::run_io_placement [info exists flags(-random)]
   }

--- a/src/ppl/src/Netlist.h
+++ b/src/ppl/src/Netlist.h
@@ -136,6 +136,11 @@ class IOPin
   {
     constraint_idx_ = constraint_idx;
   }
+  int getMirrorPinIdx() const { return mirror_pin_idx_; }
+  void setMirrorPinIdx(const int mirror_pin_idx)
+  {
+    mirror_pin_idx_ = mirror_pin_idx;
+  }
   bool isPlaced() const { return is_placed_; }
   void setPlaced() { is_placed_ = true; }
   bool isInGroup() const { return in_group_; }
@@ -160,6 +165,7 @@ class IOPin
   int layer_{-1};
   int group_idx_{-1};
   int constraint_idx_{-1};
+  int mirror_pin_idx_{-1};
   bool is_placed_{false};
   bool in_group_{false};
   bool in_constraint_{false};

--- a/src/ppl/src/SimulatedAnnealing.cpp
+++ b/src/ppl/src/SimulatedAnnealing.cpp
@@ -87,16 +87,17 @@ void SimulatedAnnealing::run(float init_temperature,
 
         const int64 cost = pre_cost + getDeltaCost(prev_cost);
         const int delta_cost = cost - pre_cost;
-        debugPrint(logger_,
-                  utl::PPL,
-                  "annealing",
-                  1,
-                  "iteration: {}; temperature: {}; assignment cost: {}um; delta "
-                  "cost: {}um",
-                  iter,
-                  temperature,
-                  dbuToMicrons(cost),
-                  dbuToMicrons(delta_cost));
+        debugPrint(
+            logger_,
+            utl::PPL,
+            "annealing",
+            1,
+            "iteration: {}; temperature: {}; assignment cost: {}um; delta "
+            "cost: {}um",
+            iter,
+            temperature,
+            dbuToMicrons(cost),
+            dbuToMicrons(delta_cost));
 
         const float rand_float = distribution(generator_);
         const float accept_prob = std::exp((-1) * delta_cost / temperature);
@@ -336,7 +337,8 @@ int SimulatedAnnealing::swapPins()
   boost::random::uniform_int_distribution<int> distribution(0, num_pins_ - 1);
   int pin1 = distribution(generator_);
   int pin2;
-  while (netlist_->getIoPin(pin1).isInGroup()) {
+  while (netlist_->getIoPin(pin1).isInGroup()
+         || netlist_->getIoPin(pin1).isMirrored()) {
     pin1 = distribution(generator_);
   }
 
@@ -354,13 +356,15 @@ int SimulatedAnnealing::swapPins()
 
     int pin_idx = distribution(generator_);
     pin2 = pin_indices[pin_idx];
-    while (pin1 == pin2 || netlist_->getIoPin(pin2).isInGroup()) {
+    while (pin1 == pin2 || netlist_->getIoPin(pin2).isInGroup()
+           || netlist_->getIoPin(pin2).isMirrored()) {
       pin_idx = distribution(generator_);
       pin2 = pin_indices[pin_idx];
     }
   } else {
     pin2 = distribution(generator_);
     while (pin1 == pin2 || netlist_->getIoPin(pin2).isInGroup()
+           || netlist_->getIoPin(pin2).isMirrored()
            || netlist_->getIoPin(pin2).getConstraintIdx() != -1) {
       pin2 = distribution(generator_);
     }

--- a/src/ppl/src/SimulatedAnnealing.cpp
+++ b/src/ppl/src/SimulatedAnnealing.cpp
@@ -505,4 +505,32 @@ void SimulatedAnnealing::getSlotsRange(const IOPin& io_pin,
   }
 }
 
+int SimulatedAnnealing::getSlotIdxByPosition(const odb::Point& position,
+                                             int layer) const
+{
+  int slot_idx = -1;
+  for (int i = 0; i < slots_.size(); i++) {
+    if (slots_[i].pos == position && slots_[i].layer == layer) {
+      slot_idx = i;
+      break;
+    }
+  }
+
+  return slot_idx;
+}
+
+bool SimulatedAnnealing::isFreeForMirrored(const int slot_idx,
+                                           int& mirrored_idx) const
+{
+  const Slot& slot = slots_[slot_idx];
+  const int layer = slot.layer;
+  const odb::Point& position = slot.pos;
+  odb::Point mirrored_pos = core_->getMirroredPosition(position);
+  mirrored_idx = getSlotIdxByPosition(mirrored_pos, layer);
+
+  const Slot& mirrored_slot = slots_[mirrored_idx];
+
+  return slot.isAvailable() && mirrored_slot.isAvailable();
+}
+
 }  // namespace ppl

--- a/src/ppl/src/SimulatedAnnealing.cpp
+++ b/src/ppl/src/SimulatedAnnealing.cpp
@@ -186,13 +186,13 @@ void SimulatedAnnealing::randomAssignment()
       int mirrored_slot;
       bool free = !slots_[slot].used;
       if (io_pin.isMirrored()) {
-        free = isFreeForMirrored(slot, mirrored_slot);
+        free = free && isFreeForMirrored(slot, mirrored_slot);
       }
       while (!free) {
         slot = distribution(generator_);
         free = !slots_[slot].used;
         if (io_pin.isMirrored()) {
-          free = isFreeForMirrored(slot, mirrored_slot);
+          free = free && isFreeForMirrored(slot, mirrored_slot);
         }
       }
       pin_assignment_[i] = slot;
@@ -207,14 +207,14 @@ void SimulatedAnnealing::randomAssignment()
       int mirrored_slot;
       bool free = !slots_[slot].used;
       if (io_pin.isMirrored()) {
-        free = isFreeForMirrored(slot, mirrored_slot);
+        free = free && isFreeForMirrored(slot, mirrored_slot);
       }
       while (!free) {
         slot_idx++;
         slot = slot_indices[slot_idx];
         free = !slots_[slot].used;
         if (io_pin.isMirrored()) {
-          free = isFreeForMirrored(slot, mirrored_slot);
+          free = free && isFreeForMirrored(slot, mirrored_slot);
         }
       }
       pin_assignment_[i] = slot;
@@ -505,7 +505,7 @@ int SimulatedAnnealing::moveGroupToFreeSlots(const int group_idx)
     for (int i = 0; i < group.pin_indices.size(); i++) {
       free_slot = slots_[slot].isAvailable();
       if (io_pin.isMirrored()) {
-        free_slot = isFreeForMirrored(slot, mirrored_slot);
+        free_slot = free_slot && isFreeForMirrored(slot, mirrored_slot);
       }
       same_edge_slot = slots_[slot].edge == edge;
       if (!free_slot || !same_edge_slot) {

--- a/src/ppl/src/SimulatedAnnealing.cpp
+++ b/src/ppl/src/SimulatedAnnealing.cpp
@@ -182,19 +182,48 @@ void SimulatedAnnealing::randomAssignment()
                                                                 last_slot);
 
       int slot = distribution(generator_);
-      while (slots_[slot].used) {
+      int mirrored_slot;
+      bool free = !slots_[slot].used;
+      if (io_pin.isMirrored()) {
+        free = isFreeForMirrored(slot, mirrored_slot);
+      }
+      while (!free) {
         slot = distribution(generator_);
+        free = !slots_[slot].used;
+        if (io_pin.isMirrored()) {
+          free = isFreeForMirrored(slot, mirrored_slot);
+        }
       }
       pin_assignment_[i] = slot;
       slots_[slot].used = true;
+      if (io_pin.isMirrored()) {
+        pin_assignment_[io_pin.getMirrorPinIdx()] = mirrored_slot;
+        slots_[mirrored_slot].used = true;
+      }
+      placed_pins.insert(io_pin.getMirrorPinIdx());
     } else {
       int slot = slot_indices[slot_idx];
-      while (slots_[slot].used) {
+      int mirrored_slot;
+      bool free = !slots_[slot].used;
+      if (io_pin.isMirrored()) {
+        free = isFreeForMirrored(slot, mirrored_slot);
+      }
+      while (!free) {
         slot_idx++;
         slot = slot_indices[slot_idx];
+        free = !slots_[slot].used;
+        if (io_pin.isMirrored()) {
+          free = isFreeForMirrored(slot, mirrored_slot);
+        }
       }
       pin_assignment_[i] = slot;
       slots_[slot].used = true;
+      if (io_pin.isMirrored()) {
+        pin_assignment_[io_pin.getMirrorPinIdx()] = mirrored_slot;
+        slots_[mirrored_slot].used = true;
+      }
+      placed_pins.insert(io_pin.getMirrorPinIdx());
+
       slot_idx++;
     }
   }

--- a/src/ppl/src/SimulatedAnnealing.h
+++ b/src/ppl/src/SimulatedAnnealing.h
@@ -93,7 +93,7 @@ class SimulatedAnnealing
   bool isFreeForGroup(int slot_idx, int group_size, int last_slot);
   void getSlotsRange(const IOPin& io_pin, int& first_slot, int& last_slot);
   int getSlotIdxByPosition(const odb::Point& position, int layer) const;
-  bool isFreeForMirrored(const int slot_idx, int& mirrored_idx) const;
+  bool isFreeForMirrored(int slot_idx, int& mirrored_idx) const;
   int getMirroredSlotIdx(int slot_idx) const;
 
   // [pin] -> slot

--- a/src/ppl/src/SimulatedAnnealing.h
+++ b/src/ppl/src/SimulatedAnnealing.h
@@ -40,6 +40,7 @@
 #include <boost/random/uniform_int_distribution.hpp>
 #include <random>
 
+#include "Core.h"
 #include "Netlist.h"
 #include "Slots.h"
 #include "odb/geom.h"
@@ -58,6 +59,7 @@ class SimulatedAnnealing
 {
  public:
   SimulatedAnnealing(Netlist* netlist,
+                     Core* core,
                      std::vector<Slot>& slots,
                      const std::vector<Constraint>& constraints,
                      Logger* logger,
@@ -66,7 +68,8 @@ class SimulatedAnnealing
   void run(float init_temperature,
            int max_iterations,
            int perturb_per_iter,
-           float alpha);
+           float alpha,
+           bool random);
   void getAssignment(std::vector<IOPin>& assignment);
 
  private:
@@ -89,11 +92,14 @@ class SimulatedAnnealing
   double dbuToMicrons(int64_t dbu);
   bool isFreeForGroup(int slot_idx, int group_size, int last_slot);
   void getSlotsRange(const IOPin& io_pin, int& first_slot, int& last_slot);
+  int getSlotIdxByPosition(const odb::Point& position, int layer) const;
+  bool isFreeForMirrored(const int slot_idx, int& mirrored_idx) const;
 
   // [pin] -> slot
   std::vector<int> pin_assignment_;
   std::vector<int> slot_indices_;
   Netlist* netlist_;
+  Core* core_;
   std::vector<Slot>& slots_;
   const std::vector<PinGroupByIndex>& pin_groups_;
   const std::vector<Constraint>& constraints_;

--- a/src/ppl/src/SimulatedAnnealing.h
+++ b/src/ppl/src/SimulatedAnnealing.h
@@ -94,6 +94,7 @@ class SimulatedAnnealing
   void getSlotsRange(const IOPin& io_pin, int& first_slot, int& last_slot);
   int getSlotIdxByPosition(const odb::Point& position, int layer) const;
   bool isFreeForMirrored(const int slot_idx, int& mirrored_idx) const;
+  int getMirroredSlotIdx(int slot_idx) const;
 
   // [pin] -> slot
   std::vector<int> pin_assignment_;

--- a/src/ppl/test/annealing_mirrored1.defok
+++ b/src/ppl/test/annealing_mirrored1.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 172710 201530 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48830 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104860 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 37100 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 138180 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 159790 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 69730 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 32900 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 65380 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 9690 70 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 142310 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 113430 70 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 46900 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 56700 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48450 201530 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78470 201530 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 109620 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 73220 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 177270 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 193610 201530 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 195580 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 180180 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 102620 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 45790 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 113260 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 16530 70 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 65170 201530 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 13490 201530 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 111020 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 182210 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 191330 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 136230 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 85820 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 169540 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 24130 70 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48830 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 104860 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 116090 201530 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 80220 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 56430 70 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 64260 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 163940 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 46900 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 45790 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 65170 70 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 13490 70 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 111020 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 182210 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 191330 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 136230 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 85820 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 56420 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 62860 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/annealing_mirrored1.ok
+++ b/src/ppl/test/annealing_mirrored1.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO PPL-0080] Mirroring pins resp_msg[0] and req_msg[0].
+[INFO PPL-0080] Mirroring pins resp_msg[1] and req_msg[1].
+[INFO PPL-0080] Mirroring pins resp_msg[2] and req_msg[2].
+[INFO PPL-0080] Mirroring pins resp_msg[3] and req_msg[3].
+[INFO PPL-0080] Mirroring pins resp_msg[4] and req_msg[4].
+[INFO PPL-0080] Mirroring pins resp_msg[5] and req_msg[5].
+[INFO PPL-0080] Mirroring pins resp_msg[6] and req_msg[6].
+[INFO PPL-0080] Mirroring pins resp_msg[7] and req_msg[7].
+[INFO PPL-0080] Mirroring pins resp_msg[8] and req_msg[8].
+[INFO PPL-0080] Mirroring pins resp_msg[9] and req_msg[9].
+[INFO PPL-0080] Mirroring pins resp_msg[10] and req_msg[10].
+Found 0 macro blocks.
+[INFO PPL-0012] I/O nets HPWL: 4774.17 um.
+No differences found.

--- a/src/ppl/test/annealing_mirrored1.tcl
+++ b/src/ppl/test/annealing_mirrored1.tcl
@@ -1,0 +1,13 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing -random
+
+set def_file [make_result_file annealing_mirrored1.def]
+
+write_def $def_file
+
+diff_file annealing_mirrored1.defok $def_file

--- a/src/ppl/test/annealing_mirrored2.defok
+++ b/src/ppl/test/annealing_mirrored2.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 120650 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 145180 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 149660 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 104690 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 172900 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 148390 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 44650 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 25650 201530 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 156750 201530 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 82740 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 64410 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 141550 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 64790 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 31730 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 127540 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 80750 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 97300 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 52250 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 110770 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 30100 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 88730 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 143500 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 34010 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165870 201530 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 113050 201530 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 26460 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176510 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 21090 201530 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176130 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 27170 201530 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 62020 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 24220 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104300 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 145180 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 149660 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 66780 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 25900 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 23940 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 134710 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26180 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 64790 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 143500 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 113050 70 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26460 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176510 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 21090 70 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176130 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 27170 70 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 62020 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 177660 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 54740 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/annealing_mirrored2.ok
+++ b/src/ppl/test/annealing_mirrored2.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO PPL-0080] Mirroring pins resp_msg[0] and req_msg[0].
+[INFO PPL-0080] Mirroring pins resp_msg[1] and req_msg[1].
+[INFO PPL-0080] Mirroring pins resp_msg[2] and req_msg[2].
+[INFO PPL-0080] Mirroring pins resp_msg[3] and req_msg[3].
+[INFO PPL-0080] Mirroring pins resp_msg[4] and req_msg[4].
+[INFO PPL-0080] Mirroring pins resp_msg[5] and req_msg[5].
+[INFO PPL-0080] Mirroring pins resp_msg[6] and req_msg[6].
+[INFO PPL-0080] Mirroring pins resp_msg[7] and req_msg[7].
+[INFO PPL-0080] Mirroring pins resp_msg[8] and req_msg[8].
+[INFO PPL-0080] Mirroring pins resp_msg[9] and req_msg[9].
+[INFO PPL-0080] Mirroring pins resp_msg[10] and req_msg[10].
+Found 0 macro blocks.
+[INFO PPL-0012] I/O nets HPWL: 1351.61 um.
+No differences found.

--- a/src/ppl/test/annealing_mirrored2.tcl
+++ b/src/ppl/test/annealing_mirrored2.tcl
@@ -1,0 +1,13 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing
+
+set def_file [make_result_file annealing_mirrored2.def]
+
+write_def $def_file
+
+diff_file annealing_mirrored2.defok $def_file

--- a/src/ppl/test/annealing_mirrored3.defok
+++ b/src/ppl/test/annealing_mirrored3.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 120650 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 155990 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 108870 70 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 105450 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 172900 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 148390 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 45410 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 25650 201530 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 156370 201530 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 82740 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 64410 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 138510 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 43890 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 29450 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 127540 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 80750 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 97300 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 51490 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 110770 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 29540 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 88730 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 58330 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 34390 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165870 201530 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 41230 70 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 32490 70 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176130 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 21090 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 175750 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 27930 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 96710 70 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 24220 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104860 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 155990 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 108870 201530 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 68460 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 25900 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 23940 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 134710 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26180 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 43890 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 58330 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 41230 201530 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 32490 201530 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 176130 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 21090 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 175750 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 27930 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 96710 201530 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 177660 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 55020 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/annealing_mirrored3.ok
+++ b/src/ppl/test/annealing_mirrored3.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO PPL-0080] Mirroring pins resp_msg[0] and req_msg[0].
+[INFO PPL-0080] Mirroring pins resp_msg[1] and req_msg[1].
+[INFO PPL-0080] Mirroring pins resp_msg[2] and req_msg[2].
+[INFO PPL-0080] Mirroring pins resp_msg[3] and req_msg[3].
+[INFO PPL-0080] Mirroring pins resp_msg[4] and req_msg[4].
+[INFO PPL-0080] Mirroring pins resp_msg[5] and req_msg[5].
+[INFO PPL-0080] Mirroring pins resp_msg[6] and req_msg[6].
+[INFO PPL-0080] Mirroring pins resp_msg[7] and req_msg[7].
+[INFO PPL-0080] Mirroring pins resp_msg[8] and req_msg[8].
+[INFO PPL-0080] Mirroring pins resp_msg[9] and req_msg[9].
+[INFO PPL-0080] Mirroring pins resp_msg[10] and req_msg[10].
+Found 0 macro blocks.
+[INFO PPL-0012] I/O nets HPWL: 2188.98 um.
+No differences found.

--- a/src/ppl/test/annealing_mirrored3.tcl
+++ b/src/ppl/test/annealing_mirrored3.tcl
@@ -1,0 +1,14 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+set_io_pin_constraint -region bottom:* -pin_names {req_msg[0] req_msg[1] req_msg[2] req_msg[3] req_msg[4] req_msg[5] req_msg[6] req_msg[7] req_msg[8] req_msg[9] req_msg[10]}
+set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing
+
+set def_file [make_result_file annealing_mirrored3.def]
+
+write_def $def_file
+
+diff_file annealing_mirrored3.defok $def_file

--- a/src/ppl/test/annealing_mirrored4.defok
+++ b/src/ppl/test/annealing_mirrored4.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 16530 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75050 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78850 70 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 85820 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104860 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 37100 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 138180 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 159790 70 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 69730 70 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 32900 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 65380 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 9690 70 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75430 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 142310 201530 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 113430 70 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 56700 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48450 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 109620 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 73220 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 177270 201530 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 193610 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 195580 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 180180 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75810 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 102620 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 113260 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76190 70 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76570 70 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76950 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 77330 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 77710 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78090 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78470 70 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 136230 70 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 191330 70 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 182210 70 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75050 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78850 201530 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 46900 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 45790 70 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 65170 201530 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 13490 201530 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 111020 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75430 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 75810 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76190 201530 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76570 201530 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76950 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 77330 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 77710 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78090 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 78470 201530 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48830 70 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/annealing_mirrored4.ok
+++ b/src/ppl/test/annealing_mirrored4.ok
@@ -1,0 +1,24 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO PPL-0044] Pin group: [ req_msg[0] req_msg[1] req_msg[2] req_msg[3] req_msg[4] req_msg[5] req_msg[6] req_msg[7] req_msg[8] req_msg[9] req_msg[10] ]
+[INFO PPL-0080] Mirroring pins resp_msg[0] and req_msg[0].
+[INFO PPL-0080] Mirroring pins resp_msg[1] and req_msg[1].
+[INFO PPL-0080] Mirroring pins resp_msg[2] and req_msg[2].
+[INFO PPL-0080] Mirroring pins resp_msg[3] and req_msg[3].
+[INFO PPL-0080] Mirroring pins resp_msg[4] and req_msg[4].
+[INFO PPL-0080] Mirroring pins resp_msg[5] and req_msg[5].
+[INFO PPL-0080] Mirroring pins resp_msg[6] and req_msg[6].
+[INFO PPL-0080] Mirroring pins resp_msg[7] and req_msg[7].
+[INFO PPL-0080] Mirroring pins resp_msg[8] and req_msg[8].
+[INFO PPL-0080] Mirroring pins resp_msg[9] and req_msg[9].
+[INFO PPL-0080] Mirroring pins resp_msg[10] and req_msg[10].
+Found 0 macro blocks.
+[INFO PPL-0012] I/O nets HPWL: 5091.84 um.
+No differences found.

--- a/src/ppl/test/annealing_mirrored4.tcl
+++ b/src/ppl/test/annealing_mirrored4.tcl
@@ -1,0 +1,14 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+set_io_pin_constraint -region bottom:* -group -order -pin_names {req_msg[0] req_msg[1] req_msg[2] req_msg[3] req_msg[4] req_msg[5] req_msg[6] req_msg[7] req_msg[8] req_msg[9] req_msg[10]}
+set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing -random
+
+set def_file [make_result_file annealing_mirrored4.def]
+
+write_def $def_file
+
+diff_file annealing_mirrored4.defok $def_file

--- a/src/ppl/test/annealing_mirrored5.defok
+++ b/src/ppl/test/annealing_mirrored5.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 76950 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 46930 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 50730 70 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 103550 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 172900 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 148390 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 44650 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 25650 201530 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 156750 201530 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 82460 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 64410 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 138510 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 47310 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 31730 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 126700 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 170430 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 80750 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 97300 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 51490 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 59470 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 110770 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 30100 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 90250 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 47690 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 34390 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 165490 201530 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48070 70 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48450 70 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48830 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49210 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49590 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49970 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 50350 70 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 23660 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 171190 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 104860 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 46930 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 50730 201530 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 68460 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 25900 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 23100 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 134710 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 26180 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 47310 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 47690 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48070 201530 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48450 201530 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 48830 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49210 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49590 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 49970 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 50350 201530 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 70 177660 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 200190 54740 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/annealing_mirrored5.ok
+++ b/src/ppl/test/annealing_mirrored5.ok
@@ -1,0 +1,24 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 88 components and 422 component-terminals.
+[INFO ODB-0133]     Created 54 nets and 88 connections.
+[INFO PPL-0044] Pin group: [ req_msg[0] req_msg[1] req_msg[2] req_msg[3] req_msg[4] req_msg[5] req_msg[6] req_msg[7] req_msg[8] req_msg[9] req_msg[10] ]
+[INFO PPL-0080] Mirroring pins resp_msg[0] and req_msg[0].
+[INFO PPL-0080] Mirroring pins resp_msg[1] and req_msg[1].
+[INFO PPL-0080] Mirroring pins resp_msg[2] and req_msg[2].
+[INFO PPL-0080] Mirroring pins resp_msg[3] and req_msg[3].
+[INFO PPL-0080] Mirroring pins resp_msg[4] and req_msg[4].
+[INFO PPL-0080] Mirroring pins resp_msg[5] and req_msg[5].
+[INFO PPL-0080] Mirroring pins resp_msg[6] and req_msg[6].
+[INFO PPL-0080] Mirroring pins resp_msg[7] and req_msg[7].
+[INFO PPL-0080] Mirroring pins resp_msg[8] and req_msg[8].
+[INFO PPL-0080] Mirroring pins resp_msg[9] and req_msg[9].
+[INFO PPL-0080] Mirroring pins resp_msg[10] and req_msg[10].
+Found 0 macro blocks.
+[INFO PPL-0012] I/O nets HPWL: 2488.56 um.
+No differences found.

--- a/src/ppl/test/annealing_mirrored5.tcl
+++ b/src/ppl/test/annealing_mirrored5.tcl
@@ -1,0 +1,14 @@
+# gcd_nangate45 IO placement
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def gcd.def
+
+set_io_pin_constraint -region bottom:* -group -order -pin_names {req_msg[0] req_msg[1] req_msg[2] req_msg[3] req_msg[4] req_msg[5] req_msg[6] req_msg[7] req_msg[8] req_msg[9] req_msg[10]}
+set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
+place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing
+
+set def_file [make_result_file annealing_mirrored5.def]
+
+write_def $def_file
+
+diff_file annealing_mirrored5.defok $def_file

--- a/src/ppl/test/regression_tests.tcl
+++ b/src/ppl/test/regression_tests.tcl
@@ -37,6 +37,8 @@ record_tests {
   annealing_mirrored1
   annealing_mirrored2
   annealing_mirrored3
+  annealing_mirrored4
+  annealing_mirrored5
   blocked_region
   cells_not_placed
   exclude1

--- a/src/ppl/test/regression_tests.tcl
+++ b/src/ppl/test/regression_tests.tcl
@@ -34,6 +34,9 @@ record_tests {
   annealing_constraint8
   annealing_large_groups1
   annealing_large_groups2
+  annealing_mirrored1
+  annealing_mirrored2
+  annealing_mirrored3
   blocked_region
   cells_not_placed
   exclude1


### PR DESCRIPTION
For now, mirrored pins and groups are only moved inside the movePinToFreeSlot function.

Swapping mirrored pins has a level of complexity similar to swapping pin groups, and they will be added to the swap in a future PR.