### PR TITLE
dft: implementing interface to support different test modes

### DIFF
--- a/src/dft/README.md
+++ b/src/dft/README.md
@@ -19,12 +19,33 @@ A simple DFT insertion consist of the following parts:
 - Parameters without square brackets `-param2 param2` are required.
 ```
 
+### Create a test mode
+
+You can create test modes with the command ```create_dft_test_mode```. Each test
+mode is architected and stitched independenly.
+
+```{note}
+Usually, you can select what cells or subset of the scan cells you can to be in
+each test mode. This is currently not implemented as this is WIP.
+```
+
+```tcl
+create_dft_test_mode 
+    [-test_mode <string>]
+```
+
+| Switch Name  | Description                          |
+| ----         | ----                                 |
+| `-test_mode` | The name of the test mode to create. |
+
+
 ### Set DFT Config 
 
 The command `set_dft_config` sets the DFT configuration variables.
 
 ```tcl
 set_dft_config 
+    [-test_mode <string>]
     [-max_length <int>]
     [-max_chains <int>]
     [-clock_mixing <string>]
@@ -35,9 +56,10 @@ set_dft_config
 
 #### Options
 
-| Switch Name | Description |
-| ---- | ---- |
-| `-max_length` | The maximum number of bits that can be in each scan chain. |
+| Switch Name   | Description                                                                                               |
+| ----          | ----                                                                                                      |
+| `-test_mode`  | The test mode where to apply this config. By default it will apply the config to the "default" test mode. |
+| `-max_length` | The maximum number of bits that can be in each scan chain.                                                |
 | `-max_chains` | The maximum number of scan chains that will be generated. This takes priority over `max_length`,
 in `no_mix` clock mode it specifies a maximum number of chains per clock-edge pair. |
 | `-clock_mixing` | How architect will mix the scan flops based on the clock driver. `no_mix`: Creates scan chains with only one type of clock and edge. This may create unbalanced chains. `clock_mix`: Creates scan chains mixing clocks and edges. Falling edge flops are going to be stitched before rising edge. |

--- a/src/dft/include/dft/Dft.hh
+++ b/src/dft/include/dft/Dft.hh
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "ClockDomain.hh"
+#include "TestModeConfig.hh"
 #include "db_sta/dbSta.hh"
 #include "odb/db.h"
 #include "utl/Logger.h"
@@ -117,6 +118,13 @@ class Dft
   // Common function to perform scan replace and scan architect. Shared between
   // preview_dft and insert_dft
   std::vector<std::unique_ptr<ScanChain>> scanArchitect();
+
+  std::vector<std::unique_ptr<ScanChain>> scanArchitect(
+      const TestModeConfig& test_mode_config);
+
+  void previewDft(const TestModeConfig& test_mode_config, bool verbose);
+
+  void insertDft(const TestModeConfig& test_mode_config);
 
   // Global state
   odb::dbDatabase* db_;

