### PR TITLE
pdn: Issue an error when -starts_with is used with -followpin in add_pdn_strip.

### DIFF
--- a/src/pdn/README.md
+++ b/src/pdn/README.md
@@ -226,7 +226,7 @@ add_pdn_stripe
 | `[-pitch]` | Value for the distance between each power/ground pair. |
 | `[-snap_to_grid]` | Snap the stripes to the defined routing grid. |
 | `[-spacing]` | Optional specification of the spacing between power/ground pairs within a single pitch (Default: pitch / 2). |
-| `[-starts_with]` | Specifies whether the first strap placed will be POWER or GROUND (Default: grid setting). |
+| `[-starts_with]` | Specifies whether the first strap placed will be POWER or GROUND (Default: grid setting). This cannot be used with -followpins (Flip sites when initializing floorplan to change followpin power/ground order). |
 | `[-width]` | Value for the width of stripe. |
 
 ### Add Sroute Connect

--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -377,8 +377,7 @@ proc add_pdn_stripe { args } {
 
   if { [info exists flags(-followpins)] } {
     if { [info exists keys(-starts_with)] } {
-      utl::error PDN 211 "Option -starts_with cannot be used with -followpins.\
-        Flip sites when initializing floorplan to change followpin power/ground order."
+      utl::warn PDN 211 "Option -starts_with cannot be used with -followpins and will be ignored."
     }
     pdn::make_followpin $grid $layer $width $extend
   } else {

--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -376,6 +376,10 @@ proc add_pdn_stripe { args } {
   }
 
   if { [info exists flags(-followpins)] } {
+    if { [info exists keys(-starts_with)] } {
+      utl::error PDN 211 "Option -starts_with cannot be used with -followpins.\
+        Flip sites when initializing floorplan to change followpin power/ground order."
+    }
     pdn::make_followpin $grid $layer $width $extend
   } else {
     pdn::make_strap \

--- a/src/pdn/test/core_grid_offset_strap.tcl
+++ b/src/pdn/test/core_grid_offset_strap.tcl
@@ -42,8 +42,7 @@ add_pdn_stripe \
   -grid stdcell_grid \
   -layer met1 \
   -width 0.48 \
-  -followpins \
-  -starts_with POWER
+  -followpins
 
 add_pdn_connect \
   -grid stdcell_grid \


### PR DESCRIPTION

Currently it is ignored when -followpin is set. Better issue an error and point to the correct way.