### PR TITLE
Revert "Merge pull request #5154 from arthurjolo/rsz_fix_longwire_split_lenght

### DIFF
--- a/src/cts/test/array.ok
+++ b/src/cts/test/array.ok
@@ -65,14 +65,14 @@
 [INFO CTS-0207]  Leaf load cells 62
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 33 long wires.
-[INFO RSZ-0048] Inserted 94 buffers in 33 nets.
+[INFO RSZ-0048] Inserted 93 buffers in 33 nets.
 Placement Analysis
 ---------------------------------
-total displacement       3218.5 u
+total displacement       3225.9 u
 average displacement        1.1 u
 max displacement          132.5 u
-original HPWL          133105.3 u
-legalized HPWL         133571.7 u
+original HPWL          132907.5 u
+legalized HPWL         133404.8 u
 delta HPWL                    0 %
 
 Clock clk

--- a/src/cts/test/array_ins_delay.ok
+++ b/src/cts/test/array_ins_delay.ok
@@ -117,22 +117,22 @@
 [INFO CTS-0207]  Leaf load cells 4
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 56 long wires.
-[INFO RSZ-0048] Inserted 115 buffers in 56 nets.
+[INFO RSZ-0048] Inserted 113 buffers in 56 nets.
 Placement Analysis
 ---------------------------------
-total displacement       4522.0 u
-average displacement        1.5 u
-max displacement          153.0 u
-original HPWL          185796.5 u
-legalized HPWL         186462.1 u
+total displacement       3930.5 u
+average displacement        1.3 u
+max displacement          132.4 u
+original HPWL          185797.7 u
+legalized HPWL         186439.5 u
 delta HPWL                    0 %
 
 Clock clk
-   1.24 source latency inst_8_12/clk ^
+   1.25 source latency inst_8_12/clk ^
   -1.09 target latency inst_10_12/clk ^
    0.00 CRPR
 --------------
-   0.15 setup skew
+   0.16 setup skew
 
 Startpoint: inst_1_1 (rising edge-triggered flip-flop clocked by clk)
 Endpoint: inst_2_1 (rising edge-triggered flip-flop clocked by clk)
@@ -145,32 +145,32 @@ Path Type: max
    0.00    0.00   clock source latency
    0.00    0.00 ^ clk (in)
    0.04    0.04 ^ wire7/Z (BUF_X8)
-   0.03    0.08 ^ wire6/Z (BUF_X16)
-   0.07    0.14 ^ wire5/Z (BUF_X32)
-   0.06    0.20 ^ wire4/Z (BUF_X32)
-   0.06    0.27 ^ wire3/Z (BUF_X32)
-   0.06    0.33 ^ wire2/Z (BUF_X32)
-   0.06    0.39 ^ wire1/Z (BUF_X32)
-   0.06    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    0.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    0.07 ^ wire6/Z (BUF_X16)
+   0.06    0.12 ^ wire5/Z (BUF_X16)
+   0.06    0.19 ^ wire4/Z (BUF_X32)
+   0.06    0.25 ^ wire3/Z (BUF_X32)
+   0.06    0.32 ^ wire2/Z (BUF_X32)
+   0.06    0.38 ^ wire1/Z (BUF_X32)
+   0.07    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    0.48 ^ delaybuf_0_clk/Z (BUF_X4)
    0.03    0.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
    0.03    0.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    0.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    0.58 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
    0.03    0.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
    0.04    0.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
    0.03    0.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    0.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    0.72 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
    0.03    0.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    0.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.03    0.79 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
    0.04    0.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
    0.03    0.86 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
    0.03    0.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
    0.04    0.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    0.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    1.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.03    0.96 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    0.99 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
    0.05    1.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    1.09 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
-   0.03    1.12 ^ max_length8/Z (BUF_X8)
+   0.04    1.08 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
+   0.03    1.11 ^ max_length8/Z (BUF_X8)
    0.04    1.15 ^ inst_1_1/clk (array_tile)
    0.21    1.36 ^ inst_1_1/e_out (array_tile)
    0.00    1.36 ^ inst_2_1/w_in (array_tile)
@@ -180,31 +180,31 @@ Path Type: max
    0.00    5.00   clock source latency
    0.00    5.00 ^ clk (in)
    0.04    5.04 ^ wire7/Z (BUF_X8)
