### PR TITLE
odb: generating a default destructor for classes without destructible fields

### DIFF
--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -264,6 +264,12 @@ for klass in schema["classes"]:
         else:
             field["setterArgumentType"] = field["getterReturnType"] = field["type"]
 
+        if field["name"] == '_name' and 'no-destruct' not in field["flags"]:
+          klass["has_destructible_fields"] = True
+
+        if "table" in field:
+          klass["has_destructible_fields"] = True
+
     klass["fields"] = [field for field in klass["fields"] if "bits" not in field]
 
     klass["hasBitFields"] = False

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -266,7 +266,7 @@ for klass in schema["classes"]:
 
         # For fields that we need to free/destroy in the destructor
         if field["name"] == '_name' and 'no-destruct' not in field["flags"] or "table" in field:
-          klass["has_destructible_fields"] = True
+          klass["needs_non_default_destructor"] = True
 
     klass["fields"] = [field for field in klass["fields"] if "bits" not in field]
 

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -264,10 +264,8 @@ for klass in schema["classes"]:
         else:
             field["setterArgumentType"] = field["getterReturnType"] = field["type"]
 
-        if field["name"] == '_name' and 'no-destruct' not in field["flags"]:
-          klass["has_destructible_fields"] = True
-
-        if "table" in field:
+        # For fields that we need to free/destroy in the destructor
+        if field["name"] == '_name' and 'no-destruct' not in field["flags"] or "table" in field:
           klass["has_destructible_fields"] = True
 
     klass["fields"] = [field for field in klass["fields"] if "bits" not in field]

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -168,8 +168,3 @@ def get_ref_type(type_name):
         return None
 
     return type_name[6:-1] + "*"
-
-def has_destructible_field(klass):
-  for field in klass["fields"]:
-    return True
-  return False

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -168,3 +168,8 @@ def get_ref_type(type_name):
         return None
 
     return type_name[6:-1] + "*"
+
+def has_destructible_field(klass):
+  for field in klass["fields"]:
+    return True
+  return False

--- a/src/odb/src/codeGenerator/templates/impl.cpp
+++ b/src/odb/src/codeGenerator/templates/impl.cpp
@@ -291,7 +291,7 @@ namespace odb {
   }
   {% endif %}
 
-  {% if klass.has_destructible_fields %}
+  {% if klass.needs_non_default_destructor %}
     _{{klass.name}}::~_{{klass.name}}()
     {
       {% for field in klass.fields %}

--- a/src/odb/src/codeGenerator/templates/impl.cpp
+++ b/src/odb/src/codeGenerator/templates/impl.cpp
@@ -291,21 +291,23 @@ namespace odb {
   }
   {% endif %}
 
-  _{{klass.name}}::~_{{klass.name}}()
-  {
-    {% for field in klass.fields %}
-      {% if field.name == '_name' and 'no-destruct' not in field.flags %}
-        if (_name) {
-          free((void*) _name);
-        }
-      {% endif %}
-      {% if field.table %}
-        delete {{field.name}};
-      {% endif %}
-    {% endfor %}
-    //User Code Begin Destructor
-    //User Code End Destructor
-  }
+  {% if klass.has_destructible_fields %}
+    _{{klass.name}}::~_{{klass.name}}()
+    {
+      {% for field in klass.fields %}
+        {% if field.name == '_name' and 'no-destruct' not in field.flags %}
+          if (_name) {
+            free((void*) _name);
+          }
+        {% endif %}
+        {% if field.table %}
+          delete {{field.name}};
+        {% endif %}
+      {% endfor %}
+      //User Code Begin Destructor
+      //User Code End Destructor
+    }
+  {% endif %}
 
   //User Code Begin PrivateMethods
   //User Code End PrivateMethods
@@ -404,5 +406,5 @@ namespace odb {
 
   //User Code Begin {{klass.name}}PublicMethods
   //User Code End {{klass.name}}PublicMethods
-}
+} // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/codeGenerator/templates/impl.h
+++ b/src/odb/src/codeGenerator/templates/impl.h
@@ -91,7 +91,7 @@ namespace odb {
     _{{klass.name}}(_dbDatabase*, const _{{klass.name}}& r);
     _{{klass.name}}(_dbDatabase*);
 
-    {% if klass.has_destructible_fields %}
+    {% if klass.needs_non_default_destructor %}
       ~_{{klass.name}}();
     {% else %}
       ~_{{klass.name}}() = default;

--- a/src/odb/src/codeGenerator/templates/impl.h
+++ b/src/odb/src/codeGenerator/templates/impl.h
@@ -90,7 +90,12 @@ namespace odb {
         
     _{{klass.name}}(_dbDatabase*, const _{{klass.name}}& r);
     _{{klass.name}}(_dbDatabase*);
-    ~_{{klass.name}}();
+
+    {% if klass.has_destructible_fields %}
+      ~_{{klass.name}}();
+    {% else %}
+      ~_{{klass.name}}() = default;
+    {% endif %}
 
     bool operator==(const _{{klass.name}}& rhs) const;
     bool operator!=(const _{{klass.name}}& rhs) const { return !operator==(rhs); }
@@ -121,5 +126,5 @@ dbIStream& operator>>(dbIStream& stream, _{{klass.name}}& obj);
 dbOStream& operator<<(dbOStream& stream, const _{{klass.name}}& obj);
 // User Code Begin General
 // User Code End General
-}
+} // namespace odb
 //Generator Code End Header

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -198,10 +198,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbAccessPoint& obj)
   return stream;
 }
 
