### PR TITLE
odb: refactor cpp tests

### DIFF
--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_LIBS
         ${TCL_LIBRARY}
         Boost::boost
         utl_lib
+        odb_test_helper
 )
 
 add_executable(OdbGTests TestDbWire.cc TestAbstractLef.cc)
@@ -68,3 +69,5 @@ add_dependencies(build_and_test
         TestMaster
         OdbGTests
 )
+
+add_subdirectory(helper)

--- a/src/odb/test/cpp/CallBack.h
+++ b/src/odb/test/cpp/CallBack.h
@@ -39,7 +39,9 @@
 #include "db.h"
 #include "dbBlockCallBackObj.h"
 #include "spdlog/fmt/fmt.h"
-using namespace odb;
+
+namespace odb {
+
 class CallBack : public dbBlockCallBackObj
 {
  private:
@@ -51,92 +53,107 @@ class CallBack : public dbBlockCallBackObj
   // dbInst Start
   void inDbInstCreate(dbInst* inst) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create inst " + inst->getName());
+    }
   }
   void inDbInstCreate(dbInst* inst, dbRegion* region) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create inst " + inst->getName() + " in region "
                        + region->getName());
+    }
   }
   void inDbInstDestroy(dbInst* inst) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy inst " + inst->getName());
+    }
   }
   void inDbInstSwapMasterBefore(dbInst* inst, dbMaster* master) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PreSwap inst " + inst->getName() + " from master "
                        + inst->getMaster()->getName() + " to master "
                        + master->getName());
+    }
   }
   void inDbInstSwapMasterAfter(dbInst* inst) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PostSwap inst " + inst->getName() + " to master "
                        + inst->getMaster()->getName());
+    }
   }
   void inDbPreMoveInst(dbInst* inst) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PreMove inst " + inst->getName());
+    }
   }
   void inDbPostMoveInst(dbInst* inst) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PostMove inst " + inst->getName());
+    }
   }
   // dbInst End
 
   // dbNet Start
   void inDbNetCreate(dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create net " + net->getName());
+    }
   }
   void inDbNetDestroy(dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy net " + net->getName());
+    }
   }
   // dbNet End
 
   // dbITerm Start
   void inDbITermCreate(dbITerm* iterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create iterm " + iterm->getMTerm()->getName()
                        + " of inst " + iterm->getInst()->getName());
+    }
   }
   void inDbITermDestroy(dbITerm* iterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy iterm " + iterm->getMTerm()->getName()
                        + " of inst " + iterm->getInst()->getName());
+    }
   }
   void inDbITermPreDisconnect(dbITerm* iterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PreDisconnect iterm from net "
                        + iterm->getNet()->getName());
+    }
   }
   void inDbITermPostDisconnect(dbITerm* iterm, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PostDisconnect iterm from net " + net->getName());
+    }
   }
   void inDbITermPreConnect(dbITerm* iterm, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PreConnect iterm to net " + net->getName());
+    }
   }
   void inDbITermPostConnect(dbITerm* iterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PostConnect iterm to net "
                        + iterm->getNet()->getName());
+    }
   }
 
   // dbITerm End
@@ -144,56 +161,65 @@ class CallBack : public dbBlockCallBackObj
   // dbBTerm Start
   void inDbBTermCreate(dbBTerm* bterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create " + bterm->getName());
+    }
   }
   void inDbBTermDestroy(dbBTerm* bterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy " + bterm->getName());
+    }
   }
   void inDbBTermPreConnect(dbBTerm* bterm, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Preconnect " + bterm->getName() + " to "
                        + net->getName());
+    }
   }
   void inDbBTermPostConnect(dbBTerm* bterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Postconnect " + bterm->getName());
+    }
   }
   void inDbBTermPreDisconnect(dbBTerm* bterm) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Predisconnect " + bterm->getName());
+    }
   }
   void inDbBTermPostDisConnect(dbBTerm* bterm, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Postdisconnect " + bterm->getName() + " from "
                        + net->getName());
+    }
   }
   // dbBTerm End
 
   // dbBPin Start
   void inDbBPinCreate(dbBPin* pin) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create BPin for " + pin->getBTerm()->getName());
