### PR TITLE
DPL: cleanup and speedups using neat optimizations based on vtune insights

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -112,18 +112,7 @@ struct Master
   bool is_multi_row = false;
 };
 
-struct GridMapKey
-{
-  int grid_index;
-  bool operator<(const GridMapKey& other) const
-  {
-    return grid_index < other.grid_index;
-  }
-  bool operator==(const GridMapKey& other) const
-  {
-    return grid_index == other.grid_index;
-  }
-};
+using GridMapKey = int;
 
 class HybridSiteInfo
 {
@@ -142,6 +131,7 @@ struct Cell
   const char* name() const;
   bool inGroup() const { return group_ != nullptr; }
   int64_t area() const;
+  mutable dbSite* cachedSite_ = nullptr;
 
   dbInst* db_inst_ = nullptr;
   int x_ = 0;  // lower left wrt core DBU
@@ -168,10 +158,16 @@ struct Cell
 
   dbSite* getSite() const
   {
+    if (cachedSite_) {
+      return cachedSite_;
+    }
+
     if (!db_inst_ || !db_inst_->getMaster()) {
       return nullptr;
     }
-    return db_inst_->getMaster()->getSite();
+
+    cachedSite_ = db_inst_->getMaster()->getSite();
+    return cachedSite_;
   }
 };
 
@@ -511,7 +507,7 @@ class Opendp
   int gridX(const Cell* cell, int site_width) const;
   int gridPaddedX(const Cell* cell) const;
   int gridPaddedX(const Cell* cell, int site_width) const;
-  int gridY(int y, int row_height) const;
+  int gridY(int y, const Cell* cell) const;
   int gridY(const Cell* cell) const;
   pair<int, int> gridY(int y, const dbSite::RowPattern& grid_sites) const;
   pair<int, int> gridEndY(int y, const dbSite::RowPattern& grid_sites) const;
@@ -520,7 +516,7 @@ class Opendp
   int gridEndX(int x, int site_width) const;
   int gridEndX(const Cell* cell) const;
   int gridEndX(const Cell* cell, int site_width) const;
-  int gridEndY(int y, int row_height) const;
+  int gridEndY(int y, const Cell* cell) const;
   int gridEndY(const Cell* cell) const;
   void setGridPaddedLoc(Cell* cell, int x, int y, int site_width) const;
   std::pair<int, GridInfo> getRowInfo(const Cell* cell) const;

--- a/src/dpl/src/FillerPlacement.cpp
+++ b/src/dpl/src/FillerPlacement.cpp
@@ -75,16 +75,16 @@ void Opendp::fillerPlacement(dbMasterSeq* filler_masters, const char* prefix)
         chosen_grid_key = grid_idx;
       }
     }
-    auto chosen_grid_info = grid_info_map_.at(chosen_grid_key);
-    int chosen_row_count = chosen_grid_info.getRowCount();
-    if (!chosen_grid_info.isHybrid()) {
+    auto chosen_grid_info = grid_info_vector_.at(chosen_grid_key);
+    int chosen_row_count = chosen_grid_info->getRowCount();
+    if (!chosen_grid_info->isHybrid()) {
       int site_height = min_height;
       for (int row = 0; row < chosen_row_count; row++) {
         placeRowFillers(
-            row, prefix, filler_masters, site_height, chosen_grid_info);
+            row, prefix, filler_masters, site_height, *chosen_grid_info);
       }
     } else {
-      const auto& hybrid_sites_vec = chosen_grid_info.getSites();
+      const auto& hybrid_sites_vec = chosen_grid_info->getSites();
       const int hybrid_sites_num = hybrid_sites_vec.size();
       for (int row = 0; row < chosen_row_count; row++) {
         placeRowFillers(
@@ -92,7 +92,7 @@ void Opendp::fillerPlacement(dbMasterSeq* filler_masters, const char* prefix)
             prefix,
             filler_masters,
             hybrid_sites_vec[row % hybrid_sites_num].site->getHeight(),
-            chosen_grid_info);
+            *chosen_grid_info);
       }
     }
   }

--- a/src/dpl/src/Place.cpp
+++ b/src/dpl/src/Place.cpp
@@ -1302,10 +1302,10 @@ Point Opendp::pointOffMacro(const Cell& cell)
                             gridY(init_y, &cell));
   Pixel* pixel3 = gridPixel(grid_info.getGridIndex(),
                             gridX(init_x, site_width),
-                            gridY(init_y + cell.height_, &cell));
+                            gridEndY(init_y, &cell));
   Pixel* pixel4 = gridPixel(grid_info.getGridIndex(),
                             gridX(init_x + cell.width_, site_width),
-                            gridY(init_y + cell.height_, &cell));
+                            gridEndY(init_y, &cell));
 
   Cell* block = nullptr;
   if (pixel1 && pixel1->cell && isBlock(pixel1->cell)) {


### PR DESCRIPTION
- replacing grid_info_map.at with grid_info_vector.at reduces runtime from 1 second on aes to 0.22 seconds and removed this: `dpl::GridMapKey::operator< 0.220s `
- caching the getSite function in the cell results in significant gains by removing all of these db calls

```
odb::dbTable<odb::_dbInstHdr>::getPtr 0.280s
odb::_dbObject::getObjectPage   0.240s
odb::dbTable<odb::_dbLib>::getPtr 0.220s
odb::_dbObject::getOwner 0.200s 
```

to only  1 `: odb::_dbObject::getObjectPage 0.164s`


