### PR TITLE
odb code gen: Allows us to control method creation for schema relations

### DIFF
--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -125,7 +125,7 @@ for relation in schema["relations"]:
     inParentField["table"] = True
     inParentField["dbSetGetter"] = True
     inParentField["components"] = [inParentField["name"]]
-    inParentField["flags"] = ["cmp", "serial", "diff", "no-set", "get"]
+    inParentField["flags"] = ["cmp", "serial", "diff", "no-set", "get"] + relation.get("flags", [])
     if "schema" in relation:
         inParentField["schema"] = relation["schema"]
 


### PR DESCRIPTION
Use case:
        adding "flags" to the relations in schema.json so we can pass
        "no-get" to prevent the generation of default get methods