### PR TITLE
ord/gui: add OPENROAD_SHARE to cmake and install .desktop file on Linux systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ project(OpenROAD VERSION 1
 )
 
 set(OPENROAD_HOME ${PROJECT_SOURCE_DIR})
+set(OPENROAD_SHARE ${CMAKE_INSTALL_PREFIX}/share/openroad)
 
 # Default c++ standard used unless otherwise specified in target_compile_features.
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "the C++ standard to use for this project")

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -117,3 +117,16 @@ target_include_directories(gui
 )
 
 add_subdirectory(test)
+
+set(OPENROAD_SHARE_GUI_DIR ${OPENROAD_SHARE}/gui)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  # configure desktop file
+  configure_file(
+    resources/openroad.desktop.cmake
+    resources/openroad.desktop
+  )
+
+  install(FILES resources/icon.png DESTINATION ${OPENROAD_SHARE_GUI_DIR})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/resources/openroad.desktop DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications/)
+endif()

--- a/src/gui/resources/openroad.desktop.cmake
+++ b/src/gui/resources/openroad.desktop.cmake
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=OpenROAD
+Exec=openroad -gui
+Icon=${OPENROAD_SHARE_GUI_DIR}/icon.png
+Categories=Development;Electronics


### PR DESCRIPTION
Closes #6173 

![image](https://github.com/user-attachments/assets/783f789d-d51e-4bb5-9628-f0e753bf9a78)

Adds a .desktop file for linux to install which allows Unbuntu24 to find the required icon for the taskbar.
