### PR TITLE
grt: adding error message when no routing layer has a track structure

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3504,6 +3504,9 @@ int GlobalRouter::computeMaxRoutingLayer()
     max_routing_layer = layer;
   }
 
+  if (max_routing_layer == -1) {
+    logger_->error(GRT, 701, "Missing track structure for routing layers.");
+  }
   return max_routing_layer;
 }
 


### PR DESCRIPTION
Adding error message when no routing layer has a track structure.
Fixes #5364