### PR TITLE
Cts add user clock buffer prefix for list inferring

### DIFF
--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -44,6 +44,7 @@ Perform clock tree synthesis.
 clock_tree_synthesis 
     [-wire_unit wire_unit]
     [-buf_list <list_of_buffers>]
+    [-buf_list_prefix prefix]\
     [-root_buf root_buf]
     [-clk_nets <list_of_clk_nets>]
     [-tree_buf <buf>]
@@ -71,6 +72,7 @@ clock_tree_synthesis
 | Switch Name | Description |
 | ----- | ----- |
 | `-buf_list` | Tcl list of master cells (buffers) that will be considered when making the wire segments (e.g. `{BUFXX, BUFYY}`). |
+| `-buf_list_prefix` | Prefix that will be used to infer the clock buffer list (e.g. `CLKBUF`). If no buffer are found using this prefix it will proceed with the normal buffer list inferring. Should not be used with `-buf_list` |
 | `-root_buffer` | The master cell of the buffer that serves as root for the clock tree. If this parameter is omitted, the first master cell from `-buf_list` is taken. |
 | `-wire_unit` | Minimum unit distance between buffers for a specific wire. If this parameter is omitted, the code gets the value from ten times the height of `-root_buffer`. |
 | `-distance_between_buffers` | Distance (in microns) between buffers that `cts` should use when creating the tree. When using this parameter, the clock tree algorithm is simplified and only uses a fraction of the segments from the LUT. |

--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -72,7 +72,7 @@ clock_tree_synthesis
 | Switch Name | Description |
 | ----- | ----- |
 | `-buf_list` | Tcl list of master cells (buffers) that will be considered when making the wire segments (e.g. `{BUFXX, BUFYY}`). |
-| `-buf_list_prefix` | Prefix that will be used to infer the clock buffer list (e.g. `CLKBUF`). If no buffer are found using this prefix it will proceed with the normal buffer list inferring. Should not be used with `-buf_list` |
+| `-buf_list_prefix` | Prefix that will be used to infer the clock buffer list (e.g. `CLKBUF`). If no buffers are found using this prefix it will proceed with the normal buffer list inferring. Should not be used with `-buf_list` |
 | `-root_buffer` | The master cell of the buffer that serves as root for the clock tree. If this parameter is omitted, the first master cell from `-buf_list` is taken. |
 | `-wire_unit` | Minimum unit distance between buffers for a specific wire. If this parameter is omitted, the code gets the value from ten times the height of `-root_buffer`. |
 | `-distance_between_buffers` | Distance (in microns) between buffers that `cts` should use when creating the tree. When using this parameter, the clock tree algorithm is simplified and only uses a fraction of the segments from the LUT. |

--- a/src/cts/src/CtsOptions.h
+++ b/src/cts/src/CtsOptions.h
@@ -43,6 +43,8 @@ class CtsOptions : public odb::dbBlockCallBackObj
   std::string getClockNets() const { return clockNets_; }
   void setRootBuffer(const std::string& buffer) { rootBuffer_ = buffer; }
   std::string getRootBuffer() const { return rootBuffer_; }
+  void setBufferListPrefix(const std::string& prefix) { bufferListPrefix_ = prefix; }
+  std::string getBufferListPrefix() const { return bufferListPrefix_; }
   void setBufferList(const std::vector<std::string>& buffers)
   {
     bufferList_ = buffers;
@@ -249,6 +251,7 @@ class CtsOptions : public odb::dbBlockCallBackObj
   std::string sinkBuffer_ = "";
   std::string treeBuffer_ = "";
   std::string metricFile_ = "";
+  std::string bufferListPrefix_ = "";
   int dbUnits_ = -1;
   unsigned wireSegmentUnit_ = 0;
   bool plotSolution_ = false;

--- a/src/cts/src/TritonCTS.i
+++ b/src/cts/src/TritonCTS.i
@@ -3,6 +3,7 @@
 
 %{
 #include <cstdint>
+#include <iostream>
 
 #include "cts/TritonCTS.h"
 #include "CtsOptions.h"
@@ -68,6 +69,12 @@ void
 set_root_buffer(const char* buffer)
 {
   getTritonCts()->setRootBuffer(buffer);
+}
+
+void
+set_buffer_list_prefix(const char* prefix)
+{
+  getTritonCts()->getParms()->setBufferListPrefix(prefix);
 }
 
 void

--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -38,6 +38,7 @@ proc configure_cts_characterization { args } {
 
 sta::define_cmd_args "clock_tree_synthesis" {[-wire_unit unit]
                                              [-buf_list buflist] \
+                                             [-buf_list_prefix prefix]\
                                              [-root_buf buf] \
                                              [-clk_nets nets] \
                                              [-tree_buf buf] \
@@ -63,8 +64,8 @@ sta::define_cmd_args "clock_tree_synthesis" {[-wire_unit unit]
 
 proc clock_tree_synthesis { args } {
   sta::parse_key_args "clock_tree_synthesis" args \
-    keys {-root_buf -buf_list -wire_unit -clk_nets -sink_clustering_size \
-          -num_static_layers -sink_clustering_buffer \
+    keys {-root_buf -buf_list -wire_unit -clk_nets -buf_list_prefix\
+          -sink_clustering_size -num_static_layers -sink_clustering_buffer \
           -distance_between_buffers -branching_point_buffers_distance \
           -clustering_exponent \
           -clustering_unbalance_ratio -sink_clustering_max_diameter \
@@ -128,6 +129,14 @@ proc clock_tree_synthesis { args } {
   if { [info exists keys(-clustering_unbalance_ratio)] } {
     set unbalance $keys(-clustering_unbalance_ratio)
     cts::set_clustering_unbalance_ratio $unbalance
+  }
+
+  if { [info exists keys(-buf_list_prefix)] } {
+    set prefix $keys(-buf_list_prefix)
+    if { [info exists keys(-buf_list)] } {
+      utl::warn CTS 129 "-buf_list_prefix will not be used, as -buf_list was already declared"
+    }
+    cts::set_buffer_list_prefix ".*${prefix}.*"
   }
 
   if { [info exists keys(-buf_list)] } {


### PR DESCRIPTION
Add the option for user to define the clock buffer name that CTS will look for when inferring the buffer list (e.g. "CLKBUF"). If no cells are found using the user's name it will proceed with the normal inferring procedure.  This helps users which PDKs don't follow the default clock buffer name defined in CTS.