### PR TITLE
ord: add build type to splash if other than release

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -350,6 +350,8 @@ target_link_libraries(openroad
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
+target_compile_definitions(openroad PRIVATE BUILD_TYPE="${CMAKE_BUILD_TYPE}")
+
 # tclReadline
 if (TCL_READLINE_LIBRARY AND TCL_READLINE_H)
   target_compile_definitions(openroad PRIVATE ENABLE_READLINE)

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -491,11 +491,13 @@ static void showSplash()
                  ord::OpenRoad::getGitDescribe());
   logger->report(
       "Features included (+) or not (-): "
-      "{}Charts {}GPU {}GUI {}Python",
+      "{}Charts {}GPU {}GUI {}Python{}",
       ord::OpenRoad::getChartsCompileOption() ? "+" : "-",
       ord::OpenRoad::getGPUCompileOption() ? "+" : "-",
       ord::OpenRoad::getGUICompileOption() ? "+" : "-",
-      ord::OpenRoad::getPythonCompileOption() ? "+" : "-");
+      ord::OpenRoad::getPythonCompileOption() ? "+" : "-",
+      strcmp(BUILD_TYPE, "Release") == 0 ? ""
+                                         : fmt::format(" : {}", BUILD_TYPE));
   logger->report(
       "This program is licensed under the BSD-3 license. See the LICENSE file "
       "for details.");


### PR DESCRIPTION
No function changes expected to the "Release" builds.

Adds:
- indicator to splash to indicate if the build is something other than Release.

Reasoning:
- in the past I've been trying to determine runtime issues and it's frequently because the build type is Debug and I forgot to switch it back to Release.
