### PR TITLE
mpl2: fail with error instead of producing invalid .odb file

### DIFF
--- a/src/mpl/src/MacroPlacer.cpp
+++ b/src/mpl/src/MacroPlacer.cpp
@@ -486,7 +486,7 @@ void MacroPlacer::placeMacrosCornerMaxWl()
     }
     updateDbInstLocations();
   } else
-    logger_->warn(MPL, 72, "No partition solutions found.");
+    logger_->error(MPL, 72, "No partition solutions found.");
 }
 
 int MacroPlacer::weight(int idx1, int idx2)


### PR DESCRIPTION
Change warning to error to avoid mysterious downstream errors in pdn.tcl:



```
v2.0-13145-gfd769f92a
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 1 thread(s).
[INFO MPL-0101] Found 4 macros.
[INFO MPL-0102] West pins 446.
[INFO MPL-0102] East pins 444.
[INFO MPL-0102] North pins 738.
[INFO MPL-0102] South pins 739.
[INFO MPL-0069] Initial weighted wire length 7.22153e+06.
Begin one level partition.
[INFO MPL-0076] Partition 4 macros.
[INFO MPL-0077] Using 4 cut lines.
[INFO MPL-0079] Cut line 129.60.
[INFO MPL-0079] Cut line 381.19.
[INFO MPL-0079] Cut line 665.01.
[INFO MPL-0079] Cut line 891.27.
End one level partition.
Begin horizontal partition.
Begin east partition.
[INFO MPL-0076] Partition 0 macros.
[INFO MPL-0077] Using 0 cut lines.
End east partition.
Begin west partition.
[INFO MPL-0076] Partition 4 macros.
[INFO MPL-0077] Using 2 cut lines.
[INFO MPL-0079] Cut line 145.53.
[INFO MPL-0079] Cut line 237.87.
End west partition.
End horizontal partition.
Begin horizontal partition.
Begin east partition.
[INFO MPL-0076] Partition 1 macros.
[INFO MPL-0077] Using 1 cut lines.
[INFO MPL-0079] Cut line 145.53.
End east partition.
Begin west partition.
[INFO MPL-0076] Partition 3 macros.
[INFO MPL-0077] Using 1 cut lines.
[INFO MPL-0079] Cut line 177.93.
End west partition.
End horizontal partition.
Begin horizontal partition.
Begin east partition.
[INFO MPL-0076] Partition 2 macros.
[INFO MPL-0077] Using 1 cut lines.
[INFO MPL-0079] Cut line 145.53.
End east partition.
Begin west partition.
[INFO MPL-0076] Partition 2 macros.
[INFO MPL-0077] Using 1 cut lines.
[INFO MPL-0079] Cut line 208.44.
End west partition.
End horizontal partition.
Begin horizontal partition.
Begin east partition.
[INFO MPL-0076] Partition 4 macros.
[INFO MPL-0077] Using 2 cut lines.
[INFO MPL-0079] Cut line 145.53.
[INFO MPL-0079] Cut line 237.87.
End east partition.
Begin west partition.
[INFO MPL-0076] Partition 0 macros.
[INFO MPL-0077] Using 0 cut lines.
End west partition.
End horizontal partition.
[INFO MPL-0070] Using 6 partition sets.
[WARNING MPL-0061] Parquet area 880.692 x 616 exceeds the partition area 1051.16 x 559.98.
[WARNING MPL-0061] Parquet area 880.692 x 616 exceeds the partition area 1051.16 x 467.64.
[WARNING MPL-0061] Parquet area 587.128 x 616 exceeds the partition area 799.578 x 527.58.
[WARNING MPL-0061] Parquet area 293.564 x 616 exceeds the partition area 650.592 x 559.98.
[WARNING MPL-0061] Parquet area 880.692 x 616 exceeds the partition area 876.852 x 559.98.
[WARNING MPL-0061] Parquet area 880.692 x 616 exceeds the partition area 876.852 x 467.64.
[WARNING MPL-0072] No partition solutions found.
openroad> 
```


Invalid .odb file generated. Names of macros redacted:



![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/7056b921-5020-4fc1-bdec-a237dec2f3f2)

