### PR TITLE
Fix building `rmp_abc_library` when `USE_SYSTEM_ABC` is set

### DIFF
--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -90,6 +90,7 @@ target_link_libraries(rmp_abc_library
     dbSta_lib
     libabc
     utl_lib
+    ${ABC_LIBRARY}
 )
 
 if (Python3_FOUND AND BUILD_PYTHON)


### PR DESCRIPTION
(Small change)