### PR TITLE
Fixed the issue of skipping mpl2 directly after initializing the cell position

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -384,7 +384,7 @@ void HierRTLMP::hierRTLMacroPlacer()
   // Check if placement is feasible in the core area when considering
   // the macro halos
   float macro_with_halo_area = 0;
-  int unplaced_macros = 0;
+  int unfixed_macros = 0;
   for (auto inst : block_->getInsts()) {
     auto master = inst->getMaster();
     if (master->isBlock()) {
@@ -393,7 +393,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       const auto height
           = dbuToMicron(master->getHeight(), dbu_) + 2 * halo_width_;
       macro_with_halo_area += width * height;
-      unplaced_macros += !inst->getPlacementStatus().isFixed();
+      unfixed_macros += !inst->getPlacementStatus().isFixed();
     }
   }
 
@@ -418,9 +418,9 @@ void HierRTLMP::hierRTLMacroPlacer()
       core_util,
       manufacturing_grid_);
 
-  if (unplaced_macros == 0) {
+  if (unfixed_macros == 0) {
     logger_->info(
-        MPL, 17, "There are no unplaced macros so placement is skipped.");
+        MPL, 17, "There are no unfixed macros so placement is skipped.");
     return;
   }
 

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -393,7 +393,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       const auto height
           = dbuToMicron(master->getHeight(), dbu_) + 2 * halo_width_;
       macro_with_halo_area += width * height;
-      unplaced_macros += !inst->getPlacementStatus().isPlaced();
+      unplaced_macros += !inst->getPlacementStatus().isFixed();
     }
   }
 


### PR DESCRIPTION
- Fixed the issue of skipping mpl2 directly after initializing the cell position
    - For example, in OpenROAD-flow-scripts, mixed sized placement is executed first, and then mpl2 is executed, so mpl2 will be skipped directly in present.