-_dbAccessPoint::~_dbAccessPoint()
-{
-}
-
 // User Code Begin PrivateMethods
 void _dbAccessPoint::setMPin(_dbMPin* mpin)
 {
@@ -483,4 +479,4 @@ void dbAccessPoint::destroy(dbAccessPoint* ap)
 }
 // User Code End dbAccessPointPublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbAccessPoint.h
+++ b/src/odb/src/db/dbAccessPoint.h
@@ -58,7 +58,8 @@ class _dbAccessPoint : public _dbObject
  public:
   _dbAccessPoint(_dbDatabase*, const _dbAccessPoint& r);
   _dbAccessPoint(_dbDatabase*);
-  ~_dbAccessPoint();
+
+  ~_dbAccessPoint() = default;
 
   bool operator==(const _dbAccessPoint& rhs) const;
   bool operator!=(const _dbAccessPoint& rhs) const { return !operator==(rhs); }

--- a/src/odb/src/db/dbGCellGrid.cpp
+++ b/src/odb/src/db/dbGCellGrid.cpp
@@ -200,10 +200,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbGCellGrid& obj)
   return stream;
 }
 
-_dbGCellGrid::~_dbGCellGrid()
-{
-}
-
 // User Code Begin PrivateMethods
 
 dbIStream& operator>>(dbIStream& stream, dbGCellGrid::GCellData& obj)
@@ -769,4 +765,4 @@ dbMatrix<dbGCellGrid::GCellData> dbGCellGrid::getCongestionMap(
 }
 // User Code End dbGCellGridPublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbGCellGrid.h
+++ b/src/odb/src/db/dbGCellGrid.h
@@ -66,7 +66,8 @@ class _dbGCellGrid : public _dbObject
  public:
   _dbGCellGrid(_dbDatabase*, const _dbGCellGrid& r);
   _dbGCellGrid(_dbDatabase*);
-  ~_dbGCellGrid();
+
+  ~_dbGCellGrid() = default;
 
   bool operator==(const _dbGCellGrid& rhs) const;
   bool operator!=(const _dbGCellGrid& rhs) const { return !operator==(rhs); }

--- a/src/odb/src/db/dbGlobalConnect.cpp
+++ b/src/odb/src/db/dbGlobalConnect.cpp
@@ -144,10 +144,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbGlobalConnect& obj)
   return stream;
 }
 
-_dbGlobalConnect::~_dbGlobalConnect()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbGlobalConnect - Methods

--- a/src/odb/src/db/dbGlobalConnect.h
+++ b/src/odb/src/db/dbGlobalConnect.h
@@ -65,7 +65,8 @@ class _dbGlobalConnect : public _dbObject
  public:
   _dbGlobalConnect(_dbDatabase*, const _dbGlobalConnect& r);
   _dbGlobalConnect(_dbDatabase*);
