### PR TITLE
mpl2: add command for writing macro placement

### DIFF
--- a/src/mpl/src/MacroPlacer.cpp
+++ b/src/mpl/src/MacroPlacer.cpp
@@ -706,7 +706,7 @@ vector<pair<Partition, Partition>> MacroPlacer::getPartitions(
         uClass = SE;
         break;
       default:
-        logger_->error(MPL, 12, "Unhandled partition class.");
+        logger_->error(MPL, 64, "Unhandled partition class.");
         lClass = W;
         uClass = E;
         break;
@@ -1285,7 +1285,7 @@ CoreEdge MacroPlacer::findNearestEdge(dbBTerm* bTerm)
   if (status == dbPlacementStatus::UNPLACED
       || status == dbPlacementStatus::NONE) {
     logger_->warn(
-        MPL, 11, "Pin {} is not placed, using west.", bTerm->getConstName());
+        MPL, 65, "Pin {} is not placed, using west.", bTerm->getConstName());
     return CoreEdge::West;
   } else {
     const double dbu = db_->getTech()->getDbUnitsPerMicron();

--- a/src/mpl2/README.md
+++ b/src/mpl2/README.md
@@ -44,6 +44,7 @@ rtl_macro_placer
     [-snap_layer snap_layer]
     [-bus_planning_flag bus_planning_flag]
     [-report_directory report_directory]
+    [-write_macro_placement file_name]
 ```
 
 #### Generic Parameters
@@ -66,6 +67,7 @@ rtl_macro_placer
 | `-snap_layer` | Snap macro origins to this routing layer track. The default value is 4, and the allowed values are integers `[1, MAX_LAYER]`). |
 | `-bus_planning_flag` | Flag to enable bus planning. The recommendation is to turn on bus planning for SKY130 and off for NanGate45/ASAP7. The default value is disabled. |
 | `-report_directory` | Save reports to this directory. |
+| `-write_macro_placement` | Generates a file with the macro placement in the format of multiple calls for the `place_macro` command. |
 
 
 #### Simulated Annealing Weight parameters
@@ -82,6 +84,33 @@ Do note that while action probabilities are normalized to 1.0, the weights are n
 | `-boundary_weight` | Weight for the boundary, or how far the hard macro clusters are from boundaries. Note that mixed macro clusters are not pushed, thus not considered in this cost.  The allowed values are floats, and the default value is `50.0`. |
 | `-notch_weight` | Weight for the notch, or the existence of dead space that cannot be used for placement & routing. Note that this cost applies only to hard macro clusters.  The allowed values are floats, and the default value is `10.0`. |
 | `-macro_blockage_weight` | Weight for macro blockage, or the overlapping instances of the macro.  The allowed values are floats, and the default value is `10.0`. |
+
+### Write Macro Placement
+
+Command to write a file with the macro placement in the format of multiple calls for the `place_macro` command:
+
+```tcl
+write_macro_placement file_name
+```
+
+### Place Macro
+
+Command for placement of one specific macro.
+
+```tcl
+place_macro
+    -macro_name macro_name
+    -location {x y}
+    [-orientation orientation]
+```
+
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-macro_name` | The name of a macro of the design. |
+| `-location` | The lower left corner of the macro in microns. |
+| `-orientation` | The orientation according to odb. If nothing is specified, defaults to `R0`.  We only allow `R0`, `MY`, `MX` and `R180`.  |
 
 ## Example scripts
 

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -102,8 +102,8 @@ class MacroPlacer2
              const char* report_directory);
 
   void placeMacro(odb::dbInst* inst,
-                  float x_origin,
-                  float y_origin,
+                  const float& x_origin,
+                  const float& y_origin,
                   const std::string& orientation_string);
   odb::dbOrientType stringToOrientType(const std::string& orientation_string);
 

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -106,8 +106,8 @@ class MacroPlacer2
                   const float& y_origin,
                   const odb::dbOrientType& orientation);
 
