### PR TITLE
grt: avoiding generating congestion reports in the incremental GRT stage

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3902,6 +3902,7 @@ void GlobalRouter::updateDirtyRoutes(bool save_guides)
     const float old_critical_nets_percentage
         = fastroute_->getCriticalNetsPercentage();
     fastroute_->setCriticalNetsPercentage(0);
+    fastroute_->setCongestionReportIterStep(0);
 
     initFastRouteIncr(dirty_nets);
 
@@ -3944,6 +3945,7 @@ void GlobalRouter::updateDirtyRoutes(bool save_guides)
       }
     }
     fastroute_->setCriticalNetsPercentage(old_critical_nets_percentage);
+    fastroute_->setCongestionReportIterStep(congestion_report_iter_step_);
     if (save_guides) {
       saveGuides();
     }


### PR DESCRIPTION
Avoiding generating congestion reports in Fastroute overflow iterations when incremental GRT is being executed.