### PR TITLE
bazel: use TEST_TEMPDIR for results folder

### DIFF
--- a/src/grt/test/congestion7.tcl
+++ b/src/grt/test/congestion7.tcl
@@ -20,5 +20,6 @@ diff_file congestion7.guideok $guide_file
 diff_file congestion7.rptok $rpt_file
 
 # check the congestion progress reports generated
-diff_file congestion7-20.rptok ./results/congestion7-tcl-20.rpt
-diff_file congestion7-40.rptok ./results/congestion7-tcl-40.rpt
+set rpt_folder [file dirname $rpt_file]
+diff_file congestion7-20.rptok [file join $rpt_folder congestion7-tcl-20.rpt]
+diff_file congestion7-40.rptok [file join $rpt_folder congestion7-tcl-40.rpt]

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -1,6 +1,10 @@
 # Helper functions common to multiple regressions.
 
-set test_dir [file dirname [file normalize [info script]]]
+if {[info exists ::env(TEST_TMPDIR)]} {
+  set test_dir $::env(TEST_TMPDIR)
+} else {
+  set test_dir [file dirname [file normalize [info script]]]
+}
 set result_dir [file join $test_dir "results"]
 
 proc make_result_file { filename } {


### PR DESCRIPTION
fixes #7109

To examine a failing test, re-run it with:

    bazel test --test_output=all --sandbox_debug //path/to:test