### PR TITLE
odb/pdn: avoid double registration of identical connect rules

### DIFF
--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -4208,7 +4208,7 @@ int dbBlock::addGlobalConnect(dbRegion* region,
   dbGlobalConnect* gc
       = odb::dbGlobalConnect::create(net, region, instPattern, pinPattern);
 
-  if (do_connect) {
+  if (gc != nullptr && do_connect) {
     return globalConnect(gc);
   }
   return 0;

--- a/src/odb/src/db/dbGlobalConnect.cpp
+++ b/src/odb/src/db/dbGlobalConnect.cpp
@@ -240,6 +240,23 @@ dbGlobalConnect* dbGlobalConnect::create(dbNet* net,
 
   gc->setupRegex();
 
+  // check if global connect is identical to another
+  for (const dbGlobalConnect* check_gc :
+       ((dbBlock*) block)->getGlobalConnects()) {
+    const _dbGlobalConnect* db_check_gc = (const _dbGlobalConnect*) check_gc;
+
+    if (db_check_gc->getOID() == gc->getOID()) {
+      // dont compare with self
+      continue;
+    }
+
+    if (*db_check_gc == *gc) {
+      destroy((dbGlobalConnect*) gc);
+      gc = nullptr;
+      break;
+    }
+  }
+
   return ((dbGlobalConnect*) gc);
 }
 

--- a/src/pdn/test/CMakeLists.txt
+++ b/src/pdn/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 or_integration_tests(
   "pdn"
   TESTS
+    add_double_global_connection
     asap7_failed_macro_grid
     asap7_no_via_generate
     asap7_no_via_generate_v1_snapped

--- a/src/pdn/test/add_double_global_connection.ok
+++ b/src/pdn/test/add_double_global_connection.ok
@@ -1,0 +1,8 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 482 components and 2074 component-terminals.
+[INFO ODB-0133]     Created 385 nets and 1110 connections.
+Global connection rules: 2
+  Instances: ".*" with pins "VDD" connect to "VDD"
+  Instances: ".*" with pins "VSS" connect to "VSS"

--- a/src/pdn/test/add_double_global_connection.tcl
+++ b/src/pdn/test/add_double_global_connection.tcl
@@ -1,0 +1,11 @@
+# test for min width violation
+source "helpers.tcl"
+
+read_lef Nangate45/Nangate45.lef
+read_def nangate_gcd/floorplan.def
+
+add_global_connection -net VDD -pin_pattern VDD -power
+add_global_connection -net VDD -pin_pattern VDD
+add_global_connection -net VSS -pin_pattern VSS -ground
+
+report_global_connect


### PR DESCRIPTION
Changes:
- I noticed that repeated calls to `add_global_connection` with identical parameters results in multiple identical rules.
- This adds a check for existing rules and removes the duplicate (this should also allow calls to global_connect to process faster since the duplicate rules would just double the runtime).