-  ~_dbGlobalConnect();
+
+  ~_dbGlobalConnect() = default;
 
   bool operator==(const _dbGlobalConnect& rhs) const;
   bool operator!=(const _dbGlobalConnect& rhs) const

--- a/src/odb/src/db/dbGroup.cpp
+++ b/src/odb/src/db/dbGroup.cpp
@@ -573,4 +573,4 @@ dbGroup* dbGroup::getGroup(dbBlock* block_, uint dbid_)
 
 // User Code End dbGroupPublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbGroup.h
+++ b/src/odb/src/db/dbGroup.h
@@ -61,6 +61,7 @@ class _dbGroup : public _dbObject
  public:
   _dbGroup(_dbDatabase*, const _dbGroup& r);
   _dbGroup(_dbDatabase*);
+
   ~_dbGroup();
 
   bool operator==(const _dbGroup& rhs) const;

--- a/src/odb/src/db/dbGuide.cpp
+++ b/src/odb/src/db/dbGuide.cpp
@@ -122,10 +122,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbGuide& obj)
   return stream;
 }
 
-_dbGuide::~_dbGuide()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbGuide - Methods

--- a/src/odb/src/db/dbGuide.h
+++ b/src/odb/src/db/dbGuide.h
@@ -49,7 +49,8 @@ class _dbGuide : public _dbObject
  public:
   _dbGuide(_dbDatabase*, const _dbGuide& r);
   _dbGuide(_dbDatabase*);
-  ~_dbGuide();
+
+  ~_dbGuide() = default;
 
   bool operator==(const _dbGuide& rhs) const;
   bool operator!=(const _dbGuide& rhs) const { return !operator==(rhs); }

--- a/src/odb/src/db/dbIsolation.h
+++ b/src/odb/src/db/dbIsolation.h
@@ -49,6 +49,7 @@ class _dbIsolation : public _dbObject
  public:
   _dbIsolation(_dbDatabase*, const _dbIsolation& r);
   _dbIsolation(_dbDatabase*);
+
   ~_dbIsolation();
 
   bool operator==(const _dbIsolation& rhs) const;

--- a/src/odb/src/db/dbLogicPort.h
+++ b/src/odb/src/db/dbLogicPort.h
@@ -48,6 +48,7 @@ class _dbLogicPort : public _dbObject
  public:
   _dbLogicPort(_dbDatabase*, const _dbLogicPort& r);
   _dbLogicPort(_dbDatabase*);
+
   ~_dbLogicPort();
 
   bool operator==(const _dbLogicPort& rhs) const;

--- a/src/odb/src/db/dbMetalWidthViaMap.cpp
+++ b/src/odb/src/db/dbMetalWidthViaMap.cpp
@@ -159,10 +159,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbMetalWidthViaMap& obj)
   return stream;
 }
 
-_dbMetalWidthViaMap::~_dbMetalWidthViaMap()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbMetalWidthViaMap - Methods

--- a/src/odb/src/db/dbMetalWidthViaMap.h
+++ b/src/odb/src/db/dbMetalWidthViaMap.h
@@ -53,7 +53,8 @@ class _dbMetalWidthViaMap : public _dbObject
  public:
   _dbMetalWidthViaMap(_dbDatabase*, const _dbMetalWidthViaMap& r);
   _dbMetalWidthViaMap(_dbDatabase*);
-  ~_dbMetalWidthViaMap();
+
+  ~_dbMetalWidthViaMap() = default;
 
   bool operator==(const _dbMetalWidthViaMap& rhs) const;
   bool operator!=(const _dbMetalWidthViaMap& rhs) const

--- a/src/odb/src/db/dbModInst.cpp
+++ b/src/odb/src/db/dbModInst.cpp
@@ -295,4 +295,4 @@ std::string dbModInst::getHierarchicalName() const
 }
 // User Code End dbModInstPublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbModInst.h
+++ b/src/odb/src/db/dbModInst.h
@@ -49,6 +49,7 @@ class _dbModInst : public _dbObject
  public:
   _dbModInst(_dbDatabase*, const _dbModInst& r);
   _dbModInst(_dbDatabase*);
+
   ~_dbModInst();
 
   bool operator==(const _dbModInst& rhs) const;

