### PR TITLE
Fix pin swap of nested not operator

### DIFF
--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -890,7 +890,7 @@ RepairSetup::getEquivPortList2(sta::FuncExpr *expr,
     using Operator = sta::FuncExpr::Operator ;
     const Operator curr_op = expr->op();
 
-    if (curr_op == Operator::op_not) {
+    if (status == Operator::op_zero && curr_op == Operator::op_not) {
         getEquivPortList2(expr->left(), ports, status);
     }
     else if (status == Operator::op_zero &&


### PR DESCRIPTION
`RepairSetup::getEquivPortList2` determines which ports on a cell are equivalent, and therefore can be swapped to improve timing.  However, it incorrectly treats a single port inside a not operator as equivalent to a port that is not inside a not operator.  This means the output of the cell is negated if the pins are swapped.

If all ports are inside the not operator it should be allowed, but if the not operator only applies to some ports it must not be.  Therefore `op_not` should only be permitted if the status is `op_zero` (no operations performed yet).

This fixes #4647.

I have tested this fix on my repro case for #4647 and it resolves the problem.