### PR TITLE
dbSta: Add -module option to report_cell_usage

### DIFF
--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -79,25 +79,27 @@ proc highlight_path { args } {
   }
 }
 
-define_cmd_args "report_cell_usage" {[-verbose] [module_inst]}
+define_cmd_args "report_cell_usage" {\
+	                             [-verbose] \
+	                             [-module]
+	                            }
 
 proc report_cell_usage { args } {
-  parse_key_args "highlight_path" args keys {} \
+  parse_key_args "highlight_path" args keys {-module} \
     flags {-verbose} 0
-
-  check_argc_eq0or1 "report_cell_usage" $args
 
   if { [ord::get_db_block] == "NULL" } {
     sta_error 1001 "No design block found."
   }
 
   set module [[ord::get_db_block] getTopModule]
-  if { $args != "" } {
-    set modinst [[ord::get_db_block] findModInst $args]
-    if { $modinst == "NULL" } {
-      sta_error 1002 "Unable to find $args"
+  if { [info exists keys(-module)] } {
+    set module_inst_name $keys(-module)
+    set module_inst [[ord::get_db_block] findModInst $module_inst_name ]
+    if { $module_inst == "NULL" } {
+      sta_error 1002 "Unable to find $module_inst_name"
     }
-    set module [$modinst getMaster]
+    set module [$module_inst getMaster]
   }
 
   report_cell_usage_cmd $module [info exists flags(-verbose)]

--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -88,6 +88,8 @@ proc report_cell_usage { args } {
   parse_key_args "highlight_path" args keys {-module} \
     flags {-verbose} 0
 
+  check_argc_eq0or1 "report_cell_usage" $args
+
   if { [ord::get_db_block] == "NULL" } {
     sta_error 1001 "No design block found."
   }

--- a/src/dbSta/test/report_cell_usage_modinsts.tcl
+++ b/src/dbSta/test/report_cell_usage_modinsts.tcl
@@ -8,5 +8,5 @@ link_design top
 
 report_cell_usage -verbose
 
-report_cell_usage -verbose b1
-report_cell_usage -verbose b2
+report_cell_usage -verbose -module b1
+report_cell_usage -verbose -module b2

--- a/src/dbSta/test/report_cell_usage_modinsts_metrics.tcl
+++ b/src/dbSta/test/report_cell_usage_modinsts_metrics.tcl
@@ -12,8 +12,8 @@ utl::open_metrics $metrics
 
 report_cell_usage -verbose
 
-report_cell_usage -verbose b1
-report_cell_usage -verbose b2
+report_cell_usage -verbose -module b1
+report_cell_usage -verbose -module b2
 
 utl::close_metrics $metrics
 

--- a/src/odb/test/replace_design2.tcl
+++ b/src/odb/test/replace_design2.tcl
@@ -19,12 +19,12 @@ create_clock -name CLK -period 1 clk
 set_max_delay -to carry_out 1.0
 
 report_checks -through _carry_out_and_/C -field input
-report_cell_usage _551_
+report_cell_usage -module _551_
 
 #set_debug_level ODB replace_design 1
 replace_design _551_ LCU_16_KOGGE_STONE
 
 report_checks -through _carry_out_and_/C -field input
-report_cell_usage _551_
+report_cell_usage -module _551_
 
 run_equivalence_test replace_design2 ./Nangate45/work_around_yosys/ "None"

--- a/src/odb/test/replace_design3.tcl
+++ b/src/odb/test/replace_design3.tcl
@@ -28,12 +28,12 @@ create_clock -name CLK -period 1 clk
 set_max_delay -to carry_out 1.0
 
 report_checks -through gcd_1/_carry_out_and_/B -fields input_pins
-report_cell_usage gcd_1/_552_
+report_cell_usage -module gcd_1/_552_
 
 replace_design gcd_1/_552_ LCU_16_KOGGE_STONE
 replace_design gcd_1/_552_ LCU_16_BRENT_KUNG
 
 report_checks -through gcd_1/_carry_out_and_/B -fields input_pins
-report_cell_usage gcd_1/_552_
+report_cell_usage -module gcd_1/_552_
 
 run_equivalence_test replace_design3 ./Nangate45/work_around_yosys/ "None"


### PR DESCRIPTION
As discussed before, we will introduce another few options to report_cell_usage. As a prerequisite, we need to add a "-module" option to the current report_cell_usage.