### PR TITLE
odb: Add pointer caching to master terminal retrival

### DIFF
--- a/src/odb/include/odb/dbObject.h
+++ b/src/odb/include/odb/dbObject.h
@@ -176,6 +176,8 @@ enum dbObjectType
 
 class dbDatabase;
 
+class dbMTerm;
+
 class dbObject
 {
  public:
@@ -190,6 +192,7 @@ class dbObject
   // not exported.  They are for internal db convenience.
   _dbObject* getImpl();
   const _dbObject* getImpl() const;
+  mutable dbMTerm* mterm_cache;
 
  protected:
   dbObject() = default;

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -263,15 +263,18 @@ dbNet* dbITerm::getNet()
 
 dbMTerm* dbITerm::getMTerm() const
 {
-  _dbITerm* iterm = (_dbITerm*) this;
-  _dbBlock* block = (_dbBlock*) iterm->getOwner();
-  _dbInst* inst = block->_inst_tbl->getPtr(iterm->_inst);
-  _dbInstHdr* inst_hdr = block->_inst_hdr_tbl->getPtr(inst->_inst_hdr);
-  _dbDatabase* db = iterm->getDatabase();
-  _dbLib* lib = db->_lib_tbl->getPtr(inst_hdr->_lib);
-  _dbMaster* master = lib->_master_tbl->getPtr(inst_hdr->_master);
-  dbId<_dbMTerm> mterm = inst_hdr->_mterms[iterm->_flags._mterm_idx];
-  return (dbMTerm*) master->_mterm_tbl->getPtr(mterm);
+  if (mterm_cache == nullptr) {
+    _dbITerm* iterm = (_dbITerm*) this;
+    _dbBlock* block = (_dbBlock*) iterm->getOwner();
+    _dbInst* inst = block->_inst_tbl->getPtr(iterm->_inst);
+    _dbInstHdr* inst_hdr = block->_inst_hdr_tbl->getPtr(inst->_inst_hdr);
+    _dbDatabase* db = iterm->getDatabase();
+    _dbLib* lib = db->_lib_tbl->getPtr(inst_hdr->_lib);
+    _dbMaster* master = lib->_master_tbl->getPtr(inst_hdr->_master);
+    dbId<_dbMTerm> mterm = inst_hdr->_mterms[iterm->_flags._mterm_idx];
+    mterm_cache = (dbMTerm*) master->_mterm_tbl->getPtr(mterm);
+  }
+  return mterm_cache;
 }
 
 dbBTerm* dbITerm::getBTerm()

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -1362,6 +1362,7 @@ bool dbInst::swapMaster(dbMaster* new_master_)
   uint i;
   for (i = 0; i < cnt; ++i) {
     _dbITerm* it = block->_iterm_tbl->getPtr(inst->_iterms[i]);
+    it->mterm_cache = nullptr;
     uint old_idx = it->_flags._mterm_idx;
     it->_flags._mterm_idx = idx_map[old_idx];
   }
@@ -1458,6 +1459,7 @@ dbInst* dbInst::create(dbBlock* block_,
   uint i;
   for (i = 0; i < mterm_cnt; ++i) {
     _dbITerm* iterm = block->_iterm_tbl->create();
+    iterm->mterm_cache = nullptr;
     inst->_iterms[i] = iterm->getOID();
     iterm->_flags._mterm_idx = i;
     iterm->_inst = inst->getOID();


### PR DESCRIPTION
`dbIterm::getMTerm()` is a good candidate to add caching to the value being returned, as updates to the underlying `dbMTerm` structure are very infrequent. The function, while already optimized, is fairly expensive for a getter, and it's called very often.

Benchmarks of the `2_1_floorplan` step:
# `nangate45/black_parrot`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `master` | 52.20 | 52.68 | 52.50 ± 0.20 | 1.04 ± 0.00 | 52.55 | 1.04 |
| `odb-add-mterm-caching` | 50.02 | 50.88 | 50.43 ± 0.33 | 1.00 ± 0.01 | 50.55 | 1.00 |

# `nangate45/ariane133`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `master` | 85.98 | 87.29 | 86.61 ± 0.47 | 1.07 ± 0.01 | 86.52 | 1.07 |
| `odb-add-mterm-caching` | 80.72 | 81.74 | 81.15 ± 0.35 | 1.00 ± 0.00 | 81.19 | 1.00 |

# `nangate45/ibex`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `master` | 28.93 | 29.01 | 28.97 ± 0.03 | 1.09 ± 0.00 | 28.98 | 1.09 |
| `odb-add-mterm-caching` | 26.41 | 26.80 | 26.56 ± 0.14 | 1.00 ± 0.01 | 26.50 | 1.00 |

# `asap7/ibex`

| Branch | Min [s] | Max [s] | Mean [s] | Relative mean | Median [s] | Relative median |
|--------|---------|---------|----------|---------------|------------|-----------------|
| `master` | 33.30 | 33.58 | 33.41 ± 0.12 | 1.07 ± 0.00 | 33.33 | 1.07 |
| `odb-add-mterm-caching` | 31.02 | 31.41 | 31.16 ± 0.15 | 1.00 ± 0.00 | 31.09 | 1.00 |

