### PR TITLE
drt: obedient acc point generation

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -216,7 +216,7 @@ class FlexPA
    * for planar access
    */
   template <typename T>
-  int FlexPA::genPinAccessViaSpecific(
+  int genPinAccessViaSpecific(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,
       std::set<std::pair<Point, frLayerNum>>& apset,
       std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -211,6 +211,19 @@ class FlexPA
       frAccessPointEnum lower_type,
       frAccessPointEnum upper_type);
 
+  /**
+   * @brief generates access points for a specific via type. Set via = nullptr
+   * for planar access
+   */
+  template <typename T>
+  int FlexPA::genPinAccessViaSpecific(
+      std::vector<std::unique_ptr<frAccessPoint>>& aps,
+      std::set<std::pair<Point, frLayerNum>>& apset,
+      std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
+      T* pin,
+      frInstTerm* inst_term,
+      frVia* via);
+
   void getViasFromMetalWidthMap(
       const Point& pt,
       frLayerNum layer_num,
@@ -435,7 +448,7 @@ class FlexPA
       const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
       T* pin,
       frInstTerm* inst_term,
-      const bool& is_std_cell_pin);
+      const bool is_std_cell_pin);
 
   /**
    * @brief Filters the accesses of a single access point
@@ -445,7 +458,7 @@ class FlexPA
    * @param polys a vector of pin shapes on all layers of the current pin
    * @param pin access pin
    * @param inst_term terminal
-   * @param deep_search TODO: not sure
+   * @param try_all_vias wether or not all vias will be attempted
    */
   template <typename T>
   void filterSingleAPAccesses(
@@ -454,7 +467,7 @@ class FlexPA
       const std::vector<gtl::polygon_90_data<frCoord>>& polys,
       T* pin,
       frInstTerm* inst_term,
-      bool deep_search = false);
+      bool try_all_vias = false);
 
   /**
    * @brief Filters access in a given planar direction.
@@ -530,8 +543,7 @@ class FlexPA
    * @param polyset polys auxilary set (same information as polys)
    * @param pin access pin
    * @param inst_term instance terminal
-   * @param deep_search TODO: I understand one of its uses but not why "deep
-   * search"
+   * @param try_all_vias wether or not all vias will be attempted
    */
   template <typename T>
   void filterViaAccess(
@@ -540,7 +552,7 @@ class FlexPA
       const gtl::polygon_90_set_data<frCoord>& polyset,
       T* pin,
       frInstTerm* inst_term,
-      bool deep_search = false);
+      bool try_all_vias = false);
 
   /**
    * @brief Checks if a Via has at least one valid planar access

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -211,19 +211,6 @@ class FlexPA
       frAccessPointEnum lower_type,
       frAccessPointEnum upper_type);
 
-  /**
-   * @brief generates access points for a specific via type. Set via = nullptr
-   * for planar access
-   */
-  template <typename T>
-  int genPinAccessViaSpecific(
-      std::vector<std::unique_ptr<frAccessPoint>>& aps,
-      std::set<std::pair<Point, frLayerNum>>& apset,
-      std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
-      T* pin,
-      frInstTerm* inst_term,
-      frVia* via);
-
   void getViasFromMetalWidthMap(
       const Point& pt,
       frLayerNum layer_num,
@@ -331,12 +318,10 @@ class FlexPA
    * will generate a Centered access point to compensate
    *
    * @param coords map from candidate access points to their cost
-   * @param layer_num number of the layer
    * @param low lower range of coordinates considered
    * @param high higher range of coordinates considered
    */
   void genAPCentered(std::map<frCoord, frAccessPointEnum>& coords,
-                     frLayerNum layer_num,
                      frCoord low,
                      frCoord high);
 
@@ -448,7 +433,7 @@ class FlexPA
       const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
       T* pin,
       frInstTerm* inst_term,
-      const bool is_std_cell_pin);
+      bool is_std_cell_pin);
 
   /**
    * @brief Filters the accesses of a single access point

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -70,20 +70,20 @@ void FlexPA::genAPCentered(std::map<frCoord, frAccessPointEnum>& coords,
                            const frCoord low,
                            const frCoord high)
 {
-  // if touching two tracks, then no center??
-  int candidates_on_grid = 0;
-  for (auto it = coords.lower_bound(low); it != coords.end(); it++) {
-    auto& [coordinate, cost] = *it;
-    if (coordinate > high) {
-      break;
-    }
-    if (cost == frAccessPointEnum::OnGrid) {
-      candidates_on_grid++;
-    }
-  }
-  if (candidates_on_grid >= 3) {
-    return;
-  }
+  // // if touching two tracks, then no center??
+  // int candidates_on_grid = 0;
+  // for (auto it = coords.lower_bound(low); it != coords.end(); it++) {
+  //   auto& [coordinate, cost] = *it;
+  //   if (coordinate > high) {
+  //     break;
+  //   }
+  //   if (cost == frAccessPointEnum::OnGrid) {
+  //     candidates_on_grid++;
+  //   }
+  // }
+  // if (candidates_on_grid >= 3) {
+  //   return;
+  // }
 
   // If there are less than 3 coords OnGrid will create a Centered Access Point
   frCoord manu_grid = getDesign()->getTech()->getManufacturingGrid();
@@ -388,8 +388,6 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
    * ? hwidth : 0;
    */
   const int offset = is_macro_cell_pin && !use_center_line ? hwidth : 0;
