### PR TITLE
gui: allow for non-uniform grids in heatmaps and apply gcells to heatmaps

### DIFF
--- a/src/grt/src/AbstractRoutingCongestionDataSource.h
+++ b/src/grt/src/AbstractRoutingCongestionDataSource.h
@@ -13,10 +13,6 @@ class AbstractRoutingCongestionDataSource
  public:
   virtual ~AbstractRoutingCongestionDataSource() = default;
 
-  virtual bool canAdjustGrid() const = 0;
-  virtual double getGridXSize() const = 0;
-  virtual double getGridYSize() const = 0;
-
   virtual void registerHeatMap() = 0;
   virtual void update() = 0;
 };

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -328,6 +328,10 @@ void RoutingCongestionDataSource::populateXYGrid()
   gCellGrid->getGridX(gcell_xgrid);
   gCellGrid->getGridY(gcell_ygrid);
 
+  const auto die_area = getBlock()->getDieArea();
+  gcell_xgrid.push_back(die_area.xMax());
+  gcell_ygrid.push_back(die_area.yMax());
+
   setXYMapGrid(gcell_xgrid, gcell_ygrid);
 }
 

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -36,10 +36,10 @@ namespace grt {
 
 RoutingCongestionDataSource::RoutingCongestionDataSource(utl::Logger* logger,
                                                          odb::dbDatabase* db)
-    : gui::HeatMapDataSource(logger,
-                             "Routing Congestion",
-                             "Routing",
-                             "RoutingCongestion"),
+    : gui::GlobalRoutingDataSource(logger,
+                                   "Routing Congestion",
+                                   "Routing",
+                                   "RoutingCongestion"),
       db_(db),
       direction_(ALL),
       layer_(nullptr),
@@ -131,50 +131,6 @@ RoutingCongestionDataSource::RoutingCongestionDataSource(utl::Logger* logger,
           type_ = Usage;
         }
       });
-}
-
-double RoutingCongestionDataSource::getGridXSize() const
-{
-  if (getBlock() == nullptr) {
-    return default_grid_;
-  }
-
-  auto* gcellgrid = getBlock()->getGCellGrid();
-  if (gcellgrid == nullptr) {
-    return default_grid_;
-  }
-
-  std::vector<int> grid;
-  gcellgrid->getGridX(grid);
-
-  if (grid.size() < 2) {
-    return default_grid_;
-  } else {
-    const double delta = grid[1] - grid[0];
-    return delta / getBlock()->getDbUnitsPerMicron();
-  }
-}
-
-double RoutingCongestionDataSource::getGridYSize() const
-{
-  if (getBlock() == nullptr) {
-    return default_grid_;
-  }
-
-  auto* gcellgrid = getBlock()->getGCellGrid();
-  if (gcellgrid == nullptr) {
-    return default_grid_;
-  }
-
-  std::vector<int> grid;
-  gcellgrid->getGridY(grid);
-
-  if (grid.size() < 2) {
-    return default_grid_;
-  } else {
-    const double delta = grid[1] - grid[0];
-    return delta / getBlock()->getDbUnitsPerMicron();
-  }
 }
 
 bool RoutingCongestionDataSource::populateMap()
@@ -311,28 +267,6 @@ void RoutingCongestionDataSource::combineMapData(bool base_has_value,
                                                  const double rect_area)
 {
   base += new_data * intersection_area / rect_area;
-}
-
-void RoutingCongestionDataSource::populateXYGrid()
-{
-  if (getBlock() == nullptr) {
-    HeatMapDataSource::populateXYGrid();
-  }
-
-  auto* gCellGrid = getBlock()->getGCellGrid();
-  if (gCellGrid == nullptr) {
-    HeatMapDataSource::populateXYGrid();
-  }
-
-  std::vector<int> gcell_xgrid, gcell_ygrid;
-  gCellGrid->getGridX(gcell_xgrid);
-  gCellGrid->getGridY(gcell_ygrid);
-
-  const auto die_area = getBlock()->getDieArea();
-  gcell_xgrid.push_back(die_area.xMax());
-  gcell_ygrid.push_back(die_area.yMax());
-
-  setXYMapGrid(gcell_xgrid, gcell_ygrid);
 }
 
 }  // namespace grt

