### PR TITLE
dbSta: Honor dont_touch attribute in Verilog

### DIFF
--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include("openroad")
 
 set(TEST_NAMES
     constant1
+    dont_touch_attr
     make_port
     network_edit1
     sdc_names1

--- a/src/dbSta/test/dont_touch_attr.ok
+++ b/src/dbSta/test/dont_touch_attr.ok
@@ -1,0 +1,3 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+1
+0

--- a/src/dbSta/test/dont_touch_attr.tcl
+++ b/src/dbSta/test/dont_touch_attr.tcl
@@ -1,0 +1,9 @@
+# port assigned to net (port with alias)
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_verilog dont_touch_attr.v
+link_design top
+
+puts [[[ord::get_db_block] findInst u1] isDoNotTouch]
+puts [[[ord::get_db_block] findInst u2] isDoNotTouch]

--- a/src/dbSta/test/dont_touch_attr.v
+++ b/src/dbSta/test/dont_touch_attr.v
@@ -1,0 +1,8 @@
+module top (in1, out1, out2);
+   input in1;
+   output out1;
+   output out2;
+
+   (* dont_touch *) BUF_X1 u1 (.A(in1), .Z(out1));
+   BUF_X1 u2 (.A(in1), .Z(out2));
+endmodule // top


### PR DESCRIPTION
This enables a cell to be marked as "don't touch" (for example, a buffer you want kept), directly inside the HDL using the attribute (as per the included test) without needing any custom Tcl scripting.