### PR TITLE
gui: fix color change to vias and allow site to be selected

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1021,16 +1021,13 @@ void DisplayControls::displayItemSelected(const QItemSelection& selection)
     if (!user_data.isValid()) {
       continue;
     }
-    auto* tech_layer = user_data.value<dbTechLayer*>();
-    if (tech_layer != nullptr) {
+
+    if (auto* tech_layer = user_data.value<dbTechLayer*>()) {
       emit selected(Gui::get()->makeSelected(tech_layer));
+    } else if (auto* site = user_data.value<odb::dbSite*>()) {
+      emit selected(Gui::get()->makeSelected(site));
     } else {
-      auto* site = user_data.value<odb::dbSite*>();
-      if (site != nullptr) {
-        emit selected(Gui::get()->makeSelected(site));
-      } else {
-        continue;
-      }
+      continue;
     }
     return;
   }


### PR DESCRIPTION
Changes:
- while looking into the via visibility issue, I noticed that the color of the via is actually not updated correctly when the display controls changes the color. This ensures that is correct.
- when selecting the site from the rows options, the site is now selected in the inspector.