### PR TITLE
rsz: dont touch special nets

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1675,7 +1675,7 @@ void Resizer::setDontTouch(const Net* net, bool dont_touch)
 bool Resizer::dontTouch(const Net* net)
 {
   dbNet* db_net = db_network_->staToDb(net);
-  return db_net->isDoNotTouch();
+  return db_net->isDoNotTouch() || db_net->isSpecial();
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -9,6 +9,8 @@ set(TEST_NAMES
     buffer_ports7
     buffer_ports8
     buffer_varying_lengths
+    eliminate_dead_logic1
+    eliminate_dead_logic2
     eqy_repair_setup2
     eqy_repair_setup5
     fanin_fanout1

--- a/src/rsz/test/eliminate_dead_logic2.ok
+++ b/src/rsz/test/eliminate_dead_logic2.ok
@@ -1,0 +1,4 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130hd_std_cell.lef, created 437 library cells
+Removed 5 unused instances and 5 unused nets.
+No differences found.

--- a/src/rsz/test/eliminate_dead_logic2.tcl
+++ b/src/rsz/test/eliminate_dead_logic2.tcl
@@ -1,0 +1,19 @@
+# make_result_file, diff_files
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130hd_std_cell.lef
+read_liberty sky130hd/sky130hd_tt.lib
+
+read_verilog eliminate_dead_logic1.v
+link_design top
+
+add_global_connection -net {VDD} -pin_pattern {VPWR} -power
+add_global_connection -net {VSS} -pin_pattern {VGND} -ground
+
+set_dont_touch \q2[0]
+eliminate_dead_logic
+
+set verilog_file [make_result_file eliminate_dead_logic2.vg]
+write_verilog -include_pwr_gnd $verilog_file
+diff_files $verilog_file eliminate_dead_logic2.vgok

--- a/src/rsz/test/eliminate_dead_logic2.vgok
+++ b/src/rsz/test/eliminate_dead_logic2.vgok
@@ -1,0 +1,71 @@
+module top (clk,
+    \q1[0] ,
+    \q1[1] ,
+    rst);
+ input clk;
+ output \q1[0] ;
+ output \q1[1] ;
+ input rst;
+
+ wire _00_;
+ wire _01_;
+ wire _04_;
+ wire _05_;
+ wire _06_;
+ wire _07_;
+ wire \q2[0] ;
+ wire \q2[1] ;
+ wire VDD;
+ wire VSS;
+
+ sky130_fd_sc_hd__xnor2_1 _09_ (.A(\q1[0] ),
+    .B(\q1[1] ),
+    .Y(_06_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__nor2_1 _10_ (.A(rst),
+    .B(\q1[0] ),
+    .Y(_05_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__nor2_1 _11_ (.A(rst),
+    .B(_06_),
+    .Y(_00_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__xnor2_1 _12_ (.A(\q2[0] ),
+    .B(\q2[1] ),
+    .Y(_07_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__nor2_1 _13_ (.A(rst),
+    .B(_07_),
+    .Y(_01_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__nand2b_1 _17_ (.A_N(rst),
+    .B(\q2[0] ),
+    .Y(_04_),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__dfxtp_1 _18_ (.D(_00_),
+    .Q(\q1[1] ),
+    .CLK(clk),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__dfxtp_1 _19_ (.D(_01_),
+    .Q(\q2[1] ),
+    .CLK(clk),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__dfxtp_1 _22_ (.D(_04_),
+    .Q(\q2[0] ),
+    .CLK(clk),
+    .VGND(VSS),
+    .VPWR(VDD));
+ sky130_fd_sc_hd__dfxtp_1 _23_ (.D(_05_),
+    .Q(\q1[0] ),
+    .CLK(clk),
+    .VGND(VSS),
+    .VPWR(VDD));
+endmodule

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -15,6 +15,7 @@ record_tests {
   buffer_ports8
   buffer_varying_lengths
   eliminate_dead_logic1
+  eliminate_dead_logic2
   eqy_repair_setup2
   eqy_repair_setup5
   fanin_fanout1


### PR DESCRIPTION
Changes:
- dont touch special nets in resizer, during eliminate_dead_logic the power nets get deleted without this.