### PR TITLE
mpl2: refactor mixed leaves splitting

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2285,13 +2285,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     if (parent == mixed_leaf) {
       addStdCellClusterToSubTree(parent, mixed_leaf, virtual_conn_clusters);
     } else {
-      // In this case, we do not to modify the physical hierarchy tree
-      mixed_leaf->clearLeafMacros();
-      mixed_leaf->setClusterType(StdCellCluster);
-
-      setClusterMetrics(mixed_leaf);
-
-      virtual_conn_clusters.push_back(mixed_leaf->getId());
+      replaceByStdCellCluster(mixed_leaf, virtual_conn_clusters);
     }
 
     // Deal with macro clusters
@@ -2484,6 +2478,18 @@ void HierRTLMP::addStdCellClusterToSubTree(
   std_cell_cluster->setParent(parent);
   parent->addChild(std_cell_cluster);
   virtual_conn_clusters.push_back(std_cell_cluster->getId());
+}
+
+// We don't modify the physical hierarchy when spliting by replacement
+void HierRTLMP::replaceByStdCellCluster(Cluster* mixed_leaf,
+                                        std::vector<int>& virtual_conn_clusters)
+{
+  mixed_leaf->clearLeafMacros();
+  mixed_leaf->setClusterType(StdCellCluster);
+
+  setClusterMetrics(mixed_leaf);
+
+  virtual_conn_clusters.push_back(mixed_leaf->getId());
 }
 
 // Print Physical Hierarchy tree in a DFS manner

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2244,15 +2244,6 @@ void HierRTLMP::fetchMixedLeaves(
   mixed_leaves.push_back(sister_mixed_leaves);
 }
 
-// Break mixed leaves into standard-cell and hard-macro clusters.
-// Merge macros based on connection signature and footprint.
-// Based on types of designs, we support two types of breaking up:
-// Suppose current cluster is A.
-//   1) Replace A by A1, A2, A3
-//   2) Type 2:  Create a subtree:
-//      A  ->        A
-//               |   |   |
-//               A1  A2  A3
 void HierRTLMP::breakMixedLeaves(
     const std::vector<std::vector<Cluster*>>& mixed_leaves)
 {
@@ -2267,6 +2258,14 @@ void HierRTLMP::breakMixedLeaves(
   }
 }
 
+// Break mixed leaf into standard-cell and hard-macro clusters.
+// Merge macros based on connection signature and footprint.
+// Based on types of designs, we support two types of breaking up:
+//   1) Replace cluster A by A1, A2, A3
+//   2) Create a subtree:
+//      A  ->        A
+//               |   |   |
+//               A1  A2  A3
 void HierRTLMP::breakMixedLeaf(Cluster* mixed_leaf)
 {
   Cluster* parent = mixed_leaf;
@@ -2294,7 +2293,7 @@ void HierRTLMP::breakMixedLeaf(Cluster* mixed_leaf)
 
   std::vector<int> macro_class(hard_macros.size(), -1);
   // Use both size and connection signature classifications to group
-  // single-macro macro clusters into the same cluster.
+  // single-macro macro clusters into the same macro cluster.
   groupSingleMacroClusters(
       macro_clusters, size_class, signature_class, macro_class);
 

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2260,24 +2260,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     std::vector<HardMacro*> hard_macros = mixed_leaf->getHardMacros();
     std::vector<Cluster*> macro_clusters;
 
-    // createOneMacroClusterForEachMacro
-    for (auto& hard_macro : hard_macros) {
-      std::string cluster_name = hard_macro->getName();
-      Cluster* single_macro_cluster
-          = new Cluster(cluster_id_, cluster_name, logger_);
-
-      single_macro_cluster->addLeafMacro(hard_macro->getInst());
-
-      setInstProperty(single_macro_cluster);
-      setClusterMetrics(single_macro_cluster);
-
-      cluster_map_[cluster_id_++] = single_macro_cluster;
-
-      // modify the physical hierachy tree
-      single_macro_cluster->setParent(parent);
-      parent->addChild(single_macro_cluster);
-      macro_clusters.push_back(single_macro_cluster);
-    }
+    createOneClusterForEachMacro(parent, hard_macros, macro_clusters);
 
     // classifyMacrosBasedOnSize
     std::vector<int> macro_size_class(hard_macros.size(), -1);
@@ -2410,6 +2393,30 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
   }
   // Set the inst property back
   setInstProperty(root_cluster);
