### PR TITLE
Move `//:opendb_def` -> `//src/odb/src/def:def`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,24 +35,21 @@
 ###############################################################################
 
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
-
-load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
 load("@rules_hdl//dependency_support/com_github_westes_flex:flex.bzl", "genlex")
-
+load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
 load(
     "//:bazel/build_helper.bzl",
-    "OPENROAD_DEFINES",
     "OPENROAD_BINARY_DEPS",
     "OPENROAD_BINARY_SRCS",
     "OPENROAD_BINARY_SRCS_WITHOUT_MAIN",
     "OPENROAD_COPTS",
+    "OPENROAD_DEFINES",
     "OPENROAD_LIBRARY_DEPS",
     "OPENROAD_LIBRARY_HDRS_INCLUDE",
     "OPENROAD_LIBRARY_INCLUDES",
     "OPENROAD_LIBRARY_SRCS_EXCLUDE",
     "OPENROAD_LIBRARY_SRCS_INCLUDE",
 )
-
 load("//:bazel/tcl_encode.bzl", "tcl_encode")
 load("//:bazel/tcl_wrap_cc.bzl", "tcl_wrap_cc")
 
@@ -107,8 +104,8 @@ cc_library(
             "src/gui/src/stub.cpp",
             "src/gui/src/stub_heatMap.cpp",
         ],
-        exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
         allow_empty = True,
