### PR TITLE
cts: check if clock edge is nullptr

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -2118,7 +2118,12 @@ float TritonCTS::getVertexClkArrival(sta::Vertex* sinkVertex,
   float clkPathArrival = 0.0;
   while (pathIter.hasNext()) {
     sta::Path* path = pathIter.next();
-    if (path->clkEdge(openSta_)->transition() != sta::RiseFall::rise()) {
+    const sta::ClockEdge* clock_edge = path->clkEdge(openSta_);
+    if (clock_edge == nullptr) {
+      continue;
+    }
+
+    if (clock_edge->transition() != sta::RiseFall::rise()) {
       // only populate with rising edges
       continue;
     }


### PR DESCRIPTION
This might indicate an issue with the design, but it looks like we need to check the return to avoid segfaulting