### PR TITLE
gui: fix placement and power density heatmaps

### DIFF
--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -349,7 +349,7 @@ HeatMapDataSource::MapView HeatMapDataSource::getMapView(
   const int x_high = std::min(
       static_cast<int>(
           std::ceil(bounds.xMax() / (getGridXSize() * dbu_per_micron))),
-      static_cast<int>(map_.shape()[0]) - 1);
+      static_cast<int>(map_.shape()[0]));
   const int y_low = std::max(
       static_cast<int>(
           std::floor(bounds.yMin() / (getGridYSize() * dbu_per_micron))),
@@ -357,7 +357,7 @@ HeatMapDataSource::MapView HeatMapDataSource::getMapView(
   const int y_high = std::min(
       static_cast<int>(
           std::ceil(bounds.yMax() / (getGridYSize() * dbu_per_micron))),
-      static_cast<int>(map_.shape()[1]) - 1);
+      static_cast<int>(map_.shape()[1]));
 
   return map_[boost::indices[Map::index_range(x_low, x_high)]
                             [Map::index_range(y_low, y_high)]];


### PR DESCRIPTION
Fixes #3863

When creating the mapview of the heatmap, the last column and row were not being taken into account. The situations where the wrong behavior was visible were only those in which the cells of the last column and row were smaller than the grid.

Power density was having the same problem.