### PR TITLE
Add `tclint` to CI and clean `Resizer.tcl`

### DIFF
--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -1,0 +1,21 @@
+name: Lint Tcl code
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install tclint
+        run: |
+          python -m pip install tclint==0.1.6
+
+      # TODO: hardcoded list of files while we incrementally lint codebase
+      # See issue #4347 for tracking
+      - name: Lint
+        run: |
+          tclint src/rsz/src/Resizer.tcl

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -156,12 +156,6 @@ proc set_wire_rc { args } {
       set wire_res [rsz::layer_resistance $layer $corner]
       set wire_cap [rsz::layer_capacitance $layer $corner]
     }
-
-    # Unfortunately this does not work very well with technologies like sky130
-    # that use inappropriate kohm/pf units.
-    if { 0 } {
-      utl::info RSZ 61 "$signal_clk wire resistance [sta::format_resistance [expr $wire_res * 1e-6] 6] [sta::unit_scale_abbreviation resistance][sta::unit_suffix resistance]/um capacitance [sta::format_capacitance [expr $wire_cap * 1e-6] 6] [sta::unit_scale_abbreviation capacitance][sta::unit_suffix capacitance]/um."
-    }
   } else {
     ord::ensure_units_initialized
     if { [info exists keys(-resistance)] } {
@@ -476,15 +470,15 @@ proc repair_timing { args } {
   if { $recover_power_percent >= 0 } {
     rsz::recover_power $recover_power_percent
   } else {
-      if { $setup } {
-    rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes \
-      $verbose \
-      $skip_pin_swap $skip_gate_cloning
+    if { $setup } {
+      rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes \
+        $verbose \
+        $skip_pin_swap $skip_gate_cloning
     }
-      if { $hold } {
-    rsz::repair_hold $setup_margin $hold_margin \
-      $allow_setup_violations $max_buffer_percent $max_passes \
-      $verbose	  
+    if { $hold } {
+      rsz::repair_hold $setup_margin $hold_margin \
+        $allow_setup_violations $max_buffer_percent $max_passes \
+        $verbose
     }
   }
 }
@@ -612,7 +606,8 @@ proc check_corner_wire_caps {} {
   set have_rc 1
   foreach corner [sta::corners] {
     if { [rsz::wire_signal_capacitance $corner] == 0.0 } {
-      utl::warn RSZ 14 "wire capacitance for corner [$corner name] is zero. Use the set_wire_rc command to set wire resistance and capacitance."
+      utl::warn RSZ 14 "wire capacitance for corner [$corner name] is zero.\
+        Use the set_wire_rc command to set wire resistance and capacitance."
       set have_rc 0
     }
   }
@@ -624,11 +619,13 @@ proc check_max_wire_length { max_wire_length } {
     set min_delay_max_wire_length [rsz::find_max_wire_length]
     if { $max_wire_length > 0 } {
       if { $max_wire_length < $min_delay_max_wire_length } {
-        utl::warn RSZ 65 "max wire length less than [format %.0fu [sta::distance_sta_ui $min_delay_max_wire_length]] increases wire delays."
+        set wire_length_fmt [format %.0fu [sta::distance_sta_ui $min_delay_max_wire_length]]
+        utl::warn RSZ 65 "max wire length less than $wire_length_fmt increases wire delays."
       }
     } else {
       set max_wire_length $min_delay_max_wire_length
-      utl::info RSZ 58 "Using max wire length [format %.0f [sta::distance_sta_ui $max_wire_length]]um."
+      set max_wire_length_fmt [format %.0f [sta::distance_sta_ui $max_wire_length]]
+      utl::info RSZ 58 "Using max wire length ${max_wire_length_fmt}um."
     }
   }
   return $max_wire_length

--- a/tclint.toml
+++ b/tclint.toml
@@ -1,0 +1,5 @@
+[style]
+indent = 2
+line-length = 100
+allow-aligned-sets = true
+indent-namespace-eval = false


### PR DESCRIPTION
Towards #4347, this PR adds `tclint` to the CI (with a hardcoded file-list) and cleans up the lint warnings in `Resizer.tcl`, which was the first file chosen as a test.