--- a/src/odb/src/db/dbModule.cpp
+++ b/src/odb/src/db/dbModule.cpp
@@ -368,4 +368,4 @@ std::string dbModule::getHierarchicalName() const
 
 // User Code End dbModulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbModule.h
+++ b/src/odb/src/db/dbModule.h
@@ -53,6 +53,7 @@ class _dbModule : public _dbObject
  public:
   _dbModule(_dbDatabase*, const _dbModule& r);
   _dbModule(_dbDatabase*);
+
   ~_dbModule();
 
   bool operator==(const _dbModule& rhs) const;

--- a/src/odb/src/db/dbNetTrack.cpp
+++ b/src/odb/src/db/dbNetTrack.cpp
@@ -122,10 +122,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbNetTrack& obj)
   return stream;
 }
 
-_dbNetTrack::~_dbNetTrack()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbNetTrack - Methods

--- a/src/odb/src/db/dbNetTrack.h
+++ b/src/odb/src/db/dbNetTrack.h
@@ -49,7 +49,8 @@ class _dbNetTrack : public _dbObject
  public:
   _dbNetTrack(_dbDatabase*, const _dbNetTrack& r);
   _dbNetTrack(_dbDatabase*);
-  ~_dbNetTrack();
+
+  ~_dbNetTrack() = default;
 
   bool operator==(const _dbNetTrack& rhs) const;
   bool operator!=(const _dbNetTrack& rhs) const { return !operator==(rhs); }

--- a/src/odb/src/db/dbPowerDomain.cpp
+++ b/src/odb/src/db/dbPowerDomain.cpp
@@ -344,4 +344,4 @@ bool dbPowerDomain::getArea(int& _x1, int& _y1, int& _x2, int& _y2)
 
 // User Code End dbPowerDomainPublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbPowerDomain.h
+++ b/src/odb/src/db/dbPowerDomain.h
@@ -51,6 +51,7 @@ class _dbPowerDomain : public _dbObject
  public:
   _dbPowerDomain(_dbDatabase*, const _dbPowerDomain& r);
   _dbPowerDomain(_dbDatabase*);
+
   ~_dbPowerDomain();
 
   bool operator==(const _dbPowerDomain& rhs) const;

--- a/src/odb/src/db/dbPowerSwitch.h
+++ b/src/odb/src/db/dbPowerSwitch.h
@@ -54,6 +54,7 @@ class _dbPowerSwitch : public _dbObject
  public:
   _dbPowerSwitch(_dbDatabase*, const _dbPowerSwitch& r);
   _dbPowerSwitch(_dbDatabase*);
+
   ~_dbPowerSwitch();
 
   bool operator==(const _dbPowerSwitch& rhs) const;

--- a/src/odb/src/db/dbTechLayer.h
+++ b/src/odb/src/db/dbTechLayer.h
@@ -98,6 +98,7 @@ class _dbTechLayer : public _dbObject
  public:
   _dbTechLayer(_dbDatabase*, const _dbTechLayer& r);
   _dbTechLayer(_dbDatabase*);
+
   ~_dbTechLayer();
 
   bool operator==(const _dbTechLayer& rhs) const;

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -166,10 +166,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerAreaRule& obj)
   return stream;
 }
 
-_dbTechLayerAreaRule::~_dbTechLayerAreaRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerAreaRule - Methods
@@ -351,4 +347,4 @@ void dbTechLayerAreaRule::destroy(dbTechLayerAreaRule* rule)
 
 // User Code End dbTechLayerAreaRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerAreaRule.h
+++ b/src/odb/src/db/dbTechLayerAreaRule.h
@@ -55,7 +55,8 @@ class _dbTechLayerAreaRule : public _dbObject
  public:
   _dbTechLayerAreaRule(_dbDatabase*, const _dbTechLayerAreaRule& r);
   _dbTechLayerAreaRule(_dbDatabase*);
-  ~_dbTechLayerAreaRule();
+
+  ~_dbTechLayerAreaRule() = default;
 
   bool operator==(const _dbTechLayerAreaRule& rhs) const;
   bool operator!=(const _dbTechLayerAreaRule& rhs) const

--- a/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
@@ -178,10 +178,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerArraySpacingRule::~_dbTechLayerArraySpacingRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerArraySpacingRule - Methods

