### PR TITLE
gui: add save histogram image

### DIFF
--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -139,6 +139,28 @@ save_clocktree_image
 |`-height`| height of the image in pixels, defaults to the height of the GUI widget. |
 |`-width`| width of the image in pixels, defaults to the width of the GUI widget. |
 
+### Save Timing Histogram Image
+
+This command saves the screenshot of timing histogram given options
+to `filename`.
+
+```tcl
+save_histogram_image
+    filename
+    [-mode mode]
+    [-width width]
+    [-height height]
+```
+
+#### Options
+
+| Switch Name | Description |
+| ---- | ---- |
+|`filename`| path to save the image to. |
+|`-mode`| chart mode to save, defaults to "setup". |
+|`-height`| height of the image in pixels, defaults to the height of the GUI widget. |
+|`-width`| width of the image in pixels, defaults to the width of the GUI widget. |
+
 ### Select Objects
 
 This command selects object based on options.

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -650,6 +650,7 @@ class Gui
 
   // Save histogram view
   void saveHistogramImage(const std::string& filename,
+                          const std::string& mode,
                           int width_px = 0,
                           int height_px = 0);
 

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -648,6 +648,11 @@ class Gui
                           int height_px = 0);
   void selectClockviewerClock(const std::string& clock_name);
 
+  // Save histogram view
+  void saveHistogramImage(const std::string& filename,
+                          int width_px = 0,
+                          int height_px = 0);
+
   // modify display controls
   void setDisplayControlsVisible(const std::string& name, bool value);
   void setDisplayControlsSelectable(const std::string& name, bool value);

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -290,48 +290,6 @@ HistogramView::HistogramView(QWidget* parent)
 {
   chart_->addAxis(axis_y_, Qt::AlignLeft);
   chart_->addAxis(axis_x_, Qt::AlignBottom);
-
-  connect(this,
-          &HistogramView::barIndex,
-          this,
-          &HistogramView::emitEndPointsInBucket);
-}
-
-void HistogramView::mousePressEvent(QMouseEvent* event)
-{
-  const auto abstract_series = chart()->series();
-  if (abstract_series.isEmpty()) {
-    return;
-  }
-
-  // There's only one series for the slack histogram mode.
-  QStackedBarSeries* series
-      = static_cast<QStackedBarSeries*>(abstract_series.front());
-
-  const QPointF series_value = chart()->mapToValue(event->pos(), series);
-
-  // Using QValueAxis for the x axis results in an offset of half unit between
-  // the chart's origin (not the widget's origin, the actual x,y origin from
-  // the chart) and the first bar.
-  const float attachment_offset = 0.5;
-  const float index_mapped_x
-      = static_cast<float>(series_value.x()) + attachment_offset;
-  const float index_mapped_y = static_cast<float>(series_value.y());
-
-  bool valid_horizontal_range
-      = index_mapped_x >= 0
-        && index_mapped_x <= series->barSets().front()->count();
-
-  QValueAxis* y_axis
-      = static_cast<QValueAxis*>(chart()->axes(Qt::Vertical).first());
-
-  bool valid_vertical_range
-      = index_mapped_y >= 0
-        && index_mapped_y <= static_cast<float>(y_axis->max());
-
-  if (valid_horizontal_range && valid_vertical_range) {
-    emit barIndex(static_cast<int>(index_mapped_x));
-  }
 }
 
 void HistogramView::clear()
@@ -580,6 +538,11 @@ std::pair<QBarSet*, QBarSet*> HistogramView::createBarSets()
 
   connect(neg_set, &QBarSet::hovered, this, &HistogramView::showToolTip);
   connect(pos_set, &QBarSet::hovered, this, &HistogramView::showToolTip);
+
+  connect(
+      neg_set, &QBarSet::clicked, this, &HistogramView::emitEndPointsInBucket);
+  connect(
+      pos_set, &QBarSet::clicked, this, &HistogramView::emitEndPointsInBucket);
 
   return {neg_set, pos_set};
 }

--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -56,19 +56,10 @@ ChartsWidget::ChartsWidget(QWidget* parent)
       stagui_(nullptr),
       mode_menu_(new QComboBox(this)),
       filters_menu_(new QComboBox(this)),
-      chart_(new QChart),
-      display_(new HistogramView(chart_, this)),
-      axis_x_(new QValueAxis(this)),
-      axis_y_(new QValueAxis(this)),
+      display_(new HistogramView(this)),
       refresh_filters_button_(new QPushButton("Refresh Filters", this)),
-      buckets_(std::make_unique<Buckets>()),
       prev_filter_index_(0),  // start with no filter
       resetting_menu_(false),
-      default_number_of_buckets_(15),
-      max_slack_(0.0f),
-      min_slack_(std::numeric_limits<float>::max()),
-      bucket_interval_(0.0f),
-      precision_count_(0),
       label_(new QLabel(this))
 {
   setObjectName("charts_widget");  // for settings
@@ -97,18 +88,15 @@ ChartsWidget::ChartsWidget(QWidget* parent)
 
   container->setLayout(layout);
 
-  chart_->addAxis(axis_y_, Qt::AlignLeft);
-  chart_->addAxis(axis_x_, Qt::AlignBottom);
-
   connect(refresh_filters_button_,
           &QPushButton::pressed,
           this,
           &ChartsWidget::updatePathGroupMenuIndexes);
 
   connect(display_,
-          &HistogramView::barIndex,
+          &HistogramView::endPointsToReport,
           this,
-          &ChartsWidget::emitEndPointsInBucket);
+          &ChartsWidget::reportEndPoints);
 
   connect(filters_menu_,
           qOverload<int>(&QComboBox::currentIndexChanged),
@@ -122,15 +110,15 @@ void ChartsWidget::changeMode()
   filters_menu_->clear();
   clearChart();
 
-  if (mode_menu_->currentIndex() == SELECT) {
-    return;
-  }
-
-  if (mode_menu_->currentIndex() == SLACK_HISTOGRAM) {
-    resetting_menu_ = true;
-    setSlackHistogramLayout();
-    setSlackHistogram();
-    resetting_menu_ = false;
+  switch (mode_menu_->currentIndex()) {
+    case SELECT:
+      break;
+    case SLACK_HISTOGRAM:
+      resetting_menu_ = true;
+      setSlackHistogramLayout();
+      setSlackHistogram();
+      resetting_menu_ = false;
+      break;
   }
 }
 
@@ -174,48 +162,9 @@ void ChartsWidget::updatePathGroupMenuIndexes()
   }
 }
 
