### PR TITLE
bazel: fix bazelisk build -c opt dpl/src/... error

### DIFF
--- a/src/dpl/BUILD
+++ b/src/dpl/BUILD
@@ -120,4 +120,7 @@ tcl_wrap_cc(
     swig_includes = [
         "src/dpl/src",
     ],
+    deps = [
+        "//src/odb:swig",
+    ],
 )


### PR DESCRIPTION
Was a spot missed in c0fe03f9b4e?

```
$ bazelisk build -c opt src/dpl/...
ERROR: /home/oyvind/OpenROAD-flow-scripts/tools/OpenROAD/src/dpl/BUILD:111:12: Action src/dpl/swig.cc failed: (Exit 1): swig failed: error executing Action command (from target //src/dpl:swig) bazel-out/k8-opt-exec-ST-d57f47055a04/bin/external/org_swig/swig -tcl8 -c++ -module dpl -namespace -prefix dpl -Isrc/dpl/src/dpl/src -o bazel-out/k8-opt/bin/src/dpl/swig.cc src/dpl/src/Opendp.i

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
src/dpl/src/Opendp.i:18: Error: Unable to find 'dbtypes.i'
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 0.544s, Critical Path: 0.09s
INFO: 10 processes: 10 internal.
ERROR: Build did NOT complete successfully
```
