### PR TITLE
gui: restore gui hide behavior

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1209,7 +1209,9 @@ void Gui::hideGui()
 {
   // ensure continue after close is true, since we want to return to tcl
   setContinueAfterClose();
-  main_window->exit();
+  if (enabled()) {
+    main_window->hide();
+  }
 }
 
 void Gui::showGui(const std::string& cmds, bool interactive)
@@ -1299,7 +1301,7 @@ int startGui(int& argc,
       main_window, &MainWindow::exit, [&]() { exit_requested = true; });
 
   // Hide the Gui if someone chooses hide from the menu in the window
-  QObject::connect(main_window, &MainWindow::hide, [gui]() { gui->hideGui(); });
+  QObject::connect(main_window, &MainWindow::hide, &app, &QApplication::quit);
 
   // Save the window's status into the settings when quitting.
   QObject::connect(
@@ -1370,8 +1372,6 @@ int startGui(int& argc,
       gui->addRestoreStateCommand(cmd);
     }
   }
-
-  main_window->exit();
 
   // delete main window and set to nullptr
   delete main_window;

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -583,6 +583,7 @@ void MainWindow::createActions()
   connect(hide_, &QAction::triggered, this, &MainWindow::hide);
   connect(exit_, &QAction::triggered, this, &MainWindow::exit);
   connect(this, &MainWindow::exit, viewers_, &LayoutTabs::exit);
+  connect(this, &MainWindow::hide, viewers_, &LayoutTabs::exit);
   connect(fit_, &QAction::triggered, viewers_, &LayoutTabs::fit);
   connect(zoom_in_,
           &QAction::triggered,


### PR DESCRIPTION
Fixes the `gui::hide` which broke in be4378f3473e4603687f1ad2261b02541284f7d1