### PR TITLE
mpl2: display cluster type when printing physical tree

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2478,13 +2478,15 @@ void HierRTLMP::printPhysicalHierarchyTree(Cluster* parent, int level)
   }
   line += fmt::format(
       "{}  ({})  num_macro :  {}   num_std_cell :  {}"
-      "  macro_area :  {}  std_cell_area : {}",
+      "  macro_area :  {}  std_cell_area : {}  cluster type: {} {}",
       parent->getName(),
       parent->getId(),
       parent->getNumMacro(),
       parent->getNumStdCell(),
       parent->getMacroArea(),
-      parent->getStdCellArea());
+      parent->getStdCellArea(),
+      parent->getIsLeafString(),
+      parent->getClusterTypeString());
   logger_->report("{}", line);
 
   for (auto& cluster : parent->getChildren()) {

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -613,7 +613,7 @@ void HierRTLMP::hierRTLMacroPlacer()
   // Check if the root cluster has other children clusters
   bool macro_only_flag = true;
   for (auto& cluster : root_cluster_->getChildren()) {
-    if (cluster->getIOClusterFlag() == false) {
+    if (cluster->isIOCluster()) {
       macro_only_flag = false;
       break;
     }
@@ -891,7 +891,7 @@ void HierRTLMP::createBundledIOs()
       }
 
       // set the cluster to a IO cluster
-      cluster->setIOClusterFlag(
+      cluster->setAsIOCluster(
           std::pair<float, float>(dbuToMicron(x, dbu_), dbuToMicron(y, dbu_)),
           dbuToMicron(width, dbu_),
           dbuToMicron(height, dbu_));
@@ -1322,7 +1322,7 @@ void HierRTLMP::breakCluster(Cluster* parent)
   // Merge small clusters
   std::vector<Cluster*> candidate_clusters;
   for (auto& cluster : parent->getChildren()) {
-    if (!cluster->getIOClusterFlag() && cluster->getNumStdCell() < min_num_inst_
+    if (!cluster->isIOCluster() && cluster->getNumStdCell() < min_num_inst_
         && cluster->getNumMacro() < min_num_macro_) {
       candidate_clusters.push_back(cluster);
     }
@@ -1398,7 +1398,7 @@ void HierRTLMP::mergeClusters(std::vector<Cluster*>& candidate_clusters)
           "Candidate cluster: {} - {}",
           candidate_clusters[i]->getName(),
           (cluster_id != -1 ? cluster_map_[cluster_id]->getName() : "   "));
-      if (cluster_id != -1 && !cluster_map_[cluster_id]->getIOClusterFlag()) {
+      if (cluster_id != -1 && !cluster_map_[cluster_id]->isIOCluster()) {
         Cluster*& cluster = cluster_map_[cluster_id];
         bool delete_flag = false;
         if (cluster->mergeCluster(*candidate_clusters[i], delete_flag)) {
@@ -3207,7 +3207,7 @@ void HierRTLMP::multiLevelMacroPlacement(Cluster* parent)
   // Place children clusters
   // map children cluster to soft macro
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getIOClusterFlag())  // ignore all the io clusters
+    if (cluster->isIOCluster())  // ignore all the io clusters
       continue;
     SoftMacro* macro = new SoftMacro(cluster);
     // no memory leakage, beacuse we set the soft macro, the old one
@@ -3275,7 +3275,7 @@ void HierRTLMP::multiLevelMacroPlacement(Cluster* parent)
   // the fences and guides for hard macros in each cluster
   for (auto& cluster : parent->getChildren()) {
     // for IO cluster
-    if (cluster->getIOClusterFlag()) {
+    if (cluster->isIOCluster()) {
       soft_macro_id_map[cluster->getName()] = macros.size();
       macros.push_back(SoftMacro(
           std::pair<float, float>(cluster->getX() - lx, cluster->getY() - ly),
@@ -4086,7 +4086,7 @@ void HierRTLMP::multiLevelMacroPlacementWithoutBusPlanning(Cluster* parent)
   // Place children clusters
   // map children cluster to soft macro
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getIOClusterFlag())  // ignore all the io clusters
+    if (cluster->isIOCluster())  // ignore all the io clusters
       continue;
     SoftMacro* macro = new SoftMacro(cluster);
     // no memory leakage, beacuse we set the soft macro, the old one
@@ -4155,7 +4155,7 @@ void HierRTLMP::multiLevelMacroPlacementWithoutBusPlanning(Cluster* parent)
   // the fences and guides for hard macros in each cluster
   for (auto& cluster : parent->getChildren()) {
     // for IO cluster
-    if (cluster->getIOClusterFlag()) {
+    if (cluster->isIOCluster()) {
       soft_macro_id_map[cluster->getName()] = macros.size();
       macros.push_back(SoftMacro(
           std::pair<float, float>(cluster->getX() - lx, cluster->getY() - ly),
@@ -4581,7 +4581,7 @@ void HierRTLMP::enhancedMacroPlacement(Cluster* parent)
   // Place children clusters
   // map children cluster to soft macro
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getIOClusterFlag())  // ignore all the io clusters
+    if (cluster->isIOCluster())  // ignore all the io clusters
       continue;
     SoftMacro* macro = new SoftMacro(cluster);
     // no memory leakage, beacuse we set the soft macro, the old one
@@ -4650,7 +4650,7 @@ void HierRTLMP::enhancedMacroPlacement(Cluster* parent)
   // the fences and guides for hard macros in each cluster
   for (auto& cluster : parent->getChildren()) {
     // for IO cluster
-    if (cluster->getIOClusterFlag()) {
+    if (cluster->isIOCluster()) {
       soft_macro_id_map[cluster->getName()] = macros.size();
       macros.push_back(SoftMacro(
           std::pair<float, float>(cluster->getX() - lx, cluster->getY() - ly),
@@ -5064,7 +5064,7 @@ bool HierRTLMP::shapeChildrenCluster(
   }
 
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getIOClusterFlag()) {
+    if (cluster->isIOCluster()) {
       continue;  // IO clusters have no area
     }
     if (cluster->getClusterType() == StdCellCluster) {
@@ -5144,7 +5144,7 @@ bool HierRTLMP::shapeChildrenCluster(
 
   // set the shape for each macro
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getIOClusterFlag()) {
+    if (cluster->isIOCluster()) {
       continue;  // the area of IO cluster is 0.0
     }
     if (cluster->getClusterType() == StdCellCluster) {

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -258,6 +258,36 @@ void Cluster::clearHardMacros()
   hard_macros_.clear();
 }
 
+std::string Cluster::getClusterTypeString() const
+{
+  std::string cluster_type = "";
+
+  switch (type_) {
+    case StdCellCluster:
+      cluster_type = "StdCell";
+      break;
+    case MixedCluster:
+      cluster_type = "Mixed";
+      break;
+    case HardMacroCluster:
+      cluster_type = "Macro";
+      break;
+  }
+
+  return cluster_type;
+}
+
+std::string Cluster::getIsLeafString() const
+{
+  std::string is_leaf_string = "";
+
+  if (children_.size() == 0) {
+    is_leaf_string = "Leaf";
+  }
+
+  return is_leaf_string;
+}
+
 // copy instances based on cluster Type
 void Cluster::copyInstances(const Cluster& cluster)
 {

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -260,11 +260,10 @@ void Cluster::clearHardMacros()
 
 std::string Cluster::getClusterTypeString() const
 {
-  std::string cluster_type = "";
+  std::string cluster_type;
 
   if (is_io_cluster_) {
-    cluster_type = "BundledIO";
-    return cluster_type;
+    return "BundledIO";
   }
 
   switch (type_) {
@@ -284,9 +283,9 @@ std::string Cluster::getClusterTypeString() const
 
 std::string Cluster::getIsLeafString() const
 {
-  std::string is_leaf_string = "";
+  std::string is_leaf_string;
 
-  if (!is_io_cluster_ && children_.size() == 0) {
+  if (!is_io_cluster_ && children_.empty()) {
     is_leaf_string = "Leaf";
   }
 

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -323,18 +323,18 @@ void Cluster::copyInstances(const Cluster& cluster)
 
 // Bundled IO (Pads) cluster support
 // The position is the center of IO pads in the cluster
-void Cluster::setIOClusterFlag(const std::pair<float, float> pos,
-                               const float width,
-                               const float height)
+void Cluster::setAsIOCluster(const std::pair<float, float> pos,
+                             const float width,
+                             const float height)
 {
-  io_cluster_flag_ = true;
+  is_io_cluster_ = true;
   // Create a SoftMacro representing the IO cluster
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
-bool Cluster::getIOClusterFlag() const
+bool Cluster::isIOCluster() const
 {
-  return io_cluster_flag_;
+  return is_io_cluster_;
 }
 
 // Metrics Support and Statistics
@@ -1278,7 +1278,7 @@ void SoftMacro::setWidth(float width)
   if (width <= 0.0 || area_ == 0.0 || width_list_.size() != height_list_.size()
       || width_list_.size() == 0 || cluster_ == nullptr
       || cluster_->getClusterType() == HardMacroCluster
-      || cluster_->getIOClusterFlag()) {
+      || cluster_->isIOCluster()) {
     return;
   }
 
@@ -1304,7 +1304,7 @@ void SoftMacro::setHeight(float height)
   if (height <= 0.0 || area_ == 0.0 || width_list_.size() != height_list_.size()
       || width_list_.size() == 0 || cluster_ == nullptr
       || cluster_->getClusterType() == HardMacroCluster
-      || cluster_->getIOClusterFlag()) {
+      || cluster_->isIOCluster()) {
     return;
   }
 
@@ -1338,7 +1338,7 @@ void SoftMacro::shrinkArea(float percent)
   if (area_ == 0.0 || width_list_.size() != height_list_.size()
       || width_list_.size() == 0 || cluster_ == nullptr
       || cluster_->getClusterType() != StdCellCluster
-      || cluster_->getIOClusterFlag()) {
+      || cluster_->isIOCluster()) {
     return;
   }
 
@@ -1352,7 +1352,7 @@ void SoftMacro::setArea(float area)
   if (area_ == 0.0 || width_list_.size() != height_list_.size()
       || width_list_.size() == 0 || cluster_ == nullptr
       || cluster_->getClusterType() == HardMacroCluster
-      || cluster_->getIOClusterFlag()
+      || cluster_->isIOCluster()
       || area <= width_list_[0].first * height_list_[0].first) {
     return;
   }
@@ -1409,7 +1409,7 @@ void SoftMacro::setShapes(
     float area)
 {
   if (width_list.size() == 0 || area <= 0.0 || cluster_ == nullptr
-      || cluster_->getIOClusterFlag()
+      || cluster_->isIOCluster()
       || cluster_->getClusterType() == HardMacroCluster) {
     return;
   }

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -262,6 +262,11 @@ std::string Cluster::getClusterTypeString() const
 {
   std::string cluster_type = "";
 
+  if (is_io_cluster_) {
+    cluster_type = "BundledIO";
+    return cluster_type;
+  }
+
   switch (type_) {
     case StdCellCluster:
       cluster_type = "StdCell";
@@ -281,7 +286,7 @@ std::string Cluster::getIsLeafString() const
 {
   std::string is_leaf_string = "";
 
-  if (children_.size() == 0) {
+  if (!is_io_cluster_ && children_.size() == 0) {
     is_leaf_string = "Leaf";
   }
 

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -183,6 +183,7 @@ class Cluster
   // cluster type (default type = MixedCluster)
   void setClusterType(const ClusterType& cluster_type);
   const ClusterType getClusterType() const;
+  std::string getClusterTypeString() const;
 
   // Instances (Here we store dbModule to reduce memory)
   void addDbModule(odb::dbModule* db_module);
@@ -235,6 +236,7 @@ class Cluster
   std::vector<Cluster*> getChildren() const;
 
   bool isLeaf() const;  // if the cluster is a leaf cluster
+  std::string getIsLeafString() const;
   bool mergeCluster(Cluster& cluster,
                     bool& delete_flag);  // return true if succeed
 

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -201,12 +201,11 @@ class Cluster
   void copyInstances(const Cluster& cluster);  // only based on cluster type
 
   // IO cluster
-  // When you specify the io cluster, you must specify the postion
-  // of this IO cluster
-  void setIOClusterFlag(const std::pair<float, float> pos,
-                        const float width,
-                        const float height);
-  bool getIOClusterFlag() const;
+  // Position must be specified when setting an IO cluster
+  void setAsIOCluster(const std::pair<float, float> pos,
+                      const float width,
+                      const float height);
+  bool isIOCluster() const;
 
   // Metrics Support
   void setMetrics(const Metrics& metrics);
@@ -297,7 +296,7 @@ class Cluster
 
   // We model bundled IOS (Pads) as a cluster with no area
   // The position be the center of IOs
-  bool io_cluster_flag_ = false;
+  bool is_io_cluster_ = false;
 
   // Each cluster uses metrics to store its statistics
   Metrics metrics_;


### PR DESCRIPTION
I also changed the names of the methods related to bundledIO clusters to improve readability.