### PR TITLE
Enforce iteration order determinism for ppl::PinSet.

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -35,12 +35,13 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 #include <set>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
+#include "odb/db.h"
 #include "odb/geom.h"
 #include "ppl/Parameters.h"
 
@@ -73,8 +74,16 @@ using odb::Rect;
 
 using utl::Logger;
 
+struct pinSetComp
+{
+  bool operator()(const odb::dbBTerm* lhs, const odb::dbBTerm* rhs) const
+  {
+    return lhs->getId() < rhs->getId();
+  }
+};
+
 // A list of pins that will be placed together in the die boundary
-using PinSet = std::set<odb::dbBTerm*>;
+using PinSet = std::set<odb::dbBTerm*, pinSetComp>;
 using PinList = std::vector<odb::dbBTerm*>;
 using MirroredPins = std::unordered_map<odb::dbBTerm*, odb::dbBTerm*>;
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -78,7 +78,7 @@ struct pinSetComp
 {
   bool operator()(const odb::dbBTerm* lhs, const odb::dbBTerm* rhs) const
   {
-    return lhs->getId() < rhs->getId();
+    return lhs->getObjName() < rhs->getObjName();
   }
 };
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -78,7 +78,7 @@ struct pinSetComp
 {
   bool operator()(const odb::dbBTerm* lhs, const odb::dbBTerm* rhs) const
   {
-    return lhs->getObjName() < rhs->getObjName();
+    return lhs->getId() < rhs->getId();
   }
 };
 

--- a/src/ppl/src/IOPlacer-py.i
+++ b/src/ppl/src/IOPlacer-py.i
@@ -44,14 +44,14 @@ using ppl::PinSet;
 using namespace ppl;
 
 template <class TYPE>
-set<TYPE> *
+set<TYPE, ppl::pinSetComp> *
 PyListSet(PyObject *const source,
           swig_type_info *swig_type)
 {
   int sz;
   if (PyList_Check(source) && PyList_Size(source) > 0) {
     sz = PyList_Size(source);
-    set<TYPE> *seq = new set<TYPE>;
+    set<TYPE, ppl::pinSetComp> *seq = new set<TYPE, ppl::pinSetComp>;
     for (int i = 0; i < sz; i++) {
       void *obj;
       SWIG_ConvertPtr(PyList_GetItem(source, i), &obj, swig_type, false);

--- a/src/ppl/src/IOPlacer.i
+++ b/src/ppl/src/IOPlacer.i
@@ -77,7 +77,7 @@ tclListStdSeq(Tcl_Obj *const source,
 }
 
 template <class TYPE>
-set<TYPE> *
+set<TYPE, ppl::pinSetComp> *
 tclSetStdSeq(Tcl_Obj *const source,
         swig_type_info *swig_type,
         Tcl_Interp *interp)
@@ -87,7 +87,7 @@ tclSetStdSeq(Tcl_Obj *const source,
 
   if (Tcl_ListObjGetElements(interp, source, &argc, &argv) == TCL_OK
       && argc > 0) {
-    set<TYPE> *seq = new set<TYPE>;
+    set<TYPE, ppl::pinSetComp> *seq = new set<TYPE, ppl::pinSetComp>;
     for (int i = 0; i < argc; i++) {
       void *obj;
       // Ignore returned TCL_ERROR because can't get swig_type_info.


### PR DESCRIPTION
We are observing non-determinism in the output of the `place_pins` step across multiple runs of OpenROAD with fixed initial conditions. The root cause seems to be iteration over a set of `odb::dbBTerm*`.

With this change, we observe deterministic pin placement. Using `dbBTerm.getId()` for the comparison was considered but we suggest using `getObjNames()` to avoid being affected by upstream allocation order.