### PR TITLE
timing report: add a more elaborate tooltip

### DIFF
--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -181,7 +181,13 @@ QVariant TimingPathsModel::headerData(int section,
         // to a header item that doesn't.
         return "";
       case Skew:
-        return "Path clock skew (crpr corrected)";
+        // A rather verbose tooltip, move some of this to a help/documentation
+        // file when one is introduced into OpenROAD. Meanwhile, this is the
+        // best that can be done.
+        return "The difference in arrival times between\n"
+               "source and destination clock pins of a macro/register,\n"
+               "adjusted for CRPR and subtracting a clock period.\n"
+               "Setup and hold times account for internal clock delays.";
       case LogicDelay:
         return "Path delay from instances (excluding buffers and consecutive "
                "inverter pairs)";


### PR DESCRIPTION
If there was a f1/help button for all menus, then
some of this tooltip would be moved in there.

Meanwhile, best that can be done is a slightly verbose tooltip.

Doesn't look too bad. Tolerable...


![image](https://github.com/user-attachments/assets/c42b64f0-9127-4973-941d-19a3a06d3556)

