### PR TITLE
Orfs test case - basis for further collaboration and discussion

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,3 +2,5 @@ build/
 debug/
 src/sta/build/
 src/sta/debug/
+# delete line below when CI can handle it and it runs in minutes
+test/orfs/

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -98,3 +98,25 @@ pip.parse(
     requirements_lock = "//bazel:requirements_lock_3_13.txt",
 )
 use_repo(pip, "openroad-pip")
+
+bazel_dep(name = "bazel-orfs")
+
+# To bump version, run: bazelisk run @bazel-orfs//:bump
+git_override(
+    module_name = "bazel-orfs",
+    commit = "afa5638555b82222d3e2f20aa29c7c7c05ad87c5",
+    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
+)
+
+orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+
+# To bump version, run: bazelisk run @bazel-orfs//:bump
+orfs.default(
+    # Official image https://hub.docker.com/r/openroad/orfs/tags
+    image = "docker.io/openroad/orfs:v3.0-2881-ga8a56ba9",
+    # Use OpenROAD of this repo instead of from the docker image
+    openroad = "//:openroad",
+    sha256 = "8c6474c59a5ea54d87bd1a1881697c2f83d833f8904a15ac19a3ccd8228fc05b",
+)
+use_repo(orfs, "com_github_nixos_patchelf_download")
+use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -29,12 +29,13 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.31.2/MODULE.bazel": "7bee702b4862612f29333590f4b658a5832d433d6f8e4395f090e8f4e85d442f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.38.0/MODULE.bazel": "6307fec451ba9962c1c969eb516ebfe1e46528f7fa92e1c9ac8646bef4cdaa3f",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/MODULE.bazel": "668e6bcb4d957fc0e284316dba546b705c8d43c857f87119619ee83c4555b859",
-    "https://bcr.bazel.build/modules/aspect_bazel_lib/1.40.3/source.json": "f5a28b1320e5f444e798b4afc1465c8b720bfaec7522cca38a23583dffe85e6d",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
+    "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/source.json": "95a6b56904e2d8bfea164dc6c98ccafe8cb75cb0623cb6ef5b3cfb15fdddabd6",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.33.1/MODULE.bazel": "db3e7f16e471cf6827059d03af7c21859e7a0d2bc65429a3a11f005d46fc501b",
     "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/MODULE.bazel": "aece421d479e3c31dc3e5f6d49a12acc2700457c03c556650ec7a0ff23fc0d95",
-    "https://bcr.bazel.build/modules/aspect_rules_js/1.39.0/source.json": "a8f93e4ad8843e8aa407fa5fd7c8b63a63846c0ce255371ff23384582813b13d",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.1.3/MODULE.bazel": "47cc48eec374d69dced3cf9b9e5926beac2f927441acfb1a3568bbb709b25666",
+    "https://bcr.bazel.build/modules/aspect_rules_js/2.1.3/source.json": "6b0fe67780c101430be087381b7a79d75eeebe1a1eae6a2cee937713603634ac",
     "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/MODULE.bazel": "e767c5dbfeb254ec03275a7701b5cfde2c4d2873676804bc7cb27ddff3728fed",
-    "https://bcr.bazel.build/modules/aspect_rules_lint/0.12.0/source.json": "9a3668e1ee219170e22c0e7f3ab959724c6198fdd12cd503fa10b1c6923a2559",
     "https://bcr.bazel.build/modules/bazel_features/0.1.0/MODULE.bazel": "47011d645b0f949f42ee67f2e8775188a9cf4a0a1528aa2fa4952f2fd00906fd",
     "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
@@ -48,6 +49,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.23.0/source.json": "c72c61b722d7c3f884994fe647afeb2ed1ae66c437f8f370753551f7b4d8be7f",
     "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.0/MODULE.bazel": "885151d58d90d8d9c811eb75e3288c11f850e1d6b481a8c9f766adee4712358b",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
     "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
@@ -428,7 +430,6 @@
     "https://bcr.bazel.build/modules/rules_bison/0.3.1/MODULE.bazel": "8288c90a34dafe7d47bd5be78ee101a9bbe3b8ae87e719385c41653869e01f75",
     "https://bcr.bazel.build/modules/rules_bison/0.3.1/source.json": "bf7935751bb686c0e82b5adbc1322e3b3e4859636d2d05d65758663527a9476c",
     "https://bcr.bazel.build/modules/rules_buf/0.1.1/MODULE.bazel": "6189aec18a4f7caff599ad41b851ab7645d4f1e114aa6431acf9b0666eb92162",
-    "https://bcr.bazel.build/modules/rules_buf/0.1.1/source.json": "021363d254f7438f3f10725355969c974bb2c67e0c28667782ade31a9cdb747f",
     "https://bcr.bazel.build/modules/rules_flex/0.3.1/MODULE.bazel": "5aea738f59e47769d219f972fc8426c53693c262895787efafa71fe9795bd7e3",
     "https://bcr.bazel.build/modules/rules_flex/0.3.1/source.json": "5c941ec77afe5c9ac7cb172c5b646c77da4295dc451b0976d66f3ca027dd7ffb",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.10.1/MODULE.bazel": "b9527010e5fef060af92b6724edb3691970a5b1f76f74b21d39f7d433641be60",
@@ -450,6 +451,7 @@
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
     "https://bcr.bazel.build/modules/rules_java/6.1.1/MODULE.bazel": "124151afe9d8e797c5779a5d7fa88ff3ef7a2a283dcc435c62626a216d6aab8e",
+    "https://bcr.bazel.build/modules/rules_java/6.3.0/MODULE.bazel": "a97c7678c19f236a956ad260d59c86e10a463badb7eb2eda787490f4c969b963",
     "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.1.0/MODULE.bazel": "30d9135a2b6561c761bd67bd4990da591e6bdc128790ce3e7afd6a3558b2fb64",
@@ -465,6 +467,7 @@
     "https://bcr.bazel.build/modules/rules_java/8.6.3/source.json": "8330cc5d277085bbcf93e9f1c85c24d06975585606a1215df4faf886a8d3cc9e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.0/MODULE.bazel": "37c93a5a78d32e895d52f86a8d0416176e915daabd029ccb5594db422e87c495",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
@@ -481,7 +484,8 @@
     "https://bcr.bazel.build/modules/rules_m4/0.2.3/MODULE.bazel": "a201ad119823e1af5024240e1e1ef294425d9be73a698cb41c8450e6c8e107e3",
     "https://bcr.bazel.build/modules/rules_m4/0.2.3/source.json": "d2fd4b91471317d0e6368ece3da2334884879ed6d6289591c7312944e50dea70",
     "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/MODULE.bazel": "6bc03c8f37f69401b888023bf511cb6ee4781433b0cb56236b2e55a21e3a026a",
-    "https://bcr.bazel.build/modules/rules_nodejs/5.8.2/source.json": "6e82cf5753d835ea18308200bc79b9c2e782efe2e2a4edc004a9162ca93382ca",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/MODULE.bazel": "45345e4aba35dd6e4701c1eebf5a4e67af4ed708def9ebcdc6027585b34ee52d",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.3.0/source.json": "1254ffd8d0d908a19c67add7fb5e2a1f604df133bc5d206425264293e2e537fc",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
@@ -530,6 +534,7 @@
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.4/MODULE.bazel": "6569966df04610b8520957cb8e97cf2e9faac2c0309657c537ab51c16c18a2a4",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.6.2/MODULE.bazel": "7060193196395f5dd668eda046ccbeacebfd98efc77fed418dbe2b82ffaa39fd",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
@@ -591,8 +596,8 @@
     },
     "@@aspect_bazel_lib~//lib:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "wbW/fEUW6Ya4TMFK5PPIgAwWuJm4AQFeqnOO5DbiZjw=",
