### PR TITLE
Initial placement-aware scan stitching

### DIFF
--- a/src/dft/README.md
+++ b/src/dft/README.md
@@ -45,11 +45,21 @@ Prints the current DFT configuration to be used by `preview_dft` and
 report_dft_config
 ```
 
+### Scan replace
+
+Replaces flipflops with equivalent scan flipflops. This will generally be called before
+placement, as it changes the area of cells.
+
+```tcl
+scan_replace
+```
+
 ### Preview DFT
 
 Prints a preview of the scan chains that will be stitched by `insert_dft`. Use
-this command to iterate and try different DFT configurations. This command do
-not perform any modification to the design.
+this command to iterate and try different DFT configurations. This command does
+not perform any modification to the design, and should be run after `scan_replace`
+and global placement.
 
 ```tcl
 preview_dft
@@ -64,19 +74,13 @@ preview_dft
 
 ### Insert DFT
 
-Implements the scan chains into the design by performing the following actions:
-
-1. Scan Replace.
-2. Scan Architect.
-3. Scan Stitch.
-
-The end result will be a design with scan flops connected to form the scan
-chains.
-
+Architect scan chains and connect them up in a way that minimises wirelength. As a result, this
+should be run after placement, and after `scan_replace`.
 
 ```tcl
 insert_dft
 ```
+
 
 ## Example scripts
 
@@ -86,6 +90,8 @@ scan flops in the scan chains.
 ```
 set_dft_config -max_length 10 -clock_mixing clock_mix
 report_dft_config
+scan_replace
+# Run global placement...
 preview_dft -verbose
 insert_dft
 ```

--- a/src/dft/include/dft/Dft.hh
+++ b/src/dft/include/dft/Dft.hh
@@ -84,7 +84,7 @@ class Dft
   //
   // If verbose is true, then we show all the cells that are inside the scan
   // chains
-  void preview_dft(bool verbose);
+  void previewDft(bool verbose);
 
   // Inserts the scan chains into the design. For now this just replace the
   // cells in the design with scan equivalent. This functions mutates the
@@ -92,11 +92,10 @@ class Dft
   //
   // Here we do:
   //  - Scan Replace
-  //  - Scan Architect
   //
-  // TODO (and not implemented yet)
-  // - scan stitching
-  void insert_dft();
+  void scanReplace();
+
+  void insertDft();
 
   // Returns a mutable version of DftConfig
   DftConfig* getMutableDftConfig();
@@ -116,7 +115,7 @@ class Dft
 
   // Common function to perform scan replace and scan architect. Shared between
   // preview_dft and insert_dft
-  std::vector<std::unique_ptr<ScanChain>> replaceAndArchitect();
+  std::vector<std::unique_ptr<ScanChain>> scanArchitect();
 
   // Global state
   odb::dbDatabase* db_;

