### PR TITLE
Add format_as for compilation using fmt v10

### DIFF
--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -50,6 +50,8 @@ using std::vector;
 
 using utl::DPL;
 
+using utl::format_as;
+
 void Opendp::checkPlacement(const bool verbose,
                             const bool disallow_one_site_gaps,
                             const string& report_file_name)

--- a/src/dpl/src/FillerPlacement.cpp
+++ b/src/dpl/src/FillerPlacement.cpp
@@ -48,6 +48,8 @@ using utl::DPL;
 using odb::dbMaster;
 using odb::dbPlacementStatus;
 
+using utl::format_as;
+
 static dbTechLayer* getImplant(dbMaster* master)
 {
   if (!master) {

--- a/src/dpl/src/Grid.cpp
+++ b/src/dpl/src/Grid.cpp
@@ -59,6 +59,8 @@ using utl::DPL;
 using odb::dbBox;
 using odb::dbRow;
 
+using utl::format_as;
+
 PixelPt::PixelPt(Pixel* pixel1, GridX grid_x, GridY grid_y)
     : pixel(pixel1), x(grid_x), y(grid_y)
 {

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -65,6 +65,8 @@ using utl::DPL;
 using odb::dbMasterType;
 using odb::Rect;
 
+using utl::format_as;
+
 ////////////////////////////////////////////////////////////////
 
 bool Opendp::isMultiRow(const Cell* cell) const

--- a/src/dpl/src/Place.cpp
+++ b/src/dpl/src/Place.cpp
@@ -63,6 +63,8 @@ using std::vector;
 
 using utl::DPL;
 
+using utl::format_as;
+
 std::string Opendp::printBgBox(
     const boost::geometry::model::box<bgPoint>& queryBox)
 {


### PR DESCRIPTION
This MR fixes compilation of OpenROAD with fmt v10. It uses the same approach as in: https://github.com/The-OpenROAD-Project/OpenROAD/pull/4351