### PR TITLE
[DO NOT REVIEW] bazel: use exec config for openroad in tests to avoid rebuilds

### DIFF
--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -44,7 +44,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -127,7 +127,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -131,7 +131,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -89,7 +89,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -173,7 +173,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -79,7 +79,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -40,7 +40,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -113,7 +113,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -93,7 +93,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -175,7 +175,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [
+        srcs = [
             ":regression_resources",
             "//src/odb/test/data/sky130hd:lef-test-data",
         ] + glob(

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -186,7 +186,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -64,7 +64,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -240,7 +240,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -156,7 +156,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -154,7 +154,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -77,7 +77,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -86,7 +86,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -128,7 +128,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -41,7 +41,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -53,7 +53,7 @@ filegroup(
 [
     filegroup(
         name = test_name + "_resources",
-        data = [":regression_resources"] + glob(
+        srcs = [":regression_resources"] + glob(
             [
                 test_name + ".*",
             ],

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -4,6 +4,86 @@
 """Instantiate a regression test based on .py or .tcl
 files using resources in //test:regression_resources"""
 
+def _regression_test_impl(ctx):
+    # Declare the test script output
+    test_script = ctx.actions.declare_file(ctx.label.name + "_test.sh")
+
+    # Generate the test script
+    ctx.actions.write(
+        output = test_script,
+        content = """
+#!/bin/bash
+set -ex
+export TEST_NAME_BAZEL={TEST_NAME_BAZEL}
+export TEST_FILE={TEST_FILE}
+export OPENROAD_EXE={OPENROAD_EXE}
+export REGRESSION_TEST={REGRESSION_TEST}
+exec "{bazel_test_sh}" "$@"
+""".format(
+            bazel_test_sh = ctx.file.bazel_test_sh.short_path,
+            TEST_NAME_BAZEL = ctx.attr.test_name,
+            TEST_FILE = ctx.file.test_file.short_path,
+            OPENROAD_EXE = ctx.executable.openroad.short_path,
+            REGRESSION_TEST = ctx.file.regression_test.short_path,
+        ),
+        is_executable = True,
+    )
+
+    # Return the test script as the executable
+    return DefaultInfo(
+        executable = test_script,
+        runfiles = ctx.runfiles(
+            transitive_files = depset(
+                ctx.files.data + [
+                    ctx.file.test_file,
+                    ctx.file.bazel_test_sh,
+                    ctx.file.regression_test,
+                    ctx.executable.openroad,
+                ],
+                transitive = [
+                    ctx.attr.openroad[DefaultInfo].default_runfiles.files,
+                    ctx.attr.openroad[DefaultInfo].default_runfiles.symlinks,
+                ],
+            ),
+        ),
+    )
+
+regression_rule_test = rule(
+    implementation = _regression_test_impl,
+    attrs = {
+        "test_name": attr.string(
+            doc = "The name of the test.",
+            mandatory = True,
+        ),
+        "test_file": attr.label(
+            doc = "The primary test file (e.g., .tcl or .py).",
+            allow_single_file = True,
+        ),
+        "data": attr.label_list(
+            doc = "Additional test files required for the test.",
+            allow_files = True,
+        ),
+        "bazel_test_sh": attr.label(
+            doc = "The Bazel test shell script.",
+            allow_single_file = True,
+        ),
+        "openroad": attr.label(
+            doc = "The OpenROAD executable.",
+            executable = True,
+            # OpenROAD is executed in the exec configuration on the host machine
+            # to build designs, so we use the exec configuration, thus
+            # avoiding rebuilding the OpenROAD executable.
+            cfg = "target",
+        ),
+        "regression_test": attr.label(
+            doc = "The regression test script.",
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+    test = True,
+)
+
 def _pop(kwargs, key, default):
     """BUILD does not support kwargs, use None as a "kwargs at home" workaround"""
     if key in kwargs:
@@ -26,29 +106,25 @@ def regression_test(
         ]],
         allow_empty = True,  # Allow to be empty; see also TODO above.
     )
+    data = _pop(kwargs, "data", [])
+    size = _pop(kwargs, "size", "small")
     for test_file in test_files:
         ext = test_file.split(".")[-1]
-        native.sh_test(
+        regression_rule_test(
             name = name + "-" + ext,
+            test_file = test_file,
+            test_name = name,
+            data = [
+                "//test:regression_resources",
+            ] + test_files + data,
+            bazel_test_sh = "//test:bazel_test.sh",
+            openroad = "//:openroad",
+            regression_test = "//test:regression_test.sh",
             # top showed me 50-400mByte of usage, so "enormous" for
             # long running tests, but the OpenROAD tests are generally
             # "small" by design.
             #
             # https://bazel.build/reference/be/common-definitions#test.size
-            size = _pop(kwargs, "size", "small"),
-            srcs = ["//test:bazel_test.sh"],
-            args = [],
-            data = [
-                "//:openroad",
-                "//test:regression_resources",
-                "//test:regression_test.sh",
-            ] + test_files + _pop(kwargs, "data", []),
-            env = {
-                "TEST_NAME_BAZEL": name,
-                "TEST_FILE": "$(location {test_file})".format(test_file = test_file),
-                "TEST_FILES_BAZEL": " ".join(["$(location {file})".format(file = file) for file in test_files]),
-                "OPENROAD_EXE": "$(location //:openroad)",
-                "REGRESSION_TEST": "$(location //test:regression_test.sh)",
-            },
+            size = size,
             **kwargs
         )


### PR DESCRIPTION
Use target configuration for tests so that `bazel build -c :opt openroad` and `bazel test -c opt ...` uses same OpenROAD build.

This saves time and is idiomatic in that OpenROAD is a tool used to build things in bazel, it is intended to be used as the build process, it is not an application that is to be created and has nothing to do with the bazel build stages afterwards.

However, a file like `src/rsz/src/Resizer.cc` is built twice, because ...(???)

Before, multiple configurations, i.e. openroad has to be built multiple times:

```
bazelisk cquery -c opt --output=graph 'allpaths(//test/..., //:openroad)' | dot -Tsvg -o file.svg
```

To view differences of configurations, run:

```
diff -u <(bazelisk config 0b24ccd)  <(bazelisk config 206f41d) | bat
```


![image](https://github.com/user-attachments/assets/024fcb85-f2c5-494e-a9b4-75ebc184b13e)


After, one configuration, openroad has to be built once:

![image](https://github.com/user-attachments/assets/86ca001b-68ec-4bb9-921e-ac23a41742f2)
