### PR TITLE
drt: prepPatternInstHelper and some refactors

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -593,7 +593,9 @@ class FlexPA
 
   void prepPattern();
 
-  int prepPatternInst(frInst* inst, int curr_unique_inst_idx, double x_weight);
+  int prepPatternInst(frInst* inst,
+                      int curr_unique_inst_idx,
+                      bool use_x = true);
 
   int genPatterns(const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
                   int curr_unique_inst_idx);

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -593,9 +593,11 @@ class FlexPA
 
   void prepPattern();
 
-  int prepPatternInst(frInst* inst,
-                      int curr_unique_inst_idx,
-                      bool use_x = true);
+  void prepPatternInst(frInst* inst, int curr_unique_inst_idx);
+
+  int prepPatternInstHelper(frInst* inst,
+                            int curr_unique_inst_idx,
+                            bool use_x = true);
 
   int genPatterns(const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
                   int curr_unique_inst_idx);

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -593,21 +593,19 @@ class FlexPA
 
   void prepPattern();
 
-  void prepPatternInst(frInst* inst, int curr_unique_inst_idx);
+  void prepPatternInst(frInst* inst);
 
-  int prepPatternInstHelper(frInst* inst,
-                            int curr_unique_inst_idx,
-                            bool use_x = true);
+  int prepPatternInstHelper(frInst* inst, bool use_x = true);
 
-  int genPatterns(const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
-                  int curr_unique_inst_idx);
+  int genPatterns(frInst* inst,
+                  const std::vector<std::pair<frMPin*, frInstTerm*>>& pins);
 
   int genPatternsHelper(
+      frInst* inst,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       std::set<std::vector<int>>& inst_access_patterns,
       std::set<std::pair<int, int>>& used_access_points,
       std::set<std::pair<int, int>>& viol_access_points,
-      int curr_unique_inst_idx,
       int max_access_point_size);
 
   /**
@@ -633,24 +631,24 @@ class FlexPA
    * @brief Determines the value of all the paths of the DP problem
    */
   void genPatternsPerform(
+      frInst* inst,
       std::vector<std::vector<std::unique_ptr<FlexDPNode>>>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       std::vector<int>& vio_edges,
       const std::set<std::pair<int, int>>& used_access_points,
       const std::set<std::pair<int, int>>& viol_access_points,
-      int curr_unique_inst_idx,
       int max_access_point_size);
 
   /**
    * @brief Determines the edge cost between two DP nodes
    */
