### PR TITLE
gui: add option to exclude buffering nodes when generating report_checks

### DIFF
--- a/src/gui/src/timingWidget.h
+++ b/src/gui/src/timingWidget.h
@@ -147,6 +147,10 @@ class TimingWidget : public QDockWidget
   void setInitialColumnsVisibility(const QVariant& columns_visibility);
   QVariantList getColumnsVisibility() const;
 
+  // Auxiliary for generating report_checks commands for Script Widget.
+  QString generateFromStartToEndString(TimingPath* path);
+  QString generateClosestMatchString(CommandType type, TimingPath* path);
+
   QMenu* commands_menu_;
 
   QModelIndex timing_paths_table_index_;

--- a/src/gui/src/timingWidget.h
+++ b/src/gui/src/timingWidget.h
@@ -70,7 +70,8 @@ class TimingWidget : public QDockWidget
  public:
   enum CommandType
   {
-    CLOSEST_MATCH,
+    EXACT,
+    NO_BUFFERING,
     FROM_START_TO_END
   };
 


### PR DESCRIPTION
This is to help when we want to check what happens to a path across different versions of OR.

Closest Match option now becomes a menu with two options:
- Exact (Same as the previous Closest Match)
- No Buffering (Exclude buffers and back-to-back inverters)