### PR TITLE
grt: make rudy a class member

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -98,6 +98,7 @@ class AbstractFastRouteRenderer;
 class GlobalRouter;
 class AbstractRoutingCongestionDataSource;
 class GRouteDbCbk;
+class Rudy;
 
 struct RegionAdjustment
 {
@@ -280,6 +281,7 @@ class GlobalRouter : public ant::GlobalRouteSource
 
   odb::dbDatabase* db() const { return db_; }
   FastRouteCore* fastroute() const { return fastroute_; }
+  Rudy* getRudy();
 
  private:
   // Net functions
@@ -481,6 +483,7 @@ class GlobalRouter : public ant::GlobalRouteSource
   std::vector<odb::dbNet*> nets_to_route_;
 
   RepairAntennas* repair_antennas_;
+  Rudy* rudy_;
   std::unique_ptr<AbstractRoutingCongestionDataSource> heatmap_;
   std::unique_ptr<AbstractRoutingCongestionDataSource> heatmap_rudy_;
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -58,6 +58,7 @@
 #include "MakeWireParasitics.h"
 #include "RepairAntennas.h"
 #include "RoutingTracks.h"
+#include "Rudy.h"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "grt/GRoute.h"
@@ -107,6 +108,7 @@ GlobalRouter::GlobalRouter()
       db_(nullptr),
       block_(nullptr),
       repair_antennas_(nullptr),
+      rudy_(nullptr),
       heatmap_(nullptr),
       heatmap_rudy_(nullptr),
       congestion_file_name_(nullptr),
@@ -545,6 +547,15 @@ void GlobalRouter::updateDirtyNets(std::vector<Net*>& dirty_nets)
     }
   }
   dirty_nets_.clear();
+}
+
+Rudy* GlobalRouter::getRudy()
+{
+  if (rudy_ == nullptr) {
+    rudy_ = new Rudy(db_->getChip()->getBlock(), this);
+  }
+
+  return rudy_;
 }
 
 bool GlobalRouter::findPinAccessPointPositions(

--- a/src/grt/src/heatMapRudy.cpp
+++ b/src/grt/src/heatMapRudy.cpp
@@ -63,7 +63,8 @@ bool RUDYDataSource::populateMap()
   if (!getBlock()) {
     return false;
   }
-  rudy_ = std::make_unique<grt::Rudy>(db_->getChip()->getBlock(), grouter_);
+
+  rudy_ = grouter_->getRudy();
 
   const auto& [x_grid_size, y_grid_size] = rudy_->getGridSize();
   if (x_grid_size == 0 || y_grid_size == 0) {

--- a/src/grt/src/heatMapRudy.h
+++ b/src/grt/src/heatMapRudy.h
@@ -85,7 +85,7 @@ class RUDYDataSource : public gui::GlobalRoutingDataSource,
  private:
   grt::GlobalRouter* grouter_;
   odb::dbDatabase* db_;
-  std::unique_ptr<grt::Rudy> rudy_;
+  grt::Rudy* rudy_;
 };
 
 }  // namespace grt


### PR DESCRIPTION
To have the RUDY heatmap and GPL using the same Rudy object, make rudy inside GRT a class member so it's available for both the heatmap and GPL. 