### PR TITLE
meta: Adds ability to locate bazel runfiles dynamically

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,7 +93,10 @@ cc_binary(
         ":platform_cli": [],
     }),
     visibility = ["//visibility:public"],
-    deps = OPENROAD_BINARY_DEPS + [":openroad_lib_private"],
+    deps = OPENROAD_BINARY_DEPS + [
+        ":openroad_lib_private",
+        "@rules_cc//cc/runfiles",
+    ],
 )
 
 cc_library(
@@ -931,10 +934,10 @@ cc_library(
     ],
     visibility = ["//:__subpackages__"],
     deps = [
-        "//src/odb/src/lef",
-        "//src/odb/src/lef:lefzlib",
         "//src/odb/src/def",
         "//src/odb/src/def:defzlib",
+        "//src/odb/src/lef",
+        "//src/odb/src/lef:lefzlib",
         "//src/utl",
         "@boost.algorithm",
         "@boost.bind",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_flex", version = "0.3.1")
 bazel_dep(name = "rules_bison", version = "0.3.1")
+bazel_dep(name = "rules_cc", version = "0.1.1")
 
 # Not all boost libs are available at the latest version yet, so use a
 # slightly older one that has all we need.

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -60,6 +60,10 @@
 #include <tclExtend.h>
 #endif
 
+#ifdef BAZEL_CURRENT_REPOSITORY
+#include "rules_cc/cc/runfiles/runfiles.h"
+#endif
+
 #include "gui/gui.h"
 #include "ord/Design.h"
 #include "ord/InitOpenRoad.hh"
@@ -240,6 +244,15 @@ int main(int argc, char* argv[])
       break;
     }
   }
+
+#ifdef BAZEL_CURRENT_REPOSITORY
+  using rules_cc::cc::runfiles::Runfiles;
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(
+      Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
+  std::string path = runfiles->Rlocation("tk_tcl/library/");
+  setenv("TCL_LIBRARY", path.c_str(), 0);
+#endif
 
   // Generate a stacktrace on crash
   signal(SIGABRT, handler);


### PR DESCRIPTION
This PR sets TCL_LIBRARY dynamically based on the runfiles location of the binary. Fixing running bazel outside the context of bazel. So that running `./bazel-bin/openroad` works as expected.