-  void setMacroPlacementFile(const char* file_name);
-  void writeMacroPlacement(const char* file_name);
+  void setMacroPlacementFile(const std::string& file_name);
+  void writeMacroPlacement(const std::string& file_name);
 
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);
 

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -101,10 +101,14 @@ class MacroPlacer2
              const bool bus_planning_flag,
              const char* report_directory);
 
+  void writeMacroPlacement(const char* file_name);
+
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);
 
  private:
   std::unique_ptr<HierRTLMP> hier_rtlmp_;
+
+  Logger* logger_ = nullptr;
 };
 
 }  // namespace mpl2

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -40,6 +40,7 @@
 namespace odb {
 class dbDatabase;
 class dbInst;
+class dbOrientType;
 }
 
 namespace sta {
@@ -100,7 +101,11 @@ class MacroPlacer2
              const bool bus_planning_flag,
              const char* report_directory);
 
-  void placeMacro(odb::dbInst* inst);
+  void placeMacro(odb::dbInst* inst,
+                  float x_origin,
+                  float y_origin,
+                  const std::string& orientation_string);
+  odb::dbOrientType stringToOrientType(const std::string& orientation_string);
 
   void writeMacroPlacement(const char* file_name);
 

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -41,7 +41,7 @@ namespace odb {
 class dbDatabase;
 class dbInst;
 class dbOrientType;
-}
+}  // namespace odb
 
 namespace sta {
 class dbNetwork;
@@ -107,6 +107,7 @@ class MacroPlacer2
                   const std::string& orientation_string);
   odb::dbOrientType stringToOrientType(const std::string& orientation_string);
 
+  void setMacroPlacementFile(const char* file_name);
   void writeMacroPlacement(const char* file_name);
 
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -115,6 +115,7 @@ class MacroPlacer2
   std::unique_ptr<HierRTLMP> hier_rtlmp_;
 
   utl::Logger* logger_ = nullptr;
+  odb::dbDatabase* db_ = nullptr;
 };
 
 }  // namespace mpl2

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -104,8 +104,7 @@ class MacroPlacer2
   void placeMacro(odb::dbInst* inst,
                   const float& x_origin,
                   const float& y_origin,
-                  const std::string& orientation_string);
-  odb::dbOrientType stringToOrientType(const std::string& orientation_string);
+                  const odb::dbOrientType& orientation);
 
   void setMacroPlacementFile(const char* file_name);
   void writeMacroPlacement(const char* file_name);

--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -35,18 +35,17 @@
 
 #include <memory>
 
+#include "utl/Logger.h"
+
 namespace odb {
 class dbDatabase;
+class dbInst;
 }
 
 namespace sta {
 class dbNetwork;
 class dbSta;
 }  // namespace sta
-
-namespace utl {
-class Logger;
-}
 
 namespace par {
 class PartitionMgr;
@@ -101,6 +100,8 @@ class MacroPlacer2
              const bool bus_planning_flag,
              const char* report_directory);
 
+  void placeMacro(odb::dbInst* inst);
+
   void writeMacroPlacement(const char* file_name);
 
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);
@@ -108,7 +109,7 @@ class MacroPlacer2
  private:
   std::unique_ptr<HierRTLMP> hier_rtlmp_;
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
 };
 
 }  // namespace mpl2

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -643,7 +643,7 @@ void HierRTLMP::hierRTLMacroPlacer()
 
   correctAllMacrosOrientation();
 
-  writeMacroPlacement(macro_placement_file_.c_str());
+  writeMacroPlacement(macro_placement_file_);
 
   // Clear the memory to avoid memory leakage
   // release all the pointers
@@ -6066,23 +6066,21 @@ void HierRTLMP::correctAllMacrosOrientation()
   }
 }
 
-void HierRTLMP::setMacroPlacementFile(const char* file_name)
+void HierRTLMP::setMacroPlacementFile(const std::string& file_name)
 {
   macro_placement_file_ = file_name;
 }
 
