### PR TITLE
ord: Redirect writeDb file opening exception to ORD.

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -507,8 +507,12 @@ void OpenRoad::writeDb(std::ostream& stream)
 
 void OpenRoad::writeDb(const char* filename)
 {
-  utl::StreamHandler stream_handler(filename, true);
-
+  utl::StreamHandler stream_handler;
+  try {
+    stream_handler.open(filename, true);
+  } catch (const std::ios_base::failure& f) {
+    logger_->error(ORD, 56, "{}", f.what());
+  }
   db_->write(stream_handler.getStream());
 }
 

--- a/src/utl/include/utl/ScopedTemporaryFile.h
+++ b/src/utl/include/utl/ScopedTemporaryFile.h
@@ -70,10 +70,13 @@ class ScopedTemporaryFile
 class StreamHandler
 {
  public:
+  StreamHandler() = default;
   // Set binary to true to open in binary mode
   StreamHandler(const char* filename, bool binary = false);
   ~StreamHandler();
   std::ofstream& getStream();
+  // Set binary to true to open in binary mode
+  void open(const char* filename, bool binary = false);
 
  private:
   std::string filename_;


### PR DESCRIPTION
Also add open method to strean handler so it can be instanciated outside the try block where file opening is done.