### PR TITLE
dft: Fix the place_sort_sky130 test

### DIFF
--- a/src/dft/test/place_sort_sky130.tcl
+++ b/src/dft/test/place_sort_sky130.tcl
@@ -13,6 +13,13 @@ set_dft_config -max_length 10
 
 scan_replace
 
+proc place_inst { inst x y } {
+  set db_inst [[ord::get_db_block] findInst $inst]
+  $db_inst setLocation $x $y
+  $db_inst setOrient R0
+  $db_inst setPlacementStatus PLACED
+}
+
 place_inst ff1_clk1_rising  1000 2000
 place_inst ff2_clk1_rising  5000 6000
 place_inst ff3_clk1_rising  9500 9000

--- a/src/dft/test/regression_tests.tcl
+++ b/src/dft/test/regression_tests.tcl
@@ -2,6 +2,7 @@ record_tests {
   one_cell_sky130
   one_cell_nangate45
   sub_modules_sky130
+  place_sort_sky130
   scan_architect_no_mix_sky130
   scan_architect_clock_mix_sky130
   #dft_man_tcl_check


### PR DESCRIPTION
I didn't sport that `dft/test/helpers.tcl` was a symlink, so forgot to add my change to it adding the `place_inst` function for the test, so the test fails on master. As this probably isn't a very useful placement function outside of this specific test, I have decided to add it to the test this time round rather than modifying the global `helpers.tcl`.

Does something else also need to be fixed so that issues in Tcl tests get caught in CI?