-void ChartsWidget::showToolTip(bool is_hovering, int bar_index)
-{
-  if (is_hovering) {
-    const QString number_of_pins
-        = QString("Number of Endpoints: %1\n")
-              .arg(static_cast<QBarSet*>(sender())->at(bar_index));
-
-    QString scaled_suffix = sta_->units()->timeUnit()->scaledSuffix();
-
-    const int neg_count_offset = static_cast<int>(buckets_->negative.size());
-
-    const float lower = (bar_index - neg_count_offset) * bucket_interval_;
-    const float upper = lower + bucket_interval_;
-
-    QString time_info
-        = QString("Interval: [%1, %2) ").arg(lower).arg(upper) + scaled_suffix;
-
-    const QString tool_tip = number_of_pins + time_info;
-
-    QToolTip::showText(QCursor::pos(), tool_tip, this);
-  } else {
-    QToolTip::hideText();
-  }
-}
-
 void ChartsWidget::clearChart()
 {
-  buckets_->positive.clear();
-  buckets_->negative.clear();
-
-  // reset limits
-  max_slack_ = 0;
-  min_slack_ = std::numeric_limits<float>::max();
-
-  chart_->setTitle("");
-  chart_->removeAllSeries();
-
-  axis_x_->setTitleText("");
-  axis_x_->hide();
-
-  axis_y_->setTitleText("");
-  axis_y_->hide();
+  display_->clear();
 }
 
 void ChartsWidget::setSlackHistogram()
@@ -230,43 +179,14 @@ void ChartsWidget::setSlackHistogram()
     return;
   }
 
-  setClocks(data.clocks);
-  setBucketInterval();
-  populateBuckets(&(data.constrained_pins), nullptr);
-
-  setVisualConfig();
-}
-
-void ChartsWidget::setVisualConfig()
-{
-  std::pair<QBarSet*, QBarSet*> bar_sets = createBarSets(); /* <neg, pos> */
-  populateBarSets(*bar_sets.first, *bar_sets.second);
-
-  QStackedBarSeries* series = new QStackedBarSeries(this);
-  series->append(bar_sets.first);
-  series->append(bar_sets.second);
-  series->setBarWidth(1.0);
-  chart_->addSeries(series);
-
-  setXAxisConfig(bar_sets.first->count());
-  setYAxisConfig();
-  series->attachAxis(axis_y_);
-
-  chart_->legend()->markers(series)[0]->setVisible(false);
-  chart_->legend()->markers(series)[1]->setVisible(false);
-  chart_->legend()->setVisible(true);
-  chart_->legend()->setAlignment(Qt::AlignBottom);
-  chart_->setTitle("Endpoint Slack");
+  display_->setData(data);
 }
 
 SlackHistogramData ChartsWidget::fetchSlackHistogramData()
 {
   SlackHistogramData data;
 
-  StaPins end_points = stagui_->getEndPoints();
-  removeUnconstrainedPinsAndSetLimits(end_points);
-
-  data.constrained_pins = std::move(end_points);
+  removeUnconstrainedPinsAndSetLimits(data);
 
   for (sta::Clock* clock : *stagui_->getClocks()) {
     data.clocks.insert(clock);
@@ -275,8 +195,9 @@ SlackHistogramData ChartsWidget::fetchSlackHistogramData()
   return data;
 }
 
-void ChartsWidget::removeUnconstrainedPinsAndSetLimits(StaPins& end_points)
+void ChartsWidget::removeUnconstrainedPinsAndSetLimits(SlackHistogramData& data)
 {
+  StaPins end_points = stagui_->getEndPoints();
   const int all_endpoints_count = end_points.size();
 
   int unconstrained_count = 0;
@@ -288,8 +209,8 @@ void ChartsWidget::removeUnconstrainedPinsAndSetLimits(StaPins& end_points)
 
     if (slack != sta::INF) {
       slack = time_unit->staToUser(slack);
-      min_slack_ = std::min(slack, min_slack_);
-      max_slack_ = std::max(slack, max_slack_);
+      data.min = std::min(slack, data.min);
+      data.max = std::max(slack, data.max);
 
       ++pin_iter;
     } else {
@@ -303,6 +224,8 @@ void ChartsWidget::removeUnconstrainedPinsAndSetLimits(StaPins& end_points)
     }
   }
 
+  data.constrained_pins = std::move(end_points);
+
   if (unconstrained_count != 0 && unconstrained_count != all_endpoints_count) {
     const QString label_message = "Number of unconstrained pins: ";
     QString unconstrained_number;
@@ -311,330 +234,19 @@ void ChartsWidget::removeUnconstrainedPinsAndSetLimits(StaPins& end_points)
   }
 }
 