-   0.03    5.08 ^ wire6/Z (BUF_X16)
-   0.07    5.14 ^ wire5/Z (BUF_X32)
-   0.06    5.20 ^ wire4/Z (BUF_X32)
-   0.06    5.27 ^ wire3/Z (BUF_X32)
-   0.06    5.33 ^ wire2/Z (BUF_X32)
-   0.06    5.39 ^ wire1/Z (BUF_X32)
-   0.06    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    5.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    5.07 ^ wire6/Z (BUF_X16)
+   0.06    5.12 ^ wire5/Z (BUF_X16)
+   0.06    5.19 ^ wire4/Z (BUF_X32)
+   0.06    5.25 ^ wire3/Z (BUF_X32)
+   0.06    5.32 ^ wire2/Z (BUF_X32)
+   0.06    5.38 ^ wire1/Z (BUF_X32)
+   0.07    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    5.48 ^ delaybuf_0_clk/Z (BUF_X4)
    0.03    5.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
    0.03    5.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    5.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    5.58 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
    0.03    5.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
    0.04    5.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
    0.03    5.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    5.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    5.72 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
    0.03    5.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    5.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.03    5.79 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
    0.04    5.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
    0.03    5.86 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
    0.03    5.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
    0.04    5.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    5.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    6.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.03    5.96 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    5.99 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
    0.05    6.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    6.09 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
+   0.04    6.08 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
    0.03    6.11 ^ max_length13/Z (BUF_X8)
    0.04    6.15 ^ inst_2_1/clk (array_tile)
    0.00    6.15   clock reconvergence pessimism
@@ -228,74 +228,74 @@ Path Type: max
    0.00    0.00   clock source latency
    0.00    0.00 ^ clk (in)
    0.04    0.04 ^ wire7/Z (BUF_X8)
-   0.03    0.08 ^ wire6/Z (BUF_X16)
-   0.07    0.14 ^ wire5/Z (BUF_X32)
-   0.06    0.20 ^ wire4/Z (BUF_X32)
-   0.06    0.27 ^ wire3/Z (BUF_X32)
-   0.06    0.33 ^ wire2/Z (BUF_X32)
-   0.06    0.39 ^ wire1/Z (BUF_X32)
-   0.06    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    0.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    0.07 ^ wire6/Z (BUF_X16)
+   0.06    0.12 ^ wire5/Z (BUF_X16)
+   0.06    0.19 ^ wire4/Z (BUF_X32)
+   0.06    0.25 ^ wire3/Z (BUF_X32)
+   0.06    0.32 ^ wire2/Z (BUF_X32)
+   0.06    0.38 ^ wire1/Z (BUF_X32)
+   0.07    0.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    0.48 ^ delaybuf_0_clk/Z (BUF_X4)
    0.03    0.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
    0.03    0.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    0.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    0.58 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
    0.03    0.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
    0.04    0.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
    0.03    0.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    0.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    0.72 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
    0.03    0.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    0.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.03    0.79 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
    0.04    0.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
    0.03    0.86 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
    0.03    0.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
    0.04    0.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    0.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    1.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.03    0.96 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    0.99 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
    0.05    1.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    1.09 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
+   0.04    1.08 ^ clkbuf_5_1_0_clk/Z (BUF_X4)
    0.03    1.11 ^ max_length13/Z (BUF_X8)
    0.04    1.15 ^ inst_2_1/clk (array_tile)
-   0.21    1.37 ^ inst_2_1/w_out (array_tile)
-   0.00    1.37 ^ inst_1_1/e_in (array_tile)
-           1.37   data arrival time
+   0.21    1.36 ^ inst_2_1/w_out (array_tile)
+   0.00    1.36 ^ inst_1_1/e_in (array_tile)
+           1.36   data arrival time
 
    5.00    5.00   clock clk (rise edge)
    0.00    5.00   clock source latency
    0.00    5.00 ^ clk (in)
    0.04    5.04 ^ wire7/Z (BUF_X8)
-   0.03    5.08 ^ wire6/Z (BUF_X16)
-   0.07    5.14 ^ wire5/Z (BUF_X32)
-   0.06    5.20 ^ wire4/Z (BUF_X32)
-   0.06    5.27 ^ wire3/Z (BUF_X32)
-   0.06    5.33 ^ wire2/Z (BUF_X32)
-   0.06    5.39 ^ wire1/Z (BUF_X32)
-   0.06    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
-   0.04    5.49 ^ delaybuf_0_clk/Z (BUF_X4)
+   0.03    5.07 ^ wire6/Z (BUF_X16)
+   0.06    5.12 ^ wire5/Z (BUF_X16)
+   0.06    5.19 ^ wire4/Z (BUF_X32)
+   0.06    5.25 ^ wire3/Z (BUF_X32)
+   0.06    5.32 ^ wire2/Z (BUF_X32)
+   0.06    5.38 ^ wire1/Z (BUF_X32)
+   0.07    5.45 ^ clkbuf_0_clk/Z (BUF_X4)
+   0.04    5.48 ^ delaybuf_0_clk/Z (BUF_X4)
    0.03    5.52 ^ clkbuf_1_0_0_clk/Z (BUF_X4)
    0.03    5.55 ^ clkbuf_1_0_1_clk/Z (BUF_X4)
