### PR TITLE
mpl2: split macros between partitions when using PAR

### DIFF
--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -209,6 +209,7 @@ class HierRTLMP
   void mergeClusters(std::vector<Cluster*>& candidate_clusters);
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
+  void splitMacrosBetweenPartitions(Cluster* parent, Cluster* new_cluster);
   std::map<odb::dbInst*, int> getMacroToStdCellPinsCountMap(Cluster* cluster);
 
   void fetchMixedLeaves(Cluster* parent,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -209,6 +209,7 @@ class HierRTLMP
   void mergeClusters(std::vector<Cluster*>& candidate_clusters);
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
+  std::map<odb::dbInst*, int> getMacroToStdCellPinsCountMap(Cluster* cluster);
 
   void fetchMixedLeaves(Cluster* parent,
                         std::vector<std::vector<Cluster*>>& mixed_leaves);


### PR DESCRIPTION
This is an idea to resolve #4539.

MPL2 uses TritonPart to partition what it calls big flat clusters which are made of a single logical module. The methodology consists of breaking the cluster in two until we get the number of std cells to be within the leaf threshold. However, nothing is done regarding the macros of this flat cluster, i. e., what we currently do is split the std cells keeping the macros in the same cluster until the end of the clustering stage. That makes all the macros be kept in the same cluster leading to something like we see in the image below:
<img src="https://github.com/The-OpenROAD-Project/OpenROAD/assets/104802710/57957a55-6a5f-4715-92bd-226ccb43c97d" width="300">

The logic here is to add the macros to a certain partition based on the number of std cell iterms connected to it. With these changes, we get something like:
<img src="https://github.com/The-OpenROAD-Project/OpenROAD/assets/104802710/70763224-fbc7-41fc-95d9-e81b58169a07" width="300">
