### PR TITLE
grt: iterating all the nets when generating the progress report

### DIFF
--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -2140,10 +2140,6 @@ void FastRouteCore::findCongestedEdgesNets(
     bool vertical)
 {
   for (int netID = 0; netID < netCount(); netID++) {
-    if (!nets_[netID]->isRouted()) {
-      continue;
-    }
-
     const auto& treeedges = sttrees_[netID].edges;
     const int num_edges = sttrees_[netID].num_edges();
 


### PR DESCRIPTION
Iterating all the nets when checking the nets that cross the congested ggrids
Finxing git issue #3867 