### PR TITLE
With swig 4.2.1, Tcl_Size is needed; provide necessary define.

### DIFF
--- a/src/gui/src/tclCmdInputWidget.h
+++ b/src/gui/src/tclCmdInputWidget.h
@@ -47,6 +47,10 @@
 
 #include "cmdInputWidget.h"
 #include "tclCmdHighlighter.h"
+
+#if (TCL_MAJOR_VERSION == 8) && (TCL_MINOR_VERSION < 7) && !defined(Tcl_Size)
+#define Tcl_Size int
+#endif
 #include "tclSwig.h"  // generated header
 
 namespace gui {


### PR DESCRIPTION
The Tcl_Size define is used in tclSwig.h, but at least with swig version 4.2.1 and tcl 8.6.15, this results in this symbol being undefined and subsequently in a compile error. Work around by including the header providing it (which is happening _before_ tclSwig.h is included).