### PR TITLE
[DO NOT REVIEW] Bazel cleanup opensta runfiles workaround

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -148,7 +148,7 @@ bazel_dep(name = "bazel-orfs")
 # To bump version, run: bazelisk run @bazel-orfs//:bump
 git_override(
     module_name = "bazel-orfs",
-    commit = "ca614657a795785bd4b472e406fc1d583e0620a2",
+    commit = "5f648463fb2680e658d5c59fe1d77778457c269a",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -359,8 +359,6 @@ orfs_run(
         "POWER_STAGE_STEM": POWER_STAGE_STEM,
     },
     data = [
-               # FIXME this is a workaround to ensure that the OpenSTA runfiles are available
-               ":opensta_runfiles",
                ":vcd",
            ] + ["{macro}_{stage}".format(
                macro = macro,
@@ -383,15 +381,4 @@ sh_test(
     data = [
         ":MockArray_power",
     ],
-)
-
-# FIXME why is this needed to ensure that cfg=exec of OpenSTA has runfiles?
-genrule(
-    name = "opensta_runfiles",
-    srcs = [],
-    outs = ["dummy"],
-    cmd = """
-    $(location //:opensta) >$@
-    """,
-    tools = ["//:opensta"],
 )

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -359,8 +359,9 @@ orfs_run(
         "POWER_STAGE_STEM": POWER_STAGE_STEM,
     },
     data = [
+               # FIXME this is a workaround to ensure that the OpenSTA runfiles are available
+               ":opensta_runfiles",
                ":vcd",
-               "//:opensta",
            ] + ["{macro}_{stage}".format(
                macro = macro,
                stage = POWER_STAGE_NAME,
@@ -368,6 +369,7 @@ orfs_run(
            (["{macro}_parasitics".format(macro = macro) for macro in MACROS] if POWER_STAGE_NAME != "final" else []),
     script = ":power.tcl",
     tags = ["manual"],
+    tools = ["//:opensta"],
     visibility = ["//visibility:public"],
 )
 
@@ -381,6 +383,15 @@ sh_test(
     data = [
         ":MockArray_power",
     ],
-    # FIXME enable when it works in CI
-    tags = ["manual"],
+)
+
+# FIXME why is this needed to ensure that cfg=exec of OpenSTA has runfiles?
+genrule(
+    name = "opensta_runfiles",
+    srcs = [],
+    outs = ["dummy"],
+    cmd = """
+    $(location //:opensta) >$@
+    """,
+    tools = ["//:opensta"],
 )


### PR DESCRIPTION
To reproduce problem:

    bazelisk clean
    bazelisk test test/orfs/mock-array:MockArray_power_test


```
- Verilator: Walltime 9.081 s (elab=0.605, cvt=7.547, bld=0.000); cpu 9.078 s on 1 threads; alloced 538.105 MB
ERROR: /home/oyvind/OpenROAD-flow-scripts/tools/OpenROAD/test/orfs/mock-array/BUILD:348:9: Action test/orfs/mock-array/power.txt failed: (Exit 2): bash failed: error executing Action command (from target //test/orfs/mock-array:MockArray_power) /bin/bash -c 'external/bazel-orfs++orfs_repositories+docker_orfs/usr/bin/make run  $@' '' --file external/bazel-orfs++orfs_repositories+docker_orfs/OpenROAD-flow-scripts/flow/Makefile

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
make: *** [external/bazel-orfs++orfs_repositories+docker_orfs/OpenROAD-flow-scripts/flow/Makefile:840: run] Error 1
(bazel-out/k8-opt-exec-ST-d57f47055a04/bin/opensta -exit -no_init -threads 16  -no_splash  test/orfs/mock-array/power.tcl 2>&1 | tee /home/oyvind/.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/sandbox/processwrapper-sandbox/12110/execroot/_main/bazel-out/k8-fastbuild/bin/test/orfs/mock-array/logs/asap7/MockArray/base/run.log)
Error initializing Bazel runfiles: ERROR: external/rules_cc+/cc/runfiles/runfiles.cc(123): cannot find runfiles (argv0="/home/oyvind/.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/execroot/_main/bazel-out/k8-opt-exec-ST-d57f47055a04/bin/opensta")
Target //test/orfs/mock-array:MockArray_power_test failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 848.282s, Critical Path: 312.74s
INFO: 6133 processes: 1516 internal, 4602 processwrapper-sandbox, 15 worker.
ERROR: Build did NOT complete successfully
//test/orfs/mock-array:MockArray_power_test                     FAILED TO BUILD

Executed 0 out of 1 test: 1 fails to build.
```
