### PR TITLE
mpl2: throw error when PAR gives MPL2 a completely unbalanced solution

### DIFF
--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -194,6 +194,8 @@ class ClusteringEngine
   void createCluster(Cluster* parent);
   void updateSubTree(Cluster* parent);
   void breakLargeFlatCluster(Cluster* parent);
+  bool partitionerSolutionIsFullyUnbalanced(const std::vector<int>& solution,
+                                            int num_other_cluster_vertices);
   void mergeChildrenBelowThresholds(std::vector<Cluster*>& small_children);
   bool attemptMerge(Cluster* receiver, Cluster* incomer);
   void fetchMixedLeaves(Cluster* parent,


### PR DESCRIPTION
To avoid the infinite recursion in #6083. This doesn't solve the problem there. I'll open a subsequent PR with the proper fix.