### PR TITLE
gpl: fix out of bounds vector access

### DIFF
--- a/src/gpl/src/routeBase.cpp
+++ b/src/gpl/src/routeBase.cpp
@@ -557,10 +557,16 @@ std::pair<bool, bool> RouteBase::routability()
       continue;
     }
 
-    int idxX = (gCell->dCx() - tg_->lx()) / tg_->tileSizeX();
-    int idxY = (gCell->dCy() - tg_->ly()) / tg_->tileSizeY();
+    int idxX = std::min((gCell->dCx() - tg_->lx()) / tg_->tileSizeX(),
+                        tg_->tileCntX() - 1);
+    int idxY = std::min((gCell->dCy() - tg_->ly()) / tg_->tileSizeY(),
+                        tg_->tileCntY() - 1);
 
-    Tile* tile = tg_->tiles()[idxY * tg_->tileCntX() + idxX];
+    size_t index = idxY * tg_->tileCntX() + idxX;
+    if (index >= tg_->tiles().size()) {
+      continue;
+    }
+    Tile* tile = tg_->tiles()[index];
 
     // Don't care when inflRatio <= 1
     if (tile->inflatedRatio() <= 1.0) {


### PR DESCRIPTION
This fix aims to prevent out-of-bounds access in a vector that stores tiles within GPL code.

The issue arises when the code iterates over instances and accesses tiles using the instances' coordinates. Should an instance be positioned too close to the border, the existing code would calculate an index exceeding the maximum permissible value. This seems to occur due to the size extension applied to border tiles.

In my testing, this problem manifested in a singular scenario: running ihp/ibex with Yosys version 0.36. The implementation of this fix has successfully addressed the issue.

FYI: within GPL code, GCells refer to instances, such as global cells, and do not denote grid cells. This is based on my current understanding.