-   0.03    5.59 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
+   0.03    5.58 ^ clkbuf_1_0_2_clk/Z (BUF_X4)
    0.03    5.62 ^ clkbuf_1_0_3_clk/Z (BUF_X4)
    0.04    5.66 ^ clkbuf_1_0_4_clk/Z (BUF_X4)
    0.03    5.69 ^ clkbuf_2_0_0_clk/Z (BUF_X4)
-   0.03    5.73 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
+   0.03    5.72 ^ clkbuf_2_0_1_clk/Z (BUF_X4)
    0.03    5.76 ^ clkbuf_2_0_2_clk/Z (BUF_X4)
-   0.03    5.80 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
+   0.03    5.79 ^ clkbuf_2_0_3_clk/Z (BUF_X4)
    0.04    5.83 ^ clkbuf_2_0_4_clk/Z (BUF_X4)
    0.03    5.86 ^ clkbuf_3_0_0_clk/Z (BUF_X4)
    0.03    5.90 ^ clkbuf_3_0_1_clk/Z (BUF_X4)
    0.04    5.94 ^ clkbuf_3_0_2_clk/Z (BUF_X4)
-   0.03    5.97 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
-   0.03    6.00 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
+   0.03    5.96 ^ clkbuf_4_0_0_clk/Z (BUF_X4)
+   0.03    5.99 ^ clkbuf_4_0_1_clk/Z (BUF_X4)
    0.05    6.04 ^ clkbuf_4_0_2_clk/Z (BUF_X4)
-   0.04    6.09 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
-   0.03    6.12 ^ max_length8/Z (BUF_X8)
+   0.04    6.08 ^ clkbuf_5_0_0_clk/Z (BUF_X4)
+   0.03    6.11 ^ max_length8/Z (BUF_X8)
    0.04    6.15 ^ inst_1_1/clk (array_tile)
    0.00    6.15   clock reconvergence pessimism
   -0.05    6.10   library setup time
            6.10   data required time
 ---------------------------------------------------------
            6.10   data required time
-          -1.37   data arrival time
+          -1.36   data arrival time
 ---------------------------------------------------------
            4.74   slack (MET)
 

--- a/src/cts/test/array_no_blockages.ok
+++ b/src/cts/test/array_no_blockages.ok
@@ -65,14 +65,14 @@
 [INFO CTS-0207]  Leaf load cells 62
 [INFO RSZ-0058] Using max wire length 693um.
 [INFO RSZ-0047] Found 33 long wires.
-[INFO RSZ-0048] Inserted 94 buffers in 33 nets.
+[INFO RSZ-0048] Inserted 93 buffers in 33 nets.
 Placement Analysis
 ---------------------------------
-total displacement       2308.2 u
+total displacement       2318.0 u
 average displacement        0.8 u
 max displacement           80.9 u
-original HPWL          133284.2 u
-legalized HPWL         133611.6 u
+original HPWL          133115.2 u
+legalized HPWL         133434.3 u
 delta HPWL                    0 %
 
 Clock clk

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -851,7 +851,7 @@ void RepairDesign::repairNetWire(
                  level,
                  units_->distanceUnit()->asString(dbuToMeters(wire_length), 1),
                  units_->distanceUnit()->asString(dbuToMeters(max_length_), 1));
-      split_length = min(max(max_length_ - wire_length_ref, 0), length / 2);
+      split_length = min(max_length_, length / 2);
 
       split_wire = true;
     }

--- a/src/rsz/test/repair_wire2.ok
+++ b/src/rsz/test/repair_wire2.ok
@@ -53,16 +53,16 @@ u4/Z manhtn 1.1 steiner 1.1 0.00
 in1 manhtn 0.7 steiner 0.7 0.00
 u1/Z manhtn 0.4 steiner 0.4 0.00
 [INFO RSZ-0037] Found 1 long wires.
-[INFO RSZ-0038] Inserted 3 buffers in 1 nets.
+[INFO RSZ-0038] Inserted 2 buffers in 1 nets.
 [INFO RSZ-0039] Resized 2 instances.
 Driver    length delay
