### PR TITLE
ip::address::from_string is deprecated, use make_address instead.

### DIFF
--- a/src/utl/src/prometheus/metrics_server.cpp
+++ b/src/utl/src/prometheus/metrics_server.cpp
@@ -70,7 +70,7 @@ PrometheusMetricsServer::~PrometheusMetricsServer()
           io_context;  // Use a separate io_context for the connection.
       boost::asio::ip::tcp::socket socket(io_context);
       boost::asio::ip::tcp::endpoint endpoint(
-          boost::asio::ip::address::from_string("127.0.0.1"), port_);
+          boost::asio::ip::make_address("127.0.0.1"), port_);
       socket.connect(endpoint);         // This will unblock the accept().
     } catch (const std::exception& e) { /*Do nothing, we're dying*/
     }


### PR DESCRIPTION
ip::address::from_string is deprecated since 1.66.0 with an explanation to use make_address() instead.
https://beta.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/ip__address/from_string.html

Last version it is available is in boost 1.86.0
https://beta.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/ip__address/from_string.html

The current 1.87.0 has it removed.