### PR TITLE
rsz: Cache result of getSwappableCells()

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -749,6 +749,9 @@ class Resizer : public dbStaState, public dbNetworkObserver
   // exact same buffers when reparing clock nets.
   LibertyCellSeq clk_buffers_;
 
+  // Cache results of getSwappableCells() as this is expensive for large PDKs.
+  std::unordered_map<LibertyCell*, LibertyCellSeq> swappable_cells_cache_;
+
   CellTargetLoadMap* target_load_map_ = nullptr;
   VertexSeq level_drvr_vertices_;
   bool level_drvr_vertices_valid_ = false;

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -2110,23 +2110,21 @@ LibertyCell* RepairDesign::findBufferUnderSlew(float max_slew, float load_cap)
                   > resizer_->bufferDriveResistance(buffer2);
          });
     for (LibertyCell* buffer : swappable_cells) {
-      if (!resizer_->dontUse(buffer) && resizer_->isLinkCell(buffer)) {
-        float slew = resizer_->bufferSlew(
-            buffer, load_cap, resizer_->tgt_slew_dcalc_ap_);
-        debugPrint(logger_,
-                   RSZ,
-                   "buffer_under_slew",
-                   1,
-                   "{:{}s}pt ({} {})",
-                   buffer->name(),
-                   units_->timeUnit()->asString(slew));
-        if (slew < max_slew) {
-          return buffer;
-        }
-        if (slew < min_slew) {
-          min_slew_buffer = buffer;
-          min_slew = slew;
-        }
+      float slew = resizer_->bufferSlew(
+          buffer, load_cap, resizer_->tgt_slew_dcalc_ap_);
+      debugPrint(logger_,
+                 RSZ,
+                 "buffer_under_slew",
+                 1,
+                 "{:{}s}pt ({} {})",
+                 buffer->name(),
+                 units_->timeUnit()->asString(slew));
+      if (slew < max_slew) {
+        return buffer;
+      }
+      if (slew < min_slew) {
+        min_slew_buffer = buffer;
+        min_slew = slew;
       }
     }
   }

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -498,9 +498,6 @@ void Resizer::balanceBin(const vector<odb::dbInst*>& bin,
       LibertyCell* cell = network_->libertyCell(sta_inst);
       LibertyCellSeq swappable_cells = getSwappableCells(cell);
       for (LibertyCell* target_cell : swappable_cells) {
-        if (dontUse(target_cell)) {
-          continue;
-        }
         dbMaster* target_master = db_network_->staToDb(target_cell);
         // TODO: pick the best choice rather than the first
         //       and consider timing criticality
@@ -1214,10 +1211,20 @@ void Resizer::resizePreamble()
 //   same footprint have the same layout boundary.
 // - User Function Class (Optional - Honored if found): Cells with the
 //   same user_function_class are electrically compatible.
+// - DontUse: Cells that are marked dont-use are not considered for
+//   replacement.
+// - Link Cell: Only link cells are considered for replacement.
+// This function is cached for performance and reset if more cells are read.
 LibertyCellSeq Resizer::getSwappableCells(LibertyCell* source_cell)
 {
+  if (swappable_cells_cache_.find(source_cell)
+      != swappable_cells_cache_.end()) {
+    return swappable_cells_cache_[source_cell];
+  }
+
   dbMaster* master = db_network_->staToDb(source_cell);
   if (master && !master->isCore()) {
+    swappable_cells_cache_[source_cell] = {};
     return {};
   }
 
@@ -1243,6 +1250,9 @@ LibertyCellSeq Resizer::getSwappableCells(LibertyCell* source_cell)
       source_cell_leakage = get_leakage(source_cell);
     }
     for (LibertyCell* equiv_cell : *equiv_cells) {
+      if (dontUse(equiv_cell) || !isLinkCell(equiv_cell)) {
+        continue;
+      }
       dbMaster* equiv_cell_master = db_network_->staToDb(equiv_cell);
       if (!equiv_cell_master) {
         continue;
@@ -1404,38 +1414,36 @@ LibertyCell* Resizer::findTargetCell(LibertyCell* cell,
                best_dist,
                delayAsString(best_delay, sta_, 3));
     for (LibertyCell* target_cell : swappable_cells) {
-      if (!dontUse(target_cell) && isLinkCell(target_cell)) {
-        float target_load = (*target_load_map_)[target_cell];
-        float delay = 0.0;
-        if (is_buf_inv) {
-          delay = bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_);
-        }
-        float dist = targetLoadDist(load_cap, target_load);
-        debugPrint(logger_,
-                   RSZ,
-                   "resize",
-                   3,
-                   " {} dist={:.2e} delay={}",
-                   target_cell->name(),
-                   dist,
-                   delayAsString(delay, sta_, 3));
-        if (is_buf_inv
-                // Library may have "delay" buffers/inverters that are
-                // functionally buffers/inverters but have additional
-                // intrinsic delay. Accept worse target load matching if
-                // delay is reduced to avoid using them.
-                ? ((delay < best_delay && dist < best_dist * 1.1)
-                   || (dist < best_dist && delay < best_delay * 1.1))
-                : dist < best_dist
-                      // If the instance has multiple outputs (generally a
-                      // register Q/QN) only allow upsizing after the first pin
-                      // is visited.
-                      && (!revisiting_inst || target_load > best_load)) {
-          best_cell = target_cell;
-          best_dist = dist;
-          best_load = target_load;
-          best_delay = delay;
-        }
+      float target_load = (*target_load_map_)[target_cell];
+      float delay = 0.0;
+      if (is_buf_inv) {
+        delay = bufferDelay(target_cell, load_cap, tgt_slew_dcalc_ap_);
+      }
+      float dist = targetLoadDist(load_cap, target_load);
+      debugPrint(logger_,
+                 RSZ,
+                 "resize",
+                 3,
+                 " {} dist={:.2e} delay={}",
+                 target_cell->name(),
+                 dist,
+                 delayAsString(delay, sta_, 3));
+      if (is_buf_inv
+              // Library may have "delay" buffers/inverters that are
+              // functionally buffers/inverters but have additional
+              // intrinsic delay. Accept worse target load matching if
+              // delay is reduced to avoid using them.
+              ? ((delay < best_delay && dist < best_dist * 1.1)
+                 || (dist < best_dist && delay < best_delay * 1.1))
+              : dist < best_dist
+                    // If the instance has multiple outputs (generally a
+                    // register Q/QN) only allow upsizing after the first pin
+                    // is visited.
+                    && (!revisiting_inst || target_load > best_load)) {
+        best_cell = target_cell;
+        best_dist = dist;
+        best_load = target_load;
+        best_delay = delay;
       }
     }
   }
@@ -4222,6 +4230,7 @@ void Resizer::eliminateDeadLogic(bool clean_nets)
 void Resizer::postReadLiberty()
 {
   copyDontUseFromLiberty();
+  swappable_cells_cache_.clear();
 }
 
 void Resizer::copyDontUseFromLiberty()

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -1892,18 +1892,20 @@ void Resizer::setDontUse(LibertyCell* cell, bool dont_use)
     dont_use_.erase(cell);
   }
 
-  // Reset buffer set to ensure it honors dont_use_
+  // Reset buffer set and swappable cells cache to ensure they honor dont_use_
   buffer_cells_.clear();
   buffer_lowest_drive_ = nullptr;
+  swappable_cells_cache_.clear();
 }
 
 void Resizer::resetDontUse()
 {
   dont_use_.clear();
 
-  // Reset buffer set to ensure it honors dont_use_
+  // Reset buffer set and swappable cells cache to ensure they honor dont_use_
   buffer_cells_.clear();
   buffer_lowest_drive_ = nullptr;
+  swappable_cells_cache_.clear();
 
   // recopy in liberty cell dont uses
   copyDontUseFromLiberty();


### PR DESCRIPTION
For large (private) PDKs that have many equivalent cells (~50 per logic type), large designs spend significant time recomputing the equivalent cell list during rsz operations. In typical OR flows, the liberty library does not change after init so this list should not have to be recomputed.

Also move checking of `dontUse()` and `isLinkCell() `to `getSwappableCells()` so it does not have to be repeatedly checked. This also eliminates the need to remember to conduct this check where it is called. The cache is reset if an additional liberty file is read or when the dont_use set is updated.

Baseline private design `global_placement -timing-driven` : 52s
With caching private design `global_placement -timing-driven`: 29s (-44%)

On a large private design, time attributed to these calls was approximately half of total flow runtime (>11hr) (
![image](https://github.com/user-attachments/assets/f919a59b-fe54-4f16-b57a-d17d9614abbd)
)