### PR TITLE
drt: cardinal directions and allow via simplification

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -198,10 +198,9 @@ void FlexPA::prepPoint_pin_genPoints_rect_ap_helper(
   auto ap = std::make_unique<frAccessPoint>(fpt, layer_num);
   if (allow_planar) {
     const auto lower_layer = getDesign()->getTech()->getLayer(layer_num);
-    ap->setAccess(frDirEnum::W, true);
-    ap->setAccess(frDirEnum::E, true);
-    ap->setAccess(frDirEnum::S, true);
-    ap->setAccess(frDirEnum::N, true);
+    for (const frDirEnum dir : frDirEnumPlanar) {
+      ap->setAccess(dir, true);
+    }
     // rectonly forbid wrongway planar access
     // rightway on grid only forbid off track rightway planar access
     // horz layer
@@ -229,17 +228,13 @@ void FlexPA::prepPoint_pin_genPoints_rect_ap_helper(
       }
     }
   } else {
-    ap->setAccess(frDirEnum::W, false);
-    ap->setAccess(frDirEnum::E, false);
-    ap->setAccess(frDirEnum::S, false);
-    ap->setAccess(frDirEnum::N, false);
+    for (const frDirEnum dir : frDirEnumPlanar) {
+      ap->setAccess(dir, false);
+    }
   }
   ap->setAccess(frDirEnum::D, false);
-  if (allow_via) {
-    ap->setAccess(frDirEnum::U, true);
-  } else {
-    ap->setAccess(frDirEnum::U, false);
-  }
+  ap->setAccess(frDirEnum::U, allow_via);
+
   ap->setAllowVia(allow_via);
   ap->setType((frAccessPointEnum) low_cost, true);
   ap->setType((frAccessPointEnum) high_cost, false);
@@ -1113,14 +1108,12 @@ bool FlexPA::prepPoint_pin_checkPoint_via_helper(
     frInstTerm* inst_term,
     const std::vector<gtl::polygon_90_data<frCoord>>& layer_polys)
 {
-  return prepPoint_pin_checkPoint_viaDir_helper(
-             ap, via, pin, inst_term, layer_polys, frDirEnum::E)
-         || prepPoint_pin_checkPoint_viaDir_helper(
-             ap, via, pin, inst_term, layer_polys, frDirEnum::W)
-         || prepPoint_pin_checkPoint_viaDir_helper(
-             ap, via, pin, inst_term, layer_polys, frDirEnum::S)
-         || prepPoint_pin_checkPoint_viaDir_helper(
-             ap, via, pin, inst_term, layer_polys, frDirEnum::N);
+  bool some_dir_is_legal = false;
+  for (const frDirEnum dir : frDirEnumPlanar) {
+    some_dir_is_legal |= prepPoint_pin_checkPoint_viaDir_helper(
+        ap, via, pin, inst_term, layer_polys, dir);
+  }
+  return some_dir_is_legal;
 }
 
 template <typename T>
@@ -1245,10 +1238,9 @@ void FlexPA::prepPoint_pin_checkPoint(
     bool deep_search)
 {
   if (!deep_search) {
-    prepPoint_pin_checkPoint_planar(ap, polys, frDirEnum::W, pin, inst_term);
-    prepPoint_pin_checkPoint_planar(ap, polys, frDirEnum::E, pin, inst_term);
-    prepPoint_pin_checkPoint_planar(ap, polys, frDirEnum::S, pin, inst_term);
-    prepPoint_pin_checkPoint_planar(ap, polys, frDirEnum::N, pin, inst_term);
+    for (const frDirEnum dir : frDirEnumPlanar) {
+      prepPoint_pin_checkPoint_planar(ap, polys, dir, pin, inst_term);
+    }
   }
   prepPoint_pin_checkPoint_via(
       ap, polys, polyset, frDirEnum::U, pin, inst_term, deep_search);

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1108,12 +1108,13 @@ bool FlexPA::prepPoint_pin_checkPoint_via_helper(
     frInstTerm* inst_term,
     const std::vector<gtl::polygon_90_data<frCoord>>& layer_polys)
 {
-  bool some_dir_is_legal = false;
   for (const frDirEnum dir : frDirEnumPlanar) {
-    some_dir_is_legal |= prepPoint_pin_checkPoint_viaDir_helper(
-        ap, via, pin, inst_term, layer_polys, dir);
+    if (prepPoint_pin_checkPoint_viaDir_helper(
+            ap, via, pin, inst_term, layer_polys, dir)) {
+      return true;
+    }
   }
-  return some_dir_is_legal;
+  return false;
 }
 
 template <typename T>


### PR DESCRIPTION
This PR simply adds the use of `frDirEnumPlanar` when appropriate.
It also simplifies
```
if (allow_via) {
    ap->setAccess(frDirEnum::U, true);
  } else {
    ap->setAccess(frDirEnum::U, false);
  }
```
to
```
ap->setAccess(frDirEnum::U, allow_via);
```