### PR TITLE
grt: append nodes and edges from removed nets when merging nets

### DIFF
--- a/src/ant/src/WireBuilder.cc
+++ b/src/ant/src/WireBuilder.cc
@@ -27,7 +27,8 @@ void WireBuilder::makeNetWiresFromGuides()
         = db_net->getWireType() == odb::dbWireType::ROUTED && db_net->getWire();
 
     if (!db_net->isSpecial() && !db_net->isConnectedByAbutment()
-        && !dbNetIsLocal(db_net) && !is_detailed_routed) {
+        && db_net->getTermCount() > 1 && !dbNetIsLocal(db_net)
+        && !is_detailed_routed) {
       makeNetWire(db_net, guide_dimension);
     }
   }
@@ -42,7 +43,8 @@ void WireBuilder::makeNetWiresFromGuides(const std::vector<odb::dbNet*>& nets)
         = db_net->getWireType() == odb::dbWireType::ROUTED && db_net->getWire();
 
     if (!db_net->isSpecial() && !db_net->isConnectedByAbutment()
-        && !dbNetIsLocal(db_net) && !is_detailed_routed) {
+        && db_net->getTermCount() > 1 && !dbNetIsLocal(db_net)
+        && !is_detailed_routed) {
       makeNetWire(db_net, guide_dimension);
     }
   }

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -303,7 +303,7 @@ class GlobalRouter
   void initRoutingTracks(int max_routing_layer);
   void setCapacities(int min_routing_layer, int max_routing_layer);
   void initNetlist(std::vector<Net*>& nets);
-  bool makeFastrouteNet(Net* net);
+  void makeFastrouteNet(Net* net);
   bool pinPositionsChanged(Net* net);
   bool newPinOnGrid(Net* net, std::multiset<RoutePt>& last_pos);
   std::vector<LayerId> findTransitionLayers();

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4206,8 +4206,11 @@ void GlobalRouter::mergeNetsRouting(odb::dbNet* db_net1, odb::dbNet* db_net2)
 {
   Net* net1 = db_net_map_[db_net1];
   Net* net2 = db_net_map_[db_net2];
-  // Do not merge the routing if the survivor net is already dirty
-  if (!net1->isDirtyNet()) {
+  // Do not merge the routing if the survivor net is already dirty.
+  // Also, do not merge if the survivor net is a local net, since it doesn't
+  // have routes inside FastRouteCore.
+  // TODO: properly handle local nets when merging global routes.
+  if (!net1->isDirtyNet() && !net1->isLocal()) {
     connectRouting(db_net1, db_net2);
     net1->setIsMergedNet(true);
     net1->setMergedNet(db_net2);

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -661,7 +661,7 @@ void GlobalRouter::updateDirtyNets(std::vector<Net*>& dirty_nets)
             GRT, 267, "Net {} has disconnected segments.", net->getName());
       }
     }
-    net->setMergedNet(false);
+    net->setIsMergedNet(false);
     net->setDirtyNet(false);
     net->clearLastPinPositions();
   }
@@ -3573,7 +3573,7 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
 {
   Net* net = db_net_map_[db_net];
   if (net != nullptr && net->isMergedNet()) {
-    fastroute_->mergeNet(db_net);
+    fastroute_->mergeNet(db_net, net->getMergedNet());
   } else {
     fastroute_->removeNet(db_net);
   }
@@ -4227,8 +4227,10 @@ void GlobalRouter::mergeNetsRouting(odb::dbNet* db_net1, odb::dbNet* db_net2)
   // Do not merge the routing if the survivor net is already dirty
   if (!net1->isDirtyNet()) {
     connectRouting(db_net1, db_net2);
-    net1->setMergedNet(true);
-    net2->setMergedNet(true);
+    net1->setIsMergedNet(true);
+    net1->setMergedNet(db_net2);
+    net2->setIsMergedNet(true);
+    net2->setMergedNet(db_net1);
   }
 }
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1141,29 +1141,13 @@ bool GlobalRouter::newPinOnGrid(Net* net, std::multiset<RoutePt>& last_pos)
   return false;
 }
 
