### PR TITLE
drt: Use boost flat hashmap when beneficial

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -74,9 +74,9 @@ _installCommonDev() {
     pcreChecksum="37d2f77cfd411a3ddf1c64e1d72e43f7"
     swigVersion=4.1.0
     swigChecksum="794433378154eb61270a3ac127d9c5f3"
-    boostVersionBig=1.80
+    boostVersionBig=1.86
     boostVersionSmall=${boostVersionBig}.0
-    boostChecksum="077f074743ea7b0cb49c6ed43953ae95"
+    boostChecksum="ac857d73bb754b718a039830b07b9624"
     eigenVersion=3.4
     cuddVersion=3.0.0
     lemonVersion=1.3.1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,8 +172,11 @@ if (SWIG_VERSION VERSION_GREATER_EQUAL "4.1.0")
 endif()
 include(UseSWIG)
 
-find_package(Boost REQUIRED)
+find_package(Boost 1.81.0)
 message(STATUS "boost: ${Boost_VERSION}")
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "No suitable version of boost found. Consider (re)running `<OpenROAD-dir>/etc/DependencyInstaller.sh -common`")
+endif()
 
 if (ENABLE_TESTS)
   find_package(GTest REQUIRED)

--- a/src/drt/src/db/infra/frPoint.h
+++ b/src/drt/src/db/infra/frPoint.h
@@ -68,8 +68,7 @@ class Point3D : public Point
   friend std::size_t hash_value(Point3D const& p)
   {
     std::size_t seed = 0;
-    boost::hash_combine(seed, p.getX());
-    boost::hash_combine(seed, p.getY());
+    boost::hash_combine(seed, hash_value(((Point)p)));
     boost::hash_combine(seed, p.getZ());
     return seed;
   }

--- a/src/drt/src/db/infra/frPoint.h
+++ b/src/drt/src/db/infra/frPoint.h
@@ -65,6 +65,15 @@ class Point3D : public Point
     return z_ < rhs.z_;
   }
 
+  friend std::size_t hash_value(Point3D const& p)
+  {
+    std::size_t seed = 0;
+    boost::hash_combine(seed, p.getX());
+    boost::hash_combine(seed, p.getY());
+    boost::hash_combine(seed, p.getZ());
+    return seed;
+  }
+
  private:
   int z_{0};
   template <class Archive>

--- a/src/drt/src/gc/FlexGC_impl.h
+++ b/src/drt/src/gc/FlexGC_impl.h
@@ -34,6 +34,7 @@
 #include "dr/FlexDR.h"
 #include "frDesign.h"
 #include "gc/FlexGC.h"
