### PR TITLE
gui: remove io type from iterm descriptor as it is now in mterm

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1688,7 +1688,6 @@ Descriptor::Properties DbITermDescriptor::getProperties(std::any object) const
     }
   }
   Properties props{{"Instance", gui->makeSelected(iterm->getInst())},
-                   {"IO type", iterm->getIoType().getString()},
                    {"Net", std::move(net_value)},
                    {"Special", iterm->isSpecial()},
                    {"MTerm", gui->makeSelected(iterm->getMTerm())},


### PR DESCRIPTION
@maliberty only the IO type was exposed in the descriptor, so that's the only one removed.