+    }
   }
   void inDbBPinDestroy(dbBPin*) override
   {
-    if (!_pause)
-      events.push_back("Destroy BPin");
+    if (!_pause) {
+      events.emplace_back("Destroy BPin");
+    }
   }
   // dbBPin End
 
   // dbBlockage Start
   void inDbBlockageCreate(dbBlockage* blockage) override
   {
-    if (_pause)
+    if (_pause) {
       return;
+    }
     char buffer[100];
     auto box = blockage->getBBox();
     sprintf(buffer,
@@ -202,15 +228,16 @@ class CallBack : public dbBlockCallBackObj
             box->yMin(),
             box->xMax(),
             box->yMax());
-    events.push_back(std::string(buffer));
+    events.emplace_back(buffer);
   }
   // dbBlockage End
 
   // dbObstruction Start
   void inDbObstructionCreate(dbObstruction* obs) override
   {
-    if (_pause)
+    if (_pause) {
       return;
+    }
     char buffer[100];
     auto box = obs->getBBox();
     sprintf(buffer,
@@ -219,124 +246,144 @@ class CallBack : public dbBlockCallBackObj
             box->yMin(),
             box->xMax(),
             box->yMax());
-    events.push_back(std::string(buffer));
+    events.emplace_back(buffer);
   }
   void inDbObstructionDestroy(dbObstruction*) override
   {
-    if (!_pause)
-      events.push_back("Destroy obstruction");
+    if (!_pause) {
+      events.emplace_back("Destroy obstruction");
+    }
   }
   // dbObstruction End
 
   // dbRegion Start
   void inDbRegionCreate(dbRegion* region) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create region " + region->getName());
+    }
   }
   void inDbRegionAddBox(dbRegion* region, dbBox* box) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back(fmt::format("Add box ({}, {}) ({}, {}) to region {}",
                                    box->xMin(),
                                    box->yMin(),
                                    box->xMax(),
                                    box->yMax(),
                                    region->getName()));
+    }
   }
   void inDbRegionDestroy(dbRegion* region) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy region " + region->getName());
+    }
   }
   // dbRegion End
 
   // dbRow Start
   void inDbRowCreate(dbRow* row) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Create row " + row->getName());
+    }
   }
   void inDbRowDestroy(dbRow* row) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("Destroy row " + row->getName());
+    }
   }
   // dbRow End
 
   // dbWire Start
   void inDbWireCreate(dbWire* wire) override
   {
-    if (!_pause)
-      events.push_back("Create wire");
+    if (!_pause) {
+      events.emplace_back("Create wire");
+    }
   }
   void inDbWirePreAttach(dbWire* wire, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PreAttach wire to " + net->getName());
+    }
   }
   void inDbWirePostAttach(dbWire* wire) override
   {
-    if (!_pause)
-      events.push_back("PostAttach wire");
+    if (!_pause) {
+      events.emplace_back("PostAttach wire");
+    }
   }
   void inDbWirePreDetach(dbWire* wire) override
   {
-    if (!_pause)
-      events.push_back("PreDetach wire");
+    if (!_pause) {
+      events.emplace_back("PreDetach wire");
+    }
   }
   void inDbWirePostDetach(dbWire* wire, dbNet* net) override
   {
-    if (!_pause)
+    if (!_pause) {
       events.push_back("PostDetach wire from " + net->getName());
+    }
   }
   void inDbWirePreAppend(dbWire* src, dbWire* dst) override
   {
-    if (!_pause)
-      events.push_back("PreAppend wire");
+    if (!_pause) {
+      events.emplace_back("PreAppend wire");
+    }
   }
   void inDbWirePostAppend(dbWire* src, dbWire* dst) override
   {
-    if (!_pause)
-      events.push_back("PostAppend wire");
+    if (!_pause) {
+      events.emplace_back("PostAppend wire");
+    }
   }
   void inDbWirePreCopy(dbWire* src, dbWire* dst) override
   {
-    if (!_pause)
-      events.push_back("PreCopy wire");
+    if (!_pause) {
+      events.emplace_back("PreCopy wire");
+    }
   }
   void inDbWirePostCopy(dbWire* src, dbWire* dst) override
   {
-    if (!_pause)
-      events.push_back("PostCopy wire");
+    if (!_pause) {
+      events.emplace_back("PostCopy wire");
+    }
   }
   void inDbWireDestroy(dbWire* wire) override
   {
-    if (!_pause)
-      events.push_back("Destroy wire");
+    if (!_pause) {
+      events.emplace_back("Destroy wire");
+    }
   }
   // dbWire End
 
   // dbSWire Start
   void inDbSWireCreate(dbSWire*) override
   {
-    if (!_pause)
-      events.push_back("Create swire");
+    if (!_pause) {
+      events.emplace_back("Create swire");
+    }
   }
   void inDbSWireDestroy(dbSWire*) override
   {
-    if (!_pause)
-      events.push_back("Destroy swire");
+    if (!_pause) {
+      events.emplace_back("Destroy swire");
+    }
   }
   void inDbSWirePreDestroySBoxes(dbSWire* swire) override
   {
-    if (!_pause)
-      events.push_back("PreDestroySBoxes");
+    if (!_pause) {
+      events.emplace_back("PreDestroySBoxes");
+    }
   }
   void inDbSWirePostDestroySBoxes(dbSWire* swire) override
   {
-    if (!_pause)
-      events.push_back("PostDestroySBoxes");
+    if (!_pause) {
+      events.emplace_back("PostDestroySBoxes");
+    }
   }
   // dbSWire End
 