--- a/src/odb/src/db/dbTechLayerArraySpacingRule.h
+++ b/src/odb/src/db/dbTechLayerArraySpacingRule.h
@@ -58,7 +58,8 @@ class _dbTechLayerArraySpacingRule : public _dbObject
   _dbTechLayerArraySpacingRule(_dbDatabase*,
                                const _dbTechLayerArraySpacingRule& r);
   _dbTechLayerArraySpacingRule(_dbDatabase*);
-  ~_dbTechLayerArraySpacingRule();
+
+  ~_dbTechLayerArraySpacingRule() = default;
 
   bool operator==(const _dbTechLayerArraySpacingRule& rhs) const;
   bool operator!=(const _dbTechLayerArraySpacingRule& rhs) const

--- a/src/odb/src/db/dbTechLayerCornerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCornerSpacingRule.cpp
@@ -252,10 +252,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerCornerSpacingRule::~_dbTechLayerCornerSpacingRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerCornerSpacingRule - Methods
@@ -573,4 +569,4 @@ void dbTechLayerCornerSpacingRule::destroy(dbTechLayerCornerSpacingRule* rule)
 }
 // User Code End dbTechLayerCornerSpacingRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCornerSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerCornerSpacingRule.h
@@ -70,7 +70,8 @@ class _dbTechLayerCornerSpacingRule : public _dbObject
   _dbTechLayerCornerSpacingRule(_dbDatabase*,
                                 const _dbTechLayerCornerSpacingRule& r);
   _dbTechLayerCornerSpacingRule(_dbDatabase*);
-  ~_dbTechLayerCornerSpacingRule();
+
+  ~_dbTechLayerCornerSpacingRule() = default;
 
   bool operator==(const _dbTechLayerCornerSpacingRule& rhs) const;
   bool operator!=(const _dbTechLayerCornerSpacingRule& rhs) const

--- a/src/odb/src/db/dbTechLayerCutClassRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutClassRule.cpp
@@ -282,4 +282,4 @@ void dbTechLayerCutClassRule::destroy(dbTechLayerCutClassRule* rule)
 }
 // User Code End dbTechLayerCutClassRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutClassRule.h
+++ b/src/odb/src/db/dbTechLayerCutClassRule.h
@@ -54,6 +54,7 @@ class _dbTechLayerCutClassRule : public _dbObject
  public:
   _dbTechLayerCutClassRule(_dbDatabase*, const _dbTechLayerCutClassRule& r);
   _dbTechLayerCutClassRule(_dbDatabase*);
+
   ~_dbTechLayerCutClassRule();
 
   bool operator==(const _dbTechLayerCutClassRule& rhs) const;

--- a/src/odb/src/db/dbTechLayerCutEnclosureRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutEnclosureRule.cpp
@@ -413,10 +413,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerCutEnclosureRule::~_dbTechLayerCutEnclosureRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerCutEnclosureRule - Methods
@@ -1029,4 +1025,4 @@ void dbTechLayerCutEnclosureRule::destroy(dbTechLayerCutEnclosureRule* rule)
 }
 // User Code End dbTechLayerCutEnclosureRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutEnclosureRule.h
+++ b/src/odb/src/db/dbTechLayerCutEnclosureRule.h
@@ -78,7 +78,8 @@ class _dbTechLayerCutEnclosureRule : public _dbObject
   _dbTechLayerCutEnclosureRule(_dbDatabase*,
                                const _dbTechLayerCutEnclosureRule& r);
   _dbTechLayerCutEnclosureRule(_dbDatabase*);
-  ~_dbTechLayerCutEnclosureRule();
+
+  ~_dbTechLayerCutEnclosureRule() = default;
 
   bool operator==(const _dbTechLayerCutEnclosureRule& rhs) const;
   bool operator!=(const _dbTechLayerCutEnclosureRule& rhs) const

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -554,10 +554,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerCutSpacingRule& obj)
   return stream;
 }
 
-_dbTechLayerCutSpacingRule::~_dbTechLayerCutSpacingRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerCutSpacingRule - Methods
@@ -1458,4 +1454,4 @@ void dbTechLayerCutSpacingRule::destroy(dbTechLayerCutSpacingRule* rule)
 }
 // User Code End dbTechLayerCutSpacingRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.h
