### PR TITLE
gitignore: update with src/rmp/test/abc.history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ debug/
 
 coverage-output
 .metals/
+src/rmp/test/abc.history


### PR DESCRIPTION
avoid accidentally committing this file left behind after running tests/regression:

$ cat src/rmp/test/abc.history 
source ./results/0ord_abc_script.tcl
source ./results/1ord_abc_script.tcl
source ./results/2ord_abc_script.tcl
source ./0ord_abc_script.tcl
source ./1ord_abc_script.tcl
source ./2ord_abc_script.tcl
