### PR TITLE
Add a configuration to use address sanitizer.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,16 @@ build --copt "-Wno-unused-parameter"  --host_copt "-Wno-unused-parameter"
 build --per_file_copt=external/.*@-w
 build --host_per_file_copt=external/.*@-w
 
+# Settings for --config=asan address sanitizer build
+build:asan --strip=never
+build:asan --copt -fsanitize=address
+build:asan --copt -DADDRESS_SANITIZER
+build:asan --copt -O1
+build:asan --copt -g
+build:asan --copt -fno-omit-frame-pointer
+build:asan --linkopt -fsanitize=address
+
+# TODO: document
 build --incompatible_strict_action_env
 
 # TODO: setup a new cache for OpenROAD


### PR DESCRIPTION
With `bazel build --config=asan ...`, enable the
llvm https://clang.llvm.org/docs/AddressSanitizer.html for easy debugging of memory access issues.