### PR TITLE
mpl: avoid calling ppl in regression tests by using new constraints' commands

### DIFF
--- a/src/mpl/test/boundary_push2.defok
+++ b/src/mpl/test/boundary_push2.defok
@@ -239,22 +239,10 @@ COMPONENTS 54 ;
     - _050_ DFF_X1 + PLACED ( 15591 18600 ) N ;
 END COMPONENTS
 PINS 4 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 274590 442260 ) N ;
-    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 90910 442260 ) N ;
-    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 415710 140 ) N ;
-    - io_4 + NET io_4 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 81950 140 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
+    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL ;
+    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL ;
+    - io_4 + NET io_4 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 4 ;
     - io_1 ( PIN io_1 ) + USE SIGNAL ;

--- a/src/mpl/test/boundary_push2.ok
+++ b/src/mpl/test/boundary_push2.ok
@@ -3,15 +3,6 @@
 [INFO ODB-0128] Design: boundary_push1
 [INFO ODB-0130]     Created 4 pins.
 [INFO ODB-0131]     Created 54 components and 308 component-terminals.
-Found 4 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0067] Restrict pins [ io_3 io_4 ] to region 0.00u-220.02u at the BOTTOM edge.
-[INFO PPL-0067] Restrict pins [ io_1 io_2 ] to region 0.00u-220.02u at the TOP edge.
-[INFO PPL-0001] Number of available slots 1560
-[INFO PPL-0002] Number of I/O             4
-[INFO PPL-0003] Number of I/O w/sink      0
-[INFO PPL-0004] Number of I/O w/o sink    4
-[INFO PPL-0012] I/O nets HPWL: 0.00 um.
 Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 221.20)
 	Number of std cell instances: 50
 	Area of std cell instances: 226.10

--- a/src/mpl/test/boundary_push2.tcl
+++ b/src/mpl/test/boundary_push2.tcl
@@ -18,9 +18,6 @@ read_def "./testcases/boundary_push2.def"
 set_io_pin_constraint -pin_names { io_1 io_2 } -region top:*
 set_io_pin_constraint -pin_names { io_3 io_4 } -region bottom:*
 
-# Run random PPL to incorporate constraints' data in ODB
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6
-
 set_thread_count 0
 rtl_macro_placer -boundary_weight 0 -report_directory results/boundary_push2 -halo_width 0.3
 

--- a/src/mpl/test/boundary_push3.defok
+++ b/src/mpl/test/boundary_push3.defok
@@ -239,22 +239,10 @@ COMPONENTS 54 ;
     - _050_ DFF_X1 + PLACED ( 15590 18601 ) N ;
 END COMPONENTS
 PINS 4 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 275660 ) N ;
-    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 90860 ) N ;
-    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 439900 417900 ) N ;
-    - io_4 + NET io_4 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 439900 81900 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
+    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL ;
+    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL ;
+    - io_4 + NET io_4 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 4 ;
     - io_1 ( PIN io_1 ) + USE SIGNAL ;

--- a/src/mpl/test/boundary_push3.ok
+++ b/src/mpl/test/boundary_push3.ok
@@ -3,15 +3,6 @@
 [INFO ODB-0128] Design: boundary_push1
 [INFO ODB-0130]     Created 4 pins.
 [INFO ODB-0131]     Created 54 components and 308 component-terminals.
-Found 4 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0067] Restrict pins [ io_3 io_4 ] to region 0.00u-221.20u at the RIGHT edge.
-[INFO PPL-0067] Restrict pins [ io_1 io_2 ] to region 0.00u-221.20u at the LEFT edge.
-[INFO PPL-0001] Number of available slots 1560
-[INFO PPL-0002] Number of I/O             4
-[INFO PPL-0003] Number of I/O w/sink      0
-[INFO PPL-0004] Number of I/O w/o sink    4
-[INFO PPL-0012] I/O nets HPWL: 0.00 um.
 Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 221.20)
 	Number of std cell instances: 50
 	Area of std cell instances: 226.10

--- a/src/mpl/test/boundary_push3.tcl
+++ b/src/mpl/test/boundary_push3.tcl
@@ -18,9 +18,6 @@ read_def "./testcases/boundary_push2.def"
 set_io_pin_constraint -pin_names { io_1 io_2 } -region left:*
 set_io_pin_constraint -pin_names { io_3 io_4 } -region right:*
 
-# Run random PPL to incorporate constraints' data in ODB
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6
-
 set_thread_count 0
 rtl_macro_placer -boundary_weight 0 -report_directory results/boundary_push3 -halo_width 0.3
 

