### PR TITLE
detailed route: do not save step 0 when -drc_report_iter_step is set

### DIFF
--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -746,7 +746,7 @@ void FlexDR::searchRepair(const SearchRepairArgs& args)
     cout << flush;
   }
   end();
-  if ((DRC_RPT_ITER_STEP && iter % DRC_RPT_ITER_STEP.value() == 0)
+  if ((DRC_RPT_ITER_STEP && iter > 0 && iter % DRC_RPT_ITER_STEP.value() == 0)
       || logger_->debugCheck(DRT, "autotuner", 1)
       || logger_->debugCheck(DRT, "report", 1)) {
     router_->reportDRC(DRC_RPT_FILE + '-' + std::to_string(iter) + ".rpt",


### PR DESCRIPTION
step 0 has a very large amount of DRC violations that are not normally interesting.

A DRC report for step 0 can be gotten by setting -droute_end_iter to 0, if that is needed for debugging purposes