### PR TITLE
stt: fixing errors detected with Coverity Scan

### DIFF
--- a/src/stt/include/stt/SteinerTreeBuilder.h
+++ b/src/stt/include/stt/SteinerTreeBuilder.h
@@ -116,7 +116,6 @@ class SteinerTreeBuilder
   Tree flute(const std::vector<int>& x, const std::vector<int>& y, int acc);
   int wirelength(Tree t);
   void plottree(Tree t);
-  void write_svg(Tree t, const char* filename);
   Tree flutes(const std::vector<int>& xs,
               const std::vector<int>& ys,
               const std::vector<int>& s,

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -74,7 +74,6 @@ class Flute
   Tree flute(const std::vector<int>& x, const std::vector<int>& y, int acc);
   int wirelength(Tree t);
   void plottree(Tree t);
-  void write_svg(Tree t, const char* filename);
   inline Tree flutes(const std::vector<int>& xs,
                      const std::vector<int>& ys,
                      const std::vector<int>& s,
@@ -195,7 +194,7 @@ class Flute
  private:
   // Dynamically allocate LUTs.
   LUT_TYPE LUT = nullptr;
-  NUMSOLN_TYPE numsoln;
+  NUMSOLN_TYPE numsoln = nullptr;
   // LUTs are initialized to this order at startup.
   const int lut_initial_d = 8;
   int lut_valid_d = 0;

--- a/src/stt/src/SteinerTreeBuilder.cpp
+++ b/src/stt/src/SteinerTreeBuilder.cpp
@@ -298,11 +298,6 @@ void SteinerTreeBuilder::plottree(Tree t)
   flute_->plottree(std::move(t));
 }
 
-void SteinerTreeBuilder::write_svg(Tree t, const char* filename)
-{
-  flute_->write_svg(std::move(t), filename);
-}
-
 Tree SteinerTreeBuilder::flutes(const std::vector<int>& xs,
                                 const std::vector<int>& ys,
                                 const std::vector<int>& s,

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -2004,50 +2004,6 @@ void Flute::plottree(Tree t)
   }
 }
 
-// Write svg file viewable in a web browser.
-void Flute::write_svg(Tree t, const char* filename)
-{
-  int x_min = INT_MAX;
-  int y_min = INT_MAX;
-  int x_max = INT_MIN;
-  int y_max = INT_MIN;
-  for (int i = 0; i < 2 * t.deg - 2; i++) {
-    x_min = std::min(x_min, t.branch[i].x);
-    y_min = std::min(y_min, t.branch[i].y);
-    x_max = std::max(x_max, t.branch[i].x);
-    y_max = std::max(y_max, t.branch[i].y);
-  }
-
-  int dx = x_max - x_min;
-  int dy = y_max - y_min;
-  const double sz = std::max(std::max(dx, dy) / 400.0, 1.0);
-  const double hsz = sz / 2;
-
-  FILE* stream = fopen(filename, "w");
-  if (stream) {
-    fprintf(stream,
-            "<svg xmlns=\"http://www.w3.org/2000/svg\" "
-            "viewBox=\"%d %d %d %d\">\n",
-            x_min,
-            y_min,
-            dx,
-            dy);
-
-    for (int i = 0; i < 2 * t.deg - 2; i++) {
-      fprintf(stream,
-              "<line x1=\"%d\" y1=\"%d\" x2=\"%d\" y2=\"%d\" "
-              "style=\"stroke: black; stroke-width: %lf\"/>\n",
-              t.branch[i].x,
-              t.branch[i].y,
-              t.branch[t.branch[i].n].x,
-              t.branch[t.branch[i].n].y,
-              hsz / 2);
-    }
-    fprintf(stream, "</svg>\n");
-    fclose(stream);
-  }
-}
-
 }  // namespace flt
 
 }  // namespace stt


### PR DESCRIPTION
The errors below were fixed by removing the write_svg function and initializing numsoln as nullptr.

** CID 1566420:    (INTEGER_OVERFLOW)
/src/stt/src/flt/flute.cpp: 2021 in stt::flt::Flute::write_svg(stt::Tree, const char *)()


** CID 1566417:  Uninitialized members  (UNINIT_CTOR)
/src/stt/include/stt/flute.h: 198 in stt::flt::Flute::Flute()()