### PR TITLE
ord: provide access functions to version information to avoid recompiling modules on commit changes

### DIFF
--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -247,8 +247,8 @@ class OpenRoad
   void addObserver(OpenRoadObserver* observer);
   void removeObserver(OpenRoadObserver* observer);
 
-  const char* getVersion() const;
-  const char* getGitDescribe() const;
+  static const char* getVersion();
+  static const char* getGitDescribe();
 
  protected:
   ~OpenRoad();

--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -247,6 +247,9 @@ class OpenRoad
   void addObserver(OpenRoadObserver* observer);
   void removeObserver(OpenRoadObserver* observer);
 
+  const char* getVersion() const;
+  const char* getGitDescribe() const;
+
  protected:
   ~OpenRoad();
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -247,8 +247,9 @@ int main(int argc, char* argv[])
     return 0;
   }
   if (argc == 2 && stringEq(argv[1], "-version")) {
-    ord::OpenRoad* openroad = ord::OpenRoad::openRoad();
-    printf("%s %s\n", openroad->getVersion(), openroad->getGitDescribe());
+    printf("%s %s\n",
+           ord::OpenRoad::getVersion(),
+           ord::OpenRoad::getGitDescribe());
     return 0;
   }
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -491,10 +491,10 @@ static void showUsage(const char* prog, const char* init_filename)
 
 static void showSplash()
 {
-  ord::OpenRoad* openroad = ord::OpenRoad::openRoad();
-  utl::Logger* logger = openroad->getLogger();
-  logger->report(
-      "OpenROAD {} {}", openroad->getVersion(), openroad->getGitDescribe());
+  utl::Logger* logger = ord::OpenRoad::openRoad()->getLogger();
+  logger->report("OpenROAD {} {}",
+                 ord::OpenRoad::getVersion(),
+                 ord::OpenRoad::getGitDescribe());
   logger->report(
       "This program is licensed under the BSD-3 license. See the LICENSE file "
       "for details.");

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -67,7 +67,6 @@
 #include "gui/gui.h"
 #include "ord/InitOpenRoad.hh"
 #include "ord/OpenRoad.hh"
-#include "ord/Version.hh"
 #include "sta/StaMain.hh"
 #include "sta/StringUtil.hh"
 #include "utl/Logger.h"
@@ -248,7 +247,8 @@ int main(int argc, char* argv[])
     return 0;
   }
   if (argc == 2 && stringEq(argv[1], "-version")) {
-    printf("%s %s\n", OPENROAD_VERSION, OPENROAD_GIT_DESCRIBE);
+    ord::OpenRoad* openroad = ord::OpenRoad::openRoad();
+    printf("%s %s\n", openroad->getVersion(), openroad->getGitDescribe());
     return 0;
   }
 
@@ -490,9 +490,10 @@ static void showUsage(const char* prog, const char* init_filename)
 
 static void showSplash()
 {
-  utl::Logger* logger = ord::OpenRoad::openRoad()->getLogger();
-  string sha = OPENROAD_GIT_DESCRIBE;
-  logger->report("OpenROAD {} {}", OPENROAD_VERSION, sha.c_str());
+  ord::OpenRoad* openroad = ord::OpenRoad::openRoad();
+  utl::Logger* logger = openroad->getLogger();
+  logger->report(
+      "OpenROAD {} {}", openroad->getVersion(), openroad->getGitDescribe());
   logger->report(
       "This program is licensed under the BSD-3 license. See the LICENSE file "
       "for details.");

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -619,12 +619,12 @@ int OpenRoad::getThreadCount()
   return threads_;
 }
 
-const char* OpenRoad::getVersion() const
+const char* OpenRoad::getVersion()
 {
   return OPENROAD_VERSION;
 }
 
-const char* OpenRoad::getGitDescribe() const
+const char* OpenRoad::getGitDescribe()
 {
   return OPENROAD_GIT_DESCRIBE;
 }

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -38,6 +38,8 @@
 #include <fstream>
 #include <iostream>
 #include <thread>
