### PR TITLE
RCX: removing static variables

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -243,13 +243,14 @@ class extDistWidthRCTable
 
   // ---------------------------------------------------------------------------------------
 
-  extDistWidthRCTable(bool dummy, uint met, uint layerCnt, uint width);
+  extDistWidthRCTable(bool dummy, uint met, uint layerCnt, uint width, bool OUREVERSEORDER);
   extDistWidthRCTable(bool over,
                       uint met,
                       uint layerCnt,
                       uint metCnt,
                       Ath__array1D<double>* widthTable,
                       AthPool<extDistRC>* rcPool,
+                      bool OUREVERSEORDER,
                       double dbFactor = 1.0);
   extDistWidthRCTable(bool over,
                       uint met,
@@ -259,13 +260,15 @@ class extDistWidthRCTable
                       int diagWidthCnt,
                       int diagDistCnt,
                       AthPool<extDistRC>* rcPool,
+                      bool OUREVERSEORDER,
                       double dbFactor = 1.0);
   extDistWidthRCTable(bool over,
                       uint met,
                       uint layerCnt,
                       uint metCnt,
                       uint maxWidthCnt,
-                      AthPool<extDistRC>* rcPool);
+                      AthPool<extDistRC>* rcPool,
+                      bool OUREVERSEORDER);
   void addRCw(uint n, uint w, extDistRC* rc);
   void createWidthMap();
   void makeWSmapping();
@@ -397,7 +400,7 @@ class extMetRCTable
   // dkf 01022024
   uint SetDefaultTechViaRes(dbTech* tech, bool dbg);
   // ----------------------------------------------------------------------------------------
-  extMetRCTable(uint layerCnt, AthPool<extDistRC>* rcPool, Logger* logger_);
+  extMetRCTable(uint layerCnt, AthPool<extDistRC>* rcPool, Logger* logger_, bool OUREVERSEORDER);
   ~extMetRCTable();
 
   // ---------------------- DKF 092024 -----------------------------------
@@ -471,6 +474,9 @@ class extMetRCTable
   // dkf 092024
   Ath__array1D<extViaModel*> _viaModel;
   AthHash<int> _viaModelHash;
+
+ private:
+  bool _OUREVERSEORDER;
 };
 
 class extRCTable
@@ -958,6 +964,8 @@ class extRCModel
   uint* _singlePlaneLayerMap;
 
   extMain* _extMain;
+
+  bool _OUREVERSEORDER {false};
 
  protected:
   Logger* logger_;

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -243,7 +243,11 @@ class extDistWidthRCTable
 
   // ---------------------------------------------------------------------------------------
 
-  extDistWidthRCTable(bool dummy, uint met, uint layerCnt, uint width, bool OUREVERSEORDER);
+  extDistWidthRCTable(bool dummy,
+                      uint met,
+                      uint layerCnt,
+                      uint width,
+                      bool OUREVERSEORDER);
   extDistWidthRCTable(bool over,
                       uint met,
                       uint layerCnt,
@@ -400,7 +404,10 @@ class extMetRCTable
   // dkf 01022024
   uint SetDefaultTechViaRes(dbTech* tech, bool dbg);
   // ----------------------------------------------------------------------------------------
-  extMetRCTable(uint layerCnt, AthPool<extDistRC>* rcPool, Logger* logger_, bool OUREVERSEORDER);
+  extMetRCTable(uint layerCnt,
+                AthPool<extDistRC>* rcPool,
+                Logger* logger_,
+                bool OUREVERSEORDER);
   ~extMetRCTable();
 
   // ---------------------- DKF 092024 -----------------------------------
@@ -965,7 +972,7 @@ class extRCModel
 
   extMain* _extMain;
 
-  bool _OUREVERSEORDER {false};
+  bool _OUREVERSEORDER{false};
 
  protected:
   Logger* logger_;

--- a/src/rcx/include/rcx/wire.h
+++ b/src/rcx/include/rcx/wire.h
@@ -310,7 +310,8 @@ class Ath__track
                     Ath__array1D<uint>* ccIdTable,
                     uint met,
                     CoupleAndCompute coupleAndCompute,
-                    void* compPtr);
+                    void* compPtr,
+                    bool ttttGetDgOverlap);
 
   uint findOverlap(Ath__wire* origWire,
                    uint ccThreshold,
@@ -541,7 +542,8 @@ class Ath__grid
                    uint& wireCnt,
                    CoupleAndCompute coupleAndCompute,
                    void* compPtr,
-                   int* limitArray);
+                   int* limitArray,
+                   bool ttttGetDgOverlap);
   int dealloc(int hiXY);
   void dealloc();
 };
