### PR TITLE
mpl2: add array support

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2265,23 +2265,8 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
 
     createOneMacroClusterForEachMacro(parent, hard_macros, macro_clusters);
 
-    // classify macros based on size
     std::vector<int> macro_size_class(hard_macros.size(), -1);
-    for (int i = 0; i < hard_macros.size(); i++) {
-      if (macro_size_class[i] == -1) {
-        for (int j = i + 1; j < hard_macros.size(); j++) {
-          if ((macro_size_class[j] == -1)
-              && ((*hard_macros[i]) == (*hard_macros[j]))) {
-            macro_size_class[j] = i;
-          }
-        }
-      }
-    }
-
-    for (int i = 0; i < hard_macros.size(); i++) {
-      macro_size_class[i]
-          = (macro_size_class[i] == -1) ? i : macro_size_class[i];
-    }
+    classifyMacrosBasedOnSize(hard_macros, macro_size_class);
 
     // classify macros based on connection signature
     calculateConnection();
@@ -2421,6 +2406,26 @@ void HierRTLMP::createOneMacroClusterForEachMacro(Cluster* parent,
     parent->addChild(single_macro_cluster);
     macro_clusters.push_back(single_macro_cluster);
   }
+}
+
+void HierRTLMP::classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
+                                          std::vector<int>& macro_size_class)
+{
+  for (int i = 0; i < hard_macros.size(); i++) {
+    if (macro_size_class[i] == -1) {
+      for (int j = i + 1; j < hard_macros.size(); j++) {
+        if ((macro_size_class[j] == -1)
+            && ((*hard_macros[i]) == (*hard_macros[j]))) {
+          macro_size_class[j] = i;
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < hard_macros.size(); i++) {
+    macro_size_class[i]
+        = (macro_size_class[i] == -1) ? i : macro_size_class[i];
+  } 
 }
 
 // Map all the macros into their HardMacro objects for all the clusters

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2389,8 +2389,6 @@ void HierRTLMP::classifyMacrosBasedOnConnSignature(
     std::vector<Cluster*>& macro_clusters,
     std::vector<int>& macro_signature_class)
 {
-  calculateConnection();
-
   for (int i = 0; i < macro_clusters.size(); i++) {
     if (macro_signature_class[i] == -1) {
       macro_signature_class[i] = i;

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2420,9 +2420,9 @@ void HierRTLMP::classifyMacrosBasedOnInterconn(
           if (macro_interconn_class[j] != -1) {
             macro_interconn_class[i] = macro_interconn_class[j];
             break;
-          } else {
-            macro_interconn_class[j] = i;
           }
+
+          macro_interconn_class[j] = i;
         }
       }
     }

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2386,9 +2386,9 @@ void HierRTLMP::classifyMacrosBasedOnConnSignature(
         if (macro_signature_class[j] != -1) {
           continue;
         }
-        bool flag = macro_clusters[i]->isSameConnSignature(
-            *macro_clusters[j], signature_net_threshold_);
-        if (flag) {
+
+        if (macro_clusters[i]->isSameConnSignature(
+            *macro_clusters[j], signature_net_threshold_)) {
           macro_signature_class[j] = i;
         }
       }

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2268,15 +2268,20 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     std::vector<int> macro_size_class(hard_macros.size(), -1);
     classifyMacrosBasedOnSize(hard_macros, macro_size_class);
     std::vector<int> macro_signature_class(hard_macros.size(), -1);
-    classifyMacrosBasedOnConnSignature(hard_macros, macro_clusters, macro_signature_class);
+    classifyMacrosBasedOnConnSignature(
+        hard_macros, macro_clusters, macro_signature_class);
 
     std::vector<int> macro_class(hard_macros.size(), -1);
-    groupSingleMacroClusters(hard_macros, macro_clusters, macro_class, macro_size_class, macro_signature_class);
+    groupSingleMacroClusters(hard_macros,
+                             macro_clusters,
+                             macro_class,
+                             macro_size_class,
+                             macro_signature_class);
 
     cluster->clearHardMacros();
 
-    // IMPORTANT: Restore the structure of physical hierarchical tree. Thus the order of leaf
-    // clusters will not change the final macro grouping results.
+    // IMPORTANT: Restore the structure of physical hierarchical tree. Thus the
+    // order of leaf clusters will not change the final macro grouping results.
     setInstProperty(cluster);
 
     std::vector<int> virtual_conn_clusters;
@@ -2321,7 +2326,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     for (int i = 0; i < virtual_conn_clusters.size(); i++) {
       for (int j = i + 1; j < virtual_conn_clusters.size(); j++) {
         parent->addVirtualConnection(virtual_conn_clusters[i],
-                                             virtual_conn_clusters[j]);
+                                     virtual_conn_clusters[j]);
       }
     }
   }
@@ -2329,13 +2334,15 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
   setInstProperty(root_cluster);
 }
 
-void HierRTLMP::createOneMacroClusterForEachMacro(Cluster* parent,
-                                                  const std::vector<HardMacro*>& hard_macros,
-																			            std::vector<Cluster*>& macro_clusters)
+void HierRTLMP::createOneMacroClusterForEachMacro(
+    Cluster* parent,
+    const std::vector<HardMacro*>& hard_macros,
+    std::vector<Cluster*>& macro_clusters)
 {
   for (auto& hard_macro : hard_macros) {
     std::string cluster_name = hard_macro->getName();
-    Cluster* single_macro_cluster = new Cluster(cluster_id_, cluster_name, logger_);
+    Cluster* single_macro_cluster
+        = new Cluster(cluster_id_, cluster_name, logger_);
 
     single_macro_cluster->addLeafMacro(hard_macro->getInst());
 
@@ -2351,8 +2358,9 @@ void HierRTLMP::createOneMacroClusterForEachMacro(Cluster* parent,
   }
 }
 
-void HierRTLMP::classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
-                                          std::vector<int>& macro_size_class)
+void HierRTLMP::classifyMacrosBasedOnSize(
+    const std::vector<HardMacro*>& hard_macros,
+    std::vector<int>& macro_size_class)
 {
   for (int i = 0; i < hard_macros.size(); i++) {
     if (macro_size_class[i] == -1) {
@@ -2366,14 +2374,14 @@ void HierRTLMP::classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_ma
   }
 
   for (int i = 0; i < hard_macros.size(); i++) {
-    macro_size_class[i]
-        = (macro_size_class[i] == -1) ? i : macro_size_class[i];
-  } 
+    macro_size_class[i] = (macro_size_class[i] == -1) ? i : macro_size_class[i];
+  }
 }
 
-void HierRTLMP::classifyMacrosBasedOnConnSignature(const std::vector<HardMacro*>& hard_macros,
-                                                   std::vector<Cluster*>& macro_clusters,
-                                                   std::vector<int>& macro_signature_class)
+void HierRTLMP::classifyMacrosBasedOnConnSignature(
+    const std::vector<HardMacro*>& hard_macros,
+    std::vector<Cluster*>& macro_clusters,
+    std::vector<int>& macro_signature_class)
 {
   calculateConnection();
 
@@ -2399,19 +2407,20 @@ void HierRTLMP::classifyMacrosBasedOnConnSignature(const std::vector<HardMacro*>
     for (auto& cluster : macro_clusters) {
       logger_->report("Macro Signature: {}", cluster->getName());
       for (auto& [cluster_id, weight] : cluster->getConnection()) {
-        logger_->report(
-            " {} {} ", cluster_map_[cluster_id]->getName(), weight);
+        logger_->report(" {} {} ", cluster_map_[cluster_id]->getName(), weight);
       }
     }
   }
 }
 
-// Macros with the same size and the same connection signature belong to the same class
-void HierRTLMP::groupSingleMacroClusters(const std::vector<HardMacro*>& hard_macros,
-                                         std::vector<Cluster*>& macro_clusters,
-                                         std::vector<int>& macro_class,
-                                         std::vector<int>& macro_size_class,
-                                         std::vector<int>& macro_signature_class)
+// Macros with the same size and the same connection signature belong to the
+// same class
+void HierRTLMP::groupSingleMacroClusters(
+    const std::vector<HardMacro*>& hard_macros,
+    std::vector<Cluster*>& macro_clusters,
+    std::vector<int>& macro_class,
+    std::vector<int>& macro_size_class,
+    std::vector<int>& macro_signature_class)
 {
   for (int i = 0; i < hard_macros.size(); i++) {
     if (macro_class[i] == -1) {
@@ -2421,12 +2430,12 @@ void HierRTLMP::groupSingleMacroClusters(const std::vector<HardMacro*>& hard_mac
             && macro_signature_class[i] == macro_signature_class[j]) {
           macro_class[j] = i;
           debugPrint(logger_,
-                      MPL,
-                      "multilevel_autoclustering",
-                      1,
-                      "merge {} with {}",
-                      macro_clusters[i]->getName(),
-                      macro_clusters[j]->getName());
+                     MPL,
+                     "multilevel_autoclustering",
+                     1,
+                     "merge {} with {}",
+                     macro_clusters[i]->getName(),
+                     macro_clusters[j]->getName());
           bool delete_flag = false;
           macro_clusters[i]->mergeCluster(*macro_clusters[j], delete_flag);
           if (delete_flag) {

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2281,8 +2281,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     // order of leaf clusters will not change the final macro grouping results.
     setInstProperty(mixed_leaf);
 
-    // Never use SetInstProperty Command in following lines for the reason
-    // above!
+    // Never use setInstProperty in following lines for the reason above!
     std::vector<int> virtual_conn_clusters;
     if (parent == mixed_leaf) {
       addStdCellClustertoSubTree(mixed_leaf, parent, virtual_conn_clusters);

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -209,6 +209,9 @@ class HierRTLMP
 																				 std::vector<Cluster*>& single_macro_clusters);
 	void classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
 																 std::vector<int>& macro_size_class);
+	void classifyMacrosBasedOnConnSignature(const std::vector<HardMacro*>& hard_macros,
+																					std::vector<Cluster*>& macro_clusters,
+																 					std::vector<int>& macro_signature_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,10 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
+  void createOneMacroClusterForEachMacro(Cluster* parent,
+																				 const std::vector<HardMacro*>& hard_macros,
+																				 std::vector<Cluster*>& single_macro_clusters);
+
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -212,6 +212,11 @@ class HierRTLMP
 	void classifyMacrosBasedOnConnSignature(const std::vector<HardMacro*>& hard_macros,
 																					std::vector<Cluster*>& macro_clusters,
 																 					std::vector<int>& macro_signature_class);
+	void groupSingleMacroClusters(const std::vector<HardMacro*>& hard_macros,
+																std::vector<Cluster*>& macro_clusters,
+																std::vector<int>& macro_class,
+																std::vector<int>& macro_size_class,
+																std::vector<int>& macro_signature_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -207,7 +207,8 @@ class HierRTLMP
   void createOneMacroClusterForEachMacro(Cluster* parent,
 																				 const std::vector<HardMacro*>& hard_macros,
 																				 std::vector<Cluster*>& single_macro_clusters);
-
+	void classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
+																 std::vector<int>& macro_size_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,7 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
+  void mapMacroInCluster2HardMacro(Cluster* cluster);
   void createOneMacroClusterForEachMacro(
       Cluster* parent,
       const std::vector<HardMacro*>& hard_macros,
@@ -219,7 +220,11 @@ class HierRTLMP
                                 std::vector<int>& macro_class,
                                 std::vector<int>& macro_size_class,
                                 std::vector<int>& macro_signature_class);
-  void mapMacroInCluster2HardMacro(Cluster* cluster);
+  void addStdCellClustertoSubTree(Cluster* mixed_leaf,
+                                  Cluster* parent,
+                                  std::vector<int>& virtual_conn_clusters);
+  void replaceByStdCellCluster(Cluster* mixed_leaf,
+                               std::vector<int>& virtual_conn_clusters);
 
   // Coarse Shaping
   void runCoarseShaping();

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -212,14 +212,18 @@ class HierRTLMP
   void classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
                                  std::vector<int>& macro_size_class);
   void classifyMacrosBasedOnConnSignature(
-      const std::vector<HardMacro*>& hard_macros,
       std::vector<Cluster*>& macro_clusters,
       std::vector<int>& macro_signature_class);
+  void classifyMacrosBasedOnInterconn(std::vector<Cluster*>& macro_clusters,
+                                      std::vector<int>& macro_interconn_class);
   void groupSingleMacroClusters(const std::vector<HardMacro*>& hard_macros,
                                 std::vector<Cluster*>& macro_clusters,
                                 std::vector<int>& macro_class,
                                 std::vector<int>& macro_size_class,
+                                std::vector<int>& macro_interconn_class,
                                 std::vector<int>& macro_signature_class);
+  void groupMacroClustersWithSameClassification(Cluster* macro_from,
+                                                Cluster* macro_to);
   void addStdCellClustertoSubTree(Cluster* mixed_leaf,
                                   Cluster* parent,
                                   std::vector<int>& virtual_conn_clusters);

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,19 +204,21 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
-  void createOneMacroClusterForEachMacro(Cluster* parent,
-																				 const std::vector<HardMacro*>& hard_macros,
-																				 std::vector<Cluster*>& single_macro_clusters);
-	void classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
-																 std::vector<int>& macro_size_class);
-	void classifyMacrosBasedOnConnSignature(const std::vector<HardMacro*>& hard_macros,
-																					std::vector<Cluster*>& macro_clusters,
-																 					std::vector<int>& macro_signature_class);
-	void groupSingleMacroClusters(const std::vector<HardMacro*>& hard_macros,
-																std::vector<Cluster*>& macro_clusters,
-																std::vector<int>& macro_class,
-																std::vector<int>& macro_size_class,
-																std::vector<int>& macro_signature_class);
+  void createOneMacroClusterForEachMacro(
+      Cluster* parent,
+      const std::vector<HardMacro*>& hard_macros,
+      std::vector<Cluster*>& single_macro_clusters);
+  void classifyMacrosBasedOnSize(const std::vector<HardMacro*>& hard_macros,
+                                 std::vector<int>& macro_size_class);
+  void classifyMacrosBasedOnConnSignature(
+      const std::vector<HardMacro*>& hard_macros,
+      std::vector<Cluster*>& macro_clusters,
+      std::vector<int>& macro_signature_class);
+  void groupSingleMacroClusters(const std::vector<HardMacro*>& hard_macros,
+                                std::vector<Cluster*>& macro_clusters,
+                                std::vector<int>& macro_class,
+                                std::vector<int>& macro_size_class,
+                                std::vector<int>& macro_signature_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -580,7 +580,16 @@ bool Cluster::isSameConnSignature(const Cluster& cluster, float net_threshold)
   return true;
 }
 
-//
+bool Cluster::isDirectlyConnectedTo(const Cluster& cluster)
+{
+  for (const auto& [cluster_id, num_of_conn] : connection_map_) {
+    if (cluster_id == cluster.getId())
+    return true;
+  }
+
+  return false;
+}
+
 // Get closely-connected cluster if such cluster exists
 // For example, if a small cluster A is closely connected to a
 // well-formed cluster B, (there are also other well-formed clusters

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -583,8 +583,9 @@ bool Cluster::isSameConnSignature(const Cluster& cluster, float net_threshold)
 bool Cluster::isDirectlyConnectedTo(const Cluster& cluster)
 {
   for (const auto& [cluster_id, num_of_conn] : connection_map_) {
-    if (cluster_id == cluster.getId())
-    return true;
+    if (cluster_id == cluster.getId()) {
+      return true;
+    }
   }
 
   return false;

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -244,6 +244,7 @@ class Cluster
   void addConnection(int cluster_id, float weight);
   const std::map<int, float> getConnection() const;
   bool isSameConnSignature(const Cluster& cluster, float net_threshold);
+  bool isDirectlyConnectedTo(const Cluster& cluster);
   // Get closely-connected cluster if such cluster exists
   // For example, if a small cluster A is closely connected to a
   // well-formed cluster B, (there are also other well-formed clusters
@@ -326,6 +327,7 @@ class Cluster
   // pin access for each bundled connection
   std::map<int, std::pair<PinAccess, float>> pin_access_map_;
   std::map<PinAccess, std::map<PinAccess, float>> boundary_connection_map_;
+
   utl::Logger* logger_;
 };
 


### PR DESCRIPTION
This draft is to show a first approach.

The idea is to create a classification based on direct connection between single-macro macro clusters && to prioritize array macro cluster grouping over connection signature grouping.

Important observation: For this initial draft I'm considering only direct connection (Not based on hops);