-void HierRTLMP::writeMacroPlacement(const char* file_name)
+void HierRTLMP::writeMacroPlacement(const std::string& file_name)
 {
-  std::string filename = file_name;
-
-  if (filename.empty()) {
+  if (file_name.empty()) {
     return;
   }
 
-  std::ofstream out(filename);
+  std::ofstream out(file_name);
 
   if (!out) {
-    logger_->error(MPL, 11, "Cannot open file {}.", filename);
+    logger_->error(MPL, 11, "Cannot open file {}.", file_name);
   }
 
   // Use only insts that were placed by mpl2

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -6085,8 +6085,8 @@ void HierRTLMP::writeMacroPlacement(const std::string& file_name)
 
   // Use only insts that were placed by mpl2
   for (auto& [inst, hard_macro] : hard_macro_map_) {
-    float x = dbuToMicron(inst->getLocation().x(), dbu_);
-    float y = dbuToMicron(inst->getLocation().y(), dbu_);
+    const float x = dbuToMicron(inst->getLocation().x(), dbu_);
+    const float y = dbuToMicron(inst->getLocation().y(), dbu_);
 
     out << "place_macro -macro_name " << inst->getName() << " -location {" << x
         << " " << y << "} -orientation " << inst->getOrient().getString()

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -643,6 +643,8 @@ void HierRTLMP::hierRTLMacroPlacer()
 
   correctAllMacrosOrientation();
 
+  writeMacroPlacement(macro_placement_file_.c_str());
+
   // Clear the memory to avoid memory leakage
   // release all the pointers
   // metrics map
@@ -6061,6 +6063,36 @@ void HierRTLMP::correctAllMacrosOrientation()
 
     inst->setOrigin(snap_origin.x(), snap_origin.y());
     inst->setPlacementStatus(odb::dbPlacementStatus::LOCKED);
+  }
+}
+
+void HierRTLMP::setMacroPlacementFile(const char* file_name)
+{
+  macro_placement_file_ = file_name;
+}
+
+void HierRTLMP::writeMacroPlacement(const char* file_name)
+{
+  std::string filename = file_name;
+
+  if (filename.empty()) {
+    return;
+  }
+
+  std::ofstream out(filename);
+
+  if (!out) {
+    logger_->error(MPL, 11, "Cannot open file {}.", filename);
+  }
+
+  // Use only insts that were placed by mpl2
+  for (auto& [inst, hard_macro] : hard_macro_map_) {
+    float x = dbuToMicron(inst->getLocation().x(), dbu_);
+    float y = dbuToMicron(inst->getLocation().y(), dbu_);
+
+    out << "place_macro -macro_name " << inst->getName() << " -location {" << x
+        << " " << y << "} -orientation " << inst->getOrient().getString()
+        << '\n';
   }
 }
 

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -145,8 +145,8 @@ class HierRTLMP
     bus_planning_flag_ = bus_planning_flag;
   }
 
-  void setMacroPlacementFile(const char* file_name);
-  void writeMacroPlacement(const char* file_name);
+  void setMacroPlacementFile(const std::string& file_name);
+  void writeMacroPlacement(const std::string& file_name);
 
  private:
   void setDefaultThresholds();

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -145,6 +145,9 @@ class HierRTLMP
     bus_planning_flag_ = bus_planning_flag;
   }
 
+  void setMacroPlacementFile(const char* file_name);
+  void writeMacroPlacement(const char* file_name);
+
  private:
   void setDefaultThresholds();
   void createDataFlow();
@@ -290,6 +293,8 @@ class HierRTLMP
 
   // Parameters related to macro placement
   std::string report_directory_;
+  std::string macro_placement_file_;
+
   // User can specify a global region for some designs
   float global_fence_lx_ = std::numeric_limits<float>::max();
   float global_fence_ly_ = std::numeric_limits<float>::max();

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -138,6 +138,12 @@ place_macro(odb::dbInst* macro_name, float x_origin, float y_origin, const char*
 }
 
 void
