### PR TITLE
Add --output-on-failure to ctest in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ def baseTests(String image) {
                 try {
                     catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
                         timeout(time: 10, unit: 'MINUTES') {
-                            sh label: 'Run ctest', script: 'ctest --test-dir build -j $(nproc)';
+                            sh label: 'Run ctest', script: 'ctest --test-dir build -j $(nproc) --output-on-failure';
                         }
                     }
                 } catch (e) {


### PR DESCRIPTION
Add the `--output-on-failure` option to the ctest command in the Jenkinsfile to improve output visibility during test failures.
Currently when tests fail, we don't see the detailed output of the failing test and the test artifacts are not produced leaving us in the dark about the nature of the failure.