### PR TITLE
odb: exception handling when `ITerm` is trying to be connected with a net in the other block

### DIFF
--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -479,6 +479,13 @@ void dbITerm::connect(dbNet* net_)
                              net->_name);
   }
 
+  if (net_->getBlock() != getInst()->getBlock()) {
+    inst->getLogger()->error(utl::ODB,
+                             433,
+                             "Connecting instances on different dies into "
+                             "one net is currently not supported");
+  }
+
   if (iterm->_net != 0)
     disconnect();
 


### PR DESCRIPTION
Since the connection between instances in different blocks is not supported, I made an exception.
You can refer a [discussion](https://github.com/The-OpenROAD-Project/OpenROAD/discussions/3777) or an [issue](https://github.com/The-OpenROAD-Project/OpenROAD/issues/3781) about this.