### PR TITLE
odb: In dbITerm::getGeometries, return layer + rect

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -3636,7 +3636,8 @@ class dbITerm : public dbObject
   ///
   /// Returns all geometries of all dbMPin associated with
   /// the dbMTerm.
-  std::vector<Rect> getGeometries() const;
+  ///
+  std::vector<std::pair<dbTechLayer*, Rect>> getGeometries() const;
 
   void setAccessPoint(dbMPin* pin, dbAccessPoint* ap);
 

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -801,16 +801,16 @@ std::vector<dbAccessPoint*> dbITerm::getPrefAccessPoints() const
   return aps;
 }
 
-std::vector<Rect> dbITerm::getGeometries() const
+std::vector<std::pair<dbTechLayer*, Rect>> dbITerm::getGeometries() const
 {
   const dbTransform transform = getInst()->getTransform();
 
-  std::vector<Rect> geometries;
+  std::vector<std::pair<dbTechLayer*, Rect>> geometries;
   for (dbMPin* mpin : getMTerm()->getMPins()) {
     for (dbBox* box : mpin->getGeometry()) {
       Rect rect = box->getBox();
       transform.apply(rect);
-      geometries.push_back(rect);
+      geometries.emplace_back(box->getTechLayer(), rect);
     }
   }
 

--- a/src/odb/src/swig/python/dbtypes.i
+++ b/src/odb/src/swig/python/dbtypes.i
@@ -141,6 +141,22 @@
     $result = list;
 }
 
+%typemap(out) std::vector< std::pair< T*, odb::Rect > > {
+    PyObject *list = PyList_New($1.size());
+    for (unsigned int i = 0; i < $1.size(); i++) {
+        PyObject *sub_list = PyList_New(2);
+        std::pair< T*, odb::Rect > p = $1.at(i);
+        T* ptr1 = p.first;
+        odb::Rect* ptr2 = new odb::Rect(p.second);
+        PyObject *obj1 = SWIG_NewInstanceObj(ptr1, $descriptor(T *), 0);
+        PyObject *obj2 = SWIG_NewInstanceObj(ptr2, $descriptor(odb::Rect *), 0);
+        PyList_SetItem(sub_list, 0, obj1);
+        PyList_SetItem(sub_list, 1, obj2);
+        PyList_SetItem(list, i, sub_list);
+    }
+    $result = list;
+}
+
 %typemap(in) std::vector< T* >* (std::vector< T* > *v, std::vector< T* > w),
              std::vector< T* >& (std::vector< T* > *v, std::vector< T* > w) {
 

--- a/src/odb/src/swig/tcl/dbtypes.i
+++ b/src/odb/src/swig/tcl/dbtypes.i
@@ -138,6 +138,22 @@
     Tcl_SetObjResult(interp, list);
 }
 
+%typemap(out) std::vector< std::pair< T*, odb::Rect > > {
+    Tcl_Obj *list = Tcl_NewListObj(0, nullptr);
+    for (unsigned int i = 0; i < $1.size(); i++) {
+        Tcl_Obj *sub_list = Tcl_NewListObj(0, nullptr);
+        std::pair< T*, odb::Rect > p = $1.at(i);
+        T* ptr1 = p.first;
+        odb::Rect* ptr2 = new odb::Rect(p.second);
+        Tcl_Obj *obj1 = SWIG_NewInstanceObj(ptr1, $descriptor(T *), 0);
+        Tcl_Obj *obj2 = SWIG_NewInstanceObj(ptr2, $descriptor(odb::Rect *), 0);
+        Tcl_ListObjAppendElement(interp, sub_list, obj1);
+        Tcl_ListObjAppendElement(interp, sub_list, obj2);
+        Tcl_ListObjAppendElement(interp, list, sub_list);
+    }
+    Tcl_SetObjResult(interp, list);
+}
+
 %typemap(in) std::vector< T* >* (std::vector< T* > *v, std::vector< T* > w),
              std::vector< T* >& (std::vector< T* > *v, std::vector< T* > w) {
     Tcl_Obj **listobjv;


### PR DESCRIPTION
Currently only the rect is returned but that's not very useful. So instead we return pairs of layer + rect.

The appropriate SWIG mapping is also added so the result is usable both in Python and in TCL.

Note that someone should definitely have a close look at the SWIG mapping because I have very little experience with those.
I did test that it seems to work as expected in both TCL and Python though.