### PR TITLE
drt: pin type check

### DIFF
--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -297,13 +297,6 @@ enum class frAccessPointEnum
   NearbyGrid = 4  // nearby grid or 1/2 grid
 };
 
-static constexpr frAccessPointEnum frAccessPointEnumAll[]
-    = {frAccessPointEnum::OnGrid,
-       frAccessPointEnum::HalfGrid,
-       frAccessPointEnum::Center,
-       frAccessPointEnum::EncOpt,
-       frAccessPointEnum::NearbyGrid};
-
 enum class RipUpMode
 {
   DRC = 0,

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -297,6 +297,13 @@ enum class frAccessPointEnum
   NearbyGrid = 4  // nearby grid or 1/2 grid
 };
 
+static constexpr frAccessPointEnum frAccessPointEnumAll[]
+    = {frAccessPointEnum::OnGrid,
+       frAccessPointEnum::HalfGrid,
+       frAccessPointEnum::Center,
+       frAccessPointEnum::EncOpt,
+       frAccessPointEnum::NearbyGrid};
+
 enum class RipUpMode
 {
   DRC = 0,

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -135,8 +135,8 @@ class FlexPA
   // prep
   void prep();
 
-  bool isStdCellPin(frInst* inst);
-  bool isMacroCellPin(frInst* inst);
+  bool isStdCell(frInst* inst);
+  bool isMacroCell(frInst* inst);
   /**
    * @brief initializes all access points of all unique instances
    */

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -135,6 +135,8 @@ class FlexPA
   // prep
   void prep();
 
+  bool isStdCellPin(frInst* inst);
+  bool isMacroCellPin(frInst* inst);
   /**
    * @brief initializes all access points of all unique instances
    */

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -53,11 +53,12 @@ using utl::ThreadException;
 // terms from OpenDB
 bool FlexPA::isStdCellPin(frInst* inst)
 {
-  dbMasterType masterType = inst->getMaster()->getMasterType();
-  return (masterType == dbMasterType::CORE
-          || masterType == dbMasterType::CORE_TIEHIGH
-          || masterType == dbMasterType::CORE_TIELOW
-          || masterType == dbMasterType::CORE_ANTENNACELL);
+  // dbMasterType masterType = inst->getMaster()->getMasterType();
+  // return (masterType == dbMasterType::CORE
+  //         || masterType == dbMasterType::CORE_TIEHIGH
+  //         || masterType == dbMasterType::CORE_TIELOW
+  //         || masterType == dbMasterType::CORE_ANTENNACELL);
+  return inst->getMaster()->getMasterType().isCore();
 }
 
 bool FlexPA::isMacroCellPin(frInst* inst)

--- a/src/drt/src/pa/FlexPA_prep.cpp
+++ b/src/drt/src/pa/FlexPA_prep.cpp
@@ -53,11 +53,6 @@ using utl::ThreadException;
 // terms from OpenDB
 bool FlexPA::isStdCell(frInst* inst)
 {
-  // dbMasterType masterType = inst->getMaster()->getMasterType();
-  // return (masterType == dbMasterType::CORE
-  //         || masterType == dbMasterType::CORE_TIEHIGH
-  //         || masterType == dbMasterType::CORE_TIELOW
-  //         || masterType == dbMasterType::CORE_ANTENNACELL);
   return inst->getMaster()->getMasterType().isCore();
 }
 


### PR DESCRIPTION
This secure CI associated with this PR passed with no changes.

In Multiple parts of the code the Master of an instance was deferenced to get its type and determine the type of the instance. In multiple parts of the code the same check was done either to verify if the instance was a Standard Cell or a Macro Cell. Two respective functions were created to make this check given an instance.

`isStdCell()` checks for as the `isCore()` instead of directly looking for various typing. This caused no changes in the secure CI Run