### PR TITLE
gui: Make drc marker blink when selected as for mouse over.

### DIFF
--- a/src/gui/src/drcWidget.cpp
+++ b/src/gui/src/drcWidget.cpp
@@ -225,6 +225,7 @@ void DRCWidget::clicked(const QModelIndex& index)
     } else {
       Selected t = Gui::get()->makeSelected(marker);
       emit selectDRC(t);
+      focusIndex(index);
     }
   } else {
     if (item->hasChildren()) {


### PR DESCRIPTION
Mouse over makes the marker blink and then clicking stops it. Make it continue blinking after selection.