### PR TITLE
gui: help browser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,6 @@ if(BUILD_MAN)
   )
   
   # Based on ${CMAKE_INSTALL_PREFIX}, we want to go to ${CMAKE_INSTALL_PREFIX}/share/man
-  set(MANPAGE_DIR ${OPENROAD_HOME}/docs/cat)
-  install(DIRECTORY ${MANPAGE_DIR} DESTINATION ${OPENROAD_SHARE}/man)
+  install(DIRECTORY ${OPENROAD_HOME}/docs/cat DESTINATION ${OPENROAD_SHARE}/man)
+  install(DIRECTORY ${OPENROAD_HOME}/docs/html DESTINATION ${OPENROAD_SHARE}/man)
 endif()

--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -251,6 +251,9 @@ class OpenRoad
   void addObserver(OpenRoadObserver* observer);
   void removeObserver(OpenRoadObserver* observer);
 
+  std::string getExePath() const;
+  std::string getDocsPath() const;
+
   static const char* getVersion();
   static const char* getGitDescribe();
 

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -35,6 +35,7 @@
 
 #include "ord/OpenRoad.hh"
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <thread>
@@ -660,22 +661,18 @@ std::string OpenRoad::getDocsPath() const
     return "";
   }
 
+  std::filesystem::path path(exe);
+
   // remove binary name
-  std::string path = exe.substr(0, exe.find_last_of('/'));
+  path = path.parent_path();
 
-  const std::size_t build_idx = exe.length() - 13;
-  if (exe.find("/src/openroad") != build_idx - 1) {
-    path = path.substr(0, build_idx);
-
+  if (path.stem() == "src") {
     // remove build
-    path = path.substr(0, path.find_last_of('/'));
-    return path + "/docs";
+    return path.parent_path().parent_path() / "docs";
   }
 
   // remove bin
-  path = path.substr(0, path.find_last_of('/'));
-
-  return path + "/share/openroad/man";
+  return path.parent_path() / "share" / "openroad" / "man";
 }
 
 const char* OpenRoad::getVersion()

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -640,6 +640,44 @@ int OpenRoad::getThreadCount()
   return threads_;
 }
 
+std::string OpenRoad::getExePath() const
+{
+  // use tcl since it already has a cross platform implementation of this
+  if (Tcl_Eval(tcl_interp_, "file normalize [info nameofexecutable]")
+      == TCL_OK) {
+    std::string path = Tcl_GetStringResult(tcl_interp_);
+    Tcl_ResetResult(tcl_interp_);
+    return path;
+  }
+  return "";
+}
+
+std::string OpenRoad::getDocsPath() const
+{
+  const std::string exe = getExePath();
+
+  if (exe.empty()) {
+    return "";
+  }
+
+  // remove binary name
+  std::string path = exe.substr(0, exe.find_last_of('/'));
+
+  const std::size_t build_idx = exe.length() - 13;
+  if (exe.find("/src/openroad") != build_idx - 1) {
+    path = path.substr(0, build_idx);
+
+    // remove build
+    path = path.substr(0, path.find_last_of('/'));
+    return path + "/docs";
+  }
+
+  // remove bin
+  path = path.substr(0, path.find_last_of('/'));
+
+  return path + "/share/openroad/man";
+}
+
 const char* OpenRoad::getVersion()
 {
   return OPENROAD_VERSION;

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -257,6 +257,8 @@ using odb::dbTech;
 //
 ////////////////////////////////////////////////////////////////
 
+%include <std_string.i>
+
 #ifdef SWIGTCL
 %include "Exception.i"
 
@@ -612,6 +614,18 @@ void design_created()
 {
   OpenRoad *ord = getOpenRoad();
   ord->designCreated();
+}
+
+std::string get_exe_path()
+{
+  OpenRoad *ord = getOpenRoad();
+  return ord->getExePath();
+}
+
+std::string get_docs_path()
+{
+  OpenRoad *ord = getOpenRoad();
+  return ord->getDocsPath();
 }
 
 }

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -63,6 +63,7 @@ if (Qt5_FOUND AND BUILD_GUI)
     src/staGuiInterface.cpp
     src/timingWidget.cpp
     src/drcWidget.cpp
