### PR TITLE
grt: make haveRoutes() a silent check

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -225,10 +225,6 @@ void GlobalRouter::saveCongestion()
 bool GlobalRouter::haveRoutes()
 {
   loadGuidesFromDB();
-  if (routes_.empty()) {
-    logger_->warn(GRT, 97, "No global routing found for nets.");
-  }
-
   bool congested_routes = is_congested_ && !allow_congestion_;
   return !routes_.empty() && !congested_routes;
 }

--- a/src/grt/test/repair_antennas_error1.ok
+++ b/src/grt/test/repair_antennas_error1.ok
@@ -5,7 +5,6 @@
 [INFO ODB-0131]     Created 1360 components and 6650 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 411 nets and 1210 connections.
-[WARNING GRT-0097] No global routing found for nets.
 [ERROR GRT-0045] Run global_route before repair_antennas.
 GRT-0045
 [ERROR GRT-0069] Diode cell sky130_fd_sc_hs__diode_ not found.


### PR DESCRIPTION
grt::have_routes should be silent in .tcl, AntennaChecker.cc has another warning of its own and EstimateireParasitics.cc uses placement if global routing is not available and it doesn't look like it should output a warning

fixes #6293