### PR TITLE
pdn/via: Fix debug print units

### DIFF
--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -1721,7 +1721,7 @@ void ViaGenerator::determineRowsAndColumns(
     const Enclosure& bottom_min_enclosure,
     const Enclosure& top_min_enclosure)
 {
-  const double dbu_to_microns = getTech()->getLefUnits();
+  const double dbu_to_microns = getTech()->getDbUnitsPerMicron();
 
   const odb::Rect& cut = getCut();
   const int cut_width = cut.dx();


### PR DESCRIPTION
Spotted this while debugging some other arrayspacing related via issues, seems like it only affects the debug prints but avoids confusion with incorrect units in the prints.