### PR TITLE
meta: Moves GPL tests to new CTest Runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ add_subdirectory(third-party)
 
 if(ENABLE_TESTS)
   enable_testing()
-  add_custom_target(build_and_test ${CMAKE_CTEST_COMMAND} --parallel --output-on-failure)
+  add_custom_target(build_and_test ${CMAKE_CTEST_COMMAND} --parallel --output-on-failure -LE IntegrationTest)
   include(GoogleTest)
 endif()
 

--- a/src/gpl/CMakeLists.txt
+++ b/src/gpl/CMakeLists.txt
@@ -149,3 +149,5 @@ if (Python3_FOUND AND BUILD_PYTHON)
   )
 
 endif()
+
+add_subdirectory(test)

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_program (BASH_PROGRAM bash)
+find_program (BASH_PROGRAM bash REQUIRED)
 
 function(gpl_test test_name)
   add_test (
@@ -38,8 +38,6 @@ clust01
 clust02
 )
 
-if (BASH_PROGRAM)
-  foreach(TEST_NAME IN LISTS TEST_NAMES)
-    gpl_test(${TEST_NAME})
-  endforeach()
-endif (BASH_PROGRAM)
+foreach(TEST_NAME IN LISTS TEST_NAMES)
+  gpl_test(${TEST_NAME})
+endforeach()

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -1,0 +1,45 @@
+find_program (BASH_PROGRAM bash)
+
+function(gpl_test test_name)
+  add_test (
+    NAME gpl.${test_name} 
+    COMMAND ${BASH_PROGRAM} ${CMAKE_CURRENT_SOURCE_DIR}/regression ${test_name}
+  )
+  set_tests_properties(gpl.${test_name}  PROPERTIES LABELS "IntegrationTest")
+endfunction()
+
+set(TEST_NAMES
+simple01
+simple01-obs
+simple01-td
+simple01-td-tune
+simple01-uniform
+simple01-ref
+simple01-skip-io
+simple02
+simple03
+simple04
+simple05
+simple06
+simple07
+simple08
+simple09
+core01
+ar01
+ar02
+incremental01
+incremental02
+error01
+diverge01
+density01
+convergence01
+nograd01
+clust01
+clust02
+)
+
+if (BASH_PROGRAM)
+  foreach(TEST_NAME IN LISTS TEST_NAMES)
+    gpl_test(${TEST_NAME})
+  endforeach()
+endif (BASH_PROGRAM)


### PR DESCRIPTION
You can now run the GPL tests in parallel with the ctest command.

`ctest -j 40`

Integration tests can be excluded with.

`ctest -j 40 -LE IntegrationTest`