### PR TITLE
[DO NOT REVIEW] bazel: run cfg=exec in sh_test() to avoid rebuild

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -2,12 +2,19 @@
 # Copyright (c) 2025-2025, The OpenROAD Authors
 
 load("//test:regression.bzl", "regression_test")
+load("//test:toolify.bzl", "toolify")
 
 exports_files(
     [
         "bazel_test.sh",
         "regression_test.sh",
     ],
+    visibility = ["//visibility:public"],
+)
+
+toolify(
+    name = "openroad",
+    bin = "//:openroad",
     visibility = ["//visibility:public"],
 )
 

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -39,7 +39,7 @@ def regression_test(
             srcs = ["//test:bazel_test.sh"],
             args = [],
             data = [
-                "//:openroad",
+                "//test:openroad",
                 "//test:regression_resources",
                 "//test:regression_test.sh",
             ] + test_files + _pop(kwargs, "data", []),
@@ -47,7 +47,7 @@ def regression_test(
                 "TEST_NAME_BAZEL": name,
                 "TEST_FILE": "$(location {test_file})".format(test_file = test_file),
                 "TEST_FILES_BAZEL": " ".join(["$(location {file})".format(file = file) for file in test_files]),
-                "OPENROAD_EXE": "$(location //:openroad)",
+                "OPENROAD_EXE": "$(location //test:openroad)",
                 "REGRESSION_TEST": "$(location //test:regression_test.sh)",
             },
             **kwargs

--- a/test/toolify.bzl
+++ b/test/toolify.bzl
@@ -1,0 +1,46 @@
+"""
+This module provides a rule to promote a binary to a cfg=exec
+to enable its use in sh_test(), this is to avoid building
+OpenROAD twice, once with -c opt cfg=exec and once with with
+-c opt target
+"""
+
+def _toolify(ctx):
+    # Declare the output script
+    output_script = ctx.actions.declare_file(ctx.attr.bin.label.name + ".sh")
+
+    # Write the script content
+    ctx.actions.write(
+        output = output_script,
+        content = """#!/bin/bash
+set -e
+exec "../{path}" "$@"
+""".format(path = ctx.executable.bin.short_path),
+        is_executable = True,
+    )
+
+    return DefaultInfo(
+        executable = output_script,
+        runfiles = ctx.runfiles(
+            [],
+            transitive_files = depset(
+                [ctx.executable.bin],
+                transitive = [
+                    ctx.attr.bin.default_runfiles.files,
+                    ctx.attr.bin.default_runfiles.symlinks,
+                ],
+            ),
+        ),
+    )
+
+toolify = rule(
+    implementation = _toolify,
+    attrs = {
+        "bin": attr.label(
+            executable = True,
+            cfg = "exec",
+            allow_files = True,
+        ),
+    },
+    executable = True,
+)


### PR DESCRIPTION
The idea here is that sh_test() and bazel build tests of OpenROAD with bazel-orfs will use the same binary, thus avoiding 
building twice.


```
bazelisk cquery -c opt --output=graph 'allpaths(//test/..., //:openroad)' | dot -Tsvg -o file.svg
```

Should show one openroad in combination with https://github.com/The-OpenROAD-Project/OpenROAD/pull/7229


```
$ bazel build -c opt :openroad
INFO: Analyzed target //:openroad (4 packages loaded, 4616 targets configured).
INFO: Found 1 target...
Target //:openroad up-to-date:
  bazel-bin/openroad
INFO: Elapsed time: 1.244s, Critical Path: 0.05s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
oyvind@small-cigar:~/OpenROAD-flow-scripts/tools/OpenROAD$ bazel test -c opt //test:error1-tcl 
INFO: Analyzed target //test:error1-tcl (1 packages loaded, 980 targets configured).
INFO: Found 1 test target...
Target //test:error1-tcl up-to-date:
  bazel-bin/test/error1-tcl
INFO: Elapsed time: 1.115s, Critical Path: 0.14s
INFO: 3 processes: 1 internal, 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
//test:error1-tcl                                                        PASSED in 0.1s

Executed 1 out of 1 test: 1 test passes.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```
