### PR TITLE
gui: use black outline for macro labels and other centered text

### DIFF
--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -32,6 +32,8 @@
 
 #include "renderThread.h"
 
+#include <QPainterPath>
+
 #include "layoutViewer.h"
 #include "odb/dbShape.h"
 #include "odb/dbTransform.h"
@@ -692,9 +694,6 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
   }
   text_bounding_box = font_metrics.boundingRect(name);
 
-  painter->setPen(QPen(text_color, 0));
-  painter->setBrush(QBrush(text_color));
-
   const QTransform initial_xfm = painter->transform();
 
   painter->translate(bbox.xMin(), bbox.yMin());
@@ -721,7 +720,16 @@ bool RenderThread::drawTextInBBox(const QColor& text_color,
       painter->translate(xOffset, -yOffset);
     }
   }
-  painter->drawText(0, 0, name);
+  if (center) {
+    QPainterPath path;
+    path.addText(0, 0, painter->font(), name);
+    painter->strokePath(path, QPen(Qt::black, 2));  // outline
+    painter->fillPath(path, QBrush(text_color));    // fill
+  } else {
+    painter->setPen(QPen(text_color, 0));
+    painter->setBrush(QBrush(text_color));
+    painter->drawText(0, 0, name);
+  }
 
   painter->setTransform(initial_xfm);
 


### PR DESCRIPTION
makes it easier to read.  Actual colors depends on PDK and what layers are blocked, etc.

Also, the monitor matters.... black outline + color makes readability more robust against different monitors and backgrounds :crossed_fingers: 

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/62f3e950-1dc4-42e9-95cf-35513f50971a)


![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/8afc90bc-9b86-42b6-9d3a-fde9f0999189)

Non-centered text is not affected:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/88dd0208-65cf-42f9-93ac-6054fb0853bf)