@@ -344,3 +391,5 @@ class CallBack : public dbBlockCallBackObj
   void unpause() { _pause = false; }
   void clearEvents() { events.clear(); }
 };
+
+}  // namespace odb

--- a/src/odb/test/cpp/TestAccessPoint.cpp
+++ b/src/odb/test/cpp/TestAccessPoint.cpp
@@ -3,7 +3,7 @@
 #include <fstream>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestAccessPoint.cpp
+++ b/src/odb/test/cpp/TestAccessPoint.cpp
@@ -3,9 +3,11 @@
 #include <fstream>
 
 #include "db.h"
+#include "env.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -27,8 +29,7 @@ BOOST_AUTO_TEST_CASE(test_default)
   ap->setHighType(dbAccessType::HalfGrid);
   ap->setAccess(true, dbDirection::DOWN);
   iterm->setAccessPoint(pin, ap);
-  std::string path
-      = std::string(std::getenv("BASE_DIR")) + "/results/TestAccessPointDbRW";
+  std::string path = testTmpPath("/results/TestAccessPointDbRW");
   std::ofstream write;
   write.exceptions(std::ifstream::failbit | std::ifstream::badbit
                    | std::ios::eofbit);
@@ -76,3 +77,6 @@ BOOST_AUTO_TEST_CASE(test_default)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -5,11 +5,12 @@
 #include "CallBack.h"
 #include "db.h"
 #include "helper.h"
-using namespace odb;
+
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 dbDatabase* db;
-dbLib* lib;
 dbBlock* block;
 CallBack* cb;
 void setup()
@@ -19,7 +20,7 @@ void setup()
 }
 void tearDown()
 {
-  db->destroy(db);
+  dbDatabase::destroy(db);
   delete cb;
 }
 BOOST_AUTO_TEST_CASE(test_inst_and_iterm)
@@ -73,7 +74,8 @@ BOOST_AUTO_TEST_CASE(test_inst_and_iterm)
   i1->findITerm("a")->disconnect();
   BOOST_TEST(cb->events.size() == 0);
 
-  i1->destroy(i1);
+  dbInst::destroy(i1);
+
   BOOST_TEST(cb->events.size() == 4);
   BOOST_TEST(cb->events[0] == "Destroy iterm a of inst i1");
   BOOST_TEST(cb->events[1] == "Destroy iterm b of inst i1");
@@ -115,7 +117,8 @@ BOOST_AUTO_TEST_CASE(test_bterm)
   BOOST_TEST(cb->events[0] == "Predisconnect IN1");
   BOOST_TEST(cb->events[1] == "Postdisconnect IN1 from n1");
   cb->clearEvents();
-  IN1->destroy(IN1);
+  dbBTerm::destroy(IN1);
+
   BOOST_TEST(cb->events.size() == 1);
   BOOST_TEST(cb->events[0] == "Destroy IN1");
   tearDown();
