### PR TITLE
Reworked sta is to use uniquified ids in hierarchy mode. 

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -65,6 +65,7 @@ using odb::dbModule;
 using odb::dbMTerm;
 using odb::dbNet;
 using odb::dbObject;
+using odb::dbObjectType;
 using odb::dbSet;
 using odb::dbSigType;
 using odb::Point;
@@ -103,6 +104,7 @@ class dbNetwork : public ConcreteNetwork
   void addObserver(dbNetworkObserver* observer);
   void removeObserver(dbNetworkObserver* observer);
 
+  ObjectId getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const;
   dbBlock* block() const { return block_; }
   void makeLibrary(dbLib* lib);
   void makeCell(Library* library, dbMaster* master);

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -92,6 +92,20 @@ class dbNetwork : public ConcreteNetwork
  public:
   dbNetwork();
   ~dbNetwork() override;
+
+  // unique addresses for the db objects
+  static constexpr unsigned DBITERM_ID = 0x0;
+  static constexpr unsigned DBBTERM_ID = 0x1;
+  static constexpr unsigned DBINST_ID = 0x2;
+  static constexpr unsigned DBNET_ID = 0x3;
+  static constexpr unsigned DBMODITERM_ID = 0x4;
+  static constexpr unsigned DBMODBTERM_ID = 0x5;
+  static constexpr unsigned DBMODINST_ID = 0x6;
+  static constexpr unsigned DBMODNET_ID = 0x7;
+  static constexpr unsigned DBMODULE_ID = 0x8;
+  // Number of lower bits used
+  static constexpr unsigned DBIDTAG_WIDTH = 0x4;
+
   void init(dbDatabase* db, Logger* logger);
   void setBlock(dbBlock* block);
   void clear() override;

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -93,19 +93,6 @@ class dbNetwork : public ConcreteNetwork
   dbNetwork();
   ~dbNetwork() override;
 
-  // unique addresses for the db objects
-  static constexpr unsigned DBITERM_ID = 0x0;
-  static constexpr unsigned DBBTERM_ID = 0x1;
-  static constexpr unsigned DBINST_ID = 0x2;
-  static constexpr unsigned DBNET_ID = 0x3;
-  static constexpr unsigned DBMODITERM_ID = 0x4;
-  static constexpr unsigned DBMODBTERM_ID = 0x5;
-  static constexpr unsigned DBMODINST_ID = 0x6;
-  static constexpr unsigned DBMODNET_ID = 0x7;
-  static constexpr unsigned DBMODULE_ID = 0x8;
-  // Number of lower bits used
-  static constexpr unsigned DBIDTAG_WIDTH = 0x4;
-
   void init(dbDatabase* db, Logger* logger);
   void setBlock(dbBlock* block);
   void clear() override;
@@ -118,7 +105,6 @@ class dbNetwork : public ConcreteNetwork
   void addObserver(dbNetworkObserver* observer);
   void removeObserver(dbNetworkObserver* observer);
 
-  ObjectId getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const;
   dbBlock* block() const { return block_; }
   void makeLibrary(dbLib* lib);
   void makeCell(Library* library, dbMaster* master);
@@ -303,12 +289,27 @@ class dbNetwork : public ConcreteNetwork
                           PinVisitor& visitor,
                           NetSet& visited_nets) const override;
   bool portMsbFirst(const char* port_name, const char* cell_name);
+  ObjectId getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const;
+
   dbDatabase* db_ = nullptr;
   Logger* logger_ = nullptr;
   dbBlock* block_ = nullptr;
   Instance* top_instance_;
   Cell* top_cell_ = nullptr;
   std::set<dbNetworkObserver*> observers_;
+
+  // unique addresses for the db objects
+  static constexpr unsigned DBITERM_ID = 0x0;
+  static constexpr unsigned DBBTERM_ID = 0x1;
+  static constexpr unsigned DBINST_ID = 0x2;
+  static constexpr unsigned DBNET_ID = 0x3;
+  static constexpr unsigned DBMODITERM_ID = 0x4;
+  static constexpr unsigned DBMODBTERM_ID = 0x5;
+  static constexpr unsigned DBMODINST_ID = 0x6;
+  static constexpr unsigned DBMODNET_ID = 0x7;
+  static constexpr unsigned DBMODULE_ID = 0x8;
+  // Number of lower bits used
+  static constexpr unsigned DBIDTAG_WIDTH = 0x4;
 
  private:
   bool hierarchy_ = false;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -101,18 +101,6 @@ char* tmpStringCopy(const char* str)
 // lower 4  bits used to encode type
 //
 