--- a/src/grt/src/heatMap.cpp
+++ b/src/grt/src/heatMap.cpp
@@ -313,4 +313,22 @@ void RoutingCongestionDataSource::combineMapData(bool base_has_value,
   base += new_data * intersection_area / rect_area;
 }
 
+void RoutingCongestionDataSource::populateXYGrid()
+{
+  if (getBlock() == nullptr) {
+    HeatMapDataSource::populateXYGrid();
+  }
+
+  auto* gCellGrid = getBlock()->getGCellGrid();
+  if (gCellGrid == nullptr) {
+    HeatMapDataSource::populateXYGrid();
+  }
+
+  std::vector<int> gcell_xgrid, gcell_ygrid;
+  gCellGrid->getGridX(gcell_xgrid);
+  gCellGrid->getGridY(gcell_ygrid);
+
+  setXYMapGrid(gcell_xgrid, gcell_ygrid);
+}
+
 }  // namespace grt

--- a/src/grt/src/heatMap.h
+++ b/src/grt/src/heatMap.h
@@ -37,15 +37,11 @@
 
 namespace grt {
 
-class RoutingCongestionDataSource : public gui::HeatMapDataSource,
+class RoutingCongestionDataSource : public gui::GlobalRoutingDataSource,
                                     public AbstractRoutingCongestionDataSource
 {
  public:
   RoutingCongestionDataSource(utl::Logger* logger, odb::dbDatabase* db);
-
-  virtual bool canAdjustGrid() const override { return false; }
-  virtual double getGridXSize() const override;
-  virtual double getGridYSize() const override;
 
   void registerHeatMap() override { gui::HeatMapDataSource::registerHeatMap(); }
   void update() override { gui::HeatMapDataSource::update(); }
@@ -60,7 +56,6 @@ class RoutingCongestionDataSource : public gui::HeatMapDataSource,
                               const double rect_area) override;
   virtual void correctMapScale(HeatMapDataSource::Map& map) override;
   virtual std::string formatValue(double value, bool legend) const override;
-  void populateXYGrid() override;
 
  private:
   enum Direction
@@ -82,8 +77,6 @@ class RoutingCongestionDataSource : public gui::HeatMapDataSource,
 
   MapType type_;
   double max_;
-
-  static constexpr double default_grid_ = 10.0;
 };
 
 }  // namespace grt

--- a/src/grt/src/heatMap.h
+++ b/src/grt/src/heatMap.h
@@ -60,6 +60,7 @@ class RoutingCongestionDataSource : public gui::HeatMapDataSource,
                               const double rect_area) override;
   virtual void correctMapScale(HeatMapDataSource::Map& map) override;
   virtual std::string formatValue(double value, bool legend) const override;
+  void populateXYGrid() override;
 
  private:
   enum Direction

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -332,4 +332,24 @@ class RealValueHeatMapDataSource : public HeatMapDataSource
   double getValueRange() const;
 };
 
+class GlobalRoutingDataSource : public HeatMapDataSource
+{
+ public:
+  GlobalRoutingDataSource(utl::Logger* logger,
+                          const std::string& name,
+                          const std::string& short_name,
+                          const std::string& settings_group = "");
+  bool canAdjustGrid() const override { return false; }
+  double getGridXSize() const override;
+  double getGridYSize() const override;
+
+ protected:
+  void populateXYGrid() override;
+
+ private:
+  static constexpr int default_grid_ = 10;
+
+  std::pair<double, double> getReportableXYGrid() const;
+};
+
 }  // namespace gui

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -212,6 +212,10 @@ class HeatMapDataSource
   void assignMapColors();
   void markColorsInvalid() { colors_correct_ = false; }
 
