### PR TITLE
rsz: Fix a crash in row balancing for PDKs with macros w/out a SITE in the LEF.

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -607,8 +607,8 @@ void Resizer::balanceRowUsage()
   for (auto inst : block_->getInsts()) {
     auto master = inst->getMaster();
     auto site = master->getSite();
-    // Ignore macros, and multi-height cells for now
-    if (inst->isBlock() || site->hasRowPattern()) {
+    // Ignore multi-height cells for now
+    if (site && site->hasRowPattern()) {
       continue;
     }
 

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -607,8 +607,8 @@ void Resizer::balanceRowUsage()
   for (auto inst : block_->getInsts()) {
     auto master = inst->getMaster();
     auto site = master->getSite();
-    // Ignore multi-height cells for now
-    if (site->hasRowPattern()) {
+    // Ignore macros, and multi-height cells for now
+    if (inst->isBlock() || site->hasRowPattern()) {
       continue;
     }
 


### PR DESCRIPTION
Macros are still later skipped by nature of being FIXED, but some PDKs do not specify the SITE in the LEF for macros, so a crash can occur if site is nullptr in balanceRowUsage().