### PR TITLE
Optimize macro floorplanning

### DIFF
--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -835,38 +835,6 @@ const std::pair<float, float> HardMacro::getLocation() const
   return std::pair<float, float>(x_, y_);
 }
 
-float HardMacro::getX() const
-{
-  return x_;
-}
-
-float HardMacro::getY() const
-{
-  return y_;
-}
-
-// The position of pins relative to the origin of the canvas;
-float HardMacro::getAbsPinX() const
-{
-  return pin_x_;
-}
-
-float HardMacro::getAbsPinY() const
-{
-  return pin_y_;
-}
-
-// width and height
-float HardMacro::getWidth() const
-{
-  return width_;
-}
-
-float HardMacro::getHeight() const
-{
-  return height_;
-}
-
 // Note that the real X and Y does NOT include halo_width
 void HardMacro::setRealLocation(const std::pair<float, float>& location)
 {
@@ -1426,31 +1394,6 @@ void SoftMacro::setShapes(
   }
   width_ = width_list_[0].first;
   height_ = height_list_[0].first;
-}
-
-float SoftMacro::getX() const
-{
-  return x_;
-}
-
-float SoftMacro::getY() const
-{
-  return y_;
-}
-
-const std::pair<float, float> SoftMacro::getLocation() const
-{
-  return std::pair<float, float>(x_, y_);
-}
-
-float SoftMacro::getWidth() const
-{
-  return width_;
-}
-
-float SoftMacro::getHeight() const
-{
-  return height_;
 }
 
 float SoftMacro::getArea() const

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -845,17 +845,6 @@ float HardMacro::getY() const
   return y_;
 }
 
