### PR TITLE
Hier fix in split load

### DIFF
--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -996,8 +996,9 @@ int BufferMove::rebufferTopDown(const BufferedNetPtr& choice,
         // add the modnet to the new output
         buffer_op_iterm->disconnect();
 
+        // hierarchy fix: simultaneously connect flat and hieararchical net
+        // to force reassociation
         db_network_->connectPin(buffer_op_pin, (Net*) net2, (Net*) mod_net_in);
-        //        buffer_op_iterm->connect(mod_net_in);
       }
 
       const int buffer_count = rebufferTopDown(
@@ -1110,7 +1111,6 @@ int BufferMove::rebufferTopDown(const BufferedNetPtr& choice,
           } else if (db_mod_net) {  // input hierarchical net
             db_network_->connectPin(
                 const_cast<Pin*>(load_pin), (Net*) db_net, (Net*) db_mod_net);
-
           } else {  // flat case
             load_iterm->connect(db_net);
           }

--- a/src/rsz/src/SplitLoadMove.cc
+++ b/src/rsz/src/SplitLoadMove.cc
@@ -197,11 +197,8 @@ bool SplitLoadMove::doMove(const Path* drvr_path,
     Vertex* load_vertex = fanout_slack.first;
     Pin* load_pin = load_vertex->pin();
 
-    odb::dbITerm* load_iterm;
-    odb::dbBTerm* load_bterm;
-    odb::dbModITerm* load_moditerm;
-
-    db_network_->staToDb(load_pin, load_iterm, load_bterm, load_moditerm);
+    odb::dbITerm* load_iterm = nullptr;
+    load_iterm = db_network_->flatPin(load_pin);
 
     // Leave ports connected to original net so verilog port names are
     // preserved.
@@ -235,10 +232,14 @@ bool SplitLoadMove::doMove(const Path* drvr_path,
                                            unique_connection_name.c_str());
         }
       } else {
-        odb::dbITerm* iterm;
-        iterm = db_network_->flatPin(load_pin);
-        if (iterm && db_mod_load_net) {
-          iterm->connect(db_mod_load_net);
+        if (load_iterm && db_mod_load_net) {
+          // For hierarchical case, we simultaneously connect the
+          // hierarchical net and the modnet to make sure they
+          // get reassociated. (so all modnet pins refer to flat net).
+          load_iterm->disconnect();
+          db_network_->connectPin(
+              load_pin, (Net*) out_net, (Net*) db_mod_load_net);
+          //          iterm->connect(db_mod_load_net);
         }
       }
     }


### PR DESCRIPTION
fix in splitLoadHier to make sure hier/flat nets correctly associated.
Replaced individual connection to hier net with simultaneous flat-net/hier-net call (makes pins on modnet refer to flat net).