### PR TITLE
gui: Reduce display controls sections min size so 3 last columns can be resize to their content.

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -281,6 +281,7 @@ DisplayControls::DisplayControls(QWidget* parent)
   view_->viewport()->installEventFilter(this);
 
   QHeaderView* header = view_->header();
+  header->setMinimumSectionSize(25);
   header->setSectionResizeMode(Name, QHeaderView::Stretch);
   header->setSectionResizeMode(Swatch, QHeaderView::ResizeToContents);
   header->setSectionResizeMode(Visible, QHeaderView::ResizeToContents);


### PR DESCRIPTION
The default min size is 60 while 3 last colums are between 26 and 28.

Before:
![before](https://github.com/user-attachments/assets/de8f4dd5-f931-4058-adaf-f7fea85b6bea)

After:
![after](https://github.com/user-attachments/assets/c305e16c-c89f-4992-85b1-1fee3b690ee9)
