### PR TITLE
pdn: dont place straps outside of die area

### DIFF
--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -216,7 +216,15 @@ void Straps::makeShapes(const Shape::ShapeTreeMap& other_shapes)
     const int abs_min = die.xMin();
     const int abs_max = die.xMax();
 
-    makeStraps(x_start, core.yMin(), x_end, core.yMax(), abs_min, abs_max, false, layer, avoid);
+    makeStraps(x_start,
+               core.yMin(),
+               x_end,
+               core.yMax(),
+               abs_min,
+               abs_max,
+               false,
+               layer,
+               avoid);
   } else {
     const int y_start = boundary.yMin();
     const int y_end = boundary.yMax();
@@ -224,7 +232,15 @@ void Straps::makeShapes(const Shape::ShapeTreeMap& other_shapes)
     const int abs_min = die.yMin();
     const int abs_max = die.yMax();
 
-    makeStraps(core.xMin(), y_start, core.xMax(), y_end, abs_min, abs_max, true, layer, avoid);
+    makeStraps(core.xMin(),
+               y_start,
+               core.xMax(),
+               y_end,
+               abs_min,
+               abs_max,
+               true,
+               layer,
+               avoid);
   }
   debugPrint(getLogger(),
              utl::PDN,
@@ -259,10 +275,13 @@ void Straps::makeStraps(int x_start,
              utl::PDN,
              "Straps",
              2,
-             "Generating straps on {} from ({:.4f}, {:.4f}) to ({:.4f}, {:.4f}) with an {}-offset of {:.4f}",
+             "Generating straps on {} from ({:.4f}, {:.4f}) to ({:.4f}, "
+             "{:.4f}) with an {}-offset of {:.4f}",
              layer_->getName(),
-             layer.dbuToMicron(x_start), layer.dbuToMicron(y_start),
-             layer.dbuToMicron(x_end), layer.dbuToMicron(y_end),
+             layer.dbuToMicron(x_start),
+             layer.dbuToMicron(y_start),
+             layer.dbuToMicron(x_end),
+             layer.dbuToMicron(y_end),
              is_delta_x ? "x" : "y",
              layer.dbuToMicron(offset_));
 
@@ -276,12 +295,15 @@ void Straps::makeStraps(int x_start,
       const int strap_start = group_pos - half_width;
       const int strap_end = strap_start + width_;
       debugPrint(getLogger(),
-                utl::PDN,
-                "Straps",
-                3,
-                "Snapped from {:.4f} -> {:.4f} resulting in strap from {:.4f} to {:.4f}",
-                layer.dbuToMicron(org_group_pos), layer.dbuToMicron(group_pos),
-                layer.dbuToMicron(strap_start), layer.dbuToMicron(strap_end));
+                 utl::PDN,
+                 "Straps",
+                 3,
+                 "Snapped from {:.4f} -> {:.4f} resulting in strap from {:.4f} "
+                 "to {:.4f}",
+                 layer.dbuToMicron(org_group_pos),
+                 layer.dbuToMicron(group_pos),
+                 layer.dbuToMicron(strap_start),
+                 layer.dbuToMicron(strap_end));
 
       if (strap_start >= pos_end) {
         // no portion of the strap is inside the limit

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -175,8 +175,9 @@ void Straps::makeShapes(const Shape::ShapeTreeMap& other_shapes)
 
   auto* grid = getGrid();
 
+  const odb::Rect die = grid->getBlock()->getDieArea();
   odb::Rect boundary;
-  odb::Rect core = grid->getDomainArea();
+  const odb::Rect core = grid->getDomainArea();
   switch (extend_mode_) {
     case CORE:
       boundary = grid->getDomainBoundary();
@@ -212,25 +213,34 @@ void Straps::makeShapes(const Shape::ShapeTreeMap& other_shapes)
     const int x_start = boundary.xMin();
     const int x_end = boundary.xMax();
 
-    makeStraps(x_start, core.yMin(), x_end, core.yMax(), false, layer, avoid);
+    const int abs_min = die.xMin();
+    const int abs_max = die.xMax();
+
+    makeStraps(x_start, core.yMin(), x_end, core.yMax(), abs_min, abs_max, false, layer, avoid);
   } else {
     const int y_start = boundary.yMin();
     const int y_end = boundary.yMax();
 
-    makeStraps(core.xMin(), y_start, core.xMax(), y_end, true, layer, avoid);
+    const int abs_min = die.yMin();
+    const int abs_max = die.yMax();
+
+    makeStraps(core.xMin(), y_start, core.xMax(), y_end, abs_min, abs_max, true, layer, avoid);
   }
   debugPrint(getLogger(),
              utl::PDN,
              "Straps",
              1,
-             "Generated {} straps",
-             getShapeCount());
+             "Generated {} straps on {}",
+             getShapeCount(),
+             layer_->getName());
 }
 
 void Straps::makeStraps(int x_start,
                         int y_start,
                         int x_end,
                         int y_end,
+                        int abs_start,
+                        int abs_end,
                         bool is_delta_x,
                         const TechLayer& layer,
                         const Shape::ObstructionTree& avoid)
