### PR TITLE
gui: controls for shape types

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -432,15 +432,25 @@ DisplayControls::DisplayControls(QWidget* parent)
   // Shape type group
   auto shape_types
       = makeParentItem(shape_type_group_, "Shape Types", root, Qt::Checked);
-  makeLeafItem(shape_types_.routing, "Routing", shape_types, Qt::Checked);
-  makeLeafItem(shape_types_.vias, "Vias", shape_types, Qt::Checked);
-  makeLeafItem(shape_types_.special_routing,
-               "Special routing",
-               shape_types,
+  auto shape_types_routing = makeParentItem(
+      shape_types_.routing_group, "Routing", shape_types, Qt::Checked);
+  makeLeafItem(shape_types_.routing.segments,
+               "Segments",
+               shape_types_routing,
                Qt::Checked);
-  makeLeafItem(shape_types_.special_routing_vias,
-               "Special routing vias",
-               shape_types,
+  makeLeafItem(
+      shape_types_.routing.vias, "Vias", shape_types_routing, Qt::Checked);
+  auto shape_types_srouting = makeParentItem(shape_types_.special_routing_group,
+                                             "Special Routing",
+                                             shape_types,
+                                             Qt::Checked);
+  makeLeafItem(shape_types_.special_routing.segments,
+               "Segments",
+               shape_types_srouting,
+               Qt::Checked);
+  makeLeafItem(shape_types_.special_routing.vias,
+               "Vias",
+               shape_types_srouting,
                Qt::Checked);
   makeLeafItem(shape_types_.pins, "Pins", shape_types, Qt::Checked);
   pin_markers_font_ = QApplication::font();  // use default font
@@ -1685,24 +1695,24 @@ bool DisplayControls::areIOPinsVisible() const
   return isModelRowVisible(&shape_types_.pins);
 }
 
-bool DisplayControls::isRoutingVisible() const
+bool DisplayControls::areRoutingSegmentsVisible() const
 {
-  return isModelRowVisible(&shape_types_.routing);
+  return isModelRowVisible(&shape_types_.routing.segments);
 }
 
-bool DisplayControls::areViasVisible() const
+bool DisplayControls::areRoutingViasVisible() const
 {
-  return isModelRowVisible(&shape_types_.vias);
+  return isModelRowVisible(&shape_types_.routing.vias);
 }
 
-bool DisplayControls::isSpecialRoutingVisible() const
+bool DisplayControls::areSpecialRoutingSegmentsVisible() const
 {
-  return isModelRowVisible(&shape_types_.special_routing);
+  return isModelRowVisible(&shape_types_.special_routing.segments);
 }
 
 bool DisplayControls::areSpecialRoutingViasVisible() const
 {
-  return isModelRowVisible(&shape_types_.special_routing_vias);
+  return isModelRowVisible(&shape_types_.special_routing.vias);
 }
 
 bool DisplayControls::areFillsVisible() const

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -422,20 +422,34 @@ DisplayControls::DisplayControls(QWidget* parent)
   // Rows / sites
   makeParentItem(site_group_, "Rows", root, Qt::Unchecked, true);
 
-  // Rows
-  makeParentItem(io_pins_, "Pins", root, Qt::Checked);
-  pin_markers_font_ = QApplication::font();  // use default font
-  setNameItemDoubleClickAction(io_pins_, [this]() {
-    pin_markers_font_ = QFontDialog::getFont(
-        nullptr, pin_markers_font_, this, "Pin marker font");
-  });
-
   // Track patterns group
   auto tracks = makeParentItem(tracks_group_, "Tracks", root, Qt::Unchecked);
 
   makeLeafItem(tracks_.pref, "Pref", tracks, Qt::Unchecked);
   makeLeafItem(tracks_.non_pref, "Non Pref", tracks, Qt::Unchecked);
   toggleParent(tracks_group_);
+
+  // Shape type group
+  auto shape_types
+      = makeParentItem(shape_type_group_, "Shape Types", root, Qt::Checked);
+  makeLeafItem(shape_types_.routing, "Routing", shape_types, Qt::Checked);
+  makeLeafItem(shape_types_.vias, "Vias", shape_types, Qt::Checked);
+  makeLeafItem(shape_types_.special_routing,
+               "Special routing",
+               shape_types,
+               Qt::Checked);
+  makeLeafItem(shape_types_.special_routing_vias,
+               "Special routing vias",
+               shape_types,
+               Qt::Checked);
+  makeLeafItem(shape_types_.pins, "Pins", shape_types, Qt::Checked);
+  pin_markers_font_ = QApplication::font();  // use default font
+  setNameItemDoubleClickAction(shape_types_.pins, [this]() {
+    pin_markers_font_ = QFontDialog::getFont(
+        nullptr, pin_markers_font_, this, "Pin marker font");
+  });
+  makeLeafItem(shape_types_.fill, "Fills", shape_types, Qt::Unchecked);
+  toggleParent(shape_type_group_);
 
   // Misc group
   auto misc = makeParentItem(misc_group_, "Misc", root, Qt::Unchecked, true);
@@ -477,7 +491,6 @@ DisplayControls::DisplayControls(QWidget* parent)
   region_color_ = QColor(0x70, 0x70, 0x70, 0x70);  // semi-transparent mid-gray
   region_pattern_ = Qt::SolidPattern;
   makeLeafItem(misc_.scale_bar, "Scale bar", misc, Qt::Checked);
-  makeLeafItem(misc_.fills, "Fills", misc, Qt::Unchecked);
   makeLeafItem(misc_.access_points, "Access points", misc, Qt::Unchecked);
   makeLeafItem(
       misc_.regions, "Regions", misc, Qt::Checked, true, region_color_);
@@ -655,9 +668,9 @@ void DisplayControls::readSettings(QSettings* settings)
   readSettingsForRow(settings, nets_group_);
   readSettingsForRow(settings, instance_group_);
   readSettingsForRow(settings, blockage_group_);
-  readSettingsForRow(settings, io_pins_);
   readSettingsForRow(settings, rulers_);
   readSettingsForRow(settings, tracks_group_);
+  readSettingsForRow(settings, shape_type_group_);
   readSettingsForRow(settings, misc_group_);
 
   readSettingsForRow(settings, site_group_, false);
@@ -729,9 +742,9 @@ void DisplayControls::writeSettings(QSettings* settings)
   writeSettingsForRow(settings, nets_group_);
   writeSettingsForRow(settings, instance_group_);
   writeSettingsForRow(settings, blockage_group_);
-  writeSettingsForRow(settings, io_pins_);
   writeSettingsForRow(settings, rulers_);
   writeSettingsForRow(settings, tracks_group_);
+  writeSettingsForRow(settings, shape_type_group_);
   writeSettingsForRow(settings, misc_group_);
   writeSettingsForRow(settings, site_group_, false);
 
@@ -1547,11 +1560,6 @@ bool DisplayControls::areInstanceBlockagesVisible()
   return isModelRowVisible(&instance_shapes_.blockages);
 }
 
