### PR TITLE
Fix memory leak in the extDistRCTable destructor

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -157,6 +157,10 @@ extDistRCTable::extDistRCTable(uint distCnt)
 
 extDistRCTable::~extDistRCTable()
 {
+  while (_measureTable->notEmpty()) {
+    delete _measureTable->pop();
+  }
+
   delete _measureTable;
   delete _computeTable;
 }


### PR DESCRIPTION
empty the table before dropping it