### PR TITLE
dbsta: swap pin ordering to make iterms handling faster

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -582,10 +582,10 @@ ObjectId dbNetwork::id(const Pin* pin) const
   dbBTerm* bterm;
   staToDb(pin, iterm, bterm);
 
-  if (iterm) {
-    return iterm->getId() + iterm->getBlock()->getBTerms().size();
+  if (iterm != nullptr) {
+    return iterm->getId();
   }
-  return bterm->getId();
+  return bterm->getId() + bterm->getBlock()->getITerms().size();
 }
 
 Instance* dbNetwork::instance(const Pin* pin) const

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -583,9 +583,9 @@ ObjectId dbNetwork::id(const Pin* pin) const
   staToDb(pin, iterm, bterm);
 
   if (iterm != nullptr) {
-    return iterm->getId();
+    return iterm->getId() << 1;
   }
-  return bterm->getId() + bterm->getBlock()->getITerms().size();
+  return (bterm->getId() << 1) + 1;
 }
 
 Instance* dbNetwork::instance(const Pin* pin) const


### PR DESCRIPTION
Since there are far more Iterms in a design, this avoids calling `.size()` when handling iterms speeding up `::id()`.