### PR TITLE
mpl: avoid creating blockages with zero depth and improve debug messages

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -94,11 +94,6 @@ void ClusteringEngine::run()
   }
 }
 
-void ClusteringEngine::setDesignMetrics(Metrics* design_metrics)
-{
-  design_metrics_ = design_metrics;
-}
-
 void ClusteringEngine::setTree(PhysicalHierarchy* tree)
 {
   tree_ = tree;

--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -155,7 +155,6 @@ class ClusteringEngine
 
   void run();
 
-  void setDesignMetrics(Metrics* design_metrics);
   void setTree(PhysicalHierarchy* tree);
 
   // Methods to update the tree as the hierarchical

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -284,10 +284,8 @@ void HierRTLMP::runMultilevelAutoclustering()
   clustering_engine_ = std::make_unique<ClusteringEngine>(
       block_, network_, logger_, tritonpart_);
 
-  // Set target structures
-  clustering_engine_->setDesignMetrics(metrics_);
+  // Set target structure
   clustering_engine_->setTree(tree_.get());
-
   clustering_engine_->run();
 
   if (!tree_->has_unfixed_macros) {
@@ -890,8 +888,11 @@ void HierRTLMP::setPinAccessBlockages()
     return;
   }
 
+  const Metrics* top_module_metrics
+      = tree_->maps.module_to_metrics.at(block_->getTopModule()).get();
+
   // Avoid creating blockages with zero depth.
-  if (metrics_->getStdCellArea() == 0.0) {
+  if (top_module_metrics->getStdCellArea() == 0.0) {
     return;
   }
 

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -67,7 +67,6 @@ namespace mpl {
 struct BundledNet;
 class Cluster;
 class HardMacro;
-class Metrics;
 struct Rect;
 class SoftMacro;
 class Snapper;
@@ -329,9 +328,6 @@ class HierRTLMP
   float exchange_swap_prob_ = 0.2;
   float flip_prob_ = 0.4;
   float resize_prob_ = 0.4;
-
-  // statistics of the design
-  Metrics* metrics_ = nullptr;
 
   // since we convert from the database unit to the micrometer
   // during calculation, we may loss some accuracy.


### PR DESCRIPTION
... so that we know which type of overlap happened when the boundary pushed is reverted.

#### Context
As I was creating the tests for boundary pushing I ran into a weird overlap push reverting which should not happen.

#### Additional
 - Remove top module `Metrics` pointer (which is accessible through the `PhysicalHierarchy` and doesn't need caching) from `HierRTLMP` class and its wrong setter API from the `ClusteringEngine` class.