### PR TITLE
gui: background color support

### DIFF
--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -739,8 +739,8 @@ gui::set_display_controls
 | Switch Name | Description |
 | ---- | ---- |
 | `name` |  is the name of the control. For example, for the power nets option this would be ``Signals/Power`` or could be ``Layers/*`` to set the option for all the layers. |
-| `display_type` | is either ``visible`` or ``selectable`` |
-| `value` |is either ``true`` or ``false`` |
+| `display_type` | is either ``visible``, ``selectable``, ``color`` |
+| `value` | is either ``true`` or ``false`` for ``visible`` or ``selectable`` or the name of the color |
 
 ### Check Display Controls
 

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -635,6 +635,8 @@ class Gui
   // modify display controls
   void setDisplayControlsVisible(const std::string& name, bool value);
   void setDisplayControlsSelectable(const std::string& name, bool value);
+  void setDisplayControlsColor(const std::string& name,
+                               const Painter::Color& color);
   // Get the visibility/selectability for a control in the 'Display Control'
   // panel.
   bool checkDisplayControlsVisible(const std::string& name);

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1001,37 +1001,41 @@ std::tuple<QColor*, Qt::BrushStyle*, bool> DisplayControls::lookupColor(
 {
   if (item == misc_.background.swatch) {
     return {&background_color_, nullptr, false};
-  } else if (item == blockages_.blockages.swatch) {
+  }
+  if (item == blockages_.blockages.swatch) {
     return {&placement_blockage_color_, &placement_blockage_pattern_, false};
-  } else if (item == misc_.regions.swatch) {
+  }
+  if (item == misc_.regions.swatch) {
     return {&region_color_, &region_pattern_, false};
-  } else if (item == instance_shapes_.names.swatch) {
+  }
+  if (item == instance_shapes_.names.swatch) {
     return {&instance_name_color_, nullptr, false};
-  } else if (item == instance_shapes_.iterm_labels.swatch) {
+  }
+  if (item == instance_shapes_.iterm_labels.swatch) {
     return {&iterm_label_color_, nullptr, false};
-  } else if (item == rulers_.swatch) {
+  }
+  if (item == rulers_.swatch) {
     return {&ruler_color_, nullptr, false};
-  } else {
-    QVariant tech_layer_data = item->data(user_data_item_idx_);
-    if (!tech_layer_data.isValid()) {
-      return {nullptr, nullptr, false};
-    }
-    auto tech_layer = tech_layer_data.value<dbTechLayer*>();
-    auto site = tech_layer_data.value<odb::dbSite*>();
-    if (tech_layer != nullptr) {
-      QColor* item_color = &layer_color_[tech_layer];
-      Qt::BrushStyle* item_pattern = &layer_pattern_[tech_layer];
-      if (tech_layer->getType() != dbTechLayerType::ROUTING) {
-        if (index && index->row() != 0) {
-          // ensure if a via is the first layer, it can still be modified
-          return {item_color, item_pattern, false};
-        }
-      } else {
-        return {item_color, item_pattern, true};
+  }
+  QVariant tech_layer_data = item->data(user_data_item_idx_);
+  if (!tech_layer_data.isValid()) {
+    return {nullptr, nullptr, false};
+  }
+  auto tech_layer = tech_layer_data.value<dbTechLayer*>();
+  auto site = tech_layer_data.value<odb::dbSite*>();
+  if (tech_layer != nullptr) {
+    QColor* item_color = &layer_color_[tech_layer];
+    Qt::BrushStyle* item_pattern = &layer_pattern_[tech_layer];
+    if (tech_layer->getType() != dbTechLayerType::ROUTING) {
+      if (index && index->row() != 0) {
+        // ensure if a via is the first layer, it can still be modified
+        return {item_color, item_pattern, false};
       }
-    } else if (site != nullptr) {
-      return {&site_color_[site], nullptr, false};
+    } else {
+      return {item_color, item_pattern, true};
     }
+  } else if (site != nullptr) {
+    return {&site_color_[site], nullptr, false};
   }
 
   return {nullptr, nullptr, false};

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -23,6 +23,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "db_sta/dbNetwork.hh"
@@ -156,6 +157,7 @@ class DisplayControls : public QDockWidget,
   void setControlByPath(const std::string& path,
                         bool is_visible,
                         Qt::CheckState value);
+  void setControlByPath(const std::string& path, const QColor& color);
   bool checkControlByPath(const std::string& path, bool is_visible);
 
   void registerRenderer(Renderer* renderer);
@@ -477,6 +479,10 @@ class DisplayControls : public QDockWidget,
   bool isModelRowSelectable(const ModelRow* row) const;
 
   void checkLiberty(bool assume_loaded = false);
+
+  std::tuple<QColor*, Qt::BrushStyle*, bool> lookupColor(
+      QStandardItem* item,
+      const QModelIndex* index = nullptr);
 
   QTreeView* view_;
   DisplayControlModel* model_;

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -20,6 +20,7 @@
 #include <QVBoxLayout>
 #include <functional>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -166,6 +167,7 @@ class DisplayControls : public QDockWidget,
   void restoreTclCommands(std::vector<std::string>& cmds);
 
   // From the Options API
+  QColor background() override;
   QColor color(const odb::dbTechLayer* layer) override;
   Qt::BrushStyle pattern(const odb::dbTechLayer* layer) override;
   QColor placementBlockageColor() override;
@@ -236,6 +238,7 @@ class DisplayControls : public QDockWidget,
  signals:
   // The display options have changed and clients need to update
   void changed();
+  void colorChanged();
 
   // Emit a selected tech layer
   void selected(const Selected& selected);
@@ -368,6 +371,7 @@ class DisplayControls : public QDockWidget,
     ModelRow module;
     ModelRow manufacturing_grid;
     ModelRow gcell_grid;
+    ModelRow background;
   };
 
   struct InstanceShapeModels
@@ -415,7 +419,7 @@ class DisplayControls : public QDockWidget,
   void makeLeafItem(ModelRow& row,
                     const QString& text,
                     QStandardItem* parent,
-                    Qt::CheckState checked,
+                    std::optional<Qt::CheckState> checked,
                     bool add_selectable = false,
                     const QColor& color = Qt::transparent,
                     const QVariant& user_data = QVariant());
@@ -529,6 +533,8 @@ class DisplayControls : public QDockWidget,
   std::map<const odb::dbTechLayer*, Qt::BrushStyle> layer_pattern_;
 
   std::map<const odb::dbSite*, QColor> site_color_;
+
+  QColor background_color_;
 
   QColor placement_blockage_color_;
   Qt::BrushStyle placement_blockage_pattern_;

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -583,6 +583,13 @@ void Gui::selectMarkers(odb::dbMarkerCategory* markers)
   main_window->getDRCViewer()->selectCategory(markers);
 }
 
+void Gui::setDisplayControlsColor(const std::string& name,
+                                  const Painter::Color& color)
+{
+  const QColor qcolor(color.r, color.g, color.b, color.a);
+  main_window->getControls()->setControlByPath(name, qcolor);
+}
+
 void Gui::setDisplayControlsVisible(const std::string& name, bool value)
 {
   main_window->getControls()->setControlByPath(

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -301,25 +301,111 @@ void clear_highlights(int highlight_group = 0)
   gui->clearHighlights(highlight_group);
 }
 
-void set_display_controls(const char* name, const char* display_type, bool value)
+void set_display_controls(const char* name, const char* display_type, const char* value)
 {
   if (!check_gui("set_display_controls")) {
     return;
   }
   auto gui = gui::Gui::get();
+  auto logger = ord::OpenRoad::openRoad()->getLogger();
   
   std::string disp_type = display_type;
+  std::string str_value = value;
   // make lower case
   std::transform(disp_type.begin(), 
                  disp_type.end(), 
                  disp_type.begin(), 
                  [](char c) { return std::tolower(c); });
   if (disp_type == "visible") {
-    gui->setDisplayControlsVisible(name, value);
+    bool bval = str_value == "true" || str_value == "1";
+    gui->setDisplayControlsVisible(name, bval);
   } else if (disp_type == "selectable") {
-    gui->setDisplayControlsSelectable(name, value);
+    bool bval = str_value == "true" || str_value == "1";
+    gui->setDisplayControlsSelectable(name, bval);
+  } else if (disp_type == "color") {
+    gui::Painter::Color color = gui::Painter::black;
+    if (str_value.empty()) {
+      logger->error(GUI, 41, "Color is required");
+    }
+    if (str_value[0] == '#' && (str_value.size() == 7 || str_value.size() == 9)) {
+      uint hex_color = 0;
+      for (int i = 1; i < str_value.size(); i++) {
+        const char c = std::tolower(str_value[i]);
+        hex_color *= 16;
+        if (c >= '0' && c <= '9') {
+          hex_color += c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+          hex_color += c - 'a' + 10;
+        } else {
+          logger->error(GUI, 43, "Unable to decode color: {}", str_value);
+        }
+      }
+      if (str_value.size() == 7) {
+        hex_color *= 256;
+        hex_color += 255;
+      }
+      color.r = (hex_color & 0xff000000) >> 24;
+      color.g = (hex_color & 0x00ff0000) >> 16;
+      color.b = (hex_color & 0x0000ff00) >> 8;
+      color.a = hex_color & 0x000000ff;
+    } else if (str_value == "black") {
+      color = gui::Painter::black;
+    } else if (str_value == "white") {
+      color = gui::Painter::white;
+    } else if (str_value == "dark_gray") {
+      color = gui::Painter::dark_gray;
+    } else if (str_value == "gray") {
+      color = gui::Painter::gray;
+    } else if (str_value == "light_gray") {
+      color = gui::Painter::light_gray;
+    } else if (str_value == "red") {
+      color = gui::Painter::red;
+    } else if (str_value == "green") {
+      color = gui::Painter::green;
+    } else if (str_value == "blue") {
+      color = gui::Painter::blue;
+    } else if (str_value == "cyan") {
+      color = gui::Painter::cyan;
+    } else if (str_value == "magenta") {
+      color = gui::Painter::magenta;
+    } else if (str_value == "yellow") {
+      color = gui::Painter::yellow;
+    } else if (str_value == "dark_red") {
+      color = gui::Painter::dark_red;
+    } else if (str_value == "dark_green") {
+      color = gui::Painter::dark_green;
+    } else if (str_value == "dark_blue") {
+      color = gui::Painter::dark_blue;
+    } else if (str_value == "dark_cyan") {
+      color = gui::Painter::dark_cyan;
+    } else if (str_value == "dark_magenta") {
+      color = gui::Painter::dark_magenta;
+    } else if (str_value == "dark_yellow") {
+      color = gui::Painter::dark_yellow;
+    } else if (str_value == "orange") {
+      color = gui::Painter::orange;
+    } else if (str_value == "purple") {
+      color = gui::Painter::purple;
+    } else if (str_value == "lime") {
+      color = gui::Painter::lime;
+    } else if (str_value == "teal") {
+      color = gui::Painter::teal;
+    } else if (str_value == "pink") {
+      color = gui::Painter::pink;
+    } else if (str_value == "brown") {
+      color = gui::Painter::brown;
+    } else if (str_value == "indigo") {
+      color = gui::Painter::indigo;
+    } else if (str_value == "turquoise") {
+      color = gui::Painter::turquoise;
+    } else if (str_value == "transparent") {
+      color = gui::Painter::transparent;
+    } else {
+      logger->error(GUI, 42, "Color not recognized: {}", str_value);
+    }
+
+    gui->setDisplayControlsColor(name, color);
   } else {
-    auto logger = ord::OpenRoad::openRoad()->getLogger();
     logger->error(GUI, 7, "Unknown display control type: {}", display_type);
   }
 }

--- a/src/gui/src/layoutTabs.cpp
+++ b/src/gui/src/layoutTabs.cpp
@@ -43,6 +43,22 @@ LayoutTabs::LayoutTabs(Options* options,
   connect(this, &QTabWidget::currentChanged, this, &LayoutTabs::tabChange);
 }
 
+void LayoutTabs::updateBackgroundColors()
+{
+  for (LayoutViewer* viewer : viewers_) {
+    updateBackgroundColor(viewer);
+    viewer->fullRepaint();
+  }
+}
+
+void LayoutTabs::updateBackgroundColor(LayoutViewer* viewer)
+{
+  QPalette palette;
+  palette.setColor(QPalette::Window, options_->background());
+  viewer->setPalette(palette);
+  viewer->setAutoFillBackground(true);
+}
+
 void LayoutTabs::blockLoaded(odb::dbBlock* block)
 {
   // Check if we already have a tab for this block
@@ -80,12 +96,7 @@ void LayoutTabs::blockLoaded(odb::dbBlock* block)
   const auto name = fmt::format("{} ({})", block->getName(), tech->getName());
   addTab(scroll, name.c_str());
 
-  // This has to be done after addTab.  For unexplained reasons it
-  // doesn't work for all users if done in LayoutViewer::LayoutViewer.
-  QPalette palette;
-  palette.setColor(QPalette::Window, LayoutViewer::background());
-  viewer->setPalette(palette);
-  viewer->setAutoFillBackground(true);
+  updateBackgroundColor(viewer);
 
   // forward signals from the viewer upward
   connect(viewer, &LayoutViewer::location, this, &LayoutTabs::location);

--- a/src/gui/src/layoutTabs.h
+++ b/src/gui/src/layoutTabs.h
@@ -77,6 +77,8 @@ class LayoutTabs : public QTabWidget
 
  public slots:
   void tabChange(int index);
+  void updateBackgroundColors();
+  void updateBackgroundColor(LayoutViewer* viewer);
 
   // These are just forwarding to the current LayoutViewer
   void zoomIn();

--- a/src/gui/src/layoutViewer.cpp
+++ b/src/gui/src/layoutViewer.cpp
@@ -1733,10 +1733,15 @@ void LayoutViewer::updatePixmap(const QImage& image, const QRect& bounds)
 void LayoutViewer::drawLoadingIndicator(QPainter* painter, const QRect& bounds)
 {
   const QRect background = computeIndicatorBackground(painter, bounds);
+  const QColor background_color = options_->background();
 
-  painter->fillRect(background, Qt::black);  // to help visualize
+  painter->fillRect(background, background_color);  // to help visualize
 
-  painter->setPen(QPen(Qt::white, 2));
+  const QColor text_color(255 - background_color.red(),
+                          255 - background_color.green(),
+                          255 - background_color.blue());
+
+  painter->setPen(QPen(text_color, 2));
   painter->drawText(background.left(),
                     background.bottom(),
                     QString::fromStdString(loading_indicator_));
@@ -2096,7 +2101,7 @@ void LayoutViewer::saveImage(const QString& filepath,
                       highlighted_,
                       rulers_,
                       render_ratio,
-                      background());
+                      options_->background());
   pixels_per_dbu_ = old_pixels_per_dbu;
 
   if (!img.save(save_filepath)) {

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -254,8 +254,6 @@ class LayoutViewer : public QWidget
   void commandFinishedExecuting();
   void executionPaused();
 
-  static QColor background() { return Qt::black; }
-
  private slots:
   void setBlock(odb::dbBlock* block);
   void updatePixmap(const QImage& image, const QRect& bounds);

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -151,6 +151,10 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
   connect(
       controls_, &DisplayControls::changed, viewers_, &LayoutTabs::fullRepaint);
   connect(controls_,
+          &DisplayControls::colorChanged,
+          viewers_,
+          &LayoutTabs::updateBackgroundColors);
+  connect(controls_,
           &DisplayControls::changed,
           hierarchy_widget_,
           &BrowserWidget::displayControlsUpdated);

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -21,6 +21,7 @@ class Options
 {
  public:
   virtual ~Options() {}
+  virtual QColor background() = 0;
   virtual QColor color(const odb::dbTechLayer* layer) = 0;
   virtual Qt::BrushStyle pattern(const odb::dbTechLayer* layer) = 0;
   virtual QColor placementBlockageColor() = 0;


### PR DESCRIPTION
Closes #7191 

Adds:
- control of background color to the display controls (as Misc/Background)
- add color option to `gui::set_display_controls` to support common colors in openroad or as `#rrbbggaa`
