### PR TITLE
rmp: removing static variable Blif::call_id_

### DIFF
--- a/src/rmp/include/rmp/Restructure.h
+++ b/src/rmp/include/rmp/Restructure.h
@@ -132,7 +132,7 @@ class Restructure
 
   Mode opt_mode_;
   bool is_area_mode_;
-  int blif_call_id_ {0};
+  int blif_call_id_{0};
 };
 
 }  // namespace rmp

--- a/src/rmp/include/rmp/Restructure.h
+++ b/src/rmp/include/rmp/Restructure.h
@@ -132,6 +132,7 @@ class Restructure
 
   Mode opt_mode_;
   bool is_area_mode_;
+  int blif_call_id_ {0};
 };
 
 }  // namespace rmp

--- a/src/rmp/include/rmp/blif.h
+++ b/src/rmp/include/rmp/blif.h
@@ -69,7 +69,8 @@ class Blif
        const std::string& const0_cell_,
        const std::string& const0_cell_port_,
        const std::string& const1_cell_,
-       const std::string& const1_cell_port_);
+       const std::string& const1_cell_port_,
+       const int call_id_);
   void setReplaceableInstances(std::set<odb::dbInst*>& insts);
   void addReplaceableInstance(odb::dbInst* inst);
   bool writeBlif(const char* file_name, bool write_arrival_requireds = false);
@@ -90,7 +91,7 @@ class Blif
   std::string const1_cell_port_;
   std::map<std::string, std::pair<float, float>> requireds_;
   std::map<std::string, std::pair<float, float>> arrivals_;
-  static int call_id_;
+  int call_id_;
 };
 
 }  // namespace rmp

--- a/src/rmp/include/rmp/blif.h
+++ b/src/rmp/include/rmp/blif.h
@@ -70,7 +70,7 @@ class Blif
        const std::string& const0_cell_port_,
        const std::string& const1_cell_,
        const std::string& const1_cell_port_,
-       const int call_id_);
+       int call_id_);
   void setReplaceableInstances(std::set<odb::dbInst*>& insts);
   void addReplaceableInstance(odb::dbInst* inst);
   bool writeBlif(const char* file_name, bool write_arrival_requireds = false);

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -169,7 +169,7 @@ void Restructure::runABC()
              "Constants before remap {}",
              countConsts(block_));
 
-  Blif blif_(logger_, open_sta_, locell_, loport_, hicell_, hiport_);
+  Blif blif_(logger_, open_sta_, locell_, loport_, hicell_, hiport_, ++blif_call_id_);
   blif_.setReplaceableInstances(path_insts_);
   blif_.writeBlif(input_blif_file_name_.c_str(), !is_area_mode_);
   debugPrint(

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -169,7 +169,8 @@ void Restructure::runABC()
              "Constants before remap {}",
              countConsts(block_));
 
-  Blif blif_(logger_, open_sta_, locell_, loport_, hicell_, hiport_, ++blif_call_id_);
+  Blif blif_(
+      logger_, open_sta_, locell_, loport_, hicell_, hiport_, ++blif_call_id_);
   blif_.setReplaceableInstances(path_insts_);
   blif_.writeBlif(input_blif_file_name_.c_str(), !is_area_mode_);
   debugPrint(

--- a/src/rmp/src/blif.cpp
+++ b/src/rmp/src/blif.cpp
@@ -62,22 +62,21 @@ using utl::RMP;
 
 namespace rmp {
 
-int Blif::call_id_ = 0;
-
 Blif::Blif(Logger* logger,
            sta::dbSta* sta,
            const std::string& const0_cell,
            const std::string& const0_cell_port,
            const std::string& const1_cell,
-           const std::string& const1_cell_port)
+           const std::string& const1_cell_port,
+           const int call_id_)
     : const0_cell_(const0_cell),
       const0_cell_port_(const0_cell_port),
       const1_cell_(const1_cell),
-      const1_cell_port_(const1_cell_port)
+      const1_cell_port_(const1_cell_port),
+      call_id_(call_id_)
 {
   logger_ = logger;
   open_sta_ = sta;
-  call_id_++;
 }
 
 void Blif::setReplaceableInstances(std::set<odb::dbInst*>& insts)

--- a/src/rmp/src/rmp.i
+++ b/src/rmp/src/rmp.i
@@ -82,8 +82,8 @@ restructure_cmd(char* liberty_file_name, char* target, float slack_threshold,
 }
 
 // Locally Exposed for testing only..
-Blif* create_blif(const char* hicell, const char* hiport, const char* locell, const char* loport){
-  return new rmp::Blif(getOpenRoad()->getLogger(), getOpenRoad()->getSta(), locell, loport, hicell, hiport);
+Blif* create_blif(const char* hicell, const char* hiport, const char* locell, const char* loport, const int call_id=1){
+  return new rmp::Blif(getOpenRoad()->getLogger(), getOpenRoad()->getSta(), locell, loport, hicell, hiport, call_id);
 }
 
 void blif_add_instance(Blif* blif_, const char* inst_){

--- a/src/rmp/test/rmp_aux.py
+++ b/src/rmp/test/rmp_aux.py
@@ -65,10 +65,10 @@ def restructure(
     )
 
 
-def create_blif(design, *, hicell="", hiport="", locell="", loport=""):
+def create_blif(design, *, hicell="", hiport="", locell="", loport="", call_id=1):
     logger = design.getLogger()
     sta = design.getTech().getSta()
-    return rmp.Blif(logger, sta, locell, loport, hicell, hiport)
+    return rmp.Blif(logger, sta, locell, loport, hicell, hiport, call_id)
 
 
 def blif_read(design, blif, filename):


### PR DESCRIPTION
Removes the static variable rmp::Blif::call_id_ by moving it to Restructure.h as discussed in https://github.com/The-OpenROAD-Project/OpenROAD/pull/5989

