### PR TITLE
Cts don't insert delay for clustering buffers

### DIFF
--- a/src/cts/include/cts/TritonCTS.h
+++ b/src/cts/include/cts/TritonCTS.h
@@ -240,7 +240,7 @@ class TritonCTS
   std::map<ClockInst*, ClockSubNet*> driver2subnet_;
 
   // db vars
-  odb::dbDatabase* db_;
+  odb::dbDatabase* db_ = nullptr;
   odb::dbBlock* block_ = nullptr;
   unsigned numberOfClocks_ = 0;
   unsigned numClkNets_ = 0;

--- a/src/cts/src/HTreeBuilder.cpp
+++ b/src/cts/src/HTreeBuilder.cpp
@@ -193,7 +193,6 @@ void HTreeBuilder::preSinkClustering(
       std::vector<ClockInst*> clusterClockInsts;  // sink clock insts
       float xSum = 0;
       float ySum = 0;
-      double insDelay = 0.0;
       for (auto point_idx : cluster) {
         const std::pair<double, double>& point = points[point_idx];
         const Point<double> mapPoint(point.first, point.second);


### PR DESCRIPTION
This PR removes the insertion delay added to the clustering buffers.

For designs with macros clustered together the delay inserted caused the clustering buffers to be placed outside of the die area causing problems during the legalization. 