### PR TITLE
gui: add layers to ITerm descriptor

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -797,9 +797,9 @@ Descriptor::Properties DbMasterDescriptor::getProperties(std::any object) const
   if (site != nullptr) {
     props.push_back({"Site", gui->makeSelected(site)});
   }
-  std::vector<std::any> mterms;
+  SelectionSet mterms;
   for (auto mterm : master->getMTerms()) {
-    mterms.emplace_back(mterm->getConstName());
+    mterms.insert(gui->makeSelected(mterm));
   }
   props.push_back({"MTerms", mterms});
 
@@ -1687,21 +1687,11 @@ Descriptor::Properties DbITermDescriptor::getProperties(std::any object) const
       aps.insert(gui->makeSelected(iap));
     }
   }
-  SelectionSet layers;
-  for (auto* mpin : iterm->getMTerm()->getMPins()) {
-    for (auto* geom : mpin->getGeometry()) {
-      auto* layer = geom->getTechLayer();
-      if (layer != nullptr) {
-        layers.insert(gui->makeSelected(layer));
-      }
-    }
-  }
   Properties props{{"Instance", gui->makeSelected(iterm->getInst())},
                    {"IO type", iterm->getIoType().getString()},
                    {"Net", std::move(net_value)},
                    {"Special", iterm->isSpecial()},
-                   {"MTerm", iterm->getMTerm()->getConstName()},
-                   {"Layers", layers},
+                   {"MTerm", gui->makeSelected(iterm->getMTerm())},
                    {"Access Points", aps}};
 
   populateODBProperties(props, iterm);
@@ -1854,6 +1844,123 @@ bool DbBTermDescriptor::getAllObjects(SelectionSet& objects) const
   for (auto* term : block->getBTerms()) {
     objects.insert(makeSelected(term));
   }
+  return true;
+}
+
+//////////////////////////////////////////////////
+
+DbMTermDescriptor::DbMTermDescriptor(odb::dbDatabase* db) : db_(db)
+{
+}
+
+std::string DbMTermDescriptor::getName(std::any object) const
+{
+  auto mterm = std::any_cast<odb::dbMTerm*>(object);
+  return mterm->getMaster()->getName() + "/" + mterm->getName();
+}
+
+std::string DbMTermDescriptor::getShortName(std::any object) const
+{
+  auto mterm = std::any_cast<odb::dbMTerm*>(object);
+  return mterm->getName();
+}
+
+std::string DbMTermDescriptor::getTypeName() const
+{
+  return "MTerm";
+}
+
+bool DbMTermDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+{
+  auto mterm = std::any_cast<odb::dbMTerm*>(object);
+  bbox = mterm->getBBox();
+  return true;
+}
+
+void DbMTermDescriptor::highlight(std::any object, Painter& painter) const
+{
+  auto mterm = std::any_cast<odb::dbMTerm*>(object);
+
+  auto* chip = db_->getChip();
+  if (chip == nullptr) {
+    return;
+  }
+  auto* block = chip->getBlock();
+  if (block == nullptr) {
+    return;
+  }
+
+  std::set<odb::Rect> mterm_rects;
+
+  for (auto mpin : mterm->getMPins()) {
+    for (auto box : mpin->getGeometry()) {
+      mterm_rects.insert(box->getBox());
+    }
+  }
+  for (auto* iterm : block->getITerms()) {
+    if (iterm->getMTerm() == mterm) {
+      if (!iterm->getInst()->getPlacementStatus().isPlaced()) {
+        continue;
+      }
+      const odb::dbTransform inst_xfm = iterm->getInst()->getTransform();
+
+      for (odb::Rect rect : mterm_rects) {
+        inst_xfm.apply(rect);
+        painter.drawRect(rect);
+      }
+    }
+  }
+}
+
+Descriptor::Properties DbMTermDescriptor::getProperties(std::any object) const
+{
+  auto gui = Gui::get();
+  auto mterm = std::any_cast<odb::dbMTerm*>(object);
+  SelectionSet layers;
+  for (auto* mpin : mterm->getMPins()) {
+    for (auto* geom : mpin->getGeometry()) {
+      auto* layer = geom->getTechLayer();
+      if (layer != nullptr) {
+        layers.insert(gui->makeSelected(layer));
+      }
+    }
+  }
+  Properties props{{"Master", gui->makeSelected(mterm->getMaster())},
+                   {"IO type", mterm->getIoType().getString()},
+                   {"Signal type", mterm->getSigType().getString()},
+                   {"# Pins", mterm->getMPins().size()},
+                   {"Layers", layers}};
+
+  populateODBProperties(props, mterm);
+
+  return props;
+}
+
+Selected DbMTermDescriptor::makeSelected(std::any object) const
+{
+  if (auto mterm = std::any_cast<odb::dbMTerm*>(&object)) {
+    return Selected(*mterm, this);
+  }
+  return Selected();
+}
+
+bool DbMTermDescriptor::lessThan(std::any l, std::any r) const
+{
+  auto l_mterm = std::any_cast<odb::dbMTerm*>(l);
+  auto r_mterm = std::any_cast<odb::dbMTerm*>(r);
+  return l_mterm->getId() < r_mterm->getId();
+}
+
+bool DbMTermDescriptor::getAllObjects(SelectionSet& objects) const
+{
+  for (auto* lib : db_->getLibs()) {
+    for (auto* master : lib->getMasters()) {
+      for (auto* mterm : master->getMTerms()) {
+        objects.insert(makeSelected(mterm));
+      }
+    }
+  }
+
   return true;
 }
 

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1687,11 +1687,21 @@ Descriptor::Properties DbITermDescriptor::getProperties(std::any object) const
       aps.insert(gui->makeSelected(iap));
     }
   }
