### PR TITLE
gui: use try_lock for flushing buffer

### DIFF
--- a/src/gui/src/scriptWidget.cpp
+++ b/src/gui/src/scriptWidget.cpp
@@ -139,7 +139,15 @@ ScriptWidget::ScriptWidget(QWidget* parent)
 // the logging, so, for reports, we use a buffer.
 void ScriptWidget::flushReportBufferToOutput()
 {
-  std::lock_guard guard(reporting_);
+  std::unique_lock guard(reporting_, std::try_to_lock);
+  if (!guard.owns_lock()) {
+    // failed to aquire lock
+    // return and this will be called at some point later
+    QTimer::singleShot(report_display_interval,
+                       this,
+                       &ScriptWidget::flushReportBufferToOutput);
+    return;
+  }
   if (report_buffer_.isEmpty()) {
     return;
   }


### PR DESCRIPTION
Why:
- I noticed the GUI would periodically lock up on me when the GUI was active and reports were printing.
- When checking in GDB it was this lock that kept coming up as waiting to lock, but not able to.

Change:
- changes this to a `try_to_lock` (non blocking), if it fails to aquire the lock it will just restart a timer to call this later and return without flushing the buffer. This might cause the GUI to print things out of order compared to the cmdline, but avoids the lock up because the flush was unable to get the mutex.

I'm open to suggestions on how to better resolve this issue, but this "lazy"-lock approach was the simplest I could think of.