+set_macro_placement_file(const char* file_name)
+{
+  getMacroPlacer2()->setMacroPlacementFile(file_name);
+}
+
+void
 write_macro_placement(const char* file_name)
 {
   getMacroPlacer2()->writeMacroPlacement(file_name);

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -146,13 +146,13 @@ place_macro(odb::dbInst* inst, float x_origin, float y_origin, std::string orien
 }
 
 void
-set_macro_placement_file(const char* file_name)
+set_macro_placement_file(std::string file_name)
 {
   getMacroPlacer2()->setMacroPlacementFile(file_name);
 }
 
 void
-write_macro_placement(const char* file_name)
+write_macro_placement(std::string file_name)
 {
   getMacroPlacer2()->writeMacroPlacement(file_name);
 }

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -130,9 +130,11 @@ set_debug_cmd()
 }
 
 void
-place_macro(odb::dbInst* macro_name)
+place_macro(odb::dbInst* macro_name, float x_origin, float y_origin, const char* orientation)
 {
-  getMacroPlacer2()->placeMacro(macro_name);
+  std::string orientation_string = orientation;
+
+  getMacroPlacer2()->placeMacro(macro_name, x_origin, y_origin, orientation_string);
 }
 
 void

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -45,6 +45,7 @@ utl::Logger* getLogger();
 odb::dbDatabase* getDb();
 }
 
+using utl::MPL;
 using ord::getMacroPlacer2;
 %}
 
@@ -131,9 +132,17 @@ set_debug_cmd()
 }
 
 void
-place_macro(odb::dbInst* macro_name, float x_origin, float y_origin, std::string orientation_string)
+place_macro(odb::dbInst* inst, float x_origin, float y_origin, std::string orientation_string)
 {
-  getMacroPlacer2()->placeMacro(macro_name, x_origin, y_origin, orientation_string);
+  odb::dbOrientType orientation(orientation_string.c_str());
+
+  utl::Logger* logger = ord::getLogger();
+
+  if (orientation.isRightAngleRotation()) {
+    logger->warn(MPL, 36, "Orientation {} specified for macro {} is a right angle rotation.", orientation_string, inst->getName());
+  }
+
+  getMacroPlacer2()->placeMacro(inst, x_origin, y_origin, orientation);
 }
 
 void

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -130,6 +130,12 @@ set_debug_cmd()
 }
 
 void
+place_macro(odb::dbInst* macro_name)
+{
+  getMacroPlacer2()->placeMacro(macro_name);
+}
+
+void
 write_macro_placement(const char* file_name)
 {
   getMacroPlacer2()->writeMacroPlacement(file_name);

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -129,6 +129,12 @@ set_debug_cmd()
   macro_placer->setDebug(graphics);
 }
 
+void
+write_macro_placement(const char* file_name)
+{
+  getMacroPlacer2()->writeMacroPlacement(file_name);
+}
+
 } // namespace
 
 %} // inline

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -49,6 +49,7 @@ using ord::getMacroPlacer2;
 %}
 
 %include "../../Exception.i"
+%include <std_string.i>
 
 %inline %{
 
@@ -130,10 +131,8 @@ set_debug_cmd()
 }
 
 void
