### PR TITLE
mpl2: add mechanism to ease outline/boundary weights based on the amount of nets

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -1855,6 +1855,11 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
     best_cost = std::numeric_limits<float>::max();
     begin_check = 0;
     end_check = std::min(check_interval, remaining_runs);
+
+    int outline_weight, boundary_weight;
+    setWeightsForConvergence(
+        outline_weight, boundary_weight, nets, num_of_macros_to_place);
+
     debugPrint(logger_,
                MPL,
                "hierarchical_macro_placement",
@@ -1919,11 +1924,11 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
             outline,
             shaped_macros,
             area_weight_,
-            outline_weight_,
+            outline_weight,
             wirelength_weight_,
             guidance_weight_,
             fence_weight_,
-            boundary_weight_,
+            boundary_weight,
             macro_blockage_weight_,
             notch_weight_,
             notch_h_th_,
@@ -2124,6 +2129,36 @@ void HierRTLMP::adjustMacroBlockageWeight()
                macro_blockage_weight_,
                new_macro_blockage_weight);
     macro_blockage_weight_ = new_macro_blockage_weight;
+  }
+}
+
+void HierRTLMP::setWeightsForConvergence(int& outline_weight,
+                                         int& boundary_weight,
+                                         const std::vector<BundledNet>& nets,
+                                         const int number_of_placeable_macros)
+{
+  outline_weight = outline_weight_;
+  boundary_weight = boundary_weight_;
+
+  if (nets.size() < number_of_placeable_macros / 2) {
+    // If a design has too few connections, there's a possibily that, for
+    // some tight outlines, the outline penalty will struggle to win the
+    // fight against the boundary penalty. This can happen specially for
+    // large hierarchical designs that were reduced by deltaDebug.
+    outline_weight *= 2;
+    boundary_weight /= 2;
+
+    debugPrint(logger_,
+               MPL,
+               "hierarchical_macro_placement",
+               1,
+               "Number of bundled nets is below half of the number of "
+               "placeable macros, adapting "
+               "weights. Outline {} -> {}, Boundary {} -> {}.",
+               outline_weight_,
+               outline_weight,
+               boundary_weight_,
+               boundary_weight);
   }
 }
 
@@ -2428,6 +2463,11 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
   float best_cost = std::numeric_limits<float>::max();
+
+  int outline_weight, boundary_weight;
+  setWeightsForConvergence(
+      outline_weight, boundary_weight, nets, num_of_macros_to_place);
+
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",
@@ -2491,11 +2531,11 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               area_weight_,
-                                              outline_weight_,
+                                              outline_weight,
                                               wirelength_weight_,
                                               guidance_weight_,
                                               fence_weight_,
-                                              boundary_weight_,
+                                              boundary_weight,
                                               macro_blockage_weight_,
                                               notch_weight_,
                                               notch_h_th_,
@@ -2913,6 +2953,11 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
   const int check_interval = 10;
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
+
+  int outline_weight, boundary_weight;
+  setWeightsForConvergence(
+      outline_weight, boundary_weight, nets, macros_to_place);
+
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",
@@ -2973,11 +3018,11 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               area_weight_,
-                                              outline_weight_,
+                                              outline_weight,
                                               wirelength_weight_,
                                               guidance_weight_,
                                               fence_weight_,
-                                              boundary_weight_,
+                                              boundary_weight,
                                               macro_blockage_weight_,
                                               notch_weight_,
                                               notch_h_th_,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -178,6 +178,10 @@ class HierRTLMP
   // Hierarchical Macro Placement 1st stage: Cluster Placement
   void runHierarchicalMacroPlacement(Cluster* parent);
   void adjustMacroBlockageWeight();
+  void setWeightsForConvergence(int& outline_weight,
+                                int& boundary_weight,
+                                const std::vector<BundledNet>& nets,
+                                int number_of_placeable_macros);
   void reportSAWeights();
   void runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent);
   void runEnhancedHierarchicalMacroPlacement(Cluster* parent);

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -106,7 +106,7 @@ proc rtl_macro_placer { args } {
   set fence_uy 100000000.0
 
   set area_weight 0.1
-  set outline_weight 100.0
+  set outline_weight 200.0
   set wirelength_weight 100.0
   set guidance_weight 10.0
   set fence_weight 10.0

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -106,7 +106,7 @@ proc rtl_macro_placer { args } {
   set fence_uy 100000000.0
 
   set area_weight 0.1
-  set outline_weight 200.0
+  set outline_weight 100.0
   set wirelength_weight 100.0
   set guidance_weight 10.0
   set fence_weight 10.0


### PR DESCRIPTION
Resolve #5655 

Increase outline weight and reduce boundary to ease SA job for cases with very few bundled nets during **_cluster placement_**. Without this, the lack of connections + boundary pushing may end up preventing macros to fit in a tight outline.

_Note: The initial idea here was to tune the outline weight to a higher value. Running CI for this resulted in GPL not converging in a private design and a failure in sky130hd/uw due to high congestion caused by a bad macro placement._