### PR TITLE
[DO NOT REVIEW] bazel: enable test/orfs/... now that CI works

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,5 +2,3 @@ build/
 debug/
 src/sta/build/
 src/sta/debug/
-# delete line below when CI can handle it and it runs in minutes
-test/orfs/


### PR DESCRIPTION
To run mock-array with power testing:

```
bazel test -c opt test/orfs/mock-array/...
```

1. Chisel build of MockArray with array dimensions/layout as specified in test/orfs/mock-array/BUILD
2. OpenROAD bazel-orfs flow through CTS and generate gate netlist + estimated .spef + .sdc files for CTS.
3. Run verilator + simulation to generate gate netlist .vcd file
4. Run OpenSTA, read in .spef, .v netlist from CTS, .sdc, .lib files for ASAP7 and .vcd file from gate netlist simulation, verify that all pins are activated and check that the power estimate is different default activations and with a .vcd file

It is not necessary for testing purposes to run all the way through detailed routing before starting the power simulation test. Running power on in testing on CTS tests estimated .spef + reduces critical path in testing time allowing power simulation and detailed routing of 

This is an A-Z smoke-test for architectural exploration and it is helpful to have it all gathered in one place available in OpenROAD and running under CI.

Bazel quite nicely handles all these dependencies without the user/developer having to read a million installation procedures. It is impressive that 380 lines in  test/orfs/mock-array/BUILD is all that it takes to describe this full flow from Chisel, to running bazel-orfs to getting PPA, to getting dynamic power.

Some observations:

- all pins are annotated by .vcd
- the power is different with default pin activations and .vcd annotations. This test-design doesn't exhibit a large difference
- If the multipliers in the Elements in the mock-array had been 32 wide and not trimmed down to reduce running times of the test, then there would be a bigger difference in default activations and .vcd activations


```
Group                  Internal  Switching    Leakage      Total
                          Power      Power      Power      Power (Watts)
----------------------------------------------------------------
Sequential             4.89e-02   1.41e-04   1.35e-06   4.91e-02  37.0%
Combinational          7.58e-04   6.61e-04   3.40e-06   1.42e-03   1.1%
Clock                  4.96e-02   3.27e-02   5.08e-07   8.23e-02  62.0%
Macro                  0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
Pad                    0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
----------------------------------------------------------------
Total                  9.93e-02   3.35e-02   5.26e-06   1.33e-01 100.0%
                          74.8%      25.2%       0.0%
Total power from VCD: 0.13280430436134338
Total power from user activity: 0.1328057050704956
report_parasitic_annotation
Found 1485 unannotated drivers.
Found 0 partially unannotated drivers.
report_activity_annotation -report_unannotated
vcd         72602
input       75464
unannotated     0
Unannotated pins:
```
