### PR TITLE
odb: relocate user derating value from GRT to dbTechLayer

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -356,7 +356,6 @@ class GlobalRouter : public ant::GlobalRouteSource
                      odb::Point& pin_position,
                      odb::dbTechLayer* layer,
                      Net* net);
-  void initAdjustments();
   odb::Point getRectMiddle(const odb::Rect& rect);
   NetRouteMap findRouting(std::vector<Net*>& nets,
                           int min_routing_layer,
@@ -453,9 +452,6 @@ class GlobalRouter : public ant::GlobalRouteSource
   std::vector<int> horizontal_capacities_;
   int macro_extension_;
   bool initialized_;
-
-  // Layer adjustment variables
-  std::vector<float> adjustments_;
 
   // Region adjustment variables
   std::vector<RegionAdjustment> region_adjustments_;

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7926,6 +7926,10 @@ class dbTechLayer : public dbObject
 
   uint getWrongWayWidth() const;
 
+  void setLayerAdjustment(float layer_adjustment);
+
+  float getLayerAdjustment() const;
+
   dbSet<dbTechLayerCutClassRule> getTechLayerCutClassRules() const;
 
   dbTechLayerCutClassRule* findTechLayerCutClassRule(const char* name) const;

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayer.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayer.json
@@ -136,6 +136,13 @@
       "flags":[
         "no-serial"
       ]
+    },
+    {
+      "name":"layer_adjustment_",
+      "type":"float",
+      "flags":[
+        "no-serial"
+      ]
     }
   ],
   "enums": [

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -70,7 +70,10 @@ namespace odb {
 const uint db_schema_major = 0;  // Not used...
 const uint db_schema_initial = 57;
 
-const uint db_schema_minor = 83;  // Current revision number
+const uint db_schema_minor = 84;  // Current revision number
+
+// Revision where GRT layer adjustment was relocated to dbTechLayer
+const uint db_schema_layer_adjustment = 84;
 
 // Revision where scan structs are added
 const uint db_schema_add_scan = 83;

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -121,6 +121,9 @@ bool _dbTechLayer::operator==(const _dbTechLayer& rhs) const
   if (wrong_way_width_ != rhs.wrong_way_width_) {
     return false;
   }
+  if (layer_adjustment_ != rhs.layer_adjustment_) {
+    return false;
+  }
   if (*cut_class_rules_tbl_ != *rhs.cut_class_rules_tbl_) {
     return false;
   }
@@ -392,6 +395,7 @@ void _dbTechLayer::differences(dbDiff& diff,
   DIFF_FIELD(flags_.rect_only_except_non_core_pins_);
   DIFF_FIELD(flags_.lef58_type_);
   DIFF_FIELD(wrong_way_width_);
+  DIFF_FIELD(layer_adjustment_);
   DIFF_TABLE(cut_class_rules_tbl_);
   DIFF_HASH_TABLE(cut_class_rules_hash_);
   DIFF_TABLE(spacing_eol_rules_tbl_);
@@ -475,6 +479,7 @@ void _dbTechLayer::out(dbDiff& diff, char side, const char* field) const
   DIFF_OUT_FIELD(flags_.rect_only_except_non_core_pins_);
   DIFF_OUT_FIELD(flags_.lef58_type_);
   DIFF_OUT_FIELD(wrong_way_width_);
+  DIFF_OUT_FIELD(layer_adjustment_);
   DIFF_OUT_TABLE(cut_class_rules_tbl_);
   DIFF_OUT_HASH_TABLE(cut_class_rules_hash_);
   DIFF_OUT_TABLE(spacing_eol_rules_tbl_);
@@ -728,6 +733,7 @@ _dbTechLayer::_dbTechLayer(_dbDatabase* db, const _dbTechLayer& r)
   flags_.lef58_type_ = r.flags_.lef58_type_;
   flags_.spare_bits_ = r.flags_.spare_bits_;
   wrong_way_width_ = r.wrong_way_width_;
+  layer_adjustment_ = r.layer_adjustment_;
   cut_class_rules_tbl_ = new dbTable<_dbTechLayerCutClassRule>(
       db, this, *r.cut_class_rules_tbl_);
   cut_class_rules_hash_.setTable(cut_class_rules_tbl_);
@@ -864,6 +870,11 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayer& obj)
     stream >> *obj.two_wires_forbidden_spc_rules_tbl_;
   }
   // User Code Begin >>
+  if (obj.getDatabase()->isSchema(db_schema_layer_adjustment)) {
+    stream >> obj.layer_adjustment_;
+  } else {
+    obj.layer_adjustment_ = 0.0;
+  }
   stream >> obj._pitch_x;
   stream >> obj._pitch_y;
   stream >> obj._offset_x;
@@ -956,6 +967,7 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayer& obj)
     stream << *obj.two_wires_forbidden_spc_rules_tbl_;
   }
   // User Code Begin <<
+  stream << obj.layer_adjustment_;
   stream << obj._pitch_x;
   stream << obj._pitch_y;
   stream << obj._offset_x;
@@ -1155,6 +1167,19 @@ uint dbTechLayer::getWrongWayWidth() const
 {
   _dbTechLayer* obj = (_dbTechLayer*) this;
   return obj->wrong_way_width_;
+}
+
+void dbTechLayer::setLayerAdjustment(float layer_adjustment)
+{
+  _dbTechLayer* obj = (_dbTechLayer*) this;
+
+  obj->layer_adjustment_ = layer_adjustment;
+}
+
+float dbTechLayer::getLayerAdjustment() const
+{
+  _dbTechLayer* obj = (_dbTechLayer*) this;
+  return obj->layer_adjustment_;
 }
 
 dbSet<dbTechLayerCutClassRule> dbTechLayer::getTechLayerCutClassRules() const

--- a/src/odb/src/db/dbTechLayer.h
+++ b/src/odb/src/db/dbTechLayer.h
@@ -120,6 +120,7 @@ class _dbTechLayer : public _dbObject
 
   dbTechLayerFlags flags_;
   uint wrong_way_width_;
+  float layer_adjustment_;
 
   dbTable<_dbTechLayerCutClassRule>* cut_class_rules_tbl_;
   dbHashTable<_dbTechLayerCutClassRule> cut_class_rules_hash_;


### PR DESCRIPTION
RUDY requires some way to load the user derating without overwriting the GRT information, now that it is shared. For that we opted to put the user layer adjustment in ODB, in dbTechLayer. The code generator was used to do so.