@@ -622,6 +624,8 @@ class Ath__gridTable
   uint _wireCnt;
 
   Ath__array1D<Ath__wire*>* _bandWire;
+
+  bool _ttttGetDgOverlap{false};
 
  public:
   // -------------------------------------------------------- v2

--- a/src/rcx/include/rcx/wire.h
+++ b/src/rcx/include/rcx/wire.h
@@ -517,11 +517,6 @@ class Ath__grid
                    uint& wireCnt,
                    Ath__array1D<Ath__wire*>* bandWire,
                    int* limitArray);
-  uint couplingCaps(Ath__grid* resGrid,
-                    uint couplingDist,
-                    Ath__array1D<uint>* ccTable,
-                    CoupleAndCompute coupleAndCompute,
-                    void* compPtr);
   AthPool<Ath__wire>* getWirePoolPtr();
   uint placeWire(Ath__wire* w);
   uint defaultWireType();
@@ -742,12 +737,6 @@ class Ath__gridTable
   void setDefaultWireType(uint v);
   void buildDgContext(int base, uint level, uint dir);
   Ath__array1D<SEQ*>* renewDgContext(uint gridn, uint trackn);
-  uint couplingCaps(Ath__gridTable* resGridTable,
-                    uint couplingDist,
-                    Ath__array1D<uint>* ccTable,
-                    CoupleAndCompute coupleAndCompute,
-                    void* compPtr);
-  uint couplingCaps(uint row, uint col, Ath__grid* resGrid, uint couplingDist);
   void getBox(uint wid,
               int* x1,
               int* y1,

--- a/src/rcx/include/rcx/wire.h
+++ b/src/rcx/include/rcx/wire.h
@@ -301,9 +301,7 @@ class Ath__track
   void findNeighborWire(Ath__wire*, Ath__array1D<Ath__wire*>*, bool);
   void getTrackWires(std::vector<Ath__wire*>& ctxwire);
   void buildDgContext(Ath__array1D<SEQ*>* dgContext,
-                      Ath__wire**& allWire,
-                      int& awcnt,
-                      int& awsize);
+                      std::vector<Ath__wire*>& allWire);
   int getBandWires(Ath__array1D<Ath__wire*>* bandWire);
   uint couplingCaps(Ath__grid* ccGrid,
                     uint srcTrack,

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -36,7 +36,6 @@
 #include "rcx/gseq.h"
 #include "wire.h"
 
-
 namespace rcx {
 
 static uint ttttGetDgOverlap;
@@ -688,7 +687,7 @@ void Ath__track::buildDgContext(Ath__array1D<SEQ*>* dgContext,
 void Ath__grid::buildDgContext(int gridn, int base)
 {
   std::vector<Ath__wire*> allCtxwire;
-  
+
   uint btrackN = getMinMaxTrackNum(base);
   uint dgContextTrackRange = _gridtable->getCcFlag();
   int lowtrack

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -36,9 +36,6 @@
 #include "rcx/gseq.h"
 #include "wire.h"
 
-namespace rcx {
-CoupleOptions coupleOptionsNull{};
-};
 
 namespace rcx {
 
@@ -562,7 +559,8 @@ uint Ath__grid::couplingCaps(Ath__grid* resGrid,
     int base = btrack->getBase();
     _gridtable->buildDgContext(base, _level, _dir);
     if (!ttttGetDgOverlap) {
-      coupleAndCompute(rcx::coupleOptionsNull, compPtr);  // try print dgContext
+      CoupleOptions coupleOptionsNull{};
+      coupleAndCompute(coupleOptionsNull, compPtr);  // try print dgContext
     }
 
     Ath__track* track = nullptr;
@@ -859,7 +857,8 @@ int Ath__grid::couplingCaps(int hiXY,
     int base = btrack->getBase();
     _gridtable->buildDgContext(base, _level, _dir);
     if (!ttttGetDgOverlap) {
-      coupleAndCompute(rcx::coupleOptionsNull, compPtr);  // try print dgContext
+      CoupleOptions coupleOptionsNull{};
+      coupleAndCompute(coupleOptionsNull, compPtr);  // try print dgContext
     }
 
     Ath__track* track = nullptr;

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -919,7 +919,7 @@ int Ath__gridTable::couplingCaps(int hiXY,
                                  bool getBandWire,
                                  int** limitArray)
 {
-  _ttttGetDgOverlap = 1;
+  _ttttGetDgOverlap = true;
   setCCFlag(couplingDist);
 
   if (getBandWire) {
@@ -990,7 +990,7 @@ void Ath__gridTable::initCouplingCapLoops(
     void* compPtr,
     int* startXY)
 {
-  _ttttGetDgOverlap = 1;
+  _ttttGetDgOverlap = true;
   setCCFlag(couplingDist);
 
   for (uint jj = 1; jj < _colCnt; jj++) {

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -38,8 +38,6 @@
 
 namespace rcx {
 
-static uint ttttGetDgOverlap;
-
 uint Ath__track::trackContextOn(int orig,
                                 int end,
                                 int base,
@@ -349,7 +347,8 @@ uint Ath__track::couplingCaps(Ath__grid* ccGrid,
                               Ath__array1D<uint>* ccIdTable,
                               uint met,
                               CoupleAndCompute coupleAndCompute,
-                              void* compPtr)
+                              void* compPtr,
+                              bool ttttGetDgOverlap)
 {
   Ath__track* tstrack;
   bool tohi = _grid->getGridTable()->targetHighTracks() > 0 ? true : false;
@@ -705,7 +704,8 @@ int Ath__grid::couplingCaps(int hiXY,
                             uint& wireCnt,
                             rcx::CoupleAndCompute coupleAndCompute,
                             void* compPtr,
-                            int* limitArray)
+                            int* limitArray,
+                            bool ttttGetDgOverlap)
 {
   uint coupleTrackNum = couplingDist;  // EXT-OPTIMIZE
   uint ccThreshold = coupleTrackNum * _pitch;
@@ -761,7 +761,8 @@ int Ath__grid::couplingCaps(int hiXY,
                                       nullptr,
                                       _level,
                                       coupleAndCompute,
-                                      compPtr);
+                                      compPtr,
+                                      ttttGetDgOverlap);
       wireCnt += cnt1;
       if (allNet || TargetHighMarkedNet) {
         _gridtable->setHandleEmptyOnly(true);
@@ -774,7 +775,8 @@ int Ath__grid::couplingCaps(int hiXY,
                                  nullptr,
                                  _level,
                                  coupleAndCompute,
-                                 compPtr);
+                                 compPtr,
+                                 ttttGetDgOverlap);
       wireCnt += cnt1;
       _gridtable->reverseTargetTrack();
     }
@@ -917,7 +919,7 @@ int Ath__gridTable::couplingCaps(int hiXY,
                                  bool getBandWire,
                                  int** limitArray)
 {
-  ttttGetDgOverlap = 1;
+  _ttttGetDgOverlap = 1;
   setCCFlag(couplingDist);
 
   if (getBandWire) {
@@ -947,7 +949,8 @@ int Ath__gridTable::couplingCaps(int hiXY,
                                              wireCnt,
                                              coupleAndCompute,
                                              compPtr,
-                                             limitArray[jj]);
+                                             limitArray[jj],
+                                             _ttttGetDgOverlap);
     }
 
     if (minExtracted > lastExtracted1) {
@@ -987,7 +990,7 @@ void Ath__gridTable::initCouplingCapLoops(
     void* compPtr,
     int* startXY)
 {
-  ttttGetDgOverlap = 1;
+  _ttttGetDgOverlap = 1;
   setCCFlag(couplingDist);
 
   for (uint jj = 1; jj < _colCnt; jj++) {

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -688,7 +688,6 @@ void Ath__track::buildDgContext(Ath__array1D<SEQ*>* dgContext,
 void Ath__grid::buildDgContext(int gridn, int base)
 {
   std::vector<Ath__wire*> allCtxwire;
-  //allCtxwire.resize(4096);
   
   uint btrackN = getMinMaxTrackNum(base);
   uint dgContextTrackRange = _gridtable->getCcFlag();

--- a/src/rcx/src/extCC.cpp
+++ b/src/rcx/src/extCC.cpp
@@ -638,9 +638,7 @@ class compareAthWire
 
 // FIXME MATT
 void Ath__track::buildDgContext(Ath__array1D<SEQ*>* dgContext,
-                                Ath__wire**& allWire,
-                                int& awcnt,
-                                int& awsize)
+                                std::vector<Ath__wire*>& allWire)
 {
   std::vector<Ath__wire*> ctxwire;
   Ath__track* track = nullptr;
@@ -666,12 +664,8 @@ void Ath__track::buildDgContext(Ath__array1D<SEQ*>* dgContext,
   SEQ* seq;
   int rsegid;
   for (jj = 0; jj < ctxsize; jj++) {
-    if (awcnt == awsize) {
-      awsize += 1024;
-      allWire = (Ath__wire**) realloc(allWire, sizeof(Ath__wire*) * awsize);
-    }
     nwire = ctxwire[jj];
-    allWire[awcnt++] = nwire;
+    allWire.push_back(nwire);
     seq = seqPool->alloc();
     lidx = _grid->getDir() == 1 ? xidx : yidx;
     bidx = _grid->getDir() == 1 ? yidx : xidx;
@@ -693,14 +687,9 @@ void Ath__track::buildDgContext(Ath__array1D<SEQ*>* dgContext,
 
 void Ath__grid::buildDgContext(int gridn, int base)
 {
-  static Ath__wire** allCtxwire = nullptr;
-  static int awcnt;
-  static int awsize;
-  if (allCtxwire == nullptr) {
-    allCtxwire = (Ath__wire**) calloc(sizeof(Ath__wire*), 4096);
-    awsize = 4096;
-  }
-  awcnt = 0;
+  std::vector<Ath__wire*> allCtxwire;
+  //allCtxwire.resize(4096);
+  
   uint btrackN = getMinMaxTrackNum(base);
   uint dgContextTrackRange = _gridtable->getCcFlag();
   int lowtrack
@@ -721,10 +710,10 @@ void Ath__grid::buildDgContext(int gridn, int base)
     }
     _gridtable->dgContextTrackBase()[gridn][dgContextTrackRange + tt]
         = ttrack->getBase();
-    ttrack->buildDgContext(dgContext, allCtxwire, awcnt, awsize);
+    ttrack->buildDgContext(dgContext, allCtxwire);
   }
-  int jj;
-  for (jj = 0; jj < awcnt; jj++) {
+  std::vector<Ath__wire*>::size_type jj;
+  for (jj = 0; jj < allCtxwire.size(); jj++) {
     allCtxwire[jj]->_ext = 0;
   }
 }

--- a/src/rcx/src/extFlow_v2.cpp
+++ b/src/rcx/src/extFlow_v2.cpp
@@ -1303,7 +1303,7 @@ uint extRCModel::readRules_v2(Ath__parser* parser,
 
   extDistWidthRCTable* dummy = NULL;
   if (ignore)
-    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt);
+    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
 
   uint diagWidthCnt = 0;
   uint diagDistCnt = 0;

--- a/src/rcx/src/extFlow_v2.cpp
+++ b/src/rcx/src/extFlow_v2.cpp
@@ -1303,7 +1303,8 @@ uint extRCModel::readRules_v2(Ath__parser* parser,
 
   extDistWidthRCTable* dummy = NULL;
   if (ignore)
-    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
+    dummy = new extDistWidthRCTable(
+        true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
 
   uint diagWidthCnt = 0;
   uint diagDistCnt = 0;

--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -43,8 +43,6 @@ namespace rcx {
 using odb::dbRSeg;
 using utl::RCX;
 
-bool OUREVERSEORDER = false;
-
 int extRCModel::getMaxMetIndexOverUnder(int met, int layerCnt)
 {
   int n = 0;
@@ -734,7 +732,8 @@ extDistWidthRCTable::extDistWidthRCTable(bool over,
                                          uint layerCnt,
                                          uint metCnt,
                                          uint maxWidthCnt,
-                                         AthPool<extDistRC>* rcPool)
+                                         AthPool<extDistRC>* rcPool,
+                                         bool OUREVERSEORDER)
 {
   _ouReadReverse = OUREVERSEORDER;
   _over = over;
@@ -829,7 +828,8 @@ void extDistWidthRCTable::makeWSmapping()
 extDistWidthRCTable::extDistWidthRCTable(bool dummy,
                                          uint met,
                                          uint layerCnt,
-                                         uint widthCnt)
+                                         uint widthCnt,
+                                         bool OUREVERSEORDER)
 {
   _ouReadReverse = OUREVERSEORDER;
   _met = met;
@@ -873,6 +873,7 @@ extDistWidthRCTable::extDistWidthRCTable(bool over,
                                          uint metCnt,
                                          Ath__array1D<double>* widthTable,
                                          AthPool<extDistRC>* rcPool,
+                                         bool OUREVERSEORDER,
                                          double dbFactor)
 {
   _ouReadReverse = OUREVERSEORDER;
@@ -962,6 +963,7 @@ extDistWidthRCTable::extDistWidthRCTable(bool over,
                                          int diagWidthCnt,
                                          int diagDistCnt,
                                          AthPool<extDistRC>* rcPool,
+                                         bool OUREVERSEORDER,
                                          double dbFactor)
 {
   _ouReadReverse = OUREVERSEORDER;
@@ -1483,7 +1485,8 @@ uint extDistWidthRCTable::writeRulesOverUnder(FILE* fp, bool bin)
 }
 extMetRCTable::extMetRCTable(uint layerCnt,
                              AthPool<extDistRC>* rcPool,
-                             Logger* logger)
+                             Logger* logger,
+                             bool OUREVERSEORDER)
 {
   logger_ = logger;
   _layerCnt = layerCnt;
@@ -1508,6 +1511,8 @@ extMetRCTable::extMetRCTable(uint layerCnt,
   }
   _rcPoolPtr = rcPool;
   _rate = -1000.0;
+
+  _OUREVERSEORDER = OUREVERSEORDER;
 }
 
 extMetRCTable::~extMetRCTable()
@@ -1540,6 +1545,7 @@ void extMetRCTable::allocDiagUnderTable(uint met,
                                                diagWidthCnt,
                                                diagDistCnt,
                                                _rcPoolPtr,
+                                               _OUREVERSEORDER,
                                                dbFactor);
 }
 
@@ -1558,7 +1564,7 @@ void extMetRCTable::allocDiagUnderTable(uint met,
                                         double dbFactor)
 {
   _capDiagUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, dbFactor);
+      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
 }
 
 void extMetRCTable::allocUnderTable(uint met,
@@ -1566,7 +1572,7 @@ void extMetRCTable::allocUnderTable(uint met,
                                     double dbFactor)
 {
   _capUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, dbFactor);
+      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
 }
 
 void extMetRCTable::allocOverUnderTable(uint met,
@@ -1579,7 +1585,7 @@ void extMetRCTable::allocOverUnderTable(uint met,
 
   int n = extRCModel::getMaxMetIndexOverUnder(met, _layerCnt);
   _capOverUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, dbFactor);
+      false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
 }
 
 extRCTable::extRCTable(bool over, uint layerCnt)
@@ -2209,7 +2215,7 @@ void extRCModel::createModelTable(uint n, uint layerCnt)
   _dataRateTable = new Ath__array1D<double>(_modelCnt);
   _modelTable = new extMetRCTable*[_modelCnt];
   for (uint jj = 0; jj < _modelCnt; jj++) {
-    _modelTable[jj] = new extMetRCTable(_layerCnt, _rcPoolPtr, logger_);
+    _modelTable[jj] = new extMetRCTable(_layerCnt, _rcPoolPtr, logger_, _OUREVERSEORDER);
   }
 }
 
@@ -3375,30 +3381,30 @@ void extMetRCTable::allocateInitialTables(uint layerCnt,
     if (over && under && (met > 1) && (met < _layerCnt - 1)) {
       int n = extRCModel::getMaxMetIndexOverUnder(met, layerCnt);
       _capOverUnder[met] = new extDistWidthRCTable(
-          false, met, layerCnt, n + 1, widthCnt, _rcPoolPtr);
+          false, met, layerCnt, n + 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
       for (uint jj = 0; jj < _wireCnt; jj++)
         _capOverUnder_open[met][jj] = new extDistWidthRCTable(
-            false, met, layerCnt, n + 1, widthCnt, _rcPoolPtr);
+            false, met, layerCnt, n + 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
     }
     if (over) {
       _capOver[met] = new extDistWidthRCTable(
-          true, met, layerCnt, met, widthCnt, _rcPoolPtr);
+          true, met, layerCnt, met, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
       _resOver[met] = new extDistWidthRCTable(
-          true, met, layerCnt, met, widthCnt, _rcPoolPtr);
+          true, met, layerCnt, met, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
       for (uint jj = 0; jj < _wireCnt; jj++)
         _capOver_open[met][jj] = new extDistWidthRCTable(
-            true, met, layerCnt, met, widthCnt, _rcPoolPtr);
+            true, met, layerCnt, met, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
     }
     if (under) {
       _capUnder[met] = new extDistWidthRCTable(
-          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr);
+          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
       for (uint jj = 0; jj < _wireCnt; jj++)
         _capUnder_open[met][jj] = new extDistWidthRCTable(
-            false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr);
+            false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
     }
     if (diag) {
       _capDiagUnder[met] = new extDistWidthRCTable(
-          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr);
+          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
     }
   }
 }
@@ -3446,7 +3452,7 @@ uint extRCModel::readRules(Ath__parser* parser,
 
   extDistWidthRCTable* dummy = nullptr;
   if (ignore) {
-    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt);
+    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
   }
 
   uint diagWidthCnt = 0;
@@ -3535,7 +3541,7 @@ bool extRCModel::readRules_v1(char* name,
                               const uint* cornerTable,
                               double dbFactor)
 {
-  OUREVERSEORDER = false;
+  _OUREVERSEORDER = false;
   diag = false;
   _ruleFileName = strdup(name);
   Ath__parser parser(logger_);
@@ -3544,7 +3550,7 @@ bool extRCModel::readRules_v1(char* name,
   while (parser.parseNextLine() > 0) {
     if (parser.isKeyword(0, "OUREVERSEORDER")) {
       if (strcmp(parser.get(1), "ON") == 0) {
-        OUREVERSEORDER = true;
+        _OUREVERSEORDER = true;
       }
     }
     if (parser.isKeyword(0, "DIAGMODEL")) {

--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -1563,16 +1563,28 @@ void extMetRCTable::allocDiagUnderTable(uint met,
                                         Ath__array1D<double>* wTable,
                                         double dbFactor)
 {
-  _capDiagUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+  _capDiagUnder[met] = new extDistWidthRCTable(false,
+                                               met,
+                                               _layerCnt,
+                                               _layerCnt - met - 1,
+                                               wTable,
+                                               _rcPoolPtr,
+                                               _OUREVERSEORDER,
+                                               dbFactor);
 }
 
 void extMetRCTable::allocUnderTable(uint met,
                                     Ath__array1D<double>* wTable,
                                     double dbFactor)
 {
-  _capUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, _layerCnt - met - 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+  _capUnder[met] = new extDistWidthRCTable(false,
+                                           met,
+                                           _layerCnt,
+                                           _layerCnt - met - 1,
+                                           wTable,
+                                           _rcPoolPtr,
+                                           _OUREVERSEORDER,
+                                           dbFactor);
 }
 
 void extMetRCTable::allocOverUnderTable(uint met,
@@ -1584,8 +1596,14 @@ void extMetRCTable::allocOverUnderTable(uint met,
   }
 
   int n = extRCModel::getMaxMetIndexOverUnder(met, _layerCnt);
-  _capOverUnder[met] = new extDistWidthRCTable(
-      false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+  _capOverUnder[met] = new extDistWidthRCTable(false,
+                                               met,
+                                               _layerCnt,
+                                               n + 1,
+                                               wTable,
+                                               _rcPoolPtr,
+                                               _OUREVERSEORDER,
+                                               dbFactor);
 }
 
 extRCTable::extRCTable(bool over, uint layerCnt)
@@ -2215,7 +2233,8 @@ void extRCModel::createModelTable(uint n, uint layerCnt)
   _dataRateTable = new Ath__array1D<double>(_modelCnt);
   _modelTable = new extMetRCTable*[_modelCnt];
   for (uint jj = 0; jj < _modelCnt; jj++) {
-    _modelTable[jj] = new extMetRCTable(_layerCnt, _rcPoolPtr, logger_, _OUREVERSEORDER);
+    _modelTable[jj]
+        = new extMetRCTable(_layerCnt, _rcPoolPtr, logger_, _OUREVERSEORDER);
   }
 }
 
@@ -3396,15 +3415,30 @@ void extMetRCTable::allocateInitialTables(uint layerCnt,
             true, met, layerCnt, met, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
     }
     if (under) {
-      _capUnder[met] = new extDistWidthRCTable(
-          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
+      _capUnder[met] = new extDistWidthRCTable(false,
+                                               met,
+                                               layerCnt,
+                                               _layerCnt - met - 1,
+                                               widthCnt,
+                                               _rcPoolPtr,
+                                               _OUREVERSEORDER);
       for (uint jj = 0; jj < _wireCnt; jj++)
-        _capUnder_open[met][jj] = new extDistWidthRCTable(
-            false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
+        _capUnder_open[met][jj] = new extDistWidthRCTable(false,
+                                                          met,
+                                                          layerCnt,
+                                                          _layerCnt - met - 1,
+                                                          widthCnt,
+                                                          _rcPoolPtr,
+                                                          _OUREVERSEORDER);
     }
     if (diag) {
-      _capDiagUnder[met] = new extDistWidthRCTable(
-          false, met, layerCnt, _layerCnt - met - 1, widthCnt, _rcPoolPtr, _OUREVERSEORDER);
+      _capDiagUnder[met] = new extDistWidthRCTable(false,
+                                                   met,
+                                                   layerCnt,
+                                                   _layerCnt - met - 1,
+                                                   widthCnt,
+                                                   _rcPoolPtr,
+                                                   _OUREVERSEORDER);
     }
   }
 }
@@ -3452,7 +3486,8 @@ uint extRCModel::readRules(Ath__parser* parser,
 
   extDistWidthRCTable* dummy = nullptr;
   if (ignore) {
-    dummy = new extDistWidthRCTable(true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
+    dummy = new extDistWidthRCTable(
+        true, met, _layerCnt, widthCnt, _OUREVERSEORDER);
   }
 
   uint diagWidthCnt = 0;

--- a/src/rcx/src/extRCmodel_solver.cpp
+++ b/src/rcx/src/extRCmodel_solver.cpp
@@ -416,12 +416,24 @@ void extMetRCTable::allocOverUnderTable(uint met,
 
   int n = extRCModel::getMaxMetIndexOverUnder(met, _layerCnt);
   if (!open)
-    _capOverUnder[met] = new extDistWidthRCTable(
-        false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+    _capOverUnder[met] = new extDistWidthRCTable(false,
+                                                 met,
+                                                 _layerCnt,
+                                                 n + 1,
+                                                 wTable,
+                                                 _rcPoolPtr,
+                                                 _OUREVERSEORDER,
+                                                 dbFactor);
   else {
     for (uint ii = 0; ii < _wireCnt; ii++)
-      _capOverUnder_open[met][ii] = new extDistWidthRCTable(
-          false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+      _capOverUnder_open[met][ii] = new extDistWidthRCTable(false,
+                                                            met,
+                                                            _layerCnt,
+                                                            n + 1,
+                                                            wTable,
+                                                            _rcPoolPtr,
+                                                            _OUREVERSEORDER,
+                                                            dbFactor);
   }
 }
 void extMetRCTable::allocOverTable(uint met,
@@ -433,8 +445,14 @@ void extMetRCTable::allocOverTable(uint met,
   _resOver[met] = new extDistWidthRCTable(
       true, met, _layerCnt, met, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
   for (uint ii = 0; ii < _wireCnt; ii++)
-    _capOver_open[met][ii] = new extDistWidthRCTable(
-        true, met, _layerCnt, met, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
+    _capOver_open[met][ii] = new extDistWidthRCTable(true,
+                                                     met,
+                                                     _layerCnt,
+                                                     met,
+                                                     wTable,
+                                                     _rcPoolPtr,
+                                                     _OUREVERSEORDER,
+                                                     dbFactor);
 }
 void extMetRCTable::allocUnderTable(uint met,
                                     bool open,

--- a/src/rcx/src/extRCmodel_solver.cpp
+++ b/src/rcx/src/extRCmodel_solver.cpp
@@ -417,11 +417,11 @@ void extMetRCTable::allocOverUnderTable(uint met,
   int n = extRCModel::getMaxMetIndexOverUnder(met, _layerCnt);
   if (!open)
     _capOverUnder[met] = new extDistWidthRCTable(
-        false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, dbFactor);
+        false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
   else {
     for (uint ii = 0; ii < _wireCnt; ii++)
       _capOverUnder_open[met][ii] = new extDistWidthRCTable(
-          false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, dbFactor);
+          false, met, _layerCnt, n + 1, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
   }
 }
 void extMetRCTable::allocOverTable(uint met,
@@ -429,12 +429,12 @@ void extMetRCTable::allocOverTable(uint met,
                                    double dbFactor)
 {
   _capOver[met] = new extDistWidthRCTable(
-      true, met, _layerCnt, met, wTable, _rcPoolPtr, dbFactor);
+      true, met, _layerCnt, met, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
   _resOver[met] = new extDistWidthRCTable(
-      true, met, _layerCnt, met, wTable, _rcPoolPtr, dbFactor);
+      true, met, _layerCnt, met, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
   for (uint ii = 0; ii < _wireCnt; ii++)
     _capOver_open[met][ii] = new extDistWidthRCTable(
-        true, met, _layerCnt, met, wTable, _rcPoolPtr, dbFactor);
+        true, met, _layerCnt, met, wTable, _rcPoolPtr, _OUREVERSEORDER, dbFactor);
 }
 void extMetRCTable::allocUnderTable(uint met,
                                     bool open,
@@ -448,6 +448,7 @@ void extMetRCTable::allocUnderTable(uint met,
                                              _layerCnt - met - 1,
                                              wTable,
                                              _rcPoolPtr,
+                                             _OUREVERSEORDER,
                                              dbFactor);
   } else {
     for (uint ii = 0; ii < _wireCnt; ii++)
@@ -457,6 +458,7 @@ void extMetRCTable::allocUnderTable(uint met,
                                                         _layerCnt - met - 1,
                                                         wTable,
                                                         _rcPoolPtr,
+                                                        _OUREVERSEORDER,
                                                         dbFactor);
   }
 }

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -719,7 +719,7 @@ void extMain::measureRC(CoupleOptions& options)
   ccReportProgress();
 }
 
-extern CoupleOptions coupleOptionsNull;
+const CoupleOptions coupleOptionsNull{};
 
 void extCompute1(CoupleOptions& options, void* computePtr)
 {

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -551,9 +551,6 @@ void extMain::ccReportProgress()
   }
 }
 
-int ttttsrcnet = 66;
-int tttttgtnet = 66;
-int ttttm = 0;
 void extMain::printNet(dbNet* net, uint netId)
 {
   if (netId == net->getId()) {
@@ -619,10 +616,7 @@ void extMain::measureRC(CoupleOptions& options)
 
   uint totLenCovered = 0;
   if (_usingMetalPlanes) {
-    if (_ccContextArray
-        && ((!srcNet || (int) srcNet->getId() == ttttsrcnet)
-            || (!tgtNet || (int) tgtNet->getId() == tttttgtnet))
-        && (!ttttm || m._met == ttttm)) {
+    if (_ccContextArray && (!srcNet || !tgtNet)) {
       int pxy = m._dir ? m._ll[0] : m._ll[1];
       int pbase = m._dir ? m._ur[1] : m._ur[0];
       logger_->info(RCX,

--- a/src/rcx/src/grids.cpp
+++ b/src/rcx/src/grids.cpp
@@ -1075,7 +1075,7 @@ bool Ath__track::place2(Ath__wire* w, int mark1, int mark2)
 
   return status;
 }
-int SdbPlaceWireNoTouchCheckForOverlap = 0;
+
 void Ath__track::linkWire(Ath__wire*& w1, Ath__wire*& w2)
 {
   Ath__overlapAdjust adj


### PR DESCRIPTION
Global and static variables removed (issue https://github.com/The-OpenROAD-Project/OpenROAD/issues/5981)

Variables changed:
- rcx::SdbPlaceWireNoTouchCheckForOverlap [Removed]
- rcx::coupleOptionsNull [Removed]
- static variables from rcx::Ath__grid::buildDgContext(int gridn, int base):
  - allCtxwire [Changed to a local vector]
  - awcnt [Removed. It was used to help manage allCtxwire memory]
  - awsize [Removed. It was used to help manage allCtxwire memory]
- rcx::OUREVERSEORDER [Moved to extRCTable and extMetRCTable] 
- rcx::ttttsrcnet [Removed]
- rcx::tttttgtnet [Removed]
- rcx::ttttm [Removed]
- rcx::ttttGetDgOverlap [Moved to Ath__gridTable]

Unused methods removed:
- uint Ath__grid::couplingCaps
- uint Ath__gridTable::couplingCaps