### PR TITLE
tcl: evaluate location of tcl installation dynamically

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -366,7 +366,13 @@ static int tclAppInit(int& argc,
     }
     Tcl_StaticPackage(
         interp, "tclreadline", Tclreadline_Init, Tclreadline_SafeInit);
-    if (Tcl_EvalFile(interp, TCLRL_LIBRARY "/tclreadlineInit.tcl") != TCL_OK) {
+    if (Tcl_Eval(interp, "set tclreadline::library") != TCL_OK) {
+      printf("Failed to run tclreadline::library\n");
+      exit(1);
+    }
+    std::string tclreadlineInitPath = Tcl_GetStringResult(interp);
+    tclreadlineInitPath += "/tclreadlineInit.tcl";
+    if (Tcl_EvalFile(interp, tclreadlineInitPath.c_str()) != TCL_OK) {
       printf("Failed to load tclreadline\n");
     }
 #endif


### PR DESCRIPTION
This avoids problems in some deployment scenarios, such as bazel hermetic builds.

https://github.com/flightaware/tclreadline/blob/be509a8c7cefcbf6881b103d9922e8845a1d0e45/tclreadline.c#L45

https://github.com/flightaware/tclreadline/blob/be509a8c7cefcbf6881b103d9922e8845a1d0e45/tclreadline.c#L605
