### PR TITLE
odb: provide dbuToMicrons for various datatypes to avoid casting errors

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1185,10 +1185,10 @@ class dbBlock : public dbObject
   ///
   /// Convert a length from database units (DBUs) to microns.
   ///
-  double dbuToMicrons(const int dbu);
-  double dbuToMicrons(const unsigned int dbu);
-  double dbuToMicrons(const int64_t dbu);
-  double dbuToMicrons(const double dbu);
+  double dbuToMicrons(int dbu);
+  double dbuToMicrons(unsigned int dbu);
+  double dbuToMicrons(int64_t dbu);
+  double dbuToMicrons(double dbu);
 
   ///
   /// Convert an area from database units squared (DBU^2) to square microns.

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1185,7 +1185,10 @@ class dbBlock : public dbObject
   ///
   /// Convert a length from database units (DBUs) to microns.
   ///
-  double dbuToMicrons(int dbu);
+  double dbuToMicrons(const int dbu);
+  double dbuToMicrons(const unsigned int dbu);
+  double dbuToMicrons(const int64_t dbu);
+  double dbuToMicrons(const double dbu);
 
   ///
   /// Convert an area from database units squared (DBU^2) to square microns.

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2319,25 +2319,25 @@ int dbBlock::getDbUnitsPerMicron()
   return block->_dbu_per_micron;
 }
 
-double dbBlock::dbuToMicrons(const int dbu)
+double dbBlock::dbuToMicrons(int dbu)
 {
   const double dbu_micron = getTech()->getDbUnitsPerMicron();
   return dbu / dbu_micron;
 }
 
-double dbBlock::dbuToMicrons(const unsigned int dbu)
+double dbBlock::dbuToMicrons(unsigned int dbu)
 {
   const double dbu_micron = getTech()->getDbUnitsPerMicron();
   return dbu / dbu_micron;
 }
 
-double dbBlock::dbuToMicrons(const int64_t dbu)
+double dbBlock::dbuToMicrons(int64_t dbu)
 {
   const double dbu_micron = getTech()->getDbUnitsPerMicron();
   return dbu / dbu_micron;
 }
 
-double dbBlock::dbuToMicrons(const double dbu)
+double dbBlock::dbuToMicrons(double dbu)
 {
   const double dbu_micron = getTech()->getDbUnitsPerMicron();
   return dbu / dbu_micron;

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2325,6 +2325,24 @@ double dbBlock::dbuToMicrons(const int dbu)
   return dbu / dbu_micron;
 }
 
+double dbBlock::dbuToMicrons(const unsigned int dbu)
+{
+  const double dbu_micron = getTech()->getDbUnitsPerMicron();
+  return dbu / dbu_micron;
+}
+
+double dbBlock::dbuToMicrons(const int64_t dbu)
+{
+  const double dbu_micron = getTech()->getDbUnitsPerMicron();
+  return dbu / dbu_micron;
+}
+
+double dbBlock::dbuToMicrons(const double dbu)
+{
+  const double dbu_micron = getTech()->getDbUnitsPerMicron();
+  return dbu / dbu_micron;
+}
+
 double dbBlock::dbuAreaToMicrons(const int64_t dbu_area)
 {
   const double dbu_micron = getTech()->getDbUnitsPerMicron();


### PR DESCRIPTION
Fixes overflow:
```
original HPWL         -964503.2 u
legalized HPWL       -2147483.6 u
```
->
```
original HPWL         3330464.1 u
legalized HPWL        3341133.7 u
```