### PR TITLE
odb: fix std::variant bug

### DIFF
--- a/src/odb/include/odb/dbStream.h
+++ b/src/odb/include/odb/dbStream.h
@@ -424,7 +424,7 @@ class dbIStream
     return *this;
   }
 
-  template <uint32_t I = 0, typename... Ts>
+  template <typename... Ts>
   dbIStream& operator>>(std::variant<Ts...>& v)
   {
     uint32_t index = 0;
@@ -447,9 +447,11 @@ class dbIStream
       return *this;
     } else {
       if (I == index) {
-        *this >> std::get<I>(v);
+        std::variant_alternative_t<I, std::variant<Ts...>> val;
+        *this >> val;
+        v = val;
       }
-      return ((*this).operator>><I + 1>(v));
+      return (*this).variantHelper<I + 1>(index, v);
     }
   }
 };


### PR DESCRIPTION
Working on some unit tests for Scan Chains in odb I found two bugs:

1. variantHelper was recursing on the wrong function (operator>> instead of variantHelper)
2. std::get<N> do not work in this case because std::variant default initialization is the first value so we get an exception trying to get any std::get<N> for N>0