### PR TITLE
gpl: switch mbff to warning when flops are not found

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -2192,7 +2192,8 @@ void MBFF::Run(const int mx_sz, const float alpha, const float beta)
   }
 
   if (!any_found) {
-    log_->error(GPL, 138, "No clusterable flops found");
+    log_->warn(GPL, 138, "No clusterable flops found");
+    return;
   }
 
   const float tcp_disp = (beta * GetPairDisplacements());

--- a/src/gpl/test/CMakeLists.txt
+++ b/src/gpl/test/CMakeLists.txt
@@ -5,6 +5,7 @@ or_integration_tests(
     ar02
     clust01
     clust02
+    clust03
     convergence01
     core01
     density01

--- a/src/gpl/test/clust03.ok
+++ b/src/gpl/test/clust03.ok
@@ -1,0 +1,5 @@
+[INFO ODB-0227] LEF file: ./asap7/asap7_tech_1x_201209.lef, created 24 layers, 9 vias
+[INFO ODB-0227] LEF file: ./SingleBit/asap7sc7p5t_28_L_1x_220121a.lef, created 212 library cells
+[INFO IFP-0001] Added 370 rows of 1851 site asap7sc7p5t.
+[INFO GPL-0137] No tray found for group of 100 flop instances containing DFFHQNx1_ASAP7_75t_L
+[WARNING GPL-0138] No clusterable flops found

--- a/src/gpl/test/clust03.tcl
+++ b/src/gpl/test/clust03.tcl
@@ -1,0 +1,53 @@
+source helpers.tcl
+set test_name clust02
+
+
+read_lef ./asap7/asap7_tech_1x_201209.lef
+read_lef ./SingleBit/asap7sc7p5t_28_L_1x_220121a.lef
+read_lib ./SingleBit/asap7sc7p5t_SEQ_LVT_TT_nldm_220123.lib 
+
+set db [ord::get_db]
+set chip [odb::dbChip_create $db]
+set block [odb::dbBlock_create $chip "top"]
+$block setDefUnits 1000
+
+set clk [odb::dbNet_create $block "clk"]
+$clk setSigType CLOCK
+
+set master [$db findMaster "DFFHQNx1_ASAP7_75t_L"]
+
+proc RandomInteger {max} {
+    return [expr {int(rand()*$max)}]
+}
+
+set width 100
+set height 100
+
+expr { srand(17) }
+for {set i 0} {$i < 100} {incr i} {
+  set x [RandomInteger [expr $width * 1000]]
+  set y [RandomInteger [expr $height * 1000]]
+
+  set inst [odb::dbInst_create $block $master "inst_${x}_${y}"]
+  $inst setLocation $x $y
+  $inst setPlacementStatus PLACED
+
+  set clk_iterm [$inst findITerm "CLK"]
+  $clk_iterm connect $clk
+
+  set d_net [odb::dbNet_create $block "net_d_${x}_${y}"]
+  set d_iterm [$inst findITerm "D"]
+  $d_iterm connect $d_net
+}
+
+ord::design_created
+
+initialize_floorplan \
+    -die_area [list 0 0 $width $height] \
+    -core_area [list 0 0 $width $height] \
+    -site asap7sc7p5t
+
+cluster_flops -tray_weight 60.0 \
+              -timing_weight 1.0 \
+              -max_split_size 50 \
+              -num_paths 0


### PR DESCRIPTION
Changes:
- `cluster_flops` changes error to warning when clusterable flops are not found (this is consistent with the `scan_replace` which doesnt error out but warns when flops are not found).