### PR TITLE
mpl2: do cluster placement for stdcell-only levels

### DIFF
--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -1731,22 +1731,21 @@ void ClusteringEngine::fetchMixedLeaves(
     Cluster* parent,
     std::vector<std::vector<Cluster*>>& mixed_leaves)
 {
-  if (parent->getChildren().empty() || parent->getNumMacro() == 0) {
-    return;
-  }
-
   std::vector<Cluster*> sister_mixed_leaves;
 
   for (auto& child : parent->getChildren()) {
     updateInstancesAssociation(child.get());
-    if (child->getNumMacro() > 0) {
-      if (child->getChildren().empty()) {
+
+    if (child->getNumMacro() == 0) {
+      child->setClusterType(StdCellCluster);
+    }
+
+    if (child->getChildren().empty()) {
+      if (child->getClusterType() != StdCellCluster) {
         sister_mixed_leaves.push_back(child.get());
-      } else {
-        fetchMixedLeaves(child.get(), mixed_leaves);
       }
     } else {
-      child->setClusterType(StdCellCluster);
+      fetchMixedLeaves(child.get(), mixed_leaves);
     }
   }
 


### PR DESCRIPTION
Run cluster placement for children of std cell clusters to allow correct generation of temporary std cell placement (and consequently allow orientation improvement) for cases in which the cluster tree has maximum level > 1.

### Context

The idea here is based on megaBoom and the big module that I'm referring to is lsu.

In the original implementation, when doing multilevel autoclustering, at the point in which we haven't yet split the macros from std cells in the leaves of the tree (meaning all the leaves are mixed) and iterating the children of a certain parent to do so, if we found a cluster without macros, we would simply classify it at as std cell cluster and move on to the next child, not caring about a possible further stdcell cluster only level i.e., a std cell parent whose children are all std cell clusters. I believe that this was to avoid a larger run-time.

However, since we added the orientation improvement step, mpl2 uses the location of the std cell clusters to generate a temporary placement for the cells and with that, have some idea of how to change the orientation of the macros.

So if we have a situation in which..
- We're creating a cluster tree with max level > 1;
- There's a big module A made of std cells that will be partitioned by TP at some point;

..when we get to cluster placement, the current behavior is to skip the placement of this std cell cluster children and only use the position of the parent. However, as the std cells of A "belong" to these children, if the children are ignored by cluster placement, their std cells will never be placed and the locations seen by orientation improvement will be wrong.
