### PR TITLE
gui: add to sta descriptors

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -344,7 +344,9 @@ class Descriptor
   virtual void highlight(std::any object, Painter& painter) const = 0;
   virtual bool isSlowHighlight(std::any /* object */) const { return false; }
 
-  static std::string convertUnits(double value, bool area = false);
+  static std::string convertUnits(double value,
+                                  bool area = false,
+                                  int digits = 3);
 };
 
 // An object selected in the gui.  The object is stored as a

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -99,7 +99,9 @@ static void populateODBProperties(Descriptor::Properties& props,
   }
 }
 
-std::string Descriptor::convertUnits(const double value, const bool area)
+std::string Descriptor::convertUnits(const double value,
+                                     const bool area,
+                                     int digits)
 {
   double log_value = value;
   if (area) {
@@ -139,8 +141,7 @@ std::string Descriptor::convertUnits(const double value, const bool area)
     unit_scale *= unit_scale;
   }
 
-  const int precision = 3;
-  auto str = utl::to_numeric_string(value * unit_scale, precision);
+  auto str = utl::to_numeric_string(value * unit_scale, digits);
   str += " " + unit;
 
   return str;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -547,10 +547,6 @@ Descriptor::Properties DbInstDescriptor::getProperties(std::any object) const
   }
   props.push_back({"Master", gui->makeSelected(inst->getMaster())});
 
-  auto* sta_inst = sta_->getDbNetwork()->dbToSta(inst);
-  if (sta_inst != nullptr) {
-    props.push_back({"STA Instance", gui->makeSelected(sta_inst)});
-  }
   props.push_back(
       {"Description", sta_->getInstanceTypeText(sta_->getInstanceType(inst))});
   props.push_back({"Placement status", placed.getString()});
@@ -585,6 +581,11 @@ Descriptor::Properties DbInstDescriptor::getProperties(std::any object) const
   auto* region = inst->getRegion();
   if (region != nullptr) {
     props.push_back({"Region", gui->makeSelected(region)});
+  }
+
+  auto* sta_inst = sta_->getDbNetwork()->dbToSta(inst);
+  if (sta_inst != nullptr) {
+    props.push_back({"Timing/Power", gui->makeSelected(sta_inst)});
   }
 
   populateODBProperties(props, inst);

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -546,6 +546,11 @@ Descriptor::Properties DbInstDescriptor::getProperties(std::any object) const
     props.push_back({"Module", gui->makeSelected(module)});
   }
   props.push_back({"Master", gui->makeSelected(inst->getMaster())});
+
+  auto* sta_inst = sta_->getDbNetwork()->dbToSta(inst);
+  if (sta_inst != nullptr) {
+    props.push_back({"STA Instance", gui->makeSelected(sta_inst)});
+  }
   props.push_back(
       {"Description", sta_->getInstanceTypeText(sta_->getInstanceType(inst))});
   props.push_back({"Placement status", placed.getString()});

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -800,6 +800,8 @@ int Inspector::getSelectedIteratorPosition()
 
 void Inspector::inspect(const Selected& object)
 {
+  QApplication::setOverrideCursor(Qt::WaitCursor);
+
   if (deselect_action_) {
     deselect_action_();
   }
@@ -830,6 +832,8 @@ void Inspector::inspect(const Selected& object)
   }
 
   adjustHeaders();
+
+  QApplication::restoreOverrideCursor();
 }
 
 void Inspector::reload()

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -534,6 +534,7 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<sta::LibertyPgPort*>(
       new LibertyPgPortDescriptor(db_, sta));
   gui->registerDescriptor<sta::Instance*>(new StaInstanceDescriptor(db_, sta));
