### PR TITLE
mpl2: fix SASoftMacro result update

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -4074,12 +4074,8 @@ void HierRTLMP::multiLevelMacroPlacement(Cluster* parent)
   }
   file.close();
 
-  // update the shapes and locations for children clusters based on simulated
-  // annealing results
-  for (auto& cluster : parent->getChildren()) {
-    *(cluster->getSoftMacro())
-        = shaped_macros[soft_macro_id_map[cluster->getName()]];
-  }
+  updateChildrenShapesAndLocations(parent, shaped_macros, soft_macro_id_map);
+
   // check if the parent cluster still need bus planning
   for (auto& child : parent->getChildren()) {
     if (child->getClusterType() == MixedCluster) {
@@ -4626,12 +4622,7 @@ void HierRTLMP::multiLevelMacroPlacementWithoutBusPlanning(Cluster* parent)
     }
     file.close();
 
-    // update the shapes and locations for children clusters based on simulated
-    // annealing results
-    for (auto& cluster : parent->getChildren()) {
-      *(cluster->getSoftMacro())
-          = shaped_macros[soft_macro_id_map[cluster->getName()]];
-    }
+    updateChildrenShapesAndLocations(parent, shaped_macros, soft_macro_id_map);
 
     // update the location of children cluster to their real location
     for (auto& cluster : parent->getChildren()) {
@@ -5123,12 +5114,7 @@ void HierRTLMP::enhancedMacroPlacement(Cluster* parent)
   }
   file.close();
 
-  // update the shapes and locations for children clusters based on simulated
-  // annealing results
-  for (auto& cluster : parent->getChildren()) {
-    *(cluster->getSoftMacro())
-        = shaped_macros[soft_macro_id_map[cluster->getName()]];
-  }
+  updateChildrenShapesAndLocations(parent, shaped_macros, soft_macro_id_map);
 
   // update the location of children cluster to their real location
   for (auto& cluster : parent->getChildren()) {
@@ -5977,6 +5963,22 @@ void HierRTLMP::alignHardMacroGlobal(Cluster* parent)
       if (flags[j] == true) {
         macro_queue.push(j);
       }
+    }
+  }
+}
+
+// Update the location from the perspective of the SA outline
+void HierRTLMP::updateChildrenShapesAndLocations(
+    Cluster* parent,
+    const std::vector<SoftMacro>& shaped_macros,
+    const std::map<std::string, int>& soft_macro_id_map)
+{
+  for (auto& child : parent->getChildren()) {
+    // IO clusters are fixed and have no area,
+    // so their shapes and locations should not be updated
+    if (!child->isIOCluster()) {
+      *(child->getSoftMacro())
+          = shaped_macros[soft_macro_id_map.at(child->getName())];
     }
   }
 }

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -249,10 +249,14 @@ class HierRTLMP
   void alignHardMacroGlobal(Cluster* parent);  // call this function after
                                                // multilevel macro placement
 
+  // Functions used to incorporate SA results in the children of a cluster
   void updateChildrenShapesAndLocations(
       Cluster* parent,
       const std::vector<SoftMacro>& shaped_macros,
       const std::map<std::string, int>& soft_macro_id_map);
+  void updateChildrenRealLocation(Cluster* parent,
+                                  float offset_x,
+                                  float offset_y);
 
   // force-directed placement to generate guides for macros
   void FDPlacement(std::vector<Rect>& blocks,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -249,6 +249,11 @@ class HierRTLMP
   void alignHardMacroGlobal(Cluster* parent);  // call this function after
                                                // multilevel macro placement
 
+  void updateChildrenShapesAndLocations(
+      Cluster* parent,
+      const std::vector<SoftMacro>& shaped_macros,
+      const std::map<std::string, int>& soft_macro_id_map);
+
   // force-directed placement to generate guides for macros
   void FDPlacement(std::vector<Rect>& blocks,
                    const std::vector<BundledNet>& nets,


### PR DESCRIPTION
After merging #4272, for some designs, the bundled io clusters were still being displayed in a weird location in debug mode after we ran SA for specifically placing children clusters of the root.

I realized then that when incorporating the SASoftMacro results for the root cluster, we were cheating the `fixed_` flag that we set to true when setting a cluster as an IO Cluster. This was being done by changing the SoftMacro pointer address directly and, this way, bypassing the flag. With this, when trying to move these clusters to their real location in the die, they would be stuck in a wrong location, however they should not have been displaced in the first place.

I'm running Secure-CI on this.

Also doing some tiny refactoring/cleaning.