### PR TITLE
gui: slack histogram filter fix

### DIFF
--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -278,14 +278,8 @@ void ChartsWidget::removeUnconstrainedPinsAndSetLimits(StaPins& end_points)
 
     if (slack != sta::INF) {
       slack = time_unit->staToUser(slack);
-
-      if (slack < min_slack_) {
-        min_slack_ = slack;
-      }
-
-      if (slack > max_slack_) {
-        max_slack_ = slack;
-      }
+      min_slack_ = std::min(slack, min_slack_);
+      max_slack_ = std::max(slack, max_slack_);
 
       ++pin_iter;
     } else {

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -334,12 +334,12 @@ void ChartsWidget::populateBuckets(StaPins* end_points, TimingPathList* paths)
     } else if (paths) {
       for (const std::unique_ptr<TimingPath>& path : *paths) {
         const float slack = time_unit->staToUser(path->getSlack());
-        const sta::Pin* pin = path->getEndStageNode()->getPinAsSTA();
+        const sta::Pin* end_point = path->getEndStageNode()->getPinAsSTA();
 
         if (negative_lower <= slack && slack < negative_upper) {
-          neg_bucket.push_back(pin);
+          neg_bucket.push_back(end_point);
         } else if (positive_lower <= slack && slack < positive_upper) {
-          pos_bucket.push_back(pin);
+          pos_bucket.push_back(end_point);
         }
       }
     }
@@ -565,7 +565,7 @@ void ChartsWidget::setYAxisConfig()
     }
   }
 