-wire2/Z manhtn 986.4 steiner 986.4 0.13
+wire2/Z manhtn 1494.2 steiner 1494.2 0.30
+u2/Z manhtn 785.1 steiner 785.1 0.08
 wire1/Z manhtn 715.2 steiner 715.2 0.07
-u2/Z manhtn 679.2 steiner 679.2 0.06
-wire3/Z manhtn 610.8 steiner 610.8 0.05
 u3/Z manhtn 1.1 steiner 1.1 0.00
 u4/Z manhtn 1.1 steiner 1.1 0.00
 u1/Z manhtn 0.8 steiner 0.8 0.00
+in1 manhtn 0.7 steiner 0.7 0.00
 Startpoint: in1 (input port)
 Endpoint: out1 (output port)
 Path Group: unconstrained
@@ -75,15 +75,13 @@ Path Type: max
             0.000    0.000    0.000 ^ u1/A (BUF_X4)
   26.763    0.018    0.030    0.030 ^ u1/Z (BUF_X4)
             0.018    0.000    0.030 ^ u2/A (BUF_X32)
-  63.456    0.006    0.023    0.052 ^ u2/Z (BUF_X32)
-            0.080    0.065    0.118 ^ wire3/A (BUF_X16)
-  58.320    0.010    0.032    0.150 ^ wire3/Z (BUF_X16)
-            0.069    0.056    0.206 ^ wire2/A (BUF_X16)
-  87.559    0.009    0.031    0.237 ^ wire2/Z (BUF_X16)
-            0.052    0.042    0.279 ^ u3/A (BUF_X1)
-   0.000    0.006    0.026    0.305 ^ u3/Z (BUF_X1)
-            0.006    0.000    0.305 ^ out1 (out)
-                              0.305   data arrival time
+  71.422    0.006    0.023    0.053 ^ u2/Z (BUF_X32)
+            0.102    0.083    0.136 ^ wire2/A (BUF_X16)
+ 125.723    0.011    0.034    0.170 ^ wire2/Z (BUF_X16)
+            0.220    0.179    0.349 ^ u3/A (BUF_X1)
+   0.000    0.011    0.026    0.375 ^ u3/Z (BUF_X1)
+            0.011    0.000    0.375 ^ out1 (out)
+                              0.375   data arrival time
 ---------------------------------------------------------------------------
 (Path is unconstrained)
 
@@ -100,17 +98,15 @@ Path Type: max
             0.000    0.000    0.000 ^ u1/A (BUF_X4)
   26.763    0.018    0.030    0.030 ^ u1/Z (BUF_X4)
             0.018    0.000    0.030 ^ u2/A (BUF_X32)
-  63.456    0.006    0.023    0.052 ^ u2/Z (BUF_X32)
-            0.080    0.065    0.118 ^ wire3/A (BUF_X16)
-  58.320    0.010    0.032    0.150 ^ wire3/Z (BUF_X16)
-            0.069    0.056    0.206 ^ wire2/A (BUF_X16)
-  87.559    0.009    0.031    0.237 ^ wire2/Z (BUF_X16)
-            0.154    0.126    0.364 ^ wire1/A (BUF_X16)
-  54.731    0.013    0.033    0.397 ^ wire1/Z (BUF_X16)
-            0.064    0.052    0.449 ^ u4/A (BUF_X1)
-   0.000    0.006    0.026    0.476 ^ u4/Z (BUF_X1)
-            0.006    0.000    0.476 ^ out2 (out)
-                              0.476   data arrival time
+  71.422    0.006    0.023    0.053 ^ u2/Z (BUF_X32)
+            0.102    0.083    0.136 ^ wire2/A (BUF_X16)
+ 125.723    0.011    0.034    0.170 ^ wire2/Z (BUF_X16)
+            0.321    0.263    0.433 ^ wire1/A (BUF_X16)
+  54.731    0.019    0.030    0.463 ^ wire1/Z (BUF_X16)
+            0.065    0.053    0.516 ^ u4/A (BUF_X1)
+   0.000    0.006    0.027    0.543 ^ u4/Z (BUF_X1)
+            0.006    0.000    0.543 ^ out2 (out)
+                              0.543   data arrival time
 ---------------------------------------------------------------------------
 (Path is unconstrained)
 


### PR DESCRIPTION
This reverts commit 4fe54e666f3bf7120b9c22edd2087e537fe19a29, reversing changes made to b16bda7e82721d10566ff7e2b68f1ff0be9f9e38.

Fixes failing secure-ci design.