### PR TITLE
Print clang-format version in use in CI format check.

### DIFF
--- a/.github/workflows/github-actions-format-on-push.yml
+++ b/.github/workflows/github-actions-format-on-push.yml
@@ -19,6 +19,7 @@ jobs:
         uses: tj-actions/changed-files@v41
       - name: Check format of cpp changed files
         run: |
+          clang-format --version
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [[ "${file##*.}" =~ ^(h|C|cc|cp|cpp|c++|CPP|cxx|hh)$ && "${file}" != "src/sta/"* && "${file}" != "src/odb/src/codeGenerator/"* ]]; then
               clang-format --dry-run --Werror $file


### PR DESCRIPTION
clang-format behaves slightly differently between versions. Print out the version number used in the CI, so that it is possible for contributors to verify that they run exactly the version locally to avoid formatting issues in PRs.