### PR TITLE
mpl2: ignore fixed instances

### DIFF
--- a/src/mpl2/src/clusterEngine.cpp
+++ b/src/mpl2/src/clusterEngine.cpp
@@ -734,19 +734,18 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
 }
 
 /* static */
-// Instances that should not be touched i.e., have their location
+// Instance that should not be touched i.e., have its location
 // altered by the macro placer.
-//
-// Obs:
-// - IO corners are sometimes marked as end caps.
-// - Markers used in designs with IO Pads are FIRM
-//   at this point and they should not be touched.
+// Note: This function also takes into account the placement status
+// of the instance, because, if it is placed outside the area that is
+// used for the macro placement, it can be safely ignored as there's
+// no risk to generate overlap.
 bool ClusteringEngine::isIgnoredInst(odb::dbInst* inst)
 {
   odb::dbMaster* master = inst->getMaster();
 
   return master->isPad() || master->isCover() || master->isEndCap()
-         || inst->getPlacementStatus() == odb::dbPlacementStatus::FIRM;
+         || inst->isFixed();
 }
 
 // Forward or Backward DFS search to find sequential paths from/to IO pins based

--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -256,7 +256,7 @@ class ClusteringEngine
   void printPhysicalHierarchyTree(Cluster* parent, int level);
   float computeMicronArea(odb::dbInst* inst);
 
-  static bool isIgnoredMaster(odb::dbMaster* master);
+  static bool isIgnoredInst(odb::dbInst* inst);
 
   odb::dbBlock* block_;
   sta::dbNetwork* network_;

--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -170,6 +170,8 @@ class ClusteringEngine
                                std::set<odb::dbMaster*>& masters);
   void clearTempMacroClusterMapping(const UniqueClusterVector& macro_clusters);
 
+  static bool isIgnoredInst(odb::dbInst* inst);
+
  private:
   using UniqueClusterQueue = std::queue<std::unique_ptr<Cluster>>;
 
@@ -255,8 +257,6 @@ class ClusteringEngine
 
   void printPhysicalHierarchyTree(Cluster* parent, int level);
   float computeMicronArea(odb::dbInst* inst);
-
-  static bool isIgnoredInst(odb::dbInst* inst);
 
   odb::dbBlock* block_;
   sta::dbNetwork* network_;

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -3995,7 +3995,7 @@ void HierRTLMP::flipRealMacro(odb::dbInst* macro, const bool& is_vertical_flip)
 void HierRTLMP::adjustRealMacroOrientation(const bool& is_vertical_flip)
 {
   for (odb::dbInst* inst : block_->getInsts()) {
-    if (!inst->isBlock()) {
+    if (!inst->isBlock() || ClusteringEngine::isIgnoredInst(inst)) {
       continue;
     }
 


### PR DESCRIPTION
Needs #6547
Resolve #6092 

Needed to switch from manual macro placement to automated macro placement in gf12/bp_single.
Note that I also needed to include the ignore check in the Orientation Improvement step.