### PR TITLE
tcl: add a fallback from hardcoded TCLRL_LIBRARY path

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -343,17 +343,17 @@ std::string findPathToTclreadlineInit(Tcl_Interp* interp)
   }
 
   const char* tclScript = R"(
-        proc find_path {} {
-            foreach dir $::auto_path {
-                set folder [file join $dir]
-                set path [file join $folder "tclreadline2.3.8" "tclreadlineInit.tcl"]
-                if {[file exists $path]} {
-                    return $path
-                }
+      namespace eval temp {
+        foreach dir $::auto_path {
+            set folder [file join $dir]
+            set path [file join $folder "tclreadline)" TCLRL_VERSION_STR
+                          R"(" "tclreadlineInit.tcl"]
+            if {[file exists $path]} {
+                return $path
             }
-            error "tclreadlineInit.tcl not found in any of the directories in auto_path"
         }
-        find_path
+        error "tclreadlineInit.tcl not found in any of the directories in auto_path"
+      }
     )";
 
   if (Tcl_Eval(interp, tclScript) == TCL_ERROR) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -342,6 +342,24 @@ std::string findPathToTclreadlineInit(Tcl_Interp* interp)
     return path;
   }
 
+  // TL;DR it is possible to run the OpenROAD binary from within the
+  // official Docker image on a different distribution than the
+  // distribution within the Docker image.
+  //
+  // In this case we have to look up
+  // the location of the tclreadline scripts instead of using the hardcoded
+  // path.
+  //
+  // It is helpful to use the official Docker image as CI infrastructure and
+  // also because it is a good way to have as similar an environment as possible
+  // during testing and deployment.
+  //
+  // See
+  // https://github.com/The-OpenROAD-Project/bazel-orfs/blob/main/docker.BUILD.bazel
+  // for the details on how this is done.
+  //
+  // Running Docker within a bazel isolated environment introduces lots of
+  // problems and is not really done.
   const char* tclScript = R"(
       namespace eval temp {
         foreach dir $::auto_path {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -334,14 +334,10 @@ static int tclReadlineInit(Tcl_Interp* interp)
 #endif
 
 namespace {
-// A fallback from the hardcoded TCLRL_LIBRARY path.
+// A stopgap fallback from the hardcoded TCLRL_LIBRARY path for OpenROAD,
+// not essential for OpenSTA
 std::string findPathToTclreadlineInit(Tcl_Interp* interp)
 {
-  std::string path(TCLRL_LIBRARY "/tclreadlineInit.tcl");
-  if (is_regular_file(path.c_str())) {
-    return path;
-  }
-
   // TL;DR it is possible to run the OpenROAD binary from within the
   // official Docker image on a different distribution than the
   // distribution within the Docker image.
@@ -425,9 +421,12 @@ static int tclAppInit(int& argc,
       Tcl_StaticPackage(
           interp, "tclreadline", Tclreadline_Init, Tclreadline_SafeInit);
 
-      std::string path = findPathToTclreadlineInit(interp);
-      if (path.empty() || Tcl_EvalFile(interp, path.c_str()) != TCL_OK) {
-        printf("Failed to load tclreadline\n");
+      if (Tcl_EvalFile(interp, TCLRL_LIBRARY "/tclreadlineInit.tcl")
+          != TCL_OK) {
+        std::string path = findPathToTclreadlineInit(interp);
+        if (path.empty() || Tcl_EvalFile(interp, path.c_str()) != TCL_OK) {
+          printf("Failed to load tclreadline\n");
+        }
       }
     }
 #endif


### PR DESCRIPTION
TL;DR This fixes the last niggling little deployment problem with non-Ubuntu systems and bazel-orfs GUI.

Not pretty, but good 'nuf to use around the house.