### PR TITLE
dpl: Allows CORE type cells to be used as fillers more seamlessly

### DIFF
--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -457,6 +457,12 @@ bool Opendp::isOverlapPadded(const Cell* cell1, const Cell* cell2) const
 bool Opendp::isCrWtBlClass(const Cell* cell) const
 {
   dbMasterType type = cell->db_inst_->getMaster()->getType();
+  dbInst* inst = cell->db_inst_;
+
+  if (inst->isPlacedAsFiller()) {
+    return false;
+  }
+
   // Use switch so if new types are added we get a compiler warning.
   switch (type) {
     case dbMasterType::CORE:

--- a/src/dpl/src/FillerPlacement.cpp
+++ b/src/dpl/src/FillerPlacement.cpp
@@ -207,7 +207,7 @@ void Opendp::removeFillers()
 bool Opendp::isFiller(odb::dbInst* db_inst)
 {
   dbMaster* db_master = db_inst->getMaster();
-  
+
   if (db_inst->isPlacedAsFiller()) {
     return true;
   }

--- a/src/dpl/src/FillerPlacement.cpp
+++ b/src/dpl/src/FillerPlacement.cpp
@@ -129,6 +129,7 @@ void Opendp::placeRowFillers(int row,
                                         master,
                                         inst_name.c_str(),
                                         /* physical_only */ true);
+          inst->setPlacedAsFiller();
           int x = core_.xMin() + k * site_width_;
           int y = core_.yMin() + row * row_height;
           inst->setOrient(orient);
@@ -206,6 +207,11 @@ void Opendp::removeFillers()
 bool Opendp::isFiller(odb::dbInst* db_inst)
 {
   dbMaster* db_master = db_inst->getMaster();
+  
+  if (db_inst->isPlacedAsFiller()) {
+    return true;
+  }
+
   return db_master->getType() == odb::dbMasterType::CORE_SPACER
          // Filter spacer cells used as tapcells.
          && db_inst->getPlacementStatus() != odb::dbPlacementStatus::LOCKED;

--- a/src/dpl/test/dpl_test.cc
+++ b/src/dpl/test/dpl_test.cc
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <stdexcept>
+#include <vector>
 
 #include "dpl/Opendp.h"
 #include "gtest/gtest.h"

--- a/src/dpl/test/dpl_test.cc
+++ b/src/dpl/test/dpl_test.cc
@@ -1,6 +1,7 @@
 #include <unistd.h>
 
 #include <memory>
+#include <stdexcept>
 
 #include "dpl/Opendp.h"
 #include "gtest/gtest.h"
@@ -22,11 +23,13 @@ class OpendpTest : public ::testing::Test
                                         &odb::dbDatabase::destroy);
     odb::lefin lef_reader(
         db_.get(), &logger_, /*ignore_non_routing_layers=*/false);
+
     lib_ = OdbUniquePtr<odb::dbLib>(
-        lef_reader.createTechAndLib("tech",
-                                    "isPlacedTestLibName",
-                                    "sky130hd/sky130_fd_sc_hd_merged.lef"),
+        lef_reader.createTechAndLib(
+            "tech", "OpenDpTest", "sky130hd/sky130hd.tlef"),
         &odb::dbLib::destroy);
+
+    lef_reader.updateLib(lib_.get(), "sky130hd/sky130_fd_sc_hd_merged.lef");
 
     chip_ = OdbUniquePtr<odb::dbChip>(odb::dbChip::create(db_.get()),
                                       &odb::dbChip::destroy);
@@ -57,6 +60,121 @@ TEST_F(OpendpTest, IsPlaced)
 
   // Act & Assert
   ASSERT_TRUE(Opendp::isPlaced(&placed));
+}
+
+TEST_F(OpendpTest, AbuttedCellsWithGlobalPaddingFailPlacementChecks)
+{
+  odb::dbMaster* and_gate = lib_->findMaster("sky130_fd_sc_hd__and2_1");
+  odb::dbSite* site = and_gate->getSite();
+  int and_gate_site_count = and_gate->getWidth() / site->getWidth();
+
+  odb::dbRow::create(block_.get(),
+                     "row1",
+                     and_gate->getSite(),
+                     /*origin_x*/ 0,
+                     /*origin_y*/ 0,
+                     odb::dbOrientType::R0,
+                     odb::dbRowDir::HORIZONTAL,
+                     /*num_sites*/ and_gate_site_count * 25,  // 25 AND2 gates
+                     site->getWidth());
+
+  auto and1_placed = OdbUniquePtr<odb::dbInst>(
+      odb::dbInst::create(block_.get(), and_gate, "and_1"),
+      &odb::dbInst::destroy);
+  auto and2_placed = OdbUniquePtr<odb::dbInst>(
+      odb::dbInst::create(block_.get(), and_gate, "and_2"),
+      &odb::dbInst::destroy);
+
+  Opendp opendp;
+  opendp.init(db_.get(), &logger_);
+  opendp.setPaddingGlobal(/* left */ 1, /* right */ 1);
+
+  /*
+  -----------------------------------------------------
+  | and1_placed | and2_placed | ... | empty_sites | ...
+  -----------------------------------------------------
+  */
+  and1_placed->setLocation(0, 0);
+  and2_placed->setLocation(and1_placed->getBBox()->getWidth(), 0);
+  and1_placed->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+  and2_placed->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+
+  // Act & Assert
+  EXPECT_THROW(opendp.checkPlacement(/* verbose */ true,
+                                     /*disallow_one_site_gaps*/ false,
+                                     /*report_file_name*/ ""),
+               std::runtime_error);
+}
+
+TEST_F(OpendpTest, CoreTypeCellsPlacedByFillerDoNotTriggerPlacementChecks)
+{
+  odb::dbMaster* and_gate = lib_->findMaster("sky130_fd_sc_hd__and2_1");
+  odb::dbSite* site = and_gate->getSite();
+  int and_gate_site_count = and_gate->getWidth() / site->getWidth();
+
+  odb::dbRow::create(block_.get(),
+                     "row1",
+                     and_gate->getSite(),
+                     /*origin_x*/ 0,
+                     /*origin_y*/ 0,
+                     odb::dbOrientType::R0,
+                     odb::dbRowDir::HORIZONTAL,
+                     /*num_sites*/ and_gate_site_count * 25,  // 25 AND2 gates
+                     site->getWidth());
+
+  std::vector<odb::dbMaster*> filler_list{and_gate};
+
+  Opendp opendp;
+  opendp.init(db_.get(), &logger_);
+  opendp.setPaddingGlobal(/* left */ 1, /* right */ 1);
+
+  /*
+  -------------------------------------------------------------------
+  | and1_placed (used as filler) | and2_placed (used as filler) | ...
+  -------------------------------------------------------------------
+  */
+  opendp.fillerPlacement(&filler_list, "filler_");
+
+  // Act & Assert
+  EXPECT_NO_THROW(opendp.checkPlacement(/* verbose */ true,
+                                        /*disallow_one_site_gaps*/ false,
+                                        /*report_file_name*/ ""));
+}
+
+TEST_F(OpendpTest, CoreTypeCellsPlacedByFillerAreRemovedByRemoveFiller)
+{
+  odb::dbMaster* and_gate = lib_->findMaster("sky130_fd_sc_hd__and2_1");
+  odb::dbSite* site = and_gate->getSite();
+  int and_gate_site_count = and_gate->getWidth() / site->getWidth();
+
+  odb::dbRow::create(block_.get(),
+                     "row1",
+                     and_gate->getSite(),
+                     /*origin_x*/ 0,
+                     /*origin_y*/ 0,
+                     odb::dbOrientType::R0,
+                     odb::dbRowDir::HORIZONTAL,
+                     /*num_sites*/ and_gate_site_count * 25,  // 25 AND2 gates
+                     site->getWidth());
+
+  std::vector<odb::dbMaster*> filler_list{and_gate};
+
+  Opendp opendp;
+  opendp.init(db_.get(), &logger_);
+  opendp.setPaddingGlobal(/* left */ 1, /* right */ 1);
+
+  /*
+  -------------------------------------------------------------------
+  | and1_placed (used as filler) | and2_placed (used as filler) | ...
+  -------------------------------------------------------------------
+  */
+
+  // Act & Assert
+  opendp.fillerPlacement(&filler_list, "filler_");
+  EXPECT_EQ(block_->getInsts().size(), 25);
+
+  opendp.removeFillers();
+  EXPECT_EQ(block_->getInsts().size(), 0);
 }
 
 }  // namespace dpl

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -3023,12 +3023,12 @@ class dbInst : public dbObject
   ///
   /// Get the user-defined flag bit.
   ///
-  bool getUserFlag3();
+  bool isPlacedAsFiller();
 
   ///
   /// Set the user-defined flag bit.
   ///
-  void setUserFlag3();
+  void setPlacedAsFiller();
 
   ///
   /// Clear the user-defined flag bit.
@@ -3253,6 +3253,11 @@ class dbInst : public dbObject
   /// Is the master's type ENDCAP or any of its subtypes
   ///
   bool isEndCap() const;
+
+  ///
+  /// If this instance was created as a physical_only inst
+  ///
+  bool isPhysicalOnly() const;
 
   void setPinAccessIdx(uint idx);
 

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -111,7 +111,7 @@ _dbInst::_dbInst(_dbDatabase*)
   _flags._status = dbPlacementStatus::NONE;
   _flags._user_flag_1 = 0;
   _flags._user_flag_2 = 0;
-  _flags._user_flag_3 = 0;
+  _flags._placed_as_filler = 0;
   _flags._physical_only = 0;
   _flags._dont_touch = 0;
   _flags._eco_create = 0;
@@ -235,7 +235,7 @@ bool _dbInst::operator==(const _dbInst& rhs) const
   if (_flags._user_flag_2 != rhs._flags._user_flag_2)
     return false;
 
-  if (_flags._user_flag_3 != rhs._flags._user_flag_3)
+  if (_flags._placed_as_filler != rhs._flags._placed_as_filler)
     return false;
 
   if (_flags._physical_only != rhs._flags._physical_only)
@@ -323,7 +323,7 @@ void _dbInst::differences(dbDiff& diff,
   DIFF_FIELD(_flags._status);
   DIFF_FIELD(_flags._user_flag_1);
   DIFF_FIELD(_flags._user_flag_2);
-  DIFF_FIELD(_flags._user_flag_3);
+  DIFF_FIELD(_flags._placed_as_filler);
   DIFF_FIELD(_flags._physical_only);
   DIFF_FIELD(_flags._dont_touch);
   DIFF_FIELD(_flags._source);
@@ -377,7 +377,7 @@ void _dbInst::out(dbDiff& diff, char side, const char* field) const
   DIFF_OUT_FIELD(_flags._status);
   DIFF_OUT_FIELD(_flags._user_flag_1);
   DIFF_OUT_FIELD(_flags._user_flag_2);
-  DIFF_OUT_FIELD(_flags._user_flag_3);
+  DIFF_OUT_FIELD(_flags._placed_as_filler);
   DIFF_OUT_FIELD(_flags._physical_only);
   DIFF_OUT_FIELD(_flags._dont_touch);
   DIFF_OUT_FIELD(_flags._source);
@@ -809,18 +809,18 @@ void dbInst::clearUserFlag2()
         this, _dbInst::FLAGS, prev_flags, flagsToUInt(inst));
 }
 
