### PR TITLE
drt: better dbInst to frInst translation

### DIFF
--- a/src/drt/src/db/obj/frBlock.h
+++ b/src/drt/src/db/obj/frBlock.h
@@ -41,6 +41,7 @@
 #include "db/obj/frNet.h"
 #include "db/obj/frTrackPattern.h"
 #include "frBaseTypes.h"
+#include "odb/db.h"
 
 namespace drt {
 namespace io {
@@ -122,6 +123,7 @@ class frBlock : public frBlockObject
     }
     return nullptr;
   }
+  frInst* findInst(odb::dbInst* inst) { return findInst(inst->getName()); }
   frNet* getNet(int id) const
   {
     if (id >= nets_.size()) {

--- a/src/drt/src/io/io.h
+++ b/src/drt/src/io/io.h
@@ -100,7 +100,7 @@ class Parser
   void setDieArea(odb::dbBlock*);
   void setTracks(odb::dbBlock*);
   void setInsts(odb::dbBlock*);
-  void setInst(odb::dbInst*);
+  frInst* setInst(odb::dbInst*);
   void setObstructions(odb::dbBlock*);
   void setBTerms(odb::dbBlock*);
   odb::Rect getViaBoxForTermAboveMaxLayer(odb::dbBTerm* term,

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -66,7 +66,7 @@ void FlexPA::getInsts(std::vector<frInst*>& insts)
 {
   std::set<frInst*> target_frinsts;
   for (auto inst : target_insts_) {
-    target_frinsts.insert(design_->getTopBlock()->findInst(inst->getName()));
+    target_frinsts.insert(design_->getTopBlock()->findInst(inst));
   }
   for (auto& inst : design_->getTopBlock()->getInsts()) {
     if (!target_insts_.empty()

--- a/src/drt/src/pa/FlexPA_unique.cpp
+++ b/src/drt/src/pa/FlexPA_unique.cpp
@@ -189,7 +189,7 @@ void UniqueInsts::computeUnique()
 
   std::set<frInst*> target_frinsts;
   for (auto inst : target_insts_) {
-    target_frinsts.insert(design_->getTopBlock()->findInst(inst->getName()));
+    target_frinsts.insert(design_->getTopBlock()->findInst(inst));
   }
 
   for (auto& inst : design_->getTopBlock()->getInsts()) {


### PR DESCRIPTION
Supports #5867.

This PR contains some minor changes to support the translation of dbInst data to frInst data. During incremental PA the GRT will only request changed to dbInst objects, while the DRT works only with frInst data. This makes changes to make this communication smoother.

#### `findInst()`
`findInst()` requires the name of the inst to retrieve the respective `frInst*`, another function of the same name, that expects a `dbInst*` instead of a string was created. This is very minor (1 single line of code + 1 import), but helps clean some other parts of the code up.

#### `io::Parser::setInst()`
The main change is that now the function returns the raw pointer of the created `frInst*`. Incremental PA is being build to support the passing of an instance not already initialized in the DRT. If this is the case, this will be done by the `io::Parser::setInst()` function. Returning the raw pointer of the inst helps dynamically creating the inst. Some other minor refactors to the function were also done.