### PR TITLE
mpl: clean up / improvements of debug messages & some fixes

### DIFF
--- a/src/mpl/doc/debugMessages.md
+++ b/src/mpl/doc/debugMessages.md
@@ -29,10 +29,9 @@ MPL2 debug messages are divided in:
 ### Hierarchical Macro Placement
 - Group Name: `hierarchical_macro_placement`
 - Levels:
-1. Overall steps of the stage.
-2. Include in logs:
-    * Clusters' connections;
-    * Simulated annealing results for both SoftMacro and HardMacro.
+1. Summary with the final costs of each penalty for cluster/macro placement.
+2. Include locations chosen for each child/macro.
+3. Include, before the summary, a list with the connections between clusters.
 
 ### Orientation Improvement
 - Group Name: `flipping`

--- a/src/mpl/src/MplObserver.h
+++ b/src/mpl/src/MplObserver.h
@@ -41,6 +41,7 @@
 #include "clusterEngine.h"
 #include "object.h"
 #include "odb/geom.h"
+#include "util.h"
 #include "utl/Logger.h"
 
 namespace mpl {
@@ -50,13 +51,6 @@ class Cluster;
 class MplObserver
 {
  public:
-  // The final cost is norm_penalty * weight
-  struct Penalty
-  {
-    float weight;
-    float norm_penalty;
-  };
-
   MplObserver() = default;
   virtual ~MplObserver() = default;
 
@@ -92,14 +86,14 @@ class MplObserver
   virtual void setGuides(const std::map<int, Rect>& guides) {}
   virtual void setFences(const std::map<int, Rect>& fences) {}
 
-  virtual void setAreaPenalty(const Penalty& penalty) {}
-  virtual void setBoundaryPenalty(const Penalty& penalty) {}
-  virtual void setFencePenalty(const Penalty& penalty) {}
-  virtual void setGuidancePenalty(const Penalty& penalty) {}
-  virtual void setMacroBlockagePenalty(const Penalty& penalty) {}
-  virtual void setNotchPenalty(const Penalty& penalty) {}
-  virtual void setOutlinePenalty(const Penalty& penalty) {}
-  virtual void setWirelengthPenalty(const Penalty& penalty) {}
+  virtual void setAreaPenalty(const PenaltyData& penalty) {}
+  virtual void setBoundaryPenalty(const PenaltyData& penalty) {}
+  virtual void setFencePenalty(const PenaltyData& penalty) {}
+  virtual void setGuidancePenalty(const PenaltyData& penalty) {}
+  virtual void setMacroBlockagePenalty(const PenaltyData& penalty) {}
+  virtual void setNotchPenalty(const PenaltyData& penalty) {}
+  virtual void setOutlinePenalty(const PenaltyData& penalty) {}
+  virtual void setWirelengthPenalty(const PenaltyData& penalty) {}
   virtual void penaltyCalculated(float norm_cost) {}
 
   virtual void eraseDrawing() {}

--- a/src/mpl/src/SACoreHardMacro.cpp
+++ b/src/mpl/src/SACoreHardMacro.cpp
@@ -92,12 +92,6 @@ void SACoreHardMacro::run()
   }
 }
 
-float SACoreHardMacro::getAreaPenalty() const
-{
-  const float outline_area = outline_.getWidth() * outline_.getHeight();
-  return (width_ * height_) / outline_area;
-}
-
 float SACoreHardMacro::calNormCost() const
 {
   float cost = 0.0;  // Initialize cost
@@ -297,75 +291,11 @@ void SACoreHardMacro::setWeights(const SACoreWeights& weights)
   core_weights_ = weights;
 }
 
-void SACoreHardMacro::printResults()
+void SACoreHardMacro::printResults() const
 {
-  debugPrint(
-      logger_, MPL, "hierarchical_macro_placement", 2, "SACoreHardMacro");
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "number of macros : {}",
-             macros_.size());
-  for (const auto& macro : macros_) {
-    debugPrint(logger_,
-               MPL,
-               "hierarchical_macro_placement",
-               2,
-               "lx = {}, ly = {}, width = {}, height = {}",
-               macro.getX(),
-               macro.getY(),
-               macro.getWidth(),
-               macro.getHeight());
-  }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "width = {}, outline_width = {}",
-             width_,
-             outline_.getWidth());
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "height = {}, outline_height = {}",
-             height_,
-             outline_.getHeight());
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "outline_penalty  = {}, norm_outline_penalty = {}",
-             outline_penalty_,
-             norm_outline_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "wirelength  = {}, norm_wirelength = {}",
-             wirelength_,
-             norm_wirelength_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "guidance_penalty  = {}, norm_guidance_penalty = {}",
-             guidance_penalty_,
-             norm_guidance_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "fence_penalty  = {}, norm_fence_penalty = {}",
-             fence_penalty_,
-             norm_fence_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "final cost = {}",
-             getNormCost());
+  reportCoreWeights();
+  reportFinalCost();
+  reportLocations();
 }
 
 }  // namespace mpl

