### PR TITLE
Correctly initialize and clear the arrays

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -153,12 +153,26 @@ extDistRCTable::extDistRCTable(uint distCnt)
   _measureTable = new Ath__array1D<extDistRC*>(n);
 
   _computeTable = nullptr;
+
+  for (int i = 0; i < 16; i++) {
+    _measureTableR[i] = nullptr;
+    _computeTableR[i] = nullptr;
+  }
 }
 
 extDistRCTable::~extDistRCTable()
 {
   delete _measureTable;
   delete _computeTable;
+
+  for (int i = 0; i < 16; i++) {
+    if (_measureTableR[i] != _measureTable) {
+      delete _measureTableR[i];
+    }
+    if (_computeTableR[i] != _computeTable) {
+      delete _computeTableR[i];
+    }
+  }
 }
 
 uint extDistRCTable::mapExtrapolate(uint loDist,


### PR DESCRIPTION
This avoid having a segfault because _computeTable may be set to an unititialized memory location due to _computeTableR