### PR TITLE
drt: explicit_wrong_dir, no_drv and pin_term/pin_net

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -857,10 +857,9 @@ void FlexPA::prepPoint_pin_checkPoint_planar(
   auto ps = std::make_unique<frPathSeg>();
   auto style = layer->getDefaultSegStyle();
   const bool vert_dir = (dir == frDirEnum::S || dir == frDirEnum::N);
-  const bool horz_dir = (dir == frDirEnum::W || dir == frDirEnum::E);
   const bool wrong_dir
       = (layer->getDir() == dbTechLayerDir::HORIZONTAL && vert_dir)
-        || (layer->getDir() == dbTechLayerDir::VERTICAL && horz_dir);
+        || (layer->getDir() == dbTechLayerDir::VERTICAL && !vert_dir);
   if (dir == frDirEnum::W || dir == frDirEnum::S) {
     ps->setPoints(end_point, begin_point);
     style.setEndStyle(frcTruncateEndStyle, 0);
@@ -1134,10 +1133,9 @@ bool FlexPA::prepPoint_pin_checkPoint_viaDir_helper(
     frDirEnum dir)
 {
   auto upper_layer = getTech()->getLayer(via->getViaDef()->getLayer2Num());
-  const bool horz_dir = (dir == frDirEnum::W || dir == frDirEnum::E);
   const bool vert_dir = (dir == frDirEnum::S || dir == frDirEnum::N);
   const bool wrong_dir = (upper_layer->isHorizontal() && vert_dir)
-                         || (upper_layer->isVertical() && horz_dir);
+                         || (upper_layer->isVertical() && !vert_dir);
   auto style = upper_layer->getDefaultSegStyle();
 
   if (wrong_dir) {


### PR DESCRIPTION
This PR has some minor changes to `prepPoint_pin_checkPoint_planar` and `prepPoint_pin_checkPoint_viaDir_helper`.
There are essentially three changes:
#### `vert_dir`, `horz_dir` and `wrong_dir` made explicit
Throughout both functions an at least on if statement has to check whether the given dir is in the preferred direction of the layer. This check is verbose and makes it difficult to follow the part of the code where those checks exists. `wrong_dir` was created to facilitate legibility.
#### `pin_term` and `pin_net` variables
Multiple getters for this variables though the code make it more bloated. Accessing them once and using them further make the code smaller.
#### `no_drv`
Both `no_drv` changes are very simple. In both cases the variable is checked, if `true` something happens using `true` as an argument (either setting the variable itself or `ap->setAccess()`), if `false` the same happens using `false`. `no_drv` is now used directly. There is no loss in readability since `no_drv` is defined right before both cases. 
One could argue that `no_drv` is unnecessary, and its condition could be used in its place, but I'd argue that the `no_drv` labeling makes its meaning more clear  