### PR TITLE
bazel: Add config with debug flags useful for creating a profile.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -41,6 +41,12 @@ build:asan --copt -g
 build:asan --copt -fno-omit-frame-pointer
 build:asan --linkopt -fsanitize=address
 
+# Flags with enough debug symbols to get useful outputs with Linux `perf`
+build:profile --strip=never
+build:profile --copt -g
+build:profile --copt -gmlt
+build:profile --copt -fno-omit-frame-pointer
+
 # TODO: document
 build --incompatible_strict_action_env
 


### PR DESCRIPTION
To create a executables that keep enough debug information to retain useful symbols for use in e.g. running Linux `perf`

```
bazel build -c opt --config=profile //:openroad
```