### PR TITLE
mpl2: improve convergence

### DIFF
--- a/src/mpl2/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl2/src/SimulatedAnnealingCore.cpp
@@ -586,7 +586,10 @@ void SimulatedAnnealingCore<T>::fastSA()
       perturb();
       cost = calNormCost();
 
-      if (cost < pre_cost && isValid()) {
+      const bool keep_result
+          = cost < pre_cost || best_valid_result.pos_sequence.empty();
+
+      if (isValid() && keep_result) {
         updateBestValidResult(best_valid_result);
       }
 

--- a/src/mpl2/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl2/src/SimulatedAnnealingCore.cpp
@@ -576,10 +576,20 @@ void SimulatedAnnealingCore<T>::fastSA()
   int num_restart = 1;
   const int max_num_restart = 2;
 
+  SequencePair best_valid_result;
+  if (isValid()) {
+    updateBestValidResult(best_valid_result);
+  }
+
   while (step <= max_num_step_) {
     for (int i = 0; i < num_perturb_per_step_; i++) {
       perturb();
       cost = calNormCost();
+
+      if (cost < pre_cost && isValid()) {
+        updateBestValidResult(best_valid_result);
+      }
+
       delta_cost = cost - pre_cost;
       const float num = distribution_(generator_);
       const float prob
@@ -616,6 +626,11 @@ void SimulatedAnnealingCore<T>::fastSA()
       calPenalty();
       pre_cost = calNormCost();
     }
+  }
+
+  if (!isValid()) {
+    pos_seq_ = best_valid_result.pos_sequence;
+    neg_seq_ = best_valid_result.neg_sequence;
   }
 
   packFloorplan();
@@ -684,6 +699,14 @@ void SimulatedAnnealingCore<T>::moveFloorplan(
   }
 
   calPenalty();
+}
+
+template <class T>
+void SimulatedAnnealingCore<T>::updateBestValidResult(
+    SequencePair& best_valid_result)
+{
+  best_valid_result.pos_sequence = pos_seq_;
+  best_valid_result.neg_sequence = neg_seq_;
 }
 
 template <class T>

--- a/src/mpl2/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl2/src/SimulatedAnnealingCore.cpp
@@ -628,16 +628,22 @@ void SimulatedAnnealingCore<T>::fastSA()
     }
   }
 
-  if (!isValid()) {
-    pos_seq_ = best_valid_result.pos_sequence;
-    neg_seq_ = best_valid_result.neg_sequence;
-  }
-
   packFloorplan();
   if (graphics_) {
     graphics_->doNotSkip();
   }
   calPenalty();
