### PR TITLE
grt: handle obstructions that completely block the die area

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3140,15 +3140,17 @@ int GlobalRouter::findObstructions(odb::Rect& die_area)
     }
   }
 
-  for (odb::dbBTerm* bterm : block_->getBTerms()) {
-    for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
-      for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
-        odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
-        if (tech_layer->getRoutingLevel() >= first_blocked_layer) {
-          logger_->error(utl::GRT,
-                         16,
-                         "Pin {} is placed at a blocked layer.",
-                         bterm->getName());
+  if (first_blocked_layer != std::numeric_limits<int>::max()) {
+    for (odb::dbBTerm* bterm : block_->getBTerms()) {
+      for (odb::dbBPin* bterm_pin : bterm->getBPins()) {
+        for (odb::dbBox* bpin_box : bterm_pin->getBoxes()) {
+          odb::dbTechLayer* tech_layer = bpin_box->getTechLayer();
+          if (tech_layer->getRoutingLevel() >= first_blocked_layer) {
+            logger_->error(utl::GRT,
+                           16,
+                           "Pin {} is placed at a blocked layer.",
+                           bterm->getName());
+          }
         }
       }
     }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3111,6 +3111,7 @@ void GlobalRouter::findLayerExtensions(std::vector<int>& layer_extensions)
 int GlobalRouter::findObstructions(odb::Rect& die_area)
 {
   int obstructions_cnt = 0;
+  odb::dbTech* tech = db_->getTech();
   for (odb::dbObstruction* obstruction : block_->getObstructions()) {
     odb::dbBox* obstruction_box = obstruction->getBBox();
 
@@ -3127,6 +3128,13 @@ int GlobalRouter::findObstructions(odb::Rect& die_area)
       }
       applyObstructionAdjustment(obstruction_rect,
                                  obstruction_box->getTechLayer());
+      if (obstruction_rect == grid_->getGridArea()) {
+        for (int l = layer; l <= max_routing_layer_; l++) {
+          odb::dbTechLayer* tech_layer = tech->findRoutingLayer(l);
+          applyObstructionAdjustment(obstruction_rect,
+                                     tech_layer);
+        }
+      }
       obstructions_cnt++;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/3020

When a routing obstruction completely blocks the die area, block the remaining layers above it since those layers are unreachable from the lower layers. Also error out when a pin is placed inside the blocked layers range.