### PR TITLE
odb: refactoring of repeated code in each parser

### DIFF
--- a/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
+++ b/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
@@ -14,7 +14,7 @@
 namespace odb {
 void CellEdgeSpacingTableParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseEntry(rule)) {
       lefin_->warning(
           299,

--- a/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
+++ b/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
@@ -9,23 +9,20 @@
 #include <vector>
 
 #include "boostParser.h"
+#include "parserUtils.h"
 
 namespace odb {
 void CellEdgeSpacingTableParser::parse(const std::string& s)
 {
-  std::vector<std::string> entries;
-  boost::split(entries, s, boost::is_any_of(";"));
-  for (auto& entry : entries) {
-    boost::algorithm::trim(entry);
-    if (entry.empty()) {
-      continue;
+  processRules(s, [this](std::string& rule) {
+    rule += " ; ";
+    if (!parseEntry(rule)) {
+      lefin_->warning(
+          299,
+          "parse mismatch in property LEF58_CELLEDGESPACINGTABLE: \"{}\"",
+          rule);
     }
-    entry += " ; ";
-    if (!parseEntry(entry)) {
-      lefin_->warning(299,
-                      "parse mismatch in property LEF58_CELLEDGESPACINGTABLE");
-    }
-  }
+  });
 }
 
 void CellEdgeSpacingTableParser::createEntry()

--- a/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
+++ b/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2025-2025, The OpenROAD Authors
 
+// Parser for LEF58 cell edge spacing table rules
 #include "CellEdgeSpacingTableParser.h"
 
 #include <functional>
@@ -12,6 +13,8 @@
 #include "parserUtils.h"
 
 namespace odb {
+
+// Parse the input string containing cell edge spacing rules
 void CellEdgeSpacingTableParser::parse(const std::string& s)
 {
   processRules(s, [this](const std::string& rule) {
@@ -46,9 +49,12 @@ void CellEdgeSpacingTableParser::setString(
   (curr_entry_->*func)(val);
 }
 
-bool CellEdgeSpacingTableParser::parseEntry(std::string s)
+// Parse a single cell edge spacing rule entry
+// Format: EDGETYPE <type1> <type2> [EXCEPTABUTTED] [EXCEPTNONFILLERINBETWEEN]
+// [OPTIONAL] [SOFT] [EXACT] <spacing> ;
+bool CellEdgeSpacingTableParser::parseEntry(const std::string& s)
 {
-  qi::rule<std::string::iterator, space_type> ENTRY
+  qi::rule<std::string::const_iterator, space_type> ENTRY
       = lit("EDGETYPE")[boost::bind(&CellEdgeSpacingTableParser::createEntry,
                                     this)]
         >> _string[boost::bind(&CellEdgeSpacingTableParser::setString,
@@ -78,7 +84,7 @@ bool CellEdgeSpacingTableParser::parseEntry(std::string s)
                                      &dbCellEdgeSpacing::setExact)]
         >> double_[boost::bind(
             &CellEdgeSpacingTableParser::setSpacing, this, _1)];
-  qi::rule<std::string::iterator, space_type> LEF58_CELLEDGESPACINGTABLE
+  qi::rule<std::string::const_iterator, space_type> LEF58_CELLEDGESPACINGTABLE
       = (lit("CELLEDGESPACINGTABLE") >> -lit("NODEFAULT") >> +ENTRY
          >> lit(";"));
 

--- a/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
+++ b/src/odb/src/lefin/CellEdgeSpacingTableParser.cpp
@@ -15,7 +15,6 @@ namespace odb {
 void CellEdgeSpacingTableParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseEntry(rule)) {
       lefin_->warning(
           299,

--- a/src/odb/src/lefin/CellEdgeSpacingTableParser.h
+++ b/src/odb/src/lefin/CellEdgeSpacingTableParser.h
@@ -23,7 +23,7 @@ class CellEdgeSpacingTableParser
   void parse(const std::string&);
 
  private:
-  bool parseEntry(std::string);
+  bool parseEntry(const std::string&);
   void createEntry();
   void setSpacing(double);
   void setBool(void (dbCellEdgeSpacing::*func)(bool));

--- a/src/odb/src/lefin/KeepOutZoneParser.cpp
+++ b/src/odb/src/lefin/KeepOutZoneParser.cpp
@@ -23,7 +23,7 @@ void KeepOutZoneParser::setInt(
 
 void KeepOutZoneParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseSubRule(rule)) {
       lefin_->warning(388,
                       "parse mismatch in layer property LEF58_KEEPOUTZONE for "

--- a/src/odb/src/lefin/KeepOutZoneParser.cpp
+++ b/src/odb/src/lefin/KeepOutZoneParser.cpp
@@ -10,6 +10,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 using namespace odb;
 
@@ -22,13 +23,7 @@ void KeepOutZoneParser::setInt(
 
 void KeepOutZoneParser::parse(const std::string& s)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(388,
@@ -37,7 +32,7 @@ void KeepOutZoneParser::parse(const std::string& s)
                       layer_->getName(),
                       rule);
     }
-  }
+  });
 }
 
 bool KeepOutZoneParser::parseSubRule(std::string s)

--- a/src/odb/src/lefin/KeepOutZoneParser.cpp
+++ b/src/odb/src/lefin/KeepOutZoneParser.cpp
@@ -24,7 +24,6 @@ void KeepOutZoneParser::setInt(
 void KeepOutZoneParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(388,
                       "parse mismatch in layer property LEF58_KEEPOUTZONE for "

--- a/src/odb/src/lefin/KeepOutZoneParser.cpp
+++ b/src/odb/src/lefin/KeepOutZoneParser.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+// Parser for LEF58 keep-out zone rules that define restricted areas around
+// cuts/vias
 #include <functional>
 #include <iostream>
 #include <string>
@@ -21,6 +23,7 @@ void KeepOutZoneParser::setInt(
   (rule_->*func)(lefin_->dbdist(val));
 }
 
+// Parse input string containing keep-out zone rules
 void KeepOutZoneParser::parse(const std::string& s)
 {
   processRules(s, [this](const std::string& rule) {
@@ -34,10 +37,15 @@ void KeepOutZoneParser::parse(const std::string& s)
   });
 }
 
-bool KeepOutZoneParser::parseSubRule(std::string s)
+// Parse a single keep-out zone rule
+// Format: KEEPOUTZONE CUTCLASS name [TO name] [EXCEPTEXACTALIGNED [SIDE|END]
+// spacing]
+//         EXTENSION side forward [ENDEXTENSION endside endforward SIDEEXTENSION
+//         sideside sideforward] SPIRALEXTENSION spacing ;
+bool KeepOutZoneParser::parseSubRule(const std::string& s)
 {
   rule_ = dbTechLayerKeepOutZoneRule::create(layer_);
-  qi::rule<std::string::iterator, space_type> EXCEPTEXACTALIGNED
+  qi::rule<std::string::const_iterator, space_type> EXCEPTEXACTALIGNED
       = (lit("EXCEPTEXACTALIGNED")
          >> -(lit("SIDE")[boost::bind(
                   &dbTechLayerKeepOutZoneRule::setExceptAlignedSide,
@@ -52,7 +60,7 @@ bool KeepOutZoneParser::parseSubRule(std::string s)
              this,
              _1,
              &odb::dbTechLayerKeepOutZoneRule::setAlignedSpacing)]);
-  qi::rule<std::string::iterator, space_type> EXTENSION
+  qi::rule<std::string::const_iterator, space_type> EXTENSION
       = ((lit("EXTENSION") >> double_[boost::bind(
               &KeepOutZoneParser::setInt,
               this,
@@ -83,14 +91,14 @@ bool KeepOutZoneParser::parseSubRule(std::string s)
                 this,
                 _1,
                 &odb::dbTechLayerKeepOutZoneRule::setSideForwardExtension)]));
-  qi::rule<std::string::iterator, space_type> SPIRALEXTENSION
+  qi::rule<std::string::const_iterator, space_type> SPIRALEXTENSION
       = ((lit("SPIRALEXTENSION") >> double_[boost::bind(
               &KeepOutZoneParser::setInt,
               this,
               _1,
               &odb::dbTechLayerKeepOutZoneRule::setSpiralExtension)]));
 
-  qi::rule<std::string::iterator, space_type> LEF58_KEEPOUTZONE
+  qi::rule<std::string::const_iterator, space_type> LEF58_KEEPOUTZONE
       = (lit("KEEPOUTZONE") >> lit("CUTCLASS") >> _string[boost::bind(
              &dbTechLayerKeepOutZoneRule::setFirstCutClass, rule_, _1)]
          >> -(lit("TO") >> _string[boost::bind(

--- a/src/odb/src/lefin/MaxSpacingParser.cpp
+++ b/src/odb/src/lefin/MaxSpacingParser.cpp
@@ -18,10 +18,10 @@ void MaxSpacingParser::setMaxSpacing(dbTechLayerMaxSpacingRule* rule,
   rule->setMaxSpacing(lefin_->dbdist(spc));
 }
 
-void MaxSpacingParser::parse(std::string s)
+void MaxSpacingParser::parse(const std::string& s)
 {
   dbTechLayerMaxSpacingRule* rule = dbTechLayerMaxSpacingRule::create(layer_);
-  qi::rule<std::string::iterator, space_type> LEF58_MAXSPACING
+  qi::rule<std::string::const_iterator, space_type> LEF58_MAXSPACING
       = (lit("MAXSPACING") >> double_[boost::bind(
              &MaxSpacingParser::setMaxSpacing, this, rule, _1)]
          >> -(lit("CUTCLASS") >> _string[boost::bind(

--- a/src/odb/src/lefin/MetalWidthViaMapParser.cpp
+++ b/src/odb/src/lefin/MetalWidthViaMapParser.cpp
@@ -8,6 +8,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 using namespace odb;
 void MetalWidthViaMapParser::addEntry(
@@ -48,13 +49,7 @@ void MetalWidthViaMapParser::setPGVia()
 
 void MetalWidthViaMapParser::parse(const std::string& s)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
@@ -62,7 +57,7 @@ void MetalWidthViaMapParser::parse(const std::string& s)
                       ":\"{}\"",
                       rule);
     }
-  }
+  });
 }
 
 bool MetalWidthViaMapParser::parseSubRule(std::string s)

--- a/src/odb/src/lefin/MetalWidthViaMapParser.cpp
+++ b/src/odb/src/lefin/MetalWidthViaMapParser.cpp
@@ -50,7 +50,6 @@ void MetalWidthViaMapParser::setPGVia()
 void MetalWidthViaMapParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in property LEF58_METALWIDTHVIAMAP"

--- a/src/odb/src/lefin/MetalWidthViaMapParser.cpp
+++ b/src/odb/src/lefin/MetalWidthViaMapParser.cpp
@@ -49,7 +49,7 @@ void MetalWidthViaMapParser::setPGVia()
 
 void MetalWidthViaMapParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in property LEF58_METALWIDTHVIAMAP"

--- a/src/odb/src/lefin/MetalWidthViaMapParser.cpp
+++ b/src/odb/src/lefin/MetalWidthViaMapParser.cpp
@@ -59,18 +59,19 @@ void MetalWidthViaMapParser::parse(const std::string& s)
   });
 }
 
-bool MetalWidthViaMapParser::parseSubRule(std::string s)
+bool MetalWidthViaMapParser::parseSubRule(const std::string& s)
 {
   cut_class_ = false;
-  qi::rule<std::string::iterator, std::string(), ascii::space_type> string_;
+  qi::rule<std::string::const_iterator, std::string(), ascii::space_type>
+      string_;
   string_ %= lexeme[(alpha >> *(char_ - ' ' - '\n'))];
-  qi::rule<std::string::iterator, space_type> ENTRY
+  qi::rule<std::string::const_iterator, space_type> ENTRY
       = (lit("VIA") >> (string_ >> double_ >> double_ >> -double_ >> -double_
                         >> string_)[boost::bind(
              &MetalWidthViaMapParser::addEntry, this, _1)]
          >> -lit(
              "PGVIA")[boost::bind(&MetalWidthViaMapParser::setPGVia, this)]);
-  qi::rule<std::string::iterator, space_type> METALWIDTHVIAMAP
+  qi::rule<std::string::const_iterator, space_type> METALWIDTHVIAMAP
       = (lit("METALWIDTHVIAMAP") >> -lit("USEVIACUTCLASS")[boost::bind(
              &MetalWidthViaMapParser::setCutClass, this)]
          >> +ENTRY >> lit(";"));

--- a/src/odb/src/lefin/MinCutParser.cpp
+++ b/src/odb/src/lefin/MinCutParser.cpp
@@ -58,7 +58,6 @@ void MinCutParser::setAreaWithin(double within)
 void MinCutParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in layer property LEF58_MINIMUMCUT for "

--- a/src/odb/src/lefin/MinCutParser.cpp
+++ b/src/odb/src/lefin/MinCutParser.cpp
@@ -68,25 +68,25 @@ void MinCutParser::parse(const std::string& s)
   });
 }
 
-bool MinCutParser::parseSubRule(std::string s)
+bool MinCutParser::parseSubRule(const std::string& s)
 {
   rule_ = dbTechLayerMinCutRule::create(layer_);
-  qi::rule<std::string::iterator, space_type> CUTCLASS
+  qi::rule<std::string::const_iterator, space_type> CUTCLASS
       = (lit("CUTCLASS") >> _string
          >> int_)[boost::bind(&MinCutParser::addCutClass, this, _1)];
-  qi::rule<std::string::iterator, space_type> WITHIN
+  qi::rule<std::string::const_iterator, space_type> WITHIN
       = (lit("WITHIN")
          >> double_)[boost::bind(&MinCutParser::setWithinCutDist, this, _1)];
-  qi::rule<std::string::iterator, space_type> LENGTH
+  qi::rule<std::string::const_iterator, space_type> LENGTH
       = (lit("LENGTH")
          >> double_[boost::bind(&MinCutParser::setLength, this, _1)]
          >> lit("WITHIN")
          >> double_[boost::bind(&MinCutParser::setLengthWithin, this, _1)]);
-  qi::rule<std::string::iterator, space_type> AREA
+  qi::rule<std::string::const_iterator, space_type> AREA
       = (lit("AREA") >> double_[boost::bind(&MinCutParser::setArea, this, _1)]
          >> -(lit("WITHIN")
               >> double_[boost::bind(&MinCutParser::setAreaWithin, this, _1)]));
-  qi::rule<std::string::iterator, space_type> LEF58_MINCUT
+  qi::rule<std::string::const_iterator, space_type> LEF58_MINCUT
       = (lit("MINIMUMCUT")
          >> (int_[boost::bind(&dbTechLayerMinCutRule::setNumCuts, rule_, _1)]
              | +CUTCLASS)

--- a/src/odb/src/lefin/MinCutParser.cpp
+++ b/src/odb/src/lefin/MinCutParser.cpp
@@ -57,7 +57,7 @@ void MinCutParser::setAreaWithin(double within)
 
 void MinCutParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in layer property LEF58_MINIMUMCUT for "

--- a/src/odb/src/lefin/MinCutParser.cpp
+++ b/src/odb/src/lefin/MinCutParser.cpp
@@ -10,6 +10,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 using namespace odb;
 
@@ -56,13 +57,7 @@ void MinCutParser::setAreaWithin(double within)
 
 void MinCutParser::parse(const std::string& s)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
@@ -71,7 +66,7 @@ void MinCutParser::parse(const std::string& s)
                       layer_->getName(),
                       rule);
     }
-  }
+  });
 }
 
 bool MinCutParser::parseSubRule(std::string s)

--- a/src/odb/src/lefin/WidthTableParser.cpp
+++ b/src/odb/src/lefin/WidthTableParser.cpp
@@ -44,7 +44,7 @@ bool WidthTableParser::parseSubRule(std::string s)
 
 void WidthTableParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseSubRule(rule)) {
       lefin_->warning(279,
                       "parse mismatch in layer property "

--- a/src/odb/src/lefin/WidthTableParser.cpp
+++ b/src/odb/src/lefin/WidthTableParser.cpp
@@ -45,7 +45,6 @@ bool WidthTableParser::parseSubRule(std::string s)
 void WidthTableParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(279,
                       "parse mismatch in layer property "

--- a/src/odb/src/lefin/WidthTableParser.cpp
+++ b/src/odb/src/lefin/WidthTableParser.cpp
@@ -10,6 +10,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 using namespace odb;
 
@@ -43,20 +44,14 @@ bool WidthTableParser::parseSubRule(std::string s)
 
 void WidthTableParser::parse(const std::string& s)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(279,
-                      "parse mismatch in layer property LEF58_WIDTHTABLE for "
-                      "layer {} :\"{}\"",
+                      "parse mismatch in layer property "
+                      "LEF58_WIDTHTABLE for layer {} :\"{}\"",
                       layer_->getName(),
                       rule);
     }
-  }
+  });
 }

--- a/src/odb/src/lefin/WidthTableParser.cpp
+++ b/src/odb/src/lefin/WidthTableParser.cpp
@@ -19,10 +19,10 @@ void WidthTableParser::addWidth(double width)
   rule_->addWidth(lefin_->dbdist(width));
 }
 
-bool WidthTableParser::parseSubRule(std::string s)
+bool WidthTableParser::parseSubRule(const std::string& s)
 {
   rule_ = dbTechLayerWidthTableRule::create(layer_);
-  qi::rule<std::string::iterator, space_type> LEF58_WIDTHTABLE
+  qi::rule<std::string::const_iterator, space_type> LEF58_WIDTHTABLE
       = (lit("WIDTHTABLE")
          >> +double_[boost::bind(&WidthTableParser::addWidth, this, _1)]
          >> -lit("WRONGDIRECTION")[boost::bind(

--- a/src/odb/src/lefin/boostParser.h
+++ b/src/odb/src/lefin/boostParser.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+// Common header for Boost.Spirit parser configurations used in LEF/DEF parsers
 #pragma once
 
 #include <boost/algorithm/string/classification.hpp>
@@ -25,12 +26,14 @@
 
 namespace odb {
 
+// Common namespace aliases for Boost.Spirit components
 namespace qi = boost::spirit::qi;
 namespace ascii = boost::spirit::ascii;
 namespace phoenix = boost::phoenix;
 
 using namespace boost::placeholders;
 
+// Common parser components
 using ascii::blank;
 using ascii::char_;
 using boost::fusion::at_c;
@@ -39,14 +42,18 @@ using boost::spirit::ascii::space_type;
 using boost::spirit::ascii::string;
 using boost::spirit::qi::lit;
 
+// Common parser rules
 using qi::double_;
 using qi::int_;
 using qi::lexeme;
 
+// Common parser utilities
 using ascii::space;
 using phoenix::ref;
 
-static const qi::rule<std::string::iterator, std::string(), ascii::space_type>
-    _string = lexeme[(alpha >> *(char_ - blank - '\n'))];
+// Rule for parsing strings: starts with alpha, followed by any non-blank chars
+static const qi::
+    rule<std::string::const_iterator, std::string(), ascii::space_type>
+        _string = lexeme[(alpha >> *(char_ - blank - '\n'))];
 
 }  // namespace odb

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -27,13 +27,13 @@ class lefTechLayerSpacingEolParser
 class lefTechLayerWrongDirSpacingParser
 {
  public:
-  static void parse(std::string, dbTechLayer*, lefinReader*);
+  static void parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerMinStepParser
 {
  public:
-  bool parse(std::string, dbTechLayer*, lefinReader*);
+  bool parse(const std::string&, dbTechLayer*, lefinReader*);
 
  private:
   odb::dbTechLayerMinStepRule* curRule;
@@ -54,7 +54,7 @@ class lefTechLayerMinStepParser
 class lefTechLayerCornerSpacingParser
 {
  public:
-  static bool parse(std::string, dbTechLayer*, lefinReader*);
+  static bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerSpacingTablePrlParser
@@ -66,38 +66,38 @@ class lefTechLayerSpacingTablePrlParser
   std::map<unsigned int, std::pair<int, int>> within_map;
   std::vector<std::tuple<int, int, int>> influence_tbl;
   int curWidthIdx = -1;
-  bool parse(std::string, dbTechLayer*, lefinReader*);
+  bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerRightWayOnGridOnlyParser
 {
  public:
-  static bool parse(std::string, dbTechLayer*, lefinReader*);
+  static bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerRectOnlyParser
 {
  public:
-  static bool parse(std::string, dbTechLayer*, lefinReader*);
+  static bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerTypeParser
 {
  public:
-  static bool parse(std::string, dbTechLayer*, lefinReader*);
+  static bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerCutClassParser
 {
  public:
-  static bool parse(std::string, dbTechLayer*, lefinReader*);
+  static bool parse(const std::string&, dbTechLayer*, lefinReader*);
 };
 
 class lefTechLayerCutSpacingParser
 {
  public:
   odb::dbTechLayerCutSpacingRule* curRule;
-  bool parse(std::string,
+  bool parse(const std::string&,
              dbTechLayer*,
              lefinReader*,
              std::vector<std::pair<odb::dbObject*, std::string>>&);
@@ -109,7 +109,7 @@ class lefTechLayerCutSpacingTableParser
   odb::dbTechLayerCutSpacingTableDefRule* curRule = nullptr;
   odb::dbTechLayer* layer;
   lefTechLayerCutSpacingTableParser(odb::dbTechLayer* inly) { layer = inly; };
-  bool parse(std::string,
+  bool parse(const std::string&,
              lefinReader*,
              std::vector<std::pair<odb::dbObject*, std::string>>&);
 };
@@ -122,7 +122,7 @@ class lefTechLayerCutEnclosureRuleParser
 
  private:
   lefinReader* lefin_;
-  bool parseSubRule(std::string, odb::dbTechLayer* layer);
+  bool parseSubRule(const std::string&, odb::dbTechLayer* layer);
   void setInt(double val,
               odb::dbTechLayerCutEnclosureRule* rule,
               void (odb::dbTechLayerCutEnclosureRule::*func)(int));
@@ -138,7 +138,7 @@ class lefTechLayerEolExtensionRuleParser
 
  private:
   lefinReader* lefin_;
-  bool parseSubRule(std::string, odb::dbTechLayer* layer);
+  bool parseSubRule(const std::string&, odb::dbTechLayer* layer);
   void setInt(double val,
               odb::dbTechLayerEolExtensionRule* rule,
               void (odb::dbTechLayerEolExtensionRule::*func)(int));
@@ -155,7 +155,7 @@ class lefTechLayerEolKeepOutRuleParser
   lefinReader* lefin_;
   void setExceptWithin(const boost::fusion::vector<double, double>& params,
                        odb::dbTechLayerEolKeepOutRule* rule);
-  bool parseSubRule(std::string, odb::dbTechLayer* layer);
+  bool parseSubRule(const std::string&, odb::dbTechLayer* layer);
   void setInt(double val,
               odb::dbTechLayerEolKeepOutRule* rule,
               void (odb::dbTechLayerEolKeepOutRule::*func)(int));
@@ -175,7 +175,7 @@ class lefTechLayerAreaRuleParser
  private:
   lefinReader* lefin_;
   bool parseSubRule(
-      std::string,
+      const std::string&,
       odb::dbTechLayer* layer,
       std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props);
   void setInt(double val,
@@ -198,7 +198,7 @@ class lefTechLayerPitchRuleParser
 {
  public:
   lefTechLayerPitchRuleParser(lefinReader*);
-  void parse(std::string, odb::dbTechLayer*);
+  void parse(const std::string&, odb::dbTechLayer*);
 
  private:
   void setInt(double val,
@@ -213,11 +213,11 @@ class lefTechLayerForbiddenSpacingRuleParser
 {
  public:
   lefTechLayerForbiddenSpacingRuleParser(lefinReader*);
-  void parse(std::string, odb::dbTechLayer*);
+  void parse(const std::string&, odb::dbTechLayer*);
 
  private:
   lefinReader* lefin_;
-  bool parseSubRule(std::string, odb::dbTechLayer* layer);
+  bool parseSubRule(const std::string&, odb::dbTechLayer* layer);
   void setInt(double val,
               odb::dbTechLayerForbiddenSpacingRule* rule,
               void (odb::dbTechLayerForbiddenSpacingRule::*func)(int));
@@ -229,11 +229,11 @@ class lefTechLayerTwoWiresForbiddenSpcRuleParser
 {
  public:
   lefTechLayerTwoWiresForbiddenSpcRuleParser(lefinReader*);
-  void parse(std::string, odb::dbTechLayer*);
+  void parse(const std::string&, odb::dbTechLayer*);
 
  private:
   lefinReader* lefin_;
-  bool parseSubRule(std::string, odb::dbTechLayer* layer);
+  bool parseSubRule(const std::string&, odb::dbTechLayer* layer);
   void setInt(double val,
               odb::dbTechLayerTwoWiresForbiddenSpcRule* rule,
               void (odb::dbTechLayerTwoWiresForbiddenSpcRule::*func)(int));
@@ -248,7 +248,7 @@ class ArraySpacingParser
       : layer_(layer), lefin_(lefinReader)
   {
   }
-  bool parse(std::string);
+  bool parse(const std::string&);
 
  private:
   void setCutClass(std::string name);
@@ -272,7 +272,7 @@ class WidthTableParser
 
  private:
   void addWidth(double width);
-  bool parseSubRule(std::string s);
+  bool parseSubRule(const std::string& s);
   dbTechLayer* layer_;
   lefinReader* lefin_;
   dbTechLayerWidthTableRule* rule_{nullptr};
@@ -288,7 +288,7 @@ class MinCutParser
   void parse(const std::string&);
 
  private:
-  bool parseSubRule(std::string);
+  bool parseSubRule(const std::string&);
   void addCutClass(boost::fusion::vector<std::string, int>&);
   void setWidth(double);
   void setWithinCutDist(double);
@@ -314,7 +314,7 @@ class MetalWidthViaMapParser
   void parse(const std::string&);
 
  private:
-  bool parseSubRule(std::string);
+  bool parseSubRule(const std::string&);
   void addEntry(boost::fusion::vector<std::string,
                                       double,
                                       double,
@@ -340,7 +340,7 @@ class KeepOutZoneParser
   void parse(const std::string&);
 
  private:
-  bool parseSubRule(std::string);
+  bool parseSubRule(const std::string&);
   void setInt(double val, void (odb::dbTechLayerKeepOutZoneRule::*func)(int));
   dbTechLayer* layer_;
   lefinReader* lefin_;
@@ -354,7 +354,7 @@ class MaxSpacingParser
       : layer_(layer), lefin_(lefinReader)
   {
   }
-  void parse(std::string);
+  void parse(const std::string&);
 
  private:
   void setMaxSpacing(dbTechLayerMaxSpacingRule*, double);

--- a/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
+++ b/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
@@ -13,7 +13,7 @@
 namespace odb {
 void lefMacroEdgeTypeParser::parse(const std::string& s)
 {
-  processRules(s, [this](std::string& rule) {
+  processRules(s, [this](const std::string& rule) {
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in layer property LEF58_EDGETYPE for "

--- a/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
+++ b/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
@@ -14,7 +14,6 @@ namespace odb {
 void lefMacroEdgeTypeParser::parse(const std::string& s)
 {
   processRules(s, [this](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
                       "parse mismatch in layer property LEF58_EDGETYPE for "

--- a/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
+++ b/src/odb/src/lefin/lefMacroEdgeTypeParser.cpp
@@ -8,17 +8,12 @@
 
 #include "boostParser.h"
 #include "lefMacroPropParser.h"
+#include "parserUtils.h"
 
 namespace odb {
 void lefMacroEdgeTypeParser::parse(const std::string& s)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule)) {
       lefin_->warning(299,
@@ -27,7 +22,7 @@ void lefMacroEdgeTypeParser::parse(const std::string& s)
                       master_->getName(),
                       rule);
     }
-  }
+  });
 }
 
 void lefMacroEdgeTypeParser::setRange(

--- a/src/odb/src/lefin/lefMacroPropParser.h
+++ b/src/odb/src/lefin/lefMacroPropParser.h
@@ -23,7 +23,7 @@ class lefMacroEdgeTypeParser
   {
   }
   void parse(const std::string&);
-  bool parseSubRule(std::string);
+  bool parseSubRule(const std::string&);
   void setRange(boost::fusion::vector<double, double>& params);
 
  private:

--- a/src/odb/src/lefin/lefMacroPropParser.h
+++ b/src/odb/src/lefin/lefMacroPropParser.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/fusion/container/vector.hpp>
 #include <string>
 #include <string_view>
 

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -25,7 +25,6 @@ void lefTechLayerAreaRuleParser::parse(
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
   processRules(s, [this, layer, &incomplete_props](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer, incomplete_props)) {
       lefin_->warning(278,
                       "parse mismatch in layer property LEF58_AREA for "

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022-2025, The OpenROAD Authors
 
+// Parser for LEF58 area rules that define minimum area requirements for shapes
 #include <functional>
 #include <string>
 #include <utility>
@@ -14,11 +15,13 @@
 
 namespace odb {
 
+// Initialize parser with LEF reader
 lefTechLayerAreaRuleParser::lefTechLayerAreaRuleParser(lefinReader* l)
 {
   lefin_ = l;
 }
 
+// Parse input string containing area rules for a layer
 void lefTechLayerAreaRuleParser::parse(
     const std::string& s,
     odb::dbTechLayer* layer,
@@ -35,6 +38,7 @@ void lefTechLayerAreaRuleParser::parse(
   });
 }
 
+// Helper function to set integer values (converts to database units)
 void lefTechLayerAreaRuleParser::setInt(
     double val,
     odb::dbTechLayerAreaRule* rule,
@@ -43,6 +47,7 @@ void lefTechLayerAreaRuleParser::setInt(
   (rule->*func)(lefin_->dbdist(val));
 }
 
+// Set edge length exception parameters
 void lefTechLayerAreaRuleParser::setExceptEdgeLengths(
     const boost::fusion::vector<double, double>& params,
     odb::dbTechLayerAreaRule* rule)
@@ -52,6 +57,7 @@ void lefTechLayerAreaRuleParser::setExceptEdgeLengths(
   rule->setExceptEdgeLengths(size);
 }
 
+// Set minimum size exception parameters
 void lefTechLayerAreaRuleParser::setExceptMinSize(
     const boost::fusion::vector<double, double>& params,
     odb::dbTechLayerAreaRule* rule)
@@ -61,6 +67,7 @@ void lefTechLayerAreaRuleParser::setExceptMinSize(
   rule->setExceptMinSize(size);
 }
 
+// Set step size exception parameters
 void lefTechLayerAreaRuleParser::setExceptStep(
     const boost::fusion::vector<double, double>& params,
     odb::dbTechLayerAreaRule* rule)
@@ -70,6 +77,7 @@ void lefTechLayerAreaRuleParser::setExceptStep(
   rule->setExceptStep(size);
 }
 
+// Set trim layer reference, handling incomplete properties
 void lefTechLayerAreaRuleParser::setTrimLayer(
     std::string val,
     odb::dbTechLayerAreaRule* rule,
@@ -84,14 +92,19 @@ void lefTechLayerAreaRuleParser::setTrimLayer(
   }
 }
 
+// Parse a single area rule
+// Format: AREA value [MASK mask] [EXCEPTMINWIDTH width] [EXCEPTEDGELENGTH
+// length1 length2]
+//         [EXCEPTMINSIZE width height] [EXCEPTSTEP stepx stepy] [RECTWIDTH
+//         width] [EXCEPTRECTANGLE] [LAYER name OVERLAP overlap] ;
 bool lefTechLayerAreaRuleParser::parseSubRule(
-    std::string s,
+    const std::string& s,
     odb::dbTechLayer* layer,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
   odb::dbTechLayerAreaRule* rule = odb::dbTechLayerAreaRule::create(layer);
 
-  qi::rule<std::string::iterator, space_type> EXCEPT_EDGE_LENGTH
+  qi::rule<std::string::const_iterator, space_type> EXCEPT_EDGE_LENGTH
       = ((lit("EXCEPTEDGELENGTH") >> double_ >> double_)[boost::bind(
              &lefTechLayerAreaRuleParser::setExceptEdgeLengths, this, _1, rule)]
          | lit("EXCEPTEDGELENGTH") >> double_[boost::bind(
@@ -101,15 +114,15 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
                rule,
                &dbTechLayerAreaRule::setExceptEdgeLength)]);
 
-  qi::rule<std::string::iterator, space_type> EXCEPT_MIN_SIZE
+  qi::rule<std::string::const_iterator, space_type> EXCEPT_MIN_SIZE
       = (lit("EXCEPTMINSIZE") >> double_ >> double_)[boost::bind(
           &lefTechLayerAreaRuleParser::setExceptMinSize, this, _1, rule)];
 
-  qi::rule<std::string::iterator, space_type> EXCEPT_STEP
+  qi::rule<std::string::const_iterator, space_type> EXCEPT_STEP
       = (lit("EXCEPTSTEP") >> double_ >> double_)[boost::bind(
           &lefTechLayerAreaRuleParser::setExceptStep, this, _1, rule)];
 
-  qi::rule<std::string::iterator, space_type> LAYER
+  qi::rule<std::string::const_iterator, space_type> LAYER
       = ((lit("LAYER")
           >> _string[boost::bind(&lefTechLayerAreaRuleParser::setTrimLayer,
                                  this,
@@ -120,7 +133,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
          >> lit("OVERLAP")
          >> int_[boost::bind(&odb::dbTechLayerAreaRule::setOverlap, rule, _1)]);
 
-  qi::rule<std::string::iterator, space_type> AREA
+  qi::rule<std::string::const_iterator, space_type> AREA
       = (lit("AREA") >> double_[boost::bind(&lefTechLayerAreaRuleParser::setInt,
                                             this,
                                             _1,

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -10,6 +10,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -23,13 +24,7 @@ void lefTechLayerAreaRuleParser::parse(
     odb::dbTechLayer* layer,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer, &incomplete_props](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer, incomplete_props)) {
       lefin_->warning(278,
@@ -38,7 +33,7 @@ void lefTechLayerAreaRuleParser::parse(
                       layer->getName(),
                       rule);
     }
-  }
+  });
 }
 
 void lefTechLayerAreaRuleParser::setInt(

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -24,7 +24,7 @@ void lefTechLayerAreaRuleParser::parse(
     odb::dbTechLayer* layer,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
-  processRules(s, [this, layer, &incomplete_props](std::string& rule) {
+  processRules(s, [this, layer, &incomplete_props](const std::string& rule) {
     if (!parseSubRule(rule, layer, incomplete_props)) {
       lefin_->warning(278,
                       "parse mismatch in layer property LEF58_AREA for "

--- a/src/odb/src/lefin/lefTechLayerCornerSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCornerSpacingParser.cpp
@@ -75,7 +75,7 @@ bool parse(Iterator first,
 {
   odb::dbTechLayerCornerSpacingRule* rule
       = odb::dbTechLayerCornerSpacingRule::create(layer);
-  qi::rule<std::string::iterator, space_type> convexCornerRule
+  qi::rule<std::string::const_iterator, space_type> convexCornerRule
       = (lit("CONVEXCORNER")[boost::bind(
              &odb::dbTechLayerCornerSpacingRule::setType,
              rule,
@@ -98,7 +98,7 @@ bool parse(Iterator first,
                        &odb::dbTechLayerCornerSpacingRule::setIncludeShape,
                        rule,
                        true)]))));
-  qi::rule<std::string::iterator, space_type> concaveCornerRule
+  qi::rule<std::string::const_iterator, space_type> concaveCornerRule
       = (lit("CONCAVECORNER")[boost::bind(
              &odb::dbTechLayerCornerSpacingRule::setType,
              rule,
@@ -111,7 +111,7 @@ bool parse(Iterator first,
                        true)]
                    >> -double_[boost::bind(
                        &setExceptNotchLength, _1, rule, lefinReader)])));
-  qi::rule<std::string::iterator, space_type> exceptSameRule
+  qi::rule<std::string::const_iterator, space_type> exceptSameRule
       = (lit("EXCEPTSAMENET")[boost::bind(
              &odb::dbTechLayerCornerSpacingRule::setExceptSameNet, rule, true)]
          | lit("EXCEPTSAMEMETAL")[boost::bind(
@@ -119,11 +119,11 @@ bool parse(Iterator first,
              rule,
              true)]);
 
-  qi::rule<std::string::iterator, space_type> spacingRule
+  qi::rule<std::string::const_iterator, space_type> spacingRule
       = (lit("WIDTH") >> double_ >> lit("SPACING") >> double_
          >> -double_)[boost::bind(&addSpacing, _1, rule, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> cornerSpacingRule
+  qi::rule<std::string::const_iterator, space_type> cornerSpacingRule
       = (lit("CORNERSPACING") >> (convexCornerRule | concaveCornerRule)
          >> -(exceptSameRule) >> +(spacingRule) >> lit(";"));
 
@@ -140,7 +140,7 @@ bool parse(Iterator first,
 
 namespace odb {
 
-bool lefTechLayerCornerSpacingParser::parse(std::string s,
+bool lefTechLayerCornerSpacingParser::parse(const std::string& s,
                                             dbTechLayer* layer,
                                             odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/lefTechLayerCutClassParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutClassParser.cpp
@@ -43,13 +43,13 @@ void addCutClassRule(
 }  // namespace odb::lefTechLayerCutClass
 
 namespace odb {
-bool lefTechLayerCutClassParser::parse(std::string s,
+bool lefTechLayerCutClassParser::parse(const std::string& s,
                                        dbTechLayer* layer,
                                        odb::lefinReader* lefin)
 {
   auto first = s.begin();
   auto last = s.end();
-  qi::rule<std::string::iterator, space_type> cutClassRule
+  qi::rule<std::string::const_iterator, space_type> cutClassRule
       = (+(lit("CUTCLASS") >> _string >> lit("WIDTH") >> double_
            >> -(lit("LENGTH") >> double_) >> -(lit("CUTS") >> int_)
            >> -(lit("ORIENT") >> _string) >> lit(";"))[boost::bind(

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
@@ -9,6 +9,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -21,13 +22,7 @@ lefTechLayerCutEnclosureRuleParser::lefTechLayerCutEnclosureRuleParser(
 void lefTechLayerCutEnclosureRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
@@ -36,7 +31,7 @@ void lefTechLayerCutEnclosureRuleParser::parse(const std::string& s,
                       layer->getName(),
                       rule);
     }
-  }
+  });
 }
 void lefTechLayerCutEnclosureRuleParser::setCutClass(
     std::string val,

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
@@ -56,12 +56,12 @@ void lefTechLayerCutEnclosureRuleParser::setInt(
 {
   (rule->*func)(lefin_->dbdist(val));
 }
-bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
+bool lefTechLayerCutEnclosureRuleParser::parseSubRule(const std::string& s,
                                                       odb::dbTechLayer* layer)
 {
   odb::dbTechLayerCutEnclosureRule* rule
       = odb::dbTechLayerCutEnclosureRule::create(layer);
-  qi::rule<std::string::iterator, space_type> EOL
+  qi::rule<std::string::const_iterator, space_type> EOL
       = (lit("EOL")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setType,
              rule,
@@ -136,7 +136,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                      rule,
                      &odb::dbTechLayerCutEnclosureRule::setExtension)])));
 
-  qi::rule<std::string::iterator, space_type> DEFAULT
+  qi::rule<std::string::const_iterator, space_type> DEFAULT
       = (double_[boost::bind(
              &lefTechLayerCutEnclosureRuleParser::setInt,
              this,
@@ -153,7 +153,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                        rule,
                        odb::dbTechLayerCutEnclosureRule::ENC_TYPE::DEFAULT)];
 
-  qi::rule<std::string::iterator, space_type> ENDSIDE
+  qi::rule<std::string::const_iterator, space_type> ENDSIDE
       = (-lit("OFFCENTERLINE")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setOffCenterLine, rule, true)]
          >> lit("END") >> double_[boost::bind(
@@ -172,7 +172,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                        rule,
                        odb::dbTechLayerCutEnclosureRule::ENC_TYPE::ENDSIDE)];
 
-  qi::rule<std::string::iterator, space_type> HORZ_AND_VERT
+  qi::rule<std::string::const_iterator, space_type> HORZ_AND_VERT
       = (lit("HORIZONTAL") >> double_[boost::bind(
              &lefTechLayerCutEnclosureRuleParser::setInt,
              this,
@@ -190,7 +190,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
               rule,
               odb::dbTechLayerCutEnclosureRule::ENC_TYPE::HORZ_AND_VERT)];
 
-  qi::rule<std::string::iterator, space_type> WIDTH_
+  qi::rule<std::string::const_iterator, space_type> WIDTH_
       = (lit("WIDTH")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setWidthValid, rule, true)]
          >> double_[boost::bind(&lefTechLayerCutEnclosureRuleParser::setInt,
@@ -217,7 +217,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                        rule,
                        true)])));
 
-  qi::rule<std::string::iterator, space_type> LENGTH
+  qi::rule<std::string::const_iterator, space_type> LENGTH
       = (lit("LENGTH")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setLengthValid, rule, true)]
          >> double_[boost::bind(
@@ -227,13 +227,13 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
              rule,
              &odb::dbTechLayerCutEnclosureRule::setMinLength)]);
 
-  qi::rule<std::string::iterator, space_type> EXTRACUT
+  qi::rule<std::string::const_iterator, space_type> EXTRACUT
       = (lit("EXTRACUT")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setExtraCutValid, rule, true)]
          >> -lit("EXTRAONLY")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setExtraOnly, rule, true)]);
 
-  qi::rule<std::string::iterator, space_type> REDUNDANTCUT
+  qi::rule<std::string::const_iterator, space_type> REDUNDANTCUT
       = (lit("REDUNDANTCUT")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setRedundantCutValid,
              rule,
@@ -245,7 +245,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
              rule,
              &odb::dbTechLayerCutEnclosureRule::setCutWithin)]);
 
-  qi::rule<std::string::iterator, space_type> PARALLEL
+  qi::rule<std::string::const_iterator, space_type> PARALLEL
       = (lit("PARALLEL")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setConcaveCornersValid,
              rule,
@@ -285,7 +285,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                   rule,
                   &odb::dbTechLayerCutEnclosureRule::setBelowEnclosure)]));
 
-  qi::rule<std::string::iterator, space_type> CONCAVECORNERS
+  qi::rule<std::string::const_iterator, space_type> CONCAVECORNERS
       = (lit("CONCAVECORNERS")[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setConcaveCornersValid,
              rule,
@@ -293,7 +293,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
          >> int_[boost::bind(
              &odb::dbTechLayerCutEnclosureRule::setNumCorners, rule, _1)]);
 
-  qi::rule<std::string::iterator, space_type> CUTCLASS
+  qi::rule<std::string::const_iterator, space_type> CUTCLASS
       = (-(lit("CUTCLASS") >> _string)[boost::bind(
              &lefTechLayerCutEnclosureRuleParser::setCutClass,
              this,
@@ -304,7 +304,7 @@ bool lefTechLayerCutEnclosureRuleParser::parseSubRule(std::string s,
                   &odb::dbTechLayerCutEnclosureRule::setAbove, rule, true)]
               | lit("BELOW")[boost::bind(
                   &odb::dbTechLayerCutEnclosureRule::setBelow, rule, true)]));
-  qi::rule<std::string::iterator, space_type> ENCLOSURE
+  qi::rule<std::string::const_iterator, space_type> ENCLOSURE
       = (lit("ENCLOSURE") >> CUTCLASS
          >> (EOL | DEFAULT | ENDSIDE | HORZ_AND_VERT) >> -WIDTH_ >> -LENGTH
          >> -EXTRACUT >> -REDUNDANTCUT >> -PARALLEL >> -CONCAVECORNERS

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
@@ -22,7 +22,7 @@ lefTechLayerCutEnclosureRuleParser::lefTechLayerCutEnclosureRuleParser(
 void lefTechLayerCutEnclosureRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
-  processRules(s, [this, layer](std::string& rule) {
+  processRules(s, [this, layer](const std::string& rule) {
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
                       "parse mismatch in layer property LEF58_ENCLOSURE for "

--- a/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutEnclosureParser.cpp
@@ -23,7 +23,6 @@ void lefTechLayerCutEnclosureRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
                       "parse mismatch in layer property LEF58_ENCLOSURE for "

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -328,7 +328,7 @@ bool parse(
     odb::lefinReader* lefinReader,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
-  qi::rule<std::string::iterator, space_type> LAYER_CUTCLASS
+  qi::rule<std::string::const_iterator, space_type> LAYER_CUTCLASS
       = (lit("CUTCLASS")
          >> _string[boost::bind(&setCutClass, _1, parser, layer)] >> -(
              lit("SHORTEDGEONLY")[boost::bind(
@@ -376,7 +376,7 @@ bool parse(
                  parser,
                  &odb::dbTechLayerCutSpacingRule::setWrongDirection,
                  true)]));
-  qi::rule<std::string::iterator, space_type> LAYER
+  qi::rule<std::string::const_iterator, space_type> LAYER
       = (lit("LAYER") >> _string[boost::bind(
              &addLayerSubRule, _1, parser, layer, boost::ref(incomplete_props))]
          >> -(
@@ -388,7 +388,7 @@ bool parse(
                    &setOrthogonalSpacing, _1, parser, lefinReader)]
              | LAYER_CUTCLASS));
 
-  qi::rule<std::string::iterator, space_type> ADJACENTCUTS
+  qi::rule<std::string::const_iterator, space_type> ADJACENTCUTS
       = (lit("ADJACENTCUTS") >> (string("1") | string("2") | string("3"))
          >> -(lit("EXACTALIGNED") >> int_)
          >> -(lit("TWOCUTS") >> int_ >> -lit("SAMECUT")[boost::bind(
@@ -406,12 +406,12 @@ bool parse(
          >> -string("SAMEMASK"))[boost::bind(
           &addAdjacentCutsSubRule, _1, parser, layer, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> PARALLELOVERLAP
+  qi::rule<std::string::const_iterator, space_type> PARALLELOVERLAP
       = (lit("PARALLELOVERLAP")
          >> -(string("EXCEPTSAMENET") | string("EXCEPTSAMEMETAL")
               | string("EXCEPTSAMEVIA") | string("EXCEPTSAMEMETALOVERLAP")))
           [boost::bind(&addParallelOverlapSubRule, _1, parser)];
-  qi::rule<std::string::iterator, space_type> PARALLELWITHIN_CUTCLASS
+  qi::rule<std::string::const_iterator, space_type> PARALLELWITHIN_CUTCLASS
       = (lit("CUTCLASS")
          >> _string[boost::bind(&setCutClass, _1, parser, layer)]
          >> -(lit("LONGEDGEONLY")[boost::bind(
@@ -424,23 +424,23 @@ bool parse(
                  >> double_ >> lit("WITHIN") >> double_)[boost::bind(
                   &setParWithinEnclosure, _1, parser, lefinReader)]));
 
-  qi::rule<std::string::iterator, space_type> PARALLELWITHIN
+  qi::rule<std::string::const_iterator, space_type> PARALLELWITHIN
       = ((lit("PARALLELWITHIN") >> double_
           >> -string("EXCEPTSAMENET"))[boost::bind(
              &addParallelWithinSubRule, _1, parser, lefinReader)]
          >> -PARALLELWITHIN_CUTCLASS);
 
-  qi::rule<std::string::iterator, space_type> SAMEMETALSHAREDEDGE
+  qi::rule<std::string::const_iterator, space_type> SAMEMETALSHAREDEDGE
       = (lit("SAMEMETALSHAREDEDGE") >> double_ >> -string("ABOVE")
          >> -(lit("CUTCLASS") >> _string) >> -string("EXCEPTTWOEDGES")
          >> -(lit("EXCEPTSAMEVIA") >> int_))[boost::bind(
           &addSameMetalSharedEdgeSubRule, _1, parser, layer, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> AREA
+  qi::rule<std::string::const_iterator, space_type> AREA
       = (lit("AREA")
          >> double_)[boost::bind(&addAreaSubRule, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> LEF58_SPACING = (+(
+  qi::rule<std::string::const_iterator, space_type> LEF58_SPACING = (+(
       lit("SPACING")
       >> double_[boost::bind(&setCutSpacing, _1, parser, layer, lefinReader)]
       >> -(lit("MAXXY")[boost::bind(&addMaxXYSubRule, parser)]
@@ -470,7 +470,7 @@ bool parse(
 namespace odb {
 
 bool lefTechLayerCutSpacingParser::parse(
-    std::string s,
+    const std::string& s,
     odb::dbTechLayer* layer,
     odb::lefinReader* l,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)

--- a/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
@@ -353,13 +353,13 @@ bool parse(
     odb::lefinReader* lefinReader,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
-  qi::rule<std::string::iterator, space_type> ORTHOGONAL
+  qi::rule<std::string::const_iterator, space_type> ORTHOGONAL
       = (lit("SPACINGTABLE") >> lit("ORTHOGONAL")
          >> +(lit("WITHIN") >> double_ >> lit("SPACING") >> double_)
          >> lit(";"))[boost::bind(
           &createOrthongonalSubRule, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> LAYER
+  qi::rule<std::string::const_iterator, space_type> LAYER
       = (lit("LAYER") >> _string[boost::bind(
              &setLayer, _1, parser, boost::ref(incomplete_props))]
          >> -lit("NOSTACK")[boost::bind(&setNoStack, parser)]
@@ -368,21 +368,21 @@ bool parse(
                  >> +(_string >> lit("TO") >> _string))[boost::bind(
                   &setPrlForAlignedCut, _1, parser)]));
 
-  qi::rule<std::string::iterator, space_type> CENTERTOCENTER
+  qi::rule<std::string::const_iterator, space_type> CENTERTOCENTER
       = (lit("CENTERTOCENTER")
          >> +(_string >> lit("TO")
               >> _string))[boost::bind(&setCenterToCenter, _1, parser)];
 
-  qi::rule<std::string::iterator, space_type> CENTERANDEDGE
+  qi::rule<std::string::const_iterator, space_type> CENTERANDEDGE
       = (lit("CENTERANDEDGE") >> -lit("NOPRL")[boost::bind(&setNoPrl, parser)]
          >> (+(_string >> lit("TO")
                >> _string))[boost::bind(&setCenterAndEdge, _1, parser)]);
-  qi::rule<std::string::iterator, space_type> PRL
+  qi::rule<std::string::const_iterator, space_type> PRL
       = (lit("PRL") >> double_ >> -(string("HORIZONTAL") | string("VERTICAL"))
          >> -string("MAXXY")
          >> *(_string >> lit("TO") >> _string
               >> double_))[boost::bind(&setPRL, _1, parser, lefinReader)];
-  qi::rule<std::string::iterator, space_type> EXTENSION
+  qi::rule<std::string::const_iterator, space_type> EXTENSION
       = ((lit("ENDEXTENSION") >> double_
           >> *(lit("TO") >> _string >> double_))[boost::bind(
              &setEndExtension, _1, parser, lefinReader)]
@@ -390,23 +390,24 @@ bool parse(
               >> +(lit("TO") >> _string >> double_))[boost::bind(
              &setSideExtension, _1, parser, lefinReader)]);
 
-  qi::rule<std::string::iterator, space_type> EXACTALIGNEDSPACING
+  qi::rule<std::string::const_iterator, space_type> EXACTALIGNEDSPACING
       = (lit("EXACTALIGNEDSPACING")
          >> -(string("HORIZONTAL") | string("VERTICAL"))
          >> +(_string >> double_))[boost::bind(
           &setExactAlignedSpacing, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> NONOPPOSITEENCLOSURESPACING
+  qi::rule<std::string::const_iterator, space_type> NONOPPOSITEENCLOSURESPACING
       = (lit("NONOPPOSITEENCLOSURESPACING")
          >> +(_string >> double_))[boost::bind(
           &setNonOppositeEnclosureSpacing, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> OPPOSITEENCLOSURERESIZESPACING
+  qi::rule<std::string::const_iterator, space_type>
+      OPPOSITEENCLOSURERESIZESPACING
       = (lit("OPPOSITEENCLOSURERESIZESPACING")
          >> +(_string >> double_ >> double_ >> double_))[boost::bind(
           &setOppositeEnclosureResizeSpacing, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> CUTCLASS
+  qi::rule<std::string::const_iterator, space_type> CUTCLASS
       = (lit("CUTCLASS")
          >> +(_string
               >> -(string("SIDE")
@@ -419,7 +420,7 @@ bool parse(
                        | double_)))  // REMAINING ROWS (3rd and below)
          )[boost::bind(&setCutClass, _1, parser, lefinReader)];
 
-  qi::rule<std::string::iterator, space_type> DEFAULT
+  qi::rule<std::string::const_iterator, space_type> DEFAULT
       = (lit("SPACINGTABLE")[boost::bind(&createDefSubRule, parser)]
          >> -(lit("DEFAULT")
               >> double_[boost::bind(&setDefault, _1, parser, lefinReader)])
@@ -431,7 +432,7 @@ bool parse(
          >> -EXACTALIGNEDSPACING >> -NONOPPOSITEENCLOSURESPACING
          >> -OPPOSITEENCLOSURERESIZESPACING >> CUTCLASS >> lit(";"));
 
-  qi::rule<std::string::iterator, space_type> LEF58_SPACINGTABLE
+  qi::rule<std::string::const_iterator, space_type> LEF58_SPACINGTABLE
       = (+(ORTHOGONAL | DEFAULT));
   bool valid = qi::phrase_parse(first, last, LEF58_SPACINGTABLE, space)
                && first == last;
@@ -449,7 +450,7 @@ bool parse(
 namespace odb {
 
 bool lefTechLayerCutSpacingTableParser::parse(
-    std::string s,
+    const std::string& s,
     odb::lefinReader* l,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {

--- a/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
@@ -22,7 +22,7 @@ lefTechLayerEolExtensionRuleParser::lefTechLayerEolExtensionRuleParser(
 void lefTechLayerEolExtensionRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
-  processRules(s, [this, layer](std::string& rule) {
+  processRules(s, [this, layer](const std::string& rule) {
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
                       "parse mismatch in layer property "

--- a/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
@@ -23,7 +23,6 @@ void lefTechLayerEolExtensionRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
                       "parse mismatch in layer property "

--- a/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
@@ -9,6 +9,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -21,13 +22,7 @@ lefTechLayerEolExtensionRuleParser::lefTechLayerEolExtensionRuleParser(
 void lefTechLayerEolExtensionRuleParser::parse(const std::string& s,
                                                odb::dbTechLayer* layer)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(260,
@@ -36,7 +31,7 @@ void lefTechLayerEolExtensionRuleParser::parse(const std::string& s,
                       layer->getName(),
                       rule);
     }
-  }
+  });
 }
 
 void lefTechLayerEolExtensionRuleParser::setInt(

--- a/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolExtensionParser.cpp
@@ -48,18 +48,18 @@ void lefTechLayerEolExtensionRuleParser::addEntry(
   double ext = at_c<1>(params);
   rule->addEntry(lefin_->dbdist(eol), lefin_->dbdist(ext));
 }
-bool lefTechLayerEolExtensionRuleParser::parseSubRule(std::string s,
+bool lefTechLayerEolExtensionRuleParser::parseSubRule(const std::string& s,
                                                       odb::dbTechLayer* layer)
 {
   odb::dbTechLayerEolExtensionRule* rule
       = odb::dbTechLayerEolExtensionRule::create(layer);
 
-  qi::rule<std::string::iterator, space_type> EXTENSION_ENTRY
+  qi::rule<std::string::const_iterator, space_type> EXTENSION_ENTRY
       = (lit("ENDOFLINE") >> double_ >> lit("EXTENSION")
          >> double_)[boost::bind(
           &lefTechLayerEolExtensionRuleParser::addEntry, this, _1, rule)];
 
-  qi::rule<std::string::iterator, space_type> EOLEXTENSIONSPACING
+  qi::rule<std::string::const_iterator, space_type> EOLEXTENSIONSPACING
       = (lit("EOLEXTENSIONSPACING")
          >> double_[boost::bind(&lefTechLayerEolExtensionRuleParser::setInt,
                                 this,

--- a/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
@@ -9,6 +9,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -21,13 +22,7 @@ lefTechLayerEolKeepOutRuleParser::lefTechLayerEolKeepOutRuleParser(
 void lefTechLayerEolKeepOutRuleParser::parse(const std::string& s,
                                              odb::dbTechLayer* layer)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(280,
@@ -36,7 +31,7 @@ void lefTechLayerEolKeepOutRuleParser::parse(const std::string& s,
                       layer->getName(),
                       rule);
     }
-  }
+  });
 }
 void lefTechLayerEolKeepOutRuleParser::setClass(
     std::string val,

--- a/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
@@ -23,7 +23,6 @@ void lefTechLayerEolKeepOutRuleParser::parse(const std::string& s,
                                              odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(280,
                       "parse mismatch in layer property LEF58_EOLKEEPOUT for "

--- a/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
@@ -57,22 +57,22 @@ void lefTechLayerEolKeepOutRuleParser::setInt(
 {
   (rule->*func)(lefin_->dbdist(val));
 }
-bool lefTechLayerEolKeepOutRuleParser::parseSubRule(std::string s,
+bool lefTechLayerEolKeepOutRuleParser::parseSubRule(const std::string& s,
                                                     odb::dbTechLayer* layer)
 {
   odb::dbTechLayerEolKeepOutRule* rule
       = odb::dbTechLayerEolKeepOutRule::create(layer);
-  qi::rule<std::string::iterator, space_type> EXCEPTWITHIN
+  qi::rule<std::string::const_iterator, space_type> EXCEPTWITHIN
       = (lit("EXCEPTWITHIN") >> double_ >> double_)[boost::bind(
           &lefTechLayerEolKeepOutRuleParser::setExceptWithin, this, _1, rule)];
-  qi::rule<std::string::iterator, space_type> CLASS
+  qi::rule<std::string::const_iterator, space_type> CLASS
       = (lit("CLASS")
          >> _string[boost::bind(&lefTechLayerEolKeepOutRuleParser::setClass,
                                 this,
                                 _1,
                                 rule,
                                 layer)]);
-  qi::rule<std::string::iterator, space_type> EOLKEEPOUT
+  qi::rule<std::string::const_iterator, space_type> EOLKEEPOUT
       = (lit("EOLKEEPOUT")
          >> double_[boost::bind(&lefTechLayerEolKeepOutRuleParser::setInt,
                                 this,

--- a/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerEolKeepOutRuleParser.cpp
@@ -22,7 +22,7 @@ lefTechLayerEolKeepOutRuleParser::lefTechLayerEolKeepOutRuleParser(
 void lefTechLayerEolKeepOutRuleParser::parse(const std::string& s,
                                              odb::dbTechLayer* layer)
 {
-  processRules(s, [this, layer](std::string& rule) {
+  processRules(s, [this, layer](const std::string& rule) {
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(280,
                       "parse mismatch in layer property LEF58_EOLKEEPOUT for "

--- a/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
@@ -20,7 +20,7 @@ lefTechLayerForbiddenSpacingRuleParser::lefTechLayerForbiddenSpacingRuleParser(
   lefin_ = l;
 }
 
-void lefTechLayerForbiddenSpacingRuleParser::parse(std::string s,
+void lefTechLayerForbiddenSpacingRuleParser::parse(const std::string& s,
                                                    odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](const std::string& rule) {
@@ -53,15 +53,16 @@ void lefTechLayerForbiddenSpacingRuleParser::setForbiddenSpacing(
 }
 
 bool lefTechLayerForbiddenSpacingRuleParser::parseSubRule(
-    std::string s,
+    const std::string& s,
     odb::dbTechLayer* layer)
 {
-  qi::rule<std::string::iterator, std::string(), ascii::space_type> _string;
+  qi::rule<std::string::const_iterator, std::string(), ascii::space_type>
+      _string;
   _string %= lexeme[+(char_ - ' ')];
   odb::dbTechLayerForbiddenSpacingRule* rule
       = odb::dbTechLayerForbiddenSpacingRule::create(layer);
 
-  qi::rule<std::string::iterator, space_type> forbiddenSpacing
+  qi::rule<std::string::const_iterator, space_type> forbiddenSpacing
       = (lit("FORBIDDENSPACING") >> double_ >> double_)[boost::bind(
             &lefTechLayerForbiddenSpacingRuleParser::setForbiddenSpacing,
             this,

--- a/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
@@ -10,6 +10,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -22,13 +23,7 @@ lefTechLayerForbiddenSpacingRuleParser::lefTechLayerForbiddenSpacingRuleParser(
 void lefTechLayerForbiddenSpacingRuleParser::parse(std::string s,
                                                    odb::dbTechLayer* layer)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
@@ -38,7 +33,7 @@ void lefTechLayerForbiddenSpacingRuleParser::parse(std::string s,
           layer->getName(),
           rule);
     }
-  }
+  });
 }
 
 void lefTechLayerForbiddenSpacingRuleParser::setInt(

--- a/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
@@ -23,7 +23,7 @@ lefTechLayerForbiddenSpacingRuleParser::lefTechLayerForbiddenSpacingRuleParser(
 void lefTechLayerForbiddenSpacingRuleParser::parse(std::string s,
                                                    odb::dbTechLayer* layer)
 {
-  processRules(s, [this, layer](std::string& rule) {
+  processRules(s, [this, layer](const std::string& rule) {
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
           438,

--- a/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerForbiddenSpacingRuleParser.cpp
@@ -24,7 +24,6 @@ void lefTechLayerForbiddenSpacingRuleParser::parse(std::string s,
                                                    odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
           438,

--- a/src/odb/src/lefin/lefTechLayerMinStepParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerMinStepParser.cpp
@@ -77,16 +77,16 @@ void lefTechLayerMinStepParser::setExceptSameCorners()
   curRule->setExceptSameCorners(true);
 }
 
-bool lefTechLayerMinStepParser::parse(std::string s,
+bool lefTechLayerMinStepParser::parse(const std::string& s,
                                       dbTechLayer* layer,
                                       odb::lefinReader* l)
 {
-  qi::rule<std::string::iterator, space_type> convexConcaveRule
+  qi::rule<std::string::const_iterator, space_type> convexConcaveRule
       = (string("CONVEXCORNER")[boost::bind(
              &lefTechLayerMinStepParser::setConvexCorner, this)]
          | string("CONCAVECORNER")[boost::bind(
              &lefTechLayerMinStepParser::setConcaveCorner, this)]);
-  qi::rule<std::string::iterator, space_type> minAdjacentRule
+  qi::rule<std::string::const_iterator, space_type> minAdjacentRule
       = (lit("MINADJACENTLENGTH") >> double_[boost::bind(
              &lefTechLayerMinStepParser::setMinAdjacentLength1, this, _1, l)]
          >> -(convexConcaveRule
@@ -96,15 +96,15 @@ bool lefTechLayerMinStepParser::parse(std::string s,
                   _1,
                   l)]));
 
-  qi::rule<std::string::iterator, space_type> minBetweenLengthRule
+  qi::rule<std::string::const_iterator, space_type> minBetweenLengthRule
       = (lit("MINBETWEENLENGTH") >> (double_[boost::bind(
              &lefTechLayerMinStepParser::minBetweenLengthParser, this, _1, l)])
          >> -(lit("EXCEPTSAMECORNERS")[boost::bind(
              &lefTechLayerMinStepParser::setExceptSameCorners, this)]));
-  qi::rule<std::string::iterator, space_type> noBetweenEolRule
+  qi::rule<std::string::const_iterator, space_type> noBetweenEolRule
       = (lit("NOBETWEENEOL") >> double_)[boost::bind(
           &lefTechLayerMinStepParser::noBetweenEolParser, this, _1, l)];
-  qi::rule<std::string::iterator, space_type> noAdjacentEolRule
+  qi::rule<std::string::const_iterator, space_type> noAdjacentEolRule
       = (lit("NOADJACENTEOL") >> double_)[boost::bind(
             &lefTechLayerMinStepParser::noAdjacentEolParser, this, _1, l)]
         >> -(lit("MINADJACENTLENGTH") >> double_[boost::bind(
@@ -112,7 +112,7 @@ bool lefTechLayerMinStepParser::parse(std::string s,
                  this,
                  _1,
                  l)]);
-  qi::rule<std::string::iterator, space_type> minstepRule
+  qi::rule<std::string::const_iterator, space_type> minstepRule
       = (+(lit("MINSTEP")[boost::bind(
                &lefTechLayerMinStepParser::createSubRule, this, layer)]
            >> double_[boost::bind(

--- a/src/odb/src/lefin/lefTechLayerPitchRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerPitchRuleParser.cpp
@@ -17,9 +17,10 @@ lefTechLayerPitchRuleParser::lefTechLayerPitchRuleParser(lefinReader* l)
   lefin_ = l;
 }
 
-void lefTechLayerPitchRuleParser::parse(std::string s, odb::dbTechLayer* layer)
+void lefTechLayerPitchRuleParser::parse(const std::string& s,
+                                        odb::dbTechLayer* layer)
 {
-  qi::rule<std::string::iterator, space_type> PITCH
+  qi::rule<std::string::const_iterator, space_type> PITCH
       = ((lit("PITCH") >> double_ >> double_)[boost::bind(
              &odb::lefTechLayerPitchRuleParser::setPitchXY, this, _1, layer)]
          | lit("PITCH")
@@ -29,7 +30,7 @@ void lefTechLayerPitchRuleParser::parse(std::string s, odb::dbTechLayer* layer)
                                       layer,
                                       &odb::dbTechLayer::setPitch)]);
 
-  qi::rule<std::string::iterator, space_type> FIRST_LAST_PTICH
+  qi::rule<std::string::const_iterator, space_type> FIRST_LAST_PTICH
       = (PITCH
          >> -(lit("FIRSTLASTPITCH")
               >> double_[boost::bind(&odb::lefTechLayerPitchRuleParser::setInt,

--- a/src/odb/src/lefin/lefTechLayerRectOnlyParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerRectOnlyParser.cpp
@@ -17,7 +17,7 @@ bool parse(Iterator first,
            odb::dbTechLayer* layer,
            odb::lefinReader* lefinReader)
 {
-  qi::rule<std::string::iterator, space_type> rightWayOnGridOnlyRule
+  qi::rule<std::string::const_iterator, space_type> rightWayOnGridOnlyRule
       = (lit("RECTONLY")[boost::bind(
              &odb::dbTechLayer::setRectOnly, layer, true)]
          >> -lit("EXCEPTNONCOREPINS")[boost::bind(
@@ -32,7 +32,7 @@ bool parse(Iterator first,
 
 namespace odb {
 
-bool lefTechLayerRectOnlyParser::parse(std::string s,
+bool lefTechLayerRectOnlyParser::parse(const std::string& s,
                                        dbTechLayer* layer,
                                        odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/lefTechLayerRightWayOnGridOnlyParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerRightWayOnGridOnlyParser.cpp
@@ -17,7 +17,7 @@ bool parse(Iterator first,
            odb::dbTechLayer* layer,
            odb::lefinReader* lefinReader)
 {
-  qi::rule<std::string::iterator, space_type> rightWayOnGridOnlyRule
+  qi::rule<std::string::const_iterator, space_type> rightWayOnGridOnlyRule
       = (lit("RIGHTWAYONGRIDONLY")[boost::bind(
              &odb::dbTechLayer::setRightWayOnGridOnly, layer, true)]
          >> -lit("CHECKMASK")[boost::bind(
@@ -31,7 +31,7 @@ bool parse(Iterator first,
 
 namespace odb {
 
-bool lefTechLayerRightWayOnGridOnlyParser::parse(std::string s,
+bool lefTechLayerRightWayOnGridOnlyParser::parse(const std::string& s,
                                                  dbTechLayer* layer,
                                                  odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
@@ -363,9 +363,7 @@ void wrongDirSpaceParser(double value,
   sc->setWrongDirSpace(l->dbdist(value));
 }
 
-template <typename Iterator>
-bool parse(Iterator first,
-           Iterator last,
+bool parse(std::string s,
            odb::dbTechLayer* layer,
            odb::lefinReader* l)
 {
@@ -454,7 +452,9 @@ bool parse(Iterator first,
               >> double_[boost::bind(&wrongDirSpaceParser, _1, sc, l)])
          >> (withinRule | toconcavecornerrule | tonotchlengthrule)
          >> -lit(";"));
-
+  
+  auto first = s.begin();
+  auto last = s.end();
   bool valid
       = qi::phrase_parse(first, last, spacingRule, space) && first == last;
 
@@ -471,7 +471,7 @@ void lefTechLayerSpacingEolParser::parse(const std::string& s,
                                          dbTechLayer* layer,
                                          odb::lefinReader* l)
 {
-  processRules(s, [layer, l](std::string& rule) {
+  processRules(s, [layer, l](const std::string& rule) {
     if (rule.find("ENDOFLINE") == std::string::npos) {
       l->warning(254,
                  "unsupported LEF58_SPACING property for layer {} :\"{}\"",
@@ -479,7 +479,7 @@ void lefTechLayerSpacingEolParser::parse(const std::string& s,
                  rule);
       return;
     }
-    if (!lefTechLayerSpacingEol::parse(rule.begin(), rule.end(), layer, l)) {
+    if (!lefTechLayerSpacingEol::parse(rule, layer, l)) {
       l->warning(255,
                  "parse mismatch in layer property LEF58_SPACING ENDOFLINE for "
                  "layer {} :\"{}\"",

--- a/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
@@ -9,6 +9,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb::lefTechLayerSpacingEol {
 
@@ -470,19 +471,13 @@ void lefTechLayerSpacingEolParser::parse(const std::string& s,
                                          dbTechLayer* layer,
                                          odb::lefinReader* l)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [layer, l](std::string& rule) {
     if (rule.find("ENDOFLINE") == std::string::npos) {
       l->warning(254,
                  "unsupported LEF58_SPACING property for layer {} :\"{}\"",
                  layer->getName(),
                  rule);
-      continue;
+      return;
     }
     if (!lefTechLayerSpacingEol::parse(rule.begin(), rule.end(), layer, l)) {
       l->warning(255,
@@ -491,7 +486,7 @@ void lefTechLayerSpacingEolParser::parse(const std::string& s,
                  layer->getName(),
                  rule);
     }
-  }
+  });
 }
 
 }  // namespace odb

--- a/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
@@ -363,53 +363,53 @@ void wrongDirSpaceParser(double value,
   sc->setWrongDirSpace(l->dbdist(value));
 }
 
-bool parse(std::string s, odb::dbTechLayer* layer, odb::lefinReader* l)
+bool parse(const std::string& s, odb::dbTechLayer* layer, odb::lefinReader* l)
 {
   odb::dbTechLayerSpacingEolRule* sc
       = odb::dbTechLayerSpacingEolRule::create(layer);
-  qi::rule<std::string::iterator, space_type> prlEdgeRule
+  qi::rule<std::string::const_iterator, space_type> prlEdgeRule
       = (string("PARALLELEDGE") >> -(string("SUBTRACTEOLWIDTH")) >> double_
          >> lit("WITHIN") >> double_ >> -(string("PRL") >> double_)
          >> -(string("MINLENGTH") >> double_) >> -(string("TWOEDGES"))
          >> -(string("SAMEMETAL")) >> -(string("NONEOLCORNERONLY")) >> -(string(
              "PARALLELSAMEMASK")))[boost::bind(&parallelEdgeParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> exceptexactRule
+  qi::rule<std::string::const_iterator, space_type> exceptexactRule
       = (string("EXCEPTEXACTWIDTH") >> double_
          >> double_)[boost::bind(&exceptExactParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> fillConcaveCornerRule
+  qi::rule<std::string::const_iterator, space_type> fillConcaveCornerRule
       = (string("FILLCONCAVECORNER")
          >> double_)[boost::bind(&fillConcaveParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> withCutRule
+  qi::rule<std::string::const_iterator, space_type> withCutRule
       = (string("WITHCUT") >> -(string("CUTCLASS") >> double_)
          >> -(string("ABOVE")) >> double_
          >> -(string("ENCLOSUREEND") >> double_
               >> -(string("WITHIN")
                    >> double_)))[boost::bind(&withcutParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> endprlspacingrule
+  qi::rule<std::string::const_iterator, space_type> endprlspacingrule
       = (string("ENDPRLSPACING") >> double_ >> string("PRL")
          >> double_)[boost::bind(&endprlspacingParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> endtoendspacingrule
+  qi::rule<std::string::const_iterator, space_type> endtoendspacingrule
       = (string("ENDTOEND") >> double_ >> -(double_ >> double_)
          >> -(string("EXTENSION") >> double_ >> -(double_))
          >> -(string("OTHERENDWIDTH")
               >> double_))[boost::bind(&endtoendspacingParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> maxminlengthrule
+  qi::rule<std::string::const_iterator, space_type> maxminlengthrule
       = ((string("MAXLENGTH") >> double_)
          | (string("MINLENGTH") >> double_ >> -(string(
                 "TWOSIDES"))))[boost::bind(&maxminlengthParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> enclosecutrule
+  qi::rule<std::string::const_iterator, space_type> enclosecutrule
       = (string("ENCLOSECUT") >> -(string("ABOVE") | string("BELOW")) >> double_
          >> string("CUTSPACING") >> double_
          >> -(string("ALLCUTS")))[boost::bind(&enclosecutParser, _1, sc, l)];
 
-  qi::rule<std::string::iterator, space_type> withinRule
+  qi::rule<std::string::const_iterator, space_type> withinRule
       = (-(string("OPPOSITEWIDTH")
            >> double_)[boost::bind(&oppositeWidthParser, _1, sc, l)]
          >> lit("WITHIN")[boost::bind(
@@ -426,19 +426,19 @@ bool parse(std::string s, odb::dbTechLayer* layer, odb::lefinReader* l)
              true)])
          >> -prlEdgeRule >> -enclosecutrule);
 
-  qi::rule<std::string::iterator, space_type> toconcavecornerrule
+  qi::rule<std::string::const_iterator, space_type> toconcavecornerrule
       = (string("TOCONCAVECORNER") >> -(string("MINLENGTH") >> double_)
          >> -(string("MINADJACENTLENGTH")
               >> ((double_ >> double_)
                   | double_)))[boost::bind(&concaveCornerParser, _1, sc, l)];
   ;
 
-  qi::rule<std::string::iterator, space_type> tonotchlengthrule
+  qi::rule<std::string::const_iterator, space_type> tonotchlengthrule
       = (lit("TONOTCHLENGTH")[boost::bind(
              &odb::dbTechLayerSpacingEolRule::setToNotchLengthValid, sc, true)]
          >> double_[boost::bind(&notchLengthParser, _1, sc, l)]);
 
-  qi::rule<std::string::iterator, space_type> spacingRule
+  qi::rule<std::string::const_iterator, space_type> spacingRule
       = (lit("SPACING") >> (double_[boost::bind(&eolSpaceParser, _1, sc, l)])
          >> lit("ENDOFLINE") >> double_[boost::bind(&eolwidthParser, _1, sc, l)]
          >> -(lit("EXACTWIDTH")[boost::bind(

--- a/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerSpacingEolParser.cpp
@@ -363,9 +363,7 @@ void wrongDirSpaceParser(double value,
   sc->setWrongDirSpace(l->dbdist(value));
 }
 
-bool parse(std::string s,
-           odb::dbTechLayer* layer,
-           odb::lefinReader* l)
+bool parse(std::string s, odb::dbTechLayer* layer, odb::lefinReader* l)
 {
   odb::dbTechLayerSpacingEolRule* sc
       = odb::dbTechLayerSpacingEolRule::create(layer);
@@ -452,7 +450,7 @@ bool parse(std::string s,
               >> double_[boost::bind(&wrongDirSpaceParser, _1, sc, l)])
          >> (withinRule | toconcavecornerrule | tonotchlengthrule)
          >> -lit(";"));
-  
+
   auto first = s.begin();
   auto last = s.end();
   bool valid

--- a/src/odb/src/lefin/lefTechLayerSpacingTablePrlParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerSpacingTablePrlParser.cpp
@@ -64,14 +64,14 @@ bool parse(Iterator first,
 {
   odb::dbTechLayerSpacingTablePrlRule* rule
       = odb::dbTechLayerSpacingTablePrlRule::create(layer);
-  qi::rule<std::string::iterator, space_type> SPACINGTABLE
+  qi::rule<std::string::const_iterator, space_type> SPACINGTABLE
       = (lit("SPACINGTABLE") >> lit("INFLUENCE")
          >> +(lit("WIDTH") >> double_ >> lit("WITHIN") >> double_
               >> lit("SPACING")
               >> double_)[boost::bind(&addInfluence, _1, parser, lefinReader)]
          >> lit(";"));
 
-  qi::rule<std::string::iterator, space_type> spacingTableRule
+  qi::rule<std::string::const_iterator, space_type> spacingTableRule
       = (lit("SPACINGTABLE") >> lit("PARALLELRUNLENGTH")
          >> -lit("WRONGDIRECTION")[boost::bind(
              &odb::dbTechLayerSpacingTablePrlRule::setWrongDirection,
@@ -122,7 +122,7 @@ bool parse(Iterator first,
 
 namespace odb {
 
-bool lefTechLayerSpacingTablePrlParser::parse(std::string s,
+bool lefTechLayerSpacingTablePrlParser::parse(const std::string& s,
                                               dbTechLayer* layer,
                                               odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
@@ -9,6 +9,7 @@
 #include "lefLayerPropParser.h"
 #include "odb/db.h"
 #include "odb/lefin.h"
+#include "parserUtils.h"
 
 namespace odb {
 
@@ -21,13 +22,7 @@ lefTechLayerTwoWiresForbiddenSpcRuleParser::
 void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(std::string s,
                                                        odb::dbTechLayer* layer)
 {
-  std::vector<std::string> rules;
-  boost::split(rules, s, boost::is_any_of(";"));
-  for (auto& rule : rules) {
-    boost::algorithm::trim(rule);
-    if (rule.empty()) {
-      continue;
-    }
+  processRules(s, [this, layer](std::string& rule) {
     rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
@@ -37,7 +32,7 @@ void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(std::string s,
           layer->getName(),
           rule);
     }
-  }
+  });
 }
 
 void lefTechLayerTwoWiresForbiddenSpcRuleParser::setInt(

--- a/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
@@ -19,7 +19,7 @@ lefTechLayerTwoWiresForbiddenSpcRuleParser::
   lefin_ = l;
 }
 
-void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(std::string s,
+void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(const std::string& s,
                                                        odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](const std::string& rule) {
@@ -51,15 +51,16 @@ void lefTechLayerTwoWiresForbiddenSpcRuleParser::setForbiddenSpacing(
 }
 
 bool lefTechLayerTwoWiresForbiddenSpcRuleParser::parseSubRule(
-    std::string s,
+    const std::string& s,
     odb::dbTechLayer* layer)
 {
-  qi::rule<std::string::iterator, std::string(), ascii::space_type> _string;
+  qi::rule<std::string::const_iterator, std::string(), ascii::space_type>
+      _string;
   _string %= lexeme[+(char_ - ' ')];
   odb::dbTechLayerTwoWiresForbiddenSpcRule* rule
       = odb::dbTechLayerTwoWiresForbiddenSpcRule::create(layer);
 
-  qi::rule<std::string::iterator, space_type> forbiddenSpacing
+  qi::rule<std::string::const_iterator, space_type> forbiddenSpacing
       = (lit("TWOWIRESFORBIDDENSPACING") >> double_ >> double_)[boost::bind(
             &lefTechLayerTwoWiresForbiddenSpcRuleParser::setForbiddenSpacing,
             this,

--- a/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
@@ -23,7 +23,6 @@ void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(std::string s,
                                                        odb::dbTechLayer* layer)
 {
   processRules(s, [this, layer](std::string& rule) {
-    rule += " ; ";
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
           438,

--- a/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerTwoWiresForbiddenSpcRuleParser.cpp
@@ -22,7 +22,7 @@ lefTechLayerTwoWiresForbiddenSpcRuleParser::
 void lefTechLayerTwoWiresForbiddenSpcRuleParser::parse(std::string s,
                                                        odb::dbTechLayer* layer)
 {
-  processRules(s, [this, layer](std::string& rule) {
+  processRules(s, [this, layer](const std::string& rule) {
     if (!parseSubRule(rule, layer)) {
       lefin_->warning(
           438,

--- a/src/odb/src/lefin/lefTechLayerTypeParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerTypeParser.cpp
@@ -17,7 +17,7 @@ bool parse(Iterator first,
            odb::dbTechLayer* layer,
            odb::lefinReader* lefinReader)
 {
-  qi::rule<std::string::iterator, space_type> TypeRule
+  qi::rule<std::string::const_iterator, space_type> TypeRule
       = (lit("TYPE")
          >> (lit("NWELL")[boost::bind(&odb::dbTechLayer::setLef58Type,
                                       layer,
@@ -97,7 +97,7 @@ bool parse(Iterator first,
 
 namespace odb {
 
-bool lefTechLayerTypeParser::parse(std::string s,
+bool lefTechLayerTypeParser::parse(const std::string& s,
                                    dbTechLayer* layer,
                                    odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/lefTechLayerWrongDirSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerWrongDirSpacingParser.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+// Parser for LEF58 wrong-direction spacing rules that define spacing
+// requirements for non-preferred direction shapes
 #include <iostream>
 #include <string>
 
@@ -11,6 +13,7 @@
 
 namespace odb::lefTechLayerWrongDirSpacing {
 
+// Set the base wrong-direction spacing value (converts to database units)
 void wrongDirParser(double value,
                     odb::dbTechLayerWrongDirSpacingRule* sc,
                     odb::lefinReader* l)
@@ -18,6 +21,7 @@ void wrongDirParser(double value,
   sc->setWrongdirSpace(l->dbdist(value));
 }
 
+// Set the non-end-of-line width parameter
 void noneolWidthParser(double value,
                        odb::dbTechLayerWrongDirSpacingRule* sc,
                        odb::lefinReader* l)
@@ -25,6 +29,7 @@ void noneolWidthParser(double value,
   sc->setNoneolWidth(l->dbdist(value));
 }
 
+// Set the parallel run length parameter
 void prlLengthParser(double value,
                      odb::dbTechLayerWrongDirSpacingRule* sc,
                      odb::lefinReader* l)
@@ -32,6 +37,7 @@ void prlLengthParser(double value,
   sc->setPrlLength(l->dbdist(value));
 }
 
+// Set the length parameter
 void lengthParser(double value,
                   odb::dbTechLayerWrongDirSpacingRule* sc,
                   odb::lefinReader* l)
@@ -39,6 +45,9 @@ void lengthParser(double value,
   sc->setLength(l->dbdist(value));
 }
 
+// Parse a single wrong-direction spacing rule
+// Format: SPACING value WRONGDIRECTION [NONEOL width] [PRL length] [LENGTH
+// length] ;
 template <typename Iterator>
 bool parse(Iterator first,
            Iterator last,
@@ -47,7 +56,7 @@ bool parse(Iterator first,
 {
   odb::dbTechLayerWrongDirSpacingRule* sc
       = odb::dbTechLayerWrongDirSpacingRule::create(layer);
-  qi::rule<std::string::iterator, space_type> wrongDirSpacingRule
+  qi::rule<std::string::const_iterator, space_type> wrongDirSpacingRule
       = (lit("SPACING") >> (double_[boost::bind(&wrongDirParser, _1, sc, l)])
          >> lit("WRONGDIRECTION")
          >> -(lit("NONEOL")[boost::bind(
@@ -75,7 +84,8 @@ bool parse(Iterator first,
 
 namespace odb {
 
-void lefTechLayerWrongDirSpacingParser::parse(std::string s,
+// Parse input string containing wrong-direction spacing rules for a layer
+void lefTechLayerWrongDirSpacingParser::parse(const std::string& s,
                                               dbTechLayer* layer,
                                               odb::lefinReader* l)
 {

--- a/src/odb/src/lefin/parserUtils.h
+++ b/src/odb/src/lefin/parserUtils.h
@@ -25,6 +25,8 @@ void processRules(const std::string& s, RuleHandler handler)
       continue;
     }
 
+    rule += " ; ";
+
     // Delegate rule processing to the provided handler
     handler(rule);
   }

--- a/src/odb/src/lefin/parserUtils.h
+++ b/src/odb/src/lefin/parserUtils.h
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2019-2025, The OpenROAD Authors
+
+#pragma once
+#include <boost/algorithm/string.hpp>
+
+namespace odb {
+
+// Utility function to split semicolon-delimited strings and process each rule.
+// This template function provides a common pattern for parsing
+// semicolon-separated rule strings that are found in LEF file parsing. It
+// handles the standard preprocessing steps and then delegates the actual rule
+// processing to a user-provided handler function.
+template <typename RuleHandler>
+void processRules(const std::string& s, RuleHandler handler)
+{
+  std::vector<std::string> rules;
+  boost::split(rules, s, boost::is_any_of(";"));
+
+  for (auto& rule : rules) {
+    boost::algorithm::trim(rule);
+
+    // Skip empty rules
+    if (rule.empty()) {
+      continue;
+    }
+
+    // Delegate rule processing to the provided handler
+    handler(rule);
+  }
+}
+}  // namespace odb


### PR DESCRIPTION
Fixes [#6560](https://github.com/The-OpenROAD-Project/OpenROAD/issues/6560)
 
## Problem
Several parser classes (`MetalWidthViaMapParser`, `lefTechLayerSpacingEolParser`, `KeepOutZoneParser`, etc.) contained identical logic for:
- Splitting semicolon-delimited rule strings
- Trimming whitespace from individual rules
- Skipping empty rules
- Iterating through each rule for processing


## Solution
Created a new `processRules` template function in `parserUtils.h` that:
- Encapsulates the common string splitting and preprocessing logic
- Uses a template parameter to accept any callable (lambda, function, functor) for rule processing
- Maintains the exact same behavior as the original implementations
