### PR TITLE
ant: return CAR and CSR violations to repair_antennas

### DIFF
--- a/src/ant/include/ant/AntennaChecker.hh
+++ b/src/ant/include/ant/AntennaChecker.hh
@@ -123,6 +123,8 @@ using GraphNodes = std::vector<GraphNode*>;
 using LayerToGraphNodes = std::unordered_map<odb::dbTechLayer*, GraphNodes>;
 using GateToLayerToNodeInfo = std::map<std::string, LayerToNodeInfo>;
 using Violations = std::vector<Violation>;
+using GateToViolationLayers
+    = std::unordered_map<std::string, std::unordered_set<odb::dbTechLayer*>>;
 
 class AntennaChecker
 {
@@ -177,6 +179,16 @@ class AntennaChecker
                       GateToLayerToNodeInfo& gate_info);
   void calculatePAR(GateToLayerToNodeInfo& gate_info);
   void calculateCAR(GateToLayerToNodeInfo& gate_info);
+  bool checkRatioViolations(odb::dbTechLayer* layer,
+                            const NodeInfo& node_info,
+                            bool verbose,
+                            bool report,
+                            std::ofstream& report_file);
+  void reportNet(odb::dbNet* db_net,
+                 GateToLayerToNodeInfo& gate_info,
+                 GateToViolationLayers& gates_with_violations,
+                 bool verbose,
+                 std::ofstream& report_file);
   int checkGates(odb::dbNet* db_net,
                  bool verbose,
                  bool report_if_no_violation,

--- a/src/ant/include/ant/AntennaChecker.hh
+++ b/src/ant/include/ant/AntennaChecker.hh
@@ -160,9 +160,7 @@ class AntennaChecker
   std::vector<std::pair<double, std::vector<odb::dbITerm*>>>
   getViolatedWireLength(odb::dbNet* net, int routing_level);
   bool isValidGate(odb::dbMTerm* mterm);
-  void buildLayerMaps(odb::dbNet* net,
-                      LayerToGraphNodes& node_by_layer_map,
-                      GateToLayerToNodeInfo& gate_info);
+  void buildLayerMaps(odb::dbNet* net, LayerToGraphNodes& node_by_layer_map);
   void checkNet(odb::dbNet* net,
                 bool verbose,
                 bool report_if_no_violation,

--- a/src/ant/test/ant_check.ok
+++ b/src/ant/test/ant_check.ok
@@ -15,10 +15,10 @@ Net: net50
     Layer: met1
       Partial area ratio:    0.45
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    2.21
-      Required ratio:   10.00 (Side area) 
       Cumulative area ratio:    0.45
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    2.21
+      Required ratio:   10.00 (Side area) 
       Cumulative area ratio:    2.21
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -31,10 +31,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   42.07
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  209.46
-      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:   42.52
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  209.46
+      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:  211.67
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -47,10 +47,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   11.70
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   43.22
-      Required ratio:   15.15 (Side area) (VIOLATED)
       Cumulative area ratio:   54.21
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   43.22
+      Required ratio:   15.15 (Side area) (VIOLATED)
       Cumulative area ratio:  254.89
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -65,10 +65,10 @@ Net: net50
     Layer: met1
       Partial area ratio:   55.12
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  275.20
-      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:   55.12
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  275.20
+      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:  275.20
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -81,10 +81,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   42.07
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  209.46
-      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:   97.18
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  209.46
+      Required ratio:   10.00 (Side area) (VIOLATED)
       Cumulative area ratio:  484.66
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -97,10 +97,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   11.70
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   43.22
-      Required ratio:   15.15 (Side area) (VIOLATED)
       Cumulative area ratio:  108.88
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   43.22
+      Required ratio:   15.15 (Side area) (VIOLATED)
       Cumulative area ratio:  527.89
       Required ratio:    0.00 (Cumulative side area) 
 

--- a/src/ant/test/check_api1.ok
+++ b/src/ant/test/check_api1.ok
@@ -13,10 +13,10 @@ Net: net50
     Layer: met1
       Partial area ratio:    0.45
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    2.21
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    0.45
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    2.21
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    2.21
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -29,10 +29,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   14.43
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   70.95
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   14.87
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   70.95
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   73.16
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -45,10 +45,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   40.49
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  218.01
-      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:   55.36
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  218.01
+      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  291.17
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -63,10 +63,10 @@ Net: net50
     Layer: met1
       Partial area ratio:   55.56
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  277.26
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   55.56
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  277.26
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  277.26
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -79,10 +79,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   84.80
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  421.83
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  140.36
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  421.83
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  699.09
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -95,10 +95,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   40.49
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  218.01
-      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  180.85
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  218.01
+      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  917.10
       Required ratio:    0.00 (Cumulative side area) 
 

--- a/src/ant/test/check_drt1.ok
+++ b/src/ant/test/check_drt1.ok
@@ -15,10 +15,10 @@ Net: net50
     Layer: met1
       Partial area ratio:    0.45
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    2.21
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    0.45
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    2.21
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    2.21
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -31,10 +31,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   14.43
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   70.95
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   14.87
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   70.95
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   73.16
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -47,10 +47,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   40.49
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  218.01
-      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:   55.36
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  218.01
+      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  291.17
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -65,10 +65,10 @@ Net: net50
     Layer: met1
       Partial area ratio:   55.56
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  277.26
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   55.56
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  277.26
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  277.26
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -81,10 +81,10 @@ Net: net50
     Layer: met2
       Partial area ratio:   84.80
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  421.83
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  140.36
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  421.83
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  699.09
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -97,10 +97,10 @@ Net: net50
     Layer: met3
       Partial area ratio:   40.49
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  218.01
-      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  180.85
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  218.01
+      Required ratio: 2878.88 (Side area) 
       Cumulative area ratio:  917.10
       Required ratio:    0.00 (Cumulative side area) 
 

--- a/src/ant/test/check_grt1.ok
+++ b/src/ant/test/check_grt1.ok
@@ -16,10 +16,10 @@ Net: clk
     Layer: met1
       Partial area ratio:   21.35
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  105.92
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   21.35
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  105.92
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  105.92
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -32,10 +32,10 @@ Net: clk
     Layer: met2
       Partial area ratio:   90.34
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  451.63
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  111.69
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  451.63
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  557.55
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -52,10 +52,10 @@ Net: req_msg[11]
     Layer: met1
       Partial area ratio:    2.51
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   11.69
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    2.51
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   11.69
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   11.69
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -68,10 +68,10 @@ Net: req_msg[11]
     Layer: met2
       Partial area ratio:   23.70
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  117.69
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   26.21
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  117.69
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  129.38
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -84,10 +84,10 @@ Net: req_msg[11]
     Layer: met3
       Partial area ratio:  256.65
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio: 1370.92
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  282.85
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio: 1370.92
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio: 1500.30
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -104,10 +104,10 @@ Net: req_msg[14]
     Layer: met1
       Partial area ratio:    4.94
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   23.84
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    4.94
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   23.84
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   23.84
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -120,10 +120,10 @@ Net: req_msg[14]
     Layer: met2
       Partial area ratio:    5.54
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   26.88
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   10.48
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   26.88
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   50.72
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -136,10 +136,10 @@ Net: req_msg[14]
     Layer: met3
       Partial area ratio:  179.00
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  956.79
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  189.47
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  956.79
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio: 1007.52
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -156,10 +156,10 @@ Net: req_msg[15]
     Layer: met1
       Partial area ratio:    3.32
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   15.78
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    3.32
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   15.78
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   15.78
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -172,10 +172,10 @@ Net: req_msg[15]
     Layer: met2
       Partial area ratio:    0.84
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    3.88
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    4.16
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    3.88
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   19.65
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -188,10 +188,10 @@ Net: req_msg[15]
     Layer: met3
       Partial area ratio:  194.48
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio: 1039.39
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  198.65
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio: 1039.39
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio: 1059.04
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -208,10 +208,10 @@ Net: req_msg[23]
     Layer: met1
       Partial area ratio:    1.41
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    6.40
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    1.41
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    6.40
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    6.40
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -224,10 +224,10 @@ Net: req_msg[23]
     Layer: met2
       Partial area ratio:    8.02
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   39.45
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    9.43
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   39.45
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   45.85
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -240,10 +240,10 @@ Net: req_msg[23]
     Layer: met3
       Partial area ratio:  172.51
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  921.78
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  181.95
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  921.78
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  967.63
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -260,10 +260,10 @@ Net: req_msg[25]
     Layer: met1
       Partial area ratio:    1.89
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    8.81
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    1.89
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    8.81
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    8.81
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -276,10 +276,10 @@ Net: req_msg[25]
     Layer: met2
       Partial area ratio:   65.83
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  328.49
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   67.72
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  328.49
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  337.29
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -292,10 +292,10 @@ Net: req_msg[25]
     Layer: met3
       Partial area ratio:  203.80
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio: 1088.66
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  271.53
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio: 1088.66
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio: 1425.95
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -312,10 +312,10 @@ Net: req_msg[28]
     Layer: met1
       Partial area ratio:    1.86
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:    8.96
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    1.86
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:    8.96
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    8.96
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -328,10 +328,10 @@ Net: req_msg[28]
     Layer: met2
       Partial area ratio:   25.82
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  128.40
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   27.68
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  128.40
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  137.35
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -344,10 +344,10 @@ Net: req_msg[28]
     Layer: met3
       Partial area ratio:  174.15
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  930.49
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  201.83
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  930.49
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio: 1067.85
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -364,10 +364,10 @@ Net: req_msg[31]
     Layer: met1
       Partial area ratio:    2.95
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   14.08
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    2.95
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   14.08
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   14.08
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -380,10 +380,10 @@ Net: req_msg[31]
     Layer: met2
       Partial area ratio:   11.63
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   57.52
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   14.58
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   57.52
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   71.59
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -396,10 +396,10 @@ Net: req_msg[31]
     Layer: met3
       Partial area ratio:  110.73
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  592.26
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  125.31
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  592.26
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  663.85
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -416,10 +416,10 @@ Net: resp_msg[11]
     Layer: met1
       Partial area ratio:  114.14
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  569.66
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  114.14
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  569.66
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  569.66
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -432,10 +432,10 @@ Net: resp_msg[11]
     Layer: met2
       Partial area ratio:   83.66
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  417.76
-      Required ratio: 3513.92 (Side area) 
       Cumulative area ratio:  197.80
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  417.76
+      Required ratio: 3513.92 (Side area) 
       Cumulative area ratio:  987.42
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -452,10 +452,10 @@ Net: resp_rdy
     Layer: met1
       Partial area ratio:    2.17
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:   10.19
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:    2.17
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:   10.19
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   10.19
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -468,10 +468,10 @@ Net: resp_rdy
     Layer: met2
       Partial area ratio:   22.47
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  111.71
-      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:   24.64
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  111.71
+      Required ratio:  400.00 (Side area) 
       Cumulative area ratio:  121.90
       Required ratio:    0.00 (Cumulative side area) 
 
@@ -484,10 +484,10 @@ Net: resp_rdy
     Layer: met3
       Partial area ratio:   95.27
       Required ratio:    0.00 (Gate area) 
-      Partial area ratio:  509.79
-      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  119.91
       Required ratio:    0.00 (Cumulative area) 
+      Partial area ratio:  509.79
+      Required ratio:  400.00 (Side area) (VIOLATED)
       Cumulative area ratio:  631.69
       Required ratio:    0.00 (Cumulative side area) 
 


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1981

This is an initial implementation, as mentioned in a comment in the code. Using this naive approach, we can reduce the number of nets with violations from 81 to 55 in ihp-sg13g2/riscv32i.