### PR TITLE
[WIP] Use pocketfft for Nesterov solver

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/abc"]
 	path = third-party/abc
 	url = ../../The-OpenROAD-Project/abc.git
+[submodule "third-party/pocketfft"]
+	path = third-party/pocketfft
+	url = https://github.com/mreineck/pocketfft

--- a/src/gpl/CMakeLists.txt
+++ b/src/gpl/CMakeLists.txt
@@ -38,6 +38,9 @@ include("openroad")
 # For Multithread
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_FFT2D_PTHREADS=1 -DFFT_2D_MAX_THREADS=16 -O3 ${OpenMP_CXX_FLAGS}")
 
+# Enable AVX extension for x86
+set(CMAKE_CXX_FLAGS "-mavx")
+
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Eigen3 REQUIRED)
@@ -71,10 +74,17 @@ target_sources(gpl
 
 messages(TARGET gpl)
 
+get_filename_component(
+  POCKETFFT_INCLUDE_DIR
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../third-party/pocketfft
+  ABSOLUTE
+)
+
 target_include_directories(gpl
   PUBLIC
     include
     ${LEMON_INCLUDE_DIRS}
+    ${POCKETFFT_INCLUDE_DIR}
 )
 
 target_link_libraries(gpl

--- a/src/gpl/src/fft.cpp
+++ b/src/gpl/src/fft.cpp
@@ -32,6 +32,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "fft.h"
+
 #include <pocketfft_hdronly.h>
 
 #include <cfloat>
@@ -137,8 +138,15 @@ void FFT::doFFT()
   const pocketfft::shape_t axes = {0, 1};
   const pocketfft::stride_t stride = {stride_x, stride_y};
 
-  pocketfft::dct<float>(shape, stride, stride, axes, 2,
-                        binDensity_[0], binDensity_[0], 0.25f, false);
+  pocketfft::dct<float>(shape,
+                        stride,
+                        stride,
+                        axes,
+                        2,
+                        binDensity_[0],
+                        binDensity_[0],
+                        0.25f,
+                        false);
 
   for (int i = 0; i < binCntX_; i++) {
     binDensity_[i][0] *= 0.5;
@@ -199,8 +207,15 @@ void FFT::doFFT()
     electroPhi_[0][i] *= 2.0f;
   }
 
-  pocketfft::dct<float>(shape, stride, stride, axes, 3,
-                        electroPhi_[0], electroPhi_[0], 0.25f, false);
+  pocketfft::dct<float>(shape,
+                        stride,
+                        stride,
+                        axes,
+                        3,
+                        electroPhi_[0],
+                        electroPhi_[0],
+                        0.25f,
+                        false);
 
   ddsct2d(binCntX_,
           binCntY_,

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(fft_test fft_test.cc)
 target_include_directories(fft_test
   PUBLIC
   ${PROJECT_SOURCE_DIR}
+  ${POCKETFFT_INCLUDE_DIR}
 )
 
 target_link_libraries(fft_test

--- a/src/gpl/test/fft_test.cc
+++ b/src/gpl/test/fft_test.cc
@@ -134,16 +134,39 @@ TEST(FloatFFTTest, Basic)
 
   print_tables(fft);
 
+  const float tol = 1.3e-4f; // Tolerance factor
+
+  double eforce1_total = 0.0;
+  double eforce2_total = 0.0;
+  double ephi_total = 0.0;
+
   for (int y = 0; y < Y_MAX; y++) {
     for (int x = 0; x < X_MAX; x++) {
       auto eForce = fft->getElectroForce(x, y);
       auto electroPhi = fft->getElectroPhi(x, y);
 
-      EXPECT_EQ(eForce.first, output_data_eForce_first[x + y * Y_MAX]);
-      EXPECT_EQ(eForce.second, output_data_eForce_second[x + y * Y_MAX]);
-      EXPECT_EQ(electroPhi, output_data_electroPhi[x + y * Y_MAX]);
+      // Compute error
+      float eforce1 = fabs(eForce.first  - output_data_eForce_first[x + y * Y_MAX]);
+      float eforce2 = fabs(eForce.second - output_data_eForce_second[x + y * Y_MAX]);
+      float ephi    = fabs(electroPhi    - output_data_electroPhi[x + y * Y_MAX]);
+
+      // Check error
+      EXPECT_LT(eforce1, tol);
+      EXPECT_LT(eforce2, tol);
+      EXPECT_LT(ephi, tol);
+
+      // Accumulate error
+      eforce1_total += eforce1;
+      eforce2_total += eforce2;
+      ephi_total += ephi;
     }
   }
+
+  // Report total error
+  std::cout << "FFT output vs. reference error (total sum)\n";
+  std::cout << fmt::format(" eForce.first : {:26.20f}\n", eforce1_total);
+  std::cout << fmt::format(" eForce.second: {:26.20f}\n", eforce2_total);
+  std::cout << fmt::format(" electroPhi   : {:26.20f}\n", ephi_total);
 }
 
 }  // namespace

--- a/src/gpl/test/fft_test.cc
+++ b/src/gpl/test/fft_test.cc
@@ -134,7 +134,7 @@ TEST(FloatFFTTest, Basic)
 
   print_tables(fft);
 
-  const float tol = 1.3e-4f; // Tolerance factor
+  const float tol = 1.3e-4f;  // Tolerance factor
 
   double eforce1_total = 0.0;
   double eforce2_total = 0.0;
@@ -146,9 +146,11 @@ TEST(FloatFFTTest, Basic)
       auto electroPhi = fft->getElectroPhi(x, y);
 
       // Compute error
-      float eforce1 = fabs(eForce.first  - output_data_eForce_first[x + y * Y_MAX]);
-      float eforce2 = fabs(eForce.second - output_data_eForce_second[x + y * Y_MAX]);
-      float ephi    = fabs(electroPhi    - output_data_electroPhi[x + y * Y_MAX]);
+      float eforce1
+          = fabs(eForce.first - output_data_eForce_first[x + y * Y_MAX]);
+      float eforce2
+          = fabs(eForce.second - output_data_eForce_second[x + y * Y_MAX]);
+      float ephi = fabs(electroPhi - output_data_electroPhi[x + y * Y_MAX]);
 
       // Check error
       EXPECT_LT(eforce1, tol);


### PR DESCRIPTION
This PR is intended to replace the FFT library used in ePlace Nesterov solver with [pocketfft](https://github.com/mreineck/pocketfft). Preliminary tests have shown that the library is faster.

Runtime measurements of the `3_3_place_gp` stage with stock FFT and `pocketff` on an Intel(R) i7-8700 @ 3.20GHz CPU:
| stock FFT lib stage runtime [s] | `pocketfft` stage runtime [s] |
| --- | --- |
| 554 | 550 |
| 553 | 545 |
| 554 | 540 |
| 546 | 539 |
| 544 | 542 |
| average |
| 550.2 | 543.2 |

The improvement is expected to increase as soon as `dsct` and `dcst` functions are replaced which is a work in progress.