### PR TITLE
Updated ODB c++ tests to only be handled via cpp_tests.tcl

### DIFF
--- a/src/odb/test/cpp/CMakeLists.txt
+++ b/src/odb/test/cpp/CMakeLists.txt
@@ -49,22 +49,17 @@ target_link_libraries(TestMaster ${TEST_LIBS})
 target_link_libraries(TestGDSIn gdsin odb_test_helper)
 #target_link_libraries(TestXML gdsin odb_test_helper)
 
-# FAILING TARGETS
-# add_test(NAME TestLef58Properties COMMAND TestLef58Properties)
-# add_test(NAME TestJournal COMMAND TestJournal)
-# add_test(NAME TestAccessPoint COMMAND TestAccessPoint)
-
+# Skip the tests from being registered here, since they are called via
+# cpp_tests.tcl and don't need to be executed twice. The cpp_tests.tcl
+# invocation is preferred for TestLef58Properties, TestJournal, and
+# TestAccessPoint, since they all write/read from the disk and calling them with
+# BASE_DIR set allows us to write to the results dir. Running them outside of
+# cpp_tests.tcl results in the output files being written in the current working
+# directory.
 gtest_discover_tests(OdbGTests
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+    TEST_FILTER "-TestAccessPoint.*,-TestCallBacks.*,-TestGCellGrid.*,-TestGeom.*,-TestGroup.*,-TestGuide.*,-TestJournal.*-TestLef58Properties.*,-TestMaster.*,-TestModule.*,-TestNetTrack.*"
 )
-add_test(NAME odb.TestCallBacks COMMAND TestCallBacks)
-add_test(NAME odb.TestGeom COMMAND TestGeom)
-add_test(NAME odb.TestModule COMMAND TestModule)
-add_test(NAME odb.TestGroup COMMAND TestGroup)
-add_test(NAME odb.TestGCellGrid COMMAND TestGCellGrid)
-add_test(NAME odb.TestGuide COMMAND TestGuide)
-add_test(NAME odb.TestNetTrack COMMAND TestNetTrack)
-add_test(NAME odb.TestMaster COMMAND TestMaster)
 
 add_dependencies(build_and_test 
         TestCallBacks 

--- a/src/odb/test/cpp/scan/CMakeLists.txt
+++ b/src/odb/test/cpp/scan/CMakeLists.txt
@@ -21,6 +21,15 @@ set(TEST_LIBS
 add_executable(TestScanChain TestScanChain.cpp)
 target_link_libraries(TestScanChain ${TEST_LIBS})
 
-gtest_discover_tests(TestScanChain WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+# Skip TestScanChain tests since they are called via cpp_tests.tcl, which is
+# preferred since BASE_DIR is set and the output files are written to the
+# results dir. Running TestScanChain outside of cpp_tests.tcl results in the
+# output files being written in the current working directory
+#
+gtest_discover_tests(TestScanChain
+    WORKING_DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    TEST_FILTER "-TestScanChain.CreateScanChain*"
+)
 
 add_dependencies(build_and_test TestScanChain)


### PR DESCRIPTION
Excluding the ODB c++ tests from CMake registration prevents a couple of issues:

1. Tests were being called twice: once from cpp_tests.tcl and once outside of it
2. Any test that writes/reads from the disk either fails or writes the output to the current working directory and not the results directory as intended

Addresses https://github.com/The-OpenROAD-Project/OpenROAD/issues/6388