### PR TITLE
gui: dont check hidden children states when toggling parent checkbox

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -872,6 +872,9 @@ void DisplayControls::toggleParent(const QStandardItem* parent,
   bool all_checked = true;
 
   for (int row = 0; row < parent->rowCount(); ++row) {
+    if (view_->isRowHidden(row, parent->index())) {
+      continue;
+    }
     auto child = parent->child(row, column);
     if (child) {
       bool checked = child->checkState() == Qt::Checked;


### PR DESCRIPTION
I noticed this when debugging https://github.com/The-OpenROAD-Project/OpenROAD/pull/6121.

Before the layers checkbox would be partially filled in (even though all visible boxes are checked):
![Pasted image](https://github.com/user-attachments/assets/c2b35bbf-0820-4ce8-8a80-b25be43963f3)

After the layers checkbox is behaving correctly:
![Pasted image (2)](https://github.com/user-attachments/assets/9aa2b40f-70db-4381-945e-22eaf6f51119)
