### PR TITLE
[Docs] Fix prebuilt instructions and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ flowchart LR
 
 ```
 
-Documentation is also available [here](https://openroad.readthedocs.io/en/latest/main/README.html).
 
 ## OpenROAD Mission
 

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -5,7 +5,7 @@ entries:
   entries:
   - file: user/Build.md
     title: Building OpenROAD
-  - file: user/ORFS.md
+  - url: https://openroad-flow-scripts.readthedocs.io/
     title: Getting Started with the OpenROAD Flow - OpenROAD-flow-scripts
   - file: tutorials/index
     title: Tutorials

--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -95,3 +95,9 @@ for using Address Sanitizer.
 
 > **Note:** Address Sanitizer adds instrumentation for detecting memory errors.
 >  Enabling this option will cause OpenROAD to run slower and consume more RAM.
+
+### Build with Prebuilt Binaries
+
+Courtesy of [Precision Innovations](https://precisioninno.com/), there are pre-built binaries
+of OpenROAD with self-contained dependencies released on a regular basis.
+Refer to this [link](https://openroad-flow-scripts.readthedocs.io/en/latest/user/BuildWithPrebuilt.html) here.

--- a/docs/user/ORFS.md
+++ b/docs/user/ORFS.md
@@ -1,9 +1,0 @@
-# Getting Started with OpenROAD Flow
-
-You can get started with OpenROAD easily using our native flow, 
-the OpenROAD-flow-scripts. 
-
-OpenROAD Flow is a full RTL-to-GDS flow built entirely on open-source EDA
-tools. The project aims for automated, no-human-in-the-loop digital 
-circuit design with 24-hour turnaround time. For more information, refer
-to this [link](https://openroad-flow-scripts.readthedocs.io/).


### PR DESCRIPTION
Addresses the following comments @vvbandeira @dralabeing 

1. The OpenROAD installation does not currently link to pre-built binaries. This is only shown for ORFS. This should be added here as well: https://openroad.readthedocs.io/en/latest/user/Build.html
This is also missing the OS information as in ORFS. 
2. The link from OpenROAD to ORFS lands on this page : https://openroad.readthedocs.io/en/latest/user/ORFS.html.  I think this can be removed since it is redirected to another page  : https://openroad-flow-scripts.readthedocs.io/en/latest/.
3. There is a redundant/recursive link reference the readme from the readme landing here: 81c8ee17-ef2e-45bf-a0cd-351f8787aca2.png
Remove the line "Documentation is also...."
