### PR TITLE
tcl: read in config file without verbose and echo

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -333,6 +333,18 @@ static int tclReadlineInit(Tcl_Interp* interp)
 }
 #endif
 
+int tclEvalFile(const char* filename, Tcl_Interp* interp)
+{
+  int code = Tcl_EvalFile(interp, filename);
+  if (code != TCL_OK) {
+    const char* result = Tcl_GetStringResult(interp);
+    if (result[0] != '\0') {
+      printf("%s\n", result);
+    }
+  }
+  return code;
+}
+
 // Tcl init executed inside Tcl_Main.
 static int tclAppInit(int& argc,
                       char* argv[],
@@ -430,7 +442,7 @@ static int tclAppInit(int& argc,
         char* cmd_file = argv[1];
         if (cmd_file) {
           if (!gui_enabled) {
-            int result = sourceTclFile(cmd_file, false, false, interp);
+            int result = tclEvalFile(cmd_file, interp);
             if (exit_after_cmd_file) {
               int exit_code = (result == TCL_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
               exit(exit_code);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -74,7 +74,6 @@
 using sta::findCmdLineFlag;
 using sta::findCmdLineKey;
 using sta::is_regular_file;
-using sta::sourceTclFile;
 using sta::stringEq;
 using std::string;
 
@@ -410,7 +409,7 @@ static int tclAppInit(int& argc,
       init /= init_filename;
       if (std::filesystem::is_regular_file(init)) {
         if (!gui_enabled) {
-          sourceTclFile(init.c_str(), true, true, interp);
+          tclEvalFile(init.c_str(), interp);
         } else {
           // need to delay loading of file until after GUI is completed
           // initialized
@@ -424,7 +423,7 @@ static int tclAppInit(int& argc,
       init_path += init_filename;
       if (is_regular_file(init_path.c_str())) {
         if (!gui_enabled) {
-          sourceTclFile(init_path.c_str(), true, true, interp);
+          tclEvalFile(init_path.c_str(), interp);
         } else {
           // need to delay loading of file until after GUI is completed
           // initialized

--- a/src/rsz/test/hi_fanout.tcl
+++ b/src/rsz/test/hi_fanout.tcl
@@ -185,7 +185,7 @@ proc write_clone_test_def1 { filename clone_gate fanout
     puts $stream "UNITS DISTANCE MICRONS $dbu ;"
     # Write out the die area 
     write_diearea $stream $fanout $load_spacing
-    puts "$filename $clone_gate $fanout $drvr_inst $drvr_cell $drvr_clk $drvr_out "
+    puts "./[string trimleft [string map [list [pwd]/ ""] [file normalize  $filename]] "/"] $clone_gate $fanout $drvr_inst $drvr_cell $drvr_clk $drvr_out "
     puts "$load_inst $load_cell $load_clk $load_in $load_spacing $port_layer $dbu"
     
     puts $stream "COMPONENTS [expr $fanout + 3] ;"


### PR DESCRIPTION
Use Tcl_EvalFile() to run config files.

This also reduces surprises with e.g. 'info script' not working:

https://github.com/The-OpenROAD-Project/OpenROAD/issues/5415