### PR TITLE
drt: check for inst_term nullptr

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1499,7 +1499,7 @@ int FlexPA::initPinAccess(T* pin, frInstTerm* inst_term)
     if (is_macro_cell_pin) {
       macro_cell_pin_no_ap_cnt_++;
     }
-  } else {
+  } else if (inst_term) {
     // write to pa
     const int pin_access_idx = unique_insts_.getPAIndex(inst_term->getInst());
     for (auto& ap : aps) {

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1499,7 +1499,10 @@ int FlexPA::initPinAccess(T* pin, frInstTerm* inst_term)
     if (is_macro_cell_pin) {
       macro_cell_pin_no_ap_cnt_++;
     }
-  } else if (inst_term) {
+  } else {
+    if (inst_term == nullptr) {
+      logger_->error(DRT, 254, "inst_term can not be nullptr");
+    }
     // write to pa
     const int pin_access_idx = unique_insts_.getPAIndex(inst_term->getInst());
     for (auto& ap : aps) {


### PR DESCRIPTION
This PR patches a Coverity scan defect. `inst_term->getInst()` could be called even if `inst_term` was a `nullprt`. Now it can't.