### PR TITLE
grt: split max layer and routing layers check

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1633,8 +1633,10 @@ void GlobalRouter::initGridAndNets()
 {
   block_ = db_->getChip()->getBlock();
   routes_.clear();
-  if (max_routing_layer_ == -1 || routing_layers_.empty()) {
+  if (max_routing_layer_ == -1) {
     max_routing_layer_ = computeMaxRoutingLayer();
+  }
+  if (routing_layers_.empty()) {
     int min_layer, max_layer;
     getMinMaxLayer(min_layer, max_layer);
 


### PR DESCRIPTION
Previously, the user-defined max routing layer was overwritten by this process, causing issues during post-drt repair_antennas by using out-of-range layers.