### PR TITLE
mpl2: fix bug introduced in io blockages computation fix

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3152,9 +3152,9 @@ void HierRTLMP::setIOClustersBlockages()
   // Note that the range can be larger than the respective core dimension.
   // As SA only sees what is inside its current outline, this is not a problem.
   if (pin_ranges[L].second > pin_ranges[L].first) {
-    macro_blockages_.emplace_back(root_ux,
+    macro_blockages_.emplace_back(root_lx,
                                   pin_ranges[L].first,
-                                  root_ux + std::min(max_width, depth),
+                                  root_lx + std::min(max_width, depth),
                                   pin_ranges[L].second);
     debugPrint(logger_,
                MPL,


### PR DESCRIPTION
A bug was introduced in #4839. I realized now when refactoring.

The bug was avoiding the generation of an io blockage for the left boundary.