### PR TITLE
ppl: use intersects instead of overlaps when checking top layer region

### DIFF
--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -2451,7 +2451,7 @@ bool IOPlacer::checkPinConstraints()
           invalid = true;
         }
       } else {
-        if (!constraint.box.overlaps(pin.getPosition())) {
+        if (!constraint.box.intersects(pin.getPosition())) {
           logger_->warn(
               PPL,
               105,


### PR DESCRIPTION
When using `overlaps`, pins cannot be placed at the border of the top layer region. Using `intersects` fix the problem.