### PR TITLE
gui: if no_init is specified on commandline previous settings will not be loaded

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -117,6 +117,7 @@ int cmd_argc;
 char** cmd_argv;
 const char* log_filename = nullptr;
 const char* metrics_filename = nullptr;
+bool no_init = false;
 
 static const char* init_filename = ".openroad";
 
@@ -257,6 +258,8 @@ int main(int argc, char* argv[])
     remove(metrics_filename);
   }
 
+  no_init = findCmdLineFlag(argc, argv, "-no_init");
+
   cmd_argc = argc;
   cmd_argv = argv;
 #ifdef ENABLE_PYTHON3
@@ -274,7 +277,7 @@ int main(int argc, char* argv[])
       logger->warn(utl::ORD, 38, "-gui is not yet supported with -python");
     }
 
-    if (!findCmdLineFlag(cmd_argc, cmd_argv, "-no_init")) {
+    if (!no_init) {
       logger->warn(utl::ORD, 39, ".openroad ignored with -python");
     }
 
@@ -350,7 +353,7 @@ static int tclAppInit(int& argc,
       ;
     }
 
-    gui::startGui(argc, argv, interp);
+    gui::startGui(argc, argv, interp, "", true, !no_init);
   } else {
     // init tcl
     if (Tcl_Init(interp) == TCL_ERROR) {
@@ -399,7 +402,7 @@ static int tclAppInit(int& argc,
     const bool gui_enabled = gui::Gui::enabled();
 
     const char* home = getenv("HOME");
-    if (!findCmdLineFlag(argc, argv, "-no_init") && home) {
+    if (!no_init && home) {
       const char* restore_state_cmd = "source -echo -verbose {{{}}}";
 #ifdef USE_STD_FILESYSTEM
       std::filesystem::path init(home);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -117,7 +117,7 @@ int cmd_argc;
 char** cmd_argv;
 const char* log_filename = nullptr;
 const char* metrics_filename = nullptr;
-bool no_init = false;
+bool no_settings = false;
 
 static const char* init_filename = ".openroad";
 
@@ -258,7 +258,7 @@ int main(int argc, char* argv[])
     remove(metrics_filename);
   }
 
-  no_init = findCmdLineFlag(argc, argv, "-no_init");
+  no_settings = findCmdLineFlag(argc, argv, "-no_settings");
 
   cmd_argc = argc;
   cmd_argv = argv;
@@ -277,7 +277,7 @@ int main(int argc, char* argv[])
       logger->warn(utl::ORD, 38, "-gui is not yet supported with -python");
     }
 
-    if (!no_init) {
+    if (!findCmdLineFlag(cmd_argc, cmd_argv, "-no_init")) {
       logger->warn(utl::ORD, 39, ".openroad ignored with -python");
     }
 
@@ -353,7 +353,7 @@ static int tclAppInit(int& argc,
       ;
     }
 
-    gui::startGui(argc, argv, interp, "", true, !no_init);
+    gui::startGui(argc, argv, interp, "", true, !no_settings);
   } else {
     // init tcl
     if (Tcl_Init(interp) == TCL_ERROR) {
@@ -402,7 +402,7 @@ static int tclAppInit(int& argc,
     const bool gui_enabled = gui::Gui::enabled();
 
     const char* home = getenv("HOME");
-    if (!no_init && home) {
+    if (!findCmdLineFlag(argc, argv, "-no_init") && home) {
       const char* restore_state_cmd = "source -echo -verbose {{{}}}";
 #ifdef USE_STD_FILESYSTEM
       std::filesystem::path init(home);
@@ -476,7 +476,7 @@ static void showUsage(const char* prog, const char* init_filename)
 {
   printf("Usage: %s [-help] [-version] [-no_init] [-no_splash] [-exit] ", prog);
   printf("[-gui] [-threads count|max] [-log file_name] [-metrics file_name] ");
-  printf("cmd_file\n");
+  printf("[-no_settings] cmd_file\n");
   printf("  -help                 show help and exit\n");
   printf("  -version              show version and exit\n");
   printf("  -no_init              do not read %s init file\n", init_filename);
@@ -484,6 +484,7 @@ static void showUsage(const char* prog, const char* init_filename)
   printf("  -no_splash            do not show the license splash at startup\n");
   printf("  -exit                 exit after reading cmd_file\n");
   printf("  -gui                  start in gui mode\n");
+  printf("  -no_settings          do not load the previous gui settings\n");
 #ifdef ENABLE_PYTHON3
   printf(
       "  -python               start with python interpreter [limited to db "

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -704,7 +704,9 @@ class Gui
   void hideGui();
 
   // Called to show the gui and return to tcl command line
-  void showGui(const std::string& cmds = "", bool interactive = true);
+  void showGui(const std::string& cmds = "",
+               bool interactive = true,
+               bool load_settings = true);
 
   // set the system logger
   void setLogger(utl::Logger* logger);
@@ -810,6 +812,7 @@ int startGui(int& argc,
              char* argv[],
              Tcl_Interp* interp,
              const std::string& script = "",
-             bool interactive = true);
+             bool interactive = true,
+             bool load_settings = true);
 
 }  // namespace gui

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1245,7 +1245,7 @@ void Gui::hideGui()
   main_window->exit();
 }
 
-void Gui::showGui(const std::string& cmds, bool interactive)
+void Gui::showGui(const std::string& cmds, bool interactive, bool load_settings)
 {
   if (enabled()) {
     logger_->warn(utl::GUI, 8, "GUI already active.");
@@ -1256,7 +1256,7 @@ void Gui::showGui(const std::string& cmds, bool interactive)
   // passing in cmd_argc and cmd_argv to meet Qt application requirement for
   // arguments nullptr for tcl interp to indicate nothing to setup and commands
   // and interactive setting
-  startGui(cmd_argc, cmd_argv, nullptr, cmds, interactive);
+  startGui(cmd_argc, cmd_argv, nullptr, cmds, interactive, load_settings);
 }
 
 void Gui::init(odb::dbDatabase* db, utl::Logger* logger)
@@ -1295,7 +1295,8 @@ int startGui(int& argc,
              char* argv[],
              Tcl_Interp* interp,
              const std::string& script,
-             bool interactive)
+             bool interactive,
+             bool load_settings)
 {
   auto gui = gui::Gui::get();
   // ensure continue after close is false
@@ -1312,7 +1313,7 @@ int startGui(int& argc,
   auto* open_road = ord::OpenRoad::openRoad();
 
   // create new MainWindow
-  main_window = new gui::MainWindow;
+  main_window = new gui::MainWindow(load_settings);
 
   open_road->addObserver(main_window);
   if (!interactive) {

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -469,10 +469,10 @@ void hide_widget(const char* name)
   return gui->showWidget(name, false);
 }
 
-void show(const char* script = "", bool interactive = true)
+void show(const char* script = "", bool interactive = true, bool load_settings = true)
 {
   auto gui = gui::Gui::get();
-  gui->showGui(script, interactive);
+  gui->showGui(script, interactive, load_settings);
 }
 
 void hide()

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -81,7 +81,7 @@ static void loadQTResources()
 
 namespace gui {
 
-MainWindow::MainWindow(QWidget* parent)
+MainWindow::MainWindow(bool load_settings, QWidget* parent)
     : QMainWindow(parent),
       db_(nullptr),
       logger_(nullptr),
@@ -385,31 +385,34 @@ MainWindow::MainWindow(QWidget* parent)
   createMenus();
   createStatusBar();
 
-  // Restore the settings (if none this is a no-op)
-  QSettings settings("OpenRoad Project", "openroad");
-  settings.beginGroup("main");
-  restoreGeometry(settings.value("geometry").toByteArray());
-  restoreState(settings.value("state").toByteArray());
-  QApplication::setFont(
-      settings.value("font", QApplication::font()).value<QFont>());
-  hide_option_->setChecked(
-      settings.value("check_exit", hide_option_->isChecked()).toBool());
-  show_dbu_->setChecked(
-      settings.value("use_dbu", show_dbu_->isChecked()).toBool());
-  default_ruler_style_->setChecked(
-      settings.value("ruler_style", default_ruler_style_->isChecked())
-          .toBool());
-  default_mouse_wheel_zoom_->setChecked(
-      settings.value("mouse_wheel_zoom", default_mouse_wheel_zoom_->isChecked())
-          .toBool());
-  arrow_keys_scroll_step_
-      = settings.value("arrow_keys_scroll_step", arrow_keys_scroll_step_)
-            .toInt();
-  script_->readSettings(&settings);
-  controls_->readSettings(&settings);
-  timing_widget_->readSettings(&settings);
-  hierarchy_widget_->readSettings(&settings);
-  settings.endGroup();
+  if (load_settings) {
+    // Restore the settings (if none this is a no-op)
+    QSettings settings("OpenRoad Project", "openroad");
+    settings.beginGroup("main");
+    restoreGeometry(settings.value("geometry").toByteArray());
+    restoreState(settings.value("state").toByteArray());
+    QApplication::setFont(
+        settings.value("font", QApplication::font()).value<QFont>());
+    hide_option_->setChecked(
+        settings.value("check_exit", hide_option_->isChecked()).toBool());
+    show_dbu_->setChecked(
+        settings.value("use_dbu", show_dbu_->isChecked()).toBool());
+    default_ruler_style_->setChecked(
+        settings.value("ruler_style", default_ruler_style_->isChecked())
+            .toBool());
+    default_mouse_wheel_zoom_->setChecked(
+        settings
+            .value("mouse_wheel_zoom", default_mouse_wheel_zoom_->isChecked())
+            .toBool());
+    arrow_keys_scroll_step_
+        = settings.value("arrow_keys_scroll_step", arrow_keys_scroll_step_)
+              .toInt();
+    script_->readSettings(&settings);
+    controls_->readSettings(&settings);
+    timing_widget_->readSettings(&settings);
+    hierarchy_widget_->readSettings(&settings);
+    settings.endGroup();
+  }
 
   // load resources and set window icon and title
   loadQTResources();

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -80,7 +80,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   Q_OBJECT
 
  public:
-  MainWindow(QWidget* parent = nullptr);
+  MainWindow(bool load_settings = true, QWidget* parent = nullptr);
   ~MainWindow();
 
   void setDatabase(odb::dbDatabase* db);

--- a/src/gui/src/stub.cpp
+++ b/src/gui/src/stub.cpp
@@ -177,7 +177,8 @@ int startGui(int& argc,
              char* argv[],
              Tcl_Interp* interp,
              const std::string& script,
-             bool interactive)
+             bool interactive,
+             bool load_settings)
 {
   printf(
       "[ERROR] This code was compiled with the GUI disabled.  Please recompile "


### PR DESCRIPTION
This provides a way to pass in the `no_init` information to the GUI on load to start the GUI in a clean state.
If we dont want to bring in the commandline flag, I suggest we still have this capability since it would be useful when debugging GUI issues and dealing with sometimes corrupted settings files.
