### PR TITLE
grt: print all pins out of die area before erroring

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3282,10 +3282,10 @@ int GlobalRouter::findInstancesObstructions(
             if (!die_area.contains(pin_box)
                 && !mterm->getSigType().isSupply()) {
               logger_->warn(GRT,
-                             39,
-                             "Found pin {} outside die area in instance {}.",
-                             mterm->getConstName(),
-                             inst->getConstName());
+                            39,
+                            "Found pin {} outside die area in instance {}.",
+                            mterm->getConstName(),
+                            inst->getConstName());
               pin_out_of_die_count++;
             }
             applyObstructionAdjustment(pin_box, box->getTechLayer());

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3281,7 +3281,7 @@ int GlobalRouter::findInstancesObstructions(
             pin_box = odb::Rect(lower_bound, upper_bound);
             if (!die_area.contains(pin_box)
                 && !mterm->getSigType().isSupply()) {
-              logger_->error(GRT,
+              logger_->warn(GRT,
                              39,
                              "Found pin {} outside die area in instance {}.",
                              mterm->getConstName(),
@@ -3297,7 +3297,7 @@ int GlobalRouter::findInstancesObstructions(
 
   if (pin_out_of_die_count > 0) {
     if (verbose_)
-      logger_->warn(
+      logger_->error(
           GRT, 28, "Found {} pins outside die area.", pin_out_of_die_count);
   }
 

--- a/src/grt/test/inst_pin_out_of_die.ok
+++ b/src/grt/test/inst_pin_out_of_die.ok
@@ -25,5 +25,8 @@
 [WARNING GRT-0038] Found blockage outside die area in instance _546_.
 [WARNING GRT-0038] Found blockage outside die area in instance _546_.
 [WARNING GRT-0038] Found blockage outside die area in instance _546_.
-[ERROR GRT-0039] Found pin A2 outside die area in instance _546_.
-GRT-0039
+[WARNING GRT-0039] Found pin A2 outside die area in instance _546_.
+[WARNING GRT-0039] Found pin Y outside die area in instance _546_.
+[WARNING GRT-0039] Found pin Y outside die area in instance _546_.
+[ERROR GRT-0028] Found 3 pins outside die area.
+GRT-0028


### PR DESCRIPTION
It seems like the code meant to do this, but got warn/error switched around. Otherwise, `GRT-0028` is actually unreachable.