### PR TITLE
Io labels

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -444,8 +444,9 @@ DisplayControls::DisplayControls(QWidget* parent)
                shape_types_srouting,
                Qt::Checked);
   makeLeafItem(shape_types_.pins, "Pins", shape_types, Qt::Checked);
+  makeLeafItem(shape_types_.pin_names, "Pin Names", shape_types, Qt::Checked);
   pin_markers_font_ = QApplication::font();  // use default font
-  setNameItemDoubleClickAction(shape_types_.pins, [this]() {
+  setNameItemDoubleClickAction(shape_types_.pin_names, [this]() {
     pin_markers_font_ = QFontDialog::getFont(
         nullptr, pin_markers_font_, this, "Pin marker font");
   });
@@ -1828,6 +1829,11 @@ bool DisplayControls::isGCellGridVisible() const
 bool DisplayControls::areIOPinsVisible() const
 {
   return isModelRowVisible(&shape_types_.pins);
+}
+
+bool DisplayControls::areIOPinNamesVisible() const
+{
+  return isModelRowVisible(&shape_types_.pin_names);
 }
 
 bool DisplayControls::areRoutingSegmentsVisible() const

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1855,7 +1855,7 @@ bool DisplayControls::areFillsVisible() const
   return isModelRowVisible(&shape_types_.fill);
 }
 
-QFont DisplayControls::pinMarkersFont() const
+QFont DisplayControls::ioPinMarkersFont() const
 {
   return pin_markers_font_;
 }

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -209,7 +209,7 @@ class DisplayControls : public QDockWidget,
   bool areSpecialRoutingSegmentsVisible() const override;
   bool areSpecialRoutingViasVisible() const override;
   bool areFillsVisible() const override;
-  QFont pinMarkersFont() const override;
+  QFont ioPinMarkersFont() const override;
 
   QColor rulerColor() override;
   QFont rulerFont() override;

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -204,12 +204,14 @@ class DisplayControls : public QDockWidget,
   bool areNonPrefTracksVisible() override;
 
   bool areIOPinsVisible() const override;
+  bool areIOPinNamesVisible() const override;
+  QFont ioPinMarkersFont() const override;
+
   bool areRoutingSegmentsVisible() const override;
   bool areRoutingViasVisible() const override;
   bool areSpecialRoutingSegmentsVisible() const override;
   bool areSpecialRoutingViasVisible() const override;
   bool areFillsVisible() const override;
-  QFont ioPinMarkersFont() const override;
 
   QColor rulerColor() override;
   QFont rulerFont() override;
@@ -395,6 +397,11 @@ class DisplayControls : public QDockWidget,
     ModelRow vias;
   };
 
+  struct IOPinModels
+  {
+    ModelRow names;
+  };
+
   struct ShapeTypeModels
   {
     ModelRow routing_group;
@@ -402,6 +409,7 @@ class DisplayControls : public QDockWidget,
     ModelRow special_routing_group;
     RoutingModels special_routing;
     ModelRow pins;
+    ModelRow pin_names;
     ModelRow fill;
   };
 

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -56,12 +56,13 @@ class Options
   virtual bool areNonPrefTracksVisible() = 0;
 
   virtual bool areIOPinsVisible() const = 0;
+  virtual QFont ioPinMarkersFont() const = 0;
+
   virtual bool areRoutingSegmentsVisible() const = 0;
   virtual bool areRoutingViasVisible() const = 0;
   virtual bool areSpecialRoutingSegmentsVisible() const = 0;
   virtual bool areSpecialRoutingViasVisible() const = 0;
   virtual bool areFillsVisible() const = 0;
-  virtual QFont pinMarkersFont() const = 0;
 
   virtual QColor rulerColor() = 0;
   virtual QFont rulerFont() = 0;

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -56,6 +56,7 @@ class Options
   virtual bool areNonPrefTracksVisible() = 0;
 
   virtual bool areIOPinsVisible() const = 0;
+  virtual bool areIOPinNamesVisible() const = 0;
   virtual QFont ioPinMarkersFont() const = 0;
 
   virtual bool areRoutingSegmentsVisible() const = 0;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1483,7 +1483,7 @@ void RenderThread::setupIOPins(odb::dbBlock* block, const odb::Rect& bounds)
   const double abs_min_dim = 8.0;  // prevent markers from falling apart
   pin_max_size_ = std::max(scale_factor * die_max_dim, abs_min_dim);
 
-  pin_font_ = viewer_->options_->pinMarkersFont();
+  pin_font_ = viewer_->options_->ioPinMarkersFont();
   const QFontMetrics font_metrics(pin_font_);
 
   QString largest_text;

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1562,6 +1562,9 @@ void RenderThread::drawIOPins(Painter& painter,
     return;
   }
 
+  const bool pin_draw_names
+      = pin_draw_names_ && viewer_->options_->areIOPinNamesVisible();
+
   const auto die_area = block->getDieArea();
 
   QPainter* qpainter = static_cast<GuiPainter&>(painter).getPainter();
@@ -1667,7 +1670,7 @@ void RenderThread::drawIOPins(Painter& painter,
 
     painter.drawRect(box->getBox());
 
-    if (pin_draw_names_) {
+    if (pin_draw_names) {
       Point text_anchor_pt = xfm.getOffset();
 
       auto text_anchor = Painter::BOTTOM_CENTER;


### PR DESCRIPTION
Closes #7387 

Adds:
- pin names control to bterms (mirrors instance name controls)
