### PR TITLE
mpl2: continue without dataflow when no liberty data is found for std cells

### DIFF
--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -572,7 +572,6 @@ void ClusteringEngine::createDataFlow()
 // Here we assume that there are std cells in the design!
 bool ClusteringEngine::stdCellsHaveLiberty()
 {
-  int valid_lib_cell_count = 0;
   for (odb::dbInst* inst : block_->getInsts()) {
     odb::dbMaster* master = inst->getMaster();
     if (isIgnoredMaster(master) || master->isBlock()) {
@@ -581,15 +580,11 @@ bool ClusteringEngine::stdCellsHaveLiberty()
 
     const sta::LibertyCell* liberty_cell = network_->libertyCell(inst);
     if (liberty_cell) {
-      ++valid_lib_cell_count;
+      return true;
     }
   }
 
-  if (valid_lib_cell_count == 0) {
-    return false;
-  }
-
-  return true;
+  return false;
 }
 
 VerticesMaps ClusteringEngine::computeVertices()

--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -529,7 +529,9 @@ void ClusteringEngine::createDataFlow()
 {
   if (!stdCellsHaveLiberty()) {
     logger_->warn(
-        MPL, 14, "No Liberty data found. Continuing without dataflow.");
+        MPL,
+        14,
+        "No Liberty data found for std cells. Continuing without dataflow.");
     data_connections_.is_empty = true;
     return;
   }
@@ -686,7 +688,8 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
       if (master->isBlock()) {
         vertex_id = odb::dbIntProperty::find(iterm, "vertex_id")->getValue();
       } else {
-        odb::dbIntProperty* int_prop = odb::dbIntProperty::find(inst, "vertex_id");
+        odb::dbIntProperty* int_prop
+            = odb::dbIntProperty::find(inst, "vertex_id");
 
         // Std cells without liberty data are not marked as vertices
         if (int_prop) {

--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -527,7 +527,7 @@ void ClusteringEngine::mapIOPads()
 // Here we model each std cell instance, IO pin and macro pin as vertices.
 void ClusteringEngine::createDataFlow()
 {
-  if (!stdCellsHaveLiberty()) {
+  if (design_metrics_->getNumStdCell() != 0 && !stdCellsHaveLiberty()) {
     logger_->warn(
         MPL,
         14,
@@ -569,6 +569,7 @@ void ClusteringEngine::createDataFlow()
   }
 }
 
+// Here we assume that there are std cells in the design!
 bool ClusteringEngine::stdCellsHaveLiberty()
 {
   int valid_lib_cell_count = 0;

--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -686,7 +686,15 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
       if (master->isBlock()) {
         vertex_id = odb::dbIntProperty::find(iterm, "vertex_id")->getValue();
       } else {
-        vertex_id = odb::dbIntProperty::find(inst, "vertex_id")->getValue();
+        odb::dbIntProperty* int_prop = odb::dbIntProperty::find(inst, "vertex_id");
+
+        // Std cells without liberty data are not marked as vertices
+        if (int_prop) {
+          vertex_id = int_prop->getValue();
+        } else {
+          ignore = true;
+          break;
+        }
       }
 
       if (iterm->getIoType() == odb::dbIoType::OUTPUT) {

--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -85,6 +85,8 @@ struct VerticesMaps
 
 struct DataFlow
 {
+  bool is_empty{false};
+
   // Macro Pins --> Registers
   // Registers --> Macro Pins
   std::vector<std::pair<odb::dbITerm*, std::vector<std::set<odb::dbInst*>>>>
@@ -232,6 +234,7 @@ class ClusteringEngine
 
   // Methods for data flow
   void createDataFlow();
+  bool stdCellsHaveLiberty();
   VerticesMaps computeVertices();
   void computeIOVertices(VerticesMaps& vertices_maps);
   void computeStdCellVertices(VerticesMaps& vertices_maps);


### PR DESCRIPTION
Fix #5285 

I'm also adding a check to allow "exceptions" - nets with std cells without liberty will be skipped when creating data flow. I.e., we'll consider data flow as empty only when there's absolutely no Liberty data for std cells.