### PR TITLE
mpl2: ensure that sa converges if a valid result was generated at any point

### DIFF
--- a/src/mpl2/src/SACoreHardMacro.cpp
+++ b/src/mpl2/src/SACoreHardMacro.cpp
@@ -85,6 +85,19 @@ SACoreHardMacro::SACoreHardMacro(
   flip_prob_ = flip_prob;
 }
 
+void SACoreHardMacro::run()
+{
+  if (graphics_) {
+    graphics_->startSA();
+  }
+
+  fastSA();
+
+  if (graphics_) {
+    graphics_->endSA(calNormCost());
+  }
+}
+
 float SACoreHardMacro::getAreaPenalty() const
 {
   const float outline_area = outline_.getWidth() * outline_.getHeight();

--- a/src/mpl2/src/SACoreHardMacro.h
+++ b/src/mpl2/src/SACoreHardMacro.h
@@ -72,6 +72,8 @@ class SACoreHardMacro : public SimulatedAnnealingCore<HardMacro>
                   Mpl2Observer* graphics,
                   utl::Logger* logger);
 
+  void run() override;
+
   void setWeights(const SACoreWeights& weights);
 
   // Initialize the SA worker

--- a/src/mpl2/src/SACoreSoftMacro.cpp
+++ b/src/mpl2/src/SACoreSoftMacro.cpp
@@ -101,6 +101,29 @@ SACoreSoftMacro::SACoreSoftMacro(
   logger_ = logger;
 }
 
+void SACoreSoftMacro::run()
+{
+  if (graphics_) {
+    graphics_->startSA();
+  }
+
+  best_valid_result_ = std::make_unique<SoftResult>();
+
+  fastSA();
+
+  if (!isValid() && !best_valid_result_->sequence_pair.pos_sequence.empty()) {
+    useBestValidResult();
+  }
+
+  if (centralization_on_) {
+    attemptCentralization(calNormCost());
+  }
+
+  if (graphics_) {
+    graphics_->endSA(calNormCost());
+  }
+}
+
 // acessors functions
 float SACoreSoftMacro::getBoundaryPenalty() const
 {
@@ -1102,6 +1125,81 @@ void SACoreSoftMacro::calSegmentLoc(float seg_start,
 void SACoreSoftMacro::addBlockages(const std::vector<Rect>& blockages)
 {
   blockages_.insert(blockages_.end(), blockages.begin(), blockages.end());
+}
+
+void SACoreSoftMacro::attemptCentralization(const float pre_cost)
+{
+  if (outline_penalty_ > 0) {
+    return;
+  }
+
+  // In order to revert the centralization, we cache the current location
+  // of the clusters to avoid floating-point evilness when creating the
+  // x,y grid to fill the dead space by expanding mixed clusters.
+  std::map<int, std::pair<float, float>> clusters_locations;
+
+  for (int& id : pos_seq_) {
+    clusters_locations[id] = {macros_[id].getX(), macros_[id].getY()};
+  }
+
+  std::pair<float, float> offset((outline_.getWidth() - width_) / 2,
+                                 (outline_.getHeight() - height_) / 2);
+  moveFloorplan(offset);
+
+  // revert centralization
+  if (calNormCost() > pre_cost) {
+    centralization_was_reverted_ = true;
+
+    for (int& id : pos_seq_) {
+      macros_[id].setX(clusters_locations[id].first);
+      macros_[id].setY(clusters_locations[id].second);
+    }
+
+    if (graphics_) {
+      graphics_->saStep(macros_);
+    }
+
+    calPenalty();
+  }
+}
+
+void SACoreSoftMacro::moveFloorplan(const std::pair<float, float>& offset)
+{
+  for (auto& id : pos_seq_) {
+    macros_[id].setX(macros_[id].getX() + offset.first);
+    macros_[id].setY(macros_[id].getY() + offset.second);
+  }
+
+  if (graphics_) {
+    graphics_->saStep(macros_);
+  }
+
+  calPenalty();
+}
+
+void SACoreSoftMacro::useBestValidResult()
+{
+  pos_seq_ = best_valid_result_->sequence_pair.pos_sequence;
+  neg_seq_ = best_valid_result_->sequence_pair.neg_sequence;
+
+  for (const int macro_id : pos_seq_) {
+    SoftMacro& macro = macros_[macro_id];
+    const float valid_result_width
+        = best_valid_result_->macro_id_to_width.at(macro_id);
+
+    if (macro.isMacroCluster()) {
+      const float valid_result_height = macro.getArea() / valid_result_width;
+      macro.setShapeF(valid_result_width, valid_result_height);
+    } else {
+      macro.setWidth(valid_result_width);
+    }
+  }
+
+  packFloorplan();
+  if (graphics_) {
+    graphics_->doNotSkip();
+  }
+  calPenalty();
 }
 
 }  // namespace mpl2

--- a/src/mpl2/src/SACoreSoftMacro.h
+++ b/src/mpl2/src/SACoreSoftMacro.h
@@ -79,6 +79,9 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
                   unsigned seed,
                   Mpl2Observer* graphics,
                   utl::Logger* logger);
