### PR TITLE
rcx: fix msan violation in destruction

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -2734,7 +2734,7 @@ class extMain
 
   Ath__array1D<SEQ*>*** _dgContextArray = nullptr;
   uint _dgContextDepth;
-  uint _dgContextPlanes;
+  uint _dgContextPlanes = 0;
   uint _dgContextTracks;
   uint _dgContextBaseLvl;
   int _dgContextLowLvl;
@@ -2746,7 +2746,7 @@ class extMain
 
   Ath__array1D<int>** _ccContextArray = nullptr;
   Ath__array1D<int>** _ccMergedContextArray = nullptr;
-  uint _ccContextPlanes;
+  uint _ccContextPlanes = 0;
 
   uint _extRun = 0;
   odb::dbExtControl* _prevControl = nullptr;


### PR DESCRIPTION
https://github.com/The-OpenROAD-Project/OpenROAD/blob/6b031011d4fc38320530de283fe709046c9239e7/src/rcx/src/extmain.cpp#L185 can be called in destruction before `extMain::initContextArray()`, in which the values of `_ccContextPlanes` and `_dgContextPlanes` can be checked before initialization. MemorySanitizer will fail on this behavior.