### PR TITLE
gui: Module view enables detailed

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1651,7 +1651,7 @@ bool DisplayControls::areSelectedVisible()
 
 bool DisplayControls::isDetailedVisibility()
 {
-  return isModelRowVisible(&misc_.detailed);
+  return isModelRowVisible(&misc_.detailed) || isModelRowVisible(&misc_.module);
 }
 
 bool DisplayControls::arePrefTracksVisible()


### PR DESCRIPTION
Module view doesn't do anything when detailed view isn't enabled, so enable detailed view when Module view is enabled.

This helps "market" this, in my opinion, undersold feature and improves usability a tad; enable it and it works without having to know that detailed view is needed.

This feature, much to my pleasant surprise, works even without hierarchical synthesis.


Megaboom:

![image](https://github.com/The-OpenROAD-Project/OpenROAD/assets/2798822/777db92a-836b-408a-b119-7e10186f8fb5)
