### PR TITLE
drt: pathseg deadcode elimination

### DIFF
--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -207,7 +207,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
       auto pin = blk->getPin();
       for (auto& uFig : pin->getFigs()) {
         auto shape = uFig.get();
-        if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
+        if (shape->typeId() == frcRect) {
           Rect frb = shape->getBBox();
           xform.apply(frb);
           impl_->shapes_.at(static_cast<frShape*>(shape)->getLayerNum())


### PR DESCRIPTION
Secure and ISPD CI safe.

In `frRegionQuery::addBlockObj()` the condition `shape->typeId() == frcPathSeg`is always false when that part of code is reached. This is a very small piece of dead code (But one that threw me off for a while).