@@ -260,3 +263,6 @@ BOOST_AUTO_TEST_CASE(test_swire)
   BOOST_TEST(cb->events[2] == "Destroy swire");
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -4,7 +4,7 @@
 
 #include "CallBack.h"
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 using namespace odb;
 
 BOOST_AUTO_TEST_SUITE(test_suite)

--- a/src/odb/test/cpp/TestGCellGrid.cpp
+++ b/src/odb/test/cpp/TestGCellGrid.cpp
@@ -4,7 +4,8 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -31,3 +32,6 @@ BOOST_AUTO_TEST_CASE(test_default)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestGCellGrid.cpp
+++ b/src/odb/test/cpp/TestGCellGrid.cpp
@@ -2,7 +2,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestGeom.cpp
+++ b/src/odb/test/cpp/TestGeom.cpp
@@ -4,7 +4,8 @@
 
 #include "db.h"
 #include "helper.h"
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -136,3 +137,6 @@ BOOST_AUTO_TEST_CASE(test_isotropy)
   BOOST_CHECK_EQUAL(test[high], 2);
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestGeom.cpp
+++ b/src/odb/test/cpp/TestGeom.cpp
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 using namespace odb;
 
 BOOST_AUTO_TEST_SUITE(test_suite)

--- a/src/odb/test/cpp/TestGroup.cpp
+++ b/src/odb/test/cpp/TestGroup.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestGroup.cpp
+++ b/src/odb/test/cpp/TestGroup.cpp
@@ -6,7 +6,8 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 struct F_DETAILED
 {
@@ -169,13 +170,15 @@ BOOST_AUTO_TEST_CASE(test_group_modinst_iterator)
   int i;
   BOOST_TEST(modinsts.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       modinsts.reverse();
+    }
     for (modinst_itr = modinsts.begin(), i = j ? 1 : 3;
          modinst_itr != modinsts.end();
-         ++modinst_itr, i = i + (j ? 1 : -1))
+         ++modinst_itr, i = i + (j ? 1 : -1)) {
       BOOST_TEST(std::string(((dbModInst*) *modinst_itr)->getName())
                  == "i" + std::to_string(i));
+    }
   }
 }
 BOOST_AUTO_TEST_CASE(test_group_inst_iterator)
@@ -185,12 +188,14 @@ BOOST_AUTO_TEST_CASE(test_group_inst_iterator)
   int i;
   BOOST_TEST(insts.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       insts.reverse();
+    }
     for (inst_itr = insts.begin(), i = j ? 1 : 3; inst_itr != insts.end();
-         ++inst_itr, i = i + (j ? 1 : -1))
+         ++inst_itr, i = i + (j ? 1 : -1)) {
       BOOST_TEST(std::string(((dbInst*) *inst_itr)->getName())
                  == "i" + std::to_string(i));
+    }
   }
 }
 BOOST_AUTO_TEST_CASE(test_group_net_iterators)
@@ -200,12 +205,14 @@ BOOST_AUTO_TEST_CASE(test_group_net_iterators)
   int i;
   BOOST_TEST(nets.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       nets.reverse();
+    }
     for (net_itr = nets.begin(), i = j ? 3 : 1; net_itr != nets.end();
-         ++net_itr, i = i + (j ? -1 : 1))
+         ++net_itr, i = i + (j ? -1 : 1)) {
       BOOST_TEST(std::string(((dbNet*) *net_itr)->getName())
                  == "n" + std::to_string(i));
+    }
   }
   group->addGroundNet(n1);
   group->addGroundNet(n2);
@@ -214,12 +221,14 @@ BOOST_AUTO_TEST_CASE(test_group_net_iterators)
   nets = group->getGroundNets();
   BOOST_TEST(nets.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       nets.reverse();
+    }
     for (net_itr = nets.begin(), i = j ? 3 : 1; net_itr != nets.end();
-         ++net_itr, i = i + (j ? -1 : 1))
+         ++net_itr, i = i + (j ? -1 : 1)) {
       BOOST_TEST(std::string(((dbNet*) *net_itr)->getName())
                  == "n" + std::to_string(i));
+    }
   }
 }
 BOOST_AUTO_TEST_CASE(test_group_group_iterator)
