### PR TITLE
Skip known bad vertices in power recovery

### DIFF
--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -66,7 +66,8 @@ using sta::Edge;
 using sta::PathExpanded;
 using sta::VertexOutEdgeIterator;
 
-RecoverPower::RecoverPower(Resizer* resizer) : resizer_(resizer)
+RecoverPower::RecoverPower(Resizer* resizer)
+    : resizer_(resizer), bad_vertices_(resizer->graph_)
 {
 }
 
@@ -142,7 +143,7 @@ void RecoverPower::recoverPower(const float recover_power_percent)
     //=====================================================================
     resizer_->journalBegin();
     PathRef end_path = sta_->vertexWorstSlackPath(end, max_);
-    const bool changed = recoverPower(end_path, end_slack_before);
+    Vertex* const changed = recoverPower(end_path, end_slack_before);
     if (changed) {
       resizer_->updateParasitics(true);
       sta_->findRequireds();
@@ -179,6 +180,8 @@ void RecoverPower::recoverPower(const float recover_power_percent)
                    worst_slack_before,
                    worst_slack_after);
       } else {
+        // Save the vertex to avoid trying it again.
+        bad_vertices_.insert(changed);
         // Undo the change here.
         ++failed_move_threshold;
         if (failed_move_threshold > failed_move_threshold_limit_) {
@@ -223,10 +226,11 @@ void RecoverPower::recoverPower(const float recover_power_percent)
   if (resizer_->overMaxArea()) {
     logger_->error(RSZ, 125, "max utilization reached.");
   }
+  bad_vertices_.clear();
 }
 
 // For testing.
-void RecoverPower::recoverPower(const Pin* end_pin)
+Vertex* RecoverPower::recoverPower(const Pin* end_pin)
 {
   init();
   resize_count_ = 0;
@@ -235,7 +239,7 @@ void RecoverPower::recoverPower(const Pin* end_pin)
   const Slack slack = sta_->vertexSlack(vertex, max_);
   const PathRef path = sta_->vertexWorstSlackPath(vertex, max_);
   resizer_->incrementalParasiticsBegin();
-  recoverPower(path, slack);
+  Vertex* drvr_vertex = recoverPower(path, slack);
   // Leave the parasitices up to date.
   resizer_->updateParasitics();
   resizer_->incrementalParasiticsEnd();
@@ -243,13 +247,14 @@ void RecoverPower::recoverPower(const Pin* end_pin)
   if (resize_count_ > 0) {
     logger_->info(RSZ, 3111, "Resized {} instances.", resize_count_);
   }
+  return drvr_vertex;
 }
 
 // This is the main routine for recovering power.
-bool RecoverPower::recoverPower(const PathRef& path, const Slack path_slack)
+Vertex* RecoverPower::recoverPower(const PathRef& path, const Slack path_slack)
 {
   PathExpanded expanded(&path, sta_);
-  bool changed = false;
+  Vertex* changed = nullptr;
 
   if (expanded.size() > 1) {
     const int path_length = expanded.size();
@@ -295,6 +300,10 @@ bool RecoverPower::recoverPower(const PathRef& path, const Slack path_slack)
     for (const auto& [drvr_index, ignored] : load_delays) {
       PathRef* drvr_path = expanded.path(drvr_index);
       Vertex* drvr_vertex = drvr_path->vertex(sta_);
+      // If we already tried this vertex and got a worse result, skip it.
+      if (bad_vertices_.find(drvr_vertex) != bad_vertices_.end()) {
+        continue;
+      }
       const Pin* drvr_pin = drvr_vertex->pin();
       const LibertyPort* drvr_port = network_->libertyPort(drvr_pin);
       const LibertyCell* drvr_cell
@@ -309,7 +318,7 @@ bool RecoverPower::recoverPower(const PathRef& path, const Slack path_slack)
                  drvr_cell ? drvr_cell->name() : "none",
                  fanout);
       if (downsizeDrvr(drvr_path, drvr_index, &expanded, true, path_slack)) {
-        changed = true;
+        changed = drvr_vertex;
         break;
       }
     }

--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -215,6 +215,7 @@ void RecoverPower::recoverPower(const float recover_power_percent)
       }
     }
   }
+  bad_vertices_.clear();
 
   resizer_->incrementalParasiticsEnd();
   // TODO: Add the appropriate metric here
