### PR TITLE
bazel: fix tclsh problems finding library

### DIFF
--- a/bazel/tcl_encode_sta.bzl
+++ b/bazel/tcl_encode_sta.bzl
@@ -23,7 +23,11 @@ def _tcl_encode_sta_impl(ctx):
         inputs = ctx.files.srcs,
         arguments = [args],
         tools = [ctx.executable._tclsh, ctx.file._encode_script],
-        executable = ([file for file in ctx.files._tclsh if file.basename == "tclsh"][0]),
+        executable = ctx.executable._tclsh,
+        env = {
+            # FIXME why is this needed?
+            "TCL_LIBRARY": ctx.executable._tclsh.path + ".runfiles/tk_tcl/library",
+        },
     )
     return [DefaultInfo(files = depset([output_file]))]
 


### PR DESCRIPTION
Hmmm... why?

Shouldn't this fix go into tclsh upstream?

@hzeller @QuantamHD Thoughts?

This fixes the `application-specific initialization failed: unknown encoding "ascii"` error with `bazel build -c opt :StaTclInitVar`

```
$ bazel build -c opt :StaTclInitVar 
INFO: Analyzed target //:StaTclInitVar (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //:StaTclInitVar up-to-date:
  bazel-bin/StaTclInitVar.cc
INFO: Elapsed time: 0.442s, Critical Path: 0.26s
INFO: 2 processes: 1 internal, 1 processwrapper-sandbox.
INFO: Build completed successfully, 2 total actions
$ bazel build -c opt @tk_tcl//:tclsh
INFO: Analyzed target @@tk_tcl//:tclsh (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target @@tk_tcl//:tclsh up-to-date:
  bazel-bin/external/tk_tcl/tclsh
INFO: Elapsed time: 0.180s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
$ bazel-bin/external/tk_tcl/tclsh
application-specific initialization failed: unknown encoding "ascii"
%
$ TCL_LIBRARY=bazel-bin/external/tk_tcl/tclsh.runfiles/tk_tcl/library bazel-bin/external/tk_tcl/tclsh
%
```