--- a/src/mpl/test/guides1.defok
+++ b/src/mpl/test/guides1.defok
@@ -517,18 +517,9 @@ COMPONENTS 401 ;
     - _400_ DFF_X1 + PLACED ( 38680 123234 ) N ;
 END COMPONENTS
 PINS 3 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 154700 ) N ;
-    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 51660 ) N ;
-    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 13580 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
+    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL ;
+    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 3 ;
     - io_1 ( PIN io_1 ) + USE SIGNAL ;

--- a/src/mpl/test/guides1.ok
+++ b/src/mpl/test/guides1.ok
@@ -5,14 +5,6 @@
 [INFO ODB-0128] Design: guides1
 [INFO ODB-0252]     Updated 3 pins.
 [INFO ODB-0253]     Updated 401 components.
-Found 1 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0067] Restrict pins [ io_1 io_2 io_3 ] to region 0.00u-125.00u at the LEFT edge.
-[INFO PPL-0001] Number of available slots 966
-[INFO PPL-0002] Number of I/O             3
-[INFO PPL-0003] Number of I/O w/sink      0
-[INFO PPL-0004] Number of I/O w/o sink    3
-[INFO PPL-0012] I/O nets HPWL: 0.00 um.
 Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 124.60)
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.79

--- a/src/mpl/test/guides1.tcl
+++ b/src/mpl/test/guides1.tcl
@@ -13,7 +13,6 @@ link_design "guides1"
 read_def "./testcases/guides1.def" -floorplan_initialize
 
 set_io_pin_constraint -direction INPUT -region left:*
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6
 
 set_macro_guidance_region -macro_name MACRO_1 -region {49 0 149 100}
 set_thread_count 0

--- a/src/mpl/test/io_constraints1.defok
+++ b/src/mpl/test/io_constraints1.defok
@@ -517,18 +517,9 @@ COMPONENTS 401 ;
     - _400_ DFF_X1 + PLACED ( 38680 123234 ) N ;
 END COMPONENTS
 PINS 3 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 154700 ) N ;
-    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 51660 ) N ;
-    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 13580 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
+    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL ;
+    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 3 ;
     - io_1 ( PIN io_1 ) + USE SIGNAL ;

--- a/src/mpl/test/io_constraints1.ok
+++ b/src/mpl/test/io_constraints1.ok
@@ -5,14 +5,6 @@
 [INFO ODB-0128] Design: io_constraints1
 [INFO ODB-0252]     Updated 3 pins.
 [INFO ODB-0253]     Updated 401 components.
-Found 1 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0067] Restrict pins [ io_1 io_2 io_3 ] to region 0.00u-125.00u at the LEFT edge.
-[INFO PPL-0001] Number of available slots 966
-[INFO PPL-0002] Number of I/O             3
-[INFO PPL-0003] Number of I/O w/sink      0
-[INFO PPL-0004] Number of I/O w/o sink    3
-[INFO PPL-0012] I/O nets HPWL: 0.00 um.
 Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 124.60)
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.79

--- a/src/mpl/test/io_constraints1.tcl
+++ b/src/mpl/test/io_constraints1.tcl
@@ -12,9 +12,7 @@ read_verilog "./testcases/io_constraints1.v"
 link_design "io_constraints1"
 read_def "./testcases/io_constraints1.def" -floorplan_initialize
 
-# Run random PPL to incorporate the constraints into ODB
 set_io_pin_constraint -direction INPUT -region left:*
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6
 
 set_thread_count 0
 rtl_macro_placer -report_directory results/io_constraints1 -halo_width 4.0

--- a/src/mpl/test/io_constraints2.defok
+++ b/src/mpl/test/io_constraints2.defok
@@ -517,18 +517,9 @@ COMPONENTS 401 ;
     - _400_ DFF_X1 + PLACED ( 146680 15234 ) N ;
 END COMPONENTS
 PINS 3 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 254430 140 ) N ;
-    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 238750 140 ) N ;
-    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal6 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 234270 140 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
+    - io_2 + NET io_2 + DIRECTION INPUT + USE SIGNAL ;
+    - io_3 + NET io_3 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 3 ;
     - io_1 ( PIN io_1 ) + USE SIGNAL ;

--- a/src/mpl/test/io_constraints2.ok
+++ b/src/mpl/test/io_constraints2.ok
@@ -5,13 +5,6 @@
 [INFO ODB-0128] Design: io_constraints1
 [INFO ODB-0252]     Updated 3 pins.
 [INFO ODB-0253]     Updated 401 components.
-Found 1 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0001] Number of available slots 264
-[INFO PPL-0002] Number of I/O             3
-[INFO PPL-0003] Number of I/O w/sink      0
-[INFO PPL-0004] Number of I/O w/o sink    3
-[INFO PPL-0012] I/O nets HPWL: 0.00 um.
 Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 124.60)
 	Number of std cell instances: 400
 	Area of std cell instances: 1808.79

