### PR TITLE
drt: endPointIsOutside split

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -237,13 +237,35 @@ class FlexPA
       frDirEnum dir,
       T* pin,
       frInstTerm* inst_term);
-  bool prepPoint_pin_checkPoint_planar_ep(
-      Point& end_point,
+
+  /**
+   * @brief Generates an end_point given an begin_point in the direction
+   *
+   * @param layer_polys Pin Polygons on the layer (used for a check)
+   * TODO: maybe the check can be moves to isPointOusideShapes, but not sure
+   * @param begin_point The begin reference point
+   * @param layer_num layer where the point is being created
+   * @param dir direction where the layer will be created
+   * @param is_block wether the begin_point is from a macro block
+   *
+   * @returns the generated end point
+   */
+  Point genEndPoint(
       const std::vector<gtl::polygon_90_data<frCoord>>& layer_polys,
       const Point& begin_point,
-      frLayerNum layer_num,
-      frDirEnum dir,
-      bool is_block);
+      const frLayerNum layer_num,
+      const frDirEnum dir,
+      const bool is_block);
+
+  /**
+   * @brief Checks if a point is outside the layer_polygons
+   *
+   * @return if the point is outside the pin shapes
+   */
+  bool isPointOutsideShapes(
+      Point& point,
+      const std::vector<gtl::polygon_90_data<frCoord>>& layer_polys);
+
   template <typename T>
   void prepPoint_pin_checkPoint_via(
       frAccessPoint* ap,


### PR DESCRIPTION
This PR is waiting for PR #5770 to merge.
`endPointIsOutside` if a function that clearly has two responsibilities:
1. Generate an end point from a begin point in some direction in some layer
2. Check if this point is contained in the pin polygons on that layer.

The function is called twice:
In `prepPoint_pin_checkPoint_planar`:
```
Point end_point;
const bool is_outside = endPointIsOutside(end_point, layer_polys, begin_point, ap->getLayerNum(), dir, is_block);
```
And `prepPoint_pin_checkPoint_viaDir_helper`:
```
Point end_point;
endPointIsOutside(end_point, layer_polys, getViaDef()->getLayer2Num(), dir, is_block);
```
In both cases the caller is interested in generating an end point, but the check for the point being outside is only pertinent for the first, as the second call does not check the returned value.
Therefore the function was split in two different, one for each responsability: `genEndPoint()`and `isPointOutsideShapes()` respectively.