### PR TITLE
odb: Move messages checking to odb to fix deps.

### DIFF
--- a/src/odb/CMakeLists.txt
+++ b/src/odb/CMakeLists.txt
@@ -81,3 +81,22 @@ if(ENABLE_TESTS)
     odb
   )
 endif()
+
+add_custom_command(
+  OUTPUT messages_checked
+  COMMAND ${CMAKE_SOURCE_DIR}/etc/find_messages.py > messages.txt && touch ${CMAKE_CURRENT_BINARY_DIR}/messages_checked
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  DEPENDS
+    db
+    cdl
+    defin
+    defout
+    lefin
+    lefout
+    zutil
+    gdsin
+)
+
+add_custom_target(odb_messages DEPENDS messages_checked)
+
+add_dependencies(odb odb_messages)

--- a/src/odb/src/db/CMakeLists.txt
+++ b/src/odb/src/db/CMakeLists.txt
@@ -179,9 +179,3 @@ target_link_libraries(db
         utl_lib
         ${TCL_LIBRARY}
 )
-
-messages(
-  TARGET db
-  OUTPUT_DIR ../..
-  SOURCE_DIR ../..
-)


### PR DESCRIPTION
The messages checking was set at db level as odb is an interface and doesn't not have a post-build trigger.
Unfortunately there were no dependencies on other libs besides db such as defin.
So since add_dependencies can only add targets but not files, create a custom target which depends on a generated files which
triggers the call to find_messages.py.