### PR TITLE
[rsz, pdn]: Fixes Strict Weak Ordering Violations

### DIFF
--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -1015,8 +1015,8 @@ bool ViaGenerator::isPreferredOver(const ViaGenerator* other) const
              getName(),
              other->getName());
 
-  const int cut_area_diff = getCutArea() - other->getCutArea();
-  if (cut_area_diff > 0) {
+  if (getCutArea() > other->getCutArea()) {
+    const int cut_area_diff = getCutArea() - other->getCutArea();
     debugPrint(logger_,
                utl::PDN,
                "ViaPreference",
@@ -1026,74 +1026,68 @@ bool ViaGenerator::isPreferredOver(const ViaGenerator* other) const
                cut_area_diff);
     return true;
   }
+  if (other->getCutArea() > getCutArea()) {
+    return false;
+  }
 
-  if (cut_area_diff == 0) {
-    const int bottom_height_diff
-        = other->getGeneratorHeight(true) - getGeneratorHeight(true);
-    const int bottom_width_diff
-        = other->getGeneratorWidth(true) - getGeneratorWidth(true);
-    const int top_height_diff
-        = other->getGeneratorHeight(false) - getGeneratorHeight(false);
-    const int top_width_diff
-        = other->getGeneratorWidth(false) - getGeneratorWidth(false);
+  const int bottom_height_diff
+      = other->getGeneratorHeight(true) - getGeneratorHeight(true);
+  const int bottom_width_diff
+      = other->getGeneratorWidth(true) - getGeneratorWidth(true);
+  const int top_height_diff
+      = other->getGeneratorHeight(false) - getGeneratorHeight(false);
+  const int top_width_diff
+      = other->getGeneratorWidth(false) - getGeneratorWidth(false);
 
-    const bool bottom_is_hor
-        = getBottomLayer()->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
-    const bool top_is_hor
-        = getTopLayer()->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
+  const bool bottom_is_hor
+      = getBottomLayer()->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
+  const bool top_is_hor
+      = getTopLayer()->getDirection() == odb::dbTechLayerDir::HORIZONTAL;
 
-    debugPrint(logger_,
-               utl::PDN,
-               "ViaPreference",
-               2,
-               "Bottom via diff ({}, {}, {}) and top diff ({}, {}, {})",
-               bottom_width_diff,
-               bottom_height_diff,
-               bottom_is_hor,
-               top_width_diff,
-               top_height_diff,
-               top_is_hor);
+  const int bottom_prefered
+      = bottom_is_hor ? bottom_height_diff : bottom_width_diff;
+  const int top_prefered = top_is_hor ? top_height_diff : top_width_diff;
+  const int bottom_non_prefered
+      = bottom_is_hor ? bottom_width_diff : bottom_height_diff;
+  const int top_non_prefered = top_is_hor ? top_width_diff : top_height_diff;
 
-    if (bottom_is_hor) {
-      if (bottom_height_diff < 0) {
-        return true;
-      }
-    } else {
-      if (bottom_width_diff < 0) {
-        return true;
-      }
-    }
+  debugPrint(logger_,
+             utl::PDN,
+             "ViaPreference",
+             2,
+             "Bottom via diff ({}, {}, {}) and top diff ({}, {}, {})",
+             bottom_width_diff,
+             bottom_height_diff,
+             bottom_is_hor,
+             top_width_diff,
+             top_height_diff,
+             top_is_hor);
 
-    if (top_is_hor) {
-      if (top_height_diff < 0) {
-        return true;
-      }
-    } else {
-      if (top_width_diff < 0) {
-        return true;
-      }
-    }
+  if (bottom_prefered < 0) {
+    return true;
+  }
+  if (bottom_prefered > 0) {
+    return false;
+  }
 
-    if (bottom_is_hor) {
-      if (bottom_width_diff < 0) {
-        return true;
-      }
-    } else {
-      if (bottom_height_diff < 0) {
-        return true;
-      }
-    }
+  if (top_prefered < 0) {
+    return true;
+  }
+  if (top_prefered > 0) {
+    return false;
+  }
 
-    if (top_is_hor) {
-      if (top_width_diff < 0) {
-        return true;
-      }
-    } else {
-      if (top_height_diff < 0) {
-        return true;
-      }
-    }
+  if (bottom_non_prefered < 0) {
+    return true;
+  }
+  if (bottom_non_prefered > 0) {
+    return false;
+  }
 
+  if (top_non_prefered < 0) {
+    return true;
+  }
+  if (top_non_prefered > 0) {
     return false;
   }
 

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -239,14 +239,27 @@ RepairSetup::rebufferBottomUp(BufferedNetPtr bnet,
     // larger required and smaller capacitance.
     // This is fanout^2.
     // Presort options to hit better options sooner.
-    sort(Z.begin(), Z.end(),
-         [=](BufferedNetPtr option1,
-             BufferedNetPtr option2)
-         { Slack slack1 = slackPenalized(option1);
+    sort(Z.begin(),
+         Z.end(),
+         [=](BufferedNetPtr option1, BufferedNetPtr option2) {
+           Slack slack1 = slackPenalized(option1);
            Slack slack2 = slackPenalized(option2);
-           return fuzzyGreater(slack1, slack2)
-             || (fuzzyEqual(slack1, slack2)
-                 && fuzzyLess(option1->cap(), option2->cap()));
+
+           if (slack1 > slack2) {
+             return true;
+           }
+           if (slack2 > slack1) {
+             return false;
+           }
+
+           if (option1->cap() < option2->cap()) {
+             return true;
+           }
+           if (option2->cap() < option1->cap()) {
+             return false;
+           }
+
+           return false;
          });
     int si = 0;
     for (size_t pi = 0; pi < Z.size(); pi++) {


### PR DESCRIPTION
Having non-compliant comparators can lead to crashes, infinite loops, or undefined behavior.

This commit makes the comparators follow strict weak ordering.

See:
https://github.com/bashrc-real/Codearchive/blob/master/cpp/Strict_weak_ordering_and_stl.md