### PR TITLE
dbSta: Add snapshot creation to report_cell_usage

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -222,7 +222,7 @@ report_global_connect
 The `report_cell_usage` command is used to print out the usage of cells for each type of cell.
 
 ```
-report_cell_usage [-verbose] [module instance]
+report_cell_usage [-verbose] [module instance] [-file file] [-stage stage]
 ```
 
 ##### Options
@@ -231,6 +231,8 @@ report_cell_usage [-verbose] [module instance]
 | ----- | ----- |
 | `-verbose` | Add information about all leaf instances. |
 | `module instance` | Report cell usage for a specified module instance. |
+| `-file file` | Create cell usage snapshot with the given path to file. |
+| `-stage stage` | Attach the stage to the snapshot. |
 
 ## TCL functions
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -36,7 +36,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -197,21 +196,6 @@ class dbSta : public Sta, public ord::OpenRoadObserver
                          bool verbose,
                          const char *file_name,
                          const char *stage_name);
-
-  // Holds the usage information of a specific cell which includes (i) name of
-  // the cell, (ii) number of instances of the cell, and (iii) area of the cell
-  // in microns^2.
-  struct CellUsageInfo {
-    std::string name;
-    int count = 0;
-    double area = 0.0;
-  };
-
-  // Holds a snapshot of cell usage information at a given stage.
-  struct CellUsageSnapshot {
-    std::string stage;
-    std::vector<CellUsageInfo> cells_usage_info;
-  };
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -36,6 +36,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <string>
+#include <vector>
 
 #include "odb/db.h"
 #include "odb/dbBlockCallBackObj.h"
@@ -190,7 +193,25 @@ class dbSta : public Sta, public ord::OpenRoadObserver
 
   std::string getInstanceTypeText(InstType type) const;
   InstType getInstanceType(odb::dbInst* inst);
-  void report_cell_usage(odb::dbModule* module, bool verbose);
+  void report_cell_usage(odb::dbModule* module,
+                         bool verbose,
+                         const char *file_name,
+                         const char *stage_name);
+
+  // Holds the usage information of a specific cell which includes (i) name of
+  // the cell, (ii) number of instances of the cell, and (iii) area of the cell
+  // in microns^2.
+  struct CellUsageInfo {
+    std::string name;
+    int count = 0;
+    double area = 0.0;
+  };
+
+  // Holds a snapshot of cell usage information at a given stage.
+  struct CellUsageSnapshot {
+    std::string stage;
+    std::vector<CellUsageInfo> cells_usage_info;
+  };
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -192,10 +192,8 @@ class dbSta : public Sta, public ord::OpenRoadObserver
 
   std::string getInstanceTypeText(InstType type) const;
   InstType getInstanceType(odb::dbInst* inst);
-  void report_cell_usage(odb::dbModule* module,
-                         bool verbose,
-                         const char *file_name,
-                         const char *stage_name);
+  void report_cell_usage(odb::dbModule* module, bool verbose,
+                         const char* file_name, const char* stage_name);
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -192,8 +192,10 @@ class dbSta : public Sta, public ord::OpenRoadObserver
 
   std::string getInstanceTypeText(InstType type) const;
   InstType getInstanceType(odb::dbInst* inst);
-  void report_cell_usage(odb::dbModule* module, bool verbose,
-                         const char* file_name, const char* stage_name);
+  void report_cell_usage(odb::dbModule* module,
+                         bool verbose,
+                         const char* file_name,
+                         const char* stage_name);
 
   BufferUse getBufferUse(sta::LibertyCell* buffer);
 

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -128,13 +128,6 @@ CellUsageInfo tag_invoke(value_to_tag<CellUsageInfo>, value const& json_value) {
           value_to<double>(json_value.at("area"))};
 }
 
