### PR TITLE
gui: Do not init std::any item var if we intend to use has_value() on it.

### DIFF
--- a/src/gui/src/drcWidget.cpp
+++ b/src/gui/src/drcWidget.cpp
@@ -647,7 +647,7 @@ void DRCWidget::loadTRReport(const QString& filename)
       std::string item_type = single_source.substr(0, ident);
       std::string item_name = single_source.substr(ident + 1);
 
-      std::any item = nullptr;
+      std::any item;
 
       if (item_type == "net") {
         odb::dbNet* net = block_->findNet(item_name.c_str());


### PR DESCRIPTION

The var should no be inited otherwise has_value() will always be true. That way the condition of the if will decide if the var has been set or not.

Fixes warning:
    [WARNING GUI-0033] No descriptor is registered for Dn.
and now
    [WARNING GUI-0033] No descriptor is registered for type
decltype(nullptr).

Caused by frFakeVSS and frFakeGND:
    [WARNING GUI-0044] Unable to find net (line: 104375): frFakeVSS
    [WARNING GUI-0044] Unable to find net (line: 104378): frFakeVDD