### PR TITLE
pdn: ensure widths are pinned to twice the manufacturing grid to avoi…

### DIFF
--- a/src/pdn/src/grid_component.cpp
+++ b/src/pdn/src/grid_component.cpp
@@ -437,6 +437,19 @@ void GridComponent::checkLayerWidth(odb::dbTechLayer* layer,
                          widths);
     }
   }
+
+  odb::dbTech* tech = layer->getTech();
+  if (tech->hasManufacturingGrid()) {
+    const int double_grid = 2 * tech->getManufacturingGrid();
+    if (width % double_grid != 0) {
+      getLogger()->error(
+          utl::PDN,
+          117,
+          "Width ({:.4f} um) specified must be a multiple of {:.4f} um.",
+          tech_layer.dbuToMicron(width),
+          tech_layer.dbuToMicron(double_grid));
+    }
+  }
 }
 
 void GridComponent::checkLayerSpacing(
@@ -457,6 +470,19 @@ void GridComponent::checkLayerSpacing(
                        tech_layer.dbuToMicron(spacing),
                        layer->getName(),
                        tech_layer.dbuToMicron(min_spacing));
+  }
+
+  odb::dbTech* tech = layer->getTech();
+  if (tech->hasManufacturingGrid()) {
+    const int grid = tech->getManufacturingGrid();
+    if (spacing % grid != 0) {
+      getLogger()->error(
+          utl::PDN,
+          118,
+          "Spacing ({:.4f} um) specified must be a multiple of {:.4f} um.",
+          tech_layer.dbuToMicron(spacing),
+          tech_layer.dbuToMicron(grid));
+    }
   }
 }
 

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -1135,7 +1135,7 @@ void PadDirectConnectionStraps::makeShapesOverPads(
 
   const int max_width = inst_width / (2 * (straps.size() + 1));
   TechLayer layer(getLayer());
-  const int target_width = layer.snapToManufacturingGrid(max_width, false);
+  const int target_width = layer.snapToManufacturingGrid(max_width, false, 2);
   if (target_width < layer.getMinWidth()) {
     // dont build anything
     debugPrint(
@@ -2375,7 +2375,7 @@ int RepairChannelStraps::getNextWidth() const
 {
   const TechLayer layer(getLayer());
 
-  int new_width = layer.snapToManufacturingGrid(getWidth() / 2);
+  int new_width = layer.snapToManufacturingGrid(getWidth() / 2, false, 2);
 
   // if new is smaller than min width use min width
   const int min_width = layer.getMinWidth();

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -144,13 +144,14 @@ int TechLayer::snapToGridInterval(odb::dbBlock* block, int dist) const
 
 int TechLayer::snapToManufacturingGrid(odb::dbTech* tech,
                                        int pos,
-                                       bool round_up)
+                                       bool round_up,
+                                       int grid_multiplier)
 {
   if (!tech->hasManufacturingGrid()) {
     return pos;
   }
 
-  const int grid = tech->getManufacturingGrid();
+  const int grid = grid_multiplier * tech->getManufacturingGrid();
 
   if (pos % grid != 0) {
     int round_pos = pos / grid;
@@ -184,21 +185,25 @@ bool TechLayer::checkIfManufacturingGrid(int value,
 {
   auto* tech = layer_->getTech();
   if (!checkIfManufacturingGrid(tech, value)) {
-    logger->error(utl::PDN,
-                  191,
-                  "{} of {:.4f} does not fit the manufacturing grid of {:.4f}.",
-                  type,
-                  dbuToMicron(value),
-                  dbuToMicron(tech->getManufacturingGrid()));
+    logger->error(
+        utl::PDN,
+        191,
+        "{} of {:.4f} um does not fit the manufacturing grid of {:.4f} um.",
+        type,
+        dbuToMicron(value),
+        dbuToMicron(tech->getManufacturingGrid()));
     return false;
   }
 
   return true;
 }
 
-int TechLayer::snapToManufacturingGrid(int pos, bool round_up) const
+int TechLayer::snapToManufacturingGrid(int pos,
+                                       bool round_up,
+                                       int grid_multiplier) const
 {
-  return snapToManufacturingGrid(layer_->getTech(), pos, round_up);
+  return snapToManufacturingGrid(
+      layer_->getTech(), pos, round_up, grid_multiplier);
 }
 
 std::vector<TechLayer::MinCutRule> TechLayer::getMinCutRules() const

--- a/src/pdn/src/techlayer.h
+++ b/src/pdn/src/techlayer.h
@@ -67,10 +67,13 @@ class TechLayer
   int snapToGridInterval(odb::dbBlock* block, int dist) const;
   bool hasGrid() const { return !grid_.empty(); }
   const std::vector<int>& getGrid() const { return grid_; }
-  int snapToManufacturingGrid(int pos, bool round_up = false) const;
+  int snapToManufacturingGrid(int pos,
+                              bool round_up = false,
+                              int grid_multiplier = 1) const;
   static int snapToManufacturingGrid(odb::dbTech* tech,
                                      int pos,
-                                     bool round_up = false);
+                                     bool round_up = false,
+                                     int grid_multiplier = 1);
   static bool checkIfManufacturingGrid(odb::dbTech* tech, int value);
   bool checkIfManufacturingGrid(int value,
                                 utl::Logger* logger,

--- a/src/pdn/test/core_grid_bad_metal_specs.ok
+++ b/src/pdn/test/core_grid_bad_metal_specs.ok
@@ -1,0 +1,12 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45_tech.lef, created 22 layers, 27 vias
+[INFO ODB-0227] LEF file: Nangate45/Nangate45_stdcell.lef, created 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 482 components and 2074 component-terminals.
+[INFO ODB-0133]     Created 385 nets and 1110 connections.
+[ERROR PDN-0117] Width (0.0750 um) specified must be a multiple of 0.0100 um.
+PDN-0117
+[ERROR PDN-0191] Pitch of 4.0040 um does not fit the manufacturing grid of 0.0050 um.
+PDN-0191
+[ERROR PDN-0118] Spacing (0.5040 um) specified must be a multiple of 0.0050 um.
+PDN-0118

--- a/src/pdn/test/core_grid_bad_metal_specs.tcl
+++ b/src/pdn/test/core_grid_bad_metal_specs.tcl
@@ -1,0 +1,21 @@
+# test for error checking against the manufacturing grid
+source "helpers.tcl"
+
+read_lef Nangate45/Nangate45_tech.lef
+read_lef Nangate45/Nangate45_stdcell.lef
+read_def nangate_gcd/floorplan.def
+
+add_global_connection -net VDD -pin_pattern VDD -power
+add_global_connection -net VSS -pin_pattern VSS -ground
+
+set_voltage_domain -power VDD -ground VSS
+
+define_pdn_grid -name "Core"
+catch {add_pdn_stripe -layer metal1 -width 0.075 -pitch 4} err
+puts $err
+
+catch {add_pdn_stripe -layer metal1 -width 0.07 -pitch 4.004} err
+puts $err
+
+catch {add_pdn_stripe -layer metal1 -width 0.07 -spacing 0.504 -pitch 4} err
+puts $err

--- a/src/pdn/test/offgrid.ok
+++ b/src/pdn/test/offgrid.ok
@@ -3,5 +3,5 @@
 [INFO ODB-0130]     Created 54 pins.
 [INFO ODB-0131]     Created 482 components and 2074 component-terminals.
 [INFO ODB-0133]     Created 385 nets and 1110 connections.
-[ERROR PDN-0191] Width of 2.0010 does not fit the manufacturing grid of 0.0050.
-PDN-0191
+[ERROR PDN-0117] Width (2.0010 um) specified must be a multiple of 0.0100 um.
+PDN-0117

--- a/src/pdn/test/regression_tests.tcl
+++ b/src/pdn/test/regression_tests.tcl
@@ -31,6 +31,7 @@ record_tests {
   core_grid_with_routing_obstructions
   core_grid_adjacentcuts
   core_grid_with_fixed_pins
+  core_grid_bad_metal_specs
 
   core_grid_obstruction
 


### PR DESCRIPTION
…d the center line of the a strap being off grid

This avoids the issue when the straps are an odd integer width forcing the vias to be placed off the manufacturing grid.
