### PR TITLE
gui: add block name to window title to make it clearer which design is open

### DIFF
--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -391,7 +391,7 @@ MainWindow::MainWindow(QWidget* parent)
   // load resources and set window icon and title
   loadQTResources();
   setWindowIcon(QIcon(":/icon.png"));
-  setWindowTitle("OpenROAD");
+  setWindowTitle(window_title_);
 
   Descriptor::Property::convert_dbu
       = [this](int value, bool add_units) -> std::string {
@@ -420,6 +420,11 @@ void MainWindow::setDatabase(odb::dbDatabase* db)
 
 void MainWindow::setBlock(odb::dbBlock* block)
 {
+  if (block != nullptr) {
+    const std::string title
+        = fmt::format("{} - {}", window_title_, block->getName());
+    setWindowTitle(QString::fromStdString(title));
+  }
   for (auto* heat_map : Gui::get()->getHeatMaps()) {
     heat_map->setBlock(block);
   }

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -337,6 +337,8 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
 
   // heat map actions
   std::map<HeatMapDataSource*, QAction*> heatmap_actions_;
+
+  static constexpr const char* window_title_ = "OpenROAD";
 };
 
 }  // namespace gui


### PR DESCRIPTION
Changes:
* updates the window title to include the block name

No functional changes