### PR TITLE
odb/gui: coverity fixes

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -139,11 +139,11 @@ ScriptWidget::ScriptWidget(QWidget* parent)
 // the logging, so, for reports, we use a buffer.
 void ScriptWidget::flushReportBufferToOutput()
 {
+  std::lock_guard guard(reporting_);
   if (report_buffer_.isEmpty()) {
     return;
   }
 
-  std::lock_guard guard(reporting_);
   // this comes from a ->report
   addTextToOutput(report_buffer_, buffer_msg_);
   report_buffer_.clear();

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7449,11 +7449,11 @@ class dbLevelShifter : public dbObject
 
   dbPowerDomain* getDomain() const;
 
-  void setSource(std::string source);
+  void setSource(const std::string& source);
 
   std::string getSource() const;
 
-  void setSink(std::string sink);
+  void setSink(const std::string& sink);
 
   std::string getSink() const;
 
@@ -7461,15 +7461,15 @@ class dbLevelShifter : public dbObject
 
   bool isUseFunctionalEquivalence() const;
 
-  void setAppliesTo(std::string applies_to);
+  void setAppliesTo(const std::string& applies_to);
 
   std::string getAppliesTo() const;
 
-  void setAppliesToBoundary(std::string applies_to_boundary);
+  void setAppliesToBoundary(const std::string& applies_to_boundary);
 
   std::string getAppliesToBoundary() const;
 
-  void setRule(std::string rule);
+  void setRule(const std::string& rule);
 
   std::string getRule() const;
 
@@ -7485,39 +7485,39 @@ class dbLevelShifter : public dbObject
 
   bool isForceShift() const;
 
-  void setLocation(std::string location);
+  void setLocation(const std::string& location);
 
   std::string getLocation() const;
 
-  void setInputSupply(std::string input_supply);
+  void setInputSupply(const std::string& input_supply);
 
   std::string getInputSupply() const;
 
-  void setOutputSupply(std::string output_supply);
+  void setOutputSupply(const std::string& output_supply);
 
   std::string getOutputSupply() const;
 
-  void setInternalSupply(std::string internal_supply);
+  void setInternalSupply(const std::string& internal_supply);
 
   std::string getInternalSupply() const;
 
-  void setNamePrefix(std::string name_prefix);
+  void setNamePrefix(const std::string& name_prefix);
 
   std::string getNamePrefix() const;
 
-  void setNameSuffix(std::string name_suffix);
+  void setNameSuffix(const std::string& name_suffix);
 
   std::string getNameSuffix() const;
 
-  void setCellName(std::string cell_name);
+  void setCellName(const std::string& cell_name);
 
   std::string getCellName() const;
 
-  void setCellInput(std::string cell_input);
+  void setCellInput(const std::string& cell_input);
 
   std::string getCellInput() const;
 
-  void setCellOutput(std::string cell_output);
+  void setCellOutput(const std::string& cell_output);
 
   std::string getCellOutput() const;
 
@@ -7577,7 +7577,7 @@ class dbMetalWidthViaMap : public dbObject
 
   int getAboveLayerWidthHigh() const;
 
-  void setViaName(std::string via_name);
+  void setViaName(const std::string& via_name);
 
   std::string getViaName() const;
 
@@ -9415,7 +9415,7 @@ class dbTechLayerEolKeepOutRule : public dbObject
 
   int getWithinHigh() const;
 
-  void setClassName(std::string class_name);
+  void setClassName(const std::string& class_name);
 
   std::string getClassName() const;
 
@@ -9484,11 +9484,11 @@ class dbTechLayerForbiddenSpacingRule : public dbObject
 class dbTechLayerKeepOutZoneRule : public dbObject
 {
  public:
-  void setFirstCutClass(std::string first_cut_class);
+  void setFirstCutClass(const std::string& first_cut_class);
 
   std::string getFirstCutClass() const;
 
-  void setSecondCutClass(std::string second_cut_class);
+  void setSecondCutClass(const std::string& second_cut_class);
 
   std::string getSecondCutClass() const;
 
@@ -9556,7 +9556,7 @@ class dbTechLayerKeepOutZoneRule : public dbObject
 class dbTechLayerMaxSpacingRule : public dbObject
 {
  public:
-  void setCutClass(std::string cut_class);
+  void setCutClass(const std::string& cut_class);
 
   std::string getCutClass() const;
 

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -21,6 +21,7 @@ from helper import (
     is_bit_fields,
     is_hash_table,
     is_pass_by_ref,
+    is_set_by_ref,
     is_ref,
     std,
 )
@@ -199,6 +200,7 @@ for klass in schema["classes"]:
         field["isHashTable"] = is_hash_table(field["type"])
         field["hashTableType"] = get_hash_table_type(field["type"])
         field["isPassByRef"] = is_pass_by_ref(field["type"])
+        field["isSetByRef"] = is_set_by_ref(field["type"])
         if "argument" not in field:
             field["argument"] = field["name"].strip("_")
         field.setdefault("flags", [])

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -136,6 +136,10 @@ def is_pass_by_ref(type_name):
     return type_name.find("dbVector") == 0
 
 
+def is_set_by_ref(type_name):
+    return type_name == "std::string"
+
+
 def _is_template_type(type_name):
     open_bracket = type_name.find("<")
     if open_bracket == -1:

--- a/src/odb/src/codeGenerator/schema/chip/dbPolygon.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbPolygon.json
@@ -21,33 +21,38 @@
     {
       "name":"polygon_",
       "type":"Polygon",
-      "flags":["no-set"]
+      "flags":["no-set"],
+      "default": "{}"
     },
     {
       "name":"design_rule_width_",
       "type":"int",
-      "flags":["no-set"]
+      "flags":["no-set"],
+      "default": "0"
     },
     {
       "name": "owner_",
       "type": "uint",
       "flags": [
         "private"
-      ]
+      ],
+      "default": "0"
     },
     {
       "name": "next_pbox_",
       "type": "dbId<_dbPolygon>",
       "flags": [
         "private"
-      ]
+      ],
+      "default": "0"
     },
     {
       "name": "boxes_",
       "type": "dbId<_dbBox>",
       "flags": [
         "private"
-      ]
+      ],
+      "default": "0"
     }
   ],
   "h_includes": [

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayerMaxSpacingRule.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayerMaxSpacingRule.json
@@ -8,7 +8,8 @@
       },
       {
         "type": "int",
-        "name": "max_spacing_"
+        "name": "max_spacing_",
+        "default": "0"
       }
     ],
     "cpp_includes": [

--- a/src/odb/src/codeGenerator/templates/db.h
+++ b/src/odb/src/codeGenerator/templates/db.h
@@ -39,7 +39,7 @@ class {{klass.name}} : public dbObject
   // User Code End {{klass.name}}Enums
   {% for field in klass.fields %}
     {% if 'no-set' not in field.flags %}
-      void {{field.setterFunctionName}} ({{field.setterArgumentType}} {{field.argument}} );
+      void {{field.setterFunctionName}} ({% if field.isSetByRef %}const {{field.setterArgumentType}}&{% else %}{{field.setterArgumentType}}{% endif %} {{field.argument}} );
   
     {% endif %}
     {% if 'no-get' not in field.flags %}

--- a/src/odb/src/codeGenerator/templates/impl.cpp
+++ b/src/odb/src/codeGenerator/templates/impl.cpp
@@ -288,7 +288,7 @@ namespace odb {
   {% for field in klass.fields %}
   
     {% if 'no-set' not in field.flags %}
-      void {{klass.name}}::{{field.setterFunctionName}}( {{field.setterArgumentType}} {{field.argument}} )
+      void {{klass.name}}::{{field.setterFunctionName}}( {% if field.isSetByRef %}const {{field.setterArgumentType}}&{% else %}{{field.setterArgumentType}}{% endif %} {{field.argument}} )
       {
     
         _{{klass.name}}* obj = (_{{klass.name}}*)this;
@@ -298,6 +298,7 @@ namespace odb {
           obj->{{field.name}}={{field.argument}}->getImpl()->getOID();
     
         {% else %}
+
           obj->{{field.name}}={{field.argument}};
     
         {% endif %}

--- a/src/odb/src/db/dbLevelShifter.cpp
+++ b/src/odb/src/db/dbLevelShifter.cpp
@@ -304,7 +304,7 @@ dbPowerDomain* dbLevelShifter::getDomain() const
   return (dbPowerDomain*) par->_powerdomain_tbl->getPtr(obj->_domain);
 }
 
-void dbLevelShifter::setSource(std::string source)
+void dbLevelShifter::setSource(const std::string& source)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -317,7 +317,7 @@ std::string dbLevelShifter::getSource() const
   return obj->_source;
 }
 
-void dbLevelShifter::setSink(std::string sink)
+void dbLevelShifter::setSink(const std::string& sink)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -344,7 +344,7 @@ bool dbLevelShifter::isUseFunctionalEquivalence() const
   return obj->_use_functional_equivalence;
 }
 
-void dbLevelShifter::setAppliesTo(std::string applies_to)
+void dbLevelShifter::setAppliesTo(const std::string& applies_to)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -357,7 +357,8 @@ std::string dbLevelShifter::getAppliesTo() const
   return obj->_applies_to;
 }
 
