### PR TITLE
gui: make same_clocktree_image a regular tcl command

### DIFF
--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -76,13 +76,19 @@ Options description:
 ### Save screenshot of clock trees
 
 ```
-gui::save_clocktree_image filename
-                          clock_name
+save_clocktree_image filename
+                     -clock clock_name
+                     [-width width]
+                     [-height height]
+                     [-corner corner]
 ```
 
 Options description:
 - ``filename`` path to save the image to.
-- ``clock_name`` name of the clock to save the clocktree for.
+- ``-clock`` name of the clock to save the clocktree for.
+- ``-corner`` name of the timing corner to save the clocktree for, default to the first corner defined.
+- ``-height`` height of the image in pixels, defaults to the height of the GUI widget.
+- ``-width`` width of the image in pixels, defualts to the width of the GUI widget.
 
 ### Selecting objects
 

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -614,7 +614,10 @@ class Gui
 
   // Save clock tree view
   void saveClockTreeImage(const std::string& clock_name,
-                          const std::string& filename);
+                          const std::string& filename,
+                          const std::string& corner = "",
+                          int width_px = 0,
+                          int height_px = 0);
 
   // modify display controls
   void setDisplayControlsVisible(const std::string& name, bool value);

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -1408,8 +1408,8 @@ void ClockWidget::postReadLiberty()
 void ClockWidget::saveImage(const std::string& clock_name,
                             const std::string& path,
                             const std::string& corner,
-                            int width_px,
-                            int height_px)
+                            const std::optional<int>& width_px,
+                            const std::optional<int>& height_px)
 {
   const bool visible = isVisible();
   if (!visible) {
@@ -1438,13 +1438,14 @@ void ClockWidget::saveImage(const std::string& clock_name,
 
       ClockTreeView print_view(
           view->getClockTree(), stagui_.get(), logger_, this);
-      if (width_px == 0) {
-        width_px = view->width();
+      QSize view_size = view->size();
+      if (width_px.has_value()) {
+        view_size.setWidth(width_px.value());
       }
-      if (height_px == 0) {
-        height_px = view->height();
+      if (height_px.has_value()) {
+        view_size.setHeight(height_px.value());
       }
-      print_view.resize(width_px, height_px);
+      print_view.resize(view_size);
       // Ensure the new view is sized correctly by Qt by processing the event
       // so fit will work
       QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -712,7 +712,7 @@ void ClockTreeScene::setRendererState(RendererState state)
 
 ////////////////
 
-ClockTreeView::ClockTreeView(ClockTree* tree,
+ClockTreeView::ClockTreeView(std::shared_ptr<ClockTree> tree,
                              const STAGuiInterface* sta,
                              utl::Logger* logger,
                              QWidget* parent)
@@ -1253,6 +1253,7 @@ void ClockTreeView::save(const QString& path)
     render_rect = scene_->sceneRect().toRect();
     render_rect.translate(-render_rect.left(), -render_rect.top());
   }
+
   show_mouse_time_tick_ = false;
   Utils::renderImage(save_path,
                      viewport(),
@@ -1281,6 +1282,7 @@ ClockWidget::ClockWidget(QWidget* parent)
       logger_(nullptr),
       block_(nullptr),
       sta_(nullptr),
+      stagui_(nullptr),
       update_button_(new QPushButton("Update", this)),
       corner_box_(new QComboBox(this)),
       clocks_tab_(new QTabWidget(this))
@@ -1321,6 +1323,10 @@ void ClockWidget::setSTA(sta::dbSta* sta)
 {
   sta_ = sta;
   if (sta_ != nullptr) {
+    stagui_ = std::make_unique<STAGuiInterface>(sta_);
+    stagui_->setMaxPathCount(1);
+    stagui_->setIncludeUnconstrainedPaths(false);
+
     sta_->getDbNetwork()->addObserver(this);
     postReadLiberty();
   }
@@ -1337,23 +1343,28 @@ void ClockWidget::setBlock(odb::dbBlock* block)
   block_ = block;
 }
 
-void ClockWidget::populate()
+void ClockWidget::populate(sta::Corner* corner)
 {
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
   clocks_tab_->clear();
   views_.clear();
 
-  STAGuiInterface stagui(sta_);
-  stagui.setMaxPathCount(1);
-  stagui.setIncludeUnconstrainedPaths(false);
-  stagui.setCorner(corner_box_->currentData().value<sta::Corner*>());
+  if (corner == nullptr) {
+    corner = corner_box_->currentData().value<sta::Corner*>();
+  } else {
+    corner_box_->setCurrentText(corner->name());
+  }
+  stagui_->setCorner(corner);
 
-  for (auto& tree : stagui.getClockTrees()) {
+  for (auto& tree : stagui_->getClockTrees()) {
     if (!tree->getNet()) {  // skip virtual clocks
       continue;
     }
-    auto* view = new ClockTreeView(tree.release(), &stagui, logger_, this);
+    auto* view = new ClockTreeView(std::shared_ptr<ClockTree>(tree.release()),
+                                   stagui_.get(),
+                                   logger_,
+                                   this);
     views_.emplace_back(view);
     clocks_tab_->addTab(view, view->getClockName());
     clocks_tab_->setCurrentWidget(view);
@@ -1395,23 +1406,50 @@ void ClockWidget::postReadLiberty()
 }
 
 void ClockWidget::saveImage(const std::string& clock_name,
-                            const std::string& path)
+                            const std::string& path,
+                            const std::string& corner,
+                            int width_px,
+                            int height_px)
 {
   const bool visible = isVisible();
   if (!visible) {
     setVisible(true);
   }
 
-  if (views_.empty()) {
-    populate();
+  bool populate_views = views_.empty();
+  sta::Corner* sta_corner = nullptr;
+  if (!corner.empty() && corner != corner_box_->currentText().toStdString()) {
+    populate_views = true;
+    const int idx = corner_box_->findText(QString::fromStdString(corner));
+    if (idx == -1) {
+      logger_->error(utl::GUI, 89, "Unable to find \"{}\" corner", corner);
+    }
+    sta_corner = corner_box_->itemData(idx).value<sta::Corner*>();
+  }
+
+  if (populate_views) {
+    populate(sta_corner);
   }
 
   bool found = false;
-  for (const auto& view : views_) {
+  for (auto& view : views_) {
     if (view->getClockName() == clock_name) {
       found = true;
-      view->fit();
-      view->save(QString::fromStdString(path));
+
+      ClockTreeView print_view(
+          view->getClockTree(), stagui_.get(), logger_, this);
+      if (width_px == 0) {
+        width_px = view->width();
+      }
+      if (height_px == 0) {
+        height_px = view->height();
+      }
+      print_view.resize(width_px, height_px);
+      // Ensure the new view is sized correctly by Qt by processing the event
+      // so fit will work
+      QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
+      print_view.fit();
+      print_view.save(QString::fromStdString(path));
     }
   }
 

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -47,6 +47,7 @@
 #include <QSpinBox>
 #include <QTabWidget>
 #include <QToolTip>
+#include <optional>
 #include <variant>
 
 #include "gui/gui.h"
@@ -469,8 +470,8 @@ class ClockWidget : public QDockWidget, sta::dbNetworkObserver
   void saveImage(const std::string& clock_name,
                  const std::string& path,
                  const std::string& corner,
-                 int width_px,
-                 int height_px);
+                 const std::optional<int>& width_px,
+                 const std::optional<int>& height_px);
 
   virtual void postReadLiberty() override;
 

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -352,12 +352,12 @@ class ClockTreeView : public QGraphicsView
   Q_OBJECT
 
  public:
-  ClockTreeView(ClockTree* tree,
+  ClockTreeView(std::shared_ptr<ClockTree> tree,
                 const STAGuiInterface* sta,
                 utl::Logger* logger,
                 QWidget* parent = nullptr);
 
-  ClockTree* getClockTree() const { return tree_.get(); }
+  std::shared_ptr<ClockTree>& getClockTree() { return tree_; }
   const char* getClockName() const;
 
   void updateRendererState() const;
@@ -385,7 +385,7 @@ class ClockTreeView : public QGraphicsView
   void mouseMoveEvent(QMouseEvent* event) override;
 
  private:
-  std::unique_ptr<ClockTree> tree_;
+  std::shared_ptr<ClockTree> tree_;
   std::unique_ptr<ClockTreeRenderer> renderer_;
   RendererState renderer_state_;
   ClockTreeScene* scene_;
@@ -466,7 +466,11 @@ class ClockWidget : public QDockWidget, sta::dbNetworkObserver
   void setLogger(utl::Logger* logger);
   void setSTA(sta::dbSta* sta);
 
-  void saveImage(const std::string& clock_name, const std::string& path);
+  void saveImage(const std::string& clock_name,
+                 const std::string& path,
+                 const std::string& corner,
+                 int width_px,
+                 int height_px);
 
   virtual void postReadLiberty() override;
 
@@ -475,7 +479,7 @@ class ClockWidget : public QDockWidget, sta::dbNetworkObserver
 
  public slots:
   void setBlock(odb::dbBlock* block);
-  void populate();
+  void populate(sta::Corner* corner = nullptr);
 
  private slots:
   void currentClockChanged(int index);
@@ -488,6 +492,7 @@ class ClockWidget : public QDockWidget, sta::dbNetworkObserver
   utl::Logger* logger_;
   odb::dbBlock* block_;
   sta::dbSta* sta_;
+  std::unique_ptr<STAGuiInterface> stagui_;
 
   QPushButton* update_button_;
   QComboBox* corner_box_;

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -688,12 +688,16 @@ void Gui::saveImage(const std::string& filename,
 }
 
 void Gui::saveClockTreeImage(const std::string& clock_name,
-                             const std::string& filename)
+                             const std::string& filename,
+                             const std::string& corner,
+                             int width_px,
+                             int height_px)
 {
   if (!enabled()) {
     return;
   }
-  main_window->getClockViewer()->saveImage(clock_name, filename);
+  main_window->getClockViewer()->saveImage(
+      clock_name, filename, corner, width_px, height_px);
 }
 
 static QWidget* findWidget(const std::string& name)

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -696,8 +696,16 @@ void Gui::saveClockTreeImage(const std::string& clock_name,
   if (!enabled()) {
     return;
   }
+  std::optional<int> width;
+  std::optional<int> height;
+  if (width_px > 0) {
+    width = width_px;
+  }
+  if (height_px > 0) {
+    height = height_px;
+  }
   main_window->getClockViewer()->saveImage(
-      clock_name, filename, corner, width_px, height_px);
+      clock_name, filename, corner, width, height);
 }
 
 static QWidget* findWidget(const std::string& name)

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -279,13 +279,13 @@ void save_image(const char* filename, double xlo, double ylo, double xhi, double
   gui->saveImage(filename, make_rect(xlo, ylo, xhi, yhi), dbu_per_pixel, display_settings);
 }
 
-void save_clocktree_image(const char* filename, const char* clock_name)
+void save_clocktree_image(const char* filename, const char* clock_name, const char* corner = "", int width_px = 0, int height_px = 0)
 {
   if (!check_gui("save_clocktree_image")) {
     return;
   }
   auto gui = gui::Gui::get();
-  gui->saveClockTreeImage(clock_name, filename);
+  gui->saveClockTreeImage(clock_name, filename, corner, width_px, height_px);
 }
 
 void clear_rulers()

--- a/src/gui/src/gui.tcl
+++ b/src/gui/src/gui.tcl
@@ -142,6 +142,43 @@ proc save_image { args } {
   rename $options ""
 }
 
+sta::define_cmd_args "save_clocktree_image" {
+  [-width width] \
+  [-height height] \
+  [-corner corner] \
+  -clock clock \
+  path
+}
+
+proc save_clocktree_image { args } {
+  sta::parse_key_args "save_image" args \
+    keys {-clock -width -height -corner} flags {}
+
+  sta::check_argc_eq1 "save_image" $args
+  set path [lindex $args 0]
+
+  set width 0
+  if { [info exists keys(-width)] } {
+    set width $keys(-width)
+  }
+  set height 0
+  if { [info exists keys(-height)] } {
+    set height $keys(-height)
+  }
+  set corner ""
+  if { [info exists keys(-corner)] } {
+    set corner $keys(-corner)
+  }
+
+  if { [info exists keys(-clock)] } {
+    set clock $keys(-clock)
+  } else {
+    utl:error GUI 88 "-clock is required"
+  }
+
+  gui::save_clocktree_image $path $clock $corner $width $height
+}
+
 sta::define_cmd_args "select" {-type object_type \
                                [-name name_regex] \
                                [-case_insensitive] \


### PR DESCRIPTION
Adds:
- `save_clocktree_image` with options to save with width/height and specify timing corner

This allows for better control of the resulting image since before it was just using the widget sizes which could result in poor quality images.