### PR TITLE
drt: Contiguous GC data

### DIFF
--- a/src/drt/src/db/Arena.h
+++ b/src/drt/src/db/Arena.h
@@ -24,18 +24,18 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 #pragma once
 
 #include <vector>
 
 template <typename T>
-struct Arena
+class TypedArena
 {
+ public:
   static const auto BLOCK_SIZE = (std::size_t) 64 * 1024;
 
-  Arena() = default;
-  Arena(const Arena&) = delete;
+  TypedArena() = default;
+  TypedArena(const TypedArena&) = delete;
 
   template <typename... Args>
   T* make(Args&&... args)
@@ -48,5 +48,30 @@ struct Arena
     return &data_.back().back();
   }
 
+ private:
   std::vector<std::vector<T>> data_;
+};
+
+template <typename... Ts>
+class Arena
+{
+};
+
+template <typename T, typename... Ts>
+class Arena<T, Ts...> : public TypedArena<T>, public Arena<Ts...>
+{
+ public:
+  Arena() = default;
+  Arena(const Arena&) = delete;
+
+  template <typename U, typename... Args>
+  U* make(Args&&... args)
+  {
+    return TypedArena<U>::make(args...);
+  }
+};
+
+template <>
+class Arena<>
+{
 };

--- a/src/drt/src/db/gcObj/gcNet.h
+++ b/src/drt/src/db/gcObj/gcNet.h
@@ -75,7 +75,7 @@ class gcNet : public gcBlockObject
       routeRectangles_[layerNum].push_back(rect);
     }
   }
