### PR TITLE
nix: add missing 'gtest' dependency

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -33,6 +33,7 @@
 ##
 ###############################################################################
 {
+  flake,
   lib,
   clangStdenv,
   fetchFromGitHub,
@@ -62,6 +63,7 @@
   flex,
   bison,
   clang-tools_14,
+  gtest,
   # or-tools
   stdenv,
   overrideSDK,
@@ -87,7 +89,7 @@
   self = clangStdenv.mkDerivation (finalAttrs: {
     name = "openroad";
 
-    src = ./.;
+    src = flake;
 
     cmakeFlags = [
       "-DTCL_LIBRARY=${tcl}/lib/libtcl${clangStdenv.hostPlatform.extensions.sharedLibrary}"
@@ -95,6 +97,10 @@
       "-DUSE_SYSTEM_BOOST:BOOL=ON"
       "-DVERBOSE=1"
     ];
+    
+    postPatch = ''
+      patchShebangs .
+    '';
     
     qt5Libs = [
       libsForQt5.qt5.qtbase
@@ -124,6 +130,7 @@
       clp
       cbc
       re2
+      gtest
     ];
 
     nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,22 @@
-# To get dependencies and build in a Nix environment:
+# To use Nix just to get an environment with dependencies:
 #   1. Install Nix: https://github.com/DeterminateSystems/nix-installer
 #   2. Invoke `nix develop` in your shell. First invocation will
 #      take around 5 minutes depending on your internet connection and
 #      CPU speed.
-#   3. `cd build`
-#   4. `cmake -G Ninja $cmakeFlags ..`
-#   5. `ninja`
-#   6. `wrapQtApp ./src/openroad`
+#   3. cd build
+#   4. cmake -G Ninja $cmakeFlags ..
+#   5. ninja
+
+# To build OpenROAD with Nix:
+#   1. Install Nix: https://github.com/DeterminateSystems/nix-installer
+#   2. nix build '.?submodules=1#'
+
 {
   inputs = {
     nixpkgs.url = github:nixos/nixpkgs/nixos-24.05;
   };
 
-  outputs = {nixpkgs, ...}: {
+  outputs = {self, nixpkgs, ...}: {
     packages = nixpkgs.lib.genAttrs [
       "x86_64-linux"
       "aarch64-linux"
@@ -21,12 +25,14 @@
     ] (
       system: let
         pkgs = import nixpkgs {inherit system;};
-        self = {
-          openroad = (nixpkgs.lib.callPackageWith pkgs) ./default.nix {};
-          default = self.openroad;
+        all = {
+          openroad = (nixpkgs.lib.callPackageWith pkgs) ./default.nix {
+            flake = self;
+          };
+          default = all.openroad;
         };
       in
-        self
+        all
     );
   };
 }


### PR DESCRIPTION
This PR's purpose was changed after discussion with maintainers. Original text follows:

---
Per @gadfort's suggestion