### PR TITLE
bumped up coverage timeout to 3h

### DIFF
--- a/jenkins/Jenkinsfile.coverage
+++ b/jenkins/Jenkinsfile.coverage
@@ -21,7 +21,7 @@ node {
 
         stage('Dynamic Code Coverage') {
             catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
-                timeout(time: 2, unit: 'HOURS') {
+                timeout(time: 3, unit: 'HOURS') {
                     sh './etc/CodeCoverage.sh dynamic';
                 }
             }


### PR DESCRIPTION
Increased timeout to 3h to see if the Dynamic Code Coverage stage completes successfully.