### PR TITLE
odb: avoid skipping bbox computation for inst when block is not valid

### DIFF
--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -471,7 +471,7 @@ void dbInst::setOrigin(int x, int y)
   _dbBlock* block = (_dbBlock*) inst->getOwner();
   int prev_x = inst->_x;
   int prev_y = inst->_y;
-  if (prev_x == x && prev_y == y)
+  if (block->_flags._valid_bbox && prev_x == x && prev_y == y)
     return;
   if (getPlacementStatus().isFixed()) {
     inst->getLogger()->error(utl::ODB,

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -61,10 +61,11 @@ BOOST_AUTO_TEST_CASE(test_inst_and_iterm)
   BOOST_TEST(cb->events.size() == 2);
   BOOST_TEST(cb->events[0] == "PreMove inst i1");
   BOOST_TEST(cb->events[1] == "PostMove inst i1");
+  cb->clearEvents();
   i1->findITerm("a")->connect(n1);
-  BOOST_TEST(cb->events.size() == 4);
-  BOOST_TEST(cb->events[2] == "PreConnect iterm to net n1");
-  BOOST_TEST(cb->events[3] == "PostConnect iterm to net n1");
+  BOOST_TEST(cb->events.size() == 2);
+  BOOST_TEST(cb->events[0] == "PreConnect iterm to net n1");
+  BOOST_TEST(cb->events[1] == "PostConnect iterm to net n1");
   cb->clearEvents();
   i1->findITerm("a")->connect(n1);
   BOOST_TEST(cb->events.size() == 0);

--- a/src/odb/test/cpp/TestCallBacks.cpp
+++ b/src/odb/test/cpp/TestCallBacks.cpp
@@ -58,11 +58,13 @@ BOOST_AUTO_TEST_CASE(test_inst_and_iterm)
   BOOST_TEST(cb->events[1] == "PostMove inst i1");
   cb->clearEvents();
   i1->setOrigin(100, 100);
-  BOOST_TEST(cb->events.size() == 0);
-  i1->findITerm("a")->connect(n1);
   BOOST_TEST(cb->events.size() == 2);
-  BOOST_TEST(cb->events[0] == "PreConnect iterm to net n1");
-  BOOST_TEST(cb->events[1] == "PostConnect iterm to net n1");
+  BOOST_TEST(cb->events[0] == "PreMove inst i1");
+  BOOST_TEST(cb->events[1] == "PostMove inst i1");
+  i1->findITerm("a")->connect(n1);
+  BOOST_TEST(cb->events.size() == 4);
+  BOOST_TEST(cb->events[2] == "PreConnect iterm to net n1");
+  BOOST_TEST(cb->events[3] == "PostConnect iterm to net n1");
   cb->clearEvents();
   i1->findITerm("a")->connect(n1);
   BOOST_TEST(cb->events.size() == 0);


### PR DESCRIPTION
Fix #4032

The callback cpp test was considering that, for a created inst whose block has not a valid bbox, calling setOrigin would only be effective in the first call. However, with the fix here, as long as the block has not a valid bbox, every setOrigin call should trigger callback events.