### PR TITLE
grt: fix pin position on grid when estimating parasitics from odb guides

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -161,7 +161,8 @@ class GlobalRouter : public ant::GlobalRouteSource
   void saveGuides();
   void writeSegments(const char* file_name);
   void readSegments(const char* file_name);
-  bool netIsCovered(odb::dbNet* db_net, std::string& pins_not_covered);
+  bool netIsCovered(odb::dbNet* db_net,
+                    std::vector<std::string>& pins_not_covered);
   bool segmentIsLine(const GSegment& segment);
   bool segmentCoversPin(const GSegment& segment, const Pin& pin);
   AdjacencyList buildNetGraph(odb::dbNet* net);
@@ -342,6 +343,7 @@ class GlobalRouter : public ant::GlobalRouteSource
                                               odb::Point& pos_on_grid);
   int getNetMaxRoutingLayer(const Net* net);
   void findPins(Net* net);
+  void computePinPositionOnGrid(Pin& pin);
   void findFastRoutePins(Net* net,
                          std::vector<RoutePt>& pins_on_grid,
                          int& root_idx);
@@ -467,6 +469,7 @@ class GlobalRouter : public ant::GlobalRouteSource
   bool is_congested_{false};
   // TODO: remove this flag after support incremental updates on DRT PA
   bool skip_drt_aps_{false};
+  bool guides_from_db_{false};
 
   // Region adjustment variables
   std::vector<RegionAdjustment> region_adjustments_;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -982,41 +982,46 @@ std::vector<odb::Point> GlobalRouter::findOnGridPositions(
 void GlobalRouter::findPins(Net* net)
 {
   for (Pin& pin : net->getPins()) {
-    bool has_access_points;
-    odb::Point pos_on_grid;
-    std::vector<odb::Point> pin_positions_on_grid
-        = findOnGridPositions(pin, has_access_points, pos_on_grid);
-
-    int votes = -1;
-
-    odb::Point pin_position;
-    for (odb::Point pos : pin_positions_on_grid) {
-      int equals = std::count(
-          pin_positions_on_grid.begin(), pin_positions_on_grid.end(), pos);
-      if (equals > votes) {
-        pin_position = pos;
-        votes = equals;
-      }
-    }
-
-    // check if the pin has access points to avoid changing the position on grid
-    // when the pin overlaps with a single track.
-    // this way, the result based on drt APs is maintained
-    if (!has_access_points && pinOverlapsWithSingleTrack(pin, pos_on_grid)) {
-      const int conn_layer = pin.getConnectionLayer();
-      odb::dbTechLayer* layer = routing_layers_[conn_layer];
-      pos_on_grid = grid_->getPositionOnGrid(pos_on_grid);
-      if (!(pos_on_grid == pin_position)
-          && ((layer->getDirection() == odb::dbTechLayerDir::HORIZONTAL
-               && pos_on_grid.y() != pin_position.y())
-              || (layer->getDirection() == odb::dbTechLayerDir::VERTICAL
-                  && pos_on_grid.x() != pin_position.x()))) {
-        pin_position = pos_on_grid;
-      }
-    }
-
-    pin.setOnGridPosition(pin_position);
+    computePinPositionOnGrid(pin);
   }
+}
+
+void GlobalRouter::computePinPositionOnGrid(Pin& pin)
+{
+  bool has_access_points;
+  odb::Point pos_on_grid;
+  std::vector<odb::Point> pin_positions_on_grid
+      = findOnGridPositions(pin, has_access_points, pos_on_grid);
+
+  int votes = -1;
+
+  odb::Point pin_position;
+  for (odb::Point pos : pin_positions_on_grid) {
+    int equals = std::count(
+        pin_positions_on_grid.begin(), pin_positions_on_grid.end(), pos);
+    if (equals > votes) {
+      pin_position = pos;
+      votes = equals;
+    }
+  }
+
+  // check if the pin has access points to avoid changing the position on grid
+  // when the pin overlaps with a single track.
+  // this way, the result based on drt APs is maintained
+  if (!has_access_points && pinOverlapsWithSingleTrack(pin, pos_on_grid)) {
+    const int conn_layer = pin.getConnectionLayer();
+    odb::dbTechLayer* layer = routing_layers_[conn_layer];
+    pos_on_grid = grid_->getPositionOnGrid(pos_on_grid);
+    if (!(pos_on_grid == pin_position)
+        && ((layer->getDirection() == odb::dbTechLayerDir::HORIZONTAL
+             && pos_on_grid.y() != pin_position.y())
+            || (layer->getDirection() == odb::dbTechLayerDir::VERTICAL
+                && pos_on_grid.x() != pin_position.x()))) {
+      pin_position = pos_on_grid;
+    }
+  }
+
+  pin.setOnGridPosition(pin_position);
 }
 
 int GlobalRouter::getNetMaxRoutingLayer(const Net* net)

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -2176,7 +2176,6 @@ void GlobalRouter::loadGuidesFromDB()
   if (!routes_.empty()) {
     return;
   }
-  skip_drt_aps_ = true;
   initGridAndNets();
   for (odb::dbNet* net : block_->getNets()) {
     for (odb::dbGuide* guide : net->getGuides()) {
@@ -2199,6 +2198,7 @@ void GlobalRouter::loadGuidesFromDB()
     updateDbCongestion();
   }
   heatmap_->update();
+  guides_from_db_ = true;
 }
 
 void GlobalRouter::updateVias()

--- a/src/grt/src/Net.cpp
+++ b/src/grt/src/Net.cpp
@@ -54,6 +54,16 @@ void Net::addPin(Pin& pin)
   pins_.push_back(pin);
 }
 
+Pin& Net::getPinByName(const std::string& pin_name)
+{
+  std::vector<Pin>::iterator it
+      = std::find_if(pins_.begin(), pins_.end(), [&](const Pin& p) {
+          return p.getName() == pin_name;
+        });
+
+  return *it;
+}
+
 std::vector<std::vector<SegmentIndex>> Net::buildSegmentsGraph()
 {
   std::vector<std::vector<SegmentIndex>> graph(parent_segment_indices_.size(),

--- a/src/grt/src/Net.h
+++ b/src/grt/src/Net.h
@@ -37,6 +37,7 @@ class Net
   {
     return parent_segment_indices_;
   }
+  Pin& getPinByName(const std::string& pin_name);
   std::vector<std::vector<SegmentIndex>> buildSegmentsGraph();
   bool isLocal();
   void destroyPins();


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/7013.

This PR should only affect ORFS' `make open`, as the checks included to `GlobalRoute::estimateRC` are only applied when estimating parasitics from odb guides.