### PR TITLE
ctest test merged with regression_tests.tcl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ if(ENABLE_TESTS)
 endif()
 
 add_subdirectory(src)
+add_subdirectory(test)
 
 # After all compiled, look for the respective flags
 target_compile_definitions(openroad PRIVATE GPU)

--- a/src/ant/test/CMakeLists.txt
+++ b/src/ant/test/CMakeLists.txt
@@ -1,13 +1,17 @@
 include("openroad")
 
 set(TEST_NAMES
-  check_api1
-  check_drt1
-  check_grt1
-  ant_check
-  ant_report
+    check_api1
+    check_drt1
+    check_grt1
+    ant_check
+    ant_report
 )
 
+# Skipped
+#ant_readme_msgs_check
+#ant_man_tcl_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("ant" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("ant" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/ant/test/CMakeLists.txt
+++ b/src/ant/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 include("openroad")
 
 set(TEST_NAMES
+    ant_check
+    ant_report
     check_api1
     check_drt1
     check_grt1
-    ant_check
-    ant_report
 )
 
 # Skipped
-#ant_readme_msgs_check
 #ant_man_tcl_check
+#ant_readme_msgs_check
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("ant" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -7,29 +7,37 @@
 include("openroad")
 
 set(TEST_NAMES
-    check_buffers
-    check_buffers_blockages
-    check_charBuf
-    find_clock
-    find_clock_pad
-    no_clocks
-    no_sinks
-    simple_test
-    simple_test_clustered
-    simple_test_clustered_max_cap
-    check_wire_rc_cts
-    post_cts_opt
-    balance_levels
-    max_cap
+    simple_test_hier
     array
     array_no_blockages
     array_ins_delay
-    insertion_delay    
+    balance_levels
+    check_buffers
+    check_buffers_blockages
+    check_charBuf
+    check_max_fanout1
+    check_max_fanout2
+    check_wire_rc_cts
     dummy_load
+    find_clock
+    find_clock_pad
+    insertion_delay
+    max_cap
+    no_clocks
+    no_sinks
+    post_cts_opt
+    simple_test
+    simple_test_clustered
+    simple_test_clustered_max_cap
+    lvt_lib
 )
 
+# Skipped
+#cts_readme_msgs_check
+#cts_man_tcl_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("cts" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("cts" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_executable(cts_unittest cts_unittest.cc)

--- a/src/cts/test/CMakeLists.txt
+++ b/src/cts/test/CMakeLists.txt
@@ -7,10 +7,9 @@
 include("openroad")
 
 set(TEST_NAMES
-    simple_test_hier
     array
-    array_no_blockages
     array_ins_delay
+    array_no_blockages
     balance_levels
     check_buffers
     check_buffers_blockages
@@ -22,6 +21,7 @@ set(TEST_NAMES
     find_clock
     find_clock_pad
     insertion_delay
+    lvt_lib
     max_cap
     no_clocks
     no_sinks
@@ -29,12 +29,12 @@ set(TEST_NAMES
     simple_test
     simple_test_clustered
     simple_test_clustered_max_cap
-    lvt_lib
+    simple_test_hier
 )
 
 # Skipped
-#cts_readme_msgs_check
 #cts_man_tcl_check
+#cts_readme_msgs_check
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("cts" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -1,25 +1,14 @@
 include("openroad")
 
 set(TEST_NAMES
-    hierclock
-    hier2
-    readdb_hier
-    constant1
-    dont_touch_attr
-    make_port
-    network_edit1
-    sdc_names1
-    sdc_names2
-    sdc_get1
-    sta1
-    sta2
-    sta3
-    sta4
-    sta5
     block_sta1
+    constant1
     find_clks1
     find_clks2
-    report_json1
+    hier2
+    hierclock
+    make_port
+    network_edit1
     power1
     read_liberty1
     read_verilog1
@@ -33,9 +22,20 @@ set(TEST_NAMES
     read_verilog9
     read_verilog10
     read_verilog11
+    readdb_hier
     report_cell_usage
     report_cell_usage_modinsts
     report_cell_usage_modinsts_metrics
+    report_json1
+    sdc_get1
+    sdc_names1
+    sdc_names2
+    sta1
+    sta2
+    sta3
+    sta4
+    sta5
+    write_sdc1
     write_verilog1
     write_verilog2
     write_verilog3
@@ -44,7 +44,6 @@ set(TEST_NAMES
     write_verilog6
     write_verilog7
     write_verilog8
-    write_sdc1
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -1,6 +1,9 @@
 include("openroad")
 
 set(TEST_NAMES
+    hierclock
+    hier2
+    readdb_hier
     constant1
     dont_touch_attr
     make_port
@@ -29,7 +32,10 @@ set(TEST_NAMES
     read_verilog8
     read_verilog9
     read_verilog10
+    read_verilog11
     report_cell_usage
+    report_cell_usage_modinsts
+    report_cell_usage_modinsts_metrics
     write_verilog1
     write_verilog2
     write_verilog3
@@ -42,5 +48,5 @@ set(TEST_NAMES
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("dbSta" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("dbSta" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/dft/test/CMakeLists.txt
+++ b/src/dft/test/CMakeLists.txt
@@ -2,17 +2,24 @@
 include("openroad")
 
 set(TEST_NAMES
-  one_cell_sky130
-  one_cell_nangate45
-  sub_modules_sky130
-  scan_architect_no_mix_sky130
-  scan_architect_clock_mix_sky130
-  place_sort_sky130
-  max_chain_count_sky130
+    one_cell_sky130
+    one_cell_nangate45
+    sub_modules_sky130
+    place_sort_sky130
+    scan_architect_no_mix_sky130
+    scan_architect_clock_mix_sky130
+    scan_architect_register_bank_no_clock_mix_sky130
+    scandef_sky130
+    scandef_core_sky130
+    max_chain_count_sky130
 )
 
+# Skipped
+#dft_man_tcl_check
+#dft_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("dft" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("dft" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 find_package(Boost)

--- a/src/dft/test/CMakeLists.txt
+++ b/src/dft/test/CMakeLists.txt
@@ -2,16 +2,16 @@
 include("openroad")
 
 set(TEST_NAMES
-    one_cell_sky130
-    one_cell_nangate45
-    sub_modules_sky130
-    place_sort_sky130
-    scan_architect_no_mix_sky130
-    scan_architect_clock_mix_sky130
-    scan_architect_register_bank_no_clock_mix_sky130
-    scandef_sky130
-    scandef_core_sky130
     max_chain_count_sky130
+    one_cell_nangate45
+    one_cell_sky130
+    place_sort_sky130
+    scan_architect_clock_mix_sky130
+    scan_architect_no_mix_sky130
+    scan_architect_register_bank_no_clock_mix_sky130
+    scandef_core_sky130
+    scandef_sky130
+    sub_modules_sky130
 )
 
 # Skipped

--- a/src/dpl/test/CMakeLists.txt
+++ b/src/dpl/test/CMakeLists.txt
@@ -71,10 +71,15 @@ set(TEST_NAMES
     simple08
     simple09
     simple10
+    blockage01
 )
 
+# Skipped
+#dpl_man_tcl_check
+#dpl_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("dpl" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("dpl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_executable(dpl_test dpl_test.cc)

--- a/src/dpl/test/CMakeLists.txt
+++ b/src/dpl/test/CMakeLists.txt
@@ -8,6 +8,7 @@ include("openroad")
 
 set(TEST_NAMES
     aes
+    blockage01
     cell_on_block1
     cell_on_block2
     check1
@@ -24,6 +25,7 @@ set(TEST_NAMES
     fence03
     fillers1
     fillers2
+    fillers2_verbose
     fillers3
     fillers4
     fillers5
@@ -31,7 +33,6 @@ set(TEST_NAMES
     fillers7
     fillers8
     fillers9
-    fillers2_verbose
     fillers9_verbose
     fragmented_row01
     fragmented_row02
@@ -71,7 +72,6 @@ set(TEST_NAMES
     simple08
     simple09
     simple10
-    blockage01
 )
 
 # Skipped

--- a/src/dpo/test/CMakeLists.txt
+++ b/src/dpo/test/CMakeLists.txt
@@ -4,9 +4,9 @@ set(TEST_NAMES
     aes
     blockage1
     gcd
+    gcd_no_one_site_gaps
     ibex
     multi_height1
-    gcd_no_one_site_gaps
     regions1
     regions2
 )

--- a/src/dpo/test/CMakeLists.txt
+++ b/src/dpo/test/CMakeLists.txt
@@ -1,15 +1,16 @@
 include("openroad")
 
 set(TEST_NAMES
-  aes
-  gcd
-  ibex
-  multi_height1
-  gcd_no_one_site_gaps
-  regions1
-  regions2
+    aes
+    blockage1
+    gcd
+    ibex
+    multi_height1
+    gcd_no_one_site_gaps
+    regions1
+    regions2
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("dpo" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("dpo" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/drt/test/CMakeLists.txt
+++ b/src/drt/test/CMakeLists.txt
@@ -2,6 +2,7 @@ include("openroad")
 
 set(TEST_NAMES
     ispd18_sample
+    ispd18_sample_incr
     ndr_vias1
     ndr_vias2
     obstruction
@@ -13,6 +14,10 @@ set(TEST_NAMES
     drc_test
 )
 
+# Skipped
+#drt_man_tcl_check
+#drt_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("drt" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("drt" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/drt/test/CMakeLists.txt
+++ b/src/drt/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 include("openroad")
 
 set(TEST_NAMES
+    drc_test
     ispd18_sample
     ispd18_sample_incr
     ndr_vias1
@@ -11,7 +12,6 @@ set(TEST_NAMES
     ta_pin_aligned
     top_level_term
     top_level_term2
-    drc_test
 )
 
 # Skipped

--- a/src/fin/test/CMakeLists.txt
+++ b/src/fin/test/CMakeLists.txt
@@ -4,6 +4,10 @@ set(TEST_NAMES
     gcd_fill
 )
 
+# Skipped
+#fin_man_tcl_check
+#fin_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("fin" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("fin" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -1,37 +1,37 @@
 include("openroad")
 
 set(TEST_NAMES
+    ar01
+    ar02
+    clust01
+    convergence01
+    core01
+    density01
+    diverge01
+    error01
+    incremental01
+    incremental02
+    nograd01
     simple01
     simple01-obs
+    simple01-rd
+    simple01-ref
+    simple01-skip-io
     simple01-td
     simple01-td-tune
     simple01-uniform
-    simple01-ref
-    simple01-skip-io
-    simple01-rd
-    simple02-rd
-    simple03-rd
-    simple04-rd
     simple02
+    simple02-rd
     simple03
+    simple03-rd
     simple04
+    simple04-rd
     simple05
     simple06
     simple07
     simple08
     simple09
     simple10
-    core01
-    ar01
-    ar02
-    incremental01
-    incremental02
-    error01
-    diverge01
-    density01
-    convergence01
-    nograd01
-    clust01
 )
 
 # Skipped

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -1,42 +1,45 @@
 include("openroad")
 
 set(TEST_NAMES
-  simple01
-  simple01-obs
-  simple01-td
-  simple01-td-tune
-  simple01-uniform
-  simple01-ref
-  simple01-skip-io
-  simple01-rd
-  simple02-rd
-  simple03-rd
-  simple04-rd
-  simple02
-  simple03
-  simple04
-  simple05
-  simple06
-  simple07
-  simple08
-  simple09
-  simple10
-  core01
-  ar01
-  ar02
-  incremental01
-  incremental02
-  error01
-  diverge01
-  density01
-  convergence01
-  nograd01
-  clust01
-#  clust02
+    simple01
+    simple01-obs
+    simple01-td
+    simple01-td-tune
+    simple01-uniform
+    simple01-ref
+    simple01-skip-io
+    simple01-rd
+    simple02-rd
+    simple03-rd
+    simple04-rd
+    simple02
+    simple03
+    simple04
+    simple05
+    simple06
+    simple07
+    simple08
+    simple09
+    simple10
+    core01
+    ar01
+    ar02
+    incremental01
+    incremental02
+    error01
+    diverge01
+    density01
+    convergence01
+    nograd01
+    clust01
 )
 
+# Skipped
+#gpl_man_tcl_check
+#gpl_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-  or_integration_test("gpl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("gpl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_executable(fft_test fft_test.cc)

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -21,16 +21,16 @@ set(TEST_NAMES
     gcd
     gcd_flute
     inst_pin_out_of_die
-    invalid_routing_layer
     invalid_pin_placement
+    invalid_routing_layer
     macro_obs_not_aligned
     modeling_instance_obs
     multiple_calls
     ndr_1w_3s
     ndr_2w_3s
     no_tracks
-    obstruction
     obs_out_of_die
+    obstruction
     overlapping_edges
     pd1
     pd2

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_NAMES
     invalid_routing_layer
     invalid_pin_placement
     macro_obs_not_aligned
+    modeling_instance_obs
     multiple_calls
     ndr_1w_3s
     ndr_2w_3s
@@ -40,7 +41,16 @@ set(TEST_NAMES
     pin_edge
     pin_track_not_aligned
     pre_routed1
+    read_segments1
+    read_segments2
+    read_segments3
+    read_segments4
+    read_segments_error1
+    read_segments_error2
+    read_segments_error3
     region_adjustment
+    remove_buffers1
+    remove_buffers2
     repair_antennas1
     repair_antennas2
     repair_antennas3
@@ -62,10 +72,16 @@ set(TEST_NAMES
     tracks1
     tracks2
     tracks3
+    unplaced_inst
     upper_layer_net
-    modeling_instance_obs
+    write_segments1
+    write_segments2
 )
 
+# Skipped
+#grt_man_tcl_check
+#grt_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("grt" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("grt" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/gui/test/CMakeLists.txt
+++ b/src/gui/test/CMakeLists.txt
@@ -4,6 +4,10 @@ set(TEST_NAMES
     supported
 )
 
+# Skipped
+#gui_man_tcl_check
+#gui_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("gui" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("gui" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/ifp/test/CMakeLists.txt
+++ b/src/ifp/test/CMakeLists.txt
@@ -2,7 +2,7 @@ include("openroad")
 
 set(TEST_NAMES
     hybrid_rows
-    hybrid_rows2 
+    hybrid_rows2
     init_floorplan1
     init_floorplan2
     init_floorplan3
@@ -26,8 +26,15 @@ set(TEST_NAMES
     tiecells
     upf_test
     upf_shifter_test
+    init_floorplan_even_rows
+    init_floorplan_odd_rows
+    init_floorplan_flip_sites
 )
 
+# Skipped
+#ifp_man_tcl_check
+#ifp_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("ifp" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("ifp" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/ifp/test/CMakeLists.txt
+++ b/src/ifp/test/CMakeLists.txt
@@ -12,6 +12,9 @@ set(TEST_NAMES
     init_floorplan7
     init_floorplan8
     init_floorplan9
+    init_floorplan_even_rows
+    init_floorplan_flip_sites
+    init_floorplan_odd_rows
     make_tracks1
     make_tracks2
     make_tracks3
@@ -24,11 +27,8 @@ set(TEST_NAMES
     placement_blockage1
     placement_blockage2
     tiecells
-    upf_test
     upf_shifter_test
-    init_floorplan_even_rows
-    init_floorplan_odd_rows
-    init_floorplan_flip_sites
+    upf_test
 )
 
 # Skipped

--- a/src/mpl/test/CMakeLists.txt
+++ b/src/mpl/test/CMakeLists.txt
@@ -8,6 +8,10 @@ set(TEST_NAMES
     snap_layer1
 )
 
+# Skipped
+#mpl_man_tcl_check
+#mpl_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("mpl" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("mpl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/mpl/test/CMakeLists.txt
+++ b/src/mpl/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 include("openroad")
 
 set(TEST_NAMES
-    level3_01
-    level3_02
     east_west1
     east_west2
+    level3_01
+    level3_02
     snap_layer1
 )
 

--- a/src/mpl2/test/CMakeLists.txt
+++ b/src/mpl2/test/CMakeLists.txt
@@ -2,10 +2,15 @@ include("openroad")
 
 set(TEST_NAMES
     macro_only
+    no_unfixed_macros
 )
 
+# Skipped
+#mpl2_man_tcl_check
+#mpl2_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("mpl2" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("mpl2" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_subdirectory(cpp)

--- a/src/odb/test/CMakeLists.txt
+++ b/src/odb/test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_NAMES
     dump_nets
     lef_mask
     write_lef_and_def
+    write_lef_polygon
     lef_data_access
     gcd_def_access
     gcd_pdn_def_access
@@ -39,10 +40,22 @@ set(TEST_NAMES
     write_macro_placement
     smash_vias
     floorplan_initialize
+    replace_design1
+    replace_design2
+    replace_design3
+    design_is_routed1
+    design_is_routed2
+    design_is_routed3
+    design_is_routed_fail1
+    design_is_routed_fail2
 )
 
+# Skipped
+#odb_man_tcl_check
+#odb_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("odb" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("odb" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_subdirectory(cpp)

--- a/src/odb/test/CMakeLists.txt
+++ b/src/odb/test/CMakeLists.txt
@@ -1,53 +1,53 @@
 include("openroad")
 
 set(TEST_NAMES
-    bterm_hier_create
-    multi_tech
-    transform
-    rounding
-    sky130hd_multi_patterned
-    dont_touch
-    import_package
-    read_lef
-    read_db
-    read_zipped
-    create_sboxes
-    dump_via_rules
-    dump_vias
-    read_def
-    read_def58
-    write_def58
-    dump_nets
-    lef_mask
-    write_lef_and_def
-    write_lef_polygon
-    lef_data_access
-    gcd_def_access
-    gcd_pdn_def_access
-    edit_def
-    wire_encoder
-    edit_via_params
-    row_settings
-    db_read_write
-    check_routing_tracks
-    polygon
-    def_parser
-    ndr
-    gcd_abstract_lef
-    gcd_abstract_lef_with_power
-    read_abstract_lef
     abstract_origin
-    write_macro_placement
-    smash_vias
-    floorplan_initialize
-    replace_design1
-    replace_design2
-    replace_design3
+    bterm_hier_create
+    check_routing_tracks
+    create_sboxes
+    db_read_write
+    def_parser
     design_is_routed1
     design_is_routed2
     design_is_routed3
     design_is_routed_fail1
     design_is_routed_fail2
+    dont_touch
+    dump_nets
+    dump_via_rules
+    dump_vias
+    edit_def
+    edit_via_params
+    floorplan_initialize
+    gcd_abstract_lef
+    gcd_abstract_lef_with_power
+    gcd_def_access
+    gcd_pdn_def_access
+    import_package
+    lef_data_access
+    lef_mask
+    multi_tech
+    ndr
+    polygon
+    read_abstract_lef
+    read_db
+    read_def
+    read_def58
+    read_lef
+    read_zipped
+    replace_design1
+    replace_design2
+    replace_design3
+    rounding
+    row_settings
+    sky130hd_multi_patterned
+    smash_vias
+    transform
+    wire_encoder
+    write_def58
+    write_lef_and_def
+    write_lef_polygon
+    write_macro_placement
 )
 
 # Skipped

--- a/src/pad/test/CMakeLists.txt
+++ b/src/pad/test/CMakeLists.txt
@@ -12,6 +12,7 @@ set(TEST_NAMES
     make_io_sites_rotations
     non_top_layer
     place_pad
+    place_pad_hv
     place_pad_with_bumps
     place_pad_outsideofrow
     place_bondpad
@@ -45,6 +46,10 @@ set(TEST_NAMES
     place_pads_bumps
 )
 
+# Skipped
+#pad_man_tcl_check
+#pad_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("pad" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("pad" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/pad/test/CMakeLists.txt
+++ b/src/pad/test/CMakeLists.txt
@@ -1,49 +1,49 @@
 include("openroad")
 
 set(TEST_NAMES
+    assign_bumps
+    assign_bumps_two_pins
     bump_array_make
+    bump_array_make_error
+    bump_array_make_single_pitch
     bump_array_remove
     bump_array_remove_single
-    bump_array_make_single_pitch
-    bump_array_make_error
+    connect_by_abutment
+    connect_by_abutment_with_single_pinnet
     make_corner_sites
     make_io_sites
     make_io_sites_different_sites
     make_io_sites_rotations
     non_top_layer
-    place_pad
-    place_pad_hv
-    place_pad_with_bumps
-    place_pad_outsideofrow
     place_bondpad
     place_bondpad_stagger
+    place_pad
+    place_pad_hv
     place_pad_no_master
+    place_pad_outsideofrow
+    place_pad_with_bumps
     place_pad_wrong_master
-    assign_bumps
-    assign_bumps_two_pins
-    connect_by_abutment
-    connect_by_abutment_with_single_pinnet
+    place_pads_bumps
+    place_pads_too_many
+    place_pads_uniform
     rdl_route
-    rdl_route_ports
-    rdl_route_failed
-    rdl_route_max_iterations
-    rdl_route_assignments
     rdl_route_45
     rdl_route_45_cost
     rdl_route_45_separate
-    rdl_route_via
-    rdl_route_bump_via
-    rdl_route_invalid
     rdl_route_45_with_2port_bump
     rdl_route_45_with_oct_bump
-    rdl_route_single_target
+    rdl_route_assignments
     rdl_route_bump_to_bump_only
-    skywater130_overlapping_filler
+    rdl_route_bump_via
+    rdl_route_failed
+    rdl_route_invalid
+    rdl_route_max_iterations
+    rdl_route_ports
+    rdl_route_single_target
+    rdl_route_via
     skywater130_caravel
     skywater130_coyote_tc
-    place_pads_uniform
-    place_pads_too_many
-    place_pads_bumps
+    skywater130_overlapping_filler
 )
 
 # Skipped

--- a/src/par/test/CMakeLists.txt
+++ b/src/par/test/CMakeLists.txt
@@ -1,8 +1,8 @@
 include("openroad")
 
 set(TEST_NAMES
-    read_part
     partition_gcd
+    read_part
 )
 
 # Skipped

--- a/src/par/test/CMakeLists.txt
+++ b/src/par/test/CMakeLists.txt
@@ -5,6 +5,10 @@ set(TEST_NAMES
     partition_gcd
 )
 
+# Skipped
+#par_man_tcl_check
+#par_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("par" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("par" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/pdn/test/CMakeLists.txt
+++ b/src/pdn/test/CMakeLists.txt
@@ -1,107 +1,107 @@
 include("openroad")
 
 set(TEST_NAMES
-    reset
-    report
-    ripup
+    asap7_failed_macro_grid
+    asap7_no_via_generate
+    asap7_no_via_generate_v1_snapped
+    asap7_offcenter_via
+    asap7_taper
+    asap7_vias
+    asap7_vias_arrayspacing
+    asap7_vias_arrayspacing_3_layer
+    asap7_vias_arrayspacing_notfirst
+    asap7_vias_arrayspacing_partial
+    asap7_vias_cutclass
+    asap7_vias_dont_use
+    asap7_vias_fixed_vias
+    asap7_vias_max_rows_columns
+    bpin_removal
     convert
-    names
-    min_width
-    max_width
-    min_spacing
-    widthtable
-    design_width
-    offgrid
     core_grid
-    core_grid_with_rings
-    core_grid_start_power
-    core_grid_start_power_strap_ground
-    core_grid_with_rings_with_straps
-    core_grid_with_single_layer_rings
-    core_grid_dual_followpins
-    core_grid_dual_followpins_error
-    core_grid_with_dual_rings
-    core_grid_with_rings_connect
-    core_grid_cut_pitch
-    core_grid_snap
-    core_grid_via_snap
-    core_grid_split_cuts
-    core_grid_with_rings_with_straps_rings_over_core
-    core_grid_with_routing_obstructions
     core_grid_adjacentcuts
-    core_grid_with_fixed_pins
-    core_grid_bad_metal_specs
-    core_grid_obstruction
     core_grid_auto_domain
     core_grid_auto_domain_multiple_nets
+    core_grid_bad_metal_specs
+    core_grid_cut_pitch
+    core_grid_dual_followpins
+    core_grid_dual_followpins_error
     core_grid_extend_to_boundary
     core_grid_extend_to_boundary_no_pins
-    core_grid_with_M7_pins
-    core_grid_with_M6_min_area
-    core_grid_strap_count
-    core_grid_no_trim
-    core_grid_offset_strap
-    core_grid_with_rings_with_limit_straps
     core_grid_failed_via_report
+    core_grid_no_trim
+    core_grid_obstruction
+    core_grid_offset_strap
+    core_grid_snap
+    core_grid_split_cuts
+    core_grid_start_power
+    core_grid_start_power_strap_ground
+    core_grid_strap_count
+    core_grid_via_snap
+    core_grid_with_M6_min_area
+    core_grid_with_M7_pins
+    core_grid_with_dual_rings
+    core_grid_with_fixed_pins
+    core_grid_with_rings
+    core_grid_with_rings_connect
+    core_grid_with_rings_with_limit_straps
+    core_grid_with_rings_with_straps
+    core_grid_with_rings_with_straps_rings_over_core
+    core_grid_with_routing_obstructions
+    core_grid_with_single_layer_rings
+    design_width
+    existing
     macros
-    macros_with_halo
-    macros_cells
-    macros_cells_orient
-    macros_with_rings
-    macros_narrow_channel
-    macros_narrow_channel_large_spacing
-    macros_narrow_channel_repair_overlap
-    macros_narrow_channel_overlap
     macros_add_twice
+    macros_cells
+    macros_cells_dont_touch
     macros_cells_extend_boundary
     macros_cells_no_grid
-    macros_narrow_channel_jog
+    macros_cells_not_fixed
+    macros_cells_orient
+    macros_cells_overlapping_ports
+    macros_cells_via_failure
     macros_different_nets
     macros_grid_through
     macros_grid_through_without_middle
-    macros_cells_dont_touch
-    macros_cells_overlapping_ports
-    macros_cells_not_fixed
-    macros_cells_via_failure
-    repair_channel_inf_loop
-    region_temp_sensor
-    region_secondary_nets
-    region_non_rect
+    macros_narrow_channel
+    macros_narrow_channel_jog
+    macros_narrow_channel_large_spacing
+    macros_narrow_channel_overlap
+    macros_narrow_channel_repair_overlap
+    macros_with_halo
+    macros_with_rings
+    max_width
+    min_spacing
+    min_width
+    names
+    offgrid
     pads_black_parrot
-    pads_black_parrot_offset
-    pads_black_parrot_no_connect
-    pads_black_parrot_limit_connect
     pads_black_parrot_flipchip
     pads_black_parrot_flipchip_connect_bumps
     pads_black_parrot_flipchip_connect_overpads
+    pads_black_parrot_limit_connect
     pads_black_parrot_max_width
-    asap7_vias
-    asap7_vias_cutclass
-    asap7_no_via_generate
-    asap7_vias_arrayspacing
-    asap7_vias_arrayspacing_notfirst
-    asap7_vias_arrayspacing_partial
-    asap7_vias_arrayspacing_3_layer
-    asap7_vias_max_rows_columns
-    asap7_vias_dont_use
-    asap7_taper
-    asap7_offcenter_via
-    asap7_no_via_generate_v1_snapped
-    asap7_failed_macro_grid
-    asap7_vias_fixed_vias
-    existing
+    pads_black_parrot_no_connect
+    pads_black_parrot_offset
     power_switch
-    power_switch_star
+    power_switch_cut_rows
     power_switch_daisy
     power_switch_regions
-    power_switch_cut_rows
-    power_switch_upf_error
-    power_switch_upf_star
+    power_switch_star
     power_switch_upf_daisy
+    power_switch_upf_error
     power_switch_upf_regions
+    power_switch_upf_star
+    region_non_rect
+    region_secondary_nets
+    region_temp_sensor
+    repair_channel_inf_loop
     repair_vias
+    report
+    reset
+    ripup
     sroute_test
-    bpin_removal
+    widthtable
 )
 
 # Skipped

--- a/src/pdn/test/CMakeLists.txt
+++ b/src/pdn/test/CMakeLists.txt
@@ -30,6 +30,7 @@ set(TEST_NAMES
     core_grid_with_routing_obstructions
     core_grid_adjacentcuts
     core_grid_with_fixed_pins
+    core_grid_bad_metal_specs
     core_grid_obstruction
     core_grid_auto_domain
     core_grid_auto_domain_multiple_nets
@@ -103,6 +104,10 @@ set(TEST_NAMES
     bpin_removal
 )
 
+# Skipped
+#pdn_man_tcl_check
+#pdn_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("pdn" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("pdn" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -25,6 +25,8 @@ set(TEST_NAMES
     add_constraint_error5
     add_constraint_error6
     add_constraint_error7
+    add_constraint_error8
+    add_constraint_error9
     annealing1
     annealing2
     annealing3
@@ -77,6 +79,8 @@ set(TEST_NAMES
     no_pins
     no_tracks
     on_grid
+    partial_tracks_error
+    partial_tracks
     pin_length
     pin_length_error
     pin_extension
@@ -113,8 +117,14 @@ set(TEST_NAMES
     write_pin_placement2
     write_pin_placement3
     write_pin_placement4
+    write_pin_placement5
+    write_pin_placement6
 )
 
+# Skipped
+#ppl_man_tcl_check
+#ppl_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("ppl" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("ppl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/ppl/test/CMakeLists.txt
+++ b/src/ppl/test/CMakeLists.txt
@@ -1,7 +1,6 @@
 include("openroad")
 
 set(TEST_NAMES
-    add_constraint_debug
     add_constraint1
     add_constraint2
     add_constraint3
@@ -18,6 +17,7 @@ set(TEST_NAMES
     add_constraint14
     add_constraint15
     add_constraint16
+    add_constraint_debug
     add_constraint_error1
     add_constraint_error2
     add_constraint_error3
@@ -79,11 +79,11 @@ set(TEST_NAMES
     no_pins
     no_tracks
     on_grid
-    partial_tracks_error
     partial_tracks
+    partial_tracks_error
+    pin_extension
     pin_length
     pin_length_error
-    pin_extension
     pin_thick_multiplier
     place_pin1
     place_pin2

--- a/src/psm/test/CMakeLists.txt
+++ b/src/psm/test/CMakeLists.txt
@@ -1,34 +1,34 @@
 include("openroad")
 
 set(TEST_NAMES
-    aes_test_vdd
-    aes_test_vss
-    gcd_test_vdd
-    gcd_no_vsrc
-    gcd_write_sp_test_vdd
-    gcd_all_vss
-    gcd_em_test_vdd
-    gcd_vss_no_vsrc
-    gcd_sky130_vdd
     aes_asap7_vdd
-    check_power_grid
-    check_power_grid_floorplanning
-    check_power_grid_disconnected
-    check_power_grid_ok_disconnected
-    check_power_grid_macros
-    check_power_grid_disconnected_macro
-    corners
     aes_test_bterms
     aes_test_multiple_bterms
-    zerosoc_pads
-    zerosoc_pads_check_only
-    zerosoc_pads_check_only_disconnected
-    pad_connected_by_abutment
-    switch_top_grid
-    top_grid_settings
+    aes_test_vdd
+    aes_test_vss
+    check_power_grid
+    check_power_grid_disconnected
+    check_power_grid_disconnected_macro
+    check_power_grid_floorplanning
+    check_power_grid_macros
+    check_power_grid_ok_disconnected
+    corners
+    gcd_all_vss
+    gcd_em_test_vdd
+    gcd_no_vsrc
+    gcd_sky130_vdd
+    gcd_test_vdd
+    gcd_vss_no_vsrc
+    gcd_write_sp_test_vdd
     insert_decap1
     insert_decap2
     insert_decap_with_padding1
+    pad_connected_by_abutment
+    switch_top_grid
+    top_grid_settings
+    zerosoc_pads
+    zerosoc_pads_check_only
+    zerosoc_pads_check_only_disconnected
 )
 
 # Skipped

--- a/src/psm/test/CMakeLists.txt
+++ b/src/psm/test/CMakeLists.txt
@@ -29,10 +29,12 @@ set(TEST_NAMES
     insert_decap1
     insert_decap2
     insert_decap_with_padding1
-    #psm_man_tcl_check
-    #psm_readme_msgs_check
 )
 
+# Skipped
+#psm_man_tcl_check
+#psm_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("psm" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("psm" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/rcx/test/CMakeLists.txt
+++ b/src/rcx/test/CMakeLists.txt
@@ -3,11 +3,16 @@ include("openroad")
 set(TEST_NAMES
     generate_pattern
     ext_pattern
-    gcd 
+    gcd
     45_gcd
     names
 )
 
+# Skipped
+#generate_rules
+#rcx_man_tcl_check
+#rcx_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("rcx" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("rcx" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/rcx/test/CMakeLists.txt
+++ b/src/rcx/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 include("openroad")
 
 set(TEST_NAMES
-    generate_pattern
+    45_gcd
     ext_pattern
     gcd
-    45_gcd
+    generate_pattern
     names
 )
 

--- a/src/rmp/test/CMakeLists.txt
+++ b/src/rmp/test/CMakeLists.txt
@@ -1,16 +1,16 @@
 include("openroad")
 
 set(TEST_NAMES
-    gcd_restructure
-    const_cell_removal
-    blif_writer
-    blif_writer_input_output
-    blif_writer_consts
-    blif_writer_hanging
-    blif_writer_sequential
     blif_reader
     blif_reader_const
     blif_reader_sequential
+    blif_writer
+    blif_writer_consts
+    blif_writer_hanging
+    blif_writer_input_output
+    blif_writer_sequential
+    const_cell_removal
+    gcd_restructure
 )
 
 # Skipped

--- a/src/rmp/test/CMakeLists.txt
+++ b/src/rmp/test/CMakeLists.txt
@@ -13,8 +13,12 @@ set(TEST_NAMES
     blif_reader_sequential
 )
 
+# Skipped
+#rmp_man_tcl_check
+#rmp_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("rmp" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("rmp" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 if (ENABLE_TESTS)

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -1,6 +1,13 @@
 include("openroad")
 
 set(TEST_NAMES
+    clone_flat
+    clone_hier
+    pinswap_flat
+    pinswap_hier
+    split_load_hier
+    resize1_hier
+    repair_hold1_hier
     buffer_ports1
     buffer_ports3
     buffer_ports4
@@ -9,9 +16,11 @@ set(TEST_NAMES
     buffer_ports7
     buffer_ports8
     buffer_varying_lengths
+    eliminate_dead_logic1
     eqy_repair_setup2
     eqy_repair_setup5
     fanin_fanout1
+    gain_buffering1
     make_parasitics1
     make_parasitics2
     make_parasitics3
@@ -28,6 +37,7 @@ set(TEST_NAMES
     resize_slack3
     remove_buffers1
     remove_buffers2
+    remove_buffers3
     repair_clk_nets1
     repair_clk_inverters1
     repair_cap1
@@ -60,12 +70,17 @@ set(TEST_NAMES
     repair_hold12
     repair_hold13
     repair_hold14
+    repair_hold15
     repair_setup1
     repair_setup2
     repair_setup3
     repair_setup4
+    repair_setup4_hier
+    repair_setup4_flat
     repair_setup5
     repair_setup6
+    repair_setup7
+    repair_setup8
     repair_slew1
     repair_slew2
     repair_slew3
@@ -111,10 +126,15 @@ set(TEST_NAMES
     repair_hold9_verbose
     set_dont_touch1
     set_dont_use1
+    repair_setup_undo
 )
 
+# Skipped
+#rsz_man_tcl_check
+#rsz_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("rsz" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("rsz" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_subdirectory(cpp)

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -1,13 +1,6 @@
 include("openroad")
 
 set(TEST_NAMES
-    clone_flat
-    clone_hier
-    pinswap_flat
-    pinswap_hier
-    split_load_hier
-    resize1_hier
-    repair_hold1_hier
     buffer_ports1
     buffer_ports3
     buffer_ports4
@@ -16,11 +9,14 @@ set(TEST_NAMES
     buffer_ports7
     buffer_ports8
     buffer_varying_lengths
+    clone_flat
+    clone_hier
     eliminate_dead_logic1
     eqy_repair_setup2
     eqy_repair_setup5
     fanin_fanout1
     gain_buffering1
+    gcd_resize
     make_parasitics1
     make_parasitics2
     make_parasitics3
@@ -28,24 +24,20 @@ set(TEST_NAMES
     make_parasitics5
     make_parasitics6
     pin_swap1
-    resize1
-    resize4
-    resize5
-    resize6
-    resize_slack1
-    resize_slack2
-    resize_slack3
+    pinswap_flat
+    pinswap_hier
     remove_buffers1
     remove_buffers2
     remove_buffers3
-    repair_clk_nets1
-    repair_clk_inverters1
     repair_cap1
     repair_cap2
     repair_cap3
+    repair_clk_inverters1
+    repair_clk_nets1
     repair_design1
     repair_design2
     repair_design3
+    repair_design3_verbose
     repair_design4
     repair_design5
     repair_fanout1
@@ -57,6 +49,7 @@ set(TEST_NAMES
     repair_fanout7
     repair_fanout8
     repair_hold1
+    repair_hold1_hier
     repair_hold2
     repair_hold3
     repair_hold4
@@ -65,6 +58,7 @@ set(TEST_NAMES
     repair_hold7
     repair_hold8
     repair_hold9
+    repair_hold9_verbose
     repair_hold10
     repair_hold11
     repair_hold12
@@ -75,12 +69,14 @@ set(TEST_NAMES
     repair_setup2
     repair_setup3
     repair_setup4
-    repair_setup4_hier
     repair_setup4_flat
+    repair_setup4_hier
+    repair_setup4_verbose
     repair_setup5
     repair_setup6
     repair_setup7
     repair_setup8
+    repair_setup_undo
     repair_slew1
     repair_slew2
     repair_slew3
@@ -98,9 +94,6 @@ set(TEST_NAMES
     repair_slew15
     repair_slew16
     repair_slew17
-    report_floating_nets1
-    report_floating_nets2
-    report_floating_nets3
     repair_tie1
     repair_tie2
     repair_tie3
@@ -120,13 +113,20 @@ set(TEST_NAMES
     repair_wire9
     repair_wire10
     repair_wire11
-    gcd_resize
-    repair_design3_verbose
-    repair_setup4_verbose
-    repair_hold9_verbose
+    report_floating_nets1
+    report_floating_nets2
+    report_floating_nets3
+    resize1
+    resize1_hier
+    resize4
+    resize5
+    resize6
+    resize_slack1
+    resize_slack2
+    resize_slack3
     set_dont_touch1
     set_dont_use1
-    repair_setup_undo
+    split_load_hier
 )
 
 # Skipped

--- a/src/stt/test/CMakeLists.txt
+++ b/src/stt/test/CMakeLists.txt
@@ -10,6 +10,10 @@ set(TEST_NAMES
     pd_gcd
 )
 
+# Skipped
+#stt_man_tcl_check
+#stt_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("stt" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("stt" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/stt/test/CMakeLists.txt
+++ b/src/stt/test/CMakeLists.txt
@@ -1,9 +1,9 @@
 include("openroad")
 
 set(TEST_NAMES
+    check
     flute1
     flute_gcd
-    check
     parse_clocks
     pd1
     pd2

--- a/src/tap/test/CMakeLists.txt
+++ b/src/tap/test/CMakeLists.txt
@@ -1,29 +1,35 @@
 include("openroad")
 
 set(TEST_NAMES
-    disallow_one_site_gaps
-    gcd_fakeram
-    gcd_nangate45
-    gcd_sky130
-    gcd_asap7
-    invalid_cells
-    multiple_calls
+    aes_gf180
     avoid_overlap
     boundary_macros
+    boundary_macros_auto_select
+    boundary_macros_separate
+    boundary_macros_tapcell
+    cut_rows
+    cut_rows_min_width
+    cut_rows_with_endcaps
+    disallow_one_site_gaps
+    gcd_asap7
+    gcd_fakeram
+    gcd_nangate45
     gcd_prefix
     gcd_ripup
-    no_endcap
-    symmetry
-    cut_rows
-    cut_rows_with_endcaps
-    boundary_macros_separate
-    boundary_macros_auto_select
-    boundary_macros_tapcell
+    gcd_sky130
     gcd_sky130_separate
+    invalid_cells
     jpeg_gf180
-    aes_gf180
+    multiple_calls
+    no_endcap
+    region1
+    symmetry
 )
 
+# Skipped
+#tap_man_tcl_check
+#tap_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("tap" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("tap" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/upf/test/CMakeLists.txt
+++ b/src/upf/test/CMakeLists.txt
@@ -1,10 +1,14 @@
 include("openroad")
 
 set(TEST_NAMES
-    upf_test
     levelshifter
+    write
 )
 
+# Skipped
+#upf_man_tcl_check
+#upf_readme_msgs_check
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("upf" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("upf" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()

--- a/src/utl/test/CMakeLists.txt
+++ b/src/utl/test/CMakeLists.txt
@@ -1,21 +1,21 @@
 include("openroad")
 
 set(TEST_NAMES
-    test_info
-    test_error
-    test_suppress_message
-    test_metrics
     logger_max_messages
     logger_redirection
     logger_redirection_nonewline
     tee
     tee_fails
+    test_error
+    test_info
+    test_metrics
+    test_suppress_message
 )
 
 # Skipped
+#test_error_exception
 #utl_man_tcl_check
 #utl_readme_msgs_check
-#test_error_exception
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("utl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)

--- a/src/utl/test/CMakeLists.txt
+++ b/src/utl/test/CMakeLists.txt
@@ -12,8 +12,13 @@ set(TEST_NAMES
     tee_fails
 )
 
+# Skipped
+#utl_man_tcl_check
+#utl_readme_msgs_check
+#test_error_exception
+
 foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("utl" ${TEST_NAME}  ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+    or_integration_test("utl" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
 endforeach()
 
 add_subdirectory(cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(TEST_NAMES
+    error1
+    get_core_die_areas
+    timing_api
+    timing_api_2
+    timing_api_3
+    timing_api_4
+    upf_test
+    upf_aes
+    two_designs
+)
+
+foreach(TEST_NAME IN LISTS TEST_NAMES)
+    or_integration_test("openroad" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
+endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,9 +5,9 @@ set(TEST_NAMES
     timing_api_2
     timing_api_3
     timing_api_4
+    two_designs
     upf_test
     upf_aes
-    two_designs
 )
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,13 +4,11 @@ set(TEST_NAMES
     timing_api
     timing_api_2
     timing_api_3
+    timing_api_4
     upf_test
     upf_aes
     two_designs
 )
-
-# Skipped
-#timing_api_4
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("openroad" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,11 +4,13 @@ set(TEST_NAMES
     timing_api
     timing_api_2
     timing_api_3
-    timing_api_4
     upf_test
     upf_aes
     two_designs
 )
+
+# Skipped
+#timing_api_4
 
 foreach(TEST_NAME IN LISTS TEST_NAMES)
     or_integration_test("openroad" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)


### PR DESCRIPTION
Ensures all tests that appear in regression_tests.tcl are present in CMakeLists.txt for the tool test dir.

No functional changes.

Notes:
- Adds the base openroad tests as well, which were missing. I had to disable timing_api_4 as it was generating a failure on my machine.
- Only includes tests from record_tests list

Additionally: any new tests getting added after this PR must appear in both files until a followon PR removes the dependency on `./regression` in the tool directories