### PR TITLE
Fix SEGFAULT when two nets have the same name

### DIFF
--- a/src/odb/src/defin/definNet.cpp
+++ b/src/odb/src/defin/definNet.cpp
@@ -331,6 +331,7 @@ void definNet::wire(dbWireType type)
         _wire = dbWire::create(_cur_net);
       }
     }
+    assert(_wire != nullptr);
     _wire_encoder.begin(_wire);
   }
 


### PR DESCRIPTION
When loading a .def file in which two nets have the same name, OpenROAD segfaults due to dereferencing a null pointer. I thus add an assert to check for this specific case.

For example, the following file, loaded through the `read_def` command, segfaults.

```def
VERSION 5.8 ;
DIVIDERCHAR "/" ;
BUSBITCHARS "[]" ;
DESIGN segfault ;
NETS 2 ;
    - a
        + ROUTED
        met2
            ( 0 0 ) ( 0 0 ) ;
    - a
        + ROUTED
        met2
            ( 0 0 ) ( 0 0 ) ;
END NETS
END DESIGN
```