### PR TITLE
ord: ensure global connects are updated when nets are destroyed

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7665,6 +7665,10 @@ class dbGlobalConnect : public dbObject
                                  const std::string& pin_pattern);
 
   static void destroy(dbGlobalConnect* global_connect);
+
+  static dbSet<dbGlobalConnect>::iterator destroy(
+      dbSet<dbGlobalConnect>::iterator& itr);
+
   // User Code End dbGlobalConnect
 };
 

--- a/src/odb/src/db/dbGlobalConnect.cpp
+++ b/src/odb/src/db/dbGlobalConnect.cpp
@@ -251,6 +251,15 @@ void dbGlobalConnect::destroy(dbGlobalConnect* gc)
   block->global_connect_tbl_->destroy(dbgc);
 }
 
+dbSet<dbGlobalConnect>::iterator dbGlobalConnect::destroy(
+    dbSet<dbGlobalConnect>::iterator& itr)
+{
+  dbGlobalConnect* g = *itr;
+  dbSet<dbGlobalConnect>::iterator next = ++itr;
+  destroy(g);
+  return next;
+}
+
 void _dbGlobalConnect::setupRegex()
 {
   inst_regex_

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -3099,6 +3099,7 @@ void dbNet::destroy(dbNet* net_)
 {
   _dbNet* net = (_dbNet*) net_;
   _dbBlock* block = (_dbBlock*) net->getOwner();
+  dbBlock* dbblock = (dbBlock*) block;
 
   if (net->_flags._dont_touch) {
     net->getLogger()->error(
@@ -3137,6 +3138,15 @@ void dbNet::destroy(dbNet* net_)
   dbSet<dbGuide> guides = net_->getGuides();
   for (auto gitr = guides.begin(); gitr != guides.end();) {
     gitr = dbGuide::destroy(gitr);
+  }
+
+  dbSet<dbGlobalConnect> connects = dbblock->getGlobalConnects();
+  for (auto gitr = connects.begin(); gitr != connects.end();) {
+    if (gitr->getNet()->getId() == net_->getId()) {
+      gitr = dbGlobalConnect::destroy(gitr);
+    } else {
+      gitr++;
+    }
   }
 
   if (block->_journal) {


### PR DESCRIPTION
I noticed that the global connects hold on to the old information after a net is destroyed (usually causing a segfault).
This fixes that by ensuring that the global connects are checked during dbNet destroy.