### PR TITLE
gui: add enablement for painting all layers

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -264,6 +264,7 @@ DisplayControls::DisplayControls(QWidget* parent)
     : QDockWidget("Display Control", parent),
       view_(new QTreeView(this)),
       model_(new DisplayControlModel(user_data_item_idx_, this)),
+      routing_layers_menu_(new QMenu(this)),
       layers_menu_(new QMenu(this)),
       layers_menu_layer_(nullptr),
       ignore_callback_(false),
@@ -295,6 +296,16 @@ DisplayControls::DisplayControls(QWidget* parent)
   auto layers
       = makeParentItem(layers_group_, "Layers", root, Qt::Checked, true);
   view_->expand(layers->index());
+  auto implant_layer
+      = makeParentItem(layers_.implant, "Implant", layers, Qt::Checked, true);
+  auto master_layer = makeParentItem(
+      layers_.master, "Masterslice", layers, Qt::Unchecked, true);
+  auto other_layer
+      = makeParentItem(layers_.other, "Other", layers, Qt::Unchecked, true);
+  // hide initially
+  view_->setRowHidden(implant_layer->row(), layers->index(), true);
+  view_->setRowHidden(master_layer->row(), layers->index(), true);
+  view_->setRowHidden(other_layer->row(), layers->index(), true);
 
   // Nets group
   auto nets_parent
@@ -556,6 +567,10 @@ void DisplayControls::createLayerMenu()
           &QAction::triggered,
           [this]() { layerShowOnlySelectedNeighbors(0, 0); });
 
+  connect(routing_layers_menu_->addAction("Show only selected"),
+          &QAction::triggered,
+          [this]() { layerShowOnlySelectedNeighbors(0, 0); });
+
   const QString show_range = "Show layer range ";
   const QString updown_arrow = "\u2195";
   const QString down_arrow = "\u2193";
@@ -576,7 +591,7 @@ void DisplayControls::createLayerMenu()
       arrows += down_arrow;
     }
 
-    connect(layers_menu_->addAction(show_range + arrows),
+    connect(routing_layers_menu_->addAction(show_range + arrows),
             &QAction::triggered,
             [this, up, down]() { layerShowOnlySelectedNeighbors(down, up); });
   };
@@ -1205,18 +1220,54 @@ void DisplayControls::addTech(odb::dbTech* tech)
   libInit(tech->getDb());
 
   for (dbTechLayer* layer : tech->getLayers()) {
-    dbTechLayerType type = layer->getType();
-    if (type == dbTechLayerType::ROUTING || type == dbTechLayerType::CUT
-        || type == dbTechLayerType::IMPLANT) {
-      auto& row = layer_controls_[layer];
-      makeLeafItem(row,
-                   QString::fromStdString(layer->getName()),
-                   layers_group_.name,
-                   Qt::Checked,
-                   true,
-                   color(layer),
-                   QVariant::fromValue(layer));
+    auto& row = layer_controls_[layer];
+    QStandardItem* parent;
+    Qt::CheckState checked;
+    switch (layer->getType()) {
+      case dbTechLayerType::ROUTING:
+      case dbTechLayerType::CUT:
+        parent = layers_group_.name;
+        checked = Qt::Checked;
+        break;
+      case dbTechLayerType::MASTERSLICE:
+        parent = layers_.master.name;
+        checked = Qt::Unchecked;
+        break;
+      case dbTechLayerType::IMPLANT:
+        parent = layers_.implant.name;
+        checked = Qt::Checked;
+        break;
+      default:
+        parent = layers_.other.name;
+        checked = Qt::Unchecked;
+        break;
     }
+    makeLeafItem(row,
+                 QString::fromStdString(layer->getName()),
+                 parent,
+                 checked,
+                 true,
+                 color(layer),
+                 QVariant::fromValue(layer));
+  }
+
+  if (layers_.implant.name->hasChildren()) {
+    view_->setRowHidden(layers_.implant.name->row(),
+                        layers_group_.name->index(),
+                        !layers_.implant.name->hasChildren());
+    toggleParent(layers_.implant);
+  }
+  if (layers_.master.name->hasChildren()) {
+    view_->setRowHidden(layers_.master.name->row(),
+                        layers_group_.name->index(),
+                        !layers_.master.name->hasChildren());
+    toggleParent(layers_.master);
+  }
+  if (layers_.other.name->hasChildren()) {
+    view_->setRowHidden(layers_.other.name->row(),
+                        layers_group_.name->index(),
+                        !layers_.other.name->hasChildren());
+    toggleParent(layers_.other);
   }
 
   toggleParent(layers_group_);
@@ -1919,14 +1970,12 @@ void DisplayControls::techInit(odb::dbTech* tech)
                        50 + gen_color() % 200,
                        50 + gen_color() % 200);
       }
