### PR TITLE
rsz: Add option for Steiner tree amending in net repair

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -135,6 +135,7 @@ class RecoverPower;
 class RepairDesign;
 class RepairSetup;
 class RepairHold;
+class TreeAmending;
 
 class NetHash
 {
@@ -322,6 +323,7 @@ class Resizer : public dbStaState
       double max_wire_length,  // max_wire_length zero for none (meters)
       double slew_margin,      // 0.0-1.0
       double cap_margin,       // 0.0-1.0
+      bool amend_tree,
       bool verbose);
   int repairDesignBufferCount() const;
   // for debugging
@@ -630,6 +632,7 @@ class Resizer : public dbStaState
   RepairDesign* repair_design_;
   RepairSetup* repair_setup_;
   RepairHold* repair_hold_;
+  TreeAmending* tree_amending_;
   std::unique_ptr<AbstractSteinerRenderer> steiner_renderer_;
 
   // Layer RC per wire length indexed by layer->getNumber(), corner->index
@@ -721,6 +724,7 @@ class Resizer : public dbStaState
   friend class RepairSetup;
   friend class RepairHold;
   friend class SteinerTree;
+  friend class TreeAmending;
 };
 
 }  // namespace rsz

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -310,6 +310,21 @@ int BufferedNet::bufferCount() const
   return 0;
 }
 
