### PR TITLE
rsz: check electrical compatibility when available

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -477,7 +477,6 @@ class Resizer : public dbStaState
 
   void resizePreamble();
   LibertyCellSeq getSwappableCells(LibertyCell* source_cell);
-  bool footprintsMatch(LibertyCell* source, LibertyCell* target);
 
   // Resize drvr_pin instance to target slew.
   // Return 1 if resized.

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1032,10 +1032,7 @@ LibertyCellSeq Resizer::getSwappableCells(LibertyCell* source_cell)
       }
 
       if (source_cell->userFunctionClass()) {
-        // Don't use stringEqIf to avoid a reduntant nullptr check.
-        // Here, we assume that the equivalent cell will also have
-        // a user_function_class attribute.
-        const bool user_function_classes_match = sta::stringEqual(
+        const bool user_function_classes_match = sta::stringEqIf(
             source_cell->userFunctionClass(), equiv_cell->userFunctionClass());
         if (!user_function_classes_match) {
           continue;


### PR DESCRIPTION
Resolve one of the tasks in #5577.

I changed the function that checks the footprints to a bool, because it looked a bit overkill. It feels more concise as well.