### PR TITLE
DependencyInstaller: Add option for constant build path

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -738,6 +738,9 @@ Usage: $0
        $0 -save-deps-prefixes=FILE
                                 # Dumps OpenROAD build arguments and variables
                                 # to FILE
+       $0 -constant-build-dir
+                                # Use constant build directory, instead of
+                                #    random one.
 
 EOF
     exit "${1:-1}"
@@ -793,6 +796,14 @@ while [ "$#" -gt 0 ]; do
             fi
             export PREFIX="${HOME}/.local"
             export isLocal="true"
+            ;;
+        -constant-build-dir)
+            if [[ -d "$baseDir" ]]; then
+                echo "INFO: removing old building directory $baseDir"
+                rm -r "$baseDir"
+            fi
+            baseDir="/tmp/DependencyInstaller-OpenROAD"
+            mkdir -p "$baseDir"
             ;;
         -prefix=*)
             if [[ ! -z ${PREFIX} ]]; then


### PR DESCRIPTION
This PR adds `-constant-build-dir` flag that sets `baseDir` for dependency building to a fixed directory instead of `mktemp`-based directory.

Dependencies like Yosys and abc use `__FILE__` macro, which is different on every build.

Such changes can lead to cache invalidation in e.g. https://github.com/The-OpenROAD-Project/bazel-orfs/