### PR TITLE
openroad: fix segfault

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -218,6 +218,10 @@ int main(int argc, char* argv[])
   std::string error;
   std::unique_ptr<Runfiles> runfiles(
       Runfiles::Create(argv[0], BAZEL_CURRENT_REPOSITORY, &error));
+  if (!runfiles) {
+    std::cerr << error << std::endl;
+    return 1;
+  }
   std::string path = runfiles->Rlocation("tk_tcl/library/");
   setenv("TCL_LIBRARY", path.c_str(), 0);
 #endif


### PR DESCRIPTION
fixes #7002

```
$ bazel build -c opt :openroad
$ cp bazel-bin/openroad .
$ ./openroad 
ERROR: external/rules_cc~/cc/runfiles/runfiles.cc(123): cannot find runfiles (argv0="./openroad")
$ echo $?
1
```
