### PR TITLE
mpl2: do not allow fixed instances inside floorplan area

### DIFF
--- a/src/mpl2/src/clusterEngine.h
+++ b/src/mpl2/src/clusterEngine.h
@@ -117,6 +117,8 @@ struct PhysicalHierarchy
   float halo_width{0.0f};
   float halo_height{0.0f};
   float macro_with_halo_area{0.0f};
+  Rect global_fence;
+  Rect floorplan_shape;
 
   bool has_io_clusters{true};
   bool has_only_macros{false};
@@ -176,9 +178,11 @@ class ClusteringEngine
   void init();
   Metrics* computeModuleMetrics(odb::dbModule* module);
   std::vector<odb::dbInst*> getUnfixedMacros();
+  void setFloorplanShape();
+  void searchForFixedInstsInsideFloorplanShape();
   float computeMacroWithHaloArea(
       const std::vector<odb::dbInst*>& unfixed_macros);
-  void reportDesignData(float core_area);
+  void reportDesignData();
   void createRoot();
   void setBaseThresholds();
   void createIOClusters();

--- a/src/mpl2/src/hier_rtlmp.cpp
+++ b/src/mpl2/src/hier_rtlmp.cpp
@@ -129,10 +129,7 @@ void HierRTLMP::setGlobalFence(float fence_lx,
                                float fence_ux,
                                float fence_uy)
 {
-  global_fence_lx_ = fence_lx;
-  global_fence_ly_ = fence_ly;
-  global_fence_ux_ = fence_ux;
-  global_fence_uy_ = fence_uy;
+  tree_->global_fence = Rect(fence_lx, fence_ly, fence_ux, fence_uy);
 }
 
 void HierRTLMP::setHaloWidth(float halo_width)
@@ -370,31 +367,15 @@ void HierRTLMP::setRootShapes()
 {
   auto root_soft_macro = std::make_unique<SoftMacro>(tree_->root.get());
 
-  const float core_lx
-      = static_cast<float>(block_->dbuToMicrons(block_->getCoreArea().xMin()));
-  const float root_lx = std::max(core_lx, global_fence_lx_);
-
-  const float core_ly
-      = static_cast<float>(block_->dbuToMicrons(block_->getCoreArea().yMin()));
-  const float root_ly = std::max(core_ly, global_fence_ly_);
-
-  const float core_ux
-      = static_cast<float>(block_->dbuToMicrons(block_->getCoreArea().xMax()));
-  const float root_ux = std::min(core_ux, global_fence_ux_);
-
-  const float core_uy
-      = static_cast<float>(block_->dbuToMicrons(block_->getCoreArea().yMax()));
-  const float root_uy = std::min(core_uy, global_fence_uy_);
-
-  const float root_area = (root_ux - root_lx) * (root_uy - root_ly);
-  const float root_width = root_ux - root_lx;
+  const float root_area = tree_->floorplan_shape.getArea();
+  const float root_width = tree_->floorplan_shape.getWidth();
   const std::vector<std::pair<float, float>> root_width_list
       = {std::pair<float, float>(root_width, root_width)};
 
   root_soft_macro->setShapes(root_width_list, root_area);
   root_soft_macro->setWidth(root_width);  // This will set height automatically
-  root_soft_macro->setX(root_lx);
-  root_soft_macro->setY(root_ly);
+  root_soft_macro->setX(tree_->floorplan_shape.xMin());
+  root_soft_macro->setY(tree_->floorplan_shape.yMin());
   tree_->root->setSoftMacro(std::move(root_soft_macro));
 }
 

--- a/src/mpl2/src/hier_rtlmp.h
+++ b/src/mpl2/src/hier_rtlmp.h
@@ -272,12 +272,6 @@ class HierRTLMP
   std::string report_directory_;
   std::string macro_placement_file_;
 
-  // User can specify a global region for some designs
-  float global_fence_lx_ = std::numeric_limits<float>::max();
-  float global_fence_ly_ = std::numeric_limits<float>::max();
-  float global_fence_ux_ = 0.0;
-  float global_fence_uy_ = 0.0;
-
   const int num_runs_ = 10;    // number of runs for SA
   int num_threads_ = 10;       // number of threads
   const int random_seed_ = 0;  // random seed for deterministic