+  virtual void populateXYGrid();
+  void setXYMapGrid(const std::vector<int>& x_grid,
+                    const std::vector<int>& y_grid);
+
   virtual bool destroyMapOnNotVisible() const { return false; }
 
   template <typename T>
@@ -248,6 +252,8 @@ class HeatMapDataSource
   bool show_legend_;
 
   Map map_;
+  std::vector<int> map_x_grid_;
+  std::vector<int> map_y_grid_;
 
   std::unique_ptr<HeatMapRenderer> renderer_;
   HeatMapSetup* setup_;

--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -37,6 +37,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <variant>
 #include <vector>
@@ -256,6 +257,8 @@ class HeatMapDataSource
   std::vector<double> color_lower_bounds_;
 
   std::vector<MapSetting> settings_;
+
+  std::mutex ensure_mutex_;
 };
 
 class HeatMapRenderer : public Renderer

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1266,7 +1266,7 @@ void Gui::init(odb::dbDatabase* db, utl::Logger* logger)
   placement_density_heat_map_
       = std::make_unique<PlacementDensityDataSource>(logger);
   placement_density_heat_map_->registerHeatMap();
-  rudy_heat_map_ = std::make_unique<RUDYDataSource>(logger, db_);
+  rudy_heat_map_ = std::make_unique<RUDYDataSource>(logger);
   rudy_heat_map_->registerHeatMap();
 }
 

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -32,6 +32,7 @@
 
 #include "gui/heatMap.h"
 
