### PR TITLE
removed dbBlock::duplicate which causes memory corruption issues

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1729,17 +1729,6 @@ class dbBlock : public dbObject
                          char hier_delimeter = 0);
 
   ///
-  /// duplicate - Make a duplicate of the specified "child" block. If name ==
-  /// nullptr, the name of the block is also duplicated. If the duplicated block
-  /// does not have a unique name, then "findChild" may return an incorrect
-  /// block. UNIQUE child-block-names are not enforced! (This should be fixed)!
-  ///
-  /// A top-block can not be duplicated. This methods returns nullptr if the
-  /// specified block has not parent.
-  ///
-  static dbBlock* duplicate(dbBlock* block, const char* name = nullptr);
-
-  ///
   /// Translate a database-id back to a pointer.
   ///
   static dbBlock* getBlock(dbChip* chip, uint oid);

--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -3158,34 +3158,6 @@ dbBlock* dbBlock::create(dbBlock* parent_,
   return (dbBlock*) child;
 }
 
-dbBlock* dbBlock::duplicate(dbBlock* child_, const char* name_)
-{
-  _dbBlock* child = (_dbBlock*) child_;
-
-  // must be a child block
-  if (child->_parent == 0) {
-    return nullptr;
-  }
-
-  _dbBlock* parent = (_dbBlock*) child_->getParent();
-  _dbChip* chip = (_dbChip*) child->getOwner();
-
-  // make a copy
-  _dbBlock* dup = chip->_block_tbl->duplicate(child);
-
-  // link child-to-parent
-  parent->_children.push_back(dup->getOID());
-  dup->_parent = parent->getOID();
-
-  if (name_ && dup->_name) {
-    free((void*) dup->_name);
-    dup->_name = strdup(name_);
-    ZALLOCATED(dup->_name);
-  }
-
-  return (dbBlock*) dup;
-}
-
 dbBlock* dbBlock::getBlock(dbChip* chip_, uint dbid_)
 {
   _dbChip* chip = (_dbChip*) chip_;


### PR DESCRIPTION
Removed the dbBlock::duplicate method, which causes memory corruptions when used in the context of a Python unit test that destroys the DB as part of the tearDown method. The duplicate method doesn't appear to be used in any other OR code after checking *.c*, *.h*, *.i, *.tcl, and *.py files.