### PR TITLE
rsz: Fix split length calculation for long wires

### DIFF
--- a/src/cts/test/array.ok
+++ b/src/cts/test/array.ok
@@ -64,14 +64,14 @@
 [INFO CTS-0102]  Path depth 18 - 19
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 33 long wires.
-[INFO RSZ-0048] Inserted 89 buffers in 33 nets.
+[INFO RSZ-0048] Inserted 92 buffers in 33 nets.
 Placement Analysis
 ---------------------------------
-total displacement       2501.3 u
-average displacement        0.9 u
-max displacement           85.3 u
-original HPWL          133077.5 u
-legalized HPWL         133357.9 u
+total displacement       2683.7 u
+average displacement        1.0 u
+max displacement          111.5 u
+original HPWL          133043.7 u
+legalized HPWL         133342.2 u
 delta HPWL                    0 %
 
 Clock clk

--- a/src/cts/test/array_ins_delay.ok
+++ b/src/cts/test/array_ins_delay.ok
@@ -115,24 +115,24 @@
 [INFO CTS-0102]  Path depth 17 - 17
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 56 long wires.
-[INFO RSZ-0048] Inserted 111 buffers in 56 nets.
+[INFO RSZ-0048] Inserted 114 buffers in 56 nets.
 Placement Analysis
 ---------------------------------
-total displacement       3169.7 u
-average displacement        1.0 u
-max displacement           85.5 u
-original HPWL          185797.2 u
-legalized HPWL         186297.4 u
+total displacement       4552.0 u
+average displacement        1.5 u
+max displacement          153.0 u
+original HPWL          185794.9 u
+legalized HPWL         186276.4 u
 delta HPWL                    0 %
 
 Clock clk
-   1.30 source latency inst_7_9/clk ^
+   1.24 source latency inst_8_12/clk ^
    0.00 source clock tree delay
-  -1.13 target latency inst_8_9/clk ^
+  -1.09 target latency inst_10_12/clk ^
   -0.00 target clock tree delay
    0.00 CRPR
 --------------
-   0.17 setup skew
+   0.15 setup skew
 
 Startpoint: inst_1_1 (rising edge-triggered flip-flop clocked by clk)
 Endpoint: inst_2_1 (rising edge-triggered flip-flop clocked by clk)
@@ -144,75 +144,75 @@ Path Type: max
    0.00    0.00   clock clk (rise edge)
    0.00    0.00   clock source latency
    0.00    0.00 ^ clk (in)
-   0.02    0.02 ^ wire7/Z (BUF_X8)
-   0.06    0.08 ^ wire6/Z (BUF_X16)
-   0.06    0.14 ^ wire5/Z (BUF_X16)
+   0.04    0.04 ^ wire7/Z (BUF_X8)
+   0.04    0.08 ^ wire6/Z (BUF_X16)
+   0.07    0.14 ^ wire5/Z (BUF_X32)
    0.06    0.20 ^ wire4/Z (BUF_X32)
    0.06    0.27 ^ wire3/Z (BUF_X32)
    0.06    0.33 ^ wire2/Z (BUF_X32)
    0.06    0.39 ^ wire1/Z (BUF_X32)
-   0.07    0.46 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    0.50 ^ delaybuf_0_clk/Z (BUF_X4)
-   0.03    0.53 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
-   0.03    0.57 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    0.60 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
-   0.03    0.63 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
-   0.04    0.67 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
-   0.03    0.71 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    0.74 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
-   0.03    0.77 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    0.81 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
-   0.04    0.84 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
-   0.03    0.88 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
-   0.03    0.91 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
-   0.04    0.95 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    0.98 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    1.01 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
-   0.05    1.06 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    1.10 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
-   0.03    1.13 ^ max_length8/Z (BUF_X8)
-   0.04    1.16 ^ inst_1_1/clk (array_tile)
-   0.21    1.38 ^ inst_1_1/e_out (array_tile)
-   0.00    1.38 ^ inst_2_1/w_in (array_tile)
-           1.38   data arrival time
+   0.06    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    0.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    0.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
+   0.03    0.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
+   0.03    0.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    0.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
+   0.04    0.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
+   0.03    0.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
+   0.03    0.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    0.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
+   0.03    0.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.04    0.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
+   0.03    0.87 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
+   0.03    0.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
+   0.04    0.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
+   0.03    0.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    1.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.05    1.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
+   0.04    1.09 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
+   0.03    1.12 ^ max_length8/Z (BUF_X8)
+   0.04    1.15 ^ inst_1_1/clk (array_tile)
+   0.21    1.36 ^ inst_1_1/e_out (array_tile)
+   0.00    1.36 ^ inst_2_1/w_in (array_tile)
+           1.36   data arrival time
 
    5.00    5.00   clock clk (rise edge)
    0.00    5.00   clock source latency
    0.00    5.00 ^ clk (in)
