### PR TITLE
Minor fixes to verilog writer/instance creation (network Edit Function)

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -202,6 +202,7 @@ class dbNetwork : public ConcreteNetwork
   Cell* cell(const Instance* instance) const override;
   Instance* parent(const Instance* instance) const override;
   bool isLeaf(const Instance* instance) const override;
+  Port* findPort(const Cell* cell, const char* name) const override;
   Instance* findInstance(const char* path_name) const override;
   Instance* findChild(const Instance* parent, const char* name) const override;
   InstanceChildIterator* childIterator(const Instance* instance) const override;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -346,9 +346,8 @@ bool DbInstanceNetIterator::hasNext()
 {
   if (network_->hasHierarchy()) {
     return mod_net_iter_ != mod_net_end_;
-  } else {
-    return iter_ != end_;
   }
+  return iter_ != end_;
 }
 
 Net* DbInstanceNetIterator::next()

--- a/src/dbSta/test/hier2_out.vok
+++ b/src/dbSta/test/hier2_out.vok
@@ -5,7 +5,6 @@ module top (a,
  input b;
  output out;
 
- wire a_int;
 
  INV_X1 _4_ (.ZN(a_int),
     .A(a));

--- a/src/dbSta/test/hierclock_out.vok
+++ b/src/dbSta/test/hierclock_out.vok
@@ -19,64 +19,6 @@ module hierclock (a_count_valid_o,
  output [3:0] b_count_o;
  input [3:0] b_i;
 
- wire clk1_int;
- wire clk2_int;
- wire \U1/_03_ ;
- wire \U1/_04_ ;
- wire \U1/_05_ ;
- wire \U1/_06_ ;
- wire \U1/_11_ ;
- wire \U1/_12_ ;
- wire \U1/_13_ ;
- wire \U1/_14_ ;
- wire \U1/_15_ ;
- wire \U1/_19_ ;
- wire \U1/_20_ ;
- wire \U1/_21_ ;
- wire \U1/_22_ ;
- wire \U2/_12_ ;
- wire \U2/_13_ ;
- wire \U2/_14_ ;
- wire \U2/_15_ ;
- wire \U2/_16_ ;
- wire \U2/_26_ ;
- wire \U2/_27_ ;
- wire \U2/_28_ ;
- wire \U2/_29_ ;
- wire \U2/_30_ ;
- wire \U2/_31_ ;
- wire \U2/_32_ ;
- wire \U2/_33_ ;
- wire \U2/_34_ ;
- wire \U2/_35_ ;
- wire \U2/_36_ ;
- wire \U2/_38_ ;
- wire \U2/_39_ ;
- wire \U2/_40_ ;
- wire \U2/_41_ ;
- wire \U2/_42_ ;
- wire \U3/_12_ ;
- wire \U3/_13_ ;
- wire \U3/_14_ ;
- wire \U3/_15_ ;
- wire \U3/_16_ ;
- wire \U3/_26_ ;
- wire \U3/_27_ ;
- wire \U3/_28_ ;
- wire \U3/_29_ ;
- wire \U3/_30_ ;
- wire \U3/_31_ ;
- wire \U3/_32_ ;
- wire \U3/_33_ ;
- wire \U3/_34_ ;
- wire \U3/_35_ ;
- wire \U3/_36_ ;
- wire \U3/_38_ ;
- wire \U3/_39_ ;
- wire \U3/_40_ ;
- wire \U3/_41_ ;
- wire \U3/_42_ ;
- wire [2:0] \U1/counter_q ;
 
  clockgen U1 (.clk_i(clk_i),
     .rst_n_i(rst_n_i),
@@ -116,6 +58,19 @@ module clockgen (clk_i,
  output clk1_o;
  output clk2_o;
 
+ wire _19_;
+ wire _20_;
+ wire _21_;
+ wire _06_;
+ wire _15_;
+ wire _05_;
+ wire _14_;
+ wire _13_;
+ wire _12_;
+ wire _03_;
+ wire _22_;
+ wire _11_;
+ wire [3:0] counter_q;
 
  INV_X1 \U1/_28_  (.A(rst_n_i),
     .ZN(_11_));
@@ -178,6 +133,26 @@ module counter (clk_i,
  output [3:0] count_value_o;
  output count_valid_o;
 
+ wire _38_;
+ wire _39_;
+ wire _40_;
+ wire _42_;
+ wire count_valid_q;
+ wire _16_;
+ wire _36_;
+ wire _35_;
+ wire _33_;
+ wire _32_;
+ wire _14_;
+ wire _31_;
+ wire _30_;
+ wire _29_;
+ wire _13_;
+ wire _28_;
+ wire _27_;
+ wire _26_;
+ wire _41_;
+ wire [3:0] counter_q;
 
  INV_X1 \U2/_49_  (.A(_41_),
     .ZN(_26_));
@@ -268,6 +243,27 @@ module counter-1 (clk_i,
  output [3:0] count_value_o;
  output count_valid_o;
 
+ wire _38_;
+ wire _39_;
+ wire _40_;
+ wire _42_;
+ wire count_valid_q;
+ wire _16_;
+ wire _36_;
+ wire _35_;
+ wire _15_;
+ wire _33_;
+ wire _32_;
+ wire _14_;
+ wire _31_;
+ wire _30_;
+ wire _29_;
+ wire _13_;
+ wire _28_;
+ wire _12_;
+ wire _26_;
+ wire _41_;
+ wire [3:0] counter_q;
 
  INV_X1 \U3/_49_  (.A(_41_),
     .ZN(_26_));

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -1,4 +1,5 @@
 record_tests {
+    resize1_hier
   buffer_ports1
   buffer_ports3
   buffer_ports4

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -1,5 +1,5 @@
 record_tests {
-    resize1_hier
+  resize1_hier
   buffer_ports1
   buffer_ports3
   buffer_ports4

--- a/src/rsz/test/resize1_hier.ok
+++ b/src/rsz/test/resize1_hier.ok
@@ -1,0 +1,12 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+Instance u1/r1
+ Cell: DFF_X2
+ Library: Nangate45
+ Path cells: DFF_X2
+ Input pins:
+  D input in1
+  CK input clk1
+ Output pins:
+  Q output r1q
+  QN output (unconnected)
+No differences found.

--- a/src/rsz/test/resize1_hier.tcl
+++ b/src/rsz/test/resize1_hier.tcl
@@ -1,0 +1,21 @@
+# resize to target_slew
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog resize1_hier.v
+link_design top -hier
+create_clock -name clk -period 10 {clk1 clk2 clk3}
+set_input_delay -clock clk 0 {in1 in2}
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+set_load 30 u1/r1q
+rsz::resize_to_target_slew [get_pin u1/r1/Q]
+report_instance u1/r1
+
+set verilog_file [make_result_file resize1_hier.v]
+write_verilog $verilog_file
+
+diff_files $verilog_file resize1_hier.vok

--- a/src/rsz/test/resize1_hier.v
+++ b/src/rsz/test/resize1_hier.v
@@ -1,0 +1,52 @@
+/*
+ Hierarchical verilog version of resize test 1
+ */
+module top (
+            input  in1,
+            input  in2,
+            input  clk1,
+            input  clk2,
+            input  clk3,
+            output out);
+   u1 u1 (.in1(in1),
+          .in2(in2),
+          .clk1(clk1),
+          .clk2(clk2),
+          .clk3(clk3),
+          .out(out));
+endmodule // top
+
+module u1 (in1,
+    in2,
+    clk1,
+    clk2,
+    clk3,
+    out);
+          
+ input in1;
+ input in2;
+ input clk1;
+ input clk2;
+ input clk3;
+ output out;
+ wire r1q;
+ wire r2q;
+ wire u1z;
+ wire u2z;
+ AND2_X1 u2 (.A1(r1q),
+    .A2(u1z),
+    .ZN(u2z));
+ BUF_X1 u1 (.A(r2q),
+    .Z(u1z));
+          
+ DFF_X1 r3 (.D(u2z),
+    .CK(clk3),
+    .Q(out));
+          
+ DFF_X1 r2 (.D(in2),
+    .CK(clk2),
+    .Q(r2q));
+ DFF_X1 r1 (.D(in1),
+    .CK(clk1),
+    .Q(r1q));
+endmodule

--- a/src/rsz/test/resize1_hier.vok
+++ b/src/rsz/test/resize1_hier.vok
@@ -1,0 +1,54 @@
+module top (clk1,
+    clk2,
+    clk3,
+    in1,
+    in2,
+    out);
+ input clk1;
+ input clk2;
+ input clk3;
+ input in1;
+ input in2;
+ output out;
+
+ wire \u1/r1q ;
+ wire \u1/r2q ;
+ wire \u1/u1z ;
+ wire \u1/u2z ;
+
+ u1 u1 (.in1(in1),
+    .in2(in2),
+    .clk1(clk1),
+    .clk2(clk2),
+    .clk3(clk3),
+    .out(out));
+endmodule
+module u1 (in1,
+    in2,
+    clk1,
+    clk2,
+    clk3,
+    out);
+ input in1;
+ input in2;
+ input clk1;
+ input clk2;
+ input clk3;
+ output out;
+
+
+ DFF_X2 \u1/r1  (.D(in1),
+    .CK(clk1),
+    .Q(r1q));
+ DFF_X1 \u1/r2  (.D(in2),
+    .CK(clk2),
+    .Q(r2q));
+ DFF_X1 \u1/r3  (.D(u2z),
+    .CK(clk3),
+    .Q(out));
+ BUF_X1 \u1/u1  (.A(r2q),
+    .Z(u1z));
+ AND2_X1 \u1/u2  (.A1(r1q),
+    .A2(u1z),
+    .ZN(u2z));
+endmodule

--- a/src/rsz/test/resize1_hier.vok
+++ b/src/rsz/test/resize1_hier.vok
@@ -11,10 +11,6 @@ module top (clk1,
  input in2;
  output out;
 
- wire \u1/r1q ;
- wire \u1/r2q ;
- wire \u1/u1z ;
- wire \u1/u2z ;
 
  u1 u1 (.in1(in1),
     .in2(in2),
@@ -36,6 +32,10 @@ module u1 (in1,
  input clk3;
  output out;
 
+ wire r2q;
+ wire u2z;
+ wire u1z;
+ wire r1q;
 
  DFF_X2 \u1/r1  (.D(in1),
     .CK(clk1),


### PR DESCRIPTION
Clean up of verilog writer to use non-concrete network net iterator. Added hierarchical tests for resizer. Instance creation in Network Edit.