### PR TITLE
pad: avoid passing list of lists to sta::parse_port_net_args

### DIFF
--- a/src/pad/src/pad.tcl
+++ b/src/pad/src/pad.tcl
@@ -420,6 +420,10 @@ proc rdl_route {args} {
     keys {-layer -width -spacing -bump_via -pad_via -turn_penalty} \
     flags {-allow45}
 
+  if { [llength $args] == 1 } {
+    set args [lindex $args 0]
+  }
+
   sta::parse_port_net_args $args sta_ports sta_nets
   set nets []
   foreach net $sta_nets {


### PR DESCRIPTION
Avoid passing list of lists to `sta::parse_port_net_args`.
Without this it seems to be triggering a bug in the opensta tcl at https://github.com/The-OpenROAD-Project/OpenSTA/blob/20925bb00965c1199c45aca0318c2baeb4042c5a/tcl/CmdArgs.tcl#L81
I'm not able to reliably replicate it to make a testcase: `9 can't read "libcells": no such variable`