@@ -229,13 +238,18 @@ BOOST_AUTO_TEST_CASE(test_group_group_iterator)
   int i;
   BOOST_TEST(children.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       children.reverse();
+    }
     for (group_itr = children.begin(), i = j ? 1 : 3;
          group_itr != children.end();
-         ++group_itr, i = i + (j ? 1 : -1))
+         ++group_itr, i = i + (j ? 1 : -1)) {
       BOOST_TEST(std::string(((dbGroup*) *group_itr)->getName())
                  == "child" + std::to_string(i));
+    }
   }
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestGuide.cpp
+++ b/src/odb/test/cpp/TestGuide.cpp
@@ -4,7 +4,8 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -45,3 +46,6 @@ BOOST_AUTO_TEST_CASE(test_clear_guides)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestGuide.cpp
+++ b/src/odb/test/cpp/TestGuide.cpp
@@ -2,7 +2,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestJournal.cpp
+++ b/src/odb/test/cpp/TestJournal.cpp
@@ -4,9 +4,11 @@
 #include <string>
 
 #include "db.h"
+#include "env.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -22,12 +24,11 @@ struct F_DEFAULT
   dbDatabase* db;
   dbLib* lib;
   dbBlock* block;
-  std::string journal_path
-      = std::string(std::getenv("BASE_DIR")) + "/results/db_jounal.eco";
+  std::string journal_path = testTmpPath("/results/db_jounal.eco");
 };
 BOOST_FIXTURE_TEST_CASE(test_write, F_DEFAULT)
 {
-  db->beginEco(block);
+  dbDatabase::beginEco(block);
   auto i1 = odb::dbInst::create(block, lib->findMaster("and2"), "i1");
   auto i2 = odb::dbInst::create(block, lib->findMaster("and2"), "i2");
   auto n1 = odb::dbNet::create(block, "n1");
@@ -42,14 +43,14 @@ BOOST_FIXTURE_TEST_CASE(test_write, F_DEFAULT)
   odb::dbBTerm::destroy(b3);
   odb::dbInst::destroy(i2);
   odb::dbNet::destroy(n2);
-  db->endEco(block);
-  db->writeEco(block, journal_path.c_str());
+  dbDatabase::endEco(block);
+  dbDatabase::writeEco(block, journal_path.c_str());
 }
 BOOST_FIXTURE_TEST_CASE(test_read, F_DEFAULT)
 {
-  db->beginEco(block);
-  db->readEco(block, journal_path.c_str());
-  db->commitEco(block);
+  dbDatabase::beginEco(block);
+  dbDatabase::readEco(block, journal_path.c_str());
+  dbDatabase::commitEco(block);
   auto i1 = block->findInst("i1");
   auto n1 = block->findNet("n1");
   auto b1 = block->findBTerm("b1");
@@ -74,3 +75,6 @@ BOOST_FIXTURE_TEST_CASE(test_read, F_DEFAULT)
   BOOST_TEST(b2->getNet() == nullptr);
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestJournal.cpp
+++ b/src/odb/test/cpp/TestJournal.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestLef58Properties.cpp
+++ b/src/odb/test/cpp/TestLef58Properties.cpp
@@ -8,10 +8,12 @@
 #include "db.h"
 #include "defin.h"
 #include "defout.h"
+#include "env.h"
 #include "lefin.h"
 #include "lefout.h"
 #include "utl/Logger.h"
-using namespace odb;
+
+namespace odb {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -23,13 +25,12 @@ BOOST_AUTO_TEST_CASE(lef58_class)
   lefin lefParser(db1, logger, false);
 
   const char* libname = "gscl45nm.lef";
-  std::string path
-      = std::string(std::getenv("BASE_DIR")) + "/data/gscl45nm.lef";
+  std::string path = testTmpPath("/data/gscl45nm.lef");
   lefParser.createTechAndLib("tech", libname, path.c_str());
 
   odb::dbLib* dbLib = db1->findLib(libname);
 
-  path = std::string(std::getenv("BASE_DIR")) + "/data/lef58class_gscl45nm.lef";
+  path = testTmpPath("/data/lef58class_gscl45nm.lef");
   lefParser.updateLib(dbLib, path.c_str());
 
   odb::dbMaster* endcap = db1->findMaster("ENDCAP_BOTTOMEDGE_NOT_A_REAL_CELL");
@@ -48,13 +49,12 @@ BOOST_AUTO_TEST_CASE(test_default)
   lefin lefParser(db1, logger, false);
   const char* libname = "gscl45nm.lef";
 
-  std::string path
-      = std::string(std::getenv("BASE_DIR")) + "/data/gscl45nm.lef";
+  std::string path = testTmpPath("/data/gscl45nm.lef");
 
   lefParser.createTechAndLib("tech", libname, path.c_str());
 
-  path = std::string(std::getenv("BASE_DIR"))
-         + "/results/TestLef58PropertiesDbRW";
+  path = testTmpPath("/results/TestLef58PropertiesDbRW");
+
   std::ofstream write;
   write.exceptions(std::ifstream::failbit | std::ifstream::badbit
                    | std::ios::eofbit);
@@ -482,3 +482,5 @@ BOOST_AUTO_TEST_CASE(test_default)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace odb

--- a/src/odb/test/cpp/TestMaster.cpp
+++ b/src/odb/test/cpp/TestMaster.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 BOOST_AUTO_TEST_SUITE(test_suite)

--- a/src/odb/test/cpp/TestMaster.cpp
+++ b/src/odb/test/cpp/TestMaster.cpp
@@ -6,7 +6,9 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
+
 BOOST_AUTO_TEST_SUITE(test_suite)
 
 struct F_DEFAULT
@@ -44,3 +46,6 @@ BOOST_FIXTURE_TEST_CASE(test_delete_module, F_DEFAULT)
   }
 }
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -6,7 +6,8 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -139,11 +140,12 @@ BOOST_FIXTURE_TEST_CASE(test_iterators, F_DETAILED)
   BOOST_TEST(children.size() == 3);
   BOOST_TEST(children.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       children.reverse();
+    }
     for (modinst_itr = children.begin(), i = j ? 1 : 3;
          modinst_itr != children.end();
-         ++modinst_itr, i = i + (j ? 1 : -1))
+         ++modinst_itr, i = i + (j ? 1 : -1)) {
       switch (i) {
         case 1:
           BOOST_TEST(*modinst_itr == i1);
@@ -158,6 +160,7 @@ BOOST_FIXTURE_TEST_CASE(test_iterators, F_DETAILED)
           BOOST_TEST(false);
           break;
       }
+    }
   }
 
   dbSet<dbInst> insts = parent_mod->getInsts();
