### PR TITLE
gui: allow display pairs to disable another row and use for pin names  with pins

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -27,6 +27,7 @@
 Q_DECLARE_METATYPE(odb::dbTechLayer*);
 Q_DECLARE_METATYPE(odb::dbSite*);
 Q_DECLARE_METATYPE(std::function<void()>);
+Q_DECLARE_METATYPE(gui::DisplayControls::ModelRow*);
 
 namespace gui {
 
@@ -445,6 +446,8 @@ DisplayControls::DisplayControls(QWidget* parent)
                Qt::Checked);
   makeLeafItem(shape_types_.pins, "Pins", shape_types, Qt::Checked);
   makeLeafItem(shape_types_.pin_names, "Pin Names", shape_types, Qt::Checked);
+  shape_types_.pins.visible->setData(
+      QVariant::fromValue(&shape_types_.pin_names), disable_row_item_idx_);
   pin_markers_font_ = QApplication::font();  // use default font
   setNameItemDoubleClickAction(shape_types_.pin_names, [this]() {
     pin_markers_font_ = QFontDialog::getFont(
@@ -480,6 +483,9 @@ DisplayControls::DisplayControls(QWidget* parent)
                Qt::Unchecked,
                false,
                iterm_label_color_);
+  instance_shapes_.pins.visible->setData(
+      QVariant::fromValue(&instance_shapes_.iterm_labels),
+      disable_row_item_idx_);
   makeLeafItem(
       instance_shapes_.blockages, "Blockages", instance_shape, Qt::Checked);
   toggleParent(misc_.instances);
@@ -981,6 +987,20 @@ void DisplayControls::itemChanged(QStandardItem* item)
       if (check_item->checkState() == Qt::Checked) {
         check_item->setCheckState(Qt::Unchecked);
       }
+    }
+  }
+
+  // check disabled pair
+  auto disabled_row_pair = item->data(disable_row_item_idx_);
+  if (disabled_row_pair.isValid()) {
+    const ModelRow* row = disabled_row_pair.value<ModelRow*>();
+    row->name->setEnabled(checked);
+    row->swatch->setEnabled(checked);
+    if (row->visible) {
+      row->visible->setEnabled(checked);
+    }
+    if (row->selectable) {
+      row->selectable->setEnabled(checked);
     }
   }
 

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1078,6 +1078,11 @@ std::tuple<QColor*, Qt::BrushStyle*, bool> DisplayControls::lookupColor(
 
 void DisplayControls::displayItemDblClicked(const QModelIndex& index)
 {
+  if (!model_->itemFromIndex(index)->isEnabled()) {
+    // ignore disabled items
+    return;
+  }
+
   if (index.column() == 0) {
     auto name_item = model_->itemFromIndex(index);
 

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -141,6 +141,15 @@ class DisplayControls : public QDockWidget,
   Q_OBJECT
 
  public:
+  // One leaf (non-group) row in the model
+  struct ModelRow
+  {
+    QStandardItem* name = nullptr;
+    QStandardItem* swatch = nullptr;
+    QStandardItem* visible = nullptr;
+    QStandardItem* selectable = nullptr;  // may be null
+  };
+
   DisplayControls(QWidget* parent = nullptr);
   ~DisplayControls() override;
 
@@ -274,15 +283,6 @@ class DisplayControls : public QDockWidget,
     Swatch,
     Visible,
     Selectable
-  };
-
-  // One leaf (non-group) row in the model
-  struct ModelRow
-  {
-    QStandardItem* name = nullptr;
-    QStandardItem* swatch = nullptr;
-    QStandardItem* visible = nullptr;
-    QStandardItem* selectable = nullptr;  // may be null
   };
 
   // The *Models are groups in the tree
@@ -578,6 +578,7 @@ class DisplayControls : public QDockWidget,
   static constexpr int callback_item_idx_ = Qt::UserRole + 1;
   static constexpr int doubleclick_item_idx_ = Qt::UserRole + 2;
   static constexpr int exclusivity_item_idx_ = Qt::UserRole + 3;
+  static constexpr int disable_row_item_idx_ = Qt::UserRole + 4;
 };
 
 }  // namespace gui


### PR DESCRIPTION
Adds:
- disable controls for pin names when pins are not visible

When pins are visible:
![image](https://github.com/user-attachments/assets/c238110b-e803-4fa5-b803-1f71217a662f)

When pins are not visible:
![image](https://github.com/user-attachments/assets/5035afc4-68b6-4a0b-a0b5-6b67d3e6ff8a)