--- a/src/mpl/src/SACoreHardMacro.cpp
+++ b/src/mpl/src/SACoreHardMacro.cpp
@@ -296,7 +296,9 @@ void SACoreHardMacro::printResults() const
 {
   reportCoreWeights();
   reportTotalCost();
-  reportLocations();
+  if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 2)) {
+    reportLocations();
+  }
 }
 
 }  // namespace mpl

--- a/src/mpl/src/SACoreHardMacro.cpp
+++ b/src/mpl/src/SACoreHardMacro.cpp
@@ -120,7 +120,8 @@ void SACoreHardMacro::calPenalty()
   calGuidancePenalty();
   calFencePenalty();
   if (graphics_) {
-    graphics_->setAreaPenalty({core_weights_.area, getAreaPenalty()});
+    graphics_->setAreaPenalty(
+        {"Area", core_weights_.area, getAreaPenalty(), norm_area_penalty_});
     graphics_->penaltyCalculated(calNormCost());
   }
 }
@@ -294,7 +295,7 @@ void SACoreHardMacro::setWeights(const SACoreWeights& weights)
 void SACoreHardMacro::printResults() const
 {
   reportCoreWeights();
-  reportFinalCost();
+  reportTotalCost();
   reportLocations();
 }
 

--- a/src/mpl/src/SACoreHardMacro.h
+++ b/src/mpl/src/SACoreHardMacro.h
@@ -74,12 +74,11 @@ class SACoreHardMacro : public SimulatedAnnealingCore<HardMacro>
   void initialize() override;
   void fillDeadSpace() override {}
   // print results
-  void printResults();
+  void printResults() const;
 
  private:
   float calNormCost() const override;
   void calPenalty() override;
-  float getAreaPenalty() const;
   void shrink() override {}
 
   void perturb() override;

--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -137,12 +137,6 @@ float SACoreSoftMacro::getNotchPenalty() const
   return notch_penalty_;
 }
 
-float SACoreSoftMacro::getAreaPenalty() const
-{
-  const float outline_area = outline_.getWidth() * outline_.getHeight();
-  return (width_ * height_) / outline_area;
-}
-
 float SACoreSoftMacro::getNormNotchPenalty() const
 {
   return norm_notch_penalty_;
@@ -822,97 +816,14 @@ void SACoreSoftMacro::shrink()
 
 void SACoreSoftMacro::printResults() const
 {
-  debugPrint(
-      logger_, MPL, "hierarchical_macro_placement", 2, "SACoreSoftMacro");
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "number of macros : {}",
-             macros_.size());
-  for (const auto& macro : macros_) {
-    debugPrint(logger_,
-               MPL,
-               "hierarchical_macro_placement",
-               2,
-               "lx = {}, ly = {}, width = {}, height = {}, name = {}",
-               macro.getX(),
-               macro.getY(),
-               macro.getWidth(),
-               macro.getHeight(),
-               macro.getName());
-  }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "width = {}, outline_width = {}",
-             width_,
-             outline_.getWidth());
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "height = {}, outline_height = {}",
-             height_,
-             outline_.getHeight());
-  debugPrint(
-      logger_,
-      MPL,
-      "hierarchical_macro_placement",
-      2,
-      "outline_weight = {}, outline_penalty  = {}, norm_outline_penalty = {}",
-      core_weights_.outline,
-      outline_penalty_,
-      norm_outline_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "wirelength_weight = {}, wirelength  = {}, norm_wirelength = {}",
-             core_weights_.wirelength,
-             wirelength_,
-             norm_wirelength_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "guidance_weight = {}, guidance_penalty  = {}, "
-             "norm_guidance_penalty = {}",
-             core_weights_.guidance,
-             guidance_penalty_,
-             norm_guidance_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "fence_weight = {}, fence_penalty  = {}, norm_fence_penalty = {}",
-             core_weights_.fence,
-             fence_penalty_,
-             norm_fence_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "macro_blockage_weight = {}, macro_blockage_penalty  = {}, "
-             "norm_macro_blockage_penalty = {}",
-             macro_blockage_weight_,
-             macro_blockage_penalty_,
-             norm_macro_blockage_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "notch_weight = {}, notch_penalty  = {}, norm_notch_penalty = {}",
-             notch_weight_,
-             notch_penalty_,
-             norm_notch_penalty_);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             2,
-             "final cost = {}",
-             getNormCost());
+  reportCoreWeights();
+  report({"Macro Blockage",
+          macro_blockage_weight_,
+          macro_blockage_penalty_,
+          norm_macro_blockage_penalty_});
+  report({"Notch", notch_weight_, notch_penalty_, norm_notch_penalty_});
+  reportFinalCost();
+  reportLocations();
 }
 
 // fill the dead space by adjust the size of MixedCluster

--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -186,7 +186,8 @@ void SACoreSoftMacro::calPenalty()
   calMacroBlockagePenalty();
   calNotchPenalty();
   if (graphics_) {
-    graphics_->setAreaPenalty({core_weights_.area, getAreaPenalty()});
+    graphics_->setAreaPenalty(
+        {"Area", core_weights_.area, getAreaPenalty(), norm_area_penalty_});
     graphics_->penaltyCalculated(calNormCost());
   }
 }