-// We define the slack interval as being inclusive in its lower
-// boundary and exclusive in upper: [lower upper)
-void ChartsWidget::populateBuckets(StaPins* end_points,
-                                   EndPointSlackMap* end_point_to_slack)
+void ChartsWidget::setLogger(utl::Logger* logger)
 {
-  sta::Unit* time_unit = sta_->units()->timeUnit();
+  logger_ = logger;
 
-  float positive_lower = 0.0f, positive_upper = 0.0f, negative_lower = 0.0f,
-        negative_upper = 0.0f;
-
-  int bucket_index = 0;
-
-  do {
-    positive_lower = bucket_interval_ * bucket_index;
-    positive_upper = bucket_interval_ * (bucket_index + 1);
-    negative_lower = -positive_upper;
-    negative_upper = -positive_lower;
-
-    std::vector<const sta::Pin*> pos_bucket, neg_bucket;
-
-    if (end_points) {
-      for (const sta::Pin* pin : *end_points) {
-        const float slack = time_unit->staToUser(stagui_->getPinSlack(pin));
-
-        if (negative_lower <= slack && slack < negative_upper) {
-          neg_bucket.push_back(pin);
-        } else if (positive_lower <= slack && slack < positive_upper) {
-          pos_bucket.push_back(pin);
-        }
-      }
-    } else if (end_point_to_slack) {
-      for (const auto [end_point, sta_slack] : *end_point_to_slack) {
-        const float slack = time_unit->staToUser(sta_slack);
-        if (negative_lower <= slack && slack < negative_upper) {
-          neg_bucket.push_back(end_point);
-        } else if (positive_lower <= slack && slack < positive_upper) {
-          pos_bucket.push_back(end_point);
-        }
-      }
-    }
-
-    // Push zeros - meaning no slack values in the current range - only in
-    // situations where the bucket is in a valid position of the queue.
-    if (min_slack_ < negative_upper) {
-      buckets_->negative.push_front(neg_bucket);
-    }
-
-    if (max_slack_ >= positive_lower) {
-      buckets_->positive.push_back(pos_bucket);
-    }
-
-    ++bucket_index;
-  } while (min_slack_ < negative_upper || max_slack_ >= positive_upper);
-}
-
-std::pair<QBarSet*, QBarSet*> ChartsWidget::createBarSets()
-{
-  QBarSet* neg_set = new QBarSet("");
-  neg_set->setBorderColor(0x8b0000);  // darkred
-  neg_set->setColor(0xf08080);        // lightcoral
-  QBarSet* pos_set = new QBarSet("");
-  pos_set->setBorderColor(0x006400);  // darkgreen
-  pos_set->setColor(0x90ee90);        // lightgreen
-
-  connect(neg_set, &QBarSet::hovered, this, &ChartsWidget::showToolTip);
-  connect(pos_set, &QBarSet::hovered, this, &ChartsWidget::showToolTip);
-
-  return {neg_set, pos_set};
-}
-
-void ChartsWidget::emitEndPointsInBucket(const int bar_index)
-{
-  std::vector<const sta::Pin*> end_points;
-
-  if (buckets_->negative.empty()) {
-    end_points = buckets_->positive[bar_index];
-  } else {
-    const int num_of_neg_buckets = static_cast<int>(buckets_->negative.size());
-
-    if (bar_index >= num_of_neg_buckets) {
-      end_points = buckets_->positive[bar_index - num_of_neg_buckets];
-    } else {
-      end_points = buckets_->negative[bar_index];
-    }
-  }
-
-  if (end_points.empty()) {
-    return;
-  }
-
-  auto compareSlack = [=](const sta::Pin* a, const sta::Pin* b) {
-    return stagui_->getPinSlack(a) < stagui_->getPinSlack(b);
-  };
-  std::sort(end_points.begin(), end_points.end(), compareSlack);
-
-  // Depeding on the size of the bucket, the report can become rather slow
-  // to generate so we define this limit.
-  const int max_number_of_pins = 50;
-  int pin_count = 0;
-
-  std::set<const sta::Pin*> report_pins;
-  for (const sta::Pin* pin : end_points) {
-    if (pin_count == max_number_of_pins) {
-      break;
-    }
-
-    report_pins.insert(pin);
-    ++pin_count;
-  }
-
-  emit endPointsToReport(report_pins, path_group_name_);
-}
-
-void ChartsWidget::setBucketInterval()
-{
-  // Avoid very tiny intervals from interfering with the presentation
-  if (min_slack_ < 0 && max_slack_ < 0) {
-    max_slack_ = 0;
-  } else if (min_slack_ > 0 && max_slack_ > 0) {
-    min_slack_ = 0;
-  }
-
-  const float exact_interval
-      = (max_slack_ - min_slack_) / default_number_of_buckets_;
-
-  int snap_interval = computeSnapBucketInterval(exact_interval);
-
-  // We compute a new number of buckets based on the snap interval.
-  const int new_number_of_buckets
-      = computeNumberofBuckets(snap_interval, max_slack_, min_slack_);
-  const int minimum_number_of_buckets = 8;
-
-  if (new_number_of_buckets < minimum_number_of_buckets) {
-    const float minimum_interval
-        = (max_slack_ - min_slack_) / minimum_number_of_buckets;
-
-    float decimal_snap_interval
-        = computeSnapBucketDecimalInterval(minimum_interval);
-
-    setBucketInterval(decimal_snap_interval);
-  } else {
-    setBucketInterval(snap_interval);
-  }
-}
-
-int ChartsWidget::computeNumberofBuckets(const int bucket_interval,
-                                         const float max_slack,
-                                         const float min_slack)
-{
-  int bucket_count = 1;
-  float current_value = min_slack;
-
-  while (current_value < max_slack) {
-    current_value += bucket_interval;
-    ++bucket_count;
-  }
-
-  return bucket_count;
-}
-
-float ChartsWidget::computeSnapBucketDecimalInterval(float minimum_interval)
-{
-  float integer_part = minimum_interval;
-  int power_count = 0;
-
-  while (static_cast<int>(integer_part) == 0) {
-    integer_part *= 10;
-    ++power_count;
-  }
-
-  setDecimalPrecision(power_count);
-
-  return std::ceil(integer_part) / std::pow(10, power_count);
-}
-
-int ChartsWidget::computeSnapBucketInterval(float exact_interval)
-{
-  if (exact_interval < 10) {
-    return std::ceil(exact_interval);
-  }
-
-  int snap_interval = 0;
-  int digits = computeNumberOfDigits(static_cast<int>(exact_interval));
-
-  while (snap_interval < exact_interval) {
-    snap_interval += 5 * std::pow(10, digits - 2);
-  }
-
-  return snap_interval;
-}
-
-void ChartsWidget::setXAxisConfig(const int all_bars_count)
-{
-  setXAxisTitle();
-
-  const QString format = "%." + QString::number(precision_count_) + "f";
-  axis_x_->setLabelFormat(format);
-
-  const int neg_count_offset = static_cast<int>(buckets_->negative.size());
-  const int pos_bars_count = all_bars_count - neg_count_offset;
-  const float min = -(static_cast<float>(neg_count_offset)) * bucket_interval_;
-  const float max = static_cast<float>(pos_bars_count) * bucket_interval_;
-  axis_x_->setRange(min, max);
-
-  axis_x_->setTickCount(all_bars_count + 1);
-  axis_x_->setGridLineVisible(false);
-  axis_x_->setVisible(true);
-}
-
-void ChartsWidget::setXAxisTitle()
-{
-  const QString start_title = "<center>Slack [";
-
-  sta::Unit* time_units = sta_->units()->timeUnit();
-
-  const QString scaled_suffix = time_units->scaledSuffix();
-  const QString end_title = "], Clocks: ";
-
-  QString axis_x_title = start_title + scaled_suffix + end_title;
-
-  int clock_count = 1;
-
-  for (sta::Clock* clock : clocks_) {
-    float period = time_units->staToUser(clock->period());
-
-    if (period < 1) {
-      const float decimal_digits = 3;
-      const float places = std::pow(10, decimal_digits);
-
-      period = std::round(period * places) / places;
-    }
-
-    // Adjust strings: two clocks in the first row and three per row afterwards
-    if (clock->name() != (*(clocks_.begin()))->name()) {
-      axis_x_title += ", ";
-
-      if (clock_count % 3 == 0) {
-        axis_x_title += "<br>";
-      }
-    }
-
-    axis_x_title
-        += QString::fromStdString(fmt::format(" {} {}", clock->name(), period));
-
-    ++clock_count;
-  }
-
-  axis_x_->setTitleText(axis_x_title);
-}
-
-void ChartsWidget::setYAxisConfig()
-{
-  int largest_slack_count = 0;
-
-  for (const std::vector<const sta::Pin*>& bucket : buckets_->negative) {
-    const int bucket_slack_count = static_cast<int>(bucket.size());
-    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
-  }
-
-  for (const std::vector<const sta::Pin*>& bucket : buckets_->positive) {
-    const int bucket_slack_count = static_cast<int>(bucket.size());
-    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
-  }
-
-  int y_interval = computeYInterval(largest_slack_count);
-  int max_y = 0;
-  int tick_count = 1;
-
-  // Do this instead of just using the return value of computeMaxYSnap()
-  // so we don't get an empty range at the end of the axis.
-  while (max_y < largest_slack_count) {
-    max_y += y_interval;
-    ++tick_count;
-  }
-
-  axis_y_->setRange(0, max_y);
-  axis_y_->setTickCount(tick_count);
-  axis_y_->setTitleText("Number of Endpoints");
-  axis_y_->setLabelFormat("%i");
-  axis_y_->setVisible(true);
-}
-
-int ChartsWidget::computeYInterval(const int largest_slack_count)
-{
-  int snap_max = computeMaxYSnap(largest_slack_count);
-  int digits = computeNumberOfDigits(snap_max);
-  int total = std::pow(10, digits);
-
-  if (computeFirstDigit(snap_max, digits) < 5) {
-    total /= 2;
-  }
-
-  // We ceil to deal with the cases in which we have less than
-  // 10 endpoints in the largest bucket.
-  return static_cast<int>(std::ceil(static_cast<float>(total) / 10));
-}
-
-// Snap to an upper value based on the first digit
-int ChartsWidget::computeMaxYSnap(const int largest_slack_count)
-{
-  if (largest_slack_count <= 10) {
-    return largest_slack_count;
-  }
-
-  int digits = computeNumberOfDigits(largest_slack_count);
-  int first_digit = computeFirstDigit(largest_slack_count, digits);
-
-  return (first_digit + 1) * std::pow(10, digits - 1);
-}
-
-int ChartsWidget::computeNumberOfDigits(int value)
-{
-  return static_cast<int>(std::log10(value)) + 1;
-}
-
-int ChartsWidget::computeFirstDigit(int value, int digits)
-{
-  return static_cast<int>(value / std::pow(10, digits - 1));
+  display_->setLogger(logger_);
 }
 
 void ChartsWidget::setSTA(sta::dbSta* sta)
 {
   sta_ = sta;
   stagui_ = std::make_unique<STAGuiInterface>(sta_);
+
+  display_->setSTA(stagui_.get());
 }
 
 void ChartsWidget::changePathGroupFilter()
