### PR TITLE
format_as: pass by reference instead of value

### DIFF
--- a/src/dst/src/BalancerConnection.cc
+++ b/src/dst/src/BalancerConnection.cc
@@ -240,7 +240,7 @@ void BalancerConnection::handle_read(boost::system::error_code const& err,
 #if !SWIG && FMT_VERSION >= 100000
 namespace boost::asio::ip {
 
-static auto format_as(const boost::asio::ip::address f)
+static auto format_as(const boost::asio::ip::address& f)
 {
   return fmt::streamed(f);
 }

--- a/src/dst/src/LoadBalancer.cc
+++ b/src/dst/src/LoadBalancer.cc
@@ -256,7 +256,7 @@ void LoadBalancer::handle_accept(const BalancerConnection::pointer& connection,
 #if !SWIG && FMT_VERSION >= 100000
 namespace boost::asio::ip {
 
-static auto format_as(const boost::asio::ip::address f)
+static auto format_as(const boost::asio::ip::address& f)
 {
   return fmt::streamed(f);
 }

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -347,7 +347,7 @@ struct test_ostream
 
 template <class T,
           class = std::enable_if_t<decltype(test_ostream::test<T>(0))::value>>
-auto format_as(T t)
+auto format_as(const T& t)
 {
   return fmt::streamed(t);
 }


### PR DESCRIPTION
Minor change.

[boost::asio::ip::address](https://www.boost.org/doc/libs/1_80_0/boost/asio/ip/address.hpp) is a class.