### PR TITLE
odb: add .center() function to Rect

### DIFF
--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -242,6 +242,7 @@ class Rect
   Point ul() const;
   Point ur() const;
   Point lr() const;
+  Point center() const;
 
   // Returns the low coordinate in the orientation
   int low(Orientation2D orient) const;
@@ -526,6 +527,11 @@ inline Point Rect::ur() const
 inline Point Rect::lr() const
 {
   return Point(xhi_, ylo_);
+}
+
+inline Point Rect::center() const
+{
+  return Point(xCenter(), yCenter());
 }
 
 inline void Rect::set(Orientation2D orient, Direction1D dir, int value)

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1211,10 +1211,8 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
   if (terms.size() == 2) {
     const auto& [shape0, term0] = *terms.begin();
     const auto& [shape1, term1] = *terms.rbegin();
-    const odb::Point shape0center(shape0.xCenter(), shape0.yCenter());
-    const odb::Point shape1center(shape1.xCenter(), shape1.yCenter());
-    pairs.push_back({{shape0center, shape0, term0.first, term0.second},
-                     {shape1center, shape1, term1.first, term1.second}});
+    pairs.push_back({{shape0.center(), shape0, term0.first, term0.second},
+                     {shape1.center(), shape1, term1.first, term1.second}});
   } else {
     std::set<odb::Rect> used;
     for (const auto& [shape0, iterm0] : terms) {
@@ -1248,7 +1246,7 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
       }
 
       int64_t dist = std::numeric_limits<int64_t>::max();
-      const odb::Point pt0(shape0.xCenter(), shape0.yCenter());
+      const odb::Point pt0 = shape0.center();
       odb::Rect shape = shape0;
       odb::Point point = pt0;
       odb::dbITerm* term = iterm0.first;
@@ -1267,7 +1265,7 @@ std::vector<RDLRouter::TargetPair> RDLRouter::generateRoutingPairs(
           continue;
         }
 
-        const odb::Point pt1(shape1.xCenter(), shape1.yCenter());
+        const odb::Point pt1 = shape1.center();
         const int64_t new_dist = distance(pt0, pt1);
 
         debugPrint(logger_,

--- a/src/psm/src/ir_network.cpp
+++ b/src/psm/src/ir_network.cpp
@@ -341,7 +341,6 @@ IRNetwork::generatePolygonsFromBTerms(std::vector<TerminalNode*>& terminals)
 
         auto* layer = geom->getTechLayer();
         const odb::Rect pin_shape = geom->getBox();
-        const odb::Point center(pin_shape.xCenter(), pin_shape.yCenter());
 
         // create bpin nodes
         auto term = std::make_unique<TerminalNode>(pin_shape, layer);
@@ -405,14 +404,14 @@ void IRNetwork::processPolygonToRectangles(
          search++) {
       if (search->intersects(rect)) {
         const odb::Rect intersect = search->intersect(rect);
-        nodes.emplace(intersect.xCenter(), intersect.yCenter());
+        nodes.emplace(intersect.center());
       }
     }
 
     auto shape = std::make_unique<Shape>(rect, layer);
 
     // Create starter nodes
-    nodes.emplace(rect.xCenter(), rect.yCenter());
+    nodes.emplace(rect.center());
     for (const auto& pt : nodes) {
       auto node = std::make_unique<Node>(pt, layer);
 
@@ -602,10 +601,9 @@ void IRNetwork::generateCutNodesForSBox(
   } else {
     for (const auto& shape : via_shapes) {
       const odb::Rect via = shape.getBox();
-      const odb::Point pt(via.xCenter(), via.yCenter());
 
-      auto bottom_node = std::make_unique<Node>(pt, bottom);
-      auto top_node = std::make_unique<Node>(pt, top);
+      auto bottom_node = std::make_unique<Node>(via.center(), bottom);
+      auto top_node = std::make_unique<Node>(via.center(), top);
 
       new_connections.push_back(std::make_unique<ViaConnection>(
           bottom_node.get(), top_node.get(), getEffectiveNumberOfCuts(shape)));

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -538,7 +538,7 @@ IRSolver::generateSourceNodesGenericBumps() const
   }
 
   if (bumps.empty()) {
-    const odb::Point die_center(die_area.xCenter(), die_area.yCenter());
+    const odb::Point die_center = die_area.center();
     bumps.emplace(die_center.x() - size / 2,
                   die_center.y() - size / 2,
                   die_center.x() + size / 2,
@@ -593,9 +593,8 @@ IRSolver::generateSourceNodesFromShapes(const std::set<odb::Rect>& shapes) const
     if (!found) {
       // Since the shape didn't intersect anything, we need to pick the nearest
       // node
-      const odb::Point pt(shape.xCenter(), shape.yCenter());
       std::vector<Node*> returned_nodes;
-      top_nodes.query(boost::geometry::index::nearest(pt, 1),
+      top_nodes.query(boost::geometry::index::nearest(shape.center(), 1),
                       std::back_inserter(returned_nodes));
 
       for (Node* node : returned_nodes) {

--- a/src/psm/src/node.cpp
+++ b/src/psm/src/node.cpp
@@ -120,7 +120,7 @@ std::string Node::getTypeName() const
 ///////////////////
 
 TerminalNode::TerminalNode(const odb::Rect& shape, odb::dbTechLayer* layer)
-    : Node(odb::Point(shape.xCenter(), shape.yCenter()), layer), shape_(shape)
+    : Node(odb::Point(shape.center()), layer), shape_(shape)
 {
 }
 

--- a/src/psm/src/shape.cpp
+++ b/src/psm/src/shape.cpp
@@ -161,7 +161,7 @@ std::set<Node*> Shape::cleanupNodes(
   const Node::NodeSet sorted_nodes = getNodes(layer_nodes);
   Node::NodeSet center_nodes;
   Node::NodeSet non_center_nodes;
-  const odb::Point shape_center(shape_.xCenter(), shape_.yCenter());
+  const odb::Point shape_center = shape_.center();
   for (auto* node : sorted_nodes) {
     const auto& pt = node->getPoint();
     if (pt.x() == shape_center.x() || pt.y() == shape_center.y()) {


### PR DESCRIPTION
I found myself typing this several times in the last couple of days so I thought a helper function would be useful.

Adds:
- helper function to get the `.center()` point of a `Rect`

Changes:
- where possible in psm/pad use `.center()`

Notes:
- more would be possible, but in many places we pass around the `x,y` coordinates and not a `Point` so there would be more places possible in the future if that changes.