@@ -651,57 +263,38 @@ void ChartsWidget::changePathGroupFilter()
 
   if (filter_index > 0) {
     path_group_name_ = filter_index_to_path_group_name_.at(filter_index);
-    end_point_to_slack = stagui_->getEndPointToSlackMap(path_group_name_);
-    setLimits(end_point_to_slack);
+    display_->setData(stagui_->getEndPointToSlackMap(path_group_name_));
   } else {
     path_group_name_.clear();
-    end_points = stagui_->getEndPoints();
-    removeUnconstrainedPinsAndSetLimits(end_points);
-  }
-
-  setBucketInterval();
-
-  if (!end_points.empty()) {
-    populateBuckets(&end_points, nullptr);
-  } else if (!end_point_to_slack.empty()) {
-    populateBuckets(nullptr, &end_point_to_slack);
-  }
-
-  if (buckets_->areEmpty()) {
-    chart_->setTitle("No paths in path group.");
-  } else {
-    setVisualConfig();
+    display_->setData(fetchSlackHistogramData());
   }
 
   prev_filter_index_ = filter_index;
 }
 
-void ChartsWidget::setLimits(const EndPointSlackMap& end_point_to_slack)
+void ChartsWidget::reportEndPoints(const std::set<const sta::Pin*>& report_pins)
 {
-  sta::Unit* time_unit = sta_->units()->timeUnit();
-  for (const auto [end_point, sta_slack] : end_point_to_slack) {
-    const float slack = time_unit->staToUser(sta_slack);
-    min_slack_ = std::min(slack, min_slack_);
-    max_slack_ = std::max(slack, max_slack_);
-  }
-}
-
-void ChartsWidget::populateBarSets(QBarSet& neg_set, QBarSet& pos_set)
-{
-  for (int i = 0; i < buckets_->negative.size(); ++i) {
-    neg_set << buckets_->negative[i].size();
-    pos_set << 0;
-  }
-  for (int i = 0; i < buckets_->positive.size(); ++i) {
-    neg_set << 0;
-    pos_set << buckets_->positive[i].size();
-  }
+  emit endPointsToReport(report_pins, path_group_name_);
 }
 
 ////// HistogramView ///////
-HistogramView::HistogramView(QChart* chart, QWidget* parent)
-    : QChartView(chart, parent)
+HistogramView::HistogramView(QWidget* parent)
+    : QChartView(new QChart, parent),
+      chart_(chart()),
+      axis_x_(new QValueAxis(this)),
+      axis_y_(new QValueAxis(this)),
+      max_slack_(std::numeric_limits<float>::lowest()),
+      min_slack_(std::numeric_limits<float>::max()),
+      bucket_interval_(0.0f),
+      precision_count_(0)
 {
+  chart_->addAxis(axis_y_, Qt::AlignLeft);
+  chart_->addAxis(axis_x_, Qt::AlignBottom);
+
+  connect(this,
+          &HistogramView::barIndex,
+          this,
+          &HistogramView::emitEndPointsInBucket);
 }
 
 void HistogramView::mousePressEvent(QMouseEvent* event)
