### PR TITLE
sta: set cmake policy 77 to NEW to forward the tcl readline setting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -280,6 +280,7 @@ if (NOT USE_SYSTEM_OPENSTA)
   if (TCL_READLINE_LIBRARY AND TCL_READLINE_H)
     # Pass along tcl readline enablement to OpenSTA build
     set(USE_TCL_READLINE ON)
+    set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   endif()
   add_subdirectory(sta)
 endif()


### PR DESCRIPTION
Fixes the cmake warning printed at the start of cmake config
```
-- spdlog: 1.8.1
CMake Warning (dev) at src/sta/CMakeLists.txt:32 (option):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'USE_TCL_READLINE'.
This warning is for project developers.  Use -Wno-dev to suppress it.

-- STA version: 2.6.0
```
Now:
```
-- spdlog: 1.8.1
-- STA version: 2.6.0
```