-  void addPin(Arena<gcPin>& pinArena,
+  void addPin(TypedArena<gcPin>& pinArena,
               const gtl::polygon_90_with_holes_data<frCoord>& shape,
               frLayerNum layerNum)
   {
@@ -83,7 +83,7 @@ class gcNet : public gcBlockObject
     pin->setId(pins_[layerNum].size());
     pins_[layerNum].push_back(pin);
   }
-  void addPin(Arena<gcPin>& pinArena,
+  void addPin(TypedArena<gcPin>& pinArena,
               const gtl::rectangle_data<frCoord>& rect,
               frLayerNum layerNum)
   {
@@ -208,7 +208,7 @@ class gcNet : public gcBlockObject
   {
     return nonTaperedRects[z];
   }
-  void addSpecialSpcRect(Arena<gcRect>& rectArena,
+  void addSpecialSpcRect(TypedArena<gcRect>& rectArena,
                          const Rect& bx,
                          frLayerNum lNum,
                          gcPin* pin,

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -2207,8 +2207,8 @@ void FlexDRWorker::modEolCosts_poly(gcNet* net, ModCostType modType)
     if (layer->getType() != dbTechLayerType::ROUTING) {
       continue;
     }
-    for (auto& pin : net->getPins(lNum)) {
-      modEolCosts_poly(pin.get(), layer, modType);
+    for (auto pin : net->getPins(lNum)) {
+      modEolCosts_poly(pin, layer, modType);
     }
   }
 }

--- a/src/drt/src/gc/FlexGC.cpp
+++ b/src/drt/src/gc/FlexGC.cpp
@@ -37,7 +37,7 @@ FlexGCWorker::FlexGCWorker(frTechObject* techIn,
                            RouterConfiguration* router_cfg,
                            FlexDRWorker* drWorkerIn)
     : impl_(
-        std::make_unique<Impl>(techIn, logger, router_cfg, drWorkerIn, this))
+          std::make_unique<Impl>(techIn, logger, router_cfg, drWorkerIn, this))
 {
 }
 
@@ -200,7 +200,7 @@ void FlexGCWorker::setIgnoreLongSideEOL()
   impl_->ignoreLongSideEOL_ = true;
 }
 
-std::vector<std::unique_ptr<gcNet>>& FlexGCWorker::getNets()
+std::vector<gcNet*>& FlexGCWorker::getNets()
 {
   return impl_->getNets();
 }

--- a/src/drt/src/gc/FlexGC.h
+++ b/src/drt/src/gc/FlexGC.h
@@ -30,6 +30,7 @@
 
 #include <memory>
 
+#include "db/Arena.h"
 #include "frDesign.h"
 
 namespace drt {
@@ -63,7 +64,7 @@ class FlexGCWorker
   void setEnableSurgicalFix(bool in);
   void addPAObj(frConnFig* obj, frBlockObject* owner);
   // getters
-  std::vector<std::unique_ptr<gcNet>>& getNets();
+  std::vector<gcNet*>& getNets();
   gcNet* getNet(frNet* net);
   frDesign* getDesign() const;
   const std::vector<std::unique_ptr<frMarker>>& getMarkers() const;

--- a/src/drt/src/gc/FlexGC_cut.cpp
+++ b/src/drt/src/gc/FlexGC_cut.cpp
@@ -660,9 +660,9 @@ void FlexGCWorker::Impl::checkMetalWidthViaTable()
       if (currLayer->getType() != dbTechLayerType::CUT) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        for (auto& maxrect : pin->getMaxRectangles()) {
-          checkMetalWidthViaTable_main(maxrect.get());
+      for (auto pin : targetNet_->getPins(i)) {
+        for (auto maxrect : pin->getMaxRectangles()) {
+          checkMetalWidthViaTable_main(maxrect);
         }
       }
     }
@@ -677,15 +677,15 @@ void FlexGCWorker::Impl::checkMetalWidthViaTable()
       if (currLayer->getType() != dbTechLayerType::CUT) {
         continue;
       }
-      for (auto& net : getNets()) {
+      for (auto net : getNets()) {
         // There is no need to check vias in nets we don't route
         auto fr_net = net->getFrNet();
         if (fr_net && (fr_net->isSpecial() || fr_net->getType().isSupply())) {
           continue;
         }
-        for (auto& pin : net->getPins(i)) {
-          for (auto& maxrect : pin->getMaxRectangles()) {
-            checkMetalWidthViaTable_main(maxrect.get());
+        for (auto pin : net->getPins(i)) {
+          for (auto maxrect : pin->getMaxRectangles()) {
+            checkMetalWidthViaTable_main(maxrect);
           }
         }
       }

--- a/src/drt/src/gc/FlexGC_eol.cpp
+++ b/src/drt/src/gc/FlexGC_eol.cpp
@@ -1295,7 +1295,7 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_main(gcPin* pin)
   bool isVertical = layer->isVertical();
 
   for (auto& edges : pin->getPolygonEdges()) {
-    for (auto& edge : edges) {
+    for (auto edge : edges) {
       if (ignoreLongSideEOL_
           && layer->getLayerNum() > 2 /* above the 1st metal layer */) {
         switch (edge->getDir()) {
@@ -1317,16 +1317,16 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_main(gcPin* pin)
       }
 
       for (auto con : cons) {
-        checkMetalEndOfLine_eol(edge.get(), con);
+        checkMetalEndOfLine_eol(edge, con);
       }
       for (auto con : lef58Cons) {
-        checkMetalEndOfLine_eol(edge.get(), con);
+        checkMetalEndOfLine_eol(edge, con);
       }
       for (auto con : keepoutCons) {
-        checkMetalEOLkeepout_main(edge.get(), con);
+        checkMetalEOLkeepout_main(edge, con);
       }
       for (auto con : extCons) {
-        checkMetalEndOfLine_ext(edge.get(), con);
+        checkMetalEndOfLine_ext(edge, con);
       }
     }
   }
@@ -1345,8 +1345,8 @@ void FlexGCWorker::Impl::checkMetalEndOfLine()
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        checkMetalEndOfLine_main(pin.get());
+      for (auto pin : targetNet_->getPins(i)) {
+        checkMetalEndOfLine_main(pin);
       }
     }
   } else {
@@ -1360,9 +1360,9 @@ void FlexGCWorker::Impl::checkMetalEndOfLine()
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
-          checkMetalEndOfLine_main(pin.get());
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
+          checkMetalEndOfLine_main(pin);
         }
       }
     }

--- a/src/drt/src/gc/FlexGC_impl.h
+++ b/src/drt/src/gc/FlexGC_impl.h
@@ -104,11 +104,10 @@ class FlexGCWorker::Impl
   }
   gcNet* addNet(frBlockObject* owner = nullptr)
   {
-    auto uNet = std::make_unique<gcNet>(getTech()->getLayers().size());
-    auto net = uNet.get();
+    auto net = netArena_.make(getTech()->getLayers().size());
     net->setOwner(owner);
     net->setId(nets_.size());
-    nets_.push_back(std::move(uNet));
+    nets_.push_back(net);
     owner2nets_[owner] = net;
     return net;
   }
@@ -123,7 +122,7 @@ class FlexGCWorker::Impl
   frTechObject* getTech() const { return tech_; }
   FlexDRWorker* getDRWorker() const { return drWorker_; }
   const Rect& getExtBox() const { return extBox_; }
-  std::vector<std::unique_ptr<gcNet>>& getNets() { return nets_; }
+  std::vector<gcNet*>& getNets() { return nets_; }
   // others
   void init(const frDesign* design);
   int main();
@@ -140,12 +139,17 @@ class FlexGCWorker::Impl
   Logger* logger_;
   RouterConfiguration* router_cfg_;
   FlexDRWorker* drWorker_;
+  Arena<gcNet> netArena_;
+  Arena<gcPin> pinArena_;
+  Arena<gcRect> rectArena_;
+  Arena<gcSegment> segmentArena_;
+  Arena<gcCorner> cornerArena_;
 
   Rect extBox_;
   Rect drcBox_;
 
   std::map<frBlockObject*, gcNet*> owner2nets_;  // no order is assumed
-  std::vector<std::unique_ptr<gcNet>> nets_;
+  std::vector<gcNet*> nets_;
 
   std::vector<std::unique_ptr<frMarker>> markers_;
   std::map<MarkerId, frMarker*> mapMarkers_;

--- a/src/drt/src/gc/FlexGC_impl.h
+++ b/src/drt/src/gc/FlexGC_impl.h
@@ -40,6 +40,7 @@ class dbTechLayerCutSpacingTableDefRule;
 }
 
 namespace drt {
+using gcArena = Arena<gcNet, gcPin, gcRect, gcSegment, gcCorner>;
 class FlexGCWorkerRegionQuery
 {
  public:
@@ -104,7 +105,7 @@ class FlexGCWorker::Impl
   }
   gcNet* addNet(frBlockObject* owner = nullptr)
   {
-    auto net = netArena_.make(getTech()->getLayers().size());
+    auto net = gcArena_.make<gcNet>(getTech()->getLayers().size());
     net->setOwner(owner);
     net->setId(nets_.size());
     nets_.push_back(net);
@@ -139,11 +140,7 @@ class FlexGCWorker::Impl
   Logger* logger_;
   RouterConfiguration* router_cfg_;
   FlexDRWorker* drWorker_;
-  Arena<gcNet> netArena_;
-  Arena<gcPin> pinArena_;
-  Arena<gcRect> rectArena_;
-  Arena<gcSegment> segmentArena_;
-  Arena<gcCorner> cornerArena_;
+  gcArena gcArena_;
 
   Rect extBox_;
   Rect drcBox_;

--- a/src/drt/src/gc/FlexGC_inf.cpp
+++ b/src/drt/src/gc/FlexGC_inf.cpp
@@ -209,8 +209,8 @@ void FlexGCWorker::Impl::checkPinMetSpcTblInf(gcPin* pin)
 {
   frLayerNum lNum = pin->getPolygon()->getLayerNum();
   auto con = getTech()->getLayer(lNum)->getSpacingTableInfluence();
-  for (auto& rect : pin->getMaxRectangles()) {
-    checkRectMetSpcTblInf(rect.get(), con);
+  for (auto rect : pin->getMaxRectangles()) {
+    checkRectMetSpcTblInf(rect, con);
   }
 }
 void FlexGCWorker::Impl::checkMetalSpacingTableInfluence()
@@ -228,8 +228,8 @@ void FlexGCWorker::Impl::checkMetalSpacingTableInfluence()
       if (!currLayer->hasSpacingTableInfluence()) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        checkPinMetSpcTblInf(pin.get());
+      for (auto pin : targetNet_->getPins(i)) {
+        checkPinMetSpcTblInf(pin);
       }
     }
   } else {
@@ -246,9 +246,9 @@ void FlexGCWorker::Impl::checkMetalSpacingTableInfluence()
       if (!currLayer->hasSpacingTableInfluence()) {
         continue;
       }
-      for (auto& uNet : getNets()) {
-        for (auto& pin : uNet->getPins(i)) {
-          checkPinMetSpcTblInf(pin.get());
+      for (auto uNet : getNets()) {
+        for (auto pin : uNet->getPins(i)) {
+          checkPinMetSpcTblInf(pin);
         }
       }
     }

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -468,16 +468,16 @@ void FlexGCWorker::Impl::initNet_pins_polygon(gcNet* net)
     layerPolys[i] += net->getPolygons(i, true);
     layerPolys[i].get(polys);
     for (auto& poly : polys) {
-      net->addPin(pinArena_, poly, i);
+      net->addPin(gcArena_, poly, i);
     }
   }
   // init pin from rectangles
   for (int i = 0; i < numLayers; i++) {
     for (auto& rect : net->getRectangles(i, false)) {
-      net->addPin(pinArena_, rect, i);
+      net->addPin(gcArena_, rect, i);
     }
     for (auto& rect : net->getRectangles(i, true)) {
-      net->addPin(pinArena_, rect, i);
+      net->addPin(gcArena_, rect, i);
     }
   }
 }
@@ -566,7 +566,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_outer(
   for (; outerIt != poly->end(); outerIt++) {
     ep = {(*outerIt).x(), (*outerIt).y()};
     ep1 = *outerIt;
-    auto edge = segmentArena_.make();
+    auto edge = gcArena_.make<gcSegment>();
     edge->setLayerNum(i);
     edge->addToPin(pin);
     edge->addToNet(net);
@@ -592,7 +592,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_outer(
     // cntOuter++;
   }
   // last edge
-  auto edge = segmentArena_.make();
+  auto edge = gcArena_.make<gcSegment>();
   edge->setLayerNum(i);
   edge->addToPin(pin);
   edge->addToNet(net);
@@ -640,7 +640,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_inner(
   for (; innerIt != hole_poly.end(); innerIt++) {
     ep = {(*innerIt).x(), (*innerIt).y()};
     ep1 = *innerIt;
-    auto edge = segmentArena_.make();
+    auto edge = gcArena_.make<gcSegment>();
     edge->setLayerNum(i);
     edge->addToPin(pin);
     edge->addToNet(net);
@@ -665,7 +665,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_inner(
     bp1 = ep1;
     // cntInner++;
   }
-  auto edge = segmentArena_.make();
+  auto edge = gcArena_.make<gcSegment>();
   edge->setLayerNum(i);
   edge->addToPin(pin);
   edge->addToNet(net);
@@ -750,7 +750,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonCorners_helper(gcNet* net,
     auto layerNum = prevEdge->getLayerNum();
     gcCorner* prevCorner = nullptr;
     for (auto nextEdge : edges) {
-      auto currCorner = cornerArena_.make();
+      auto currCorner = gcArena_.make<gcCorner>();
       tmpCorners.push_back(currCorner);
       // set edge attributes
       prevEdge->setHighCorner(currCorner);
@@ -877,7 +877,7 @@ void FlexGCWorker::Impl::initNet_pins_maxRectangles_helper(
     frLayerNum i,
     const std::vector<std::set<std::pair<Point, Point>>>& fixedMaxRectangles)
 {
-  auto rectangle = rectArena_.make();
+  auto rectangle = gcArena_.make<gcRect>();
   rectangle->setRect(rect);
   rectangle->setLayerNum(i);
   rectangle->addToPin(pin);
@@ -900,7 +900,7 @@ void FlexGCWorker::Impl::initNet_pins_maxRectangles_helper(
         for (auto& nt : net->getNonTaperedRects(k)) {
           if (rectangle->intersects(nt)) {
             net->addSpecialSpcRect(
-                rectArena_, nt, i, rectangle->getPin(), rectangle->getNet());
+                gcArena_, nt, i, rectangle->getPin(), rectangle->getNet());
           }
         }
         break;

--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -889,30 +889,29 @@ void FlexGCWorker::Impl::checkMetalSpacing()
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
+      for (auto pin : targetNet_->getPins(i)) {
         if (currLayer->hasLef58SpacingWrongDirConstraints()) {
-          checkMetalSpacing_wrongDir(pin.get(), currLayer);
+          checkMetalSpacing_wrongDir(pin, currLayer);
         }
-        for (auto& maxrect : pin->getMaxRectangles()) {
+        for (auto maxrect : pin->getMaxRectangles()) {
           checkMetalSpacing_main(
-              maxrect.get(),
-              getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS);
+              maxrect, getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS);
           if (currLayer->hasTwoWiresForbiddenSpacingConstraints()) {
             for (auto con :
                  currLayer->getTwoWiresForbiddenSpacingConstraints()) {
-              checkTwoWiresForbiddenSpc_main(maxrect.get(), con);
+              checkTwoWiresForbiddenSpc_main(maxrect, con);
             }
           }
           if (currLayer->hasForbiddenSpacingConstraints()) {
             for (auto con : currLayer->getForbiddenSpacingConstraints()) {
-              checkForbiddenSpc_main(maxrect.get(), con);
+              checkForbiddenSpc_main(maxrect, con);
             }
           }
         }
       }
       for (auto& sr : targetNet_->getSpecialSpcRects()) {
         checkMetalSpacing_main(
-            sr.get(), getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS, true);
+            sr, getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS, true);
       }
     }
   } else {
@@ -926,34 +925,31 @@ void FlexGCWorker::Impl::checkMetalSpacing()
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
           if (currLayer->hasLef58SpacingWrongDirConstraints()) {
-            checkMetalSpacing_wrongDir(pin.get(), currLayer);
+            checkMetalSpacing_wrongDir(pin, currLayer);
           }
-          for (auto& maxrect : pin->getMaxRectangles()) {
+          for (auto maxrect : pin->getMaxRectangles()) {
             // Short, NSMetal, metSpc
             checkMetalSpacing_main(
-                maxrect.get(),
-                getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS);
+                maxrect, getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS);
             if (currLayer->hasTwoWiresForbiddenSpacingConstraints()) {
               for (auto con :
                    currLayer->getTwoWiresForbiddenSpacingConstraints()) {
-                checkTwoWiresForbiddenSpc_main(maxrect.get(), con);
+                checkTwoWiresForbiddenSpc_main(maxrect, con);
               }
             }
             if (currLayer->hasForbiddenSpacingConstraints()) {
               for (auto con : currLayer->getForbiddenSpacingConstraints()) {
-                checkForbiddenSpc_main(maxrect.get(), con);
+                checkForbiddenSpc_main(maxrect, con);
               }
             }
           }
         }
         for (auto& sr : net->getSpecialSpcRects()) {
           checkMetalSpacing_main(
-              sr.get(),
-              getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS,
-              true);
+              sr, getDRWorker() || !router_cfg_->AUTO_TAPER_NDR_NETS, true);
         }
       }
     }
@@ -1037,7 +1033,7 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
     auto spcVal = rule->getWrongdirSpace();
     // Loop over all edges of pin
     for (auto& edges : pin->getPolygonEdges()) {
-      for (auto& edge : edges) {
+      for (auto edge : edges) {
         // Check wrongDir edge
         if (edge->isVertical() != layer->isVertical()) {
           // Check noneol flag
@@ -1054,14 +1050,14 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
                                              edge->getHighCorner()->x(),
                                              edge->getHighCorner()->y());
           box_t queryBox;
-          checkMetalSpacing_wrongDir_getQueryBox(edge.get(), spcVal, queryBox);
+          checkMetalSpacing_wrongDir_getQueryBox(edge, spcVal, queryBox);
           std::vector<std::pair<segment_t, gcSegment*>> results;
           auto& workerRegionQuery = getWorkerRegionQuery();
           workerRegionQuery.queryPolygonEdge(queryBox, layerNum, results);
           for (auto& [boostSeg, ptr] : results) {
             // Check query edge wrongDir
             if (ptr->isVertical() != layer->isVertical()) {
-              if (edge.get() == ptr) {
+              if (edge == ptr) {
                 continue;
               }
 
@@ -1072,7 +1068,7 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
 
               // Get edges prl
               const gtl::orientation_2d orient = edge->getOrientation();
-              const frCoord prl = getPrl(edge.get(), ptr, orient);
+              const frCoord prl = getPrl(edge, ptr, orient);
               // Check PRL branch
               auto prlLength = rule->getPrlLength();
               if (prl <= prlLength) {
@@ -1388,15 +1384,15 @@ void FlexGCWorker::Impl::checkMetalCornerSpacing()
               && currLayer->getWidthTblOrthCon() == nullptr)) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
+      for (auto pin : targetNet_->getPins(i)) {
         for (auto& corners : pin->getPolygonCorners()) {
-          for (auto& corner : corners) {
+          for (auto corner : corners) {
             // LEF58 corner spacing
             if (currLayer->hasLef58CornerSpacingConstraint()) {
-              checkMetalCornerSpacing_main(corner.get());
+              checkMetalCornerSpacing_main(corner);
             }
             if (currLayer->getWidthTblOrthCon()) {
-              checkWidthTableOrth(corner.get());
+              checkWidthTableOrth(corner);
             }
           }
         }
@@ -1415,16 +1411,16 @@ void FlexGCWorker::Impl::checkMetalCornerSpacing()
               && currLayer->getWidthTblOrthCon() == nullptr)) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
           for (auto& corners : pin->getPolygonCorners()) {
-            for (auto& corner : corners) {
+            for (auto corner : corners) {
               // LEF58 corner spacing
               if (currLayer->hasLef58CornerSpacingConstraint()) {
-                checkMetalCornerSpacing_main(corner.get());
+                checkMetalCornerSpacing_main(corner);
               }
               if (currLayer->getWidthTblOrthCon()) {
-                checkWidthTableOrth(corner.get());
+                checkWidthTableOrth(corner);
               }
             }
           }
@@ -1646,7 +1642,7 @@ void FlexGCWorker::Impl::checkMetalShape_minArea(gcPin* pin)
     return;
   }
   for (auto& edges : pin->getPolygonEdges()) {
-    for (auto& edge : edges) {
+    for (auto edge : edges) {
       if (edge->isFixed()) {
         return;
       }
@@ -1673,9 +1669,9 @@ void FlexGCWorker::Impl::checkMetalShape_lef58MinStep_noBetweenEol(
   auto eolWidth = con->getEolWidth();
   for (auto& edges : pin->getPolygonEdges()) {
     // get the first edge that is >= minstep length
-    for (auto& e : edges) {
+    for (auto e : edges) {
       if (gtl::length(*e) < minStepLength) {
-        startEdges.push_back(e.get());
+        startEdges.push_back(e);
       }
     }
   }
@@ -1768,9 +1764,9 @@ void FlexGCWorker::Impl::checkMetalShape_lef58MinStep_minAdjLength(
   auto minStepLength = con->getMinStepLength();
   for (auto& edges : pin->getPolygonEdges()) {
     // get the first edge that is >= minstep length
-    for (auto& e : edges) {
+    for (auto e : edges) {
       if (gtl::length(*e) < minStepLength) {
-        startEdges.push_back(e.get());
+        startEdges.push_back(e);
       }
     }
   }
@@ -1870,9 +1866,9 @@ void FlexGCWorker::Impl::checkMetalShape_minStep(gcPin* pin)
   for (auto& edges : pin->getPolygonEdges()) {
     // get the first edge that is >= minstep length
     firste = nullptr;
-    for (auto& e : edges) {
+    for (auto e : edges) {
       if (gtl::length(*e) >= minStepLength) {
-        firste = e.get();
+        firste = e;
         break;
       }
     }
@@ -1967,8 +1963,8 @@ void FlexGCWorker::Impl::checkMetalShape_rectOnly(gcPin* pin)
   std::vector<gtl::point_data<frCoord>> concaveCorners;
   // get concave corners of the polygon
   for (auto& edges : pin->getPolygonEdges()) {
-    for (auto& edge : edges) {
-      auto currEdge = edge.get();
+    for (auto edge : edges) {
+      auto currEdge = edge;
       auto nextEdge = currEdge->getNextEdge();
       if (orientation(*currEdge, *nextEdge) == -1) {
         concaveCorners.push_back(boost::polygon::high(*currEdge));
@@ -2019,8 +2015,7 @@ void FlexGCWorker::Impl::checkMetalShape_offGrid(gcPin* pin)
   // Needs to be signed to make modulo work correctly with
   // negative coordinates
   int mGrid = getTech()->getManufacturingGrid();
-  for (auto& rect : pin->getMaxRectangles()) {
-    auto maxRect = rect.get();
+  for (auto maxRect : pin->getMaxRectangles()) {
     auto layerNum = maxRect->getLayerNum();
     // off grid maxRect
     if (gtl::xl(*maxRect) % mGrid || gtl::xh(*maxRect) % mGrid
@@ -2140,7 +2135,7 @@ void FlexGCWorker::Impl::checkMetalShape_lef58Area(gcPin* pin)
       continue;
     }
     for (auto& edges : pin->getPolygonEdges()) {
-      for (auto& edge : edges) {
+      for (auto edge : edges) {
         if (edge->isFixed()) {
           continue;
         }
@@ -2257,10 +2252,10 @@ void FlexGCWorker::Impl::checkMetalShape_addPatch(gcPin* pin, int min_area)
   gcSegment* chosenEdg = nullptr;
   // traverse polygon edges, searching for the best edge to amend a patch
   for (auto& edges : pin->getPolygonEdges()) {
-    for (auto& e : edges) {
+    for (auto e : edges) {
       if (e->isVertical() != prefDirIsVert
-          && (!chosenEdg || bestSuitable(e.get(), chosenEdg) == e.get())) {
-        chosenEdg = e.get();
+          && (!chosenEdg || bestSuitable(e, chosenEdg) == e)) {
+        chosenEdg = e;
       }
     }
   }
@@ -2418,8 +2413,8 @@ void FlexGCWorker::Impl::checkMetalShape(bool allow_patching)
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        checkMetalShape_main(pin.get(), allow_patching);
+      for (auto pin : targetNet_->getPins(i)) {
+        checkMetalShape_main(pin, allow_patching);
       }
     }
   } else {
@@ -2433,9 +2428,9 @@ void FlexGCWorker::Impl::checkMetalShape(bool allow_patching)
       if (currLayer->getType() != dbTechLayerType::ROUTING) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
-          checkMetalShape_main(pin.get(), allow_patching);
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
+          checkMetalShape_main(pin, allow_patching);
         }
       }
     }
@@ -3644,10 +3639,10 @@ void FlexGCWorker::Impl::checkCutSpacing()
       if (currLayer->getType() != dbTechLayerType::CUT) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        for (auto& maxrect : pin->getMaxRectangles()) {
-          checkCutSpacing_main(maxrect.get());
-          checkLef58Enclosure_main(maxrect.get());
+      for (auto pin : targetNet_->getPins(i)) {
+        for (auto maxrect : pin->getMaxRectangles()) {
+          checkCutSpacing_main(maxrect);
+          checkLef58Enclosure_main(maxrect);
         }
       }
     }
@@ -3662,11 +3657,11 @@ void FlexGCWorker::Impl::checkCutSpacing()
       if (currLayer->getType() != dbTechLayerType::CUT) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
-          for (auto& maxrect : pin->getMaxRectangles()) {
-            checkCutSpacing_main(maxrect.get());
-            checkLef58Enclosure_main(maxrect.get());
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
+          for (auto maxrect : pin->getMaxRectangles()) {
+            checkCutSpacing_main(maxrect);
+            checkLef58Enclosure_main(maxrect);
           }
         }
       }
@@ -4030,9 +4025,9 @@ void FlexGCWorker::Impl::checkMinimumCut()
       if (!currLayer->hasMinimumcut()) {
         continue;
       }
-      for (auto& pin : targetNet_->getPins(i)) {
-        for (auto& maxrect : pin->getMaxRectangles()) {
-          checkMinimumCut_main(maxrect.get());
+      for (auto pin : targetNet_->getPins(i)) {
+        for (auto maxrect : pin->getMaxRectangles()) {
+          checkMinimumCut_main(maxrect);
         }
       }
     }
@@ -4050,10 +4045,10 @@ void FlexGCWorker::Impl::checkMinimumCut()
       if (!currLayer->hasMinimumcut()) {
         continue;
       }
-      for (auto& net : getNets()) {
-        for (auto& pin : net->getPins(i)) {
-          for (auto& maxrect : pin->getMaxRectangles()) {
-            checkMinimumCut_main(maxrect.get());
+      for (auto net : getNets()) {
+        for (auto pin : net->getPins(i)) {
+          for (auto maxrect : pin->getMaxRectangles()) {
+            checkMinimumCut_main(maxrect);
           }
         }
       }

--- a/src/drt/src/gc/FlexGC_rq.cpp
+++ b/src/drt/src/gc/FlexGC_rq.cpp
@@ -208,21 +208,21 @@ void FlexGCWorkerRegionQuery::Impl::init(int numLayers)
   std::vector<std::vector<rq_box_value_t<gcRect*>>> allMaxRectangles(numLayers);
   std::vector<std::vector<rq_box_value_t<gcRect>>> allSpcRectangles(numLayers);
 
-  for (auto& net : gcWorker_->getNets()) {
+  for (auto net : gcWorker_->getNets()) {
     for (auto& pins : net->getPins()) {
-      for (auto& pin : pins) {
+      for (auto pin : pins) {
         for (auto& edges : pin->getPolygonEdges()) {
-          for (auto& edge : edges) {
-            addPolygonEdge(edge.get(), allPolygonEdges);
+          for (auto edge : edges) {
+            addPolygonEdge(edge, allPolygonEdges);
           }
         }
-        for (auto& rect : pin->getMaxRectangles()) {
-          addMaxRectangle(rect.get(), allMaxRectangles);
+        for (auto rect : pin->getMaxRectangles()) {
+          addMaxRectangle(rect, allMaxRectangles);
         }
       }
     }
-    for (auto& spcRect : net->getSpecialSpcRects()) {
-      addSpcRectangle(spcRect.get(), allSpcRectangles);
+    for (auto spcRect : net->getSpecialSpcRects()) {
+      addSpcRectangle(spcRect, allSpcRectangles);
     }
   }
 
@@ -237,38 +237,38 @@ void FlexGCWorkerRegionQuery::Impl::init(int numLayers)
 void FlexGCWorkerRegionQuery::addToRegionQuery(gcNet* net)
 {
   for (auto& pins : net->getPins()) {
-    for (auto& pin : pins) {
+    for (auto pin : pins) {
       for (auto& edges : pin->getPolygonEdges()) {
-        for (auto& edge : edges) {
-          addPolygonEdge(edge.get());
+        for (auto edge : edges) {
+          addPolygonEdge(edge);
         }
       }
-      for (auto& rect : pin->getMaxRectangles()) {
-        addMaxRectangle(rect.get());
+      for (auto rect : pin->getMaxRectangles()) {
+        addMaxRectangle(rect);
       }
     }
   }
-  for (auto& spcR : net->getSpecialSpcRects()) {
-    addSpcRectangle(spcR.get());
+  for (auto spcR : net->getSpecialSpcRects()) {
+    addSpcRectangle(spcR);
   }
 }
 
 void FlexGCWorkerRegionQuery::removeFromRegionQuery(gcNet* net)
 {
   for (auto& pins : net->getPins()) {
-    for (auto& pin : pins) {
+    for (auto pin : pins) {
       for (auto& edges : pin->getPolygonEdges()) {
-        for (auto& edge : edges) {
-          removePolygonEdge(edge.get());
+        for (auto edge : edges) {
+          removePolygonEdge(edge);
         }
       }
-      for (auto& rect : pin->getMaxRectangles()) {
-        removeMaxRectangle(rect.get());
+      for (auto rect : pin->getMaxRectangles()) {
+        removeMaxRectangle(rect);
       }
     }
   }
-  for (auto& spcR : net->getSpecialSpcRects()) {
-    removeSpcRectangle(spcR.get());
+  for (auto spcR : net->getSpecialSpcRects()) {
+    removeSpcRectangle(spcR);
   }
 }
 

--- a/src/drt/src/rp/FlexRP.h
+++ b/src/drt/src/rp/FlexRP.h
@@ -30,6 +30,8 @@
 
 #include <boost/icl/interval_set.hpp>
 
+#include "db/Arena.h"
+#include "db/gcObj/gcShape.h"
 #include "frDesign.h"
 
 namespace drt {
@@ -160,5 +162,6 @@ class FlexRP
   frTechObject* tech_;
   Logger* logger_;
   RouterConfiguration* router_cfg_;
+  Arena<gcSegment> segment_arena_;
 };
 }  // namespace drt

--- a/src/drt/src/rp/FlexRP.h
+++ b/src/drt/src/rp/FlexRP.h
@@ -162,6 +162,6 @@ class FlexRP
   frTechObject* tech_;
   Logger* logger_;
   RouterConfiguration* router_cfg_;
-  Arena<gcSegment> segment_arena_;
+  Arena<gcSegment> arena_;
 };
 }  // namespace drt

--- a/src/drt/src/rp/FlexRP_prep.cpp
+++ b/src/drt/src/rp/FlexRP_prep.cpp
@@ -100,45 +100,45 @@ void FlexRP::prep_minStepViasCheck()
     }
 
     gtl::polygon_90_with_holes_data<frCoord> poly = *polys.begin();
-    std::unique_ptr<gcNet> uTestNet = std::make_unique<gcNet>(0);
-    gcNet* testNet = uTestNet.get();
-    auto uTestPin = std::make_unique<gcPin>(poly, lNum, testNet);
-    gcPin* testPin = uTestPin.get();
+    gcNet uTestNet(0);
+    gcNet* testNet = &uTestNet;
+    gcPin uTestPin(poly, lNum, testNet);
+    gcPin* testPin = &uTestPin;
     testPin->setNet(testNet);
 
     bool first = true;
-    std::vector<std::unique_ptr<gcSegment>> tmpEdges;
+    std::vector<gcSegment*> tmpEdges;
     gtl::point_data<frCoord> prev;
     for (const gtl::point_data<frCoord>& cur : poly) {
       if (first) {
         prev = cur;
         first = false;
       } else {
-        auto edge = std::make_unique<gcSegment>();
+        auto edge = segment_arena_.make();
         edge->setLayerNum(lNum);
         edge->addToPin(testPin);
         edge->addToNet(testNet);
         edge->setSegment(prev, cur);
         if (!tmpEdges.empty()) {
-          edge->setPrevEdge(tmpEdges.back().get());
-          tmpEdges.back()->setNextEdge(edge.get());
+          edge->setPrevEdge(tmpEdges.back());
+          tmpEdges.back()->setNextEdge(edge);
         }
-        tmpEdges.push_back(std::move(edge));
+        tmpEdges.push_back(edge);
         prev = cur;
       }
     }
     // last edge
-    auto edge = std::make_unique<gcSegment>();
+    auto edge = segment_arena_.make();
     edge->setLayerNum(lNum);
     edge->addToPin(testPin);
     edge->addToNet(testNet);
     edge->setSegment(prev, *poly.begin());
-    edge->setPrevEdge(tmpEdges.back().get());
-    tmpEdges.back()->setNextEdge(edge.get());
+    edge->setPrevEdge(tmpEdges.back());
+    tmpEdges.back()->setNextEdge(edge);
     // set first edge
-    tmpEdges.front()->setPrevEdge(edge.get());
-    edge->setNextEdge(tmpEdges.front().get());
-    tmpEdges.push_back(std::move(edge));
+    tmpEdges.front()->setPrevEdge(edge);
+    edge->setNextEdge(tmpEdges.front());
+    tmpEdges.push_back(edge);
     // add to polygon edges
     testPin->addPolygonEdges(tmpEdges);
     // check gc minstep violations
@@ -771,46 +771,45 @@ bool FlexRP::hasMinStepViol(const Rect& r1,
   }
 
   gtl::polygon_90_with_holes_data<frCoord> poly = *polys.begin();
-  std::unique_ptr<gcNet> uTestNet = std::make_unique<gcNet>(0);
-  gcNet* testNet = uTestNet.get();
-  std::unique_ptr<gcPin> uTestPin
-      = std::make_unique<gcPin>(poly, lNum, testNet);
-  gcPin* testPin = uTestPin.get();
+  gcNet uTestNet(0);
+  gcNet* testNet = &uTestNet;
+  gcPin uTestPin(poly, lNum, testNet);
+  gcPin* testPin = &uTestPin;
   testPin->setNet(testNet);
 
   bool first = true;
-  std::vector<std::unique_ptr<gcSegment>> tmpEdges;
+  std::vector<gcSegment*> tmpEdges;
   gtl::point_data<frCoord> prev;
   for (const gtl::point_data<frCoord>& cur : poly) {
     if (first) {
       prev = cur;
       first = false;
     } else {
-      auto edge = std::make_unique<gcSegment>();
+      auto edge = segment_arena_.make();
       edge->setLayerNum(lNum);
       edge->addToPin(testPin);
       edge->addToNet(testNet);
       edge->setSegment(prev, cur);
       if (!tmpEdges.empty()) {
-        edge->setPrevEdge(tmpEdges.back().get());
-        tmpEdges.back()->setNextEdge(edge.get());
+        edge->setPrevEdge(tmpEdges.back());
+        tmpEdges.back()->setNextEdge(edge);
       }
-      tmpEdges.push_back(std::move(edge));
+      tmpEdges.push_back(edge);
       prev = cur;
     }
   }
   // last edge
-  auto edge = std::make_unique<gcSegment>();
+  auto edge = segment_arena_.make();
   edge->setLayerNum(lNum);
   edge->addToPin(testPin);
   edge->addToNet(testNet);
   edge->setSegment(prev, *poly.begin());
-  edge->setPrevEdge(tmpEdges.back().get());
-  tmpEdges.back()->setNextEdge(edge.get());
+  edge->setPrevEdge(tmpEdges.back());
+  tmpEdges.back()->setNextEdge(edge);
   // set first edge
-  tmpEdges.front()->setPrevEdge(edge.get());
-  edge->setNextEdge(tmpEdges.front().get());
-  tmpEdges.push_back(std::move(edge));
+  tmpEdges.front()->setPrevEdge(edge);
+  edge->setNextEdge(tmpEdges.front());
+  tmpEdges.push_back(edge);
   // add to polygon edges
   testPin->addPolygonEdges(tmpEdges);
   // check gc minstep violations

--- a/src/drt/src/rp/FlexRP_prep.cpp
+++ b/src/drt/src/rp/FlexRP_prep.cpp
@@ -114,7 +114,7 @@ void FlexRP::prep_minStepViasCheck()
         prev = cur;
         first = false;
       } else {
-        auto edge = segment_arena_.make();
+        auto edge = arena_.make<gcSegment>();
         edge->setLayerNum(lNum);
         edge->addToPin(testPin);
         edge->addToNet(testNet);
@@ -128,7 +128,7 @@ void FlexRP::prep_minStepViasCheck()
       }
     }
     // last edge
-    auto edge = segment_arena_.make();
+    auto edge = arena_.make<gcSegment>();
     edge->setLayerNum(lNum);
     edge->addToPin(testPin);
     edge->addToNet(testNet);
@@ -785,7 +785,7 @@ bool FlexRP::hasMinStepViol(const Rect& r1,
       prev = cur;
       first = false;
     } else {
-      auto edge = segment_arena_.make();
+      auto edge = arena_.make<gcSegment>();
       edge->setLayerNum(lNum);
       edge->addToPin(testPin);
       edge->addToNet(testNet);
@@ -799,7 +799,7 @@ bool FlexRP::hasMinStepViol(const Rect& r1,
     }
   }
   // last edge
-  auto edge = segment_arena_.make();
+  auto edge = arena_.make<gcSegment>();
   edge->setLayerNum(lNum);
   edge->addToPin(testPin);
   edge->addToNet(testNet);


### PR DESCRIPTION
Store some of the GC data in contiguous arrays. The last commit is to ensure no one pushes to these vectors, as other code references this data via pointers, so we cannot invalidate them.

### `asap7/aes`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| baseline | 400.30 | 401.20 | 400.77 ± 0.27 | 1.03 | 400.83 | 1.03 |
| `drt-contiguous-gc` | 390.57 | 390.82 | 390.66 ± 0.08 | 1.00 | 390.63 | 1.00 |

### `asap7/ibex`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| baseline | 570.74 | 571.73 | 571.13 ± 0.31 | 1.03 | 571.08 | 1.03 |
| `drt-contiguous-gc` | 555.77 | 557.53 | 556.71 ± 0.50 | 1.00 | 556.69 | 1.00 |