### PR TITLE
grt: FastRoute unused functions

### DIFF
--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -136,16 +136,6 @@ class FastRouteCore
                      int layer,
                      uint16_t reducedCap,
                      bool isReduce);
-  void applyVerticalAdjustments(const odb::Point& first_tile,
-                                const odb::Point& last_tile,
-                                int layer,
-                                int first_tile_reduce,
-                                int last_tile_reduce);
-  void applyHorizontalAdjustments(const odb::Point& first_tile,
-                                  const odb::Point& last_tile,
-                                  int layer,
-                                  int first_tile_reduce,
-                                  int last_tile_reduce);
   void addVerticalAdjustments(
       const odb::Point& first_tile,
       const odb::Point& last_tile,
@@ -282,7 +272,6 @@ class FastRouteCore
   void InitLastUsage(const int upType);
   void InitEstUsage();
   void SaveLastRouteLen();
-  void fixEmbeddedTrees();
   void checkAndFixEmbeddedTree(const int net_id);
   bool areEdgesOverlapping(const int net_id,
                            const int edge_id,
@@ -291,11 +280,6 @@ class FastRouteCore
       const int net_id,
       const int edge,
       std::vector<std::pair<short, short>>& blocked_positions);
-  void bendEdge(TreeEdge* treeedge,
-                std::vector<TreeNode>& treenodes,
-                std::vector<short>& new_route_x,
-                std::vector<short>& new_route_y,
-                std::vector<std::pair<short, short>>& blocked_positions);
   void routeLShape(const TreeNode& startpoint,
                    const TreeNode& endpoint,
                    std::vector<std::pair<short, short>>& blocked_positions,
@@ -452,7 +436,6 @@ class FastRouteCore
 
   // ripup functions
   void ripupSegL(const Segment* seg);
-  void ripupSegZ(const Segment* seg);
   void newRipup(const TreeEdge* treeedge,
                 const int x1,
                 const int y1,

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -496,6 +496,17 @@ class FastRouteCore
   void checkRoute3D();
   void StNetOrder();
   float CalculatePartialSlack();
+  /**
+   * @brief Validates the routing of edges for a specified net.
+   *
+   * Checks various aspects of the routing, including edge lengths,
+   * grid positions, and the distances between routing points. Warnings are logged
+   * if verbose_ is set.
+   *
+   * @param netID The ID of the net to be validated.
+   *
+   * @returns true if any issues are detected in the routing. Else, false.
+   */
   bool checkRoute2DTree(int netID);
   void removeLoops();
   void netedgeOrderDec(int netID);
@@ -504,8 +515,22 @@ class FastRouteCore
   void printEdge3D(int netID, int edgeID);
   void printTree3D(int netID);
   void check2DEdgesUsage();
+  /**
+   * @brief Compares edges used by routing and usage in h/v edges of the routing graph.
+   *
+   * Performs a full comparison between edges used by routing and
+   * usage in the h/v edges of the routing graph. 
+   * Somewhat expensive but helpful for finding usage errors.
+   */
   void verify2DEdgesUsage();
-  void verifyEdgeUsage();
+    /**
+   * @brief Compares edges used by routing and usage in h/v edges of the routing graph.
+   *
+   * Perfmorms a full comparison between edges used by routing and
+   * usage in the h/v edges of the routing graph. 
+   * Somewhat expensive but helpful for finding usage errors.
+   */
+  void verify3DEdgesUsage();
   void layerAssignment();
   void copyBR(void);
   void copyRS(void);

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -500,8 +500,8 @@ class FastRouteCore
    * @brief Validates the routing of edges for a specified net.
    *
    * Checks various aspects of the routing, including edge lengths,
-   * grid positions, and the distances between routing points. Warnings are logged
-   * if verbose_ is set.
+   * grid positions, and the distances between routing points. Warnings are
+   * logged if verbose_ is set.
    *
    * @param netID The ID of the net to be validated.
    *
@@ -516,18 +516,20 @@ class FastRouteCore
   void printTree3D(int netID);
   void check2DEdgesUsage();
   /**
-   * @brief Compares edges used by routing and usage in h/v edges of the routing graph.
+   * @brief Compares edges used by routing and usage in h/v edges of the routing
+   * graph.
    *
    * Performs a full comparison between edges used by routing and
-   * usage in the h/v edges of the routing graph. 
+   * usage in the h/v edges of the routing graph.
    * Somewhat expensive but helpful for finding usage errors.
    */
   void verify2DEdgesUsage();
-    /**
-   * @brief Compares edges used by routing and usage in h/v edges of the routing graph.
+  /**
+   * @brief Compares edges used by routing and usage in h/v edges of the routing
+   * graph.
    *
    * Perfmorms a full comparison between edges used by routing and
-   * usage in the h/v edges of the routing graph. 
+   * usage in the h/v edges of the routing graph.
    * Somewhat expensive but helpful for finding usage errors.
    */
   void verify3DEdgesUsage();

--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -507,60 +507,6 @@ void FastRouteCore::addAdjustment(int x1,
   }
 }
 
-void FastRouteCore::applyVerticalAdjustments(const odb::Point& first_tile,
-                                             const odb::Point& last_tile,
-                                             int layer,
-                                             int first_tile_reduce,
-                                             int last_tile_reduce)
-{
-  for (int x = first_tile.getX(); x <= last_tile.getX(); x++) {
-    for (int y = first_tile.getY(); y < last_tile.getY(); y++) {
-      if (x == first_tile.getX()) {
-        int edge_cap = getEdgeCapacity(x, y, x, y + 1, layer);
-        edge_cap -= first_tile_reduce;
-        if (edge_cap < 0)
-          edge_cap = 0;
-        addAdjustment(x, y, x, y + 1, layer, edge_cap, true);
-      } else if (x == last_tile.getX()) {
-        int edge_cap = getEdgeCapacity(x, y, x, y + 1, layer);
-        edge_cap -= last_tile_reduce;
-        if (edge_cap < 0)
-          edge_cap = 0;
-        addAdjustment(x, y, x, y + 1, layer, edge_cap, true);
-      } else {
-        addAdjustment(x, y, x, y + 1, layer, 0, true);
-      }
-    }
-  }
-}
-
-void FastRouteCore::applyHorizontalAdjustments(const odb::Point& first_tile,
-                                               const odb::Point& last_tile,
-                                               int layer,
-                                               int first_tile_reduce,
-                                               int last_tile_reduce)
-{
-  for (int x = first_tile.getX(); x < last_tile.getX(); x++) {
-    for (int y = first_tile.getY(); y <= last_tile.getY(); y++) {
-      if (y == first_tile.getY()) {
-        int edge_cap = getEdgeCapacity(x, y, x + 1, y, layer);
-        edge_cap -= first_tile_reduce;
-        if (edge_cap < 0)
-          edge_cap = 0;
-        addAdjustment(x, y, x + 1, y, layer, edge_cap, true);
-      } else if (y == last_tile.getY()) {
-        int edge_cap = getEdgeCapacity(x, y, x + 1, y, layer);
-        edge_cap -= last_tile_reduce;
-        if (edge_cap < 0)
-          edge_cap = 0;
-        addAdjustment(x, y, x + 1, y, layer, edge_cap, true);
-      } else {
-        addAdjustment(x, y, x + 1, y, layer, 0, true);
-      }
-    }
-  }
-}
-
 void FastRouteCore::addVerticalAdjustments(
     const odb::Point& first_tile,
     const odb::Point& last_tile,

--- a/src/grt/src/fastroute/src/RipUp.cpp
+++ b/src/grt/src/fastroute/src/RipUp.cpp
@@ -62,50 +62,6 @@ void FastRouteCore::ripupSegL(const Segment* seg)
   }
 }
 
-void FastRouteCore::ripupSegZ(const Segment* seg)
-{
-  const int edgeCost = nets_[seg->netID]->getEdgeCost();
-
-  const int ymin = std::min(seg->y1, seg->y2);
-  const int ymax = std::max(seg->y1, seg->y2);
-
-  if (seg->x1 == seg->x2) {
-    // remove V routing
-    for (int i = ymin; i < ymax; i++)
-      v_edges_[i][seg->x1].est_usage -= edgeCost;
-  } else if (seg->y1 == seg->y2) {
-    // remove H routing
-    for (int i = seg->x1; i < seg->x2; i++)
-      h_edges_[seg->y1][i].est_usage -= edgeCost;
-  } else {
-    // remove Z routing
-    if (seg->HVH) {
-      for (int i = seg->x1; i < seg->Zpoint; i++)
-        h_edges_[seg->y1][i].est_usage -= edgeCost;
-      for (int i = seg->Zpoint; i < seg->x2; i++)
-        h_edges_[seg->y2][i].est_usage -= edgeCost;
-      for (int i = ymin; i < ymax; i++)
-        v_edges_[i][seg->Zpoint].est_usage -= edgeCost;
-    } else {
-      if (seg->y1 < seg->y2) {
-        for (int i = seg->y1; i < seg->Zpoint; i++)
-          v_edges_[i][seg->x1].est_usage -= edgeCost;
-        for (int i = seg->Zpoint; i < seg->y2; i++)
-          v_edges_[i][seg->x2].est_usage -= edgeCost;
-        for (int i = seg->x1; i < seg->x2; i++)
-          h_edges_[seg->Zpoint][i].est_usage -= 1;
-      } else {
-        for (int i = seg->y2; i < seg->Zpoint; i++)
-          v_edges_[i][seg->x2].est_usage -= edgeCost;
-        for (int i = seg->Zpoint; i < seg->y1; i++)
-          v_edges_[i][seg->x1].est_usage -= edgeCost;
-        for (int i = seg->x1; i < seg->x2; i++)
-          h_edges_[seg->Zpoint][i].est_usage -= 1;
-      }
-    }
-  }
-}
-
 void FastRouteCore::newRipup(const TreeEdge* treeedge,
                              const int x1,
                              const int y1,

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -55,17 +55,6 @@ static int right_index(int i)
   return 2 * i + 2;
 }
 
-// void FastRouteCore::fixEmbeddedTrees()
-// {
-//   // check embedded trees only when maze router is called
-//   // i.e., when running overflow iterations
-//   if (overflow_iterations_ > 0) {
-//     for (const int& netID : net_ids_) {
-//       checkAndFixEmbeddedTree(netID);
-//     }
-//   }
-// }
-
 void FastRouteCore::checkAndFixEmbeddedTree(const int net_id)
 {
   const auto& treeedges = sttrees_[net_id].edges;

--- a/src/grt/src/fastroute/src/maze.cpp
+++ b/src/grt/src/fastroute/src/maze.cpp
@@ -55,16 +55,16 @@ static int right_index(int i)
   return 2 * i + 2;
 }
 
-void FastRouteCore::fixEmbeddedTrees()
-{
-  // check embedded trees only when maze router is called
-  // i.e., when running overflow iterations
-  if (overflow_iterations_ > 0) {
-    for (const int& netID : net_ids_) {
-      checkAndFixEmbeddedTree(netID);
-    }
-  }
-}
+// void FastRouteCore::fixEmbeddedTrees()
+// {
+//   // check embedded trees only when maze router is called
+//   // i.e., when running overflow iterations
+//   if (overflow_iterations_ > 0) {
+//     for (const int& netID : net_ids_) {
+//       checkAndFixEmbeddedTree(netID);
+//     }
+//   }
+// }
 
 void FastRouteCore::checkAndFixEmbeddedTree(const int net_id)
 {
@@ -209,69 +209,6 @@ void FastRouteCore::fixOverlappingEdge(
     treeedge->route.routelen = new_route_x.size() - 1;
     treeedge->route.gridsX = std::move(new_route_x);
     treeedge->route.gridsY = std::move(new_route_y);
-  }
-}
-
-void FastRouteCore::bendEdge(
-    TreeEdge* treeedge,
-    std::vector<TreeNode>& treenodes,
-    std::vector<short>& new_route_x,
-    std::vector<short>& new_route_y,
-    std::vector<std::pair<short, short>>& blocked_positions)
-{
-  const std::vector<short>& gridsX = treeedge->route.gridsX;
-  const std::vector<short>& gridsY = treeedge->route.gridsY;
-
-  for (int i = 0; i <= treeedge->route.routelen; i++) {
-    std::pair<short, short> pos = {gridsX[i], gridsY[i]};
-    if (pos == blocked_positions.front()) {
-      break;
-    } else {
-      new_route_x.push_back(pos.first);
-      new_route_y.push_back(pos.second);
-    }
-  }
-
-  short x_min = std::min(treenodes[treeedge->n1].x, treenodes[treeedge->n2].x);
-  short y_min = std::min(treenodes[treeedge->n1].y, treenodes[treeedge->n2].y);
-
-  const TreeNode& endpoint = treenodes[treeedge->n2];
-  if (blocked_positions.front().second == blocked_positions.back().second) {
-    // blocked positions are horizontally aligned
-    short y = (new_route_y.back() == y_min) ? new_route_y.back() + 1
-                                            : new_route_y.back() - 1;
-    new_route_x.push_back(new_route_x.back());
-    new_route_y.push_back(y);
-
-    for (short x = new_route_x.back(); x < endpoint.x; x++) {
-      new_route_x.push_back(x + 1);
-      new_route_y.push_back(y);
-    }
-
-    new_route_x.push_back(endpoint.x);
-    new_route_y.push_back(endpoint.y);
-  } else if (blocked_positions.front().first
-             == blocked_positions.back().first) {
-    // blocked positions are vertically aligned
-    short x = (new_route_x.back() == x_min) ? new_route_x.back() + 1
-                                            : new_route_x.back() - 1;
-    new_route_x.push_back(x);
-    new_route_y.push_back(new_route_y.back());
-
-    if (new_route_y.back() < endpoint.y) {
-      for (short y = new_route_y.back(); y < endpoint.y; y++) {
-        new_route_x.push_back(x);
-        new_route_y.push_back(y + 1);
-      }
-    } else {
-      for (short y = new_route_y.back(); y > endpoint.y; y--) {
-        new_route_x.push_back(x);
-        new_route_y.push_back(y - 1);
-      }
-    }
-
-    new_route_x.push_back(endpoint.x);
-    new_route_y.push_back(endpoint.y);
   }
 }
 

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -1441,87 +1441,6 @@ void FastRouteCore::removeLoops()
   }
 }
 
