### PR TITLE
grt: ensure only modified nets are rerouted

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4698,6 +4698,7 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
   std::vector<Net*> dirty_nets;
   if (!dirty_nets_.empty()) {
     fastroute_->setVerbose(false);
+    fastroute_->clearNetsToRoute();
 
     updateDirtyNets(dirty_nets);
     if (verbose_) {

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -141,6 +141,7 @@ class FastRouteCore
   void removeNet(odb::dbNet* db_net);
   void mergeNet(odb::dbNet* db_net);
   void clearNetRoute(odb::dbNet* db_net);
+  void clearNetsToRoute() { net_ids_.clear(); }
   void initEdges();
   void setNumAdjustments(int nAdjustements);
   void addAdjustment(int x1,
@@ -597,7 +598,6 @@ class FastRouteCore
   int enlarge_;
   int costheight_;
   int ahth_;
-  std::vector<int> route_net_ids_;  // IDs of nets to route
   int num_layers_;
   int total_overflow_;  // total # overflow
   bool has_2D_overflow_;

--- a/src/grt/src/fastroute/src/RipUp.cpp
+++ b/src/grt/src/fastroute/src/RipUp.cpp
@@ -220,7 +220,11 @@ bool FastRouteCore::newRipupType2(const TreeEdge* treeedge,
     }
     return needRipup;
   } else {
-    logger_->error(GRT, 226, "Type2 ripup not type L.");
+    logger_->error(GRT,
+                   226,
+                   "Net {} ripup type is {}. Expected LRoute.",
+                   nets_[netID]->getName(),
+                   ripuptype);
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/The-OpenROAD-Project/OpenROAD/issues/5980

When loading an odb file to run post-grt optimizations (incremental timing repair or repair_antennas), the nets are initialized in FastRouteCore, but not all of them must be rerouted. This PR ensures that only the nets modified during the incremental calls are rerouted.