### PR TITLE
[DO NOT REVIEW] ctrl-c: restore behavior to stop immediately

### DIFF
--- a/src/utl/include/utl/Progress.h
+++ b/src/utl/include/utl/Progress.h
@@ -26,7 +26,7 @@ class Progress
     Progress* progress = nullptr;
     Logger* logger = nullptr;
 
-    struct sigaction orig_sigaction;
+    sighandler_t org_signal_handler;
 
     std::queue<std::time_t> interrupts;
     constexpr static int max_idle_interrupts = 2;

--- a/src/utl/src/Progress.cpp
+++ b/src/utl/src/Progress.cpp
@@ -58,16 +58,12 @@ Progress::Progress(Logger* logger) : logger_(logger)
   prev_signal_halt_ = signal_halt;
   signal_halt = &signal_halt_;
 
-  struct sigaction act;
-  act.sa_handler = controlC_handler;
-  sigemptyset(&act.sa_mask);
-  act.sa_flags = 0;
-  sigaction(SIGINT, &act, &signal_halt_.orig_sigaction);
+  signal_halt_.org_signal_handler = signal(SIGINT, controlC_handler);
 }
 
 Progress::~Progress()
 {
-  sigaction(SIGINT, &signal_halt_.orig_sigaction, nullptr);
+  signal(SIGINT, signal_halt_.org_signal_handler);
   signal_halt = prev_signal_halt_;
 }
 


### PR DESCRIPTION
Revert "utl: switch signal to sigaction for Mac compatibility"

This reverts commit c9720ecf927ed959ab1e25d2f417d87805b7ab18.

and parts of 9e747a8