### PR TITLE
rcx: check bounds in extDistRCTable in case of empty table

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -1633,6 +1633,9 @@ double extRCModel::getTotCapOverSub(uint met)
 
 extDistRC* extDistRCTable::getRC_index(int n)
 {
+  if (n < 0) {
+    return nullptr;
+  }
   int cnt = _measureTable->getCnt();
   if (n >= cnt) {
     return nullptr;
@@ -1643,7 +1646,7 @@ extDistRC* extDistRCTable::getRC_index(int n)
 extDistRC* extDistRCTable::getLastRC()
 {
   int cnt = _measureTable->getCnt();
-  return _measureTable->get(cnt - 1);
+  return getRC_index(cnt - 1);
 }
 
 extDistRC* extDistRCTable::getRC(uint s, bool compute)


### PR DESCRIPTION
Changes:
- checks the lower bound on array access for `extDistRCTable`, since this table can be empty, `getLastRC` would access `-1` which throws an error.