### PR TITLE
odb: refactoring out serialization code for std::variant

### DIFF
--- a/src/odb/src/codeGenerator/schema/scan/dbScanPin.json
+++ b/src/odb/src/codeGenerator/schema/scan/dbScanPin.json
@@ -2,6 +2,11 @@
   "name": "dbScanPin",
   "type": "dbObject",
   "fields": [
+    {
+      "name": "pin_",
+      "type": "std::variant<dbId<_dbBTerm>, dbId<_dbITerm>>",
+      "flags": ["private", "no-template"]
+    }
   ],
   "h_includes": [
     "dbBTerm.h",

--- a/src/odb/src/db/dbScanPin.cpp
+++ b/src/odb/src/db/dbScanPin.cpp
@@ -111,33 +111,13 @@ _dbScanPin::_dbScanPin(_dbDatabase* db, const _dbScanPin& r)
 
 dbIStream& operator>>(dbIStream& stream, _dbScanPin& obj)
 {
-  // User Code Begin >>
-  int index = 0;
-  stream >> index;
-  if (index == 0) {
-    dbId<_dbBTerm> bterm;
-    stream >> bterm;
-    obj.pin_ = bterm;
-  } else if (index == 1) {
-    dbId<_dbITerm> iterm;
-    stream >> iterm;
-    obj.pin_ = iterm;
-  }
-  // User Code End >>
+  stream >> obj.pin_;
   return stream;
 }
 
 dbOStream& operator<<(dbOStream& stream, const _dbScanPin& obj)
 {
-  // User Code Begin <<
-  int index = obj.pin_.index();
-  stream << index;
-  if (index == 0) {
-    stream << std::get<0>(obj.pin_);
-  } else if (index == 1) {
-    stream << std::get<1>(obj.pin_);
-  }
-  // User Code End <<
+  stream << obj.pin_;
   return stream;
 }
 

--- a/src/odb/src/db/dbScanPin.h
+++ b/src/odb/src/db/dbScanPin.h
@@ -64,9 +64,7 @@ class _dbScanPin : public _dbObject
                    const _dbScanPin& rhs) const;
   void out(dbDiff& diff, char side, const char* field) const;
 
-  // User Code Begin Fields
   std::variant<dbId<_dbBTerm>, dbId<_dbITerm>> pin_;
-  // User Code End Fields
 };
 dbIStream& operator>>(dbIStream& stream, _dbScanPin& obj);
 dbOStream& operator<<(dbOStream& stream, const _dbScanPin& obj);


### PR DESCRIPTION
- Makes the code in dbScanPin more simple
- std::variant now is available to be use for serialization by others