@@ -422,8 +423,10 @@ void SACoreSoftMacro::calBoundaryPenalty()
   // normalization
   boundary_penalty_ = boundary_penalty_ / tot_num_macros;
   if (graphics_) {
-    graphics_->setBoundaryPenalty(
-        {boundary_weight_, boundary_penalty_ / norm_boundary_penalty_});
+    graphics_->setBoundaryPenalty({"Boundary",
+                                   boundary_weight_,
+                                   boundary_penalty_,
+                                   norm_boundary_penalty_});
   }
 }
 
@@ -483,9 +486,10 @@ void SACoreSoftMacro::calMacroBlockagePenalty()
   // normalization
   macro_blockage_penalty_ = macro_blockage_penalty_ / tot_num_macros;
   if (graphics_) {
-    graphics_->setMacroBlockagePenalty(
-        {macro_blockage_weight_,
-         macro_blockage_penalty_ / norm_macro_blockage_penalty_});
+    graphics_->setMacroBlockagePenalty({"Macro Blockage",
+                                        macro_blockage_weight_,
+                                        macro_blockage_penalty_,
+                                        norm_macro_blockage_penalty_});
   }
 }
 
@@ -728,7 +732,7 @@ void SACoreSoftMacro::calNotchPenalty()
       = notch_penalty_ / (outline_.getWidth() * outline_.getHeight());
   if (graphics_) {
     graphics_->setNotchPenalty(
-        {notch_weight_, notch_penalty_ / norm_notch_penalty_});
+        {"Notch", notch_weight_, notch_penalty_, norm_notch_penalty_});
   }
 }
 
@@ -822,7 +826,7 @@ void SACoreSoftMacro::printResults() const
           macro_blockage_penalty_,
           norm_macro_blockage_penalty_});
   report({"Notch", notch_weight_, notch_penalty_, norm_notch_penalty_});
-  reportFinalCost();
+  reportTotalCost();
   reportLocations();
 }
 

--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -827,7 +827,9 @@ void SACoreSoftMacro::printResults() const
           norm_macro_blockage_penalty_});
   report({"Notch", notch_weight_, notch_penalty_, norm_notch_penalty_});
   reportTotalCost();
-  reportLocations();
+  if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 2)) {
+    reportLocations();
+  }
 }
 
 // fill the dead space by adjust the size of MixedCluster

--- a/src/mpl/src/SACoreSoftMacro.h
+++ b/src/mpl/src/SACoreSoftMacro.h
@@ -99,7 +99,6 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
   };
 
  private:
-  float getAreaPenalty() const;
   float calNormCost() const override;
   void calPenalty() override;
 

--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -268,8 +268,10 @@ void SimulatedAnnealingCore<T>::calOutlinePenalty()
   // normalization
   outline_penalty_ = outline_penalty_ / (outline_area);
   if (graphics_) {
-    graphics_->setOutlinePenalty(
-        {core_weights_.outline, outline_penalty_ / norm_outline_penalty_});
+    graphics_->setOutlinePenalty({"Outline",
+                                  core_weights_.outline,
+                                  outline_penalty_,
+                                  norm_outline_penalty_});
   }
 }
 
@@ -313,8 +315,10 @@ void SimulatedAnnealingCore<T>::calWirelength()
                 / (outline_.getHeight() + outline_.getWidth());
 
   if (graphics_) {
-    graphics_->setWirelengthPenalty(
-        {core_weights_.wirelength, wirelength_ / norm_wirelength_});
+    graphics_->setWirelengthPenalty({"Wire Length",
+                                     core_weights_.wirelength,
+                                     wirelength_,
+                                     norm_wirelength_});
   }
 }
 
@@ -424,7 +428,7 @@ void SimulatedAnnealingCore<T>::calFencePenalty()
   fence_penalty_ = fence_penalty_ / fences_.size();
   if (graphics_) {
     graphics_->setFencePenalty(
-        {core_weights_.fence, fence_penalty_ / norm_fence_penalty_});
+        {"Fence", core_weights_.fence, fence_penalty_, norm_fence_penalty_});
   }
 }
 
@@ -463,8 +467,10 @@ void SimulatedAnnealingCore<T>::calGuidancePenalty()
   guidance_penalty_ = guidance_penalty_ / guides_.size();
 
   if (graphics_) {
-    graphics_->setGuidancePenalty(
-        {core_weights_.guidance, guidance_penalty_ / norm_guidance_penalty_});
+    graphics_->setGuidancePenalty({"Guidance",
+                                   core_weights_.guidance,
+                                   guidance_penalty_,
+                                   norm_guidance_penalty_});
   }
 }
 
@@ -641,28 +647,30 @@ float SimulatedAnnealingCore<T>::calAverage(std::vector<float>& value_list)
 }
 
 template <class T>