@@ -738,6 +331,448 @@ void HistogramView::mousePressEvent(QMouseEvent* event)
 
   if (valid_horizontal_range && valid_vertical_range) {
     emit barIndex(static_cast<int>(index_mapped_x));
+  }
+}
+
+void HistogramView::clear()
+{
+  buckets_.positive.clear();
+  buckets_.negative.clear();
+
+  // reset limits
+  max_slack_ = std::numeric_limits<float>::lowest();
+  min_slack_ = std::numeric_limits<float>::max();
+
+  chart_->setTitle("");
+  chart_->removeAllSeries();
+
+  axis_x_->setTitleText("");
+  axis_x_->hide();
+
+  axis_y_->setTitleText("");
+  axis_y_->hide();
+}
+
+void HistogramView::showToolTip(bool is_hovering, int bar_index)
+{
+  if (is_hovering) {
+    const QString number_of_pins
+        = QString("Number of Endpoints: %1\n")
+              .arg(static_cast<QBarSet*>(sender())->at(bar_index));
+
+    QString scaled_suffix = sta_->getSTA()->units()->timeUnit()->scaledSuffix();
+
+    const int neg_count_offset = static_cast<int>(buckets_.negative.size());
+
+    const float lower = (bar_index - neg_count_offset) * bucket_interval_;
+    const float upper = lower + bucket_interval_;
+
+    QString time_info
+        = QString("Interval: [%1, %2) ").arg(lower).arg(upper) + scaled_suffix;
+
+    const QString tool_tip = number_of_pins + time_info;
+
+    QToolTip::showText(QCursor::pos(), tool_tip, this);
+  } else {
+    QToolTip::hideText();
+  }
+}
+
+void HistogramView::setData(const SlackHistogramData& data)
+{
+  clear();
+
+  min_slack_ = data.min;
+  max_slack_ = data.max;
+
+  clocks_ = data.clocks;
+  setBucketInterval();
+  populateBuckets(&data.constrained_pins, nullptr);
+
+  setVisualConfig();
+}
+
+void HistogramView::setData(const EndPointSlackMap& data)
+{
+  clear();
+
+  setLimits(data);
+
+  setBucketInterval();
+  populateBuckets(nullptr, &data);
+
+  setVisualConfig();
+}
+
+void HistogramView::setBucketInterval()
+{
+  // Avoid very tiny intervals from interfering with the presentation
+  if (min_slack_ < 0 && max_slack_ < 0) {
+    max_slack_ = 0;
+  } else if (min_slack_ > 0 && max_slack_ > 0) {
+    min_slack_ = 0;
+  }
+
+  const float exact_interval
+      = (max_slack_ - min_slack_) / default_number_of_buckets_;
+
+  int snap_interval = computeSnapBucketInterval(exact_interval);
+
+  // We compute a new number of buckets based on the snap interval.
+  const int new_number_of_buckets
+      = computeNumberofBuckets(snap_interval, max_slack_, min_slack_);
+  const int minimum_number_of_buckets = 8;
+
+  if (new_number_of_buckets < minimum_number_of_buckets) {
+    const float minimum_interval
+        = (max_slack_ - min_slack_) / minimum_number_of_buckets;
+
+    float decimal_snap_interval
+        = computeSnapBucketDecimalInterval(minimum_interval);
+
+    bucket_interval_ = decimal_snap_interval;
+  } else {
+    bucket_interval_ = snap_interval;
+  }
+}
+
+int HistogramView::computeNumberofBuckets(const int bucket_interval,
+                                          const float max_slack,
+                                          const float min_slack)
+{
+  int bucket_count = 1;
+  float current_value = min_slack;
+
+  while (current_value < max_slack) {
+    current_value += bucket_interval;
+    ++bucket_count;
+  }
+
+  return bucket_count;
+}
+
+float HistogramView::computeSnapBucketDecimalInterval(float minimum_interval)
+{
+  float integer_part = minimum_interval;
+  int power_count = 0;
+
+  while (static_cast<int>(integer_part) == 0) {
+    integer_part *= 10;
+    ++power_count;
+  }
+
+  precision_count_ = power_count;
+
+  return std::ceil(integer_part) / std::pow(10, power_count);
+}
+
+int HistogramView::computeSnapBucketInterval(float exact_interval)
+{
+  if (exact_interval < 10) {
+    return std::ceil(exact_interval);
+  }
+
+  int snap_interval = 0;
+  int digits = computeNumberOfDigits(static_cast<int>(exact_interval));
+
+  while (snap_interval < exact_interval) {
+    snap_interval += 5 * std::pow(10, digits - 2);
+  }
+
+  return snap_interval;
+}
+
+int HistogramView::computeNumberOfDigits(int value)
+{
+  return static_cast<int>(std::log10(value)) + 1;
+}
+
+void HistogramView::setVisualConfig()
+{
+  if (buckets_.areEmpty()) {
+    chart_->setTitle("No paths in path group.");
+    return;
+  }
+
+  std::pair<QBarSet*, QBarSet*> bar_sets = createBarSets(); /* <neg, pos> */
+  populateBarSets(*bar_sets.first, *bar_sets.second);
+
+  QStackedBarSeries* series = new QStackedBarSeries(this);
+  series->append(bar_sets.first);
+  series->append(bar_sets.second);
+  series->setBarWidth(1.0);
+  chart_->addSeries(series);
+
+  setXAxisConfig(bar_sets.first->count());
+  setYAxisConfig();
+  series->attachAxis(axis_y_);
+
+  chart_->legend()->markers(series)[0]->setVisible(false);
+  chart_->legend()->markers(series)[1]->setVisible(false);
+  chart_->legend()->setVisible(true);
+  chart_->legend()->setAlignment(Qt::AlignBottom);
+  chart_->setTitle("Endpoint Slack");
+}
+
+// We define the slack interval as being inclusive in its lower
+// boundary and exclusive in upper: [lower upper)
+void HistogramView::populateBuckets(const StaPins* end_points,
+                                    const EndPointSlackMap* end_point_to_slack)
+{
+  sta::Unit* time_unit = sta_->getSTA()->units()->timeUnit();
+
+  float positive_lower = 0.0f, positive_upper = 0.0f, negative_lower = 0.0f,
+        negative_upper = 0.0f;
+
+  int bucket_index = 0;
+
+  do {
+    positive_lower = bucket_interval_ * bucket_index;
+    positive_upper = bucket_interval_ * (bucket_index + 1);
+    negative_lower = -positive_upper;
+    negative_upper = -positive_lower;
+
+    std::vector<const sta::Pin*> pos_bucket, neg_bucket;
+
+    if (end_points) {
+      for (const sta::Pin* pin : *end_points) {
+        const float slack = time_unit->staToUser(sta_->getPinSlack(pin));
+
+        if (negative_lower <= slack && slack < negative_upper) {
+          neg_bucket.push_back(pin);
+        } else if (positive_lower <= slack && slack < positive_upper) {
+          pos_bucket.push_back(pin);
+        }
+      }
+    } else if (end_point_to_slack) {
+      for (const auto [end_point, sta_slack] : *end_point_to_slack) {
+        const float slack = time_unit->staToUser(sta_slack);
+        if (negative_lower <= slack && slack < negative_upper) {
+          neg_bucket.push_back(end_point);
+        } else if (positive_lower <= slack && slack < positive_upper) {
+          pos_bucket.push_back(end_point);
+        }
+      }
+    }
+
+    // Push zeros - meaning no slack values in the current range - only in
+    // situations where the bucket is in a valid position of the queue.
+    if (min_slack_ < negative_upper) {
+      buckets_.negative.push_front(neg_bucket);
+    }
+
+    if (max_slack_ >= positive_lower) {
+      buckets_.positive.push_back(pos_bucket);
+    }
+
+    ++bucket_index;
+  } while (min_slack_ < negative_upper || max_slack_ >= positive_upper);
+}
+
+std::pair<QBarSet*, QBarSet*> HistogramView::createBarSets()
+{
+  QBarSet* neg_set = new QBarSet("");
+  neg_set->setBorderColor(0x8b0000);  // darkred
+  neg_set->setColor(0xf08080);        // lightcoral
+  QBarSet* pos_set = new QBarSet("");
+  pos_set->setBorderColor(0x006400);  // darkgreen
+  pos_set->setColor(0x90ee90);        // lightgreen
+
+  connect(neg_set, &QBarSet::hovered, this, &HistogramView::showToolTip);
+  connect(pos_set, &QBarSet::hovered, this, &HistogramView::showToolTip);
+
+  return {neg_set, pos_set};
+}
+
+void HistogramView::emitEndPointsInBucket(const int bar_index)
+{
+  std::vector<const sta::Pin*> end_points;
+
+  if (buckets_.negative.empty()) {
+    end_points = buckets_.positive[bar_index];
+  } else {
+    const int num_of_neg_buckets = static_cast<int>(buckets_.negative.size());
+
+    if (bar_index >= num_of_neg_buckets) {
+      end_points = buckets_.positive[bar_index - num_of_neg_buckets];
+    } else {
+      end_points = buckets_.negative[bar_index];
+    }
+  }
+
+  if (end_points.empty()) {
+    return;
+  }
+
+  auto compareSlack = [=](const sta::Pin* a, const sta::Pin* b) {
+    return sta_->getPinSlack(a) < sta_->getPinSlack(b);
+  };
+  std::sort(end_points.begin(), end_points.end(), compareSlack);
+
+  // Depeding on the size of the bucket, the report can become rather slow
+  // to generate so we define this limit.
+  const int max_number_of_pins = 50;
+  int pin_count = 0;
+
+  std::set<const sta::Pin*> report_pins;
+  for (const sta::Pin* pin : end_points) {
+    if (pin_count == max_number_of_pins) {
+      break;
+    }
+
+    report_pins.insert(pin);
+    ++pin_count;
+  }
+
+  emit endPointsToReport(report_pins);
+}
+
+void HistogramView::setXAxisTitle()
+{
+  const QString start_title = "<center>Slack [";
+
+  sta::Unit* time_units = sta_->getSTA()->units()->timeUnit();
+
+  const QString scaled_suffix = time_units->scaledSuffix();
+  const QString end_title = "], Clocks: ";
+
+  QString axis_x_title = start_title + scaled_suffix + end_title;
+
+  int clock_count = 1;
+
+  for (sta::Clock* clock : clocks_) {
+    float period = time_units->staToUser(clock->period());
+
+    if (period < 1) {
+      const float decimal_digits = 3;
+      const float places = std::pow(10, decimal_digits);
+
+      period = std::round(period * places) / places;
+    }
+
+    // Adjust strings: two clocks in the first row and three per row afterwards
+    if (clock->name() != (*(clocks_.begin()))->name()) {
+      axis_x_title += ", ";
+
+      if (clock_count % 3 == 0) {
+        axis_x_title += "<br>";
+      }
+    }
+
+    axis_x_title
+        += QString::fromStdString(fmt::format(" {} {}", clock->name(), period));
+
+    ++clock_count;
+  }
+
+  axis_x_->setTitleText(axis_x_title);
+}
+
+void HistogramView::setYAxisConfig()
+{
+  int largest_slack_count = 0;
+
+  for (const std::vector<const sta::Pin*>& bucket : buckets_.negative) {
+    const int bucket_slack_count = static_cast<int>(bucket.size());
+    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
+  }
+
+  for (const std::vector<const sta::Pin*>& bucket : buckets_.positive) {
+    const int bucket_slack_count = static_cast<int>(bucket.size());
+    largest_slack_count = std::max(bucket_slack_count, largest_slack_count);
+  }
+
+  int y_interval = computeYInterval(largest_slack_count);
+  int max_y = 0;
+  int tick_count = 1;
+
+  // Do this instead of just using the return value of computeMaxYSnap()
+  // so we don't get an empty range at the end of the axis.
+  while (max_y < largest_slack_count) {
+    max_y += y_interval;
+    ++tick_count;
+  }
+
+  axis_y_->setRange(0, max_y);
+  axis_y_->setTickCount(tick_count);
+  axis_y_->setTitleText("Number of Endpoints");
+  axis_y_->setLabelFormat("%i");
+  axis_y_->setVisible(true);
+}
+
+void HistogramView::setXAxisConfig(const int all_bars_count)
+{
+  setXAxisTitle();
+
+  const QString format = "%." + QString::number(precision_count_) + "f";
+  axis_x_->setLabelFormat(format);
+
+  const int neg_count_offset = static_cast<int>(buckets_.negative.size());
+  const int pos_bars_count = all_bars_count - neg_count_offset;
+  const float min = -(static_cast<float>(neg_count_offset)) * bucket_interval_;
+  const float max = static_cast<float>(pos_bars_count) * bucket_interval_;
+  axis_x_->setRange(min, max);
+
+  axis_x_->setTickCount(all_bars_count + 1);
+  axis_x_->setGridLineVisible(false);
+  axis_x_->setVisible(true);
+}
+
+int HistogramView::computeYInterval(const int largest_slack_count)
+{
+  int snap_max = computeMaxYSnap(largest_slack_count);
+  int digits = computeNumberOfDigits(snap_max);
+  int total = std::pow(10, digits);
+
+  if (computeFirstDigit(snap_max, digits) < 5) {
+    total /= 2;
+  }
+
+  // We ceil to deal with the cases in which we have less than
+  // 10 endpoints in the largest bucket.
+  return static_cast<int>(std::ceil(static_cast<float>(total) / 10));
+}
+
+// Snap to an upper value based on the first digit
+int HistogramView::computeMaxYSnap(const int largest_slack_count)
+{
+  if (largest_slack_count <= 10) {
+    return largest_slack_count;
+  }
+
+  int digits = computeNumberOfDigits(largest_slack_count);
+  int first_digit = computeFirstDigit(largest_slack_count, digits);
+
+  return (first_digit + 1) * std::pow(10, digits - 1);
+}
+
+int HistogramView::computeFirstDigit(int value, int digits)
+{
+  return static_cast<int>(value / std::pow(10, digits - 1));
+}
+
+void HistogramView::setLimits(const EndPointSlackMap& end_point_to_slack)
+{
+  max_slack_ = std::numeric_limits<float>::lowest();
+  min_slack_ = std::numeric_limits<float>::max();
+
+  sta::Unit* time_unit = sta_->getSTA()->units()->timeUnit();
+  for (const auto [end_point, sta_slack] : end_point_to_slack) {
+    const float slack = time_unit->staToUser(sta_slack);
+    min_slack_ = std::min(slack, min_slack_);
+    max_slack_ = std::max(slack, max_slack_);
+  }
+}
+
+void HistogramView::populateBarSets(QBarSet& neg_set, QBarSet& pos_set)
+{
+  for (int i = 0; i < buckets_.negative.size(); ++i) {
+    neg_set << buckets_.negative[i].size();
+    pos_set << 0;
+  }
+  for (int i = 0; i < buckets_.positive.size(); ++i) {
+    neg_set << 0;
+    pos_set << buckets_.positive[i].size();
   }
 }
 

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -38,6 +38,7 @@
 #include <QPushButton>
 #include <QString>
 #include <QtCharts>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -56,6 +57,8 @@ struct SlackHistogramData
 {
   StaPins constrained_pins;
   std::set<sta::Clock*> clocks;
+  float min = std::numeric_limits<float>::max();
+  float max = std::numeric_limits<float>::lowest();
 };
 
 struct Buckets
