### PR TITLE
gpl: fix insts start position

### DIFF
--- a/src/gpl/src/initialPlace.cpp
+++ b/src/gpl/src/initialPlace.cpp
@@ -137,6 +137,8 @@ void InitialPlace::placeInstsCenter()
                               domain_y_max - (domain_y_max - domain_y_min) / 2);
       ++count_region_center;
     } else if (pbc_->skipIoMode() && db_inst->isPlaced()) {
+      // It is helpful to pick up the placement from mpl if available,
+      // particularly when you are going to run skip_io.
       const auto bbox = db_inst->getBBox()->getBox();
       inst->setCenterLocation(bbox.xCenter(), bbox.yCenter());
       ++count_db_location;

--- a/src/gpl/test/simple05.ok
+++ b/src/gpl/test/simple05.ok
@@ -32,7 +32,7 @@
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-        1 |   0.0000 |  2.887100e+04 |   +0.00% |  3.97e-11 |      
+        1 |   0.0000 |  2.887100e+04 |   +0.00% |  4.17e-11 |      
 [INFO GPL-1001] Finished with Overflow: 0.000000
 [INFO GPL-1002] Placed Cell Area                1.8620
 [INFO GPL-1003] Available Free Area            34.0480

--- a/src/gpl/test/simple09.ok
+++ b/src/gpl/test/simple09.ok
@@ -32,7 +32,7 @@
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
-        1 |   0.0000 |  1.007300e+04 |   +0.00% |  2.62e-09 |      
+        1 |   0.0000 |  1.007300e+04 |   +0.00% |  2.36e-09 |      
 [INFO GPL-1001] Finished with Overflow: 0.000000
 [INFO GPL-1002] Placed Cell Area                1.8620
 [INFO GPL-1003] Available Free Area           953.8760


### PR DESCRIPTION
Both `-skip_io` and `-skip_initial_place` options set the CG initial placement procedure to zero max iterations.

However, using the zero-iteration condition to decide whether to use existing database instance positions causes issues when `-skip_initial_place` is used. In this case, we end up using the final placement from a previous run, which is not desirable.

The expected behavior when skipping CG initial placement (e.g., via `-skip_initial_place`) is to place instances at the center of the domain, not to reuse existing placement. For example, in stage 3-3 in ORFS, it might lead to using the final placement from stage 3-2 in ORFS.

I believe it is better to explicitly check for `-skip_io` when deciding to use database positions.