### PR TITLE
drt: Flip map keys in graph init

### DIFF
--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -730,16 +730,28 @@ class FlexDRWorker
 
   void initGridGraph(const frDesign* design);
   void initTrackCoords(
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap);
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
   void initTrackCoords_route(
       drNet* net,
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap);
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
   void initTrackCoords_pin(
       drNet* net,
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-      std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap);
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
   void initMazeIdx();
   void initMazeIdx_connFig(drConnFig* connFig);
   void initMazeIdx_ap(drAccessPattern* ap);

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -729,29 +729,14 @@ class FlexDRWorker
   void initNets_boundaryArea();
 
   void initGridGraph(const frDesign* design);
-  void initTrackCoords(
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
-  void initTrackCoords_route(
-      drNet* net,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
-  void initTrackCoords_pin(
-      drNet* net,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap);
+  void initTrackCoords(frLayerCoordTrackPatternMap& xMap,
+                       frLayerCoordTrackPatternMap& yMap);
+  void initTrackCoords_route(drNet* net,
+                             frLayerCoordTrackPatternMap& xMap,
+                             frLayerCoordTrackPatternMap& yMap);
+  void initTrackCoords_pin(drNet* net,
+                           frLayerCoordTrackPatternMap& xMap,
+                           frLayerCoordTrackPatternMap& yMap);
   void initMazeIdx();
   void initMazeIdx_connFig(drConnFig* connFig);
   void initMazeIdx_ap(drAccessPattern* ap);

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -1580,11 +1580,11 @@ void FlexDRWorker::initNets(const frDesign* design)
 void FlexDRWorker::initTrackCoords_route(
     drNet* net,
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
 {
   // add for routes
   std::vector<drConnFig*> allObjs;
@@ -1604,29 +1604,29 @@ void FlexDRWorker::initTrackCoords_route(
         // non pref dir
         if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::HORIZONTAL) {
           if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            xMap[bp.x()][lNum + 2]
+            xMap[lNum + 2][bp.x()]
                 = nullptr;  // default add track to upper layer
           } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            xMap[bp.x()][lNum - 2] = nullptr;
+            xMap[lNum - 2][bp.x()] = nullptr;
           } else {
             std::cout << "Error: initTrackCoords cannot add non-pref track"
                       << std::endl;
           }
           // add bp, ep
-          yMap[bp.y()][lNum] = nullptr;
-          yMap[ep.y()][lNum] = nullptr;
+          yMap[lNum][bp.y()] = nullptr;
+          yMap[lNum][ep.y()] = nullptr;
           // pref dir
         } else {
-          xMap[bp.x()][lNum] = nullptr;
+          xMap[lNum][bp.x()] = nullptr;
           // add bp, ep
           if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            yMap[bp.y()][lNum + 2]
+            yMap[lNum + 2][bp.y()]
                 = nullptr;  // default add track to upper layer
-            yMap[ep.y()][lNum + 2]
+            yMap[lNum + 2][ep.y()]
                 = nullptr;  // default add track to upper layer
           } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            yMap[bp.y()][lNum - 2] = nullptr;
-            yMap[ep.y()][lNum - 2] = nullptr;
+            yMap[lNum - 2][bp.y()] = nullptr;
+            yMap[lNum - 2][ep.y()] = nullptr;
           } else {
             std::cout << "Error: initTrackCoords cannot add non-pref track"
                       << std::endl;
@@ -1637,27 +1637,27 @@ void FlexDRWorker::initTrackCoords_route(
         // non pref dir
         if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::VERTICAL) {
           if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            yMap[bp.y()][lNum + 2] = nullptr;
+            yMap[lNum + 2][bp.y()] = nullptr;
           } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            yMap[bp.y()][lNum - 2] = nullptr;
+            yMap[lNum - 2][bp.y()] = nullptr;
           } else {
             std::cout << "Error: initTrackCoords cannot add non-pref track"
                       << std::endl;
           }
           // add bp, ep
-          xMap[bp.x()][lNum] = nullptr;
-          xMap[ep.x()][lNum] = nullptr;
+          xMap[lNum][bp.x()] = nullptr;
+          xMap[lNum][ep.x()] = nullptr;
         } else {
-          yMap[bp.y()][lNum] = nullptr;
+          yMap[lNum][bp.y()] = nullptr;
           // add bp, ep
           if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            xMap[bp.x()][lNum + 2]
+            xMap[lNum + 2][bp.x()]
                 = nullptr;  // default add track to upper layer
-            xMap[ep.x()][lNum + 2]
+            xMap[lNum + 2][ep.x()]
                 = nullptr;  // default add track to upper layer
           } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            xMap[bp.x()][lNum - 2] = nullptr;
