### PR TITLE
rmp: Moves Logic Cut to net based primary IO

### DIFF
--- a/src/rmp/src/logic_cut.h
+++ b/src/rmp/src/logic_cut.h
@@ -23,8 +23,8 @@ class LogicCut
 {
  public:
   LogicCut() = default;
-  LogicCut(std::vector<sta::Pin*>& primary_inputs,
-           std::vector<sta::Pin*>& primary_outputs,
+  LogicCut(std::vector<sta::Net*>& primary_inputs,
+           std::vector<sta::Net*>& primary_outputs,
            std::unordered_set<sta::Instance*>& cut_instances)
       : primary_inputs_(std::move(primary_inputs)),
         primary_outputs_(std::move(primary_outputs)),
@@ -33,11 +33,11 @@ class LogicCut
   }
   ~LogicCut() = default;
 
-  const std::vector<sta::Pin*>& primary_inputs() const
+  const std::vector<sta::Net*>& primary_inputs() const
   {
     return primary_inputs_;
   }
-  const std::vector<sta::Pin*>& primary_outputs() const
+  const std::vector<sta::Net*>& primary_outputs() const
   {
     return primary_outputs_;
   }
@@ -58,8 +58,8 @@ class LogicCut
       utl::Logger* logger);
 
  private:
-  std::vector<sta::Pin*> primary_inputs_;
-  std::vector<sta::Pin*> primary_outputs_;
+  std::vector<sta::Net*> primary_inputs_;
+  std::vector<sta::Net*> primary_outputs_;
   std::unordered_set<sta::Instance*> cut_instances_;
 };
 }  // namespace rmp

--- a/src/rmp/src/logic_extractor.h
+++ b/src/rmp/src/logic_extractor.h
@@ -15,6 +15,7 @@
 #include "sta/Graph.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/SearchPred.hh"
+#include "utl/Logger.h"
 
 namespace rmp {
 
@@ -45,7 +46,10 @@ class SearchPredNonReg2AbcSupport : public sta::SearchPredNonReg2
 class LogicExtractorFactory
 {
  public:
-  LogicExtractorFactory(sta::dbSta* open_sta) : open_sta_(open_sta) {}
+  LogicExtractorFactory(sta::dbSta* open_sta, utl::Logger* logger)
+      : open_sta_(open_sta), logger_(logger)
+  {
+  }
   LogicExtractorFactory& AppendEndpoint(sta::Vertex* vertex);
   LogicCut BuildLogicCut(AbcLibrary& abc_network);
 
@@ -61,8 +65,14 @@ class LogicExtractorFactory
   std::vector<sta::Pin*> FilterUndrivenOutputs(
       std::vector<sta::Pin*>& primary_outputs,
       std::unordered_set<sta::Instance*>& cut_instances);
+  std::vector<sta::Net*> ConvertIoPinsToNets(
+      std::vector<sta::Pin*>& primary_inputs);
+  void RemovePrimaryOutputInstances(
+      std::unordered_set<sta::Instance*>& cut_instances,
+      std::vector<sta::Pin*>& primary_io_pins);
 
   std::vector<sta::Vertex*> endpoints_;
   sta::dbSta* open_sta_;
+  utl::Logger* logger_;
 };
 }  // namespace rmp

--- a/src/rmp/src/logic_extractor.h
+++ b/src/rmp/src/logic_extractor.h
@@ -66,10 +66,10 @@ class LogicExtractorFactory
       std::vector<sta::Pin*>& primary_outputs,
       std::unordered_set<sta::Instance*>& cut_instances);
   std::vector<sta::Net*> ConvertIoPinsToNets(
-      std::vector<sta::Pin*>& primary_inputs);
+      std::vector<sta::Pin*>& primary_io_pins);
   void RemovePrimaryOutputInstances(
       std::unordered_set<sta::Instance*>& cut_instances,
-      std::vector<sta::Pin*>& primary_io_pins);
+      std::vector<sta::Pin*>& primary_output_pins);
 
   std::vector<sta::Vertex*> endpoints_;
   sta::dbSta* open_sta_;

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -300,7 +300,7 @@ TEST_F(AbcTest, ExtractsAndGateCorrectly)
   }
   EXPECT_NE(flop_input_vertex, nullptr);
 