-void SimulatedAnnealingCore<T>::report(const Penalty& penalty) const
+void SimulatedAnnealingCore<T>::report(const PenaltyData& penalty) const
 {
-  logger_->report("{:>15s} | {:>8.4f} | {:>7.4f} | {:>13.4f} | {:>7.4f} ",
-                  penalty.name,
-                  penalty.weight,
-                  penalty.value,
-                  penalty.initial_average,
-                  penalty.weight * penalty.value / penalty.initial_average);
+  logger_->report(
+      "{:>15s} | {:>8.4f} | {:>7.4f} | {:>14.4f} | {:>7.4f} ",
+      penalty.name,
+      penalty.weight,
+      penalty.value,
+      penalty.normalization_factor,
+      penalty.weight * penalty.value / penalty.normalization_factor);
 }
 
 template <class T>
 void SimulatedAnnealingCore<T>::reportCoreWeights() const
 {
   logger_->report(
-      "\n  Penalty Type  |  Weight  |  Value  |  Initial Avg  |  Cost");
+      "\n  Penalty Type  |  Weight  |  Value  |  Norm. Factor  |  Cost");
   logger_->report(
-      "--------------------------------------------------------------");
+      "---------------------------------------------------------------");
   report({"Area", core_weights_.area, getAreaPenalty(), 1.0f});
   report({"Outline",
           core_weights_.outline,
           outline_penalty_,
           norm_outline_penalty_});
+
   report(
       {"Wire Length", core_weights_.wirelength, wirelength_, norm_wirelength_});
   report({"Guidance",
@@ -673,11 +681,11 @@ void SimulatedAnnealingCore<T>::reportCoreWeights() const
 }
 
 template <class T>
-void SimulatedAnnealingCore<T>::reportFinalCost() const
+void SimulatedAnnealingCore<T>::reportTotalCost() const
 {
   logger_->report(
-      "--------------------------------------------------------------");
-  logger_->report("  Final Cost  {:>48.4f} \n", getNormCost());
+      "---------------------------------------------------------------");
+  logger_->report("  Total Cost  {:>49.4f} \n", getNormCost());
 }
 
 template <class T>

--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -691,52 +691,50 @@ void SimulatedAnnealingCore<T>::reportTotalCost() const
 template <class T>
 void SimulatedAnnealingCore<T>::reportLocations() const
 {
-  if (logger_->debugCheck(utl::MPL, "hierarchical_macro_placement", 2)) {
-    if constexpr (std::is_same_v<T, HardMacro>) {
-      logger_->report("     Id     |                                Location");
-    } else {
-      logger_->report(" Cluster Id |                                Location");
-    }
-
-    logger_->report("-----------------------------------------------------");
-
-    // First the moveable macros. I.e., those from the sequence pair.
-    for (const int macro_id : pos_seq_) {
-      int display_id;
-      if constexpr (std::is_same_v<T, SoftMacro>) {
-        const SoftMacro& soft_macro = macros_[macro_id];
-        Cluster* cluster = soft_macro.getCluster();
-        display_id = cluster->getId();
-      } else {
-        display_id = macro_id;
-      }
-
-      const T& macro = macros_[macro_id];
-      logger_->report("{:>11d} | ({:^8.2f} {:^8.2f}) ({:^8.2f} {:^8.2f})",
-                      display_id,
-                      macro.getX(),
-                      macro.getY(),
-                      macro.getWidth(),
-                      macro.getHeight());
-    }
-
-    // Then, the fixed terminals.
-    const int number_of_moveable_macros = static_cast<int>(pos_seq_.size());
-    for (int i = 0; i < macros_.size(); ++i) {
-      if (i <= number_of_moveable_macros) {
-        continue;
-      }
-
-      const T& macro = macros_[i];
-      logger_->report("{:>11s} | ({:^8.2f} {:^8.2f}) ({:^8.2f} {:^8.2f})",
-                      "fixed",
-                      macro.getX(),
-                      macro.getY(),
-                      macro.getWidth(),
-                      macro.getHeight());
-    }
-    logger_->report("");
+  if constexpr (std::is_same_v<T, HardMacro>) {
+    logger_->report("     Id     |                                Location");
+  } else {
+    logger_->report(" Cluster Id |                                Location");
   }
+
+  logger_->report("-----------------------------------------------------");
+
+  // First the moveable macros. I.e., those from the sequence pair.
+  for (const int macro_id : pos_seq_) {
+    int display_id;
+    if constexpr (std::is_same_v<T, SoftMacro>) {
+      const SoftMacro& soft_macro = macros_[macro_id];
+      Cluster* cluster = soft_macro.getCluster();
+      display_id = cluster->getId();
+    } else {
+      display_id = macro_id;
+    }
+
+    const T& macro = macros_[macro_id];
+    logger_->report("{:>11d} | ({:^8.2f} {:^8.2f}) ({:^8.2f} {:^8.2f})",
+                    display_id,
+                    macro.getX(),
+                    macro.getY(),
+                    macro.getWidth(),
+                    macro.getHeight());
+  }
+
+  // Then, the fixed terminals.
+  const int number_of_moveable_macros = static_cast<int>(pos_seq_.size());
+  for (int i = 0; i < macros_.size(); ++i) {
+    if (i <= number_of_moveable_macros) {
+      continue;
+    }
+
+    const T& macro = macros_[i];
+    logger_->report("{:>11s} | ({:^8.2f} {:^8.2f}) ({:^8.2f} {:^8.2f})",
+                    "fixed",
+                    macro.getX(),
+                    macro.getY(),
+                    macro.getWidth(),
+                    macro.getHeight());
+  }
+  logger_->report("");
 }
 
 template <class T>

--- a/src/mpl/src/SimulatedAnnealingCore.h
+++ b/src/mpl/src/SimulatedAnnealingCore.h
@@ -158,9 +158,9 @@ class SimulatedAnnealingCore
 
   // For debugging
   void reportCoreWeights() const;
-  void reportFinalCost() const;
+  void reportTotalCost() const;
   void reportLocations() const;
-  void report(const Penalty& penalty) const;
+  void report(const PenaltyData& penalty) const;
 
   /////////////////////////////////////////////
   // private member variables

--- a/src/mpl/src/SimulatedAnnealingCore.h
+++ b/src/mpl/src/SimulatedAnnealingCore.h
@@ -99,6 +99,7 @@ class SimulatedAnnealingCore
   float getNormCost() const;
   float getWidth() const;
   float getHeight() const;
+  float getAreaPenalty() const;
   float getOutlinePenalty() const;
   float getNormOutlinePenalty() const;
   float getWirelength() const;
@@ -154,6 +155,12 @@ class SimulatedAnnealingCore
 
   // utilities
   static float calAverage(std::vector<float>& value_list);
+
+  // For debugging
+  void reportCoreWeights() const;
+  void reportFinalCost() const;
+  void reportLocations() const;
+  void report(const Penalty& penalty) const;
 
   /////////////////////////////////////////////
   // private member variables

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -129,30 +129,33 @@ void Graphics::saStep(const std::vector<HardMacro>& macros)
 }
 
 template <typename T>
