### PR TITLE
test: disable sta mt

### DIFF
--- a/test/flow.tcl
+++ b/test/flow.tcl
@@ -40,6 +40,8 @@ link_design $top_module
 read_sdc $sdc_file
 
 set_thread_count [exec getconf _NPROCESSORS_ONLN]
+# Temporarily disable sta's threading due to random failures
+sta::set_thread_count 1
 
 utl::metric "IFP::ord_version" [ord::openroad_git_describe]
 # Note that sta::network_instance_count is not valid after tapcells are added.


### PR DESCRIPTION
I noticed a few random crashes in some PRs that are unrelated to their changes. The stack trace is similar to what we saw on ORFS, caused by using MT in sta. This PR disables sta mt to avoid these random crashes.