### PR TITLE
rmp: Adds support to create an abc standard cell library from opensta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ configure_file(
 
 ################################################################
 
+link_libraries(stdc++fs)
 # Ask CMake to output a compile_commands.json file for use with things like clang-tidy
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -166,7 +166,7 @@ class dbSta : public Sta, public ord::OpenRoadObserver
 
   dbNetwork* db_network_ = nullptr;
   dbStaReport* db_report_ = nullptr;
-  dbStaCbk* db_cbk_ = nullptr;
+  std::unique_ptr<dbStaCbk> db_cbk_;
 
   std::unique_ptr<AbstractPathRenderer> path_renderer_;
   std::unique_ptr<AbstractPowerDensityDataSource> power_density_data_source_;

--- a/src/dbSta/src/CMakeLists.txt
+++ b/src/dbSta/src/CMakeLists.txt
@@ -50,9 +50,10 @@ target_include_directories(dbSta_lib
 
 
 target_link_libraries(dbSta_lib
-  PRIVATE
-    OpenSTA
+  PUBLIC
     odb
+    OpenSTA
+  PRIVATE
     utl_lib
 )
 

--- a/src/dbSta/src/MakeDbSta.cc
+++ b/src/dbSta/src/MakeDbSta.cc
@@ -29,11 +29,6 @@ namespace ord {
 
 using sta::dbSta;
 
-dbSta* makeDbSta()
-{
-  return new dbSta;
-}
-
 void deleteDbSta(sta::dbSta* sta)
 {
   delete sta;

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -68,6 +68,16 @@
 
 ////////////////////////////////////////////////////////////////
 
+namespace ord {
+
+using sta::dbSta;
+
+dbSta* makeDbSta()
+{
+  return new dbSta;
+}
+}  // namespace ord
+
 namespace sta {
 
 using utl::Logger;
@@ -154,7 +164,9 @@ void dbSta::initVars(Tcl_Interp* tcl_interp,
   db_ = db;
   logger_ = logger;
   makeComponents();
-  setTclInterp(tcl_interp);
+  if (tcl_interp) {
+    setTclInterp(tcl_interp);
+  }
   db_report_->setLogger(logger);
   db_network_->init(db, logger);
   db_cbk_ = new dbStaCbk(this, logger);

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -169,7 +169,7 @@ void dbSta::initVars(Tcl_Interp* tcl_interp,
   }
   db_report_->setLogger(logger);
   db_network_->init(db, logger);
-  db_cbk_ = new dbStaCbk(this, logger);
+  db_cbk_ = std::make_unique<dbStaCbk>(this, logger);
 }
 
 void dbSta::setPathRenderer(std::unique_ptr<AbstractPathRenderer> path_renderer)

--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -80,12 +80,14 @@ add_library(rmp_abc_library
 target_include_directories(rmp_abc_library
   PUBLIC
     ../include
+  PRIVATE
     .
 )
 
 target_link_libraries(rmp_abc_library
   PUBLIC
     OpenSTA
+    dbSta_lib
     libabc
     utl_lib
 )

--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -73,6 +73,23 @@ target_link_libraries(rmp
     ${ABC_LIBRARY}
  )
 
+add_library(rmp_abc_library 
+  abc_library_factory.cpp
+)
+
+target_include_directories(rmp_abc_library
+  PUBLIC
+    ../include
+    .
+)
+
+target_link_libraries(rmp_abc_library
+  PUBLIC
+    OpenSTA
+    libabc
+    utl_lib
+)
+
 if (Python3_FOUND AND BUILD_PYTHON)
   swig_lib(NAME          rmp_py
            NAMESPACE     rmp

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -213,7 +213,7 @@ std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcOutputPins(
     // Get list of input ports
     abc::Vec_Ptr_t* input_names_abc = abc::Vec_PtrAlloc(input_names.size());
     for (const std::string& port_name : input_names) {
-      abc::Vec_PtrPush(input_names_abc, strdup(port_name.c_str()));
+      abc::Vec_PtrPush(input_names_abc, const_cast<char*>(port_name.c_str()));
     }
 
     // Set standard cell function
@@ -307,8 +307,8 @@ utl::deleted_unique_ptr<abc::SC_Lib> AbcLibraryFactory::Build()
   }
 
   abc::SC_Lib* abc_library = abc::Abc_SclLibAlloc();
-  sta::LibertyLibraryIterator* library_iter
-      = db_sta_->network()->libertyLibraryIterator();
+  std::unique_ptr<sta::LibertyLibraryIterator> library_iter(
+      db_sta_->network()->libertyLibraryIterator());
   while (library_iter->hasNext()) {
     sta::LibertyLibrary* library = library_iter->next();
     PopulateAbcSclLibFromSta(abc_library, library);

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -99,28 +99,29 @@ static bool HasOnlyPowerAndGroundPorts(sta::LibertyCell* cell)
   return true;
 }
 
-static bool isCompatibleWithAbc(sta::LibertyCell* cell) {
+static bool isCompatibleWithAbc(sta::LibertyCell* cell)
+{
   if (!IsCombinational(cell)) {
-      return false;
-    }
+    return false;
+  }
 
-    if (IsMultiOutputCell(cell)) {
-      return false;
-    }
+  if (IsMultiOutputCell(cell)) {
+    return false;
+  }
 
-    if (!HasOutputs(cell)) {
-      return false;
-    }
+  if (!HasOutputs(cell)) {
+    return false;
+  }
 
-    if (HasNonInputOutputPorts(cell)) {
-      return false;
-    }
+  if (HasNonInputOutputPorts(cell)) {
+    return false;
+  }
 
-    if (HasOnlyPowerAndGroundPorts(cell)) {
-      return false;
-    }
+  if (HasOnlyPowerAndGroundPorts(cell)) {
+    return false;
+  }
 
-    return true;
+  return true;
 }
 
 void AbcLibraryFactory::AbcPopulateAbcSurfaceFromSta(

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -40,7 +40,7 @@ static bool IsCombinational(sta::LibertyCell* cell)
           && !cell->isIsolationCell() && !cell->isClockGate());
 }
 
-static bool HasOutputs(sta::LibertyCell* cell)
+static int CountOutputPins(sta::LibertyCell* cell)
 {
   sta::LibertyCellPortIterator cell_port_iterator(cell);
   int output_count = 0;
@@ -51,21 +51,7 @@ static bool HasOutputs(sta::LibertyCell* cell)
     }
   }
 
-  return output_count != 0;
-}
-
-static bool IsMultiOutputCell(sta::LibertyCell* cell)
-{
-  sta::LibertyCellPortIterator cell_port_iterator(cell);
-  int output_count = 0;
-  while (cell_port_iterator.hasNext()) {
-    sta::LibertyPort* port = cell_port_iterator.next();
-    if (port->direction()->isOutput()) {
-      output_count++;
-    }
-  }
-
-  return output_count > 1;
+  return output_count;
 }
 
 static bool HasNonInputOutputPorts(sta::LibertyCell* cell)
@@ -105,11 +91,7 @@ static bool isCompatibleWithAbc(sta::LibertyCell* cell)
     return false;
   }
 
-  if (IsMultiOutputCell(cell)) {
-    return false;
-  }
-
-  if (!HasOutputs(cell)) {
+  if (CountOutputPins(cell) != 1) {
     return false;
   }
 

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -279,7 +279,7 @@ std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcOutputPins(
 
       if (!rise_gate_model || !fall_gate_model) {
         logger_->error(utl::RMP,
-                       19,
+                       23,
                        "rise/fall Gate model is empty for cell {}. Need timing "
                        "information",
                        cell->name());
@@ -393,7 +393,7 @@ void AbcLibraryFactory::PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library)
       abc_cell->leakage = power_unit->staToUser(leakage_power);
     } else {
       logger_->warn(utl::RMP,
-                    16,
+                    22,
                     "Leakage power doesn't exist for cell {}",
                     cell->name());
     }
@@ -405,7 +405,7 @@ void AbcLibraryFactory::PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library)
     abc_cell->n_inputs = input_pins.size();
     for (abc::SC_Pin* pin : input_pins) {
       abc::Vec_PtrPush(&abc_cell->vPins, pin);
-      input_pin_names.push_back(pin->pName);
+      input_pin_names.emplace_back(pin->pName);
     }
 
     std::vector<abc::SC_Pin*> output_pins
@@ -443,7 +443,7 @@ int AbcLibraryFactory::StaTimeUnitToAbcInt(sta::Unit* time_unit)
 }
 
 int AbcLibraryFactory::ScaleAbbreviationToExponent(
-    std::string scale_abbreviation)
+    const std::string& scale_abbreviation)
 {
   if (scale_abbreviation == "m") {
     return 3;

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -261,7 +261,7 @@ std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcOutputPins(
         time_table->tsense = abc::SC_TSense::sc_ts_Non;
       } else {
         logger_->error(utl::RMP,
-                       16,
+                       24,
                        "Unrecognized sta::TimingSense -> {}",
                        static_cast<int>(timing_sense));
       }

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -213,7 +213,7 @@ std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcOutputPins(
     // Get list of input ports
     abc::Vec_Ptr_t* input_names_abc = abc::Vec_PtrAlloc(input_names.size());
     for (const std::string& port_name : input_names) {
-      abc::Vec_PtrPush(input_names_abc, const_cast<char*>(port_name.c_str()));
+      abc::Vec_PtrPush(input_names_abc, const_cast<char*>(port_name.data()));
     }
 
     // Set standard cell function

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -72,19 +72,6 @@ static bool HasNonInputOutputPorts(sta::LibertyCell* cell)
   return false;
 }
 
-static bool HasOnlyPowerAndGroundPorts(sta::LibertyCell* cell)
-{
-  sta::LibertyCellPortIterator cell_port_iterator(cell);
-  while (cell_port_iterator.hasNext()) {
-    sta::LibertyPort* port = cell_port_iterator.next();
-    if (!port->direction()->isPowerGround()) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 static bool isCompatibleWithAbc(sta::LibertyCell* cell)
 {
   if (!IsCombinational(cell)) {
@@ -96,10 +83,6 @@ static bool isCompatibleWithAbc(sta::LibertyCell* cell)
   }
 
   if (HasNonInputOutputPorts(cell)) {
-    return false;
-  }
-
-  if (HasOnlyPowerAndGroundPorts(cell)) {
     return false;
   }
 

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -1,0 +1,468 @@
+// Copyright 2024 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include "abc_library_factory.h"
+
+#include <cmath>
+#include <unordered_set>
+#include <vector>
+
+// Poor include definitions in ABC
+// clang-format off
+#include "misc/st/st.h"
+#include "map/mio/mio.h"
+#include "misc/util/utilNam.h"
+#include "map/scl/sclCon.h"
+// clang-format on
+#include "sta/FuncExpr.hh"
+#include "sta/Liberty.hh"
+#include "sta/PortDirection.hh"
+#include "sta/Sta.hh"
+#include "sta/TableModel.hh"
+#include "sta/TimingArc.hh"
+#include "sta/Units.hh"
+#include "utl/deleter.h"
+
+namespace rmp {
+
+static bool IsCombinational(sta::LibertyCell* cell)
+{
+  if (!cell) {
+    return false;
+  }
+  return (!cell->isClockGate() && !cell->isPad() && !cell->isMacro()
+          && !cell->hasSequentials());
+}
+
+static bool HasOutputs(sta::LibertyCell* cell)
+{
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  int output_count = 0;
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* port = cell_port_iterator.next();
+    if (port->direction()->isOutput()) {
+      output_count++;
+    }
+  }
+
+  return output_count != 0;
+}
+
+static bool IsMultiOutputCell(sta::LibertyCell* cell)
+{
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  int output_count = 0;
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* port = cell_port_iterator.next();
+    if (port->direction()->isOutput()) {
+      output_count++;
+    }
+  }
+
+  return output_count > 1;
+}
+
+static bool HasNonInputOutputPorts(sta::LibertyCell* cell)
+{
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* port = cell_port_iterator.next();
+    if (port->direction()->isOutput()) {
+      continue;
+    }
+    if (port->direction()->isInput()) {
+      continue;
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+static bool HasOnlyPowerAndGroundPorts(sta::LibertyCell* cell)
+{
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* port = cell_port_iterator.next();
+    if (!port->direction()->isPowerGround()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void AbcLibraryFactory::AbcPopulateAbcSurfaceFromSta(
+    abc::SC_Surface* abc_table,
+    const sta::TableModel* model)
+{
+  sta::Units* units = library_->units();
+  sta::Unit* time_unit = units->timeUnit();
+  sta::Unit* capacitance_unit = units->capacitanceUnit();
+
+  // 2 axis tables are expected in Liberty timing constructs
+  if (model->order() != 2) {
+    logger_->error(utl::RMP,
+                   17,
+                   "sta::TableModel order not equal to 2, order: {}",
+                   model->order());
+  }
+
+  const sta::TableAxis* axis_1 = model->axis1();
+  sta::FloatSeq* axis1_values = axis_1->values();
+  if (!axis1_values) {
+    logger_->error(utl::RMP, 18, "axis 1 null cannot create ABC table");
+  }
+
+  for (float axis_value : *axis1_values) {
+    double adjusted_value = time_unit->staToUser(axis_value);
+    abc::Vec_FltPush(&abc_table->vIndex0, adjusted_value);
+    abc::Vec_IntPush(&abc_table->vIndex0I, abc::Scl_Flt2Int(adjusted_value));
+  }
+
+  const sta::TableAxis* axis_2 = model->axis2();
+  sta::FloatSeq* axis2_values = axis_2->values();
+  if (!axis2_values) {
+    logger_->error(utl::RMP, 19, "axis 2 null cannot create ABC table");
+  }
+
+  for (float axis_value : *axis2_values) {
+    double adjusted_value = capacitance_unit->staToUser(axis_value);
+    abc::Vec_FltPush(&abc_table->vIndex1, adjusted_value);
+    abc::Vec_IntPush(&abc_table->vIndex1I, abc::Scl_Flt2Int(adjusted_value));
+  }
+
+  // Vec<Vec<float> > -- 'vData[i0][i1]' gives value at '(index0[i0],
+  // index1[i1])' Building the 2D table from STA to ABC's data structure.
+  for (size_t i = 0; i < axis1_values->size(); i++) {
+    abc::Vec_Flt_t* axis_1_abc_vec = abc::Vec_FltAlloc(axis1_values->size());
+    abc::Vec_Int_t* axis_1_abc_int_vec
+        = abc::Vec_IntAlloc(axis1_values->size());
+    abc::Vec_PtrPush(&abc_table->vData, axis_1_abc_vec);
+    abc::Vec_PtrPush(&abc_table->vDataI, axis_1_abc_int_vec);
+
+    for (size_t j = 0; j < axis2_values->size(); j++) {
+      float value = time_unit->staToUser(model->value(i, j, 0));
+      abc::Vec_FltPush(axis_1_abc_vec, value);
+      abc::Vec_IntPush(axis_1_abc_int_vec, abc::Scl_Flt2Int(value));
+    }
+  }
+}
+
+std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcInputPins(
+    sta::LibertyCell* cell)
+{
+  sta::Units* units = library_->units();
+  sta::Unit* capacitance_unit = units->capacitanceUnit();
+
+  std::vector<abc::SC_Pin*> result;
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* cell_port = cell_port_iterator.next();
+    if (!cell_port->direction()->isInput()) {
+      continue;
+    }
+
+    abc::SC_Pin* input_pin = abc::Abc_SclPinAlloc();
+    input_pin->dir = abc::sc_dir_Input;
+    input_pin->pName = strdup(cell_port->name());
+    input_pin->rise_cap = capacitance_unit->staToUser(
+        cell_port->capacitance(sta::RiseFall::rise(), sta::MinMax::max()));
+    input_pin->fall_cap = capacitance_unit->staToUser(
+        cell_port->capacitance(sta::RiseFall::fall(), sta::MinMax::max()));
+
+    result.push_back(input_pin);
+  }
+
+  return result;
+}
+
+std::vector<abc::SC_Pin*> AbcLibraryFactory::CreateAbcOutputPins(
+    sta::LibertyCell* cell,
+    const std::vector<std::string>& input_names)
+{
+  sta::Units* units = library_->units();
+  sta::Unit* time_unit = units->timeUnit();
+  sta::Unit* cap_unit = units->capacitanceUnit();
+
+  std::vector<abc::SC_Pin*> result;
+  sta::LibertyCellPortIterator cell_port_iterator(cell);
+  while (cell_port_iterator.hasNext()) {
+    sta::LibertyPort* cell_port = cell_port_iterator.next();
+    if (!cell_port->direction()->isOutput()) {
+      continue;
+    }
+
+    abc::SC_Pin* output_pin = abc::Abc_SclPinAlloc();
+    output_pin->dir = abc::sc_dir_Output;
+    output_pin->pName = strdup(cell_port->name());
+
+    float max_output_capacitance = 0;
+    bool exists = false;
+    cell_port->capacitanceLimit(
+        sta::MinMax::max(), max_output_capacitance, exists);
+    if (exists) {
+      output_pin->max_out_cap = cap_unit->staToUser(max_output_capacitance);
+    }
+
+    float max_output_slew = 0;
+    cell_port->slewLimit(sta::MinMax::max(), max_output_slew, exists);
+    if (exists) {
+      output_pin->max_out_slew = time_unit->staToUser(max_output_slew);
+    }
+
+    output_pin->func_text = strdup(cell_port->function()->asString());
+
+    // Get list of input ports
+    abc::Vec_Ptr_t* input_names_abc = abc::Vec_PtrAlloc(input_names.size());
+    for (const std::string& port_name : input_names) {
+      abc::Vec_PtrPush(input_names_abc, strdup(port_name.c_str()));
+    }
+
+    // Set standard cell function
+    abc::Vec_Wrd_t* vFunc;
+    abc::Vec_WrdErase(&output_pin->vFunc);
+    vFunc = abc::Mio_ParseFormulaTruth(
+        output_pin->func_text,
+        (char**) (abc::Vec_PtrArray(input_names_abc)),
+        input_names.size());
+
+    output_pin->vFunc = *vFunc;
+    ABC_FREE(vFunc);
+    abc::Vec_PtrFree(input_names_abc);
+
+    // ABC has a limit of one timing arc per input pin. Keep track
+    // of pins that have already recieved a timing arc.
+    std::unordered_set<std::string> pins;
+    for (sta::TimingArcSet* arc_set :
+         cell_port->libertyCell()->timingArcSets(nullptr, cell_port)) {
+      std::string arc_pin_name = arc_set->from()->name();
+      if (pins.find(arc_pin_name) != pins.end()) {
+        continue;
+      }
+      pins.insert(arc_pin_name);
+
+      abc::SC_Timings* timings = abc::Abc_SclTimingsAlloc();
+      abc::Vec_PtrPush(&output_pin->vRTimings, timings);
+      timings->pName = strdup(arc_pin_name.c_str());
+      abc::SC_Timing* time_table = abc::Abc_SclTimingAlloc();
+      abc::Vec_PtrPush(&timings->vTimings, time_table);
+
+      sta::TimingSense timing_sense = arc_set->sense();
+      if (timing_sense == sta::TimingSense::negative_unate) {
+        time_table->tsense = abc::SC_TSense::sc_ts_Neg;
+      } else if (timing_sense == sta::TimingSense::positive_unate) {
+        time_table->tsense = abc::SC_TSense::sc_ts_Pos;
+      } else if (timing_sense == sta::TimingSense::non_unate) {
+        time_table->tsense = abc::SC_TSense::sc_ts_Non;
+      } else {
+        logger_->error(utl::RMP,
+                       16,
+                       "Unrecognized sta::TimingSense -> {}",
+                       static_cast<int>(timing_sense));
+      }
+
+      sta::TimingArc* rise_arc = arc_set->arcTo(sta::RiseFall::rise());
+      sta::TimingArc* fall_arc = arc_set->arcTo(sta::RiseFall::fall());
+
+      sta::TimingModel* rise_model = rise_arc->model();
+      sta::TimingModel* fall_model = fall_arc->model();
+
+      const sta::GateTableModel* rise_gate_model
+          = dynamic_cast<sta::GateTableModel*>(rise_model);
+      const sta::GateTableModel* fall_gate_model
+          = dynamic_cast<sta::GateTableModel*>(fall_model);
+
+      if (!rise_gate_model || !fall_gate_model) {
+        logger_->error(utl::RMP,
+                       19,
+                       "rise/fall Gate model is empty for cell {}. Need timing "
+                       "information",
+                       cell->name());
+      }
+
+      AbcPopulateAbcSurfaceFromSta(&time_table->pCellRise,
+                                   rise_gate_model->delayModel());
+      AbcPopulateAbcSurfaceFromSta(&time_table->pCellFall,
+                                   fall_gate_model->delayModel());
+      AbcPopulateAbcSurfaceFromSta(&time_table->pRiseTrans,
+                                   rise_gate_model->slewModel());
+      AbcPopulateAbcSurfaceFromSta(&time_table->pFallTrans,
+                                   fall_gate_model->slewModel());
+    }
+
+    result.push_back(output_pin);
+  }
+
+  return result;
+}
+
+AbcLibraryFactory& AbcLibraryFactory::AddStaLibrary(
+    sta::LibertyLibrary* library)
+{
+  library_ = library;
+  return *this;
+}
+
+utl::deleted_unique_ptr<abc::SC_Lib> AbcLibraryFactory::Build()
+{
+  if (!library_) {
+    logger_->error(utl::RMP, 15, "Build called with null sta library");
+  }
+
+  abc::SC_Lib* abc_library = abc::Abc_SclLibAlloc();
+  PopulateAbcSclLibFromSta(abc_library);
+  return utl::deleted_unique_ptr<abc::SC_Lib>(
+      abc_library, [](abc::SC_Lib* lib) { abc::Abc_SclLibFree(lib); });
+}
+
+void AbcLibraryFactory::PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library)
+{
+  sta::Units* units = library_->units();
+  sta::Unit* time_unit = units->timeUnit();
+  sta::Unit* cap_unit = units->capacitanceUnit();
+  sta::Unit* power_unit = units->powerUnit();
+
+  sc_library->pName = strdup(library_->name());
+  sc_library->pFileName = strdup(library_->filename());
+
+  sc_library->default_wire_load = nullptr;
+  sc_library->default_wire_load_sel = nullptr;
+  // TODO: Read and construct wireload tables
+
+  // unit selection
+
+  sc_library->unit_cap_fst = StaCapacitanceToAbc(cap_unit);
+  sc_library->unit_cap_snd
+      = ScaleAbbreviationToExponent(cap_unit->scaleAbbreviation());
+  sc_library->unit_time = StaTimeUnitToAbcInt(time_unit);
+
+  // defaults
+  float slew = -1.0;
+  bool max_slew_exists = false;
+  library_->defaultMaxSlew(slew, max_slew_exists);
+
+  if (max_slew_exists) {
+    sc_library->default_max_out_slew = time_unit->staToUser(slew);
+  } else {
+    sc_library->default_max_out_slew = -1.0;
+  }
+
+  // Loop through all of the cells in STA and create equivalents in
+  // the ABC structure.
+  sta::LibertyCellIterator cell_iterator(library_);
+  while (cell_iterator.hasNext()) {
+    sta::LibertyCell* cell = cell_iterator.next();
+
+    if (!IsCombinational(cell)) {
+      continue;
+    }
+
+    if (IsMultiOutputCell(cell)) {
+      continue;
+    }
+
+    if (!HasOutputs(cell)) {
+      continue;
+    }
+
+    if (HasNonInputOutputPorts(cell)) {
+      continue;
+    }
+
+    if (HasOnlyPowerAndGroundPorts(cell)) {
+      continue;
+    }
+
+    abc::SC_Cell* abc_cell = abc::Abc_SclCellAlloc();
+    abc_cell->Id = abc::SC_LibCellNum(sc_library);
+    abc::Vec_PtrPush(&sc_library->vCells, abc_cell);
+
+    abc_cell->pName = strdup(cell->name());
+    abc_cell->area = cell->area();
+    abc_cell->drive_strength = 0;
+
+    bool leakage_power_exists;
+    float leakage_power = 0;
+    cell->leakagePower(leakage_power, leakage_power_exists);
+    if (leakage_power_exists) {
+      abc_cell->leakage = power_unit->staToUser(leakage_power);
+    } else {
+      logger_->warn(utl::RMP,
+                    16,
+                    "Leakage power doesn't exist for cell {}",
+                    cell->name());
+    }
+
+    // Input Pin Creation
+    std::vector<abc::SC_Pin*> input_pins = CreateAbcInputPins(cell);
+    std::vector<std::string> input_pin_names;
+    input_pin_names.reserve(input_pins.size());
+    abc_cell->n_inputs = input_pins.size();
+    for (abc::SC_Pin* pin : input_pins) {
+      abc::Vec_PtrPush(&abc_cell->vPins, pin);
+      input_pin_names.push_back(pin->pName);
+    }
+
+    std::vector<abc::SC_Pin*> output_pins
+        = CreateAbcOutputPins(cell, input_pin_names);
+    abc_cell->n_outputs = output_pins.size();
+    for (abc::SC_Pin* pin : output_pins) {
+      abc::Vec_PtrPush(&abc_cell->vPins, pin);
+    }
+  }
+
+  abc::Abc_SclLibNormalize(sc_library);
+}
+
+float AbcLibraryFactory::StaCapacitanceToAbc(sta::Unit* cap_unit)
+{
+  // Abc stores capacitance as two variables x(float) * 10^y(int)
+  // This function extracts the x variable from STA scale value.
+  float cap_scale = cap_unit->scale();
+  int exponent_y
+      = std::floor(std::abs(std::log10(std::abs(cap_unit->scale()))));
+  return cap_scale * std::pow(10.0, exponent_y);
+}
+
+int AbcLibraryFactory::StaTimeUnitToAbcInt(sta::Unit* time_unit)
+{
+  float scale = std::abs(std::log10(std::abs(time_unit->scale())));
+  int abc_time_unit = std::floor(scale);
+
+  if (abc_time_unit < 9 || abc_time_unit > 12) {
+    logger_->error(
+        utl::RMP, 14, "Time unit {} outside abc range [1e-9, 1e-12]", scale);
+  }
+
+  return abc_time_unit;
+}
+
+int AbcLibraryFactory::ScaleAbbreviationToExponent(
+    std::string scale_abbreviation)
+{
+  if (scale_abbreviation == "m") {
+    return 3;
+  }
+  if (scale_abbreviation == "u") {
+    return 6;
+  }
+  if (scale_abbreviation == "n") {
+    return 9;
+  }
+  if (scale_abbreviation == "p") {
+    return 12;
+  }
+  if (scale_abbreviation == "f") {
+    return 15;
+  }
+
+  logger_->error(
+      utl::RMP, 13, "Can't convert scale abbreviation {}", scale_abbreviation);
+}
+
+}  // namespace rmp

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "db_sta/dbSta.hh"
 #include "map/scl/sclLib.h"
 #include "sta/Sta.hh"
 #include "utl/Logger.h"
@@ -24,11 +25,12 @@ class AbcLibraryFactory
 {
  public:
   explicit AbcLibraryFactory(utl::Logger* logger) : logger_(logger) {}
-  AbcLibraryFactory& AddStaLibrary(sta::LibertyLibrary* library);
+  AbcLibraryFactory& AddDbSta(sta::dbSta* db_sta);
   utl::deleted_unique_ptr<abc::SC_Lib> Build();
 
  private:
-  void PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library);
+  void PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library,
+                                sta::LibertyLibrary* library);
   int ScaleAbbreviationToExponent(const std::string& scale_abbreviation);
   int StaTimeUnitToAbcInt(sta::Unit* time_unit);
   float StaCapacitanceToAbc(sta::Unit* cap_unit);
@@ -36,11 +38,12 @@ class AbcLibraryFactory
       sta::LibertyCell* cell,
       const std::vector<std::string>& input_names);
   void AbcPopulateAbcSurfaceFromSta(abc::SC_Surface* abc_table,
-                                    const sta::TableModel* model);
+                                    const sta::TableModel* model,
+                                    sta::Units* units);
   std::vector<abc::SC_Pin*> CreateAbcInputPins(sta::LibertyCell* cell);
 
   utl::Logger* logger_;
-  sta::LibertyLibrary* library_ = nullptr;
+  sta::dbSta* db_sta_ = nullptr;
 };
 
 }  // namespace rmp

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -29,7 +29,7 @@ class AbcLibraryFactory
 
  private:
   void PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library);
