### PR TITLE
[Docs] fix failing CI due to psm

### DIFF
--- a/docs/contrib/ReadmeFormat.md
+++ b/docs/contrib/ReadmeFormat.md
@@ -13,6 +13,11 @@ the format and replace the contents where necessary.
 
 ### Command ABC
 
+```{note}
+Please add a description, even a one-liner will be sufficient to 
+avoid triggering CI errors.
+```
+
 The `command_abc` command performs...
 
 The developer arguments are...

--- a/docs/src/scripts/md_roff_compat.py
+++ b/docs/src/scripts/md_roff_compat.py
@@ -94,7 +94,13 @@ def man2_translate(doc, path):
         Options: {len(func_options)},\
         Args: {len(func_args)}''')
         assert len(func_names) == len(func_descs) == len(func_synopsis) == len(func_options) == len(func_args),\
-            "Counts for all 5 categories must match up."
+            f"""Counts for all 5 categories must match up.\n
+            {func_names}\n
+            {func_descs}\n
+            {func_synopsis}\n
+            {func_options}\n
+            {func_args}\n
+            """
 
         for func_id in range(len(func_synopsis)):
             manpage = ManPage()

--- a/src/psm/README.md
+++ b/src/psm/README.md
@@ -31,7 +31,7 @@ analyze_power_grid
     [-error_file error_file]
     [-voltage_file voltage_file]
     [-enable_em]
-    [-em_file em_file]
+    [-em_outfile em_file]
     [-vsrc voltage_source_file]
     [-source_type FULL|BUMPS|STRAPS]
 ```
@@ -112,6 +112,8 @@ set_pdnsim_net_voltage
 
 ### Set PDNSim Power Source Settings
 
+Set PDNSim power source setting.
+
 ```tcl
 set_pdnsim_source_settings
     [-bump_dx pitch]
@@ -130,7 +132,7 @@ set_pdnsim_source_settings
 | `-bump_interval` | Set the bump population interval, this is used to depopulate the bump grid to emulate signals and other power connections. The default bump pitch is 3. |
 | `-strap_track_pitch` | Sets the track pitck to use for moduling voltage sources as straps. The default is 10x. |
 
-### Source grid options
+## Source grid options
 
 The source grid models how power is going be delivered to the power grid.
 The image below illustrate how they can be modeled, the red elements are the source models, the black horizontal boxes represent the top metal layer of the power grid, and the gray boxes indicate these are not used in the modeling.


### PR DESCRIPTION
@maliberty 

The problems in PSM readme
- Non-command headers in README should not be given a `###` - that is reserved for command parsing
- Missing description in function
- Wrong option/flag name, must match Tcl definition