### PR TITLE
gpl: mbff clock pin issue fix

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -172,8 +172,7 @@ int MBFF::GetBitIdx(int bit_cnt)
 bool MBFF::IsClockPin(odb::dbITerm* iterm)
 {
   const bool yes = (iterm->getSigType() == odb::dbSigType::CLOCK);
-  const sta::Pin* pin = network_->dbToSta(iterm);
-  return yes || sta_->isClock(pin);
+  return yes; 
 }
 
 bool MBFF::ClockOn(odb::dbInst* inst)

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -172,7 +172,7 @@ int MBFF::GetBitIdx(int bit_cnt)
 bool MBFF::IsClockPin(odb::dbITerm* iterm)
 {
   const bool yes = (iterm->getSigType() == odb::dbSigType::CLOCK);
-  return yes; 
+  return yes;
 }
 
 bool MBFF::ClockOn(odb::dbInst* inst)

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -172,7 +172,8 @@ int MBFF::GetBitIdx(int bit_cnt)
 bool MBFF::IsClockPin(odb::dbITerm* iterm)
 {
   const bool yes = (iterm->getSigType() == odb::dbSigType::CLOCK);
-  return yes;
+  const sta::Pin* pin = network_->dbToSta(iterm);
+  return yes || network_->isRegClkPin(pin);
 }
 
 bool MBFF::ClockOn(odb::dbInst* inst)


### PR DESCRIPTION
IsClockPin() returned true for various pins in the synthetic ASAP7 MBFFs due to sta::Pin* -- removed for now.