### PR TITLE
mpl2: don't move macro if all layers are already snapped

### DIFF
--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -4621,9 +4621,15 @@ void Snapper::attemptSnapToExtraLayers(
   bool all_layers_snapped = false;
 
   while (remaining_attempts > 0) {
-    // Move one track ahead.
-    new_origin += snap_layer_params.pitch;
-    setOrigin(new_origin, target_direction);
+    const bool is_first_attempt = remaining_attempts == total_attempts;
+    // The pins may already be aligned for all extra layers (in that case,
+    // we don't need to move the macro at all), hence, we use the first
+    // attempt to check if there are in fact any extra layers to snap.
+    if (!is_first_attempt) {
+      // Move one track ahead.
+      new_origin += snap_layer_params.pitch;
+      setOrigin(new_origin, target_direction);
+    }
 
     int curr_number_of_snapped_layers = 1;
     for (const auto [layer, pin] : layers_data.layer_to_pin) {

--- a/src/odb/src/zutil/util.cpp
+++ b/src/odb/src/zutil/util.cpp
@@ -259,20 +259,13 @@ std::string generateMacroPlacementString(dbBlock* block)
 {
   std::string macro_placement;
 
-  const float dbu = block->getTech()->getDbUnitsPerMicron();
-  float x = 0.0f;
-  float y = 0.0f;
-
   for (odb::dbInst* inst : block->getInsts()) {
     if (inst->isBlock()) {
-      x = (inst->getLocation().x()) / dbu;
-      y = (inst->getLocation().y()) / dbu;
-
       macro_placement += fmt::format(
           "place_macro -macro_name {} -location {{{} {}}} -orientation {}\n",
           inst->getName(),
-          x,
-          y,
+          block->dbuToMicrons(inst->getLocation().x()),
+          block->dbuToMicrons(inst->getLocation().y()),
           inst->getOrient().getString());
     }
   }


### PR DESCRIPTION
Fix #5983 

Also: use new block methods when writing mpl string.