### PR TITLE
Fix `rsz` metric types

### DIFF
--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -519,8 +519,8 @@ proc report_floating_nets { args } {
     }
   }
 
-  utl::metric "timing__drv__floating__nets" $floating_net_count
-  utl::metric "timing__drv__floating__pins" $floating_pin_count
+  utl::metric_int "timing__drv__floating__nets" $floating_net_count
+  utl::metric_int "timing__drv__floating__pins" $floating_pin_count
 }
 
 sta::define_cmd_args "report_long_wires" {count}


### PR DESCRIPTION
* Fix types of `timing__drv__floating__nets` and `timing__drv__floating__pins`, which were mistakenly reported as strings.