### PR TITLE
Update minimum SWIG version in `src/CMakeLists.txt`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,7 +166,7 @@ if (BUILD_TCLX AND TCLX_H)
   message(STATUS "TclX header: ${TCLX_H}")
 endif()
 
-find_package(SWIG 3.0 REQUIRED)
+find_package(SWIG 4.0 REQUIRED)
 if (SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
   message(STATUS "Using SWIG >= ${SWIG_VERSION} -flatstaticmethod flag for python")
 endif()


### PR DESCRIPTION
As per https://github.com/The-OpenROAD-Project/OpenROAD/issues/4401#issuecomment-1980207992, "swig3 is ancient and we don't support it. Please use swig 4".

This updates the build files to reflect that statement.