### PR TITLE
gui: fixes to segfaults and allow for better debugging

### DIFF
--- a/src/dbSta/src/heatMap.cpp
+++ b/src/dbSta/src/heatMap.cpp
@@ -61,16 +61,8 @@ PowerDensityDataSource::PowerDensityDataSource(sta::dbSta* sta,
         }
         return corners;
       },
-      [this]() -> std::string {
-        ensureCorner();
-        if (corner_ == nullptr) {
-          return "";
-        }
-        return corner_->name();
-      },
-      [this](const std::string& value) {
-        corner_ = sta_->findCorner(value.c_str());
-      });
+      [this]() -> std::string { return corner_; },
+      [this](const std::string& value) { corner_ = value; });
   addBooleanSetting(
       "Internal",
       "Internal power:",
@@ -100,8 +92,6 @@ bool PowerDensityDataSource::populateMap()
     return false;
   }
 
-  ensureCorner();
-
   auto* network = sta_->getDbNetwork();
 
   const bool include_all
@@ -111,7 +101,7 @@ bool PowerDensityDataSource::populateMap()
       continue;
     }
 
-    sta::PowerResult power = sta_->power(network->dbToSta(inst), corner_);
+    sta::PowerResult power = sta_->power(network->dbToSta(inst), getCorner());
 
     float pwr = 0.0;
     if (include_all) {
@@ -146,19 +136,19 @@ void PowerDensityDataSource::combineMapData(bool base_has_value,
   base += (new_data / data_area) * intersection_area;
 }
 
-void PowerDensityDataSource::ensureCorner()
+sta::Corner* PowerDensityDataSource::getCorner() const
 {
-  if (corner_ != nullptr) {
-    return;
+  auto* corner = sta_->findCorner(corner_.c_str());
+  if (corner != nullptr) {
+    return corner;
   }
 
   auto corners = sta_->corners()->corners();
-  corner_ = corners[0];
-}
+  if (corners.size() > 0) {
+    return corners[0];
+  }
 
-void PowerDensityDataSource::setCorner(const std::string& name)
-{
-  corner_ = sta_->findCorner(name.c_str());
+  return nullptr;
 }
 
 }  // namespace sta

--- a/src/dbSta/src/heatMap.cpp
+++ b/src/dbSta/src/heatMap.cpp
@@ -144,7 +144,7 @@ sta::Corner* PowerDensityDataSource::getCorner() const
   }
 
   auto corners = sta_->corners()->corners();
-  if (corners.size() > 0) {
+  if (!corners.empty()) {
     return corners[0];
   }
 

--- a/src/dbSta/src/heatMap.h
+++ b/src/dbSta/src/heatMap.h
@@ -61,10 +61,9 @@ class PowerDensityDataSource : public gui::RealValueHeatMapDataSource,
   bool include_leakage_ = true;
   bool include_switching_ = true;
 
-  sta::Corner* corner_ = nullptr;
+  std::string corner_;
 
-  void ensureCorner();
-  void setCorner(const std::string& name);
+  sta::Corner* getCorner() const;
 };
 
 }  // namespace sta

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -716,6 +716,8 @@ class Gui
   void setHeatMapSetting(const std::string& name,
                          const std::string& option,
                          const Renderer::Setting& value);
+  Renderer::Setting getHeatMapSetting(const std::string& name,
+                                      const std::string& option);
   void dumpHeatMap(const std::string& name, const std::string& file);
 
   // accessors for to add and remove commands needed to restore the state of the

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -169,6 +169,8 @@ class HeatMapDataSource
   MapView getMapView(const odb::Rect& bounds);
   bool isPopulated() const { return populated_; }
 
+  bool hasData() const;
+
   std::vector<std::pair<int, double>> getLegendValues() const;
   Painter::Color getColor(double value) const;
   const SpectrumGenerator& getColorGenerator() const

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -892,6 +892,7 @@ void Gui::setHeatMapSetting(const std::string& name,
   const std::string rebuild_map_option = "rebuild";
   if (option == rebuild_map_option) {
     source->destroyMap();
+    source->ensureMap();
   } else {
     auto settings = source->getSettings();
 
@@ -952,6 +953,33 @@ void Gui::setHeatMapSetting(const std::string& name,
   }
 
   source->getRenderer()->redraw();
+}
+
+Renderer::Setting Gui::getHeatMapSetting(const std::string& name,
+                                         const std::string& option)
+{
+  HeatMapDataSource* source = getHeatMap(name);
+
+  const std::string map_has_option = "has_data";
+  if (option == map_has_option) {
+    return source->hasData();
+  }
+
+  auto settings = source->getSettings();
+
+  if (settings.count(option) == 0) {
+    QStringList options;
+    for (const auto& [key, kv] : settings) {
+      options.append(QString::fromStdString(key));
+    }
+    logger_->error(utl::GUI,
+                   95,
+                   "{} is not a valid option. Valid options are: {}",
+                   option,
+                   options.join(", ").toStdString());
+  }
+
+  return settings[option];
 }
 
 void Gui::dumpHeatMap(const std::string& name, const std::string& file)

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -580,6 +580,58 @@ void selection_animate(int repeat = 0)
   gui->animateSelection(repeat);
 }
 
