### PR TITLE
grt: do not init clock nets when checking if design is routed

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -406,7 +406,7 @@ class GlobalRouter : public ant::GlobalRouteSource
   void initGrid(int max_layer);
   void computeCapacities(int max_layer);
   void findTrackPitches(int max_layer);
-  std::vector<Net*> findNets();
+  std::vector<Net*> findNets(bool init_clock_nets);
   void computeObstructionsAdjustments();
   void findLayerExtensions(std::vector<int>& layer_extensions);
   int findObstructions(odb::Rect& die_area);

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -158,7 +158,7 @@ std::vector<Net*> GlobalRouter::initFastRoute(int min_routing_layer,
   applyAdjustments(min_routing_layer, max_routing_layer);
   perturbCapacities();
 
-  std::vector<Net*> nets = findNets();
+  std::vector<Net*> nets = findNets(true);
   checkPinPlacement();
   initNetlist(nets);
 
@@ -2037,7 +2037,7 @@ void GlobalRouter::initGridAndNets()
     setCapacities(min_layer, max_layer);
     applyAdjustments(min_layer, max_layer);
   }
-  std::vector<Net*> nets = findNets();
+  std::vector<Net*> nets = findNets(false);
   initNetlist(nets);
 }
 
@@ -3461,9 +3461,11 @@ static bool nameLess(const Net* a, const Net* b)
   return a->getName() < b->getName();
 }
 
-std::vector<Net*> GlobalRouter::findNets()
+std::vector<Net*> GlobalRouter::findNets(bool init_clock_nets)
 {
-  initClockNets();
+  if (init_clock_nets) {
+    initClockNets();
+  }
 
   std::vector<odb::dbNet*> db_nets;
   if (nets_to_route_.empty()) {


### PR DESCRIPTION
Partial solution for https://github.com/The-OpenROAD-Project/OpenROAD/issues/7100.