### PR TITLE
staGui: End column is now visible

### DIFF
--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -110,7 +110,7 @@ int TimingPathsModel::rowCount(const QModelIndex& parent) const
 
 int TimingPathsModel::columnCount(const QModelIndex& parent) const
 {
-  return 6;
+  return getColumnNames().size();
 }
 
 QVariant TimingPathsModel::data(const QModelIndex& index, int role) const
@@ -157,22 +157,7 @@ QVariant TimingPathsModel::headerData(int section,
                                       int role) const
 {
   if (role == Qt::DisplayRole && orientation == Qt::Horizontal) {
-    switch (static_cast<Column>(section)) {
-      case Clock:
-        return "Capture Clock";
-      case Required:
-        return "Required";
-      case Arrival:
-        return "Arrival";
-      case Slack:
-        return "Slack";
-      case Skew:
-        return "Skew";
-      case Start:
-        return "Start";
-      case End:
-        return "End";
-    }
+    return getColumnNames().at(static_cast<Column>(section));
   }
   return QVariant();
 }
@@ -292,7 +277,7 @@ int TimingPathDetailModel::rowCount(const QModelIndex& parent) const
 
 int TimingPathDetailModel::columnCount(const QModelIndex& parent) const
 {
-  return 7;
+  return TimingPathsModel::getColumnNames().size();
 }
 
 const TimingPathNode* TimingPathDetailModel::getNodeAt(

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -70,7 +70,32 @@ class TimingPathsModel : public QAbstractTableModel
 {
   Q_OBJECT
 
+ private:
+  enum Column
+  {
+    Clock,
+    Required,
+    Arrival,
+    Slack,
+    Skew,
+    Start,
+    End
+  };
+
  public:
+  static const std::map<Column, const char*>& getColumnNames()
+  {
+    static const std::map<Column, const char*> columnNames
+        = {{Clock, "Capture Clock"},
+           {Required, "Required"},
+           {Arrival, "Arrival"},
+           {Slack, "Slack"},
+           {Skew, "Skew"},
+           {Start, "Start"},
+           {End, "End"}};
+    return columnNames;
+  }
+
   TimingPathsModel(bool is_setup,
                    STAGuiInterface* sta,
                    QObject* parent = nullptr);
@@ -103,17 +128,6 @@ class TimingPathsModel : public QAbstractTableModel
   STAGuiInterface* sta_;
   bool is_setup_;
   std::vector<std::unique_ptr<TimingPath>> timing_paths_;
-
-  enum Column
-  {
-    Clock,
-    Required,
-    Arrival,
-    Slack,
-    Skew,
-    Start,
-    End
-  };
 };
 
 class TimingPathDetailModel : public QAbstractTableModel


### PR DESCRIPTION
there's no great way in C++ to get the maximum value/count for an enum, but at least it's no longer hardcoded if new columns are added.

The "End" column was hidden since there was a gaffe when adding End and not updating the hardcoded count of the enum everywhere:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/5100942c-7e72-4cd4-a6ec-7be72b0725b9)