--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -84,18 +84,29 @@ void Dft::pre_dft()
 
 void Dft::previewDft(bool verbose)
 {
+  for (const auto& [test_mode, test_mode_config] :
+       dft_config_->getTestModesConfig()) {
+    previewDft(test_mode_config, verbose);
+  }
+}
+
+void Dft::previewDft(const TestModeConfig& test_mode_config, bool verbose)
+{
   if (need_to_run_pre_dft_) {
     pre_dft();
   }
 
-  std::vector<std::unique_ptr<ScanChain>> scan_chains = scanArchitect();
+  std::vector<std::unique_ptr<ScanChain>> scan_chains
+      = scanArchitect(test_mode_config);
 
   logger_->report("***************************");
   logger_->report("Preview DFT Report");
+  logger_->report("Test mode: {:s}", test_mode_config.getName());
   logger_->report("Number of chains: {:d}", scan_chains.size());
-  logger_->report("Clock domain: {:s}",
-                  ScanArchitectConfig::ClockMixingName(
-                      dft_config_->getScanArchitectConfig().getClockMixing()));
+  logger_->report(
+      "Clock domain: {:s}",
+      ScanArchitectConfig::ClockMixingName(
+          test_mode_config.getScanArchitectConfig().getClockMixing()));
   logger_->report("***************************\n");
   for (const auto& scan_chain : scan_chains) {
     scan_chain->report(logger_, verbose);
@@ -113,12 +124,21 @@ void Dft::scanReplace()
 
 void Dft::insertDft()
 {
+  // iterate and call per test mode
+  for (const auto& [_, test_mode_config] : dft_config_->getTestModesConfig()) {
+    insertDft(test_mode_config);
+  }
+}
+
+void Dft::insertDft(const TestModeConfig& test_mode_config)
+{
   if (need_to_run_pre_dft_) {
     pre_dft();
   }
-  std::vector<std::unique_ptr<ScanChain>> scan_chains = scanArchitect();
+  std::vector<std::unique_ptr<ScanChain>> scan_chains
+      = scanArchitect(test_mode_config);
 
-  ScanStitch stitch(db_, logger_, dft_config_->getScanStitchConfig());
+  ScanStitch stitch(db_, logger_, test_mode_config.getScanStitchConfig());
   stitch.Stitch(scan_chains);
 
   // Write scan chains to odb
@@ -179,7 +199,8 @@ void Dft::reportDftConfig() const
   dft_config_->report(logger_);
 }
 
-std::vector<std::unique_ptr<ScanChain>> Dft::scanArchitect()
+std::vector<std::unique_ptr<ScanChain>> Dft::scanArchitect(
+    const TestModeConfig& test_mode_config)
 {
   std::vector<std::unique_ptr<ScanCell>> scan_cells
       = CollectScanCells(db_, sta_, logger_);
@@ -187,11 +208,12 @@ std::vector<std::unique_ptr<ScanChain>> Dft::scanArchitect()
   // Scan Architect
   std::unique_ptr<ScanCellsBucket> scan_cells_bucket
       = std::make_unique<ScanCellsBucket>(logger_);
-  scan_cells_bucket->init(dft_config_->getScanArchitectConfig(), scan_cells);
+  scan_cells_bucket->init(test_mode_config.getScanArchitectConfig(),
+                          scan_cells);
 
   std::unique_ptr<ScanArchitect> scan_architect
       = ScanArchitect::ConstructScanScanArchitect(
-          dft_config_->getScanArchitectConfig(),
+          test_mode_config.getScanArchitectConfig(),
           std::move(scan_cells_bucket),
           logger_);
   scan_architect->init();

--- a/src/dft/src/config/CMakeLists.txt
+++ b/src/dft/src/config/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(dft_config_lib
   # Keep sorted
   DftConfig.cpp
+  TestModeConfig.cpp
   ScanArchitectConfig.cpp
   ScanStitchConfig.cpp
 )

--- a/src/dft/src/config/DftConfig.hh
+++ b/src/dft/src/config/DftConfig.hh
@@ -31,8 +31,9 @@
 // POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
-#include "ScanArchitectConfig.hh"
-#include "ScanStitchConfig.hh"
+#include <unordered_map>
+
+#include "TestModeConfig.hh"
 #include "utl/Logger.h"
 
 namespace dft {
@@ -47,18 +48,18 @@ class DftConfig
   DftConfig(const DftConfig&) = delete;
   DftConfig& operator=(const DftConfig&) = delete;
 
-  ScanArchitectConfig* getMutableScanArchitectConfig();
-  const ScanArchitectConfig& getScanArchitectConfig() const;
-
-  ScanStitchConfig* getMutableScanStitchConfig();
-  const ScanStitchConfig& getScanStitchConfig() const;
+  TestModeConfig* createTestMode(const std::string& name);
+  TestModeConfig* getOrDefaultMutableTestModeConfig(const std::string& name);
+  const std::unordered_map<std::string, TestModeConfig>& getTestModesConfig()
+      const;
 
   // Prints the information currently being used by DFT for config
   void report(utl::Logger* logger) const;
 
  private:
-  ScanArchitectConfig scan_architect_config_;
-  ScanStitchConfig scan_stitch_config_;
+  // A DFT config can have multiple test modes. If no test mode was defined by
+  // the user, then we use the "default" test mode.
+  std::unordered_map<std::string, TestModeConfig> test_modes_config_;
 };
 
 }  // namespace dft

--- a/src/dft/src/config/ScanArchitectConfig.hh
+++ b/src/dft/src/config/ScanArchitectConfig.hh
@@ -48,6 +48,8 @@ class ScanArchitectConfig
     ClockMix  // We architect the flops of different clock and edge together
   };
 
+  ScanArchitectConfig() : clock_mixing_(ClockMixing::NoMix) {}
+
   void setClockMixing(ClockMixing clock_mixing);
 
   // The max length in bits that a scan chain can have

--- a/src/dft/src/config/TestModeConfig.cpp
+++ b/src/dft/src/config/TestModeConfig.cpp
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Google LLC
+// Copyright (c) 2025, Google LLC
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -30,51 +30,39 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-#include "DftConfig.hh"
+#include "TestModeConfig.hh"
 
 namespace dft {
 
-namespace {
-constexpr std::string_view kDefaultTestModeName = "default";
-}  // namespace
-
-void DftConfig::report(utl::Logger* logger) const
+ScanArchitectConfig* TestModeConfig::getMutableScanArchitectConfig()
 {
-  logger->report("***************************");
-  logger->report("DFT Config Report:\n");
-
-  for (const auto& [test_mode, test_mode_config] : test_modes_config_) {
-    logger->report("\nTest mode: {}", test_mode);
-    test_mode_config.report(logger);
-  }
-
-  logger->report("***************************");
+  return &scan_architect_config_;
 }
 
-TestModeConfig* DftConfig::createTestMode(const std::string& name)
+const ScanArchitectConfig& TestModeConfig::getScanArchitectConfig() const
 {
-  auto pair = test_modes_config_.try_emplace(name, name);
-  return &pair.first->second;
+  return scan_architect_config_;
 }
 
-TestModeConfig* DftConfig::getOrDefaultMutableTestModeConfig(
-    const std::string& name)
+ScanStitchConfig* TestModeConfig::getMutableScanStitchConfig()
 {
-  auto found = test_modes_config_.find(name);
-  if (found == test_modes_config_.end()) {
-    if (name == kDefaultTestModeName) {
-      return createTestMode(name);
-    } else {
-      return nullptr;
-    }
-  }
-  return &found->second;
+  return &scan_stitch_config_;
 }
 
-const std::unordered_map<std::string, TestModeConfig>&
-DftConfig::getTestModesConfig() const
+const ScanStitchConfig& TestModeConfig::getScanStitchConfig() const
 {
-  return test_modes_config_;
+  return scan_stitch_config_;
+}
+
+void TestModeConfig::report(utl::Logger* logger) const
+{
+  scan_architect_config_.report(logger);
+  scan_stitch_config_.report(logger);
+}
+
+const std::string& TestModeConfig::getName() const
+{
+  return name_;
 }
 
 }  // namespace dft

--- a/src/dft/src/config/TestModeConfig.hh
+++ b/src/dft/src/config/TestModeConfig.hh
@@ -1,7 +1,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // BSD 3-Clause License
 //
-// Copyright (c) 2023, Google LLC
+// Copyright (c) 2025, Google LLC
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -29,52 +29,36 @@
 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
+#pragma once
 
-#include "DftConfig.hh"
+#include "ScanArchitectConfig.hh"
+#include "ScanStitchConfig.hh"
 
 namespace dft {
 
-namespace {
-constexpr std::string_view kDefaultTestModeName = "default";
-}  // namespace
-
-void DftConfig::report(utl::Logger* logger) const
+// Holds the config of this particular test mode.
+class TestModeConfig
 {
-  logger->report("***************************");
-  logger->report("DFT Config Report:\n");
+ public:
+  TestModeConfig(const std::string& name) : name_(name) {}
+  // Not copyable or movable.
+  TestModeConfig(const TestModeConfig&) = delete;
+  TestModeConfig& operator=(const TestModeConfig&) = delete;
 
-  for (const auto& [test_mode, test_mode_config] : test_modes_config_) {
-    logger->report("\nTest mode: {}", test_mode);
-    test_mode_config.report(logger);
-  }
+  ScanArchitectConfig* getMutableScanArchitectConfig();
+  const ScanArchitectConfig& getScanArchitectConfig() const;
 
-  logger->report("***************************");
-}
+  ScanStitchConfig* getMutableScanStitchConfig();
+  const ScanStitchConfig& getScanStitchConfig() const;
 
-TestModeConfig* DftConfig::createTestMode(const std::string& name)
-{
-  auto pair = test_modes_config_.try_emplace(name, name);
-  return &pair.first->second;
-}
+  void report(utl::Logger* logger) const;
 
-TestModeConfig* DftConfig::getOrDefaultMutableTestModeConfig(
-    const std::string& name)
-{
-  auto found = test_modes_config_.find(name);
-  if (found == test_modes_config_.end()) {
-    if (name == kDefaultTestModeName) {
-      return createTestMode(name);
-    } else {
-      return nullptr;
-    }
-  }
-  return &found->second;
-}
+  const std::string& getName() const;
 
-const std::unordered_map<std::string, TestModeConfig>&
-DftConfig::getTestModesConfig() const
-{
-  return test_modes_config_;
-}
+ private:
+  std::string name_;
+  ScanArchitectConfig scan_architect_config_;
+  ScanStitchConfig scan_stitch_config_;
+};
 
 }  // namespace dft