+int BufferedNet::wireLength() const
+{
+  switch (type_) {
+    case BufferedNetType::wire:
+      return length() + ref_->wireLength();
+    case BufferedNetType::junction:
+      return ref_->wireLength() + ref2_->wireLength();
+    case BufferedNetType::load:
+      return 0;
+    case BufferedNetType::buffer:
+      return ref_->wireLength();
+  }
+  return 0;
+}
+
 int BufferedNet::maxLoadWireLength() const
 {
   switch (type_) {
@@ -457,7 +472,7 @@ static BufferedNetPtr makeBufferedNetFromTree(
     }
   }
   if (bnet && from != SteinerTree::null_pt
-      && tree->location(to) != tree->location(from)) {
+      /* && tree->location(to) != tree->location(from)*/) {
     bnet = make_shared<BufferedNet>(BufferedNetType::wire,
                                     tree->location(from),
                                     BufferedNet::null_layer,

--- a/src/rsz/src/BufferedNet.hh
+++ b/src/rsz/src/BufferedNet.hh
@@ -152,6 +152,8 @@ class BufferedNet
   // repairNet
   int maxLoadWireLength() const;
 
+  int wireLength() const;
+
   // Rebuffer
   Required required(const StaState* sta) const;
   const PathRef& requiredPath() const { return required_path_; }
@@ -187,6 +189,21 @@ class BufferedNet
   PathRef required_path_;
   // Max delay from here to the loads.
   Delay required_delay_;
+
+public:
+  // tree amending annotations
+  BufferedNetPtr pairing_candidate_;
+  std::vector<BufferedNetPtr> pending_candidates_;
+
+  BufferedNet *place_ = NULL;
+
+  BufferedNet *upstream_ = NULL;
+  void setUpstream(BufferedNet *upstream) {
+    upstream_ = upstream;
+  }
+  BufferedNet *upstream() {
+    return upstream_;
+  }
 };
 
 }  // namespace rsz

--- a/src/rsz/src/CMakeLists.txt
+++ b/src/rsz/src/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(rsz_lib
     SteinerTree.cc
     EstimateWireParasitics.cc
     Resizer.cc
+    TreeAmending.cc
 )
 
 target_sources(rsz

--- a/src/rsz/src/RecoverPower.hh
+++ b/src/rsz/src/RecoverPower.hh
@@ -131,11 +131,6 @@ class RecoverPower : public sta::dbStaState
   static constexpr int failed_move_threshold_limit_ = 500;
 
   sta::VertexSet bad_vertices_;
-
-  static constexpr int decreasing_slack_max_passes_ = 50;
-  static constexpr int rebuffer_max_fanout_ = 20;
-  static constexpr int split_load_min_fanout_ = 8;
-  static constexpr double rebuffer_buffer_penalty_ = .01;
 };
 
 }  // namespace rsz

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -88,10 +88,12 @@ class RepairDesign : dbStaState
   void repairDesign(double max_wire_length,
                     double slew_margin,
                     double cap_margin,
+                    bool amend_tree,
                     bool verbose);
   void repairDesign(double max_wire_length,  // zero for none (meters)
                     double slew_margin,
                     double cap_margin,
+                    bool amend_tree,
                     bool verbose,
                     int& repaired_net_count,
                     int& slew_violations,
@@ -116,6 +118,7 @@ class RepairDesign : dbStaState
                  bool check_fanout,
                  int max_length,  // dbu
                  bool resize_drvr,
+                 bool amend_tree,
                  int& repaired_net_count,
                  int& slew_violations,
                  int& cap_violations,

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -139,6 +139,7 @@ class RepairSetup : public sta::dbStaState
   // Rebuffer one net (for testing).
   // resizerPreamble() required.
   void rebufferNet(const Pin* drvr_pin);
+  void rebufferNet(const Pin* drvr_pin, BufferedNetPtr bnet);
 
  private:
   void init();
@@ -192,6 +193,7 @@ class RepairSetup : public sta::dbStaState
   bool hasTopLevelOutputPort(Net* net);
 
   int rebuffer(const Pin* drvr_pin);
+  int rebuffer(const Pin* drvr_pin, BufferedNetPtr bnet);
   BufferedNetSeq rebufferBottomUp(const BufferedNetPtr& bnet, int level);
   int rebufferTopDown(const BufferedNetPtr& choice, Net* net, int level);
   BufferedNetSeq addWireAndBuffer(const BufferedNetSeq& Z,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -45,6 +45,7 @@
 #include "RepairDesign.hh"
 #include "RepairHold.hh"
 #include "RepairSetup.hh"
+#include "TreeAmending.hh"
 #include "boost/multi_array.hpp"
 #include "db_sta/dbNetwork.hh"
 #include "sta/ArcDelayCalc.hh"
@@ -130,6 +131,7 @@ Resizer::Resizer()
       repair_design_(new RepairDesign(this)),
       repair_setup_(new RepairSetup(this)),
       repair_hold_(new RepairHold(this)),
+      tree_amending_(new TreeAmending(this)),
       wire_signal_res_(0.0),
       wire_signal_cap_(0.0),
       wire_clk_res_(0.0),
@@ -1267,6 +1269,7 @@ void Resizer::findResizeSlacks()
   repair_design_->repairDesign(max_wire_length_,
                                0.0,
                                0.0,
+                               false,
                                false,
                                repaired_net_count,
                                slew_violations,
@@ -2586,6 +2589,7 @@ bool Resizer::isFuncOneZero(const Pin* drvr_pin)
 void Resizer::repairDesign(double max_wire_length,
                            double slew_margin,
                            double cap_margin,
+                           bool amend_tree,
                            bool verbose)
 {
   resizePreamble();
@@ -2593,7 +2597,7 @@ void Resizer::repairDesign(double max_wire_length,
     opendp_->initMacrosAndGrid();
   }
   repair_design_->repairDesign(
-      max_wire_length, slew_margin, cap_margin, verbose);
+      max_wire_length, slew_margin, cap_margin, amend_tree, verbose);
 }
 
 int Resizer::repairDesignBufferCount() const

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -503,11 +503,12 @@ void
 repair_design_cmd(double max_length,
                   double slew_margin,
                   double cap_margin,
+                  bool amend_tree,
                   bool verbose)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  resizer->repairDesign(max_length, slew_margin, cap_margin, verbose);
+  resizer->repairDesign(max_length, slew_margin, cap_margin, amend_tree, verbose);
 }
 
 int

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -433,12 +433,13 @@ sta::define_cmd_args "repair_design" {[-max_wire_length max_wire_length] \
                                       [-max_utilization util] \
                                       [-slew_margin slack_margin] \
                                       [-cap_margin cap_margin] \
+                                      [-amend_tree] \
                                       [-verbose]}
 
 proc repair_design { args } {
   sta::parse_key_args "repair_design" args \
     keys {-max_wire_length -max_utilization -slew_margin -cap_margin} \
-    flags {-verbose}
+    flags {-verbose -amend_tree}
 
   set max_wire_length [rsz::parse_max_wire_length keys]
   set slew_margin [rsz::parse_percent_margin_arg "-slew_margin" keys]
@@ -448,8 +449,9 @@ proc repair_design { args } {
   sta::check_argc_eq0 "repair_design" $args
   rsz::check_parasitics
   set max_wire_length [rsz::check_max_wire_length $max_wire_length]
+  set amend_tree [info exists flags(-amend_tree)]
   set verbose [info exists flags(-verbose)]
-  rsz::repair_design_cmd $max_wire_length $slew_margin $cap_margin $verbose
+  rsz::repair_design_cmd $max_wire_length $slew_margin $cap_margin $amend_tree $verbose
 }
 
 sta::define_cmd_args "repair_clock_nets" {[-max_wire_length max_wire_length]}

--- a/src/rsz/src/TreeAmending.cc
+++ b/src/rsz/src/TreeAmending.cc
@@ -1,0 +1,431 @@
+#include "TreeAmending.hh"
+#include "BufferedNet.hh"
+
+#include "rsz/Resizer.hh"
+#include "sta/Corner.hh"
+#include "sta/Graph.hh"
+#include "sta/Liberty.hh"
+#include "sta/PortDirection.hh"
+#include "sta/GraphDelayCalc.hh"
+#include "sta/DcalcAnalysisPt.hh"
+#include "sta/Units.hh"
+#include "sta/PathVertex.hh"
+#include "sta/Fuzzy.hh"
+#include "utl/Logger.h"
+
+#include "RepairSetup.hh"
+#include "SteinerTree.hh"
+
+namespace rsz {
+
+using sta::LibertyCellPortIterator;
+using sta::NetConnectedPinIterator;
+using sta::PortDirection;
+using sta::Port;
+using utl::RSZ;
+using sta::MinMaxAll;
+using sta::RiseFallBoth;
+using sta::DcalcAPIndex;
+using sta::VertexPathIterator;
+using sta::VertexIterator;
+using sta::Graph;
+using sta::Network;
+using sta::stringLess;
+using sta::fuzzyLessEqual;
+
+TreeAmending::TreeAmending(Resizer* resizer) : resizer_(resizer)
+{
+}
+
+TreeAmending::~TreeAmending() = default;
+
+void TreeAmending::init()
+{
+  logger_ = resizer_->logger_;
+  sta_ = resizer_->sta_;
+  db_network_ = resizer_->db_network_;
+  copyState(sta_);
+}
+
+void dumpBranch(std::ostream &f, BufferedNetPtr net, float scale, int level=0)
+{
+  switch (net->type()) {
+  case BufferedNetType::buffer:
+    dumpBranch(f, net->ref(), scale, level);
+    break;
+  case BufferedNetType::wire:
+    {
+      Point a = net->location(), b = net->ref()->location();
+      f << std::string(level, ' ')
+          << "<line x1=\"" << (float) a.x() * scale << "\" y1=\"" << (float) a.y() * scale << "\" x2=\""
+          << (float) b.x() * scale << "\" y2=\"" << (float) b.y() * scale
+          << "\" style=\"stroke: "
+          << (net->ref()->type() == BufferedNetType::load ? "gray" : "black") << "; stroke-width: 2;\"/>\n";
+      dumpBranch(f, net->ref(), scale, level);
+    }
+    break;
+  case BufferedNetType::junction:
+    dumpBranch(f, net->ref(), scale, level+1);
+    dumpBranch(f, net->ref2(), scale, level+1);
+    break;
+  case BufferedNetType::load:
+    break;
+  }
+}
+
+void dumpSvg(std::string fname, BufferedNetPtr net)
+{
+  std::ofstream f(fname, std::ios::out);
+  f << "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"" \
+        << 0 << " " << 0 << " " << 1000 << " " << 1000 << "\">\n";
+  dumpBranch(f, net, 0.001);
+  f << "</svg>\n";
+  f.close();
+}
+
+template <typename F>
+void visitBnetLoads(BufferedNetPtr net, F&& f) {
+  switch (net->type()) {
+    case BufferedNetType::load:
+      f(net);
+      break;
+    case BufferedNetType::wire:
+      visitBnetLoads(net->ref(), f);
+      break;
+    case BufferedNetType::junction:
+      visitBnetLoads(net->ref(), f);
+      visitBnetLoads(net->ref2(), f);
+      break;
+    case BufferedNetType::buffer:
+      // so far a no-op
+      return;
+  }
+}
+
+void setUpstreams(BufferedNetPtr net)
+{
+  switch (net->type()) {
+    case BufferedNetType::load:
+      break;
+    case BufferedNetType::wire:
+    case BufferedNetType::buffer:
+      net->ref()->setUpstream(net.get());
+      setUpstreams(net->ref());
+      return;
+    case BufferedNetType::junction:
+      net->ref()->setUpstream(net.get());
+      setUpstreams(net->ref());
+      net->ref2()->setUpstream(net.get());
+      setUpstreams(net->ref2());
+      break;
+  }
+}
+
+void updateCandidate(StaState *sta_, BufferedNet *net)
+{
+  if (!net->pairing_candidate_ || net->pairing_candidate_->place_ != net) {
+    BufferedNetPtr left = net->ref();
+    while (left->type() == BufferedNetType::wire)
+      left = left->ref();
+    BufferedNetPtr right = net->ref2();
+    while (right->type() == BufferedNetType::wire)
+      right = right->ref();
+
+    left = left->pairing_candidate_;
+    right = right->pairing_candidate_;
+
+    BufferedNetPtr chosen = right;
+    if (left && (!chosen || left->required(sta_) > chosen->required(sta_)))
+      chosen = left;
+
+    for (auto other : net->pending_candidates_) {
+      if (!chosen || other->required(sta_) > chosen->required(sta_))
+        chosen = other;
+    }
+
+    net->pairing_candidate_ = chosen;
+  }
+}
+
+void updateCandidatesAll(StaState *sta_, BufferedNet *net)
+{
+  switch (net->type()) {
+    case BufferedNetType::buffer:
+    case BufferedNetType::load:
+      break;
+    case BufferedNetType::wire:
+      updateCandidatesAll(sta_, net->ref().get());
+      return;
+    case BufferedNetType::junction:
+      updateCandidatesAll(sta_, net->ref().get());
+      updateCandidatesAll(sta_, net->ref2().get());
+      updateCandidate(sta_, net);
+      break;
+  }
+}
+
+void junctionEndpoints(BufferedNetPtr &j, BufferedNetPtr &left, BufferedNetPtr &right)
+{
+  left = j->ref(); right = j->ref2();
+  while (left->type() == BufferedNetType::wire)
+    left = left->ref();
+  while (right->type() == BufferedNetType::wire)
+    right = right->ref();
+}
+
+void sort_pair(int &a, int &b)
+{
+  if (a > b)
+    std::swap(a, b);
+}
+
+BufferedNetPtr TreeAmending::refineJunctionPlacement(BufferedNetPtr net)
+{
+  BufferedNetPtr endpoint = net;
+  while (endpoint->type() == BufferedNetType::wire)
+    endpoint = endpoint->ref();
+
+  switch (endpoint->type()) {
+    case BufferedNetType::junction:
+      {
+        BufferedNetPtr left, right;
+
+        left = refineJunctionPlacement(endpoint->ref());
+        right = refineJunctionPlacement(endpoint->ref2());
+
+        while (left->type() == BufferedNetType::wire)
+          left = left->ref();
+        while (right->type() == BufferedNetType::wire)
+          right = right->ref();
+
+        int x1, x2, x3, y1, y2, y3;
+        x1 = left->location().x();
+        x2 = right->location().x();
+        x3 = net->location().x();
+        y1 = left->location().y();
+        y2 = right->location().y();
+        y3 = net->location().y();
+
+        sort_pair(x1, x2);
+        sort_pair(x2, x3);
+        sort_pair(x1, x2);
+        sort_pair(y1, y2);
+        sort_pair(y2, y3);
+        sort_pair(y1, y2);
+
+        auto loc = Point(x2, y2);
+
+        if (loc != left->location())
+          left = std::make_shared<BufferedNet>(
+            BufferedNetType::wire, loc, BufferedNet::null_layer,
+            left, corner_, resizer_);
+        if (loc != right->location())
+          right = std::make_shared<BufferedNet>(
+            BufferedNetType::wire, loc, BufferedNet::null_layer,
+            right, corner_, resizer_);
+
+        auto junc = std::make_shared<BufferedNet>(
+            BufferedNetType::junction,
+            loc,
+            left,
+            right,
+            resizer_);
+
+        if (loc != net->location())
+          return std::make_shared<BufferedNet>(
+            BufferedNetType::wire, net->location(), BufferedNet::null_layer,
+            junc, corner_, resizer_);
+        else
+          return junc;
+      }
+    case BufferedNetType::load:
+      return net;
+    default:
+      logger_->critical(RSZ, 306, "unhandled BufferedNet type {}", (int) endpoint->type());
+  }
+}
+
+float TreeAmending::estimatedWireCap(BufferedNet *p1, BufferedNet *p2)
+{
+  double dx
+    = resizer_->dbuToMeters(std::abs(p1->location().x() - p2->location().x()));
+  double dy
+    = resizer_->dbuToMeters(std::abs(p1->location().y() - p2->location().y())); 
+
+  return dx * resizer_->wireSignalHCapacitance(corner_)
+            + dy * resizer_->wireSignalVCapacitance(corner_);
+}
+
+BufferedNetPtr TreeAmending::build(BufferedNet *root, float cutoff, float eps, float min_cap)
+{
+  assert(root->pairing_candidate_ && fuzzyLessEqual(cutoff, root->pairing_candidate_->required(sta_)));
+
+  BufferedNetPtr seed = root->pairing_candidate_;
+  BufferedNet *place = seed->place_;
+
+  place->pairing_candidate_ = NULL;
+
+  // walk upwards and pair until we hit root
+  while (true) {
+    assert(place);
+
+    if (place->type() == BufferedNetType::junction) {
+      updateCandidate(sta_, place);
+
+      BufferedNet *estimate_pt = (place->upstream()) ? place->upstream() : place;
+      float cap_estimated = seed->cap() + estimatedWireCap(estimate_pt, seed.get());
+
+      // find the required cutoff
+      float seed_cutoff = std::max(seed->required(sta_)
+              - ((cap_estimated < min_cap) ? 0 : (std::logf(cap_estimated / min_cap) * eps)),
+              cutoff);
+
+      BufferedNetPtr pair_seed = place->pairing_candidate_;
+
+      if (pair_seed && fuzzyLessEqual(seed_cutoff, pair_seed->required(sta_))) {
+        BufferedNetPtr pair = build(place, seed_cutoff, eps, min_cap);
+
+        float combined_cap = pair->cap() + estimatedWireCap(place, pair.get())
+            + (estimatedWireCap(place, seed.get()) + seed->cap())
+               * std::expf((pair->required(sta_) - seed->required(sta_)) / eps);
+        float combined_delay = pair->requiredDelay();
+
+        // create a junction
+        auto new_seed = std::make_shared<BufferedNet>(
+          BufferedNetType::junction,
+          place->location(),
+          std::make_shared<BufferedNet>(
+            BufferedNetType::wire, place->location(), BufferedNet::null_layer, seed,
+            corner_, resizer_),
+          std::make_shared<BufferedNet>(
+            BufferedNetType::wire, place->location(), BufferedNet::null_layer, pair,
+            corner_, resizer_),
+          resizer_);
+        new_seed->setRequiredPath(pair->requiredPath());
+        new_seed->setRequiredDelay(combined_delay);
+        new_seed->setCapacitance(combined_cap);
+        new_seed->place_ = place;
+        seed = new_seed;
+      } else {
+        if (place == root)
+          break;
+
+        place = place->upstream();
+      }
+    } else {
+      if (place == root)
+        break;
+
+      place = place->upstream();
+    }
+  }
+
+  return seed;
+}
+
+BufferedNetPtr TreeAmending::amendedTree(const Pin *drvr_pin, const Corner *corner)
+{
+  corner_ = corner;
+
+  BufferedNetPtr bnet = resizer_->makeBufferedNetSteiner(drvr_pin, corner_);
+
+  if (!bnet) {
+    logger_->report("steiner bad {}", network_->name(drvr_pin));
+    return bnet;
+  }
+
+  std::list<BufferedNetPtr> loads;
+  visitBnetLoads(bnet, [&](BufferedNetPtr load){
+    const Pin *load_pin = load->loadPin();
+    Vertex *vertex = graph_->pinLoadVertex(load_pin);
+    PathRef req_path = sta_->vertexWorstSlackPath(vertex, MinMax::max());
+    const DcalcAnalysisPt* dcalc_ap = req_path.isNull()
+                                            ? resizer_->tgt_slew_dcalc_ap_
+                                            : req_path.dcalcAnalysisPt(sta_);
+    load->setCapacitance(resizer_->pinCapacitance(load_pin, dcalc_ap));
+    load->setRequiredPath(req_path);
+    load->pairing_candidate_ = load;
+    load->place_ = load.get();
+    loads.push_back(load);
+  });
+
+  loads.sort([&](BufferedNetPtr a, BufferedNetPtr b) {
+    return a->required(sta_) > b->required(sta_);
+  });
+
+  if (loads.size() <= 2)
+    return bnet;
+
+  // values for sky130hd
+  float eps = 0.072e-9;
+  float min_cap = 0.002e-12;
+
+  bool fixup_req = false;
+  float mark, req, weight = 0.0f;
+
+  for (auto load : loads) {
+    if (weight != 0.0f) {
+      weight *= std::expf((load->required(sta_) - req) / eps);
+    }
+
+    if (weight < min_cap) {
+      fixup_req = true;
+      mark = load->required(sta_);
+    }
+
+    weight += load->cap();
+    req = load->required(sta_);
+  }
+
+  float req_cutoff;
+  if (fixup_req) {
+    float cap_sum = 0;
+
+    for (auto load : loads) {
+      if (cap_sum * std::expf((mark - load->required(sta_)) / eps) > min_cap) {
+        req_cutoff = mark + std::logf(cap_sum / min_cap) * eps;
+        break;
+      }
+      cap_sum += load->cap();
+    }
+  }
+
+  // make sure the req_cutoff is no higher than the 25th percentile
+  // of required times on the loads
+  for (auto load : loads) {
+    if (m++ == loads.size() / 4 && (!fixup_req || load->required(sta_) < req_cutoff)) {
+      req_cutoff = load->required(sta_);
+    }
+  }
+
+  for (auto load : loads) {
+    if (load->required(sta_) > req_cutoff) {
+      load->setRequiredDelay(load->required(sta_) - req_cutoff);
+    }
+  }
+
+  setUpstreams(bnet);
+  updateCandidatesAll(sta_, bnet.get());
+
+  BufferedNet *top_junction = bnet.get();
+  while (top_junction->type() == BufferedNetType::wire)
+    top_junction = top_junction->ref().get();
+
+  BufferedNetPtr amended = build(top_junction, -sta::INF, eps, min_cap);
+
+  amended = std::make_shared<BufferedNet>(
+              BufferedNetType::wire, bnet->location(), BufferedNet::null_layer, amended,
+              corner_, resizer_);
+
+  // do two rounds of refinement
+  amended = refineJunctionPlacement(amended);
+  amended = refineJunctionPlacement(amended);
+
+  // clear the overridden delays due to `req_cutoff`
+  for (auto load : loads)
+    load->setRequiredDelay(0);
+
+  return amended;
+}
+
+}  // namespace rsz

--- a/src/rsz/src/TreeAmending.hh
+++ b/src/rsz/src/TreeAmending.hh
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "db_sta/dbNetwork.hh"
+#include "db_sta/dbSta.hh"
+#include "sta/Sta.hh"
+#include "sta/Search.hh"
+#include "utl/Logger.h"
+
+namespace rsz {
+
+class Resizer;
+class BufferedNet;
+using BufferedNetPtr = std::shared_ptr<BufferedNet>;
+
+using sta::dbNetwork;
+using sta::dbSta;
+using sta::Pin;
+using sta::Net;
+using sta::StaState;
+using sta::LibertyCell;
+using sta::Corner;
+using utl::Logger;
+using sta::Vertex;
+using sta::ArrivalVisitor;
+using sta::RequiredVisitor;
+using odb::Point;
+
+class TreeAmending : StaState
+{
+ public:
+  explicit TreeAmending(Resizer* resizer);
+  ~TreeAmending() override;
+  void init();
+
+  BufferedNetPtr amendedTree(const Pin *drvr_pin, const Corner *corner);
+
+ private:
+  BufferedNetPtr build(BufferedNet *root, float cutoff, float eps, float min_cap);
+  BufferedNetPtr refineJunctionPlacement(BufferedNetPtr net);
+  float estimatedWireCap(BufferedNet *p1, BufferedNet *p2);
+
+  Logger* logger_ = nullptr;
+  dbSta* sta_ = nullptr;
+  dbNetwork* db_network_ = nullptr;
+  Resizer* resizer_;
+  const Corner* corner_ = nullptr;
+};
+
+}  // namespace rsz


### PR DESCRIPTION
*Note: This is up so that it can be discussed. There are no plans to get it merged at the moment.*

Add an option `-amend_tree` to `repair_design` for requesting
timing-aware amending of the Steiner trees used in the repair process.

The buffers inserted by `repair_design` dictate much of the final buffer
tree topology. The intent with `-amend_tree` is for `repair_design` to
place its buffers in a way that has less of a chance of constraining us
into a buffering topology which would be a timing bottleneck later on.