### PR TITLE
Fix incorrect and ambiguous help strings

### DIFF
--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -73,24 +73,24 @@ sta::define_cmd_args "clock_tree_synthesis" {[-wire_unit unit]
                                              [-root_buf buf] \
                                              [-clk_nets nets] \
                                              [-tree_buf buf] \
-                                             [-distance_between_buffers] \
-                                             [-branching_point_buffers_distance] \
-                                             [-clustering_exponent] \
-                                             [-clustering_unbalance_ratio] \
-                                             [-sink_clustering_size] \
-                                             [-sink_clustering_max_diameter] \
+                                             [-distance_between_buffers distance] \
+                                             [-branching_point_buffers_distance distance] \
+                                             [-clustering_exponent exponent] \
+                                             [-clustering_unbalance_ratio ratio] \
+                                             [-sink_clustering_size size] \
+                                             [-sink_clustering_max_diameter diameter] \
                                              [-sink_clustering_enable] \
                                              [-balance_levels] \
                                              [-sink_clustering_levels levels] \
-                                             [-num_static_layers] \
-                                             [-sink_clustering_buffer] \
+                                             [-num_static_layers num] \
+                                             [-sink_clustering_buffer buf] \
                                              [-obstruction_aware] \
                                              [-no_obstruction_aware] \
                                              [-apply_ndr] \
-                                             [-sink_buffer_max_cap_derate] \
+                                             [-sink_buffer_max_cap_derate derate] \
                                              [-dont_use_dummy_load] \
-                                             [-delay_buffer_derate] \
-                                             [-library] \
+                                             [-delay_buffer_derate derate] \
+                                             [-library library] \
 } ;# checker off
 
 proc clock_tree_synthesis { args } {

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -212,7 +212,7 @@ sta::define_cmd_args "detailed_route_debug" {
     [-maze]
     [-net name]
     [-pin name]
-    [-box x1 y1 x2 y2]
+    [-box {x1 y1 x2 y2}]
     [-dump_last_worker]
     [-iter iter]
     [-pa_markers]

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -255,7 +255,7 @@ proc global_route { args } {
   }
 }
 
-sta::define_cmd_args "repair_antennas" { diode_cell \
+sta::define_cmd_args "repair_antennas" { [diode_cell] \
                                          [-iterations iterations] \
                                          [-ratio_margin ratio_margin]}
 

--- a/src/pad/src/pad.tcl
+++ b/src/pad/src/pad.tcl
@@ -230,11 +230,11 @@ proc place_corners { args } {
   pad::place_corner $master $index
 }
 
-sta::define_cmd_args "place_pad" {[-master master] \
+sta::define_cmd_args "place_pad" {name \
+                                  [-master master] \
                                   -row row_name \
                                   -location x_or_y_offset \
-                                  -mirror \
-                                  name}
+                                  -mirror}
 
 proc place_pad { args } {
   sta::parse_key_args "place_pad" args \


### PR DESCRIPTION
This PR updates some help strings that are incorrect or ambiguous. These were caught by some old work I was doing on parsing OpenROAD help strings.

`clock_tree_synthesis`: a bunch of the switches were missing arguments, making them look like flags
- `detailed_route_debug`: putting braces around list items is more consistent with e.g. `initialize_floorplan`, and makes it explicit that these items need to be part of a list (rather than 4 separate words)
- `repair_antennas`: the `diode_cell` argument is optional
- `place_pad`: this one feels the least important since I think most people could infer this, but putting the positional argument makes it extra clear that `-mirror` doesn't accept a value "name". I think this is also consistent with how some other help strings are defined. 