### PR TITLE
gpl: reduce counting of new cells after callback removal

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -3202,6 +3202,7 @@ std::pair<odb::dbInst*, size_t> NesterovBaseCommon::destroyCbkGCell(
   int64_t area_change = static_cast<int64_t>(gCellStor_.back().dx())
                         * static_cast<int64_t>(gCellStor_.back().dy());
   delta_area_ -= area_change;
+  new_gcells_count_--;
 
   gCellStor_.pop_back();
   minRcCellSize_.pop_back();

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -895,7 +895,7 @@ class NesterovBaseCommon
 
   int num_threads_;
   int64_t delta_area_;
-  uint new_gcells_count_;
+  int new_gcells_count_;
   nesterovDbCbk* db_cbk_{nullptr};
 };
 


### PR DESCRIPTION
This has no functional change, since we do not trigger callback removals yet.