### PR TITLE
python: fewer red lines in editor by adhering to pep8 formatting

### DIFF
--- a/src/odb/test/unitTestsPython/TestDestroy.py
+++ b/src/odb/test/unitTestsPython/TestDestroy.py
@@ -1,9 +1,14 @@
 import opendbpy as odb
 import helper
 import odbUnitTest
-#destroying   dbInst,  dbNet,  dbBTerm,  dbBlock,  dbBPin,  dbWire,  dbCapNode,  dbCcSeg,  dbLib,  dbSWire,  dbObstruction,  dbRegion
-#TODO         dbRSeg,  dbRCSeg,  dbRow,  dbTarget,  dbTech
+
+# destroying   dbInst,  dbNet,  dbBTerm,  dbBlock,  dbBPin,  dbWire,  dbCapNode,
+# dbCcSeg,  dbLib,  dbSWire,  dbObstruction,  dbRegion
+# TODO         dbRSeg,  dbRCSeg,  dbRow,  dbTarget,  dbTech
+
+
 class TestDestroy(odbUnitTest.TestCase):
+
     def setUp(self):
         self.db, lib = helper.createSimpleDB()
         self.parentBlock = odb.dbBlock_create(self.db.getChip(), 'Parent')
@@ -18,22 +23,22 @@ class TestDestroy(odbUnitTest.TestCase):
         self.n5 = self.i3.findITerm('a').getNet()
         self.n6 = self.i3.findITerm('b').getNet()
         self.n7 = self.i3.findITerm('o').getNet()
-        
+
     def tearDown(self):
         self.db.destroy(self.db)
-        
+
     def test_destroy_net(self):
         self.n1.destroy(self.n1)
-        #check for Inst
+        # check for Inst
         self.assertIsNone(self.i1.findITerm('a').getNet())
-        #check for Iterms
+        # check for Iterms
         for iterm in self.block.getITerms():
-            if(iterm.getNet() is None):
+            if (iterm.getNet() is None):
                 self.assertEqual(iterm.getInst().getName(), 'i1')
                 self.assertEqual(iterm.getMTerm().getName(), 'a')
             else:
                 self.assertNotEqual(iterm.getNet().getName(), 'n1')
-        #check for block and BTerms
+        # check for block and BTerms
         nets = self.block.getNets()
         for net in nets:
             self.assertNotEqual(net.getName(), 'n1')
@@ -44,68 +49,75 @@ class TestDestroy(odbUnitTest.TestCase):
             self.assertNotEqual(bterm.getNet().getName(), 'n1')
         self.assertIsNone(self.block.findBTerm('IN1'))
         self.assertIsNone(self.block.findNet('n1'))
+
     def test_destroy_inst(self):
         self.i1.destroy(self.i1)
-        #check for block
+        # check for block
         self.assertIsNone(self.block.findInst('i1'))
         for inst in self.block.getInsts():
             self.assertNotEqual(inst.getName(), 'i1')
         self.assertEqual(len(self.block.getITerms()), 6)
-        #check for Iterms
+        # check for Iterms
         for iterm in self.block.getITerms():
             self.assertNotIn(iterm.getNet().getName(), ['n1', 'n2'])
             self.assertNotEqual(iterm.getInst().getName(), 'i1')
-        #check for BTERMS
+        # check for BTERMS
         IN1 = self.block.findBTerm('IN1')
         self.assertIsNone(IN1.getITerm())
         IN2 = self.block.findBTerm('IN2')
         self.assertIsNone(IN2.getITerm())
-        #check for nets
+        # check for nets
         self.assertEqual(self.n1.getITermCount(), 0)
         self.assertEqual(self.n2.getITermCount(), 0)
         self.assertEqual(self.n5.getITermCount(), 1)
         self.assertNotEqual(self.n5.getITerms()[0].getInst().getName(), 'i1')
+
     def test_destroy_bterm(self):
         IN1 = self.block.findBTerm('IN1')
         IN1.destroy(IN1)
-        #check for block and BTerms
+        # check for block and BTerms
         self.assertIsNone(self.block.findBTerm('IN1'))
         bterms = self.block.getBTerms()
         self.assertEqual(len(bterms), 4)
         for bterm in bterms:
             self.assertNotEqual(bterm.getName(), 'IN1')
-        #check for n1
+        # check for n1
         self.assertEqual(self.n1.getBTermCount(), 0)
         self.assertEqual(self.n1.getBTerms(), [])
+
     def test_destroy_block(self):
