### PR TITLE
drt: genAPsFromRect code duplication elimination

### DIFF
--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -502,148 +502,87 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   }
 
   // gen all full/half grid coords
+  int offset = is_macro_cell_pin ? hwidth : 0;
+  int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
+  int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
+  int layer2_rect_min = is_layer1_horz ? gtl::xl(rect) : gtl::yl(rect);
+  int layer2_rect_max = is_layer1_horz ? gtl::xh(rect) : gtl::yh(rect);
+  std::map<frCoord, frAccessPointEnum>& layer1_coords
+      = is_layer1_horz ? y_coords : x_coords;
+  std::map<frCoord, frAccessPointEnum>& layer2_coords
+      = is_layer1_horz ? x_coords : y_coords;
+
   if (!is_macro_cell_pin || !use_center_line) {
-    if (is_layer1_horz) {
-      genAPOnTrack(y_coords, layer1_track_coords, gtl::yl(rect), gtl::yh(rect));
-      genAPOnTrack(x_coords,
+    genAPOnTrack(
+        layer1_coords, layer1_track_coords, layer1_rect_min, layer1_rect_max);
+    genAPOnTrack(layer2_coords,
+                 layer2_track_coords,
+                 layer2_rect_min + offset,
+                 layer2_rect_max - offset);
+    if (lower_type >= frAccessPointEnum::Center) {
+      genAPCentered(layer1_coords, layer_num, layer1_rect_min, layer1_rect_max);
+    }
+    if (lower_type >= frAccessPointEnum::EncOpt) {
+      genAPEnclosedBoundary(layer1_coords, rect, layer_num, is_layer1_horz);
+    }
+    if (upper_type >= frAccessPointEnum::Center) {
+      genAPCentered(layer2_coords,
+                    layer_num,
+                    layer2_rect_min + offset,
+                    layer2_rect_max - offset);
+    }
+    if (upper_type >= frAccessPointEnum::EncOpt) {
+      genAPEnclosedBoundary(layer2_coords, rect, layer_num, !is_layer1_horz);
+    }
+    if (lower_type >= frAccessPointEnum::NearbyGrid) {
+      genAPOnTrack(layer1_coords,
+                   layer1_track_coords,
+                   layer1_rect_max,
+                   layer1_rect_max + min_width_layer1,
+                   true);
+      genAPOnTrack(layer1_coords,
+                   layer1_track_coords,
+                   layer1_rect_min - min_width_layer1,
+                   layer1_rect_min,
+                   true);
+    }
+    if (upper_type >= frAccessPointEnum::NearbyGrid) {
+      genAPOnTrack(layer2_coords,
                    layer2_track_coords,
-                   gtl::xl(rect) + (is_macro_cell_pin ? hwidth : 0),
-                   gtl::xh(rect) - (is_macro_cell_pin ? hwidth : 0));
-      if (lower_type >= frAccessPointEnum::Center) {
-        genAPCentered(y_coords, layer_num, gtl::yl(rect), gtl::yh(rect));
-      }
-      if (lower_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(y_coords, rect, layer_num, is_layer1_horz);
-      }
-      if (upper_type >= frAccessPointEnum::Center) {
-        genAPCentered(x_coords,
-                      layer_num,
-                      gtl::xl(rect) + (is_macro_cell_pin ? hwidth : 0),
-                      gtl::xh(rect) - (is_macro_cell_pin ? hwidth : 0));
-      }
-      if (upper_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(x_coords, rect, layer_num, !is_layer1_horz);
-      }
-      if (lower_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(y_coords,
-                     layer1_track_coords,
-                     gtl::yh(rect),
-                     gtl::yh(rect) + min_width_layer1,
-                     true);
-        genAPOnTrack(y_coords,
-                     layer1_track_coords,
-                     gtl::yl(rect) - min_width_layer1,
-                     gtl::yl(rect),
-                     true);
-      }
-      if (upper_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(x_coords,
-                     layer2_track_coords,
-                     gtl::xh(rect),
-                     gtl::xh(rect) + min_width_layer2,
-                     true);
-        genAPOnTrack(x_coords,
-                     layer2_track_coords,
-                     gtl::xl(rect) - min_width_layer2,
-                     gtl::xl(rect),
-                     true);
-      }
-    } else {
-      genAPOnTrack(x_coords, layer1_track_coords, gtl::xl(rect), gtl::xh(rect));
-      genAPOnTrack(y_coords,
+                   layer2_rect_max,
+                   layer2_rect_max + min_width_layer2,
+                   true);
+      genAPOnTrack(layer2_coords,
                    layer2_track_coords,
-                   gtl::yl(rect) + (is_macro_cell_pin ? hwidth : 0),
-                   gtl::yh(rect) - (is_macro_cell_pin ? hwidth : 0));
-      if (lower_type >= frAccessPointEnum::Center) {
-        genAPCentered(x_coords, layer_num, gtl::xl(rect), gtl::xh(rect));
-      }
-      if (lower_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(x_coords, rect, layer_num, is_layer1_horz);
-      }
-      if (upper_type >= frAccessPointEnum::Center) {
-        genAPCentered(y_coords,
-                      layer_num,
-                      gtl::yl(rect) + (is_macro_cell_pin ? hwidth : 0),
-                      gtl::yh(rect) - (is_macro_cell_pin ? hwidth : 0));
-      }
-      if (upper_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(y_coords, rect, layer_num, !is_layer1_horz);
-      }
-      if (lower_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(x_coords,
-                     layer1_track_coords,
-                     gtl::xh(rect),
-                     gtl::xh(rect) + min_width_layer1,
-                     true);
-        genAPOnTrack(x_coords,
-                     layer1_track_coords,
-                     gtl::xl(rect) - min_width_layer1,
-                     gtl::xl(rect),
-                     true);
-      }
-      if (upper_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(y_coords,
-                     layer2_track_coords,
-                     gtl::yh(rect),
-                     gtl::yh(rect) + min_width_layer2,
-                     true);
-        genAPOnTrack(y_coords,
-                     layer2_track_coords,
-                     gtl::yl(rect) - min_width_layer2,
-                     gtl::yl(rect),
-                     true);
-      }
+                   layer2_rect_min - min_width_layer2,
+                   layer2_rect_min,
+                   true);
     }
   } else {
-    if (is_layer1_horz) {
-      lower_type = frAccessPointEnum::OnGrid;
-      genAPOnTrack(x_coords, layer2_track_coords, gtl::xl(rect), gtl::xh(rect));
-      if (upper_type >= frAccessPointEnum::Center) {
-        genAPCentered(x_coords, layer_num, gtl::xl(rect), gtl::xh(rect));
-      }
-      if (upper_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(x_coords, rect, layer_num, !is_layer1_horz);
-      }
-      if (upper_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(x_coords,
-                     layer2_track_coords,
-                     gtl::xh(rect),
-                     gtl::xh(rect) + min_width_layer2,
-                     true);
-        genAPOnTrack(x_coords,
-                     layer2_track_coords,
-                     gtl::xl(rect) - min_width_layer2,
-                     gtl::xl(rect),
-                     true);
-      }
-      genAPCentered(y_coords, layer_num, gtl::yl(rect), gtl::yh(rect));
-      for (auto& [y_coord, cost] : y_coords) {
-        y_coords[y_coord] = frAccessPointEnum::OnGrid;
-      }
-    } else {
-      genAPOnTrack(y_coords, layer2_track_coords, gtl::yl(rect), gtl::yh(rect));
-      if (upper_type >= frAccessPointEnum::Center) {
-        genAPCentered(y_coords, layer_num, gtl::yl(rect), gtl::yh(rect));
-      }
-      if (upper_type >= frAccessPointEnum::EncOpt) {
-        genAPEnclosedBoundary(y_coords, rect, layer_num, !is_layer1_horz);
-      }
-      if (upper_type >= frAccessPointEnum::NearbyGrid) {
-        genAPOnTrack(y_coords,
-                     layer2_track_coords,
-                     gtl::yh(rect),
-                     gtl::yh(rect) + min_width_layer2,
-                     true);
-        genAPOnTrack(y_coords,
-                     layer2_track_coords,
-                     gtl::yl(rect) - min_width_layer2,
-                     gtl::yl(rect),
-                     true);
-      }
-      genAPCentered(x_coords, layer_num, gtl::xl(rect), gtl::xh(rect));
-      for (auto& [x_coord, cost] : x_coords) {
-        x_coords[x_coord] = frAccessPointEnum::OnGrid;
-      }
+    lower_type = frAccessPointEnum::OnGrid;
+    genAPOnTrack(
+        layer2_coords, layer2_track_coords, layer2_rect_min, layer2_rect_max);
+    if (upper_type >= frAccessPointEnum::Center) {
+      genAPCentered(layer2_coords, layer_num, layer2_rect_min, layer2_rect_max);
+    }
+    if (upper_type >= frAccessPointEnum::EncOpt) {
+      genAPEnclosedBoundary(layer2_coords, rect, layer_num, !is_layer1_horz);
+    }
+    if (upper_type >= frAccessPointEnum::NearbyGrid) {
+      genAPOnTrack(layer2_coords,
+                   layer2_track_coords,
+                   layer2_rect_max,
+                   layer2_rect_max + min_width_layer2,
+                   true);
+      genAPOnTrack(layer2_coords,
+                   layer2_track_coords,
+                   layer2_rect_min - min_width_layer2,
+                   layer2_rect_min,
+                   true);
+    }
+    genAPCentered(layer1_coords, layer_num, layer1_rect_min, layer1_rect_max);
+    for (auto& [layer1_coord, cost] : layer1_coords) {
+      layer1_coords[layer1_coord] = frAccessPointEnum::OnGrid;
     }
   }
   gen_initializeAccessPoints(aps,

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -557,7 +557,6 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
                    true);
     }
   } else {
-    lower_type = frAccessPointEnum::OnGrid;
     genAPOnTrack(
         layer2_coords, layer2_track_coords, layer2_rect_min, layer2_rect_max);
     if (upper_type >= frAccessPointEnum::Center) {
@@ -583,6 +582,11 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
       layer1_coords[layer1_coord] = frAccessPointEnum::OnGrid;
     }
   }
