### PR TITLE
gui: optimizing find in clock tree viewer

### DIFF
--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -847,9 +847,13 @@ bool ClockTreeView::changeSelection(const SelectionSet& selections)
   if (!nodes.empty()) {
     // remove old selection
     clearSelection();
+
+    // prevent ClockTreeView to draw until unlock
+    lockRender();
     for (auto node : nodes) {
       node->setSelected(true);
     }
+    unlockRender();
     return true;
   }
   return false;
@@ -1012,6 +1016,8 @@ void ClockTreeView::wheelEvent(QWheelEvent* event)
 
 void ClockTreeView::selectionChanged()
 {
+  if (lock_render_)
+    return;
   renderer_->resetTree();
 
   for (const auto& sel : scene_->selectedItems()) {

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -854,6 +854,7 @@ bool ClockTreeView::changeSelection(const SelectionSet& selections)
       node->setSelected(true);
     }
     unlockRender();
+    selectionChanged();
     return true;
   }
   return false;

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -1016,8 +1016,9 @@ void ClockTreeView::wheelEvent(QWheelEvent* event)
 
 void ClockTreeView::selectionChanged()
 {
-  if (lock_render_)
+  if (lock_render_) {
     return;
+}
   renderer_->resetTree();
 
   for (const auto& sel : scene_->selectedItems()) {

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -1018,7 +1018,7 @@ void ClockTreeView::selectionChanged()
 {
   if (lock_render_) {
     return;
-}
+  }
   renderer_->resetTree();
 
   for (const auto& sel : scene_->selectedItems()) {

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -419,8 +419,11 @@ class ClockTreeView : public QGraphicsView
   void mousePressEvent(QMouseEvent* event) override;
   void mouseReleaseEvent(QMouseEvent* event) override;
   void mouseMoveEvent(QMouseEvent* event) override;
+  void lockRender() { lock_render_ = true; };
+  void unlockRender() { lock_render_ = false; };
 
  private:
+  bool lock_render_{false};
   std::shared_ptr<ClockTree> tree_;
   std::unique_ptr<ClockTreeRenderer> renderer_;
   RendererState renderer_state_;
@@ -446,7 +449,7 @@ class ClockTreeView : public QGraphicsView
   std::vector<ClockNodeGraphicsViewItem*> buildTree(const ClockTree* tree,
                                                     const STAGuiInterface* sta,
                                                     int center_index);
-  std::map<std::string, ClockNodeGraphicsViewItem*> items_;
+  std::unordered_map<std::string, ClockNodeGraphicsViewItem*> items_;
 
   struct PinArrival
   {


### PR DESCRIPTION
Closes #6400.

Changes:
- Optimizes instance search in CTS Viewer by disabling rendering when setting nodes to selected
  - Previously, the CTS Viewer was rendering everything after each node was set to selected
- Changes items name hash table to unordered_map 