### PR TITLE
Added a new function to remove unused dbMasters.

### DIFF
--- a/etc/deltaDebug.py
+++ b/etc/deltaDebug.py
@@ -191,6 +191,9 @@ class deltaDebugger:
                 if err is None or cuts == 0:
                     break
 
+        # Delete unused master-cells from design
+        self.remove_unused_masters()
+
         # Change deltaDebug resultant base_db file name to a representative name
         if os.path.exists(self.temp_base_db_file):
             os.rename(self.temp_base_db_file, self.deltaDebug_result_base_file)
@@ -390,6 +393,25 @@ class deltaDebugger:
             elif self.cut_level == cutLevel.Nets:
                 self.clear_dont_touch_net(elm)
             elm.destroy(elm)
+
+    def remove_unused_masters(self):
+        # Create new clean dbDatabase
+        self.base_db = Design.createDetachedDb()
+        print(f"Reading {self.temp_base_db_file}  file ")
+        self.base_db = odb.read_db(self.base_db, self.temp_base_db_file)
+        print("Removing unused masters...")
+        unused = self.base_db.removeUnusedMasters()
+        print(f"Removed {unused} masters.")
+        odb.write_db(self.base_db, self.temp_base_db_file)
+
+        if (self.dump_def != 0):
+            print("Writing def file")
+            odb.write_def(self.base_db.getChip().getBlock(),
+                          self.temp_base_db_file[:-3] + "def")
+
+        if (self.base_db is not None):
+            self.base_db.destroy(self.base_db)
+            self.base_db = None
 
 
 if __name__ == '__main__':

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -347,6 +347,12 @@ class dbDatabase : public dbObject
   dbMaster* findMaster(const char* name);
 
   ///
+  /// This function is used to delete unused master-cells.
+  /// Returns the number of unused master-cells that have been deleted.
+  ///
+  int removeUnusedMasters();
+
+  ///
   /// Get the chip of this database.
   /// Returns nullptr if no chip has been created.
   ///

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -432,13 +432,11 @@ int dbDatabase::removeUnusedMasters()
   std::vector<dbMaster*> unused_masters;
   dbSet<dbLib> libs = getLibs();
 
-  for (auto it = libs.begin(); it != libs.end(); ++it) {
-    dbLib* lib = *it;
+  for (auto lib : libs) {
     dbSet<dbMaster> masters = lib->getMasters();
     // Collect all dbMasters for later comparision
-    for (auto masterIt = masters.begin(); masterIt != masters.end();
-         ++masterIt) {
-      unused_masters.push_back(*masterIt);
+    for (auto master : masters) {
+      unused_masters.push_back(master);
     }
   }
   // Get instances from this Database
@@ -446,8 +444,8 @@ int dbDatabase::removeUnusedMasters()
   dbBlock* block = chip->getBlock();
   dbSet<dbInst> insts = block->getInsts();
 
-  for (auto instIt = insts.begin(); instIt != insts.end(); ++instIt) {
-    dbMaster* master = instIt->getMaster();
+  for (auto inst : insts) {
+    dbMaster* master = inst->getMaster();
     // Filter out the master that matches inst_master
     auto masterIt
         = std::find(unused_masters.begin(), unused_masters.end(), master);


### PR DESCRIPTION
This PR closes #2910. C++ and Python new functions have been added:

- `int dbDatabase::removeUnusedMasters()` - removes unused masters
- `def remove_unused_masters(self)` - to prepare database and call above C++ function