### PR TITLE
rcx: remove calls to system in favor of using std::filesystem

### DIFF
--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+#include <filesystem>
 #include <limits>
 #include <map>
 #include <vector>
-#include <filesystem>
 
 #include "parse.h"
 #include "rcx/extRCap.h"
@@ -2810,7 +2810,8 @@ bool extRCModel::openCapLogFile()
 
       std::filesystem::rename(path0, path1);
     } catch (const std::filesystem::filesystem_error&) {
-      logger_->error(RCX, 489, "mv failed: {}/{}/{}", _topDir, _patternName, capLog);
+      logger_->error(
+          RCX, 489, "mv failed: {}/{}/{}", _topDir, _patternName, capLog);
     }
 
     _capLogFP = openFile(buff, capLog, nullptr, "w");

--- a/src/rcx/src/parse.cpp
+++ b/src/rcx/src/parse.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 
 #include "odb/odb.h"
 
@@ -278,9 +279,7 @@ int Ath__parser::mkWords(const char* word, const char* sep)
 
 bool Ath__parser::mkDir(char* word)
 {
-  char command[1024];
-  sprintf(command, "mkdir -p %s", word);
-  return system(command) == 0;
+  return std::filesystem::create_directories(word);
 }
 
 int Ath__parser::mkDirTree(const char* word, const char* sep)


### PR DESCRIPTION
Removes calls to system in rcx, this is part one of #7583 (the easy stuff)