### PR TITLE
odb: add mirrored bterm info for both pins of the pair

### DIFF
--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -1015,6 +1015,7 @@ void dbBTerm::setMirroredBTerm(dbBTerm* mirrored_bterm)
   bterm->_mirrored_bterm = mirrored_bterm->getImpl()->getOID();
   _dbBTerm* mirrored = (_dbBTerm*) mirrored_bterm;
   mirrored->_is_mirrored = true;
+  mirrored->_mirrored_bterm = bterm->getImpl()->getOID();
 
   if (!bterm->_constraint_region.isInverted()
       && mirrored_bterm->getConstraintRegion() == std::nullopt) {
@@ -1045,7 +1046,7 @@ dbBTerm* dbBTerm::getMirroredBTerm()
 bool dbBTerm::hasMirroredBTerm()
 {
   _dbBTerm* bterm = (_dbBTerm*) this;
-  return bterm->_mirrored_bterm != 0;
+  return bterm->_mirrored_bterm != 0 && !bterm->_is_mirrored;
 }
 
 bool dbBTerm::isMirrored()


### PR DESCRIPTION
Previously, for a pair `{p1, p2}` of mirrored pins, only _p1_ had the information about _p2_ being its mirrored pin.

Now, both pins of the pair knows about each other, and we keep the information of what is the "main" pin by checking if the pin is mirrored when defining if it has a mirrored bterm.