### PR TITLE
fix crash for commands when no design were loaded

### DIFF
--- a/src/ant/src/AntennaChecker.tcl
+++ b/src/ant/src/AntennaChecker.tcl
@@ -34,9 +34,14 @@ sta::define_cmd_args "check_antennas" { [-verbose]\
 };# checker off
 
 proc check_antennas { args } {
+
   sta::parse_key_args "check_antennas" args \
     keys {-report_file -net} \
     flags {-verbose -report_violating_nets};# checker off
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error ANT 3 "No design block found."
+  }
 
   sta::check_argc_eq0 "check_antennas" $args
 

--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -41,6 +41,10 @@ proc highlight_path { args } {
   parse_key_args "highlight_path" args keys {} \
     flags {-max -min} 0
 
+  if { [ord::get_db_block] == "NULL" } {
+    sta_error "No design block found."
+  }
+
   if {[info exists flags(-min)] && [info exists flags(-max)]} {
     sta_error "-min and -max cannot both be specified."
   } elseif {[info exists flags(-min)]} {
@@ -79,6 +83,9 @@ proc highlight_path { args } {
 define_cmd_args "report_cell_usage" {}
 
 proc report_cell_usage {} {
+  if { [ord::get_db_block] == "NULL" } {
+    sta_error "No design block found."
+  }
   report_cell_usage_cmd
 }
 

--- a/src/dft/src/dft.tcl
+++ b/src/dft/src/dft.tcl
@@ -38,6 +38,10 @@ proc preview_dft { args } {
 
   sta::check_argc_eq0 "preview_dft" $args
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DFT 1 "No design block found."
+  }
+
   set verbose [info exists flags(-verbose)]
 
   dft::preview_dft $verbose
@@ -47,6 +51,10 @@ sta::define_cmd_args "insert_dft" { }
 proc insert_dft { args } {
   sta::parse_key_args "insert_dft" args \
     keys {} flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DFT 8 "No design block found."
+  }
   dft::insert_dft
 }
 

--- a/src/dpl/src/Opendp.tcl
+++ b/src/dpl/src/Opendp.tcl
@@ -141,6 +141,9 @@ sta::define_cmd_args "remove_fillers" {}
 proc remove_fillers { args } {
   sta::parse_key_args "remove_fillers" args keys {} flags {}
   sta::check_argc_eq0 "remove_fillers" $args
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DPL 105 "No design block found."
+  }
   dpl::remove_fillers_cmd
 }
 
@@ -149,6 +152,11 @@ sta::define_cmd_args "check_placement" {[-verbose] \
                                         [-report_file_name file_name]}
 
 proc check_placement { args } {
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DPL 103 "No design block found."
+  }
+
   sta::parse_key_args "check_placement" args \
     keys {-report_file_name} flags {-verbose -disallow_one_site_gaps}
   set verbose [info exists flags(-verbose)]
@@ -164,7 +172,13 @@ proc check_placement { args } {
 sta::define_cmd_args "optimize_mirroring" {}
 
 proc optimize_mirroring { args } {
+
   sta::parse_key_args "optimize_mirroring" args keys {} flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DPL 104 "No design block found."
+  }
+
   sta::check_argc_eq0 "optimize_mirroring" $args
   dpl::optimize_mirroring_cmd
 }

--- a/src/dpo/src/Optdp.tcl
+++ b/src/dpo/src/Optdp.tcl
@@ -43,7 +43,7 @@ proc improve_placement { args } {
   if { [ord::get_db_block] == "NULL" } {
     utl::error DPO 2 "No design block found."
   }
-  
+
   set disallow_one_site_gaps [info exists flags(-disallow_one_site_gaps)]
   set seed 1
   if { [info exists keys(-random_seed)] } {

--- a/src/dpo/src/Optdp.tcl
+++ b/src/dpo/src/Optdp.tcl
@@ -40,6 +40,10 @@ proc improve_placement { args } {
   sta::parse_key_args "improve_placement" args \
     keys {-random_seed -max_displacement} flags {-disallow_one_site_gaps}
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DPO 2 "No design block found."
+  }
+  
   set disallow_one_site_gaps [info exists flags(-disallow_one_site_gaps)]
   set seed 1
   if { [info exists keys(-random_seed)] } {

--- a/src/gpl/src/replace.tcl
+++ b/src/gpl/src/replace.tcl
@@ -331,6 +331,10 @@ proc cluster_flops { args } {
     keys { -tray_weight -timing_weight -max_split_size -num_paths } \
     flags {}
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error GPL 104 "No design block found."
+  }
+
   set tray_weight 20.0
   set timing_weight 1.0
   set max_split_size 250
@@ -360,6 +364,10 @@ proc global_placement_debug { args } {
     keys {-pause -update -inst} \
     flags {-draw_bins -initial};# checker off
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error GPL 105 "No design block found."
+  }
+
   set pause 10
   if { [info exists keys(-pause)] } {
     set pause $keys(-pause)
@@ -385,6 +393,11 @@ proc global_placement_debug { args } {
 
 namespace eval gpl {
 proc get_global_placement_uniform_density { args } {
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error GPL 106 "No design block found."
+  }
+
   sta::parse_key_args "get_global_placement_uniform_density" args \
     keys { -pad_left -pad_right } \
     flags {};# checker off

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -311,7 +311,7 @@ proc repair_antennas { args } {
   if { [ord::get_db_block] == "NULL" } {
     utl::error GRT 104 "No design block found."
   }
-  
+
   if { [grt::have_routes] || [grt::have_detailed_routes] } {
 
     if { [llength $args] == 0 } {

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -308,7 +308,12 @@ sta::define_cmd_args "repair_antennas" { diode_cell \
 proc repair_antennas { args } {
   sta::parse_key_args "repair_antennas" args \
     keys {-iterations -ratio_margin} flags {}
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error GRT 104 "No design block found."
+  }
+  
   if { [grt::have_routes] || [grt::have_detailed_routes] } {
+
     if { [llength $args] == 0 } {
       # repairAntennas locates diode
       set diode_mterm "NULL"

--- a/src/par/src/partitionmgr.tcl
+++ b/src/par/src/partitionmgr.tcl
@@ -514,6 +514,11 @@ proc triton_part_design { args } {
           -num_vertices_threshold_ilp \
           -global_net_threshold } \
     flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error PAR 103 "No design block found."
+  }
+
   set num_parts 2
   set balance_constraint 1.0
   set base_balance { 1.0 }
@@ -727,7 +732,6 @@ proc triton_part_design { args } {
     set global_net_threshold $keys(-global_net_threshold)
   }
 
-
   par::triton_part_design $num_parts \
     $balance_constraint \
     $base_balance \
@@ -829,6 +833,11 @@ proc evaluate_part_design_solution { args } {
           -e_wt_factors \
           -v_wt_factors  } \
     flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error PAR 104 "No design block found."
+  }
+
   set num_parts 2
   set balance_constraint 1.0
   set base_balance { 1.0 }

--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -43,6 +43,10 @@ proc pdngen { args } {
 
   sta::check_argc_eq0 "pdngen" $args
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error PDN 2 "No design block found."
+  }
+
   pdn::depricated flags -verbose
 
   if {[info exists flags(-reset)]} {

--- a/src/tap/src/tapcell.tcl
+++ b/src/tap/src/tapcell.tcl
@@ -69,6 +69,10 @@ proc tapcell { args } {
 
   sta::check_argc_eq0 "tapcell" $args
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error TAP 1 "No design block found."
+  }
+
   tap::clear
 
   if { [info exists keys(-endcap_cpp)] } {
@@ -233,6 +237,10 @@ proc tapcell_ripup { args } {
     keys {-tap_prefix -endcap_prefix} \
     flags {}
 
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error TAP 2 "No design block found."
+  }
+
   sta::check_argc_eq0 "tapcell_ripup" $args
 
   set tap_prefix "TAP_"
@@ -299,6 +307,10 @@ proc place_endcaps { args } {
       -left_edge -right_edge
       -top_edge -bottom_edge} \
     flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error TAP 6 "No design block found."
+  }
 
   sta::check_argc_eq0 "place_endcaps" $args
 

--- a/test/commands_without_load.tcl
+++ b/test/commands_without_load.tcl
@@ -1,24 +1,7 @@
 # Ensure that running commands without loading a design doesn't crash.
 
 set skip {
-  cluster_flops
-  check_placement
-  repair_antennas
-  triton_part_design
-  optimize_mirroring
-  evaluate_part_design_solution
-  place_endcaps
-  highlight_path
-  remove_fillers
-  check_antennas
-  global_placement_debug
-  improve_placement
-  pdngen
-  insert_dft
   set_driving_cell
-  tapcell
-  tapcell_ripup
-  preview_dft
   define_corners
   exit
 }


### PR DESCRIPTION
Fixes [#4993 ](https://github.com/The-OpenROAD-Project/OpenROAD/issues/4993)

This PR adds a check on commands to prevent them from crashing if no design was loaded.