### PR TITLE
dpl: add API to get adjacent cells cluster

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -163,8 +163,8 @@ class Opendp
   void addDecapMaster(dbMaster* decap_master, double decap_cap);
   void insertDecapCells(double target, IRDropByPoint& psm_ir_drops);
 
-  // Get instances adjacent to the left/right of an instance
-  std::pair<dbInst*, dbInst*> getAdjacentInstances(dbInst* inst) const;
+  // Get the instance adjacent to the left or right of a given instance
+  dbInst* getAdjacentInstance(dbInst* inst, bool left) const;
 
   // Find a cluster of instances that are touching each other
   std::vector<dbInst*> getAdjacentInstancesCluster(dbInst* inst) const;

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -166,6 +166,9 @@ class Opendp
   // Get instances adjacent to the left/right of an instance
   std::pair<dbInst*, dbInst*> getAdjacentInstances(dbInst* inst) const;
 
+  // Find a cluster of instances that are touching each other
+  std::vector<dbInst*> getAdjacentInstancesCluster(dbInst* inst) const;
+
  private:
   using bgPoint
       = boost::geometry::model::d2::point_xy<int,

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -163,6 +163,9 @@ class Opendp
   void addDecapMaster(dbMaster* decap_master, double decap_cap);
   void insertDecapCells(double target, IRDropByPoint& psm_ir_drops);
 
+  // Get instances adjacent to the left/right of an instance
+  std::pair<dbInst*, dbInst*> getAdjacentInstances(dbInst* inst) const;
+
  private:
   using bgPoint
       = boost::geometry::model::d2::point_xy<int,

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -377,6 +377,40 @@ void Opendp::groupInitPixels2()
   }
 }
 
+std::pair<dbInst*, dbInst*> Opendp::getAdjacentInstances(dbInst* inst) const
+{
+  const Rect inst_rect = inst->getBBox()->getBox();
+  Point left(inst_rect.xMin() - 1, inst_rect.center().getY());
+  Point right(inst_rect.xMax() + 1, inst_rect.center().getY());
+
+  const Rect core = grid_->getCore();
+  GridX left_x = grid_->gridX(DbuX{left.getX() - core.xMin()});
+  GridY left_y = grid_->gridSnapDownY(DbuY{left.getY() - core.yMin()});
+
+  GridX right_x = grid_->gridX(DbuX{right.getX() - core.xMin()});
+  GridY right_y = grid_->gridSnapDownY(DbuY{right.getY() - core.yMin()});
+
+  Pixel* left_pixel = grid_->gridPixel(left_x, left_y);
+  Pixel* right_pixel = grid_->gridPixel(right_x, right_y);
+
+  dbInst* left_inst = nullptr;
+  dbInst* right_inst = nullptr;
+
+  if (left_pixel != nullptr) {
+    if (left_pixel->cell) {
+      left_inst = left_pixel->cell->db_inst_;
+    }
+  }
+
+  if (right_pixel != nullptr) {
+    if (right_pixel->cell) {
+      right_inst = right_pixel->cell->db_inst_;
+    }
+  }
+
+  return {left_inst, right_inst};
+}
+
 /* static */
 bool Opendp::isInside(const Rect& cell, const Rect& box)
 {

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -397,13 +397,15 @@ std::pair<dbInst*, dbInst*> Opendp::getAdjacentInstances(dbInst* inst) const
   dbInst* right_inst = nullptr;
 
   if (left_pixel != nullptr) {
-    if (left_pixel->cell) {
+    // do not return macros, endcaps and tapcells
+    if (left_pixel->cell && left_pixel->cell->db_inst_->isCore()) {
       left_inst = left_pixel->cell->db_inst_;
     }
   }
 
   if (right_pixel != nullptr) {
-    if (right_pixel->cell) {
+    // do not return macros, endcaps and tapcells
+    if (right_pixel->cell && right_pixel->cell->db_inst_->isCore()) {
       right_inst = right_pixel->cell->db_inst_;
     }
   }

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -379,19 +379,15 @@ void Opendp::groupInitPixels2()
 
 std::pair<dbInst*, dbInst*> Opendp::getAdjacentInstances(dbInst* inst) const
 {
-  const Rect inst_rect = inst->getBBox()->getBox();
-  Point left(inst_rect.xMin() - 1, inst_rect.center().getY());
-  Point right(inst_rect.xMax() + 1, inst_rect.center().getY());
-
   const Rect core = grid_->getCore();
-  GridX left_x = grid_->gridX(DbuX{left.getX() - core.xMin()});
-  GridY left_y = grid_->gridSnapDownY(DbuY{left.getY() - core.yMin()});
+  const Rect inst_rect = inst->getBBox()->getBox();
+  GridX left_x = grid_->gridX(DbuX{inst_rect.xMin() - 1 - core.xMin()});
+  GridX right_x = grid_->gridX(DbuX{inst_rect.xMax() + 1 - core.xMin()});
 
-  GridX right_x = grid_->gridX(DbuX{right.getX() - core.xMin()});
-  GridY right_y = grid_->gridSnapDownY(DbuY{right.getY() - core.yMin()});
+  GridY y = grid_->gridSnapDownY(DbuY{inst_rect.yMin() - core.yMin()});
 
-  Pixel* left_pixel = grid_->gridPixel(left_x, left_y);
-  Pixel* right_pixel = grid_->gridPixel(right_x, right_y);
+  Pixel* left_pixel = grid_->gridPixel(left_x, y);
+  Pixel* right_pixel = grid_->gridPixel(right_x, y);
 
   dbInst* left_inst = nullptr;
   dbInst* right_inst = nullptr;

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -411,6 +411,33 @@ std::pair<dbInst*, dbInst*> Opendp::getAdjacentInstances(dbInst* inst) const
   return {left_inst, right_inst};
 }
 
+std::vector<dbInst*> Opendp::getAdjacentInstancesCluster(dbInst* inst) const
+{
+  std::vector<dbInst*> adj_inst_cluster;
+  adj_inst_cluster.push_back(inst);
+
+  auto [left, right] = getAdjacentInstances(inst);
+  while (left != nullptr) {
+    adj_inst_cluster.push_back(left);
+    // the right instance can be ignored, since it was added in the line above
+    auto [l, r] = getAdjacentInstances(left);
+    left = l;
+  }
+
+  while (right != nullptr) {
+    adj_inst_cluster.push_back(right);
+    // the left instance can be ignored, since it was added in the line above
+    auto [l, r] = getAdjacentInstances(right);
+    right = r;
+  }
+
+  auto cmp = [](const dbInst* inst1, const dbInst* inst2) {
+    return inst1->getLocation().getX() < inst2->getLocation().getX();
+  };
+  std::sort(adj_inst_cluster.begin(), adj_inst_cluster.end(), cmp);
+  return adj_inst_cluster;
+}
+
 /* static */
 bool Opendp::isInside(const Rect& cell, const Rect& box)
 {


### PR DESCRIPTION
This PR adds a public API for DPL that returns a cluster of instances, where every instances is adjacent to at least one instance inside the cluster.

This was requested by @bnmfw for his incremental pin access update.

This cluster should only contain instances that the pin access will do something, so tapcells and endcaps are ignored. Also, since macros are handled separately, they're also ignored.