+  gui->registerDescriptor<sta::Clock*>(new ClockDescriptor(db_, sta));
 
   gui->registerDescriptor<BufferTree>(
       new BufferTreeDescriptor(db_,

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -524,6 +524,7 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbMetalWidthViaMap*>(
       new DbMetalWidthViaMapDescriptor(db_));
 
+  gui->registerDescriptor<sta::Corner*>(new CornerDescriptor(db_, sta));
   gui->registerDescriptor<sta::LibertyLibrary*>(
       new LibertyLibraryDescriptor(db_, sta));
   gui->registerDescriptor<sta::LibertyCell*>(
@@ -532,6 +533,7 @@ void MainWindow::init(sta::dbSta* sta)
       new LibertyPortDescriptor(db_, sta));
   gui->registerDescriptor<sta::LibertyPgPort*>(
       new LibertyPgPortDescriptor(db_, sta));
+  gui->registerDescriptor<sta::Instance*>(new StaInstanceDescriptor(db_, sta));
 
   gui->registerDescriptor<BufferTree>(
       new BufferTreeDescriptor(db_,

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -853,23 +853,24 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
       const sta::Unit* timeunit = sta_->units()->timeUnit();
       const auto setup_arrival
           = sta_->pinArrival(pin, nullptr, sta::MinMax::max());
-      port_arrival_setup.push_back(
-          {port_id,
-           is_inf(setup_arrival)
-               ? "None"
-               : fmt::format(
-                     "{} {}",
-                     timeunit->asString(setup_arrival, float_precision_),
-                     timeunit->scaledSuffix())});
+      const std::string setup_text
+          = is_inf(setup_arrival)
+                ? "None"
+                : fmt::format(
+                      "{} {}",
+                      timeunit->asString(setup_arrival, float_precision_),
+                      timeunit->scaledSuffix());
+      port_arrival_setup.push_back({port_id, setup_text});
       const auto hold_arrival
           = sta_->pinArrival(pin, nullptr, sta::MinMax::min());
-      port_arrival_hold.push_back(
-          {port_id,
-           is_inf(setup_arrival)
-               ? "None"
-               : fmt::format("{} {}",
-                             timeunit->asString(hold_arrival, float_precision_),
-                             timeunit->scaledSuffix())});
+      const std::string hold_text
+          = is_inf(hold_arrival)
+                ? "None"
+                : fmt::format(
+                      "{} {}",
+                      timeunit->asString(hold_arrival, float_precision_),
+                      timeunit->scaledSuffix());
+      port_arrival_hold.push_back({port_id, hold_text});
     }
   }
   props.push_back({"Max arrival times", port_arrival_setup});

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -499,9 +499,11 @@ Descriptor::Properties LibertyPortDescriptor::getProperties(
   sta::LibertyCellPgPortIterator pg_port_iter(port->libertyCell());
   while (pg_port_iter.hasNext()) {
     auto* pg_port = pg_port_iter.next();
-    if (strcmp(pg_port->name(), power_pin_name) == 0) {
+    if (power_pin_name != nullptr
+        && strcmp(pg_port->name(), power_pin_name) == 0) {
       power_pin = gui->makeSelected(pg_port);
-    } else if (strcmp(pg_port->name(), ground_pin_name) == 0) {
+    } else if (ground_pin_name != nullptr
+               && strcmp(pg_port->name(), ground_pin_name) == 0) {
       ground_pin = gui->makeSelected(pg_port);
     }
   }

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -857,9 +857,9 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
           = is_inf(setup_arrival)
                 ? "None"
                 : fmt::format(
-                      "{} {}",
-                      timeunit->asString(setup_arrival, float_precision_),
-                      timeunit->scaledSuffix());
+                    "{} {}",
+                    timeunit->asString(setup_arrival, float_precision_),
+                    timeunit->scaledSuffix());
       port_arrival_setup.push_back({port_id, setup_text});
       const auto hold_arrival
           = sta_->pinArrival(pin, nullptr, sta::MinMax::min());
@@ -867,9 +867,9 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
           = is_inf(hold_arrival)
                 ? "None"
                 : fmt::format(
-                      "{} {}",
-                      timeunit->asString(hold_arrival, float_precision_),
-                      timeunit->scaledSuffix());
+                    "{} {}",
+                    timeunit->asString(hold_arrival, float_precision_),
+                    timeunit->scaledSuffix());
       port_arrival_hold.push_back({port_id, hold_text});
     }
   }

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -296,7 +296,10 @@ Descriptor::Properties LibertyCellDescriptor::getProperties(
 
   sta::LibertyLibrary* library = cell->libertyLibrary();
 
-  props.push_back({"DB Master", gui->makeSelected(network->staToDb(cell))});
+  auto* db_master = network->staToDb(cell);
+  if (db_master != nullptr) {
+    props.push_back({"DB Master", gui->makeSelected(db_master)});
+  }
 
   if (auto area = cell->area()) {
     props.push_back({"Area", fmt::format("{} μm²", area)});
@@ -345,7 +348,10 @@ Descriptor::Properties LibertyCellDescriptor::getProperties(
   props.push_back({"PG Ports", pg_ports});
 
   SelectionSet insts;
-  for (auto* inst : network->leafInstances()) {
+  std::unique_ptr<sta::LeafInstanceIterator> lib_iter(
+      network->leafInstanceIterator());
+  while (lib_iter->hasNext()) {
+    auto* inst = lib_iter->next();
     if (network->libertyCell(inst) == cell) {
       insts.insert(gui->makeSelected(inst));
     }

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -481,6 +481,17 @@ Descriptor::Properties LibertyPortDescriptor::getProperties(
   add_limit<sta::RiseFall>(
       props, port, "Min Pulse Width", &sta::LibertyPort::minPulseWidth, "s");
 
+  if (port->hasMembers()) {
+    SelectionSet members;
+    for (auto* member : *port->memberPorts()) {
+      auto lib_port = member->libertyPort();
+      if (lib_port != nullptr) {
+        members.insert(makeSelected(lib_port));
+      }
+    }
+    props.push_back({"Member ports", members});
+  }
+
   std::any power_pin;
   std::any ground_pin;
   const char* power_pin_name = port->relatedPowerPin();
@@ -796,8 +807,8 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
   PropertyList port_arrival_hold;
   PropertyList port_arrival_setup;
   SelectionSet clocks;
-  std::unique_ptr<sta::CellPortIterator> port_itr(
-      network->portIterator(network->cell(inst)));
+  std::unique_ptr<sta::CellPortBitIterator> port_itr(
+      network->portBitIterator(network->cell(inst)));
   while (port_itr->hasNext()) {
     sta::Port* port = port_itr->next();
     sta::Pin* pin = network->findPin(inst, port);

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -842,7 +842,8 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
     }
 
     if (is_lib_port) {
-      const std::string freq = Descriptor::convertUnits(power.activity());
+      const std::string freq
+          = Descriptor::convertUnits(power.activity(), false, float_precision_);
       const std::string activity_info = fmt::format("{:.2f}% at {}Hz from {}",
                                                     100 * power.duty(),
                                                     freq,
@@ -856,17 +857,19 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
           {port_id,
            is_inf(setup_arrival)
                ? "None"
-               : fmt::format("{} {}",
-                             timeunit->asString(setup_arrival),
-                             timeunit->scaledSuffix())});
+               : fmt::format(
+                     "{} {}",
+                     timeunit->asString(setup_arrival, float_precision_),
+                     timeunit->scaledSuffix())});
       const auto hold_arrival
           = sta_->pinArrival(pin, nullptr, sta::MinMax::min());
       port_arrival_hold.push_back(
           {port_id,
-           is_inf(setup_arrival) ? "None"
-                                 : fmt::format("{} {}",
-                                               timeunit->asString(hold_arrival),
-                                               timeunit->scaledSuffix())});
+           is_inf(setup_arrival)
+               ? "None"
+               : fmt::format("{} {}",
+                             timeunit->asString(hold_arrival, float_precision_),
+                             timeunit->scaledSuffix())});
     }
   }
   props.push_back({"Max arrival times", port_arrival_setup});
@@ -876,8 +879,10 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
   PropertyList power;
   for (auto* corner : *sta_->corners()) {
     const auto power_info = sta_->power(inst, corner);
-    power.push_back({gui->makeSelected(corner),
-                     Descriptor::convertUnits(power_info.total()) + "W"});
+    power.push_back(
+        {gui->makeSelected(corner),
+         Descriptor::convertUnits(power_info.total(), false, float_precision_)
+             + "W"});
   }
   props.push_back({"Total power", power});
 

--- a/src/gui/src/staDescriptors.h
+++ b/src/gui/src/staDescriptors.h
@@ -180,6 +180,8 @@ class StaInstanceDescriptor : public Descriptor
  private:
   odb::dbDatabase* db_;
   sta::dbSta* sta_;
+
+  static constexpr int float_precision_ = 2;
 };
 
 class ClockDescriptor : public Descriptor

