### PR TITLE
rsz: Fixing bug when used repair_timing -recover_power

### DIFF
--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -191,8 +191,9 @@ RecoverPower::recoverPower()
     }
     // Leave the parasitics up to date.
     resizer_->updateParasitics();
-    resizer_->incrementalParasiticsEnd();
   }
+
+  resizer_->incrementalParasiticsEnd();
 
   // TODO: Add the appropriate metric here
   // logger_->metric("design__instance__count__setup_buffer", inserted_buffer_count_);


### PR DESCRIPTION
At the end of the first iteration of the `RecoverPower::recoverPower()` function, the function `Resizer::incrementalParasiticsEnd()` is called, which causes the elimination of the variable `incr_groute_`, which is still used but when it is eliminated, it will cause the error #3659
To correct the error, I moved the `Resizer::incrementalParasiticsEnd()` function to the end of all iterations.