### PR TITLE
[Docs] Fix mermaid diagram README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ flowchart LR
     subgraph ORFlow
     direction TB
     style ORFlow fill:#ffffff00, stroke-width:0px
-        A[Verilog\n+ libraries\n + constraints] --> FLOW
+        A[Verilog
+        + libraries
+        + constraints] --> FLOW
         style A fill:#74c2b5,stroke:#000000,stroke-width:4px
         subgraph FLOW
         style FLOW fill:#FFFFFF00,stroke-width:4px
@@ -64,7 +66,8 @@ flowchart LR
             style G fill:#ff6666,stroke:#000000,stroke-width:4px
         end
 
-        FLOW --> H[GDSII\n Final Layout]
+        FLOW --> H[GDSII
+        Final Layout]
         %% H --- H1[ ]
         %% style H1 stroke-width:0px, fill: #FFFFFF00
         %% linkStyle 11 stroke-width:0px


### PR DESCRIPTION
Removes `\n` from README, seems to be a new mermaid compiler