@@ -165,10 +168,11 @@ BOOST_FIXTURE_TEST_CASE(test_iterators, F_DETAILED)
   BOOST_TEST(insts.size() == 3);
   BOOST_TEST(insts.reversible());
   for (int j = 0; j < 2; j++) {
-    if (j == 1)
+    if (j == 1) {
       insts.reverse();
+    }
     for (inst_itr = insts.begin(), i = j ? 1 : 3; inst_itr != insts.end();
-         ++inst_itr, i = i + (j ? 1 : -1))
+         ++inst_itr, i = i + (j ? 1 : -1)) {
       switch (i) {
         case 1:
           BOOST_TEST(*inst_itr == inst1);
@@ -183,7 +187,11 @@ BOOST_FIXTURE_TEST_CASE(test_iterators, F_DETAILED)
           BOOST_TEST(false);
           break;
       }
+    }
   }
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestModule.cpp
+++ b/src/odb/test/cpp/TestModule.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/TestNetTrack.cpp
+++ b/src/odb/test/cpp/TestNetTrack.cpp
@@ -4,7 +4,8 @@
 #include "db.h"
 #include "helper.h"
 
-using namespace odb;
+namespace odb {
+namespace {
 
 BOOST_AUTO_TEST_SUITE(test_suite)
 
@@ -45,3 +46,6 @@ BOOST_AUTO_TEST_CASE(test_clear_tracks)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+}  // namespace
+}  // namespace odb

