### PR TITLE
ppl: update place_pin command

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -154,8 +154,7 @@ class IOPlacer
                 int y,
                 int width,
                 int height,
-                bool force_to_die_bound,
-                bool placed_status);
+                bool force_to_die_bound);
 
   static Direction getDirection(const std::string& direction);
   static Edge getEdge(const std::string& edge);

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -704,8 +704,7 @@ void IOPlacer::writePinPlacement()
         const odb::Point& pos = io_pin.getPosition();
         out << "place_pin -pin_name " << io_pin.getName() << " -layer "
             << tech_layer->getName() << " -location {" << dbuToMicrons(pos.x())
-            << " " << dbuToMicrons(pos.y())
-            << "} -force_to_die_boundary\n";
+            << " " << dbuToMicrons(pos.y()) << "} -force_to_die_boundary\n";
       }
     }
   }

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -705,7 +705,7 @@ void IOPlacer::writePinPlacement()
         out << "place_pin -pin_name " << io_pin.getName() << " -layer "
             << tech_layer->getName() << " -location {" << dbuToMicrons(pos.x())
             << " " << dbuToMicrons(pos.y())
-            << "} -force_to_die_boundary -placed_status\n";
+            << "} -force_to_die_boundary\n";
       }
     }
   }
@@ -2134,8 +2134,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
                         int y,
                         int width,
                         int height,