--- a/src/gui/src/staDescriptors.h
+++ b/src/gui/src/staDescriptors.h
@@ -132,6 +132,52 @@ class LibertyPgPortDescriptor : public Descriptor
  private:
   odb::dbDatabase* db_;
   sta::dbSta* sta_;
+
+  odb::dbMTerm* getMTerm(std::any object) const;
+};
+
+class CornerDescriptor : public Descriptor
+{
+ public:
+  CornerDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+  sta::dbSta* sta_;
+};
+
+class StaInstanceDescriptor : public Descriptor
+{
+ public:
+  StaInstanceDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+  sta::dbSta* sta_;
 };
 
 };  // namespace gui

--- a/src/gui/src/staDescriptors.h
+++ b/src/gui/src/staDescriptors.h
@@ -40,7 +40,9 @@
 
 namespace sta {
 class dbSta;
-}
+class Clock;
+class Pin;
+}  // namespace sta
 
 namespace gui {
 
@@ -178,6 +180,30 @@ class StaInstanceDescriptor : public Descriptor
  private:
   odb::dbDatabase* db_;
   sta::dbSta* sta_;
+};
+
+class ClockDescriptor : public Descriptor
+{
+ public:
+  ClockDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  Properties getProperties(std::any object) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ private:
+  odb::dbDatabase* db_;
+  sta::dbSta* sta_;
+
+  std::set<const sta::Pin*> getAllClockPins(sta::Clock* clock) const;
 };
 
 };  // namespace gui

--- a/src/gui/src/staDescriptors.h
+++ b/src/gui/src/staDescriptors.h
@@ -203,7 +203,7 @@ class ClockDescriptor : public Descriptor
   odb::dbDatabase* db_;
   sta::dbSta* sta_;
 
-  std::set<const sta::Pin*> getAllClockPins(sta::Clock* clock) const;
+  std::set<const sta::Pin*> getClockPins(sta::Clock* clock) const;
 };
 
 };  // namespace gui


### PR DESCRIPTION
Adds:
- sta::Corner descriptor
- sta::Instance descriptor
- adds fields to the properties in allow access to more information
- add highlighting where possible
- sta::Instance can be slow to load the first time since it needs to get power information, but I think it's worth having access to that, especially when debugging things like clock gating power @QuantamHD (the added loading time is also why I think it makes sense to keep it separate the DB descriptor).

Discussion:
- I don't like the names I've chosen for `STA Instance` and `DB ???`, so I'm open to suggestions for what to rename those to make it better