### PR TITLE
Add a simple CI to run the bazel build.

### DIFF
--- a/.github/workflows/github-actions-bazel-build.yml
+++ b/.github/workflows/github-actions-bazel-build.yml
@@ -1,0 +1,51 @@
+name: bazel-build
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Create Cache Timestamp
+        id: cache_timestamp
+        uses: nanzm/get-time-action@v2.0
+        with:
+          format: 'YYYY-MM-DD-HH-mm-ss'
+
+      - name: Mount bazel cache
+        uses: actions/cache@v4
+        with:
+          path: "~/.cache/bazel"
+          key: bazelcache_${{ steps.cache_timestamp.outputs.time }}
+          restore-keys: bazelcache_
+
+      - name: Build
+        run: |
+          # There are no cc_test()s yet, so just build for now.
+          # For now, just run, but don't fail the whole CI, as bazel build is
+          # experimental at this stage.
+          bazel build --keep_going --show_timestamps --curses=no ... || /bin/true
+
+      - name: Smoke test
+        run: |
+          bazel-bin/openroad -help
+
+      - name: Trim Bazel Cache
+        run: |
+          echo "Trim download cache"
+          du -sh $(bazel info repository_cache)
+          rm -r $(bazel info repository_cache)
+
+          echo "Other remaining things that are big"
+          du -h -t 200M ~/.cache/bazel/*/ | sort -hr

--- a/bazel/build_helper.bzl
+++ b/bazel/build_helper.bzl
@@ -141,7 +141,7 @@ OPENROAD_COPTS = [
 ]
 
 OPENROAD_DEFINES = [
-    "OPENROAD_GIT_DESCRIBE=\\\"bazel_rules_hdl\\\"",
+    "OPENROAD_GIT_DESCRIBE=\\\"bazel-build\\\"",
     "BUILD_TYPE=\\\"release\\\"",
     "GPU=false",
     "BUILD_PYTHON=false",


### PR DESCRIPTION
Since it is experimental, I wrapped it in a `|| /bin/true` so that even if it fails, the CI is fine.