### PR TITLE
odb: moving dbModule::makeUniqueDbModule()::name_id_map to dbBlock 

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1694,11 +1694,6 @@ class dbBlock : public dbObject
 
   void clearUserInstFlags();
 
-  ///
-  /// return the module name id map
-  ///
-  std::map<std::string, int>* getModuleNameIdMap();
-
  public:
   ///
   /// This method copies the via-table from the src block to the destination

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1694,6 +1694,11 @@ class dbBlock : public dbObject
 
   void clearUserInstFlags();
 
+  ///
+  /// return the module name id map
+  ///
+  std::map<std::string, int>* getModuleNameIdMap();
+
  public:
   ///
   /// This method copies the via-table from the src block to the destination

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -4088,6 +4088,13 @@ void dbBlock::clearUserInstFlags()
     inst->clearUserFlag3();
   }
 }
+
+std::map<std::string, int>* dbBlock::getModuleNameIdMap()
+{
+  _dbBlock* block = (_dbBlock*) this;
+  return &(block->_module_name_id_map);
+}
+
 void dbBlock::setDrivingItermsforNets()
 {
   dbSet<dbNet> nets = getNets();

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -4089,12 +4089,6 @@ void dbBlock::clearUserInstFlags()
   }
 }
 
-std::map<std::string, int>* dbBlock::getModuleNameIdMap()
-{
-  _dbBlock* block = (_dbBlock*) this;
-  return &(block->_module_name_id_map);
-}
-
 void dbBlock::setDrivingItermsforNets()
 {
   dbSet<dbNet> nets = getNets();

--- a/src/odb/src/db/dbBlock.h
+++ b/src/odb/src/db/dbBlock.h
@@ -290,6 +290,8 @@ class _dbBlock : public _dbObject
   dbPropertyItr* _prop_itr;
   dbBlockSearch* _searchDb;
 
+  std::map<std::string, int> _module_name_id_map;
+
   unsigned char _num_ext_dbs;
 
   std::list<dbBlockCallBackObj*> _callbacks;

--- a/src/odb/src/db/dbModule.cpp
+++ b/src/odb/src/db/dbModule.cpp
@@ -554,7 +554,8 @@ dbModule* dbModule::makeUniqueDbModule(const char* cell_name,
     return module;
   }
 
-  std::map<std::string, int>& name_id_map = *(block->getModuleNameIdMap());
+  std::map<std::string, int>& name_id_map
+      = ((_dbBlock*) block)->_module_name_id_map;
   std::string orig_cell_name(cell_name);
   std::string module_name = orig_cell_name + '_' + std::string(inst_name);
   do {

--- a/src/odb/src/db/dbModule.cpp
+++ b/src/odb/src/db/dbModule.cpp
@@ -549,12 +549,12 @@ dbModule* dbModule::makeUniqueDbModule(const char* cell_name,
                                        dbBlock* block)
 
 {
-  static std::map<std::string, int> name_id_map;
   dbModule* module = dbModule::create(block, cell_name);
   if (module != nullptr) {
     return module;
   }
 
+  std::map<std::string, int>& name_id_map = *(block->getModuleNameIdMap());
   std::string orig_cell_name(cell_name);
   std::string module_name = orig_cell_name + '_' + std::string(inst_name);
   do {


### PR DESCRIPTION
Removes the static variable name_id_map from the dbModule::makeUniqueDbModule method (issue https://github.com/The-OpenROAD-Project/OpenROAD/issues/5981)

Variable name_id_map moved to dbBlock, as suggested by @maliberty in https://github.com/The-OpenROAD-Project/OpenROAD/pull/6245#issuecomment-2501902499, and is now accessed via the dbBlock::getModuleNameIdMap() method.