-  int getEdgeCost(FlexDPNode* prev_node,
+  int getEdgeCost(frInst* inst,
+                  FlexDPNode* prev_node,
                   FlexDPNode* curr_node,
                   const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
                   std::vector<int>& vio_edges,
                   const std::set<std::pair<int, int>>& used_access_points,
                   const std::set<std::pair<int, int>>& viol_access_points,
-                  int curr_unique_inst_idx,
                   int max_access_point_size);
 
   /**
@@ -673,13 +671,13 @@ class FlexPA
    * @brief Commits to the best path (solution) on the DP graph
    */
   bool genPatternsCommit(
+      frInst* inst,
       const std::vector<std::vector<std::unique_ptr<FlexDPNode>>>& nodes,
       const std::vector<std::pair<frMPin*, frInstTerm*>>& pins,
       bool& is_valid,
       std::set<std::vector<int>>& inst_access_patterns,
       std::set<std::pair<int, int>>& used_access_points,
       std::set<std::pair<int, int>>& viol_access_points,
-      int curr_unique_inst_idx,
       int max_access_point_size);
 
   /**

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -745,8 +745,7 @@ bool FlexPA::genPatternsCommit(
   frCoord left_pt = std::numeric_limits<frCoord>::max();
   frCoord right_pt = std::numeric_limits<frCoord>::min();
 
-  const auto& [pin, inst_term] = pins[0];
-  const auto inst = inst_term->getInst();
+  const auto inst = (pins[0].second)->getInst();
   for (auto& inst_term : inst->getInstTerms()) {
     if (isSkipInstTerm(inst_term.get())) {
       continue;
@@ -789,17 +788,15 @@ bool FlexPA::genPatternsCommit(
     // genPatternsPrint(nodes, pins);
     is_valid = true;
   } else {
-    for (int idx_1 = 0; idx_1 < (int) pins.size(); idx_1++) {
-      auto idx_2 = access_pattern[idx_1];
-      auto& [pin, inst_term] = pins[idx_1];
+    for (int pin_idx = 0; pin_idx < (int) pins.size(); pin_idx++) {
+      auto acc_pattern_idx = access_pattern[pin_idx];
+      auto inst_term = pins[pin_idx].second;
+      frBlockObject* owner = inst_term;
       if (inst_term->hasNet()) {
-        if (owners.find(inst_term->getNet()) != owners.end()) {
-          viol_access_points.insert(std::make_pair(idx_1, idx_2));  // idx ;
-        }
-      } else {
-        if (owners.find(inst_term) != owners.end()) {
-          viol_access_points.insert(std::make_pair(idx_1, idx_2));  // idx ;
-        }
+        owner = inst_term->getNet();
+      }
+      if (owners.find(owner) != owners.end()) {
+        viol_access_points.insert({pin_idx, acc_pattern_idx});  // idx ;
       }
     }
   }

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -117,12 +117,12 @@ void FlexPA::prepPattern()
         continue;
       }
 
-      int num_valid_pattern = prepPatternInst(inst, curr_unique_inst_idx, 1.0);
+      int num_valid_pattern = prepPatternInst(inst, curr_unique_inst_idx);
 
       if (num_valid_pattern == 0) {
         // In FAx1_ASAP7_75t_R (in asap7) the pins are mostly horizontal
         // and sorting in X works poorly.  So we try again sorting in Y.
-        num_valid_pattern = prepPatternInst(inst, curr_unique_inst_idx, 0.0);
+        num_valid_pattern = prepPatternInst(inst, curr_unique_inst_idx, false);
         if (num_valid_pattern == 0) {
           logger_->warn(
               DRT,
@@ -210,7 +210,7 @@ void FlexPA::prepPattern()
 // the input inst must be unique instance
 int FlexPA::prepPatternInst(frInst* inst,
                             const int curr_unique_inst_idx,
-                            const double x_weight)
+                            const bool use_x)
 {
   std::vector<std::pair<frCoord, std::pair<frMPin*, frInstTerm*>>> pins;
   // TODO: add assert in case input inst is not unique inst
@@ -234,8 +234,7 @@ int FlexPA::prepPatternInst(frInst* inst,
       }
       n_aps += cnt;
       if (cnt != 0) {
-        const double coord
-            = (x_weight * sum_x_coord + (1.0 - x_weight) * sum_y_coord) / cnt;
+        const double coord = use_x ? sum_x_coord / cnt : sum_y_coord / cnt;
         pins.push_back({(int) std::round(coord), {pin.get(), inst_term.get()}});
       }
     }


### PR DESCRIPTION
Supports #5867.

This PR has an ISPD and Secure CI associated and will be opened once they pass.

This PR has some refactoring of the access pattern code to support incremental PA.

### `prepPatternInstHelper`
Currently, there is no single function that _actually_ supports the passing of an unique inst to solve its access patterns, although `prepPatternInst` is almost it. The aforementioned function was renamed to `prepPatternInstHelper` and a new function that now has the name `prepPatternInst` was created in its place to simply receive the unique inst and solve its access pattern.

### `curr_unique_inst_idx` plumbing elimination.
Something very weird happens in the access pattern code as mentioned in the discussion of #6731. Many functions of the access patterns code expect both a pointer to an unique inst (`frInst* inst`) as well as the index this unique inst exists in the unique_ vector (`int curr_unique_inst_idx`). This is redundant and very error prone, so the passing of the index was eliminated, and any function that required it now gets the pointer to the instance itself. Some functions that used to get both now just get the instance. 

The appropriate refactoring was done to accommodate for this change. In some cases, deep into functions calls the inst was actually retrieved through some other way, such as getting the instance from the pin analyzed. Now that those functions get the instance, those methods are not needed.

### Other smaller refactors
The now `prepPatternInstHelper` had a weird parameter (`x_weight`) that acted as a boolean, but was a int that assumed wither 1 or 0 value and was used inside an equation. The parameter (now `use_x`) now actually acts as a boolean.

`genPatternsCommit` also had some slight refactoring at its end, two variable name changes (I don't know how those were not caught on the PA general refactor), and a slight owner refactor (that code repetition bothered me).
