### PR TITLE
clang-format: ran it on this file

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4602,10 +4602,7 @@ void GlobalRouter::reportNetDetailedRouteWL(odb::dbWire* wire,
 void GlobalRouter::createWLReportFile(const char* file_name, bool verbose)
 {
   std::ofstream out(file_name);
-  out << "tool "
-      << "net "
-      << "total_wl "
-      << "#pins ";
+  out << "tool " << "net " << "total_wl " << "#pins ";
 
   if (verbose) {
     out << "#vias ";


### PR DESCRIPTION
Curious... I didn't get a clang-format failure on https://github.com/The-OpenROAD-Project/OpenROAD/pull/6305, even if clang-format had more work to do on the file I changed.

Perhaps CI knows not to complain about formatting problems that isn't in the part of the code that I changed? If so, nice feature. :-)