### PR TITLE
gui: fix selection in inspector when using navigation

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -96,7 +96,7 @@ static void message_handler(QtMsgType type,
   }
   switch (type) {
     case QtDebugMsg:
-      logger->debug(utl::GUI, "qt", print_msg);
+      debugPrint(logger, utl::GUI, "qt", 1, print_msg);
       break;
     case QtInfoMsg:
       logger->info(utl::GUI, 75, print_msg);

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -37,6 +37,7 @@
 #include <QHeaderView>
 #include <QLineEdit>
 #include <QPushButton>
+#include <QDebug>
 
 #include "gui/gui.h"
 #include "gui_utils.h"
@@ -812,6 +813,11 @@ void Inspector::inspect(const Selected& object)
     navigation_history_.clear();
   }
 
+  if (object) {
+    qDebug() << "Inspector change selection to" << QString::fromStdString(object.getName());
+  } else {
+    qDebug() << "Inspector change selection to nothing";
+  }
   selection_ = object;
   emit selection(object);
 
@@ -1141,6 +1147,7 @@ void Inspector::navigateBack()
     }
   }
 
+  qDebug() << "Navigate to" << QString::fromStdString(next.getName());
   emit selected(next);
 }
 

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -34,10 +34,10 @@
 
 #include <QApplication>
 #include <QComboBox>
+#include <QDebug>
 #include <QHeaderView>
 #include <QLineEdit>
 #include <QPushButton>
-#include <QDebug>
 
 #include "gui/gui.h"
 #include "gui_utils.h"
@@ -814,7 +814,8 @@ void Inspector::inspect(const Selected& object)
   }
 
   if (object) {
-    qDebug() << "Inspector change selection to" << QString::fromStdString(object.getName());
+    qDebug() << "Inspector change selection to"
+             << QString::fromStdString(object.getName());
   } else {
     qDebug() << "Inspector change selection to nothing";
   }

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -1141,7 +1141,7 @@ void Inspector::navigateBack()
     }
   }
 
-  emit inspect(next);
+  emit selected(next);
 }
 
 ////////////


### PR DESCRIPTION
Fixes #5999

Changes:
- make qDebug messages go to `debugPrint` to allow for easier QT debugging.