### PR TITLE
Avoid non-standard use of `uint`/`ushort`

### DIFF
--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -14,7 +14,7 @@ with pkgs; let
       cmakeFlags = builtins.filter (flag: (!lib.strings.hasPrefix "-DSPDLOG_FMT_EXTERNAL" flag)) old.cmakeFlags;
       doCheck = false;
   }));
-in (mkShell.override { stdenv = clangStdenv; }) {
+in (mkShell.override { stdenv = clang_14.stdenv; }) {
   # Runtime Dependencies
   buildInputs = [
     boost
@@ -45,6 +45,7 @@ in (mkShell.override { stdenv = clangStdenv; }) {
     gnumake
     flex
     bison
+    clang-tools_14
   ];
   
   # Environment variable in resulting shell

--- a/etc/shell.nix
+++ b/etc/shell.nix
@@ -1,0 +1,52 @@
+# To get dependencies and build in a Nix environment:
+#   1. Get the Nix package manager (https://nixos.org/download)
+#   2. Invoke `nix-shell ./etc/shell.nix` in your shell. First invocation will
+#      take around 5 minutes depending on your internet connection
+#   3. `cd build`
+#   4. `cmake $CMAKE_FLAGS ..`
+{
+  # Using nixpkgs 23.05
+  pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/41de143fda10e33be0f47eab2bfe08a50f234267.tar.gz") {}
+}:
+with pkgs; let
+  # Default spdlog package uses external libfmt, which causes compile issues
+  spdlog-internal-fmt = (spdlog.overrideAttrs(new: old: {
+      cmakeFlags = builtins.filter (flag: (!lib.strings.hasPrefix "-DSPDLOG_FMT_EXTERNAL" flag)) old.cmakeFlags;
+      doCheck = false;
+  }));
+in (mkShell.override { stdenv = clangStdenv; }) {
+  # Runtime Dependencies
+  buildInputs = [
+    boost
+    eigen
+    tcl
+    python3
+    readline
+    tclreadline
+    libffi
+    libsForQt5.qtbase
+    llvmPackages.openmp
+    spdlog-internal-fmt
+
+    lemon-graph
+    or-tools
+    glpk
+    zlib
+    clp
+    cbc
+    re2
+  ];
+
+  # Compile-time Dependencies
+  nativeBuildInputs = [
+    swig
+    pkg-config
+    cmake
+    gnumake
+    flex
+    bison
+  ];
+  
+  # Environment variable in resulting shell
+  CMAKE_FLAGS = "-DUSE_SYSTEM_BOOST:BOOL=ON -DTCL_LIBRARY=${tcl}/lib/libtcl${stdenv.hostPlatform.extensions.sharedLibrary}";
+}

--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -63,6 +63,7 @@ using odb::dbVia;
 using odb::dbWire;
 using odb::dbWireGraph;
 using odb::dbWireType;
+using odb::uint;
 
 using utl::ANT;
 

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -639,7 +639,7 @@ void TritonCTS::writeClockNetsToDb(Clock& clockNet)
   topClockInstInputPin->connect(topClockNet);
   topClockNet->setSigType(odb::dbSigType::CLOCK);
 
-  std::map<int, uint> fanoutcount;
+  std::map<int, odb::uint> fanoutcount;
 
   // create subNets
   numClkNets_ = 0;

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -17,7 +17,7 @@ using sta::Instance;
 %}
 
 %import "odb.i"
-%include "../../src/Exception.i"
+%include "../../Exception.i"
 // OpenSTA swig files
 %include "tcl/StaTcl.i"
 %include "tcl/NetworkEdit.i"

--- a/src/dpo/src/Optdp.cpp
+++ b/src/dpo/src/Optdp.cpp
@@ -691,7 +691,7 @@ void Optdp::createArchitecture()
     min_row_height = std::min(min_row_height, row->getSite()->getHeight());
   }
 
-  std::map<uint, std::unordered_set<std::string>> skip_list;
+  std::map<odb::uint, std::unordered_set<std::string>> skip_list;
 
   for (dbRow* row : block->getRows()) {
     if (row->getSite()->getClass() == odb::dbSiteClass::PAD) {

--- a/src/dpo/src/detailed_manager.h
+++ b/src/dpo/src/detailed_manager.h
@@ -263,7 +263,7 @@ class DetailedMgr
   // For help aligning cells to sites.
   bool alignPos(Node* ndi, int& xi, int xl, int xr);
   int getMoveLimit() { return moveLimit_; }
-  void setMoveLimit(uint newMoveLimit) { moveLimit_ = newMoveLimit; }
+  void setMoveLimit(unsigned int newMoveLimit) { moveLimit_ = newMoveLimit; }
 
   struct compareNodesX
   {

--- a/src/drt/src/db/drObj/drNet.h
+++ b/src/drt/src/db/drObj/drNet.h
@@ -104,14 +104,14 @@ class drNet : public drBlockObject
   bool isInQueue() const { return inQueue_; }
   bool isRouted() const { return routed_; }
   const std::vector<frRect>& getOrigGuides() const { return origGuides_; }
-  unsigned short getPriority() const { return priority_; }
+  uint16_t getPriority() const { return priority_; }
   // setters
   void incPriority()
   {
-    if (priority_ < std::numeric_limits<unsigned short>::max())
+    if (priority_ < std::numeric_limits<uint16_t>::max())
       priority_++;
   }
-  void setPriority(unsigned short in) { priority_ = in; }
+  void setPriority(uint16_t in) { priority_ = in; }
   void addPin(std::unique_ptr<drPin> pinIn)
   {
     pinIn->setNet(this);
@@ -276,7 +276,7 @@ class drNet : public drBlockObject
   bool routed_;
 
   std::vector<frRect> origGuides_;
-  unsigned short priority_{0};
+  uint16_t priority_{0};
 
   drNet()
       : fNet_(nullptr),

--- a/src/drt/src/db/drObj/drNet.h
+++ b/src/drt/src/db/drObj/drNet.h
@@ -104,14 +104,14 @@ class drNet : public drBlockObject
   bool isInQueue() const { return inQueue_; }
   bool isRouted() const { return routed_; }
   const std::vector<frRect>& getOrigGuides() const { return origGuides_; }
-  ushort getPriority() const { return priority_; }
+  unsigned short getPriority() const { return priority_; }
   // setters
   void incPriority()
   {
-    if (priority_ < std::numeric_limits<ushort>::max())
+    if (priority_ < std::numeric_limits<unsigned short>::max())
       priority_++;
   }
-  void setPriority(ushort in) { priority_ = in; }
+  void setPriority(unsigned short in) { priority_ = in; }
   void addPin(std::unique_ptr<drPin> pinIn)
   {
     pinIn->setNet(this);
@@ -276,7 +276,7 @@ class drNet : public drBlockObject
   bool routed_;
 
   std::vector<frRect> origGuides_;
-  ushort priority_{0};
+  unsigned short priority_{0};
 
   drNet()
       : fNet_(nullptr),

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <cstdint>
 
 #include "db/obj/frMarker.h"
 #include "frBaseTypes.h"

--- a/src/drt/src/global.h
+++ b/src/drt/src/global.h
@@ -28,11 +28,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <memory>
 #include <optional>
 #include <string>
-#include <cstdint>
 
 #include "db/obj/frMarker.h"
 #include "frBaseTypes.h"

--- a/src/drt/src/gr/FlexGR.cpp
+++ b/src/drt/src/gr/FlexGR.cpp
@@ -674,13 +674,13 @@ void FlexGR::updateDbCongestion(odb::dbDatabase* db, FlexGRCMap* cmap)
     }
     for (unsigned xIdx = 0; xIdx < xgp->getCount(); xIdx++)
       for (unsigned yIdx = 0; yIdx < ygp->getCount(); yIdx++) {
-        uint horizontal_capacity
+        auto horizontal_capacity
             = cmap->getRawSupply(xIdx, yIdx, cmapLayerIdx, frDirEnum::E);
-        uint horizontal_usage
+        auto horizontal_usage
             = cmap->getRawDemand(xIdx, yIdx, cmapLayerIdx, frDirEnum::E);
-        uint vertical_capacity
+        auto vertical_capacity
             = cmap->getRawSupply(xIdx, yIdx, cmapLayerIdx, frDirEnum::N);
-        uint vertical_usage
+        auto vertical_usage
             = cmap->getRawDemand(xIdx, yIdx, cmapLayerIdx, frDirEnum::N);
         gcell->setCapacity(
             layer, xIdx, yIdx, horizontal_capacity, vertical_capacity, 0);

--- a/src/drt/src/pa/FlexPA.cpp
+++ b/src/drt/src/pa/FlexPA.cpp
@@ -157,7 +157,7 @@ void FlexPA::setTargetInstances(const frCollection<odb::dbInst*>& insts)
 }
 
 void FlexPA::setDistributed(const std::string& rhost,
-                            const ushort rport,
+                            const unsigned short rport,
                             const std::string& shared_vol,
                             const int cloud_sz)
 {

--- a/src/drt/src/pa/FlexPA.cpp
+++ b/src/drt/src/pa/FlexPA.cpp
@@ -157,7 +157,7 @@ void FlexPA::setTargetInstances(const frCollection<odb::dbInst*>& insts)
 }
 
 void FlexPA::setDistributed(const std::string& rhost,
-                            const unsigned short rport,
+                            const uint16_t rport,
                             const std::string& shared_vol,
                             const int cloud_sz)
 {

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <boost/polygon/polygon.hpp>
+#include <cstdint>
 
 #include "FlexPA_unique.h"
 #include "frDesign.h"
@@ -71,7 +72,7 @@ class FlexPA
   void setDebug(frDebugSettings* settings, odb::dbDatabase* db);
   void setTargetInstances(const frCollection<odb::dbInst*>& insts);
   void setDistributed(const std::string& rhost,
-                      unsigned short rport,
+                      uint16_t rport,
                       const std::string& shared_vol,
                       int cloud_sz);
 
@@ -106,7 +107,7 @@ class FlexPA
   frCollection<odb::dbInst*> target_insts_;
 
   std::string remote_host_;
-  unsigned short remote_port_;
+  uint16_t remote_port_;
   std::string shared_vol_;
   int cloud_sz_;
 

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -71,7 +71,7 @@ class FlexPA
   void setDebug(frDebugSettings* settings, odb::dbDatabase* db);
   void setTargetInstances(const frCollection<odb::dbInst*>& insts);
   void setDistributed(const std::string& rhost,
-                      ushort rport,
+                      unsigned short rport,
                       const std::string& shared_vol,
                       int cloud_sz);
 
@@ -106,7 +106,7 @@ class FlexPA
   frCollection<odb::dbInst*> target_insts_;
 
   std::string remote_host_;
-  ushort remote_port_;
+  unsigned short remote_port_;
   std::string shared_vol_;
   int cloud_sz_;
 

--- a/src/drt/src/serialization.h
+++ b/src/drt/src/serialization.h
@@ -56,6 +56,9 @@
 #include "global.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+
+using uint = odb::uint;
+
 namespace gtl = boost::polygon;
 namespace bg = boost::geometry;
 

--- a/src/drt/src/serialization.h
+++ b/src/drt/src/serialization.h
@@ -57,8 +57,6 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 
-using uint = odb::uint;
-
 namespace gtl = boost::polygon;
 namespace bg = boost::geometry;
 
@@ -66,7 +64,7 @@ namespace boost::serialization {
 
 // Enable serialization of a std::tuple using recursive templates.
 // For some reason boost serialize seems to leave out this std class.
-template <uint N>
+template <unsigned int N>
 struct TupleSerializer
 {
   template <class Archive, typename... Types>

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3028,11 +3028,11 @@ void GlobalRouter::findLayerExtensions(std::vector<int>& layer_extensions)
       // one found, use them as the macro extension instead of PARALLELRUNLENGTH
 
       if (obstruct_layer->hasTwoWidthsSpacingRules()) {
-        std::vector<std::vector<uint>> spacing_table;
+        std::vector<std::vector<odb::uint>> spacing_table;
         obstruct_layer->getTwoWidthsSpacingTable(spacing_table);
         if (!spacing_table.empty()) {
-          std::vector<uint> last_row = spacing_table.back();
-          uint last_value = last_row.back();
+          std::vector<odb::uint> last_row = spacing_table.back();
+          odb::uint last_value = last_row.back();
           if (last_value > spacing_extension) {
             spacing_extension = last_value;
           }
@@ -3286,7 +3286,7 @@ void GlobalRouter::findNetsObstructions(odb::Rect& die_area)
   }
 
   for (odb::dbNet* db_net : nets) {
-    uint wire_cnt = 0, via_cnt = 0;
+    odb::uint wire_cnt = 0, via_cnt = 0;
     db_net->getWireCount(wire_cnt, via_cnt);
     if (wire_cnt == 0)
       continue;

--- a/src/grt/src/Net.cpp
+++ b/src/grt/src/Net.cpp
@@ -104,7 +104,7 @@ int Net::getNumBTermsAboveMaxLayer(odb::dbTechLayer* max_routing_layer)
 bool Net::hasStackedVias(odb::dbTechLayer* max_routing_layer)
 {
   int bterms_above_max_layer = getNumBTermsAboveMaxLayer(max_routing_layer);
-  uint wire_cnt = 0, via_cnt = 0;
+  odb::uint wire_cnt = 0, via_cnt = 0;
   net_->getWireCount(wire_cnt, via_cnt);
 
   if (wire_cnt != 0 || via_cnt == 0) {

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -195,12 +195,12 @@ bool RoutingCongestionDataSource::populateMap()
 
   std::vector<int> x_grid, y_grid;
   grid->getGridX(x_grid);
-  const uint x_grid_sz = x_grid.size();
+  const odb::uint x_grid_sz = x_grid.size();
   grid->getGridY(y_grid);
-  const uint y_grid_sz = y_grid.size();
+  const odb::uint y_grid_sz = y_grid.size();
 
-  for (uint x_idx = 0; x_idx < gcell_congestion_data.numRows(); ++x_idx) {
-    for (uint y_idx = 0; y_idx < gcell_congestion_data.numCols(); ++y_idx) {
+  for (odb::uint x_idx = 0; x_idx < gcell_congestion_data.numRows(); ++x_idx) {
+    for (odb::uint y_idx = 0; y_idx < gcell_congestion_data.numCols(); ++y_idx) {
       const auto& cong_data = gcell_congestion_data(x_idx, y_idx);
 
       const int next_x = (x_idx + 1) == x_grid_sz

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -200,7 +200,8 @@ bool RoutingCongestionDataSource::populateMap()
   const odb::uint y_grid_sz = y_grid.size();
 
   for (odb::uint x_idx = 0; x_idx < gcell_congestion_data.numRows(); ++x_idx) {
-    for (odb::uint y_idx = 0; y_idx < gcell_congestion_data.numCols(); ++y_idx) {
+    for (odb::uint y_idx = 0; y_idx < gcell_congestion_data.numCols();
+         ++y_idx) {
       const auto& cong_data = gcell_congestion_data(x_idx, y_idx);
 
       const int next_x = (x_idx + 1) == x_grid_sz

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -96,6 +96,7 @@ using odb::dbTechLayerType;
 using odb::dbTrackGrid;
 using odb::dbTransform;
 using odb::Rect;
+using odb::uint;
 
 using upf::eval_upf;
 

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -119,7 +119,7 @@ void addAdjacentCutsSubRule(
   auto className = at_c<6>(params);
   auto sideParallelNoPrl = at_c<7>(params);
   auto sameMask = at_c<8>(params);
-  uint cuts_int = (uint) cuts[0] - (uint) '0';
+  odb::uint cuts_int = (odb::uint) cuts[0] - (odb::uint) '0';
   parser->curRule->setAdjacentCuts(cuts_int);
   if (aligned.is_initialized()) {
     parser->curRule->setExactAligned(true);

--- a/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
@@ -271,11 +271,11 @@ void setCutClass(
   auto colsNamesAndFirstRowName = at_c<0>(params);
   auto firstRowWithOutName = at_c<1>(params);
   auto allRows = at_c<2>(params);
-  std::map<std::string, uint> cols;
-  std::map<std::string, uint> rows;
+  std::map<std::string, odb::uint> cols;
+  std::map<std::string, odb::uint> rows;
   std::vector<std::vector<std::pair<int, int>>> table;
-  uint colSz = colsNamesAndFirstRowName.size() - 1;
-  for (uint i = 0; i < colSz; i++) {
+  odb::uint colSz = colsNamesAndFirstRowName.size() - 1;
+  for (odb::uint i = 0; i < colSz; i++) {
     std::string name = at_c<0>(colsNamesAndFirstRowName[i]);
     auto OPTION = at_c<1>(colsNamesAndFirstRowName[i]);
     if (OPTION.is_initialized()) {
@@ -293,8 +293,8 @@ void setCutClass(
                at_c<1>(colsNamesAndFirstRowName[colSz]),
                firstRowWithOutName);
   allRows.insert(allRows.begin(), firstRow);
-  uint rowSz = allRows.size();
-  for (uint i = 0; i < rowSz; i++) {
+  odb::uint rowSz = allRows.size();
+  for (odb::uint i = 0; i < rowSz; i++) {
     std::string name = at_c<0>(allRows[i]);
     auto OPTION = at_c<1>(allRows[i]);
     auto items = at_c<2>(allRows[i]);
@@ -303,7 +303,7 @@ void setCutClass(
     }
     rows[name] = i;
     table.push_back(std::vector<std::pair<int, int>>(colSz));
-    for (uint j = 0; j < items.size(); j++) {
+    for (odb::uint j = 0; j < items.size(); j++) {
       auto item = items[j];
       auto spacing1 = at_c<0>(item);
       auto spacing2 = at_c<1>(item);

--- a/src/pdn/src/sroute.h
+++ b/src/pdn/src/sroute.h
@@ -67,7 +67,7 @@ class SRoute
                      odb::dbInst* inst,
                      const char* iterm_name,
                      const std::vector<odb::dbSBox*>& ring);
-  std::vector<odb::dbSBox*> findRingShapes(odb::dbNet* net, uint& Hdy);
+  std::vector<odb::dbSBox*> findRingShapes(odb::dbNet* net, odb::uint& Hdy);
   std::vector<VoltageDomain*> getDomains() const;
 
   utl::Logger* logger_;

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -167,8 +167,8 @@ std::vector<TechLayer::MinCutRule> TechLayer::getMinCutRules() const
 
   // get all the LEF55 rules
   for (auto* min_cut_rule : layer_->getMinCutRules()) {
-    uint numcuts;
-    uint rule_width;
+    odb::uint numcuts;
+    odb::uint rule_width;
     min_cut_rule->getMinimumCuts(numcuts, rule_width);
 
     rules.push_back(MinCutRule{nullptr,

--- a/src/pdn/src/via.h
+++ b/src/pdn/src/via.h
@@ -82,6 +82,7 @@ using ViaValue = std::pair<Box, ViaPtr>;
 using ShapeTree = bgi::rtree<ShapeValue, bgi::quadratic<16>>;
 using ViaTree = bgi::rtree<ViaValue, bgi::quadratic<16>>;
 using ShapeTreeMap = std::map<odb::dbTechLayer*, ShapeTree>;
+using uint = odb::uint;
 
 using ViaReport = std::map<std::string, int>;
 

--- a/src/pdn/src/via.h
+++ b/src/pdn/src/via.h
@@ -651,7 +651,7 @@ class GenerateViaGenerator : public ViaGenerator
  private:
   odb::dbTechViaGenerateRule* rule_;
 
-  std::array<uint, 3> layers_;
+  std::array<odb::uint, 3> layers_;
 
   bool isLayerValidForWidth(odb::dbTechViaLayerRule*, int width) const;
   bool getLayerEnclosureRule(odb::dbTechViaLayerRule* rule,

--- a/src/rmp/src/blif.cpp
+++ b/src/rmp/src/blif.cpp
@@ -107,7 +107,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
   }
 
   std::set<odb::dbInst*>& insts = this->instances_to_optimize;
-  std::map<uint, odb::dbInst*> instMap;
+  std::map<odb::uint, odb::dbInst*> instMap;
   std::vector<std::string> subckts;
   std::set<std::string> inputs, outputs, const0, const1, clocks;
 
@@ -115,7 +115,7 @@ bool Blif::writeBlif(const char* file_name, bool write_arrival_requireds)
   int instIndex = 0;
 
   for (auto&& inst : insts) {
-    instMap.insert(std::pair<uint, odb::dbInst*>(inst->getId(), inst));
+    instMap.insert(std::pair<odb::uint, odb::dbInst*>(inst->getId(), inst));
   }
 
   for (auto&& inst : insts) {


### PR DESCRIPTION
* Change uses of `uint` to `odb::uint` where available (by explicit namespace access or `using` as appropriate) or by expansion to `unsigned int` in files where `odb` is not imported
* Change the few uses of `ushort` to `uint16_t`, importing `cstdint` as appropriate
* `src/dbSta/src/dbSta.i`: Change import of `Exception.i` to match that of other `.i` files (Current import only works when `USE_SYSTEM_OPENSTA` is `OFF`)
* Added a recommended compile environment to `./etc/shell.nix` for posterity

---

Granted, this only helps on some freak setups such GCC-based compile environments on aarch64 macOS. I can confirm it doesn't hurt at least (and I hope the CI backs me up on that. 🙂)