+#include <algorithm>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -340,22 +341,14 @@ void HeatMapDataSource::setSettings(const Renderer::Settings& settings)
 HeatMapDataSource::MapView HeatMapDataSource::getMapView(
     const odb::Rect& bounds)
 {
-  const auto x_low_find = std::find_if(
-      map_x_grid_.begin(), map_x_grid_.end(), [&bounds](const int x) {
-        return x >= bounds.xMin();
-      });
+  const auto x_low_find
+      = std::lower_bound(map_x_grid_.begin(), map_x_grid_.end(), bounds.xMin());
   const auto x_high_find
-      = std::find_if(x_low_find, map_x_grid_.end(), [&bounds](const int x) {
-          return x > bounds.xMax();
-        });
-  const auto y_low_find = std::find_if(
-      map_y_grid_.begin(), map_y_grid_.end(), [&bounds](const int y) {
-        return y >= bounds.yMin();
-      });
+      = std::upper_bound(x_low_find, map_x_grid_.end(), bounds.xMax());
+  const auto y_low_find
+      = std::lower_bound(map_y_grid_.begin(), map_y_grid_.end(), bounds.yMin());
   const auto y_high_find
-      = std::find_if(y_low_find, map_y_grid_.end(), [&bounds](const int y) {
-          return y > bounds.yMax();
-        });
+      = std::upper_bound(y_low_find, map_y_grid_.end(), bounds.yMax());
 
   const int shape_x = static_cast<int>(map_.shape()[0]);
   const int shape_y = static_cast<int>(map_.shape()[1]);

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -344,18 +344,18 @@ HeatMapDataSource::MapView HeatMapDataSource::getMapView(
       map_x_grid_.begin(), map_x_grid_.end(), [&bounds](const int x) {
         return x >= bounds.xMin();
       });
-  const auto x_high_find = std::find_if(
-      map_x_grid_.begin(), map_x_grid_.end(), [&bounds](const int x) {
-        return x > bounds.xMax();
-      });
+  const auto x_high_find
+      = std::find_if(x_low_find, map_x_grid_.end(), [&bounds](const int x) {
+          return x > bounds.xMax();
+        });
   const auto y_low_find = std::find_if(
       map_y_grid_.begin(), map_y_grid_.end(), [&bounds](const int y) {
         return y >= bounds.yMin();
       });
-  const auto y_high_find = std::find_if(
-      map_y_grid_.begin(), map_y_grid_.end(), [&bounds](const int y) {
-        return y > bounds.yMax();
-      });
+  const auto y_high_find
+      = std::find_if(y_low_find, map_y_grid_.end(), [&bounds](const int y) {
+          return y > bounds.yMax();
+        });
 
   const int shape_x = static_cast<int>(map_.shape()[0]);
   const int shape_y = static_cast<int>(map_.shape()[1]);

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -461,31 +461,39 @@ void HeatMapDataSource::populateXYGrid()
   const int x_grid = std::ceil(bounds.dx() / static_cast<double>(dx));
   const int y_grid = std::ceil(bounds.dy() / static_cast<double>(dy));
 
-  std::set<int> x_grid_set, y_grid_set;
+  std::vector<int> x_grid_set, y_grid_set;
   for (int x = 0; x < x_grid; x++) {
     const int xMin = bounds.xMin() + x * dx;
     const int xMax = std::min(xMin + dx, bounds.xMax());
-    x_grid_set.insert(xMin);
-    x_grid_set.insert(xMax);
+    if (x == 0) {
+      x_grid_set.push_back(xMin);
+    }
+    x_grid_set.push_back(xMax);
   }
   for (int y = 0; y < y_grid; y++) {
     const int yMin = bounds.yMin() + y * dy;
     const int yMax = std::min(yMin + dy, bounds.yMax());
-    y_grid_set.insert(yMin);
-    y_grid_set.insert(yMax);
+    if (y == 0) {
+      y_grid_set.push_back(yMin);
+    }
+    y_grid_set.push_back(yMax);
   }
 
-  map_x_grid_.clear();
-  map_x_grid_.insert(map_x_grid_.end(), x_grid_set.begin(), x_grid_set.end());
-  map_y_grid_.clear();
-  map_y_grid_.insert(map_y_grid_.end(), y_grid_set.begin(), y_grid_set.end());
+  setXYMapGrid(x_grid_set, y_grid_set);
 }
 
 void HeatMapDataSource::setXYMapGrid(const std::vector<int>& x_grid,
                                      const std::vector<int>& y_grid)
 {
-  map_x_grid_ = x_grid;
-  map_y_grid_ = y_grid;
+  // ensure sorted and uniqueness
+  const std::set<int> x_grid_set(x_grid.begin(), x_grid.end());
+  const std::set<int> y_grid_set(y_grid.begin(), y_grid.end());
+
+  map_x_grid_.clear();
+  map_y_grid_.clear();
+
+  map_x_grid_.insert(map_x_grid_.end(), x_grid_set.begin(), x_grid_set.end());
+  map_y_grid_.insert(map_y_grid_.end(), y_grid_set.begin(), y_grid_set.end());
 }
 
 void HeatMapDataSource::destroyMap()

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -460,20 +460,26 @@ bool HeatMapDataSource::hasData() const
 
 void HeatMapDataSource::ensureMap()
 {
+  std::unique_lock<std::mutex> lock(ensure_mutex_);
+
   if (destroy_map_) {
+    debugPrint(logger_, utl::GUI, "HeatMap", 1, "Destroying map");
     clearMap();
     destroy_map_ = false;
   }
 
   const bool build_map = map_[0][0] == nullptr;
   if (build_map) {
+    debugPrint(logger_, utl::GUI, "HeatMap", 1, "Setting up map");
     setupMap();
   }
 
   if (build_map || !isPopulated()) {
+    debugPrint(logger_, utl::GUI, "HeatMap", 1, "Populating map");
     populated_ = populateMap();
 
     if (isPopulated()) {
+      debugPrint(logger_, utl::GUI, "HeatMap", 1, "Correcting map scale");
       correctMapScale(map_);
     }
 
@@ -486,6 +492,7 @@ void HeatMapDataSource::ensureMap()
   }
 
   if (!colors_correct_ && isPopulated()) {
+    debugPrint(logger_, utl::GUI, "HeatMap", 1, "Assigning map colors");
     assignMapColors();
   }
 }

