### PR TITLE
Cts techchar: Turn off hierarchical api during characterization

### DIFF
--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -821,8 +821,8 @@ void TechChar::collectSlewsLoadsFromTableAxis(sta::LibertyCell* libCell,
           axisLoads.push_back((*loads)[i]);
         }
       }
-    }  // if (gateModel)
-  }    // for each arc
+    }
+  }
 
   if (logger_->debugCheck(utl::CTS, "tech char", 2)) {
     logger_->report("axis slews at {}", libCell->name());
@@ -1676,8 +1676,8 @@ void TechChar::create()
                          "Number of created patterns = {}.",
                          topologiesCreated);
             }
-          }  // for each slew
-        }    // for each load
+          }
+        }
         // If the solution is not a pure-wire, update the buffer topologies.
         if (!solution.isPureWire) {
           updateBufferTopologies(solution);

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -822,7 +822,7 @@ void TechChar::collectSlewsLoadsFromTableAxis(sta::LibertyCell* libCell,
         }
       }
     }  // if (gateModel)
-  }  // for each arc
+  }    // for each arc
 
   if (logger_->debugCheck(utl::CTS, "tech char", 2)) {
     logger_->report("axis slews at {}", libCell->name());
@@ -1544,6 +1544,17 @@ unsigned TechChar::normalizeCharResults(float value,
 
 void TechChar::create()
 {
+  //
+  // Note that none of the techchar uses anything hierarchical
+  // and builds intermediate networks of (liberty) gates in a separate block
+  // Rather than register then as concrete we simply turn of hierarchy
+  // here so that the default (flat) dbNetwork apis are used
+  // during characterization.
+  //
+  bool is_hierarchical = db_network_->hasHierarchy();
+  if (is_hierarchical) {
+    db_network_->disableHierarchy();
+  }
   // Setup of the attributes required to run the characterization.
   initCharacterization();
   long unsigned int topologiesCreated = 0;
@@ -1664,7 +1675,7 @@ void TechChar::create()
                          topologiesCreated);
             }
           }  // for each slew
-        }  // for each load
+        }    // for each load
         // If the solution is not a pure-wire, update the buffer topologies.
         if (!solution.isPureWire) {
           updateBufferTopologies(solution);
@@ -1688,6 +1699,9 @@ void TechChar::create()
     printSolution();
   }
   odb::dbBlock::destroy(charBlock_);
+  if (is_hierarchical) {
+    db_network_->setHierarchy();
+  }
 }
 
 // Compute possible buffering solution combinations given #buffers and

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -1545,11 +1545,13 @@ unsigned TechChar::normalizeCharResults(float value,
 void TechChar::create()
 {
   //
-  // Note that none of the techchar uses anything hierarchical
-  // and builds intermediate networks of (liberty) gates in a separate block
-  // Rather than register then as concrete we simply turn of hierarchy
+  // Note that none of the techchar uses anything hierarchical.
+  // Techchar builds intermediate structures of (liberty) gates in a separate
+  // block Rather than register them as concrete we simply turn off hierarchy
   // here so that the default (flat) dbNetwork apis are used
-  // during characterization.
+  // during characterization. This pattern is likely to repeat
+  // whenever a "scratchpad" dbBlock and sta are created for characterizing
+  // structures.
   //
   bool is_hierarchical = db_network_->hasHierarchy();
   if (is_hierarchical) {


### PR DESCRIPTION
The cts tech char creates a scratch pad dbBlock and Sta and creates low level liberty gates in a partial network.
Rather than register these as concrete, we turn off the hierarchical api (if hierarchical mode enabled) so that the default "Concrete" api calls are made.
This pattern seems likely to occur any time flat scratch pad sta/dbBlocks are created to evaluate different liberty gates.