### PR TITLE
Assume port direction is input if io_type is unspecified in LEF.

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1454,20 +1454,27 @@ PortDirection* dbNetwork::dbToSta(const dbSigType& sig_type,
   if (sig_type == dbSigType::GROUND) {
     return PortDirection::ground();
   }
-  if (io_type == dbIoType::INPUT) {
-    return PortDirection::input();
+  switch (io_type.getValue()) {
+    case dbIoType::INPUT: {
+      return PortDirection::input();
+    }
+    case dbIoType::OUTPUT: {
+      return PortDirection::output();
+    }
+    case dbIoType::INOUT: {
+      return PortDirection::bidirect();
+    }
+    case dbIoType::FEEDTHRU: {
+      return PortDirection::bidirect();
+    }
+    default: {
+      logger_->warn(
+      ORD, 2008, "unknown master term type: sig_type is {} and io_type is {}, "
+      "assuming port is input.",
+      sig_type.getString(), io_type.getString());
+      return PortDirection::input();
+    }
   }
-  if (io_type == dbIoType::OUTPUT) {
-    return PortDirection::output();
-  }
-  if (io_type == dbIoType::INOUT) {
-    return PortDirection::bidirect();
-  }
-  if (io_type == dbIoType::FEEDTHRU) {
-    return PortDirection::bidirect();
-  }
-  logger_->critical(ORD, 2008, "unknown master term type");
-  return PortDirection::bidirect();
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1469,9 +1469,12 @@ PortDirection* dbNetwork::dbToSta(const dbSigType& sig_type,
     }
     default: {
       logger_->warn(
-      ORD, 2008, "unknown master term type: sig_type is {} and io_type is {}, "
-      "assuming port is input.",
-      sig_type.getString(), io_type.getString());
+          ORD,
+          2008,
+          "unknown master term type: sig_type is {} and io_type is {}, "
+          "assuming port is input.",
+          sig_type.getString(),
+          io_type.getString());
       return PortDirection::input();
     }
   }


### PR DESCRIPTION
in an offline chat with @maliberty, he suggests that even with an unknown type we should default to input.