--- a/src/odb/test/cpp/TestNetTrack.cpp
+++ b/src/odb/test/cpp/TestNetTrack.cpp
@@ -2,7 +2,7 @@
 #include <boost/test/included/unit_test.hpp>
 
 #include "db.h"
-#include "helper.cpp"
+#include "helper.h"
 
 using namespace odb;
 

--- a/src/odb/test/cpp/helper/CMakeLists.txt
+++ b/src/odb/test/cpp/helper/CMakeLists.txt
@@ -1,0 +1,16 @@
+include(openroad)
+
+
+add_library(odb_test_helper helper.cpp)
+
+
+target_link_libraries(odb_test_helper
+  PRIVATE
+    odb
+)
+
+
+target_include_directories(odb_test_helper
+  PUBLIC
+    ${CMAKE_CURRENT_LIST_DIR}
+)

--- a/src/odb/test/cpp/helper/CMakeLists.txt
+++ b/src/odb/test/cpp/helper/CMakeLists.txt
@@ -1,7 +1,7 @@
 include(openroad)
 
 
-add_library(odb_test_helper helper.cpp)
+add_library(odb_test_helper helper.cpp env.cpp)
 
 
 target_link_libraries(odb_test_helper

--- a/src/odb/test/cpp/helper/env.cpp
+++ b/src/odb/test/cpp/helper/env.cpp
@@ -1,0 +1,12 @@
+#include "env.h"
+
+#include <stdexcept>
+
+std::string testTmpPath(const std::string& file)
+{
+  const char* base_dir = std::getenv("BASE_DIR");
+  if (!base_dir) {
+    throw std::runtime_error("BASE_DIR environment variable not set");
+  }
+  return std::string(base_dir) + file;
+}

--- a/src/odb/test/cpp/helper/env.cpp
+++ b/src/odb/test/cpp/helper/env.cpp
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Google LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "env.h"
 
 #include <stdexcept>

--- a/src/odb/test/cpp/helper/env.cpp
+++ b/src/odb/test/cpp/helper/env.cpp
@@ -34,6 +34,8 @@
 
 #include <stdexcept>
 
+namespace odb {
+
 std::string testTmpPath(const std::string& file)
 {
   const char* base_dir = std::getenv("BASE_DIR");
@@ -42,3 +44,5 @@ std::string testTmpPath(const std::string& file)
   }
   return std::string(base_dir) + file;
 }
+
+}  // namespace odb

--- a/src/odb/test/cpp/helper/env.h
+++ b/src/odb/test/cpp/helper/env.h
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Google LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include <string>
 
 #pragma once

--- a/src/odb/test/cpp/helper/env.h
+++ b/src/odb/test/cpp/helper/env.h
@@ -1,0 +1,5 @@
+#include <string>
+
+#pragma once
+
+std::string testTmpPath(const std::string& file);

--- a/src/odb/test/cpp/helper/env.h
+++ b/src/odb/test/cpp/helper/env.h
@@ -34,4 +34,6 @@
 
 #pragma once
 
+namespace odb {
 std::string testTmpPath(const std::string& file);
+}  // namespace odb

--- a/src/odb/test/cpp/helper/helper.cpp
+++ b/src/odb/test/cpp/helper/helper.cpp
@@ -1,11 +1,9 @@
 #include "helper.h"
 
-#include <stdio.h>
-
 #include "db.h"
 #include "utl/Logger.h"
 
-using namespace odb;
+namespace odb {
 
 dbMaster* createMaster2X1(dbLib* lib,
                           const char* name,
@@ -86,3 +84,5 @@ dbDatabase* create2LevetDbWithBTerms()
   OUT->setIoType(dbIoType::OUTPUT);
   return db;
 }
+
+}  // namespace odb

--- a/src/odb/test/cpp/helper/helper.cpp
+++ b/src/odb/test/cpp/helper/helper.cpp
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Google LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "helper.h"
 
 #include "db.h"

--- a/src/odb/test/cpp/helper/helper.cpp
+++ b/src/odb/test/cpp/helper/helper.cpp
@@ -1,3 +1,5 @@
+#include "helper.h"
+
 #include <stdio.h>
 
 #include "db.h"