+        exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
     ) + [
         "src/stt/src/flt/etc/POST9.cpp",
         "src/stt/src/flt/etc/POWV9.cpp",
@@ -137,8 +134,8 @@ cc_library(
             "src/gui/src/stub.cpp",
             "src/gui/src/stub_heatMap.cpp",
         ],
-        exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
         allow_empty = True,
+        exclude = OPENROAD_LIBRARY_SRCS_EXCLUDE,
     ) + [
         "src/OpenRoad.cc",
         "src/stt/src/flt/etc/POST9.cpp",
@@ -915,9 +912,6 @@ cc_library(
         "src/utl/include/utl/*.h",
         "src/odb/src/db/*.h",
     ]) + [
-        "src/odb/src/def/def/defiAlias.hpp",
-        "src/odb/src/def/def/defrReader.hpp",
-        "src/odb/src/def/def/defwWriter.hpp",
         "src/odb/src/lef/lef/lefiDebug.hpp",
         "src/odb/src/lef/lef/lefiUtil.hpp",
         "src/odb/src/lef/lef/lefrReader.hpp",
@@ -942,9 +936,10 @@ cc_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//src/utl",
-        ":opendb_def",
         ":opendb_lef",
+        "//src/odb/src/def",
+        "//src/odb/src/def:defzlib",
+        "//src/utl",
         "@boost.algorithm",
         "@boost.bind",
         "@boost.config",
@@ -1005,61 +1000,6 @@ cc_library(
     deps = [
         "@zlib",
     ],
-)
-
-cc_library(
-    name = "opendb_def",
-    srcs = glob(
-        include = [
-            "src/odb/src/def/def/*.cpp",
-            "src/odb/src/def/def/*.h",
-            "src/odb/src/def/def/*.hpp",
-            "src/odb/src/def/defzlib/*.hpp",
-            "src/odb/src/def/defzlib/*.cpp",
-        ],
-        exclude = [
-            "src/odb/src/def/def/defiComponent.hpp",
-            "src/odb/src/def/def/defiUtil.hpp",
-        ],
-    ) + [
-        "src/odb/src/def/def/def_parser.cpp",
-        "src/odb/src/def/def/def_parser.hpp",
-    ],
-    hdrs = glob([
-        "src/odb/include/odb/*.h",
-        "src/odb/include/odb/*.hpp",
-    ]) + [
-        "src/odb/src/def/def/defiAlias.hpp",
-        "src/odb/src/def/def/defiComponent.hpp",
-        "src/odb/src/def/def/defiUtil.hpp",
-        "src/odb/src/def/def/defrReader.hpp",
-        "src/odb/src/def/def/defwWriter.hpp",
-        "src/odb/src/def/defzlib/defzlib.hpp",
-    ],
-    copts = [
-        "-fexceptions",
-        "-Wno-error",
-    ],
-    features = ["-use_header_modules"],
-    includes = [
-        "src/odb/include/odb",
-        "src/odb/src/def/def",
-        "src/odb/src/def/defzlib",
-    ],
-    visibility = [
-        "//visibility:private",
-    ],
-    deps = [
-        "@zlib",
-    ],
-)
-
-genyacc(
-    name = "def_bison",
-    src = "src/odb/src/def/def/def.y",
-    header_out = "src/odb/src/def/def/def_parser.hpp",
-    prefix = "defyy",
-    source_out = "src/odb/src/def/def/def_parser.cpp",
 )
 
 genyacc(
@@ -1391,14 +1331,13 @@ cc_library(
     ) + [
         "src/sta/util/Machine.cc",
         ":StaConfig",
-    ]
+    ],
     #+ select({
-#        "@bazel_tools//src/conditions:windows": ["src/sta/util/MachineWin32.cc"],
-#        "@bazel_tools//src/conditions:darwin": ["src/sta/util/MachineApple.cc"],
-#        "@bazel_tools//src/conditions:linux": ["src/sta/util/MachineLinux.cc"],
-#        "//conditions:default": ["src/sta/util/MachineUnknown.cc"],
-#    })
-,
+    #        "@bazel_tools//src/conditions:windows": ["src/sta/util/MachineWin32.cc"],
+    #        "@bazel_tools//src/conditions:darwin": ["src/sta/util/MachineApple.cc"],
+    #        "@bazel_tools//src/conditions:linux": ["src/sta/util/MachineLinux.cc"],
+    #        "//conditions:default": ["src/sta/util/MachineUnknown.cc"],
+    #    })
     hdrs = glob(
         include = ["src/sta/include/sta/*.hh"],
     ),
@@ -1430,14 +1369,14 @@ cc_library(
         "src/sta/util",
         "src/sta/verilog",
     ],
-    textual_hdrs = ["src/sta/util/MachineLinux.cc",],
+    textual_hdrs = ["src/sta/util/MachineLinux.cc"],
     visibility = ["//:__subpackages__"],
     deps = [
+        "@cudd",
+        "@eigen",
+        "@rules_flex//flex:current_flex_toolchain",
         "@tk_tcl//:tcl",
         "@zlib",
-        "@eigen",
-        "@cudd",
-        "@rules_flex//flex:current_flex_toolchain",
     ],
 )
 

