### PR TITLE
utl: fix pager behavior

### DIFF
--- a/src/utl/src/Utl.tcl
+++ b/src/utl/src/Utl.tcl
@@ -75,12 +75,6 @@ proc man { args } {
     set no_pager 1
   }
 
-  #set MAN_PATH [utl::get_input]
-  #if { [utl::check_valid_man_path $MAN_PATH] == false } {
-  #  puts "Using default manpath."
-  #  set MAN_PATH $DEFAULT_MAN_PATH
-  #}
-
   set man_path $MAN_PATH
   set man_sections {}
   foreach man_section {cat1 cat2 cat3} {
@@ -107,11 +101,12 @@ proc man { args } {
       set page_size 40
 
       for { set i 0 } { $i < $num_lines } { incr i $page_size } {
-        set page [lrange $lines $i [expr { $i + $page_size - 1 }]]
+        set page_end [expr { $i + $page_size - 1 }]
+        set page [lrange $lines $i $page_end]
         puts [join $page "\n"]
 
         # Ask user to continue or quit
-        if { !$no_pager && [llength $lines] > $page_size } {
+        if { !$no_pager && $num_lines > $page_size && $page_end < $num_lines } {
           puts -nonewline "---\nPress 'q' to quit or any other key to continue: \n---"
           flush stdout
           set input [gets stdin]

--- a/src/utl/src/Utl.tcl
+++ b/src/utl/src/Utl.tcl
@@ -75,6 +75,10 @@ proc man { args } {
     set no_pager 1
   }
 
+  if { [gui::enabled] && !$no_pager } {
+    set no_pager 1
+  }
+
   set man_path $MAN_PATH
   set man_sections {}
   foreach man_section {cat1 cat2 cat3} {


### PR DESCRIPTION
Changes:
- when gui is enabled the pager does not work since it is requesting inputs from an unused stdin. The gui already have scrollbars on the log so this feature doesnt add much.
- on the last page where is no reason to ask for a user input to continue.