### PR TITLE
drt: validate ap via

### DIFF
--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -548,6 +548,15 @@ class FlexPA
       frInstTerm* inst_term,
       bool deep_search = false);
 
+  template <typename T>
+  bool validateAPForVia(
+      frAccessPoint* ap,
+      const frViaDef* via_def,
+      const std::vector<gtl::polygon_90_data<frCoord>>& layer_polys,
+      const gtl::polygon_90_set_data<frCoord>& polyset,
+      T* pin,
+      frInstTerm* inst_term);
+
   /**
    * @brief Checks if a Via has at least one valid planar access
    *

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -205,7 +205,9 @@ class FlexPA
   bool genPinAccessCostBounded(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,
       std::set<std::pair<Point, frLayerNum>>& apset,
-      std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
+      const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
+      const std::vector<std::vector<gtl::polygon_90_data<frCoord>>>&
+          layer_polys,
       T* pin,
       frInstTerm* inst_term,
       frAccessPointEnum lower_type,
@@ -431,6 +433,7 @@ class FlexPA
    *
    * @param aps vector of access points of the pin
    * @param pin_shapes vector of pin shapes of the pin
+   * @param layer_polys another representation of pin shapes
    * @param pin the pin
    * @param inst_term terminal
    * @param is_std_cell_pin if the pin if from a standard cell
@@ -439,6 +442,8 @@ class FlexPA
   void filterMultipleAPAccesses(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,
       const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
+      const std::vector<std::vector<gtl::polygon_90_data<frCoord>>>&
+          layer_polys,
       T* pin,
       frInstTerm* inst_term,
       const bool& is_std_cell_pin);

--- a/src/drt/test/ispd18_sample.defok
+++ b/src/drt/test/ispd18_sample.defok
@@ -58,7 +58,7 @@ NETS 11 ;
       + ROUTED Metal2 ( 92200 73530 ) ( * 78470 )
       NEW Metal3 ( 92200 78470 ) ( 95800 * )
       NEW Metal2 ( 95800 78470 ) ( * 83790 )
-      NEW Metal1 ( 92200 73530 ) VIA12_1C_V
+      NEW Metal1 ( 92200 73530 ) VIA12_1C
       NEW Metal2 ( 92200 78470 ) VIA23_1C
       NEW Metal2 ( 95800 78470 ) VIA23_1C
       NEW Metal1 ( 95800 83790 ) VIA12_1C_V ;
@@ -69,7 +69,7 @@ NETS 11 ;
       NEW Metal1 ( 91000 77710 ) VIA12_1C_V
       NEW Metal2 ( 91000 77710 ) VIA23_1C
       NEW Metal2 ( 85800 77710 ) VIA23_1C
-      NEW Metal1 ( 85400 86450 ) VIA12_1C_V
+      NEW Metal1 ( 85400 86450 ) VIA12_1C
       NEW Metal2 ( 91000 77710 ) RECT ( -70 -442 70 0 )  ;
     - net1232 ( inst4382 C ) ( inst4062 Y ) + USE SIGNAL
       + ROUTED Metal3 ( 85400 79990 ) ( 98200 * )
@@ -102,7 +102,7 @@ NETS 11 ;
       NEW Metal1 ( 103000 87590 ) VIA12_1C
       NEW Metal1 ( 103000 84930 ) VIA12_1C
       NEW Metal1 ( 98600 84930 ) VIA12_1C
-      NEW Metal1 ( 98600 76950 ) VIA12_1C_V ;
+      NEW Metal1 ( 98600 76950 ) VIA12_1C ;
     - net1236 ( inst2908 D ) ( inst2591 Y ) + USE SIGNAL
       + ROUTED Metal3 ( 85800 76950 ) ( 102600 * )
       NEW Metal2 ( 102600 72770 ) ( * 76950 )
@@ -117,13 +117,13 @@ NETS 11 ;
       NEW Metal1 ( 99000 80750 ) VIA12_1C
       NEW Metal2 ( 99000 80750 ) VIA23_1C
       NEW Metal2 ( 92200 80750 ) VIA23_1C
-      NEW Metal1 ( 92200 83030 ) VIA12_1C_V
+      NEW Metal1 ( 92200 83030 ) VIA12_1C
       NEW Metal2 ( 99000 80750 ) RECT ( -70 -442 70 0 )  ;
     - net1238 ( inst3444 Y ) ( inst3428 A ) + USE SIGNAL
       + ROUTED Metal3 ( 87800 83410 ) ( 97400 * )
-      NEW Metal1 ( 87800 83410 ) VIA12_1C_V
+      NEW Metal1 ( 87800 83410 ) VIA12_1C
       NEW Metal2 ( 87800 83410 ) VIA23_1C
-      NEW Metal1 ( 97400 83410 ) VIA12_1C_V
+      NEW Metal1 ( 97400 83410 ) VIA12_1C
       NEW Metal2 ( 97400 83410 ) VIA23_1C
       NEW Metal2 ( 87800 83410 ) RECT ( -70 -442 70 0 ) 
       NEW Metal2 ( 97400 83410 ) RECT ( -70 -442 70 0 )  ;
@@ -133,7 +133,7 @@ NETS 11 ;
       NEW Metal1 ( 102600 80370 ) VIA12_1C_V
       NEW Metal2 ( 102600 80370 ) VIA23_1C
       NEW Metal2 ( 91800 80370 ) VIA23_1C
-      NEW Metal1 ( 91800 86830 ) VIA12_1C_V
+      NEW Metal1 ( 91800 86830 ) VIA12_1C
       NEW Metal2 ( 102600 80370 ) RECT ( -70 -442 70 0 )  ;
     - net1240 ( inst3502 A ) ( inst2015 Y ) + USE SIGNAL
       + ROUTED Metal2 ( 91000 79230 ) ( * 80750 )
@@ -142,6 +142,6 @@ NETS 11 ;
       NEW Metal1 ( 91000 80750 ) VIA12_1C
       NEW Metal2 ( 91000 79230 ) VIA23_1C
       NEW Metal2 ( 96200 79230 ) VIA23_1C
-      NEW Metal1 ( 96200 76950 ) VIA12_1C_V ;
+      NEW Metal1 ( 96200 76950 ) VIA12_1C ;
 END NETS
 END DESIGN

--- a/src/drt/test/ta_ap_aligned.defok
+++ b/src/drt/test/ta_ap_aligned.defok
@@ -106,13 +106,13 @@ END COMPONENTS
 NETS 2 ;
     - net_M2 ( inv_M2_2 A ) ( inv_M2_1 A ) + USE SIGNAL
       + ROUTED metal2 ( 100130 21140 ) ( * 180460 )
-      NEW metal1 ( 100130 21140 ) via1_4
-      NEW metal1 ( 100130 180460 ) via1_4 ;
+      NEW metal1 ( 100130 21140 ) via1_7
+      NEW metal1 ( 100130 180460 ) via1_7 ;
     - net_M3 ( inv_M3_2 A ) ( inv_M3_1 A ) + USE SIGNAL
       + ROUTED metal3 ( 20330 102060 ) ( 180310 * )
-      NEW metal1 ( 20330 102060 ) via1_4
+      NEW metal1 ( 20330 102060 ) via1_7
       NEW metal2 ( 20330 102060 ) via2_5
-      NEW metal1 ( 180310 102060 ) via1_4
+      NEW metal1 ( 180310 102060 ) via1_7
       NEW metal2 ( 180310 102060 ) via2_5 ;
 END NETS
 END DESIGN


### PR DESCRIPTION
Supports #7153

Moves some of the code from `filterViaAccess` to the new `validateAPForVia`. The new function takes an Access Point and a Via and validate whether or note the via can be used to access it.