### PR TITLE
mpl: convert pin access blockages to placement blockages

### DIFF
--- a/src/mpl2/src/Mpl2Observer.h
+++ b/src/mpl2/src/Mpl2Observer.h
@@ -74,10 +74,6 @@ class Mpl2Observer
   virtual void setMacroBlockages(const std::vector<mpl2::Rect>& macro_blockages)
   {
   }
-  virtual void setPlacementBlockages(
-      const std::vector<mpl2::Rect>& placement_blockages)
-  {
-  }
   virtual void setBundledNets(const std::vector<BundledNet>& bundled_nets) {}
   virtual void setShowBundledNets(bool show_bundled_nets) {}
   virtual void setShowClustersIds(bool show_clusters_ids) {}

--- a/src/mpl2/src/SACoreSoftMacro.cpp
+++ b/src/mpl2/src/SACoreSoftMacro.cpp
@@ -448,7 +448,7 @@ void SACoreSoftMacro::calBoundaryPenalty()
 void SACoreSoftMacro::calMacroBlockagePenalty()
 {
   macro_blockage_penalty_ = 0.0;
-  if (blockages_.empty() || macro_blockage_weight_ <= 0.0) {
+  if (macro_blockages_.empty() || macro_blockage_weight_ <= 0.0) {
     return;
   }
 
@@ -460,7 +460,7 @@ void SACoreSoftMacro::calMacroBlockagePenalty()
     return;
   }
 
-  for (auto& blockage : blockages_) {
+  for (auto& blockage : macro_blockages_) {
     for (const auto& macro_id : pos_seq_) {
       if (macros_[macro_id].getNumMacro() > 0) {
         const float soft_macro_x_min = macros_[macro_id].getX();
@@ -654,8 +654,8 @@ void SACoreSoftMacro::calNotchPenalty()
         if (grids[j][i] != -1) {
           flag = false;  // we cannot extend the current cluster
           break;
-        }           // end if
-      }             // end y
+        }  // end if
+      }  // end y
       if (!flag) {  // extension done
         break;
       }
@@ -671,8 +671,8 @@ void SACoreSoftMacro::calNotchPenalty()
         if (grids[j][i] != -1) {
           flag = false;  // we cannot extend the current cluster
           break;
-        }           // end if
-      }             // end y
+        }  // end if
+      }  // end y
       if (!flag) {  // extension done
         break;
       }
@@ -688,8 +688,8 @@ void SACoreSoftMacro::calNotchPenalty()
         if (grids[j][i] != -1) {
           flag = false;  // we cannot extend the current cluster
           break;
-        }           // end if
-      }             // end y
+        }  // end if
+      }  // end y
       if (!flag) {  // extension done
         break;
       }
@@ -705,8 +705,8 @@ void SACoreSoftMacro::calNotchPenalty()
         if (grids[j][i] != -1) {
           flag = false;  // we cannot extend the current cluster
           break;
-        }           // end if
-      }             // end y
+        }  // end if
+      }  // end y
       if (!flag) {  // extension done
         break;
       }
@@ -1019,8 +1019,8 @@ void SACoreSoftMacro::fillDeadSpace()
           if (grids[j][i] != -1) {
             flag = false;  // we cannot extend the current cluster
             break;
-          }           // end if
-        }             // end y
+          }  // end if
+        }  // end y
         if (!flag) {  // extension done
           break;
         }
@@ -1037,8 +1037,8 @@ void SACoreSoftMacro::fillDeadSpace()
           if (grids[j][i] != -1) {
             flag = false;  // we cannot extend the current cluster
             break;
-          }           // end if
-        }             // end y
+          }  // end if
+        }  // end y
         if (!flag) {  // extension done
           break;
         }
@@ -1055,8 +1055,8 @@ void SACoreSoftMacro::fillDeadSpace()
           if (grids[j][i] != -1) {
             flag = false;  // we cannot extend the current cluster
             break;
-          }           // end if
-        }             // end y
+          }  // end if
+        }  // end y
         if (!flag) {  // extension done
           break;
         }
@@ -1073,8 +1073,8 @@ void SACoreSoftMacro::fillDeadSpace()
           if (grids[j][i] != -1) {
             flag = false;  // we cannot extend the current cluster
             break;
-          }           // end if
-        }             // end y
+          }  // end if
+        }  // end y
         if (!flag) {  // extension done
           break;
         }
@@ -1116,9 +1116,11 @@ void SACoreSoftMacro::calSegmentLoc(float seg_start,
 }
 
 // The blockages here are only those that overlap with the annealing outline.
-void SACoreSoftMacro::addBlockages(const std::vector<Rect>& blockages)
+void SACoreSoftMacro::setMacroBlockages(
+    const std::vector<Rect>& macro_blockages)
 {
-  blockages_.insert(blockages_.end(), blockages.begin(), blockages.end());
+  macro_blockages_.insert(
+      macro_blockages_.end(), macro_blockages.begin(), macro_blockages.end());
 }
 
 void SACoreSoftMacro::attemptCentralization(const float pre_cost)

