### PR TITLE
drt: init instance access points

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -136,6 +136,13 @@ class FlexPA
   void prep();
 
   /**
+   * @brief initializes all access points of a single unique instance
+   *
+   * @param inst the unique instance
+   */
+  void initInstAccessPoints(frInst* inst);
+
+  /**
    * @brief initializes all access points of all unique instances
    */
   void initAllAccessPoints();

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1457,6 +1457,28 @@ static inline void serializeInstRows(
   paUpdate::serialize(update, file_name);
 }
 
+void FlexPA::initInstAccessPoints(frInst* inst)
+{
+  ProfileTask profile("PA:uniqueInstance");
+  for (auto& inst_term : inst->getInstTerms()) {
+    // only do for normal and clock terms
+    if (isSkipInstTerm(inst_term.get())) {
+      continue;
+    }
+    int n_aps = 0;
+    for (auto& pin : inst_term->getTerm()->getPins()) {
+      n_aps += initPinAccess(pin.get(), inst_term.get());
+    }
+    if (!n_aps) {
+      logger_->error(DRT,
+                     73,
+                     "No access point for {}/{}.",
+                     inst_term->getInst()->getName(),
+                     inst_term->getTerm()->getName());
+    }
+  }
+}
+
 void FlexPA::initAllAccessPoints()
 {
   ProfileTask profile("PA:point");
@@ -1464,11 +1486,13 @@ void FlexPA::initAllAccessPoints()
 
   omp_set_num_threads(MAX_THREADS);
   ThreadException exception;
-  const auto& unique = unique_insts_.getUnique();
+
+  const std::vector<frInst*>& unique = unique_insts_.getUnique();
 #pragma omp parallel for schedule(dynamic)
   for (int i = 0; i < (int) unique.size(); i++) {  // NOLINT
     try {
-      auto& inst = unique[i];
+      frInst* inst = unique[i];
+
       // only do for core and block cells
       dbMasterType masterType = inst->getMaster()->getMasterType();
       if (masterType != dbMasterType::CORE
@@ -1479,35 +1503,20 @@ void FlexPA::initAllAccessPoints()
           && masterType != dbMasterType::RING) {
         continue;
       }
-      ProfileTask profile("PA:uniqueInstance");
-      for (auto& inst_term : inst->getInstTerms()) {
-        // only do for normal and clock terms
-        if (isSkipInstTerm(inst_term.get())) {
-          continue;
-        }
-        int n_aps = 0;
-        for (auto& pin : inst_term->getTerm()->getPins()) {
-          n_aps += initPinAccess(pin.get(), inst_term.get());
-        }
-        if (!n_aps) {
-          logger_->error(DRT,
-                         73,
-                         "No access point for {}/{}.",
-                         inst_term->getInst()->getName(),
-                         inst_term->getTerm()->getName());
-        }
+
+      initInstAccessPoints(inst);
+      int inst_terms_cnt = static_cast<int>(inst->getInstTerms().size());
 #pragma omp critical
-        {
-          cnt++;
-          if (VERBOSE > 0) {
-            if (cnt < 10000) {
-              if (cnt % 1000 == 0) {
-                logger_->info(DRT, 76, "  Complete {} pins.", cnt);
-              }
-            } else {
-              if (cnt % 10000 == 0) {
-                logger_->info(DRT, 77, "  Complete {} pins.", cnt);
-              }
+      for (int i = 0; i < inst_terms_cnt; i++, cnt++) {
+        cnt++;
+        if (VERBOSE > 0) {
+          if (cnt < 10000) {
+            if (cnt % 1000 == 0) {
+              logger_->info(DRT, 76, "  Complete {} pins.", cnt);
+            }
+          } else {
+            if (cnt % 10000 == 0) {
+              logger_->info(DRT, 77, "  Complete {} pins.", cnt);
             }
           }
         }

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1482,7 +1482,8 @@ void FlexPA::initInstAccessPoints(frInst* inst)
 void FlexPA::initAllAccessPoints()
 {
   ProfileTask profile("PA:point");
-  int cnt = 0;
+  int pin_count = 0;
+  int pin_count_inform = 1000;
 
   omp_set_num_threads(MAX_THREADS);
   ThreadException exception;
@@ -1505,19 +1506,18 @@ void FlexPA::initAllAccessPoints()
       }
 
       initInstAccessPoints(inst);
+      if (VERBOSE <= 0) {
+        continue;
+      }
+
       int inst_terms_cnt = static_cast<int>(inst->getInstTerms().size());
 #pragma omp critical
-      for (int i = 0; i < inst_terms_cnt; i++, cnt++) {
-        cnt++;
-        if (VERBOSE > 0) {
-          if (cnt < 10000) {
-            if (cnt % 1000 == 0) {
-              logger_->info(DRT, 76, "  Complete {} pins.", cnt);
-            }
-          } else {
-            if (cnt % 10000 == 0) {
-              logger_->info(DRT, 77, "  Complete {} pins.", cnt);
-            }
+      for (int i = 0; i < inst_terms_cnt; i++, pin_count++) {
+        pin_count++;
+        if (pin_count % pin_count_inform == 0) {
+          logger_->info(DRT, 76, "  Complete {} pins.", cnt);
+          if (cnt >= 10000) {
+            pin_count_inform = 10000;
           }
         }
       }

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -1515,8 +1515,8 @@ void FlexPA::initAllAccessPoints()
       for (int i = 0; i < inst_terms_cnt; i++, pin_count++) {
         pin_count++;
         if (pin_count % pin_count_inform == 0) {
-          logger_->info(DRT, 76, "  Complete {} pins.", cnt);
-          if (cnt >= 10000) {
+          logger_->info(DRT, 76, "  Complete {} pins.", pin_count);
+          if (pin_count >= 10000) {
             pin_count_inform = 10000;
           }
         }
@@ -1559,7 +1559,7 @@ void FlexPA::initAllAccessPoints()
   }
 
   if (VERBOSE > 0) {
-    logger_->info(DRT, 78, "  Complete {} pins.", cnt);
+    logger_->info(DRT, 78, "  Complete {} pins.", pin_count);
   }
 }
 


### PR DESCRIPTION
Creates `initInstAccessPoints`, a separate function for initializing the access point of a single instance. 
Might be pertinent to #5867  