### PR TITLE
rtlmp: change 'total area' with Core area in debug output

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -409,6 +409,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       "\tNumber of macros: {}\n"
       "\tArea of macros: {:.2f}\n"
       "\tArea of macros with halos: {:.2f}\n"
+      "\tArea of std cell instances + Area of macros: {:.2f}\n"
       "\tCore area: {:.2f}\n"
       "\tDesign Utilization: {:.2f}\n"
       "\tCore Utilization: {:.2f}\n"
@@ -418,6 +419,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       metrics_->getNumMacro(),
       metrics_->getMacroArea(),
       macro_with_halo_area,
+      metrics_->getStdCellArea() + metrics_->getMacroArea(),
       core_area,
       util,
       core_util,

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -404,13 +404,13 @@ void HierRTLMP::hierRTLMacroPlacer()
 
   logger_->report(
       "Traversed logical hierarchy\n"
-      "\tNumber of std cell instances : {}\n"
-      "\tArea of std cell instances : {:.2f}\n"
-      "\tNumber of macros : {}\n"
-      "\tArea of macros : {:.2f}\n"
-      "\tArea of macros with halos : {:.2f}\n"
-      "\tTotal area : {:.2f}\n"
-      "\tDesign Utilization : {:.2f}\n"
+      "\tNumber of std cell instances: {}\n"
+      "\tArea of std cell instances: {:.2f}\n"
+      "\tNumber of macros: {}\n"
+      "\tArea of macros: {:.2f}\n"
+      "\tArea of macros with halos: {:.2f}\n"
+      "\tCore area: {:.2f}\n"
+      "\tDesign Utilization: {:.2f}\n"
       "\tCore Utilization: {:.2f}\n"
       "\tManufacturing Grid: {}\n",
       metrics_->getNumStdCell(),
@@ -418,7 +418,7 @@ void HierRTLMP::hierRTLMacroPlacer()
       metrics_->getNumMacro(),
       metrics_->getMacroArea(),
       macro_with_halo_area,
-      metrics_->getStdCellArea() + metrics_->getMacroArea(),
+      core_area,
       util,
       core_util,
       manufacturing_grid_);


### PR DESCRIPTION
It is not clear from the printed information what 'total area' means.

Why should total area not include halos of macros?

The individual area information is now printed and the user can add those together to get the numbers they need.