--- a/src/mpl2/src/object.h
+++ b/src/mpl2/src/object.h
@@ -629,12 +629,12 @@ struct Rect
   float yMax() const { return uy; }
 
   float getX() const { return (lx + ux) / 2.0; }
-
   float getY() const { return (ly + uy) / 2.0; }
 
   float getWidth() const { return ux - lx; }
-
   float getHeight() const { return uy - ly; }
+
+  float getArea() const { return getWidth() * getHeight(); }
 
   void setLoc(float x,
               float y,

--- a/src/mpl2/test/guides1.ok
+++ b/src/mpl2/test/guides1.ok
@@ -13,7 +13,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO PPL-0003] Number of I/O w/sink      0
 [INFO PPL-0004] Number of I/O w/o sink    3
 [INFO PPL-0012] I/O nets HPWL: 0.00 um.
-Floorplan Outline: (0, 0) (150, 125),  Core Outline: (0, 0) (149.91, 124.6)
+Die Area: (0, 0) (150, 125),  Floorplan Area: (0, 0) (149.91, 124.6)
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.79
 	Number of macros: 1
@@ -22,9 +22,9 @@ Floorplan Outline: (0, 0) (150, 125),  Core Outline: (0, 0) (149.91, 124.6)
 	Halo height: 4.00
 	Area of macros with halos: 11664.00
 	Area of std cell instances + Area of macros: 11808.79
-	Core area: 18678.79
+	Floorplan area: 18678.79
 	Design Utilization: 0.63
-	Core Utilization: 0.21
+	Floorplan Utilization: 0.21
 	Manufacturing Grid: 10
 
 [WARNING MPL-0014] No Liberty data found for std cells. Continuing without dataflow.

--- a/src/mpl2/test/guides2.ok
+++ b/src/mpl2/test/guides2.ok
@@ -3,7 +3,7 @@
 [WARNING STA-1171] ./testcases/macro_only.lib line 32, default_max_transition is 0.0.
 [INFO ODB-0128] Design: macro_only
 [INFO ODB-0253]     Updated 10 components.
-Floorplan Outline: (0, 0) (450, 450),  Core Outline: (4.94, 4.2) (444.98, 443.8)
+Die Area: (0, 0) (450, 450),  Floorplan Area: (4.94, 4.2) (444.98, 443.8)
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 10
@@ -12,9 +12,9 @@ Floorplan Outline: (0, 0) (450, 450),  Core Outline: (4.94, 4.2) (444.98, 443.8)
 	Halo height: 4.00
 	Area of macros with halos: 187920.00
 	Area of std cell instances + Area of macros: 166000.00
-	Core area: 193441.58
+	Floorplan area: 193441.58
 	Design Utilization: 0.86
-	Core Utilization: 0.00
+	Floorplan Utilization: 0.00
 	Manufacturing Grid: 10
 
 [WARNING MPL-0026] Design has no IO pins!

--- a/src/mpl2/test/macro_only.ok
+++ b/src/mpl2/test/macro_only.ok
@@ -3,7 +3,7 @@
 [WARNING STA-1171] ./testcases/macro_only.lib line 32, default_max_transition is 0.0.
 [INFO ODB-0128] Design: macro_only
 [INFO ODB-0253]     Updated 10 components.
-Floorplan Outline: (0, 0) (450, 450),  Core Outline: (4.94, 4.2) (444.98, 443.8)
+Die Area: (0, 0) (450, 450),  Floorplan Area: (4.94, 4.2) (444.98, 443.8)
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00
 	Number of macros: 10
@@ -12,9 +12,9 @@ Floorplan Outline: (0, 0) (450, 450),  Core Outline: (4.94, 4.2) (444.98, 443.8)
 	Halo height: 4.00
 	Area of macros with halos: 187920.00
 	Area of std cell instances + Area of macros: 166000.00
-	Core area: 193441.58
+	Floorplan area: 193441.58
 	Design Utilization: 0.86
-	Core Utilization: 0.00
+	Floorplan Utilization: 0.00
 	Manufacturing Grid: 10
 
 [WARNING MPL-0026] Design has no IO pins!


### PR DESCRIPTION
Based on the discussion in #6543 so that we can ignore fixed instances.

Also changing the feasibility of the macro placement to be based on the area computed using the global fence instead of directly the core.
