### PR TITLE
gui: use base descriptor class to remove duplicated code for lessThan, makeSelected, and populateODBProps

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1562,7 +1562,7 @@ Descriptor::Actions DbNetDescriptor::getActions(std::any object) const
 
 Selected DbNetDescriptor::makeSelected(std::any object) const
 {
-  const auto net_selected = BaseDbDescriptor::makeSelected(object);
+  Selected net_selected = BaseDbDescriptor::makeSelected(object);
   if (net_selected) {
     return net_selected;
   }
@@ -3792,7 +3792,7 @@ Descriptor::Properties DbSiteDescriptor::getDBProperties(
 
 Selected DbSiteDescriptor::makeSelected(std::any object) const
 {
-  const auto site_selected = BaseDbDescriptor::makeSelected(object);
+  Selected site_selected = BaseDbDescriptor::makeSelected(object);
   if (site_selected) {
     return site_selected;
   }

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -52,7 +52,25 @@ namespace gui {
 
 // Descriptor classes for OpenDB objects.  Eventually these should
 // become part of the database code generation.
-class DbTechDescriptor : public Descriptor
+template <typename T>
+class BaseDbDescriptor : public Descriptor
+{
+ public:
+  BaseDbDescriptor(odb::dbDatabase* db);
+
+  virtual Properties getProperties(std::any object) const override;
+
+  virtual Selected makeSelected(std::any object) const override;
+  virtual bool lessThan(std::any l, std::any r) const override;
+
+ protected:
+  odb::dbDatabase* db_;
+
+  virtual T* getObject(const std::any& object) const;
+  virtual Properties getDBProperties(T* object) const = 0;
+};
+
+class DbTechDescriptor : public BaseDbDescriptor<odb::dbTech>
 {
  public:
   DbTechDescriptor(odb::dbDatabase* db);
@@ -63,17 +81,13 @@ class DbTechDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTech* tech) const override;
 };
 
-class DbBlockDescriptor : public Descriptor
+class DbBlockDescriptor : public BaseDbDescriptor<odb::dbBlock>
 {
  public:
   DbBlockDescriptor(odb::dbDatabase* db);
@@ -84,17 +98,13 @@ class DbBlockDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbBlock* block) const override;
 };
 
-class DbInstDescriptor : public Descriptor
+class DbInstDescriptor : public BaseDbDescriptor<odb::dbInst>
 {
  public:
   DbInstDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
@@ -107,13 +117,13 @@ class DbInstDescriptor : public Descriptor
 
   bool isInst(std::any object) const override;
 
-  Properties getProperties(std::any object) const override;
   Actions getActions(std::any object) const override;
   Editors getEditors(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
+
+ protected:
+  Properties getDBProperties(odb::dbInst* inst) const override;
 
  private:
   void makeMasterOptions(odb::dbMaster* master,
@@ -124,11 +134,10 @@ class DbInstDescriptor : public Descriptor
                       const std::any& value,
                       bool is_x) const;
 
-  odb::dbDatabase* db_;
   sta::dbSta* sta_;
 };
 
-class DbMasterDescriptor : public Descriptor
+class DbMasterDescriptor : public BaseDbDescriptor<odb::dbMaster>
 {
  public:
   DbMasterDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
@@ -139,24 +148,22 @@ class DbMasterDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
   static void getMasterEquivalent(sta::dbSta* sta,
                                   odb::dbMaster* master,
                                   std::set<odb::dbMaster*>& masters);
 
+ protected:
+  Properties getDBProperties(odb::dbMaster* master) const override;
+
  private:
   void getInstances(odb::dbMaster* master, std::set<odb::dbInst*>& insts) const;
 
-  odb::dbDatabase* db_;
   sta::dbSta* sta_;
 };
 
-class DbNetDescriptor : public Descriptor
+class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
 {
  public:
   struct NetWithSink
@@ -180,16 +187,17 @@ class DbNetDescriptor : public Descriptor
 
   bool isNet(std::any object) const override;
 
-  Properties getProperties(std::any object) const override;
   Editors getEditors(std::any object) const override;
   Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Selected makeSelected(std::any obj) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
 
+ protected:
+  odb::dbNet* getObject(const std::any& object) const override;
+  Properties getDBProperties(odb::dbNet* net) const override;
+
  private:
-  odb::dbDatabase* db_;
   sta::dbSta* sta_;
 
   using Node = odb::dbWireGraph::Node;
@@ -220,13 +228,12 @@ class DbNetDescriptor : public Descriptor
   const std::set<odb::dbNet*>& guide_nets_;
   const std::set<odb::dbNet*>& tracks_nets_;
 
-  odb::dbNet* getNet(const std::any& object) const;
   odb::dbObject* getSink(const std::any& object) const;
 
   static const int max_iterms_ = 10000;
 };
 
-class DbITermDescriptor : public Descriptor
+class DbITermDescriptor : public BaseDbDescriptor<odb::dbITerm>
 {
  public:
   DbITermDescriptor(odb::dbDatabase* db,
@@ -239,19 +246,18 @@ class DbITermDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
   Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
 
+ protected:
+  Properties getDBProperties(odb::dbITerm* iterm) const override;
+
  private:
-  odb::dbDatabase* db_;
   std::function<bool(void)> usingPolyDecompView_;
 };
 
-class DbBTermDescriptor : public Descriptor
+class DbBTermDescriptor : public BaseDbDescriptor<odb::dbBTerm>
 {
  public:
   DbBTermDescriptor(odb::dbDatabase* db);
@@ -262,19 +268,16 @@ class DbBTermDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
   Editors getEditors(std::any object) const override;
   Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbBTerm* bterm) const override;
 };
 
-class DbBPinDescriptor : public Descriptor
+class DbBPinDescriptor : public BaseDbDescriptor<odb::dbBPin>
 {
  public:
   DbBPinDescriptor(odb::dbDatabase* db);
@@ -285,17 +288,13 @@ class DbBPinDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbBPin* bpin) const override;
 };
 
-class DbMTermDescriptor : public Descriptor
+class DbMTermDescriptor : public BaseDbDescriptor<odb::dbMTerm>
 {
  public:
   DbMTermDescriptor(odb::dbDatabase* db,
@@ -308,18 +307,16 @@ class DbMTermDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
+ protected:
+  Properties getDBProperties(odb::dbMTerm* mterm) const override;
+
  private:
-  odb::dbDatabase* db_;
   std::function<bool(void)> usingPolyDecompView_;
 };
 
-class DbViaDescriptor : public Descriptor
+class DbViaDescriptor : public BaseDbDescriptor<odb::dbVia>
 {
  public:
   DbViaDescriptor(odb::dbDatabase* db);
@@ -330,17 +327,13 @@ class DbViaDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbVia* via) const override;
 };
 
-class DbBlockageDescriptor : public Descriptor
+class DbBlockageDescriptor : public BaseDbDescriptor<odb::dbBlockage>
 {
  public:
   DbBlockageDescriptor(odb::dbDatabase* db);
@@ -351,18 +344,15 @@ class DbBlockageDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
   Editors getEditors(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbBlockage* blockage) const override;
 };
 
-class DbObstructionDescriptor : public Descriptor
+class DbObstructionDescriptor : public BaseDbDescriptor<odb::dbObstruction>
 {
  public:
   DbObstructionDescriptor(odb::dbDatabase* db);
@@ -373,18 +363,15 @@ class DbObstructionDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
   Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
 
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbObstruction* obs) const override;
 };
 
-class DbTechLayerDescriptor : public Descriptor
+class DbTechLayerDescriptor : public BaseDbDescriptor<odb::dbTechLayer>
 {
  public:
   DbTechLayerDescriptor(odb::dbDatabase* db);
@@ -395,14 +382,10 @@ class DbTechLayerDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechLayer* layer) const override;
 };
 
 // The ap doesn't know its location as it is associated the master and