+
+  if (is_macro_cell_pin && use_center_line && is_layer1_horz) {
+    lower_type = frAccessPointEnum::OnGrid;
+  }
+
   gen_initializeAccessPoints(aps,
                              apset,
                              rect,

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -502,15 +502,13 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   }
 
   // gen all full/half grid coords
-  int offset = is_macro_cell_pin ? hwidth : 0;
-  int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
-  int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
-  int layer2_rect_min = is_layer1_horz ? gtl::xl(rect) : gtl::yl(rect);
-  int layer2_rect_max = is_layer1_horz ? gtl::xh(rect) : gtl::yh(rect);
-  std::map<frCoord, frAccessPointEnum>& layer1_coords
-      = is_layer1_horz ? y_coords : x_coords;
-  std::map<frCoord, frAccessPointEnum>& layer2_coords
-      = is_layer1_horz ? x_coords : y_coords;
+  const int offset = is_macro_cell_pin ? hwidth : 0;
+  const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
+  const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
+  const int layer2_rect_min = is_layer1_horz ? gtl::xl(rect) : gtl::yl(rect);
+  const int layer2_rect_max = is_layer1_horz ? gtl::xh(rect) : gtl::yh(rect);
+  auto& layer1_coords = is_layer1_horz ? y_coords : x_coords;
+  auto& layer2_coords = is_layer1_horz ? x_coords : y_coords;
 
   if (!is_macro_cell_pin || !use_center_line) {
     genAPOnTrack(


### PR DESCRIPTION
genAPsFromRect has a lot of code duplication. 
### Problem:
When generating access points for a given rectangle shape there are two relevant layer, a layer 1 and layer 2. Currently, the code verifies if layer 1 was horizontal. If true it made a bunch of calls to generate access points. In some cases Y/vertical coordinates were used and other X/horizontal coordinates were used. If false it made the exact functions calls with the same patterns, except Y/vertical and X/horizontal were switched. This happened twice.
### Solution:
Auxiliary variables `layer1_rect_min`, `layer1_rect_max`, `layer2_rect_min`, `layer2_rect_max`, `layer1_coords` and `layer2_coords` were created. The logic to check if layer 1 is horizontal is done in them through ternary operations and they are used in posterior calls, so code does not have to be duplicated
### Others:
An auxilary `offset` variable was created to substitute the ternary `is_macro_cell_pin ? hwidth : 0` as it appeared 6 times in the code