### PR TITLE
tcl: fixes 'info string' for normal use case

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -333,6 +333,18 @@ static int tclReadlineInit(Tcl_Interp* interp)
 }
 #endif
 
+int tclEvalFile(const char* filename, Tcl_Interp* interp)
+{
+  int code = Tcl_EvalFile(interp, filename);
+  if (code != TCL_OK) {
+    const char* result = Tcl_GetStringResult(interp);
+    if (result[0] != '\0') {
+      printf("%s\n", result);
+    }
+  }
+  return code;
+}
+
 // Tcl init executed inside Tcl_Main.
 static int tclAppInit(int& argc,
                       char* argv[],
@@ -430,7 +442,7 @@ static int tclAppInit(int& argc,
         char* cmd_file = argv[1];
         if (cmd_file) {
           if (!gui_enabled) {
-            int result = sourceTclFile(cmd_file, false, false, interp);
+            int result = tclEvalFile(cmd_file, interp);
             if (exit_after_cmd_file) {
               int exit_code = (result == TCL_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
               exit(exit_code);

--- a/src/rsz/test/hi_fanout.tcl
+++ b/src/rsz/test/hi_fanout.tcl
@@ -185,7 +185,7 @@ proc write_clone_test_def1 { filename clone_gate fanout
     puts $stream "UNITS DISTANCE MICRONS $dbu ;"
     # Write out the die area 
     write_diearea $stream $fanout $load_spacing
-    puts "$filename $clone_gate $fanout $drvr_inst $drvr_cell $drvr_clk $drvr_out "
+    puts "./[string trimleft [string map [list [pwd]/ ""] [file normalize  $filename]] "/"] $clone_gate $fanout $drvr_inst $drvr_cell $drvr_clk $drvr_out "
     puts "$load_inst $load_cell $load_clk $load_in $load_spacing $port_layer $dbu"
     
     puts $stream "COMPONENTS [expr $fanout + 3] ;"


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/5415 for normal, most important, use case where a file is executed from a batch file without a GUI.