### PR TITLE
many: switch to use iterm->getName() where possible

### DIFF
--- a/src/Design.cc
+++ b/src/Design.cc
@@ -217,9 +217,7 @@ bool Design::isInClock(odb::dbInst* inst)
 
 std::string Design::getITermName(odb::dbITerm* pin)
 {
-  auto MTerm_name = pin->getMTerm()->getName();
-  auto inst_name = pin->getInst()->getName();
-  return inst_name + "/" + MTerm_name;
+  return pin->getName();
 }
 
 bool Design::isInSupply(odb::dbITerm* pin)

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -567,11 +567,10 @@ void io::Parser::setNets(odb::dbBlock* block)
         logger_->error(DRT,
                        307,
                        "Net {} of signal type {} cannot be connected to iterm "
-                       "{}/{} with signal type {}",
+                       "{} with signal type {}",
                        net->getName(),
                        net->getSigType().getString(),
-                       term->getInst()->getName(),
-                       term->getMTerm()->getName(),
+                       term->getName(),
                        term->getSigType().getString());
       if (tmpBlock_->name2inst_.find(term->getInst()->getName())
           == tmpBlock_->name2inst_.end())
@@ -581,11 +580,8 @@ void io::Parser::setNets(odb::dbBlock* block)
       // gettin inst term
       auto frterm = inst->getMaster()->getTerm(term->getMTerm()->getName());
       if (frterm == nullptr)
-        logger_->error(DRT,
-                       106,
-                       "Component pin {}/{} not found.",
-                       term->getInst()->getName(),
-                       term->getMTerm()->getName());
+        logger_->error(
+            DRT, 106, "Component pin {} not found.", term->getName());
       int idx = frterm->getIndexInOwner();
       auto& instTerms = inst->getInstTerms();
       auto instTerm = instTerms[idx].get();
@@ -1122,9 +1118,8 @@ void io::Parser::setAccessPoints(odb::dbDatabase* db)
         if (ap_map.find(db_ap) == ap_map.end())
           logger_->error(DRT,
                          1011,
-                         "Access Point not found for iterm {}/{}",
-                         db_inst->getName(),
-                         db_term->getMTerm()->getName());
+                         "Access Point not found for iterm {}",
+                         db_term->getName());
         db_aps_map[db_ap->getMPin()] = db_ap;
       }
       int idx = 0;

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -340,8 +340,7 @@ std::string Pin::name() const
     return "DUMMY";
   }
   if (isITerm()) {
-    return dbITerm()->getInst()->getName() + '/'
-           + dbITerm()->getMTerm()->getName();
+    return dbITerm()->getName();
   }
   return dbBTerm()->getName();
 }

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -362,10 +362,7 @@ QPointF ClockNodeGraphicsViewItem::getBottomAnchor() const
 
 QString ClockNodeGraphicsViewItem::getITermName(odb::dbITerm* term)
 {
-  std::string name = term->getInst()->getName();
-  name += "/";
-  name += term->getMTerm()->getName();
-  return QString::fromStdString(name);
+  return QString::fromStdString(term->getName());
 }
 
 void ClockNodeGraphicsViewItem::setName(odb::dbITerm* term)

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1769,7 +1769,7 @@ DbITermDescriptor::DbITermDescriptor(odb::dbDatabase* db) : db_(db)
 std::string DbITermDescriptor::getName(std::any object) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
-  return iterm->getInst()->getName() + '/' + iterm->getMTerm()->getName();
+  return iterm->getName();
 }
 
 std::string DbITermDescriptor::getShortName(std::any object) const

