### PR TITLE
includes: prune some unused includes

### DIFF
--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -3,13 +3,8 @@
 
 #include "dpl/Opendp.h"
 
-#include <boost/property_tree/json_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
 #include <cfloat>
 #include <cmath>
-#include <iostream>
-#include <limits>
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/dpl/src/objective/detailed_displacement.cxx
+++ b/src/dpl/src/objective/detailed_displacement.cxx
@@ -3,14 +3,8 @@
 
 #include "detailed_displacement.h"
 
-#include <algorithm>
-#include <boost/tokenizer.hpp>
 #include <cmath>
 #include <cstddef>
-#include <iostream>
-#include <stack>
-#include <utility>
-#include <vector>
 
 #include "optimization/detailed_manager.h"
 #include "optimization/detailed_orient.h"

--- a/src/dpl/src/objective/detailed_hpwl.cxx
+++ b/src/dpl/src/objective/detailed_hpwl.cxx
@@ -3,8 +3,6 @@
 
 #include "detailed_hpwl.h"
 
-#include <vector>
-
 #include "optimization/detailed_orient.h"
 
 namespace dpl {

--- a/src/dpl/src/optimization/detailed.cxx
+++ b/src/dpl/src/optimization/detailed.cxx
@@ -1,15 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2021-2025, The OpenROAD Authors
 
-#include <algorithm>
-#include <boost/format.hpp>
-#include <boost/tokenizer.hpp>
 #include <cmath>
-#include <iostream>
-#include <stack>
 #include <string>
-#include <utility>
-#include <vector>
 
 #include "util/utility.h"
 #include "utl/Logger.h"

--- a/src/dpl/src/optimization/detailed_reorder.cxx
+++ b/src/dpl/src/optimization/detailed_reorder.cxx
@@ -4,12 +4,9 @@
 #include "detailed_reorder.h"
 
 #include <algorithm>
-#include <boost/tokenizer.hpp>
 #include <cstddef>
 #include <limits>
 #include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "detailed_manager.h"
 #include "infrastructure/architecture.h"

--- a/src/dpl/src/optimization/detailed_vertical.cxx
+++ b/src/dpl/src/optimization/detailed_vertical.cxx
@@ -4,7 +4,6 @@
 #include "detailed_vertical.h"
 
 #include <algorithm>
-#include <boost/tokenizer.hpp>
 #include <cmath>
 #include <cstddef>
 #include <string>

--- a/src/dpl/test/dpl_test.cc
+++ b/src/dpl/test/dpl_test.cc
@@ -1,5 +1,3 @@
-#include <unistd.h>
-
 #include <memory>
 
 #include "dpl/Opendp.h"


### PR DESCRIPTION
Tried these instructions https://github.com/The-OpenROAD-Project/OpenROAD/pull/7269#issuecomment-2849049020

There are many 1358 "warning: included header ... is not used directly" warnings, fixed a few at the compilation unit level.

Fixing those in include headers is trickier as it requires adding include files in some other file where they are used.

Google coding standard, which I guess we're following here, is to disallow forward declarations like "struct Foo;". Rather one should include onlyh what is used in a .h/.cpp file.