### PR TITLE
cts: Fix messages check.

### DIFF
--- a/src/cts/src/CMakeLists.txt
+++ b/src/cts/src/CMakeLists.txt
@@ -102,6 +102,7 @@ target_link_libraries(cts
 messages(
   TARGET cts
   OUTPUT_DIR ..
+  DEPENDS cts_lib
 )
 
 if (Python3_FOUND AND BUILD_PYTHON)

--- a/src/odb/CMakeLists.txt
+++ b/src/odb/CMakeLists.txt
@@ -84,10 +84,8 @@ if(ENABLE_TESTS)
   )
 endif()
 
-add_custom_command(
-  OUTPUT messages_checked
-  COMMAND ${CMAKE_SOURCE_DIR}/etc/find_messages.py > messages.txt && touch ${CMAKE_CURRENT_BINARY_DIR}/messages_checked
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+messages(
+  TARGET odb
   DEPENDS
     db
     cdl
@@ -99,7 +97,3 @@ add_custom_command(
     gdsin
     gdsout
 )
-
-add_custom_target(odb_messages DEPENDS messages_checked)
-
-add_dependencies(odb odb_messages)


### PR DESCRIPTION
For https://github.com/The-OpenROAD-Project/OpenROAD/issues/6406.

This is similar to what is done for odb but in a generic way that can be reused.
The new messages_multi cmake function can probably be merged in the messages one.
