### PR TITLE
mpl2: do cluster placement for stdcell-only levels

### DIFF
--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -1731,22 +1731,21 @@ void ClusteringEngine::fetchMixedLeaves(
     Cluster* parent,
     std::vector<std::vector<Cluster*>>& mixed_leaves)
 {
-  if (parent->getChildren().empty() || parent->getNumMacro() == 0) {
-    return;
-  }
-
   std::vector<Cluster*> sister_mixed_leaves;
 
   for (auto& child : parent->getChildren()) {
     updateInstancesAssociation(child.get());
-    if (child->getNumMacro() > 0) {
-      if (child->getChildren().empty()) {
+
+    if (child->getNumMacro() == 0) {
+      child->setClusterType(StdCellCluster);
+    }
+
+    if (child->getChildren().empty()) {
+      if (child->getClusterType() != StdCellCluster) {
         sister_mixed_leaves.push_back(child.get());
-      } else {
-        fetchMixedLeaves(child.get(), mixed_leaves);
       }
     } else {
-      child->setClusterType(StdCellCluster);
+      fetchMixedLeaves(child.get(), mixed_leaves);
     }
   }
 

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -1174,16 +1174,12 @@ void HierRTLMP::adjustCongestionWeight()
 // summation of pin access size is equal to the area of standard-cell clusters
 void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
 {
-  // base case
-  // If the parent cluster has no macros (parent cluster is a StdCellCluster or
-  // IOCluster) We do not need to determine the positions and shapes of its
-  // children clusters
-  if (parent->getNumMacro() == 0) {
-    return;
-  }
-  // If the parent is a HardMacroCluster
   if (parent->getClusterType() == HardMacroCluster) {
     placeMacros(parent);
+    return;
+  }
+
+  if (parent->isLeaf()) { // Cover IO Clusters && Leaf Std Cells
     return;
   }
 
@@ -2078,16 +2074,12 @@ void HierRTLMP::runHierarchicalMacroPlacement(Cluster* parent)
   }
 
   updateChildrenRealLocation(parent, outline.xMin(), outline.yMin());
+  sa_containers.clear();
 
   // Continue cluster placement on children
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getClusterType() == MixedCluster
-        || cluster->getClusterType() == HardMacroCluster) {
-      runHierarchicalMacroPlacement(cluster.get());
-    }
+    runHierarchicalMacroPlacement(cluster.get());
   }
-
-  sa_containers.clear();
 
   clustering_engine_->updateInstancesAssociation(parent);
 }
@@ -2159,19 +2151,14 @@ void HierRTLMP::reportSAWeights()
   logger_->report("Macro Blockage = {}\n", macro_blockage_weight_);
 }
 
-// Multilevel macro placement without bus planning
 void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
 {
-  // base case
-  // If the parent cluster has no macros (parent cluster is a StdCellCluster or
-  // IOCluster) We do not need to determine the positions and shapes of its
-  // children clusters
-  if (parent->getNumMacro() == 0) {
-    return;
-  }
-  // If the parent is a HardMacroCluster
   if (parent->getClusterType() == HardMacroCluster) {
     placeMacros(parent);
+    return;
+  }
+
+  if (parent->isLeaf()) { // Cover IO Clusters && Leaf Std Cells
     return;
   }
 
@@ -2648,10 +2635,7 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
 
   // Continue cluster placement on children
   for (auto& cluster : parent->getChildren()) {
-    if (cluster->getClusterType() == MixedCluster
-        || cluster->getClusterType() == HardMacroCluster) {
-      runHierarchicalMacroPlacementWithoutBusPlanning(cluster.get());
-    }
+    runHierarchicalMacroPlacementWithoutBusPlanning(cluster.get());
   }
 
   clustering_engine_->updateInstancesAssociation(parent);
@@ -2663,18 +2647,12 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
 // This should be only be used in mixed clusters.
 void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
 {
-  // base case
-  // If the parent cluster has no macros (parent cluster is a StdCellCluster or
-  // IOCluster) We do not need to determine the positions and shapes of its
-  // children clusters
-  if (parent->getNumMacro() == 0) {
-    return;
-  }
-  // If the parent is the not the mixed cluster
   if (parent->getClusterType() != MixedCluster) {
     return;
   }
-  // If the parent has children of mixed cluster
+
+  // We only run this enhanced macro placement version if there are no
+  // further levels ahead in the current branch of the physical hierarchy.
   for (auto& cluster : parent->getChildren()) {
     if (cluster->getClusterType() == MixedCluster) {
       return;


### PR DESCRIPTION
This is an idea to improve mpl2 results / allow different test cases for situations in which we have a physical hierarchical tree with more than 1 level.

### Context

The idea here is based on megaBoom and the big module that I'm referring to is _lsu_.

In the original implementation, when doing multilevel autoclustering, at the point in which we haven't yet split the macros from std cells in the leaves of the tree (meaning all the leaves are mixed) and iterating the children of a certain parent to do so, if we found a cluster without macros, we would simply classify it at as std cell cluster and move on to the next child, not caring about a possible further stdcell cluster only level i.e., a std cell parent whose children are all std cell clusters. _I believe that this was to avoid a larger run-time._

However, since we added the orientation improvement step, mpl2 uses the location of the std cell clusters to generate a temporary placement for the cells and with that, have some idea of how to change the orientation of the macros.

So if we have a situation in which..
- We're creating a cluster tree with max level > 1;
- There's a big module A made of std cells that will be partitioned by TP at some point;

..when we get to cluster placement, the current behavior is to skip the placement of this std cell cluster children and only use the position of the parent. However, as the std cells of A now belong to these children, if the children are ignored by cluster placement, their std cells will never be placed and the locations seen by orientation improvement will be wrong.

### Changes
Do cluster placement for children of std cell clusters.