+}
+
+void HierRTLMP::createOneClusterForEachMacro(
+    Cluster* parent,
+    const std::vector<HardMacro*>& hard_macros,
+    std::vector<Cluster*>& macro_clusters)
+{
+  for (auto& hard_macro : hard_macros) {
+    std::string cluster_name = hard_macro->getName();
+    Cluster* single_macro_cluster
+        = new Cluster(cluster_id_, cluster_name, logger_);
+
+    single_macro_cluster->addLeafMacro(hard_macro->getInst());
+
+    setInstProperty(single_macro_cluster);
+    setClusterMetrics(single_macro_cluster);
+
+    cluster_map_[cluster_id_++] = single_macro_cluster;
+
+    // modify the physical hierachy tree
+    single_macro_cluster->setParent(parent);
+    parent->addChild(single_macro_cluster);
+    macro_clusters.push_back(single_macro_cluster);
+  }
 }
 
 // Map all the macros into their HardMacro objects for all the clusters

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2283,22 +2283,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
     std::vector<int> virtual_conn_clusters;
 
     if (parent == mixed_leaf) {
-      std::string std_cell_cluster_name = mixed_leaf->getName();
-      Cluster* std_cell_cluster
-          = new Cluster(cluster_id_, std_cell_cluster_name, logger_);
-
-      std_cell_cluster->copyInstances(*mixed_leaf);
-      std_cell_cluster->clearLeafMacros();
-      std_cell_cluster->setClusterType(StdCellCluster);
-
-      setClusterMetrics(std_cell_cluster);
-
-      cluster_map_[cluster_id_++] = std_cell_cluster;
-
-      // modify the physical hierachy tree
-      std_cell_cluster->setParent(parent);
-      parent->addChild(std_cell_cluster);
-      virtual_conn_clusters.push_back(std_cell_cluster->getId());
+      addStdCellClusterToSubTree(parent, mixed_leaf, virtual_conn_clusters);
     } else {
       // In this case, we do not to modify the physical hierarchy tree
       mixed_leaf->clearLeafMacros();
@@ -2476,6 +2461,29 @@ void HierRTLMP::groupSingleMacroClusters(
       }
     }
   }
+}
+
+void HierRTLMP::addStdCellClusterToSubTree(
+    Cluster* parent,
+    Cluster* mixed_leaf,
+    std::vector<int>& virtual_conn_clusters)
+{
+  std::string std_cell_cluster_name = mixed_leaf->getName();
+  Cluster* std_cell_cluster
+      = new Cluster(cluster_id_, std_cell_cluster_name, logger_);
+
+  std_cell_cluster->copyInstances(*mixed_leaf);
+  std_cell_cluster->clearLeafMacros();
+  std_cell_cluster->setClusterType(StdCellCluster);
+
+  setClusterMetrics(std_cell_cluster);
+
+  cluster_map_[cluster_id_++] = std_cell_cluster;
+
+  // modify the physical hierachy tree
+  std_cell_cluster->setParent(parent);
+  parent->addChild(std_cell_cluster);
+  virtual_conn_clusters.push_back(std_cell_cluster->getId());
 }
 
 // Print Physical Hierarchy tree in a DFS manner

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -2262,22 +2262,8 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
 
     createOneClusterForEachMacro(parent, hard_macros, macro_clusters);
 
-    // classifyMacrosBasedOnSize
-    std::vector<int> macro_size_class(hard_macros.size(), -1);
-    for (int i = 0; i < hard_macros.size(); i++) {
-      if (macro_size_class[i] == -1) {
-        for (int j = i + 1; j < hard_macros.size(); j++) {
-          if ((macro_size_class[j] == -1)
-              && ((*hard_macros[i]) == (*hard_macros[j]))) {
-            macro_size_class[j] = i;
-          }
-        }
-      }
-    }
-    for (int i = 0; i < hard_macros.size(); i++) {
-      macro_size_class[i]
-          = (macro_size_class[i] == -1) ? i : macro_size_class[i];
-    }
+    std::vector<int> size_class(hard_macros.size(), -1);
+    classifyMacrosBySize(hard_macros, size_class);
 
     calculateConnection();
 