--- a/src/dft/src/architect/CMakeLists.txt
+++ b/src/dft/src/architect/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(dft_architect_lib
   # Keep sorted
+  Opt.cpp
   ScanArchitect.cpp
   ScanArchitectHeuristic.cpp
   ScanChain.cpp

--- a/src/dft/src/architect/Opt.cpp
+++ b/src/dft/src/architect/Opt.cpp
@@ -1,0 +1,119 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (c) 2024, Myrtle Shah
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "Opt.hh"
+
+#include <boost/geometry.hpp>
+#include <boost/geometry/geometries/register/point.hpp>
+#include <boost/geometry/index/rtree.hpp>
+#include <iostream>
+
+#include "ClockDomain.hh"
+
+namespace bg = boost::geometry;
+namespace bgi = boost::geometry::index;
+
+namespace dft {
+
+namespace {
+// Max number of cells we assume could be placed at the same point (hopefully,
+// after DP, this is never more than one)
+constexpr int kMaxCellsToSearch = 10;
+}  // namespace
+
+void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
+                            utl::Logger* logger)
+{
+  // Nothing to order
+  if (cells.empty()) {
+    return;
+  }
+  // No point running this if the cells aren't placed yet
+  for (const auto& cell : cells) {
+    if (!cell->isPlaced()) {
+      return;
+    }
+  }
+  // Define the starting node as the lower leftmost, so we don't accidentally
+  // start somewhere in the middle
+  size_t start_index = 0;
+  int64_t lowest_dist = std::numeric_limits<int64_t>::max();
+  // Get points in a form ready to insert into index
+  typedef bg::model::point<int, 2, bg::cs::cartesian> bg_point;
+  std::vector<std::pair<bg_point, size_t>> transformed;
+
+  for (size_t i = 0; i < cells.size(); i++) {
+    // Find the lower leftmost cell by looking for the cell with the lowest
+    // manhattan distance to the origin
+    auto origin = cells[i]->getOrigin();
+    const int64_t dist = origin.x() + origin.y();
+    if (dist < lowest_dist) {
+      start_index = i;
+      lowest_dist = dist;
+    }
+    // Add the point to the set of points
+    transformed.emplace_back(bg_point(origin.x(), origin.y()), i);
+  }
+  // Update the index
+  bgi::rtree<std::pair<bg_point, size_t>, bgi::rstar<4>> rtree(transformed);
+  auto cursor = transformed[start_index];
+
+  // Search nearest neighbours
+  std::vector<std::unique_ptr<ScanCell>> result;
+  result.emplace_back(std::move(cells[cursor.second]));
+  while (result.size() < cells.size()) {
+    // Search for next nearest
+    auto next = cursor;
+    for (auto it = rtree.qbegin(bgi::nearest(cursor.first, kMaxCellsToSearch));
+         it != rtree.qend();
+         ++it) {
+      next = *it;
+      if (next.second != cursor.second) {
+        break;
+      }
+    }
+    if (next.second == cursor.second) {
+      logger->error(
+          utl::DFT,
+          10,
+          "Couldn't find nearest neighbor, too many overlapping cells");
+    }
+    // Make sure we only visit things once
+    rtree.remove(cursor);
+    cursor = next;
+    result.emplace_back(std::move(cells[cursor.second]));
+  }
+  // Replace with sorted vector
+  std::swap(cells, result);
+}
+
+}  // namespace dft

--- a/src/dft/src/architect/Opt.hh
+++ b/src/dft/src/architect/Opt.hh
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Google LLC
+// Copyright (c) 2024, Myrtle Shah
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -31,43 +31,13 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "ScanCell.hh"
-#include "ScanPin.hh"
-#include "db_sta/dbNetwork.hh"
-#include "odb/db.h"
-#include "sta/Liberty.hh"
+#include "ScanArchitect.hh"
+#include "utl/Logger.h"
 
 namespace dft {
 
-// A simple single cell with just one bit. Usually one scan FF
-class OneBitScanCell : public ScanCell
-{
- public:
-  OneBitScanCell(const std::string& name,
-                 std::unique_ptr<ClockDomain> clock_domain,
-                 odb::dbInst* inst,
-                 sta::TestCell* test_cell,
-                 sta::dbNetwork* db_network,
-                 utl::Logger* logger);
-  // Not copyable or movable
-  OneBitScanCell(const OneBitScanCell&) = delete;
-  OneBitScanCell& operator=(const OneBitScanCell&) = delete;
-
-  uint64_t getBits() const override;
-  void connectScanEnable(const ScanDriver& driver) const override;
-  void connectScanIn(const ScanDriver& driver) const override;
-  void connectScanOut(const ScanLoad& load) const override;
-  ScanDriver getScanOut() const override;
-
-  odb::Point getOrigin() const override;
-  bool isPlaced() const override;
-
- private:
-  odb::dbITerm* findITerm(sta::LibertyPort* liberty_port) const;
-
-  odb::dbInst* inst_;
-  sta::TestCell* test_cell_;
-  sta::dbNetwork* db_network_;
-};
+// Order scan cells to reduce wirelength
+void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
+                            utl::Logger* logger);
 
 }  // namespace dft

