### PR TITLE
bazel: disable more C++ warnings below PR acceptance bar

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,6 +30,15 @@ build --copt "-Wno-c++20-designator"      --host_copt "-Wno-c++20-designator"
 build --copt "-Wno-gcc-compat"            --host_copt "-Wno-gcc-compat"
 build --copt "-Wno-nullability-extension" --host_copt "-Wno-nullability-extension"
 
+# The warning acceptance bar in CI for PRs is set by -Werror of a specific
+# version of some chosen compiler. Disable warnings from other compilers until
+# they are fixed and under CI -Werror acceptance critera as there is nothing the
+# developers can(they can't be reproduced locally or in CI) or should do about
+# these warnings in code they are not working on.
+build --copt "-Wno-unused-private-field"  --host_copt "-Wno-unused-private-field"
+build --copt "-Wno-cast-function-type-mismatch"  --host_copt "-Wno-cast-function-type-mismatch"
+build --copt "-Wunused-but-set-variable"  --host_copt "-Wunused-but-set-variable"
+
 # For 3rd party code: Disable warnings entirely.
 # They are not actionable and just create noise.
 build --per_file_copt=external/.*@-w

--- a/.bazelrc
+++ b/.bazelrc
@@ -37,7 +37,7 @@ build --copt "-Wno-nullability-extension" --host_copt "-Wno-nullability-extensio
 # these warnings in code they are not working on.
 build --copt "-Wno-unused-private-field"  --host_copt "-Wno-unused-private-field"
 build --copt "-Wno-cast-function-type-mismatch"  --host_copt "-Wno-cast-function-type-mismatch"
-build --copt "-Wunused-but-set-variable"  --host_copt "-Wunused-but-set-variable"
+build --copt "-Wno-unused-but-set-variable"  --host_copt "-Wno-unused-but-set-variable"
 
 # For 3rd party code: Disable warnings entirely.
 # They are not actionable and just create noise.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -101,6 +101,8 @@ OPENROAD_COPTS = [
     "-Wformat-security",
     "-Wno-sign-compare",
     "-Wno-unused-parameter",
+    # FIXME reenable when warnings are fixed
+    "-Wno-unused-but-set-variable",
 ]
 
 OPENROAD_DEFINES = [


### PR DESCRIPTION
`bazelisk build -c opt :openroad` clean of warnings.

A starting point for further refinement and collaboration.

Further refinements: hook up bazel -Werror in CI to avoid regressions and later to fix warnings and re-enable disabled warnings that are useful.