### PR TITLE
gui: ensure flush is called on the buffer before logging output to preserve printing order

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -432,6 +432,7 @@ class ScriptWidget::GuiSink : public spdlog::sinks::base_sink<Mutex>
                                     ? widget_->error_msg_
                                     : widget_->buffer_msg_;
 
+      widget_->flushReportBufferToOutput();
       widget_->addLogToOutput(formatted_msg, msg_color);
     }
 


### PR DESCRIPTION
I noticed that the order of the printouts in the gui were wrong. This corrects it by ensuring that the buffer is flushed before processing more text. There should not be any performance slowdown from this.

![image](https://github.com/user-attachments/assets/f8c628dc-6609-4f57-ad97-a689f3fad701)

vs . 

![image](https://github.com/user-attachments/assets/280ce3b0-ca3a-4842-a7ab-55bfcd23a6db)
