### PR TITLE
[DO NOT REVIEW]  Bazel or tools openmp

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -15,6 +15,8 @@ common --incompatible_disallow_empty_glob
 build --cxxopt "-std=c++17"        --host_cxxopt "-std=c++17"
 build --cxxopt "-xc++"             --host_cxxopt "-xc++"
 build --cxxopt "-ffp-contract=off" --host_cxxopt "-ffp-contract=off"
+# Use OpenMP for everything, not just OpenROAD.
+build --cxxopt "-fopenmp"          --host_cxxopt "-fopenmp"
 
 # allow exceptions.
 build  --cxxopt=-fexceptions    --host_cxxopt=-fexceptions

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -103,7 +103,6 @@ OPENROAD_COPTS = [
     "-Wno-unused-parameter",
     # FIXME reenable when warnings are fixed
     "-Wno-unused-but-set-variable",
-    "-fopenmp"
 ]
 
 OPENROAD_DEFINES = [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ git_override(
     remote = "https://github.com/bazelbuild/rules_scala",
 )
 
+
 # The current rules_cc 0.1.1 hardcodes script locations to `#!/bin/bash`
 # instead of using `#!/usr/bin/env bash`.
 # This is fixed by https://github.com/bazelbuild/rules_cc/pull/306 but
@@ -96,6 +97,12 @@ bazel_dep(name = "boost.utility", version = BOOST_VERSION)
 bazel_dep(name = "cudd", version = "3.0.0")
 bazel_dep(name = "eigen", version = "3.4.0.bcr.3")
 bazel_dep(name = "or-tools", version = "9.12")
+single_version_override(
+    module_name = "or-tools",
+    patches = ["//bazel:or-tools.patch"],
+    patch_strip = 1,
+    version = "9.12",
+)
 bazel_dep(name = "spdlog", version = "1.15.1")
 bazel_dep(name = "tcmalloc", version = "0.0.0-20250331-43fcf6e")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")

--- a/bazel/or-tools.patch
+++ b/bazel/or-tools.patch
@@ -1,0 +1,168 @@
+diff -u -r orig-or-tools/ortools/glop/BUILD.bazel or-tools-9.12/ortools/glop/BUILD.bazel
+--- orig-or-tools/ortools/glop/BUILD.bazel	2025-02-12 17:15:38.000000000 +0100
++++ or-tools-9.12/ortools/glop/BUILD.bazel	2025-05-28 09:17:20.792076032 +0200
+@@ -312,6 +312,7 @@
+         "//ortools/util:random_engine",
+         "//ortools/util:stats",
+         "@com_google_absl//absl/random:bit_gen_ref",
++        "@openroad@openmp//:openmp",
+     ],
+ )
+ 
+diff -u -r orig-or-tools/ortools/math_opt/solvers/BUILD.bazel or-tools-9.12/ortools/math_opt/solvers/BUILD.bazel
+--- orig-or-tools/ortools/math_opt/solvers/BUILD.bazel	2025-02-12 17:15:38.000000000 +0100
++++ or-tools-9.12/ortools/math_opt/solvers/BUILD.bazel	2025-05-28 09:13:26.971361311 +0200
+@@ -383,6 +383,7 @@
+         "@com_google_absl//absl/strings",
+         "@com_google_absl//absl/types:span",
+         "@eigen",
++        "@openroad@openmp//:openmp",
+     ],
+ )
+ 
+diff -u -r orig-or-tools/ortools/pdlp/BUILD.bazel or-tools-9.12/ortools/pdlp/BUILD.bazel
+--- orig-or-tools/ortools/pdlp/BUILD.bazel	2025-02-12 17:15:38.000000000 +0100
++++ or-tools-9.12/ortools/pdlp/BUILD.bazel	2025-05-28 09:16:34.239940412 +0200
+@@ -27,6 +27,7 @@
+         "//ortools/base:threadpool",
+         "@com_google_absl//absl/functional:any_invocable",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -98,6 +99,7 @@
+         "//ortools/base:mathutil",
+         "@com_google_absl//absl/random:distributions",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -114,6 +116,7 @@
+         ":test_util",
+         "//ortools/base:protobuf_util",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -150,6 +153,7 @@
+         "@com_google_absl//absl/time",
+         "@com_google_protobuf//:protobuf",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -178,6 +182,7 @@
+         "@com_google_absl//absl/status:statusor",
+         "@com_google_absl//absl/strings",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -193,6 +198,7 @@
+         "@com_google_absl//absl/status:statusor",
+         "@com_google_absl//absl/strings",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -210,6 +216,7 @@
+         "@com_google_absl//absl/status",
+         "@com_google_absl//absl/status:statusor",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -233,6 +240,7 @@
+         "@com_google_absl//absl/strings",
+         "@com_google_absl//absl/strings:str_format",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -249,6 +257,7 @@
+         "//ortools/base:mathutil",
+         "@com_google_absl//absl/random:distributions",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -265,6 +274,7 @@
+         ":solve_log_cc_proto",
+         ":test_util",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -282,6 +292,7 @@
+         "@com_google_absl//absl/memory",
+         "@com_google_absl//absl/strings",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -295,6 +306,7 @@
+         ":sharder",
+         ":test_util",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -310,6 +322,7 @@
+         "@com_google_absl//absl/synchronization",
+         "@com_google_absl//absl/time",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -325,6 +338,7 @@
+         "//ortools/base:mathutil",
+         "@com_google_absl//absl/random:distributions",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -388,6 +402,7 @@
+         "//ortools/base:gmock",
+         "@com_google_absl//absl/types:span",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -400,6 +415,7 @@
+         "//ortools/base",
+         "@com_google_absl//absl/types:span",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -416,6 +432,7 @@
+         "//ortools/base:mathutil",
+         "@com_google_absl//absl/algorithm:container",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )
+ 
+@@ -432,5 +449,6 @@
+         ":trust_region",
+         "@com_google_absl//absl/strings",
+         "@eigen",
++        "@openroad@openmp//:openmp",        
+     ],
+ )


### PR DESCRIPTION
```
$ bazelisk build -c opt :openroad
INFO: Invocation ID: 077ffe47-e32d-412a-ab7e-76d939bcc6af
INFO: Analyzed target //:openroad (1 packages loaded, 1050 targets configured).
ERROR: /home/oyvind/.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/external/or-tools~/ortools/pdlp/BUILD.bazel:184:11: Compiling ortools/pdlp/quadratic_program.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from target @@or-tools~//ortools/pdlp:quadratic_program) external/toolchains_llvm~~llvm~llvm_toolchain/bin/cc_wrapper.sh -U_FORTIFY_SOURCE '--target=x86_64-unknown-linux-gnu' -U_FORTIFY_SOURCE -fstack-protector -fno-omit-frame-pointer -fcolor-diagnostics ... (remaining 93 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from external/or-tools~/ortools/pdlp/quadratic_program.cc:14:
In file included from external/or-tools~/ortools/pdlp/quadratic_program.h:24:
external/eigen~/Eigen/Core:70:10: fatal error: 'omp.h' file not found
   70 | #include <omp.h>
      |          ^~~~~~~
1 error generated.
Target //:openroad failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 6.419s, Critical Path: 4.98s
INFO: 83 processes: 54 internal, 29 processwrapper-sandbox.
ERROR: Build did NOT complete successfully
FAILED: 
```
