### PR TITLE
drt: genViaEnclosedCoord

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -327,6 +327,12 @@ class FlexPA
                      frCoord low,
                      frCoord high);
 
+  void genViaEnclosedCoords(std::map<frCoord, frAccessPointEnum>& coords,
+                            const gtl::rectangle_data<frCoord>& rect,
+                            const frViaDef* via_def,
+                            const frLayerNum layer_num,
+                            const bool is_curr_layer_horz);
+
   /**
    * @brief Generates an Enclosed Boundary access point
    *

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -330,8 +330,8 @@ class FlexPA
   void genViaEnclosedCoords(std::map<frCoord, frAccessPointEnum>& coords,
                             const gtl::rectangle_data<frCoord>& rect,
                             const frViaDef* via_def,
-                            const frLayerNum layer_num,
-                            const bool is_curr_layer_horz);
+                            frLayerNum layer_num,
+                            bool is_curr_layer_horz);
 
   /**
    * @brief Generates an Enclosed Boundary access point

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -96,6 +96,34 @@ void FlexPA::genAPCentered(std::map<frCoord, frAccessPointEnum>& coords,
   }
 }
 
+void FlexPA::genViaEnclosedCoords(std::map<frCoord, frAccessPointEnum>& coords,
+                                  const gtl::rectangle_data<frCoord>& rect,
+                                  const frViaDef* via_def,
+                                  const frLayerNum layer_num,
+                                  const bool is_curr_layer_horz)
+{
+  const auto rect_width = gtl::delta(rect, gtl::HORIZONTAL);
+  const auto rect_height = gtl::delta(rect, gtl::VERTICAL);
+  frVia via(via_def);
+  const Rect box = via.getLayer1BBox();
+  const auto via_width = box.dx();
+  const auto via_height = box.dy();
+  if (via_width > rect_width || via_height > rect_height) {
+    return;
+  }
+  const int coord_top = is_curr_layer_horz ? gtl::yh(rect) - box.yMax()
+                                           : gtl::xh(rect) - box.xMax();
+  const int coord_low = is_curr_layer_horz ? gtl::yl(rect) - box.yMin()
+                                           : gtl::xl(rect) - box.xMin();
+  for (const int coord : {coord_top, coord_low}) {
+    if (coords.find(coord) == coords.end()) {
+      coords.insert(std::make_pair(coord, frAccessPointEnum::EncOpt));
+    } else {
+      coords[coord] = std::min(coords[coord], frAccessPointEnum::EncOpt);
+    }
+  }
+}
+
 /**
  * @details This follows the Tao of PAO paper cost structure.
  * Enclosed Boundary APs satisfy via-in-pin requirement.
@@ -107,40 +135,17 @@ void FlexPA::genAPEnclosedBoundary(std::map<frCoord, frAccessPointEnum>& coords,
                                    const frLayerNum layer_num,
                                    const bool is_curr_layer_horz)
 {
-  const auto rect_width = gtl::delta(rect, gtl::HORIZONTAL);
-  const auto rect_height = gtl::delta(rect, gtl::VERTICAL);
-  const int max_num_via_trial = 2;
   if (layer_num + 1 > getDesign()->getTech()->getTopLayerNum()) {
     return;
   }
   // hardcode first two single vias
-  std::vector<const frViaDef*> via_defs;
+  const int max_num_via_trial = 2;
   int cnt = 0;
   for (auto& [tup, via] : layer_num_to_via_defs_[layer_num + 1][1]) {
-    via_defs.push_back(via);
+    genViaEnclosedCoords(coords, rect, via, layer_num, is_curr_layer_horz);
     cnt++;
     if (cnt >= max_num_via_trial) {
       break;
-    }
-  }
-  for (auto& via_def : via_defs) {
-    frVia via(via_def);
-    const Rect box = via.getLayer1BBox();
-    const auto via_width = box.dx();
-    const auto via_height = box.dy();
-    if (via_width > rect_width || via_height > rect_height) {
-      continue;
-    }
-    const int coord_top = is_curr_layer_horz ? gtl::yh(rect) - box.yMax()
-                                             : gtl::xh(rect) - box.xMax();
-    const int coord_low = is_curr_layer_horz ? gtl::yl(rect) - box.yMin()
-                                             : gtl::xl(rect) - box.xMin();
-    for (const int coord : {coord_top, coord_low}) {
-      if (coords.find(coord) == coords.end()) {
-        coords.insert(std::make_pair(coord, frAccessPointEnum::EncOpt));
-      } else {
-        coords[coord] = std::min(coords[coord], frAccessPointEnum::EncOpt);
-      }
     }
   }
 }


### PR DESCRIPTION
Supports #7153.

Isolates the piece of code that receives a Via, a Rectangle and a direction and inserts the PA coords onto the input map.
This is a very cheap and almost inconsequential refactor but I think it can be useful later down the line when trying to generate new access points for vias besides the first 2