### PR TITLE
Avoid ubsan runtime failure

### DIFF
--- a/src/odb/src/lef/lef/lefrData.cpp
+++ b/src/odb/src/lef/lef/lefrData.cpp
@@ -257,7 +257,7 @@ lefrData::lefrData()
   }
 
   lef_nlines = 1;
-  last = current_buffer - 1;
+  last = &current_buffer[0] - 1;
   next = current_buffer;
   encrypted = 0;
   first_buffer = 1;


### PR DESCRIPTION
When compiled with ubsan, the previous formulation resulted in `runtime error: index -1 out of bounds for type 'char[16384]'`. Changed to avoid without changing behavior.