### PR TITLE
drt: functions changed to have more explicit output

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -122,7 +122,7 @@ class FlexPA
     unique_insts_.setDesign(in);
   }
   void applyPatternsFile(const char* file_path);
-  void getViaRawPriority(frViaDef* via_def, ViaRawPriorityTuple& priority);
+  ViaRawPriorityTuple getViaRawPriority(frViaDef* via_def);
   bool isSkipInstTermLocal(frInstTerm* in);
   bool isSkipInstTerm(frInstTerm* in);
   bool isDistributed() const { return !remote_host_.empty(); }
@@ -143,11 +143,8 @@ class FlexPA
   template <typename T>
   int prepPoint_pin(T* pin, frInstTerm* inst_term = nullptr);
   template <typename T>
-  void prepPoint_pin_mergePinShapes(
-      std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
-      T* pin,
-      frInstTerm* inst_term,
-      bool is_shrink = false);
+  std::vector<gtl::polygon_90_set_data<frCoord>>
+  mergePinShapes(T* pin, frInstTerm* inst_term, bool is_shrink = false);
   // type 0 -- on-grid; 1 -- half-grid; 2 -- center; 3 -- via-enc-opt
   template <typename T>
   void prepPoint_pin_genPoints(

--- a/src/drt/src/pa/FlexPA_init.cpp
+++ b/src/drt/src/pa/FlexPA_init.cpp
@@ -48,7 +48,7 @@ void FlexPA::initViaRawPriority()
     for (auto& via_def :
          design_->getTech()->getLayer(layer_num)->getViaDefs()) {
       const int cutNum = int(via_def->getCutFigs().size());
-      ViaRawPriorityTuple priority = getViaRawPriority(via_def);
+      const ViaRawPriorityTuple priority = getViaRawPriority(via_def);
       layer_num_to_via_defs_[layer_num][cutNum][priority] = via_def;
     }
   }

--- a/src/drt/src/pa/FlexPA_init.cpp
+++ b/src/drt/src/pa/FlexPA_init.cpp
@@ -48,14 +48,13 @@ void FlexPA::initViaRawPriority()
     for (auto& via_def :
          design_->getTech()->getLayer(layer_num)->getViaDefs()) {
       const int cutNum = int(via_def->getCutFigs().size());
-      ViaRawPriorityTuple priority;
-      getViaRawPriority(via_def, priority);
+      ViaRawPriorityTuple priority = getViaRawPriority(via_def);
       layer_num_to_via_defs_[layer_num][cutNum][priority] = via_def;
     }
   }
 }
 
