### PR TITLE
Delete LUT

### DIFF
--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "SteinerTreeBuilder.h"
+#include "boost/multi_array.hpp"
 
 #pragma once
 
@@ -32,7 +33,7 @@ class Flute
   struct csoln;
 
  private:
-  using LUT_TYPE = struct csoln***;
+  using LUT_TYPE = boost::multi_array<std::shared_ptr<struct csoln[]>, 2>*;
   using NUMSOLN_TYPE = int**;
 
  public:

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -34,6 +34,7 @@ class Flute
  private:
   using LUT_TYPE = struct csoln***;
   using NUMSOLN_TYPE = int**;
+  using LUT_ALLOC_TYPE = bool**;
 
  public:
   Flute() = default;
@@ -59,11 +60,11 @@ class Flute
 
  private:
   void readLUT();
-  void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln);
-  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln);
+  void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc);
+  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln);
+  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete);
 
   int flute_wl(int d,
                const std::vector<int>& x,
@@ -166,6 +167,7 @@ class Flute
   // Dynamically allocate LUTs.
   LUT_TYPE LUT = nullptr;
   NUMSOLN_TYPE numsoln = nullptr;
+  LUT_ALLOC_TYPE LUT_alloc = nullptr;
   // LUTs are initialized to this order at startup.
   const int lut_initial_d = 8;
   int lut_valid_d = 0;

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -64,7 +64,7 @@ class Flute
   void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, bool use_delete);
+  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete);
 
   int flute_wl(int d,
                const std::vector<int>& x,

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -61,10 +61,16 @@ class Flute
  private:
   void readLUT();
   void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc);
-  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
+  void initLUT(int to_d,
+               LUT_TYPE LUT,
+               NUMSOLN_TYPE numsoln,
+               LUT_ALLOC_TYPE LUT_alloc);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, bool use_delete);
+  void deleteLUT(LUT_TYPE& LUT,
+                 NUMSOLN_TYPE& numsoln,
+                 LUT_ALLOC_TYPE LUT_alloc,
+                 bool use_delete);
 
   int flute_wl(int d,
                const std::vector<int>& x,

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -64,7 +64,7 @@ class Flute
   void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete);
+  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, bool use_delete);
 
   int flute_wl(int d,
                const std::vector<int>& x,

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -61,16 +61,10 @@ class Flute
  private:
   void readLUT();
   void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc);
-  void initLUT(int to_d,
-               LUT_TYPE LUT,
-               NUMSOLN_TYPE numsoln,
-               LUT_ALLOC_TYPE LUT_alloc);
+  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT,
-                 NUMSOLN_TYPE& numsoln,
-                 LUT_ALLOC_TYPE LUT_alloc,
-                 bool use_delete);
+  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, bool use_delete);
 
   int flute_wl(int d,
                const std::vector<int>& x,

--- a/src/stt/include/stt/flute.h
+++ b/src/stt/include/stt/flute.h
@@ -34,7 +34,6 @@ class Flute
  private:
   using LUT_TYPE = struct csoln***;
   using NUMSOLN_TYPE = int**;
-  using LUT_ALLOC_TYPE = bool**;
 
  public:
   Flute() = default;
@@ -60,11 +59,11 @@ class Flute
 
  private:
   void readLUT();
-  void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc);
-  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc);
+  void makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln);
+  void initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln);
   void ensureLUT(int d);
   void deleteLUT();
