### PR TITLE
Enable misc-include-cleaner in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,7 +52,6 @@ Checks: >
   -modernize-use-transparent-functors,
   misc-*,
   -misc-const-correctness,
-  -misc-include-cleaner,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-redundant-expression,


### PR DESCRIPTION
This will help finding missing and superfluous includes. Right now, over the project, there are a lot of findings, so let's see if this will be good or annoying until most of it is fixed.