### PR TITLE
flake.nix: add openroad-release attrubute

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,17 @@
           openroad = (nixpkgs.lib.callPackageWith pkgs) ./default.nix {
             flake = self;
           };
+          openroad-release = all.openroad.overrideAttrs (fa: pa: {
+            pname = "openroad-release";
+            version = "24Q3";
+            src = pkgs.fetchFromGitHub {
+              owner = "The-OpenROAD-Project";
+              repo = "OpenROAD";
+              rev = fa.version;
+              fetchSubmodules = true;
+              sha256 = "sha256-Ye9XJcoUxtg031eazT4qrexvyN0jZHd8/kmvAr/lPzk=";
+            };
+          });
           default = all.openroad;
         };
       in


### PR DESCRIPTION
The current `flake.nix` `openroad` attribute can't be imported into other flakes for consumption nor used to install `openroad`. This is due to a limitation in `nix` that doesn't fetch submodules (with the exception of self with '.?submodules=1'). Due to this limitation, peoples using `nix` wanting to install `openroad` have to
1. clone the OpenROAD repository with git
2. use `nix` to build or install `openroad` from the git clone using a special undocumented flag.

Step 2. copies the git source code in the nix store ending up with two copies of a large repo on disk.

 To remedy this we propose to add a second attribute `openroad-release` using `fetchFromGitHub` which is capable to retrieve submodules and pointing to a git commit (tag) known to work. (I tried to compile HEAD with the `nix` flake without success.)

@donn 