@@ -93,7 +93,8 @@ class _dbTechLayerCutSpacingRule : public _dbObject
  public:
   _dbTechLayerCutSpacingRule(_dbDatabase*, const _dbTechLayerCutSpacingRule& r);
   _dbTechLayerCutSpacingRule(_dbDatabase*);
-  ~_dbTechLayerCutSpacingRule();
+
+  ~_dbTechLayerCutSpacingRule() = default;
 
   bool operator==(const _dbTechLayerCutSpacingRule& rhs) const;
   bool operator!=(const _dbTechLayerCutSpacingRule& rhs) const

--- a/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
@@ -315,10 +315,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerCutSpacingTableDefRule::~_dbTechLayerCutSpacingTableDefRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerCutSpacingTableDefRule - Methods
@@ -1063,4 +1059,4 @@ void dbTechLayerCutSpacingTableDefRule::destroy(
 
 // User Code End dbTechLayerCutSpacingTableDefRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.h
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.h
@@ -82,7 +82,8 @@ class _dbTechLayerCutSpacingTableDefRule : public _dbObject
       _dbDatabase*,
       const _dbTechLayerCutSpacingTableDefRule& r);
   _dbTechLayerCutSpacingTableDefRule(_dbDatabase*);
-  ~_dbTechLayerCutSpacingTableDefRule();
+
+  ~_dbTechLayerCutSpacingTableDefRule() = default;
 
   bool operator==(const _dbTechLayerCutSpacingTableDefRule& rhs) const;
   bool operator!=(const _dbTechLayerCutSpacingTableDefRule& rhs) const

--- a/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
@@ -98,10 +98,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerCutSpacingTableOrthRule::~_dbTechLayerCutSpacingTableOrthRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerCutSpacingTableOrthRule - Methods
@@ -154,4 +150,4 @@ void dbTechLayerCutSpacingTableOrthRule::destroy(
 
 // User Code End dbTechLayerCutSpacingTableOrthRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.h
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.h
@@ -50,7 +50,8 @@ class _dbTechLayerCutSpacingTableOrthRule : public _dbObject
       _dbDatabase*,
       const _dbTechLayerCutSpacingTableOrthRule& r);
   _dbTechLayerCutSpacingTableOrthRule(_dbDatabase*);
-  ~_dbTechLayerCutSpacingTableOrthRule();
+
+  ~_dbTechLayerCutSpacingTableOrthRule() = default;
 
   bool operator==(const _dbTechLayerCutSpacingTableOrthRule& rhs) const;
   bool operator!=(const _dbTechLayerCutSpacingTableOrthRule& rhs) const

--- a/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
@@ -128,10 +128,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerEolExtensionRule::~_dbTechLayerEolExtensionRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerEolExtensionRule - Methods
@@ -204,4 +200,4 @@ void dbTechLayerEolExtensionRule::destroy(dbTechLayerEolExtensionRule* rule)
 
 // User Code End dbTechLayerEolExtensionRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerEolExtensionRule.h
+++ b/src/odb/src/db/dbTechLayerEolExtensionRule.h
@@ -55,7 +55,8 @@ class _dbTechLayerEolExtensionRule : public _dbObject
   _dbTechLayerEolExtensionRule(_dbDatabase*,
                                const _dbTechLayerEolExtensionRule& r);
   _dbTechLayerEolExtensionRule(_dbDatabase*);
-  ~_dbTechLayerEolExtensionRule();
+
+  ~_dbTechLayerEolExtensionRule() = default;
 
   bool operator==(const _dbTechLayerEolExtensionRule& rhs) const;
   bool operator!=(const _dbTechLayerEolExtensionRule& rhs) const

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
@@ -187,10 +187,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerEolKeepOutRule& obj)
   return stream;
 }
 
-_dbTechLayerEolKeepOutRule::~_dbTechLayerEolKeepOutRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerEolKeepOutRule - Methods
@@ -358,4 +354,4 @@ void dbTechLayerEolKeepOutRule::destroy(dbTechLayerEolKeepOutRule* rule)
 
 // User Code End dbTechLayerEolKeepOutRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.h
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.h
@@ -59,7 +59,8 @@ class _dbTechLayerEolKeepOutRule : public _dbObject
  public:
   _dbTechLayerEolKeepOutRule(_dbDatabase*, const _dbTechLayerEolKeepOutRule& r);
   _dbTechLayerEolKeepOutRule(_dbDatabase*);