--- a/src/gui/src/heatMapRUDY.cpp
+++ b/src/gui/src/heatMapRUDY.cpp
@@ -130,4 +130,24 @@ void RUDYDataSource::inDbPostMoveInst(odb::dbInst*)
   destroyMap();
 }
 
+void RUDYDataSource::inDbITermPostDisconnect(odb::dbITerm*, odb::dbNet*)
+{
+  destroyMap();
+}
+
+void RUDYDataSource::inDbITermPostConnect(odb::dbITerm*)
+{
+  destroyMap();
+}
+
+void RUDYDataSource::inDbBTermPostConnect(odb::dbBTerm*)
+{
+  destroyMap();
+}
+
+void RUDYDataSource::inDbBTermPostDisConnect(odb::dbBTerm*, odb::dbNet*)
+{
+  destroyMap();
+}
+
 }  // namespace gui

--- a/src/gui/src/heatMapRUDY.cpp
+++ b/src/gui/src/heatMapRUDY.cpp
@@ -149,6 +149,10 @@ void RUDYDataSource::populateXYGrid()
   gCellGrid->getGridX(gcell_xgrid);
   gCellGrid->getGridY(gcell_ygrid);
 
+  const auto die_area = getBlock()->getDieArea();
+  gcell_xgrid.push_back(die_area.xMax());
+  gcell_ygrid.push_back(die_area.yMax());
+
   setXYMapGrid(gcell_xgrid, gcell_ygrid);
 }
 

--- a/src/gui/src/heatMapRUDY.cpp
+++ b/src/gui/src/heatMapRUDY.cpp
@@ -57,14 +57,17 @@ double RUDYDataSource::getGridXSize() const
     return default_grid_;
   }
 
-  std::vector<int> grid;
-  gCellGrid->getGridX(grid);
+  int max_gridx = 0;
+  for (int i = 0; i < gCellGrid->getNumGridPatternsX(); i++) {
+    int origin, count, step;
+    gCellGrid->getGridPatternX(i, origin, count, step);
+    max_gridx = std::max(max_gridx, step);
+  }
 
-  if (grid.size() < 2) {
+  if (max_gridx == 0) {
     return default_grid_;
   }
-  const double delta = grid[1] - grid[0];
-  return delta / getBlock()->getDbUnitsPerMicron();
+  return max_gridx / getBlock()->getDbUnitsPerMicron();
 }
 
 double RUDYDataSource::getGridYSize() const
@@ -78,14 +81,17 @@ double RUDYDataSource::getGridYSize() const
     return default_grid_;
   }
 
-  std::vector<int> grid;
-  gCellGrid->getGridY(grid);
+  int max_gridy = 0;
+  for (int i = 0; i < gCellGrid->getNumGridPatternsY(); i++) {
+    int origin, count, step;
+    gCellGrid->getGridPatternY(i, origin, count, step);
+    max_gridy = std::max(max_gridy, step);
+  }
 