@@ -71,12 +74,68 @@ class HistogramView : public QChartView
   Q_OBJECT
 
  public:
-  HistogramView(QChart* chart, QWidget* parent);
+  HistogramView(QWidget* parent);
+
+  void setSTA(STAGuiInterface* sta) { sta_ = sta; }
+  void setLogger(utl::Logger* logger) { logger_ = logger; }
+
+  void clear();
+  void setData(const SlackHistogramData& data);
+  void setData(const EndPointSlackMap& data);
 
   void mousePressEvent(QMouseEvent* event) override;
 
  signals:
   void barIndex(int bar_index);
+  void endPointsToReport(const std::set<const sta::Pin*>& report_pins);
+
+ private slots:
+  void showToolTip(bool is_hovering, int bar_index);
+  void emitEndPointsInBucket(int bar_index);
+
+ private:
+  void setBucketInterval();
+  int computeSnapBucketInterval(float exact_interval);
+  float computeSnapBucketDecimalInterval(float minimum_interval);
+  int computeNumberofBuckets(int bucket_interval,
+                             float max_slack,
+                             float min_slack);
+  int computeNumberOfDigits(int value);
+
+  void setVisualConfig();
+
+  void populateBuckets(const StaPins* end_points,
+                       const EndPointSlackMap* end_point_to_slack);
+  std::pair<QBarSet*, QBarSet*> createBarSets();
+  void populateBarSets(QBarSet& neg_set, QBarSet& pos_set);
+
+  void setXAxisConfig(int all_bars_count);
+  void setXAxisTitle();
+  void setYAxisConfig();
+  int computeYInterval(int largest_slack_count);
+  int computeMaxYSnap(int largest_slack_count);
+  int computeFirstDigit(int value, int digits);
+
+  void setLimits(const EndPointSlackMap& end_point_to_slack);
+
+  utl::Logger* logger_;
+  STAGuiInterface* sta_;
+
+  QChart* chart_;
+  QValueAxis* axis_x_;
+  QValueAxis* axis_y_;
+
+  // Settings
+  float max_slack_;
+  float min_slack_;
+  float bucket_interval_;
+  int precision_count_;  // Used to configure the x labels.
+
+  // Data
+  std::set<sta::Clock*> clocks_;
+  Buckets buckets_;
+
+  static constexpr int default_number_of_buckets_ = 15;
 };
 
 class ChartsWidget : public QDockWidget
