### PR TITLE
gpl: simplify divergence detection logic

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2611,8 +2611,6 @@ bool NesterovBase::nesterovUpdateStepLength()
 
   if (std::isnan(newStepLength) || std::isinf(newStepLength)) {
     isDiverged_ = true;
-    divergeMsg_ = "RePlAce diverged at newStepLength.";
-    divergeCode_ = 305;
     return false;
   }
 
@@ -2805,9 +2803,6 @@ bool NesterovBase::checkDivergence()
   if (sumOverflowUnscaled_ < 0.2f
       && sumOverflowUnscaled_ - minSumOverflow_ >= 0.02f
       && hpwlWithMinSumOverflow_ * 1.2f < prevHpwl_) {
-    divergeMsg_ = "RePlAce divergence detected. ";
-    divergeMsg_ += "Re-run with a smaller max_phi_cof value.";
-    divergeCode_ = 307;
     isDiverged_ = true;
   }
 
@@ -2830,8 +2825,6 @@ bool NesterovBase::revertToSnapshot()
   updateDensityForceBin();
 
   isDiverged_ = false;
-  divergeCode_ = 0;
-  divergeMsg_ = "";
 
   return true;
 }

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -1156,10 +1156,7 @@ class NesterovBase
   int64_t prevHpwl_ = 0;
   int64_t prevReportedHpwl_ = 0;
 
