### PR TITLE
mpl: model blockages as macro clusters constrained by fences

### DIFF
--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -390,7 +390,7 @@ void Graphics::drawObjects(gui::Painter& painter)
 
   int i = 0;
   for (const auto& macro : soft_macros_) {
-    if (isSkippable(macro)) {
+    if (isSkippable(macro) && !macro.isBlockage()) {
       continue;
     }
 
@@ -630,6 +630,11 @@ void Graphics::addOutlineOffsetToLine(odb::Point& from, odb::Point& to)
 void Graphics::setSoftMacroBrush(gui::Painter& painter,
                                  const SoftMacro& soft_macro)
 {
+  if (soft_macro.isBlockage()) {
+    painter.setBrush(gui::Painter::dark_red);
+    return;
+  }
+
   if (soft_macro.getCluster()->getClusterType() == StdCellCluster) {
     painter.setBrush(gui::Painter::dark_blue);
   } else if (soft_macro.getCluster()->getClusterType() == HardMacroCluster) {

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -4,6 +4,7 @@
 #include "hier_rtlmp.h"
 
 #include <algorithm>
+#include <boost/polygon/polygon.hpp>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -23,6 +24,7 @@
 #include "db_sta/dbNetwork.hh"
 #include "object.h"
 #include "odb/db.h"
+#include "odb/geom_boost.h"
 #include "odb/util.h"
 #include "par/PartitionMgr.h"
 #include "sta/Liberty.hh"
@@ -1307,10 +1309,9 @@ void HierRTLMP::placeChildren(Cluster* parent)
   std::vector<SoftMacro> macros;
   std::vector<BundledNet> nets;
 
-  std::vector<Rect> placement_blockages;
-  std::vector<Rect> macro_blockages;
-
-  findBlockagesWithinOutline(macro_blockages, placement_blockages, outline);
+  std::vector<Rect> blockages = findBlockagesWithinOutline(outline);
+  eliminateOverlaps(blockages);
+  createSoftMacrosForBlockages(blockages, soft_macro_id_map, macros, fences);
 
   // We store the io clusters to push them into the macros' vector
   // only after it is already populated with the clusters we're trying to
@@ -1566,8 +1567,6 @@ void HierRTLMP::placeChildren(Cluster* parent)
       sa->setFences(fences);
       sa->setGuides(guides);
       sa->setNets(nets);
-      sa->addBlockages(placement_blockages);
-      sa->addBlockages(macro_blockages);
       sa_batch.push_back(std::move(sa));
     }
     if (sa_batch.size() == 1) {
@@ -1709,10 +1708,9 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
   std::vector<SoftMacro> macros;
   std::vector<BundledNet> nets;
 
-  std::vector<Rect> placement_blockages;
-  std::vector<Rect> macro_blockages;
-
-  findBlockagesWithinOutline(macro_blockages, placement_blockages, outline);
+  std::vector<Rect> blockages = findBlockagesWithinOutline(outline);
+  eliminateOverlaps(blockages);
+  createSoftMacrosForBlockages(blockages, soft_macro_id_map, macros, fences);
 
   // We store the io clusters to push them into the macros' vector
   // only after it is already populated with the clusters we're trying to
@@ -1954,8 +1952,6 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
       sa->setFences(fences);
       sa->setGuides(guides);
       sa->setNets(nets);
-      sa->addBlockages(placement_blockages);
-      sa->addBlockages(macro_blockages);
       sa_batch.push_back(std::move(sa));
     }
     if (sa_batch.size() == 1) {
@@ -2057,23 +2053,20 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
 }
 
 // Find the area of blockages that are inside the outline.
-void HierRTLMP::findBlockagesWithinOutline(
-    std::vector<Rect>& macro_blockages,
-    std::vector<Rect>& placement_blockages,
+std::vector<Rect> HierRTLMP::findBlockagesWithinOutline(
     const Rect& outline) const
 {
+  std::vector<Rect> blockages_within_outline;
+
   for (auto& blockage : placement_blockages_) {
-    getBlockageRegionWithinOutline(placement_blockages, blockage, outline);
+    getBlockageRegionWithinOutline(blockages_within_outline, blockage, outline);
   }
 
   for (auto& blockage : io_blockages_) {
-    getBlockageRegionWithinOutline(macro_blockages, blockage, outline);
+    getBlockageRegionWithinOutline(blockages_within_outline, blockage, outline);
   }
 
-  if (graphics_) {
-    graphics_->setMacroBlockages(macro_blockages);
-    graphics_->setPlacementBlockages(placement_blockages);
-  }
+  return blockages_within_outline;
 }
 
 void HierRTLMP::getBlockageRegionWithinOutline(
@@ -2091,6 +2084,49 @@ void HierRTLMP::getBlockageRegionWithinOutline(
                                           b_ly - outline.yMin(),
                                           b_ux - outline.xMin(),
                                           b_uy - outline.yMin());
+  }
+}
+
+void HierRTLMP::eliminateOverlaps(std::vector<Rect>& blockages) const
+{
+  namespace gtl = boost::polygon;
+  using gtl::operators::operator+=;
+  using PolygonSet = gtl::polygon_90_set_data<int>;
+
+  PolygonSet polygons;
+  for (const Rect& blockage : blockages) {
+    const odb::Rect dbu_blockage = micronsToDbu(blockage);
+    polygons += dbu_blockage;
+  }
+
+  blockages.clear();
+
+  std::vector<odb::Rect> new_blockages;
+  polygons.get_rectangles(new_blockages);
+
+  for (const odb::Rect& new_blockage : new_blockages) {
+    blockages.push_back(dbuToMicrons(new_blockage));
+  }
+}
+
+// We model blockages as macro clusters (SoftMacros) constrained to fences.
+// The rationale of this model comes from the fact that the area occupied
+// by blockages should be empty, i.e., with neither macros or std cells.
+void HierRTLMP::createSoftMacrosForBlockages(
+    const std::vector<Rect>& blockages,
+    std::map<std::string, int>& soft_macro_id_map,
+    std::vector<SoftMacro>& macros,
+    std::map<int, Rect>& fences)
+{
+  for (const Rect& blockage : blockages) {
+    const int macro_id = static_cast<int>(macros.size());
+    std::string macro_name = fmt::format("blockage_{}", macro_id);
+
+    soft_macro_id_map[macro_name] = macro_id;
+    fences[macro_id] = blockage;
+
+    SoftMacro macro(blockage.getWidth(), blockage.getHeight(), macro_name);
+    macros.push_back(macro);
   }
 }
 

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -176,13 +176,17 @@ class HierRTLMP
   void placeChildren(Cluster* parent);
   void placeChildrenUsingMinimumTargetUtil(Cluster* parent);
 
-  void findBlockagesWithinOutline(std::vector<Rect>& macro_blockages,
-                                  std::vector<Rect>& placement_blockages,
-                                  const Rect& outline) const;
+  std::vector<Rect> findBlockagesWithinOutline(const Rect& outline) const;
   void getBlockageRegionWithinOutline(
       std::vector<Rect>& blockages_within_outline,
       const Rect& blockage,
       const Rect& outline) const;
+  void eliminateOverlaps(std::vector<Rect>& blockages) const;
+  void createSoftMacrosForBlockages(
+      const std::vector<Rect>& blockages,
+      std::map<std::string, int>& soft_macro_id_map,
+      std::vector<SoftMacro>& macros,
+      std::map<int, Rect>& fences);
   void createFixedTerminals(Cluster* parent,
                             std::map<std::string, int>& soft_macro_id_map,
                             std::vector<SoftMacro>& soft_macros);

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -75,7 +75,7 @@ proc rtl_macro_placer { args } {
   set outline_weight 100.0
   set wirelength_weight 100.0
   set guidance_weight 10.0
-  set fence_weight 10.0
+  set fence_weight 1000.0
   set boundary_weight 50.0
   set notch_weight 10.0
   set macro_blockage_weight 10.0

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -945,6 +945,7 @@ SoftMacro::SoftMacro(float width, float height, const std::string& name)
   height_ = height;
   area_ = width * height;
   cluster_ = nullptr;
+  is_blockage_ = true;
 }
 
 // Represent an IO cluster or fixed terminal.

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -476,6 +476,7 @@ class SoftMacro
   bool isMixedCluster() const;
   bool isClusterOfUnplacedIOPins() const;
   bool isClusterOfUnconstrainedIOPins() const;
+  bool isBlockage() const { return is_blockage_; }
   void setLocationF(float x, float y);
   void setShapeF(float width, float height);
   int getNumMacro() const;
@@ -509,6 +510,7 @@ class SoftMacro
   // Interfaces with hard macro
   Cluster* cluster_ = nullptr;
   bool fixed_ = false;  // if the macro is fixed
+  bool is_blockage_ = false;
 
   // Alignment support
   // if the cluster has been aligned related to other macro_cluster or


### PR DESCRIPTION
Replaces #6502

### Context
Currently, in cluster placement, blockages are modeled as regions that should not be occupied by clusters with macros - penalty based on overlap area. With this approach, the only way to reduce the overlap penalty is to either fill the blockage region with std cell clusters or leave it empty (the latter is very challenging because of the sequence pair representation).

### Idea Here
Model blockages as macro clusters constrained to fences to prevent any cluster from occupying the blockage region.

### Also Needed
Increase fence penalty so that if effectively places the blockages where they belong.



_Just for the record, this is a very aggressive idea. I'm studying it as a possible, but not certain enhancement._