@@ -92,7 +151,7 @@ class ChartsWidget : public QDockWidget
 
   ChartsWidget(QWidget* parent = nullptr);
   void setSTA(sta::dbSta* sta);
-  void setLogger(utl::Logger* logger) { logger_ = logger; }
+  void setLogger(utl::Logger* logger);
 
   void setMode(Mode mode);
 
@@ -100,52 +159,21 @@ class ChartsWidget : public QDockWidget
   void endPointsToReport(const std::set<const sta::Pin*>& report_pins,
                          const std::string& path_group_name);
 
+ public slots:
+  void reportEndPoints(const std::set<const sta::Pin*>& report_pins);
+
  private slots:
   void changeMode();
   void updatePathGroupMenuIndexes();
   void changePathGroupFilter();
-  void showToolTip(bool is_hovering, int bar_index);
-  void emitEndPointsInBucket(int bar_index);
 
  private:
   void setSlackHistogram();
   void setSlackHistogramLayout();
   void setModeMenu();
-  void setBucketInterval();
-  void setBucketInterval(float bucket_interval)
-  {
-    bucket_interval_ = bucket_interval;
-  }
-  void setDecimalPrecision(int precision_count)
-  {
-    precision_count_ = precision_count;
-  }
-  void setClocks(const std::set<sta::Clock*>& clocks) { clocks_ = clocks; }
 
   SlackHistogramData fetchSlackHistogramData();
-  void removeUnconstrainedPinsAndSetLimits(StaPins& end_points);
-  void setLimits(const EndPointSlackMap& end_point_to_slack);
-
-  void populateBuckets(StaPins* end_points,
-                       EndPointSlackMap* end_point_to_slack);
-  std::pair<QBarSet*, QBarSet*> createBarSets();
-  void populateBarSets(QBarSet& neg_set, QBarSet& pos_set);
-
-  void setVisualConfig();
-
-  int computeSnapBucketInterval(float exact_interval);
-  float computeSnapBucketDecimalInterval(float minimum_interval);
-  int computeNumberofBuckets(int bucket_interval,
-                             float max_slack,
-                             float min_slack);
-
-  void setXAxisConfig(int all_bars_count);
-  void setXAxisTitle();
-  void setYAxisConfig();
-  int computeYInterval(int largest_slack_count);
-  int computeMaxYSnap(int largest_slack_count);
-  int computeNumberOfDigits(int value);
-  int computeFirstDigit(int value, int digits);
+  void removeUnconstrainedPinsAndSetLimits(SlackHistogramData& data);
 
   void clearChart();
 
@@ -155,26 +183,15 @@ class ChartsWidget : public QDockWidget
 
   QComboBox* mode_menu_;
   QComboBox* filters_menu_;
-  QChart* chart_;
   HistogramView* display_;
-  QValueAxis* axis_x_;
-  QValueAxis* axis_y_;
   QPushButton* refresh_filters_button_;
 
   std::string path_group_name_;  // Current selected filter
-  std::set<sta::Clock*> clocks_;
-  std::unique_ptr<Buckets> buckets_;
   std::map<int, std::string> filter_index_to_path_group_name_;
 
   int prev_filter_index_;
   bool resetting_menu_;
 
-  const int default_number_of_buckets_;
-  float max_slack_;
-  float min_slack_;
-  float bucket_interval_;
-
-  int precision_count_;  // Used to configure the x labels.
   QLabel* label_;
 };
 

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -83,10 +83,7 @@ class HistogramView : public QChartView
   void setData(const SlackHistogramData& data);
   void setData(const EndPointSlackMap& data);
 
-  void mousePressEvent(QMouseEvent* event) override;
-
  signals:
-  void barIndex(int bar_index);
   void endPointsToReport(const std::set<const sta::Pin*>& report_pins);
 
  private slots:

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -35,11 +35,13 @@
 #include <QComboBox>
 #include <QDockWidget>
 #include <QLabel>
+#include <QMenu>
 #include <QPushButton>
 #include <QString>
 #include <QtCharts>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "gui/gui.h"
@@ -83,12 +85,20 @@ class HistogramView : public QChartView
   void setData(const SlackHistogramData& data);
   void setData(const EndPointSlackMap& data);
 
+  void save(const QString& path);
+
+ public slots:
+  void saveImage();
+
  signals:
   void endPointsToReport(const std::set<const sta::Pin*>& report_pins);
 
  private slots:
   void showToolTip(bool is_hovering, int bar_index);
   void emitEndPointsInBucket(int bar_index);
