### PR TITLE
mpl: include boundary penalty in debug table

### DIFF
--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -833,6 +833,10 @@ void SACoreSoftMacro::shrink()
 void SACoreSoftMacro::printResults() const
 {
   reportCoreWeights();
+  report({"Boundary",
+          boundary_weight_,
+          boundary_penalty_,
+          norm_boundary_penalty_});
   report({"Macro Blockage",
           macro_blockage_weight_,
           macro_blockage_penalty_,


### PR DESCRIPTION
Missing line in the table.

Old:
```
  Penalty Type  |  Weight  |  Value  |  Norm. Factor  |  Cost
---------------------------------------------------------------
           Area |   0.1000 |  0.9751 |         1.0000 |  0.0975 
        Outline | 100.0000 |  0.0000 |         4.4037 |  0.0000 
    Wire Length | 100.0000 |  0.1420 |         0.6828 | 20.8028 
       Guidance |  10.0000 |  0.0000 |         1.0000 |  0.0000 
          Fence |  10.0000 |  0.0000 |         1.0000 |  0.0000 
 Macro Blockage |  10.0000 |  0.0000 |         9.8476 |  0.0000 
          Notch |  10.0000 |  0.0000 |         1.0000 |  0.0000 
---------------------------------------------------------------
  Total Cost                                            35.3747 
```

New:
```
  Penalty Type  |  Weight  |  Value  |  Norm. Factor  |  Cost
---------------------------------------------------------------
           Area |   0.1000 |  0.9751 |         1.0000 |  0.0975 
        Outline | 100.0000 |  0.0000 |         4.4037 |  0.0000 
    Wire Length | 100.0000 |  0.1420 |         0.6828 | 20.8028 
       Guidance |  10.0000 |  0.0000 |         1.0000 |  0.0000 
          Fence |  10.0000 |  0.0000 |         1.0000 |  0.0000 
       Boundary |  50.0000 | 78.4780 |       271.0931 | 14.4744 
 Macro Blockage |  10.0000 |  0.0000 |         9.8476 |  0.0000 
          Notch |  10.0000 |  0.0000 |         1.0000 |  0.0000 
---------------------------------------------------------------
  Total Cost                                            35.3747 
```