@@ -443,7 +426,7 @@ class DbTermAccessPointDescriptor : public Descriptor
   odb::dbDatabase* db_;
 };
 
-class DbGroupDescriptor : public Descriptor
+class DbGroupDescriptor : public BaseDbDescriptor<odb::dbGroup>
 {
  public:
   DbGroupDescriptor(odb::dbDatabase* db);
@@ -454,17 +437,13 @@ class DbGroupDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbGroup* group) const override;
 };
 
-class DbRegionDescriptor : public Descriptor
+class DbRegionDescriptor : public BaseDbDescriptor<odb::dbRegion>
 {
  public:
   DbRegionDescriptor(odb::dbDatabase* db);
@@ -475,17 +454,13 @@ class DbRegionDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbRegion* region) const override;
 };
 
-class DbModuleDescriptor : public Descriptor
+class DbModuleDescriptor : public BaseDbDescriptor<odb::dbModule>
 {
  public:
   DbModuleDescriptor(odb::dbDatabase* db);
@@ -497,19 +472,16 @@ class DbModuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbModule* module) const override;
 
+ private:
   void getModules(odb::dbModule* module, SelectionSet& objects) const;
 };
 
-class DbTechViaDescriptor : public Descriptor
+class DbTechViaDescriptor : public BaseDbDescriptor<odb::dbTechVia>
 {
  public:
   DbTechViaDescriptor(odb::dbDatabase* db);
@@ -521,17 +493,13 @@ class DbTechViaDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechVia* via) const override;
 };
 
