### PR TITLE
bazelrc: fix typo for try-import

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,4 +55,4 @@ build --incompatible_strict_action_env
 #build --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts
 #build --remote_cache_compression=true
 
-try-import %workspace$/user.bazelrc
+try-import %workspace%/user.bazelrc


### PR DESCRIPTION
This explains why I didn't see any artifacts or error messages w.r.t. user.bazelrc setup for artifact server.