-   0.02    5.02 ^ wire7/Z (BUF_X8)
-   0.06    5.08 ^ wire6/Z (BUF_X16)
-   0.06    5.14 ^ wire5/Z (BUF_X16)
+   0.04    5.04 ^ wire7/Z (BUF_X8)
+   0.04    5.08 ^ wire6/Z (BUF_X16)
+   0.07    5.14 ^ wire5/Z (BUF_X32)
    0.06    5.20 ^ wire4/Z (BUF_X32)
    0.06    5.27 ^ wire3/Z (BUF_X32)
    0.06    5.33 ^ wire2/Z (BUF_X32)
    0.06    5.39 ^ wire1/Z (BUF_X32)
-   0.07    5.46 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    5.50 ^ delaybuf_0_clk/Z (BUF_X4)
-   0.03    5.53 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
-   0.03    5.57 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    5.60 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
-   0.03    5.63 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
-   0.04    5.67 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
-   0.03    5.71 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    5.74 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
-   0.03    5.77 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    5.81 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
-   0.04    5.84 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
-   0.03    5.88 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
-   0.03    5.91 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
-   0.04    5.95 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    5.98 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    6.01 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
-   0.05    6.06 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    6.10 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
-   0.03    6.13 ^ max_length13/Z (BUF_X8)
-   0.04    6.16 ^ inst_2_1/clk (array_tile)
-   0.00    6.16   clock reconvergence pessimism
-  -0.05    6.11   library setup time
-           6.11   data required time
+   0.06    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    5.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    5.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
+   0.03    5.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
+   0.03    5.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    5.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
+   0.04    5.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
+   0.03    5.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
+   0.03    5.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    5.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
+   0.03    5.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.04    5.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
+   0.03    5.87 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
+   0.03    5.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
+   0.04    5.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
+   0.03    5.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    6.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.05    6.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
+   0.04    6.09 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
+   0.03    6.12 ^ max_length13/Z (BUF_X8)
+   0.04    6.15 ^ inst_2_1/clk (array_tile)
+   0.00    6.15   clock reconvergence pessimism
+  -0.05    6.10   library setup time
+           6.10   data required time
 ---------------------------------------------------------
-           6.11   data required time
-          -1.38   data arrival time
+           6.10   data required time
+          -1.36   data arrival time
 ---------------------------------------------------------
            4.74   slack (MET)
 
@@ -227,75 +227,75 @@ Path Type: max
    0.00    0.00   clock clk (rise edge)
    0.00    0.00   clock source latency
    0.00    0.00 ^ clk (in)
-   0.02    0.02 ^ wire7/Z (BUF_X8)
-   0.06    0.08 ^ wire6/Z (BUF_X16)
-   0.06    0.14 ^ wire5/Z (BUF_X16)
+   0.04    0.04 ^ wire7/Z (BUF_X8)
+   0.04    0.08 ^ wire6/Z (BUF_X16)
+   0.07    0.14 ^ wire5/Z (BUF_X32)
    0.06    0.20 ^ wire4/Z (BUF_X32)
    0.06    0.27 ^ wire3/Z (BUF_X32)
    0.06    0.33 ^ wire2/Z (BUF_X32)
    0.06    0.39 ^ wire1/Z (BUF_X32)