-bool DisplayControls::areFillsVisible()
-{
-  return isModelRowVisible(&misc_.fills);
-}
-
 bool DisplayControls::areRulersVisible()
 {
   return isModelRowVisible(&rulers_);
@@ -1647,16 +1655,6 @@ bool DisplayControls::isScaleBarVisible() const
   return isModelRowVisible(&misc_.scale_bar);
 }
 
-bool DisplayControls::areIOPinsVisible() const
-{
-  return isModelRowVisible(&io_pins_);
-}
-
-QFont DisplayControls::pinMarkersFont()
-{
-  return pin_markers_font_;
-}
-
 bool DisplayControls::areAccessPointsVisible() const
 {
   return isModelRowVisible(&misc_.access_points);
@@ -1680,6 +1678,41 @@ bool DisplayControls::isModuleView() const
 bool DisplayControls::isGCellGridVisible() const
 {
   return isModelRowVisible(&misc_.gcell_grid);
+}
+
+bool DisplayControls::areIOPinsVisible() const
+{
+  return isModelRowVisible(&shape_types_.pins);
+}
+
+bool DisplayControls::isRoutingVisible() const
+{
+  return isModelRowVisible(&shape_types_.routing);
+}
+
+bool DisplayControls::areViasVisible() const
+{
+  return isModelRowVisible(&shape_types_.vias);
+}
+
+bool DisplayControls::isSpecialRoutingVisible() const
+{
+  return isModelRowVisible(&shape_types_.special_routing);
+}
+
+bool DisplayControls::areSpecialRoutingViasVisible() const
+{
+  return isModelRowVisible(&shape_types_.special_routing_vias);
+}
+
+bool DisplayControls::areFillsVisible() const
+{
+  return isModelRowVisible(&shape_types_.fill);
+}
+
+QFont DisplayControls::pinMarkersFont() const
+{
+  return pin_markers_font_;
 }
 
 void DisplayControls::registerRenderer(Renderer* renderer)

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -229,9 +229,9 @@ class DisplayControls : public QDockWidget,
   bool areNonPrefTracksVisible() override;
 
   bool areIOPinsVisible() const override;
-  bool isRoutingVisible() const override;
-  bool areViasVisible() const override;
-  bool isSpecialRoutingVisible() const override;
+  bool areRoutingSegmentsVisible() const override;
+  bool areRoutingViasVisible() const override;
+  bool areSpecialRoutingSegmentsVisible() const override;
   bool areSpecialRoutingViasVisible() const override;
   bool areFillsVisible() const override;
   QFont pinMarkersFont() const override;
@@ -397,12 +397,18 @@ class DisplayControls : public QDockWidget,
     ModelRow blockages;
   };
 
+  struct RoutingModels
+  {
+    ModelRow segments;
+    ModelRow vias;
+  };
+
   struct ShapeTypeModels
   {
-    ModelRow routing;
-    ModelRow vias;
-    ModelRow special_routing;
-    ModelRow special_routing_vias;
+    ModelRow routing_group;
+    RoutingModels routing;
+    ModelRow special_routing_group;
+    RoutingModels special_routing;
     ModelRow pins;
     ModelRow fill;
   };

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -217,7 +217,6 @@ class DisplayControls : public QDockWidget,
   bool areInstancePinsSelectable() override;
   bool areInstancePinNamesVisible() override;
   bool areInstanceBlockagesVisible() override;
-  bool areFillsVisible() override;
   bool areBlockagesVisible() override;
   bool areBlockagesSelectable() override;
   bool areObstructionsVisible() override;
@@ -229,6 +228,14 @@ class DisplayControls : public QDockWidget,
   bool arePrefTracksVisible() override;
   bool areNonPrefTracksVisible() override;
 
+  bool areIOPinsVisible() const override;
+  bool isRoutingVisible() const override;
+  bool areViasVisible() const override;
+  bool isSpecialRoutingVisible() const override;
+  bool areSpecialRoutingViasVisible() const override;
+  bool areFillsVisible() const override;
+  QFont pinMarkersFont() const override;
+
   QColor rulerColor() override;
   QFont rulerFont() override;
   bool areRulersVisible() override;
@@ -239,8 +246,6 @@ class DisplayControls : public QDockWidget,
   bool areSelectedVisible() override;
 
   bool isScaleBarVisible() const override;
-  bool areIOPinsVisible() const override;
-  QFont pinMarkersFont() override;
   bool areAccessPointsVisible() const override;
   bool areRegionsVisible() const override;
   bool areRegionsSelectable() const override;
@@ -375,7 +380,6 @@ class DisplayControls : public QDockWidget,
   {
     ModelRow instances;
     ModelRow scale_bar;
-    ModelRow fills;
     ModelRow access_points;
     ModelRow regions;
     ModelRow detailed;
@@ -391,6 +395,16 @@ class DisplayControls : public QDockWidget,
     ModelRow pins;
     ModelRow iterm_labels;
     ModelRow blockages;
+  };
+
+  struct ShapeTypeModels
+  {
+    ModelRow routing;
+    ModelRow vias;
+    ModelRow special_routing;
+    ModelRow special_routing_vias;
+    ModelRow pins;
+    ModelRow fill;
   };
 
   void techInit(odb::dbTech* tech);
@@ -491,6 +505,7 @@ class DisplayControls : public QDockWidget,
   ModelRow blockage_group_;
   ModelRow misc_group_;
   ModelRow site_group_;
+  ModelRow shape_type_group_;
 
   // instances
   InstanceModels instances_;
@@ -501,10 +516,10 @@ class DisplayControls : public QDockWidget,
   PhysicalModels physical_instances_;
 
   InstanceShapeModels instance_shapes_;
+  ShapeTypeModels shape_types_;
 
   // Object controls
   NetModels nets_;
-  ModelRow io_pins_;
   ModelRow rulers_;
   BlockageModels blockages_;
   TrackModels tracks_;

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -615,8 +615,8 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
       }
     }
 
-    const bool routing_visible = options_->isRoutingVisible();
-    const bool vias_visible = options_->areViasVisible();
+    const bool routing_visible = options_->areRoutingSegmentsVisible();
+    const bool vias_visible = options_->areRoutingViasVisible();
     if (routing_visible || vias_visible) {
       auto box_shapes = search_.searchBoxShapes(block_,
                                                 layer,
@@ -654,7 +654,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
       }
     }
 
