### PR TITLE
placement: improve error message, no need to hunt down value in log

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1289,7 +1289,7 @@ void PlacerBase::printInfo() const
   log_->info(GPL, 21, "MacroInstsArea: {}", macroInstsArea_);
 
   if (util >= 100.1) {
-    log_->error(GPL, 301, "Utilization exceeds 100%.");
+    log_->error(GPL, 301, "Utilization {:.2f}% exceeds 100%.", util);
   }
 }
 


### PR DESCRIPTION
as soon as the user sees this error message, they have to hunt down the value in the log, simply provide it in the error message instead.

```
Running global_place_skip_io.tcl
[INFO GPL-0002] DBU: 1000
[INFO GPL-0003] SiteSize: 54 270
[INFO GPL-0004] CoreAreaLxLy: 14418 14580
[INFO GPL-0005] CoreAreaUxUy: 129600 129600
[INFO GPL-0006] NumInstances: 104598
[INFO GPL-0007] NumPlaceInstances: 102890
[INFO GPL-0008] NumFixedInstances: 1708
[INFO GPL-0009] NumDummyInstances: 0
[INFO GPL-0010] NumNets: 118071
[INFO GPL-0011] NumPins: 378191
[INFO GPL-0012] DieAreaLxLy: 0 0
[INFO GPL-0013] DieAreaUxUy: 144000 144000
[INFO GPL-0014] CoreAreaLxLy: 14418 14580
[INFO GPL-0015] CoreAreaUxUy: 129600 129600
[INFO GPL-0016] CoreArea: 13248233640
[INFO GPL-0017] NonPlaceInstsArea: 49805280
[INFO GPL-0018] PlaceInstsArea: 17668306440
[INFO GPL-0019] Util(%): 133.87
[INFO GPL-0020] StdInstsArea: 17668306440
[INFO GPL-0021] MacroInstsArea: 0
[ERROR GPL-0301] Utilization 133.87% exceeds 100%.
Error: global_place_skip_io.tcl, 30 GPL-0301
Command exited with non-zero status 1
```
