### PR TITLE
mpl2: avoid creating clusters for empty modules

### DIFF
--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -189,7 +189,7 @@ class ClusteringEngine
   void updateSizeThresholds();
   void breakCluster(Cluster* parent);
   void createFlatCluster(odb::dbModule* module, Cluster* parent);
-  void addModuleInstsToCluster(Cluster* cluster, odb::dbModule* module);
+  void addModuleLeafInstsToCluster(Cluster* cluster, odb::dbModule* module);
   void createCluster(odb::dbModule* module, Cluster* parent);
   void createCluster(Cluster* parent);
   void updateSubTree(Cluster* parent);

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -138,6 +138,11 @@ float Metrics::getArea() const
   return std_cell_area_ + macro_area_;
 }
 
+bool Metrics::empty() const
+{
+  return num_macro_ == 0 && num_std_cell_ == 0;
+}
+
 ///////////////////////////////////////////////////////////////////////
 // Cluster Class
 // Constructors and Destructors

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -147,6 +147,7 @@ class Metrics
   float getStdCellArea() const;
   float getMacroArea() const;
   float getArea() const;
+  bool empty() const;
 
  private:
   // In the hierarchical autoclustering part,


### PR DESCRIPTION
This PR addresses one of the problems showed in #5655, that is: the clustering engine leaves the physical hierarchy with empty clusters created from empty modules:
![image](https://github.com/user-attachments/assets/61ade700-3403-41dc-9499-4ae5537261bd)


Subsequent work is needed in order to address other things.

_I also made some renaming, because it was a bit confusing._