### PR TITLE
Revert "gui: assume qtcharts is available and remove ENABLE_CHARTS"

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -3,7 +3,7 @@ option(BUILD_GUI "Build the GUI" ON)
 
 # If Qt is not installed there will not be cmake
 # support for the package so this needs to be "quiet".
-find_package(Qt5 QUIET COMPONENTS Core Widgets Charts)
+find_package(Qt5 QUIET COMPONENTS Core Widgets OPTIONAL_COMPONENTS Charts)
 
 include("openroad")
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -23,6 +23,18 @@ if (Qt5_FOUND AND BUILD_GUI)
            SCRIPTS   src/gui.tcl
            RUNTIME_HEADER tclSwig.h
   )
+
+  if (TARGET Qt5::Charts)
+    message(STATUS "Charts widget is enabled")
+
+    target_compile_definitions(gui PRIVATE ENABLE_CHARTS)
+
+    list(APPEND CHARTS_LIB
+      "Qt5::Charts"
+    )
+  else()
+    message(STATUS "Charts widget is not enabled")
+  endif()
 
   set_property(SOURCE ${GUI_WRAP} PROPERTY SKIP_AUTOMOC ON)
 
@@ -72,7 +84,7 @@ if (Qt5_FOUND AND BUILD_GUI)
     PRIVATE
       Qt5::Core
       Qt5::Widgets
-      Qt5::Charts
+      ${CHARTS_LIB}
       utl
       Boost::boost
   )

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -32,9 +32,11 @@
 
 #include "chartsWidget.h"
 
+#include <QHBoxLayout>
+
+#ifdef ENABLE_CHARTS
 #include <QColor>
 #include <QFrame>
-#include <QHBoxLayout>
 #include <QString>
 #include <QWidget>
 #include <QtCharts>
@@ -46,11 +48,13 @@
 #include "sta/MinMax.hh"
 #include "sta/PortDirection.hh"
 #include "sta/Units.hh"
+#endif
 
 namespace gui {
 
 ChartsWidget::ChartsWidget(QWidget* parent)
     : QDockWidget("Charts", parent),
+#ifdef ENABLE_CHARTS
       logger_(nullptr),
       sta_(nullptr),
       stagui_(nullptr),
@@ -69,6 +73,7 @@ ChartsWidget::ChartsWidget(QWidget* parent)
       min_slack_(std::numeric_limits<float>::max()),
       bucket_interval_(0.0f),
       precision_count_(0),
+#endif
       label_(new QLabel(this))
 {
   setObjectName("charts_widget");  // for settings
@@ -77,6 +82,7 @@ ChartsWidget::ChartsWidget(QWidget* parent)
   QHBoxLayout* controls_layout = new QHBoxLayout;
   controls_layout->addWidget(label_);
 
+#ifdef ENABLE_CHARTS
   QVBoxLayout* layout = new QVBoxLayout;
   QFrame* controls_frame = new QFrame;
 
@@ -114,9 +120,16 @@ ChartsWidget::ChartsWidget(QWidget* parent)
           qOverload<int>(&QComboBox::currentIndexChanged),
           this,
           &ChartsWidget::changePathGroupFilter);
+#else
+  label_->setText("QtCharts is not installed.");
+  label_->setAlignment(Qt::AlignCenter);
+  // We need this layout in order to centralize the label.
+  container->setLayout(controls_layout);
+#endif
   setWidget(container);
 }
 
+#ifdef ENABLE_CHARTS
 void ChartsWidget::changeMode()
 {
   filters_menu_->clear();
@@ -741,4 +754,5 @@ void HistogramView::mousePressEvent(QMouseEvent* event)
   }
 }
 
+#endif
 }  // namespace gui

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -32,9 +32,11 @@
 
 #pragma once
 
-#include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
+
+#ifdef ENABLE_CHARTS
+#include <QComboBox>
 #include <QPushButton>
 #include <QString>
 #include <QtCharts>
@@ -48,8 +50,10 @@ class Pin;
 class dbSta;
 class Clock;
 }  // namespace sta
+#endif
 
 namespace gui {
+#ifdef ENABLE_CHARTS
 
 struct SlackHistogramData
 {
@@ -78,6 +82,8 @@ class HistogramView : public QChartView
   void barIndex(int bar_index);
 };
 
+#endif
+
 class ChartsWidget : public QDockWidget
 {
   Q_OBJECT
@@ -90,8 +96,12 @@ class ChartsWidget : public QDockWidget
   };
 
   ChartsWidget(QWidget* parent = nullptr);
+#ifdef ENABLE_CHARTS
   void setSTA(sta::dbSta* sta);
-  void setLogger(utl::Logger* logger) { logger_ = logger; }
+  void setLogger(utl::Logger* logger)
+  {
+    logger_ = logger;
+  }
 
   void setMode(Mode mode);
 
@@ -119,7 +129,10 @@ class ChartsWidget : public QDockWidget
   {
     precision_count_ = precision_count;
   }
-  void setClocks(const std::set<sta::Clock*>& clocks) { clocks_ = clocks; }
+  void setClocks(const std::set<sta::Clock*>& clocks)
+  {
+    clocks_ = clocks;
+  }
 
   SlackHistogramData fetchSlackHistogramData();
   void removeUnconstrainedPinsAndSetLimits(StaPins& end_points);
@@ -174,6 +187,7 @@ class ChartsWidget : public QDockWidget
   float bucket_interval_;
 
   int precision_count_;  // Used to configure the x labels.
+#endif
   QLabel* label_;
 };
 

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1300,6 +1300,7 @@ void Gui::selectHelp(const std::string& item)
 
 void Gui::selectChart(const std::string& name)
 {
+#ifdef ENABLE_CHARTS
   if (!enabled()) {
     return;
   }
@@ -1313,6 +1314,9 @@ void Gui::selectChart(const std::string& name)
     logger_->error(utl::GUI, 105, "Chart {} is unknown.", name);
   }
   main_window->getChartsWidget()->setMode(mode);