-class DbTechViaRuleDescriptor : public Descriptor
+class DbTechViaRuleDescriptor : public BaseDbDescriptor<odb::dbTechViaRule>
 {
  public:
   DbTechViaRuleDescriptor(odb::dbDatabase* db);
@@ -543,17 +511,14 @@ class DbTechViaRuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechViaRule* via_rule) const override;
 };
 
-class DbTechViaLayerRuleDescriptor : public Descriptor
+class DbTechViaLayerRuleDescriptor
+    : public BaseDbDescriptor<odb::dbTechViaLayerRule>
 {
  public:
   DbTechViaLayerRuleDescriptor(odb::dbDatabase*);
@@ -565,17 +530,15 @@ class DbTechViaLayerRuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(
+      odb::dbTechViaLayerRule* via_layer_rule) const override;
 };
 
-class DbMetalWidthViaMapDescriptor : public Descriptor
+class DbMetalWidthViaMapDescriptor
+    : public BaseDbDescriptor<odb::dbMetalWidthViaMap>
 {
  public:
   DbMetalWidthViaMapDescriptor(odb::dbDatabase* db);
@@ -587,17 +550,14 @@ class DbMetalWidthViaMapDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbMetalWidthViaMap* via_map) const override;
 };
 
-class DbGenerateViaDescriptor : public Descriptor
+class DbGenerateViaDescriptor
+    : public BaseDbDescriptor<odb::dbTechViaGenerateRule>
 {
  public:
   DbGenerateViaDescriptor(odb::dbDatabase* db);
@@ -609,17 +569,14 @@ class DbGenerateViaDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechViaGenerateRule* via) const override;
 };
 
-class DbNonDefaultRuleDescriptor : public Descriptor
+class DbNonDefaultRuleDescriptor
+    : public BaseDbDescriptor<odb::dbTechNonDefaultRule>
 {
  public:
   DbNonDefaultRuleDescriptor(odb::dbDatabase* db);
@@ -631,19 +588,17 @@ class DbNonDefaultRuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechNonDefaultRule* rule) const override;
 };
 
-class DbTechLayerRuleDescriptor : public Descriptor
+class DbTechLayerRuleDescriptor : public BaseDbDescriptor<odb::dbTechLayerRule>
 {
  public:
+  DbTechLayerRuleDescriptor(odb::dbDatabase* db);
+
   std::string getName(std::any object) const override;
   std::string getTypeName() const override;
 
@@ -651,14 +606,14 @@ class DbTechLayerRuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
+
+ protected:
+  Properties getDBProperties(odb::dbTechLayerRule* rule) const override;
 };
 