-  if (grid.size() < 2) {
+  if (max_gridy == 0) {
     return default_grid_;
   }
-  const double delta = grid[1] - grid[0];
-  return delta / getBlock()->getDbUnitsPerMicron();
+  return max_gridy / getBlock()->getDbUnitsPerMicron();
 }
 
 void RUDYDataSource::combineMapData(bool base_has_value,

--- a/src/gui/src/heatMapRUDY.cpp
+++ b/src/gui/src/heatMapRUDY.cpp
@@ -36,62 +36,12 @@
 
 namespace gui {
 
-RUDYDataSource::RUDYDataSource(utl::Logger* logger, odb::dbDatabase* db)
-    : gui::HeatMapDataSource(logger,
-                             "Estimated Congestion (RUDY)",
-                             "RUDY",
-                             "RUDY")
+RUDYDataSource::RUDYDataSource(utl::Logger* logger)
+    : GlobalRoutingDataSource(logger,
+                              "Estimated Congestion (RUDY)",
+                              "RUDY",
+                              "RUDY")
 {
-  logger_ = logger;
-  db_ = db;
-}
-
-double RUDYDataSource::getGridXSize() const
-{
-  if (getBlock() == nullptr) {
-    return default_grid_;
-  }
-
-  auto* gCellGrid = getBlock()->getGCellGrid();
-  if (gCellGrid == nullptr) {
-    return default_grid_;
-  }
-
-  int max_gridx = 0;
-  for (int i = 0; i < gCellGrid->getNumGridPatternsX(); i++) {
-    int origin, count, step;
-    gCellGrid->getGridPatternX(i, origin, count, step);
-    max_gridx = std::max(max_gridx, step);
-  }
-
-  if (max_gridx == 0) {
-    return default_grid_;
-  }
-  return max_gridx / getBlock()->getDbUnitsPerMicron();
-}
-
-double RUDYDataSource::getGridYSize() const
-{
-  if (getBlock() == nullptr) {
-    return default_grid_;
-  }
-
-  auto* gCellGrid = getBlock()->getGCellGrid();
-  if (gCellGrid == nullptr) {
-    return default_grid_;
-  }
-
-  int max_gridy = 0;
-  for (int i = 0; i < gCellGrid->getNumGridPatternsY(); i++) {
-    int origin, count, step;
-    gCellGrid->getGridPatternY(i, origin, count, step);
-    max_gridy = std::max(max_gridy, step);
-  }
-
-  if (max_gridy == 0) {
-    return default_grid_;
-  }
-  return max_gridy / getBlock()->getDbUnitsPerMicron();
 }
 
 void RUDYDataSource::combineMapData(bool base_has_value,
@@ -134,28 +84,6 @@ void RUDYDataSource::setBlock(odb::dbBlock* block)
   rudyInfo_ = std::make_unique<odb::RUDYCalculator>(getBlock());
 }
 
-void RUDYDataSource::populateXYGrid()
-{
-  if (getBlock() == nullptr) {
-    HeatMapDataSource::populateXYGrid();
-  }
-
-  auto* gCellGrid = getBlock()->getGCellGrid();
-  if (gCellGrid == nullptr) {
-    HeatMapDataSource::populateXYGrid();
-  }
-
-  std::vector<int> gcell_xgrid, gcell_ygrid;
-  gCellGrid->getGridX(gcell_xgrid);
-  gCellGrid->getGridY(gcell_ygrid);
-
-  const auto die_area = getBlock()->getDieArea();
-  gcell_xgrid.push_back(die_area.xMax());
-  gcell_ygrid.push_back(die_area.yMax());
-
-  setXYMapGrid(gcell_xgrid, gcell_ygrid);
-}
-
 void RUDYDataSource::onShow()
 {
   HeatMapDataSource::onShow();
@@ -192,17 +120,7 @@ void RUDYDataSource::inDbInstPlacementStatusBefore(
   destroyMap();
 }
 
-void RUDYDataSource::inDbInstSwapMasterBefore(odb::dbInst*, odb::dbMaster*)
-{
-  destroyMap();
-}
-
 void RUDYDataSource::inDbInstSwapMasterAfter(odb::dbInst*)
-{
-  destroyMap();
-}
-
-void RUDYDataSource::inDbPreMoveInst(odb::dbInst*)
 {
   destroyMap();
 }

--- a/src/gui/src/heatMapRUDY.h
+++ b/src/gui/src/heatMapRUDY.h
@@ -59,6 +59,10 @@ class RUDYDataSource : public GlobalRoutingDataSource,
                                      const odb::dbPlacementStatus&) override;
   void inDbInstSwapMasterAfter(odb::dbInst*) override;
   void inDbPostMoveInst(odb::dbInst*) override;
+  void inDbITermPostDisconnect(odb::dbITerm*, odb::dbNet*) override;
+  void inDbITermPostConnect(odb::dbITerm*) override;
+  void inDbBTermPostConnect(odb::dbBTerm*) override;
+  void inDbBTermPostDisConnect(odb::dbBTerm*, odb::dbNet*) override;
 
  protected:
   bool populateMap() override;

--- a/src/gui/src/heatMapRUDY.h
+++ b/src/gui/src/heatMapRUDY.h
@@ -33,16 +33,33 @@
 #pragma once
 
 #include "gui/heatMap.h"
+#include "odb/dbBlockCallBackObj.h"
 #include "odb/util.h"
 
 namespace gui {
-class RUDYDataSource : public gui::HeatMapDataSource
+class RUDYDataSource : public gui::HeatMapDataSource,
+                       public odb::dbBlockCallBackObj
 {
  public:
   RUDYDataSource(utl::Logger* logger, odb::dbDatabase* db);
   bool canAdjustGrid() const override { return false; }
   double getGridXSize() const override;
   double getGridYSize() const override;
+
+  virtual void onShow() override;
+  virtual void onHide() override;
+
+  // from dbBlockCallBackObj API
+  virtual void inDbInstCreate(odb::dbInst*) override;
+  virtual void inDbInstCreate(odb::dbInst*, odb::dbRegion*) override;
+  virtual void inDbInstDestroy(odb::dbInst*) override;
+  virtual void inDbInstPlacementStatusBefore(
+      odb::dbInst*,
+      const odb::dbPlacementStatus&) override;
+  virtual void inDbInstSwapMasterBefore(odb::dbInst*, odb::dbMaster*) override;
+  virtual void inDbInstSwapMasterAfter(odb::dbInst*) override;
+  virtual void inDbPreMoveInst(odb::dbInst*) override;
+  virtual void inDbPostMoveInst(odb::dbInst*) override;
 
  protected:
   bool populateMap() override;
@@ -53,6 +70,7 @@ class RUDYDataSource : public gui::HeatMapDataSource
                       const double intersection_area,
                       const double rect_area) override;
   void setBlock(odb::dbBlock* block) override;
+  void populateXYGrid() override;
 
  private:
   static constexpr int default_grid_ = 10;

--- a/src/gui/src/heatMapRUDY.h
+++ b/src/gui/src/heatMapRUDY.h
@@ -36,30 +36,29 @@
 #include "odb/dbBlockCallBackObj.h"
 #include "odb/util.h"
 
+namespace odb {
+class dbDatabase;
+}
+
 namespace gui {
-class RUDYDataSource : public gui::HeatMapDataSource,
+
+class RUDYDataSource : public GlobalRoutingDataSource,
                        public odb::dbBlockCallBackObj
 {
  public:
-  RUDYDataSource(utl::Logger* logger, odb::dbDatabase* db);
-  bool canAdjustGrid() const override { return false; }
-  double getGridXSize() const override;
-  double getGridYSize() const override;
+  RUDYDataSource(utl::Logger* logger);
 
-  virtual void onShow() override;
-  virtual void onHide() override;
+  void onShow() override;
+  void onHide() override;
 
   // from dbBlockCallBackObj API
-  virtual void inDbInstCreate(odb::dbInst*) override;
-  virtual void inDbInstCreate(odb::dbInst*, odb::dbRegion*) override;
-  virtual void inDbInstDestroy(odb::dbInst*) override;
-  virtual void inDbInstPlacementStatusBefore(
-      odb::dbInst*,
-      const odb::dbPlacementStatus&) override;
-  virtual void inDbInstSwapMasterBefore(odb::dbInst*, odb::dbMaster*) override;
-  virtual void inDbInstSwapMasterAfter(odb::dbInst*) override;
-  virtual void inDbPreMoveInst(odb::dbInst*) override;
-  virtual void inDbPostMoveInst(odb::dbInst*) override;
+  void inDbInstCreate(odb::dbInst*) override;
+  void inDbInstCreate(odb::dbInst*, odb::dbRegion*) override;
+  void inDbInstDestroy(odb::dbInst*) override;
+  void inDbInstPlacementStatusBefore(odb::dbInst*,
+                                     const odb::dbPlacementStatus&) override;
+  void inDbInstSwapMasterAfter(odb::dbInst*) override;
+  void inDbPostMoveInst(odb::dbInst*) override;
 
  protected:
   bool populateMap() override;
@@ -70,13 +69,9 @@ class RUDYDataSource : public gui::HeatMapDataSource,
                       const double intersection_area,
                       const double rect_area) override;
   void setBlock(odb::dbBlock* block) override;
-  void populateXYGrid() override;
 
  private:
-  static constexpr int default_grid_ = 10;
   std::unique_ptr<odb::RUDYCalculator> rudyInfo_;
-  odb::dbDatabase* db_;
-  utl::Logger* logger_;
 };
 
 }  // namespace gui

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1180,7 +1180,13 @@ void RenderThread::drawGCellGrid(QPainter* painter, const odb::Rect& bounds)
     return;
   }
 
-  const odb::Rect draw_bounds = bounds.intersect(viewer_->block_->getDieArea());
+  const auto die_area = viewer_->block_->getDieArea();
+
+  if (!bounds.intersects(die_area)) {
+    return;
+  }
+
+  const odb::Rect draw_bounds = bounds.intersect(die_area);
 
   std::vector<int> x_grid, y_grid;
   grid->getGridX(x_grid);

--- a/src/gui/src/stub_heatMap.cpp
+++ b/src/gui/src/stub_heatMap.cpp
@@ -195,4 +195,29 @@ void RealValueHeatMapDataSource::determineMinMax(
 {
 }
 
+//////////
+
+GlobalRoutingDataSource::GlobalRoutingDataSource(
+    utl::Logger* logger,
+    const std::string& name,
+    const std::string& short_name,
+    const std::string& settings_group)
+    : HeatMapDataSource(logger, name, short_name, settings_group)
+{
+}
+
+void GlobalRoutingDataSource::populateXYGrid()
+{
+}
+
+double GlobalRoutingDataSource::getGridXSize() const
+{
+  return HeatMapDataSource::getGridXSize();
+}
+
+double GlobalRoutingDataSource::getGridYSize() const
+{
+  return HeatMapDataSource::getGridYSize();
+}
+
 }  // namespace gui

--- a/src/gui/src/stub_heatMap.cpp
+++ b/src/gui/src/stub_heatMap.cpp
@@ -134,6 +134,15 @@ odb::Rect HeatMapDataSource::getBounds() const
   return {};
 }
 
