### PR TITLE
gpl: modify log and readme for timing driven mode clarity

### DIFF
--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -40,7 +40,7 @@ Timing-driven iterations are triggered based on a list of overflow threshold
 values. Each time the placer execution reaches these overflow values, the 
 resizer is executed. This process can be costly in terms of runtime. The 
 overflow values for recalculating weights can be modified with 
-`-timing_driven_net_reweight_overflow`, you may use less overflow threhsold 
+`-timing_driven_net_reweight_overflow`, you may use less overflow threshold 
 values to decrease runtime, for example.
 
 When the routability-driven option is enabled, each of its iterations will 
@@ -49,9 +49,9 @@ will have the area of their logic cells inflated to reduce routing congestion.
 The iterations will attempt to achieve the target RC (routing congestion) 
 by comparing it to the final RC at each iteration. If the algorithm takes too 
 long during routability-driven execution, consider raising the target RC value 
-to alleviate the constraints. The final RC value is calculated based on the 
-weight coefficients. The algorithm will stop if the RC is not decreasing 
-for three consecutive iterations.
+(`-routability_target_rc_metric`) to alleviate the constraints. The final RC 
+value is calculated based on the weight coefficients. The algorithm will stop 
+if the RC is not decreasing for three consecutive iterations.
 
 Routability-driven arguments
 - They begin with `-routability`.
@@ -274,6 +274,10 @@ about this tool.
 -   The routability-driven mode has been implemented by Mingyu Woo.
 -   Timing-driven mode re-implementation is ongoing with the current
     clean-code structure.
