### PR TITLE
mpl2: decrease connection signature weight threshold

### DIFF
--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -445,7 +445,7 @@ class HierRTLMP
 
   // minimum number of connections between two clusters
   // for them to be identified as connected
-  int signature_net_threshold_ = 20;
+  int signature_net_threshold_ = 0;
   int large_net_threshold_ = 100;     // ignore global nets when clustering
   const int bus_net_threshold_ = 32;  // only for bus planning
   float congestion_weight_ = 0.5;     // for balance timing and congestion

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -94,7 +94,7 @@ proc rtl_macro_placer { args } {
   set coarsening_ratio 10.0
   set num_bundled_ios 3
   set large_net_threshold 50
-  set signature_net_threshold 50
+  set signature_net_threshold 20
   set halo_width 0.0
   set halo_height 0.0
   set fence_lx 0.0


### PR DESCRIPTION
When running Secure-CI for #4991 asap7/aes-block showed some metrics degradation. After some digging it looked like the problem wasn't specifically related to that PR itself, but rather there was something weird going on with the clustering.

Actually, asap7/aes-block shows a very narrow case where the minimum weight threshold for MPL2 to consider two clusters connected was impacting on how the clusters were formed.

These changes are to ensure that, for smaller designs, we won't end up splitting macros unconveniently.