-  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete);
+  void deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln);
 
   int flute_wl(int d,
                const std::vector<int>& x,
@@ -167,7 +166,6 @@ class Flute
   // Dynamically allocate LUTs.
   LUT_TYPE LUT = nullptr;
   NUMSOLN_TYPE numsoln = nullptr;
-  LUT_ALLOC_TYPE LUT_alloc = nullptr;
   // LUTs are initialized to this order at startup.
   const int lut_initial_d = 8;
   int lut_valid_d = 0;

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -74,7 +74,6 @@ static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
 {
   unsigned char charnum[256], line[32], *linep, c;
   FILE *fpwv, *fprt;
-  struct csoln* p;
   int d, i, j, k, kk, ns, nn;
 
   for (i = 0; i <= 255; i++) {
@@ -118,8 +117,7 @@ static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
       } else {
         fgetc(fpwv);  // '\n'
         numsoln[d][k] = ns;
-        p = new struct csoln[ns];
-        (*LUT)[d][k] = std::shared_ptr<struct csoln[]>(p);
+        auto p = std::make_shared<struct csoln[]>(ns);
         for (i = 1; i <= ns; i++) {
           linep = (unsigned char*) fgets((char*) line, 32, fpwv);
           p->parent = charnum[*(linep++)];
@@ -147,6 +145,7 @@ static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
 #endif
           p++;
         }
+        (*LUT)[d][k] = std::move(p);
       }
     }
   }

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -70,7 +70,7 @@ inline T ADIFF(T x, T y)
 ////////////////////////////////////////////////////////////////
 
 #if LUT_SOURCE == LUT_FILE || LUT_SOURCE == LUT_VAR_CHECK
-static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
+static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
 {
   unsigned char charnum[256], line[32], *linep, c;
   FILE *fpwv, *fprt;
@@ -115,12 +115,10 @@ static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_
         fgetc(fpwv);  // '/n'
         numsoln[d][k] = numsoln[d][kk];
         LUT[d][k] = LUT[d][kk];
-        LUT_alloc[d][k] = false;
       } else {
         fgetc(fpwv);  // '\n'
         numsoln[d][k] = ns;
         p = (struct csoln*) malloc(ns * sizeof(struct csoln));
-        LUT_alloc[d][k] = true;
         LUT[d][k] = p;
         for (i = 1; i <= ns; i++) {
           linep = (unsigned char*) fgets((char*) line, 32, fpwv);
@@ -173,59 +171,46 @@ extern const char* powv9[];
 
 void Flute::readLUT()
 {
-  makeLUT(LUT, numsoln, LUT_alloc);
+  makeLUT(LUT, numsoln);
 
 #if LUT_SOURCE == LUT_FILE
-  readLUTfiles(LUT, numsoln, LUT_alloc);
+  readLUTfiles(LUT, numsoln);
   lut_valid_d = FLUTE_D;
 
 #elif LUT_SOURCE == LUT_VAR
   // Only init to d=8 on startup because d=9 is big and slow.
-  initLUT(lut_initial_d, LUT, numsoln, LUT_alloc);
+  initLUT(lut_initial_d, LUT, numsoln);
 
 #elif LUT_SOURCE == LUT_VAR_CHECK
-  readLUTfiles(LUT, numsoln, LUT_alloc);
+  readLUTfiles(LUT, numsoln);
   // Temporaries to compare to file results.
   LUT_TYPE LUT_;
   NUMSOLN_TYPE numsoln_;
-  LUT_ALLOC_TYPE LUT_alloc_;
-  makeLUT(LUT_, numsoln_, LUT_alloc_);
-  initLUT(FLUTE_D, LUT_, numsoln_, LUT_alloc_);
+  makeLUT(LUT_, numsoln_);
+  initLUT(FLUTE_D, LUT_, numsoln_);
   checkLUT(LUT, numsoln, LUT_, numsoln_);
-  deleteLUT(LUT_, numsoln_, LUT_alloc_, true);
 #endif
 }
 
-void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc)
+void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln)
 {
   LUT = new struct csoln**[FLUTE_D + 1];
   numsoln = new int*[FLUTE_D + 1];
-  LUT_alloc = new bool*[FLUTE_D + 1];
   for (int d = 4; d <= FLUTE_D; d++) {
     LUT[d] = new struct csoln*[MGROUP];
     numsoln[d] = new int[MGROUP];
-    LUT_alloc[d] = new bool[MGROUP];
   }
 }
 
 void Flute::deleteLUT()
 {
-  deleteLUT(LUT, numsoln, LUT_alloc, LUT_SOURCE == LUT_VAR);
+  deleteLUT(LUT, numsoln);
 }
 
