### PR TITLE
rsz: account for dont use during repairDesign and hold

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -270,6 +270,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   bool dontTouch(const Instance* inst);
   void setDontTouch(const Net* net, bool dont_touch);
   bool dontTouch(const Net* net);
+  bool dontTouch(const Pin* pin);
   void reportDontTouch();
 
   void setMaxUtilization(double max_utilization);

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -671,7 +671,9 @@ void RepairDesign::repairNet(Net* net,
     const Corner* corner = sta_->cmdCorner();
     bool repaired_net = false;
 
-    if (buffer_gain_ != 0.0) {
+    const bool can_repair = !resizer_->dontTouch(drvr_pin);
+
+    if (can_repair && buffer_gain_ != 0.0) {
       float fanout, max_fanout, fanout_slack;
       sta_->checkFanout(drvr_pin, max_, fanout, max_fanout, fanout_slack);
 
@@ -709,7 +711,8 @@ void RepairDesign::repairNet(Net* net,
     }
 
     // Resize the driver to normalize slews before repairing limit violations.
-    if (parasitics_src_ == ParasiticsSrc::placement && resize_drvr) {
+    if (can_repair && parasitics_src_ == ParasiticsSrc::placement
+        && resize_drvr) {
       resize_count_ += resizer_->resizeToTargetSlew(drvr_pin);
     }
     // For tristate nets all we can do is resize the driver.
@@ -734,7 +737,9 @@ void RepairDesign::repairNet(Net* net,
 
         if (need_repair) {
           if (parasitics_src_ == ParasiticsSrc::global_routing && resize_drvr) {
-            resize_count_ += resizer_->resizeToTargetSlew(drvr_pin);
+            if (can_repair) {
+              resize_count_ += resizer_->resizeToTargetSlew(drvr_pin);
+            }
             wire_length = bnet->maxLoadWireLength();
             need_repair = needRepair(drvr_pin,
                                      corner,
@@ -764,7 +769,7 @@ void RepairDesign::repairNet(Net* net,
             repairNet(bnet, drvr_pin, max_cap, max_length, corner);
             repaired_net = true;
 
-            if (resize_drvr) {
+            if (can_repair && resize_drvr) {
               resize_count_ += resizer_->resizeToTargetSlew(drvr_pin);
             }
           }
@@ -1855,6 +1860,12 @@ void RepairDesign::makeRepeater(const char* reason,
       if (!load_pins1.hasKey(pin)) {
         Port* port = network_->port(pin);
         Instance* inst = network_->instance(pin);
+
+        // do not disconnect/reconnect don't touch instances
+        if (resizer_->dontTouch(inst)) {
+          continue;
+        }
+
         sta_->disconnectPin(const_cast<Pin*>(pin));
         sta_->connectPin(inst, port, in_net);
       }

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -409,7 +409,7 @@ void RepairHold::repairEndHold(Vertex* end_vertex,
                             ? network_->net(network_->term(path_pin))
                             : network_->net(path_pin);
         dbNet* db_path_net = db_network_->staToDb(path_net);
-        if (path_vertex->isDriver(network_) && !resizer_->dontTouch(path_net)
+        if (path_vertex->isDriver(network_) && !resizer_->dontTouch(path_pin)
             && !db_path_net->isConnectedByAbutment()) {
           PinSeq load_pins;
           Slacks slacks;
@@ -671,6 +671,10 @@ void RepairHold::makeHoldDelay(Vertex* drvr,
 
   // hook up loads to buffer
   for (const Pin* load_pin : load_pins) {
+    if (resizer_->dontTouch(load_pin)) {
+      continue;
+    }
+
     Net* load_net = network_->isTopLevelPort(load_pin)
                         ? network_->net(network_->term(load_pin))
                         : network_->net(load_pin);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1861,7 +1861,15 @@ void Resizer::setDontTouch(const Net* net, bool dont_touch)
 bool Resizer::dontTouch(const Net* net)
 {
   dbNet* db_net = db_network_->staToDb(net);
+  if (db_net == nullptr) {
+    return false;
+  }
   return db_net->isDoNotTouch();
+}
+
+bool Resizer::dontTouch(const Pin* pin)
+{
+  return dontTouch(network_->instance(pin)) || dontTouch(network_->net(pin));
 }
 
 void Resizer::reportDontTouch()


### PR DESCRIPTION
@maliberty these are the fixes I needed to make dontTouch work for resizer (not universal, but point fixes for each place I found it violating the dontTouch flag).