### PR TITLE
nix: update to nixos 24.11, fix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724316499,
-        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "lastModified": 1733261153,
+        "narHash": "sha256-eq51hyiaIwtWo19fPEeE0Zr2s83DYMKJoukNLgGGpek=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "rev": "b681065d0919f7eb5309a93cea2cfa84dec9aa88",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-24.05;
+    nixpkgs.url = github:nixos/nixpkgs/nixos-24.11;
   };
 
   outputs = {self, nixpkgs, ...}: {

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,14 @@
       default = pkgs': pkgs: {
         or-tools_9_11 = (nixpkgs.lib.callPackageWith pkgs') ./nix/or-tools_9_11.nix {
           inherit (pkgs'.darwin) DarwinTools;
+          clangStdenv =
+            if pkgs'.system == "x86_64-darwin"
+            then (pkgs'.overrideSDK pkgs'.clangStdenv "11.0")
+            else pkgs'.clangStdenv;
         };
         openroad = (nixpkgs.lib.callPackageWith pkgs') ./nix/default.nix {
           flake = self;
+          inherit (pkgs'.llvmPackages_16) clang-tools;
         };
         openroad-release = pkgs'.openroad.overrideAttrs (finalAttrs: previousAttrs: {
           pname = "openroad-release";

--- a/flake.nix
+++ b/flake.nix
@@ -6,44 +6,66 @@
 #   3. cd build
 #   4. cmake -G Ninja $cmakeFlags ..
 #   5. ninja
-
 # To build OpenROAD with Nix:
 #   1. Install Nix: https://github.com/DeterminateSystems/nix-installer
 #   2. nix build '.?submodules=1#'
-
 {
   inputs = {
     nixpkgs.url = github:nixos/nixpkgs/nixos-24.11;
   };
 
-  outputs = {self, nixpkgs, ...}: {
-    packages = nixpkgs.lib.genAttrs [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ] (
-      system: let
-        pkgs = import nixpkgs {inherit system;};
-        all = {
-          openroad = (nixpkgs.lib.callPackageWith pkgs) ./default.nix {
-            flake = self;
-          };
-          openroad-release = all.openroad.overrideAttrs (fa: pa: {
-            pname = "openroad-release";
-            version = "24Q3";
-            src = pkgs.fetchFromGitHub {
-              owner = "The-OpenROAD-Project";
-              repo = "OpenROAD";
-              rev = fa.version;
-              fetchSubmodules = true;
-              sha256 = "sha256-Ye9XJcoUxtg031eazT4qrexvyN0jZHd8/kmvAr/lPzk=";
-            };
-          });
-          default = all.openroad;
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: {
+    overlays = {
+      default = pkgs': pkgs: {
+        or-tools_9_11 = (nixpkgs.lib.callPackageWith pkgs') ./nix/or-tools_9_11.nix {
+          inherit (pkgs'.darwin) DarwinTools;
         };
-      in
-        all
-    );
+        openroad = (nixpkgs.lib.callPackageWith pkgs') ./nix/default.nix {
+          flake = self;
+        };
+        openroad-release = pkgs'.openroad.overrideAttrs (finalAttrs: previousAttrs: {
+          pname = "openroad-release";
+          version = "24Q3";
+          src = pkgs.fetchFromGitHub {
+            owner = "The-OpenROAD-Project";
+            repo = "OpenROAD";
+            rev = finalAttrs.version;
+            fetchSubmodules = true;
+            sha256 = "sha256-Ye9XJcoUxtg031eazT4qrexvyN0jZHd8/kmvAr/lPzk=";
+          };
+        });
+      };
+    };
+
+    legacyPackages =
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ] (
+        system:
+          import nixpkgs {
+            inherit system;
+            overlays = [
+              self.overlays.default
+            ];
+          }
+      );
+
+    packages =
+      nixpkgs.lib.genAttrs [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ] (system: {
+        inherit (self.legacyPackages.${system}) openroad openroad-release;
+        default = self.legacyPackages.${system}.openroad;
+      });
   };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -35,9 +35,11 @@
 {
   flake,
   lib,
-  llvmPackages_17,
+  clangStdenv,
+  clang-tools,
   fetchFromGitHub,
   libsForQt5,
+  bzip2,
   boost186,
   eigen,
   cudd,
@@ -66,16 +68,13 @@
   or-tools_9_11,
   highs, # for or-tools
   re2, # for or-tools
-}: let
-  stdenv = llvmPackages_17.stdenv;
-in
-  stdenv.mkDerivation (finalAttrs: {
+}: clangStdenv.mkDerivation (finalAttrs: {
     name = "openroad";
 
     src = flake;
 
     cmakeFlags = [
-      "-DTCL_LIBRARY=${tcl}/lib/libtcl${stdenv.hostPlatform.extensions.sharedLibrary}"
+      "-DTCL_LIBRARY=${tcl}/lib/libtcl${clangStdenv.hostPlatform.extensions.sharedLibrary}"
       "-DTCL_HEADER=${tcl}/include/tcl.h"
       "-DUSE_SYSTEM_BOOST:BOOL=ON"
       "-DVERBOSE=1"
@@ -121,8 +120,7 @@ in
         zlib
 
         or-tools_9_11
-        highs
-        re2
+        bzip2
       ];
 
     nativeBuildInputs = [
@@ -134,6 +132,6 @@ in
       flex
       bison
       libsForQt5.wrapQtAppsHook
-      llvmPackages_17.clang-tools
+      clang-tools
     ];
   })

--- a/nix/or-tools_9_11.nix
+++ b/nix/or-tools_9_11.nix
@@ -1,0 +1,167 @@
+###############################################################################
+##
+## BSD 3-Clause License
+##
+## Copyright (c) 2023-2024, Efabless Corporation
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of source code must retain the above copyright notice, this
+##   list of conditions and the following disclaimer.
+##
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and#or other materials provided with the distribution.
+##
+## * Neither the name of the copyright holder nor the names of its
+##   contributors may be used to endorse or promote products derived from
+##   this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+## LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+## CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+## SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+## INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+##
+###############################################################################
+# ---
+# Original license follows:
+#
+# Copyright (c) 2003-2024 Eelco Dolstra and the Nixpkgs/NixOS contributors
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{
+  abseil-cpp,
+  bzip2,
+  cbc,
+  cmake,
+  DarwinTools, # sw_vers
+  eigen,
+  ensureNewerSourcesForZipFilesHook,
+  fetchFromGitHub,
+  glpk,
+  lib,
+  pkg-config,
+  protobuf,
+  re2,
+  llvmPackages_17,
+  swig,
+  unzip,
+  zlib,
+  highs,
+}: let
+  stdenv = llvmPackages_17.stdenv;
+in
+  stdenv.mkDerivation (finalAttrs: {
+    pname = "or-tools";
+    version = "9.11";
+
+    src = fetchFromGitHub {
+      owner = "google";
+      repo = "or-tools";
+      rev = "v${finalAttrs.version}";
+      hash = "sha256-aRhUAs9Otvra7VPJvrf0fhDCGpYhOw1//BC4dFJ7/xI=";
+    };
+
+    cmakeFlags =
+      [
+        "-DBUILD_DEPS=OFF"
+        "-DBUILD_absl=OFF"
+        "-DCMAKE_INSTALL_BINDIR=bin"
+        "-DCMAKE_INSTALL_INCLUDEDIR=include"
+        "-DCMAKE_INSTALL_LIBDIR=lib"
+        "-DUSE_GLPK=ON"
+        "-DUSE_SCIP=OFF"
+        "-DPROTOC_PRG=${protobuf}/bin/protoc"
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin ["-DCMAKE_MACOSX_RPATH=OFF"];
+
+    strictDeps = true;
+
+    nativeBuildInputs =
+      [
+        cmake
+        ensureNewerSourcesForZipFilesHook
+        pkg-config
+        swig
+        unzip
+      ]
+      ++ lib.optionals stdenv.hostPlatform.isDarwin [
+        DarwinTools
+      ];
+
+    buildInputs = [
+      abseil-cpp
+      bzip2
+      cbc
+      eigen
+      glpk
+      re2
+      zlib
+      highs
+    ];
+
+    propagatedBuildInputs = [
+      abseil-cpp
+      protobuf
+    ];
+
+    env.NIX_CFLAGS_COMPILE = toString [
+      # fatal error: 'python/google/protobuf/proto_api.h' file not found
+      "-I${protobuf.src}"
+    ];
+
+    # some tests fail on linux and hang on darwin
+    doCheck = false;
+
+    preCheck = ''
+      export LD_LIBRARY_PATH=$LD_LIBRARY_PATH''${LD_LIBRARY_PATH:+:}$PWD/lib
+    '';
+
+    # This extra configure step prevents the installer from littering
+    # $out/bin with sample programs that only really function as tests,
+    # and disables the upstream installation of a zipped Python egg that
+    # can’t be imported with our Python setup.
+    installPhase = ''
+      cmake . -DBUILD_EXAMPLES=OFF -DBUILD_PYTHON=OFF -DBUILD_SAMPLES=OFF
+      cmake --install .
+    '';
+
+    outputs = ["out"];
+
+    meta = with lib; {
+      homepage = "https://github.com/google/or-tools";
+      license = licenses.asl20;
+      description = ''
+        Google's software suite for combinatorial optimization.
+      '';
+      mainProgram = "fzn-ortools";
+      maintainers = with maintainers; [andersk];
+      platforms = with platforms; linux ++ darwin;
+    };
+  })

--- a/src/drt/src/dr/FlexGridGraph_maze.cpp
+++ b/src/drt/src/dr/FlexGridGraph_maze.cpp
@@ -58,7 +58,7 @@ void FlexGridGraph::printExpansion(const FlexWavefrontGrid& currGrid,
       pt,
       currGrid.getCost(),
       currGrid.getPathCost(),
-      currGrid.getLastDir(),
+      int(currGrid.getLastDir()),
       currGrid.getCost() - currGrid.getPathCost(),
       gridX,
       gridY);

--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -33,6 +33,10 @@
 #pragma once
 
 #include <tcl.h>
+// Workaround for https://github.com/swig/swig/issues/2887
+#ifndef TCL_SIZE_MAX
+using Tcl_Size = int;
+#endif
 
 #include <QCompleter>
 #include <QMenu>

--- a/src/odb/src/db/dbMarker.cpp
+++ b/src/odb/src/db/dbMarker.cpp
@@ -506,8 +506,10 @@ void _dbMarker::fromPTree(const _dbMarkerCategory::PropertyTree& tree)
       } else if (shape_type.value() == "polygon") {
         shapes_.emplace_back(Polygon(pts));
       } else {
-        getLogger()->warn(
-            utl::ODB, 256, "Unable to find shape of violation: {}", shape_type);
+        getLogger()->warn(utl::ODB,
+                          256,
+                          "Unable to find shape of violation: {}",
+                          shape_type.value());
       }
     }
   }
@@ -561,7 +563,7 @@ void _dbMarker::fromPTree(const _dbMarkerCategory::PropertyTree& tree)
           src_found = true;
         } else {
           getLogger()->warn(
-              utl::ODB, 262, "Unable to find bterm: {}", src_name);
+              utl::ODB, 262, "Unable to find bterm: {}", src_name.value());
         }
       } else if (src_type.value() == "obstruction") {
         src_found = marker->addObstructionFromBlock(block);


### PR DESCRIPTION
* updated nix package set to nixos 24.11
  * changed compiler to clang 17
  * bumped boost to 1.86
* src/gui/src/tclCmdInputWidget.h: add workaround for swig issue https://github.com/swig/swig/issues/2887
* work around a number of fmt peculiarities
  * src/odb/src/db/dbMarker.cpp: use .value() for two logging instances where the optional variable has already been unwrapped as some combinations of boost and fmt cannot format boost::optional
  * src/drt/src/dr/FlexGridGraph_maze.cpp: explicitly cast enum to int because fmt apparently stopped doing so started fmt 10

--

I'm not sure why the fmt issues are happening. I tried downgrading and upgrading fmt to 9 and 11 (Nix's default is 10) and neither helped.

(cc @widlarizer / thanks for tracking down the SWIG patch from freebsd)

