### PR TITLE
Handling overlaps differently

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -47,6 +47,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>  // pair
 #include <vector>
@@ -221,7 +222,7 @@ class Opendp
   int padLeft(dbInst* inst) const;
   // Return error count.
   void processViolationsPtree(boost::property_tree::ptree& entry,
-                              const std::vector<Cell*>& failures) const;
+                              const std::vector<Cell*>& failures, std::string violation_type = "") const;
   void checkPlacement(bool verbose,
                       bool disallow_one_site_gaps = false,
                       string report_file_name = "report.json");

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -223,7 +223,7 @@ class Opendp
   // Return error count.
   void processViolationsPtree(boost::property_tree::ptree& entry,
                               const std::vector<Cell*>& failures,
-                              std::string violation_type = "") const;
+                              const std::string& violation_type = "") const;
   void checkPlacement(bool verbose,
                       bool disallow_one_site_gaps = false,
                       string report_file_name = "report.json");

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -222,7 +222,8 @@ class Opendp
   int padLeft(dbInst* inst) const;
   // Return error count.
   void processViolationsPtree(boost::property_tree::ptree& entry,
-                              const std::vector<Cell*>& failures, std::string violation_type = "") const;
+                              const std::vector<Cell*>& failures,
+                              std::string violation_type = "") const;
   void checkPlacement(bool verbose,
                       bool disallow_one_site_gaps = false,
                       string report_file_name = "report.json");

--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -131,7 +131,7 @@ void Opendp::checkPlacement(bool verbose,
 
 void Opendp::processViolationsPtree(boost::property_tree::ptree& entry,
                                     const std::vector<Cell*>& failures,
-                                    string violation_type) const
+                                    const string& violation_type) const
 {
   using boost::property_tree::ptree;
   ptree violations;
@@ -152,12 +152,22 @@ void Opendp::processViolationsPtree(boost::property_tree::ptree& entry,
                        "Could not find overlapping cell for cell {}",
                        failure->name());
       }
-      xMin = std::min(xMin, (o_cell->x_ + core.xMin()) / dbUnits);
-      yMin = std::min(yMin, (o_cell->y_ + core.yMin()) / dbUnits);
-      xMax = std::max(xMax,
-                      (o_cell->x_ + o_cell->width_ + core.xMin()) / dbUnits);
-      yMax = std::max(yMax,
-                      (o_cell->y_ + o_cell->height_ + core.yMin()) / dbUnits);
+      odb::Rect o_rect(o_cell->x_,
+                       o_cell->y_,
+                       o_cell->x_ + o_cell->width_,
+                       o_cell->y_ + o_cell->height_);
+      odb::Rect f_rect(failure->x_,
+                       failure->y_,
+                       failure->x_ + failure->width_,
+                       failure->y_ + failure->height_);
+
+      odb::Rect overlap_rect;
+      o_rect.intersection(f_rect, overlap_rect);
+
+      xMin = (overlap_rect.xMin() + core.xMin()) / dbUnits;
+      yMin = (overlap_rect.yMin() + core.yMin()) / dbUnits;
+      xMax = (overlap_rect.xMax() + core.xMin()) / dbUnits;
+      yMax = (overlap_rect.yMax() + core.yMin()) / dbUnits;
 
       ptree overlap_source;
       overlap_source.put("type", "inst");

--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -128,22 +128,48 @@ void Opendp::checkPlacement(bool verbose,
     logger_->error(DPL, 33, "detailed placement checks failed.");
   }
 }
