### PR TITLE
mpl2: improve debug messages

### DIFF
--- a/src/mpl2/doc/debugMessages.md
+++ b/src/mpl2/doc/debugMessages.md
@@ -1,0 +1,39 @@
+# MPL2 Debug Messages
+
+MPL2 debug messages are divided in:
+- 4 groups according to HierRTLMP flow stages.
+- 1 group for the special case in which bus planning is used.
+
+## Groups
+
+### Multilevel Autoclustering
+- Group Name: `multilevel_autoclustering`
+- Levels:
+1. Overall steps of the stage.
+2. Include in logs:
+    * Macro signatures;
+    * Connections of candidate clusters to be merged.
+
+### Coarse Shaping
+- Group Name: `coarse_shaping`
+- Levels:
+1. Overall steps of the stage;
+2. Log clusters' tilings.
+
+### Fine Shaping
+- Group Name: `fine_shaping`
+- Levels:
+1. Overall steps of the stage;
+2. Details of the shapes of each cluster's children.
+
+### Hierarchical Macro Placement
+- Group Name: `hierarchical_macro_placement`
+- Levels:
+1. Overall steps of the stage.
+2. Include in logs:
+    * Clusters' connections;
+    * Simulated Anneling results for both SoftMacro and HardMacro.
+
+### Bus Planning
+Special case for bus planning.
+- Group Name: `bus_planning`

--- a/src/mpl2/doc/debugMessages.md
+++ b/src/mpl2/doc/debugMessages.md
@@ -32,7 +32,7 @@ MPL2 debug messages are divided in:
 1. Overall steps of the stage.
 2. Include in logs:
     * Clusters' connections;
-    * Simulated Anneling results for both SoftMacro and HardMacro.
+    * Simulated annealing results for both SoftMacro and HardMacro.
 
 ### Bus Planning
 Special case for bus planning with a single level.

--- a/src/mpl2/doc/debugMessages.md
+++ b/src/mpl2/doc/debugMessages.md
@@ -35,5 +35,5 @@ MPL2 debug messages are divided in:
     * Simulated Anneling results for both SoftMacro and HardMacro.
 
 ### Bus Planning
-Special case for bus planning.
+Special case for bus planning with a single level.
 - Group Name: `bus_planning`

--- a/src/mpl2/src/SACoreHardMacro.cpp
+++ b/src/mpl2/src/SACoreHardMacro.cpp
@@ -287,18 +287,19 @@ void SACoreHardMacro::initialize()
 
 void SACoreHardMacro::printResults()
 {
-  debugPrint(logger_, MPL, "macro_placement", 1, "SACoreHardMacro");
+  debugPrint(
+      logger_, MPL, "hierarchical_macro_placement", 2, "SACoreHardMacro");
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "number of macros : {}",
              macros_.size());
   for (const auto& macro : macros_) {
     debugPrint(logger_,
                MPL,
-               "macro_placement",
-               1,
+               "hierarchical_macro_placement",
+               2,
                "lx = {}, ly = {}, width = {}, height = {}",
                macro.getX(),
                macro.getY(),
@@ -307,48 +308,52 @@ void SACoreHardMacro::printResults()
   }
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "width = {}, outline_width = {}",
              width_,
              outline_width_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "height = {}, outline_height = {}",
              height_,
              outline_height_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "outline_penalty  = {}, norm_outline_penalty = {}",
              outline_penalty_,
              norm_outline_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "wirelength  = {}, norm_wirelength = {}",
              wirelength_,
              norm_wirelength_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "guidance_penalty  = {}, norm_guidance_penalty = {}",
              guidance_penalty_,
              norm_guidance_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "fence_penalty  = {}, norm_fence_penalty = {}",
              fence_penalty_,
              norm_fence_penalty_);
-  debugPrint(
-      logger_, MPL, "macro_placement", 1, "final cost = {}", getNormCost());
+  debugPrint(logger_,
+             MPL,
+             "hierarchical_macro_placement",
+             2,
+             "final cost = {}",
+             getNormCost());
 }
 
 }  // namespace mpl2

