### PR TITLE
gpl: fix debug print segmentation fault and levels for callbacks

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -3017,13 +3017,12 @@ void NesterovBase::updateGCellState(float wlCoeffX, float wlCoeffY)
       // analogous to updatePrevGradient()
       updateSinglePrevGradient(gcells_index, wlCoeffX, wlCoeffY);
     } else {
-      debugPrint(log_,
-                 GPL,
-                 "callbacks",
-                 1,
-                 "warning: updateGCellState, db_inst not found in "
-                 "db_inst_index_map_ for instance: {}",
-                 db_inst->getName());
+      debugPrint(
+          log_,
+          GPL,
+          "callbacks",
+          1,
+          "warning: updateGCellState, db_inst not found in db_inst_index_map_");
     }
   }
   new_instances.clear();
@@ -3034,7 +3033,7 @@ void NesterovBase::createCbkGCell(odb::dbInst* db_inst, size_t stor_index)
   debugPrint(log_,
              GPL,
              "callbacks",
-             1,
+             2,
              "NesterovBase: createGCell {}",
              db_inst->getName());
   auto gcell = nbc_->getGCellByIndex(stor_index);
@@ -3246,7 +3245,7 @@ void NesterovBase::destroyFillerGCell(size_t index_remove)
 
 void NesterovBaseCommon::destroyCbkGNet(odb::dbNet* db_net)
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NBC::destroyGNet");
+  debugPrint(log_, GPL, "callbacks", 3, "NBC destroyGNet");
   auto db_it = db_net_to_index_map_.find(db_net);
   if (db_it == db_net_to_index_map_.end()) {
     log_->error(GPL,
@@ -3283,7 +3282,7 @@ void NesterovBaseCommon::destroyCbkGNet(odb::dbNet* db_net)
 void NesterovBaseCommon::destroyCbkITerm(odb::dbITerm* db_iterm)
 
 {
-  debugPrint(log_, GPL, "callbacks", 3, "NBC::destroyITerm");
+  debugPrint(log_, GPL, "callbacks", 3, "NBC destroyITerm");
   auto db_it = db_iterm_to_index_map_.find(db_iterm);
   if (db_it != db_iterm_to_index_map_.end()) {
     size_t last_index = gPinStor_.size() - 1;

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -3035,7 +3035,7 @@ void NesterovBase::createCbkGCell(odb::dbInst* db_inst, size_t stor_index)
              GPL,
              "callbacks",
              1,
-             "NesterovBase: creatGCell {}",
+             "NesterovBase: createGCell {}",
              db_inst->getName());
   auto gcell = nbc_->getGCellByIndex(stor_index);
   if (gcell != nullptr) {
@@ -3097,7 +3097,7 @@ size_t NesterovBaseCommon::createCbkGCell(odb::dbInst* db_inst)
 
 void NesterovBaseCommon::createCbkGNet(odb::dbNet* db_net, bool skip_io_mode)
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NBC createGNet");
+  debugPrint(log_, GPL, "callbacks", 3, "NBC createGNet");
   Net gpl_net(db_net, skip_io_mode);
   pb_nets_stor_.push_back(gpl_net);
   GNet gnet(&pb_nets_stor_.back());
@@ -3109,7 +3109,7 @@ void NesterovBaseCommon::createCbkGNet(odb::dbNet* db_net, bool skip_io_mode)
 
 void NesterovBaseCommon::createCbkITerm(odb::dbITerm* iTerm)
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NBC createITerm");
+  debugPrint(log_, GPL, "callbacks", 3, "NBC createITerm");
   Pin gpl_pin(iTerm);
   pb_pins_stor_.push_back(gpl_pin);
   GPin gpin(&pb_pins_stor_.back());
@@ -3123,7 +3123,13 @@ void NesterovBaseCommon::createCbkITerm(odb::dbITerm* iTerm)
 //  maintaining consistency in NBC::gcellStor_ and NB::gCells_
 void NesterovBase::destroyCbkGCell(odb::dbInst* db_inst)
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NesterovBase::destroyGCel");
+  debugPrint(log_,
+             GPL,
+             "callbacks",
+             2,
+             "NesterovBase: destroyCbkGCell {}",
+             db_inst->getName());
+
   auto db_it = db_inst_to_nb_index_map_.find(db_inst);
   if (db_it != db_inst_to_nb_index_map_.end()) {
     size_t last_index = nb_gcells_.size() - 1;
@@ -3240,7 +3246,7 @@ void NesterovBase::destroyFillerGCell(size_t index_remove)
 
 void NesterovBaseCommon::destroyCbkGNet(odb::dbNet* db_net)
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NesterovBaseCommon::destroyGNet");
+  debugPrint(log_, GPL, "callbacks", 2, "NBC::destroyGNet");
   auto db_it = db_net_to_index_map_.find(db_net);
   if (db_it == db_net_to_index_map_.end()) {
     log_->error(GPL,
@@ -3277,7 +3283,7 @@ void NesterovBaseCommon::destroyCbkGNet(odb::dbNet* db_net)
 void NesterovBaseCommon::destroyCbkITerm(odb::dbITerm* db_iterm)
 
 {
-  debugPrint(log_, GPL, "callbacks", 2, "NesterovBaseCommon::destroyITerm");
+  debugPrint(log_, GPL, "callbacks", 3, "NBC::destroyITerm");
   auto db_it = db_iterm_to_index_map_.find(db_iterm);
   if (db_it != db_iterm_to_index_map_.end()) {
     size_t last_index = gPinStor_.size() - 1;


### PR DESCRIPTION
Avoid a segmentation fault by not attempting to access the name of a destructed db inst.