### PR TITLE
drt: genPinAccessCostBounded refactor and EnoughAccessPoints

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -169,6 +169,24 @@ class FlexPA
   int genPinAccess(T* pin, frInstTerm* inst_term = nullptr);
 
   /**
+   * @brief determines if the current access points are enough to say PA is done
+   * with this pin.
+   *
+   * for the access points to be considered enough there must exist a minimum of
+   * aps:
+   * 1. far enough from each other greater than the minimum specified in
+   * router_cfg.
+   * 2. far enough from the cell edge.
+   *
+   * @param aps the list of candidate access points
+   * @param inst_term terminal related to the pin
+   *
+   * @returns True if the current aps are enough for the pin
+   */
+  bool EnoughAccessPoints(std::vector<std::unique_ptr<frAccessPoint>>& aps,
+                          frInstTerm* inst_term);
+
+  /**
    * @brief initializes the pin accesses of a given pin only considering a given
    * cost for both the lower and upper layer.
    *
@@ -180,7 +198,7 @@ class FlexPA
    * @param lower_type lower layer access type
    * @param upper_type upper layer access type
    *
-   * @return if the initialization was sucessful
+   * @return if enough access points were found for the pin.
    */
   template <typename T>
   bool genPinAccessCostBounded(

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -1110,7 +1110,7 @@ void FlexPA::filterMultipleAPAccesses(
 
 template <typename T>
 void FlexPA::updatePinStats(
-    const std::vector<std::unique_ptr<frAccessPoint>>& tmp_aps,
+    const std::vector<std::unique_ptr<frAccessPoint>>& new_aps,
     T* pin,
     frInstTerm* inst_term)
 {
@@ -1120,7 +1120,7 @@ void FlexPA::updatePinStats(
     is_std_cell_pin = isStdCell(inst_term->getInst());
     is_macro_cell_pin = isMacroCell(inst_term->getInst());
   }
-  for (auto& ap : tmp_aps) {
+  for (auto& ap : new_aps) {
     if (ap->hasAccess(frDirEnum::W) || ap->hasAccess(frDirEnum::E)
         || ap->hasAccess(frDirEnum::S) || ap->hasAccess(frDirEnum::N)) {
       if (is_std_cell_pin) {
@@ -1145,6 +1145,51 @@ void FlexPA::updatePinStats(
   }
 }
 
+bool FlexPA::EnoughAccessPoints(
+    std::vector<std::unique_ptr<frAccessPoint>>& aps,
+    frInstTerm* inst_term)
+{
+  const bool is_std_cell_pin = inst_term && isStdCell(inst_term->getInst());
+  const bool is_macro_cell_pin = inst_term && isMacroCell(inst_term->getInst());
+  const bool is_io_pin = (inst_term == nullptr);
+  bool enough_sparse_acc_points = false;
+
+  if (is_io_pin) {
+    return (aps.size() > 0);
+  }
+
+  /* This is a Max Clique problem, each ap is a node, draw an edge between two
+   aps if they are far away as to not intersect. n_sparse_access_points,
+   ideally, is the Max Clique of this graph. the current implementation gives a
+   very rough approximation, it works, but I think it can be improved.
+   */
+  int n_sparse_access_points = (int) aps.size();
+  for (int i = 0; i < (int) aps.size(); i++) {
+    const int colision_dist
+        = design_->getTech()->getLayer(aps[i]->getLayerNum())->getWidth() / 2;
+    Rect ap_colision_box;
+    Rect(aps[i]->getPoint(), aps[i]->getPoint())
+        .bloat(colision_dist, ap_colision_box);
+    for (int j = i + 1; j < (int) aps.size(); j++) {
+      if (aps[i]->getLayerNum() == aps[j]->getLayerNum()
+          && ap_colision_box.intersects(aps[j]->getPoint())) {
+        n_sparse_access_points--;
+        break;
+      }
+    }
+  }
+
+  if (is_std_cell_pin
+      && n_sparse_access_points >= router_cfg_->MINNUMACCESSPOINT_STDCELLPIN) {
+    enough_sparse_acc_points = true;
+  } else if (is_macro_cell_pin
+             && n_sparse_access_points
+                    >= router_cfg_->MINNUMACCESSPOINT_MACROCELLPIN) {
+    enough_sparse_acc_points = true;
+  }
+  return enough_sparse_acc_points;
+}
+
 template <typename T>
 bool FlexPA::genPinAccessCostBounded(
     std::vector<std::unique_ptr<frAccessPoint>>& aps,
@@ -1155,61 +1200,48 @@ bool FlexPA::genPinAccessCostBounded(
     const frAccessPointEnum lower_type,
     const frAccessPointEnum upper_type)
 {
-  bool is_std_cell_pin = false;
-  bool is_macro_cell_pin = false;
-  if (inst_term) {
-    is_std_cell_pin = isStdCell(inst_term->getInst());
-    is_macro_cell_pin = isMacroCell(inst_term->getInst());
-  }
+  const bool is_std_cell_pin = inst_term && isStdCell(inst_term->getInst());
+  ;
+  const bool is_macro_cell_pin = inst_term && isMacroCell(inst_term->getInst());
   const bool is_io_pin = (inst_term == nullptr);
-  std::vector<std::unique_ptr<frAccessPoint>> tmp_aps;
+  std::vector<std::unique_ptr<frAccessPoint>> new_aps;
   genAPsFromPinShapes(
-      tmp_aps, apset, pin, inst_term, pin_shapes, lower_type, upper_type);
+      new_aps, apset, pin, inst_term, pin_shapes, lower_type, upper_type);
   filterMultipleAPAccesses(
-      tmp_aps, pin_shapes, pin, inst_term, is_std_cell_pin);
+      new_aps, pin_shapes, pin, inst_term, is_std_cell_pin);
   if (is_std_cell_pin) {
 #pragma omp atomic
-    std_cell_pin_gen_ap_cnt_ += tmp_aps.size();
+    std_cell_pin_gen_ap_cnt_ += new_aps.size();
   }
   if (is_macro_cell_pin) {
 #pragma omp atomic
-    macro_cell_pin_gen_ap_cnt_ += tmp_aps.size();
+    macro_cell_pin_gen_ap_cnt_ += new_aps.size();
   }
   if (graphics_) {
-    graphics_->setAPs(tmp_aps, lower_type, upper_type);
+    graphics_->setAPs(new_aps, lower_type, upper_type);
   }
-  for (auto& ap : tmp_aps) {
+  for (auto& ap : new_aps) {
+    if (!ap->hasAccess()) {
+      continue;
+    }
     // for stdcell, add (i) planar access if layer_num != VIA_ACCESS_LAYERNUM,
     // and (ii) access if exist access for macro, allow pure planar ap
     if (is_std_cell_pin) {
-      const auto layer_num = ap->getLayerNum();
-      if ((layer_num == router_cfg_->VIA_ACCESS_LAYERNUM
-           && ap->hasAccess(frDirEnum::U))
-          || (layer_num != router_cfg_->VIA_ACCESS_LAYERNUM
-              && ap->hasAccess())) {
+      const bool ap_in_via_acc_layer
+          = (ap->getLayerNum() == router_cfg_->VIA_ACCESS_LAYERNUM);
+      if (!ap_in_via_acc_layer || ap->hasAccess(frDirEnum::U)) {
         aps.push_back(std::move(ap));
       }
-    } else if ((is_macro_cell_pin || is_io_pin) && ap->hasAccess()) {
+    } else if (is_macro_cell_pin || is_io_pin) {
       aps.push_back(std::move(ap));
     }
   }
-  int n_sparse_access_points = (int) aps.size();
-  Rect tbx;
-  for (int i = 0; i < (int) aps.size();
-       i++) {  // not perfect but will do the job
-    int r = design_->getTech()->getLayer(aps[i]->getLayerNum())->getWidth() / 2;
-    tbx.init(
-        aps[i]->x() - r, aps[i]->y() - r, aps[i]->x() + r, aps[i]->y() + r);
-    for (int j = i + 1; j < (int) aps.size(); j++) {
-      if (aps[i]->getLayerNum() == aps[j]->getLayerNum()
-          && tbx.intersects(aps[j]->getPoint())) {
-        n_sparse_access_points--;
-        break;
-      }
-    }
+
+  if (!EnoughAccessPoints(aps, inst_term)) {
+    return false;
   }
-  if (is_std_cell_pin
-      && n_sparse_access_points >= router_cfg_->MINNUMACCESSPOINT_STDCELLPIN) {
+
+  if (is_std_cell_pin || is_macro_cell_pin) {
     updatePinStats(aps, pin, inst_term);
     // write to pa
     const int pin_access_idx = unique_insts_.getPAIndex(inst_term->getInst());
@@ -1218,24 +1250,17 @@ bool FlexPA::genPinAccessCostBounded(
     }
     return true;
   }
-  if (is_macro_cell_pin
-      && n_sparse_access_points
-             >= router_cfg_->MINNUMACCESSPOINT_MACROCELLPIN) {
-    updatePinStats(aps, pin, inst_term);
-    // write to pa
-    const int pin_access_idx = unique_insts_.getPAIndex(inst_term->getInst());
-    for (auto& ap : aps) {
-      pin->getPinAccess(pin_access_idx)->addAccessPoint(std::move(ap));
-    }
-    return true;
-  }
-  if (is_io_pin && (int) aps.size() > 0) {
+
+  if (is_io_pin) {
     // IO term pin always only have one access
     for (auto& ap : aps) {
       pin->getPinAccess(0)->addAccessPoint(std::move(ap));
     }
     return true;
   }
+
+  // weird edge case where pin is not from std_cell, macro or io, not sure it
+  // can even happen
   return false;
 }
 


### PR DESCRIPTION
Supports #6097.

This PR is a first of a pair, the second one actually solves the issue. This PR adds the `EnoughAccessPoints()` function, in which the condition for having at least a single access point far enough from the instance edge will be implemented.
I'm splitting this in two PRs because the part that adds the new requirement actually changes some unit test .DEFOK files. This PR is just refactoring to isolate this part of the code. I want it to be clear that none of these changes are what are changing the .DEF files.