### PR TITLE
gui: use a buffer to store report text to avoid slowing down OR when logging in Scripting

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -233,7 +233,7 @@ void ScriptWidget::addLogToOutput(const QString& text, const QColor& color)
 
 void ScriptWidget::startReportTimer()
 {
-  report_timer_->start(20 /*ms*/);
+  report_timer_->start(report_display_interval);
 }
 
 void ScriptWidget::addMsgToReportBuffer(const QString& text)

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -239,6 +239,7 @@ void ScriptWidget::startReportTimer()
 
 void ScriptWidget::addMsgToReportBuffer(const QString& text)
 {
+  std::lock_guard guard(reporting_);
   report_buffer_ += text;
 }
 
@@ -414,12 +415,12 @@ class ScriptWidget::GuiSink : public spdlog::sinks::base_sink<Mutex>
         std::string(formatted.data(), formatted.size()));
 
     if (msg.level == spdlog::level::level_enum::off) {
+      widget_->addMsgToReportBuffer(formatted_msg);
+
       if (QThread::currentThread() == widget_->thread()) {
         if (!widget_->report_timer_->isActive()) {
           widget_->startReportTimer();
         }
-
-        widget_->addMsgToReportBuffer(formatted_msg);
 
         // the event loop is blocked so we need to manually process
         // events so that the timer keeps going

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -110,6 +110,10 @@ ScriptWidget::ScriptWidget(QWidget* parent)
           &TclCmdInputWidget::commandFinishedExecuting,
           this,
           &ScriptWidget::commandExecuted);
+  connect(input_,
+          &TclCmdInputWidget::commandFinishedExecuting,
+          this,
+          &ScriptWidget::flushReportBufferToOuput);
   connect(output_,
           &QPlainTextEdit::textChanged,
           this,

--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -143,6 +143,7 @@ void ScriptWidget::flushReportBufferToOutput()
     return;
   }
 
+  std::lock_guard guard(reporting_);
   // this comes from a ->report
   addTextToOutput(report_buffer_, buffer_msg_);
   report_buffer_.clear();

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -119,6 +119,8 @@ class ScriptWidget : public QDockWidget
   void setPauserToRunning();
   void resetPauser();
 
+  void flushReportBufferToOuput();
+
  protected:
   // required to ensure input command space it set to correct height
   void resizeEvent(QResizeEvent* event) override;
@@ -126,13 +128,16 @@ class ScriptWidget : public QDockWidget
  private:
   void triggerPauseCountDown(int timeout);
 
-  void addReportToOutput(const QString& text);
+  bool reportTimerIsActive();
+  void startReportTimer();
+  void addMsgToReportBuffer(const QString& text);
   void addLogToOutput(const QString& text, const QColor& color);
 
   QPlainTextEdit* output_;
   TclCmdInputWidget* input_;
   QPushButton* pauser_;
   std::unique_ptr<QTimer> pause_timer_;
+  std::unique_ptr<QTimer> report_timer_;
   bool paused_;
   utl::Logger* logger_;
 
@@ -143,6 +148,7 @@ class ScriptWidget : public QDockWidget
   template <typename Mutex>
   class GuiSink;
   std::shared_ptr<spdlog::sinks::sink> sink_;
+  QString report_buffer_;
 
   // maximum number of character to display in a log line
   const int max_output_line_length_ = 1000;

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -119,7 +119,7 @@ class ScriptWidget : public QDockWidget
   void setPauserToRunning();
   void resetPauser();
 
-  void flushReportBufferToOuput();
+  void flushReportBufferToOutput();
 
  protected:
   // required to ensure input command space it set to correct height
@@ -128,7 +128,6 @@ class ScriptWidget : public QDockWidget
  private:
   void triggerPauseCountDown(int timeout);
 
-  bool reportTimerIsActive();
   void startReportTimer();
   void addMsgToReportBuffer(const QString& text);
   void addLogToOutput(const QString& text, const QColor& color);

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -147,6 +147,7 @@ class ScriptWidget : public QDockWidget
   template <typename Mutex>
   class GuiSink;
   std::shared_ptr<spdlog::sinks::sink> sink_;
+  std::mutex reporting_;
   QString report_buffer_;
 
   // maximum number of character to display in a log line

--- a/src/gui/src/scriptWidget.h
+++ b/src/gui/src/scriptWidget.h
@@ -152,6 +152,11 @@ class ScriptWidget : public QDockWidget
   // maximum number of character to display in a log line
   const int max_output_line_length_ = 1000;
 
+  // Interval in ms between every flush of the report buffer to
+  // the output. Testing with many lines of log showed that lower
+  // frequencies don't make much more impact.
+  static constexpr int report_display_interval = 50;
+
   const QColor cmd_msg_ = Qt::black;
   const QColor error_msg_ = Qt::red;
   const QColor ok_msg_ = Qt::blue;


### PR DESCRIPTION
Resolve #5340 