-   0.07    0.46 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    0.50 ^ delaybuf_0_clk/Z (BUF_X4)
-   0.03    0.53 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
-   0.03    0.57 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    0.60 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
-   0.03    0.63 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
-   0.04    0.67 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
-   0.03    0.71 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    0.74 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
-   0.03    0.77 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    0.81 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
-   0.04    0.84 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
-   0.03    0.88 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
-   0.03    0.91 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
-   0.04    0.95 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    0.98 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    1.01 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
-   0.05    1.06 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    1.10 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
-   0.03    1.13 ^ max_length13/Z (BUF_X8)
-   0.04    1.16 ^ inst_2_1/clk (array_tile)
-   0.21    1.38 ^ inst_2_1/w_out (array_tile)
-   0.00    1.38 ^ inst_1_1/e_in (array_tile)
-           1.38   data arrival time
+   0.06    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    0.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    0.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
+   0.03    0.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
+   0.03    0.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    0.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
+   0.04    0.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
+   0.03    0.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
+   0.03    0.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    0.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
+   0.03    0.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.04    0.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
+   0.03    0.87 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
+   0.03    0.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
+   0.04    0.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
+   0.03    0.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    1.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.05    1.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
+   0.04    1.09 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
+   0.03    1.12 ^ max_length13/Z (BUF_X8)
+   0.04    1.15 ^ inst_2_1/clk (array_tile)
+   0.21    1.37 ^ inst_2_1/w_out (array_tile)
+   0.00    1.37 ^ inst_1_1/e_in (array_tile)
+           1.37   data arrival time
 
    5.00    5.00   clock clk (rise edge)
    0.00    5.00   clock source latency
    0.00    5.00 ^ clk (in)
-   0.02    5.02 ^ wire7/Z (BUF_X8)
-   0.06    5.08 ^ wire6/Z (BUF_X16)
-   0.06    5.14 ^ wire5/Z (BUF_X16)
+   0.04    5.04 ^ wire7/Z (BUF_X8)
+   0.04    5.08 ^ wire6/Z (BUF_X16)
+   0.07    5.14 ^ wire5/Z (BUF_X32)
    0.06    5.20 ^ wire4/Z (BUF_X32)
    0.06    5.27 ^ wire3/Z (BUF_X32)
    0.06    5.33 ^ wire2/Z (BUF_X32)
    0.06    5.39 ^ wire1/Z (BUF_X32)
-   0.07    5.46 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    5.50 ^ delaybuf_0_clk/Z (BUF_X4)
-   0.03    5.53 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
-   0.03    5.57 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    5.60 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
-   0.03    5.63 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
-   0.04    5.67 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
-   0.03    5.71 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    5.74 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
-   0.03    5.77 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    5.81 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
-   0.04    5.84 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
-   0.03    5.88 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
-   0.03    5.91 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
-   0.04    5.95 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    5.98 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    6.01 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
-   0.05    6.06 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    6.10 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
-   0.03    6.13 ^ max_length8/Z (BUF_X8)
-   0.04    6.16 ^ inst_1_1/clk (array_tile)
-   0.00    6.16   clock reconvergence pessimism
-  -0.05    6.11   library setup time
-           6.11   data required time
+   0.06    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    5.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    5.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
+   0.03    5.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
+   0.03    5.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    5.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
+   0.04    5.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
+   0.03    5.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
+   0.03    5.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    5.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
+   0.03    5.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.04    5.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
+   0.03    5.87 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
+   0.03    5.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
+   0.04    5.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
+   0.03    5.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    6.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.05    6.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
+   0.04    6.09 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
+   0.03    6.12 ^ max_length8/Z (BUF_X8)
+   0.04    6.15 ^ inst_1_1/clk (array_tile)
+   0.00    6.15   clock reconvergence pessimism
+  -0.05    6.10   library setup time
+           6.10   data required time
 ---------------------------------------------------------
-           6.11   data required time
-          -1.38   data arrival time
+           6.10   data required time
+          -1.37   data arrival time
 ---------------------------------------------------------
            4.74   slack (MET)
 

