### PR TITLE
drt: handle PDN repair for block vias

### DIFF
--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -222,6 +222,7 @@ class TritonRoute
                  bool has_routing);
   int countNetBTermsAboveMaxLayer(odb::dbNet* net);
   bool netHasStackedVias(odb::dbNet* net);
+  void repairPDNVias();
   friend class FlexDR;
 };
 

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -660,77 +660,126 @@ void TritonRoute::endFR()
   }
 
   num_drvs_ = design_->getTopBlock()->getNumMarkers();
-  if (!REPAIR_PDN_LAYER_NAME.empty()) {
-    auto dbBlock = db_->getChip()->getBlock();
-    auto pdnLayer = design_->getTech()->getLayer(REPAIR_PDN_LAYER_NAME);
-    frLayerNum pdnLayerNum = pdnLayer->getLayerNum();
-    frList<std::unique_ptr<frMarker>> markers;
-    auto blockBox = design_->getTopBlock()->getBBox();
-    REPAIR_PDN_LAYER_NUM = pdnLayerNum;
-    GC_IGNORE_PDN_LAYER_NUM = -1;
-    getDRCMarkers(markers, blockBox);
-    std::vector<std::pair<odb::Rect, odb::dbId<odb::dbSBox>>> allWires;
-    for (auto* net : dbBlock->getNets()) {
-      if (!net->getSigType().isSupply()) {
-        continue;
-      }
-      for (auto* swire : net->getSWires()) {
-        for (auto* wire : swire->getWires()) {
-          if (!wire->isVia()) {
+
+  repairPDNVias();
+}
+
+void TritonRoute::repairPDNVias()
+{
+  if (REPAIR_PDN_LAYER_NAME.empty()) {
+    return;
+  }
+
+  auto dbBlock = db_->getChip()->getBlock();
+  auto pdnLayer = design_->getTech()->getLayer(REPAIR_PDN_LAYER_NAME);
+  frLayerNum pdnLayerNum = pdnLayer->getLayerNum();
+  frList<std::unique_ptr<frMarker>> markers;
+  auto blockBox = design_->getTopBlock()->getBBox();
+  REPAIR_PDN_LAYER_NUM = pdnLayerNum;
+  GC_IGNORE_PDN_LAYER_NUM = -1;
+  getDRCMarkers(markers, blockBox);
+  markers.erase(std::remove_if(markers.begin(),
+                               markers.end(),
+                               [pdnLayerNum](const auto& marker) {
+                                 if (marker->getLayerNum() != pdnLayerNum) {
+                                   return true;
+                                 }
+                                 for (auto src : marker->getSrcs()) {
+                                   if (src->typeId() == frcNet) {
+                                     frNet* net = static_cast<frNet*>(src);
+                                     if (net->getType().isSupply()) {
+                                       return false;
+                                     }
+                                   }
+                                 }
+                                 return true;
+                               }),
+                markers.end());
+
+  if (markers.empty()) {
+    // nothing to do
+    return;
+  }
+
+  std::vector<std::pair<odb::Rect, odb::dbId<odb::dbSBox>>> all_vias;
+  std::vector<std::pair<odb::Rect, odb::dbId<odb::dbSBox>>> block_vias;
+  for (auto* net : dbBlock->getNets()) {
+    if (!net->getSigType().isSupply()) {
+      continue;
+    }
+    for (auto* swire : net->getSWires()) {
+      for (auto* wire : swire->getWires()) {
+        if (!wire->isVia()) {
+          continue;
+        }
+        //
+        std::vector<odb::dbShape> via_boxes;
+        wire->getViaBoxes(via_boxes);
+        for (const auto& via_box : via_boxes) {
+          auto* layer = via_box.getTechLayer();
+          if (layer != pdnLayer->getDbLayer()) {
             continue;
           }
-          //
-          std::vector<odb::dbShape> via_boxes;
-          wire->getViaBoxes(via_boxes);
-          for (const auto& via_box : via_boxes) {
-            auto* layer = via_box.getTechLayer();
-            if (layer->getType() != odb::dbTechLayerType::CUT) {
-              continue;
-            }
-            if (layer->getName() != pdnLayer->getName()) {
-              continue;
-            }
-            allWires.emplace_back(via_box.getBox(), wire->getId());
+
+          if (wire->getTechVia() != nullptr) {
+            all_vias.emplace_back(via_box.getBox(), wire->getId());
+          } else {
+            block_vias.emplace_back(via_box.getBox(), wire->getId());
           }
         }
       }
     }
-    RTree<odb::dbId<odb::dbSBox>> pdnTree(allWires);
-    std::set<odb::dbId<odb::dbSBox>> removedBoxes;
-    for (const auto& marker : markers) {
-      if (marker->getLayerNum() != pdnLayerNum) {
-        continue;
-      }
-      bool supply = false;
-      for (auto src : marker->getSrcs()) {
-        if (src->typeId() == frcNet) {
-          frNet* net = static_cast<frNet*>(src);
-          if (net->getType().isSupply()) {
-            supply = true;
-            break;
+  }
+
+  const RTree<odb::dbId<odb::dbSBox>> pdnBlockViaTree(block_vias);
+  std::set<odb::dbId<odb::dbSBox>> removedBoxes;
+  for (const auto& marker : markers) {
+    odb::Rect queryBox;
+    marker->getBBox().bloat(1, queryBox);
+    std::vector<rq_box_value_t<odb::dbId<odb::dbSBox>>> results;
+    pdnBlockViaTree.query(bgi::intersects(queryBox), back_inserter(results));
+    for (auto& [rect, bid] : results) {
+      if (removedBoxes.find(bid) == removedBoxes.end()) {
+        removedBoxes.insert(bid);
+        auto boxPtr = odb::dbSBox::getSBox(dbBlock, bid);
+
+        const auto new_vias = boxPtr->smashVia();
+        for (auto* new_via : new_vias) {
+          std::vector<odb::dbShape> via_boxes;
+          new_via->getViaBoxes(via_boxes);
+          for (const auto& via_box : via_boxes) {
+            auto* layer = via_box.getTechLayer();
+            if (layer != pdnLayer->getDbLayer()) {
+              continue;
+            }
+            all_vias.emplace_back(via_box.getBox(), new_via->getId());
           }
         }
-      }
-      if (!supply) {
-        continue;
-      }
-      auto markerBox = marker->getBBox();
-      odb::Rect queryBox;
-      markerBox.bloat(1, queryBox);
-      std::vector<rq_box_value_t<odb::dbId<odb::dbSBox>>> results;
-      pdnTree.query(bgi::intersects(queryBox), back_inserter(results));
-      for (auto& [rect, bid] : results) {
-        if (removedBoxes.find(bid) == removedBoxes.end()) {
-          removedBoxes.insert(bid);
-          auto boxPtr = odb::dbSBox::getSBox(dbBlock, bid);
+
+        if (!new_vias.empty()) {
           odb::dbSBox::destroy(boxPtr);
         }
       }
     }
-    logger_->report("Removed {} pdn vias on layer {}",
-                    removedBoxes.size(),
-                    pdnLayer->getName());
   }
+  removedBoxes.clear();
+
+  const RTree<odb::dbId<odb::dbSBox>> pdnTree(all_vias);
+  for (const auto& marker : markers) {
+    odb::Rect queryBox;
+    marker->getBBox().bloat(1, queryBox);
+    std::vector<rq_box_value_t<odb::dbId<odb::dbSBox>>> results;
+    pdnTree.query(bgi::intersects(queryBox), back_inserter(results));
+    for (auto& [rect, bid] : results) {
+      if (removedBoxes.find(bid) == removedBoxes.end()) {
+        removedBoxes.insert(bid);
+        odb::dbSBox::destroy(odb::dbSBox::getSBox(dbBlock, bid));
+      }
+    }
+  }
+  logger_->report("Removed {} pdn vias on layer {}",
+                  removedBoxes.size(),
+                  pdnLayer->getName());
 }
 
 void TritonRoute::reportConstraints()

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -765,6 +765,11 @@ class dbSBox : public dbBox
   bool hasViaLayerMasks();
 
   ///
+  /// Create a set of new sboxes from a via array
+  ///
+  std::vector<dbSBox*> smashVia();
+
+  ///
   /// Add a rect to a dbSWire.
   ///
   /// If direction == UNDEFINED

--- a/src/odb/src/db/dbSBox.cpp
+++ b/src/odb/src/db/dbSBox.cpp
@@ -43,6 +43,7 @@
 #include "dbTechVia.h"
 #include "dbVia.h"
 #include "odb/db.h"
+#include "odb/dbShape.h"
 
 namespace odb {
 
@@ -457,6 +458,70 @@ void dbSBox::destroy(dbSBox* box_)
   block->remove_rect(box->_shape._rect);
   dbProperty::destroyProperties(box);
   block->_sbox_tbl->destroy(box);
+}
+
+std::vector<dbSBox*> dbSBox::smashVia()
+{
+  if (!isVia()) {
+    return {};
+  }
+
+  auto* block_via = getBlockVia();
+
+  if (block_via == nullptr) {
+    return {};
+  }
+
+  if (block_via->getTechVia() != nullptr) {
+    return {};
+  }
+
+  auto params = block_via->getViaParams();
+
+  if (params.getNumCutCols() == 1 && params.getNumCutRows() == 1) {
+    // nothing to do
+    return {};
+  }
+
+  const std::string name = block_via->getName() + "_smashed";
+
+  _dbSWire* wire = (_dbSWire*) getSWire();
+  dbBlock* block = (dbBlock*) wire->getOwner();
+  dbSWire* swire = (dbSWire*) wire;
+
+  odb::dbVia* new_block_via = block->findVia(name.c_str());
+
+  if (new_block_via == nullptr) {
+    new_block_via = odb::dbVia::create(block, name.c_str());
+
+    params.setNumCutCols(1);
+    params.setNumCutRows(1);
+
+    new_block_via->setViaParams(params);
+  }
+
+  std::vector<dbSBox*> new_boxes;
+
+  std::vector<odb::dbShape> via_boxes;
+  getViaBoxes(via_boxes);
+  for (const auto& via_box : via_boxes) {
+    auto* layer = via_box.getTechLayer();
+    if (layer->getType() != odb::dbTechLayerType::CUT) {
+      continue;
+    }
+
+    const auto& box = via_box.getBox();
+    auto* sbox_via = odb::dbSBox::create(
+        swire, new_block_via, box.xCenter(), box.yCenter(), getWireShapeType());
+    new_boxes.push_back(sbox_via);
+
+    if (hasViaLayerMasks()) {
+      sbox_via->setViaLayerMask(
+          getViaBottomLayerMask(), getViaCutLayerMask(), getViaTopLayerMask());
+    }
+  }
+
+  return new_boxes;
 }
 
 }  // namespace odb

--- a/src/odb/test/regression_tests.tcl
+++ b/src/odb/test/regression_tests.tcl
@@ -34,6 +34,7 @@ record_tests {
   gcd_abstract_lef_with_power
   abstract_origin
   write_macro_placement
+  smash_vias
   #odb_man_tcl_check
   #odb_readme_msgs_check
 }

--- a/src/odb/test/smash_vias.defok
+++ b/src/odb/test/smash_vias.defok
@@ -1,0 +1,120 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN counter ;
+UNITS DISTANCE MICRONS 1000 ;
+VIAS 2 ;
+    - testing_via + VIARULE M2_M1 + CUTSIZE 65 65  + LAYERS metal1 via1 metal2  + CUTSPACING 195 195  + ENCLOSURE 0 0 0 0  + ROWCOL 5 5  ;
+    - testing_via_smashed + RECT metal1 ( -32 -32 ) ( 32 32 ) + RECT metal2 ( -32 -32 ) ( 32 32 ) + RECT via1 ( -32 -32 ) ( 32 32 ) ;
+END VIAS
+COMPONENTMASKSHIFT metal2 metal3 ;
+COMPONENTS 12 ;
+    - _d0_ DFFPOSX1 ;
+    - _d1_ DFFPOSX1 ;
+    - _d2_ DFFPOSX1 ;
+    - _d3_ DFFPOSX1 ;
+    - _d4_ DFFPOSX1 ;
+    - _d5_ DFFPOSX1 ;
+    - _d6_ DFFPOSX1 ;
+    - _d7_ DFFPOSX1 ;
+    - _d8_ DFFPOSX1 ;
+    - _g0_ NOR2X1 ;
+    - _g1_ NOR2X1 ;
+    - _g2_ NOR2X1 ;
+END COMPONENTS
+PINS 12 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL ;
+    - inp0 + NET inp0 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal1 MASK 2 ( -25 -25 ) ( 25 25 )
+        + LAYER metal2 ( -10 -25 ) ( 10 50 )
+        + FIXED ( 10000 5025 ) N
+      + PORT
+        + LAYER metal1 ( -25 -25 ) ( 25 25 )
+        + LAYER metal2 ( -10 -25 ) ( 10 50 )
+        + FIXED ( 10000 5025 ) N ;
+    - inp1 + NET inp1 + DIRECTION INPUT + USE SIGNAL ;
+    - out[0] + NET out[0] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[1] + NET out[1] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[2] + NET out[2] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[3] + NET out[3] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[4] + NET out[4] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[5] + NET out[5] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[6] + NET out[6] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[7] + NET out[7] + DIRECTION OUTPUT + USE SIGNAL ;
+    - out[8] + NET out[8] + DIRECTION OUTPUT + USE SIGNAL ;
+END PINS
+SPECIALNETS 2 ;
+    - VDD ( * vdd ) + USE POWER
+      + ROUTED metal1 0 + SHAPE IOWIRE ( 1980 1980 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2240 1980 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2500 1980 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2760 1980 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 3020 1980 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 1980 2240 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2240 2240 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2500 2240 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2760 2240 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 3020 2240 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 1980 2500 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2240 2500 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2500 2500 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2760 2500 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 3020 2500 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 1980 2760 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2240 2760 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2500 2760 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2760 2760 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 3020 2760 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 1980 3020 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2240 3020 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2500 3020 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 2760 3020 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 3020 3020 ) testing_via_smashed
+      NEW metal1 0 + SHAPE IOWIRE ( 1000 1000 ) testing_via
+      NEW metal1 0 + SHAPE IOWIRE ( 50 50 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 50 55 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 50 60 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 50 65 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 52 50 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 52 55 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 52 60 ) M2_M1_via
+      NEW metal1 0 + SHAPE IOWIRE ( 52 65 ) M2_M1_via ;
+    - VSS + USE GROUND
+      + FIXED metal3 10 + SHAPE RING + MASK 2 + ( 5 0 ) ( 5 10 )
+      + ROUTED metal1 2000 ( 10 0 ) MASK 3 ( 10 20 )
+      NEW metal1 0 ( 10 20 ) M2_M1_via
+      NEW metal2 1000 ( 10 10 ) ( 20 10 )
+      NEW metal2 1000 ( 20 10 ) MASK 1 ( 20 20 )
+      NEW metal1 0 ( 20 20 ) MASK 031 M2_M1_via ;
+END SPECIALNETS
+NETS 24 ;
+    - _w0_ ( _g0_ Y ) ( _d1_ D ) ( _d0_ D ) ( _d2_ D ) + USE SIGNAL
+      + ROUTED metal2 ( 50 50 ) ( * 300 )
+      NEW metal1 ( 50 300 ) MASK 001 M2_M1_via ;
+    - _w1_ ( _d5_ D ) ( _g1_ Y ) ( _d3_ D ) ( _d4_ D ) + USE SIGNAL ;
+    - _w2_ ( _g2_ Y ) ( _d6_ D ) ( _d8_ D ) ( _d7_ D ) + USE SIGNAL ;
+    - _xout0 + USE SIGNAL ;
+    - _xout1 + USE SIGNAL ;
+    - _xout2 + USE SIGNAL ;
+    - _xout3 + USE SIGNAL ;
+    - _xout4 + USE SIGNAL ;
+    - _xout5 + USE SIGNAL ;
+    - _xout6 + USE SIGNAL ;
+    - _xout7 + USE SIGNAL ;
+    - _xout8 + USE SIGNAL ;
+    - clk ( PIN clk ) ( _d5_ CLK ) ( _d3_ CLK ) ( _d6_ CLK ) ( _d4_ CLK ) ( _d1_ CLK ) ( _d8_ CLK )
+      ( _d0_ CLK ) ( _d2_ CLK ) ( _d7_ CLK ) + USE SIGNAL ;
+    - inp0 ( PIN inp0 ) ( _g2_ A ) ( _g1_ A ) ( _g0_ A ) + USE SIGNAL ;
+    - inp1 ( PIN inp1 ) ( _g2_ B ) ( _g0_ B ) ( _g1_ B ) + USE SIGNAL ;
+    - out[0] ( PIN out[0] ) ( _d0_ Q ) + USE SIGNAL ;
+    - out[1] ( PIN out[1] ) ( _d1_ Q ) + USE SIGNAL ;
+    - out[2] ( PIN out[2] ) ( _d2_ Q ) + USE SIGNAL ;
+    - out[3] ( PIN out[3] ) ( _d3_ Q ) + USE SIGNAL ;
+    - out[4] ( PIN out[4] ) ( _d4_ Q ) + USE SIGNAL ;
+    - out[5] ( PIN out[5] ) ( _d5_ Q ) + USE SIGNAL ;
+    - out[6] ( PIN out[6] ) ( _d6_ Q ) + USE SIGNAL ;
+    - out[7] ( PIN out[7] ) ( _d7_ Q ) + USE SIGNAL ;
+    - out[8] ( PIN out[8] ) ( _d8_ Q ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/odb/test/smash_vias.ok
+++ b/src/odb/test/smash_vias.ok
@@ -1,0 +1,20 @@
+[INFO ODB-0388] unsupported contactResistance property for layer contact :"10.5"
+[INFO ODB-0388] unsupported contactResistance property for layer via1 :"5.69"
+[WARNING ODB-0423] LEF58_REGION layer via1R1 ignored
+[INFO ODB-0388] unsupported contactResistance property for layer via2 :"11.39"
+[INFO ODB-0388] unsupported contactResistance property for layer via3 :"16.73"
+[INFO ODB-0388] unsupported contactResistance property for layer via4 :"21.44"
+[INFO ODB-0388] unsupported contactResistance property for layer via5 :"24.08"
+[INFO ODB-0388] unsupported contactResistance property for layer via6 :"11.39"
+[INFO ODB-0388] unsupported contactResistance property for layer via7 :"5.69"
+[INFO ODB-0388] unsupported contactResistance property for layer via8 :"16.73"
+[INFO ODB-0388] unsupported contactResistance property for layer via9 :"21.44"
+[INFO ODB-0227] LEF file: data/gscl45nm.lef, created 22 layers, 14 vias, 33 library cells
+[INFO ODB-0128] Design: counter
+[INFO ODB-0130]     Created 12 pins.
+[INFO ODB-0131]     Created 12 components and 60 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 12 connections.
+[INFO ODB-0133]     Created 24 nets and 45 connections.
+25
+No differences found.
+pass

--- a/src/odb/test/smash_vias.tcl
+++ b/src/odb/test/smash_vias.tcl
@@ -1,0 +1,44 @@
+source "helpers.tcl"
+
+read_lef "data/gscl45nm.lef"
+read_def "data/design58.def"
+
+set via [odb::dbVia_create [ord::get_db_block] "testing_via"]
+
+foreach viagen [[ord::get_db_tech] getViaGenerateRules] {
+    if {[$viagen getName] == "M2_M1"} {
+        break
+    }
+}
+
+$via setViaGenerateRule $viagen
+
+set params [$via getViaParams]
+$params setBottomLayer [[ord::get_db_tech] findLayer metal1]
+$params setCutLayer [[ord::get_db_tech] findLayer via1]
+$params setTopLayer [[ord::get_db_tech] findLayer metal2]
+$params setXCutSize 130
+$params setYCutSize 130
+$params setXCutSpacing 390
+$params setYCutSpacing 390
+$params setNumCutRows 5
+$params setNumCutCols 5
+
+$via setViaParams $params
+
+set swire [[[ord::get_db_block] findNet VDD] getSWires]
+
+set via0 [odb::dbSBox_create $swire $via 2000 2000 IOWIRE]
+set via1 [odb::dbSBox_create $swire $via 5000 5000 IOWIRE]
+
+puts [llength [$via1 smashVia]]
+
+odb::dbSBox_destroy $via1
+
+set out_def [make_result_file "smash_vias.def"]
+write_def $out_def
+
+diff_files $out_def "smash_vias.defok"
+
+puts "pass"
+exit 0


### PR DESCRIPTION
Changes:
- repair via will now "smash" a block via array into individual vias and then remove all violating vias. This avoids the issue where a single via in a block via array causes drt to remove the entire via array disconnecting the power grid.