--- a/src/dft/src/architect/ScanArchitect.cpp
+++ b/src/dft/src/architect/ScanArchitect.cpp
@@ -111,10 +111,11 @@ uint64_t ScanCellsBucket::numberOfCells(size_t hash_domain) const
 
 std::unique_ptr<ScanArchitect> ScanArchitect::ConstructScanScanArchitect(
     const ScanArchitectConfig& config,
-    std::unique_ptr<ScanCellsBucket> scan_cells_bucket)
+    std::unique_ptr<ScanCellsBucket> scan_cells_bucket,
+    utl::Logger* logger_)
 {
-  return std::make_unique<ScanArchitectHeuristic>(config,
-                                                  std::move(scan_cells_bucket));
+  return std::make_unique<ScanArchitectHeuristic>(
+      config, std::move(scan_cells_bucket), logger_);
 }
 
 ScanArchitect::ScanArchitect(const ScanArchitectConfig& config,

--- a/src/dft/src/architect/ScanArchitect.hh
+++ b/src/dft/src/architect/ScanArchitect.hh
@@ -39,6 +39,7 @@
 #include "ScanArchitectConfig.hh"
 #include "ScanCell.hh"
 #include "ScanChain.hh"
+#include "utl/Logger.h"
 
 namespace dft {
 
@@ -112,7 +113,8 @@ class ScanArchitect
   // since some of them could generate better scan chains for some designs
   static std::unique_ptr<ScanArchitect> ConstructScanScanArchitect(
       const ScanArchitectConfig& config,
-      std::unique_ptr<ScanCellsBucket> scan_cells_bucket);
+      std::unique_ptr<ScanCellsBucket> scan_cells_bucket,
+      utl::Logger* logger);
 
  protected:
   void createScanChains();

--- a/src/dft/src/architect/ScanArchitectHeuristic.hh
+++ b/src/dft/src/architect/ScanArchitectHeuristic.hh
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "ScanArchitect.hh"
+#include "utl/Logger.h"
 
 namespace dft {
 
@@ -42,13 +43,18 @@ class ScanArchitectHeuristic : public ScanArchitect
 {
  public:
   ScanArchitectHeuristic(const ScanArchitectConfig& config,
-                         std::unique_ptr<ScanCellsBucket> scan_cells_bucket);
+                         std::unique_ptr<ScanCellsBucket> scan_cells_bucket,
+                         utl::Logger* logger);
   // Not copyable or movable
   ScanArchitectHeuristic(const ScanArchitectHeuristic&) = delete;
   ScanArchitectHeuristic& operator=(const ScanArchitectHeuristic&) = delete;
   ~ScanArchitectHeuristic() override = default;
 
   void architect() override;
+
+  utl::Logger* logger_;
+
+ private:
 };
 
 }  // namespace dft

--- a/src/dft/src/cells/OneBitScanCell.cpp
+++ b/src/dft/src/cells/OneBitScanCell.cpp
@@ -88,4 +88,14 @@ odb::dbITerm* OneBitScanCell::findITerm(sta::LibertyPort* liberty_port) const
   return inst_->getITerm(mterm);
 }
 
+odb::Point OneBitScanCell::getOrigin() const
+{
+  return inst_->getOrigin();
+}
+
+bool OneBitScanCell::isPlaced() const
+{
+  return inst_->isPlaced();
+}
+
 }  // namespace dft

--- a/src/dft/src/cells/ScanCell.hh
+++ b/src/dft/src/cells/ScanCell.hh
@@ -69,6 +69,9 @@ class ScanCell
   const ClockDomain& getClockDomain() const;
   std::string_view getName() const;
 
+  virtual odb::Point getOrigin() const = 0;
+  virtual bool isPlaced() const = 0;
+
  private:
   std::string name_;
   std::unique_ptr<ClockDomain> clock_domain_;

--- a/src/dft/src/dft.i
+++ b/src/dft/src/dft.i
@@ -56,12 +56,18 @@ utl::Logger* getLogger()
 
 void preview_dft(bool verbose)
 {
-  getDft()->preview_dft(verbose);
+  getDft()->previewDft(verbose);
 }
+
+void scan_replace()
+{
+  getDft()->scanReplace();
+}
+
 
 void insert_dft()
 {
-  getDft()->insert_dft();
+  getDft()->insertDft();
 }
 
 void set_dft_config_max_length(int max_length)

--- a/src/dft/src/dft.tcl
+++ b/src/dft/src/dft.tcl
@@ -47,17 +47,27 @@ proc preview_dft { args } {
   dft::preview_dft $verbose
 }
 