-        "usagesDigest": "2yV4A8xZ6FZbGGe74q8xCktC2QFZ9qOJZI8VbIbhxtE=",
+        "bzlTransitiveDigest": "7dUTNg3iBL3n4jGiBJEkQIvlejRjH/FAR+4XLx1N6Ug=",
+        "usagesDigest": "G7+soeEmZ7LLgLaiMnIUSm/lpOSfIJkTK5CMBT/YMl4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -700,7 +705,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "darwin_amd64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq_darwin_arm64": {
@@ -708,7 +713,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "darwin_arm64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq_linux_amd64": {
@@ -716,7 +721,15 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "linux_amd64",
-              "version": "1.6"
+              "version": "1.7"
+            }
+          },
+          "jq_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:jq_toolchain.bzl",
+            "ruleClassName": "jq_platform_repo",
+            "attributes": {
+              "platform": "linux_arm64",
+              "version": "1.7"
             }
           },
           "jq_windows_amd64": {
@@ -724,7 +737,7 @@
             "ruleClassName": "jq_platform_repo",
             "attributes": {
               "platform": "windows_amd64",
-              "version": "1.6"
+              "version": "1.7"
             }
           },
           "jq": {
@@ -812,7 +825,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "darwin_amd64",
-              "version": "0.0.16"
+              "version": "0.0.26"
             }
           },
           "coreutils_darwin_arm64": {
@@ -820,7 +833,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "darwin_arm64",
-              "version": "0.0.16"
+              "version": "0.0.26"
             }
           },
           "coreutils_linux_amd64": {
@@ -828,7 +841,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "linux_amd64",
-              "version": "0.0.16"
+              "version": "0.0.26"
             }
           },
           "coreutils_linux_arm64": {
@@ -836,7 +849,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "linux_arm64",
-              "version": "0.0.16"
+              "version": "0.0.26"
             }
           },
           "coreutils_windows_amd64": {
@@ -844,7 +857,7 @@
             "ruleClassName": "coreutils_platform_repo",
             "attributes": {
               "platform": "windows_amd64",
-              "version": "0.0.16"
+              "version": "0.0.26"
             }
           },
           "coreutils_toolchains": {
@@ -852,6 +865,83 @@
             "ruleClassName": "coreutils_toolchains_repo",
             "attributes": {
               "user_repository_name": "coreutils"
+            }
+          },
+          "bsd_tar_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "bsd_tar_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "bsd_tar_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "bsd_tar_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "bsd_tar_windows_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "bsdtar_binary_repo",
+            "attributes": {
+              "platform": "windows_amd64"
+            }
+          },
+          "bsd_tar_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:tar_toolchain.bzl",
+            "ruleClassName": "tar_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "bsd_tar"
+            }
+          },
+          "zstd_darwin_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_amd64"
+            }
+          },
+          "zstd_darwin_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "darwin_arm64"
+            }
+          },
+          "zstd_linux_amd64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_amd64"
+            }
+          },
+          "zstd_linux_arm64": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_binary_repo",
+            "attributes": {
+              "platform": "linux_arm64"
+            }
+          },
+          "zstd_toolchains": {
+            "bzlFile": "@@aspect_bazel_lib~//lib/private:zstd_toolchain.bzl",
+            "ruleClassName": "zstd_toolchains_repo",
+            "attributes": {
+              "user_repository_name": "zstd"
             }
           },
           "expand_template_darwin_amd64": {
@@ -902,6 +992,54 @@
             "attributes": {
               "user_repository_name": "expand_template"
             }
+          },
+          "bats_support": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "7815237aafeb42ddcc1b8c698fc5808026d33317d8701d5ec2396e9634e2918f",
+              "urls": [
+                "https://github.com/bats-core/bats-support/archive/v0.3.0.tar.gz"
+              ],
+              "strip_prefix": "bats-support-0.3.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"support\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-support\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_assert": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "98ca3b685f8b8993e48ec057565e6e2abcc541034ed5b0e81f191505682037fd",
+              "urls": [
+                "https://github.com/bats-core/bats-assert/archive/v2.1.0.tar.gz"
+              ],
+              "strip_prefix": "bats-assert-2.1.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"assert\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-assert\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_file": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "9b69043241f3af1c2d251f89b4fcafa5df3f05e97b89db18d7c9bdf5731bb27a",
+              "urls": [
+                "https://github.com/bats-core/bats-file/archive/v0.4.0.tar.gz"
+              ],
+              "strip_prefix": "bats-file-0.4.0",
+              "build_file_content": "load(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"file\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"src/**\",\n        \"load.bash\",\n    ]),\n    out = \"bats-file\",\n    visibility = [\"//visibility:public\"]\n)\n"
+            }
+          },
+          "bats_toolchains": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "sha256": "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd",
+              "urls": [
+                "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
+              ],
+              "strip_prefix": "bats-core-1.10.0",
+              "build_file_content": "load(\"@local_config_platform//:constraints.bzl\", \"HOST_CONSTRAINTS\")\nload(\"@aspect_bazel_lib//lib/private:bats_toolchain.bzl\", \"bats_toolchain\")\nload(\"@aspect_bazel_lib//lib:copy_to_directory.bzl\", \"copy_to_directory\")\n\ncopy_to_directory(\n    name = \"core\",\n    hardlink = \"on\",\n    srcs = glob([\n        \"lib/**\",\n        \"libexec/**\"\n    ]) + [\"bin/bats\"],\n    out = \"bats-core\",\n)\n\nbats_toolchain(\n    name = \"toolchain\",\n    core = \":core\",\n    libraries = [\"@bats_support//:support\", \"@bats_assert//:assert\", \"@bats_file//:file\"]\n)\n\ntoolchain(\n    name = \"bats_toolchain\",\n    exec_compatible_with = HOST_CONSTRAINTS,\n    toolchain = \":toolchain\",\n    toolchain_type = \"@aspect_bazel_lib//lib:bats_toolchain_type\",\n)\n"
+            }
           }
         },
         "recordedRepoMappingEntries": [
@@ -919,6 +1057,68 @@
             "aspect_bazel_lib~",
             "bazel_tools",
             "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@bazel-orfs~//:extension.bzl%orfs_repositories": {
+      "general": {
+        "bzlTransitiveDigest": "gEO3L8nT0efjc8b8O8nLk9gxcVCkKh3Bavx36cohUrk=",
+        "usagesDigest": "aK0gvC2A5prXNNvXHQ7gY32Vui5HS07AfcQVFXJMCPs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_nixos_patchelf_download": {
+            "bzlFile": "@@bazel_tools//tools/build_defs/repo:http.bzl",
+            "ruleClassName": "http_archive",
+            "attributes": {
+              "build_file_content": "\n    export_files(\n      [\"bin/patchelf\"],\n      visibility = [\"//visibility:public\"],\n    )\n    ",
+              "sha256": "ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0",
+              "urls": [
+                "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-x86_64.tar.gz"
+              ]
+            }
+          },
+          "docker_orfs": {
+            "bzlFile": "@@bazel-orfs~//:docker.bzl",
+            "ruleClassName": "docker_pkg",
+            "attributes": {
+              "image": "docker.io/openroad/orfs:v3.0-2881-ga8a56ba9",
+              "sha256": "8c6474c59a5ea54d87bd1a1881697c2f83d833f8904a15ac19a3ccd8228fc05b",
+              "build_file": "@@bazel-orfs~//:docker.BUILD.bazel",
+              "timeout": 3600,
+              "patch_cmds": [
+                "find . -name BUILD.bazel -delete"
+              ]
+            }
+          },
+          "config": {
+            "bzlFile": "@@bazel-orfs~//:config.bzl",
+            "ruleClassName": "global_config",
+            "attributes": {
+              "makefile": "@@bazel-orfs~~orfs_repositories~docker_orfs//:makefile",
+              "pdk": "@@bazel-orfs~~orfs_repositories~docker_orfs//:asap7",
+              "makefile_yosys": "@@bazel-orfs~~orfs_repositories~docker_orfs//:makefile_yosys",
+              "openroad": "@@//:openroad"
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel-orfs~",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "bazel-orfs~",
+            "com_github_nixos_patchelf_download",
+            "bazel-orfs~~orfs_repositories~com_github_nixos_patchelf_download"
+          ],
+          [
+            "bazel-orfs~",
+            "docker_orfs",
+            "bazel-orfs~~orfs_repositories~docker_orfs"
           ]
         ]
       }
@@ -955,31 +1155,6 @@
           "reproducible": false
         },
         "recordedRepoMappingEntries": []
-      }
-    },
-    "@@rules_buf~//buf:extensions.bzl%ext": {
-      "general": {
-        "bzlTransitiveDigest": "gmPmM7QT5Jez2VVFcwbbMf/QWSRag+nJ1elFJFFTcn0=",
-        "usagesDigest": "1E3NeLCRI6VyKiersXVtONCbNopc5jIVqoHBOpcWb0A=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "rules_buf_toolchains": {
-            "bzlFile": "@@rules_buf~//buf/internal:toolchain.bzl",
-            "ruleClassName": "buf_download_releases",
-            "attributes": {
-              "version": "v1.27.0"
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_buf~",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
       }
     },
     "@@rules_flex~//flex/internal:default_toolchain_ext.bzl%default_toolchain_ext": {
@@ -1484,66 +1659,108 @@
     },
     "@@rules_nodejs~//nodejs:extensions.bzl%node": {
       "general": {
-        "bzlTransitiveDigest": "xRRX0NuyvfLtjtzM4AqJgxdMSWWnLIw28rUUi10y6k0=",
-        "usagesDigest": "9IUJvk13jWE1kE+N3sP2y0mw9exjO9CGQ2oAgwKTNK4=",
+        "bzlTransitiveDigest": "SqbzUarOVzAfK28Ca5+NIU3LUwnW/b3h0xXBUS97oyI=",
+        "usagesDigest": "vmfHywZCXchJqbQW4G6223xyz/u2CXNbv8BoImtyMPo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "nodejs_linux_amd64": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "linux_amd64",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "linux_amd64"
             }
           },
           "nodejs_linux_arm64": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "linux_arm64",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "linux_arm64"
             }
           },
           "nodejs_linux_s390x": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "linux_s390x",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "linux_s390x"
             }
           },
           "nodejs_linux_ppc64le": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "linux_ppc64le",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "linux_ppc64le"
             }
           },
           "nodejs_darwin_amd64": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "darwin_amd64",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "darwin_amd64"
             }
           },
           "nodejs_darwin_arm64": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "darwin_arm64",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "darwin_arm64"
             }
           },
           "nodejs_windows_amd64": {
             "bzlFile": "@@rules_nodejs~//nodejs:repositories.bzl",
-            "ruleClassName": "node_repositories",
+            "ruleClassName": "_nodejs_repositories",
             "attributes": {
-              "platform": "windows_amd64",
-              "node_version": "16.19.0"
+              "node_download_auth": {},
+              "node_repositories": {},
+              "node_urls": [
+                "https://nodejs.org/dist/v{version}/{filename}"
+              ],
+              "node_version": "16.14.2",
+              "include_headers": false,
+              "platform": "windows_amd64"
             }
           },
           "nodejs": {
@@ -1561,23 +1778,11793 @@
             }
           },
           "nodejs_toolchains": {
-            "bzlFile": "@@rules_nodejs~//nodejs/private:toolchains_repo.bzl",
-            "ruleClassName": "toolchains_repo",
+            "bzlFile": "@@rules_nodejs~//nodejs/private:nodejs_toolchains_repo.bzl",
+            "ruleClassName": "nodejs_toolchains_repo",
             "attributes": {
               "user_node_repository_name": "nodejs"
             }
           }
         },
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_python~//python/extensions:pip.bzl%pip": {
+      "general": {
+        "bzlTransitiveDigest": "wLeJNIgtgOERotKBbHuhZsLYXjAU0hJru6565IcBZAI=",
+        "usagesDigest": "fFPU/re8SY3d+E9gziehmG9ImbHgTBjbIltDugHunCE=",
+        "recordedFileInputs": {
+          "@@or-tools~//bazel/ortools_requirements.txt": "37e22395e78ef3572ab57b7717fd8f54851919bb73ca404f367536dc15a8e3eb",
+          "@@pybind11_abseil~//pybind11_abseil/requirements/requirements_lock_3_11.txt": "7d1074311e9f32f25ca112fc86fbec98bc024d820a8dc00f94e8679a7e6b480c",
+          "@@rules_python~//tools/publish/requirements_linux.txt": "d576e0d8542df61396a9b38deeaa183c24135ed5e8e73bb9622f298f2671811e",
+          "@@or-tools~//bazel/notebook_requirements.txt": "ca78fad693f1b35eed8bb7c54e5ddf7ad255c4b9d94ce18efa55859759a8fb70",
+          "@@pybind11_protobuf~//pybind11_protobuf/requirements/requirements_lock_3_10.txt": "afd6f9406f4e80a504f1575121a937f4c15388aec4a17393f0cb1ac9f09d18dd",
+          "@@pybind11_abseil~//pybind11_abseil/requirements/requirements_lock_3_9.txt": "f3908c1ef1a2947ed92693fb9797ac2050db90a86bd422921c7f226ed650d7ce",
+          "@@pybind11_protobuf~//pybind11_protobuf/requirements/requirements_lock_3_12.txt": "7cb4e656a0c88702302bae562670c4dd2bf85e44ff22c4704953b8ff807af7df",
+          "@@rules_fuzzing~//fuzzing/requirements.txt": "ab04664be026b632a0d2a2446c4f65982b7654f5b6851d2f9d399a19b7242a5b",
+          "@@pybind11_protobuf~//pybind11_protobuf/requirements/requirements_lock_3_9.txt": "8b2739fd19485d1f3ee7e8303d7620fe4d953980d88e2b9edbcf4781f041be48",
+          "@@pybind11_abseil~//pybind11_abseil/requirements/requirements_lock_3_10.txt": "68e27caaca02d9a3be1e3a3f23e32c8e128508c7600805fb86f9848219e3fe1f",
+          "@@pybind11_abseil~//pybind11_abseil/requirements/requirements_lock_3_12.txt": "5cedc131b03d5f59c31fd3349ab15ba58d28c383ff189853366722d2226fadbd",
+          "@@bazel-orfs~//requirements_lock_3_13.txt": "fcabafb7192fe8f92d82e7ec8ddd8e3fd6787f8acea3ec694f105ed63821416a",
+          "@@grpc~//requirements.bazel.txt": "95a27c3f9a46b8114d464c70ba93cda18cfe8c02004db81028f9306b2691701e",
+          "@@pybind11_protobuf~//pybind11_protobuf/requirements/requirements_lock_3_11.txt": "9b1a0d8d75f6786b630fec859e7a2c289ec6c3aba8355d7e1d9aa6b473e3bcbc",
+          "@@//bazel/requirements_lock_3_13.txt": "e153f3d398c8db7efc25a203ab8d82a3cb513f4a492a58c72425c3e62c21044b",
+          "@@rules_python~//tools/publish/requirements_windows.txt": "d18538a3982beab378fd5687f4db33162ee1ece69801f9a451661b1b64286b76",
+          "@@pybind11_abseil~//pybind11_abseil/requirements/requirements_lock_3_8.txt": "9a29cdc6313dbcebf36742bc88c01a376eb89082d24a64cad883dfa16c2f3a20",
+          "@@pybind11_protobuf~//pybind11_protobuf/requirements/requirements_lock_3_8.txt": "661bd110107e5c236fe9a98a88f68702b89d43ba865bc75e63b7b3bffca7e234",
+          "@@rules_python~//tools/publish/requirements_darwin.txt": "095d4a4f3d639dce831cd493367631cd51b53665292ab20194bac2c0c6458fa8"
+        },
+        "recordedDirentsInputs": {},
+        "envVariables": {
+          "RULES_PYTHON_REPO_DEBUG": null,
+          "RULES_PYTHON_REPO_DEBUG_VERBOSITY": null
+        },
+        "generatedRepoSpecs": {
+          "bazel-orfs-pip_313_contourpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "contourpy==1.3.1 --hash=sha256:041b640d4ec01922083645a94bb3b2e777e6b626788f4095cf21abbe266413c1 --hash=sha256:05e806338bfeaa006acbdeba0ad681a10be63b26e1b17317bfac3c5d98f36cda --hash=sha256:08d9d449a61cf53033612cb368f3a1b26cd7835d9b8cd326647efe43bca7568d --hash=sha256:0ffa84be8e0bd33410b17189f7164c3589c229ce5db85798076a3fa136d0e509 --hash=sha256:113231fe3825ebf6f15eaa8bc1f5b0ddc19d42b733345eae0934cb291beb88b6 --hash=sha256:14c102b0eab282427b662cb590f2e9340a9d91a1c297f48729431f2dcd16e14f --hash=sha256:174e758c66bbc1c8576992cec9599ce8b6672b741b5d336b5c74e35ac382b18e --hash=sha256:19c1555a6801c2f084c7ddc1c6e11f02eb6a6016ca1318dd5452ba3f613a1751 --hash=sha256:19d40d37c1c3a4961b4619dd9d77b12124a453cc3d02bb31a07d58ef684d3d86 --hash=sha256:1bf98051f1045b15c87868dbaea84f92408337d4f81d0e449ee41920ea121d3b --hash=sha256:20914c8c973f41456337652a6eeca26d2148aa96dd7ac323b74516988bea89fc --hash=sha256:287ccc248c9e0d0566934e7d606201abd74761b5703d804ff3df8935f523d546 --hash=sha256:2ba94a401342fc0f8b948e57d977557fbf4d515f03c67682dd5c6191cb2d16ec --hash=sha256:31c1b55c1f34f80557d3830d3dd93ba722ce7e33a0b472cba0ec3b6535684d8f --hash=sha256:36987a15e8ace5f58d4d5da9dca82d498c2bbb28dff6e5d04fbfcc35a9cb3a82 --hash=sha256:3a04ecd68acbd77fa2d39723ceca4c3197cb2969633836ced1bea14e219d077c --hash=sha256:3e8b974d8db2c5610fb4e76307e265de0edb655ae8169e8b21f41807ccbeec4b --hash=sha256:3ea9924d28fc5586bf0b42d15f590b10c224117e74409dd7a0be3b62b74a501c --hash=sha256:4318af1c925fb9a4fb190559ef3eec206845f63e80fb603d47f2d6d67683901c --hash=sha256:44a29502ca9c7b5ba389e620d44f2fbe792b1fb5734e8b931ad307071ec58c53 --hash=sha256:47734d7073fb4590b4a40122b35917cd77be5722d80683b249dac1de266aac80 --hash=sha256:4d76d5993a34ef3df5181ba3c92fabb93f1eaa5729504fb03423fcd9f3177242 --hash=sha256:4dbbc03a40f916a8420e420d63e96a1258d3d1b58cbdfd8d1f07b49fcbd38e85 --hash=sha256:500360b77259914f7805af7462e41f9cb7ca92ad38e9f94d6c8641b089338124 --hash=sha256:523a8ee12edfa36f6d2a49407f705a6ef4c5098de4f498619787e272de93f2d5 --hash=sha256:573abb30e0e05bf31ed067d2f82500ecfdaec15627a59d63ea2d95714790f5c2 --hash=sha256:5b75aa69cb4d6f137b36f7eb2ace9280cfb60c55dc5f61c731fdf6f037f958a3 --hash=sha256:61332c87493b00091423e747ea78200659dc09bdf7fd69edd5e98cef5d3e9a8d --hash=sha256:805617228ba7e2cbbfb6c503858e626ab528ac2a32a04a2fe88ffaf6b02c32bc --hash=sha256:841ad858cff65c2c04bf93875e384ccb82b654574a6d7f30453a04f04af71342 --hash=sha256:89785bb2a1980c1bd87f0cb1517a71cde374776a5f150936b82580ae6ead44a1 --hash=sha256:8eb96e79b9f3dcadbad2a3891672f81cdcab7f95b27f28f1c67d75f045b6b4f1 --hash=sha256:974d8145f8ca354498005b5b981165b74a195abfae9a8129df3e56771961d595 --hash=sha256:9ddeb796389dadcd884c7eb07bd14ef12408aaae358f0e2ae24114d797eede30 --hash=sha256:a045f341a77b77e1c5de31e74e966537bba9f3c4099b35bf4c2e3939dd54cdab --hash=sha256:a0cffcbede75c059f535725c1680dfb17b6ba8753f0c74b14e6a9c68c29d7ea3 --hash=sha256:a761d9ccfc5e2ecd1bf05534eda382aa14c3e4f9205ba5b1684ecfe400716ef2 --hash=sha256:a7895f46d47671fa7ceec40f31fae721da51ad34bdca0bee83e38870b1f47ffd --hash=sha256:a9fa36448e6a3a1a9a2ba23c02012c43ed88905ec80163f2ffe2421c7192a5d7 --hash=sha256:ab29962927945d89d9b293eabd0d59aea28d887d4f3be6c22deaefbb938a7277 --hash=sha256:abbb49fb7dac584e5abc6636b7b2a7227111c4f771005853e7d25176daaf8453 --hash=sha256:ac4578ac281983f63b400f7fe6c101bedc10651650eef012be1ccffcbacf3697 --hash=sha256:adce39d67c0edf383647a3a007de0a45fd1b08dedaa5318404f1a73059c2512b --hash=sha256:ade08d343436a94e633db932e7e8407fe7de8083967962b46bdfc1b0ced39454 --hash=sha256:b2bdca22a27e35f16794cf585832e542123296b4687f9fd96822db6bae17bfc9 --hash=sha256:b2f926efda994cdf3c8d3fdb40b9962f86edbc4457e739277b961eced3d0b4c1 --hash=sha256:b457d6430833cee8e4b8e9b6f07aa1c161e5e0d52e118dc102c8f9bd7dd060d6 --hash=sha256:c414fc1ed8ee1dbd5da626cf3710c6013d3d27456651d156711fa24f24bd1291 --hash=sha256:cb76c1a154b83991a3cbbf0dfeb26ec2833ad56f95540b442c73950af2013750 --hash=sha256:dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699 --hash=sha256:e914a8cb05ce5c809dd0fe350cfbb4e881bde5e2a38dc04e3afe1b3e58bd158e --hash=sha256:ece6df05e2c41bd46776fbc712e0996f7c94e0d0543af1656956d150c4ca7c81 --hash=sha256:efa874e87e4a647fd2e4f514d5e91c7d493697127beb95e77d2f7561f6905bd9 --hash=sha256:f611e628ef06670df83fce17805c344710ca5cde01edfdc72751311da8585375"
+            }
+          },
+          "bazel-orfs-pip_313_cycler": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "cycler==0.12.1 --hash=sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30 --hash=sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"
+            }
+          },
+          "bazel-orfs-pip_313_fonttools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "fonttools==4.55.3 --hash=sha256:07f8288aacf0a38d174445fc78377a97fb0b83cfe352a90c9d9c1400571963c7 --hash=sha256:11e5de1ee0d95af4ae23c1a138b184b7f06e0b6abacabf1d0db41c90b03d834b --hash=sha256:1bc7ad24ff98846282eef1cbeac05d013c2154f977a79886bb943015d2b1b261 --hash=sha256:1dcc07934a2165ccdc3a5a608db56fb3c24b609658a5b340aee4ecf3ba679dc0 --hash=sha256:22f38464daa6cdb7b6aebd14ab06609328fe1e9705bb0fcc7d1e69de7109ee02 --hash=sha256:27e4ae3592e62eba83cd2c4ccd9462dcfa603ff78e09110680a5444c6925d841 --hash=sha256:3983313c2a04d6cc1fe9251f8fc647754cf49a61dac6cb1e7249ae67afaafc45 --hash=sha256:529cef2ce91dc44f8e407cc567fae6e49a1786f2fefefa73a294704c415322a4 --hash=sha256:5323a22eabddf4b24f66d26894f1229261021dacd9d29e89f7872dd8c63f0b8b --hash=sha256:54153c49913f45065c8d9e6d0c101396725c5621c8aee744719300f79771d75a --hash=sha256:546565028e244a701f73df6d8dd6be489d01617863ec0c6a42fa25bf45d43048 --hash=sha256:5480673f599ad410695ca2ddef2dfefe9df779a9a5cda89503881e503c9c7d90 --hash=sha256:5e8d657cd7326eeaba27de2740e847c6b39dde2f8d7cd7cc56f6aad404ddf0bd --hash=sha256:62d65a3022c35e404d19ca14f291c89cc5890032ff04f6c17af0bd1927299674 --hash=sha256:6314bf82c54c53c71805318fcf6786d986461622dd926d92a465199ff54b1b72 --hash=sha256:7a8aa2c5e5b8b3bcb2e4538d929f6589a5c6bdb84fd16e2ed92649fb5454f11c --hash=sha256:827e95fdbbd3e51f8b459af5ea10ecb4e30af50221ca103bea68218e9615de07 --hash=sha256:859c358ebf41db18fb72342d3080bce67c02b39e86b9fbcf1610cca14984841b --hash=sha256:86721fbc389ef5cc1e2f477019e5069e8e4421e8d9576e9c26f840dbb04678de --hash=sha256:89bdc5d88bdeec1b15af790810e267e8332d92561dce4f0748c2b95c9bdf3926 --hash=sha256:8c4491699bad88efe95772543cd49870cf756b019ad56294f6498982408ab03e --hash=sha256:8c5ec45428edaa7022f1c949a632a6f298edc7b481312fc7dc258921e9399628 --hash=sha256:8e75f12c82127486fac2d8bfbf5bf058202f54bf4f158d367e41647b972342ca --hash=sha256:a430178ad3e650e695167cb53242dae3477b35c95bef6525b074d87493c4bf29 --hash=sha256:a8c2794ded89399cc2169c4d0bf7941247b8d5932b2659e09834adfbb01589aa --hash=sha256:aca318b77f23523309eec4475d1fbbb00a6b133eb766a8bdc401faba91261abe --hash=sha256:ae3b6600565b2d80b7c05acb8e24d2b26ac407b27a3f2e078229721ba5698427 --hash=sha256:aedbeb1db64496d098e6be92b2e63b5fac4e53b1b92032dfc6988e1ea9134a4d --hash=sha256:aee3b57643827e237ff6ec6d28d9ff9766bd8b21e08cd13bff479e13d4b14765 --hash=sha256:b54baf65c52952db65df39fcd4820668d0ef4766c0ccdf32879b77f7c804d5c5 --hash=sha256:b586ab5b15b6097f2fb71cafa3c98edfd0dba1ad8027229e7b1e204a58b0e09d --hash=sha256:b8d5e8916c0970fbc0f6f1bece0063363bb5857a7f170121a4493e31c3db3314 --hash=sha256:bc5dbb4685e51235ef487e4bd501ddfc49be5aede5e40f4cefcccabc6e60fb4b --hash=sha256:bdcc9f04b36c6c20978d3f060e5323a43f6222accc4e7fcbef3f428e216d96af --hash=sha256:c3ca99e0d460eff46e033cd3992a969658c3169ffcd533e0a39c63a38beb6831 --hash=sha256:caf8230f3e10f8f5d7593eb6d252a37caf58c480b19a17e250a63dad63834cf3 --hash=sha256:cd70de1a52a8ee2d1877b6293af8a2484ac82514f10b1c67c1c5762d38073e56 --hash=sha256:cf4fe7c124aa3f4e4c1940880156e13f2f4d98170d35c749e6b4f119a872551e --hash=sha256:d342e88764fb201286d185093781bf6628bbe380a913c24adf772d901baa8276 --hash=sha256:da9da6d65cd7aa6b0f806556f4985bcbf603bf0c5c590e61b43aa3e5a0f822d0 --hash=sha256:dc5294a3d5c84226e3dbba1b6f61d7ad813a8c0238fceea4e09aa04848c3d851 --hash=sha256:dd68c87a2bfe37c5b33bcda0fba39b65a353876d3b9006fde3adae31f97b3ef5 --hash=sha256:e6e8766eeeb2de759e862004aa11a9ea3d6f6d5ec710551a88b476192b64fd54 --hash=sha256:e894b5bd60d9f473bed7a8f506515549cc194de08064d829464088d23097331b --hash=sha256:eb6ca911c4c17eb51853143624d8dc87cdcdf12a711fc38bf5bd21521e79715f --hash=sha256:ed63959d00b61959b035c7d47f9313c2c1ece090ff63afea702fe86de00dbed4 --hash=sha256:f412604ccbeee81b091b420272841e5ec5ef68967a9790e80bffd0e30b8e2977 --hash=sha256:f7d66c15ba875432a2d2fb419523f5d3d347f91f48f57b8b08a2dfc3c39b8a3f --hash=sha256:f9e736f60f4911061235603a6119e72053073a12c6d7904011df2d8fad2c0e35 --hash=sha256:fb594b5a99943042c702c550d5494bdd7577f6ef19b0bc73877c948a63184a32"
+            }
+          },
+          "bazel-orfs-pip_313_kiwisolver": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "kiwisolver==1.4.7 --hash=sha256:073a36c8273647592ea332e816e75ef8da5c303236ec0167196793eb1e34657a --hash=sha256:08471d4d86cbaec61f86b217dd938a83d85e03785f51121e791a6e6689a3be95 --hash=sha256:0c18ec74c0472de033e1bebb2911c3c310eef5649133dd0bedf2a169a1b269e5 --hash=sha256:0c6c43471bc764fad4bc99c5c2d6d16a676b1abf844ca7c8702bdae92df01ee0 --hash=sha256:10849fb2c1ecbfae45a693c070e0320a91b35dd4bcf58172c023b994283a124d --hash=sha256:18077b53dc3bb490e330669a99920c5e6a496889ae8c63b58fbc57c3d7f33a18 --hash=sha256:18e0cca3e008e17fe9b164b55735a325140a5a35faad8de92dd80265cd5eb80b --hash=sha256:22f499f6157236c19f4bbbd472fa55b063db77a16cd74d49afe28992dff8c258 --hash=sha256:2a8781ac3edc42ea4b90bc23e7d37b665d89423818e26eb6df90698aa2287c95 --hash=sha256:2e6039dcbe79a8e0f044f1c39db1986a1b8071051efba3ee4d74f5b365f5226e --hash=sha256:34ea1de54beef1c104422d210c47c7d2a4999bdecf42c7b5718fbe59a4cac383 --hash=sha256:3ab58c12a2cd0fc769089e6d38466c46d7f76aced0a1f54c77652446733d2d02 --hash=sha256:3abc5b19d24af4b77d1598a585b8a719beb8569a71568b66f4ebe1fb0449460b --hash=sha256:3bf1ed55088f214ba6427484c59553123fdd9b218a42bbc8c6496d6754b1e523 --hash=sha256:3ce6b2b0231bda412463e152fc18335ba32faf4e8c23a754ad50ffa70e4091ee --hash=sha256:3da53da805b71e41053dc670f9a820d1157aae77b6b944e08024d17bcd51ef88 --hash=sha256:3f9362ecfca44c863569d3d3c033dbe8ba452ff8eed6f6b5806382741a1334bd --hash=sha256:409afdfe1e2e90e6ee7fc896f3df9a7fec8e793e58bfa0d052c8a82f99c37abb --hash=sha256:40fa14dbd66b8b8f470d5fc79c089a66185619d31645f9b0773b88b19f7223c4 --hash=sha256:4322872d5772cae7369f8351da1edf255a604ea7087fe295411397d0cfd9655e --hash=sha256:44756f9fd339de0fb6ee4f8c1696cfd19b2422e0d70b4cefc1cc7f1f64045a8c --hash=sha256:46707a10836894b559e04b0fd143e343945c97fd170d69a2d26d640b4e297935 --hash=sha256:48b571ecd8bae15702e4f22d3ff6a0f13e54d3d00cd25216d5e7f658242065ee --hash=sha256:48be928f59a1f5c8207154f935334d374e79f2b5d212826307d072595ad76a2e --hash=sha256:4bfa75a048c056a411f9705856abfc872558e33c055d80af6a380e3658766038 --hash=sha256:4c00336b9dd5ad96d0a558fd18a8b6f711b7449acce4c157e7343ba92dd0cf3d --hash=sha256:4c26ed10c4f6fa6ddb329a5120ba3b6db349ca192ae211e882970bfc9d91420b --hash=sha256:4d05d81ecb47d11e7f8932bd8b61b720bf0b41199358f3f5e36d38e28f0532c5 --hash=sha256:4e77f2126c3e0b0d055f44513ed349038ac180371ed9b52fe96a32aa071a5107 --hash=sha256:5337ec7809bcd0f424c6b705ecf97941c46279cf5ed92311782c7c9c2026f07f --hash=sha256:5360cc32706dab3931f738d3079652d20982511f7c0ac5711483e6eab08efff2 --hash=sha256:58370b1ffbd35407444d57057b57da5d6549d2d854fa30249771775c63b5fe17 --hash=sha256:58cb20602b18f86f83a5c87d3ee1c766a79c0d452f8def86d925e6c60fbf7bfb --hash=sha256:599b5c873c63a1f6ed7eead644a8a380cfbdf5db91dcb6f85707aaab213b1674 --hash=sha256:5b7dfa3b546da08a9f622bb6becdb14b3e24aaa30adba66749d38f3cc7ea9706 --hash=sha256:5b9c3f4ee0b9a439d2415012bd1b1cc2df59e4d6a9939f4d669241d30b414327 --hash=sha256:5d34eb8494bea691a1a450141ebb5385e4b69d38bb8403b5146ad279f4b30fa3 --hash=sha256:5d5abf8f8ec1f4e22882273c423e16cae834c36856cac348cfbfa68e01c40f3a --hash=sha256:5e3bc157fed2a4c02ec468de4ecd12a6e22818d4f09cde2c31ee3226ffbefab2 --hash=sha256:612a10bdae23404a72941a0fc8fa2660c6ea1217c4ce0dbcab8a8f6543ea9e7f --hash=sha256:657a05857bda581c3656bfc3b20e353c232e9193eb167766ad2dc58b56504948 --hash=sha256:65e720d2ab2b53f1f72fb5da5fb477455905ce2c88aaa671ff0a447c2c80e8e3 --hash=sha256:693902d433cf585133699972b6d7c42a8b9f8f826ebcaf0132ff55200afc599e --hash=sha256:6af936f79086a89b3680a280c47ea90b4df7047b5bdf3aa5c524bbedddb9e545 --hash=sha256:71bb308552200fb2c195e35ef05de12f0c878c07fc91c270eb3d6e41698c3bcc --hash=sha256:764202cc7e70f767dab49e8df52c7455e8de0df5d858fa801a11aa0d882ccf3f --hash=sha256:76c8094ac20ec259471ac53e774623eb62e6e1f56cd8690c67ce6ce4fcb05650 --hash=sha256:78a42513018c41c2ffd262eb676442315cbfe3c44eed82385c2ed043bc63210a --hash=sha256:79849239c39b5e1fd906556c474d9b0439ea6792b637511f3fe3a41158d89ca8 --hash=sha256:7ab9ccab2b5bd5702ab0803676a580fffa2aa178c2badc5557a84cc943fcf750 --hash=sha256:7bbfcb7165ce3d54a3dfbe731e470f65739c4c1f85bb1018ee912bae139e263b --hash=sha256:7c06a4c7cf15ec739ce0e5971b26c93638730090add60e183530d70848ebdd34 --hash=sha256:801fa7802e5cfabe3ab0c81a34c323a319b097dfb5004be950482d882f3d7225 --hash=sha256:803b8e1459341c1bb56d1c5c010406d5edec8a0713a0945851290a7930679b51 --hash=sha256:82a5c2f4b87c26bb1a0ef3d16b5c4753434633b83d365cc0ddf2770c93829e3c --hash=sha256:84ec80df401cfee1457063732d90022f93951944b5b58975d34ab56bb150dfb3 --hash=sha256:8705f17dfeb43139a692298cb6637ee2e59c0194538153e83e9ee0c75c2eddde --hash=sha256:88a9ca9c710d598fd75ee5de59d5bda2684d9db36a9f50b6125eaea3969c2599 --hash=sha256:88f17c5ffa8e9462fb79f62746428dd57b46eb931698e42e990ad63103f35e6c --hash=sha256:8a3ec5aa8e38fc4c8af308917ce12c536f1c88452ce554027e55b22cbbfbff76 --hash=sha256:8a9c83f75223d5e48b0bc9cb1bf2776cf01563e00ade8775ffe13b0b6e1af3a6 --hash=sha256:8b01aac285f91ca889c800042c35ad3b239e704b150cfd3382adfc9dcc780e39 --hash=sha256:8d53103597a252fb3ab8b5845af04c7a26d5e7ea8122303dd7a021176a87e8b9 --hash=sha256:8e045731a5416357638d1700927529e2b8ab304811671f665b225f8bf8d8f933 --hash=sha256:8f0ea6da6d393d8b2e187e6a5e3fb81f5862010a40c3945e2c6d12ae45cfb2ad --hash=sha256:90da3b5f694b85231cf93586dad5e90e2d71b9428f9aad96952c99055582f520 --hash=sha256:913983ad2deb14e66d83c28b632fd35ba2b825031f2fa4ca29675e665dfecbe1 --hash=sha256:9242795d174daa40105c1d86aba618e8eab7bf96ba8c3ee614da8302a9f95503 --hash=sha256:929e294c1ac1e9f615c62a4e4313ca1823ba37326c164ec720a803287c4c499b --hash=sha256:933d4de052939d90afbe6e9d5273ae05fb836cc86c15b686edd4b3560cc0ee36 --hash=sha256:942216596dc64ddb25adb215c3c783215b23626f8d84e8eff8d6d45c3f29f75a --hash=sha256:94252291e3fe68001b1dd747b4c0b3be12582839b95ad4d1b641924d68fd4643 --hash=sha256:9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60 --hash=sha256:9e838bba3a3bac0fe06d849d29772eb1afb9745a59710762e4ba3f4cb8424483 --hash=sha256:a0f64a48bb81af7450e641e3fe0b0394d7381e342805479178b3d335d60ca7cf --hash=sha256:a17f6a29cf8935e587cc8a4dbfc8368c55edc645283db0ce9801016f83526c2d --hash=sha256:a1ecf0ac1c518487d9d23b1cd7139a6a65bc460cd101ab01f1be82ecf09794b6 --hash=sha256:a79ae34384df2b615eefca647a2873842ac3b596418032bef9a7283675962644 --hash=sha256:a91b5f9f1205845d488c928e8570dcb62b893372f63b8b6e98b863ebd2368ff2 --hash=sha256:aa0abdf853e09aff551db11fce173e2177d00786c688203f52c87ad7fcd91ef9 --hash=sha256:ac542bf38a8a4be2dc6b15248d36315ccc65f0743f7b1a76688ffb6b5129a5c2 --hash=sha256:ad42ba922c67c5f219097b28fae965e10045ddf145d2928bfac2eb2e17673640 --hash=sha256:aeb3531b196ef6f11776c21674dba836aeea9d5bd1cf630f869e3d90b16cfade --hash=sha256:b38ac83d5f04b15e515fd86f312479d950d05ce2368d5413d46c088dda7de90a --hash=sha256:b7d755065e4e866a8086c9bdada157133ff466476a2ad7861828e17b6026e22c --hash=sha256:bd3de6481f4ed8b734da5df134cd5a6a64fe32124fe83dde1e5b5f29fe30b1e6 --hash=sha256:bfa1acfa0c54932d5607e19a2c24646fb4c1ae2694437789129cf099789a3b00 --hash=sha256:c619b101e6de2222c1fcb0531e1b17bbffbe54294bfba43ea0d411d428618c27 --hash=sha256:ce8be0466f4c0d585cdb6c1e2ed07232221df101a4c6f28821d2aa754ca2d9e2 --hash=sha256:cf0438b42121a66a3a667de17e779330fc0f20b0d97d59d2f2121e182b0505e4 --hash=sha256:cf8bcc23ceb5a1b624572a1623b9f79d2c3b337c8c455405ef231933a10da379 --hash=sha256:d2b0e12a42fb4e72d509fc994713d099cbb15ebf1103545e8a45f14da2dfca54 --hash=sha256:d83db7cde68459fc803052a55ace60bea2bae361fc3b7a6d5da07e11954e4b09 --hash=sha256:dda56c24d869b1193fcc763f1284b9126550eaf84b88bbc7256e15028f19188a --hash=sha256:dea0bf229319828467d7fca8c7c189780aa9ff679c94539eed7532ebe33ed37c --hash=sha256:e1631290ee9271dffe3062d2634c3ecac02c83890ada077d225e081aca8aab89 --hash=sha256:e28c7fea2196bf4c2f8d46a0415c77a1c480cc0724722f23d7410ffe9842c407 --hash=sha256:e2e6c39bd7b9372b0be21456caab138e8e69cc0fc1190a9dfa92bd45a1e6e904 --hash=sha256:e33e8fbd440c917106b237ef1a2f1449dfbb9b6f6e1ce17c94cd6a1e0d438376 --hash=sha256:e8df2eb9b2bac43ef8b082e06f750350fbbaf2887534a5be97f6cf07b19d9583 --hash=sha256:e968b84db54f9d42046cf154e02911e39c0435c9801681e3fc9ce8a3c4130278 --hash=sha256:eb542fe7933aa09d8d8f9d9097ef37532a7df6497819d16efe4359890a2f417a --hash=sha256:edcfc407e4eb17e037bca59be0e85a2031a2ac87e4fed26d3e9df88b4165f92d --hash=sha256:eee3ea935c3d227d49b4eb85660ff631556841f6e567f0f7bda972df6c2c9935 --hash=sha256:ef97b8df011141c9b0f6caf23b29379f87dd13183c978a30a3c546d2c47314cb --hash=sha256:f106407dda69ae456dd1227966bf445b157ccc80ba0dff3802bb63f30b74e895 --hash=sha256:f3160309af4396e0ed04db259c3ccbfdc3621b5559b5453075e5de555e1f3a1b --hash=sha256:f32d6edbc638cde7652bd690c3e728b25332acbadd7cad670cc4a02558d9c417 --hash=sha256:f37cfe618a117e50d8c240555331160d73d0411422b59b5ee217843d7b693608 --hash=sha256:f4c9aee212bc89d4e13f58be11a56cc8036cabad119259d12ace14b34476fd07 --hash=sha256:f4d742cb7af1c28303a51b7a27aaee540e71bb8e24f68c736f6f2ffc82f2bf05 --hash=sha256:f5a8b53bdc0b3961f8b6125e198617c40aeed638b387913bf1ce78afb1b0be2a --hash=sha256:f816dd2277f8d63d79f9c8473a79fe54047bc0467754962840782c575522224d --hash=sha256:f9a9e8a507420fe35992ee9ecb302dab68550dedc0da9e2880dd88071c5fb052"
+            }
+          },
+          "bazel-orfs-pip_313_matplotlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "matplotlib==3.10.0 --hash=sha256:01d2b19f13aeec2e759414d3bfe19ddfb16b13a1250add08d46d5ff6f9be83c6 --hash=sha256:12eaf48463b472c3c0f8dbacdbf906e573013df81a0ab82f0616ea4b11281908 --hash=sha256:2c5829a5a1dd5a71f0e31e6e8bb449bc0ee9dbfb05ad28fc0c6b55101b3a4be6 --hash=sha256:2fbbabc82fde51391c4da5006f965e36d86d95f6ee83fb594b279564a4c5d0d2 --hash=sha256:3547d153d70233a8496859097ef0312212e2689cdf8d7ed764441c77604095ae --hash=sha256:359f87baedb1f836ce307f0e850d12bb5f1936f70d035561f90d41d305fdacea --hash=sha256:3b427392354d10975c1d0f4ee18aa5844640b512d5311ef32efd4dd7db106ede --hash=sha256:4659665bc7c9b58f8c00317c3c2a299f7f258eeae5a5d56b4c64226fca2f7c59 --hash=sha256:4673ff67a36152c48ddeaf1135e74ce0d4bce1bbf836ae40ed39c29edf7e2765 --hash=sha256:503feb23bd8c8acc75541548a1d709c059b7184cde26314896e10a9f14df5f12 --hash=sha256:5439f4c5a3e2e8eab18e2f8c3ef929772fd5641876db71f08127eed95ab64683 --hash=sha256:5cdbaf909887373c3e094b0318d7ff230b2ad9dcb64da7ade654182872ab2593 --hash=sha256:5e6c6461e1fc63df30bf6f80f0b93f5b6784299f721bc28530477acd51bfc3d1 --hash=sha256:5fd41b0ec7ee45cd960a8e71aea7c946a28a0b8a4dcee47d2856b2af051f334c --hash=sha256:607b16c8a73943df110f99ee2e940b8a1cbf9714b65307c040d422558397dac5 --hash=sha256:7e8632baebb058555ac0cde75db885c61f1212e47723d63921879806b40bec6a --hash=sha256:81713dd0d103b379de4516b861d964b1d789a144103277769238c732229d7f03 --hash=sha256:845d96568ec873be63f25fa80e9e7fae4be854a66a7e2f0c8ccc99e94a8bd4ef --hash=sha256:95b710fea129c76d30be72c3b38f330269363fbc6e570a5dd43580487380b5ff --hash=sha256:96f2886f5c1e466f21cc41b70c5a0cd47bfa0015eb2d5793c88ebce658600e25 --hash=sha256:994c07b9d9fe8d25951e3202a68c17900679274dadfc1248738dcfa1bd40d7f3 --hash=sha256:9ade1003376731a971e398cc4ef38bb83ee8caf0aee46ac6daa4b0506db1fd06 --hash=sha256:9b0558bae37f154fffda54d779a592bc97ca8b4701f1c710055b609a3bac44c8 --hash=sha256:a2a43cbefe22d653ab34bb55d42384ed30f611bcbdea1f8d7f431011a2e1c62e --hash=sha256:a994f29e968ca002b50982b27168addfd65f0105610b6be7fa515ca4b5307c95 --hash=sha256:ad2e15300530c1a94c63cfa546e3b7864bd18ea2901317bae8bbf06a5ade6dcf --hash=sha256:ae80dc3a4add4665cf2faa90138384a7ffe2a4e37c58d83e115b54287c4f06ef --hash=sha256:b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278 --hash=sha256:c40ba2eb08b3f5de88152c2333c58cee7edcead0a2a0d60fcafa116b17117adc --hash=sha256:c55b20591ced744aa04e8c3e4b7543ea4d650b6c3c4b208c08a05b4010e8b442 --hash=sha256:c58a9622d5dbeb668f407f35f4e6bfac34bb9ecdcc81680c04d0258169747997 --hash=sha256:d44cb942af1693cced2604c33a9abcef6205601c445f6d0dc531d813af8a2f5a --hash=sha256:d907fddb39f923d011875452ff1eca29a9e7f21722b873e90db32e5d8ddff12e --hash=sha256:fd44fc75522f58612ec4a33958a7e5552562b7705b42ef1b4f8c0818e304a363"
+            }
+          },
+          "bazel-orfs-pip_313_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "numpy==2.2.0 --hash=sha256:0557eebc699c1c34cccdd8c3778c9294e8196df27d713706895edc6f57d29608 --hash=sha256:0798b138c291d792f8ea40fe3768610f3c7dd2574389e37c3f26573757c8f7ef --hash=sha256:0da8495970f6b101ddd0c38ace92edea30e7e12b9a926b57f5fabb1ecc25bb90 --hash=sha256:0f0986e917aca18f7a567b812ef7ca9391288e2acb7a4308aa9d265bd724bdae --hash=sha256:122fd2fcfafdefc889c64ad99c228d5a1f9692c3a83f56c292618a59aa60ae83 --hash=sha256:140dd80ff8981a583a60980be1a655068f8adebf7a45a06a6858c873fcdcd4a0 --hash=sha256:16757cf28621e43e252c560d25b15f18a2f11da94fea344bf26c599b9cf54b73 --hash=sha256:18142b497d70a34b01642b9feabb70156311b326fdddd875a9981f34a369b671 --hash=sha256:1c92113619f7b272838b8d6702a7f8ebe5edea0df48166c47929611d0b4dea69 --hash=sha256:1e25507d85da11ff5066269d0bd25d06e0a0f2e908415534f3e603d2a78e4ffa --hash=sha256:30bf971c12e4365153afb31fc73f441d4da157153f3400b82db32d04de1e4066 --hash=sha256:3579eaeb5e07f3ded59298ce22b65f877a86ba8e9fe701f5576c99bb17c283da --hash=sha256:36b2b43146f646642b425dd2027730f99bac962618ec2052932157e213a040e9 --hash=sha256:3905a5fffcc23e597ee4d9fb3fcd209bd658c352657548db7316e810ca80458e --hash=sha256:3a4199f519e57d517ebd48cb76b36c82da0360781c6a0353e64c0cac30ecaad3 --hash=sha256:3f2f5cddeaa4424a0a118924b988746db6ffa8565e5829b1841a8a3bd73eb59a --hash=sha256:40deb10198bbaa531509aad0cd2f9fadb26c8b94070831e2208e7df543562b74 --hash=sha256:440cfb3db4c5029775803794f8638fbdbf71ec702caf32735f53b008e1eaece3 --hash=sha256:4723a50e1523e1de4fccd1b9a6dcea750c2102461e9a02b2ac55ffeae09a4410 --hash=sha256:4bddbaa30d78c86329b26bd6aaaea06b1e47444da99eddac7bf1e2fab717bd72 --hash=sha256:4e58666988605e251d42c2818c7d3d8991555381be26399303053b58a5bbf30d --hash=sha256:54dc1d6d66f8d37843ed281773c7174f03bf7ad826523f73435deb88ba60d2d4 --hash=sha256:57fcc997ffc0bef234b8875a54d4058afa92b0b0c4223fc1f62f24b3b5e86038 --hash=sha256:58b92a5828bd4d9aa0952492b7de803135038de47343b2aa3cc23f3b71a3dc4e --hash=sha256:5a145e956b374e72ad1dff82779177d4a3c62bc8248f41b80cb5122e68f22d13 --hash=sha256:6ab153263a7c5ccaf6dfe7e53447b74f77789f28ecb278c3b5d49db7ece10d6d --hash=sha256:7832f9e8eb00be32f15fdfb9a981d6955ea9adc8574c521d48710171b6c55e95 --hash=sha256:7fe4bb0695fe986a9e4deec3b6857003b4cfe5c5e4aac0b95f6a658c14635e31 --hash=sha256:7fe8f3583e0607ad4e43a954e35c1748b553bfe9fdac8635c02058023277d1b3 --hash=sha256:85ad7d11b309bd132d74397fcf2920933c9d1dc865487128f5c03d580f2c3d03 --hash=sha256:9874bc2ff574c40ab7a5cbb7464bf9b045d617e36754a7bc93f933d52bd9ffc6 --hash=sha256:a184288538e6ad699cbe6b24859206e38ce5fba28f3bcfa51c90d0502c1582b2 --hash=sha256:a222d764352c773aa5ebde02dd84dba3279c81c6db2e482d62a3fa54e5ece69b --hash=sha256:a50aeff71d0f97b6450d33940c7181b08be1441c6c193e678211bff11aa725e7 --hash=sha256:a55dc7a7f0b6198b07ec0cd445fbb98b05234e8b00c5ac4874a63372ba98d4ab --hash=sha256:a62eb442011776e4036af5c8b1a00b706c5bc02dc15eb5344b0c750428c94219 --hash=sha256:a7d41d1612c1a82b64697e894b75db6758d4f21c3ec069d841e60ebe54b5b571 --hash=sha256:a98f6f20465e7618c83252c02041517bd2f7ea29be5378f09667a8f654a5918d --hash=sha256:afe8fb968743d40435c3827632fd36c5fbde633b0423da7692e426529b1759b1 --hash=sha256:b0b227dcff8cdc3efbce66d4e50891f04d0a387cce282fe1e66199146a6a8fca --hash=sha256:b30042fe92dbd79f1ba7f6898fada10bdaad1847c44f2dff9a16147e00a93661 --hash=sha256:b606b1aaf802e6468c2608c65ff7ece53eae1a6874b3765f69b8ceb20c5fa78e --hash=sha256:b6207dc8fb3c8cb5668e885cef9ec7f70189bec4e276f0ff70d5aa078d32c88e --hash=sha256:c2aed8fcf8abc3020d6a9ccb31dbc9e7d7819c56a348cc88fd44be269b37427e --hash=sha256:cb24cca1968b21355cc6f3da1a20cd1cebd8a023e3c5b09b432444617949085a --hash=sha256:cff210198bb4cae3f3c100444c5eaa573a823f05c253e7188e1362a5555235b3 --hash=sha256:d35717333b39d1b6bb8433fa758a55f1081543de527171543a2b710551d40881 --hash=sha256:df12a1f99b99f569a7c2ae59aa2d31724e8d835fc7f33e14f4792e3071d11221 --hash=sha256:e09d40edfdb4e260cb1567d8ae770ccf3b8b7e9f0d9b5c2a9992696b30ce2742 --hash=sha256:e12c6c1ce84628c52d6367863773f7c8c8241be554e8b79686e91a43f1733773 --hash=sha256:e2b8cd48a9942ed3f85b95ca4105c45758438c7ed28fff1e4ce3e57c3b589d8e --hash=sha256:e500aba968a48e9019e42c0c199b7ec0696a97fa69037bea163b55398e390529 --hash=sha256:ebe5e59545401fbb1b24da76f006ab19734ae71e703cdb4a8b347e84a0cece67 --hash=sha256:f0dd071b95bbca244f4cb7f70b77d2ff3aaaba7fa16dc41f58d14854a6204e6c --hash=sha256:f8c8b141ef9699ae777c6278b52c706b653bf15d135d302754f6b2e90eb30367"
+            }
+          },
+          "bazel-orfs-pip_313_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "packaging==24.2 --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"
+            }
+          },
+          "bazel-orfs-pip_313_pillow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "pillow==11.0.0 --hash=sha256:00177a63030d612148e659b55ba99527803288cea7c75fb05766ab7981a8c1b7 --hash=sha256:006bcdd307cc47ba43e924099a038cbf9591062e6c50e570819743f5607404f5 --hash=sha256:084a07ef0821cfe4858fe86652fffac8e187b6ae677e9906e192aafcc1b69903 --hash=sha256:0ae08bd8ffc41aebf578c2af2f9d8749d91f448b3bfd41d7d9ff573d74f2a6b2 --hash=sha256:0e038b0745997c7dcaae350d35859c9715c71e92ffb7e0f4a8e8a16732150f38 --hash=sha256:1187739620f2b365de756ce086fdb3604573337cc28a0d3ac4a01ab6b2d2a6d2 --hash=sha256:16095692a253047fe3ec028e951fa4221a1f3ed3d80c397e83541a3037ff67c9 --hash=sha256:1a61b54f87ab5786b8479f81c4b11f4d61702830354520837f8cc791ebba0f5f --hash=sha256:1c1d72714f429a521d8d2d018badc42414c3077eb187a59579f28e4270b4b0fc --hash=sha256:1e2688958a840c822279fda0086fec1fdab2f95bf2b717b66871c4ad9859d7e8 --hash=sha256:20ec184af98a121fb2da42642dea8a29ec80fc3efbaefb86d8fdd2606619045d --hash=sha256:21a0d3b115009ebb8ac3d2ebec5c2982cc693da935f4ab7bb5c8ebe2f47d36f2 --hash=sha256:224aaa38177597bb179f3ec87eeefcce8e4f85e608025e9cfac60de237ba6316 --hash=sha256:2679d2258b7f1192b378e2893a8a0a0ca472234d4c2c0e6bdd3380e8dfa21b6a --hash=sha256:27a7860107500d813fcd203b4ea19b04babe79448268403172782754870dac25 --hash=sha256:290f2cc809f9da7d6d622550bbf4c1e57518212da51b6a30fe8e0a270a5b78bd --hash=sha256:2e46773dc9f35a1dd28bd6981332fd7f27bec001a918a72a79b4133cf5291dba --hash=sha256:3107c66e43bda25359d5ef446f59c497de2b5ed4c7fdba0894f8d6cf3822dafc --hash=sha256:375b8dd15a1f5d2feafff536d47e22f69625c1aa92f12b339ec0b2ca40263273 --hash=sha256:45c566eb10b8967d71bf1ab8e4a525e5a93519e29ea071459ce517f6b903d7fa --hash=sha256:499c3a1b0d6fc8213519e193796eb1a86a1be4b1877d678b30f83fd979811d1a --hash=sha256:4ad70c4214f67d7466bea6a08061eba35c01b1b89eaa098040a35272a8efb22b --hash=sha256:4b60c9520f7207aaf2e1d94de026682fc227806c6e1f55bba7606d1c94dd623a --hash=sha256:5178952973e588b3f1360868847334e9e3bf49d19e169bbbdfaf8398002419ae --hash=sha256:52a2d8323a465f84faaba5236567d212c3668f2ab53e1c74c15583cf507a0291 --hash=sha256:598b4e238f13276e0008299bd2482003f48158e2b11826862b1eb2ad7c768b97 --hash=sha256:5bd2d3bdb846d757055910f0a59792d33b555800813c3b39ada1829c372ccb06 --hash=sha256:5c39ed17edea3bc69c743a8dd3e9853b7509625c2462532e62baa0732163a904 --hash=sha256:5d203af30149ae339ad1b4f710d9844ed8796e97fda23ffbc4cc472968a47d0b --hash=sha256:5ddbfd761ee00c12ee1be86c9c0683ecf5bb14c9772ddbd782085779a63dd55b --hash=sha256:607bbe123c74e272e381a8d1957083a9463401f7bd01287f50521ecb05a313f8 --hash=sha256:61b887f9ddba63ddf62fd02a3ba7add935d053b6dd7d58998c630e6dbade8527 --hash=sha256:6619654954dc4936fcff82db8eb6401d3159ec6be81e33c6000dfd76ae189947 --hash=sha256:674629ff60030d144b7bca2b8330225a9b11c482ed408813924619c6f302fdbb --hash=sha256:6ec0d5af64f2e3d64a165f490d96368bb5dea8b8f9ad04487f9ab60dc4bb6003 --hash=sha256:6f4dba50cfa56f910241eb7f883c20f1e7b1d8f7d91c750cd0b318bad443f4d5 --hash=sha256:70fbbdacd1d271b77b7721fe3cdd2d537bbbd75d29e6300c672ec6bb38d9672f --hash=sha256:72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739 --hash=sha256:7326a1787e3c7b0429659e0a944725e1b03eeaa10edd945a86dead1913383944 --hash=sha256:73853108f56df97baf2bb8b522f3578221e56f646ba345a372c78326710d3830 --hash=sha256:73e3a0200cdda995c7e43dd47436c1548f87a30bb27fb871f352a22ab8dcf45f --hash=sha256:75acbbeb05b86bc53cbe7b7e6fe00fbcf82ad7c684b3ad82e3d711da9ba287d3 --hash=sha256:8069c5179902dcdce0be9bfc8235347fdbac249d23bd90514b7a47a72d9fecf4 --hash=sha256:846e193e103b41e984ac921b335df59195356ce3f71dcfd155aa79c603873b84 --hash=sha256:8594f42df584e5b4bb9281799698403f7af489fba84c34d53d1c4bfb71b7c4e7 --hash=sha256:86510e3f5eca0ab87429dd77fafc04693195eec7fd6a137c389c3eeb4cfb77c6 --hash=sha256:8853a3bf12afddfdf15f57c4b02d7ded92c7a75a5d7331d19f4f9572a89c17e6 --hash=sha256:88a58d8ac0cc0e7f3a014509f0455248a76629ca9b604eca7dc5927cc593c5e9 --hash=sha256:8ba470552b48e5835f1d23ecb936bb7f71d206f9dfeee64245f30c3270b994de --hash=sha256:8c676b587da5673d3c75bd67dd2a8cdfeb282ca38a30f37950511766b26858c4 --hash=sha256:8ec4a89295cd6cd4d1058a5e6aec6bf51e0eaaf9714774e1bfac7cfc9051db47 --hash=sha256:94f3e1780abb45062287b4614a5bc0874519c86a777d4a7ad34978e86428b8dd --hash=sha256:9a0f748eaa434a41fccf8e1ee7a3eed68af1b690e75328fd7a60af123c193b50 --hash=sha256:a5629742881bcbc1f42e840af185fd4d83a5edeb96475a575f4da50d6ede337c --hash=sha256:a65149d8ada1055029fcb665452b2814fe7d7082fcb0c5bed6db851cb69b2086 --hash=sha256:b3c5ac4bed7519088103d9450a1107f76308ecf91d6dabc8a33a2fcfb18d0fba --hash=sha256:b4fd7bd29610a83a8c9b564d457cf5bd92b4e11e79a4ee4716a63c959699b306 --hash=sha256:bcd1fb5bb7b07f64c15618c89efcc2cfa3e95f0e3bcdbaf4642509de1942a699 --hash=sha256:c12b5ae868897c7338519c03049a806af85b9b8c237b7d675b8c5e089e4a618e --hash=sha256:c26845094b1af3c91852745ae78e3ea47abf3dbcd1cf962f16b9a5fbe3ee8488 --hash=sha256:c6a660307ca9d4867caa8d9ca2c2658ab685de83792d1876274991adec7b93fa --hash=sha256:c809a70e43c7977c4a42aefd62f0131823ebf7dd73556fa5d5950f5b354087e2 --hash=sha256:c8b2351c85d855293a299038e1f89db92a2f35e8d2f783489c6f0b2b5f3fe8a3 --hash=sha256:cb929ca942d0ec4fac404cbf520ee6cac37bf35be479b970c4ffadf2b6a1cad9 --hash=sha256:d2c0a187a92a1cb5ef2c8ed5412dd8d4334272617f532d4ad4de31e0495bd923 --hash=sha256:d69bfd8ec3219ae71bcde1f942b728903cad25fafe3100ba2258b973bd2bc1b2 --hash=sha256:daffdf51ee5db69a82dd127eabecce20729e21f7a3680cf7cbb23f0829189790 --hash=sha256:e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734 --hash=sha256:eda2616eb2313cbb3eebbe51f19362eb434b18e3bb599466a1ffa76a033fb916 --hash=sha256:ee217c198f2e41f184f3869f3e485557296d505b5195c513b2bfe0062dc537f1 --hash=sha256:f02541ef64077f22bf4924f225c0fd1248c168f86e4b7abdedd87d6ebaceab0f --hash=sha256:f1b82c27e89fffc6da125d5eb0ca6e68017faf5efc078128cfaa42cf5cb38798 --hash=sha256:fba162b8872d30fea8c52b258a542c5dfd7b235fb5cb352240c8d63b414013eb --hash=sha256:fbbcb7b57dc9c794843e3d1258c0fbf0f48656d46ffe9e09b63bbd6e8cd5d0a2 --hash=sha256:fcb4621042ac4b7865c179bb972ed0da0218a076dc1820ffc48b1d74c1e37fe9"
+            }
+          },
+          "bazel-orfs-pip_313_pyparsing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "pyparsing==3.2.0 --hash=sha256:93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84 --hash=sha256:cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c"
+            }
+          },
+          "bazel-orfs-pip_313_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "python-dateutil==2.9.0.post0 --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            }
+          },
+          "bazel-orfs-pip_313_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "pyyaml==6.0.2 --hash=sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff --hash=sha256:0833f8694549e586547b576dcfaba4a6b55b9e96098b36cdc7ebefe667dfed48 --hash=sha256:0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086 --hash=sha256:0b69e4ce7a131fe56b7e4d770c67429700908fc0752af059838b1cfb41960e4e --hash=sha256:0ffe8360bab4910ef1b9e87fb812d8bc0a308b0d0eef8c8f44e0254ab3b07133 --hash=sha256:11d8f3dd2b9c1207dcaf2ee0bbbfd5991f571186ec9cc78427ba5bd32afae4b5 --hash=sha256:17e311b6c678207928d649faa7cb0d7b4c26a0ba73d41e99c4fff6b6c3276484 --hash=sha256:1e2120ef853f59c7419231f3bf4e7021f1b936f6ebd222406c3b60212205d2ee --hash=sha256:1f71ea527786de97d1a0cc0eacd1defc0985dcf6b3f17bb77dcfc8c34bec4dc5 --hash=sha256:23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68 --hash=sha256:24471b829b3bf607e04e88d79542a9d48bb037c2267d7927a874e6c205ca7e9a --hash=sha256:29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf --hash=sha256:2e99c6826ffa974fe6e27cdb5ed0021786b03fc98e5ee3c5bfe1fd5015f42b99 --hash=sha256:39693e1f8320ae4f43943590b49779ffb98acb81f788220ea932a6b6c51004d8 --hash=sha256:3ad2a3decf9aaba3d29c8f537ac4b243e36bef957511b4766cb0057d32b0be85 --hash=sha256:3b1fdb9dc17f5a7677423d508ab4f243a726dea51fa5e70992e59a7411c89d19 --hash=sha256:41e4e3953a79407c794916fa277a82531dd93aad34e29c2a514c2c0c5fe971cc --hash=sha256:43fa96a3ca0d6b1812e01ced1044a003533c47f6ee8aca31724f78e93ccc089a --hash=sha256:50187695423ffe49e2deacb8cd10510bc361faac997de9efef88badc3bb9e2d1 --hash=sha256:5ac9328ec4831237bec75defaf839f7d4564be1e6b25ac710bd1a96321cc8317 --hash=sha256:5d225db5a45f21e78dd9358e58a98702a0302f2659a3c6cd320564b75b86f47c --hash=sha256:6395c297d42274772abc367baaa79683958044e5d3835486c16da75d2a694631 --hash=sha256:688ba32a1cffef67fd2e9398a2efebaea461578b0923624778664cc1c914db5d --hash=sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652 --hash=sha256:70b189594dbe54f75ab3a1acec5f1e3faa7e8cf2f1e08d9b561cb41b845f69d5 --hash=sha256:797b4f722ffa07cc8d62053e4cff1486fa6dc094105d13fea7b1de7d8bf71c9e --hash=sha256:7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b --hash=sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8 --hash=sha256:80bab7bfc629882493af4aa31a4cfa43a4c57c83813253626916b8c7ada83476 --hash=sha256:82d09873e40955485746739bcb8b4586983670466c23382c19cffecbf1fd8706 --hash=sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563 --hash=sha256:8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237 --hash=sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b --hash=sha256:9056c1ecd25795207ad294bcf39f2db3d845767be0ea6e6a34d856f006006083 --hash=sha256:936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180 --hash=sha256:9b22676e8097e9e22e36d6b7bda33190d0d400f345f23d4065d48f4ca7ae0425 --hash=sha256:a4d3091415f010369ae4ed1fc6b79def9416358877534caf6a0fdd2146c87a3e --hash=sha256:a8786accb172bd8afb8be14490a16625cbc387036876ab6ba70912730faf8e1f --hash=sha256:a9f8c2e67970f13b16084e04f134610fd1d374bf477b17ec1599185cf611d725 --hash=sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183 --hash=sha256:c70c95198c015b85feafc136515252a261a84561b7b1d51e3384e0655ddf25ab --hash=sha256:cc1c1159b3d456576af7a3e4d1ba7e6924cb39de8f67111c735f6fc832082774 --hash=sha256:ce826d6ef20b1bc864f0a68340c8b3287705cae2f8b4b1d932177dcc76721725 --hash=sha256:d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e --hash=sha256:d7fded462629cfa4b685c5416b949ebad6cec74af5e2d42905d41e257e0869f5 --hash=sha256:d84a1718ee396f54f3a086ea0a66d8e552b2ab2017ef8b420e92edbc841c352d --hash=sha256:d8e03406cac8513435335dbab54c0d385e4a49e4945d2909a581c83647ca0290 --hash=sha256:e10ce637b18caea04431ce14fabcf5c64a1c61ec9c56b071a4b7ca131ca52d44 --hash=sha256:ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed --hash=sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4 --hash=sha256:efdca5630322a10774e8e98e1af481aad470dd62c3170801852d752aa7a783ba --hash=sha256:f753120cb8181e736c57ef7636e83f31b9c0d1722c516f7e86cf15b7aa57ff12 --hash=sha256:ff3824dc5261f50c9b0dfb3be22b4567a6f938ccce4587b38952d85fd9e9afe4"
+            }
+          },
+          "bazel-orfs-pip_313_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@bazel-orfs-pip//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "bazel-orfs-pip_313",
+              "requirement": "six==1.17.0 --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            }
+          },
+          "grpc_python_dependencies_310_cachetools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "cachetools==4.2.4"
+            }
+          },
+          "grpc_python_dependencies_310_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "certifi==2017.4.17"
+            }
+          },
+          "grpc_python_dependencies_310_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_310_coverage": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_310_cython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "cython==0.29.21"
+            }
+          },
+          "grpc_python_dependencies_310_gevent": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "gevent==22.8.0"
+            }
+          },
+          "grpc_python_dependencies_310_google_auth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "google-auth==1.24.0"
+            }
+          },
+          "grpc_python_dependencies_310_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "googleapis-common-protos==1.5.5"
+            }
+          },
+          "grpc_python_dependencies_310_greenlet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_310_grpcio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "grpcio==1.56.2"
+            }
+          },
+          "grpc_python_dependencies_310_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_310_oauth2client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_310_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "protobuf>=3.5.0.post1, < 4.0dev"
+            }
+          },
+          "grpc_python_dependencies_310_pyasn1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "pyasn1==0.5.1"
+            }
+          },
+          "grpc_python_dependencies_310_pyasn1_modules": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_310_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_310_rsa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_310_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "setuptools==69.0.3"
+            }
+          },
+          "grpc_python_dependencies_310_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_310_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "urllib3==1.26.5"
+            }
+          },
+          "grpc_python_dependencies_310_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "wheel==0.36.2"
+            }
+          },
+          "grpc_python_dependencies_310_xds_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "xds-protos==0.0.11"
+            }
+          },
+          "grpc_python_dependencies_310_zope_event": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "zope-event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_310_zope_interface": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "grpc_python_dependencies_310",
+              "requirement": "zope-interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_311_cachetools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "cachetools==4.2.4"
+            }
+          },
+          "grpc_python_dependencies_311_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "certifi==2017.4.17"
+            }
+          },
+          "grpc_python_dependencies_311_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_311_coverage": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_311_cython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "cython==0.29.21"
+            }
+          },
+          "grpc_python_dependencies_311_gevent": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "gevent==22.8.0"
+            }
+          },
+          "grpc_python_dependencies_311_google_auth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "google-auth==1.24.0"
+            }
+          },
+          "grpc_python_dependencies_311_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "googleapis-common-protos==1.5.5"
+            }
+          },
+          "grpc_python_dependencies_311_greenlet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_311_grpcio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "grpcio==1.56.2"
+            }
+          },
+          "grpc_python_dependencies_311_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_311_oauth2client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_311_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "protobuf>=3.5.0.post1, < 4.0dev"
+            }
+          },
+          "grpc_python_dependencies_311_pyasn1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "pyasn1==0.5.1"
+            }
+          },
+          "grpc_python_dependencies_311_pyasn1_modules": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_311_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_311_rsa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_311_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "setuptools==69.0.3"
+            }
+          },
+          "grpc_python_dependencies_311_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_311_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "urllib3==1.26.5"
+            }
+          },
+          "grpc_python_dependencies_311_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "wheel==0.36.2"
+            }
+          },
+          "grpc_python_dependencies_311_xds_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "xds-protos==0.0.11"
+            }
+          },
+          "grpc_python_dependencies_311_zope_event": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "zope-event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_311_zope_interface": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "grpc_python_dependencies_311",
+              "requirement": "zope-interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_312_cachetools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "cachetools==4.2.4"
+            }
+          },
+          "grpc_python_dependencies_312_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "certifi==2017.4.17"
+            }
+          },
+          "grpc_python_dependencies_312_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_312_coverage": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_312_cython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "cython==0.29.21"
+            }
+          },
+          "grpc_python_dependencies_312_gevent": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "gevent==22.8.0"
+            }
+          },
+          "grpc_python_dependencies_312_google_auth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "google-auth==1.24.0"
+            }
+          },
+          "grpc_python_dependencies_312_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "googleapis-common-protos==1.5.5"
+            }
+          },
+          "grpc_python_dependencies_312_greenlet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_312_grpcio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "grpcio==1.56.2"
+            }
+          },
+          "grpc_python_dependencies_312_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_312_oauth2client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_312_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "protobuf>=3.5.0.post1, < 4.0dev"
+            }
+          },
+          "grpc_python_dependencies_312_pyasn1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "pyasn1==0.5.1"
+            }
+          },
+          "grpc_python_dependencies_312_pyasn1_modules": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_312_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_312_rsa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_312_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "setuptools==69.0.3"
+            }
+          },
+          "grpc_python_dependencies_312_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_312_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "urllib3==1.26.5"
+            }
+          },
+          "grpc_python_dependencies_312_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "wheel==0.36.2"
+            }
+          },
+          "grpc_python_dependencies_312_xds_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "xds-protos==0.0.11"
+            }
+          },
+          "grpc_python_dependencies_312_zope_event": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "zope-event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_312_zope_interface": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "grpc_python_dependencies_312",
+              "requirement": "zope-interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_38_cachetools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "cachetools==4.2.4"
+            }
+          },
+          "grpc_python_dependencies_38_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "certifi==2017.4.17"
+            }
+          },
+          "grpc_python_dependencies_38_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_38_coverage": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_38_cython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "cython==0.29.21"
+            }
+          },
+          "grpc_python_dependencies_38_gevent": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "gevent==22.8.0"
+            }
+          },
+          "grpc_python_dependencies_38_google_auth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "google-auth==1.24.0"
+            }
+          },
+          "grpc_python_dependencies_38_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "googleapis-common-protos==1.5.5"
+            }
+          },
+          "grpc_python_dependencies_38_greenlet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_38_grpcio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "grpcio==1.56.2"
+            }
+          },
+          "grpc_python_dependencies_38_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_38_oauth2client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_38_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "protobuf>=3.5.0.post1, < 4.0dev"
+            }
+          },
+          "grpc_python_dependencies_38_pyasn1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "pyasn1==0.5.1"
+            }
+          },
+          "grpc_python_dependencies_38_pyasn1_modules": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_38_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_38_rsa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_38_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "setuptools==69.0.3"
+            }
+          },
+          "grpc_python_dependencies_38_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_38_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "urllib3==1.26.5"
+            }
+          },
+          "grpc_python_dependencies_38_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "wheel==0.36.2"
+            }
+          },
+          "grpc_python_dependencies_38_xds_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "xds-protos==0.0.11"
+            }
+          },
+          "grpc_python_dependencies_38_zope_event": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "zope-event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_38_zope_interface": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "grpc_python_dependencies_38",
+              "requirement": "zope-interface==6.1"
+            }
+          },
+          "grpc_python_dependencies_39_cachetools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "cachetools==4.2.4"
+            }
+          },
+          "grpc_python_dependencies_39_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "certifi==2017.4.17"
+            }
+          },
+          "grpc_python_dependencies_39_chardet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "chardet==3.0.4"
+            }
+          },
+          "grpc_python_dependencies_39_coverage": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "coverage==4.5.4"
+            }
+          },
+          "grpc_python_dependencies_39_cython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "cython==0.29.21"
+            }
+          },
+          "grpc_python_dependencies_39_gevent": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "gevent==22.8.0"
+            }
+          },
+          "grpc_python_dependencies_39_google_auth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "google-auth==1.24.0"
+            }
+          },
+          "grpc_python_dependencies_39_googleapis_common_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "googleapis-common-protos==1.5.5"
+            }
+          },
+          "grpc_python_dependencies_39_greenlet": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "greenlet==1.1.3.post0"
+            }
+          },
+          "grpc_python_dependencies_39_grpcio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "grpcio==1.56.2"
+            }
+          },
+          "grpc_python_dependencies_39_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "idna==2.7"
+            }
+          },
+          "grpc_python_dependencies_39_oauth2client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "oauth2client==4.1.0"
+            }
+          },
+          "grpc_python_dependencies_39_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "protobuf>=3.5.0.post1, < 4.0dev"
+            }
+          },
+          "grpc_python_dependencies_39_pyasn1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "pyasn1==0.5.1"
+            }
+          },
+          "grpc_python_dependencies_39_pyasn1_modules": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "pyasn1-modules==0.3.0"
+            }
+          },
+          "grpc_python_dependencies_39_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "requests==2.25.1"
+            }
+          },
+          "grpc_python_dependencies_39_rsa": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "rsa==4.9"
+            }
+          },
+          "grpc_python_dependencies_39_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "setuptools==69.0.3"
+            }
+          },
+          "grpc_python_dependencies_39_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "grpc_python_dependencies_39_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "urllib3==1.26.5"
+            }
+          },
+          "grpc_python_dependencies_39_wheel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "wheel==0.36.2"
+            }
+          },
+          "grpc_python_dependencies_39_xds_protos": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "xds-protos==0.0.11"
+            }
+          },
+          "grpc_python_dependencies_39_zope_event": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "zope-event==4.5.0"
+            }
+          },
+          "grpc_python_dependencies_39_zope_interface": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@grpc_python_dependencies//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "grpc_python_dependencies_39",
+              "requirement": "zope-interface==6.1"
+            }
+          },
+          "ortools_notebook_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_notebook_deps_310_anyio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "anyio==4.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_argon2_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "argon2-cffi==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_310_argon2_cffi_bindings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "argon2-cffi-bindings==21.2.0"
+            }
+          },
+          "ortools_notebook_deps_310_arrow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "arrow==1.2.3"
+            }
+          },
+          "ortools_notebook_deps_310_asttokens": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "asttokens==2.4.0"
+            }
+          },
+          "ortools_notebook_deps_310_async_lru": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "async-lru==2.0.4"
+            }
+          },
+          "ortools_notebook_deps_310_attrs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "attrs==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_310_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "babel==2.12.1"
+            }
+          },
+          "ortools_notebook_deps_310_backcall": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "backcall==0.2.0"
+            }
+          },
+          "ortools_notebook_deps_310_beautifulsoup4": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "beautifulsoup4==4.12.2"
+            }
+          },
+          "ortools_notebook_deps_310_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_notebook_deps_310_bleach": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_notebook_deps_310_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "ortools_notebook_deps_310_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "charset-normalizer==3.2.0"
+            }
+          },
+          "ortools_notebook_deps_310_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_notebook_deps_310_comm": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "comm==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_310_debugpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "debugpy==1.6.7.post1"
+            }
+          },
+          "ortools_notebook_deps_310_decorator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "decorator==5.1.1"
+            }
+          },
+          "ortools_notebook_deps_310_defusedxml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "defusedxml==0.7.1"
+            }
+          },
+          "ortools_notebook_deps_310_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_notebook_deps_310_executing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "executing==1.2.0"
+            }
+          },
+          "ortools_notebook_deps_310_fastjsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "fastjsonschema==2.18.0"
+            }
+          },
+          "ortools_notebook_deps_310_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_notebook_deps_310_fqdn": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "fqdn==1.5.1"
+            }
+          },
+          "ortools_notebook_deps_310_h11": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "h11==0.14.0"
+            }
+          },
+          "ortools_notebook_deps_310_httpcore": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "httpcore==1.0.5"
+            }
+          },
+          "ortools_notebook_deps_310_httpx": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "httpx==0.27.2"
+            }
+          },
+          "ortools_notebook_deps_310_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_notebook_deps_310_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_ipykernel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "ipykernel==6.25.2"
+            }
+          },
+          "ortools_notebook_deps_310_ipython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "ipython==8.15.0"
+            }
+          },
+          "ortools_notebook_deps_310_isoduration": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "isoduration==20.11.0"
+            }
+          },
+          "ortools_notebook_deps_310_jedi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jedi==0.19.0"
+            }
+          },
+          "ortools_notebook_deps_310_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jinja2==3.1.4"
+            }
+          },
+          "ortools_notebook_deps_310_json5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "json5==0.9.14"
+            }
+          },
+          "ortools_notebook_deps_310_jsonpointer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jsonpointer==2.4"
+            }
+          },
+          "ortools_notebook_deps_310_jsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jsonschema[format-nongpl]==4.19.0"
+            }
+          },
+          "ortools_notebook_deps_310_jsonschema_specifications": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jsonschema-specifications==2023.7.1"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-client==8.3.1"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_core": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-core==5.3.1"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_events": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-events==0.9.0"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_lsp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-lsp==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-server==2.14.2"
+            }
+          },
+          "ortools_notebook_deps_310_jupyter_server_terminals": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyter-server-terminals==0.4.4"
+            }
+          },
+          "ortools_notebook_deps_310_jupyterlab": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyterlab==4.2.5"
+            }
+          },
+          "ortools_notebook_deps_310_jupyterlab_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyterlab-pygments==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_310_jupyterlab_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "jupyterlab-server==2.27.3"
+            }
+          },
+          "ortools_notebook_deps_310_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "markupsafe==2.1.3"
+            }
+          },
+          "ortools_notebook_deps_310_matplotlib_inline": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "matplotlib-inline==0.1.6"
+            }
+          },
+          "ortools_notebook_deps_310_mistune": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "mistune==3.0.1"
+            }
+          },
+          "ortools_notebook_deps_310_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_notebook_deps_310_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_notebook_deps_310_nbclient": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "nbclient==0.8.0"
+            }
+          },
+          "ortools_notebook_deps_310_nbconvert": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "nbconvert==7.8.0"
+            }
+          },
+          "ortools_notebook_deps_310_nbformat": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "nbformat==5.9.2"
+            }
+          },
+          "ortools_notebook_deps_310_nest_asyncio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "nest-asyncio==1.5.7"
+            }
+          },
+          "ortools_notebook_deps_310_notebook": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "notebook==7.2.2"
+            }
+          },
+          "ortools_notebook_deps_310_notebook_shim": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "notebook-shim==0.2.3"
+            }
+          },
+          "ortools_notebook_deps_310_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_notebook_deps_310_overrides": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "overrides==7.4.0"
+            }
+          },
+          "ortools_notebook_deps_310_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_notebook_deps_310_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_notebook_deps_310_pandocfilters": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pandocfilters==1.5.0"
+            }
+          },
+          "ortools_notebook_deps_310_parso": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "parso==0.8.3"
+            }
+          },
+          "ortools_notebook_deps_310_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_notebook_deps_310_pexpect": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pexpect==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_310_pickleshare": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pickleshare==0.7.5"
+            }
+          },
+          "ortools_notebook_deps_310_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_notebook_deps_310_plotly": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "plotly==5.15.0"
+            }
+          },
+          "ortools_notebook_deps_310_prometheus_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "prometheus-client==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_310_prompt_toolkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "prompt-toolkit==3.0.39"
+            }
+          },
+          "ortools_notebook_deps_310_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_notebook_deps_310_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "psutil==5.9.5"
+            }
+          },
+          "ortools_notebook_deps_310_ptyprocess": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "ptyprocess==0.7.0"
+            }
+          },
+          "ortools_notebook_deps_310_pure_eval": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pure-eval==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_310_pycparser": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "ortools_notebook_deps_310_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pygments==2.15.0"
+            }
+          },
+          "ortools_notebook_deps_310_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_notebook_deps_310_python_json_logger": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "python-json-logger==2.0.7"
+            }
+          },
+          "ortools_notebook_deps_310_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_notebook_deps_310_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pyyaml==6.0.1"
+            }
+          },
+          "ortools_notebook_deps_310_pyzmq": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "pyzmq==25.1.1"
+            }
+          },
+          "ortools_notebook_deps_310_referencing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "referencing==0.30.2"
+            }
+          },
+          "ortools_notebook_deps_310_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "requests==2.32.0"
+            }
+          },
+          "ortools_notebook_deps_310_rfc3339_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "rfc3339-validator==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_310_rfc3986_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "rfc3986-validator==0.1.1"
+            }
+          },
+          "ortools_notebook_deps_310_rpds_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "rpds-py==0.10.2"
+            }
+          },
+          "ortools_notebook_deps_310_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_notebook_deps_310_send2trash": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "send2trash==1.8.2"
+            }
+          },
+          "ortools_notebook_deps_310_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "setuptools==74.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_notebook_deps_310_sniffio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "sniffio==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_310_soupsieve": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "soupsieve==2.5"
+            }
+          },
+          "ortools_notebook_deps_310_stack_data": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "stack-data==0.6.2"
+            }
+          },
+          "ortools_notebook_deps_310_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_notebook_deps_310_tenacity": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "tenacity==8.2.1"
+            }
+          },
+          "ortools_notebook_deps_310_terminado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "terminado==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_310_tinycss2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "tinycss2==1.2.1"
+            }
+          },
+          "ortools_notebook_deps_310_tornado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "tornado==6.4.2"
+            }
+          },
+          "ortools_notebook_deps_310_traitlets": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "traitlets==5.9.0"
+            }
+          },
+          "ortools_notebook_deps_310_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_notebook_deps_310_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_310_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_notebook_deps_310_uri_template": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "uri-template==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_310_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_310_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_notebook_deps_310_wcwidth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "wcwidth==0.2.6"
+            }
+          },
+          "ortools_notebook_deps_310_webcolors": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "webcolors==1.13"
+            }
+          },
+          "ortools_notebook_deps_310_webencodings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "ortools_notebook_deps_310_websocket_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_notebook_deps_310",
+              "requirement": "websocket-client==1.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_notebook_deps_311_anyio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "anyio==4.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_argon2_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "argon2-cffi==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_311_argon2_cffi_bindings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "argon2-cffi-bindings==21.2.0"
+            }
+          },
+          "ortools_notebook_deps_311_arrow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "arrow==1.2.3"
+            }
+          },
+          "ortools_notebook_deps_311_asttokens": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "asttokens==2.4.0"
+            }
+          },
+          "ortools_notebook_deps_311_async_lru": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "async-lru==2.0.4"
+            }
+          },
+          "ortools_notebook_deps_311_attrs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "attrs==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_311_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "babel==2.12.1"
+            }
+          },
+          "ortools_notebook_deps_311_backcall": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "backcall==0.2.0"
+            }
+          },
+          "ortools_notebook_deps_311_beautifulsoup4": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "beautifulsoup4==4.12.2"
+            }
+          },
+          "ortools_notebook_deps_311_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_bleach": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_notebook_deps_311_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "ortools_notebook_deps_311_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "charset-normalizer==3.2.0"
+            }
+          },
+          "ortools_notebook_deps_311_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_notebook_deps_311_comm": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "comm==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_311_debugpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "debugpy==1.6.7.post1"
+            }
+          },
+          "ortools_notebook_deps_311_decorator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "decorator==5.1.1"
+            }
+          },
+          "ortools_notebook_deps_311_defusedxml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "defusedxml==0.7.1"
+            }
+          },
+          "ortools_notebook_deps_311_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_notebook_deps_311_executing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "executing==1.2.0"
+            }
+          },
+          "ortools_notebook_deps_311_fastjsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "fastjsonschema==2.18.0"
+            }
+          },
+          "ortools_notebook_deps_311_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_notebook_deps_311_fqdn": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "fqdn==1.5.1"
+            }
+          },
+          "ortools_notebook_deps_311_h11": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "h11==0.14.0"
+            }
+          },
+          "ortools_notebook_deps_311_httpcore": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "httpcore==1.0.5"
+            }
+          },
+          "ortools_notebook_deps_311_httpx": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "httpx==0.27.2"
+            }
+          },
+          "ortools_notebook_deps_311_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_notebook_deps_311_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_ipykernel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "ipykernel==6.25.2"
+            }
+          },
+          "ortools_notebook_deps_311_ipython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "ipython==8.15.0"
+            }
+          },
+          "ortools_notebook_deps_311_isoduration": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "isoduration==20.11.0"
+            }
+          },
+          "ortools_notebook_deps_311_jedi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jedi==0.19.0"
+            }
+          },
+          "ortools_notebook_deps_311_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jinja2==3.1.4"
+            }
+          },
+          "ortools_notebook_deps_311_json5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "json5==0.9.14"
+            }
+          },
+          "ortools_notebook_deps_311_jsonpointer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jsonpointer==2.4"
+            }
+          },
+          "ortools_notebook_deps_311_jsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jsonschema[format-nongpl]==4.19.0"
+            }
+          },
+          "ortools_notebook_deps_311_jsonschema_specifications": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jsonschema-specifications==2023.7.1"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-client==8.3.1"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_core": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-core==5.3.1"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_events": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-events==0.9.0"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_lsp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-lsp==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-server==2.14.2"
+            }
+          },
+          "ortools_notebook_deps_311_jupyter_server_terminals": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyter-server-terminals==0.4.4"
+            }
+          },
+          "ortools_notebook_deps_311_jupyterlab": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyterlab==4.2.5"
+            }
+          },
+          "ortools_notebook_deps_311_jupyterlab_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyterlab-pygments==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_311_jupyterlab_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "jupyterlab-server==2.27.3"
+            }
+          },
+          "ortools_notebook_deps_311_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "markupsafe==2.1.3"
+            }
+          },
+          "ortools_notebook_deps_311_matplotlib_inline": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "matplotlib-inline==0.1.6"
+            }
+          },
+          "ortools_notebook_deps_311_mistune": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "mistune==3.0.1"
+            }
+          },
+          "ortools_notebook_deps_311_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_notebook_deps_311_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_notebook_deps_311_nbclient": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "nbclient==0.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_nbconvert": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "nbconvert==7.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_nbformat": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "nbformat==5.9.2"
+            }
+          },
+          "ortools_notebook_deps_311_nest_asyncio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "nest-asyncio==1.5.7"
+            }
+          },
+          "ortools_notebook_deps_311_notebook": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "notebook==7.2.2"
+            }
+          },
+          "ortools_notebook_deps_311_notebook_shim": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "notebook-shim==0.2.3"
+            }
+          },
+          "ortools_notebook_deps_311_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_notebook_deps_311_overrides": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "overrides==7.4.0"
+            }
+          },
+          "ortools_notebook_deps_311_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_notebook_deps_311_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_notebook_deps_311_pandocfilters": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pandocfilters==1.5.0"
+            }
+          },
+          "ortools_notebook_deps_311_parso": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "parso==0.8.3"
+            }
+          },
+          "ortools_notebook_deps_311_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_notebook_deps_311_pexpect": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pexpect==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_pickleshare": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pickleshare==0.7.5"
+            }
+          },
+          "ortools_notebook_deps_311_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_notebook_deps_311_plotly": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "plotly==5.15.0"
+            }
+          },
+          "ortools_notebook_deps_311_prometheus_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "prometheus-client==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_311_prompt_toolkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "prompt-toolkit==3.0.39"
+            }
+          },
+          "ortools_notebook_deps_311_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_notebook_deps_311_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "psutil==5.9.5"
+            }
+          },
+          "ortools_notebook_deps_311_ptyprocess": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "ptyprocess==0.7.0"
+            }
+          },
+          "ortools_notebook_deps_311_pure_eval": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pure-eval==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_311_pycparser": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "ortools_notebook_deps_311_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pygments==2.15.0"
+            }
+          },
+          "ortools_notebook_deps_311_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_notebook_deps_311_python_json_logger": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "python-json-logger==2.0.7"
+            }
+          },
+          "ortools_notebook_deps_311_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_notebook_deps_311_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pyyaml==6.0.1"
+            }
+          },
+          "ortools_notebook_deps_311_pyzmq": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "pyzmq==25.1.1"
+            }
+          },
+          "ortools_notebook_deps_311_referencing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "referencing==0.30.2"
+            }
+          },
+          "ortools_notebook_deps_311_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "requests==2.32.0"
+            }
+          },
+          "ortools_notebook_deps_311_rfc3339_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "rfc3339-validator==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_311_rfc3986_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "rfc3986-validator==0.1.1"
+            }
+          },
+          "ortools_notebook_deps_311_rpds_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "rpds-py==0.10.2"
+            }
+          },
+          "ortools_notebook_deps_311_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_notebook_deps_311_send2trash": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "send2trash==1.8.2"
+            }
+          },
+          "ortools_notebook_deps_311_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "setuptools==74.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_notebook_deps_311_sniffio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "sniffio==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_311_soupsieve": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "soupsieve==2.5"
+            }
+          },
+          "ortools_notebook_deps_311_stack_data": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "stack-data==0.6.2"
+            }
+          },
+          "ortools_notebook_deps_311_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_notebook_deps_311_tenacity": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "tenacity==8.2.1"
+            }
+          },
+          "ortools_notebook_deps_311_terminado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "terminado==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_311_tinycss2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "tinycss2==1.2.1"
+            }
+          },
+          "ortools_notebook_deps_311_tornado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "tornado==6.4.2"
+            }
+          },
+          "ortools_notebook_deps_311_traitlets": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "traitlets==5.9.0"
+            }
+          },
+          "ortools_notebook_deps_311_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_notebook_deps_311_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_311_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_notebook_deps_311_uri_template": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "uri-template==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_311_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_311_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_notebook_deps_311_wcwidth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "wcwidth==0.2.6"
+            }
+          },
+          "ortools_notebook_deps_311_webcolors": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "webcolors==1.13"
+            }
+          },
+          "ortools_notebook_deps_311_webencodings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "ortools_notebook_deps_311_websocket_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_notebook_deps_311",
+              "requirement": "websocket-client==1.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_notebook_deps_312_anyio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "anyio==4.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_argon2_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "argon2-cffi==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_312_argon2_cffi_bindings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "argon2-cffi-bindings==21.2.0"
+            }
+          },
+          "ortools_notebook_deps_312_arrow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "arrow==1.2.3"
+            }
+          },
+          "ortools_notebook_deps_312_asttokens": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "asttokens==2.4.0"
+            }
+          },
+          "ortools_notebook_deps_312_async_lru": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "async-lru==2.0.4"
+            }
+          },
+          "ortools_notebook_deps_312_attrs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "attrs==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_312_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "babel==2.12.1"
+            }
+          },
+          "ortools_notebook_deps_312_backcall": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "backcall==0.2.0"
+            }
+          },
+          "ortools_notebook_deps_312_beautifulsoup4": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "beautifulsoup4==4.12.2"
+            }
+          },
+          "ortools_notebook_deps_312_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_bleach": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_notebook_deps_312_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "ortools_notebook_deps_312_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "charset-normalizer==3.2.0"
+            }
+          },
+          "ortools_notebook_deps_312_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_notebook_deps_312_comm": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "comm==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_312_debugpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "debugpy==1.6.7.post1"
+            }
+          },
+          "ortools_notebook_deps_312_decorator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "decorator==5.1.1"
+            }
+          },
+          "ortools_notebook_deps_312_defusedxml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "defusedxml==0.7.1"
+            }
+          },
+          "ortools_notebook_deps_312_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_notebook_deps_312_executing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "executing==1.2.0"
+            }
+          },
+          "ortools_notebook_deps_312_fastjsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "fastjsonschema==2.18.0"
+            }
+          },
+          "ortools_notebook_deps_312_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_notebook_deps_312_fqdn": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "fqdn==1.5.1"
+            }
+          },
+          "ortools_notebook_deps_312_h11": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "h11==0.14.0"
+            }
+          },
+          "ortools_notebook_deps_312_httpcore": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "httpcore==1.0.5"
+            }
+          },
+          "ortools_notebook_deps_312_httpx": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "httpx==0.27.2"
+            }
+          },
+          "ortools_notebook_deps_312_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_notebook_deps_312_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_ipykernel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "ipykernel==6.25.2"
+            }
+          },
+          "ortools_notebook_deps_312_ipython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "ipython==8.15.0"
+            }
+          },
+          "ortools_notebook_deps_312_isoduration": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "isoduration==20.11.0"
+            }
+          },
+          "ortools_notebook_deps_312_jedi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jedi==0.19.0"
+            }
+          },
+          "ortools_notebook_deps_312_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jinja2==3.1.4"
+            }
+          },
+          "ortools_notebook_deps_312_json5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "json5==0.9.14"
+            }
+          },
+          "ortools_notebook_deps_312_jsonpointer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jsonpointer==2.4"
+            }
+          },
+          "ortools_notebook_deps_312_jsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jsonschema[format-nongpl]==4.19.0"
+            }
+          },
+          "ortools_notebook_deps_312_jsonschema_specifications": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jsonschema-specifications==2023.7.1"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-client==8.3.1"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_core": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-core==5.3.1"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_events": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-events==0.9.0"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_lsp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-lsp==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-server==2.14.2"
+            }
+          },
+          "ortools_notebook_deps_312_jupyter_server_terminals": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyter-server-terminals==0.4.4"
+            }
+          },
+          "ortools_notebook_deps_312_jupyterlab": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyterlab==4.2.5"
+            }
+          },
+          "ortools_notebook_deps_312_jupyterlab_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyterlab-pygments==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_312_jupyterlab_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "jupyterlab-server==2.27.3"
+            }
+          },
+          "ortools_notebook_deps_312_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "markupsafe==2.1.3"
+            }
+          },
+          "ortools_notebook_deps_312_matplotlib_inline": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "matplotlib-inline==0.1.6"
+            }
+          },
+          "ortools_notebook_deps_312_mistune": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "mistune==3.0.1"
+            }
+          },
+          "ortools_notebook_deps_312_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_notebook_deps_312_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_notebook_deps_312_nbclient": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "nbclient==0.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_nbconvert": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "nbconvert==7.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_nbformat": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "nbformat==5.9.2"
+            }
+          },
+          "ortools_notebook_deps_312_nest_asyncio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "nest-asyncio==1.5.7"
+            }
+          },
+          "ortools_notebook_deps_312_notebook": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "notebook==7.2.2"
+            }
+          },
+          "ortools_notebook_deps_312_notebook_shim": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "notebook-shim==0.2.3"
+            }
+          },
+          "ortools_notebook_deps_312_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_notebook_deps_312_overrides": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "overrides==7.4.0"
+            }
+          },
+          "ortools_notebook_deps_312_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_notebook_deps_312_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_notebook_deps_312_pandocfilters": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pandocfilters==1.5.0"
+            }
+          },
+          "ortools_notebook_deps_312_parso": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "parso==0.8.3"
+            }
+          },
+          "ortools_notebook_deps_312_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_notebook_deps_312_pexpect": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pexpect==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_pickleshare": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pickleshare==0.7.5"
+            }
+          },
+          "ortools_notebook_deps_312_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_notebook_deps_312_plotly": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "plotly==5.15.0"
+            }
+          },
+          "ortools_notebook_deps_312_prometheus_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "prometheus-client==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_312_prompt_toolkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "prompt-toolkit==3.0.39"
+            }
+          },
+          "ortools_notebook_deps_312_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_notebook_deps_312_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "psutil==5.9.5"
+            }
+          },
+          "ortools_notebook_deps_312_ptyprocess": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "ptyprocess==0.7.0"
+            }
+          },
+          "ortools_notebook_deps_312_pure_eval": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pure-eval==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_312_pycparser": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "ortools_notebook_deps_312_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pygments==2.15.0"
+            }
+          },
+          "ortools_notebook_deps_312_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_notebook_deps_312_python_json_logger": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "python-json-logger==2.0.7"
+            }
+          },
+          "ortools_notebook_deps_312_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_notebook_deps_312_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pyyaml==6.0.1"
+            }
+          },
+          "ortools_notebook_deps_312_pyzmq": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "pyzmq==25.1.1"
+            }
+          },
+          "ortools_notebook_deps_312_referencing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "referencing==0.30.2"
+            }
+          },
+          "ortools_notebook_deps_312_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "requests==2.32.0"
+            }
+          },
+          "ortools_notebook_deps_312_rfc3339_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "rfc3339-validator==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_312_rfc3986_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "rfc3986-validator==0.1.1"
+            }
+          },
+          "ortools_notebook_deps_312_rpds_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "rpds-py==0.10.2"
+            }
+          },
+          "ortools_notebook_deps_312_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_notebook_deps_312_send2trash": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "send2trash==1.8.2"
+            }
+          },
+          "ortools_notebook_deps_312_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "setuptools==74.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_notebook_deps_312_sniffio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "sniffio==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_312_soupsieve": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "soupsieve==2.5"
+            }
+          },
+          "ortools_notebook_deps_312_stack_data": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "stack-data==0.6.2"
+            }
+          },
+          "ortools_notebook_deps_312_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_notebook_deps_312_tenacity": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "tenacity==8.2.1"
+            }
+          },
+          "ortools_notebook_deps_312_terminado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "terminado==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_312_tinycss2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "tinycss2==1.2.1"
+            }
+          },
+          "ortools_notebook_deps_312_tornado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "tornado==6.4.2"
+            }
+          },
+          "ortools_notebook_deps_312_traitlets": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "traitlets==5.9.0"
+            }
+          },
+          "ortools_notebook_deps_312_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_notebook_deps_312_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_312_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_notebook_deps_312_uri_template": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "uri-template==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_312_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_312_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_notebook_deps_312_wcwidth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "wcwidth==0.2.6"
+            }
+          },
+          "ortools_notebook_deps_312_webcolors": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "webcolors==1.13"
+            }
+          },
+          "ortools_notebook_deps_312_webencodings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "ortools_notebook_deps_312_websocket_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_notebook_deps_312",
+              "requirement": "websocket-client==1.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_notebook_deps_313_anyio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "anyio==4.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_argon2_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "argon2-cffi==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_313_argon2_cffi_bindings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "argon2-cffi-bindings==21.2.0"
+            }
+          },
+          "ortools_notebook_deps_313_arrow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "arrow==1.2.3"
+            }
+          },
+          "ortools_notebook_deps_313_asttokens": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "asttokens==2.4.0"
+            }
+          },
+          "ortools_notebook_deps_313_async_lru": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "async-lru==2.0.4"
+            }
+          },
+          "ortools_notebook_deps_313_attrs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "attrs==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_313_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "babel==2.12.1"
+            }
+          },
+          "ortools_notebook_deps_313_backcall": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "backcall==0.2.0"
+            }
+          },
+          "ortools_notebook_deps_313_beautifulsoup4": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "beautifulsoup4==4.12.2"
+            }
+          },
+          "ortools_notebook_deps_313_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_bleach": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_notebook_deps_313_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "ortools_notebook_deps_313_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "charset-normalizer==3.2.0"
+            }
+          },
+          "ortools_notebook_deps_313_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_notebook_deps_313_comm": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "comm==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_313_debugpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "debugpy==1.6.7.post1"
+            }
+          },
+          "ortools_notebook_deps_313_decorator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "decorator==5.1.1"
+            }
+          },
+          "ortools_notebook_deps_313_defusedxml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "defusedxml==0.7.1"
+            }
+          },
+          "ortools_notebook_deps_313_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_notebook_deps_313_executing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "executing==1.2.0"
+            }
+          },
+          "ortools_notebook_deps_313_fastjsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "fastjsonschema==2.18.0"
+            }
+          },
+          "ortools_notebook_deps_313_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_notebook_deps_313_fqdn": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "fqdn==1.5.1"
+            }
+          },
+          "ortools_notebook_deps_313_h11": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "h11==0.14.0"
+            }
+          },
+          "ortools_notebook_deps_313_httpcore": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "httpcore==1.0.5"
+            }
+          },
+          "ortools_notebook_deps_313_httpx": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "httpx==0.27.2"
+            }
+          },
+          "ortools_notebook_deps_313_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_notebook_deps_313_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_ipykernel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "ipykernel==6.25.2"
+            }
+          },
+          "ortools_notebook_deps_313_ipython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "ipython==8.15.0"
+            }
+          },
+          "ortools_notebook_deps_313_isoduration": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "isoduration==20.11.0"
+            }
+          },
+          "ortools_notebook_deps_313_jedi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jedi==0.19.0"
+            }
+          },
+          "ortools_notebook_deps_313_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jinja2==3.1.4"
+            }
+          },
+          "ortools_notebook_deps_313_json5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "json5==0.9.14"
+            }
+          },
+          "ortools_notebook_deps_313_jsonpointer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jsonpointer==2.4"
+            }
+          },
+          "ortools_notebook_deps_313_jsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jsonschema[format-nongpl]==4.19.0"
+            }
+          },
+          "ortools_notebook_deps_313_jsonschema_specifications": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jsonschema-specifications==2023.7.1"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-client==8.3.1"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_core": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-core==5.3.1"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_events": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-events==0.9.0"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_lsp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-lsp==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-server==2.14.2"
+            }
+          },
+          "ortools_notebook_deps_313_jupyter_server_terminals": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyter-server-terminals==0.4.4"
+            }
+          },
+          "ortools_notebook_deps_313_jupyterlab": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyterlab==4.2.5"
+            }
+          },
+          "ortools_notebook_deps_313_jupyterlab_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyterlab-pygments==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_313_jupyterlab_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "jupyterlab-server==2.27.3"
+            }
+          },
+          "ortools_notebook_deps_313_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "markupsafe==2.1.3"
+            }
+          },
+          "ortools_notebook_deps_313_matplotlib_inline": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "matplotlib-inline==0.1.6"
+            }
+          },
+          "ortools_notebook_deps_313_mistune": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "mistune==3.0.1"
+            }
+          },
+          "ortools_notebook_deps_313_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_notebook_deps_313_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_notebook_deps_313_nbclient": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "nbclient==0.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_nbconvert": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "nbconvert==7.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_nbformat": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "nbformat==5.9.2"
+            }
+          },
+          "ortools_notebook_deps_313_nest_asyncio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "nest-asyncio==1.5.7"
+            }
+          },
+          "ortools_notebook_deps_313_notebook": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "notebook==7.2.2"
+            }
+          },
+          "ortools_notebook_deps_313_notebook_shim": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "notebook-shim==0.2.3"
+            }
+          },
+          "ortools_notebook_deps_313_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_notebook_deps_313_overrides": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "overrides==7.4.0"
+            }
+          },
+          "ortools_notebook_deps_313_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_notebook_deps_313_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_notebook_deps_313_pandocfilters": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pandocfilters==1.5.0"
+            }
+          },
+          "ortools_notebook_deps_313_parso": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "parso==0.8.3"
+            }
+          },
+          "ortools_notebook_deps_313_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_notebook_deps_313_pexpect": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pexpect==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_pickleshare": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pickleshare==0.7.5"
+            }
+          },
+          "ortools_notebook_deps_313_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_notebook_deps_313_plotly": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "plotly==5.15.0"
+            }
+          },
+          "ortools_notebook_deps_313_prometheus_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "prometheus-client==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_313_prompt_toolkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "prompt-toolkit==3.0.39"
+            }
+          },
+          "ortools_notebook_deps_313_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_notebook_deps_313_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "psutil==5.9.5"
+            }
+          },
+          "ortools_notebook_deps_313_ptyprocess": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "ptyprocess==0.7.0"
+            }
+          },
+          "ortools_notebook_deps_313_pure_eval": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pure-eval==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_313_pycparser": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "ortools_notebook_deps_313_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pygments==2.15.0"
+            }
+          },
+          "ortools_notebook_deps_313_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_notebook_deps_313_python_json_logger": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "python-json-logger==2.0.7"
+            }
+          },
+          "ortools_notebook_deps_313_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_notebook_deps_313_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pyyaml==6.0.1"
+            }
+          },
+          "ortools_notebook_deps_313_pyzmq": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "pyzmq==25.1.1"
+            }
+          },
+          "ortools_notebook_deps_313_referencing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "referencing==0.30.2"
+            }
+          },
+          "ortools_notebook_deps_313_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "requests==2.32.0"
+            }
+          },
+          "ortools_notebook_deps_313_rfc3339_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "rfc3339-validator==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_313_rfc3986_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "rfc3986-validator==0.1.1"
+            }
+          },
+          "ortools_notebook_deps_313_rpds_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "rpds-py==0.10.2"
+            }
+          },
+          "ortools_notebook_deps_313_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_notebook_deps_313_send2trash": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "send2trash==1.8.2"
+            }
+          },
+          "ortools_notebook_deps_313_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "setuptools==74.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_notebook_deps_313_sniffio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "sniffio==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_313_soupsieve": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "soupsieve==2.5"
+            }
+          },
+          "ortools_notebook_deps_313_stack_data": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "stack-data==0.6.2"
+            }
+          },
+          "ortools_notebook_deps_313_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_notebook_deps_313_tenacity": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "tenacity==8.2.1"
+            }
+          },
+          "ortools_notebook_deps_313_terminado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "terminado==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_313_tinycss2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "tinycss2==1.2.1"
+            }
+          },
+          "ortools_notebook_deps_313_tornado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "tornado==6.4.2"
+            }
+          },
+          "ortools_notebook_deps_313_traitlets": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "traitlets==5.9.0"
+            }
+          },
+          "ortools_notebook_deps_313_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_notebook_deps_313_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_313_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_notebook_deps_313_uri_template": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "uri-template==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_313_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_313_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_notebook_deps_313_wcwidth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "wcwidth==0.2.6"
+            }
+          },
+          "ortools_notebook_deps_313_webcolors": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "webcolors==1.13"
+            }
+          },
+          "ortools_notebook_deps_313_webencodings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "ortools_notebook_deps_313_websocket_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_notebook_deps_313",
+              "requirement": "websocket-client==1.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_notebook_deps_39_anyio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "anyio==4.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_argon2_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "argon2-cffi==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_39_argon2_cffi_bindings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "argon2-cffi-bindings==21.2.0"
+            }
+          },
+          "ortools_notebook_deps_39_arrow": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "arrow==1.2.3"
+            }
+          },
+          "ortools_notebook_deps_39_asttokens": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "asttokens==2.4.0"
+            }
+          },
+          "ortools_notebook_deps_39_async_lru": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "async-lru==2.0.4"
+            }
+          },
+          "ortools_notebook_deps_39_attrs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "attrs==23.1.0"
+            }
+          },
+          "ortools_notebook_deps_39_babel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "babel==2.12.1"
+            }
+          },
+          "ortools_notebook_deps_39_backcall": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "backcall==0.2.0"
+            }
+          },
+          "ortools_notebook_deps_39_beautifulsoup4": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "beautifulsoup4==4.12.2"
+            }
+          },
+          "ortools_notebook_deps_39_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_bleach": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "bleach==6.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_notebook_deps_39_cffi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "cffi==1.15.1"
+            }
+          },
+          "ortools_notebook_deps_39_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "charset-normalizer==3.2.0"
+            }
+          },
+          "ortools_notebook_deps_39_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_notebook_deps_39_comm": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "comm==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_39_debugpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "debugpy==1.6.7.post1"
+            }
+          },
+          "ortools_notebook_deps_39_decorator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "decorator==5.1.1"
+            }
+          },
+          "ortools_notebook_deps_39_defusedxml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "defusedxml==0.7.1"
+            }
+          },
+          "ortools_notebook_deps_39_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_notebook_deps_39_executing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "executing==1.2.0"
+            }
+          },
+          "ortools_notebook_deps_39_fastjsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "fastjsonschema==2.18.0"
+            }
+          },
+          "ortools_notebook_deps_39_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_notebook_deps_39_fqdn": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "fqdn==1.5.1"
+            }
+          },
+          "ortools_notebook_deps_39_h11": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "h11==0.14.0"
+            }
+          },
+          "ortools_notebook_deps_39_httpcore": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "httpcore==1.0.5"
+            }
+          },
+          "ortools_notebook_deps_39_httpx": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "httpx==0.27.2"
+            }
+          },
+          "ortools_notebook_deps_39_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_notebook_deps_39_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_ipykernel": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "ipykernel==6.25.2"
+            }
+          },
+          "ortools_notebook_deps_39_ipython": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "ipython==8.15.0"
+            }
+          },
+          "ortools_notebook_deps_39_isoduration": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "isoduration==20.11.0"
+            }
+          },
+          "ortools_notebook_deps_39_jedi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jedi==0.19.0"
+            }
+          },
+          "ortools_notebook_deps_39_jinja2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jinja2==3.1.4"
+            }
+          },
+          "ortools_notebook_deps_39_json5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "json5==0.9.14"
+            }
+          },
+          "ortools_notebook_deps_39_jsonpointer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jsonpointer==2.4"
+            }
+          },
+          "ortools_notebook_deps_39_jsonschema": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jsonschema[format-nongpl]==4.19.0"
+            }
+          },
+          "ortools_notebook_deps_39_jsonschema_specifications": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jsonschema-specifications==2023.7.1"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-client==8.3.1"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_core": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-core==5.3.1"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_events": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-events==0.9.0"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_lsp": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-lsp==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-server==2.14.2"
+            }
+          },
+          "ortools_notebook_deps_39_jupyter_server_terminals": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyter-server-terminals==0.4.4"
+            }
+          },
+          "ortools_notebook_deps_39_jupyterlab": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyterlab==4.2.5"
+            }
+          },
+          "ortools_notebook_deps_39_jupyterlab_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyterlab-pygments==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_39_jupyterlab_server": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "jupyterlab-server==2.27.3"
+            }
+          },
+          "ortools_notebook_deps_39_markupsafe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "markupsafe==2.1.3"
+            }
+          },
+          "ortools_notebook_deps_39_matplotlib_inline": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "matplotlib-inline==0.1.6"
+            }
+          },
+          "ortools_notebook_deps_39_mistune": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "mistune==3.0.1"
+            }
+          },
+          "ortools_notebook_deps_39_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_notebook_deps_39_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_notebook_deps_39_nbclient": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "nbclient==0.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_nbconvert": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "nbconvert==7.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_nbformat": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "nbformat==5.9.2"
+            }
+          },
+          "ortools_notebook_deps_39_nest_asyncio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "nest-asyncio==1.5.7"
+            }
+          },
+          "ortools_notebook_deps_39_notebook": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "notebook==7.2.2"
+            }
+          },
+          "ortools_notebook_deps_39_notebook_shim": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "notebook-shim==0.2.3"
+            }
+          },
+          "ortools_notebook_deps_39_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_notebook_deps_39_overrides": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "overrides==7.4.0"
+            }
+          },
+          "ortools_notebook_deps_39_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_notebook_deps_39_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_notebook_deps_39_pandocfilters": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pandocfilters==1.5.0"
+            }
+          },
+          "ortools_notebook_deps_39_parso": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "parso==0.8.3"
+            }
+          },
+          "ortools_notebook_deps_39_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_notebook_deps_39_pexpect": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pexpect==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_pickleshare": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pickleshare==0.7.5"
+            }
+          },
+          "ortools_notebook_deps_39_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_notebook_deps_39_plotly": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "plotly==5.15.0"
+            }
+          },
+          "ortools_notebook_deps_39_prometheus_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "prometheus-client==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_39_prompt_toolkit": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "prompt-toolkit==3.0.39"
+            }
+          },
+          "ortools_notebook_deps_39_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_notebook_deps_39_psutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "psutil==5.9.5"
+            }
+          },
+          "ortools_notebook_deps_39_ptyprocess": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "ptyprocess==0.7.0"
+            }
+          },
+          "ortools_notebook_deps_39_pure_eval": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pure-eval==0.2.2"
+            }
+          },
+          "ortools_notebook_deps_39_pycparser": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pycparser==2.21"
+            }
+          },
+          "ortools_notebook_deps_39_pygments": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pygments==2.15.0"
+            }
+          },
+          "ortools_notebook_deps_39_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_notebook_deps_39_python_json_logger": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "python-json-logger==2.0.7"
+            }
+          },
+          "ortools_notebook_deps_39_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_notebook_deps_39_pyyaml": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pyyaml==6.0.1"
+            }
+          },
+          "ortools_notebook_deps_39_pyzmq": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "pyzmq==25.1.1"
+            }
+          },
+          "ortools_notebook_deps_39_referencing": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "referencing==0.30.2"
+            }
+          },
+          "ortools_notebook_deps_39_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "requests==2.32.0"
+            }
+          },
+          "ortools_notebook_deps_39_rfc3339_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "rfc3339-validator==0.1.4"
+            }
+          },
+          "ortools_notebook_deps_39_rfc3986_validator": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "rfc3986-validator==0.1.1"
+            }
+          },
+          "ortools_notebook_deps_39_rpds_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "rpds-py==0.10.2"
+            }
+          },
+          "ortools_notebook_deps_39_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_notebook_deps_39_send2trash": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "send2trash==1.8.2"
+            }
+          },
+          "ortools_notebook_deps_39_setuptools": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "setuptools==74.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_notebook_deps_39_sniffio": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "sniffio==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_39_soupsieve": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "soupsieve==2.5"
+            }
+          },
+          "ortools_notebook_deps_39_stack_data": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "stack-data==0.6.2"
+            }
+          },
+          "ortools_notebook_deps_39_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_notebook_deps_39_tenacity": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "tenacity==8.2.1"
+            }
+          },
+          "ortools_notebook_deps_39_terminado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "terminado==0.17.1"
+            }
+          },
+          "ortools_notebook_deps_39_tinycss2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "tinycss2==1.2.1"
+            }
+          },
+          "ortools_notebook_deps_39_tornado": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "tornado==6.4.2"
+            }
+          },
+          "ortools_notebook_deps_39_traitlets": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "traitlets==5.9.0"
+            }
+          },
+          "ortools_notebook_deps_39_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_notebook_deps_39_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_notebook_deps_39_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_notebook_deps_39_uri_template": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "uri-template==1.3.0"
+            }
+          },
+          "ortools_notebook_deps_39_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_notebook_deps_39_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_notebook_deps_39_wcwidth": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "wcwidth==0.2.6"
+            }
+          },
+          "ortools_notebook_deps_39_webcolors": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "webcolors==1.13"
+            }
+          },
+          "ortools_notebook_deps_39_webencodings": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "webencodings==0.5.1"
+            }
+          },
+          "ortools_notebook_deps_39_websocket_client": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_notebook_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_notebook_deps_39",
+              "requirement": "websocket-client==1.8.0"
+            }
+          },
+          "ortools_pip_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_pip_deps_310_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_pip_deps_310_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_pip_deps_310_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "ortools_pip_deps_310_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_pip_deps_310_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_pip_deps_310_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_pip_deps_310_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_pip_deps_310_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_pip_deps_310_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_pip_deps_310_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_pip_deps_310_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_pip_deps_310_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_pip_deps_310_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_pip_deps_310_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_pip_deps_310_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_pip_deps_310_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_pip_deps_310_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_pip_deps_310_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_pip_deps_310_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_pip_deps_310_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "requests==2.32.3"
+            }
+          },
+          "ortools_pip_deps_310_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_pip_deps_310_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_pip_deps_310_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_pip_deps_310_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_pip_deps_310_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_pip_deps_310_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_pip_deps_310_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_pip_deps_310_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "ortools_pip_deps_310",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_pip_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_pip_deps_311_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_pip_deps_311_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_pip_deps_311_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "ortools_pip_deps_311_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_pip_deps_311_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_pip_deps_311_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_pip_deps_311_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_pip_deps_311_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_pip_deps_311_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_pip_deps_311_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_pip_deps_311_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_pip_deps_311_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_pip_deps_311_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_pip_deps_311_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_pip_deps_311_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_pip_deps_311_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_pip_deps_311_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_pip_deps_311_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_pip_deps_311_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_pip_deps_311_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "requests==2.32.3"
+            }
+          },
+          "ortools_pip_deps_311_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_pip_deps_311_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_pip_deps_311_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_pip_deps_311_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_pip_deps_311_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_pip_deps_311_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_pip_deps_311_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_pip_deps_311_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "ortools_pip_deps_311",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_pip_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_pip_deps_312_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_pip_deps_312_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_pip_deps_312_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "ortools_pip_deps_312_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_pip_deps_312_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_pip_deps_312_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_pip_deps_312_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_pip_deps_312_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_pip_deps_312_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_pip_deps_312_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_pip_deps_312_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_pip_deps_312_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_pip_deps_312_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_pip_deps_312_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_pip_deps_312_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_pip_deps_312_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_pip_deps_312_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_pip_deps_312_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_pip_deps_312_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_pip_deps_312_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "requests==2.32.3"
+            }
+          },
+          "ortools_pip_deps_312_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_pip_deps_312_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_pip_deps_312_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_pip_deps_312_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_pip_deps_312_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_pip_deps_312_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_pip_deps_312_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_pip_deps_312_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "ortools_pip_deps_312",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_pip_deps_313_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_pip_deps_313_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_pip_deps_313_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_pip_deps_313_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "ortools_pip_deps_313_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_pip_deps_313_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_pip_deps_313_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_pip_deps_313_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_pip_deps_313_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_pip_deps_313_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_pip_deps_313_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_pip_deps_313_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_pip_deps_313_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_pip_deps_313_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_pip_deps_313_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_pip_deps_313_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_pip_deps_313_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_pip_deps_313_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_pip_deps_313_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_pip_deps_313_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_pip_deps_313_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "requests==2.32.3"
+            }
+          },
+          "ortools_pip_deps_313_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_pip_deps_313_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_pip_deps_313_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_pip_deps_313_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_pip_deps_313_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_pip_deps_313_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_pip_deps_313_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_pip_deps_313_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_13_host//:python",
+              "repo": "ortools_pip_deps_313",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "ortools_pip_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "absl-py==2.1.0"
+            }
+          },
+          "ortools_pip_deps_39_black": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "black==24.8.0"
+            }
+          },
+          "ortools_pip_deps_39_certifi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "certifi==2024.7.4"
+            }
+          },
+          "ortools_pip_deps_39_charset_normalizer": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "charset-normalizer==3.3.2"
+            }
+          },
+          "ortools_pip_deps_39_click": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "click==8.1.3"
+            }
+          },
+          "ortools_pip_deps_39_distlib": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "distlib==0.3.7"
+            }
+          },
+          "ortools_pip_deps_39_filelock": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "filelock==3.12.2"
+            }
+          },
+          "ortools_pip_deps_39_idna": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "idna==3.7"
+            }
+          },
+          "ortools_pip_deps_39_immutabledict": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "immutabledict==3.0.0"
+            }
+          },
+          "ortools_pip_deps_39_mypy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "mypy==1.6.1"
+            }
+          },
+          "ortools_pip_deps_39_mypy_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "mypy-extensions==1.0.0"
+            }
+          },
+          "ortools_pip_deps_39_mypy_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "mypy-protobuf==3.5.0"
+            }
+          },
+          "ortools_pip_deps_39_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "numpy==2.2.0"
+            }
+          },
+          "ortools_pip_deps_39_packaging": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "packaging==23.1"
+            }
+          },
+          "ortools_pip_deps_39_pandas": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "pandas==2.2.3"
+            }
+          },
+          "ortools_pip_deps_39_pathspec": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "pathspec==0.11.1"
+            }
+          },
+          "ortools_pip_deps_39_platformdirs": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "platformdirs==3.10.0"
+            }
+          },
+          "ortools_pip_deps_39_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "protobuf==5.29.3"
+            }
+          },
+          "ortools_pip_deps_39_python_dateutil": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "python-dateutil==2.8.2"
+            }
+          },
+          "ortools_pip_deps_39_pytz": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "pytz==2022.7.1"
+            }
+          },
+          "ortools_pip_deps_39_requests": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "requests==2.32.3"
+            }
+          },
+          "ortools_pip_deps_39_scipy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "scipy==1.14.1"
+            }
+          },
+          "ortools_pip_deps_39_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "six==1.16.0"
+            }
+          },
+          "ortools_pip_deps_39_svgwrite": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "svgwrite==1.4.3"
+            }
+          },
+          "ortools_pip_deps_39_types_protobuf": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "types-protobuf==4.24.0.0"
+            }
+          },
+          "ortools_pip_deps_39_typing_extensions": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "typing-extensions==4.8.0"
+            }
+          },
+          "ortools_pip_deps_39_tzdata": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "tzdata==2023.3"
+            }
+          },
+          "ortools_pip_deps_39_urllib3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "urllib3==2.2.2"
+            }
+          },
+          "ortools_pip_deps_39_virtualenv": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@ortools_pip_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "ortools_pip_deps_39",
+              "requirement": "virtualenv==20.28.1"
+            }
+          },
+          "pybind11_protobuf_py_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pybind11_protobuf_py_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pybind11_protobuf_py_deps_310",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pybind11_protobuf_py_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pybind11_protobuf_py_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pybind11_protobuf_py_deps_311",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pybind11_protobuf_py_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pybind11_protobuf_py_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "pybind11_protobuf_py_deps_312",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pybind11_protobuf_py_deps_38_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pybind11_protobuf_py_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "pybind11_protobuf_py_deps_38",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pybind11_protobuf_py_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pybind11_protobuf_py_deps//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pybind11_protobuf_py_deps_39",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pypi_310",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_310_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "pypi_310",
+              "requirement": "numpy==1.26.4 --hash=sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b --hash=sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818 --hash=sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20 --hash=sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0 --hash=sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 --hash=sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c --hash=sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71 --hash=sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110 --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be --hash=sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a --hash=sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a --hash=sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5 --hash=sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c --hash=sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e --hash=sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0 --hash=sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c --hash=sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a --hash=sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b --hash=sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0 --hash=sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6 --hash=sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2 --hash=sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a --hash=sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30 --hash=sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218 --hash=sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5 --hash=sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07 --hash=sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2 --hash=sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4 --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
+            }
+          },
+          "pypi_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pypi_311",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_311_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "pypi_311",
+              "requirement": "numpy==1.26.4 --hash=sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b --hash=sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818 --hash=sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20 --hash=sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0 --hash=sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 --hash=sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c --hash=sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71 --hash=sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110 --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be --hash=sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a --hash=sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a --hash=sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5 --hash=sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c --hash=sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e --hash=sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0 --hash=sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c --hash=sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a --hash=sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b --hash=sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0 --hash=sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6 --hash=sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2 --hash=sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a --hash=sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30 --hash=sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218 --hash=sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5 --hash=sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07 --hash=sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2 --hash=sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4 --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
+            }
+          },
+          "pypi_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "pypi_312",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_312_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "pypi_312",
+              "requirement": "numpy==1.26.4 --hash=sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b --hash=sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818 --hash=sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20 --hash=sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0 --hash=sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 --hash=sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c --hash=sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71 --hash=sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110 --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be --hash=sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a --hash=sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a --hash=sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5 --hash=sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c --hash=sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e --hash=sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0 --hash=sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c --hash=sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a --hash=sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b --hash=sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0 --hash=sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6 --hash=sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2 --hash=sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a --hash=sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30 --hash=sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218 --hash=sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5 --hash=sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07 --hash=sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2 --hash=sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4 --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
+            }
+          },
+          "pypi_38_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "pypi_38",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_38_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "pypi_38",
+              "requirement": "numpy==1.24.4 --hash=sha256:04640dab83f7c6c85abf9cd729c5b65f1ebd0ccf9de90b270cd61935eef0197f --hash=sha256:1452241c290f3e2a312c137a9999cdbf63f78864d63c79039bda65ee86943f61 --hash=sha256:222e40d0e2548690405b0b3c7b21d1169117391c2e82c378467ef9ab4c8f0da7 --hash=sha256:2541312fbf09977f3b3ad449c4e5f4bb55d0dbf79226d7724211acc905049400 --hash=sha256:31f13e25b4e304632a4619d0e0777662c2ffea99fcae2029556b17d8ff958aef --hash=sha256:4602244f345453db537be5314d3983dbf5834a9701b7723ec28923e2889e0bb2 --hash=sha256:4979217d7de511a8d57f4b4b5b2b965f707768440c17cb70fbf254c4b225238d --hash=sha256:4c21decb6ea94057331e111a5bed9a79d335658c27ce2adb580fb4d54f2ad9bc --hash=sha256:6620c0acd41dbcb368610bb2f4d83145674040025e5536954782467100aa8835 --hash=sha256:692f2e0f55794943c5bfff12b3f56f99af76f902fc47487bdfe97856de51a706 --hash=sha256:7215847ce88a85ce39baf9e89070cb860c98fdddacbaa6c0da3ffb31b3350bd5 --hash=sha256:79fc682a374c4a8ed08b331bef9c5f582585d1048fa6d80bc6c35bc384eee9b4 --hash=sha256:7ffe43c74893dbf38c2b0a1f5428760a1a9c98285553c89e12d70a96a7f3a4d6 --hash=sha256:80f5e3a4e498641401868df4208b74581206afbee7cf7b8329daae82676d9463 --hash=sha256:95f7ac6540e95bc440ad77f56e520da5bf877f87dca58bd095288dce8940532a --hash=sha256:9667575fb6d13c95f1b36aca12c5ee3356bf001b714fc354eb5465ce1609e62f --hash=sha256:a5425b114831d1e77e4b5d812b69d11d962e104095a5b9c3b641a218abcc050e --hash=sha256:b4bea75e47d9586d31e892a7401f76e909712a0fd510f58f5337bea9572c571e --hash=sha256:b7b1fc9864d7d39e28f41d089bfd6353cb5f27ecd9905348c24187a768c79694 --hash=sha256:befe2bf740fd8373cf56149a5c23a0f601e82869598d41f8e188a0e9869926f8 --hash=sha256:c0bfb52d2169d58c1cdb8cc1f16989101639b34c7d3ce60ed70b19c63eba0b64 --hash=sha256:d11efb4dbecbdf22508d55e48d9c8384db795e1b7b51ea735289ff96613ff74d --hash=sha256:dd80e219fd4c71fc3699fc1dadac5dcf4fd882bfc6f7ec53d30fa197b8ee22dc --hash=sha256:e2926dac25b313635e4d6cf4dc4e51c8c0ebfed60b801c799ffc4c32bf3d1254 --hash=sha256:e98f220aa76ca2a977fe435f5b04d7b3470c0a2e6312907b37ba6068f26787f2 --hash=sha256:ed094d4f0c177b1b8e7aa9cba7d6ceed51c0e569a5318ac0ca9a090680a6a1b1 --hash=sha256:f136bab9c2cfd8da131132c2cf6cc27331dd6fae65f95f69dcd4ae3c3639c810 --hash=sha256:f3a86ed21e4f87050382c7bc96571755193c4c1392490744ac73d660e8f564a9"
+            }
+          },
+          "pypi_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pypi_39",
+              "requirement": "absl-py==2.1.0 --hash=sha256:526a04eadab8b4ee719ce68f204172ead1027549089702d99b9059f129ff1308 --hash=sha256:7820790efbb316739cde8b4e19357243fc3608a152024288513dd968d7d959ff"
+            }
+          },
+          "pypi_39_numpy": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@pypi//{name}:{target}",
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "pypi_39",
+              "requirement": "numpy==1.26.4 --hash=sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b --hash=sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818 --hash=sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20 --hash=sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0 --hash=sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010 --hash=sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a --hash=sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea --hash=sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c --hash=sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71 --hash=sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110 --hash=sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be --hash=sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a --hash=sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a --hash=sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5 --hash=sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed --hash=sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd --hash=sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c --hash=sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e --hash=sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0 --hash=sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c --hash=sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a --hash=sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b --hash=sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0 --hash=sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6 --hash=sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2 --hash=sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a --hash=sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30 --hash=sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218 --hash=sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5 --hash=sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07 --hash=sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2 --hash=sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4 --hash=sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764 --hash=sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef --hash=sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3 --hash=sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f"
+            }
+          },
+          "rules_fuzzing_py_deps_310_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_310_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_10_host//:python",
+              "repo": "rules_fuzzing_py_deps_310",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_311_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_311_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_fuzzing_py_deps_311",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_312_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_312_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_12_host//:python",
+              "repo": "rules_fuzzing_py_deps_312",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_38_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_38_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_8_host//:python",
+              "repo": "rules_fuzzing_py_deps_38",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_fuzzing_py_deps_39_absl_py": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "absl-py==2.0.0 --hash=sha256:9a28abb62774ae4e8edbe2dd4c49ffcd45a6a848952a5eccc6a49f3f0fc1e2f3"
+            }
+          },
+          "rules_fuzzing_py_deps_39_six": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_fuzzing_py_deps//{name}:{target}",
+              "extra_pip_args": [
+                "--require-hashes"
+              ],
+              "python_interpreter_target": "@@rules_python~~python~python_3_9_host//:python",
+              "repo": "rules_fuzzing_py_deps_39",
+              "requirement": "six==1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "backports.tarfile-1.2.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "backports_tarfile-1.2.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "backports-tarfile==1.2.0",
+              "sha256": "d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991",
+              "urls": [
+                "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_py3_none_any_922820b5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "certifi-2024.8.30-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_certifi_sdist_bec941d2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "certifi-2024.8.30.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "certifi==2024.8.30",
+              "sha256": "bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2e/ea/70ce63780f096e16ce8588efe039d3c4f91deb1dc01e9c73a287939c79a6/cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1c/a0/a4fa9f4f781bda074c3ddd57a572b060fa0df7655d2a4247bbe277200146/cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/12/ce8710b5b8affbcdd5c6e367217c242524ad17a02fe5beec3ee339f69f85/cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/6b/d45873c5e0242196f042d555526f92aa9e0c32355a1be1ff8c27f077fd37/cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1a/52/d9a0e523a572fbccf2955f5abe883cfa8bcc570d7faeee06336fbd50c9fc/cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f8/4a/34599cac7dfcd888ff54e801afe06a19c17787dfd94495ab0c8d35fe99fb/cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cffi_sdist_1c39c601": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cffi-1.17.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cffi==1.17.1",
+              "sha256": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+              "urls": [
+                "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "0d99dd8ff461990f12d6e42c7347fd9ab2532fb70e9621ba520f9e8637161d7c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9c/61/73589dcc7a719582bf56aae309b6103d2762b526bffe189d635a7fcfd998/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "c57516e58fd17d03ebe67e181a4e4e2ccab1168f8c2976c6a334d4f819fe5944",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/d5/8c982d58144de49f59571f940e329ad6e8615e1e82ef84584c5eeb5e1d72/charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "6dba5d19c4dfab08e58d5b36304b3f92f3bd5d42c1a3fa37b5ba5cdf6dfcbcee",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/19/411a64f01ee971bed3231111b69eb56f9331a769072de479eae7de52296d/charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bf4475b82be41b07cc5e5ff94810e6a01f276e37c2d55571e3fe175e467a1a1c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/4c/92/97509850f0d00e9f14a46bc751daabd0ad7765cff29cdfb66c68b6dad57f/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "ce031db0408e487fd2775d745ce30a7cd2923667cf3b69d48d219f1d8f5ddeb6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e2/29/d227805bff72ed6d6cb1ce08eec707f7cfbd9868044893617eb331f16295/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "8ff4e7cdfdb1ab5698e675ca622e72d58a6fa2a8aa58195de0c0061288e6e3ea",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/bc/87c2c9f2c144bedfa62f894c3007cd4530ba4b5351acb10dc786428a50f0/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "3710a9751938947e6327ea9f3ea6332a09bf0ba0c09cae9cb1f250bd1f1549bc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/5b/6f10bad0f6461fa272bfbbdf5d0023b5fb9bc6217c92bf068fa5a99820f5/charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "47334db71978b23ebcf3c0f9f5ee98b8d65992b65c9c4f2d34c2eaf5bcaf0594",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d7/a1/493919799446464ed0299c8eef3c3fad0daf1c3cd48bff9263c731b0d9e2/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "f1a2f519ae173b5b6a2c9d5fa3116ce16e48b3462c8b96dfdded11055e3d6365",
+              "urls": [
+                "https://files.pythonhosted.org/packages/75/d2/0ab54463d3410709c09266dfb416d032a08f97fd7d60e94b8c6ef54ae14b/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "63bc5c4ae26e4bc6be6469943b8253c0fd4e4186c43ad46e713ea61a0ba49129",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8d/c9/27e41d481557be53d51e60750b85aa40eaf52b841946b3cdeff363105737/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "bcb4f8ea87d03bc51ad04add8ceaf9b0f085ac045ab4d74e73bbc2dc033f0236",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ee/44/4f62042ca8cdc0cabf87c0fc00ae27cd8b53ab68be3605ba6d071f742ad3/charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "cee4373f4d3ad28f1ab6290684d8e2ebdb9e7a1b74fdc39e4c211995f77bec27",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0b/6e/b13bd47fa9023b3699e94abf565b5a2f0b0be6e9ddac9812182596ee62e4/charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "charset_normalizer-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "urls": [
+                "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_charset_normalizer_sdist_223217c3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "charset_normalizer-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "charset-normalizer==3.4.0",
+              "sha256": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "846da004a5804145a5f441b8530b4bf35afbf7da70f82409f151695b127213d5",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/78/55356eb9075d0be6e81b59f45c7b48df87f76a20e73893872170471f3ee8/cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "0f996e7268af62598f2fc1204afa98a3b5712313a55c4c9d434aef49cadc91d4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/2c/488776a3dc843f95f86d2f957ca0fc3407d0242b50bede7fad1e339be03f/cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "f7b178f11ed3664fd0e995a47ed2b5ff0a12d893e41dd0494f406d1cf555cab7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7c/04/2345ca92f7a22f601a9c62961741ef7dd0127c39f7310dffa0041c80f16f/cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "c2e6fc39c4ab499049df3bdf567f768a723a5e8464816e8f009f121a5a9f4405",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ac/25/e715fa0bc24ac2114ed69da33adf451a38abb6f3f24ec207908112e9ba53/cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "e1be4655c7ef6e1bbe6b5d0403526601323420bcf414598955968c9ef3eb7d16",
+              "urls": [
+                "https://files.pythonhosted.org/packages/21/ce/b9c9ff56c7164d8e2edfb6c9305045fbc0df4508ccfdb13ee66eb8c95b0e/cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "df6b6c6d742395dd77a23ea3728ab62f98379eff8fb61be2744d4679ab678f73",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2a/33/b3682992ab2e9476b9c81fff22f02c8b0a1e6e1d49ee1750a67d85fd7ed2/cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_cryptography_sdist_315b9001": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "cryptography-43.0.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "cryptography==43.0.3",
+              "sha256": "315b9001266a492a6ff443b61238f956b214dbec9910a081ba5b6646a055a805",
+              "urls": [
+                "https://files.pythonhosted.org/packages/0d/05/07b55d1fa21ac18c3a8c79f764e2514e6f6a9698f1be44994f5adf0d29db/cryptography-43.0.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "docutils-0.21.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_docutils_sdist_3a6b1873": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "docutils-0.21.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "docutils==0.21.2",
+              "sha256": "3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_py3_none_any_946d195a": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "idna-3.10-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_idna_sdist_12f65c9b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "idna-3.10.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "idna==3.10",
+              "sha256": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "importlib_metadata-8.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_importlib_metadata_sdist_71522656": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "importlib_metadata-8.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "importlib-metadata==8.5.0",
+              "sha256": "71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7",
+              "urls": [
+                "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.classes-3.4.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790",
+              "urls": [
+                "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco.classes-3.4.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-classes==3.4.0",
+              "sha256": "47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.context-6.0.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "f797fc481b490edb305122c9181830a3a5b76d84ef6d1aef2fb9b47ab956f9e4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/db/0c52c4cf5e4bd9f5d7135ec7669a3a767af21b3a308e1ed3674881e52b62/jaraco.context-6.0.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_context-6.0.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-context==6.0.1",
+              "sha256": "9bae4ea555cf0b14938dc0aee7c9f32ed303aa20a3b73e7dc80111628792d1b3",
+              "urls": [
+                "https://files.pythonhosted.org/packages/df/ad/f3777b81bf0b6e7bc7514a1656d3e637b2e8e15fab2ce3235730b3e7a4e6/jaraco_context-6.0.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "jaraco.functools-4.1.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "ad159f13428bc4acbf5541ad6dec511f91573b90fba04df61dafa2a1231cf649",
+              "urls": [
+                "https://files.pythonhosted.org/packages/9f/4f/24b319316142c44283d7540e76c7b5a6dbd5db623abd86bb7b3491c21018/jaraco.functools-4.1.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jaraco_functools-4.1.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jaraco-functools==4.1.0",
+              "sha256": "70f7e0e2ae076498e212562325e805204fc092d7b4c17e0e86c959e249701a9d",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/23/9894b3df5d0a6eb44611c36aec777823fc2e07740dabbd0b810e19594013/jaraco_functools-4.1.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "jeepney-0.8.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_jeepney_sdist_5efe48d2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "jeepney-0.8.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "jeepney==0.8.0",
+              "sha256": "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_py3_none_any_5426f817": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "keyring-25.4.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "5426f817cf7f6f007ba5ec722b1bcad95a75b27d780343772ad76b17cb47b0bf",
+              "urls": [
+                "https://files.pythonhosted.org/packages/83/25/e6d59e5f0a0508d0dca8bb98c7f7fd3772fc943ac3f53d5ab18a218d32c0/keyring-25.4.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_keyring_sdist_b07ebc55": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "keyring-25.4.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "keyring==25.4.1",
+              "sha256": "b07ebc55f3e8ed86ac81dd31ef14e81ace9dd9c3d4b5d77a6e9a2016d0d71a1b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a5/1c/2bdbcfd5d59dc6274ffb175bc29aa07ecbfab196830e0cfbde7bd861a2ea/keyring-25.4.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "markdown_it_py-3.0.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "markdown-it-py-3.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "markdown-it-py==3.0.0",
+              "sha256": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+              "urls": [
+                "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_py3_none_any_84008a41": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "mdurl-0.1.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_mdurl_sdist_bb413d29": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "mdurl-0.1.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "mdurl==0.1.2",
+              "sha256": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "urls": [
+                "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "more_itertools-10.5.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "037b0d3203ce90cca8ab1defbbdac29d5f993fc20131f3664dc8d6acfa872aef",
+              "urls": [
+                "https://files.pythonhosted.org/packages/48/7e/3a64597054a70f7c86eb0a7d4fc315b8c1ab932f64883a297bdffeb5f967/more_itertools-10.5.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_more_itertools_sdist_5482bfef": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "more-itertools-10.5.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "more-itertools==10.5.0",
+              "sha256": "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "14c5a72e9fe82aea5fe3072116ad4661af5cf8e8ff8fc5ad3450f123e4925e86",
+              "urls": [
+                "https://files.pythonhosted.org/packages/b3/89/1daff5d9ba5a95a157c092c7c5f39b8dd2b1ddb4559966f808d31cfb67e0/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "7b7c2a3c9eb1a827d42539aa64091640bd275b81e097cd1d8d82ef91ffa2e811",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2c/b6/42fc3c69cabf86b6b81e4c051a9b6e249c5ba9f8155590222c2622961f58/nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "42c64511469005058cd17cc1537578eac40ae9f7200bedcfd1fc1a05f4f8c200",
+              "urls": [
+                "https://files.pythonhosted.org/packages/45/b9/833f385403abaf0023c6547389ec7a7acf141ddd9d1f21573723a6eab39a/nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "0411beb0589eacb6734f28d5497ca2ed379eafab8ad8c84b31bb5c34072b7164",
+              "urls": [
+                "https://files.pythonhosted.org/packages/05/2b/85977d9e11713b5747595ee61f381bc820749daf83f07b90b6c9964cf932/nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "5f36b271dae35c465ef5e9090e1fdaba4a60a56f0bb0ba03e0932a66f28b9189",
+              "urls": [
+                "https://files.pythonhosted.org/packages/72/f2/5c894d5265ab80a97c68ca36f25c8f6f0308abac649aaf152b74e7e854a8/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "34c03fa78e328c691f982b7c03d4423bdfd7da69cd707fe572f544cf74ac23ad",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/a7/375afcc710dbe2d64cfbd69e31f82f3e423d43737258af01f6a56d844085/nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "19aaba96e0f795bd0a6c56291495ff59364f4300d4a39b29a0abc9cb3774a84b",
+              "urls": [
+                "https://files.pythonhosted.org/packages/c2/a8/3bb02d0c60a03ad3a112b76c46971e9480efa98a8946677b5a59f60130ca/nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "de3ceed6e661954871d6cd78b410213bdcb136f79aafe22aa7182e028b8c7307",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1b/63/6ab90d0e5225ab9780f6c9fb52254fa36b52bb7c188df9201d05b647e5e1/nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "f0eca9ca8628dbb4e916ae2491d72957fdd35f7a5d326b7032a345f111ac07fe",
+              "urls": [
+                "https://files.pythonhosted.org/packages/a3/da/0c4e282bc3cff4a0adf37005fa1fb42257673fbc1bbf7d1ff639ec3d255a/nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "3a157ab149e591bb638a55c8c6bcb8cdb559c8b12c13a8affaba6cedfe51713a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/81/c291231463d21da5f8bba82c8167a6d6893cc5419b0639801ee5d3aeb8a9/nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "36c95d4b70530b320b365659bb5034341316e6a9b30f0b25fa9c9eff4c27a204",
+              "urls": [
+                "https://files.pythonhosted.org/packages/eb/61/73a007c74c37895fdf66e0edcd881f5eaa17a348ff02f4bb4bc906d61085/nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "nh3-0.2.18-cp37-abi3-win_amd64.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "8ce0f819d2f1933953fca255db2471ad58184a60508f03e6285e5114b6254844",
+              "urls": [
+                "https://files.pythonhosted.org/packages/26/8d/53c5b19c4999bdc6ba95f246f4ef35ca83d7d7423e5e38be43ad66544e5d/nh3-0.2.18-cp37-abi3-win_amd64.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_nh3_sdist_94a16692": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "nh3-0.2.18.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "nh3==0.2.18",
+              "sha256": "94a166927e53972a9698af9542ace4e38b9de50c34352b962f4d9a7d4c927af4",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/73/10df50b42ddb547a907deeb2f3c9823022580a7a47281e8eae8e003a9639/nh3-0.2.18.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pkginfo-1.10.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "889a6da2ed7ffc58ab5b900d888ddce90bce912f2d2de1dc1c26f4cb9fe65097",
+              "urls": [
+                "https://files.pythonhosted.org/packages/56/09/054aea9b7534a15ad38a363a2bd974c20646ab1582a387a95b8df1bfea1c/pkginfo-1.10.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pkginfo_sdist_5df73835": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pkginfo-1.10.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pkginfo==1.10.0",
+              "sha256": "5df73835398d10db79f8eecd5cd86b1f6d29317589ea70796994d49399af6297",
+              "urls": [
+                "https://files.pythonhosted.org/packages/2f/72/347ec5be4adc85c182ed2823d8d1c7b51e13b9a6b0c1aae59582eca652df/pkginfo-1.10.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "pycparser-2.22-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "urls": [
+                "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pycparser_sdist_491c8be9": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pycparser-2.22.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pycparser==2.22",
+              "sha256": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pygments-2.18.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pygments_sdist_786ff802": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pygments-2.18.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pygments==2.18.0",
+              "sha256": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "urls": [
+                "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "filename": "pywin32_ctypes-0.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8",
+              "urls": [
+                "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "pywin32-ctypes-0.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "pywin32-ctypes==0.2.3",
+              "sha256": "d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "readme_renderer-44.0-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151",
+              "urls": [
+                "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_readme_renderer_sdist_8712034e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "readme_renderer-44.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "readme-renderer==44.0",
+              "sha256": "8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_py3_none_any_70761cfe": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests-2.32.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_sdist_55365417": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-2.32.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests==2.32.3",
+              "sha256": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "urls": [
+                "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "requests_toolbelt-1.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06",
+              "urls": [
+                "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "requests-toolbelt-1.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "requests-toolbelt==1.0.0",
+              "sha256": "7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6",
+              "urls": [
+                "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rfc3986-2.0.0-py2.py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rfc3986_sdist_97aacf9d": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "rfc3986-2.0.0.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rfc3986==2.0.0",
+              "sha256": "97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c",
+              "urls": [
+                "https://files.pythonhosted.org/packages/85/40/1520d68bfa07ab5a6f065a186815fb6610c86fe957bc065754e47f7b0840/rfc3986-2.0.0.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_py3_none_any_6049d5e6": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "rich-13.9.4-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.4",
+              "sha256": "6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90",
+              "urls": [
+                "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_rich_sdist_43959497": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "rich-13.9.4.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "rich==13.9.4",
+              "sha256": "439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "filename": "SecretStorage-3.3.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_secretstorage_sdist_2403533e": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "SecretStorage-3.3.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "secretstorage==3.3.3",
+              "sha256": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+              "urls": [
+                "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_py3_none_any_215dbe7b": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "twine-5.1.1-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "215dbe7b4b94c2c50a7315c0275d2258399280fbb7d04182c7e55e24b5f93997",
+              "urls": [
+                "https://files.pythonhosted.org/packages/5d/ec/00f9d5fd040ae29867355e559a94e9a8429225a0284a3f5f091a3878bfc0/twine-5.1.1-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_twine_sdist_9aa08251": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "twine-5.1.1.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "twine==5.1.1",
+              "sha256": "9aa0825139c02b3434d913545c7b847a21c835e11597f5255842d457da2322db",
+              "urls": [
+                "https://files.pythonhosted.org/packages/77/68/bd982e5e949ef8334e6f7dcf76ae40922a8750aa2e347291ae1477a4782b/twine-5.1.1.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "urllib3-2.2.3-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_urllib3_sdist_e7d814a8": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "urllib3-2.2.3.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "urllib3==2.2.3",
+              "sha256": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+              "urls": [
+                "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_py3_none_any_a817ac80": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "filename": "zipp-3.20.2-py3-none-any.whl",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
+              "urls": [
+                "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl"
+              ]
+            }
+          },
+          "rules_python_publish_deps_311_zipp_sdist_bc9eb26f": {
+            "bzlFile": "@@rules_python~//python/private/pypi:whl_library.bzl",
+            "ruleClassName": "whl_library",
+            "attributes": {
+              "dep_template": "@rules_python_publish_deps//{name}:{target}",
+              "experimental_target_platforms": [
+                "cp311_linux_aarch64",
+                "cp311_linux_arm",
+                "cp311_linux_ppc",
+                "cp311_linux_s390x",
+                "cp311_linux_x86_64",
+                "cp311_osx_aarch64",
+                "cp311_osx_x86_64",
+                "cp311_windows_x86_64"
+              ],
+              "extra_pip_args": [
+                "--index-url",
+                "https://pypi.org/simple"
+              ],
+              "filename": "zipp-3.20.2.tar.gz",
+              "python_interpreter_target": "@@rules_python~~python~python_3_11_host//:python",
+              "repo": "rules_python_publish_deps_311",
+              "requirement": "zipp==3.20.2",
+              "sha256": "bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29",
+              "urls": [
+                "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz"
+              ]
+            }
+          },
+          "bazel-orfs-pip": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "bazel-orfs-pip",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "contourpy": "{\"bazel-orfs-pip_313_contourpy\":[{\"version\":\"3.13\"}]}",
+                "cycler": "{\"bazel-orfs-pip_313_cycler\":[{\"version\":\"3.13\"}]}",
+                "fonttools": "{\"bazel-orfs-pip_313_fonttools\":[{\"version\":\"3.13\"}]}",
+                "kiwisolver": "{\"bazel-orfs-pip_313_kiwisolver\":[{\"version\":\"3.13\"}]}",
+                "matplotlib": "{\"bazel-orfs-pip_313_matplotlib\":[{\"version\":\"3.13\"}]}",
+                "numpy": "{\"bazel-orfs-pip_313_numpy\":[{\"version\":\"3.13\"}]}",
+                "packaging": "{\"bazel-orfs-pip_313_packaging\":[{\"version\":\"3.13\"}]}",
+                "pillow": "{\"bazel-orfs-pip_313_pillow\":[{\"version\":\"3.13\"}]}",
+                "pyparsing": "{\"bazel-orfs-pip_313_pyparsing\":[{\"version\":\"3.13\"}]}",
+                "python_dateutil": "{\"bazel-orfs-pip_313_python_dateutil\":[{\"version\":\"3.13\"}]}",
+                "pyyaml": "{\"bazel-orfs-pip_313_pyyaml\":[{\"version\":\"3.13\"}]}",
+                "six": "{\"bazel-orfs-pip_313_six\":[{\"version\":\"3.13\"}]}"
+              },
+              "packages": [
+                "contourpy",
+                "cycler",
+                "fonttools",
+                "kiwisolver",
+                "matplotlib",
+                "numpy",
+                "packaging",
+                "pillow",
+                "pyparsing",
+                "python_dateutil",
+                "pyyaml",
+                "six"
+              ],
+              "groups": {}
+            }
+          },
+          "grpc_python_dependencies": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "grpc_python_dependencies",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "cachetools": "{\"grpc_python_dependencies_310_cachetools\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_cachetools\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_cachetools\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_cachetools\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_cachetools\":[{\"version\":\"3.9\"}]}",
+                "certifi": "{\"grpc_python_dependencies_310_certifi\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_certifi\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_certifi\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_certifi\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_certifi\":[{\"version\":\"3.9\"}]}",
+                "chardet": "{\"grpc_python_dependencies_310_chardet\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_chardet\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_chardet\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_chardet\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_chardet\":[{\"version\":\"3.9\"}]}",
+                "coverage": "{\"grpc_python_dependencies_310_coverage\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_coverage\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_coverage\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_coverage\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_coverage\":[{\"version\":\"3.9\"}]}",
+                "cython": "{\"grpc_python_dependencies_310_cython\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_cython\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_cython\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_cython\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_cython\":[{\"version\":\"3.9\"}]}",
+                "gevent": "{\"grpc_python_dependencies_310_gevent\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_gevent\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_gevent\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_gevent\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_gevent\":[{\"version\":\"3.9\"}]}",
+                "google_auth": "{\"grpc_python_dependencies_310_google_auth\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_google_auth\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_google_auth\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_google_auth\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_google_auth\":[{\"version\":\"3.9\"}]}",
+                "googleapis_common_protos": "{\"grpc_python_dependencies_310_googleapis_common_protos\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_googleapis_common_protos\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_googleapis_common_protos\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_googleapis_common_protos\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_googleapis_common_protos\":[{\"version\":\"3.9\"}]}",
+                "greenlet": "{\"grpc_python_dependencies_310_greenlet\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_greenlet\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_greenlet\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_greenlet\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_greenlet\":[{\"version\":\"3.9\"}]}",
+                "grpcio": "{\"grpc_python_dependencies_310_grpcio\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_grpcio\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_grpcio\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_grpcio\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_grpcio\":[{\"version\":\"3.9\"}]}",
+                "idna": "{\"grpc_python_dependencies_310_idna\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_idna\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_idna\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_idna\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_idna\":[{\"version\":\"3.9\"}]}",
+                "oauth2client": "{\"grpc_python_dependencies_310_oauth2client\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_oauth2client\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_oauth2client\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_oauth2client\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_oauth2client\":[{\"version\":\"3.9\"}]}",
+                "protobuf": "{\"grpc_python_dependencies_310_protobuf\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_protobuf\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_protobuf\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_protobuf\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_protobuf\":[{\"version\":\"3.9\"}]}",
+                "pyasn1": "{\"grpc_python_dependencies_310_pyasn1\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_pyasn1\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_pyasn1\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_pyasn1\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_pyasn1\":[{\"version\":\"3.9\"}]}",
+                "pyasn1_modules": "{\"grpc_python_dependencies_310_pyasn1_modules\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_pyasn1_modules\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_pyasn1_modules\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_pyasn1_modules\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_pyasn1_modules\":[{\"version\":\"3.9\"}]}",
+                "requests": "{\"grpc_python_dependencies_310_requests\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_requests\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_requests\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_requests\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_requests\":[{\"version\":\"3.9\"}]}",
+                "rsa": "{\"grpc_python_dependencies_310_rsa\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_rsa\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_rsa\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_rsa\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_rsa\":[{\"version\":\"3.9\"}]}",
+                "setuptools": "{\"grpc_python_dependencies_310_setuptools\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_setuptools\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_setuptools\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_setuptools\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_setuptools\":[{\"version\":\"3.9\"}]}",
+                "six": "{\"grpc_python_dependencies_310_six\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_six\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_six\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_six\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_six\":[{\"version\":\"3.9\"}]}",
+                "urllib3": "{\"grpc_python_dependencies_310_urllib3\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_urllib3\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_urllib3\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_urllib3\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_urllib3\":[{\"version\":\"3.9\"}]}",
+                "wheel": "{\"grpc_python_dependencies_310_wheel\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_wheel\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_wheel\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_wheel\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_wheel\":[{\"version\":\"3.9\"}]}",
+                "xds_protos": "{\"grpc_python_dependencies_310_xds_protos\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_xds_protos\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_xds_protos\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_xds_protos\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_xds_protos\":[{\"version\":\"3.9\"}]}",
+                "zope_event": "{\"grpc_python_dependencies_310_zope_event\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_zope_event\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_zope_event\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_zope_event\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_zope_event\":[{\"version\":\"3.9\"}]}",
+                "zope_interface": "{\"grpc_python_dependencies_310_zope_interface\":[{\"version\":\"3.10\"}],\"grpc_python_dependencies_311_zope_interface\":[{\"version\":\"3.11\"}],\"grpc_python_dependencies_312_zope_interface\":[{\"version\":\"3.12\"}],\"grpc_python_dependencies_38_zope_interface\":[{\"version\":\"3.8\"}],\"grpc_python_dependencies_39_zope_interface\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "cachetools",
+                "certifi",
+                "chardet",
+                "coverage",
+                "cython",
+                "gevent",
+                "google_auth",
+                "googleapis_common_protos",
+                "greenlet",
+                "grpcio",
+                "idna",
+                "oauth2client",
+                "protobuf",
+                "pyasn1",
+                "pyasn1_modules",
+                "requests",
+                "rsa",
+                "setuptools",
+                "six",
+                "urllib3",
+                "wheel",
+                "xds_protos",
+                "zope_event",
+                "zope_interface"
+              ],
+              "groups": {}
+            }
+          },
+          "openroad-pip": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "openroad-pip",
+              "extra_hub_aliases": {},
+              "whl_map": {},
+              "packages": [],
+              "groups": {}
+            }
+          },
+          "ortools_notebook_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "ortools_notebook_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"ortools_notebook_deps_310_absl_py\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_absl_py\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_absl_py\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_absl_py\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_absl_py\":[{\"version\":\"3.9\"}]}",
+                "anyio": "{\"ortools_notebook_deps_310_anyio\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_anyio\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_anyio\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_anyio\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_anyio\":[{\"version\":\"3.9\"}]}",
+                "argon2_cffi": "{\"ortools_notebook_deps_310_argon2_cffi\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_argon2_cffi\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_argon2_cffi\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_argon2_cffi\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_argon2_cffi\":[{\"version\":\"3.9\"}]}",
+                "argon2_cffi_bindings": "{\"ortools_notebook_deps_310_argon2_cffi_bindings\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_argon2_cffi_bindings\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_argon2_cffi_bindings\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_argon2_cffi_bindings\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_argon2_cffi_bindings\":[{\"version\":\"3.9\"}]}",
+                "arrow": "{\"ortools_notebook_deps_310_arrow\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_arrow\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_arrow\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_arrow\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_arrow\":[{\"version\":\"3.9\"}]}",
+                "asttokens": "{\"ortools_notebook_deps_310_asttokens\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_asttokens\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_asttokens\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_asttokens\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_asttokens\":[{\"version\":\"3.9\"}]}",
+                "async_lru": "{\"ortools_notebook_deps_310_async_lru\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_async_lru\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_async_lru\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_async_lru\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_async_lru\":[{\"version\":\"3.9\"}]}",
+                "attrs": "{\"ortools_notebook_deps_310_attrs\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_attrs\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_attrs\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_attrs\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_attrs\":[{\"version\":\"3.9\"}]}",
+                "babel": "{\"ortools_notebook_deps_310_babel\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_babel\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_babel\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_babel\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_babel\":[{\"version\":\"3.9\"}]}",
+                "backcall": "{\"ortools_notebook_deps_310_backcall\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_backcall\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_backcall\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_backcall\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_backcall\":[{\"version\":\"3.9\"}]}",
+                "beautifulsoup4": "{\"ortools_notebook_deps_310_beautifulsoup4\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_beautifulsoup4\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_beautifulsoup4\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_beautifulsoup4\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_beautifulsoup4\":[{\"version\":\"3.9\"}]}",
+                "black": "{\"ortools_notebook_deps_310_black\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_black\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_black\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_black\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_black\":[{\"version\":\"3.9\"}]}",
+                "bleach": "{\"ortools_notebook_deps_310_bleach\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_bleach\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_bleach\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_bleach\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_bleach\":[{\"version\":\"3.9\"}]}",
+                "certifi": "{\"ortools_notebook_deps_310_certifi\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_certifi\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_certifi\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_certifi\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_certifi\":[{\"version\":\"3.9\"}]}",
+                "cffi": "{\"ortools_notebook_deps_310_cffi\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_cffi\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_cffi\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_cffi\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_cffi\":[{\"version\":\"3.9\"}]}",
+                "charset_normalizer": "{\"ortools_notebook_deps_310_charset_normalizer\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_charset_normalizer\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_charset_normalizer\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_charset_normalizer\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_charset_normalizer\":[{\"version\":\"3.9\"}]}",
+                "click": "{\"ortools_notebook_deps_310_click\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_click\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_click\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_click\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_click\":[{\"version\":\"3.9\"}]}",
+                "comm": "{\"ortools_notebook_deps_310_comm\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_comm\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_comm\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_comm\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_comm\":[{\"version\":\"3.9\"}]}",
+                "debugpy": "{\"ortools_notebook_deps_310_debugpy\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_debugpy\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_debugpy\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_debugpy\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_debugpy\":[{\"version\":\"3.9\"}]}",
+                "decorator": "{\"ortools_notebook_deps_310_decorator\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_decorator\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_decorator\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_decorator\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_decorator\":[{\"version\":\"3.9\"}]}",
+                "defusedxml": "{\"ortools_notebook_deps_310_defusedxml\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_defusedxml\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_defusedxml\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_defusedxml\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_defusedxml\":[{\"version\":\"3.9\"}]}",
+                "distlib": "{\"ortools_notebook_deps_310_distlib\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_distlib\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_distlib\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_distlib\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_distlib\":[{\"version\":\"3.9\"}]}",
+                "executing": "{\"ortools_notebook_deps_310_executing\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_executing\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_executing\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_executing\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_executing\":[{\"version\":\"3.9\"}]}",
+                "fastjsonschema": "{\"ortools_notebook_deps_310_fastjsonschema\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_fastjsonschema\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_fastjsonschema\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_fastjsonschema\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_fastjsonschema\":[{\"version\":\"3.9\"}]}",
+                "filelock": "{\"ortools_notebook_deps_310_filelock\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_filelock\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_filelock\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_filelock\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_filelock\":[{\"version\":\"3.9\"}]}",
+                "fqdn": "{\"ortools_notebook_deps_310_fqdn\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_fqdn\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_fqdn\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_fqdn\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_fqdn\":[{\"version\":\"3.9\"}]}",
+                "h11": "{\"ortools_notebook_deps_310_h11\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_h11\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_h11\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_h11\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_h11\":[{\"version\":\"3.9\"}]}",
+                "httpcore": "{\"ortools_notebook_deps_310_httpcore\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_httpcore\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_httpcore\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_httpcore\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_httpcore\":[{\"version\":\"3.9\"}]}",
+                "httpx": "{\"ortools_notebook_deps_310_httpx\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_httpx\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_httpx\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_httpx\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_httpx\":[{\"version\":\"3.9\"}]}",
+                "idna": "{\"ortools_notebook_deps_310_idna\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_idna\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_idna\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_idna\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_idna\":[{\"version\":\"3.9\"}]}",
+                "immutabledict": "{\"ortools_notebook_deps_310_immutabledict\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_immutabledict\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_immutabledict\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_immutabledict\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_immutabledict\":[{\"version\":\"3.9\"}]}",
+                "ipykernel": "{\"ortools_notebook_deps_310_ipykernel\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_ipykernel\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_ipykernel\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_ipykernel\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_ipykernel\":[{\"version\":\"3.9\"}]}",
+                "ipython": "{\"ortools_notebook_deps_310_ipython\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_ipython\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_ipython\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_ipython\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_ipython\":[{\"version\":\"3.9\"}]}",
+                "isoduration": "{\"ortools_notebook_deps_310_isoduration\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_isoduration\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_isoduration\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_isoduration\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_isoduration\":[{\"version\":\"3.9\"}]}",
+                "jedi": "{\"ortools_notebook_deps_310_jedi\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jedi\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jedi\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jedi\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jedi\":[{\"version\":\"3.9\"}]}",
+                "jinja2": "{\"ortools_notebook_deps_310_jinja2\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jinja2\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jinja2\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jinja2\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jinja2\":[{\"version\":\"3.9\"}]}",
+                "json5": "{\"ortools_notebook_deps_310_json5\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_json5\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_json5\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_json5\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_json5\":[{\"version\":\"3.9\"}]}",
+                "jsonpointer": "{\"ortools_notebook_deps_310_jsonpointer\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jsonpointer\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jsonpointer\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jsonpointer\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jsonpointer\":[{\"version\":\"3.9\"}]}",
+                "jsonschema": "{\"ortools_notebook_deps_310_jsonschema\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jsonschema\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jsonschema\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jsonschema\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jsonschema\":[{\"version\":\"3.9\"}]}",
+                "jsonschema_specifications": "{\"ortools_notebook_deps_310_jsonschema_specifications\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jsonschema_specifications\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jsonschema_specifications\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jsonschema_specifications\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jsonschema_specifications\":[{\"version\":\"3.9\"}]}",
+                "jupyter_client": "{\"ortools_notebook_deps_310_jupyter_client\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_client\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_client\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_client\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_client\":[{\"version\":\"3.9\"}]}",
+                "jupyter_core": "{\"ortools_notebook_deps_310_jupyter_core\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_core\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_core\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_core\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_core\":[{\"version\":\"3.9\"}]}",
+                "jupyter_events": "{\"ortools_notebook_deps_310_jupyter_events\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_events\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_events\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_events\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_events\":[{\"version\":\"3.9\"}]}",
+                "jupyter_lsp": "{\"ortools_notebook_deps_310_jupyter_lsp\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_lsp\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_lsp\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_lsp\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_lsp\":[{\"version\":\"3.9\"}]}",
+                "jupyter_server": "{\"ortools_notebook_deps_310_jupyter_server\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_server\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_server\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_server\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_server\":[{\"version\":\"3.9\"}]}",
+                "jupyter_server_terminals": "{\"ortools_notebook_deps_310_jupyter_server_terminals\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyter_server_terminals\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyter_server_terminals\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyter_server_terminals\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyter_server_terminals\":[{\"version\":\"3.9\"}]}",
+                "jupyterlab": "{\"ortools_notebook_deps_310_jupyterlab\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyterlab\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyterlab\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyterlab\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyterlab\":[{\"version\":\"3.9\"}]}",
+                "jupyterlab_pygments": "{\"ortools_notebook_deps_310_jupyterlab_pygments\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyterlab_pygments\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyterlab_pygments\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyterlab_pygments\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyterlab_pygments\":[{\"version\":\"3.9\"}]}",
+                "jupyterlab_server": "{\"ortools_notebook_deps_310_jupyterlab_server\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_jupyterlab_server\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_jupyterlab_server\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_jupyterlab_server\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_jupyterlab_server\":[{\"version\":\"3.9\"}]}",
+                "markupsafe": "{\"ortools_notebook_deps_310_markupsafe\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_markupsafe\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_markupsafe\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_markupsafe\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_markupsafe\":[{\"version\":\"3.9\"}]}",
+                "matplotlib_inline": "{\"ortools_notebook_deps_310_matplotlib_inline\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_matplotlib_inline\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_matplotlib_inline\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_matplotlib_inline\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_matplotlib_inline\":[{\"version\":\"3.9\"}]}",
+                "mistune": "{\"ortools_notebook_deps_310_mistune\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_mistune\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_mistune\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_mistune\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_mistune\":[{\"version\":\"3.9\"}]}",
+                "mypy": "{\"ortools_notebook_deps_310_mypy\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_mypy\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_mypy\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_mypy\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_mypy\":[{\"version\":\"3.9\"}]}",
+                "mypy_extensions": "{\"ortools_notebook_deps_310_mypy_extensions\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_mypy_extensions\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_mypy_extensions\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_mypy_extensions\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_mypy_extensions\":[{\"version\":\"3.9\"}]}",
+                "mypy_protobuf": "{\"ortools_notebook_deps_310_mypy_protobuf\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_mypy_protobuf\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_mypy_protobuf\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_mypy_protobuf\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_mypy_protobuf\":[{\"version\":\"3.9\"}]}",
+                "nbclient": "{\"ortools_notebook_deps_310_nbclient\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_nbclient\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_nbclient\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_nbclient\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_nbclient\":[{\"version\":\"3.9\"}]}",
+                "nbconvert": "{\"ortools_notebook_deps_310_nbconvert\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_nbconvert\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_nbconvert\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_nbconvert\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_nbconvert\":[{\"version\":\"3.9\"}]}",
+                "nbformat": "{\"ortools_notebook_deps_310_nbformat\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_nbformat\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_nbformat\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_nbformat\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_nbformat\":[{\"version\":\"3.9\"}]}",
+                "nest_asyncio": "{\"ortools_notebook_deps_310_nest_asyncio\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_nest_asyncio\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_nest_asyncio\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_nest_asyncio\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_nest_asyncio\":[{\"version\":\"3.9\"}]}",
+                "notebook": "{\"ortools_notebook_deps_310_notebook\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_notebook\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_notebook\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_notebook\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_notebook\":[{\"version\":\"3.9\"}]}",
+                "notebook_shim": "{\"ortools_notebook_deps_310_notebook_shim\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_notebook_shim\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_notebook_shim\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_notebook_shim\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_notebook_shim\":[{\"version\":\"3.9\"}]}",
+                "numpy": "{\"ortools_notebook_deps_310_numpy\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_numpy\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_numpy\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_numpy\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_numpy\":[{\"version\":\"3.9\"}]}",
+                "overrides": "{\"ortools_notebook_deps_310_overrides\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_overrides\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_overrides\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_overrides\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_overrides\":[{\"version\":\"3.9\"}]}",
+                "packaging": "{\"ortools_notebook_deps_310_packaging\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_packaging\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_packaging\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_packaging\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_packaging\":[{\"version\":\"3.9\"}]}",
+                "pandas": "{\"ortools_notebook_deps_310_pandas\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pandas\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pandas\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pandas\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pandas\":[{\"version\":\"3.9\"}]}",
+                "pandocfilters": "{\"ortools_notebook_deps_310_pandocfilters\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pandocfilters\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pandocfilters\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pandocfilters\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pandocfilters\":[{\"version\":\"3.9\"}]}",
+                "parso": "{\"ortools_notebook_deps_310_parso\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_parso\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_parso\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_parso\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_parso\":[{\"version\":\"3.9\"}]}",
+                "pathspec": "{\"ortools_notebook_deps_310_pathspec\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pathspec\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pathspec\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pathspec\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pathspec\":[{\"version\":\"3.9\"}]}",
+                "pexpect": "{\"ortools_notebook_deps_310_pexpect\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pexpect\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pexpect\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pexpect\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pexpect\":[{\"version\":\"3.9\"}]}",
+                "pickleshare": "{\"ortools_notebook_deps_310_pickleshare\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pickleshare\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pickleshare\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pickleshare\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pickleshare\":[{\"version\":\"3.9\"}]}",
+                "platformdirs": "{\"ortools_notebook_deps_310_platformdirs\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_platformdirs\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_platformdirs\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_platformdirs\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_platformdirs\":[{\"version\":\"3.9\"}]}",
+                "plotly": "{\"ortools_notebook_deps_310_plotly\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_plotly\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_plotly\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_plotly\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_plotly\":[{\"version\":\"3.9\"}]}",
+                "prometheus_client": "{\"ortools_notebook_deps_310_prometheus_client\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_prometheus_client\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_prometheus_client\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_prometheus_client\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_prometheus_client\":[{\"version\":\"3.9\"}]}",
+                "prompt_toolkit": "{\"ortools_notebook_deps_310_prompt_toolkit\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_prompt_toolkit\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_prompt_toolkit\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_prompt_toolkit\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_prompt_toolkit\":[{\"version\":\"3.9\"}]}",
+                "protobuf": "{\"ortools_notebook_deps_310_protobuf\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_protobuf\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_protobuf\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_protobuf\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_protobuf\":[{\"version\":\"3.9\"}]}",
+                "psutil": "{\"ortools_notebook_deps_310_psutil\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_psutil\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_psutil\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_psutil\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_psutil\":[{\"version\":\"3.9\"}]}",
+                "ptyprocess": "{\"ortools_notebook_deps_310_ptyprocess\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_ptyprocess\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_ptyprocess\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_ptyprocess\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_ptyprocess\":[{\"version\":\"3.9\"}]}",
+                "pure_eval": "{\"ortools_notebook_deps_310_pure_eval\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pure_eval\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pure_eval\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pure_eval\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pure_eval\":[{\"version\":\"3.9\"}]}",
+                "pycparser": "{\"ortools_notebook_deps_310_pycparser\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pycparser\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pycparser\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pycparser\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pycparser\":[{\"version\":\"3.9\"}]}",
+                "pygments": "{\"ortools_notebook_deps_310_pygments\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pygments\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pygments\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pygments\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pygments\":[{\"version\":\"3.9\"}]}",
+                "python_dateutil": "{\"ortools_notebook_deps_310_python_dateutil\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_python_dateutil\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_python_dateutil\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_python_dateutil\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_python_dateutil\":[{\"version\":\"3.9\"}]}",
+                "python_json_logger": "{\"ortools_notebook_deps_310_python_json_logger\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_python_json_logger\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_python_json_logger\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_python_json_logger\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_python_json_logger\":[{\"version\":\"3.9\"}]}",
+                "pytz": "{\"ortools_notebook_deps_310_pytz\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pytz\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pytz\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pytz\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pytz\":[{\"version\":\"3.9\"}]}",
+                "pyyaml": "{\"ortools_notebook_deps_310_pyyaml\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pyyaml\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pyyaml\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pyyaml\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pyyaml\":[{\"version\":\"3.9\"}]}",
+                "pyzmq": "{\"ortools_notebook_deps_310_pyzmq\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_pyzmq\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_pyzmq\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_pyzmq\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_pyzmq\":[{\"version\":\"3.9\"}]}",
+                "referencing": "{\"ortools_notebook_deps_310_referencing\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_referencing\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_referencing\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_referencing\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_referencing\":[{\"version\":\"3.9\"}]}",
+                "requests": "{\"ortools_notebook_deps_310_requests\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_requests\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_requests\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_requests\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_requests\":[{\"version\":\"3.9\"}]}",
+                "rfc3339_validator": "{\"ortools_notebook_deps_310_rfc3339_validator\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_rfc3339_validator\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_rfc3339_validator\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_rfc3339_validator\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_rfc3339_validator\":[{\"version\":\"3.9\"}]}",
+                "rfc3986_validator": "{\"ortools_notebook_deps_310_rfc3986_validator\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_rfc3986_validator\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_rfc3986_validator\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_rfc3986_validator\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_rfc3986_validator\":[{\"version\":\"3.9\"}]}",
+                "rpds_py": "{\"ortools_notebook_deps_310_rpds_py\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_rpds_py\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_rpds_py\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_rpds_py\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_rpds_py\":[{\"version\":\"3.9\"}]}",
+                "scipy": "{\"ortools_notebook_deps_310_scipy\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_scipy\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_scipy\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_scipy\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_scipy\":[{\"version\":\"3.9\"}]}",
+                "send2trash": "{\"ortools_notebook_deps_310_send2trash\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_send2trash\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_send2trash\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_send2trash\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_send2trash\":[{\"version\":\"3.9\"}]}",
+                "setuptools": "{\"ortools_notebook_deps_310_setuptools\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_setuptools\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_setuptools\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_setuptools\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_setuptools\":[{\"version\":\"3.9\"}]}",
+                "six": "{\"ortools_notebook_deps_310_six\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_six\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_six\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_six\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_six\":[{\"version\":\"3.9\"}]}",
+                "sniffio": "{\"ortools_notebook_deps_310_sniffio\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_sniffio\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_sniffio\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_sniffio\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_sniffio\":[{\"version\":\"3.9\"}]}",
+                "soupsieve": "{\"ortools_notebook_deps_310_soupsieve\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_soupsieve\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_soupsieve\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_soupsieve\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_soupsieve\":[{\"version\":\"3.9\"}]}",
+                "stack_data": "{\"ortools_notebook_deps_310_stack_data\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_stack_data\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_stack_data\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_stack_data\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_stack_data\":[{\"version\":\"3.9\"}]}",
+                "svgwrite": "{\"ortools_notebook_deps_310_svgwrite\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_svgwrite\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_svgwrite\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_svgwrite\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_svgwrite\":[{\"version\":\"3.9\"}]}",
+                "tenacity": "{\"ortools_notebook_deps_310_tenacity\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_tenacity\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_tenacity\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_tenacity\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_tenacity\":[{\"version\":\"3.9\"}]}",
+                "terminado": "{\"ortools_notebook_deps_310_terminado\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_terminado\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_terminado\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_terminado\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_terminado\":[{\"version\":\"3.9\"}]}",
+                "tinycss2": "{\"ortools_notebook_deps_310_tinycss2\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_tinycss2\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_tinycss2\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_tinycss2\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_tinycss2\":[{\"version\":\"3.9\"}]}",
+                "tornado": "{\"ortools_notebook_deps_310_tornado\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_tornado\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_tornado\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_tornado\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_tornado\":[{\"version\":\"3.9\"}]}",
+                "traitlets": "{\"ortools_notebook_deps_310_traitlets\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_traitlets\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_traitlets\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_traitlets\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_traitlets\":[{\"version\":\"3.9\"}]}",
+                "types_protobuf": "{\"ortools_notebook_deps_310_types_protobuf\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_types_protobuf\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_types_protobuf\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_types_protobuf\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_types_protobuf\":[{\"version\":\"3.9\"}]}",
+                "typing_extensions": "{\"ortools_notebook_deps_310_typing_extensions\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_typing_extensions\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_typing_extensions\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_typing_extensions\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_typing_extensions\":[{\"version\":\"3.9\"}]}",
+                "tzdata": "{\"ortools_notebook_deps_310_tzdata\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_tzdata\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_tzdata\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_tzdata\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_tzdata\":[{\"version\":\"3.9\"}]}",
+                "uri_template": "{\"ortools_notebook_deps_310_uri_template\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_uri_template\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_uri_template\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_uri_template\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_uri_template\":[{\"version\":\"3.9\"}]}",
+                "urllib3": "{\"ortools_notebook_deps_310_urllib3\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_urllib3\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_urllib3\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_urllib3\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_urllib3\":[{\"version\":\"3.9\"}]}",
+                "virtualenv": "{\"ortools_notebook_deps_310_virtualenv\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_virtualenv\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_virtualenv\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_virtualenv\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_virtualenv\":[{\"version\":\"3.9\"}]}",
+                "wcwidth": "{\"ortools_notebook_deps_310_wcwidth\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_wcwidth\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_wcwidth\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_wcwidth\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_wcwidth\":[{\"version\":\"3.9\"}]}",
+                "webcolors": "{\"ortools_notebook_deps_310_webcolors\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_webcolors\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_webcolors\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_webcolors\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_webcolors\":[{\"version\":\"3.9\"}]}",
+                "webencodings": "{\"ortools_notebook_deps_310_webencodings\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_webencodings\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_webencodings\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_webencodings\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_webencodings\":[{\"version\":\"3.9\"}]}",
+                "websocket_client": "{\"ortools_notebook_deps_310_websocket_client\":[{\"version\":\"3.10\"}],\"ortools_notebook_deps_311_websocket_client\":[{\"version\":\"3.11\"}],\"ortools_notebook_deps_312_websocket_client\":[{\"version\":\"3.12\"}],\"ortools_notebook_deps_313_websocket_client\":[{\"version\":\"3.13\"}],\"ortools_notebook_deps_39_websocket_client\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py",
+                "anyio",
+                "argon2_cffi",
+                "argon2_cffi_bindings",
+                "arrow",
+                "asttokens",
+                "async_lru",
+                "attrs",
+                "babel",
+                "backcall",
+                "beautifulsoup4",
+                "black",
+                "bleach",
+                "certifi",
+                "cffi",
+                "charset_normalizer",
+                "click",
+                "comm",
+                "debugpy",
+                "decorator",
+                "defusedxml",
+                "distlib",
+                "executing",
+                "fastjsonschema",
+                "filelock",
+                "fqdn",
+                "h11",
+                "httpcore",
+                "httpx",
+                "idna",
+                "immutabledict",
+                "ipykernel",
+                "ipython",
+                "isoduration",
+                "jedi",
+                "jinja2",
+                "json5",
+                "jsonpointer",
+                "jsonschema",
+                "jsonschema_specifications",
+                "jupyter_client",
+                "jupyter_core",
+                "jupyter_events",
+                "jupyter_lsp",
+                "jupyter_server",
+                "jupyter_server_terminals",
+                "jupyterlab",
+                "jupyterlab_pygments",
+                "jupyterlab_server",
+                "markupsafe",
+                "matplotlib_inline",
+                "mistune",
+                "mypy",
+                "mypy_extensions",
+                "mypy_protobuf",
+                "nbclient",
+                "nbconvert",
+                "nbformat",
+                "nest_asyncio",
+                "notebook",
+                "notebook_shim",
+                "numpy",
+                "overrides",
+                "packaging",
+                "pandas",
+                "pandocfilters",
+                "parso",
+                "pathspec",
+                "pexpect",
+                "pickleshare",
+                "platformdirs",
+                "plotly",
+                "prometheus_client",
+                "prompt_toolkit",
+                "protobuf",
+                "psutil",
+                "ptyprocess",
+                "pure_eval",
+                "pycparser",
+                "pygments",
+                "python_dateutil",
+                "python_json_logger",
+                "pytz",
+                "pyyaml",
+                "pyzmq",
+                "referencing",
+                "requests",
+                "rfc3339_validator",
+                "rfc3986_validator",
+                "rpds_py",
+                "scipy",
+                "send2trash",
+                "setuptools",
+                "six",
+                "sniffio",
+                "soupsieve",
+                "stack_data",
+                "svgwrite",
+                "tenacity",
+                "terminado",
+                "tinycss2",
+                "tornado",
+                "traitlets",
+                "types_protobuf",
+                "typing_extensions",
+                "tzdata",
+                "uri_template",
+                "urllib3",
+                "virtualenv",
+                "wcwidth",
+                "webcolors",
+                "webencodings",
+                "websocket_client"
+              ],
+              "groups": {}
+            }
+          },
+          "ortools_pip_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "ortools_pip_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"ortools_pip_deps_310_absl_py\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_absl_py\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_absl_py\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_absl_py\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_absl_py\":[{\"version\":\"3.9\"}]}",
+                "black": "{\"ortools_pip_deps_310_black\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_black\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_black\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_black\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_black\":[{\"version\":\"3.9\"}]}",
+                "certifi": "{\"ortools_pip_deps_310_certifi\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_certifi\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_certifi\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_certifi\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_certifi\":[{\"version\":\"3.9\"}]}",
+                "charset_normalizer": "{\"ortools_pip_deps_310_charset_normalizer\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_charset_normalizer\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_charset_normalizer\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_charset_normalizer\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_charset_normalizer\":[{\"version\":\"3.9\"}]}",
+                "click": "{\"ortools_pip_deps_310_click\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_click\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_click\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_click\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_click\":[{\"version\":\"3.9\"}]}",
+                "distlib": "{\"ortools_pip_deps_310_distlib\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_distlib\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_distlib\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_distlib\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_distlib\":[{\"version\":\"3.9\"}]}",
+                "filelock": "{\"ortools_pip_deps_310_filelock\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_filelock\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_filelock\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_filelock\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_filelock\":[{\"version\":\"3.9\"}]}",
+                "idna": "{\"ortools_pip_deps_310_idna\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_idna\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_idna\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_idna\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_idna\":[{\"version\":\"3.9\"}]}",
+                "immutabledict": "{\"ortools_pip_deps_310_immutabledict\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_immutabledict\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_immutabledict\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_immutabledict\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_immutabledict\":[{\"version\":\"3.9\"}]}",
+                "mypy": "{\"ortools_pip_deps_310_mypy\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_mypy\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_mypy\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_mypy\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_mypy\":[{\"version\":\"3.9\"}]}",
+                "mypy_extensions": "{\"ortools_pip_deps_310_mypy_extensions\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_mypy_extensions\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_mypy_extensions\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_mypy_extensions\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_mypy_extensions\":[{\"version\":\"3.9\"}]}",
+                "mypy_protobuf": "{\"ortools_pip_deps_310_mypy_protobuf\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_mypy_protobuf\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_mypy_protobuf\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_mypy_protobuf\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_mypy_protobuf\":[{\"version\":\"3.9\"}]}",
+                "numpy": "{\"ortools_pip_deps_310_numpy\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_numpy\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_numpy\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_numpy\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_numpy\":[{\"version\":\"3.9\"}]}",
+                "packaging": "{\"ortools_pip_deps_310_packaging\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_packaging\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_packaging\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_packaging\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_packaging\":[{\"version\":\"3.9\"}]}",
+                "pandas": "{\"ortools_pip_deps_310_pandas\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_pandas\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_pandas\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_pandas\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_pandas\":[{\"version\":\"3.9\"}]}",
+                "pathspec": "{\"ortools_pip_deps_310_pathspec\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_pathspec\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_pathspec\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_pathspec\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_pathspec\":[{\"version\":\"3.9\"}]}",
+                "platformdirs": "{\"ortools_pip_deps_310_platformdirs\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_platformdirs\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_platformdirs\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_platformdirs\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_platformdirs\":[{\"version\":\"3.9\"}]}",
+                "protobuf": "{\"ortools_pip_deps_310_protobuf\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_protobuf\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_protobuf\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_protobuf\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_protobuf\":[{\"version\":\"3.9\"}]}",
+                "python_dateutil": "{\"ortools_pip_deps_310_python_dateutil\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_python_dateutil\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_python_dateutil\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_python_dateutil\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_python_dateutil\":[{\"version\":\"3.9\"}]}",
+                "pytz": "{\"ortools_pip_deps_310_pytz\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_pytz\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_pytz\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_pytz\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_pytz\":[{\"version\":\"3.9\"}]}",
+                "requests": "{\"ortools_pip_deps_310_requests\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_requests\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_requests\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_requests\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_requests\":[{\"version\":\"3.9\"}]}",
+                "scipy": "{\"ortools_pip_deps_310_scipy\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_scipy\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_scipy\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_scipy\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_scipy\":[{\"version\":\"3.9\"}]}",
+                "six": "{\"ortools_pip_deps_310_six\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_six\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_six\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_six\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_six\":[{\"version\":\"3.9\"}]}",
+                "svgwrite": "{\"ortools_pip_deps_310_svgwrite\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_svgwrite\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_svgwrite\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_svgwrite\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_svgwrite\":[{\"version\":\"3.9\"}]}",
+                "types_protobuf": "{\"ortools_pip_deps_310_types_protobuf\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_types_protobuf\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_types_protobuf\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_types_protobuf\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_types_protobuf\":[{\"version\":\"3.9\"}]}",
+                "typing_extensions": "{\"ortools_pip_deps_310_typing_extensions\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_typing_extensions\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_typing_extensions\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_typing_extensions\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_typing_extensions\":[{\"version\":\"3.9\"}]}",
+                "tzdata": "{\"ortools_pip_deps_310_tzdata\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_tzdata\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_tzdata\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_tzdata\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_tzdata\":[{\"version\":\"3.9\"}]}",
+                "urllib3": "{\"ortools_pip_deps_310_urllib3\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_urllib3\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_urllib3\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_urllib3\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_urllib3\":[{\"version\":\"3.9\"}]}",
+                "virtualenv": "{\"ortools_pip_deps_310_virtualenv\":[{\"version\":\"3.10\"}],\"ortools_pip_deps_311_virtualenv\":[{\"version\":\"3.11\"}],\"ortools_pip_deps_312_virtualenv\":[{\"version\":\"3.12\"}],\"ortools_pip_deps_313_virtualenv\":[{\"version\":\"3.13\"}],\"ortools_pip_deps_39_virtualenv\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py",
+                "black",
+                "certifi",
+                "charset_normalizer",
+                "click",
+                "distlib",
+                "filelock",
+                "idna",
+                "immutabledict",
+                "mypy",
+                "mypy_extensions",
+                "mypy_protobuf",
+                "numpy",
+                "packaging",
+                "pandas",
+                "pathspec",
+                "platformdirs",
+                "protobuf",
+                "python_dateutil",
+                "pytz",
+                "requests",
+                "scipy",
+                "six",
+                "svgwrite",
+                "types_protobuf",
+                "typing_extensions",
+                "tzdata",
+                "urllib3",
+                "virtualenv"
+              ],
+              "groups": {}
+            }
+          },
+          "pybind11_protobuf_py_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "pybind11_protobuf_py_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"pybind11_protobuf_py_deps_310_absl_py\":[{\"version\":\"3.10\"}],\"pybind11_protobuf_py_deps_311_absl_py\":[{\"version\":\"3.11\"}],\"pybind11_protobuf_py_deps_312_absl_py\":[{\"version\":\"3.12\"}],\"pybind11_protobuf_py_deps_38_absl_py\":[{\"version\":\"3.8\"}],\"pybind11_protobuf_py_deps_39_absl_py\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py"
+              ],
+              "groups": {}
+            }
+          },
+          "pypi": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "pypi",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"pypi_310_absl_py\":[{\"version\":\"3.10\"}],\"pypi_311_absl_py\":[{\"version\":\"3.11\"}],\"pypi_312_absl_py\":[{\"version\":\"3.12\"}],\"pypi_38_absl_py\":[{\"version\":\"3.8\"}],\"pypi_39_absl_py\":[{\"version\":\"3.9\"}]}",
+                "numpy": "{\"pypi_310_numpy\":[{\"version\":\"3.10\"}],\"pypi_311_numpy\":[{\"version\":\"3.11\"}],\"pypi_312_numpy\":[{\"version\":\"3.12\"}],\"pypi_38_numpy\":[{\"version\":\"3.8\"}],\"pypi_39_numpy\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py",
+                "numpy"
+              ],
+              "groups": {}
+            }
+          },
+          "rules_fuzzing_py_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "rules_fuzzing_py_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "absl_py": "{\"rules_fuzzing_py_deps_310_absl_py\":[{\"version\":\"3.10\"}],\"rules_fuzzing_py_deps_311_absl_py\":[{\"version\":\"3.11\"}],\"rules_fuzzing_py_deps_312_absl_py\":[{\"version\":\"3.12\"}],\"rules_fuzzing_py_deps_38_absl_py\":[{\"version\":\"3.8\"}],\"rules_fuzzing_py_deps_39_absl_py\":[{\"version\":\"3.9\"}]}",
+                "six": "{\"rules_fuzzing_py_deps_310_six\":[{\"version\":\"3.10\"}],\"rules_fuzzing_py_deps_311_six\":[{\"version\":\"3.11\"}],\"rules_fuzzing_py_deps_312_six\":[{\"version\":\"3.12\"}],\"rules_fuzzing_py_deps_38_six\":[{\"version\":\"3.8\"}],\"rules_fuzzing_py_deps_39_six\":[{\"version\":\"3.9\"}]}"
+              },
+              "packages": [
+                "absl_py",
+                "six"
+              ],
+              "groups": {}
+            }
+          },
+          "rules_python_publish_deps": {
+            "bzlFile": "@@rules_python~//python/private/pypi:hub_repository.bzl",
+            "ruleClassName": "hub_repository",
+            "attributes": {
+              "repo_name": "rules_python_publish_deps",
+              "extra_hub_aliases": {},
+              "whl_map": {
+                "backports_tarfile": "{\"rules_python_publish_deps_311_backports_tarfile_py3_none_any_77e284d7\":[{\"filename\":\"backports.tarfile-1.2.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_backports_tarfile_sdist_d75e02c2\":[{\"filename\":\"backports_tarfile-1.2.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "certifi": "{\"rules_python_publish_deps_311_certifi_py3_none_any_922820b5\":[{\"filename\":\"certifi-2024.8.30-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_certifi_sdist_bec941d2\":[{\"filename\":\"certifi-2024.8.30.tar.gz\",\"version\":\"3.11\"}]}",
+                "cffi": "{\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_aarch64_a1ed2dd2\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_ppc64le_46bf4316\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_s390x_a24ed04c\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_manylinux_2_17_x86_64_610faea7\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_aarch64_a9b15d49\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_cp311_cp311_musllinux_1_1_x86_64_fc48c783\":[{\"filename\":\"cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cffi_sdist_1c39c601\":[{\"filename\":\"cffi-1.17.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "charset_normalizer": "{\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_universal2_0d99dd8f\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_universal2.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_10_9_x86_64_c57516e5\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_10_9_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_macosx_11_0_arm64_6dba5d19\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-macosx_11_0_arm64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_aarch64_bf4475b8\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_ppc64le_ce031db0\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_s390x_8ff4e7cd\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_manylinux_2_17_x86_64_3710a975\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_aarch64_47334db7\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_ppc64le_f1a2f519\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_s390x_63bc5c4a\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_musllinux_1_2_x86_64_bcb4f8ea\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_cp311_cp311_win_amd64_cee4373f\":[{\"filename\":\"charset_normalizer-3.4.0-cp311-cp311-win_amd64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_py3_none_any_fe9f97fe\":[{\"filename\":\"charset_normalizer-3.4.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_charset_normalizer_sdist_223217c3\":[{\"filename\":\"charset_normalizer-3.4.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "cryptography": "{\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_aarch64_846da004\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_17_x86_64_0f996e72\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_aarch64_f7b178f1\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_manylinux_2_28_x86_64_c2e6fc39\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-manylinux_2_28_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_aarch64_e1be4655\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_cp39_abi3_musllinux_1_2_x86_64_df6b6c6d\":[{\"filename\":\"cryptography-43.0.3-cp39-abi3-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_cryptography_sdist_315b9001\":[{\"filename\":\"cryptography-43.0.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "docutils": "{\"rules_python_publish_deps_311_docutils_py3_none_any_dafca5b9\":[{\"filename\":\"docutils-0.21.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_docutils_sdist_3a6b1873\":[{\"filename\":\"docutils-0.21.2.tar.gz\",\"version\":\"3.11\"}]}",
+                "idna": "{\"rules_python_publish_deps_311_idna_py3_none_any_946d195a\":[{\"filename\":\"idna-3.10-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_idna_sdist_12f65c9b\":[{\"filename\":\"idna-3.10.tar.gz\",\"version\":\"3.11\"}]}",
+                "importlib_metadata": "{\"rules_python_publish_deps_311_importlib_metadata_py3_none_any_45e54197\":[{\"filename\":\"importlib_metadata-8.5.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_importlib_metadata_sdist_71522656\":[{\"filename\":\"importlib_metadata-8.5.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_classes": "{\"rules_python_publish_deps_311_jaraco_classes_py3_none_any_f662826b\":[{\"filename\":\"jaraco.classes-3.4.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_classes_sdist_47a024b5\":[{\"filename\":\"jaraco.classes-3.4.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_context": "{\"rules_python_publish_deps_311_jaraco_context_py3_none_any_f797fc48\":[{\"filename\":\"jaraco.context-6.0.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_context_sdist_9bae4ea5\":[{\"filename\":\"jaraco_context-6.0.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "jaraco_functools": "{\"rules_python_publish_deps_311_jaraco_functools_py3_none_any_ad159f13\":[{\"filename\":\"jaraco.functools-4.1.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jaraco_functools_sdist_70f7e0e2\":[{\"filename\":\"jaraco_functools-4.1.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "jeepney": "{\"rules_python_publish_deps_311_jeepney_py3_none_any_c0a454ad\":[{\"filename\":\"jeepney-0.8.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_jeepney_sdist_5efe48d2\":[{\"filename\":\"jeepney-0.8.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "keyring": "{\"rules_python_publish_deps_311_keyring_py3_none_any_5426f817\":[{\"filename\":\"keyring-25.4.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_keyring_sdist_b07ebc55\":[{\"filename\":\"keyring-25.4.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "markdown_it_py": "{\"rules_python_publish_deps_311_markdown_it_py_py3_none_any_35521684\":[{\"filename\":\"markdown_it_py-3.0.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_markdown_it_py_sdist_e3f60a94\":[{\"filename\":\"markdown-it-py-3.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "mdurl": "{\"rules_python_publish_deps_311_mdurl_py3_none_any_84008a41\":[{\"filename\":\"mdurl-0.1.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_mdurl_sdist_bb413d29\":[{\"filename\":\"mdurl-0.1.2.tar.gz\",\"version\":\"3.11\"}]}",
+                "more_itertools": "{\"rules_python_publish_deps_311_more_itertools_py3_none_any_037b0d32\":[{\"filename\":\"more_itertools-10.5.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_more_itertools_sdist_5482bfef\":[{\"filename\":\"more-itertools-10.5.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "nh3": "{\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_14c5a72e\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_macosx_10_12_x86_64_7b7c2a3c\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-macosx_10_12_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_aarch64_42c64511\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_armv7l_0411beb0\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64_5f36b271\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_ppc64le_34c03fa7\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_s390x_19aaba96\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_manylinux_2_17_x86_64_de3ceed6\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_aarch64_f0eca9ca\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_aarch64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_armv7l_3a157ab1\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_armv7l.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_musllinux_1_2_x86_64_36c95d4b\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-musllinux_1_2_x86_64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_cp37_abi3_win_amd64_8ce0f819\":[{\"filename\":\"nh3-0.2.18-cp37-abi3-win_amd64.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_nh3_sdist_94a16692\":[{\"filename\":\"nh3-0.2.18.tar.gz\",\"version\":\"3.11\"}]}",
+                "pkginfo": "{\"rules_python_publish_deps_311_pkginfo_py3_none_any_889a6da2\":[{\"filename\":\"pkginfo-1.10.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pkginfo_sdist_5df73835\":[{\"filename\":\"pkginfo-1.10.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "pycparser": "{\"rules_python_publish_deps_311_pycparser_py3_none_any_c3702b6d\":[{\"filename\":\"pycparser-2.22-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pycparser_sdist_491c8be9\":[{\"filename\":\"pycparser-2.22.tar.gz\",\"version\":\"3.11\"}]}",
+                "pygments": "{\"rules_python_publish_deps_311_pygments_py3_none_any_b8e6aca0\":[{\"filename\":\"pygments-2.18.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pygments_sdist_786ff802\":[{\"filename\":\"pygments-2.18.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "pywin32_ctypes": "{\"rules_python_publish_deps_311_pywin32_ctypes_py3_none_any_8a151337\":[{\"filename\":\"pywin32_ctypes-0.2.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_pywin32_ctypes_sdist_d162dc04\":[{\"filename\":\"pywin32-ctypes-0.2.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "readme_renderer": "{\"rules_python_publish_deps_311_readme_renderer_py3_none_any_2fbca89b\":[{\"filename\":\"readme_renderer-44.0-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_readme_renderer_sdist_8712034e\":[{\"filename\":\"readme_renderer-44.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "requests": "{\"rules_python_publish_deps_311_requests_py3_none_any_70761cfe\":[{\"filename\":\"requests-2.32.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_requests_sdist_55365417\":[{\"filename\":\"requests-2.32.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "requests_toolbelt": "{\"rules_python_publish_deps_311_requests_toolbelt_py2_none_any_cccfdd66\":[{\"filename\":\"requests_toolbelt-1.0.0-py2.py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_requests_toolbelt_sdist_7681a0a3\":[{\"filename\":\"requests-toolbelt-1.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "rfc3986": "{\"rules_python_publish_deps_311_rfc3986_py2_none_any_50b1502b\":[{\"filename\":\"rfc3986-2.0.0-py2.py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_rfc3986_sdist_97aacf9d\":[{\"filename\":\"rfc3986-2.0.0.tar.gz\",\"version\":\"3.11\"}]}",
+                "rich": "{\"rules_python_publish_deps_311_rich_py3_none_any_6049d5e6\":[{\"filename\":\"rich-13.9.4-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_rich_sdist_43959497\":[{\"filename\":\"rich-13.9.4.tar.gz\",\"version\":\"3.11\"}]}",
+                "secretstorage": "{\"rules_python_publish_deps_311_secretstorage_py3_none_any_f356e662\":[{\"filename\":\"SecretStorage-3.3.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_secretstorage_sdist_2403533e\":[{\"filename\":\"SecretStorage-3.3.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "twine": "{\"rules_python_publish_deps_311_twine_py3_none_any_215dbe7b\":[{\"filename\":\"twine-5.1.1-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_twine_sdist_9aa08251\":[{\"filename\":\"twine-5.1.1.tar.gz\",\"version\":\"3.11\"}]}",
+                "urllib3": "{\"rules_python_publish_deps_311_urllib3_py3_none_any_ca899ca0\":[{\"filename\":\"urllib3-2.2.3-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_urllib3_sdist_e7d814a8\":[{\"filename\":\"urllib3-2.2.3.tar.gz\",\"version\":\"3.11\"}]}",
+                "zipp": "{\"rules_python_publish_deps_311_zipp_py3_none_any_a817ac80\":[{\"filename\":\"zipp-3.20.2-py3-none-any.whl\",\"version\":\"3.11\"}],\"rules_python_publish_deps_311_zipp_sdist_bc9eb26f\":[{\"filename\":\"zipp-3.20.2.tar.gz\",\"version\":\"3.11\"}]}"
+              },
+              "packages": [
+                "backports_tarfile",
+                "certifi",
+                "charset_normalizer",
+                "docutils",
+                "idna",
+                "importlib_metadata",
+                "jaraco_classes",
+                "jaraco_context",
+                "jaraco_functools",
+                "keyring",
+                "markdown_it_py",
+                "mdurl",
+                "more_itertools",
+                "nh3",
+                "pkginfo",
+                "pygments",
+                "readme_renderer",
+                "requests",
+                "requests_toolbelt",
+                "rfc3986",
+                "rich",
+                "twine",
+                "urllib3",
+                "zipp"
+              ],
+              "groups": {}
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
         "recordedRepoMappingEntries": [
           [
-            "rules_nodejs~",
+            "bazel_features~",
+            "bazel_features_globals",
+            "bazel_features~~version_extension~bazel_features_globals"
+          ],
+          [
+            "bazel_features~",
+            "bazel_features_version",
+            "bazel_features~~version_extension~bazel_features_version"
+          ],
+          [
+            "rules_python~",
+            "bazel_features",
+            "bazel_features~"
+          ],
+          [
+            "rules_python~",
             "bazel_skylib",
             "bazel_skylib~"
           ],
           [
-            "rules_nodejs~",
+            "rules_python~",
             "bazel_tools",
             "bazel_tools"
+          ],
+          [
+            "rules_python~",
+            "pypi__build",
+            "rules_python~~internal_deps~pypi__build"
+          ],
+          [
+            "rules_python~",
+            "pypi__click",
+            "rules_python~~internal_deps~pypi__click"
+          ],
+          [
+            "rules_python~",
+            "pypi__colorama",
+            "rules_python~~internal_deps~pypi__colorama"
+          ],
+          [
+            "rules_python~",
+            "pypi__importlib_metadata",
+            "rules_python~~internal_deps~pypi__importlib_metadata"
+          ],
+          [
+            "rules_python~",
+            "pypi__installer",
+            "rules_python~~internal_deps~pypi__installer"
+          ],
+          [
+            "rules_python~",
+            "pypi__more_itertools",
+            "rules_python~~internal_deps~pypi__more_itertools"
+          ],
+          [
+            "rules_python~",
+            "pypi__packaging",
+            "rules_python~~internal_deps~pypi__packaging"
+          ],
+          [
+            "rules_python~",
+            "pypi__pep517",
+            "rules_python~~internal_deps~pypi__pep517"
+          ],
+          [
+            "rules_python~",
+            "pypi__pip",
+            "rules_python~~internal_deps~pypi__pip"
+          ],
+          [
+            "rules_python~",
+            "pypi__pip_tools",
+            "rules_python~~internal_deps~pypi__pip_tools"
+          ],
+          [
+            "rules_python~",
+            "pypi__pyproject_hooks",
+            "rules_python~~internal_deps~pypi__pyproject_hooks"
+          ],
+          [
+            "rules_python~",
+            "pypi__setuptools",
+            "rules_python~~internal_deps~pypi__setuptools"
+          ],
+          [
+            "rules_python~",
+            "pypi__tomli",
+            "rules_python~~internal_deps~pypi__tomli"
+          ],
+          [
+            "rules_python~",
+            "pypi__wheel",
+            "rules_python~~internal_deps~pypi__wheel"
+          ],
+          [
+            "rules_python~",
+            "pypi__zipp",
+            "rules_python~~internal_deps~pypi__zipp"
+          ],
+          [
+            "rules_python~",
+            "pythons_hub",
+            "rules_python~~python~pythons_hub"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_10_host",
+            "rules_python~~python~python_3_10_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_11_host",
+            "rules_python~~python~python_3_11_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_12_host",
+            "rules_python~~python~python_3_12_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_13_host",
+            "rules_python~~python~python_3_13_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_8_host",
+            "rules_python~~python~python_3_8_host"
+          ],
+          [
+            "rules_python~~python~pythons_hub",
+            "python_3_9_host",
+            "rules_python~~python~python_3_9_host"
           ]
         ]
       }

--- a/test/orfs/README.md
+++ b/test/orfs/README.md
@@ -1,0 +1,9 @@
+# ORFS smoke tests
+
+A set of ORFS integration tests that runs in a few minutes suitable for inclusion in the local fast regression testing workflow prior to creating a PR:
+
+    bazel -c opt test ...
+
+## Updating ORFS and bazel-orfs
+
+`bazel run @bazel-orfs//:bump`, this will find the latest bazel-orfs and ORFS docker image and update MODULE.bazel and MODULE.bazel.lock.

--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -1,0 +1,20 @@
+load("@bazel-orfs//:openroad.bzl", "orfs_flow")
+
+orfs_flow(
+    name = "gcd",
+    arguments = {
+        # Faster builds
+        "SKIP_INCREMENTAL_REPAIR": "1",
+        "GPL_TIMING_DRIVEN": "0",
+        "SKIP_LAST_GASP": "1",
+        # Various
+        "DIE_AREA": "0 0 16.2 16.2",
+        "CORE_AREA": "1.08 1.08 15.12 15.12",
+        "PLACE_DENSITY": "0.35",
+    },
+    sources = {
+        "SDC_FILE": [":constraint.sdc"],
+    },
+    verilog_files = ["gcd.v"],
+    tags = ["manual"],
+)

--- a/test/orfs/gcd/README.md
+++ b/test/orfs/gcd/README.md
@@ -1,0 +1,12 @@
+# Summary
+
+Simple GCD (greatest common denominator) core. This is an extremely small
+design mostly used to test the sanity of the flow.
+
+Originally generated using [PyMTL](https://github.com/cornell-brg/pymtl).
+
+This design has about 250 cells.
+
+# Source
+
+Re-used code derived from http://opencelerity.org/ project.

--- a/test/orfs/gcd/constraint.sdc
+++ b/test/orfs/gcd/constraint.sdc
@@ -1,0 +1,15 @@
+current_design gcd
+
+set clk_name core_clock
+set clk_port_name clk
+set clk_period 310
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]

--- a/test/orfs/gcd/gcd.v
+++ b/test/orfs/gcd/gcd.v
@@ -1,0 +1,757 @@
+//-----------------------------------------------------------------------------
+// GcdUnit
+//-----------------------------------------------------------------------------
+//
+// Originally Generated from PyMTL with a few modifications to make it more
+// friendly to OpenROAD tools
+//
+// dump-vcd: False
+// verilator-xinit: zeros
+//module GcdUnit
+module gcd
+(
+  input  wire clk,
+  input  wire [  31:0] req_msg,
+  output wire req_rdy,
+  input  wire req_val,
+  input  wire reset,
+  output wire [  15:0] resp_msg,
+  input  wire resp_rdy,
+  output wire resp_val
+);
+
+  // ctrl temporaries
+  wire   [   0:0] ctrl$is_b_zero;
+  wire   [   0:0] ctrl$resp_rdy;
+  wire   [   0:0] ctrl$clk;
+  wire   [   0:0] ctrl$is_a_lt_b;
+  wire   [   0:0] ctrl$req_val;
+  wire   [   0:0] ctrl$reset;
+  wire   [   1:0] ctrl$a_mux_sel;
+  wire   [   0:0] ctrl$resp_val;
+  wire   [   0:0] ctrl$b_mux_sel;
+  wire   [   0:0] ctrl$b_reg_en;
+  wire   [   0:0] ctrl$a_reg_en;
+  wire   [   0:0] ctrl$req_rdy;
+
+  GcdUnitCtrlRTL_0x4d0fc71ead8d3d9e ctrl
+  (
+    .is_b_zero ( ctrl$is_b_zero ),
+    .resp_rdy  ( ctrl$resp_rdy ),
+    .clk       ( ctrl$clk ),
+    .is_a_lt_b ( ctrl$is_a_lt_b ),
+    .req_val   ( ctrl$req_val ),
+    .reset     ( ctrl$reset ),
+    .a_mux_sel ( ctrl$a_mux_sel ),
+    .resp_val  ( ctrl$resp_val ),
+    .b_mux_sel ( ctrl$b_mux_sel ),
+    .b_reg_en  ( ctrl$b_reg_en ),
+    .a_reg_en  ( ctrl$a_reg_en ),
+    .req_rdy   ( ctrl$req_rdy )
+  );
+
+  // dpath temporaries
+  wire   [   1:0] dpath$a_mux_sel;
+  wire   [   0:0] dpath$clk;
+  wire   [  15:0] dpath$req_msg_b;
+  wire   [  15:0] dpath$req_msg_a;
+  wire   [   0:0] dpath$b_mux_sel;
+  wire   [   0:0] dpath$reset;
+  wire   [   0:0] dpath$b_reg_en;
+  wire   [   0:0] dpath$a_reg_en;
+  wire   [   0:0] dpath$is_b_zero;
+  wire   [  15:0] dpath$resp_msg;
+  wire   [   0:0] dpath$is_a_lt_b;
+
+  GcdUnitDpathRTL_0x4d0fc71ead8d3d9e dpath
+  (
+    .a_mux_sel ( dpath$a_mux_sel ),
+    .clk       ( dpath$clk ),
+    .req_msg_b ( dpath$req_msg_b ),
+    .req_msg_a ( dpath$req_msg_a ),
+    .b_mux_sel ( dpath$b_mux_sel ),
+    .reset     ( dpath$reset ),
+    .b_reg_en  ( dpath$b_reg_en ),
+    .a_reg_en  ( dpath$a_reg_en ),
+    .is_b_zero ( dpath$is_b_zero ),
+    .resp_msg  ( dpath$resp_msg ),
+    .is_a_lt_b ( dpath$is_a_lt_b )
+  );
+
+  // signal connections
+  assign ctrl$clk        = clk;
+  assign ctrl$is_a_lt_b  = dpath$is_a_lt_b;
+  assign ctrl$is_b_zero  = dpath$is_b_zero;
+  assign ctrl$req_val    = req_val;
+  assign ctrl$reset      = reset;
+  assign ctrl$resp_rdy   = resp_rdy;
+  assign dpath$a_mux_sel = ctrl$a_mux_sel;
+  assign dpath$a_reg_en  = ctrl$a_reg_en;
+  assign dpath$b_mux_sel = ctrl$b_mux_sel;
+  assign dpath$b_reg_en  = ctrl$b_reg_en;
+  assign dpath$clk       = clk;
+  assign dpath$req_msg_a = req_msg[31:16];
+  assign dpath$req_msg_b = req_msg[15:0];
+  assign dpath$reset     = reset;
+  assign req_rdy         = ctrl$req_rdy;
+  assign resp_msg        = dpath$resp_msg;
+  assign resp_val        = ctrl$resp_val;
+
+
+
+endmodule // GcdUnit
+
+//-----------------------------------------------------------------------------
+// GcdUnitCtrlRTL_0x4d0fc71ead8d3d9e
+//-----------------------------------------------------------------------------
+// dump-vcd: False
+// verilator-xinit: zeros
+module GcdUnitCtrlRTL_0x4d0fc71ead8d3d9e
+(
+  output reg  [   1:0] a_mux_sel,
+  output reg  [   0:0] a_reg_en,
+  output reg  [   0:0] b_mux_sel,
+  output reg  [   0:0] b_reg_en,
+  input  wire [   0:0] clk,
+  input  wire [   0:0] is_a_lt_b,
+  input  wire [   0:0] is_b_zero,
+  output reg  [   0:0] req_rdy,
+  input  wire [   0:0] req_val,
+  input  wire [   0:0] reset,
+  input  wire [   0:0] resp_rdy,
+  output reg  [   0:0] resp_val
+);
+
+  // register declarations
+  reg    [   1:0] curr_state__0;
+  reg    [   1:0] current_state__1;
+  reg    [   0:0] do_sub;
+  reg    [   0:0] do_swap;
+  reg    [   1:0] next_state__0;
+  reg    [   1:0] state$in_;
+
+  // localparam declarations
+  localparam A_MUX_SEL_B = 2;
+  localparam A_MUX_SEL_IN = 0;
+  localparam A_MUX_SEL_SUB = 1;
+  localparam A_MUX_SEL_X = 0;
+  localparam B_MUX_SEL_A = 0;
+  localparam B_MUX_SEL_IN = 1;
+  localparam B_MUX_SEL_X = 0;
+  localparam STATE_CALC = 1;
+  localparam STATE_DONE = 2;
+  localparam STATE_IDLE = 0;
+
+  // state temporaries
+  wire   [   0:0] state$reset;
+  wire   [   0:0] state$clk;
+  wire   [   1:0] state$out;
+
+  RegRst_0x9f365fdf6c8998a state
+  (
+    .reset ( state$reset ),
+    .in_   ( state$in_ ),
+    .clk   ( state$clk ),
+    .out   ( state$out )
+  );
+
+  // signal connections
+  assign state$clk   = clk;
+  assign state$reset = reset;
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def state_transitions():
+  //
+  //       curr_state = s.state.out
+  //       next_state = s.state.out
+  //
+  //       # Transistions out of IDLE state
+  //
+  //       if ( curr_state == s.STATE_IDLE ):
+  //         if ( s.req_val and s.req_rdy ):
+  //           next_state = s.STATE_CALC
+  //
+  //       # Transistions out of CALC state
+  //
+  //       if ( curr_state == s.STATE_CALC ):
+  //         if ( not s.is_a_lt_b and s.is_b_zero ):
+  //           next_state = s.STATE_DONE
+  //
+  //       # Transistions out of DONE state
+  //
+  //       if ( curr_state == s.STATE_DONE ):
+  //         if ( s.resp_val and s.resp_rdy ):
+  //           next_state = s.STATE_IDLE
+  //
+  //       s.state.in_.value = next_state
+
+  // logic for state_transitions()
+  always @ (*) begin
+    curr_state__0 = state$out;
+    next_state__0 = state$out;
+    if ((curr_state__0 == STATE_IDLE)) begin
+      if ((req_val&&req_rdy)) begin
+        next_state__0 = STATE_CALC;
+      end
+      else begin
+      end
+    end
+    else begin
+    end
+    if ((curr_state__0 == STATE_CALC)) begin
+      if ((!is_a_lt_b&&is_b_zero)) begin
+        next_state__0 = STATE_DONE;
+      end
+      else begin
+      end
+    end
+    else begin
+    end
+    if ((curr_state__0 == STATE_DONE)) begin
+      if ((resp_val&&resp_rdy)) begin
+        next_state__0 = STATE_IDLE;
+      end
+      else begin
+      end
+    end
+    else begin
+    end
+    state$in_ = next_state__0;
+  end
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def state_outputs():
+  //
+  //       current_state = s.state.out
+  //
+  //       # In IDLE state we simply wait for inputs to arrive and latch them
+  //
+  //       if current_state == s.STATE_IDLE:
+  //         s.req_rdy.value   = 1
+  //         s.resp_val.value  = 0
+  //         s.a_mux_sel.value = A_MUX_SEL_IN
+  //         s.a_reg_en.value  = 1
+  //         s.b_mux_sel.value = B_MUX_SEL_IN
+  //         s.b_reg_en.value  = 1
+  //
+  //       # In CALC state we iteratively swap/sub to calculate GCD
+  //
+  //       elif current_state == s.STATE_CALC:
+  //
+  //         s.do_swap.value = s.is_a_lt_b
+  //         s.do_sub.value  = ~s.is_b_zero
+  //
+  //         s.req_rdy.value   = 0
+  //         s.resp_val.value  = 0
+  //         s.a_mux_sel.value = A_MUX_SEL_B if s.do_swap else A_MUX_SEL_SUB
+  //         s.a_reg_en.value  = 1
+  //         s.b_mux_sel.value = B_MUX_SEL_A
+  //         s.b_reg_en.value  = s.do_swap
+  //
+  //       # In DONE state we simply wait for output transaction to occur
+  //
+  //       elif current_state == s.STATE_DONE:
+  //         s.req_rdy.value   = 0
+  //         s.resp_val.value  = 1
+  //         s.a_mux_sel.value = A_MUX_SEL_X
+  //         s.a_reg_en.value  = 0
+  //         s.b_mux_sel.value = B_MUX_SEL_X
+  //         s.b_reg_en.value  = 0
+  //
+  //       # Default case that we should not hit
+  //
+  //       else:
+  //         s.req_rdy.value   = 0
+  //         s.resp_val.value  = 0
+  //         s.a_mux_sel.value = A_MUX_SEL_X
+  //         s.a_reg_en.value  = 0
+  //         s.b_mux_sel.value = B_MUX_SEL_X
+  //         s.b_reg_en.value  = 0
+
+  // logic for state_outputs()
+  always @ (*) begin
+    current_state__1 = state$out;
+    if ((current_state__1 == STATE_IDLE)) begin
+      req_rdy = 1;
+      resp_val = 0;
+      a_mux_sel = A_MUX_SEL_IN;
+      a_reg_en = 1;
+      b_mux_sel = B_MUX_SEL_IN;
+      b_reg_en = 1;
+    end
+    else begin
+      if ((current_state__1 == STATE_CALC)) begin
+        do_swap = is_a_lt_b;
+        do_sub = ~is_b_zero;
+        req_rdy = 0;
+        resp_val = 0;
+        a_mux_sel = do_swap ? A_MUX_SEL_B : A_MUX_SEL_SUB;
+        a_reg_en = 1;
+        b_mux_sel = B_MUX_SEL_A;
+        b_reg_en = do_swap;
+      end
+      else begin
+        if ((current_state__1 == STATE_DONE)) begin
+          req_rdy = 0;
+          resp_val = 1;
+          a_mux_sel = A_MUX_SEL_X;
+          a_reg_en = 0;
+          b_mux_sel = B_MUX_SEL_X;
+          b_reg_en = 0;
+        end
+        else begin
+          req_rdy = 0;
+          resp_val = 0;
+          a_mux_sel = A_MUX_SEL_X;
+          a_reg_en = 0;
+          b_mux_sel = B_MUX_SEL_X;
+          b_reg_en = 0;
+        end
+      end
+    end
+  end
+
+
+endmodule // GcdUnitCtrlRTL_0x4d0fc71ead8d3d9e
+
+//-----------------------------------------------------------------------------
+// RegRst_0x9f365fdf6c8998a
+//-----------------------------------------------------------------------------
+// dtype: 2
+// reset_value: 0
+// dump-vcd: False
+// verilator-xinit: zeros
+module RegRst_0x9f365fdf6c8998a
+(
+  input  wire [   0:0] clk,
+  input  wire [   1:0] in_,
+  output reg  [   1:0] out,
+  input  wire [   0:0] reset
+);
+
+  // localparam declarations
+  localparam reset_value = 0;
+
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.posedge_clk
+  // def seq_logic():
+  //       if s.reset:
+  //         s.out.next = reset_value
+  //       else:
+  //         s.out.next = s.in_
+
+  // logic for seq_logic()
+  always @ (posedge clk) begin
+    if (reset) begin
+      out <= reset_value;
+    end
+    else begin
+      out <= in_;
+    end
+  end
+
+
+endmodule // RegRst_0x9f365fdf6c8998a
+
+//-----------------------------------------------------------------------------
+// GcdUnitDpathRTL_0x4d0fc71ead8d3d9e
+//-----------------------------------------------------------------------------
+// dump-vcd: False
+// verilator-xinit: zeros
+module GcdUnitDpathRTL_0x4d0fc71ead8d3d9e
+(
+  input  wire [   1:0] a_mux_sel,
+  input  wire [   0:0] a_reg_en,
+  input  wire [   0:0] b_mux_sel,
+  input  wire [   0:0] b_reg_en,
+  input  wire [   0:0] clk,
+  output wire [   0:0] is_a_lt_b,
+  output wire [   0:0] is_b_zero,
+  input  wire [  15:0] req_msg_a,
+  input  wire [  15:0] req_msg_b,
+  input  wire [   0:0] reset,
+  output wire [  15:0] resp_msg
+);
+
+  // wire declarations
+  wire   [  15:0] sub_out;
+  wire   [  15:0] b_reg_out;
+
+
+  // a_reg temporaries
+  wire   [   0:0] a_reg$reset;
+  wire   [  15:0] a_reg$in_;
+  wire   [   0:0] a_reg$clk;
+  wire   [   0:0] a_reg$en;
+  wire   [  15:0] a_reg$out;
+
+  RegEn_0x68db79c4ec1d6e5b a_reg
+  (
+    .reset ( a_reg$reset ),
+    .in_   ( a_reg$in_ ),
+    .clk   ( a_reg$clk ),
+    .en    ( a_reg$en ),
+    .out   ( a_reg$out )
+  );
+
+  // a_lt_b temporaries
+  wire   [   0:0] a_lt_b$reset;
+  wire   [   0:0] a_lt_b$clk;
+  wire   [  15:0] a_lt_b$in0;
+  wire   [  15:0] a_lt_b$in1;
+  wire   [   0:0] a_lt_b$out;
+
+  LtComparator_0x422b1f52edd46a85 a_lt_b
+  (
+    .reset ( a_lt_b$reset ),
+    .clk   ( a_lt_b$clk ),
+    .in0   ( a_lt_b$in0 ),
+    .in1   ( a_lt_b$in1 ),
+    .out   ( a_lt_b$out )
+  );
+
+  // b_zero temporaries
+  wire   [   0:0] b_zero$reset;
+  wire   [  15:0] b_zero$in_;
+  wire   [   0:0] b_zero$clk;
+  wire   [   0:0] b_zero$out;
+
+  ZeroComparator_0x422b1f52edd46a85 b_zero
+  (
+    .reset ( b_zero$reset ),
+    .in_   ( b_zero$in_ ),
+    .clk   ( b_zero$clk ),
+    .out   ( b_zero$out )
+  );
+
+  // a_mux temporaries
+  wire   [   0:0] a_mux$reset;
+  wire   [  15:0] a_mux$in_$000;
+  wire   [  15:0] a_mux$in_$001;
+  wire   [  15:0] a_mux$in_$002;
+  wire   [   0:0] a_mux$clk;
+  wire   [   1:0] a_mux$sel;
+  wire   [  15:0] a_mux$out;
+
+  Mux_0x683fa1a418b072c9 a_mux
+  (
+    .reset   ( a_mux$reset ),
+    .in_$000 ( a_mux$in_$000 ),
+    .in_$001 ( a_mux$in_$001 ),
+    .in_$002 ( a_mux$in_$002 ),
+    .clk     ( a_mux$clk ),
+    .sel     ( a_mux$sel ),
+    .out     ( a_mux$out )
+  );
+
+  // b_mux temporaries
+  wire   [   0:0] b_mux$reset;
+  wire   [  15:0] b_mux$in_$000;
+  wire   [  15:0] b_mux$in_$001;
+  wire   [   0:0] b_mux$clk;
+  wire   [   0:0] b_mux$sel;
+  wire   [  15:0] b_mux$out;
+
+  Mux_0xdd6473406d1a99a b_mux
+  (
+    .reset   ( b_mux$reset ),
+    .in_$000 ( b_mux$in_$000 ),
+    .in_$001 ( b_mux$in_$001 ),
+    .clk     ( b_mux$clk ),
+    .sel     ( b_mux$sel ),
+    .out     ( b_mux$out )
+  );
+
+  // sub temporaries
+  wire   [   0:0] sub$reset;
+  wire   [   0:0] sub$clk;
+  wire   [  15:0] sub$in0;
+  wire   [  15:0] sub$in1;
+  wire   [  15:0] sub$out;
+
+  Subtractor_0x422b1f52edd46a85 sub
+  (
+    .reset ( sub$reset ),
+    .clk   ( sub$clk ),
+    .in0   ( sub$in0 ),
+    .in1   ( sub$in1 ),
+    .out   ( sub$out )
+  );
+
+  // b_reg temporaries
+  wire   [   0:0] b_reg$reset;
+  wire   [  15:0] b_reg$in_;
+  wire   [   0:0] b_reg$clk;
+  wire   [   0:0] b_reg$en;
+  wire   [  15:0] b_reg$out;
+
+  RegEn_0x68db79c4ec1d6e5b b_reg
+  (
+    .reset ( b_reg$reset ),
+    .in_   ( b_reg$in_ ),
+    .clk   ( b_reg$clk ),
+    .en    ( b_reg$en ),
+    .out   ( b_reg$out )
+  );
+
+  // signal connections
+  assign a_lt_b$clk    = clk;
+  assign a_lt_b$in0    = a_reg$out;
+  assign a_lt_b$in1    = b_reg$out;
+  assign a_lt_b$reset  = reset;
+  assign a_mux$clk     = clk;
+  assign a_mux$in_$000 = req_msg_a;
+  assign a_mux$in_$001 = sub_out;
+  assign a_mux$in_$002 = b_reg_out;
+  assign a_mux$reset   = reset;
+  assign a_mux$sel     = a_mux_sel;
+  assign a_reg$clk     = clk;
+  assign a_reg$en      = a_reg_en;
+  assign a_reg$in_     = a_mux$out;
+  assign a_reg$reset   = reset;
+  assign b_mux$clk     = clk;
+  assign b_mux$in_$000 = a_reg$out;
+  assign b_mux$in_$001 = req_msg_b;
+  assign b_mux$reset   = reset;
+  assign b_mux$sel     = b_mux_sel;
+  assign b_reg$clk     = clk;
+  assign b_reg$en      = b_reg_en;
+  assign b_reg$in_     = b_mux$out;
+  assign b_reg$reset   = reset;
+  assign b_reg_out     = b_reg$out;
+  assign b_zero$clk    = clk;
+  assign b_zero$in_    = b_reg$out;
+  assign b_zero$reset  = reset;
+  assign is_a_lt_b     = a_lt_b$out;
+  assign is_b_zero     = b_zero$out;
+  assign resp_msg      = sub$out;
+  assign sub$clk       = clk;
+  assign sub$in0       = a_reg$out;
+  assign sub$in1       = b_reg$out;
+  assign sub$reset     = reset;
+  assign sub_out       = sub$out;
+
+
+
+endmodule // GcdUnitDpathRTL_0x4d0fc71ead8d3d9e
+
+//-----------------------------------------------------------------------------
+// RegEn_0x68db79c4ec1d6e5b
+//-----------------------------------------------------------------------------
+// dtype: 16
+// dump-vcd: False
+// verilator-xinit: zeros
+module RegEn_0x68db79c4ec1d6e5b
+(
+  input  wire [   0:0] clk,
+  input  wire [   0:0] en,
+  input  wire [  15:0] in_,
+  output reg  [  15:0] out,
+  input  wire [   0:0] reset
+);
+
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.posedge_clk
+  // def seq_logic():
+  //       if s.en:
+  //         s.out.next = s.in_
+
+  // logic for seq_logic()
+  always @ (posedge clk) begin
+    if (en) begin
+      out <= in_;
+    end
+    else begin
+    end
+  end
+
+
+endmodule // RegEn_0x68db79c4ec1d6e5b
+
+//-----------------------------------------------------------------------------
+// LtComparator_0x422b1f52edd46a85
+//-----------------------------------------------------------------------------
+// nbits: 16
+// dump-vcd: False
+// verilator-xinit: zeros
+module LtComparator_0x422b1f52edd46a85
+(
+  input  wire [   0:0] clk,
+  input  wire [  15:0] in0,
+  input  wire [  15:0] in1,
+  output reg  [   0:0] out,
+  input  wire [   0:0] reset
+);
+
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def comb_logic():
+  //       s.out.value = s.in0 < s.in1
+
+  // logic for comb_logic()
+  always @ (*) begin
+    out = (in0 < in1);
+  end
+
+
+endmodule // LtComparator_0x422b1f52edd46a85
+
+//-----------------------------------------------------------------------------
+// ZeroComparator_0x422b1f52edd46a85
+//-----------------------------------------------------------------------------
+// nbits: 16
+// dump-vcd: False
+// verilator-xinit: zeros
+module ZeroComparator_0x422b1f52edd46a85
+(
+  input  wire [   0:0] clk,
+  input  wire [  15:0] in_,
+  output reg  [   0:0] out,
+  input  wire [   0:0] reset
+);
+
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def comb_logic():
+  //       s.out.value = s.in_ == 0
+
+  // logic for comb_logic()
+  always @ (*) begin
+    out = (in_ == 0);
+  end
+
+
+endmodule // ZeroComparator_0x422b1f52edd46a85
+
+//-----------------------------------------------------------------------------
+// Mux_0x683fa1a418b072c9
+//-----------------------------------------------------------------------------
+// dtype: 16
+// nports: 3
+// dump-vcd: False
+// verilator-xinit: zeros
+module Mux_0x683fa1a418b072c9
+(
+  input  wire [   0:0] clk,
+  input  wire [  15:0] in_$000,
+  input  wire [  15:0] in_$001,
+  input  wire [  15:0] in_$002,
+  output reg  [  15:0] out,
+  input  wire [   0:0] reset,
+  input  wire [   1:0] sel
+);
+
+  // localparam declarations
+  localparam nports = 3;
+
+
+  // array declarations
+  wire   [  15:0] in_[0:2];
+  assign in_[  0] = in_$000;
+  assign in_[  1] = in_$001;
+  assign in_[  2] = in_$002;
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def comb_logic():
+  //       assert s.sel < nports
+  //       s.out.v = s.in_[ s.sel ]
+
+  // logic for comb_logic()
+  always @ (*) begin
+    out = in_[sel];
+  end
+
+
+endmodule // Mux_0x683fa1a418b072c9
+
+//-----------------------------------------------------------------------------
+// Mux_0xdd6473406d1a99a
+//-----------------------------------------------------------------------------
+// dtype: 16
+// nports: 2
+// dump-vcd: False
+// verilator-xinit: zeros
+module Mux_0xdd6473406d1a99a
+(
+  input  wire [   0:0] clk,
+  input  wire [  15:0] in_$000,
+  input  wire [  15:0] in_$001,
+  output reg  [  15:0] out,
+  input  wire [   0:0] reset,
+  input  wire [   0:0] sel
+);
+
+  // localparam declarations
+  localparam nports = 2;
+
+
+  // array declarations
+  wire   [  15:0] in_[0:1];
+  assign in_[  0] = in_$000;
+  assign in_[  1] = in_$001;
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def comb_logic():
+  //       assert s.sel < nports
+  //       s.out.v = s.in_[ s.sel ]
+
+  // logic for comb_logic()
+  always @ (*) begin
+    out = in_[sel];
+  end
+
+
+endmodule // Mux_0xdd6473406d1a99a
+
+//-----------------------------------------------------------------------------
+// Subtractor_0x422b1f52edd46a85
+//-----------------------------------------------------------------------------
+// nbits: 16
+// dump-vcd: False
+// verilator-xinit: zeros
+module Subtractor_0x422b1f52edd46a85
+(
+  input  wire [   0:0] clk,
+  input  wire [  15:0] in0,
+  input  wire [  15:0] in1,
+  output reg  [  15:0] out,
+  input  wire [   0:0] reset
+);
+
+
+
+  // PYMTL SOURCE:
+  //
+  // @s.combinational
+  // def comb_logic():
+  //       s.out.value = s.in0 - s.in1
+
+  // logic for comb_logic()
+  always @ (*) begin
+    out = (in0-in1);
+  end
+
+
+endmodule // Subtractor_0x422b1f52edd46a85
+


### PR DESCRIPTION
These tests are disabled for now because there's CI infrastructure updates that are needed and also various dominos in OpenROAD that have to be toppled(performance problems such as omp not working in bazel and various other things).

However, merging now will set direction and simplify collaboration and discussion.

Use case is to update fast local tests for OpenROAD to include some important ORFS integration tests.

1. Modify OpenROAD source code as usual
2. Run `bazel test -c opt ...`, this will build openroad and run all tests in a few minutes.

Tests that are too long running or not yet ready to be included in this fast local test case, have the `tags = ["manual"]` set such that they have to be invoked explicitly. The ORFS tests currently go one step further and add the test/orfs/ folder to .bazelignore to work around CI infrastructure limitations.