-    if (options_->isSpecialRoutingVisible()) {
+    if (options_->areSpecialRoutingSegmentsVisible()) {
       auto polygon_shapes = search_.searchSNetShapes(block_,
                                                      layer,
                                                      search_line.xMin(),
@@ -833,8 +833,8 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
       }
     }
 
-    const bool routing_visible = options_->isRoutingVisible();
-    const bool vias_visible = options_->areViasVisible();
+    const bool routing_visible = options_->areRoutingSegmentsVisible();
+    const bool vias_visible = options_->areRoutingViasVisible();
     if (routing_visible || vias_visible) {
       auto box_shapes = search_.searchBoxShapes(block_,
                                                 layer,
@@ -870,7 +870,7 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
       }
     }
 
-    if (options_->isSpecialRoutingVisible()) {
+    if (options_->areSpecialRoutingSegmentsVisible()) {
       auto polygon_shapes = search_.searchSNetShapes(block_,
                                                      layer,
                                                      region.xMin(),

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -84,9 +84,9 @@ class Options
   virtual bool areNonPrefTracksVisible() = 0;
 
   virtual bool areIOPinsVisible() const = 0;
-  virtual bool isRoutingVisible() const = 0;
-  virtual bool areViasVisible() const = 0;
-  virtual bool isSpecialRoutingVisible() const = 0;
+  virtual bool areRoutingSegmentsVisible() const = 0;
+  virtual bool areRoutingViasVisible() const = 0;
+  virtual bool areSpecialRoutingSegmentsVisible() const = 0;
   virtual bool areSpecialRoutingViasVisible() const = 0;
   virtual bool areFillsVisible() const = 0;
   virtual QFont pinMarkersFont() const = 0;

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -72,7 +72,6 @@ class Options
   virtual bool areInstancePinsSelectable() = 0;
   virtual bool areInstancePinNamesVisible() = 0;
   virtual bool areInstanceBlockagesVisible() = 0;
-  virtual bool areFillsVisible() = 0;
   virtual bool areBlockagesVisible() = 0;
   virtual bool areBlockagesSelectable() = 0;
   virtual bool areObstructionsVisible() = 0;
@@ -84,6 +83,14 @@ class Options
   virtual bool arePrefTracksVisible() = 0;
   virtual bool areNonPrefTracksVisible() = 0;
 
+  virtual bool areIOPinsVisible() const = 0;
+  virtual bool isRoutingVisible() const = 0;
+  virtual bool areViasVisible() const = 0;
+  virtual bool isSpecialRoutingVisible() const = 0;
+  virtual bool areSpecialRoutingViasVisible() const = 0;
+  virtual bool areFillsVisible() const = 0;
+  virtual QFont pinMarkersFont() const = 0;
+
   virtual QColor rulerColor() = 0;
   virtual QFont rulerFont() = 0;
   virtual bool areRulersVisible() = 0;
@@ -94,8 +101,6 @@ class Options
   virtual bool areSelectedVisible() = 0;
 
   virtual bool isScaleBarVisible() const = 0;
-  virtual bool areIOPinsVisible() const = 0;
-  virtual QFont pinMarkersFont() = 0;
   virtual bool areAccessPointsVisible() const = 0;
   virtual bool areRegionsVisible() const = 0;
   virtual bool areRegionsSelectable() const = 0;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -923,7 +923,7 @@ void RenderThread::drawLayer(QPainter* painter,
       }
     }
 
-    if (draw_shapes && viewer_->options_->areSpecialRoutingViasVisible()) {
+    if (viewer_->options_->areSpecialRoutingViasVisible()) {
       if (layer->getType() == dbTechLayerType::CUT) {
         drawViaShapes(painter, block, layer, layer, bounds, shape_limit);
       } else {

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -884,8 +884,8 @@ void RenderThread::drawLayer(QPainter* painter,
 
   drawObstructions(block, layer, painter, bounds);
 
-  const bool draw_routing = viewer_->options_->isRoutingVisible();
-  const bool draw_vias = viewer_->options_->areViasVisible();
+  const bool draw_routing = viewer_->options_->areRoutingSegmentsVisible();
+  const bool draw_vias = viewer_->options_->areRoutingViasVisible();
   // Now draw the shapes
   QColor color = getColor(layer);
   Qt::BrushStyle brush_pattern = getPattern(layer);
@@ -944,7 +944,7 @@ void RenderThread::drawLayer(QPainter* painter,
       }
     }
 
-    if (viewer_->options_->isSpecialRoutingVisible()) {
+    if (viewer_->options_->areSpecialRoutingSegmentsVisible()) {
       auto polygon_iter = viewer_->search_.searchSNetShapes(block,
                                                             layer,
                                                             bounds.xMin(),

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -996,6 +996,18 @@ void RenderThread::drawLayer(QPainter* painter,
   }
 
   if (draw_shapes) {
+    if (viewer_->options_->areIOPinsVisible()) {
+      utl::Timer io_pins;
+      drawIOPins(gui_painter, block, bounds, layer);
+      debugPrint(logger_,
+                 GUI,
+                 "draw",
+                 1,
+                 "io pins on {} {}",
+                 layer->getName(),
+                 io_pins);
+    }
+
     drawTracks(layer, painter, bounds);
     drawRouteGuides(gui_painter, layer);
     drawNetTracks(gui_painter, layer);
@@ -1074,6 +1086,10 @@ void RenderThread::drawBlock(QPainter* painter,
   }
   debugPrint(logger_, GUI, "draw", 1, "inst search {}", inst_timer);
 
+  utl::Timer io_pins_setup;
+  setupIOPins(block, bounds);
+  debugPrint(logger_, GUI, "draw", 1, "io pins setup {}", io_pins_setup);
+
   utl::Timer insts_outline;
   drawInstanceOutlines(painter, insts);
   debugPrint(logger_, GUI, "draw", 1, "inst outline render {}", insts_outline);
@@ -1133,12 +1149,6 @@ void RenderThread::drawBlock(QPainter* painter,
   utl::Timer inst_regions;
   drawRegions(painter, block);
   debugPrint(logger_, GUI, "draw", 1, "regions {}", inst_regions);
-
-  utl::Timer inst_io_pins;
-  if (viewer_->options_->areIOPinsVisible()) {
-    drawIOPins(gui_painter, block, bounds);
-  }
-  debugPrint(logger_, GUI, "draw", 1, "io pins {}", inst_io_pins);
 
   utl::Timer inst_cell_grid;
   drawGCellGrid(painter, bounds);
@@ -1397,25 +1407,26 @@ void RenderThread::drawModuleView(QPainter* painter,
   }
 }
 
-void RenderThread::drawIOPins(Painter& painter,
-                              odb::dbBlock* block,
-                              const odb::Rect& bounds)
+void RenderThread::setupIOPins(odb::dbBlock* block, const odb::Rect& bounds)
 {
-  auto die_area = block->getDieArea();
-  auto die_width = die_area.dx();
-  auto die_height = die_area.dy();
+  pins_.clear();
+  if (!viewer_->options_->areIOPinsVisible()) {
+    return;
+  }
+
+  const auto die_area = block->getDieArea();
+  const auto die_width = die_area.dx();
+  const auto die_height = die_area.dy();
 
   const double scale_factor
       = 0.02;  // 4 Percent of bounds is used to draw pin-markers
   const int die_max_dim
       = std::min(std::max(die_width, die_height), bounds.maxDXDY());
   const double abs_min_dim = 8.0;  // prevent markers from falling apart
-  const double max_dim = std::max(scale_factor * die_max_dim, abs_min_dim);
+  pin_max_size_ = std::max(scale_factor * die_max_dim, abs_min_dim);
 
-  QPainter* qpainter = static_cast<GuiPainter&>(painter).getPainter();
-  const QFont initial_font = qpainter->font();
-  QFont marker_font = viewer_->options_->pinMarkersFont();
-  const QFontMetrics font_metrics(marker_font);
+  pin_font_ = viewer_->options_->pinMarkersFont();
+  const QFontMetrics font_metrics(pin_font_);
 
   QString largest_text;
   for (auto pin : block->getBTerms()) {
@@ -1437,9 +1448,9 @@ void RenderThread::drawIOPins(Painter& painter,
 
   const int available_space
       = std::min(vertical_gap, horizontal_gap)
-        - std::ceil(max_dim) * viewer_->pixels_per_dbu_;  // in pixels
+        - std::ceil(pin_max_size_) * viewer_->pixels_per_dbu_;  // in pixels
 
-  int font_size = marker_font.pointSize();
+  int font_size = pin_font_.pointSize();
   int largest_text_width = font_metrics.boundingRect(largest_text).width();
   const int drawing_font_size = 6;  // in points
 
@@ -1451,35 +1462,74 @@ void RenderThread::drawIOPins(Painter& painter,
       break;
     }
     font_size -= 1;
-    marker_font.setPointSize(font_size);
-    QFontMetrics current_font_metrics(marker_font);
+    pin_font_.setPointSize(font_size);
+    QFontMetrics current_font_metrics(pin_font_);
     largest_text_width
         = current_font_metrics.boundingRect(largest_text).width();
   }
 
-  qpainter->setFont(marker_font);
-
   // draw names of pins when text height is at least 6 pts
-  const bool draw_names = font_size >= drawing_font_size;
+  pin_draw_names_ = font_size >= drawing_font_size;
+
+  for (odb::dbBTerm* term : block->getBTerms()) {
+    if (restart_) {
+      break;
+    }
+    if (!viewer_->isNetVisible(term->getNet())) {
+      continue;
+    }
+    for (odb::dbBPin* pin : term->getBPins()) {
+      odb::dbPlacementStatus status = pin->getPlacementStatus();
+      if (!status.isPlaced()) {
+        continue;
+      }
+      for (odb::dbBox* box : pin->getBoxes()) {
+        if (!box) {
+          continue;
+        }
+
+        pins_[box->getTechLayer()].emplace_back(term, box);
+      }
+    }
+  }
+}
+
+void RenderThread::drawIOPins(Painter& painter,
+                              odb::dbBlock* block,
+                              const odb::Rect& bounds,
+                              odb::dbTechLayer* layer)
+{
+  const auto& pins = pins_[layer];
+  if (pins.empty()) {
+    return;
+  }
+
+  const auto die_area = block->getDieArea();
+
+  QPainter* qpainter = static_cast<GuiPainter&>(painter).getPainter();
+  const QFont initial_font = qpainter->font();
+  qpainter->setFont(pin_font_);
+
   const int text_margin = 2.0 / viewer_->pixels_per_dbu_;
 
   // templates of pin markers (block top)
   const std::vector<Point> in_marker{// arrow head pointing in to block
-                                     Point(max_dim / 4, max_dim),
+                                     Point(pin_max_size_ / 4, pin_max_size_),
                                      Point(0, 0),
-                                     Point(-max_dim / 4, max_dim),
-                                     Point(max_dim / 4, max_dim)};
+                                     Point(-pin_max_size_ / 4, pin_max_size_),
+                                     Point(pin_max_size_ / 4, pin_max_size_)};
   const std::vector<Point> out_marker{// arrow head pointing out of block
-                                      Point(0, max_dim),
-                                      Point(-max_dim / 4, 0),
-                                      Point(max_dim / 4, 0),
-                                      Point(0, max_dim)};
-  const std::vector<Point> bi_marker{// diamond
-                                     Point(0, 0),
-                                     Point(-max_dim / 4, max_dim / 2),
-                                     Point(0, max_dim),
-                                     Point(max_dim / 4, max_dim / 2),
-                                     Point(0, 0)};
+                                      Point(0, pin_max_size_),
+                                      Point(-pin_max_size_ / 4, 0),
+                                      Point(pin_max_size_ / 4, 0),
+                                      Point(0, pin_max_size_)};
+  const std::vector<Point> bi_marker{
+      // diamond
+      Point(0, 0),
+      Point(-pin_max_size_ / 4, pin_max_size_ / 2),
+      Point(0, pin_max_size_),
+      Point(pin_max_size_ / 4, pin_max_size_ / 2),
+      Point(0, 0)};
 
   // RTree used to search for overlapping shapes and decide if rotation of
   // text is needed.
@@ -1488,142 +1538,128 @@ void RenderThread::drawIOPins(Painter& painter,
   {
     Search::Box rect;
     bool can_rotate;
-    odb::dbTechLayer* layer;
     std::string text;
     odb::Point pt;
     Painter::Anchor anchor;
   };
   std::vector<PinText> pin_text_spec;
 
-  for (odb::dbBTerm* term : block->getBTerms()) {
+  painter.setPen(layer);
+  painter.setBrush(layer);
+
+  for (const auto& [term, box] : pins) {
     if (restart_) {
       break;
     }
-    for (odb::dbBPin* pin : term->getBPins()) {
-      odb::dbPlacementStatus status = pin->getPlacementStatus();
-      if (!status.isPlaced()) {
-        continue;
+    const auto pin_dir = term->getIoType();
+
+    Point pin_center((box->xMin() + box->xMax()) / 2,
+                     (box->yMin() + box->yMax()) / 2);
+
+    auto dist_to_left = std::abs(box->xMin() - die_area.xMin());
+    auto dist_to_right = std::abs(box->xMax() - die_area.xMax());
+    auto dist_to_top = std::abs(box->yMax() - die_area.yMax());
+    auto dist_to_bot = std::abs(box->yMin() - die_area.yMin());
+    std::vector<int> dists{
+        dist_to_left, dist_to_right, dist_to_top, dist_to_bot};
+    int arg_min = std::distance(dists.begin(),
+                                std::min_element(dists.begin(), dists.end()));
+
+    odb::dbTransform xfm(pin_center);
+    if (arg_min == 0) {  // left
+      xfm.setOrient(dbOrientType::R90);
+      if (dist_to_left == 0) {  // touching edge so draw on edge
+        xfm.setOffset({die_area.xMin(), pin_center.y()});
       }
-      auto pin_dir = term->getIoType();
-      for (odb::dbBox* box : pin->getBoxes()) {
-        if (!box) {
-          continue;
-        }
-
-        Point pin_center((box->xMin() + box->xMax()) / 2,
-                         (box->yMin() + box->yMax()) / 2);
-
-        auto dist_to_left = std::abs(box->xMin() - die_area.xMin());
-        auto dist_to_right = std::abs(box->xMax() - die_area.xMax());
-        auto dist_to_top = std::abs(box->yMax() - die_area.yMax());
-        auto dist_to_bot = std::abs(box->yMin() - die_area.yMin());
-        std::vector<int> dists{
-            dist_to_left, dist_to_right, dist_to_top, dist_to_bot};
-        int arg_min = std::distance(
-            dists.begin(), std::min_element(dists.begin(), dists.end()));
-
-        odb::dbTransform xfm(pin_center);
-        if (arg_min == 0) {  // left
-          xfm.setOrient(dbOrientType::R90);
-          if (dist_to_left == 0) {  // touching edge so draw on edge
-            xfm.setOffset({die_area.xMin(), pin_center.y()});
-          }
-        } else if (arg_min == 1) {  // right
-          xfm.setOrient(dbOrientType::R270);
-          if (dist_to_right == 0) {  // touching edge so draw on edge
-            xfm.setOffset({die_area.xMax(), pin_center.y()});
-          }
-        } else if (arg_min == 2) {  // top
-          // none needed
-          if (dist_to_top == 0) {  // touching edge so draw on edge
-            xfm.setOffset({pin_center.x(), die_area.yMax()});
-          }
-        } else {  // bottom
-          xfm.setOrient(dbOrientType::MX);
-          if (dist_to_bot == 0) {  // touching edge so draw on edge
-            xfm.setOffset({pin_center.x(), die_area.yMin()});
-          }
-        }
-
-        odb::dbTechLayer* layer = box->getTechLayer();
-        painter.setPen(layer);
-        painter.setBrush(layer);
-
-        // select marker
-        const std::vector<Point>* template_points = &bi_marker;
-        if (pin_dir == odb::dbIoType::INPUT) {
-          template_points = &in_marker;
-        } else if (pin_dir == odb::dbIoType::OUTPUT) {
-          template_points = &out_marker;
-        }
-
-        // make new marker based on pin location
-        std::vector<Point> marker;
-        for (const auto& pt : *template_points) {
-          Point new_pt = pt;
-          xfm.apply(new_pt);
-          marker.push_back(new_pt);
-        }
-
-        // draw marker to indicate signal direction
-        painter.drawPolygon(marker);
-
-        if (!viewer_->isNetVisible(term->getNet())) {
-          // draw pin's geometry only when it's not
-          // already being drawn by its Net
-          painter.drawRect(box->getBox());
-        }
-
-        if (draw_names) {
-          Point text_anchor_pt = xfm.getOffset();
-
-          auto text_anchor = Painter::BOTTOM_CENTER;
-          if (arg_min == 0) {  // left
-            text_anchor = Painter::RIGHT_CENTER;
-            text_anchor_pt.setX(text_anchor_pt.x() - max_dim - text_margin);
-          } else if (arg_min == 1) {  // right
-            text_anchor = Painter::LEFT_CENTER;
-            text_anchor_pt.setX(text_anchor_pt.x() + max_dim + text_margin);
-          } else if (arg_min == 2) {  // top
-            text_anchor = Painter::BOTTOM_CENTER;
-            text_anchor_pt.setY(text_anchor_pt.y() + max_dim + text_margin);
-          } else {  // bottom
-            text_anchor = Painter::TOP_CENTER;
-            text_anchor_pt.setY(text_anchor_pt.y() - max_dim - text_margin);
-          }
-
-          PinText pin_specs;
-          pin_specs.layer = layer;
-          pin_specs.text = term->getName();
-          pin_specs.pt = text_anchor_pt;
-          pin_specs.anchor = text_anchor;
-          pin_specs.can_rotate = arg_min == 2 || arg_min == 3;
-          // only need bounding box when rotation is possible
-          if (pin_specs.can_rotate) {
-            odb::Rect text_rect = painter.stringBoundaries(pin_specs.pt.x(),
-                                                           pin_specs.pt.y(),
-                                                           pin_specs.anchor,
-                                                           pin_specs.text);
-            text_rect.bloat(text_margin, text_rect);
-            pin_specs.rect = Search::Box(
-                Search::Point(text_rect.xMin(), text_rect.yMin()),
-                Search::Point(text_rect.xMax(), text_rect.yMax()));
-            pin_text_spec_shapes.insert(pin_specs.rect);
-          } else {
-            pin_specs.rect = Search::Box();
-          }
-          pin_text_spec.push_back(pin_specs);
-        }
+    } else if (arg_min == 1) {  // right
+      xfm.setOrient(dbOrientType::R270);
+      if (dist_to_right == 0) {  // touching edge so draw on edge
+        xfm.setOffset({die_area.xMax(), pin_center.y()});
+      }
+    } else if (arg_min == 2) {  // top
+      // none needed
+      if (dist_to_top == 0) {  // touching edge so draw on edge
+        xfm.setOffset({pin_center.x(), die_area.yMax()});
+      }
+    } else {  // bottom
+      xfm.setOrient(dbOrientType::MX);
+      if (dist_to_bot == 0) {  // touching edge so draw on edge
+        xfm.setOffset({pin_center.x(), die_area.yMin()});
       }
     }
+
+    // select marker
+    const std::vector<Point>* template_points = &bi_marker;
+    if (pin_dir == odb::dbIoType::INPUT) {
+      template_points = &in_marker;
+    } else if (pin_dir == odb::dbIoType::OUTPUT) {
+      template_points = &out_marker;
+    }
+
+    // make new marker based on pin location
+    std::vector<Point> marker;
+    for (const auto& pt : *template_points) {
+      Point new_pt = pt;
+      xfm.apply(new_pt);
+      marker.push_back(new_pt);
+    }
+
+    // draw marker to indicate signal direction
+    painter.drawPolygon(marker);
+
+    painter.drawRect(box->getBox());
+
+    if (pin_draw_names_) {
+      Point text_anchor_pt = xfm.getOffset();
+
+      auto text_anchor = Painter::BOTTOM_CENTER;
+      if (arg_min == 0) {  // left
+        text_anchor = Painter::RIGHT_CENTER;
+        text_anchor_pt.setX(text_anchor_pt.x() - pin_max_size_ - text_margin);
+      } else if (arg_min == 1) {  // right
+        text_anchor = Painter::LEFT_CENTER;
+        text_anchor_pt.setX(text_anchor_pt.x() + pin_max_size_ + text_margin);
+      } else if (arg_min == 2) {  // top
+        text_anchor = Painter::BOTTOM_CENTER;
+        text_anchor_pt.setY(text_anchor_pt.y() + pin_max_size_ + text_margin);
+      } else {  // bottom
+        text_anchor = Painter::TOP_CENTER;
+        text_anchor_pt.setY(text_anchor_pt.y() - pin_max_size_ - text_margin);
+      }
+
+      PinText pin_specs;
+      pin_specs.text = term->getName();
+      pin_specs.pt = text_anchor_pt;
+      pin_specs.anchor = text_anchor;
+      pin_specs.can_rotate = arg_min == 2 || arg_min == 3;
+      // only need bounding box when rotation is possible
+      if (pin_specs.can_rotate) {
+        odb::Rect text_rect = painter.stringBoundaries(pin_specs.pt.x(),
+                                                       pin_specs.pt.y(),
+                                                       pin_specs.anchor,
+                                                       pin_specs.text);
+        text_rect.bloat(text_margin, text_rect);
+        pin_specs.rect
+            = Search::Box(Search::Point(text_rect.xMin(), text_rect.yMin()),
+                          Search::Point(text_rect.xMax(), text_rect.yMax()));
+        pin_text_spec_shapes.insert(pin_specs.rect);
+      } else {
+        pin_specs.rect = Search::Box();
+      }
+      pin_text_spec.push_back(pin_specs);
+    }
   }
+
+  painter.setPen(layer);
+  auto color = painter.getPenColor();
+  color.a = 255;
+  painter.setPen(color);
+  painter.setBrush(color);
 
   for (const auto& pin : pin_text_spec) {
     if (restart_) {
       break;
     }
-
-    odb::dbTechLayer* layer = pin.layer;
 
     bool do_rotate = false;
     auto anchor = pin.anchor;
@@ -1642,12 +1678,6 @@ void RenderThread::drawIOPins(Painter& painter,
         do_rotate = true;
       }
     }
-
-    painter.setPen(layer);
-    auto color = painter.getPenColor();
-    color.a = 255;
-    painter.setPen(color);
-    painter.setBrush(color);
 
     painter.drawString(pin.pt.x(), pin.pt.y(), anchor, pin.text, do_rotate);
   }

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -79,6 +79,8 @@ class RenderThread : public QThread
  private:
   void run() override;
 
+  void setupIOPins(odb::dbBlock* block, const odb::Rect& bounds);
+
   void drawBlock(QPainter* painter,
                  odb::dbBlock* block,
                  const odb::Rect& bounds,
@@ -134,7 +136,8 @@ class RenderThread : public QThread
   void drawHighlighted(Painter& painter, const HighlightSet& highlighted);
   void drawIOPins(Painter& painter,
                   odb::dbBlock* block,
-                  const odb::Rect& bounds);
+                  const odb::Rect& bounds,
+                  odb::dbTechLayer* layer);
   void drawAccessPoints(Painter& painter,
                         const std::vector<odb::dbInst*>& insts);
   void drawRouteGuides(Painter& painter, odb::dbTechLayer* layer);
@@ -169,6 +172,13 @@ class RenderThread : public QThread
   bool restart_ = false;
   bool abort_ = false;
   bool is_first_render_done_ = false;
+
+  QFont pin_font_;
+  bool pin_draw_names_ = false;
+  double pin_max_size_ = 0.0;
+  std::map<odb::dbTechLayer*,
+           std::vector<std::pair<odb::dbBTerm*, odb::dbBox*>>>
+      pins_;
 };
 
 }  // namespace gui

--- a/src/gui/src/search.cpp
+++ b/src/gui/src/search.cpp
@@ -254,8 +254,8 @@ void Search::updateShapes(odb::dbBlock* block)
   }
 
   data.box_shapes_.clear();
-  data.via_sbox_shapes_.clear();
-  data.polygon_shapes_.clear();
+  data.snet_via_shapes_.clear();
+  data.snet_shapes_.clear();
 
   for (odb::dbNet* net : block->getNets()) {
     addNet(net);
@@ -276,7 +276,7 @@ void Search::updateShapes(odb::dbBlock* block)
         Box bbox(Point(box->xMin(), box->yMin()),
                  Point(box->xMax(), box->yMax()));
         odb::dbTechLayer* layer = box->getTechLayer();
-        data.box_shapes_[layer].insert({bbox, term->getNet()});
+        data.box_shapes_[layer].insert({bbox, false, term->getNet()});
       }
     }
   }
@@ -384,7 +384,7 @@ void Search::addVia(odb::dbNet* net, odb::dbShape* shape, int x, int y)
       Point ll(x + box->xMin(), y + box->yMin());
       Point ur(x + box->xMax(), y + box->yMax());
       Box bbox(ll, ur);
-      data.box_shapes_[box->getTechLayer()].insert({bbox, net});
+      data.box_shapes_[box->getTechLayer()].insert({bbox, true, net});
     }
   } else {
     odb::dbVia* via = shape->getVia();
@@ -392,7 +392,7 @@ void Search::addVia(odb::dbNet* net, odb::dbShape* shape, int x, int y)
       Point ll(x + box->xMin(), y + box->yMin());
       Point ur(x + box->xMax(), y + box->yMax());
       Box bbox(ll, ur);
-      data.box_shapes_[box->getTechLayer()].insert({bbox, net});
+      data.box_shapes_[box->getTechLayer()].insert({bbox, true, net});
     }
   }
 }
@@ -414,7 +414,7 @@ void Search::addSNet(odb::dbNet* net)
           auto block_via = box->getBlockVia();
           layer = block_via->getBottomLayer()->getUpperLayer();
         }
-        data.via_sbox_shapes_[layer].insert({geom_bbox, box, net});
+        data.snet_via_shapes_[layer].insert({geom_bbox, box, net});
       } else {
         Box bbox(Point(box->xMin(), box->yMin()),
                  Point(box->xMax(), box->yMax()));
@@ -429,7 +429,7 @@ void Search::addSNet(odb::dbNet* net)
         for (const auto& point : points) {
           bg::append(poly.outer(), Point(point.getX(), point.getY()));
         }
-        data.polygon_shapes_[box->getTechLayer()].insert({bbox, poly, net});
+        data.snet_shapes_[box->getTechLayer()].insert({bbox, poly, net});
       }
     }
   }
@@ -439,8 +439,9 @@ void Search::addNet(odb::dbNet* net)
 {
   odb::dbWire* wire = net->getWire();
 
-  if (wire == NULL)
+  if (wire == NULL) {
     return;
+  }
 
   BlockData& data = getData(net->getBlock());
 
@@ -452,7 +453,7 @@ void Search::addNet(odb::dbNet* net)
       addVia(net, &s, itr._prev_x, itr._prev_y);
     } else {
       Box box(Point(s.xMin(), s.yMin()), Point(s.xMax(), s.yMax()));
-      data.box_shapes_[s.getTechLayer()].insert({box, net});
+      data.box_shapes_[s.getTechLayer()].insert({box, false, net});
     }
   }
 }
