### PR TITLE
ifp: add check for instance sizes in init flooorplan to fail quickly

### DIFF
--- a/src/ifp/include/ifp/InitFloorplan.hh
+++ b/src/ifp/include/ifp/InitFloorplan.hh
@@ -114,6 +114,7 @@ class InitFloorplan
   using SitesByName = std::map<std::string, odb::dbSite*>;
 
   double designArea();
+  void checkInstanceDimensions(const odb::Rect& core) const;
   void makeRows(const odb::dbSite::RowPattern& pattern, const odb::Rect& core);
   void makeUniformRows(odb::dbSite* base_site,
                        const SitesByName& sites_by_name,

--- a/src/ifp/test/CMakeLists.txt
+++ b/src/ifp/test/CMakeLists.txt
@@ -12,6 +12,7 @@ or_integration_tests(
     init_floorplan7
     init_floorplan8
     init_floorplan9
+    init_floorplan10
     init_floorplan_even_rows
     init_floorplan_flip_sites
     init_floorplan_odd_rows

--- a/src/ifp/test/Nangate45_data/macros.v
+++ b/src/ifp/test/Nangate45_data/macros.v
@@ -1,0 +1,735 @@
+module RocketTile (auto_int_in_xing_in_0_sync_0,
+    auto_int_in_xing_in_0_sync_1,
+    auto_int_in_xing_in_1_sync_0,
+    auto_intsink_in_sync_0,
+    auto_tl_master_xing_out_a_bits_corrupt,
+    auto_tl_master_xing_out_a_bits_source,
+    auto_tl_master_xing_out_a_ready,
+    auto_tl_master_xing_out_a_valid,
+    auto_tl_master_xing_out_d_bits_corrupt,
+    auto_tl_master_xing_out_d_bits_denied,
+    auto_tl_master_xing_out_d_bits_sink,
+    auto_tl_master_xing_out_d_bits_source,
+    auto_tl_master_xing_out_d_ready,
+    auto_tl_master_xing_out_d_valid,
+    auto_tl_slave_xing_in_a_ready,
+    auto_tl_slave_xing_in_a_valid,
+    auto_tl_slave_xing_in_d_bits_corrupt,
+    auto_tl_slave_xing_in_d_bits_denied,
+    auto_tl_slave_xing_in_d_bits_sink,
+    auto_tl_slave_xing_in_d_ready,
+    auto_tl_slave_xing_in_d_valid,
+    clock,
+    reset,
+    auto_tl_master_xing_out_a_bits_address,
+    auto_tl_master_xing_out_a_bits_data,
+    auto_tl_master_xing_out_a_bits_mask,
+    auto_tl_master_xing_out_a_bits_opcode,
+    auto_tl_master_xing_out_a_bits_param,
+    auto_tl_master_xing_out_a_bits_size,
+    auto_tl_master_xing_out_d_bits_data,
+    auto_tl_master_xing_out_d_bits_opcode,
+    auto_tl_master_xing_out_d_bits_param,
+    auto_tl_master_xing_out_d_bits_size,
+    auto_tl_slave_xing_in_a_bits_address,
+    auto_tl_slave_xing_in_a_bits_data,
+    auto_tl_slave_xing_in_a_bits_mask,
+    auto_tl_slave_xing_in_a_bits_opcode,
+    auto_tl_slave_xing_in_a_bits_param,
+    auto_tl_slave_xing_in_a_bits_size,
+    auto_tl_slave_xing_in_a_bits_source,
+    auto_tl_slave_xing_in_d_bits_data,
+    auto_tl_slave_xing_in_d_bits_opcode,
+    auto_tl_slave_xing_in_d_bits_param,
+    auto_tl_slave_xing_in_d_bits_size,
+    auto_tl_slave_xing_in_d_bits_source);
+ input auto_int_in_xing_in_0_sync_0;
+ input auto_int_in_xing_in_0_sync_1;
+ input auto_int_in_xing_in_1_sync_0;
+ input auto_intsink_in_sync_0;
+ output auto_tl_master_xing_out_a_bits_corrupt;
+ output auto_tl_master_xing_out_a_bits_source;
+ input auto_tl_master_xing_out_a_ready;
+ output auto_tl_master_xing_out_a_valid;
+ input auto_tl_master_xing_out_d_bits_corrupt;
+ input auto_tl_master_xing_out_d_bits_denied;
+ input auto_tl_master_xing_out_d_bits_sink;
+ input auto_tl_master_xing_out_d_bits_source;
+ output auto_tl_master_xing_out_d_ready;
+ input auto_tl_master_xing_out_d_valid;
+ output auto_tl_slave_xing_in_a_ready;
+ input auto_tl_slave_xing_in_a_valid;
+ output auto_tl_slave_xing_in_d_bits_corrupt;
+ output auto_tl_slave_xing_in_d_bits_denied;
+ output auto_tl_slave_xing_in_d_bits_sink;
+ input auto_tl_slave_xing_in_d_ready;
+ output auto_tl_slave_xing_in_d_valid;
+ input clock;
+ input reset;
+ output [31:0] auto_tl_master_xing_out_a_bits_address;
+ output [31:0] auto_tl_master_xing_out_a_bits_data;
+ output [3:0] auto_tl_master_xing_out_a_bits_mask;
+ output [2:0] auto_tl_master_xing_out_a_bits_opcode;
+ output [2:0] auto_tl_master_xing_out_a_bits_param;
+ output [3:0] auto_tl_master_xing_out_a_bits_size;
+ input [31:0] auto_tl_master_xing_out_d_bits_data;
+ input [2:0] auto_tl_master_xing_out_d_bits_opcode;
+ input [1:0] auto_tl_master_xing_out_d_bits_param;
+ input [3:0] auto_tl_master_xing_out_d_bits_size;
+ input [31:0] auto_tl_slave_xing_in_a_bits_address;
+ input [31:0] auto_tl_slave_xing_in_a_bits_data;
+ input [3:0] auto_tl_slave_xing_in_a_bits_mask;
+ input [2:0] auto_tl_slave_xing_in_a_bits_opcode;
+ input [2:0] auto_tl_slave_xing_in_a_bits_param;
+ input [2:0] auto_tl_slave_xing_in_a_bits_size;
+ input [4:0] auto_tl_slave_xing_in_a_bits_source;
+ output [31:0] auto_tl_slave_xing_in_d_bits_data;
+ output [2:0] auto_tl_slave_xing_in_d_bits_opcode;
+ output [1:0] auto_tl_slave_xing_in_d_bits_param;
+ output [2:0] auto_tl_slave_xing_in_d_bits_size;
+ output [4:0] auto_tl_slave_xing_in_d_bits_source;
+
+
+ FILLCELL_X1 PHY_0 ();
+ FILLCELL_X1 PHY_1 ();
+ FILLCELL_X1 PHY_10 ();
+ FILLCELL_X1 PHY_100 ();
+ FILLCELL_X1 PHY_101 ();
+ FILLCELL_X1 PHY_102 ();
+ FILLCELL_X1 PHY_103 ();
+ FILLCELL_X1 PHY_104 ();
+ FILLCELL_X1 PHY_105 ();
+ FILLCELL_X1 PHY_106 ();
+ FILLCELL_X1 PHY_107 ();
+ FILLCELL_X1 PHY_108 ();
+ FILLCELL_X1 PHY_109 ();
+ FILLCELL_X1 PHY_11 ();
+ FILLCELL_X1 PHY_110 ();
+ FILLCELL_X1 PHY_111 ();
+ FILLCELL_X1 PHY_112 ();
+ FILLCELL_X1 PHY_113 ();
+ FILLCELL_X1 PHY_114 ();
+ FILLCELL_X1 PHY_115 ();
+ FILLCELL_X1 PHY_116 ();
+ FILLCELL_X1 PHY_117 ();
+ FILLCELL_X1 PHY_118 ();
+ FILLCELL_X1 PHY_119 ();
+ FILLCELL_X1 PHY_12 ();
+ FILLCELL_X1 PHY_120 ();
+ FILLCELL_X1 PHY_121 ();
+ FILLCELL_X1 PHY_122 ();
+ FILLCELL_X1 PHY_123 ();
+ FILLCELL_X1 PHY_124 ();
+ FILLCELL_X1 PHY_125 ();
+ FILLCELL_X1 PHY_126 ();
+ FILLCELL_X1 PHY_127 ();
+ FILLCELL_X1 PHY_128 ();
+ FILLCELL_X1 PHY_129 ();
+ FILLCELL_X1 PHY_13 ();
+ FILLCELL_X1 PHY_130 ();
+ FILLCELL_X1 PHY_131 ();
+ FILLCELL_X1 PHY_132 ();
+ FILLCELL_X1 PHY_133 ();
+ FILLCELL_X1 PHY_134 ();
+ FILLCELL_X1 PHY_135 ();
+ FILLCELL_X1 PHY_136 ();
+ FILLCELL_X1 PHY_137 ();
+ FILLCELL_X1 PHY_138 ();
+ FILLCELL_X1 PHY_139 ();
+ FILLCELL_X1 PHY_14 ();
+ FILLCELL_X1 PHY_140 ();
+ FILLCELL_X1 PHY_141 ();
+ FILLCELL_X1 PHY_142 ();
+ FILLCELL_X1 PHY_143 ();
+ FILLCELL_X1 PHY_144 ();
+ FILLCELL_X1 PHY_145 ();
+ FILLCELL_X1 PHY_146 ();
+ FILLCELL_X1 PHY_147 ();
+ FILLCELL_X1 PHY_148 ();
+ FILLCELL_X1 PHY_149 ();
+ FILLCELL_X1 PHY_15 ();
+ FILLCELL_X1 PHY_150 ();
+ FILLCELL_X1 PHY_151 ();
+ FILLCELL_X1 PHY_152 ();
+ FILLCELL_X1 PHY_153 ();
+ FILLCELL_X1 PHY_154 ();
+ FILLCELL_X1 PHY_155 ();
+ FILLCELL_X1 PHY_156 ();
+ FILLCELL_X1 PHY_157 ();
+ FILLCELL_X1 PHY_158 ();
+ FILLCELL_X1 PHY_159 ();
+ FILLCELL_X1 PHY_16 ();
+ FILLCELL_X1 PHY_160 ();
+ FILLCELL_X1 PHY_161 ();
+ FILLCELL_X1 PHY_162 ();
+ FILLCELL_X1 PHY_163 ();
+ FILLCELL_X1 PHY_164 ();
+ FILLCELL_X1 PHY_165 ();
+ FILLCELL_X1 PHY_166 ();
+ FILLCELL_X1 PHY_167 ();
+ FILLCELL_X1 PHY_168 ();
+ FILLCELL_X1 PHY_169 ();
+ FILLCELL_X1 PHY_17 ();
+ FILLCELL_X1 PHY_170 ();
+ FILLCELL_X1 PHY_171 ();
+ FILLCELL_X1 PHY_172 ();
+ FILLCELL_X1 PHY_173 ();
+ FILLCELL_X1 PHY_174 ();
+ FILLCELL_X1 PHY_175 ();
+ FILLCELL_X1 PHY_176 ();
+ FILLCELL_X1 PHY_177 ();
+ FILLCELL_X1 PHY_178 ();
+ FILLCELL_X1 PHY_179 ();
+ FILLCELL_X1 PHY_18 ();
+ FILLCELL_X1 PHY_180 ();
+ FILLCELL_X1 PHY_181 ();
+ FILLCELL_X1 PHY_182 ();
+ FILLCELL_X1 PHY_183 ();
+ FILLCELL_X1 PHY_184 ();
+ FILLCELL_X1 PHY_185 ();
+ FILLCELL_X1 PHY_186 ();
+ FILLCELL_X1 PHY_187 ();
+ FILLCELL_X1 PHY_188 ();
+ FILLCELL_X1 PHY_189 ();
+ FILLCELL_X1 PHY_19 ();
+ FILLCELL_X1 PHY_190 ();
+ FILLCELL_X1 PHY_191 ();
+ FILLCELL_X1 PHY_192 ();
+ FILLCELL_X1 PHY_193 ();
+ FILLCELL_X1 PHY_194 ();
+ FILLCELL_X1 PHY_195 ();
+ FILLCELL_X1 PHY_196 ();
+ FILLCELL_X1 PHY_197 ();
+ FILLCELL_X1 PHY_198 ();
+ FILLCELL_X1 PHY_199 ();
+ FILLCELL_X1 PHY_2 ();
+ FILLCELL_X1 PHY_20 ();
+ FILLCELL_X1 PHY_200 ();
+ FILLCELL_X1 PHY_201 ();
+ FILLCELL_X1 PHY_202 ();
+ FILLCELL_X1 PHY_203 ();
+ FILLCELL_X1 PHY_204 ();
+ FILLCELL_X1 PHY_205 ();
+ FILLCELL_X1 PHY_206 ();
+ FILLCELL_X1 PHY_207 ();
+ FILLCELL_X1 PHY_208 ();
+ FILLCELL_X1 PHY_209 ();
+ FILLCELL_X1 PHY_21 ();
+ FILLCELL_X1 PHY_210 ();
+ FILLCELL_X1 PHY_211 ();
+ FILLCELL_X1 PHY_212 ();
+ FILLCELL_X1 PHY_213 ();
+ FILLCELL_X1 PHY_214 ();
+ FILLCELL_X1 PHY_215 ();
+ FILLCELL_X1 PHY_216 ();
+ FILLCELL_X1 PHY_217 ();
+ FILLCELL_X1 PHY_218 ();
+ FILLCELL_X1 PHY_219 ();
+ FILLCELL_X1 PHY_22 ();
+ FILLCELL_X1 PHY_220 ();
+ FILLCELL_X1 PHY_221 ();
+ FILLCELL_X1 PHY_222 ();
+ FILLCELL_X1 PHY_223 ();
+ FILLCELL_X1 PHY_224 ();
+ FILLCELL_X1 PHY_225 ();
+ FILLCELL_X1 PHY_226 ();
+ FILLCELL_X1 PHY_227 ();
+ FILLCELL_X1 PHY_228 ();
+ FILLCELL_X1 PHY_229 ();
+ FILLCELL_X1 PHY_23 ();
+ FILLCELL_X1 PHY_230 ();
+ FILLCELL_X1 PHY_231 ();
+ FILLCELL_X1 PHY_232 ();
+ FILLCELL_X1 PHY_233 ();
+ FILLCELL_X1 PHY_234 ();
+ FILLCELL_X1 PHY_235 ();
+ FILLCELL_X1 PHY_236 ();
+ FILLCELL_X1 PHY_237 ();
+ FILLCELL_X1 PHY_238 ();
+ FILLCELL_X1 PHY_239 ();
+ FILLCELL_X1 PHY_24 ();
+ FILLCELL_X1 PHY_240 ();
+ FILLCELL_X1 PHY_241 ();
+ FILLCELL_X1 PHY_242 ();
+ FILLCELL_X1 PHY_243 ();
+ FILLCELL_X1 PHY_244 ();
+ FILLCELL_X1 PHY_245 ();
+ FILLCELL_X1 PHY_246 ();
+ FILLCELL_X1 PHY_247 ();
+ FILLCELL_X1 PHY_248 ();
+ FILLCELL_X1 PHY_249 ();
+ FILLCELL_X1 PHY_25 ();
+ FILLCELL_X1 PHY_250 ();
+ FILLCELL_X1 PHY_251 ();
+ FILLCELL_X1 PHY_252 ();
+ FILLCELL_X1 PHY_253 ();
+ FILLCELL_X1 PHY_254 ();
+ FILLCELL_X1 PHY_255 ();
+ FILLCELL_X1 PHY_256 ();
+ FILLCELL_X1 PHY_257 ();
+ FILLCELL_X1 PHY_258 ();
+ FILLCELL_X1 PHY_259 ();
+ FILLCELL_X1 PHY_26 ();
+ FILLCELL_X1 PHY_260 ();
+ FILLCELL_X1 PHY_261 ();
+ FILLCELL_X1 PHY_262 ();
+ FILLCELL_X1 PHY_263 ();
+ FILLCELL_X1 PHY_264 ();
+ FILLCELL_X1 PHY_265 ();
+ FILLCELL_X1 PHY_266 ();
+ FILLCELL_X1 PHY_267 ();
+ FILLCELL_X1 PHY_268 ();
+ FILLCELL_X1 PHY_269 ();
+ FILLCELL_X1 PHY_27 ();
+ FILLCELL_X1 PHY_270 ();
+ FILLCELL_X1 PHY_271 ();
+ FILLCELL_X1 PHY_272 ();
+ FILLCELL_X1 PHY_273 ();
+ FILLCELL_X1 PHY_274 ();
+ FILLCELL_X1 PHY_275 ();
+ FILLCELL_X1 PHY_276 ();
+ FILLCELL_X1 PHY_277 ();
+ FILLCELL_X1 PHY_278 ();
+ FILLCELL_X1 PHY_279 ();
+ FILLCELL_X1 PHY_28 ();
+ FILLCELL_X1 PHY_280 ();
+ FILLCELL_X1 PHY_281 ();
+ FILLCELL_X1 PHY_282 ();
+ FILLCELL_X1 PHY_283 ();
+ FILLCELL_X1 PHY_284 ();
+ FILLCELL_X1 PHY_285 ();
+ FILLCELL_X1 PHY_286 ();
+ FILLCELL_X1 PHY_287 ();
+ FILLCELL_X1 PHY_288 ();
+ FILLCELL_X1 PHY_289 ();
+ FILLCELL_X1 PHY_29 ();
+ FILLCELL_X1 PHY_290 ();
+ FILLCELL_X1 PHY_291 ();
+ FILLCELL_X1 PHY_292 ();
+ FILLCELL_X1 PHY_293 ();
+ FILLCELL_X1 PHY_294 ();
+ FILLCELL_X1 PHY_295 ();
+ FILLCELL_X1 PHY_296 ();
+ FILLCELL_X1 PHY_297 ();
+ FILLCELL_X1 PHY_298 ();
+ FILLCELL_X1 PHY_299 ();
+ FILLCELL_X1 PHY_3 ();
+ FILLCELL_X1 PHY_30 ();
+ FILLCELL_X1 PHY_300 ();
+ FILLCELL_X1 PHY_301 ();
+ FILLCELL_X1 PHY_302 ();
+ FILLCELL_X1 PHY_303 ();
+ FILLCELL_X1 PHY_304 ();
+ FILLCELL_X1 PHY_305 ();
+ FILLCELL_X1 PHY_306 ();
+ FILLCELL_X1 PHY_307 ();
+ FILLCELL_X1 PHY_308 ();
+ FILLCELL_X1 PHY_309 ();
+ FILLCELL_X1 PHY_31 ();
+ FILLCELL_X1 PHY_310 ();
+ FILLCELL_X1 PHY_311 ();
+ FILLCELL_X1 PHY_312 ();
+ FILLCELL_X1 PHY_313 ();
+ FILLCELL_X1 PHY_314 ();
+ FILLCELL_X1 PHY_315 ();
+ FILLCELL_X1 PHY_316 ();
+ FILLCELL_X1 PHY_317 ();
+ FILLCELL_X1 PHY_318 ();
+ FILLCELL_X1 PHY_319 ();
+ FILLCELL_X1 PHY_32 ();
+ FILLCELL_X1 PHY_320 ();
+ FILLCELL_X1 PHY_321 ();
+ FILLCELL_X1 PHY_322 ();
+ FILLCELL_X1 PHY_323 ();
+ FILLCELL_X1 PHY_324 ();
+ FILLCELL_X1 PHY_325 ();
+ FILLCELL_X1 PHY_326 ();
+ FILLCELL_X1 PHY_327 ();
+ FILLCELL_X1 PHY_328 ();
+ FILLCELL_X1 PHY_329 ();
+ FILLCELL_X1 PHY_33 ();
+ FILLCELL_X1 PHY_330 ();
+ FILLCELL_X1 PHY_331 ();
+ FILLCELL_X1 PHY_332 ();
+ FILLCELL_X1 PHY_333 ();
+ FILLCELL_X1 PHY_334 ();
+ FILLCELL_X1 PHY_335 ();
+ FILLCELL_X1 PHY_336 ();
+ FILLCELL_X1 PHY_337 ();
+ FILLCELL_X1 PHY_338 ();
+ FILLCELL_X1 PHY_339 ();
+ FILLCELL_X1 PHY_34 ();
+ FILLCELL_X1 PHY_340 ();
+ FILLCELL_X1 PHY_341 ();
+ FILLCELL_X1 PHY_342 ();
+ FILLCELL_X1 PHY_343 ();
+ FILLCELL_X1 PHY_344 ();
+ FILLCELL_X1 PHY_345 ();
+ FILLCELL_X1 PHY_346 ();
+ FILLCELL_X1 PHY_347 ();
+ FILLCELL_X1 PHY_348 ();
+ FILLCELL_X1 PHY_349 ();
+ FILLCELL_X1 PHY_35 ();
+ FILLCELL_X1 PHY_350 ();
+ FILLCELL_X1 PHY_351 ();
+ FILLCELL_X1 PHY_352 ();
+ FILLCELL_X1 PHY_353 ();
+ FILLCELL_X1 PHY_354 ();
+ FILLCELL_X1 PHY_355 ();
+ FILLCELL_X1 PHY_356 ();
+ FILLCELL_X1 PHY_357 ();
+ FILLCELL_X1 PHY_358 ();
+ FILLCELL_X1 PHY_359 ();
+ FILLCELL_X1 PHY_36 ();
+ FILLCELL_X1 PHY_360 ();
+ FILLCELL_X1 PHY_361 ();
+ FILLCELL_X1 PHY_362 ();
+ FILLCELL_X1 PHY_363 ();
+ FILLCELL_X1 PHY_364 ();
+ FILLCELL_X1 PHY_365 ();
+ FILLCELL_X1 PHY_366 ();
+ FILLCELL_X1 PHY_367 ();
+ FILLCELL_X1 PHY_368 ();
+ FILLCELL_X1 PHY_369 ();
+ FILLCELL_X1 PHY_37 ();
+ FILLCELL_X1 PHY_370 ();
+ FILLCELL_X1 PHY_371 ();
+ FILLCELL_X1 PHY_372 ();
+ FILLCELL_X1 PHY_373 ();
+ FILLCELL_X1 PHY_374 ();
+ FILLCELL_X1 PHY_375 ();
+ FILLCELL_X1 PHY_376 ();
+ FILLCELL_X1 PHY_377 ();
+ FILLCELL_X1 PHY_378 ();
+ FILLCELL_X1 PHY_379 ();
+ FILLCELL_X1 PHY_38 ();
+ FILLCELL_X1 PHY_380 ();
+ FILLCELL_X1 PHY_381 ();
+ FILLCELL_X1 PHY_382 ();
+ FILLCELL_X1 PHY_383 ();
+ FILLCELL_X1 PHY_384 ();
+ FILLCELL_X1 PHY_385 ();
+ FILLCELL_X1 PHY_386 ();
+ FILLCELL_X1 PHY_387 ();
+ FILLCELL_X1 PHY_388 ();
+ FILLCELL_X1 PHY_389 ();
+ FILLCELL_X1 PHY_39 ();
+ FILLCELL_X1 PHY_390 ();
+ FILLCELL_X1 PHY_391 ();
+ FILLCELL_X1 PHY_392 ();
+ FILLCELL_X1 PHY_393 ();
+ FILLCELL_X1 PHY_394 ();
+ FILLCELL_X1 PHY_395 ();
+ FILLCELL_X1 PHY_396 ();
+ FILLCELL_X1 PHY_397 ();
+ FILLCELL_X1 PHY_398 ();
+ FILLCELL_X1 PHY_399 ();
+ FILLCELL_X1 PHY_4 ();
+ FILLCELL_X1 PHY_40 ();
+ FILLCELL_X1 PHY_400 ();
+ FILLCELL_X1 PHY_401 ();
+ FILLCELL_X1 PHY_41 ();
+ FILLCELL_X1 PHY_42 ();
+ FILLCELL_X1 PHY_43 ();
+ FILLCELL_X1 PHY_44 ();
+ FILLCELL_X1 PHY_45 ();
+ FILLCELL_X1 PHY_46 ();
+ FILLCELL_X1 PHY_47 ();
+ FILLCELL_X1 PHY_48 ();
+ FILLCELL_X1 PHY_49 ();
+ FILLCELL_X1 PHY_5 ();
+ FILLCELL_X1 PHY_50 ();
+ FILLCELL_X1 PHY_51 ();
+ FILLCELL_X1 PHY_52 ();
+ FILLCELL_X1 PHY_53 ();
+ FILLCELL_X1 PHY_54 ();
+ FILLCELL_X1 PHY_55 ();
+ FILLCELL_X1 PHY_56 ();
+ FILLCELL_X1 PHY_57 ();
+ FILLCELL_X1 PHY_58 ();
+ FILLCELL_X1 PHY_59 ();
+ FILLCELL_X1 PHY_6 ();
+ FILLCELL_X1 PHY_60 ();
+ FILLCELL_X1 PHY_61 ();
+ FILLCELL_X1 PHY_62 ();
+ FILLCELL_X1 PHY_63 ();
+ FILLCELL_X1 PHY_64 ();
+ FILLCELL_X1 PHY_65 ();
+ FILLCELL_X1 PHY_66 ();
+ FILLCELL_X1 PHY_67 ();
+ FILLCELL_X1 PHY_68 ();
+ FILLCELL_X1 PHY_69 ();
+ FILLCELL_X1 PHY_7 ();
+ FILLCELL_X1 PHY_70 ();
+ FILLCELL_X1 PHY_71 ();
+ FILLCELL_X1 PHY_72 ();
+ FILLCELL_X1 PHY_73 ();
+ FILLCELL_X1 PHY_74 ();
+ FILLCELL_X1 PHY_75 ();
+ FILLCELL_X1 PHY_76 ();
+ FILLCELL_X1 PHY_77 ();
+ FILLCELL_X1 PHY_78 ();
+ FILLCELL_X1 PHY_79 ();
+ FILLCELL_X1 PHY_8 ();
+ FILLCELL_X1 PHY_80 ();
+ FILLCELL_X1 PHY_81 ();
+ FILLCELL_X1 PHY_82 ();
+ FILLCELL_X1 PHY_83 ();
+ FILLCELL_X1 PHY_84 ();
+ FILLCELL_X1 PHY_85 ();
+ FILLCELL_X1 PHY_86 ();
+ FILLCELL_X1 PHY_87 ();
+ FILLCELL_X1 PHY_88 ();
+ FILLCELL_X1 PHY_89 ();
+ FILLCELL_X1 PHY_9 ();
+ FILLCELL_X1 PHY_90 ();
+ FILLCELL_X1 PHY_91 ();
+ FILLCELL_X1 PHY_92 ();
+ FILLCELL_X1 PHY_93 ();
+ FILLCELL_X1 PHY_94 ();
+ FILLCELL_X1 PHY_95 ();
+ FILLCELL_X1 PHY_96 ();
+ FILLCELL_X1 PHY_97 ();
+ FILLCELL_X1 PHY_98 ();
+ FILLCELL_X1 PHY_99 ();
+ FILLCELL_X1 TAP_402 ();
+ FILLCELL_X1 TAP_403 ();
+ FILLCELL_X1 TAP_404 ();
+ FILLCELL_X1 TAP_405 ();
+ FILLCELL_X1 TAP_406 ();
+ FILLCELL_X1 TAP_407 ();
+ FILLCELL_X1 TAP_408 ();
+ FILLCELL_X1 TAP_409 ();
+ FILLCELL_X1 TAP_410 ();
+ FILLCELL_X1 TAP_411 ();
+ FILLCELL_X1 TAP_412 ();
+ FILLCELL_X1 TAP_413 ();
+ FILLCELL_X1 TAP_414 ();
+ FILLCELL_X1 TAP_415 ();
+ FILLCELL_X1 TAP_416 ();
+ FILLCELL_X1 TAP_417 ();
+ FILLCELL_X1 TAP_418 ();
+ FILLCELL_X1 TAP_419 ();
+ FILLCELL_X1 TAP_420 ();
+ FILLCELL_X1 TAP_421 ();
+ FILLCELL_X1 TAP_422 ();
+ FILLCELL_X1 TAP_423 ();
+ FILLCELL_X1 TAP_424 ();
+ FILLCELL_X1 TAP_425 ();
+ FILLCELL_X1 TAP_426 ();
+ FILLCELL_X1 TAP_427 ();
+ FILLCELL_X1 TAP_428 ();
+ FILLCELL_X1 TAP_429 ();
+ FILLCELL_X1 TAP_430 ();
+ FILLCELL_X1 TAP_431 ();
+ FILLCELL_X1 TAP_432 ();
+ FILLCELL_X1 TAP_433 ();
+ FILLCELL_X1 TAP_434 ();
+ FILLCELL_X1 TAP_435 ();
+ FILLCELL_X1 TAP_436 ();
+ FILLCELL_X1 TAP_437 ();
+ fakeram45_64x32 \dcache.data.data_arrays_0.data_arrays_0_ext.mem  (.addr_in({_NC1,
+    _NC2,
+    _NC3,
+    _NC4,
+    _NC5,
+    _NC6}),
+    .rd_out({_NC7,
+    _NC8,
+    _NC9,
+    _NC10,
+    _NC11,
+    _NC12,
+    _NC13,
+    _NC14,
+    _NC15,
+    _NC16,
+    _NC17,
+    _NC18,
+    _NC19,
+    _NC20,
+    _NC21,
+    _NC22,
+    _NC23,
+    _NC24,
+    _NC25,
+    _NC26,
+    _NC27,
+    _NC28,
+    _NC29,
+    _NC30,
+    _NC31,
+    _NC32,
+    _NC33,
+    _NC34,
+    _NC35,
+    _NC36,
+    _NC37,
+    _NC38}),
+    .w_mask_in({_NC39,
+    _NC40,
+    _NC41,
+    _NC42,
+    _NC43,
+    _NC44,
+    _NC45,
+    _NC46,
+    _NC47,
+    _NC48,
+    _NC49,
+    _NC50,
+    _NC51,
+    _NC52,
+    _NC53,
+    _NC54,
+    _NC55,
+    _NC56,
+    _NC57,
+    _NC58,
+    _NC59,
+    _NC60,
+    _NC61,
+    _NC62,
+    _NC63,
+    _NC64,
+    _NC65,
+    _NC66,
+    _NC67,
+    _NC68,
+    _NC69,
+    _NC70}),
+    .wd_in({_NC71,
+    _NC72,
+    _NC73,
+    _NC74,
+    _NC75,
+    _NC76,
+    _NC77,
+    _NC78,
+    _NC79,
+    _NC80,
+    _NC81,
+    _NC82,
+    _NC83,
+    _NC84,
+    _NC85,
+    _NC86,
+    _NC87,
+    _NC88,
+    _NC89,
+    _NC90,
+    _NC91,
+    _NC92,
+    _NC93,
+    _NC94,
+    _NC95,
+    _NC96,
+    _NC97,
+    _NC98,
+    _NC99,
+    _NC100,
+    _NC101,
+    _NC102}));
+ fakeram45_64x32 \frontend.icache.data_arrays_0.data_arrays_0_0_ext.mem  (.addr_in({_NC103,
+    _NC104,
+    _NC105,
+    _NC106,
+    _NC107,
+    _NC108}),
+    .rd_out({_NC109,
+    _NC110,
+    _NC111,
+    _NC112,
+    _NC113,
+    _NC114,
+    _NC115,
+    _NC116,
+    _NC117,
+    _NC118,
+    _NC119,
+    _NC120,
+    _NC121,
+    _NC122,
+    _NC123,
+    _NC124,
+    _NC125,
+    _NC126,
+    _NC127,
+    _NC128,
+    _NC129,
+    _NC130,
+    _NC131,
+    _NC132,
+    _NC133,
+    _NC134,
+    _NC135,
+    _NC136,
+    _NC137,
+    _NC138,
+    _NC139,
+    _NC140}),
+    .w_mask_in({_NC141,
+    _NC142,
+    _NC143,
+    _NC144,
+    _NC145,
+    _NC146,
+    _NC147,
+    _NC148,
+    _NC149,
+    _NC150,
+    _NC151,
+    _NC152,
+    _NC153,
+    _NC154,
+    _NC155,
+    _NC156,
+    _NC157,
+    _NC158,
+    _NC159,
+    _NC160,
+    _NC161,
+    _NC162,
+    _NC163,
+    _NC164,
+    _NC165,
+    _NC166,
+    _NC167,
+    _NC168,
+    _NC169,
+    _NC170,
+    _NC171,
+    _NC172}),
+    .wd_in({_NC173,
+    _NC174,
+    _NC175,
+    _NC176,
+    _NC177,
+    _NC178,
+    _NC179,
+    _NC180,
+    _NC181,
+    _NC182,
+    _NC183,
+    _NC184,
+    _NC185,
+    _NC186,
+    _NC187,
+    _NC188,
+    _NC189,
+    _NC190,
+    _NC191,
+    _NC192,
+    _NC193,
+    _NC194,
+    _NC195,
+    _NC196,
+    _NC197,
+    _NC198,
+    _NC199,
+    _NC200,
+    _NC201,
+    _NC202,
+    _NC203,
+    _NC204}));
+endmodule

--- a/src/ifp/test/init_floorplan10.ok
+++ b/src/ifp/test/init_floorplan10.ok
@@ -1,0 +1,4 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0227] LEF file: Nangate45/fakeram45_64x32.lef, created 1 library cells
+[ERROR IFP-0002] dcache.data.data_arrays_0.data_arrays_0_ext.mem (59.090um, 65.800um) does not fit in the core area: (20.000um, 20.000um) - (80.000um, 80.000um)
+IFP-0002

--- a/src/ifp/test/init_floorplan10.tcl
+++ b/src/ifp/test/init_floorplan10.tcl
@@ -1,0 +1,13 @@
+# init_floorplan with core area too small for memories
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_lef Nangate45/fakeram45_64x32.lef
+read_liberty Nangate45/Nangate45_typ.lib
+read_liberty Nangate45/fakeram45_64x32.lib
+read_verilog Nangate45_data/macros.v
+link_design RocketTile
+
+catch {initialize_floorplan -die_area "0 0 100.0 100.0" \
+  -core_area "20.0 20.0 80.0 80.0" \
+  -site FreePDK45_38x28_10R_NP_162NW_34O} err
+puts $err


### PR DESCRIPTION
Adds:
- check for instances sizes against core area to avoid continuing when core will not support macros.