### PR TITLE
gui: pin selecting and drawing 

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -443,16 +443,17 @@ DisplayControls::DisplayControls(QWidget* parent)
   iterm_label_color_ = Qt::yellow;
 
   auto instance_shape
-      = makeParentItem(misc_.instances, "Instances", misc, Qt::Checked);
+      = makeParentItem(misc_.instances, "Instances", misc, Qt::Checked, true);
   makeLeafItem(instance_shapes_.names,
                "Names",
                instance_shape,
                Qt::Checked,
                false,
                instance_name_color_);
-  makeLeafItem(instance_shapes_.pins, "Pins", instance_shape, Qt::Checked);
+  makeLeafItem(
+      instance_shapes_.pins, "Pins", instance_shape, Qt::Checked, true);
   makeLeafItem(instance_shapes_.iterm_labels,
-               "Iterm Labels",
+               "Pin labels",
                instance_shape,
                Qt::Unchecked,
                false,
@@ -466,7 +467,7 @@ DisplayControls::DisplayControls(QWidget* parent)
   });
   setNameItemDoubleClickAction(instance_shapes_.iterm_labels, [this]() {
     iterm_label_font_ = QFontDialog::getFont(
-        nullptr, iterm_label_font_, this, "Instance ITerm name font");
+        nullptr, iterm_label_font_, this, "Instance pin name font");
   });
 
   region_color_ = QColor(0x70, 0x70, 0x70, 0x70);  // semi-transparent mid-gray
@@ -1534,7 +1535,12 @@ bool DisplayControls::areInstancePinsVisible()
   return isModelRowVisible(&instance_shapes_.pins);
 }
 
-bool DisplayControls::areITermsVisible()
+bool DisplayControls::areInstancePinsSelectable()
+{
+  return isModelRowSelectable(&instance_shapes_.pins);
+}
+
+bool DisplayControls::areInstancePinNamesVisible()
 {
   return isModelRowVisible(&instance_shapes_.iterm_labels);
 }

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -214,7 +214,8 @@ class DisplayControls : public QDockWidget,
   bool isInstanceSelectable(odb::dbInst* inst) override;
   bool areInstanceNamesVisible() override;
   bool areInstancePinsVisible() override;
-  bool areITermsVisible() override;
+  bool areInstancePinsSelectable() override;
+  bool areInstancePinNamesVisible() override;
   bool areInstanceBlockagesVisible() override;
   bool areFillsVisible() override;
   bool areBlockagesVisible() override;

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1582,6 +1582,7 @@ void MainWindow::openDesign()
 
   try {
     if (file.endsWith(".odb", Qt::CaseInsensitive)) {
+      open_->setEnabled(false);
       ord::OpenRoad::openRoad()->readDb(file.toStdString().c_str());
       logger_->warn(utl::GUI,
                     77,
@@ -1592,7 +1593,8 @@ void MainWindow::openDesign()
       logger_->error(utl::GUI, 76, "Unknown filetype: {}", file.toStdString());
     }
   } catch (const std::exception&) {
-    // do nothing
+    // restore option
+    open_->setEnabled(true);
   }
 }
 

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -69,7 +69,8 @@ class Options
   virtual bool isInstanceSelectable(odb::dbInst* inst) = 0;
   virtual bool areInstanceNamesVisible() = 0;
   virtual bool areInstancePinsVisible() = 0;
-  virtual bool areITermsVisible() = 0;
+  virtual bool areInstancePinsSelectable() = 0;
+  virtual bool areInstancePinNamesVisible() = 0;
   virtual bool areInstanceBlockagesVisible() = 0;
   virtual bool areFillsVisible() = 0;
   virtual bool areBlockagesVisible() = 0;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -611,8 +611,7 @@ void RenderThread::drawITermLabels(QPainter* painter,
           if (layer == nullptr) {
             continue;
           }
-          if (viewer_->options_->isVisible(layer)
-              && viewer_->options_->isSelectable(layer)) {
+          if (viewer_->options_->isVisible(layer)) {
             Rect pin_rect = geom->getBox();
             xform.apply(pin_rect);
             const QString name = inst_iterm->getMTerm()->getConstName();

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -584,7 +584,8 @@ void RenderThread::drawInstanceNames(QPainter* painter,
 void RenderThread::drawITermLabels(QPainter* painter,
                                    const std::vector<odb::dbInst*>& insts)
 {
-  if (!viewer_->options_->areITermsVisible()) {
+  if (!viewer_->options_->areInstancePinsVisible()
+      || !viewer_->options_->areInstancePinNamesVisible()) {
     return;
   }
 

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -105,7 +105,7 @@ class RenderThread : public QThread
                          const std::vector<odb::dbInst*>& insts);
   void drawITermLabels(QPainter* painter,
                        const std::vector<odb::dbInst*>& insts);
-  void drawTextInBBox(const QColor& text_color,
+  bool drawTextInBBox(const QColor& text_color,
                       const QFont& text_font,
                       odb::Rect bbox,
                       QString name,


### PR DESCRIPTION
Adds:
- pin selection control for instances

Changes:
- only allow selection of pins when visible and when layers are visible for that pin
- draw the pin label in the first mpin box that it will fit it otherwise pins are left floating off the metal shape.