-  ~_dbTechLayerEolKeepOutRule();
+
+  ~_dbTechLayerEolKeepOutRule() = default;
 
   bool operator==(const _dbTechLayerEolKeepOutRule& rhs) const;
   bool operator!=(const _dbTechLayerEolKeepOutRule& rhs) const

--- a/src/odb/src/db/dbTechLayerForbiddenSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerForbiddenSpacingRule.cpp
@@ -133,10 +133,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerForbiddenSpacingRule::~_dbTechLayerForbiddenSpacingRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerForbiddenSpacingRule - Methods
@@ -269,4 +265,4 @@ void dbTechLayerForbiddenSpacingRule::destroy(
 
 // User Code End dbTechLayerForbiddenSpacingRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerForbiddenSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerForbiddenSpacingRule.h
@@ -48,7 +48,8 @@ class _dbTechLayerForbiddenSpacingRule : public _dbObject
   _dbTechLayerForbiddenSpacingRule(_dbDatabase*,
                                    const _dbTechLayerForbiddenSpacingRule& r);
   _dbTechLayerForbiddenSpacingRule(_dbDatabase*);
-  ~_dbTechLayerForbiddenSpacingRule();
+
+  ~_dbTechLayerForbiddenSpacingRule() = default;
 
   bool operator==(const _dbTechLayerForbiddenSpacingRule& rhs) const;
   bool operator!=(const _dbTechLayerForbiddenSpacingRule& rhs) const

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
@@ -224,10 +224,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerKeepOutZoneRule& obj)
   return stream;
 }
 
-_dbTechLayerKeepOutZoneRule::~_dbTechLayerKeepOutZoneRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerKeepOutZoneRule - Methods

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.h
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.h
@@ -58,7 +58,8 @@ class _dbTechLayerKeepOutZoneRule : public _dbObject
   _dbTechLayerKeepOutZoneRule(_dbDatabase*,
                               const _dbTechLayerKeepOutZoneRule& r);
   _dbTechLayerKeepOutZoneRule(_dbDatabase*);
-  ~_dbTechLayerKeepOutZoneRule();
+
+  ~_dbTechLayerKeepOutZoneRule() = default;
 
   bool operator==(const _dbTechLayerKeepOutZoneRule& rhs) const;
   bool operator!=(const _dbTechLayerKeepOutZoneRule& rhs) const

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -222,10 +222,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerMinCutRule& obj)
   return stream;
 }
 
-_dbTechLayerMinCutRule::~_dbTechLayerMinCutRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerMinCutRule - Methods

--- a/src/odb/src/db/dbTechLayerMinCutRule.h
+++ b/src/odb/src/db/dbTechLayerMinCutRule.h
@@ -61,7 +61,8 @@ class _dbTechLayerMinCutRule : public _dbObject
  public:
   _dbTechLayerMinCutRule(_dbDatabase*, const _dbTechLayerMinCutRule& r);
   _dbTechLayerMinCutRule(_dbDatabase*);
-  ~_dbTechLayerMinCutRule();
+
+  ~_dbTechLayerMinCutRule() = default;
 
   bool operator==(const _dbTechLayerMinCutRule& rhs) const;
   bool operator!=(const _dbTechLayerMinCutRule& rhs) const

--- a/src/odb/src/db/dbTechLayerMinStepRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinStepRule.cpp
@@ -203,10 +203,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerMinStepRule& obj)
   return stream;
 }
 
-_dbTechLayerMinStepRule::~_dbTechLayerMinStepRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerMinStepRule - Methods
@@ -413,4 +409,4 @@ void dbTechLayerMinStepRule::destroy(dbTechLayerMinStepRule* rule)
 }
 // User Code End dbTechLayerMinStepRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerMinStepRule.h
+++ b/src/odb/src/db/dbTechLayerMinStepRule.h
@@ -59,7 +59,8 @@ class _dbTechLayerMinStepRule : public _dbObject
  public:
   _dbTechLayerMinStepRule(_dbDatabase*, const _dbTechLayerMinStepRule& r);
   _dbTechLayerMinStepRule(_dbDatabase*);
