### PR TITLE
docs: add dft to docs

### DIFF
--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -38,6 +38,8 @@ entries:
     title: Floorplan Initialization
   - file: main/src/ppl/README
     title: Pin Placement
+  - file: main/src/dft/README
+    title: Design for Test
   - file: main/src/pad/README
     title: Chip-level Connections
   - file: main/src/mpl/README


### PR DESCRIPTION
DFT seems to be missing from the docs build. 