### PR TITLE
deltaDebug: tweak heuristic to speed up bisection

### DIFF
--- a/etc/deltaDebug.py
+++ b/etc/deltaDebug.py
@@ -110,13 +110,17 @@ class deltaDebugger:
 
             for i in range(self.persistence):
                 for j in range(self.n):
-                    err = self.perform_step(cut_index = j)
-                    if(err == "NOCUT"):
+                    current_err = self.perform_step(cut_index = j)
+                    if(current_err == "NOCUT"):
                         break
-                    elif(err != None): # Found the target error with the cut DB
+                    elif(current_err != None):
+                        # Found the target error with the cut DB
+                        #
+                        # This is a suitable level of detail to look for more errors,
+                        # complete this level of detail.
+                        err = current_err
                         self.prepare_new_step()
-                        break
-                
+
                 if(err == None):
                     # Increase the granularity of the cut in case target error not found
                     self.n *= 2


### PR DESCRIPTION
Find the right level of detail to look for cuts and complete cuts at this level.

This speeds up deltaDebug as it is not necessary to start at the top every time an error is found and I believe it to be general and significant improvement over the current heuristic for searching for cuts.

I do believe that even better heuristics exist for deltaDebug, but this step is significant enough and simple enough that I think it makes sense to accept this PR as a new baseline.

I had a case of a deltaDebug that I stopped after 2 days, with this change it takes "only" 12 hours or so.