+#include <boost/unordered/unordered_flat_set.hpp>
 
 namespace odb {
 class dbTechLayerCutSpacingTableDefRule;
@@ -189,31 +190,31 @@ class FlexGCWorker::Impl
   void initNet_pins_polygonEdges(gcNet* net);
   void initNet_pins_polygonEdges_getFixedPolygonEdges(
       gcNet* net,
-      std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges);
+      std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges);
   void initNet_pins_polygonEdges_helper_outer(
       gcNet* net,
       gcPin* pin,
       gcPolygon* poly,
       frLayerNum i,
-      const std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges);
+      const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges);
   void initNet_pins_polygonEdges_helper_inner(
       gcNet* net,
       gcPin* pin,
       const gtl::polygon_90_data<frCoord>& hole_poly,
       frLayerNum i,
-      const std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges);
+      const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges);
   void initNet_pins_polygonCorners(gcNet* net);
   void initNet_pins_polygonCorners_helper(gcNet* net, gcPin* pin);
   void initNet_pins_maxRectangles(gcNet* net);
   void initNet_pins_maxRectangles_getFixedMaxRectangles(
       gcNet* net,
-      std::vector<std::set<std::pair<Point, Point>>>& fixedMaxRectangles);
+      std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedMaxRectangles);
   void initNet_pins_maxRectangles_helper(
       gcNet* net,
       gcPin* pin,
       const gtl::rectangle_data<frCoord>& rect,
       frLayerNum i,
-      const std::vector<std::set<std::pair<Point, Point>>>& fixedMaxRectangles);
+      const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedMaxRectangles);
 
   void initRegionQuery();
 

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -486,7 +486,7 @@ void FlexGCWorker::Impl::initNet_pins_polygon(gcNet* net)
 
 void FlexGCWorker::Impl::initNet_pins_polygonEdges_getFixedPolygonEdges(
     gcNet* net,
-    std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges)
+    std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges)
 {
   int numLayers = getTech()->getLayers().size();
   std::vector<gtl::polygon_90_with_holes_data<frCoord>> polys;
@@ -552,7 +552,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_outer(
     gcPin* pin,
     gcPolygon* poly,
     frLayerNum i,
-    const std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges)
+    const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges)
 {
   Point bp, ep, firstPt;
   gtl::point_data<frCoord> bp1, ep1, firstPt1;
@@ -626,7 +626,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_inner(
     gcPin* pin,
     const gtl::polygon_90_data<frCoord>& hole_poly,
     frLayerNum i,
-    const std::vector<std::set<std::pair<Point, Point>>>& fixedPolygonEdges)
+    const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedPolygonEdges)
 {
   Point bp, ep, firstPt;
   gtl::point_data<frCoord> bp1, ep1, firstPt1;
@@ -698,7 +698,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonEdges_helper_inner(
 void FlexGCWorker::Impl::initNet_pins_polygonEdges(gcNet* net)
 {
   int numLayers = getTech()->getLayers().size();
-  std::vector<std::set<std::pair<Point, Point>>> fixedPolygonEdges(numLayers);
+  std::vector<boost::unordered_flat_set<std::pair<Point, Point>>> fixedPolygonEdges(numLayers);
   // get all fixed polygon edges
   initNet_pins_polygonEdges_getFixedPolygonEdges(net, fixedPolygonEdges);
 
@@ -820,7 +820,7 @@ void FlexGCWorker::Impl::initNet_pins_polygonCorners(gcNet* net)
 
 void FlexGCWorker::Impl::initNet_pins_maxRectangles_getFixedMaxRectangles(
     gcNet* net,
-    std::vector<std::set<std::pair<Point, Point>>>& fixedMaxRectangles)
+    std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedMaxRectangles)
 {
   int numLayers = getTech()->getLayers().size();
   std::vector<gtl::rectangle_data<frCoord>> rects;
@@ -846,7 +846,7 @@ void FlexGCWorker::Impl::initNet_pins_maxRectangles_helper(
     gcPin* pin,
     const gtl::rectangle_data<frCoord>& rect,
     frLayerNum i,
-    const std::vector<std::set<std::pair<Point, Point>>>& fixedMaxRectangles)
+    const std::vector<boost::unordered_flat_set<std::pair<Point, Point>>>& fixedMaxRectangles)
 {
   auto rectangle = std::make_unique<gcRect>();
   rectangle->setRect(rect);
@@ -884,7 +884,7 @@ void FlexGCWorker::Impl::initNet_pins_maxRectangles_helper(
 void FlexGCWorker::Impl::initNet_pins_maxRectangles(gcNet* net)
 {
   int numLayers = getTech()->getLayers().size();
-  std::vector<std::set<std::pair<Point, Point>>> fixedMaxRectangles(numLayers);
+  std::vector<boost::unordered_flat_set<std::pair<Point, Point>>> fixedMaxRectangles(numLayers);
   // get all fixed max rectangles
   initNet_pins_maxRectangles_getFixedMaxRectangles(net, fixedMaxRectangles);
 

--- a/src/drt/src/io/GuideProcessor.cpp
+++ b/src/drt/src/io/GuideProcessor.cpp
@@ -1155,7 +1155,7 @@ void addSplitRect(const frCoord track_idx,
 void GuideProcessor::genGuides_split(
     std::vector<frRect>& rects,
     const TrackIntervalsByLayer& intvs,
-    const std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+    const boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
     frBlockObjectMap<std::set<Point3D>>& pin_gcell_map,
     bool via_access_only) const
 {
@@ -1258,7 +1258,7 @@ void GuideProcessor::genGuides_split(
 }
 
 void GuideProcessor::mapPinShapesToGCells(
-    std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+    boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
     frBlockObject* term) const
 {
   const auto pin_shapes = getPinShapes(term);
@@ -1279,7 +1279,7 @@ void GuideProcessor::mapPinShapesToGCells(
 
 void GuideProcessor::initGCellPinMap(
     const frNet* net,
-    std::map<Point3D, frBlockObjectSet>& gcell_pin_map) const
+    boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map) const
 {
   for (auto instTerm : net->getInstTerms()) {
     mapTermAccessPointsToGCells(gcell_pin_map, instTerm);
@@ -1290,7 +1290,7 @@ void GuideProcessor::initGCellPinMap(
 }
 
 void GuideProcessor::mapTermAccessPointsToGCells(
-    std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+    boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
     frBlockObject* pin) const
 {
   for (const auto& ap_loc : getAccessPoints(pin)) {
@@ -1372,7 +1372,7 @@ std::vector<std::pair<frBlockObject*, Point>> GuideProcessor::genGuides(
   }
   genGuides_prep(rects, intvs);
 
-  std::map<Point3D, frBlockObjectSet> gcell_pin_map;
+  boost::unordered_flat_map<Point3D, frBlockObjectSet> gcell_pin_map;
   frBlockObjectMap<std::set<Point3D>> pin_gcell_map;
   initGCellPinMap(net, gcell_pin_map);
   initPinGCellMap(net, pin_gcell_map);

--- a/src/drt/src/io/GuideProcessor.h
+++ b/src/drt/src/io/GuideProcessor.h
@@ -32,6 +32,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #pragma once
 #include <boost/icl/interval_set.hpp>
+#include <boost/unordered/unordered_flat_map.hpp>
 
 #include "db/tech/frTechObject.h"
 #include "frDesign.h"
@@ -173,7 +174,7 @@ class GuideProcessor
    */
   void genGuides_split(std::vector<frRect>& rects,
                        const TrackIntervalsByLayer& intvs,
-                       const std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+                       const boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
                        frBlockObjectMap<std::set<Point3D>>& pin_gcell_map,
                        bool via_access_only) const;
   /**
@@ -188,7 +189,7 @@ class GuideProcessor
    */
   void initGCellPinMap(
       const frNet* net,
-      std::map<Point3D, frBlockObjectSet>& gcell_pin_map) const;
+      boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map) const;
   /**
    * Populates gcell_pin_map with the values associated with the passed term
    * based on pin shapes.
@@ -200,7 +201,7 @@ class GuideProcessor
    * @param gcell_pin_map The map to be populated with the results.
    * @param term The current pin we are processing.
    */
-  void mapPinShapesToGCells(std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+  void mapPinShapesToGCells(boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
                             frBlockObject* term) const;
   /**
    * Populates gcell_pin_map with the values associated with the passed pin
@@ -214,7 +215,7 @@ class GuideProcessor
    * @param term The current pin we are processing.
    */
   void mapTermAccessPointsToGCells(
-      std::map<Point3D, frBlockObjectSet>& gcell_pin_map,
+      boost::unordered_flat_map<Point3D, frBlockObjectSet>& gcell_pin_map,
       frBlockObject* pin) const;
 
   void initPinGCellMap(frNet* net,
@@ -423,7 +424,7 @@ class GuidePathFinder
   Logger* logger_{nullptr};
   frNet* net_{nullptr};
   bool force_feed_through_{false};
-  std::map<Point3D, std::set<int>> node_map_;
+  boost::unordered_flat_map<Point3D, std::set<int>> node_map_;
   int guide_count_{0};
   int node_count_{0};
   bool allow_warnings_{false};

--- a/src/drt/src/pa/FlexPA_unique.h
+++ b/src/drt/src/pa/FlexPA_unique.h
@@ -27,6 +27,8 @@
 
 #pragma once
 
+#include <boost/unordered/unordered_flat_map.hpp>
+
 #include "frDesign.h"
 
 namespace drt {
@@ -156,7 +158,7 @@ class UniqueInsts
   // Mapp all instances to their representative unique instance
   std::map<frInst*, frInst*, frBlockObjectComp> inst_to_unique_;
   // Maps all instances to the set of instances with the same unique inst
-  std::unordered_map<frInst*, InstSet*> inst_to_class_;
+  boost::unordered_flat_map<frInst*, InstSet*> inst_to_class_;
   // Maps a unique instance to its pin access index
   std::map<frInst*, int, frBlockObjectComp> unique_to_pa_idx_;
   // Maps a unique instance to its index in unique_

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -40,6 +40,7 @@
 #include "isotropy.h"
 #include "odb.h"
 #include "utl/Logger.h"
+#include <boost/functional/hash.hpp>
 
 namespace odb {
 
@@ -89,6 +90,19 @@ class Point
   int x_ = 0;
   int y_ = 0;
 };
+
+inline std::size_t hash_value(Point const& p)
+{
+  size_t hash = 0;
+  if constexpr (sizeof(size_t) == 8 && sizeof(size_t) == 2*sizeof(int)) {
+    // Use fast identity hash if possible. We don't care about avalanching since it will be mixed later by flat_map anyway
+    return ((size_t)p.getX() << 32) | p.getY();
+   } else {
+    boost::hash_combine(hash, p.x());
+    boost::hash_combine(hash, p.y());
+  }
+  return hash;
+}
 
 std::ostream& operator<<(std::ostream& os, const Point& pIn);
 


### PR DESCRIPTION
- Bump `boost` to get flat hashtables
- Replace `std::set` indexed by pair of Points with boost `boost::unordered_flat_set`
- Replace `std::map` indexed by Point3D with `boost::unordered_flat_map`
- Replace `std::unordered_map` with `boost::unordered_flat_map` (this was the single case, in which DRT already used hashtable rather than search tree)

Benchmarks of `drt`:

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `boost-flat-hashmap-opt` | 286.27 | 287.44 | 286.77 ± 0.35 | 1.00 ± 0.00 | 286.73 | 1.00 |
| baseline | 290.79 | 292.14 | 291.41 ± 0.41 | 1.02 ± 0.00 | 291.35 | 1.02 |
| boost-1.86 | 290.49 | 292.40 | 291.36 ± 0.54 | 1.02 ± 0.00 | 291.26 | 1.02 |                                                                                                                                                                                                       

# `ibex`, PDK: `nangate45`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `boost-flat-hashmap-opt` | 87.66 | 88.38 | 88.00 ± 0.17 | 1.00 ± 0.00 | 88.00 | 1.00 |
| baseline | 89.15 | 89.83 | 89.39 ± 0.22 | 1.02 ± 0.00 | 89.31 | 1.01 |
| boost-1.86 | 89.11 | 89.51 | 89.33 ± 0.12 | 1.02 ± 0.00 | 89.31 | 1.01 |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
# `black_parrot`, PDK: `nangate45`                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                          
| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |                                                                                                                                                                                                  
|--------|---------|---------|----------|---------------|------------|-----------------|                                                                                                                                                                                                  
| `boost-flat-hashmap-opt` | 1035.30 | 1039.40 | 1036.90 ± 1.01 | 1.00 ± 0.00 | 1036.85 | 1.00 |                                                                                                                                                                                    
| baseline | 1056.01 | 1057.20 | 1056.48 ± 0.33 | 1.02 ± 0.00 | 1056.44 | 1.02 |                                                                                                                                                                                             
| boost-1.86 | 1057.09 | 1058.94 | 1057.84 ± 0.54 | 1.02 ± 0.00 | 1057.72 | 1.02 |   

 