@@ -2315,7 +2301,7 @@ void HierRTLMP::breakMixedLeafCluster(Cluster* root_cluster)
       if (macro_class[i] == -1) {
         macro_class[i] = i;
         for (int j = i + 1; j < hard_macros.size(); j++) {
-          if (macro_class[j] == -1 && macro_size_class[i] == macro_size_class[j]
+          if (macro_class[j] == -1 && size_class[i] == size_class[j]
               && macro_signature_class[i] == macro_signature_class[j]) {
             macro_class[j] = i;
             debugPrint(logger_,
@@ -2416,6 +2402,24 @@ void HierRTLMP::createOneClusterForEachMacro(
     single_macro_cluster->setParent(parent);
     parent->addChild(single_macro_cluster);
     macro_clusters.push_back(single_macro_cluster);
+  }
+}
+
+void HierRTLMP::classifyMacrosBySize(const std::vector<HardMacro*>& hard_macros,
+                                     std::vector<int>& size_class)
+{
+  for (int i = 0; i < hard_macros.size(); i++) {
+    if (size_class[i] == -1) {
+      for (int j = i + 1; j < hard_macros.size(); j++) {
+        if ((size_class[j] == -1) && ((*hard_macros[i]) == (*hard_macros[j]))) {
+          size_class[j] = i;
+        }
+      }
+    }
+  }
+
+  for (int i = 0; i < hard_macros.size(); i++) {
+    size_class[i] = (size_class[i] == -1) ? i : size_class[i];
   }
 }
 

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -212,6 +212,10 @@ class HierRTLMP
   void classifyMacrosByConnSignature(
       const std::vector<Cluster*>& macro_clusters,
       std::vector<int>& signature_class);
+  void groupSingleMacroClusters(const std::vector<Cluster*>& macro_clusters,
+                                const std::vector<int>& size_class,
+                                const std::vector<int>& signature_class,
+                                std::vector<int>& macro_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -220,6 +220,8 @@ class HierRTLMP
   void addStdCellClusterToSubTree(Cluster* parent,
                                   Cluster* mixed_leaf,
                                   std::vector<int>& virtual_conn_clusters);
+  void replaceByStdCellCluster(Cluster* mixed_leaf,
+                               std::vector<int>& virtual_conn_clusters);
 
   // Coarse Shaping
   void runCoarseShaping();

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,7 +204,7 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
-	void mapMacroInCluster2HardMacro(Cluster* cluster);
+  void mapMacroInCluster2HardMacro(Cluster* cluster);
   void createOneClusterForEachMacro(Cluster* parent,
                                     const std::vector<HardMacro*>& hard_macros,
                                     std::vector<Cluster*>& macro_clusters);
@@ -217,6 +217,9 @@ class HierRTLMP
                                 const std::vector<int>& size_class,
                                 const std::vector<int>& signature_class,
                                 std::vector<int>& macro_class);
+  void addStdCellClusterToSubTree(Cluster* parent,
+                                  Cluster* mixed_leaf,
+                                  std::vector<int>& virtual_conn_clusters);
 
   // Coarse Shaping
   void runCoarseShaping();

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,9 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
+  void createOneClusterForEachMacro(Cluster* parent,
+                                    const std::vector<HardMacro*>& hard_macros,
+                                    std::vector<Cluster*>& macro_clusters);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -203,7 +203,11 @@ class HierRTLMP
   void mergeClusters(std::vector<Cluster*>& candidate_clusters);
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
-  void breakMixedLeafCluster(Cluster* root_cluster);
+
+  void fetchMixedLeaves(Cluster* parent,
+                        std::vector<std::vector<Cluster*>>& mixed_leaves);
+  void breakMixedLeaves(const std::vector<std::vector<Cluster*>>& mixed_leaves);
+
   void breakMixedLeaf(Cluster* mixed_leaf);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
   void createOneClusterForEachMacro(Cluster* parent,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -209,6 +209,9 @@ class HierRTLMP
                                     std::vector<Cluster*>& macro_clusters);
   void classifyMacrosBySize(const std::vector<HardMacro*>& hard_macros,
                             std::vector<int>& size_class);
+  void classifyMacrosByConnSignature(
+      const std::vector<Cluster*>& macro_clusters,
+      std::vector<int>& signature_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,7 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
+  void breakMixedLeaf(Cluster* mixed_leaf);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
   void createOneClusterForEachMacro(Cluster* parent,
                                     const std::vector<HardMacro*>& hard_macros,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,7 @@ class HierRTLMP
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
   void breakMixedLeafCluster(Cluster* root_cluster);
+	void mapMacroInCluster2HardMacro(Cluster* cluster);
   void createOneClusterForEachMacro(Cluster* parent,
                                     const std::vector<HardMacro*>& hard_macros,
                                     std::vector<Cluster*>& macro_clusters);
@@ -216,7 +217,6 @@ class HierRTLMP
                                 const std::vector<int>& size_class,
                                 const std::vector<int>& signature_class,
                                 std::vector<int>& macro_class);
-  void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping
   void runCoarseShaping();

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -207,6 +207,8 @@ class HierRTLMP
   void createOneClusterForEachMacro(Cluster* parent,
                                     const std::vector<HardMacro*>& hard_macros,
                                     std::vector<Cluster*>& macro_clusters);
+  void classifyMacrosBySize(const std::vector<HardMacro*>& hard_macros,
+                            std::vector<int>& size_class);
   void mapMacroInCluster2HardMacro(Cluster* cluster);
 
   // Coarse Shaping


### PR DESCRIPTION
Refactoring to prepare for macro array support.

Originally, we had one function to both search and split the mixed leaves in the multilevel autoclustering stage.

This PR is to split this function into two: one to fetch the mixed leaves and other to actually split them into std cells and macro clusters.

If the approach is ok, I'll run Secure-CI