### PR TITLE
gitignore: ignore bazel & Scala stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,12 @@ debian/openroad
 obj-x86_64-linux-gnu/
 
 user.bazelrc
-bazel-*
+
+bazel-bin
+bazel-out
+bazel-testlogs
+bazel-OpenROAD
+
+projectview.bazelproject
+.bsp/
+.bazelbsp/


### PR DESCRIPTION
make bazel-* ignore pattern narrower to clean up local goop more regularly. bazel-* folders can accrue in local `make issue` folders.

gitignore should:

- include all files that should exist locally, like IDE files, but should not be committed
- not include local goop that should be cleaned up regularly

git status should list:

- changes to be committed new or exisiting files
- files that should be deleted locally to keep the source folder nice and short and make sure that use-cases like IDE and "grep -r" remain nice and fast.