### PR TITLE
gui: draw ellipsis animation while rendering

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1093,7 +1093,7 @@ odb::Point LayoutViewer::findNextSnapPoint(const odb::Point& end_pt,
 
 void LayoutViewer::mousePressEvent(QMouseEvent* event)
 {
-  if (!hasDesign()) {
+  if (!hasDesign() || !viewer_thread_.isFirstRenderDone()) {
     return;
   }
 
@@ -1124,7 +1124,7 @@ void LayoutViewer::mousePressEvent(QMouseEvent* event)
 
 void LayoutViewer::mouseMoveEvent(QMouseEvent* event)
 {
-  if (!hasDesign()) {
+  if (!hasDesign() || !viewer_thread_.isFirstRenderDone()) {
     return;
   }
 
@@ -1187,7 +1187,7 @@ void LayoutViewer::mouseMoveEvent(QMouseEvent* event)
 
 void LayoutViewer::mouseReleaseEvent(QMouseEvent* event)
 {
-  if (!hasDesign()) {
+  if (!hasDesign() || !viewer_thread_.isFirstRenderDone()) {
     return;
   }
 

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1709,7 +1709,7 @@ void LayoutViewer::drawLoadingIndicator(QPainter* painter, const QRect& bounds)
 }
 
 QRect LayoutViewer::computeIndicatorBackground(QPainter* painter,
-                                               const QRect& bounds)
+                                               const QRect& bounds) const
 {
   painter->setFont(painter->font());
 

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1220,6 +1220,9 @@ void LayoutViewer::mouseReleaseEvent(QMouseEvent* event)
     rubber_band_dbu.set_yhi(qMin(rubber_band_dbu.yMax(), bbox.yMax()));
 
     if (event->button() == Qt::LeftButton) {
+      should_indicate_rendering_ = true;
+      repaint();
+
       auto selection = selectAt(rubber_band_dbu);
       if (!(qGuiApp->keyboardModifiers() & Qt::ShiftModifier)) {
         emit selected(Selected());  // remove previous selections

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -354,7 +354,8 @@ class LayoutViewer : public QWidget
 
   void drawScaleBar(QPainter* painter, const QRect& rect);
   void drawLoadingIndicator(QPainter* painter, const QRect& bounds);
-  QRect computeIndicatorBackground(QPainter* painter, const QRect& bounds);
+  QRect computeIndicatorBackground(QPainter* painter,
+                                   const QRect& bounds) const;
 
   void populateModuleColors();
 

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -353,8 +353,8 @@ class LayoutViewer : public QWidget
   bool isNetVisible(odb::dbNet* net);
 
   void drawScaleBar(QPainter* painter, const QRect& rect);
-  void drawRenderingIndication(QPainter* painter, const QRect& bounds);
-  QRect computeIndicationBackground(QPainter* painter, const QRect& bounds);
+  void drawLoadingIndicator(QPainter* painter, const QRect& bounds);
+  QRect computeIndicatorBackground(QPainter* painter, const QRect& bounds);
 
   void populateModuleColors();
 
@@ -439,12 +439,12 @@ class LayoutViewer : public QWidget
   const std::set<odb::dbNet*>& route_guides_;
   const std::set<odb::dbNet*>& net_tracks_;
 
-  bool should_indicate_rendering_ = false;
+  bool should_indicate_loading_ = false;
 
   RenderThread viewer_thread_;
   QPixmap draw_pixmap_;
   QRect draw_pixmap_bounds_;
-  const std::string rendering_indication_ = "...";
+  const std::string loading_indicator_ = "...";
 
   static constexpr qreal zoom_scale_factor_ = 1.2;
 

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -353,6 +353,8 @@ class LayoutViewer : public QWidget
   bool isNetVisible(odb::dbNet* net);
 
   void drawScaleBar(QPainter* painter, const QRect& rect);
+  void drawRenderingIndication(QPainter* painter, const QRect& bounds);
+  QRect computeIndicationBackground(QPainter* painter, const QRect& bounds);
 
   void populateModuleColors();
 
@@ -437,9 +439,12 @@ class LayoutViewer : public QWidget
   const std::set<odb::dbNet*>& route_guides_;
   const std::set<odb::dbNet*>& net_tracks_;
 
+  bool should_indicate_rendering_ = false;
+
   RenderThread viewer_thread_;
   QPixmap draw_pixmap_;
   QRect draw_pixmap_bounds_;
+  const std::string rendering_indication_ = "...";
 
   static constexpr qreal zoom_scale_factor_ = 1.2;
 

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -282,6 +282,7 @@ class LayoutViewer : public QWidget
  private slots:
   void setBlock(odb::dbBlock* block);
   void updatePixmap(const QImage& image, const QRect& bounds);
+  void handleLoadingIndication();
 
  private:
   struct Boxes
@@ -356,6 +357,7 @@ class LayoutViewer : public QWidget
   void drawLoadingIndicator(QPainter* painter, const QRect& bounds);
   QRect computeIndicatorBackground(QPainter* painter,
                                    const QRect& bounds) const;
+  void setLoadingState();
 
   void populateModuleColors();
 
@@ -440,12 +442,11 @@ class LayoutViewer : public QWidget
   const std::set<odb::dbNet*>& route_guides_;
   const std::set<odb::dbNet*>& net_tracks_;
 
-  bool should_indicate_loading_ = false;
-
   RenderThread viewer_thread_;
   QPixmap draw_pixmap_;
   QRect draw_pixmap_bounds_;
-  const std::string loading_indicator_ = "...";
+  QTimer* loading_timer_;
+  std::string loading_indicator_;
 
   static constexpr qreal zoom_scale_factor_ = 1.2;
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -144,20 +144,20 @@ void RenderThread::run()
   }
 }
 
-void RenderThread::drawRenderIndication(Painter& painter,
-                                        const odb::Rect& bounds)
+void RenderThread::drawDesignLoadingMessage(Painter& painter,
+                                            const odb::Rect& bounds)
 {
   QPainter* qpainter = static_cast<GuiPainter&>(painter).getPainter();
   const QFont initial_font = qpainter->font();
-  QFont indication_render_font = qpainter->font();
-  indication_render_font.setPointSize(16);
+  QFont design_loading_font = qpainter->font();
+  design_loading_font.setPointSize(16);
 
-  qpainter->setFont(indication_render_font);
+  qpainter->setFont(design_loading_font);
 
-  std::string rendering_message = "Design loading...";
+  std::string message = "Design loading...";
   painter.setPen(gui::Painter::white, true);
   painter.drawString(
-      bounds.xCenter(), bounds.yCenter(), Painter::CENTER, rendering_message);
+      bounds.xCenter(), bounds.yCenter(), Painter::CENTER, message);
 
   qpainter->setFont(initial_font);
 }
@@ -197,7 +197,7 @@ void RenderThread::draw(QImage& image,
                          viewer_->block_->getDbUnitsPerMicron());
 
   if (!is_first_render_done_ && !restart_) {
-    drawRenderIndication(gui_painter, dbu_bounds);
+    drawDesignLoadingMessage(gui_painter, dbu_bounds);
     emit done(image, draw_bounds);
     is_first_render_done_ = true;
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -130,6 +130,10 @@ void RenderThread::run()
          Qt::transparent);
     if (!restart_) {
       emit done(image, draw_bounds);
+
+      if (!is_first_render_done_) {
+        is_first_render_done_ = true;
+      }
     }
     if (abort_) {
       return;
@@ -199,7 +203,6 @@ void RenderThread::draw(QImage& image,
   if (!is_first_render_done_ && !restart_) {
     drawDesignLoadingMessage(gui_painter, dbu_bounds);
     emit done(image, draw_bounds);
-    is_first_render_done_ = true;
 
     // Erase the first render indication so it does not remain on the screen
     // when the design is drawn for the first time

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -86,6 +86,9 @@ void RenderThread::render(const QRect& draw_rect,
     return;
   }
 
+  is_rendering_ = true;
+  viewer_->setLoadingState();
+
   QMutexLocker locker(&mutex_);
   draw_rect_ = draw_rect;
   selected_ = selected;
@@ -129,6 +132,8 @@ void RenderThread::run()
          1.0,
          Qt::transparent);
     if (!restart_) {
+      is_rendering_ = false;
+
       emit done(image, draw_bounds);
 
       if (!is_first_render_done_) {

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -73,6 +73,8 @@ class RenderThread : public QThread
             qreal render_ratio,
             const QColor& background);
 
+  bool isFirstRenderDone() { return is_first_render_done_; };
+
  signals:
   void done(const QImage& image, const QRect& bounds);
 

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -152,7 +152,7 @@ class RenderThread : public QThread
   QColor getColor(odb::dbTechLayer* layer);
   Qt::BrushStyle getPattern(odb::dbTechLayer* layer);
 
-  void drawRenderIndication(Painter& painter, const odb::Rect& bounds);
+  void drawDesignLoadingMessage(Painter& painter, const odb::Rect& bounds);
 
   utl::Logger* logger_ = nullptr;
   LayoutViewer* viewer_;

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -74,6 +74,7 @@ class RenderThread : public QThread
             const QColor& background);
 
   bool isFirstRenderDone() { return is_first_render_done_; };
+  bool isRendering() { return is_rendering_; };
 
  signals:
   void done(const QImage& image, const QRect& bounds);
@@ -173,6 +174,7 @@ class RenderThread : public QThread
   QWaitCondition condition_;
   bool restart_ = false;
   bool abort_ = false;
+  bool is_rendering_ = false;
   bool is_first_render_done_ = false;
 
   QFont pin_font_;


### PR DESCRIPTION
Fix #4450 

Also making a small change to prevent interactions between the cursor and the layoutViewer while the design loading message is drawn.