--- a/src/mpl/test/io_constraints2.tcl
+++ b/src/mpl/test/io_constraints2.tcl
@@ -12,9 +12,7 @@ read_verilog "./testcases/io_constraints1.v"
 link_design "io_constraints1"
 read_def "./testcases/io_constraints1.def" -floorplan_initialize
 
-# Run random PPL to incorporate the -exclude constraints into ODB
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6 \
-           -exclude left:* -exclude right:* -exclude top:*
+exclude_io_pin_region -region left:* -region right:* -region top:*
 
 set_thread_count 0
 rtl_macro_placer -report_directory results/io_constraints2 -halo_width 4.0

--- a/src/mpl/test/orientation_improve1.defok
+++ b/src/mpl/test/orientation_improve1.defok
@@ -100,10 +100,7 @@ COMPONENTS 1 ;
     - MACRO_1 HM_100x100_1x1 + FIXED ( 21080 21050 ) S ;
 END COMPONENTS
 PINS 1 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 239860 34860 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 1 ;
     - io_1 ( PIN io_1 ) ( MACRO_1 I1 ) + USE SIGNAL ;

--- a/src/mpl/test/orientation_improve1.ok
+++ b/src/mpl/test/orientation_improve1.ok
@@ -4,14 +4,6 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 1 components and 2 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 1 connections.
-Found 1 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0067] Restrict pins [ io_1 ] to region 10.00u-30.00u at the RIGHT edge.
-[INFO PPL-0001] Number of available slots 842
-[INFO PPL-0002] Number of I/O             1
-[INFO PPL-0003] Number of I/O w/sink      1
-[INFO PPL-0004] Number of I/O w/o sink    0
-[INFO PPL-0012] I/O nets HPWL: 102.57 um.
 Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 110.60)
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00

--- a/src/mpl/test/orientation_improve1.tcl
+++ b/src/mpl/test/orientation_improve1.tcl
@@ -6,9 +6,7 @@ read_lef "./testcases/orientation_improve1.lef"
 
 read_def "./testcases/orientation_improve1.def"
 
-# Run random PPL to incorporate the constraints into ODB
 set_io_pin_constraint -direction INPUT -region right:10-30*
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6
 
 set_thread_count 0
 rtl_macro_placer -report_directory results/orientation_improve1 -halo_width 0.3

--- a/src/mpl/test/orientation_improve2.defok
+++ b/src/mpl/test/orientation_improve2.defok
@@ -100,10 +100,7 @@ COMPONENTS 1 ;
     - MACRO_1 HM_100x100_1x1 + FIXED ( 18600 20490 ) FS ;
 END COMPONENTS
 PINS 1 ;
-    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL
-      + PORT
-        + LAYER metal5 ( -140 -140 ) ( 140 140 )
-        + PLACED ( 140 154700 ) N ;
+    - io_1 + NET io_1 + DIRECTION INPUT + USE SIGNAL ;
 END PINS
 NETS 1 ;
     - io_1 ( PIN io_1 ) ( MACRO_1 I1 ) + USE SIGNAL ;

--- a/src/mpl/test/orientation_improve2.ok
+++ b/src/mpl/test/orientation_improve2.ok
@@ -4,13 +4,6 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 1 components and 2 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 1 connections.
-Found 1 macro blocks.
-Using 2 tracks default min distance between IO pins.
-[INFO PPL-0001] Number of available slots 211
-[INFO PPL-0002] Number of I/O             1
-[INFO PPL-0003] Number of I/O w/sink      1
-[INFO PPL-0004] Number of I/O w/o sink    0
-[INFO PPL-0012] I/O nets HPWL: 77.35 um.
 Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 110.60)
 	Number of std cell instances: 0
 	Area of std cell instances: 0.00

--- a/src/mpl/test/orientation_improve2.tcl
+++ b/src/mpl/test/orientation_improve2.tcl
@@ -7,9 +7,7 @@ read_lef "./testcases/orientation_improve1.lef"
 
 read_def "./testcases/orientation_improve1.def"
 
-# Run random PPL to incorporate the -exclude constraints into ODB
-place_pins -annealing -random -hor_layers metal5 -ver_layer metal6 \
-           -exclude bottom:* -exclude right:* -exclude top:*
+exclude_io_pin_region -region bottom:* -region right:* -region top:*
 
 set_thread_count 0
 rtl_macro_placer -report_directory results/orientation_improve2 -halo_width 0.3


### PR DESCRIPTION
Resolve #6886

We now use only the commands for setting the constraints instead of also calling `place_pins`, because running them  will already incorporate the constraints' data into ODB.