### PR TITLE
grt: destroy pins from disconnected terms

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4730,9 +4730,10 @@ void GRouteDbCbk::inDbNetPreMerge(odb::dbNet* preserved_net,
 
 void GRouteDbCbk::inDbITermPreDisconnect(odb::dbITerm* iterm)
 {
-  // missing net pin update
-  odb::dbNet* net = iterm->getNet();
-  if (net != nullptr && !net->isSpecial()) {
+  odb::dbNet* db_net = iterm->getNet();
+  if (db_net != nullptr && !db_net->isSpecial()) {
+    Net* net = grouter_->getNet(db_net);
+    net->destroyITermPin(iterm);
     grouter_->addDirtyNet(iterm->getNet());
   }
 }
@@ -4757,9 +4758,10 @@ void GRouteDbCbk::inDbBTermPostConnect(odb::dbBTerm* bterm)
 
 void GRouteDbCbk::inDbBTermPreDisconnect(odb::dbBTerm* bterm)
 {
-  // missing net pin update
-  odb::dbNet* net = bterm->getNet();
-  if (net != nullptr && !net->isSpecial()) {
+  odb::dbNet* db_net = bterm->getNet();
+  if (db_net != nullptr && !db_net->isSpecial()) {
+    Net* net = grouter_->getNet(db_net);
+    net->destroyBTermPin(bterm);
     grouter_->addDirtyNet(bterm->getNet());
   }
 }

--- a/src/grt/src/Net.cpp
+++ b/src/grt/src/Net.cpp
@@ -35,6 +35,7 @@
 
 #include "Net.h"
 
+#include "grt/GlobalRouter.h"
 #include "odb/dbShape.h"
 
 namespace grt {
@@ -109,6 +110,26 @@ bool Net::isLocal()
 void Net::destroyPins()
 {
   pins_.clear();
+}
+
+void Net::destroyITermPin(odb::dbITerm* iterm)
+{
+  pins_.erase(std::remove_if(pins_.begin(),
+                             pins_.end(),
+                             [&](const Pin& pin) {
+                               return pin.getName() == getITermName(iterm);
+                             }),
+              pins_.end());
+}
+
+void Net::destroyBTermPin(odb::dbBTerm* bterm)
+{
+  pins_.erase(std::remove_if(pins_.begin(),
+                             pins_.end(),
+                             [&](const Pin& pin) {
+                               return pin.getName() == bterm->getName();
+                             }),
+              pins_.end());
 }
 
 int Net::getNumBTermsAboveMaxLayer(odb::dbTechLayer* max_routing_layer)

--- a/src/grt/src/Net.h
+++ b/src/grt/src/Net.h
@@ -71,6 +71,8 @@ class Net
   std::vector<std::vector<SegmentIndex>> buildSegmentsGraph();
   bool isLocal();
   void destroyPins();
+  void destroyITermPin(odb::dbITerm* iterm);
+  void destroyBTermPin(odb::dbBTerm* bterm);
   bool hasWires() const { return has_wires_; }
   bool hasStackedVias(odb::dbTechLayer* max_routing_layer);
   void setMergedNet(bool merged_net) { merged_net_ = merged_net; }


### PR DESCRIPTION
Fix crash in remove_buffers2 unit test, related to the merging of nets that were connected by a removed buffer.