### PR TITLE
bazel: add runfiles deps to OpenSTA

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -937,6 +937,7 @@ cc_binary(
     visibility = ["//visibility:public"],
     deps = [
         ":opensta_lib",
+        "@rules_cc//cc/runfiles",
         "@tk_tcl//:tcl",
     ],
 )


### PR DESCRIPTION
This is used to find tcl files in a future PR in OpenSTA