### PR TITLE
Added Python SWIG typemaps for uint64_t

### DIFF
--- a/src/odb/src/swig/python/dbtypes.i
+++ b/src/odb/src/swig/python/dbtypes.i
@@ -64,6 +64,10 @@
     $result = list;
 }
 
+%typemap(out) uint64_t {
+    $result = PyLong_FromUnsignedLongLong($1);
+}
+
 %typemap(out) std::optional<uint8_t> {
     if ($1.has_value()) {
         $result = PyInt_FromLong((long)$1.value());


### PR DESCRIPTION
Introduced in d827454e. Absence of the typemap results in:

```
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
swig/python detected a memory leak of type 'uint64_t *', no destructor found.
Traceback (most recent call last):
  File "/home/karim/work/openlane2/sandbox/worktrees/upgrade-nixos-24.11/reproducible/./scripts/odbpy/wire_lengths.py", line 93, in <module>
    main()
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/home/karim/work/openlane2/sandbox/worktrees/upgrade-nixos-24.11/reproducible/scripts/odbpy/reader.py", line 217, in wrapper
    function(**kwargs)
  File "/home/karim/work/openlane2/sandbox/worktrees/upgrade-nixos-24.11/reproducible/./scripts/odbpy/wire_lengths.py", line 67, in main
    nets.sort(key=lambda net: net.getWire().getLength(), reverse=True)
TypeError: '<' not supported between instances of 'SwigPyObject' and 'SwigPyObject'
```