### PR TITLE
gui: skip "macro alignment" of the current outline when SA centralized floorplan

### DIFF
--- a/src/mpl2/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl2/src/SimulatedAnnealingCore.cpp
@@ -642,6 +642,8 @@ void SimulatedAnnealingCore<T>::attemptCentralization(const float pre_cost)
 
   // revert centralization
   if (calNormCost() > pre_cost) {
+    centralization_was_reverted_ = true;
+
     for (int& id : pos_seq_) {
       macros_[id].setX(clusters_locations[id].first);
       macros_[id].setY(clusters_locations[id].second);

--- a/src/mpl2/src/SimulatedAnnealingCore.h
+++ b/src/mpl2/src/SimulatedAnnealingCore.h
@@ -97,6 +97,7 @@ class SimulatedAnnealingCore
   {
     centralization_on_ = centralization_on;
   };
+  bool centralizationWasReverted() { return centralization_was_reverted_; }
 
   void setNets(const std::vector<BundledNet>& nets);
   // Fence corresponds to each macro (macro_id, fence)
@@ -243,6 +244,7 @@ class SimulatedAnnealingCore
 
   bool has_initial_sequence_pair_ = false;
   bool centralization_on_ = false;
+  bool centralization_was_reverted_ = false;
 };
 
 // SACore wrapper function

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3926,8 +3926,12 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
 
     logger_->error(MPL, 5, "Failed on cluster {}", parent->getName());
   }
-  best_sa->alignMacroClusters();
+
+  if (best_sa->centralizationWasReverted()) {
+    best_sa->alignMacroClusters();
+  }
   best_sa->fillDeadSpace();
+
   // update the clusters and do bus planning
   std::vector<SoftMacro> shaped_macros;
   best_sa->getMacros(shaped_macros);
@@ -4179,8 +4183,12 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
 
       logger_->error(MPL, 6, "Failed on cluster {}", parent->getName());
     }
-    best_sa->alignMacroClusters();
+
+    if (best_sa->centralizationWasReverted()) {
+      best_sa->alignMacroClusters();
+    }
     best_sa->fillDeadSpace();
+
     // update the clusters and do bus planning
     best_sa->getMacros(shaped_macros);
   }
@@ -4715,7 +4723,9 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
 
     runEnhancedHierarchicalMacroPlacement(parent);
   } else {
-    best_sa->alignMacroClusters();
+    if (best_sa->centralizationWasReverted()) {
+      best_sa->alignMacroClusters();
+    }
     best_sa->fillDeadSpace();
 
     std::vector<SoftMacro> shaped_macros;
@@ -5198,8 +5208,12 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
     }
     logger_->error(MPL, 40, "Failed on cluster {}", parent->getName());
   }
-  best_sa->alignMacroClusters();
+
+  if (best_sa->centralizationWasReverted()) {
+    best_sa->alignMacroClusters();
+  }
   best_sa->fillDeadSpace();
+
   // update the clusters and do bus planning
   std::vector<SoftMacro> shaped_macros;
   best_sa->getMacros(shaped_macros);


### PR DESCRIPTION
Resolves the centralization problem showed in [#2020](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2020)

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/104802710/509a11c1-bbe1-4cab-bfbc-e1b337223708)