-// The position of pins relative to the lower left of the instance
-float HardMacro::getPinX() const
-{
-  return x_ + pin_x_;
-}
-
-float HardMacro::getPinY() const
-{
-  return y_ + pin_y_;
-}
-
 // The position of pins relative to the origin of the canvas;
 float HardMacro::getAbsPinX() const
 {
@@ -1447,16 +1436,6 @@ float SoftMacro::getX() const
 float SoftMacro::getY() const
 {
   return y_;
-}
-
-float SoftMacro::getPinX() const
-{
-  return x_ + width_ / 2.0;
-}
-
-float SoftMacro::getPinY() const
-{
-  return y_ + height_ / 2.0;
 }
 
 const std::pair<float, float> SoftMacro::getLocation() const

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -1170,15 +1170,6 @@ const std::string SoftMacro::getName() const
 // Physical Information
 void SoftMacro::setX(float x)
 {
-  if (refer_lx_ > 0.0 && refer_ly_ > 0.0) {
-    if (x > refer_lx_) {
-      x_ = x;
-    } else {
-      x_ = refer_lx_;
-    }
-    return;
-  }
-
   if (!fixed_) {
     x_ = x;
   }
@@ -1186,15 +1177,6 @@ void SoftMacro::setX(float x)
 
 void SoftMacro::setY(float y)
 {
-  if (refer_lx_ > 0.0 && refer_ly_ > 0.0) {
-    if (y > refer_ly_) {
-      y_ = y;
-    } else {
-      y_ = refer_ly_;
-    }
-    return;
-  }
-
   if (!fixed_) {
     y_ = y;
   }

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -364,8 +364,8 @@ class HardMacro
   float getX() const;
   float getY() const;
   // The position of pins relative to the lower left of the instance
-  float getPinX() const;
-  float getPinY() const;
+  inline float getPinX() const {return x_ + pin_x_;}
+  inline float getPinY() const {return y_ + pin_y_;}
   // The position of pins relative to the origin of the canvas;
   float getAbsPinX() const;
   float getAbsPinY() const;
@@ -549,8 +549,11 @@ class SoftMacro
                  float area);
   float getX() const;
   float getY() const;
-  float getPinX() const;
-  float getPinY() const;
+
+  // The position of pins relative to the lower left of the instance
+  inline float getPinX() const {return x_ + 0.5f * width_;}
+  inline float getPinY() const {return y_ + 0.5f * height_;}
+
   const std::pair<float, float> getLocation() const;
   float getWidth() const;
   float getHeight() const;

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -547,7 +547,7 @@ class SoftMacro
   float getPinX() const { return x_ + 0.5f * width_; }
   float getPinY() const { return y_ + 0.5f * height_; }
 
-  const std::pair<float, float> getLocation() const
+  std::pair<float, float> getLocation() const
   {
     return std::pair<float, float>(x_, y_);
   }

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -521,14 +521,7 @@ class SoftMacro
 
   // name
   const std::string getName() const;
-  // Physical Information
-  void setReference(float refer_lx, float refer_ly)
-  {
-    refer_lx_ = refer_lx;
-    refer_ly_ = refer_ly;
-    x_ = refer_lx;
-    y_ = refer_ly;
-  }
+
   void setX(float x);
   void setY(float y);
   void setLocation(const std::pair<float, float>& location);
@@ -597,8 +590,6 @@ class SoftMacro
   // Interfaces with hard macro
   Cluster* cluster_ = nullptr;
   bool fixed_ = false;  // if the macro is fixed
-  float refer_lx_ = -1.0;
-  float refer_ly_ = -1.0;
 
   // Alignment support
   // if the cluster has been aligned related to other macro_cluster or

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -361,17 +361,17 @@ class HardMacro
   void setX(float x);
   void setY(float y);
   const std::pair<float, float> getLocation() const;
-  float getX() const;
-  float getY() const;
+  float getX() const { return x_; }
+  float getY() const { return y_; }
   // The position of pins relative to the lower left of the instance
-  inline float getPinX() const {return x_ + pin_x_;}
-  inline float getPinY() const {return y_ + pin_y_;}
+  float getPinX() const { return x_ + pin_x_; }
+  float getPinY() const { return y_ + pin_y_; }
   // The position of pins relative to the origin of the canvas;
-  float getAbsPinX() const;
-  float getAbsPinY() const;
+  float getAbsPinX() const { return pin_x_; }
+  float getAbsPinY() const { return pin_y_; }
   // width, height (include halo_width)
-  float getWidth() const;
-  float getHeight() const;
+  float getWidth() const { return width_; }
+  float getHeight() const { return height_; }
 
   // Note that the real X and Y does NOT include halo_width
   void setRealLocation(const std::pair<float, float>& location);
@@ -547,16 +547,19 @@ class SoftMacro
   // for StdCellCluster and MixedCluster
   void setShapes(const std::vector<std::pair<float, float>>& width_list,
                  float area);
-  float getX() const;
-  float getY() const;
+  float getX() const { return x_; }
+  float getY() const { return y_; }
 
   // The position of pins relative to the lower left of the instance
-  inline float getPinX() const {return x_ + 0.5f * width_;}
-  inline float getPinY() const {return y_ + 0.5f * height_;}
+  float getPinX() const { return x_ + 0.5f * width_; }
+  float getPinY() const { return y_ + 0.5f * height_; }
 
-  const std::pair<float, float> getLocation() const;
-  float getWidth() const;
-  float getHeight() const;
+  const std::pair<float, float> getLocation() const
+  {
+    return std::pair<float, float>(x_, y_);
+  }
+  float getWidth() const { return width_; }
+  float getHeight() const { return height_; }
   float getArea() const;
   // Num Macros
   bool isMacroCluster() const;
@@ -670,9 +673,9 @@ struct Rect
 
   float getY() const { return (ly + uy) / 2.0; }
 
-  inline float getWidth() const { return ux - lx; }
+  float getWidth() const { return ux - lx; }
 
-  inline float getHeight() const { return uy - ly; }
+  float getHeight() const { return uy - ly; }
 
   void setLoc(float x,
               float y,
@@ -712,24 +715,24 @@ struct Rect
     }
   }
 
-  inline void moveHor(float dist)
+  void moveHor(float dist)
   {
     lx = lx + dist;
     ux = ux + dist;
   }
 
-  inline void moveVer(float dist)
+  void moveVer(float dist)
   {
     ly = ly + dist;
     uy = uy + dist;
   }
 
-  inline void move(float x_dist,
-                   float y_dist,
-                   float core_lx,
-                   float core_ly,
-                   float core_ux,
-                   float core_uy)
+  void move(float x_dist,
+            float y_dist,
+            float core_lx,
+            float core_ly,
+            float core_ux,
+            float core_uy)
   {
     if (fixed_flag == true) {
       return;
@@ -768,7 +771,7 @@ struct Rect
     }
   }
 
-  inline void resetForce()
+  void resetForce()
   {
     f_x_a = 0.0;
     f_y_a = 0.0;
@@ -778,7 +781,7 @@ struct Rect
     f_y = 0.0;
   }
 
-  inline void makeSquare(float ar = 1.0)
+  void makeSquare(float ar = 1.0)
   {
     if (fixed_flag == true) {
       return;
@@ -793,19 +796,19 @@ struct Rect
     uy = y + height / 2.0;
   }
 
-  inline void addAttractiveForce(float f_x, float f_y)
+  void addAttractiveForce(float f_x, float f_y)
   {
     f_x_a += f_x;
     f_y_a += f_y;
   }
 
-  inline void addRepulsiveForce(float f_x, float f_y)
+  void addRepulsiveForce(float f_x, float f_y)
   {
     f_x_r += f_x;
     f_y_r += f_y;
   }
 
-  inline void setForce(float f_x_, float f_y_)
+  void setForce(float f_x_, float f_y_)
   {
     f_x = f_x_;
     f_y = f_y_;


### PR DESCRIPTION
The optimization include getter inlining and removal of `refer_lx_` and `refer_ly_` which were effectively unused but took part in checks in `SoftMacro::setX` and `SoftMacro::setY`.

The effect of the optimization was tested with `OpenROAD-flow-scripts` on `ariane133` design with `nandgate45` PDK. The stage `2_4_floorplan_macro` before the optimization took roughly **104** seconds whereas after the optimization about **83** seconds (on an Intel i7-8700 @ 3.20GHz CPU).