### PR TITLE
gui: add multithreaded rendering

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -4,6 +4,7 @@ option(BUILD_GUI "Build the GUI" ON)
 # If Qt is not installed there will not be cmake
 # support for the package so this needs to be "quiet".
 find_package(Qt5 QUIET COMPONENTS Core Widgets OPTIONAL_COMPONENTS Charts)
+find_package(Qt5 COMPONENTS Concurrent REQUIRED)
 
 include("openroad")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -85,6 +86,7 @@ if (Qt5_FOUND AND BUILD_GUI)
     PRIVATE
       Qt5::Core
       Qt5::Widgets
+      Qt5::Concurrent
       ${CHARTS_LIB}
       utl
       Boost::boost


### PR DESCRIPTION
For discussion... I can't see a difference in performance in the case I tried. Perhaps searching for rectangles dominates?

My theory, which didn't seem to hold up, was:

KISS multithreaded rendering: one subrectangle per thread.

This means that a search for objects to draw into each subrectangle is done once per thread, so that might be more wasteful than searching for rectangles once and then rendering one layer per thread.

However, in terms of the rendering time this might not matter, because no rendering starts until the search for objects to draw within a rectangle as completed.