### PR TITLE
bazel: stopgap way to create debug build

### DIFF
--- a/src/odb/src/def/BUILD
+++ b/src/odb/src/def/BUILD
@@ -54,7 +54,7 @@ cc_library(
     ],
     hdrs = DEF_HEADERS,
     # Ignore warnings in generated code
-    copts = ["-Wno-unused-but-set-variable"],
+    copts = ["-Wno-unused-but-set-variable", "-Wno-modules-import-nested-redundant"],
     includes = ["def"],
 )
 


### PR DESCRIPTION
This produces an openroad build now:
    
    bazelisk build --cxxopt=-stdlib=libstdc++ --linkopt=-lstdc++ -c dbg :openroad

Whereas this [still fails](https://github.com/The-OpenROAD-Project/OpenROAD/issues/7349):

    bazelisk build -c dbg :openroad
