### PR TITLE
mbff: Fix missing fmt include

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -46,6 +46,7 @@
 #include "db_sta/dbSta.hh"
 #include "graphics.h"
 #include "odb/dbTransform.h"
+#include "spdlog/fmt/ranges.h"
 #include "sta/ArcDelayCalc.hh"
 #include "sta/ClkNetwork.hh"
 #include "sta/DcalcAnalysisPt.hh"


### PR DESCRIPTION
On my system this was causing a `no member named 'join' in namespace 'fmt'` error.