### PR TITLE
scriptWidget: fix rethrowing exception

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -194,8 +194,7 @@ void ScriptWidget::addResultToOutput(const QString& result, bool is_ok)
       logger_->error(utl::GUI, 70, result.toStdString());
     } catch (const std::runtime_error& e) {
       if (!is_interactive_) {
-        // rethrow error
-        throw e;
+        throw;
       }
     }
   }


### PR DESCRIPTION
To rethrow, use `throw;` idiom.