### PR TITLE
Sta gui 50 paths is enough

### DIFF
--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -697,7 +697,7 @@ STAGuiInterface::STAGuiInterface(sta::dbSta* sta)
       corner_(nullptr),
       use_max_(true),
       one_path_per_endpoint_(true),
-      max_path_count_(1000),
+      max_path_count_(50),
       include_unconstrained_(false),
       include_capture_path_(false)
 {


### PR DESCRIPTION
1000 paths can take a LONG time to update, who needs more than 50 initially?

Alternatively, the GUI could return immediately and populate in the background