+
+  if (!isValid() && !best_valid_result.pos_sequence.empty()) {
+    pos_seq_ = best_valid_result.pos_sequence;
+    neg_seq_ = best_valid_result.neg_sequence;
+
+    packFloorplan();
+    if (graphics_) {
+      graphics_->doNotSkip();
+    }
+    calPenalty();
+  }
 
   if (centralization_on_) {
     attemptCentralization(calNormCost());

--- a/src/mpl2/src/SimulatedAnnealingCore.h
+++ b/src/mpl2/src/SimulatedAnnealingCore.h
@@ -134,6 +134,7 @@ class SimulatedAnnealingCore
   void initSequencePair();
   void attemptCentralization(float pre_cost);
   void moveFloorplan(const std::pair<float, float>& offset);
+  void updateBestValidResult(SequencePair& best_valid_result);
 
   virtual float calNormCost() const = 0;
   virtual void calPenalty() = 0;

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -1855,11 +1855,6 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
     best_cost = std::numeric_limits<float>::max();
     begin_check = 0;
     end_check = std::min(check_interval, remaining_runs);
-
-    int outline_weight, boundary_weight;
-    setWeightsForConvergence(
-        outline_weight, boundary_weight, nets, num_of_macros_to_place);
-
     debugPrint(logger_,
                MPL,
                "hierarchical_macro_placement",
@@ -1924,11 +1919,11 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
             outline,
             shaped_macros,
             area_weight_,
-            outline_weight,
+            outline_weight_,
             wirelength_weight_,
             guidance_weight_,
             fence_weight_,
-            boundary_weight,
+            boundary_weight_,
             macro_blockage_weight_,
             notch_weight_,
             notch_h_th_,
@@ -2129,36 +2124,6 @@ void HierRTLMP::adjustMacroBlockageWeight()
                macro_blockage_weight_,
                new_macro_blockage_weight);
     macro_blockage_weight_ = new_macro_blockage_weight;
-  }
-}
-
-void HierRTLMP::setWeightsForConvergence(int& outline_weight,
-                                         int& boundary_weight,
-                                         const std::vector<BundledNet>& nets,
-                                         const int number_of_placeable_macros)
-{
-  outline_weight = outline_weight_;
-  boundary_weight = boundary_weight_;
-
-  if (nets.size() < number_of_placeable_macros / 2) {
-    // If a design has too few connections, there's a possibily that, for
-    // some tight outlines, the outline penalty will struggle to win the
-    // fight against the boundary penalty. This can happen specially for
-    // large hierarchical designs that were reduced by deltaDebug.
-    outline_weight *= 2;
-    boundary_weight /= 2;
-
-    debugPrint(logger_,
-               MPL,
-               "hierarchical_macro_placement",
-               1,
-               "Number of bundled nets is below half of the number of "
-               "placeable macros, adapting "
-               "weights. Outline {} -> {}, Boundary {} -> {}.",
-               outline_weight_,
-               outline_weight,
-               boundary_weight_,
-               boundary_weight);
   }
 }
 
@@ -2463,11 +2428,6 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
   float best_cost = std::numeric_limits<float>::max();
-
-  int outline_weight, boundary_weight;
-  setWeightsForConvergence(
-      outline_weight, boundary_weight, nets, num_of_macros_to_place);
-
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",
@@ -2531,11 +2491,11 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               area_weight_,
-                                              outline_weight,
+                                              outline_weight_,
                                               wirelength_weight_,
                                               guidance_weight_,
                                               fence_weight_,
-                                              boundary_weight,
+                                              boundary_weight_,
                                               macro_blockage_weight_,
                                               notch_weight_,
                                               notch_h_th_,
@@ -2953,11 +2913,6 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
   const int check_interval = 10;
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
-
-  int outline_weight, boundary_weight;
-  setWeightsForConvergence(
-      outline_weight, boundary_weight, nets, macros_to_place);
-
   debugPrint(logger_,
              MPL,
              "hierarchical_macro_placement",
@@ -3018,11 +2973,11 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               area_weight_,
-                                              outline_weight,
+                                              outline_weight_,
                                               wirelength_weight_,
                                               guidance_weight_,
                                               fence_weight_,
-                                              boundary_weight,
+                                              boundary_weight_,
                                               macro_blockage_weight_,
                                               notch_weight_,
                                               notch_h_th_,

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -192,10 +192,6 @@ class HierRTLMP
   // Hierarchical Macro Placement 1st stage: Cluster Placement
   void runHierarchicalMacroPlacement(Cluster* parent);
   void adjustMacroBlockageWeight();
-  void setWeightsForConvergence(int& outline_weight,
-                                int& boundary_weight,
-                                const std::vector<BundledNet>& nets,
-                                int number_of_placeable_macros);
   void reportSAWeights();
   void runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent);
   void runEnhancedHierarchicalMacroPlacement(Cluster* parent);


### PR DESCRIPTION
Resolves #5884

This PR is the proper fix for #5655, that's the reason why it also reverts #5799.

Changes:
1. Keep the lowest cost valid result as SA goes so that, if the lowest cost result is not valid we use the former.
2. Minor cleanup


