### PR TITLE
included libomp-15-dev to clang-tidy action

### DIFF
--- a/.github/workflows/github-actions-clang-tidy.yml
+++ b/.github/workflows/github-actions-clang-tidy.yml
@@ -16,7 +16,7 @@ jobs:
         id: review
         with:
           build_dir: './build'
-          cmake_command: cmake . -B build
+          cmake_command: cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on
           config_file: '.clang-tidy'
           exclude: "*/codeGenerator/templates/*"
           split_workflow: true

--- a/.github/workflows/github-actions-clang-tidy.yml
+++ b/.github/workflows/github-actions-clang-tidy.yml
@@ -20,7 +20,7 @@ jobs:
           config_file: '.clang-tidy'
           exclude: "*/codeGenerator/templates/*"
           split_workflow: true
-          apt_packages: libomp-15-dev,libomp-14-dev
+          apt_packages: libomp-15-dev
       - uses: The-OpenROAD-Project/clang-tidy-review/upload@master
         id: upload-review
       - if: steps.review.outputs.total_comments > 0

--- a/.github/workflows/github-actions-clang-tidy.yml
+++ b/.github/workflows/github-actions-clang-tidy.yml
@@ -20,6 +20,7 @@ jobs:
           config_file: '.clang-tidy'
           exclude: "*/codeGenerator/templates/*"
           split_workflow: true
+          apt_packages: libomp-15-dev
       - uses: The-OpenROAD-Project/clang-tidy-review/upload@master
         id: upload-review
       - if: steps.review.outputs.total_comments > 0

--- a/.github/workflows/github-actions-clang-tidy.yml
+++ b/.github/workflows/github-actions-clang-tidy.yml
@@ -20,7 +20,7 @@ jobs:
           config_file: '.clang-tidy'
           exclude: "*/codeGenerator/templates/*"
           split_workflow: true
-          apt_packages: libomp-15-dev
+          apt_packages: libomp-15-dev,libomp-14-dev
       - uses: The-OpenROAD-Project/clang-tidy-review/upload@master
         id: upload-review
       - if: steps.review.outputs.total_comments > 0

--- a/.github/workflows/github-actions-clang-tidy.yml
+++ b/.github/workflows/github-actions-clang-tidy.yml
@@ -16,7 +16,7 @@ jobs:
         id: review
         with:
           build_dir: './build'
-          cmake_command: cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on
+          cmake_command: cmake . -B build
           config_file: '.clang-tidy'
           exclude: "*/codeGenerator/templates/*"
           split_workflow: true


### PR DESCRIPTION
We're seeing linting issues like in this [PR](https://github.com/The-OpenROAD-Project/OpenROAD/pull/6916)
`warning: 'omp.h' file not found [clang-diagnostic-error]`
The underlying problem was that the correct version of libomp was not installed as a dependency.

![image](https://github.com/user-attachments/assets/78c778dc-4897-4077-8f73-50952e4dee11)