--- a/src/dft/src/dft.i
+++ b/src/dft/src/dft.i
@@ -34,11 +34,16 @@
 
 %{
 
+#include <functional>
+
 #include "dft/Dft.hh"
 #include "DftConfig.hh"
 #include "ord/OpenRoad.hh"
 #include "ScanArchitect.hh"
 #include "ClockDomain.hh"
+#include "TestModeConfig.hh"
+
+namespace {
 
 dft::Dft * getDft()
 {
@@ -49,6 +54,19 @@ utl::Logger* getLogger()
 {
   return ord::OpenRoad::openRoad()->getLogger();
 }
+
+void withTestMode(std::string_view test_mode, std::function<void(dft::TestModeConfig*)> fn) {
+  dft::TestModeConfig* test_mode_config = getDft()
+    ->getMutableDftConfig()
+    ->getOrDefaultMutableTestModeConfig(std::string(test_mode));
+  if (!test_mode_config) {
+    getLogger()->error(utl::DFT, 41, "Test mode {} not defiend", test_mode); 
+    return;
+  }
+  fn(test_mode_config);
+}
+
+} // namespace
 
 %}
 
@@ -114,38 +132,52 @@ void insert_dft()
   getDft()->insertDft();
 }
 
-void set_dft_config_max_length(int max_length)
+void set_dft_config_max_length(const char* test_mode, int max_length)
 {
-  getDft()->getMutableDftConfig()->getMutableScanArchitectConfig()->setMaxLength(max_length);
+  withTestMode(test_mode, [max_length](dft::TestModeConfig* test_mode_config) {
+    test_mode_config->getMutableScanArchitectConfig()->setMaxLength(max_length);
+  });
 }
 
