### PR TITLE
utl/man: ensure man pages get installed in openroad share directory to avoid clobbering other installs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,13 +179,15 @@ target_compile_definitions(openroad PRIVATE ENABLE_CHARTS)
 
 # Build man pages (Optional)
 
-# Use the processor_count command to get the number of cores
-include(ProcessorCount)
-ProcessorCount(PROCESSOR_COUNT)
-message("Number of processor cores: ${PROCESSOR_COUNT}")
-
 option(BUILD_MAN "Enable building man pages" OFF)
 if(BUILD_MAN)
+  message(STATUS "man is enabled")
+
+  # Use the processor_count command to get the number of cores
+  include(ProcessorCount)
+  ProcessorCount(PROCESSOR_COUNT)
+  message(STATUS "Number of processor cores: ${PROCESSOR_COUNT}")
+
   add_custom_target(
     man_page ALL
     COMMAND make clean && make preprocess && make all -j${PROCESSOR_COUNT}
@@ -194,6 +196,5 @@ if(BUILD_MAN)
   
   # Based on ${CMAKE_INSTALL_PREFIX}, we want to go to ${CMAKE_INSTALL_PREFIX}/share/man
   set(MANPAGE_DIR ${OPENROAD_HOME}/docs/cat)
-  install(DIRECTORY ${MANPAGE_DIR} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man)
-
+  install(DIRECTORY ${MANPAGE_DIR} DESTINATION ${OPENROAD_SHARE}/man)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -484,11 +484,6 @@ endif()
 # executable
 install(TARGETS openroad DESTINATION bin)
 
-
-if(BUILD_MAN)
-  install(DIRECTORY ${MANPAGE_DIR} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man)
-endif()
-
 ################################################################
 
 add_custom_target(openroad_tags etags -o TAGS

--- a/src/utl/src/Utl.tcl
+++ b/src/utl/src/Utl.tcl
@@ -49,14 +49,14 @@ proc man { args } {
 
   # check the default man path based on executable path
   set exec_output [info nameofexecutable]
+  set install_path [file normalize [file dirname [file dirname [info nameofexecutable]]]]
 
   # Check if the output contains 'build/src'
   if { [string match "*build/src*" $exec_output] } {
-    set executable_path [file normalize [file dirname [info nameofexecutable]]]
-    set man_path [file normalize [file dirname [file dirname $executable_path]]]
+    set man_path [file normalize [file dirname $install_path]]
     set DEFAULT_MAN_PATH [file join $man_path "docs" "cat"]
   } else {
-    set DEFAULT_MAN_PATH "/usr/local/share/man/cat"
+    set DEFAULT_MAN_PATH [file join $install_path "share" "openroad" "man" "cat"]
   }
 
   global MAN_PATH


### PR DESCRIPTION
Changes:
- installs the pages for `man` in the `OPENROAD_SHARE` share directory to avoid interfering with other installs