-void Graphics::report(const char* name, const std::optional<T>& value)
+void Graphics::report(const std::optional<T>& value)
 {
   if (value) {
-    auto penalty = value.value();
+    const PenaltyData& penalty_data = value.value();
+    const float normalized_penalty
+        = penalty_data.value / penalty_data.normalization_factor;
+
     logger_->report(
         "{:25}(Norm penalty {:>8.4f}) * (weight {:>8.4f}) = cost {:>8.4f}",
-        name,
-        penalty.norm_penalty,
-        penalty.weight,
-        penalty.norm_penalty * penalty.weight);
+        penalty_data.name,
+        normalized_penalty,
+        penalty_data.weight,
+        normalized_penalty * penalty_data.weight);
   }
 }
 
 void Graphics::report(const float norm_cost)
 {
-  report("Area", area_penalty_);
-  report("Outline Penalty", outline_penalty_);
-  report("Wirelength", wirelength_penalty_);
-  report("Fence Penalty", fence_penalty_);
-  report("Guidance Penalty", guidance_penalty_);
-  report("Boundary Penalty", boundary_penalty_);
-  report("Macro Blockage Penalty", macro_blockage_penalty_);
-  report("Notch Penalty", notch_penalty_);
-  report("Normalized Cost", std::optional<Penalty>({1.0f, norm_cost}));
+  report(area_penalty_);
+  report(outline_penalty_);
+  report(wirelength_penalty_);
+  report(fence_penalty_);
+  report(guidance_penalty_);
+  report(boundary_penalty_);
+  report(macro_blockage_penalty_);
+  report(notch_penalty_);
+  report(std::optional<PenaltyData>({"Total", 1.0f, norm_cost, 1.0f}));
 }
 
 void Graphics::drawResult()
@@ -259,42 +262,42 @@ void Graphics::resetPenalties()
   notch_penalty_.reset();
 }
 
-void Graphics::setNotchPenalty(const Penalty& penalty)
+void Graphics::setNotchPenalty(const PenaltyData& penalty)
 {
   notch_penalty_ = penalty;
 }
 
-void Graphics::setMacroBlockagePenalty(const Penalty& penalty)
+void Graphics::setMacroBlockagePenalty(const PenaltyData& penalty)
 {
   macro_blockage_penalty_ = penalty;
 }
 
-void Graphics::setBoundaryPenalty(const Penalty& penalty)
+void Graphics::setBoundaryPenalty(const PenaltyData& penalty)
 {
   boundary_penalty_ = penalty;
 }
 
-void Graphics::setFencePenalty(const Penalty& penalty)
+void Graphics::setFencePenalty(const PenaltyData& penalty)
 {
   fence_penalty_ = penalty;
 }
 
-void Graphics::setGuidancePenalty(const Penalty& penalty)
+void Graphics::setGuidancePenalty(const PenaltyData& penalty)
 {
   guidance_penalty_ = penalty;
 }
 
-void Graphics::setAreaPenalty(const Penalty& penalty)
+void Graphics::setAreaPenalty(const PenaltyData& penalty)
 {
   area_penalty_ = penalty;
 }
 
-void Graphics::setOutlinePenalty(const Penalty& penalty)
+void Graphics::setOutlinePenalty(const PenaltyData& penalty)
 {
   outline_penalty_ = penalty;
 }
 
-void Graphics::setWirelengthPenalty(const Penalty& penalty)
+void Graphics::setWirelengthPenalty(const PenaltyData& penalty)
 {
   wirelength_penalty_ = penalty;
 }

