### PR TITLE
Inspector: add width, height for convenience alongside BBox

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1442,8 +1442,10 @@ Descriptor::Properties Selected::getProperties() const
   if (getBBox(bbox)) {
     props.push_back({"BBox", bbox});
     // convenience; the user may want to know the dimensions
-    props.push_back({"Width", std::string(Descriptor::Property::convert_dbu(bbox.dx(), false))});
-    props.push_back({"Height", std::string(Descriptor::Property::convert_dbu(bbox.dy(), false))});
+    props.push_back(
+        {"BBox Width, Height",
+         std::string("(") + Descriptor::Property::convert_dbu(bbox.dx(), false)
+             + ", " + Descriptor::Property::convert_dbu(bbox.dy(), false)});
   }
 
   return props;

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1441,6 +1441,9 @@ Descriptor::Properties Selected::getProperties() const
   odb::Rect bbox;
   if (getBBox(bbox)) {
     props.push_back({"BBox", bbox});
+    // convenience; the user may want to know the dimensions
+    props.push_back({"Width", std::string(Descriptor::Property::convert_dbu(bbox.dx(), false))});
+    props.push_back({"Height", std::string(Descriptor::Property::convert_dbu(bbox.dy(), false))});
   }
 
   return props;

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1445,7 +1445,8 @@ Descriptor::Properties Selected::getProperties() const
     props.push_back(
         {"BBox Width, Height",
          std::string("(") + Descriptor::Property::convert_dbu(bbox.dx(), false)
-             + ", " + Descriptor::Property::convert_dbu(bbox.dy(), false)});
+             + ", " + Descriptor::Property::convert_dbu(bbox.dy(), false)
+             + ")"});
   }
 
   return props;


### PR DESCRIPTION
Example use case: compare dimensions of two macros.

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/ff58a582-3935-4c90-8f20-475acab9635a)
