### PR TITLE
grt: check layer range when adding resources from deleted net wires

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4836,7 +4836,7 @@ std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)
 {
   std::vector<Net*> dirty_nets;
   if (!dirty_nets_.empty()) {
-    fastroute_->setVerbose(true);
+    fastroute_->setVerbose(false);
     fastroute_->clearNetsToRoute();
 
     updateDirtyNets(dirty_nets);


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/7556.

Secure-ci started, as it will affect resources values and can lead to congestion in some designs.