### PR TITLE
Fixed the issue of skipping mpl2 directly after initializing the cell position

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -393,7 +393,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       const auto height
           = dbuToMicron(master->getHeight(), dbu_) + 2 * halo_width_;
       macro_with_halo_area += width * height;
-      unplaced_macros += !inst->getPlacementStatus().isPlaced();
+      unplaced_macros += !inst->getPlacementStatus().isFixed();
     }
   }
 


### PR DESCRIPTION
- Fixed the issue of skipping **mpl2** directly after initializing the cell position
    - For example, in `OpenROAD-flow-scripts`
, mixed sized placement is executed first, and then mpl2 is executed, so mpl2 will be skipped directly in present.