### PR TITLE
Parallel Nesterov's method

### DIFF
--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -82,11 +82,11 @@ class Replace
             utl::Logger* logger);
   void reset();
 
-  void doIncrementalPlace();
+  void doIncrementalPlace(int threads);
   void doInitialPlace();
   void runMBFF(int max_sz, float alpha, float beta, int threads, int num_paths);
 
-  int doNesterovPlace(int start_iter = 0);
+  int doNesterovPlace(int threads, int start_iter = 0);
 
   // Initial Place param settings
   void setInitialPlaceMaxIter(int iter);
@@ -107,7 +107,7 @@ class Replace
   void setMinPhiCoef(float minPhiCoef);
   void setMaxPhiCoef(float maxPhiCoef);
 
-  float getUniformTargetDensity();
+  float getUniformTargetDensity(int threads);
 
   // HPWL: half-parameter wire length.
   void setReferenceHpwl(float refHpwl);
@@ -144,7 +144,7 @@ class Replace
                 odb::dbInst* inst = nullptr);
 
  private:
-  bool initNesterovPlace();
+  bool initNesterovPlace(int threads);
 
   odb::dbDatabase* db_ = nullptr;
   sta::dbSta* sta_ = nullptr;

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -683,9 +683,9 @@ void BinGrid::updateBinsNonPlaceArea()
   for (auto& inst : pb_->nonPlaceInsts()) {
     std::pair<int, int> pairX = getMinMaxIdxX(inst);
     std::pair<int, int> pairY = getMinMaxIdxY(inst);
-    for (int i = pairX.first; i < pairX.second; i++) {
-      for (int j = pairY.first; j < pairY.second; j++) {
-        Bin& bin = bins_[j * binCntX_ + i];
+    for (int y = pairY.first; y < pairY.second; y++) {
+      for (int x = pairX.first; x < pairX.second; x++) {
+        Bin& bin = bins_[y * binCntX_ + x];
 
         // Note that nonPlaceArea should have scale-down with
         // target density.
@@ -725,9 +725,9 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCell*>& cells)
       // macro should have
       // scale-down with target-density
       if (cell->isMacroInstance()) {
-        for (int i = pairX.first; i < pairX.second; i++) {
-          for (int j = pairY.first; j < pairY.second; j++) {
-            Bin& bin = bins_[j * binCntX_ + i];
+        for (int y = pairY.first; y < pairY.second; y++) {
+          for (int x = pairX.first; x < pairX.second; x++) {
+            Bin& bin = bins_[y * binCntX_ + x];
 
             const float scaledAvea = getOverlapDensityArea(bin, cell)
                                      * cell->densityScale()
@@ -739,9 +739,9 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCell*>& cells)
       }
       // normal cells
       else if (cell->isStdInstance()) {
-        for (int i = pairX.first; i < pairX.second; i++) {
-          for (int j = pairY.first; j < pairY.second; j++) {
-            Bin& bin = bins_[j * binCntX_ + i];
+        for (int y = pairY.first; y < pairY.second; y++) {
+          for (int x = pairX.first; x < pairX.second; x++) {
+            Bin& bin = bins_[y * binCntX_ + x];
             const float scaledArea
                 = getOverlapDensityArea(bin, cell) * cell->densityScale();
             bin.addInstPlacedArea(scaledArea);
@@ -750,9 +750,9 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCell*>& cells)
         }
       }
     } else if (cell->isFiller()) {
-      for (int i = pairX.first; i < pairX.second; i++) {
-        for (int j = pairY.first; j < pairY.second; j++) {
-          Bin& bin = bins_[j * binCntX_ + i];
+      for (int y = pairY.first; y < pairY.second; y++) {
+        for (int x = pairX.first; x < pairX.second; x++) {
+          Bin& bin = bins_[y * binCntX_ + x];
           bin.addFillerArea(getOverlapDensityArea(bin, cell)
                             * cell->densityScale());
         }

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -509,6 +509,7 @@ class GPin
 class Bin
 {
  public:
+  Bin() = default;
   Bin(int x, int y, int lx, int ly, int ux, int uy, float targetDensity);
 
   int x() const { return x_; };
@@ -670,6 +671,7 @@ class BinGrid
   void setBinCnt(int binCntX, int binCntY);
   void setTargetDensity(float density);
   void updateBinsGCellDensityArea(const std::vector<GCell*>& cells);
+  void setNumThreads(int num_threads) { num_threads_ = num_threads; }
 
   void initBins();
 
@@ -719,6 +721,7 @@ class BinGrid
   int64_t overflowArea_ = 0;
   int64_t overflowAreaUnscaled_ = 0;
   bool isSetBinCnt_ = false;
+  int num_threads_ = 1;
 };
 
 inline std::vector<Bin>& BinGrid::bins()
@@ -777,7 +780,8 @@ class NesterovBaseCommon
  public:
   NesterovBaseCommon(NesterovBaseVars nbVars,
                      std::shared_ptr<PlacerBaseCommon> pb,
-                     utl::Logger* log);
+                     utl::Logger* log,
+                     int num_threads);
 
   const std::vector<GCell*>& gCells() const { return gCells_; }
   const std::vector<GNet*>& gNets() const { return gNets_; }
@@ -823,6 +827,9 @@ class NesterovBaseCommon
 
   void updateDbGCells();
 
+  // Number of threads of execution
+  size_t getNumThreads() { return num_threads_; }
+
  private:
   NesterovBaseVars nbVars_;
   std::shared_ptr<PlacerBaseCommon> pbc_;
@@ -839,6 +846,8 @@ class NesterovBaseCommon
   std::unordered_map<Instance*, GCell*> gCellMap_;
   std::unordered_map<Pin*, GPin*> gPinMap_;
   std::unordered_map<Net*, GNet*> gNetMap_;
+
+  int num_threads_;
 };
 
 // Stores instances belonging to a specific power domain

--- a/src/gpl/src/replace.i
+++ b/src/gpl/src/replace.i
@@ -40,7 +40,8 @@ void
 replace_nesterov_place_cmd()
 {
   Replace* replace = getReplace();
-  replace->doNesterovPlace();
+  int threads = ord::OpenRoad::openRoad()->getThreadCount();
+  replace->doNesterovPlace(threads);
 }
 
 
@@ -141,7 +142,8 @@ void
 replace_incremental_place_cmd()
 {
   Replace* replace = getReplace();
-  replace->doIncrementalPlace();
+  int threads = ord::OpenRoad::openRoad()->getThreadCount();
+  replace->doIncrementalPlace(threads);
 }
 
 
@@ -251,7 +253,8 @@ float
 get_global_placement_uniform_density_cmd() 
 {
   Replace* replace = getReplace();
-  return replace->getUniformTargetDensity();
+  int threads = ord::OpenRoad::openRoad()->getThreadCount();
+  return replace->getUniformTargetDensity(threads);
 }
 
 void 

--- a/src/gpl/test/gpl_aux.py
+++ b/src/gpl/test/gpl_aux.py
@@ -157,11 +157,11 @@ def global_placement(design, *,
 
     if len(design.getBlock().getRows()) > 0:  # db_has_rows
         if incremental:
-            gpl.doIncrementalPlace()
+            gpl.doIncrementalPlace(1)
         else:
             gpl.doInitialPlace()
             if not skip_nesterov_place:
-                gpl.doNesterovPlace()
+                gpl.doNesterovPlace(1)
         gpl.reset()
     else:
         utl.error(utl.GPL, 506, "No rows defined in design. Use initialize_floorplan to add rows.")


### PR DESCRIPTION
Uses OpenMP to parallelize Nesterov's method in global placement.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| ibex / master / 1 thread | 32.251 ± 0.138 | 31.985 | 32.428 | 1.33 ± 0.01 |
| ibex / omp-nesterov / 1 thread | 32.621 ± 0.144 | 32.303 | 32.872 | 1.35 ± 0.01 |
| black_parrot / master / 1 thread | 505.898 ± 2.452 | 503.023 | 510.608 | 1.27 ± 0.01 |
| black_parrot / omp-nesterov / 1 thread | 500.197 ± 7.726 | 487.191 | 507.588 | 1.26 ± 0.02 |
| ariane133 / master / 1 thread | 434.566 ± 1.666 | 432.692 | 436.897 | 1.28 ± 0.01 |
| ariane133 / omp-nesterov / 1 thread | 431.179 ± 6.552 | 418.658 | 436.884 | 1.27 ± 0.02 |
| ibex / master / 8 threads | 25.579 ± 0.069 | 25.454 | 25.692 | 1.06 ± 0.00 |
| ibex / omp-nesterov / 8 threads | 24.172 ± 0.077 | 24.059 | 24.333 | 1.00 |
| black_parrot / master / 8 threads | 437.729 ± 0.715 | 436.601 | 439.140 | 1.10 ± 0.01 |
| black_parrot / omp-nesterov / 8 threads | 397.716 ± 2.942 | 389.520 | 399.385 | 1.00 |
| ariane133 / master / 8 threads | 363.903 ± 0.709 | 363.251 | 365.558 | 1.07 ± 0.00 |
| ariane133 / omp-nesterov / 8 threads | 340.758 ± 1.030 | 338.728 | 342.136 | 1.00 | 

This is the `3_3_place_gp` target from OpenROAD flow scripts. Best case is BlackParrot with about 10% speedup.

**Note the first 6 measurements are single-threaded**; they're just to make sure there's no slowdown in single-threaded mode. The real comparison is 8-thread `master` vs 8-thread `omp-nesterov`.