-  for (const std::vector<const sta::Pin *>& bucket : buckets_->positive) {
+  for (const std::vector<const sta::Pin*>& bucket : buckets_->positive) {
     const int bucket_slack_count = static_cast<int>(bucket.size());
 
     if (bucket_slack_count > largest_slack_count) {

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -67,6 +67,12 @@ ChartsWidget::ChartsWidget(QWidget* parent)
       prev_filter_index_(0),  // start with no filter
       max_slack_(0.0f),
       min_slack_(std::numeric_limits<float>::max()),
+      resetting_menu_(false),
+      default_number_of_buckets_(15),
+      largest_slack_count_(0),
+      precision_count_(0),
+      bucket_interval_(0.0f),
+      neg_count_offset_(0),
 #endif
       label_(new QLabel(this))
 {
@@ -124,7 +130,11 @@ void ChartsWidget::changeMode()
   clearChart();
 
   if (mode_menu_->currentIndex() == SLACK_HISTOGRAM) {
-    filters_menu_->setCurrentIndex(0);
+    if (filters_menu_->currentIndex() != 0) {
+      resetting_menu_ = true;
+      filters_menu_->setCurrentIndex(0);
+    }
+
     filters_menu_->show();
     setSlackHistogram();
   }
@@ -187,6 +197,8 @@ void ChartsWidget::clearChart()
   // reset limits
   max_slack_ = 0;
   min_slack_ = std::numeric_limits<float>::max();
+
+  largest_slack_count_ = 0;
 
   chart_->setTitle("");
   chart_->removeAllSeries();
@@ -617,6 +629,11 @@ void ChartsWidget::setSTA(sta::dbSta* sta)
 
 void ChartsWidget::changeStartEndFilter()
 {
+  if (resetting_menu_) {
+    resetting_menu_ = false;
+    return;
+  }
+
   clearChart();
 
   StaPins end_points;

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -124,6 +124,7 @@ void ChartsWidget::changeMode()
   clearChart();
 
   if (mode_menu_->currentIndex() == SLACK_HISTOGRAM) {
+    filters_menu_->setCurrentIndex(0);
     filters_menu_->show();
     setSlackHistogram();
   }
@@ -180,10 +181,6 @@ void ChartsWidget::showToolTip(bool is_hovering, int bar_index)
 
 void ChartsWidget::clearChart()
 {
-  if (filters_menu_->isVisible()) {
-    filters_menu_->hide();
-  }
-
   buckets_->positive.clear();
   buckets_->negative.clear();
 
@@ -639,7 +636,13 @@ void ChartsWidget::changeStartEndFilter()
   }
 
   setBucketInterval();
-  populateBuckets(nullptr, &paths);
+
+  if (!end_points.empty()) {
+    populateBuckets(&end_points, nullptr);
+  } else if (!paths.empty()) {
+    populateBuckets(nullptr, &paths);
+  }
+
   setVisualConfig();
 
   prev_filter_index_ = filter_index;

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -559,18 +559,12 @@ void ChartsWidget::setYAxisConfig()
 
   for (const std::vector<const sta::Pin*>& bucket : buckets_->negative) {
     const int bucket_slack_count = static_cast<int>(bucket.size());
-
-    if (bucket_slack_count > largest_slack_count) {
-      largest_slack_count = bucket_slack_count;
-    }
+    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
   }
 
   for (const std::vector<const sta::Pin*>& bucket : buckets_->positive) {
     const int bucket_slack_count = static_cast<int>(bucket.size());
-
-    if (bucket_slack_count > largest_slack_count) {
-      largest_slack_count = bucket_slack_count;
-    }
+    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
   }
 
   int y_interval = computeYInterval(largest_slack_count);
@@ -679,13 +673,8 @@ void ChartsWidget::setLimits(const TimingPathList& paths)
   for (const std::unique_ptr<TimingPath>& path : paths) {
     const float slack = time_unit->staToUser(path->getSlack());
 
-    if (slack < min_slack_) {
-      min_slack_ = slack;
-    }
-
-    if (slack > max_slack_) {
-      max_slack_ = slack;
-    }
+    min_slack_ = std::min(slack, min_slack_);
+    max_slack_ = std::max(slack, max_slack_);
   }
 }
 

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -191,7 +191,7 @@ class ChartsWidget : public QDockWidget
   float min_slack_;
   float bucket_interval_;
 
-  int precision_count_; // Used to configure the x labels.
+  int precision_count_;  // Used to configure the x labels.
 #endif
   QLabel* label_;
 };

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -192,12 +192,14 @@ class ChartsWidget : public QDockWidget
   float max_slack_;
   float min_slack_;
 
-  const int default_number_of_buckets_ = 15;
-  int largest_slack_count_ = 0;  // Used to configure the y axis.
-  int precision_count_ = 0;      // Used to configure the x labels.
+  bool resetting_menu_;
 
-  float bucket_interval_ = 0;
-  int neg_count_offset_ = 0;
+  const int default_number_of_buckets_;
+  int largest_slack_count_;  // Used to configure the y axis.
+  int precision_count_;      // Used to configure the x labels.
+
+  float bucket_interval_;
+  int neg_count_offset_;
 #endif
   QLabel* label_;
 };

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -131,10 +131,6 @@ class ChartsWidget : public QDockWidget
   {
     bucket_interval_ = bucket_interval;
   }
-  void setNegativeCountOffset(int neg_count_offset)
-  {
-    neg_count_offset_ = neg_count_offset;
-  }
   void setDecimalPrecision(int precision_count)
   {
     precision_count_ = precision_count;
@@ -166,11 +162,10 @@ class ChartsWidget : public QDockWidget
   void setXAxisConfig(int all_bars_count);
   void setXAxisTitle();
   void setYAxisConfig();
-
-  int computeMaxYSnap();
+  int computeYInterval(int largest_slack_count);
+  int computeMaxYSnap(int largest_slack_count);
   int computeNumberOfDigits(int value);
   int computeFirstDigit(int value, int digits);
-  int computeYInterval();
 
   void clearChart();
 
@@ -187,19 +182,16 @@ class ChartsWidget : public QDockWidget
 
   std::set<sta::Clock*> clocks_;
   std::unique_ptr<Buckets> buckets_;
+
   int prev_filter_index_;
-
-  float max_slack_;
-  float min_slack_;
-
   bool resetting_menu_;
 
   const int default_number_of_buckets_;
-  int largest_slack_count_;  // Used to configure the y axis.
-  int precision_count_;      // Used to configure the x labels.
-
+  float max_slack_;
+  float min_slack_;
   float bucket_interval_;
-  int neg_count_offset_;
+
+  int precision_count_; // Used to configure the x labels.
 #endif
   QLabel* label_;
 };

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -139,15 +139,23 @@ class ChartsWidget : public QDockWidget
   {
     precision_count_ = precision_count;
   }
+  void setClocks(const std::set<sta::Clock*>& clocks)
+  {
+    clocks_ = clocks;
+  }
 
   SlackHistogramData fetchSlackHistogramData();
-  void removeUnconstrainedPins(StaPins& end_points);
+  void removeUnconstrainedPinsAndSetLimits(StaPins& end_points);
   TimingPathList fetchPathsBasedOnStartEnd(const StartEndPathType path_type);
   StaPins getEndPointsFromPaths(const TimingPathList& paths);
   ITermBTermPinsLists separatePinsIntoBTermsAndITerms(const StaPins& pins);
+  void setLimits(const TimingPathList& paths);
 
-  void populateBuckets(const StaPins& end_points);
+  void populateBuckets(StaPins* end_points, TimingPathList* paths);
+  std::pair<QBarSet*, QBarSet*> createBarSets();
   void populateBarSets(QBarSet& neg_set, QBarSet& pos_set);
+
+  void setVisualConfig();
 
   int computeSnapBucketInterval(float exact_interval);
   float computeSnapBucketDecimalInterval(float minimum_interval);
@@ -155,14 +163,14 @@ class ChartsWidget : public QDockWidget
                              float max_slack,
                              float min_slack);
 
-  void setXAxisConfig(int all_bars_count, const std::set<sta::Clock*>& clocks);
+  void setXAxisConfig(int all_bars_count);
+  void setXAxisTitle();
   void setYAxisConfig();
-  QString createXAxisTitle(const std::set<sta::Clock*>& clocks);
+
   int computeMaxYSnap();
   int computeNumberOfDigits(int value);
   int computeFirstDigit(int value, int digits);
   int computeYInterval();
-  void clearBarSets();
 
   void clearChart();
 
@@ -177,6 +185,7 @@ class ChartsWidget : public QDockWidget
   QValueAxis* axis_x_;
   QValueAxis* axis_y_;
 
+  std::set<sta::Clock*> clocks_;
   std::unique_ptr<Buckets> buckets_;
   int prev_filter_index_;
 


### PR DESCRIPTION
While working on improving performance I realized that there was a bug making us show the wrong slack data when using the filter feature. These changes are to ensure we actually show the correct data and reset the axis and limits to improve the presentation.

Changes:
- Use the API from the TimingPath rather than the sta API which gives always the worst slack
- Ensure that for tiny intervals of min/max slack, we use a reasonable slack interval for the x axis
- Clicking on empty bins won't trigger timing report (based on [Oyvind's Comment](https://github.com/The-OpenROAD-Project/OpenROAD/pull/5139#issuecomment-2125400329))