+
+  void run() override;
+
   // accessors
   float getBoundaryPenalty() const;
   float getNormBoundaryPenalty() const;
@@ -95,6 +98,12 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   void fillDeadSpace() override;
   void alignMacroClusters();
   void addBlockages(const std::vector<Rect>& blockages);
+
+  bool centralizationWasReverted() { return centralization_was_reverted_; }
+  void setCentralizationAttemptOn(bool centralization_on)
+  {
+    centralization_on_ = centralization_on;
+  };
 
  private:
   float getAreaPenalty() const;
@@ -120,6 +129,13 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   void calBoundaryPenalty();
   void calNotchPenalty();
   void calMacroBlockagePenalty();
+
+  // Only for Cluster Placement:
+  void attemptCentralization(float pre_cost);
+  void moveFloorplan(const std::pair<float, float>& offset);
+
+  void useBestValidResult();
+
   std::vector<Rect> blockages_;
 
   Cluster* root_;
@@ -151,6 +167,9 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
 
   // action prob
   float resize_prob_ = 0.0;
+
+  bool centralization_on_ = false;
+  bool centralization_was_reverted_ = false;
 };
 
 }  // namespace mpl2

--- a/src/mpl2/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl2/src/SimulatedAnnealingCore.cpp
@@ -560,10 +560,6 @@ float SimulatedAnnealingCore<T>::calAverage(std::vector<float>& value_list)
 template <class T>
 void SimulatedAnnealingCore<T>::fastSA()
 {
-  if (graphics_) {
-    graphics_->startSA();
-  }
-
   float cost = calNormCost();
   float pre_cost = cost;
   float delta_cost = 0.0;
@@ -580,9 +576,8 @@ void SimulatedAnnealingCore<T>::fastSA()
   int num_restart = 1;
   const int max_num_restart = 2;
 
-  SequencePair best_valid_result;
-  if (isValid()) {
-    updateBestValidResult(best_valid_result);
+  if (best_valid_result_ && isValid()) {
+    updateBestValidSoftResult();
   }
 
   while (step <= max_num_step_) {
@@ -590,11 +585,13 @@ void SimulatedAnnealingCore<T>::fastSA()
       perturb();
       cost = calNormCost();
 
-      const bool keep_result
-          = cost < pre_cost || best_valid_result.pos_sequence.empty();
-
-      if (isValid() && keep_result) {
-        updateBestValidResult(best_valid_result);
+      if (best_valid_result_) {
+        const bool keep_result
+            = cost < pre_cost
+              || best_valid_result_->sequence_pair.pos_sequence.empty();
+        if (isValid() && keep_result) {
+          updateBestValidSoftResult();
+        }
       }
 
       delta_cost = cost - pre_cost;
@@ -640,86 +637,18 @@ void SimulatedAnnealingCore<T>::fastSA()
     graphics_->doNotSkip();
   }
   calPenalty();
-
-  if (!isValid() && !best_valid_result.pos_sequence.empty()) {
-    pos_seq_ = best_valid_result.pos_sequence;
-    neg_seq_ = best_valid_result.neg_sequence;
-
-    packFloorplan();
-    if (graphics_) {
-      graphics_->doNotSkip();
-    }
-    calPenalty();
-  }
-
-  if (centralization_on_) {
-    attemptCentralization(calNormCost());
-  }
-
-  if (graphics_) {
-    graphics_->endSA(calNormCost());
-  }
 }
 
 template <class T>
-void SimulatedAnnealingCore<T>::attemptCentralization(const float pre_cost)
+void SimulatedAnnealingCore<T>::updateBestValidSoftResult()
 {
-  if (outline_penalty_ > 0) {
-    return;
+  best_valid_result_->sequence_pair.pos_sequence = pos_seq_;
+  best_valid_result_->sequence_pair.neg_sequence = neg_seq_;
+
+  for (const int macro_id : pos_seq_) {
+    T& macro = macros_[macro_id];
+    best_valid_result_->macro_id_to_width[macro_id] = macro.getWidth();
   }
-
-  // In order to revert the centralization, we cache the current location
-  // of the clusters to avoid floating-point evilness when creating the
-  // x,y grid to fill the dead space by expanding mixed clusters.
-  std::map<int, std::pair<float, float>> clusters_locations;
-
-  for (int& id : pos_seq_) {
-    clusters_locations[id] = {macros_[id].getX(), macros_[id].getY()};
-  }
-
-  std::pair<float, float> offset((outline_.getWidth() - width_) / 2,
-                                 (outline_.getHeight() - height_) / 2);
-  moveFloorplan(offset);
-
-  // revert centralization
-  if (calNormCost() > pre_cost) {
-    centralization_was_reverted_ = true;
-
-    for (int& id : pos_seq_) {
-      macros_[id].setX(clusters_locations[id].first);
-      macros_[id].setY(clusters_locations[id].second);
-    }
-
-    if (graphics_) {
-      graphics_->saStep(macros_);
-    }
-
-    calPenalty();
-  }
-}
-
-template <class T>
-void SimulatedAnnealingCore<T>::moveFloorplan(
-    const std::pair<float, float>& offset)
-{
-  for (auto& id : pos_seq_) {
-    macros_[id].setX(macros_[id].getX() + offset.first);
-    macros_[id].setY(macros_[id].getY() + offset.second);
-  }
-
-  if (graphics_) {
-    graphics_->saStep(macros_);
-  }
-
-  calPenalty();
-}
-
-template <class T>
-void SimulatedAnnealingCore<T>::updateBestValidResult(
-    SequencePair& best_valid_result)
-{
-  best_valid_result.pos_sequence = pos_seq_;
-  best_valid_result.neg_sequence = neg_seq_;
 }
 
 template <class T>

--- a/src/mpl2/src/SimulatedAnnealingCore.h
+++ b/src/mpl2/src/SimulatedAnnealingCore.h
@@ -118,10 +118,8 @@ class SimulatedAnnealingCore
   float getNormFencePenalty() const;
   void getMacros(std::vector<T>& macros) const;
 
-  // Initialize the SA worker
   virtual void initialize() = 0;
   virtual void run() = 0;
-  void fastSA();
   virtual void fillDeadSpace() = 0;
 
  protected:
@@ -132,6 +130,8 @@ class SimulatedAnnealingCore
     SequencePair sequence_pair;
     std::map<int, float> macro_id_to_width;  // Macros' shapes.
   };
+
+  void fastSA();
 
   void initSequencePair();
   void updateBestValidSoftResult();

--- a/src/mpl2/src/SimulatedAnnealingCore.h
+++ b/src/mpl2/src/SimulatedAnnealingCore.h
@@ -95,12 +95,6 @@ class SimulatedAnnealingCore
   {
     macros_to_place_ = macros_to_place;
   };
-  void setCentralizationAttemptOn(bool centralization_on)
-  {
-    centralization_on_ = centralization_on;
-  };
-  bool centralizationWasReverted() { return centralization_was_reverted_; }
-
   void setNets(const std::vector<BundledNet>& nets);
   // Fence corresponds to each macro (macro_id, fence)
   void setFences(const std::map<int, Rect>& fences);
@@ -126,15 +120,21 @@ class SimulatedAnnealingCore
 
   // Initialize the SA worker
   virtual void initialize() = 0;
-  // Run FastSA algorithm
+  virtual void run() = 0;
   void fastSA();
   virtual void fillDeadSpace() = 0;
 
  protected:
+  // The same sequence pair can represent different floorplan
+  // arrangements depending on the macros' shapes.
+  struct SoftResult
+  {
+    SequencePair sequence_pair;
+    std::map<int, float> macro_id_to_width;  // Macros' shapes.
+  };
+
   void initSequencePair();
-  void attemptCentralization(float pre_cost);
-  void moveFloorplan(const std::pair<float, float>& offset);
-  void updateBestValidResult(SequencePair& best_valid_result);
+  void updateBestValidSoftResult();
 
   virtual float calNormCost() const = 0;
   virtual void calPenalty() = 0;
@@ -239,6 +239,8 @@ class SimulatedAnnealingCore
   utl::Logger* logger_ = nullptr;
   Mpl2Observer* graphics_ = nullptr;
 
+  std::unique_ptr<SoftResult> best_valid_result_;
+
   std::vector<float> cost_list_;  // store the cost in the list
   std::vector<float> T_list_;     // store the temperature
   // we define accuracy to determine whether the floorplan is valid
@@ -246,8 +248,6 @@ class SimulatedAnnealingCore
   static constexpr float acc_tolerance_ = 0.001;
 
   bool has_initial_sequence_pair_ = false;
-  bool centralization_on_ = false;
-  bool centralization_was_reverted_ = false;
 };
 
 // SACore wrapper function
@@ -256,7 +256,7 @@ template <class T>
 void runSA(T* sa_core)
 {
   sa_core->initialize();
-  sa_core->fastSA();
+  sa_core->run();
 }
 
 }  // namespace mpl2


### PR DESCRIPTION
Resolves #5996,
Resolves #6031,
Resolves #6055.

When I implemented #5908 I missed one fundamental thing: the cluster placement result (and all the other SoftMacro annealing results) is not just the sequence pair itself but rather a combination of the sequence pair along with the specific shapes chosen during a perturbation iteration. _I.e., the same sequence pair can represent different floorplan arrangements depending on the clusters' shapes._

As this only applies for SoftMacro annealing, even though the logic for storing the best valid result happens inside the base class SimulatedAnnealingCore, we can only actually use that result in the derived SACoreSoftMacro, because we need SoftMacro APIs to set the shapes that we cached. Because of that, I thought it was time to also remove the methods for floorplan centralization (which are cluster placement specific) from the base class as well.

The SoftMacro annealing result now consists of both a sequence pair and the shapes of that floorplan arrangement.

