### PR TITLE
Fix for geting name in presence of modinsts but non-hierarchical mode

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -720,7 +720,13 @@ const char* dbNetwork::name(const Instance* instance) const
     name = mod_inst->getName();
   }
 
-  if (hierarchy_) {
+  bool has_mod_insts = false;
+  dbModule* module = block_->getTopModule();
+  if (module && module->getModInstCount() > 0) {
+    has_mod_insts = true;
+  }
+
+  if (hierarchy_ || has_mod_insts) {
     size_t last_idx = name.find_last_of('/');
     if (last_idx != string::npos) {
       name = name.substr(last_idx + 1);
@@ -843,9 +849,7 @@ Instance* dbNetwork::parent(const Instance* instance) const
   if (instance == top_instance_) {
     return nullptr;
   }
-  if (!hasHierarchy()) {
-    return top_instance_;
-  }
+
   dbInst* db_inst;
   dbModInst* mod_inst;
   staToDb(instance, db_inst, mod_inst);

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -720,13 +720,12 @@ const char* dbNetwork::name(const Instance* instance) const
     name = mod_inst->getName();
   }
 
-  bool has_mod_insts = false;
-  dbModule* module = block_->getTopModule();
-  if (module && module->getModInstCount() > 0) {
-    has_mod_insts = true;
-  }
+  // it is possible to have hierarchy without -hier !
+  // because parent(instance) won't always return
+  // topInstance we need to construct the name
+  // hierarchically.
 
-  if (hierarchy_ || has_mod_insts) {
+  if (hierarchy_ || mod_inst) {
     size_t last_idx = name.find_last_of('/');
     if (last_idx != string::npos) {
       name = name.substr(last_idx + 1);


### PR DESCRIPTION
Matt this is my attempt at cleaning up the naming stuff for when in non-hierarchy mode but in the presence of modInsts.
Please do not merge in. I would be interested to see if it fixes the Boom case referenced in https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2485

(I hasten to add I was unable to regenerate that test case -- but was able to write out the verilog for it and see there was no name repetition)