### PR TITLE
dpo: optimize DetailedMis::gatherNeighbours

### DIFF
--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -498,15 +498,14 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
               || ndi->getHeight() != ndj->getHeight()))
         continue;
 
-      // Must span the same number of rows and also be voltage compatible.
-      const int spanned_j = std::lround(ndj->getHeight() / singleRowHeight);
-      if (spanned_i != spanned_j
-          || ndi->getBottomPower() != ndj->getBottomPower()
-          || ndi->getTopPower() != ndj->getTopPower())
-        continue;
-
       // Must be in the same region.
       if (ndj->getRegionId() != ndi->getRegionId())
+        continue;
+
+      // Must span the same number of rows and also be voltage compatible.
+      if (ndi->getBottomPower() != ndj->getBottomPower()
+          || ndi->getTopPower() != ndj->getTopPower()
+          || spanned_i != std::lround(ndj->getHeight() / singleRowHeight))
         continue;
 
       // If compatible, include this current cell.

--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -485,33 +485,33 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
       // Check to make sure the cell is not the original, that they have
       // the same region, that they have the same size (if applicable),
       // and that they have the same color (if applicable).
-      bool compat = ndj != ndi;  // diff nodes
-      if (compat) {
-        // Must be the same color to avoid sharing nets.
-        compat
-            = !useSameColor_ || colors_[ndi->getId()] == colors_[ndj->getId()];
-      }
-      if (compat) {
-        // Must be the same size.
-        compat = !useSameSize_
-                 || (ndi->getWidth() == ndj->getWidth()
-                     && ndi->getHeight() == ndj->getHeight());
-      }
-      if (compat) {
-        // Must span the same number of rows and also be voltage compatible.
-        compat = spanned_i == spanned_j
-                 && ndi->getBottomPower() == ndj->getBottomPower()
-                 && ndi->getTopPower() == ndj->getTopPower();
-      }
-      if (compat) {
-        // Must be in the same region.
-        compat = ndj->getRegionId() == ndi->getRegionId();
-      }
+
+      // diff nodes
+      if (ndj == ndi)
+        continue;
+
+      // Must be the same color to avoid sharing nets.
+      if (useSameColor_ && colors_[ndi->getId()] != colors_[ndj->getId()])
+        continue;
+
+      // Must be the same size.
+      if (useSameSize_
+          && (ndi->getWidth() != ndj->getWidth()
+              || ndi->getHeight() != ndj->getHeight()))
+        continue;
+
+      // Must span the same number of rows and also be voltage compatible.
+      if (spanned_i != spanned_j
+          || ndi->getBottomPower() != ndj->getBottomPower()
+          || ndi->getTopPower() != ndj->getTopPower())
+        continue;
+
+      // Must be in the same region.
+      if (ndj->getRegionId() != ndi->getRegionId())
+        continue;
 
       // If compatible, include this current cell.
