### PR TITLE
pdn: remove floating shapes when vias failed to generate

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -701,6 +701,9 @@ class dbBox : public dbObject
   ///
   static dbBox* create(dbInst* inst, int x1, int y1, int x2, int y2);
 
+  // Destroy box
+  static void destroy(dbBox* box);
+
   ///
   /// Translate a database-id back to a pointer.
   /// This function translates any dbBox which is part of a block.

--- a/src/odb/src/db/dbBPin.cpp
+++ b/src/odb/src/db/dbBPin.cpp
@@ -285,4 +285,32 @@ void _dbBPin::collectMemInfo(MemInfo& info)
   info.children_["ap"].add(aps_);
 }
 
+void _dbBPin::removeBox(_dbBox* box)
+{
+  _dbBlock* block = (_dbBlock*) getOwner();
+
+  dbId<_dbBox> boxid = box->getOID();
+  if (boxid == _boxes) {
+    // at head of list, need to move head
+    _boxes = box->_next_box;
+  } else {
+    // in the middle of the list, need to iterate and relink
+    dbId<_dbBox> id = _boxes;
+    if (id == 0) {
+      return;
+    }
+    while (id != 0) {
+      _dbBox* nbox = block->_box_tbl->getPtr(id);
+      dbId<_dbBox> nid = nbox->_next_box;
+
+      if (nid == boxid) {
+        nbox->_next_box = box->_next_box;
+        break;
+      }
+
+      id = nid;
+    }
+  }
+}
+
 }  // namespace odb

--- a/src/odb/src/db/dbBPin.h
+++ b/src/odb/src/db/dbBPin.h
@@ -44,6 +44,7 @@ class _dbBPin : public _dbObject
   bool operator==(const _dbBPin& rhs) const;
   bool operator!=(const _dbBPin& rhs) const { return !operator==(rhs); }
   void collectMemInfo(MemInfo& info);
+  void removeBox(_dbBox* box);
 };
 
 dbIStream& operator>>(dbIStream& stream, _dbBPin& bpin);

--- a/src/odb/src/db/dbBox.cpp
+++ b/src/odb/src/db/dbBox.cpp
@@ -994,6 +994,34 @@ dbBox* dbBox::create(dbInst* inst_, int x1, int y1, int x2, int y2)
   return (dbBox*) box;
 }
 
+void dbBox::destroy(dbBox* box)
+{
+  _dbBox* db_box = (_dbBox*) box;
+  switch (db_box->_flags._owner_type) {
+    case dbBoxOwner::BPIN: {
+      _dbBPin* pin = (_dbBPin*) box->getBoxOwner();
+      pin->removeBox(db_box);
+      _dbBlock* block = (_dbBlock*) pin->getOwner();
+      block->_box_tbl->destroy(db_box);
+      break;
+    }
+    case dbBoxOwner::UNKNOWN:
+    case dbBoxOwner::BLOCK:
+    case dbBoxOwner::INST:
+    case dbBoxOwner::BTERM:
+    case dbBoxOwner::VIA:
+    case dbBoxOwner::OBSTRUCTION:
+    case dbBoxOwner::SWIRE:
+    case dbBoxOwner::BLOCKAGE:
+    case dbBoxOwner::MASTER:
+    case dbBoxOwner::MPIN:
+    case dbBoxOwner::TECH_VIA:
+    case dbBoxOwner::REGION:
+    case dbBoxOwner::PBOX:
+      return;
+  }
+}
+
 dbBox* dbBox::getBox(dbBlock* block_, uint dbid_)
 {
   _dbBlock* block = (_dbBlock*) block_;

--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -862,9 +862,10 @@ void Grid::removeGridComponent(GridComponent* component)
   }
 }
 
-void Grid::writeToDb(const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
-                     bool do_pins,
-                     const Shape::ObstructionTreeMap& obstructions) const
+std::map<Shape*, std::vector<odb::dbBox*>> Grid::writeToDb(
+    const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
+    bool do_pins,
+    const Shape::ObstructionTreeMap& obstructions) const
 {
   // write vias first do shapes can be adjusted if needed
   std::vector<ViaPtr> vias;
@@ -897,11 +898,16 @@ void Grid::writeToDb(const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
     connect->printViaReport();
   }
 
+  std::map<Shape*, std::vector<odb::dbBox*>> shape_map;
+
   std::set<odb::dbTechLayer*> pin_layers(pin_layers_.begin(),
                                          pin_layers_.end());
   for (auto* component : getGridComponents()) {
-    component->writeToDb(net_map, do_pins, pin_layers);
+    const auto db_shapes = component->writeToDb(net_map, do_pins, pin_layers);
+    shape_map.insert(db_shapes.begin(), db_shapes.end());
   }
+
+  return shape_map;
 }
 
 void Grid::getGridLevelObstructions(ShapeVectorMap& obstructions) const

--- a/src/pdn/src/grid.h
+++ b/src/pdn/src/grid.h
@@ -136,9 +136,10 @@ class Grid
 
   void resetShapes();
 
-  void writeToDb(const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
-                 bool do_pins,
-                 const Shape::ObstructionTreeMap& obstructions) const;
+  std::map<Shape*, std::vector<odb::dbBox*>> writeToDb(
+      const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
+      bool do_pins,
+      const Shape::ObstructionTreeMap& obstructions) const;
   void makeRoutingObstructions(odb::dbBlock* block) const;
 
   static void makeInitialObstructions(odb::dbBlock* block,

--- a/src/pdn/src/grid_component.cpp
+++ b/src/pdn/src/grid_component.cpp
@@ -303,7 +303,7 @@ void GridComponent::cutShapes(const Shape::ObstructionTreeMap& obstructions)
              getShapeCount());
 }
 
-void GridComponent::writeToDb(
+std::map<Shape*, std::vector<odb::dbBox*>> GridComponent::writeToDb(
     const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
     bool add_pins,
     const std::set<odb::dbTechLayer*>& convert_layer_to_pin) const
@@ -314,6 +314,8 @@ void GridComponent::writeToDb(
       all_shapes.push_back(shape);
     }
   }
+
+  std::map<Shape*, std::vector<odb::dbBox*>> shape_map;
 
   // sort shapes so they get written to db in the same order
   std::sort(
@@ -334,8 +336,11 @@ void GridComponent::writeToDb(
     }
     const bool is_pin_layer = convert_layer_to_pin.find(shape->getLayer())
                               != convert_layer_to_pin.end();
-    shape->writeToDb(net->second, add_pins, is_pin_layer);
+    shape_map[shape.get()]
+        = shape->writeToDb(net->second, add_pins, is_pin_layer);
   }
+
+  return shape_map;
 }
 
 void GridComponent::checkLayerWidth(odb::dbTechLayer* layer,

--- a/src/pdn/src/grid_component.h
+++ b/src/pdn/src/grid_component.h
@@ -70,9 +70,10 @@ class GridComponent
   // violations.
   virtual void cutShapes(const Shape::ObstructionTreeMap& obstructions);
 
-  void writeToDb(const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
-                 bool add_pins,
-                 const std::set<odb::dbTechLayer*>& convert_layer_to_pin) const;
+  std::map<Shape*, std::vector<odb::dbBox*>> writeToDb(
+      const std::map<odb::dbNet*, odb::dbSWire*>& net_map,
+      bool add_pins,
+      const std::set<odb::dbTechLayer*>& convert_layer_to_pin) const;
 
   virtual void report() const = 0;
   virtual Type type() const = 0;

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -328,36 +328,58 @@ bool Shape::hasDBConnectivity() const
   return false;
 }
 
-void Shape::writeToDb(odb::dbSWire* swire,
-                      bool add_pins,
-                      bool make_rect_as_pin) const
+bool Shape::hasInternalConnections() const
+{
+  if (hasITermConnections() || type_ == odb::dbWireShapeType::FOLLOWPIN) {
+    // if shape is connected to an instance or block pin allow it is valid
+    // if shape is a followpin assume it will be connected
+    return true;
+  }
+
+  for (const auto& via : vias_) {
+    if (!via->isFailed()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::vector<odb::dbBox*> Shape::writeToDb(odb::dbSWire* swire,
+                                          bool add_pins,
+                                          bool make_rect_as_pin) const
 {
   debugPrint(getLogger(),
              utl::PDN,
              "Shape",
              5,
-             "Adding shape {} with pins {} and rect as pin {}",
+             "Adding shape {} with pins {} and rect as pin {} / {} {} - {}",
              getReportText(),
              add_pins,
-             make_rect_as_pin);
+             make_rect_as_pin,
+             is_locked_,
+             hasITermConnections(),
+             hasBTermConnections());
 
   if (!is_locked_ && !hasDBConnectivity()) {
     getLogger()->warn(
         utl::PDN, 200, "Removing floating shape: {}", getReportText());
-    return;
+    return {};
   }
 
-  odb::dbSBox::create(swire,
-                      layer_,
-                      rect_.xMin(),
-                      rect_.yMin(),
-                      rect_.xMax(),
-                      rect_.yMax(),
-                      type_);
+  std::vector<odb::dbBox*> objs;
+
+  objs.push_back(odb::dbSBox::create(swire,
+                                     layer_,
+                                     rect_.xMin(),
+                                     rect_.yMin(),
+                                     rect_.xMax(),
+                                     rect_.yMax(),
+                                     type_));
 
   if (add_pins) {
     if (make_rect_as_pin) {
-      addBPinToDb(rect_);
+      objs.push_back(addBPinToDb(rect_));
     }
     const odb::Rect block_area = getGridComponent()->getBlock()->getDieArea();
     for (const auto& bterm : bterm_connections_) {
@@ -372,12 +394,13 @@ void Shape::writeToDb(odb::dbSWire* swire,
         bterm_shape.set_xlo(rect_.xMin());
         bterm_shape.set_xhi(rect_.xMax());
       }
-      addBPinToDb(bterm_shape);
+      objs.push_back(addBPinToDb(bterm_shape));
     }
   }
+  return objs;
 }
 
-void Shape::addBPinToDb(const odb::Rect& rect) const
+odb::dbBox* Shape::addBPinToDb(const odb::Rect& rect) const
 {
   // find existing bterm, else make it
   odb::dbBTerm* bterm = nullptr;
@@ -389,6 +412,8 @@ void Shape::addBPinToDb(const odb::Rect& rect) const
   }
   bterm->setSigType(net_->getSigType());
   bterm->setSpecial();
+
+  odb::dbBox* box = nullptr;
 
   odb::dbBPin* pin = nullptr;
   auto pins = bterm->getBPins();
@@ -409,11 +434,13 @@ void Shape::addBPinToDb(const odb::Rect& rect) const
     } else {
       pin = *pins.begin();
     }
-    odb::dbBox::create(
+    box = odb::dbBox::create(
         pin, layer_, rect.xMin(), rect.yMin(), rect.xMax(), rect.yMax());
   }
 
   pin->setPlacementStatus(odb::dbPlacementStatus::FIRM);
+
+  return box;
 }
 
 void Shape::populateMapFromDb(odb::dbNet* net, ShapeVectorMap& map)

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -167,6 +167,7 @@ class Shape
   bool hasTermConnections() const;
   bool hasITermConnections() const { return !iterm_connections_.empty(); }
   bool hasBTermConnections() const { return !bterm_connections_.empty(); };
+  bool hasInternalConnections() const;
 
   // returns the smallest shape possible when attempting to trim
   virtual odb::Rect getMinimumRect() const;
@@ -201,9 +202,10 @@ class Shape
   std::string getReportText() const;
   static std::string getRectText(const odb::Rect& rect, double dbu_to_micron);
 
-  void writeToDb(odb::dbSWire* swire,
-                 bool add_pins,
-                 bool make_rect_as_pin) const;
+  std::vector<odb::dbBox*> writeToDb(odb::dbSWire* swire,
+                                     bool add_pins,
+                                     bool make_rect_as_pin) const;
+
   // copy existing shapes into the map
   static void populateMapFromDb(odb::dbNet* net, ShapeVectorMap& map);
 
@@ -242,7 +244,7 @@ class Shape
   std::set<odb::Rect> bterm_connections_;
 
   // add rect as bterm to database
-  void addBPinToDb(const odb::Rect& rect) const;
+  odb::dbBox* addBPinToDb(const odb::Rect& rect) const;
 
   void updateIBTermConnections(std::set<odb::Rect>& terms);
 

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -111,6 +111,7 @@ COMPULSORY_TESTS = [
     "report",
     "reset",
     "ripup",
+    "sky130_spm_floating_bpin",
     "sroute_test",
     "widthtable",
 ]

--- a/src/pdn/test/CMakeLists.txt
+++ b/src/pdn/test/CMakeLists.txt
@@ -110,6 +110,7 @@ or_integration_tests(
     report
     reset
     ripup
+    sky130_spm_floating_bpin
     sroute_test
     widthtable
 )

--- a/src/pdn/test/sky130_spm/delayed_serial_adder.lef
+++ b/src/pdn/test/sky130_spm/delayed_serial_adder.lef
@@ -1,0 +1,102 @@
+VERSION 5.7 ;
+  NOWIREEXTENSIONATPIN ON ;
+  DIVIDERCHAR "/" ;
+  BUSBITCHARS "[]" ;
+MACRO delayed_serial_adder
+  CLASS BLOCK ;
+  FOREIGN delayed_serial_adder ;
+  ORIGIN 0.000 0.000 ;
+  SIZE 29.645 BY 40.365 ;
+  PIN VGND
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER met4 ;
+        RECT 13.220 10.640 15.220 27.440 ;
+    END
+  END VGND
+  PIN VPWR
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER met4 ;
+        RECT 9.520 10.640 11.520 27.440 ;
+    END
+  END VPWR
+  PIN a
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAGATEAREA 0.196500 ;
+    PORT
+      LAYER met3 ;
+        RECT 25.645 13.640 29.645 14.240 ;
+    END
+  END a
+  PIN clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAGATEAREA 0.852000 ;
+    PORT
+      LAYER met3 ;
+        RECT 0.000 17.040 4.000 17.640 ;
+    END
+  END clk
+  PIN rst
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAGATEAREA 0.196500 ;
+    PORT
+      LAYER met3 ;
+        RECT 25.645 17.040 29.645 17.640 ;
+    END
+  END rst
+  PIN x
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAGATEAREA 0.196500 ;
+    PORT
+      LAYER met3 ;
+        RECT 25.645 23.840 29.645 24.440 ;
+    END
+  END x
+  PIN y_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    ANTENNAGATEAREA 0.196500 ;
+    PORT
+      LAYER met3 ;
+        RECT 0.000 20.440 4.000 21.040 ;
+    END
+  END y_in
+  PIN y_out
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    ANTENNADIFFAREA 0.445500 ;
+    PORT
+      LAYER met3 ;
+        RECT 25.645 20.440 29.645 21.040 ;
+    END
+  END y_out
+  OBS
+      LAYER nwell ;
+        RECT 5.330 10.795 24.110 27.285 ;
+      LAYER li1 ;
+        RECT 5.520 10.795 23.920 27.285 ;
+      LAYER met1 ;
+        RECT 4.210 10.240 23.920 27.440 ;
+      LAYER met2 ;
+        RECT 4.230 10.210 22.450 27.385 ;
+      LAYER met3 ;
+        RECT 3.990 24.840 25.645 27.365 ;
+        RECT 3.990 23.440 25.245 24.840 ;
+        RECT 3.990 21.440 25.645 23.440 ;
+        RECT 4.400 20.040 25.245 21.440 ;
+        RECT 3.990 18.040 25.645 20.040 ;
+        RECT 4.400 16.640 25.245 18.040 ;
+        RECT 3.990 14.640 25.645 16.640 ;
+        RECT 3.990 13.240 25.245 14.640 ;
+        RECT 3.990 10.715 25.645 13.240 ;
+  END
+END delayed_serial_adder
+END LIBRARY
+

