### PR TITLE
Don't use `using std::something` in header files.

### DIFF
--- a/src/dpl/include/dpl/Coordinates.h
+++ b/src/dpl/include/dpl/Coordinates.h
@@ -12,8 +12,6 @@
 
 namespace dpl {
 
-using std::abs;
-
 // Strongly type the difference between pixel and DBU locations.
 //
 // Multiplication and division are intentionally not defined as they

--- a/src/dpl/include/dpl/Objects.h
+++ b/src/dpl/include/dpl/Objects.h
@@ -151,15 +151,15 @@ class Group
 {
  public:
   // getters
-  string getName() const;
-  const vector<Rect>& getRects() const;
-  vector<Node*> getCells() const;
+  std::string getName() const;
+  const std::vector<Rect>& getRects() const;
+  std::vector<Node*> getCells() const;
   const Rect& getBBox() const;
   double getUtil() const;
   int getId() const;
   // setters
   void setId(int id);
-  void setName(const string& in);
+  void setName(const std::string& in);
   void addRect(const Rect& in);
   void addCell(Node* cell);
   void setBoundary(const Rect& in);
@@ -167,9 +167,9 @@ class Group
 
  private:
   int id_;
-  string name_;
-  vector<Rect> region_boundaries_;
-  vector<Node*> cells_;
+  std::string name_;
+  std::vector<Rect> region_boundaries_;
+  std::vector<Node*> cells_;
   Rect boundary_;
   double util_{0.0};
 };

--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -23,12 +23,6 @@ class Logger;
 
 namespace dpl {
 
-using std::map;
-using std::pair;
-using std::set;
-using std::string;
-using std::vector;
-
 using utl::Logger;
 
 using odb::dbBlock;
@@ -74,7 +68,7 @@ struct GridPt;
 struct DbuPt;
 struct DbuRect;
 
-using dbMasterSeq = vector<dbMaster*>;
+using dbMasterSeq = std::vector<dbMaster*>;
 
 using IRDropByPoint = std::map<odb::Point, double>;
 struct GapInfo;
@@ -114,7 +108,7 @@ class Opendp
   int padLeft(dbInst* inst) const;
   int padRight(dbInst* inst) const;
 
-  void checkPlacement(bool verbose, const string& report_file_name = "");
+  void checkPlacement(bool verbose, const std::string& report_file_name = "");
   void fillerPlacement(dbMasterSeq* filler_masters,
                        const char* prefix,
                        bool verbose);
@@ -142,11 +136,11 @@ class Opendp
                                       boost::geometry::index::quadratic<16>>;
 
   // gap -> sequence of masters to fill the gap
-  using GapFillers = vector<dbMasterSeq>;
+  using GapFillers = std::vector<dbMasterSeq>;
 
   using MasterByImplant = std::map<dbTechLayer*, dbMasterSeq>;
 
-  using YCoordToGap = std::map<DbuY, vector<GapInfo*>>;
+  using YCoordToGap = std::map<DbuY, std::vector<GapInfo*>>;
 
   friend class OpendpTest_IsPlaced_Test;
   friend class Graphics;
@@ -209,7 +203,8 @@ class Opendp
                          const DbuPt& legal_pt,
                          const Rect& block_bbox) const;
 
-  void findOverlapInRtree(const bgBox& queryBox, vector<bgBox>& overlaps) const;
+  void findOverlapInRtree(const bgBox& queryBox,
+                          std::vector<bgBox>& overlaps) const;
   bool moveHopeless(const Node* cell, GridX& grid_x, GridY& grid_y) const;
   void placeGroups();
   void prePlace();
@@ -237,26 +232,26 @@ class Opendp
   static bool isOverlapPadded(const Node* cell1, const Node* cell2);
   static bool isCrWtBlClass(const Node* cell);
   static bool isWellTap(const Node* cell);
-  void reportFailures(const vector<Node*>& failures,
+  void reportFailures(const std::vector<Node*>& failures,
                       int msg_id,
                       const char* msg,
                       bool verbose) const;
   void reportFailures(
-      const vector<Node*>& failures,
+      const std::vector<Node*>& failures,
       int msg_id,
       const char* msg,
       bool verbose,
       const std::function<void(Node* cell)>& report_failure) const;
   void reportOverlapFailure(Node* cell) const;
-  void saveFailures(const vector<Node*>& placed_failures,
-                    const vector<Node*>& in_rows_failures,
-                    const vector<Node*>& overlap_failures,
-                    const vector<Node*>& one_site_gap_failures,
-                    const vector<Node*>& site_align_failures,
-                    const vector<Node*>& region_placement_failures,
-                    const vector<Node*>& placement_failures,
-                    const vector<Node*>& edge_spacing_failures);
-  void writeJsonReport(const string& filename);
+  void saveFailures(const std::vector<Node*>& placed_failures,
+                    const std::vector<Node*>& in_rows_failures,
+                    const std::vector<Node*>& overlap_failures,
+                    const std::vector<Node*>& one_site_gap_failures,
+                    const std::vector<Node*>& site_align_failures,
+                    const std::vector<Node*>& region_placement_failures,
+                    const std::vector<Node*>& placement_failures,
+                    const std::vector<Node*>& edge_spacing_failures);
+  void writeJsonReport(const std::string& filename);
 
   void rectDist(const Node* cell,
                 const Rect& rect,
@@ -285,11 +280,11 @@ class Opendp
   const char* gridInstName(GridY row, GridX col);
 
   // Place decaps
-  vector<int> findDecapCellIndices(const DbuX& gap_width,
-                                   const double& current,
-                                   const double& target);
+  std::vector<int> findDecapCellIndices(const DbuX& gap_width,
+                                        const double& current,
+                                        const double& target);
   void insertDecapInPos(dbMaster* master, const DbuX& pos_x, const DbuY& pos_y);
-  void insertDecapInRow(const vector<GapInfo*>& gaps,
+  void insertDecapInRow(const std::vector<GapInfo*>& gaps,
                         DbuY gap_y,
                         DbuX irdrop_x,
                         DbuY irdrop_y,
@@ -310,17 +305,17 @@ class Opendp
   std::shared_ptr<Padding> padding_;
   std::unique_ptr<PlacementDRC> drc_engine_;
 
-  vector<Node> cells_;
-  vector<Group> groups_;
+  std::vector<Node> cells_;
+  std::vector<Group> groups_;
 
-  map<const dbMaster*, Master> db_master_map_;
-  map<dbInst*, Node*> db_inst_map_;
+  std::map<const dbMaster*, Master> db_master_map_;
+  std::map<dbInst*, Node*> db_inst_map_;
 
   bool have_multi_row_cells_ = false;
   int max_displacement_x_ = 0;  // sites
   int max_displacement_y_ = 0;  // sites
   bool disallow_one_site_gaps_ = false;
-  vector<Node*> placement_failures_;
+  std::vector<Node*> placement_failures_;
 
   // 2D pixel grid
   std::unique_ptr<Grid> grid_;
@@ -328,12 +323,12 @@ class Opendp
 
   // Filler placement.
   // gap (in sites) -> seq of masters by implant
-  map<dbTechLayer*, GapFillers> gap_fillers_;
-  map<dbMaster*, int> filler_count_;
+  std::map<dbTechLayer*, GapFillers> gap_fillers_;
+  std::map<dbMaster*, int> filler_count_;
   bool have_fillers_ = false;
 
   // Decap placement.
-  vector<DecapCell*> decap_masters_;
+  std::vector<DecapCell*> decap_masters_;
   int decap_count_ = 0;
   YCoordToGap gaps_;
 

--- a/src/dpl/include/dpl/OptMirror.h
+++ b/src/dpl/include/dpl/OptMirror.h
@@ -18,9 +18,6 @@ using odb::dbInst;
 using odb::dbNet;
 using odb::Rect;
 
-using std::unordered_map;
-using std::vector;
-
 using utl::Logger;
 
 class NetBox
@@ -38,8 +35,8 @@ class NetBox
   bool ignore_ = false;
 };
 
-using NetBoxMap = unordered_map<dbNet*, NetBox>;
-using NetBoxes = vector<NetBox*>;
+using NetBoxMap = std::unordered_map<dbNet*, NetBox>;
+using NetBoxes = std::vector<NetBox*>;
 
 class OptimizeMirroring
 {
@@ -49,7 +46,7 @@ class OptimizeMirroring
   void run();
 
  private:
-  int mirrorCandidates(vector<dbInst*>& mirror_candidates);
+  int mirrorCandidates(std::vector<dbInst*>& mirror_candidates);
   void findNetBoxes();
   std::vector<dbInst*> findMirrorCandidates(NetBoxes& net_boxes);
 

--- a/src/dpl/include/dpl/Padding.h
+++ b/src/dpl/include/dpl/Padding.h
@@ -3,6 +3,9 @@
 
 #pragma once
 
+#include <map>
+#include <utility>
+
 #include "Coordinates.h"
 #include "Opendp.h"
 
@@ -28,8 +31,8 @@ class Padding
   DbuX paddedWidth(const Node* cell) const;
 
  private:
-  using InstPaddingMap = map<dbInst*, pair<GridX, GridX>>;
-  using MasterPaddingMap = map<dbMaster*, pair<GridX, GridX>>;
+  using InstPaddingMap = std::map<dbInst*, std::pair<GridX, GridX>>;
+  using MasterPaddingMap = std::map<dbMaster*, std::pair<GridX, GridX>>;
 
   GridX pad_left_{0};
   GridX pad_right_{0};

--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -21,17 +21,18 @@ using utl::DPL;
 
 using utl::format_as;
 
-void Opendp::checkPlacement(const bool verbose, const string& report_file_name)
+void Opendp::checkPlacement(const bool verbose,
+                            const std::string& report_file_name)
 {
   importDb();
 
-  vector<Node*> placed_failures;
-  vector<Node*> in_rows_failures;
-  vector<Node*> overlap_failures;
-  vector<Node*> one_site_gap_failures;
-  vector<Node*> site_align_failures;
-  vector<Node*> region_placement_failures;
-  vector<Node*> edge_spacing_failures;
+  std::vector<Node*> placed_failures;
+  std::vector<Node*> in_rows_failures;
+  std::vector<Node*> overlap_failures;
+  std::vector<Node*> one_site_gap_failures;
+  std::vector<Node*> site_align_failures;
+  std::vector<Node*> region_placement_failures;
+  std::vector<Node*> edge_spacing_failures;
 
   initGrid();
   groupAssignCellRegions();
@@ -116,7 +117,7 @@ void Opendp::checkPlacement(const bool verbose, const string& report_file_name)
 
 void Opendp::saveViolations(const std::vector<Node*>& failures,
                             odb::dbMarkerCategory* category,
-                            const string& violation_type) const
+                            const std::string& violation_type) const
 {
   const Rect core = grid_->getCore();
   for (auto failure : failures) {
@@ -233,7 +234,7 @@ void Opendp::saveFailures(const vector<Node*>& placed_failures,
   }
 }
 
-void Opendp::writeJsonReport(const string& filename)
+void Opendp::writeJsonReport(const std::string& filename)
 {
   auto* tool_category = block_->findMarkerCategory("DPL");
   if (tool_category) {

--- a/src/dpl/src/DecapPlacement.cpp
+++ b/src/dpl/src/DecapPlacement.cpp
@@ -29,11 +29,11 @@ void Opendp::addDecapMaster(dbMaster* decap_master, double decap_cap)
 }
 
 // Return list of decap indices to fill gap
-vector<int> Opendp::findDecapCellIndices(const DbuX& gap_width,
-                                         const double& current,
-                                         const double& target)
+std::vector<int> Opendp::findDecapCellIndices(const DbuX& gap_width,
+                                              const double& current,
+                                              const double& target)
 {
-  vector<int> id_masters;
+  std::vector<int> id_masters;
   double cap_acum = 0.0;
   int width_acum = 0;
   const DbuX site_width = grid_->getSiteWidth();
@@ -160,7 +160,7 @@ void Opendp::insertDecapCells(const double target, IRDropByPoint& psm_ir_drops)
                 total_cap);
 }
 
-void Opendp::insertDecapInRow(const vector<GapInfo*>& gaps,
+void Opendp::insertDecapInRow(const std::vector<GapInfo*>& gaps,
                               const DbuY gap_y,
                               const DbuX irdrop_x,
                               const DbuY irdrop_y,
@@ -198,7 +198,7 @@ void Opendp::insertDecapInPos(dbMaster* master,
                               const DbuY& pos_y)
 {
   // insert decap inst
-  string inst_name = "DECAP_" + to_string(decap_count_);
+  std::string inst_name = "DECAP_" + to_string(decap_count_);
   dbInst* inst = dbInst::create(block_,
                                 master,
                                 inst_name.c_str(),

--- a/src/dpl/src/FillerPlacement.cpp
+++ b/src/dpl/src/FillerPlacement.cpp
@@ -178,7 +178,8 @@ void Opendp::placeRowFillers(GridY row,
       debugPrint(
           logger_, DPL, "filler", 2, "fillers size is {}.", fillers.size());
       for (dbMaster* master : fillers) {
-        string inst_name = prefix + to_string(row.v) + "_" + to_string(k.v);
+        std::string inst_name
+            = prefix + to_string(row.v) + "_" + to_string(k.v);
         dbInst* inst = dbInst::create(block_,
                                       master,
                                       inst_name.c_str(),

--- a/src/dpl/src/Objects.cpp
+++ b/src/dpl/src/Objects.cpp
@@ -394,15 +394,15 @@ bool Node::adjustCurrOrient(const dbOrientType& newOri)
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 
-string Group::getName() const
+std::string Group::getName() const
 {
   return name_;
 }
-const vector<Rect>& Group::getRects() const
+const std::vector<Rect>& Group::getRects() const
 {
   return region_boundaries_;
 }
-vector<Node*> Group::getCells() const
+std::vector<Node*> Group::getCells() const
 {
   return cells_;
 }
@@ -422,7 +422,7 @@ void Group::setId(int id)
 {
   id_ = id;
 }
-void Group::setName(const string& in)
+void Group::setName(const std::string& in)
 {
   name_ = in;
 }

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -240,7 +240,7 @@ void Opendp::deleteGrid()
 }
 
 void Opendp::findOverlapInRtree(const bgBox& queryBox,
-                                vector<bgBox>& overlaps) const
+                                std::vector<bgBox>& overlaps) const
 {
   overlaps.clear();
   regions_rtree_.query(boost::geometry::index::intersects(queryBox),

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -66,7 +66,7 @@ void OptimizeMirroring::run()
          return net_box1->hpwl() > net_box2->hpwl();
        });
 
-  vector<dbInst*> mirror_candidates = findMirrorCandidates(sorted_boxes);
+  std::vector<dbInst*> mirror_candidates = findMirrorCandidates(sorted_boxes);
   odb::WireLengthEvaluator eval(block_);
   int64_t hpwl_before = eval.hpwl();
   int mirror_count = mirrorCandidates(mirror_candidates);
@@ -110,9 +110,10 @@ void OptimizeMirroring::findNetBoxes()
   }
 }
 
-vector<dbInst*> OptimizeMirroring::findMirrorCandidates(NetBoxes& net_boxes)
+std::vector<dbInst*> OptimizeMirroring::findMirrorCandidates(
+    NetBoxes& net_boxes)
 {
-  vector<dbInst*> mirror_candidates;
+  std::vector<dbInst*> mirror_candidates;
   unordered_set<dbInst*> existing;
   // Find inst terms on the boundary of the net boxes.
   for (NetBox* net_box : net_boxes) {
@@ -143,7 +144,7 @@ vector<dbInst*> OptimizeMirroring::findMirrorCandidates(NetBoxes& net_boxes)
   return mirror_candidates;
 }
 
-int OptimizeMirroring::mirrorCandidates(vector<dbInst*>& mirror_candidates)
+int OptimizeMirroring::mirrorCandidates(std::vector<dbInst*>& mirror_candidates)
 {
   int mirror_count = 0;
   for (dbInst* inst : mirror_candidates) {

--- a/src/dpl/src/dbToOpendp.cpp
+++ b/src/dpl/src/dbToOpendp.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cfloat>
 #include <limits>
+#include <map>
+#include <set>
 #include <string>
 #include <unordered_set>
 
@@ -322,7 +324,7 @@ void Opendp::makeGroups()
       continue;
     }
     std::set<DbuY> unique_heights;
-    map<DbuY, Group*> cell_height_to_group_map;
+    std::map<DbuY, Group*> cell_height_to_group_map;
     for (auto db_inst : db_group->getInsts()) {
       unique_heights.insert(db_inst_map_[db_inst]->getHeight());
     }

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -30,10 +30,6 @@ class SpefWriter;
 
 namespace rsz {
 
-using std::array;
-using std::string;
-using std::vector;
-
 using utl::Logger;
 
 using odb::dbBlock;
@@ -120,7 +116,7 @@ class NetHash
 };
 
 using CellTargetLoadMap = Map<LibertyCell*, float>;
-using TgtSlews = array<Slew, RiseFall::index_count>;
+using TgtSlews = std::array<Slew, RiseFall::index_count>;
 
 enum class ParasiticsSrc
 {
@@ -389,7 +385,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   // Return net slack, if any (indicated by the bool).
   std::optional<Slack> resizeNetSlack(const Net* net);
   // db flavor
-  vector<dbNet*> resizeWorstSlackDbNets();
+  std::vector<dbNet*> resizeWorstSlackDbNets();
   std::optional<Slack> resizeNetSlack(const dbNet* db_net);
 
   ////////////////////////////////////////////////////////////////
@@ -442,7 +438,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   void findFastBuffers();
   bool isLinkCell(LibertyCell* cell) const;
   void findTargetLoads();
-  void balanceBin(const vector<odb::dbInst*>& bin,
+  void balanceBin(const std::vector<odb::dbInst*>& bin,
                   const std::set<odb::dbSite*>& base_sites);
 
   //==============================
@@ -563,10 +559,10 @@ class Resizer : public dbStaState, public dbNetworkObserver
                          double wire_length,  // meters
                          const Corner* corner,
                          Parasitics* parasitics);
-  string makeUniqueNetName(Instance* parent = nullptr);
+  std::string makeUniqueNetName(Instance* parent = nullptr);
   Net* makeUniqueNet();
-  string makeUniqueInstName(const char* base_name);
-  string makeUniqueInstName(const char* base_name, bool underscore);
+  std::string makeUniqueInstName(const char* base_name);
+  std::string makeUniqueInstName(const char* base_name, bool underscore);
   bool overMaxArea();
   bool bufferBetweenPorts(Instance* buffer);
   bool hasPort(const Net* net);
@@ -706,14 +702,14 @@ class Resizer : public dbStaState, public dbNetworkObserver
   std::unique_ptr<AbstractSteinerRenderer> steiner_renderer_;
 
   // Layer RC per wire length indexed by layer->getNumber(), corner->index
-  vector<vector<double>> layer_res_;  // ohms/meter
-  vector<vector<double>> layer_cap_;  // Farads/meter
+  std::vector<std::vector<double>> layer_res_;  // ohms/meter
+  std::vector<std::vector<double>> layer_cap_;  // Farads/meter
   // Signal wire RC indexed by corner->index
-  vector<ParasiticsResistance> wire_signal_res_;   // ohms/metre
-  vector<ParasiticsCapacitance> wire_signal_cap_;  // Farads/meter
+  std::vector<ParasiticsResistance> wire_signal_res_;   // ohms/metre
+  std::vector<ParasiticsCapacitance> wire_signal_cap_;  // Farads/meter
   // Clock wire RC.
-  vector<ParasiticsResistance> wire_clk_res_;   // ohms/metre
-  vector<ParasiticsCapacitance> wire_clk_cap_;  // Farads/meter
+  std::vector<ParasiticsResistance> wire_clk_res_;   // ohms/metre
+  std::vector<ParasiticsCapacitance> wire_clk_cap_;  // Farads/meter
   LibertyCellSet dont_use_;
   double max_area_ = 0.0;
 

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -190,7 +190,7 @@ void BufferedNet::reportTree(const int level, const Resizer* resizer) const
   }
 }
 
-string BufferedNet::to_string(const Resizer* resizer) const
+std::string BufferedNet::to_string(const Resizer* resizer) const
 {
   Network* sdc_network = resizer->sdcNetwork();
   Units* units = resizer->units();
@@ -377,7 +377,7 @@ BufferedNetPtr Resizer::makeBufferedNet(const Pin* drvr_pin,
   return nullptr;
 }
 
-using SteinerPtAdjacents = vector<vector<SteinerPt>>;
+using SteinerPtAdjacents = std::vector<std::vector<SteinerPt>>;
 using SteinerPtPinVisited = std::unordered_set<Point, PointHash, PointEqual>;
 
 static BufferedNetPtr makeBufferedNetFromTree(
@@ -515,8 +515,8 @@ class RoutePtEqual
   bool operator()(const RoutePt& pt1, const RoutePt& pt2) const;
 };
 
-using GRoutePtAdjacents
-    = std::unordered_map<RoutePt, vector<RoutePt>, RoutePtHash, RoutePtEqual>;
+using GRoutePtAdjacents = std::
+    unordered_map<RoutePt, std::vector<RoutePt>, RoutePtHash, RoutePtEqual>;
 
 size_t RoutePtHash::operator()(const RoutePt& pt) const
 {

--- a/src/rsz/src/BufferedNet.hh
+++ b/src/rsz/src/BufferedNet.hh
@@ -16,9 +16,6 @@
 
 namespace rsz {
 
-using std::array;
-using std::string;
-
 using utl::Logger;
 
 using odb::Point;
@@ -41,7 +38,7 @@ class RepairSetup;
 
 class BufferedNet;
 using BufferedNetPtr = std::shared_ptr<BufferedNet>;
-using Requireds = array<Required, RiseFall::index_count>;
+using Requireds = std::array<Required, RiseFall::index_count>;
 
 enum class BufferedNetType
 {
@@ -83,7 +80,7 @@ class BufferedNet
               const BufferedNetPtr& ref,
               const Corner* corner,
               const Resizer* resizer);
-  string to_string(const Resizer* resizer) const;
+  std::string to_string(const Resizer* resizer) const;
   void reportTree(const Resizer* resizer) const;
   void reportTree(int level, const Resizer* resizer) const;
   BufferedNetType type() const { return type_; }

--- a/src/rsz/src/RecoverPower.hh
+++ b/src/rsz/src/RecoverPower.hh
@@ -18,8 +18,6 @@ namespace rsz {
 
 class Resizer;
 
-using std::vector;
-
 using utl::Logger;
 
 using sta::Corner;
@@ -41,7 +39,7 @@ using sta::Vertex;
 class BufferedNet;
 enum class BufferedNetType;
 using BufferedNetPtr = std::shared_ptr<BufferedNet>;
-using BufferedNetSeq = vector<BufferedNetPtr>;
+using BufferedNetSeq = std::vector<BufferedNetPtr>;
 
 class RecoverPower : public sta::dbStaState
 {

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -648,7 +648,7 @@ bool RepairDesign::performGainBuffering(Net* net,
     dbNet* new_net_db = db_network_->staToDb(new_net);
     new_net_db->setSigType(net_db->getSigType());
 
-    string buffer_name = resizer_->makeUniqueInstName("gain");
+    std::string buffer_name = resizer_->makeUniqueInstName("gain");
     const Point drvr_loc = db_network_->location(drvr_pin);
 
     // create instance in driver parent
@@ -1903,7 +1903,7 @@ bool RepairDesign::makeRepeater(
 {
   LibertyPort *buffer_input_port, *buffer_output_port;
   buffer_cell->bufferPorts(buffer_input_port, buffer_output_port);
-  string buffer_name = resizer_->makeUniqueInstName(reason);
+  std::string buffer_name = resizer_->makeUniqueInstName(reason);
 
   debugPrint(logger_,
              RSZ,

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -19,8 +19,6 @@ namespace rsz {
 class Resizer;
 enum class ParasiticsSrc;
 
-using std::vector;
-
 using sta::Corner;
 using sta::dbNetwork;
 using sta::dbSta;
@@ -45,7 +43,7 @@ class LoadRegion
 
   PinSeq pins_;
   Rect bbox_;  // dbu
-  vector<LoadRegion> regions_;
+  std::vector<LoadRegion> regions_;
 };
 
 class RepairDesign : dbStaState

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -22,8 +22,6 @@ class Resizer;
 class RemoveBuffer;
 
 using odb::Point;
-using std::pair;
-using std::vector;
 using utl::Logger;
 
 using sta::Corner;
@@ -48,7 +46,7 @@ using sta::Vertex;
 class BufferedNet;
 enum class BufferedNetType;
 using BufferedNetPtr = std::shared_ptr<BufferedNet>;
-using BufferedNetSeq = vector<BufferedNetPtr>;
+using BufferedNetSeq = std::vector<BufferedNetPtr>;
 struct SlackEstimatorParams
 {
   Pin* driver_pin;
@@ -158,7 +156,7 @@ class RepairSetup : public sta::dbStaState
                   PathExpanded* expanded);
   Point computeCloneGateLocation(
       const Pin* drvr_pin,
-      const vector<pair<Vertex*, Slack>>& fanout_slacks);
+      const std::vector<std::pair<Vertex*, Slack>>& fanout_slacks);
   bool cloneDriver(const PathRef* drvr_path,
                    int drvr_index,
                    Slack drvr_slack,

--- a/src/rsz/src/SteinerTree.cc
+++ b/src/rsz/src/SteinerTree.cc
@@ -62,7 +62,8 @@ SteinerTree* Resizer::makeSteinerTree(const Pin* drvr_pin)
   int pin_count = pinlocs.size();
   bool is_placed = true;
   if (pin_count >= 2) {
-    vector<int> x, y;  // Two separate vectors of coordinates needed by flute.
+    std::vector<int> x;  // Two separate vectors of coordinates needed by flute.
+    std::vector<int> y;
     int drvr_idx = 0;  // The "driver_pin" or the root of the Steiner tree.
     for (int i = 0; i < pin_count; i++) {
       const PinLoc& pinloc = pinlocs[i];

--- a/src/rsz/src/SteinerTree.hh
+++ b/src/rsz/src/SteinerTree.hh
@@ -16,8 +16,6 @@ const int SteinerNull = -1;
 
 namespace rsz {
 
-using std::vector;
-
 using utl::Logger;
 
 using odb::Point;


### PR DESCRIPTION
Shortcuts like `using std::vector` pollute the namespace for everyone including the header. Even if they are used within a namespace, now a `foo` namespace suddenly has a `foo::vector`.

This first fix works on fixing the `std::` using statements, but there are a bunch more that need to be addressed.