### PR TITLE
cts: Adds a CKMeans mode without branching

### DIFF
--- a/src/cts/src/Clustering.cpp
+++ b/src/cts/src/Clustering.cpp
@@ -77,15 +77,22 @@ struct Sink
 };
 
 Clustering::Clustering(const std::vector<std::pair<float, float>>& sinks,
-                       const float xBranch,
-                       const float yBranch,
                        Logger* logger)
-    : logger_(logger), branching_point_(xBranch, yBranch)
 {
+  logger_ = logger;
   sinks_.reserve(sinks.size());
   for (size_t i = 0; i < sinks.size(); ++i) {
     sinks_.emplace_back(sinks[i].first, sinks[i].second, i);
   }
+}
+
+Clustering::Clustering(const std::vector<std::pair<float, float>>& sinks,
+                       const float xBranch,
+                       const float yBranch,
+                       Logger* logger)
+    : Clustering(sinks, logger)
+{
+  branching_point_ = {xBranch, yBranch};
   srand(56);
 }
 
@@ -126,11 +133,15 @@ void Clustering::iterKmeans(const unsigned iter,
 
 void Clustering::fixSegmentLengths(std::vector<std::pair<float, float>>& means)
 {
+  if (!branching_point_) {
+    return;
+  }
   // First, fix the middle positions
   const unsigned midIdx = means.size() / 2 - 1;
 
-  fixSegment(branching_point_, segment_length_ / 2.0, means[midIdx]);
-  fixSegment(branching_point_, segment_length_ / 2.0, means[midIdx + 1]);
+  fixSegment(branching_point_.value(), segment_length_ / 2.0, means[midIdx]);
+  fixSegment(
+      branching_point_.value(), segment_length_ / 2.0, means[midIdx + 1]);
 
   // Fix lower branch
   for (unsigned i = midIdx; i > 0; --i) {

--- a/src/cts/src/Clustering.h
+++ b/src/cts/src/Clustering.h
@@ -34,6 +34,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include <cmath>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -50,6 +51,7 @@ struct Sink;
 class Clustering
 {
  public:
+  Clustering(const std::vector<std::pair<float, float>>& sinks, Logger* logger);
   Clustering(const std::vector<std::pair<float, float>>& sinks,
              float xBranch,
              float yBranch,
@@ -90,7 +92,7 @@ class Clustering
   std::vector<std::vector<Sink*>> clusters_;
 
   float segment_length_ = 0.0;
-  std::pair<float, float> branching_point_;
+  std::optional<std::pair<float, float>> branching_point_;
 };
 
 }  // namespace cts::CKMeans

--- a/src/cts/test/cts_unittest.cc
+++ b/src/cts/test/cts_unittest.cc
@@ -37,18 +37,18 @@ TEST(Cluster, BranchingPointIsDisabledIfNoBranchesAreProvided)
   std::vector<std::pair<float, float>> means_without_branching
       = {{16, 41}, {33, 18}};
 
-      // Better names
-      //  iter
-      //  number_of_clusters
-      //  max_cluster_size
-      //  maximum_iteration_count
-      //  power
-      clustering_engine.iterKmeans(/*iter=*/1,
-                                   /*n=*/2,
-                                   /*cap=*/2,
-                                   /*max*/ 5,
-                                   /*power*/ 4,
-                                   means_without_branching);
+  // Better names
+  //  iter
+  //  number_of_clusters
+  //  max_cluster_size
+  //  maximum_iteration_count
+  //  power
+  clustering_engine.iterKmeans(/*iter=*/1,
+                               /*n=*/2,
+                               /*cap=*/2,
+                               /*max*/ 5,
+                               /*power*/ 4,
+                               means_without_branching);
 
   CKMeans::Clustering clustering_engine_with_branching(/*sinks=*/
                                                        {{10, 20},

--- a/src/cts/test/cts_unittest.cc
+++ b/src/cts/test/cts_unittest.cc
@@ -36,12 +36,19 @@ TEST(Cluster, BranchingPointIsDisabledIfNoBranchesAreProvided)
                                         &logger);
   std::vector<std::pair<float, float>> means_without_branching
       = {{16, 41}, {33, 18}};
-  clustering_engine.iterKmeans(/*iter=*/1,
-                               /*number_of_clusters=*/2,
-                               /*max_cluster_size=*/2,
-                               /*maximum_iteration_count*/ 5,
-                               /*power*/ 4,
-                               means_without_branching);
+
+      // Better names
+      //  iter
+      //  number_of_clusters
+      //  max_cluster_size
+      //  maximum_iteration_count
+      //  power
+      clustering_engine.iterKmeans(/*iter=*/1,
+                                   /*n=*/2,
+                                   /*cap=*/2,
+                                   /*max*/ 5,
+                                   /*power*/ 4,
+                                   means_without_branching);
 
   CKMeans::Clustering clustering_engine_with_branching(/*sinks=*/
                                                        {{10, 20},

--- a/src/cts/test/cts_unittest.cc
+++ b/src/cts/test/cts_unittest.cc
@@ -6,6 +6,7 @@
 
 #include "gtest/gtest.h"
 #include "src/cts/src/Clock.h"
+#include "src/cts/src/Clustering.h"
 #include "src/cts/src/HTreeBuilder.h"
 #include "utl/Logger.h"
 
@@ -22,6 +23,44 @@ TEST(HTreeBuilderTest, Instantiates)
   utl::Logger logger;
   HTreeBuilder instance(
       /*options=*/nullptr, clock, /*parent=*/nullptr, &logger, nullptr);
+}
+
+TEST(Cluster, BranchingPointIsDisabledIfNoBranchesAreProvided)
+{
+  utl::Logger logger;
+  CKMeans::Clustering clustering_engine(/*sinks=*/
+                                        {{10, 20},
+                                         {10, 10},
+                                         {40, 40},
+                                         {50, 50}},
+                                        &logger);
+  std::vector<std::pair<float, float>> means_without_branching
+      = {{16, 41}, {33, 18}};
+  clustering_engine.iterKmeans(/*iter=*/1,
+                               /*number_of_clusters=*/2,
+                               /*max_cluster_size=*/2,
+                               /*maximum_iteration_count*/ 5,
+                               /*power*/ 4,
+                               means_without_branching);
+
+  CKMeans::Clustering clustering_engine_with_branching(/*sinks=*/
+                                                       {{10, 20},
+                                                        {10, 10},
+                                                        {40, 40},
+                                                        {50, 50}},
+                                                       0,
+                                                       0,
+                                                       &logger);
+  std::vector<std::pair<float, float>> means_with_branching
+      = {{16, 41}, {33, 18}};
+  clustering_engine_with_branching.iterKmeans(/*iter=*/1,
+                                              /*number_of_clusters=*/2,
+                                              /*max_cluster_size=*/2,
+                                              /*maximum_iteration_count*/ 5,
+                                              /*power*/ 4,
+                                              means_with_branching);
+
+  EXPECT_NE(means_without_branching[0].first, means_with_branching[0].first);
 }
 
 }  // namespace cts


### PR DESCRIPTION
Adding a new mode to CKMeans that does not adjust
the branch length. The start of some infrastructure to do high fanout net synthesis.