### PR TITLE
flake.nix: replace deprecated url literal with a string literal

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
 {
   inputs = {
-    nixpkgs.url = github:nixos/nixpkgs/nixos-24.05;
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
   };
 
   outputs = {self, nixpkgs, ...}: {


### PR DESCRIPTION
URL Literals are legacy syntax which has been long disallowed in NixOS/nixpkgs, since Lix release 2.92 they have been deprecated in Lix. See <https://lix.systems/blog/2025-01-18-lix-2.92-release/>. Using the normal string syntax makes this flake compatible with both Nix implementations without any special flags.