### PR TITLE
gui: render instance text centered, easier to read

### DIFF
--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -573,7 +573,9 @@ void RenderThread::drawInstanceNames(QPainter* painter,
 
     Rect instance_box = inst->getBBox()->getBox();
     QString name = inst->getName().c_str();
-    drawTextInBBox(text_color, text_font, instance_box, name, painter);
+    auto master = inst->getMaster();
+    auto center = master->isBlock() || master->isPad();
+    drawTextInBBox(text_color, text_font, instance_box, name, painter, center);
   }
   painter->setFont(initial_font);
 }
@@ -616,7 +618,7 @@ void RenderThread::drawITermLabels(QPainter* painter,
             xform.apply(pin_rect);
             const QString name = inst_iterm->getMTerm()->getConstName();
             drawn = drawTextInBBox(
-                text_color, text_font, pin_rect, name, painter);
+                text_color, text_font, pin_rect, name, painter, false);
           }
           if (drawn) {
             // Only draw on the first box
@@ -637,7 +639,8 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
                                   const QFont& text_font,
                                   Rect bbox,
                                   QString name,
-                                  QPainter* painter)
+                                  QPainter* painter,
+                                  bool center)
 {
   const QFontMetricsF font_metrics(text_font);
 
@@ -703,13 +706,17 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
     painter->translate(-text_bounding_box.width(), 0);
     // account for descent of font
     painter->translate(-font_metrics.descent(), 0);
-    painter->translate(-xOffset, -yOffset);
+    if (center) {
+      painter->translate(-xOffset, -yOffset);
+    }
   } else {
     // account for descent of font
     auto xOffset = (bbox_in_px.width() - text_bounding_box.width()) / 2;
     auto yOffset = (bbox_in_px.height() - text_bounding_box.height()) / 2;
     painter->translate(font_metrics.descent(), 0);
-    painter->translate(xOffset, -yOffset);
+    if (center) {
+      painter->translate(xOffset, -yOffset);
+    }
   }
   painter->drawText(0, 0, name);
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -697,13 +697,19 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
   painter->scale(scale_adjust, -scale_adjust);
   if (do_rotate) {
     text_bounding_box = font_metrics.boundingRect(name);
+    auto xOffset = (bbox_in_px.height() - text_bounding_box.width()) / 2;
+    auto yOffset = (bbox_in_px.width() - text_bounding_box.height()) / 2;
     painter->rotate(90);
     painter->translate(-text_bounding_box.width(), 0);
     // account for descent of font
     painter->translate(-font_metrics.descent(), 0);
+    painter->translate(-xOffset, -yOffset);
   } else {
     // account for descent of font
+    auto xOffset = (bbox_in_px.width() - text_bounding_box.width()) / 2;
+    auto yOffset = (bbox_in_px.height() - text_bounding_box.height()) / 2;
     painter->translate(font_metrics.descent(), 0);
+    painter->translate(xOffset, -yOffset);
   }
   painter->drawText(0, 0, name);
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -700,21 +700,24 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
   painter->scale(scale_adjust, -scale_adjust);
   if (do_rotate) {
     text_bounding_box = font_metrics.boundingRect(name);
-    auto xOffset = (bbox_in_px.height() - text_bounding_box.width()) / 2;
-    auto yOffset = (bbox_in_px.width() - text_bounding_box.height()) / 2;
     painter->rotate(90);
     painter->translate(-text_bounding_box.width(), 0);
     // account for descent of font
     painter->translate(-font_metrics.descent(), 0);
     if (center) {
+      const auto xOffset
+          = (bbox_in_px.height() - text_bounding_box.width()) / 2;
+      const auto yOffset
+          = (bbox_in_px.width() - text_bounding_box.height()) / 2;
       painter->translate(-xOffset, -yOffset);
     }
   } else {
     // account for descent of font
-    auto xOffset = (bbox_in_px.width() - text_bounding_box.width()) / 2;
-    auto yOffset = (bbox_in_px.height() - text_bounding_box.height()) / 2;
     painter->translate(font_metrics.descent(), 0);
     if (center) {
+      const auto xOffset = (bbox_in_px.width() - text_bounding_box.width()) / 2;
+      const auto yOffset
+          = (bbox_in_px.height() - text_bounding_box.height()) / 2;
       painter->translate(xOffset, -yOffset);
     }
   }

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -109,7 +109,8 @@ class RenderThread : public QThread
                       const QFont& text_font,
                       odb::Rect bbox,
                       QString name,
-                      QPainter* painter);
+                      QPainter* painter,
+                      bool center);
 
   void drawBlockages(QPainter* painter,
                      odb::dbBlock* block,


### PR DESCRIPTION
Before:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/baf137a9-612d-449a-be2e-222b543b242b)

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/2039f33f-75d1-44bd-80b3-e190ebb66826)

After:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/7774ca77-64fa-4d82-a000-dffd866c4435)

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/28db7a3d-7dda-449f-8b5f-bc9985416e8c)
