### PR TITLE
grt: only snap pins that crosses multiple gcells

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -979,7 +979,8 @@ std::vector<odb::Point> GlobalRouter::findOnGridPositions(
     for (const odb::Rect& pin_box : pin_boxes) {
       odb::Point rect_middle = getRectMiddle(pin_box);
       const int box_length = std::max(pin_box.dx(), pin_box.dy());
-      if (pin.getEdge() != PinEdge::none && box_length >= grid_->getTileSize()) {
+      if (pin.getEdge() != PinEdge::none
+          && box_length >= grid_->getTileSize()) {
         pos_on_grid = grid_->getPositionOnGrid(
             pin.getPositionNearInstEdge(pin_box, rect_middle));
       } else {

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -978,11 +978,12 @@ std::vector<odb::Point> GlobalRouter::findOnGridPositions(
     const std::vector<odb::Rect>& pin_boxes = pin.getBoxes().at(conn_layer);
     for (const odb::Rect& pin_box : pin_boxes) {
       odb::Point rect_middle = getRectMiddle(pin_box);
-      if (pin.getEdge() == PinEdge::none) {
-        pos_on_grid = grid_->getPositionOnGrid(rect_middle);
-      } else {
+      const int box_length = std::max(pin_box.dx(), pin_box.dy());
+      if (pin.getEdge() != PinEdge::none && box_length >= grid_->getTileSize()) {
         pos_on_grid = grid_->getPositionOnGrid(
             pin.getPositionNearInstEdge(pin_box, rect_middle));
+      } else {
+        pos_on_grid = grid_->getPositionOnGrid(rect_middle);
       }
       positions_on_grid.push_back(pos_on_grid);
     }


### PR DESCRIPTION
Fix CI failures.

With this update, only long pins (i.e., pins that crosses more than 2 gcells) will have their positions snapped closer to the instance edge.