### PR TITLE
gpl: bugfix for desync between divergence member fields

### DIFF
--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -587,6 +587,7 @@ int NesterovPlace::doNesterovPlace(int start_iter)
     }
 
     if (numDiverge > 0) {
+      isDiverged_ = true;
       log_->report("Divergence occured in {} regions.", numDiverge);
 
       // TODO: this divergence treatment uses the non-deterministic aspect of


### PR DESCRIPTION
When using `global_placement -disable_revert_if_diverge` Nesterov can diverge  without returning an error:

```
[NesterovSolve] Iter: 3880 overflow: 0.138 HPWL: 174132312097
[NesterovSolve] Iter: 3890 overflow: 0.137 HPWL: 182727771488
[NesterovSolve] Iter: 3900 overflow: 0.171 HPWL: 302608526652
Divergence occured in 1 regions.
<next command output>
```

NesterovPlace has private field isDiverged_ [1] which is the actual bool used for exiting with divergence in the core nesterov loop. NesterovPlace also has its private std::vector\<NesterovBase\>, which has its own float isDiverged_ [2]. When the loop does divergence detection [3], the condition for divergence is met but only NesterovBase's isDiverged_ is set, and then NesterovPlace's numDiverge is incremented, but NesterovPlace's isDiverged_ remains false (not updated). with disableRevertIfDiverge set to true, it skips checking for revert and breaks out of the loop here [4]. NesterovPlace's isDiverged_  is never updated again and an error is omitted. 

[1] https://github.com/The-OpenROAD-Project/OpenROAD/blob/359623a96826d2137a82ffcd90b6d94627f2466a/src/gpl/src/nesterovPlace.h#L115

[2] https://github.com/The-OpenROAD-Project/OpenROAD/blob/359623a96826d2137a82ffcd90b6d94627f2466a/src/gpl/src/nesterovBase.h#L1159

[3] https://github.com/The-OpenROAD-Project/OpenROAD/blob/359623a96826d2137a82ffcd90b6d94627f2466a/src/gpl/src/nesterovPlace.cpp#L586

[4] https://github.com/The-OpenROAD-Project/OpenROAD/blob/359623a96826d2137a82ffcd90b6d94627f2466a/src/gpl/src/nesterovPlace.cpp#L641