### PR TITLE
gui: use boost geom for shapes

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -708,7 +708,9 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                        search_line.xMax(),
                                        search_line.yMax(),
                                        shape_limit);
-      for (const auto& [box, fill] : fills) {
+      for (auto* fill : fills) {
+        odb::Rect box;
+        fill->getRect(box);
         check_rect(box);
       }
     }

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -602,13 +602,13 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
   // Cache the search results as we will iterate over the instances
   // for each layer.
   std::vector<dbInst*> insts;
-  for (const auto& [box, inst] : inst_range) {
+  for (auto* inst : inst_range) {
     if (options_->isInstanceVisible(inst)) {
       if (inst_internals_visible) {
         // only add inst if it can be used for pin or obs search
         insts.push_back(inst);
       }
-      check_rect(box->getBox());
+      check_rect(inst->getBBox()->getBox());
     }
   }
 
@@ -723,8 +723,8 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                             search_line.xMax(),
                                             search_line.yMax(),
                                             shape_limit);
-      for (const auto& [box, ob] : obs) {
-        check_rect(box->getBox());
+      for (auto* ob : obs) {
+        check_rect(ob->getBBox()->getBox());
       }
     }
   }
@@ -736,8 +736,8 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                          search_line.xMax(),
                                          search_line.yMax(),
                                          shape_limit);
-    for (const auto& [box, blck] : blcks) {
-      check_rect(box->getBox());
+    for (auto* blck : blcks) {
+      check_rect(blck->getBBox()->getBox());
     }
   }
 
@@ -829,7 +829,7 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
                                              region.xMax(),
                                              region.yMax(),
                                              shape_limit);
-    for (auto& [box, blockage] : blockages) {
+    for (auto* blockage : blockages) {
       selections.push_back(gui_->makeSelected(blockage));
     }
   }
@@ -861,8 +861,8 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
                                             region.xMax(),
                                             region.yMax(),
                                             shape_limit);
-      for (auto& [box, obs] : obs) {
-        selections.push_back(gui_->makeSelected(obs));
+      for (auto* ob : obs) {
+        selections.push_back(gui_->makeSelected(ob));
       }
     }
 
@@ -935,7 +935,7 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
                                    region.yMax(),
                                    instanceSizeLimit());
 