-void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
+void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln)
 {
   if (LUT) {
     for (int d = 4; d <= FLUTE_D; d++) {
-      for (int k = 0; k < MGROUP; k++) {
-        if (LUT_alloc[d][k]) {
-          if (use_delete) {
-            delete[] LUT[d][k];
-          } else {
-            free(LUT[d][k]);
-          }
-        }
-      }
       delete[] LUT[d];
       delete[] numsoln[d];
     }
@@ -265,7 +250,7 @@ inline const char* readDecimalInt(const char* s, int& value)
 }
 
 // Init LUTs from base64 encoded string variables.
-void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
+void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
 {
   std::string pwv_string = utl::base64_decode(powv9);
   const char* pwv = pwv_string.c_str();
@@ -293,12 +278,10 @@ void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE
         pwv = readDecimalInt(pwv, kk) + 1;
         numsoln[d][k] = numsoln[d][kk];
         LUT[d][k] = LUT[d][kk];
-        LUT_alloc[d][k] = false;
       } else {
         pwv++;  // '\n'
         numsoln[d][k] = ns;
         struct csoln* p = new struct csoln[ns];
-        LUT_alloc[d][k] = true;
         LUT[d][k] = p;
         for (int i = 1; i <= ns; i++) {
           p->parent = charNum(*pwv++);
@@ -349,7 +332,7 @@ void Flute::ensureLUT(int d)
     readLUT();
   }
   if (d > lut_valid_d && d <= FLUTE_D) {
-    initLUT(FLUTE_D, LUT, numsoln, LUT_alloc);
+    initLUT(FLUTE_D, LUT, numsoln);
   }
 }
 

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -196,7 +196,7 @@ void Flute::readLUT()
 #endif
 }
 
-void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc)
+void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc)
 {
   LUT = new struct csoln**[FLUTE_D + 1];
   numsoln = new int*[FLUTE_D + 1];

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -70,9 +70,7 @@ inline T ADIFF(T x, T y)
 ////////////////////////////////////////////////////////////////
 
 #if LUT_SOURCE == LUT_FILE || LUT_SOURCE == LUT_VAR_CHECK
-static void readLUTfiles(LUT_TYPE LUT,
-                         NUMSOLN_TYPE numsoln,
-                         LUT_ALLOC_TYPE LUT_alloc)
+static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
 {
   unsigned char charnum[256], line[32], *linep, c;
   FILE *fpwv, *fprt;
@@ -198,9 +196,7 @@ void Flute::readLUT()
 #endif
 }
 
-void Flute::makeLUT(LUT_TYPE& LUT,
-                    NUMSOLN_TYPE& numsoln,
-                    LUT_ALLOC_TYPE& LUT_alloc)
+void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc)
 {
   LUT = new struct csoln**[FLUTE_D + 1];
   numsoln = new int*[FLUTE_D + 1];
@@ -217,10 +213,7 @@ void Flute::deleteLUT()
   deleteLUT(LUT, numsoln, LUT_alloc, LUT_SOURCE == LUT_VAR);
 }
 
-void Flute::deleteLUT(LUT_TYPE& LUT,
-                      NUMSOLN_TYPE& numsoln,
-                      LUT_ALLOC_TYPE LUT_alloc,
-                      const bool use_delete)
+void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
 {
   if (LUT) {
     for (int d = 4; d <= FLUTE_D; d++) {
@@ -272,10 +265,7 @@ inline const char* readDecimalInt(const char* s, int& value)
 }
 
 // Init LUTs from base64 encoded string variables.
-void Flute::initLUT(int to_d,
-                    LUT_TYPE LUT,
-                    NUMSOLN_TYPE numsoln,
-                    LUT_ALLOC_TYPE LUT_alloc)
+void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
 {
   std::string pwv_string = utl::base64_decode(powv9);
   const char* pwv = pwv_string.c_str();

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -196,7 +196,7 @@ void Flute::readLUT()
 #endif
 }
 
-void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc)
+void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc)
 {
   LUT = new struct csoln**[FLUTE_D + 1];
   numsoln = new int*[FLUTE_D + 1];

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -213,7 +213,7 @@ void Flute::deleteLUT()
   deleteLUT(LUT, numsoln, LUT_alloc, LUT_SOURCE == LUT_VAR);
 }
 
