### PR TITLE
gui: fix gui::unminimize on Ubuntu 24.04

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1365,16 +1365,15 @@ int startGui(int& argc,
 
   // create new MainWindow
   main_window = new gui::MainWindow(load_settings);
-  if (minimize) {
-    main_window->showMinimized();
-  }
 
   open_road->addObserver(main_window);
   if (!interactive) {
     gui->setContinueAfterClose();
     main_window->setAttribute(Qt::WA_DontShowOnScreen);
   }
-  main_window->show();
+  if (!minimize) {
+    main_window->show();
+  }
 
   gui->setLogger(open_road->getLogger());
 


### PR DESCRIPTION
Always broken on Wayland, sometimes broken on xcb.

Apparently this part of the Qt API is a bit fickle w.r.t. initial conditions

fixes #6172