### PR TITLE
fix gitignore and report file generation

### DIFF
--- a/src/cts/.gitignore
+++ b/src/cts/.gitignore
@@ -1,3 +1,2 @@
 test/src
 test/results
-test/cts.clk.buffer

--- a/src/cts/.gitignore
+++ b/src/cts/.gitignore
@@ -1,2 +1,3 @@
 test/src
 test/results
+test/cts.clk.buffer

--- a/src/cts/test/check_buffers_blockages.ok
+++ b/src/cts/test/check_buffers_blockages.ok
@@ -50,8 +50,6 @@ TritonCTS forced slew degradation on these wires.
 [DEBUG CTS-legalizer]   selectBestNewLocation for level 1 buffer: [(11.178, 8.122)] => [(11.358, 7.302)]
 [DEBUG CTS-legalizer] createClockSubNets legalizeOneBuffer clkbuf_0: [(7.358, 6.302)] => [(7.358, 6.064)]
 [INFO CTS-0035]  Number of sinks covered: 29.
-[DEBUG CTS-legalizer] Htree file cts.clk.buffer has been generated
-[DEBUG CTS-legalizer] Run 'obsAwareCts.py cts.clk.buffer' to produce cts.clk.buffer.png
 [INFO CTS-0018]     Created 34 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 3.
 [INFO CTS-0013]     Maximum number of buffers in the clock path: 3.

--- a/src/cts/test/check_buffers_blockages.tcl
+++ b/src/cts/test/check_buffers_blockages.tcl
@@ -7,7 +7,7 @@ read_def check_buffers_blockages.def
 create_clock -period 5 clk
 set_wire_rc -clock -layer metal5
 
-set_debug_level CTS legalizer 3
+set_debug_level CTS legalizer 2
 
 clock_tree_synthesis -root_buf CLKBUF_X3 \
                      -buf_list CLKBUF_X3 \

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -227,7 +227,7 @@ class Opendp
                               const std::string& violation_type = "") const;
   void checkPlacement(bool verbose,
                       bool disallow_one_site_gaps = false,
-                      string report_file_name = "report.json");
+                      string report_file_name = "");
   void writeJsonReport(const string& filename,
                        const vector<Cell*>& placed_failures,
                        const vector<Cell*>& in_rows_failures,

--- a/src/dpl/test/report_failures.tcl
+++ b/src/dpl/test/report_failures.tcl
@@ -1,9 +1,12 @@
 source "helpers.tcl"
 read_lef Nangate45/Nangate45.lef
 read_def report_failures.def
-catch { detailed_placement -report_file_name "report_failures.json" } msg
+
+set report_file [make_result_file report_failures.json]
+
+catch { detailed_placement -report_file_name $report_file } msg
 
 set def_file [make_result_file report_failures.def]
 write_def $def_file
 diff_file $def_file report_failures.defok
-diff_file report_failures.json report_failures.jsonok
+diff_file $report_file report_failures.jsonok

--- a/src/gui/.gitignore
+++ b/src/gui/.gitignore
@@ -1,0 +1,1 @@
+test/results


### PR DESCRIPTION
Minor fixes to avoid creating unwanted report files. Currently, a bunch of files is created when running the regression tests, leaving the branch "dirt" with git status.