### PR TITLE
odb/defin: Redirect defWarning to the logger.

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1921,7 +1921,14 @@ void definReader::contextLogFunctionCallback(DefParser::defiUserData data,
                                              const char* msg)
 {
   definReader* reader = (definReader*) data;
-  reader->_logger->warn(utl::ODB, 1003, msg);
+  reader->_logger->warn(utl::ODB, 3, msg);
+}
+
+void definReader::contextWarningLogFunctionCallback(DefParser::defiUserData data,
+                                                    const char* msg)
+{
+  definReader* reader = (definReader*)data;
+  reader->_logger->warn(utl::ODB, 4, msg);
 }
 
 void definReader::line(int line_num)
@@ -2123,6 +2130,7 @@ bool definReader::createBlock(const char* file)
   defrSetPinEndCbk(pinsEndCallback);
   defrSetPinPropCbk(pinPropCallback);
   DefParser::defrSetContextLogFunction(contextLogFunctionCallback);
+  DefParser::defrSetContextWarningLogFunction(contextWarningLogFunctionCallback);
 
   if (_mode == defin::DEFAULT || _mode == defin::FLOORPLAN) {
     defrSetDieAreaCbk(dieAreaCallback);

--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -1924,10 +1924,11 @@ void definReader::contextLogFunctionCallback(DefParser::defiUserData data,
   reader->_logger->warn(utl::ODB, 3, msg);
 }
 
-void definReader::contextWarningLogFunctionCallback(DefParser::defiUserData data,
-                                                    const char* msg)
+void definReader::contextWarningLogFunctionCallback(
+    DefParser::defiUserData data,
+    const char* msg)
 {
-  definReader* reader = (definReader*)data;
+  definReader* reader = (definReader*) data;
   reader->_logger->warn(utl::ODB, 4, msg);
 }
 
@@ -2130,7 +2131,8 @@ bool definReader::createBlock(const char* file)
   defrSetPinEndCbk(pinsEndCallback);
   defrSetPinPropCbk(pinPropCallback);
   DefParser::defrSetContextLogFunction(contextLogFunctionCallback);
-  DefParser::defrSetContextWarningLogFunction(contextWarningLogFunctionCallback);
+  DefParser::defrSetContextWarningLogFunction(
+      contextWarningLogFunctionCallback);
 
   if (_mode == defin::DEFAULT || _mode == defin::FLOORPLAN) {
     defrSetDieAreaCbk(dieAreaCallback);

--- a/src/odb/src/defin/definReader.h
+++ b/src/odb/src/defin/definReader.h
@@ -250,6 +250,9 @@ class definReader : public definBase
   static void contextLogFunctionCallback(DefParser::defiUserData data,
                                          const char* msg);
 
+  static void contextWarningLogFunctionCallback(DefParser::defiUserData data,
+                                                const char* msg);
+
  public:
   definReader(dbDatabase* db,
               utl::Logger* logger,

--- a/src/odb/test/create_sboxes.ok
+++ b/src/odb/test/create_sboxes.ok
@@ -11,6 +11,15 @@
 [INFO ODB-0388] unsupported contactResistance property for layer via9 :"21.44"
 [INFO ODB-0227] LEF file: data/gscl45nm.lef, created 22 layers, 14 vias, 33 library cells
 [INFO ODB-0128] Design: counter
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 188.
+
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 197.
+
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 205.
+
 [INFO ODB-0130]     Created 13 pins.
 [INFO ODB-0131]     Created 12 components and 60 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 24 connections.

--- a/src/odb/test/def_parser.ok
+++ b/src/odb/test/def_parser.ok
@@ -11,6 +11,15 @@
 [INFO ODB-0388] unsupported contactResistance property for layer via9 :"21.44"
 [INFO ODB-0227] LEF file: data/gscl45nm.lef, created 22 layers, 14 vias, 33 library cells
 [INFO ODB-0128] Design: counter
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 188.
+
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 197.
+
+[WARNING ODB-0004] WARNING (DEFPARS-7019): The PATTERNNAME statement is obsolete in version 5.6 and later.
+The DEF parser will ignore this statement. See file data/parser_test.def at line 205.
+
 [INFO ODB-0130]     Created 13 pins.
 [INFO ODB-0131]     Created 12 components and 60 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 24 connections.


### PR DESCRIPTION
Also changed error callback ID from 1003 to 3, to avoid duplicate.
    As find message doesn't catch message without double quote.