### PR TITLE
dst: dst_lib linkable

### DIFF
--- a/src/dst/CMakeLists.txt
+++ b/src/dst/CMakeLists.txt
@@ -39,21 +39,42 @@ find_package(TCL)
 project(dst
   LANGUAGES CXX
 )
+
 find_package(Boost REQUIRED COMPONENTS serialization system thread)
 swig_lib(NAME      dst
          NAMESPACE dst
          I_FILE    src/Distributed.i
          SCRIPTS   src/Distributed.tcl
 )
-target_sources(dst
-  PRIVATE
+
+add_library(dst_lib
   src/JobMessage.cc
   src/Worker.cc
   src/LoadBalancer.cc
   src/WorkerConnection.cc
   src/BalancerConnection.cc
-  src/MakeDistributed.cc
   src/Distributed.cc
+)
+
+target_include_directories(dst_lib
+  PUBLIC
+    include
+)
+
+target_link_libraries(dst_lib
+  PUBLIC
+    utl_lib
+    OpenSTA
+    ${TCL_LIBRARY}
+    ${ZLIB_LIBRARIES}
+    Boost::serialization
+    Boost::system
+    Boost::thread
+)
+
+target_sources(dst
+  PRIVATE
+  src/MakeDistributed.cc
 )
 
 target_include_directories(dst
@@ -63,13 +84,7 @@ target_include_directories(dst
 
 target_link_libraries(dst
   PUBLIC
-    utl_lib
-    OpenSTA
-    ${TCL_LIBRARY}
-    ${ZLIB_LIBRARIES}
-    Boost::serialization
-    Boost::system
-    Boost::thread
+    dst_lib
 )
 
 messages(

--- a/src/dst/include/dst/Distributed.h
+++ b/src/dst/include/dst/Distributed.h
@@ -28,8 +28,6 @@
 
 #pragma once
 
-#include <tcl.h>
-
 #include <boost/asio.hpp>
 #include <memory>
 #include <string>
@@ -53,7 +51,7 @@ class Distributed
  public:
   Distributed(utl::Logger* logger = nullptr);
   ~Distributed();
-  void init(Tcl_Interp* tcl_interp, utl::Logger* logger);
+  void init(utl::Logger* logger);
   void runWorker(const char* ip, unsigned short port, bool interactive);
   void runLoadBalancer(const char* ip,
                        unsigned short port,

--- a/src/dst/src/Distributed.cc
+++ b/src/dst/src/Distributed.cc
@@ -37,22 +37,12 @@
 #include "Worker.h"
 #include "dst/JobCallBack.h"
 #include "dst/JobMessage.h"
-#include "sta/StaMain.hh"
 #include "utl/Logger.h"
 namespace dst {
 const int MAX_TRIES = 5;
 }
 
 using namespace dst;
-
-namespace sta {
-// Tcl files encoded into strings.
-extern const char* dst_tcl_inits[];
-}  // namespace sta
-
-extern "C" {
-extern int Dst_Init(Tcl_Interp* interp);
-}
 
 Distributed::Distributed(utl::Logger* logger) : logger_(logger)
 {
@@ -66,12 +56,9 @@ Distributed::~Distributed()
   callbacks_.clear();
 }
 
-void Distributed::init(Tcl_Interp* tcl_interp, utl::Logger* logger)
+void Distributed::init(utl::Logger* logger)
 {
   logger_ = logger;
-  // Define swig TCL commands.
-  Dst_Init(tcl_interp);
-  sta::evalTclInit(tcl_interp, sta::dst_tcl_inits);
 }
 
 void Distributed::runWorker(const char* ip,

--- a/src/dst/src/MakeDistributed.cc
+++ b/src/dst/src/MakeDistributed.cc
@@ -28,8 +28,20 @@
 
 #include "dst/MakeDistributed.h"
 
+#include <tcl.h>
+
 #include "dst/Distributed.h"
 #include "ord/OpenRoad.hh"
+#include "sta/StaMain.hh"
+
+namespace sta {
+// Tcl files encoded into strings.
+extern const char* dst_tcl_inits[];
+}  // namespace sta
+
+extern "C" {
+extern int Dst_Init(Tcl_Interp* interp);
+}
 
 namespace ord {
 
@@ -45,8 +57,11 @@ void deleteDistributed(dst::Distributed* dstr)
 
 void initDistributed(OpenRoad* openroad)
 {
-  openroad->getDistributed()->init(openroad->tclInterp(),
-                                   openroad->getLogger());
+  // Define swig TCL commands.
+  auto tcl_interp = openroad->tclInterp();
+  Dst_Init(tcl_interp);
+  sta::evalTclInit(tcl_interp, sta::dst_tcl_inits);
+  openroad->getDistributed()->init(openroad->getLogger());
 }
 
 }  // namespace ord


### PR DESCRIPTION
Tackles #6532.

GRT depends on DRT, which in turn depends on DST. Thus, it is necessary for a DST_LIB linkable with core code to exists that does not depend on the ORD singleton. This PR creates this separation.

This should be the final PR on the issue, as the three together actually solve the issue.