### PR TITLE
Provide id-sorting map/set typedefs for frBlockObjects.

### DIFF
--- a/src/drt/src/db/grObj/grNet.h
+++ b/src/drt/src/db/grObj/grNet.h
@@ -49,13 +49,11 @@ class grNet : public grBlockObject
   {
     return pinGCellNodePairs;
   }
-  const std::map<grNode*, std::vector<grNode*>, frBlockObjectComp>&
-  getGCell2PinNodes() const
+  const frOrderedIdMap<grNode*, std::vector<grNode*>>& getGCell2PinNodes() const
   {
     return gcell2PinNodes;
   }
-  std::map<grNode*, std::vector<grNode*>, frBlockObjectComp>&
-  getGCell2PinNodes()
+  frOrderedIdMap<grNode*, std::vector<grNode*>>& getGCell2PinNodes()
   {
     return gcell2PinNodes;
   }
@@ -69,14 +67,11 @@ class grNet : public grBlockObject
   {
     return pinNodePairs;
   }
-  const std::map<grNode*, frNode*, frBlockObjectComp>& getGR2FrPinNode() const
+  const frOrderedIdMap<grNode*, frNode*>& getGR2FrPinNode() const
   {
     return gr2FrPinNode;
   }
-  std::map<grNode*, frNode*, frBlockObjectComp>& getGR2FrPinNode()
-  {
-    return gr2FrPinNode;
-  }
+  frOrderedIdMap<grNode*, frNode*>& getGR2FrPinNode() { return gr2FrPinNode; }
   bool isModified() const { return modified; }
   int getNumOverConGCells() const { return numOverConGCells; }
   int getNumPinsIn() const { return numPinsIn; }
@@ -122,7 +117,7 @@ class grNet : public grBlockObject
     pinGCellNodePairs = in;
   }
   void setGCell2PinNodes(
-      const std::map<grNode*, std::vector<grNode*>, frBlockObjectComp>& in)
+      const frOrderedIdMap<grNode*, std::vector<grNode*>>& in)
   {
     gcell2PinNodes = in;
   }
@@ -131,7 +126,7 @@ class grNet : public grBlockObject
   {
     pinNodePairs = in;
   }
-  void setGR2FrPinNode(const std::map<grNode*, frNode*, frBlockObjectComp>& in)
+  void setGR2FrPinNode(const frOrderedIdMap<grNode*, frNode*>& in)
   {
     gr2FrPinNode = in;
   }
@@ -190,11 +185,11 @@ class grNet : public grBlockObject
 
   // pair of <pinNode, gcellNode> with first (0th) element always being root
   std::vector<std::pair<grNode*, grNode*>> pinGCellNodePairs;
-  std::map<grNode*, std::vector<grNode*>, frBlockObjectComp> gcell2PinNodes;
+  frOrderedIdMap<grNode*, std::vector<grNode*>> gcell2PinNodes;
   // unique, first (0th) element always being root
   std::vector<grNode*> pinGCellNodes;
   std::vector<std::pair<frNode*, grNode*>> pinNodePairs;
-  std::map<grNode*, frNode*, frBlockObjectComp> gr2FrPinNode;
+  frOrderedIdMap<grNode*, frNode*> gr2FrPinNode;
   // std::set<frBlockObject*>                 fNetTerms;
   std::list<std::unique_ptr<grNode>> nodes;
   grNode* root{nullptr};

--- a/src/drt/src/db/obj/frBlockObject.h
+++ b/src/drt/src/db/obj/frBlockObject.h
@@ -33,6 +33,8 @@ class frBlockObject
   friend class boost::serialization::access;
 };
 
+namespace internal {
+// Don't use directly, use the sets below
 struct frBlockObjectComp
 {
   bool operator()(const frBlockObject* lhs, const frBlockObject* rhs) const
@@ -40,8 +42,23 @@ struct frBlockObjectComp
     return *lhs < *rhs;
   }
 };
+}  // namespace internal
 
-using frBlockObjectSet = std::set<frBlockObject*, frBlockObjectComp>;
-template <typename T>
-using frBlockObjectMap = std::map<frBlockObject*, T, frBlockObjectComp>;
+// A set that is compatible with keys derived from
+// frBlockObject*
+template <typename K>
+using frOrderedIdSet = std::set<K, internal::frBlockObjectComp>;
+
+// Legacy container for a frBlockObject* values; consider using the
+// templated container.
+using frBlockObjectSet = frOrderedIdSet<frBlockObject*>;
+
+template <typename K, typename V>
+using frOrderedIdMap = std::map<K, V, internal::frBlockObjectComp>;
+
+// Legacy container for a frBlockObject* key; consider using
+// using the <K, V> container.
+template <typename V>
+using frBlockObjectMap = frOrderedIdMap<frBlockObject*, V>;
+
 }  // namespace drt

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -329,14 +329,12 @@ void FlexDR::initGCell2BoundaryPin()
   auto gCellPatterns = topBlock->getGCellPatterns();
   auto& xgp = gCellPatterns.at(0);
   auto& ygp = gCellPatterns.at(1);