--- a/src/cts/test/array_no_blockages.ok
+++ b/src/cts/test/array_no_blockages.ok
@@ -64,14 +64,14 @@
 [INFO CTS-0102]  Path depth 18 - 19
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 33 long wires.
-[INFO RSZ-0048] Inserted 88 buffers in 33 nets.
+[INFO RSZ-0048] Inserted 92 buffers in 33 nets.
 Placement Analysis
 ---------------------------------
-total displacement       1829.5 u
+total displacement       1895.3 u
 average displacement        0.7 u
 max displacement           84.5 u
-original HPWL          133339.3 u
-legalized HPWL         133583.9 u
+original HPWL          133259.3 u
+legalized HPWL         133525.7 u
 delta HPWL                    0 %
 
 Clock clk

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -852,7 +852,7 @@ void RepairDesign::repairNetWire(
                  level,
                  units_->distanceUnit()->asString(dbuToMeters(wire_length), 1),
                  units_->distanceUnit()->asString(dbuToMeters(max_length_), 1));
-      split_length = min(split_length, max_length_);
+      split_length = min(split_length, max(max_length_ - wire_length_ref, 0));
       split_wire = true;
     }
     if (wire_cap > 0.0 && load_cap > max_cap_) {

--- a/src/rsz/test/repair_wire2.ok
+++ b/src/rsz/test/repair_wire2.ok
@@ -53,15 +53,15 @@ u4/Z manhtn 1.1 steiner 1.1 0.00
 in1 manhtn 0.7 steiner 0.7 0.00
 u1/Z manhtn 0.4 steiner 0.4 0.00
 [INFO RSZ-0037] Found 1 long wires.
-[INFO RSZ-0038] Inserted 2 buffers in 1 nets.
-[INFO RSZ-0039] Resized 2 instances.
+[INFO RSZ-0038] Inserted 3 buffers in 1 nets.
+[INFO RSZ-0039] Resized 3 instances.
 Driver    length delay
-wire2/Z manhtn 1497.0 steiner 1497.0 0.30
+wire2/Z manhtn 974.5 steiner 974.5 0.13
 wire1/Z manhtn 952.7 steiner 952.7 0.12
-u2/Z manhtn 544.8 steiner 544.8 0.04
+wire3/Z manhtn 948.4 steiner 948.4 0.12
+u2/Z manhtn 120.2 steiner 120.2 0.00
 u3/Z manhtn 1.1 steiner 1.1 0.00
 u4/Z manhtn 1.1 steiner 1.1 0.00
-u1/Z manhtn 0.8 steiner 0.8 0.00
 in1 manhtn 0.7 steiner 0.7 0.00
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
@@ -71,17 +71,19 @@ Path Type: max
      Cap     Slew    Delay     Time   Description
 ---------------------------------------------------------------------------
                      0.000    0.000 ^ input external delay
-   3.451    0.000    0.000    0.000 ^ in1 (in)
-            0.000    0.000    0.000 ^ u1/A (BUF_X4)
-  26.763    0.018    0.030    0.030 ^ u1/Z (BUF_X4)
-            0.018    0.000    0.030 ^ u2/A (BUF_X32)
-  53.360    0.006    0.022    0.052 ^ u2/Z (BUF_X32)
-            0.056    0.046    0.098 ^ wire2/A (BUF_X16)
- 125.932    0.010    0.032    0.130 ^ wire2/Z (BUF_X16)
-            0.267    0.218    0.348 ^ u3/A (BUF_X1)
-   0.000    0.012    0.024    0.372 ^ u3/Z (BUF_X1)
-            0.012    0.000    0.372 ^ out1 (out)
-                              0.372   data arrival time
+   1.456    0.000    0.000    0.000 ^ in1 (in)
+            0.000    0.000    0.000 ^ u1/A (CLKBUF_X2)
+  12.443    0.017    0.035    0.035 ^ u1/Z (CLKBUF_X2)
+            0.017    0.000    0.035 ^ u2/A (BUF_X16)
+  15.623    0.006    0.022    0.057 ^ u2/Z (BUF_X16)
+            0.007    0.004    0.061 ^ wire3/A (BUF_X8)
+  83.696    0.015    0.029    0.090 ^ wire3/Z (BUF_X8)
+            0.147    0.120    0.210 ^ wire2/A (BUF_X16)
+  86.665    0.012    0.032    0.242 ^ wire2/Z (BUF_X16)
+            0.097    0.078    0.320 ^ u3/A (BUF_X1)
+   0.000    0.007    0.028    0.348 ^ u3/Z (BUF_X1)
+            0.007    0.000    0.348 ^ out1 (out)
+                              0.348   data arrival time
 ---------------------------------------------------------------------------
 (Path is unconstrained)
 
@@ -94,19 +96,21 @@ Path Type: max
      Cap     Slew    Delay     Time   Description
 ---------------------------------------------------------------------------
                      0.000    0.000 ^ input external delay
-   3.451    0.000    0.000    0.000 ^ in1 (in)
-            0.000    0.000    0.000 ^ u1/A (BUF_X4)
-  26.763    0.018    0.030    0.030 ^ u1/Z (BUF_X4)
-            0.018    0.000    0.030 ^ u2/A (BUF_X32)
-  53.360    0.006    0.022    0.052 ^ u2/Z (BUF_X32)
-            0.056    0.046    0.098 ^ wire2/A (BUF_X16)
- 125.932    0.010    0.032    0.130 ^ wire2/Z (BUF_X16)
-            0.322    0.264    0.394 ^ wire1/A (BUF_X16)
-  72.581    0.020    0.033    0.427 ^ wire1/Z (BUF_X16)
-            0.110    0.090    0.517 ^ u4/A (BUF_X1)
-   0.000    0.008    0.028    0.545 ^ u4/Z (BUF_X1)
-            0.008    0.000    0.545 ^ out2 (out)
-                              0.545   data arrival time
+   1.456    0.000    0.000    0.000 ^ in1 (in)
+            0.000    0.000    0.000 ^ u1/A (CLKBUF_X2)
+  12.443    0.017    0.035    0.035 ^ u1/Z (CLKBUF_X2)
+            0.017    0.000    0.035 ^ u2/A (BUF_X16)
+  15.623    0.006    0.022    0.057 ^ u2/Z (BUF_X16)
+            0.007    0.004    0.061 ^ wire3/A (BUF_X8)
+  83.696    0.015    0.029    0.090 ^ wire3/Z (BUF_X8)
+            0.147    0.120    0.210 ^ wire2/A (BUF_X16)
+  86.665    0.012    0.032    0.242 ^ wire2/Z (BUF_X16)
+            0.153    0.125    0.367 ^ wire1/A (BUF_X16)
+  72.581    0.014    0.035    0.402 ^ wire1/Z (BUF_X16)
+            0.110    0.090    0.491 ^ u4/A (BUF_X1)
+   0.000    0.008    0.028    0.519 ^ u4/Z (BUF_X1)
+            0.008    0.000    0.519 ^ out2 (out)
+                              0.519   data arrival time
 ---------------------------------------------------------------------------
 (Path is unconstrained)
 

--- a/src/rsz/test/resize_slack1.ok
+++ b/src/rsz/test/resize_slack1.ok
@@ -5,4 +5,4 @@
 [INFO ODB-0132]     Created 2 special nets and 34 connections.
 [INFO ODB-0133]     Created 7 nets and 30 connections.
 [INFO RSZ-0026] Removed 5 buffers.
-r1q 0.747
+r1q 0.749

--- a/src/rsz/test/resize_slack3.ok
+++ b/src/rsz/test/resize_slack3.ok
@@ -5,4 +5,4 @@
 [INFO ODB-0132]     Created 2 special nets and 34 connections.
 [INFO ODB-0133]     Created 7 nets and 30 connections.
 [INFO RSZ-0026] Removed 5 buffers.
-r1q 0.747
+r1q 0.749


### PR DESCRIPTION
From the commit message:

> The `repairNetWire` function works on one wire segment at a time. To detect an overly long wire, we compare `wire_length > max_length_`, where `wire_length` is inclusive of previous segments.
> 
> When we request splitting, `split_length` is in terms of the current segment only, so add a missing offset that accounts for the length contributed from previous segments.

As far as I can tell there's an actual bug, but I wonder how come this hasn't been caught by some kind of DRC before.