### PR TITLE
gpl: debug options for overflow

### DIFF
--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -454,7 +454,8 @@ bool Graphics::populateMap()
           0.0f,
           static_cast<float>(bin.instPlacedAreaUnscaled())
               + static_cast<float>(bin.nonPlaceAreaUnscaled()) - scaledBinArea);
-      addToMap(box, value);
+      odb::dbBlock* block = pbc_->db()->getChip()->getBlock();
+      addToMap(box, block->dbuAreaToMicrons(value));
     }
   }
 

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -735,8 +735,8 @@ class BinGrid
   int binSizeX_ = 0;
   int binSizeY_ = 0;
   float targetDensity_ = 0;
-  int64_t overflowArea_ = 0;
-  int64_t overflowAreaUnscaled_ = 0;
+  int64_t sumOverflowArea_ = 0;
+  int64_t sumOverflowAreaUnscaled_ = 0;
   bool isSetBinCnt_ = false;
   int num_threads_ = 1;
 };


### PR DESCRIPTION
These modifications does not change any functionality.

- Add debug prints for overflow calculation values.
- Show microns instead of dbu for bins in debug mode on gui.