### PR TITLE
Use pattern_formatter.h from details when using spdlog < 1.6.1

### DIFF
--- a/src/utl/src/Logger.cpp
+++ b/src/utl/src/Logger.cpp
@@ -9,7 +9,11 @@
 #include <string_view>
 
 #include "CommandLineProgress.h"
+#if SPDLOG_VERSION < 10601
+#include "spdlog/details/pattern_formatter.h"
+#else
 #include "spdlog/pattern_formatter.h"
+#endif
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ostream_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"


### PR DESCRIPTION
When using a system spdlog library with version < 1.6.1 (e.g. [ubuntu 20.04 focal](https://packages.ubuntu.com/focal/libspdlog-dev)), compiling OpenROAD fails.

This is due to a [location change of `spdlog/details/pattern_formatter.h` to `spdlog/pattern_formatter.h`](https://github.com/gabime/spdlog/commit/752d5685dce44307bf3b0db9673f385628a32af0#diff-bbb51ff727831e269d19b7faac49198b7194a9d859ae2434df2e58f40219bd2b). I added a preprocessor directive to `src/utl/src/Logger.cpp` to support both locations.