### PR TITLE
RSZ: remove max_steiner_pin_count_ limit on pins per net handled by rsz

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -741,8 +741,6 @@ class Resizer : public dbStaState
 
   // "factor debatable"
   static constexpr float tgt_slew_load_cap_factor = 10.0;
-  // Prim/Dijkstra gets out of hand with bigger nets.
-  static constexpr int max_steiner_pin_count_ = 200000;
 
   // Use actual input slews for accurate delay/slew estimation
   sta::UnorderedMap<LibertyPort*, InputSlews> input_slew_map_;

--- a/src/rsz/src/SteinerTree.cc
+++ b/src/rsz/src/SteinerTree.cc
@@ -81,14 +81,7 @@ SteinerTree* Resizer::makeSteinerTree(const Pin* drvr_pin)
   });
   int pin_count = pinlocs.size();
   bool is_placed = true;
-  // Warn if there are too many pins (>10000)
-  if (pin_count > max_steiner_pin_count_) {
-    logger_->warn(RSZ,
-                  69,
-                  "skipping net {} with {} pins.",
-                  sdc_network->pathName(net),
-                  pin_count);
-  } else if (pin_count >= 2) {
+  if (pin_count >= 2) {
     vector<int> x, y;  // Two separate vectors of coordinates needed by flute.
     int drvr_idx = 0;  // The "driver_pin" or the root of the Steiner tree.
     for (int i = 0; i < pin_count; i++) {


### PR DESCRIPTION
RSZ skips nets with more pins than 200000. This PR removes this limit.