### PR TITLE
Hide reassociateHierFlatNet api from app code, journalling fix.

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -2289,6 +2289,7 @@ void dbNetwork::connectPin(Pin* pin, Net* flat_net, Net* hier_net)
   dbNet* flat_net_db = nullptr;
   dbModNet* hier_net_db = nullptr;
 
+  // connect the flat net first
   if (flat_net) {
     staToDb(flat_net, flat_net_db, hier_net_db);
     if (hier_net_db) {
@@ -2297,7 +2298,6 @@ void dbNetwork::connectPin(Pin* pin, Net* flat_net, Net* hier_net)
                      "Illegal net combination. hierarchical flat net supplied "
                      "as flat net argument to api:connectPin");
     }
-
     if (flat_net_db) {
       if (iterm) {
         iterm->connect(flat_net_db);
@@ -2313,8 +2313,10 @@ void dbNetwork::connectPin(Pin* pin, Net* flat_net, Net* hier_net)
   }
 
   if (hier_net) {
-    staToDb(hier_net, flat_net_db, hier_net_db);
-    if (flat_net_db) {
+    // sanity check to make hier argument is ok
+    dbNet* flat_net_local_check = nullptr;
+    staToDb(hier_net, flat_net_local_check, hier_net_db);
+    if (flat_net_local_check) {
       logger_->error(ORD,
                      2027,
                      "Illegal net combination. flat net supplied as hier net "
@@ -2336,13 +2338,19 @@ void dbNetwork::connectPin(Pin* pin, Net* flat_net, Net* hier_net)
                        "Illegal net combination. hier net expected to be "
                        "hooked to one of iterm, bterm, moditerm, modbterm");
       }
+      // do the house keeping. Mod net must always have the flat net associated
+      // with it.
+      if (flat_net_db) {
+        reassociateHierFlatNet(hier_net_db, flat_net_db, nullptr);
+      }
     }
   }
 }
 
 /*
 Generic pin -> net connection with support for hierarchical
-nets
+nets. If connecting a hierarchical net and associated_flat_net
+not null then reassociate the hierarhical net.
 */
 void dbNetwork::connectPin(Pin* pin, Net* net)
 {
@@ -3606,10 +3614,8 @@ void dbNetwork::hierarchicalConnect(dbITerm* source_pin,
       mod_bterm->setSigType(dbSigType::SIGNAL);
       dbModInst* parent_inst = cur_module->getModInst();
       cur_module = parent_inst->getParent();
-      dbModITerm* mod_iterm
-          = dbModITerm::create(parent_inst, connection_name_o.c_str());
-      mod_iterm->setChildModBTerm(mod_bterm);
-      mod_bterm->setParentModITerm(mod_iterm);
+      dbModITerm* mod_iterm = dbModITerm::create(
+          parent_inst, connection_name_o.c_str(), mod_bterm);
       source_db_mod_net = dbModNet::create(cur_module, connection_name);
       mod_iterm->connect(source_db_mod_net);
       top_net = source_db_mod_net;
@@ -3636,10 +3642,8 @@ void dbNetwork::hierarchicalConnect(dbITerm* source_pin,
       mod_bterm->setSigType(dbSigType::SIGNAL);
       dbModInst* parent_inst = cur_module->getModInst();
       cur_module = parent_inst->getParent();
-      dbModITerm* mod_iterm
-          = dbModITerm::create(parent_inst, connection_name_i.c_str());
-      mod_iterm->setChildModBTerm(mod_bterm);
-      mod_bterm->setParentModITerm(mod_iterm);
+      dbModITerm* mod_iterm = dbModITerm::create(
+          parent_inst, connection_name_i.c_str(), mod_bterm);
       if (cur_module != highest_common_module) {
         dest_db_mod_net = dbModNet::create(cur_module, connection_name);
         mod_iterm->connect(dest_db_mod_net);

--- a/src/dbSta/src/dbReadVerilog.cc
+++ b/src/dbSta/src/dbReadVerilog.cc
@@ -460,7 +460,7 @@ void Verilog2db::makeModITerms(Instance* inst, dbModInst* modinst)
     // we do not need to store the pin names.. But they are
     // assumed to exist in the STA world.
     //
-    dbModITerm* moditerm = dbModITerm::create(modinst, pin_name_string.c_str());
+
     dbModBTerm* modbterm;
     std::string port_name_str = std::move(pin_name_string);
     const size_t last_idx = port_name_str.find_last_of('/');
@@ -469,9 +469,10 @@ void Verilog2db::makeModITerms(Instance* inst, dbModInst* modinst)
     }
     dbModule* module = modinst->getMaster();
     modbterm = module->findModBTerm(port_name_str.c_str());
-    moditerm->setChildModBTerm(modbterm);
-    modbterm->setParentModITerm(moditerm);
-
+    // pass the modbterm into the moditerm creator
+    // so that during journalling we keep the moditerm/modbterm correlation
+    dbModITerm* moditerm
+        = dbModITerm::create(modinst, pin_name_string.c_str(), modbterm);
     debugPrint(logger_,
                utl::ODB,
                "dbReadVerilog",

--- a/src/dbSta/test/cpp/TestHconn.cpp
+++ b/src/dbSta/test/cpp/TestHconn.cpp
@@ -317,8 +317,10 @@ class TestHconn : public ::testing::Test
     inv1_mod_inst
         = dbModInst::create(root_mod, inv1_mod_master, "inv1_mod_inst");
 
-    inv1_mod_inst_i0_miterm = dbModITerm::create(inv1_mod_inst, "i0");
-    inv1_mod_inst_o0_miterm = dbModITerm::create(inv1_mod_inst, "o0");
+    inv1_mod_inst_i0_miterm
+        = dbModITerm::create(inv1_mod_inst, "i0", inv1_mod_i0_port);
+    inv1_mod_inst_o0_miterm
+        = dbModITerm::create(inv1_mod_inst, "o0", inv1_mod_o0_port);
     // correlate the iterms and bterms
     inv1_mod_inst_i0_miterm->setChildModBTerm(inv1_mod_i0_port);
     inv1_mod_i0_port->setParentModITerm(inv1_mod_inst_i0_miterm);

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -8048,7 +8048,9 @@ class dbModITerm : public dbObject
   dbModBTerm* getChildModBTerm() const;
   void connect(dbModNet* modnet);
   void disconnect();
-  static dbModITerm* create(dbModInst* parentInstance, const char* name);
+  static dbModITerm* create(dbModInst* parentInstance,
+                            const char* name,
+                            dbModBTerm* modbterm = nullptr);
   static void destroy(dbModITerm*);
   static dbSet<dbModITerm>::iterator destroy(dbSet<dbModITerm>::iterator& itr);
   static dbModITerm* getModITerm(dbBlock* block, uint dbid);

--- a/src/odb/src/db/dbModBTerm.cpp
+++ b/src/odb/src/db/dbModBTerm.cpp
@@ -272,7 +272,6 @@ dbModBTerm* dbModBTerm::create(dbModule* parentModule, const char* name)
   if (ret) {
     return ret;
   }
-
   _dbModule* module = (_dbModule*) parentModule;
   _dbBlock* block = (_dbBlock*) module->getOwner();
 
@@ -427,8 +426,6 @@ void dbModBTerm::destroy(dbModBTerm* val)
   _dbModule* module = block->_module_tbl->getPtr(_modbterm->_parent);
 
   if (block->_journal) {
-    //    printf("LOG delete dbModBTerm %s %d\n",
-    //	   val -> getName(), val -> getId());
     block->_journal->beginAction(dbJournal::DELETE_OBJECT);
     block->_journal->pushParam(dbModBTermObj);
     block->_journal->pushParam(val->getName());

--- a/src/odb/src/db/dbModITerm.cpp
+++ b/src/odb/src/db/dbModITerm.cpp
@@ -199,7 +199,9 @@ dbModBTerm* dbModITerm::getChildModBTerm() const
   return (dbModBTerm*) par->_modbterm_tbl->getPtr(obj->_child_modbterm);
 }
 
-dbModITerm* dbModITerm::create(dbModInst* parentInstance, const char* name)
+dbModITerm* dbModITerm::create(dbModInst* parentInstance,
+                               const char* name,
+                               dbModBTerm* modbterm)
 {
   _dbModInst* parent = (_dbModInst*) parentInstance;
   _dbBlock* block = (_dbBlock*) parent->getOwner();
@@ -227,8 +229,18 @@ dbModITerm* dbModITerm::create(dbModInst* parentInstance, const char* name)
     block->_journal->pushParam(dbModITermObj);
     block->_journal->pushParam(name);
     block->_journal->pushParam(moditerm->getId());
+    if (modbterm) {
+      block->_journal->pushParam(modbterm->getId());
+    } else {
+      block->_journal->pushParam(0U);
+    }
     block->_journal->pushParam(parent->getId());
     block->_journal->endAction();
+  }
+
+  if (modbterm) {
+    ((dbModITerm*) moditerm)->setChildModBTerm(modbterm);
+    modbterm->setParentModITerm(((dbModITerm*) moditerm));
   }
 
   return (dbModITerm*) moditerm;
@@ -320,6 +332,7 @@ void dbModITerm::destroy(dbModITerm* val)
     block->_journal->pushParam(dbModITermObj);
     block->_journal->pushParam(val->getName());
     block->_journal->pushParam(val->getId());
+    block->_journal->pushParam(_moditerm->_child_modbterm);
     block->_journal->pushParam(_moditerm->_parent);
     block->_journal->endAction();
   }

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -661,21 +661,14 @@ bool RepairDesign::performGainBuffering(Net* net,
     Pin* buffer_op_pin = nullptr;
     resizer_->getBufferPins(inst, buffer_ip_pin, buffer_op_pin);
     db_network_->connectPin(buffer_ip_pin, net);
-    // connect the buffer output to the new flat net.
+
+    // connect the buffer output to the new flat net and any modnet
     // Keep the original input net driving the buffer.
-    // Note that this means we have to change the
-    // hierarchical net/flat net correspondence because
+    // Update the hierarchical net/flat net correspondence because
     // the hierarhical net is moved to the output of the buffer.
-    db_network_->connectPin(buffer_op_pin, new_net);
-    // put the mod net on the output of the buffer.
-    if (driver_mod_net) {
-      db_network_->connectPin(buffer_op_pin,
-                              db_network_->dbToSta(driver_mod_net));
-      // Because we have rewired the hierarchical net (and changed the
-      // underlying flat net) we have to reassociate the hierarchical net with
-      // the flat net.
-      db_network_->reassociateHierFlatNet(driver_mod_net, new_net_db, nullptr);
-    }
+
+    db_network_->connectPin(
+        buffer_op_pin, new_net, db_network_->dbToSta(driver_mod_net));
 
     repaired_net = true;
     inserted_buffer_count_++;
@@ -692,18 +685,12 @@ bool RepairDesign::performGainBuffering(Net* net,
 
       odb::dbModNet* sink_mod_net = db_network_->hierNet(sink_pin);
       // rewire the sink pin, taking care of both the flat net
-      // and the hierarchical net.
+      // and the hierarchical net. Update the hierarchical net
+      // flat net correspondence
       db_network_->disconnectPin(sink_pin);
-      db_network_->connectPin(sink_pin, db_network_->dbToSta(new_net_db));
-
-      if (sink_mod_net) {
-        db_network_->connectPin(sink_pin, db_network_->dbToSta(sink_mod_net));
-        // because we have changed the flat net on the sink pin, we
-        // have to update the association of the hierarchical net
-        // on the sink pin with the flat net.
-        db_network_->reassociateHierFlatNet(sink_mod_net, new_net_db, nullptr);
-      }
-
+      db_network_->connectPin(sink_pin,
+                              db_network_->dbToSta(new_net_db),
+                              db_network_->dbToSta(sink_mod_net));
       if (it->level == 0) {
         Pin* new_pin = network_->findPin(sink_inst, sink_port);
         tree_boundary.push_back(graph_->pinLoadVertex(new_pin));


### PR DESCRIPTION
1. Hide the reassociateHierNet api (gainBuffer)in resizer.cc
2. Update create moditerm so moditerm/modbterm correlation available to journaller.
3. Update journaller to support moditer/modbterm correlation on undo.