### PR TITLE
floorplan: utilization beyond 100% is useful for mock abstracts

### DIFF
--- a/src/ifp/README.md
+++ b/src/ifp/README.md
@@ -28,7 +28,7 @@ initialize_floorplan
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-utilization` | Percentage utilization. Allowed values are `double` in the range `(0-100]`. |
+| `-utilization` | Percentage utilization. Allowed values are `double` `>0`, more than 100% utilization can be useful with mock abstracts. |
 | `-aspect_ratio` | Ratio $\frac{height}{width}$. The default value is `1.0` and the allowed values are floats `[0, 1.0]`. |
 | `-core_space` | Space around the core, default `0.0` microns. Allowed values are either one value for all margins or a set of four values, one for each margin. The order of the four values are: `{bottom top left right}`. |
 | `-sites` | Tcl list of sites to make rows for (e.g. `{SITEXX, SITEYY}`) |

--- a/src/ifp/src/InitFloorplan.cc
+++ b/src/ifp/src/InitFloorplan.cc
@@ -108,7 +108,7 @@ void InitFloorplan::initFloorplan(double utilization,
                                   const std::vector<odb::dbSite*>& extra_sites)
 {
   utl::Validator v(logger_, IFP);
-  v.check_percentage("utilization", utilization, 12);
+  v.check_non_negative("utilization", utilization, 12);
   v.check_non_negative("core_space_bottom", core_space_bottom, 32);
   v.check_non_negative("core_space_top", core_space_top, 33);
   v.check_non_negative("core_space_left", core_space_left, 34);


### PR DESCRIPTION
Example of mocked SRAMs that will be refined later where utilization beyond 100% is useful:

```
boom_tile_rams = [
        "ebtb_128x40",
        "array_256x64",
        "dataArrayB_256x64",
        "l2_tlb_ram_0_512x45"]

[build_openroad(
        name = ram,
        io_constraints="io-sram.tcl",
        verilog_files=["rtl/" + ram + ".sv"],
        stage_sources={'synth': ["constraints-sram.sdc", "util.tcl"],
        'floorplan': ["util.tcl"],
        'place': ["util.tcl"]},
        stage_args={
                'floorplan': ['CORE_UTILIZATION=200'],
                'place': ['PLACE_DENSITY=0.65']},
        mock_abstract=True,
        mock_stage=2
        )
 for ram in boom_tile_rams + boom_tile_small_srams]
```