### PR TITLE
grt: Only insert required number of diodes in repairAntennas

### DIFF
--- a/src/ant/include/ant/AntennaChecker.hh
+++ b/src/ant/include/ant/AntennaChecker.hh
@@ -103,7 +103,7 @@ struct Violation
 {
   int routing_level;
   std::vector<odb::dbITerm*> gates;
-  int diode_count_per_gate;
+  int diode_count;
   double excess_ratio;
 };
 

--- a/src/ant/include/ant/AntennaChecker.hh
+++ b/src/ant/include/ant/AntennaChecker.hh
@@ -104,7 +104,6 @@ struct Violation
   int routing_level;
   std::vector<odb::dbITerm*> gates;
   int diode_count;
-  double excess_ratio;
 };
 
 using LayerToNodeInfo = std::map<odb::dbTechLayer*, NodeInfo>;

--- a/src/ant/include/ant/AntennaChecker.hh
+++ b/src/ant/include/ant/AntennaChecker.hh
@@ -114,6 +114,8 @@ using Violations = std::vector<Violation>;
 using GateToViolationLayers
     = std::map<odb::dbITerm*, std::set<odb::dbTechLayer*>>;
 
+using GateDiodes = std::map<odb::dbITerm*, int>;
+
 class AntennaChecker
 {
  public:
@@ -174,10 +176,15 @@ class AntennaChecker
   int checkGates(odb::dbNet* db_net,
                  bool verbose,
                  bool save_report,
-                 odb::dbMTerm* diode_mterm,
                  float ratio_margin,
-                 GateToLayerToNodeInfo& gate_info,
-                 Violations& antenna_violations);
+                 GateToLayerToNodeInfo& gate_info);
+  GateDiodes determineParPsrDiodes(
+      GateToViolationLayers& gates_with_violations,
+      odb::dbNet* db_net,
+      odb::dbMTerm* diode_mterm,
+      float ratio_margin,
+      GateToLayerToNodeInfo& gate_info,
+      Violations& antenna_violations); 
   void calculateViaPar(odb::dbTechLayer* tech_layer, NodeInfo& info);
   void calculateWirePar(odb::dbTechLayer* tech_layer, NodeInfo& info);
   bool checkPAR(odb::dbNet* db_net,

--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -886,7 +886,7 @@ int AntennaChecker::checkGates(odb::dbNet* db_net,
           if (violated) {
             antenna_violations.push_back({layer->getRoutingLevel(),
                                           gates_for_diode_insertion,
-                                          diode_count_per_gate,
+                                          diode_count_per_gate * (int)gates_for_diode_insertion.size(),
                                           excess_ratio});
           }
 
@@ -918,7 +918,7 @@ int AntennaChecker::checkGates(odb::dbNet* db_net,
             }
             antenna_violations.push_back({layer->getRoutingLevel(),
                                           std::move(gates_for_diode_insertion),
-                                          1,
+                                          1 * (int)gates_for_diode_insertion.size(),
                                           1.0});
           }
         }

--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -884,10 +884,11 @@ int AntennaChecker::checkGates(odb::dbNet* db_net,
           gates_for_diode_insertion.push_back(gate);
           // save antenna violation
           if (violated) {
-            antenna_violations.push_back({layer->getRoutingLevel(),
-                                          gates_for_diode_insertion,
-                                          diode_count_per_gate * (int)gates_for_diode_insertion.size(),
-                                          excess_ratio});
+            antenna_violations.push_back(
+                {layer->getRoutingLevel(),
+                 gates_for_diode_insertion,
+                 diode_count_per_gate * (int) gates_for_diode_insertion.size(),
+                 excess_ratio});
           }
 
           bool car_violation = checkCAR(db_net,
@@ -916,9 +917,10 @@ int AntennaChecker::checkGates(odb::dbNet* db_net,
                 gates_for_diode_insertion.push_back(gate);
               }
             }
+            const int diode_count = (int) gates_for_diode_insertion.size();
             antenna_violations.push_back({layer->getRoutingLevel(),
                                           std::move(gates_for_diode_insertion),
-                                          1 * (int)gates_for_diode_insertion.size(),
+                                          diode_count,
                                           1.0});
           }
         }

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -471,10 +471,10 @@ void RepairAntennas::repairAntennas(odb::dbMTerm* diode_mterm)
                  2,
                  "antenna {} insert {} diodes",
                  db_net->getConstName(),
