### PR TITLE
Upf: choose isolation

### DIFF
--- a/src/ifp/test/upf/mpd_top.upf
+++ b/src/ifp/test/upf/mpd_top.upf
@@ -84,25 +84,25 @@ set_isolation iso_d_4 \
   -update \
   -location parent
 
-use_interface_cell \
+use_interface_cell PD_D1 \
   -domain PD_D1 \
   -strategy iso_d_1 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D2 \
   -domain PD_D2 \
   -strategy iso_d_2 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D3 \
   -domain PD_D3 \
   -strategy iso_d_3 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D4 \
   -domain PD_D4 \
   -strategy iso_d_4 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}

--- a/src/upf/README.md
+++ b/src/upf/README.md
@@ -134,9 +134,10 @@ This command sets the interface cell.
 
 ```tcl 
 use_interface_cell
-    [-domain domain]
-    [-strategy strategy]
-    [-lib_cells lib_cells]
+    -domain domain
+    -strategy strategy
+    -lib_cells lib_cells
+    [interface_implementation_name]
 ```
 
 #### Options
@@ -146,6 +147,7 @@ use_interface_cell
 | `-domain` | Power domain name. |
 | `-strategy` | Isolation strategy name. |
 | `-lib_cells` | List of lib cells that could be used. |
+| `interface_implementation_name` | For compatibility only. OpenRoad doesn't use it. |
 
 ### Set Domain Area
 

--- a/src/upf/README.md
+++ b/src/upf/README.md
@@ -137,7 +137,7 @@ use_interface_cell
     -domain domain
     -strategy strategy
     -lib_cells lib_cells
