### PR TITLE
dbSta: Remove debug variable

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1273,8 +1273,6 @@ Port* dbNetwork::port(const Pin* pin) const
   dbModITerm* moditerm;
   dbModBTerm* modbterm;
   Port* ret = nullptr;
-  static int debug;
-  debug++;
   // Will return the bterm for a top level pin
   staToDb(pin, iterm, bterm, moditerm, modbterm);
 


### PR DESCRIPTION
This PR removes `debug` variable, which seems to be a leftover. It was introduced in https://github.com/The-OpenROAD-Project/OpenROAD/commit/85eabe6685f2e7e665e3d7fef30f13dbd07de849 and all its references are already gone. Moreover, this variable produces a lot of data race warnings when OR is run with ThreadSanitizer.