### PR TITLE
gui: dont eval error code if Qt says an exit was requested

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1356,7 +1356,7 @@ int startGui(int& argc,
     // disconnect tcl return lister
     QObject::disconnect(tcl_return_code_connect);
 
-    if (!tcl_ok) {
+    if (!exit_requested && !tcl_ok) {
       auto& cmds = gui->getRestoreStateCommands();
       if (cmds[cmds.size() - 1]
           == "exit") {  // exit, will be the last command if it is present


### PR DESCRIPTION
Fixes exit code issue caused by: https://github.com/The-OpenROAD-Project/OpenROAD/pull/5258