### PR TITLE
CTS-Avoid level balance buffers overlap.

### DIFF
--- a/src/cts/src/LevelBalancer.cpp
+++ b/src/cts/src/LevelBalancer.cpp
@@ -101,16 +101,16 @@ void LevelBalancer::addBufferLevels(TreeBuilder* builder,
   const double centroidY = totalY / cluster.size();
   int x = prevLevelSubNet->getDriver()->getX();
   int y = prevLevelSubNet->getDriver()->getY();
-  
-  int steps = std::max((int)((centroidY - y) / height), 1);
-  int buffPerStep = std::ceil((float)bufLevels / (float)steps);
+
+  int steps = std::max((int) ((centroidY - y) / height), 1);
+  int buffPerStep = std::ceil((float) bufLevels / (float) steps);
 
   for (unsigned level = 0; level < bufLevels; level++) {
     // Add buffer
-    if(level % buffPerStep) {
-      x = (x + width) ;
+    if (level % buffPerStep) {
+      x = (x + width);
     } else {
-      y = (y + height) ;
+      y = (y + height);
     }
     Point<double> bufferLoc(x / wireSegmentUnit_, y / wireSegmentUnit_);
     Point<double> legalBufferLoc

--- a/src/cts/src/LevelBalancer.cpp
+++ b/src/cts/src/LevelBalancer.cpp
@@ -94,22 +94,25 @@ void LevelBalancer::addBufferLevels(TreeBuilder* builder,
     totalX += clockInstObj->getX();
     totalY += clockInstObj->getY();
   }
+  double height = builder->getBufferHeight() * wireSegmentUnit_;
+  double width = builder->getBufferWidth() * wireSegmentUnit_;
+
   const double centroidX = totalX / cluster.size();
   const double centroidY = totalY / cluster.size();
-  const int driverX = prevLevelSubNet->getDriver()->getX();
-  const int driverY = prevLevelSubNet->getDriver()->getY();
+  int x = prevLevelSubNet->getDriver()->getX();
+  int y = prevLevelSubNet->getDriver()->getY();
+  
+  int steps = std::max((int)((centroidY - y) / height), 1);
+  int buffPerStep = std::ceil((float)bufLevels / (float)steps);
 
   for (unsigned level = 0; level < bufLevels; level++) {
     // Add buffer
-    double x
-        = (driverX
-           + (centroidX - driverX) * (double) (level + 1) / (bufLevels + 1))
-          / wireSegmentUnit_;
-    double y
-        = (driverY
-           + (centroidY - driverY) * (double) (level + 1) / (bufLevels + 1))
-          / wireSegmentUnit_;
-    Point<double> bufferLoc(x, y);
+    if(level % buffPerStep) {
+      x = (x + width) ;
+    } else {
+      y = (y + height) ;
+    }
+    Point<double> bufferLoc(x / wireSegmentUnit_, y / wireSegmentUnit_);
     Point<double> legalBufferLoc
         = builder->legalizeOneBuffer(bufferLoc, options_->getSinkBuffer());
     ClockInst& levelBuffer = builder->getClock().addClockBuffer(


### PR DESCRIPTION
The current Level Balancer of CTS tends to insert buffers one on top of the other and when they are legalized a cluster of buffers is formed, issue [#2305](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2305) shows an example of this. This happens specially if the clock buffers are large and it creates a high congested area that can lead to the global router finishing with overflow.

This PR changes the level balancer to avoid overlapping the inserted buffers and preventing the creation of the clusters of buffers. The next images show the result for the regressions test of CTS _balance_levels_:
Current:
![image](https://github.com/user-attachments/assets/4b990039-e253-49d8-b258-feb678108006)


New:
![image](https://github.com/user-attachments/assets/7435fed8-1080-4398-b21a-9c1ba3da7670)
