### PR TITLE
output: reduce log spam

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -382,13 +382,14 @@ static int tclAppInit(int& argc,
 
     ord::initOpenRoad(interp);
 
-    if (!findCmdLineFlag(argc, argv, "-no_splash")) {
+    bool no_splash = findCmdLineFlag(argc, argv, "-no_splash");
+    if (!no_splash) {
       showSplash();
     }
 
     const char* threads = findCmdLineKey(argc, argv, "-threads");
     if (threads) {
-      ord::OpenRoad::openRoad()->setThreadCount(threads);
+      ord::OpenRoad::openRoad()->setThreadCount(threads, !no_splash);
     } else {
       // set to default number of threads
       ord::OpenRoad::openRoad()->setThreadCount(


### PR DESCRIPTION
The "-threads" is option always specified in ORFS, which results in log spam.

Only print out number of threads when the splash screen is enabled

Manual test/demo...

Before:

```
$ make do-2_4_floorplan_macro
Running macro_place.tcl, stage 2_4_floorplan_macro
[INFO ORD-0030] Using 48 thread(s).
No macros found: Skipping macro_placement
Elapsed time: 0:00.30[h:]min:sec. CPU time: user 0.24 sys 0.06 (100%). Peak memory: 119424KB.
$ openroad -threads 12345 -no_splash
[INFO ORD-0030] Using 48 thread(s).
openroad> 
$ openroad -threads 12345
OpenROAD v2.0-16246-gc20457a6c 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 48 thread(s).
openroad> 
```

After:

```
$ make do-2_4_floorplan_macro
Running macro_place.tcl, stage 2_4_floorplan_macro
No macros found: Skipping macro_placement
Elapsed time: 0:00.30[h:]min:sec. CPU time: user 0.24 sys 0.06 (100%). Peak memory: 119424KB.
$ openroad -threads 12345 -no_splash
openroad> 
$ openroad -threads 12345
OpenROAD v2.0-16246-gc20457a6c 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 48 thread(s).
openroad> 
```