@@ -39,17 +41,6 @@ dbDatabase* createSimpleDB()
   return db;
 }
 
-// #     (n1)   +-----
-// #    --------|a    \    (n5)
-// #     (n2)   | (i1)o|-----------+
-// #    --------|b    /            |       +-------
-// #            +-----             +--------\a     \    (n7)
-// #                                         ) (i3)o|---------------
-// #     (n3)   +-----             +--------/b     /
-// #    --------|a    \    (n6)    |       +-------
-// #     (n4)   | (i2)o|-----------+
-// #    --------|b    /
-// #            +-----
 dbDatabase* create2LevetDbNoBTerms()
 {
   dbDatabase* db = createSimpleDB();
@@ -79,6 +70,7 @@ dbDatabase* create2LevetDbNoBTerms()
   i3->findITerm("o")->connect(n7);
   return db;
 }
+
 dbDatabase* create2LevetDbWithBTerms()
 {
   dbDatabase* db = create2LevetDbNoBTerms();

--- a/src/odb/test/cpp/helper/helper.h
+++ b/src/odb/test/cpp/helper/helper.h
@@ -1,3 +1,35 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2023, Google LLC
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "db.h"
 
 namespace odb {

--- a/src/odb/test/cpp/helper/helper.h
+++ b/src/odb/test/cpp/helper/helper.h
@@ -1,0 +1,26 @@
+#include "db.h"
+
+odb::dbMaster* createMaster2X1(odb::dbLib* lib,
+                               const char* name,
+                               uint width,
+                               uint height,
+                               const char* in1,
+                               const char* in2,
+                               const char* out);
+
+odb::dbDatabase* createSimpleDB();
+
+// #     (n1)   +-----
+// #    --------|a    \    (n5)
+// #     (n2)   | (i1)o|-----------+
+// #    --------|b    /            |       +-------
+// #            +-----             +--------\a     \    (n7)
+// #                                         ) (i3)o|---------------
+// #     (n3)   +-----             +--------/b     /
+// #    --------|a    \    (n6)    |       +-------
+// #     (n4)   | (i2)o|-----------+
+// #    --------|b    /
+// #            +-----
+odb::dbDatabase* create2LevetDbNoBTerms();
+
+odb::dbDatabase* create2LevetDbWithBTerms();

--- a/src/odb/test/cpp/helper/helper.h
+++ b/src/odb/test/cpp/helper/helper.h
@@ -1,5 +1,7 @@
 #include "db.h"
 
+namespace odb {
+
 odb::dbMaster* createMaster2X1(odb::dbLib* lib,
                                const char* name,
                                uint width,
@@ -24,3 +26,5 @@ odb::dbDatabase* createSimpleDB();
 odb::dbDatabase* create2LevetDbNoBTerms();
 
 odb::dbDatabase* create2LevetDbWithBTerms();
+
+}  // namespace odb

--- a/src/odb/test/cpp_tests.tcl
+++ b/src/odb/test/cpp_tests.tcl
@@ -2,7 +2,7 @@ source "helpers.tcl"
 
 set test_dir [pwd]
 set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
-set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp" ""]
+set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp"]
 
 set tests_list [split [exec sh -c "find $tests_path -maxdepth 2 -name 'Test*' ! -name '*.cmake' -type f"] \n]
 

--- a/src/odb/test/cpp_tests.tcl
+++ b/src/odb/test/cpp_tests.tcl
@@ -2,9 +2,9 @@ source "helpers.tcl"
 
 set test_dir [pwd]
 set openroad_dir [file dirname [file dirname [file dirname $test_dir]]]
-set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp"]
+set tests_path [file join $openroad_dir "build" "src" "odb" "test" "cpp" ""]
 
-set tests_list [split [exec sh -c "find $tests_path -maxdepth 1 -name 'Test*' ! -name '*.cmake'"] \n]
+set tests_list [split [exec sh -c "find $tests_path -maxdepth 2 -name 'Test*' ! -name '*.cmake' -type f"] \n]
 
 foreach test $tests_list {
     set test_name [file tail $test]


### PR DESCRIPTION
Some refactors to support subfolders for other projects inside cpp for odb (like scan) and also fixed clang-tidy warnings in the tests.