### PR TITLE
etc: update eqy version

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -10,7 +10,7 @@ _versionCompare() {
 
 _equivalenceDeps() {
     yosysVersion=yosys-0.33
-    eqyVersion=0cc2ff0
+    eqyVersion=8327ac7
 
     # yosys
     yosysPrefix=${PREFIX:-"/usr/local"}


### PR DESCRIPTION
Use latest version to avoid "Argument list is too long" error.