### PR TITLE
GRT: Updated GlobalRouter::computeMaxRoutingLayer

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3644,17 +3644,13 @@ int GlobalRouter::computeMaxRoutingLayer()
 
   odb::dbTech* tech = db_->getTech();
 
-  int valid_layers = 1;
   for (int layer = 1; layer <= tech->getRoutingLayerCount(); layer++) {
-    odb::dbTechLayer* tech_layer = tech->findRoutingLayer(valid_layers);
-    if (tech_layer->getRoutingLevel() != 0) {
-      odb::dbTrackGrid* track_grid = block_->findTrackGrid(tech_layer);
-      if (track_grid == nullptr) {
-        break;
-      }
-      max_routing_layer = valid_layers;
-      valid_layers++;
+    odb::dbTechLayer* tech_layer = tech->findRoutingLayer(layer);
+    odb::dbTrackGrid* track_grid = block_->findTrackGrid(tech_layer);
+    if (track_grid == nullptr) {
+      break;
     }
+    max_routing_layer = layer;
   }
 
   return max_routing_layer;


### PR DESCRIPTION
I was reading the source code and noticed that the condition `if (tech_layer->getRoutingLevel() != 0)` on line 3650 was always evaluating to true, because the `tech_layer` is already a routing layer.
Hence, the variable `valid_layers` is the same as the variable `layer`, that is being iterated in the for loop.
In this PR, the variable `valid_layers` is removed and replaced by `layer` and the if statement `if (tech_layer->getRoutingLevel() != 0)` is removed.