--- a/src/odb/src/def/BUILD
+++ b/src/odb/src/def/BUILD
@@ -1,0 +1,121 @@
+# -*- Python -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, Precision Innovations Inc.
+
+load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
+
+package(
+    default_visibility = ["//:__subpackages__"],
+    features = ["layering_check"],
+)
+
+# TODO: This can probably be broken into smaller, more specific parts.
+# TODO: once we establish src/odb as package, make aliases so that we
+#  don't need the awkward long path with double src
+#  //src/odb/src/def:def but can say //src/odb:def
+cc_library(
+    name = "def",
+    srcs = [
+        "def/def_keywords.cpp",
+        "def/def_parser.cpp",
+        "def/defiAlias.cpp",
+        "def/defiAssertion.cpp",
+        "def/defiBlockage.cpp",
+        "def/defiComponent.cpp",
+        "def/defiDebug.cpp",
+        "def/defiFPC.cpp",
+        "def/defiFill.cpp",
+        "def/defiGroup.cpp",
+        "def/defiIOTiming.cpp",
+        "def/defiMisc.cpp",
+        "def/defiNet.cpp",
+        "def/defiNonDefault.cpp",
+        "def/defiPartition.cpp",
+        "def/defiPath.cpp",
+        "def/defiPinCap.cpp",
+        "def/defiPinProp.cpp",
+        "def/defiProp.cpp",
+        "def/defiPropType.cpp",
+        "def/defiRegion.cpp",
+        "def/defiRowTrack.cpp",
+        "def/defiScanchain.cpp",
+        "def/defiSite.cpp",
+        "def/defiSlot.cpp",
+        "def/defiTimingDisable.cpp",
+        "def/defiUtil.cpp",
+        "def/defiVia.cpp",
+        "def/defrCallbacks.cpp",
+        "def/defrData.cpp",
+        "def/defrReader.cpp",
+        "def/defrSettings.cpp",
+        "def/defwWriter.cpp",
+        "def/defwWriterCalls.cpp",
+    ],
+    hdrs = [
+        "def/def_parser.hpp",
+        "def/defiAlias.hpp",
+        "def/defiAssertion.hpp",
+        "def/defiBlockage.hpp",
+        "def/defiComponent.hpp",
+        "def/defiDebug.hpp",
+        "def/defiDefs.hpp",
+        "def/defiFPC.hpp",
+        "def/defiFill.hpp",
+        "def/defiGroup.hpp",
+        "def/defiIOTiming.hpp",
+        "def/defiKRDefs.hpp",
+        "def/defiMisc.hpp",
+        "def/defiNet.hpp",
+        "def/defiNonDefault.hpp",
+        "def/defiPartition.hpp",
+        "def/defiPath.hpp",
+        "def/defiPinCap.hpp",
+        "def/defiPinProp.hpp",
+        "def/defiProp.hpp",
+        "def/defiPropType.hpp",
+        "def/defiRegion.hpp",
+        "def/defiRowTrack.hpp",
+        "def/defiScanchain.hpp",
+        "def/defiSite.hpp",
+        "def/defiSlot.hpp",
+        "def/defiTimingDisable.hpp",
+        "def/defiUser.hpp",
+        "def/defiUtil.hpp",
+        "def/defiVia.hpp",
+        "def/defrCallBacks.hpp",
+        "def/defrData.hpp",
+        "def/defrReader.hpp",
+        "def/defrSettings.hpp",
+        "def/defwWriter.hpp",
+        "def/defwWriterCalls.hpp",
+        "def/lex.h",
+    ],
+    includes = ["def"],
+)
+
+genyacc(
+    name = "def_bison",
+    src = "def/def.y",
+    header_out = "def/def_parser.hpp",
+    prefix = "defyy",
+    source_out = "def/def_parser.cpp",
+)
+
+cc_library(
+    name = "defzlib",
+    srcs = [
+        "defzlib/defzlib.cpp",
+    ],
+    hdrs = [
+        "defzlib/defzlib.hpp",
+    ],
+    features = [
+        # TODO: figure out why it complains about zlib while we depend on it
+        "-layering_check",
+    ],
+    includes = ["defzlib"],
+    deps = [
+        ":def",
+        "@zlib",
+    ],
+)

--- a/src/utl/BUILD
+++ b/src/utl/BUILD
@@ -1,7 +1,9 @@
 # -*- Python -*-
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, Precision Innovations Inc.
 
-load("//:bazel/tcl_wrap_cc.bzl", "tcl_wrap_cc")
 load("//:bazel/tcl_encode.bzl", "tcl_encode")
+load("//:bazel/tcl_wrap_cc.bzl", "tcl_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -62,12 +64,12 @@ cc_library(
     ],
     includes = ["include"],
     deps = [
+        "//:opensta_lib",
         "@boost.asio",
         "@boost.beast",
         "@boost.core",
         "@spdlog",
         "@tk_tcl//:tcl",
-        "//:opensta_lib",
     ],
 )
 


### PR DESCRIPTION
Move the BUILD for this target more closely to the sources.

While at it, run `buildifier` on all BUILD files
to get a canonical formatting (`buildifier` is
for BUILD files what `clang-format` is for c++ files).