### PR TITLE
Switch off performance-enum-size clang-tidy check for now.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,7 @@ Checks: >
   -google-runtime-references,
   -google-explicit-constructor,
   performance-*,
+  -performance-enum-size,
   bugprone-*,
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,


### PR DESCRIPTION
It warns on every enum if it is smaller than fitting into a uint32_t to use a smaller type. While it might be an interesting exercise at some point to look at these, right now, this is a somewhat noisy check.