### PR TITLE
rsz: add report_dont_* commands

### DIFF
--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -145,6 +145,14 @@ The `unset_dont_use` command reverses the `set_dont_use` command.
 unset_dont_use lib_cells
 ```
 
+### Report Don't Use
+
+The `report_dont_use` reports all the cells that are marked as dont use.
+
+```tcl
+report_dont_use
+```
+
 ### Set Don't Touch
 
 The `set_dont_touch` command prevents the resizer commands from
@@ -160,6 +168,14 @@ The `unset_dont_touch` command reverse the `set_dont_touch` command.
 
 ```tcl
 unset_dont_touch instances_nets
+```
+
+### Report Don't Touch
+
+The `report_dont_touch` reports all the instances and nets that are marked as dont touch.
+
+```tcl
+report_dont_touch
 ```
 
 ### Buffer Ports

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -262,10 +262,12 @@ class Resizer : public dbStaState
 
   void setDontUse(LibertyCell* cell, bool dont_use);
   bool dontUse(LibertyCell* cell);
+  void reportDontUse() const;
   void setDontTouch(const Instance* inst, bool dont_touch);
   bool dontTouch(const Instance* inst);
   void setDontTouch(const Net* net, bool dont_touch);
   bool dontTouch(const Net* net);
+  void reportDontTouch();
 
   void setMaxUtilization(double max_utilization);
   // Remove all or selected buffers from the netlist.

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1803,6 +1803,19 @@ bool Resizer::dontUse(LibertyCell* cell)
   return cell->dontUse() || dont_use_.hasKey(cell);
 }
 
+void Resizer::reportDontUse() const
+{
+  logger_->report("Don't Use Cells:");
+
+  if (dont_use_.empty()) {
+    logger_->report("  none");
+  } else {
+    for (auto* cell : dont_use_) {
+      logger_->report("  {}", cell->name());
+    }
+  }
+}
+
 void Resizer::setDontTouch(const Instance* inst, bool dont_touch)
 {
   dbInst* db_inst = db_network_->staToDb(inst);
@@ -1828,6 +1841,45 @@ bool Resizer::dontTouch(const Net* net)
 {
   dbNet* db_net = db_network_->staToDb(net);
   return db_net->isDoNotTouch();
+}
+
+void Resizer::reportDontTouch()
+{
+  initBlock();
+
+  std::set<odb::dbInst*> insts;
+  std::set<odb::dbNet*> nets;
+
+  for (auto* inst : block_->getInsts()) {
+    if (inst->isDoNotTouch()) {
+      insts.insert(inst);
+    }
+  }
+
+  for (auto* net : block_->getNets()) {
+    if (net->isDoNotTouch()) {
+      nets.insert(net);
+    }
+  }
+
+  logger_->report("Don't Touch Instances:");
+
+  if (insts.empty()) {
+    logger_->report("  none");
+  } else {
+    for (auto* inst : insts) {
+      logger_->report("  {}", inst->getName());
+    }
+  }
+
+  logger_->report("Don't Touch Nets:");
+  if (nets.empty()) {
+    logger_->report("  none");
+  } else {
+    for (auto* net : nets) {
+      logger_->report("  {}", net->getName());
+    }
+  }
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -467,6 +467,7 @@ report_dont_use()
 void
 report_dont_touch()
 {
+  ensureLinked();
   Resizer *resizer = getResizer();
   resizer->reportDontTouch();
 }

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -458,6 +458,20 @@ set_dont_touch_instance(Instance *inst,
 }
 
 void
+report_dont_use()
+{
+  Resizer *resizer = getResizer();
+  resizer->reportDontUse();
+}
+
+void
+report_dont_touch()
+{
+  Resizer *resizer = getResizer();
+  resizer->reportDontTouch();
+}
+
+void
 set_dont_touch_net(Net *net,
                    bool dont_touch)
 {

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -386,6 +386,24 @@ proc set_dont_touch_cmd { cmd cmd_args dont_touch } {
   }
 }
 
+sta::define_cmd_args "report_dont_use" {}
+
+proc report_dont_use { args } {
+  sta::parse_key_args "report_dont_use" args keys {} flags {}
+  sta::check_argc_eq0 "report_dont_use" $args
+
+  rsz::report_dont_use
+}
+
+sta::define_cmd_args "report_dont_touch" {}
+
+proc report_dont_touch { args } {
+  sta::parse_key_args "report_dont_touch" args keys {} flags {}
+  sta::check_argc_eq0 "report_dont_touch" $args
+
+  rsz::report_dont_touch
+}
+
 sta::define_cmd_args "buffer_ports" {[-inputs] [-outputs]\
                                        [-max_utilization util]\
                                        [-buffer_cell buf_cell]}

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -114,6 +114,8 @@ set(TEST_NAMES
     repair_wire9
     repair_wire10
     repair_wire11
+    report_dont_touch
+    report_dont_use
     report_floating_nets1
     report_floating_nets2
     report_floating_nets3

--- a/src/rsz/test/regression_tests.tcl
+++ b/src/rsz/test/regression_tests.tcl
@@ -97,6 +97,8 @@ record_tests {
   repair_slew15
   repair_slew16
   repair_slew17
+  report_dont_touch
+  report_dont_use
   report_floating_nets1
   report_floating_nets2
   report_floating_nets3

--- a/src/rsz/test/report_dont_touch.ok
+++ b/src/rsz/test/report_dont_touch.ok
@@ -1,0 +1,23 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 571 components and 2554 component-terminals.
+[INFO ODB-0132]     Created 5 special nets and 1142 connections.
+[INFO ODB-0133]     Created 528 nets and 1412 connections.
+Don't Touch Instances:
+  none
+Don't Touch Nets:
+  none
+Don't Touch Instances:
+  _505_
+Don't Touch Nets:
+  _050_
+  _051_
+  _052_
+  _053_
+  _054_
+  _055_
+  _056_
+  _057_
+  _058_
+  _059_

--- a/src/rsz/test/report_dont_touch.tcl
+++ b/src/rsz/test/report_dont_touch.tcl
@@ -1,0 +1,14 @@
+# check for report_dont_touch
+
+source "helpers.tcl"
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def "gcd_nangate45_placed.def"
+
+report_dont_touch
+
+set_dont_touch "_505_"
+set_dont_touch "_05*_"
+
+report_dont_touch

--- a/src/rsz/test/report_dont_use.ok
+++ b/src/rsz/test/report_dont_use.ok
@@ -1,0 +1,18 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 571 components and 2554 component-terminals.
+[INFO ODB-0132]     Created 5 special nets and 1142 connections.
+[INFO ODB-0133]     Created 528 nets and 1412 connections.
+Don't Use Cells:
+  none
+Don't Use Cells:
+  CLKBUF_X1
+  CLKBUF_X2
+  CLKBUF_X3
+  INV_X1
+  INV_X2
+  INV_X4
+  INV_X8
+  INV_X16
+  INV_X32

--- a/src/rsz/test/report_dont_use.tcl
+++ b/src/rsz/test/report_dont_use.tcl
@@ -1,0 +1,14 @@
+# check for report_dont_use
+
+source "helpers.tcl"
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def "gcd_nangate45_placed.def"
+
+report_dont_use
+
+set_dont_use "CLKBUF*"
+set_dont_use "INV*"
+
+report_dont_use


### PR DESCRIPTION
Adds:
- `report_dont_use` and `report_dont_touch` to provide feedback about the instance, cells, and nets that have been marked by resizer.