### PR TITLE
correct realvalued heatmap handling

### DIFF
--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -104,6 +104,8 @@ class HeatMapDataSource
   const std::string& getName() const { return name_; }
   const std::string& getShortName() const { return short_name_; }
 
+  utl::Logger* getLogger() const { return logger_; }
+
   void dumpToFile(const std::string& file);
 
   // setup

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -850,14 +850,15 @@ void RealValueHeatMapDataSource::correctMapScale(HeatMapDataSource::Map& map)
 {
   determineMinMax(map);
   determineUnits();
-  min_ = roundData(min_);
-  max_ = roundData(max_);
 
   for (const auto& map_col : map) {
     for (const auto& map_pt : map_col) {
       map_pt->value = convertValueToPercent(map_pt->value);
     }
   }
+
+  min_ = roundData(min_ * scale_);
+  max_ = roundData(max_ * scale_);
 
   // reset since all data has been scaled by the appropriate amount
   scale_ = 1.0;
@@ -866,15 +867,14 @@ void RealValueHeatMapDataSource::correctMapScale(HeatMapDataSource::Map& map)
 double RealValueHeatMapDataSource::roundData(double value) const
 {
   const double precision = 1000.0;
-  double new_value = value * scale_;
-  return std::round(new_value * precision) / precision;
+  return std::round(value * precision) / precision;
 }
 
 void RealValueHeatMapDataSource::determineMinMax(
     const HeatMapDataSource::Map& map)
 {
   min_ = std::numeric_limits<double>::max();
-  max_ = std::numeric_limits<double>::min();
+  max_ = std::numeric_limits<double>::lowest();
 
   for (const auto& map_col : map) {
     for (const auto& map_pt : map_col) {
@@ -886,8 +886,8 @@ void RealValueHeatMapDataSource::determineMinMax(
 
 void RealValueHeatMapDataSource::determineUnits()
 {
-  const double range = max_ - min_;
-  if (range > 1.0 || range == 0) {
+  const double range = getValueRange();
+  if (range >= 1.0 || range == 0) {
     units_ = "";
     scale_ = 1.0;
   } else if (range > 1e-3) {

--- a/src/psm/src/heatMap.cpp
+++ b/src/psm/src/heatMap.cpp
@@ -119,7 +119,7 @@ bool IRDropDataSource::populateMap()
 
   // track min/max here to make it constant across all layers
   double min = std::numeric_limits<double>::max();
-  double max = std::numeric_limits<double>::min();
+  double max = std::numeric_limits<double>::lowest();
   for (const auto& [layer, drop_map] : ir_drops) {
     for (const auto& [point, drop] : drop_map) {
       min = std::min(min, drop);


### PR DESCRIPTION
Issue:
* when converting to a `%`, the previous code was applying the scaling factor to the the percent value, which was be incorrect.

Changes:
* avoid applying scaling factor to percent and delay setting min and max with the scaling factor until after processing map
* provide access to logger (no functional change, but helpful when attempting to debug)
* use `lowest` vs. `min` for finding max values.