### PR TITLE
dft: Add support for specifying a max number of chains

### DIFF
--- a/src/dft/README.md
+++ b/src/dft/README.md
@@ -26,6 +26,7 @@ The command `set_dft_config` sets the DFT configuration variables.
 ```tcl
 set_dft_config 
     [-max_length <int>]
+    [-max_chains <int>]
     [-clock_mixing <string>]
 ```
 
@@ -33,8 +34,10 @@ set_dft_config
 
 | Switch Name | Description |
 | ---- | ---- |
-| `-max_length` | The maxinum number of bits that can be in each scan chain. |
-| `-clock_mixing` | How architect will mix the scan flops based on the clock driver. `no_mix`: Creates scan chains with only one type of clock and edge. This may create unbalanced chains. `clock_mix`: Craetes scan chains mixing clocks and edges. Falling edge flops are going to be stitched before rising edge. |
+| `-max_length` | The maximum number of bits that can be in each scan chain. |
+| `-max_chains` | The maximum number of scan chains that will be generated. This takes priority over `max_length`,
+in `no_mix` clock mode it specifies a maximum number of chains per clock-edge pair. |
+| `-clock_mixing` | How architect will mix the scan flops based on the clock driver. `no_mix`: Creates scan chains with only one type of clock and edge. This may create unbalanced chains. `clock_mix`: Creates scan chains mixing clocks and edges. Falling edge flops are going to be stitched before rising edge. |
 
 ### Report DFT Config
 

--- a/src/dft/src/architect/ScanArchitect.cpp
+++ b/src/dft/src/architect/ScanArchitect.cpp
@@ -134,12 +134,10 @@ void ScanArchitect::inferChainCount()
   std::unordered_map<size_t, uint64_t> hash_domains_total_bits
       = scan_cells_bucket_->getTotalBitsPerHashDomain();
 
