### PR TITLE
grt: reset FastRouteCore when repairing antennas from detailed routing

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -172,6 +172,7 @@ GlobalRouter::~GlobalRouter()
 std::vector<Net*> GlobalRouter::initFastRoute(int min_routing_layer,
                                               int max_routing_layer)
 {
+  fastroute_->clear();
   ensureLayerForGuideDimension(max_routing_layer);
 
   configFastRoute();
@@ -342,7 +343,7 @@ void GlobalRouter::repairAntennas(odb::dbMTerm* diode_mterm,
                                   float ratio_margin,
                                   const int num_threads)
 {
-  if (!initialized_) {
+  if (!initialized_ || haveDetailedRoutes()) {
     int min_layer, max_layer;
     getMinMaxLayer(min_layer, max_layer);
     initFastRoute(min_layer, max_layer);


### PR DESCRIPTION
Partial fix for https://github.com/The-OpenROAD-Project/OpenROAD/issues/5668.

When running repair_antennas post-DRT, it is necessary to reset FastRouteCore values to ensure the correct resource values are at the edges of the routing grid. By resetting it, the resources used by the routed nets are freed, and it will consider only the resource reductions from the routing wires of the nets.

This helps to largely reduce the runtime of repair_antennas post-DRT and keep the final routing DRC clean.