### PR TITLE
gpl: dummies ignore fixed instances in other regions

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1192,6 +1192,9 @@ void PlacerBase::initInstsForUnusableSites()
     if (!inst->isFixed()) {
       continue;
     }
+    if (inst->dbInst() && inst->dbInst()->getGroup() != group_) {
+      continue;
+    }
     std::pair<int, int> pairX = getMinMaxIdx(
         inst->lx(), inst->ux(), die_.coreLx(), siteSizeX_, 0, siteCountX);
     std::pair<int, int> pairY = getMinMaxIdx(


### PR DESCRIPTION
Creates dummy instances on top of fixed instances from other regions.

PR #7405 removed the creation of dummy instances on top of fixed instances, but the placerBase can only see instances that belong to its region, so dummy instances still need to be created on top of fixed instances from other regions.