### PR TITLE
CTS fix wrong clock net skiping

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -1159,7 +1159,8 @@ bool TritonCTS::separateMacroRegSinks(
   for (odb::dbITerm* iterm : net->getITerms()) {
     odb::dbInst* inst = iterm->getInst();
 
-    if (buffer_masters.find(inst->getMaster()) != buffer_masters.end()) {
+    if (buffer_masters.find(inst->getMaster()) != buffer_masters.end()
+        && inst->getSourceType() == odb::dbSourceType::TIMING) {
       logger_->warn(CTS,
                     105,
                     "Net \"{}\" already has clock buffer {}. Skipping...",


### PR DESCRIPTION
Fixes [#6352](https://github.com/The-OpenROAD-Project/OpenROAD/issues/6352)

CTS skips building the clock tree for clock nets that already have a clock tree. The way CTS checks if the clock tree is already generated is by looking at the clock nets and checking if there is a clock buffer in it and if the master of the buffer is the same as the masters used by CTS.

This check can cause a misunderstanding, if there is a buffer in the clock tree that is not from a clock tree but has the same master, and it will skip creating a clock tree when it shouldn't.

This PR fixes this by also checking the source type of the buffer, and only skips if the source of the buffer is `TIMING`.