-  ~_dbTechLayerMinStepRule();
+
+  ~_dbTechLayerMinStepRule() = default;
 
   bool operator==(const _dbTechLayerMinStepRule& rhs) const;
   bool operator!=(const _dbTechLayerMinStepRule& rhs) const

--- a/src/odb/src/db/dbTechLayerSpacingEolRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingEolRule.cpp
@@ -697,10 +697,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerSpacingEolRule& obj)
   return stream;
 }
 
-_dbTechLayerSpacingEolRule::~_dbTechLayerSpacingEolRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerSpacingEolRule - Methods
@@ -1755,4 +1751,4 @@ void dbTechLayerSpacingEolRule::destroy(dbTechLayerSpacingEolRule* rule)
 
 // User Code End dbTechLayerSpacingEolRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerSpacingEolRule.h
+++ b/src/odb/src/db/dbTechLayerSpacingEolRule.h
@@ -96,7 +96,8 @@ class _dbTechLayerSpacingEolRule : public _dbObject
  public:
   _dbTechLayerSpacingEolRule(_dbDatabase*, const _dbTechLayerSpacingEolRule& r);
   _dbTechLayerSpacingEolRule(_dbDatabase*);
-  ~_dbTechLayerSpacingEolRule();
+
+  ~_dbTechLayerSpacingEolRule() = default;
 
   bool operator==(const _dbTechLayerSpacingEolRule& rhs) const;
   bool operator!=(const _dbTechLayerSpacingEolRule& rhs) const

--- a/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
@@ -149,10 +149,6 @@ dbOStream& operator<<(dbOStream& stream,
   return stream;
 }
 
-_dbTechLayerSpacingTablePrlRule::~_dbTechLayerSpacingTablePrlRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerSpacingTablePrlRule - Methods
@@ -336,4 +332,4 @@ std::pair<int, int> dbTechLayerSpacingTablePrlRule::getExceptWithin(
 
 // User Code End dbTechLayerSpacingTablePrlRulePublicMethods
 }  // namespace odb
-   // Generator Code End Cpp
+// Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerSpacingTablePrlRule.h
+++ b/src/odb/src/db/dbTechLayerSpacingTablePrlRule.h
@@ -61,7 +61,8 @@ class _dbTechLayerSpacingTablePrlRule : public _dbObject
   _dbTechLayerSpacingTablePrlRule(_dbDatabase*,
                                   const _dbTechLayerSpacingTablePrlRule& r);
   _dbTechLayerSpacingTablePrlRule(_dbDatabase*);
-  ~_dbTechLayerSpacingTablePrlRule();
+
+  ~_dbTechLayerSpacingTablePrlRule() = default;
 
   bool operator==(const _dbTechLayerSpacingTablePrlRule& rhs) const;
   bool operator!=(const _dbTechLayerSpacingTablePrlRule& rhs) const

--- a/src/odb/src/db/dbTechLayerWidthTableRule.cpp
+++ b/src/odb/src/db/dbTechLayerWidthTableRule.cpp
@@ -120,10 +120,6 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerWidthTableRule& obj)
   return stream;
 }
 
-_dbTechLayerWidthTableRule::~_dbTechLayerWidthTableRule()
-{
-}
-
 ////////////////////////////////////////////////////////////////////
 //
 // dbTechLayerWidthTableRule - Methods

--- a/src/odb/src/db/dbTechLayerWidthTableRule.h
+++ b/src/odb/src/db/dbTechLayerWidthTableRule.h
@@ -55,7 +55,8 @@ class _dbTechLayerWidthTableRule : public _dbObject
  public:
   _dbTechLayerWidthTableRule(_dbDatabase*, const _dbTechLayerWidthTableRule& r);
   _dbTechLayerWidthTableRule(_dbDatabase*);
-  ~_dbTechLayerWidthTableRule();
+
+  ~_dbTechLayerWidthTableRule() = default;
 
   bool operator==(const _dbTechLayerWidthTableRule& rhs) const;
   bool operator!=(const _dbTechLayerWidthTableRule& rhs) const


### PR DESCRIPTION
To fix clang-tidy's warning:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/1619948/3c28af01-ead9-490f-a196-a3f30ff65d7a)
