### PR TITLE
dbsta: add modinst optional argument to report_cell_usage

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -222,8 +222,15 @@ report_global_connect
 The `report_cell_usage` command is used to print out the usage of cells for each type of cell.
 
 ```
-report_cell_usage
+report_cell_usage [-verbose] [module instance]
 ```
+
+##### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-verbose` | Add information about all leaf instances. |
+| `module instance` | Report cell usage for a specified module instance. |
 
 ## TCL functions
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -186,10 +186,10 @@ class dbSta : public Sta, public ord::OpenRoadObserver
     int count{0};
     int64_t area{0};
   };
-  std::map<InstType, TypeStats> countInstancesByType();
+  std::map<InstType, TypeStats> countInstancesByType(odb::dbModule* module);
   std::string getInstanceTypeText(InstType type);
   InstType getInstanceType(odb::dbInst* inst);
-  void report_cell_usage(bool verbose);
+  void report_cell_usage(odb::dbModule* module, bool verbose);
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -492,12 +492,12 @@ dbSta::InstType dbSta::getInstanceType(odb::dbInst* inst)
   return STD_COMBINATIONAL;
 }
 
-std::map<dbSta::InstType, dbSta::TypeStats> dbSta::countInstancesByType()
+std::map<dbSta::InstType, dbSta::TypeStats> dbSta::countInstancesByType(
+    odb::dbModule* module)
 {
-  auto insts = db_->getChip()->getBlock()->getInsts();
   std::map<InstType, TypeStats> inst_type_stats;
 
-  for (auto inst : insts) {
+  for (auto inst : module->getLeafInsts()) {
     InstType type = getInstanceType(inst);
     auto& stats = inst_type_stats[type];
     stats.count++;
@@ -515,11 +515,11 @@ std::string toLowerCase(std::string str)
   return str;
 }
 
-void dbSta::report_cell_usage(const bool verbose)
+void dbSta::report_cell_usage(odb::dbModule* module, const bool verbose)
 {
-  auto instances_types = countInstancesByType();
+  auto instances_types = countInstancesByType(module);
   auto block = db_->getChip()->getBlock();
-  auto insts = block->getInsts();
+  auto insts = module->getLeafInsts();
   const int total_usage = insts.size();
   int64_t total_area = 0;
   const double area_to_microns = std::pow(block->getDbUnitsPerMicron(), 2);

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -526,6 +526,11 @@ void dbSta::report_cell_usage(odb::dbModule* module, const bool verbose)
 
   const char* header_format = "{:37} {:>7} {:>10}";
   const char* format = "  {:35} {:>7} {:>10.2f}";
+  if (block->getTopModule() != module) {
+    logger_->report("Cell type report for {} ({})",
+                    module->getModInst()->getHierarchicalName(),
+                    module->getName());
+  }
   logger_->report(header_format, "Cell type report:", "Count", "Area");
   for (auto [type, stats] : instances_types) {
     std::string type_name = getInstanceTypeText(type);

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -165,12 +165,12 @@ db_network_defined()
 }
 
 void
-report_cell_usage_cmd(const bool verbose)
+report_cell_usage_cmd(odb::dbModule* mod, const bool verbose)
 {
   cmdLinkedNetwork();
   ord::OpenRoad *openroad = ord::getOpenRoad();
   sta::dbSta *sta = openroad->getSta();
-  sta->report_cell_usage(verbose);
+  sta->report_cell_usage(mod, verbose);
 }
 
 // Copied from sta/verilog/Verilog.i because we don't want sta::read_verilog

--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -79,16 +79,28 @@ proc highlight_path { args } {
   }
 }
 
-define_cmd_args "report_cell_usage" {[-verbose]}
+define_cmd_args "report_cell_usage" {[-verbose] [module_inst]}
 
 proc report_cell_usage { args } {
   parse_key_args "highlight_path" args keys {} \
     flags {-verbose} 0
 
+  check_argc_eq0or1 "report_cell_usage" $args
+
   if { [ord::get_db_block] == "NULL" } {
-    sta_error "No design block found."
+    sta_error 1001 "No design block found."
   }
-  report_cell_usage_cmd [info exists flags(-verbose)]
+
+  set module [[ord::get_db_block] getTopModule]
+  if { $args != "" } {
+    set modinst [[ord::get_db_block] findModInst $args]
+    if { $modinst == "NULL" } {
+      sta_error 1002 "Unable to find $args"
+    }
+    set module [$modinst getMaster]
+  }
+
+  report_cell_usage_cmd $module [info exists flags(-verbose)]
 }
 
 # redefine sta::sta_warn/error to call utl::warn/error

--- a/src/dbSta/test/regression_tests.tcl
+++ b/src/dbSta/test/regression_tests.tcl
@@ -34,6 +34,7 @@ record_tests {
   read_verilog11
 
   report_cell_usage
+  report_cell_usage_modinsts
 
   write_verilog1
   write_verilog2

--- a/src/dbSta/test/report_cell_usage_modinsts.ok
+++ b/src/dbSta/test/report_cell_usage_modinsts.ok
@@ -7,6 +7,7 @@ Cell type report:                       Count       Area
 Cell instance report:
   snl_bufx1                                 4    4000.00
   snl_ffqx1                                 2    2000.00
+Cell type report for b1 (block1)
 Cell type report:                       Count       Area
   Buffer                                    2    2000.00
   Sequential cell                           1    1000.00
@@ -15,6 +16,7 @@ Cell type report:                       Count       Area
 Cell instance report:
   snl_bufx1                                 2    2000.00
   snl_ffqx1                                 1    1000.00
+Cell type report for b2 (block1-1)
 Cell type report:                       Count       Area
   Buffer                                    2    2000.00
   Sequential cell                           1    1000.00

--- a/src/dbSta/test/report_cell_usage_modinsts.ok
+++ b/src/dbSta/test/report_cell_usage_modinsts.ok
@@ -1,0 +1,25 @@
+[INFO ODB-0227] LEF file: liberty1.lef, created 2 layers, 6 library cells
+Cell type report:                       Count       Area
+  Buffer                                    4    4000.00
+  Sequential cell                           2    2000.00
+  Total                                     6    6000.00
+
+Cell instance report:
+  snl_bufx1                                 4    4000.00
+  snl_ffqx1                                 2    2000.00
+Cell type report:                       Count       Area
+  Buffer                                    2    2000.00
+  Sequential cell                           1    1000.00
+  Total                                     3    3000.00
+
+Cell instance report:
+  snl_bufx1                                 2    2000.00
+  snl_ffqx1                                 1    1000.00
+Cell type report:                       Count       Area
+  Buffer                                    2    2000.00
+  Sequential cell                           1    1000.00
+  Total                                     3    3000.00
+
+Cell instance report:
+  snl_bufx1                                 2    2000.00
+  snl_ffqx1                                 1    1000.00

--- a/src/dbSta/test/report_cell_usage_modinsts.tcl
+++ b/src/dbSta/test/report_cell_usage_modinsts.tcl
@@ -1,0 +1,12 @@
+# Report cell usage for modinsts
+
+source "helpers.tcl"
+read_lef liberty1.lef
+read_liberty liberty1.lib
+read_verilog hier1.v
+link_design top
+
+report_cell_usage -verbose
+
+report_cell_usage -verbose b1
+report_cell_usage -verbose b2


### PR DESCRIPTION
Changes:
- adds optional module inst argument to `report_cell_usage` to report the usage of cells in submodules. Default stays the top module.