### PR TITLE
rsz: add detailed_routing as parasitics source

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -414,6 +414,7 @@ class Resizer : public dbStaState
 
   dbNetwork* getDbNetwork() { return db_network_; }
   ParasiticsSrc getParasiticsSrc() { return parasitics_src_; }
+  void setParasiticsSrc(ParasiticsSrc src) { parasitics_src_ = src; }
   dbBlock* getDbBlock() { return block_; };
   double dbuToMeters(int dist) const;
   int metersToDbu(double dist) const;

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -152,7 +152,8 @@ enum class ParasiticsSrc
 {
   none,
   placement,
-  global_routing
+  global_routing,
+  detailed_routing
 };
 
 struct ParasiticsResistance

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -375,8 +375,8 @@ BufferedNetPtr Resizer::makeBufferedNet(const Pin* drvr_pin,
     case ParasiticsSrc::placement:
       return makeBufferedNetSteiner(drvr_pin, corner);
     case ParasiticsSrc::global_routing:
-      return makeBufferedNetGroute(drvr_pin, corner);
     case ParasiticsSrc::detailed_routing:
+      return makeBufferedNetGroute(drvr_pin, corner);
     case ParasiticsSrc::none:
       return nullptr;
   }

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -376,6 +376,7 @@ BufferedNetPtr Resizer::makeBufferedNet(const Pin* drvr_pin,
       return makeBufferedNetSteiner(drvr_pin, corner);
     case ParasiticsSrc::global_routing:
       return makeBufferedNetGroute(drvr_pin, corner);
+    case ParasiticsSrc::detailed_routing:
     case ParasiticsSrc::none:
       return nullptr;
   }

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -349,7 +349,8 @@ void Resizer::updateParasitics(bool save_guides)
       }
       parasitics_invalid_.clear();
       break;
-    case ParasiticsSrc::global_routing: {
+    case ParasiticsSrc::global_routing:
+    case ParasiticsSrc::detailed_routing: {
       incr_groute_->updateRoutes(save_guides);
       for (const Net* net : parasitics_invalid_) {
         global_router_->estimateRC(db_network_->staToDb(net));
@@ -357,7 +358,6 @@ void Resizer::updateParasitics(bool save_guides)
       parasitics_invalid_.clear();
       break;
     }
-    case ParasiticsSrc::detailed_routing:
     case ParasiticsSrc::none:
       break;
   }

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -294,6 +294,9 @@ void Resizer::estimateParasitics(ParasiticsSrc src,
       global_router_->estimateRC(spef_writer.get());
       parasitics_src_ = ParasiticsSrc::global_routing;
       break;
+    case ParasiticsSrc::detailed_routing:
+      parasitics_src_ = ParasiticsSrc::detailed_routing;
+      break;
     case ParasiticsSrc::none:
       break;
   }
@@ -310,6 +313,7 @@ void Resizer::incrementalParasiticsBegin()
     case ParasiticsSrc::placement:
       break;
     case ParasiticsSrc::global_routing:
+    case ParasiticsSrc::detailed_routing:
       incr_groute_ = new IncrementalGRoute(global_router_, block_);
       // Don't print verbose messages for incremental routing
       global_router_->setVerbose(false);
@@ -326,6 +330,7 @@ void Resizer::incrementalParasiticsEnd()
     case ParasiticsSrc::placement:
       break;
     case ParasiticsSrc::global_routing:
+    case ParasiticsSrc::detailed_routing:
       delete incr_groute_;
       incr_groute_ = nullptr;
       break;
@@ -352,6 +357,7 @@ void Resizer::updateParasitics(bool save_guides)
       parasitics_invalid_.clear();
       break;
     }
+    case ParasiticsSrc::detailed_routing:
     case ParasiticsSrc::none:
       break;
   }
@@ -391,6 +397,8 @@ void Resizer::ensureWireParasitic(const Pin* drvr_pin, const Net* net)
         parasitics_invalid_.erase(net);
         break;
       }
+      case ParasiticsSrc::detailed_routing:
+        break;
       case ParasiticsSrc::none:
         break;
     }

