### PR TITLE
gpl: fix inclusion of test only when tests enabled

### DIFF
--- a/src/gpl/CMakeLists.txt
+++ b/src/gpl/CMakeLists.txt
@@ -149,4 +149,6 @@ if (Python3_FOUND AND BUILD_PYTHON)
 
 endif()
 
-add_subdirectory(test)
+if(ENABLE_TESTS)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
The addition of the test in gpl caused builds to build when `ENABLE_TEST=OFF` this corrects this behavior.

@maliberty it might be nice to add a test to the Jenkinsfile to check this behavior. It doesn't actually have to build openroad, just run cmake, since the failure is in the cmake configuration. https://github.com/siliconcompiler/siliconcompiler/actions/runs/7508809382/job/20444951866