### PR TITLE
DRT skip adding access points for db pins with no net

### DIFF
--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -3637,10 +3637,10 @@ void io::Writer::updateDbAccessPoints(odb::dbBlock* block, odb::dbTech* db_tech)
         logger_->error(DRT, 298, "iterm {} not found in db", term->getName());
       }
 
-      if(db_iterm->getNet() == nullptr) {
+      if (db_iterm->getNet() == nullptr) {
         continue;
       }
-      
+
       auto db_pins = db_iterm->getMTerm()->getMPins();
       if (aps.size() != db_pins.size()) {
         logger_->error(

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -3636,6 +3636,11 @@ void io::Writer::updateDbAccessPoints(odb::dbBlock* block, odb::dbTech* db_tech)
       if (db_iterm == nullptr) {
         logger_->error(DRT, 298, "iterm {} not found in db", term->getName());
       }
+
+      if(db_iterm->getNet() == nullptr) {
+        continue;
+      }
+      
       auto db_pins = db_iterm->getMTerm()->getMPins();
       if (aps.size() != db_pins.size()) {
         logger_->error(


### PR DESCRIPTION
Fixes [#5005](https://github.com/The-OpenROAD-Project/OpenROAD/issues/5005)

This PR avoids creating access points for db pins that aren't connected to any net. This is to prevent errors from happening to pins that are not connected to any net.