@@ -226,7 +227,6 @@ void RecoverPower::recoverPower(const float recover_power_percent)
   if (resizer_->overMaxArea()) {
     logger_->error(RSZ, 125, "max utilization reached.");
   }
-  bad_vertices_.clear();
 }
 
 // For testing.

--- a/src/rsz/src/RecoverPower.hh
+++ b/src/rsz/src/RecoverPower.hh
@@ -37,6 +37,7 @@
 
 #include "db_sta/dbSta.hh"
 #include "sta/FuncExpr.hh"
+#include "sta/Graph.hh"
 #include "sta/MinMax.hh"
 #include "sta/StaState.hh"
 #include "utl/Logger.h"
@@ -80,11 +81,11 @@ class RecoverPower : StaState
   RecoverPower(Resizer* resizer);
   void recoverPower(float recover_power_percent);
   // For testing.
-  void recoverPower(const Pin* end_pin);
+  Vertex* recoverPower(const Pin* end_pin);
 
  private:
   void init();
-  bool recoverPower(const PathRef& path, Slack path_slack);
+  Vertex* recoverPower(const PathRef& path, Slack path_slack);
   bool meetsSizeCriteria(const LibertyCell* cell,
                          const LibertyCell* equiv,
                          bool match_size);
@@ -130,7 +131,7 @@ class RecoverPower : StaState
   // trying
   static constexpr int failed_move_threshold_limit_ = 500;
 
-  sta::UnorderedMap<LibertyCell*, sta::LibertyPortSet> equiv_pin_map_;
+  sta::VertexSet bad_vertices_;
 
   static constexpr int decreasing_slack_max_passes_ = 50;
   static constexpr int rebuffer_max_fanout_ = 20;


### PR DESCRIPTION
In power recovery, vertices that have already been tried and rejected can be tried again if they happen to be on another path we look at. Usually, the result is the same – we reject the vertex. Not only is this work unnecessary, it also prevents us from trying another (possibly better) vertex later in the path. Some stats on vertices that are tried in #4982:

| Vertex | Total tries | Better | Worse |
| - | - | - | - |
| `max_length492/Y` | 1325 | 1 | 1324 |
| `load_slew487/Y` | 130 | 1 | 129 |
| `load_slew465/Y` | 309 | 1 | 308 |
| `load_slew447/Y` | 231 | 1 | 230 |
| `load_slew409/Y` | 49 | 0 | 49 |
| `load_slew400/Y` | 294 | 2 | 292 |
| `load_slew375/Y` | 262 | 1 | 261 |
| `load_slew57/Y` | 240 | 0 | 240 |
| `load_slew407/Y` | 124 | 0 | 124 |
| `fdct_zigzag.dct_mod.dct_block_0.dct_unit_0.ddin\[7\]$_DFFE_PN0P_/QN` | 141 | 0 | 141 |
| `max_length63/Y` | 63 | 1 | 62 |
| `_085272_/Y` | 481 | 0 | 481 |
| `load_slew402/Y` | 56 | 1 | 55 |
| `_083048_/Y` | 2 | 1 | 1 |
| `wire301/Y` | 26 | 1 | 25 |
| `load_slew62/Y` | 4 | 2 | 2 |
| `load_slew446/Y` | 12 | 2 | 10 |
| `_078958_/Y` | 3 | 0 | 3 |
| `load_slew399/Y` | 2 | 1 | 1 |
| `load_slew486/Y` | 14 | 1 | 13 |
| `load_slew462/Y` | 27 | 2 | 25 |
| `load_slew461/Y` | 8 | 1 | 7 |
| `_118922_/Y` | 2 | 0 | 2 |
| `_122581_/CON` | 3 | 0 | 3 |
| `load_slew177/Y` | 3 | 0 | 3 |

In the worst case, one vertex is visited 1325 times, 1324 of which result in worse worst slack. That's also about a quarter of all attempts.

This patch makes it so we don't revisit the vertices that were already rejected.

In the example in #4982, this speeds up GRT from ~1.5h to around 6 minutes, so we're looking at ~15x the performance on that particular design.

Also, the actual power recovery seems overall more effective (not sure how to weigh these values against each other).
![power-diff](https://github.com/The-OpenROAD-Project/OpenROAD/assets/9216518/b28a3224-7dd2-4ee9-a606-af099d3962e3)
