### PR TITLE
drt: Push node index computation up

### DIFF
--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -867,19 +867,13 @@ class FlexDRWorker
   void modMinSpacingCostVia_eol(const Rect& box,
                                 const Rect& tmpBx,
                                 ModCostType type,
-                                bool isUpperVia,
                                 const drEolSpacingConstraint& drCon,
-                                frMIdx i,
-                                frMIdx j,
-                                frMIdx z,
+                                frMIdx idx,
                                 bool ndr = false);
   void modMinSpacingCostVia_eol_helper(const Rect& box,
                                        const Rect& testBox,
                                        ModCostType type,
-                                       bool isUpperVia,
-                                       frMIdx i,
-                                       frMIdx j,
-                                       frMIdx z,
+                                       frMIdx idx,
                                        bool ndr = false);
   // eolSpc
   void modEolSpacingCost_helper(const Rect& testbox,

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -79,44 +79,38 @@ void FlexDRWorker::modViaForbiddenThrough(const FlexMazeIdx& bi,
   if (isHorz) {
     for (int xIdx = bi.x(); xIdx < ei.x(); xIdx++) {
       if (isLowerViaForbidden) {
+        frMIdx idx = gridGraph_.getIdx(xIdx, bi.y(), bi.z() - 1);
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(
-                xIdx, bi.y(), bi.z() - 1);  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(
-                xIdx, bi.y(), bi.z() - 1);  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(
-                xIdx, bi.y(), bi.z() - 1);  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(
-                xIdx, bi.y(), bi.z() - 1);  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
       }
 
       if (isUpperViaForbidden) {
+        frMIdx idx = gridGraph_.getIdx(xIdx, bi.y(), bi.z());
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(
-                xIdx, bi.y(), bi.z());  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(
-                xIdx, bi.y(), bi.z());  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(
-                xIdx, bi.y(), bi.z());  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(
-                xIdx, bi.y(), bi.z());  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
@@ -125,44 +119,38 @@ void FlexDRWorker::modViaForbiddenThrough(const FlexMazeIdx& bi,
   } else {
     for (int yIdx = bi.y(); yIdx < ei.y(); yIdx++) {
       if (isLowerViaForbidden) {
+        frMIdx idx = gridGraph_.getIdx(bi.x(), yIdx, bi.z() - 1);
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(
-                bi.x(), yIdx, bi.z() - 1);  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(
-                bi.x(), yIdx, bi.z() - 1);  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(
-                bi.x(), yIdx, bi.z() - 1);  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(
-                bi.x(), yIdx, bi.z() - 1);  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
       }
 
       if (isUpperViaForbidden) {
+        frMIdx idx = gridGraph_.getIdx(bi.x(), yIdx, bi.z());
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(
-                bi.x(), yIdx, bi.z());  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(
-                bi.x(), yIdx, bi.z());  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(
-                bi.x(), yIdx, bi.z());  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(
-                bi.x(), yIdx, bi.z());  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
@@ -219,18 +207,19 @@ void FlexDRWorker::modCornerToCornerSpacing_helper(const Rect& box,
   gridGraph_.getIdxBox(p1, p2, box, FlexGridGraph::isEnclosed);
   for (int i = p1.x(); i <= p2.x(); i++) {
     for (int j = p1.y(); j <= p2.y(); j++) {
+      frMIdx idx = gridGraph_.getIdx(i, j, z);
       switch (type) {
         case subRouteShape:
-          gridGraph_.subRouteShapeCostPlanar(i, j, z);
+          gridGraph_.subRouteShapeCostPlanar(idx);
           break;
         case addRouteShape:
-          gridGraph_.addRouteShapeCostPlanar(i, j, z);
+          gridGraph_.addRouteShapeCostPlanar(idx);
           break;
         case subFixedShape:
-          gridGraph_.subFixedShapeCostPlanar(i, j, z);
+          gridGraph_.subFixedShapeCostPlanar(idx);
           break;
         case addFixedShape:
-          gridGraph_.addFixedShapeCostPlanar(i, j, z);
+          gridGraph_.addFixedShapeCostPlanar(idx);
           break;
         default:;
       }
@@ -373,33 +362,37 @@ void FlexDRWorker::modMinSpacingCostPlanarHelper(const Rect& box,
       if (distSquare < bloatDistSquare) {
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostPlanar(i, j, z, ndr);  // safe access
+            gridGraph_.subRouteShapeCostPlanar(gridGraph_.getIdx(i, j, z),
+                                               ndr);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostPlanar(i, j, z, ndr);  // safe access
+            gridGraph_.addRouteShapeCostPlanar(gridGraph_.getIdx(i, j, z),
+                                               ndr);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostPlanar(i, j, z, ndr);  // safe access
+            gridGraph_.subFixedShapeCostPlanar(gridGraph_.getIdx(i, j, z),
+                                               ndr);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostPlanar(i, j, z, ndr);  // safe access
+            gridGraph_.addFixedShapeCostPlanar(gridGraph_.getIdx(i, j, z),
+                                               ndr);  // safe access
             break;
           case resetFixedShape:
             if (resetHorz) {
               gridGraph_.setFixedShapeCostPlanarHorz(
-                  i, j, z, 0, ndr);  // safe access
+                  gridGraph_.getIdx(i, j, z), 0, ndr);  // safe access
             }
             if (resetVert) {
               gridGraph_.setFixedShapeCostPlanarVert(
-                  i, j, z, 0, ndr);  // safe access
+                  gridGraph_.getIdx(i, j, z), 0, ndr);  // safe access
             }
             break;
-          case setFixedShape:
-            gridGraph_.setFixedShapeCostPlanarHorz(
-                i, j, z, 1, ndr);  // safe access
-            gridGraph_.setFixedShapeCostPlanarVert(
-                i, j, z, 1, ndr);  // safe access
+          case setFixedShape: {
+            frMIdx idx = gridGraph_.getIdx(i, j, z);
+            gridGraph_.setFixedShapeCostPlanarHorz(idx, 1, ndr);  // safe access
+            gridGraph_.setFixedShapeCostPlanarVert(idx, 1, ndr);  // safe access
             break;
+          }
           case resetBlocked:
             if (ndr) {
               return;
@@ -451,26 +444,22 @@ void FlexDRWorker::modMinSpacingCostPlanarHelper(const Rect& box,
 void FlexDRWorker::modMinSpacingCostVia_eol_helper(const Rect& box,
                                                    const Rect& testBox,
                                                    ModCostType type,
-                                                   bool isUpperVia,
-                                                   frMIdx i,
-                                                   frMIdx j,
-                                                   frMIdx z,
+                                                   frMIdx idx,
                                                    bool ndr)
 {
-  frMIdx zIdx = isUpperVia ? z : z - 1;
   if (testBox.overlaps(box)) {
     switch (type) {
       case subRouteShape:
-        gridGraph_.subRouteShapeCostVia(i, j, zIdx, ndr);
+        gridGraph_.subRouteShapeCostVia(idx, ndr);
         break;
       case addRouteShape:
-        gridGraph_.addRouteShapeCostVia(i, j, zIdx, ndr);
+        gridGraph_.addRouteShapeCostVia(idx, ndr);
         break;
       case subFixedShape:
-        gridGraph_.subFixedShapeCostVia(i, j, zIdx, ndr);  // safe access
+        gridGraph_.subFixedShapeCostVia(idx, ndr);  // safe access
         break;
       case addFixedShape:
-        gridGraph_.addFixedShapeCostVia(i, j, zIdx, ndr);  // safe access
+        gridGraph_.addFixedShapeCostVia(idx, ndr);  // safe access
         break;
       default:;
     }
@@ -480,11 +469,8 @@ void FlexDRWorker::modMinSpacingCostVia_eol_helper(const Rect& box,
 void FlexDRWorker::modMinSpacingCostVia_eol(const Rect& box,
                                             const Rect& tmpBx,
                                             ModCostType type,
-                                            bool isUpperVia,
                                             const drEolSpacingConstraint& drCon,
-                                            frMIdx i,
-                                            frMIdx j,
-                                            frMIdx z,
+                                            frMIdx idx,
                                             bool ndr)
 {
   if (drCon.eolSpace == 0) {
@@ -500,15 +486,13 @@ void FlexDRWorker::modMinSpacingCostVia_eol(const Rect& box,
                  tmpBx.yMax(),
                  tmpBx.xMax() + eolWithin,
                  tmpBx.yMax() + eolSpace);
-    modMinSpacingCostVia_eol_helper(
-        box, testBox, type, isUpperVia, i, j, z, ndr);
+    modMinSpacingCostVia_eol_helper(box, testBox, type, idx, ndr);
 
     testBox.init(tmpBx.xMin() - eolWithin,
                  tmpBx.yMin() - eolSpace,
                  tmpBx.xMax() + eolWithin,
                  tmpBx.yMin());
-    modMinSpacingCostVia_eol_helper(
-        box, testBox, type, isUpperVia, i, j, z, ndr);
+    modMinSpacingCostVia_eol_helper(box, testBox, type, idx, ndr);
   }
   // eol to left and right
   if (tmpBx.dy() <= eolWidth) {
@@ -516,15 +500,13 @@ void FlexDRWorker::modMinSpacingCostVia_eol(const Rect& box,
                  tmpBx.yMin() - eolWithin,
                  tmpBx.xMax() + eolSpace,
                  tmpBx.yMax() + eolWithin);
-    modMinSpacingCostVia_eol_helper(
-        box, testBox, type, isUpperVia, i, j, z, ndr);
+    modMinSpacingCostVia_eol_helper(box, testBox, type, idx, ndr);
 
     testBox.init(tmpBx.xMin() - eolSpace,
                  tmpBx.yMin() - eolWithin,
                  tmpBx.xMin(),
                  tmpBx.yMax() + eolWithin);
-    modMinSpacingCostVia_eol_helper(
-        box, testBox, type, isUpperVia, i, j, z, ndr);
+    modMinSpacingCostVia_eol_helper(box, testBox, type, idx, ndr);
   }
 }
 
@@ -600,7 +582,8 @@ void FlexDRWorker::modMinimumcutCostVia(const Rect& box,
           gridGraph_.getPoint(pt, i, j);
           dbTransform xform(pt);
           tmpBx = viaBox;
-          if (gridGraph_.isSVia(i, j, zIdx)) {
+          frMIdx idx = gridGraph_.getIdx(i, j, zIdx);
+          if (gridGraph_.isSVia(idx)) {
             auto sViaDef = apSVia_[FlexMazeIdx(i, j, zIdx)]->getAccessViaDef();
             sVia.setViaDef(sViaDef);
             sViaBox = sVia.getCutBBox();
@@ -625,22 +608,24 @@ void FlexDRWorker::modMinimumcutCostVia(const Rect& box,
           }
           switch (type) {
             case subRouteShape:
-              gridGraph_.subRouteShapeCostVia(i, j, zIdx);  // safe access
+              gridGraph_.subRouteShapeCostVia(idx);  // safe access
               break;
             case addRouteShape:
-              gridGraph_.addRouteShapeCostVia(i, j, zIdx);  // safe access
+              gridGraph_.addRouteShapeCostVia(idx);  // safe access
               break;
             case subFixedShape:
-              gridGraph_.subFixedShapeCostVia(i, j, zIdx);  // safe access
+              gridGraph_.subFixedShapeCostVia(idx);  // safe access
               break;
             case addFixedShape:
-              gridGraph_.addFixedShapeCostVia(i, j, zIdx);  // safe access
+              gridGraph_.addFixedShapeCostVia(idx);  // safe access
               break;
             case resetFixedShape:
-              gridGraph_.setFixedShapeCostVia(i, j, z, 0);  // safe access
+              gridGraph_.setFixedShapeCostVia(gridGraph_.getIdx(i, j, z),
+                                              0);  // safe access
               break;
             case setFixedShape:
-              gridGraph_.setFixedShapeCostVia(i, j, z, 1);  // safe access
+              gridGraph_.setFixedShapeCostVia(gridGraph_.getIdx(i, j, z),
+                                              1);  // safe access
             default:;
           }
         }
@@ -803,7 +788,8 @@ void FlexDRWorker::modMinSpacingCostViaHelper(const Rect& box,
       gridGraph_.getPoint(pt, i, j);
       dbTransform xform(pt);
       tmpBx = viaBox;
-      if (gridGraph_.isSVia(i, j, zIdx)) {
+      frMIdx idx = gridGraph_.getIdx(i, j, zIdx);
+      if (gridGraph_.isSVia(idx)) {
         auto sViaDef = apSVia_[FlexMazeIdx(i, j, zIdx)]->getAccessViaDef();
         sVia.setViaDef(sViaDef);
         Rect sViaBox;
@@ -840,23 +826,22 @@ void FlexDRWorker::modMinSpacingCostViaHelper(const Rect& box,
       if (distSquare < (frSquaredDistance) reqDist * reqDist) {
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(i, j, zIdx, ndr);  // safe access
+            gridGraph_.subRouteShapeCostVia(idx, ndr);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(i, j, zIdx, ndr);  // safe access
+            gridGraph_.addRouteShapeCostVia(idx, ndr);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(i, j, zIdx, ndr);  // safe access
+            gridGraph_.subFixedShapeCostVia(idx, ndr);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(i, j, zIdx, ndr);  // safe access
+            gridGraph_.addFixedShapeCostVia(idx, ndr);  // safe access
             break;
           default:;
         }
       }
       // eol, other obj to curr obj
-      modMinSpacingCostVia_eol(
-          box, tmpBx, type, isUpperVia, drCon, i, j, z, ndr);
+      modMinSpacingCostVia_eol(box, tmpBx, type, drCon, idx, ndr);
     }
   }
 }
@@ -922,37 +907,37 @@ void FlexDRWorker::modEolSpacingCost_helper(const Rect& testbox,
   for (int i = mIdx1.x(); i <= mIdx2.x(); i++) {
     for (int j = mIdx1.y(); j <= mIdx2.y(); j++) {
       if (eolType == 0) {
+        frMIdx idx = gridGraph_.getIdx(i, j, z);
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostPlanar(i, j, z);  // safe access
+            gridGraph_.subRouteShapeCostPlanar(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostPlanar(i, j, z);  // safe access
+            gridGraph_.addRouteShapeCostPlanar(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostPlanar(i, j, z);  // safe access
+            gridGraph_.subFixedShapeCostPlanar(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostPlanar(i, j, z);  // safe access
+            gridGraph_.addFixedShapeCostPlanar(idx);  // safe access
             break;
           case resetFixedShape:
             if (resetHorz) {
-              gridGraph_.setFixedShapeCostPlanarHorz(
-                  i, j, z, 0);  // safe access
+              gridGraph_.setFixedShapeCostPlanarHorz(idx, 0);  // safe access
             }
             if (resetVert) {
-              gridGraph_.setFixedShapeCostPlanarVert(
-                  i, j, z, 0);  // safe access
+              gridGraph_.setFixedShapeCostPlanarVert(idx, 0);  // safe access
             }
             break;
           case setFixedShape:
-            gridGraph_.setFixedShapeCostPlanarHorz(i, j, z, 1);  // safe access
-            gridGraph_.setFixedShapeCostPlanarVert(i, j, z, 1);  // safe access
+            gridGraph_.setFixedShapeCostPlanarHorz(idx, 1);  // safe access
+            gridGraph_.setFixedShapeCostPlanarVert(idx, 1);  // safe access
             break;
           default:;
         }
       } else if (eolType == 1) {
-        if (gridGraph_.isSVia(i, j, z - 1)) {
+        frMIdx idx = gridGraph_.getIdx(i, j, z - 1);
+        if (gridGraph_.isSVia(idx)) {
           gridGraph_.getPoint(pt, i, j);
           auto sViaDef = apSVia_[FlexMazeIdx(i, j, z - 1)]->getAccessViaDef();
           sVia.setViaDef(sViaDef);
@@ -964,21 +949,22 @@ void FlexDRWorker::modEolSpacingCost_helper(const Rect& testbox,
         }
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(i, j, z - 1);  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(i, j, z - 1);  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(i, j, z - 1);  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(i, j, z - 1);  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
       } else if (eolType == 2) {
-        if (gridGraph_.isSVia(i, j, z)) {
+        frMIdx idx = gridGraph_.getIdx(i, j, z);
+        if (gridGraph_.isSVia(idx)) {
           gridGraph_.getPoint(pt, i, j);
           auto sViaDef = apSVia_[FlexMazeIdx(i, j, z)]->getAccessViaDef();
           sVia.setViaDef(sViaDef);
@@ -990,16 +976,16 @@ void FlexDRWorker::modEolSpacingCost_helper(const Rect& testbox,
         }
         switch (type) {
           case subRouteShape:
-            gridGraph_.subRouteShapeCostVia(i, j, z);  // safe access
+            gridGraph_.subRouteShapeCostVia(idx);  // safe access
             break;
           case addRouteShape:
-            gridGraph_.addRouteShapeCostVia(i, j, z);  // safe access
+            gridGraph_.addRouteShapeCostVia(idx);  // safe access
             break;
           case subFixedShape:
-            gridGraph_.subFixedShapeCostVia(i, j, z);  // safe access
+            gridGraph_.subFixedShapeCostVia(idx);  // safe access
             break;
           case addFixedShape:
-            gridGraph_.addFixedShapeCostVia(i, j, z);  // safe access
+            gridGraph_.addFixedShapeCostVia(idx);  // safe access
             break;
           default:;
         }
@@ -1307,18 +1293,19 @@ void FlexDRWorker::modAdjCutSpacingCost_fixedObj(const frDesign* design,
         }
 
         if (hasViol) {
+          frMIdx idx = gridGraph_.getIdx(i, j, z);
           switch (type) {
             case subRouteShape:
-              gridGraph_.subRouteShapeCostVia(i, j, z);  // safe access
+              gridGraph_.subRouteShapeCostVia(idx);  // safe access
               break;
             case addRouteShape:
-              gridGraph_.addRouteShapeCostVia(i, j, z);  // safe access
+              gridGraph_.addRouteShapeCostVia(idx);  // safe access
               break;
             case subFixedShape:
-              gridGraph_.subFixedShapeCostVia(i, j, z);  // safe access
+              gridGraph_.subFixedShapeCostVia(idx);  // safe access
               break;
             case addFixedShape:
-              gridGraph_.addFixedShapeCostVia(i, j, z);  // safe access
+              gridGraph_.addFixedShapeCostVia(idx);  // safe access
               break;
             default:;
           }
@@ -1461,18 +1448,19 @@ void FlexDRWorker::modInterLayerCutSpacingCost(const Rect& box,
         }
 
         if (hasViol) {
+          frMIdx idx = gridGraph_.getIdx(i, j, z2);
           switch (type) {
             case subRouteShape:
-              gridGraph_.subRouteShapeCostVia(i, j, z2);  // safe access
+              gridGraph_.subRouteShapeCostVia(idx);  // safe access
               break;
             case addRouteShape:
-              gridGraph_.addRouteShapeCostVia(i, j, z2);  // safe access
+              gridGraph_.addRouteShapeCostVia(idx);  // safe access
               break;
             case subFixedShape:
-              gridGraph_.subFixedShapeCostVia(i, j, z2);  // safe access
+              gridGraph_.subFixedShapeCostVia(idx);  // safe access
               break;
             case addFixedShape:
-              gridGraph_.addFixedShapeCostVia(i, j, z2);  // safe access
+              gridGraph_.addFixedShapeCostVia(idx);  // safe access
               break;
             default:;
           }

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -90,6 +90,7 @@ class FlexGridGraph
   {
     return nodes_[getIdx(x, y, z)].hasSpecialVia;
   }
+  bool isSVia(frMIdx idx) const { return nodes_[idx].hasSpecialVia; }
   // unsafe access, no check
   bool hasGridCostE(frMIdx x, frMIdx y, frMIdx z) const
   {
@@ -524,27 +525,27 @@ class FlexGridGraph
       }
     }
   }
-  void addRouteShapeCostPlanar(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void addRouteShapeCostPlanar(frMIdx idx, bool ndr = false)
   {
-    auto& node = nodes_[getIdx(x, y, z)];
+    auto& node = nodes_[idx];
     if (ndr) {
       node.routeShapeCostPlanarNDR = addToByte(node.routeShapeCostPlanarNDR, 1);
     } else {
       node.routeShapeCostPlanar = addToByte(node.routeShapeCostPlanar, 1);
     }
   }
-  void addRouteShapeCostVia(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void addRouteShapeCostVia(frMIdx idx, bool ndr = false)
   {
-    auto& node = nodes_[getIdx(x, y, z)];
+    auto& node = nodes_[idx];
     if (ndr) {
       node.routeShapeCostViaNDR = addToByte(node.routeShapeCostViaNDR, 1);
     } else {
       node.routeShapeCostVia = addToByte(node.routeShapeCostVia, 1);
     }
   }
-  void subRouteShapeCostPlanar(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void subRouteShapeCostPlanar(frMIdx idx, bool ndr = false)
   {
-    auto& node = nodes_[getIdx(x, y, z)];
+    auto& node = nodes_[idx];
     if (ndr) {
       node.routeShapeCostPlanarNDR
           = subFromByte(node.routeShapeCostPlanarNDR, 1);
@@ -552,22 +553,22 @@ class FlexGridGraph
       node.routeShapeCostPlanar = subFromByte(node.routeShapeCostPlanar, 1);
     }
   }
-  void subRouteShapeCostVia(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void subRouteShapeCostVia(frMIdx idx, bool ndr = false)
   {
-    auto& node = nodes_[getIdx(x, y, z)];
+    auto& node = nodes_[idx];
     if (ndr) {
       node.routeShapeCostViaNDR = subFromByte(node.routeShapeCostViaNDR, 1);
     } else {
       node.routeShapeCostVia = subFromByte(node.routeShapeCostVia, 1);
     }
   }
-  void resetRouteShapeCostVia(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void resetRouteShapeCostVia(frMIdx idx, bool ndr = false)
   {
-    auto idx = getIdx(x, y, z);
+    auto& node = nodes_[idx];
     if (ndr) {
-      nodes_[idx].routeShapeCostViaNDR = 0;
+      node.routeShapeCostViaNDR = 0;
     } else {
-      nodes_[idx].routeShapeCostVia = 0;
+      node.routeShapeCostVia = 0;
     }
   }
   void addMarkerCostPlanar(frMIdx x, frMIdx y, frMIdx z)
@@ -664,105 +665,79 @@ class FlexGridGraph
     }
     return (currCost == 0);
   }
-  void addFixedShapeCostPlanar(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void addFixedShapeCostPlanar(frMIdx idx, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostPlanarHorzNDR
-            = addToByte(node.fixedShapeCostPlanarHorzNDR, 1);
-        node.fixedShapeCostPlanarVertNDR
-            = addToByte(node.fixedShapeCostPlanarVertNDR, 1);
-      } else {
-        node.fixedShapeCostPlanarHorz
-            = addToByte(node.fixedShapeCostPlanarHorz, 1);
-        node.fixedShapeCostPlanarVert
-            = addToByte(node.fixedShapeCostPlanarVert, 1);
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostPlanarHorzNDR
+          = addToByte(node.fixedShapeCostPlanarHorzNDR, 1);
+      node.fixedShapeCostPlanarVertNDR
+          = addToByte(node.fixedShapeCostPlanarVertNDR, 1);
+    } else {
+      node.fixedShapeCostPlanarHorz
+          = addToByte(node.fixedShapeCostPlanarHorz, 1);
+      node.fixedShapeCostPlanarVert
+          = addToByte(node.fixedShapeCostPlanarVert, 1);
     }
   }
-  void setFixedShapeCostPlanarVert(frMIdx x,
-                                   frMIdx y,
-                                   frMIdx z,
-                                   frUInt4 c,
-                                   bool ndr = false)
+  void setFixedShapeCostPlanarVert(frMIdx idx, frUInt4 c, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostPlanarVertNDR = c;
-      } else {
-        node.fixedShapeCostPlanarVert = c;
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostPlanarVertNDR = c;
+    } else {
+      node.fixedShapeCostPlanarVert = c;
     }
   }
-  void setFixedShapeCostPlanarHorz(frMIdx x,
-                                   frMIdx y,
-                                   frMIdx z,
-                                   frUInt4 c,
-                                   bool ndr = false)
+  void setFixedShapeCostPlanarHorz(frMIdx idx, frUInt4 c, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostPlanarHorzNDR = c;
-      } else {
-        node.fixedShapeCostPlanarHorz = c;
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostPlanarHorzNDR = c;
+    } else {
+      node.fixedShapeCostPlanarHorz = c;
     }
   }
-  void addFixedShapeCostVia(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void addFixedShapeCostVia(frMIdx idx, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostViaNDR = addToByte(node.fixedShapeCostViaNDR, 1);
-      } else {
-        node.fixedShapeCostVia = addToByte(node.fixedShapeCostVia, 1);
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostViaNDR = addToByte(node.fixedShapeCostViaNDR, 1);
+    } else {
+      node.fixedShapeCostVia = addToByte(node.fixedShapeCostVia, 1);
     }
   }
-  void setFixedShapeCostVia(frMIdx x,
-                            frMIdx y,
-                            frMIdx z,
-                            frUInt4 c,
-                            bool ndr = false)
+  void setFixedShapeCostVia(frMIdx idx, frUInt4 c, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostViaNDR = c;
-      } else {
-        node.fixedShapeCostVia = c;
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostViaNDR = c;
+    } else {
+      node.fixedShapeCostVia = c;
     }
   }
-  void subFixedShapeCostPlanar(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void subFixedShapeCostPlanar(frMIdx idx, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostPlanarHorzNDR
-            = subFromByte(node.fixedShapeCostPlanarHorzNDR, 1);
-        node.fixedShapeCostPlanarVertNDR
-            = subFromByte(node.fixedShapeCostPlanarVertNDR, 1);
-      } else {
-        node.fixedShapeCostPlanarHorz
-            = subFromByte(node.fixedShapeCostPlanarHorz, 1);
-        node.fixedShapeCostPlanarVert
-            = subFromByte(node.fixedShapeCostPlanarVert, 1);
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostPlanarHorzNDR
+          = subFromByte(node.fixedShapeCostPlanarHorzNDR, 1);
+      node.fixedShapeCostPlanarVertNDR
+          = subFromByte(node.fixedShapeCostPlanarVertNDR, 1);
+    } else {
+      node.fixedShapeCostPlanarHorz
+          = subFromByte(node.fixedShapeCostPlanarHorz, 1);
+      node.fixedShapeCostPlanarVert
+          = subFromByte(node.fixedShapeCostPlanarVert, 1);
     }
   }
-  void subFixedShapeCostVia(frMIdx x, frMIdx y, frMIdx z, bool ndr = false)
+  void subFixedShapeCostVia(frMIdx idx, bool ndr = false)
   {
-    if (isValid(x, y, z)) {
-      auto& node = nodes_[getIdx(x, y, z)];
-      if (ndr) {
-        node.fixedShapeCostViaNDR = subFromByte(node.fixedShapeCostViaNDR, 1);
-      } else {
-        node.fixedShapeCostVia = subFromByte(node.fixedShapeCostVia, 1);
-      }
+    auto& node = nodes_[idx];
+    if (ndr) {
+      node.fixedShapeCostViaNDR = subFromByte(node.fixedShapeCostViaNDR, 1);
+    } else {
+      node.fixedShapeCostVia = subFromByte(node.fixedShapeCostVia, 1);
     }
   }
 


### PR DESCRIPTION
No functional change intended. This speeds up DRT by 3-8%, at least for `asap7` (varies depending on the design). Baseline is a recent commit from Oct 6.

## `asap7/aes` - stage `5_2_route` - 8 thread(s)

| Branch | Min [s] | Median [s] | Relative |
|--------|---------|------------|----------|
| Baseline | 221.96 | 222.23 | 1.03 |
| This PR | 215.48 | 215.91 | 1.00 |

## `asap7/ibex` - stage `5_2_route` - 8 thread(s)

| Branch | Min [s] | Median [s] | Relative |
|--------|---------|------------|----------|
| Baseline | 337.61 | 338.30 | 1.08 |
| This PR | 312.99 | 313.16 | 1.00 |
