### PR TITLE
gui: ensure inst pins are from register insts

### DIFF
--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -55,7 +55,7 @@ class Clock;
 namespace gui {
 #ifdef ENABLE_CHARTS
 
-using ITermBTermPinsLists = std::pair<StaPins, StaPins>;
+using RegisterPinsAndPorts = std::pair<StaPins, StaPins>;
 
 enum StartEndPathType
 {
@@ -144,7 +144,7 @@ class ChartsWidget : public QDockWidget
   void removeUnconstrainedPinsAndSetLimits(StaPins& end_points);
   TimingPathList fetchPathsBasedOnStartEnd(const StartEndPathType path_type);
   StaPins getEndPointsFromPaths(const TimingPathList& paths);
-  ITermBTermPinsLists separatePinsIntoBTermsAndITerms(const StaPins& pins);
+  RegisterPinsAndPorts getRegisterPinsAndPorts(const StaPins& pins);
   void setLimits(const TimingPathList& paths);
 
   void populateBuckets(StaPins* end_points, TimingPathList* paths);


### PR DESCRIPTION
The filter was not excluding instances that are not registers. So we might end displaying data of a path from/to e.g., a buffer.

This should have some impact on performance as the number of total endpoints will be generally smaller. E. g., ngt45/black-parrot:
```
Start Points
	Instance Pins 38501
	Register Pins 38477
End Points
	Instance Pins 111839
	Register Pins 76486