### PR TITLE
tcl: use tclint config to control paths to make it easier to run locally

### DIFF
--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -14,37 +14,6 @@ jobs:
         run: |
           python -m pip install tclint==0.2.0
 
-      # TODO: hardcoded list of files while we incrementally lint codebase
-      # See issue #4347 for tracking
       - name: Lint
         run: |
-          tclint \
-            src/Metrics.tcl \
-            src/OpenRoad.tcl \
-            src/ant/src/AntennaChecker.tcl \
-            src/cts/src/TritonCTS.tcl \
-            src/dbSta/src/dbReadVerilog.tcl \
-            src/dbSta/src/dbSta.tcl \
-            src/dft/src/dft.tcl \
-            src/dpl/src/Opendp.tcl \
-            src/dpo/src/Optdp.tcl \
-            src/drt/src/TritonRoute.tcl \
-            src/dst/src/Distributed.tcl \
-            src/fin/src/finale.tcl \
-            src/gpl/src/replace.tcl \
-            src/grt/src/GlobalRouter.tcl \
-            src/gui/ \
-            src/ifp/src/InitFloorplan.tcl \
-            src/mpl/src/MacroPlacer.tcl \
-            src/mpl2/src/mpl.tcl \
-            src/pad/ \
-            src/par/src/partitionmgr.tcl \
-            src/pdn/ \
-            src/ppl/src/IOPlacer.tcl \
-            src/psm/ \
-            src/rcx/src/OpenRCX.tcl \
-            src/rmp/src/rmp.tcl \
-            src/rsz/src/Resizer.tcl \
-            src/stt/src/SteinerTreeBuilder.tcl \
-            src/tap/src/tapcell.tcl \
-            src/upf/src/upf.tcl
+          tclint .

--- a/tclint.toml
+++ b/tclint.toml
@@ -1,3 +1,40 @@
+# hardcoded list of paths to exclude while we incrementally lint codebase
+# See issue #4347 for tracking
+ exclude = [
+    "src/sta/",
+    "test/",
+    "src/ant/test/",
+    "src/cts/test/",
+    "src/dbSta/test/",
+    "src/dft/test/",
+    "src/dpl/test/",
+    "src/dpo/test/",
+    "src/drt/test/",
+    "src/dst/test/",
+    "src/fin/test/",
+    "src/gpl/test/",
+    "src/grt/etc/scripts/",
+    "src/grt/test/",
+    "src/ifp/test/",
+    "src/mpl/test/",
+    "src/mpl2/test/",
+    "src/odb/",
+    "src/par/examples/",
+    "src/par/test/",
+    "src/ppl/test/",
+    "src/rcx/calibration/",
+    "src/rcx/example/",
+    "src/rcx/rule_scripts/",
+    "src/rcx/test/",
+    "src/rmp/test/",
+    "src/rsz/test/",
+    "src/stt/test/",
+    "src/tap/etc/scripts/",
+    "src/tap/test/",
+    "src/upf/test/",
+    "src/utl/test/"
+]
+
 [style]
 indent = 2
 line-length = 100


### PR DESCRIPTION
This moves the paths to not be tclint-ed to the config file so its much easier to execute this test locally