### PR TITLE
gui: add layer type to tool tip + fix overlapping property names

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2284,7 +2284,7 @@ Descriptor::Properties DbTechLayerDescriptor::getProperties(
   auto layer = std::any_cast<odb::dbTechLayer*>(object);
   Properties props({{"Technology", gui->makeSelected(layer->getTech())},
                     {"Direction", layer->getDirection().getString()},
-                    {"Type", layer->getType().getString()}});
+                    {"Layer type", layer->getType().getString()}});
   if (layer->getLef58Type() != odb::dbTechLayer::NONE) {
     props.push_back({"LEF58 type", layer->getLef58TypeString()});
   }

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -205,6 +205,9 @@ QVariant DisplayControlModel::data(const QModelIndex& index, int role) const
             return true;
           };
 
+          // type
+          add_prop("Layer type", information);
+
           // direction
           add_prop("Direction", information);
 


### PR DESCRIPTION
With the addition of implant layers, this makes it a little easier to identify them in the GUI.
Plus, "Type" is a reserved property, so renaming the layer type to "Layer type" to avoid the overlapping names