### PR TITLE
gui: escape populateBuckets when paths are empty

### DIFF
--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -552,6 +552,16 @@ void HistogramView::setVisualConfig()
 void HistogramView::populateBuckets(const StaPins* end_points,
                                     const EndPointSlackMap* end_point_to_slack)
 {
+  if (end_points) {
+    if (end_points->empty()) {
+      return;
+    }
+  } else if (end_point_to_slack) {
+    if (end_point_to_slack->empty()) {
+      return;
+    }
+  }
+
   sta::Unit* time_unit = sta_->getSTA()->units()->timeUnit();
 
   float positive_lower = 0.0f, positive_upper = 0.0f, negative_lower = 0.0f,


### PR DESCRIPTION
Fixes:
- this function enters an infinite loop when there are no paths