### PR TITLE
drt: genApCosted

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -294,14 +294,14 @@ class FlexPA
    * @param is_curr_layer_horz if the current layer is horizontal
    * @param offset TODO: not sure, something to do with macro cells
    */
-  void genAPCosted(const frAccessPointEnum cost,
+  void genAPCosted(frAccessPointEnum cost,
                    std::map<frCoord, frAccessPointEnum>& coords,
                    const std::map<frCoord, frAccessPointEnum>& track_coords,
-                   const frLayerNum base_layer_num,
-                   const frLayerNum layer_num,
+                   frLayerNum base_layer_num,
+                   frLayerNum layer_num,
                    const gtl::rectangle_data<frCoord>& rect,
-                   const bool is_curr_layer_horz,
-                   const int offset = 0);
+                   bool is_curr_layer_horz,
+                   int offset = 0);
 
   void gen_initializeAccessPoints(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -275,10 +275,33 @@ class FlexPA
    * @param rect pin rectangle to which via is bounded
    * @param layer_num number of the layer
    */
+
   void genAPEnclosedBoundary(std::map<frCoord, frAccessPointEnum>& coords,
                              const gtl::rectangle_data<frCoord>& rect,
                              frLayerNum layer_num,
                              bool is_curr_layer_horz);
+
+  /**
+   * @brief Calls the other genAP functions according to the informed cost
+   *
+   * @param cost access point cost
+   * @param coords access points cost map (will get at least one new entry)
+   * @param track_coords coordinates of tracks on the layer
+   * @param base_layer_num if two layers are being considered this is the lower,
+   * if only one is being considered this is the layer
+   * @param layer_num number of the current layer
+   * @param rect rectangle representing pin shape
+   * @param is_curr_layer_horz if the current layer is horizontal
+   * @param offset TODO: not sure, something to do with macro cells
+   */
+  void genAPCosted(const frAccessPointEnum cost,
+                   std::map<frCoord, frAccessPointEnum>& coords,
+                   const std::map<frCoord, frAccessPointEnum>& track_coords,
+                   const frLayerNum base_layer_num,
+                   const frLayerNum layer_num,
+                   const gtl::rectangle_data<frCoord>& rect,
+                   const bool is_curr_layer_horz,
+                   const int offset = 0);
 
   void gen_initializeAccessPoints(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -527,6 +527,10 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   }
 
   // gen all full/half grid coords
+  /** offset used to only be used after an if (!is_macro_cell_pin ||
+   * !use_center_line), so this logic was combined with offset is_macro_cell_pin
+   * ? hwidth : 0;
+   */
   const int offset = is_macro_cell_pin && !use_center_line ? hwidth : 0;
   const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
   const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -263,9 +263,7 @@ void FlexPA::genAPCosted(
       genAPOnTrack(coords, track_coords, rect_min + offset, rect_max - offset);
       break;
 
-    case (frAccessPointEnum::HalfGrid):
-      genAPOnTrack(coords, track_coords, rect_min + offset, rect_max - offset);
-      break;
+      // frAccessPointEnum::Halfgrid not defined
 
     case (frAccessPointEnum::Center):
       genAPCentered(
@@ -529,8 +527,7 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   }
 
   // gen all full/half grid coords
-  int offset = is_macro_cell_pin ? hwidth : 0;
-  offset = !is_macro_cell_pin || !use_center_line ? offset : 0;
+  const int offset = is_macro_cell_pin && !use_center_line ? hwidth : 0;
   const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
   const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
   auto& layer1_coords = is_layer1_horz ? y_coords : x_coords;
@@ -553,7 +550,7 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
                   offset);
     }
   }
