### PR TITLE
bazel: configure timeout times in .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,9 @@ common --enable_workspace  # explicitly currently still needing this
 # versions found in dependency graph.
 common --check_direct_dependencies=off
 
+# Test timeouts for various levels.
+test --test_timeout=300,1800,1800,9600
+
 # bazel 7 is somewhat forgiving for glob patterns that don't
 # match, but bazel 8 will be strict. So start now.
 common --incompatible_disallow_empty_glob

--- a/.github/workflows/github-actions-bazel-build.yml
+++ b/.github/workflows/github-actions-bazel-build.yml
@@ -32,8 +32,6 @@ jobs:
 
       - name: Build
         run: |
-          # Timeout is not per test, but for the entire CI job. Running
-          # times are tracked in ORFS tests over time.
           bazel test \
            -c opt \
            --keep_going \
@@ -41,7 +39,6 @@ jobs:
            --test_output=errors \
            --curses=no \
            --force_pic \
-           --test_timeout=3600,3600,3600,3600 \
            ...
 
       - name: Smoke test


### PR DESCRIPTION
... so that it is not necessary to remember the flag everyt time one runs the flow tests.