### PR TITLE
mpl: Fix random index generation with hack

### DIFF
--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -738,8 +738,15 @@ void SACoreSoftMacro::calNotchPenalty()
 
 void SACoreSoftMacro::resizeOneCluster()
 {
-  const int idx = static_cast<int>(
-      std::floor(distribution_(generator_) * pos_seq_.size()));
+  // TODO: See for explanation
+  // https://github.com/The-OpenROAD-Project/OpenROAD/pull/6649
+  float random_variable_0_1;
+  do {
+    random_variable_0_1 = distribution_(generator_);
+  } while (random_variable_0_1 >= 1.0);
+
+  const int idx
+      = static_cast<int>(std::floor(random_variable_0_1 * pos_seq_.size()));
   macro_id_ = idx;
   SoftMacro& src_macro = macros_[idx];
   if (src_macro.isMacroCluster()) {

--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -626,11 +626,27 @@ void SimulatedAnnealingCore<T>::exchangeMacros()
 template <class T>
 void SimulatedAnnealingCore<T>::generateRandomIndices(int& index1, int& index2)
 {
-  index1 = (int) (std::floor(distribution_(generator_) * pos_seq_.size()));
-  index2 = (int) (std::floor(distribution_(generator_) * pos_seq_.size()));
+  // TODO: See for explanation.
+  // https://github.com/The-OpenROAD-Project/OpenROAD/pull/6649
+  // This code is ugly on purpose to incentivize merging the proper
+  // fix.
+  float random_variable_0_1_index1;
+  float random_variable_0_1_index2;
+  do {
+    random_variable_0_1_index1 = distribution_(generator_);
+    random_variable_0_1_index2 = distribution_(generator_);
+  } while (random_variable_0_1_index1 >= 1.0
+           || random_variable_0_1_index2 >= 1.0);
+
+  index1 = (int) (std::floor(random_variable_0_1_index1 * pos_seq_.size()));
+  index2 = (int) (std::floor(random_variable_0_1_index2 * pos_seq_.size()));
 
   while (index1 == index2) {
-    index2 = (int) (std::floor(distribution_(generator_) * pos_seq_.size()));
+    do {
+      random_variable_0_1_index2 = distribution_(generator_);
+    } while (random_variable_0_1_index2 >= 1.0);
+
+    index2 = (int) (std::floor(random_variable_0_1_index2 * pos_seq_.size()));
   }
 }
 

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -1261,8 +1261,15 @@ void SoftMacro::resizeRandomly(
   if (width_list_.empty()) {
     return;
   }
-  const int idx = static_cast<int>(
-      std::floor(distribution(generator) * width_list_.size()));
+  // TODO: See for explanation
+  // https://github.com/The-OpenROAD-Project/OpenROAD/pull/6649
+  float random_variable_0_1;
+  do {
+    random_variable_0_1 = distribution(generator);
+  } while (random_variable_0_1 >= 1.0);
+
+  const int idx
+      = static_cast<int>(std::floor(random_variable_0_1 * width_list_.size()));
   const float min_width = width_list_[idx].first;
   const float max_width = width_list_[idx].second;
   width_ = min_width + distribution(generator) * (max_width - min_width);


### PR DESCRIPTION
This is a hack fix for the compiler bug or real returning [a,b] inclusive. See https://github.com/The-OpenROAD-Project/OpenROAD/pull/6649 for the proper fix