-  int ScaleAbbreviationToExponent(std::string scale_abbreviation);
+  int ScaleAbbreviationToExponent(const std::string& scale_abbreviation);
   int StaTimeUnitToAbcInt(sta::Unit* time_unit);
   float StaCapacitanceToAbc(sta::Unit* cap_unit);
   std::vector<abc::SC_Pin*> CreateAbcOutputPins(

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -1,0 +1,46 @@
+// Copyright 2024 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "map/scl/sclLib.h"
+#include "sta/Sta.hh"
+#include "utl/Logger.h"
+#include "utl/deleter.h"
+
+namespace rmp {
+
+// A Factory to construct an abc::SC_Lib* from an OpenSTA library.
+// It is key to reconstructing cuts from OpenROAD in ABC's AIG
+// datastructure.
+class AbcLibraryFactory
+{
+ public:
+  explicit AbcLibraryFactory(utl::Logger* logger) : logger_(logger) {}
+  AbcLibraryFactory& AddStaLibrary(sta::LibertyLibrary* library);
+  utl::deleted_unique_ptr<abc::SC_Lib> Build();
+
+ private:
+  void PopulateAbcSclLibFromSta(abc::SC_Lib* sc_library);
+  int ScaleAbbreviationToExponent(std::string scale_abbreviation);
+  int StaTimeUnitToAbcInt(sta::Unit* time_unit);
+  float StaCapacitanceToAbc(sta::Unit* cap_unit);
+  std::vector<abc::SC_Pin*> CreateAbcOutputPins(
+      sta::LibertyCell* cell,
+      const std::vector<std::string>& input_names);
+  void AbcPopulateAbcSurfaceFromSta(abc::SC_Surface* abc_table,
+                                    const sta::TableModel* model);
+  std::vector<abc::SC_Pin*> CreateAbcInputPins(sta::LibertyCell* cell);
+
+  utl::Logger* logger_;
+  sta::LibertyLibrary* library_ = nullptr;
+};
+
+}  // namespace rmp

--- a/src/rmp/test/CMakeLists.txt
+++ b/src/rmp/test/CMakeLists.txt
@@ -16,3 +16,5 @@ set(TEST_NAMES
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("rmp" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
+
+add_subdirectory(cpp)

--- a/src/rmp/test/cpp/CMakeLists.txt
+++ b/src/rmp/test/cpp/CMakeLists.txt
@@ -6,9 +6,16 @@ target_link_libraries(RmpGTests
         gtest
         gmock
         gtest_main
-        libabc
         rmp_abc_library
+        dbSta_lib
         utl_lib
+        libabc
+        ${TCL_LIBRARY}
+)
+
+target_include_directories(RmpGTests
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/rmp/src
 )
 
 gtest_discover_tests(RmpGTests

--- a/src/rmp/test/cpp/CMakeLists.txt
+++ b/src/rmp/test/cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(openroad)
+
+add_executable(RmpGTests TestAbc.cc)
+target_link_libraries(RmpGTests 
+        OpenSTA
+        gtest
+        gmock
+        gtest_main
+        libabc
+        rmp_abc_library
+        utl_lib
+)
+
+gtest_discover_tests(RmpGTests
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_dependencies(build_and_test RmpGTests
+)

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -213,7 +213,8 @@ TEST_F(AbcTest, TestLibraryInstallation)
   abc::Abc_ObjAddFanin(and_gate, input_1_net);  // A
   abc::Abc_ObjAddFanin(and_gate, input_2_net);  // B
 
-  abc::Abc_ObjAssignName(output_net, strdup("out"), /*pSuffix=*/nullptr);
+  std::string output_name = "out";
+  abc::Abc_ObjAssignName(output_net, const_cast<char*>(output_name.c_str()), /*pSuffix=*/nullptr);
   abc::Abc_ObjAddFanin(output_net, and_gate);
 
   abc::Abc_ObjAddFanin(output, output_net);
@@ -222,9 +223,9 @@ TEST_F(AbcTest, TestLibraryInstallation)
       abc::Abc_NtkToLogic(network.get()), &abc::Abc_NtkDelete);
 
   std::array<int, 2> input_vector = {1, 1};
-  std::unique_ptr<int[]> output_vector(abc::Abc_NtkVerifySimulatePattern(
-      logic_network.get(), input_vector.data()));
+  utl::deleted_unique_ptr<int> output_vector(abc::Abc_NtkVerifySimulatePattern(
+      logic_network.get(), input_vector.data()), &free);
 
-  EXPECT_EQ(output_vector[0], 1);  // Expect that 1 & 1 == 1
+  EXPECT_EQ(output_vector.get()[0], 1);  // Expect that 1 & 1 == 1
 }
 }  // namespace rmp

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -33,9 +33,8 @@
 #include "utl/Logger.h"
 #include "utl/deleter.h"
 
-
 namespace abc {
-  void* Abc_FrameReadLibGen();
+void* Abc_FrameReadLibGen();
 }
 
 namespace rmp {

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -18,7 +18,7 @@
 #include "abc_library_factory.h"
 #include "base/abc/abc.h"
 #include "base/io/ioAbc.h"
-#include "base/main/main.h"
+#include "base/main/abcapis.h"
 #include "db_sta/MakeDbSta.hh"
 #include "db_sta/dbSta.hh"
 #include "gmock/gmock.h"
@@ -32,6 +32,11 @@
 #include "sta/Units.hh"
 #include "utl/Logger.h"
 #include "utl/deleter.h"
+
+
+namespace abc {
+  void* Abc_FrameReadLibGen();
+}
 
 namespace rmp {
 
@@ -214,8 +219,7 @@ TEST_F(AbcTest, TestLibraryInstallation)
   abc::Abc_ObjAddFanin(and_gate, input_2_net);  // B
 
   std::string output_name = "out";
-  abc::Abc_ObjAssignName(
-      output_net, output_name.data(), /*pSuffix=*/nullptr);
+  abc::Abc_ObjAssignName(output_net, output_name.data(), /*pSuffix=*/nullptr);
   abc::Abc_ObjAddFanin(output_net, and_gate);
 
   abc::Abc_ObjAddFanin(output, output_net);

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -214,7 +214,8 @@ TEST_F(AbcTest, TestLibraryInstallation)
   abc::Abc_ObjAddFanin(and_gate, input_2_net);  // B
 
   std::string output_name = "out";
-  abc::Abc_ObjAssignName(output_net, const_cast<char*>(output_name.c_str()), /*pSuffix=*/nullptr);
+  abc::Abc_ObjAssignName(
+      output_net, const_cast<char*>(output_name.c_str()), /*pSuffix=*/nullptr);
   abc::Abc_ObjAddFanin(output_net, and_gate);
 
   abc::Abc_ObjAddFanin(output, output_net);
@@ -223,8 +224,10 @@ TEST_F(AbcTest, TestLibraryInstallation)
       abc::Abc_NtkToLogic(network.get()), &abc::Abc_NtkDelete);
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleted_unique_ptr<int> output_vector(abc::Abc_NtkVerifySimulatePattern(
-      logic_network.get(), input_vector.data()), &free);
+  utl::deleted_unique_ptr<int> output_vector(
+      abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
+                                        input_vector.data()),
+      &free);
 
   EXPECT_EQ(output_vector.get()[0], 1);  // Expect that 1 & 1 == 1
 }

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -33,6 +33,9 @@
 #include "utl/Logger.h"
 #include "utl/deleter.h"
 
+// Headers have duplicate declarations so we include
+// a forward one to get at this function without angering
+// gcc.
 namespace abc {
 void* Abc_FrameReadLibGen();
 }

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -174,7 +174,7 @@ TEST_F(AbcTest, TestLibraryInstallation)
 
   // When you set these params to zero they essentially turned off.
   abc::Abc_SclInstallGenlib(
-      abc_library.get(), /*SlewInit=*/0, /*Gain=*/0, /*nGatesMin=*/0);
+      abc_library.get(), /*Slew=*/0, /*Gain=*/0, /*nGatesMin=*/0);
   abc::Mio_LibraryTransferCellIds();
   abc::Mio_Library_t* lib
       = static_cast<abc::Mio_Library_t*>(abc::Abc_FrameReadLibGen());
