### PR TITLE
remove old mpl macro_place_channel

### DIFF
--- a/test/Nangate45/Nangate45.vars
+++ b/test/Nangate45/Nangate45.vars
@@ -20,7 +20,6 @@ set global_place_pad 2
 set detail_place_pad 1
 
 set macro_place_halo {22.4 15.12}
-set macro_place_channel {18.8 19.95}
 
 set layer_rc_file "Nangate45/Nangate45.rc"
 # equiv -resistance .0035 -capacitance .052

--- a/test/sky130hd/sky130hd.vars
+++ b/test/sky130hd/sky130hd.vars
@@ -25,7 +25,6 @@ set global_place_pad 4
 set detail_place_pad 2
 
 set macro_place_halo {1 1}
-set macro_place_channel {80 80}
 
 set layer_rc_file "sky130hd/sky130hd.rc"
 set wire_rc_layer "met2"

--- a/test/sky130hs/sky130hs.vars
+++ b/test/sky130hs/sky130hs.vars
@@ -19,7 +19,6 @@ set global_place_pad 4
 set detail_place_pad 2
 
 set macro_place_halo {1 1}
-set macro_place_channel {80 80}
 
 set layer_rc_file "sky130hs/sky130hs.rc"
 set wire_rc_layer "met2"


### PR DESCRIPTION
`macro_place_channel` is not used in flow.tcl anymore.