+bool get_heatmap_bool(const std::string& name, const std::string& option)
+{
+  auto gui = gui::Gui::get();
+  auto value = gui->getHeatMapSetting(name, option);
+  if (std::holds_alternative<bool>(value)) {
+      return std::get<bool>(value);
+  } else {
+    auto logger = ord::OpenRoad::openRoad()->getLogger();
+    logger->error(GUI, 90, "Heatmap setting \"{}\" is not a boolean", option);
+  }
+  return false;
+}
+
+int get_heatmap_int(const std::string& name, const std::string& option)
+{
+  auto gui = gui::Gui::get();
+  auto value = gui->getHeatMapSetting(name, option);
+  if (std::holds_alternative<int>(value)) {
+      return std::get<int>(value);
+  } else {
+    auto logger = ord::OpenRoad::openRoad()->getLogger();
+    logger->error(GUI, 91, "Heatmap setting \"{}\" is not an integer", option);
+  }
+  return 0;
+}
+
+double get_heatmap_double(const std::string& name, const std::string& option)
+{
+  auto gui = gui::Gui::get();
+  auto value = gui->getHeatMapSetting(name, option);
+  if (std::holds_alternative<double>(value)) {
+      return std::get<double>(value);
+  } else {
+    auto logger = ord::OpenRoad::openRoad()->getLogger();
+    logger->error(GUI, 92, "Heatmap setting \"{}\" is not a double", option);
+  }
+  return 0.0;
+}
+
+const char* get_heatmap_string(const std::string& name, const std::string& option)
+{
+  auto gui = gui::Gui::get();
+  auto value = gui->getHeatMapSetting(name, option);
+  if (std::holds_alternative<std::string>(value)) {
+    return std::get<std::string>(value).c_str();
+  } else {
+    auto logger = ord::OpenRoad::openRoad()->getLogger();
+    logger->error(GUI, 93, "Heatmap setting \"{}\" is not a string", option);
+  }
+  return "";
+}
+
 void set_heatmap(const std::string& name, const std::string& option, double value = 0.0)
 {
   auto gui = gui::Gui::get();
@@ -653,4 +705,3 @@ void trigger_action(const std::string& name)
 }
 
 %} // inline
-

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -441,6 +441,23 @@ void HeatMapDataSource::destroyMap()
   redraw();
 }
 
+bool HeatMapDataSource::hasData() const
+{
+  if (!populated_) {
+    return false;
+  }
+
+  for (const auto& map_col : map_) {
+    for (const auto& map_pt : map_col) {
+      if (map_pt->has_value) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 void HeatMapDataSource::ensureMap()
 {
   if (destroy_map_) {

--- a/src/psm/include/psm/pdnsim.h
+++ b/src/psm/include/psm/pdnsim.h
@@ -103,6 +103,8 @@ class PDNSim
                                      bool require_voltage) const;
   std::unique_ptr<IRSolver> getIRSolver(bool require_voltage);
 
+  void saveIRDrop(IRSolver* ir_solver);
+
   odb::dbDatabase* db_ = nullptr;
   sta::dbSta* sta_ = nullptr;
   rsz::Resizer* resizer_ = nullptr;

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -149,9 +149,7 @@ void PDNSim::saveIRDrop(psm::IRSolver* ir_solver)
         = std::abs(ir_solver->getSupplyVoltageSrc() - voltage);
   }
   ir_drop_ = ir_drop;
-  min_resolution_ = ir_solver->getMinimumResolution();
 
-  heatmap_->update();
   if (debug_gui_) {
     debug_gui_->setSources(ir_solver->getSources());
   }
@@ -169,7 +167,6 @@ void PDNSim::analyzePowerGrid(const std::string& voltage_file,
     logger_->error(
         utl::PSM, 78, "IR drop setup failed.  Analysis can't proceed.");
   }
-  GMat* gmat_obj = irsolve_h->getGMat();
   const std::string corner_name
       = corner_ != nullptr ? corner_->name() : "default";
   const std::string metric_suffix
@@ -220,6 +217,8 @@ void PDNSim::analyzePowerGrid(const std::string& voltage_file,
   }
 
   saveIRDrop(irsolve_h.get());
+  min_resolution_ = irsolve_h->getMinimumResolution();
+  heatmap_->update();
 }
 
 bool PDNSim::checkConnectivity(const std::string& error_file)


### PR DESCRIPTION
Adds:
- tcl commands to access heatmap settings
- avoids using corner in dbSta for power density as this can segfault
- ensure nodes are saved after failed IRDrop analysis for better debugging.