### PR TITLE
gui: consider last row/column when populating routing map

### DIFF
--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -203,12 +203,14 @@ bool RoutingCongestionDataSource::populateMap()
     for (uint y_idx = 0; y_idx < gcell_congestion_data.numCols(); ++y_idx) {
       const auto& cong_data = gcell_congestion_data(x_idx, y_idx);
 
-      if (x_idx + 1 >= x_grid_sz || y_idx + 1 >= y_grid_sz) {
-        continue;
-      }
+      const int next_x = (x_idx + 1) == x_grid_sz
+                             ? getBlock()->getDieArea().xMax()
+                             : x_grid[x_idx + 1];
+      const int next_y = (y_idx + 1) == y_grid_sz
+                             ? getBlock()->getDieArea().yMax()
+                             : y_grid[y_idx + 1];
 
-      const odb::Rect gcell_rect(
-          x_grid[x_idx], y_grid[y_idx], x_grid[x_idx + 1], y_grid[y_idx + 1]);
+      const odb::Rect gcell_rect(x_grid[x_idx], y_grid[y_idx], next_x, next_y);
 
       const auto hor_capacity = cong_data.horizontal_capacity;
       const auto hor_usage = cong_data.horizontal_usage;


### PR DESCRIPTION
Fixes #3862 

The routing map last column/row were being skipped when populating the map.