### PR TITLE
mpl: removing parquetfp::BTreeAreaWireAnnealer::makeMoveSlacks()

### DIFF
--- a/src/mpl/src/ParquetFP/src/btreeanneal.cxx
+++ b/src/mpl/src/ParquetFP/src/btreeanneal.cxx
@@ -1117,26 +1117,6 @@ int BTreeAreaWireAnnealer::makeMove(int& indexOrient,
   return MISC;
 }
 // --------------------------------------------------------
-int BTreeAreaWireAnnealer::makeMoveSlacks()
-{
-  //  cout << "makeMoveSlacks" << endl;
-  int movedir = rand() % 100;
-  int threshold = 50;
-  bool horizontal = (movedir < threshold);
-
-  makeMoveSlacksCore(horizontal);
-
-  static int total = 0;
-  static int numHoriz = 0;
-
-  total++;
-  numHoriz += ((horizontal) ? 1 : 0);
-
-  if (total % 1000 == 0 && _params->verb > 0)
-    cout << "total: " << total << "horiz: " << numHoriz << endl;
-  return SLACKS_MOVE;
-}
-// --------------------------------------------------------
 int BTreeAreaWireAnnealer::makeARMove()
 {
   //  cout << "makeARMove" << endl;

--- a/src/mpl/src/ParquetFP/src/btreeanneal.h
+++ b/src/mpl/src/ParquetFP/src/btreeanneal.h
@@ -75,7 +75,6 @@ class BTreeAreaWireAnnealer : public BaseAnnealer
   int makeMove(int& indexOrient,
                parquetfp::ORIENT& newOrient,
                parquetfp::ORIENT& oldOrient);  // returns 1,2,3,4,5 or -1
-  int makeMoveSlacks();                        // returns 6
   int makeMoveSlacksOrient() { return 10; }    // returns 10
   int makeMoveOrient() { return 10; }          // returns 10
   int makeARMove();                            // returns 7
@@ -137,7 +136,7 @@ class BTreeAreaWireAnnealer : public BaseAnnealer
 
   void DBfromSoln(const BTree& soln);  // update *_db from "soln"
 
-  void makeMoveSlacksCore(bool);  // used by "makeMoveSlacks" and "makeARMove"
+  void makeMoveSlacksCore(bool);  // used by "makeARMove"
   void locateSearchBlocks(int,
                           std::vector<int>&);  // used by HPWL and ARWL moves
 


### PR DESCRIPTION
Removing unused makeMoveSlacks function from parquetfp::BTreeAreaWireAnnealer.

This removes 2 static variables from mpl (issue #5981):
- parquetfp::BTreeAreaWireAnnealer::makeMoveSlacks()::total
- parquetfp::BTreeAreaWireAnnealer::makeMoveSlacks()::numHoriz