-  LogicExtractorFactory logic_extractor(sta_.get());
+  LogicExtractorFactory logic_extractor(sta_.get(), &logger_);
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
@@ -325,7 +325,7 @@ TEST_F(AbcTest, ExtractsEmptyCutSetCorrectly)
   }
   EXPECT_NE(flop_input_vertex, nullptr);
 
-  LogicExtractorFactory logic_extractor(sta_.get());
+  LogicExtractorFactory logic_extractor(sta_.get(), &logger_);
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
@@ -349,18 +349,18 @@ TEST_F(AbcTest, ExtractSideOutputsCorrectly)
   }
   EXPECT_NE(flop_input_vertex, nullptr);
 
-  LogicExtractorFactory logic_extractor(sta_.get());
+  LogicExtractorFactory logic_extractor(sta_.get(), &logger_);
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
   std::unordered_set<std::string> primary_output_names;
-  for (sta::Pin* pin : cut.primary_outputs()) {
-    primary_output_names.insert(network->name(pin));
+  for (sta::Net* net : cut.primary_outputs()) {
+    primary_output_names.insert(network->name(net));
   }
 
-  EXPECT_EQ(cut.primary_outputs().size(), 2);
-  EXPECT_THAT(primary_output_names, Contains("output_flop/D"));
-  EXPECT_THAT(primary_output_names, Contains("output_flop2/D"));
+  // Since a single net feeds both of these outputs should expect just 1 output
+  EXPECT_EQ(cut.primary_outputs().size(), 1);
+  EXPECT_THAT(primary_output_names, Contains("flop_net"));
 }
 
 TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
@@ -380,7 +380,7 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
   }
   EXPECT_NE(flop_input_vertex, nullptr);
 
-  LogicExtractorFactory logic_extractor(sta_.get());
+  LogicExtractorFactory logic_extractor(sta_.get(), &logger_);
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
@@ -392,6 +392,14 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
   utl::deleted_unique_ptr<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(abc_network.get()), &abc::Abc_NtkDelete);
 
+  // Build map of primary output names to primary output indicies in ABC
+  std::map<std::string, int> primary_output_name_to_index;
+  for (int i = 0; i < abc::Abc_NtkPoNum(logic_network.get()); i++) {
+    abc::Abc_Obj_t* po = abc::Abc_NtkPo(logic_network.get(), i);
+    std::string po_name = abc::Abc_ObjName(po);
+    primary_output_name_to_index[po_name] = i;
+  }
+
   std::array<int, 2> input_vector = {1, 1};
   utl::deleted_unique_ptr<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
@@ -399,8 +407,10 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
       &free);
 
   // Both outputs are just the and gate.
-  EXPECT_EQ(output_vector.get()[0], 0);  // Expect that !(1 & 1) == 0
-  EXPECT_EQ(output_vector.get()[1], 0);  // Expect that !(1 & 1) == 0
+  EXPECT_EQ(output_vector.get()[primary_output_name_to_index.at("flop_net")],
+            0);  // Expect that !(1 & 1) == 0
+  EXPECT_EQ(output_vector.get()[primary_output_name_to_index.at("and_output")],
+            1);  // Expect that (1 & 1) == 1
 }
 
 TEST_F(AbcTest, BuildComplexLogicCone)
@@ -420,7 +430,7 @@ TEST_F(AbcTest, BuildComplexLogicCone)
   }
   EXPECT_NE(flop_input_vertex, nullptr);
 
-  LogicExtractorFactory logic_extractor(sta_.get());
+  LogicExtractorFactory logic_extractor(sta_.get(), &logger_);
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 

--- a/src/rmp/test/side_outputs_extract_logic_depth.v
+++ b/src/rmp/test/side_outputs_extract_logic_depth.v
@@ -38,7 +38,7 @@ module top(clk, a, b, c, d);
 
   DFF_X1 output_flop2 (
     .CK(clk),
-    .D(flop_net),
+    .D(and_output),
     .Q(d),
     .QN(_unconnected_2)
   );


### PR DESCRIPTION
Before this change logic cuts were sta::Pin* terminated this lead to weird effects where ABC would see two pins with the same driving net, and do weird things to its internal datastructure.

It also has the nice property that a logic cut based on nets can be reused multiple times if a user wants to run two versions of a script on a Abc_Ntk*.