### PR TITLE
bazel: enable test/orfs tests

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,5 +2,3 @@ build/
 debug/
 src/sta/build/
 src/sta/debug/
-# delete line below when CI can handle it and it runs in minutes
-test/orfs/


### PR DESCRIPTION
CI won't be enabled until a more beefy machine is available and OpenMP is working, so simplify local testing by enabling all tests by default.