### PR TITLE
grt: use boost polygon90set in layerIsBlocked to speedup init

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3796,7 +3796,7 @@ bool GlobalRouter::layerIsBlocked(
     const std::unordered_map<int, std::vector<odb::Rect>>& macro_obs_per_layer,
     std::vector<odb::Rect>& extended_obs)
 {
-  using namespace boost::polygon::operators;
+  using boost::polygon::operators::operator&;
   using Polygon90Set = boost::polygon::polygon_90_set_data<int>;
 
   // if layer is max or min, then all obs the nearest layer are added


### PR DESCRIPTION
Changes:
- removes the nested loops and replaces it with a "&" operation on two Boost Polygon90set.

On zerosoc sky130:
Previous implementation: `layerIsBlocked` takes 187.15s
New implementation: `layerIsBlocked` takes 0.28s
Speedup of 99.8%