--- a/src/mpl/src/graphics.h
+++ b/src/mpl/src/graphics.h
@@ -63,14 +63,14 @@ class Graphics : public gui::Renderer, public MplObserver
   void finishedClustering(PhysicalHierarchy* tree) override;
 
   void setMaxLevel(int max_level) override;
-  void setAreaPenalty(const Penalty& penalty) override;
-  void setBoundaryPenalty(const Penalty& penalty) override;
-  void setFencePenalty(const Penalty& penalty) override;
-  void setGuidancePenalty(const Penalty& penalty) override;
-  void setMacroBlockagePenalty(const Penalty& penalty) override;
-  void setNotchPenalty(const Penalty& penalty) override;
-  void setOutlinePenalty(const Penalty& penalty) override;
-  void setWirelengthPenalty(const Penalty& penalty) override;
+  void setAreaPenalty(const PenaltyData& penalty) override;
+  void setBoundaryPenalty(const PenaltyData& penalty) override;
+  void setFencePenalty(const PenaltyData& penalty) override;
+  void setGuidancePenalty(const PenaltyData& penalty) override;
+  void setMacroBlockagePenalty(const PenaltyData& penalty) override;
+  void setNotchPenalty(const PenaltyData& penalty) override;
+  void setOutlinePenalty(const PenaltyData& penalty) override;
+  void setWirelengthPenalty(const PenaltyData& penalty) override;
   void penaltyCalculated(float norm_cost) override;
 
   void drawObjects(gui::Painter& painter) override;
@@ -129,7 +129,7 @@ class Graphics : public gui::Renderer, public MplObserver
   bool isTargetCluster();
 
   template <typename T>
-  void report(const char* name, const std::optional<T>& value);
+  void report(const std::optional<T>& value);
   void report(float norm_cost);
 
   std::vector<SoftMacro> soft_macros_;
@@ -162,14 +162,14 @@ class Graphics : public gui::Renderer, public MplObserver
   utl::Logger* logger_;
 
   std::optional<int> max_level_;
-  std::optional<Penalty> outline_penalty_;
-  std::optional<Penalty> fence_penalty_;
-  std::optional<Penalty> wirelength_penalty_;
-  std::optional<Penalty> guidance_penalty_;
-  std::optional<Penalty> boundary_penalty_;
-  std::optional<Penalty> macro_blockage_penalty_;
-  std::optional<Penalty> notch_penalty_;
-  std::optional<Penalty> area_penalty_;
+  std::optional<PenaltyData> outline_penalty_;
+  std::optional<PenaltyData> fence_penalty_;
+  std::optional<PenaltyData> wirelength_penalty_;
+  std::optional<PenaltyData> guidance_penalty_;
+  std::optional<PenaltyData> boundary_penalty_;
+  std::optional<PenaltyData> macro_blockage_penalty_;
+  std::optional<PenaltyData> notch_penalty_;
+  std::optional<PenaltyData> area_penalty_;
 
   float best_norm_cost_ = 0;
   int skipped_ = 0;

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -307,10 +307,6 @@ void HierRTLMP::runHierarchicalMacroPlacement()
   }
 
   adjustMacroBlockageWeight();
-  if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 1)) {
-    reportSAWeights();
-  }
-
   placeChildren(tree_->root.get());
 }
 
@@ -1092,19 +1088,6 @@ void HierRTLMP::adjustMacroBlockageWeight()
                new_macro_blockage_weight);
     macro_blockage_weight_ = new_macro_blockage_weight;
   }
-}
-
-void HierRTLMP::reportSAWeights()
-{
-  logger_->report("\nSimmulated Annealing Weights:\n");
-  logger_->report("Area = {}", placement_core_weights_.area);
-  logger_->report("Outline = {}", placement_core_weights_.outline);
-  logger_->report("WL = {}", placement_core_weights_.wirelength);
-  logger_->report("Guidance = {}", placement_core_weights_.guidance);
-  logger_->report("Fence = {}", placement_core_weights_.fence);
-  logger_->report("Boundary = {}", boundary_weight_);
-  logger_->report("Notch = {}", notch_weight_);
-  logger_->report("Macro Blockage = {}\n", macro_blockage_weight_);
 }
 
 void HierRTLMP::placeChildren(Cluster* parent)

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1118,6 +1118,13 @@ void HierRTLMP::placeChildren(Cluster* parent)
     return;
   }
 
+  debugPrint(logger_,
+             MPL,
+             "hierarchical_macro_placement",
+             1,
+             "Placing children of cluster {}",
+             parent->getName());
+
   if (graphics_) {
     graphics_->setCurrentCluster(parent);
   }
@@ -1138,22 +1145,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
   }
 
   // The simulated annealing outline is determined by the parent's shape
-  const Rect outline(parent->getX(),
-                     parent->getY(),
-                     parent->getX() + parent->getWidth(),
-                     parent->getY() + parent->getHeight());
-
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Working on children of cluster: {}, Outline "
-             "{}, {}  {}, {}",
-             parent->getName(),
-             outline.xMin(),
-             outline.yMin(),
-             outline.getWidth(),
-             outline.getHeight());
+  const Rect outline = parent->getBBox();
 
   // Suppose the region, fence, guide has been mapped to cooresponding macros
   // This step is done when we enter the Hier-RTLMP program