-    [interface_implementation_name]
+    interface_implementation_name
 ```
 
 #### Options

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -623,6 +623,7 @@ static bool find_smallest_inverter(sta::dbNetwork* network,
 static bool find_smallest_isolation(sta::dbNetwork* network,
                                     utl::Logger* logger,
                                     odb::dbIsolation* iso,
+                                    odb::dbMaster* inverter_m,
                                     odb::dbMaster*& smallest_iso_m,
                                     odb::dbMTerm*& enable_term,
                                     odb::dbMTerm*& data_term,
@@ -642,77 +643,94 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
     return false;
   }
 
-  // For now using the first defined isolaton cell
-
-  sta::LibertyCell* smallest_iso_l = nullptr;
+  // Search for the most appropriate isolation cell
   float smallest_area = std::numeric_limits<float>::max();
 
   for (auto&& iso : iso_cells) {
     sta::Cell* masterCell = network->dbToSta(iso);
     sta::LibertyCell* libertyCell = network->libertyCell(masterCell);
 
-    if (libertyCell->area() < smallest_area) {
-      smallest_iso_l = libertyCell;
+    // Find enable & data pins for the isolation cell
+    sta::LibertyPort* tmp_enable_lib_port = nullptr;
+    sta::LibertyPort* tmp_out_lib_port = nullptr;
+    odb::dbMTerm* tmp_enable_term = nullptr; 
+    odb::dbMTerm* tmp_data_term = nullptr; 
+    odb::dbMTerm* tmp_output_term = nullptr;
+
+    for (auto&& term : iso->getMTerms()) {
+      sta::LibertyPort* lib_port
+          = libertyCell->findLibertyPort(term->getName().c_str());
+
+      if (!lib_port) {
+        continue;
+      }
+
+      if (lib_port->isolationCellData()) {
+        tmp_data_term = term;
+      }
+
+      if (lib_port->isolationCellEnable()) {
+        tmp_enable_term = term;
+        tmp_enable_lib_port = lib_port;
+      }
+
+      if (term->getIoType() == odb::dbIoType::OUTPUT) {
+        tmp_output_term = term;
+        tmp_out_lib_port = lib_port;
+      }
+    }
+
+    if (!tmp_output_term || !tmp_data_term || !tmp_enable_term) {
+      // Isolation cell defined, but can't find one of output, data or enable terms.
+      continue;
+    }
+    
+    // Determine if an inverter is needed for the control pin & output
+    bool tmp_invert_output = false;
+    bool tmp_invert_control = false;
+    bool matched = check_isolation_match(
+      tmp_out_lib_port->function(),
+      tmp_enable_lib_port,
+      isolation_sense,
+      isolation_clamp_val,
+      logger,
+      tmp_invert_control,
+      tmp_invert_output);
+    if (!matched) {
+      continue;
+    }
+
+    // Update the smallest_area
+    float tmp_area = libertyCell->area();
+    if (tmp_invert_control || tmp_invert_output) {
+      if (!inverter_m)
+        continue;
+      
+      if (tmp_invert_control)
+        tmp_area += inverter_m->getArea();
+      if (tmp_invert_output)
+        tmp_area += inverter_m->getArea();
+    } 
+
+    if (tmp_area < smallest_area) {
+      smallest_area = tmp_area;
       smallest_iso_m = iso;
-      smallest_area = libertyCell->area();
+      enable_term = tmp_enable_term;
+      data_term = tmp_data_term;
+      output_term = tmp_output_term;
+      invert_control = tmp_invert_control;
+      invert_output = tmp_invert_output;
     }
   }
 
-  if (smallest_iso_m == nullptr) {
+  if (smallest_area == std::numeric_limits<float>::max()) {
     logger->warn(utl::UPF,
                  25,
                  "Isolation {} cells defined, but can't find any in the lib.",
                  iso->getName());
     return false;
   }
-
-  auto cell_terms = smallest_iso_m->getMTerms();
-
-  // Find enable & data pins for the isolation cell
-  sta::LibertyPort* out_lib_port = nullptr;
-  sta::LibertyPort* enable_lib_port = nullptr;
-  for (auto&& term : cell_terms) {
-    sta::LibertyPort* lib_port
-        = smallest_iso_l->findLibertyPort(term->getName().c_str());
-
-    if (!lib_port) {
-      continue;
-    }
-
-    if (lib_port->isolationCellData()) {
-      data_term = term;
-    }
-
-    if (lib_port->isolationCellEnable()) {
-      enable_term = term;
-      enable_lib_port = lib_port;
-    }
-
-    if (term->getIoType() == odb::dbIoType::OUTPUT) {
-      output_term = term;
-      out_lib_port = lib_port;
-    }
-  }
-
-  if (!output_term || !data_term || !enable_term || !out_lib_port) {
-    logger->warn(utl::UPF,
-                 26,
-                 "Isolation {} cells defined, but can't find one of output, "
-                 "data or enable terms.",
-                 iso->getName());
-    return false;
-  }
-
-  // Determine if an inverter is needed for the control pin & output
-  auto func = out_lib_port->function();
-
-  return check_isolation_match(func,
-                               enable_lib_port,
-                               isolation_sense,
-                               isolation_clamp_val,
-                               logger,
-                               invert_control,
-                               invert_output);
+  return true;
 }
 
 static bool insert_isolation_cell(odb::dbBlock* block,
@@ -992,6 +1010,7 @@ static bool isolate_connection(odb::dbITerm* src_term,
   if (!find_smallest_isolation(network,
                                logger,
                                iso,
+                               inverter_m,
                                smallest_iso_m,
                                enable_term,
                                data_term,

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -646,7 +646,7 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
   // Search for the most appropriate isolation cell
   float smallest_area = std::numeric_limits<float>::max();
   float inverter_area = 0;
-  if (inverter_m) { 
+  if (inverter_m) {
     inverter_area = inverter_m->getArea();
   }
 

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -653,8 +653,8 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
     // Find enable & data pins for the isolation cell
     sta::LibertyPort* tmp_enable_lib_port = nullptr;
     sta::LibertyPort* tmp_out_lib_port = nullptr;
-    odb::dbMTerm* tmp_enable_term = nullptr; 
-    odb::dbMTerm* tmp_data_term = nullptr; 
+    odb::dbMTerm* tmp_enable_term = nullptr;
+    odb::dbMTerm* tmp_data_term = nullptr;
     odb::dbMTerm* tmp_output_term = nullptr;
 
     for (auto&& term : iso_cell->getMTerms()) {
@@ -681,21 +681,21 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
     }
 
     if (!tmp_output_term || !tmp_data_term || !tmp_enable_term) {
-      // Isolation cell defined, but can't find one of output, data or enable terms.
+      // Isolation cell defined, but can't find one of output, data or enable
+      // terms.
       continue;
     }
-    
+
     // Determine if an inverter is needed for the control pin & output
     bool tmp_invert_output = false;
     bool tmp_invert_control = false;
-    bool matched = check_isolation_match(
-      tmp_out_lib_port->function(),
-      tmp_enable_lib_port,
-      isolation_sense,
-      isolation_clamp_val,
-      logger,
-      tmp_invert_control,
-      tmp_invert_output);
+    bool matched = check_isolation_match(tmp_out_lib_port->function(),
+                                         tmp_enable_lib_port,
+                                         isolation_sense,
+                                         isolation_clamp_val,
+                                         logger,
+                                         tmp_invert_control,
+                                         tmp_invert_output);
     if (!matched) {
       continue;
     }
@@ -705,12 +705,12 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
     if (tmp_invert_control || tmp_invert_output) {
       if (!inverter_m)
         continue;
-      
+
       if (tmp_invert_control)
         tmp_area += inverter_m->getArea();
       if (tmp_invert_output)
         tmp_area += inverter_m->getArea();
-    } 
+    }
 
     if (tmp_area < smallest_area) {
       smallest_area = tmp_area;
@@ -1000,11 +1000,11 @@ static bool isolate_connection(odb::dbITerm* src_term,
   odb::dbMTerm *input_m = nullptr, *output_m = nullptr;
   bool inverter_found
       = find_smallest_inverter(network, block, inverter_m, input_m, output_m);
-  
+
   if (!inverter_found) {
     logger->warn(utl::UPF, 31, "can't find any inverters");
   }
-  
+
   odb::dbMTerm* enable_term = nullptr;
   odb::dbMTerm* data_term = nullptr;
   odb::dbMTerm* output_term = nullptr;

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -645,6 +645,10 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
 
   // Search for the most appropriate isolation cell
   float smallest_area = std::numeric_limits<float>::max();
+  float inverter_area = 0;
+  if (inverter_m) { 
+    inverter_area = inverter_m->getArea();
+  }
 
   for (auto&& iso_cell : iso_cells) {
     sta::Cell* masterCell = network->dbToSta(iso_cell);
@@ -703,13 +707,16 @@ static bool find_smallest_isolation(sta::dbNetwork* network,
     // Update the smallest_area
     float tmp_area = libertyCell->area();
     if (tmp_invert_control || tmp_invert_output) {
-      if (!inverter_m)
+      if (!inverter_m) {
         continue;
+      }
 
-      if (tmp_invert_control)
-        tmp_area += inverter_m->getArea();
-      if (tmp_invert_output)
-        tmp_area += inverter_m->getArea();
+      if (tmp_invert_control) {
+        tmp_area += inverter_area;
+      }
+      if (tmp_invert_output) {
+        tmp_area += inverter_area;
+      }
     }
 
     if (tmp_area < smallest_area) {

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -257,7 +257,7 @@ sta::define_cmd_args "use_interface_cell" { \
     -domain domain \
     -strategy strategy \
     -lib_cells lib_cells \
-    [interface_implementation_name]
+    interface_implementation_name
 }
 proc use_interface_cell { args } {
   upf::check_block_exists
@@ -265,7 +265,7 @@ proc use_interface_cell { args } {
   sta::parse_key_args "use_interface_cell" args \
     keys {-domain -strategy -lib_cells} flags {}
 
-  sta::check_argc_eq0or1 "use_interface_cell" $args
+  sta::check_argc_eq1 "use_interface_cell" $args
 
   set domain ""
   set strategy ""

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -254,9 +254,9 @@ proc set_isolation { args } {
 # - interface_implementation_name: for compatibility only. OpenRoad doesn't use it.
 
 sta::define_cmd_args "use_interface_cell" { \
-    [-domain domain] \
-    [-strategy strategy] \
-    [-lib_cells lib_cells] \
+    -domain domain \
+    -strategy strategy \
+    -lib_cells lib_cells \
     interface_implementation_name
 }
 proc use_interface_cell { args } {

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -257,7 +257,7 @@ sta::define_cmd_args "use_interface_cell" { \
     -domain domain \
     -strategy strategy \
     -lib_cells lib_cells \
-    interface_implementation_name
+    [interface_implementation_name]
 }
 proc use_interface_cell { args } {
   upf::check_block_exists

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -251,11 +251,13 @@ proc set_isolation { args } {
 # - domain: power domain
 # - strategy: isolation strategy name
 # - lib_cells: list of lib cells that could be used
+# - interface_implementation_name: for compatibility only. OpenRoad doesn't use it.
 
 sta::define_cmd_args "use_interface_cell" { \
     [-domain domain] \
     [-strategy strategy] \
-    [-lib_cells lib_cells]
+    [-lib_cells lib_cells] \
+    interface_implementation_name
 }
 proc use_interface_cell { args } {
   upf::check_block_exists
@@ -263,7 +265,7 @@ proc use_interface_cell { args } {
   sta::parse_key_args "use_interface_cell" args \
     keys {-domain -strategy -lib_cells} flags {}
 
-  sta::check_argc_eq0 "use_interface_cell" $args
+  sta::check_argc_eq0or1 "use_interface_cell" $args
 
   set domain ""
   set strategy ""
@@ -271,18 +273,26 @@ proc use_interface_cell { args } {
 
   if { [info exists keys(-domain)] } {
     set domain $keys(-domain)
+  } else {
+    utl::error UPF 75 "-domain is required for use_interface_cell"
   }
 
   if { [info exists keys(-strategy)] } {
     set strategy $keys(-strategy)
+  } else {
+    utl::error UPF 76 "-strategy is required for use_interface_cell"
   }
 
   if { [info exists keys(-lib_cells)] } {
     set lib_cells $keys(-lib_cells)
+  } else {
+    utl::error UPF 77 "-lib_cells is required for use_interface_cell"
   }
 
-  foreach {cell} $lib_cells {
-    upf::use_interface_cell_cmd $domain $strategy $cell
+  foreach {strat} $strategy {
+    foreach {cell} $lib_cells {
+      upf::use_interface_cell_cmd $domain $strat $cell
+    }
   }
 }
 

--- a/src/upf/test/CMakeLists.txt
+++ b/src/upf/test/CMakeLists.txt
@@ -4,6 +4,7 @@ or_integration_tests(
     levelshifter
     write
     isolation
+    isolation_select
 )
 
 # Skipped

--- a/src/upf/test/data/isolation/mpd_top.upf
+++ b/src/upf/test/data/isolation/mpd_top.upf
@@ -83,25 +83,25 @@ set_isolation iso_d_4 \
   -update \
   -location parent
 
-use_interface_cell \
+use_interface_cell PD_D1\
   -domain PD_D1 \
   -strategy iso_d_1 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D2\
   -domain PD_D2 \
   -strategy iso_d_2 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D3\
   -domain PD_D3 \
   -strategy iso_d_3 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
 
 
-use_interface_cell \
+use_interface_cell PD_D4\
   -domain PD_D4 \
   -strategy iso_d_4 \
   -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}

--- a/src/upf/test/data/isolation/mpd_top_select_iso.upf
+++ b/src/upf/test/data/isolation/mpd_top_select_iso.upf
@@ -1,0 +1,94 @@
+create_power_domain PD_TOP \
+  -elements {.}  \
+
+create_power_domain PD_D1 \
+  -elements {d1} \
+
+create_power_domain PD_D2 \
+  -elements {d2} \
+
+create_power_domain PD_D3 \
+  -elements {d3} \
+
+create_power_domain PD_D4 \
+  -elements {d4} \
+
+create_logic_port d1_iso_control
+create_logic_port d2_iso_control
+create_logic_port d3_iso_control
+create_logic_port d4_iso_control
+
+set_isolation iso_d_1 \
+  -domain PD_D1 \
+  -clamp_value 0
+
+set_isolation iso_d_2 \
+  -domain PD_D2 \
+  -applies_to inputs \
+  -clamp_value 0
+
+set_isolation iso_d_3 \
+  -domain PD_D3 \
+  -applies_to outputs \
+  -clamp_value 1
+
+set_isolation iso_d_4 \
+  -domain PD_D4 \
+  -applies_to both \
+  -clamp_value 1
+
+set_isolation iso_d_1 \
+  -domain PD_D1 \
+  -update \
+  -isolation_signal d1_iso_control \
+  -isolation_sense low
+
+set_isolation iso_d_2 \
+  -domain PD_D2 \
+  -update \
+  -isolation_signal d2_iso_control \
+  -isolation_sense high
+
+set_isolation iso_d_3 \
+  -domain PD_D3 \
+  -update \
+  -isolation_signal d3_iso_control \
+  -isolation_sense low
+
+set_isolation iso_d_4 \
+  -domain PD_D4 \
+  -update \
+  -isolation_signal d4_iso_control \
+  -isolation_sense high
+
+
+set_isolation iso_d_1 \
+  -domain PD_D1 \
+  -update \
+  -location parent
+
+set_isolation iso_d_2 \
+  -domain PD_D2 \
+  -update \
+  -location parent
+
+
+set_isolation iso_d_3 \
+  -domain PD_D3 \
+  -update \
+  -location parent
+
+set_isolation iso_d_4 \
+  -domain PD_D4 \
+  -update \
+  -location parent
+
+use_interface_cell isolation_cells \
+  -domain PD_D1 \
+  -strategy {iso_d_1 iso_d_2 iso_d_3 iso_d_4} \
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+    }

--- a/src/upf/test/data/isolation/mpd_top_select_iso.upf
+++ b/src/upf/test/data/isolation/mpd_top_select_iso.upf
@@ -85,7 +85,37 @@ set_isolation iso_d_4 \
 
 use_interface_cell isolation_cells \
   -domain PD_D1 \
-  -strategy {iso_d_1 iso_d_2 iso_d_3 iso_d_4} \
+  -strategy iso_d_1 \
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+    }
+
+use_interface_cell isolation_cells \
+  -domain PD_D2 \
+  -strategy iso_d_2 \
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+    }
+
+use_interface_cell isolation_cells \
+  -domain PD_D3 \
+  -strategy iso_d_3 \
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+    }
+
+use_interface_cell isolation_cells \
+  -domain PD_D4 \
+  -strategy iso_d_4 \
   -lib_cells {
     sky130_fd_sc_hd__lpflow_inputiso0n_1
     sky130_fd_sc_hd__lpflow_inputiso1n_1

--- a/src/upf/test/isolation_select.ok
+++ b/src/upf/test/isolation_select.ok
@@ -1,0 +1,5 @@
+[INFO ODB-0227] LEF file: data/sky130hd/sky130_fd_sc_hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: data/sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+[WARNING IFP-0028] Core area lower left (100.000, 100.000) snapped to (100.280, 100.640).
+[INFO IFP-0001] Added 110 rows of 651 site unithd.
+No differences found.

--- a/src/upf/test/isolation_select.tcl
+++ b/src/upf/test/isolation_select.tcl
@@ -1,0 +1,22 @@
+source "helpers.tcl"
+
+read_liberty data/sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib
+read_lef data/sky130hd/sky130_fd_sc_hd.tlef
+read_lef data/sky130hd/sky130_fd_sc_hd_merged.lef
+read_verilog data/isolation/mpd_top.v
+link_design mpd_top
+
+read_upf -file data/isolation/mpd_top_select_iso.upf
+
+set_domain_area PD_D1 -area {27 27 60 60}
+set_domain_area PD_D2 -area {100 100 180 180}
+set_domain_area PD_D3 -area {200 200 300 300}
+set_domain_area PD_D4 -area {300 300 400 400}
+
+initialize_floorplan -die_area { 0 0 500 500 } \
+    -core_area { 100 100 400 400 } \
+    -site unithd
+
+set v_file [make_result_file isolation_select.v]
+write_verilog -include_pwr_gnd $v_file
+diff_file $v_file isolation_select.vok

--- a/src/upf/test/isolation_select.vok
+++ b/src/upf/test/isolation_select.vok
@@ -1,0 +1,145 @@
+module mpd_top (in1,
+    in2,
+    out1,
+    out2,
+    out3,
+    d1_iso_control,
+    d2_iso_control,
+    d3_iso_control,
+    d4_iso_control);
+ input in1;
+ input in2;
+ output out1;
+ output out2;
+ output out3;
+ input d1_iso_control;
+ input d2_iso_control;
+ input d3_iso_control;
+ input d4_iso_control;
+
+ wire _0_;
+ wire d1_out1;
+ wire d1_out2;
+ wire d1_out3;
+ wire d2_out1;
+ wire d2_out2;
+ wire d2_out3;
+ wire d3_out1;
+ wire d3_out2;
+ wire d3_out3;
+ wire d4_out1;
+ wire d4_out2;
+ wire d4_out3;
+ wire d1_out2_o;
+ wire in1_o;
+ wire d1_out1_o;
+ wire d1_out3_o;
+ wire d1_out1_o_o;
+ wire in1_o_o;
+ wire d3_out2_o;
+ wire d3_out1_o;
+ wire d3_out3_o;
+ wire d2_out2_o;
+ wire d4_out2_o;
+ wire d3_out1_o_o;
+ wire d4_out1_o;
+ wire d4_out3_o;
+
+ sky130_fd_sc_hd__xnor2_1 _1_ (.A(d2_out3),
+    .B(d1_out3_o),
+    .Y(out1));
+ sky130_fd_sc_hd__xnor2_1 _2_ (.A(d4_out3_o),
+    .B(d3_out2_o),
+    .Y(out2));
+ sky130_fd_sc_hd__xnor2_1 _3_ (.A(d3_out3_o),
+    .B(d4_out2_o),
+    .Y(_0_));
+ sky130_fd_sc_hd__and2_1 _4_ (.A(d4_out1_o),
+    .B(_0_),
+    .X(out3));
+ sky130_fd_sc_hd__and2_1 \d1/_0_  (.A(in2),
+    .B(in1),
+    .X(d1_out3));
+ sky130_fd_sc_hd__buf_4 \d1/_1_  (.A(in1),
+    .X(d1_out1));
+ sky130_fd_sc_hd__buf_4 \d1/_2_  (.A(in2),
+    .X(d1_out2));
+ sky130_fd_sc_hd__and2_1 \d2/_0_  (.A(d1_out1_o),
+    .B(in1_o),
+    .X(d2_out3));
+ sky130_fd_sc_hd__buf_4 \d2/_1_  (.A(in1_o),
+    .X(d2_out1));
+ sky130_fd_sc_hd__buf_4 \d2/_2_  (.A(d1_out1_o),
+    .X(d2_out2_o));
+ sky130_fd_sc_hd__and2_1 \d3/_0_  (.A(d1_out2_o),
+    .B(d2_out1),
+    .X(d3_out3));
+ sky130_fd_sc_hd__buf_4 \d3/_1_  (.A(d2_out1),
+    .X(d3_out1));
+ sky130_fd_sc_hd__buf_4 \d3/_2_  (.A(d1_out2_o),
+    .X(d3_out2));
+ sky130_fd_sc_hd__and2_1 \d4/_0_  (.A(d2_out2),
+    .B(d3_out1_o),
+    .X(d4_out3));
+ sky130_fd_sc_hd__buf_4 \d4/_1_  (.A(d3_out1_o),
+    .X(d4_out1));
+ sky130_fd_sc_hd__buf_4 \d4/_2_  (.A(d2_out2),
+    .X(d4_out2));
+ sky130_fd_sc_hd__lpflow_inputiso0n_1 \d1/_2__d1_out2_d1_out2_o_isolation  (.A(d1_out2),
+    .SLEEP_B(d1_iso_control),
+    .X(d1_out2_o));
+ sky130_fd_sc_hd__lpflow_inputiso0n_1 \d1/_1__in1_in1_o_isolation  (.A(in1_o_o),
+    .SLEEP_B(d1_iso_control),
+    .X(in1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0n_1 \d1/_1__d1_out1_d1_out1_o_isolation  (.A(d1_out1),
+    .SLEEP_B(d1_iso_control),
+    .X(d1_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0n_1 \d1/_0__in1_in1_o_isolation  (.A(in1),
+    .SLEEP_B(d1_iso_control),
+    .X(in1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0n_1 \d1/_0__d1_out3_d1_out3_o_isolation  (.A(d1_out3),
+    .SLEEP_B(d1_iso_control),
+    .X(d1_out3_o));
+ sky130_fd_sc_hd__lpflow_inputiso0p_1 \d2/_2__d1_out1_o_d1_out1_o_o_isolation  (.A(d1_out1_o_o),
+    .SLEEP(d2_iso_control),
+    .X(d1_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0p_1 \d2/_1__in1_o_in1_o_o_isolation  (.A(in1_o_o),
+    .SLEEP(d2_iso_control),
+    .X(in1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0p_1 \d2/_0__d1_out1_o_d1_out1_o_o_isolation  (.A(d1_out1_o),
+    .SLEEP(d2_iso_control),
+    .X(d1_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso0p_1 \d2/_0__in1_o_in1_o_o_isolation  (.A(in1_o),
+    .SLEEP(d2_iso_control),
+    .X(in1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso1n_1 \d3/_2__d3_out2_d3_out2_o_isolation  (.A(d3_out2),
+    .SLEEP_B(d3_iso_control),
+    .X(d3_out2_o));
+ sky130_fd_sc_hd__lpflow_inputiso1n_1 \d3/_1__d3_out1_d3_out1_o_isolation  (.A(d3_out1),
+    .SLEEP_B(d3_iso_control),
+    .X(d3_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso1n_1 \d3/_0__d3_out3_d3_out3_o_isolation  (.A(d3_out3),
+    .SLEEP_B(d3_iso_control),
+    .X(d3_out3_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_2__d2_out2_d2_out2_o_isolation  (.A(d2_out2_o),
+    .SLEEP(d4_iso_control),
+    .X(d2_out2_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_2__d4_out2_d4_out2_o_isolation  (.A(d4_out2),
+    .SLEEP(d4_iso_control),
+    .X(d4_out2_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_1__d3_out1_o_d3_out1_o_o_isolation  (.A(d3_out1_o_o),
+    .SLEEP(d4_iso_control),
+    .X(d3_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_1__d4_out1_d4_out1_o_isolation  (.A(d4_out1),
+    .SLEEP(d4_iso_control),
+    .X(d4_out1_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_0__d2_out2_d2_out2_o_isolation  (.A(d2_out2),
+    .SLEEP(d4_iso_control),
+    .X(d2_out2_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_0__d3_out1_o_d3_out1_o_o_isolation  (.A(d3_out1_o),
+    .SLEEP(d4_iso_control),
+    .X(d3_out1_o_o));
+ sky130_fd_sc_hd__lpflow_inputiso1p_1 \d4/_0__d4_out3_d4_out3_o_isolation  (.A(d4_out3),
+    .SLEEP(d4_iso_control),
+    .X(d4_out3_o));
+endmodule

--- a/test/upf/mpd_aes.upf
+++ b/test/upf/mpd_aes.upf
@@ -59,7 +59,7 @@ set_isolation iso_aes_2 \
   -location parent
 
 
-use_interface_cell \
+use_interface_cell iso_aes_1\
   -domain PD_AES_1 \
   -strategy iso_aes_1 \
   -lib_cells {
@@ -70,7 +70,7 @@ use_interface_cell \
   }
 
 
-use_interface_cell \
+use_interface_cell iso_aes_2\
   -domain PD_AES_2 \
   -strategy iso_aes_2 \
   -lib_cells {

--- a/test/upf/mpd_aes.upf
+++ b/test/upf/mpd_aes.upf
@@ -62,10 +62,20 @@ set_isolation iso_aes_2 \
 use_interface_cell \
   -domain PD_AES_1 \
   -strategy iso_aes_1 \
-  -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+  }
 
 
 use_interface_cell \
   -domain PD_AES_2 \
   -strategy iso_aes_2 \
-  -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+  }

--- a/test/upf/mpd_top.upf
+++ b/test/upf/mpd_top.upf
@@ -48,7 +48,7 @@ set_isolation iso_d_2 \
 
 
 
-use_interface_cell \
+use_interface_cell iso_d_1\
   -domain PD_D1 \
   -strategy iso_d_1 \
   -lib_cells {
@@ -59,7 +59,7 @@ use_interface_cell \
   }
 
 
-use_interface_cell \
+use_interface_cell iso_d_2\
   -domain PD_D2 \
   -strategy iso_d_2 \
   -lib_cells {

--- a/test/upf/mpd_top.upf
+++ b/test/upf/mpd_top.upf
@@ -51,10 +51,20 @@ set_isolation iso_d_2 \
 use_interface_cell \
   -domain PD_D1 \
   -strategy iso_d_1 \
-  -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+  }
 
 
 use_interface_cell \
   -domain PD_D2 \
   -strategy iso_d_2 \
-  -lib_cells {sky130_fd_sc_hd__lpflow_inputiso0n_1}
+  -lib_cells {
+    sky130_fd_sc_hd__lpflow_inputiso0n_1
+    sky130_fd_sc_hd__lpflow_inputiso1n_1
+    sky130_fd_sc_hd__lpflow_inputiso0p_1
+    sky130_fd_sc_hd__lpflow_inputiso1p_1
+  }

--- a/test/upf_test.defok
+++ b/test/upf_test.defok
@@ -71,32 +71,29 @@ REGIONS 2 ;
     - PD_D1 ( 2300 2720 ) ( 57500 19040 ) + TYPE FENCE ;
     - PD_D2 ( 2300 92480 ) ( 57500 108800 ) + TYPE FENCE ;
 END REGIONS
-COMPONENTS 25 ;
-    - _1_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 67620 54400 ) FS ;
-    - _2_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 58420 57120 ) N ;
-    - _3_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 55200 57120 ) N ;
-    - _4_ sky130_fd_sc_hd__and2_1 + PLACED ( 62560 57120 ) N ;
+COMPONENTS 22 ;
+    - _1_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 63480 54400 ) FS ;
+    - _2_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 71300 57120 ) N ;
+    - _3_ sky130_fd_sc_hd__xnor2_1 + PLACED ( 60720 59840 ) FS ;
+    - _4_ sky130_fd_sc_hd__and2_1 + PLACED ( 69460 59840 ) FS ;
     - d1/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 55200 16320 ) FS ;
-    - d1/_0__d1_out3_d1_out3_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 60720 54400 ) FS ;
-    - d1/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 51520 16320 ) S ;
-    - d1/_1__d1_out1_d1_out1_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 52440 54400 ) FS ;
-    - d1/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 51520 13600 ) FN ;
-    - d1/_2__d1_out2_d1_out2_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 54740 54400 ) FS ;
-    - d2/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 52900 92480 ) FS ;
-    - d2/_0__d2_out3_d2_out3_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 55200 92480 ) FS ;
-    - d2/_0__d2_out3_d2_out3_o_isolation_inv_control sky130_fd_sc_hd__clkinv_1 + PLACED ( 56120 95200 ) FN ;
-    - d2/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 49680 92480 ) S ;
-    - d2/_1__d2_out1_d2_out1_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 50600 97920 ) FS ;
-    - d2/_1__d2_out1_d2_out1_o_isolation_inv_control sky130_fd_sc_hd__clkinv_1 + PLACED ( 49220 97920 ) FS ;
-    - d2/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 52900 95200 ) N ;
-    - d2/_2__d2_out2_d2_out2_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 50600 95200 ) N ;
-    - d2/_2__d2_out2_d2_out2_o_isolation_inv_control sky130_fd_sc_hd__clkinv_1 + PLACED ( 49220 95200 ) N ;
-    - d3/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 52900 57120 ) N ;
-    - d3/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 51980 59840 ) FS ;
-    - d3/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 57960 54400 ) FS ;
-    - d4/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 57040 59840 ) FS ;
-    - d4/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 60720 59840 ) FS ;
-    - d4/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 54280 62560 ) N ;
+    - d1/_0__d1_out3_d1_out3_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 61180 54400 ) FS ;
+    - d1/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 46000 16320 ) S ;
+    - d1/_1__d1_out1_d1_out1_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 47380 54400 ) FS ;
+    - d1/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 52440 16320 ) S ;
+    - d1/_2__d1_out2_d1_out2_o_isolation sky130_fd_sc_hd__lpflow_inputiso0n_1 + PLACED ( 53820 54400 ) FS ;
+    - d2/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 48760 95200 ) N ;
+    - d2/_0__d2_out3_d2_out3_o_isolation sky130_fd_sc_hd__lpflow_inputiso0p_1 + PLACED ( 51060 95200 ) N ;
+    - d2/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 54740 95200 ) N ;
+    - d2/_1__d2_out1_d2_out1_o_isolation sky130_fd_sc_hd__lpflow_inputiso0p_1 + PLACED ( 54740 92480 ) FS ;
+    - d2/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 48300 92480 ) FS ;
+    - d2/_2__d2_out2_d2_out2_o_isolation sky130_fd_sc_hd__lpflow_inputiso0p_1 + PLACED ( 51060 92480 ) FS ;
+    - d3/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 59800 57120 ) N ;
+    - d3/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 62560 57120 ) N ;
+    - d3/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 68540 54400 ) FS ;
+    - d4/_0_ sky130_fd_sc_hd__and2_1 + PLACED ( 65780 57120 ) N ;
+    - d4/_1_ sky130_fd_sc_hd__buf_4 + PLACED ( 68080 57120 ) N ;
+    - d4/_2_ sky130_fd_sc_hd__buf_4 + PLACED ( 57960 59840 ) FS ;
 END COMPONENTS
 PINS 7 ;
     - d1_iso_control + NET d1_iso_control + DIRECTION INPUT + USE SIGNAL
@@ -128,7 +125,7 @@ PINS 7 ;
         + LAYER met3 ( -400 -150 ) ( 400 150 )
         + PLACED ( 112050 60180 ) N ;
 END PINS
-NETS 29 ;
+NETS 26 ;
     - _0_ ( _4_ B ) ( _3_ Y ) + USE SIGNAL ;
     - d1_iso_control ( PIN d1_iso_control ) ( d1/_0__d1_out3_d1_out3_o_isolation SLEEP_B ) ( d1/_1__d1_out1_d1_out1_o_isolation SLEEP_B ) ( d1/_2__d1_out2_d1_out2_o_isolation SLEEP_B ) + USE SIGNAL ;
     - d1_out1 ( d1/_1__d1_out1_d1_out1_o_isolation A ) ( d1/_1_ X ) + USE SIGNAL ;
@@ -137,10 +134,7 @@ NETS 29 ;
     - d1_out2_o ( d3/_0_ A ) ( d3/_2_ A ) ( d1/_2__d1_out2_d1_out2_o_isolation X ) + USE SIGNAL ;
     - d1_out3 ( d1/_0__d1_out3_d1_out3_o_isolation A ) ( d1/_0_ X ) + USE SIGNAL ;
     - d1_out3_o ( _1_ B ) ( d1/_0__d1_out3_d1_out3_o_isolation X ) + USE SIGNAL ;
-    - d2/_0__d2_out3_d2_out3_o_isolation_inv_control ( d2/_0__d2_out3_d2_out3_o_isolation SLEEP_B ) ( d2/_0__d2_out3_d2_out3_o_isolation_inv_control Y ) + USE SIGNAL ;
-    - d2/_1__d2_out1_d2_out1_o_isolation_inv_control ( d2/_1__d2_out1_d2_out1_o_isolation SLEEP_B ) ( d2/_1__d2_out1_d2_out1_o_isolation_inv_control Y ) + USE SIGNAL ;
-    - d2/_2__d2_out2_d2_out2_o_isolation_inv_control ( d2/_2__d2_out2_d2_out2_o_isolation SLEEP_B ) ( d2/_2__d2_out2_d2_out2_o_isolation_inv_control Y ) + USE SIGNAL ;
-    - d2_iso_control ( PIN d2_iso_control ) ( d2/_0__d2_out3_d2_out3_o_isolation_inv_control A ) ( d2/_1__d2_out1_d2_out1_o_isolation_inv_control A ) ( d2/_2__d2_out2_d2_out2_o_isolation_inv_control A ) + USE SIGNAL ;
+    - d2_iso_control ( PIN d2_iso_control ) ( d2/_0__d2_out3_d2_out3_o_isolation SLEEP ) ( d2/_1__d2_out1_d2_out1_o_isolation SLEEP ) ( d2/_2__d2_out2_d2_out2_o_isolation SLEEP ) + USE SIGNAL ;
     - d2_out1 ( d2/_1__d2_out1_d2_out1_o_isolation A ) ( d2/_1_ X ) + USE SIGNAL ;
     - d2_out1_o ( d3/_0_ B ) ( d3/_1_ A ) ( d2/_1__d2_out1_d2_out1_o_isolation X ) + USE SIGNAL ;
     - d2_out2 ( d2/_2__d2_out2_d2_out2_o_isolation A ) ( d2/_2_ X ) + USE SIGNAL ;
@@ -161,8 +155,7 @@ NETS 29 ;
 END NETS
 GROUPS 2 ;
     - PD_D1 d1/_2_ d1/_1_ d1/_0_ + REGION PD_D1 ;
-    - PD_D2 d2/_0__d2_out3_d2_out3_o_isolation_inv_control d2/_0__d2_out3_d2_out3_o_isolation d2/_1__d2_out1_d2_out1_o_isolation_inv_control
-         d2/_1__d2_out1_d2_out1_o_isolation d2/_2__d2_out2_d2_out2_o_isolation_inv_control d2/_2__d2_out2_d2_out2_o_isolation d2/_2_
-         d2/_1_ d2/_0_ + REGION PD_D2 ;
+    - PD_D2 d2/_0__d2_out3_d2_out3_o_isolation d2/_1__d2_out1_d2_out1_o_isolation d2/_2__d2_out2_d2_out2_o_isolation
+         d2/_2_ d2/_1_ d2/_0_ + REGION PD_D2 ;
 END GROUPS
 END DESIGN

--- a/test/upf_test.ok
+++ b/test/upf_test.ok
@@ -18,8 +18,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0007] NumPlaceInstances:           13
 [INFO GPL-0008] NumFixedInstances:            0
 [INFO GPL-0009] NumDummyInstances:           24
-[INFO GPL-0010] NumNets:                     29
-[INFO GPL-0011] NumPins:                     71
+[INFO GPL-0010] NumNets:                     26
+[INFO GPL-0011] NumPins:                     65
 [INFO GPL-0012] DieBBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
 [INFO GPL-0013] CoreBBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
 [INFO GPL-0016] CoreArea:             11467.248 um^2
@@ -32,8 +32,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0007] NumPlaceInstances:            3
 [INFO GPL-0008] NumFixedInstances:            0
 [INFO GPL-0009] NumDummyInstances:           39
-[INFO GPL-0010] NumNets:                     29
-[INFO GPL-0011] NumPins:                     71
+[INFO GPL-0010] NumNets:                     26
+[INFO GPL-0011] NumPins:                     65
 [INFO GPL-0012] DieBBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
 [INFO GPL-0013] CoreBBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
 [INFO GPL-0016] CoreArea:             11467.248 um^2
@@ -42,23 +42,23 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0019] Util:                     2.361 %
 [INFO GPL-0020] StdInstsArea:            21.270 um^2
 [INFO GPL-0021] MacroInstsArea:           0.000 um^2
-[INFO GPL-0006] NumInstances:                48
-[INFO GPL-0007] NumPlaceInstances:            9
+[INFO GPL-0006] NumInstances:                45
+[INFO GPL-0007] NumPlaceInstances:            6
 [INFO GPL-0008] NumFixedInstances:            0
 [INFO GPL-0009] NumDummyInstances:           39
-[INFO GPL-0010] NumNets:                     29
-[INFO GPL-0011] NumPins:                     71
+[INFO GPL-0010] NumNets:                     26
+[INFO GPL-0011] NumPins:                     65
 [INFO GPL-0012] DieBBox:  (  0.000  0.000 ) ( 112.450 112.450 ) um
 [INFO GPL-0013] CoreBBox: (  2.300  2.720 ) ( 110.400 108.800 ) um
 [INFO GPL-0016] CoreArea:             11467.248 um^2
 [INFO GPL-0017] NonPlaceInstsArea:    10566.384 um^2
-[INFO GPL-0018] PlaceInstsArea:          51.299 um^2
-[INFO GPL-0019] Util:                     5.694 %
-[INFO GPL-0020] StdInstsArea:            51.299 um^2
+[INFO GPL-0018] PlaceInstsArea:          43.792 um^2
+[INFO GPL-0019] Util:                     4.861 %
+[INFO GPL-0020] StdInstsArea:            43.792 um^2
 [INFO GPL-0021] MacroInstsArea:           0.000 um^2
 [INFO GPL-0031] FillerInit:NumGCells:       672
-[INFO GPL-0032] FillerInit:NumGNets:         29
-[INFO GPL-0033] FillerInit:NumGPins:         71
+[INFO GPL-0032] FillerInit:NumGNets:         26
+[INFO GPL-0033] FillerInit:NumGPins:         65
 [INFO GPL-0023] TargetDensity:            0.700
 [INFO GPL-0024] AvrgPlaceInstArea:        7.218 um^2
 [INFO GPL-0025] IdealBinArea:            10.312 um^2
@@ -68,8 +68,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0029] BinSize: (  3.379  3.315 )
 [INFO GPL-0030] NumBins: 1024
 [INFO GPL-0031] FillerInit:NumGCells:        91
-[INFO GPL-0032] FillerInit:NumGNets:         29
-[INFO GPL-0033] FillerInit:NumGPins:         71
+[INFO GPL-0032] FillerInit:NumGNets:         26
+[INFO GPL-0033] FillerInit:NumGPins:         65
 [INFO GPL-0023] TargetDensity:            0.700
 [INFO GPL-0024] AvrgPlaceInstArea:        7.090 um^2
 [INFO GPL-0025] IdealBinArea:            10.129 um^2
@@ -78,209 +78,218 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] BinCnt:        32     32
 [INFO GPL-0029] BinSize: (  3.379  3.315 )
 [INFO GPL-0030] NumBins: 1024
-[INFO GPL-0031] FillerInit:NumGCells:       114
-[INFO GPL-0032] FillerInit:NumGNets:         29
-[INFO GPL-0033] FillerInit:NumGPins:         71
+[INFO GPL-0031] FillerInit:NumGCells:        86
+[INFO GPL-0032] FillerInit:NumGNets:         26
+[INFO GPL-0033] FillerInit:NumGPins:         65
 [INFO GPL-0023] TargetDensity:            0.700
-[INFO GPL-0024] AvrgPlaceInstArea:        5.700 um^2
-[INFO GPL-0025] IdealBinArea:             8.143 um^2
-[INFO GPL-0026] IdealBinCnt:               1408
+[INFO GPL-0024] AvrgPlaceInstArea:        7.299 um^2
+[INFO GPL-0025] IdealBinArea:            10.427 um^2
+[INFO GPL-0026] IdealBinCnt:               1099
 [INFO GPL-0027] TotalBinArea:         11467.248 um^2
 [INFO GPL-0028] BinCnt:        32     32
 [INFO GPL-0029] BinSize: (  3.379  3.315 )
 [INFO GPL-0030] NumBins: 1024
-[NesterovSolve] Iter:    1 overflow: 0.384 HPWL: 1159011
-[NesterovSolve] Iter:    1 overflow: 1.000 HPWL: 1159011 (PD_D1)
-[NesterovSolve] Iter:    1 overflow: 0.294 HPWL: 1159011 (PD_D2)
-[NesterovSolve] Finished with Overflow: 0.059938
-[NesterovSolve] Iter:   10 overflow: 1.000 HPWL: 593507 (PD_D1)
-[NesterovSolve] Iter:   10 overflow: 1.000 HPWL: 593507 (PD_D2)
-[NesterovSolve] Iter:   20 overflow: 1.000 HPWL: 568146 (PD_D1)
-[NesterovSolve] Iter:   20 overflow: 1.000 HPWL: 568146 (PD_D2)
-[NesterovSolve] Iter:   30 overflow: 1.000 HPWL: 564664 (PD_D1)
-[NesterovSolve] Iter:   30 overflow: 1.000 HPWL: 564664 (PD_D2)
-[NesterovSolve] Iter:   40 overflow: 1.000 HPWL: 565643 (PD_D1)
-[NesterovSolve] Iter:   40 overflow: 1.000 HPWL: 565643 (PD_D2)
-[NesterovSolve] Iter:   50 overflow: 1.000 HPWL: 565960 (PD_D1)
-[NesterovSolve] Iter:   50 overflow: 1.000 HPWL: 565960 (PD_D2)
-[NesterovSolve] Iter:   60 overflow: 1.000 HPWL: 565831 (PD_D1)
-[NesterovSolve] Iter:   60 overflow: 1.000 HPWL: 565831 (PD_D2)
-[NesterovSolve] Iter:   70 overflow: 1.000 HPWL: 565822 (PD_D1)
-[NesterovSolve] Iter:   70 overflow: 1.000 HPWL: 565822 (PD_D2)
-[NesterovSolve] Iter:   80 overflow: 1.000 HPWL: 565803 (PD_D1)
-[NesterovSolve] Iter:   80 overflow: 1.000 HPWL: 565803 (PD_D2)
-[NesterovSolve] Iter:   90 overflow: 1.000 HPWL: 565778 (PD_D1)
-[NesterovSolve] Iter:   90 overflow: 1.000 HPWL: 565778 (PD_D2)
-[NesterovSolve] Iter:  100 overflow: 1.000 HPWL: 565760 (PD_D1)
-[NesterovSolve] Iter:  100 overflow: 1.000 HPWL: 565760 (PD_D2)
-[NesterovSolve] Iter:  110 overflow: 1.000 HPWL: 565726 (PD_D1)
-[NesterovSolve] Iter:  110 overflow: 1.000 HPWL: 565726 (PD_D2)
-[NesterovSolve] Iter:  120 overflow: 1.000 HPWL: 565705 (PD_D1)
-[NesterovSolve] Iter:  120 overflow: 1.000 HPWL: 565705 (PD_D2)
-[NesterovSolve] Iter:  130 overflow: 1.000 HPWL: 565694 (PD_D1)
-[NesterovSolve] Iter:  130 overflow: 1.000 HPWL: 565694 (PD_D2)
-[NesterovSolve] Iter:  140 overflow: 1.000 HPWL: 565689 (PD_D1)
-[NesterovSolve] Iter:  140 overflow: 1.000 HPWL: 565689 (PD_D2)
-[NesterovSolve] Iter:  150 overflow: 1.000 HPWL: 565682 (PD_D1)
-[NesterovSolve] Iter:  150 overflow: 1.000 HPWL: 565682 (PD_D2)
-[NesterovSolve] Iter:  160 overflow: 1.000 HPWL: 565674 (PD_D1)
-[NesterovSolve] Iter:  160 overflow: 1.000 HPWL: 565674 (PD_D2)
-[NesterovSolve] Iter:  170 overflow: 1.000 HPWL: 565951 (PD_D1)
-[NesterovSolve] Iter:  170 overflow: 1.000 HPWL: 565951 (PD_D2)
-[NesterovSolve] Iter:  180 overflow: 1.000 HPWL: 566417 (PD_D1)
-[NesterovSolve] Iter:  180 overflow: 1.000 HPWL: 566417 (PD_D2)
-[NesterovSolve] Iter:  190 overflow: 1.000 HPWL: 566918 (PD_D1)
-[NesterovSolve] Iter:  190 overflow: 1.000 HPWL: 566918 (PD_D2)
-[NesterovSolve] Iter:  200 overflow: 1.000 HPWL: 567508 (PD_D1)
-[NesterovSolve] Iter:  200 overflow: 1.000 HPWL: 567508 (PD_D2)
-[NesterovSolve] Iter:  210 overflow: 0.963 HPWL: 568013 (PD_D1)
-[NesterovSolve] Iter:  210 overflow: 1.000 HPWL: 568013 (PD_D2)
-[NesterovSolve] Iter:  220 overflow: 0.919 HPWL: 567899 (PD_D1)
-[NesterovSolve] Iter:  220 overflow: 1.000 HPWL: 567899 (PD_D2)
-[NesterovSolve] Iter:  230 overflow: 0.879 HPWL: 567422 (PD_D1)
-[NesterovSolve] Iter:  230 overflow: 1.000 HPWL: 567422 (PD_D2)
-[NesterovSolve] Iter:  240 overflow: 0.842 HPWL: 566998 (PD_D1)
-[NesterovSolve] Iter:  240 overflow: 1.000 HPWL: 566998 (PD_D2)
-[NesterovSolve] Iter:  250 overflow: 0.808 HPWL: 566763 (PD_D1)
-[NesterovSolve] Iter:  250 overflow: 1.000 HPWL: 566763 (PD_D2)
-[NesterovSolve] Iter:  260 overflow: 0.777 HPWL: 566095 (PD_D1)
-[NesterovSolve] Iter:  260 overflow: 1.000 HPWL: 566095 (PD_D2)
-[NesterovSolve] Iter:  270 overflow: 0.748 HPWL: 564051 (PD_D1)
-[NesterovSolve] Iter:  270 overflow: 1.000 HPWL: 564051 (PD_D2)
-[NesterovSolve] Iter:  280 overflow: 0.721 HPWL: 562545 (PD_D1)
-[NesterovSolve] Iter:  280 overflow: 1.000 HPWL: 562545 (PD_D2)
-[NesterovSolve] Iter:  290 overflow: 0.696 HPWL: 561901 (PD_D1)
-[NesterovSolve] Iter:  290 overflow: 1.000 HPWL: 561901 (PD_D2)
-[NesterovSolve] Iter:  300 overflow: 0.673 HPWL: 560725 (PD_D1)
-[NesterovSolve] Iter:  300 overflow: 1.000 HPWL: 560725 (PD_D2)
-[NesterovSolve] Iter:  310 overflow: 0.651 HPWL: 559529 (PD_D1)
-[NesterovSolve] Iter:  310 overflow: 1.000 HPWL: 559529 (PD_D2)
-[NesterovSolve] Iter:  320 overflow: 0.631 HPWL: 558656 (PD_D1)
-[NesterovSolve] Iter:  320 overflow: 1.000 HPWL: 558656 (PD_D2)
-[NesterovSolve] Iter:  330 overflow: 0.612 HPWL: 558257 (PD_D1)
-[NesterovSolve] Iter:  330 overflow: 1.000 HPWL: 558257 (PD_D2)
-[NesterovSolve] Iter:  340 overflow: 0.594 HPWL: 556135 (PD_D1)
-[NesterovSolve] Iter:  340 overflow: 1.000 HPWL: 556135 (PD_D2)
-[NesterovSolve] Iter:  350 overflow: 0.577 HPWL: 556149 (PD_D1)
-[NesterovSolve] Iter:  350 overflow: 1.000 HPWL: 556149 (PD_D2)
-[NesterovSolve] Iter:  360 overflow: 0.561 HPWL: 556081 (PD_D1)
-[NesterovSolve] Iter:  360 overflow: 1.000 HPWL: 556081 (PD_D2)
-[NesterovSolve] Iter:  370 overflow: 0.545 HPWL: 554090 (PD_D1)
-[NesterovSolve] Iter:  370 overflow: 1.000 HPWL: 554090 (PD_D2)
-[NesterovSolve] Iter:  380 overflow: 0.531 HPWL: 553447 (PD_D1)
-[NesterovSolve] Iter:  380 overflow: 1.000 HPWL: 553447 (PD_D2)
-[NesterovSolve] Iter:  390 overflow: 0.517 HPWL: 548340 (PD_D1)
-[NesterovSolve] Iter:  390 overflow: 1.000 HPWL: 548340 (PD_D2)
-[NesterovSolve] Iter:  400 overflow: 0.504 HPWL: 547584 (PD_D1)
-[NesterovSolve] Iter:  400 overflow: 1.000 HPWL: 547584 (PD_D2)
-[NesterovSolve] Iter:  410 overflow: 0.492 HPWL: 546938 (PD_D1)
-[NesterovSolve] Iter:  410 overflow: 1.000 HPWL: 546938 (PD_D2)
-[NesterovSolve] Iter:  420 overflow: 0.480 HPWL: 544381 (PD_D1)
-[NesterovSolve] Iter:  420 overflow: 1.000 HPWL: 544381 (PD_D2)
-[NesterovSolve] Iter:  430 overflow: 0.469 HPWL: 542611 (PD_D1)
-[NesterovSolve] Iter:  430 overflow: 1.000 HPWL: 542611 (PD_D2)
-[NesterovSolve] Iter:  440 overflow: 0.458 HPWL: 540759 (PD_D1)
-[NesterovSolve] Iter:  440 overflow: 1.000 HPWL: 540759 (PD_D2)
-[NesterovSolve] Iter:  450 overflow: 0.448 HPWL: 539150 (PD_D1)
-[NesterovSolve] Iter:  450 overflow: 1.000 HPWL: 539150 (PD_D2)
-[NesterovSolve] Iter:  460 overflow: 0.438 HPWL: 537365 (PD_D1)
-[NesterovSolve] Iter:  460 overflow: 1.000 HPWL: 537365 (PD_D2)
-[NesterovSolve] Iter:  470 overflow: 0.429 HPWL: 534147 (PD_D1)
-[NesterovSolve] Iter:  470 overflow: 1.000 HPWL: 534147 (PD_D2)
-[NesterovSolve] Iter:  480 overflow: 0.420 HPWL: 535187 (PD_D1)
-[NesterovSolve] Iter:  480 overflow: 1.000 HPWL: 535187 (PD_D2)
-[NesterovSolve] Iter:  490 overflow: 0.412 HPWL: 530647 (PD_D1)
-[NesterovSolve] Iter:  490 overflow: 0.993 HPWL: 530647 (PD_D2)
-[NesterovSolve] Iter:  500 overflow: 0.403 HPWL: 529093 (PD_D1)
-[NesterovSolve] Iter:  500 overflow: 0.973 HPWL: 529093 (PD_D2)
-[NesterovSolve] Iter:  510 overflow: 0.395 HPWL: 528996 (PD_D1)
-[NesterovSolve] Iter:  510 overflow: 0.954 HPWL: 528996 (PD_D2)
-[NesterovSolve] Iter:  520 overflow: 0.388 HPWL: 524553 (PD_D1)
-[NesterovSolve] Iter:  520 overflow: 0.935 HPWL: 524553 (PD_D2)
-[NesterovSolve] Iter:  530 overflow: 0.380 HPWL: 524224 (PD_D1)
-[NesterovSolve] Iter:  530 overflow: 0.918 HPWL: 524224 (PD_D2)
-[NesterovSolve] Iter:  540 overflow: 0.373 HPWL: 523949 (PD_D1)
-[NesterovSolve] Iter:  540 overflow: 0.901 HPWL: 523949 (PD_D2)
-[NesterovSolve] Iter:  550 overflow: 0.367 HPWL: 520478 (PD_D1)
-[NesterovSolve] Iter:  550 overflow: 0.884 HPWL: 520478 (PD_D2)
-[NesterovSolve] Iter:  560 overflow: 0.360 HPWL: 520247 (PD_D1)
-[NesterovSolve] Iter:  560 overflow: 0.868 HPWL: 520247 (PD_D2)
-[NesterovSolve] Iter:  570 overflow: 0.354 HPWL: 517813 (PD_D1)
-[NesterovSolve] Iter:  570 overflow: 0.853 HPWL: 517813 (PD_D2)
-[NesterovSolve] Iter:  580 overflow: 0.348 HPWL: 517137 (PD_D1)
-[NesterovSolve] Iter:  580 overflow: 0.838 HPWL: 517137 (PD_D2)
-[NesterovSolve] Iter:  590 overflow: 0.342 HPWL: 516742 (PD_D1)
-[NesterovSolve] Iter:  590 overflow: 0.824 HPWL: 516742 (PD_D2)
-[NesterovSolve] Iter:  600 overflow: 0.336 HPWL: 516719 (PD_D1)
-[NesterovSolve] Iter:  600 overflow: 0.810 HPWL: 516719 (PD_D2)
-[NesterovSolve] Iter:  610 overflow: 0.330 HPWL: 516793 (PD_D1)
-[NesterovSolve] Iter:  610 overflow: 0.797 HPWL: 516793 (PD_D2)
-[NesterovSolve] Iter:  620 overflow: 0.325 HPWL: 517069 (PD_D1)
-[NesterovSolve] Iter:  620 overflow: 0.784 HPWL: 517069 (PD_D2)
-[NesterovSolve] Iter:  630 overflow: 0.320 HPWL: 517326 (PD_D1)
-[NesterovSolve] Iter:  630 overflow: 0.772 HPWL: 517326 (PD_D2)
-[NesterovSolve] Iter:  640 overflow: 0.315 HPWL: 517883 (PD_D1)
-[NesterovSolve] Iter:  640 overflow: 0.760 HPWL: 517883 (PD_D2)
-[NesterovSolve] Iter:  650 overflow: 0.310 HPWL: 518930 (PD_D1)
-[NesterovSolve] Iter:  650 overflow: 0.748 HPWL: 518930 (PD_D2)
-[NesterovSolve] Iter:  660 overflow: 0.305 HPWL: 520776 (PD_D1)
-[NesterovSolve] Iter:  660 overflow: 0.737 HPWL: 520776 (PD_D2)
-[NesterovSolve] Iter:  670 overflow: 0.301 HPWL: 523033 (PD_D1)
-[NesterovSolve] Iter:  670 overflow: 0.726 HPWL: 523033 (PD_D2)
-[NesterovSolve] Iter:  680 overflow: 0.296 HPWL: 525730 (PD_D1)
-[NesterovSolve] Iter:  680 overflow: 0.715 HPWL: 525730 (PD_D2)
-[NesterovSolve] Iter:  690 overflow: 0.292 HPWL: 528859 (PD_D1)
-[NesterovSolve] Iter:  690 overflow: 0.705 HPWL: 528859 (PD_D2)
-[NesterovSolve] Iter:  700 overflow: 0.288 HPWL: 533606 (PD_D1)
-[NesterovSolve] Iter:  700 overflow: 0.694 HPWL: 533606 (PD_D2)
-[NesterovSolve] Iter:  710 overflow: 0.284 HPWL: 540072 (PD_D1)
-[NesterovSolve] Iter:  710 overflow: 0.685 HPWL: 540072 (PD_D2)
-[NesterovSolve] Iter:  720 overflow: 0.280 HPWL: 550234 (PD_D1)
-[NesterovSolve] Iter:  720 overflow: 0.675 HPWL: 550234 (PD_D2)
-[NesterovSolve] Iter:  730 overflow: 0.276 HPWL: 574815 (PD_D1)
-[NesterovSolve] Iter:  730 overflow: 0.666 HPWL: 574815 (PD_D2)
-[NesterovSolve] Iter:  740 overflow: 0.272 HPWL: 634775 (PD_D1)
-[NesterovSolve] Iter:  740 overflow: 0.433 HPWL: 634775 (PD_D2)
-[NesterovSolve] Iter:  750 overflow: 0.269 HPWL: 651909 (PD_D1)
-[NesterovSolve] Iter:  750 overflow: 0.427 HPWL: 651909 (PD_D2)
-[NesterovSolve] Iter:  760 overflow: 0.265 HPWL: 679321 (PD_D1)
-[NesterovSolve] Iter:  760 overflow: 0.291 HPWL: 679321 (PD_D2)
-[NesterovSolve] Iter:  770 overflow: 0.262 HPWL: 699366 (PD_D1)
-[NesterovSolve] Iter:  770 overflow: 0.240 HPWL: 699366 (PD_D2)
-[NesterovSolve] Iter:  780 overflow: 0.258 HPWL: 708573 (PD_D1)
-[NesterovSolve] Iter:  780 overflow: 0.192 HPWL: 708573 (PD_D2)
-[NesterovSolve] PowerDomain PD_D2 finished with Overflow: 0.099741
-[NesterovSolve] Iter:  790 overflow: 0.255 HPWL: 723742 (PD_D1)
-[NesterovSolve] Iter:  800 overflow: 0.252 HPWL: 726526 (PD_D1)
-[NesterovSolve] Iter:  810 overflow: 0.249 HPWL: 734537 (PD_D1)
-[NesterovSolve] Iter:  820 overflow: 0.246 HPWL: 757059 (PD_D1)
-[NesterovSolve] Iter:  830 overflow: 0.233 HPWL: 802452 (PD_D1)
-[NesterovSolve] Iter:  840 overflow: 0.170 HPWL: 839377 (PD_D1)
-[NesterovSolve] Iter:  850 overflow: 0.175 HPWL: 830714 (PD_D1)
-[NesterovSolve] Iter:  860 overflow: 0.152 HPWL: 845021 (PD_D1)
-[NesterovSolve] Iter:  870 overflow: 0.150 HPWL: 871420 (PD_D1)
-[NesterovSolve] PowerDomain PD_D1 finished with Overflow: 0.081185
+[NesterovSolve] Iter:    1 overflow: 0.422 HPWL: 1127956
+[NesterovSolve] Iter:    1 overflow: 1.000 HPWL: 1127956 (PD_D1)
+[NesterovSolve] Iter:    1 overflow: 0.167 HPWL: 1127956 (PD_D2)
+[NesterovSolve] Finished with Overflow: 0.081593
+[NesterovSolve] Iter:   10 overflow: 1.000 HPWL: 449530 (PD_D1)
+[NesterovSolve] Iter:   10 overflow: 1.000 HPWL: 449530 (PD_D2)
+[NesterovSolve] Iter:   20 overflow: 1.000 HPWL: 430594 (PD_D1)
+[NesterovSolve] Iter:   20 overflow: 1.000 HPWL: 430594 (PD_D2)
+[NesterovSolve] Iter:   30 overflow: 1.000 HPWL: 428982 (PD_D1)
+[NesterovSolve] Iter:   30 overflow: 1.000 HPWL: 428982 (PD_D2)
+[NesterovSolve] Iter:   40 overflow: 1.000 HPWL: 428824 (PD_D1)
+[NesterovSolve] Iter:   40 overflow: 1.000 HPWL: 428824 (PD_D2)
+[NesterovSolve] Iter:   50 overflow: 1.000 HPWL: 428812 (PD_D1)
+[NesterovSolve] Iter:   50 overflow: 1.000 HPWL: 428812 (PD_D2)
+[NesterovSolve] Iter:   60 overflow: 1.000 HPWL: 428820 (PD_D1)
+[NesterovSolve] Iter:   60 overflow: 1.000 HPWL: 428820 (PD_D2)
+[NesterovSolve] Iter:   70 overflow: 1.000 HPWL: 428823 (PD_D1)
+[NesterovSolve] Iter:   70 overflow: 1.000 HPWL: 428823 (PD_D2)
+[NesterovSolve] Iter:   80 overflow: 1.000 HPWL: 428863 (PD_D1)
+[NesterovSolve] Iter:   80 overflow: 1.000 HPWL: 428863 (PD_D2)
+[NesterovSolve] Iter:   90 overflow: 1.000 HPWL: 428894 (PD_D1)
+[NesterovSolve] Iter:   90 overflow: 1.000 HPWL: 428894 (PD_D2)
+[NesterovSolve] Iter:  100 overflow: 1.000 HPWL: 428954 (PD_D1)
+[NesterovSolve] Iter:  100 overflow: 1.000 HPWL: 428954 (PD_D2)
+[NesterovSolve] Iter:  110 overflow: 1.000 HPWL: 429006 (PD_D1)
+[NesterovSolve] Iter:  110 overflow: 1.000 HPWL: 429006 (PD_D2)
+[NesterovSolve] Iter:  120 overflow: 1.000 HPWL: 429072 (PD_D1)
+[NesterovSolve] Iter:  120 overflow: 1.000 HPWL: 429072 (PD_D2)
+[NesterovSolve] Iter:  130 overflow: 1.000 HPWL: 429167 (PD_D1)
+[NesterovSolve] Iter:  130 overflow: 1.000 HPWL: 429167 (PD_D2)
+[NesterovSolve] Iter:  140 overflow: 1.000 HPWL: 429378 (PD_D1)
+[NesterovSolve] Iter:  140 overflow: 1.000 HPWL: 429378 (PD_D2)
+[NesterovSolve] Iter:  150 overflow: 1.000 HPWL: 429642 (PD_D1)
+[NesterovSolve] Iter:  150 overflow: 1.000 HPWL: 429642 (PD_D2)
+[NesterovSolve] Iter:  160 overflow: 1.000 HPWL: 430052 (PD_D1)
+[NesterovSolve] Iter:  160 overflow: 1.000 HPWL: 430052 (PD_D2)
+[NesterovSolve] Iter:  170 overflow: 1.000 HPWL: 430677 (PD_D1)
+[NesterovSolve] Iter:  170 overflow: 1.000 HPWL: 430677 (PD_D2)
+[NesterovSolve] Iter:  180 overflow: 1.000 HPWL: 431496 (PD_D1)
+[NesterovSolve] Iter:  180 overflow: 1.000 HPWL: 431496 (PD_D2)
+[NesterovSolve] Iter:  190 overflow: 1.000 HPWL: 432453 (PD_D1)
+[NesterovSolve] Iter:  190 overflow: 1.000 HPWL: 432453 (PD_D2)
+[NesterovSolve] Iter:  200 overflow: 1.000 HPWL: 433497 (PD_D1)
+[NesterovSolve] Iter:  200 overflow: 1.000 HPWL: 433497 (PD_D2)
+[NesterovSolve] Iter:  210 overflow: 0.963 HPWL: 434716 (PD_D1)
+[NesterovSolve] Iter:  210 overflow: 1.000 HPWL: 434716 (PD_D2)
+[NesterovSolve] Iter:  220 overflow: 0.919 HPWL: 435824 (PD_D1)
+[NesterovSolve] Iter:  220 overflow: 1.000 HPWL: 435824 (PD_D2)
+[NesterovSolve] Iter:  230 overflow: 0.879 HPWL: 436999 (PD_D1)
+[NesterovSolve] Iter:  230 overflow: 1.000 HPWL: 436999 (PD_D2)
+[NesterovSolve] Iter:  240 overflow: 0.842 HPWL: 437701 (PD_D1)
+[NesterovSolve] Iter:  240 overflow: 1.000 HPWL: 437701 (PD_D2)
+[NesterovSolve] Iter:  250 overflow: 0.808 HPWL: 437642 (PD_D1)
+[NesterovSolve] Iter:  250 overflow: 1.000 HPWL: 437642 (PD_D2)
+[NesterovSolve] Iter:  260 overflow: 0.777 HPWL: 437834 (PD_D1)
+[NesterovSolve] Iter:  260 overflow: 1.000 HPWL: 437834 (PD_D2)
+[NesterovSolve] Iter:  270 overflow: 0.748 HPWL: 437389 (PD_D1)
+[NesterovSolve] Iter:  270 overflow: 1.000 HPWL: 437389 (PD_D2)
+[NesterovSolve] Iter:  280 overflow: 0.721 HPWL: 437334 (PD_D1)
+[NesterovSolve] Iter:  280 overflow: 1.000 HPWL: 437334 (PD_D2)
+[NesterovSolve] Iter:  290 overflow: 0.696 HPWL: 438478 (PD_D1)
+[NesterovSolve] Iter:  290 overflow: 1.000 HPWL: 438478 (PD_D2)
+[NesterovSolve] Iter:  300 overflow: 0.673 HPWL: 437491 (PD_D1)
+[NesterovSolve] Iter:  300 overflow: 1.000 HPWL: 437491 (PD_D2)
+[NesterovSolve] Iter:  310 overflow: 0.651 HPWL: 437969 (PD_D1)
+[NesterovSolve] Iter:  310 overflow: 1.000 HPWL: 437969 (PD_D2)
+[NesterovSolve] Iter:  320 overflow: 0.631 HPWL: 439249 (PD_D1)
+[NesterovSolve] Iter:  320 overflow: 1.000 HPWL: 439249 (PD_D2)
+[NesterovSolve] Iter:  330 overflow: 0.612 HPWL: 440173 (PD_D1)
+[NesterovSolve] Iter:  330 overflow: 1.000 HPWL: 440173 (PD_D2)
+[NesterovSolve] Iter:  340 overflow: 0.594 HPWL: 439733 (PD_D1)
+[NesterovSolve] Iter:  340 overflow: 1.000 HPWL: 439733 (PD_D2)
+[NesterovSolve] Iter:  350 overflow: 0.577 HPWL: 439215 (PD_D1)
+[NesterovSolve] Iter:  350 overflow: 1.000 HPWL: 439215 (PD_D2)
+[NesterovSolve] Iter:  360 overflow: 0.561 HPWL: 438796 (PD_D1)
+[NesterovSolve] Iter:  360 overflow: 1.000 HPWL: 438796 (PD_D2)
+[NesterovSolve] Iter:  370 overflow: 0.545 HPWL: 437061 (PD_D1)
+[NesterovSolve] Iter:  370 overflow: 1.000 HPWL: 437061 (PD_D2)
+[NesterovSolve] Iter:  380 overflow: 0.531 HPWL: 436184 (PD_D1)
+[NesterovSolve] Iter:  380 overflow: 1.000 HPWL: 436184 (PD_D2)
+[NesterovSolve] Iter:  390 overflow: 0.517 HPWL: 436780 (PD_D1)
+[NesterovSolve] Iter:  390 overflow: 1.000 HPWL: 436780 (PD_D2)
+[NesterovSolve] Iter:  400 overflow: 0.504 HPWL: 435760 (PD_D1)
+[NesterovSolve] Iter:  400 overflow: 1.000 HPWL: 435760 (PD_D2)
+[NesterovSolve] Iter:  410 overflow: 0.492 HPWL: 433052 (PD_D1)
+[NesterovSolve] Iter:  410 overflow: 1.000 HPWL: 433052 (PD_D2)
+[NesterovSolve] Iter:  420 overflow: 0.480 HPWL: 432370 (PD_D1)
+[NesterovSolve] Iter:  420 overflow: 0.989 HPWL: 432370 (PD_D2)
+[NesterovSolve] Iter:  430 overflow: 0.469 HPWL: 431444 (PD_D1)
+[NesterovSolve] Iter:  430 overflow: 0.966 HPWL: 431444 (PD_D2)
+[NesterovSolve] Iter:  440 overflow: 0.458 HPWL: 428463 (PD_D1)
+[NesterovSolve] Iter:  440 overflow: 0.944 HPWL: 428463 (PD_D2)
+[NesterovSolve] Iter:  450 overflow: 0.448 HPWL: 428044 (PD_D1)
+[NesterovSolve] Iter:  450 overflow: 0.923 HPWL: 428044 (PD_D2)
+[NesterovSolve] Iter:  460 overflow: 0.438 HPWL: 426119 (PD_D1)
+[NesterovSolve] Iter:  460 overflow: 0.903 HPWL: 426119 (PD_D2)
+[NesterovSolve] Iter:  470 overflow: 0.429 HPWL: 423968 (PD_D1)
+[NesterovSolve] Iter:  470 overflow: 0.884 HPWL: 423968 (PD_D2)
+[NesterovSolve] Iter:  480 overflow: 0.420 HPWL: 424557 (PD_D1)
+[NesterovSolve] Iter:  480 overflow: 0.865 HPWL: 424557 (PD_D2)
+[NesterovSolve] Iter:  490 overflow: 0.412 HPWL: 423705 (PD_D1)
+[NesterovSolve] Iter:  490 overflow: 0.847 HPWL: 423705 (PD_D2)
+[NesterovSolve] Iter:  500 overflow: 0.403 HPWL: 421774 (PD_D1)
+[NesterovSolve] Iter:  500 overflow: 0.830 HPWL: 421774 (PD_D2)
+[NesterovSolve] Iter:  510 overflow: 0.395 HPWL: 421481 (PD_D1)
+[NesterovSolve] Iter:  510 overflow: 0.814 HPWL: 421481 (PD_D2)
+[NesterovSolve] Iter:  520 overflow: 0.388 HPWL: 423114 (PD_D1)
+[NesterovSolve] Iter:  520 overflow: 0.798 HPWL: 423114 (PD_D2)
+[NesterovSolve] Iter:  530 overflow: 0.380 HPWL: 417634 (PD_D1)
+[NesterovSolve] Iter:  530 overflow: 0.783 HPWL: 417634 (PD_D2)
+[NesterovSolve] Iter:  540 overflow: 0.373 HPWL: 417554 (PD_D1)
+[NesterovSolve] Iter:  540 overflow: 0.769 HPWL: 417554 (PD_D2)
+[NesterovSolve] Iter:  550 overflow: 0.367 HPWL: 417645 (PD_D1)
+[NesterovSolve] Iter:  550 overflow: 0.755 HPWL: 417645 (PD_D2)
+[NesterovSolve] Iter:  560 overflow: 0.360 HPWL: 417461 (PD_D1)
+[NesterovSolve] Iter:  560 overflow: 0.741 HPWL: 417461 (PD_D2)
+[NesterovSolve] Iter:  570 overflow: 0.354 HPWL: 417725 (PD_D1)
+[NesterovSolve] Iter:  570 overflow: 0.728 HPWL: 417725 (PD_D2)
+[NesterovSolve] Iter:  580 overflow: 0.348 HPWL: 418865 (PD_D1)
+[NesterovSolve] Iter:  580 overflow: 0.716 HPWL: 418865 (PD_D2)
+[NesterovSolve] Iter:  590 overflow: 0.342 HPWL: 416360 (PD_D1)
+[NesterovSolve] Iter:  590 overflow: 0.704 HPWL: 416360 (PD_D2)
+[NesterovSolve] Iter:  600 overflow: 0.336 HPWL: 416351 (PD_D1)
+[NesterovSolve] Iter:  600 overflow: 0.692 HPWL: 416351 (PD_D2)
+[NesterovSolve] Iter:  610 overflow: 0.330 HPWL: 416452 (PD_D1)
+[NesterovSolve] Iter:  610 overflow: 0.680 HPWL: 416452 (PD_D2)
+[NesterovSolve] Iter:  620 overflow: 0.325 HPWL: 416725 (PD_D1)
+[NesterovSolve] Iter:  620 overflow: 0.669 HPWL: 416725 (PD_D2)
+[NesterovSolve] Iter:  630 overflow: 0.320 HPWL: 417094 (PD_D1)
+[NesterovSolve] Iter:  630 overflow: 0.659 HPWL: 417094 (PD_D2)
+[NesterovSolve] Iter:  640 overflow: 0.315 HPWL: 417133 (PD_D1)
+[NesterovSolve] Iter:  640 overflow: 0.648 HPWL: 417133 (PD_D2)
+[NesterovSolve] Iter:  650 overflow: 0.310 HPWL: 417814 (PD_D1)
+[NesterovSolve] Iter:  650 overflow: 0.638 HPWL: 417814 (PD_D2)
+[NesterovSolve] Iter:  660 overflow: 0.305 HPWL: 418255 (PD_D1)
+[NesterovSolve] Iter:  660 overflow: 0.629 HPWL: 418255 (PD_D2)
+[NesterovSolve] Iter:  670 overflow: 0.301 HPWL: 419078 (PD_D1)
+[NesterovSolve] Iter:  670 overflow: 0.619 HPWL: 419078 (PD_D2)
+[NesterovSolve] Iter:  680 overflow: 0.296 HPWL: 420652 (PD_D1)
+[NesterovSolve] Iter:  680 overflow: 0.610 HPWL: 420652 (PD_D2)
+[NesterovSolve] Iter:  690 overflow: 0.292 HPWL: 421316 (PD_D1)
+[NesterovSolve] Iter:  690 overflow: 0.601 HPWL: 421316 (PD_D2)
+[NesterovSolve] Iter:  700 overflow: 0.288 HPWL: 427503 (PD_D1)
+[NesterovSolve] Iter:  700 overflow: 0.593 HPWL: 427503 (PD_D2)
+[NesterovSolve] Iter:  710 overflow: 0.284 HPWL: 431937 (PD_D1)
+[NesterovSolve] Iter:  710 overflow: 0.584 HPWL: 431937 (PD_D2)
+[NesterovSolve] Iter:  720 overflow: 0.280 HPWL: 435935 (PD_D1)
+[NesterovSolve] Iter:  720 overflow: 0.576 HPWL: 435935 (PD_D2)
+[NesterovSolve] Iter:  730 overflow: 0.276 HPWL: 441967 (PD_D1)
+[NesterovSolve] Iter:  730 overflow: 0.568 HPWL: 441967 (PD_D2)
+[NesterovSolve] Iter:  740 overflow: 0.272 HPWL: 452689 (PD_D1)
+[NesterovSolve] Iter:  740 overflow: 0.561 HPWL: 452689 (PD_D2)
+[NesterovSolve] Iter:  750 overflow: 0.269 HPWL: 464936 (PD_D1)
+[NesterovSolve] Iter:  750 overflow: 0.553 HPWL: 464936 (PD_D2)
+[NesterovSolve] Iter:  760 overflow: 0.265 HPWL: 492164 (PD_D1)
+[NesterovSolve] Iter:  760 overflow: 0.546 HPWL: 492164 (PD_D2)
+[NesterovSolve] Iter:  770 overflow: 0.262 HPWL: 573554 (PD_D1)
+[NesterovSolve] Iter:  770 overflow: 0.446 HPWL: 573554 (PD_D2)
+[NesterovSolve] Iter:  780 overflow: 0.258 HPWL: 602792 (PD_D1)
+[NesterovSolve] Iter:  780 overflow: 0.361 HPWL: 602792 (PD_D2)
+[NesterovSolve] Iter:  790 overflow: 0.255 HPWL: 641170 (PD_D1)
+[NesterovSolve] Iter:  790 overflow: 0.345 HPWL: 641170 (PD_D2)
+[NesterovSolve] Iter:  800 overflow: 0.252 HPWL: 694661 (PD_D1)
+[NesterovSolve] Iter:  800 overflow: 0.169 HPWL: 694661 (PD_D2)
+[NesterovSolve] Iter:  810 overflow: 0.249 HPWL: 682614 (PD_D1)
+[NesterovSolve] Iter:  810 overflow: 0.172 HPWL: 682614 (PD_D2)
+[NesterovSolve] Iter:  820 overflow: 0.246 HPWL: 697716 (PD_D1)
+[NesterovSolve] Iter:  820 overflow: 0.174 HPWL: 697716 (PD_D2)
+[NesterovSolve] Iter:  830 overflow: 0.243 HPWL: 722791 (PD_D1)
+[NesterovSolve] Iter:  830 overflow: 0.176 HPWL: 722791 (PD_D2)
+[NesterovSolve] Iter:  840 overflow: 0.240 HPWL: 769720 (PD_D1)
+[NesterovSolve] Iter:  840 overflow: 0.099 HPWL: 769720 (PD_D2)
+[NesterovSolve] PowerDomain PD_D2 finished with Overflow: 0.099244
+[NesterovSolve] Iter:  850 overflow: 0.237 HPWL: 792572 (PD_D1)
+[NesterovSolve] Iter:  860 overflow: 0.152 HPWL: 852570 (PD_D1)
+[NesterovSolve] Iter:  870 overflow: 0.152 HPWL: 868177 (PD_D1)
+[NesterovSolve] Iter:  880 overflow: 0.148 HPWL: 880757 (PD_D1)
+[NesterovSolve] Iter:  890 overflow: 0.146 HPWL: 917942 (PD_D1)
+[NesterovSolve] Iter:  900 overflow: 0.142 HPWL: 986907 (PD_D1)
+[NesterovSolve] PowerDomain PD_D1 finished with Overflow: 0.077729
 Placement Analysis
 ---------------------------------
-total displacement         81.5 u
-average displacement        3.3 u
-max displacement           45.4 u
-original HPWL             907.2 u
-legalized HPWL            981.7 u
-delta HPWL                    8 %
+total displacement         70.7 u
+average displacement        3.2 u
+max displacement           33.8 u
+original HPWL             996.5 u
+legalized HPWL           1062.3 u
+delta HPWL                    7 %
 
 Detailed placement improvement.
 Importing netlist into detailed improver.
-[INFO DPO-0100] Creating network with 25 cells, 7 terminals, 29 edges, 71 pins, and 0 blockages.
-[INFO DPO-0109] Network stats: inst 32, edges 29, pins 71
+[INFO DPO-0100] Creating network with 22 cells, 7 terminals, 26 edges, 65 pins, and 0 blockages.
+[INFO DPO-0109] Network stats: inst 29, edges 26, pins 65
 [INFO DPO-0110] Number of regions is 3
 [INFO DPO-0401] Setting random seed to 1.
 [INFO DPO-0402] Setting maximum displacement 0 0 to 216200 216200 units.
 [INFO DPO-0320] Collected 31 fixed cells.
-[INFO DPO-0318] Collected 25 single height cells.
+[INFO DPO-0318] Collected 22 single height cells.
 [INFO DPO-0321] Collected 0 wide cells.
 [INFO DPO-0322] Image (2300, 2720) - (110400, 108800)
-[INFO DPO-0310] Assigned 25 cells into segments.  Movement in X-direction is 0.000000, movement in Y-direction is 0.000000.
+[INFO DPO-0310] Assigned 22 cells into segments.  Movement in X-direction is 0.000000, movement in Y-direction is 0.000000.
 [INFO DPO-0313] Found 0 cells in wrong regions.
 [INFO DPO-0315] Found 0 row alignment problems.
 [INFO DPO-0314] Found 0 site alignment problems.
@@ -288,42 +297,40 @@ Importing netlist into detailed improver.
 [INFO DPO-0312] Found 0 edge spacing violations and 0 padding violations.
 [INFO DPO-0303] Running algorithm for independent set matching.
 [INFO DPO-0300] Set matching objective is wirelength.
-[INFO DPO-0301] Pass   1 of matching; objective is 9.826675e+05.
-[INFO DPO-0302] End of matching; objective is 9.826675e+05, improvement is 0.00 percent.
+[INFO DPO-0301] Pass   1 of matching; objective is 1.063798e+06.
+[INFO DPO-0301] Pass   2 of matching; objective is 1.032382e+06.
+[INFO DPO-0302] End of matching; objective is 1.032382e+06, improvement is 2.95 percent.
 [INFO DPO-0303] Running algorithm for global swaps.
-[INFO DPO-0306] Pass   1 of global swaps; hpwl is 9.438200e+05.
-[INFO DPO-0306] Pass   2 of global swaps; hpwl is 9.381225e+05.
-[INFO DPO-0307] End of global swaps; objective is 9.381225e+05, improvement is 4.53 percent.
+[INFO DPO-0306] Pass   1 of global swaps; hpwl is 9.567825e+05.
+[INFO DPO-0306] Pass   2 of global swaps; hpwl is 9.465875e+05.
+[INFO DPO-0306] Pass   3 of global swaps; hpwl is 9.465875e+05.
+[INFO DPO-0307] End of global swaps; objective is 9.465875e+05, improvement is 8.31 percent.
 [INFO DPO-0303] Running algorithm for vertical swaps.
-[INFO DPO-0308] Pass   1 of vertical swaps; hpwl is 9.381225e+05.
-[INFO DPO-0309] End of vertical swaps; objective is 9.381225e+05, improvement is 0.00 percent.
+[INFO DPO-0308] Pass   1 of vertical swaps; hpwl is 9.354800e+05.
+[INFO DPO-0308] Pass   2 of vertical swaps; hpwl is 9.274050e+05.
+[INFO DPO-0309] End of vertical swaps; objective is 9.274050e+05, improvement is 2.03 percent.
 [INFO DPO-0303] Running algorithm for reordering.
-[INFO DPO-0304] Pass   1 of reordering; objective is 9.381225e+05.
-[INFO DPO-0305] End of reordering; objective is 9.381225e+05, improvement is 0.00 percent.
+[INFO DPO-0304] Pass   1 of reordering; objective is 9.264850e+05.
+[INFO DPO-0305] End of reordering; objective is 9.264850e+05, improvement is 0.10 percent.
 [INFO DPO-0303] Running algorithm for random improvement.
 [INFO DPO-0324] Random improver is using displacement generator.
 [INFO DPO-0325] Random improver is using hpwl objective.
 [INFO DPO-0326] Random improver cost string is (a).
-[INFO DPO-0332] End of pass, Generator displacement called 500 times.
-[INFO DPO-0335] Generator displacement, Cumulative attempts 500, swaps 42, moves   442 since last reset.
-[INFO DPO-0333] End of pass, Objective hpwl, Initial cost 9.381225e+05, Scratch cost 9.280175e+05, Incremental cost 9.280575e+05, Mismatch? Y
-[INFO DPO-0338] End of pass, Total cost is 9.280175e+05.
-[INFO DPO-0327] Pass   1 of random improver; improvement in cost is 1.07 percent.
-[INFO DPO-0332] End of pass, Generator displacement called 500 times.
-[INFO DPO-0335] Generator displacement, Cumulative attempts 1000, swaps 84, moves   887 since last reset.
-[INFO DPO-0333] End of pass, Objective hpwl, Initial cost 9.280175e+05, Scratch cost 9.148850e+05, Incremental cost 9.151650e+05, Mismatch? Y
-[INFO DPO-0338] End of pass, Total cost is 9.148850e+05.
-[INFO DPO-0327] Pass   2 of random improver; improvement in cost is 1.38 percent.
-[INFO DPO-0332] End of pass, Generator displacement called 500 times.
-[INFO DPO-0335] Generator displacement, Cumulative attempts 1500, swaps 128, moves  1325 since last reset.
-[INFO DPO-0333] End of pass, Objective hpwl, Initial cost 9.148850e+05, Scratch cost 9.144850e+05, Incremental cost 9.144850e+05, Mismatch? N
-[INFO DPO-0338] End of pass, Total cost is 9.144850e+05.
-[INFO DPO-0327] Pass   3 of random improver; improvement in cost is 0.04 percent.
-[INFO DPO-0328] End of random improver; improvement is 2.519660 percent.
+[INFO DPO-0332] End of pass, Generator displacement called 440 times.
+[INFO DPO-0335] Generator displacement, Cumulative attempts 440, swaps 30, moves   396 since last reset.
+[INFO DPO-0333] End of pass, Objective hpwl, Initial cost 9.264850e+05, Scratch cost 9.001800e+05, Incremental cost 9.001800e+05, Mismatch? N
+[INFO DPO-0338] End of pass, Total cost is 9.001800e+05.
+[INFO DPO-0327] Pass   1 of random improver; improvement in cost is 2.84 percent.
+[INFO DPO-0332] End of pass, Generator displacement called 440 times.
+[INFO DPO-0335] Generator displacement, Cumulative attempts 880, swaps 61, moves   792 since last reset.
+[INFO DPO-0333] End of pass, Objective hpwl, Initial cost 9.001800e+05, Scratch cost 9.001800e+05, Incremental cost 9.001800e+05, Mismatch? N
+[INFO DPO-0338] End of pass, Total cost is 9.001800e+05.
+[INFO DPO-0327] Pass   2 of random improver; improvement in cost is 0.00 percent.
+[INFO DPO-0328] End of random improver; improvement is 2.839226 percent.
 [INFO DPO-0380] Cell flipping.
 [INFO DPO-0382] Changed 0 cell orientations for row compatibility.
-[INFO DPO-0383] Performed 4 cell flips.
-[INFO DPO-0384] End of flipping; objective is 9.098450e+05, improvement is 0.51 percent.
+[INFO DPO-0383] Performed 2 cell flips.
+[INFO DPO-0384] End of flipping; objective is 8.963400e+05, improvement is 0.43 percent.
 [INFO DPO-0313] Found 0 cells in wrong regions.
 [INFO DPO-0315] Found 0 row alignment problems.
 [INFO DPO-0314] Found 0 site alignment problems.
@@ -331,8 +338,8 @@ Importing netlist into detailed improver.
 [INFO DPO-0312] Found 0 edge spacing violations and 0 padding violations.
 Detailed Improvement Results
 ------------------------------------------
-Original HPWL              981.7 u
-Final HPWL                 908.8 u
-Delta HPWL                  -7.4 %
+Original HPWL             1062.3 u
+Final HPWL                 894.7 u
+Delta HPWL                 -15.8 %
 
 No differences found.


### PR DESCRIPTION
The smallest isolation cell was selected without considering whether inverters were needed, so in some cases, the smallest isolation plus the required inverters had a bigger area than the isolation cell that didn't require any inverters.

Changes:
- `find_smallest_isolation` now chooses the smallest area of isolation cell plus the required inverters.
- `isolation_select` test added.
- `use_interface_cell` tcl/upf command:
  - `lib_cells` argument now supports lists;
  - `interface_implementation_name` argument has been added to be UPF 2.1 compliant.
- Additional isolation cells options added to the tests:
  - `test/upf_test`;
  - `test/aes`.