### PR TITLE
Update(Doc): Missing bracket in Tool Flow Namespace Section

### DIFF
--- a/docs/contrib/DeveloperGuide.md
+++ b/docs/contrib/DeveloperGuide.md
@@ -272,7 +272,7 @@ Tool namespaces are usually three-lettered lowercase letters.
 - Metal fill insertion ([fin](../main/src/fin/README.md))
 - Design for Test ([dft](../main/src/dft/README.md))
 - OpenRCX Parasitic Extraction ([rcx](../main/src/rcx/README.md))
-- OpenSTA timing/power analyzer ([sta](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/README.md)
+- OpenSTA timing/power analyzer ([sta](https://github.com/The-OpenROAD-Project/OpenSTA/blob/master/README.md))
 - Graphical User Interface ([gui](../main/src/gui/README.md))
 - Static IR analyzer ([psm](../main/src/psm/README.md))
 


### PR DESCRIPTION
Small typo, missing right bracket when referencing OpenSTA.

In HTML:
![Screenshot 2025-01-22 at 17 52 20](https://github.com/user-attachments/assets/476db3b4-310c-40bb-b9bb-5dfc227b04f5)
