### PR TITLE
Fix type errors in odb I/BTerm iteration logic.

### DIFF
--- a/src/odb/src/db/dbModInstITermItr.cpp
+++ b/src/odb/src/db/dbModInstITermItr.cpp
@@ -34,6 +34,7 @@
 #include "dbModInstITermItr.h"
 
 #include "dbModITerm.h"
+#include "dbModInst.h"
 #include "dbTable.h"
 
 namespace odb {
@@ -92,8 +93,7 @@ uint dbModInstITermItr::end(dbObject* /* unused: parent */)
 uint dbModInstITermItr::next(uint id, ...)
 {
   // User Code Begin next
-  _dbModInstITerm* iterm = _moditerm_tbl->getPtr(id);
-  return iterm->_next_entry;
+  return _moditerm_tbl->getPtr(id)->_next_entry;
   // User Code End next
 }
 

--- a/src/odb/src/db/dbModuleBTermItr.cpp
+++ b/src/odb/src/db/dbModuleBTermItr.cpp
@@ -34,6 +34,9 @@
 #include "dbModuleBTermItr.h"
 
 #include "dbModBTerm.h"
+#include "dbModITerm.h"
+#include "dbModule.h"
+#include "dbObject.h"
 #include "dbTable.h"
 
 namespace odb {
@@ -80,7 +83,7 @@ uint dbModuleBTermItr::begin(dbObject* parent)
 {
   // User Code Begin begin
   _dbModule* _module = (_dbModule*) parent;
-  _dbModBTerm* _modbterm = _module->_modbterms;
+  return _module->_modbterms;
   // User Code End begin
 }
 
@@ -92,8 +95,7 @@ uint dbModuleBTermItr::end(dbObject* /* unused: parent */)
 uint dbModuleBTermItr::next(uint id, ...)
 {
   // User Code Begin next
-  _dbModITerm* modbterm = _modbterm_tbl->getPtr(id);
-  return modbterm->_next_entry;
+  return _modbterm_tbl->getPtr(id)->_next_entry;
   // User Code End next
 }
 

--- a/src/odb/src/db/dbModuleBTermItr.cpp
+++ b/src/odb/src/db/dbModuleBTermItr.cpp
@@ -36,7 +36,6 @@
 #include "dbModBTerm.h"
 #include "dbModITerm.h"
 #include "dbModule.h"
-#include "dbObject.h"
 #include "dbTable.h"
 
 namespace odb {

--- a/src/odb/src/db/dbModuleModInstITermItr.cpp
+++ b/src/odb/src/db/dbModuleModInstITermItr.cpp
@@ -93,8 +93,7 @@ uint dbModuleModInstITermItr::end(dbObject* /* unused: parent */)
 uint dbModuleModInstITermItr::next(uint id, ...)
 {
   // User Code Begin next
-  _dbModITerm* moditerm = _moditerm_tbl->getPtr(id);
-  return moditerm->_next_entry;
+  return _moditerm_tbl->getPtr(id)->_next_entry;
   // User Code End next
 }
 


### PR DESCRIPTION
Some minor tweaks to return types and included headers were necessary to build openroad using our build setup.