### PR TITLE
grt: clean containers with dbNets data when initializing grid and nets

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -2050,6 +2050,8 @@ void GlobalRouter::initGridAndNets()
   }
   block_ = db_->getChip()->getBlock();
   routes_.clear();
+  nets_to_route_.clear();
+  db_net_map_.clear();
   if (getMaxRoutingLayer() == -1) {
     setMaxRoutingLayer(computeMaxRoutingLayer());
   }


### PR DESCRIPTION
Fix https://github.com/The-OpenROAD-Project/OpenROAD/issues/6926