### PR TITLE
[drt] Only spawn new threads when distributed_ is true

### DIFF
--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -220,7 +220,7 @@ class TritonRoute
   std::mutex results_mutex_;
   int results_sz_{0};
   unsigned int cloud_sz_{0};
-  boost::asio::thread_pool dist_pool_{1};
+  std::optional<boost::asio::thread_pool> dist_pool_;
 
   void initDesign();
   void gr();

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -76,6 +76,9 @@ TritonRoute::TritonRoute()
       router_cfg_(std::make_unique<RouterConfiguration>()),
       gui_(gui::Gui::get())
 {
+  if (distributed_) {
+    dist_pool_.emplace(1);
+  }
 }
 
 TritonRoute::~TritonRoute() = default;
@@ -109,6 +112,9 @@ void TritonRoute::setDebugTA(bool on)
 void TritonRoute::setDistributed(bool on)
 {
   distributed_ = on;
+  if (distributed_ && !dist_pool_.has_value()) {
+    dist_pool_.emplace(1);
+  }
 }
 
 void TritonRoute::setDebugWriteNetTracks(bool on)
@@ -957,7 +963,7 @@ int TritonRoute::main()
         dist_->sendJob(msg, dist_ip_.c_str(), dist_port_, result);
       });
     } else {
-      asio::post(dist_pool_, boost::bind(&TritonRoute::sendDesignDist, this));
+      asio::post(*dist_pool_, boost::bind(&TritonRoute::sendDesignDist, this));
     }
   }
   initDesign();
@@ -986,7 +992,7 @@ int TritonRoute::main()
       writer.updateDb(db_, router_cfg_.get(), true);
     }
     if (distributed_) {
-      asio::post(dist_pool_, [this]() {
+      asio::post(*dist_pool_, [this]() {
         dst::JobMessage msg(dst::JobMessage::GRDR_INIT,
                             dst::JobMessage::BROADCAST),
             result;
@@ -1009,7 +1015,7 @@ int TritonRoute::main()
   prep();
   ta();
   if (distributed_) {
-    asio::post(dist_pool_,
+    asio::post(*dist_pool_,
                boost::bind(&TritonRoute::sendDesignUpdates, this, ""));
   }
   dr();
@@ -1022,7 +1028,7 @@ int TritonRoute::main()
 void TritonRoute::pinAccess(const std::vector<odb::dbInst*>& target_insts)
 {
   if (distributed_) {
-    asio::post(dist_pool_, [this]() {
+    asio::post(*dist_pool_, [this]() {
       sendDesignDist();
       dst::JobMessage msg(dst::JobMessage::PIN_ACCESS,
                           dst::JobMessage::BROADCAST),
@@ -1042,7 +1048,7 @@ void TritonRoute::pinAccess(const std::vector<odb::dbInst*>& target_insts)
   pa.setDebug(debug_.get(), db_);
   if (distributed_) {
     pa.setDistributed(dist_ip_, dist_port_, shared_volume_, cloud_sz_);
-    dist_pool_.join();
+    dist_pool_->join();
   }
   pa.main();
   io::Writer writer(getDesign(), logger_);

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -737,7 +737,9 @@ void FlexDR::processWorkersBatchDistributed(
     int& version,
     IterationProgress& iter_prog)
 {
-  router_->dist_pool_.join();
+  if (router_->dist_pool_.has_value()) {
+    router_->dist_pool_->join();
+  }
   if (version++ == 0 && !design_->hasUpdates()) {
     std::string serializedViaData;
     serializeViaData(via_data_, serializedViaData);


### PR DESCRIPTION
Before this patch the constructor of boost::asio::thread_pool{1} created a thread, regardless of if distributed_ was true.

Now it is wrapped in an optional so that it is only created if or when distributed_ becomes true.

This means that OpenROAD can be initialized without spawning any new threads (a niche usecase for sure, but useful in certain environments).