-    } else if (type == dbTechLayerType::IMPLANT) {
+    } else {
       // Do not draw from the existing palette so the metal layers can claim
       // those colors.
       color = QColor(50 + gen_color() % 200,
                      50 + gen_color() % 200,
                      50 + gen_color() % 200);
-    } else {
-      continue;
     }
     color.setAlpha(180);
     layer_color_[layer] = std::move(color);
@@ -2009,18 +2058,22 @@ void DisplayControls::itemContextMenu(const QPoint& point)
     return;
   }
 
-  auto* parent_item = model_->itemFromIndex(parent);
-  if (parent_item != layers_group_.name) {
-    // not a member of the layers
-    return;
-  }
-
   const QModelIndex name_index = model_->index(index.row(), Name, parent);
   auto* name_item = model_->itemFromIndex(name_index);
   layers_menu_layer_
       = name_item->data(user_data_item_idx_).value<dbTechLayer*>();
 
-  layers_menu_->popup(view_->viewport()->mapToGlobal(point));
+  if (layers_menu_layer_ != nullptr) {
+    switch (layers_menu_layer_->getType()) {
+      case dbTechLayerType::CUT:
+      case dbTechLayerType::ROUTING:
+        routing_layers_menu_->popup(view_->viewport()->mapToGlobal(point));
+        break;
+      default:
+        layers_menu_->popup(view_->viewport()->mapToGlobal(point));
+        break;
+    }
+  }
 }
 
 void DisplayControls::layerShowOnlySelectedNeighbors(int lower, int upper)

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -312,6 +312,13 @@ class DisplayControls : public QDockWidget,
     ModelRow clock;
   };
 
+  struct LayerModels
+  {
+    ModelRow implant;
+    ModelRow master;
+    ModelRow other;
+  };
+
   struct InstanceModels
   {
     ModelRow stdcells;
@@ -495,6 +502,7 @@ class DisplayControls : public QDockWidget,
 
   QTreeView* view_;
   DisplayControlModel* model_;
+  QMenu* routing_layers_menu_;
   QMenu* layers_menu_;
   odb::dbTechLayer* layers_menu_layer_;
 
@@ -514,6 +522,7 @@ class DisplayControls : public QDockWidget,
   ModelRow shape_type_group_;
 
   // instances
+  LayerModels layers_;
   InstanceModels instances_;
   StdCellModels stdcell_instances_;
   BufferInverterModels bufinv_instances_;

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1328,10 +1328,6 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
   for (dbBox* box : master->getObstructions()) {
     dbTechLayer* layer = box->getTechLayer();
     dbTechLayerType type = layer->getType();
-    if (type != dbTechLayerType::ROUTING && type != dbTechLayerType::CUT
-        && type != dbTechLayerType::IMPLANT) {
-      continue;
-    }
     boxes[layer].obs.emplace_back(box_to_qrect(box));
   }
 
@@ -1350,10 +1346,6 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
             odb::Rect box_rect = via_box->getBox();
             dbTechLayer* layer = via_box->getTechLayer();
             dbTechLayerType type = layer->getType();
-            if (type != dbTechLayerType::ROUTING
-                && type != dbTechLayerType::CUT) {
-              continue;
-            }
             via_transform.apply(box_rect);
             boxes[layer].mterms.emplace_back(
                 QRect{box_rect.xMin(),
@@ -1364,10 +1356,6 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
         } else {
           dbTechLayer* layer = box->getTechLayer();
           dbTechLayerType type = layer->getType();
-          if (type != dbTechLayerType::ROUTING
-              && type != dbTechLayerType::CUT) {
-            continue;
-          }
           boxes[layer].mterms.emplace_back(box_to_qrect(box));
         }
       }


### PR DESCRIPTION
Changes:
- moves implant layers into a sub category of layers (in case of a lot of implant layers this allows the routing and cut layers to be a little easier to find.)
- adds masterslice and other groups to enable non-implant layers too, there are very few shapes in this so should not add much to the render time.
- masterslice and other are not enabled by default

Before):
![Screenshot 2024-07-21 111958](https://github.com/user-attachments/assets/a0f06f07-43da-4217-9b15-ed604f63958c)

New default view:
![Screenshot 2024-07-21 111912](https://github.com/user-attachments/assets/2f01edff-3b4e-4665-8b7c-bd6d0967b2f8)

Expanded:
![Screenshot 2024-07-21 112226](https://github.com/user-attachments/assets/fc09569f-8dc5-4a3c-a5d0-b2e0743dd188)
