### PR TITLE
dpl: Fixes out of bounds in grid paint

### DIFF
--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -656,7 +656,7 @@ void Opendp::paintPixel(Cell* cell, int grid_x, int grid_y)
       ++layer_y_end;
     }
 
-    if (layer_y_end >= layer.second.row_count) {
+    if (layer_y_end > layer.second.row_count) {
       logger_->error(DPL,
                      49,
                      "Cannot paint grid index: {} because it is out of bounds. "

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -657,13 +657,13 @@ void Opendp::paintPixel(Cell* cell, int grid_x, int grid_y)
     }
 
     if (layer_y_end >= layer.second.row_count) {
-      // In some cases you can have a double height row
-      // with only a single layer row below it instead of two.
-      // In that case if you were painting a double height
-      // cell then you would go out of bounds.
-      //
-      // This check ensures that does not happen.
-      layer_y_end = layer.second.row_count;
+      logger_->error(DPL,
+                     49,
+                     "Cannot paint grid index: {} because it is out of bounds. "
+                     "Calculated (row end {}) > (rows {}). This is a bug",
+                     layer.first,
+                     layer_y_end,
+                     layer.second.row_count);
     }
 
     for (int x = layer_x; x < layer_x_end; x++) {

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -647,12 +647,23 @@ void Opendp::paintPixel(Cell* cell, int grid_x, int grid_y)
     int layer_x_end = map_coordinates(x_end, site_width, site_width);
     int layer_y = map_coordinates(grid_y, row_height, layer.first);
     int layer_y_end = map_coordinates(y_end, row_height, layer.first);
+
     if (layer_x_end == layer_x) {
       ++layer_x_end;
     }
 
     if (layer_y_end == layer_y) {
       ++layer_y_end;
+    }
+
+    if (layer_y_end >= layer.second.row_count) {
+      // In some cases you can have a double height row
+      // with only a single layer row below it instead of two.
+      // In that case if you were painting a double height
+      // cell then you would go out of bounds.
+      //
+      // This check ensures that does not happen.
+      layer_y_end = layer.second.row_count;
     }
 
     for (int x = layer_x; x < layer_x_end; x++) {


### PR DESCRIPTION
In some cases you can have a double height row
with only a single layer row below it instead of two. In that case if you were painting a double height
cell then you would go out of bounds.

This commit adds a check to ensure, that does not happen.