### PR TITLE
detailed route: reduce frequency of progress update

### DIFF
--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -731,12 +731,12 @@ void frRegionQuery::Impl::init()
     }
     cnt++;
     if (VERBOSE > 0) {
-      if (cnt < 100000) {
-        if (cnt % 10000 == 0) {
+      if (cnt < 1000000) {
+        if (cnt % 100000 == 0) {
           logger_->info(DRT, 18, "  Complete {} insts.", cnt);
         }
       } else {
-        if (cnt % 100000 == 0) {
+        if (cnt % 1000000 == 0) {
           logger_->info(DRT, 19, "  Complete {} insts.", cnt);
         }
       }
@@ -819,12 +819,12 @@ void frRegionQuery::Impl::initOrigGuide(
       addOrigGuide(net, rect, allShapes);
       cnt++;
       if (VERBOSE > 0) {
-        if (cnt < 100000) {
-          if (cnt % 10000 == 0) {
+        if (cnt < 1000000) {
+          if (cnt % 100000 == 0) {
             logger_->info(DRT, 26, "  Complete {} origin guides.", cnt);
           }
         } else {
-          if (cnt % 100000 == 0) {
+          if (cnt % 1000000 == 0) {
             logger_->info(DRT, 27, "  Complete {} origin guides.", cnt);
           }
         }
@@ -863,12 +863,12 @@ void frRegionQuery::Impl::initGuide()
     }
     cnt++;
     if (VERBOSE > 0) {
-      if (cnt < 100000) {
-        if (cnt % 10000 == 0) {
+      if (cnt < 1000000) {
+        if (cnt % 100000 == 0) {
           logger_->info(DRT, 29, "  Complete {} nets (guide).", cnt);
         }
       } else {
-        if (cnt % 100000 == 0) {
+        if (cnt % 1000000 == 0) {
           logger_->info(DRT, 30, "  Complete {} nets (guide).", cnt);
         }
       }

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -861,12 +861,12 @@ void io::Parser::postProcessGuide()
     genGuides(net, rects);
     cnt++;
     if (VERBOSE > 0) {
-      if (cnt < 100000) {
-        if (cnt % 10000 == 0) {
+      if (cnt < 1000000) {
+        if (cnt % 100000 == 0) {
           logger_->report("  complete {} nets.", cnt);
         }
       } else {
-        if (cnt % 100000 == 0) {
+        if (cnt % 1000000 == 0) {
           logger_->report("  complete {} nets.", cnt);
         }
       }

--- a/src/drt/src/io/io_pin.cpp
+++ b/src/drt/src/io/io_pin.cpp
@@ -113,12 +113,12 @@ void io::Parser::instAnalysis()
     trackOffsetMap_[inst->getMaster()][orient][offset].insert(inst.get());
     cnt++;
     if (VERBOSE > 0) {
-      if (cnt < 100000) {
-        if (cnt % 10000 == 0) {
+      if (cnt < 1000000) {
+        if (cnt % 100000 == 0) {
           logger_->report("  Complete {} instances.", cnt);
         }
       } else {
-        if (cnt % 100000 == 0) {
+        if (cnt % 1000000 == 0) {
           logger_->report("  Complete {} instances.", cnt);
         }
       }

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1570,12 +1570,12 @@ void FlexPA::prepPoint()
         {
           cnt++;
           if (VERBOSE > 0) {
-            if (cnt < 1000) {
-              if (cnt % 100 == 0) {
+            if (cnt < 10000) {
+              if (cnt % 1000 == 0) {
                 logger_->info(DRT, 76, "  Complete {} pins.", cnt);
               }
             } else {
-              if (cnt % 1000 == 0) {
+              if (cnt % 10000 == 0) {
                 logger_->info(DRT, 77, "  Complete {} pins.", cnt);
               }
             }
@@ -1669,12 +1669,12 @@ void FlexPA::prepPatternInstRows(std::vector<std::vector<frInst*>> inst_rows)
           }
           cnt += batch.size();
           if (VERBOSE > 0) {
-            if (cnt < 10000) {
-              if (cnt % 1000 == 0) {
+            if (cnt < 100000) {
+              if (cnt % 10000 == 0) {
                 logger_->info(DRT, 110, "  Complete {} groups.", cnt);
               }
             } else {
-              if (cnt % 10000 == 0) {
+              if (cnt % 100000 == 0) {
                 logger_->info(DRT, 111, "  Complete {} groups.", cnt);
               }
             }
@@ -1715,12 +1715,12 @@ void FlexPA::prepPatternInstRows(std::vector<std::vector<frInst*>> inst_rows)
           rowIdx++;
           cnt++;
           if (VERBOSE > 0) {
-            if (cnt < 10000) {
-              if (cnt % 1000 == 0) {
+            if (cnt < 100000) {
+              if (cnt % 10000 == 0) {
                 logger_->info(DRT, 82, "  Complete {} groups.", cnt);
               }
             } else {
-              if (cnt % 10000 == 0) {
+              if (cnt % 100000 == 0) {
                 logger_->info(DRT, 83, "  Complete {} groups.", cnt);
               }
             }


### PR DESCRIPTION
computers are faster than they used to be, some of these updates spammed the log several times a second.

10x rarer still gives progress updates several times per minute plenty fast for detailed route.

This is helpful for larger designs, such as the one in this github issue https://github.com/The-OpenROAD-Project/OpenROAD/issues/4821