-                 violation.diode_count_per_gate * violation.gates.size());
-      if (violation.diode_count_per_gate > 0) {
+                 violation.diode_count);
+      if (violation.diode_count > 0) {
         for (odb::dbITerm* gate : violation.gates) {
-          for (int j = 0; j < violation.diode_count_per_gate; j++) {
+          for (int j = 0; j < (violation.diode_count / (int)violation.gates.size()); j++) {
             odb::dbTechLayer* violation_layer
                 = tech->findRoutingLayer(violation.routing_level);
             insertDiode(db_net,

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -469,10 +469,22 @@ void RepairAntennas::repairAntennas(odb::dbMTerm* diode_mterm)
                  GRT,
                  "repair_antennas",
                  2,
-                 "antenna {} insert {} diodes",
+                 "antenna {} insert {} diodes, distribute among {} gates",
                  db_net->getConstName(),
-                 violation.diode_count);
+                 violation.diode_count,
+                 violation.gates.size());
       if (violation.diode_count > 0) {
+        if (violation.gates.empty()) {
+          logger_->warn(GRT,
+                        303,
+                        "No gates found for net {} but wanted to add {} "
+                        "diodes. Unable to repair "
+                        "antenna violations.",
+                        db_net->getConstName(),
+                        violation.diode_count);
+          continue;
+        }
+
         int total_diode_count = 0;
         const int diode_count_per_gate
             = std::max(1, violation.diode_count / (int) violation.gates.size());

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -458,10 +458,42 @@ void RepairAntennas::repairAntennas(odb::dbMTerm* diode_mterm)
   setDiodesAndGatesPlacementStatus(odb::dbPlacementStatus::FIRM);
   getFixedInstances(fixed_insts);
 
+  {
+    int total_diode_count = 0;
+    for (auto const& net_violations : antenna_violations_) {
+      auto violations = net_violations.second;
+      for (ant::Violation& violation : violations) {
+        total_diode_count += violation.diode_count;
+      }
+    }
+    logger_->info(GRT,
+                  1025,
+                  "Total {} diodes needed to fix {} antenna violations.",
+                  total_diode_count,
+                  antenna_violations_.size());
+  }
+
   bool repair_failures = false;
+  int net_count = 0;
   for (auto const& net_violations : antenna_violations_) {
     odb::dbNet* db_net = net_violations.first;
     auto violations = net_violations.second;
+
+    {
+      int diode_count = 0;
+      for (ant::Violation& violation : violations) {
+        diode_count += violation.diode_count;
+      }
+      logger_->info(
+          GRT,
+          1024,
+          "{}/{}: net {} with {} violations. Need to insert {} diodes.",
+          ++net_count,
+          antenna_violations_.size(),
+          db_net->getConstName(),
+          violations.size(),
+          diode_count);
+    }
 
     bool inserted_diodes = false;
     for (ant::Violation& violation : violations) {

--- a/test/aes_nangate45.metrics_limits
+++ b/test/aes_nangate45.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.2060136305315337"
  ,"RSZ::tns_max" : "-147.99042787491084"
  ,"RSZ::hold_buffer_count" : "201"
+ ,"grt__antenna_diodes_count": "0"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.0916106124567693"

--- a/test/aes_sky130hd.metrics_limits
+++ b/test/aes_sky130hd.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-1.1324484366338525"
  ,"RSZ::tns_max" : "-695.2275522219505"
  ,"RSZ::hold_buffer_count" : "564"
+ ,"grt__antenna_diodes_count": "981"
  ,"GRT::ANT::errors" : "1"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.5371710368561858"

--- a/test/aes_sky130hs.metrics_limits
+++ b/test/aes_sky130hs.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-1.0465779249353768"
  ,"RSZ::tns_max" : "-508.7502141498551"
  ,"RSZ::hold_buffer_count" : "772"
+ ,"grt__antenna_diodes_count": "291"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.6011876321262581"

--- a/test/flow_metrics.tcl
+++ b/test/flow_metrics.tcl
@@ -122,6 +122,7 @@ define_metric "RSZ::worst_slack_max" "slack" "max" 5 "%5.2f" ">" {$value  - $clo
 define_metric "RSZ::tns_max" "tns" "max" 5 "%5.1f" ">" {$value - $clock_period * .1 * $instance_count * .1}
 define_metric "RSZ::hold_buffer_count" "hold" "bufs" 4 "%4d" "<=" {int($value * 1.2)}
 
+define_metric "grt__antenna_diodes_count" "" "ANT" 3 "%3d" "<=" {$value}
 define_metric "GRT::ANT::errors" "" "ANT" 3 "%3d" "<=" {$value}
 
 define_metric "DRT::drv" "" "drv" 3 "%3d" "<=" {$value}

--- a/test/gcd_nangate45.metrics_limits
+++ b/test/gcd_nangate45.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.09151487066067931"
  ,"RSZ::tns_max" : "-1.9896549637073635"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "0"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "0.0015581430753334041"

--- a/test/gcd_sky130hd.metrics_limits
+++ b/test/gcd_sky130hd.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-1.0592794456967143"
  ,"RSZ::tns_max" : "-15.597335098291936"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "0"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "0.04917979895858854"

--- a/test/gcd_sky130hs.metrics_limits
+++ b/test/gcd_sky130hs.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.46641663207396666"
  ,"RSZ::tns_max" : "-7.87196589872168"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "1"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.08679062403306513"

--- a/test/ibex_sky130hd.metrics_limits
+++ b/test/ibex_sky130hd.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-2.6038045883631527"
  ,"RSZ::tns_max" : "-2385.6421474235444"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "201"
  ,"GRT::ANT::errors" : "1"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-1.4796353543981875"

--- a/test/ibex_sky130hs.metrics_limits
+++ b/test/ibex_sky130hs.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.940476131481052"
  ,"RSZ::tns_max" : "-1573.2615"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "139"
  ,"GRT::ANT::errors" : "1"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.8256937224324676"

--- a/test/jpeg_sky130hd.metrics_limits
+++ b/test/jpeg_sky130hd.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.8841051696537403"
  ,"RSZ::tns_max" : "-3650.8134177206484"
  ,"RSZ::hold_buffer_count" : "78"
+ ,"grt__antenna_diodes_count": "84"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.9391273802210877"

--- a/test/jpeg_sky130hs.metrics_limits
+++ b/test/jpeg_sky130hs.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.6376155341188754"
  ,"RSZ::tns_max" : "-3185.0691600000005"
  ,"RSZ::hold_buffer_count" : "21"
+ ,"grt__antenna_diodes_count": "31"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.7193668088492328"

--- a/test/tinyRocket_nangate45.metrics_limits
+++ b/test/tinyRocket_nangate45.metrics_limits
@@ -10,6 +10,7 @@
  ,"RSZ::worst_slack_max" : "-0.04022975366703899"
  ,"RSZ::tns_max" : "-484.72339999999997"
  ,"RSZ::hold_buffer_count" : "0"
+ ,"grt__antenna_diodes_count": "0"
  ,"GRT::ANT::errors" : "0"
  ,"DRT::drv" : "0"
  ,"DRT::worst_slack_min" : "-0.12187812459789107"


### PR DESCRIPTION
DRAFT!

This change aims to rework the repair_antenna logic and the number of inserted Antenna-Diodes to a minimum.

Approach:
- [x] flow: Add number of diodes to metric limits
- [x] ant: Make number of diodes in violation structure absolut
- [x] grt/repairAntennas: Only insert up to a total number of diodes. Distribute them evenly among gates. Test results should be the same
- [ ] ant/checkGates: Rework antenna diode logic

Testing:
We should see the same number and severity of Antenna Violations initially, but if violations are fixed with a lower number of Diodes.