-void dbLevelShifter::setAppliesToBoundary(std::string applies_to_boundary)
+void dbLevelShifter::setAppliesToBoundary(
+    const std::string& applies_to_boundary)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -370,7 +371,7 @@ std::string dbLevelShifter::getAppliesToBoundary() const
   return obj->_applies_to_boundary;
 }
 
-void dbLevelShifter::setRule(std::string rule)
+void dbLevelShifter::setRule(const std::string& rule)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -422,7 +423,7 @@ bool dbLevelShifter::isForceShift() const
   return obj->_force_shift;
 }
 
-void dbLevelShifter::setLocation(std::string location)
+void dbLevelShifter::setLocation(const std::string& location)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -435,7 +436,7 @@ std::string dbLevelShifter::getLocation() const
   return obj->_location;
 }
 
-void dbLevelShifter::setInputSupply(std::string input_supply)
+void dbLevelShifter::setInputSupply(const std::string& input_supply)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -448,7 +449,7 @@ std::string dbLevelShifter::getInputSupply() const
   return obj->_input_supply;
 }
 
-void dbLevelShifter::setOutputSupply(std::string output_supply)
+void dbLevelShifter::setOutputSupply(const std::string& output_supply)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -461,7 +462,7 @@ std::string dbLevelShifter::getOutputSupply() const
   return obj->_output_supply;
 }
 