+
+ protected:
+  void contextMenuEvent(QContextMenuEvent* event) override;
 
  private:
   void setBucketInterval();
@@ -122,6 +132,8 @@ class HistogramView : public QChartView
   QValueAxis* axis_x_;
   QValueAxis* axis_y_;
 
+  QMenu* menu_;
+
   // Settings
   float max_slack_;
   float min_slack_;
@@ -151,6 +163,10 @@ class ChartsWidget : public QDockWidget
   void setLogger(utl::Logger* logger);
 
   void setMode(Mode mode);
+
+  void saveImage(const std::string& path,
+                 const std::optional<int>& width_px,
+                 const std::optional<int>& height_px);
 
  signals:
   void endPointsToReport(const std::set<const sta::Pin*>& report_pins,

--- a/src/gui/src/chartsWidget.h
+++ b/src/gui/src/chartsWidget.h
@@ -155,7 +155,8 @@ class ChartsWidget : public QDockWidget
   enum Mode
   {
     SELECT,
-    SLACK_HISTOGRAM
+    SETUP_SLACK,
+    HOLD_SLACK
   };
 
   ChartsWidget(QWidget* parent = nullptr);
@@ -165,8 +166,11 @@ class ChartsWidget : public QDockWidget
   void setMode(Mode mode);
 
   void saveImage(const std::string& path,
+                 const Mode mode,
                  const std::optional<int>& width_px,
                  const std::optional<int>& height_px);
+
+  Mode modeFromString(const std::string& mode) const;
 
  signals:
   void endPointsToReport(const std::set<const sta::Pin*>& report_pins,
@@ -185,10 +189,10 @@ class ChartsWidget : public QDockWidget
   void setSlackHistogramLayout();
   void setModeMenu();
 
-  SlackHistogramData fetchSlackHistogramData();
-  void removeUnconstrainedPinsAndSetLimits(SlackHistogramData& data);
+  void setData(HistogramView* view, const std::string& path_group) const;
 
-  void clearChart();
+  SlackHistogramData fetchSlackHistogramData() const;
+  void removeUnconstrainedPinsAndSetLimits(SlackHistogramData& data) const;
 
   utl::Logger* logger_;
   sta::dbSta* sta_;

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -781,6 +781,24 @@ void Gui::saveClockTreeImage(const std::string& clock_name,
       clock_name, filename, corner, width, height);
 }
 
+void Gui::saveHistogramImage(const std::string& filename,
+                             int width_px,
+                             int height_px)
+{
+  if (!enabled()) {
+    return;
+  }
+  std::optional<int> width;
+  std::optional<int> height;
+  if (width_px > 0) {
+    width = width_px;
+  }
+  if (height_px > 0) {
+    height = height_px;
+  }
+  main_window->getChartsWidget()->saveImage(filename, width, height);
+}
+
 void Gui::selectClockviewerClock(const std::string& clock_name)
 {
   if (!enabled()) {

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -782,6 +782,7 @@ void Gui::saveClockTreeImage(const std::string& clock_name,
 }
 
 void Gui::saveHistogramImage(const std::string& filename,
+                             const std::string& mode,
                              int width_px,
                              int height_px)
 {
@@ -796,7 +797,10 @@ void Gui::saveHistogramImage(const std::string& filename,
   if (height_px > 0) {
     height = height_px;
   }
-  main_window->getChartsWidget()->saveImage(filename, width, height);
+  const ChartsWidget::Mode chart_mode
+      = main_window->getChartsWidget()->modeFromString(mode);
+  main_window->getChartsWidget()->saveImage(
+      filename, chart_mode, width, height);
 }
 
 void Gui::selectClockviewerClock(const std::string& clock_name)
@@ -1338,14 +1342,8 @@ void Gui::selectChart(const std::string& name)
     return;
   }
 
-  ChartsWidget::Mode mode;
-  if (name == "Endpoint Slack") {
-    mode = ChartsWidget::Mode::SLACK_HISTOGRAM;
-  } else if (name == "Select Mode") {
-    mode = ChartsWidget::Mode::SELECT;
-  } else {
-    logger_->error(utl::GUI, 105, "Chart {} is unknown.", name);
-  }
+  const ChartsWidget::Mode mode
+      = main_window->getChartsWidget()->modeFromString(name);
   main_window->getChartsWidget()->setMode(mode);
 }
 

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -297,6 +297,15 @@ void select_clockviewer_clock(const char* clock_name)
   gui->selectClockviewerClock(clock_name);
 }
 
+void save_histogram_image(const char* filename, int width_px = 0, int height_px = 0)
+{
+  if (!check_gui("save_histogram_image")) {
+    return;
+  }
+  auto gui = gui::Gui::get();
+  gui->saveHistogramImage(filename, width_px, height_px);
+}
+
 void clear_rulers()
 {
   if (!check_gui("clear_rulers")) {

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -297,13 +297,13 @@ void select_clockviewer_clock(const char* clock_name)
   gui->selectClockviewerClock(clock_name);
 }
 
-void save_histogram_image(const char* filename, int width_px = 0, int height_px = 0)
+void save_histogram_image(const char* filename, const char* mode, int width_px = 0, int height_px = 0)
 {
   if (!check_gui("save_histogram_image")) {
     return;
   }
   auto gui = gui::Gui::get();
-  gui->saveHistogramImage(filename, width_px, height_px);
+  gui->saveHistogramImage(filename, mode, width_px, height_px);
 }
 
 void clear_rulers()

--- a/src/gui/src/gui.tcl
+++ b/src/gui/src/gui.tcl
@@ -205,6 +205,36 @@ proc save_clocktree_image { args } {
   gui::save_clocktree_image $path $clock $corner $width $height
 }
 
+sta::define_cmd_args "save_histogram_image" {
+  [-width width] \
+  [-height height] \
+  [-mode mode] \
+  path
+}
+
+proc save_histogram_image { args } {
+  sta::parse_key_args "save_histogram_image" args \
+    keys {-width -height -mode} flags {}
+
+  sta::check_argc_eq1 "save_histogram_image" $args
+  set path [lindex $args 0]
+
+  set width 0
+  if { [info exists keys(-width)] } {
+    set width $keys(-width)
+  }
+  set height 0
+  if { [info exists keys(-height)] } {
+    set height $keys(-height)
+  }
+  set mode "setup"
+  if { [info exists keys(-mode)] } {
+    set mode $keys(-mode)
+  }
+
+  gui::save_histogram_image $path $mode $width $height
+}
+
 sta::define_cmd_args "select" {-type object_type \
                                [-name name_regex] \
                                [-case_insensitive] \


### PR DESCRIPTION
Changes:
- reorganized the ChartsWidget to ensure the histogramwidget owns all the display data to allow for easier integration with the save image code.
- added a save option to the mouse menu
- added access from tcl to save the image via `save_histogram_image`
- added hold timing to to bar chart
