### PR TITLE
Do not skip the destructor in extMeasure

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -2363,7 +2363,6 @@ void extMeasure::allocOUpool()
 
 extMeasure::~extMeasure()
 {
-  return;
   for (auto& ii : _rc) {
     delete ii;
   }


### PR DESCRIPTION
Since 4c290dc, the extMeasure destructor is skipped, leading to memory leaks notably of the _rc array. Why was such behaviour introduced in the first place, and shouldn't it be reverted?