### PR TITLE
drt: suport por setting multiple accesses in a single call

### DIFF
--- a/src/drt/src/db/obj/frAccess.h
+++ b/src/drt/src/db/obj/frAccess.h
@@ -169,6 +169,13 @@ class frAccessPoint : public frBlockObject
         std::cout << "Error: unexpected direction in setValidAccess\n";
     }
   }
+  template <std::size_t N>
+  void setMultipleAccesses(const frDirEnum (&dirArray)[N], bool isValid = true)
+  {
+    for (std::size_t i = 0; i < N; ++i) {
+      setAccess(dirArray[i], isValid);
+    }
+  }
   void addViaDef(frViaDef* in);
   void addToPinAccess(frPinAccess* in) { aps_ = in; }
   void setType(frAccessPointEnum in, bool isL = true)

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -273,6 +273,12 @@ static constexpr frDirEnum frDirEnumAll[] = {frDirEnum::D,
 static constexpr frDirEnum frDirEnumPlanar[]
     = {frDirEnum::S, frDirEnum::W, frDirEnum::E, frDirEnum::N};
 
+static constexpr frDirEnum frDirEnumVia[] = {frDirEnum::U, frDirEnum::D};
+
+static constexpr frDirEnum frDirEnumVert[] = {frDirEnum::N, frDirEnum::S};
+
+static constexpr frDirEnum frDirEnumHorz[] = {frDirEnum::W, frDirEnum::E};
+
 enum class AccessPointTypeEnum
 {
   Ideal,

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -211,40 +211,32 @@ void FlexPA::gen_createAccessPoint(
     return;
   }
   auto ap = std::make_unique<frAccessPoint>(fpt, layer_num);
+
+  ap->setMultipleAccesses(frDirEnumPlanar, allow_planar);
+
   if (allow_planar) {
     const auto lower_layer = getDesign()->getTech()->getLayer(layer_num);
-    for (const frDirEnum dir : frDirEnumPlanar) {
-      ap->setAccess(dir, true);
-    }
     // rectonly forbid wrongway planar access
     // rightway on grid only forbid off track rightway planar access
     // horz layer
     if (lower_layer->getDir() == dbTechLayerDir::HORIZONTAL) {
       if (lower_layer->isUnidirectional()) {
-        ap->setAccess(frDirEnum::S, false);
-        ap->setAccess(frDirEnum::N, false);
+        ap->setMultipleAccesses(frDirEnumVert, false);
       }
       if (lower_layer->getLef58RightWayOnGridOnlyConstraint()
           && low_cost != frAccessPointEnum::OnGrid) {
-        ap->setAccess(frDirEnum::W, false);
-        ap->setAccess(frDirEnum::E, false);
+        ap->setMultipleAccesses(frDirEnumHorz, false);
       }
     }
     // vert layer
     if (lower_layer->getDir() == dbTechLayerDir::VERTICAL) {
       if (lower_layer->isUnidirectional()) {
-        ap->setAccess(frDirEnum::W, false);
-        ap->setAccess(frDirEnum::E, false);
+        ap->setMultipleAccesses(frDirEnumHorz, false);
       }
       if (lower_layer->getLef58RightWayOnGridOnlyConstraint()
           && low_cost != frAccessPointEnum::OnGrid) {
-        ap->setAccess(frDirEnum::S, false);
-        ap->setAccess(frDirEnum::N, false);
+        ap->setMultipleAccesses(frDirEnumVert, false);
       }
-    }
-  } else {
-    for (const frDirEnum dir : frDirEnumPlanar) {
-      ap->setAccess(dir, false);
     }
   }
   ap->setAccess(frDirEnum::D, false);


### PR DESCRIPTION
Adds arrays for `frDirEnumVia`, `frDirEnumHorz` and `frDirEnumVert` in the same format as `frDirEnumPlanar` and `frDirEnumAll`.

Adds support for setting multiple accesses with a single call: `setMultipleAccesses`.

Implements the new function in `gen_createAccessPoint`

Also refactored:
```
if (allow_planar) {
  ...
  for (const frDirEnum dir : frDirEnumPlanar) {
    ap->setAccess(dir, true);
  }
  ...
} else {
    for (const frDirEnum dir : frDirEnumPlanar) {
      ap->setAccess(dir, false);
    }
  }
```
to:
```
ap->setMultipleAccesses(frDirEnumPlanar, allow_planar);
```