-      if (compat) {
-        neighbours_.push_back(ndj);
-      }
+      neighbours_.push_back(ndj);
     }
 
     if (neighbours_.size() >= maxProblemSize_) {

--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -480,8 +480,6 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
     // Scan all the cells in this bucket.  If they are compatible with the
     // original cell, then add them to the neighbour list.
     for (Node* ndj : currPtr->nodes_) {
-      const int spanned_j = std::lround(ndj->getHeight() / singleRowHeight);
-
       // Check to make sure the cell is not the original, that they have
       // the same region, that they have the same size (if applicable),
       // and that they have the same color (if applicable).
@@ -501,6 +499,7 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
         continue;
 
       // Must span the same number of rows and also be voltage compatible.
+      const int spanned_j = std::lround(ndj->getHeight() / singleRowHeight);
       if (spanned_i != spanned_j
           || ndi->getBottomPower() != ndj->getBottomPower()
           || ndi->getTopPower() != ndj->getTopPower())

--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -517,16 +517,16 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
     }
 
     // Add more bins to the queue if we have not yet collected enough cells.
-    if (currPtr->i_ - 1 >= 0) {
+    if (currPtr->i_ > 0) {
       Q.push(grid_[currPtr->i_ - 1][currPtr->j_]);
     }
-    if (currPtr->i_ + 1 <= dimW_ - 1) {
+    if (currPtr->i_ + 1 < dimW_) {
       Q.push(grid_[currPtr->i_ + 1][currPtr->j_]);
     }
-    if (currPtr->j_ - 1 >= 0) {
+    if (currPtr->j_ > 0) {
       Q.push(grid_[currPtr->i_][currPtr->j_ - 1]);
     }
-    if (currPtr->j_ + 1 <= dimH_ - 1) {
+    if (currPtr->j_ + 1 < dimH_) {
       Q.push(grid_[currPtr->i_][currPtr->j_ + 1]);
     }
   }

--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -54,7 +54,7 @@
 #include <lemon/smart_graph.h>
 
 #include <boost/tokenizer.hpp>
-#include <deque>
+#include <queue>
 #include <vector>
 
 #include "architecture.h"
@@ -465,12 +465,12 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
 
   const int spanned_i = std::lround(ndi->getHeight() / singleRowHeight);
 
-  std::deque<Bucket*> Q;
-  Q.push_back(it->second);
+  std::queue<Bucket*> Q;
+  Q.push(it->second);
   ++traversal_;
   while (!Q.empty()) {
     Bucket* currPtr = Q.front();
-    Q.pop_front();
+    Q.pop();
 
     if (currPtr->travId_ == traversal_) {
       continue;
@@ -520,16 +520,16 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
 
     // Add more bins to the queue if we have not yet collected enough cells.
     if (currPtr->i_ - 1 >= 0) {
-      Q.push_back(grid_[currPtr->i_ - 1][currPtr->j_]);
+      Q.push(grid_[currPtr->i_ - 1][currPtr->j_]);
     }
     if (currPtr->i_ + 1 <= dimW_ - 1) {
-      Q.push_back(grid_[currPtr->i_ + 1][currPtr->j_]);
+      Q.push(grid_[currPtr->i_ + 1][currPtr->j_]);
     }
     if (currPtr->j_ - 1 >= 0) {
-      Q.push_back(grid_[currPtr->i_][currPtr->j_ - 1]);
+      Q.push(grid_[currPtr->i_][currPtr->j_ - 1]);
     }
     if (currPtr->j_ + 1 <= dimH_ - 1) {
-      Q.push_back(grid_[currPtr->i_][currPtr->j_ + 1]);
+      Q.push(grid_[currPtr->i_][currPtr->j_ + 1]);
     }
   }
   return true;

--- a/src/dpo/src/detailed_mis.cxx
+++ b/src/dpo/src/detailed_mis.cxx
@@ -485,28 +485,33 @@ bool DetailedMis::gatherNeighbours(Node* ndi)
       // and that they have the same color (if applicable).
 
       // diff nodes
-      if (ndj == ndi)
+      if (ndj == ndi) {
         continue;
+      }
 
       // Must be the same color to avoid sharing nets.
-      if (useSameColor_ && colors_[ndi->getId()] != colors_[ndj->getId()])
+      if (useSameColor_ && colors_[ndi->getId()] != colors_[ndj->getId()]) {
         continue;
+      }
 
       // Must be the same size.
       if (useSameSize_
           && (ndi->getWidth() != ndj->getWidth()
-              || ndi->getHeight() != ndj->getHeight()))
+              || ndi->getHeight() != ndj->getHeight())) {
         continue;
+      }
 
       // Must be in the same region.
-      if (ndj->getRegionId() != ndi->getRegionId())
+      if (ndj->getRegionId() != ndi->getRegionId()) {
         continue;
+      }
 
       // Must span the same number of rows and also be voltage compatible.
       if (ndi->getBottomPower() != ndj->getBottomPower()
           || ndi->getTopPower() != ndj->getTopPower()
-          || spanned_i != std::lround(ndj->getHeight() / singleRowHeight))
+          || spanned_i != std::lround(ndj->getHeight() / singleRowHeight)) {
         continue;
+      }
 
       // If compatible, include this current cell.
       neighbours_.push_back(ndj);


### PR DESCRIPTION
It adds a few simple changes to `DetailedMis::gatherNeighbours` function, which results in ~4.7% speedup in `place_dp` stage (measured on `black_parrot`).
It changes `std::deque` to `std::queue` (because the deque was used as a queue), simplifies the conditions, evaluates `std::lround` only if it is needed and moves that condition to the end and skips the rest of conditions after the first that don't pass.

Results (from 8 runs):
|                | min time [min]   | avg time [min]   | med time [min]   | max time [min]   | sum time [min]   |
|:--------------------------|:-----------------|:-----------------|:-----------------|:-----------------|:-----------------|
| master         | 2:40             | 2:44             | 2:45             | 2:46             | 21:52            |
| my branch     | 2:34             | 2:37             | 2:37             | 2:40             | 20:58            |