### PR TITLE
mpl2: corrections in place_macro

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -6058,7 +6058,7 @@ void HierRTLMP::correctAllMacrosOrientation()
 
     const odb::dbOrientType inst_orientation = inst->getOrient();
 
-    const odb::Point snap_origin = hard_macro->alignOriginWithGrids(
+    const odb::Point snap_origin = hard_macro->computeSnapOrigin(
         inst_box, inst_orientation, pitch_x_, pitch_y_, block_);
 
     inst->setOrigin(snap_origin.x(), snap_origin.y());

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -6003,6 +6003,13 @@ float HierRTLMP::calculateRealMacroWirelength(odb::dbInst* macro)
           wirelength += (std::abs(x2 - x1) + std::abs(y2 - y1));
         }
       }
+
+      for (odb::dbBTerm* net_bterm : net->getBTerms()) {
+        const float x2 = dbuToMicron(net_bterm->getBBox().xCenter(), dbu_);
+        const float y2 = dbuToMicron(net_bterm->getBBox().yCenter(), dbu_);
+
+        wirelength += (std::abs(x2 - x1) + std::abs(y2 - y1));
+      }
     }
   }
 

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -136,12 +136,6 @@ place_macro(odb::dbInst* inst, float x_origin, float y_origin, std::string orien
 {
   odb::dbOrientType orientation(orientation_string.c_str());
 
-  utl::Logger* logger = ord::getLogger();
-
-  if (orientation.isRightAngleRotation()) {
-    logger->warn(MPL, 36, "Orientation {} specified for macro {} is a right angle rotation.", orientation_string, inst->getName());
-  }
-
   getMacroPlacer2()->placeMacro(inst, x_origin, y_origin, orientation);
 }
 

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -396,11 +396,11 @@ class HardMacro
   // update the location and orientation of the macro inst in OpenDB
   // The macro should be snaped to placement grids
   void updateDb(float pitch_x, float pitch_y, odb::dbBlock* block);
-  odb::Point alignOriginWithGrids(const Rect& macro_box,
-                                  const odb::dbOrientType& orientation,
-                                  float& pitch_x,
-                                  float& pitch_y,
-                                  odb::dbBlock* block);
+  odb::Point computeSnapOrigin(const Rect& macro_box,
+                               const odb::dbOrientType& orientation,
+                               float& pitch_x,
+                               float& pitch_y,
+                               odb::dbBlock* block);
 
   void computeDirectionSpacingParameters(odb::dbBlock* block,
                                          odb::dbTechLayer* layer,

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -145,7 +145,9 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
                    "place macro outside of the core.");
   }
 
-  // Orientation must be set before location so we don't end up flipping
+  // As HardMacro is created from inst, the latter must be placed before
+  // we actually snap the macro to align the pins with the grids. Also,
+  // orientation must be set before location so we don't end up flipping
   // and misplacing the macro.
   inst->setOrient(orientation);
   inst->setLocation(x1, y1);
@@ -163,9 +165,11 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
   float pitch_x = 0.0;
   float pitch_y = 0.0;
 
-  macro.alignOriginWithGrids(
+  odb::Point snap_origin = macro.computeSnapOrigin(
       macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
 
+  // Orientation is already set, so now we set the origin to snap macro.
+  inst->setOrigin(snap_origin.x(), snap_origin.y());
   inst->setPlacementStatus(odb::dbPlacementStatus::LOCKED);
 
   logger_->info(MPL,
@@ -173,10 +177,10 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
                 "Macro {} placed. Bounding box ({:.3f}um, {:.3f}um), "
                 "({:.3f}um, {:.3f}um). Orientation {}",
                 inst->getName(),
-                macro_new_bbox_micron.xMin(),
-                macro_new_bbox_micron.yMin(),
-                macro_new_bbox_micron.xMax(),
-                macro_new_bbox_micron.yMax(),
+                dbuToMicron(inst->getBBox()->xMin(), dbu_per_micron),
+                dbuToMicron(inst->getBBox()->yMin(), dbu_per_micron),
+                dbuToMicron(inst->getBBox()->xMax(), dbu_per_micron),
+                dbuToMicron(inst->getBBox()->yMax(), dbu_per_micron),
                 orientation.getString());
 }
 

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -152,24 +152,34 @@ void MacroPlacer2::placeMacro(odb::dbInst* inst,
   inst->setOrient(orientation);
   inst->setLocation(x1, y1);
 
-  int manufacturing_grid = db_->getTech()->getManufacturingGrid();
+  if (!orientation.isRightAngleRotation()) {
+    int manufacturing_grid = db_->getTech()->getManufacturingGrid();
 
-  HardMacro macro(inst, dbu_per_micron, manufacturing_grid, 0, 0);
+    HardMacro macro(inst, dbu_per_micron, manufacturing_grid, 0, 0);
 
-  mpl2::Rect macro_new_bbox_micron(
-      x_origin,
-      y_origin,
-      dbuToMicron(macro_new_bbox.xMax(), dbu_per_micron),
-      dbuToMicron(macro_new_bbox.yMax(), dbu_per_micron));
+    mpl2::Rect macro_new_bbox_micron(
+        x_origin,
+        y_origin,
+        dbuToMicron(macro_new_bbox.xMax(), dbu_per_micron),
+        dbuToMicron(macro_new_bbox.yMax(), dbu_per_micron));
 
-  float pitch_x = 0.0;
-  float pitch_y = 0.0;
+    float pitch_x = 0.0;
+    float pitch_y = 0.0;
 
-  odb::Point snap_origin = macro.computeSnapOrigin(
-      macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
+    odb::Point snap_origin = macro.computeSnapOrigin(
+        macro_new_bbox_micron, orientation, pitch_x, pitch_y, inst->getBlock());
 
-  // Orientation is already set, so now we set the origin to snap macro.
-  inst->setOrigin(snap_origin.x(), snap_origin.y());
+    // Orientation is already set, so now we set the origin to snap macro.
+    inst->setOrigin(snap_origin.x(), snap_origin.y());
+  } else {
+    logger_->warn(
+        MPL,
+        36,
+        "Orientation {} specified for macro {} is a right angle rotation.",
+        orientation.getString(),
+        inst->getName());
+  }
+
   inst->setPlacementStatus(odb::dbPlacementStatus::LOCKED);
 
   logger_->info(MPL,


### PR DESCRIPTION
I'm making three corrections here:
1. I used wrongly the function to snap the macro. The name I chose for the function was misleading its use, so I changed it. I'm using the function correctly now.

2. I realized then that this same function would not work if a macro have pins in only one direction (e. g. `src/mpl2/test/mp_test1.tcl`), so now we calculate the coordinate of the snap origin only when we actually have pins in that direction.

3. Finally, now we also don't try to snap the macro placed by `place_macro` if it has a rotation which is not allowed in HierRTLMP.

Also:
We're now using not only iterms, but bterms in the wirelength computation for adjusting orientation.