+
+#include "ord/Version.hh"
 #ifdef ENABLE_PYTHON3
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
@@ -615,6 +617,16 @@ void OpenRoad::setThreadCount(const char* threads, bool printInfo)
 int OpenRoad::getThreadCount()
 {
   return threads_;
+}
+
+const char* OpenRoad::getVersion() const
+{
+  return OPENROAD_VERSION;
+}
+
+const char* OpenRoad::getGitDescribe() const
+{
+  return OPENROAD_GIT_DESCRIBE;
 }
 
 }  // namespace ord

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -294,15 +294,13 @@ using odb::dbTech;
 const char *
 openroad_version()
 {
-  OpenRoad *openroad = getOpenRoad();
-  return openroad->getVersion();
+  return ord::OpenRoad::getVersion();
 }
 
 const char *
 openroad_git_describe()
 {
-  OpenRoad *openroad = getOpenRoad();
-  return openroad->getGitDescribe();
+  return ord::OpenRoad::getGitDescribe();
 }
 
 void

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -44,7 +44,6 @@
 #include "db_sta/dbSta.hh"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbReadVerilog.hh"
-#include "ord/Version.hh"
 #include "utl/Logger.h"
 #include "ord/OpenRoad.hh"
 
@@ -295,13 +294,15 @@ using odb::dbTech;
 const char *
 openroad_version()
 {
-  return OPENROAD_VERSION;
+  OpenRoad *openroad = getOpenRoad();
+  return openroad->getVersion();
 }
 
 const char *
 openroad_git_describe()
 {
-  return OPENROAD_GIT_DESCRIBE;
+  OpenRoad *openroad = getOpenRoad();
+  return openroad->getGitDescribe();
 }
 
 void

--- a/src/rcx/src/MakeOpenRCX.cpp
+++ b/src/rcx/src/MakeOpenRCX.cpp
@@ -64,7 +64,7 @@ void initOpenRCX(OpenRoad* openroad)
 {
   openroad->getOpenRCX()->init(openroad->getDb(),
                                openroad->getLogger(),
-                               openroad->getVersion(),
+                               ord::OpenRoad::getVersion(),
                                [openroad] {
                                  rcx::Rcx_Init(openroad->tclInterp());
                                  sta::evalTclInit(openroad->tclInterp(),

--- a/src/rcx/src/MakeOpenRCX.cpp
+++ b/src/rcx/src/MakeOpenRCX.cpp
@@ -34,7 +34,6 @@
 #include "rcx/MakeOpenRCX.h"
 
 #include "ord/OpenRoad.hh"
-#include "ord/Version.hh"
 #include "rcx/ext.h"
 #include "sta/StaMain.hh"
 
@@ -63,11 +62,14 @@ void deleteOpenRCX(rcx::Ext* extractor)
 
 void initOpenRCX(OpenRoad* openroad)
 {
-  openroad->getOpenRCX()->init(
-      openroad->getDb(), openroad->getLogger(), OPENROAD_VERSION, [openroad] {
-        rcx::Rcx_Init(openroad->tclInterp());
-        sta::evalTclInit(openroad->tclInterp(), sta::rcx_tcl_inits);
-      });
+  openroad->getOpenRCX()->init(openroad->getDb(),
+                               openroad->getLogger(),
+                               openroad->getVersion(),
+                               [openroad] {
+                                 rcx::Rcx_Init(openroad->tclInterp());
+                                 sta::evalTclInit(openroad->tclInterp(),
+                                                  sta::rcx_tcl_inits);
+                               });
 }
 
 }  // namespace ord


### PR DESCRIPTION
No functional changes.

Changes:
- Moves OpenROAD version functionality to the OpenROAD object and removing the dependency on Version.hh everywhere except for the openroad object.