### PR TITLE
pad: fix debug segfault when GUI is in use

### DIFF
--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -1612,7 +1612,9 @@ void RDLGui::drawObjects(gui::Painter& painter)
 void RDLGui::setRouter(RDLRouter* router)
 {
   router_ = router;
-  router_->setRDLGui(this);
+  if (router_) {
+    router_->setRDLGui(this);
+  }
 }
 
 void RDLGui::pause()


### PR DESCRIPTION
Fixes:
- segfault when the GUI is in use with the router and the router is called again.