### PR TITLE
gui: add charts event when qtcharts is not installed

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -29,10 +29,6 @@ if (Qt5_FOUND AND BUILD_GUI)
 
     target_compile_definitions(gui PRIVATE ENABLE_CHARTS)
 
-    list(APPEND CHARTS_SRC
-      "src/chartsWidget.cpp"
-    )
-
     list(APPEND CHARTS_LIB
       "Qt5::Charts"
     )
@@ -77,7 +73,7 @@ if (Qt5_FOUND AND BUILD_GUI)
     src/gui_utils.cpp
     src/colorGenerator.cpp
     src/bufferTreeDescriptor.cpp
-    ${CHARTS_SRC}
+    src/chartsWidget.cpp
     resources/resource.qrc
   )
 

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -32,10 +32,11 @@
 
 #include "chartsWidget.h"
 
+#include <QWidget>
+#ifdef ENABLE_CHARTS
 #include <QColor>
 #include <QFrame>
 #include <QString>
-#include <QWidget>
 #include <QtCharts>
 #include <algorithm>
 #include <cmath>
@@ -254,5 +255,20 @@ void ChartsWidget::setLogger(utl::Logger* logger)
 {
   logger_ = logger;
 }
+#else
+ChartsWidget::ChartsWidget(QWidget* parent)
+    : QDockWidget("Charts", parent), label_(new QLabel(this))
+{
+  setObjectName("charts_widget");  // for settings
+
+  QWidget* container = new QWidget(this);
+  container->addWidget(label_);
+
+  label_->setText("QtCharts is not installed.")
+      label_->setAlignment(Qt::AlignCenter);
+
+  setWidget(container);
+}
+#endif
 
 }  // namespace gui

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -100,7 +100,7 @@ ChartsWidget::ChartsWidget(QWidget* parent)
   label_->setText("QtCharts is not installed.");
   label_->setAlignment(Qt::AlignCenter);
 #endif
-  container->setLayout(layout);
+  container->setLayout(controls_layout);
 
   setWidget(container);
 }

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -32,6 +32,8 @@
 
 #include "chartsWidget.h"
 
+#include <QHBoxLayout>
+
 #ifdef ENABLE_CHARTS
 #include <QColor>
 #include <QFrame>
@@ -47,35 +49,37 @@
 #include "sta/MinMax.hh"
 #include "sta/Units.hh"
 #include "staGuiInterface.h"
-#else
-#include <QHBoxLayout>
 #endif
 
 namespace gui {
-#ifdef ENABLE_CHARTS
+
 ChartsWidget::ChartsWidget(QWidget* parent)
     : QDockWidget("Charts", parent),
+#ifdef ENABLE_CHARTS
       logger_(nullptr),
       sta_(nullptr),
-      label_(new QLabel(this)),
       mode_menu_(new QComboBox(this)),
       chart_(new QChart),
       display_(new QChartView(chart_, this)),
       axis_x_(new QBarCategoryAxis(this)),
-      axis_y_(new QValueAxis(this))
+      axis_y_(new QValueAxis(this)),
+#endif
+      label_(new QLabel(this))
 {
   setObjectName("charts_widget");  // for settings
 
   QWidget* container = new QWidget(this);
+  QHBoxLayout* controls_layout = new QHBoxLayout;
+  controls_layout->addWidget(label_);
+
+#ifdef ENABLE_CHARTS
   QVBoxLayout* layout = new QVBoxLayout;
   QFrame* controls_frame = new QFrame;
-  QHBoxLayout* controls_layout = new QHBoxLayout;
 
   mode_menu_->addItem("Select Mode");
   mode_menu_->addItem("Endpoint Slack");
 
-  controls_layout->addWidget(mode_menu_);
-  controls_layout->addWidget(label_);
+  controls_layout->insertWidget(0, mode_menu_);
   controls_layout->insertStretch(1);
 
   controls_frame->setLayout(controls_layout);
@@ -84,8 +88,6 @@ ChartsWidget::ChartsWidget(QWidget* parent)
 
   layout->addWidget(controls_frame);
   layout->addWidget(display_);
-  container->setLayout(layout);
-  setWidget(container);
 
   chart_->addAxis(axis_y_, Qt::AlignLeft);
   chart_->addAxis(axis_x_, Qt::AlignBottom);
@@ -94,8 +96,16 @@ ChartsWidget::ChartsWidget(QWidget* parent)
           qOverload<int>(&QComboBox::currentIndexChanged),
           this,
           &ChartsWidget::changeMode);
+#else
+  label_->setText("QtCharts is not installed.");
+  label_->setAlignment(Qt::AlignCenter);
+#endif
+  container->setLayout(layout);
+
+  setWidget(container);
 }
 
