### PR TITLE
rsz: hold check dont touch instances

### DIFF
--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -68,6 +68,7 @@ or_integration_tests(
     repair_hold13
     repair_hold14
     repair_hold15
+    repair_hold16
     repair_setup1
     repair_setup2
     repair_setup3

--- a/src/rsz/test/repair_hold16.ok
+++ b/src/rsz/test/repair_hold16.ok
@@ -1,0 +1,119 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: top
+[INFO ODB-0130]     Created 4 pins.
+[INFO ODB-0131]     Created 13 components and 59 component-terminals.
+[INFO ODB-0133]     Created 16 nets and 30 connections.
+Startpoint: in2 (input port clocked by clk)
+Endpoint: r2 (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: min
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (propagated)
+   0.00    0.00 ^ input external delay
+   0.00    0.00 ^ in2 (in)
+   0.00    0.00 ^ r2/D (DFF_X1)
+           0.00   data arrival time
+
+   0.00    0.00   clock clk (rise edge)
+   0.08    0.08   clock network delay (propagated)
+   0.00    0.08   clock reconvergence pessimism
+           0.08 ^ r2/CK (DFF_X1)
+   0.01    0.09   library hold time
+           0.09   data required time
+---------------------------------------------------------
+           0.09   data required time
+          -0.00   data arrival time
+---------------------------------------------------------
+          -0.09   slack (VIOLATED)
+
+
+Startpoint: r1 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: r3 (rising edge-triggered flip-flop clocked by clk)
+Path Group: clk
+Path Type: min
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.02    0.02   clock network delay (propagated)
+   0.00    0.02 ^ r1/CK (DFF_X1)
+   0.08    0.10 v r1/Q (DFF_X1)
+   0.03    0.13 v u2/ZN (AND2_X1)
+   0.00    0.13 v r3/D (DFF_X1)
+           0.13   data arrival time
+
+   0.00    0.00   clock clk (rise edge)
+   0.16    0.16   clock network delay (propagated)
+   0.00    0.16   clock reconvergence pessimism
+           0.16 ^ r3/CK (DFF_X1)
+   0.00    0.17   library hold time
+           0.17   data required time
+---------------------------------------------------------
+           0.17   data required time
+          -0.13   data arrival time
+---------------------------------------------------------
+          -0.04   slack (VIOLATED)
+
+
+Startpoint: r3 (rising edge-triggered flip-flop clocked by clk)
+Endpoint: out (output port clocked by clk)
+Path Group: clk
+Path Type: min
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock clk (rise edge)
+   0.16    0.16   clock network delay (propagated)
+   0.00    0.16 ^ r3/CK (DFF_X1)
+   0.09    0.25 v r3/Q (DFF_X1)
+   0.00    0.26 v out (out)
+           0.26   data arrival time
+
+   0.00    0.00   clock clk (rise edge)
+   0.00    0.00   clock network delay (propagated)
+   0.00    0.00   clock reconvergence pessimism
+   0.30    0.30   output external delay
+           0.30   data required time
+---------------------------------------------------------
+           0.30   data required time
+          -0.26   data arrival time
+---------------------------------------------------------
+          -0.04   slack (VIOLATED)
+
+
+[INFO RSZ-0046] Found 4 endpoints with hold violations.
+[WARNING RSZ-0066] Unable to repair all hold violations.
+[INFO RSZ-0032] Inserted 6 hold buffers.
+worst slack -0.09
+worst slack 1.88
+Net in2
+ Pin capacitance: 1.06-1.14
+ Wire capacitance: 5.42
+ Total capacitance: 6.48-6.56
+ Number of drivers: 1
+ Number of loads: 1
+ Number of pins: 2
+
+Driver pins
+ in2 input port (20, 0)
+
+Load pins
+ r2/D input (DFF_X1) 1.06-1.14 (41, 43)
+
+Net out
+ Pin capacitance: 0.00
+ Wire capacitance: 6.95
+ Total capacitance: 6.95
+ Number of drivers: 1
+ Number of loads: 1
+ Number of pins: 2
+
+Driver pins
+ hold1/Z output (CLKBUF_X1) (41, 41)
+
+Load pins
+ out output port (0, 0)
+

--- a/src/rsz/test/repair_hold16.tcl
+++ b/src/rsz/test/repair_hold16.tcl
@@ -1,0 +1,30 @@
+# repair_timing -hold with dont_touch
+source helpers.tcl
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def repair_hold1.def
+
+create_clock -period 2 clk
+set_input_delay -clock clk 0.0 {in1 in2}
+set_output_delay -clock clk -0.3 out
+set_propagated_clock clk
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal1
+estimate_parasitics -placement
+
+set_dont_touch r2
+
+report_checks -path_delay min -to r2/D
+report_checks -path_delay min -to r3/D
+report_checks -path_delay min -to out
+
+repair_timing -hold
+
+report_worst_slack -min
+report_worst_slack -max
+
+# Verilog "ports" are based on net names so make sure port nets
+# are preserved on inputs and outputs.
+report_net in2
+report_net out


### PR DESCRIPTION
Adds:
- check for dont_touch on hold repair for instances to prevent resizer from attempting to change instance connections.