### PR TITLE
odb: Convert old error message to logger.

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1890,8 +1890,7 @@ dbChip* definReader::createChip(std::vector<dbLib*>& libs,
       _logger->error(utl::ODB, 250, "Chip does not exist");
     }
   } else if (chip != nullptr) {
-    fprintf(stderr, "Error: Chip already exists\n");
-    return nullptr;
+    _logger->error(utl::ODB, 251, "Chip already exists");
   } else {
     chip = dbChip::create(_db);
   }


### PR DESCRIPTION
I'm marking this PR as draft as generally in the build, duplicate message numbers generate an error.
In this case, there are 2 errors with number 250 and  I don't get any an error. Something is wrong with the build.

Can someone take a look at it?

  if (_mode != defin::DEFAULT) {
    if (chip == nullptr) {
      _logger->error(utl::ODB, **250**, "Chip does not exist");
    }
  } else if (chip != nullptr) {
    _logger->error(utl::ODB, **250**, "Chip already exists");
  } else {
    chip = dbChip::create(_db);
  }