+#ifdef ENABLE_CHARTS
 void ChartsWidget::changeMode()
 {
   if (mode_menu_->currentIndex() == SELECT) {
@@ -258,20 +268,5 @@ void ChartsWidget::setLogger(utl::Logger* logger)
 {
   logger_ = logger;
 }
-#else
-ChartsWidget::ChartsWidget(QWidget* parent) : QDockWidget("Charts", parent)
-{
-  setObjectName("charts_widget");  // for settings
-
-  QWidget* container = new QWidget(this);
-  QHBoxLayout* layout = new QHBoxLayout;
-  QLabel* label = new QLabel("QtCharts is not installed.");
-  label->setAlignment(Qt::AlignCenter);
-  layout->addWidget(label);
-  container->setLayout(layout);
-
-  setWidget(container);
-}
 #endif
-
 }  // namespace gui

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -89,6 +89,8 @@ ChartsWidget::ChartsWidget(QWidget* parent)
   layout->addWidget(controls_frame);
   layout->addWidget(display_);
 
+  container->setLayout(layout);
+
   chart_->addAxis(axis_y_, Qt::AlignLeft);
   chart_->addAxis(axis_x_, Qt::AlignBottom);
 
@@ -99,9 +101,9 @@ ChartsWidget::ChartsWidget(QWidget* parent)
 #else
   label_->setText("QtCharts is not installed.");
   label_->setAlignment(Qt::AlignCenter);
-#endif
+  // We need this layout in order to centralize the label.
   container->setLayout(controls_layout);
-
+#endif
   setWidget(container);
 }
 

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -32,11 +32,11 @@
 
 #include "chartsWidget.h"
 
-#include <QWidget>
 #ifdef ENABLE_CHARTS
 #include <QColor>
 #include <QFrame>
 #include <QString>
+#include <QWidget>
 #include <QtCharts>
 #include <algorithm>
 #include <cmath>
@@ -47,9 +47,10 @@
 #include "sta/MinMax.hh"
 #include "sta/Units.hh"
 #include "staGuiInterface.h"
+#endif
 
 namespace gui {
-
+#ifdef ENABLE_CHARTS
 ChartsWidget::ChartsWidget(QWidget* parent)
     : QDockWidget("Charts", parent),
       logger_(nullptr),
@@ -261,13 +262,8 @@ ChartsWidget::ChartsWidget(QWidget* parent)
 {
   setObjectName("charts_widget");  // for settings
 
-  QWidget* container = new QWidget(this);
-  container->addWidget(label_);
-
-  label_->setText("QtCharts is not installed.")
-      label_->setAlignment(Qt::AlignCenter);
-
-  setWidget(container);
+  label_->setText("QtCharts is not installed.");
+  label_->setAlignment(Qt::AlignCenter);
 }
 #endif
 

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -47,6 +47,8 @@
 #include "sta/MinMax.hh"
 #include "sta/Units.hh"
 #include "staGuiInterface.h"
+#else
+#include <QHBoxLayout>
 #endif
 
 namespace gui {
@@ -257,13 +259,18 @@ void ChartsWidget::setLogger(utl::Logger* logger)
   logger_ = logger;
 }
 #else
-ChartsWidget::ChartsWidget(QWidget* parent)
-    : QDockWidget("Charts", parent), label_(new QLabel(this))
+ChartsWidget::ChartsWidget(QWidget* parent) : QDockWidget("Charts", parent)
 {
   setObjectName("charts_widget");  // for settings
 
-  label_->setText("QtCharts is not installed.");
-  label_->setAlignment(Qt::AlignCenter);
+  QWidget* container = new QWidget(this);
+  QHBoxLayout* layout = new QHBoxLayout;
+  QLabel* label = new QLabel("QtCharts is not installed.");
+  label->setAlignment(Qt::AlignCenter);
+  layout->addWidget(label);
+  container->setLayout(layout);
+
+  setWidget(container);
 }
 #endif
 

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -32,9 +32,10 @@
 
 #pragma once
 
-#include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
+#ifdef ENABLE_CHARTS
+#include <QComboBox>
 #include <QPushButton>
 #include <QString>
 #include <QtCharts>
@@ -79,5 +80,16 @@ class ChartsWidget : public QDockWidget
   QBarCategoryAxis* axis_x_;
   QValueAxis* axis_y_;
 };
+#else
+class ChartsWidget : public QDockWidget
+{
+  Q_OBJECT
 
+ public:
+  ChartsWidget(QWidget* parent = nullptr);
+
+ private:
+  QLabel* label_;
+};
+#endif
 }  // namespace gui

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -34,6 +34,7 @@
 
 #include <QDockWidget>
 #include <QLabel>
+
 #ifdef ENABLE_CHARTS
 #include <QComboBox>
 #include <QPushButton>