+
 void Opendp::processViolationsPtree(boost::property_tree::ptree& entry,
-                                    const std::vector<Cell*>& failures) const
+                                    const std::vector<Cell*>& failures,
+                                    string violation_type) const
 {
   using boost::property_tree::ptree;
   ptree violations;
   double dbUnits = block_->getDataBase()->getTech()->getDbUnitsPerMicron();
   const Rect core = getCore();
   for (auto failure : failures) {
-    ptree shape, violation, shapes, source, sources;
+    ptree violation, shapes, source, sources, shape;
+    double xMin = (failure->x_ + core.xMin()) / dbUnits;
+    double yMin = (failure->y_ + core.yMin()) / dbUnits;
+    double xMax = (failure->x_ + failure->width_ + core.xMin()) / dbUnits;
+    double yMax = (failure->y_ + failure->height_ + core.yMin()) / dbUnits;
 
-    shape.put("x", (failure->x_ + core.xMin()) / dbUnits);
-    shape.put("y", (failure->y_ + core.yMin()) / dbUnits);
+    if (violation_type == "overlap") {
+      const Cell* o_cell = checkOverlap(*failure);
+      if (!o_cell) {
+        logger_->error(DPL,
+                       48,
+                       "Could not find overlapping cell for cell {}",
+                       failure->name());
+      }
+      xMin = std::min(xMin, (o_cell->x_ + core.xMin()) / dbUnits);
+      yMin = std::min(yMin, (o_cell->y_ + core.yMin()) / dbUnits);
+      xMax = std::max(xMax,
+                      (o_cell->x_ + o_cell->width_ + core.xMin()) / dbUnits);
+      yMax = std::max(yMax,
+                      (o_cell->y_ + o_cell->height_ + core.yMin()) / dbUnits);
+
+      ptree overlap_source;
+      overlap_source.put("type", "inst");
+      overlap_source.put("name", o_cell->name());
+      sources.push_back(std::make_pair("", overlap_source));
+    }
+    shape.put("x", xMin);
+    shape.put("y", yMin);
     shapes.push_back(std::make_pair("", shape));
     shape.clear();
-    shape.put("x", (failure->x_ + failure->width_ + core.xMin()) / dbUnits);
-    shape.put("y", (failure->y_ + failure->height_ + core.yMin()) / dbUnits);
+    shape.put("x", xMax);
+    shape.put("y", yMax);
     shapes.push_back(std::make_pair("", shape));
 
     source.put("type", "inst");
@@ -194,7 +220,7 @@ void Opendp::writeJsonReport(const string& filename,
       ptree entry;
       entry.put("name", "Overlap_failures");
       entry.put("description", "Cells that are overlapping with other cells.");
-      processViolationsPtree(entry, overlap_failures);
+      processViolationsPtree(entry, overlap_failures, "overlap");
       drcArray.push_back(std::make_pair("", entry));
     }
     if (!one_site_gap_failures.empty()) {

--- a/src/gui/src/drcWidget.cpp
+++ b/src/gui/src/drcWidget.cpp
@@ -794,7 +794,7 @@ void DRCWidget::loadJSONReport(const QString& filename)
       odb::dbTechLayer* layer = nullptr;
       if (!layer_str.empty()) {
         layer = tech->findLayer(layer_str.c_str());
-        if (layer == nullptr) {
+        if (layer == nullptr && layer_str != "-") {
           logger_->warn(
               utl::GUI, 79, "Unable to find tech layer: {}", layer_str);
         }


### PR DESCRIPTION
In the case of overlapping failures, the tool would draw a bounding box around both overlapping cells together. 
It will also add both cells to the sources in the JSON report.

The json would look like this:
```JSON
 {
            "name": "Overlap_failures",
            "description": "Cells that are overlapping with other cells.",
            "violations": [
                {
                    "type": "box",
                    "shape": [
                        {
                            "x": "14",
                            "y": "14"
                        },
                        {
                            "x": "14.57",
                            "y": "15.4"
                        }
                    ],
                    "sources": [
                        {
                            "type": "inst",
                            "name": "f0\/_285_"
                        },
                        {
                            "type": "inst",
                            "name": "f0\/_284_"
                        }
                    ]
                },
                {
                    "type": "box",
                    "shape": [
                        {
                            "x": "14",
                            "y": "14"
                        },
                        {
                            "x": "14.57",
                            "y": "15.4"
                        }
                    ],
                    "sources": [
                        {
                            "type": "inst",
                            "name": "f0\/_285_"
                        },
                        {
                            "type": "inst",
                            "name": "f0\/_283_"
                        }
                    ]
                }
     ]
}
```