### PR TITLE
pdn: Fix typo in code

### DIFF
--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -100,7 +100,7 @@ proc set_voltage_domain { args } {
     }
 
     if { [info exists keys(-name)] } {
-      set name [pdn::modify_voltage_domain_name $key(-name)]
+      set name [pdn::modify_voltage_domain_name $keys(-name)]
     } else {
       set name [$region getName]
     }


### PR DESCRIPTION
Change `$key`, which does not exist,  to `$keys`.