### PR TITLE
gui: Demangle type name when printing an warning.

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -287,10 +287,11 @@ Selected Gui::makeSelected(const std::any& object)
   if (it != descriptors_.end()) {
     return it->second->makeSelected(object);
   }
-  logger_->warn(utl::GUI,
-                33,
-                "No descriptor is registered for {}.",
-                object.type().name());
+  char* type_name
+      = abi::__cxa_demangle(object.type().name(), nullptr, nullptr, nullptr);
+  logger_->warn(
+      utl::GUI, 33, "No descriptor is registered for type {}.", type_name);
+  free(type_name);
   return Selected();  // FIXME: null descriptor
 }
 


### PR DESCRIPTION
The type names are mangled.

```
$ echo "PN3gui12DRCViolationE" | c++filt -t
gui::DRCViolation*
$ echo "Dn" | c++filt -t
decltype(nullptr)
```

The type name "decltype(nullptr)" is more straightforwards than "Dn".
