### PR TITLE
rsz: RepairSetup: reduce calls to findRequireds

### DIFF
--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -148,8 +148,6 @@ void RepairSetup::repairSetup(const float setup_slack_margin,
   }
   for (const auto& end_original_slack : violating_ends) {
     Vertex* end = end_original_slack.first;
-    resizer_->updateParasitics();
-    sta_->findRequireds();
     Slack end_slack = sta_->vertexSlack(end, max_);
     Slack worst_slack;
     Vertex* worst_vertex;
@@ -185,36 +183,44 @@ void RepairSetup::repairSetup(const float setup_slack_margin,
       }
 
       if (end_slack > setup_slack_margin) {
-        debugPrint(logger_,
-                   RSZ,
-                   "repair_setup",
-                   2,
-                   "Restoring best slack end slack {} worst slack {}",
-                   delayAsString(prev_end_slack, sta_, digits),
-                   delayAsString(prev_worst_slack, sta_, digits));
-        resizer_->journalRestore(
-            resize_count_, inserted_buffer_count_, cloned_gate_count_);
+        if (pass != 1) {
+          debugPrint(logger_,
+                     RSZ,
+                     "repair_setup",
+                     2,
+                     "Restoring best slack end slack {} worst slack {}",
+                     delayAsString(prev_end_slack, sta_, digits),
+                     delayAsString(prev_worst_slack, sta_, digits));
+          resizer_->journalRestore(
+              resize_count_, inserted_buffer_count_, cloned_gate_count_);
+          resizer_->updateParasitics();
+          sta_->findRequireds();
+        }
         break;
       }
       PathRef end_path = sta_->vertexWorstSlackPath(end, max_);
       const bool changed
           = repairPath(end_path, end_slack, skip_pin_swap, skip_gate_cloning);
       if (!changed) {
-        debugPrint(logger_,
-                   RSZ,
-                   "repair_setup",
-                   2,
-                   "No change after {} decreasing slack passes.",
-                   decreasing_slack_passes);
-        debugPrint(logger_,
-                   RSZ,
-                   "repair_setup",
-                   2,
-                   "Restoring best slack end slack {} worst slack {}",
-                   delayAsString(prev_end_slack, sta_, digits),
-                   delayAsString(prev_worst_slack, sta_, digits));
-        resizer_->journalRestore(
-            resize_count_, inserted_buffer_count_, cloned_gate_count_);
+        if (pass != 1) {
+          debugPrint(logger_,
+                     RSZ,
+                     "repair_setup",
+                     2,
+                     "No change after {} decreasing slack passes.",
+                     decreasing_slack_passes);
+          debugPrint(logger_,
+                     RSZ,
+                     "repair_setup",
+                     2,
+                     "Restoring best slack end slack {} worst slack {}",
+                     delayAsString(prev_end_slack, sta_, digits),
+                     delayAsString(prev_worst_slack, sta_, digits));
+          resizer_->journalRestore(
+              resize_count_, inserted_buffer_count_, cloned_gate_count_);
+          resizer_->updateParasitics();
+          sta_->findRequireds();
+        }
         break;
       }
       resizer_->updateParasitics();
@@ -261,6 +267,8 @@ void RepairSetup::repairSetup(const float setup_slack_margin,
                      delayAsString(prev_worst_slack, sta_, digits));
           resizer_->journalRestore(
               resize_count_, inserted_buffer_count_, cloned_gate_count_);
+          resizer_->updateParasitics();
+          sta_->findRequireds();
           break;
         }
       }


### PR DESCRIPTION
This MR reduces the number of calls to `sta::Sta::findRequireds`.

Previously, we would always call `sta::Sta::findRequireds` in the beginning of the loop, but instead we should only call it after anything changes in the graph.
This approach reduces the number of calls to this function from `5029` to `1927` in `ariane133` design.

I also checked that the sha of the resulting `.odb` file matches the original version.
I measured the run times of CTS in 5 runs of ariane133:

|                     | min time [min] | avg time [min] | med time [min] | max time [min] |
|---------------------|----------------|----------------|----------------|----------------|
| master (74da93a32)  | 42:46          |  43:70         |  44:06         |  44:32         |
| this PR             | 36:51          |  38:02         |  38:52         |  38:55         |


Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>