-  for (auto& [box, inst] : insts) {
+  for (auto* inst : insts) {
     if (options_->isInstanceVisible(inst)) {
       if (options_->isInstanceSelectable(inst)) {
         selections.push_back(gui_->makeSelected(inst));

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -483,7 +483,7 @@ void LayoutViewer::searchNearestViaEdge(
                                                 search_line.yMax(),
                                                 shape_limit);
   std::vector<odb::dbShape> shapes;
-  for (auto& [box, sbox, net] : via_shapes) {
+  for (const auto& [sbox, net] : via_shapes) {
     if (isNetVisible(net)) {
       sbox->getViaLayerBoxes(search_layer, shapes);
       for (auto& shape : shapes) {
@@ -602,13 +602,13 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
   // Cache the search results as we will iterate over the instances
   // for each layer.
   std::vector<dbInst*> insts;
-  for (auto& [box, inst] : inst_range) {
+  for (const auto& [box, inst] : inst_range) {
     if (options_->isInstanceVisible(inst)) {
       if (inst_internals_visible) {
         // only add inst if it can be used for pin or obs search
         insts.push_back(inst);
       }
-      check_rect(box);
+      check_rect(box->getBox());
     }
   }
 
@@ -656,7 +656,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                                 search_line.xMax(),
                                                 search_line.yMax(),
                                                 shape_limit);
-      for (auto& [box, is_via, net] : box_shapes) {
+      for (const auto& [box, is_via, net] : box_shapes) {
         if (!routing_visible && !is_via) {
           continue;
         }
@@ -693,9 +693,9 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                                      search_line.xMax(),
                                                      search_line.yMax(),
                                                      shape_limit);
-      for (auto& [box, poly, net] : polygon_shapes) {
+      for (const auto& [box, poly, net] : polygon_shapes) {
         if (isNetVisible(net)) {
-          check_rect(box);
+          check_rect(box->getBox());
         }
       }
     }
@@ -708,7 +708,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                        search_line.xMax(),
                                        search_line.yMax(),
                                        shape_limit);
-      for (auto& [box, fill] : fills) {
+      for (const auto& [box, fill] : fills) {
         check_rect(box);
       }
     }
@@ -721,8 +721,8 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                             search_line.xMax(),
                                             search_line.yMax(),
                                             shape_limit);
-      for (auto& [box, ob] : obs) {
-        check_rect(box);
+      for (const auto& [box, ob] : obs) {
+        check_rect(box->getBox());
       }
     }
   }
@@ -734,8 +734,8 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                          search_line.xMax(),
                                          search_line.yMax(),
                                          shape_limit);
-    for (auto& [box, blck] : blcks) {
-      check_rect(box);
+    for (const auto& [box, blck] : blcks) {
+      check_rect(box->getBox());
     }
   }
 
@@ -796,7 +796,7 @@ void LayoutViewer::selectViaShapesAt(dbTechLayer* cut_layer,
                                                 shape_limit);
 
   std::vector<odb::dbShape> shapes;
-  for (auto& [box, sbox, net] : via_shapes) {
+  for (const auto& [sbox, net] : via_shapes) {
     if (isNetVisible(net) && options_->isNetSelectable(net)) {
       sbox->getViaLayerBoxes(select_layer, shapes);
       for (auto& shape : shapes) {

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -560,15 +560,6 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
           }
         };
 
-  auto convert_box_to_rect = [](const Search::Box& box) -> odb::Rect {
-    const auto min_corner = box.min_corner();
-    const auto max_corner = box.max_corner();
-    const odb::Point ll(min_corner.x(), min_corner.y());
-    const odb::Point ur(max_corner.x(), max_corner.y());
-
-    return odb::Rect(ll, ur);
-  };
-
   // get die bounding box
   Rect bbox = block_->getDieArea();
   check_rect(bbox);
@@ -617,7 +608,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
         // only add inst if it can be used for pin or obs search
         insts.push_back(inst);
       }
-      check_rect(convert_box_to_rect(box));
+      check_rect(box);
     }
   }
 
@@ -673,7 +664,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
           continue;
         }
         if (isNetVisible(net)) {
-          check_rect(convert_box_to_rect(box));
+          check_rect(box);
         }
       }
     }
@@ -704,7 +695,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                                      shape_limit);
       for (auto& [box, poly, net] : polygon_shapes) {
         if (isNetVisible(net)) {
-          check_rect(convert_box_to_rect(box));
+          check_rect(box);
         }
       }
     }
@@ -718,7 +709,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                        search_line.yMax(),
                                        shape_limit);
       for (auto& [box, fill] : fills) {
-        check_rect(convert_box_to_rect(box));
+        check_rect(box);
       }
     }
 
@@ -731,7 +722,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                             search_line.yMax(),
                                             shape_limit);
       for (auto& [box, ob] : obs) {
-        check_rect(convert_box_to_rect(box));
+        check_rect(box);
       }
     }
   }
@@ -744,7 +735,7 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
                                          search_line.yMax(),
                                          shape_limit);
     for (auto& [box, blck] : blcks) {
-      check_rect(convert_box_to_rect(box));
+      check_rect(box);
     }
   }
 

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -540,7 +540,7 @@ void RenderThread::drawInstanceShapes(dbTechLayer* layer,
                                                      instance_limit);
       child_insts.clear();
       child_insts.reserve(10000);
