### PR TITLE
bazel: run tests in the CI

### DIFF
--- a/.github/workflows/github-actions-bazel-build.yml
+++ b/.github/workflows/github-actions-bazel-build.yml
@@ -32,10 +32,9 @@ jobs:
 
       - name: Build
         run: |
-          # There are no cc_test()s yet, so just build for now.
           # For now, just run, but don't fail the whole CI, as bazel build is
           # experimental at this stage.
-          bazel build --keep_going --show_timestamps --curses=no ... || /bin/true
+          bazel test -c opt --keep_going --show_timestamps --test_output=errors --curses=no --force_pic ... || /bin/true
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
We have now the first tests wired up, let's run them. Switch to `-c opt` mode to not have them time out
(unfortunately, that also means a longer initial build time, but things will be cached)