### PR TITLE
drt: Transform slight refactoring

### DIFF
--- a/src/drt/src/db/drObj/drVia.cpp
+++ b/src/drt/src/db/drObj/drVia.cpp
@@ -100,9 +100,7 @@ Rect drVia::getBBox() const
     }
   }
   Rect box(xl, yl, xh, yh);
-  dbTransform xform;
-  xform.setOffset(origin_);
-  xform.apply(box);
+  getTransform().apply(box);
   return box;
 }
 

--- a/src/drt/src/db/drObj/drVia.h
+++ b/src/drt/src/db/drObj/drVia.h
@@ -56,7 +56,7 @@ class drVia : public drRef
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getCutBBox() const
@@ -66,7 +66,7 @@ class drVia : public drRef
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getLayer2BBox() const
@@ -76,7 +76,7 @@ class drVia : public drRef
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   // setters
@@ -97,7 +97,7 @@ class drVia : public drRef
   void setOrient(const dbOrientType& tmpOrient) override { ; }
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& tmpPoint) override { origin_ = tmpPoint; }
-  dbTransform getTransform() const override { return origin_; }
+  dbTransform getTransform() const override { return dbTransform(origin_); }
   void setTransform(const dbTransform& xformIn) override {}
 
   /* from frPinFig

--- a/src/drt/src/db/obj/frVia.h
+++ b/src/drt/src/db/obj/frVia.h
@@ -64,7 +64,7 @@ class frVia : public frRef
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getCutBBox() const
@@ -74,7 +74,7 @@ class frVia : public frRef
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getLayer2BBox() const
@@ -84,7 +84,7 @@ class frVia : public frRef
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   // setters
@@ -105,7 +105,7 @@ class frVia : public frRef
   void setOrient(const dbOrientType& tmpOrient) override { ; }
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& tmpPoint) override { origin_ = tmpPoint; }
-  dbTransform getTransform() const override { return origin_; }
+  dbTransform getTransform() const override { return dbTransform(origin_); }
   void setTransform(const dbTransform& xformIn) override {}
 
   /* from frPinFig
@@ -209,9 +209,7 @@ class frVia : public frRef
       }
     }
     Rect box(xl, yl, xh, yh);
-    dbTransform xform;
-    xform.setOffset(origin_);
-    xform.apply(box);
+    getTransform().apply(box);
     return box;
   }
   void move(const dbTransform& xform) override { ; }

--- a/src/drt/src/db/taObj/taVia.h
+++ b/src/drt/src/db/taObj/taVia.h
@@ -65,7 +65,7 @@ class taVia : public taRef
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getCutBBox() const
@@ -75,7 +75,7 @@ class taVia : public taRef
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   Rect getLayer2BBox() const
@@ -85,7 +85,7 @@ class taVia : public taRef
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
     }
-    dbTransform(origin_).apply(box);
+    getTransform().apply(box);
     return box;
   }
   // setters
@@ -205,9 +205,7 @@ class taVia : public taRef
       }
     }
     Rect box(xl, yl, xh, yh);
-    dbTransform xform;
-    xform.setOffset(origin_);
-    xform.apply(box);
+    getTransform().apply(box);
     return box;
   }
   void move(const dbTransform& xform) override { ; }

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -556,7 +556,6 @@ void FlexDRWorker::modMinimumcutCostVia(const Rect& box,
 
   FlexMazeIdx mIdx1, mIdx2;
   Rect bx, tmpBx, sViaBox;
-  dbTransform xform;
   Point pt;
   frCoord dx, dy;
   frVia sVia;
@@ -599,7 +598,7 @@ void FlexDRWorker::modMinimumcutCostVia(const Rect& box,
       for (int i = mIdx1.x(); i <= mIdx2.x(); i++) {
         for (int j = mIdx1.y(); j <= mIdx2.y(); j++) {
           gridGraph_.getPoint(pt, i, j);
-          xform.setOffset(pt);
+          dbTransform xform(pt);
           tmpBx = viaBox;
           if (gridGraph_.isSVia(i, j, zIdx)) {
             auto sViaDef = apSVia_[FlexMazeIdx(i, j, zIdx)]->getAccessViaDef();
@@ -797,13 +796,12 @@ void FlexDRWorker::modMinSpacingCostViaHelper(const Rect& box,
   Rect tmpBx;
   frSquaredDistance distSquare = 0;
   frCoord dx, dy;
-  dbTransform xform;
   frVia sVia;
   frMIdx zIdx = isUpperVia ? z : z - 1;
   for (int i = mIdx1.x(); i <= mIdx2.x(); i++) {
     for (int j = mIdx1.y(); j <= mIdx2.y(); j++) {
       gridGraph_.getPoint(pt, i, j);
-      xform.setOffset(pt);
+      dbTransform xform(pt);
       tmpBx = viaBox;
       if (gridGraph_.isSVia(i, j, zIdx)) {
         auto sViaDef = apSVia_[FlexMazeIdx(i, j, zIdx)]->getAccessViaDef();
@@ -1223,7 +1221,6 @@ void FlexDRWorker::modAdjCutSpacingCost_fixedObj(const frDesign* design,
   frSquaredDistance distSquare = 0;
   frSquaredDistance c2cSquare = 0;
   frCoord dx, dy, prl;
-  dbTransform xform;
   frSquaredDistance reqDistSquare = 0;
   Point boxCenter, tmpBxCenter;
   boxCenter = {(box.xMin() + box.xMax()) / 2, (box.yMin() + box.yMax()) / 2};
@@ -1237,7 +1234,7 @@ void FlexDRWorker::modAdjCutSpacingCost_fixedObj(const frDesign* design,
       for (auto& uFig : via.getViaDef()->getCutFigs()) {
         auto obj = static_cast<frRect*>(uFig.get());
         gridGraph_.getPoint(pt, i, j);
-        xform.setOffset(pt);
+        dbTransform xform(pt);
         Rect tmpBx = obj->getBBox();
         xform.apply(tmpBx);
         tmpBxCenter = {(tmpBx.xMin() + tmpBx.xMax()) / 2,
@@ -1414,7 +1411,6 @@ void FlexDRWorker::modInterLayerCutSpacingCost(const Rect& box,
   frSquaredDistance distSquare = 0;
   frSquaredDistance c2cSquare = 0;
   frCoord prl, dx, dy;
-  dbTransform xform;
   frSquaredDistance reqDistSquare = 0;
   Point boxCenter, tmpBxCenter;
   boxCenter = {(box.xMin() + box.xMax()) / 2, (box.yMin() + box.yMax()) / 2};
@@ -1425,7 +1421,7 @@ void FlexDRWorker::modInterLayerCutSpacingCost(const Rect& box,
       for (auto& uFig : via.getViaDef()->getCutFigs()) {
         auto obj = static_cast<frRect*>(uFig.get());
         gridGraph_.getPoint(pt, i, j);
-        xform.setOffset(pt);
+        dbTransform xform(pt);
         Rect tmpBx = obj->getBBox();
         xform.apply(tmpBx);
         tmpBxCenter = {(tmpBx.xMin() + tmpBx.xMax()) / 2,
@@ -1561,9 +1557,8 @@ void FlexDRWorker::modPathCost(drConnFig* connFig,
       modEolSpacingRulesCost(box, ei.z(), type, false, ndr);
     }
 
-    dbTransform xform;
     Point pt = obj->getOrigin();
-    xform.setOffset(pt);
+    dbTransform xform(pt);
     for (auto& uFig : obj->getViaDef()->getCutFigs()) {
       auto rect = static_cast<frRect*>(uFig.get());
       box = rect->getBBox();

--- a/src/drt/src/dr/FlexDR_rq.cpp
+++ b/src/drt/src/dr/FlexDR_rq.cpp
@@ -72,9 +72,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
     impl_->shapes_.at(obj->getLayerNum()).insert(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -124,9 +122,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -174,9 +170,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
     impl_->shapes_.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -388,9 +388,7 @@ void frRegionQuery::removeMarker(frMarker* in)
 void frRegionQuery::Impl::add(frVia* via,
                               ObjectsByLayer<frBlockObject>& allShapes)
 {
-  dbTransform xform;
-  Point origin = via->getOrigin();
-  xform.setOffset(origin);
+  dbTransform xform = via->getTransform();
   for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
     auto shape = uShape.get();
     if (shape->typeId() == frcRect) {

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -283,7 +283,6 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
   if (currNet == nullptr) {
     currNet = getNet(obj);
   }
-  dbTransform xform;
   frLayerNum layerNum;
   if (obj->typeId() == drcPathSeg) {
     auto pathSeg = static_cast<drPathSeg*>(obj);
@@ -299,7 +298,7 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
   } else if (obj->typeId() == drcVia) {
     auto via = static_cast<drVia*>(obj);
     layerNum = via->getViaDef()->getLayer1Num();
-    xform = via->getTransform();
+    dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
       Rect box = fig->getBBox();
       xform.apply(box);
@@ -343,7 +342,6 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
   if (currNet == nullptr) {
     currNet = getNet(obj);
   }
-  dbTransform xform;
   frLayerNum layerNum;
   if (obj->typeId() == frcPathSeg) {
     auto pathSeg = static_cast<frPathSeg*>(obj);
@@ -358,7 +356,7 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
   } else if (obj->typeId() == frcVia) {
     auto via = static_cast<frVia*>(obj);
     layerNum = via->getViaDef()->getLayer1Num();
-    xform = via->getTransform();
+    dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
       Rect box = fig->getBBox();
       xform.apply(box);

--- a/src/drt/src/gr/FlexGR_rq.cpp
+++ b/src/drt/src/gr/FlexGR_rq.cpp
@@ -44,9 +44,7 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
     shapes_.at(obj->getLayerNum()).insert(std::make_pair(boostr, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -95,9 +93,7 @@ void FlexGRWorkerRegionQuery::add(
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -144,9 +140,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
     shapes_.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform;
-    Point origin = via->getOrigin();
-    xform.setOffset(origin);
+    dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1175,10 +1175,8 @@ odb::Rect io::Parser::getViaBoxForTermAboveMaxLayer(odb::dbBTerm* term,
                       ->getLayerNum();
             if (layerNum == router_cfg_->TOP_ROUTING_LAYER) {
               odb::Rect viaBox = vbox->getBox();
-              odb::dbTransform xform;
               odb::Point path_origin = pshape.point;
-              xform.setOffset({path_origin.x(), path_origin.y()});
-              xform.setOrient(odb::dbOrientType(odb::dbOrientType::R0));
+              odb::dbTransform xform(path_origin);
               xform.apply(viaBox);
               if (bbox.intersects(viaBox)) {
                 bbox = viaBox;

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -852,12 +852,11 @@ void io::Parser::checkPins()
     foundTracks = false;
     foundCenterTracks = false;
     hasPolys = false;
-    dbTransform xform;
     for (auto& pin : bTerm->getPins()) {
       for (auto& uFig : pin->getFigs()) {
         checkFig(uFig.get(),
                  bTerm->getName(),
-                 xform,
+                 dbTransform(),
                  foundTracks,
                  foundCenterTracks,
                  hasPolys);

--- a/src/drt/src/ta/FlexTA_assign.cpp
+++ b/src/drt/src/ta/FlexTA_assign.cpp
@@ -89,13 +89,12 @@ void FlexTAWorker::modMinSpacingCostPlanar(
               idx2);
 
   Rect box2(-halfwidth2, -halfwidth2, halfwidth2, halfwidth2);
-  dbTransform xform;
   frCoord dx, dy;
   auto& trackLocs = getTrackLocs(lNum);
   auto& workerRegionQuery = getWorkerRegionQuery();
   for (int i = idx1; i <= idx2; i++) {
     auto trackLoc = trackLocs[i];
-    xform.setOffset(Point(boxLeft, trackLoc));
+    dbTransform xform(Point(boxLeft, trackLoc));
     xform.apply(box2);
     box2boxDistSquare(box1, box2, dx, dy);
     if (dy >= bloatDist) {
@@ -562,9 +561,8 @@ void FlexTAWorker::modCost(taPinFig* fig,
     modMinSpacingCostVia(box, layerNum, obj, isAddCost, true, false, pinS);
     modMinSpacingCostVia(box, layerNum, obj, isAddCost, false, false, pinS);
 
-    dbTransform xform;
     Point pt = obj->getOrigin();
-    xform.setOffset(pt);
+    dbTransform xform(pt);
     for (auto& uFig : obj->getViaDef()->getCutFigs()) {
       auto rect = static_cast<frRect*>(uFig.get());
       box = rect->getBBox();

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -194,7 +194,7 @@ frInst* Fixture::makeInst(const char* name,
   auto ptr_db_inst = std::make_unique<odb::dbInst>();
   odb::dbInst* db_inst
       = ptr_db_inst->create(db_->getChip()->getBlock(), db_master, "dummy");
-  dbTransform trans = dbTransform();
+  dbTransform trans;
   db_inst->setTransform(trans);
   auto uInst = std::make_unique<frInst>(name, master, db_inst);
   auto tmpInst = uInst.get();


### PR DESCRIPTION
This PR is auxiliary to #6326, regarding issue #5712.

The aforementioned PR is failing a regression test, I'm hunting the reason for this failing. This is probability due to setting some Transform "by hand" instead of taking it from another object, as is a problem on the whole drt codebase that is being fixed. I organized some of the Transform on drt to help find this bug and figured this was getting big enough to be a separate PR since it is just minor refactoring. Mainly, This PR avoids the direct creation of `dbTransform` on drt and opts to get from already set objects when available.