### PR TITLE
Add libstdc++ dependence in Ubuntu versions

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -371,6 +371,14 @@ _installUbuntuPackages() {
         zlib1g-dev
 
     packages=()
+
+    # Choose libstdc++ version
+    if _versionCompare $1 -ge 24.04; then
+        packages+=("libstdc++-14-dev")
+    elif _versionCompare $1 -ge 22.10; then
+        packages+=("libstdc++-12-dev")
+    fi
+
     # Chose Python version
     if _versionCompare $1 -ge 24.04; then
         packages+=("libpython3.12")


### PR DESCRIPTION
This should fix the dependency problem in 
https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2937
I wasn't sure if there was a version needed for Ubuntu 20.04, however.