### PR TITLE
psm: remove dpl and pad as dependencies for psm

### DIFF
--- a/src/psm/include/psm/pdnsim.h
+++ b/src/psm/include/psm/pdnsim.h
@@ -8,8 +8,8 @@
 #include <optional>
 #include <string>
 
-#include "dpl/Opendp.h"
 #include "odb/dbBlockCallBackObj.h"
+#include "odb/dbCompare.h"
 
 namespace odb {
 class dbDatabase;
@@ -27,6 +27,9 @@ class Logger;
 }
 namespace rsz {
 class Resizer;
+}
+namespace dpl {
+class Opendp;
 }
 
 namespace psm {

--- a/src/psm/src/CMakeLists.txt
+++ b/src/psm/src/CMakeLists.txt
@@ -40,7 +40,6 @@ target_link_libraries(psm
     rsz_lib
     Eigen3::Eigen
     gui
-    pad
     Boost::boost
 )
 
@@ -70,7 +69,6 @@ if (Python3_FOUND AND BUILD_PYTHON)
     PUBLIC
       odb
       psm
-      dpl_lib
   )
 
 endif()

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -11,6 +11,7 @@
 
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "dpl/Opendp.h"
 #include "heatMap.h"
 #include "ir_network.h"
 #include "ir_solver.h"
@@ -257,6 +258,7 @@ void PDNSim::addDecapMaster(dbMaster* decap_master, double decap_cap)
 {
   opendp_->addDecapMaster(decap_master, decap_cap);
 }
+
 // Return the lowest layer of db_net route
 odb::dbTechLayer* PDNSim::getLowestLayer(odb::dbNet* db_net)
 {


### PR DESCRIPTION
No functional changes, just removing pad as a dependency from psm and fix the inclusion of dpl (which really should be in dpl and not in psm)