### PR TITLE
rsz: if no layers or orientation are specifeid consider bot H & V resistance for clk wires

### DIFF
--- a/src/rsz/src/EstimateWireParasitics.cc
+++ b/src/rsz/src/EstimateWireParasitics.cc
@@ -207,10 +207,7 @@ double Resizer::wireClkResistance(const Corner* corner) const
   if (wire_clk_res_.empty()) {
     return 0.0;
   }
-  double h_clk_res = wire_clk_res_[corner->index()].h_res;
-  if (h_clk_res > 0.0) {
-    return h_clk_res;
-  }
+
   return (wire_clk_res_[corner->index()].h_res
           + wire_clk_res_[corner->index()].v_res)
          / 2;


### PR DESCRIPTION
As mentioned in [#6651]( https://github.com/The-OpenROAD-Project/OpenROAD/discussions/6651#discussioncomment-12083425), the resistance for clk wires when there is no layer or orientation provided always uses horizontal resistance. It should consider also the vertical resistance, like it is done for clk wire capacitance.