-        #creating a child block to parent block
-        _block = helper.create1LevelBlock(self.db, self.db.getLibs()[0], self.parentBlock)
+        # creating a child block to parent block
+        _block = helper.create1LevelBlock(self.db,
+                                          self.db.getLibs()[0],
+                                          self.parentBlock)
         self.assertEqual(len(self.parentBlock.getChildren()), 2)
         _block.destroy(_block)
         self.assertEqual(len(self.parentBlock.getChildren()), 1)
         odb.dbBlock_destroy(self.parentBlock)
 
-        
     def test_destroy_bpin(self):
         IN1 = self.block.findBTerm('IN1')
         self.assertEqual(len(IN1.getBPins()), 1)
         P1 = IN1.getBPins()[0]
         P1.destroy(P1)
         self.assertEqual(len(IN1.getBPins()), 0)
+
     def test_create_destroy_wire(self):
         w = odb.dbWire.create(self.n7)
         self.assertIsNotNone(self.n7.getWire())
         w.destroy(w)
         self.assertIsNone(self.n7.getWire())
+
     def test_destroy_capnode(self):
         node2 = odb.dbCapNode_create(self.n2, 0, False)
         node1 = odb.dbCapNode_create(self.n1, 1, False)
-        ccseg = odb.dbCCSeg_create(node1, node2)
+        _ = odb.dbCCSeg_create(node1, node2)
         self.assertEqual(self.n1.getCapNodeCount(), 1)
         self.assertEqual(self.n1.getCcCount(), 1)
         node1.destroy(node1)
         self.assertEqual(self.n1.getCapNodeCount(), 0)
         self.assertEqual(self.n1.getCcCount(), 0)
+
     def test_destroy_ccseg(self):
         node2 = odb.dbCapNode_create(self.n2, 0, False)
         node1 = odb.dbCapNode_create(self.n1, 1, False)
@@ -117,16 +129,19 @@ class TestDestroy(odbUnitTest.TestCase):
         self.assertEqual(node1.getCCSegs(), [])
         self.assertEqual(self.block.getCCSegs(), [])
         self.assertEqual(self.n1.getCcCount(), 0)
+
     def test_destroy_lib(self):
         lib = self.db.getLibs()[0]
         lib.destroy(lib)
         self.assertEqual(self.db.getLibs(), [])
+
     def test_destroy_swire(self):
         swire = odb.dbSWire_create(self.n4, 'ROUTED')
         self.assertNotEqual(self.n4.getSWires(), [])
         self.assertEqual(swire.getNet().getName(), self.n4.getName())
         swire.destroy(swire)
         self.assertEqual(self.n4.getSWires(), [])
+
     def test_destroy_obstruction(self):
         tech = self.db.getLibs()[0].getTech()
         L1 = tech.getLayers()[0]
@@ -134,43 +149,49 @@ class TestDestroy(odbUnitTest.TestCase):
         self.assertEqual(len(self.block.getObstructions()), 1)
         obst.destroy(obst)
         self.assertEqual(len(self.block.getObstructions()), 0)
+
     def setup_regions(self):
         parentRegion = odb.dbRegion_create(self.block, 'parentRegion')
         childRegion = odb.dbRegion_create(parentRegion, 'childRegion')
         childRegion.addInst(self.i1)
         return parentRegion, childRegion
+
     def test_create_regions(self):
         parentRegion, childRegion = self.setup_regions()
         self.assertEqual(self.i1.getRegion().getName(), childRegion.getName())
         self.assertEqual(len(parentRegion.getChildren()), 1)
         self.assertEqual(len(childRegion.getChildren()), 0)
-        self.assertEqual(parentRegion.getChildren()[0].getName(), childRegion.getName())
+        self.assertEqual(parentRegion.getChildren()[0].getName(),
+                         childRegion.getName())
         self.assertEqual(len(self.block.getRegions()), 2)
         self.assertEqual(self.i1.getRegion().getName(), childRegion.getName())
-        self.assertEqual(childRegion.getParent().getName(), parentRegion.getName())
+        self.assertEqual(childRegion.getParent().getName(),
+                         parentRegion.getName())
         self.assertIsNone(parentRegion.getParent())
+
     def test_destroy_region_child(self):
         parentRegion, childRegion = self.setup_regions()
         childRegion.destroy(childRegion)
         self.assertIsNone(self.i1.getRegion())
         self.assertEqual(len(parentRegion.getChildren()), 0)
         self.assertEqual(len(self.block.getRegions()), 1)
-        self.assertEqual(self.block.getRegions()[0].getName(), parentRegion.getName())
-        
+        self.assertEqual(self.block.getRegions()[0].getName(),
+                         parentRegion.getName())
+
     def test_destroy_region_parent(self):
         parentRegion, childRegion = self.setup_regions()
         parentRegion.destroy(parentRegion)
         self.assertEqual(len(self.block.getRegions()), 0)
