### PR TITLE
drt: warning 88 is now a debug print message

### DIFF
--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -1378,11 +1378,13 @@ int FlexPA::genPinAccess(T* pin, frInstTerm* inst_term)
                           router_cfg_->MINNUMACCESSPOINT_MACROCELLPIN))
              + " sparse access points";
     }
-    logger_->warn(DRT,
-                  88,
-                  "Access point generation for {} did not meet :{}",
-                  inst_term->getName(),
-                  unmet_requirements);
+    debugPrint(logger_,
+               utl::DRT,
+               "pin_access",
+               1,
+               "Access point generation for {} did not meet :{}",
+               inst_term->getName(),
+               unmet_requirements);
   }
 
   // inst_term aps are written back here if not early stopped

--- a/src/drt/test/ndr_vias1.ok
+++ b/src/drt/test/ndr_vias1.ok
@@ -38,8 +38,6 @@
 [INFO DRT-0033] met4 shape region query size = 0.
 [INFO DRT-0033] via4 shape region query size = 0.
 [INFO DRT-0033] met5 shape region query size = 0.
-[WARNING DRT-0088] Access point generation for _279_/A did not meet :
-	At least 3 sparse access points
 [INFO DRT-0178] Init guide query.
 [INFO DRT-0036] FR_MASTERSLICE guide region query size = 0.
 [INFO DRT-0036] FR_VIA guide region query size = 0.

--- a/src/drt/test/ndr_vias2.ok
+++ b/src/drt/test/ndr_vias2.ok
@@ -38,8 +38,6 @@
 [INFO DRT-0033] met4 shape region query size = 0.
 [INFO DRT-0033] via4 shape region query size = 0.
 [INFO DRT-0033] met5 shape region query size = 0.
-[WARNING DRT-0088] Access point generation for _279_/A did not meet :
-	At least 3 sparse access points
 [INFO DRT-0178] Init guide query.
 [INFO DRT-0036] FR_MASTERSLICE guide region query size = 0.
 [INFO DRT-0036] FR_VIA guide region query size = 0.

--- a/src/drt/test/ndr_vias3.ok
+++ b/src/drt/test/ndr_vias3.ok
@@ -44,8 +44,6 @@
 [INFO DRT-0033] met4 shape region query size = 0.
 [INFO DRT-0033] via4 shape region query size = 0.
 [INFO DRT-0033] met5 shape region query size = 0.
-[WARNING DRT-0088] Access point generation for _279_/A did not meet :
-	At least 3 sparse access points
 [INFO DRT-0178] Init guide query.
 [INFO DRT-0036] FR_MASTERSLICE guide region query size = 0.
 [INFO DRT-0036] FR_VIA guide region query size = 0.

--- a/src/grt/test/pin_access2.ok
+++ b/src/grt/test/pin_access2.ok
@@ -38,10 +38,6 @@
 [INFO DRT-0033] met4 shape region query size = 435.
 [INFO DRT-0033] via4 shape region query size = 0.
 [INFO DRT-0033] met5 shape region query size = 0.
-[WARNING DRT-0088] Access point generation for _331_/D did not meet :
-	At least 3 sparse access points
-[WARNING DRT-0088] Access point generation for _497_/A did not meet :
-	At least 3 sparse access points
 [INFO GRT-0020] Min routing layer: met1
 [INFO GRT-0021] Max routing layer: met5
 [INFO GRT-0022] Global adjustment: 50%


### PR DESCRIPTION
Fixes #7305.

Warning 88 is now a debug print, what it should have been from the start.