### PR TITLE
upf: add missing port in upf tests

### DIFF
--- a/src/upf/test/data/mpd_top/mpd_top.upf
+++ b/src/upf/test/data/mpd_top/mpd_top.upf
@@ -8,6 +8,7 @@ create_power_domain PD_AES_2 \
   -elements {u_aes_2} \
 
 create_logic_port power_down_aes_1 -direction in
+create_logic_port power_down_aes_2 -direction in
 
 create_power_switch psw_aes_1 \
   -domain PD_AES_1 \

--- a/src/upf/test/data/mpd_top/mpd_top_combined.upf
+++ b/src/upf/test/data/mpd_top/mpd_top_combined.upf
@@ -8,6 +8,7 @@ create_power_domain PD_AES_2 \
   -elements {u_aes_2} \
 
 create_logic_port power_down_aes_1 -direction in
+create_logic_port power_down_aes_2 -direction in
 
 create_power_switch psw_aes_1 \
   -domain PD_AES_1 \

--- a/src/upf/test/write.upfok
+++ b/src/upf/test/write.upfok
@@ -15,6 +15,8 @@ create_power_domain PD_AES_2 \
 #############
 create_logic_port power_down_aes_1 \
   -direction in
+create_logic_port power_down_aes_2 \
+  -direction in
 create_logic_port isolaten_aes_1 \
   -direction in
 

--- a/test/upf/mpd_aes.upf
+++ b/test/upf/mpd_aes.upf
@@ -8,6 +8,7 @@ create_power_domain PD_AES_2 \
   -elements {u_aes_2} \
 
 create_logic_port power_down_aes_1 -direction in
+create_logic_port power_down_aes_2 -direction in
 
 create_power_switch psw_aes_1 \
   -domain PD_AES_1 \

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -5,9 +5,9 @@
 Found 0 macro blocks.
 Using 2 tracks default min distance between IO pins.
 [INFO PPL-0001] Number of available slots 4940
-[INFO PPL-0002] Number of I/O             394
+[INFO PPL-0002] Number of I/O             395
 [INFO PPL-0003] Number of I/O w/sink      391
-[INFO PPL-0004] Number of I/O w/o sink    3
+[INFO PPL-0004] Number of I/O w/o sink    4
 [INFO PPL-0005] Slots per section         200
 [INFO PPL-0008] Successfully assigned pins to sections.
 [INFO PPL-0012] I/O nets HPWL: 291688.94 um.
@@ -18,8 +18,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0007] Movable instances:               17661
 [INFO GPL-0008] Fixed instances:                     0
 [INFO GPL-0009] Dummy instances:                   218
-[INFO GPL-0010] Number of nets:                  51670
-[INFO GPL-0011] Number of pins:                 199033
+[INFO GPL-0010] Number of nets:                  51671
+[INFO GPL-0011] Number of pins:                 199034
 [INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1358.995 1358.995 ) um
 [INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 1356.540 1354.560 ) um
 [INFO GPL-0016] Core area:                  1830715.802 um^2
@@ -32,8 +32,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0007] Movable instances:               16862
 [INFO GPL-0008] Fixed instances:                     0
 [INFO GPL-0009] Dummy instances:                   497
-[INFO GPL-0010] Number of nets:                  51670
-[INFO GPL-0011] Number of pins:                 199033
+[INFO GPL-0010] Number of nets:                  51671
+[INFO GPL-0011] Number of pins:                 199034
 [INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1358.995 1358.995 ) um
 [INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 1356.540 1354.560 ) um
 [INFO GPL-0016] Core area:                  1830715.802 um^2
@@ -46,8 +46,8 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0007] Movable instances:               16862
 [INFO GPL-0008] Fixed instances:                     0
 [INFO GPL-0009] Dummy instances:                   497
-[INFO GPL-0010] Number of nets:                  51670
-[INFO GPL-0011] Number of pins:                 199033
+[INFO GPL-0010] Number of nets:                  51671
+[INFO GPL-0011] Number of pins:                 199034
 [INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 1358.995 1358.995 ) um
 [INFO GPL-0013] Core BBox: (  2.300  2.720 ) ( 1356.540 1354.560 ) um
 [INFO GPL-0016] Core area:                  1830715.802 um^2
@@ -258,7 +258,7 @@ delta HPWL                    5 %
 Detailed placement improvement.
 [INFO DPL-0401] Setting random seed to 1.
 [INFO DPL-0402] Setting maximum displacement 0 0 to 2708480 2708480 units.
-[INFO DPL-0320] Collected 612 fixed cells.
+[INFO DPL-0320] Collected 613 fixed cells.
 [INFO DPL-0318] Collected 51385 single height cells.
 [INFO DPL-0321] Collected 0 wide cells.
 [INFO DPL-0322] Image (2300, 2720) - (1356540, 1354560)


### PR DESCRIPTION
Closes #7363.

Add missing port in upf tests.