--- a/src/mpl2/src/SACoreSoftMacro.cpp
+++ b/src/mpl2/src/SACoreSoftMacro.cpp
@@ -772,18 +772,19 @@ void SACoreSoftMacro::shrink()
 
 void SACoreSoftMacro::printResults() const
 {
-  debugPrint(logger_, MPL, "macro_placement", 1, "SACoreSoftMacro");
+  debugPrint(
+      logger_, MPL, "hierarchical_macro_placement", 2, "SACoreSoftMacro");
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "number of macros : {}",
              macros_.size());
   for (const auto& macro : macros_)
     debugPrint(logger_,
                MPL,
-               "macro_placement",
-               1,
+               "hierarchical_macro_placement",
+               2,
                "lx = {}, ly = {}, width = {}, height = {}, name = {}",
                macro.getX(),
                macro.getY(),
@@ -792,39 +793,39 @@ void SACoreSoftMacro::printResults() const
                macro.getName());
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "width = {}, outline_width = {}",
              width_,
              outline_width_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "height = {}, outline_height = {}",
              height_,
              outline_height_);
   debugPrint(
       logger_,
       MPL,
-      "macro_placement",
-      1,
+      "hierarchical_macro_placement",
+      2,
       "outline_weight = {}, outline_penalty  = {}, norm_outline_penalty = {}",
       outline_weight_,
       outline_penalty_,
       norm_outline_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "wirelength_weight = {}, wirelength  = {}, norm_wirelength = {}",
              wirelength_weight_,
              wirelength_,
              norm_wirelength_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "guidance_weight = {}, guidance_penalty  = {}, "
              "norm_guidance_penalty = {}",
              guidance_weight_,
@@ -832,16 +833,16 @@ void SACoreSoftMacro::printResults() const
              norm_guidance_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "fence_weight = {}, fence_penalty  = {}, norm_fence_penalty = {}",
              fence_weight_,
              fence_penalty_,
              norm_fence_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "macro_blockage_weight = {}, macro_blockage_penalty  = {}, "
              "norm_macro_blockage_penalty = {}",
              macro_blockage_weight_,
@@ -849,14 +850,18 @@ void SACoreSoftMacro::printResults() const
              norm_macro_blockage_penalty_);
   debugPrint(logger_,
              MPL,
-             "macro_placement",
-             1,
+             "hierarchical_macro_placement",
+             2,
              "notch_weight = {}, notch_penalty  = {}, norm_notch_penalty = {}",
              notch_weight_,
              notch_penalty_,
              norm_notch_penalty_);
