### PR TITLE
Add APIs for LEF macro ANTENNADIFFAREA and ANTENNAGATEAREA 

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -5704,6 +5704,8 @@ class dbMTerm : public dbObject
   // From LEF's ANTENNADIFFAREA on the MACRO's PIN
   void getDiffArea(std::vector<std::pair<double, dbTechLayer*>>& data);
 
+  bool hasDiffArea();
+
   void* staPort();
   void staSetPort(void* port);
 
@@ -6665,6 +6667,7 @@ class dbTechAntennaPinModel : public dbObject
   void addMaxSideAreaCAREntry(double inval, dbTechLayer* refly = nullptr);
   void addMaxCutCAREntry(double inval, dbTechLayer* refly = nullptr);
 
+  bool hasGateArea();
   void getGateArea(std::vector<std::pair<double, dbTechLayer*>>& data);
   void getMaxAreaCAR(std::vector<std::pair<double, dbTechLayer*>>& data);
   void getMaxSideAreaCAR(std::vector<std::pair<double, dbTechLayer*>>& data);

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -5703,7 +5703,6 @@ class dbMTerm : public dbObject
 
   // From LEF's ANTENNADIFFAREA on the MACRO's PIN
   void getDiffArea(std::vector<std::pair<double, dbTechLayer*>>& data);
-
   bool hasDiffArea();
 
   void* staPort();

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -490,6 +490,16 @@ void dbMTerm::getDiffArea(std::vector<std::pair<double, dbTechLayer*>>& data)
       mterm->getDatabase(), mterm->_diffarea, data);
 }
 
+bool dbMTerm::hasDiffArea()
+{
+  std::vector<std::pair<double, dbTechLayer*>> diff_areas;
+  getDiffArea(diff_areas);
+  if (diff_areas.size() > 0)
+    return true;
+  else
+    return false;
+}
+
 void dbMTerm::writeAntennaLef(lefout& writer) const
 {
   _dbMTerm* mterm = (_dbMTerm*) this;

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -494,10 +494,7 @@ bool dbMTerm::hasDiffArea()
 {
   std::vector<std::pair<double, dbTechLayer*>> diff_areas;
   getDiffArea(diff_areas);
-  if (!diff_areas.empty()) {
-    return true;
-  }
-  return false;
+  return !diff_areas.empty();
 }
 
 void dbMTerm::writeAntennaLef(lefout& writer) const

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -494,10 +494,10 @@ bool dbMTerm::hasDiffArea()
 {
   std::vector<std::pair<double, dbTechLayer*>> diff_areas;
   getDiffArea(diff_areas);
-  if (diff_areas.size() > 0)
+  if (!diff_areas.empty()) {
     return true;
-  else
-    return false;
+  }
+  return false;
 }
 
 void dbMTerm::writeAntennaLef(lefout& writer) const

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -985,6 +985,16 @@ void _dbTechAntennaPinModel::getAntennaValues(
   }
 }
 
+bool dbTechAntennaPinModel::hasGateArea()
+{
+  vector<std::pair<double, dbTechLayer*>> gate_areas;
+  getGateArea(gate_areas);
+  if (gate_areas.size() > 0)
+    return true;
+  else
+    return false;
+}
+
 void dbTechAntennaPinModel::getGateArea(
     std::vector<std::pair<double, dbTechLayer*>>& data)
 {

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -990,6 +990,7 @@ bool dbTechAntennaPinModel::hasGateArea()
   vector<std::pair<double, dbTechLayer*>> gate_areas;
   getGateArea(gate_areas);
   return !gate_areas.empty();
+}
 
 void dbTechAntennaPinModel::getGateArea(
     std::vector<std::pair<double, dbTechLayer*>>& data)

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -989,10 +989,10 @@ bool dbTechAntennaPinModel::hasGateArea()
 {
   vector<std::pair<double, dbTechLayer*>> gate_areas;
   getGateArea(gate_areas);
-  if (gate_areas.size() > 0)
+  if (!gate_areas.empty()) {
     return true;
-  else
-    return false;
+  }
+  return false;
 }
 
 void dbTechAntennaPinModel::getGateArea(

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -989,11 +989,7 @@ bool dbTechAntennaPinModel::hasGateArea()
 {
   vector<std::pair<double, dbTechLayer*>> gate_areas;
   getGateArea(gate_areas);
-  if (!gate_areas.empty()) {
-    return true;
-  }
-  return false;
-}
+  return !gate_areas.empty();
 
 void dbTechAntennaPinModel::getGateArea(
     std::vector<std::pair<double, dbTechLayer*>>& data)


### PR DESCRIPTION
* Add dbTechAntennaPinModel.hasGateArea
* Add dbMTerm.hasDiffArea

---

The incentive behind this PR is to access the antenna information using python APIs. Currently, I was unable to call `getDiffArea` and `getGateArea` using the python APIs as they require passing a specific object which I was unable to create. 