### PR TITLE
gui: change placement, pin, and power density heatmaps to use core ar…

### DIFF
--- a/src/gui/include/gui/heatMap.h
+++ b/src/gui/include/gui/heatMap.h
@@ -332,6 +332,8 @@ class PowerDensityDataSource : public RealValueHeatMapDataSource
  public:
   PowerDensityDataSource(sta::dbSta* sta, utl::Logger* logger);
 
+  odb::Rect getBounds() const override { return getBlock()->getCoreArea(); }
+
  protected:
   bool populateMap() override;
   void combineMapData(bool base_has_value,

--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -352,6 +352,10 @@ void HeatMapDataSource::addToMap(const odb::Rect& region, double value)
 {
   for (const auto& map_col : getMapView(region)) {
     for (const auto& map_pt : map_col) {
+      if (map_pt == nullptr) {
+        continue;
+      }
+
       odb::Rect intersection;
       map_pt->rect.intersection(region, intersection);
 

--- a/src/gui/src/heatMapPinDensity.h
+++ b/src/gui/src/heatMapPinDensity.h
@@ -16,6 +16,8 @@ class PinDensityDataSource : public RealValueHeatMapDataSource,
  public:
   PinDensityDataSource(utl::Logger* logger);
 
+  odb::Rect getBounds() const override { return getBlock()->getCoreArea(); }
+
   void onShow() override;
   void onHide() override;
   double getGridSizeMinimumValue() const override { return 0.1; }

--- a/src/gui/src/heatMapPlacementDensity.h
+++ b/src/gui/src/heatMapPlacementDensity.h
@@ -16,6 +16,8 @@ class PlacementDensityDataSource : public HeatMapDataSource,
  public:
   PlacementDensityDataSource(utl::Logger* logger);
 
+  odb::Rect getBounds() const override { return getBlock()->getCoreArea(); }
+
   void onShow() override;
   void onHide() override;
 


### PR DESCRIPTION
…ea instead of die area for map bounds

Changes:
- heatmaps that only need to cover the core area uses the the core area to build the map.
- add a check for nullptr in `addToMap` (this should not happen right now, but once a Polygon core area can be used some of the map sites will be blank.

Notes:
- when the Polygon floorplanning is available and the db has a `getCorePolygon()`, it should be relatively easy to update this to handle that correctly.