--- a/src/mpl2/src/SACoreSoftMacro.h
+++ b/src/mpl2/src/SACoreSoftMacro.h
@@ -97,7 +97,7 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   // adjust the size of MixedCluster to fill the empty space
   void fillDeadSpace() override;
   void alignMacroClusters();
-  void addBlockages(const std::vector<Rect>& blockages);
+  void setMacroBlockages(const std::vector<Rect>& macro_blockages);
 
   bool centralizationWasReverted() { return centralization_was_reverted_; }
   void setCentralizationAttemptOn(bool centralization_on)
@@ -134,7 +134,7 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   void attemptCentralization(float pre_cost);
   void moveFloorplan(const std::pair<float, float>& offset);
 
-  std::vector<Rect> blockages_;
+  std::vector<Rect> macro_blockages_;
 
   Cluster* root_;
 

--- a/src/mpl2/src/graphics.cpp
+++ b/src/mpl2/src/graphics.cpp
@@ -332,15 +332,6 @@ void Graphics::drawAllBlockages(gui::Painter& painter)
       drawOffsetRect(blockage, "", painter);
     }
   }
-
-  if (!placement_blockages_.empty()) {
-    painter.setPen(gui::Painter::green, true);
-    painter.setBrush(gui::Painter::green, gui::Painter::DIAGONAL);
-
-    for (const auto& blockage : placement_blockages_) {
-      drawOffsetRect(blockage, "", painter);
-    }
-  }
 }
 
 void Graphics::drawFences(gui::Painter& painter)
