### PR TITLE
deltaDebug: decrease granularity by steps instead of going straight back to start

### DIFF
--- a/etc/deltaDebug.py
+++ b/etc/deltaDebug.py
@@ -108,7 +108,8 @@ class deltaDebugger:
             err = None
             self.n = 2 # Initial Number of cuts
 
-            for i in range(self.persistence):
+            while self.n <= (2 ** self.persistence):
+                error_in_range = None
                 for j in range(self.n):
                     current_err = self.perform_step(cut_index = j)
                     if(current_err == "NOCUT"):
@@ -119,11 +120,15 @@ class deltaDebugger:
                         # This is a suitable level of detail to look for more errors,
                         # complete this level of detail.
                         err = current_err
+                        error_in_range = current_err
                         self.prepare_new_step()
 
-                if(err == None):
+                if(error_in_range == None):
                     # Increase the granularity of the cut in case target error not found
                     self.n *= 2
+                elif self.n >= 8:
+                    # Found errors, decrease granularity
+                    self.n = int(self.n / 2)
                 else:
                     break
 


### PR DESCRIPTION
The granularity is increased when no error found and reduced when errors are found.

Previously the granularity would go all the way to two sections as soon as an error was found, this resulted in a lot of extra iterations when the approperiate granularity to find errors is high.

This results in fewer iterations.

After:

- 217 steps to complete insts, in my test case each negative test was on the order of 10 minutes
- 596 steps to complete nets, here a negative test was no more than a minute or so

Before:

- 270 steps to complete insts
- 526 steps to complete nets
