### PR TITLE
etc: Get boost package from https://archives.boost.io as referenced by official site.

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -148,8 +148,7 @@ _installCommonDev() {
     if [[ -z $(grep "BOOST_LIB_VERSION \"${boostVersionBig//./_}\"" ${boostPrefix}/include/boost/version.hpp 2> /dev/null) ]]; then
         cd "${baseDir}"
         boostVersionUnderscore=${boostVersionSmall//./_}
-        eval wget https://sourceforge.net/projects/boost/files/boost/${boostVersionSmall}/boost_${boostVersionUnderscore}.tar.gz
-        # eval wget https://boostorg.jfrog.io/artifactory/main/release/${boostVersionSmall}/source/boost_${boostVersionUnderscore}.tar.gz
+        eval wget https://archives.boost.io/release/${boostVersionSmall}/source/boost_${boostVersionUnderscore}.tar.gz
         md5sum -c <(echo "${boostChecksum}  boost_${boostVersionUnderscore}.tar.gz") || exit 1
         tar -xf boost_${boostVersionUnderscore}.tar.gz
         cd boost_${boostVersionUnderscore}


### PR DESCRIPTION
Official site download links are at https://www.boost.org/users/history/.

Sourceforge causes troubles with my company Zscaler gateway and makes wget to fail. Accessing Sourceforge from a browser shows the message below asking to confirm access to the site. Once done the gateway allows wget to do the download.

You tried to visit: https://sourceforge.net/
Request method cautioned for category Shareware Download This website is providing free to try software downloads. We remind you that, in accordance with your company policy, you must not download any software from the internet directly.