### PR TITLE
Revert "grt: generalize layer name regex in layer range parsing"

### DIFF
--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -42,7 +42,7 @@ proc set_global_routing_layer_adjustment { args } {
     if {$layer == "*"} {
       sta::check_positive_float "adjustment" $adj
       grt::set_capacity_adjustment $adj
-    } elseif [regexp -all {([^-]+)-([^_]+)} $layer] {
+    } elseif [regexp -all {([a-zA-Z0-9]+)-([a-zA-Z0-9]+)} $layer] {
       lassign [grt::parse_layer_range "set_global_routing_layer_adjustment" $layer] first_layer last_layer
       for {set l $first_layer} {$l <= $last_layer} {incr l} {
         grt::check_routing_layer $l
@@ -491,7 +491,7 @@ proc parse_layer_name { layer_name } {
 }
 
 proc parse_layer_range { cmd layer_range } {
-  if [regexp -all {([^-]+)-([^-]+)} $layer_range - min_layer_name max_layer_name] {
+  if [regexp -all {([a-zA-Z0-9]+)-([a-zA-Z0-9]+)} $layer_range - min_layer_name max_layer_name] {
     set min_layer [parse_layer_name $min_layer_name]
     set max_layer [parse_layer_name $max_layer_name]
 


### PR DESCRIPTION
This reverts commit 7f449467ade1eb06af581e0ab683cc07319a5a60, which breaks support for gf12.