-  auto tmpVec = std::vector<std::map<frNet*,
-                                     std::set<std::pair<Point, frLayerNum>>,
-                                     frBlockObjectComp>>((int) ygp.getCount());
-  gcell2BoundaryPin_
-      = std::vector<std::vector<std::map<frNet*,
-                                         std::set<std::pair<Point, frLayerNum>>,
-                                         frBlockObjectComp>>>(
-          (int) xgp.getCount(), tmpVec);
+  auto tmpVec = std::vector<
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>>(
+      (int) ygp.getCount());
+  gcell2BoundaryPin_ = std::vector<std::vector<
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>>>(
+      (int) xgp.getCount(), tmpVec);
   for (auto& net : topBlock->getNets()) {
     auto netPtr = net.get();
     for (auto& guide : net->getGuides()) {
@@ -501,14 +499,13 @@ void FlexDR::removeGCell2BoundaryPin()
   gcell2BoundaryPin_.shrink_to_fit();
 }
 
-std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
+frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>
 FlexDR::initDR_mergeBoundaryPin(int startX,
                                 int startY,
                                 int size,
                                 const Rect& routeBox) const
 {
-  std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
-      bp;
+  frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>> bp;
   auto gCellPatterns = getDesign()->getTopBlock()->getGCellPatterns();
   auto& xgp = gCellPatterns.at(0);
   auto& ygp = gCellPatterns.at(1);

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -133,9 +133,8 @@ class FlexDR
   Logger* logger_;
   odb::dbDatabase* db_;
   RouterConfiguration* router_cfg_;
-  std::vector<std::vector<std::map<frNet*,
-                                   std::set<std::pair<Point, frLayerNum>>,
-                                   frBlockObjectComp>>>
+  std::vector<std::vector<
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>>>
       gcell2BoundaryPin_;
 
   FlexDRViaData via_data_;
@@ -163,7 +162,7 @@ class FlexDR
   void init_halfViaEncArea();
 
   void removeGCell2BoundaryPin();
-  std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
+  frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>
   initDR_mergeBoundaryPin(int startX,
                           int startY,
                           int size,
@@ -281,18 +280,16 @@ class FlexDRWorker
   void setExtBox(const Rect& boxIn) { extBox_ = boxIn; }
   void setDrcBox(const Rect& boxIn) { drcBox_ = boxIn; }
   void setDRIter(int in) { drIter_ = in; }
-  void setDRIter(int in,
-                 std::map<frNet*,
-                          std::set<std::pair<Point, frLayerNum>>,
-                          frBlockObjectComp>& bp)
+  void setDRIter(
+      int in,
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& bp)
   {
     drIter_ = in;
     boundaryPin_ = std::move(bp);
   }
   bool isCongested() const { return isCongested_; }
-  void setBoundaryPins(std::map<frNet*,
-                                std::set<std::pair<Point, frLayerNum>>,
-                                frBlockObjectComp>& bp)
+  void setBoundaryPins(
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& bp)
   {
     boundaryPin_ = std::move(bp);
   }
@@ -502,8 +499,7 @@ class FlexDRWorker
   frUInt4 workerFixedShapeCost_{0};
   float workerMarkerDecay_{0};
   // used in init route as gr boundary pin
-  std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
-      boundaryPin_;
+  frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>> boundaryPin_;
   int pinCnt_{0};
   int initNumMarkers_{0};
   std::map<FlexMazeIdx, drAccessPattern*> apSVia_;
@@ -513,7 +509,7 @@ class FlexDRWorker
 
   // local storage
   std::vector<std::unique_ptr<drNet>> nets_;
-  std::map<frNet*, std::vector<drNet*>, frBlockObjectComp> owner2nets_;
+  frOrderedIdMap<frNet*, std::vector<drNet*>> owner2nets_;
   FlexGridGraph gridGraph_;
   std::vector<frMarker> markers_;
   std::vector<frMarker> bestMarkers_;
@@ -545,54 +541,47 @@ class FlexDRWorker
   void initRipUpNetsFromMarkers();
   void initNetObjs(
       const frDesign* design,
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netRouteObjs,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netExtObjs,
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides,
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netGuides);
-  void initNetObjs_pathSeg(frPathSeg* pathSeg,
-                           std::set<frNet*, frBlockObjectComp>& nets,
-                           std::map<frNet*,
-                                    std::vector<std::unique_ptr<drConnFig>>,
-                                    frBlockObjectComp>& netRouteObjs,
-                           std::map<frNet*,
-                                    std::vector<std::unique_ptr<drConnFig>>,
-                                    frBlockObjectComp>& netExtObjs);
-  void initNetObjs_via(const frVia* via,
-                       std::set<frNet*, frBlockObjectComp>& nets,
-                       std::map<frNet*,
-                                std::vector<std::unique_ptr<drConnFig>>,
-                                frBlockObjectComp>& netRouteObjs,
-                       std::map<frNet*,
-                                std::vector<std::unique_ptr<drConnFig>>,
-                                frBlockObjectComp>& netExtObjs);
-  void initNetObjs_patchWire(frPatchWire* pwire,
-                             std::set<frNet*, frBlockObjectComp>& nets,
-                             std::map<frNet*,
-                                      std::vector<std::unique_ptr<drConnFig>>,
-                                      frBlockObjectComp>& netRouteObjs,
-                             std::map<frNet*,
-                                      std::vector<std::unique_ptr<drConnFig>>,
-                                      frBlockObjectComp>& netExtObjs);
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs,
+      frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides,
+      frOrderedIdMap<frNet*, std::vector<frRect>>& netGuides);
+  void initNetObjs_pathSeg(
+      frPathSeg* pathSeg,
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs);
+  void initNetObjs_via(
+      const frVia* via,
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs);
+  void initNetObjs_patchWire(
+      frPatchWire* pwire,
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs);
   void initNets_segmentTerms(const Point& bp,
                              frLayerNum lNum,
                              const frNet* net,
                              frBlockObjectSet& terms);
   void initNets_initDR(
       const frDesign* design,
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netRouteObjs,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netExtObjs,
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides,
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netGuides);
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs,
+      frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides,
+      frOrderedIdMap<frNet*, std::vector<frRect>>& netGuides);
   int initNets_initDR_helper_getObjComponent(
       drConnFig* obj,
       const std::vector<std::vector<int>>& connectedComponents,
@@ -607,36 +596,31 @@ class FlexDRWorker
 
   void initNets_searchRepair(
       const frDesign* design,
-      const std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netRouteObjs,
-      std::map<frNet*,
-               std::vector<std::unique_ptr<drConnFig>>,
-               frBlockObjectComp>& netExtObjs,
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides);
+      const frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netRouteObjs,
+      frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+          netExtObjs,
+      frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides);
   void initNets_searchRepair_pin2epMap(
       const frDesign* design,
       const frNet* net,
       const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
-      std::map<frBlockObject*,
-               std::set<std::pair<Point, frLayerNum>>,
-               frBlockObjectComp>& pin2epMap);
+      frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+          pin2epMap);
 
   void initNets_searchRepair_pin2epMap_helper(
       const frDesign* design,
       const frNet* net,
       const Point& bp,
       frLayerNum lNum,
-      std::map<frBlockObject*,
-               std::set<std::pair<Point, frLayerNum>>,
-               frBlockObjectComp>& pin2epMap);
+      frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+          pin2epMap);
   void initNets_searchRepair_nodeMap(
       const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
       std::vector<frBlockObject*>& netPins,
-      const std::map<frBlockObject*,
-                     std::set<std::pair<Point, frLayerNum>>,
-                     frBlockObjectComp>& pin2epMap,
+      const frOrderedIdMap<frBlockObject*,
+                           std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
       std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap);
 
   void initNets_searchRepair_nodeMap_routeObjEnd(
@@ -657,9 +641,8 @@ class FlexDRWorker
   void initNets_searchRepair_nodeMap_pin(
       const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
       std::vector<frBlockObject*>& netPins,
-      const std::map<frBlockObject*,
-                     std::set<std::pair<Point, frLayerNum>>,
-                     frBlockObjectComp>& pin2epMap,
+      const frOrderedIdMap<frBlockObject*,
+                           std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
       std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap);
   void initNets_searchRepair_connComp(
       frNet* net,
@@ -895,20 +878,19 @@ class FlexDRWorker
   void mazeNetInit(drNet* net);
   void mazeNetEnd(drNet* net);
   bool routeNet(drNet* net, std::vector<FlexMazeIdx>& paths);
-  void routeNet_prep(drNet* net,
-                     std::set<drPin*, frBlockObjectComp>& unConnPins,
-                     std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-                         mazeIdx2unConnPins,
-                     std::set<FlexMazeIdx>& apMazeIdx,
-                     std::set<FlexMazeIdx>& realPinAPMazeIdx,
-                     std::map<FlexMazeIdx, frBox3D*>& mazeIdx2TaperBox,
-                     std::list<std::pair<drPin*, frBox3D>>& pinTaperBoxes);
+  void routeNet_prep(
+      drNet* net,
+      frOrderedIdSet<drPin*>& unConnPins,
+      std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
+      std::set<FlexMazeIdx>& apMazeIdx,
+      std::set<FlexMazeIdx>& realPinAPMazeIdx,
+      std::map<FlexMazeIdx, frBox3D*>& mazeIdx2TaperBox,
+      std::list<std::pair<drPin*, frBox3D>>& pinTaperBoxes);
   void routeNet_prepAreaMap(drNet* net,
                             std::map<FlexMazeIdx, frCoord>& areaMap);
   void routeNet_setSrc(
-      std::set<drPin*, frBlockObjectComp>& unConnPins,
-      std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-          mazeIdx2unConnPins,
+      frOrderedIdSet<drPin*>& unConnPins,
+      std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
       std::vector<FlexMazeIdx>& connComps,
       FlexMazeIdx& ccMazeIdx1,
       FlexMazeIdx& ccMazeIdx2,
@@ -917,15 +899,13 @@ class FlexDRWorker
   drPin* routeNet_getNextDst(
       FlexMazeIdx& ccMazeIdx1,
       FlexMazeIdx& ccMazeIdx2,
-      std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-          mazeIdx2unConnPins,
+      std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
       std::list<std::pair<drPin*, frBox3D>>& pinTaperBoxes);
   void routeNet_postAstarUpdate(
       std::vector<FlexMazeIdx>& path,
       std::vector<FlexMazeIdx>& connComps,
-      std::set<drPin*, frBlockObjectComp>& unConnPins,
-      std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-          mazeIdx2unConnPins,
+      frOrderedIdSet<drPin*>& unConnPins,
+      std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
       bool isFirstConn);
   void routeNet_postAstarWritePath(
       drNet* net,
@@ -1044,21 +1024,19 @@ class FlexDRWorker
   // end
   void cleanup();
   void identifyCongestionLevel();
-  void endGetModNets(std::set<frNet*, frBlockObjectComp>& modNets);
-  void endRemoveNets(frDesign* design,
-                     std::set<frNet*, frBlockObjectComp>& modNets,
-                     std::map<frNet*,
-                              std::set<std::pair<Point, frLayerNum>>,
-                              frBlockObjectComp>& boundPts);
+  void endGetModNets(frOrderedIdSet<frNet*>& modNets);
+  void endRemoveNets(
+      frDesign* design,
+      frOrderedIdSet<frNet*>& modNets,
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& boundPts);
   void endRemoveNets_pathSeg(frDesign* design,
                              frPathSeg* pathSeg,
                              std::set<std::pair<Point, frLayerNum>>& boundPts);
   void endRemoveNets_via(frDesign* design, frVia* via);
   void endRemoveNets_patchWire(frDesign* design, frPatchWire* pwire);
-  void endAddNets(frDesign* design,
-                  std::map<frNet*,
-                           std::set<std::pair<Point, frLayerNum>>,
-                           frBlockObjectComp>& boundPts);
+  void endAddNets(
+      frDesign* design,
+      frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& boundPts);
   void endAddNets_pathSeg(frDesign* design, drPathSeg* pathSeg);
   void endAddNets_via(frDesign* design, drVia* via);
   void endAddNets_patchWire(frDesign* design, drPatchWire* pwire);

--- a/src/drt/src/dr/FlexDR_conn.cpp
+++ b/src/drt/src/dr/FlexDR_conn.cpp
@@ -33,9 +33,8 @@ void FlexDRConnectivityChecker::pin2epMap_helper(
     const frNet* net,
     const Point& pt,
     const frLayerNum lNum,
-    std::map<frBlockObject*,
-             std::set<std::pair<Point, frLayerNum>>,
-             frBlockObjectComp>& pin2epMap)
+    frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+        pin2epMap)
 {
   auto regionQuery = getRegionQuery();
   frRegionQuery::Objects<frBlockObject> result;
@@ -66,9 +65,8 @@ void FlexDRConnectivityChecker::pin2epMap_helper(
 void FlexDRConnectivityChecker::buildPin2epMap(
     const frNet* net,
     const NetRouteObjs& netRouteObjs,
-    std::map<frBlockObject*,
-             std::set<std::pair<Point, frLayerNum>>,
-             frBlockObjectComp>& pin2epMap)
+    frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+        pin2epMap)
 {
   // to avoid delooping fake planar ep in pin
   std::set<std::pair<Point, frLayerNum>> extEndPoints;
@@ -249,9 +247,8 @@ void FlexDRConnectivityChecker::nodeMap_routeObjSplit(
 void FlexDRConnectivityChecker::nodeMap_pin(
     const std::vector<frConnFig*>& netRouteObjs,
     std::vector<frBlockObject*>& netPins,
-    const std::map<frBlockObject*,
-                   std::set<std::pair<Point, frLayerNum>>,
-                   frBlockObjectComp>& pin2epMap,
+    const frOrderedIdMap<frBlockObject*,
+                         std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
     std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap)
 {
   int currCnt = (int) netRouteObjs.size();
@@ -268,9 +265,8 @@ void FlexDRConnectivityChecker::buildNodeMap(
     const frNet* net,
     const NetRouteObjs& netRouteObjs,
     std::vector<frBlockObject*>& netPins,
-    const std::map<frBlockObject*,
-                   std::set<std::pair<Point, frLayerNum>>,
-                   frBlockObjectComp>& pin2epMap,
+    const frOrderedIdMap<frBlockObject*,
+                         std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
     std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap)
 {
   nodeMap_routeObjEnd(net, netRouteObjs, nodeMap);
@@ -1254,9 +1250,8 @@ void FlexDRConnectivityChecker::check(int iter)
                             vertNewSegSpans);
     }
     // net->term/instTerm->pt_layer
-    std::vector<std::map<frBlockObject*,
-                         std::set<std::pair<Point, frLayerNum>>,
-                         frBlockObjectComp>>
+    std::vector<
+        frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>>
         aPin2epMap(batchSize);
     std::vector<std::vector<frBlockObject*>> aNetPins(batchSize);
     std::vector<std::map<std::pair<Point, frLayerNum>, std::set<int>>> aNodeMap(

--- a/src/drt/src/dr/FlexDR_conn.h
+++ b/src/drt/src/dr/FlexDR_conn.h
@@ -54,24 +54,23 @@ class FlexDRConnectivityChecker
    * the segments and vias to the list netRouteObjs.
    */
   void initRouteObjs(const frNet* net, NetRouteObjs& netRouteObjs);
-  void buildPin2epMap(const frNet* net,
-                      const NetRouteObjs& netRouteObjs,
-                      std::map<frBlockObject*,
-                               std::set<std::pair<Point, frLayerNum>>,
-                               frBlockObjectComp>& pin2epMap);
-  void pin2epMap_helper(const frNet* net,
-                        const Point& pt,
-                        frLayerNum lNum,
-                        std::map<frBlockObject*,
-                                 std::set<std::pair<Point, frLayerNum>>,
-                                 frBlockObjectComp>& pin2epMap);
+  void buildPin2epMap(
+      const frNet* net,
+      const NetRouteObjs& netRouteObjs,
+      frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+          pin2epMap);
+  void pin2epMap_helper(
+      const frNet* net,
+      const Point& pt,
+      frLayerNum lNum,
+      frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+          pin2epMap);
   void buildNodeMap(
       const frNet* net,
       const NetRouteObjs& netRouteObjs,
       std::vector<frBlockObject*>& netPins,
-      const std::map<frBlockObject*,
-                     std::set<std::pair<Point, frLayerNum>>,
-                     frBlockObjectComp>& pin2epMap,
+      const frOrderedIdMap<frBlockObject*,
+                           std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
       std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap);
   void nodeMap_routeObjEnd(
       const frNet* net,
@@ -93,9 +92,8 @@ class FlexDRConnectivityChecker
   void nodeMap_pin(
       const std::vector<frConnFig*>& netRouteObjs,
       std::vector<frBlockObject*>& netPins,
-      const std::map<frBlockObject*,
-                     std::set<std::pair<Point, frLayerNum>>,
-                     frBlockObjectComp>& pin2epMap,
+      const frOrderedIdMap<frBlockObject*,
+                           std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
       std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap);
   /**
    * Maps the net's segments to track indices.

--- a/src/drt/src/dr/FlexDR_end.cpp
+++ b/src/drt/src/dr/FlexDR_end.cpp
@@ -7,7 +7,7 @@
 
 namespace drt {
 
-void FlexDRWorker::endGetModNets(std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexDRWorker::endGetModNets(frOrderedIdSet<frNet*>& modNets)
 {
   for (auto& net : nets_) {
     if (net->isModified()) {
@@ -257,9 +257,8 @@ void FlexDRWorker::endRemoveNets_patchWire(frDesign* design, frPatchWire* pwire)
 
 void FlexDRWorker::endRemoveNets(
     frDesign* design,
-    std::set<frNet*, frBlockObjectComp>& modNets,
-    std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>&
-        boundPts)
+    frOrderedIdSet<frNet*>& modNets,
+    frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& boundPts)
 {
   std::vector<frBlockObject*> result;
   design->getRegionQuery()->queryDRObj(getExtBox(), result);
@@ -585,8 +584,7 @@ void FlexDRWorker::endAddNets_updateExtFigs(drNet* net)
 }
 void FlexDRWorker::endAddNets(
     frDesign* design,
-    std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>&
-        boundPts)
+    frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>& boundPts)
 {
   for (auto& net : nets_) {
     if (!net->isModified()) {
@@ -691,11 +689,10 @@ bool FlexDRWorker::end(frDesign* design)
     return false;
   }
   save_updates_ = dist_on_;
-  std::set<frNet*, frBlockObjectComp> modNets;
+  frOrderedIdSet<frNet*> modNets;
   endGetModNets(modNets);
   // get lock
-  std::map<frNet*, std::set<std::pair<Point, frLayerNum>>, frBlockObjectComp>
-      boundPts;
+  frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>> boundPts;
   endRemoveNets(design, modNets, boundPts);
   endAddNets(design, boundPts);  // if two subnets have diff isModified()
                                  // status, then should always write back

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -27,13 +27,10 @@ bool FlexDRWorker::isRouteVia(const frVia* via) const
 
 void FlexDRWorker::initNetObjs_pathSeg(
     frPathSeg* pathSeg,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs)
 {
   const auto [begin, end] = pathSeg->getPoints();
   auto net = pathSeg->getNet();
@@ -144,13 +141,10 @@ void FlexDRWorker::initNetObjs_pathSeg(
 
 void FlexDRWorker::initNetObjs_via(
     const frVia* via,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs)
 {
   auto net = via->getNet();
   nets.insert(net);
@@ -165,13 +159,10 @@ void FlexDRWorker::initNetObjs_via(
 
 void FlexDRWorker::initNetObjs_patchWire(
     frPatchWire* pwire,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs)
 {
   auto net = pwire->getNet();
   nets.insert(net);
@@ -191,15 +182,12 @@ void FlexDRWorker::initNetObjs_patchWire(
 // the same criterion above
 void FlexDRWorker::initNetObjs(
     const frDesign* design,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs,
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides,
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netGuides)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs,
+    frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides,
+    frOrderedIdMap<frNet*, std::vector<frRect>>& netGuides)
 {
   std::vector<frBlockObject*> result;
   design->getRegionQuery()->queryDRObj(getExtBox(), result);
@@ -633,17 +621,14 @@ void FlexDRWorker::initNets_initDR_helper(
 // inits nets based on the pins
 void FlexDRWorker::initNets_initDR(
     const frDesign* design,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs,
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides,
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netGuides)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs,
+    frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides,
+    frOrderedIdMap<frNet*, std::vector<frRect>>& netGuides)
 {
-  std::map<frNet*, frBlockObjectSet, frBlockObjectComp> netTerms;
+  frOrderedIdMap<frNet*, frBlockObjectSet> netTerms;
   std::vector<frBlockObject*> result;
   design->getRegionQuery()->queryGRPin(getRouteBox(), result);
   for (auto obj : result) {
@@ -718,9 +703,8 @@ void FlexDRWorker::initNets_searchRepair_pin2epMap_helper(
     const frNet* net,
     const Point& bp,
     const frLayerNum lNum,
-    std::map<frBlockObject*,
-             std::set<std::pair<Point, frLayerNum>>,
-             frBlockObjectComp>& pin2epMap)
+    frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+        pin2epMap)
 {
   frRegionQuery::Objects<frBlockObject> result;
   design->getRegionQuery()->query({bp, bp}, lNum, result);
@@ -750,9 +734,8 @@ void FlexDRWorker::initNets_searchRepair_pin2epMap(
     const frDesign* design,
     const frNet* net,
     const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
-    std::map<frBlockObject*,
-             std::set<std::pair<Point, frLayerNum>>,
-             frBlockObjectComp>& pin2epMap)
+    frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>&
+        pin2epMap)
 {
   // should not count extObjs in union find
   for (auto& uPtr : netRouteObjs) {
@@ -924,9 +907,8 @@ void FlexDRWorker::initNets_searchRepair_nodeMap_routeObjSplit(
 void FlexDRWorker::initNets_searchRepair_nodeMap_pin(
     const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
     std::vector<frBlockObject*>& netPins,
-    const std::map<frBlockObject*,
-                   std::set<std::pair<Point, frLayerNum>>,
-                   frBlockObjectComp>& pin2epMap,
+    const frOrderedIdMap<frBlockObject*,
+                         std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
     std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap)
 {
   int currCnt = (int) netRouteObjs.size();
@@ -945,9 +927,8 @@ void FlexDRWorker::initNets_searchRepair_nodeMap_pin(
 void FlexDRWorker::initNets_searchRepair_nodeMap(
     const std::vector<std::unique_ptr<drConnFig>>& netRouteObjs,
     std::vector<frBlockObject*>& netPins,
-    const std::map<frBlockObject*,
-                   std::set<std::pair<Point, frLayerNum>>,
-                   frBlockObjectComp>& pin2epMap,
+    const frOrderedIdMap<frBlockObject*,
+                         std::set<std::pair<Point, frLayerNum>>>& pin2epMap,
     std::map<std::pair<Point, frLayerNum>, std::set<int>>& nodeMap)
 {
   initNets_searchRepair_nodeMap_routeObjEnd(netRouteObjs, nodeMap);
@@ -1018,14 +999,11 @@ void FlexDRWorker::initNets_searchRepair_connComp(
 
 void FlexDRWorker::initNets_searchRepair(
     const frDesign* design,
-    const std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netRouteObjs,
-    std::map<frNet*,
-             std::vector<std::unique_ptr<drConnFig>>,
-             frBlockObjectComp>& netExtObjs,
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& netOrigGuides)
+    const frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>&
+        netRouteObjs,
+    frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>>& netExtObjs,
+    frOrderedIdMap<frNet*, std::vector<frRect>>& netOrigGuides)
 {
   for (auto net : nets) {
     if (isInitDR() && getRipupMode() == RipUpMode::INCR
@@ -1034,9 +1012,7 @@ void FlexDRWorker::initNets_searchRepair(
     }
     // build big graph;
     // node number : routeObj, pins
-    std::map<frBlockObject*,
-             std::set<std::pair<Point, frLayerNum>>,
-             frBlockObjectComp>
+    frOrderedIdMap<frBlockObject*, std::set<std::pair<Point, frLayerNum>>>
         pin2epMap;
     initNets_searchRepair_pin2epMap(design, net, netRouteObjs[net], pin2epMap);
 
@@ -1525,13 +1501,11 @@ void FlexDRWorker::initRipUpNetsFromMarkers()
 
 void FlexDRWorker::initNets(const frDesign* design)
 {
-  std::set<frNet*, frBlockObjectComp> nets;
-  std::map<frNet*, std::vector<std::unique_ptr<drConnFig>>, frBlockObjectComp>
-      netRouteObjs;
-  std::map<frNet*, std::vector<std::unique_ptr<drConnFig>>, frBlockObjectComp>
-      netExtObjs;
-  std::map<frNet*, std::vector<frRect>, frBlockObjectComp> netOrigGuides;
-  std::map<frNet*, std::vector<frRect>, frBlockObjectComp> netGuides;
+  frOrderedIdSet<frNet*> nets;
+  frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>> netRouteObjs;
+  frOrderedIdMap<frNet*, std::vector<std::unique_ptr<drConnFig>>> netExtObjs;
+  frOrderedIdMap<frNet*, std::vector<frRect>> netOrigGuides;
+  frOrderedIdMap<frNet*, std::vector<frRect>> netGuides;
   // get lock
   initNetObjs(design, nets, netRouteObjs, netExtObjs, netOrigGuides, netGuides);
   // release lock

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -2181,9 +2181,8 @@ void FlexDRWorker::modEolCosts_poly(gcNet* net, ModCostType modType)
 
 void FlexDRWorker::routeNet_prep(
     drNet* net,
-    std::set<drPin*, frBlockObjectComp>& unConnPins,
-    std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-        mazeIdx2unConnPins,
+    frOrderedIdSet<drPin*>& unConnPins,
+    std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
     std::set<FlexMazeIdx>& apMazeIdx,
     std::set<FlexMazeIdx>& realPinAPMazeIdx,
     std::map<FlexMazeIdx, frBox3D*>& mazeIdx2TaperBox,
@@ -2250,9 +2249,8 @@ void FlexDRWorker::routeNet_prep(
 }
 
 void FlexDRWorker::routeNet_setSrc(
-    std::set<drPin*, frBlockObjectComp>& unConnPins,
-    std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-        mazeIdx2unConnPins,
+    frOrderedIdSet<drPin*>& unConnPins,
+    std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
     std::vector<FlexMazeIdx>& connComps,
     FlexMazeIdx& ccMazeIdx1,
     FlexMazeIdx& ccMazeIdx2,
@@ -2349,8 +2347,7 @@ void FlexDRWorker::routeNet_setSrc(
 drPin* FlexDRWorker::routeNet_getNextDst(
     FlexMazeIdx& ccMazeIdx1,
     FlexMazeIdx& ccMazeIdx2,
-    std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-        mazeIdx2unConnPins,
+    std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
     std::list<std::pair<drPin*, frBox3D>>& pinTaperBoxes)
 {
   Point pt;
@@ -2398,9 +2395,8 @@ void FlexDRWorker::mazePinInit()
 void FlexDRWorker::routeNet_postAstarUpdate(
     std::vector<FlexMazeIdx>& path,
     std::vector<FlexMazeIdx>& connComps,
-    std::set<drPin*, frBlockObjectComp>& unConnPins,
-    std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>>&
-        mazeIdx2unConnPins,
+    frOrderedIdSet<drPin*>& unConnPins,
+    std::map<FlexMazeIdx, frOrderedIdSet<drPin*>>& mazeIdx2unConnPins,
     bool isFirstConn)
 {
   // first point is dst
@@ -3193,8 +3189,8 @@ bool FlexDRWorker::routeNet(drNet* net, std::vector<FlexMazeIdx>& paths)
   if (graphics_) {
     graphics_->show(true);
   }
-  std::set<drPin*, frBlockObjectComp> unConnPins;
-  std::map<FlexMazeIdx, std::set<drPin*, frBlockObjectComp>> mazeIdx2unConnPins;
+  frOrderedIdSet<drPin*> unConnPins;
+  std::map<FlexMazeIdx, frOrderedIdSet<drPin*>> mazeIdx2unConnPins;
   std::map<FlexMazeIdx, frBox3D*>
       mazeIdx2TaperBox;  // access points -> taper box: used to efficiently know
                          // what points are in what taper boxes

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <vector>
 
+#include "db/obj/frBlockObject.h"
 #include "frDesign.h"
 #include "frRTree.h"
 #include "global.h"
@@ -44,8 +45,7 @@ struct frRegionQuery::Impl
 
   Impl() = default;
   void init();
-  void initOrigGuide(
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& tmpGuides);
+  void initOrigGuide(frOrderedIdMap<frNet*, std::vector<frRect>>& tmpGuides);
   void initGuide();
   void initRPin();
   void initGRPin(std::vector<std::pair<frBlockObject*, Point>>& in);
@@ -795,13 +795,13 @@ void frRegionQuery::Impl::init()
 }
 
 void frRegionQuery::initOrigGuide(
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& tmpGuides)
+    frOrderedIdMap<frNet*, std::vector<frRect>>& tmpGuides)
 {
   impl_->initOrigGuide(tmpGuides);
 }
 
 void frRegionQuery::Impl::initOrigGuide(
-    std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& tmpGuides)
+    frOrderedIdMap<frNet*, std::vector<frRect>>& tmpGuides)
 {
   const frLayerNum numLayers = design_->getTech()->getLayers().size();
   origGuides_.clear();

--- a/src/drt/src/frRegionQuery.h
+++ b/src/drt/src/frRegionQuery.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
 
 namespace odb {
@@ -16,7 +17,6 @@ class Rect;
 namespace drt {
 using odb::Rect;
 class frBlockObject;
-struct frBlockObjectComp;
 class frDesign;
 class frGuide;
 class frMarker;
@@ -103,8 +103,7 @@ class frRegionQuery
   // init
   void init();
   void initGuide();
-  void initOrigGuide(
-      std::map<frNet*, std::vector<frRect>, frBlockObjectComp>& tmpGuides);
+  void initOrigGuide(frOrderedIdMap<frNet*, std::vector<frRect>>& tmpGuides);
   void initGRPin(std::vector<std::pair<frBlockObject*, odb::Point>>& in);
   void initRPin();
   void initDRObj();

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -967,7 +967,7 @@ void FlexGCWorker::Impl::updateGCWorker()
   }
 
   // get all frNets, must be sorted by id
-  std::set<frNet*, frBlockObjectComp> fnets;
+  frOrderedIdSet<frNet*> fnets;
   for (auto dnet : modifiedDRNets_) {
     fnets.insert(dnet->getFrNet());
   }

--- a/src/drt/src/gr/FlexGR.h
+++ b/src/drt/src/gr/FlexGR.h
@@ -64,15 +64,11 @@ class FlexGR
   Logger* logger_;
   stt::SteinerTreeBuilder* stt_builder_;
   RouterConfiguration* router_cfg_;
-  std::map<frNet*,
-           std::map<std::pair<int, int>, std::vector<frNode*>>,
-           frBlockObjectComp>
+  frOrderedIdMap<frNet*, std::map<std::pair<int, int>, std::vector<frNode*>>>
       net2GCellIdx2Nodes_;
-  std::map<frNet*, std::vector<frNode*>, frBlockObjectComp> net2GCellNodes_;
-  std::map<frNet*, std::vector<frNode*>, frBlockObjectComp> net2SteinerNodes_;
-  std::map<frNet*,
-           std::map<frNode*, std::vector<frNode*>, frBlockObjectComp>,
-           frBlockObjectComp>
+  frOrderedIdMap<frNet*, std::vector<frNode*>> net2GCellNodes_;
+  frOrderedIdMap<frNet*, std::vector<frNode*>> net2SteinerNodes_;
+  frOrderedIdMap<frNet*, frOrderedIdMap<frNode*, std::vector<frNode*>>>
       net2GCellNode2RPinNodes_;
   std::vector<frCoord> trackPitches_;
   std::vector<frCoord> line2ViaPitches_;
@@ -337,7 +333,7 @@ class FlexGRWorker
 
   // local storage
   std::vector<std::unique_ptr<grNet>> nets_;
-  std::map<frNet*, std::vector<grNet*>, frBlockObjectComp> owner2nets_;
+  frOrderedIdMap<frNet*, std::vector<grNet*>> owner2nets_;
 
   FlexGRGridGraph gridGraph_;
   FlexGRWorkerRegionQuery rq_;
@@ -355,20 +351,19 @@ class FlexGRWorker
   // init
   void init();
   void initNets();
-  void initNets_roots(
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots);
+  void initNets_roots(frOrderedIdSet<frNet*>& nets,
+                      frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots);
   void initNetObjs_roots_pathSeg(
       grPathSeg* pathSeg,
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots);
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots);
   void initNetObjs_roots_via(
       grVia* via,
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots);
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots);
   void initNets_searchRepair(
-      std::set<frNet*, frBlockObjectComp>& nets,
-      std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots);
+      frOrderedIdSet<frNet*>& nets,
+      frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots);
   void initNet(frNet* net, const std::vector<frNode*>& netRoots);
   void initNet_initNodes(grNet* net, frNode* fRoot);
   void initNet_initRoot(grNet* net);
@@ -384,7 +379,7 @@ class FlexGRWorker
   void initNets_printNets();
   void initNets_printNet(grNet* net);
   void initNets_printFNets(
-      std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots);
+      frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots);
   void initNets_printFNet(frNode* root);
 
   // route
@@ -401,12 +396,12 @@ class FlexGRWorker
   void mazeNetInit_removeNetNodes(grNet* net);
   bool routeNet(grNet* net);
   void routeNet_prep(grNet* net,
-                     std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+                     frOrderedIdSet<grNode*>& unConnPinGCellNodes,
                      std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode,
                      std::map<FlexMazeIdx, grNode*>& mazeIdx2endPointNode);
   void routeNet_setSrc(
       grNet* net,
-      std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+      frOrderedIdSet<grNode*>& unConnPinGCellNodes,
       std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode,
       std::vector<FlexMazeIdx>& connComps,
       FlexMazeIdx& ccMazeIdx1,
@@ -419,7 +414,7 @@ class FlexGRWorker
   grNode* routeNet_postAstarUpdate(
       std::vector<FlexMazeIdx>& path,
       std::vector<FlexMazeIdx>& connComps,
-      std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+      frOrderedIdSet<grNode*>& unConnPinGCellNodes,
       std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode);
   void routeNet_postAstarWritePath(
       grNet* net,
@@ -433,15 +428,15 @@ class FlexGRWorker
   void route_decayHistCost();
 
   // end
-  void endGetModNets(std::set<frNet*, frBlockObjectComp>& modNets);
-  void endRemoveNets(const std::set<frNet*, frBlockObjectComp>& modNets);
-  void endRemoveNets_objs(const std::set<frNet*, frBlockObjectComp>& modNets);
+  void endGetModNets(frOrderedIdSet<frNet*>& modNets);
+  void endRemoveNets(const frOrderedIdSet<frNet*>& modNets);
+  void endRemoveNets_objs(const frOrderedIdSet<frNet*>& modNets);
   void endRemoveNets_pathSeg(grPathSeg* pathSeg);
   void endRemoveNets_via(grVia* via);
-  void endRemoveNets_nodes(const std::set<frNet*, frBlockObjectComp>& modNets);
+  void endRemoveNets_nodes(const frOrderedIdSet<frNet*>& modNets);
   void endRemoveNets_nodes_net(grNet* net, frNet* fnet);
   void endRemoveNets_node(frNode* node);
-  void endAddNets(std::set<frNet*, frBlockObjectComp>& modNets);
+  void endAddNets(frOrderedIdSet<frNet*>& modNets);
   void endAddNets_stitchRouteBound(grNet* net);
   void endAddNets_stitchRouteBound_node(grNode* node);
   void endAddNets_addNet(grNet* net, frNet* fnet);

--- a/src/drt/src/gr/FlexGR_end.cpp
+++ b/src/drt/src/gr/FlexGR_end.cpp
@@ -10,7 +10,7 @@ namespace drt {
 
 void FlexGRWorker::end()
 {
-  std::set<frNet*, frBlockObjectComp> modNets;
+  frOrderedIdSet<frNet*> modNets;
   endGetModNets(modNets);
   endRemoveNets(modNets);
   endAddNets(modNets);
@@ -21,7 +21,7 @@ void FlexGRWorker::end()
   cleanup();
 }
 
-void FlexGRWorker::endGetModNets(std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexGRWorker::endGetModNets(frOrderedIdSet<frNet*>& modNets)
 {
   for (auto& net : nets_) {
     if (net->isModified()) {
@@ -36,15 +36,13 @@ void FlexGRWorker::endGetModNets(std::set<frNet*, frBlockObjectComp>& modNets)
   }
 }
 
-void FlexGRWorker::endRemoveNets(
-    const std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexGRWorker::endRemoveNets(const frOrderedIdSet<frNet*>& modNets)
 {
   endRemoveNets_objs(modNets);
   endRemoveNets_nodes(modNets);
 }
 
-void FlexGRWorker::endRemoveNets_objs(
-    const std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexGRWorker::endRemoveNets_objs(const frOrderedIdSet<frNet*>& modNets)
 {
   // remove pathSeg and via (all nets based)
   std::vector<grBlockObject*> result;
@@ -91,8 +89,7 @@ void FlexGRWorker::endRemoveNets_via(grVia* via)
   net->removeGRVia(via);
 }
 
-void FlexGRWorker::endRemoveNets_nodes(
-    const std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexGRWorker::endRemoveNets_nodes(const frOrderedIdSet<frNet*>& modNets)
 {
   for (auto fnet : modNets) {
     for (auto net : owner2nets_[fnet]) {
@@ -142,7 +139,7 @@ void FlexGRWorker::endRemoveNets_nodes_net(grNet* net, frNet* fnet)
   }
 }
 
-void FlexGRWorker::endAddNets(std::set<frNet*, frBlockObjectComp>& modNets)
+void FlexGRWorker::endAddNets(frOrderedIdSet<frNet*>& modNets)
 {
   for (auto fnet : modNets) {
     for (auto net : owner2nets_[fnet]) {

--- a/src/drt/src/gr/FlexGR_init.cpp
+++ b/src/drt/src/gr/FlexGR_init.cpp
@@ -430,8 +430,8 @@ void FlexGRWorker::init()
 
 void FlexGRWorker::initNets()
 {
-  std::set<frNet*, frBlockObjectComp> nets;
-  std::map<frNet*, std::vector<frNode*>, frBlockObjectComp> netRoots;
+  frOrderedIdSet<frNet*> nets;
+  frOrderedIdMap<frNet*, std::vector<frNode*>> netRoots;
 
   initNets_roots(nets, netRoots);
   initNets_searchRepair(nets, netRoots);
@@ -440,8 +440,8 @@ void FlexGRWorker::initNets()
 
 // get all roots of subnets
 void FlexGRWorker::initNets_roots(
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots)
 {
   std::vector<grBlockObject*> result;
   getRegionQuery()->queryGRObj(routeBox_, result);
@@ -472,8 +472,8 @@ void FlexGRWorker::initNets_roots(
 // root (i.e., outgoing edge)
 void FlexGRWorker::initNetObjs_roots_pathSeg(
     grPathSeg* pathSeg,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots)
 {
   auto net = pathSeg->getNet();
   nets.insert(net);
@@ -498,8 +498,8 @@ void FlexGRWorker::initNetObjs_roots_pathSeg(
 // grandparent is a subnet root
 void FlexGRWorker::initNetObjs_roots_via(
     grVia* via,
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots)
 {
   auto net = via->getNet();
   nets.insert(net);
@@ -512,8 +512,8 @@ void FlexGRWorker::initNetObjs_roots_via(
 }
 
 void FlexGRWorker::initNets_searchRepair(
-    std::set<frNet*, frBlockObjectComp>& nets,
-    std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots)
+    frOrderedIdSet<frNet*>& nets,
+    frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots)
 {
   for (auto net : nets) {
     initNet(net, netRoots[net]);
@@ -522,7 +522,7 @@ void FlexGRWorker::initNets_searchRepair(
 
 void FlexGRWorker::initNet(frNet* net, const std::vector<frNode*>& netRoots)
 {
-  std::set<frNode*, frBlockObjectComp> uniqueRoots;
+  frOrderedIdSet<frNode*> uniqueRoots;
   for (auto fRoot : netRoots) {
     if (uniqueRoots.find(fRoot) != uniqueRoots.end()) {
       continue;
@@ -551,7 +551,7 @@ void FlexGRWorker::initNet_initNodes(grNet* net, frNode* fRoot)
   // map from loc to gcell node
   // std::map<std::pair<Point, frlayerNum>, grNode*> loc2GCellNode;
   std::vector<std::pair<frNode*, grNode*>> pinNodePairs;
-  std::map<grNode*, frNode*, frBlockObjectComp> gr2FrPinNode;
+  frOrderedIdMap<grNode*, frNode*> gr2FrPinNode;
   // parent grNode to children frNode
   std::deque<std::pair<grNode*, frNode*>> nodeQ;
   nodeQ.emplace_back(nullptr, fRoot);
@@ -791,7 +791,7 @@ void FlexGRWorker::initNet_updateCMap(grNet* net, bool isAdd)
 void FlexGRWorker::initNet_initPinGCellNodes(grNet* net)
 {
   std::vector<std::pair<grNode*, grNode*>> pinGCellNodePairs;
-  std::map<grNode*, std::vector<grNode*>, frBlockObjectComp> gcell2PinNodes;
+  frOrderedIdMap<grNode*, std::vector<grNode*>> gcell2PinNodes;
   std::vector<grNode*> pinGCellNodes;
   std::map<FlexMazeIdx, grNode*> midx2PinGCellNode;
   grNode* rootGCellNode = nullptr;
@@ -1023,7 +1023,7 @@ void FlexGRWorker::initNets_printNet(grNet* net)
 }
 
 void FlexGRWorker::initNets_printFNets(
-    std::map<frNet*, std::vector<frNode*>, frBlockObjectComp>& netRoots)
+    frOrderedIdMap<frNet*, std::vector<frNode*>>& netRoots)
 {
   std::cout << std::endl << "printing frNets\n";
   for (auto& [net, roots] : netRoots) {

--- a/src/drt/src/gr/FlexGR_maze.cpp
+++ b/src/drt/src/gr/FlexGR_maze.cpp
@@ -404,7 +404,7 @@ bool FlexGRWorker::routeNet(grNet* net)
     return true;
   }
 
-  std::set<grNode*, frBlockObjectComp> unConnPinGCellNodes;
+  frOrderedIdSet<grNode*> unConnPinGCellNodes;
   std::map<FlexMazeIdx, grNode*> mazeIdx2unConnPinGCellNode;
   std::map<FlexMazeIdx, grNode*> mazeIdx2endPointNode;
   routeNet_prep(net,
@@ -452,7 +452,7 @@ bool FlexGRWorker::routeNet(grNet* net)
 
 void FlexGRWorker::routeNet_prep(
     grNet* net,
-    std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+    frOrderedIdSet<grNode*>& unConnPinGCellNodes,
     std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode,
     std::map<FlexMazeIdx, grNode*>& mazeIdx2endPointNode)
 {
@@ -527,7 +527,7 @@ void FlexGRWorker::routeNet_printNet(grNet* net)
 // current set subnet root to be src with the absence of reroot
 void FlexGRWorker::routeNet_setSrc(
     grNet* net,
-    std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+    frOrderedIdSet<grNode*>& unConnPinGCellNodes,
     std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode,
     std::vector<FlexMazeIdx>& connComps,
     FlexMazeIdx& ccMazeIdx1,
@@ -624,7 +624,7 @@ grNode* FlexGRWorker::routeNet_getNextDst(
 grNode* FlexGRWorker::routeNet_postAstarUpdate(
     std::vector<FlexMazeIdx>& path,
     std::vector<FlexMazeIdx>& connComps,
-    std::set<grNode*, frBlockObjectComp>& unConnPinGCellNodes,
+    frOrderedIdSet<grNode*>& unConnPinGCellNodes,
     std::map<FlexMazeIdx, grNode*>& mazeIdx2unConnPinGCellNode)
 {
   std::set<FlexMazeIdx> localConnComps;

--- a/src/drt/src/gr/FlexGR_topo.cpp
+++ b/src/drt/src/gr/FlexGR_topo.cpp
@@ -31,8 +31,7 @@ void FlexGR::genSTTopology_FLUTE(std::vector<frNode*>& pinGCellNodes,
   auto fluteTree = stt_builder_->makeSteinerTree(xs, ys, 0);
 
   std::map<Point, frNode*> pinGCell2Nodes, steinerGCell2Nodes;
-  std::map<frNode*, std::set<frNode*, frBlockObjectComp>, frBlockObjectComp>
-      adjacencyList;
+  frOrderedIdMap<frNode*, frOrderedIdSet<frNode*>> adjacencyList;
 
   for (auto pinNode : pinGCellNodes) {
     pinGCell2Nodes[pinNode->getLoc()] = pinNode;
@@ -538,8 +537,7 @@ void FlexGR::genSTTopology_build_tree_splitSeg(
     std::vector<frNode*>& steinerNodes)
 {
   std::map<frCoord, std::set<std::pair<frCoord, frCoord>>> horzSegs, vertSegs;
-  std::map<frNode*, std::set<frNode*, frBlockObjectComp>, frBlockObjectComp>
-      adjacencyList;
+  frOrderedIdMap<frNode*, frOrderedIdSet<frNode*>> adjacencyList;
 
   auto root = pinNodes[0];
   auto net = root->getNet();
@@ -767,7 +765,7 @@ void FlexGR::genSTTopology_build_tree_splitSeg(
     node->reset();
   }
 
-  std::set<frNode*, frBlockObjectComp> visitedNodes;
+  frOrderedIdSet<frNode*> visitedNodes;
   std::deque<frNode*> nodeQueue;
 
   nodeQueue.push_front(root);

--- a/src/drt/src/io/GuideProcessor.h
+++ b/src/drt/src/io/GuideProcessor.h
@@ -202,7 +202,7 @@ class GuideProcessor
   Logger* logger_;
   odb::dbDatabase* db_;
   RouterConfiguration* router_cfg_;
-  std::map<frNet*, std::vector<frRect>, frBlockObjectComp> tmp_guides_;
+  frOrderedIdMap<frNet*, std::vector<frRect>> tmp_guides_;
 };
 
 /**

--- a/src/drt/src/io/io.h
+++ b/src/drt/src/io/io.h
@@ -137,11 +137,10 @@ class Parser
   // temporary variables
   int readLayerCnt_;
   odb::dbTechLayer* masterSliceLayer_;
-  std::map<frMaster*,
-           std::map<dbOrientType,
-                    std::map<std::vector<frCoord>,
-                             std::set<frInst*, frBlockObjectComp>>>,
-           frBlockObjectComp>
+  frOrderedIdMap<
+      frMaster*,
+      std::map<dbOrientType,
+               std::map<std::vector<frCoord>, frOrderedIdSet<frInst*>>>>
       trackOffsetMap_;
   std::vector<frTrackPattern*> prefTrackPatterns_;
 };

--- a/src/drt/src/io/io_pin.cpp
+++ b/src/drt/src/io/io_pin.cpp
@@ -30,7 +30,7 @@ void io::Parser::instAnalysis()
   }
 
   int numLayers = getTech()->getLayers().size();
-  std::map<frMaster*, std::tuple<frLayerNum, frLayerNum>, frBlockObjectComp>
+  frOrderedIdMap<frMaster*, std::tuple<frLayerNum, frLayerNum>>
       masterPinLayerRange;
   for (auto& uMaster : getDesign()->getMasters()) {
     auto master = uMaster.get();

--- a/src/drt/src/pa/AbstractPAGraphics.h
+++ b/src/drt/src/pa/AbstractPAGraphics.h
@@ -19,12 +19,12 @@ class AbstractPAGraphics
 
   virtual void startPin(frBPin* pin,
                         frInstTerm* inst_term,
-                        std::set<frInst*, frBlockObjectComp>* inst_class)
+                        frOrderedIdSet<frInst*>* inst_class)
       = 0;
 
   virtual void startPin(frMPin* pin,
                         frInstTerm* inst_term,
-                        std::set<frInst*, frBlockObjectComp>* inst_class)
+                        frOrderedIdSet<frInst*>* inst_class)
       = 0;
 
   virtual void setAPs(const std::vector<std::unique_ptr<frAccessPoint>>& aps,

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -1332,7 +1332,7 @@ int FlexPA::genPinAccess(T* pin, frInstTerm* inst_term)
   std::set<std::pair<Point, frLayerNum>> apset;
 
   if (graphics_) {
-    std::set<frInst*, frBlockObjectComp>* inst_class = nullptr;
+    frOrderedIdSet<frInst*>* inst_class = nullptr;
     if (inst_term) {
       inst_class = unique_insts_.getClass(inst_term->getInst());
     }

--- a/src/drt/src/pa/FlexPA_graphics.cpp
+++ b/src/drt/src/pa/FlexPA_graphics.cpp
@@ -144,7 +144,7 @@ void FlexPAGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
 
 void FlexPAGraphics::startPin(frMPin* pin,
                               frInstTerm* inst_term,
-                              std::set<frInst*, frBlockObjectComp>* inst_class)
+                              frOrderedIdSet<frInst*>* inst_class)
 {
   pin_ = nullptr;
 
@@ -173,7 +173,7 @@ void FlexPAGraphics::startPin(frMPin* pin,
 
 void FlexPAGraphics::startPin(frBPin* pin,
                               frInstTerm* inst_term,
-                              std::set<frInst*, frBlockObjectComp>* inst_class)
+                              frOrderedIdSet<frInst*>* inst_class)
 {
   pin_ = nullptr;
 

--- a/src/drt/src/pa/FlexPA_graphics.h
+++ b/src/drt/src/pa/FlexPA_graphics.h
@@ -46,11 +46,11 @@ class FlexPAGraphics : public gui::Renderer, public AbstractPAGraphics
 
   void startPin(frBPin* pin,
                 frInstTerm* inst_term,
-                std::set<frInst*, frBlockObjectComp>* inst_class) override;
+                frOrderedIdSet<frInst*>* inst_class) override;
 
   void startPin(frMPin* pin,
                 frInstTerm* inst_term,
-                std::set<frInst*, frBlockObjectComp>* inst_class) override;
+                frOrderedIdSet<frInst*>* inst_class) override;
 
   void setAPs(const std::vector<std::unique_ptr<frAccessPoint>>& aps,
               frAccessPointEnum lower_type,

--- a/src/drt/src/pa/FlexPA_unique.h
+++ b/src/drt/src/pa/FlexPA_unique.h
@@ -22,7 +22,7 @@ namespace drt {
 class UniqueInsts
 {
  public:
-  using InstSet = std::set<frInst*, frBlockObjectComp>;
+  using InstSet = frOrderedIdSet<frInst*>;
   // if target_insts is non-empty then analysis is limited to
   // those instances.
   UniqueInsts(frDesign* design,
@@ -80,7 +80,7 @@ class UniqueInsts
 
  private:
   using LayerRange = std::pair<frLayerNum, frLayerNum>;
-  using MasterLayerRange = std::map<frMaster*, LayerRange, frBlockObjectComp>;
+  using MasterLayerRange = frOrderedIdMap<frMaster*, LayerRange>;
 
   frDesign* getDesign() const { return design_; }
   frTechObject* getTech() const { return design_->getTech(); }
@@ -149,15 +149,15 @@ class UniqueInsts
   // All the unique instances
   std::vector<frInst*> unique_;
   // Maps all instances to their representative unique instance
-  std::map<frInst*, frInst*, frBlockObjectComp> inst_to_unique_;
+  frOrderedIdMap<frInst*, frInst*> inst_to_unique_;
   // Maps all instances to the set of instances with the same unique inst
   std::unordered_map<frInst*, InstSet*> inst_to_class_;
   // Maps a unique instance to its index in unique_
-  std::map<frInst*, int, frBlockObjectComp> unique_to_idx_;
+  frOrderedIdMap<frInst*, int> unique_to_idx_;
   // master orient track-offset to instances
-  std::map<frMaster*,
-           std::map<dbOrientType, std::map<std::vector<frCoord>, InstSet>>,
-           frBlockObjectComp>
+  frOrderedIdMap<
+      frMaster*,
+      std::map<dbOrientType, std::map<std::vector<frCoord>, InstSet>>>
       master_orient_trackoffset_to_insts_;
   std::vector<frTrackPattern*> pref_track_patterns_;
   MasterLayerRange master_to_pin_layer_range_;

--- a/src/drt/src/ta/FlexTA.h
+++ b/src/drt/src/ta/FlexTA.h
@@ -58,7 +58,7 @@ class FlexTAWorkerRegionQuery
   void remove(taPinFig* fig);
   void query(const Rect& box,
              frLayerNum layerNum,
-             std::set<taPin*, frBlockObjectComp>& result) const;
+             frOrderedIdSet<taPin*>& result) const;
 
   void addCost(const Rect& box,
                frLayerNum layerNum,
@@ -252,38 +252,33 @@ class FlexTAWorker
                                       const Rect& box2,
                                       frCoord& dx,
                                       frCoord& dy);
-  void addCost(taPinFig* fig,
-               std::set<taPin*, frBlockObjectComp>* pinS = nullptr);
-  void subCost(taPinFig* fig,
-               std::set<taPin*, frBlockObjectComp>* pinS = nullptr);
+  void addCost(taPinFig* fig, frOrderedIdSet<taPin*>* pinS = nullptr);
+  void subCost(taPinFig* fig, frOrderedIdSet<taPin*>* pinS = nullptr);
   void modCost(taPinFig* fig,
                bool isAddCost,
-               std::set<taPin*, frBlockObjectComp>* pinS = nullptr);
+               frOrderedIdSet<taPin*>* pinS = nullptr);
   void modMinSpacingCostPlanar(const Rect& box,
                                frLayerNum lNum,
                                taPinFig* fig,
                                bool isAddCost,
-                               std::set<taPin*, frBlockObjectComp>* pinS
-                               = nullptr);
+                               frOrderedIdSet<taPin*>* pinS = nullptr);
   void modMinSpacingCostVia(const Rect& box,
                             frLayerNum lNum,
                             taPinFig* fig,
                             bool isAddCost,
                             bool isUpperVia,
                             bool isCurrPs,
-                            std::set<taPin*, frBlockObjectComp>* pinS
-                            = nullptr);
+                            frOrderedIdSet<taPin*>* pinS = nullptr);
   void modCutSpacingCost(const Rect& box,
                          frLayerNum lNum,
                          taPinFig* fig,
                          bool isAddCost,
-                         std::set<taPin*, frBlockObjectComp>* pinS = nullptr);
+                         frOrderedIdSet<taPin*>* pinS = nullptr);
 
   // initTA
   void assign();
   void assignIroute(taPin* iroute);
-  void assignIroute_init(taPin* iroute,
-                         std::set<taPin*, frBlockObjectComp>* pinS);
+  void assignIroute_init(taPin* iroute, frOrderedIdSet<taPin*>* pinS);
   void assignIroute_availTracks(taPin* iroute,
                                 frLayerNum& lNum,
                                 int& idx1,
@@ -311,8 +306,8 @@ class FlexTAWorker
                                          frLayerNum lNum);
   void assignIroute_updateIroute(taPin* iroute,
                                  frCoord bestTrackLoc,
-                                 std::set<taPin*, frBlockObjectComp>* pinS);
-  void assignIroute_updateOthers(std::set<taPin*, frBlockObjectComp>& pinS);
+                                 frOrderedIdSet<taPin*>* pinS);
+  void assignIroute_updateOthers(frOrderedIdSet<taPin*>& pinS);
 
   // end
   void end();

--- a/src/drt/src/ta/FlexTA_assign.cpp
+++ b/src/drt/src/ta/FlexTA_assign.cpp
@@ -23,12 +23,11 @@ frSquaredDistance FlexTAWorker::box2boxDistSquare(const Rect& box1,
 }
 
 // must be current TA layer
-void FlexTAWorker::modMinSpacingCostPlanar(
-    const Rect& box,
-    frLayerNum lNum,
-    taPinFig* fig,
-    bool isAddCost,
-    std::set<taPin*, frBlockObjectComp>* pinS)
+void FlexTAWorker::modMinSpacingCostPlanar(const Rect& box,
+                                           frLayerNum lNum,
+                                           taPinFig* fig,
+                                           bool isAddCost,
+                                           frOrderedIdSet<taPin*>* pinS)
 {
   // obj1 = curr obj
   frCoord width1 = box.minDXDY();
@@ -106,14 +105,13 @@ void FlexTAWorker::modMinSpacingCostPlanar(
 }
 
 // given a shape on any routing layer n, block via @(n+1) if isUpperVia is true
-void FlexTAWorker::modMinSpacingCostVia(
-    const Rect& box,
-    frLayerNum lNum,
-    taPinFig* fig,
-    bool isAddCost,
-    bool isUpperVia,
-    bool isCurrPs,
-    std::set<taPin*, frBlockObjectComp>* pinS)
+void FlexTAWorker::modMinSpacingCostVia(const Rect& box,
+                                        frLayerNum lNum,
+                                        taPinFig* fig,
+                                        bool isAddCost,
+                                        bool isUpperVia,
+                                        bool isCurrPs,
+                                        frOrderedIdSet<taPin*>* pinS)
 {
   // obj1 = curr obj
   frCoord width1 = box.minDXDY();
@@ -294,7 +292,7 @@ void FlexTAWorker::modCutSpacingCost(const Rect& box,
                                      frLayerNum lNum,
                                      taPinFig* fig,
                                      bool isAddCost,
-                                     std::set<taPin*, frBlockObjectComp>* pinS)
+                                     frOrderedIdSet<taPin*>* pinS)
 {
   if (!getDesign()->getTech()->getLayer(lNum)->hasCutSpacing()) {
     return;
@@ -492,21 +490,19 @@ void FlexTAWorker::modCutSpacingCost(const Rect& box,
   }
 }
 
-void FlexTAWorker::addCost(taPinFig* fig,
-                           std::set<taPin*, frBlockObjectComp>* pinS)
+void FlexTAWorker::addCost(taPinFig* fig, frOrderedIdSet<taPin*>* pinS)
 {
   modCost(fig, true, pinS);
 }
 
-void FlexTAWorker::subCost(taPinFig* fig,
-                           std::set<taPin*, frBlockObjectComp>* pinS)
+void FlexTAWorker::subCost(taPinFig* fig, frOrderedIdSet<taPin*>* pinS)
 {
   modCost(fig, false, pinS);
 }
 
 void FlexTAWorker::modCost(taPinFig* fig,
                            bool isAddCost,
-                           std::set<taPin*, frBlockObjectComp>* pinS)
+                           frOrderedIdSet<taPin*>* pinS)
 {
   if (fig->typeId() == tacPathSeg) {
     auto obj = static_cast<taPathSeg*>(fig);
@@ -879,7 +875,7 @@ frUInt4 FlexTAWorker::assignIroute_getAlignCost(taPin* iroute, frCoord trackLoc)
       auto lNum = obj->getLayerNum();
       pitch = getDesign()->getTech()->getLayer(lNum)->getPitch();
       auto& workerRegionQuery = getWorkerRegionQuery();
-      std::set<taPin*, frBlockObjectComp> result;
+      frOrderedIdSet<taPin*> result;
       Rect box;
       if (isH) {
         box.init(bp.x(), trackLoc, ep.x(), trackLoc);
@@ -1097,10 +1093,9 @@ int FlexTAWorker::assignIroute_bestTrack(taPin* iroute,
   return bestTrackLoc;
 }
 
-void FlexTAWorker::assignIroute_updateIroute(
-    taPin* iroute,
-    frCoord bestTrackLoc,
-    std::set<taPin*, frBlockObjectComp>* pinS)
+void FlexTAWorker::assignIroute_updateIroute(taPin* iroute,
+                                             frCoord bestTrackLoc,
+                                             frOrderedIdSet<taPin*>* pinS)
 {
   auto& workerRegionQuery = getWorkerRegionQuery();
   bool isH = (getDir() == dbTechLayerDir::HORIZONTAL);
@@ -1142,7 +1137,7 @@ void FlexTAWorker::assignIroute_updateIroute(
 }
 
 void FlexTAWorker::assignIroute_init(taPin* iroute,
-                                     std::set<taPin*, frBlockObjectComp>* pinS)
+                                     frOrderedIdSet<taPin*>* pinS)
 {
   auto& workerRegionQuery = getWorkerRegionQuery();
   // subCost
@@ -1155,8 +1150,7 @@ void FlexTAWorker::assignIroute_init(taPin* iroute,
   }
 }
 
-void FlexTAWorker::assignIroute_updateOthers(
-    std::set<taPin*, frBlockObjectComp>& pinS)
+void FlexTAWorker::assignIroute_updateOthers(frOrderedIdSet<taPin*>& pinS)
 {
   bool isH = (getDir() == dbTechLayerDir::HORIZONTAL);
   if (isInitTA()) {
@@ -1200,7 +1194,7 @@ void FlexTAWorker::assignIroute_updateOthers(
 
 void FlexTAWorker::assignIroute(taPin* iroute)
 {
-  std::set<taPin*, frBlockObjectComp> pinS;
+  frOrderedIdSet<taPin*> pinS;
   assignIroute_init(iroute, &pinS);
   frLayerNum lNum;
   int idx1, idx2;

--- a/src/drt/src/ta/FlexTA_rq.cpp
+++ b/src/drt/src/ta/FlexTA_rq.cpp
@@ -73,10 +73,9 @@ void FlexTAWorkerRegionQuery::remove(taPinFig* fig)
   }
 }
 
-void FlexTAWorkerRegionQuery::query(
-    const Rect& box,
-    const frLayerNum layerNum,
-    std::set<taPin*, frBlockObjectComp>& result) const
+void FlexTAWorkerRegionQuery::query(const Rect& box,
+                                    const frLayerNum layerNum,
+                                    frOrderedIdSet<taPin*>& result) const
 {
   std::vector<rq_box_value_t<taPinFig*>> temp;
   auto& tree = impl_->shapes_.at(layerNum);


### PR DESCRIPTION
Instead of manually having to define these containers with the comparator function, pre-define such containers with the comparator already configured.

Give them a name that makes it easy to see at a glance what they doe.

This improves readability and allows to play with various container implementations later.