### PR TITLE
odb: load Polygon points with setPoints

### DIFF
--- a/src/odb/src/db/dbStream.cpp
+++ b/src/odb/src/db/dbStream.cpp
@@ -67,7 +67,9 @@ dbOStream& operator<<(dbOStream& stream, const Polygon& p)
 
 dbIStream& operator>>(dbIStream& stream, Polygon& p)
 {
-  stream >> p.points_;
+  std::vector<Point> p_vec;
+  stream >> p_vec;
+  p.setPoints(p_vec);
   return stream;
 }
 


### PR DESCRIPTION
Closes #7549.

The Odb reader appends the points stored in ODB to the _dbBlock._die_area polygon.

Changes:
- Use the Polygon::setPoints method to load the points.

