### PR TITLE
odb: adding a helper function to get the dbObjects of a dbVector with a generic OutputIterator

### DIFF
--- a/src/odb/src/db/dbTable.h
+++ b/src/odb/src/db/dbTable.h
@@ -171,6 +171,17 @@ class dbTable : public dbObjectTable, public dbIterator
   dbObject* getObject(uint id, ...) override;
   void getObjects(std::vector<T*>& objects);
 
+  template <class OutputIterator>
+  void getObjects(OutputIterator back_inserter)
+  {
+    uint i;
+    for (i = _bottom_idx; i <= _top_idx; ++i) {
+      if (validId(i)) {
+        back_inserter = getPtr(i);
+      }
+    }
+  }
+
  private:
   void copy_pages(const dbTable<T>&);
   void copy_page(uint page_id, dbTablePage* page);

--- a/src/odb/src/db/dbTable.hpp
+++ b/src/odb/src/db/dbTable.hpp
@@ -823,14 +823,7 @@ void dbTable<T>::getObjects(std::vector<T*>& objects)
 {
   objects.clear();
   objects.reserve(size());
-
-  uint i;
-
-  for (i = _bottom_idx; i <= _top_idx; ++i) {
-    if (validId(i)) {
-      objects.push_back(getPtr(i));
-    }
-  }
+  getObjects(std::back_inserter(objects));
 }
 
 }  // namespace odb


### PR DESCRIPTION
Use case:
  The original getObjects function fills a vector with the private class
  (underscore). In some cases, we want to return the public class.

  Without this implementation, we would need to create a temporal vector
  to hold the private class and then cast this into a new vector for the
  public class.