### PR TITLE
[docs] odb: minor layout/typo fix for db.h code comments

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -2815,7 +2815,8 @@ class dbInst : public dbObject
   /// There are seven methods used to get/set the placement.
   ///
   ///     getOrigin           - Get the origin of this instance (Where the
-  ///     master is setOrigin           - Set the origin of this instance
+  ///                           master is 
+  ///     setOrigin           - Set the origin of this instance
   ///     getOrient           - Get orient of this instance
   ///     setOrient           - Set orient of this instance
   ///     getLocation         - Get the lower-left corner of this instance

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -2814,8 +2814,7 @@ class dbInst : public dbObject
   ///
   /// There are seven methods used to get/set the placement.
   ///
-  ///     getOrigin           - Get the origin of this instance (Where the
-  ///                           master is 
+  ///     getOrigin           - Get the origin of this instance
   ///     setOrigin           - Set the origin of this instance
   ///     getOrient           - Get orient of this instance
   ///     setOrient           - Set orient of this instance


### PR DESCRIPTION
I found these comments confusing at first, and then realized there was a minor typo/lack of newline.