### PR TITLE
ord: provide helper function to parse list arguments

### DIFF
--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -395,5 +395,34 @@ proc get_core_area { } {
   return $area
 }
 
+proc parse_list_args {cmd arg_var list_var lists_args} {
+  upvar 1 $arg_var args
+  upvar 1 $list_var list
+
+  foreach arg_opt $lists_args {
+    set remaining_args []
+
+    set list($arg_opt) []
+    for {set i 0} {$i < [llength $args]} {incr i} {
+      set arg [lindex $args $i]
+      if { [sta::is_keyword_arg $arg] } {
+        if { $arg == $arg_opt } {
+          incr i
+          if { [llength $args] == $i } {
+            utl::error ORD 560 "$cmd $arg_opt missing value."
+          }
+          lappend list($arg_opt) [lindex $args $i]
+        } else {
+          lappend remaining_args $arg
+        }
+      } else {
+        lappend remaining_args $arg
+      }
+    }
+
+    set args $remaining_args
+  }
+}
+
 # namespace ord
 }

--- a/src/gui/src/gui.tcl
+++ b/src/gui/src/gui.tcl
@@ -108,9 +108,21 @@ sta::define_cmd_args "save_image" {[-area {x0 y0 x1 y1}] \
 }
 
 proc save_image { args } {
-  set options [gui::parse_options $args]
+  ord::parse_list_args "save_image" args list {-display_option}
   sta::parse_key_args "save_image" args \
-    keys {-area -width -resolution -display_option} flags {}
+    keys {-area -width -resolution} flags {}
+
+  set options [gui::DisplayControlMap]
+  foreach opt $list(-display_option) {
+    if {[llength $opt] != 2} {
+      utl::error GUI 19 "Display option must have 2 elements {control name} {value}."
+    }
+
+    set key [lindex $opt 0]
+    set val [lindex $opt 1]
+
+    $options set $key $val
+  }
 
   set resolution 0
   if { [info exists keys(-resolution)] } {
@@ -165,10 +177,10 @@ sta::define_cmd_args "save_clocktree_image" {
 }
 
 proc save_clocktree_image { args } {
-  sta::parse_key_args "save_image" args \
+  sta::parse_key_args "save_clocktree_image" args \
     keys {-clock -width -height -corner} flags {}
 
-  sta::check_argc_eq1 "save_image" $args
+  sta::check_argc_eq1 "save_clocktree_image" $args
   set path [lindex $args 0]
 
   set width 0
@@ -329,31 +341,4 @@ proc focus_net { args } {
   } else {
     gui::focus_net $net
   }
-}
-
-namespace eval gui {
-proc parse_options { args_var } {
-  set options [gui::DisplayControlMap]
-  while { $args_var != {} } {
-    set arg [lindex $args_var 0]
-    if { $arg == "-display_option" } {
-      set opt [lindex $args_var 1]
-
-      if {[llength $opt] != 2} {
-        utl::error GUI 19 "Display option must have 2 elements {control name} {value}."
-      }
-
-      set key [lindex $opt 0]
-      set val [lindex $opt 1]
-
-      $options set $key $val
-
-      set args_var [lrange $args_var 1 end]
-    } else {
-      set args_var [lrange $args_var 1 end]
-    }
-  }
-
-  return $options
-}
 }

--- a/src/stt/src/SteinerTreeBuilder.tcl
+++ b/src/stt/src/SteinerTreeBuilder.tcl
@@ -42,8 +42,10 @@ sta::define_cmd_args "set_routing_alpha" { alpha \
 proc set_routing_alpha { args } {
   ord::parse_list_args "set_routing_alpha" args list {-net}
   sta::parse_key_args "set_routing_alpha" args \
-    keys {-net -min_fanout -min_hpwl} \
+    keys {-min_fanout -min_hpwl} \
     flags {-clock_nets}
+
+  sta::check_argc_eq1 "set_routing_alpha" $args
 
   set alpha [lindex $args 0]
   if { ![string is double $alpha] || $alpha < 0.0 || $alpha > 1.0 } {
@@ -65,17 +67,15 @@ proc set_routing_alpha { args } {
     foreach net $nets {
       stt::set_net_alpha $net $alpha
     }
-  } elseif { [llength $args] == 1 } {
-    stt::set_routing_alpha_cmd $alpha
   } else {
-    utl::error STT 2 "set_routing_alpha: Wrong number of arguments."
+    stt::set_routing_alpha_cmd $alpha
   }
 }
 
 namespace eval stt {
 
 proc find_net {name} {
-  return [sta::sta_to_db_net $name]
+  return [sta::sta_to_db_net [get_nets $name]]
 }
 
 proc filter_clk_nets {cmd} {

--- a/src/stt/test/parse_clocks.tcl
+++ b/src/stt/test/parse_clocks.tcl
@@ -9,7 +9,7 @@ current_design gcd
 create_clock -name core_clock -period 2.0000 -waveform {0.0000 1.0000} [get_ports {clk}]
 set_propagated_clock [get_clocks {core_clock}]
 
-set clocks [stt::parse_clock_nets "test"]
+set clocks [stt::filter_clk_nets "test"]
 
 foreach clock $clocks {
   puts "[$clock getName]"


### PR DESCRIPTION
Add helper function: `ord::parse_list_args` to help parse arguments with multiple allowed uses.
This will be useful for UPF support since it supports the same set of arguments provided and this function ensures a common methodology for handling these arguments.

Changes:
- changes the couple of examples in ORD (except for UPF) that is currently using this scheme, that I was able to find.