### PR TITLE
gpl: fix corner case issue with revert if diverge

### DIFF
--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -50,7 +50,7 @@
 [INFO GPL-0030] NumBins: 64
 [NesterovSolve] Iter:    1 overflow: 0.127 HPWL: 397899
 [INFO GPL-0100] Timing-driven iteration 1/5, virtual: false.
-[INFO GPL-0101] Iter: 0, overflow: 0.127, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 1, overflow: 0.127, keep rsz at: 0.3, HPWL: 397899
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |        98

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -38,7 +38,7 @@
 [INFO GPL-0030] NumBins: 256
 [NesterovSolve] Iter:    1 overflow: 0.832 HPWL: 3651238
 [INFO GPL-0100] Timing-driven iteration 1/7, virtual: true.
-[INFO GPL-0101] Iter: 2, overflow: 0.761, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 3, overflow: 0.761, keep rsz at: 0.3, HPWL: 3932272
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -64,7 +64,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  160 overflow: 0.715 HPWL: 4037658
 [NesterovSolve] Iter:  170 overflow: 0.704 HPWL: 4057804
 [INFO GPL-0100] Timing-driven iteration 2/7, virtual: true.
-[INFO GPL-0101] Iter: 176, overflow: 0.695, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 177, overflow: 0.695, keep rsz at: 0.3, HPWL: 4076876
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -77,7 +77,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  200 overflow: 0.649 HPWL: 4204028
 [NesterovSolve] Iter:  210 overflow: 0.618 HPWL: 4266347
 [INFO GPL-0100] Timing-driven iteration 3/7, virtual: true.
-[INFO GPL-0101] Iter: 216, overflow: 0.594, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 217, overflow: 0.594, keep rsz at: 0.3, HPWL: 4313387
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -89,7 +89,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  230 overflow: 0.542 HPWL: 4396817
 [NesterovSolve] Iter:  240 overflow: 0.497 HPWL: 4448439
 [INFO GPL-0100] Timing-driven iteration 4/7, virtual: true.
-[INFO GPL-0101] Iter: 240, overflow: 0.492, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 241, overflow: 0.492, keep rsz at: 0.3, HPWL: 4450361
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -99,7 +99,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [INFO GPL-0103] Timing-driven: weighted 31 nets.
 [NesterovSolve] Iter:  250 overflow: 0.437 HPWL: 4448311
 [INFO GPL-0100] Timing-driven iteration 5/7, virtual: true.
-[INFO GPL-0101] Iter: 257, overflow: 0.393, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 258, overflow: 0.393, keep rsz at: 0.3, HPWL: 4435715
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -110,7 +110,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  260 overflow: 0.384 HPWL: 4438815
 [NesterovSolve] Iter:  270 overflow: 0.334 HPWL: 4468479
 [INFO GPL-0100] Timing-driven iteration 6/7, virtual: false.
-[INFO GPL-0101] Iter: 278, overflow: 0.294, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 279, overflow: 0.294, keep rsz at: 0.3, HPWL: 4477648
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -126,7 +126,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  310 overflow: 0.217 HPWL: 2621283
 [NesterovSolve] Iter:  320 overflow: 0.202 HPWL: 2639961
 [INFO GPL-0100] Timing-driven iteration 7/7, virtual: false.
-[INFO GPL-0101] Iter: 322, overflow: 0.194, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 323, overflow: 0.194, keep rsz at: 0.3, HPWL: 2649932
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -38,7 +38,7 @@
 [INFO GPL-0030] NumBins: 256
 [NesterovSolve] Iter:    1 overflow: 0.832 HPWL: 3651238
 [INFO GPL-0100] Timing-driven iteration 1/5, virtual: true.
-[INFO GPL-0101] Iter: 2, overflow: 0.761, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 3, overflow: 0.761, keep rsz at: 0.3, HPWL: 3932272
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -67,7 +67,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  190 overflow: 0.674 HPWL: 4128327
 [NesterovSolve] Iter:  200 overflow: 0.652 HPWL: 4181482
 [INFO GPL-0100] Timing-driven iteration 2/5, virtual: true.
-[INFO GPL-0101] Iter: 205, overflow: 0.632, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 206, overflow: 0.632, keep rsz at: 0.3, HPWL: 4214522
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -84,7 +84,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  270 overflow: 0.331 HPWL: 4450617
 [NesterovSolve] Iter:  280 overflow: 0.305 HPWL: 4478236
 [INFO GPL-0100] Timing-driven iteration 3/5, virtual: false.
-[INFO GPL-0101] Iter: 285, overflow: 0.284, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 286, overflow: 0.284, keep rsz at: 0.3, HPWL: 4471956
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -98,7 +98,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  300 overflow: 0.263 HPWL: 2656033
 [NesterovSolve] Iter:  310 overflow: 0.228 HPWL: 2638435
 [INFO GPL-0100] Timing-driven iteration 4/5, virtual: false.
-[INFO GPL-0101] Iter: 316, overflow: 0.202, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 317, overflow: 0.202, keep rsz at: 0.3, HPWL: 2638631
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356
@@ -112,7 +112,7 @@ Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 [NesterovSolve] Iter:  330 overflow: 0.180 HPWL: 2655060
 [NesterovSolve] Iter:  340 overflow: 0.151 HPWL: 2683596
 [INFO GPL-0100] Timing-driven iteration 5/5, virtual: false.
-[INFO GPL-0101] Iter: 341, overflow: 0.145, keep rsz at: 0.3
+[INFO GPL-0101]    Iter: 342, overflow: 0.145, keep rsz at: 0.3, HPWL: 2688300
 Iteration |   Area    | Resized | Buffers | Nets repaired | Remaining
 ---------------------------------------------------------------------
         0 |     +0.0% |       0 |       0 |             0 |       356


### PR DESCRIPTION
This PR solves the issue described in: https://github.com/The-OpenROAD-Project/OpenROAD/issues/6745

It is a corner case where the saving of the snapshot happens before the timing-driven iteration. With this PR we save the snapshot after the TD iteration execution.