### PR TITLE
bazel: expose compilation mode to build_type to allow to proper splash

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -93,7 +93,7 @@ OPENROAD_COPTS = [
 
 OPENROAD_DEFINES = [
     "OPENROAD_GIT_DESCRIBE=\\\"bazel-build\\\"",
-    "BUILD_TYPE=\\\"release\\\"",
+    "BUILD_TYPE=\\\"$(COMPILATION_MODE)\\\"",
     "GPU=false",
     "BUILD_PYTHON=false",
     "ABC_NAMESPACE=abc",

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -591,7 +591,11 @@ static void showSplash()
       ord::OpenRoad::getGPUCompileOption() ? "+" : "-",
       ord::OpenRoad::getGUICompileOption() ? "+" : "-",
       ord::OpenRoad::getPythonCompileOption() ? "+" : "-",
+#ifdef BAZEL_CURRENT_REPOSITORY
+      strcasecmp(BUILD_TYPE, "opt") == 0
+#else
       strcasecmp(BUILD_TYPE, "release") == 0
+#endif
           ? ""
           : fmt::format(" : {}", BUILD_TYPE));
   logger->report(


### PR DESCRIPTION
Closes https://github.com/The-OpenROAD-Project/OpenROAD/issues/7111

Adds enablement for bazel to control BUILD_TYPE (assuming "opt" is equalish to release in bazel)