### PR TITLE
gpl: reduce couting of new cells after callback removal

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -3202,6 +3202,7 @@ std::pair<odb::dbInst*, size_t> NesterovBaseCommon::destroyCbkGCell(
   int64_t area_change = static_cast<int64_t>(gCellStor_.back().dx())
                         * static_cast<int64_t>(gCellStor_.back().dy());
   delta_area_ -= area_change;
+  new_gcells_count_--;
 
   gCellStor_.pop_back();
   minRcCellSize_.pop_back();


### PR DESCRIPTION
This should have no effect on master. Since we do not use removals from callbacks yet.