### PR TITLE
rsz/odb: check for mergeNet success before removing buffer

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -2867,7 +2867,7 @@ class dbNet : public dbObject
   ///
   /// Merge the iterms and bterms of the in_net with this net
   ///
-  void mergeNet(dbNet* in_net);
+  bool mergeNet(dbNet* in_net);
 
   dbSet<dbGuide> getGuides() const;
 

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -3238,21 +3238,29 @@ dbNet* dbNet::getValidNet(dbBlock* block_, uint dbid_)
   return (dbNet*) block->_net_tbl->getPtr(dbid_);
 }
 
-void dbNet::mergeNet(dbNet* in_net)
+bool dbNet::mergeNet(dbNet* in_net)
 {
   _dbNet* net = (_dbNet*) this;
   _dbBlock* block = (_dbBlock*) net->getOwner();
-  for (auto callback : block->_callbacks) {
-    callback->inDbNetPreMerge(this, in_net);
+
+  if (isDoNotTouch() || in_net->isDoNotTouch()) {
+    return false;
   }
 
   std::vector<dbITerm*> iterms;
   for (dbITerm* iterm : in_net->getITerms()) {
-    iterm->disconnect();
     iterms.push_back(iterm);
+    if (iterm->getInst()->isDoNotTouch()) {
+      return false;
+    }
+  }
+
+  for (auto callback : block->_callbacks) {
+    callback->inDbNetPreMerge(this, in_net);
   }
 
   for (dbITerm* iterm : iterms) {
+    iterm->disconnect();
     iterm->connect(this);
   }
 
@@ -3265,6 +3273,8 @@ void dbNet::mergeNet(dbNet* in_net)
   for (dbBTerm* bterm : bterms) {
     bterm->connect(this);
   }
+
+  return true;
 }
 
 void dbNet::markNets(std::vector<dbNet*>& nets, dbBlock* block, bool mk)

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -3260,17 +3260,10 @@ bool dbNet::mergeNet(dbNet* in_net)
   }
 
   for (dbITerm* iterm : iterms) {
-    iterm->disconnect();
     iterm->connect(this);
   }
 
-  std::vector<dbBTerm*> bterms;
   for (dbBTerm* bterm : in_net->getBTerms()) {
-    bterm->disconnect();
-    bterms.push_back(bterm);
-  }
-
-  for (dbBTerm* bterm : bterms) {
     bterm->connect(this);
   }
 

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -384,22 +384,23 @@ bool Resizer::removeBuffer(Instance* buffer,
                1,
                "remove {}",
                db_network_->name(buffer));
-    buffer_removed = true;
 
     if (removed) {
       odb::dbNet* db_survivor = db_network_->staToDb(survivor);
       odb::dbNet* db_removed = db_network_->staToDb(removed);
-      db_survivor->mergeNet(db_removed);
+      if (db_survivor->mergeNet(db_removed)) {
+        buffer_removed = true;
+        sta_->disconnectPin(in_pin);
+        sta_->disconnectPin(out_pin);
+        sta_->deleteInstance(buffer);
 
-      sta_->disconnectPin(in_pin);
-      sta_->disconnectPin(out_pin);
-      sta_->deleteInstance(buffer);
+        sta_->deleteNet(removed);
+        parasitics_invalid_.erase(removed);
 
-      sta_->deleteNet(removed);
-      parasitics_invalid_.erase(removed);
+        parasiticsInvalid(survivor);
+        updateParasitics();
+      }
     }
-    parasiticsInvalid(survivor);
-    updateParasitics();
   }
   return buffer_removed;
 }


### PR DESCRIPTION
Fixes remove_buffers failing with dont_touch set

Changes:
- mergeNet checks if iterm insts are marked dontTouch and return before making modifications to the design if any are set.
- removeBuffers will not remove a buffer is the net fails to be merged