-place_macro(odb::dbInst* macro_name, float x_origin, float y_origin, const char* orientation)
+place_macro(odb::dbInst* macro_name, float x_origin, float y_origin, std::string orientation_string)
 {
-  std::string orientation_string = orientation;
-
   getMacroPlacer2()->placeMacro(macro_name, x_origin, y_origin, orientation_string);
 }
 

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -62,6 +62,7 @@ sta::define_cmd_args "rtl_macro_placer" { -max_num_macro  max_num_macro \
                                           -snap_layer snap_layer \
                                           -bus_planning_flag bus_planning_flag \
                                           -report_directory report_directory \
+                                          -write_macro_placement file_name \
                                         }
 proc rtl_macro_placer { args } {
     sta::parse_key_args "rtl_macro_placer" args keys { 
@@ -75,6 +76,7 @@ proc rtl_macro_placer { args } {
         -target_dead_space -min_ar -snap_layer \
         -bus_planning_flag \
         -report_directory \
+        -write_macro_placement \
     } flag {  }
 #
 # Check for valid design
@@ -216,10 +218,14 @@ proc rtl_macro_placer { args } {
       set bus_planning_flag $keys(-bus_planning_flag)
     }
     if { [info exists keys(-report_directory)] } {
-        set report_directory $keys(-report_directory)
+      set report_directory $keys(-report_directory)
     }
         
     file mkdir $report_directory
+
+    if { [info exists keys(-write_macro_placement)] } {
+      mpl2::set_macro_placement_file $keys(-write_macro_placement)
+    }
 
     if {![mpl2::rtl_macro_placer_cmd  $max_num_macro  \
                                       $min_num_macro  \

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -258,8 +258,8 @@ proc rtl_macro_placer { args } {
     return true
 }
 
-sta::define_cmd_args "place_macro" {[-macro_name macro_name] \
-                                    [-location location] \
+sta::define_cmd_args "place_macro" {-macro_name macro_name \
+                                    -location location \
                                     [-orientation orientation] \
 }
 

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -252,6 +252,13 @@ proc rtl_macro_placer { args } {
     return true
 }
 
+sta::define_cmd_args "write_macro_placement" { file_name }
+
+proc write_macro_placement { args } {
+  set file_name $args
+  mpl2::write_macro_placement $file_name
+}
+
 namespace eval mpl2 {
 proc mpl_debug { args } {
   mpl2::set_debug_cmd

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -252,11 +252,14 @@ proc rtl_macro_placer { args } {
     return true
 }
 
-sta::define_cmd_args "place_macro" {[-macro_name macro_name]}
+sta::define_cmd_args "place_macro" {[-macro_name macro_name] \
+                                    [-location location] \
+                                    [-orientation orientation] \
+}
 
 proc place_macro { args } {
   sta::parse_key_args "place_macro" args \
-  keys {-macro_name} \
+  keys {-macro_name -location -orientation} \
 
   if [info exists keys(-macro_name)] {
     set macro_name $keys(-macro_name)
@@ -266,7 +269,27 @@ proc place_macro { args } {
 
   set macro [mpl2::parse_macro_name "place_macro" $macro_name]
 
-  mpl2::place_macro $macro
+  if [info exists keys(-location)] {
+    set location $keys(-location)
+  } else {
+    utl::error MPL 22 "-location is required."
+  }
+
+  if { [llength $location] != 2 } {
+    utl::error MPL 12 "-location is not a list of 2 values."
+  }
+  lassign $location x_origin y_origin
+  set x_origin $x_origin
+  set y_origin $y_origin
+
+  set orientation R0
+  if [info exists keys(-orientation)] {
+    set orientation $keys(-orientation)
+  } else {
+    utl::warn MPL 18 "No orientation specified for [$macro getName], defaulting to R0."
+  }
+
+  mpl2::place_macro $macro $x_origin $y_origin $orientation
 }
 
 sta::define_cmd_args "write_macro_placement" { file_name }

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -252,6 +252,23 @@ proc rtl_macro_placer { args } {
     return true
 }
 
+sta::define_cmd_args "place_macro" {[-macro_name macro_name]}
+
+proc place_macro { args } {
+  sta::parse_key_args "place_macro" args \
+  keys {-macro_name} \
+
+  if [info exists keys(-macro_name)] {
+    set macro_name $keys(-macro_name)
+  } else {
+    utl::error MPL 19 "-macro_name is required."
+  }
+
+  set macro [mpl2::parse_macro_name "place_macro" $macro_name]
+
+  mpl2::place_macro $macro
+}
+
 sta::define_cmd_args "write_macro_placement" { file_name }
 
 proc write_macro_placement { args } {
@@ -260,7 +277,22 @@ proc write_macro_placement { args } {
 }
 
 namespace eval mpl2 {
+
+proc parse_macro_name {cmd macro_name} {
+  set block [ord::get_db_block]
+  set inst [$block findInst "$macro_name"]
+
+  if { $inst == "NULL" } {
+    utl::error MPL 20 "Couldn't find a macro named $macro_name."
+  } elseif { ![$inst isBlock] } {
+    utl::error MPL 21 "[$inst getName] is not a macro."
+  }
+
+  return $inst
+}
+
 proc mpl_debug { args } {
   mpl2::set_debug_cmd
 }
+
 }

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -180,12 +180,12 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
                 orientation.getString());
 }
 
-void MacroPlacer2::setMacroPlacementFile(const char* file_name)
+void MacroPlacer2::setMacroPlacementFile(const std::string& file_name)
 {
   hier_rtlmp_->setMacroPlacementFile(file_name);
 }
 
-void MacroPlacer2::writeMacroPlacement(const char* file_name)
+void MacroPlacer2::writeMacroPlacement(const std::string& file_name)
 {
   hier_rtlmp_->writeMacroPlacement(file_name);
 }

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -123,30 +123,10 @@ bool MacroPlacer2::place(const int max_num_macro,
   return true;
 }
 
-odb::dbOrientType MacroPlacer2::stringToOrientType(
-    const std::string& orientation_string)
-{
-  odb::dbOrientType orientation;
-
-  if (orientation_string == "R0") {
-    orientation = odb::dbOrientType::R0;
-  } else if (orientation_string == "MY") {
-    orientation = odb::dbOrientType::MY;
-  } else if (orientation_string == "MX") {
-    orientation = odb::dbOrientType::MX;
-  } else if (orientation_string == "R180") {
-    orientation = odb::dbOrientType::R180;
-  } else {
-    logger_->error(MPL, 33, "Invalid orientation {}.", orientation_string);
-  }
-
-  return orientation;
-}
-
 void MacroPlacer2::placeMacro(odb::dbInst* inst,
                               const float& x_origin,
                               const float& y_origin,
-                              const std::string& orientation_string)
+                              const odb::dbOrientType& orientation)
 {
   float dbu_per_micron = db_->getTech()->getDbUnitsPerMicron();
 
@@ -164,8 +144,6 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
                    "Specified location results in illegal placement. Cannot "
                    "place macro outside of the core.");
   }
-
-  odb::dbOrientType orientation = stringToOrientType(orientation_string);
 
   // Orientation must be set before location so we don't end up flipping
   // and misplacing the macro.

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -36,7 +36,7 @@
 #include "Mpl2Observer.h"
 #include "hier_rtlmp.h"
 #include "object.h"
-#include "utl/Logger.h"
+#include "odb/db.h"
 
 namespace mpl2 {
 using odb::dbDatabase;
@@ -122,6 +122,11 @@ bool MacroPlacer2::place(const int max_num_macro,
   return true;
 }
 
+void MacroPlacer2::placeMacro(odb::dbInst* inst)
+{
+  std::cout << "Macro = " << inst->getName() << '\n';
+}
+
 void MacroPlacer2::writeMacroPlacement(const char* file_name)
 {
   std::string filename = file_name;
@@ -132,7 +137,7 @@ void MacroPlacer2::writeMacroPlacement(const char* file_name)
   std::ofstream out(filename);
 
   if (!out) {
-    logger_->error(MPL, 11, "Cannot open file {}.", filename)
+    logger_->error(MPL, 11, "Cannot open file {}.", filename);
   }
 }
 

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -189,6 +189,17 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
       macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
 
   inst->setPlacementStatus(odb::dbPlacementStatus::LOCKED);
+
+  logger_->info(MPL,
+                35,
+                "Macro {} placed. Bounding box ({:.3f}um, {:.3f}um), "
+                "({:.3f}um, {:.3f}um). Orientation {}",
+                inst->getName(),
+                macro_new_bbox_micron.xMin(),
+                macro_new_bbox_micron.yMin(),
+                macro_new_bbox_micron.xMax(),
+                macro_new_bbox_micron.yMax(),
+                orientation.getString());
 }
 
 void MacroPlacer2::setMacroPlacementFile(const char* file_name)

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -144,16 +144,16 @@ odb::dbOrientType MacroPlacer2::stringToOrientType(
 }
 
 void MacroPlacer2::placeMacro(odb::dbInst* inst,
-                              float x_origin,
-                              float y_origin,
+                              const float& x_origin,
+                              const float& y_origin,
                               const std::string& orientation_string)
 {
   float dbu_per_micron = db_->getTech()->getDbUnitsPerMicron();
 
-  int x1 = micronToDbu(x_origin, dbu_per_micron);
-  int y1 = micronToDbu(y_origin, dbu_per_micron);
-  int x2 = x1 + inst->getBBox()->getDX();
-  int y2 = y1 + inst->getBBox()->getDY();
+  const int x1 = micronToDbu(x_origin, dbu_per_micron);
+  const int y1 = micronToDbu(y_origin, dbu_per_micron);
+  const int x2 = x1 + inst->getBBox()->getDX();
+  const int y2 = y1 + inst->getBBox()->getDY();
 
   odb::Rect macro_new_bbox(x1, y1, x2, y2);
   odb::Rect core_area = inst->getBlock()->getCoreArea();

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -157,7 +157,7 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
 
   odb::Rect macro_new_bbox(x1, y1, x2, y2);
   odb::Rect core_area = inst->getBlock()->getCoreArea();
-  
+
   if (!core_area.contains(macro_new_bbox)) {
     logger_->error(MPL,
                    34,
@@ -176,31 +176,29 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
 
   HardMacro macro(inst, dbu_per_micron, manufacturing_grid, 0, 0);
 
-  mpl2::Rect macro_new_bbox_micron(x_origin,
-                                   y_origin,
-                                   dbuToMicron(macro_new_bbox.xMax(), dbu_per_micron),
-                                   dbuToMicron(macro_new_bbox.yMax(), dbu_per_micron));
+  mpl2::Rect macro_new_bbox_micron(
+      x_origin,
+      y_origin,
+      dbuToMicron(macro_new_bbox.xMax(), dbu_per_micron),
+      dbuToMicron(macro_new_bbox.yMax(), dbu_per_micron));
 
   float pitch_x = 0.0;
   float pitch_y = 0.0;
 
-  macro.alignOriginWithGrids(macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
+  macro.alignOriginWithGrids(
+      macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
 
   inst->setPlacementStatus(odb::dbPlacementStatus::LOCKED);
 }
 
+void MacroPlacer2::setMacroPlacementFile(const char* file_name)
+{
+  hier_rtlmp_->setMacroPlacementFile(file_name);
+}
+
 void MacroPlacer2::writeMacroPlacement(const char* file_name)
 {
-  std::string filename = file_name;
-  if (filename.empty()) {
-    return;
-  }
-
-  std::ofstream out(filename);
-
-  if (!out) {
-    logger_->error(MPL, 11, "Cannot open file {}.", filename);
-  }
+  hier_rtlmp_->writeMacroPlacement(file_name);
 }
 
 void MacroPlacer2::setDebug(std::unique_ptr<Mpl2Observer>& graphics)

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -122,9 +122,36 @@ bool MacroPlacer2::place(const int max_num_macro,
   return true;
 }
 
-void MacroPlacer2::placeMacro(odb::dbInst* inst)
+odb::dbOrientType MacroPlacer2::stringToOrientType(const std::string& orientation_string)
+{
+  odb::dbOrientType orientation;
+
+  if (orientation_string == "R0") {
+    orientation = odb::dbOrientType::R0;
+  } else if (orientation_string == "MY") {
+    orientation = odb::dbOrientType::MY;
+  } else if (orientation_string == "MX") {
+    orientation = odb::dbOrientType::MX;
+  } else if (orientation_string == "R180") {
+    orientation = odb::dbOrientType::R180;
+  } else {
+    logger_->error(MPL, 33, "Invalid orientation {}.", orientation_string);
+  }
+
+  return orientation;
+}
+
+void MacroPlacer2::placeMacro(odb::dbInst* inst,
+                              float x_origin,
+                              float y_origin,
+                              const std::string& orientation_string)
 {
   std::cout << "Macro = " << inst->getName() << '\n';
+  std::cout << "Origin Location = " << x_origin << " " << y_origin << '\n';
+  
+  odb::dbOrientType orientation = stringToOrientType(orientation_string);
+
+  std::cout << "Orientation = " << orientation.getString() << '\n';
 }
 
 void MacroPlacer2::writeMacroPlacement(const char* file_name)

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -56,6 +56,7 @@ void MacroPlacer2::init(sta::dbNetwork* network,
 {
   hier_rtlmp_
       = std::make_unique<HierRTLMP>(network, db, sta, logger, tritonpart);
+  logger_ = logger;
 }
 
 bool MacroPlacer2::place(const int max_num_macro,
@@ -119,6 +120,20 @@ bool MacroPlacer2::place(const int max_num_macro,
   hier_rtlmp_->hierRTLMacroPlacer();
 
   return true;
+}
+
+void MacroPlacer2::writeMacroPlacement(const char* file_name)
+{
+  std::string filename = file_name;
+  if (filename.empty()) {
+    return;
+  }
+
+  std::ofstream out(filename);
+
+  if (!out) {
+    logger_->error(MPL, 11, "Cannot open file {}.", filename)
+  }
 }
 
 void MacroPlacer2::setDebug(std::unique_ptr<Mpl2Observer>& graphics)

--- a/src/mpl2/test/mp_test1.tcl
+++ b/src/mpl2/test/mp_test1.tcl
@@ -22,6 +22,8 @@ link_design $top_module
 #
 read_def $floorplan_def -floorplan_initialize
 
+
+place_macro -macro_name xabalau
 rtl_macro_placer -report_directory results/mp_test1 -halo_width 5.0
 
 set def_file [make_result_file mp_test1.def]

--- a/src/mpl2/test/mp_test1.tcl
+++ b/src/mpl2/test/mp_test1.tcl
@@ -22,12 +22,6 @@ link_design $top_module
 #
 read_def $floorplan_def -floorplan_initialize
 
-place_macro -macro_name U1 -location {20 20}
-place_macro -macro_name U2 -location {34 34} -orientation R180
-place_macro -macro_name U3 -location {34 34} -orientation MY
-place_macro -macro_name U4 -location {34 34} -orientation MX
-place_macro -macro_name U5 -location {34 34} -orientation R0
-place_macro -macro_name U5 -location {34 34} -orientation chelou
 rtl_macro_placer -report_directory results/mp_test1 -halo_width 5.0
 
 set def_file [make_result_file mp_test1.def]

--- a/src/mpl2/test/mp_test1.tcl
+++ b/src/mpl2/test/mp_test1.tcl
@@ -22,8 +22,12 @@ link_design $top_module
 #
 read_def $floorplan_def -floorplan_initialize
 
-
-place_macro -macro_name xabalau
+place_macro -macro_name U1 -location {20 20}
+place_macro -macro_name U2 -location {34 34} -orientation R180
+place_macro -macro_name U3 -location {34 34} -orientation MY
+place_macro -macro_name U4 -location {34 34} -orientation MX
+place_macro -macro_name U5 -location {34 34} -orientation R0
+place_macro -macro_name U5 -location {34 34} -orientation chelou
 rtl_macro_placer -report_directory results/mp_test1 -halo_width 5.0
 
 set def_file [make_result_file mp_test1.def]

--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -109,6 +109,11 @@ class dbOrientType
   ///
   dbOrientType flipY() const;
 
+  ///
+  /// Returns true if the orientation is any kind of 90 degrees rotation
+  ///
+  bool isRightAngleRotation() const;
+
  private:
   Value _value;
 };

--- a/src/odb/src/db/dbTypes.cpp
+++ b/src/odb/src/db/dbTypes.cpp
@@ -188,6 +188,24 @@ dbOrientType dbOrientType::flipY() const
   return R0;
 }
 
+bool dbOrientType::isRightAngleRotation() const
+{
+  switch (_value) {
+    case R90:
+    case R270:
+    case MYR90:
+    case MXR90:
+      return true;
+    case R0:
+    case R180:
+    case MY:
+    case MX:
+      return false;
+  }
+  assert(false);
+  return false;
+}
+
 dbGroupType::dbGroupType(const char* orient)
 {
   if (strcasecmp(orient, "PHYSICAL_CLUSTER") == 0)


### PR DESCRIPTION
Resolves #4068 

In this PR I'm also implementing the command `place_macro` to place macros individually.
The output file of write_macro_placement will be written in the format of `place_macro` commands
as we currently do in PPL.