### PR TITLE
drt: add net when it does not exist in drt yet

### DIFF
--- a/src/drt/src/io/io.h
+++ b/src/drt/src/io/io.h
@@ -107,6 +107,7 @@ class Parser
   void setVias(odb::dbBlock*);
   void updateNetRouting(frNet*, odb::dbNet*);
   void setNets(odb::dbBlock*);
+  frNet* addNet(odb::dbNet* db_net);
   void setAccessPoints(odb::dbDatabase*);
   void getSBoxCoords(odb::dbSBox*,
                      frCoord&,


### PR DESCRIPTION
This update allow incremental DRT to route nets that are created by post-DRT repair_timing.