### PR TITLE
odb: add mirrored pin data into dbBTerm

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1848,7 +1848,7 @@ class dbBTerm : public dbObject
 
   ///
   /// Set the bterm which position is mirrored to this bterm
-  /// 
+  ///
   void setMirroredBTerm(dbBTerm* mirrored_bterm);
 
   ///

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1845,6 +1845,16 @@ class dbBTerm : public dbObject
   /// Get the region where the BTerm is constrained
   ///
   std::optional<Rect> getConstraintRegion();
+
+  ///
+  /// Set the bterm which position is mirrored to this bterm
+  /// 
+  void setMirroredBTerm(dbBTerm* mirrored_bterm);
+
+  ///
+  /// Get the bterm that is mirrored to this bterm
+  ///
+  dbBTerm* getMirroredBTerm();
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -205,6 +205,10 @@ dbOStream& operator<<(dbOStream& stream, const _dbBTerm& bterm)
   if (bterm.getDatabase()->isSchema(db_schema_bterm_constraint_region)) {
     stream << bterm._constraint_region;
   }
+  if (bterm.getDatabase()->isSchema(db_schema_bterm_mirrored_pin)) {
+    stream << bterm._mirrored_bterm;
+  }
+
   return stream;
 }
 
@@ -232,6 +236,9 @@ dbIStream& operator>>(dbIStream& stream, _dbBTerm& bterm)
   stream >> bterm._supply_pin;
   if (bterm.getDatabase()->isSchema(db_schema_bterm_constraint_region)) {
     stream >> bterm._constraint_region;
+  }
+  if (bterm.getDatabase()->isSchema(db_schema_bterm_mirrored_pin)) {
+    stream >> bterm._mirrored_bterm;
   }
 
   return stream;
@@ -895,6 +902,26 @@ std::optional<Rect> dbBTerm::getConstraintRegion()
   }
 
   return bterm->_constraint_region;
+}
+
+void dbBTerm::setMirroredBTerm(dbBTerm* mirrored_bterm)
+{
+  _dbBTerm* bterm = (_dbBTerm*) this;
+
+  bterm->_mirrored_bterm = mirrored_bterm->getImpl()->getOID();
+}
+
+dbBTerm* dbBTerm::getMirroredBTerm()
+{
+  _dbBTerm* bterm = (_dbBTerm*) this;
+  _dbBlock* block = (_dbBlock*) getBlock();
+
+  if (bterm->_mirrored_bterm == 0) {
+    return nullptr;
+  }
+
+  _dbBTerm* mirrored_bterm = block->_bterm_tbl->getPtr(bterm->_mirrored_bterm);
+  return (dbBTerm*) mirrored_bterm;
 }
 
 }  // namespace odb

--- a/src/odb/src/db/dbBTerm.h
+++ b/src/odb/src/db/dbBTerm.h
@@ -92,6 +92,7 @@ class _dbBTerm : public _dbObject
   dbId<_dbBTerm> _supply_pin;
   std::uint32_t _sta_vertex_id;  // not saved
   Rect _constraint_region;
+  dbId<_dbBTerm> _mirrored_bterm;
 
   _dbBTerm(_dbDatabase*);
   _dbBTerm(_dbDatabase*, const _dbBTerm& b);

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -70,7 +70,10 @@ namespace odb {
 const uint db_schema_major = 0;  // Not used...
 const uint db_schema_initial = 57;
 
-const uint db_schema_minor = 102;  // Current revision number
+const uint db_schema_minor = 103;  // Current revision number
+
+// Revision where support for mirrored pins was added
+const uint db_schema_bterm_mirrored_pin = 103;
 
 // Revision where support for LEF58_CELLEDGESPACINGTABLE was added
 const uint db_schema_cell_edge_spc_tbl = 102;


### PR DESCRIPTION
First step to store mirrored pins in odb. The next PR will update PPL to write the data into odb.