-void dbLevelShifter::setInternalSupply(std::string internal_supply)
+void dbLevelShifter::setInternalSupply(const std::string& internal_supply)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -474,7 +475,7 @@ std::string dbLevelShifter::getInternalSupply() const
   return obj->_internal_supply;
 }
 
-void dbLevelShifter::setNamePrefix(std::string name_prefix)
+void dbLevelShifter::setNamePrefix(const std::string& name_prefix)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -487,7 +488,7 @@ std::string dbLevelShifter::getNamePrefix() const
   return obj->_name_prefix;
 }
 
-void dbLevelShifter::setNameSuffix(std::string name_suffix)
+void dbLevelShifter::setNameSuffix(const std::string& name_suffix)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -500,7 +501,7 @@ std::string dbLevelShifter::getNameSuffix() const
   return obj->_name_suffix;
 }
 
-void dbLevelShifter::setCellName(std::string cell_name)
+void dbLevelShifter::setCellName(const std::string& cell_name)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -513,7 +514,7 @@ std::string dbLevelShifter::getCellName() const
   return obj->_cell_name;
 }
 
-void dbLevelShifter::setCellInput(std::string cell_input)
+void dbLevelShifter::setCellInput(const std::string& cell_input)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 
@@ -526,7 +527,7 @@ std::string dbLevelShifter::getCellInput() const
   return obj->_cell_input;
 }
 
