### PR TITLE
Fix the shuffle function

### DIFF
--- a/src/utl/include/utl/algorithms.h
+++ b/src/utl/include/utl/algorithms.h
@@ -19,7 +19,7 @@ template <class RandomIt, class URBG>
 void shuffle(RandomIt first, RandomIt last, URBG&& g)
 {
   int n = last - first;
-  if (n == 0) {
+  if (n <= 1) {
     return;
   }
 


### PR DESCRIPTION
The shuffle function doesn't handle correctly the case where the iterator passed has exactly one element (it tries to create a distribution between 1 and 0, which causes an assertion error in boost)