@@ -49,20 +50,23 @@ class dbSta;
 #endif
 
 namespace gui {
-#ifdef ENABLE_CHARTS
+
 class ChartsWidget : public QDockWidget
 {
   Q_OBJECT
 
  public:
+  ChartsWidget(QWidget* parent = nullptr);
+#ifdef ENABLE_CHARTS
   enum Mode
   {
     SELECT,
     SLACK_HISTOGRAM
   };
-  ChartsWidget(QWidget* parent = nullptr);
-
-  void setSTA(sta::dbSta* sta) { sta_ = sta; };
+  void setSTA(sta::dbSta* sta)
+  {
+    sta_ = sta;
+  };
   void setLogger(utl::Logger* logger);
   void setSlackMode();
   void clearChart();
@@ -74,20 +78,13 @@ class ChartsWidget : public QDockWidget
   utl::Logger* logger_;
   sta::dbSta* sta_;
 
-  QLabel* label_;
   QComboBox* mode_menu_;
   QChart* chart_;
   QChartView* display_;
   QBarCategoryAxis* axis_x_;
   QValueAxis* axis_y_;
-};
-#else
-class ChartsWidget : public QDockWidget
-{
-  Q_OBJECT
-
- public:
-  ChartsWidget(QWidget* parent = nullptr);
-};
 #endif
+  QLabel* label_;
+};
+
 }  // namespace gui

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -46,9 +46,10 @@
 namespace sta {
 class dbSta;
 }
+#endif
 
 namespace gui {
-
+#ifdef ENABLE_CHARTS
 class ChartsWidget : public QDockWidget
 {
   Q_OBJECT

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -88,9 +88,6 @@ class ChartsWidget : public QDockWidget
 
  public:
   ChartsWidget(QWidget* parent = nullptr);
-
- private:
-  QLabel* label_;
 };
 #endif
 }  // namespace gui

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -53,9 +53,7 @@
 
 #include "browserWidget.h"
 #include "bufferTreeDescriptor.h"
-#ifdef ENABLE_CHARTS
 #include "chartsWidget.h"
-#endif
 #include "clockWidget.h"
 #include "dbDescriptors.h"
 #include "displayControls.h"
@@ -105,9 +103,7 @@ MainWindow::MainWindow(QWidget* parent)
       clock_viewer_(new ClockWidget(this)),
       hierarchy_widget_(
           new BrowserWidget(viewers_->getModuleSettings(), controls_, this)),
-#ifdef ENABLE_CHARTS
       charts_widget_(new ChartsWidget(this)),
-#endif
       find_dialog_(new FindObjectDialog(this)),
       goto_dialog_(new GotoLocationDialog(this, viewers_))
 {
@@ -129,9 +125,7 @@ MainWindow::MainWindow(QWidget* parent)
   addDockWidget(Qt::RightDockWidgetArea, timing_widget_);
   addDockWidget(Qt::RightDockWidgetArea, drc_viewer_);
   addDockWidget(Qt::RightDockWidgetArea, clock_viewer_);
-#ifdef ENABLE_CHARTS
   addDockWidget(Qt::RightDockWidgetArea, charts_widget_);
-#endif
 
   tabifyDockWidget(selection_browser_, script_);
   selection_browser_->hide();
@@ -682,9 +676,7 @@ void MainWindow::createMenus()
   windows_menu_->addAction(drc_viewer_->toggleViewAction());
   windows_menu_->addAction(clock_viewer_->toggleViewAction());
   windows_menu_->addAction(hierarchy_widget_->toggleViewAction());
-#ifdef ENABLE_CHARTS
   windows_menu_->addAction(charts_widget_->toggleViewAction());
-#endif
 
   auto option_menu = menuBar()->addMenu("&Options");
   option_menu->addAction(hide_option_);

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -66,9 +66,7 @@ class TimingWidget;
 class DRCWidget;
 class ClockWidget;
 class BrowserWidget;
-#ifdef ENABLE_CHARTS
 class ChartsWidget;
-#endif
 
 // This is the main window for the GUI.  Currently we use a single
 // instance of this class.
@@ -299,9 +297,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   DRCWidget* drc_viewer_;
   ClockWidget* clock_viewer_;
   BrowserWidget* hierarchy_widget_;
-#ifdef ENABLE_CHARTS
   ChartsWidget* charts_widget_;
-#endif
 
   FindObjectDialog* find_dialog_;
   GotoLocationDialog* goto_dialog_;


### PR DESCRIPTION
Resolves #4433 

With these changes, Charts will always be built within the GUI, but if QtCharts is not installed, a message will be displayed "QtCharts is not installed".

![Screenshot from 2024-01-15 14-58-16](https://github.com/The-OpenROAD-Project/OpenROAD/assets/104802710/619b5058-b9ef-49e2-8d76-34eb65e56fbf)
