### PR TITLE
gui: use odb::Polygon instead of boost polygon and implement select by polygons

### DIFF
--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -643,12 +643,14 @@ std::pair<LayoutViewer::Edge, bool> LayoutViewer::searchNearestEdge(
         }
       }
       if (inst_pins_visible) {
-        for (auto& box : inst_boxes->mterms) {
-          const QRect rect = box.boundingRect();
-          odb::Rect trans_box(
-              rect.left(), rect.bottom(), rect.right(), rect.top());
-          inst_xfm.apply(trans_box);
-          check_rect(trans_box);
+        for (const auto& [mterm, boxes] : inst_boxes->mterms) {
+          for (const auto& box : boxes) {
+            const QRect rect = box.boundingRect();
+            odb::Rect trans_box(
+                rect.left(), rect.bottom(), rect.right(), rect.top());
+            inst_xfm.apply(trans_box);
+            check_rect(trans_box);
+          }
         }
       }
     }
@@ -950,17 +952,18 @@ void LayoutViewer::selectAt(odb::Rect region, std::vector<Selected>& selections)
       if (options_->areInstancePinsVisible()
           && options_->areInstancePinsSelectable()) {
         const odb::dbTransform xform = inst->getTransform();
-        for (auto* iterm : inst->getITerms()) {
-          for (auto* mpin : iterm->getMTerm()->getMPins()) {
-            for (auto* geom : mpin->getGeometry()) {
-              const auto layer = geom->getTechLayer();
-              if (layer == nullptr) {
-                continue;
-              }
-              if (options_->isVisible(layer) && options_->isSelectable(layer)) {
-                Rect pin_rect = geom->getBox();
-                xform.apply(pin_rect);
-                if (region.intersects(pin_rect)) {
+        for (const auto& [layer, boxes] : cell_boxes_[inst->getMaster()]) {
+          if (options_->isVisible(layer) && options_->isSelectable(layer)) {
+            for (const auto& [mterm, geoms] : boxes.mterms) {
+              odb::dbITerm* iterm = inst->getITerm(mterm);
+              for (const auto& geom : geoms) {
+                std::vector<odb::Point> points(geom.size());
+                for (const auto& pt : geom) {
+                  points.emplace_back(pt.x(), pt.y());
+                }
+                odb::Polygon poly(points);
+                xform.apply(poly);
+                if (boost::geometry::intersects(poly, region)) {
                   selections.push_back(gui_->makeSelected(iterm));
                 }
               }
@@ -1363,11 +1366,11 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
       if (!is_db_view) {
         for (dbPolygon* box : mpin->getPolygonGeometry()) {
           dbTechLayer* layer = box->getTechLayer();
-          boxes[layer].mterms.emplace_back(pbox_to_qpolygon(box));
+          boxes[layer].mterms[mterm].emplace_back(pbox_to_qpolygon(box));
         }
         for (dbBox* box : mpin->getGeometry(false)) {
           dbTechLayer* layer = box->getTechLayer();
-          boxes[layer].mterms.emplace_back(box_to_qpolygon(box));
+          boxes[layer].mterms[mterm].emplace_back(box_to_qpolygon(box));
         }
       }
       for (dbBox* box : mpin->getGeometry()) {
@@ -1382,7 +1385,7 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
             odb::Rect box_rect = via_box->getBox();
             dbTechLayer* layer = via_box->getTechLayer();
             via_transform.apply(box_rect);
-            boxes[layer].mterms.emplace_back(
+            boxes[layer].mterms[mterm].emplace_back(
                 QRect{box_rect.xMin(),
                       box_rect.yMin(),
                       box_rect.xMax() - box_rect.xMin(),
@@ -1391,7 +1394,7 @@ void LayoutViewer::boxesByLayer(dbMaster* master, LayerBoxes& boxes)
         } else if (is_db_view) {
           odb::Rect box_rect = box->getBox();
           dbTechLayer* layer = box->getTechLayer();
-          boxes[layer].mterms.emplace_back(
+          boxes[layer].mterms[mterm].emplace_back(
               QRect{box_rect.xMin(),
                     box_rect.yMin(),
                     box_rect.xMax() - box_rect.xMin(),

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -291,7 +291,7 @@ class LayoutViewer : public QWidget
   struct Boxes
   {
     std::vector<QPolygon> obs;
-    std::vector<QPolygon> mterms;
+    std::map<odb::dbMTerm*, std::vector<QPolygon>> mterms;
   };
 
   using LayerBoxes = std::map<odb::dbTechLayer*, Boxes>;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -584,8 +584,10 @@ void RenderThread::drawInstanceShapes(dbTechLayer* layer,
 
     if (show_pins) {
       painter->setBrush(QBrush(color, brush_pattern));
-      for (const auto& poly : boxes->mterms) {
-        painter->drawPolygon(poly);
+      for (const auto& [mterm, polys] : boxes->mterms) {
+        for (const auto& poly : polys) {
+          painter->drawPolygon(poly);
+        }
       }
     }
   }
@@ -979,10 +981,11 @@ void RenderThread::drawLayer(QPainter* painter,
         if (!viewer_->isNetVisible(net)) {
           continue;
         }
-        const int size = poly.outer().size();
-        QPolygon qpoly(size);
-        for (int i = 0; i < size; i++) {
-          qpoly.setPoint(i, poly.outer()[i].x(), poly.outer()[i].y());
+        const auto& points = poly.getPoints();
+        QPolygon qpoly(points.size());
+        for (int i = 0; i < points.size(); i++) {
+          const auto& pt = points[i];
+          qpoly.setPoint(i, pt.x(), pt.y());
         }
         painter->drawPolygon(qpoly);
       }

--- a/src/gui/src/search.cpp
+++ b/src/gui/src/search.cpp
@@ -452,18 +452,11 @@ void Search::addSNet(
         }
         via_shapes[layer].emplace_back(box, net);
       } else {
-        std::vector<odb::Point> points;
         if (box->getDirection() == odb::dbSBox::OCTILINEAR) {
-          points = box->getOct().getPoints();
+          net_shapes[box->getTechLayer()].emplace_back(box, box->getOct(), net);
         } else {
-          const odb::Rect rect = box->getBox();
-          points = rect.getPoints();
+          net_shapes[box->getTechLayer()].emplace_back(box, box->getBox(), net);
         }
-        Polygon poly;
-        for (const auto& point : points) {
-          bg::append(poly.outer(), point);
-        }
-        net_shapes[box->getTechLayer()].emplace_back(box, poly, net);
       }
     }
   }
@@ -532,6 +525,32 @@ class Search::MinSizePredicate
 
  private:
   int min_size_;
+};
+
+template <typename T>
+class Search::PolygonIntersectPredicate
+{
+ public:
+  PolygonIntersectPredicate(const odb::Rect& region) : region_(region) {}
+  bool operator()(const SNetValue<T>& o) const
+  {
+    return checkPolygon(std::get<1>(o));
+  }
+
+  bool operator()(const RectValue<T>& o) const { return checkPolygon(o.first); }
+
+  bool operator()(const RouteBoxValue<T>& o) const
+  {
+    return checkPolygon(std::get<0>(o));
+  }
+
+  bool checkPolygon(const odb::Polygon& poly) const
+  {
+    return boost::geometry::intersects(region_, poly);
+  }
+
+ private:
+  odb::Rect region_;
 };
 
 template <typename T>
@@ -656,11 +675,16 @@ Search::SNetShapeRange Search::searchSNetShapes(odb::dbBlock* block,
     return SNetShapeRange(
         rtree.qbegin(
             bgi::intersects(query)
-            && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size))),
+            && bgi::satisfies(MinSizePredicate<odb::dbNet*>(min_size))
+            && bgi::satisfies(PolygonIntersectPredicate<odb::dbNet*>(query))),
         rtree.qend());
   }
 
-  return SNetShapeRange(rtree.qbegin(bgi::intersects(query)), rtree.qend());
+  return SNetShapeRange(
+      rtree.qbegin(
+          bgi::intersects(query)
+          && bgi::satisfies(PolygonIntersectPredicate<odb::dbNet*>(query))),
+      rtree.qend());
 }
 
 Search::FillRange Search::searchFills(odb::dbBlock* block,

--- a/src/gui/src/search.h
+++ b/src/gui/src/search.h
@@ -63,19 +63,19 @@ class Search : public QObject, public odb::dbBlockCallBackObj
   template <typename T>
   class MinHeightPredicate;
 
+  template <typename T>
+  class PolygonIntersectPredicate;
+
  public:
   template <typename T>
   using LayerMap = std::map<odb::dbTechLayer*, T>;
 
-  using Polygon
-      = bg::model::polygon<odb::Point,
-                           false>;  // counterclockwise(clockwise=false)
   template <typename T>
   using RectValue = std::pair<odb::Rect, T>;
   template <typename T>
   using RouteBoxValue = std::tuple<odb::Rect, bool, T>;
   template <typename T>
-  using SNetValue = std::tuple<odb::dbSBox*, Polygon, T>;
+  using SNetValue = std::tuple<odb::dbSBox*, odb::Polygon, T>;
   template <typename T>
   using SNetDBoxValue = std::pair<odb::dbSBox*, T>;
   ;


### PR DESCRIPTION
Changes:
- use polygons for intersection searching to better control `selectAt` to avoid selecting the entire bounding box but actually select the Octagon or polygon correctly.
- use CellBoxes to search MTerms since we have already done this for rendering.
