### PR TITLE
dft: fix lib-related crashes

### DIFF
--- a/src/dft/src/cells/ScanCellFactory.cpp
+++ b/src/dft/src/cells/ScanCellFactory.cpp
@@ -59,9 +59,18 @@ sta::LibertyCell* GetLibertyCell(odb::dbMaster* master,
   return db_network->libertyCell(master_cell);
 }
 
-sta::TestCell* GetTestCell(odb::dbMaster* master, sta::dbNetwork* db_network)
+sta::TestCell* GetTestCell(odb::dbMaster* master,
+                           sta::dbNetwork* db_network,
+                           utl::Logger* logger)
 {
   sta::LibertyCell* liberty_cell = GetLibertyCell(master, db_network);
+  if (liberty_cell == nullptr) {
+    logger->warn(utl::DFT,
+                 11,
+                 "Cell master '{:s}' has no lib info. Can't find scan cell",
+                 master->getName());
+    return nullptr;
+  }
   sta::TestCell* test_cell = liberty_cell->testCell();
   if (test_cell && test_cell->scanIn() != nullptr
       && test_cell->scanEnable() != nullptr) {
@@ -131,7 +140,7 @@ std::unique_ptr<OneBitScanCell> CreateOneBitCell(odb::dbInst* inst,
   sta::dbNetwork* db_network = sta->getDbNetwork();
   std::unique_ptr<ClockDomain> clock_domain
       = FindOneBitCellClockDomain(inst, sta);
-  sta::TestCell* test_cell = GetTestCell(inst->getMaster(), db_network);
+  sta::TestCell* test_cell = GetTestCell(inst->getMaster(), db_network, logger);
 
   if (!clock_domain) {
     logger->warn(utl::DFT,

--- a/src/dft/src/replace/ScanReplace.cpp
+++ b/src/dft/src/replace/ScanReplace.cpp
@@ -368,7 +368,8 @@ void ScanReplace::scanReplace(odb::dbBlock* block)
 
     if (from_liberty_cell == nullptr) {
       // cell doesn't exist in lib, no timing info
-      if (no_lib_warned.find(master) == no_lib_warned.end()) {
+      if (master->getType() == odb::dbMasterType::CORE
+          && no_lib_warned.find(master) == no_lib_warned.end()) {
         logger_->warn(
             utl::DFT,
             12,

--- a/src/dft/src/replace/ScanReplace.cpp
+++ b/src/dft/src/replace/ScanReplace.cpp
@@ -339,6 +339,8 @@ void ScanReplace::scanReplace()
 void ScanReplace::scanReplace(odb::dbBlock* block)
 {
   std::unordered_set<odb::dbInst*> already_replaced;
+  std::unordered_set<odb::dbMaster*> no_lib_warned;
+
   for (odb::dbInst* inst : block->getInsts()) {
     // The instances already scan replaced are skipped
     if (already_replaced.find(inst) != already_replaced.end()) {
@@ -360,14 +362,27 @@ void ScanReplace::scanReplace(odb::dbBlock* block)
       continue;
     }
 
-    if (!utils::IsSequentialCell(db_network_, inst)) {
-      // If the cell is not sequential, then there is nothing to replace
-      continue;
-    }
-
     odb::dbMaster* master = inst->getMaster();
     sta::Cell* master_cell = db_network_->dbToSta(master);
     sta::LibertyCell* from_liberty_cell = db_network_->libertyCell(master_cell);
+
+    if (from_liberty_cell == nullptr) {
+      // cell doesn't exist in lib, no timing info
+      if (no_lib_warned.find(master) == no_lib_warned.end()) {
+        logger_->warn(
+            utl::DFT,
+            12,
+            "Cell master '{:s}' has no lib info. Can't create scan cell(s)",
+            master->getName());
+        no_lib_warned.insert(master);
+      }
+      continue;
+    }
+
+    if (!from_liberty_cell->hasSequentials()) {
+      // If the cell is not sequential, then there is nothing to replace
+      continue;
+    }
 
     if (available_scan_lib_cells_.find(from_liberty_cell)
         != available_scan_lib_cells_.end()) {


### PR DESCRIPTION
Fixes two null pointer dereferencing crashes:
* One where no valid lib files have not been read prior to DFT function invocation
* One where a cell might be missing entirely from the lib files in a PDK (such as `sky130_fd_sc_hd__tapvpwrvgnd_1` in sky130)

Warnings are printed in both situations.


---

@maliberty i just incremented the numbers for the new messages- not sure if that's okay or not