### PR TITLE
mpl: warn/exception when a pin is not aligned by Snapper

### DIFF
--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -3451,13 +3451,13 @@ int Snapper::totalAlignedPins(const LayerDataList& layers_data_list,
           if (data.track_grid->getTechLayer()->isRightWayOnGridOnly()) {
             logger_->error(MPL,
                            5,
-                           "Pin {} from layer {} is not aligned to a track",
+                           "Couldn't align pin {} from the RightWayOnGridOnly layer {} with the track-grid.",
                            data.pins[i]->getName(),
                            data.track_grid->getTechLayer()->getName());
           } else {
             logger_->warn(MPL,
                           2,
-                          "Pin {} from layer {} is not aligned to a track",
+                          "Couldn't align pin {} from layer {} to the track-grid.",
                           data.pins[i]->getName(),
                           data.track_grid->getTechLayer()->getName());
           }

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -3451,15 +3451,17 @@ int Snapper::totalAlignedPins(const LayerDataList& layers_data_list,
           if (data.track_grid->getTechLayer()->isRightWayOnGridOnly()) {
             logger_->error(MPL,
                            5,
-                           "Couldn't align pin {} from the RightWayOnGridOnly layer {} with the track-grid.",
+                           "Couldn't align pin {} from the RightWayOnGridOnly "
+                           "layer {} with the track-grid.",
                            data.pins[i]->getName(),
                            data.track_grid->getTechLayer()->getName());
           } else {
-            logger_->warn(MPL,
-                          2,
-                          "Couldn't align pin {} from layer {} to the track-grid.",
-                          data.pins[i]->getName(),
-                          data.track_grid->getTechLayer()->getName());
+            logger_->warn(
+                MPL,
+                2,
+                "Couldn't align pin {} from layer {} to the track-grid.",
+                data.pins[i]->getName(),
+                data.track_grid->getTechLayer()->getName());
           }
         }
 

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -3407,7 +3407,7 @@ void Snapper::attemptSnapToExtraPatterns(
     }
     snapPinToPosition(snap_pin, positions[current_index], target_direction);
 
-    int snapped_pins = totalPinsAligned(layers_data_list, target_direction);
+    int snapped_pins = totalAlignedPins(layers_data_list, target_direction);
 
     if (snapped_pins > best_snapped_pins) {
       best_snapped_pins = snapped_pins;
@@ -3418,16 +3418,23 @@ void Snapper::attemptSnapToExtraPatterns(
     }
   }
 
+  if (best_snapped_pins != total_pins) {
+    reportUnalignedPins(layers_data_list, target_direction);
+  }
+
   snapPinToPosition(snap_pin, positions[best_index], target_direction);
 }
 
