### PR TITLE
rsz: add command to report nets driven by multiple drivers

### DIFF
--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -401,8 +401,16 @@ The `report_overdriven_nets` command reports nets with connected by multiple dri
 
 ```tcl
 report_overdriven_nets
+    [-include_parallel_driven]
     [-verbose]
 ```
+
+#### Options
+
+| Switch Name | Description |
+| ----- | ----- |
+| `-include_parallel_driven` | Include nets that are driven by multiple parallel drivers. |
+| `-verbose` | Print the net names. |
 
 ### Eliminate Dead Logic
 

--- a/src/rsz/README.md
+++ b/src/rsz/README.md
@@ -395,6 +395,15 @@ report_floating_nets
     [-verbose]
 ```
 
+### Report Overdriven Nets
+
+The `report_overdriven_nets` command reports nets with connected by multiple drivers.
+
+```tcl
+report_overdriven_nets
+    [-verbose]
+```
+
 ### Eliminate Dead Logic
 
 The `eliminate_dead_logic` command eliminates dead logic, i.e. it removes standard cell instances which can be removed without affecting the function of the design.

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -343,6 +343,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   // Caller owns return value.
   NetSeq* findFloatingNets();
   PinSet* findFloatingPins();
+  NetSeq* findOverdrivenNets();
   void repairTieFanout(LibertyPort* tie_port,
                        double separation,  // meters
                        bool verbose);

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -343,7 +343,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   // Caller owns return value.
   NetSeq* findFloatingNets();
   PinSet* findFloatingPins();
-  NetSeq* findOverdrivenNets();
+  NetSeq* findOverdrivenNets(bool include_parallel_driven);
   void repairTieFanout(LibertyPort* tie_port,
                        double separation,  // meters
                        bool verbose);

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2468,7 +2468,7 @@ PinSet* Resizer::findFloatingPins()
   return floating_pins;
 }
 
-NetSeq* Resizer::findOverdrivenNets()
+NetSeq* Resizer::findOverdrivenNets(bool include_parallel_driven)
 {
   NetSeq* overdriven_nets = new NetSeq;
   std::unique_ptr<NetIterator> net_iter(
@@ -2488,9 +2488,54 @@ NetSeq* Resizer::findOverdrivenNets()
         }
       }
 
-      if (!all_tristate) {
-        overdriven_nets->emplace_back(net);
+      if (all_tristate) {
+        continue;
       }
+
+      if (!include_parallel_driven) {
+        bool allowed = true;
+        bool has_buffers = false;
+        bool has_inverters = false;
+        std::set<sta::Net*> input_nets;
+
+        for (const Pin* drvr : drvrs) {
+          const Instance* inst = network_->instance(drvr);
+          const LibertyCell* cell = network_->libertyCell(inst);
+          if (cell == nullptr) {
+            allowed = false;
+            break;
+          }
+          if (cell->isBuffer()) {
+            has_buffers = true;
+          }
+          if (cell->isInverter()) {
+            has_inverters = true;
+          }
+
+          std::unique_ptr<InstancePinIterator> inst_pin_iter(
+              network_->pinIterator(inst));
+          while (inst_pin_iter->hasNext()) {
+            Pin* inst_pin = inst_pin_iter->next();
+            sta::PortDirection* dir = network_->direction(inst_pin);
+            if (dir->isAnyInput()) {
+              input_nets.insert(network_->net(inst_pin));
+            }
+          }
+        }
+
+        if (has_inverters && has_buffers) {
+          allowed = false;
+        }
+
+        if (input_nets.size() > 1) {
+          allowed = false;
+        }
+
+        if (allowed) {
+          continue;
+        }
+      }
+      overdriven_nets->emplace_back(net);
     }
   }
   sort(overdriven_nets, sta::NetPathNameLess(network_));

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -454,6 +454,14 @@ find_floating_pins()
   return resizer->findFloatingPins();
 }
 
+TmpNetSeq *
+find_overdriven_nets()
+{
+  ensureLinked();
+  Resizer *resizer = getResizer();
+  return resizer->findOverdrivenNets();
+}
+
 void
 repair_tie_fanout_cmd(LibertyPort *tie_port,
                       double separation, // meters

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -455,11 +455,11 @@ find_floating_pins()
 }
 
 TmpNetSeq *
-find_overdriven_nets()
+find_overdriven_nets(bool include_parallel_driven)
 {
   ensureLinked();
   Resizer *resizer = getResizer();
-  return resizer->findOverdrivenNets();
+  return resizer->findOverdrivenNets(include_parallel_driven);
 }
 
 void

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -709,6 +709,26 @@ sta::proc_redirect report_floating_nets {
   utl::metric_int "timing__drv__floating__pins" $floating_pin_count
 }
 
+sta::define_cmd_args "report_overdriven_nets" {[-verbose] [> filename] [>> filename]} ;# checker off
+
+sta::proc_redirect report_overdriven_nets {
+  sta::parse_key_args "report_overdriven_nets" args keys {} flags {-verbose};# checker off
+
+  set verbose [info exists flags(-verbose)]
+  set overdriven_nets [rsz::find_overdriven_nets]
+  set overdriven_net_count [llength $overdriven_nets]
+  if { $overdriven_net_count > 0 } {
+    utl::warn RSZ 24 "found $overdriven_net_count overdriven nets."
+    if { $verbose } {
+      foreach net $overdriven_nets {
+        utl::report " [get_full_name $net]"
+      }
+    }
+  }
+
+  utl::metric_int "timing__drv__overdriven__nets" $overdriven_net_count
+}
+
 sta::define_cmd_args "report_long_wires" {count [> filename] [>> filename]} ;# checker off
 
 sta::proc_redirect report_long_wires {

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -709,10 +709,15 @@ sta::proc_redirect report_floating_nets {
   utl::metric_int "timing__drv__floating__pins" $floating_pin_count
 }
 
-sta::define_cmd_args "report_overdriven_nets" {[-include_parallel_driven] [-verbose] [> filename] [>> filename]} ;# checker off
+sta::define_cmd_args "report_overdriven_nets" {[-include_parallel_driven] \
+                                               [-verbose] \
+                                               [> filename] \
+                                               [>> filename]} ;# checker off
 
 sta::proc_redirect report_overdriven_nets {
-  sta::parse_key_args "report_overdriven_nets" args keys {} flags {-verbose -include_parallel_driven};# checker off
+  sta::parse_key_args "report_overdriven_nets" args \
+    keys {} \
+    flags {-verbose -include_parallel_driven};# checker off
 
   set verbose [info exists flags(-verbose)]
   set overdriven_nets [rsz::find_overdriven_nets [info exists flags(-include_parallel_driven)]]

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -709,13 +709,13 @@ sta::proc_redirect report_floating_nets {
   utl::metric_int "timing__drv__floating__pins" $floating_pin_count
 }
 
-sta::define_cmd_args "report_overdriven_nets" {[-verbose] [> filename] [>> filename]} ;# checker off
+sta::define_cmd_args "report_overdriven_nets" {[-include_parallel_driven] [-verbose] [> filename] [>> filename]} ;# checker off
 
 sta::proc_redirect report_overdriven_nets {
-  sta::parse_key_args "report_overdriven_nets" args keys {} flags {-verbose};# checker off
+  sta::parse_key_args "report_overdriven_nets" args keys {} flags {-verbose -include_parallel_driven};# checker off
 
   set verbose [info exists flags(-verbose)]
-  set overdriven_nets [rsz::find_overdriven_nets]
+  set overdriven_nets [rsz::find_overdriven_nets [info exists flags(-include_parallel_driven)]]
   set overdriven_net_count [llength $overdriven_nets]
   if { $overdriven_net_count > 0 } {
     utl::warn RSZ 24 "found $overdriven_net_count overdriven nets."

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -127,6 +127,10 @@ or_integration_tests(
     report_floating_nets1
     report_floating_nets2
     report_floating_nets3
+    report_overdriven_nets1
+    report_overdriven_nets2
+    report_overdriven_nets3
+    report_overdriven_nets4
     resize1
     resize1_hier
     resize4

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -131,6 +131,8 @@ or_integration_tests(
     report_overdriven_nets2
     report_overdriven_nets3
     report_overdriven_nets4
+    report_overdriven_nets5
+    report_overdriven_nets6
     resize1
     resize1_hier
     resize4

--- a/src/rsz/test/report_overdriven_nets1.ok
+++ b/src/rsz/test/report_overdriven_nets1.ok
@@ -1,0 +1,1 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells

--- a/src/rsz/test/report_overdriven_nets1.tcl
+++ b/src/rsz/test/report_overdriven_nets1.tcl
@@ -1,0 +1,8 @@
+# report_overdriven_nets with none
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog report_overdriven_nets1.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose

--- a/src/rsz/test/report_overdriven_nets1.v
+++ b/src/rsz/test/report_overdriven_nets1.v
@@ -1,0 +1,12 @@
+module top (in1, clk1, clk2, clk3, out);
+  input in1, clk1, clk2, clk3;
+  output out;
+
+   // unconnected reg output
+  DFF_X1 r1 (.D(in1), .CK(clk1), .Q(r1q), .QN(r1qn));
+
+  // no driver for r2q
+  BUF_X1 u1 (.A(r2q), .Z(u1z));
+  AND2_X1 u2 (.A1(r1q), .A2(u1z), .ZN(u2z));
+  DFF_X1 r3 (.D(u2z), .CK(clk3), .Q(out));
+endmodule // top

--- a/src/rsz/test/report_overdriven_nets2.ok
+++ b/src/rsz/test/report_overdriven_nets2.ok
@@ -1,0 +1,4 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[WARNING RSZ-0024] found 1 overdriven nets.
+[WARNING RSZ-0024] found 1 overdriven nets.
+ u1z

--- a/src/rsz/test/report_overdriven_nets2.tcl
+++ b/src/rsz/test/report_overdriven_nets2.tcl
@@ -1,0 +1,8 @@
+# report_overdriven_nets with 1 net
+source "helpers.tcl"
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_verilog report_overdriven_nets2.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose

--- a/src/rsz/test/report_overdriven_nets2.v
+++ b/src/rsz/test/report_overdriven_nets2.v
@@ -1,0 +1,12 @@
+module top (in1, clk1, clk2, clk3, out);
+  input in1, clk1, clk2, clk3;
+  output out;
+
+   // unconnected reg output
+  DFF_X1 r1 (.D(in1), .CK(clk1), .Q(r1q), .QN(r1qn));
+
+  // no driver for r2q
+  BUF_X1 u1 (.A(r2q), .Z(u1z));
+  AND2_X1 u2 (.A1(r1q), .A2(u1z), .ZN(u1z));
+  DFF_X1 r3 (.D(u2z), .CK(clk3), .Q(out));
+endmodule // top

--- a/src/rsz/test/report_overdriven_nets3.ok
+++ b/src/rsz/test/report_overdriven_nets3.ok
@@ -1,0 +1,2 @@
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells

--- a/src/rsz/test/report_overdriven_nets3.tcl
+++ b/src/rsz/test/report_overdriven_nets3.tcl
@@ -1,0 +1,9 @@
+# report_overdriven_nets with tristate
+source "helpers.tcl"
+read_liberty sky130hs/sky130hs_tt.lib
+read_lef sky130hs/sky130hs.tlef
+read_lef sky130hs/sky130hs_std_cell.lef
+read_verilog report_overdriven_nets3.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose

--- a/src/rsz/test/report_overdriven_nets3.v
+++ b/src/rsz/test/report_overdriven_nets3.v
@@ -1,0 +1,8 @@
+module top (in1, in2, en1, en2, out);
+  input in1, in2, en1, en2;
+  output out;
+
+  sky130_fd_sc_hs__ebufn_4 u0 (.A(in1), .TE_B(en1), .Z(out));
+  sky130_fd_sc_hs__ebufn_4 u1 (.A(in2), .TE_B(en2), .Z(out));
+
+endmodule // top

--- a/src/rsz/test/report_overdriven_nets4.ok
+++ b/src/rsz/test/report_overdriven_nets4.ok
@@ -1,0 +1,5 @@
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells
+[WARNING RSZ-0024] found 1 overdriven nets.
+[WARNING RSZ-0024] found 1 overdriven nets.
+ out

--- a/src/rsz/test/report_overdriven_nets4.tcl
+++ b/src/rsz/test/report_overdriven_nets4.tcl
@@ -1,0 +1,9 @@
+# report_overdriven_nets with tristate and additional driver
+source "helpers.tcl"
+read_liberty sky130hs/sky130hs_tt.lib
+read_lef sky130hs/sky130hs.tlef
+read_lef sky130hs/sky130hs_std_cell.lef
+read_verilog report_overdriven_nets4.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose

--- a/src/rsz/test/report_overdriven_nets4.v
+++ b/src/rsz/test/report_overdriven_nets4.v
@@ -1,0 +1,9 @@
+module top (in1, in2, en1, en2, out);
+  input in1, in2, en1, en2;
+  output out;
+
+  sky130_fd_sc_hs__ebufn_4 u0 (.A(in1), .TE_B(en1), .Z(out));
+  sky130_fd_sc_hs__ebufn_4 u1 (.A(in2), .TE_B(en2), .Z(out));
+  sky130_fd_sc_hs__inv_1 u2 (.A(in2), .Y(out));
+
+endmodule // top

--- a/src/rsz/test/report_overdriven_nets5.ok
+++ b/src/rsz/test/report_overdriven_nets5.ok
@@ -1,0 +1,5 @@
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells
+check include_parallel_driven
+[WARNING RSZ-0024] found 1 overdriven nets.
+ out

--- a/src/rsz/test/report_overdriven_nets5.tcl
+++ b/src/rsz/test/report_overdriven_nets5.tcl
@@ -1,0 +1,11 @@
+# report_overdriven_nets with parallel drivers
+source "helpers.tcl"
+read_liberty sky130hs/sky130hs_tt.lib
+read_lef sky130hs/sky130hs.tlef
+read_lef sky130hs/sky130hs_std_cell.lef
+read_verilog report_overdriven_nets5.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose
+puts "check include_parallel_driven"
+report_overdriven_nets -verbose -include_parallel_driven

--- a/src/rsz/test/report_overdriven_nets5.v
+++ b/src/rsz/test/report_overdriven_nets5.v
@@ -1,0 +1,8 @@
+module top (in1, in2, en1, en2, out);
+  input in1, in2, en1, en2;
+  output out;
+
+  sky130_fd_sc_hs__inv_1 u0 (.A(in2), .Y(out));
+  sky130_fd_sc_hs__inv_1 u1 (.A(in2), .Y(out));
+
+endmodule // top

--- a/src/rsz/test/report_overdriven_nets6.ok
+++ b/src/rsz/test/report_overdriven_nets6.ok
@@ -1,0 +1,5 @@
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells
+[WARNING RSZ-0024] found 1 overdriven nets.
+[WARNING RSZ-0024] found 1 overdriven nets.
+ out

--- a/src/rsz/test/report_overdriven_nets6.tcl
+++ b/src/rsz/test/report_overdriven_nets6.tcl
@@ -1,0 +1,9 @@
+# report_overdriven_nets with parallel drivers
+source "helpers.tcl"
+read_liberty sky130hs/sky130hs_tt.lib
+read_lef sky130hs/sky130hs.tlef
+read_lef sky130hs/sky130hs_std_cell.lef
+read_verilog report_overdriven_nets6.v
+link_design top
+report_overdriven_nets
+report_overdriven_nets -verbose

--- a/src/rsz/test/report_overdriven_nets6.v
+++ b/src/rsz/test/report_overdriven_nets6.v
@@ -1,0 +1,8 @@
+module top (in1, in2, en1, en2, out);
+  input in1, in2, en1, en2;
+  output out;
+
+  sky130_fd_sc_hs__inv_1 u0 (.A(in1), .Y(out));
+  sky130_fd_sc_hs__inv_1 u1 (.A(in2), .Y(out));
+
+endmodule // top


### PR DESCRIPTION
When debugging the dont_touch issues, I noticed several instances were resizer ended up with multiple drivers on a net (fixed by https://github.com/The-OpenROAD-Project/OpenROAD/pull/6708) but it didn't appear that we had any way of reporting these types of issues.

This adds:
- `report_overdriven_nets` (a mirror to `report_floating_nets`) which report nets with multiple drivers accounting for nets with tristate drivers.