+sta::define_cmd_args "scan_replace" { }
+proc scan_replace { args } {
+  sta::parse_key_args "scan_replace" args \
+    keys {} flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error DFT 8 "No design block found."
+  }
+  dft::scan_replace
+}
+
 sta::define_cmd_args "insert_dft" { }
 proc insert_dft { args } {
   sta::parse_key_args "insert_dft" args \
     keys {} flags {}
 
   if { [ord::get_db_block] == "NULL" } {
-    utl::error DFT 8 "No design block found."
+    utl::error DFT 9 "No design block found."
   }
   dft::insert_dft
 }
-
 
 sta::define_cmd_args "set_dft_config" { [-max_length max_length] \
                                         [-clock_mixing clock_mixing]}

--- a/src/dft/test/CMakeLists.txt
+++ b/src/dft/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_NAMES
   sub_modules_sky130
   scan_architect_no_mix_sky130
   scan_architect_clock_mix_sky130
+  place_sort_sky130
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)

--- a/src/dft/test/cpp/ScanCellMock.cpp
+++ b/src/dft/test/cpp/ScanCellMock.cpp
@@ -34,5 +34,15 @@ ScanDriver ScanCellMock::getScanOut() const
   return ScanDriver(static_cast<odb::dbBTerm*>(nullptr));
 }
 
+odb::Point ScanCellMock::getOrigin() const
+{
+  return odb::Point();
+}
+
+bool ScanCellMock::isPlaced() const
+{
+  return false;
+}
+
 }  // namespace test
 }  // namespace dft

--- a/src/dft/test/cpp/ScanCellMock.hh
+++ b/src/dft/test/cpp/ScanCellMock.hh
@@ -17,6 +17,8 @@ class ScanCellMock : public ScanCell
   void connectScanIn(const ScanDriver& pin) const override;
   void connectScanOut(const ScanLoad& pin) const override;
   ScanDriver getScanOut() const override;
+  odb::Point getOrigin() const override;
+  bool isPlaced() const override;
 };
 
 }  // namespace test

--- a/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
+++ b/src/dft/test/cpp/TestScanArchitectHeuristic.cpp
@@ -35,8 +35,8 @@ TEST(TestScanArchitectHeuristic, ArchitectWithOneClockDomainNoMix)
   scan_cells_bucket->init(config, scan_cells);
 
   std::unique_ptr<ScanArchitect> scan_architect
-      = ScanArchitect::ConstructScanScanArchitect(config,
-                                                  std::move(scan_cells_bucket));
+      = ScanArchitect::ConstructScanScanArchitect(
+          config, std::move(scan_cells_bucket), logger);
   scan_architect->init();
   scan_architect->architect();
   std::vector<std::unique_ptr<ScanChain>> scan_chains
@@ -99,8 +99,8 @@ TEST(TestScanArchitectHeuristic, ArchitectWithTwoClockDomainNoMix)
   scan_cells_bucket->init(config, scan_cells);
 
   std::unique_ptr<ScanArchitect> scan_architect
-      = ScanArchitect::ConstructScanScanArchitect(config,
-                                                  std::move(scan_cells_bucket));
+      = ScanArchitect::ConstructScanScanArchitect(
+          config, std::move(scan_cells_bucket), logger);
   scan_architect->init();
   scan_architect->architect();
   std::vector<std::unique_ptr<ScanChain>> scan_chains
@@ -156,8 +156,8 @@ TEST(TestScanArchitectHeuristic, ArchitectWithTwoEdgesNoMix)
   scan_cells_bucket->init(config, scan_cells);
 
   std::unique_ptr<ScanArchitect> scan_architect
-      = ScanArchitect::ConstructScanScanArchitect(config,
-                                                  std::move(scan_cells_bucket));
+      = ScanArchitect::ConstructScanScanArchitect(
+          config, std::move(scan_cells_bucket), logger);
   scan_architect->init();
   scan_architect->architect();
   std::vector<std::unique_ptr<ScanChain>> scan_chains

