### PR TITLE
psm: allow reuse of previous solution

### DIFF
--- a/src/psm/README.md
+++ b/src/psm/README.md
@@ -34,6 +34,7 @@ analyze_power_grid
     [-em_outfile em_file]
     [-vsrc voltage_source_file]
     [-source_type FULL|BUMPS|STRAPS]
+    [-allow_reuse]
 ```
 
 #### Options
@@ -48,6 +49,7 @@ analyze_power_grid
 | `-em_outfile` | Write the per-segment current values into a file. This option is only available if used in combination with `-enable_em`. |
 | `-voltage_file` | Write per-instance voltage into the file. |
 | `-source_type` | Indicate the type of voltage source grid to [model](#source-grid-options). FULL uses all the nodes on the top layer as voltage sources, BUMPS will model a bump grid array, and STRAPS will model power straps on the layer above the top layer. |
+| `-allow_reuse` | Allow the analysis to reuse a previous solution, if one exists. |
 
 ### Check Power Grid
 

--- a/src/psm/include/psm/pdnsim.h
+++ b/src/psm/include/psm/pdnsim.h
@@ -105,6 +105,7 @@ class PDNSim : public odb::dbBlockCallBackObj
                         sta::Corner* corner,
                         GeneratedSourceType source_type,
                         const std::string& voltage_file,
+                        bool use_prev_solution,
                         bool enable_em,
                         const std::string& em_file,
                         const std::string& error_file,

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -105,6 +105,7 @@ void PDNSim::analyzePowerGrid(odb::dbNet* net,
                               sta::Corner* corner,
                               GeneratedSourceType source_type,
                               const std::string& voltage_file,
+                              bool use_prev_solution,
                               bool enable_em,
                               const std::string& em_file,
                               const std::string& error_file,
@@ -116,7 +117,9 @@ void PDNSim::analyzePowerGrid(odb::dbNet* net,
 
   last_corner_ = corner;
   auto* solver = getIRSolver(net, false);
-  solver->solve(corner, source_type, voltage_source_file);
+  if (!use_prev_solution || !solver->hasSolution(corner)) {
+    solver->solve(corner, source_type, voltage_source_file);
+  }
   solver->report(corner);
 
   heatmap_->setNet(net);

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -119,6 +119,8 @@ void PDNSim::analyzePowerGrid(odb::dbNet* net,
   auto* solver = getIRSolver(net, false);
   if (!use_prev_solution || !solver->hasSolution(corner)) {
     solver->solve(corner, source_type, voltage_source_file);
+  } else {
+    logger_->info(utl::PSM, 11, "Reusing previous solution");
   }
   solver->report(corner);
 

--- a/src/psm/src/pdnsim.i
+++ b/src/psm/src/pdnsim.i
@@ -78,10 +78,10 @@ set_net_voltage_cmd(odb::dbNet* net, Corner* corner, double voltage)
 }
 
 void 
-analyze_power_grid_cmd(odb::dbNet* net, Corner* corner, psm::GeneratedSourceType type, const char* error_file, bool enable_em, const char* em_file, const char* voltage_file, const char* voltage_source_file)
+analyze_power_grid_cmd(odb::dbNet* net, Corner* corner, psm::GeneratedSourceType type, const char* error_file, bool reuse_solution, bool enable_em, const char* em_file, const char* voltage_file, const char* voltage_source_file)
 {
   PDNSim* pdnsim = getPDNSim();
-  pdnsim->analyzePowerGrid(net, corner, type, voltage_file, enable_em, em_file, error_file, voltage_source_file);
+  pdnsim->analyzePowerGrid(net, corner, type, voltage_file, reuse_solution, enable_em, em_file, error_file, voltage_source_file);
 }
 
 void

--- a/src/psm/src/pdnsim.tcl
+++ b/src/psm/src/pdnsim.tcl
@@ -66,13 +66,14 @@ sta::define_cmd_args "analyze_power_grid" {
   [-em_outfile em_file]
   [-vsrc voltage_source_file]
   [-source_type FULL|BUMPS|STRAPS]
+  [-allow_reuse]
 }
 
 proc analyze_power_grid { args } {
   sta::parse_key_args "analyze_power_grid" args \
     keys {-net -corner -voltage_file -error_file -em_outfile -vsrc \
       -source_type} \
-    flags {-enable_em}
+    flags {-enable_em -allow_reuse}
   if { ![info exists keys(-net)] } {
     utl::error PSM 58 "Argument -net not specified."
   }
@@ -111,6 +112,7 @@ proc analyze_power_grid { args } {
     [sta::parse_corner_or_default keys] \
     $source_type \
     $error_file \
+    [info exists flags(-allow_reuse)] \
     $enable_em \
     $em_file \
     $voltage_file \

--- a/src/psm/test/CMakeLists.txt
+++ b/src/psm/test/CMakeLists.txt
@@ -17,6 +17,7 @@ or_integration_tests(
     gcd_all_vss
     gcd_em_test_vdd
     gcd_no_vsrc
+    gcd_no_vsrc_reuse
     gcd_sky130_vdd
     gcd_test_assign_power
     gcd_test_vdd

--- a/src/psm/test/gcd_no_vsrc_reuse.ok
+++ b/src/psm/test/gcd_no_vsrc_reuse.ok
@@ -1,0 +1,76 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 624 components and 2752 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 1248 connections.
+[INFO ODB-0133]     Created 581 nets and 1504 connections.
+[INFO PSM-0040] All shapes on net VDD are connected.
+[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
+########## IR report #################
+Net              : VDD
+Corner           : default
+Supply voltage   : 1.50e+00 V
+Worstcase voltage: 1.50e+00 V
+Average voltage  : 1.50e+00 V
+Average IR drop  : 1.87e-04 V
+Worstcase IR drop: 3.28e-04 V
+Percentage drop  : 0.02 %
+######################################
+[INFO PSM-0040] All shapes on net VSS are connected.
+[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
+########## IR report #################
+Net              : VSS
+Corner           : default
+Supply voltage   : 0.00e+00 V
+Worstcase voltage: 1.49e-03 V
+Average voltage  : 9.19e-04 V
+Average IR drop  : 9.19e-04 V
+Worstcase IR drop: 1.49e-03 V
+Percentage drop  : 0.10 %
+######################################
+[INFO PSM-0040] All shapes on net VDD are connected.
+########## IR report #################
+Net              : VDD
+Corner           : default
+Supply voltage   : 1.50e+00 V
+Worstcase voltage: 1.50e+00 V
+Average voltage  : 1.50e+00 V
+Average IR drop  : 1.87e-04 V
+Worstcase IR drop: 3.28e-04 V
+Percentage drop  : 0.02 %
+######################################
+[INFO PSM-0040] All shapes on net VSS are connected.
+########## IR report #################
+Net              : VSS
+Corner           : default
+Supply voltage   : 0.00e+00 V
+Worstcase voltage: 1.49e-03 V
+Average voltage  : 9.19e-04 V
+Average IR drop  : 9.19e-04 V
+Worstcase IR drop: 1.49e-03 V
+Percentage drop  : 0.10 %
+######################################
+[INFO PSM-0040] All shapes on net VDD are connected.
+[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
+########## IR report #################
+Net              : VDD
+Corner           : default
+Supply voltage   : 1.50e+00 V
+Worstcase voltage: 1.49e+00 V
+Average voltage  : 1.50e+00 V
+Average IR drop  : 1.33e-03 V
+Worstcase IR drop: 1.41e-02 V
+Percentage drop  : 0.94 %
+######################################
+[INFO PSM-0040] All shapes on net VSS are connected.
+[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
+########## IR report #################
+Net              : VSS
+Corner           : default
+Supply voltage   : 0.00e+00 V
+Worstcase voltage: 3.00e-02 V
+Average voltage  : 8.15e-03 V
+Average IR drop  : 8.15e-03 V
+Worstcase IR drop: 3.00e-02 V
+Percentage drop  : 2.00 %
+######################################

--- a/src/psm/test/gcd_no_vsrc_reuse.ok
+++ b/src/psm/test/gcd_no_vsrc_reuse.ok
@@ -29,6 +29,7 @@ Worstcase IR drop: 1.49e-03 V
 Percentage drop  : 0.10 %
 ######################################
 [INFO PSM-0040] All shapes on net VDD are connected.
+[INFO PSM-0011] Reusing previous solution
 ########## IR report #################
 Net              : VDD
 Corner           : default
@@ -40,6 +41,7 @@ Worstcase IR drop: 3.28e-04 V
 Percentage drop  : 0.02 %
 ######################################
 [INFO PSM-0040] All shapes on net VSS are connected.
+[INFO PSM-0011] Reusing previous solution
 ########## IR report #################
 Net              : VSS
 Corner           : default
@@ -49,28 +51,4 @@ Average voltage  : 9.19e-04 V
 Average IR drop  : 9.19e-04 V
 Worstcase IR drop: 1.49e-03 V
 Percentage drop  : 0.10 %
-######################################
-[INFO PSM-0040] All shapes on net VDD are connected.
-[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
-########## IR report #################
-Net              : VDD
-Corner           : default
-Supply voltage   : 1.50e+00 V
-Worstcase voltage: 1.49e+00 V
-Average voltage  : 1.50e+00 V
-Average IR drop  : 1.33e-03 V
-Worstcase IR drop: 1.41e-02 V
-Percentage drop  : 0.94 %
-######################################
-[INFO PSM-0040] All shapes on net VSS are connected.
-[INFO PSM-0073] Using bump pattern with x-pitch 140.0000um, y-pitch 140.0000um, and size 70.0000um with an reduction factor of 3x.
-########## IR report #################
-Net              : VSS
-Corner           : default
-Supply voltage   : 0.00e+00 V
-Worstcase voltage: 3.00e-02 V
-Average voltage  : 8.15e-03 V
-Average IR drop  : 8.15e-03 V
-Worstcase IR drop: 3.00e-02 V
-Percentage drop  : 2.00 %
 ######################################

--- a/src/psm/test/gcd_no_vsrc_reuse.tcl
+++ b/src/psm/test/gcd_no_vsrc_reuse.tcl
@@ -1,0 +1,17 @@
+source helpers.tcl
+
+read_lef Nangate45/Nangate45.lef
+read_def Nangate45_data/gcd.def
+read_liberty Nangate45/Nangate45_typ.lib
+read_sdc Nangate45_data/gcd.sdc
+set_pdnsim_net_voltage -net VDD -voltage 1.5
+analyze_power_grid -net VDD -allow_reuse
+analyze_power_grid -net VSS -allow_reuse
+
+set_pdnsim_inst_power -inst _440_ -power 1e-3
+
+analyze_power_grid -net VDD -allow_reuse
+analyze_power_grid -net VSS -allow_reuse
+
+analyze_power_grid -net VDD
+analyze_power_grid -net VSS

--- a/src/psm/test/gcd_no_vsrc_reuse.tcl
+++ b/src/psm/test/gcd_no_vsrc_reuse.tcl
@@ -8,10 +8,5 @@ set_pdnsim_net_voltage -net VDD -voltage 1.5
 analyze_power_grid -net VDD -allow_reuse
 analyze_power_grid -net VSS -allow_reuse
 
-set_pdnsim_inst_power -inst _440_ -power 1e-3
-
 analyze_power_grid -net VDD -allow_reuse
 analyze_power_grid -net VSS -allow_reuse
-
-analyze_power_grid -net VDD
-analyze_power_grid -net VSS

--- a/src/psm/test/pdnsim_aux.py
+++ b/src/psm/test/pdnsim_aux.py
@@ -42,6 +42,7 @@ def analyze_power_grid(
     vsrc=None,
     outfile=None,
     error_file=None,
+    allow_reuse=False,
     enable_em=False,
     em_outfile=None,
     net=None,
@@ -76,7 +77,7 @@ def analyze_power_grid(
         em_outfile = ""
 
     pdnsim.analyzePowerGrid(
-        net, corner, 2, outfile, enable_em, em_outfile, error_file, vsrc
+        net, corner, 2, outfile, allow_reuse, enable_em, em_outfile, error_file, vsrc
     )
 
 


### PR DESCRIPTION
Changes:
- if a previous solution is available, this allows the user to specify they want to use that instead of recomputing.