### PR TITLE
ord: remove charts from options as this is not optional anymore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,6 @@ add_subdirectory(test)
 target_compile_definitions(openroad PRIVATE GPU)
 target_compile_definitions(openroad PRIVATE BUILD_PYTHON)
 target_compile_definitions(openroad PRIVATE BUILD_GUI)
-target_compile_definitions(openroad PRIVATE ENABLE_CHARTS)
 
 ####################################################################
 

--- a/include/ord/OpenRoad.hh
+++ b/include/ord/OpenRoad.hh
@@ -260,7 +260,6 @@ class OpenRoad
   static bool getGPUCompileOption();
   static bool getPythonCompileOption();
   static bool getGUICompileOption();
-  static bool getChartsCompileOption();
 
  protected:
   ~OpenRoad();

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -575,8 +575,7 @@ static void showSplash()
                  ord::OpenRoad::getGitDescribe());
   logger->report(
       "Features included (+) or not (-): "
-      "{}Charts {}GPU {}GUI {}Python{}",
-      ord::OpenRoad::getChartsCompileOption() ? "+" : "-",
+      "{}GPU {}GUI {}Python{}",
       ord::OpenRoad::getGPUCompileOption() ? "+" : "-",
       ord::OpenRoad::getGUICompileOption() ? "+" : "-",
       ord::OpenRoad::getPythonCompileOption() ? "+" : "-",

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -700,9 +700,4 @@ bool OpenRoad::getGUICompileOption()
   return BUILD_GUI;
 }
 
-bool OpenRoad::getChartsCompileOption()
-{
-  return ENABLE_CHARTS;
-}
-
 }  // namespace ord

--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -323,12 +323,6 @@ openroad_gui_compiled()
   return ord::OpenRoad::getGUICompileOption();
 }
 
-const bool
-openroad_charts_compiled()
-{
-  return ord::OpenRoad::getChartsCompileOption();
-}
-
 void
 read_lef_cmd(const char *filename,
 	     const char *lib_name,


### PR DESCRIPTION
Now that charts is not optional for compile it doesn't need to be in the options list