-  debugPrint(
-      logger_, MPL, "macro_placement", 1, "final cost = {}", getNormCost());
+  debugPrint(logger_,
+             MPL,
+             "hierarchical_macro_placement",
+             2,
+             "final cost = {}",
+             getNormCost());
 }
 
 // fill the dead space by adjust the size of MixedCluster

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -772,7 +772,7 @@ void HierRTLMP::setClusterMetrics(Cluster* cluster)
   debugPrint(logger_,
              MPL,
              "multilevel_autoclustering",
-             2,
+             1,
              "Setting Cluster Metrics for {}: Num Macros: {} Num Std Cells: {}",
              cluster->getName(),
              metrics.getNumMacro(),

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -5176,14 +5176,14 @@ bool HierRTLMP::shapeChildrenCluster(
       debugPrint(logger_,
                  MPL,
                  "fine_shaping",
-                 1,
+                 2,
                  "hard_macro_cluster : {}",
                  cluster->getName());
       for (auto& shape : cluster->getMacroTilings()) {
         debugPrint(logger_,
                    MPL,
                    "fine_shaping",
-                   1,
+                   2,
                    "    ( {} , {} ) ",
                    shape.first,
                    shape.second);
@@ -5206,16 +5206,16 @@ bool HierRTLMP::shapeChildrenCluster(
       debugPrint(logger_,
                  MPL,
                  "fine_shaping",
-                 1,
+                 2,
                  "name:  {} area: {}",
                  cluster->getName(),
                  area);
-      debugPrint(logger_, MPL, "fine_shaping", 1, "width_list :  ");
+      debugPrint(logger_, MPL, "fine_shaping", 2, "width_list :  ");
       for (auto& width : width_list) {
         debugPrint(logger_,
                    MPL,
                    "fine_shaping",
-                   1,
+                   2,
                    " [  {} {}  ] ",
                    width.first,
                    width.second);

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -5035,9 +5035,9 @@ bool HierRTLMP::shapeChildrenCluster(
 {
   debugPrint(logger_,
              MPL,
-             "macro_placement",
+             "fine_shaping",
              1,
-             "Starting ShapeChildrenCluster for cluster :  {}",
+             "Starting fine shaping for cluster:  {}",
              parent->getName());
   // check the valid values
   const float outline_width = parent->getWidth();
@@ -5163,14 +5163,14 @@ bool HierRTLMP::shapeChildrenCluster(
           cluster->getMacroTilings());
       debugPrint(logger_,
                  MPL,
-                 "macro_placement",
+                 "fine_shaping",
                  1,
-                 "  [ShapeChildrenCluster] hard_macro_cluster : {}",
+                 "hard_macro_cluster : {}",
                  cluster->getName());
       for (auto& shape : cluster->getMacroTilings()) {
         debugPrint(logger_,
                    MPL,
-                   "macro_placement",
+                   "fine_shaping",
                    1,
                    "    ( {} , {} ) ",
                    shape.first,
@@ -5193,16 +5193,16 @@ bool HierRTLMP::shapeChildrenCluster(
 
       debugPrint(logger_,
                  MPL,
-                 "macro_placement",
+                 "fine_shaping",
                  1,
-                 "[ShapeChildrenCluster] name:  {} area: {}",
+                 "name:  {} area: {}",
                  cluster->getName(),
                  area);
-      debugPrint(logger_, MPL, "macro_placement", 1, "width_list :  ");
+      debugPrint(logger_, MPL, "fine_shaping", 1, "width_list :  ");
       for (auto& width : width_list) {
         debugPrint(logger_,
                    MPL,
-                   "macro_placement",
+                   "fine_shaping",
                    1,
                    " [  {} {}  ] ",
                    width.first,
@@ -5213,9 +5213,9 @@ bool HierRTLMP::shapeChildrenCluster(
   }
   debugPrint(logger_,
              MPL,
-             "macro_placement",
+             "fine_shaping",
              1,
-             "Finish ShapeChildrenCluster for cluster :  {}",
+             "Finish fine shaping for cluster:  {}",
              parent->getName());
   return true;
 }

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -626,11 +626,6 @@ void HierRTLMP::hierRTLMacroPlacer()
     }
     hardMacroClusterMacroPlacement(root_cluster_);
   } else {
-    debugPrint(logger_,
-               MPL,
-               "coarse_shaping",
-               1,
-               "Computing macro tilings ignoring std-cells clusters...");
     if (graphics_) {
       graphics_->startCoarse();
     }
@@ -2744,7 +2739,7 @@ void HierRTLMP::calClusterMacroTilings(Cluster* parent)
     debugPrint(logger_,
                MPL,
                "coarse_shaping",
-               1,
+               2,
                "width: {}, height: {}, aspect_ratio: {}, min_ar: {}",
                shape.first,
                shape.second,
@@ -2777,7 +2772,7 @@ void HierRTLMP::calClusterMacroTilings(Cluster* parent)
       line += std::to_string(shape.second) + " >  ";
     }
     line += "\n";
-    debugPrint(logger_, MPL, "coarse_shaping", 1, "{}", line);
+    debugPrint(logger_, MPL, "coarse_shaping", 2, "{}", line);
   }
 }
 
@@ -2968,7 +2963,7 @@ void HierRTLMP::calHardMacroClusterShape(Cluster* cluster)
     debugPrint(logger_,
                MPL,
                "coarse_shaping",
-               1,
+               2,
                "width: {}, height: {}",
                shape.first,
                shape.second);
@@ -2998,7 +2993,7 @@ void HierRTLMP::calHardMacroClusterShape(Cluster* cluster)
     line += std::to_string(shape.second) + " >  ";
   }
   line += "\n";
-  debugPrint(logger_, MPL, "coarse_shaping", 1, "{}", line);
+  debugPrint(logger_, MPL, "coarse_shaping", 2, "{}", line);
 }
 
 //

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -564,7 +564,7 @@ int Cluster::getCloseCluster(const std::vector<int>& candidate_clusters,
   for (auto& [cluster_id, num_nets] : connection_map_) {
     debugPrint(logger_,
                MPL,
-               "clustering",
+               "multilevel_autoclustering",
                2,
                "cluster_id: {}, nets: {}",
                cluster_id,


### PR DESCRIPTION
The way the debug messages' groups were structured was making it difficult to debug due to the amount of information related to different steps of HierRTLMP flow.

I divided `macro_placement`and `clustering` into groups with two levels according to the stages of HierRTLMP. They're described in `src/mpl2/doc/debugMessages.md`.