### PR TITLE
gui: separate routing and cut colors

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -2052,64 +2052,44 @@ void DisplayControls::techInit(odb::dbTech* tech)
   misc_.manufacturing_grid.name->setEnabled(tech->hasManufacturingGrid());
   misc_.manufacturing_grid.visible->setEnabled(tech->hasManufacturingGrid());
 
-  // Default colors
-  // From http://vrl.cs.brown.edu/color seeded with #00F, #F00, #0D0
-  const QColor colors[] = {QColor(0, 0, 254),
-                           QColor(254, 0, 0),
-                           QColor(9, 221, 0),
-                           QColor(190, 244, 81),
-                           QColor(222, 33, 96),  // Metal 5
-                           QColor(32, 216, 253),
-                           QColor(253, 108, 160),
-                           QColor(117, 63, 194),
-                           QColor(128, 155, 49),
-                           QColor(234, 63, 252),
-                           QColor(9, 96, 19),
-                           QColor(214, 120, 239),
-                           QColor(192, 222, 164),
-                           QColor(110, 68, 107)};
-  const int num_colors = sizeof(colors) / sizeof(QColor);
   int metal = 0;
   int via = 0;
 
   // ensure if random colors are used they are consistent
   std::mt19937 gen_color(1);
 
+  auto generate_next_color = [&gen_color]() -> QColor {
+    return QColor(
+        50 + gen_color() % 200, 50 + gen_color() % 200, 50 + gen_color() % 200);
+  };
+
   // Iterate through the layers and set default colors
   for (dbTechLayer* layer : tech->getLayers()) {
     dbTechLayerType type = layer->getType();
     QColor color;
     if (type == dbTechLayerType::ROUTING) {
-      if (metal < num_colors) {
-        color = colors[metal++];
+      if (metal < default_metal_colors_.size()) {
+        color = default_metal_colors_[metal++];
       } else {
         // pick a random color as we exceeded the built-in palette size
-        color = QColor(50 + gen_color() % 200,
-                       50 + gen_color() % 200,
-                       50 + gen_color() % 200);
+        color = generate_next_color();
       }
     } else if (type == dbTechLayerType::CUT) {
-      if (via < num_colors) {
+      if (via < default_metal_colors_.size()) {
         if (metal != 0) {
-          color = colors[via++];
+          color = default_metal_colors_[via++];
         } else {
           // via came first, so pick random color
-          color = QColor(50 + gen_color() % 200,
-                         50 + gen_color() % 200,
-                         50 + gen_color() % 200);
+          color = generate_next_color();
         }
       } else {
         // pick a random color as we exceeded the built-in palette size
-        color = QColor(50 + gen_color() % 200,
-                       50 + gen_color() % 200,
-                       50 + gen_color() % 200);
+        color = generate_next_color();
       }
     } else {
       // Do not draw from the existing palette so the metal layers can claim
       // those colors.
-      color = QColor(50 + gen_color() % 200,
-                     50 + gen_color() % 200,
-                     50 + gen_color() % 200);
+      color = generate_next_color();
     }
     color.setAlpha(180);
     layer_color_[layer] = std::move(color);

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -12,6 +12,7 @@
 #include <QRegExp>
 #include <QSettings>
 #include <QVBoxLayout>
+#include <array>
 #include <functional>
 #include <random>
 #include <string>
@@ -2031,6 +2032,38 @@ void DisplayControls::techInit(odb::dbTech* tech)
   misc_.manufacturing_grid.name->setEnabled(tech->hasManufacturingGrid());
   misc_.manufacturing_grid.visible->setEnabled(tech->hasManufacturingGrid());
 
+  // Default colors
+  // From http://vrl.cs.brown.edu/color seeded with #00F, #F00, #0D0
+  const std::array<QColor, 14> default_metal_colors
+      = {QColor(0, 0, 254),
+         QColor(254, 0, 0),
+         QColor(9, 221, 0),
+         QColor(190, 244, 81),
+         QColor(222, 33, 96),  // Metal 5
+         QColor(32, 216, 253),
+         QColor(253, 108, 160),
+         QColor(117, 63, 194),
+         QColor(128, 155, 49),
+         QColor(234, 63, 252),  // Metal 10
+         QColor(9, 96, 19),
+         QColor(214, 120, 239),
+         QColor(192, 222, 164),
+         QColor(110, 68, 107)};  // Metal 14
+  const std::array<QColor, 14> default_cut_colors
+      = {QColor(126, 126, 255),
+         QColor(255, 126, 126),
+         QColor(4, 110, 0),
+         QColor(95, 122, 40),
+         QColor(111, 17, 48),  // Metal 5
+         QColor(16, 108, 126),
+         QColor(126, 54, 80),
+         QColor(58, 32, 97),
+         QColor(225, 255, 136),
+         QColor(117, 32, 126),  // Metal 10
+         QColor(18, 192, 38),
+         QColor(107, 60, 119),
+         QColor(96, 111, 82),
+         QColor(220, 136, 214)};  // Metal 14
   int metal = 0;
   int via = 0;
 
@@ -2047,16 +2080,16 @@ void DisplayControls::techInit(odb::dbTech* tech)
     dbTechLayerType type = layer->getType();
     QColor color;
     if (type == dbTechLayerType::ROUTING) {
-      if (metal < default_metal_colors_.size()) {
-        color = default_metal_colors_[metal++];
+      if (metal < default_metal_colors.size()) {
+        color = default_metal_colors[metal++];
       } else {
         // pick a random color as we exceeded the built-in palette size
         color = generate_next_color();
       }
     } else if (type == dbTechLayerType::CUT) {
-      if (via < default_cut_colors_.size()) {
+      if (via < default_cut_colors.size()) {
         if (metal != 0) {
-          color = default_cut_colors_[via++];
+          color = default_cut_colors[via++];
         } else {
           // via came first, so pick random color
           color = generate_next_color();

--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -2075,9 +2075,9 @@ void DisplayControls::techInit(odb::dbTech* tech)
         color = generate_next_color();
       }
     } else if (type == dbTechLayerType::CUT) {
-      if (via < default_metal_colors_.size()) {
+      if (via < default_cut_colors_.size()) {
         if (metal != 0) {
-          color = default_metal_colors_[via++];
+          color = default_cut_colors_[via++];
         } else {
           // via came first, so pick random color
           color = generate_next_color();

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -18,7 +18,6 @@
 #include <QTextEdit>
 #include <QTreeView>
 #include <QVBoxLayout>
-#include <array>
 #include <functional>
 #include <map>
 #include <optional>
@@ -579,39 +578,6 @@ class DisplayControls : public QDockWidget,
   static constexpr int doubleclick_item_idx_ = Qt::UserRole + 2;
   static constexpr int exclusivity_item_idx_ = Qt::UserRole + 3;
   static constexpr int disable_row_item_idx_ = Qt::UserRole + 4;
-
-  // Default colors
-  // From http://vrl.cs.brown.edu/color seeded with #00F, #F00, #0D0
-  static constexpr std::array<QColor, 14> default_metal_colors_
-      = {QColor(0, 0, 254),
-         QColor(254, 0, 0),
-         QColor(9, 221, 0),
-         QColor(190, 244, 81),
-         QColor(222, 33, 96),  // Metal 5
-         QColor(32, 216, 253),
-         QColor(253, 108, 160),
-         QColor(117, 63, 194),
-         QColor(128, 155, 49),
-         QColor(234, 63, 252),  // Metal 10
-         QColor(9, 96, 19),
-         QColor(214, 120, 239),
-         QColor(192, 222, 164),
-         QColor(110, 68, 107)};  // Metal 14
-  static constexpr std::array<QColor, 14> default_cut_colors_
-      = {QColor(126, 126, 255),
-         QColor(255, 126, 126),
-         QColor(4, 110, 0),
-         QColor(95, 122, 40),
-         QColor(111, 17, 48),  // Metal 5
-         QColor(16, 108, 126),
-         QColor(126, 54, 80),
-         QColor(58, 32, 97),
-         QColor(225, 255, 136),
-         QColor(117, 32, 126),  // Metal 10
-         QColor(18, 192, 38),
-         QColor(107, 60, 119),
-         QColor(96, 111, 82),
-         QColor(220, 136, 214)};  // Metal 14
 };
 
 }  // namespace gui

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -24,7 +24,6 @@
 #include <optional>
 #include <set>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "db_sta/dbNetwork.hh"
@@ -494,9 +493,9 @@ class DisplayControls : public QDockWidget,
 
   void checkLiberty(bool assume_loaded = false);
 
-  std::tuple<QColor*, Qt::BrushStyle*, bool> lookupColor(
-      QStandardItem* item,
-      const QModelIndex* index = nullptr);
+  std::pair<QColor*, Qt::BrushStyle*> lookupColor(QStandardItem* item,
+                                                  const QModelIndex* index
+                                                  = nullptr);
 
   QTreeView* view_;
   DisplayControlModel* model_;

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -598,6 +598,21 @@ class DisplayControls : public QDockWidget,
          QColor(214, 120, 239),
          QColor(192, 222, 164),
          QColor(110, 68, 107)};  // Metal 14
+  static constexpr std::array<QColor, 14> default_cut_colors_
+      = {QColor(126, 126, 255),
+         QColor(255, 126, 126),
+         QColor(4, 110, 0),
+         QColor(95, 122, 40),
+         QColor(111, 17, 48),  // Metal 5
+         QColor(16, 108, 126),
+         QColor(126, 54, 80),
+         QColor(58, 32, 97),
+         QColor(225, 255, 136),
+         QColor(117, 32, 126),  // Metal 10
+         QColor(18, 192, 38),
+         QColor(107, 60, 119),
+         QColor(96, 111, 82),
+         QColor(220, 136, 214)};  // Metal 14
 };
 
 }  // namespace gui

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -18,6 +18,7 @@
 #include <QTextEdit>
 #include <QTreeView>
 #include <QVBoxLayout>
+#include <array>
 #include <functional>
 #include <map>
 #include <optional>
@@ -579,6 +580,24 @@ class DisplayControls : public QDockWidget,
   static constexpr int doubleclick_item_idx_ = Qt::UserRole + 2;
   static constexpr int exclusivity_item_idx_ = Qt::UserRole + 3;
   static constexpr int disable_row_item_idx_ = Qt::UserRole + 4;
+
+  // Default colors
+  // From http://vrl.cs.brown.edu/color seeded with #00F, #F00, #0D0
+  static constexpr std::array<QColor, 14> default_metal_colors_
+      = {QColor(0, 0, 254),
+         QColor(254, 0, 0),
+         QColor(9, 221, 0),
+         QColor(190, 244, 81),
+         QColor(222, 33, 96),  // Metal 5
+         QColor(32, 216, 253),
+         QColor(253, 108, 160),
+         QColor(117, 63, 194),
+         QColor(128, 155, 49),
+         QColor(234, 63, 252),  // Metal 10
+         QColor(9, 96, 19),
+         QColor(214, 120, 239),
+         QColor(192, 222, 164),
+         QColor(110, 68, 107)};  // Metal 14
 };
 
 }  // namespace gui


### PR DESCRIPTION
Changes:
 - when routing layer color changes, the cut layers do not change with them (this also makes it easier for users to specify the color of a layer they want without having to undo the cut layer change as well).
 - change default cut colors

Initial cut colors were chosen by calling `color.lighter()` or `color.darker()` to generate a color that is "related" to the initial metal color, but with some contrast to the metal.

If someone wants to suggest a different color for the specific layer, feel free to do so. My goal here was to get a starting point that I thought was sufficient to begin the discussion.

Examples m1-m10:
![m1](https://github.com/user-attachments/assets/218a7f6b-bde4-4715-8b2e-eb05c639a4b2)
![m2](https://github.com/user-attachments/assets/d940962d-5804-45aa-a1c9-b390514ceb02)
![m3](https://github.com/user-attachments/assets/d528e82b-f396-48a2-b4c2-4f462d69265f)
![m4](https://github.com/user-attachments/assets/63f59a51-ced2-45f4-be65-5bc56024d5b5)
![m5](https://github.com/user-attachments/assets/ffd85cc5-31aa-40c1-922e-d8b989b8e342)
![m6](https://github.com/user-attachments/assets/8f5f2819-cc34-4f53-b0e1-4e7647438c9a)
![m7](https://github.com/user-attachments/assets/a34994fc-bf62-42c6-ac27-494ae5d157df)
![m8](https://github.com/user-attachments/assets/a35126c9-78be-4880-9e8f-66c8c6e4ef3f)
![m9](https://github.com/user-attachments/assets/3f2fa6c5-72f1-48d1-b3f5-54de240b8ea3)
![m10](https://github.com/user-attachments/assets/5dfb30f6-4d4a-4cf3-919b-f56cbd959888)
