### PR TITLE
Avoid undefined behavior initializing 'last'

### DIFF
--- a/src/odb/src/def/def/def_keywords.cpp
+++ b/src/odb/src/def/def/def_keywords.cpp
@@ -143,7 +143,7 @@ int defrData::GETC()
 {
   // Remove '\r' symbols from Windows streams.
   for (;;) {
-    if (next > last)
+    if (last == nullptr || next > last)
       reload_buffer();
     if (next == nullptr)
       return EOF;

--- a/src/odb/src/def/def/defrData.cpp
+++ b/src/odb/src/def/def/defrData.cpp
@@ -101,7 +101,6 @@ defrData::defrData(const defrCallbacks* pCallbacks,
   }
 
   nlines = 1;
-  last = buffer - 1;
   next = buffer;
   first_buffer = 1;
 

--- a/src/odb/src/def/def/defrData.hpp
+++ b/src/odb/src/def/def/defrData.hpp
@@ -247,7 +247,7 @@ class defrData
   int defaultCapWarnings{0};
   FILE* defrLog{nullptr};
   int input_level{-1};
-  char* last{nullptr};
+  char* last{nullptr};  // points to the last valid char in the buffer, or null
   int new_is_keyword{0};
   long long nlines{1};
   char* rowName{nullptr};  // to hold the rowName for message


### PR DESCRIPTION
Resolves #7637.

It would be more idiomatic C/C++ to make `last` point one beyond the last valid character in the buffer. But this is a slightly smaller change because we don't change what `last` means, we just use null to represent the situation when there is no valid character in the buffer.