--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -55,10 +55,9 @@ std::string TimingPathNode::getNodeName(bool include_master) const
   if (isPinITerm()) {
     odb::dbITerm* iterm = getPinAsITerm();
 
-    odb::dbInst* inst = iterm->getInst();
-
-    std::string name = inst->getName() + "/" + iterm->getMTerm()->getName();
+    std::string name = iterm->getName();
     if (include_master) {
+      odb::dbInst* inst = iterm->getInst();
       name += " (" + inst->getMaster()->getName() + ")";
     }
 

--- a/src/pad/src/ICeWall.cpp
+++ b/src/pad/src/ICeWall.cpp
@@ -218,20 +218,16 @@ void ICeWall::assignBump(odb::dbInst* inst,
           routing_map_.end(),
           [terminal](const auto& other) { return other.second == terminal; });
       if (already_assigned != routing_map_.end()) {
-        logger_->error(utl::PAD,
-                       35,
-                       "{}/{} has already been assigned.",
-                       terminal->getInst()->getName(),
-                       terminal->getMTerm()->getName());
+        logger_->error(
+            utl::PAD, 35, "{} has already been assigned.", terminal->getName());
       }
       if (terminal->getNet() == nullptr) {
         terminal->connect(net);
       } else if (terminal->getNet() != net) {
         logger_->error(utl::PAD,
                        36,
-                       "{}/{} is not connected to {}, but connected to {}.",
-                       terminal->getInst()->getName(),
-                       terminal->getMTerm()->getName(),
+                       "{} is not connected to {}, but connected to {}.",
+                       terminal->getName(),
                        net->getName(),
                        terminal->getNet()->getName());
       }
@@ -1094,9 +1090,7 @@ void ICeWall::connectByAbutment()
   for (const auto& [iterm0, iterm1] : connections) {
     auto* net = iterm0->getNet();
     if (net == nullptr) {
-      const std::string netname = fmt::format("{}.{}_RING",
-                                              iterm0->getInst()->getName(),
-                                              iterm0->getMTerm()->getName());
+      const std::string netname = fmt::format("{}_RING", iterm0->getName('.'));
       odb::dbNet* new_net = odb::dbNet::create(getBlock(), netname.c_str());
       iterm0->connect(new_net);
       iterm1->connect(new_net);
@@ -1139,13 +1133,11 @@ std::set<odb::dbNet*> ICeWall::connectByAbutment(
         // ERROR, touching, but different nets
         logger_->error(utl::PAD,
                        2,
-                       "{}/{} ({}) and {}/{} ({}) are touching, but are "
+                       "{} ({}) and {} ({}) are touching, but are "
                        "connected to different nets",
-                       iterm0->getInst()->getName(),
-                       iterm0->getMTerm()->getName(),
+                       iterm0->getName(),
                        net0->getName(),
-                       iterm1->getInst()->getName(),
-                       iterm1->getMTerm()->getName(),
+                       iterm1->getName(),
                        net1->getName());
       }
 
@@ -1158,13 +1150,11 @@ std::set<odb::dbNet*> ICeWall::connectByAbutment(
                  utl::PAD,
                  "Connect",
                  1,
-                 "Connecting net {} to {}/{} ({}) and {}/{} ({})",
+                 "Connecting net {} to {} ({}) and {} ({})",
                  connect_net->getName(),
-                 iterm0->getInst()->getName(),
-                 iterm0->getMTerm()->getName(),
+                 iterm0->getName(),
                  net0 != nullptr ? net0->getName() : "NULL",
-                 iterm1->getInst()->getName(),
-                 iterm1->getMTerm()->getName(),
+                 iterm1->getName(),
                  net1 != nullptr ? net1->getName() : "NULL");
 
       if (net0 != connect_net) {

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -280,11 +280,9 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
     for (const auto& [net, segments] : failed) {
       logger_->report("  {}", net->getName());
       for (const auto& segment : segments) {
-        logger_->report("    {}/{} -> {}/{}",
-                        segment.target0.terminal->getInst()->getName(),
-                        segment.target0.terminal->getMTerm()->getName(),
-                        segment.target1.terminal->getInst()->getName(),
-                        segment.target1.terminal->getMTerm()->getName());
+        logger_->report("    {} -> {}",
+                        segment.target0.terminal->getName(),
+                        segment.target1.terminal->getName());
       }
     }
   }
@@ -1240,9 +1238,8 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
                  utl::PAD,
                  "Router",
                  2,
-                 "Finding routing pair for {}/{} ({})",
-                 iterm0.first->getInst()->getName(),
-                 iterm0.first->getMTerm()->getName(),
+                 "Finding routing pair for {} ({})",
+                 iterm0.first->getName(),
                  iterm0.first->getNet()->getName());
 
       odb::dbITerm* find_terminal = nullptr;
@@ -1284,9 +1281,8 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
                    utl::PAD,
                    "Router",
                    2,
-                   "  {}/{} ({}): {:.4f}um",
-                   iterm1.first->getInst()->getName(),
-                   iterm1.first->getMTerm()->getName(),
+                   "  {} ({}): {:.4f}um",
+                   iterm1.first->getName(),
                    iterm1.first->getNet()->getName(),
                    new_dist / dbus);
 
@@ -1302,9 +1298,8 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
       if (pt0 == point) {
         logger_->error(utl::PAD,
                        37,
-                       "Unable to find routing pair for {}/{} ({})",
-                       iterm0.first->getInst()->getName(),
-                       iterm0.first->getMTerm()->getName(),
+                       "Unable to find routing pair for {} ({})",
+                       iterm0.first->getName(),
                        iterm0.first->getNet()->getName());
       }
 

--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -854,12 +854,10 @@ void PdnGen::checkDesign(odb::dbBlock* block) const
     }
     for (auto* term : inst->getITerms()) {
       if (term->getSigType().isSupply() && term->getNet() == nullptr) {
-        logger_->warn(
-            utl::PDN,
-            189,
-            "Supply pin {} of instance {} is not connected to any net.",
-            term->getMTerm()->getName(),
-            inst->getName());
+        logger_->warn(utl::PDN,
+                      189,
+                      "Supply pin {} is not connected to any net.",
+                      term->getName());
       }
     }
   }

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -808,7 +808,7 @@ void PadDirectConnectionStraps::report() const
 
 std::string PadDirectConnectionStraps::getName() const
 {
-  return iterm_->getInst()->getName() + "/" + iterm_->getMTerm()->getName();
+  return iterm_->getName();
 }
 
 bool PadDirectConnectionStraps::isConnectHorizontal() const

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -1122,9 +1122,7 @@ static bool insert_level_shifter(utl::Logger* logger,
   }
 
   // create dbInst
-  std::string inst_name = inst->getName() + "_" + iterm->getMTerm()->getName()
-                          + "_" + target_iterm->getInst()->getName() + "_"
-                          + target_iterm->getMTerm()->getName()
+  std::string inst_name = iterm->getName('_') + "_" + target_iterm->getName('_')
                           + "_level_shifter";
 
   odb::dbInst* shifter_inst


### PR DESCRIPTION
With the introduction of `dbITerm::getName` this PR just removes the places where it's constructed in favor of the function from odb.