### PR TITLE
ppl: check if slot location is used by a fixed bterm

### DIFF
--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -263,7 +263,7 @@ class IOPlacer
                       int height,
                       const Rect& die_boundary);
   Interval getIntervalFromPin(IOPin& io_pin, const Rect& die_boundary);
-  bool checkBlocked(Edge edge, int pos, int layer);
+  bool checkBlocked(Edge edge, const odb::Point& pos, int layer);
   std::vector<Interval> findBlockedIntervals(const odb::Rect& die_area,
                                              const odb::Rect& box);
   void getBlockedRegionsFromMacros();
@@ -304,6 +304,7 @@ class IOPlacer
   std::vector<PinGroup> pin_groups_;
   MirroredPins mirrored_pins_;
   FallbackPins fallback_pins_;
+  std::map<int, std::vector<odb::Rect>> layer_fixed_pins_shapes_;
 
   Logger* logger_ = nullptr;
   std::unique_ptr<Parameters> parms_;


### PR DESCRIPTION
Fix overlaps between FIXED pins placed with the `place_pin` command and the remaining pins placed with `place_pins` command.