### PR TITLE
rsz: add metrics and pins check to report_floating_nets

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -263,6 +263,7 @@ public:
   void designAreaIncr(float delta);
   // Caller owns return value.
   NetSeq *findFloatingNets();
+  PinSet *findFloatingPins();
   void repairTieFanout(LibertyPort *tie_port,
                        double separation, // meters
                        bool verbose);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1955,6 +1955,33 @@ Resizer::findFloatingNets()
   return floating_nets;
 }
 
+PinSet *
+Resizer::findFloatingPins()
+{
+  PinSet *floating_pins = new PinSet(network_);
+
+  // Find instances with inputs without a net
+  LeafInstanceIterator *leaf_iter = network_->leafInstanceIterator();
+  while (leaf_iter->hasNext()) {
+    const Instance *inst = leaf_iter->next();
+    InstancePinIterator *pin_iter = network_->pinIterator(inst);
+    while (pin_iter->hasNext()) {
+      Pin *pin = pin_iter->next();
+      if (network_->direction(pin) != sta::PortDirection::input()) {
+        continue;
+      }
+      if (network_->net(pin) != nullptr) {
+        continue;
+      }
+      floating_pins->insert(pin);
+    }
+    delete pin_iter;
+  }
+  delete leaf_iter;
+
+  return floating_pins;
+}
+
 ////////////////////////////////////////////////////////////////
 
 string

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -154,6 +154,19 @@ tclListNetworkSet(Tcl_Obj *const source,
   Tcl_SetObjResult(interp, list);
 }
 
+%typemap(out) TmpPinSet* {
+  Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
+  PinSet *pins = $1;
+  PinSet::Iterator pin_iter(pins);
+  while (pin_iter.hasNext()) {
+    const Pin *pin = pin_iter.next();
+    Tcl_Obj *obj = SWIG_NewInstanceObj(const_cast<Pin*>(pin), SWIGTYPE_p_Pin, false);
+    Tcl_ListObjAppendElement(interp, list, obj);
+  }
+  delete pins;
+  Tcl_SetObjResult(interp, list);
+}
+
 %typemap(out) NetSeq* {
   Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
   NetSeq *nets = $1;
@@ -418,6 +431,14 @@ find_floating_nets()
   ensureLinked();
   Resizer *resizer = getResizer();
   return resizer->findFloatingNets();
+}
+
+TmpPinSet *
+find_floating_pins()
+{
+  ensureLinked();
+  Resizer *resizer = getResizer();
+  return resizer->findFloatingPins();
 }
 
 void

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -499,7 +499,9 @@ proc report_floating_nets { args } {
 
   set verbose [info exists flags(-verbose)]
   set floating_nets [rsz::find_floating_nets]
+  set floating_pins [rsz::find_floating_pins]
   set floating_net_count [llength $floating_nets]
+  set floating_pin_count [llength $floating_pins]
   if { $floating_net_count > 0 } {
     utl::warn RSZ 20 "found $floating_net_count floating nets."
     if { $verbose } {
@@ -508,6 +510,17 @@ proc report_floating_nets { args } {
       }
     }
   }
+  if { $floating_pin_count > 0 } {
+    utl::warn RSZ 95 "found $floating_pin_count floating pins."
+    if { $verbose } {
+      foreach pin $floating_pins {
+        utl::report " [get_full_name $pin]"
+      }
+    }
+  }
+
+  utl::metric "timing__drv__floating__nets" $floating_net_count
+  utl::metric "timing__drv__floating__pins" $floating_pin_count
 }
 
 sta::define_cmd_args "report_long_wires" {count}

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -78,6 +78,8 @@ record_tests {
   repair_slew16
   repair_slew17
   report_floating_nets1
+  report_floating_nets2
+  report_floating_nets3
   repair_tie1
   repair_tie2
   repair_tie3

--- a/src/rsz/test/report_floating_nets2.ok
+++ b/src/rsz/test/report_floating_nets2.ok
@@ -1,0 +1,8 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[WARNING RSZ-0095] found 1 floating pins.
+[WARNING RSZ-0095] found 1 floating pins.
+ u1/A

--- a/src/rsz/test/report_floating_nets2.tcl
+++ b/src/rsz/test/report_floating_nets2.tcl
@@ -1,0 +1,8 @@
+# report_floating_nets
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog report_floating_nets2.v
+link_design top
+report_floating_nets
+report_floating_nets -verbose

--- a/src/rsz/test/report_floating_nets2.v
+++ b/src/rsz/test/report_floating_nets2.v
@@ -1,0 +1,12 @@
+module top (in1, clk1, clk2, clk3, out);
+  input in1, clk1, clk2, clk3;
+  output out;
+
+   // unconnected reg output
+  DFF_X1 r1 (.D(in1), .CK(clk1), .Q(r1q), .QN(r1qn));
+
+  // no driver for r2q
+  BUF_X1 u1 (.A(), .Z(u1z));
+  AND2_X1 u2 (.A1(r1q), .A2(u1z), .ZN(u2z));
+  DFF_X1 r3 (.D(u2z), .CK(clk3), .Q(out));
+endmodule // top

--- a/src/rsz/test/report_floating_nets3.ok
+++ b/src/rsz/test/report_floating_nets3.ok
@@ -1,0 +1,8 @@
+[INFO ODB-0222] Reading LEF file: Nangate45/Nangate45.lef
+[INFO ODB-0223]     Created 22 technology layers
+[INFO ODB-0224]     Created 27 technology vias
+[INFO ODB-0225]     Created 135 library cells
+[INFO ODB-0226] Finished LEF file:  Nangate45/Nangate45.lef
+[WARNING RSZ-0020] found 1 floating nets.
+[WARNING RSZ-0020] found 1 floating nets.
+ out

--- a/src/rsz/test/report_floating_nets3.tcl
+++ b/src/rsz/test/report_floating_nets3.tcl
@@ -1,0 +1,8 @@
+# report_floating_nets
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog report_floating_nets3.v
+link_design top
+report_floating_nets
+report_floating_nets -verbose

--- a/src/rsz/test/report_floating_nets3.v
+++ b/src/rsz/test/report_floating_nets3.v
@@ -1,0 +1,12 @@
+module top (in1, clk1, clk2, clk3, out);
+  input in1, clk1, clk2, clk3;
+  output out;
+
+   // unconnected reg output
+  DFF_X1 r1 (.D(in1), .CK(clk1), .Q(r1q), .QN(r1qn));
+
+  // no driver for r2q
+  BUF_X1 u1 (.A(r1q), .Z(u1z));
+  AND2_X1 u2 (.A1(r1q), .A2(u1z), .ZN(u2z));
+  DFF_X1 r3 (.D(u2z), .CK(clk3), .Q());
+endmodule // top


### PR DESCRIPTION
Adds:
- check for input pins with no nets indicating that they are not driven
- unit tests to check
- metrics for floating nets and pins