### PR TITLE
Odb fix core area redundancy

### DIFF
--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -155,7 +155,7 @@ _dbBlock::_dbBlock(_dbDatabase* db)
   _corners_per_block = 0;
   _corner_name_list = nullptr;
   _name = nullptr;
-  _die_area = Rect(0, 0, 0, 0);
+  _die_area = Polygon();
   _maxCapNodeId = 0;
   _maxRSegId = 0;
   _maxCCSegId = 0;


### PR DESCRIPTION
Closes #7549.

The Odb reader appends the points stored in ODB to the _dbBlock._die_area polygon.
_dbBlock._die_area was initialized as Rect(0, 0, 0, 0) and then converted to Polygon({0,0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}), so the new points were added to this vector.

Changes:
- Initialize _dbBlock._die_area as an empty Polygon.