+  SelectionSet layers;
+  for (auto* mpin : iterm->getMTerm()->getMPins()) {
+    for (auto* geom : mpin->getGeometry()) {
+      auto* layer = geom->getTechLayer();
+      if (layer != nullptr) {
+        layers.insert(gui->makeSelected(layer));
+      }
+    }
+  }
   Properties props{{"Instance", gui->makeSelected(iterm->getInst())},
                    {"IO type", iterm->getIoType().getString()},
                    {"Net", std::move(net_value)},
                    {"Special", iterm->isSpecial()},
                    {"MTerm", iterm->getMTerm()->getConstName()},
+                   {"Layers", layers},
                    {"Access Points", aps}};
 
   populateODBProperties(props, iterm);

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -272,6 +272,28 @@ class DbBTermDescriptor : public Descriptor
   odb::dbDatabase* db_;
 };
 
+class DbMTermDescriptor : public Descriptor
+{
+ public:
+  DbMTermDescriptor(odb::dbDatabase* db);
+
+  std::string getName(std::any object) const override;
+  std::string getShortName(std::any object) const override;
+  std::string getTypeName() const override;
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+};
+
 class DbViaDescriptor : public Descriptor
 {
  public:

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -479,6 +479,7 @@ void MainWindow::init(sta::dbSta* sta)
                           viewers_->getNetTracks()));
   gui->registerDescriptor<odb::dbITerm*>(new DbITermDescriptor(db_));
   gui->registerDescriptor<odb::dbBTerm*>(new DbBTermDescriptor(db_));
+  gui->registerDescriptor<odb::dbMTerm*>(new DbMTermDescriptor(db_));
   gui->registerDescriptor<odb::dbVia*>(new DbViaDescriptor(db_));
   gui->registerDescriptor<odb::dbBlockage*>(new DbBlockageDescriptor(db_));
   gui->registerDescriptor<odb::dbObstruction*>(


### PR DESCRIPTION
Adds:
- list of layers an iterm can be found on. For most it will only be one, but on memory macros and IO pads it can be be several