-bool dbInst::getUserFlag3()
+bool dbInst::isPlacedAsFiller()
 {
   _dbInst* inst = (_dbInst*) this;
-  return inst->_flags._user_flag_3 == 1;
+  return inst->_flags._placed_as_filler == 1;
 }
 
-void dbInst::setUserFlag3()
+void dbInst::setPlacedAsFiller()
 {
   _dbInst* inst = (_dbInst*) this;
   _dbBlock* block = (_dbBlock*) inst->getOwner();
   uint prev_flags = flagsToUInt(inst);
-  inst->_flags._user_flag_3 = 1;
+  inst->_flags._placed_as_filler = 1;
 
   if (block->_journal)
     block->_journal->updateField(
@@ -832,7 +832,7 @@ void dbInst::clearUserFlag3()
   _dbInst* inst = (_dbInst*) this;
   _dbBlock* block = (_dbBlock*) inst->getOwner();
   uint prev_flags = flagsToUInt(inst);
-  inst->_flags._user_flag_3 = 0;
+  inst->_flags._placed_as_filler = 0;
 
   if (block->_journal)
     block->_journal->updateField(
@@ -884,6 +884,12 @@ bool dbInst::isPad() const
 bool dbInst::isEndCap() const
 {
   return getMaster()->isEndCap();
+}
+
+bool dbInst::isPhysicalOnly() const
+{
+  _dbInst* inst = (_dbInst*) this;
+  return static_cast<bool>(inst->_flags._physical_only);
 }
 
 dbSet<dbITerm> dbInst::getITerms()

--- a/src/odb/src/db/dbInst.h
+++ b/src/odb/src/db/dbInst.h
@@ -60,7 +60,7 @@ struct _dbInstFlags
   dbPlacementStatus::Value _status : 4;
   uint _user_flag_1 : 1;
   uint _user_flag_2 : 1;
-  uint _user_flag_3 : 1;
+  uint _placed_as_filler : 1;
   uint _physical_only : 1;
   uint _dont_touch : 1;
   dbSourceType::Value _source : 4;

--- a/src/par/src/Hypergraph.h
+++ b/src/par/src/Hypergraph.h
@@ -55,7 +55,7 @@
 
 namespace par {
 
-struct Hypergraph;
+class Hypergraph;
 using HGraphPtr = std::shared_ptr<Hypergraph>;
 
 // The data structure for critical timing path


### PR DESCRIPTION
This PR repurposes a user_flag in dbInst to store whether or not
that inst was placed by the filler engine. If it was then downstream
tools that operate on fillers will recognize these cells as fillers
regardless of their LEF type.

There's probably other places we should pipe this, but for now it's
integrated into check_placement and remove_fillers.