### PR TITLE
gui: warn and ignore about ITermPins that are invalid

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3077,7 +3077,8 @@ void GlobalRouter::makeItermPins(Net* net,
 
     odb::dbInst* inst = iterm->getInst();
     if (!inst->isPlaced()) {
-      logger_->error(GRT, 10, "Instance {} is not placed.", inst->getName());
+      logger_->warn(GRT, 10, "Instance {} is not placed.", inst->getName());
+      continue;
     }
     const odb::dbTransform transform = inst->getTransform();
 
@@ -3115,12 +3116,13 @@ void GlobalRouter::makeItermPins(Net* net,
     }
 
     if (pin_layers.empty()) {
-      logger_->error(
+      logger_->warn(
           GRT,
           29,
           "Pin {} does not have geometries below the max routing layer ({}).",
           getITermName(iterm),
           getLayerName(max_routing_layer, db_));
+      continue;
     }
 
     Pin pin(iterm,


### PR DESCRIPTION
A possible solution to #5121

Tested: this lets the GUI run with warnings, even if the .odb file has some problems. This is nice, because the GUI can crash on startup if e.g. the RUDY estimated congestion was enabled in a previous session for a different design.

Fixing the problems in the .odb file is a separate concern/issue. Will look into filing a github issue for that later.