-void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
+void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
 {
   if (LUT) {
     for (int d = 4; d <= FLUTE_D; d++) {

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -70,7 +70,9 @@ inline T ADIFF(T x, T y)
 ////////////////////////////////////////////////////////////////
 
 #if LUT_SOURCE == LUT_FILE || LUT_SOURCE == LUT_VAR_CHECK
-static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
+static void readLUTfiles(LUT_TYPE LUT,
+                         NUMSOLN_TYPE numsoln,
+                         LUT_ALLOC_TYPE LUT_alloc)
 {
   unsigned char charnum[256], line[32], *linep, c;
   FILE *fpwv, *fprt;
@@ -196,7 +198,9 @@ void Flute::readLUT()
 #endif
 }
 
-void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE& LUT_alloc)
+void Flute::makeLUT(LUT_TYPE& LUT,
+                    NUMSOLN_TYPE& numsoln,
+                    LUT_ALLOC_TYPE& LUT_alloc)
 {
   LUT = new struct csoln**[FLUTE_D + 1];
   numsoln = new int*[FLUTE_D + 1];
@@ -213,7 +217,10 @@ void Flute::deleteLUT()
   deleteLUT(LUT, numsoln, LUT_alloc, LUT_SOURCE == LUT_VAR);
 }
 
-void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
+void Flute::deleteLUT(LUT_TYPE& LUT,
+                      NUMSOLN_TYPE& numsoln,
+                      LUT_ALLOC_TYPE LUT_alloc,
+                      const bool use_delete)
 {
   if (LUT) {
     for (int d = 4; d <= FLUTE_D; d++) {
@@ -265,7 +272,10 @@ inline const char* readDecimalInt(const char* s, int& value)
 }
 
 // Init LUTs from base64 encoded string variables.
-void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln, LUT_ALLOC_TYPE LUT_alloc)
+void Flute::initLUT(int to_d,
+                    LUT_TYPE LUT,
+                    NUMSOLN_TYPE numsoln,
+                    LUT_ALLOC_TYPE LUT_alloc)
 {
   std::string pwv_string = utl::base64_decode(powv9);
   const char* pwv = pwv_string.c_str();

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -213,7 +213,7 @@ void Flute::deleteLUT()
   deleteLUT(LUT, numsoln, LUT_alloc, LUT_SOURCE == LUT_VAR);
 }
 
-void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
+void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln, const LUT_ALLOC_TYPE LUT_alloc, const bool use_delete)
 {
   if (LUT) {
     for (int d = 4; d <= FLUTE_D; d++) {

--- a/src/stt/src/flt/flute.cpp
+++ b/src/stt/src/flt/flute.cpp
@@ -114,12 +114,12 @@ static void readLUTfiles(LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
         fscanf(fpwv, "%d", &kk);
         fgetc(fpwv);  // '/n'
         numsoln[d][k] = numsoln[d][kk];
-        LUT[d][k] = LUT[d][kk];
+        (*LUT)[d][k] = (*LUT)[d][kk];
       } else {
         fgetc(fpwv);  // '\n'
         numsoln[d][k] = ns;
-        p = (struct csoln*) malloc(ns * sizeof(struct csoln));
-        LUT[d][k] = p;
+        p = new struct csoln[ns];
+        (*LUT)[d][k] = std::shared_ptr<struct csoln[]>(p);
         for (i = 1; i <= ns; i++) {
           linep = (unsigned char*) fgets((char*) line, 32, fpwv);
           p->parent = charnum[*(linep++)];
@@ -189,15 +189,16 @@ void Flute::readLUT()
   makeLUT(LUT_, numsoln_);
   initLUT(FLUTE_D, LUT_, numsoln_);
   checkLUT(LUT, numsoln, LUT_, numsoln_);
+  deleteLUT(LUT_, numsoln_);
 #endif
 }
 
 void Flute::makeLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln)
 {
-  LUT = new struct csoln**[FLUTE_D + 1];
+  LUT = new boost::multi_array<std::shared_ptr<struct csoln[]>, 2>(
+      boost::extents[FLUTE_D + 1][MGROUP]);
   numsoln = new int*[FLUTE_D + 1];
   for (int d = 4; d <= FLUTE_D; d++) {
-    LUT[d] = new struct csoln*[MGROUP];
     numsoln[d] = new int[MGROUP];
   }
 }
@@ -210,13 +211,11 @@ void Flute::deleteLUT()
 void Flute::deleteLUT(LUT_TYPE& LUT, NUMSOLN_TYPE& numsoln)
 {
   if (LUT) {
+    delete LUT;
     for (int d = 4; d <= FLUTE_D; d++) {
-      delete[] LUT[d];
       delete[] numsoln[d];
     }
     delete[] numsoln;
-    delete[] LUT;
-    LUT = nullptr;
   }
 }
 
@@ -277,12 +276,12 @@ void Flute::initLUT(int to_d, LUT_TYPE LUT, NUMSOLN_TYPE numsoln)
         int kk;
         pwv = readDecimalInt(pwv, kk) + 1;
         numsoln[d][k] = numsoln[d][kk];
-        LUT[d][k] = LUT[d][kk];
+        (*LUT)[d][k] = (*LUT)[d][kk];
       } else {
         pwv++;  // '\n'
         numsoln[d][k] = ns;
         struct csoln* p = new struct csoln[ns];
-        LUT[d][k] = p;
+        (*LUT)[d][k] = std::shared_ptr<struct csoln[]>(p);
         for (int i = 1; i <= ns; i++) {
           p->parent = charNum(*pwv++);
 
@@ -348,8 +347,8 @@ static void checkLUT(LUT_TYPE LUT1,
       int ns2 = numsoln2[d][k];
       if (ns1 != ns2)
         printf("numsoln[%d][%d] mismatch\n", d, k);
-      struct csoln* soln1 = LUT1[d][k];
-      struct csoln* soln2 = LUT2[d][k];
+      struct csoln* soln1 = LUT1[d][k].get();
+      struct csoln* soln2 = LUT2[d][k].get();
       if (soln1->parent != soln2->parent)
         printf("LUT[%d][%d]->parent mismatch\n", d, k);
       for (int j = 0; soln1->seg[j] != 0; j++) {
@@ -573,7 +572,7 @@ int Flute::flutes_wl_LD(int d,
     }
 
     minl = l[0] = xs[d - 1] - xs[0] + ys[d - 1] - ys[0];
-    rlist = LUT[d][k];
+    rlist = (*LUT)[d][k].get();
     for (i = 0; rlist->seg[i] > 0; i++) {
       minl += dd[rlist->seg[i]];
     }
@@ -1135,7 +1134,7 @@ Tree Flute::flutes_LD(int d,
     }
 
     minl = l[0] = xs[d - 1] - xs[0] + ys[d - 1] - ys[0];
-    rlist = LUT[d][k];
+    rlist = (*LUT)[d][k].get();
     for (i = 0; rlist->seg[i] > 0; i++) {
       minl += dd[rlist->seg[i]];
     }


### PR DESCRIPTION
Correctly delete LUT.

A better solution I'd prefer would imply using shared_ptr, however I'm unsure whether they work correctly with struct arrays, and in `readLUTfiles` `malloc` is used instead of `new[]`, which is why I went with manually tracking the allocations