### PR TITLE
grt: initializing variable in Route structure

### DIFF
--- a/src/grt/src/fastroute/include/DataType.h
+++ b/src/grt/src/fastroute/include/DataType.h
@@ -205,7 +205,7 @@ struct Route
   // valid for MazeRoute: the number of edges in the route
   int routelen;
 
-  int last_routelen;  // the last routelen before overflow itter
+  int last_routelen = 0;  // the last routelen before overflow itter
 };
 
 struct TreeEdge


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/4201
Initializing variable `last_routelen` in Route structure to be used in the `FastRouteCore::newRipupCheck` function