### PR TITLE
bazel: ignore src/sta/build and debug folders

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,4 @@
 build/
 debug/
+src/sta/build/
+src/sta/debug/


### PR DESCRIPTION
vscode with CMake plugins will create these dirs if you open src/sta and this will confuse Bazel.

Same as f3ec3697be2e3462bb684531f791838b49dc54c3 but for src/sta