### PR TITLE
Check that the design in linked in TCL in insert_tiecells

### DIFF
--- a/src/ifp/src/InitFloorplan.tcl
+++ b/src/ifp/src/InitFloorplan.tcl
@@ -241,6 +241,8 @@ proc insert_tiecells { args } {
     utl::error "IFP" 32 "Unable to find master pin: $args"
   }
 
+  ord::ensure_linked
+
   ifp::insert_tiecells_cmd $mterm $prefix
 }
 


### PR DESCRIPTION
In the current behavior, this will still fail later with a different error. However, for consistency with the other passes in this file that require a linked design, we check `ord::ensure_linked` before proceeding.