### PR TITLE
grt: check if rudy is nullptr to avoid segfault if an error occurs in grt setup

### DIFF
--- a/src/grt/src/heatMapRudy.cpp
+++ b/src/grt/src/heatMapRudy.cpp
@@ -113,6 +113,10 @@ bool RUDYDataSource::populateMap()
     return false;
   }
 
+  if (rudy_ == nullptr) {
+    return false;
+  }
+
   for (odb::dbInst* inst : getBlock()->getInsts()) {
     if (!inst->isPlaced()) {
       getLogger()->warn(


### PR DESCRIPTION
Fixes: if grt throws an exception `populateXYGrid` this leaves `rudy_` a nullptr, but because the exception is caught execution continues.