@@ -1243,19 +1235,8 @@ void HierRTLMP::placeChildren(Cluster* parent)
 
   createFixedTerminals(parent, soft_macro_id_map, macros);
 
-  // update the connnection
   clustering_engine_->updateConnections();
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished calculating connection");
   clustering_engine_->updateDataFlow();
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished updating dataflow");
 
   // add the virtual connections (the weight related to IOs and macros belong to
   // the same cluster)
@@ -1277,7 +1258,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
       debugPrint(logger_,
                  MPL,
                  "hierarchical_macro_placement",
-                 2,
+                 3,
                  " Cluster connection: {} {} {} ",
                  cluster->getName(),
                  tree_->maps.id_to_cluster[cluster_id]->getName(),
@@ -1292,11 +1273,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
       }
     }
   }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished creating bundled connections");
+
   // merge nets to reduce runtime
   mergeNets(nets);
 
@@ -1364,23 +1341,12 @@ void HierRTLMP::placeChildren(Cluster* parent)
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
   float best_cost = std::numeric_limits<float>::max();
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Start Simulated Annealing Core");
+
   while (remaining_runs > 0) {
     SoftSAVector sa_batch;
     const int run_thread
         = graphics_ ? 1 : std::min(remaining_runs, num_threads_);
     for (int i = 0; i < run_thread; i++) {
-      debugPrint(logger_,
-                 MPL,
-                 "hierarchical_macro_placement",
-                 1,
-                 "Start Simulated Annealing (run_id = {})",
-                 run_id);
-
       std::vector<SoftMacro> shaped_macros = macros;  // copy for multithread
 
       const float target_util = target_util_list[run_id];
@@ -1489,11 +1455,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
       break;
     }
   }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished Simulated Annealing Core");
+
   if (best_sa == nullptr) {
     debugPrint(logger_,
                MPL,
@@ -1531,13 +1493,12 @@ void HierRTLMP::placeChildren(Cluster* parent)
            << std::endl;
     }
     file.close();
-    debugPrint(logger_,
-               MPL,
-               "hierarchical_macro_placement",
-               1,
-               "Finished Simulated Annealing for cluster {}",
-               parent->getName());
-    best_sa->printResults();
+
+    if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 1)) {
+      logger_->report("Cluster Placement Summary");
+      printPlacementResult(parent, outline, best_sa);
+    }
+
     // write the cost function. This can be used to tune the temperature
     // schedule and cost weight
     best_sa->writeCostFile(file_name + ".cost.txt");
@@ -1580,6 +1541,13 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
     }
   }
 
+  debugPrint(logger_,
+             MPL,
+             "hierarchical_macro_placement",
+             1,
+             "Conventional cluster placement failed. Attempting with minimum "
+             "target utilization.");
+
   if (graphics_) {
     graphics_->setCurrentCluster(parent);
   }
@@ -1601,18 +1569,6 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
                      parent->getY(),
                      parent->getX() + parent->getWidth(),
                      parent->getY() + parent->getHeight());
-
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Working on children of cluster: {}, Outline "
-             "{}, {}  {}, {}",
-             parent->getName(),
-             outline.xMin(),
-             outline.yMin(),
-             outline.getWidth(),
-             outline.getHeight());
 
   // Suppose the region, fence, guide has been mapped to cooresponding macros
   // This step is done when we enter the Hier-RTLMP program
@@ -1702,19 +1658,8 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
 
   createFixedTerminals(parent, soft_macro_id_map, macros);
 
-  // update the connnection
   clustering_engine_->updateConnections();
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished calculating connection");
   clustering_engine_->updateDataFlow();
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished updating dataflow");
 
   // add the virtual connections (the weight related to IOs and macros belong to
   // the same cluster)
@@ -1736,7 +1681,7 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
       debugPrint(logger_,
                  MPL,
                  "hierarchical_macro_placement",
-                 2,
+                 3,
                  " Cluster connection: {} {} {} ",
                  cluster->getName(),
                  tree_->maps.id_to_cluster[cluster_id]->getName(),
@@ -1751,11 +1696,7 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
       }
     }
   }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished creating bundled connections");
+
   // merge nets to reduce runtime
   mergeNets(nets);
 
@@ -1811,24 +1752,14 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
   const int check_interval = 10;
   int begin_check = 0;
   int end_check = std::min(check_interval, remaining_runs);
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Start Simulated Annealing Core");
+
   while (remaining_runs > 0) {
     SoftSAVector sa_batch;
     const int run_thread
         = graphics_ ? 1 : std::min(remaining_runs, num_threads_);
     for (int i = 0; i < run_thread; i++) {
       std::vector<SoftMacro> shaped_macros = macros;  // copy for multithread
-      // determine the shape for each macro
-      debugPrint(logger_,
-                 MPL,
-                 "hierarchical_macro_placement",
-                 1,
-                 "Start Simulated Annealing (run_id = {})",
-                 run_id);
+
       const float target_util = target_util_list[run_id];
       const float target_dead_space = target_dead_space_list[run_id++];
       debugPrint(logger_,
@@ -1933,11 +1864,7 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
       break;
     }
   }
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finished Simulated Annealing Core");
+
   if (best_sa == nullptr) {
     debugPrint(logger_,
                MPL,
@@ -1976,14 +1903,11 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
   }
   file.close();
 
-  debugPrint(logger_,
-             MPL,
-             "hierarchical_macro_placement",
-             1,
-             "Finish Simulated Annealing for cluster {}",
-             parent->getName());
+  if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 1)) {
+    logger_->report("Cluster Placement Summary (Minimum Target Utilization)");
+    printPlacementResult(parent, outline, best_sa);
+  }
 
