### PR TITLE
Opendp: Fix missing include

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -46,7 +46,7 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <numeric> // accumulate
+#include <numeric>  // accumulate
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -46,6 +46,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <numeric> // accumulate
 #include <set>
 #include <string>
 #include <unordered_map>


### PR DESCRIPTION
We have been seeing this error in some build environments:
```
src/dpl/include/dpl/Opendp.h:230:17: error: 'accumulate' is not a member of 'std'
```

This is fixed by this patch.