### PR TITLE
Reduce number of pin location lookups in Steiner tree construction

### DIFF
--- a/src/rsz/src/SteinerTree.hh
+++ b/src/rsz/src/SteinerTree.hh
@@ -80,6 +80,13 @@ public:
                   const Point &pt2) const;
 };
 
+class PinLoc
+{
+public:
+  const Pin* pin;
+  Point loc;
+};
+
 using LocPinMap = std::unordered_map<Point, PinSeq, PointHash, PointEqual>;
 
 class SteinerTree;
@@ -97,8 +104,8 @@ class SteinerTree
 {
 public:
   SteinerTree(const Pin *drvr_pin, Resizer *resizer);
-  PinSeq &pins() { return pins_; }
-  int pinCount() const { return pins_.size(); }
+  Vector<PinLoc> &pinlocs() { return pinlocs_; }
+  int pinCount() const { return pinlocs_.size(); }
   int branchCount() const;
   void branch(int index,
               // Return values.
@@ -147,13 +154,13 @@ public:
   static SteinerPt null_pt;
 
 protected:
-  void locAddPin(Point &loc,
+  void locAddPin(const Point &loc,
                  const Pin *pin);
 
   stt::Tree tree_;
   const Pin *drvr_pin_;
   int drvr_steiner_pt_;            // index into tree_.branch
-  PinSeq pins_;                    // Initial input
+  Vector<PinLoc> pinlocs_;         // Initial input
   LocPinMap loc_pin_map_;          // location -> pins map
   std::vector<SteinerPt>  left_;
   std::vector<SteinerPt>  right_;


### PR DESCRIPTION
There are some unnecessary pin location lookups during Steiner tree construction in global placement. This change fetches these locations once and reuses them.

| `gpl` run | Mean [s] | Min [s] | Max [s] |
|:---|---:|---:|---:|
| `ariane133` (before) | 486.971 ± 0.833 | 485.887 | 487.765 |
| `ariane133` (after) | 447.517 ± 1.311 | 446.120 | 449.581 |
| `black_parrot` (before) | 562.767 ± 2.765 | 553.641 | 565.986 |
| `black_parrot` (after) | 525.773 ± 1.841 | 522.481 | 530.099 |

Global placement speedup is about 7-8%.