### PR TITLE
mpl2: consider macro dominance when computing io blockages' depth

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3150,8 +3150,8 @@ void HierRTLMP::setIOClustersBlockages()
   const float macro_dominance_factor
       = macro_with_halo_area_
         / (root_cluster_->getWidth() * root_cluster_->getHeight());
-  const float depth
-      = (std_cell_area / sum_length) * std::pow((1 - macro_dominance_factor), 2);
+  const float depth = (std_cell_area / sum_length)
+                      * std::pow((1 - macro_dominance_factor), 2);
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3151,7 +3151,7 @@ void HierRTLMP::setIOClustersBlockages()
       = macro_with_halo_area_
         / (root_cluster_->getWidth() * root_cluster_->getHeight());
   const float depth
-      = (std_cell_area / sum_length) * (1 - macro_dominance_factor);
+      = (std_cell_area / sum_length) * std::pow((1 - macro_dominance_factor), 2);
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -141,8 +141,7 @@ class HierRTLMP
   // General Hier-RTLMP flow functions
   void initMacroPlacer();
   void computeMetricsForModules(float core_area);
-  void reportLogicalHierarchyInformation(float macro_with_halo_area,
-                                         float core_area,
+  void reportLogicalHierarchyInformation(float core_area,
                                          float util,
                                          float core_util);
   void updateDataFlow();
@@ -389,6 +388,7 @@ class HierRTLMP
   float floorplan_ly_ = 0.0;
   float floorplan_ux_ = 0.0;
   float floorplan_uy_ = 0.0;
+  float macro_with_halo_area_ = 0.0;
 
   // dataflow parameters and store the dataflow
   int max_num_ff_dist_ = 5;  // maximum number of FF distances between


### PR DESCRIPTION
This PR is to ensure we don't generate huge io blockages and end up deteriorating QoR when using the changes in #4206.
The quadratic power is to make the factor more aggressive as the problems below were not solved using the factor without it.


Secure-CI for #4206 showed, among some other metrics failures, problems for the following designs:

gf121/ariane: [ERROR GPL-0307] RePlAce divergence detected. Re-run with a smaller max_phi_cof value.
tsmc65lp/bp_be: [ERROR DPL-0036] Detailed placement failed.

Both of these designs had huge io blockages for pin access. Running the changes here combined with #4206 lead both designs to finish without metric failures.

I'm starting a Secure-CI only for this.