@@ -245,14 +255,34 @@ void Straps::makeStraps(int x_start,
 
   const int group_pitch = spacing_ + width_;
 
-  int next_minimum_track = 0;
+  debugPrint(getLogger(),
+             utl::PDN,
+             "Straps",
+             2,
+             "Generating straps on {} from ({:.4f}, {:.4f}) to ({:.4f}, {:.4f}) with an {}-offset of {:.4f}",
+             layer_->getName(),
+             layer.dbuToMicron(x_start), layer.dbuToMicron(y_start),
+             layer.dbuToMicron(x_end), layer.dbuToMicron(y_end),
+             is_delta_x ? "x" : "y",
+             layer.dbuToMicron(offset_));
+
+  int next_minimum_track = std::numeric_limits<int>::lowest();
   for (pos += offset_; pos <= pos_end; pos += pitch_) {
     int group_pos = pos;
     for (auto* net : nets) {
       // snap to grid if needed
-      group_pos = layer.snapToGrid(group_pos, next_minimum_track);
+      const int org_group_pos = group_pos;
+      group_pos = layer.snapToGrid(org_group_pos, next_minimum_track);
       const int strap_start = group_pos - half_width;
       const int strap_end = strap_start + width_;
+      debugPrint(getLogger(),
+                utl::PDN,
+                "Straps",
+                3,
+                "Snapped from {:.4f} -> {:.4f} resulting in strap from {:.4f} to {:.4f}",
+                layer.dbuToMicron(org_group_pos), layer.dbuToMicron(group_pos),
+                layer.dbuToMicron(strap_start), layer.dbuToMicron(strap_end));
+
       if (strap_start >= pos_end) {
         // no portion of the strap is inside the limit
         return;
@@ -274,6 +304,16 @@ void Straps::makeStraps(int x_start,
       if (avoid.qbegin(bgi::intersects(strap_rect)) != avoid.qend()) {
         // dont add this strap as it intersects an avoidance
         continue;
+      }
+
+      if (is_delta_x) {
+        if (strap_rect.xMin() < abs_start || strap_rect.xMax() > abs_end) {
+          continue;
+        }
+      } else {
+        if (strap_rect.yMin() < abs_start || strap_rect.yMax() > abs_end) {
+          continue;
+        }
       }
 
       addShape(

--- a/src/pdn/src/straps.h
+++ b/src/pdn/src/straps.h
@@ -116,6 +116,8 @@ class Straps : public GridComponent
                   int y_start,
                   int x_end,
                   int y_end,
+                  int abs_start,
+                  int abs_end,
                   bool is_delta_x,
                   const TechLayer& layer,
                   const Shape::ObstructionTree& avoid);

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -33,6 +33,7 @@
 #include "techlayer.h"
 
 #include <limits>
+#include <optional>
 
 #include "utl/Logger.h"
 
@@ -82,7 +83,7 @@ int TechLayer::snapToGrid(int pos, int greater_than) const
     return pos;
   }
 
-  int delta_pos = 0;
+  std::optional<int> delta_pos;
   int delta = std::numeric_limits<int>::max();
   for (const int grid_pos : grid_) {
     if (grid_pos < greater_than) {
@@ -99,7 +100,11 @@ int TechLayer::snapToGrid(int pos, int greater_than) const
       break;
     }
   }
-  return delta_pos;
+
+  if (delta_pos.has_value()) {
+    return delta_pos.value();
+  }
+  return pos;
 }
 
 int TechLayer::snapToManufacturingGrid(odb::dbTech* tech,


### PR DESCRIPTION
Fixes:
- when core area is the same as die area straps would appear on the edges going outside the die area, this avoids generating straps if they will exceed the die area.