### PR TITLE
mpl2: add option to show cluster id instead of sequence pair id

### DIFF
--- a/src/mpl2/include/mpl2/rtl_mp.h
+++ b/src/mpl2/include/mpl2/rtl_mp.h
@@ -111,6 +111,7 @@ class MacroPlacer2
 
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);
   void setDebugShowBundledNets(bool show_bundled_nets);
+  void setDebugShowClustersIds(bool show_clusters_ids);
   void setDebugSkipSteps(bool skip_steps);
   void setDebugOnlyFinalResult(bool only_final_result);
   void setDebugTargetClusterId(int target_cluster_id);

--- a/src/mpl2/src/Mpl2Observer.h
+++ b/src/mpl2/src/Mpl2Observer.h
@@ -80,6 +80,7 @@ class Mpl2Observer
   }
   virtual void setBundledNets(const std::vector<BundledNet>& bundled_nets) {}
   virtual void setShowBundledNets(bool show_bundled_nets) {}
+  virtual void setShowClustersIds(bool show_clusters_ids) {}
   virtual void setSkipSteps(bool skip_steps) {}
   virtual void doNotSkip() {}
   virtual void setOnlyFinalResult(bool skip_to_end) {}

--- a/src/mpl2/src/graphics.cpp
+++ b/src/mpl2/src/graphics.cpp
@@ -46,6 +46,7 @@ Graphics::Graphics(bool coarse,
     : coarse_(coarse),
       fine_(fine),
       show_bundled_nets_(false),
+      show_clusters_ids_(false),
       skip_steps_(false),
       is_skipping_(false),
       only_final_result_(false),
@@ -384,11 +385,20 @@ void Graphics::drawObjects(gui::Painter& painter)
 
     bbox.moveDelta(outline_.xMin(), outline_.yMin());
 
+    std::string cluster_id_string;
+    if (show_clusters_ids_) {
+      Cluster* cluster = macro.getCluster();
+      cluster_id_string = cluster ? std::to_string(cluster->getId()) : "fixed";
+    } else {
+      // Use the ID of the sequence pair itself.
+      cluster_id_string = std::to_string(i++);
+    }
+
     painter.drawRect(bbox);
     painter.drawString(bbox.xCenter(),
                        bbox.yCenter(),
                        gui::Painter::CENTER,
-                       std::to_string(i++));
+                       cluster_id_string);
   }
 
   painter.setPen(gui::Painter::white, true);
@@ -540,6 +550,11 @@ void Graphics::setPlacementBlockages(
 void Graphics::setShowBundledNets(bool show_bundled_nets)
 {
   show_bundled_nets_ = show_bundled_nets;
+}
+
+void Graphics::setShowClustersIds(bool show_clusters_ids)
+{
+  show_clusters_ids_ = show_clusters_ids;
 }
 
 void Graphics::setSkipSteps(bool skip_steps)

--- a/src/mpl2/src/graphics.h
+++ b/src/mpl2/src/graphics.h
@@ -81,6 +81,7 @@ class Graphics : public gui::Renderer, public Mpl2Observer
       const std::vector<mpl2::Rect>& placement_blockages) override;
   void setBundledNets(const std::vector<BundledNet>& bundled_nets) override;
   void setShowBundledNets(bool show_bundled_nets) override;
+  void setShowClustersIds(bool show_clusters_ids) override;
   void setSkipSteps(bool skip_steps) override;
   void doNotSkip() override;
   void setOnlyFinalResult(bool only_final_result) override;
@@ -125,6 +126,7 @@ class Graphics : public gui::Renderer, public Mpl2Observer
   bool coarse_;
   bool fine_;
   bool show_bundled_nets_;
+  bool show_clusters_ids_;
   bool skip_steps_;
   bool is_skipping_;
   bool only_final_result_;

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -4120,6 +4120,11 @@ void HierRTLMP::setDebugShowBundledNets(bool show_bundled_nets)
   graphics_->setShowBundledNets(show_bundled_nets);
 }
 
+void HierRTLMP::setDebugShowClustersIds(bool show_clusters_ids)
+{
+  graphics_->setShowClustersIds(show_clusters_ids);
+}
+
 void HierRTLMP::setDebugSkipSteps(bool skip_steps)
 {
   graphics_->setSkipSteps(skip_steps);

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -143,6 +143,7 @@ class HierRTLMP
   void setReportDirectory(const char* report_directory);
   void setDebug(std::unique_ptr<Mpl2Observer>& graphics);
   void setDebugShowBundledNets(bool show_bundled_nets);
+  void setDebugShowClustersIds(bool show_clusters_ids);
   void setDebugSkipSteps(bool skip_steps);
   void setDebugOnlyFinalResult(bool only_final_result);
   void setDebugTargetClusterId(int target_cluster_id);

--- a/src/mpl2/src/mpl.i
+++ b/src/mpl2/src/mpl.i
@@ -128,6 +128,7 @@ void set_debug_cmd(odb::dbBlock* block,
                    bool coarse,
                    bool fine,
                    bool show_bundled_nets,
+                   bool show_clusters_ids,
                    bool skip_steps,
                    bool only_final_result,
                    int target_cluster_id)
@@ -137,6 +138,7 @@ void set_debug_cmd(odb::dbBlock* block,
     = std::make_unique<Graphics>(coarse, fine, block, ord::getLogger());
   macro_placer->setDebug(graphics);
   macro_placer->setDebugShowBundledNets(show_bundled_nets);
+  macro_placer->setDebugShowClustersIds(show_clusters_ids);
   macro_placer->setDebugSkipSteps(skip_steps);
   macro_placer->setDebugOnlyFinalResult(only_final_result);
   macro_placer->setDebugTargetClusterId(target_cluster_id);

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -312,6 +312,7 @@ proc mpl_debug { args } {
   sta::parse_key_args "mpl_debug" args \
     keys { -target_cluster_id target_cluster_id } \
     flags {-coarse -fine -show_bundled_nets \
+           -show_clusters_ids \
            -skip_steps -only_final_result} ;# checker off
 
   set coarse [info exists flags(-coarse)]
@@ -331,6 +332,7 @@ proc mpl_debug { args } {
     $coarse \
     $fine \
     [info exists flags(-show_bundled_nets)] \
+    [info exists flags(-show_clusters_ids)] \
     [info exists flags(-skip_steps)] \
     [info exists flags(-only_final_result)] \
     $target_cluster_id

--- a/src/mpl2/src/rtl_mp.cpp
+++ b/src/mpl2/src/rtl_mp.cpp
@@ -204,6 +204,10 @@ void MacroPlacer2::setDebugShowBundledNets(bool show_bundled_nets)
 {
   hier_rtlmp_->setDebugShowBundledNets(show_bundled_nets);
 }
+void MacroPlacer2::setDebugShowClustersIds(bool show_clusters_ids)
+{
+  hier_rtlmp_->setDebugShowClustersIds(show_clusters_ids);
+}
 
 void MacroPlacer2::setDebugSkipSteps(bool skip_steps)
 {


### PR DESCRIPTION
So we can know where a specific cluster is being placed.