-void dbLevelShifter::setCellOutput(std::string cell_output)
+void dbLevelShifter::setCellOutput(const std::string& cell_output)
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
 

--- a/src/odb/src/db/dbMetalWidthViaMap.cpp
+++ b/src/odb/src/db/dbMetalWidthViaMap.cpp
@@ -238,7 +238,7 @@ int dbMetalWidthViaMap::getAboveLayerWidthHigh() const
   return obj->above_layer_width_high_;
 }
 
-void dbMetalWidthViaMap::setViaName(std::string via_name)
+void dbMetalWidthViaMap::setViaName(const std::string& via_name)
 {
   _dbMetalWidthViaMap* obj = (_dbMetalWidthViaMap*) this;
 

--- a/src/odb/src/db/dbPolygon.cpp
+++ b/src/odb/src/db/dbPolygon.cpp
@@ -118,6 +118,11 @@ void _dbPolygon::out(dbDiff& diff, char side, const char* field) const
 _dbPolygon::_dbPolygon(_dbDatabase* db)
 {
   flags_ = {};
+  polygon_ = {};
+  design_rule_width_ = 0;
+  owner_ = 0;
+  next_pbox_ = 0;
+  boxes_ = 0;
 }
 
 _dbPolygon::_dbPolygon(_dbDatabase* db, const _dbPolygon& r)

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
@@ -271,7 +271,7 @@ int dbTechLayerEolKeepOutRule::getWithinHigh() const
   return obj->within_high_;
 }
 
-void dbTechLayerEolKeepOutRule::setClassName(std::string class_name)
+void dbTechLayerEolKeepOutRule::setClassName(const std::string& class_name)
 {
   _dbTechLayerEolKeepOutRule* obj = (_dbTechLayerEolKeepOutRule*) this;
 

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
@@ -230,7 +230,8 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerKeepOutZoneRule& obj)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbTechLayerKeepOutZoneRule::setFirstCutClass(std::string first_cut_class)
+void dbTechLayerKeepOutZoneRule::setFirstCutClass(
+    const std::string& first_cut_class)
 {
   _dbTechLayerKeepOutZoneRule* obj = (_dbTechLayerKeepOutZoneRule*) this;
 
@@ -243,7 +244,8 @@ std::string dbTechLayerKeepOutZoneRule::getFirstCutClass() const
   return obj->first_cut_class_;
 }
 
-void dbTechLayerKeepOutZoneRule::setSecondCutClass(std::string second_cut_class)
+void dbTechLayerKeepOutZoneRule::setSecondCutClass(
+    const std::string& second_cut_class)
 {
   _dbTechLayerKeepOutZoneRule* obj = (_dbTechLayerKeepOutZoneRule*) this;
 

--- a/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
@@ -85,6 +85,7 @@ void _dbTechLayerMaxSpacingRule::out(dbDiff& diff,
 
 _dbTechLayerMaxSpacingRule::_dbTechLayerMaxSpacingRule(_dbDatabase* db)
 {
+  max_spacing_ = 0;
 }
 
 _dbTechLayerMaxSpacingRule::_dbTechLayerMaxSpacingRule(

--- a/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
@@ -116,7 +116,7 @@ dbOStream& operator<<(dbOStream& stream, const _dbTechLayerMaxSpacingRule& obj)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbTechLayerMaxSpacingRule::setCutClass(std::string cut_class)
+void dbTechLayerMaxSpacingRule::setCutClass(const std::string& cut_class)
 {
   _dbTechLayerMaxSpacingRule* obj = (_dbTechLayerMaxSpacingRule*) this;
 


### PR DESCRIPTION
Added:
- `const std::string& arg` to code generator in ODB since that seemed to be a common warning from the SWIG generated code.
- defaults to the two classes identified.