### PR TITLE
odb/cdl: Handle top-level pins wired to nets of different name

### DIFF
--- a/src/odb/src/cdl/cdl.cpp
+++ b/src/odb/src/cdl/cdl.cpp
@@ -105,6 +105,11 @@ std::string getNetName(dbBlock* block,
     return getUnconnectedNet(block, unconnectedNets);
   }
 
+  dbBTerm* bterm = net->get1stBTerm();
+  if (bterm) {
+    return bterm->getName();
+  }
+
   return net->getName();
 }
 

--- a/src/odb/test/data/gcd/gcd.def
+++ b/src/odb/test/data/gcd/gcd.def
@@ -623,8 +623,8 @@ PINS 54 ;
     - resp_msg[2] + NET resp_msg[2] + DIRECTION OUTPUT + USE SIGNAL + FIXED ( 145790 140 ) N + LAYER metal6 ( -140 -140 ) ( 140 140 ) ;
     - resp_msg[1] + NET resp_msg[1] + DIRECTION OUTPUT + USE SIGNAL + FIXED ( 140 147980 ) N + LAYER metal5 ( -140 -140 ) ( 140 140 ) ;
     - resp_msg[0] + NET resp_msg[0] + DIRECTION OUTPUT + USE SIGNAL + FIXED ( 174910 140 ) N + LAYER metal6 ( -140 -140 ) ( 140 140 ) ;
-    - resp_rdy + NET resp_rdy + DIRECTION INPUT + USE SIGNAL + FIXED ( 200120 178220 ) N + LAYER metal5 ( -140 -140 ) ( 140 140 ) ;
-    - resp_val + NET resp_val + DIRECTION OUTPUT + USE SIGNAL + FIXED ( 140 31500 ) N + LAYER metal5 ( -140 -140 ) ( 140 140 ) ;
+    - resp_rdy + NET resp_rdy_i + DIRECTION INPUT + USE SIGNAL + FIXED ( 200120 178220 ) N + LAYER metal5 ( -140 -140 ) ( 140 140 ) ;
+    - resp_val + NET resp_val_i + DIRECTION OUTPUT + USE SIGNAL + FIXED ( 140 31500 ) N + LAYER metal5 ( -140 -140 ) ( 140 140 ) ;
 END PINS
 SPECIALNETS 2 ;
     - VDD ( * VDD ) + USE POWER
@@ -1028,8 +1028,8 @@ NETS 385 ;
     - resp_msg[2] ( PIN resp_msg[2] ) ( _422_ ZN ) ( _423_ A2 ) + USE SIGNAL ;
     - resp_msg[1] ( PIN resp_msg[1] ) ( _416_ Z ) ( _417_ A2 ) + USE SIGNAL ;
     - resp_msg[0] ( PIN resp_msg[0] ) ( _299_ Z ) ( _396_ A2 ) ( _401_ A2 ) + USE SIGNAL ;
-    - resp_rdy ( PIN resp_rdy ) ( _312_ A2 ) ( _321_ A3 ) + USE SIGNAL ;
-    - resp_val ( PIN resp_val ) ( _298_ ZN ) ( _312_ A1 ) ( _321_ A1 ) + USE SIGNAL ;
+    - resp_rdy_i ( PIN resp_rdy ) ( _312_ A2 ) ( _321_ A3 ) + USE SIGNAL ;
+    - resp_val_i ( PIN resp_val ) ( _298_ ZN ) ( _312_ A1 ) ( _321_ A1 ) + USE SIGNAL ;
     - _000_ ( _324_ ZN ) ( _576_ D ) + USE SIGNAL ;
     - _001_ ( _314_ ZN ) ( _577_ D ) + USE SIGNAL ;
     - _002_ ( _320_ ZN ) ( _578_ D ) + USE SIGNAL ;


### PR DESCRIPTION
ATM the code seem to assume that for each top level pin, the net name is equal to the pin name.

That's not always the case and this produces an incorect netlist.

To solve that, during pin name enumeration when creating the subckt line, we create a mapping from "net name" -> "pin name" for each pin connected to a net of a different name. Then when outputting the connections between sub blocks, we use the pin name instead of the DB net name.