### PR TITLE
ci: update tclint to v0.3.2

### DIFF
--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Install tclint
         run: |
-          python -m pip install tclint==0.2.0
+          python -m pip install tclint==0.3.2
 
       - name: Lint
         run: |

--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -211,7 +211,7 @@ proc assign_ndr { args } {
   if { ![info exists keys(-ndr)] } {
     utl::error ORD 1009 "-name is missing."
   }
-  if { ! ([info exists keys(-net)] ^ [info exists flags(-all_clocks)]) } {
+  if { !([info exists keys(-net)] ^ [info exists flags(-all_clocks)]) } {
     utl::error ORD 1010 "Either -net or -all_clocks need to be defined."
   }
   set block [[[ord::get_db] getChip] getBlock]

--- a/src/gpl/src/replace.tcl
+++ b/src/gpl/src/replace.tcl
@@ -164,7 +164,7 @@ proc global_placement { args } {
   gpl::set_routability_use_grt $routability_use_grt
   if { $routability_driven } {
     if { $routability_use_grt } {
-      utl::warn "GPL" 152\
+      utl::warn "GPL" 152 \
         "Using GRT FastRoute instead of default RUDY for congestion in routability driven."
     }
   }

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -222,19 +222,19 @@ proc rtl_macro_placer { args } {
     mpl2::set_macro_placement_file $keys(-write_macro_placement)
   }
 
-  if {![mpl2::rtl_macro_placer_cmd $max_num_macro  \
-                                   $min_num_macro  \
-                                   $max_num_inst   \
-                                   $min_num_inst   \
-                                   $tolerance      \
-                                   $max_num_level  \
+  if {![mpl2::rtl_macro_placer_cmd $max_num_macro \
+                                   $min_num_macro \
+                                   $max_num_inst \
+                                   $min_num_inst \
+                                   $tolerance \
+                                   $max_num_level \
                                    $coarsening_ratio \
-                                   $num_bundled_ios  \
+                                   $num_bundled_ios \
                                    $large_net_threshold \
                                    $signature_net_threshold \
                                    $halo_width \
                                    $halo_height \
-                                   $fence_lx $fence_ly $fence_ux $fence_uy  \
+                                   $fence_lx $fence_ly $fence_ux $fence_uy \
                                    $area_weight $outline_weight $wirelength_weight \
                                    $guidance_weight $fence_weight $boundary_weight \
                                    $notch_weight $macro_blockage_weight \
@@ -306,7 +306,6 @@ proc parse_macro_name {cmd macro_name} {
   return $inst
 }
 
-# tclint-disable indent
 proc mpl_debug { args } {
   sta::parse_key_args "mpl_debug" args \
     keys {} \
@@ -322,12 +321,11 @@ proc mpl_debug { args } {
   set block [ord::get_db_block]
 
   mpl2::set_debug_cmd $block \
-                      $coarse  \
-                      $fine \
-                      [info exists flags(-show_bundled_nets)] \
-                      [info exists flags(-skip_steps)] \
-                      [info exists flags(-only_final_result)] \
+    $coarse \
+    $fine \
+    [info exists flags(-show_bundled_nets)] \
+    [info exists flags(-skip_steps)] \
+    [info exists flags(-only_final_result)]
 }
-# tclint-enable indent
 
 }

--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -587,7 +587,7 @@ proc add_pdn_connect {args} {
     set cut_pitch [pdn::get_one_to_two "-cut_pitch" $keys(-cut_pitch)]
   }
   set cut_pitch [list \
-    [ord::microns_to_dbu [lindex $cut_pitch 0]]\
+    [ord::microns_to_dbu [lindex $cut_pitch 0]] \
     [ord::microns_to_dbu [lindex $cut_pitch 1]]
   ]
 

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -41,7 +41,7 @@ sta::define_cmd_args "set_layer_rc" { [-layer layer]\
                                         [-corner corner]}
 proc set_layer_rc {args} {
   sta::parse_key_args "set_layer_rc" args \
-    keys {-layer -via -capacitance -resistance -corner}\
+    keys {-layer -via -capacitance -resistance -corner} \
     flags {}
 
   if { [info exists keys(-layer)] && [info exists keys(-via)] } {

--- a/src/tap/src/tapcell.tcl
+++ b/src/tap/src/tapcell.tcl
@@ -348,18 +348,18 @@ proc place_endcaps { args } {
     [tap::parse_endcap_key keys -bottom_edge -endcap_horizontal -endcap]]
 
   tap::place_endcaps \
-    $left_top_corner\
-    $right_top_corner\
-    $left_bottom_corner\
-    $right_bottom_corner\
-    $left_top_edge\
-    $right_top_edge\
-    $left_bottom_edge\
-    $right_bottom_edge\
-    $top_edge\
-    $bottom_edge\
-    $left_edge\
-    $right_edge\
+    $left_top_corner \
+    $right_top_corner \
+    $left_bottom_corner \
+    $right_bottom_corner \
+    $left_top_edge \
+    $right_top_edge \
+    $left_bottom_edge \
+    $right_bottom_edge \
+    $top_edge \
+    $bottom_edge \
+    $left_edge \
+    $right_edge \
     $prefix
 }
 

--- a/tclint.toml
+++ b/tclint.toml
@@ -35,8 +35,14 @@
     "src/utl/test/"
 ]
 
+ignore = [
+    "spaces-in-braces",
+    "unbraced-expr",
+]
+
 [style]
 indent = 2
 line-length = 100
 allow-aligned-sets = true
 indent-namespace-eval = false
+spaces-in-braces = true


### PR DESCRIPTION
This PR updates `tclint` to v0.3.2. Since CI was a bit behind the latest version, there are a few new categories of violations that require fixes. I've gone ahead and fixed all the newline escape spacing violations in this PR (there weren't that many), but I ignored [`spaces-in-braces`](https://github.com/nmoroze/tclint/blob/main/docs/violations.md#spaces-in-braces) and [`unbraced-expr`](https://github.com/nmoroze/tclint/blob/main/docs/violations.md#unbraced-expr), since there were too many instances of these violations to hit in one go. 

This latest version also includes a bug fix for the issue in `mpl.tcl`. With that fix + updating the indentation pattern to fix the other violations, the comment annotations to disable checks can be removed. 

It might be worth looking into setting up Dependabot to update Python dependencies, which could help stay up to date with `tclint` going forward. 