### PR TITLE
rsz: return if repair_timing did something in the design

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -283,7 +283,7 @@ class Resizer : public dbStaState
   float targetLoadCap(LibertyCell* cell);
 
   ////////////////////////////////////////////////////////////////
-  void repairSetup(double setup_margin,
+  bool repairSetup(double setup_margin,
                    double repair_tns_end_percent,
                    int max_passes,
                    bool match_cell_footprint,
@@ -303,7 +303,7 @@ class Resizer : public dbStaState
 
   ////////////////////////////////////////////////////////////////
 
-  void repairHold(double setup_margin,
+  bool repairHold(double setup_margin,
                   double hold_margin,
                   bool allow_setup_violations,
                   // Max buffer count as percent of design instance count.
@@ -320,7 +320,7 @@ class Resizer : public dbStaState
   int holdBufferCount() const;
 
   ////////////////////////////////////////////////////////////////
-  void recoverPower(float recover_power_percent, bool match_cell_footprint);
+  bool recoverPower(float recover_power_percent, bool match_cell_footprint);
 
   ////////////////////////////////////////////////////////////////
   // Area of the design in meter^2.

--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -78,8 +78,9 @@ void RecoverPower::init()
   db_network_ = resizer_->db_network_;
 }
 
-void RecoverPower::recoverPower(const float recover_power_percent)
+bool RecoverPower::recoverPower(const float recover_power_percent)
 {
+  bool recovered = false;
   init();
   constexpr int digits = 3;
   resize_count_ = 0;
@@ -222,11 +223,14 @@ void RecoverPower::recoverPower(const float recover_power_percent)
   // logger_->metric("design__instance__count__setup_buffer",
   // inserted_buffer_count_);
   if (resize_count_ > 0) {
+    recovered = true;
     logger_->info(RSZ, 141, "Resized {} instances.", resize_count_);
   }
   if (resizer_->overMaxArea()) {
     logger_->error(RSZ, 125, "max utilization reached.");
   }
+
+  return recovered;
 }
 
 // For testing.

--- a/src/rsz/src/RecoverPower.hh
+++ b/src/rsz/src/RecoverPower.hh
@@ -79,7 +79,7 @@ class RecoverPower : public sta::dbStaState
 {
  public:
   RecoverPower(Resizer* resizer);
-  void recoverPower(float recover_power_percent);
+  bool recoverPower(float recover_power_percent);
   // For testing.
   Vertex* recoverPower(const Pin* end_pin);
 

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -111,13 +111,13 @@ bool RepairHold::repairHold(
   max_buffer_count = std::max(max_buffer_count, 100);
   resizer_->incrementalParasiticsBegin();
   repaired = repairHold(ends1,
-             buffer_cell,
-             setup_margin,
-             hold_margin,
-             allow_setup_violations,
-             max_buffer_count,
-             max_passes,
-             verbose);
+                        buffer_cell,
+                        setup_margin,
+                        hold_margin,
+                        allow_setup_violations,
+                        max_buffer_count,
+                        max_passes,
+                        verbose);
 
   // Leave the parasitices up to date.
   resizer_->updateParasitics();

--- a/src/rsz/src/RepairHold.hh
+++ b/src/rsz/src/RepairHold.hh
@@ -67,7 +67,7 @@ class RepairHold : public sta::dbStaState
 {
  public:
   RepairHold(Resizer* resizer);
-  void repairHold(double setup_margin,
+  bool repairHold(double setup_margin,
                   double hold_margin,
                   bool allow_setup_violations,
                   // Max buffer count as percent of design instance count.
@@ -94,7 +94,7 @@ class RepairHold : public sta::dbStaState
                           // Return values.
                           Slack& worst_slack,
                           VertexSeq& hold_violations);
-  void repairHold(VertexSeq& ends,
+  bool repairHold(VertexSeq& ends,
                   LibertyCell* buffer_cell,
                   double setup_margin,
                   double hold_margin,

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -124,7 +124,7 @@ class RepairSetup : public sta::dbStaState
 {
  public:
   RepairSetup(Resizer* resizer);
-  void repairSetup(float setup_slack_margin,
+  bool repairSetup(float setup_slack_margin,
                    // Percent of violating ends to repair to
                    // reduce tns (0.0-1.0).
                    double repair_tns_end_percent,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2831,7 +2831,7 @@ void Resizer::cloneClkInverter(Instance* inv)
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::repairSetup(double setup_margin,
+bool Resizer::repairSetup(double setup_margin,
                           double repair_tns_end_percent,
                           int max_passes,
                           bool match_cell_footprint,
@@ -2848,7 +2848,7 @@ void Resizer::repairSetup(double setup_margin,
   if (parasitics_src_ == ParasiticsSrc::global_routing) {
     opendp_->initMacrosAndGrid();
   }
-  repair_setup_->repairSetup(setup_margin,
+  return repair_setup_->repairSetup(setup_margin,
                              repair_tns_end_percent,
                              max_passes,
                              verbose,
@@ -2879,7 +2879,7 @@ void Resizer::rebufferNet(const Pin* drvr_pin)
 
 ////////////////////////////////////////////////////////////////
 
-void Resizer::repairHold(
+bool Resizer::repairHold(
     double setup_margin,
     double hold_margin,
     bool allow_setup_violations,
@@ -2906,7 +2906,7 @@ void Resizer::repairHold(
   if (parasitics_src_ == ParasiticsSrc::global_routing) {
     opendp_->initMacrosAndGrid();
   }
-  repair_hold_->repairHold(setup_margin,
+  return repair_hold_->repairHold(setup_margin,
                            hold_margin,
                            allow_setup_violations,
                            max_buffer_percent,
@@ -2942,7 +2942,7 @@ int Resizer::holdBufferCount() const
 }
 
 ////////////////////////////////////////////////////////////////
-void Resizer::recoverPower(float recover_power_percent,
+bool Resizer::recoverPower(float recover_power_percent,
                            bool match_cell_footprint)
 {
   utl::SetAndRestore<bool> set_match_footprint(match_cell_footprint_,
@@ -2951,7 +2951,7 @@ void Resizer::recoverPower(float recover_power_percent,
   if (parasitics_src_ == ParasiticsSrc::global_routing) {
     opendp_->initMacrosAndGrid();
   }
-  recover_power_->recoverPower(recover_power_percent);
+  return recover_power_->recoverPower(recover_power_percent);
 }
 ////////////////////////////////////////////////////////////////
 // Journal to roll back changes

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2849,14 +2849,14 @@ bool Resizer::repairSetup(double setup_margin,
     opendp_->initMacrosAndGrid();
   }
   return repair_setup_->repairSetup(setup_margin,
-                             repair_tns_end_percent,
-                             max_passes,
-                             verbose,
-                             skip_pin_swap,
-                             skip_gate_cloning,
-                             skip_buffering,
-                             skip_buffer_removal,
-                             skip_last_gasp);
+                                    repair_tns_end_percent,
+                                    max_passes,
+                                    verbose,
+                                    skip_pin_swap,
+                                    skip_gate_cloning,
+                                    skip_buffering,
+                                    skip_buffer_removal,
+                                    skip_last_gasp);
 }
 
 void Resizer::reportSwappablePins()
@@ -2907,11 +2907,11 @@ bool Resizer::repairHold(
     opendp_->initMacrosAndGrid();
   }
   return repair_hold_->repairHold(setup_margin,
-                           hold_margin,
-                           allow_setup_violations,
-                           max_buffer_percent,
-                           max_passes,
-                           verbose);
+                                  hold_margin,
+                                  allow_setup_violations,
+                                  max_buffer_percent,
+                                  max_passes,
+                                  verbose);
 }
 
 void Resizer::repairHold(const Pin* end_pin,

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -590,7 +590,7 @@ repair_net_cmd(Net *net,
   resizer->repairNet(net, max_length, slew_margin, cap_margin); 
 }
 
-void
+bool
 repair_setup(double setup_margin,
              double repair_tns_end_percent,
              int max_passes,
@@ -601,7 +601,7 @@ repair_setup(double setup_margin,
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  resizer->repairSetup(setup_margin, repair_tns_end_percent,
+  return resizer->repairSetup(setup_margin, repair_tns_end_percent,
                        max_passes, match_cell_footprint, verbose,
                        skip_pin_swap, skip_gate_cloning,
                        skip_buffering, skip_buffer_removal,
@@ -624,7 +624,7 @@ report_swappable_pins_cmd()
   resizer->reportSwappablePins();
 }
 
-void
+bool
 repair_hold(double setup_margin,
             double hold_margin,
             bool allow_setup_violations,
@@ -635,7 +635,7 @@ repair_hold(double setup_margin,
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  resizer->repairHold(setup_margin, hold_margin,
+  return resizer->repairHold(setup_margin, hold_margin,
                       allow_setup_violations,
                       max_buffer_percent, max_passes,
                       match_cell_footprint, verbose);
@@ -664,12 +664,12 @@ hold_buffer_count()
 }
 
 ////////////////////////////////////////////////////////////////
-void
+bool
 recover_power(float recover_power_percent, bool match_cell_footprint)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  resizer->recoverPower(recover_power_percent, match_cell_footprint);
+  return resizer->recoverPower(recover_power_percent, match_cell_footprint);
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -616,21 +616,27 @@ proc repair_timing { args } {
 
   sta::check_argc_eq0 "repair_timing" $args
   rsz::check_parasitics
+
+  set recovered_power 0
+  set repaired_setup 0
+  set repaired_hold 0
   if { $recover_power_percent >= 0 } {
-    rsz::recover_power $recover_power_percent $match_cell_footprint
+    set recovered_power [rsz::recover_power $recover_power_percent $match_cell_footprint]
   } else {
     if { $setup } {
-      rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes \
+      set repaired_setup [rsz::repair_setup $setup_margin $repair_tns_end_percent $max_passes \
         $match_cell_footprint $verbose \
         $skip_pin_swap $skip_gate_cloning $skip_buffering \
-        $skip_buffer_removal $skip_last_gasp
+        $skip_buffer_removal $skip_last_gasp]
     }
     if { $hold } {
-      rsz::repair_hold $setup_margin $hold_margin \
+      set repaired_hold [rsz::repair_hold $setup_margin $hold_margin \
         $allow_setup_violations $max_buffer_percent $max_passes \
-        $match_cell_footprint $verbose
+        $match_cell_footprint $verbose]
     }
   }
+
+  return [expr $recovered_power || $repaired_setup || $repaired_hold]
 }
 
 ################################################################


### PR DESCRIPTION
This PR checks if `repair_timing` did something in the design. This is specially useful in the post-DRT timing repair project to avoid calling DRT when repair_timing didn't executed or didn't changed anything in the design.