+-   RUDY: Spindler, Peter, and Frank M. Johannes. "Fast and accurate routing 
+    demand estimation for efficient routability-driven placement. In 2007 
+    Design, Automation & Test in Europe Conference & Exhibition." (2007): 1-6.
+    [(.pdf)](https://past.date-conference.com/proceedings-archive/2007/DATE07/PDFFILES/08.7_1.PDF)
 
  ## Authors
 

--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -39,9 +39,9 @@ resistance and capacitance of estimated wires used for timing.
 Timing-driven iterations are triggered based on a list of overflow threshold 
 values. Each time the placer execution reaches these overflow values, the 
 resizer is executed. This process can be costly in terms of runtime. The 
-default overflow values for recalculating weights are [79, 64, 49, 29, 21, 15] 
-and can be modified with `-timing_driven_net_reweight_overflow`, you may use 
-less overflow threhsold values to decrease runtime, for example.
+overflow values for recalculating weights can be modified with 
+`-timing_driven_net_reweight_overflow`, you may use less overflow threhsold 
+values to decrease runtime, for example.
 
 When the routability-driven option is enabled, each of its iterations will 
 execute RUDY to provide an estimation of routing congestion. Congested tiles 
@@ -138,7 +138,7 @@ global_placement
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-timing_driven_net_reweight_overflow` | Set overflow threshold for timing-driven net reweighting. Allowed value is a Tcl list of integers where each number is `[0, 100]`. |
+| `-timing_driven_net_reweight_overflow` | Set overflow threshold for timing-driven net reweighting. Allowed value is a Tcl list of integers where each number is `[0, 100]`. Default values are [79, 64, 49, 29, 21, 15] |
 | `-timing_driven_net_weight_max` | Set the multiplier for the most timing-critical nets. The default value is `1.9`, and the allowed values are floats. |
 | `-timing_driven_nets_percentage` | Set the reweighted percentage of nets in timing-driven mode. The default value is 10. Allowed values are floats `[0, 100]`. |
 

--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -34,17 +34,24 @@ weight nets with low slack. It adjusts the worst slacks (modified with
 `-timing_driven_net_weight_max`). The multiplier
 is scaled from the full value for the worst slack, to 1.0 at the
 `timing_driven_nets_percentage` point. Use the `set_wire_rc` command to set
-resistance and capacitance of estimated wires used for timing.
+resistance and capacitance of estimated wires used for timing. 
+
+Timing-driven iterations are triggered based on a list of overflow threshold 
+values. Each time the placer execution reaches these overflow values, the 
+resizer is executed. This process can be costly in terms of runtime. The 
+default overflow values for recalculating weights are [79, 64, 49, 29, 21, 15] 
+and can be modified with `-timing_driven_net_reweight_overflow`, you may use 
+less overflow threhsold values to decrease runtime, for example.
 
 When the routability-driven option is enabled, each of its iterations will 
-execute FastRoute to provide an estimation of routing congestion, which is 
-typically costly in terms of runtime. Congested tiles will have the area of 
-their logic cells inflated to reduce routing congestion. The iterations will 
-attempt to achieve the target RC (routing congestion) by comparing it to the 
-final RC. If the algorithm takes too long during routability-driven execution, 
-consider raising the target RC value to alleviate the constraints. The final 
-RC value is calculated based on the weight coefficients. The algorithm will 
-stop if the RC is not decreasing for three consecutive iterations.
+execute RUDY to provide an estimation of routing congestion. Congested tiles 
+will have the area of their logic cells inflated to reduce routing congestion. 
+The iterations will attempt to achieve the target RC (routing congestion) 
+by comparing it to the final RC at each iteration. If the algorithm takes too 
+long during routability-driven execution, consider raising the target RC value 
+to alleviate the constraints. The final RC value is calculated based on the 
+weight coefficients. The algorithm will stop if the RC is not decreasing 
+for three consecutive iterations.
 
 Routability-driven arguments
 - They begin with `-routability`.
@@ -117,13 +124,14 @@ global_placement
 
 | Switch Name | Description |
 | ----- | ----- |
+| `-routability_use_grt` | Use this tag to execute routability using FastRoute from grt for routing congestion, which is more precise but has a high runtime cost. By default, routability mode uses RUDY, which is faster. |
 | `-routability_target_rc_metric` | Set target RC metric for routability mode. The algorithm will try to reach this RC value. The default value is `1.01`, and the allowed values are floats. |
-| `-routability_check_overflow` | Set overflow threshold for routability mode. The default value is `0.2`, and the allowed values are floats `[0, 1]`. |
+| `-routability_check_overflow` | Set overflow threshold for routability mode. The default value is `0.3`, and the allowed values are floats `[0, 1]`. |
 | `-routability_max_density` | Set density threshold for routability mode. The default value is `0.99`, and the allowed values are floats `[0, 1]`. |
 | `-routability_max_bloat_iter` | Set bloat iteration threshold for routability mode. The default value is `1`, and the allowed values are integers `[1, MAX_INT]`.|
 | `-routability_max_inflation_iter` | Set inflation iteration threshold for routability mode. The default value is `4`, and the allowed values are integers `[1, MAX_INT]`. |
-| `-routability_inflation_ratio_coef` | Set inflation ratio coefficient for routability mode. The default value is `2.5`, and the allowed values are floats. |
-| `-routability_max_inflation_ratio` | Set inflation ratio threshold for routability mode to prevent overly aggressive adjustments. The default value is `2.5`, and the allowed values are floats. |
+| `-routability_inflation_ratio_coef` | Set inflation ratio coefficient for routability mode. The default value is `5`, and the allowed values are floats. |
+| `-routability_max_inflation_ratio` | Set inflation ratio threshold for routability mode to prevent overly aggressive adjustments. The default value is `8`, and the allowed values are floats. |
 | `-routability_rc_coefficients` | Set routability RC coefficients for calculating the final RC. They relate to the 0.5%, 1%, 2%, and 5% most congested tiles. It comes in the form of a Tcl List `{k1, k2, k3, k4}`. The default value for each coefficient is `{1.0, 1.0, 0.0, 0.0}` respectively, and the allowed values are floats. |
 
 #### Timing-Driven Arguments

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -429,7 +429,8 @@ int NesterovPlace::doNesterovPlace(int start_iter)
       // and update GNet's weights from worst timing paths.
       //
       // See timingBase.cpp in detail
-      log_->info(GPL,100, "Timing-driven: executing resizer for reweighting nets.");
+      log_->info(
+          GPL, 100, "Timing-driven: executing resizer for reweighting nets.");
       bool shouldTdProceed = tb_->updateGNetWeights(average_overflow_);
 
       // problem occured

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -429,6 +429,7 @@ int NesterovPlace::doNesterovPlace(int start_iter)
       // and update GNet's weights from worst timing paths.
       //
       // See timingBase.cpp in detail
+      log_->info(GPL,100, "Timing-driven: executing resizer for reweighting nets.");
       bool shouldTdProceed = tb_->updateGNetWeights(average_overflow_);
 
       // problem occured

--- a/src/gpl/src/timingBase.cpp
+++ b/src/gpl/src/timingBase.cpp
@@ -150,7 +150,10 @@ bool TimingBase::updateGNetWeights(float overflow)
   sta::NetSeq& worst_slack_nets = rs_->resizeWorstSlackNets();
 
   if (worst_slack_nets.empty()) {
-    log_->warn(GPL, 114, "Timing-driven: no net slacks found. Timing-driven mode disabled.");
+    log_->warn(
+        GPL,
+        114,
+        "Timing-driven: no net slacks found. Timing-driven mode disabled.");
     return false;
   }
 
@@ -163,7 +166,9 @@ bool TimingBase::updateGNetWeights(float overflow)
   log_->info(GPL, 101, "Timing-driven: worst slack {:.3g}", slack_min);
 
   if (sta::fuzzyInf(slack_min)) {
-    log_->warn(GPL, 102, "Timing-driven: no slacks found. Timing-driven mode disabled.");
+    log_->warn(GPL,
+               102,
+               "Timing-driven: no slacks found. Timing-driven mode disabled.");
     return false;
   }
 

--- a/src/gpl/src/timingBase.cpp
+++ b/src/gpl/src/timingBase.cpp
@@ -150,7 +150,7 @@ bool TimingBase::updateGNetWeights(float overflow)
   sta::NetSeq& worst_slack_nets = rs_->resizeWorstSlackNets();
 
   if (worst_slack_nets.empty()) {
-    log_->warn(GPL, 114, "No net slacks found. Timing-driven mode disabled.");
+    log_->warn(GPL, 114, "Timing-driven: no net slacks found. Timing-driven mode disabled.");
     return false;
   }
 
@@ -160,10 +160,10 @@ bool TimingBase::updateGNetWeights(float overflow)
       = rs_->resizeNetSlack(worst_slack_nets[worst_slack_nets.size() - 1])
             .value();
 
-  log_->info(GPL, 100, "worst slack {:.3g}", slack_min);
+  log_->info(GPL, 101, "Timing-driven: worst slack {:.3g}", slack_min);
 
   if (sta::fuzzyInf(slack_min)) {
-    log_->warn(GPL, 102, "No slacks found. Timing-driven mode disabled.");
+    log_->warn(GPL, 102, "Timing-driven: no slacks found. Timing-driven mode disabled.");
     return false;
   }
 
@@ -201,7 +201,7 @@ bool TimingBase::updateGNetWeights(float overflow)
     }
   }
 
-  log_->info(GPL, 103, "Weighted {} nets.", weighted_net_count);
+  log_->info(GPL, 103, "Timing-driven: weighted {} nets.", weighted_net_count);
   return true;
 }
 

--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -49,8 +49,9 @@
 [INFO GPL-0029] BinSize: (  1.377  1.350 )
 [INFO GPL-0030] NumBins: 64
 [NesterovSolve] Iter:    1 overflow: 0.127 HPWL: 397899
-[INFO GPL-0100] worst slack 6.35e-09
-[INFO GPL-0103] Weighted 8 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 6.35e-09
+[INFO GPL-0103] Timing-driven: weighted 8 nets.
 [NesterovSolve] Iter:   10 overflow: 0.234 HPWL: 398615
 [NesterovSolve] Iter:   20 overflow: 0.223 HPWL: 398901
 [NesterovSolve] Iter:   30 overflow: 0.217 HPWL: 398906

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -37,8 +37,9 @@
 [INFO GPL-0029] BinSize: (  1.936  1.925 )
 [INFO GPL-0030] NumBins: 256
 [NesterovSolve] Iter:    1 overflow: 0.832 HPWL: 3651238
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:   10 overflow: 0.727 HPWL: 4009562
 [NesterovSolve] Iter:   20 overflow: 0.731 HPWL: 3997062
 [NesterovSolve] Iter:   30 overflow: 0.732 HPWL: 3995030
@@ -56,32 +57,38 @@
 [NesterovSolve] Iter:  150 overflow: 0.722 HPWL: 4025227
 [NesterovSolve] Iter:  160 overflow: 0.714 HPWL: 4039990
 [NesterovSolve] Iter:  170 overflow: 0.703 HPWL: 4061044
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  180 overflow: 0.676 HPWL: 4127122
 [NesterovSolve] Iter:  190 overflow: 0.664 HPWL: 4152168
 [NesterovSolve] Iter:  200 overflow: 0.640 HPWL: 4202374
 [NesterovSolve] Iter:  210 overflow: 0.610 HPWL: 4259798
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  220 overflow: 0.574 HPWL: 4317137
 [NesterovSolve] Iter:  230 overflow: 0.535 HPWL: 4384909
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  240 overflow: 0.485 HPWL: 4422542
 [NesterovSolve] Iter:  250 overflow: 0.433 HPWL: 4433114
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  260 overflow: 0.377 HPWL: 4431530
 [NesterovSolve] Iter:  270 overflow: 0.325 HPWL: 4435491
 [NesterovSolve] Iter:  280 overflow: 0.294 HPWL: 4464120
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  290 overflow: 0.269 HPWL: 4501197
 [NesterovSolve] Iter:  300 overflow: 0.235 HPWL: 4537610
 [NesterovSolve] Iter:  310 overflow: 0.201 HPWL: 4566148
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  320 overflow: 0.176 HPWL: 4597391
 [NesterovSolve] Iter:  330 overflow: 0.146 HPWL: 4619555
 [NesterovSolve] Iter:  340 overflow: 0.120 HPWL: 4633301

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -37,8 +37,9 @@
 [INFO GPL-0029] BinSize: (  1.936  1.925 )
 [INFO GPL-0030] NumBins: 256
 [NesterovSolve] Iter:    1 overflow: 0.832 HPWL: 3651238
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:   10 overflow: 0.727 HPWL: 4009562
 [NesterovSolve] Iter:   20 overflow: 0.731 HPWL: 3997062
 [NesterovSolve] Iter:   30 overflow: 0.732 HPWL: 3995030
@@ -59,29 +60,34 @@
 [NesterovSolve] Iter:  180 overflow: 0.689 HPWL: 4091062
 [NesterovSolve] Iter:  190 overflow: 0.670 HPWL: 4129418
 [NesterovSolve] Iter:  200 overflow: 0.648 HPWL: 4183257
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  210 overflow: 0.604 HPWL: 4268793
 [NesterovSolve] Iter:  220 overflow: 0.575 HPWL: 4319755
 [NesterovSolve] Iter:  230 overflow: 0.535 HPWL: 4382648
 [NesterovSolve] Iter:  240 overflow: 0.486 HPWL: 4420453
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  250 overflow: 0.431 HPWL: 4430170
 [NesterovSolve] Iter:  260 overflow: 0.381 HPWL: 4441333
 [NesterovSolve] Iter:  270 overflow: 0.326 HPWL: 4458862
 [NesterovSolve] Iter:  280 overflow: 0.290 HPWL: 4480268
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  290 overflow: 0.270 HPWL: 4517654
 [NesterovSolve] Iter:  300 overflow: 0.235 HPWL: 4553354
 [NesterovSolve] Iter:  310 overflow: 0.204 HPWL: 4579957
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  320 overflow: 0.176 HPWL: 4601768
 [NesterovSolve] Iter:  330 overflow: 0.150 HPWL: 4633587
-[INFO GPL-0100] worst slack 1.39e-09
-[INFO GPL-0103] Weighted 35 nets.
+[INFO GPL-0100] Timing-driven: executing resizer for reweighting nets.
+[INFO GPL-0101] Timing-driven: worst slack 1.39e-09
+[INFO GPL-0103] Timing-driven: weighted 35 nets.
 [NesterovSolve] Iter:  340 overflow: 0.122 HPWL: 4652410
 [NesterovSolve] Iter:  350 overflow: 0.101 HPWL: 4673183
 [NesterovSolve] Finished with Overflow: 0.098980


### PR DESCRIPTION
Include more clear messages during timing driven mode so the user can better understand what is happening. 
Include possible actions for user to improve runtime due to slow timing driven mode.
Include new tcl command in README for using grt(previous) routing congestion estimator during routability.
Fix default inflation parameters in README.