### PR TITLE
rsz: Source `StaTclTypes.i` and clean up the binding

### DIFF
--- a/src/rsz/src/CMakeLists.txt
+++ b/src/rsz/src/CMakeLists.txt
@@ -35,10 +35,20 @@
 
 include("openroad")
 
-swig_lib(NAME      rsz
+swig_lib(NAME      rsz_swig
          NAMESPACE rsz
          I_FILE    Resizer.i
+         SWIG_INCLUDES ${OPENSTA_HOME}
          SCRIPTS   Resizer.tcl
+)
+
+target_include_directories(rsz_swig
+  PUBLIC
+    ../include
+  PRIVATE
+    # A side-effect of including OpenSTA swig files
+    ${OPENSTA_HOME}
+    ${OPENSTA_HOME}/include/sta
 )
 
 add_library(rsz_lib
@@ -56,8 +66,7 @@ add_library(rsz_lib
     OdbCallBack.cc
 )
 
-target_sources(rsz
-  PRIVATE
+add_library(rsz
     MakeResizer.cc
     SteinerRenderer.cc
 )
@@ -82,7 +91,7 @@ target_link_libraries(rsz_lib
     utl_lib
 )
 
-target_link_libraries(rsz
+target_link_libraries(rsz_swig
   PUBLIC
     rsz_lib
     stt
@@ -92,6 +101,20 @@ target_link_libraries(rsz
     grt
     gui
     utl_lib
+)
+
+target_link_libraries(rsz
+  PUBLIC
+    rsz_lib
+    stt
+    odb
+    OpenSTA
+    dbSta
+    grt
+    gui
+    utl
+  PRIVATE
+    rsz_swig
 )
 
 messages(

--- a/src/rsz/src/CMakeLists.txt
+++ b/src/rsz/src/CMakeLists.txt
@@ -35,20 +35,11 @@
 
 include("openroad")
 
-swig_lib(NAME      rsz_swig
+swig_lib(NAME      rsz
          NAMESPACE rsz
          I_FILE    Resizer.i
          SWIG_INCLUDES ${OPENSTA_HOME}
          SCRIPTS   Resizer.tcl
-)
-
-target_include_directories(rsz_swig
-  PUBLIC
-    ../include
-  PRIVATE
-    # A side-effect of including OpenSTA swig files
-    ${OPENSTA_HOME}
-    ${OPENSTA_HOME}/include/sta
 )
 
 add_library(rsz_lib
@@ -66,7 +57,8 @@ add_library(rsz_lib
     OdbCallBack.cc
 )
 
-add_library(rsz
+target_sources(rsz
+  PRIVATE
     MakeResizer.cc
     SteinerRenderer.cc
 )
@@ -74,6 +66,10 @@ add_library(rsz
 target_include_directories(rsz
   PUBLIC
     ../include
+  PRIVATE
+    # A side-effect of including OpenSTA swig files
+    ${OPENSTA_HOME}
+    ${OPENSTA_HOME}/include/sta
 )
 
 target_include_directories(rsz_lib
@@ -91,18 +87,6 @@ target_link_libraries(rsz_lib
     utl_lib
 )
 
-target_link_libraries(rsz_swig
-  PUBLIC
-    rsz_lib
-    stt
-    odb
-    OpenSTA
-    dbSta
-    grt
-    gui
-    utl_lib
-)
-
 target_link_libraries(rsz
   PUBLIC
     rsz_lib
@@ -112,9 +96,7 @@ target_link_libraries(rsz
     dbSta
     grt
     gui
-    utl
-  PRIVATE
-    rsz_swig
+    utl_lib
 )
 
 messages(

--- a/src/rsz/src/MakeResizer.cc
+++ b/src/rsz/src/MakeResizer.cc
@@ -42,11 +42,11 @@
 #include "sta/StaMain.hh"
 
 extern "C" {
-extern int Rsz_Init(Tcl_Interp* interp);
+extern int Rsz_swig_Init(Tcl_Interp* interp);
 }
 
 namespace sta {
-extern const char* rsz_tcl_inits[];
+extern const char* rsz_swig_tcl_inits[];
 }
 
 namespace ord {
@@ -76,9 +76,9 @@ void initResizer(OpenRoad* openroad)
                                openroad->getOpendp(),
                                std::move(steiner_renderer));
   // Define swig TCL commands.
-  Rsz_Init(interp);
+  Rsz_swig_Init(interp);
   // Eval encoded sta TCL sources.
-  sta::evalTclInit(interp, sta::rsz_tcl_inits);
+  sta::evalTclInit(interp, sta::rsz_swig_tcl_inits);
 }
 
 }  // namespace ord

--- a/src/rsz/src/MakeResizer.cc
+++ b/src/rsz/src/MakeResizer.cc
@@ -42,11 +42,11 @@
 #include "sta/StaMain.hh"
 
 extern "C" {
-extern int Rsz_swig_Init(Tcl_Interp* interp);
+extern int Rsz_Init(Tcl_Interp* interp);
 }
 
 namespace sta {
-extern const char* rsz_swig_tcl_inits[];
+extern const char* rsz_tcl_inits[];
 }
 
 namespace ord {
@@ -76,9 +76,9 @@ void initResizer(OpenRoad* openroad)
                                openroad->getOpendp(),
                                std::move(steiner_renderer));
   // Define swig TCL commands.
-  Rsz_swig_Init(interp);
+  Rsz_Init(interp);
   // Eval encoded sta TCL sources.
-  sta::evalTclInit(interp, sta::rsz_swig_tcl_inits);
+  sta::evalTclInit(interp, sta::rsz_tcl_inits);
 }
 
 }  // namespace ord

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -57,6 +57,9 @@ ensureLinked();
 
 namespace sta {
 
+// The aliases are created to attach different conversion rules:
+// TmpNetSeq, TmpPinSet pointers are freed when crossing into Tcl,
+// NetSeq, PinSet pointers are not
 using TmpNetSeq = NetSeq;
 using TmpPinSet = PinSet;
 

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -57,15 +57,7 @@ ensureLinked();
 
 namespace sta {
 
-// Defined in StaTcl.i
-LibertyCellSeq *
-tclListSeqLibertyCell(Tcl_Obj *const source,
-                      Tcl_Interp *interp);
-PinSet *
-tclListSetPin(Tcl_Obj *source,
-              Tcl_Interp *interp);
-
-using TmpNetSeq = NetSeq ;
+using TmpNetSeq = NetSeq;
 using TmpPinSet = PinSet;
 
 } // namespace
@@ -84,8 +76,6 @@ using sta::Pin;
 using sta::PinSet;
 using sta::TmpPinSet;
 using sta::RiseFall;
-using sta::tclListSeqLibertyCell;
-using sta::tclListSetPin;
 using sta::TmpNetSeq;
 using sta::LibertyPort;
 using sta::Delay;

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -43,7 +43,6 @@
 #include "sta/Corner.hh"
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
-#include "sta/Liberty.hh"
 #include "db_sta/dbNetwork.hh"
 
 namespace ord {

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -122,6 +122,9 @@ tclListNetworkSet(Tcl_Obj *const source,
 }
 %}
 
+// OpenSTA swig files
+%include "tcl/StaTclTypes.i"
+
 ////////////////////////////////////////////////////////////////
 //
 // SWIG type definitions.

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -70,6 +70,7 @@ using sta::LibertyCellSeq;
 using sta::LibertyCell;
 using sta::Instance;
 using sta::InstanceSeq;
+using sta::InstanceSet;
 using sta::Net;
 using sta::NetSeq;
 using sta::Pin;
@@ -301,31 +302,17 @@ have_estimated_parasitics()
   return resizer->haveEstimatedParasitics();
 }
 
-InstanceSeq*
-init_insts_cmd()
-{
-  InstanceSeq* insts = new InstanceSeq;
-  return insts;
-}
-
 void
-add_to_insts_cmd(Instance* inst, InstanceSeq* insts)
-{
-  insts->emplace_back(inst);
-}
-
-void
-delete_insts_cmd(InstanceSeq* insts)
-{
-  delete insts;
-}
-
-void
-remove_buffers_cmd(InstanceSeq insts)
+remove_buffers_cmd(InstanceSeq *insts)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  resizer->removeBuffers(std::move(insts));
+  if (insts) {
+    resizer->removeBuffers(*insts);
+    delete insts;
+  } else {
+    resizer->removeBuffers({});
+  }
 }
 
 void

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -441,7 +441,7 @@ sta::define_cmd_args "remove_buffers" { instances }
 
 proc remove_buffers { args } {
   sta::parse_key_args "remove_buffers" args keys {} flags {}
-  rsz::remove_buffers_cmd [ get_cells $args ]
+  rsz::remove_buffers_cmd [get_cells $args]
 }
 
 sta::define_cmd_args "balance_row_usage" {}

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -441,13 +441,7 @@ sta::define_cmd_args "remove_buffers" { instances }
 
 proc remove_buffers { args } {
   sta::parse_key_args "remove_buffers" args keys {} flags {}
-  set insts [rsz::init_insts_cmd]
-  foreach arg $args {
-    set inst [get_cells $arg]
-    rsz::add_to_insts_cmd $inst $insts
-  }
-  rsz::remove_buffers_cmd $insts
-  rsz::delete_insts_cmd $insts
+  rsz::remove_buffers_cmd [ get_cells $args ]
 }
 
 sta::define_cmd_args "balance_row_usage" {}


### PR DESCRIPTION
To get all the SWIG type conversion rules around basic STA types, it's best if we can source `StaTclTypes.i`. Here we make the change in the resizer binding, and use it to clean up some of the binding code. See the commits.