-  if (!is_macro_cell_pin || !use_center_line) {
+  if (!(is_macro_cell_pin && use_center_line)) {
     for (const auto cost : frDirEnums) {
       if (lower_type >= cost) {
         genAPCosted(cost,

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -243,6 +243,51 @@ void FlexPA::genAPEnclosedBoundary(std::map<frCoord, frAccessPointEnum>& coords,
   }
 }
 
+void FlexPA::genAPCosted(
+    const frAccessPointEnum cost,
+    std::map<frCoord, frAccessPointEnum>& coords,
+    const std::map<frCoord, frAccessPointEnum>& track_coords,
+    const frLayerNum base_layer_num,
+    const frLayerNum layer_num,
+    const gtl::rectangle_data<frCoord>& rect,
+    const bool is_curr_layer_horz,
+    const int offset)
+{
+  auto layer = getDesign()->getTech()->getLayer(layer_num);
+  const auto min_width_layer = layer->getMinWidth();
+  const int rect_min = is_curr_layer_horz ? gtl::yl(rect) : gtl::xl(rect);
+  const int rect_max = is_curr_layer_horz ? gtl::yh(rect) : gtl::xh(rect);
+
+  switch (cost) {
+    case (frAccessPointEnum::OnGrid):
+      genAPOnTrack(coords, track_coords, rect_min + offset, rect_max - offset);
+      break;
+
+    case (frAccessPointEnum::HalfGrid):
+      genAPOnTrack(coords, track_coords, rect_min + offset, rect_max - offset);
+      break;
+
+    case (frAccessPointEnum::Center):
+      genAPCentered(
+          coords, base_layer_num, rect_min + offset, rect_max - offset);
+      break;
+
+    case (frAccessPointEnum::EncOpt):
+      genAPEnclosedBoundary(coords, rect, base_layer_num, is_curr_layer_horz);
+      break;
+
+    case (frAccessPointEnum::NearbyGrid):
+      genAPOnTrack(
+          coords, track_coords, rect_min - min_width_layer, rect_min, true);
+      genAPOnTrack(
+          coords, track_coords, rect_max, rect_max + min_width_layer, true);
+      break;
+
+    default:
+      logger_->error(DRT, 257, "Invalid frAccessPointEnum type");
+  }
+}
+
 // Responsible for checking if an AP is valid and configuring it
 void FlexPA::gen_createAccessPoint(
     std::vector<std::unique_ptr<frAccessPoint>>& aps,
@@ -461,8 +506,6 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   } else {
     logger_->error(DRT, 68, "genAPsFromRect cannot find second_layer_num.");
   }
-  const auto min_width_layer2
-      = getDesign()->getTech()->getLayer(second_layer_num)->getMinWidth();
   auto& layer1_track_coords = track_coords_[layer_num];
   auto& layer2_track_coords = track_coords_[second_layer_num];
   const bool is_layer1_horz = (layer->getDir() == dbTechLayerDir::HORIZONTAL);
@@ -486,81 +529,43 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
   }
 
   // gen all full/half grid coords
-  const int offset = is_macro_cell_pin ? hwidth : 0;
+  int offset = is_macro_cell_pin ? hwidth : 0;
+  offset = !is_macro_cell_pin || !use_center_line ? offset : 0;
   const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
   const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
-  const int layer2_rect_min = is_layer1_horz ? gtl::xl(rect) : gtl::yl(rect);
-  const int layer2_rect_max = is_layer1_horz ? gtl::xh(rect) : gtl::yh(rect);
   auto& layer1_coords = is_layer1_horz ? y_coords : x_coords;
   auto& layer2_coords = is_layer1_horz ? x_coords : y_coords;
 
+  const frAccessPointEnum frDirEnums[] = {frAccessPointEnum::OnGrid,
+                                          frAccessPointEnum::Center,
+                                          frAccessPointEnum::EncOpt,
+                                          frAccessPointEnum::NearbyGrid};
+
+  for (const auto cost : frDirEnums) {
+    if (upper_type >= cost) {
+      genAPCosted(cost,
+                  layer2_coords,
+                  layer2_track_coords,
+                  layer_num,
+                  second_layer_num,
+                  rect,
+                  !is_layer1_horz,
+                  offset);
+    }
+  }
   if (!is_macro_cell_pin || !use_center_line) {
-    genAPOnTrack(
-        layer1_coords, layer1_track_coords, layer1_rect_min, layer1_rect_max);
-    genAPOnTrack(layer2_coords,
-                 layer2_track_coords,
-                 layer2_rect_min + offset,
-                 layer2_rect_max - offset);
-    if (lower_type >= frAccessPointEnum::Center) {
-      genAPCentered(layer1_coords, layer_num, layer1_rect_min, layer1_rect_max);
-    }
-    if (lower_type >= frAccessPointEnum::EncOpt) {
-      genAPEnclosedBoundary(layer1_coords, rect, layer_num, is_layer1_horz);
-    }
-    if (upper_type >= frAccessPointEnum::Center) {
-      genAPCentered(layer2_coords,
+    for (const auto cost : frDirEnums) {
+      if (lower_type >= cost) {
+        genAPCosted(cost,
+                    layer1_coords,
+                    layer1_track_coords,
                     layer_num,
-                    layer2_rect_min + offset,
-                    layer2_rect_max - offset);
-    }
-    if (upper_type >= frAccessPointEnum::EncOpt) {
-      genAPEnclosedBoundary(layer2_coords, rect, layer_num, !is_layer1_horz);
-    }
-    if (lower_type >= frAccessPointEnum::NearbyGrid) {
-      genAPOnTrack(layer1_coords,
-                   layer1_track_coords,
-                   layer1_rect_max,
-                   layer1_rect_max + min_width_layer1,
-                   true);
-      genAPOnTrack(layer1_coords,
-                   layer1_track_coords,
-                   layer1_rect_min - min_width_layer1,
-                   layer1_rect_min,
-                   true);
-    }
-    if (upper_type >= frAccessPointEnum::NearbyGrid) {
-      genAPOnTrack(layer2_coords,
-                   layer2_track_coords,
-                   layer2_rect_max,
-                   layer2_rect_max + min_width_layer2,
-                   true);
-      genAPOnTrack(layer2_coords,
-                   layer2_track_coords,
-                   layer2_rect_min - min_width_layer2,
-                   layer2_rect_min,
-                   true);
+                    layer_num,
+                    rect,
+                    is_layer1_horz);
+      }
     }
   } else {
-    genAPOnTrack(
-        layer2_coords, layer2_track_coords, layer2_rect_min, layer2_rect_max);
-    if (upper_type >= frAccessPointEnum::Center) {
-      genAPCentered(layer2_coords, layer_num, layer2_rect_min, layer2_rect_max);
-    }
-    if (upper_type >= frAccessPointEnum::EncOpt) {
-      genAPEnclosedBoundary(layer2_coords, rect, layer_num, !is_layer1_horz);
-    }
-    if (upper_type >= frAccessPointEnum::NearbyGrid) {
-      genAPOnTrack(layer2_coords,
-                   layer2_track_coords,
-                   layer2_rect_max,
-                   layer2_rect_max + min_width_layer2,
-                   true);
-      genAPOnTrack(layer2_coords,
-                   layer2_track_coords,
-                   layer2_rect_min - min_width_layer2,
-                   layer2_rect_min,
-                   true);
-    }
     genAPCentered(layer1_coords, layer_num, layer1_rect_min, layer1_rect_max);
     for (auto& [layer1_coord, cost] : layer1_coords) {
       layer1_coords[layer1_coord] = frAccessPointEnum::OnGrid;


### PR DESCRIPTION
A secure CI associated with this branch passed.

The latter part of `genAPsFromRect` is a bit verbose for what it is doing. In essence, it goes through 4 access point costs (`OnGrid`, `Center`, `EncOpt` and `NearbyGrid`), checks if the layer cost limit allows for these costs and creates them with their respective functions. This takes a lot of lines and is verbose for a simple ideia. 

To encapsulate this simple ideia the function `genAPCosted` was created. It takes a cost and the necessary arguments to create any kind of access point and creates the according access point. I very much like the fact that the association between cost and function is made very clear, although it makes the use of some arguments (like `offset`) a little harder to understand.

More importantly, the use of the function makes `genAPsFromRect` smaller and much easier to understand its general flow, although it might make it harder to understand in detail.

I would like to hear opinions in this solution, although I like most parts of it and makes parts of the code more readable it can make other parts less.