### PR TITLE
drt: Use Bottom/Top routing layer in FlexDRWorker::initTrackCoords

### DIFF
--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -711,6 +711,7 @@ class FlexDRWorker
   void initTrackCoords_pin(drNet* net,
                            frLayerCoordTrackPatternMap& xMap,
                            frLayerCoordTrackPatternMap& yMap);
+  frLayerNum initTrackCoords_getNonPref(frLayerNum lNum);
   void initMazeIdx();
   void initMazeIdx_connFig(drConnFig* connFig);
   void initMazeIdx_ap(drAccessPattern* ap);

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -1562,6 +1562,43 @@ void FlexDRWorker::initNets(const frDesign* design)
   }
 }
 
+frLayerNum FlexDRWorker::initTrackCoords_getNonPref(frLayerNum lNum)
+{
+  const auto lDir = getTech()->getLayer(lNum)->getDir();
+  auto lDir2 = dbTechLayerDir::NONE;
+
+  switch (lDir) {
+    case dbTechLayerDir::HORIZONTAL:
+      lDir2 = dbTechLayerDir::VERTICAL;
+      break;
+    case dbTechLayerDir::VERTICAL:
+      lDir2 = dbTechLayerDir::HORIZONTAL;
+      break;
+    case dbTechLayerDir::NONE:
+      logger_->error(DRT, 49, "initTrackCoords invalid routing direction");
+      return -1;
+  }
+
+  frLayerNum lTop
+      = std::min(router_cfg_->TOP_ROUTING_LAYER, getTech()->getTopLayerNum());
+  frLayerNum lBot = std::max(router_cfg_->BOTTOM_ROUTING_LAYER,
+                             getTech()->getBottomLayerNum());
+
+  if ((lNum + 2 <= lTop)
+      && (getTech()->getLayer(lNum + 2)->getDir() == lDir2)) {
+    return lNum + 2;
+  }
+
+  if ((lNum - 2 >= lBot)
+      && (getTech()->getLayer(lNum - 2)->getDir() == lDir2)) {
+    return lNum - 2;
+  }
+
+  logger_->error(DRT, 64, "initTrackCoords cannot add non-pref track");
+
+  return -1;
+}
+
 void FlexDRWorker::initTrackCoords_route(drNet* net,
                                          frLayerCoordTrackPatternMap& xMap,
                                          frLayerCoordTrackPatternMap& yMap)
@@ -1579,69 +1616,32 @@ void FlexDRWorker::initTrackCoords_route(drNet* net,
       auto obj = static_cast<drPathSeg*>(uConnFig);
       const auto [bp, ep] = obj->getPoints();
       const auto lNum = obj->getLayerNum();
+      const auto lNum2 = initTrackCoords_getNonPref(lNum);
       // vertical
       if (bp.x() == ep.x()) {
         // non pref dir
         if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::HORIZONTAL) {
-          if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            xMap[lNum + 2][bp.x()]
-                = nullptr;  // default add track to upper layer
-          } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            xMap[lNum - 2][bp.x()] = nullptr;
-          } else {
-            std::cout << "Error: initTrackCoords cannot add non-pref track"
-                      << std::endl;
-          }
-          // add bp, ep
+          xMap[lNum2][bp.x()] = nullptr;
           yMap[lNum][bp.y()] = nullptr;
           yMap[lNum][ep.y()] = nullptr;
           // pref dir
         } else {
           xMap[lNum][bp.x()] = nullptr;
-          // add bp, ep
-          if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            yMap[lNum + 2][bp.y()]
-                = nullptr;  // default add track to upper layer
-            yMap[lNum + 2][ep.y()]
-                = nullptr;  // default add track to upper layer
-          } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            yMap[lNum - 2][bp.y()] = nullptr;
-            yMap[lNum - 2][ep.y()] = nullptr;
-          } else {
-            std::cout << "Error: initTrackCoords cannot add non-pref track"
-                      << std::endl;
-          }
+          yMap[lNum2][bp.y()] = nullptr;
+          yMap[lNum2][ep.y()] = nullptr;
         }
         // horizontal
       } else {
         // non pref dir
         if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::VERTICAL) {
-          if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            yMap[lNum + 2][bp.y()] = nullptr;
-          } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            yMap[lNum - 2][bp.y()] = nullptr;
-          } else {
-            std::cout << "Error: initTrackCoords cannot add non-pref track"
-                      << std::endl;
-          }
-          // add bp, ep
           xMap[lNum][bp.x()] = nullptr;
           xMap[lNum][ep.x()] = nullptr;
+          yMap[lNum2][bp.y()] = nullptr;
+          // pref dir
         } else {
+          xMap[lNum2][bp.x()] = nullptr;
+          xMap[lNum2][ep.x()] = nullptr;
           yMap[lNum][bp.y()] = nullptr;
-          // add bp, ep
-          if (lNum + 2 <= getTech()->getTopLayerNum()) {
-            xMap[lNum + 2][bp.x()]
-                = nullptr;  // default add track to upper layer
-            xMap[lNum + 2][ep.x()]
-                = nullptr;  // default add track to upper layer
-          } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-            xMap[lNum - 2][bp.x()] = nullptr;
-            xMap[lNum - 2][ep.x()] = nullptr;
-          } else {
-            std::cout << "Error: initTrackCoords cannot add non-pref track"
-                      << std::endl;
-          }
         }
       }
     } else if (uConnFig->typeId() == drcVia) {
@@ -1679,26 +1679,17 @@ void FlexDRWorker::initTrackCoords_pin(drNet* net,
     for (auto& ap : pin->getAccessPatterns()) {
       const Point pt = ap->getPoint();
       const auto lNum = ap->getBeginLayerNum();
-      frLayerNum lNum2 = 0;
-      if (lNum + 2 <= getTech()->getTopLayerNum()) {
-        lNum2 = lNum + 2;
-      } else if (lNum - 2 >= getTech()->getBottomLayerNum()) {
-        lNum2 = lNum - 2;
-      } else {
-        std::cout << "Error: initTrackCoords cannot add non-pref track"
-                  << std::endl;
-      }
+      const auto lNum2 = initTrackCoords_getNonPref(lNum);
+
       gridGraph_.addAccessPointLocation(lNum, pt.x(), pt.y());
       gridGraph_.addAccessPointLocation(lNum2, pt.x(), pt.y());
+
       if (getTech()->getLayer(lNum)->getDir() == dbTechLayerDir::HORIZONTAL) {
+        xMap[lNum2][pt.x()] = nullptr;
         yMap[lNum][pt.y()] = nullptr;
       } else {
         xMap[lNum][pt.x()] = nullptr;
-      }
-      if (getTech()->getLayer(lNum2)->getDir() == dbTechLayerDir::HORIZONTAL) {
         yMap[lNum2][pt.y()] = nullptr;
-      } else {
-        xMap[lNum2][pt.x()] = nullptr;
       }
     }
   }


### PR DESCRIPTION
When trying to find a matching layer in the other routing direction, the search is limited to layers selected for routing rather than all tech layers.

In addition, the code now also checks the layer is in the actual routing direction that's expected.

Finally because that code logic was duplicated a few times, it gets isolated in a helper function to make it easier to follow and track what's going on.