### PR TITLE
spef: writing dates in output files is an anachronism

### DIFF
--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1648,8 +1648,6 @@ void extSpef::writeHeaderInfo()
                 "%H:%M:%S %A %B %d, %Y",
                 std::localtime(&currentTime));
 
-  fprintf(_outFP, "*DATE \"%s\"\n", buffer);
-
   fprintf(_outFP, "*VENDOR \"The OpenROAD Project\"\n");
   fprintf(_outFP, "*PROGRAM \"OpenROAD\"\n");
   fprintf(_outFP, "*VERSION \"%s\"\n", _version);

--- a/src/rcx/src/extSpef.cpp
+++ b/src/rcx/src/extSpef.cpp
@@ -1641,12 +1641,9 @@ void extSpef::writeHeaderInfo()
 
   std::time_t currentTime = std::time(nullptr);
 
-  // Format the current time as a string
-  char buffer[128];
-  std::strftime(buffer,
-                sizeof(buffer),
-                "%H:%M:%S %A %B %d, %Y",
-                std::localtime(&currentTime));
+  // With repeatable builds being the norm now, date in output files is
+  // an anachronism. Leave an N/A string as this is a required field.
+  fprintf(_outFP, "*DATE \"N/A\"\n");
 
   fprintf(_outFP, "*VENDOR \"The OpenROAD Project\"\n");
   fprintf(_outFP, "*PROGRAM \"OpenROAD\"\n");


### PR DESCRIPTION
@QuantamHD Thoughts? 

See also CI test https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2223

I saw global routing failing after I set SKIP_REPORT_METRICS=1, though I suspect it can also come from some other change I was not aware I did that changed the initial conditions.

This got me thinking that it would be nice for options that should have no effect on the result to have a CI smoke test...

Documenting non-functional behaviors is pretty much worthless, if there's no CI test, don't expect some desired non-functional behavior to be conserved over time... You become what you test and measure...