@@ -215,7 +215,7 @@ TEST_F(AbcTest, TestLibraryInstallation)
 
   std::string output_name = "out";
   abc::Abc_ObjAssignName(
-      output_net, const_cast<char*>(output_name.c_str()), /*pSuffix=*/nullptr);
+      output_net, output_name.data(), /*pSuffix=*/nullptr);
   abc::Abc_ObjAddFanin(output_net, and_gate);
 
   abc::Abc_ObjAddFanin(output, output_net);

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -131,4 +131,26 @@ TEST_F(AbcTest, DoesNotContainSequentialCells)
 
   EXPECT_THAT(abc_cells, Not(Contains("DFFRS_X2")));
 }
+
+TEST_F(AbcTest, ContainsLogicCells)
+{
+  AbcLibraryFactory factory(&logger_);
+  factory.AddDbSta(sta_.get());
+  utl::deleted_unique_ptr<abc::SC_Lib> abc_library = factory.Build();
+
+  std::set<std::string> abc_cells;
+  using ::testing::Contains;
+  using ::testing::Not;
+
+  for (size_t i = 0; i < Vec_PtrSize(&abc_library->vCells); i++) {
+    abc::SC_Cell* abc_cell = static_cast<abc::SC_Cell*>(
+        abc::Vec_PtrEntry(&abc_library->vCells, i));
+    abc_cells.emplace(abc_cell->pName);
+  }
+
+  EXPECT_THAT(abc_cells, Contains("AND2_X1"));
+  EXPECT_THAT(abc_cells, Contains("AND2_X2"));
+  EXPECT_THAT(abc_cells, Contains("AND2_X4"));
+  EXPECT_THAT(abc_cells, Contains("AOI21_X1"));
+}
 }  // namespace rmp

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -1,0 +1,113 @@
+// Copyright 2023 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <unistd.h>
+
+#include <filesystem>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <set>
+
+#include "abc_library_factory.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "map/scl/sclLib.h"
+#include "sta/FuncExpr.hh"
+#include "sta/Liberty.hh"
+#include "sta/Sta.hh"
+#include "sta/Units.hh"
+#include "utl/Logger.h"
+
+namespace rmp {
+
+std::once_flag init_sta_flag;
+
+class AbcTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    std::call_once(init_sta_flag, []() { sta::initSta(); });
+    sta_ = new sta::Sta;
+    sta_->makeComponents();
+    auto path = std::filesystem::canonical("./Nangate45/Nangate45_fast.lib");
+    library_ = sta_->readLiberty(path.string().c_str(),
+                                 sta_->findCorner("default"),
+                                 /*min_max=*/nullptr,
+                                 /*infer_latches=*/false);
+    sta::Units* units = library_->units();
+    power_unit_ = units->powerUnit();
+  }
+
+  sta::Unit* power_unit_;
+  sta::Sta* sta_;
+  sta::LibertyLibrary* library_;
+  utl::Logger logger_;
+};
+
+TEST_F(AbcTest, CellPropertiesMatchOpenSta)
+{
+  AbcLibraryFactory factory(&logger_);
+  factory.AddStaLibrary(library_);
+  utl::deleted_unique_ptr<abc::SC_Lib> abc_library = factory.Build();
+
+  for (size_t i = 0; i < Vec_PtrSize(&abc_library->vCells); i++) {
+    abc::SC_Cell* abc_cell = static_cast<abc::SC_Cell*>(
+        abc::Vec_PtrEntry(&abc_library->vCells, i));
+    sta::LibertyCell* sta_cell = library_->findLibertyCell(abc_cell->pName);
+    EXPECT_NE(nullptr, sta_cell);
+    // Expect area matches
+    EXPECT_FLOAT_EQ(abc_cell->area, sta_cell->area());
+
+    float leakage_power = -1;
+    bool exists;
+    sta_cell->leakagePower(leakage_power, exists);
+    if (exists) {
+      EXPECT_FLOAT_EQ(abc_cell->leakage, power_unit_->staToUser(leakage_power));
+    }
+  }
+}
+
+TEST_F(AbcTest, DoesNotContainPhysicalCells)
+{
+  AbcLibraryFactory factory(&logger_);
+  factory.AddStaLibrary(library_);
+  utl::deleted_unique_ptr<abc::SC_Lib> abc_library = factory.Build();
+
+  std::set<std::string> abc_cells;
+  using ::testing::Contains;
+  using ::testing::Not;
+
+  for (size_t i = 0; i < Vec_PtrSize(&abc_library->vCells); i++) {
+    abc::SC_Cell* abc_cell = static_cast<abc::SC_Cell*>(
+        abc::Vec_PtrEntry(&abc_library->vCells, i));
+    abc_cells.emplace(abc_cell->pName);
+  }
+
+  EXPECT_THAT(abc_cells, Not(Contains("ANTENNA_X1")));
+  EXPECT_THAT(abc_cells, Not(Contains("FILLCELL_X1")));
+}
+
+TEST_F(AbcTest, DoesNotContainSequentialCells)
+{
+  AbcLibraryFactory factory(&logger_);
+  factory.AddStaLibrary(library_);
+  utl::deleted_unique_ptr<abc::SC_Lib> abc_library = factory.Build();
+
+  std::set<std::string> abc_cells;
+  using ::testing::Contains;
+  using ::testing::Not;
+
+  for (size_t i = 0; i < Vec_PtrSize(&abc_library->vCells); i++) {
+    abc::SC_Cell* abc_cell = static_cast<abc::SC_Cell*>(
+        abc::Vec_PtrEntry(&abc_library->vCells, i));
+    abc_cells.emplace(abc_cell->pName);
+  }
+
+  EXPECT_THAT(abc_cells, Not(Contains("DFFRS_X2")));
+}
+}  // namespace rmp

--- a/src/utl/include/utl/deleter.h
+++ b/src/utl/include/utl/deleter.h
@@ -1,0 +1,15 @@
+// Copyright 2024 Google LLC
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file or at
+// https://developers.google.com/open-source/licenses/bsd
+
+#include <functional>
+#include <memory>
+
+namespace utl {
+
+template <typename T>
+using deleted_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
+
+}


### PR DESCRIPTION
Creates a factory class to map an sta library into an abc one. This library can be used to unmap a netlist in ABC into an AIG for optimization, and then back into a mapped netlist