-  const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
-  const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
   auto& layer1_coords = is_layer1_horz ? y_coords : x_coords;
   auto& layer2_coords = is_layer1_horz ? x_coords : y_coords;
 
@@ -423,6 +421,8 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
       }
     }
   } else {
+    const int layer1_rect_min = is_layer1_horz ? gtl::yl(rect) : gtl::xl(rect);
+    const int layer1_rect_max = is_layer1_horz ? gtl::yh(rect) : gtl::xh(rect);
     genAPCentered(layer1_coords, layer_num, layer1_rect_min, layer1_rect_max);
     for (auto& [layer1_coord, cost] : layer1_coords) {
       layer1_coords[layer1_coord] = frAccessPointEnum::OnGrid;
@@ -1339,6 +1339,7 @@ int FlexPA::genPinAccessViaSpecific(
     frInstTerm* inst_term,
     frVia* via)
 {
+  return 0;
 }
 
 // first create all access points with costs

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -385,10 +385,11 @@ void FlexPA::genAPsFromRect(std::vector<std::unique_ptr<frAccessPoint>>& aps,
               !is_layer1_horz,
               offset);
   if (!is_macro_cell_pin || !use_center_line) {
+    auto base_layer_num = layer_num;  // clang-tidy pleaser
     genAPCosted(lower_type,
                 layer1_coords,
                 layer1_track_coords,
-                layer_num,
+                base_layer_num,
                 layer_num,
                 rect,
                 is_layer1_horz);

--- a/src/drt/test/ispd18_sample.defok
+++ b/src/drt/test/ispd18_sample.defok
@@ -63,14 +63,14 @@ NETS 11 ;
       NEW Metal2 ( 95800 78470 ) VIA23_1C
       NEW Metal1 ( 95800 83790 ) VIA12_1C_V ;
     - net1231 ( inst5821 B ) ( inst5275 Y ) + USE SIGNAL
-      + ROUTED Metal3 ( 85800 77710 ) ( 91000 * )
-      NEW Metal2 ( 85800 77710 ) ( * 86450 )
-      NEW Metal2 ( 85400 86450 ) ( 85800 * )
-      NEW Metal1 ( 91000 77710 ) VIA12_1C_V
-      NEW Metal2 ( 91000 77710 ) VIA23_1C
-      NEW Metal2 ( 85800 77710 ) VIA23_1C
-      NEW Metal1 ( 85400 86450 ) VIA12_1C_V
-      NEW Metal2 ( 91000 77710 ) RECT ( -70 -442 70 0 )  ;
+      + ROUTED Metal2 ( 90600 76950 ) ( 91000 * )
+      NEW Metal2 ( 90600 76950 ) ( * 81890 )
+      NEW Metal3 ( 85400 81890 ) ( 90600 * )
+      NEW Metal2 ( 85400 81890 ) ( * 86450 )
+      NEW Metal1 ( 91000 76950 ) VIA12_1C_V
+      NEW Metal2 ( 90600 81890 ) VIA23_1C
+      NEW Metal2 ( 85400 81890 ) VIA23_1C
+      NEW Metal1 ( 85400 86450 ) VIA12_1C_V ;
     - net1232 ( inst4382 C ) ( inst4062 Y ) + USE SIGNAL
       + ROUTED Metal3 ( 85400 79990 ) ( 98200 * )
       NEW Metal2 ( 98200 79990 ) ( * 86450 )
@@ -136,12 +136,12 @@ NETS 11 ;
       NEW Metal1 ( 91800 86830 ) VIA12_1C_V
       NEW Metal2 ( 102600 80370 ) RECT ( -70 -442 70 0 )  ;
     - net1240 ( inst3502 A ) ( inst2015 Y ) + USE SIGNAL
-      + ROUTED Metal2 ( 91000 79230 ) ( * 80750 )
-      NEW Metal3 ( 91000 79230 ) ( 96200 * )
-      NEW Metal2 ( 96200 76950 ) ( * 79230 )
-      NEW Metal1 ( 91000 80750 ) VIA12_1C
-      NEW Metal2 ( 91000 79230 ) VIA23_1C
-      NEW Metal2 ( 96200 79230 ) VIA23_1C
-      NEW Metal1 ( 96200 76950 ) VIA12_1C_V ;
+      + ROUTED Metal2 ( 96200 76950 ) ( * 77710 )
+      NEW Metal3 ( 91000 77710 ) ( 96200 * )
+      NEW Metal2 ( 91000 77710 ) ( * 80750 )
+      NEW Metal1 ( 96200 76950 ) VIA12_1C_V
+      NEW Metal2 ( 96200 77710 ) VIA23_1C
+      NEW Metal2 ( 91000 77710 ) VIA23_1C
+      NEW Metal1 ( 91000 80750 ) VIA12_1C ;
 END NETS
 END DESIGN


### PR DESCRIPTION
Supports #7153.

### genAPCentered
Currently, `genAPCentered` can decide to not generate an access point if it detects that 3 OnTrack access points were already generated. This comes directly of [Tao of PAO](https://doi.org/10.1109/DAC18072.2020.9218532), page 3, first paragraph. This limitation expects all access points to be generated at once, which is not the case in our flow.

#### try_all_vias
On a minor note I (Matt actually) finally understood what `deep_search` means. It means it will try every single via when validating that access point. Therefore `deep_search` was renamed to `try_all_vias`