### PR TITLE
gpl: debug mode, create gif for initial place

### DIFF
--- a/src/gpl/src/initialPlace.cpp
+++ b/src/gpl/src/initialPlace.cpp
@@ -54,6 +54,10 @@ void InitialPlace::doBicgstabPlace(int threads)
   // set ExtId for idx reference // easy recovery
   setPlaceInstExtId();
 
+  if (graphics) {
+    graphics->getGuiObjectFromGraphics()->gifStart("initPlacement.gif");
+  }
+
   for (size_t iter = 1; iter <= ipVars_.maxIter; iter++) {
     updatePinInfo();
     createSparseMatrix();
@@ -78,11 +82,24 @@ void InitialPlace::doBicgstabPlace(int threads)
 
     if (graphics) {
       graphics->cellPlot(true);
+
+      gui::Gui* gui = graphics->getGuiObjectFromGraphics();
+      odb::Rect region;
+      int width_px = 500;
+      odb::Rect bbox = pbc_->db()->getChip()->getBlock()->getBBox()->getBox();
+      int max_dim = std::max(bbox.dx(), bbox.dy());
+      double dbu_per_pixel = static_cast<double>(max_dim) / 1000.0;
+      int delay = 20;
+      gui->gifAddFrame(region, width_px, dbu_per_pixel, delay);
     }
 
     if (error_max <= 1e-5 && iter >= 5) {
       break;
     }
+  }
+
+  if (graphics) {
+    graphics->getGuiObjectFromGraphics()->gifEnd();
   }
 }
 

--- a/src/gpl/src/initialPlace.cpp
+++ b/src/gpl/src/initialPlace.cpp
@@ -85,12 +85,10 @@ void InitialPlace::doBicgstabPlace(int threads)
 
       gui::Gui* gui = graphics->getGuiObjectFromGraphics();
       odb::Rect region;
-      int width_px = 500;
       odb::Rect bbox = pbc_->db()->getChip()->getBlock()->getBBox()->getBox();
       int max_dim = std::max(bbox.dx(), bbox.dy());
       double dbu_per_pixel = static_cast<double>(max_dim) / 1000.0;
-      int delay = 20;
-      gui->gifAddFrame(region, width_px, dbu_per_pixel, delay);
+      gui->gifAddFrame(region, 500, dbu_per_pixel, 20);
     }
 
     if (error_max <= 1e-5 && iter >= 5) {


### PR DESCRIPTION
If the `-initial` parameter is used with the `global_placement_debug` command in GPL debug mode, create a GIF for the `initialPlacement` procedure executed in `InitialPlace::doBicgstabPlace()`.