+void HeatMapDataSource::populateXYGrid()
+{
+}
+
+void HeatMapDataSource::setXYMapGrid(const std::vector<int>& x_grid,
+                                     const std::vector<int>& y_grid)
+{
+}
+
 //////////
 
 RealValueHeatMapDataSource::RealValueHeatMapDataSource(

--- a/src/odb/include/odb/util.h
+++ b/src/odb/include/odb/util.h
@@ -487,6 +487,7 @@ class RUDYCalculator
     void setRect(int lx, int ly, int ux, int uy);
     void addRUDY(float rudy);
     float getRUDY() const { return rudy_; }
+    void clearRUDY() { rudy_ = 0.0; }
 
    private:
     odb::Rect rect_;

--- a/src/odb/src/zutil/util.cpp
+++ b/src/odb/src/zutil/util.cpp
@@ -102,6 +102,13 @@ void RUDYCalculator::makeGrid()
 
 void RUDYCalculator::calculateRUDY()
 {
+  // Clear previous computation
+  for (auto& gridColumn : grid_) {
+    for (auto& tile : gridColumn) {
+      tile.clearRUDY();
+    }
+  }
+
   // refer: https://ieeexplore.ieee.org/document/4211973
   const int tile_width = gridBlock_.dx() / tileCntX_;
   const int tile_height = gridBlock_.dy() / tileCntY_;


### PR DESCRIPTION
Changes:
- allow for heatmaps to have non-uniform grids
- add reset to RUDY calculation, otherwise each call just sums on the previous
- add db callbacks to RUDY heatmap to update when instances move
- add mutex to heatmap `ensureMap` to prevent RenderThread from calling it more than once at a time

Closes: #4618
