### PR TITLE
gui: cluster net wire nodes by pins to avoid drawing flywires on strongly connected pins with multiple geometries

### DIFF
--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -186,12 +186,12 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
   void findSourcesAndSinksInGraph(odb::dbNet* net,
                                   const odb::dbObject* sink,
                                   odb::dbWireGraph* graph,
-                                  NodeList& source_nodes,
-                                  NodeList& sink_nodes) const;
+                                  std::set<NodeList>& source_nodes,
+                                  std::set<NodeList>& sink_nodes) const;
   void findSourcesAndSinks(odb::dbNet* net,
                            const odb::dbObject* sink,
-                           std::vector<GraphTarget>& sources,
-                           std::vector<GraphTarget>& sinks) const;
+                           std::vector<std::set<GraphTarget>>& sources,
+                           std::vector<std::set<GraphTarget>>& sinks) const;
   void findPath(NodeMap& graph,
                 const Node* source,
                 const Node* sink,


### PR DESCRIPTION
Closes #7197

Issue:
- before each Node intersecting an iterm geometry in the wire graph was considered a source, but this caused multiple nodes to appear as unrouted segments even if the a different node pair was found.

Fix:
- cluster nodes by iterm mpin so any node pair that is found between two iterm mpins is considered routed and no flywire is needed. If no pairs are found the same set of flywires are drawn.