### PR TITLE
pdn: fix lef for powerswitch to align with site

### DIFF
--- a/src/pdn/test/sky130_power_switch/power_switch.lef
+++ b/src/pdn/test/sky130_power_switch/power_switch.lef
@@ -5,26 +5,26 @@ MACRO POWER_SWITCH
   ORIGIN 0 0 ;
   SIZE 4.6 BY 5.44 ;
   SITE unithddbl ;
-  PIN VPWR
+  PIN VGND
     DIRECTION INOUT ;
-    USE POWER ;
+    USE GROUND ;
     SHAPE ABUTMENT ;
     PORT
       LAYER met1 ;
         RECT 0.0 -0.24 4.6 0.24 ;
         RECT 0.0  5.20 4.6 5.68 ;
     END
-  END VPWR
-  PIN VGND
+  END VGND
+  PIN VPWR
     DIRECTION INOUT ;
-    USE GROUND ; 
+    USE POWER ; 
     SHAPE ABUTMENT ;
 
     PORT
       LAYER met1 ;
         RECT  0.0 2.48 4.6 2.96 ;
     END
-  END VGND
+  END VPWR
   PIN VDDG
     DIRECTION INOUT ;
     USE POWER ;


### PR DESCRIPTION
This ensures the lef matches the row pattern and power grid pattern.