-  if (config_.getMaxLength().has_value()) {
+  if (auto max_length = config_.getMaxLength(); max_length.has_value()) {
     // The user is saying that we should respect this max_length
-    hash_domain_to_limits_
-        = inferChainCountFromMaxLength(hash_domains_total_bits,
-                                       config_.getMaxLength().value(),
-                                       config_.getMaxChains());
+    hash_domain_to_limits_ = inferChainCountFromMaxLength(
+        hash_domains_total_bits, max_length.value(), config_.getMaxChains());
   } else {
     // The user did not specify any max_length, let's use a default of 200
     hash_domain_to_limits_ = inferChainCountFromMaxLength(

--- a/src/dft/src/architect/ScanArchitect.cpp
+++ b/src/dft/src/architect/ScanArchitect.cpp
@@ -134,22 +134,24 @@ void ScanArchitect::inferChainCount()
   std::unordered_map<size_t, uint64_t> hash_domains_total_bits
       = scan_cells_bucket_->getTotalBitsPerHashDomain();
 
-  // TODO(fgaray): Handle more options like a specific chain_count
   if (config_.getMaxLength().has_value()) {
     // The user is saying that we should respect this max_length
-    hash_domain_to_limits_ = inferChainCountFromMaxLength(
-        hash_domains_total_bits, config_.getMaxLength().value());
+    hash_domain_to_limits_
+        = inferChainCountFromMaxLength(hash_domains_total_bits,
+                                       config_.getMaxLength().value(),
+                                       config_.getMaxChains());
   } else {
     // The user did not specify any max_length, let's use a default of 200
-    hash_domain_to_limits_
-        = inferChainCountFromMaxLength(hash_domains_total_bits, 200);
+    hash_domain_to_limits_ = inferChainCountFromMaxLength(
+        hash_domains_total_bits, 200, config_.getMaxChains());
   }
 }
 
 std::map<size_t, ScanArchitect::HashDomainLimits>
 ScanArchitect::inferChainCountFromMaxLength(
     const std::unordered_map<size_t, uint64_t>& hash_domains_total_bit,
-    uint64_t max_length)
+    uint64_t max_length,
+    const std::optional<uint64_t>& max_chains)
 {
   std::map<size_t, HashDomainLimits> hash_domain_to_limits;
   for (const auto& [hash_domain, bits] : hash_domains_total_bit) {
@@ -159,6 +161,10 @@ ScanArchitect::inferChainCountFromMaxLength(
       domain_chain_count = bits / max_length + 1;
     } else {
       domain_chain_count = bits / max_length;
+    }
+
+    if (max_chains.has_value()) {
+      domain_chain_count = std::min(domain_chain_count, max_chains.value());
     }
 
     uint64_t domain_max_length = 0;

--- a/src/dft/src/architect/ScanArchitect.hh
+++ b/src/dft/src/architect/ScanArchitect.hh
@@ -104,7 +104,8 @@ class ScanArchitect
   // max_length
   static std::map<size_t, HashDomainLimits> inferChainCountFromMaxLength(
       const std::unordered_map<size_t, uint64_t>& hash_domains_total_bit,
-      uint64_t max_length);
+      uint64_t max_length,
+      const std::optional<uint64_t>& max_chains);
 
   // Returns an ScanArchitect object based on the configuration.
   //

--- a/src/dft/src/config/ScanArchitectConfig.cpp
+++ b/src/dft/src/config/ScanArchitectConfig.cpp
@@ -46,9 +46,19 @@ const std::optional<uint64_t>& ScanArchitectConfig::getMaxLength() const
   return max_length_;
 }
 
+const std::optional<uint64_t>& ScanArchitectConfig::getMaxChains() const
+{
+  return max_chains_;
+}
+
 void ScanArchitectConfig::setClockMixing(ClockMixing clock_mixing)
 {
   clock_mixing_ = clock_mixing;
+}
+
+void ScanArchitectConfig::setMaxChains(uint64_t max_chains)
+{
+  max_chains_ = max_chains;
 }
 
 void ScanArchitectConfig::setMaxLength(uint64_t max_length)
@@ -60,6 +70,7 @@ void ScanArchitectConfig::report(utl::Logger* logger) const
 {
   logger->report("Scan Architect Config:");
   logger->report("- Max Length: {}", utils::FormatForReport(max_length_));
+  logger->report("- Max Chains: {}", utils::FormatForReport(max_chains_));
   logger->report("- Clock Mixing: {}", ClockMixingName(clock_mixing_));
 }
 

--- a/src/dft/src/config/ScanArchitectConfig.hh
+++ b/src/dft/src/config/ScanArchitectConfig.hh
@@ -54,6 +54,10 @@ class ScanArchitectConfig
   void setMaxLength(uint64_t max_length);
   const std::optional<uint64_t>& getMaxLength() const;
 
+  // The max number of scan chains (per clock in NoMixe mode) to generate
+  void setMaxChains(uint64_t max_chains);
+  const std::optional<uint64_t>& getMaxChains() const;
+
   ClockMixing getClockMixing() const;
 
   // Prints using logger->report the config used by Scan Architect
@@ -64,6 +68,8 @@ class ScanArchitectConfig
  private:
   // The max length in bits of the scan chain
   std::optional<uint64_t> max_length_;
+  // The max number of chains to generate
+  std::optional<uint64_t> max_chains_;
 
   // How we are going to mix the clocks of the scan cells
   ClockMixing clock_mixing_;

--- a/src/dft/src/dft.i
+++ b/src/dft/src/dft.i
@@ -75,6 +75,11 @@ void set_dft_config_max_length(int max_length)
   getDft()->getMutableDftConfig()->getMutableScanArchitectConfig()->setMaxLength(max_length);
 }
 
