### PR TITLE
dft: fix reporting config problem

### DIFF
--- a/src/dft/src/dft.tcl
+++ b/src/dft/src/dft.tcl
@@ -99,7 +99,7 @@ proc set_dft_config { args } {
 }
 
 sta::define_cmd_args "report_dft_config" { }
-proc report_dft_config { } {
+proc report_dft_config { args } {
   sta::parse_key_args "report_dft_config" args keys {} flags {}
   dft::report_dft_config
 }


### PR DESCRIPTION
there was an error generated when running report_dft_config
[ERROR GUI-0070] can't read "args": no such variable