### PR TITLE
dbSta: Add create_cell_usage_snapshot command

### DIFF
--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -35,7 +35,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
 
 #include "odb/db.h"
 #include "odb/dbBlockCallBackObj.h"
@@ -190,6 +194,30 @@ class dbSta : public Sta, public ord::OpenRoadObserver
   std::string getInstanceTypeText(InstType type);
   InstType getInstanceType(odb::dbInst* inst);
   void report_cell_usage(odb::dbModule* module, bool verbose);
+
+  // Creates a cell usage snapshot for the given module at the given stage.
+  // The snapshot is written to the given path as a JSON file.
+  void CreateCellUsageSnapshot(
+      odb::dbModule* module, std::string_view path, std::string_view stage);
+
+  // Holds the usage information of a specific cell.
+  struct CellUsageInfo {
+    // Name of the cell.
+    std::string name;
+
+    // Number of instances of the cell.
+    int count = 0;
+
+    // Area of the cell in microns^2. Total area of the cell instances can be
+    // calculated by multiplying the count by this value.
+    double area = 0.0;
+  };
+
+  // Holds a snapshot of cell usage information at a given stage.
+  struct CellUsageSnapshot {
+    std::string stage;
+    std::vector<CellUsageInfo> cells_usage_info;
+  };
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -173,6 +173,16 @@ report_cell_usage_cmd(odb::dbModule* mod, const bool verbose)
   sta->report_cell_usage(mod, verbose);
 }
 
+
+void
+create_cell_usage_snapshot_cmd(
+    odb::dbModule* module, const char* path, const char* stage) {
+  cmdLinkedNetwork();
+  ord::OpenRoad *openroad = ord::getOpenRoad();
+  sta::dbSta *sta = openroad->getSta();
+  sta->CreateCellUsageSnapshot(module, std::string(path), std::string(stage));
+}
+
 // Copied from sta/verilog/Verilog.i because we don't want sta::read_verilog
 // that is in the same file.
 void

--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -103,6 +103,36 @@ proc report_cell_usage { args } {
   report_cell_usage_cmd $module [info exists flags(-verbose)]
 }
 
+
+define_cmd_args "create_cell_usage_snapshot" { \
+                                               [-path path]\
+                                               [-stage stage]
+                                             }
+
+proc create_cell_usage_snapshot { args } {
+  parse_key_args "create_cell_usage_snapshot" args keys {-path -stage} \
+    flags {}
+
+  if { [ord::get_db_block] == "NULL" } {
+    sta_error 1001 "No design block found."
+  }
+  set module_name [[ord::get_db_block] getTopModule]
+
+  if { [info exists keys(-path)] } {
+    set path_name $keys(-path)
+  } else {
+    sta_error 1002 "Missing argument -path"
+  }
+
+  if { [info exists keys(-stage)] } {
+    set stage_name $keys(-stage)
+  } else {
+    sta_error 1003 "Missing argument -stage"
+  }
+
+  create_cell_usage_snapshot_cmd $module_name $path_name $stage_name
+}
+
 # redefine sta::sta_warn/error to call utl::warn/error
 proc sta_error { id msg } {
   utl::error STA $id $msg

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -3,6 +3,7 @@ or_integration_tests(
   TESTS
     block_sta1
     constant1
+    create_cell_usage_snapshot
     find_clks1
     find_clks2
     hier2

--- a/src/dbSta/test/cell_usage_snapshot-top-test_stage.jsonok
+++ b/src/dbSta/test/cell_usage_snapshot-top-test_stage.jsonok
@@ -1,0 +1,1 @@
+{"stage":"test_stage","cell_usage_info":[{"name":"snl_bufx1","count":4,"area":1E3},{"name":"snl_ffqx1","count":2,"area":1E3}]}

--- a/src/dbSta/test/create_cell_usage_snapshot.tcl
+++ b/src/dbSta/test/create_cell_usage_snapshot.tcl
@@ -1,0 +1,17 @@
+# Test for creating a cell usage snapshot.
+
+# Test environment setup.
+set snapshot_file_name cell_usage_snapshot-top-test_stage.json
+source "helpers.tcl"
+make_result_dir
+
+# Populate DB with the test design.
+read_lef liberty1.lef
+read_liberty liberty1.lib
+read_verilog hier1.v
+link_design top
+
+# Create the cell usage snapshot and compare it to the golden file.
+create_cell_usage_snapshot -path $result_dir -stage test_stage
+diff_files cell_usage_snapshot-top-test_stage.jsonok $result_dir/$snapshot_file_name
+

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -3,6 +3,13 @@
 set test_dir [file dirname [file normalize [info script]]]
 set result_dir [file join $test_dir "results"]
 
+proc make_result_dir {} {
+  variable result_dir
+  if { ![file exists $result_dir] } {
+    file mkdir $result_dir
+  }
+}
+
 proc make_result_file { filename } {
   variable result_dir
   if { ![file exists $result_dir] } {


### PR DESCRIPTION
Add create_cell_usage_snapshot command to create a cell usage snapshot in JSON format.

create_cell_usage_snapshot -path <path> -stage <stage_name> will create a JSON file named as cell_usage_snapshot-<module_name>-<stage_name>.json under <path>. The snapshot reflects (i) the name of the stage and (ii) cell usage statistics. Currently cell usage statistics consist of (a) cell name, (b) number of instance of the cell and (c) the cell area in um^2.

As compared to current implementation of report_cell_usage -v, this is more structured and more extensible and testable. We have planned work to support diff of such snapshots such that we can better evaluate the performance of each flow step / stage by capturing snapshots as often as needed.