+void set_dft_config_max_chains(int max_chains)
+{
+  getDft()->getMutableDftConfig()->getMutableScanArchitectConfig()->setMaxChains(max_chains);
+}
+
 void set_dft_config_clock_mixing(const char* clock_mixing_ptr)
 {
   std::string_view clock_mixing(clock_mixing_ptr);

--- a/src/dft/src/dft.tcl
+++ b/src/dft/src/dft.tcl
@@ -70,10 +70,11 @@ proc insert_dft { args } {
 }
 
 sta::define_cmd_args "set_dft_config" { [-max_length max_length] \
+                                        [-max_chains max_chains] \
                                         [-clock_mixing clock_mixing]}
 proc set_dft_config { args } {
   sta::parse_key_args "set_dft_config" args \
-    keys {-max_length -clock_mixing} \
+    keys {-max_length -max_chains -clock_mixing} \
     flags {}
 
   sta::check_argc_eq0 "set_dft_config" $args
@@ -82,6 +83,12 @@ proc set_dft_config { args } {
     set max_length $keys(-max_length)
     sta::check_positive_integer "-max_length" $max_length
     dft::set_dft_config_max_length $max_length
+  }
+
+  if {[info exists keys(-max_chains)]} {
+    set max_chains $keys(-max_chains)
+    sta::check_positive_integer "-max_chains" $max_chains
+    dft::set_dft_config_max_chains $max_chains
   }
 
   if {[info exists keys(-clock_mixing)]} {

--- a/src/dft/test/CMakeLists.txt
+++ b/src/dft/test/CMakeLists.txt
@@ -8,6 +8,7 @@ set(TEST_NAMES
   scan_architect_no_mix_sky130
   scan_architect_clock_mix_sky130
   place_sort_sky130
+  max_chain_count_sky130
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)

--- a/src/dft/test/cpp/TestScanArchitect.cpp
+++ b/src/dft/test/cpp/TestScanArchitect.cpp
@@ -45,34 +45,39 @@ TEST(TestScanArchitect, CalculatesChainCountAndMaxLength)
   // For 1 hash domain (1) with 10 bits and a max length of 5, we need to have a
   // chain count of 2 in that hash domain (1)
   EXPECT_TRUE(CompareUnordered(
-      ScanArchitect::inferChainCountFromMaxLength({{1, 10}}, 5),
+      ScanArchitect::inferChainCountFromMaxLength({{1, 10}}, 5, {}),
       {{1, CreateTestHashDomainLimits(2, 5)}}));
   // Unbalance cases
   // We create 2 chains with max_length of 4
-  EXPECT_TRUE(
-      CompareUnordered(ScanArchitect::inferChainCountFromMaxLength({{1, 9}}, 5),
-                       {{1, CreateTestHashDomainLimits(2, 5)}}));
+  EXPECT_TRUE(CompareUnordered(
+      ScanArchitect::inferChainCountFromMaxLength({{1, 9}}, 5, {}),
+      {{1, CreateTestHashDomainLimits(2, 5)}}));
   // We create 2 chains with max_length of 3
-  EXPECT_TRUE(
-      CompareUnordered(ScanArchitect::inferChainCountFromMaxLength({{1, 6}}, 5),
-                       {{1, CreateTestHashDomainLimits(2, 3)}}));
+  EXPECT_TRUE(CompareUnordered(
+      ScanArchitect::inferChainCountFromMaxLength({{1, 6}}, 5, {}),
+      {{1, CreateTestHashDomainLimits(2, 3)}}));
 
   // Two hash domains, balance case
   EXPECT_TRUE(CompareUnordered(
-      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 10}}, 5),
+      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 10}}, 5, {}),
       {{1, CreateTestHashDomainLimits(2, 5)},
        {2, CreateTestHashDomainLimits(2, 5)}}));
   // Unbalance
   EXPECT_TRUE(CompareUnordered(
-      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 9}}, 5),
+      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 9}}, 5, {}),
       {{1, CreateTestHashDomainLimits(2, 5)},
        {2, CreateTestHashDomainLimits(2, 5)}}));
 
   //// Two hash domains with different number of cells
   EXPECT_TRUE(CompareUnordered(
-      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 15}}, 5),
+      ScanArchitect::inferChainCountFromMaxLength({{1, 10}, {2, 15}}, 5, {}),
       {{1, CreateTestHashDomainLimits(2, 5)},
        {2, CreateTestHashDomainLimits(3, 5)}}));
+
+  // Constrained max chain count
+  EXPECT_TRUE(CompareUnordered(
+      ScanArchitect::inferChainCountFromMaxLength({{1, 10}}, 5, {1}),
+      {{1, CreateTestHashDomainLimits(1, 10)}}));
 }
 
 }  // namespace

--- a/src/dft/test/max_chain_count_sky130.ok
+++ b/src/dft/test/max_chain_count_sky130.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+***************************
+Preview DFT Report
+Number of chains: 1
+Clock domain: No Mix
+***************************
+
+Scan chain 'chain_0' has 10 cells (10 bits)
+
+  ff9_clk1_rising (main_clock, rising)
+  ff8_clk1_rising
+  ff7_clk1_rising
+  ff6_clk1_rising
+  ff5_clk1_rising
+  ff4_clk1_rising
+  ff3_clk1_rising
+  ff2_clk1_rising
+  ff1_clk1_rising
+  ff10_clk1_rising
+
+
+No differences found.

