### PR TITLE
odb: remove link with aps only for instances that have aps

### DIFF
--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -1584,8 +1584,8 @@ void dbInst::destroy(dbInst* inst_)
           _dbAccessPoint* _ap = (_dbAccessPoint*) ap;
           _ap->iterms_.erase(
               std::remove_if(_ap->iterms_.begin(),
-                            _ap->iterms_.end(),
-                            [id](const auto& id_in) { return id_in == id; }),
+                             _ap->iterms_.end(),
+                             [id](const auto& id_in) { return id_in == id; }),
               _ap->iterms_.end());
         }
       }

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -127,7 +127,7 @@ _dbInst::_dbInst(_dbDatabase*)
   _x = 0;
   _y = 0;
   _weight = 0;
-  pin_access_idx_ = 0;
+  pin_access_idx_ = -1;
 }
 
 _dbInst::_dbInst(_dbDatabase*, const _dbInst& i)
@@ -1578,14 +1578,16 @@ void dbInst::destroy(dbInst* inst_)
     _dbITerm* _iterm = block->_iterm_tbl->getPtr(id);
     dbITerm* iterm = (dbITerm*) _iterm;
     iterm->disconnect();
-    for (auto [pin, aps] : iterm->getAccessPoints()) {
-      for (auto ap : aps) {
-        _dbAccessPoint* _ap = (_dbAccessPoint*) ap;
-        _ap->iterms_.erase(
-            std::remove_if(_ap->iterms_.begin(),
-                           _ap->iterms_.end(),
-                           [id](const auto& id_in) { return id_in == id; }),
-            _ap->iterms_.end());
+    if (inst_->getPinAccessIdx() >= 0) {
+      for (auto [pin, aps] : iterm->getAccessPoints()) {
+        for (auto ap : aps) {
+          _dbAccessPoint* _ap = (_dbAccessPoint*) ap;
+          _ap->iterms_.erase(
+              std::remove_if(_ap->iterms_.begin(),
+                            _ap->iterms_.end(),
+                            [id](const auto& id_in) { return id_in == id; }),
+              _ap->iterms_.end());
+        }
       }
     }
 


### PR DESCRIPTION
When running pin_access before global routing in ORFS, access points are created for the existing instances. When it reaches the incremental repair stage, new instances that were inserted by resizer can be deleted. However, these instances don't have access points, and when destroying them, OR was crashing when calling `iterm->getAccessPoints()`.

This update changes the default value for `pin_access_idx_` to -1, and use it to check if the instance have access points before removing the link between their iterms and the access points.