-void set_dft_config_max_chains(int max_chains)
+void set_dft_config_max_chains(const char* test_mode, int max_chains)
 {
-  getDft()->getMutableDftConfig()->getMutableScanArchitectConfig()->setMaxChains(max_chains);
+  withTestMode(test_mode, [max_chains](dft::TestModeConfig* test_mode_config) {
+    test_mode_config->getMutableScanArchitectConfig()->setMaxChains(max_chains);
+  });
 }
 
-void set_dft_config_clock_mixing(dft::ScanArchitectConfig::ClockMixing clock_mixing)
+void set_dft_config_clock_mixing(const char* test_mode, dft::ScanArchitectConfig::ClockMixing clock_mixing)
 {
-  getDft()->getMutableDftConfig()->getMutableScanArchitectConfig()->setClockMixing(clock_mixing);
+  withTestMode(test_mode, [clock_mixing](dft::TestModeConfig* test_mode_config) {
+    test_mode_config->getMutableScanArchitectConfig()->setClockMixing(clock_mixing);
+  });
 }
 
-void set_dft_config_scan_signal_name_pattern(const char* signal_ptr, const char* pattern_ptr) {
-  dft::ScanStitchConfig* config = getDft()->getMutableDftConfig()->getMutableScanStitchConfig();
-  std::string_view signal(signal_ptr), pattern(pattern_ptr);
-  
-  if (signal == "scan_in") {
-    config->setInNamePattern(pattern);
-  } else if (signal == "scan_enable") {
-    config->setEnableNamePattern(pattern);
-  } else if (signal == "scan_out") {
-    config->setOutNamePattern(pattern);
-  } else {
-    getLogger()->error(utl::DFT, 6, "Internal error: unrecognized signal '{}' to set a pattern for", signal); 
-  }
+void set_dft_config_scan_signal_name_pattern(const char* test_mode, const char* signal_ptr, const char* pattern_ptr) {
+  withTestMode(test_mode, [signal_ptr, pattern_ptr](dft::TestModeConfig* test_mode_config) {
+    dft::ScanStitchConfig* config = test_mode_config->getMutableScanStitchConfig();
+
+    std::string_view signal(signal_ptr);
+    std::string_view pattern(pattern_ptr);
+    
+    if (signal == "scan_in") {
+      config->setInNamePattern(pattern);
+    } else if (signal == "scan_enable") {
+      config->setEnableNamePattern(pattern);
+    } else if (signal == "scan_out") {
+      config->setOutNamePattern(pattern);
+    } else {
+      getLogger()->error(utl::DFT, 6, "Internal error: unrecognized signal '{}' to set a pattern for", signal); 
+    }
+  });
 }
 
 void report_dft_config() {
   getDft()->reportDftConfig();
+}
+
+void create_dft_test_mode(const char* test_mode) {
+  getDft()->getMutableDftConfig()->createTestMode(test_mode);
 }
 
 %}  // inline