--- a/src/dft/test/one_cell_nangate45.tcl
+++ b/src/dft/test/one_cell_nangate45.tcl
@@ -28,6 +28,7 @@ foreach lib_file $fake_macro_lib {
 read_verilog one_cell_nangate45.v
 link_design one_cell
 
+scan_replace
 insert_dft
 
 set verilog_file [make_result_file one_cell_nandgate45.v]

--- a/src/dft/test/one_cell_sky130.ok
+++ b/src/dft/test/one_cell_sky130.ok
@@ -10,6 +10,19 @@ Instance ff1
   CLK input clock
  Output pins:
   Q output output1
+Instance ff1
+ Cell: sky130_fd_sc_hd__sdfsbp_1
+ Library: sky130_fd_sc_hd_merged
+ Path cells: sky130_fd_sc_hd__sdfsbp_1
+ Input pins:
+  D input port1
+  SCD input (unconnected)
+  SCE input (unconnected)
+  SET_B input set_b
+  CLK input clock
+ Output pins:
+  Q output output1
+  Q_N output (unconnected)
 ***************************
 Preview DFT Report
 Number of chains: 1
@@ -22,15 +35,18 @@ Scan chain 'chain_0' has 1 cells (1 bits)
 
 
 Instance ff1
- Cell: sky130_fd_sc_hd__dfstp_1
+ Cell: sky130_fd_sc_hd__sdfsbp_1
  Library: sky130_fd_sc_hd_merged
- Path cells: sky130_fd_sc_hd__dfstp_1
+ Path cells: sky130_fd_sc_hd__sdfsbp_1
  Input pins:
   D input port1
+  SCD input (unconnected)
+  SCE input (unconnected)
   SET_B input set_b
   CLK input clock
  Output pins:
   Q output output1
+  Q_N output (unconnected)
 Instance ff1
  Cell: sky130_fd_sc_hd__sdfsbp_1
  Library: sky130_fd_sc_hd_merged

--- a/src/dft/test/one_cell_sky130.tcl
+++ b/src/dft/test/one_cell_sky130.tcl
@@ -12,6 +12,8 @@ create_clock -name main_clock -period 2.0000 -waveform {0.0000 1.0000} [get_port
 set_dft_config -max_length 10
 
 report_instance ff1
+scan_replace
+report_instance ff1
 preview_dft -verbose
 report_instance ff1
 insert_dft

--- a/src/dft/test/place_sort_sky130.ok
+++ b/src/dft/test/place_sort_sky130.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+***************************
+Preview DFT Report
+Number of chains: 1
+Clock domain: No Mix
+***************************
+
+Scan chain 'chain_0' has 10 cells (10 bits)
+
+  ff5_clk1_rising (main_clock, rising)
+  ff1_clk1_rising
+  ff10_clk1_rising
+  ff8_clk1_rising
+  ff2_clk1_rising
+  ff6_clk1_rising
+  ff7_clk1_rising
+  ff9_clk1_rising
+  ff4_clk1_rising
+  ff3_clk1_rising
+
+
+No differences found.

--- a/src/dft/test/place_sort_sky130.tcl
+++ b/src/dft/test/place_sort_sky130.tcl
@@ -1,0 +1,32 @@
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_liberty sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib
+
+read_verilog place_sort_sky130.v
+link_design place_sort
+
+create_clock -name main_clock -period 2.0000 -waveform {0.0000 1.0000} [get_ports {clock}]
+
+set_dft_config -max_length 10
+
+scan_replace
+
+place_inst ff1_clk1_rising  1000 2000
+place_inst ff2_clk1_rising  5000 6000
+place_inst ff3_clk1_rising  9500 9000
+place_inst ff4_clk1_rising  9000 9000
+place_inst ff5_clk1_rising  1000 1000
+place_inst ff6_clk1_rising  7000 7000
+place_inst ff7_clk1_rising  7500 7000
+place_inst ff8_clk1_rising  4000 3000
+place_inst ff9_clk1_rising  8000 8000
+place_inst ff10_clk1_rising 3000 3000
+
+preview_dft -verbose
+insert_dft
+
+set verilog_file [make_result_file place_sort_sky130.v]
+write_verilog $verilog_file
+diff_files $verilog_file place_sort_sky130.vok

--- a/src/dft/test/place_sort_sky130.v
+++ b/src/dft/test/place_sort_sky130.v
@@ -1,0 +1,100 @@
+module place_sort(port1,
+  clock,
+  set_b,
+  output1,
+  output2,
+  output3,
+  output4,
+  output5,
+  output6,
+  output7,
+  output8,
+  output9,
+  output10);
+  input port1;
+  input clock;
+  input set_b;
+  output output1;
+  output output2;
+  output output3;
+  output output4;
+  output output5;
+  output output6;
+  output output7;
+  output output8;
+  output output9;
+  output output10;
+
+
+  // Rising edge flops
+  sky130_fd_sc_hd__dfstp_1 ff1_clk1_rising(
+    .Q(output1),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff2_clk1_rising(
+    .Q(output2),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff3_clk1_rising(
+    .Q(output3),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff4_clk1_rising(
+    .Q(output4),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff5_clk1_rising(
+    .Q(output5),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff6_clk1_rising(
+    .Q(output6),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+  sky130_fd_sc_hd__dfstp_1 ff7_clk1_rising(
+    .Q(output7),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff8_clk1_rising(
+    .Q(output8),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff9_clk1_rising(
+    .Q(output9),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff10_clk1_rising(
+    .Q(output10),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+
+endmodule

--- a/src/dft/test/place_sort_sky130.vok
+++ b/src/dft/test/place_sort_sky130.vok
@@ -1,0 +1,93 @@
+module place_sort (clock,
+    output1,
+    output10,
+    output2,
+    output3,
+    output4,
+    output5,
+    output6,
+    output7,
+    output8,
+    output9,
+    port1,
+    set_b,
+    scan_enable_1,
+    scan_in_1);
+ input clock;
+ output output1;
+ output output10;
+ output output2;
+ output output3;
+ output output4;
+ output output5;
+ output output6;
+ output output7;
+ output output8;
+ output output9;
+ input port1;
+ input set_b;
+ input scan_enable_1;
+ input scan_in_1;
+
+
+ sky130_fd_sc_hd__sdfsbp_1 ff1_clk1_rising (.D(port1),
+    .Q(output1),
+    .SCD(output5),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff2_clk1_rising (.D(port1),
+    .Q(output2),
+    .SCD(output8),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff3_clk1_rising (.D(port1),
+    .Q(output3),
+    .SCD(output4),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff4_clk1_rising (.D(port1),
+    .Q(output4),
+    .SCD(output9),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff5_clk1_rising (.D(port1),
+    .Q(output5),
+    .SCD(scan_in_1),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff6_clk1_rising (.D(port1),
+    .Q(output6),
+    .SCD(output2),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff7_clk1_rising (.D(port1),
+    .Q(output7),
+    .SCD(output6),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff8_clk1_rising (.D(port1),
+    .Q(output8),
+    .SCD(output10),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff9_clk1_rising (.D(port1),
+    .Q(output9),
+    .SCD(output7),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff10_clk1_rising (.D(port1),
+    .Q(output10),
+    .SCD(output1),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+endmodule

--- a/src/dft/test/scan_architect_clock_mix_sky130.tcl
+++ b/src/dft/test/scan_architect_clock_mix_sky130.tcl
@@ -12,6 +12,7 @@ create_clock -name clock2 -period 2.0000 -waveform {0.0000 1.0000} [get_ports {c
 
 set_dft_config -max_length 3 -clock_mixing clock_mix
 
+scan_replace
 
 set verilog_file_before_preview [make_result_file scan_architect_clock_mix_sky130_before_preview.v]
 write_verilog -sort $verilog_file_before_preview

--- a/src/dft/test/scan_architect_clock_mix_sky130.vok
+++ b/src/dft/test/scan_architect_clock_mix_sky130.vok
@@ -64,6 +64,18 @@ module scan_architect (clock1,
  input scan_in_7;
 
 
+ sky130_fd_sc_hd__sdfsbp_1 ff10_clk2_rising (.D(port1),
+    .Q(output10),
+    .SCD(output14),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock2));
+ sky130_fd_sc_hd__sdfbbn_1 ff1_clk1_falling (.D(port1),
+    .Q(output11),
+    .SCD(scan_in_4),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK_N(clock1));
  sky130_fd_sc_hd__sdfsbp_1 ff1_clk1_rising (.D(port1),
     .Q(output1),
     .SCD(scan_in_7),
@@ -172,16 +184,4 @@ module scan_architect (clock1,
     .SCE(scan_enable_1),
     .SET_B(set_b),
     .CLK_N(clock2));
- sky130_fd_sc_hd__sdfsbp_1 ff10_clk2_rising (.D(port1),
-    .Q(output10),
-    .SCD(output14),
-    .SCE(scan_enable_1),
-    .SET_B(set_b),
-    .CLK(clock2));
- sky130_fd_sc_hd__sdfbbn_1 ff1_clk1_falling (.D(port1),
-    .Q(output11),
-    .SCD(scan_in_4),
-    .SCE(scan_enable_1),
-    .SET_B(set_b),
-    .CLK_N(clock1));
 endmodule

--- a/src/dft/test/scan_architect_no_mix_sky130.tcl
+++ b/src/dft/test/scan_architect_no_mix_sky130.tcl
@@ -12,6 +12,7 @@ create_clock -name clock2 -period 2.0000 -waveform {0.0000 1.0000} [get_ports {c
 
 set_dft_config -max_length 5
 
+scan_replace
 
 set verilog_file_before_preview [make_result_file scan_architect_no_mix_sky130_before_preview.v]
 write_verilog -sort $verilog_file_before_preview

--- a/src/dft/test/scan_architect_no_mix_sky130.vok
+++ b/src/dft/test/scan_architect_no_mix_sky130.vok
@@ -58,6 +58,18 @@ module scan_architect (clock1,
  input scan_in_4;
 
 
+ sky130_fd_sc_hd__sdfsbp_1 ff10_clk2_rising (.D(port1),
+    .Q(output10),
+    .SCD(output2),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock2));
+ sky130_fd_sc_hd__sdfbbn_1 ff1_clk1_falling (.D(port1),
+    .Q(output11),
+    .SCD(output13),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK_N(clock1));
  sky130_fd_sc_hd__sdfsbp_1 ff1_clk1_rising (.D(port1),
     .Q(output1),
     .SCD(output3),
@@ -166,16 +178,4 @@ module scan_architect (clock1,
     .SCE(scan_enable_1),
     .SET_B(set_b),
     .CLK_N(clock2));
- sky130_fd_sc_hd__sdfsbp_1 ff10_clk2_rising (.D(port1),
-    .Q(output10),
-    .SCD(output2),
-    .SCE(scan_enable_1),
-    .SET_B(set_b),
-    .CLK(clock2));
- sky130_fd_sc_hd__sdfbbn_1 ff1_clk1_falling (.D(port1),
-    .Q(output11),
-    .SCD(output13),
-    .SCE(scan_enable_1),
-    .SET_B(set_b),
-    .CLK_N(clock1));
 endmodule

--- a/src/dft/test/sub_modules_sky130.tcl
+++ b/src/dft/test/sub_modules_sky130.tcl
@@ -9,6 +9,7 @@ link_design sub_modules
 
 create_clock -name main_clock -period 2.0000 -waveform {0.0000 1.0000} [get_ports {clock}]
 
+scan_replace
 preview_dft -verbose
 insert_dft
 


### PR DESCRIPTION
This isn't quite complete as I haven't updated tests yet, but I'd appreciate feedback on the direction here before I do that.

This PR makes two changes to the DFT code:
 
 - `insert_dft` is now only performing scan cell replacement, a new command `connect_dft` is used to perform scan architect and stitch. This is because replacement needs to be done before placement (as it affects cell areas) but stitching needs to be done after placement (where it can use placement information to minimise scan wirelength)
 - A basic wirelength minimising sort is used on the scan chain before stitching. This is a simple greedy nearest neighbour approach using Boost rtrees - I also briefly explored using the or-tools TSP solver a bit but all the modes I tried were considerably too slow (and the only way to improve this seemed to be by setting a timeout, which is obviously a no-go due to nondeterminism).

After this PR, I plan to work on the scan chain connectivity, so it's easier to create scan ports ahead of time or connect the scan chain to existing signals (like top level IO pad cells, if not using a macro based flow). Any feedback on what might be wanted here is appreciated, too.