### PR TITLE
repair_timing upsizeCell swappable sort BugFix?

### DIFF
--- a/src/rsz/src/BaseMove.cc
+++ b/src/rsz/src/BaseMove.cc
@@ -632,8 +632,8 @@ LibertyCell* BaseMove::upsizeCell(LibertyPort* in_port,
            const ArcDelay intrinsic2 = port2->intrinsicDelay(this);
            const float capacitance1 = port1->capacitance();
            const float capacitance2 = port2->capacitance();
-           return std::tie(drive2, intrinsic1, capacitance1)
-                  < std::tie(drive1, intrinsic2, capacitance2);
+           return std::tie(drive1, intrinsic1, capacitance1)
+                  < std::tie(drive2, intrinsic2, capacitance2);
          });
     const float drive = drvr_port->cornerPort(lib_ap)->driveResistance();
     const float delay


### PR DESCRIPTION
When call command "repair_timing", in upsize move, the swappable cells will be sorted.
However, the sorting order seems to be strange..?

return std::tie(drive2, intrinsic1, capacitance1) < std::tie(drive1, intrinsic2, capacitance2);

Is there any specific heuristic or reason to sort in this way?