### PR TITLE
Fix pin acccess for 130BCD IO library

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -157,7 +157,7 @@ void FlexPA::prepPoint_pin_genPoints_rect_genCenter(
       cnt++;
     }
   }
-  if (cnt >= 2) {
+  if (cnt >= 3) {
     return;
   }
 


### PR DESCRIPTION
The middle of the pin needs to be used even though it intersects two routing tracks, as either track is too close to the blockages around the pin.

As a result, increase the threshold for checking the middle of the pin as an option from two to three routing tracks.

Let me know if you prefer a more specific solution.