### PR TITLE
add files and line numbers to find_messages to make it easier to track down there the duplicate is

### DIFF
--- a/etc/find_messages.py
+++ b/etc/find_messages.py
@@ -176,7 +176,7 @@ def main():
             )
             for idloc in sorted(msgs[key]):
                 fileloc, *_ = idloc.split()
-                file, line = fileloc.split(':')
+                file, line = fileloc.split(":")
                 print(
                     "  Appears in {} on line {} ".format(file, line),
                     file=sys.stderr,

--- a/etc/find_messages.py
+++ b/etc/find_messages.py
@@ -174,6 +174,13 @@ def main():
                 ),
                 file=sys.stderr,
             )
+            for idloc in sorted(msgs[key]):
+                fileloc, *_ = idloc.split()
+                file, line = fileloc.split(':')
+                print(
+                    "  Appears in {} on line {} ".format(file, line),
+                    file=sys.stderr,
+                )
             has_error = True
 
     for key in sorted(msgs):


### PR DESCRIPTION
Adds:
- file and line number information to the find_messages script to make it easier to track down errors.

Sample output on STDERR:
```
Error: ODB 0256 used 2 times, next free message id is 273
  Appears in dbMarker.cpp on line 494 
  Appears in dbMarker.cpp on line 509 
```