-  float isDiverged_ = false;
-
-  std::string divergeMsg_;
-  int divergeCode_ = 0;
+  bool isDiverged_ = false;
 
   NesterovPlaceVars* npVars_;
 

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -72,10 +72,10 @@ NesterovPlace::~NesterovPlace()
 void NesterovPlace::updatePrevGradient(const std::shared_ptr<NesterovBase>& nb)
 {
   nb->updatePrevGradient(wireLengthCoefX_, wireLengthCoefY_);
-  auto wireLengthGradSum_ = nb->getWireLengthGradSum();
-  auto densityGradSum_ = nb->getDensityGradSum();
+  float wireLengthGradSum = nb->getWireLengthGradSum();
+  float densityGradSum = nb->getDensityGradSum();
 
-  if (wireLengthGradSum_ == 0
+  if (wireLengthGradSum == 0
       && recursionCntWlCoef_ < gpl::NesterovPlaceVars::maxRecursionWlCoef) {
     wireLengthCoefX_ *= 0.5;
     wireLengthCoefY_ *= 0.5;
@@ -98,23 +98,16 @@ void NesterovPlace::updatePrevGradient(const std::shared_ptr<NesterovBase>& nb)
     return;
   }
 
-  // divergence detection on
-  // Wirelength / density gradient calculation
-  if (std::isnan(wireLengthGradSum_) || std::isinf(wireLengthGradSum_)
-      || std::isnan(densityGradSum_) || std::isinf(densityGradSum_)) {
-    num_region_diverged_ = 1;
-    divergeMsg_ = "RePlAce diverged at wire/density gradient Sum.";
-    divergeCode_ = 306;
-  }
+  checkInvalidValues(wireLengthGradSum, densityGradSum);
 }
 
 void NesterovPlace::updateCurGradient(const std::shared_ptr<NesterovBase>& nb)
 {
   nb->updateCurGradient(wireLengthCoefX_, wireLengthCoefY_);
-  auto wireLengthGradSum_ = nb->getWireLengthGradSum();
-  auto densityGradSum_ = nb->getDensityGradSum();
+  float wireLengthGradSum = nb->getWireLengthGradSum();
+  float densityGradSum = nb->getDensityGradSum();
 
-  if (wireLengthGradSum_ == 0
+  if (wireLengthGradSum == 0
       && recursionCntWlCoef_ < gpl::NesterovPlaceVars::maxRecursionWlCoef) {
     wireLengthCoefX_ *= 0.5;
     wireLengthCoefY_ *= 0.5;
@@ -137,24 +130,17 @@ void NesterovPlace::updateCurGradient(const std::shared_ptr<NesterovBase>& nb)
     return;
   }
 
-  // divergence detection on
-  // Wirelength / density gradient calculation
-  if (std::isnan(wireLengthGradSum_) || std::isinf(wireLengthGradSum_)
-      || std::isnan(densityGradSum_) || std::isinf(densityGradSum_)) {
-    num_region_diverged_ = 1;
-    divergeMsg_ = "RePlAce diverged at wire/density gradient Sum.";
-    divergeCode_ = 306;
-  }
+  checkInvalidValues(wireLengthGradSum, densityGradSum);
 }
 
 void NesterovPlace::updateNextGradient(const std::shared_ptr<NesterovBase>& nb)
 {
   nb->updateNextGradient(wireLengthCoefX_, wireLengthCoefY_);
 
-  auto wireLengthGradSum_ = nb->getWireLengthGradSum();
-  auto densityGradSum_ = nb->getDensityGradSum();
+  float wireLengthGradSum = nb->getWireLengthGradSum();
+  float densityGradSum = nb->getDensityGradSum();
 
-  if (wireLengthGradSum_ == 0
+  if (wireLengthGradSum == 0
       && recursionCntWlCoef_ < gpl::NesterovPlaceVars::maxRecursionWlCoef) {
     wireLengthCoefX_ *= 0.5;
     wireLengthCoefY_ *= 0.5;
@@ -176,15 +162,7 @@ void NesterovPlace::updateNextGradient(const std::shared_ptr<NesterovBase>& nb)
     updateNextGradient(nb);
     return;
   }
-
-  // divergence detection on
-  // Wirelength / density gradient calculation
-  if (std::isnan(wireLengthGradSum_) || std::isinf(wireLengthGradSum_)
-      || std::isnan(densityGradSum_) || std::isinf(densityGradSum_)) {
-    num_region_diverged_ = 1;
-    divergeMsg_ = "RePlAce diverged at wire/density gradient Sum.";
-    divergeCode_ = 306;
-  }
+  checkInvalidValues(wireLengthGradSum, densityGradSum);
 }
 
 void NesterovPlace::init()
@@ -771,6 +749,22 @@ void NesterovPlace::updateNextIter(const int iter)
 void NesterovPlace::updateDb()
 {
   nbc_->updateDbGCells();
+}
+
+// divergence detection on
+// Wirelength / density gradient calculation
+void NesterovPlace::checkInvalidValues(float wireLengthGradSum,
+                                       float densityGradSum)
+{
+  if (std::isnan(wireLengthGradSum) || std::isnan(densityGradSum)
+      || std::isinf(wireLengthGradSum) || std::isinf(densityGradSum)) {
+    divergeMsg_
+        = "RePlAce diverged at wire/density gradient Sum. An internal value is "
+          "NaN or Inf.";
+    divergeCode_ = 306;
+    num_region_diverged_ = 1;
+    return;
+  }
 }
 
 nesterovDbCbk::nesterovDbCbk(NesterovPlace* nesterov_place)

--- a/src/gpl/src/nesterovPlace.h
+++ b/src/gpl/src/nesterovPlace.h
@@ -112,7 +112,7 @@ class NesterovPlace
   // half-parameter-wire-length
   int64_t prevHpwl_ = 0;
 
-  bool isDiverged_ = false;
+  int num_region_diverged_ = 0;
   bool is_routability_need_ = true;
   float routability_save_snapshot_ = 0.6;
 

--- a/src/gpl/src/nesterovPlace.h
+++ b/src/gpl/src/nesterovPlace.h
@@ -52,6 +52,8 @@ class NesterovPlace
 
   void updateDb();
 
+  void checkInvalidValues(float wireLengthGradSum, float densityGradSum);
+
   float getWireLengthCoefX() const { return wireLengthCoefX_; }
   float getWireLengthCoefY() const { return wireLengthCoefY_; }
 


### PR DESCRIPTION
Instead of using both an error counter per region and a boolean flag to check for divergences, use only the counter and check if it's greater than zero where needed.

Remove unnecessary variables. Since NesterovPlace reports the errors, there's no need for a separate error message in NesterovBase.

Ensure that the divergence snapshot is stored after checking for divergence.