+    src/helpWidget.cpp
     src/ruler.cpp
     src/heatMap.cpp
     src/heatMapSetup.cpp

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -608,6 +608,21 @@ To remove all the rulers:
 gui::clear_rulers
 ```
 
+### Display help
+
+To display the help for a specific command or messasge.
+
+```tcl
+gui::show_help
+    cmd_msg
+```
+
+#### Options
+
+| Switch Name | Description |
+| ---- | ---- |
+| `cmd_msg`| command or message ID. |
+
 ### Set Heatmap
 
 To control the settings in the heat maps:

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -731,6 +731,8 @@ class Gui
                                       const std::string& option);
   void dumpHeatMap(const std::string& name, const std::string& file);
 
+  void selectHelp(const std::string& item);
+
   // accessors for to add and remove commands needed to restore the state of the
   // gui
   const std::vector<std::string>& getRestoreStateCommands()

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -41,6 +41,7 @@
 #include "displayControls.h"
 #include "drcWidget.h"
 #include "heatMapPlacementDensity.h"
+#include "helpWidget.h"
 #include "inspector.h"
 #include "layoutViewer.h"
 #include "mainWindow.h"
@@ -1286,6 +1287,15 @@ void Gui::init(odb::dbDatabase* db, utl::Logger* logger)
   placement_density_heat_map_->registerHeatMap();
 }
 
+void Gui::selectHelp(const std::string& item)
+{
+  if (!enabled()) {
+    return;
+  }
+
+  main_window->getHelpViewer()->selectHelp(item);
+}
+
 class SafeApplication : public QApplication
 {
  public:
@@ -1356,7 +1366,7 @@ int startGui(int& argc,
       interp, interactive, init_openroad, [&]() {
         // init remainder of GUI, to be called immediately after OpenRoad is
         // guaranteed to be initialized.
-        main_window->init(open_road->getSta());
+        main_window->init(open_road->getSta(), open_road->getDocsPath());
         // announce design created to ensure GUI gets setup
         main_window->postReadDb(main_window->getDb());
       });

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -741,4 +741,13 @@ void unminimize()
   gui->unminimize();
 }
 
+void show_help(const std::string& item)
+{
+  if (!check_gui("show_help")) {
+    return;
+  }
+  auto gui = gui::Gui::get();
+  gui->selectHelp(item);
+}
+
 %} // inline

--- a/src/gui/src/helpWidget.cpp
+++ b/src/gui/src/helpWidget.cpp
@@ -1,0 +1,189 @@
+/////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2024, The Regents of the University of California
+// All rights reserved.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#include "helpWidget.h"
+
+#include <dirent.h>
+#include <sys/stat.h>
+
+#include <QFile>
+#include <QHBoxLayout>
+#include <QListWidgetItem>
+#include <QTextStream>
+#include <QVBoxLayout>
+
+namespace gui {
+
+HelpWidget::HelpWidget(QWidget* parent)
+    : QDockWidget("Help Browser", parent),
+      category_selector_(new QComboBox(this)),
+      help_list_(new QListWidget(this)),
+      viewer_(new QTextBrowser(this))
+{
+  setObjectName("help_viewer");
+
+  has_help_ = false;
+
+  viewer_->setOpenExternalLinks(true);
+
+  QHBoxLayout* layout = new QHBoxLayout;
+
+  QVBoxLayout* select_layout = new QVBoxLayout;
+  select_layout->addWidget(category_selector_);
+  select_layout->addWidget(help_list_, /* stretch*/ 1);
+
+  layout->addLayout(select_layout);
+  layout->addWidget(viewer_, /* stretch*/ 1);
+
+  QWidget* container = new QWidget(this);
+  container->setLayout(layout);
+  setWidget(container);
+
+  // add connect
+  connect(category_selector_,
+          qOverload<int>(&QComboBox::currentIndexChanged),
+          this,
+          &HelpWidget::changeCategory);
+  connect(help_list_,
+          &QListWidget::currentItemChanged,
+          this,
+          &HelpWidget::showHelpInformation);
+}
+
+void HelpWidget::init(const std::string& path)
+{
+  category_selector_->clear();
+
+  // validate path
+  struct stat dir_info;
+  if (stat(path.c_str(), &dir_info) == 0) {
+    // check for html
+    const std::string html_path = path + "/html";
+    if (stat(html_path.c_str(), &dir_info) != 0) {
+      return;
+    }
+
+    // add html1, html2, html3
+    auto add_help = [this, &html_path](const std::string& category,
+                                       const std::string dir) {
+      struct stat dir_info;
+      const std::string doc_path = html_path + "/" + dir;
+      if (stat(doc_path.c_str(), &dir_info) == 0) {
+        category_selector_->addItem(QString::fromStdString(category),
+                                    QString::fromStdString(doc_path));
+        has_help_ = true;
+      }
+    };
+
+    add_help("application", "html1");
+    add_help("commands", "html2");
+    add_help("messages", "html3");
+  }
+
+  if (hasHelp()) {
+    category_selector_->setCurrentIndex(1);
+  }
+}
+
+void HelpWidget::changeCategory()
+{
+  help_list_->clear();
+
+  const std::string path
+      = category_selector_->currentData().toString().toStdString();
+
+  DIR* dir = opendir(path.c_str());
+
+  if (dir == nullptr) {
+    return;
+  }
+
+  struct dirent* ent;
+  while ((ent = readdir(dir)) != nullptr) {
+    const std::string help_path = path + "/" + ent->d_name;
+
+    if (help_path.find(".html") == std::string::npos) {
+      continue;
+    }
+
+    const std::string name = std::string(ent->d_name, strlen(ent->d_name) - 5);
+
+    auto* qitem = new QListWidgetItem(QString::fromStdString(name));
+    qitem->setData(Qt::UserRole, QString::fromStdString(help_path));
+    help_list_->addItem(qitem);
+  }
+
+  closedir(dir);
+
+  help_list_->sortItems();
+}
+
+void HelpWidget::showHelpInformation(QListWidgetItem* item)
+{
+  if (item == nullptr) {
+    return;
+  }
+  const QString path = item->data(Qt::UserRole).toString();
+  QFile html_file(path);
+  if (html_file.open(QIODevice::ReadOnly)) {
+    QTextStream in(&html_file);
+    viewer_->setHtml(in.readAll());
+  } else {
+    viewer_->setHtml("Unable to open: " + path);
+  }
+}
+
+void HelpWidget::selectHelp(const std::string& item)
+{
+  const int start_index = category_selector_->currentIndex();
+
+  for (int i = 0; i < category_selector_->count(); i++) {
+    category_selector_->setCurrentIndex(i);
+
+    const auto help_items
+        = help_list_->findItems(QString::fromStdString(item), Qt::MatchExactly);
+    if (!help_items.empty()) {
+      raise();
+      show();
+
+      help_list_->setCurrentItem(help_items[0]);
+      return;
+    }
+  }
+
+  category_selector_->setCurrentIndex(start_index);
+}
+
+}  // namespace gui

--- a/src/gui/src/helpWidget.h
+++ b/src/gui/src/helpWidget.h
@@ -1,0 +1,70 @@
+/////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2024, The Regents of the University of California
+// All rights reserved.
+//
+// BSD 3-Clause License
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// * Neither the name of the copyright holder nor the names of its
+//   contributors may be used to endorse or promote products derived from
+//   this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <QComboBox>
+#include <QDockWidget>
+#include <QListWidget>
+#include <QTextBrowser>
+
+#include "gui/gui.h"
+
+namespace gui {
+
+class HelpWidget : public QDockWidget
+{
+  Q_OBJECT
+
+ public:
+  HelpWidget(QWidget* parent = nullptr);
+
+  void init(const std::string& path);
+  bool hasHelp() const { return has_help_; }
+  void selectHelp(const std::string& item);
+
+ public slots:
+  void changeCategory();
+  void showHelpInformation(QListWidgetItem* item);
+
+ private:
+  QComboBox* category_selector_;
+  QListWidget* help_list_;
+  QTextBrowser* viewer_;
+
+  bool has_help_;
+};
+
+}  // namespace gui

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -60,6 +60,7 @@
 #include "drcWidget.h"
 #include "globalConnectDialog.h"
 #include "gui/heatMap.h"
+#include "helpWidget.h"
 #include "highlightGroupDialog.h"
 #include "inspector.h"
 #include "layoutTabs.h"
@@ -109,6 +110,7 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
       hierarchy_widget_(
           new BrowserWidget(viewers_->getModuleSettings(), controls_, this)),
       charts_widget_(new ChartsWidget(this)),
+      help_widget_(new HelpWidget(this)),
       find_dialog_(new FindObjectDialog(this)),
       goto_dialog_(new GotoLocationDialog(this, viewers_))
 {
@@ -131,6 +133,7 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
   addDockWidget(Qt::RightDockWidgetArea, drc_viewer_);
   addDockWidget(Qt::RightDockWidgetArea, clock_viewer_);
   addDockWidget(Qt::RightDockWidgetArea, charts_widget_);
+  addDockWidget(Qt::RightDockWidgetArea, help_widget_);
 
   tabifyDockWidget(selection_browser_, script_);
   selection_browser_->hide();
@@ -140,6 +143,8 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
   tabifyDockWidget(inspector_, drc_viewer_);
   tabifyDockWidget(inspector_, clock_viewer_);
   tabifyDockWidget(inspector_, charts_widget_);
+  tabifyDockWidget(inspector_, help_widget_);
+
   drc_viewer_->hide();
   clock_viewer_->hide();
 
@@ -461,7 +466,7 @@ void MainWindow::setBlock(odb::dbBlock* block)
   hierarchy_widget_->setBlock(block);
 }
 
-void MainWindow::init(sta::dbSta* sta)
+void MainWindow::init(sta::dbSta* sta, const std::string& help_path)
 {
   // Setup widgets
   timing_widget_->init(sta);
@@ -471,6 +476,7 @@ void MainWindow::init(sta::dbSta* sta)
 #ifdef ENABLE_CHARTS
   charts_widget_->setSTA(sta);
 #endif
+  help_widget_->init(help_path);
 
   // register descriptors
   auto* gui = Gui::get();
@@ -785,6 +791,7 @@ void MainWindow::createMenus()
   windows_menu_->addAction(clock_viewer_->toggleViewAction());
   windows_menu_->addAction(hierarchy_widget_->toggleViewAction());
   windows_menu_->addAction(charts_widget_->toggleViewAction());
+  windows_menu_->addAction(help_widget_->toggleViewAction());
 
   auto option_menu = menuBar()->addMenu("&Options");
   option_menu->addAction(hide_option_);

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -72,6 +72,7 @@ class DRCWidget;
 class ClockWidget;
 class BrowserWidget;
 class ChartsWidget;
+class HelpWidget;
 
 // This is the main window for the GUI.  Currently we use a single
 // instance of this class.
@@ -84,7 +85,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   ~MainWindow();
 
   void setDatabase(odb::dbDatabase* db);
-  void init(sta::dbSta* sta);
+  void init(sta::dbSta* sta, const std::string& help_path);
 
   odb::dbDatabase* getDb() const { return db_; }
 
@@ -106,6 +107,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   ClockWidget* getClockViewer() const { return clock_viewer_; }
   ScriptWidget* getScriptWidget() const { return script_; }
   Inspector* getInspector() const { return inspector_; }
+  HelpWidget* getHelpViewer() const { return help_widget_; }
 
   std::vector<std::string> getRestoreTclCommands();
 
@@ -318,6 +320,7 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   ClockWidget* clock_viewer_;
   BrowserWidget* hierarchy_widget_;
   ChartsWidget* charts_widget_;
+  HelpWidget* help_widget_;
 
   FindObjectDialog* find_dialog_;
   GotoLocationDialog* goto_dialog_;

--- a/src/utl/src/Utl.tcl
+++ b/src/utl/src/Utl.tcl
@@ -47,17 +47,7 @@ proc man { args } {
 
   set name [lindex $args 0]
 
-  # check the default man path based on executable path
-  set exec_output [info nameofexecutable]
-  set install_path [file normalize [file dirname [file dirname [info nameofexecutable]]]]
-
-  # Check if the output contains 'build/src'
-  if { [string match "*build/src*" $exec_output] } {
-    set man_path [file normalize [file dirname $install_path]]
-    set DEFAULT_MAN_PATH [file join $man_path "docs" "cat"]
-  } else {
-    set DEFAULT_MAN_PATH [file join $install_path "share" "openroad" "man" "cat"]
-  }
+  set DEFAULT_MAN_PATH [file join [ord::get_docs_path] "cat"]
 
   global MAN_PATH
   if { [info exists keys(-manpath)] } {


### PR DESCRIPTION
Adds:
- `HelpBrowser` widget to allow for interactive / offline viewing of help if it's available.

Changes:
- Adds two functions to OpenROAD to allow for a centralized location to determine the location of the docs
- `man` switched to use new path access.

Notes:
- ~Due to the exclusion of `std::filesystem` I had to do path and directory handling manually, this can be simplified if `std::filesystem` is allowed.~
- `man` could be configured to open the gui help if we want.
- The HTML help is not particularly pretty and I don't find it helpful to know the compile date or header, but these issues can be handled separately.
- The script widget could be modified to allow for hyperlinks to this widget got commands and error messages (that would be best handled in a separate PR).
- there are lots of missing functions from this (outside the scope of this PR), but anything in ODB, ORD, and STA are completely missing.
- the GUI commands probably just need to be promoted out of the namespace from `gui::show` -> `gui_show` or `show_gui` since the man page generation clobbers its name (should be done in a separate PR).

Preview:
![image](https://github.com/user-attachments/assets/c17d2346-5372-40de-89fa-94c8d70c85c1)
