### PR TITLE
openroad: add -no_exit option

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -292,7 +292,8 @@ int main(int argc, char* argv[])
     return Py_RunMain();
 #else
     initPython();
-    bool exit = findCmdLineFlag(cmd_argc, cmd_argv, "-exit");
+    bool exit = findCmdLineFlag(cmd_argc, cmd_argv, "-exit")
+                && !findCmdLineFlag(cmd_argc, cmd_argv, "-no_exit");
     std::vector<wchar_t*> args;
     args.push_back(Py_DecodeLocale(cmd_argv[0], nullptr));
     if (!exit) {
@@ -386,7 +387,9 @@ static int tclAppInit(int& argc,
           ord::OpenRoad::openRoad()->getThreadCount(), false);
     }
 
-    bool exit_after_cmd_file = findCmdLineFlag(argc, argv, "-exit");
+    bool exit_after_cmd_file
+        = findCmdLineFlag(cmd_argc, cmd_argv, "-exit")
+          && !findCmdLineFlag(cmd_argc, cmd_argv, "-no_exit");
 
     const bool gui_enabled = gui::Gui::enabled();
 
@@ -471,6 +474,8 @@ static void showUsage(const char* prog, const char* init_filename)
   printf("  -threads count|max    use count threads\n");
   printf("  -no_splash            do not show the license splash at startup\n");
   printf("  -exit                 exit after reading cmd_file\n");
+  printf(
+      "  -no_exit              do not exit after reading cmd_file (default)\n");
   printf("  -gui                  start in gui mode\n");
 #ifdef ENABLE_PYTHON3
   printf(


### PR DESCRIPTION
used to override -exit argument passed on command line in ORFS

Example use-case:

rm -f results/asap7/mock-array_Element/base/2_2_floorplan_io.odb && \
  make OPENROAD_ARGS="-no_exit -gui" \
  DESIGN_CONFIG=designs/asap7/mock-array/Element/config.mk \
  results/asap7/mock-array_Element/base/2_2_floorplan_io.odb

Closest I get to a "Rebuild" button in the GUI for now https://github.com/The-OpenROAD-Project/OpenROAD/issues/5093