### PR TITLE
mpl2: fix hardmacro halos

### DIFF
--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -197,7 +197,7 @@ Metrics* ClusteringEngine::computeModuleMetrics(odb::dbModule* module)
 
       // add hard macro to corresponding map
       HardMacro* macro
-          = new HardMacro(inst, tree_->halo_width, tree_->halo_width);
+          = new HardMacro(inst, tree_->halo_width, tree_->halo_height);
       tree_->maps.inst_to_hard[inst] = macro;
     } else {
       num_std_cell += 1;


### PR DESCRIPTION
While running mock-array with the latest ORFS / OR and using mpl2 I realized that both halos were being set as the horizontal halo (width).