### PR TITLE
grt: ignore nets connected by abutment in repair_antennas

### DIFF
--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -134,7 +134,8 @@ void RepairAntennas::makeNetWires(NetRouteMap& routing, int max_routing_layer)
   for (odb::dbNet* db_net : block_->getNets()) {
     if (grouter_->isDetailedRouted(db_net)) {
       odb::orderWires(logger_, db_net);
-    } else if (!db_net->isSpecial() && !grouter_->getNet(db_net)->isLocal()) {
+    } else if (!db_net->isSpecial() && !db_net->isConnectedByAbutment()
+               && !grouter_->getNet(db_net)->isLocal()) {
       makeNetWire(db_net, routing[db_net], default_vias);
     }
   }


### PR DESCRIPTION
Fix crash in mock-array