### PR TITLE
Fix deb installer

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,9 @@ export DH_VERBOSE = 1
 
 export DEB_BUILD_MAINT_OPTIONS=optimize=-lto
 
+export OPENROAD_EXE = $(abspath ./obj-x86_64-linux-gnu/src/openroad)
+
+
 %:
 	dh $@
 

--- a/test/regression_vars.tcl
+++ b/test/regression_vars.tcl
@@ -18,7 +18,11 @@
 
 # Application program to run tests on.
 set app "openroad"
-set app_path [file join $openroad_dir "build" "src" $app]
+if { [info exist ::env(OPENROAD_EXE)] } {
+  set app_path "$::env(OPENROAD_EXE)"
+} else {
+  set app_path [file join $openroad_dir "build" "src" $app]
+}
 # Application options.
 set app_options "-no_init -no_splash -exit"
 # Log files for each test are placed in result_dir.


### PR DESCRIPTION
The debian installer uses `./obj-x86_64-linux-gnu/src/openroad` instead of `build/src/openroad` as the binary location. This change allows us to set the env var `OPENROAD_EXE` to point to anywhere.

Reference: https://github.com/Precision-Innovations/OpenROAD/actions/runs/7265482983/job/19795253692