### PR TITLE
cts: fix pattern match regexp and remove manual string filtering

### DIFF
--- a/src/cts/include/cts/TritonCTS.h
+++ b/src/cts/include/cts/TritonCTS.h
@@ -96,9 +96,6 @@ class TritonCTS
   int setClockNets(const char* names);
   void setBufferList(const char* buffers);
   void inferBufferList(std::vector<std::string>& buffers);
-  std::vector<std::string> findMatchingSubset(
-      const std::string& pattern,
-      const std::vector<std::string>& buffers);
   bool isClockCellCandidate(sta::LibertyCell* cell);
   void setRootBuffer(const char* buffers);
   std::string selectRootBuffer(std::vector<std::string>& buffers);

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -605,7 +605,7 @@ void TritonCTS::inferBufferList(std::vector<std::string>& buffers)
 
   // second, look for all buffers with name CLKBUF or clkbuf
   if (buffers.empty()) {
-    sta::PatternMatch patternClkBuf("*CLKBUF*",
+    sta::PatternMatch patternClkBuf(".*CLKBUF.*",
                                     /* is_regexp */ true,
                                     /* nocase */ true,
                                     /* Tcl_interp* */ nullptr);
@@ -624,7 +624,7 @@ void TritonCTS::inferBufferList(std::vector<std::string>& buffers)
 
   // third, look for all buffers with name BUF or buf
   if (buffers.empty()) {
-    sta::PatternMatch patternBuf("*BUF*",
+    sta::PatternMatch patternBuf(".*BUF.*",
                                  /* is_regexp */ true,
                                  /* nocase */ true,
                                  /* Tcl_interp* */ nullptr);
@@ -660,29 +660,6 @@ void TritonCTS::inferBufferList(std::vector<std::string>& buffers)
           110,
           "No clock buffer candidates could be found from any libraries.");
     }
-
-    // it's possible that pattern-based lib cell search missed
-    // clock buffers (because they are not loaded or linked?)
-    std::string pattern("clkbuf");
-    std::vector<std::string> clockBuffers
-        = findMatchingSubset(pattern, buffers);
-    // clang-format off
-    debugPrint(logger_, CTS, "buffering", 1, "{} buffers with 'clkbuf' "
-               "have been found", clockBuffers.size());
-    // clang-format on
-    if (!clockBuffers.empty()) {
-      buffers = std::move(clockBuffers);
-    } else {
-      pattern = std::string("buf");
-      clockBuffers = findMatchingSubset(pattern, buffers);
-      // clang-format off
-      debugPrint(logger_, CTS, "buffering", 1, "{} buffers with 'buf' "
-                 "have been found", clockBuffers.size());
-      // clang-format on
-      if (!clockBuffers.empty()) {
-        buffers = std::move(clockBuffers);
-      }
-    }
   }
 
   options_->setBufferListInferred(true);
@@ -699,21 +676,6 @@ std::string toLowerCase(std::string str)
     return std::tolower(c);
   });
   return str;
-}
-
-std::vector<std::string> TritonCTS::findMatchingSubset(
-    const std::string& pattern,
-    const std::vector<std::string>& buffers)
-{
-  std::vector<std::string> subset;
-  std::copy_if(buffers.begin(),
-               buffers.end(),
-               std::back_inserter(subset),
-               [&pattern](const std::string& str) {
-                 std::string lowerCaseStr = toLowerCase(str);
-                 return lowerCaseStr.find(pattern) != std::string::npos;
-               });
-  return subset;
 }
 
 bool TritonCTS::isClockCellCandidate(sta::LibertyCell* cell)


### PR DESCRIPTION
Make the cells with clkbuf/CLKBUF in their name to be correctly found when inferring buffers without needing to do manual string filtering after the search.

This fix is necessary for #5577 so that RSZ can choose correctly which buffers not to use for resizing.
_I tested this with aes for all public and private PDKs and the pattern match doesn't fail._

Example with some printing for debug in sky130hs/aes:

Without the fix
```
Infer Buffer List
	Looking for buffers with is_clock_cell attr:
		No buffers found.

	Looking for buffers with name CLKBUF or clkbuf:
		No buffers found.

	Looking for buffers with name BUF or buf:
		No buffers found.

	Looking for all buffers:
		sky130_fd_sc_hs__buf_1
		sky130_fd_sc_hs__buf_16
		sky130_fd_sc_hs__buf_2
		sky130_fd_sc_hs__buf_4
		sky130_fd_sc_hs__buf_8
		sky130_fd_sc_hs__bufbuf_16
		sky130_fd_sc_hs__bufbuf_8
		sky130_fd_sc_hs__clkbuf_1
		sky130_fd_sc_hs__clkbuf_16
		sky130_fd_sc_hs__clkbuf_2
		sky130_fd_sc_hs__clkbuf_4
		sky130_fd_sc_hs__clkbuf_8
		sky130_fd_sc_hs__dlygate4sd1_1
		sky130_fd_sc_hs__dlygate4sd2_1
		sky130_fd_sc_hs__dlygate4sd3_1
		sky130_fd_sc_hs__dlymetal6s2s_1
		sky130_fd_sc_hs__dlymetal6s4s_1
		sky130_fd_sc_hs__dlymetal6s6s_1

	Filtering all buffers manually with clkbuf
		sky130_fd_sc_hs__clkbuf_1
		sky130_fd_sc_hs__clkbuf_16
		sky130_fd_sc_hs__clkbuf_2
		sky130_fd_sc_hs__clkbuf_4
		sky130_fd_sc_hs__clkbuf_8
```

With the fix
```
Infer Buffer List
	Looking for buffers with is_clock_cell attr:
		No buffers found.

	Looking for buffers with name CLKBUF or clkbuf:
		sky130_fd_sc_hs__clkbuf_1
		sky130_fd_sc_hs__clkbuf_16
		sky130_fd_sc_hs__clkbuf_2
		sky130_fd_sc_hs__clkbuf_4
		sky130_fd_sc_hs__clkbuf_8
```

**_Note: I'm opening this as a draft as I'd like input to whether or not we should keep the manual filtering code._**