### PR TITLE
[DO NOT REVIEW] bazel: hook up one openroad test

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,16 +1,16 @@
 [sh_test(
-    name = "{test}".format(test=test),
+    name = "{test}".format(test = test),
     srcs = ["bazel_test.sh"],
     args = [],
     data = [
         "//:openroad",
-    ] + glob(["*.sh", "*.ok"]),
+    ] + glob(["**/*"]),
     env = {
         "TEST_NAME_BAZEL": test,
-        "OPENROAD_EXE": "../$(location //:openroad)",
+        "OPENROAD_EXE": "$(location //:openroad)",
         "TEST_EXT": "tcl",
-        "TEST_CHECK_LOG": "True",
-        "TEST_CHECK_PASSFAIL": "True",
-
     },
-) for test in ["gcd_sky130hs", "place_inst"]]
+) for test in [file.split(".")[0] for file in glob(
+    ["*.tcl"],
+    exclude = ["regression.tcl"],
+)]]

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -14,6 +14,9 @@
         "OPENROAD_EXE": "$(location //:openroad)",
         "TEST_EXT": "tcl",
     },
+    # No point in running these tests with unless they fail,
+    # they would be too slow.
+    tags = ["optonly"],
 ) for test in [file.split(".")[0] for file in glob(
     ["*.tcl"],
     exclude = ["regression.tcl"],

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,16 @@
+[sh_test(
+    name = "{test}".format(test=test),
+    srcs = ["bazel_test.sh"],
+    args = [],
+    data = [
+        "//:openroad",
+    ] + glob(["*.sh", "*.ok"]),
+    env = {
+        "TEST_NAME_BAZEL": test,
+        "OPENROAD_EXE": "../$(location //:openroad)",
+        "TEST_EXT": "tcl",
+        "TEST_CHECK_LOG": "True",
+        "TEST_CHECK_PASSFAIL": "True",
+
+    },
+) for test in ["gcd_sky130hs", "place_inst"]]

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,5 +1,9 @@
 [sh_test(
     name = "{test}".format(test = test),
+    # top showed me 50-400mByte of usage, so "enormous"...
+    #
+    # https://bazel.build/reference/be/common-definitions#test.size
+    size = "enormous",
     srcs = ["bazel_test.sh"],
     args = [],
     data = [

--- a/test/bazel_test.sh
+++ b/test/bazel_test.sh
@@ -4,9 +4,6 @@ set -e
 
 echo "Directory: ${PWD}"
 
-DIR=$(dirname "$0")
-cd $DIR
-
 # TEST_NAME is used in cmake and bazel...
 export TEST_NAME=$TEST_NAME_BAZEL
-./regression_test.sh
+test/regression_test.sh

--- a/test/bazel_test.sh
+++ b/test/bazel_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Directory: ${PWD}"
+
+DIR=$(dirname "$0")
+cd $DIR
+
+# TEST_NAME is used in cmake and bazel...
+export TEST_NAME=$TEST_NAME_BAZEL
+./regression_test.sh

--- a/test/regression_test.sh
+++ b/test/regression_test.sh
@@ -20,7 +20,7 @@ $OPENROAD_EXE $ORD_ARGS -no_splash -no_init -exit <(cat <<EOF
 cd "$PREFIX"
 source "$TEST_NAME.$TEST_EXT"
 EOF
-) 2>&1 | tee $LOG_FILE
+) 2>&1 | tee $(realpath $LOG_FILE)
 
 echo "Exitcode:  $?"
 

--- a/test/regression_test.sh
+++ b/test/regression_test.sh
@@ -2,25 +2,31 @@
 
 set -e
 
-mkdir -p results
+# Make this work with a different pwd
+PREFIX=$(realpath $(realpath --relative-to=$(pwd) $(dirname $0)))
 
-LOG_FILE=results/$TEST_NAME-$TEST_EXT.log
+mkdir -p $PREFIX/results
+
+LOG_FILE=$PREFIX/results/$TEST_NAME-$TEST_EXT.log
 
 ORD_ARGS=""
 if [ "$TEST_TYPE" == "python" ]; then
     ORD_ARGS="-python"
 fi
 
-echo "Directory: ${PWD}"
-echo "Command:   $OPENROAD_EXE $ORD_ARGS -no_splash -no_init -exit  $TEST_NAME.$TEST_EXT > $LOG_FILE"
+echo "Command:   $OPENROAD_EXE $ORD_ARGS -no_splash -no_init -exit  $PREFIX/$TEST_NAME.$TEST_EXT > $LOG_FILE"
 
-$OPENROAD_EXE $ORD_ARGS -no_splash -no_init -exit $TEST_NAME.$TEST_EXT &> $LOG_FILE
+$OPENROAD_EXE $ORD_ARGS -no_splash -no_init -exit <(cat <<EOF
+cd "$PREFIX"
+source "$TEST_NAME.$TEST_EXT"
+EOF
+) 2>&1 | tee $LOG_FILE
 
 echo "Exitcode:  $?"
 
 if [ "$TEST_CHECK_LOG" == "True" ]; then
-    echo "Diff:      ${PWD}/results/$TEST_NAME-$TEST_EXT.diff"
-    diff $LOG_FILE $TEST_NAME.ok > results/$TEST_NAME-$TEST_EXT.diff || (head -n 10 $LOG_FILE && exit 1)
+    echo "Diff:      $PREFIX/results/$TEST_NAME-$TEST_EXT.diff"
+    diff $LOG_FILE $PREFIX/$TEST_NAME.ok > $PREFIX/results/$TEST_NAME-$TEST_EXT.diff || (head -n 10 $LOG_FILE && exit 1)
 fi
 
 if [ "$TEST_CHECK_PASSFAIL" == "True" ]; then

--- a/test/regression_test.sh
+++ b/test/regression_test.sh
@@ -20,7 +20,7 @@ echo "Exitcode:  $?"
 
 if [ "$TEST_CHECK_LOG" == "True" ]; then
     echo "Diff:      ${PWD}/results/$TEST_NAME-$TEST_EXT.diff"
-    diff $LOG_FILE $TEST_NAME.ok > results/$TEST_NAME-$TEST_EXT.diff
+    diff $LOG_FILE $TEST_NAME.ok > results/$TEST_NAME-$TEST_EXT.diff || (head -n 10 $LOG_FILE && exit 1)
 fi
 
 if [ "$TEST_CHECK_PASSFAIL" == "True" ]; then


### PR DESCRIPTION
@hzeller @maliberty I know it is too early, but I had a quick stab at adding a test. I think this PR is useful to leave in draft as DO NOT REVIEW, it shows some problems that have to be resolved as Bazel support for OpenROAD progresses. Eventually some form of it should be merged to make it possible to run `bazel test ...` to run the regression tests.

Note that this PR also proposes a solution to fix the [inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control) that stops tests from running in parallel without bazel.

The test fails because openroad won't work unless PWD is the runfiles _main folder:

```
$ bazel build :openroad
$ bazel-bin/openroad
application-specific initialization failed: unknown encoding "ascii"
```

Expected was:

```
$ bazel run :openroad
INFO: Analyzed target //:openroad (194 packages loaded, 16307 targets configured).
INFO: Found 1 target...
Target //:openroad up-to-date:
  bazel-bin/openroad
INFO: Elapsed time: 3.024s, Critical Path: 0.06s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/openroad
OpenROAD HDL-HEAD bazel_rules_hdl
Features included (+) or not (-): -GPU -GUI -Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
% 
$
```





```
$ bazel test //test:place_inst
[deleted]
INFO: Found 1 test target...
Target //test:place_inst up-to-date:
  bazel-bin/test/place_inst
INFO: Elapsed time: 366.250s, Critical Path: 33.09s
INFO: 792 processes: 4 internal, 788 linux-sandbox.
INFO: Build completed, 1 test FAILED, 792 total actions
//test:place_inst                                                        FAILED in 0.0s
  .../.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/execroot/_main/bazel-out/k8-fastbuild/testlogs/test/place_inst/test.log

Executed 1 out of 1 test: 1 fails locally.
```

```
$ cat .../.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/execroot/_main/bazel-out/k8-fastbuild/testlogs/test/place_inst/test.log
exec ${PAGER:-/usr/bin/less} "$0" || exit 1
Executing tests from //test:place_inst
-----------------------------------------------------------------------------
Directory: .../.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/sandbox/linux-sandbox/815/execroot/_main/bazel-out/k8-fastbuild/bin/test/place_inst.runfiles/_main
Directory: .../.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/sandbox/linux-sandbox/815/execroot/_main/bazel-out/k8-fastbuild/bin/test/place_inst.runfiles/_main/test
Command:   .././openroad  -no_splash -no_init -exit  place_inst.tcl > results/place_inst-tcl.log
Exitcode:  0
Diff:      .../.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/sandbox/linux-sandbox/815/execroot/_main/bazel-out/k8-fastbuild/bin/test/place_inst.runfiles/_main/test/results/place_inst-tcl.diff
application-specific initialization failed: unknown encoding "ascii"
```
