### PR TITLE
ppl: escape backslashes in python tests

### DIFF
--- a/src/ppl/test/group_pins7.py
+++ b/src/ppl/test/group_pins7.py
@@ -11,36 +11,36 @@ design.readDef("group_pins3.def")
 
 ppl_aux.set_io_pin_constraint(
     design,
-    pin_names="req_msg\[10\] req_msg\[11\] req_msg\[12\] req_msg\[13\] "
-    + "req_msg\[14\] req_msg\[15\] req_msg\[16\] req_msg\[17\] "
-    + "req_msg\[18\] req_msg\[19\] req_msg\[20\] req_msg\[21\] "
-    + "req_msg\[22\] req_msg\[23\] req_msg\[0\] req_msg\[1\]",
+    pin_names=r"req_msg\[10\] req_msg\[11\] req_msg\[12\] req_msg\[13\] "
+    + r"req_msg\[14\] req_msg\[15\] req_msg\[16\] req_msg\[17\] "
+    + r"req_msg\[18\] req_msg\[19\] req_msg\[20\] req_msg\[21\] "
+    + r"req_msg\[22\] req_msg\[23\] req_msg\[0\] req_msg\[1\]",
     region="left:*",
 )
 
 ppl_aux.set_io_pin_constraint(
     design,
-    pin_names="req_msg\[24\] req_msg\[25\] req_msg\[26\] "
-    + "req_msg\[27\] req_msg\[28\] req_msg\[29\] req_msg\[2\] "
-    + "req_msg\[30\] req_msg\[31\] req_msg\[3\] req_msg\[4\] "
-    + "req_msg\[5\] req_msg\[6\] req_msg\[7\] req_msg\[8\] req_msg\[9\]",
+    pin_names=r"req_msg\[24\] req_msg\[25\] req_msg\[26\] "
+    + r"req_msg\[27\] req_msg\[28\] req_msg\[29\] req_msg\[2\] "
+    + r"req_msg\[30\] req_msg\[31\] req_msg\[3\] req_msg\[4\] "
+    + r"req_msg\[5\] req_msg\[6\] req_msg\[7\] req_msg\[8\] req_msg\[9\]",
     region="bottom:*",
 )
 
 ppl_aux.set_io_pin_constraint(
     design,
-    pin_names="clk req_rdy req_val reset resp_msg\[0\] "
-    + "resp_msg\[10\] resp_msg\[11\] resp_msg\[12\] "
-    + "resp_msg\[13\] resp_msg\[14\] resp_msg\[15\]",
+    pin_names=r"clk req_rdy req_val reset resp_msg\[0\] "
+    + r"resp_msg\[10\] resp_msg\[11\] resp_msg\[12\] "
+    + r"resp_msg\[13\] resp_msg\[14\] resp_msg\[15\]",
     region="top:*",
 )
 
 ppl_aux.set_io_pin_constraint(
     design,
-    pin_names="resp_rdy resp_val resp_msg\[1\] "
-    + "resp_msg\[2\] resp_msg\[3\] resp_msg\[4\] "
-    + "resp_msg\[5\] resp_msg\[6\] resp_msg\[7\] "
-    + "resp_msg\[8\] resp_msg\[9\]",
+    pin_names=r"resp_rdy resp_val resp_msg\[1\] "
+    + r"resp_msg\[2\] resp_msg\[3\] resp_msg\[4\] "
+    + r"resp_msg\[5\] resp_msg\[6\] resp_msg\[7\] "
+    + r"resp_msg\[8\] resp_msg\[9\]",
     region="right:*",
 )
 

--- a/src/ppl/test/place_pin2.py
+++ b/src/ppl/test/place_pin2.py
@@ -16,7 +16,11 @@ ppl_aux.place_pin(
     design, pin_name="resp_val", layer="metal4", location=[12, 50], pin_size=[2, 2]
 )
 ppl_aux.place_pin(
-    design, pin_name="req_msg\[0\]", layer="metal10", location=[25, 70], pin_size=[4, 4]
+    design,
+    pin_name=r"req_msg\[0\]",
+    layer="metal10",
+    location=[25, 70],
+    pin_size=[4, 4],
 )
 
 ppl_aux.place_pins(

--- a/src/ppl/test/ppl_aux.py
+++ b/src/ppl/test/ppl_aux.py
@@ -340,7 +340,7 @@ def set_io_pin_constraint(
     direction -- "input" | "output" | "inout" | "feedthru"
     pin_names -- string list of pins to constrain, can contain regex.
                  Note that we need to escape regex characters for exact matching,
-                 ie, use "rqst\[23\]" instead of "rqst[23]"
+                 ie, use "rqst\\[23\\]" instead of "rqst[23]"
     region    -- region constraint, e.g. "top:*" or "left:1.2-3.4"
                  "up" takes an area spec, ie "up:10 10 300 300" or specify
                  entire area with "up:*"

--- a/src/ppl/test/random4.py
+++ b/src/ppl/test/random4.py
@@ -13,7 +13,7 @@ ppl_aux.set_io_pin_constraint(
 )
 ppl_aux.set_io_pin_constraint(
     design,
-    pin_names="req_msg\[15\] req_msg\[14\] resp_msg\[15\] resp_msg\[14\]",
+    pin_names=r"req_msg\[15\] req_msg\[14\] resp_msg\[15\] resp_msg\[14\]",
     region="top:*",
 )
 


### PR DESCRIPTION
Python 3.12 generates a SynthesisWarning for strings containing unescaped `\[` or `\]`. This causes the test suite to fail, and indirectly blocks building .deb packages for Ubuntu 24.04 (which comes with Python 3.12 as the default).