### PR TITLE
Fix Use After Free in splitBySj

### DIFF
--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -322,6 +322,7 @@ void tmg_conn::splitBySj(const int j,
                          const int sjxMax,
                          const int sjyMax)
 {
+  tmg_rc_sh* sj = &(_rcV[j]._shape);
   const int isVia = sj->isVia() ? 1 : 0;
   _search->searchStart(rt, {sjxMin, sjyMin, sjxMax, sjyMax}, isVia);
   int klast = -1;
@@ -334,7 +335,7 @@ void tmg_conn::splitBySj(const int j,
         || _rcV[j]._from_idx == _rcV[k]._to_idx) {
       continue;
     }
-    tmg_rc_sh* sj = &(_rcV[j]._shape);
+    sj = &(_rcV[j]._shape);
     if (!sj->isVia() && _rcV[j]._is_vertical == _rcV[k]._is_vertical) {
       continue;
     }

--- a/src/odb/src/db/tmg_conn.cpp
+++ b/src/odb/src/db/tmg_conn.cpp
@@ -316,7 +316,6 @@ void tmg_conn::loadWire(dbWire* wire)
 }
 
 void tmg_conn::splitBySj(const int j,
-                         const tmg_rc_sh* sj,
                          const int rt,
                          const int sjxMin,
                          const int sjyMin,
@@ -335,6 +334,7 @@ void tmg_conn::splitBySj(const int j,
         || _rcV[j]._from_idx == _rcV[k]._to_idx) {
       continue;
     }
+    tmg_rc_sh* sj = &(_rcV[j]._shape);
     if (!sj->isVia() && _rcV[j]._is_vertical == _rcV[k]._is_vertical) {
       continue;
     }
@@ -424,7 +424,6 @@ void tmg_conn::splitTtop()
       for (dbBox* b : boxes) {
         if (b->getTechLayer() == layb) {
           splitBySj(j,
-                    sj,
                     layb->getRoutingLevel(),
                     via_x + b->xMin(),
                     via_y + b->yMin(),
@@ -432,7 +431,6 @@ void tmg_conn::splitTtop()
                     via_y + b->yMax());
         } else if (b->getTechLayer() == layt) {
           splitBySj(j,
-                    sj,
                     layt->getRoutingLevel(),
                     via_x + b->xMin(),
                     via_y + b->yMin(),
@@ -442,7 +440,7 @@ void tmg_conn::splitTtop()
       }
     } else {
       const int rt = sj->getTechLayer()->getRoutingLevel();
-      splitBySj(j, sj, rt, sj->xMin(), sj->yMin(), sj->xMax(), sj->yMax());
+      splitBySj(j, rt, sj->xMin(), sj->yMin(), sj->xMax(), sj->yMax());
     }
   }
 }

--- a/src/odb/src/db/tmg_conn.h
+++ b/src/odb/src/db/tmg_conn.h
@@ -109,12 +109,7 @@ class tmg_conn
 
  private:
   void splitTtop();
-  void splitBySj(int j,
-                 int rt,
-                 int sjxMin,
-                 int sjyMin,
-                 int sjxMax,
-                 int sjyMax);
+  void splitBySj(int j, int rt, int sjxMin, int sjyMin, int sjxMax, int sjyMax);
   void findConnections();
   void removeShortLoops();
   void removeWireLoops();

--- a/src/odb/src/db/tmg_conn.h
+++ b/src/odb/src/db/tmg_conn.h
@@ -110,7 +110,6 @@ class tmg_conn
  private:
   void splitTtop();
   void splitBySj(int j,
-                 const tmg_rc_sh* sj,
                  int rt,
                  int sjxMin,
                  int sjyMin,


### PR DESCRIPTION
In the function `splitBySj`, the call to `addRc` in the `while` loop pushes an element to the vector `_rcV`. It may thus be reallocated, causing the pointer `sj` to become invalid and a use-after-free when this pointer is later dereferenced.

My fix consists in re-defining the `sj` pointer on each loop based on the index in the vector, to ensure that it is always valid.

I observed this bug by providing as input a design in which one net has 395 wire segments in a single wiring.