-static constexpr unsigned DBITERM_ID = 0x0;
-static constexpr unsigned DBBTERM_ID = 0x1;
-static constexpr unsigned DBINST_ID = 0x2;
-static constexpr unsigned DBNET_ID = 0x3;
-static constexpr unsigned DBMODITERM_ID = 0x4;
-static constexpr unsigned DBMODBTERM_ID = 0x5;
-static constexpr unsigned DBMODINST_ID = 0x6;
-static constexpr unsigned DBMODNET_ID = 0x7;
-static constexpr unsigned DBMODULE_ID = 0x8;
-// Number of lower bits used
-static constexpr unsigned DBIDTAG_WIDTH = 0x4;
-
 ObjectId dbNetwork::getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const
 {
   if (db_id > (std::numeric_limits<ObjectId>::max() >> DBIDTAG_WIDTH)) {

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -101,19 +101,19 @@ char* tmpStringCopy(const char* str)
 // lower 4  bits used to encode type
 //
 
-#define DBITERM_ID 0x0
-#define DBBTERM_ID 0x1
-#define DBINST_ID 0x2
-#define DBNET_ID 0x3
-#define DBMODITERM_ID 0x4
-#define DBMODBTERM_ID 0x5
-#define DBMODINST_ID 0x6
-#define DBMODNET_ID 0x7
-#define DBMODULE_ID 0x8
+static constexpr unsigned DBITERM_ID = 0x0;
+static constexpr unsigned DBBTERM_ID = 0x1;
+static constexpr unsigned DBINST_ID = 0x2;
+static constexpr unsigned DBNET_ID = 0x3;
+static constexpr unsigned DBMODITERM_ID = 0x4;
+static constexpr unsigned DBMODBTERM_ID = 0x5;
+static constexpr unsigned DBMODINST_ID = 0x6;
+static constexpr unsigned DBMODNET_ID = 0x7;
+static constexpr unsigned DBMODULE_ID = 0x8;
 // Number of lower bits used
-#define DBIDTAG_WIDTH 0x4
+static constexpr unsigned DBIDTAG_WIDTH = 0x4;
 
-ObjectId getDbNwkObjectId(dbObjectType typ, ObjectId db_id)
+ObjectId dbNetwork::getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const
 {
   switch (typ) {
     case dbITermObj: {
@@ -144,6 +144,12 @@ ObjectId getDbNwkObjectId(dbObjectType typ, ObjectId db_id)
       return ((db_id << DBIDTAG_WIDTH) | DBMODULE_ID);
     } break;
     default:
+      logger_->error(
+          ORD,
+          2017,
+          "Error: unknown database type passed into unique id generation");
+      // note the default "exception undefined case" in database is 0.
+      // so we reasonably expect upstream tools to handle this.
       return 0;
       break;
   }

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -115,6 +115,10 @@ static constexpr unsigned DBIDTAG_WIDTH = 0x4;
 
 ObjectId dbNetwork::getDbNwkObjectId(dbObjectType typ, ObjectId db_id) const
 {
+  if (db_id > (std::numeric_limits<ObjectId>::max() >> DBIDTAG_WIDTH)) {
+    logger_->error(ORD, 2019, "Error: database id exceeds capacity");
+  }
+
   switch (typ) {
     case dbITermObj: {
       return ((db_id << DBIDTAG_WIDTH) | DBITERM_ID);


### PR DESCRIPTION
This pull request reworks the id mechanism used in dbNetwork.cc in hierarchy mode to avoid using the concrete network infra structure (which uses the sta object id) and instead use the database id. 

(Matt this step seems sufficiently complex and atomic to merit a pull request in its own right. I factored the code so that the database object id is used to determine the uniquified object id. The database id is shifted left by 4 and then a tag inserted into the lower 4 bits to determine the type of the object.) 