### PR TITLE
drt/grt: fix drt crash caused by temporary wires from repair_antennas

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -222,6 +222,7 @@ class GlobalRouter : public ant::GlobalRouteSource
   // check_antennas
   bool haveRoutes() override;
   bool haveDetailedRoutes();
+  bool haveDetailedRoutes(const std::vector<odb::dbNet*>& db_nets);
   void makeNetWires() override;
   void destroyNetWires() override;
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -245,6 +245,16 @@ bool GlobalRouter::haveDetailedRoutes()
   return false;
 }
 
+bool GlobalRouter::haveDetailedRoutes(const std::vector<odb::dbNet*>& db_nets)
+{
+  for (odb::dbNet* db_net : db_nets) {
+    if (isDetailedRouted(db_net)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void GlobalRouter::globalRoute(bool save_guides,
                                bool start_incremental,
                                bool end_incremental)
@@ -618,6 +628,7 @@ void GlobalRouter::updateDirtyNets(std::vector<Net*>& dirty_nets)
     if (pinPositionsChanged(net, last_pos)
         && (!net->isMergedNet() || !netIsCovered(db_net, pins_not_covered))) {
       dirty_nets.push_back(db_net_map_[db_net]);
+      fastroute_->clearNetRoute(db_net);
     } else if (net->isMergedNet()) {
       if (!isConnected(db_net)) {
         logger_->error(

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -156,9 +156,6 @@ odb::dbWire* RepairAntennas::makeNetWire(
     GRoute& route,
     std::map<int, odb::dbTechVia*>& default_vias)
 {
-  if (db_net->getName() == "_13305_") {
-    logger_->report("Making wires for net _13305_");
-  }
   odb::dbWire* wire = odb::dbWire::create(db_net);
   if (wire) {
     Net* net = grouter_->getNet(db_net);
@@ -437,9 +434,6 @@ void RepairAntennas::destroyNetWires(
   for (odb::dbNet* db_net : nets_to_repair) {
     odb::dbWire* wire = db_net->getWire();
     if (wire) {
-      if (db_net->getName() == "_13305_") {
-        logger_->report("Destroying wires for net _13305_");
-      }
       odb::dbWire::destroy(wire);
     }
   }

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -85,7 +85,7 @@ bool RepairAntennas::checkAntennaViolations(
     antenna_violations_[db_net];
   }
 
-  bool destroy_wires = !grouter_->haveDetailedRoutes();
+  bool destroy_wires = !grouter_->haveDetailedRoutes(nets_to_repair);
 
   makeNetWires(routing, nets_to_repair, max_routing_layer);
   arc_->initAntennaRules();
@@ -156,6 +156,9 @@ odb::dbWire* RepairAntennas::makeNetWire(
     GRoute& route,
     std::map<int, odb::dbTechVia*>& default_vias)
 {
+  if (db_net->getName() == "_13305_") {
+    logger_->report("Making wires for net _13305_");
+  }
   odb::dbWire* wire = odb::dbWire::create(db_net);
   if (wire) {
     Net* net = grouter_->getNet(db_net);
@@ -434,6 +437,9 @@ void RepairAntennas::destroyNetWires(
   for (odb::dbNet* db_net : nets_to_repair) {
     odb::dbWire* wire = db_net->getWire();
     if (wire) {
+      if (db_net->getName() == "_13305_") {
+        logger_->report("Destroying wires for net _13305_");
+      }
       odb::dbWire::destroy(wire);
     }
   }

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -120,6 +120,7 @@ class FastRouteCore
   void deleteNet(odb::dbNet* db_net);
   void removeNet(odb::dbNet* db_net);
   void mergeNet(odb::dbNet* db_net);
+  void clearNetRoute(odb::dbNet* db_net);
   void initEdges();
   void setNumAdjustments(int nAdjustements);
   void addAdjustment(int x1,

--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -313,6 +313,14 @@ void FastRouteCore::mergeNet(odb::dbNet* db_net)
   }
 }
 
+void FastRouteCore::clearNetRoute(odb::dbNet* db_net)
+{
+  if (db_net_id_map_.find(db_net) != db_net_id_map_.end()) {
+    const int net_id = db_net_id_map_[db_net];
+    clearNetRoute(net_id);
+  }
+}
+
 void FastRouteCore::getNetId(odb::dbNet* db_net, int& net_id, bool& exists)
 {
   auto itr = db_net_id_map_.find(db_net);


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/5565.