### PR TITLE
ppl: a group is on a single metal layer

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -385,7 +385,8 @@ int IOPlacer::placeFallbackPins(bool random)
             logger_->error(PPL,
                            93,
                            "Pin group of size {} does not fit in the "
-                           "constrained region {:.2f}-{:.2f} at {} edge. "
+                           "constrained region {:.2f}-{:.2f} at {} edge on a "
+                           "single metal layer. "
                            "First pin of the group is {}.",
                            group.first.size(),
                            getBlock()->dbuToMicrons(interval.getBegin()),

--- a/src/ppl/test/large_groups3.ok
+++ b/src/ppl/test/large_groups3.ok
@@ -12,5 +12,5 @@ Found 0 macro blocks.
 [WARNING PPL-0042] Unsuccessfully assigned I/O groups.
 [WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
 [WARNING PPL-0097] The max contiguous slots (35) is smaller than the group size (71).
-[ERROR PPL-0093] Pin group of size 71 does not fit in the constrained region 0.00-100.13 at TOP edge. First pin of the group is pin300.
+[ERROR PPL-0093] Pin group of size 71 does not fit in the constrained region 0.00-100.13 at TOP edge on a single metal layer. First pin of the group is pin300.
 PPL-0093


### PR DESCRIPTION
Improve error message for non-obvious problem.

I have a macro that is routed by abutment and temporarily during development I need to have a LOT of pins which can't fit on a single metal layer. I therefore increase the number of metal layers via IO_LAYER_H, but it still failed because I had a `set_io_pin_constraint -group -order` constraint which forced all pins to be put on a single metal layer.

It was not obvious to me that a group can't span metal layers... I'm hoping that mentioning "metal layer" here will key the user onto the problem.

Knowing this, I was able to work around some global routing congestion errors by removing a constraint:

```
 foreach {direction direction2 names} $assignments {
     set mirrored [zip {*}$names]
     set_io_pin_constraint -region $direction2:* -pin_names [lindex $names 1]
-    set_io_pin_constraint -group -order -pin_names [lindex $names 1]
+    #set_io_pin_constraint -group -order -pin_names [lindex $names 1]
     set_io_pin_constraint -mirrored_pins $mirrored
 }
```
