### PR TITLE
grt: fastroute: maze.cpp: Parallelized getOverflow3D with OpenMP

### DIFF
--- a/src/grt/src/fastroute/CMakeLists.txt
+++ b/src/grt/src/fastroute/CMakeLists.txt
@@ -34,6 +34,8 @@
 ## POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
+find_package(OpenMP REQUIRED)
+
 add_library(FastRoute4.1
   src/FastRoute.cpp
   src/RSMT.cpp
@@ -59,4 +61,5 @@ target_link_libraries(FastRoute4.1
     stt_lib
     odb
     Boost::boost
+    OpenMP::OpenMP_CXX
 )


### PR DESCRIPTION
This PR:

* introduces usage of OpenMP to `grt::FastRouteCore::getOverflow3D` method to run overflow computation in parallel
* removes unused `max_H_overflow` and `max_V_overflow` computation

The comparison of speed (checked on 16 threads machine):

| grt        | master                      | PR                          |
|------------|-----------------------------|-----------------------------|
| ariane     | 9:20 (min: 9:11, max: 9:36) | 8:51 (min: 8:44, max: 8:47) |
| tinyRocket | 0:25 (min: 0:25, max: 0:25) | 0:22 (min: 0:22, max: 0:22) |
| ibex       | 0:43 (min: 0:42, max: 0:43) | 0:42 (min: 0:42, max: 0:42) |