-      for (auto& [box, inst] : inst_range) {
+      for (const auto& [box, inst] : inst_range) {
         if (viewer_->options_->isInstanceVisible(inst)) {
           child_insts.push_back(inst);
         }
@@ -788,11 +788,11 @@ void RenderThread::drawBlockages(QPainter* painter,
                                          bounds.yMax(),
                                          viewer_->shapeSizeLimit());
 
-  for (auto& [box, blockage] : blockage_range) {
+  for (const auto& [box, blockage] : blockage_range) {
     if (restart_) {
       break;
     }
-    Rect bbox = blockage->getBBox()->getBox();
+    Rect bbox = box->getBox();
     painter->drawRect(bbox.xMin(), bbox.yMin(), bbox.dx(), bbox.dy());
   }
 }
@@ -821,11 +821,11 @@ void RenderThread::drawObstructions(odb::dbBlock* block,
                                             bounds.yMax(),
                                             viewer_->shapeSizeLimit());
 
-  for (auto& [box, obs] : obstructions_range) {
+  for (const auto& [box, obs] : obstructions_range) {
     if (restart_) {
       break;
     }
-    Rect bbox = obs->getBBox()->getBox();
+    Rect bbox = box->getBox();
     painter->drawRect(bbox.xMin(), bbox.yMin(), bbox.dx(), bbox.dy());
   }
 }
@@ -846,7 +846,7 @@ void RenderThread::drawViaShapes(QPainter* painter,
                                                             shape_limit);
 
   std::vector<odb::dbShape> via_shapes;
-  for (auto& [box, sbox, net] : via_sbox_iter) {
+  for (const auto& [sbox, net] : via_sbox_iter) {
     if (restart_) {
       break;
     }
@@ -1079,7 +1079,7 @@ void RenderThread::drawBlock(QPainter* painter,
   // for each layer.
   std::vector<dbInst*> insts;
   insts.reserve(10000);
-  for (auto& [box, inst] : inst_range) {
+  for (const auto& [box, inst] : inst_range) {
     if (restart_) {
       break;
     }

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -540,7 +540,7 @@ void RenderThread::drawInstanceShapes(dbTechLayer* layer,
                                                      instance_limit);
       child_insts.clear();
       child_insts.reserve(10000);
-      for (const auto& [box, inst] : inst_range) {
+      for (auto* inst : inst_range) {
         if (viewer_->options_->isInstanceVisible(inst)) {
           child_insts.push_back(inst);
         }
@@ -788,11 +788,11 @@ void RenderThread::drawBlockages(QPainter* painter,
                                          bounds.yMax(),
                                          viewer_->shapeSizeLimit());
 
-  for (const auto& [box, blockage] : blockage_range) {
+  for (auto* blockage : blockage_range) {
     if (restart_) {
       break;
     }
-    Rect bbox = box->getBox();
+    Rect bbox = blockage->getBBox()->getBox();
     painter->drawRect(bbox.xMin(), bbox.yMin(), bbox.dx(), bbox.dy());
   }
 }
@@ -821,11 +821,11 @@ void RenderThread::drawObstructions(odb::dbBlock* block,
                                             bounds.yMax(),
                                             viewer_->shapeSizeLimit());
 
-  for (const auto& [box, obs] : obstructions_range) {
+  for (auto* obs : obstructions_range) {
     if (restart_) {
       break;
     }
-    Rect bbox = box->getBox();
+    Rect bbox = obs->getBBox()->getBox();
     painter->drawRect(bbox.xMin(), bbox.yMin(), bbox.dx(), bbox.dy());
   }
 }
@@ -1081,7 +1081,7 @@ void RenderThread::drawBlock(QPainter* painter,
   // for each layer.
   std::vector<dbInst*> insts;
   insts.reserve(10000);
-  for (const auto& [box, inst] : inst_range) {
+  for (auto* inst : inst_range) {
     if (restart_) {
       break;
     }

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -923,8 +923,8 @@ void RenderThread::drawLayer(QPainter* painter,
         if (!viewer_->isNetVisible(net)) {
           continue;
         }
-        const auto& ll = box.min_corner();
-        const auto& ur = box.max_corner();
+        const auto& ll = box.ll();
+        const auto& ur = box.ur();
         painter->drawRect(
             QRect(ll.x(), ll.y(), ur.x() - ll.x(), ur.y() - ll.y()));
       }
@@ -994,8 +994,8 @@ void RenderThread::drawLayer(QPainter* painter,
         if (restart_) {
           break;
         }
-        const auto& ll = std::get<0>(i).min_corner();
-        const auto& ur = std::get<0>(i).max_corner();
+        const auto& ll = std::get<0>(i).ll();
+        const auto& ur = std::get<0>(i).ur();
         painter->drawRect(
             QRect(ll.x(), ll.y(), ur.x() - ll.x(), ur.y() - ll.y()));
       }
@@ -1546,10 +1546,10 @@ void RenderThread::drawIOPins(Painter& painter,
 
   // RTree used to search for overlapping shapes and decide if rotation of
   // text is needed.
-  bgi::rtree<Search::Box, bgi::quadratic<16>> pin_text_spec_shapes;
+  bgi::rtree<odb::Rect, bgi::quadratic<16>> pin_text_spec_shapes;
   struct PinText
   {
-    Search::Box rect;
+    odb::Rect rect;
     bool can_rotate;
     std::string text;
     odb::Point pt;
@@ -1652,12 +1652,10 @@ void RenderThread::drawIOPins(Painter& painter,
                                                        pin_specs.anchor,
                                                        pin_specs.text);
         text_rect.bloat(text_margin, text_rect);
-        pin_specs.rect
-            = Search::Box(Search::Point(text_rect.xMin(), text_rect.yMin()),
-                          Search::Point(text_rect.xMax(), text_rect.yMax()));
+        pin_specs.rect = text_rect;
         pin_text_spec_shapes.insert(pin_specs.rect);
       } else {
-        pin_specs.rect = Search::Box();
+        pin_specs.rect = odb::Rect();
       }
       pin_text_spec.push_back(pin_specs);
     }

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -924,9 +924,7 @@ void RenderThread::drawLayer(QPainter* painter,
           continue;
         }
         const auto& ll = box.ll();
-        const auto& ur = box.ur();
-        painter->drawRect(
-            QRect(ll.x(), ll.y(), ur.x() - ll.x(), ur.y() - ll.y()));
+        painter->drawRect(QRect(ll.x(), ll.y(), box.dx(), box.dy()));
       }
     }
 
@@ -990,14 +988,12 @@ void RenderThread::drawLayer(QPainter* painter,
                                                bounds.yMax(),
                                                shape_limit);
 
-      for (auto& i : iter) {
+      for (const auto& [box, fill] : iter) {
         if (restart_) {
           break;
         }
-        const auto& ll = std::get<0>(i).ll();
-        const auto& ur = std::get<0>(i).ur();
-        painter->drawRect(
-            QRect(ll.x(), ll.y(), ur.x() - ll.x(), ur.y() - ll.y()));
+        const auto& ll = box.ll();
+        painter->drawRect(QRect(ll.x(), ll.y(), box.dx(), box.dy()));
       }
     }
   }

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -988,10 +988,12 @@ void RenderThread::drawLayer(QPainter* painter,
                                                bounds.yMax(),
                                                shape_limit);
 
-      for (const auto& [box, fill] : iter) {
+      for (auto* fill : iter) {
         if (restart_) {
           break;
         }
+        odb::Rect box;
+        fill->getRect(box);
         const auto& ll = box.ll();
         painter->drawRect(QRect(ll.x(), ll.y(), box.dx(), box.dy()));
       }

--- a/src/gui/src/search.cpp
+++ b/src/gui/src/search.cpp
@@ -312,15 +312,12 @@ void Search::updateFills(odb::dbBlock* block)
 
   data.fills_.clear();
 
-  LayerMap<std::vector<RectValue<odb::dbFill*>>> fills;
+  LayerMap<std::vector<odb::dbFill*>> fills;
   for (odb::dbFill* fill : block->getFills()) {
-    odb::Rect rect;
-    fill->getRect(rect);
-    fills[fill->getTechLayer()].emplace_back(rect, fill);
+    fills[fill->getTechLayer()].push_back(fill);
   }
   for (const auto& [layer, layer_fill] : fills) {
-    data.fills_[layer]
-        = RtreeRect<odb::dbFill*>(layer_fill.begin(), layer_fill.end());
+    data.fills_[layer] = RtreeFill(layer_fill.begin(), layer_fill.end());
   }
 
   data.fills_init_ = true;
@@ -508,6 +505,13 @@ class Search::MinSizePredicate
   bool operator()(const DBoxValue<T>& o) const
   {
     return checkBox(o.first->getBox());
+  }
+
+  bool operator()(odb::dbFill* o) const
+  {
+    odb::Rect fill;
+    o->getRect(fill);
+    return checkBox(fill);
   }
 
   bool checkBox(const odb::Rect& box) const

--- a/src/gui/src/search.h
+++ b/src/gui/src/search.h
@@ -40,6 +40,7 @@
 #include "odb/db.h"
 #include "odb/dbBlockCallBackObj.h"
 #include "odb/geom.h"
+#include "odb/geom_boost.h"
 
 namespace gui {
 
@@ -66,18 +67,17 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   template <typename T>
   using LayerMap = std::map<odb::dbTechLayer*, T>;
 
-  using Point = bg::model::d2::point_xy<int, bg::cs::cartesian>;
-  using Box = bg::model::box<Point>;
   using Polygon
-      = bg::model::polygon<Point, false>;  // counterclockwise(clockwise=false)
+      = bg::model::polygon<odb::Point,
+                           false>;  // counterclockwise(clockwise=false)
   template <typename T>
-  using BoxValue = std::tuple<Box, T>;
+  using BoxValue = std::tuple<odb::Rect, T>;
   template <typename T>
-  using RouteBoxValue = std::tuple<Box, bool, T>;
+  using RouteBoxValue = std::tuple<odb::Rect, bool, T>;
   template <typename T>
-  using SNetSBoxValue = std::tuple<Box, odb::dbSBox*, T>;
+  using SNetSBoxValue = std::tuple<odb::Rect, odb::dbSBox*, T>;
   template <typename T>
-  using SNetValue = std::tuple<Box, Polygon, T>;
+  using SNetValue = std::tuple<odb::Rect, Polygon, T>;
 
   template <typename T>
   using RtreeBox = bgi::rtree<BoxValue<T>, bgi::quadratic<16>>;
@@ -253,8 +253,6 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   void updateBlockages(odb::dbBlock* block);
   void updateObstructions(odb::dbBlock* block);
   void updateRows(odb::dbBlock* block);
-
-  Box convertRect(const odb::Rect& box) const;
 
   void clear();
 

--- a/src/gui/src/search.h
+++ b/src/gui/src/search.h
@@ -93,6 +93,17 @@ class Search : public QObject, public odb::dbBlockCallBackObj
     }
   };
 
+  struct FillIndexableGetter
+  {
+    using result_type = odb::Rect;
+    odb::Rect operator()(odb::dbFill* t) const
+    {
+      odb::Rect fill;
+      t->getRect(fill);
+      return fill;
+    }
+  };
+
   template <typename T>
   using RtreeRect = bgi::rtree<RectValue<T>, bgi::quadratic<16>>;
   template <typename T>
@@ -103,6 +114,8 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   template <typename T>
   using RtreeSNetShapes
       = bgi::rtree<SNetValue<T>, bgi::quadratic<16>, BBoxIndexableGetter<T>>;
+  using RtreeFill
+      = bgi::rtree<odb::dbFill*, bgi::quadratic<16>, FillIndexableGetter>;
 
   // This is an iterator range for return values
   template <typename Tree>
@@ -127,7 +140,7 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   using RoutingRange = Range<RtreeRoutingShapes<odb::dbNet*>>;
   using SNetSBoxRange = Range<RtreeDBox<odb::dbNet*>>;
   using SNetShapeRange = Range<RtreeSNetShapes<odb::dbNet*>>;
-  using FillRange = Range<RtreeRect<odb::dbFill*>>;
+  using FillRange = Range<RtreeFill>;
   using ObstructionRange = Range<RtreeDBox<odb::dbObstruction*>>;
   using BlockageRange = Range<RtreeDBox<odb::dbBlockage*>>;
   using RowRange = Range<RtreeRect<odb::dbRow*>>;
@@ -287,7 +300,7 @@ class Search : public QObject, public odb::dbBlockCallBackObj
     LayerMap<RtreeSNetShapes<odb::dbNet*>> snet_shapes_;
     std::atomic_bool shapes_init_{false};
     std::mutex shapes_init_mutex_;
-    LayerMap<RtreeRect<odb::dbFill*>> fills_;
+    LayerMap<RtreeFill> fills_;
     std::atomic_bool fills_init_{false};
     std::mutex fills_init_mutex_;
     RtreeDBox<odb::dbInst*> insts_;


### PR DESCRIPTION
Changes:
- converts shapes.h and shapes.cpp to use the boost geom interface.

Notes:
- dbBox* could be further simplified to Rect, but it appears that accessing the dbBox requires several calculations to find the pointer, so I left that in (still reduces the total memory needed).