### PR TITLE
Rename deleted_unique_ptr to UniquePtrWithDeleter

### DIFF
--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -317,7 +317,7 @@ AbcLibrary AbcLibraryFactory::Build()
   }
   abc::Abc_SclLibNormalize(abc_library);
 
-  return AbcLibrary(utl::deleter_unique_ptr<abc::SC_Lib>(
+  return AbcLibrary(utl::UniquePtrWithDeleter<abc::SC_Lib>(
       abc_library, [](abc::SC_Lib* lib) { abc::Abc_SclLibFree(lib); }));
 }
 

--- a/src/rmp/src/abc_library_factory.cpp
+++ b/src/rmp/src/abc_library_factory.cpp
@@ -317,7 +317,7 @@ AbcLibrary AbcLibraryFactory::Build()
   }
   abc::Abc_SclLibNormalize(abc_library);
 
-  return AbcLibrary(utl::deleted_unique_ptr<abc::SC_Lib>(
+  return AbcLibrary(utl::deleter_unique_ptr<abc::SC_Lib>(
       abc_library, [](abc::SC_Lib* lib) { abc::Abc_SclLibFree(lib); }));
 }
 

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -22,7 +22,7 @@ namespace rmp {
 class AbcLibrary
 {
  public:
-  AbcLibrary(utl::deleted_unique_ptr<abc::SC_Lib> abc_library)
+  AbcLibrary(utl::deleter_unique_ptr<abc::SC_Lib> abc_library)
       : abc_library_(std::move(abc_library))
   {
   }
@@ -31,7 +31,7 @@ class AbcLibrary
   bool IsSupportedCell(const std::string& cell_name);
 
  private:
-  utl::deleted_unique_ptr<abc::SC_Lib> abc_library_;
+  utl::deleter_unique_ptr<abc::SC_Lib> abc_library_;
   std::set<std::string> supported_cells_;
 };
 

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -22,7 +22,7 @@ namespace rmp {
 class AbcLibrary
 {
  public:
-  AbcLibrary(utl::deleter_unique_ptr<abc::SC_Lib> abc_library)
+  AbcLibrary(utl::UniquePtrWithDeleter<abc::SC_Lib> abc_library)
       : abc_library_(std::move(abc_library))
   {
   }
@@ -31,7 +31,7 @@ class AbcLibrary
   bool IsSupportedCell(const std::string& cell_name);
 
  private:
-  utl::deleter_unique_ptr<abc::SC_Lib> abc_library_;
+  utl::UniquePtrWithDeleter<abc::SC_Lib> abc_library_;
   std::set<std::string> supported_cells_;
 };
 

--- a/src/rmp/src/logic_cut.cpp
+++ b/src/rmp/src/logic_cut.cpp
@@ -256,12 +256,12 @@ void CreateNets(
   }
 }
 
-utl::deleted_unique_ptr<abc::Abc_Ntk_t> LogicCut::BuildMappedAbcNetwork(
+utl::deleter_unique_ptr<abc::Abc_Ntk_t> LogicCut::BuildMappedAbcNetwork(
     AbcLibrary& abc_library,
     sta::dbNetwork* network,
     utl::Logger* logger)
 {
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> abc_network(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> abc_network(
       abc::Abc_NtkAlloc(abc::Abc_NtkType_t::ABC_NTK_NETLIST,
                         abc::Abc_NtkFunc_t::ABC_FUNC_MAP,
                         /*fUseMemMan=*/1),

--- a/src/rmp/src/logic_cut.cpp
+++ b/src/rmp/src/logic_cut.cpp
@@ -256,12 +256,12 @@ void CreateNets(
   }
 }
 
-utl::deleter_unique_ptr<abc::Abc_Ntk_t> LogicCut::BuildMappedAbcNetwork(
+utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> LogicCut::BuildMappedAbcNetwork(
     AbcLibrary& abc_library,
     sta::dbNetwork* network,
     utl::Logger* logger)
 {
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> abc_network(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> abc_network(
       abc::Abc_NtkAlloc(abc::Abc_NtkType_t::ABC_NTK_NETLIST,
                         abc::Abc_NtkFunc_t::ABC_FUNC_MAP,
                         /*fUseMemMan=*/1),

--- a/src/rmp/src/logic_cut.h
+++ b/src/rmp/src/logic_cut.h
@@ -52,7 +52,7 @@ class LogicCut
            && cut_instances_.empty();
   }
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> BuildMappedAbcNetwork(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> BuildMappedAbcNetwork(
       AbcLibrary& abc_library,
       sta::dbNetwork* network,
       utl::Logger* logger);

--- a/src/rmp/src/logic_cut.h
+++ b/src/rmp/src/logic_cut.h
@@ -52,7 +52,7 @@ class LogicCut
            && cut_instances_.empty();
   }
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> BuildMappedAbcNetwork(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> BuildMappedAbcNetwork(
       AbcLibrary& abc_library,
       sta::dbNetwork* network,
       utl::Logger* logger);

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -54,7 +54,7 @@ class AbcTest : public ::testing::Test
  protected:
   void SetUp() override
   {
-    db_ = utl::deleted_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
+    db_ = utl::deleter_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
                                                    &odb::dbDatabase::destroy);
     std::call_once(init_sta_flag, []() {
       sta::initSta();
@@ -137,7 +137,7 @@ class AbcTest : public ::testing::Test
     return primary_output_name_to_index;
   }
 
-  utl::deleted_unique_ptr<odb::dbDatabase> db_;
+  utl::deleter_unique_ptr<odb::dbDatabase> db_;
   sta::Unit* power_unit_;
   std::unique_ptr<sta::dbSta> sta_;
   sta::LibertyLibrary* library_;
@@ -251,7 +251,7 @@ TEST_F(AbcTest, TestLibraryInstallation)
     gate = abc::Mio_GateReadNext(gate);
   }
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> network(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> network(
       abc::Abc_NtkAlloc(abc::Abc_NtkType_t::ABC_NTK_NETLIST,
                         abc::Abc_NtkFunc_t::ABC_FUNC_MAP,
                         /*fUseMemMan=*/1),
@@ -284,11 +284,11 @@ TEST_F(AbcTest, TestLibraryInstallation)
 
   abc::Abc_ObjAddFanin(output, output_net);
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(network.get()), &abc::Abc_NtkDelete);
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleted_unique_ptr<int> output_vector(
+  utl::deleter_unique_ptr<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);
@@ -397,12 +397,12 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> abc_network
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   abc::Abc_NtkSetName(abc_network.get(), strdup("temp_network_name"));
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(abc_network.get()), &abc::Abc_NtkDelete);
 
   // Build map of primary output names to primary output indicies in ABC
@@ -410,7 +410,7 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
       = AbcLogicNetworkNameToPrimaryOutputIds(logic_network.get());
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleted_unique_ptr<int> output_vector(
+  utl::deleter_unique_ptr<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);
@@ -467,7 +467,7 @@ TEST_F(AbcTest, InsertingMappedLogicCutDoesNotThrow)
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   rmp::UniqueName unique_name;
@@ -497,7 +497,7 @@ TEST_F(AbcTest,
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   rmp::UniqueName unique_name;
@@ -511,13 +511,13 @@ TEST_F(AbcTest,
   LogicCut cut_post_insert
       = logic_extractor_post_insert.BuildLogicCut(abc_library);
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network_post_insert
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network_post_insert
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   abc::Abc_NtkSetName(mapped_abc_network_post_insert.get(),
                       strdup("temp_network_name"));
 
-  utl::deleted_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(mapped_abc_network_post_insert.get()),
       &abc::Abc_NtkDelete);
 
@@ -526,7 +526,7 @@ TEST_F(AbcTest,
       = AbcLogicNetworkNameToPrimaryOutputIds(logic_network.get());
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleted_unique_ptr<int> output_vector(
+  utl::deleter_unique_ptr<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -54,8 +54,8 @@ class AbcTest : public ::testing::Test
  protected:
   void SetUp() override
   {
-    db_ = utl::deleter_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
-                                                   &odb::dbDatabase::destroy);
+    db_ = utl::UniquePtrWithDeleter<odb::dbDatabase>(odb::dbDatabase::create(),
+                                                     &odb::dbDatabase::destroy);
     std::call_once(init_sta_flag, []() {
       sta::initSta();
       abc::Abc_Start();
@@ -137,7 +137,7 @@ class AbcTest : public ::testing::Test
     return primary_output_name_to_index;
   }
 
-  utl::deleter_unique_ptr<odb::dbDatabase> db_;
+  utl::UniquePtrWithDeleter<odb::dbDatabase> db_;
   sta::Unit* power_unit_;
   std::unique_ptr<sta::dbSta> sta_;
   sta::LibertyLibrary* library_;
@@ -251,7 +251,7 @@ TEST_F(AbcTest, TestLibraryInstallation)
     gate = abc::Mio_GateReadNext(gate);
   }
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> network(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> network(
       abc::Abc_NtkAlloc(abc::Abc_NtkType_t::ABC_NTK_NETLIST,
                         abc::Abc_NtkFunc_t::ABC_FUNC_MAP,
                         /*fUseMemMan=*/1),
@@ -284,11 +284,11 @@ TEST_F(AbcTest, TestLibraryInstallation)
 
   abc::Abc_ObjAddFanin(output, output_net);
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(network.get()), &abc::Abc_NtkDelete);
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleter_unique_ptr<int> output_vector(
+  utl::UniquePtrWithDeleter<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);
@@ -397,12 +397,12 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> abc_network
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   abc::Abc_NtkSetName(abc_network.get(), strdup("temp_network_name"));
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(abc_network.get()), &abc::Abc_NtkDelete);
 
   // Build map of primary output names to primary output indicies in ABC
@@ -410,7 +410,7 @@ TEST_F(AbcTest, BuildAbcMappedNetworkFromLogicCut)
       = AbcLogicNetworkNameToPrimaryOutputIds(logic_network.get());
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleter_unique_ptr<int> output_vector(
+  utl::UniquePtrWithDeleter<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);
@@ -467,7 +467,7 @@ TEST_F(AbcTest, InsertingMappedLogicCutDoesNotThrow)
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> mapped_abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   rmp::UniqueName unique_name;
@@ -497,7 +497,7 @@ TEST_F(AbcTest,
   logic_extractor.AppendEndpoint(flop_input_vertex);
   LogicCut cut = logic_extractor.BuildLogicCut(abc_library);
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> mapped_abc_network
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   rmp::UniqueName unique_name;
@@ -511,13 +511,13 @@ TEST_F(AbcTest,
   LogicCut cut_post_insert
       = logic_extractor_post_insert.BuildLogicCut(abc_library);
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> mapped_abc_network_post_insert
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> mapped_abc_network_post_insert
       = cut.BuildMappedAbcNetwork(abc_library, network, &logger_);
 
   abc::Abc_NtkSetName(mapped_abc_network_post_insert.get(),
                       strdup("temp_network_name"));
 
-  utl::deleter_unique_ptr<abc::Abc_Ntk_t> logic_network(
+  utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> logic_network(
       abc::Abc_NtkToLogic(mapped_abc_network_post_insert.get()),
       &abc::Abc_NtkDelete);
 
@@ -526,7 +526,7 @@ TEST_F(AbcTest,
       = AbcLogicNetworkNameToPrimaryOutputIds(logic_network.get());
 
   std::array<int, 2> input_vector = {1, 1};
-  utl::deleter_unique_ptr<int> output_vector(
+  utl::UniquePtrWithDeleter<int> output_vector(
       abc::Abc_NtkVerifySimulatePattern(logic_network.get(),
                                         input_vector.data()),
       &free);

--- a/src/rsz/test/cpp/TestBufferRemoval.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval.cc
@@ -48,8 +48,8 @@ class BufRemTest : public ::testing::Test
   void SetUp() override
   {
     // this will be so much easier with read_def
-    db_ = utl::deleter_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
-                                                   &odb::dbDatabase::destroy);
+    db_ = utl::UniquePtrWithDeleter<odb::dbDatabase>(odb::dbDatabase::create(),
+                                                     &odb::dbDatabase::destroy);
     std::call_once(init_sta_flag, []() { sta::initSta(); });
     sta_ = std::unique_ptr<sta::dbSta>(ord::makeDbSta());
     sta_->initVars(Tcl_CreateInterp(), db_.get(), &logger_);
@@ -197,7 +197,7 @@ class BufRemTest : public ::testing::Test
     return nullptr;
   }
 
-  utl::deleter_unique_ptr<odb::dbDatabase> db_;
+  utl::UniquePtrWithDeleter<odb::dbDatabase> db_;
   sta::Unit* power_unit_;
   std::unique_ptr<sta::dbSta> sta_;
   sta::LibertyLibrary* library_;

--- a/src/rsz/test/cpp/TestBufferRemoval.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval.cc
@@ -48,7 +48,7 @@ class BufRemTest : public ::testing::Test
   void SetUp() override
   {
     // this will be so much easier with read_def
-    db_ = utl::deleted_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
+    db_ = utl::deleter_unique_ptr<odb::dbDatabase>(odb::dbDatabase::create(),
                                                    &odb::dbDatabase::destroy);
     std::call_once(init_sta_flag, []() { sta::initSta(); });
     sta_ = std::unique_ptr<sta::dbSta>(ord::makeDbSta());
@@ -197,7 +197,7 @@ class BufRemTest : public ::testing::Test
     return nullptr;
   }
 
-  utl::deleted_unique_ptr<odb::dbDatabase> db_;
+  utl::deleter_unique_ptr<odb::dbDatabase> db_;
   sta::Unit* power_unit_;
   std::unique_ptr<sta::dbSta> sta_;
   sta::LibertyLibrary* library_;

--- a/src/utl/include/utl/deleter.h
+++ b/src/utl/include/utl/deleter.h
@@ -10,6 +10,6 @@
 namespace utl {
 
 template <typename T>
-using deleter_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
+using UniquePtrWithDeleter = std::unique_ptr<T, std::function<void(T*)>>;
 
 }

--- a/src/utl/include/utl/deleter.h
+++ b/src/utl/include/utl/deleter.h
@@ -10,6 +10,6 @@
 namespace utl {
 
 template <typename T>
-using deleted_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
+using deleter_unique_ptr = std::unique_ptr<T, std::function<void(T*)>>;
 
 }


### PR DESCRIPTION
`deleted_unique_ptr` implies that the contents are already deleted or something which is both confusing and incorrect. `UniquePtrWithDeleter` more accurately captures the intent of a unique_ptr with a custom Deleter.