### PR TITLE
mpl: add support for IO Pads

### DIFF
--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -302,7 +302,7 @@ void SimulatedAnnealingCore<T>::calWirelength()
     T& source = macros_[net.terminals.first];
     T& target = macros_[net.terminals.second];
 
-    if (target.isIOCluster()) {
+    if (target.isClusterOfUnplacedIOPins()) {
       addBoundaryDistToWirelength(source, target, net.weight);
       continue;
     }

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -65,10 +65,11 @@ void ClusteringEngine::run()
   createRoot();
   setBaseThresholds();
 
+  mapIOPinsAndPads();
+  createDataFlow();
+
   createIOClusters();
   classifyBoundariesStateForIOs();
-
-  createDataFlow();
 
   if (design_metrics_->getNumStdCell() == 0) {
     logger_->warn(MPL, 25, "Design has no standard cells!");
@@ -357,13 +358,20 @@ void ClusteringEngine::setBaseThresholds()
       tree_->base_min_std_cell);
 }
 
-// Group IOs with the same constraints:
-// 1. If an IO has a constraint region in a certain boundary,
-//    it is constrained to that entire boundary.
-// 2. If an IO has no constraints, it is constrained to all boundaries.
+// An IO Cluster may represent:
+// 1. A Group of Unplaced Pins;
+// 2. An IO Pad.
+//
+// For the former, we group IO pins with the same constraints based on:
+// - If an IO pin has a constraint region in a certain boundary,
+//   it is constrained to that entire boundary;
+// - If an IO pin has no constraints, it is constrained to all boundaries.
 void ClusteringEngine::createIOClusters()
 {
-  mapIOPads();
+  if (!tree_->maps.pad_to_bterm.empty()) {
+    createIOPadClusters();
+    return;
+  }
 
   // Boundary with constrained IOs -> cluster
   std::map<Boundary, Cluster*> boundary_to_cluster;
@@ -434,7 +442,7 @@ void ClusteringEngine::createIOCluster(
     setIOClusterDimensions(die, constraint_boundary, x, y, width, height);
   }
 
-  cluster->setAsIOCluster(
+  cluster->setAsClusterOfUnplacedIOPins(
       std::pair<float, float>(block_->dbuToMicrons(x), block_->dbuToMicrons(y)),
       block_->dbuToMicrons(width),
       block_->dbuToMicrons(height),
@@ -512,7 +520,7 @@ void ClusteringEngine::setIOClusterDimensions(const odb::Rect& die,
   }
 }
 
-void ClusteringEngine::mapIOPads()
+void ClusteringEngine::mapIOPinsAndPads()
 {
   bool design_has_io_pads = false;
   for (auto inst : block_->getInsts()) {
@@ -531,15 +539,54 @@ void ClusteringEngine::mapIOPads()
       continue;
     }
 
-    // If the design has IO pads, there is a net
-    // connecting the IO pin and IO pad instance
     for (odb::dbBTerm* bterm : net->getBTerms()) {
       for (odb::dbITerm* iterm : net->getITerms()) {
         odb::dbInst* inst = iterm->getInst();
-        tree_->maps.bterm_to_inst[bterm] = inst;
+        tree_->maps.pad_to_bterm[inst] = bterm;
+        tree_->maps.bterm_to_pad[bterm] = inst;
       }
     }
   }
+}
+
+void ClusteringEngine::createIOPadClusters()
+{
+  for (const auto& io_pad_path : data_connections_.io_and_regs) {
+    // Registers or Macros
+    const PathInsts& connected_insts = io_pad_path.second;
+    bool path_is_empty = true;
+    for (const std::set<odb::dbInst*>& insts_of_curr_hop_dist :
+         connected_insts) {
+      if (!insts_of_curr_hop_dist.empty()) {
+        path_is_empty = false;
+        break;
+      }
+    }
+
+    if (path_is_empty) {
+      continue;
+    }
+
+    odb::dbBTerm* bterm = io_pad_path.first;
+    odb::dbInst* pad = tree_->maps.bterm_to_pad.at(bterm);
+
+    createIOPadCluster(pad, bterm);
+  }
+}
+
+void ClusteringEngine::createIOPadCluster(odb::dbInst* pad, odb::dbBTerm* bterm)
+{
+  auto cluster = std::make_unique<Cluster>(id_, pad->getName(), logger_);
+  tree_->maps.bterm_to_cluster_id[bterm] = id_;
+  tree_->maps.id_to_cluster[id_++] = cluster.get();
+
+  const odb::Rect& pad_bbox = pad->getBBox()->getBox();
+
+  cluster->setAsIOPadCluster({block_->dbuToMicrons(pad_bbox.xMin()),
+                              block_->dbuToMicrons(pad_bbox.yMin())},
+                             block_->dbuToMicrons(pad_bbox.dx()),
+                             block_->dbuToMicrons(pad_bbox.dy()));
+  tree_->root->addChild(std::move(cluster));
 }
 
 // Dataflow is used to improve quality of macro placement.
@@ -682,23 +729,25 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
   graph.backward_vertices.resize(num_of_vertices);
 
   for (odb::dbNet* net : block_->getNets()) {
-    if (net->getSigType().isSupply()) {
+    if (!isValidNet(net)) {
       continue;
     }
 
     int driver_id = -1;
     std::set<int> loads_id;
-    bool ignore = false;
+    bool net_has_stdcell_without_liberty = false;
     for (odb::dbITerm* iterm : net->getITerms()) {
       odb::dbInst* inst = iterm->getInst();
-      if (isIgnoredInst(inst)) {
-        ignore = true;
-        break;
-      }
-
       int vertex_id = -1;
+
       if (inst->isBlock()) {
         vertex_id = odb::dbIntProperty::find(iterm, "vertex_id")->getValue();
+      } else if (inst->isPad()) {
+        // To properly consider the path of a signal that travels from a PAD
+        // to the core we use the path's bterm as the vertex.
+        odb::dbBTerm* pad_bterm = tree_->maps.pad_to_bterm.at(inst);
+        vertex_id
+            = odb::dbIntProperty::find(pad_bterm, "vertex_id")->getValue();
       } else {
         odb::dbIntProperty* int_prop
             = odb::dbIntProperty::find(inst, "vertex_id");
@@ -707,7 +756,7 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
         if (int_prop) {
           vertex_id = int_prop->getValue();
         } else {
-          ignore = true;
+          net_has_stdcell_without_liberty = true;
           break;
         }
       }
@@ -719,7 +768,7 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
       }
     }
 
-    if (ignore) {
+    if (net_has_stdcell_without_liberty) {
       continue;
     }
 
@@ -1733,21 +1782,15 @@ void ClusteringEngine::updateConnections()
   }
 
   for (odb::dbNet* net : block_->getNets()) {
-    if (net->getSigType().isSupply()) {
+    if (!isValidNet(net)) {
       continue;
     }
 
     int driver_cluster_id = -1;
     std::vector<int> load_clusters_ids;
-    bool net_has_pad_or_cover = false;
 
     for (odb::dbITerm* iterm : net->getITerms()) {
       odb::dbInst* inst = iterm->getInst();
-      if (isIgnoredInst(inst)) {
-        net_has_pad_or_cover = true;
-        break;
-      }
-
       const int cluster_id = tree_->maps.inst_to_cluster_id.at(inst);
 
       if (iterm->getIoType() == odb::dbIoType::OUTPUT) {
@@ -1755,10 +1798,6 @@ void ClusteringEngine::updateConnections()
       } else {
         load_clusters_ids.push_back(cluster_id);
       }
-    }
-
-    if (net_has_pad_or_cover) {
-      continue;
     }
 
     bool net_has_io_pin = false;
@@ -1787,6 +1826,21 @@ void ClusteringEngine::updateConnections()
       }
     }
   }
+}
+
+bool ClusteringEngine::isValidNet(odb::dbNet* net)
+{
+  if (net->getSigType().isSupply()) {
+    return false;
+  }
+
+  for (odb::dbITerm* iterm : net->getITerms()) {
+    if (!isIgnoredInst(iterm->getInst())) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void ClusteringEngine::fetchMixedLeaves(
@@ -2162,7 +2216,7 @@ void ClusteringEngine::printPhysicalHierarchyTree(Cluster* parent, int level)
                       parent->getId(),
                       parent->getClusterTypeString());
 
-  if (parent->isIOCluster()) {
+  if (parent->isClusterOfUnplacedIOPins()) {
     int number_of_pins = 0;
     for (const auto [pin, cluster_id] : tree_->maps.bterm_to_cluster_id) {
       if (cluster_id == parent->getId()) {
@@ -2171,7 +2225,7 @@ void ClusteringEngine::printPhysicalHierarchyTree(Cluster* parent, int level)
     }
 
     line += fmt::format(" Pins: {}", number_of_pins);
-  } else {
+  } else if (!parent->isIOPadCluster()) {
     line += fmt::format(" {}, StdCells: {} ({} μ²), Macros: {} ({} μ²)",
                         parent->getIsLeafString(),
                         parent->getNumStdCell(),

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -444,7 +444,7 @@ void Graphics::drawObjects(gui::Painter& painter)
       continue;
     }
 
-    if (cluster->isIOCluster()) {
+    if (cluster->isClusterOfUnplacedIOPins()) {
       continue;
     }
 
@@ -607,7 +607,7 @@ void Graphics::drawBundledNets(gui::Painter& painter,
     const T& source = macros[bundled_net.terminals.first];
     const T& target = macros[bundled_net.terminals.second];
 
-    if (target.isIOCluster()) {
+    if (target.isClusterOfUnplacedIOPins()) {
       drawDistToIoConstraintBoundary(painter, source, target);
       continue;
     }

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -914,17 +914,20 @@ void HierRTLMP::setTightPackingTilings(Cluster* macro_array)
 
 void HierRTLMP::setPinAccessBlockages()
 {
-  if (!tree_->maps.bterm_to_inst.empty()) {
+  if (!tree_->maps.pad_to_bterm.empty()) {
     return;
   }
 
-  std::vector<Cluster*> io_clusters = getIOClusters();
+  std::vector<Cluster*> clusters_of_unplaced_io_pins
+      = getClustersOfUnplacedIOPins();
   const Rect die = dbuToMicrons(block_->getDieArea());
 
-  const float depth = computePinAccessBlockagesDepth(io_clusters, die);
+  const float depth
+      = computePinAccessBlockagesDepth(clusters_of_unplaced_io_pins, die);
 
-  for (Cluster* io_cluster : io_clusters) {
-    Boundary constraint_boundary = io_cluster->getConstraintBoundary();
+  for (Cluster* cluster_of_unplaced_io_pins : clusters_of_unplaced_io_pins) {
+    Boundary constraint_boundary
+        = cluster_of_unplaced_io_pins->getConstraintBoundary();
     if (constraint_boundary != NONE) {
       createPinAccessBlockage(constraint_boundary, depth, die);
     }
@@ -978,17 +981,17 @@ void HierRTLMP::createPinAccessBlockage(Boundary constraint_boundary,
   macro_blockages_.push_back(blockage);
 }
 
-std::vector<Cluster*> HierRTLMP::getIOClusters()
+std::vector<Cluster*> HierRTLMP::getClustersOfUnplacedIOPins()
 {
-  std::vector<Cluster*> io_clusters;
+  std::vector<Cluster*> clusters_of_unplaced_io_pins;
 
   for (const auto& child : tree_->root->getChildren()) {
-    if (child->isIOCluster()) {
-      io_clusters.push_back(child.get());
+    if (child->isClusterOfUnplacedIOPins()) {
+      clusters_of_unplaced_io_pins.push_back(child.get());
     }
   }
 
-  return io_clusters;
+  return clusters_of_unplaced_io_pins;
 }
 
 // The depth of pin access blockages is computed based on:
@@ -2268,10 +2271,11 @@ void HierRTLMP::runHierarchicalMacroPlacementWithoutBusPlanning(Cluster* parent)
               cluster->getName(),
               0.0,
               0.0,
-              // The information of whether or not a cluster is an IO cluster is
-              // needed inside the SA Core, so if a fixed terminal corresponds
-              // to an IO Cluster it needs to contains that cluster data.
-              cluster->isIOCluster() ? cluster.get() : nullptr);
+              // The information of whether or not a cluster is a group of
+              // unplaced IO pins is needed inside the SA Core, so if a fixed
+              // terminal corresponds to a cluster of unplaced IO pins it needs
+              // to contain that cluster data.
+              cluster->isClusterOfUnplacedIOPins() ? cluster.get() : nullptr);
           debugPrint(
               logger_,
               MPL,
@@ -2772,10 +2776,11 @@ void HierRTLMP::runEnhancedHierarchicalMacroPlacement(Cluster* parent)
               cluster->getName(),
               0.0,
               0.0,
-              // The information of whether or not a cluster is an IO cluster is
-              // needed inside the SA Core, so if a fixed terminal corresponds
-              // to an IO Cluster it needs to contains that cluster data.
-              cluster->isIOCluster() ? cluster.get() : nullptr);
+              // The information of whether or not a cluster is a group of
+              // unplaced IO pins is needed inside the SA Core, so if a fixed
+              // terminal corresponds to a cluster of unplaced IO pins it needs
+              // to contain that cluster data.
+              cluster->isClusterOfUnplacedIOPins() ? cluster.get() : nullptr);
           debugPrint(
               logger_,
               MPL,
@@ -3171,7 +3176,7 @@ bool HierRTLMP::runFineShaping(Cluster* parent,
 
   for (auto& cluster : parent->getChildren()) {
     if (cluster->isIOCluster()) {
-      continue;  // IO clusters have no area
+      continue;
     }
     if (cluster->getClusterType() == StdCellCluster) {
       std_cell_cluster_area += cluster->getStdCellArea();
@@ -3250,7 +3255,7 @@ bool HierRTLMP::runFineShaping(Cluster* parent,
   // set the shape for each macro
   for (auto& cluster : parent->getChildren()) {
     if (cluster->isIOCluster()) {
-      continue;  // the area of IO cluster is 0.0
+      continue;
     }
     if (cluster->getClusterType() == StdCellCluster) {
       float area = cluster->getArea();
@@ -3638,10 +3643,11 @@ void HierRTLMP::createFixedTerminals(const Rect& outline,
             temp_cluster->getY() + temp_cluster->getHeight() / 2.0
                 - outline.yMin()),
         temp_cluster->getName(),
-        // The information of whether or not a cluster is an IO cluster is
-        // needed inside the SA Core, so if a fixed terminal corresponds
-        // to an IO Cluster it needs to contains that cluster data.
-        temp_cluster->isIOCluster() ? temp_cluster : nullptr);
+        // The information of whether or not a cluster is a group of
+        // unplaced IO pins is needed inside the SA Core, so if a fixed
+        // terminal corresponds to a cluster of unplaced IO pins it needs
+        // to contain that cluster data.
+        temp_cluster->isClusterOfUnplacedIOPins() ? temp_cluster : nullptr);
   }
 }
 

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -179,7 +179,7 @@ class HierRTLMP
   void calculateMacroTilings(Cluster* cluster);
   void setTightPackingTilings(Cluster* macro_array);
   void setPinAccessBlockages();
-  std::vector<Cluster*> getIOClusters();
+  std::vector<Cluster*> getClustersOfUnplacedIOPins();
   float computePinAccessBlockagesDepth(const std::vector<Cluster*>& io_clusters,
                                        const Rect& die);
   void createPinAccessBlockage(Boundary constraint_boundary,

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -199,13 +199,22 @@ class Cluster
   void clearHardMacros();
   void copyInstances(const Cluster& cluster);  // only based on cluster type
 
-  // Position must be specified when setting an IO cluster
-  void setAsIOCluster(const std::pair<float, float>& pos,
-                      float width,
-                      float height,
-                      Boundary constraint_boundary);
   bool isIOCluster() const;
+
+  bool isClusterOfUnplacedIOPins() const
+  {
+    return is_cluster_of_unplaced_io_pins_;
+  }
+  void setAsClusterOfUnplacedIOPins(const std::pair<float, float>& pos,
+                                    float width,
+                                    float height,
+                                    Boundary constraint_boundary);
   Boundary getConstraintBoundary() const { return constraint_boundary_; }
+
+  bool isIOPadCluster() const { return is_io_pad_cluster_; }
+  void setAsIOPadCluster(const std::pair<float, float>& pos,
+                         float width,
+                         float height);
 
   void setAsArrayOfInterconnectedMacros();
   bool isArrayOfInterconnectedMacros() const;
@@ -300,9 +309,8 @@ class Cluster
   // all the macros in the cluster
   std::vector<HardMacro*> hard_macros_;
 
-  // We model pads as clusters with no area
-  // The position be the center of IOs
-  bool is_io_cluster_ = false;
+  bool is_cluster_of_unplaced_io_pins_{false};
+  bool is_io_pad_cluster_{false};
   Boundary constraint_boundary_ = NONE;
 
   bool is_array_of_interconnected_macros = false;
@@ -365,7 +373,7 @@ class HardMacro
 
   void setCluster(Cluster* cluster) { cluster_ = cluster; }
   Cluster* getCluster() const { return cluster_; }
-  bool isIOCluster() const;
+  bool isClusterOfUnplacedIOPins() const;
 
   // Get Physical Information
   // Note that the default X and Y include halo_width
@@ -539,7 +547,7 @@ class SoftMacro
   bool isMacroCluster() const;
   bool isStdCellCluster() const;
   bool isMixedCluster() const;
-  bool isIOCluster() const;
+  bool isClusterOfUnplacedIOPins() const;
   void setLocationF(float x, float y);
   void setShapeF(float width, float height);
   int getNumMacro() const;


### PR DESCRIPTION
Resolve #6585 

Changes:
- Divide the IO Clusters into two types:
  1) Group of Unplaced IO Pins
  2) IO Pad
- When creating the hypergraph that will be used to build the dataflow maps and iterating over the terminals of an IO PAD net, consider the start of the path to be the bterm mapped to that PAD instead of the PAD itself so that MPL can see the connection properly inside SA.
- Do data flow before creating IO Clusters so that the IO Clusters creation can be based on the dataflow. With this, we'll only create IO Pad Clusters for the PADs that have useful connections macro placement wise.
     Obs: Large nets are excluded from the hypergraph and not used by SA, so we don't want to look at those.
- Use the distance to boundary technique inside SA only for the first type of IO Clusters.