### PR TITLE
deltaDebug.py: abort immediately if we can't find the error

### DIFF
--- a/etc/deltaDebug.py
+++ b/etc/deltaDebug.py
@@ -20,6 +20,7 @@
 
 import odb
 import os
+import sys
 import signal
 import subprocess
 import argparse
@@ -103,7 +104,9 @@ class deltaDebugger:
 
         # Perform a step with no cuts to measure timeout
         print("Performing a step with the original input file to calculate timeout.")
-        self.perform_step()
+        if self.perform_step() is None:
+            print("No error found in the original input file.")
+            sys.exit(1)
 
         while (True):
             err = None


### PR DESCRIPTION
Don't continue doomed run if the error string couldn't be found.

```
$ openroad -python ~/OpenROAD-flow-scripts/tools/OpenROAD/etc/deltaDebug.py --persistence 3 --use_stdout --error_string "signal 11" --base_db_path bazel-bin/results/asap7/ChipTop/flat/3_2_place_iop.odb --step "echo hello"
OpenROAD v2.0-11865-g6471c0995 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING ORD-0039] .openroad ignored with -python
Backing up original base file.
Performing a step with the original input file to calculate timeout.
No error found in the original input file.
Traceback (most recent call last):
  File "/home/oyvind/OpenROAD-flow-scripts/tools/OpenROAD/etc/deltaDebug.py", line 325, in <module>
    debugger.debug()
  File "/home/oyvind/OpenROAD-flow-scripts/tools/OpenROAD/etc/deltaDebug.py", line 109, in debug
    sys.exit(1)
SystemExit: 1
>>> 
```