-    
+
     def test_destroy_trackgrid(self):
         tech = self.db.getLibs()[0].getTech()
         L1 = tech.findLayer("L1")
-        grid = odb.dbTrackGrid_create(self.block,L1)
-        self.assertIsNone(odb.dbTrackGrid_create(self.block,L1))
+        grid = odb.dbTrackGrid_create(self.block, L1)
+        self.assertIsNone(odb.dbTrackGrid_create(self.block, L1))
         grid.destroy(grid)
-        self.assertIsNotNone(odb.dbTrackGrid_create(self.block,L1))
+        self.assertIsNotNone(odb.dbTrackGrid_create(self.block, L1))
+
 
 if __name__=='__main__':
     odbUnitTest.mainParallel(TestDestroy)
 #     odbUnitTest.main()
-    

--- a/src/odb/test/unitTestsPython/helper.py
+++ b/src/odb/test/unitTestsPython/helper.py
@@ -1,5 +1,4 @@
 import opendbpy as odb
-import os
 
 
 def createSimpleDB():
@@ -8,7 +7,7 @@ def createSimpleDB():
     L1 = odb.dbTechLayer_create(tech, 'L1', 'ROUTING')
     lib = odb.dbLib.create(db, "lib")
     odb.dbChip.create(db)
-    #Creating Master and2 and or2
+    # Creating Master and2 and or2
     and2 = createMaster2X1(lib, 'and2', 1000, 1000, 'a', 'b', 'o')
     or2  = createMaster2X1(lib, 'or2', 500, 500, 'a', 'b', 'o')
     return db, lib
@@ -17,7 +16,7 @@ def createSimpleDB():
 def createMultiLayerDB():
     db = odb.dbDatabase.create()
     tech = odb.dbTech.create(db)
-    
+
     m1 = odb.dbTechLayer_create(tech, "M1", 'ROUTING')
     m1.setWidth(2000)
     m2 = odb.dbTechLayer_create(tech, "M2", 'ROUTING')
@@ -36,21 +35,20 @@ def createMultiLayerDB():
     return db, tech, m1, m2, m3, v12, v23
 
 
-    
-#logical expr OUT = (IN1&IN2)
+# logical expr OUT = (IN1&IN2)
 #
 #     (n1)   +-----
 # IN1--------|a    \    (n3)
 #     (n2)   | (i1)o|-----------OUT
-# IN2--------|b    /            
-#            +-----             
+# IN2--------|b    /
+#            +-----
 def create1LevelBlock(db, lib, parent):
     blockName = '1LevelBlock'
     block = odb.dbBlock_create(parent, blockName, ',')
-    #Creating Master and2 and instance inst
+    # Creating Master and2 and instance inst
     and2 = lib.findMaster('and2')
     inst = odb.dbInst.create(block, and2, "inst")
-    #creating our nets
+    # creating our nets
     n1 = odb.dbNet.create(block, "n1")
     n2 = odb.dbNet.create(block, "n2")
     n3 = odb.dbNet.create(block, "n3")
@@ -60,15 +58,14 @@ def create1LevelBlock(db, lib, parent):
     IN2.setIoType('INPUT')
     OUT = odb.dbBTerm.create(n3, 'OUT')
     OUT.setIoType('OUTPUT')
-    #connecting nets
+    # connecting nets
     odb.dbITerm.connect(inst, n1, inst.getMaster().findMTerm('a'))
     odb.dbITerm.connect(inst, n2, inst.getMaster().findMTerm('b'))
     odb.dbITerm.connect(inst, n3, inst.getMaster().findMTerm('o'))
     return block
 
 
-
-#logical expr OUT = (IN1&IN2) | (IN3&IN4)
+# logical expr OUT = (IN1&IN2) | (IN3&IN4)
 #     (n1)   +-----
 # IN1--------|a    \    (n5)
 #     (n2)   | (i1)o|-----------+
@@ -81,17 +78,16 @@ def create1LevelBlock(db, lib, parent):
 # IN4--------|b    /
 #            +-----
 def create2LevelBlock(db, lib, parent):
-    
     blockName = '2LevelBlock'
     block = odb.dbBlock_create(parent, blockName, ',')
-    
+
     and2 = lib.findMaster('and2')
     or2 = lib.findMaster('or2')
-    #creating instances
+    # creating instances
     i1 = odb.dbInst.create(block, and2, "i1")
     i2 = odb.dbInst.create(block, and2, "i2")
     i3 = odb.dbInst.create(block, or2, "i3")