-class DbTechSameNetRuleDescriptor : public Descriptor
+class DbTechSameNetRuleDescriptor
+    : public BaseDbDescriptor<odb::dbTechSameNetRule>
 {
  public:
   DbTechSameNetRuleDescriptor(odb::dbDatabase* db);
@@ -670,17 +625,13 @@ class DbTechSameNetRuleDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbTechSameNetRule* rule) const override;
 };
 
-class DbSiteDescriptor : public Descriptor
+class DbSiteDescriptor : public BaseDbDescriptor<odb::dbSite>
 {
  public:
   struct SpecificSite
@@ -705,15 +656,17 @@ class DbSiteDescriptor : public Descriptor
 
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  odb::dbSite* getObject(const std::any& object) const override;
+  Properties getDBProperties(odb::dbSite* site) const override;
 
+ private:
   odb::dbSite* getSite(const std::any& object) const;
   odb::Rect getRect(const std::any& object) const;
   bool isSpecificSite(const std::any& object) const;
 };
 
-class DbRowDescriptor : public Descriptor
+class DbRowDescriptor : public BaseDbDescriptor<odb::dbRow>
 {
  public:
   DbRowDescriptor(odb::dbDatabase* db);
@@ -725,17 +678,14 @@ class DbRowDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbRow* row) const override;
 };
 
-class DbMarkerCategoryDescriptor : public Descriptor
+class DbMarkerCategoryDescriptor
+    : public BaseDbDescriptor<odb::dbMarkerCategory>
 {
  public:
   DbMarkerCategoryDescriptor(odb::dbDatabase* db);
@@ -747,17 +697,13 @@ class DbMarkerCategoryDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbMarkerCategory* category) const override;
 };
 
-class DbMarkerDescriptor : public Descriptor
+class DbMarkerDescriptor : public BaseDbDescriptor<odb::dbMarker>
 {
  public:
   DbMarkerDescriptor(odb::dbDatabase* db);
@@ -769,16 +715,12 @@ class DbMarkerDescriptor : public Descriptor
 
   void highlight(std::any object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
-
   bool getAllObjects(SelectionSet& objects) const override;
 
   void paintMarker(odb::dbMarker* marker, Painter& painter) const;
 
- private:
-  odb::dbDatabase* db_;
+ protected:
+  Properties getDBProperties(odb::dbMarker* marker) const override;
 };
 
 };  // namespace gui

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -58,10 +58,10 @@ class BaseDbDescriptor : public Descriptor
  public:
   BaseDbDescriptor(odb::dbDatabase* db);
 
-  virtual Properties getProperties(std::any object) const override;
+  Properties getProperties(std::any object) const override;
 
-  virtual Selected makeSelected(std::any object) const override;
-  virtual bool lessThan(std::any l, std::any r) const override;
+  Selected makeSelected(std::any object) const override;
+  bool lessThan(std::any l, std::any r) const override;
 
  protected:
   odb::dbDatabase* db_;

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -515,7 +515,7 @@ void MainWindow::init(sta::dbSta* sta)
   gui->registerDescriptor<odb::dbTechNonDefaultRule*>(
       new DbNonDefaultRuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechLayerRule*>(
-      new DbTechLayerRuleDescriptor());
+      new DbTechLayerRuleDescriptor(db_));
   gui->registerDescriptor<odb::dbTechSameNetRule*>(
       new DbTechSameNetRuleDescriptor(db_));
   gui->registerDescriptor<odb::dbSite*>(new DbSiteDescriptor(db_));


### PR DESCRIPTION
No functional changes expected.

The last time I was adding a ODB descriptor I noticed that I was just copying and pasting the makeSelected, lessThan, and forgot to add the ODB properties to the getProperties.

So this is an attempt to create a base class that can do these things and remove that duplicated code.
