### PR TITLE
gpl: include Testing folder to gitignore

### DIFF
--- a/src/gpl/.gitignore
+++ b/src/gpl/.gitignore
@@ -1,3 +1,4 @@
 *~
 test/results
+test/Testing
 *.jpg


### PR DESCRIPTION
As suggested in https://github.com/The-OpenROAD-Project/OpenROAD/pull/6897

The folder was accidentally added on a [commit to update gpl tests](https://github.com/The-OpenROAD-Project/OpenROAD/commit/250e48e05383b78791663ae7105b572ae860acd8). 