### PR TITLE
drt: valid access points

### DIFF
--- a/src/drt/src/db/obj/frAccess.h
+++ b/src/drt/src/db/obj/frAccess.h
@@ -134,6 +134,7 @@ class frAccessPoint : public frBlockObject
     return typeH_;
   }
   bool isViaAllowed() const { return allow_via_; }
+  bool isValid() const { return is_valid_; }
   // setters
   void setPoint(const Point& in) { point_ = in; }
   void setLayer(const frLayerNum& layerNum) { layerNum_ = layerNum; }
@@ -180,7 +181,7 @@ class frAccessPoint : public frBlockObject
     }
   }
   void setAllowVia(bool in) { allow_via_ = in; }
-  // others
+  void setIsValid(bool is_valid) { is_valid_ = is_valid; }  // others
   frBlockObjectEnum typeId() const override { return frcAccessPoint; }
   frCoord x() const { return point_.x(); }
   frCoord y() const { return point_.y(); }
@@ -200,6 +201,7 @@ class frAccessPoint : public frBlockObject
   frPinAccess* aps_{nullptr};
   std::vector<frPathSeg> pathSegs_;
   bool allow_via_{false};
+  bool is_valid_{false};
   template <class Archive>
   void serialize(Archive& ar, unsigned int version);
   friend class boost::serialization::access;

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -202,7 +202,7 @@ class FlexPA
    *
    * @returns True if the current aps are enough for the pin
    */
-  bool EnoughAccessPoints(std::vector<std::unique_ptr<frAccessPoint>>& aps,
+  bool EnoughAccessPoints(std::vector<frAccessPoint*>& aps,
                           frInstTerm* inst_term,
                           pa_requirements_met& reqs);
 
@@ -214,7 +214,7 @@ class FlexPA
    *
    * @returns True if the requirement is met
    */
-  bool EnoughSparsePoints(std::vector<std::unique_ptr<frAccessPoint>>& aps,
+  bool EnoughSparsePoints(std::vector<frAccessPoint*>& aps,
                           frInstTerm* inst_term);
 
   /**
@@ -245,6 +245,7 @@ class FlexPA
   template <typename T>
   bool genPinAccessCostBounded(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,
+      std::vector<frAccessPoint*>& valid_aps,
       std::set<std::pair<Point, frLayerNum>>& apset,
       const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
       const std::vector<std::vector<gtl::polygon_90_data<frCoord>>>&
@@ -482,15 +483,15 @@ class FlexPA
    * @param pin_shapes vector of pin shapes of the pin
    * @param pin the pin
    * @param inst_term terminal
-   * @param is_std_cell_pin if the pin if from a standard cell
    */
   template <typename T>
   void filterMultipleAPAccesses(
       std::vector<std::unique_ptr<frAccessPoint>>& aps,
       const std::vector<gtl::polygon_90_set_data<frCoord>>& pin_shapes,
+      const std::vector<std::vector<gtl::polygon_90_data<frCoord>>>&
+          layer_polys,
       T* pin,
-      frInstTerm* inst_term,
-      const bool& is_std_cell_pin);
+      frInstTerm* inst_term);
 
   /**
    * @brief Filters access in a given planar direction.
@@ -668,9 +669,8 @@ class FlexPA
   /**
    * @brief Serially updates some of general pin stats
    */
-  void updatePinStats(
-      const std::vector<std::unique_ptr<frAccessPoint>>& tmp_aps,
-      frInstTerm* inst_term);
+  void updatePinStats(const std::vector<frAccessPoint*>& valid_aps,
+                      frInstTerm* inst_term);
 
   /**
    * @brief Adjusts the coordinates for all access points


### PR DESCRIPTION
Supports #7150.

Full CI Safe.

I'm currently trying to isolate a loop on `genPinAccessCostBounded` that goes through all access points in order with little success. With this single loop, access points could be examined one by one and discarded if they do not further progress.

### Valid APs Structure
Introduces a structure that separates valid access points from the normal ones. This lays some ground to the PA on Demand project. My objective is to get rid of the `new_aps` structure, so every ap is held by the `aps` vector. This is part of it