### PR TITLE
drt: genPattern code duplication elimination

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -485,8 +485,8 @@ class FlexPA
       std::set<std::vector<int>>& inst_access_patterns,
       std::set<std::pair<int, int>>& used_access_points,
       std::set<std::pair<int, int>>& viol_access_points,
-      const int curr_unique_inst_idx,
-      const int max_access_point_size);
+      int curr_unique_inst_idx,
+      int max_access_point_size);
 
   void genPatternsInit(std::vector<FlexDPNode>& nodes,
                        const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -472,20 +472,34 @@ class FlexPA
       frAccessPointEnum upper_type);
 
   void prepPattern();
+
   void prepPatternInstRows(std::vector<std::vector<frInst*>> inst_rows);
+
   int prepPatternInst(frInst* inst, int curr_unique_inst_idx, double x_weight);
+
   int genPatterns(const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
                   int curr_unique_inst_idx);
+
+  int genPatterns_helper(
+      const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
+      std::set<std::vector<int>>& inst_access_patterns,
+      std::set<std::pair<int, int>>& used_access_points,
+      std::set<std::pair<int, int>>& viol_access_points,
+      const int curr_unique_inst_idx,
+      const int max_access_point_size);
+
   void genPatternsInit(std::vector<FlexDPNode>& nodes,
                        const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
                        std::set<std::vector<int>>& inst_access_patterns,
                        std::set<std::pair<int, int>>& used_access_points,
                        std::set<std::pair<int, int>>& viol_access_points,
                        int max_access_point_size);
+
   void genPatterns_reset(
       std::vector<FlexDPNode>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       int max_access_point_size);
+
   void genPatterns_perform(
       std::vector<FlexDPNode>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
@@ -494,6 +508,7 @@ class FlexPA
       const std::set<std::pair<int, int>>& viol_access_points,
       int curr_unique_inst_idx,
       int max_access_point_size);
+
   int getEdgeCost(int prev_node_idx,
                   int curr_node_idx,
                   const std::vector<FlexDPNode>& nodes,
@@ -503,6 +518,7 @@ class FlexPA
                   const std::set<std::pair<int, int>>& viol_access_points,
                   int curr_unique_inst_idx,
                   int max_access_point_size);
+
   bool genPatterns_commit(
       const std::vector<FlexDPNode>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
@@ -512,16 +528,21 @@ class FlexPA
       std::set<std::pair<int, int>>& viol_access_points,
       int curr_unique_inst_idx,
       int max_access_point_size);
+
   void genPatternsPrintDebug(
       std::vector<FlexDPNode>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       int max_access_point_size);
+
   void genPatterns_print(
       std::vector<FlexDPNode>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       int max_access_point_size);
+
   int getFlatIdx(int idx_1, int idx_2, int idx_2_dim);
+
   void getNestedIdx(int flat_idx, int& idx_1, int& idx_2, int idx_2_dim);
+
   int getFlatEdgeIdx(int prev_idx_1,
                      int prev_idx_2,
                      int curr_idx_2,
@@ -534,20 +555,28 @@ class FlexPA
       std::set<frBlockObject*>* owners = nullptr);
 
   void getInsts(std::vector<frInst*>& insts);
+
   void genInstRowPattern(std::vector<frInst*>& insts);
+
   void genInstRowPatternInit(std::vector<FlexDPNode>& nodes,
                              const std::vector<frInst*>& insts);
+
   void genInstRowPatternPerform(std::vector<FlexDPNode>& nodes,
                                 const std::vector<frInst*>& insts);
+
   void genInstRowPattern_commit(std::vector<FlexDPNode>& nodes,
                                 const std::vector<frInst*>& insts);
+
   void genInstRowPattern_print(std::vector<FlexDPNode>& nodes,
                                const std::vector<frInst*>& insts);
+
   int getEdgeCost(int prev_node_idx,
                   int curr_node_idx,
                   const std::vector<FlexDPNode>& nodes,
                   const std::vector<frInst*>& insts);
+
   void revertAccessPoints();
+
   void addAccessPatternObj(
       frInst* inst,
       FlexPinAccessPattern* access_pattern,


### PR DESCRIPTION
[Context] I'm starting to take a look at the Access Pattern generation in the PA module, as until now I only looked at the Access Point generation. I just started, but this code duplication case stood out like a sore thumb. I don't like naming functions "helper" but I intend to change the names of Access Patterns generation functions later so I created a temporary name.

Eliminates code duplication in `genPatterns`. Creates an auxiliary function `genPatterns_helper` to execute the duplicated code so the helper is called twice instead of repeating the code.

Git diff is making it hard to see that the code was in fact duplicated. If its hard to see I recommend looking at `genPatterns` in master to see that there is a clear repetition just changing `pins` to `reversed_pins`.

Also adds spaces between functions declarations on the header file. This will make future git diffs adding doxygen and changing names more clear.