### PR TITLE
mpl2: avoid groupping macros with empty conn signature

### DIFF
--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -555,6 +555,10 @@ bool Cluster::isSameConnSignature(const Cluster& cluster, float net_threshold)
     }
   }
 
+  if (neighbors.empty()) {
+    return false;
+  }
+
   for (auto& [cluster_id, weight] : cluster.connection_map_) {
     if ((cluster_id != id_) && (cluster_id != cluster.id_)
         && (weight >= net_threshold)) {


### PR DESCRIPTION
This is an idea to make it possible for mpl2 to find a valid tiling for the root in cases such as sky130hd/chameleon. For this design, multilevel autoclustering engine generates a cluster with three very big macros that have no connection signature at all. This cluster will be further fine shaped to what we see in the image below .

<img src="https://github.com/The-OpenROAD-Project/OpenROAD/assets/104802710/85d7f2ae-ea25-47d2-a8fb-ba1b7d870cac" width="400">

The existence of this cluster ends up preventing SA from fitting all clusters in the outline later on.