### PR TITLE
DRT: support higher via access layer num correctly and minor fixes

### DIFF
--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1028,6 +1028,9 @@ int TritonRoute::main()
 
 void TritonRoute::pinAccess(const std::vector<odb::dbInst*>& target_insts)
 {
+  if (router_cfg_->DBPROCESSNODE == "GF14_13M_3Mx_2Cx_4Kx_2Hx_2Gx_LB") {
+    router_cfg_->USENONPREFTRACKS = false;
+  }
   if (distributed_) {
     asio::post(*dist_pool_, [this]() {
       sendDesignDist();

--- a/src/drt/src/TritonRoute.i
+++ b/src/drt/src/TritonRoute.i
@@ -103,7 +103,9 @@ void pin_access_cmd(const char* dbProcessNode,
                     const char* bottomRoutingLayer,
                     const char* topRoutingLayer,
                     int verbose,
-                    int minAccessPoints)
+                    int minAccessPoints,
+                    const char* viaInPinBottomLayer,
+                    const char* viaInPinTopLayer)
 {
   auto* router = ord::OpenRoad::openRoad()->getTritonRoute();
   drt::ParamStruct params;
@@ -112,6 +114,8 @@ void pin_access_cmd(const char* dbProcessNode,
   params.topRoutingLayer = topRoutingLayer;
   params.verbose = verbose;
   params.minAccessPoints = minAccessPoints;
+  params.viaInPinBottomLayer = viaInPinBottomLayer;
+  params.viaInPinTopLayer = viaInPinTopLayer;
   params.num_threads = ord::OpenRoad::openRoad()->getThreadCount();
   router->setParams(params);
   router->pinAccess();
@@ -219,3 +223,4 @@ void check_drc_cmd(const char* drc_file, int x1, int y1, int x2, int y2, const c
   router->checkDRC(drc_file, x1, y1, x2, y2, marker_name, num_threads);
 }
 %} // inline
+

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -259,6 +259,8 @@ sta::define_cmd_args "pin_access" {
     [-db_process_node name]
     [-bottom_routing_layer layer]
     [-top_routing_layer layer]
+    [-via_in_pin_bottom_layer layer]
+    [-via_in_pin_top_layer layer]
     [-min_access_points count]
     [-verbose level]
     [-distributed]
@@ -270,7 +272,8 @@ sta::define_cmd_args "pin_access" {
 proc pin_access { args } {
   sta::parse_key_args "pin_access" args \
     keys {-db_process_node -bottom_routing_layer -top_routing_layer -verbose \
-          -min_access_points -remote_host -remote_port -shared_volume -cloud_size } \
+          -min_access_points -remote_host -remote_port -shared_volume -cloud_size \
+          -via_in_pin_bottom_layer -via_in_pin_top_layer} \
     flags {-distributed}
   sta::check_argc_eq0 "detailed_route_debug" $args
   if { [info exists keys(-db_process_node)] } {
@@ -323,8 +326,19 @@ proc pin_access { args } {
     }
     drt::detailed_route_distributed $rhost $rport $vol $cloudsz
   }
+  if { [info exists keys(-via_in_pin_bottom_layer)] } {
+    set via_in_pin_bottom_layer $keys(-via_in_pin_bottom_layer)
+  } else {
+    set via_in_pin_bottom_layer ""
+  }
+  if { [info exists keys(-via_in_pin_top_layer)] } {
+    set via_in_pin_top_layer $keys(-via_in_pin_top_layer)
+  } else {
+    set via_in_pin_top_layer ""
+  }
   drt::pin_access_cmd $db_process_node $bottom_routing_layer \
-    $top_routing_layer $verbose $min_access_points
+    $top_routing_layer $verbose $min_access_points $via_in_pin_bottom_layer \
+    $via_in_pin_top_layer
 }
 
 sta::define_cmd_args "detailed_route_run_worker" {

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -2701,7 +2701,12 @@ void FlexDRWorker::initMazeCost_fixedObj(const frDesign* design)
             // unblock planar edge for obs over pin, ap will unblock via edge
             // for legal pin access
             modBlockedPlanar(box, zIdx, false);
-            if (zIdx <= (router_cfg_->VIA_ACCESS_LAYERNUM / 2 - 1)) {
+            bool costVia = zIdx <= (router_cfg_->VIA_ACCESS_LAYERNUM / 2 - 1);
+            costVia
+                = costVia
+                  || (zIdx >= (router_cfg_->VIAINPIN_BOTTOMLAYERNUM / 2 - 1)
+                      && zIdx <= (router_cfg_->VIAINPIN_TOPLAYERNUM / 2 - 1));
+            if (costVia) {
               modMinSpacingCostPlanar(
                   box, zIdx, ModCostType::addFixedShape, true);
               modEolSpacingRulesCost(box, zIdx, ModCostType::addFixedShape);

--- a/src/drt/src/pa/AbstractPAGraphics.h
+++ b/src/drt/src/pa/AbstractPAGraphics.h
@@ -35,6 +35,7 @@ class AbstractPAGraphics
 
   virtual void setViaAP(const frAccessPoint* ap,
                         const frVia* via,
+                        const frPathSeg* path_seg,
                         const std::vector<std::unique_ptr<frMarker>>& markers)
       = 0;
 

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -1034,7 +1034,7 @@ bool FlexPA::isViaViolationFree(frAccessPoint* ap,
   const bool no_drv = design_rule_checker.getMarkers().empty();
 
   if (graphics_) {
-    graphics_->setViaAP(ap, via, design_rule_checker.getMarkers());
+    graphics_->setViaAP(ap, via, ps, design_rule_checker.getMarkers());
   }
   return no_drv;
 }
@@ -1061,10 +1061,12 @@ void FlexPA::filterMultipleAPAccesses(
                     pin,
                     inst_term);
     if (is_std_cell_pin) {
-      has_access |= ((layer_num == router_cfg_->VIA_ACCESS_LAYERNUM
-                      && ap->hasAccess(frDirEnum::U))
-                     || (layer_num != router_cfg_->VIA_ACCESS_LAYERNUM
-                         && ap->hasAccess()));
+      const bool isViaAccessLayer
+          = layer_num == router_cfg_->VIA_ACCESS_LAYERNUM
+            || (layer_num >= router_cfg_->VIAINPIN_BOTTOMLAYERNUM
+                && layer_num <= router_cfg_->VIAINPIN_TOPLAYERNUM);
+      has_access |= ((isViaAccessLayer && ap->hasAccess(frDirEnum::U))
+                     || (!isViaAccessLayer && ap->hasAccess()));
     } else {
       has_access |= ap->hasAccess();
     }
@@ -1235,7 +1237,10 @@ bool FlexPA::genPinAccessCostBounded(
     // and (ii) access if exist access for macro, allow pure planar ap
     if (is_std_cell_pin) {
       const bool ap_in_via_acc_layer
-          = (ap->getLayerNum() == router_cfg_->VIA_ACCESS_LAYERNUM);
+          = (ap->getLayerNum() == router_cfg_->VIA_ACCESS_LAYERNUM
+        || (ap->getLayerNum() >= router_cfg_->VIAINPIN_BOTTOMLAYERNUM
+                 && ap->getLayerNum() <= router_cfg_->VIAINPIN_TOPLAYERNUM));
+
       if (!ap_in_via_acc_layer || ap->hasAccess(frDirEnum::U)) {
         aps.push_back(std::move(ap));
       }

--- a/src/drt/src/pa/FlexPA_graphics.cpp
+++ b/src/drt/src/pa/FlexPA_graphics.cpp
@@ -103,6 +103,8 @@ void FlexPAGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
       bbox = via->getLayer1BBox();
     } else if (via_def->getLayer2Num() == layer_num) {
       bbox = via->getLayer2BBox();
+    } else if (via_def->getCutLayerNum() == layer_num) {
+      bbox = via->getCutBBox();
     } else {
       skip = true;
     }
@@ -240,15 +242,20 @@ void FlexPAGraphics::setAPs(
 void FlexPAGraphics::setViaAP(
     const frAccessPoint* ap,
     const frVia* via,
+    const frPathSeg* path_seg,
     const std::vector<std::unique_ptr<frMarker>>& markers)
 {
   if (!pin_ || !settings_->paMarkers) {
     return;
   }
-
+  if (markers.size() > 0) {
+    return;
+  }
+  logger_->report(
+      "Via {} markers {}", via->getViaDef()->getName(), markers.size());
   pa_ap_ = ap;
   pa_vias_ = {via};
-  pa_segs_.clear();
+  pa_segs_ = {path_seg};
   pa_markers_ = &markers;
   for (auto& marker : markers) {
     Rect bbox = marker->getBBox();
@@ -275,6 +282,7 @@ void FlexPAGraphics::setViaAP(
 
   // These are going away once we return
   pa_ap_ = nullptr;
+  pa_segs_.clear();
   pa_vias_.clear();
   pa_markers_ = nullptr;
 }

--- a/src/drt/src/pa/FlexPA_graphics.h
+++ b/src/drt/src/pa/FlexPA_graphics.h
@@ -59,6 +59,7 @@ class FlexPAGraphics : public gui::Renderer, public AbstractPAGraphics
 
   void setViaAP(const frAccessPoint* ap,
                 const frVia* via,
+                const frPathSeg* path_seg,
                 const std::vector<std::unique_ptr<frMarker>>& markers) override;
 
   void setPlanarAP(


### PR DESCRIPTION
- Add VIA access layer range in the pin access command
- Apply the correct via cost considering the via access layer range not only the via layer.
- Correctly evaluate via guides in guides processing
- Show the path segment connecting to the via in pin access debug mode.