-    #creating nets and block terms
+    # creating nets and block terms
     n1 = odb.dbNet.create(block, "n1")
     n2 = odb.dbNet.create(block, "n2")
     n3 = odb.dbNet.create(block, "n3")
@@ -99,7 +95,7 @@ def create2LevelBlock(db, lib, parent):
     n5 = odb.dbNet.create(block, "n5")
     n6 = odb.dbNet.create(block, "n6")
     n7 = odb.dbNet.create(block, "n7")
-    
+
     IN1 = odb.dbBTerm.create(n1, 'IN1')
     IN1.setIoType('INPUT')
     IN2 = odb.dbBTerm.create(n2, 'IN2')
@@ -110,32 +106,33 @@ def create2LevelBlock(db, lib, parent):
     IN4.setIoType('INPUT')
     OUT = odb.dbBTerm.create(n7, 'OUT')
     OUT.setIoType('OUTPUT')
-    #connecting nets
+    # connecting nets
     odb.dbITerm.connect(i1, n1, i1.getMaster().findMTerm('a'))
     odb.dbITerm.connect(i1, n2, i1.getMaster().findMTerm('b'))
     odb.dbITerm.connect(i1, n5, i1.getMaster().findMTerm('o'))
-    
+
     odb.dbITerm.connect(i2, n3, i2.getMaster().findMTerm('a'))
     odb.dbITerm.connect(i2, n4, i2.getMaster().findMTerm('b'))
     odb.dbITerm.connect(i2, n6, i2.getMaster().findMTerm('o'))
-    
+
     odb.dbITerm.connect(i3, n5, i3.getMaster().findMTerm('a'))
     odb.dbITerm.connect(i3, n6, i3.getMaster().findMTerm('b'))
     odb.dbITerm.connect(i3, n7, i3.getMaster().findMTerm('o'))
-    
+
     P1 = odb.dbBPin_create(IN1)
     P2 = odb.dbBPin_create(IN2)
     P3 = odb.dbBPin_create(IN3)
     P4 = odb.dbBPin_create(IN4)
     P5 = odb.dbBPin_create(OUT)
-    
+
     return block
 
+
 #  +-----
-#  |in1   \    
+#  |in1   \
 #      out|
-#  |in2  /            
-#  +-----  
+#  |in2  /
+#  +-----
 def createMaster2X1(lib, name, width, height, in1, in2, out):
     master = odb.dbMaster_create(lib, name)
     master.setWidth(width)
@@ -146,6 +143,8 @@ def createMaster2X1(lib, name, width, height, in1, in2, out):
     odb.dbMTerm.create(master, out, 'OUTPUT')
     master.setFrozen()
     return master
+
+
 def createMaster3X1(lib, name, width, height, in1, in2, in3, out):
     master = odb.dbMaster_create(lib, name)
     master.setWidth(width)

--- a/src/odb/test/unitTestsPython/odbUnitTest.py
+++ b/src/odb/test/unitTestsPython/odbUnitTest.py
@@ -1,27 +1,36 @@
 import unittest
 import testtools
 
+
 class TestCase(unittest.TestCase):
-    #Function to change a value and test the change effect
+    # Function to change a value and test the change effect
     def changeAndTest(self, obj, SetterName, GetterName, expectedVal, *args):
         getattr(obj,  SetterName)(*args)
         self.assertEqual(getattr(obj,  GetterName)(), expectedVal)
+
     def check(self, obj, GetterName, expectedVal, *args):
         self.assertEqual(getattr(obj,  GetterName)(*args), expectedVal)
+
     def change(self, obj, SetterName, *args):
         return getattr(obj,  SetterName)(*args)
-    
+
+
 class TracingStreamResult(testtools.StreamResult):
     def status(self,  *args,  **kwargs):
         tid = kwargs['test_id'].split('.')
-        if(kwargs['test_status'] in ['success', 'fail']):
+        if (kwargs['test_status'] in ['success', 'fail']):
             print(tid[2], ' : ', kwargs['test_status'])
 #         print('{0[test_id]}: {0[test_status]}'.format(kwargs))
+
+
 def main():
     unittest.main()
+
+
 def mainParallel(Test):
     suite = unittest.TestLoader().loadTestsFromTestCase(Test)
-    concurrent_suite = testtools.ConcurrentStreamTestSuite(lambda: ((case,  None) for case in suite))
+    concurrent_suite = testtools.ConcurrentStreamTestSuite(
+        lambda: ((case, None) for case in suite))
     result = TracingStreamResult()
     result.startTestRun()
     concurrent_suite.run(result)


### PR DESCRIPTION
PEP8 red lines fixed while wandering through the code