-                        bool force_to_die_bound,
-                        bool placed_status)
+                        bool force_to_die_bound)
 {
   if (width == 0 && height == 0) {
     const int database_unit = getTech()->getLefUnits();
@@ -2244,9 +2243,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
   odb::Point ll = odb::Point(pos.x() - width / 2, pos.y() - height / 2);
   odb::Point ur = odb::Point(pos.x() + width / 2, pos.y() + height / 2);
 
-  odb::dbPlacementStatus placement_status = placed_status
-                                                ? odb::dbPlacementStatus::PLACED
-                                                : odb::dbPlacementStatus::FIRM;
+  odb::dbPlacementStatus placement_status = odb::dbPlacementStatus::FIRM;
   IOPin io_pin
       = IOPin(bterm, pos, Direction::invalid, ll, ur, placement_status);
   io_pin.setLayer(layer_level);

--- a/src/ppl/src/IOPlacer.i
+++ b/src/ppl/src/IOPlacer.i
@@ -306,9 +306,9 @@ get_top_layer()
 void
 place_pin(odb::dbBTerm* bterm, odb::dbTechLayer* layer,
           int x, int y, int width, int height,
-          bool force_to_die_bound, bool placed_status)
+          bool force_to_die_bound)
 {
-  getIOPlacer()->placePin(bterm, layer, x, y, width, height, force_to_die_bound, placed_status);
+  getIOPlacer()->placePin(bterm, layer, x, y, width, height, force_to_die_bound);
 }
 
 void

--- a/src/ppl/src/IOPlacer.tcl
+++ b/src/ppl/src/IOPlacer.tcl
@@ -359,8 +359,7 @@ sta::define_cmd_args "place_pin" {[-pin_name pin_name]\
                                   [-layer layer]\
                                   [-location location]\
                                   [-pin_size pin_size]\
-                                  [-force_to_die_boundary]\
-                                  [-placed_status]
+                                  [-force_to_die_boundary]
 }
 
 proc place_pin { args } {
@@ -415,7 +414,7 @@ proc place_pin { args } {
 
   set layer [ppl::parse_layer_name $layer]
 
-  ppl::place_pin $pin $layer $x $y $width $height [info exists flags(-force_to_die_boundary)] [info exists flags(-placed_status)]
+  ppl::place_pin $pin $layer $x $y $width $height [info exists flags(-force_to_die_boundary)]
 }
 
 sta::define_cmd_args "place_pins" {[-hor_layers h_layers]\

--- a/src/ppl/test/ppl_aux.py
+++ b/src/ppl/test/ppl_aux.py
@@ -205,14 +205,14 @@ def place_pins(design, *,
 
 
 def place_pin(design, pin_name=None, layer=None, location=None, pin_size=None,
-              force_to_die_boundary=False, placed_status=False):
+              force_to_die_boundary=False):
     x      = design.micronToDBU(location[0])
     y      = design.micronToDBU(location[1])
     width  = design.micronToDBU(pin_size[0])
     height = design.micronToDBU(pin_size[1])
     pin    = parse_pin_names(design, pin_name)
     lay    = parse_layer_name(design, layer)
-    design.getIOPlacer().placePin(pin[0], lay, x, y, width, height, force_to_die_boundary, placed_status)
+    design.getIOPlacer().placePin(pin[0], lay, x, y, width, height, force_to_die_boundary)
 
 
 def parse_layer_name(design, layer_name):

--- a/src/ppl/test/write_pin_placement1.defok
+++ b/src/ppl/test/write_pin_placement1.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 84550 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 95950 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 103550 70 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 104310 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 105070 70 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 105830 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 106590 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 107350 70 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 108110 70 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 108870 70 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 109630 70 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 110390 70 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 96710 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 111150 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 111910 70 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 112670 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 113430 70 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 114190 70 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 114950 70 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 115710 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 116470 70 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 117230 70 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 117990 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 97470 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 118750 70 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 119510 70 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 98230 70 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 98990 70 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 99750 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 100510 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 101270 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 102030 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 102790 70 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 23660 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 168910 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 105980 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 41230 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 48830 201530 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 49590 201530 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 50350 201530 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 51110 201530 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 51870 201530 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 52630 201530 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 41990 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 42750 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 43510 201530 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 44270 201530 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 45030 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 45790 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 46550 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 47310 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 48070 201530 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 177380 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 53900 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/write_pin_placement1.tcl
+++ b/src/ppl/test/write_pin_placement1.tcl
@@ -7,17 +7,14 @@ set_io_pin_constraint -region bottom:* -group -order -pin_names {req_msg[0] req_
 set_io_pin_constraint -region top:* -group -order -pin_names {resp_msg[0] resp_msg[1] resp_msg[2] resp_msg[3] resp_msg[4] resp_msg[5] resp_msg[6] resp_msg[7] resp_msg[8] resp_msg[9] resp_msg[10] resp_msg[11] resp_msg[12] resp_msg[13] resp_msg[14] resp_msg[15]}
 
 set tcl_file [make_result_file write_pin_placement1.tcl]
-set def_file1 [make_result_file write_pin_placement1.def1]
-set def_file2 [make_result_file write_pin_placement1.def2]
+set def_file [make_result_file write_pin_placement1.def]
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.36 -annealing -write_pin_placement $tcl_file
 
-write_def $def_file1
-
 source $tcl_file
 
-write_def $def_file2
+write_def $def_file
 
-diff_file $def_file1 $def_file2
+diff_file write_pin_placement1.defok $def_file
 
 diff_file write_pin_placement1.tclok $tcl_file

--- a/src/ppl/test/write_pin_placement1.tclok
+++ b/src/ppl/test/write_pin_placement1.tclok
@@ -1,58 +1,58 @@
 #Edge: BOTTOM
-place_pin -pin_name clk -layer metal2 -location {42.275 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[31] -layer metal2 -location {59.755 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[30] -layer metal2 -location {59.375 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[29] -layer metal2 -location {58.995 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[28] -layer metal2 -location {58.615 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[27] -layer metal2 -location {58.235 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[26] -layer metal2 -location {57.855 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[25] -layer metal2 -location {57.475 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[24] -layer metal2 -location {57.095 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[23] -layer metal2 -location {56.715 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[22] -layer metal2 -location {56.335 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[21] -layer metal2 -location {55.955 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[20] -layer metal2 -location {55.575 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[19] -layer metal2 -location {55.195 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[18] -layer metal2 -location {54.815 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[17] -layer metal2 -location {54.435 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[16] -layer metal2 -location {54.055 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[15] -layer metal2 -location {53.675 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[14] -layer metal2 -location {53.295 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[13] -layer metal2 -location {52.915 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[12] -layer metal2 -location {52.535 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[11] -layer metal2 -location {52.155 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[10] -layer metal2 -location {51.775 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[9] -layer metal2 -location {51.395 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[8] -layer metal2 -location {51.015 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[7] -layer metal2 -location {50.635 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[6] -layer metal2 -location {50.255 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[5] -layer metal2 -location {49.875 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[4] -layer metal2 -location {49.495 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[3] -layer metal2 -location {49.115 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[2] -layer metal2 -location {48.735 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[1] -layer metal2 -location {48.355 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[0] -layer metal2 -location {47.975 0} -force_to_die_boundary -placed_status
+place_pin -pin_name clk -layer metal2 -location {42.275 0} -force_to_die_boundary
+place_pin -pin_name req_msg[31] -layer metal2 -location {59.755 0} -force_to_die_boundary
+place_pin -pin_name req_msg[30] -layer metal2 -location {59.375 0} -force_to_die_boundary
+place_pin -pin_name req_msg[29] -layer metal2 -location {58.995 0} -force_to_die_boundary
+place_pin -pin_name req_msg[28] -layer metal2 -location {58.615 0} -force_to_die_boundary
+place_pin -pin_name req_msg[27] -layer metal2 -location {58.235 0} -force_to_die_boundary
+place_pin -pin_name req_msg[26] -layer metal2 -location {57.855 0} -force_to_die_boundary
+place_pin -pin_name req_msg[25] -layer metal2 -location {57.475 0} -force_to_die_boundary
+place_pin -pin_name req_msg[24] -layer metal2 -location {57.095 0} -force_to_die_boundary
+place_pin -pin_name req_msg[23] -layer metal2 -location {56.715 0} -force_to_die_boundary
+place_pin -pin_name req_msg[22] -layer metal2 -location {56.335 0} -force_to_die_boundary
+place_pin -pin_name req_msg[21] -layer metal2 -location {55.955 0} -force_to_die_boundary
+place_pin -pin_name req_msg[20] -layer metal2 -location {55.575 0} -force_to_die_boundary
+place_pin -pin_name req_msg[19] -layer metal2 -location {55.195 0} -force_to_die_boundary
+place_pin -pin_name req_msg[18] -layer metal2 -location {54.815 0} -force_to_die_boundary
+place_pin -pin_name req_msg[17] -layer metal2 -location {54.435 0} -force_to_die_boundary
+place_pin -pin_name req_msg[16] -layer metal2 -location {54.055 0} -force_to_die_boundary
+place_pin -pin_name req_msg[15] -layer metal2 -location {53.675 0} -force_to_die_boundary
+place_pin -pin_name req_msg[14] -layer metal2 -location {53.295 0} -force_to_die_boundary
+place_pin -pin_name req_msg[13] -layer metal2 -location {52.915 0} -force_to_die_boundary
+place_pin -pin_name req_msg[12] -layer metal2 -location {52.535 0} -force_to_die_boundary
+place_pin -pin_name req_msg[11] -layer metal2 -location {52.155 0} -force_to_die_boundary
+place_pin -pin_name req_msg[10] -layer metal2 -location {51.775 0} -force_to_die_boundary
+place_pin -pin_name req_msg[9] -layer metal2 -location {51.395 0} -force_to_die_boundary
+place_pin -pin_name req_msg[8] -layer metal2 -location {51.015 0} -force_to_die_boundary
+place_pin -pin_name req_msg[7] -layer metal2 -location {50.635 0} -force_to_die_boundary
+place_pin -pin_name req_msg[6] -layer metal2 -location {50.255 0} -force_to_die_boundary
+place_pin -pin_name req_msg[5] -layer metal2 -location {49.875 0} -force_to_die_boundary
+place_pin -pin_name req_msg[4] -layer metal2 -location {49.495 0} -force_to_die_boundary
+place_pin -pin_name req_msg[3] -layer metal2 -location {49.115 0} -force_to_die_boundary
+place_pin -pin_name req_msg[2] -layer metal2 -location {48.735 0} -force_to_die_boundary
+place_pin -pin_name req_msg[1] -layer metal2 -location {48.355 0} -force_to_die_boundary
+place_pin -pin_name req_msg[0] -layer metal2 -location {47.975 0} -force_to_die_boundary
 #Edge: RIGHT
-place_pin -pin_name resp_val -layer metal3 -location {100.13 26.95} -force_to_die_boundary -placed_status
+place_pin -pin_name resp_val -layer metal3 -location {100.13 26.95} -force_to_die_boundary
 #Edge: TOP
-place_pin -pin_name req_val -layer metal2 -location {84.455 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[15] -layer metal2 -location {26.315 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[14] -layer metal2 -location {25.935 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[13] -layer metal2 -location {25.555 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[12] -layer metal2 -location {25.175 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[11] -layer metal2 -location {24.795 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[10] -layer metal2 -location {24.415 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[9] -layer metal2 -location {24.035 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[8] -layer metal2 -location {23.655 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[7] -layer metal2 -location {23.275 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[6] -layer metal2 -location {22.895 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[5] -layer metal2 -location {22.515 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[4] -layer metal2 -location {22.135 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[3] -layer metal2 -location {21.755 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[2] -layer metal2 -location {21.375 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[1] -layer metal2 -location {20.995 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[0] -layer metal2 -location {20.615 100.8} -force_to_die_boundary -placed_status
+place_pin -pin_name req_val -layer metal2 -location {84.455 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[15] -layer metal2 -location {26.315 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[14] -layer metal2 -location {25.935 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[13] -layer metal2 -location {25.555 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[12] -layer metal2 -location {25.175 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[11] -layer metal2 -location {24.795 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[10] -layer metal2 -location {24.415 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[9] -layer metal2 -location {24.035 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[8] -layer metal2 -location {23.655 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[7] -layer metal2 -location {23.275 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[6] -layer metal2 -location {22.895 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[5] -layer metal2 -location {22.515 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[4] -layer metal2 -location {22.135 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[3] -layer metal2 -location {21.755 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[2] -layer metal2 -location {21.375 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[1] -layer metal2 -location {20.995 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[0] -layer metal2 -location {20.615 100.8} -force_to_die_boundary
 #Edge: LEFT
-place_pin -pin_name req_rdy -layer metal3 -location {0 11.83} -force_to_die_boundary -placed_status
-place_pin -pin_name reset -layer metal3 -location {0 52.99} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_rdy -layer metal3 -location {0 88.69} -force_to_die_boundary -placed_status
+place_pin -pin_name req_rdy -layer metal3 -location {0 11.83} -force_to_die_boundary
+place_pin -pin_name reset -layer metal3 -location {0 52.99} -force_to_die_boundary
+place_pin -pin_name resp_rdy -layer metal3 -location {0 88.69} -force_to_die_boundary

--- a/src/ppl/test/write_pin_placement2.defok
+++ b/src/ppl/test/write_pin_placement2.defok
@@ -1,0 +1,1685 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 1 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+END COMPONENTS
+PINS 400 ;
+    - pin0 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 54180 ) N ;
+    - pin1 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 54460 ) N ;
+    - pin10 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 56980 ) N ;
+    - pin100 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 82180 ) N ;
+    - pin101 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 82460 ) N ;
+    - pin102 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 82740 ) N ;
+    - pin103 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 83020 ) N ;
+    - pin104 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 83300 ) N ;
+    - pin105 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 83580 ) N ;
+    - pin106 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 83860 ) N ;
+    - pin107 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 84140 ) N ;
+    - pin108 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 84420 ) N ;
+    - pin109 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 84700 ) N ;
+    - pin11 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 57260 ) N ;
+    - pin110 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 84980 ) N ;
+    - pin111 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 85260 ) N ;
+    - pin112 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 85540 ) N ;
+    - pin113 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 85820 ) N ;
+    - pin114 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 86100 ) N ;
+    - pin115 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 86380 ) N ;
+    - pin116 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 86660 ) N ;
+    - pin117 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 86940 ) N ;
+    - pin118 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 87220 ) N ;
+    - pin119 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 87500 ) N ;
+    - pin12 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 57540 ) N ;
+    - pin120 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 87780 ) N ;
+    - pin121 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 88060 ) N ;
+    - pin122 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 88340 ) N ;
+    - pin123 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 88620 ) N ;
+    - pin124 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 88900 ) N ;
+    - pin125 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 89180 ) N ;
+    - pin126 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 89460 ) N ;
+    - pin127 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 89740 ) N ;
+    - pin128 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 90020 ) N ;
+    - pin129 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 90300 ) N ;
+    - pin13 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 57820 ) N ;
+    - pin130 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 90580 ) N ;
+    - pin131 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 90860 ) N ;
+    - pin132 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 91140 ) N ;
+    - pin133 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 91420 ) N ;
+    - pin134 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 91700 ) N ;
+    - pin135 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 91980 ) N ;
+    - pin136 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 92260 ) N ;
+    - pin137 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 92540 ) N ;
+    - pin138 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 92820 ) N ;
+    - pin139 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 93100 ) N ;
+    - pin14 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 58100 ) N ;
+    - pin140 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 93380 ) N ;
+    - pin141 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 93660 ) N ;
+    - pin142 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 93940 ) N ;
+    - pin143 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 94220 ) N ;
+    - pin144 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 94500 ) N ;
+    - pin145 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 94780 ) N ;
+    - pin146 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 95060 ) N ;
+    - pin147 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 95340 ) N ;
+    - pin148 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 95620 ) N ;
+    - pin149 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 95900 ) N ;
+    - pin15 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 58380 ) N ;
+    - pin150 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 96180 ) N ;
+    - pin151 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 96460 ) N ;
+    - pin152 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 96740 ) N ;
+    - pin153 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 97020 ) N ;
+    - pin154 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 97300 ) N ;
+    - pin155 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 97580 ) N ;
+    - pin156 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 97860 ) N ;
+    - pin157 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 98140 ) N ;
+    - pin158 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 98420 ) N ;
+    - pin159 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 98700 ) N ;
+    - pin16 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 58660 ) N ;
+    - pin160 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 98980 ) N ;
+    - pin161 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 99260 ) N ;
+    - pin162 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 99540 ) N ;
+    - pin163 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 99820 ) N ;
+    - pin164 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 100100 ) N ;
+    - pin165 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 100380 ) N ;
+    - pin166 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 100660 ) N ;
+    - pin167 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 100940 ) N ;
+    - pin168 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 101220 ) N ;
+    - pin169 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 101500 ) N ;
+    - pin17 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 58940 ) N ;
+    - pin170 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 101780 ) N ;
+    - pin171 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 102060 ) N ;
+    - pin172 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 102340 ) N ;
+    - pin173 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 102620 ) N ;
+    - pin174 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 102900 ) N ;
+    - pin175 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 103180 ) N ;
+    - pin176 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 103460 ) N ;
+    - pin177 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 103740 ) N ;
+    - pin178 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 104020 ) N ;
+    - pin179 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 104300 ) N ;
+    - pin18 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 59220 ) N ;
+    - pin180 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 104580 ) N ;
+    - pin181 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 104860 ) N ;
+    - pin182 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 105140 ) N ;
+    - pin183 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 105420 ) N ;
+    - pin184 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 105700 ) N ;
+    - pin185 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 105980 ) N ;
+    - pin186 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 106260 ) N ;
+    - pin187 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 106540 ) N ;
+    - pin188 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 106820 ) N ;
+    - pin189 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 107100 ) N ;
+    - pin19 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 59500 ) N ;
+    - pin190 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 107380 ) N ;
+    - pin191 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 107660 ) N ;
+    - pin192 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 107940 ) N ;
+    - pin193 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 108220 ) N ;
+    - pin194 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 108500 ) N ;
+    - pin195 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 108780 ) N ;
+    - pin196 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 109060 ) N ;
+    - pin197 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 109340 ) N ;
+    - pin198 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 109620 ) N ;
+    - pin199 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 109900 ) N ;
+    - pin2 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 54740 ) N ;
+    - pin20 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 59780 ) N ;
+    - pin200 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 110180 ) N ;
+    - pin201 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 110460 ) N ;
+    - pin202 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 110740 ) N ;
+    - pin203 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 111020 ) N ;
+    - pin204 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 111300 ) N ;
+    - pin205 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 111580 ) N ;
+    - pin206 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 111860 ) N ;
+    - pin207 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 112140 ) N ;
+    - pin208 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 112420 ) N ;
+    - pin209 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 112700 ) N ;
+    - pin21 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 60060 ) N ;
+    - pin210 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 112980 ) N ;
+    - pin211 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 113260 ) N ;
+    - pin212 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 113540 ) N ;
+    - pin213 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 113820 ) N ;
+    - pin214 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 114100 ) N ;
+    - pin215 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 114380 ) N ;
+    - pin216 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 114660 ) N ;
+    - pin217 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 114940 ) N ;
+    - pin218 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 115220 ) N ;
+    - pin219 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 115500 ) N ;
+    - pin22 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 60340 ) N ;
+    - pin220 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 115780 ) N ;
+    - pin221 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 116060 ) N ;
+    - pin222 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 116340 ) N ;
+    - pin223 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 116620 ) N ;
+    - pin224 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 116900 ) N ;
+    - pin225 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 117180 ) N ;
+    - pin226 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 117460 ) N ;
+    - pin227 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 117740 ) N ;
+    - pin228 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 118020 ) N ;
+    - pin229 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 118300 ) N ;
+    - pin23 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 60620 ) N ;
+    - pin230 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 118580 ) N ;
+    - pin231 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 118860 ) N ;
+    - pin232 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 119140 ) N ;
+    - pin233 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 119420 ) N ;
+    - pin234 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 119700 ) N ;
+    - pin235 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 119980 ) N ;
+    - pin236 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 120260 ) N ;
+    - pin237 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 120540 ) N ;
+    - pin238 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 120820 ) N ;
+    - pin239 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 121100 ) N ;
+    - pin24 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 60900 ) N ;
+    - pin240 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 121380 ) N ;
+    - pin241 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 121660 ) N ;
+    - pin242 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 121940 ) N ;
+    - pin243 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 122220 ) N ;
+    - pin244 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 122500 ) N ;
+    - pin245 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 122780 ) N ;
+    - pin246 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 123060 ) N ;
+    - pin247 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 123340 ) N ;
+    - pin248 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 123620 ) N ;
+    - pin249 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 123900 ) N ;
+    - pin25 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 61180 ) N ;
+    - pin250 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 124180 ) N ;
+    - pin251 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 124460 ) N ;
+    - pin252 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 124740 ) N ;
+    - pin253 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 125020 ) N ;
+    - pin254 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 125300 ) N ;
+    - pin255 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 125580 ) N ;
+    - pin256 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 125860 ) N ;
+    - pin257 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 126140 ) N ;
+    - pin258 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 126420 ) N ;
+    - pin259 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 126700 ) N ;
+    - pin26 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 61460 ) N ;
+    - pin260 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 126980 ) N ;
+    - pin261 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 127260 ) N ;
+    - pin262 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 127540 ) N ;
+    - pin263 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 127820 ) N ;
+    - pin264 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 128100 ) N ;
+    - pin265 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 128380 ) N ;
+    - pin266 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 128660 ) N ;
+    - pin267 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 128940 ) N ;
+    - pin268 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 129220 ) N ;
+    - pin269 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 129500 ) N ;
+    - pin27 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 61740 ) N ;
+    - pin270 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 129780 ) N ;
+    - pin271 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 130060 ) N ;
+    - pin272 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 130340 ) N ;
+    - pin273 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 130620 ) N ;
+    - pin274 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 130900 ) N ;
+    - pin275 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 131180 ) N ;
+    - pin276 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 131460 ) N ;
+    - pin277 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 131740 ) N ;
+    - pin278 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 132020 ) N ;
+    - pin279 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 132300 ) N ;
+    - pin28 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 62020 ) N ;
+    - pin280 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 132580 ) N ;
+    - pin281 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 132860 ) N ;
+    - pin282 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 133140 ) N ;
+    - pin283 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 133420 ) N ;
+    - pin284 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 133700 ) N ;
+    - pin285 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 133980 ) N ;
+    - pin286 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 134260 ) N ;
+    - pin287 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 134540 ) N ;
+    - pin288 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 134820 ) N ;
+    - pin289 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 135100 ) N ;
+    - pin29 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 62300 ) N ;
+    - pin290 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 135380 ) N ;
+    - pin291 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 135660 ) N ;
+    - pin292 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 135940 ) N ;
+    - pin293 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 136220 ) N ;
+    - pin294 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 136500 ) N ;
+    - pin295 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 136780 ) N ;
+    - pin296 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 137060 ) N ;
+    - pin297 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 137340 ) N ;
+    - pin298 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 137620 ) N ;
+    - pin299 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 137900 ) N ;
+    - pin3 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 55020 ) N ;
+    - pin30 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 62580 ) N ;
+    - pin300 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 138180 ) N ;
+    - pin301 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 138460 ) N ;
+    - pin302 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 138740 ) N ;
+    - pin303 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 139020 ) N ;
+    - pin304 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 139300 ) N ;
+    - pin305 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 139580 ) N ;
+    - pin306 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 139860 ) N ;
+    - pin307 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 140140 ) N ;
+    - pin308 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 140420 ) N ;
+    - pin309 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 140700 ) N ;
+    - pin31 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 62860 ) N ;
+    - pin310 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 140980 ) N ;
+    - pin311 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 141260 ) N ;
+    - pin312 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 141540 ) N ;
+    - pin313 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 141820 ) N ;
+    - pin314 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 142100 ) N ;
+    - pin315 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 142380 ) N ;
+    - pin316 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 142660 ) N ;
+    - pin317 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 142940 ) N ;
+    - pin318 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 143220 ) N ;
+    - pin319 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 143500 ) N ;
+    - pin32 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 63140 ) N ;
+    - pin320 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 143780 ) N ;
+    - pin321 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 144060 ) N ;
+    - pin322 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 144340 ) N ;
+    - pin323 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 144620 ) N ;
+    - pin324 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 144900 ) N ;
+    - pin325 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 145180 ) N ;
+    - pin326 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 145460 ) N ;
+    - pin327 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 145740 ) N ;
+    - pin328 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 146020 ) N ;
+    - pin329 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 146300 ) N ;
+    - pin33 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 63420 ) N ;
+    - pin330 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 146580 ) N ;
+    - pin331 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 146860 ) N ;
+    - pin332 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 147140 ) N ;
+    - pin333 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 147420 ) N ;
+    - pin334 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 147700 ) N ;
+    - pin335 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 147980 ) N ;
+    - pin336 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 148260 ) N ;
+    - pin337 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 148540 ) N ;
+    - pin338 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 148820 ) N ;
+    - pin339 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 149100 ) N ;
+    - pin34 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 63700 ) N ;
+    - pin340 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 149380 ) N ;
+    - pin341 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 149660 ) N ;
+    - pin342 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 149940 ) N ;
+    - pin343 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 150220 ) N ;
+    - pin344 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 150500 ) N ;
+    - pin345 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 150780 ) N ;
+    - pin346 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 151060 ) N ;
+    - pin347 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 151340 ) N ;
+    - pin348 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 151620 ) N ;
+    - pin349 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 151900 ) N ;
+    - pin35 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 63980 ) N ;
+    - pin350 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 152180 ) N ;
+    - pin351 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 152460 ) N ;
+    - pin352 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 152740 ) N ;
+    - pin353 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 153020 ) N ;
+    - pin354 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 153300 ) N ;
+    - pin355 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 153580 ) N ;
+    - pin356 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 153860 ) N ;
+    - pin357 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 154140 ) N ;
+    - pin358 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 154420 ) N ;
+    - pin359 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 154700 ) N ;
+    - pin36 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 64260 ) N ;
+    - pin360 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 154980 ) N ;
+    - pin361 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 155260 ) N ;
+    - pin362 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 155540 ) N ;
+    - pin363 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 155820 ) N ;
+    - pin364 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 156100 ) N ;
+    - pin365 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 156380 ) N ;
+    - pin366 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 156660 ) N ;
+    - pin367 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 156940 ) N ;
+    - pin368 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 157220 ) N ;
+    - pin369 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 157500 ) N ;
+    - pin37 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 64540 ) N ;
+    - pin370 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 157780 ) N ;
+    - pin371 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 158060 ) N ;
+    - pin372 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 158340 ) N ;
+    - pin373 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 158620 ) N ;
+    - pin374 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 158900 ) N ;
+    - pin375 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 159180 ) N ;
+    - pin376 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 159460 ) N ;
+    - pin377 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 159740 ) N ;
+    - pin378 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 160020 ) N ;
+    - pin379 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 160300 ) N ;
+    - pin38 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 64820 ) N ;
+    - pin380 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 160580 ) N ;
+    - pin381 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 160860 ) N ;
+    - pin382 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 161140 ) N ;
+    - pin383 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 161420 ) N ;
+    - pin384 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 161700 ) N ;
+    - pin385 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 161980 ) N ;
+    - pin386 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 162260 ) N ;
+    - pin387 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 162540 ) N ;
+    - pin388 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 162820 ) N ;
+    - pin389 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 163100 ) N ;
+    - pin39 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 65100 ) N ;
+    - pin390 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 163380 ) N ;
+    - pin391 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 163660 ) N ;
+    - pin392 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 163940 ) N ;
+    - pin393 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 164220 ) N ;
+    - pin394 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 164500 ) N ;
+    - pin395 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 164780 ) N ;
+    - pin396 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 165060 ) N ;
+    - pin397 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 165340 ) N ;
+    - pin398 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 165620 ) N ;
+    - pin399 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 165900 ) N ;
+    - pin4 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 55300 ) N ;
+    - pin40 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 65380 ) N ;
+    - pin41 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 65660 ) N ;
+    - pin42 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 65940 ) N ;
+    - pin43 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 66220 ) N ;
+    - pin44 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 66500 ) N ;
+    - pin45 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 66780 ) N ;
+    - pin46 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 67060 ) N ;
+    - pin47 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 67340 ) N ;
+    - pin48 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 67620 ) N ;
+    - pin49 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 67900 ) N ;
+    - pin5 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 55580 ) N ;
+    - pin50 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 68180 ) N ;
+    - pin51 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 68460 ) N ;
+    - pin52 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 68740 ) N ;
+    - pin53 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 69020 ) N ;
+    - pin54 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 69300 ) N ;
+    - pin55 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 69580 ) N ;
+    - pin56 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 69860 ) N ;
+    - pin57 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 70140 ) N ;
+    - pin58 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 70420 ) N ;
+    - pin59 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 70700 ) N ;
+    - pin6 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 55860 ) N ;
+    - pin60 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 70980 ) N ;
+    - pin61 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 71260 ) N ;
+    - pin62 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 71540 ) N ;
+    - pin63 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 71820 ) N ;
+    - pin64 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 72100 ) N ;
+    - pin65 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 72380 ) N ;
+    - pin66 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 72660 ) N ;
+    - pin67 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 72940 ) N ;
+    - pin68 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 73220 ) N ;
+    - pin69 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 73500 ) N ;
+    - pin7 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 56140 ) N ;
+    - pin70 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 73780 ) N ;
+    - pin71 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 74060 ) N ;
+    - pin72 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 74340 ) N ;
+    - pin73 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 74620 ) N ;
+    - pin74 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 74900 ) N ;
+    - pin75 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 75180 ) N ;
+    - pin76 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 75460 ) N ;
+    - pin77 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 75740 ) N ;
+    - pin78 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 76020 ) N ;
+    - pin79 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 76300 ) N ;
+    - pin8 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 56420 ) N ;
+    - pin80 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 76580 ) N ;
+    - pin81 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 76860 ) N ;
+    - pin82 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 77140 ) N ;
+    - pin83 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 77420 ) N ;
+    - pin84 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 77700 ) N ;
+    - pin85 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 77980 ) N ;
+    - pin86 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 78260 ) N ;
+    - pin87 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 78540 ) N ;
+    - pin88 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 78820 ) N ;
+    - pin89 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 79100 ) N ;
+    - pin9 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 56700 ) N ;
+    - pin90 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 79380 ) N ;
+    - pin91 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 79660 ) N ;
+    - pin92 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 79940 ) N ;
+    - pin93 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 80220 ) N ;
+    - pin94 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 80500 ) N ;
+    - pin95 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 80780 ) N ;
+    - pin96 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 81060 ) N ;
+    - pin97 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 81340 ) N ;
+    - pin98 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 81620 ) N ;
+    - pin99 + NET net + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 81900 ) N ;
+END PINS
+NETS 1 ;
+    - net ( PIN pin99 ) ( PIN pin98 ) ( PIN pin97 ) ( PIN pin96 ) ( PIN pin95 ) ( PIN pin94 ) ( PIN pin93 )
+      ( PIN pin92 ) ( PIN pin91 ) ( PIN pin90 ) ( PIN pin9 ) ( PIN pin89 ) ( PIN pin88 ) ( PIN pin87 ) ( PIN pin86 )
+      ( PIN pin85 ) ( PIN pin84 ) ( PIN pin83 ) ( PIN pin82 ) ( PIN pin81 ) ( PIN pin80 ) ( PIN pin8 ) ( PIN pin79 )
+      ( PIN pin78 ) ( PIN pin77 ) ( PIN pin76 ) ( PIN pin75 ) ( PIN pin74 ) ( PIN pin73 ) ( PIN pin72 ) ( PIN pin71 )
+      ( PIN pin70 ) ( PIN pin7 ) ( PIN pin69 ) ( PIN pin68 ) ( PIN pin67 ) ( PIN pin66 ) ( PIN pin65 ) ( PIN pin64 )
+      ( PIN pin63 ) ( PIN pin62 ) ( PIN pin61 ) ( PIN pin60 ) ( PIN pin6 ) ( PIN pin59 ) ( PIN pin58 ) ( PIN pin57 )
+      ( PIN pin56 ) ( PIN pin55 ) ( PIN pin54 ) ( PIN pin53 ) ( PIN pin52 ) ( PIN pin51 ) ( PIN pin50 ) ( PIN pin5 )
+      ( PIN pin49 ) ( PIN pin48 ) ( PIN pin47 ) ( PIN pin46 ) ( PIN pin45 ) ( PIN pin44 ) ( PIN pin43 ) ( PIN pin42 )
+      ( PIN pin41 ) ( PIN pin40 ) ( PIN pin4 ) ( PIN pin399 ) ( PIN pin398 ) ( PIN pin397 ) ( PIN pin396 ) ( PIN pin395 )
+      ( PIN pin394 ) ( PIN pin393 ) ( PIN pin392 ) ( PIN pin391 ) ( PIN pin390 ) ( PIN pin39 ) ( PIN pin389 ) ( PIN pin388 )
+      ( PIN pin387 ) ( PIN pin386 ) ( PIN pin385 ) ( PIN pin384 ) ( PIN pin383 ) ( PIN pin382 ) ( PIN pin381 ) ( PIN pin380 )
+      ( PIN pin38 ) ( PIN pin379 ) ( PIN pin378 ) ( PIN pin377 ) ( PIN pin376 ) ( PIN pin375 ) ( PIN pin374 ) ( PIN pin373 )
+      ( PIN pin372 ) ( PIN pin371 ) ( PIN pin370 ) ( PIN pin37 ) ( PIN pin369 ) ( PIN pin368 ) ( PIN pin367 ) ( PIN pin366 )
+      ( PIN pin365 ) ( PIN pin364 ) ( PIN pin363 ) ( PIN pin362 ) ( PIN pin361 ) ( PIN pin360 ) ( PIN pin36 ) ( PIN pin359 )
+      ( PIN pin358 ) ( PIN pin357 ) ( PIN pin356 ) ( PIN pin355 ) ( PIN pin354 ) ( PIN pin353 ) ( PIN pin352 ) ( PIN pin351 )
+      ( PIN pin350 ) ( PIN pin35 ) ( PIN pin349 ) ( PIN pin348 ) ( PIN pin347 ) ( PIN pin346 ) ( PIN pin345 ) ( PIN pin344 )
+      ( PIN pin343 ) ( PIN pin342 ) ( PIN pin341 ) ( PIN pin340 ) ( PIN pin34 ) ( PIN pin339 ) ( PIN pin338 ) ( PIN pin337 )
+      ( PIN pin336 ) ( PIN pin335 ) ( PIN pin334 ) ( PIN pin333 ) ( PIN pin332 ) ( PIN pin331 ) ( PIN pin330 ) ( PIN pin33 )
+      ( PIN pin329 ) ( PIN pin328 ) ( PIN pin327 ) ( PIN pin326 ) ( PIN pin325 ) ( PIN pin324 ) ( PIN pin323 ) ( PIN pin322 )
+      ( PIN pin321 ) ( PIN pin320 ) ( PIN pin32 ) ( PIN pin319 ) ( PIN pin318 ) ( PIN pin317 ) ( PIN pin316 ) ( PIN pin315 )
+      ( PIN pin314 ) ( PIN pin313 ) ( PIN pin312 ) ( PIN pin311 ) ( PIN pin310 ) ( PIN pin31 ) ( PIN pin309 ) ( PIN pin308 )
+      ( PIN pin307 ) ( PIN pin306 ) ( PIN pin305 ) ( PIN pin304 ) ( PIN pin303 ) ( PIN pin302 ) ( PIN pin301 ) ( PIN pin300 )
+      ( PIN pin30 ) ( PIN pin3 ) ( PIN pin299 ) ( PIN pin298 ) ( PIN pin297 ) ( PIN pin296 ) ( PIN pin295 ) ( PIN pin294 )
+      ( PIN pin293 ) ( PIN pin292 ) ( PIN pin291 ) ( PIN pin290 ) ( PIN pin29 ) ( PIN pin289 ) ( PIN pin288 ) ( PIN pin287 )
+      ( PIN pin286 ) ( PIN pin285 ) ( PIN pin284 ) ( PIN pin283 ) ( PIN pin282 ) ( PIN pin281 ) ( PIN pin280 ) ( PIN pin28 )
+      ( PIN pin279 ) ( PIN pin278 ) ( PIN pin277 ) ( PIN pin276 ) ( PIN pin275 ) ( PIN pin274 ) ( PIN pin273 ) ( PIN pin272 )
+      ( PIN pin271 ) ( PIN pin270 ) ( PIN pin27 ) ( PIN pin269 ) ( PIN pin268 ) ( PIN pin267 ) ( PIN pin266 ) ( PIN pin265 )
+      ( PIN pin264 ) ( PIN pin263 ) ( PIN pin262 ) ( PIN pin261 ) ( PIN pin260 ) ( PIN pin26 ) ( PIN pin259 ) ( PIN pin258 )
+      ( PIN pin257 ) ( PIN pin256 ) ( PIN pin255 ) ( PIN pin254 ) ( PIN pin253 ) ( PIN pin252 ) ( PIN pin251 ) ( PIN pin250 )
+      ( PIN pin25 ) ( PIN pin249 ) ( PIN pin248 ) ( PIN pin247 ) ( PIN pin246 ) ( PIN pin245 ) ( PIN pin244 ) ( PIN pin243 )
+      ( PIN pin242 ) ( PIN pin241 ) ( PIN pin240 ) ( PIN pin24 ) ( PIN pin239 ) ( PIN pin238 ) ( PIN pin237 ) ( PIN pin236 )
+      ( PIN pin235 ) ( PIN pin234 ) ( PIN pin233 ) ( PIN pin232 ) ( PIN pin231 ) ( PIN pin230 ) ( PIN pin23 ) ( PIN pin229 )
+      ( PIN pin228 ) ( PIN pin227 ) ( PIN pin226 ) ( PIN pin225 ) ( PIN pin224 ) ( PIN pin223 ) ( PIN pin222 ) ( PIN pin221 )
+      ( PIN pin220 ) ( PIN pin22 ) ( PIN pin219 ) ( PIN pin218 ) ( PIN pin217 ) ( PIN pin216 ) ( PIN pin215 ) ( PIN pin214 )
+      ( PIN pin213 ) ( PIN pin212 ) ( PIN pin211 ) ( PIN pin210 ) ( PIN pin21 ) ( PIN pin209 ) ( PIN pin208 ) ( PIN pin207 )
+      ( PIN pin206 ) ( PIN pin205 ) ( PIN pin204 ) ( PIN pin203 ) ( PIN pin202 ) ( PIN pin201 ) ( PIN pin200 ) ( PIN pin20 )
+      ( PIN pin2 ) ( PIN pin199 ) ( PIN pin198 ) ( PIN pin197 ) ( PIN pin196 ) ( PIN pin195 ) ( PIN pin194 ) ( PIN pin193 )
+      ( PIN pin192 ) ( PIN pin191 ) ( PIN pin190 ) ( PIN pin19 ) ( PIN pin189 ) ( PIN pin188 ) ( PIN pin187 ) ( PIN pin186 )
+      ( PIN pin185 ) ( PIN pin184 ) ( PIN pin183 ) ( PIN pin182 ) ( PIN pin181 ) ( PIN pin180 ) ( PIN pin18 ) ( PIN pin179 )
+      ( PIN pin178 ) ( PIN pin177 ) ( PIN pin176 ) ( PIN pin175 ) ( PIN pin174 ) ( PIN pin173 ) ( PIN pin172 ) ( PIN pin171 )
+      ( PIN pin170 ) ( PIN pin17 ) ( PIN pin169 ) ( PIN pin168 ) ( PIN pin167 ) ( PIN pin166 ) ( PIN pin165 ) ( PIN pin164 )
+      ( PIN pin163 ) ( PIN pin162 ) ( PIN pin161 ) ( PIN pin160 ) ( PIN pin16 ) ( PIN pin159 ) ( PIN pin158 ) ( PIN pin157 )
+      ( PIN pin156 ) ( PIN pin155 ) ( PIN pin154 ) ( PIN pin153 ) ( PIN pin152 ) ( PIN pin151 ) ( PIN pin150 ) ( PIN pin15 )
+      ( PIN pin149 ) ( PIN pin148 ) ( PIN pin147 ) ( PIN pin146 ) ( PIN pin145 ) ( PIN pin144 ) ( PIN pin143 ) ( PIN pin142 )
+      ( PIN pin141 ) ( PIN pin140 ) ( PIN pin14 ) ( PIN pin139 ) ( PIN pin138 ) ( PIN pin137 ) ( PIN pin136 ) ( PIN pin135 )
+      ( PIN pin134 ) ( PIN pin133 ) ( PIN pin132 ) ( PIN pin131 ) ( PIN pin130 ) ( PIN pin13 ) ( PIN pin129 ) ( PIN pin128 )
+      ( PIN pin127 ) ( PIN pin126 ) ( PIN pin125 ) ( PIN pin124 ) ( PIN pin123 ) ( PIN pin122 ) ( PIN pin121 ) ( PIN pin120 )
+      ( PIN pin12 ) ( PIN pin119 ) ( PIN pin118 ) ( PIN pin117 ) ( PIN pin116 ) ( PIN pin115 ) ( PIN pin114 ) ( PIN pin113 )
+      ( PIN pin112 ) ( PIN pin111 ) ( PIN pin110 ) ( PIN pin11 ) ( PIN pin109 ) ( PIN pin108 ) ( PIN pin107 ) ( PIN pin106 )
+      ( PIN pin105 ) ( PIN pin104 ) ( PIN pin103 ) ( PIN pin102 ) ( PIN pin101 ) ( PIN pin100 ) ( PIN pin10 ) ( PIN pin1 )
+      ( PIN pin0 ) ( _858_ CK ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/write_pin_placement2.tcl
+++ b/src/ppl/test/write_pin_placement2.tcl
@@ -18,17 +18,14 @@ set_io_pin_constraint -group -order -pin_names $group1
 set_io_pin_constraint -group -order -pin_names $group2
 
 set tcl_file [make_result_file write_pin_placement2.tcl]
-set def_file1 [make_result_file write_pin_placement2.def1]
-set def_file2 [make_result_file write_pin_placement2.def2]
+set def_file [make_result_file write_pin_placement2.def]
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing -write_pin_placement $tcl_file
 
-write_def $def_file1
-
 source $tcl_file
 
-write_def $def_file2
+write_def $def_file
 
-diff_file $def_file1 $def_file2
+diff_file write_pin_placement2.defok $def_file
 
 diff_file write_pin_placement2.tclok $tcl_file

--- a/src/ppl/test/write_pin_placement2.tclok
+++ b/src/ppl/test/write_pin_placement2.tclok
@@ -2,403 +2,403 @@
 #Edge: RIGHT
 #Edge: TOP
 #Edge: LEFT
-place_pin -pin_name pin0 -layer metal3 -location {0 27.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin1 -layer metal3 -location {0 27.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin10 -layer metal3 -location {0 28.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin100 -layer metal3 -location {0 41.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin101 -layer metal3 -location {0 41.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin102 -layer metal3 -location {0 41.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin103 -layer metal3 -location {0 41.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin104 -layer metal3 -location {0 41.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin105 -layer metal3 -location {0 41.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin106 -layer metal3 -location {0 41.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin107 -layer metal3 -location {0 42.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin108 -layer metal3 -location {0 42.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin109 -layer metal3 -location {0 42.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin11 -layer metal3 -location {0 28.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin110 -layer metal3 -location {0 42.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin111 -layer metal3 -location {0 42.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin112 -layer metal3 -location {0 42.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin113 -layer metal3 -location {0 42.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin114 -layer metal3 -location {0 43.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin115 -layer metal3 -location {0 43.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin116 -layer metal3 -location {0 43.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin117 -layer metal3 -location {0 43.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin118 -layer metal3 -location {0 43.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin119 -layer metal3 -location {0 43.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin12 -layer metal3 -location {0 28.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin120 -layer metal3 -location {0 43.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin121 -layer metal3 -location {0 44.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin122 -layer metal3 -location {0 44.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin123 -layer metal3 -location {0 44.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin124 -layer metal3 -location {0 44.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin125 -layer metal3 -location {0 44.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin126 -layer metal3 -location {0 44.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin127 -layer metal3 -location {0 44.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin128 -layer metal3 -location {0 45.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin129 -layer metal3 -location {0 45.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin13 -layer metal3 -location {0 28.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin130 -layer metal3 -location {0 45.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin131 -layer metal3 -location {0 45.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin132 -layer metal3 -location {0 45.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin133 -layer metal3 -location {0 45.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin134 -layer metal3 -location {0 45.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin135 -layer metal3 -location {0 45.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin136 -layer metal3 -location {0 46.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin137 -layer metal3 -location {0 46.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin138 -layer metal3 -location {0 46.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin139 -layer metal3 -location {0 46.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin14 -layer metal3 -location {0 29.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin140 -layer metal3 -location {0 46.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin141 -layer metal3 -location {0 46.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin142 -layer metal3 -location {0 46.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin143 -layer metal3 -location {0 47.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin144 -layer metal3 -location {0 47.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin145 -layer metal3 -location {0 47.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin146 -layer metal3 -location {0 47.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin147 -layer metal3 -location {0 47.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin148 -layer metal3 -location {0 47.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin149 -layer metal3 -location {0 47.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin15 -layer metal3 -location {0 29.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin150 -layer metal3 -location {0 48.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin151 -layer metal3 -location {0 48.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin152 -layer metal3 -location {0 48.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin153 -layer metal3 -location {0 48.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin154 -layer metal3 -location {0 48.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin155 -layer metal3 -location {0 48.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin156 -layer metal3 -location {0 48.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin157 -layer metal3 -location {0 49.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin158 -layer metal3 -location {0 49.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin159 -layer metal3 -location {0 49.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin16 -layer metal3 -location {0 29.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin160 -layer metal3 -location {0 49.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin161 -layer metal3 -location {0 49.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin162 -layer metal3 -location {0 49.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin163 -layer metal3 -location {0 49.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin164 -layer metal3 -location {0 50.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin165 -layer metal3 -location {0 50.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin166 -layer metal3 -location {0 50.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin167 -layer metal3 -location {0 50.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin168 -layer metal3 -location {0 50.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin169 -layer metal3 -location {0 50.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin17 -layer metal3 -location {0 29.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin170 -layer metal3 -location {0 50.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin171 -layer metal3 -location {0 51.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin172 -layer metal3 -location {0 51.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin173 -layer metal3 -location {0 51.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin174 -layer metal3 -location {0 51.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin175 -layer metal3 -location {0 51.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin176 -layer metal3 -location {0 51.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin177 -layer metal3 -location {0 51.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin178 -layer metal3 -location {0 52.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin179 -layer metal3 -location {0 52.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin18 -layer metal3 -location {0 29.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin180 -layer metal3 -location {0 52.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin181 -layer metal3 -location {0 52.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin182 -layer metal3 -location {0 52.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin183 -layer metal3 -location {0 52.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin184 -layer metal3 -location {0 52.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin185 -layer metal3 -location {0 52.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin186 -layer metal3 -location {0 53.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin187 -layer metal3 -location {0 53.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin188 -layer metal3 -location {0 53.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin189 -layer metal3 -location {0 53.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin19 -layer metal3 -location {0 29.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin190 -layer metal3 -location {0 53.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin191 -layer metal3 -location {0 53.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin192 -layer metal3 -location {0 53.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin193 -layer metal3 -location {0 54.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin194 -layer metal3 -location {0 54.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin195 -layer metal3 -location {0 54.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin196 -layer metal3 -location {0 54.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin197 -layer metal3 -location {0 54.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin198 -layer metal3 -location {0 54.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin199 -layer metal3 -location {0 54.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin2 -layer metal3 -location {0 27.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin20 -layer metal3 -location {0 29.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin200 -layer metal3 -location {0 55.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin201 -layer metal3 -location {0 55.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin202 -layer metal3 -location {0 55.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin203 -layer metal3 -location {0 55.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin204 -layer metal3 -location {0 55.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin205 -layer metal3 -location {0 55.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin206 -layer metal3 -location {0 55.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin207 -layer metal3 -location {0 56.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin208 -layer metal3 -location {0 56.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin209 -layer metal3 -location {0 56.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin21 -layer metal3 -location {0 30.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin210 -layer metal3 -location {0 56.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin211 -layer metal3 -location {0 56.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin212 -layer metal3 -location {0 56.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin213 -layer metal3 -location {0 56.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin214 -layer metal3 -location {0 57.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin215 -layer metal3 -location {0 57.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin216 -layer metal3 -location {0 57.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin217 -layer metal3 -location {0 57.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin218 -layer metal3 -location {0 57.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin219 -layer metal3 -location {0 57.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin22 -layer metal3 -location {0 30.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin220 -layer metal3 -location {0 57.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin221 -layer metal3 -location {0 58.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin222 -layer metal3 -location {0 58.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin223 -layer metal3 -location {0 58.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin224 -layer metal3 -location {0 58.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin225 -layer metal3 -location {0 58.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin226 -layer metal3 -location {0 58.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin227 -layer metal3 -location {0 58.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin228 -layer metal3 -location {0 59.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin229 -layer metal3 -location {0 59.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin23 -layer metal3 -location {0 30.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin230 -layer metal3 -location {0 59.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin231 -layer metal3 -location {0 59.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin232 -layer metal3 -location {0 59.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin233 -layer metal3 -location {0 59.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin234 -layer metal3 -location {0 59.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin235 -layer metal3 -location {0 59.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin236 -layer metal3 -location {0 60.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin237 -layer metal3 -location {0 60.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin238 -layer metal3 -location {0 60.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin239 -layer metal3 -location {0 60.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin24 -layer metal3 -location {0 30.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin240 -layer metal3 -location {0 60.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin241 -layer metal3 -location {0 60.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin242 -layer metal3 -location {0 60.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin243 -layer metal3 -location {0 61.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin244 -layer metal3 -location {0 61.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin245 -layer metal3 -location {0 61.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin246 -layer metal3 -location {0 61.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin247 -layer metal3 -location {0 61.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin248 -layer metal3 -location {0 61.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin249 -layer metal3 -location {0 61.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin25 -layer metal3 -location {0 30.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin250 -layer metal3 -location {0 62.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin251 -layer metal3 -location {0 62.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin252 -layer metal3 -location {0 62.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin253 -layer metal3 -location {0 62.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin254 -layer metal3 -location {0 62.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin255 -layer metal3 -location {0 62.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin256 -layer metal3 -location {0 62.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin257 -layer metal3 -location {0 63.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin258 -layer metal3 -location {0 63.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin259 -layer metal3 -location {0 63.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin26 -layer metal3 -location {0 30.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin260 -layer metal3 -location {0 63.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin261 -layer metal3 -location {0 63.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin262 -layer metal3 -location {0 63.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin263 -layer metal3 -location {0 63.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin264 -layer metal3 -location {0 64.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin265 -layer metal3 -location {0 64.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin266 -layer metal3 -location {0 64.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin267 -layer metal3 -location {0 64.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin268 -layer metal3 -location {0 64.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin269 -layer metal3 -location {0 64.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin27 -layer metal3 -location {0 30.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin270 -layer metal3 -location {0 64.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin271 -layer metal3 -location {0 65.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin272 -layer metal3 -location {0 65.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin273 -layer metal3 -location {0 65.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin274 -layer metal3 -location {0 65.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin275 -layer metal3 -location {0 65.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin276 -layer metal3 -location {0 65.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin277 -layer metal3 -location {0 65.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin278 -layer metal3 -location {0 66.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin279 -layer metal3 -location {0 66.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin28 -layer metal3 -location {0 31.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin280 -layer metal3 -location {0 66.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin281 -layer metal3 -location {0 66.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin282 -layer metal3 -location {0 66.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin283 -layer metal3 -location {0 66.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin284 -layer metal3 -location {0 66.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin285 -layer metal3 -location {0 66.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin286 -layer metal3 -location {0 67.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin287 -layer metal3 -location {0 67.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin288 -layer metal3 -location {0 67.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin289 -layer metal3 -location {0 67.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin29 -layer metal3 -location {0 31.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin290 -layer metal3 -location {0 67.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin291 -layer metal3 -location {0 67.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin292 -layer metal3 -location {0 67.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin293 -layer metal3 -location {0 68.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin294 -layer metal3 -location {0 68.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin295 -layer metal3 -location {0 68.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin296 -layer metal3 -location {0 68.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin297 -layer metal3 -location {0 68.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin298 -layer metal3 -location {0 68.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin299 -layer metal3 -location {0 68.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin3 -layer metal3 -location {0 27.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin30 -layer metal3 -location {0 31.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin300 -layer metal3 -location {0 69.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin301 -layer metal3 -location {0 69.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin302 -layer metal3 -location {0 69.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin303 -layer metal3 -location {0 69.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin304 -layer metal3 -location {0 69.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin305 -layer metal3 -location {0 69.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin306 -layer metal3 -location {0 69.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin307 -layer metal3 -location {0 70.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin308 -layer metal3 -location {0 70.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin309 -layer metal3 -location {0 70.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin31 -layer metal3 -location {0 31.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin310 -layer metal3 -location {0 70.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin311 -layer metal3 -location {0 70.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin312 -layer metal3 -location {0 70.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin313 -layer metal3 -location {0 70.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin314 -layer metal3 -location {0 71.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin315 -layer metal3 -location {0 71.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin316 -layer metal3 -location {0 71.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin317 -layer metal3 -location {0 71.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin318 -layer metal3 -location {0 71.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin319 -layer metal3 -location {0 71.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin32 -layer metal3 -location {0 31.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin320 -layer metal3 -location {0 71.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin321 -layer metal3 -location {0 72.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin322 -layer metal3 -location {0 72.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin323 -layer metal3 -location {0 72.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin324 -layer metal3 -location {0 72.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin325 -layer metal3 -location {0 72.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin326 -layer metal3 -location {0 72.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin327 -layer metal3 -location {0 72.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin328 -layer metal3 -location {0 73.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin329 -layer metal3 -location {0 73.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin33 -layer metal3 -location {0 31.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin330 -layer metal3 -location {0 73.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin331 -layer metal3 -location {0 73.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin332 -layer metal3 -location {0 73.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin333 -layer metal3 -location {0 73.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin334 -layer metal3 -location {0 73.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin335 -layer metal3 -location {0 73.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin336 -layer metal3 -location {0 74.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin337 -layer metal3 -location {0 74.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin338 -layer metal3 -location {0 74.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin339 -layer metal3 -location {0 74.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin34 -layer metal3 -location {0 31.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin340 -layer metal3 -location {0 74.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin341 -layer metal3 -location {0 74.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin342 -layer metal3 -location {0 74.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin343 -layer metal3 -location {0 75.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin344 -layer metal3 -location {0 75.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin345 -layer metal3 -location {0 75.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin346 -layer metal3 -location {0 75.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin347 -layer metal3 -location {0 75.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin348 -layer metal3 -location {0 75.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin349 -layer metal3 -location {0 75.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin35 -layer metal3 -location {0 31.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin350 -layer metal3 -location {0 76.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin351 -layer metal3 -location {0 76.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin352 -layer metal3 -location {0 76.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin353 -layer metal3 -location {0 76.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin354 -layer metal3 -location {0 76.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin355 -layer metal3 -location {0 76.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin356 -layer metal3 -location {0 76.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin357 -layer metal3 -location {0 77.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin358 -layer metal3 -location {0 77.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin359 -layer metal3 -location {0 77.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin36 -layer metal3 -location {0 32.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin360 -layer metal3 -location {0 77.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin361 -layer metal3 -location {0 77.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin362 -layer metal3 -location {0 77.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin363 -layer metal3 -location {0 77.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin364 -layer metal3 -location {0 78.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin365 -layer metal3 -location {0 78.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin366 -layer metal3 -location {0 78.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin367 -layer metal3 -location {0 78.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin368 -layer metal3 -location {0 78.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin369 -layer metal3 -location {0 78.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin37 -layer metal3 -location {0 32.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin370 -layer metal3 -location {0 78.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin371 -layer metal3 -location {0 79.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin372 -layer metal3 -location {0 79.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin373 -layer metal3 -location {0 79.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin374 -layer metal3 -location {0 79.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin375 -layer metal3 -location {0 79.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin376 -layer metal3 -location {0 79.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin377 -layer metal3 -location {0 79.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin378 -layer metal3 -location {0 80.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin379 -layer metal3 -location {0 80.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin38 -layer metal3 -location {0 32.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin380 -layer metal3 -location {0 80.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin381 -layer metal3 -location {0 80.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin382 -layer metal3 -location {0 80.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin383 -layer metal3 -location {0 80.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin384 -layer metal3 -location {0 80.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin385 -layer metal3 -location {0 80.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin386 -layer metal3 -location {0 81.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin387 -layer metal3 -location {0 81.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin388 -layer metal3 -location {0 81.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin389 -layer metal3 -location {0 81.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin39 -layer metal3 -location {0 32.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin390 -layer metal3 -location {0 81.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin391 -layer metal3 -location {0 81.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin392 -layer metal3 -location {0 81.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin393 -layer metal3 -location {0 82.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin394 -layer metal3 -location {0 82.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin395 -layer metal3 -location {0 82.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin396 -layer metal3 -location {0 82.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin397 -layer metal3 -location {0 82.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin398 -layer metal3 -location {0 82.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin399 -layer metal3 -location {0 82.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin4 -layer metal3 -location {0 27.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin40 -layer metal3 -location {0 32.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin41 -layer metal3 -location {0 32.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin42 -layer metal3 -location {0 32.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin43 -layer metal3 -location {0 33.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin44 -layer metal3 -location {0 33.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin45 -layer metal3 -location {0 33.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin46 -layer metal3 -location {0 33.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin47 -layer metal3 -location {0 33.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin48 -layer metal3 -location {0 33.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin49 -layer metal3 -location {0 33.95} -force_to_die_boundary -placed_status
-place_pin -pin_name pin5 -layer metal3 -location {0 27.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin50 -layer metal3 -location {0 34.09} -force_to_die_boundary -placed_status
-place_pin -pin_name pin51 -layer metal3 -location {0 34.23} -force_to_die_boundary -placed_status
-place_pin -pin_name pin52 -layer metal3 -location {0 34.37} -force_to_die_boundary -placed_status
-place_pin -pin_name pin53 -layer metal3 -location {0 34.51} -force_to_die_boundary -placed_status
-place_pin -pin_name pin54 -layer metal3 -location {0 34.65} -force_to_die_boundary -placed_status
-place_pin -pin_name pin55 -layer metal3 -location {0 34.79} -force_to_die_boundary -placed_status
-place_pin -pin_name pin56 -layer metal3 -location {0 34.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin57 -layer metal3 -location {0 35.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin58 -layer metal3 -location {0 35.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin59 -layer metal3 -location {0 35.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin6 -layer metal3 -location {0 27.93} -force_to_die_boundary -placed_status
-place_pin -pin_name pin60 -layer metal3 -location {0 35.49} -force_to_die_boundary -placed_status
-place_pin -pin_name pin61 -layer metal3 -location {0 35.63} -force_to_die_boundary -placed_status
-place_pin -pin_name pin62 -layer metal3 -location {0 35.77} -force_to_die_boundary -placed_status
-place_pin -pin_name pin63 -layer metal3 -location {0 35.91} -force_to_die_boundary -placed_status
-place_pin -pin_name pin64 -layer metal3 -location {0 36.05} -force_to_die_boundary -placed_status
-place_pin -pin_name pin65 -layer metal3 -location {0 36.19} -force_to_die_boundary -placed_status
-place_pin -pin_name pin66 -layer metal3 -location {0 36.33} -force_to_die_boundary -placed_status
-place_pin -pin_name pin67 -layer metal3 -location {0 36.47} -force_to_die_boundary -placed_status
-place_pin -pin_name pin68 -layer metal3 -location {0 36.61} -force_to_die_boundary -placed_status
-place_pin -pin_name pin69 -layer metal3 -location {0 36.75} -force_to_die_boundary -placed_status
-place_pin -pin_name pin7 -layer metal3 -location {0 28.07} -force_to_die_boundary -placed_status
-place_pin -pin_name pin70 -layer metal3 -location {0 36.89} -force_to_die_boundary -placed_status
-place_pin -pin_name pin71 -layer metal3 -location {0 37.03} -force_to_die_boundary -placed_status
-place_pin -pin_name pin72 -layer metal3 -location {0 37.17} -force_to_die_boundary -placed_status
-place_pin -pin_name pin73 -layer metal3 -location {0 37.31} -force_to_die_boundary -placed_status
-place_pin -pin_name pin74 -layer metal3 -location {0 37.45} -force_to_die_boundary -placed_status
-place_pin -pin_name pin75 -layer metal3 -location {0 37.59} -force_to_die_boundary -placed_status
-place_pin -pin_name pin76 -layer metal3 -location {0 37.73} -force_to_die_boundary -placed_status
-place_pin -pin_name pin77 -layer metal3 -location {0 37.87} -force_to_die_boundary -placed_status
-place_pin -pin_name pin78 -layer metal3 -location {0 38.01} -force_to_die_boundary -placed_status
-place_pin -pin_name pin79 -layer metal3 -location {0 38.15} -force_to_die_boundary -placed_status
-place_pin -pin_name pin8 -layer metal3 -location {0 28.21} -force_to_die_boundary -placed_status
-place_pin -pin_name pin80 -layer metal3 -location {0 38.29} -force_to_die_boundary -placed_status
-place_pin -pin_name pin81 -layer metal3 -location {0 38.43} -force_to_die_boundary -placed_status
-place_pin -pin_name pin82 -layer metal3 -location {0 38.57} -force_to_die_boundary -placed_status
-place_pin -pin_name pin83 -layer metal3 -location {0 38.71} -force_to_die_boundary -placed_status
-place_pin -pin_name pin84 -layer metal3 -location {0 38.85} -force_to_die_boundary -placed_status
-place_pin -pin_name pin85 -layer metal3 -location {0 38.99} -force_to_die_boundary -placed_status
-place_pin -pin_name pin86 -layer metal3 -location {0 39.13} -force_to_die_boundary -placed_status
-place_pin -pin_name pin87 -layer metal3 -location {0 39.27} -force_to_die_boundary -placed_status
-place_pin -pin_name pin88 -layer metal3 -location {0 39.41} -force_to_die_boundary -placed_status
-place_pin -pin_name pin89 -layer metal3 -location {0 39.55} -force_to_die_boundary -placed_status
-place_pin -pin_name pin9 -layer metal3 -location {0 28.35} -force_to_die_boundary -placed_status
-place_pin -pin_name pin90 -layer metal3 -location {0 39.69} -force_to_die_boundary -placed_status
-place_pin -pin_name pin91 -layer metal3 -location {0 39.83} -force_to_die_boundary -placed_status
-place_pin -pin_name pin92 -layer metal3 -location {0 39.97} -force_to_die_boundary -placed_status
-place_pin -pin_name pin93 -layer metal3 -location {0 40.11} -force_to_die_boundary -placed_status
-place_pin -pin_name pin94 -layer metal3 -location {0 40.25} -force_to_die_boundary -placed_status
-place_pin -pin_name pin95 -layer metal3 -location {0 40.39} -force_to_die_boundary -placed_status
-place_pin -pin_name pin96 -layer metal3 -location {0 40.53} -force_to_die_boundary -placed_status
-place_pin -pin_name pin97 -layer metal3 -location {0 40.67} -force_to_die_boundary -placed_status
-place_pin -pin_name pin98 -layer metal3 -location {0 40.81} -force_to_die_boundary -placed_status
-place_pin -pin_name pin99 -layer metal3 -location {0 40.95} -force_to_die_boundary -placed_status
+place_pin -pin_name pin0 -layer metal3 -location {0 27.09} -force_to_die_boundary
+place_pin -pin_name pin1 -layer metal3 -location {0 27.23} -force_to_die_boundary
+place_pin -pin_name pin10 -layer metal3 -location {0 28.49} -force_to_die_boundary
+place_pin -pin_name pin100 -layer metal3 -location {0 41.09} -force_to_die_boundary
+place_pin -pin_name pin101 -layer metal3 -location {0 41.23} -force_to_die_boundary
+place_pin -pin_name pin102 -layer metal3 -location {0 41.37} -force_to_die_boundary
+place_pin -pin_name pin103 -layer metal3 -location {0 41.51} -force_to_die_boundary
+place_pin -pin_name pin104 -layer metal3 -location {0 41.65} -force_to_die_boundary
+place_pin -pin_name pin105 -layer metal3 -location {0 41.79} -force_to_die_boundary
+place_pin -pin_name pin106 -layer metal3 -location {0 41.93} -force_to_die_boundary
+place_pin -pin_name pin107 -layer metal3 -location {0 42.07} -force_to_die_boundary
+place_pin -pin_name pin108 -layer metal3 -location {0 42.21} -force_to_die_boundary
+place_pin -pin_name pin109 -layer metal3 -location {0 42.35} -force_to_die_boundary
+place_pin -pin_name pin11 -layer metal3 -location {0 28.63} -force_to_die_boundary
+place_pin -pin_name pin110 -layer metal3 -location {0 42.49} -force_to_die_boundary
+place_pin -pin_name pin111 -layer metal3 -location {0 42.63} -force_to_die_boundary
+place_pin -pin_name pin112 -layer metal3 -location {0 42.77} -force_to_die_boundary
+place_pin -pin_name pin113 -layer metal3 -location {0 42.91} -force_to_die_boundary
+place_pin -pin_name pin114 -layer metal3 -location {0 43.05} -force_to_die_boundary
+place_pin -pin_name pin115 -layer metal3 -location {0 43.19} -force_to_die_boundary
+place_pin -pin_name pin116 -layer metal3 -location {0 43.33} -force_to_die_boundary
+place_pin -pin_name pin117 -layer metal3 -location {0 43.47} -force_to_die_boundary
+place_pin -pin_name pin118 -layer metal3 -location {0 43.61} -force_to_die_boundary
+place_pin -pin_name pin119 -layer metal3 -location {0 43.75} -force_to_die_boundary
+place_pin -pin_name pin12 -layer metal3 -location {0 28.77} -force_to_die_boundary
+place_pin -pin_name pin120 -layer metal3 -location {0 43.89} -force_to_die_boundary
+place_pin -pin_name pin121 -layer metal3 -location {0 44.03} -force_to_die_boundary
+place_pin -pin_name pin122 -layer metal3 -location {0 44.17} -force_to_die_boundary
+place_pin -pin_name pin123 -layer metal3 -location {0 44.31} -force_to_die_boundary
+place_pin -pin_name pin124 -layer metal3 -location {0 44.45} -force_to_die_boundary
+place_pin -pin_name pin125 -layer metal3 -location {0 44.59} -force_to_die_boundary
+place_pin -pin_name pin126 -layer metal3 -location {0 44.73} -force_to_die_boundary
+place_pin -pin_name pin127 -layer metal3 -location {0 44.87} -force_to_die_boundary
+place_pin -pin_name pin128 -layer metal3 -location {0 45.01} -force_to_die_boundary
+place_pin -pin_name pin129 -layer metal3 -location {0 45.15} -force_to_die_boundary
+place_pin -pin_name pin13 -layer metal3 -location {0 28.91} -force_to_die_boundary
+place_pin -pin_name pin130 -layer metal3 -location {0 45.29} -force_to_die_boundary
+place_pin -pin_name pin131 -layer metal3 -location {0 45.43} -force_to_die_boundary
+place_pin -pin_name pin132 -layer metal3 -location {0 45.57} -force_to_die_boundary
+place_pin -pin_name pin133 -layer metal3 -location {0 45.71} -force_to_die_boundary
+place_pin -pin_name pin134 -layer metal3 -location {0 45.85} -force_to_die_boundary
+place_pin -pin_name pin135 -layer metal3 -location {0 45.99} -force_to_die_boundary
+place_pin -pin_name pin136 -layer metal3 -location {0 46.13} -force_to_die_boundary
+place_pin -pin_name pin137 -layer metal3 -location {0 46.27} -force_to_die_boundary
+place_pin -pin_name pin138 -layer metal3 -location {0 46.41} -force_to_die_boundary
+place_pin -pin_name pin139 -layer metal3 -location {0 46.55} -force_to_die_boundary
+place_pin -pin_name pin14 -layer metal3 -location {0 29.05} -force_to_die_boundary
+place_pin -pin_name pin140 -layer metal3 -location {0 46.69} -force_to_die_boundary
+place_pin -pin_name pin141 -layer metal3 -location {0 46.83} -force_to_die_boundary
+place_pin -pin_name pin142 -layer metal3 -location {0 46.97} -force_to_die_boundary
+place_pin -pin_name pin143 -layer metal3 -location {0 47.11} -force_to_die_boundary
+place_pin -pin_name pin144 -layer metal3 -location {0 47.25} -force_to_die_boundary
+place_pin -pin_name pin145 -layer metal3 -location {0 47.39} -force_to_die_boundary
+place_pin -pin_name pin146 -layer metal3 -location {0 47.53} -force_to_die_boundary
+place_pin -pin_name pin147 -layer metal3 -location {0 47.67} -force_to_die_boundary
+place_pin -pin_name pin148 -layer metal3 -location {0 47.81} -force_to_die_boundary
+place_pin -pin_name pin149 -layer metal3 -location {0 47.95} -force_to_die_boundary
+place_pin -pin_name pin15 -layer metal3 -location {0 29.19} -force_to_die_boundary
+place_pin -pin_name pin150 -layer metal3 -location {0 48.09} -force_to_die_boundary
+place_pin -pin_name pin151 -layer metal3 -location {0 48.23} -force_to_die_boundary
+place_pin -pin_name pin152 -layer metal3 -location {0 48.37} -force_to_die_boundary
+place_pin -pin_name pin153 -layer metal3 -location {0 48.51} -force_to_die_boundary
+place_pin -pin_name pin154 -layer metal3 -location {0 48.65} -force_to_die_boundary
+place_pin -pin_name pin155 -layer metal3 -location {0 48.79} -force_to_die_boundary
+place_pin -pin_name pin156 -layer metal3 -location {0 48.93} -force_to_die_boundary
+place_pin -pin_name pin157 -layer metal3 -location {0 49.07} -force_to_die_boundary
+place_pin -pin_name pin158 -layer metal3 -location {0 49.21} -force_to_die_boundary
+place_pin -pin_name pin159 -layer metal3 -location {0 49.35} -force_to_die_boundary
+place_pin -pin_name pin16 -layer metal3 -location {0 29.33} -force_to_die_boundary
+place_pin -pin_name pin160 -layer metal3 -location {0 49.49} -force_to_die_boundary
+place_pin -pin_name pin161 -layer metal3 -location {0 49.63} -force_to_die_boundary
+place_pin -pin_name pin162 -layer metal3 -location {0 49.77} -force_to_die_boundary
+place_pin -pin_name pin163 -layer metal3 -location {0 49.91} -force_to_die_boundary
+place_pin -pin_name pin164 -layer metal3 -location {0 50.05} -force_to_die_boundary
+place_pin -pin_name pin165 -layer metal3 -location {0 50.19} -force_to_die_boundary
+place_pin -pin_name pin166 -layer metal3 -location {0 50.33} -force_to_die_boundary
+place_pin -pin_name pin167 -layer metal3 -location {0 50.47} -force_to_die_boundary
+place_pin -pin_name pin168 -layer metal3 -location {0 50.61} -force_to_die_boundary
+place_pin -pin_name pin169 -layer metal3 -location {0 50.75} -force_to_die_boundary
+place_pin -pin_name pin17 -layer metal3 -location {0 29.47} -force_to_die_boundary
+place_pin -pin_name pin170 -layer metal3 -location {0 50.89} -force_to_die_boundary
+place_pin -pin_name pin171 -layer metal3 -location {0 51.03} -force_to_die_boundary
+place_pin -pin_name pin172 -layer metal3 -location {0 51.17} -force_to_die_boundary
+place_pin -pin_name pin173 -layer metal3 -location {0 51.31} -force_to_die_boundary
+place_pin -pin_name pin174 -layer metal3 -location {0 51.45} -force_to_die_boundary
+place_pin -pin_name pin175 -layer metal3 -location {0 51.59} -force_to_die_boundary
+place_pin -pin_name pin176 -layer metal3 -location {0 51.73} -force_to_die_boundary
+place_pin -pin_name pin177 -layer metal3 -location {0 51.87} -force_to_die_boundary
+place_pin -pin_name pin178 -layer metal3 -location {0 52.01} -force_to_die_boundary
+place_pin -pin_name pin179 -layer metal3 -location {0 52.15} -force_to_die_boundary
+place_pin -pin_name pin18 -layer metal3 -location {0 29.61} -force_to_die_boundary
+place_pin -pin_name pin180 -layer metal3 -location {0 52.29} -force_to_die_boundary
+place_pin -pin_name pin181 -layer metal3 -location {0 52.43} -force_to_die_boundary
+place_pin -pin_name pin182 -layer metal3 -location {0 52.57} -force_to_die_boundary
+place_pin -pin_name pin183 -layer metal3 -location {0 52.71} -force_to_die_boundary
+place_pin -pin_name pin184 -layer metal3 -location {0 52.85} -force_to_die_boundary
+place_pin -pin_name pin185 -layer metal3 -location {0 52.99} -force_to_die_boundary
+place_pin -pin_name pin186 -layer metal3 -location {0 53.13} -force_to_die_boundary
+place_pin -pin_name pin187 -layer metal3 -location {0 53.27} -force_to_die_boundary
+place_pin -pin_name pin188 -layer metal3 -location {0 53.41} -force_to_die_boundary
+place_pin -pin_name pin189 -layer metal3 -location {0 53.55} -force_to_die_boundary
+place_pin -pin_name pin19 -layer metal3 -location {0 29.75} -force_to_die_boundary
+place_pin -pin_name pin190 -layer metal3 -location {0 53.69} -force_to_die_boundary
+place_pin -pin_name pin191 -layer metal3 -location {0 53.83} -force_to_die_boundary
+place_pin -pin_name pin192 -layer metal3 -location {0 53.97} -force_to_die_boundary
+place_pin -pin_name pin193 -layer metal3 -location {0 54.11} -force_to_die_boundary
+place_pin -pin_name pin194 -layer metal3 -location {0 54.25} -force_to_die_boundary
+place_pin -pin_name pin195 -layer metal3 -location {0 54.39} -force_to_die_boundary
+place_pin -pin_name pin196 -layer metal3 -location {0 54.53} -force_to_die_boundary
+place_pin -pin_name pin197 -layer metal3 -location {0 54.67} -force_to_die_boundary
+place_pin -pin_name pin198 -layer metal3 -location {0 54.81} -force_to_die_boundary
+place_pin -pin_name pin199 -layer metal3 -location {0 54.95} -force_to_die_boundary
+place_pin -pin_name pin2 -layer metal3 -location {0 27.37} -force_to_die_boundary
+place_pin -pin_name pin20 -layer metal3 -location {0 29.89} -force_to_die_boundary
+place_pin -pin_name pin200 -layer metal3 -location {0 55.09} -force_to_die_boundary
+place_pin -pin_name pin201 -layer metal3 -location {0 55.23} -force_to_die_boundary
+place_pin -pin_name pin202 -layer metal3 -location {0 55.37} -force_to_die_boundary
+place_pin -pin_name pin203 -layer metal3 -location {0 55.51} -force_to_die_boundary
+place_pin -pin_name pin204 -layer metal3 -location {0 55.65} -force_to_die_boundary
+place_pin -pin_name pin205 -layer metal3 -location {0 55.79} -force_to_die_boundary
+place_pin -pin_name pin206 -layer metal3 -location {0 55.93} -force_to_die_boundary
+place_pin -pin_name pin207 -layer metal3 -location {0 56.07} -force_to_die_boundary
+place_pin -pin_name pin208 -layer metal3 -location {0 56.21} -force_to_die_boundary
+place_pin -pin_name pin209 -layer metal3 -location {0 56.35} -force_to_die_boundary
+place_pin -pin_name pin21 -layer metal3 -location {0 30.03} -force_to_die_boundary
+place_pin -pin_name pin210 -layer metal3 -location {0 56.49} -force_to_die_boundary
+place_pin -pin_name pin211 -layer metal3 -location {0 56.63} -force_to_die_boundary
+place_pin -pin_name pin212 -layer metal3 -location {0 56.77} -force_to_die_boundary
+place_pin -pin_name pin213 -layer metal3 -location {0 56.91} -force_to_die_boundary
+place_pin -pin_name pin214 -layer metal3 -location {0 57.05} -force_to_die_boundary
+place_pin -pin_name pin215 -layer metal3 -location {0 57.19} -force_to_die_boundary
+place_pin -pin_name pin216 -layer metal3 -location {0 57.33} -force_to_die_boundary
+place_pin -pin_name pin217 -layer metal3 -location {0 57.47} -force_to_die_boundary
+place_pin -pin_name pin218 -layer metal3 -location {0 57.61} -force_to_die_boundary
+place_pin -pin_name pin219 -layer metal3 -location {0 57.75} -force_to_die_boundary
+place_pin -pin_name pin22 -layer metal3 -location {0 30.17} -force_to_die_boundary
+place_pin -pin_name pin220 -layer metal3 -location {0 57.89} -force_to_die_boundary
+place_pin -pin_name pin221 -layer metal3 -location {0 58.03} -force_to_die_boundary
+place_pin -pin_name pin222 -layer metal3 -location {0 58.17} -force_to_die_boundary
+place_pin -pin_name pin223 -layer metal3 -location {0 58.31} -force_to_die_boundary
+place_pin -pin_name pin224 -layer metal3 -location {0 58.45} -force_to_die_boundary
+place_pin -pin_name pin225 -layer metal3 -location {0 58.59} -force_to_die_boundary
+place_pin -pin_name pin226 -layer metal3 -location {0 58.73} -force_to_die_boundary
+place_pin -pin_name pin227 -layer metal3 -location {0 58.87} -force_to_die_boundary
+place_pin -pin_name pin228 -layer metal3 -location {0 59.01} -force_to_die_boundary
+place_pin -pin_name pin229 -layer metal3 -location {0 59.15} -force_to_die_boundary
+place_pin -pin_name pin23 -layer metal3 -location {0 30.31} -force_to_die_boundary
+place_pin -pin_name pin230 -layer metal3 -location {0 59.29} -force_to_die_boundary
+place_pin -pin_name pin231 -layer metal3 -location {0 59.43} -force_to_die_boundary
+place_pin -pin_name pin232 -layer metal3 -location {0 59.57} -force_to_die_boundary
+place_pin -pin_name pin233 -layer metal3 -location {0 59.71} -force_to_die_boundary
+place_pin -pin_name pin234 -layer metal3 -location {0 59.85} -force_to_die_boundary
+place_pin -pin_name pin235 -layer metal3 -location {0 59.99} -force_to_die_boundary
+place_pin -pin_name pin236 -layer metal3 -location {0 60.13} -force_to_die_boundary
+place_pin -pin_name pin237 -layer metal3 -location {0 60.27} -force_to_die_boundary
+place_pin -pin_name pin238 -layer metal3 -location {0 60.41} -force_to_die_boundary
+place_pin -pin_name pin239 -layer metal3 -location {0 60.55} -force_to_die_boundary
+place_pin -pin_name pin24 -layer metal3 -location {0 30.45} -force_to_die_boundary
+place_pin -pin_name pin240 -layer metal3 -location {0 60.69} -force_to_die_boundary
+place_pin -pin_name pin241 -layer metal3 -location {0 60.83} -force_to_die_boundary
+place_pin -pin_name pin242 -layer metal3 -location {0 60.97} -force_to_die_boundary
+place_pin -pin_name pin243 -layer metal3 -location {0 61.11} -force_to_die_boundary
+place_pin -pin_name pin244 -layer metal3 -location {0 61.25} -force_to_die_boundary
+place_pin -pin_name pin245 -layer metal3 -location {0 61.39} -force_to_die_boundary
+place_pin -pin_name pin246 -layer metal3 -location {0 61.53} -force_to_die_boundary
+place_pin -pin_name pin247 -layer metal3 -location {0 61.67} -force_to_die_boundary
+place_pin -pin_name pin248 -layer metal3 -location {0 61.81} -force_to_die_boundary
+place_pin -pin_name pin249 -layer metal3 -location {0 61.95} -force_to_die_boundary
+place_pin -pin_name pin25 -layer metal3 -location {0 30.59} -force_to_die_boundary
+place_pin -pin_name pin250 -layer metal3 -location {0 62.09} -force_to_die_boundary
+place_pin -pin_name pin251 -layer metal3 -location {0 62.23} -force_to_die_boundary
+place_pin -pin_name pin252 -layer metal3 -location {0 62.37} -force_to_die_boundary
+place_pin -pin_name pin253 -layer metal3 -location {0 62.51} -force_to_die_boundary
+place_pin -pin_name pin254 -layer metal3 -location {0 62.65} -force_to_die_boundary
+place_pin -pin_name pin255 -layer metal3 -location {0 62.79} -force_to_die_boundary
+place_pin -pin_name pin256 -layer metal3 -location {0 62.93} -force_to_die_boundary
+place_pin -pin_name pin257 -layer metal3 -location {0 63.07} -force_to_die_boundary
+place_pin -pin_name pin258 -layer metal3 -location {0 63.21} -force_to_die_boundary
+place_pin -pin_name pin259 -layer metal3 -location {0 63.35} -force_to_die_boundary
+place_pin -pin_name pin26 -layer metal3 -location {0 30.73} -force_to_die_boundary
+place_pin -pin_name pin260 -layer metal3 -location {0 63.49} -force_to_die_boundary
+place_pin -pin_name pin261 -layer metal3 -location {0 63.63} -force_to_die_boundary
+place_pin -pin_name pin262 -layer metal3 -location {0 63.77} -force_to_die_boundary
+place_pin -pin_name pin263 -layer metal3 -location {0 63.91} -force_to_die_boundary
+place_pin -pin_name pin264 -layer metal3 -location {0 64.05} -force_to_die_boundary
+place_pin -pin_name pin265 -layer metal3 -location {0 64.19} -force_to_die_boundary
+place_pin -pin_name pin266 -layer metal3 -location {0 64.33} -force_to_die_boundary
+place_pin -pin_name pin267 -layer metal3 -location {0 64.47} -force_to_die_boundary
+place_pin -pin_name pin268 -layer metal3 -location {0 64.61} -force_to_die_boundary
+place_pin -pin_name pin269 -layer metal3 -location {0 64.75} -force_to_die_boundary
+place_pin -pin_name pin27 -layer metal3 -location {0 30.87} -force_to_die_boundary
+place_pin -pin_name pin270 -layer metal3 -location {0 64.89} -force_to_die_boundary
+place_pin -pin_name pin271 -layer metal3 -location {0 65.03} -force_to_die_boundary
+place_pin -pin_name pin272 -layer metal3 -location {0 65.17} -force_to_die_boundary
+place_pin -pin_name pin273 -layer metal3 -location {0 65.31} -force_to_die_boundary
+place_pin -pin_name pin274 -layer metal3 -location {0 65.45} -force_to_die_boundary
+place_pin -pin_name pin275 -layer metal3 -location {0 65.59} -force_to_die_boundary
+place_pin -pin_name pin276 -layer metal3 -location {0 65.73} -force_to_die_boundary
+place_pin -pin_name pin277 -layer metal3 -location {0 65.87} -force_to_die_boundary
+place_pin -pin_name pin278 -layer metal3 -location {0 66.01} -force_to_die_boundary
+place_pin -pin_name pin279 -layer metal3 -location {0 66.15} -force_to_die_boundary
+place_pin -pin_name pin28 -layer metal3 -location {0 31.01} -force_to_die_boundary
+place_pin -pin_name pin280 -layer metal3 -location {0 66.29} -force_to_die_boundary
+place_pin -pin_name pin281 -layer metal3 -location {0 66.43} -force_to_die_boundary
+place_pin -pin_name pin282 -layer metal3 -location {0 66.57} -force_to_die_boundary
+place_pin -pin_name pin283 -layer metal3 -location {0 66.71} -force_to_die_boundary
+place_pin -pin_name pin284 -layer metal3 -location {0 66.85} -force_to_die_boundary
+place_pin -pin_name pin285 -layer metal3 -location {0 66.99} -force_to_die_boundary
+place_pin -pin_name pin286 -layer metal3 -location {0 67.13} -force_to_die_boundary
+place_pin -pin_name pin287 -layer metal3 -location {0 67.27} -force_to_die_boundary
+place_pin -pin_name pin288 -layer metal3 -location {0 67.41} -force_to_die_boundary
+place_pin -pin_name pin289 -layer metal3 -location {0 67.55} -force_to_die_boundary
+place_pin -pin_name pin29 -layer metal3 -location {0 31.15} -force_to_die_boundary
+place_pin -pin_name pin290 -layer metal3 -location {0 67.69} -force_to_die_boundary
+place_pin -pin_name pin291 -layer metal3 -location {0 67.83} -force_to_die_boundary
+place_pin -pin_name pin292 -layer metal3 -location {0 67.97} -force_to_die_boundary
+place_pin -pin_name pin293 -layer metal3 -location {0 68.11} -force_to_die_boundary
+place_pin -pin_name pin294 -layer metal3 -location {0 68.25} -force_to_die_boundary
+place_pin -pin_name pin295 -layer metal3 -location {0 68.39} -force_to_die_boundary
+place_pin -pin_name pin296 -layer metal3 -location {0 68.53} -force_to_die_boundary
+place_pin -pin_name pin297 -layer metal3 -location {0 68.67} -force_to_die_boundary
+place_pin -pin_name pin298 -layer metal3 -location {0 68.81} -force_to_die_boundary
+place_pin -pin_name pin299 -layer metal3 -location {0 68.95} -force_to_die_boundary
+place_pin -pin_name pin3 -layer metal3 -location {0 27.51} -force_to_die_boundary
+place_pin -pin_name pin30 -layer metal3 -location {0 31.29} -force_to_die_boundary
+place_pin -pin_name pin300 -layer metal3 -location {0 69.09} -force_to_die_boundary
+place_pin -pin_name pin301 -layer metal3 -location {0 69.23} -force_to_die_boundary
+place_pin -pin_name pin302 -layer metal3 -location {0 69.37} -force_to_die_boundary
+place_pin -pin_name pin303 -layer metal3 -location {0 69.51} -force_to_die_boundary
+place_pin -pin_name pin304 -layer metal3 -location {0 69.65} -force_to_die_boundary
+place_pin -pin_name pin305 -layer metal3 -location {0 69.79} -force_to_die_boundary
+place_pin -pin_name pin306 -layer metal3 -location {0 69.93} -force_to_die_boundary
+place_pin -pin_name pin307 -layer metal3 -location {0 70.07} -force_to_die_boundary
+place_pin -pin_name pin308 -layer metal3 -location {0 70.21} -force_to_die_boundary
+place_pin -pin_name pin309 -layer metal3 -location {0 70.35} -force_to_die_boundary
+place_pin -pin_name pin31 -layer metal3 -location {0 31.43} -force_to_die_boundary
+place_pin -pin_name pin310 -layer metal3 -location {0 70.49} -force_to_die_boundary
+place_pin -pin_name pin311 -layer metal3 -location {0 70.63} -force_to_die_boundary
+place_pin -pin_name pin312 -layer metal3 -location {0 70.77} -force_to_die_boundary
+place_pin -pin_name pin313 -layer metal3 -location {0 70.91} -force_to_die_boundary
+place_pin -pin_name pin314 -layer metal3 -location {0 71.05} -force_to_die_boundary
+place_pin -pin_name pin315 -layer metal3 -location {0 71.19} -force_to_die_boundary
+place_pin -pin_name pin316 -layer metal3 -location {0 71.33} -force_to_die_boundary
+place_pin -pin_name pin317 -layer metal3 -location {0 71.47} -force_to_die_boundary
+place_pin -pin_name pin318 -layer metal3 -location {0 71.61} -force_to_die_boundary
+place_pin -pin_name pin319 -layer metal3 -location {0 71.75} -force_to_die_boundary
+place_pin -pin_name pin32 -layer metal3 -location {0 31.57} -force_to_die_boundary
+place_pin -pin_name pin320 -layer metal3 -location {0 71.89} -force_to_die_boundary
+place_pin -pin_name pin321 -layer metal3 -location {0 72.03} -force_to_die_boundary
+place_pin -pin_name pin322 -layer metal3 -location {0 72.17} -force_to_die_boundary
+place_pin -pin_name pin323 -layer metal3 -location {0 72.31} -force_to_die_boundary
+place_pin -pin_name pin324 -layer metal3 -location {0 72.45} -force_to_die_boundary
+place_pin -pin_name pin325 -layer metal3 -location {0 72.59} -force_to_die_boundary
+place_pin -pin_name pin326 -layer metal3 -location {0 72.73} -force_to_die_boundary
+place_pin -pin_name pin327 -layer metal3 -location {0 72.87} -force_to_die_boundary
+place_pin -pin_name pin328 -layer metal3 -location {0 73.01} -force_to_die_boundary
+place_pin -pin_name pin329 -layer metal3 -location {0 73.15} -force_to_die_boundary
+place_pin -pin_name pin33 -layer metal3 -location {0 31.71} -force_to_die_boundary
+place_pin -pin_name pin330 -layer metal3 -location {0 73.29} -force_to_die_boundary
+place_pin -pin_name pin331 -layer metal3 -location {0 73.43} -force_to_die_boundary
+place_pin -pin_name pin332 -layer metal3 -location {0 73.57} -force_to_die_boundary
+place_pin -pin_name pin333 -layer metal3 -location {0 73.71} -force_to_die_boundary
+place_pin -pin_name pin334 -layer metal3 -location {0 73.85} -force_to_die_boundary
+place_pin -pin_name pin335 -layer metal3 -location {0 73.99} -force_to_die_boundary
+place_pin -pin_name pin336 -layer metal3 -location {0 74.13} -force_to_die_boundary
+place_pin -pin_name pin337 -layer metal3 -location {0 74.27} -force_to_die_boundary
+place_pin -pin_name pin338 -layer metal3 -location {0 74.41} -force_to_die_boundary
+place_pin -pin_name pin339 -layer metal3 -location {0 74.55} -force_to_die_boundary
+place_pin -pin_name pin34 -layer metal3 -location {0 31.85} -force_to_die_boundary
+place_pin -pin_name pin340 -layer metal3 -location {0 74.69} -force_to_die_boundary
+place_pin -pin_name pin341 -layer metal3 -location {0 74.83} -force_to_die_boundary
+place_pin -pin_name pin342 -layer metal3 -location {0 74.97} -force_to_die_boundary
+place_pin -pin_name pin343 -layer metal3 -location {0 75.11} -force_to_die_boundary
+place_pin -pin_name pin344 -layer metal3 -location {0 75.25} -force_to_die_boundary
+place_pin -pin_name pin345 -layer metal3 -location {0 75.39} -force_to_die_boundary
+place_pin -pin_name pin346 -layer metal3 -location {0 75.53} -force_to_die_boundary
+place_pin -pin_name pin347 -layer metal3 -location {0 75.67} -force_to_die_boundary
+place_pin -pin_name pin348 -layer metal3 -location {0 75.81} -force_to_die_boundary
+place_pin -pin_name pin349 -layer metal3 -location {0 75.95} -force_to_die_boundary
+place_pin -pin_name pin35 -layer metal3 -location {0 31.99} -force_to_die_boundary
+place_pin -pin_name pin350 -layer metal3 -location {0 76.09} -force_to_die_boundary
+place_pin -pin_name pin351 -layer metal3 -location {0 76.23} -force_to_die_boundary
+place_pin -pin_name pin352 -layer metal3 -location {0 76.37} -force_to_die_boundary
+place_pin -pin_name pin353 -layer metal3 -location {0 76.51} -force_to_die_boundary
+place_pin -pin_name pin354 -layer metal3 -location {0 76.65} -force_to_die_boundary
+place_pin -pin_name pin355 -layer metal3 -location {0 76.79} -force_to_die_boundary
+place_pin -pin_name pin356 -layer metal3 -location {0 76.93} -force_to_die_boundary
+place_pin -pin_name pin357 -layer metal3 -location {0 77.07} -force_to_die_boundary
+place_pin -pin_name pin358 -layer metal3 -location {0 77.21} -force_to_die_boundary
+place_pin -pin_name pin359 -layer metal3 -location {0 77.35} -force_to_die_boundary
+place_pin -pin_name pin36 -layer metal3 -location {0 32.13} -force_to_die_boundary
+place_pin -pin_name pin360 -layer metal3 -location {0 77.49} -force_to_die_boundary
+place_pin -pin_name pin361 -layer metal3 -location {0 77.63} -force_to_die_boundary
+place_pin -pin_name pin362 -layer metal3 -location {0 77.77} -force_to_die_boundary
+place_pin -pin_name pin363 -layer metal3 -location {0 77.91} -force_to_die_boundary
+place_pin -pin_name pin364 -layer metal3 -location {0 78.05} -force_to_die_boundary
+place_pin -pin_name pin365 -layer metal3 -location {0 78.19} -force_to_die_boundary
+place_pin -pin_name pin366 -layer metal3 -location {0 78.33} -force_to_die_boundary
+place_pin -pin_name pin367 -layer metal3 -location {0 78.47} -force_to_die_boundary
+place_pin -pin_name pin368 -layer metal3 -location {0 78.61} -force_to_die_boundary
+place_pin -pin_name pin369 -layer metal3 -location {0 78.75} -force_to_die_boundary
+place_pin -pin_name pin37 -layer metal3 -location {0 32.27} -force_to_die_boundary
+place_pin -pin_name pin370 -layer metal3 -location {0 78.89} -force_to_die_boundary
+place_pin -pin_name pin371 -layer metal3 -location {0 79.03} -force_to_die_boundary
+place_pin -pin_name pin372 -layer metal3 -location {0 79.17} -force_to_die_boundary
+place_pin -pin_name pin373 -layer metal3 -location {0 79.31} -force_to_die_boundary
+place_pin -pin_name pin374 -layer metal3 -location {0 79.45} -force_to_die_boundary
+place_pin -pin_name pin375 -layer metal3 -location {0 79.59} -force_to_die_boundary
+place_pin -pin_name pin376 -layer metal3 -location {0 79.73} -force_to_die_boundary
+place_pin -pin_name pin377 -layer metal3 -location {0 79.87} -force_to_die_boundary
+place_pin -pin_name pin378 -layer metal3 -location {0 80.01} -force_to_die_boundary
+place_pin -pin_name pin379 -layer metal3 -location {0 80.15} -force_to_die_boundary
+place_pin -pin_name pin38 -layer metal3 -location {0 32.41} -force_to_die_boundary
+place_pin -pin_name pin380 -layer metal3 -location {0 80.29} -force_to_die_boundary
+place_pin -pin_name pin381 -layer metal3 -location {0 80.43} -force_to_die_boundary
+place_pin -pin_name pin382 -layer metal3 -location {0 80.57} -force_to_die_boundary
+place_pin -pin_name pin383 -layer metal3 -location {0 80.71} -force_to_die_boundary
+place_pin -pin_name pin384 -layer metal3 -location {0 80.85} -force_to_die_boundary
+place_pin -pin_name pin385 -layer metal3 -location {0 80.99} -force_to_die_boundary
+place_pin -pin_name pin386 -layer metal3 -location {0 81.13} -force_to_die_boundary
+place_pin -pin_name pin387 -layer metal3 -location {0 81.27} -force_to_die_boundary
+place_pin -pin_name pin388 -layer metal3 -location {0 81.41} -force_to_die_boundary
+place_pin -pin_name pin389 -layer metal3 -location {0 81.55} -force_to_die_boundary
+place_pin -pin_name pin39 -layer metal3 -location {0 32.55} -force_to_die_boundary
+place_pin -pin_name pin390 -layer metal3 -location {0 81.69} -force_to_die_boundary
+place_pin -pin_name pin391 -layer metal3 -location {0 81.83} -force_to_die_boundary
+place_pin -pin_name pin392 -layer metal3 -location {0 81.97} -force_to_die_boundary
+place_pin -pin_name pin393 -layer metal3 -location {0 82.11} -force_to_die_boundary
+place_pin -pin_name pin394 -layer metal3 -location {0 82.25} -force_to_die_boundary
+place_pin -pin_name pin395 -layer metal3 -location {0 82.39} -force_to_die_boundary
+place_pin -pin_name pin396 -layer metal3 -location {0 82.53} -force_to_die_boundary
+place_pin -pin_name pin397 -layer metal3 -location {0 82.67} -force_to_die_boundary
+place_pin -pin_name pin398 -layer metal3 -location {0 82.81} -force_to_die_boundary
+place_pin -pin_name pin399 -layer metal3 -location {0 82.95} -force_to_die_boundary
+place_pin -pin_name pin4 -layer metal3 -location {0 27.65} -force_to_die_boundary
+place_pin -pin_name pin40 -layer metal3 -location {0 32.69} -force_to_die_boundary
+place_pin -pin_name pin41 -layer metal3 -location {0 32.83} -force_to_die_boundary
+place_pin -pin_name pin42 -layer metal3 -location {0 32.97} -force_to_die_boundary
+place_pin -pin_name pin43 -layer metal3 -location {0 33.11} -force_to_die_boundary
+place_pin -pin_name pin44 -layer metal3 -location {0 33.25} -force_to_die_boundary
+place_pin -pin_name pin45 -layer metal3 -location {0 33.39} -force_to_die_boundary
+place_pin -pin_name pin46 -layer metal3 -location {0 33.53} -force_to_die_boundary
+place_pin -pin_name pin47 -layer metal3 -location {0 33.67} -force_to_die_boundary
+place_pin -pin_name pin48 -layer metal3 -location {0 33.81} -force_to_die_boundary
+place_pin -pin_name pin49 -layer metal3 -location {0 33.95} -force_to_die_boundary
+place_pin -pin_name pin5 -layer metal3 -location {0 27.79} -force_to_die_boundary
+place_pin -pin_name pin50 -layer metal3 -location {0 34.09} -force_to_die_boundary
+place_pin -pin_name pin51 -layer metal3 -location {0 34.23} -force_to_die_boundary
+place_pin -pin_name pin52 -layer metal3 -location {0 34.37} -force_to_die_boundary
+place_pin -pin_name pin53 -layer metal3 -location {0 34.51} -force_to_die_boundary
+place_pin -pin_name pin54 -layer metal3 -location {0 34.65} -force_to_die_boundary
+place_pin -pin_name pin55 -layer metal3 -location {0 34.79} -force_to_die_boundary
+place_pin -pin_name pin56 -layer metal3 -location {0 34.93} -force_to_die_boundary
+place_pin -pin_name pin57 -layer metal3 -location {0 35.07} -force_to_die_boundary
+place_pin -pin_name pin58 -layer metal3 -location {0 35.21} -force_to_die_boundary
+place_pin -pin_name pin59 -layer metal3 -location {0 35.35} -force_to_die_boundary
+place_pin -pin_name pin6 -layer metal3 -location {0 27.93} -force_to_die_boundary
+place_pin -pin_name pin60 -layer metal3 -location {0 35.49} -force_to_die_boundary
+place_pin -pin_name pin61 -layer metal3 -location {0 35.63} -force_to_die_boundary
+place_pin -pin_name pin62 -layer metal3 -location {0 35.77} -force_to_die_boundary
+place_pin -pin_name pin63 -layer metal3 -location {0 35.91} -force_to_die_boundary
+place_pin -pin_name pin64 -layer metal3 -location {0 36.05} -force_to_die_boundary
+place_pin -pin_name pin65 -layer metal3 -location {0 36.19} -force_to_die_boundary
+place_pin -pin_name pin66 -layer metal3 -location {0 36.33} -force_to_die_boundary
+place_pin -pin_name pin67 -layer metal3 -location {0 36.47} -force_to_die_boundary
+place_pin -pin_name pin68 -layer metal3 -location {0 36.61} -force_to_die_boundary
+place_pin -pin_name pin69 -layer metal3 -location {0 36.75} -force_to_die_boundary
+place_pin -pin_name pin7 -layer metal3 -location {0 28.07} -force_to_die_boundary
+place_pin -pin_name pin70 -layer metal3 -location {0 36.89} -force_to_die_boundary
+place_pin -pin_name pin71 -layer metal3 -location {0 37.03} -force_to_die_boundary
+place_pin -pin_name pin72 -layer metal3 -location {0 37.17} -force_to_die_boundary
+place_pin -pin_name pin73 -layer metal3 -location {0 37.31} -force_to_die_boundary
+place_pin -pin_name pin74 -layer metal3 -location {0 37.45} -force_to_die_boundary
+place_pin -pin_name pin75 -layer metal3 -location {0 37.59} -force_to_die_boundary
+place_pin -pin_name pin76 -layer metal3 -location {0 37.73} -force_to_die_boundary
+place_pin -pin_name pin77 -layer metal3 -location {0 37.87} -force_to_die_boundary
+place_pin -pin_name pin78 -layer metal3 -location {0 38.01} -force_to_die_boundary
+place_pin -pin_name pin79 -layer metal3 -location {0 38.15} -force_to_die_boundary
+place_pin -pin_name pin8 -layer metal3 -location {0 28.21} -force_to_die_boundary
+place_pin -pin_name pin80 -layer metal3 -location {0 38.29} -force_to_die_boundary
+place_pin -pin_name pin81 -layer metal3 -location {0 38.43} -force_to_die_boundary
+place_pin -pin_name pin82 -layer metal3 -location {0 38.57} -force_to_die_boundary
+place_pin -pin_name pin83 -layer metal3 -location {0 38.71} -force_to_die_boundary
+place_pin -pin_name pin84 -layer metal3 -location {0 38.85} -force_to_die_boundary
+place_pin -pin_name pin85 -layer metal3 -location {0 38.99} -force_to_die_boundary
+place_pin -pin_name pin86 -layer metal3 -location {0 39.13} -force_to_die_boundary
+place_pin -pin_name pin87 -layer metal3 -location {0 39.27} -force_to_die_boundary
+place_pin -pin_name pin88 -layer metal3 -location {0 39.41} -force_to_die_boundary
+place_pin -pin_name pin89 -layer metal3 -location {0 39.55} -force_to_die_boundary
+place_pin -pin_name pin9 -layer metal3 -location {0 28.35} -force_to_die_boundary
+place_pin -pin_name pin90 -layer metal3 -location {0 39.69} -force_to_die_boundary
+place_pin -pin_name pin91 -layer metal3 -location {0 39.83} -force_to_die_boundary
+place_pin -pin_name pin92 -layer metal3 -location {0 39.97} -force_to_die_boundary
+place_pin -pin_name pin93 -layer metal3 -location {0 40.11} -force_to_die_boundary
+place_pin -pin_name pin94 -layer metal3 -location {0 40.25} -force_to_die_boundary
+place_pin -pin_name pin95 -layer metal3 -location {0 40.39} -force_to_die_boundary
+place_pin -pin_name pin96 -layer metal3 -location {0 40.53} -force_to_die_boundary
+place_pin -pin_name pin97 -layer metal3 -location {0 40.67} -force_to_die_boundary
+place_pin -pin_name pin98 -layer metal3 -location {0 40.81} -force_to_die_boundary
+place_pin -pin_name pin99 -layer metal3 -location {0 40.95} -force_to_die_boundary

--- a/src/ppl/test/write_pin_placement3.defok
+++ b/src/ppl/test/write_pin_placement3.defok
@@ -1,0 +1,395 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN gcd ;
+UNITS DISTANCE MICRONS 2000 ;
+DIEAREA ( 0 0 ) ( 200260 201600 ) ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 527 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 720 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 358 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 360 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 126 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 63 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 63 STEP 3200 LAYER metal10 ;
+COMPONENTS 88 ;
+    - _858_ DFF_X1 + PLACED ( 54340 106400 ) FS ;
+    - _859_ DFF_X1 + PLACED ( 55100 117600 ) FS ;
+    - _860_ DFF_X1 + PLACED ( 74100 112000 ) FS ;
+    - _861_ DFF_X1 + PLACED ( 148200 131600 ) N ;
+    - _862_ DFF_X1 + PLACED ( 84740 131600 ) N ;
+    - _863_ DFF_X1 + PLACED ( 100700 148400 ) N ;
+    - _864_ DFF_X1 + PLACED ( 128060 145600 ) FS ;
+    - _865_ DFF_X1 + PLACED ( 149720 75600 ) N ;
+    - _866_ DFF_X1 + PLACED ( 152000 117600 ) FS ;
+    - _867_ DFF_X1 + PLACED ( 132240 70000 ) N ;
+    - _868_ DFF_X1 + PLACED ( 130720 123200 ) FS ;
+    - _869_ DFF_X1 + PLACED ( 49780 92400 ) N ;
+    - _870_ DFF_X1 + PLACED ( 54720 72800 ) FS ;
+    - _871_ DFF_X1 + PLACED ( 58140 64400 ) N ;
+    - _872_ DFF_X1 + PLACED ( 119700 64400 ) N ;
+    - _873_ DFF_X1 + PLACED ( 114380 44800 ) FS ;
+    - _874_ DFF_X1 + PLACED ( 86640 30800 ) N ;
+    - _875_ DFF_X1 + PLACED ( 73340 36400 ) N ;
+    - _876_ DFF_X1 + PLACED ( 107160 89600 ) FS ;
+    - _877_ DFF_X1 + PLACED ( 135280 131600 ) N ;
+    - _878_ DFF_X1 + PLACED ( 85120 123200 ) FS ;
+    - _879_ DFF_X1 + PLACED ( 104120 142800 ) N ;
+    - _880_ DFF_X1 + PLACED ( 119700 137200 ) N ;
+    - _881_ DFF_X1 + PLACED ( 150100 84000 ) FS ;
+    - _882_ DFF_X1 + PLACED ( 154660 106400 ) FS ;
+    - _883_ DFF_X1 + PLACED ( 124260 84000 ) FS ;
+    - _884_ DFF_X1 + PLACED ( 134520 114800 ) N ;
+    - _885_ DFF_X1 + PLACED ( 62700 98000 ) N ;
+    - _886_ DFF_X1 + PLACED ( 50920 84000 ) FS ;
+    - _887_ DFF_X1 + PLACED ( 69920 58800 ) N ;
+    - _888_ DFF_X1 + PLACED ( 109060 70000 ) N ;
+    - _889_ DFF_X1 + PLACED ( 113620 53200 ) N ;
+    - _890_ DFF_X1 + PLACED ( 100700 30800 ) N ;
+    - _891_ DFF_X1 + PLACED ( 69540 50400 ) FS ;
+    - _892_ DFF_X1 + PLACED ( 103360 75600 ) N ;
+    - buffer1 BUF_X4 + PLACED ( 165300 176400 ) N ;
+    - buffer10 BUF_X4 + PLACED ( 170240 22400 ) FS ;
+    - buffer11 BUF_X4 + PLACED ( 175180 126000 ) N ;
+    - buffer12 BUF_X4 + PLACED ( 30400 22400 ) FS ;
+    - buffer13 BUF_X4 + PLACED ( 139840 176400 ) N ;
+    - buffer14 BUF_X4 + PLACED ( 66120 176400 ) N ;
+    - buffer15 BUF_X4 + PLACED ( 175180 81200 ) N ;
+    - buffer16 BUF_X4 + PLACED ( 155800 176400 ) N ;
+    - buffer17 BUF_X4 + PLACED ( 25460 176400 ) N ;
+    - buffer18 BUF_X4 + PLACED ( 43700 22400 ) FS ;
+    - buffer19 BUF_X4 + PLACED ( 147820 22400 ) FS ;
+    - buffer2 BUF_X4 + PLACED ( 35720 176400 ) N ;
+    - buffer20 BUF_X4 + PLACED ( 175180 170800 ) N ;
+    - buffer21 BUF_X4 + PLACED ( 104120 22400 ) FS ;
+    - buffer22 BUF_X4 + PLACED ( 125400 176400 ) N ;
+    - buffer23 BUF_X4 + PLACED ( 20520 72800 ) FS ;
+    - buffer24 BUF_X4 + PLACED ( 30400 176400 ) N ;
+    - buffer25 BUF_X4 + PLACED ( 175180 156800 ) FS ;
+    - buffer26 BUF_X4 + PLACED ( 20520 58800 ) N ;
+    - buffer27 BUF_X4 + PLACED ( 175180 28000 ) FS ;
+    - buffer28 BUF_X4 + PLACED ( 175180 112000 ) FS ;
+    - buffer29 BUF_X4 + PLACED ( 20520 173600 ) FS ;
+    - buffer3 BUF_X4 + PLACED ( 88540 22400 ) FS ;
+    - buffer30 BUF_X4 + PLACED ( 150860 176400 ) N ;
+    - buffer31 BUF_X4 + PLACED ( 74100 22400 ) FS ;
+    - buffer32 BUF_X4 + PLACED ( 175180 140000 ) FS ;
+    - buffer33 BUF_X4 + PLACED ( 170240 176400 ) N ;
+    - buffer34 BUF_X4 + PLACED ( 20520 103600 ) N ;
+    - buffer35 BUF_X4 + PLACED ( 20520 176400 ) N ;
+    - buffer36 BUF_X4 + PLACED ( 20520 22400 ) FS ;
+    - buffer37 BUF_X4 + PLACED ( 20520 25200 ) N ;
+    - buffer38 BUF_X4 + PLACED ( 133380 22400 ) FS ;
+    - buffer39 BUF_X4 + PLACED ( 175180 22400 ) FS ;
+    - buffer4 BUF_X4 + PLACED ( 20520 28000 ) FS ;
+    - buffer40 BUF_X4 + PLACED ( 175180 25200 ) N ;
+    - buffer41 BUF_X4 + PLACED ( 175180 67200 ) FS ;
+    - buffer42 BUF_X4 + PLACED ( 20520 89600 ) FS ;
+    - buffer43 BUF_X4 + PLACED ( 118560 22400 ) FS ;
+    - buffer44 BUF_X4 + PLACED ( 20520 117600 ) FS ;
+    - buffer45 BUF_X4 + PLACED ( 175180 176400 ) N ;
+    - buffer46 BUF_X4 + PLACED ( 20520 44800 ) FS ;
+    - buffer47 BUF_X4 + PLACED ( 175180 36400 ) N ;
+    - buffer48 BUF_X4 + PLACED ( 25460 22400 ) FS ;
+    - buffer49 BUF_X4 + PLACED ( 163400 22400 ) FS ;
+    - buffer5 BUF_X4 + PLACED ( 110960 176400 ) N ;
+    - buffer50 BUF_X4 + PLACED ( 20520 134400 ) FS ;
+    - buffer51 BUF_X4 + PLACED ( 20520 148400 ) N ;
+    - buffer52 BUF_X4 + PLACED ( 20520 162400 ) FS ;
+    - buffer53 BUF_X4 + PLACED ( 175180 53200 ) N ;
+    - buffer6 BUF_X4 + PLACED ( 59280 22400 ) FS ;
+    - buffer7 BUF_X4 + PLACED ( 51680 176400 ) N ;
+    - buffer8 BUF_X4 + PLACED ( 175180 95200 ) FS ;
+    - buffer9 BUF_X4 + PLACED ( 80560 176400 ) N ;
+END COMPONENTS
+PINS 54 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 78850 70 ) N ;
+    - req_msg[0] + NET req_msg[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 53390 70 ) N ;
+    - req_msg[10] + NET req_msg[10] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 57190 70 ) N ;
+    - req_msg[11] + NET req_msg[11] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 103930 70 ) N ;
+    - req_msg[12] + NET req_msg[12] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 172900 ) N ;
+    - req_msg[13] + NET req_msg[13] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 148010 70 ) N ;
+    - req_msg[14] + NET req_msg[14] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 44650 70 ) N ;
+    - req_msg[15] + NET req_msg[15] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 25650 201530 ) N ;
+    - req_msg[16] + NET req_msg[16] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 156370 201530 ) N ;
+    - req_msg[17] + NET req_msg[17] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 82460 ) N ;
+    - req_msg[18] + NET req_msg[18] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 65550 201530 ) N ;
+    - req_msg[19] + NET req_msg[19] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 141550 201530 ) N ;
+    - req_msg[1] + NET req_msg[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 53770 70 ) N ;
+    - req_msg[20] + NET req_msg[20] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 31730 70 ) N ;
+    - req_msg[21] + NET req_msg[21] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 127540 ) N ;
+    - req_msg[22] + NET req_msg[22] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 170430 70 ) N ;
+    - req_msg[23] + NET req_msg[23] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 79610 201530 ) N ;
+    - req_msg[24] + NET req_msg[24] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 97300 ) N ;
+    - req_msg[25] + NET req_msg[25] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 51870 201530 ) N ;
+    - req_msg[26] + NET req_msg[26] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 59850 70 ) N ;
+    - req_msg[27] + NET req_msg[27] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 110770 201530 ) N ;
+    - req_msg[28] + NET req_msg[28] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 30100 ) N ;
+    - req_msg[29] + NET req_msg[29] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 88730 70 ) N ;
+    - req_msg[2] + NET req_msg[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54150 70 ) N ;
+    - req_msg[30] + NET req_msg[30] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 33250 201530 ) N ;
+    - req_msg[31] + NET req_msg[31] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 165490 201530 ) N ;
+    - req_msg[3] + NET req_msg[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54530 70 ) N ;
+    - req_msg[4] + NET req_msg[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54910 70 ) N ;
+    - req_msg[5] + NET req_msg[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 55290 70 ) N ;
+    - req_msg[6] + NET req_msg[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 55670 70 ) N ;
+    - req_msg[7] + NET req_msg[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56050 70 ) N ;
+    - req_msg[8] + NET req_msg[8] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56430 70 ) N ;
+    - req_msg[9] + NET req_msg[9] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56810 70 ) N ;
+    - req_rdy + NET req_rdy + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 23660 ) N ;
+    - req_val + NET req_val + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 171190 201530 ) N ;
+    - reset + NET reset + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 104860 ) N ;
+    - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 53390 201530 ) N ;
+    - resp_msg[10] + NET resp_msg[10] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 57190 201530 ) N ;
+    - resp_msg[11] + NET resp_msg[11] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 67900 ) N ;
+    - resp_msg[12] + NET resp_msg[12] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 26460 ) N ;
+    - resp_msg[13] + NET resp_msg[13] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 23940 ) N ;
+    - resp_msg[14] + NET resp_msg[14] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 134330 70 ) N ;
+    - resp_msg[15] + NET resp_msg[15] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 26180 ) N ;
+    - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 53770 201530 ) N ;
+    - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54150 201530 ) N ;
+    - resp_msg[3] + NET resp_msg[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54530 201530 ) N ;
+    - resp_msg[4] + NET resp_msg[4] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 54910 201530 ) N ;
+    - resp_msg[5] + NET resp_msg[5] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 55290 201530 ) N ;
+    - resp_msg[6] + NET resp_msg[6] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 55670 201530 ) N ;
+    - resp_msg[7] + NET resp_msg[7] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56050 201530 ) N ;
+    - resp_msg[8] + NET resp_msg[8] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56430 201530 ) N ;
+    - resp_msg[9] + NET resp_msg[9] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 56810 201530 ) N ;
+    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 70 178220 ) N ;
+    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER metal3 ( -70 -70 ) ( 70 70 )
+        + FIXED ( 200190 52780 ) N ;
+END PINS
+NETS 54 ;
+    - clk ( PIN clk ) ( _858_ CK ) ( _859_ CK ) ( _860_ CK ) ( _861_ CK ) ( _862_ CK ) ( _863_ CK )
+      ( _864_ CK ) ( _865_ CK ) ( _866_ CK ) ( _867_ CK ) ( _868_ CK ) ( _869_ CK ) ( _870_ CK ) ( _871_ CK )
+      ( _872_ CK ) ( _873_ CK ) ( _874_ CK ) ( _875_ CK ) ( _876_ CK ) ( _877_ CK ) ( _878_ CK ) ( _879_ CK )
+      ( _880_ CK ) ( _881_ CK ) ( _882_ CK ) ( _883_ CK ) ( _884_ CK ) ( _885_ CK ) ( _886_ CK ) ( _887_ CK )
+      ( _888_ CK ) ( _889_ CK ) ( _890_ CK ) ( _891_ CK ) ( _892_ CK ) + USE SIGNAL ;
+    - req_msg[0] ( PIN req_msg[0] ) ( buffer32 A ) + USE SIGNAL ;
+    - req_msg[10] ( PIN req_msg[10] ) ( buffer22 A ) + USE SIGNAL ;
+    - req_msg[11] ( PIN req_msg[11] ) ( buffer21 A ) + USE SIGNAL ;
+    - req_msg[12] ( PIN req_msg[12] ) ( buffer20 A ) + USE SIGNAL ;
+    - req_msg[13] ( PIN req_msg[13] ) ( buffer19 A ) + USE SIGNAL ;
+    - req_msg[14] ( PIN req_msg[14] ) ( buffer18 A ) + USE SIGNAL ;
+    - req_msg[15] ( PIN req_msg[15] ) ( buffer17 A ) + USE SIGNAL ;
+    - req_msg[16] ( PIN req_msg[16] ) ( buffer16 A ) + USE SIGNAL ;
+    - req_msg[17] ( PIN req_msg[17] ) ( buffer15 A ) + USE SIGNAL ;
+    - req_msg[18] ( PIN req_msg[18] ) ( buffer14 A ) + USE SIGNAL ;
+    - req_msg[19] ( PIN req_msg[19] ) ( buffer13 A ) + USE SIGNAL ;
+    - req_msg[1] ( PIN req_msg[1] ) ( buffer31 A ) + USE SIGNAL ;
+    - req_msg[20] ( PIN req_msg[20] ) ( buffer12 A ) + USE SIGNAL ;
+    - req_msg[21] ( PIN req_msg[21] ) ( buffer11 A ) + USE SIGNAL ;
+    - req_msg[22] ( PIN req_msg[22] ) ( buffer10 A ) + USE SIGNAL ;
+    - req_msg[23] ( PIN req_msg[23] ) ( buffer9 A ) + USE SIGNAL ;
+    - req_msg[24] ( PIN req_msg[24] ) ( buffer8 A ) + USE SIGNAL ;
+    - req_msg[25] ( PIN req_msg[25] ) ( buffer7 A ) + USE SIGNAL ;
+    - req_msg[26] ( PIN req_msg[26] ) ( buffer6 A ) + USE SIGNAL ;
+    - req_msg[27] ( PIN req_msg[27] ) ( buffer5 A ) + USE SIGNAL ;
+    - req_msg[28] ( PIN req_msg[28] ) ( buffer4 A ) + USE SIGNAL ;
+    - req_msg[29] ( PIN req_msg[29] ) ( buffer3 A ) + USE SIGNAL ;
+    - req_msg[2] ( PIN req_msg[2] ) ( buffer30 A ) + USE SIGNAL ;
+    - req_msg[30] ( PIN req_msg[30] ) ( buffer2 A ) + USE SIGNAL ;
+    - req_msg[31] ( PIN req_msg[31] ) ( buffer1 A ) + USE SIGNAL ;
+    - req_msg[3] ( PIN req_msg[3] ) ( buffer29 A ) + USE SIGNAL ;
+    - req_msg[4] ( PIN req_msg[4] ) ( buffer28 A ) + USE SIGNAL ;
+    - req_msg[5] ( PIN req_msg[5] ) ( buffer27 A ) + USE SIGNAL ;
+    - req_msg[6] ( PIN req_msg[6] ) ( buffer26 A ) + USE SIGNAL ;
+    - req_msg[7] ( PIN req_msg[7] ) ( buffer25 A ) + USE SIGNAL ;
+    - req_msg[8] ( PIN req_msg[8] ) ( buffer24 A ) + USE SIGNAL ;
+    - req_msg[9] ( PIN req_msg[9] ) ( buffer23 A ) + USE SIGNAL ;
+    - req_rdy ( PIN req_rdy ) ( buffer36 Z ) + USE SIGNAL ;
+    - req_val ( PIN req_val ) ( buffer33 A ) + USE SIGNAL ;
+    - reset ( PIN reset ) ( buffer34 A ) + USE SIGNAL ;
+    - resp_msg[0] ( PIN resp_msg[0] ) ( buffer52 Z ) + USE SIGNAL ;
+    - resp_msg[10] ( PIN resp_msg[10] ) ( buffer42 Z ) + USE SIGNAL ;
+    - resp_msg[11] ( PIN resp_msg[11] ) ( buffer41 Z ) + USE SIGNAL ;
+    - resp_msg[12] ( PIN resp_msg[12] ) ( buffer40 Z ) + USE SIGNAL ;
+    - resp_msg[13] ( PIN resp_msg[13] ) ( buffer39 Z ) + USE SIGNAL ;
+    - resp_msg[14] ( PIN resp_msg[14] ) ( buffer38 Z ) + USE SIGNAL ;
+    - resp_msg[15] ( PIN resp_msg[15] ) ( buffer37 Z ) + USE SIGNAL ;
+    - resp_msg[1] ( PIN resp_msg[1] ) ( buffer51 Z ) + USE SIGNAL ;
+    - resp_msg[2] ( PIN resp_msg[2] ) ( buffer50 Z ) + USE SIGNAL ;
+    - resp_msg[3] ( PIN resp_msg[3] ) ( buffer49 Z ) + USE SIGNAL ;
+    - resp_msg[4] ( PIN resp_msg[4] ) ( buffer48 Z ) + USE SIGNAL ;
+    - resp_msg[5] ( PIN resp_msg[5] ) ( buffer47 Z ) + USE SIGNAL ;
+    - resp_msg[6] ( PIN resp_msg[6] ) ( buffer46 Z ) + USE SIGNAL ;
+    - resp_msg[7] ( PIN resp_msg[7] ) ( buffer45 Z ) + USE SIGNAL ;
+    - resp_msg[8] ( PIN resp_msg[8] ) ( buffer44 Z ) + USE SIGNAL ;
+    - resp_msg[9] ( PIN resp_msg[9] ) ( buffer43 Z ) + USE SIGNAL ;
+    - resp_rdy ( PIN resp_rdy ) ( buffer35 A ) + USE SIGNAL ;
+    - resp_val ( PIN resp_val ) ( buffer53 Z ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/ppl/test/write_pin_placement3.tcl
+++ b/src/ppl/test/write_pin_placement3.tcl
@@ -7,17 +7,14 @@ set_io_pin_constraint -region bottom:* -group -order -pin_names {req_msg[0] req_
 set_io_pin_constraint -mirrored_pins {resp_msg[0] req_msg[0] resp_msg[1] req_msg[1] resp_msg[2] req_msg[2] resp_msg[3] req_msg[3] resp_msg[4] req_msg[4] resp_msg[5] req_msg[5] resp_msg[6] req_msg[6] resp_msg[7] req_msg[7] resp_msg[8] req_msg[8] resp_msg[9] req_msg[9] resp_msg[10] req_msg[10]}
 
 set tcl_file [make_result_file write_pin_placement3.tcl]
-set def_file1 [make_result_file write_pin_placement3.def1]
-set def_file2 [make_result_file write_pin_placement3.def2]
+set def_file [make_result_file write_pin_placement3.def]
 
 place_pins -hor_layers metal3 -ver_layers metal2 -corner_avoidance 0 -min_distance 0.12 -annealing -write_pin_placement $tcl_file
 
-write_def $def_file1
-
 source $tcl_file
 
-write_def $def_file2
+write_def $def_file
 
-diff_file $def_file1 $def_file2
+diff_file write_pin_placement3.defok $def_file
 
 diff_file write_pin_placement3.tclok $tcl_file

--- a/src/ppl/test/write_pin_placement3.tclok
+++ b/src/ppl/test/write_pin_placement3.tclok
@@ -1,58 +1,58 @@
 #Edge: BOTTOM
-place_pin -pin_name clk -layer metal2 -location {39.425 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[29] -layer metal2 -location {44.365 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[26] -layer metal2 -location {29.925 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[22] -layer metal2 -location {85.215 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[20] -layer metal2 -location {15.865 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[14] -layer metal2 -location {22.325 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[13] -layer metal2 -location {74.005 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[11] -layer metal2 -location {51.965 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[10] -layer metal2 -location {28.595 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[9] -layer metal2 -location {28.405 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[8] -layer metal2 -location {28.215 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[7] -layer metal2 -location {28.025 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[6] -layer metal2 -location {27.835 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[5] -layer metal2 -location {27.645 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[4] -layer metal2 -location {27.455 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[3] -layer metal2 -location {27.265 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[2] -layer metal2 -location {27.075 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[1] -layer metal2 -location {26.885 0} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[0] -layer metal2 -location {26.695 0} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[14] -layer metal2 -location {67.165 0} -force_to_die_boundary -placed_status
+place_pin -pin_name clk -layer metal2 -location {39.425 0} -force_to_die_boundary
+place_pin -pin_name req_msg[29] -layer metal2 -location {44.365 0} -force_to_die_boundary
+place_pin -pin_name req_msg[26] -layer metal2 -location {29.925 0} -force_to_die_boundary
+place_pin -pin_name req_msg[22] -layer metal2 -location {85.215 0} -force_to_die_boundary
+place_pin -pin_name req_msg[20] -layer metal2 -location {15.865 0} -force_to_die_boundary
+place_pin -pin_name req_msg[14] -layer metal2 -location {22.325 0} -force_to_die_boundary
+place_pin -pin_name req_msg[13] -layer metal2 -location {74.005 0} -force_to_die_boundary
+place_pin -pin_name req_msg[11] -layer metal2 -location {51.965 0} -force_to_die_boundary
+place_pin -pin_name req_msg[10] -layer metal2 -location {28.595 0} -force_to_die_boundary
+place_pin -pin_name req_msg[9] -layer metal2 -location {28.405 0} -force_to_die_boundary
+place_pin -pin_name req_msg[8] -layer metal2 -location {28.215 0} -force_to_die_boundary
+place_pin -pin_name req_msg[7] -layer metal2 -location {28.025 0} -force_to_die_boundary
+place_pin -pin_name req_msg[6] -layer metal2 -location {27.835 0} -force_to_die_boundary
+place_pin -pin_name req_msg[5] -layer metal2 -location {27.645 0} -force_to_die_boundary
+place_pin -pin_name req_msg[4] -layer metal2 -location {27.455 0} -force_to_die_boundary
+place_pin -pin_name req_msg[3] -layer metal2 -location {27.265 0} -force_to_die_boundary
+place_pin -pin_name req_msg[2] -layer metal2 -location {27.075 0} -force_to_die_boundary
+place_pin -pin_name req_msg[1] -layer metal2 -location {26.885 0} -force_to_die_boundary
+place_pin -pin_name req_msg[0] -layer metal2 -location {26.695 0} -force_to_die_boundary
+place_pin -pin_name resp_msg[14] -layer metal2 -location {67.165 0} -force_to_die_boundary
 #Edge: RIGHT
-place_pin -pin_name req_msg[24] -layer metal3 -location {100.13 48.65} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[21] -layer metal3 -location {100.13 63.77} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[17] -layer metal3 -location {100.13 41.23} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[12] -layer metal3 -location {100.13 86.45} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[13] -layer metal3 -location {100.13 11.97} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[12] -layer metal3 -location {100.13 13.23} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[11] -layer metal3 -location {100.13 33.95} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_val -layer metal3 -location {100.13 26.39} -force_to_die_boundary -placed_status
+place_pin -pin_name req_msg[24] -layer metal3 -location {100.13 48.65} -force_to_die_boundary
+place_pin -pin_name req_msg[21] -layer metal3 -location {100.13 63.77} -force_to_die_boundary
+place_pin -pin_name req_msg[17] -layer metal3 -location {100.13 41.23} -force_to_die_boundary
+place_pin -pin_name req_msg[12] -layer metal3 -location {100.13 86.45} -force_to_die_boundary
+place_pin -pin_name resp_msg[13] -layer metal3 -location {100.13 11.97} -force_to_die_boundary
+place_pin -pin_name resp_msg[12] -layer metal3 -location {100.13 13.23} -force_to_die_boundary
+place_pin -pin_name resp_msg[11] -layer metal3 -location {100.13 33.95} -force_to_die_boundary
+place_pin -pin_name resp_val -layer metal3 -location {100.13 26.39} -force_to_die_boundary
 #Edge: TOP
-place_pin -pin_name req_msg[31] -layer metal2 -location {82.745 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[30] -layer metal2 -location {16.625 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[27] -layer metal2 -location {55.385 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[25] -layer metal2 -location {25.935 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[23] -layer metal2 -location {39.805 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[19] -layer metal2 -location {70.775 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[18] -layer metal2 -location {32.775 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[16] -layer metal2 -location {78.185 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_msg[15] -layer metal2 -location {12.825 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name req_val -layer metal2 -location {85.595 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[10] -layer metal2 -location {28.595 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[9] -layer metal2 -location {28.405 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[8] -layer metal2 -location {28.215 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[7] -layer metal2 -location {28.025 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[6] -layer metal2 -location {27.835 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[5] -layer metal2 -location {27.645 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[4] -layer metal2 -location {27.455 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[3] -layer metal2 -location {27.265 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[2] -layer metal2 -location {27.075 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[1] -layer metal2 -location {26.885 100.8} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[0] -layer metal2 -location {26.695 100.8} -force_to_die_boundary -placed_status
+place_pin -pin_name req_msg[31] -layer metal2 -location {82.745 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[30] -layer metal2 -location {16.625 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[27] -layer metal2 -location {55.385 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[25] -layer metal2 -location {25.935 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[23] -layer metal2 -location {39.805 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[19] -layer metal2 -location {70.775 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[18] -layer metal2 -location {32.775 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[16] -layer metal2 -location {78.185 100.8} -force_to_die_boundary
+place_pin -pin_name req_msg[15] -layer metal2 -location {12.825 100.8} -force_to_die_boundary
+place_pin -pin_name req_val -layer metal2 -location {85.595 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[10] -layer metal2 -location {28.595 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[9] -layer metal2 -location {28.405 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[8] -layer metal2 -location {28.215 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[7] -layer metal2 -location {28.025 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[6] -layer metal2 -location {27.835 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[5] -layer metal2 -location {27.645 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[4] -layer metal2 -location {27.455 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[3] -layer metal2 -location {27.265 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[2] -layer metal2 -location {27.075 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[1] -layer metal2 -location {26.885 100.8} -force_to_die_boundary
+place_pin -pin_name resp_msg[0] -layer metal2 -location {26.695 100.8} -force_to_die_boundary
 #Edge: LEFT
-place_pin -pin_name req_msg[28] -layer metal3 -location {0 15.05} -force_to_die_boundary -placed_status
-place_pin -pin_name req_rdy -layer metal3 -location {0 11.83} -force_to_die_boundary -placed_status
-place_pin -pin_name reset -layer metal3 -location {0 52.43} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_msg[15] -layer metal3 -location {0 13.09} -force_to_die_boundary -placed_status
-place_pin -pin_name resp_rdy -layer metal3 -location {0 89.11} -force_to_die_boundary -placed_status
+place_pin -pin_name req_msg[28] -layer metal3 -location {0 15.05} -force_to_die_boundary
+place_pin -pin_name req_rdy -layer metal3 -location {0 11.83} -force_to_die_boundary
+place_pin -pin_name reset -layer metal3 -location {0 52.43} -force_to_die_boundary
+place_pin -pin_name resp_msg[15] -layer metal3 -location {0 13.09} -force_to_die_boundary
+place_pin -pin_name resp_rdy -layer metal3 -location {0 89.11} -force_to_die_boundary


### PR DESCRIPTION
The option to place an individual pin as PLACED does not work as expected. If place_pin is called before placing all pins, the individual pins will be modified. This PR sets the pins placed individually always as FIXED, avoiding changing them later in the PPL flow.