### PR TITLE
Fix issue with linking dependency of -lstdc++fs when using flatpak

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,8 @@ configure_file(
 
 ################################################################
 
-if (NOT APPLE)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9.1")
+  MESSAGE(STATUS "Older version of GCC detected. Linking against stdc++fs")
   link_libraries(stdc++fs)
 endif()
 


### PR DESCRIPTION
I had to fork OpenROAD as there is an issue during linking of `stdc++fs`. It seems to be an old practice to put this line and is an issue when building with Flatpak. 

I made a similar request for Surelog that has been accepted (maybe it can be done for OpenROAD as well):
https://github.com/chipsalliance/Surelog/pull/3966