### PR TITLE
Update mbff.cpp to use max threads in the solver.

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -1241,6 +1241,7 @@ double MBFF::RunILP(const std::vector<Flop>& flops,
 
   sat::Model model;
   sat::SatParameters parameters;
+  parameters.set_num_workers(num_threads_);
   model.Add(NewSatParameters(parameters));
   sat::CpSolverResponse response = sat::SolveCpModel(cp_model.Build(), &model);
 


### PR DESCRIPTION
The default value for `num_workers` is 0 which implies all threads on the machine, so this is a no-op. This declares this behavior explicitly.