### PR TITLE
pdn: fix gf180 power grid and correct incorrect use of direction

### DIFF
--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -1558,11 +1558,19 @@ RepairChannelStraps::RepairChannelStraps(
   }
 
   odb::dbTechLayerDir connect_direction = connect_to->getDirection();
+  // find the connecting strap and use it's direction
+  for (const auto& comp : grid->getStraps()) {
+    if (comp->getLayer() == connect_to) {
+      connect_direction = comp->getDirection();
+    }
+  }
+
   if (connect_direction == odb::dbTechLayerDir::NONE) {
-    // Assume this layer is horizontal
+    // Assume this layer is horizontal if not set
     connect_direction = odb::dbTechLayerDir::HORIZONTAL;
   }
-  if (connect_to->getDirection() == getDirection()) {
+
+  if (connect_direction == getDirection()) {
     debugPrint(
         getLogger(),
         utl::PDN,


### PR DESCRIPTION
https://github.com/The-OpenROAD-Project/OpenROAD/pull/5927 broke repair channels on gf180
This ensures that the connecting strap directions are used if they can be found.

See https://github.com/siliconcompiler/siliconcompiler/actions/runs/11308313835/job/31451523568?pr=2885 for failing grid