-void FastRouteCore::verifyEdgeUsage()
-{
-  multi_array<std::set<int>, 2> s_v_edges(boost::extents[y_grid_ - 1][x_grid_]);
-  multi_array<std::set<int>, 2> s_h_edges(boost::extents[y_grid_][x_grid_ - 1]);
-
-  multi_array<int, 2> v_edges(boost::extents[y_grid_ - 1][x_grid_]);
-  multi_array<int, 2> h_edges(boost::extents[y_grid_][x_grid_ - 1]);
-
-  multi_array<int, 3> v_edges_3D(
-      boost::extents[num_layers_][y_grid_ - 1][x_grid_]);
-  multi_array<int, 3> h_edges_3D(
-      boost::extents[num_layers_][y_grid_][x_grid_ - 1]);
-
-  for (int netID = 0; netID < netCount(); netID++) {
-    if (nets_[netID] == nullptr) {
-      continue;
-    }
-    const auto& treeedges = sttrees_[netID].edges;
-    const int num_edges = sttrees_[netID].num_edges();
-
-    const int edgeCost = nets_[netID]->getEdgeCost();
-
-    for (int edgeID = 0; edgeID < num_edges; edgeID++) {
-      const TreeEdge* treeedge = &(treeedges[edgeID]);
-      const std::vector<short>& gridsX = treeedge->route.gridsX;
-      const std::vector<short>& gridsY = treeedge->route.gridsY;
-      const std::vector<short>& gridsL = treeedge->route.gridsL;
-      const int routeLen = treeedge->route.routelen;
-
-      for (int i = 0; i < routeLen; i++) {
-        if (gridsL[i] != gridsL[i + 1]) {
-          continue;
-        }
-        if (gridsX[i] == gridsX[i + 1]) {  // a vertical edge
-          const int ymin = std::min(gridsY[i], gridsY[i + 1]);
-          s_v_edges[ymin][gridsX[i]].insert(netID);
-          v_edges[ymin][gridsX[i]] += edgeCost;
-          v_edges_3D[gridsL[i]][ymin][gridsX[i]]
-              += nets_[netID]->getLayerEdgeCost(gridsL[i]);
-        } else if (gridsY[i] == gridsY[i + 1]) {  // a horizontal edge
-          const int xmin = std::min(gridsX[i], gridsX[i + 1]);
-          s_h_edges[gridsY[i]][xmin].insert(netID);
-          h_edges[gridsY[i]][xmin] += edgeCost;
-          h_edges_3D[gridsL[i]][gridsY[i]][xmin]
-              += nets_[netID]->getLayerEdgeCost(gridsL[i]);
-        }
-      }
-    }
-  }
-
-  for (int k = 0; k < num_layers_; k++) {
-    for (int y = 0; y < y_grid_ - 1; ++y) {
-      for (int x = 0; x < x_grid_; ++x) {
-        if (v_edges_3D[k][y][x] != v_edges_3D_[k][y][x].usage) {
-          logger_->error(GRT,
-                         1247,
-                         "v_edge mismatch {} vs {}",
-                         v_edges_3D[k][y][x],
-                         v_edges_3D_[k][y][x].usage);
-        }
-      }
-    }
-  }
-  for (int k = 0; k < num_layers_; k++) {
-    for (int y = 0; y < y_grid_; ++y) {
-      for (int x = 0; x < x_grid_ - 1; ++x) {
-        if (h_edges_3D[k][y][x] != h_edges_3D_[k][y][x].usage) {
-          logger_->error(GRT,
-                         1248,
-                         "h_edge mismatch {} vs {}",
-                         h_edges_3D[k][y][x],
-                         h_edges_3D_[k][y][x].usage);
-        }
-      }
-    }
-  }
-}
-
-// This is a full comparison between edges used by the routing and
-// the usage in the h/v edges of the routing graph.  It is somewhat
-// expensive but helpful for finding usage errors.
 void FastRouteCore::verify2DEdgesUsage()
 {
   multi_array<int, 2> v_edges(boost::extents[y_grid_ - 1][x_grid_]);
@@ -1624,6 +1543,84 @@ void FastRouteCore::verify2DEdgesUsage()
                        "h_edge mismatch {} vs {}",
                        h_edges[y][x],
                        h_edges_[y][x].est_usage);
