### PR TITLE
utl: pin to 0..bins-1

### DIFF
--- a/src/utl/src/histogram.cpp
+++ b/src/utl/src/histogram.cpp
@@ -96,6 +96,9 @@ int Histogram<DataType>::getBinIndex(DataType val) const
   if (bin >= bins) {  // Special case for val with the maximum value.
     bin = bins - 1;
   }
+  if (bin < 0) {
+    return 0;
+  }
 
   return bin;
 }


### PR DESCRIPTION
Fixes:
- index out of bounds on huge numbers (inf) that cause calculation to be `-1`.
