### PR TITLE
drt: allow changing snapshot directory

### DIFF
--- a/src/drt/README.md
+++ b/src/drt/README.md
@@ -116,6 +116,7 @@ detailed_route_debug
     [-pa_markers]
     [-dump_dr]
     [-dump_dir dir]
+    [-snapshot_dir dir]
     [-dump_last_worker]
     [-pa_edge]
     [-pa_commit]
@@ -138,6 +139,7 @@ detailed_route_debug
 | `-pa_markers` | Enable pin access markers. |
 | `-dump_dr` | Filename for detailed routing dump. |
 | `-dump_dir` | Directory for detailed routing dump. |
+| `-snapshot_dir` | Directory for snapshots produced if the debug level of `DRT snapshot` is set to 1. |
 | `-pa_edge` | Enable visibility of pin access edges. |
 | `-pa_commit` | Enable visibility of pin access commits. |
 | `-write_net_tracks` | Enable writing of net track assigments. |

--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -114,7 +114,7 @@ class TritonRoute
 
   void setDebugDR(bool on = true);
   void setDebugDumpDR(bool on, const std::string& dumpDir);
-  void setDebugSnapshotDir(const std::string& dumpDir);
+  void setDebugSnapshotDir(const std::string& snapshotDir);
   void setDebugMaze(bool on = true);
   void setDebugPA(bool on = true);
   void setDebugTA(bool on = true);

--- a/src/drt/include/triton_route/TritonRoute.h
+++ b/src/drt/include/triton_route/TritonRoute.h
@@ -114,6 +114,7 @@ class TritonRoute
 
   void setDebugDR(bool on = true);
   void setDebugDumpDR(bool on, const std::string& dumpDir);
+  void setDebugSnapshotDir(const std::string& dumpDir);
   void setDebugMaze(bool on = true);
   void setDebugPA(bool on = true);
   void setDebugTA(bool on = true);

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -67,6 +67,11 @@ void TritonRoute::setDebugDumpDR(bool on, const std::string& dumpDir)
   debug_->dumpDir = dumpDir;
 }
 
+void TritonRoute::setDebugSnapshotDir(const std::string& snapshotDir)
+{
+  debug_->snapshotDir = snapshotDir;
+}
+
 void TritonRoute::setDebugMaze(bool on)
 {
   debug_->debugMaze = on;

--- a/src/drt/src/TritonRoute.i
+++ b/src/drt/src/TritonRoute.i
@@ -141,6 +141,7 @@ set_detailed_route_debug_cmd(const char* net_name,
                              bool pa_edge,
                              bool pa_commit,
                              const char* dumpDir,
+                             const char* snapshotDir,
                              bool ta,
                              bool write_net_tracks,
                              bool dump_last_worker)
@@ -150,6 +151,7 @@ set_detailed_route_debug_cmd(const char* net_name,
   router->setDebugPinName(pin_name);
   router->setDebugDR(dr);
   router->setDebugDumpDR(dump_dr, dumpDir);
+  router->setDebugSnapshotDir(snapshotDir);
   router->setDebugPA(pa);
   router->setDebugMaze(maze);
   router->setDebugBox(x1, y1, x2, y2);

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -193,7 +193,7 @@ sta::define_cmd_args "detailed_route_debug" {
 
 proc detailed_route_debug { args } {
   sta::parse_key_args "detailed_route_debug" args \
-    keys {-net -iter -pin -dump_dir -box} \
+    keys {-net -iter -pin -dump_dir -snapshot_dir -box} \
     flags {-dr -maze -pa -pa_markers -pa_edge -pa_commit -dump_dr -ta \
            -write_net_tracks -dump_last_worker}
 
@@ -214,6 +214,12 @@ proc detailed_route_debug { args } {
     set net_name $keys(-net)
   } else {
     set net_name ""
+  }
+
+  if { [info exists keys(-snapshot_dir)] } {
+    set snapshot_dir $keys(-snapshot_dir)
+  } else {
+    set snapshot_dir "."
   }
 
   if { [info exists keys(-pin)] } {
@@ -252,7 +258,7 @@ proc detailed_route_debug { args } {
 
   drt::set_detailed_route_debug_cmd $net_name $pin_name $dr $dump_dr $pa $maze \
     $box_x1 $box_y1 $box_x2 $box_y2 $iter $pa_markers $pa_edge $pa_commit \
-    $dump_dir $ta $write_net_tracks $dump_last_worker
+    $dump_dir $snapshot_dir $ta $write_net_tracks $dump_last_worker
 }
 
 sta::define_cmd_args "pin_access" {

--- a/src/drt/src/TritonRoute.tcl
+++ b/src/drt/src/TritonRoute.tcl
@@ -186,6 +186,7 @@ sta::define_cmd_args "detailed_route_debug" {
     [-pa_markers]
     [-dump_dr]
     [-dump_dir dir]
+    [-snapshot_dir dir]
     [-pa_edge]
     [-pa_commit]
     [-write_net_tracks]

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -1860,9 +1860,9 @@ int FlexDR::main()
       io::Writer writer(getDesign(), logger_);
       writer.updateDb(db_, router_cfg_, false, true);
 
-      db_->write(utl::OutStreamHandler(
-                     fmt::format("drt_iter{}.odb", iter_).c_str(), true)
-                     .getStream());
+      std::string snapshotPath = fmt::format(
+          "{}/drt_iter{}.odb", router_->getDebugSettings()->snapshotDir, iter_);
+      db_->write(utl::OutStreamHandler(snapshotPath.c_str(), true).getStream());
     }
     if (reporter->incrementProgress()) {
       break;

--- a/src/drt/src/frBaseTypes.h
+++ b/src/drt/src/frBaseTypes.h
@@ -313,6 +313,7 @@ struct frDebugSettings
   bool paEdge{false};
   bool paCommit{false};
   std::string dumpDir;
+  std::string snapshotDir{"."};
 
   int mazeEndIter{-1};
   int drcCost{-1};


### PR DESCRIPTION
- detailed_route_debug: add new option, -snapshot_dir, that allows the directory where snapshots are dumped to be changed. if unset the current working directory is used, maintaining the previous behavior.

---

Resolves #6752 