@@ -507,19 +508,28 @@ class Search::MinSizePredicate
 {
  public:
   MinSizePredicate(int min_size) : min_size_(min_size) {}
-  bool operator()(const std::tuple<Box, Polygon, T>& o) const
+  bool operator()(const SNetValue<T>& o) const
   {
-    return operator()({std::get<0>(o), std::get<2>(o)});
+    return checkBox(std::get<0>(o));
   }
 
-  bool operator()(const std::tuple<Box, odb::dbSBox*, T>& o) const
+  bool operator()(const SNetSBoxValue<T>& o) const
   {
-    return operator()({std::get<0>(o), std::get<2>(o)});
+    return checkBox(std::get<0>(o));
   }
 
-  bool operator()(const std::tuple<Box, T>& o) const
+  bool operator()(const BoxValue<T>& o) const
   {
-    Box box = std::get<0>(o);
+    return checkBox(std::get<0>(o));
+  }
+
+  bool operator()(const RouteBoxValue<T>& o) const
+  {
+    return checkBox(std::get<0>(o));
+  }
+
+  bool checkBox(const Box& box) const
+  {
     const Point& ll = box.min_corner();
     const Point& ur = box.max_corner();
     int w = ur.x() - ll.x();
@@ -536,14 +546,23 @@ class Search::MinHeightPredicate
 {
  public:
   MinHeightPredicate(int min_height) : min_height_(min_height) {}
-  bool operator()(const std::tuple<Box, Polygon, T>& o) const
+  bool operator()(const SNetValue<T>& o) const
   {
-    return operator()({std::get<0>(o), std::get<2>(o)});
+    return checkBox(std::get<0>(o));
   }
 
-  bool operator()(const std::tuple<Box, T>& o) const
+  bool operator()(const RouteBoxValue<T>& o) const
   {
-    Box box = std::get<0>(o);
+    return checkBox(std::get<0>(o));
+  }
+
+  bool operator()(const BoxValue<T>& o) const
+  {
+    return checkBox(std::get<0>(o));
+  }
+
+  bool checkBox(const Box& box) const
+  {
     const Point& ll = box.min_corner();
     const Point& ur = box.max_corner();
     int h = ur.y() - ll.y();
@@ -554,13 +573,13 @@ class Search::MinHeightPredicate
   int min_height_;
 };
 
-Search::BoxRange Search::searchBoxShapes(odb::dbBlock* block,
-                                         odb::dbTechLayer* layer,
-                                         int x_lo,
-                                         int y_lo,
-                                         int x_hi,
-                                         int y_hi,
-                                         int min_size)
+Search::RoutingRange Search::searchBoxShapes(odb::dbBlock* block,
+                                             odb::dbTechLayer* layer,
+                                             int x_lo,
+                                             int y_lo,
+                                             int x_hi,
+                                             int y_hi,
+                                             int min_size)
 {
   BlockData& data = getData(block);
   if (!data.shapes_init_) {
@@ -569,83 +588,85 @@ Search::BoxRange Search::searchBoxShapes(odb::dbBlock* block,
 
   auto it = data.box_shapes_.find(layer);
   if (it == data.box_shapes_.end()) {
-    return BoxRange();
+    return RoutingRange();
   }
 
   auto& rtree = it->second;
 
   Box query(Point(x_lo, y_lo), Point(x_hi, y_hi));
   if (min_size > 0) {
-    return BoxRange(rtree.qbegin(bgi::intersects(query)
-                                 && bgi::satisfies(
-                                     MinSizePredicate<odb::dbNet*>(min_size))),
-                    rtree.qend());
-  }
-
-  return BoxRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
-}
-
-Search::SBoxRange Search::searchViaSBoxShapes(odb::dbBlock* block,
-                                              odb::dbTechLayer* layer,
-                                              int x_lo,
-                                              int y_lo,
-                                              int x_hi,
-                                              int y_hi,
-                                              int min_size)
-{
-  BlockData& data = getData(block);
-  if (!data.shapes_init_) {
-    updateShapes(block);
-  }
-
-  auto it = data.via_sbox_shapes_.find(layer);
-  if (it == data.via_sbox_shapes_.end()) {
-    return SBoxRange();
-  }
-
-  auto& rtree = it->second;
-
-  Box query(Point(x_lo, y_lo), Point(x_hi, y_hi));
-  if (min_size > 0) {
-    return SBoxRange(rtree.qbegin(bgi::intersects(query)
-                                  && bgi::satisfies(
-                                      MinSizePredicate<odb::dbNet*>(min_size))),
-                     rtree.qend());
-  }
-
-  return SBoxRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
-}
-
-Search::PolygonRange Search::searchPolygonShapes(odb::dbBlock* block,
-                                                 odb::dbTechLayer* layer,
-                                                 int x_lo,
-                                                 int y_lo,
-                                                 int x_hi,
-                                                 int y_hi,
-                                                 int min_size)
-{
-  BlockData& data = getData(block);
-  if (!data.shapes_init_) {
-    updateShapes(block);
-  }
-
-  auto it = data.polygon_shapes_.find(layer);
-  if (it == data.polygon_shapes_.end()) {
-    return PolygonRange();
-  }
-
-  auto& rtree = it->second;
-
-  Box query(Point(x_lo, y_lo), Point(x_hi, y_hi));
-  if (min_size > 0) {
-    return PolygonRange(
+    return RoutingRange(
         rtree.qbegin(
             bgi::intersects(query)
             && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size))),
         rtree.qend());
   }
 
-  return PolygonRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
+  return RoutingRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
+}
+
+Search::SNetSBoxRange Search::searchSNetViaShapes(odb::dbBlock* block,
+                                                  odb::dbTechLayer* layer,
+                                                  int x_lo,
+                                                  int y_lo,
+                                                  int x_hi,
+                                                  int y_hi,
+                                                  int min_size)
+{
+  BlockData& data = getData(block);
+  if (!data.shapes_init_) {
+    updateShapes(block);
+  }
+
+  auto it = data.snet_via_shapes_.find(layer);
+  if (it == data.snet_via_shapes_.end()) {
+    return SNetSBoxRange();
+  }
+
+  auto& rtree = it->second;
+
+  Box query(Point(x_lo, y_lo), Point(x_hi, y_hi));
+  if (min_size > 0) {
+    return SNetSBoxRange(
+        rtree.qbegin(
+            bgi::intersects(query)
+            && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size))),
+        rtree.qend());
+  }
+
+  return SNetSBoxRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
+}
+
+Search::SNetShapeRange Search::searchSNetShapes(odb::dbBlock* block,
+                                                odb::dbTechLayer* layer,
+                                                int x_lo,
+                                                int y_lo,
+                                                int x_hi,
+                                                int y_hi,
+                                                int min_size)
+{
+  BlockData& data = getData(block);
+  if (!data.shapes_init_) {
+    updateShapes(block);
+  }
+
+  auto it = data.snet_shapes_.find(layer);
+  if (it == data.snet_shapes_.end()) {
+    return SNetShapeRange();
+  }
+
+  auto& rtree = it->second;
+
+  Box query(Point(x_lo, y_lo), Point(x_hi, y_hi));
+  if (min_size > 0) {
+    return SNetShapeRange(
+        rtree.qbegin(
+            bgi::intersects(query)
+            && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size))),
+        rtree.qend());
+  }
+
+  return SNetShapeRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
 }
 
 Search::FillRange Search::searchFills(odb::dbBlock* block,

--- a/src/gui/src/search.cpp
+++ b/src/gui/src/search.cpp
@@ -439,7 +439,7 @@ void Search::addNet(odb::dbNet* net)
 {
   odb::dbWire* wire = net->getWire();
 
-  if (wire == NULL) {
+  if (wire == nullptr) {
     return;
   }
 

--- a/src/gui/src/search.h
+++ b/src/gui/src/search.h
@@ -70,16 +70,20 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   template <typename T>
   using BoxValue = std::tuple<Box, T>;
   template <typename T>
-  using SBoxValue = std::tuple<Box, odb::dbSBox*, T>;
+  using RouteBoxValue = std::tuple<Box, bool, T>;
   template <typename T>
-  using PolygonValue = std::tuple<Box, Polygon, T>;
+  using SNetSBoxValue = std::tuple<Box, odb::dbSBox*, T>;
+  template <typename T>
+  using SNetValue = std::tuple<Box, Polygon, T>;
 
   template <typename T>
   using RtreeBox = bgi::rtree<BoxValue<T>, bgi::quadratic<16>>;
   template <typename T>
-  using RtreeSBox = bgi::rtree<SBoxValue<T>, bgi::quadratic<16>>;
+  using RtreeRoutingShapes = bgi::rtree<RouteBoxValue<T>, bgi::quadratic<16>>;
   template <typename T>
-  using RtreePolygon = bgi::rtree<PolygonValue<T>, bgi::quadratic<16>>;
+  using RtreeSNetSBox = bgi::rtree<SNetSBoxValue<T>, bgi::quadratic<16>>;
+  template <typename T>
+  using RtreeSNetShapes = bgi::rtree<SNetValue<T>, bgi::quadratic<16>>;
 
   // This is an iterator range for return values
   template <typename Tree>
@@ -102,8 +106,9 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   };
   using InstRange = Range<RtreeBox<odb::dbInst*>>;
   using BoxRange = Range<RtreeBox<odb::dbNet*>>;
-  using SBoxRange = Range<RtreeSBox<odb::dbNet*>>;
-  using PolygonRange = Range<RtreePolygon<odb::dbNet*>>;
+  using RoutingRange = Range<RtreeRoutingShapes<odb::dbNet*>>;
+  using SNetSBoxRange = Range<RtreeSNetSBox<odb::dbNet*>>;
+  using SNetShapeRange = Range<RtreeSNetShapes<odb::dbNet*>>;
   using FillRange = Range<RtreeBox<odb::dbFill*>>;
   using ObstructionRange = Range<RtreeBox<odb::dbObstruction*>>;
   using BlockageRange = Range<RtreeBox<odb::dbBlockage*>>;
@@ -116,33 +121,33 @@ class Search : public QObject, public odb::dbBlockCallBackObj
 
   // Find all box shapes in the given bounds on the given layer which
   // are at least min_size in either dimension.
-  BoxRange searchBoxShapes(odb::dbBlock* block,
-                           odb::dbTechLayer* layer,
-                           int x_lo,
-                           int y_lo,
-                           int x_hi,
-                           int y_hi,
-                           int min_size = 0);
+  RoutingRange searchBoxShapes(odb::dbBlock* block,
+                               odb::dbTechLayer* layer,
+                               int x_lo,
+                               int y_lo,
+                               int x_hi,
+                               int y_hi,
+                               int min_size = 0);
 
   // Find all via sbox shapes in the given bounds on the given layer which
   // are at least min_size in either dimension.
-  SBoxRange searchViaSBoxShapes(odb::dbBlock* block,
-                                odb::dbTechLayer* layer,
-                                int x_lo,
-                                int y_lo,
-                                int x_hi,
-                                int y_hi,
-                                int min_size = 0);
+  SNetSBoxRange searchSNetViaShapes(odb::dbBlock* block,
+                                    odb::dbTechLayer* layer,
+                                    int x_lo,
+                                    int y_lo,
+                                    int x_hi,
+                                    int y_hi,
+                                    int min_size = 0);
 
   // Find all polgyon shapes in the given bounds on the given layer which
   // are at least min_size in either dimension.
-  PolygonRange searchPolygonShapes(odb::dbBlock* block,
-                                   odb::dbTechLayer* layer,
-                                   int x_lo,
-                                   int y_lo,
-                                   int x_hi,
-                                   int y_hi,
-                                   int min_size = 0);
+  SNetShapeRange searchSNetShapes(odb::dbBlock* block,
+                                  odb::dbTechLayer* layer,
+                                  int x_lo,
+                                  int y_lo,
+                                  int x_hi,
+                                  int y_hi,
+                                  int min_size = 0);
 
   // Find all fills in the given bounds on the given layer which
   // are at least min_size in either dimension.
@@ -255,12 +260,12 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   struct BlockData
   {
     // The net is used for filter shapes by net type
-    std::map<odb::dbTechLayer*, RtreeBox<odb::dbNet*>> box_shapes_;
+    std::map<odb::dbTechLayer*, RtreeRoutingShapes<odb::dbNet*>> box_shapes_;
     // Special net vias may be large multi-cut vias.  It is more efficient
     // to store the dbSBox (ie the via) than all the cuts.  This is
     // particularly true when you have parallel straps like m1 & m2 in asap7.
-    std::map<odb::dbTechLayer*, RtreeSBox<odb::dbNet*>> via_sbox_shapes_;
-    std::map<odb::dbTechLayer*, RtreePolygon<odb::dbNet*>> polygon_shapes_;
+    std::map<odb::dbTechLayer*, RtreeSNetSBox<odb::dbNet*>> snet_via_shapes_;
+    std::map<odb::dbTechLayer*, RtreeSNetShapes<odb::dbNet*>> snet_shapes_;
     std::atomic_bool shapes_init_{false};
     std::mutex shapes_init_mutex_;
     std::map<odb::dbTechLayer*, RtreeBox<odb::dbFill*>> fills_;


### PR DESCRIPTION
Adds:
- controls for via and segment shapes for routing and snet routing

Changes:
- bpins are drawn in layer order and are only visible with the net and layer controls

Replaces: https://github.com/The-OpenROAD-Project/OpenROAD/pull/4565