--- a/src/dft/test/max_chain_count_sky130.tcl
+++ b/src/dft/test/max_chain_count_sky130.tcl
@@ -1,0 +1,21 @@
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_liberty sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib
+
+read_verilog max_chain_count_sky130.v
+link_design max_chain_count
+
+create_clock -name main_clock -period 2.0000 -waveform {0.0000 1.0000} [get_ports {clock}]
+
+set_dft_config -max_length 4 -max_chains 1
+
+scan_replace
+
+preview_dft -verbose
+insert_dft
+
+set verilog_file [make_result_file max_chain_count_sky130.v]
+write_verilog $verilog_file
+diff_files $verilog_file max_chain_count_sky130.vok

--- a/src/dft/test/max_chain_count_sky130.v
+++ b/src/dft/test/max_chain_count_sky130.v
@@ -1,0 +1,100 @@
+module max_chain_count(port1,
+  clock,
+  set_b,
+  output1,
+  output2,
+  output3,
+  output4,
+  output5,
+  output6,
+  output7,
+  output8,
+  output9,
+  output10);
+  input port1;
+  input clock;
+  input set_b;
+  output output1;
+  output output2;
+  output output3;
+  output output4;
+  output output5;
+  output output6;
+  output output7;
+  output output8;
+  output output9;
+  output output10;
+
+
+  // Rising edge flops
+  sky130_fd_sc_hd__dfstp_1 ff1_clk1_rising(
+    .Q(output1),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff2_clk1_rising(
+    .Q(output2),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff3_clk1_rising(
+    .Q(output3),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff4_clk1_rising(
+    .Q(output4),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff5_clk1_rising(
+    .Q(output5),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff6_clk1_rising(
+    .Q(output6),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+  sky130_fd_sc_hd__dfstp_1 ff7_clk1_rising(
+    .Q(output7),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff8_clk1_rising(
+    .Q(output8),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff9_clk1_rising(
+    .Q(output9),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+  sky130_fd_sc_hd__dfstp_1 ff10_clk1_rising(
+    .Q(output10),
+    .D(port1),
+    .CLK(clock),
+    .SET_B(set_b)
+  );
+
+
+endmodule

--- a/src/dft/test/max_chain_count_sky130.vok
+++ b/src/dft/test/max_chain_count_sky130.vok
@@ -1,0 +1,93 @@
+module max_chain_count (clock,
+    output1,
+    output10,
+    output2,
+    output3,
+    output4,
+    output5,
+    output6,
+    output7,
+    output8,
+    output9,
+    port1,
+    set_b,
+    scan_enable_1,
+    scan_in_1);
+ input clock;
+ output output1;
+ output output10;
+ output output2;
+ output output3;
+ output output4;
+ output output5;
+ output output6;
+ output output7;
+ output output8;
+ output output9;
+ input port1;
+ input set_b;
+ input scan_enable_1;
+ input scan_in_1;
+
+
+ sky130_fd_sc_hd__sdfsbp_1 ff1_clk1_rising (.D(port1),
+    .Q(output1),
+    .SCD(output2),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff2_clk1_rising (.D(port1),
+    .Q(output2),
+    .SCD(output3),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff3_clk1_rising (.D(port1),
+    .Q(output3),
+    .SCD(output4),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff4_clk1_rising (.D(port1),
+    .Q(output4),
+    .SCD(output5),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff5_clk1_rising (.D(port1),
+    .Q(output5),
+    .SCD(output6),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff6_clk1_rising (.D(port1),
+    .Q(output6),
+    .SCD(output7),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff7_clk1_rising (.D(port1),
+    .Q(output7),
+    .SCD(output8),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff8_clk1_rising (.D(port1),
+    .Q(output8),
+    .SCD(output9),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff9_clk1_rising (.D(port1),
+    .Q(output9),
+    .SCD(scan_in_1),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+ sky130_fd_sc_hd__sdfsbp_1 ff10_clk1_rising (.D(port1),
+    .Q(output10),
+    .SCD(output1),
+    .SCE(scan_enable_1),
+    .SET_B(set_b),
+    .CLK(clock));
+endmodule

--- a/src/dft/test/regression_tests.tcl
+++ b/src/dft/test/regression_tests.tcl
@@ -4,6 +4,7 @@ record_tests {
   sub_modules_sky130
   scan_architect_no_mix_sky130
   scan_architect_clock_mix_sky130
+  max_chain_count_sky130
   #dft_man_tcl_check
   #dft_readme_msgs_check
 }


### PR DESCRIPTION
This will be useful in applications where we are building to connect to a scan controller or external scan pins, with a fixed expected maximum number of chains (quite possibly one).