### PR TITLE
cts avoid removing sinks

### DIFF
--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -1776,10 +1776,10 @@ void HTreeBuilder::createClockSubNets()
   bool isFirstPoint = true;
   topLevelTopology.forEachBranchingPoint([&](unsigned idx,
                                              Point<double> branchPoint) {
-    
-    // If the branch point is a leaf and has no sinks that will be connected to it
-    //don't create a clock sub net for it
-    if(topologyForEachLevel_.size() == 1
+    // If the branch point is a leaf and has no sinks that will be connected to
+    // it
+    // don't create a clock sub net for it
+    if (topologyForEachLevel_.size() == 1
         && topLevelTopology.getBranchSinksLocations(idx).empty()) {
       return;
     }
@@ -1831,10 +1831,10 @@ void HTreeBuilder::createClockSubNets()
     isFirstPoint = true;
     topology.forEachBranchingPoint([&](unsigned idx,
                                        Point<double> branchPoint) {
-
-      // If the branch point is a leaf and has no sinks that will be connected to it
-      //don't create a clock sub net for it
-      if((levelIdx == topologyForEachLevel_.size() -1)
+      // If the branch point is a leaf and has no sinks that will be connected
+      // to it
+      // don't create a clock sub net for it
+      if ((levelIdx == topologyForEachLevel_.size() - 1)
           && topology.getBranchSinksLocations(idx).empty()) {
         return;
       }
@@ -1895,11 +1895,11 @@ void HTreeBuilder::createClockSubNets()
       [&](unsigned idx, Point<double> branchPoint) {
         ClockSubNet* subNet = leafTopology.getBranchDrivingSubNet(idx);
         // If no clock sub net was created for a leaf branch point no sinks
-        //connect to it, so just skip.
-        if(subNet == nullptr) {
+        // connect to it, so just skip.
+        if (subNet == nullptr) {
           return;
         }
-        
+
         subNet->setLeafLevel(true);
 
         const std::vector<Point<double>>& sinkLocs

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -1777,8 +1777,7 @@ void HTreeBuilder::createClockSubNets()
   topLevelTopology.forEachBranchingPoint([&](unsigned idx,
                                              Point<double> branchPoint) {
     // If the branch point is a leaf and has no sinks that will be connected to
-    // it
-    // don't create a clock sub net for it
+    // it don't create a clock sub net for it
     if (topologyForEachLevel_.size() == 1
         && topLevelTopology.getBranchSinksLocations(idx).empty()) {
       return;
@@ -1832,8 +1831,7 @@ void HTreeBuilder::createClockSubNets()
     topology.forEachBranchingPoint([&](unsigned idx,
                                        Point<double> branchPoint) {
       // If the branch point is a leaf and has no sinks that will be connected
-      // to it
-      // don't create a clock sub net for it
+      // to it don't create a clock sub net for it
       if ((levelIdx == topologyForEachLevel_.size() - 1)
           && topology.getBranchSinksLocations(idx).empty()) {
         return;

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -1776,6 +1776,13 @@ void HTreeBuilder::createClockSubNets()
   bool isFirstPoint = true;
   topLevelTopology.forEachBranchingPoint([&](unsigned idx,
                                              Point<double> branchPoint) {
+    
+    // If the branch point is a leaf and has no sinks that will be connected to it
+    //don't create a clock sub net for it
+    if(topologyForEachLevel_.size() == 1
+        && topLevelTopology.getBranchSinksLocations(idx).empty()) {
+      return;
+    }
     Point<double> legalBranchPoint
         = legalizeOneBuffer(branchPoint, options_->getRootBuffer());
     commitMoveLoc(branchPoint, legalBranchPoint);
@@ -1824,6 +1831,13 @@ void HTreeBuilder::createClockSubNets()
     isFirstPoint = true;
     topology.forEachBranchingPoint([&](unsigned idx,
                                        Point<double> branchPoint) {
+
+      // If the branch point is a leaf and has no sinks that will be connected to it
+      //don't create a clock sub net for it
+      if((levelIdx == topologyForEachLevel_.size() -1)
+          && topology.getBranchSinksLocations(idx).empty()) {
+        return;
+      }
       unsigned parentIdx = topology.getBranchingPointParentIdx(idx);
       LevelTopology& parentTopology = topologyForEachLevel_[levelIdx - 1];
       Point<double> parentPoint = parentTopology.getBranchingPoint(parentIdx);
@@ -1880,6 +1894,12 @@ void HTreeBuilder::createClockSubNets()
   leafTopology.forEachBranchingPoint(
       [&](unsigned idx, Point<double> branchPoint) {
         ClockSubNet* subNet = leafTopology.getBranchDrivingSubNet(idx);
+        // If no clock sub net was created for a leaf branch point no sinks
+        //connect to it, so just skip.
+        if(subNet == nullptr) {
+          return;
+        }
+        
         subNet->setLeafLevel(true);
 
         const std::vector<Point<double>>& sinkLocs

--- a/src/cts/test/insertion_delay.ok
+++ b/src/cts/test/insertion_delay.ok
@@ -54,12 +54,11 @@
 [INFO CTS-0034]     Segment length (rounded): 4.
 [INFO CTS-0032]  Stop criterion found. Max number of sinks is 15.
 [INFO CTS-0035]  Number of sinks covered: 28.
-[INFO CTS-0018]     Created 3 clock buffers.
+[INFO CTS-0018]     Created 2 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 2.
 [INFO CTS-0013]     Maximum number of buffers in the clock path: 2.
-[INFO CTS-0014]     1 clock nets were removed/fixed.
 [INFO CTS-0015]     Created 2 clock nets.
-[INFO CTS-0016]     Fanout distribution for the current clock = 0:1, 1:1..
+[INFO CTS-0016]     Fanout distribution for the current clock = 1:1..
 [INFO CTS-0017]     Max level of the clock tree: 1.
 [INFO CTS-0018]     Created 31 clock buffers.
 [INFO CTS-0012]     Minimum number of buffers in the clock path: 3.


### PR DESCRIPTION
During the HTree building step of cts we can create more Clock subNets then needed, these extra Clock subNets were deleted at the end of CTS, but this can cause crashes (like it was mentioned in https://github.com/The-OpenROAD-Project/OpenROAD/pull/4938).

To prevent having to delete these nets at the end of CTS, this PR avoids creating subnets that aren't connected to anything.