### PR TITLE
[DO NOT MERGE] gui: multithreaded renderer

### DIFF
--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -90,7 +90,7 @@ class RenderThread : public QThread
  private:
   void run() override;
 
-  void drawBlockConcurrent(QImage& image,
+  void drawBlockConcurrent(QPainter* painter,
                            odb::dbBlock* block,
                            QVector<QRect>& subRects,
                            QVector<QFuture<QImage>>& futures,

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -37,6 +37,8 @@
 #include <QThread>
 #include <QWaitCondition>
 #include <mutex>
+#include <QtConcurrent/QtConcurrent>
+
 
 #include "gui/gui.h"
 #include "odb/db.h"
@@ -65,6 +67,15 @@ class RenderThread : public QThread
   void exit();
 
   // Only to be used by save_image for synchronous rendering
+  void drawConcurrent(QImage& image,
+                      const QRect& draw_bounds,
+                      const SelectionSet& selected,
+                      const HighlightSet& highlighted,
+                      const Rulers& rulers,
+                      qreal render_ratio,
+                      const QColor& background);
+
+  // Only to be used by save_image for synchronous rendering
   void draw(QImage& image,
             const QRect& draw_bounds,
             const SelectionSet& selected,
@@ -79,6 +90,13 @@ class RenderThread : public QThread
  private:
   void run() override;
 
+  void drawBlockConcurrent(QImage& image,
+                           odb::dbBlock* block,
+                           QVector<QRect>& subRects,
+                           QVector<QFuture<QImage>>& futures,
+                           int threadCount,
+                           const QRect& draw_bounds,
+                           int depth);
   void drawBlock(QPainter* painter,
                  odb::dbBlock* block,
                  const odb::Rect& bounds,


### PR DESCRIPTION
This PR shows the approach I am taking to implement multithreading inside renderThread.cpp. An approach was discussed in  #3359 to have individual layers drawn as separate images, and then collate these images after the threads have finished.

However as shown by the GUI timers in #3348, there are other functions that would benefit from multithreading besides drawLayers() that cannot necessarily be divided by layer, such as drawInstanceOutlines().

I borrowed from @oharboe in #3824 to divide the layout by subrectangle, but then used these subrectangles to divide the inst_range into sub instance ranges.

I created two additional functions drawConcurrent() and drawBlockConcurrent(). The idea is a thread pool is created inside drawConcurrent() for collating images. The thread pool can then be reused by each function inside drawBlockConcurrent(). I also created a second thread pool just for the purpose of returning sub insts vectors from Search::searchInsts().

I still have several changes to make, and I need to determine if there is any benefit performance from this. This is more or less an update on my progress.

Also, can anyone tell me what is the purpose of the GuiPainter class? 