### PR TITLE
drt: frVia takes origin during construction

### DIFF
--- a/src/drt/src/db/obj/frVia.h
+++ b/src/drt/src/db/obj/frVia.h
@@ -19,6 +19,10 @@ class frVia : public frRef
   // constructors
   frVia() = default;
   frVia(const frViaDef* in) : viaDef_(in) {}
+  frVia(const frViaDef* def_in, const Point& pt_in)
+      : origin_(pt_in), viaDef_(def_in)
+  {
+  }
   frVia(const frVia& in)
       : frRef(in),
         origin_(in.origin_),

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -879,8 +879,7 @@ void io::Parser::updateNetRouting(frNet* netIn, odb::dbNet* net)
             p = {beginX, beginY};
           }
           auto viaDef = getTech()->name2via_[viaName];
-          auto tmpP = std::make_unique<frVia>(viaDef);
-          tmpP->setOrigin(p);
+          auto tmpP = std::make_unique<frVia>(viaDef, p);
           tmpP->addToNet(netIn);
           netIn->addVia(std::move(tmpP));
         }

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -444,12 +444,12 @@ int FlexPA::getEdgeCost(
     const auto target_obj = inst_term_1->getInst();
     const int pin_access_idx = target_obj->getPinAccessIdx();
     const auto pa_1 = pin_1->getPinAccess(pin_access_idx);
+    const frAccessPoint* ap_1 = pa_1->getAccessPoint(prev_acc_point_idx);
     std::unique_ptr<frVia> via1;
-    if (pa_1->getAccessPoint(prev_acc_point_idx)->hasAccess(frDirEnum::U)) {
-      via1 = std::make_unique<frVia>(
-          pa_1->getAccessPoint(prev_acc_point_idx)->getViaDef());
-      Point pt1(pa_1->getAccessPoint(prev_acc_point_idx)->getPoint());
+    if (ap_1->hasAccess(frDirEnum::U)) {
+      Point pt1(ap_1->getPoint());
       xform.apply(pt1);
+      via1 = std::make_unique<frVia>(ap_1->getViaDef(), pt1);
       via1->setOrigin(pt1);
       if (inst_term_1->hasNet()) {
         objs.emplace_back(via1.get(), inst_term_1->getNet());
@@ -460,13 +460,12 @@ int FlexPA::getEdgeCost(
 
     const auto& [pin_2, inst_term_2] = pins[curr_pin_idx];
     const auto pa_2 = pin_2->getPinAccess(pin_access_idx);
+    const frAccessPoint* ap_2 = pa_2->getAccessPoint(curr_acc_point_idx);
     std::unique_ptr<frVia> via2;
-    if (pa_2->getAccessPoint(curr_acc_point_idx)->hasAccess(frDirEnum::U)) {
-      via2 = std::make_unique<frVia>(
-          pa_2->getAccessPoint(curr_acc_point_idx)->getViaDef());
-      Point pt2(pa_2->getAccessPoint(curr_acc_point_idx)->getPoint());
+    if (ap_2->hasAccess(frDirEnum::U)) {
+      Point pt2(ap_2->getPoint());
       xform.apply(pt2);
-      via2->setOrigin(pt2);
+      via2 = std::make_unique<frVia>(ap_2->getViaDef(), pt2);
       if (inst_term_2->hasNet()) {
         objs.emplace_back(via2.get(), inst_term_2->getNet());
       } else {
@@ -486,16 +485,14 @@ int FlexPA::getEdgeCost(
             = prev_prev_node->getIdx();
         if (!prev_prev_node->isSource()) {
           const auto& [pin_3, inst_term_3] = pins[prev_prev_pin_idx];
-          auto pa_3 = pin_3->getPinAccess(pin_access_idx);
+          const auto pa_3 = pin_3->getPinAccess(pin_access_idx);
+          const frAccessPoint* ap_3
+              = pa_3->getAccessPoint(prev_prev_acc_point_idx);
           std::unique_ptr<frVia> via3;
-          if (pa_3->getAccessPoint(prev_prev_acc_point_idx)
-                  ->hasAccess(frDirEnum::U)) {
-            via3 = std::make_unique<frVia>(
-                pa_3->getAccessPoint(prev_prev_acc_point_idx)->getViaDef());
-            Point pt3(
-                pa_3->getAccessPoint(prev_prev_acc_point_idx)->getPoint());
+          if (ap_3->hasAccess(frDirEnum::U)) {
+            Point pt3(ap_3->getPoint());
             xform.apply(pt3);
-            via3->setOrigin(pt3);
+            via3 = std::make_unique<frVia>(ap_3->getViaDef(), pt3);
             if (inst_term_3->hasNet()) {
               objs.emplace_back(via3.get(), inst_term_3->getNet());
             } else {

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -831,8 +831,7 @@ void FlexPA::filterViaAccess(
 
   std::set<std::tuple<frCoord, int, const frViaDef*>> valid_via_defs;
   for (auto& [idx, via_def] : via_defs) {
-    auto via = std::make_unique<frVia>(via_def);
-    via->setOrigin(begin_point);
+    auto via = std::make_unique<frVia>(via_def, begin_point);
     const Rect box = via->getLayer1BBox();
     if (inst_term) {
       if (!boundary_bbox.contains(box)) {

--- a/src/drt/src/pa/FlexPA_row_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_row_pattern.cpp
@@ -495,10 +495,9 @@ void FlexPA::addAccessPatternObj(
         continue;
       }
       if (access_point->hasAccess(frDirEnum::U)) {
-        auto via = std::make_unique<frVia>(access_point->getViaDef());
         Point pt(access_point->getPoint());
         xform.apply(pt);
-        via->setOrigin(pt);
+        auto via = std::make_unique<frVia>(access_point->getViaDef(), pt);
         auto rvia = via.get();
         if (inst_term->hasNet()) {
           objs.emplace_back(rvia, inst_term->getNet());

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -748,8 +748,7 @@ frViaDef* Fixture::makeViaDef(const char* name,
 
 frVia* Fixture::makeVia(frViaDef* viaDef, frNet* net, const Point& origin)
 {
-  auto via_p = std::make_unique<frVia>(viaDef);
-  via_p->setOrigin(origin);
+  auto via_p = std::make_unique<frVia>(viaDef, origin);
   via_p->addToNet(net);
   frVia* via = via_p.get();
   net->addVia(std::move(via_p));


### PR DESCRIPTION
Just quickly did this because it was bothering me a little. Pet peeve PR.

Full Safe

`frVia` can now take an origin point during construction. We keep using `setOrigin()` when it clearly wants to be in construction. The part of the code on `FlexPA_acc_pattern.cpp` touched by this is very verbose for essentially just creating 3 `frVias`. 

I actually think `frVia` should have a constructor that just takes and access point as input but that would require each access point to know the transform from its unique instance which is not the case currently.