--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -295,6 +295,7 @@ void Resizer::estimateParasitics(ParasiticsSrc src,
       parasitics_src_ = ParasiticsSrc::global_routing;
       break;
     case ParasiticsSrc::detailed_routing:
+      // TODO: call rcx to extract parasitics and load them to STA
       parasitics_src_ = ParasiticsSrc::detailed_routing;
       break;
     case ParasiticsSrc::none:
@@ -314,6 +315,7 @@ void Resizer::incrementalParasiticsBegin()
       break;
     case ParasiticsSrc::global_routing:
     case ParasiticsSrc::detailed_routing:
+      // TODO: add IncrementalDRoute
       incr_groute_ = new IncrementalGRoute(global_router_, block_);
       // Don't print verbose messages for incremental routing
       global_router_->setVerbose(false);
@@ -331,6 +333,7 @@ void Resizer::incrementalParasiticsEnd()
       break;
     case ParasiticsSrc::global_routing:
     case ParasiticsSrc::detailed_routing:
+      // TODO: add IncrementalDRoute
       delete incr_groute_;
       incr_groute_ = nullptr;
       break;
@@ -351,6 +354,7 @@ void Resizer::updateParasitics(bool save_guides)
       break;
     case ParasiticsSrc::global_routing:
     case ParasiticsSrc::detailed_routing: {
+      // TODO: update detailed route for modified nets
       incr_groute_->updateRoutes(save_guides);
       for (const Net* net : parasitics_invalid_) {
         global_router_->estimateRC(db_network_->staToDb(net));
@@ -398,6 +402,7 @@ void Resizer::ensureWireParasitic(const Pin* drvr_pin, const Net* net)
         break;
       }
       case ParasiticsSrc::detailed_routing:
+        // TODO: call incremental drt for the modified net
         break;
       case ParasiticsSrc::none:
         break;

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1157,9 +1157,10 @@ LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
     for (LibertyCell* target_cell : swappable_cells) {
       if (!dontUse(target_cell) && isLinkCell(target_cell)) {
         float target_load = (*target_load_map_)[target_cell];
-        float delay = is_buf_inv ? bufferDelay(
-                          target_cell, load_cap, tgt_slew_dcalc_ap_)
-                                 : 0.0;
+        float delay
+            = is_buf_inv
+                  ? bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_)
+                  : 0.0;
         float dist = targetLoadDist(load_cap, target_load);
         debugPrint(logger_,
                    RSZ,
@@ -1276,7 +1277,8 @@ bool Resizer::replaceCell(Instance* inst,
     designAreaIncr(area(replacement_master));
 
     // Legalize the position of the instance in case it leaves the die
-    if (parasitics_src_ == ParasiticsSrc::global_routing) {
+    if (parasitics_src_ == ParasiticsSrc::global_routing
+        || parasitics_src_ == ParasiticsSrc::detailed_routing) {
       opendp_->legalCellPos(db_network_->staToDb(inst));
     }
     if (haveEstimatedParasitics()) {
@@ -2691,7 +2693,8 @@ void Resizer::repairDesign(double max_wire_length,
   utl::SetAndRestore<bool> set_match_footprint(match_cell_footprint_,
                                                match_cell_footprint);
   resizePreamble();
-  if (parasitics_src_ == ParasiticsSrc::global_routing) {
+  if (parasitics_src_ == ParasiticsSrc::global_routing
+      || parasitics_src_ == ParasiticsSrc::detailed_routing) {
     opendp_->initMacrosAndGrid();
   }
   repair_design_->repairDesign(
@@ -2845,7 +2848,8 @@ void Resizer::repairSetup(double setup_margin,
   utl::SetAndRestore<bool> set_match_footprint(match_cell_footprint_,
                                                match_cell_footprint);
   resizePreamble();
-  if (parasitics_src_ == ParasiticsSrc::global_routing) {
+  if (parasitics_src_ == ParasiticsSrc::global_routing
+      || parasitics_src_ == ParasiticsSrc::detailed_routing) {
     opendp_->initMacrosAndGrid();
   }
   repair_setup_->repairSetup(setup_margin,
@@ -2903,7 +2907,8 @@ void Resizer::repairHold(
                                                  LibertyCellSeq());
 
   resizePreamble();
-  if (parasitics_src_ == ParasiticsSrc::global_routing) {
+  if (parasitics_src_ == ParasiticsSrc::global_routing
+      || parasitics_src_ == ParasiticsSrc::detailed_routing) {
     opendp_->initMacrosAndGrid();
   }
   repair_hold_->repairHold(setup_margin,
@@ -2948,7 +2953,8 @@ void Resizer::recoverPower(float recover_power_percent,
   utl::SetAndRestore<bool> set_match_footprint(match_cell_footprint_,
                                                match_cell_footprint);
   resizePreamble();
-  if (parasitics_src_ == ParasiticsSrc::global_routing) {
+  if (parasitics_src_ == ParasiticsSrc::global_routing
+      || parasitics_src_ == ParasiticsSrc::detailed_routing) {
     opendp_->initMacrosAndGrid();
   }
   recover_power_->recoverPower(recover_power_percent);
@@ -3479,7 +3485,8 @@ Instance* Resizer::makeInstance(LibertyCell* cell,
   db_inst->setSourceType(odb::dbSourceType::TIMING);
   setLocation(db_inst, loc);
   // Legalize the position of the instance in case it leaves the die
-  if (parasitics_src_ == ParasiticsSrc::global_routing) {
+  if (parasitics_src_ == ParasiticsSrc::global_routing
+      || parasitics_src_ == ParasiticsSrc::detailed_routing) {
     opendp_->legalCellPos(db_inst);
   }
   designAreaIncr(area(db_inst->getMaster()));

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1157,10 +1157,9 @@ LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
     for (LibertyCell* target_cell : swappable_cells) {
       if (!dontUse(target_cell) && isLinkCell(target_cell)) {
         float target_load = (*target_load_map_)[target_cell];
-        float delay
-            = is_buf_inv
-                  ? bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_)
-                  : 0.0;
+        float delay = is_buf_inv ? bufferDelay(
+                          target_cell, load_cap, tgt_slew_dcalc_ap_)
+                                 : 0.0;
         float dist = targetLoadDist(load_cap, target_load);
         debugPrint(logger_,
                    RSZ,

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -213,6 +213,8 @@ tclListNetworkSet(Tcl_Obj *const source,
     $1 = ParasiticsSrc::placement;
   else if (stringEq(arg, "global_routing"))
     $1 = ParasiticsSrc::global_routing;
+  else if (stringEq(arg, "detailed_routing"))
+    $1 = ParasiticsSrc::detailed_routing;
   else {
     Tcl_SetResult(interp,const_cast<char*>("Error: parasitics source."), TCL_STATIC);
     return TCL_ERROR;
@@ -814,6 +816,13 @@ set_worst_slack_nets_percent(float percent)
 {
   Resizer *resizer = getResizer();
   resizer->setWorstSlackNetsPercent(percent);
+}
+
+void
+set_parasitics_src(ParasiticsSrc src)
+{
+  Resizer *resizer = getResizer();
+  resizer->setParasiticsSrc(src);
 }
 
 } // namespace

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -613,6 +613,9 @@ proc repair_timing { args } {
   }
 
   set match_cell_footprint [info exists flags(-match_cell_footprint)]
+  if { [design_is_routed] } {
+    rsz::set_parasitics_src "detailed_routing"
+  }
 
   sta::check_argc_eq0 "repair_timing" $args
   rsz::check_parasitics


### PR DESCRIPTION
This first step only adds `detailed_routing` as a new source of parasitics, and is used mainly to avoid calculating the parasitics from wire load models.

In the first iteration on each net, the droute parasitics are used, but once the net is changed, later iterations will use the global routing parasitics for estimation. At some point we should be able to detail route again specific nets inside the repair_timing flow.

Last, I'm checking if the design is routed to define the parasitics source as detailed_routing. It doesn't seem the ideal way, but I didn't find any functions in STA to detect there are parasitics present in its internal structures. Another option would be have a command that the user explicitly calls to define detailed_routing as the parasitics source.

I'm open to suggestions on how to improve this part of the code.