### PR TITLE
pdn: clang-tidy unused namespace

### DIFF
--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -50,7 +50,6 @@ class Logger;
 
 namespace pdn {
 
-namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 class Shape;

--- a/src/pdn/src/via.h
+++ b/src/pdn/src/via.h
@@ -51,7 +51,6 @@ class Logger;
 
 namespace pdn {
 
-namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
 
 class Connect;


### PR DESCRIPTION
No functional changes.
Just an attempt to run the parallel clang-tidy thing.