### PR TITLE
gui: add CTS renderer controls and fix display options

### DIFF
--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -47,11 +47,16 @@ namespace gui {
 ClockTreeRenderer::ClockTreeRenderer(ClockTree* tree)
     : tree_(tree), max_depth_(1), path_to_(nullptr)
 {
+  addDisplayControl(render_label_, true);
 }
 
 void ClockTreeRenderer::drawObjects(Painter& painter)
 {
   if (tree_ == nullptr) {
+    return;
+  }
+
+  if (!checkDisplayControl(render_label_)) {
     return;
   }
 

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -67,6 +67,7 @@ class ClockTreeRenderer : public Renderer
   odb::dbITerm* path_to_;
 
   static constexpr int pen_width_ = 2;
+  static constexpr const char* render_label_ = "Clock trees";
 
   void drawTree(Painter& painter,
                 const Descriptor* descriptor,

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1241,8 +1241,20 @@ void DisplayControls::save()
 
 void DisplayControls::restore()
 {
+  // Collect current controls in case some were removed after save was called.
+  std::map<std::string, QStandardItem*> all_controls;
+  collectControls(model_->invisibleRootItem(), Visible, all_controls);
+  collectControls(model_->invisibleRootItem(), Selectable, all_controls);
+  std::set<QStandardItem*> controls;
+
+  for (auto& [control_name, control] : all_controls) {
+    controls.insert(control);
+  }
+
   for (auto& [control, state] : saved_state_) {
-    control->setCheckState(state);
+    if (controls.find(control) != controls.end()) {
+      control->setCheckState(state);
+    }
   }
 }
 

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -267,6 +267,8 @@ DisplayControls::DisplayControls(QWidget* parent)
 
   auto* root = model_->invisibleRootItem();
 
+  custom_controls_start_ = -1;
+
   auto layers
       = makeParentItem(layers_group_, "Layers", root, Qt::Checked, true);
   view_->expand(layers->index());
@@ -535,6 +537,9 @@ DisplayControls::DisplayControls(QWidget* parent)
 
   connect(
       this, &DisplayControls::colorChanged, this, &DisplayControls::changed);
+
+  custom_controls_start_ = root->rowCount();
+
   // register renderers
   if (gui::Gui::get() != nullptr) {
     for (auto renderer : gui::Gui::get()->renderers()) {
@@ -1924,6 +1929,7 @@ void DisplayControls::registerRenderer(Renderer* renderer)
     }
 
     auto& add_rows = custom_controls_[renderer];
+
     add_rows.insert(add_rows.begin(), rows.begin(), rows.end());
   }
 
@@ -1934,6 +1940,22 @@ void DisplayControls::registerRenderer(Renderer* renderer)
     if (setting != custom_controls_settings_.end()) {
       renderer->setSettings(setting->second);
     }
+  }
+
+  // Sort custom_controls
+  std::vector<QList<QStandardItem*>> custom_controls;
+  while (model_->invisibleRootItem()->rowCount() > custom_controls_start_) {
+    custom_controls.push_back(
+        model_->takeRow(model_->invisibleRootItem()->rowCount() - 1));
+  }
+  std::stable_sort(custom_controls.begin(),
+                   custom_controls.end(),
+                   [](const QList<QStandardItem*>& list0,
+                      const QList<QStandardItem*>& list1) {
+                     return list0[Name]->text() < list1[Name]->text();
+                   });
+  for (const auto& row : custom_controls) {
+    model_->appendRow(row);
   }
 }
 

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -531,6 +531,7 @@ class DisplayControls : public QDockWidget,
 
   std::map<const odb::dbTechLayer*, ModelRow> layer_controls_;
   std::map<const odb::dbSite*, ModelRow> site_controls_;
+  int custom_controls_start_;
   std::map<Renderer*, std::vector<ModelRow>> custom_controls_;
   std::map<std::string, Renderer::Settings> custom_controls_settings_;
   std::map<QStandardItem*, Qt::CheckState> saved_state_;


### PR DESCRIPTION
Adds:
- CTS widget renderer option in display controls to disable or enable the rendering

Fixes:
- segfault in display controls restore when custom controls have been removed from the widget before restore is called
- order the custom controls at the bottom of the display controls option in alphabetical order to avoid options showing up out of order depending on the order the renderers were enabled.