@@ -569,13 +560,22 @@ void Graphics::drawBundledNets(gui::Painter& painter,
 void Graphics::setSoftMacroBrush(gui::Painter& painter,
                                  const SoftMacro& soft_macro)
 {
-  if (soft_macro.getCluster() == nullptr) {  // fixed terminals
+  if (soft_macro.isBlockage()) {
+    painter.setBrush(gui::Painter::dark_red);
     return;
   }
 
-  if (soft_macro.getCluster()->getClusterType() == StdCellCluster) {
+  const Cluster* cluster = soft_macro.getCluster();
+
+  if (!cluster) {  // fixed terminal
+    return;
+  }
+
+  const mpl2::ClusterType cluster_type = cluster->getClusterType();
+
+  if (cluster_type == StdCellCluster) {
     painter.setBrush(gui::Painter::dark_blue);
-  } else if (soft_macro.getCluster()->getClusterType() == HardMacroCluster) {
+  } else if (cluster_type == HardMacroCluster) {
     // dark red
     painter.setBrush(gui::Painter::Color(0x80, 0x00, 0x00, 150));
   } else {
@@ -587,12 +587,6 @@ void Graphics::setSoftMacroBrush(gui::Painter& painter,
 void Graphics::setMacroBlockages(const std::vector<mpl2::Rect>& macro_blockages)
 {
   macro_blockages_ = macro_blockages;
-}
-
-void Graphics::setPlacementBlockages(
-    const std::vector<mpl2::Rect>& placement_blockages)
-{
-  placement_blockages_ = placement_blockages;
 }
 
 void Graphics::setShowBundledNets(bool show_bundled_nets)
@@ -664,7 +658,6 @@ void Graphics::eraseDrawing()
   soft_macros_.clear();
   hard_macros_.clear();
   macro_blockages_.clear();
-  placement_blockages_.clear();
   bundled_nets_.clear();
   outline_.reset(0, 0, 0, 0);
   outlines_.clear();

--- a/src/mpl2/src/graphics.h
+++ b/src/mpl2/src/graphics.h
@@ -77,8 +77,6 @@ class Graphics : public gui::Renderer, public Mpl2Observer
 
   void setMacroBlockages(
       const std::vector<mpl2::Rect>& macro_blockages) override;
-  void setPlacementBlockages(
-      const std::vector<mpl2::Rect>& placement_blockages) override;
   void setBundledNets(const std::vector<BundledNet>& bundled_nets) override;
   void setShowBundledNets(bool show_bundled_nets) override;
   void setShowClustersIds(bool show_clusters_ids) override;
@@ -119,7 +117,6 @@ class Graphics : public gui::Renderer, public Mpl2Observer
   std::vector<SoftMacro> soft_macros_;
   std::vector<HardMacro> hard_macros_;
   std::vector<mpl2::Rect> macro_blockages_;
-  std::vector<mpl2::Rect> placement_blockages_;
   std::vector<BundledNet> bundled_nets_;
   odb::Rect outline_;
   int target_cluster_id_{-1};

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -204,6 +204,11 @@ class HierRTLMP
   void computeBlockageOverlap(std::vector<Rect>& overlapping_blockages,
                               const Rect& blockage,
                               const Rect& outline);
+  void convertPlacementBlockagesToMacroClusters(
+      const std::vector<Rect>& placement_blockages,
+      std::map<std::string, int>& soft_macro_id_map,
+      std::vector<SoftMacro>& macros,
+      std::map<int, Rect>& fences);
   void updateChildrenShapesAndLocations(
       Cluster* parent,
       const std::vector<SoftMacro>& shaped_macros,

--- a/src/mpl2/src/mpl.tcl
+++ b/src/mpl2/src/mpl.tcl
@@ -109,7 +109,7 @@ proc rtl_macro_placer { args } {
   set outline_weight 100.0
   set wirelength_weight 100.0
   set guidance_weight 10.0
-  set fence_weight 10.0
+  set fence_weight 1000.0
   set boundary_weight 50.0
   set notch_weight 10.0
   set macro_blockage_weight 10.0

--- a/src/mpl2/src/object.cpp
+++ b/src/mpl2/src/object.cpp
@@ -996,6 +996,7 @@ SoftMacro::SoftMacro(float width, float height, const std::string& name)
   height_ = height;
   area_ = width * height;
   cluster_ = nullptr;
+  is_blockage_ = true;
 }
 
 // Create a SoftMacro representing the IO cluster or fixed terminals

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -446,37 +446,23 @@ class HardMacro
   odb::dbBlock* block_ = nullptr;
 };
 
-// We have three types of SoftMacros
-// Type 1:  a SoftMacro corresponding to a Cluster (MixedCluster,
-// StdCellCluster, HardMacroCluster)
-// Type 2:  a SoftMacro corresponding to a IO cluster
-// Type 3:  a SoftMacro corresponding to a all kinds of blockages
-// Here (x, y) is the lower left corner of the soft macro
-// For all the soft macros, we model the bundled pin at the center
-// of the soft macro. So we do not need private variables for pin positions
-// SoftMacro is a physical abstraction for Cluster.
-// Note that constrast to classical soft macro definition,
-// we allow the soft macro to change its area.
-// For the SoftMacro corresponding to different types of clusters,
-// we allow different shape constraints:
-// For SoftMacro corresponding to MixedCluster and StdCellCluster,
-// the macro must have fixed area
-// For SoftMacro corresponding to HardMacroCluster,
-// the macro can have different sizes. In this case, the width_list and
-// height_list is not sorted. Generally speaking we can have following types of
-// SoftMacro (1) SoftMacro : MixedCluster (2) SoftMacro : StdCellCluster (3)
-// SoftMacro : HardMacroCluster (4) SoftMacro : Fixed Hard Macro (or blockage)
-// (5) SoftMacro : Hard Macro (or pin access blockage)
-// (6) SoftMacro : Fixed Terminals
-
+// This is the object used as the physical abstraction for the Clusters.
+// A SoftMacro can represent:
+//  - a regular Cluster (Mixed, StdCell or Macro);
+//  - an IO Cluster - which has its position fixed;
+//  - a placement blockage.
+//
+// Some Observations:
+//  - The bundled pin of a SoftMacro is always its center.
+//  - SoftMacros that represent StdCell clusters change their area
+//    based on target utilization.
 class SoftMacro
 {
  public:
-  // Create a SoftMacro with specified size
-  // Create a SoftMacro representing the blockage
+  // Create a SoftMacro representing a placement blockage
   SoftMacro(float width, float height, const std::string& name);
 
-  // Create a SoftMacro representing the IO cluster
+  // Create a SoftMacro representing an IO cluster
   SoftMacro(const std::pair<float, float>& pos,
             const std::string& name,
             float width = 0.0,
@@ -536,6 +522,7 @@ class SoftMacro
   Cluster* getCluster() const;
   // calculate macro utilization
   float getMacroUtil() const;
+  bool isBlockage() const { return is_blockage_; }
 
  private:
   // utility function
@@ -558,6 +545,7 @@ class SoftMacro
   // Interfaces with hard macro
   Cluster* cluster_ = nullptr;
   bool fixed_ = false;  // if the macro is fixed
+  bool is_blockage_{false};
 
   // Alignment support
   // if the cluster has been aligned related to other macro_cluster or


### PR DESCRIPTION
Based on #6371.

Ideas here:
1. Make mpl2 placement blockages and macro blockages be treated differently. Macro blockages will keep being treated as regions that should not be occupied by clusters with macros - penalty based on overlap area. Placement blockages, on the other hand, will be treated as macro clusters constrained to fences - the idea of this representation is to allow the generation of more intelligent results by the annealer: If we use the former approach, the only way to reduce  overlap penalty is to fill the macro blockage area with either std cell clusters or leave it empty (the latter is very challenging because of the sequence pair representation), so treating the placement blockages as macro clusters works as if we could leave the area of that blockage empty using the macro blockage approach.
2. Model pin access as placement blockages instead of macro blockages.

Collateral:
1. Increase fence penalty so that if effectively places the blockages where they belong.

If we prove this approach to be more beneficial in terms of QoR and these changes are incorporated, I wonder what would be the usage of the macro blockages and if we couldn't use this same strategy to handle pre-placed macros.
