### PR TITLE
cmake: improve handling of using system abc/opensta

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,15 @@ if(USE_SYSTEM_OPENSTA)
   endif()
   include_directories(${OPENSTA_INCLUDE_DIR})
   message(STATUS "Using OPENSTA_INCLUDE_DIR=${OPENSTA_INCLUDE_DIR}")
+  add_library(OpenSTA STATIC IMPORTED)
+  set_target_properties(OpenSTA PROPERTIES
+    IMPORTED_LOCATION "${OPENSTA_LIBRARY}"
+  )
+  if(CUDD_LIB)
+    set_target_properties(OpenSTA PROPERTIES 
+      INTERFACE_LINK_LIBRARIES "${CUDD_LIB}"
+    )
+  endif()
 else()
   # local build of opensta
   set(OPENSTA_LIBRARY "sta_swig")

--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -65,7 +65,6 @@ target_link_libraries(rmp_abc_library
   PUBLIC
     OpenSTA
     dbSta_lib
-    libabc
     utl_lib
     ${ABC_LIBRARY}
 )

--- a/src/rmp/test/cpp/CMakeLists.txt
+++ b/src/rmp/test/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(RmpGTests
         rmp_abc_library
         dbSta_lib
         utl_lib
-        libabc
+        ${ABC_LIBRARY}
         ${TCL_LIBRARY}
 )
 


### PR DESCRIPTION
1. Fixing two CMakeLists.txt files in src/rmp which use `libabc` unqualified, instead of ${ABC_LIBRARY} (in spite of the fact one of them already links ${ABC_LIBRARY}). This breaks using an ABC_LIBRARY with an absolute path which is supported by the rest of the CMake build scripts.
2. Adding OpenSTA as a STATIC, IMPORTED library when USE_SYSTEM_OPENSTA is set. This in turn allows CUDD_LIB to be added to its INTERFACE_LINK_LIBRARIES property, meaning all of the test binaries linked against OpenSTA will automatically be linked against CUDD_LIB. This is not propagated automatically otherwise and CUDD_LIB would have to be added to every single one of them.
