### PR TITLE
Grt fix ndr track consumption

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1042,9 +1042,7 @@ void GlobalRouter::computeTrackConsumption(
 
       int ndr_spacing = layer_rule->getSpacing();
       int ndr_width = layer_rule->getWidth();
-      int ndr_pitch = 2
-                      * (std::ceil(ndr_width / 2 + ndr_spacing
-                                   + default_width / 2 - default_pitch));
+      int ndr_pitch = ndr_width / 2 + ndr_spacing + default_width / 2;
 
       int consumption = std::ceil((float) ndr_pitch / default_pitch);
       (*edge_costs_per_layer)[layerIdx - 1] = consumption;

--- a/src/grt/test/ndr_1w_3s.ok
+++ b/src/grt/test/ndr_1w_3s.ok
@@ -38,19 +38,19 @@ met5       Horizontal       2964          1443          51.32%
 [INFO GRT-0198] Via related Steiner nodes: 10
 [INFO GRT-0199] Via filling finished.
 [INFO GRT-0111] Final number of vias: 211
-[INFO GRT-0112] Final usage 3D: 865
+[INFO GRT-0112] Final usage 3D: 916
 
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
 ---------------------------------------------------------------------------------------
 li1                  0             0            0.00%             0 /  0 /  0
 met1              4315           120            2.78%             0 /  0 /  0
-met2              5772            56            0.97%             0 /  0 /  0
+met2              5772            95            1.65%             0 /  0 /  0
 met3              5807            44            0.76%             0 /  0 /  0
-met4              4366            12            0.27%             0 /  0 /  0
+met4              4366            24            0.55%             0 /  0 /  0
 met5              1443             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            21703           232            1.07%             0 /  0 /  0
+Total            21703           283            1.30%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1699 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/ndr_2w_3s.ok
+++ b/src/grt/test/ndr_2w_3s.ok
@@ -38,19 +38,19 @@ met5       Horizontal       2964          1443          51.32%
 [INFO GRT-0198] Via related Steiner nodes: 10
 [INFO GRT-0199] Via filling finished.
 [INFO GRT-0111] Final number of vias: 214
-[INFO GRT-0112] Final usage 3D: 871
+[INFO GRT-0112] Final usage 3D: 923
 
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
 ---------------------------------------------------------------------------------------
 li1                  0             0            0.00%             0 /  0 /  0
 met1              4315           116            2.69%             0 /  0 /  0
-met2              5772            57            0.99%             0 /  0 /  0
+met2              5772            97            1.68%             0 /  0 /  0
 met3              5807            44            0.76%             0 /  0 /  0
-met4              4366            12            0.27%             0 /  0 /  0
+met4              4366            24            0.55%             0 /  0 /  0
 met5              1443             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            21703           229            1.06%             0 /  0 /  0
+Total            21703           281            1.29%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1706 um
 [INFO GRT-0014] Routed nets: 15


### PR DESCRIPTION
Currently GRT is computing the wrong  consumption for ndr nets. This PR fixes this error.