### PR TITLE
mpl2: use best valid result for both Hard/Soft

### DIFF
--- a/src/mpl2/src/SACoreSoftMacro.cpp
+++ b/src/mpl2/src/SACoreSoftMacro.cpp
@@ -107,13 +107,7 @@ void SACoreSoftMacro::run()
     graphics_->startSA();
   }
 
-  best_valid_result_ = std::make_unique<SoftResult>();
-
   fastSA();
-
-  if (!isValid() && !best_valid_result_->sequence_pair.pos_sequence.empty()) {
-    useBestValidResult();
-  }
 
   if (centralization_on_) {
     attemptCentralization(calNormCost());
@@ -1174,31 +1168,6 @@ void SACoreSoftMacro::moveFloorplan(const std::pair<float, float>& offset)
     graphics_->saStep(macros_);
   }
 
-  calPenalty();
-}
-
-void SACoreSoftMacro::useBestValidResult()
-{
-  pos_seq_ = best_valid_result_->sequence_pair.pos_sequence;
-  neg_seq_ = best_valid_result_->sequence_pair.neg_sequence;
-
-  for (const int macro_id : pos_seq_) {
-    SoftMacro& macro = macros_[macro_id];
-    const float valid_result_width
-        = best_valid_result_->macro_id_to_width.at(macro_id);
-
-    if (macro.isMacroCluster()) {
-      const float valid_result_height = macro.getArea() / valid_result_width;
-      macro.setShapeF(valid_result_width, valid_result_height);
-    } else {
-      macro.setWidth(valid_result_width);
-    }
-  }
-
-  packFloorplan();
-  if (graphics_) {
-    graphics_->doNotSkip();
-  }
   calPenalty();
 }
 

--- a/src/mpl2/src/SACoreSoftMacro.h
+++ b/src/mpl2/src/SACoreSoftMacro.h
@@ -134,8 +134,6 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   void attemptCentralization(float pre_cost);
   void moveFloorplan(const std::pair<float, float>& offset);
 
-  void useBestValidResult();
-
   std::vector<Rect> blockages_;
 
   Cluster* root_;

--- a/src/mpl2/src/SimulatedAnnealingCore.h
+++ b/src/mpl2/src/SimulatedAnnealingCore.h
@@ -123,18 +123,19 @@ class SimulatedAnnealingCore
   virtual void fillDeadSpace() = 0;
 
  protected:
-  // The same sequence pair can represent different floorplan
-  // arrangements depending on the macros' shapes.
-  struct SoftResult
+  struct Result
   {
     SequencePair sequence_pair;
-    std::map<int, float> macro_id_to_width;  // Macros' shapes.
+    // [Only for SoftMacro] The same sequence pair can represent different
+    // floorplan arrangements depending on the macros' shapes.
+    std::map<int, float> macro_id_to_width;
   };
 
   void fastSA();
 
   void initSequencePair();
-  void updateBestValidSoftResult();
+  void updateBestValidResult();
+  void useBestValidResult();
 
   virtual float calNormCost() const = 0;
   virtual void calPenalty() = 0;
@@ -239,7 +240,7 @@ class SimulatedAnnealingCore
   utl::Logger* logger_ = nullptr;
   Mpl2Observer* graphics_ = nullptr;
 
-  std::unique_ptr<SoftResult> best_valid_result_;
+  Result best_valid_result_;
 
   std::vector<float> cost_list_;  // store the cost in the list
   std::vector<float> T_list_;     // store the temperature


### PR DESCRIPTION
Make the Result live inside the Core so that we can use the same struct for both types of Macro.
For each type there's a different type of result now:

Soft -> Sequence Pair + Shapes
Hard -> Sequence Pair (I'm not including the orientation, because the flip perturbations in SA are now deprecated and should be removed. See #6102 )