-int Snapper::totalPinsAligned(const LayerDataList& layers_data_list,
-                              const odb::dbTechLayerDir& direction)
+int Snapper::totalAlignedPins(const LayerDataList& layers_data_list,
+                              const odb::dbTechLayerDir& direction,
+                              bool report_unaligned_pins)
 {
   int pins_aligned = 0;
 
   for (auto& data : layers_data_list) {
-    std::vector<int> pin_centers(data.pins.size());
+    std::vector<int> pin_centers;
+    pin_centers.reserve(data.pins.size());
+
     for (auto& pin : data.pins) {
       pin_centers.push_back(direction == odb::dbTechLayerDir::VERTICAL
                                 ? pin->getBBox().xCenter()
@@ -3440,6 +3447,22 @@ int Snapper::totalPinsAligned(const LayerDataList& layers_data_list,
         pins_aligned++;
         i++;
       } else if (pin_centers[i] < data.available_positions[j]) {
+        if (report_unaligned_pins) {
+          if (data.track_grid->getTechLayer()->isRightWayOnGridOnly()) {
+            logger_->error(MPL,
+                           5,
+                           "Pin {} from layer {} is not aligned to a track",
+                           data.pins[i]->getName(),
+                           data.track_grid->getTechLayer()->getName());
+          } else {
+            logger_->warn(MPL,
+                          2,
+                          "Pin {} from layer {} is not aligned to a track",
+                          data.pins[i]->getName(),
+                          data.track_grid->getTechLayer()->getName());
+          }
+        }
+
         i++;
       } else {
         j++;
@@ -3447,6 +3470,12 @@ int Snapper::totalPinsAligned(const LayerDataList& layers_data_list,
     }
   }
   return pins_aligned;
+}
+
+void Snapper::reportUnalignedPins(const LayerDataList& layers_data_list,
+                                  const odb::dbTechLayerDir& direction)
+{
+  totalAlignedPins(layers_data_list, direction, true);
 }
 
 void Snapper::alignWithManufacturingGrid(int& origin)

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -364,8 +364,11 @@ class Snapper
   void snap(const odb::dbTechLayerDir& target_direction);
   void alignWithManufacturingGrid(int& origin);
   void setOrigin(int origin, const odb::dbTechLayerDir& target_direction);
-  int totalPinsAligned(const LayerDataList& layers_data_list,
-                       const odb::dbTechLayerDir& direction);
+  int totalAlignedPins(const LayerDataList& layers_data_list,
+                       const odb::dbTechLayerDir& direction,
+                       bool report_unaligned_pins = false);
+  void reportUnalignedPins(const LayerDataList& layers_data_list,
+                           const odb::dbTechLayerDir& direction);
 
   LayerDataList computeLayerDataList(
       const odb::dbTechLayerDir& target_direction);

--- a/src/mpl/test/cpp/TestSnapper.cpp
+++ b/src/mpl/test/cpp/TestSnapper.cpp
@@ -416,7 +416,7 @@ TEST_F(TestSnapper, SingleLayerWithUnalignablePin)
 // Snaps a macro using one horizontal layer, aligning one pin while the other is
 // unalignable and the layer is RightWayOnlyGrid, which should throw an
 // expection if a pin is unaligned
-TEST_F(TestSnapper, SingleLayerWithUnalignablePinCrash)
+TEST_F(TestSnapper, SingleLayerWithUnalignablePinThrowsException)
 {
   db_->getTech()->setManufacturingGrid(1);
 

--- a/src/mpl/test/cpp/TestSnapper.cpp
+++ b/src/mpl/test/cpp/TestSnapper.cpp
@@ -415,7 +415,7 @@ TEST_F(TestSnapper, SingleLayerWithUnalignablePin)
 
 // Snaps a macro using one horizontal layer, aligning one pin while the other is
 // unalignable and the layer is RightWayOnlyGrid, which should throw an
-// expection if a pin is unaligned
+// exception if a pin is unaligned
 TEST_F(TestSnapper, SingleLayerWithUnalignablePinThrowsException)
 {
   db_->getTech()->setManufacturingGrid(1);

--- a/src/mpl/test/cpp/TestSnapper.cpp
+++ b/src/mpl/test/cpp/TestSnapper.cpp
@@ -347,9 +347,6 @@ TEST_F(TestSnapper, MultiOriginPattern)
 // unalignable
 TEST_F(TestSnapper, SingleLayerWithUnalignablePin)
 {
-  std::string expected_warning
-      = "[WARNING MPL-0002] Pin macro/pin2 from layer H1 is not aligned to a "
-        "track\n";
   db_->getTech()->setManufacturingGrid(1);
 
   const int track_pitch = 36;
@@ -405,6 +402,9 @@ TEST_F(TestSnapper, SingleLayerWithUnalignablePin)
   snapper_->snapMacro();
   std::string snap_warning = testing::internal::GetCapturedStdout();
 
+  std::string expected_warning
+      = "[WARNING MPL-0002] Couldn't align pin macro/pin2 from layer H1 to the "
+        "track-grid.\n";
   // Snapped to manufacturing grid
   EXPECT_EQ(macro->getOrigin().x(), 1500);
   // 1523 (origin) + 25 (pin center) equals 1548 which is

--- a/src/mpl/test/cpp/TestSnapper.cpp
+++ b/src/mpl/test/cpp/TestSnapper.cpp
@@ -315,7 +315,7 @@ TEST_F(TestSnapper, MultiOriginPattern)
                      pin3_y + pin_width);
 
   const int pin4_x = 0;
-  const int pin4_y = 230;
+  const int pin4_y = 218;
   odb::dbMTerm* mterm4 = odb::dbMTerm::create(
       macro_master, "pin4", odb::dbIoType::INPUT, odb::dbSigType::SIGNAL);
   odb::dbMPin* mpin4 = odb::dbMPin::create(mterm4);
@@ -341,6 +341,144 @@ TEST_F(TestSnapper, MultiOriginPattern)
   // 1528 (origin) + 171 (pin3 center) - 7 (pattern2 origin) equals 1692 which
   // is a multiple of 36 (pin is aligned to pattern2)
   EXPECT_EQ(macro->getOrigin().y(), 1528);
+}
+
+// Snaps a macro using one horizontal layer, aligning one pin while the other is
+// unalignable
+TEST_F(TestSnapper, SingleLayerWithUnalignablePin)
+{
+  std::string expected_warning
+      = "[WARNING MPL-0002] Pin macro/pin2 from layer H1 is not aligned to a "
+        "track\n";
+  db_->getTech()->setManufacturingGrid(1);
+
+  const int track_pitch = 36;
+  odb::dbTechLayer* horizontal_layer = odb::dbTechLayer::create(
+      db_->getTech(), "H1", odb::dbTechLayerType::DEFAULT);
+  horizontal_layer->setDirection(odb::dbTechLayerDir::HORIZONTAL);
+  odb::dbTrackGrid* track
+      = odb::dbTrackGrid::create(db_->getChip()->getBlock(), horizontal_layer);
+  track->addGridPatternY(0, die_height_ / track_pitch, track_pitch);
+
+  odb::dbMaster* macro_master
+      = odb::dbMaster::create(db_->findLib("lib"), "macro_master");
+  macro_master->setHeight(10000);
+  macro_master->setWidth(10000);
+  macro_master->setType(odb::dbMasterType::BLOCK);
+
+  const int pin_height = 20;
+  const int pin_width = 50;
+
+  const int pin1_x = 0;
+  const int pin1_y = 0;
+  odb::dbMTerm* mterm1 = odb::dbMTerm::create(
+      macro_master, "pin1", odb::dbIoType::INPUT, odb::dbSigType::SIGNAL);
+  odb::dbMPin* mpin1 = odb::dbMPin::create(mterm1);
+  odb::dbBox::create(mpin1,
+                     horizontal_layer,
+                     pin1_x,
+                     pin1_y,
+                     pin1_x + pin_height,
+                     pin1_y + pin_width);
+
+  const int pin2_x = 0;
+  const int pin2_y = 50;
+  odb::dbMTerm* mterm2 = odb::dbMTerm::create(
+      macro_master, "pin2", odb::dbIoType::INPUT, odb::dbSigType::SIGNAL);
+  odb::dbMPin* mpin2 = odb::dbMPin::create(mterm2);
+  odb::dbBox::create(mpin2,
+                     horizontal_layer,
+                     pin2_x,
+                     pin2_y,
+                     pin2_x + pin_height,
+                     pin2_y + pin_width);
+
+  macro_master->setFrozen();
+
+  odb::dbInst* macro
+      = odb::dbInst::create(db_->getChip()->getBlock(), macro_master, "macro");
+  macro->setOrigin(1500, 1500);
+
+  snapper_->setMacro(macro);
+
+  testing::internal::CaptureStdout();
+  snapper_->snapMacro();
+  std::string snap_warning = testing::internal::GetCapturedStdout();
+
+  // Snapped to manufacturing grid
+  EXPECT_EQ(macro->getOrigin().x(), 1500);
+  // 1523 (origin) + 25 (pin center) equals 1548 which is
+  // a multiple of 36 (pin is aligned to track)
+  EXPECT_EQ(macro->getOrigin().y(), 1523);
+  EXPECT_EQ(snap_warning, expected_warning);
+}
+
+// Snaps a macro using one horizontal layer, aligning one pin while the other is
+// unalignable and the layer is RightWayOnlyGrid, which should throw an
+// expection if a pin is unaligned
+TEST_F(TestSnapper, SingleLayerWithUnalignablePinCrash)
+{
+  db_->getTech()->setManufacturingGrid(1);
+
+  const int track_pitch = 36;
+  odb::dbTechLayer* horizontal_layer = odb::dbTechLayer::create(
+      db_->getTech(), "H1", odb::dbTechLayerType::DEFAULT);
+  horizontal_layer->setDirection(odb::dbTechLayerDir::HORIZONTAL);
+  horizontal_layer->setRightWayOnGridOnly(true);
+
+  odb::dbTrackGrid* track
+      = odb::dbTrackGrid::create(db_->getChip()->getBlock(), horizontal_layer);
+  track->addGridPatternY(0, die_height_ / track_pitch, track_pitch);
+
+  odb::dbMaster* macro_master
+      = odb::dbMaster::create(db_->findLib("lib"), "macro_master");
+  macro_master->setHeight(10000);
+  macro_master->setWidth(10000);
+  macro_master->setType(odb::dbMasterType::BLOCK);
+
+  const int pin_height = 20;
+  const int pin_width = 50;
+
+  const int pin1_x = 0;
+  const int pin1_y = 0;
+  odb::dbMTerm* mterm1 = odb::dbMTerm::create(
+      macro_master, "pin1", odb::dbIoType::INPUT, odb::dbSigType::SIGNAL);
+  odb::dbMPin* mpin1 = odb::dbMPin::create(mterm1);
+  odb::dbBox::create(mpin1,
+                     horizontal_layer,
+                     pin1_x,
+                     pin1_y,
+                     pin1_x + pin_height,
+                     pin1_y + pin_width);
+
+  const int pin2_x = 0;
+  const int pin2_y = 50;
+  odb::dbMTerm* mterm2 = odb::dbMTerm::create(
+      macro_master, "pin2", odb::dbIoType::INPUT, odb::dbSigType::SIGNAL);
+  odb::dbMPin* mpin2 = odb::dbMPin::create(mterm2);
+  odb::dbBox::create(mpin2,
+                     horizontal_layer,
+                     pin2_x,
+                     pin2_y,
+                     pin2_x + pin_height,
+                     pin2_y + pin_width);
+
+  macro_master->setFrozen();
+
+  odb::dbInst* macro
+      = odb::dbInst::create(db_->getChip()->getBlock(), macro_master, "macro");
+  macro->setOrigin(1500, 1500);
+
+  snapper_->setMacro(macro);
+
+  try {
+    snapper_->snapMacro();
+    FAIL() << "Expected exception MPL-0005";
+  } catch (const std::exception& e) {
+    EXPECT_STREQ(e.what(), "MPL-0005");
+  } catch (...) {
+    FAIL() << "Unexpected exception (other than MPL-0005)";
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Related to #6267, #6836 and #6991.

This PR adds a warning when a pin from a macro wasn't aligned by the Snapper, and throw an exception if the related pin's layer has the constraint RightWayOnly. 
The code was integrated with the function `totalAlignedPins` (renamed from `totalPinsAligned`) and wrapped by `reportUnalignedPins`.

This PR also incorporates a small optimization where previously I was creating a vector with a amount of zeros and then used `push_back` on it, when I actually meant to use `reserve`. This does not change the code behaviour.

With this being merged, I think most work on the Snapper is finished for the time being, closing the related issues.