+#else
+  logger_->warn(utl::GUI, 106, "Charts are not enabled.");
+#endif
 }
 
 void Gui::updateTimingReport()

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -343,10 +343,12 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
           &TimingWidget::setCommand,
           script_,
           &ScriptWidget::setCommand);
+#ifdef ENABLE_CHARTS
   connect(charts_widget_,
           &ChartsWidget::endPointsToReport,
           this,
           &MainWindow::reportSlackHistogramPaths);
+#endif
 
   connect(this, &MainWindow::blockLoaded, this, &MainWindow::setBlock);
   connect(this, &MainWindow::blockLoaded, drc_viewer_, &DRCWidget::setBlock);
@@ -471,7 +473,9 @@ void MainWindow::init(sta::dbSta* sta, const std::string& help_path)
   controls_->setSTA(sta);
   hierarchy_widget_->setSTA(sta);
   clock_viewer_->setSTA(sta);
+#ifdef ENABLE_CHARTS
   charts_widget_->setSTA(sta);
+#endif
   help_widget_->init(help_path);
 
   // register descriptors
@@ -1501,7 +1505,9 @@ void MainWindow::setLogger(utl::Logger* logger)
   viewers_->setLogger(logger);
   drc_viewer_->setLogger(logger);
   clock_viewer_->setLogger(logger);
+#ifdef ENABLE_CHARTS
   charts_widget_->setLogger(logger);
+#endif
 }
 
 void MainWindow::fit()
@@ -1742,6 +1748,7 @@ void MainWindow::enableDeveloper()
   show_poly_decomp_view_->setVisible(true);
 }
 
+#ifdef ENABLE_CHARTS
 void MainWindow::reportSlackHistogramPaths(
     const std::set<const sta::Pin*>& report_pins,
     const std::string& path_group_name)
@@ -1758,4 +1765,5 @@ void MainWindow::reportSlackHistogramPaths(
 
   timing_widget_->reportSlackHistogramPaths(report_pins, path_group_name);
 }
+#endif
 }  // namespace gui

--- a/src/gui/src/mainWindow.h
+++ b/src/gui/src/mainWindow.h
@@ -53,11 +53,11 @@ class dbDatabase;
 namespace utl {
 class Logger;
 }
-
+#ifdef ENABLE_CHARTS
 namespace sta {
 class Pin;
 }
-
+#endif
 namespace gui {
 
 class LayoutViewer;
@@ -272,8 +272,10 @@ class MainWindow : public QMainWindow, public ord::OpenRoadObserver
   void showGlobalConnect();
   void openDesign();
   void saveDesign();
+#ifdef ENABLE_CHARTS
   void reportSlackHistogramPaths(const std::set<const sta::Pin*>& report_pins,
                                  const std::string& path_group_name);
+#endif
   void enableDeveloper();
 
  protected:

--- a/src/gui/src/timingWidget.cpp
+++ b/src/gui/src/timingWidget.cpp
@@ -731,6 +731,7 @@ void TimingWidget::showSettings()
   settings_->show();
 }
 
+#ifdef ENABLE_CHARTS
 void TimingWidget::reportSlackHistogramPaths(
     const std::set<const sta::Pin*>& report_pins,
     const std::string& path_group_name)
@@ -738,5 +739,6 @@ void TimingWidget::reportSlackHistogramPaths(
   clearPathDetails();
   populateAndSortModels({}, {report_pins}, {}, path_group_name);
 }
+#endif
 
 }  // namespace gui

--- a/src/gui/src/timingWidget.h
+++ b/src/gui/src/timingWidget.h
@@ -87,8 +87,10 @@ class TimingWidget : public QDockWidget
   TimingControlsDialog* getSettings() { return settings_; }
 
   void updatePaths();
+#ifdef ENABLE_CHARTS
   void reportSlackHistogramPaths(const std::set<const sta::Pin*>& report_pins,
                                  const std::string& path_group_name);
+#endif
 
  signals:
   void highlightTimingPath(TimingPath* timing_path);


### PR DESCRIPTION
This reverts commit 3bdbf7f025727c5289732ceb9bb911fcbeee614a.

With this commit, the GUI is not enabled in the GCP machines (including the private CI). Will investigate it further to understand how to properly fix this.