### PR TITLE
gpl: debug mode update db option

### DIFF
--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -186,6 +186,8 @@ global_placement_debug
     [-inst]
     [-draw_bins]
     [-initial]
+    [-start_iter]
+    [-update_db]
 ```
 
 #### Options
@@ -197,6 +199,8 @@ global_placement_debug
 | `-inst` | Targets a specific instance name for debugging focus. Allowed value is a string, the default behavior focuses on no specific instance. |
 | `-draw_bins` | Activates visualization of placement bins, showcasing their density (indicated by the shade of white) and the direction of forces acting on them (depicted in red). The default setting is disabled. |
 | `-initial` | Pauses the debug process during the initial placement phase. The default setting is disabled. |
+| `-start_iter` | Start debug mode from such iteration. |
+| `-update_db` | Updates OpenROAD db during every gpl iteration, allowing for up to date location of instances. |
 
 Example: `global_placement_debug -pause 100 -update 1 -initial -draw_bins -inst _614_`
 This command configures the debugger to pause every 100 iterations, with layout updates occurring every iteration. It enables initial placement stage visualization, bin drawing, and specifically highlights instance 614.

--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -144,7 +144,8 @@ class Replace
                 bool draw_bins,
                 bool initial,
                 odb::dbInst* inst,
-                int start_iter);
+                int start_iter,
+                bool update_db);
 
  private:
   bool initNesterovPlace(int threads);
@@ -221,5 +222,6 @@ class Replace
   int gui_debug_initial_ = false;
   odb::dbInst* gui_debug_inst_ = nullptr;
   int gui_debug_start_iter_ = 0;
+  bool gui_debug_update_db_every_iteration = false;
 };
 }  // namespace gpl

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -792,6 +792,7 @@ class NesterovPlaceVars
   bool debug_draw_bins = true;
   odb::dbInst* debug_inst = nullptr;
   int debug_start_iter = 0;
+  bool debug_update_db_every_iteration = false;
 
   void reset();
 };

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -424,7 +424,7 @@ int NesterovPlace::doNesterovPlace(int start_iter)
 
     // For JPEG Saving
     // debug
-    if (npVars_.debug_update_db_every_iteration) {
+    if (npVars_.debug && npVars_.debug_update_db_every_iteration) {
       updateDb();
     }
     const int debug_start_iter = npVars_.debug_start_iter;

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -424,6 +424,9 @@ int NesterovPlace::doNesterovPlace(int start_iter)
 
     // For JPEG Saving
     // debug
+    if (npVars_.debug_update_db_every_iteration) {
+      updateDb();
+    }
     const int debug_start_iter = npVars_.debug_start_iter;
     if (graphics_ && (debug_start_iter == 0 || iter + 1 >= debug_start_iter)) {
       bool update

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -361,6 +361,8 @@ bool Replace::initNesterovPlace(int threads)
     npVars.debug_draw_bins = gui_debug_draw_bins_;
     npVars.debug_inst = gui_debug_inst_;
     npVars.debug_start_iter = gui_debug_start_iter_;
+    npVars.debug_update_db_every_iteration
+        = gui_debug_update_db_every_iteration;
     npVars.disableRevertIfDiverge = disableRevertIfDiverge_;
 
     for (const auto& nb : nbVec_) {
@@ -495,7 +497,8 @@ void Replace::setDebug(int pause_iterations,
                        bool draw_bins,
                        bool initial,
                        odb::dbInst* inst,
-                       int start_iter)
+                       int start_iter,
+                       bool update_db)
 {
   gui_debug_ = true;
   gui_debug_pause_iterations_ = pause_iterations;
@@ -504,6 +507,7 @@ void Replace::setDebug(int pause_iterations,
   gui_debug_initial_ = initial;
   gui_debug_inst_ = inst;
   gui_debug_start_iter_ = start_iter;
+  gui_debug_update_db_every_iteration = update_db;
 }
 
 void Replace::setDisableRevertIfDiverge(bool mode)

--- a/src/gpl/src/replace.i
+++ b/src/gpl/src/replace.i
@@ -297,7 +297,8 @@ set_debug_cmd(int pause_iterations,
               bool draw_bins,
               bool initial,
               const char* inst_name,
-              int start_iter)
+              int start_iter,
+              bool update_db)
 {
   Replace* replace = getReplace();
   odb::dbInst* inst = nullptr;
@@ -306,7 +307,7 @@ set_debug_cmd(int pause_iterations,
     inst = block->findInst(inst_name);
   }
   replace->setDebug(pause_iterations, update_iterations, draw_bins,
-                    initial, inst, start_iter);
+                    initial, inst, start_iter, update_db);
 }
 
 %} // inline

--- a/src/gpl/src/replace.tcl
+++ b/src/gpl/src/replace.tcl
@@ -383,7 +383,7 @@ proc cluster_flops { args } {
 proc global_placement_debug { args } {
   sta::parse_key_args "global_placement_debug" args \
     keys {-pause -update -inst -start_iter} \
-    flags {-draw_bins -initial} ;# checker off
+    flags {-draw_bins -initial -update_db} ;# checker off
 
   if { [ord::get_db_block] == "NULL" } {
     utl::error GPL 117 "No design block found."
@@ -414,8 +414,9 @@ proc global_placement_debug { args } {
 
   set draw_bins [info exists flags(-draw_bins)]
   set initial [info exists flags(-initial)]
+  set update_db [info exists flags(-update_db)]
 
-  gpl::set_debug_cmd $pause $update $draw_bins $initial $inst $start_iter
+  gpl::set_debug_cmd $pause $update $draw_bins $initial $inst $start_iter $update_db
 }
 
 sta::define_cmd_args "placement_cluster" {}


### PR DESCRIPTION
This change allows for updating OpenROAD db during every iteration of gpl, allowing for up to date locations during gpl debug mode.

We currently have this situation, where the instances as seen by the tool are always delayed until a call to the function updateDb() happens. Notice how gpl drawings in green do not align with instances from the gui.
![Screenshot from 2025-03-13 18-13-05](https://github.com/user-attachments/assets/0f130298-8ecf-461e-8f52-2c81a1005708)


with the new option we have:
![Screenshot from 2025-03-13 18-13-36](https://github.com/user-attachments/assets/a10520cf-44ef-498c-897c-279e818f31e4)


This option maybe costly in runtime, so is set as false for default.
