### PR TITLE
Added build retention policy for multi-branch pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ def getParallelTests(String image) {
 node {
 
     def isDefaultBranch = (env.BRANCH_NAME == 'master') 
-    def daysToKeep = (isDefaultBranch ? '20' : '-1');
+    def daysToKeep = '20';
     def numToKeep = (isDefaultBranch ? '-1' : '10');
 
     properties([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,6 +224,20 @@ def getParallelTests(String image) {
 }
 
 node {
+
+    def isDefaultBranch = (env.BRANCH_NAME == 'master') 
+    def daysToKeep = (isDefaultBranch ? '20' : '-1');
+    def numToKeep = (isDefaultBranch ? '-1' : '10');
+
+    properties([
+        buildDiscarder(logRotator(
+            daysToKeepStr:         daysToKeep,
+            artifactDaysToKeepStr: daysToKeep,
+
+            numToKeepStr:          numToKeep,
+            artifactNumToKeepStr:  numToKeep
+        ))
+    ]);
     stage('Checkout') {
         checkout scm;
     }


### PR DESCRIPTION
Implement a build retention policy that retains builds and artifacts for 20 days for the default branch.
Any other branches are limited by 10 builds on rotation.