-void FlexPA::getViaRawPriority(frViaDef* via_def, ViaRawPriorityTuple& priority)
+ViaRawPriorityTuple FlexPA::getViaRawPriority(frViaDef* via_def)
 {
   const bool is_not_default_via = !(via_def->getDefault());
   gtl::polygon_90_set_data<frCoord> via_layer_PS1;
@@ -108,13 +107,13 @@ void FlexPA::getViaRawPriority(frViaDef* via_def, ViaRawPriorityTuple& priority)
   const frCoord layer1_area = gtl::area(via_layer_PS1);
   const frCoord layer2_area = gtl::area(via_layer_PS2);
 
-  priority = std::make_tuple(is_not_default_via,
-                             layer1_width,
-                             layer2_width,
-                             is_not_upper_align,
-                             layer2_area,
-                             layer1_area,
-                             is_not_lower_align);
+  return std::make_tuple(is_not_default_via,
+                         layer1_width,
+                         layer2_width,
+                         is_not_upper_align,
+                         layer2_area,
+                         layer1_area,
+                         is_not_lower_align);
 }
 
 void FlexPA::initTrackCoords()

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -112,7 +112,6 @@ FlexPA::mergePinShapes(T* pin, frInstTerm* inst_term, const bool is_shrink)
       pin_shapes[layer_num] += poly;
     } else {
       logger_->error(DRT, 67, "FlexPA mergePinShapes unsupported shape.");
-      exit(1);
     }
   }
   return pin_shapes;

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -50,12 +50,10 @@ namespace drt {
 using utl::ThreadException;
 
 template <typename T>
-void FlexPA::prepPoint_pin_mergePinShapes(
-    std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
-    T* pin,
-    frInstTerm* inst_term,
-    const bool is_shrink)
+std::vector<gtl::polygon_90_set_data<frCoord>>
+FlexPA::mergePinShapes(T* pin, frInstTerm* inst_term, const bool is_shrink)
 {
+  std::vector<gtl::polygon_90_set_data<frCoord>> pin_shapes;
   frInst* inst = nullptr;
   if (inst_term) {
     inst = inst_term->getInst();
@@ -113,11 +111,11 @@ void FlexPA::prepPoint_pin_mergePinShapes(
       using boost::polygon::operators::operator+=;
       pin_shapes[layer_num] += poly;
     } else {
-      logger_->error(
-          DRT, 67, "FlexPA prepPoint_pin_mergePinShapes unsupported shape.");
+      logger_->error(DRT, 67, "FlexPA mergePinShapes unsupported shape.");
       exit(1);
     }
   }
+  return pin_shapes;
 }
 
 void FlexPA::prepPoint_pin_genPoints_rect_genGrid(
@@ -1488,8 +1486,8 @@ int FlexPA::prepPoint_pin(T* pin, frInstTerm* inst_term)
     graphics_->startPin(pin, inst_term, inst_class);
   }
 
-  std::vector<gtl::polygon_90_set_data<frCoord>> pin_shapes;
-  prepPoint_pin_mergePinShapes(pin_shapes, pin, inst_term);
+  std::vector<gtl::polygon_90_set_data<frCoord>> pin_shapes
+      = mergePinShapes(pin, inst_term);
 
   for (auto upper : {frAccessPointEnum::OnGrid,
                      frAccessPointEnum::HalfGrid,

--- a/src/drt/src/pa/FlexPA_unique.cpp
+++ b/src/drt/src/pa/FlexPA_unique.cpp
@@ -38,9 +38,9 @@ UniqueInsts::UniqueInsts(frDesign* design,
 {
 }
 
-void UniqueInsts::getPrefTrackPatterns(
-    std::vector<frTrackPattern*>& pref_track_patterns)
+std::vector<frTrackPattern*> UniqueInsts::getPrefTrackPatterns()
 {
+  std::vector<frTrackPattern*> pref_track_patterns;
   for (const auto& track_pattern : design_->getTopBlock()->getTrackPatterns()) {
     const bool is_vertical_track = track_pattern->isHorizontal();
     const frLayerNum layer_num = track_pattern->getLayerNum();
@@ -55,11 +55,12 @@ void UniqueInsts::getPrefTrackPatterns(
       }
     }
   }
+  return pref_track_patterns;
 }
 
-void UniqueInsts::initMaster2PinLayerRange(
-    MasterLayerRange& master_to_pin_layer_range)
+UniqueInsts::MasterLayerRange UniqueInsts::initMasterToPinLayerRange()
 {
+  MasterLayerRange master_to_pin_layer_range;
   std::set<frString> masters;
   for (odb::dbInst* inst : target_insts_) {
     masters.insert(inst->getMaster()->getName());
@@ -105,6 +106,7 @@ void UniqueInsts::initMaster2PinLayerRange(
     max_layer_num = std::min(max_layer_num + 2, num_layers);
     master_to_pin_layer_range[master] = {min_layer_num, max_layer_num};
   }
+  return master_to_pin_layer_range;
 }
 
 bool UniqueInsts::hasTrackPattern(frTrackPattern* tp, const Rect& box) const
@@ -209,11 +211,9 @@ void UniqueInsts::computeUnique(
 
 void UniqueInsts::initUniqueInstance()
 {
-  std::vector<frTrackPattern*> pref_track_patterns;
-  getPrefTrackPatterns(pref_track_patterns);
+  std::vector<frTrackPattern*> pref_track_patterns = getPrefTrackPatterns();
 
-  MasterLayerRange master_to_pin_layer_range;
-  initMaster2PinLayerRange(master_to_pin_layer_range);
+  MasterLayerRange master_to_pin_layer_range = initMasterToPinLayerRange();
 
   computeUnique(master_to_pin_layer_range, pref_track_patterns);
 }

--- a/src/drt/src/pa/FlexPA_unique.h
+++ b/src/drt/src/pa/FlexPA_unique.h
@@ -69,7 +69,7 @@ class UniqueInsts
   void setDesign(frDesign* design) { design_ = design; }
 
  private:
-  using LayerRange = std::tuple<frLayerNum, frLayerNum>;
+  using LayerRange = std::pair<frLayerNum, frLayerNum>;
   using MasterLayerRange = std::map<frMaster*, LayerRange, frBlockObjectComp>;
 
   frDesign* getDesign() const { return design_; }
@@ -77,13 +77,13 @@ class UniqueInsts
   bool isNDRInst(frInst& inst);
   bool hasTrackPattern(frTrackPattern* tp, const Rect& box) const;
 
-  void getPrefTrackPatterns(std::vector<frTrackPattern*>& pref_track_patterns);
+  std::vector<frTrackPattern*> getPrefTrackPatterns();
   void applyPatternsFile(const char* file_path);
 
   void initUniqueInstance();
   void prepPoint_pin();
 
-  void initMaster2PinLayerRange(MasterLayerRange& master_to_pin_layer_range);
+  MasterLayerRange initMasterToPinLayerRange();
 
   void computeUnique(const MasterLayerRange& master_to_pin_layer_range,
                      const std::vector<frTrackPattern*>& pref_track_patterns);

--- a/src/drt/src/pa/FlexPA_unique.h
+++ b/src/drt/src/pa/FlexPA_unique.h
@@ -77,6 +77,16 @@ class UniqueInsts
   bool isNDRInst(frInst& inst);
   bool hasTrackPattern(frTrackPattern* tp, const Rect& box) const;
 
+  /**
+   * @brief Creates a vector of preferred track patterns.
+   *
+   * Not every track pattern is a preferred one,
+   * this function acts as filter of design_->getTopBlock()->getTrackPatterns()
+   * to only take the preferred ones, which are the ones in the routing
+   * direction of the layer.
+   *
+   * @return A vector of track patterns objects.
+   */
   std::vector<frTrackPattern*> getPrefTrackPatterns();
   void applyPatternsFile(const char* file_path);
 


### PR DESCRIPTION
This PR contain minor changes to some functions in PA. Functions changed take a reference to a container and fill said container. This PR changes it so instead it returns it.

This makes the functions role easier to understand, as its more obvious that its role is to return that structure and that it is an output, not an input.

This should not affect performance as due to **move semantics** instead of copying the returned structure its ownership is transferred to the caller.

Some functions have name changes:
- `prepPoint_pin_mergePinShapes` → `mergePinShapes` (Conform to PR [#5770](https://github.com/The-OpenROAD-Project/OpenROAD/pull/5770))
- `initMaster2PinLayerRange` → `initMasterToPinLayerRange`

Also `LayerRange` was changed to a pair instead of a tuple, as its always a tuple of 2 elements. This does not affect its use in code as it is accessed using `auto [a, b] = LayerRange`. 