-CellUsageSnapshot tag_invoke(value_to_tag<CellUsageSnapshot>,
-                             value const& json_value) {
-  return {
-      value_to<std::string>(json_value.at("stage")),
-      value_to<std::vector<CellUsageInfo>>(json_value.at("cell_usage_info"))};
-}
-
 }  // namespace boost::json
 
 namespace sta {

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -82,20 +82,21 @@ namespace {
 // Holds the usage information of a specific cell which includes (i) name of
 // the cell, (ii) number of instances of the cell, and (iii) area of the cell
 // in microns^2.
-struct CellUsageInfo {
+struct CellUsageInfo
+{
   std::string name;
   int count = 0;
   double area = 0.0;
 };
 
 // Holds a snapshot of cell usage information at a given stage.
-struct CellUsageSnapshot {
+struct CellUsageSnapshot
+{
   std::string stage;
   std::vector<CellUsageInfo> cells_usage_info;
 };
 
 }  // namespace
-
 
 namespace ord {
 
@@ -108,21 +109,27 @@ dbSta* makeDbSta()
 }  // namespace ord
 
 namespace boost::json {
-void tag_invoke(json::value_from_tag, json::value& json_value,
-                CellUsageInfo const& cell_usage_info) {
+void tag_invoke(json::value_from_tag,
+                json::value& json_value,
+                CellUsageInfo const& cell_usage_info)
+{
   json_value = {{"name", cell_usage_info.name},
                 {"count", cell_usage_info.count},
                 {"area", cell_usage_info.area}};
 }
 
-void tag_invoke(json::value_from_tag, json::value& json_value,
-                CellUsageSnapshot const& cell_usage_snapshot) {
-  json_value = {{"stage", cell_usage_snapshot.stage},
-                {"cell_usage_info", boost::json::value_from(
-                                        cell_usage_snapshot.cells_usage_info)}};
+void tag_invoke(json::value_from_tag,
+                json::value& json_value,
+                CellUsageSnapshot const& cell_usage_snapshot)
+{
+  json_value
+      = {{"stage", cell_usage_snapshot.stage},
+         {"cell_usage_info",
+          boost::json::value_from(cell_usage_snapshot.cells_usage_info)}};
 }
 
-CellUsageInfo tag_invoke(value_to_tag<CellUsageInfo>, value const& json_value) {
+CellUsageInfo tag_invoke(value_to_tag<CellUsageInfo>, value const& json_value)
+{
   return {value_to<std::string>(json_value.at("name")),
           value_to<int>(json_value.at("count")),
           value_to<double>(json_value.at("area"))};

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -88,30 +88,37 @@ dbSta* makeDbSta()
 }  // namespace ord
 
 namespace boost::json {
-void tag_invoke(json::value_from_tag, json::value& json_value,
-                ord::dbSta::CellUsageInfo const& cell_usage_info) {
+void tag_invoke(json::value_from_tag,
+                json::value& json_value,
+                ord::dbSta::CellUsageInfo const& cell_usage_info)
+{
   json_value = {{"name", cell_usage_info.name},
                 {"count", cell_usage_info.count},
                 {"area", cell_usage_info.area}};
 }
 
-void tag_invoke(json::value_from_tag, json::value& json_value,
-                ord::dbSta::CellUsageSnapshot const& cell_usage_snapshot) {
-  json_value = {
-      {"stage", cell_usage_snapshot.stage},
-      {"cell_usage_info",
-       boost::json::value_from(cell_usage_snapshot.cells_usage_info)}};
+void tag_invoke(json::value_from_tag,
+                json::value& json_value,
+                ord::dbSta::CellUsageSnapshot const& cell_usage_snapshot)
+{
+  json_value
+      = {{"stage", cell_usage_snapshot.stage},
+         {"cell_usage_info",
+          boost::json::value_from(cell_usage_snapshot.cells_usage_info)}};
 }
 
 ord::dbSta::CellUsageInfo tag_invoke(value_to_tag<ord::dbSta::CellUsageInfo>,
-                                     value const& json_value) {
+                                     value const& json_value)
+{
   return {value_to<std::string>(json_value.at("name")),
           value_to<int>(json_value.at("count")),
           value_to<double>(json_value.at("area"))};
 }
 
 ord::dbSta::CellUsageSnapshot tag_invoke(
-    value_to_tag<ord::dbSta::CellUsageSnapshot>, value const& json_value) {
+    value_to_tag<ord::dbSta::CellUsageSnapshot>,
+    value const& json_value)
+{
   return {value_to<std::string>(json_value.at("stage")),
           value_to<std::vector<ord::dbSta::CellUsageInfo>>(
               json_value.at("cell_usage_info"))};
@@ -579,8 +586,8 @@ std::string toLowerCase(std::string str)
 
 void dbSta::report_cell_usage(odb::dbModule* module,
                               const bool verbose,
-                              const char *file_name,
-                              const char *stage_name)
+                              const char* file_name,
+                              const char* stage_name)
 {
   InstTypeMap instances_types;
   std::vector<dbInst*> insts;

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -128,13 +128,6 @@ void tag_invoke(json::value_from_tag,
           boost::json::value_from(cell_usage_snapshot.cells_usage_info)}};
 }
 
-CellUsageInfo tag_invoke(value_to_tag<CellUsageInfo>, value const& json_value)
-{
-  return {value_to<std::string>(json_value.at("name")),
-          value_to<int>(json_value.at("count")),
-          value_to<double>(json_value.at("area"))};
-}
-
 }  // namespace boost::json
 
 namespace sta {

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -77,6 +77,26 @@
 
 ////////////////////////////////////////////////////////////////
 
+namespace {
+
+// Holds the usage information of a specific cell which includes (i) name of
+// the cell, (ii) number of instances of the cell, and (iii) area of the cell
+// in microns^2.
+struct CellUsageInfo {
+  std::string name;
+  int count = 0;
+  double area = 0.0;
+};
+
+// Holds a snapshot of cell usage information at a given stage.
+struct CellUsageSnapshot {
+  std::string stage;
+  std::vector<CellUsageInfo> cells_usage_info;
+};
+
+}  // namespace
+
+
 namespace ord {
 
 using sta::dbSta;
@@ -88,40 +108,31 @@ dbSta* makeDbSta()
 }  // namespace ord
 
 namespace boost::json {
-void tag_invoke(json::value_from_tag,
-                json::value& json_value,
-                ord::dbSta::CellUsageInfo const& cell_usage_info)
-{
+void tag_invoke(json::value_from_tag, json::value& json_value,
+                CellUsageInfo const& cell_usage_info) {
   json_value = {{"name", cell_usage_info.name},
                 {"count", cell_usage_info.count},
                 {"area", cell_usage_info.area}};
 }
 
-void tag_invoke(json::value_from_tag,
-                json::value& json_value,
-                ord::dbSta::CellUsageSnapshot const& cell_usage_snapshot)
-{
-  json_value
-      = {{"stage", cell_usage_snapshot.stage},
-         {"cell_usage_info",
-          boost::json::value_from(cell_usage_snapshot.cells_usage_info)}};
+void tag_invoke(json::value_from_tag, json::value& json_value,
+                CellUsageSnapshot const& cell_usage_snapshot) {
+  json_value = {{"stage", cell_usage_snapshot.stage},
+                {"cell_usage_info", boost::json::value_from(
+                                        cell_usage_snapshot.cells_usage_info)}};
 }
 
-ord::dbSta::CellUsageInfo tag_invoke(value_to_tag<ord::dbSta::CellUsageInfo>,
-                                     value const& json_value)
-{
+CellUsageInfo tag_invoke(value_to_tag<CellUsageInfo>, value const& json_value) {
   return {value_to<std::string>(json_value.at("name")),
           value_to<int>(json_value.at("count")),
           value_to<double>(json_value.at("area"))};
 }
 
-ord::dbSta::CellUsageSnapshot tag_invoke(
-    value_to_tag<ord::dbSta::CellUsageSnapshot>,
-    value const& json_value)
-{
-  return {value_to<std::string>(json_value.at("stage")),
-          value_to<std::vector<ord::dbSta::CellUsageInfo>>(
-              json_value.at("cell_usage_info"))};
+CellUsageSnapshot tag_invoke(value_to_tag<CellUsageSnapshot>,
+                             value const& json_value) {
+  return {
+      value_to<std::string>(json_value.at("stage")),
+      value_to<std::vector<CellUsageInfo>>(json_value.at("cell_usage_info"))};
 }
 
 }  // namespace boost::json

--- a/src/dbSta/src/dbSta.i
+++ b/src/dbSta/src/dbSta.i
@@ -165,12 +165,15 @@ db_network_defined()
 }
 
 void
-report_cell_usage_cmd(odb::dbModule* mod, const bool verbose)
+report_cell_usage_cmd(odb::dbModule* mod,
+                      const bool verbose,
+                      const char *file_name,
+                      const char *stage_name)
 {
   ord::OpenRoad *openroad = ord::getOpenRoad();
   sta::dbSta *sta = openroad->getSta();
   sta->ensureLinked();
-  sta->report_cell_usage(mod, verbose);
+  sta->report_cell_usage(mod, verbose, file_name, stage_name);
 }
 
 // Copied from sta/verilog/Verilog.i because we don't want sta::read_verilog

--- a/src/dbSta/src/dbSta.tcl
+++ b/src/dbSta/src/dbSta.tcl
@@ -79,10 +79,11 @@ proc highlight_path { args } {
   }
 }
 
-define_cmd_args "report_cell_usage" {[-verbose] [module_inst]}
+define_cmd_args "report_cell_usage" { \
+  [-verbose] [module_inst] [-file file] [-stage stage]}
 
 proc report_cell_usage { args } {
-  parse_key_args "highlight_path" args keys {} \
+  parse_key_args "highlight_path" args keys {-file -stage} \
     flags {-verbose} 0
 
   check_argc_eq0or1 "report_cell_usage" $args
@@ -99,8 +100,17 @@ proc report_cell_usage { args } {
     }
     set module [$modinst getMaster]
   }
+  set verbose [info exists flags(-verbose)]
+  set file_name ""
+  if { [info exists keys(-file)] } {
+    set file_name $keys(-file)
+  }
+  set stage_name ""
+  if { [info exists keys(-stage)] } {
+    set stage_name $keys(-stage)
+  }
 
-  report_cell_usage_cmd $module [info exists flags(-verbose)]
+  report_cell_usage_cmd $module $verbose $file_name $stage_name
 }
 
 # redefine sta::sta_warn/error to call utl::warn/error


### PR DESCRIPTION
Add snapshot creation functionality to report_cell_usage. This will only be active if -file flag is specified (and optionally a name can be given to the stage at which the snapshot is created)