### PR TITLE
odb: add int64_t to swig to ensure getArea works in TCL

### DIFF
--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -58,6 +58,7 @@ using namespace odb;
 %typemap(in) (uint) = (int);
 %typemap(out) (uint) = (int);
 %typemap(out) (uint64) = (long);
+%typemap(out) (int64_t) = (long);
 %apply int* OUTPUT {int* x, int* y};
 
 %ignore odb::dbTechLayerAntennaRule::pwl_pair;


### PR DESCRIPTION
Before:
```
>>> _906ffb309d5d0000_p_odb__dbMaster getArea 
_00a1d12f9d5d0000_p_int64_t
```

After:
```
>>> _f0af0448c7590000_p_odb__dbMaster getArea
4256000
```