+      }
+    }
+  }
+}
+
+void FastRouteCore::verify3DEdgesUsage()
+{
+  multi_array<std::set<int>, 2> s_v_edges(boost::extents[y_grid_ - 1][x_grid_]);
+  multi_array<std::set<int>, 2> s_h_edges(boost::extents[y_grid_][x_grid_ - 1]);
+
+  multi_array<int, 2> v_edges(boost::extents[y_grid_ - 1][x_grid_]);
+  multi_array<int, 2> h_edges(boost::extents[y_grid_][x_grid_ - 1]);
+
+  multi_array<int, 3> v_edges_3D(
+      boost::extents[num_layers_][y_grid_ - 1][x_grid_]);
+  multi_array<int, 3> h_edges_3D(
+      boost::extents[num_layers_][y_grid_][x_grid_ - 1]);
+
+  for (int netID = 0; netID < netCount(); netID++) {
+    if (nets_[netID] == nullptr) {
+      continue;
+    }
+    const auto& treeedges = sttrees_[netID].edges;
+    const int num_edges = sttrees_[netID].num_edges();
+
+    const int edgeCost = nets_[netID]->getEdgeCost();
+
+    for (int edgeID = 0; edgeID < num_edges; edgeID++) {
+      const TreeEdge* treeedge = &(treeedges[edgeID]);
+      const std::vector<short>& gridsX = treeedge->route.gridsX;
+      const std::vector<short>& gridsY = treeedge->route.gridsY;
+      const std::vector<short>& gridsL = treeedge->route.gridsL;
+      const int routeLen = treeedge->route.routelen;
+
+      for (int i = 0; i < routeLen; i++) {
+        if (gridsL[i] != gridsL[i + 1]) {
+          continue;
+        }
+        if (gridsX[i] == gridsX[i + 1]) {  // a vertical edge
+          const int ymin = std::min(gridsY[i], gridsY[i + 1]);
+          s_v_edges[ymin][gridsX[i]].insert(netID);
+          v_edges[ymin][gridsX[i]] += edgeCost;
+          v_edges_3D[gridsL[i]][ymin][gridsX[i]]
+              += nets_[netID]->getLayerEdgeCost(gridsL[i]);
+        } else if (gridsY[i] == gridsY[i + 1]) {  // a horizontal edge
+          const int xmin = std::min(gridsX[i], gridsX[i + 1]);
+          s_h_edges[gridsY[i]][xmin].insert(netID);
+          h_edges[gridsY[i]][xmin] += edgeCost;
+          h_edges_3D[gridsL[i]][gridsY[i]][xmin]
+              += nets_[netID]->getLayerEdgeCost(gridsL[i]);
+        }
+      }
+    }
+  }
+
+  for (int k = 0; k < num_layers_; k++) {
+    for (int y = 0; y < y_grid_ - 1; ++y) {
+      for (int x = 0; x < x_grid_; ++x) {
+        if (v_edges_3D[k][y][x] != v_edges_3D_[k][y][x].usage) {
+          logger_->error(GRT,
+                         1247,
+                         "v_edge mismatch {} vs {}",
+                         v_edges_3D[k][y][x],
+                         v_edges_3D_[k][y][x].usage);
+        }
+      }
+    }
+  }
+  for (int k = 0; k < num_layers_; k++) {
+    for (int y = 0; y < y_grid_; ++y) {
+      for (int x = 0; x < x_grid_ - 1; ++x) {
+        if (h_edges_3D[k][y][x] != h_edges_3D_[k][y][x].usage) {
+          logger_->error(GRT,
+                         1248,
+                         "h_edge mismatch {} vs {}",
+                         h_edges_3D[k][y][x],
+                         h_edges_3D_[k][y][x].usage);
+        }
       }
     }
   }

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -1572,9 +1572,9 @@ void FastRouteCore::verify3DEdgesUsage()
 
     for (int edgeID = 0; edgeID < num_edges; edgeID++) {
       const TreeEdge* treeedge = &(treeedges[edgeID]);
-      const std::vector<short>& gridsX = treeedge->route.gridsX;
-      const std::vector<short>& gridsY = treeedge->route.gridsY;
-      const std::vector<short>& gridsL = treeedge->route.gridsL;
+      const std::vector<int16_t>& gridsX = treeedge->route.gridsX;
+      const std::vector<int16_t>& gridsY = treeedge->route.gridsY;
+      const std::vector<int16_t>& gridsL = treeedge->route.gridsL;
       const int routeLen = treeedge->route.routelen;
 
       for (int i = 0; i < routeLen; i++) {


### PR DESCRIPTION
Removes the following unused functions:
- applyVerticalAdjustments
- applyHorizontalAdjustments
- fixEmbeddedTrees
- bendEdge
- ripupSegZ

Adds a better description to unused but useful during development functions:
- checkRoute2DTree
- verify2DEdgesUsage
- verify3DEdgesUsage (renamed from verifyEdgeUsage for clarity)