--- a/src/pdn/test/sky130_spm/floorplan.def
+++ b/src/pdn/test/sky130_spm/floorplan.def
@@ -1,0 +1,555 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN spm ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 189675 200395 ) ;
+ROW ROW_1_2 unithd 45540 13600 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_2_2 unithd 45540 16320 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_3_2 unithd 45540 19040 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_4_2 unithd 45540 21760 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_5_2 unithd 45540 24480 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_6_2 unithd 45540 27200 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_7_2 unithd 45540 29920 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_8_2 unithd 45540 32640 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_9_2 unithd 45540 35360 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_10_2 unithd 45540 38080 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_11_2 unithd 45540 40800 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_12_2 unithd 45540 43520 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_13_2 unithd 45540 46240 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_14_2 unithd 45540 48960 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_15_2 unithd 45540 51680 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_16_2 unithd 45540 54400 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_17_2 unithd 45540 57120 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_18_2 unithd 45540 59840 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_19 unithd 5520 62560 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_20 unithd 5520 65280 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_21 unithd 5520 68000 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_22 unithd 5520 70720 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_46_1 unithd 5520 136000 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_42 unithd 5520 125120 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_43 unithd 5520 127840 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_44 unithd 5520 130560 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_45 unithd 5520 133280 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_47_1 unithd 5520 138720 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_48_1 unithd 5520 141440 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_49_1 unithd 5520 144160 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_50_1 unithd 5520 146880 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_51_1 unithd 5520 149600 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_52_1 unithd 5520 152320 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_53_1 unithd 5520 155040 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_54_1 unithd 5520 157760 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_55_1 unithd 5520 160480 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_56_1 unithd 5520 163200 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_57_1 unithd 5520 165920 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_58_1 unithd 5520 168640 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_59_1 unithd 5520 171360 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_60_1 unithd 5520 174080 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_61_1 unithd 5520 176800 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_62_1 unithd 5520 179520 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_63_1 unithd 5520 182240 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_64_1 unithd 5520 184960 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_0_2 unithd 45540 10880 N DO 214 BY 1 STEP 460 0 ;
+TRACKS X 230 DO 412 STEP 460 LAYER li1 ;
+TRACKS Y 170 DO 589 STEP 340 LAYER li1 ;
+TRACKS X 170 DO 558 STEP 340 LAYER met1 ;
+TRACKS Y 170 DO 589 STEP 340 LAYER met1 ;
+TRACKS X 230 DO 412 STEP 460 LAYER met2 ;
+TRACKS Y 230 DO 435 STEP 460 LAYER met2 ;
+TRACKS X 340 DO 279 STEP 680 LAYER met3 ;
+TRACKS Y 340 DO 294 STEP 680 LAYER met3 ;
+TRACKS X 460 DO 206 STEP 920 LAYER met4 ;
+TRACKS Y 460 DO 218 STEP 920 LAYER met4 ;
+TRACKS X 1700 DO 56 STEP 3400 LAYER met5 ;
+TRACKS Y 1700 DO 59 STEP 3400 LAYER met5 ;
+COMPONENTS 309 ;
+    - PHY_EDGE_ROW_0_2_Left_18 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 10880 ) N ;
+    - PHY_EDGE_ROW_0_2_Right_37 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 10880 ) FN ;
+    - PHY_EDGE_ROW_10_2_Left_9 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 38080 ) N ;
+    - PHY_EDGE_ROW_10_2_Right_28 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 38080 ) FN ;
+    - PHY_EDGE_ROW_11_2_Left_10 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 40800 ) FS ;
+    - PHY_EDGE_ROW_11_2_Right_29 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 40800 ) S ;
+    - PHY_EDGE_ROW_12_2_Left_11 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 43520 ) N ;
+    - PHY_EDGE_ROW_12_2_Right_30 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 43520 ) FN ;
+    - PHY_EDGE_ROW_13_2_Left_12 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 46240 ) FS ;
+    - PHY_EDGE_ROW_13_2_Right_31 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 46240 ) S ;
+    - PHY_EDGE_ROW_14_2_Left_13 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 48960 ) N ;
+    - PHY_EDGE_ROW_14_2_Right_32 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 48960 ) FN ;
+    - PHY_EDGE_ROW_15_2_Left_14 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 51680 ) FS ;
+    - PHY_EDGE_ROW_15_2_Right_33 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 51680 ) S ;
+    - PHY_EDGE_ROW_16_2_Left_15 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 54400 ) N ;
+    - PHY_EDGE_ROW_16_2_Right_34 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 54400 ) FN ;
+    - PHY_EDGE_ROW_17_2_Left_16 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 57120 ) FS ;
+    - PHY_EDGE_ROW_17_2_Right_35 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 57120 ) S ;
+    - PHY_EDGE_ROW_18_2_Left_17 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 59840 ) N ;
+    - PHY_EDGE_ROW_18_2_Right_36 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 59840 ) FN ;
+    - PHY_EDGE_ROW_19_Left_42 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 62560 ) FS ;
+    - PHY_EDGE_ROW_19_Right_38 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 62560 ) S ;
+    - PHY_EDGE_ROW_1_2_Left_0 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 13600 ) FS ;
+    - PHY_EDGE_ROW_1_2_Right_19 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 13600 ) S ;
+    - PHY_EDGE_ROW_20_Left_43 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 65280 ) N ;
+    - PHY_EDGE_ROW_20_Right_39 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 65280 ) FN ;
+    - PHY_EDGE_ROW_21_Left_44 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 68000 ) FS ;
+    - PHY_EDGE_ROW_21_Right_40 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 68000 ) S ;
+    - PHY_EDGE_ROW_22_Left_45 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 70720 ) N ;
+    - PHY_EDGE_ROW_22_Right_41 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 70720 ) FN ;
+    - PHY_EDGE_ROW_2_2_Left_1 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 16320 ) N ;
+    - PHY_EDGE_ROW_2_2_Right_20 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 16320 ) FN ;
+    - PHY_EDGE_ROW_3_2_Left_2 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 19040 ) FS ;
+    - PHY_EDGE_ROW_3_2_Right_21 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 19040 ) S ;
+    - PHY_EDGE_ROW_42_Left_70 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 125120 ) N ;
+    - PHY_EDGE_ROW_42_Right_46 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 125120 ) FN ;
+    - PHY_EDGE_ROW_43_Left_71 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 127840 ) FS ;
+    - PHY_EDGE_ROW_43_Right_47 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 127840 ) S ;
+    - PHY_EDGE_ROW_44_Left_72 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 130560 ) N ;
+    - PHY_EDGE_ROW_44_Right_48 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 130560 ) FN ;
+    - PHY_EDGE_ROW_45_Left_73 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 133280 ) FS ;
+    - PHY_EDGE_ROW_45_Right_49 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 133280 ) S ;
+    - PHY_EDGE_ROW_46_1_Left_69 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 136000 ) N ;
+    - PHY_EDGE_ROW_46_1_Right_50 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 136000 ) FN ;
+    - PHY_EDGE_ROW_47_1_Left_74 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 138720 ) FS ;
+    - PHY_EDGE_ROW_47_1_Right_51 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 138720 ) S ;
+    - PHY_EDGE_ROW_48_1_Left_75 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 141440 ) N ;
+    - PHY_EDGE_ROW_48_1_Right_52 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 141440 ) FN ;
+    - PHY_EDGE_ROW_49_1_Left_76 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 144160 ) FS ;
+    - PHY_EDGE_ROW_49_1_Right_53 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 144160 ) S ;
+    - PHY_EDGE_ROW_4_2_Left_3 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 21760 ) N ;
+    - PHY_EDGE_ROW_4_2_Right_22 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 21760 ) FN ;
+    - PHY_EDGE_ROW_50_1_Left_77 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 146880 ) N ;
+    - PHY_EDGE_ROW_50_1_Right_54 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 146880 ) FN ;
+    - PHY_EDGE_ROW_51_1_Left_78 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 149600 ) FS ;
+    - PHY_EDGE_ROW_51_1_Right_55 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 149600 ) S ;
+    - PHY_EDGE_ROW_52_1_Left_79 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 152320 ) N ;
+    - PHY_EDGE_ROW_52_1_Right_56 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 152320 ) FN ;
+    - PHY_EDGE_ROW_53_1_Left_80 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 155040 ) FS ;
+    - PHY_EDGE_ROW_53_1_Right_57 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 155040 ) S ;
+    - PHY_EDGE_ROW_54_1_Left_81 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 157760 ) N ;
+    - PHY_EDGE_ROW_54_1_Right_58 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 157760 ) FN ;
+    - PHY_EDGE_ROW_55_1_Left_82 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 160480 ) FS ;
+    - PHY_EDGE_ROW_55_1_Right_59 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 160480 ) S ;
+    - PHY_EDGE_ROW_56_1_Left_83 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 163200 ) N ;
+    - PHY_EDGE_ROW_56_1_Right_60 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 163200 ) FN ;
+    - PHY_EDGE_ROW_57_1_Left_84 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 165920 ) FS ;
+    - PHY_EDGE_ROW_57_1_Right_61 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 165920 ) S ;
+    - PHY_EDGE_ROW_58_1_Left_85 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 168640 ) N ;
+    - PHY_EDGE_ROW_58_1_Right_62 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 168640 ) FN ;
+    - PHY_EDGE_ROW_59_1_Left_86 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 171360 ) FS ;
+    - PHY_EDGE_ROW_59_1_Right_63 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 171360 ) S ;
+    - PHY_EDGE_ROW_5_2_Left_4 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 24480 ) FS ;
+    - PHY_EDGE_ROW_5_2_Right_23 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 24480 ) S ;
+    - PHY_EDGE_ROW_60_1_Left_87 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 174080 ) N ;
+    - PHY_EDGE_ROW_60_1_Right_64 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 174080 ) FN ;
+    - PHY_EDGE_ROW_61_1_Left_88 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 176800 ) FS ;
+    - PHY_EDGE_ROW_61_1_Right_65 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 176800 ) S ;
+    - PHY_EDGE_ROW_62_1_Left_89 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 179520 ) N ;
+    - PHY_EDGE_ROW_62_1_Right_66 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 179520 ) FN ;
+    - PHY_EDGE_ROW_63_1_Left_90 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 182240 ) FS ;
+    - PHY_EDGE_ROW_63_1_Right_67 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 182240 ) S ;
+    - PHY_EDGE_ROW_64_1_Left_91 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 184960 ) N ;
+    - PHY_EDGE_ROW_64_1_Right_68 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 184960 ) FN ;
+    - PHY_EDGE_ROW_6_2_Left_5 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 27200 ) N ;
+    - PHY_EDGE_ROW_6_2_Right_24 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 27200 ) FN ;
+    - PHY_EDGE_ROW_7_2_Left_6 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 29920 ) FS ;
+    - PHY_EDGE_ROW_7_2_Right_25 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 29920 ) S ;
+    - PHY_EDGE_ROW_8_2_Left_7 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 32640 ) N ;
+    - PHY_EDGE_ROW_8_2_Right_26 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 32640 ) FN ;
+    - PHY_EDGE_ROW_9_2_Left_8 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 35360 ) FS ;
+    - PHY_EDGE_ROW_9_2_Right_27 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 35360 ) S ;
+    - TAP_TAPCELL_ROW_0_2_293 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_294 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_295 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_296 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_297 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_298 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_299 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 10880 ) N ;
+    - TAP_TAPCELL_ROW_10_2_123 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_124 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_125 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_126 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 38080 ) N ;
+    - TAP_TAPCELL_ROW_11_2_127 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 40800 ) FS ;
+    - TAP_TAPCELL_ROW_11_2_128 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 40800 ) FS ;
+    - TAP_TAPCELL_ROW_11_2_129 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 40800 ) FS ;
+    - TAP_TAPCELL_ROW_12_2_130 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_131 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_132 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_133 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 43520 ) N ;
+    - TAP_TAPCELL_ROW_13_2_134 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 46240 ) FS ;
+    - TAP_TAPCELL_ROW_13_2_135 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 46240 ) FS ;
+    - TAP_TAPCELL_ROW_13_2_136 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 46240 ) FS ;
+    - TAP_TAPCELL_ROW_14_2_137 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_138 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_139 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_140 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 48960 ) N ;
+    - TAP_TAPCELL_ROW_15_2_141 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 51680 ) FS ;
+    - TAP_TAPCELL_ROW_15_2_142 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 51680 ) FS ;
+    - TAP_TAPCELL_ROW_15_2_143 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 51680 ) FS ;
+    - TAP_TAPCELL_ROW_16_2_144 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_145 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_146 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_147 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 54400 ) N ;
+    - TAP_TAPCELL_ROW_17_2_148 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 57120 ) FS ;
+    - TAP_TAPCELL_ROW_17_2_149 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 57120 ) FS ;
+    - TAP_TAPCELL_ROW_17_2_150 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 57120 ) FS ;
+    - TAP_TAPCELL_ROW_18_2_151 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_152 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_153 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_154 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 59840 ) N ;
+    - TAP_TAPCELL_ROW_19_155 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_156 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_157 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_158 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_159 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_160 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_161 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_162 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_163 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_164 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_165 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_166 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_167 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 62560 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_92 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 13600 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_93 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 13600 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_94 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 13600 ) FS ;
+    - TAP_TAPCELL_ROW_20_168 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_169 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_170 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_171 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_172 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_173 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_174 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 65280 ) N ;
+    - TAP_TAPCELL_ROW_21_175 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_176 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_177 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_178 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_179 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_180 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 68000 ) FS ;
+    - TAP_TAPCELL_ROW_22_181 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_182 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_183 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_184 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_185 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_186 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_187 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_188 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_189 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_190 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_191 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_192 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_193 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 70720 ) N ;
+    - TAP_TAPCELL_ROW_2_2_95 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_96 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_97 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_98 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 16320 ) N ;
+    - TAP_TAPCELL_ROW_3_2_100 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 19040 ) FS ;
+    - TAP_TAPCELL_ROW_3_2_101 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 19040 ) FS ;
+    - TAP_TAPCELL_ROW_3_2_99 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 19040 ) FS ;
+    - TAP_TAPCELL_ROW_42_197 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_198 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_199 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_200 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_201 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_202 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_203 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_204 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_205 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_206 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_207 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_208 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_209 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 125120 ) N ;
+    - TAP_TAPCELL_ROW_43_210 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_211 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_212 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_213 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_214 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_215 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 127840 ) FS ;
+    - TAP_TAPCELL_ROW_44_216 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_217 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_218 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_219 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_220 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_221 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_222 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 130560 ) N ;
+    - TAP_TAPCELL_ROW_45_223 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_224 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_225 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_226 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_227 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_228 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_229 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_230 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_231 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_232 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_233 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_234 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_235 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 133280 ) FS ;
+    - TAP_TAPCELL_ROW_46_1_194 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 136000 ) N ;
+    - TAP_TAPCELL_ROW_46_1_195 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 136000 ) N ;
+    - TAP_TAPCELL_ROW_46_1_196 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 136000 ) N ;
+    - TAP_TAPCELL_ROW_47_1_236 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 138720 ) FS ;
+    - TAP_TAPCELL_ROW_47_1_237 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 138720 ) FS ;
+    - TAP_TAPCELL_ROW_47_1_238 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 138720 ) FS ;
+    - TAP_TAPCELL_ROW_48_1_239 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 141440 ) N ;
+    - TAP_TAPCELL_ROW_48_1_240 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 141440 ) N ;
+    - TAP_TAPCELL_ROW_48_1_241 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 141440 ) N ;
+    - TAP_TAPCELL_ROW_49_1_242 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 144160 ) FS ;
+    - TAP_TAPCELL_ROW_49_1_243 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 144160 ) FS ;
+    - TAP_TAPCELL_ROW_49_1_244 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 144160 ) FS ;
+    - TAP_TAPCELL_ROW_4_2_102 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_103 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_104 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_105 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 21760 ) N ;
+    - TAP_TAPCELL_ROW_50_1_245 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 146880 ) N ;
+    - TAP_TAPCELL_ROW_50_1_246 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 146880 ) N ;
+    - TAP_TAPCELL_ROW_50_1_247 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 146880 ) N ;
+    - TAP_TAPCELL_ROW_51_1_248 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 149600 ) FS ;
+    - TAP_TAPCELL_ROW_51_1_249 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 149600 ) FS ;
+    - TAP_TAPCELL_ROW_51_1_250 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 149600 ) FS ;
+    - TAP_TAPCELL_ROW_52_1_251 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 152320 ) N ;
+    - TAP_TAPCELL_ROW_52_1_252 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 152320 ) N ;
+    - TAP_TAPCELL_ROW_52_1_253 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 152320 ) N ;
+    - TAP_TAPCELL_ROW_53_1_254 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 155040 ) FS ;
+    - TAP_TAPCELL_ROW_53_1_255 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 155040 ) FS ;
+    - TAP_TAPCELL_ROW_53_1_256 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 155040 ) FS ;
+    - TAP_TAPCELL_ROW_54_1_257 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 157760 ) N ;
+    - TAP_TAPCELL_ROW_54_1_258 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 157760 ) N ;
+    - TAP_TAPCELL_ROW_54_1_259 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 157760 ) N ;
+    - TAP_TAPCELL_ROW_55_1_260 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 160480 ) FS ;
+    - TAP_TAPCELL_ROW_55_1_261 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 160480 ) FS ;
+    - TAP_TAPCELL_ROW_55_1_262 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 160480 ) FS ;
+    - TAP_TAPCELL_ROW_56_1_263 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 163200 ) N ;
+    - TAP_TAPCELL_ROW_56_1_264 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 163200 ) N ;
+    - TAP_TAPCELL_ROW_56_1_265 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 163200 ) N ;
+    - TAP_TAPCELL_ROW_57_1_266 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 165920 ) FS ;
+    - TAP_TAPCELL_ROW_57_1_267 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 165920 ) FS ;
+    - TAP_TAPCELL_ROW_57_1_268 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 165920 ) FS ;
+    - TAP_TAPCELL_ROW_58_1_269 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 168640 ) N ;
+    - TAP_TAPCELL_ROW_58_1_270 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 168640 ) N ;
+    - TAP_TAPCELL_ROW_58_1_271 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 168640 ) N ;
+    - TAP_TAPCELL_ROW_59_1_272 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 171360 ) FS ;
+    - TAP_TAPCELL_ROW_59_1_273 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 171360 ) FS ;
+    - TAP_TAPCELL_ROW_59_1_274 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 171360 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_106 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 24480 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_107 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 24480 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_108 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 24480 ) FS ;
+    - TAP_TAPCELL_ROW_60_1_275 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 174080 ) N ;
+    - TAP_TAPCELL_ROW_60_1_276 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 174080 ) N ;
+    - TAP_TAPCELL_ROW_60_1_277 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 174080 ) N ;
+    - TAP_TAPCELL_ROW_61_1_278 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 176800 ) FS ;
+    - TAP_TAPCELL_ROW_61_1_279 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 176800 ) FS ;
+    - TAP_TAPCELL_ROW_61_1_280 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 176800 ) FS ;
+    - TAP_TAPCELL_ROW_62_1_281 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 179520 ) N ;
+    - TAP_TAPCELL_ROW_62_1_282 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 179520 ) N ;
+    - TAP_TAPCELL_ROW_62_1_283 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 179520 ) N ;
+    - TAP_TAPCELL_ROW_63_1_284 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 182240 ) FS ;
+    - TAP_TAPCELL_ROW_63_1_285 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 182240 ) FS ;
+    - TAP_TAPCELL_ROW_63_1_286 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 182240 ) FS ;
+    - TAP_TAPCELL_ROW_64_1_287 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_288 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_289 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_290 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_291 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_292 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 184960 ) N ;
+    - TAP_TAPCELL_ROW_6_2_109 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_110 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_111 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_112 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 27200 ) N ;
+    - TAP_TAPCELL_ROW_7_2_113 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 29920 ) FS ;
+    - TAP_TAPCELL_ROW_7_2_114 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 29920 ) FS ;
+    - TAP_TAPCELL_ROW_7_2_115 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 29920 ) FS ;
+    - TAP_TAPCELL_ROW_8_2_116 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_117 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_118 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_119 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 32640 ) N ;
+    - TAP_TAPCELL_ROW_9_2_120 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 35360 ) FS ;
+    - TAP_TAPCELL_ROW_9_2_121 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 35360 ) FS ;
+    - TAP_TAPCELL_ROW_9_2_122 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 35360 ) FS ;
+    - TIE_ZERO_zero_ sky130_fd_sc_hd__conb_1 ;
+    - dsa\[0\] delayed_serial_adder + FIXED ( 10520 15640 ) N ;
+    - dsa\[1\] delayed_serial_adder + FIXED ( 10520 78880 ) N ;
+    - dsa\[2\] delayed_serial_adder + FIXED ( 60115 78880 ) N ;
+    - dsa\[3\] delayed_serial_adder + FIXED ( 99760 78880 ) N ;
+    - dsa\[4\] delayed_serial_adder + FIXED ( 99760 142120 ) N ;
+    - dsa\[5\] delayed_serial_adder + FIXED ( 149355 142120 ) N ;
+    - dsa\[6\] delayed_serial_adder + FIXED ( 149355 16075 ) FS ;
+    - dsa\[7\] delayed_serial_adder + FIXED ( 149355 78880 ) N ;
+END COMPONENTS
+PINS 12 ;
+    - a[0] + NET a[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 78540 ) N ;
+    - a[1] + NET a[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 92140 ) N ;
+    - a[2] + NET a[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 109140 ) N ;
+    - a[3] + NET a[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 85340 ) N ;
+    - a[4] + NET a[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 95540 ) N ;
+    - a[5] + NET a[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 81940 ) N ;
+    - a[6] + NET a[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 88740 ) N ;
+    - a[7] + NET a[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -140 -2000 ) ( 140 2000 )
+        + PLACED ( 96830 2000 ) N ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 2000 95540 ) N ;
+    - rst + NET rst + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 98940 ) N ;
+    - x + NET x + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 105740 ) N ;
+    - y + NET y + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 102340 ) N ;
+END PINS
+SPECIALNETS 2 ;
+    - VGND ( TIE_ZERO_zero_ VGND ) ( PHY_EDGE_ROW_64_1_Left_91 VGND ) ( PHY_EDGE_ROW_63_1_Left_90 VGND ) ( PHY_EDGE_ROW_62_1_Left_89 VGND ) ( PHY_EDGE_ROW_61_1_Left_88 VGND ) ( PHY_EDGE_ROW_60_1_Left_87 VGND ) ( PHY_EDGE_ROW_59_1_Left_86 VGND )
+      ( PHY_EDGE_ROW_58_1_Left_85 VGND ) ( PHY_EDGE_ROW_57_1_Left_84 VGND ) ( PHY_EDGE_ROW_56_1_Left_83 VGND ) ( PHY_EDGE_ROW_55_1_Left_82 VGND ) ( PHY_EDGE_ROW_54_1_Left_81 VGND ) ( PHY_EDGE_ROW_53_1_Left_80 VGND ) ( PHY_EDGE_ROW_52_1_Left_79 VGND ) ( PHY_EDGE_ROW_51_1_Left_78 VGND )
+      ( PHY_EDGE_ROW_50_1_Left_77 VGND ) ( PHY_EDGE_ROW_49_1_Left_76 VGND ) ( PHY_EDGE_ROW_48_1_Left_75 VGND ) ( PHY_EDGE_ROW_47_1_Left_74 VGND ) ( PHY_EDGE_ROW_45_Left_73 VGND ) ( PHY_EDGE_ROW_44_Left_72 VGND ) ( PHY_EDGE_ROW_43_Left_71 VGND ) ( PHY_EDGE_ROW_42_Left_70 VGND )
+      ( PHY_EDGE_ROW_46_1_Left_69 VGND ) ( PHY_EDGE_ROW_64_1_Right_68 VGND ) ( PHY_EDGE_ROW_63_1_Right_67 VGND ) ( PHY_EDGE_ROW_62_1_Right_66 VGND ) ( PHY_EDGE_ROW_61_1_Right_65 VGND ) ( PHY_EDGE_ROW_60_1_Right_64 VGND ) ( PHY_EDGE_ROW_59_1_Right_63 VGND ) ( PHY_EDGE_ROW_58_1_Right_62 VGND )
+      ( PHY_EDGE_ROW_57_1_Right_61 VGND ) ( PHY_EDGE_ROW_56_1_Right_60 VGND ) ( PHY_EDGE_ROW_55_1_Right_59 VGND ) ( PHY_EDGE_ROW_54_1_Right_58 VGND ) ( PHY_EDGE_ROW_53_1_Right_57 VGND ) ( PHY_EDGE_ROW_52_1_Right_56 VGND ) ( PHY_EDGE_ROW_51_1_Right_55 VGND ) ( PHY_EDGE_ROW_50_1_Right_54 VGND )
+      ( PHY_EDGE_ROW_49_1_Right_53 VGND ) ( PHY_EDGE_ROW_48_1_Right_52 VGND ) ( PHY_EDGE_ROW_47_1_Right_51 VGND ) ( PHY_EDGE_ROW_46_1_Right_50 VGND ) ( PHY_EDGE_ROW_45_Right_49 VGND ) ( PHY_EDGE_ROW_44_Right_48 VGND ) ( PHY_EDGE_ROW_43_Right_47 VGND ) ( PHY_EDGE_ROW_42_Right_46 VGND )
+      ( PHY_EDGE_ROW_22_Left_45 VGND ) ( PHY_EDGE_ROW_21_Left_44 VGND ) ( PHY_EDGE_ROW_20_Left_43 VGND ) ( PHY_EDGE_ROW_19_Left_42 VGND ) ( PHY_EDGE_ROW_22_Right_41 VGND ) ( PHY_EDGE_ROW_21_Right_40 VGND ) ( PHY_EDGE_ROW_20_Right_39 VGND ) ( PHY_EDGE_ROW_19_Right_38 VGND )
+      ( PHY_EDGE_ROW_0_2_Right_37 VGND ) ( PHY_EDGE_ROW_18_2_Right_36 VGND ) ( PHY_EDGE_ROW_17_2_Right_35 VGND ) ( PHY_EDGE_ROW_16_2_Right_34 VGND ) ( PHY_EDGE_ROW_15_2_Right_33 VGND ) ( PHY_EDGE_ROW_14_2_Right_32 VGND ) ( PHY_EDGE_ROW_13_2_Right_31 VGND ) ( PHY_EDGE_ROW_12_2_Right_30 VGND )
+      ( PHY_EDGE_ROW_11_2_Right_29 VGND ) ( PHY_EDGE_ROW_10_2_Right_28 VGND ) ( PHY_EDGE_ROW_9_2_Right_27 VGND ) ( PHY_EDGE_ROW_8_2_Right_26 VGND ) ( PHY_EDGE_ROW_7_2_Right_25 VGND ) ( PHY_EDGE_ROW_6_2_Right_24 VGND ) ( PHY_EDGE_ROW_5_2_Right_23 VGND ) ( PHY_EDGE_ROW_4_2_Right_22 VGND )
+      ( PHY_EDGE_ROW_3_2_Right_21 VGND ) ( PHY_EDGE_ROW_2_2_Right_20 VGND ) ( PHY_EDGE_ROW_1_2_Right_19 VGND ) ( PHY_EDGE_ROW_0_2_Left_18 VGND ) ( PHY_EDGE_ROW_18_2_Left_17 VGND ) ( PHY_EDGE_ROW_17_2_Left_16 VGND ) ( PHY_EDGE_ROW_16_2_Left_15 VGND ) ( PHY_EDGE_ROW_15_2_Left_14 VGND )
+      ( PHY_EDGE_ROW_14_2_Left_13 VGND ) ( PHY_EDGE_ROW_13_2_Left_12 VGND ) ( PHY_EDGE_ROW_12_2_Left_11 VGND ) ( PHY_EDGE_ROW_11_2_Left_10 VGND ) ( PHY_EDGE_ROW_10_2_Left_9 VGND ) ( PHY_EDGE_ROW_9_2_Left_8 VGND ) ( PHY_EDGE_ROW_8_2_Left_7 VGND ) ( PHY_EDGE_ROW_7_2_Left_6 VGND )
+      ( PHY_EDGE_ROW_6_2_Left_5 VGND ) ( PHY_EDGE_ROW_5_2_Left_4 VGND ) ( PHY_EDGE_ROW_4_2_Left_3 VGND ) ( PHY_EDGE_ROW_3_2_Left_2 VGND ) ( PHY_EDGE_ROW_2_2_Left_1 VGND ) ( PHY_EDGE_ROW_1_2_Left_0 VGND ) ( TIE_ZERO_zero_ VGND ) ( TAP_TAPCELL_ROW_0_2_299 VGND )
+      ( TAP_TAPCELL_ROW_0_2_298 VGND ) ( TAP_TAPCELL_ROW_0_2_297 VGND ) ( TAP_TAPCELL_ROW_0_2_296 VGND ) ( TAP_TAPCELL_ROW_0_2_295 VGND ) ( TAP_TAPCELL_ROW_0_2_294 VGND ) ( TAP_TAPCELL_ROW_0_2_293 VGND ) ( TAP_TAPCELL_ROW_64_1_292 VGND ) ( TAP_TAPCELL_ROW_64_1_291 VGND )
+      ( TAP_TAPCELL_ROW_64_1_290 VGND ) ( TAP_TAPCELL_ROW_64_1_289 VGND ) ( TAP_TAPCELL_ROW_64_1_288 VGND ) ( TAP_TAPCELL_ROW_64_1_287 VGND ) ( TAP_TAPCELL_ROW_63_1_286 VGND ) ( TAP_TAPCELL_ROW_63_1_285 VGND ) ( TAP_TAPCELL_ROW_63_1_284 VGND ) ( TAP_TAPCELL_ROW_62_1_283 VGND )
+      ( TAP_TAPCELL_ROW_62_1_282 VGND ) ( TAP_TAPCELL_ROW_62_1_281 VGND ) ( TAP_TAPCELL_ROW_61_1_280 VGND ) ( TAP_TAPCELL_ROW_61_1_279 VGND ) ( TAP_TAPCELL_ROW_61_1_278 VGND ) ( TAP_TAPCELL_ROW_60_1_277 VGND ) ( TAP_TAPCELL_ROW_60_1_276 VGND ) ( TAP_TAPCELL_ROW_60_1_275 VGND )
+      ( TAP_TAPCELL_ROW_59_1_274 VGND ) ( TAP_TAPCELL_ROW_59_1_273 VGND ) ( TAP_TAPCELL_ROW_59_1_272 VGND ) ( TAP_TAPCELL_ROW_58_1_271 VGND ) ( TAP_TAPCELL_ROW_58_1_270 VGND ) ( TAP_TAPCELL_ROW_58_1_269 VGND ) ( TAP_TAPCELL_ROW_57_1_268 VGND ) ( TAP_TAPCELL_ROW_57_1_267 VGND )
+      ( TAP_TAPCELL_ROW_57_1_266 VGND ) ( TAP_TAPCELL_ROW_56_1_265 VGND ) ( TAP_TAPCELL_ROW_56_1_264 VGND ) ( TAP_TAPCELL_ROW_56_1_263 VGND ) ( TAP_TAPCELL_ROW_55_1_262 VGND ) ( TAP_TAPCELL_ROW_55_1_261 VGND ) ( TAP_TAPCELL_ROW_55_1_260 VGND ) ( TAP_TAPCELL_ROW_54_1_259 VGND )
+      ( TAP_TAPCELL_ROW_54_1_258 VGND ) ( TAP_TAPCELL_ROW_54_1_257 VGND ) ( TAP_TAPCELL_ROW_53_1_256 VGND ) ( TAP_TAPCELL_ROW_53_1_255 VGND ) ( TAP_TAPCELL_ROW_53_1_254 VGND ) ( TAP_TAPCELL_ROW_52_1_253 VGND ) ( TAP_TAPCELL_ROW_52_1_252 VGND ) ( TAP_TAPCELL_ROW_52_1_251 VGND )
+      ( TAP_TAPCELL_ROW_51_1_250 VGND ) ( TAP_TAPCELL_ROW_51_1_249 VGND ) ( TAP_TAPCELL_ROW_51_1_248 VGND ) ( TAP_TAPCELL_ROW_50_1_247 VGND ) ( TAP_TAPCELL_ROW_50_1_246 VGND ) ( TAP_TAPCELL_ROW_50_1_245 VGND ) ( TAP_TAPCELL_ROW_49_1_244 VGND ) ( TAP_TAPCELL_ROW_49_1_243 VGND )
+      ( TAP_TAPCELL_ROW_49_1_242 VGND ) ( TAP_TAPCELL_ROW_48_1_241 VGND ) ( TAP_TAPCELL_ROW_48_1_240 VGND ) ( TAP_TAPCELL_ROW_48_1_239 VGND ) ( TAP_TAPCELL_ROW_47_1_238 VGND ) ( TAP_TAPCELL_ROW_47_1_237 VGND ) ( TAP_TAPCELL_ROW_47_1_236 VGND ) ( TAP_TAPCELL_ROW_45_235 VGND )
+      ( TAP_TAPCELL_ROW_45_234 VGND ) ( TAP_TAPCELL_ROW_45_233 VGND ) ( TAP_TAPCELL_ROW_45_232 VGND ) ( TAP_TAPCELL_ROW_45_231 VGND ) ( TAP_TAPCELL_ROW_45_230 VGND ) ( TAP_TAPCELL_ROW_45_229 VGND ) ( TAP_TAPCELL_ROW_45_228 VGND ) ( TAP_TAPCELL_ROW_45_227 VGND )
+      ( TAP_TAPCELL_ROW_45_226 VGND ) ( TAP_TAPCELL_ROW_45_225 VGND ) ( TAP_TAPCELL_ROW_45_224 VGND ) ( TAP_TAPCELL_ROW_45_223 VGND ) ( TAP_TAPCELL_ROW_44_222 VGND ) ( TAP_TAPCELL_ROW_44_221 VGND ) ( TAP_TAPCELL_ROW_44_220 VGND ) ( TAP_TAPCELL_ROW_44_219 VGND )
+      ( TAP_TAPCELL_ROW_44_218 VGND ) ( TAP_TAPCELL_ROW_44_217 VGND ) ( TAP_TAPCELL_ROW_44_216 VGND ) ( TAP_TAPCELL_ROW_43_215 VGND ) ( TAP_TAPCELL_ROW_43_214 VGND ) ( TAP_TAPCELL_ROW_43_213 VGND ) ( TAP_TAPCELL_ROW_43_212 VGND ) ( TAP_TAPCELL_ROW_43_211 VGND )
+      ( TAP_TAPCELL_ROW_43_210 VGND ) ( TAP_TAPCELL_ROW_42_209 VGND ) ( TAP_TAPCELL_ROW_42_208 VGND ) ( TAP_TAPCELL_ROW_42_207 VGND ) ( TAP_TAPCELL_ROW_42_206 VGND ) ( TAP_TAPCELL_ROW_42_205 VGND ) ( TAP_TAPCELL_ROW_42_204 VGND ) ( TAP_TAPCELL_ROW_42_203 VGND )
+      ( TAP_TAPCELL_ROW_42_202 VGND ) ( TAP_TAPCELL_ROW_42_201 VGND ) ( TAP_TAPCELL_ROW_42_200 VGND ) ( TAP_TAPCELL_ROW_42_199 VGND ) ( TAP_TAPCELL_ROW_42_198 VGND ) ( TAP_TAPCELL_ROW_42_197 VGND ) ( TAP_TAPCELL_ROW_46_1_196 VGND ) ( TAP_TAPCELL_ROW_46_1_195 VGND )
+      ( TAP_TAPCELL_ROW_46_1_194 VGND ) ( TAP_TAPCELL_ROW_22_193 VGND ) ( TAP_TAPCELL_ROW_22_192 VGND ) ( TAP_TAPCELL_ROW_22_191 VGND ) ( TAP_TAPCELL_ROW_22_190 VGND ) ( TAP_TAPCELL_ROW_22_189 VGND ) ( TAP_TAPCELL_ROW_22_188 VGND ) ( TAP_TAPCELL_ROW_22_187 VGND )
+      ( TAP_TAPCELL_ROW_22_186 VGND ) ( TAP_TAPCELL_ROW_22_185 VGND ) ( TAP_TAPCELL_ROW_22_184 VGND ) ( TAP_TAPCELL_ROW_22_183 VGND ) ( TAP_TAPCELL_ROW_22_182 VGND ) ( TAP_TAPCELL_ROW_22_181 VGND ) ( TAP_TAPCELL_ROW_21_180 VGND ) ( TAP_TAPCELL_ROW_21_179 VGND )
+      ( TAP_TAPCELL_ROW_21_178 VGND ) ( TAP_TAPCELL_ROW_21_177 VGND ) ( TAP_TAPCELL_ROW_21_176 VGND ) ( TAP_TAPCELL_ROW_21_175 VGND ) ( TAP_TAPCELL_ROW_20_174 VGND ) ( TAP_TAPCELL_ROW_20_173 VGND ) ( TAP_TAPCELL_ROW_20_172 VGND ) ( TAP_TAPCELL_ROW_20_171 VGND )
+      ( TAP_TAPCELL_ROW_20_170 VGND ) ( TAP_TAPCELL_ROW_20_169 VGND ) ( TAP_TAPCELL_ROW_20_168 VGND ) ( TAP_TAPCELL_ROW_19_167 VGND ) ( TAP_TAPCELL_ROW_19_166 VGND ) ( TAP_TAPCELL_ROW_19_165 VGND ) ( TAP_TAPCELL_ROW_19_164 VGND ) ( TAP_TAPCELL_ROW_19_163 VGND )
+      ( TAP_TAPCELL_ROW_19_162 VGND ) ( TAP_TAPCELL_ROW_19_161 VGND ) ( TAP_TAPCELL_ROW_19_160 VGND ) ( TAP_TAPCELL_ROW_19_159 VGND ) ( TAP_TAPCELL_ROW_19_158 VGND ) ( TAP_TAPCELL_ROW_19_157 VGND ) ( TAP_TAPCELL_ROW_19_156 VGND ) ( TAP_TAPCELL_ROW_19_155 VGND )
+      ( TAP_TAPCELL_ROW_18_2_154 VGND ) ( TAP_TAPCELL_ROW_18_2_153 VGND ) ( TAP_TAPCELL_ROW_18_2_152 VGND ) ( TAP_TAPCELL_ROW_18_2_151 VGND ) ( TAP_TAPCELL_ROW_17_2_150 VGND ) ( TAP_TAPCELL_ROW_17_2_149 VGND ) ( TAP_TAPCELL_ROW_17_2_148 VGND ) ( TAP_TAPCELL_ROW_16_2_147 VGND )
+      ( TAP_TAPCELL_ROW_16_2_146 VGND ) ( TAP_TAPCELL_ROW_16_2_145 VGND ) ( TAP_TAPCELL_ROW_16_2_144 VGND ) ( TAP_TAPCELL_ROW_15_2_143 VGND ) ( TAP_TAPCELL_ROW_15_2_142 VGND ) ( TAP_TAPCELL_ROW_15_2_141 VGND ) ( TAP_TAPCELL_ROW_14_2_140 VGND ) ( TAP_TAPCELL_ROW_14_2_139 VGND )
+      ( TAP_TAPCELL_ROW_14_2_138 VGND ) ( TAP_TAPCELL_ROW_14_2_137 VGND ) ( TAP_TAPCELL_ROW_13_2_136 VGND ) ( TAP_TAPCELL_ROW_13_2_135 VGND ) ( TAP_TAPCELL_ROW_13_2_134 VGND ) ( TAP_TAPCELL_ROW_12_2_133 VGND ) ( TAP_TAPCELL_ROW_12_2_132 VGND ) ( TAP_TAPCELL_ROW_12_2_131 VGND )
+      ( TAP_TAPCELL_ROW_12_2_130 VGND ) ( TAP_TAPCELL_ROW_11_2_129 VGND ) ( TAP_TAPCELL_ROW_11_2_128 VGND ) ( TAP_TAPCELL_ROW_11_2_127 VGND ) ( TAP_TAPCELL_ROW_10_2_126 VGND ) ( TAP_TAPCELL_ROW_10_2_125 VGND ) ( TAP_TAPCELL_ROW_10_2_124 VGND ) ( TAP_TAPCELL_ROW_10_2_123 VGND )
+      ( TAP_TAPCELL_ROW_9_2_122 VGND ) ( TAP_TAPCELL_ROW_9_2_121 VGND ) ( TAP_TAPCELL_ROW_9_2_120 VGND ) ( TAP_TAPCELL_ROW_8_2_119 VGND ) ( TAP_TAPCELL_ROW_8_2_118 VGND ) ( TAP_TAPCELL_ROW_8_2_117 VGND ) ( TAP_TAPCELL_ROW_8_2_116 VGND ) ( TAP_TAPCELL_ROW_7_2_115 VGND )
+      ( TAP_TAPCELL_ROW_7_2_114 VGND ) ( TAP_TAPCELL_ROW_7_2_113 VGND ) ( TAP_TAPCELL_ROW_6_2_112 VGND ) ( TAP_TAPCELL_ROW_6_2_111 VGND ) ( TAP_TAPCELL_ROW_6_2_110 VGND ) ( TAP_TAPCELL_ROW_6_2_109 VGND ) ( TAP_TAPCELL_ROW_5_2_108 VGND ) ( TAP_TAPCELL_ROW_5_2_107 VGND )
+      ( TAP_TAPCELL_ROW_5_2_106 VGND ) ( TAP_TAPCELL_ROW_4_2_105 VGND ) ( TAP_TAPCELL_ROW_4_2_104 VGND ) ( TAP_TAPCELL_ROW_4_2_103 VGND ) ( TAP_TAPCELL_ROW_4_2_102 VGND ) ( TAP_TAPCELL_ROW_3_2_101 VGND ) ( TAP_TAPCELL_ROW_3_2_100 VGND ) ( TAP_TAPCELL_ROW_3_2_99 VGND )
+      ( TAP_TAPCELL_ROW_2_2_98 VGND ) ( TAP_TAPCELL_ROW_2_2_97 VGND ) ( TAP_TAPCELL_ROW_2_2_96 VGND ) ( TAP_TAPCELL_ROW_2_2_95 VGND ) ( TAP_TAPCELL_ROW_1_2_94 VGND ) ( TAP_TAPCELL_ROW_1_2_93 VGND ) ( TAP_TAPCELL_ROW_1_2_92 VGND ) ( PHY_EDGE_ROW_64_1_Left_91 VGND )
+      ( PHY_EDGE_ROW_63_1_Left_90 VGND ) ( PHY_EDGE_ROW_62_1_Left_89 VGND ) ( PHY_EDGE_ROW_61_1_Left_88 VGND ) ( PHY_EDGE_ROW_60_1_Left_87 VGND ) ( PHY_EDGE_ROW_59_1_Left_86 VGND ) ( PHY_EDGE_ROW_58_1_Left_85 VGND ) ( PHY_EDGE_ROW_57_1_Left_84 VGND ) ( PHY_EDGE_ROW_56_1_Left_83 VGND )
+      ( PHY_EDGE_ROW_55_1_Left_82 VGND ) ( PHY_EDGE_ROW_54_1_Left_81 VGND ) ( PHY_EDGE_ROW_53_1_Left_80 VGND ) ( PHY_EDGE_ROW_52_1_Left_79 VGND ) ( PHY_EDGE_ROW_51_1_Left_78 VGND ) ( PHY_EDGE_ROW_50_1_Left_77 VGND ) ( PHY_EDGE_ROW_49_1_Left_76 VGND ) ( PHY_EDGE_ROW_48_1_Left_75 VGND )
+      ( PHY_EDGE_ROW_47_1_Left_74 VGND ) ( PHY_EDGE_ROW_45_Left_73 VGND ) ( PHY_EDGE_ROW_44_Left_72 VGND ) ( PHY_EDGE_ROW_43_Left_71 VGND ) ( PHY_EDGE_ROW_42_Left_70 VGND ) ( PHY_EDGE_ROW_46_1_Left_69 VGND ) ( PHY_EDGE_ROW_64_1_Right_68 VGND ) ( PHY_EDGE_ROW_63_1_Right_67 VGND )
+      ( PHY_EDGE_ROW_62_1_Right_66 VGND ) ( PHY_EDGE_ROW_61_1_Right_65 VGND ) ( PHY_EDGE_ROW_60_1_Right_64 VGND ) ( PHY_EDGE_ROW_59_1_Right_63 VGND ) ( PHY_EDGE_ROW_58_1_Right_62 VGND ) ( PHY_EDGE_ROW_57_1_Right_61 VGND ) ( PHY_EDGE_ROW_56_1_Right_60 VGND ) ( PHY_EDGE_ROW_55_1_Right_59 VGND )
+      ( PHY_EDGE_ROW_54_1_Right_58 VGND ) ( PHY_EDGE_ROW_53_1_Right_57 VGND ) ( PHY_EDGE_ROW_52_1_Right_56 VGND ) ( PHY_EDGE_ROW_51_1_Right_55 VGND ) ( PHY_EDGE_ROW_50_1_Right_54 VGND ) ( PHY_EDGE_ROW_49_1_Right_53 VGND ) ( PHY_EDGE_ROW_48_1_Right_52 VGND ) ( PHY_EDGE_ROW_47_1_Right_51 VGND )
+      ( PHY_EDGE_ROW_46_1_Right_50 VGND ) ( PHY_EDGE_ROW_45_Right_49 VGND ) ( PHY_EDGE_ROW_44_Right_48 VGND ) ( PHY_EDGE_ROW_43_Right_47 VGND ) ( PHY_EDGE_ROW_42_Right_46 VGND ) ( PHY_EDGE_ROW_22_Left_45 VGND ) ( PHY_EDGE_ROW_21_Left_44 VGND ) ( PHY_EDGE_ROW_20_Left_43 VGND )
+      ( PHY_EDGE_ROW_19_Left_42 VGND ) ( PHY_EDGE_ROW_22_Right_41 VGND ) ( PHY_EDGE_ROW_21_Right_40 VGND ) ( PHY_EDGE_ROW_20_Right_39 VGND ) ( PHY_EDGE_ROW_19_Right_38 VGND ) ( PHY_EDGE_ROW_0_2_Right_37 VGND ) ( PHY_EDGE_ROW_18_2_Right_36 VGND ) ( PHY_EDGE_ROW_17_2_Right_35 VGND )
+      ( PHY_EDGE_ROW_16_2_Right_34 VGND ) ( PHY_EDGE_ROW_15_2_Right_33 VGND ) ( PHY_EDGE_ROW_14_2_Right_32 VGND ) ( PHY_EDGE_ROW_13_2_Right_31 VGND ) ( PHY_EDGE_ROW_12_2_Right_30 VGND ) ( PHY_EDGE_ROW_11_2_Right_29 VGND ) ( PHY_EDGE_ROW_10_2_Right_28 VGND ) ( PHY_EDGE_ROW_9_2_Right_27 VGND )
+      ( PHY_EDGE_ROW_8_2_Right_26 VGND ) ( PHY_EDGE_ROW_7_2_Right_25 VGND ) ( PHY_EDGE_ROW_6_2_Right_24 VGND ) ( PHY_EDGE_ROW_5_2_Right_23 VGND ) ( PHY_EDGE_ROW_4_2_Right_22 VGND ) ( PHY_EDGE_ROW_3_2_Right_21 VGND ) ( PHY_EDGE_ROW_2_2_Right_20 VGND ) ( PHY_EDGE_ROW_1_2_Right_19 VGND )
+      ( PHY_EDGE_ROW_0_2_Left_18 VGND ) ( PHY_EDGE_ROW_18_2_Left_17 VGND ) ( PHY_EDGE_ROW_17_2_Left_16 VGND ) ( PHY_EDGE_ROW_16_2_Left_15 VGND ) ( PHY_EDGE_ROW_15_2_Left_14 VGND ) ( PHY_EDGE_ROW_14_2_Left_13 VGND ) ( PHY_EDGE_ROW_13_2_Left_12 VGND ) ( PHY_EDGE_ROW_12_2_Left_11 VGND )
+      ( PHY_EDGE_ROW_11_2_Left_10 VGND ) ( PHY_EDGE_ROW_10_2_Left_9 VGND ) ( PHY_EDGE_ROW_9_2_Left_8 VGND ) ( PHY_EDGE_ROW_8_2_Left_7 VGND ) ( PHY_EDGE_ROW_7_2_Left_6 VGND ) ( PHY_EDGE_ROW_6_2_Left_5 VGND ) ( PHY_EDGE_ROW_5_2_Left_4 VGND ) ( PHY_EDGE_ROW_4_2_Left_3 VGND )
+      ( PHY_EDGE_ROW_3_2_Left_2 VGND ) ( PHY_EDGE_ROW_2_2_Left_1 VGND ) ( PHY_EDGE_ROW_1_2_Left_0 VGND ) ( dsa\[7\] VGND ) ( dsa\[6\] VGND ) ( dsa\[5\] VGND ) ( dsa\[4\] VGND ) ( dsa\[3\] VGND )
+      ( dsa\[2\] VGND ) ( dsa\[1\] VGND ) ( dsa\[0\] VGND ) + USE GROUND ;
+    - VPWR ( TIE_ZERO_zero_ VPWR ) ( PHY_EDGE_ROW_64_1_Left_91 VPWR ) ( PHY_EDGE_ROW_63_1_Left_90 VPWR ) ( PHY_EDGE_ROW_62_1_Left_89 VPWR ) ( PHY_EDGE_ROW_61_1_Left_88 VPWR ) ( PHY_EDGE_ROW_60_1_Left_87 VPWR ) ( PHY_EDGE_ROW_59_1_Left_86 VPWR )
+      ( PHY_EDGE_ROW_58_1_Left_85 VPWR ) ( PHY_EDGE_ROW_57_1_Left_84 VPWR ) ( PHY_EDGE_ROW_56_1_Left_83 VPWR ) ( PHY_EDGE_ROW_55_1_Left_82 VPWR ) ( PHY_EDGE_ROW_54_1_Left_81 VPWR ) ( PHY_EDGE_ROW_53_1_Left_80 VPWR ) ( PHY_EDGE_ROW_52_1_Left_79 VPWR ) ( PHY_EDGE_ROW_51_1_Left_78 VPWR )
+      ( PHY_EDGE_ROW_50_1_Left_77 VPWR ) ( PHY_EDGE_ROW_49_1_Left_76 VPWR ) ( PHY_EDGE_ROW_48_1_Left_75 VPWR ) ( PHY_EDGE_ROW_47_1_Left_74 VPWR ) ( PHY_EDGE_ROW_45_Left_73 VPWR ) ( PHY_EDGE_ROW_44_Left_72 VPWR ) ( PHY_EDGE_ROW_43_Left_71 VPWR ) ( PHY_EDGE_ROW_42_Left_70 VPWR )
+      ( PHY_EDGE_ROW_46_1_Left_69 VPWR ) ( PHY_EDGE_ROW_64_1_Right_68 VPWR ) ( PHY_EDGE_ROW_63_1_Right_67 VPWR ) ( PHY_EDGE_ROW_62_1_Right_66 VPWR ) ( PHY_EDGE_ROW_61_1_Right_65 VPWR ) ( PHY_EDGE_ROW_60_1_Right_64 VPWR ) ( PHY_EDGE_ROW_59_1_Right_63 VPWR ) ( PHY_EDGE_ROW_58_1_Right_62 VPWR )
+      ( PHY_EDGE_ROW_57_1_Right_61 VPWR ) ( PHY_EDGE_ROW_56_1_Right_60 VPWR ) ( PHY_EDGE_ROW_55_1_Right_59 VPWR ) ( PHY_EDGE_ROW_54_1_Right_58 VPWR ) ( PHY_EDGE_ROW_53_1_Right_57 VPWR ) ( PHY_EDGE_ROW_52_1_Right_56 VPWR ) ( PHY_EDGE_ROW_51_1_Right_55 VPWR ) ( PHY_EDGE_ROW_50_1_Right_54 VPWR )
+      ( PHY_EDGE_ROW_49_1_Right_53 VPWR ) ( PHY_EDGE_ROW_48_1_Right_52 VPWR ) ( PHY_EDGE_ROW_47_1_Right_51 VPWR ) ( PHY_EDGE_ROW_46_1_Right_50 VPWR ) ( PHY_EDGE_ROW_45_Right_49 VPWR ) ( PHY_EDGE_ROW_44_Right_48 VPWR ) ( PHY_EDGE_ROW_43_Right_47 VPWR ) ( PHY_EDGE_ROW_42_Right_46 VPWR )
+      ( PHY_EDGE_ROW_22_Left_45 VPWR ) ( PHY_EDGE_ROW_21_Left_44 VPWR ) ( PHY_EDGE_ROW_20_Left_43 VPWR ) ( PHY_EDGE_ROW_19_Left_42 VPWR ) ( PHY_EDGE_ROW_22_Right_41 VPWR ) ( PHY_EDGE_ROW_21_Right_40 VPWR ) ( PHY_EDGE_ROW_20_Right_39 VPWR ) ( PHY_EDGE_ROW_19_Right_38 VPWR )
+      ( PHY_EDGE_ROW_0_2_Right_37 VPWR ) ( PHY_EDGE_ROW_18_2_Right_36 VPWR ) ( PHY_EDGE_ROW_17_2_Right_35 VPWR ) ( PHY_EDGE_ROW_16_2_Right_34 VPWR ) ( PHY_EDGE_ROW_15_2_Right_33 VPWR ) ( PHY_EDGE_ROW_14_2_Right_32 VPWR ) ( PHY_EDGE_ROW_13_2_Right_31 VPWR ) ( PHY_EDGE_ROW_12_2_Right_30 VPWR )
+      ( PHY_EDGE_ROW_11_2_Right_29 VPWR ) ( PHY_EDGE_ROW_10_2_Right_28 VPWR ) ( PHY_EDGE_ROW_9_2_Right_27 VPWR ) ( PHY_EDGE_ROW_8_2_Right_26 VPWR ) ( PHY_EDGE_ROW_7_2_Right_25 VPWR ) ( PHY_EDGE_ROW_6_2_Right_24 VPWR ) ( PHY_EDGE_ROW_5_2_Right_23 VPWR ) ( PHY_EDGE_ROW_4_2_Right_22 VPWR )
+      ( PHY_EDGE_ROW_3_2_Right_21 VPWR ) ( PHY_EDGE_ROW_2_2_Right_20 VPWR ) ( PHY_EDGE_ROW_1_2_Right_19 VPWR ) ( PHY_EDGE_ROW_0_2_Left_18 VPWR ) ( PHY_EDGE_ROW_18_2_Left_17 VPWR ) ( PHY_EDGE_ROW_17_2_Left_16 VPWR ) ( PHY_EDGE_ROW_16_2_Left_15 VPWR ) ( PHY_EDGE_ROW_15_2_Left_14 VPWR )
+      ( PHY_EDGE_ROW_14_2_Left_13 VPWR ) ( PHY_EDGE_ROW_13_2_Left_12 VPWR ) ( PHY_EDGE_ROW_12_2_Left_11 VPWR ) ( PHY_EDGE_ROW_11_2_Left_10 VPWR ) ( PHY_EDGE_ROW_10_2_Left_9 VPWR ) ( PHY_EDGE_ROW_9_2_Left_8 VPWR ) ( PHY_EDGE_ROW_8_2_Left_7 VPWR ) ( PHY_EDGE_ROW_7_2_Left_6 VPWR )
+      ( PHY_EDGE_ROW_6_2_Left_5 VPWR ) ( PHY_EDGE_ROW_5_2_Left_4 VPWR ) ( PHY_EDGE_ROW_4_2_Left_3 VPWR ) ( PHY_EDGE_ROW_3_2_Left_2 VPWR ) ( PHY_EDGE_ROW_2_2_Left_1 VPWR ) ( PHY_EDGE_ROW_1_2_Left_0 VPWR ) ( TIE_ZERO_zero_ VPWR ) ( TAP_TAPCELL_ROW_0_2_299 VPWR )
+      ( TAP_TAPCELL_ROW_0_2_298 VPWR ) ( TAP_TAPCELL_ROW_0_2_297 VPWR ) ( TAP_TAPCELL_ROW_0_2_296 VPWR ) ( TAP_TAPCELL_ROW_0_2_295 VPWR ) ( TAP_TAPCELL_ROW_0_2_294 VPWR ) ( TAP_TAPCELL_ROW_0_2_293 VPWR ) ( TAP_TAPCELL_ROW_64_1_292 VPWR ) ( TAP_TAPCELL_ROW_64_1_291 VPWR )
+      ( TAP_TAPCELL_ROW_64_1_290 VPWR ) ( TAP_TAPCELL_ROW_64_1_289 VPWR ) ( TAP_TAPCELL_ROW_64_1_288 VPWR ) ( TAP_TAPCELL_ROW_64_1_287 VPWR ) ( TAP_TAPCELL_ROW_63_1_286 VPWR ) ( TAP_TAPCELL_ROW_63_1_285 VPWR ) ( TAP_TAPCELL_ROW_63_1_284 VPWR ) ( TAP_TAPCELL_ROW_62_1_283 VPWR )
+      ( TAP_TAPCELL_ROW_62_1_282 VPWR ) ( TAP_TAPCELL_ROW_62_1_281 VPWR ) ( TAP_TAPCELL_ROW_61_1_280 VPWR ) ( TAP_TAPCELL_ROW_61_1_279 VPWR ) ( TAP_TAPCELL_ROW_61_1_278 VPWR ) ( TAP_TAPCELL_ROW_60_1_277 VPWR ) ( TAP_TAPCELL_ROW_60_1_276 VPWR ) ( TAP_TAPCELL_ROW_60_1_275 VPWR )
+      ( TAP_TAPCELL_ROW_59_1_274 VPWR ) ( TAP_TAPCELL_ROW_59_1_273 VPWR ) ( TAP_TAPCELL_ROW_59_1_272 VPWR ) ( TAP_TAPCELL_ROW_58_1_271 VPWR ) ( TAP_TAPCELL_ROW_58_1_270 VPWR ) ( TAP_TAPCELL_ROW_58_1_269 VPWR ) ( TAP_TAPCELL_ROW_57_1_268 VPWR ) ( TAP_TAPCELL_ROW_57_1_267 VPWR )
+      ( TAP_TAPCELL_ROW_57_1_266 VPWR ) ( TAP_TAPCELL_ROW_56_1_265 VPWR ) ( TAP_TAPCELL_ROW_56_1_264 VPWR ) ( TAP_TAPCELL_ROW_56_1_263 VPWR ) ( TAP_TAPCELL_ROW_55_1_262 VPWR ) ( TAP_TAPCELL_ROW_55_1_261 VPWR ) ( TAP_TAPCELL_ROW_55_1_260 VPWR ) ( TAP_TAPCELL_ROW_54_1_259 VPWR )
+      ( TAP_TAPCELL_ROW_54_1_258 VPWR ) ( TAP_TAPCELL_ROW_54_1_257 VPWR ) ( TAP_TAPCELL_ROW_53_1_256 VPWR ) ( TAP_TAPCELL_ROW_53_1_255 VPWR ) ( TAP_TAPCELL_ROW_53_1_254 VPWR ) ( TAP_TAPCELL_ROW_52_1_253 VPWR ) ( TAP_TAPCELL_ROW_52_1_252 VPWR ) ( TAP_TAPCELL_ROW_52_1_251 VPWR )
+      ( TAP_TAPCELL_ROW_51_1_250 VPWR ) ( TAP_TAPCELL_ROW_51_1_249 VPWR ) ( TAP_TAPCELL_ROW_51_1_248 VPWR ) ( TAP_TAPCELL_ROW_50_1_247 VPWR ) ( TAP_TAPCELL_ROW_50_1_246 VPWR ) ( TAP_TAPCELL_ROW_50_1_245 VPWR ) ( TAP_TAPCELL_ROW_49_1_244 VPWR ) ( TAP_TAPCELL_ROW_49_1_243 VPWR )
+      ( TAP_TAPCELL_ROW_49_1_242 VPWR ) ( TAP_TAPCELL_ROW_48_1_241 VPWR ) ( TAP_TAPCELL_ROW_48_1_240 VPWR ) ( TAP_TAPCELL_ROW_48_1_239 VPWR ) ( TAP_TAPCELL_ROW_47_1_238 VPWR ) ( TAP_TAPCELL_ROW_47_1_237 VPWR ) ( TAP_TAPCELL_ROW_47_1_236 VPWR ) ( TAP_TAPCELL_ROW_45_235 VPWR )
+      ( TAP_TAPCELL_ROW_45_234 VPWR ) ( TAP_TAPCELL_ROW_45_233 VPWR ) ( TAP_TAPCELL_ROW_45_232 VPWR ) ( TAP_TAPCELL_ROW_45_231 VPWR ) ( TAP_TAPCELL_ROW_45_230 VPWR ) ( TAP_TAPCELL_ROW_45_229 VPWR ) ( TAP_TAPCELL_ROW_45_228 VPWR ) ( TAP_TAPCELL_ROW_45_227 VPWR )
+      ( TAP_TAPCELL_ROW_45_226 VPWR ) ( TAP_TAPCELL_ROW_45_225 VPWR ) ( TAP_TAPCELL_ROW_45_224 VPWR ) ( TAP_TAPCELL_ROW_45_223 VPWR ) ( TAP_TAPCELL_ROW_44_222 VPWR ) ( TAP_TAPCELL_ROW_44_221 VPWR ) ( TAP_TAPCELL_ROW_44_220 VPWR ) ( TAP_TAPCELL_ROW_44_219 VPWR )
+      ( TAP_TAPCELL_ROW_44_218 VPWR ) ( TAP_TAPCELL_ROW_44_217 VPWR ) ( TAP_TAPCELL_ROW_44_216 VPWR ) ( TAP_TAPCELL_ROW_43_215 VPWR ) ( TAP_TAPCELL_ROW_43_214 VPWR ) ( TAP_TAPCELL_ROW_43_213 VPWR ) ( TAP_TAPCELL_ROW_43_212 VPWR ) ( TAP_TAPCELL_ROW_43_211 VPWR )
+      ( TAP_TAPCELL_ROW_43_210 VPWR ) ( TAP_TAPCELL_ROW_42_209 VPWR ) ( TAP_TAPCELL_ROW_42_208 VPWR ) ( TAP_TAPCELL_ROW_42_207 VPWR ) ( TAP_TAPCELL_ROW_42_206 VPWR ) ( TAP_TAPCELL_ROW_42_205 VPWR ) ( TAP_TAPCELL_ROW_42_204 VPWR ) ( TAP_TAPCELL_ROW_42_203 VPWR )
+      ( TAP_TAPCELL_ROW_42_202 VPWR ) ( TAP_TAPCELL_ROW_42_201 VPWR ) ( TAP_TAPCELL_ROW_42_200 VPWR ) ( TAP_TAPCELL_ROW_42_199 VPWR ) ( TAP_TAPCELL_ROW_42_198 VPWR ) ( TAP_TAPCELL_ROW_42_197 VPWR ) ( TAP_TAPCELL_ROW_46_1_196 VPWR ) ( TAP_TAPCELL_ROW_46_1_195 VPWR )
+      ( TAP_TAPCELL_ROW_46_1_194 VPWR ) ( TAP_TAPCELL_ROW_22_193 VPWR ) ( TAP_TAPCELL_ROW_22_192 VPWR ) ( TAP_TAPCELL_ROW_22_191 VPWR ) ( TAP_TAPCELL_ROW_22_190 VPWR ) ( TAP_TAPCELL_ROW_22_189 VPWR ) ( TAP_TAPCELL_ROW_22_188 VPWR ) ( TAP_TAPCELL_ROW_22_187 VPWR )
+      ( TAP_TAPCELL_ROW_22_186 VPWR ) ( TAP_TAPCELL_ROW_22_185 VPWR ) ( TAP_TAPCELL_ROW_22_184 VPWR ) ( TAP_TAPCELL_ROW_22_183 VPWR ) ( TAP_TAPCELL_ROW_22_182 VPWR ) ( TAP_TAPCELL_ROW_22_181 VPWR ) ( TAP_TAPCELL_ROW_21_180 VPWR ) ( TAP_TAPCELL_ROW_21_179 VPWR )
+      ( TAP_TAPCELL_ROW_21_178 VPWR ) ( TAP_TAPCELL_ROW_21_177 VPWR ) ( TAP_TAPCELL_ROW_21_176 VPWR ) ( TAP_TAPCELL_ROW_21_175 VPWR ) ( TAP_TAPCELL_ROW_20_174 VPWR ) ( TAP_TAPCELL_ROW_20_173 VPWR ) ( TAP_TAPCELL_ROW_20_172 VPWR ) ( TAP_TAPCELL_ROW_20_171 VPWR )
+      ( TAP_TAPCELL_ROW_20_170 VPWR ) ( TAP_TAPCELL_ROW_20_169 VPWR ) ( TAP_TAPCELL_ROW_20_168 VPWR ) ( TAP_TAPCELL_ROW_19_167 VPWR ) ( TAP_TAPCELL_ROW_19_166 VPWR ) ( TAP_TAPCELL_ROW_19_165 VPWR ) ( TAP_TAPCELL_ROW_19_164 VPWR ) ( TAP_TAPCELL_ROW_19_163 VPWR )
+      ( TAP_TAPCELL_ROW_19_162 VPWR ) ( TAP_TAPCELL_ROW_19_161 VPWR ) ( TAP_TAPCELL_ROW_19_160 VPWR ) ( TAP_TAPCELL_ROW_19_159 VPWR ) ( TAP_TAPCELL_ROW_19_158 VPWR ) ( TAP_TAPCELL_ROW_19_157 VPWR ) ( TAP_TAPCELL_ROW_19_156 VPWR ) ( TAP_TAPCELL_ROW_19_155 VPWR )
+      ( TAP_TAPCELL_ROW_18_2_154 VPWR ) ( TAP_TAPCELL_ROW_18_2_153 VPWR ) ( TAP_TAPCELL_ROW_18_2_152 VPWR ) ( TAP_TAPCELL_ROW_18_2_151 VPWR ) ( TAP_TAPCELL_ROW_17_2_150 VPWR ) ( TAP_TAPCELL_ROW_17_2_149 VPWR ) ( TAP_TAPCELL_ROW_17_2_148 VPWR ) ( TAP_TAPCELL_ROW_16_2_147 VPWR )
+      ( TAP_TAPCELL_ROW_16_2_146 VPWR ) ( TAP_TAPCELL_ROW_16_2_145 VPWR ) ( TAP_TAPCELL_ROW_16_2_144 VPWR ) ( TAP_TAPCELL_ROW_15_2_143 VPWR ) ( TAP_TAPCELL_ROW_15_2_142 VPWR ) ( TAP_TAPCELL_ROW_15_2_141 VPWR ) ( TAP_TAPCELL_ROW_14_2_140 VPWR ) ( TAP_TAPCELL_ROW_14_2_139 VPWR )
+      ( TAP_TAPCELL_ROW_14_2_138 VPWR ) ( TAP_TAPCELL_ROW_14_2_137 VPWR ) ( TAP_TAPCELL_ROW_13_2_136 VPWR ) ( TAP_TAPCELL_ROW_13_2_135 VPWR ) ( TAP_TAPCELL_ROW_13_2_134 VPWR ) ( TAP_TAPCELL_ROW_12_2_133 VPWR ) ( TAP_TAPCELL_ROW_12_2_132 VPWR ) ( TAP_TAPCELL_ROW_12_2_131 VPWR )
+      ( TAP_TAPCELL_ROW_12_2_130 VPWR ) ( TAP_TAPCELL_ROW_11_2_129 VPWR ) ( TAP_TAPCELL_ROW_11_2_128 VPWR ) ( TAP_TAPCELL_ROW_11_2_127 VPWR ) ( TAP_TAPCELL_ROW_10_2_126 VPWR ) ( TAP_TAPCELL_ROW_10_2_125 VPWR ) ( TAP_TAPCELL_ROW_10_2_124 VPWR ) ( TAP_TAPCELL_ROW_10_2_123 VPWR )
+      ( TAP_TAPCELL_ROW_9_2_122 VPWR ) ( TAP_TAPCELL_ROW_9_2_121 VPWR ) ( TAP_TAPCELL_ROW_9_2_120 VPWR ) ( TAP_TAPCELL_ROW_8_2_119 VPWR ) ( TAP_TAPCELL_ROW_8_2_118 VPWR ) ( TAP_TAPCELL_ROW_8_2_117 VPWR ) ( TAP_TAPCELL_ROW_8_2_116 VPWR ) ( TAP_TAPCELL_ROW_7_2_115 VPWR )
+      ( TAP_TAPCELL_ROW_7_2_114 VPWR ) ( TAP_TAPCELL_ROW_7_2_113 VPWR ) ( TAP_TAPCELL_ROW_6_2_112 VPWR ) ( TAP_TAPCELL_ROW_6_2_111 VPWR ) ( TAP_TAPCELL_ROW_6_2_110 VPWR ) ( TAP_TAPCELL_ROW_6_2_109 VPWR ) ( TAP_TAPCELL_ROW_5_2_108 VPWR ) ( TAP_TAPCELL_ROW_5_2_107 VPWR )
+      ( TAP_TAPCELL_ROW_5_2_106 VPWR ) ( TAP_TAPCELL_ROW_4_2_105 VPWR ) ( TAP_TAPCELL_ROW_4_2_104 VPWR ) ( TAP_TAPCELL_ROW_4_2_103 VPWR ) ( TAP_TAPCELL_ROW_4_2_102 VPWR ) ( TAP_TAPCELL_ROW_3_2_101 VPWR ) ( TAP_TAPCELL_ROW_3_2_100 VPWR ) ( TAP_TAPCELL_ROW_3_2_99 VPWR )
+      ( TAP_TAPCELL_ROW_2_2_98 VPWR ) ( TAP_TAPCELL_ROW_2_2_97 VPWR ) ( TAP_TAPCELL_ROW_2_2_96 VPWR ) ( TAP_TAPCELL_ROW_2_2_95 VPWR ) ( TAP_TAPCELL_ROW_1_2_94 VPWR ) ( TAP_TAPCELL_ROW_1_2_93 VPWR ) ( TAP_TAPCELL_ROW_1_2_92 VPWR ) ( PHY_EDGE_ROW_64_1_Left_91 VPWR )
+      ( PHY_EDGE_ROW_63_1_Left_90 VPWR ) ( PHY_EDGE_ROW_62_1_Left_89 VPWR ) ( PHY_EDGE_ROW_61_1_Left_88 VPWR ) ( PHY_EDGE_ROW_60_1_Left_87 VPWR ) ( PHY_EDGE_ROW_59_1_Left_86 VPWR ) ( PHY_EDGE_ROW_58_1_Left_85 VPWR ) ( PHY_EDGE_ROW_57_1_Left_84 VPWR ) ( PHY_EDGE_ROW_56_1_Left_83 VPWR )
+      ( PHY_EDGE_ROW_55_1_Left_82 VPWR ) ( PHY_EDGE_ROW_54_1_Left_81 VPWR ) ( PHY_EDGE_ROW_53_1_Left_80 VPWR ) ( PHY_EDGE_ROW_52_1_Left_79 VPWR ) ( PHY_EDGE_ROW_51_1_Left_78 VPWR ) ( PHY_EDGE_ROW_50_1_Left_77 VPWR ) ( PHY_EDGE_ROW_49_1_Left_76 VPWR ) ( PHY_EDGE_ROW_48_1_Left_75 VPWR )
+      ( PHY_EDGE_ROW_47_1_Left_74 VPWR ) ( PHY_EDGE_ROW_45_Left_73 VPWR ) ( PHY_EDGE_ROW_44_Left_72 VPWR ) ( PHY_EDGE_ROW_43_Left_71 VPWR ) ( PHY_EDGE_ROW_42_Left_70 VPWR ) ( PHY_EDGE_ROW_46_1_Left_69 VPWR ) ( PHY_EDGE_ROW_64_1_Right_68 VPWR ) ( PHY_EDGE_ROW_63_1_Right_67 VPWR )
+      ( PHY_EDGE_ROW_62_1_Right_66 VPWR ) ( PHY_EDGE_ROW_61_1_Right_65 VPWR ) ( PHY_EDGE_ROW_60_1_Right_64 VPWR ) ( PHY_EDGE_ROW_59_1_Right_63 VPWR ) ( PHY_EDGE_ROW_58_1_Right_62 VPWR ) ( PHY_EDGE_ROW_57_1_Right_61 VPWR ) ( PHY_EDGE_ROW_56_1_Right_60 VPWR ) ( PHY_EDGE_ROW_55_1_Right_59 VPWR )
+      ( PHY_EDGE_ROW_54_1_Right_58 VPWR ) ( PHY_EDGE_ROW_53_1_Right_57 VPWR ) ( PHY_EDGE_ROW_52_1_Right_56 VPWR ) ( PHY_EDGE_ROW_51_1_Right_55 VPWR ) ( PHY_EDGE_ROW_50_1_Right_54 VPWR ) ( PHY_EDGE_ROW_49_1_Right_53 VPWR ) ( PHY_EDGE_ROW_48_1_Right_52 VPWR ) ( PHY_EDGE_ROW_47_1_Right_51 VPWR )
+      ( PHY_EDGE_ROW_46_1_Right_50 VPWR ) ( PHY_EDGE_ROW_45_Right_49 VPWR ) ( PHY_EDGE_ROW_44_Right_48 VPWR ) ( PHY_EDGE_ROW_43_Right_47 VPWR ) ( PHY_EDGE_ROW_42_Right_46 VPWR ) ( PHY_EDGE_ROW_22_Left_45 VPWR ) ( PHY_EDGE_ROW_21_Left_44 VPWR ) ( PHY_EDGE_ROW_20_Left_43 VPWR )
+      ( PHY_EDGE_ROW_19_Left_42 VPWR ) ( PHY_EDGE_ROW_22_Right_41 VPWR ) ( PHY_EDGE_ROW_21_Right_40 VPWR ) ( PHY_EDGE_ROW_20_Right_39 VPWR ) ( PHY_EDGE_ROW_19_Right_38 VPWR ) ( PHY_EDGE_ROW_0_2_Right_37 VPWR ) ( PHY_EDGE_ROW_18_2_Right_36 VPWR ) ( PHY_EDGE_ROW_17_2_Right_35 VPWR )
+      ( PHY_EDGE_ROW_16_2_Right_34 VPWR ) ( PHY_EDGE_ROW_15_2_Right_33 VPWR ) ( PHY_EDGE_ROW_14_2_Right_32 VPWR ) ( PHY_EDGE_ROW_13_2_Right_31 VPWR ) ( PHY_EDGE_ROW_12_2_Right_30 VPWR ) ( PHY_EDGE_ROW_11_2_Right_29 VPWR ) ( PHY_EDGE_ROW_10_2_Right_28 VPWR ) ( PHY_EDGE_ROW_9_2_Right_27 VPWR )
+      ( PHY_EDGE_ROW_8_2_Right_26 VPWR ) ( PHY_EDGE_ROW_7_2_Right_25 VPWR ) ( PHY_EDGE_ROW_6_2_Right_24 VPWR ) ( PHY_EDGE_ROW_5_2_Right_23 VPWR ) ( PHY_EDGE_ROW_4_2_Right_22 VPWR ) ( PHY_EDGE_ROW_3_2_Right_21 VPWR ) ( PHY_EDGE_ROW_2_2_Right_20 VPWR ) ( PHY_EDGE_ROW_1_2_Right_19 VPWR )
+      ( PHY_EDGE_ROW_0_2_Left_18 VPWR ) ( PHY_EDGE_ROW_18_2_Left_17 VPWR ) ( PHY_EDGE_ROW_17_2_Left_16 VPWR ) ( PHY_EDGE_ROW_16_2_Left_15 VPWR ) ( PHY_EDGE_ROW_15_2_Left_14 VPWR ) ( PHY_EDGE_ROW_14_2_Left_13 VPWR ) ( PHY_EDGE_ROW_13_2_Left_12 VPWR ) ( PHY_EDGE_ROW_12_2_Left_11 VPWR )
+      ( PHY_EDGE_ROW_11_2_Left_10 VPWR ) ( PHY_EDGE_ROW_10_2_Left_9 VPWR ) ( PHY_EDGE_ROW_9_2_Left_8 VPWR ) ( PHY_EDGE_ROW_8_2_Left_7 VPWR ) ( PHY_EDGE_ROW_7_2_Left_6 VPWR ) ( PHY_EDGE_ROW_6_2_Left_5 VPWR ) ( PHY_EDGE_ROW_5_2_Left_4 VPWR ) ( PHY_EDGE_ROW_4_2_Left_3 VPWR )
+      ( PHY_EDGE_ROW_3_2_Left_2 VPWR ) ( PHY_EDGE_ROW_2_2_Left_1 VPWR ) ( PHY_EDGE_ROW_1_2_Left_0 VPWR ) ( dsa\[7\] VPWR ) ( dsa\[6\] VPWR ) ( dsa\[5\] VPWR ) ( dsa\[4\] VPWR ) ( dsa\[3\] VPWR )
+      ( dsa\[2\] VPWR ) ( dsa\[1\] VPWR ) ( dsa\[0\] VPWR ) + USE POWER ;
+END SPECIALNETS
+NETS 20 ;
+    - a[0] ( PIN a[0] ) ( dsa\[7\] a ) + USE SIGNAL ;
+    - a[1] ( PIN a[1] ) ( dsa\[6\] a ) + USE SIGNAL ;
+    - a[2] ( PIN a[2] ) ( dsa\[5\] a ) + USE SIGNAL ;
+    - a[3] ( PIN a[3] ) ( dsa\[4\] a ) + USE SIGNAL ;
+    - a[4] ( PIN a[4] ) ( dsa\[3\] a ) + USE SIGNAL ;
+    - a[5] ( PIN a[5] ) ( dsa\[2\] a ) + USE SIGNAL ;
+    - a[6] ( PIN a[6] ) ( dsa\[1\] a ) + USE SIGNAL ;
+    - a[7] ( PIN a[7] ) ( dsa\[0\] a ) + USE SIGNAL ;
+    - clk ( PIN clk ) ( dsa\[7\] clk ) ( dsa\[6\] clk ) ( dsa\[5\] clk ) ( dsa\[4\] clk ) ( dsa\[3\] clk ) ( dsa\[2\] clk )
+      ( dsa\[1\] clk ) ( dsa\[0\] clk ) + USE SIGNAL ;
+    - rst ( PIN rst ) ( dsa\[7\] rst ) ( dsa\[6\] rst ) ( dsa\[5\] rst ) ( dsa\[4\] rst ) ( dsa\[3\] rst ) ( dsa\[2\] rst )
+      ( dsa\[1\] rst ) ( dsa\[0\] rst ) + USE SIGNAL ;
+    - x ( PIN x ) ( dsa\[7\] x ) ( dsa\[6\] x ) ( dsa\[5\] x ) ( dsa\[4\] x ) ( dsa\[3\] x ) ( dsa\[2\] x )
+      ( dsa\[1\] x ) ( dsa\[0\] x ) + USE SIGNAL ;
+    - y ( PIN y ) ( dsa\[7\] y_out ) + USE SIGNAL ;
+    - y_chain\[1\] ( dsa\[1\] y_in ) ( dsa\[0\] y_out ) + USE SIGNAL ;
+    - y_chain\[2\] ( dsa\[2\] y_in ) ( dsa\[1\] y_out ) + USE SIGNAL ;
+    - y_chain\[3\] ( dsa\[3\] y_in ) ( dsa\[2\] y_out ) + USE SIGNAL ;
+    - y_chain\[4\] ( dsa\[4\] y_in ) ( dsa\[3\] y_out ) + USE SIGNAL ;
+    - y_chain\[5\] ( dsa\[5\] y_in ) ( dsa\[4\] y_out ) + USE SIGNAL ;
+    - y_chain\[6\] ( dsa\[6\] y_in ) ( dsa\[5\] y_out ) + USE SIGNAL ;
+    - y_chain\[7\] ( dsa\[7\] y_in ) ( dsa\[6\] y_out ) + USE SIGNAL ;
+    - zero_ ( TIE_ZERO_zero_ LO ) ( dsa\[0\] y_in ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/pdn/test/sky130_spm_floating_bpin.defok
+++ b/src/pdn/test/sky130_spm_floating_bpin.defok
@@ -1,0 +1,2372 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN spm ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 189675 200395 ) ;
+ROW ROW_1_2 unithd 45540 13600 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_2_2 unithd 45540 16320 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_3_2 unithd 45540 19040 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_4_2 unithd 45540 21760 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_5_2 unithd 45540 24480 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_6_2 unithd 45540 27200 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_7_2 unithd 45540 29920 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_8_2 unithd 45540 32640 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_9_2 unithd 45540 35360 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_10_2 unithd 45540 38080 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_11_2 unithd 45540 40800 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_12_2 unithd 45540 43520 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_13_2 unithd 45540 46240 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_14_2 unithd 45540 48960 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_15_2 unithd 45540 51680 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_16_2 unithd 45540 54400 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_17_2 unithd 45540 57120 FS DO 214 BY 1 STEP 460 0 ;
+ROW ROW_18_2 unithd 45540 59840 N DO 214 BY 1 STEP 460 0 ;
+ROW ROW_19 unithd 5520 62560 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_20 unithd 5520 65280 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_21 unithd 5520 68000 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_22 unithd 5520 70720 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_46_1 unithd 5520 136000 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_42 unithd 5520 125120 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_43 unithd 5520 127840 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_44 unithd 5520 130560 N DO 388 BY 1 STEP 460 0 ;
+ROW ROW_45 unithd 5520 133280 FS DO 388 BY 1 STEP 460 0 ;
+ROW ROW_47_1 unithd 5520 138720 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_48_1 unithd 5520 141440 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_49_1 unithd 5520 144160 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_50_1 unithd 5520 146880 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_51_1 unithd 5520 149600 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_52_1 unithd 5520 152320 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_53_1 unithd 5520 155040 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_54_1 unithd 5520 157760 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_55_1 unithd 5520 160480 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_56_1 unithd 5520 163200 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_57_1 unithd 5520 165920 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_58_1 unithd 5520 168640 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_59_1 unithd 5520 171360 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_60_1 unithd 5520 174080 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_61_1 unithd 5520 176800 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_62_1 unithd 5520 179520 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_63_1 unithd 5520 182240 FS DO 194 BY 1 STEP 460 0 ;
+ROW ROW_64_1 unithd 5520 184960 N DO 194 BY 1 STEP 460 0 ;
+ROW ROW_0_2 unithd 45540 10880 N DO 214 BY 1 STEP 460 0 ;
+TRACKS X 230 DO 412 STEP 460 LAYER li1 ;
+TRACKS Y 170 DO 589 STEP 340 LAYER li1 ;
+TRACKS X 170 DO 558 STEP 340 LAYER met1 ;
+TRACKS Y 170 DO 589 STEP 340 LAYER met1 ;
+TRACKS X 230 DO 412 STEP 460 LAYER met2 ;
+TRACKS Y 230 DO 435 STEP 460 LAYER met2 ;
+TRACKS X 340 DO 279 STEP 680 LAYER met3 ;
+TRACKS Y 340 DO 294 STEP 680 LAYER met3 ;
+TRACKS X 460 DO 206 STEP 920 LAYER met4 ;
+TRACKS Y 460 DO 218 STEP 920 LAYER met4 ;
+TRACKS X 1700 DO 56 STEP 3400 LAYER met5 ;
+TRACKS Y 1700 DO 59 STEP 3400 LAYER met5 ;
+VIAS 5 ;
+    - via2_3_2000_480_1_6_320_320 + VIARULE M1M2_PR + CUTSIZE 150 150  + LAYERS met1 via met2  + CUTSPACING 170 170  + ENCLOSURE 85 165 55 85  + ROWCOL 1 6  ;
+    - via3_4_2000_480_1_5_400_400 + VIARULE M2M3_PR + CUTSIZE 200 200  + LAYERS met2 via2 met3  + CUTSPACING 200 200  + ENCLOSURE 40 85 65 65  + ROWCOL 1 5  ;
+    - via4_5_2000_480_1_5_400_400 + VIARULE M3M4_PR + CUTSIZE 200 200  + LAYERS met3 via3 met4  + CUTSPACING 200 200  + ENCLOSURE 90 60 100 65  + ROWCOL 1 5  ;
+    - via5_6_2000_2000_1_1_1600_1600 + VIARULE M4M5_PR + CUTSIZE 800 800  + LAYERS met4 via4 met5  + CUTSPACING 800 800  + ENCLOSURE 600 190 310 600  ;
+    - via5_6_2000_1440_1_1_1600_1600 + VIARULE M4M5_PR + CUTSIZE 800 800  + LAYERS met4 via4 met5  + CUTSPACING 800 800  + ENCLOSURE 600 320 310 320  ;
+END VIAS
+COMPONENTS 309 ;
+    - PHY_EDGE_ROW_0_2_Left_18 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 10880 ) N ;
+    - PHY_EDGE_ROW_0_2_Right_37 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 10880 ) FN ;
+    - PHY_EDGE_ROW_10_2_Left_9 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 38080 ) N ;
+    - PHY_EDGE_ROW_10_2_Right_28 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 38080 ) FN ;
+    - PHY_EDGE_ROW_11_2_Left_10 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 40800 ) FS ;
+    - PHY_EDGE_ROW_11_2_Right_29 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 40800 ) S ;
+    - PHY_EDGE_ROW_12_2_Left_11 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 43520 ) N ;
+    - PHY_EDGE_ROW_12_2_Right_30 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 43520 ) FN ;
+    - PHY_EDGE_ROW_13_2_Left_12 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 46240 ) FS ;
+    - PHY_EDGE_ROW_13_2_Right_31 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 46240 ) S ;
+    - PHY_EDGE_ROW_14_2_Left_13 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 48960 ) N ;
+    - PHY_EDGE_ROW_14_2_Right_32 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 48960 ) FN ;
+    - PHY_EDGE_ROW_15_2_Left_14 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 51680 ) FS ;
+    - PHY_EDGE_ROW_15_2_Right_33 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 51680 ) S ;
+    - PHY_EDGE_ROW_16_2_Left_15 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 54400 ) N ;
+    - PHY_EDGE_ROW_16_2_Right_34 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 54400 ) FN ;
+    - PHY_EDGE_ROW_17_2_Left_16 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 57120 ) FS ;
+    - PHY_EDGE_ROW_17_2_Right_35 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 57120 ) S ;
+    - PHY_EDGE_ROW_18_2_Left_17 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 59840 ) N ;
+    - PHY_EDGE_ROW_18_2_Right_36 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 59840 ) FN ;
+    - PHY_EDGE_ROW_19_Left_42 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 62560 ) FS ;
+    - PHY_EDGE_ROW_19_Right_38 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 62560 ) S ;
+    - PHY_EDGE_ROW_1_2_Left_0 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 13600 ) FS ;
+    - PHY_EDGE_ROW_1_2_Right_19 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 13600 ) S ;
+    - PHY_EDGE_ROW_20_Left_43 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 65280 ) N ;
+    - PHY_EDGE_ROW_20_Right_39 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 65280 ) FN ;
+    - PHY_EDGE_ROW_21_Left_44 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 68000 ) FS ;
+    - PHY_EDGE_ROW_21_Right_40 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 68000 ) S ;
+    - PHY_EDGE_ROW_22_Left_45 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 70720 ) N ;
+    - PHY_EDGE_ROW_22_Right_41 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 70720 ) FN ;
+    - PHY_EDGE_ROW_2_2_Left_1 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 16320 ) N ;
+    - PHY_EDGE_ROW_2_2_Right_20 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 16320 ) FN ;
+    - PHY_EDGE_ROW_3_2_Left_2 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 19040 ) FS ;
+    - PHY_EDGE_ROW_3_2_Right_21 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 19040 ) S ;
+    - PHY_EDGE_ROW_42_Left_70 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 125120 ) N ;
+    - PHY_EDGE_ROW_42_Right_46 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 125120 ) FN ;
+    - PHY_EDGE_ROW_43_Left_71 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 127840 ) FS ;
+    - PHY_EDGE_ROW_43_Right_47 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 127840 ) S ;
+    - PHY_EDGE_ROW_44_Left_72 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 130560 ) N ;
+    - PHY_EDGE_ROW_44_Right_48 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 130560 ) FN ;
+    - PHY_EDGE_ROW_45_Left_73 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 133280 ) FS ;
+    - PHY_EDGE_ROW_45_Right_49 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 182620 133280 ) S ;
+    - PHY_EDGE_ROW_46_1_Left_69 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 136000 ) N ;
+    - PHY_EDGE_ROW_46_1_Right_50 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 136000 ) FN ;
+    - PHY_EDGE_ROW_47_1_Left_74 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 138720 ) FS ;
+    - PHY_EDGE_ROW_47_1_Right_51 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 138720 ) S ;
+    - PHY_EDGE_ROW_48_1_Left_75 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 141440 ) N ;
+    - PHY_EDGE_ROW_48_1_Right_52 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 141440 ) FN ;
+    - PHY_EDGE_ROW_49_1_Left_76 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 144160 ) FS ;
+    - PHY_EDGE_ROW_49_1_Right_53 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 144160 ) S ;
+    - PHY_EDGE_ROW_4_2_Left_3 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 21760 ) N ;
+    - PHY_EDGE_ROW_4_2_Right_22 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 21760 ) FN ;
+    - PHY_EDGE_ROW_50_1_Left_77 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 146880 ) N ;
+    - PHY_EDGE_ROW_50_1_Right_54 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 146880 ) FN ;
+    - PHY_EDGE_ROW_51_1_Left_78 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 149600 ) FS ;
+    - PHY_EDGE_ROW_51_1_Right_55 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 149600 ) S ;
+    - PHY_EDGE_ROW_52_1_Left_79 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 152320 ) N ;
+    - PHY_EDGE_ROW_52_1_Right_56 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 152320 ) FN ;
+    - PHY_EDGE_ROW_53_1_Left_80 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 155040 ) FS ;
+    - PHY_EDGE_ROW_53_1_Right_57 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 155040 ) S ;
+    - PHY_EDGE_ROW_54_1_Left_81 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 157760 ) N ;
+    - PHY_EDGE_ROW_54_1_Right_58 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 157760 ) FN ;
+    - PHY_EDGE_ROW_55_1_Left_82 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 160480 ) FS ;
+    - PHY_EDGE_ROW_55_1_Right_59 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 160480 ) S ;
+    - PHY_EDGE_ROW_56_1_Left_83 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 163200 ) N ;
+    - PHY_EDGE_ROW_56_1_Right_60 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 163200 ) FN ;
+    - PHY_EDGE_ROW_57_1_Left_84 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 165920 ) FS ;
+    - PHY_EDGE_ROW_57_1_Right_61 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 165920 ) S ;
+    - PHY_EDGE_ROW_58_1_Left_85 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 168640 ) N ;
+    - PHY_EDGE_ROW_58_1_Right_62 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 168640 ) FN ;
+    - PHY_EDGE_ROW_59_1_Left_86 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 171360 ) FS ;
+    - PHY_EDGE_ROW_59_1_Right_63 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 171360 ) S ;
+    - PHY_EDGE_ROW_5_2_Left_4 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 24480 ) FS ;
+    - PHY_EDGE_ROW_5_2_Right_23 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 24480 ) S ;
+    - PHY_EDGE_ROW_60_1_Left_87 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 174080 ) N ;
+    - PHY_EDGE_ROW_60_1_Right_64 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 174080 ) FN ;
+    - PHY_EDGE_ROW_61_1_Left_88 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 176800 ) FS ;
+    - PHY_EDGE_ROW_61_1_Right_65 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 176800 ) S ;
+    - PHY_EDGE_ROW_62_1_Left_89 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 179520 ) N ;
+    - PHY_EDGE_ROW_62_1_Right_66 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 179520 ) FN ;
+    - PHY_EDGE_ROW_63_1_Left_90 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 182240 ) FS ;
+    - PHY_EDGE_ROW_63_1_Right_67 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 182240 ) S ;
+    - PHY_EDGE_ROW_64_1_Left_91 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 5520 184960 ) N ;
+    - PHY_EDGE_ROW_64_1_Right_68 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 93380 184960 ) FN ;
+    - PHY_EDGE_ROW_6_2_Left_5 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 27200 ) N ;
+    - PHY_EDGE_ROW_6_2_Right_24 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 27200 ) FN ;
+    - PHY_EDGE_ROW_7_2_Left_6 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 29920 ) FS ;
+    - PHY_EDGE_ROW_7_2_Right_25 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 29920 ) S ;
+    - PHY_EDGE_ROW_8_2_Left_7 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 32640 ) N ;
+    - PHY_EDGE_ROW_8_2_Right_26 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 32640 ) FN ;
+    - PHY_EDGE_ROW_9_2_Left_8 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 45540 35360 ) FS ;
+    - PHY_EDGE_ROW_9_2_Right_27 sky130_fd_sc_hd__decap_3 + SOURCE DIST + FIXED ( 142600 35360 ) S ;
+    - TAP_TAPCELL_ROW_0_2_293 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_294 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_295 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_296 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_297 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_298 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 10880 ) N ;
+    - TAP_TAPCELL_ROW_0_2_299 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 10880 ) N ;
+    - TAP_TAPCELL_ROW_10_2_123 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_124 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_125 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 38080 ) N ;
+    - TAP_TAPCELL_ROW_10_2_126 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 38080 ) N ;
+    - TAP_TAPCELL_ROW_11_2_127 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 40800 ) FS ;
+    - TAP_TAPCELL_ROW_11_2_128 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 40800 ) FS ;
+    - TAP_TAPCELL_ROW_11_2_129 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 40800 ) FS ;
+    - TAP_TAPCELL_ROW_12_2_130 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_131 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_132 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 43520 ) N ;
+    - TAP_TAPCELL_ROW_12_2_133 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 43520 ) N ;
+    - TAP_TAPCELL_ROW_13_2_134 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 46240 ) FS ;
+    - TAP_TAPCELL_ROW_13_2_135 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 46240 ) FS ;
+    - TAP_TAPCELL_ROW_13_2_136 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 46240 ) FS ;
+    - TAP_TAPCELL_ROW_14_2_137 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_138 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_139 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 48960 ) N ;
+    - TAP_TAPCELL_ROW_14_2_140 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 48960 ) N ;
+    - TAP_TAPCELL_ROW_15_2_141 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 51680 ) FS ;
+    - TAP_TAPCELL_ROW_15_2_142 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 51680 ) FS ;
+    - TAP_TAPCELL_ROW_15_2_143 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 51680 ) FS ;
+    - TAP_TAPCELL_ROW_16_2_144 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_145 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_146 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 54400 ) N ;
+    - TAP_TAPCELL_ROW_16_2_147 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 54400 ) N ;
+    - TAP_TAPCELL_ROW_17_2_148 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 57120 ) FS ;
+    - TAP_TAPCELL_ROW_17_2_149 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 57120 ) FS ;
+    - TAP_TAPCELL_ROW_17_2_150 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 57120 ) FS ;
+    - TAP_TAPCELL_ROW_18_2_151 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_152 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_153 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 59840 ) N ;
+    - TAP_TAPCELL_ROW_18_2_154 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 59840 ) N ;
+    - TAP_TAPCELL_ROW_19_155 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_156 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_157 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_158 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_159 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_160 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_161 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_162 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_163 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_164 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_165 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_166 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 62560 ) FS ;
+    - TAP_TAPCELL_ROW_19_167 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 62560 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_92 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 13600 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_93 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 13600 ) FS ;
+    - TAP_TAPCELL_ROW_1_2_94 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 13600 ) FS ;
+    - TAP_TAPCELL_ROW_20_168 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_169 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_170 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_171 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_172 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_173 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 65280 ) N ;
+    - TAP_TAPCELL_ROW_20_174 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 65280 ) N ;
+    - TAP_TAPCELL_ROW_21_175 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_176 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_177 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_178 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_179 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 68000 ) FS ;
+    - TAP_TAPCELL_ROW_21_180 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 68000 ) FS ;
+    - TAP_TAPCELL_ROW_22_181 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_182 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_183 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_184 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_185 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_186 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_187 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_188 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_189 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_190 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_191 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_192 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 70720 ) N ;
+    - TAP_TAPCELL_ROW_22_193 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 70720 ) N ;
+    - TAP_TAPCELL_ROW_2_2_95 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_96 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_97 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 16320 ) N ;
+    - TAP_TAPCELL_ROW_2_2_98 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 16320 ) N ;
+    - TAP_TAPCELL_ROW_3_2_100 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 19040 ) FS ;
+    - TAP_TAPCELL_ROW_3_2_101 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 19040 ) FS ;
+    - TAP_TAPCELL_ROW_3_2_99 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 19040 ) FS ;
+    - TAP_TAPCELL_ROW_42_197 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_198 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_199 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_200 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_201 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_202 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_203 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_204 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_205 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_206 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_207 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_208 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 125120 ) N ;
+    - TAP_TAPCELL_ROW_42_209 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 125120 ) N ;
+    - TAP_TAPCELL_ROW_43_210 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_211 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_212 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_213 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_214 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 127840 ) FS ;
+    - TAP_TAPCELL_ROW_43_215 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 127840 ) FS ;
+    - TAP_TAPCELL_ROW_44_216 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_217 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_218 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_219 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_220 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_221 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 130560 ) N ;
+    - TAP_TAPCELL_ROW_44_222 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 130560 ) N ;
+    - TAP_TAPCELL_ROW_45_223 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_224 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_225 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_226 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_227 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_228 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_229 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 95680 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_230 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 108560 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_231 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 121440 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_232 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 134320 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_233 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 147200 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_234 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 160080 133280 ) FS ;
+    - TAP_TAPCELL_ROW_45_235 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 172960 133280 ) FS ;
+    - TAP_TAPCELL_ROW_46_1_194 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 136000 ) N ;
+    - TAP_TAPCELL_ROW_46_1_195 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 136000 ) N ;
+    - TAP_TAPCELL_ROW_46_1_196 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 136000 ) N ;
+    - TAP_TAPCELL_ROW_47_1_236 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 138720 ) FS ;
+    - TAP_TAPCELL_ROW_47_1_237 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 138720 ) FS ;
+    - TAP_TAPCELL_ROW_47_1_238 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 138720 ) FS ;
+    - TAP_TAPCELL_ROW_48_1_239 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 141440 ) N ;
+    - TAP_TAPCELL_ROW_48_1_240 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 141440 ) N ;
+    - TAP_TAPCELL_ROW_48_1_241 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 141440 ) N ;
+    - TAP_TAPCELL_ROW_49_1_242 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 144160 ) FS ;
+    - TAP_TAPCELL_ROW_49_1_243 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 144160 ) FS ;
+    - TAP_TAPCELL_ROW_49_1_244 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 144160 ) FS ;
+    - TAP_TAPCELL_ROW_4_2_102 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_103 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_104 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 21760 ) N ;
+    - TAP_TAPCELL_ROW_4_2_105 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 21760 ) N ;
+    - TAP_TAPCELL_ROW_50_1_245 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 146880 ) N ;
+    - TAP_TAPCELL_ROW_50_1_246 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 146880 ) N ;
+    - TAP_TAPCELL_ROW_50_1_247 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 146880 ) N ;
+    - TAP_TAPCELL_ROW_51_1_248 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 149600 ) FS ;
+    - TAP_TAPCELL_ROW_51_1_249 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 149600 ) FS ;
+    - TAP_TAPCELL_ROW_51_1_250 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 149600 ) FS ;
+    - TAP_TAPCELL_ROW_52_1_251 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 152320 ) N ;
+    - TAP_TAPCELL_ROW_52_1_252 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 152320 ) N ;
+    - TAP_TAPCELL_ROW_52_1_253 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 152320 ) N ;
+    - TAP_TAPCELL_ROW_53_1_254 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 155040 ) FS ;
+    - TAP_TAPCELL_ROW_53_1_255 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 155040 ) FS ;
+    - TAP_TAPCELL_ROW_53_1_256 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 155040 ) FS ;
+    - TAP_TAPCELL_ROW_54_1_257 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 157760 ) N ;
+    - TAP_TAPCELL_ROW_54_1_258 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 157760 ) N ;
+    - TAP_TAPCELL_ROW_54_1_259 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 157760 ) N ;
+    - TAP_TAPCELL_ROW_55_1_260 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 160480 ) FS ;
+    - TAP_TAPCELL_ROW_55_1_261 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 160480 ) FS ;
+    - TAP_TAPCELL_ROW_55_1_262 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 160480 ) FS ;
+    - TAP_TAPCELL_ROW_56_1_263 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 163200 ) N ;
+    - TAP_TAPCELL_ROW_56_1_264 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 163200 ) N ;
+    - TAP_TAPCELL_ROW_56_1_265 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 163200 ) N ;
+    - TAP_TAPCELL_ROW_57_1_266 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 165920 ) FS ;
+    - TAP_TAPCELL_ROW_57_1_267 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 165920 ) FS ;
+    - TAP_TAPCELL_ROW_57_1_268 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 165920 ) FS ;
+    - TAP_TAPCELL_ROW_58_1_269 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 168640 ) N ;
+    - TAP_TAPCELL_ROW_58_1_270 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 168640 ) N ;
+    - TAP_TAPCELL_ROW_58_1_271 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 168640 ) N ;
+    - TAP_TAPCELL_ROW_59_1_272 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 171360 ) FS ;
+    - TAP_TAPCELL_ROW_59_1_273 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 171360 ) FS ;
+    - TAP_TAPCELL_ROW_59_1_274 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 171360 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_106 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 24480 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_107 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 24480 ) FS ;
+    - TAP_TAPCELL_ROW_5_2_108 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 24480 ) FS ;
+    - TAP_TAPCELL_ROW_60_1_275 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 174080 ) N ;
+    - TAP_TAPCELL_ROW_60_1_276 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 174080 ) N ;
+    - TAP_TAPCELL_ROW_60_1_277 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 174080 ) N ;
+    - TAP_TAPCELL_ROW_61_1_278 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 176800 ) FS ;
+    - TAP_TAPCELL_ROW_61_1_279 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 176800 ) FS ;
+    - TAP_TAPCELL_ROW_61_1_280 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 176800 ) FS ;
+    - TAP_TAPCELL_ROW_62_1_281 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 179520 ) N ;
+    - TAP_TAPCELL_ROW_62_1_282 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 179520 ) N ;
+    - TAP_TAPCELL_ROW_62_1_283 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 179520 ) N ;
+    - TAP_TAPCELL_ROW_63_1_284 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 182240 ) FS ;
+    - TAP_TAPCELL_ROW_63_1_285 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 182240 ) FS ;
+    - TAP_TAPCELL_ROW_63_1_286 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 182240 ) FS ;
+    - TAP_TAPCELL_ROW_64_1_287 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 18400 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_288 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 31280 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_289 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 44160 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_290 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 57040 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_291 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 69920 184960 ) N ;
+    - TAP_TAPCELL_ROW_64_1_292 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 82800 184960 ) N ;
+    - TAP_TAPCELL_ROW_6_2_109 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_110 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_111 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 27200 ) N ;
+    - TAP_TAPCELL_ROW_6_2_112 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 27200 ) N ;
+    - TAP_TAPCELL_ROW_7_2_113 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 29920 ) FS ;
+    - TAP_TAPCELL_ROW_7_2_114 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 29920 ) FS ;
+    - TAP_TAPCELL_ROW_7_2_115 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 29920 ) FS ;
+    - TAP_TAPCELL_ROW_8_2_116 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 58420 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_117 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 84180 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_118 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 109940 32640 ) N ;
+    - TAP_TAPCELL_ROW_8_2_119 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 135700 32640 ) N ;
+    - TAP_TAPCELL_ROW_9_2_120 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 71300 35360 ) FS ;
+    - TAP_TAPCELL_ROW_9_2_121 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 97060 35360 ) FS ;
+    - TAP_TAPCELL_ROW_9_2_122 sky130_fd_sc_hd__tapvpwrvgnd_1 + SOURCE DIST + FIXED ( 122820 35360 ) FS ;
+    - TIE_ZERO_zero_ sky130_fd_sc_hd__conb_1 ;
+    - dsa\[0\] delayed_serial_adder + FIXED ( 10520 15640 ) N ;
+    - dsa\[1\] delayed_serial_adder + FIXED ( 10520 78880 ) N ;
+    - dsa\[2\] delayed_serial_adder + FIXED ( 60115 78880 ) N ;
+    - dsa\[3\] delayed_serial_adder + FIXED ( 99760 78880 ) N ;
+    - dsa\[4\] delayed_serial_adder + FIXED ( 99760 142120 ) N ;
+    - dsa\[5\] delayed_serial_adder + FIXED ( 149355 142120 ) N ;
+    - dsa\[6\] delayed_serial_adder + FIXED ( 149355 16075 ) FS ;
+    - dsa\[7\] delayed_serial_adder + FIXED ( 149355 78880 ) N ;
+END COMPONENTS
+PINS 14 ;
+    - VGND + NET VGND + SPECIAL + DIRECTION INOUT + USE GROUND
+      + PORT
+        + LAYER met5 ( -89480 -1000 ) ( 89480 1000 )
+        + LAYER met5 ( -89480 -16000 ) ( 89480 -14000 )
+        + LAYER met5 ( -89480 -31000 ) ( 89480 -29000 )
+        + LAYER met5 ( -89480 -46000 ) ( 89480 -44000 )
+        + LAYER met5 ( -89480 -61000 ) ( 89480 -59000 )
+        + LAYER met5 ( -89480 -76000 ) ( 89480 -74000 )
+        + LAYER met5 ( -89480 -91000 ) ( 89480 -89000 )
+        + LAYER met5 ( -89480 -106000 ) ( 89480 -104000 )
+        + LAYER met5 ( -89480 -121000 ) ( 89480 -119000 )
+        + LAYER met5 ( -89480 -136000 ) ( 89480 -134000 )
+        + LAYER met5 ( -89480 -151000 ) ( 89480 -149000 )
+        + LAYER met5 ( -89480 -166000 ) ( 89480 -164000 )
+        + LAYER met4 ( 83460 -173940 ) ( 85460 3340 )
+        + LAYER met4 ( 68460 -4420 ) ( 70460 3340 )
+        + LAYER met4 ( 68460 -67660 ) ( 70460 -42420 )
+        + LAYER met4 ( 68460 -128180 ) ( 70460 -105660 )
+        + LAYER met4 ( 53460 -173940 ) ( 55460 3340 )
+        + LAYER met4 ( 38460 -173940 ) ( 40460 3340 )
+        + LAYER met4 ( 23460 -173940 ) ( 25460 3340 )
+        + LAYER met4 ( 8460 -173940 ) ( 10460 3340 )
+        + LAYER met4 ( -6540 -173940 ) ( -4540 3340 )
+        + LAYER met4 ( -21540 -67660 ) ( -19540 3340 )
+        + LAYER met4 ( -21540 -173940 ) ( -19540 -105660 )
+        + LAYER met4 ( -36540 -173940 ) ( -34540 3340 )
+        + LAYER met4 ( -51540 -173940 ) ( -49540 3340 )
+        + LAYER met4 ( -66540 -173940 ) ( -64540 3340 )
+        + LAYER met4 ( -81540 -173940 ) ( -79540 3340 )
+        + FIXED ( 94760 184580 ) N ;
+    - VPWR + NET VPWR + SPECIAL + DIRECTION INOUT + USE POWER
+      + PORT
+        + LAYER met5 ( -89480 -1000 ) ( 89480 1000 )
+        + LAYER met5 ( -89480 -16000 ) ( 89480 -14000 )
+        + LAYER met5 ( -89480 -31000 ) ( 89480 -29000 )
+        + LAYER met5 ( -89480 -46000 ) ( 89480 -44000 )
+        + LAYER met5 ( -89480 -61000 ) ( 89480 -59000 )
+        + LAYER met5 ( -89480 -76000 ) ( 89480 -74000 )
+        + LAYER met5 ( -89480 -91000 ) ( 89480 -89000 )
+        + LAYER met5 ( -89480 -106000 ) ( 89480 -104000 )
+        + LAYER met5 ( -89480 -121000 ) ( 89480 -119000 )
+        + LAYER met5 ( -89480 -136000 ) ( 89480 -134000 )
+        + LAYER met5 ( -89480 -151000 ) ( 89480 -149000 )
+        + LAYER met5 ( -89480 -166000 ) ( 89480 -164000 )
+        + LAYER met4 ( 79760 -170240 ) ( 81760 7040 )
+        + LAYER met4 ( 64760 -1000 ) ( 66760 7040 )
+        + LAYER met4 ( 64760 -63960 ) ( 66760 -38720 )
+        + LAYER met4 ( 64760 -124480 ) ( 66760 -101960 )
+        + LAYER met4 ( 64760 -170240 ) ( 66760 -162480 )
+        + LAYER met4 ( 49760 -170240 ) ( 51760 7040 )
+        + LAYER met4 ( 34760 -170240 ) ( 36760 7040 )
+        + LAYER met4 ( 19760 -1000 ) ( 21760 7040 )
+        + LAYER met4 ( 19760 -63960 ) ( 21760 -38720 )
+        + LAYER met4 ( 19760 -170240 ) ( 21760 -101960 )
+        + LAYER met4 ( 4760 -170240 ) ( 6760 7040 )
+        + LAYER met4 ( -10240 -170240 ) ( -8240 7040 )
+        + LAYER met4 ( -25240 -63960 ) ( -23240 7040 )
+        + LAYER met4 ( -25240 -170240 ) ( -23240 -101960 )
+        + LAYER met4 ( -40240 -170240 ) ( -38240 7040 )
+        + LAYER met4 ( -55240 -170240 ) ( -53240 7040 )
+        + LAYER met4 ( -70240 -63960 ) ( -68240 7040 )
+        + LAYER met4 ( -70240 -127200 ) ( -68240 -101960 )
+        + LAYER met4 ( -85240 -170240 ) ( -83240 7040 )
+        + FIXED ( 94760 180880 ) N ;
+    - a[0] + NET a[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 78540 ) N ;
+    - a[1] + NET a[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 92140 ) N ;
+    - a[2] + NET a[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 109140 ) N ;
+    - a[3] + NET a[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 85340 ) N ;
+    - a[4] + NET a[4] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 95540 ) N ;
+    - a[5] + NET a[5] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 81940 ) N ;
+    - a[6] + NET a[6] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 88740 ) N ;
+    - a[7] + NET a[7] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -140 -2000 ) ( 140 2000 )
+        + PLACED ( 96830 2000 ) N ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 2000 95540 ) N ;
+    - rst + NET rst + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 98940 ) N ;
+    - x + NET x + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 105740 ) N ;
+    - y + NET y + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met3 ( -2000 -300 ) ( 2000 300 )
+        + PLACED ( 187675 102340 ) N ;
+END PINS
+SPECIALNETS 2 ;
+    - VGND ( PIN VGND ) ( * VGND ) + USE GROUND
+      + ROUTED met4 0 + SHAPE STRIPE ( 179220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 163575 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 163575 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 163575 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 113980 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 113980 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74335 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 24740 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 24740 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 59840 ) ( 143980 59840 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 54400 ) ( 143980 54400 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 48960 ) ( 143980 48960 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 43520 ) ( 143980 43520 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 38080 ) ( 143980 38080 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 32640 ) ( 143980 32640 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 27200 ) ( 143980 27200 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 21760 ) ( 143980 21760 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 16320 ) ( 143980 16320 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 10880 ) ( 143980 10880 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 184960 ) ( 94760 184960 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 179520 ) ( 94760 179520 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 174080 ) ( 94760 174080 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 168640 ) ( 94760 168640 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 163200 ) ( 94760 163200 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 157760 ) ( 94760 157760 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 152320 ) ( 94760 152320 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 146880 ) ( 94760 146880 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 141440 ) ( 94760 141440 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 136000 ) ( 184000 136000 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 130560 ) ( 184000 130560 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 125120 ) ( 184000 125120 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 70720 ) ( 184000 70720 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 65280 ) ( 184000 65280 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 184580 ) ( 184240 184580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 169580 ) ( 184240 169580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 154580 ) ( 184240 154580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 139580 ) ( 184240 139580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 124580 ) ( 184240 124580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 109580 ) ( 184240 109580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 94580 ) ( 184240 94580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 79580 ) ( 184240 79580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 64580 ) ( 184240 64580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 49580 ) ( 184240 49580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 34580 ) ( 184240 34580 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 19580 ) ( 184240 19580 )
+      NEW met4 2000 + SHAPE STRIPE ( 179220 10640 ) ( 179220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 164220 180160 ) ( 164220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 164220 116920 ) ( 164220 142160 )
+      NEW met4 2000 + SHAPE STRIPE ( 164220 56400 ) ( 164220 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 149220 10640 ) ( 149220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 134220 10640 ) ( 134220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 119220 10640 ) ( 119220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 104220 10640 ) ( 104220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 89220 10640 ) ( 89220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 74220 116920 ) ( 74220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 74220 10640 ) ( 74220 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 59220 10640 ) ( 59220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 44220 10640 ) ( 44220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 29220 10640 ) ( 29220 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 14220 10640 ) ( 14220 187920 )
+      NEW met4 0 + SHAPE STRIPE ( 179220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 179220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 164220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 164220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 164220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 164220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 149220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 134220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 119220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 104220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 89220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 74220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 59220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 44220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 29220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 184580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 169580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 154580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 139580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 124580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 109580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 94580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 79580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 64580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 49580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 34580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 14220 19580 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met3 330 + SHAPE STRIPE ( 178230 136000 ) ( 180210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 179220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 179220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 179220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 178230 130560 ) ( 180210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 179220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 179220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 179220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 178230 125120 ) ( 180210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 179220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 179220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 179220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 178230 70720 ) ( 180210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 179220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 179220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 179220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 178230 65280 ) ( 180210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 179220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 179220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 179220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 163230 136000 ) ( 165210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 164220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 164220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 164220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 163230 130560 ) ( 165210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 164220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 164220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 164220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 163230 125120 ) ( 165210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 164220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 164220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 164220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 163230 70720 ) ( 165210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 164220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 164220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 164220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 163230 65280 ) ( 165210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 164220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 164220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 164220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 148230 136000 ) ( 150210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 149220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 149220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 149220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 148230 130560 ) ( 150210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 149220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 149220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 149220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 148230 125120 ) ( 150210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 149220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 149220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 149220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 148230 70720 ) ( 150210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 149220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 149220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 149220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 148230 65280 ) ( 150210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 149220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 149220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 149220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 136000 ) ( 135210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 130560 ) ( 135210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 125120 ) ( 135210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 70720 ) ( 135210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 65280 ) ( 135210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 59840 ) ( 135210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 54400 ) ( 135210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 48960 ) ( 135210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 43520 ) ( 135210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 38080 ) ( 135210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 32640 ) ( 135210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 27200 ) ( 135210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 21760 ) ( 135210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 16320 ) ( 135210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 133230 10880 ) ( 135210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 134220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 134220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 134220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 136000 ) ( 120210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 130560 ) ( 120210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 125120 ) ( 120210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 70720 ) ( 120210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 65280 ) ( 120210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 59840 ) ( 120210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 54400 ) ( 120210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 48960 ) ( 120210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 43520 ) ( 120210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 38080 ) ( 120210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 32640 ) ( 120210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 27200 ) ( 120210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 21760 ) ( 120210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 16320 ) ( 120210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 118230 10880 ) ( 120210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 119220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 119220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 119220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 136000 ) ( 105210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 130560 ) ( 105210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 125120 ) ( 105210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 70720 ) ( 105210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 65280 ) ( 105210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 59840 ) ( 105210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 54400 ) ( 105210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 48960 ) ( 105210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 43520 ) ( 105210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 38080 ) ( 105210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 32640 ) ( 105210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 27200 ) ( 105210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 21760 ) ( 105210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 16320 ) ( 105210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 103230 10880 ) ( 105210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 104220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 104220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 104220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 184960 ) ( 90210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 179520 ) ( 90210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 174080 ) ( 90210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 168640 ) ( 90210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 157760 ) ( 90210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 152320 ) ( 90210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 146880 ) ( 90210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 141440 ) ( 90210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 136000 ) ( 90210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 130560 ) ( 90210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 125120 ) ( 90210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 70720 ) ( 90210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 65280 ) ( 90210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 59840 ) ( 90210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 54400 ) ( 90210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 48960 ) ( 90210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 43520 ) ( 90210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 38080 ) ( 90210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 32640 ) ( 90210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 27200 ) ( 90210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 21760 ) ( 90210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 16320 ) ( 90210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 88230 10880 ) ( 90210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 89220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 89220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 89220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 184960 ) ( 75210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 179520 ) ( 75210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 174080 ) ( 75210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 168640 ) ( 75210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 163200 ) ( 75210 163200 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 163200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 163200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 163200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 157760 ) ( 75210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 152320 ) ( 75210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 146880 ) ( 75210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 141440 ) ( 75210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 136000 ) ( 75210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 130560 ) ( 75210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 125120 ) ( 75210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 70720 ) ( 75210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 65280 ) ( 75210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 59840 ) ( 75210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 54400 ) ( 75210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 48960 ) ( 75210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 43520 ) ( 75210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 38080 ) ( 75210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 32640 ) ( 75210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 27200 ) ( 75210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 21760 ) ( 75210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 16320 ) ( 75210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 73230 10880 ) ( 75210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 74220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 74220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 74220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 184960 ) ( 60210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 179520 ) ( 60210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 174080 ) ( 60210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 168640 ) ( 60210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 163200 ) ( 60210 163200 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 163200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 163200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 163200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 157760 ) ( 60210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 152320 ) ( 60210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 146880 ) ( 60210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 141440 ) ( 60210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 136000 ) ( 60210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 130560 ) ( 60210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 125120 ) ( 60210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 70720 ) ( 60210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 65280 ) ( 60210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 59840 ) ( 60210 59840 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 59840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 59840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 59840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 54400 ) ( 60210 54400 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 54400 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 54400 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 54400 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 48960 ) ( 60210 48960 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 48960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 48960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 48960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 43520 ) ( 60210 43520 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 43520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 43520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 43520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 38080 ) ( 60210 38080 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 38080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 38080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 38080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 32640 ) ( 60210 32640 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 32640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 32640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 32640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 27200 ) ( 60210 27200 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 27200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 27200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 27200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 21760 ) ( 60210 21760 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 21760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 21760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 21760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 16320 ) ( 60210 16320 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 16320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 16320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 16320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 58230 10880 ) ( 60210 10880 )
+      NEW met3 0 + SHAPE STRIPE ( 59220 10880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 59220 10880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 59220 10880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 184960 ) ( 45210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 179520 ) ( 45210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 174080 ) ( 45210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 168640 ) ( 45210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 163200 ) ( 45210 163200 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 163200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 163200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 163200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 157760 ) ( 45210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 152320 ) ( 45210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 146880 ) ( 45210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 141440 ) ( 45210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 136000 ) ( 45210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 130560 ) ( 45210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 125120 ) ( 45210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 70720 ) ( 45210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 43230 65280 ) ( 45210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 44220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 44220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 44220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 184960 ) ( 30210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 179520 ) ( 30210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 174080 ) ( 30210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 168640 ) ( 30210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 163200 ) ( 30210 163200 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 163200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 163200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 163200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 157760 ) ( 30210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 152320 ) ( 30210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 146880 ) ( 30210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 141440 ) ( 30210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 136000 ) ( 30210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 130560 ) ( 30210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 125120 ) ( 30210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 70720 ) ( 30210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 28230 65280 ) ( 30210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 29220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 29220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 29220 65280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 184960 ) ( 15210 184960 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 184960 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 184960 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 184960 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 179520 ) ( 15210 179520 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 179520 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 179520 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 179520 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 174080 ) ( 15210 174080 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 174080 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 174080 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 174080 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 168640 ) ( 15210 168640 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 168640 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 168640 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 168640 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 163200 ) ( 15210 163200 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 163200 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 163200 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 163200 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 157760 ) ( 15210 157760 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 157760 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 157760 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 157760 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 152320 ) ( 15210 152320 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 152320 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 152320 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 152320 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 146880 ) ( 15210 146880 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 146880 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 146880 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 146880 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 141440 ) ( 15210 141440 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 141440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 141440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 141440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 136000 ) ( 15210 136000 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 136000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 136000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 136000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 130560 ) ( 15210 130560 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 130560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 130560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 130560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 125120 ) ( 15210 125120 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 125120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 125120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 125120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 70720 ) ( 15210 70720 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 70720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 70720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 70720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 13230 65280 ) ( 15210 65280 )
+      NEW met3 0 + SHAPE STRIPE ( 14220 65280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 14220 65280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 14220 65280 ) via2_3_2000_480_1_6_320_320 ;
+    - VPWR ( PIN VPWR ) ( * VPWR ) + USE POWER
+      + ROUTED met4 0 + SHAPE STRIPE ( 175520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 159875 105600 ) via5_6_2000_1440_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 159875 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 159875 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 159875 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 110280 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 110280 105600 ) via5_6_2000_1440_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 110280 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70635 105600 ) via5_6_2000_1440_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70635 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 21040 105600 ) via5_6_2000_1440_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 21040 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 21040 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 57120 ) ( 143980 57120 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 51680 ) ( 143980 51680 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 46240 ) ( 143980 46240 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 40800 ) ( 143980 40800 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 35360 ) ( 143980 35360 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 29920 ) ( 143980 29920 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 24480 ) ( 143980 24480 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 19040 ) ( 143980 19040 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 45540 13600 ) ( 143980 13600 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 187680 ) ( 94760 187680 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 182240 ) ( 94760 182240 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 176800 ) ( 94760 176800 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 171360 ) ( 94760 171360 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 165920 ) ( 94760 165920 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 160480 ) ( 94760 160480 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 155040 ) ( 94760 155040 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 149600 ) ( 94760 149600 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 144160 ) ( 94760 144160 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 138720 ) ( 94760 138720 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 133280 ) ( 184000 133280 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 127840 ) ( 184000 127840 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 73440 ) ( 184000 73440 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 68000 ) ( 184000 68000 )
+      NEW met1 480 + SHAPE FOLLOWPIN ( 5520 62560 ) ( 184000 62560 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 180880 ) ( 184240 180880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 165880 ) ( 184240 165880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 150880 ) ( 184240 150880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 135880 ) ( 184240 135880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 120880 ) ( 184240 120880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 105880 ) ( 184240 105880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 90880 ) ( 184240 90880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 75880 ) ( 184240 75880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 60880 ) ( 184240 60880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 45880 ) ( 184240 45880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 30880 ) ( 184240 30880 )
+      NEW met5 2000 + SHAPE STRIPE ( 5280 15880 ) ( 184240 15880 )
+      NEW met4 2000 + SHAPE STRIPE ( 175520 10640 ) ( 175520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 160520 179880 ) ( 160520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 160520 116920 ) ( 160520 142160 )
+      NEW met4 2000 + SHAPE STRIPE ( 160520 56400 ) ( 160520 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 160520 10640 ) ( 160520 18400 )
+      NEW met4 2000 + SHAPE STRIPE ( 145520 10640 ) ( 145520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 130520 10640 ) ( 130520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 115520 179880 ) ( 115520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 115520 116920 ) ( 115520 142160 )
+      NEW met4 2000 + SHAPE STRIPE ( 115520 10640 ) ( 115520 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 100520 10640 ) ( 100520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 85520 10640 ) ( 85520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 70520 116920 ) ( 70520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 70520 10640 ) ( 70520 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 55520 10640 ) ( 55520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 40520 10640 ) ( 40520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 25520 116920 ) ( 25520 187920 )
+      NEW met4 2000 + SHAPE STRIPE ( 25520 53680 ) ( 25520 78920 )
+      NEW met4 2000 + SHAPE STRIPE ( 10520 10640 ) ( 10520 187920 )
+      NEW met4 0 + SHAPE STRIPE ( 175520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 175520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 160520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 145520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 130520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 115520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 100520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 85520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 70520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 55520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 40520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 25520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 180880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 165880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 150880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 135880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 120880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 105880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 90880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 75880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 60880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 45880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 30880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met4 0 + SHAPE STRIPE ( 10520 15880 ) via5_6_2000_2000_1_1_1600_1600
+      NEW met3 330 + SHAPE STRIPE ( 174530 133280 ) ( 176510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 175520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 175520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 175520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 174530 127840 ) ( 176510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 175520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 175520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 175520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 174530 73440 ) ( 176510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 175520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 175520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 175520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 174530 68000 ) ( 176510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 175520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 175520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 175520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 174530 62560 ) ( 176510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 175520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 175520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 175520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 159530 133280 ) ( 161510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 160520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 160520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 160520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 159530 127840 ) ( 161510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 160520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 160520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 160520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 159530 73440 ) ( 161510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 160520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 160520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 160520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 159530 68000 ) ( 161510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 160520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 160520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 160520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 159530 62560 ) ( 161510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 160520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 160520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 160520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 144530 133280 ) ( 146510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 145520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 145520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 145520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 144530 127840 ) ( 146510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 145520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 145520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 145520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 144530 73440 ) ( 146510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 145520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 145520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 145520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 144530 68000 ) ( 146510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 145520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 145520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 145520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 144530 62560 ) ( 146510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 145520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 145520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 145520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 133280 ) ( 131510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 127840 ) ( 131510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 73440 ) ( 131510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 68000 ) ( 131510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 62560 ) ( 131510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 57120 ) ( 131510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 51680 ) ( 131510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 46240 ) ( 131510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 40800 ) ( 131510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 35360 ) ( 131510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 29920 ) ( 131510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 24480 ) ( 131510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 19040 ) ( 131510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 129530 13600 ) ( 131510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 130520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 130520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 130520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 133280 ) ( 116510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 127840 ) ( 116510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 73440 ) ( 116510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 68000 ) ( 116510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 62560 ) ( 116510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 57120 ) ( 116510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 51680 ) ( 116510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 46240 ) ( 116510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 40800 ) ( 116510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 35360 ) ( 116510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 29920 ) ( 116510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 24480 ) ( 116510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 19040 ) ( 116510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 114530 13600 ) ( 116510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 115520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 115520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 115520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 133280 ) ( 101510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 127840 ) ( 101510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 73440 ) ( 101510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 68000 ) ( 101510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 62560 ) ( 101510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 57120 ) ( 101510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 51680 ) ( 101510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 46240 ) ( 101510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 40800 ) ( 101510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 35360 ) ( 101510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 29920 ) ( 101510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 24480 ) ( 101510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 19040 ) ( 101510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 99530 13600 ) ( 101510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 100520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 100520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 100520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 187680 ) ( 86510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 182240 ) ( 86510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 176800 ) ( 86510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 171360 ) ( 86510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 165920 ) ( 86510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 160480 ) ( 86510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 155040 ) ( 86510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 149600 ) ( 86510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 144160 ) ( 86510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 138720 ) ( 86510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 133280 ) ( 86510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 127840 ) ( 86510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 73440 ) ( 86510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 68000 ) ( 86510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 62560 ) ( 86510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 57120 ) ( 86510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 51680 ) ( 86510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 46240 ) ( 86510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 40800 ) ( 86510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 35360 ) ( 86510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 29920 ) ( 86510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 24480 ) ( 86510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 19040 ) ( 86510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 84530 13600 ) ( 86510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 85520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 85520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 85520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 187680 ) ( 71510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 182240 ) ( 71510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 176800 ) ( 71510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 171360 ) ( 71510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 165920 ) ( 71510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 160480 ) ( 71510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 155040 ) ( 71510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 149600 ) ( 71510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 144160 ) ( 71510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 138720 ) ( 71510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 133280 ) ( 71510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 127840 ) ( 71510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 73440 ) ( 71510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 68000 ) ( 71510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 62560 ) ( 71510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 57120 ) ( 71510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 51680 ) ( 71510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 46240 ) ( 71510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 40800 ) ( 71510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 35360 ) ( 71510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 29920 ) ( 71510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 24480 ) ( 71510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 19040 ) ( 71510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 69530 13600 ) ( 71510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 70520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 70520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 70520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 187680 ) ( 56510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 182240 ) ( 56510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 176800 ) ( 56510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 171360 ) ( 56510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 165920 ) ( 56510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 160480 ) ( 56510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 155040 ) ( 56510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 149600 ) ( 56510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 144160 ) ( 56510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 138720 ) ( 56510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 133280 ) ( 56510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 127840 ) ( 56510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 73440 ) ( 56510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 68000 ) ( 56510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 62560 ) ( 56510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 57120 ) ( 56510 57120 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 57120 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 57120 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 57120 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 51680 ) ( 56510 51680 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 51680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 51680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 51680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 46240 ) ( 56510 46240 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 46240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 46240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 46240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 40800 ) ( 56510 40800 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 40800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 40800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 40800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 35360 ) ( 56510 35360 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 35360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 35360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 35360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 29920 ) ( 56510 29920 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 29920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 29920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 29920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 24480 ) ( 56510 24480 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 24480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 24480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 24480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 19040 ) ( 56510 19040 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 19040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 19040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 19040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 54530 13600 ) ( 56510 13600 )
+      NEW met3 0 + SHAPE STRIPE ( 55520 13600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 55520 13600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 55520 13600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 187680 ) ( 41510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 182240 ) ( 41510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 176800 ) ( 41510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 171360 ) ( 41510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 165920 ) ( 41510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 160480 ) ( 41510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 155040 ) ( 41510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 149600 ) ( 41510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 144160 ) ( 41510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 138720 ) ( 41510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 133280 ) ( 41510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 127840 ) ( 41510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 73440 ) ( 41510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 68000 ) ( 41510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 39530 62560 ) ( 41510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 40520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 40520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 40520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 187680 ) ( 26510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 182240 ) ( 26510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 176800 ) ( 26510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 171360 ) ( 26510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 165920 ) ( 26510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 160480 ) ( 26510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 155040 ) ( 26510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 149600 ) ( 26510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 144160 ) ( 26510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 138720 ) ( 26510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 133280 ) ( 26510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 127840 ) ( 26510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 73440 ) ( 26510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 68000 ) ( 26510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 24530 62560 ) ( 26510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 25520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 25520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 25520 62560 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 187680 ) ( 11510 187680 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 187680 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 187680 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 187680 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 182240 ) ( 11510 182240 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 182240 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 182240 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 182240 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 176800 ) ( 11510 176800 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 176800 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 176800 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 176800 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 171360 ) ( 11510 171360 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 171360 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 171360 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 171360 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 165920 ) ( 11510 165920 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 165920 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 165920 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 165920 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 160480 ) ( 11510 160480 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 160480 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 160480 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 160480 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 155040 ) ( 11510 155040 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 155040 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 155040 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 155040 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 149600 ) ( 11510 149600 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 149600 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 149600 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 149600 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 144160 ) ( 11510 144160 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 144160 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 144160 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 144160 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 138720 ) ( 11510 138720 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 138720 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 138720 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 138720 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 133280 ) ( 11510 133280 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 133280 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 133280 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 133280 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 127840 ) ( 11510 127840 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 127840 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 127840 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 127840 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 73440 ) ( 11510 73440 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 73440 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 73440 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 73440 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 68000 ) ( 11510 68000 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 68000 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 68000 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 68000 ) via2_3_2000_480_1_6_320_320
+      NEW met3 330 + SHAPE STRIPE ( 9530 62560 ) ( 11510 62560 )
+      NEW met3 0 + SHAPE STRIPE ( 10520 62560 ) via4_5_2000_480_1_5_400_400
+      NEW met2 0 + SHAPE STRIPE ( 10520 62560 ) via3_4_2000_480_1_5_400_400
+      NEW met1 0 + SHAPE STRIPE ( 10520 62560 ) via2_3_2000_480_1_6_320_320 ;
+END SPECIALNETS
+NETS 20 ;
+    - a[0] ( PIN a[0] ) ( dsa\[7\] a ) + USE SIGNAL ;
+    - a[1] ( PIN a[1] ) ( dsa\[6\] a ) + USE SIGNAL ;
+    - a[2] ( PIN a[2] ) ( dsa\[5\] a ) + USE SIGNAL ;
+    - a[3] ( PIN a[3] ) ( dsa\[4\] a ) + USE SIGNAL ;
+    - a[4] ( PIN a[4] ) ( dsa\[3\] a ) + USE SIGNAL ;
+    - a[5] ( PIN a[5] ) ( dsa\[2\] a ) + USE SIGNAL ;
+    - a[6] ( PIN a[6] ) ( dsa\[1\] a ) + USE SIGNAL ;
+    - a[7] ( PIN a[7] ) ( dsa\[0\] a ) + USE SIGNAL ;
+    - clk ( PIN clk ) ( dsa\[7\] clk ) ( dsa\[6\] clk ) ( dsa\[5\] clk ) ( dsa\[4\] clk ) ( dsa\[3\] clk ) ( dsa\[2\] clk )
+      ( dsa\[1\] clk ) ( dsa\[0\] clk ) + USE SIGNAL ;
+    - rst ( PIN rst ) ( dsa\[7\] rst ) ( dsa\[6\] rst ) ( dsa\[5\] rst ) ( dsa\[4\] rst ) ( dsa\[3\] rst ) ( dsa\[2\] rst )
+      ( dsa\[1\] rst ) ( dsa\[0\] rst ) + USE SIGNAL ;
+    - x ( PIN x ) ( dsa\[7\] x ) ( dsa\[6\] x ) ( dsa\[5\] x ) ( dsa\[4\] x ) ( dsa\[3\] x ) ( dsa\[2\] x )
+      ( dsa\[1\] x ) ( dsa\[0\] x ) + USE SIGNAL ;
+    - y ( PIN y ) ( dsa\[7\] y_out ) + USE SIGNAL ;
+    - y_chain\[1\] ( dsa\[1\] y_in ) ( dsa\[0\] y_out ) + USE SIGNAL ;
+    - y_chain\[2\] ( dsa\[2\] y_in ) ( dsa\[1\] y_out ) + USE SIGNAL ;
+    - y_chain\[3\] ( dsa\[3\] y_in ) ( dsa\[2\] y_out ) + USE SIGNAL ;
+    - y_chain\[4\] ( dsa\[4\] y_in ) ( dsa\[3\] y_out ) + USE SIGNAL ;
+    - y_chain\[5\] ( dsa\[5\] y_in ) ( dsa\[4\] y_out ) + USE SIGNAL ;
+    - y_chain\[6\] ( dsa\[6\] y_in ) ( dsa\[5\] y_out ) + USE SIGNAL ;
+    - y_chain\[7\] ( dsa\[7\] y_in ) ( dsa\[6\] y_out ) + USE SIGNAL ;
+    - zero_ ( TIE_ZERO_zero_ LO ) ( dsa\[0\] y_in ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/pdn/test/sky130_spm_floating_bpin.ok
+++ b/src/pdn/test/sky130_spm_floating_bpin.ok
@@ -1,0 +1,30 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file sky130_spm/delayed_serial_adder.lef at line 2.
+
+[INFO ODB-0227] LEF file: sky130_spm/delayed_serial_adder.lef, created 1 library cells
+[INFO ODB-0128] Design: spm
+[INFO ODB-0130]     Created 12 pins.
+[INFO ODB-0131]     Created 309 components and 668 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 804 connections.
+[INFO ODB-0133]     Created 20 nets and 49 connections.
+[INFO PDN-0001] Inserting grid: stdcell_grid
+[INFO PDN-0001] Inserting grid: macro - dsa\[0\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[1\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[2\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[3\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[4\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[5\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[6\]
+[INFO PDN-0001] Inserting grid: macro - dsa\[7\]
+[WARNING PDN-0110] No via inserted between met4 and met5 at (24.5200, 14.8800) - (26.5200, 15.6800) on VPWR
+[WARNING PDN-0110] No via inserted between met4 and met5 at (73.2200, 78.5800) - (75.2200, 78.9200) on VGND
+[WARNING PDN-0110] No via inserted between met4 and met5 at (163.2200, 78.5800) - (165.2200, 78.9200) on VGND
+[WARNING PDN-0110] No via inserted between met4 and met5 at (24.5200, 14.8800) - (26.5200, 15.6800) on VPWR
+[WARNING PDN-0110] No via inserted between met4 and met5 at (73.2200, 78.5800) - (75.2200, 78.9200) on VGND
+[WARNING PDN-0110] No via inserted between met4 and met5 at (112.9800, 168.5800) - (114.9800, 169.5600) on VGND
+[WARNING PDN-0110] No via inserted between met4 and met5 at (162.5750, 168.5800) - (164.5750, 169.5600) on VGND
+[WARNING PDN-0110] No via inserted between met4 and met5 at (158.8750, 44.8800) - (160.8750, 45.8000) on VPWR
+[WARNING PDN-0110] No via inserted between met4 and met5 at (163.2200, 78.5800) - (165.2200, 78.9200) on VGND
+No differences found.

--- a/src/pdn/test/sky130_spm_floating_bpin.tcl
+++ b/src/pdn/test/sky130_spm_floating_bpin.tcl
@@ -1,0 +1,66 @@
+# test the insertion of power switches into a design.
+# The power switch control is connected in a STAR configuration
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_lef sky130_spm/delayed_serial_adder.lef
+
+read_def sky130_spm/floorplan.def
+
+set_voltage_domain -name CORE -power VPWR -ground VGND
+
+define_pdn_grid \
+    -name stdcell_grid \
+    -starts_with POWER \
+    -voltage_domain CORE \
+    -pins "met4 met5"
+
+add_pdn_stripe \
+    -grid stdcell_grid \
+    -layer met4 \
+    -width 2 \
+    -pitch 15 \
+    -offset 5 \
+    -spacing 1.7 \
+    -starts_with POWER -extend_to_core_ring
+
+add_pdn_stripe \
+    -grid stdcell_grid \
+    -layer met5 \
+    -width 2 \
+    -pitch 15 \
+    -offset 5 \
+    -spacing 1.7 \
+    -starts_with POWER -extend_to_core_ring
+
+add_pdn_connect \
+    -grid stdcell_grid \
+    -layers "met4 met5"
+
+add_pdn_stripe \
+    -grid stdcell_grid \
+    -layer met1 \
+    -width 0.48 \
+    -followpins
+
+add_pdn_connect \
+    -grid stdcell_grid \
+    -layers "met1 met4"
+
+define_pdn_grid \
+    -macro \
+    -default \
+    -name macro \
+    -starts_with POWER \
+    -halo "10 10"
+
+add_pdn_connect \
+    -grid macro \
+    -layers "met4 met5"
+
+pdngen
+
+set def_file [make_result_file sky130_spm_floating_bpin.def]
+write_def $def_file
+diff_files sky130_spm_floating_bpin.defok $def_file


### PR DESCRIPTION
Closes #5659

Adds:
- dbBox::destroy for dbBPins boxes (any others should be added in a separate PR).

Fixes:
- floating shapes that left the power grid broken when a via failed to generate