-bool GlobalRouter::makeFastrouteNet(Net* net)
+void GlobalRouter::makeFastrouteNet(Net* net)
 {
   std::vector<RoutePt> pins_on_grid;
   int root_idx;
   findFastRoutePins(net, pins_on_grid, root_idx);
 
-  if (pins_on_grid.size() <= 1) {
-    return false;
-  }
-
-  // check if net is local in the global routing grid position
-  // the (x,y) pin positions here may be different from the original
-  // (x,y) pin positions because of findFakePinPosition function
-  bool on_grid_local = true;
-  RoutePt position = pins_on_grid[0];
-  for (RoutePt& pin_pos : pins_on_grid) {
-    if (pin_pos.x() != position.x() || pin_pos.y() != position.y()) {
-      on_grid_local = false;
-      break;
-    }
-  }
-
-  if (!on_grid_local) {
+  if (pins_on_grid.size() > 1) {
     bool is_clock = (net->getSignalType() == odb::dbSigType::CLOCK);
     std::vector<int>* edge_cost_per_layer;
     int edge_cost_for_net;
@@ -1197,9 +1181,7 @@ bool GlobalRouter::makeFastrouteNet(Net* net)
         && net->getDbNet() == fastroute_->getDebugNet()) {
       saveSttInputFile(net);
     }
-    return true;
   }
-  return false;
 }
 
 void GlobalRouter::saveSttInputFile(Net* net)

--- a/src/grt/src/Net.cpp
+++ b/src/grt/src/Net.cpp
@@ -18,7 +18,8 @@ Net::Net(odb::dbNet* net, bool has_wires)
     : net_(net),
       slack_(0),
       has_wires_(has_wires),
-      merged_net_(false),
+      merged_net_(nullptr),
+      is_merged_net_(false),
       is_dirty_net_(false)
 {
 }

--- a/src/grt/src/Net.h
+++ b/src/grt/src/Net.h
@@ -50,8 +50,10 @@ class Net
   {
     return last_pin_positions_;
   }
-  void setMergedNet(bool merged_net) { merged_net_ = merged_net; }
-  bool isMergedNet() const { return merged_net_; }
+  void setMergedNet(odb::dbNet* merged_net) { merged_net_ = merged_net; }
+  odb::dbNet* getMergedNet() const { return merged_net_; }
+  void setIsMergedNet(bool merged_net) { is_merged_net_ = merged_net; }
+  bool isMergedNet() const { return is_merged_net_; }
   void setDirtyNet(bool is_dirty_net) { is_dirty_net_ = is_dirty_net; }
   bool isDirtyNet() const { return is_dirty_net_; }
 
@@ -64,7 +66,8 @@ class Net
   bool has_wires_;
   std::vector<SegmentIndex> parent_segment_indices_;
   std::multiset<RoutePt> last_pin_positions_;
-  bool merged_net_;
+  odb::dbNet* merged_net_;
+  bool is_merged_net_;
   bool is_dirty_net_;
 };
 

--- a/src/grt/src/fastroute/include/FastRoute.h
+++ b/src/grt/src/fastroute/include/FastRoute.h
@@ -109,7 +109,7 @@ class FastRouteCore
                 std::vector<int>* edge_cost_per_layer);
   void deleteNet(odb::dbNet* db_net);
   void removeNet(odb::dbNet* db_net);
-  void mergeNet(odb::dbNet* db_net);
+  void mergeNet(odb::dbNet* removed_net, odb::dbNet* preserved_net);
   void clearNetRoute(odb::dbNet* db_net);
   void clearNetsToRoute() { net_ids_.clear(); }
   void initEdges();

