### PR TITLE
bazel: `bazelisk test -c opt ...` now builds OpenROAD once

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -62,6 +62,11 @@ build:profile --copt -fno-omit-frame-pointer
 # TODO: document
 build --incompatible_strict_action_env
 
+# Without this, `bazelisk test -c opt ...` will run a `bazelisk build -c opt ...` first,
+# which will build cfg=target versions of targets and afterwards OpenROAD will be built
+# again for `bazel-orfs` and `regression.bzl` tests that use the cfg=exec configuration.
+test --build_tests_only
+
 # TODO: setup a new cache for OpenROAD
 # Read only remote cache, updated by OpenROAD team members and CI.
 #build --remote_cache=https://storage.googleapis.com/megaboom-bazel-artifacts

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -70,7 +70,11 @@ regression_rule_test = rule(
         "openroad": attr.label(
             doc = "The OpenROAD executable.",
             executable = True,
-            cfg = "target",
+            # Avoid building OpenROAD twice with "bazelisk test -c opt ..."
+            #
+            # OpenROAD is used to build more stuff in bazel-orfs,
+            # hence we want the "exec" (host) configuration.
+            cfg = "exec",
         ),
         "regression_test": attr.label(
             doc = "The regression test script.",


### PR DESCRIPTION
TL;DR Minimize surprises, build OpenROAD once instead of twice and run all tests:

```
bazelisk test -c opt ...
```

Configs, "exec" is a host configuration, so "k8-opt-exec..." is used to run `regression.bzl` tests and bazel-orfs tests. 

Use "exec" configuration to run tests to avoid building OpenROAD with two configurations "exec" and "target". More info https://github.com/The-OpenROAD-Project/OpenROAD/discussions/7295

```
$ bazelisk config
INFO: Invocation ID: ac5e40a2-0ad6-4926-be42-b559d5cde6e9
Available configurations:
227a4f0a56582136a9c238b40665fb23e8f08f5dae30fa8d28a146d384142d99 k8-opt-exec-ST-d57f47055a04 (exec)
729e8bf41f646cfcb07402580a35d32ec5d99e07d267cdc9c51abe36ab3139a8 k8-opt
7ec72a8f466254106038ebc53574a58b9d30d6afff8d93bf6ebcf819884f6438 k8-opt-exec-ST-d57f47055a04 (exec)
ab8cba103302292a2b1ba4f5816adc45d4e4bc4d1f3a0e0ddbfd94da0f3bd83b fastbuild-noconfig
c8daafd9d3326c8b691942be60cfb41ca3a9ce28c376aaf3b28aa8b6aa31eb60 k8-opt-exec-ST-6f5a6fb95be7 (exec)
fa32d83b7f5df576e050e3977f99f694126856d16bb10b48bad74982f50380df k8-opt
```

To see how many times OpenROAD is built, once with this PR, run:

```
bazelisk cquery -c opt --output=graph 'allpaths(//..., //:openroad)' | xdot /dev/stdin
```

![image](https://github.com/user-attachments/assets/12cb22f0-b0e2-4ade-93d5-ba629017e379)

It used to be twice:

![image](https://github.com/user-attachments/assets/94277411-5407-400e-9b3a-e5edba9dac25)
