### PR TITLE
Remove * from macOS support in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Legend:
 | Debian 11    | `Y` | `Y` | `Y` | `-` |
 | RHEL         | `Y` | `-` | `Y` | `-` |
 | Windows 10 and above | `-` | `-` | `Y` | `Y` |
-| macOS        | `Y*` | `-` | `Y` | `-` |
+| macOS        | `Y` | `-` | `Y` | `-` |
 
 
 ## Code of conduct


### PR DESCRIPTION
The * is a vestige from when macOS didn't support `par` and `mpl2`