### PR TITLE
Optimize `pdr::get_nearest_neighbors`

### DIFF
--- a/src/stt/src/pdr/src/pd.cpp
+++ b/src/stt/src/pdr/src/pd.cpp
@@ -66,7 +66,7 @@ static vector<Neighbors> get_nearest_neighbors(const vector<Point>& pts)
   thread_local static vector<int> data;
   data.clear();
 
-  const int pt_count = pts.size();
+  const size_t pt_count = pts.size();
 
   vector<Neighbors> neighbors(pt_count);
 
@@ -76,22 +76,20 @@ static vector<Neighbors> get_nearest_neighbors(const vector<Point>& pts)
   // therefore not a nearest neighbor.  This depends on processing the
   // nodes in order of increasing y distance.
   data.reserve(pt_count * 5);
-  data.resize(pt_count, std::numeric_limits<int>::max());
-  data.resize(pt_count * 2, std::numeric_limits<int>::min());
-  data.resize(pt_count * 3, std::numeric_limits<int>::max());
+  data.resize(pt_count * 2, std::numeric_limits<int>::max());
   data.resize(pt_count * 4, std::numeric_limits<int>::min());
   data.resize(pt_count * 5);
-  int* const ur = &data[0];
-  int* const ul = &data[pt_count];
-  int* const lr = &data[pt_count * 2];
+  int* const ur = &data[0];  // NOLINT
+  int* const lr = &data[pt_count];
+  int* const ul = &data[pt_count * 2];
   int* const ll = &data[pt_count * 3];
   int* const sorted = &data[pt_count * 4];
 
   // sort in y-axis
   std::iota(sorted, sorted + pt_count, 0);
   std::stable_sort(sorted, sorted + pt_count, [&pts](int i, int j) {
-      return std::make_pair(pts[i].getY(), pts[i].getX())
-      < std::make_pair(pts[j].getY(), pts[j].getX());
+    return std::make_pair(pts[i].getY(), pts[i].getX())
+           < std::make_pair(pts[j].getY(), pts[j].getX());
   });
 
   // Compute neighbors going from bottom to top in Y


### PR DESCRIPTION
It's a hot function in global placement. Probably the biggest win here is capturing `pts` by reference instead of by copy, but also there's fewer allocations.

| `gpl` run | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `ariane133` (before) | 486.971 ± 0.833 | 485.887 | 487.765 |
| `ariane133` (after) | 447.314 ± 6.410 | 441.101 | 454.566 |
| `black_parrot` (before) | 562.767 ± 2.765 | 553.641 | 565.986 |
| `black_parrot` (after) | 537.563 ± 5.191 | 524.795 | 543.223 |

Global placement speedup is about 5-8%.