### PR TITLE
dbsta: remove stray or_integration_test from ctest

### DIFF
--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -47,10 +47,6 @@ or_integration_tests(
     write_verilog8
 )
 
-
-foreach(TEST_NAME IN LISTS TEST_NAMES)
-    or_integration_test("dbSta" ${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/regression)
-endforeach()
 if(ENABLE_TESTS)
   add_subdirectory(cpp)
 endif()


### PR DESCRIPTION
This does not do anything, since the code above handles the integration tests