### PR TITLE
gui: use one control for drawing bterms' marker, geometry and text in the layout

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -457,7 +457,7 @@ DisplayControls::DisplayControls(QWidget* parent)
   makeLeafItem(
       instance_shapes_.pins, "Pins", instance_shape, Qt::Checked, true);
   makeLeafItem(instance_shapes_.iterm_labels,
-               "Pin labels",
+               "Pin Names",
                instance_shape,
                Qt::Unchecked,
                false,

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -423,9 +423,9 @@ DisplayControls::DisplayControls(QWidget* parent)
   makeParentItem(site_group_, "Rows", root, Qt::Unchecked, true);
 
   // Rows
-  makeParentItem(pin_markers_, "Pin Markers", root, Qt::Checked);
+  makeParentItem(io_pins_, "Pins", root, Qt::Checked);
   pin_markers_font_ = QApplication::font();  // use default font
-  setNameItemDoubleClickAction(pin_markers_, [this]() {
+  setNameItemDoubleClickAction(io_pins_, [this]() {
     pin_markers_font_ = QFontDialog::getFont(
         nullptr, pin_markers_font_, this, "Pin marker font");
   });
@@ -655,7 +655,7 @@ void DisplayControls::readSettings(QSettings* settings)
   readSettingsForRow(settings, nets_group_);
   readSettingsForRow(settings, instance_group_);
   readSettingsForRow(settings, blockage_group_);
-  readSettingsForRow(settings, pin_markers_);
+  readSettingsForRow(settings, io_pins_);
   readSettingsForRow(settings, rulers_);
   readSettingsForRow(settings, tracks_group_);
   readSettingsForRow(settings, misc_group_);
@@ -729,7 +729,7 @@ void DisplayControls::writeSettings(QSettings* settings)
   writeSettingsForRow(settings, nets_group_);
   writeSettingsForRow(settings, instance_group_);
   writeSettingsForRow(settings, blockage_group_);
-  writeSettingsForRow(settings, pin_markers_);
+  writeSettingsForRow(settings, io_pins_);
   writeSettingsForRow(settings, rulers_);
   writeSettingsForRow(settings, tracks_group_);
   writeSettingsForRow(settings, misc_group_);
@@ -1647,9 +1647,9 @@ bool DisplayControls::isScaleBarVisible() const
   return isModelRowVisible(&misc_.scale_bar);
 }
 
-bool DisplayControls::arePinMarkersVisible() const
+bool DisplayControls::areIOPinsVisible() const
 {
-  return isModelRowVisible(&pin_markers_);
+  return isModelRowVisible(&io_pins_);
 }
 
 QFont DisplayControls::pinMarkersFont()

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -239,7 +239,7 @@ class DisplayControls : public QDockWidget,
   bool areSelectedVisible() override;
 
   bool isScaleBarVisible() const override;
-  bool arePinMarkersVisible() const override;
+  bool areIOPinsVisible() const override;
   QFont pinMarkersFont() override;
   bool areAccessPointsVisible() const override;
   bool areRegionsVisible() const override;
@@ -504,7 +504,7 @@ class DisplayControls : public QDockWidget,
 
   // Object controls
   NetModels nets_;
-  ModelRow pin_markers_;
+  ModelRow io_pins_;
   ModelRow rulers_;
   BlockageModels blockages_;
   TrackModels tracks_;

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -94,7 +94,7 @@ class Options
   virtual bool areSelectedVisible() = 0;
 
   virtual bool isScaleBarVisible() const = 0;
-  virtual bool arePinMarkersVisible() const = 0;
+  virtual bool areIOPinsVisible() const = 0;
   virtual QFont pinMarkersFont() = 0;
   virtual bool areAccessPointsVisible() const = 0;
   virtual bool areRegionsVisible() const = 0;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1124,11 +1124,11 @@ void RenderThread::drawBlock(QPainter* painter,
   drawRegions(painter, block);
   debugPrint(logger_, GUI, "draw", 1, "regions {}", inst_regions);
 
-  utl::Timer inst_pin_markers;
-  if (viewer_->options_->arePinMarkersVisible()) {
-    drawPinMarkers(gui_painter, block, bounds);
+  utl::Timer inst_io_pins;
+  if (viewer_->options_->areIOPinsVisible()) {
+    drawIOPins(gui_painter, block, bounds);
   }
-  debugPrint(logger_, GUI, "draw", 1, "pin markers {}", inst_pin_markers);
+  debugPrint(logger_, GUI, "draw", 1, "io pins {}", inst_io_pins);
 
   utl::Timer inst_cell_grid;
   drawGCellGrid(painter, bounds);
@@ -1387,9 +1387,9 @@ void RenderThread::drawModuleView(QPainter* painter,
   }
 }
 
-void RenderThread::drawPinMarkers(Painter& painter,
-                                  odb::dbBlock* block,
-                                  const odb::Rect& bounds)
+void RenderThread::drawIOPins(Painter& painter,
+                              odb::dbBlock* block,
+                              const odb::Rect& bounds)
 {
   auto die_area = block->getDieArea();
   auto die_width = die_area.dx();
@@ -1499,6 +1499,7 @@ void RenderThread::drawPinMarkers(Painter& painter,
         if (!box) {
           continue;
         }
+
         Point pin_center((box->xMin() + box->xMax()) / 2,
                          (box->yMin() + box->yMax()) / 2);
 
@@ -1554,7 +1555,14 @@ void RenderThread::drawPinMarkers(Painter& painter,
           marker.push_back(new_pt);
         }
 
+        // draw marker to indicate signal direction
         painter.drawPolygon(marker);
+
+        if (!viewer_->isNetVisible(term->getNet())) {
+          // draw pin's geometry only when it's not
+          // already being drawn by its Net
+          painter.drawRect(box->getBox());
+        }
 
         if (draw_names) {
           Point text_anchor_pt = xfm.getOffset();

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -132,9 +132,9 @@ class RenderThread : public QThread
   void drawGCellGrid(QPainter* painter, const odb::Rect& bounds);
   void drawSelected(Painter& painter, const SelectionSet& selected);
   void drawHighlighted(Painter& painter, const HighlightSet& highlighted);
-  void drawPinMarkers(Painter& painter,
-                      odb::dbBlock* block,
-                      const odb::Rect& bounds);
+  void drawIOPins(Painter& painter,
+                  odb::dbBlock* block,
+                  const odb::Rect& bounds);
   void drawAccessPoints(Painter& painter,
                         const std::vector<odb::dbInst*>& insts);
   void drawRouteGuides(Painter& painter, odb::dbTechLayer* layer);


### PR DESCRIPTION
#Resolves #4050

Also renaming "Misc->Instances->Pin labels" to "Misc->Instances->Pin Name".