--- a/src/dft/src/dft.tcl
+++ b/src/dft/src/dft.tcl
@@ -70,7 +70,8 @@ proc insert_dft { args } {
   dft::insert_dft
 }
 
-sta::define_cmd_args "set_dft_config" { [-max_length max_length]
+sta::define_cmd_args "set_dft_config" { [-test_mode test_mode]
+                                        [-max_length max_length]
                                         [-max_chains max_chains]
                                         [-clock_mixing clock_mixing]
                                         [-scan_enable_name_pattern scan_enable_name_pattern]
@@ -80,6 +81,7 @@ sta::define_cmd_args "set_dft_config" { [-max_length max_length]
 proc set_dft_config { args } {
   sta::parse_key_args "set_dft_config" args \
     keys {
+      -test_mode
       -max_length
       -max_chains
       -clock_mixing
@@ -91,21 +93,28 @@ proc set_dft_config { args } {
 
   sta::check_argc_eq0 "set_dft_config" $args
 
+  if { [info exists keys(-test_mode)] } {
+    set test_mode $keys(-max_length)
+  } else {
+    # all commands are by default applied to the "default" test mode
+    set test_mode "default"
+  }
+
   if { [info exists keys(-max_length)] } {
     set max_length $keys(-max_length)
     sta::check_positive_integer "-max_length" $max_length
-    dft::set_dft_config_max_length $max_length
+    dft::set_dft_config_max_length $test_mode $max_length
   }
 
   if { [info exists keys(-max_chains)] } {
     set max_chains $keys(-max_chains)
     sta::check_positive_integer "-max_chains" $max_chains
-    dft::set_dft_config_max_chains $max_chains
+    dft::set_dft_config_max_chains $test_mode $max_chains
   }
 
   if { [info exists keys(-clock_mixing)] } {
     set clock_mixing $keys(-clock_mixing)
-    dft::set_dft_config_clock_mixing $clock_mixing
+    dft::set_dft_config_clock_mixing $test_mode $clock_mixing
   }
 
   foreach {flag signal} {
@@ -114,7 +123,7 @@ proc set_dft_config { args } {
     -scan_out_name_pattern "scan_out"
   } {
     if { [info exists keys($flag)] } {
-      dft::set_dft_config_scan_signal_name_pattern $signal $keys($flag)
+      dft::set_dft_config_scan_signal_name_pattern $test_mode $signal $keys($flag)
     }
   }
 }
@@ -123,4 +132,26 @@ sta::define_cmd_args "report_dft_config" { }
 proc report_dft_config { args } {
   sta::parse_key_args "report_dft_config" args keys {} flags {}
   dft::report_dft_config
+}
+
+
+sta::define_cmd_args "create_dft_test_mode" { [-test_mode test_mode] }
+proc create_dft_test_mode { args } {
+  sta::parse_key_args "create_dft_test_mode" args \
+    keys {
+      -test_mode
+      -max_length
+      -max_chains
+      -clock_mixing
+      -scan_enable_name_pattern
+      -scan_in_name_pattern
+      -scan_out_name_pattern
+    } \
+    flags {}
+  sta::check_argc_eq0 "create_dft_test_mode" $args
+
+  if { [info exists keys(-test_mode)] } {
+    set test_mode $keys(-test_mode)
+    dft::create_dft_test_mode $test_mode;
+  }
 }

--- a/src/dft/test/max_chain_count_sky130.ok
+++ b/src/dft/test/max_chain_count_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 1
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/one_cell_sky130.ok
+++ b/src/dft/test/one_cell_sky130.ok
@@ -29,6 +29,7 @@ Instance ff1
   Q_N output (unconnected)
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 1
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/place_sort_sky130.ok
+++ b/src/dft/test/place_sort_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 1
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/scan_architect_clock_mix_sky130.ok
+++ b/src/dft/test/scan_architect_clock_mix_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 7
 Clock domain: Clock Mix
 ***************************

--- a/src/dft/test/scan_architect_no_mix_sky130.ok
+++ b/src/dft/test/scan_architect_no_mix_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 4
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/scan_architect_register_bank_no_clock_mix_sky130.ok
+++ b/src/dft/test/scan_architect_register_bank_no_clock_mix_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 2
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/sub_modules_sky130.ok
+++ b/src/dft/test/sub_modules_sky130.ok
@@ -2,6 +2,7 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
 ***************************
 Preview DFT Report
+Test mode: default
 Number of chains: 1
 Clock domain: No Mix
 ***************************

--- a/src/dft/test/sub_modules_sky130.tcl
+++ b/src/dft/test/sub_modules_sky130.tcl
@@ -9,6 +9,8 @@ link_design sub_modules
 
 create_clock -name main_clock -period 2.0000 -waveform {0.0000 1.0000} [get_ports {clock}]
 
+set_dft_config -max_chains 1
+
 scan_replace
 preview_dft -verbose
 insert_dft


### PR DESCRIPTION
This is a refactoring change + public API change where we start supporting different tests modes. The test mode currently does nothing except for independendly architect and stitch each test mode.

In the future, different tests modes may have different types of scan (ex: internal scan, scan compression, boundary scan, etc) and may support to include/exclude cells in certain modes.