-            xMap[ep.x()][lNum - 2] = nullptr;
+            xMap[lNum - 2][bp.x()] = nullptr;
+            xMap[lNum - 2][ep.x()] = nullptr;
           } else {
             std::cout << "Error: initTrackCoords cannot add non-pref track"
                       << std::endl;
@@ -1671,17 +1671,17 @@ void FlexDRWorker::initTrackCoords_route(
       auto layer1Num = obj->getViaDef()->getLayer1Num();
       if (getTech()->getLayer(layer1Num)->getDir()
           == dbTechLayerDir::HORIZONTAL) {
-        yMap[pt.y()][layer1Num] = nullptr;
+        yMap[layer1Num][pt.y()] = nullptr;
       } else {
-        xMap[pt.x()][layer1Num] = nullptr;
+        xMap[layer1Num][pt.x()] = nullptr;
       }
       // add pref dir track to layer2
       auto layer2Num = obj->getViaDef()->getLayer2Num();
       if (getTech()->getLayer(layer2Num)->getDir()
           == dbTechLayerDir::HORIZONTAL) {
-        yMap[pt.y()][layer2Num] = nullptr;
+        yMap[layer2Num][pt.y()] = nullptr;
       } else {
-        xMap[pt.x()][layer2Num] = nullptr;
+        xMap[layer2Num][pt.x()] = nullptr;
       }
     } else if (uConnFig->typeId() == drcPatchWire) {
     } else {
@@ -1693,11 +1693,11 @@ void FlexDRWorker::initTrackCoords_route(
 void FlexDRWorker::initTrackCoords_pin(
     drNet* net,
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
 {
   // add for aps
   for (auto& pin : net->getPins()) {
@@ -1716,14 +1716,14 @@ void FlexDRWorker::initTrackCoords_pin(
       gridGraph_.addAccessPointLocation(lNum, pt.x(), pt.y());
       gridGraph_.addAccessPointLocation(lNum2, pt.x(), pt.y());
       if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::HORIZONTAL) {
-        yMap[pt.y()][lNum] = nullptr;
+        yMap[lNum][pt.y()] = nullptr;
       } else {
-        xMap[pt.x()][lNum] = nullptr;
+        xMap[lNum][pt.x()] = nullptr;
       }
       if (getTech()->getLayer(lNum2)->getDir() == dbTechLayerDir::HORIZONTAL) {
-        yMap[pt.y()][lNum2] = nullptr;
+        yMap[lNum2][pt.y()] = nullptr;
       } else {
-        xMap[pt.x()][lNum2] = nullptr;
+        xMap[lNum2][pt.x()] = nullptr;
       }
     }
   }
@@ -1731,24 +1731,24 @@ void FlexDRWorker::initTrackCoords_pin(
 
 void FlexDRWorker::initTrackCoords(
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
     boost::container::flat_map<
-        frCoord,
-        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
+        frLayerNum,
+        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
 {
   // add boundary points
   // lNum = -10 to indicate routeBox and extBox frCoord
   const auto rbox = getRouteBox();
   const auto ebox = getExtBox();
-  yMap[rbox.yMin()][-10] = nullptr;
-  yMap[rbox.yMax()][-10] = nullptr;
-  yMap[ebox.yMin()][-10] = nullptr;
-  yMap[ebox.yMax()][-10] = nullptr;
-  xMap[rbox.xMin()][-10] = nullptr;
-  xMap[rbox.xMax()][-10] = nullptr;
-  xMap[ebox.xMin()][-10] = nullptr;
-  xMap[ebox.xMax()][-10] = nullptr;
+  yMap[-10][rbox.yMin()] = nullptr;
+  yMap[-10][rbox.yMax()] = nullptr;
+  yMap[-10][ebox.yMin()] = nullptr;
+  yMap[-10][ebox.yMax()] = nullptr;
+  xMap[-10][rbox.xMin()] = nullptr;
+  xMap[-10][rbox.xMax()] = nullptr;
+  xMap[-10][ebox.xMin()] = nullptr;
+  xMap[-10][ebox.xMax()] = nullptr;
   // add all track coords
   for (auto& net : nets_) {
     initTrackCoords_route(net.get(), xMap, yMap);
@@ -1760,11 +1760,14 @@ void FlexDRWorker::initGridGraph(const frDesign* design)
 {
   // get all track coords based on existing objs and aps
   boost::container::
-      flat_map<frCoord, boost::container::flat_map<frLayerNum, frTrackPattern*>>
+      flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>
           xMap;
   boost::container::
-      flat_map<frCoord, boost::container::flat_map<frLayerNum, frTrackPattern*>>
+      flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>
           yMap;
+  size_t layerCount = design->getTech()->getLayers().size();
+  xMap.reserve(layerCount + 1);
+  yMap.reserve(layerCount + 1);
   initTrackCoords(xMap, yMap);
   gridGraph_.setCost(workerDRCCost_, workerMarkerCost_, workerFixedShapeCost_);
   gridGraph_.init(design,

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -1579,8 +1579,12 @@ void FlexDRWorker::initNets(const frDesign* design)
 
 void FlexDRWorker::initTrackCoords_route(
     drNet* net,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap)
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
 {
   // add for routes
   std::vector<drConnFig*> allObjs;
@@ -1688,8 +1692,12 @@ void FlexDRWorker::initTrackCoords_route(
 
 void FlexDRWorker::initTrackCoords_pin(
     drNet* net,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap)
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
 {
   // add for aps
   for (auto& pin : net->getPins()) {
@@ -1722,8 +1730,12 @@ void FlexDRWorker::initTrackCoords_pin(
 }
 
 void FlexDRWorker::initTrackCoords(
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap)
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap)
 {
   // add boundary points
   // lNum = -10 to indicate routeBox and extBox frCoord
@@ -1747,8 +1759,12 @@ void FlexDRWorker::initTrackCoords(
 void FlexDRWorker::initGridGraph(const frDesign* design)
 {
   // get all track coords based on existing objs and aps
-  std::map<frCoord, std::map<frLayerNum, frTrackPattern*>> xMap;
-  std::map<frCoord, std::map<frLayerNum, frTrackPattern*>> yMap;
+  boost::container::
+      flat_map<frCoord, boost::container::flat_map<frLayerNum, frTrackPattern*>>
+          xMap;
+  boost::container::
+      flat_map<frCoord, boost::container::flat_map<frLayerNum, frTrackPattern*>>
+          yMap;
   initTrackCoords(xMap, yMap);
   gridGraph_.setCost(workerDRCCost_, workerMarkerCost_, workerFixedShapeCost_);
   gridGraph_.init(design,

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -1577,14 +1577,9 @@ void FlexDRWorker::initNets(const frDesign* design)
   }
 }
 
-void FlexDRWorker::initTrackCoords_route(
-    drNet* net,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
+void FlexDRWorker::initTrackCoords_route(drNet* net,
+                                         frLayerCoordTrackPatternMap& xMap,
+                                         frLayerCoordTrackPatternMap& yMap)
 {
   // add for routes
   std::vector<drConnFig*> allObjs;
@@ -1690,14 +1685,9 @@ void FlexDRWorker::initTrackCoords_route(
   }
 }
 
-void FlexDRWorker::initTrackCoords_pin(
-    drNet* net,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
+void FlexDRWorker::initTrackCoords_pin(drNet* net,
+                                       frLayerCoordTrackPatternMap& xMap,
+                                       frLayerCoordTrackPatternMap& yMap)
 {
   // add for aps
   for (auto& pin : net->getPins()) {
@@ -1729,13 +1719,8 @@ void FlexDRWorker::initTrackCoords_pin(
   }
 }
 
-void FlexDRWorker::initTrackCoords(
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap)
+void FlexDRWorker::initTrackCoords(frLayerCoordTrackPatternMap& xMap,
+                                   frLayerCoordTrackPatternMap& yMap)
 {
   // add boundary points
   // lNum = -10 to indicate routeBox and extBox frCoord
@@ -1759,12 +1744,8 @@ void FlexDRWorker::initTrackCoords(
 void FlexDRWorker::initGridGraph(const frDesign* design)
 {
   // get all track coords based on existing objs and aps
-  boost::container::
-      flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>
-          xMap;
-  boost::container::
-      flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>
-          yMap;
+  frLayerCoordTrackPatternMap xMap;
+  frLayerCoordTrackPatternMap yMap;
   size_t layerCount = design->getTech()->getLayers().size();
   xMap.reserve(layerCount + 1);
   yMap.reserve(layerCount + 1);

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -284,16 +284,16 @@ void FlexGridGraph::initEdges(const frDesign* design,
           }
         }
       }
-      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        auto xCoord = xCoords_[xIdx];
-        auto xIt3 = xNonPrefLayerMap.find(xCoord);
-        if (xIt3 == xNonPrefLayerMap.end()) {
-          continue;
-        }
-        for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-          // get non pref track layer --> use upper layer pref dir track if
-          // possible
-          if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+      // get non pref track layer --> use upper layer pref dir track if
+      // possible
+      if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+        for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+          auto xCoord = xCoords_[xIdx];
+          auto xIt3 = xNonPrefLayerMap.find(xCoord);
+          if (xIt3 == xNonPrefLayerMap.end()) {
+            continue;
+          }
+          for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
             // add edge for non-preferred direction
             // vertical non-pref track
             if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
@@ -349,16 +349,16 @@ void FlexGridGraph::initEdges(const frDesign* design,
           }
         }
       }
-      for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-        auto yCoord = yCoords_[yIdx];
-        auto yIt3 = yNonPrefLayerMap.find(yCoord);
-        if (yIt3 == yNonPrefLayerMap.end()) {
-          continue;
-        }
-        for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-          // get non pref track layer --> use upper layer pref dir track if
-          // possible
-          if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+      // get non pref track layer --> use upper layer pref dir track if
+      // possible
+      if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+        for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
+          auto yCoord = yCoords_[yIdx];
+          auto yIt3 = yNonPrefLayerMap.find(yCoord);
+          if (yIt3 == yNonPrefLayerMap.end()) {
+            continue;
+          }
+          for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
             // add edge for non-preferred direction
             // vertical non-pref track
             if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -293,13 +293,11 @@ void FlexGridGraph::initEdges(
         }
       }
     }
-    for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-      auto yCoord = yCoords_[yIdx];
-      auto yIt2 = yLayer2Map.find(yCoord);
-      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        auto xCoord = xCoords_[xIdx];
-        auto xIt = xLayerMap.find(xCoord);
-        if (xIt == xLayerMap.end()) continue;
+    for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+      auto xCoord = xCoords_[xIdx];
+      auto xIt = xLayerMap.find(xCoord);
+      if (xIt == xLayerMap.end()) continue;
+      for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
         // add cost to out-of-die edge
         bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
         // add edge for preferred direction
@@ -315,6 +313,8 @@ void FlexGridGraph::initEdges(
               }
             }
           }
+          auto yCoord = yCoords_[yIdx];
+          auto yIt2 = yLayer2Map.find(yCoord);
           if (yIt2 == yLayer2Map.end()) continue;
           // via to upper layer
           if (!isOutOfDieVia) {
@@ -334,11 +334,11 @@ void FlexGridGraph::initEdges(
         }
       }
     }
-    for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        auto xCoord = xCoords_[xIdx];
-        auto xIt3 = xNonPrefLayerMap.find(xCoord);
-        if (xIt3 == xNonPrefLayerMap.end()) continue;
+    for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+      auto xCoord = xCoords_[xIdx];
+      auto xIt3 = xNonPrefLayerMap.find(xCoord);
+      if (xIt3 == xNonPrefLayerMap.end()) continue;
+      for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
         // get non pref track layer --> use upper layer pref dir track if
         // possible
         if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -75,11 +75,10 @@ bool FlexGridGraph::isAccessPointLocation(frLayerNum layer_num,
   const auto& layer_maze_locs = ap_locs_[layer_num];
   return layer_maze_locs.find(Point(x_coord, y_coord)) != layer_maze_locs.end();
 }
-void FlexGridGraph::initGrids(
-    const frLayerCoordTrackPatternMap& xMap,
-    const frLayerCoordTrackPatternMap& yMap,
-    const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
-    bool followGuide)
+void FlexGridGraph::initGrids(const frLayerCoordTrackPatternMap& xMap,
+                              const frLayerCoordTrackPatternMap& yMap,
+                              const frLayerDirMap& zMap,
+                              bool followGuide)
 {
   // initialize coord vectors
   initCoords(xMap, xCoords_);
@@ -214,13 +213,12 @@ bool FlexGridGraph::hasAlignedUpDefTrack(
   return false;
 }
 
-void FlexGridGraph::initEdges(
-    const frDesign* design,
-    frLayerCoordTrackPatternMap& xMap,
-    frLayerCoordTrackPatternMap& yMap,
-    const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
-    const Rect& bbox,
-    bool initDR)
+void FlexGridGraph::initEdges(const frDesign* design,
+                              frLayerCoordTrackPatternMap& xMap,
+                              frLayerCoordTrackPatternMap& yMap,
+                              const frLayerDirMap& zMap,
+                              const Rect& bbox,
+                              bool initDR)
 {
   frMIdx xDim, yDim, zDim;
   getDim(xDim, yDim, zDim);
@@ -445,7 +443,7 @@ void FlexGridGraph::init(const frDesign* design,
   halfViaEncArea_ = &via_data->halfViaEncArea;
 
   // get tracks intersecting with the Maze bbox
-  boost::container::flat_map<frLayerNum, dbTechLayerDir> zMap;
+  frLayerDirMap zMap;
   size_t layerCount = design->getTech()->getLayers().size();
   zMap.reserve(layerCount);
 
@@ -462,8 +460,7 @@ void FlexGridGraph::initTracks(
     const frDesign* design,
     frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
     frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
-    boost::container::flat_map<frLayerNum, dbTechLayerDir>&
-        layerNum2PreRouteDir,
+    frLayerDirMap& layerNum2PreRouteDir,
     const Rect& bbox)
 {
   for (auto& layer : getTech()->getLayers()) {

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -42,9 +42,7 @@ void FlexGridGraph::addAccessPointLocation(frLayerNum layer_num,
   ap_locs_[layer_num].insert(Point(x_coord, y_coord));
 }
 
-void initCoords(const boost::container::flat_map<
-                    frLayerNum,
-                    boost::container::flat_map<frCoord, frTrackPattern*>>& map,
+void initCoords(const frLayerCoordTrackPatternMap& map,
                 std::vector<frCoord>& coords)
 {
   coords.clear();
@@ -78,12 +76,8 @@ bool FlexGridGraph::isAccessPointLocation(frLayerNum layer_num,
   return layer_maze_locs.find(Point(x_coord, y_coord)) != layer_maze_locs.end();
 }
 void FlexGridGraph::initGrids(
-    const boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    const boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap,
+    const frLayerCoordTrackPatternMap& xMap,
+    const frLayerCoordTrackPatternMap& yMap,
     const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
     bool followGuide)
 {
@@ -222,12 +216,8 @@ bool FlexGridGraph::hasAlignedUpDefTrack(
 
 void FlexGridGraph::initEdges(
     const frDesign* design,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap,
+    frLayerCoordTrackPatternMap& xMap,
+    frLayerCoordTrackPatternMap& yMap,
     const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
     const Rect& bbox,
     bool initDR)
@@ -443,18 +433,13 @@ void FlexGridGraph::initEdges(
 }
 
 // initialization: update grid graph topology, does not assign edge cost
-void FlexGridGraph::init(
-    const frDesign* design,
-    const Rect& routeBBox,
-    const Rect& extBBox,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& xMap,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>& yMap,
-    bool initDR,
-    bool followGuide)
+void FlexGridGraph::init(const frDesign* design,
+                         const Rect& routeBBox,
+                         const Rect& extBBox,
+                         frLayerCoordTrackPatternMap& xMap,
+                         frLayerCoordTrackPatternMap& yMap,
+                         bool initDR,
+                         bool followGuide)
 {
   auto* via_data = getDRWorker()->getViaData();
   halfViaEncArea_ = &via_data->halfViaEncArea;
@@ -475,14 +460,8 @@ void FlexGridGraph::init(
 // get all tracks intersecting with the Maze bbox, left/bottom are inclusive
 void FlexGridGraph::initTracks(
     const frDesign* design,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>&
-        horLoc2TrackPatterns,
-    boost::container::flat_map<
-        frLayerNum,
-        boost::container::flat_map<frCoord, frTrackPattern*>>&
-        vertLoc2TrackPatterns,
+    frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
+    frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
     boost::container::flat_map<frLayerNum, dbTechLayerDir>&
         layerNum2PreRouteDir,
     const Rect& bbox)

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -263,23 +263,24 @@ void FlexGridGraph::initEdges(const frDesign* design,
               }
             }
           }
+          if (isOutOfDieVia) {
+            continue;
+          }
           auto xCoord = xCoords_[xIdx];
           auto xIt2 = xLayer2Map.find(xCoord);
           if (xIt2 == xLayer2Map.end()) {
             continue;
           }
           // via to upper layer
-          if (!isOutOfDieVia) {
-            const bool is_on_grid
-                = yIt->second != nullptr && xIt2->second != nullptr;
-            const bool allow_off_grid
-                = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
-                  || isAccessPointLocation(layerNum, xCoord, yCoord);
-            if (is_on_grid || allow_off_grid) {
-              addEdge(xIdx, yIdx, zIdx, frDirEnum::U, bbox, initDR);
-              if (!is_on_grid) {
-                setGridCostU(xIdx, yIdx, zIdx);
-              }
+          const bool is_on_grid
+              = yIt->second != nullptr && xIt2->second != nullptr;
+          const bool allow_off_grid
+              = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
+                || isAccessPointLocation(layerNum, xCoord, yCoord);
+          if (is_on_grid || allow_off_grid) {
+            addEdge(xIdx, yIdx, zIdx, frDirEnum::U, bbox, initDR);
+            if (!is_on_grid) {
+              setGridCostU(xIdx, yIdx, zIdx);
             }
           }
         }
@@ -327,24 +328,25 @@ void FlexGridGraph::initEdges(const frDesign* design,
               }
             }
           }
+          if (isOutOfDieVia) {
+            continue;
+          }
           auto yCoord = yCoords_[yIdx];
           auto yIt2 = yLayer2Map.find(yCoord);
           if (yIt2 == yLayer2Map.end()) {
             continue;
           }
           // via to upper layer
-          if (!isOutOfDieVia) {
-            const bool is_on_grid
-                = xIt->second != nullptr && yIt2->second != nullptr;
-            const bool allow_off_grid
-                = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
-                  || isAccessPointLocation(layerNum, xCoord, yCoord);
+          const bool is_on_grid
+              = xIt->second != nullptr && yIt2->second != nullptr;
+          const bool allow_off_grid
+              = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
+                || isAccessPointLocation(layerNum, xCoord, yCoord);
 
-            if (is_on_grid || allow_off_grid) {
-              addEdge(xIdx, yIdx, zIdx, frDirEnum::U, bbox, initDR);
-              if (!is_on_grid) {
-                setGridCostU(xIdx, yIdx, zIdx);
-              }
+          if (is_on_grid || allow_off_grid) {
+            addEdge(xIdx, yIdx, zIdx, frDirEnum::U, bbox, initDR);
+            if (!is_on_grid) {
+              setGridCostU(xIdx, yIdx, zIdx);
             }
           }
         }

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -292,6 +292,23 @@ void FlexGridGraph::initEdges(
           }
         }
       }
+      auto yIt3 = yNonPrefLayerMap.find(yCoord);
+      if (yIt3 == yNonPrefLayerMap.end()) continue;
+      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+        // get non pref track layer --> use upper layer pref dir track if
+        // possible
+        if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+          // add edge for non-preferred direction
+          // vertical non-pref track
+          if (dir == dbTechLayerDir::VERTICAL) {
+            if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
+                && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
+              addEdge(xIdx, yIdx, zIdx, frDirEnum::E, bbox, initDR);
+              setGridCostE(xIdx, yIdx, zIdx);
+            }
+          }
+        }
+      }
     }
     for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
       auto xCoord = xCoords_[xIdx];
@@ -333,9 +350,6 @@ void FlexGridGraph::initEdges(
           }
         }
       }
-    }
-    for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-      auto xCoord = xCoords_[xIdx];
       auto xIt3 = xNonPrefLayerMap.find(xCoord);
       if (xIt3 == xNonPrefLayerMap.end()) continue;
       for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
@@ -351,26 +365,6 @@ void FlexGridGraph::initEdges(
               setGridCostN(xIdx, yIdx, zIdx);
             }
             // horizontal non-pref track
-          }
-        }
-      }
-    }
-    for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-      auto yCoord = yCoords_[yIdx];
-      auto yIt3 = yNonPrefLayerMap.find(yCoord);
-      if (yIt3 == yNonPrefLayerMap.end()) continue;
-      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        // get non pref track layer --> use upper layer pref dir track if
-        // possible
-        if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
-          // add edge for non-preferred direction
-          // vertical non-pref track
-          if (dir == dbTechLayerDir::VERTICAL) {
-            if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
-                && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
-              addEdge(xIdx, yIdx, zIdx, frDirEnum::E, bbox, initDR);
-              setGridCostE(xIdx, yIdx, zIdx);
-            }
           }
         }
       }

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -245,7 +245,9 @@ void FlexGridGraph::initEdges(const frDesign* design,
       for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
         auto yCoord = yCoords_[yIdx];
         auto yIt = yLayerMap.find(yCoord);
-        if (yIt == yLayerMap.end()) continue;
+        if (yIt == yLayerMap.end()) {
+          continue;
+        }
         for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
           // add cost to out-of-die edge
           bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
@@ -263,14 +265,16 @@ void FlexGridGraph::initEdges(const frDesign* design,
           }
           auto xCoord = xCoords_[xIdx];
           auto xIt2 = xLayer2Map.find(xCoord);
-          if (xIt2 == xLayer2Map.end()) continue;
+          if (xIt2 == xLayer2Map.end()) {
+            continue;
+          }
           // via to upper layer
           if (!isOutOfDieVia) {
             const bool is_on_grid
-              = yIt->second != nullptr && xIt2->second != nullptr;
+                = yIt->second != nullptr && xIt2->second != nullptr;
             const bool allow_off_grid
-              = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
-              || isAccessPointLocation(layerNum, xCoord, yCoord);
+                = layer->getLef58RightWayOnGridOnlyConstraint() == nullptr
+                  || isAccessPointLocation(layerNum, xCoord, yCoord);
             if (is_on_grid || allow_off_grid) {
               addEdge(xIdx, yIdx, zIdx, frDirEnum::U, bbox, initDR);
               if (!is_on_grid) {
@@ -283,7 +287,9 @@ void FlexGridGraph::initEdges(const frDesign* design,
       for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
         auto xCoord = xCoords_[xIdx];
         auto xIt3 = xNonPrefLayerMap.find(xCoord);
-        if (xIt3 == xNonPrefLayerMap.end()) continue;
+        if (xIt3 == xNonPrefLayerMap.end()) {
+          continue;
+        }
         for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
           // get non pref track layer --> use upper layer pref dir track if
           // possible
@@ -303,7 +309,9 @@ void FlexGridGraph::initEdges(const frDesign* design,
       for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
         auto xCoord = xCoords_[xIdx];
         auto xIt = xLayerMap.find(xCoord);
-        if (xIt == xLayerMap.end()) continue;
+        if (xIt == xLayerMap.end()) {
+          continue;
+        }
         for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
           // add cost to out-of-die edge
           bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
@@ -321,7 +329,9 @@ void FlexGridGraph::initEdges(const frDesign* design,
           }
           auto yCoord = yCoords_[yIdx];
           auto yIt2 = yLayer2Map.find(yCoord);
-          if (yIt2 == yLayer2Map.end()) continue;
+          if (yIt2 == yLayer2Map.end()) {
+            continue;
+          }
           // via to upper layer
           if (!isOutOfDieVia) {
             const bool is_on_grid
@@ -342,7 +352,9 @@ void FlexGridGraph::initEdges(const frDesign* design,
       for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
         auto yCoord = yCoords_[yIdx];
         auto yIt3 = yNonPrefLayerMap.find(yCoord);
-        if (yIt3 == yNonPrefLayerMap.end()) continue;
+        if (yIt3 == yNonPrefLayerMap.end()) {
+          continue;
+        }
         for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
           // get non pref track layer --> use upper layer pref dir track if
           // possible

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -253,15 +253,15 @@ void FlexGridGraph::initEdges(
     auto& xLayerMap = xMap[layerNum];
     auto& xLayer2Map = xMap[layerNum + 2];
     auto& xNonPrefLayerMap = xMap[nonPrefLayerNum];
-    for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-      auto yCoord = yCoords_[yIdx];
-      auto yIt = yLayerMap.find(yCoord);
-      if (yIt == yLayerMap.end()) continue;
-      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        // add cost to out-of-die edge
-        bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
-        // add edge for preferred direction
-        if (dir == dbTechLayerDir::HORIZONTAL) {
+    if (dir == dbTechLayerDir::HORIZONTAL) {
+      for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
+        auto yCoord = yCoords_[yIdx];
+        auto yIt = yLayerMap.find(yCoord);
+        if (yIt == yLayerMap.end()) continue;
+        for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+          // add cost to out-of-die edge
+          bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
+          // add edge for preferred direction
           if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
               && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
             if ((!isOutOfDieVia || !hasOutOfDieViol(xIdx, yIdx, zIdx))
@@ -292,33 +292,34 @@ void FlexGridGraph::initEdges(
           }
         }
       }
-      auto yIt3 = yNonPrefLayerMap.find(yCoord);
-      if (yIt3 == yNonPrefLayerMap.end()) continue;
       for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-        // get non pref track layer --> use upper layer pref dir track if
-        // possible
-        if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
-          // add edge for non-preferred direction
-          // vertical non-pref track
-          if (dir == dbTechLayerDir::VERTICAL) {
+        auto xCoord = xCoords_[xIdx];
+        auto xIt3 = xNonPrefLayerMap.find(xCoord);
+        if (xIt3 == xNonPrefLayerMap.end()) continue;
+        for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
+          // get non pref track layer --> use upper layer pref dir track if
+          // possible
+          if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+            // add edge for non-preferred direction
+            // vertical non-pref track
             if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
                 && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
-              addEdge(xIdx, yIdx, zIdx, frDirEnum::E, bbox, initDR);
-              setGridCostE(xIdx, yIdx, zIdx);
+              addEdge(xIdx, yIdx, zIdx, frDirEnum::N, bbox, initDR);
+              setGridCostN(xIdx, yIdx, zIdx);
             }
+            // horizontal non-pref track
           }
         }
       }
-    }
-    for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
-      auto xCoord = xCoords_[xIdx];
-      auto xIt = xLayerMap.find(xCoord);
-      if (xIt == xLayerMap.end()) continue;
-      for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-        // add cost to out-of-die edge
-        bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
-        // add edge for preferred direction
-        if (dir == dbTechLayerDir::VERTICAL) {
+    } else if (dir == dbTechLayerDir::VERTICAL) {
+      for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+        auto xCoord = xCoords_[xIdx];
+        auto xIt = xLayerMap.find(xCoord);
+        if (xIt == xLayerMap.end()) continue;
+        for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
+          // add cost to out-of-die edge
+          bool isOutOfDieVia = outOfDieVia(xIdx, yIdx, zIdx, dieBox_);
+          // add edge for preferred direction
           if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
               && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
             if ((!isOutOfDieVia || !hasOutOfDieViol(xIdx, yIdx, zIdx))
@@ -350,21 +351,21 @@ void FlexGridGraph::initEdges(
           }
         }
       }
-      auto xIt3 = xNonPrefLayerMap.find(xCoord);
-      if (xIt3 == xNonPrefLayerMap.end()) continue;
       for (frMIdx yIdx = 0; yIdx < yCoords_.size(); yIdx++) {
-        // get non pref track layer --> use upper layer pref dir track if
-        // possible
-        if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
-          // add edge for non-preferred direction
-          // vertical non-pref track
-          if (dir == dbTechLayerDir::HORIZONTAL) {
+        auto yCoord = yCoords_[yIdx];
+        auto yIt3 = yNonPrefLayerMap.find(yCoord);
+        if (yIt3 == yNonPrefLayerMap.end()) continue;
+        for (frMIdx xIdx = 0; xIdx < xCoords_.size(); xIdx++) {
+          // get non pref track layer --> use upper layer pref dir track if
+          // possible
+          if (router_cfg_->USENONPREFTRACKS && !layer->isUnidirectional()) {
+            // add edge for non-preferred direction
+            // vertical non-pref track
             if (layerNum >= router_cfg_->BOTTOM_ROUTING_LAYER
                 && layerNum <= router_cfg_->TOP_ROUTING_LAYER) {
-              addEdge(xIdx, yIdx, zIdx, frDirEnum::N, bbox, initDR);
-              setGridCostN(xIdx, yIdx, zIdx);
+              addEdge(xIdx, yIdx, zIdx, frDirEnum::E, bbox, initDR);
+              setGridCostE(xIdx, yIdx, zIdx);
             }
-            // horizontal non-pref track
           }
         }
       }

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -53,9 +53,13 @@ bool FlexGridGraph::isAccessPointLocation(frLayerNum layer_num,
   return layer_maze_locs.find(Point(x_coord, y_coord)) != layer_maze_locs.end();
 }
 void FlexGridGraph::initGrids(
-    const std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    const std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
-    const std::map<frLayerNum, dbTechLayerDir>& zMap,
+    const boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    const boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+    const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
     bool followGuide)
 {
   // initialize coord vectors
@@ -200,9 +204,13 @@ bool FlexGridGraph::hasAlignedUpDefTrack(
 
 void FlexGridGraph::initEdges(
     const frDesign* design,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
-    const std::map<frLayerNum, dbTechLayerDir>& zMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+    const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
     const Rect& bbox,
     bool initDR)
 {
@@ -395,8 +403,12 @@ void FlexGridGraph::init(
     const frDesign* design,
     const Rect& routeBBox,
     const Rect& extBBox,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
     bool initDR,
     bool followGuide)
 {
@@ -404,7 +416,7 @@ void FlexGridGraph::init(
   halfViaEncArea_ = &via_data->halfViaEncArea;
 
   // get tracks intersecting with the Maze bbox
-  std::map<frLayerNum, dbTechLayerDir> zMap;
+  boost::container::flat_map<frLayerNum, dbTechLayerDir> zMap;
   initTracks(design, xMap, yMap, zMap, extBBox);
   initGrids(xMap, yMap, zMap, followGuide);  // buildGridGraph
   initEdges(
@@ -416,11 +428,16 @@ void FlexGridGraph::init(
 // get all tracks intersecting with the Maze bbox, left/bottom are inclusive
 void FlexGridGraph::initTracks(
     const frDesign* design,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>&
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>&
         horLoc2TrackPatterns,
-    std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>&
+    boost::container::flat_map<
+        frCoord,
+        boost::container::flat_map<frLayerNum, frTrackPattern*>>&
         vertLoc2TrackPatterns,
-    std::map<frLayerNum, dbTechLayerDir>& layerNum2PreRouteDir,
+    boost::container::flat_map<frLayerNum, dbTechLayerDir>&
+        layerNum2PreRouteDir,
     const Rect& bbox)
 {
   for (auto& layer : getTech()->getLayers()) {

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <boost/container/flat_map.hpp>
+#include <boost/container/flat_set.hpp>
 #include <cstdint>
 #include <cstring>
 #include <fstream>

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -46,6 +46,9 @@
 
 namespace drt {
 
+using frLayerCoordTrackPatternMap = boost::container::
+    flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>;
+
 class FlexDRWorker;
 class FlexDRGraphics;
 class FlexGridGraph
@@ -940,12 +943,8 @@ class FlexGridGraph
   void init(const frDesign* design,
             const Rect& routeBBox,
             const Rect& extBBox,
-            boost::container::flat_map<
-                frCoord,
-                boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-            boost::container::flat_map<
-                frCoord,
-                boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+            frLayerCoordTrackPatternMap& xMap,
+            frLayerCoordTrackPatternMap& yMap,
             bool initDR,
             bool followGuide);
   void print() const;
@@ -1290,34 +1289,20 @@ class FlexGridGraph
   }
   // internal init utility
   void initTracks(const frDesign* design,
-                  boost::container::flat_map<
-                      frCoord,
-                      boost::container::flat_map<frLayerNum, frTrackPattern*>>&
-                      horLoc2TrackPatterns,
-                  boost::container::flat_map<
-                      frCoord,
-                      boost::container::flat_map<frLayerNum, frTrackPattern*>>&
-                      vertLoc2TrackPatterns,
+                  frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
+                  frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
                   boost::container::flat_map<frLayerNum, dbTechLayerDir>&
                       layerNum2PreRouteDir,
                   const Rect& bbox);
   void initGrids(
-      const boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-      const boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+      const frLayerCoordTrackPatternMap& xMap,
+      const frLayerCoordTrackPatternMap& yMap,
       const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
       bool followGuide);
   void initEdges(
       const frDesign* design,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
-      boost::container::flat_map<
-          frCoord,
-          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+      frLayerCoordTrackPatternMap& xMap,
+      frLayerCoordTrackPatternMap& yMap,
       const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
       const Rect& bbox,
       bool initDR);

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -48,6 +48,7 @@ namespace drt {
 
 using frLayerCoordTrackPatternMap = boost::container::
     flat_map<frLayerNum, boost::container::flat_map<frCoord, frTrackPattern*>>;
+using frLayerDirMap = boost::container::flat_map<frLayerNum, dbTechLayerDir>;
 
 class FlexDRWorker;
 class FlexDRGraphics;
@@ -1291,21 +1292,18 @@ class FlexGridGraph
   void initTracks(const frDesign* design,
                   frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
                   frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
-                  boost::container::flat_map<frLayerNum, dbTechLayerDir>&
-                      layerNum2PreRouteDir,
+                  frLayerDirMap& layerNum2PreRouteDir,
                   const Rect& bbox);
-  void initGrids(
-      const frLayerCoordTrackPatternMap& xMap,
-      const frLayerCoordTrackPatternMap& yMap,
-      const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
-      bool followGuide);
-  void initEdges(
-      const frDesign* design,
-      frLayerCoordTrackPatternMap& xMap,
-      frLayerCoordTrackPatternMap& yMap,
-      const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
-      const Rect& bbox,
-      bool initDR);
+  void initGrids(const frLayerCoordTrackPatternMap& xMap,
+                 const frLayerCoordTrackPatternMap& yMap,
+                 const frLayerDirMap& zMap,
+                 bool followGuide);
+  void initEdges(const frDesign* design,
+                 frLayerCoordTrackPatternMap& xMap,
+                 frLayerCoordTrackPatternMap& yMap,
+                 const frLayerDirMap& zMap,
+                 const Rect& bbox,
+                 bool initDR);
   frCost getEstCost(const FlexMazeIdx& src,
                     const FlexMazeIdx& dstMazeIdx1,
                     const FlexMazeIdx& dstMazeIdx2,

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <boost/container/flat_map.hpp>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -938,8 +939,12 @@ class FlexGridGraph
   void init(const frDesign* design,
             const Rect& routeBBox,
             const Rect& extBBox,
-            std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-            std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
+            boost::container::flat_map<
+                frCoord,
+                boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+            boost::container::flat_map<
+                frCoord,
+                boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
             bool initDR,
             bool followGuide);
   void print() const;
@@ -1284,23 +1289,37 @@ class FlexGridGraph
   }
   // internal init utility
   void initTracks(const frDesign* design,
-                  std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>&
+                  boost::container::flat_map<
+                      frCoord,
+                      boost::container::flat_map<frLayerNum, frTrackPattern*>>&
                       horLoc2TrackPatterns,
-                  std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>&
+                  boost::container::flat_map<
+                      frCoord,
+                      boost::container::flat_map<frLayerNum, frTrackPattern*>>&
                       vertLoc2TrackPatterns,
-                  std::map<frLayerNum, dbTechLayerDir>& layerNum2PreRouteDir,
+                  boost::container::flat_map<frLayerNum, dbTechLayerDir>&
+                      layerNum2PreRouteDir,
                   const Rect& bbox);
   void initGrids(
-      const std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-      const std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
-      const std::map<frLayerNum, dbTechLayerDir>& zMap,
+      const boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+      const boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+      const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
       bool followGuide);
-  void initEdges(const frDesign* design,
-                 std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& xMap,
-                 std::map<frCoord, std::map<frLayerNum, frTrackPattern*>>& yMap,
-                 const std::map<frLayerNum, dbTechLayerDir>& zMap,
-                 const Rect& bbox,
-                 bool initDR);
+  void initEdges(
+      const frDesign* design,
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& xMap,
+      boost::container::flat_map<
+          frCoord,
+          boost::container::flat_map<frLayerNum, frTrackPattern*>>& yMap,
+      const boost::container::flat_map<frLayerNum, dbTechLayerDir>& zMap,
+      const Rect& bbox,
+      bool initDR);
   frCost getEstCost(const FlexMazeIdx& src,
                     const FlexMazeIdx& dstMazeIdx1,
                     const FlexMazeIdx& dstMazeIdx2,


### PR DESCRIPTION
Also use Boost's `flat_map` instead of `std::map`.

### `aes` - `asap7` - `5_2_route` - 8 thread(s)

| Branch | Min [s] | Max [s] | Mean [s] | Median [s] | Relative |
|--------|---------|---------|----------|------------|----------|
| baseline | 400.68 | 400.80 | 400.74 ± 0.04 | 400.73 | 1.05 |
| `drt-graph-init-flip-keys` | 379.85 | 380.59 | 380.27 ± 0.26 | 380.37 | 1.00 |

### `ibex` - `asap7` - `5_2_route` - 8 thread(s)

| Branch | Min [s] | Max [s] | Mean [s] | Median [s] | Relative |
|--------|---------|---------|----------|------------|----------|
| baseline | 570.60 | 570.74 | 570.67 ± 0.05 | 570.66 | 1.06 |
| `drt-graph-init-flip-keys` | 538.44 | 538.73 | 538.57 ± 0.11 | 538.54 | 1.00 |

---

### `ibex` - `nangate45` - `5_2_route` - 8 thread(s)

| Branch | Min [s] | Max [s] | Mean [s] | Median [s] | Relative |
|--------|---------|---------|----------|------------|----------|
| baseline | 168.32 | 168.69 | 168.53 ± 0.16 | 168.59 | 1.02 |
| `drt-graph-init-flip-keys` | 165.32 | 165.73 | 165.53 ± 0.17 | 165.54 | 1.00 |

### `black_parrot` - `nangate45` - `5_2_route` - 8 thread(s)

| Branch | Min [s] | Max [s] | Mean [s] | Median [s] | Relative |
|--------|---------|---------|----------|------------|----------|
| baseline | 1878.71 | 1880.53 | 1879.36 ± 0.83 | 1878.84 | 1.03 |
| `drt-graph-init-flip-keys` | 1824.96 | 1827.76 | 1826.00 ± 1.25 | 1825.29 | 1.00 |

---

I observed up to 10% speedup on some designs that I cannot share. I believe this scales nicely for bigger designs.