-  best_sa->printResults();
   // write the cost function. This can be used to tune the temperature schedule
   // and cost weight
   best_sa->writeCostFile(file_name + ".cost.txt");
@@ -2286,7 +2210,7 @@ void HierRTLMP::placeMacros(Cluster* cluster)
              MPL,
              "hierarchical_macro_placement",
              1,
-             "Place macros in cluster: {}",
+             "Placing macros of macro cluster {}",
              cluster->getName());
 
   if (graphics_) {
@@ -2452,7 +2376,11 @@ void HierRTLMP::placeMacros(Cluster* cluster)
   } else {
     std::vector<HardMacro> best_macros;
     best_sa->getMacros(best_macros);
-    best_sa->printResults();
+
+    if (logger_->debugCheck(MPL, "hierarchical_macro_placement", 1)) {
+      logger_->report("Macro Placement Summary");
+      printPlacementResult(cluster, outline, best_sa);
+    }
 
     for (int i = 0; i < hard_macros.size(); i++) {
       *(hard_macros[i]) = best_macros[i];
@@ -3144,6 +3072,20 @@ Rect HierRTLMP::dbuToMicrons(const odb::Rect& dbu_rect)
               block_->dbuToMicrons(dbu_rect.yMin()),
               block_->dbuToMicrons(dbu_rect.xMax()),
               block_->dbuToMicrons(dbu_rect.yMax()));
+}
+
+template <typename SACore>
+void HierRTLMP::printPlacementResult(Cluster* parent,
+                                     const Rect& outline,
+                                     SACore* sa_core)
+{
+  logger_->report("Id: {}", parent->getId());
+  logger_->report("Outline: ({:^8.2f} {:^8.2f}) ({:^8.2f} {:^8.2f})",
+                  outline.xMin(),
+                  outline.yMin(),
+                  outline.xMax(),
+                  outline.yMax());
+  sa_core->printResults();
 }
 
 //////// Pusher ////////

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -252,6 +252,12 @@ class HierRTLMP
   odb::Rect micronsToDbu(const Rect& micron_rect);
   Rect dbuToMicrons(const odb::Rect& dbu_rect);
 
+  // For debugging
+  template <typename SACore>
+  void printPlacementResult(Cluster* parent,
+                            const Rect& outline,
+                            SACore* sa_core);
+
   sta::dbNetwork* network_ = nullptr;
   odb::dbDatabase* db_ = nullptr;
   odb::dbBlock* block_ = nullptr;

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -195,7 +195,6 @@ class HierRTLMP
 
   // Hierarchical Macro Placement 1st stage: Cluster Placement
   void adjustMacroBlockageWeight();
-  void reportSAWeights();
   void placeChildren(Cluster* parent);
   void placeChildrenUsingMinimumTargetUtil(Cluster* parent);
 

--- a/src/mpl/src/util.h
+++ b/src/mpl/src/util.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+namespace mpl {
+
 struct SACoreWeights
 {
   float area{0.0f};
@@ -42,10 +44,20 @@ struct SACoreWeights
   float fence{0.0f};
 };
 
-struct Penalty
+// The cost of a certain penalty is:
+//   cost = weight * normalized_penalty
+//
+// Where the normalized_penalty is:
+//   normalized_penalty = value / normalization_factor
+//
+// Note: the normalization factor is generated during the
+// annealer core initialization.
+struct PenaltyData
 {
   std::string name;
   float weight{0.0f};
   float value{0.0f};
-  float initial_average{0.0f};
+  float normalization_factor{0.0f};
 };
+
+}  // namespace mpl

--- a/src/mpl/src/util.h
+++ b/src/mpl/src/util.h
@@ -41,3 +41,11 @@ struct SACoreWeights
   float guidance{0.0f};
   float fence{0.0f};
 };
+
+struct Penalty
+{
+  std::string name;
+  float weight{0.0f};
+  float value{0.0f};
+  float initial_average{0.0f};
+};

--- a/src/mpl/src/util.h
+++ b/src/mpl/src/util.h
@@ -33,6 +33,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace mpl {
 
 struct SACoreWeights


### PR DESCRIPTION
This will help a lot to see the results for each outline of cluster placement, especially when we need to know what happened at the level of each individual cost inside the annealer.

#### Colateral Changes / Fixes
1. Wrap utilities in mpl namespace;
2. Adapt debug docs.
3. Compute area penalty in base class to avoid duplicated code and allow the debug report approach used in this PR.

### Changes
1. Remove unused debugPrint messages
2. Report summary for each cluster/macro placement in table format.