### PR TITLE
gui: Fixes stub initialization

### DIFF
--- a/src/gui/src/stub.cpp
+++ b/src/gui/src/stub.cpp
@@ -67,6 +67,9 @@ Gui::Gui()
 
 Gui* gui::Gui::get()
 {
+  if (singleton_ == nullptr) {
+    singleton_ = new Gui();
+  }
   return singleton_;
 }
 


### PR DESCRIPTION
See discussion https://github.com/The-OpenROAD-Project/OpenROAD/pull/3629#issuecomment-1668739671

The root of the issue is that gui::Gui::get() returns nullptr, and some tools try to run tools against it yielding segfaults.