### PR TITLE
gpl: remove callback prints

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2920,21 +2920,13 @@ void NesterovBase::destroyGCell(odb::dbInst* db_inst)
     swapAndPopParallelVectors(gcell_index, last_index);
     gCells_.pop_back();
     db_inst_index_map_.erase(db_it);
-  } else {
-    log_->report(
-        "warning: db_inst not found in db_inst_index_map_ for instance: {}",
-        db_inst->getName());
   }
 }
 
 void NesterovBaseCommon::destroyGCell(size_t index_remove)
 {
-  log_->report("before destroy gCellStor_.size():{}", gCellStor_.size());
   size_t last_index = gCellStor_.size() - 1;
   if (index_remove > last_index) {
-    log_->report("error: index {} out of bounds for fillerStor_ (max:{})",
-                 index_remove,
-                 last_index);
     return;
   }
   if (index_remove != last_index) {
@@ -2942,7 +2934,6 @@ void NesterovBaseCommon::destroyGCell(size_t index_remove)
   }
   gCellStor_.pop_back();
 
-  log_->report("after destroy gCellStor_.size():{}", gCellStor_.size());
   // TODO: update deltaArea_ after cell destruction.
 }
 
@@ -2950,9 +2941,6 @@ void NesterovBase::destroyFillerGCell(size_t index_remove)
 {
   size_t last_index = fillerStor_.size() - 1;
   if (index_remove > last_index) {
-    log_->report("error: index {} out of bounds for fillerStor_ (max:{})",
-                 index_remove,
-                 last_index);
     return;
   }
   if (index_remove != last_index) {
@@ -2969,24 +2957,15 @@ void NesterovBaseCommon::destroyITerm(odb::dbITerm* db_iterm)
 {
   auto db_it = db_iterm_map_.find(db_iterm);
   if (db_it != db_iterm_map_.end()) {
-    log_->report("before destroy gPinStor_.size():{}", gPinStor_.size());
     size_t last_index = gPinStor_.size() - 1;
     size_t index_remove = db_it->second;
     if (index_remove > last_index) {
-      log_->report("error: index {} out of bounds for gPinStor_ (max:{})",
-                   index_remove,
-                   last_index);
       return;
     }
     if (index_remove != last_index) {
       std::swap(gPinStor_[index_remove], gPinStor_[last_index]);
     }
     gPinStor_.pop_back();
-
-    log_->report("after destroy gPinStor_.size():{}", gPinStor_.size());
-  } else {
-    log_->report("error: db_iterm not found in db_iterm_map_ for iterm: {}",
-                 db_iterm->getMTerm()->getName());
   }
 }
 
@@ -2995,16 +2974,10 @@ void NesterovBase::swapAndPop(std::vector<FloatPoint>& vec,
                               size_t last_index)
 {
   if (last_index != vec.size() - 1) {
-    log_->report(
-        "Error: last_index {} does not match the actual last index {}.",
-        last_index,
-        vec.size() - 1);
     return;
   }
 
   if (remove_index != last_index) {
-    log_->report(
-        "Swapping index {} with last_index {}", remove_index, last_index);
     std::swap(vec[remove_index], vec[last_index]);
   }
   vec.pop_back();
@@ -3013,11 +2986,6 @@ void NesterovBase::swapAndPop(std::vector<FloatPoint>& vec,
 void NesterovBase::swapAndPopParallelVectors(size_t remove_index,
                                              size_t last_index)
 {
-  log_->report(
-      "Swapping and popping parallel vectors with remove_index {} and "
-      "last_index {}",
-      remove_index,
-      last_index);
   swapAndPop(curSLPCoordi_, remove_index, last_index);
   swapAndPop(curSLPWireLengthGrads_, remove_index, last_index);
   swapAndPop(curSLPDensityGrads_, remove_index, last_index);


### PR DESCRIPTION
There are probably meant to be debugPrints, but removing them and they can always be added back correctly.