--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -291,13 +291,25 @@ void FastRouteCore::removeNet(odb::dbNet* db_net)
   }
 }
 
-void FastRouteCore::mergeNet(odb::dbNet* db_net)
+void FastRouteCore::mergeNet(odb::dbNet* removed_net, odb::dbNet* preserved_net)
 {
-  if (db_net_id_map_.find(db_net) != db_net_id_map_.end()) {
-    const int net_id = db_net_id_map_[db_net];
-    sttrees_[net_id].nodes.clear();
-    sttrees_[net_id].edges.clear();
-    deleteNet(db_net);
+  if (db_net_id_map_.find(removed_net) != db_net_id_map_.end()) {
+    const int preserved_net_id = db_net_id_map_[preserved_net];
+    auto& preserved_nodes = sttrees_[preserved_net_id].nodes;
+    auto& preserved_edges = sttrees_[preserved_net_id].edges;
+
+    const int removed_net_id = db_net_id_map_[removed_net];
+    auto& removed_nodes = sttrees_[removed_net_id].nodes;
+    auto& removed_edges = sttrees_[removed_net_id].edges;
+
+    preserved_nodes.insert(
+        preserved_nodes.end(), removed_nodes.begin(), removed_nodes.end());
+    preserved_edges.insert(
+        preserved_edges.end(), removed_edges.begin(), removed_edges.end());
+
+    removed_nodes.clear();
+    removed_edges.clear();
+    deleteNet(removed_net);
   }
 }
 

--- a/src/grt/src/fastroute/src/FastRoute.cpp
+++ b/src/grt/src/fastroute/src/FastRoute.cpp
@@ -294,18 +294,22 @@ void FastRouteCore::removeNet(odb::dbNet* db_net)
 void FastRouteCore::mergeNet(odb::dbNet* removed_net, odb::dbNet* preserved_net)
 {
   if (db_net_id_map_.find(removed_net) != db_net_id_map_.end()) {
-    const int preserved_net_id = db_net_id_map_[preserved_net];
-    auto& preserved_nodes = sttrees_[preserved_net_id].nodes;
-    auto& preserved_edges = sttrees_[preserved_net_id].edges;
-
     const int removed_net_id = db_net_id_map_[removed_net];
     auto& removed_nodes = sttrees_[removed_net_id].nodes;
     auto& removed_edges = sttrees_[removed_net_id].edges;
 
-    preserved_nodes.insert(
-        preserved_nodes.end(), removed_nodes.begin(), removed_nodes.end());
-    preserved_edges.insert(
-        preserved_edges.end(), removed_edges.begin(), removed_edges.end());
+    if (db_net_id_map_.find(preserved_net) != db_net_id_map_.end()) {
+      const int preserved_net_id = db_net_id_map_[preserved_net];
+      sttrees_[preserved_net_id].num_terminals
+          += sttrees_[removed_net_id].num_terminals;
+      auto& preserved_nodes = sttrees_[preserved_net_id].nodes;
+      auto& preserved_edges = sttrees_[preserved_net_id].edges;
+
+      preserved_nodes.insert(
+          preserved_nodes.end(), removed_nodes.begin(), removed_nodes.end());
+      preserved_edges.insert(
+          preserved_edges.end(), removed_edges.begin(), removed_edges.end());
+    }
 
     removed_nodes.clear();
     removed_edges.clear();


### PR DESCRIPTION
**Problem**
When merging the routing of two nets after buffer removal, the FastRouteCore data regarding edges and nodes of the deleted net was just being deleted, but the congestion information of them wasn't updated. This caused multiple congestion issues during post-GRT incremental repair, since the congestion data of these edges was never updated.

**Solution**
Instead of just deleting the edges and nodes of the deleted nets, append them to the edges and nodes of the preserved net (i.e., the net that will "receive" the routing of the deleted net). This way, the congestion data can be properly updated in future iterations of the global routing tool.