### PR TITLE
rcx: wire spacing and middle wire selection in extSolverGen::writeWirePatterns()

### DIFF
--- a/src/rcx/src/extSolverGen.cpp
+++ b/src/rcx/src/extSolverGen.cpp
@@ -504,9 +504,10 @@ double extSolverGen::writeWirePatterns(FILE* fp,
   double xd[10] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
   double X0 = x - targetPitch;  // next neighbor spacing
   // double W0= targetWidth; // next neighbor width
-  xd[1] = X0 - min_pitch;
+  xd[1] = X0;
   double min_x = xd[1];
-  for (int ii = 2; ii < n; ii++) {
+
+  for (int ii = 2; ii > 1; ii--) {
     xd[ii] = xd[ii - 1] - min_pitch;  // next over neighbor spacing
     if (min_x > xd[ii]) {
       min_x = xd[ii];

--- a/src/rcx/src/extSolverGen.cpp
+++ b/src/rcx/src/extSolverGen.cpp
@@ -506,14 +506,13 @@ double extSolverGen::writeWirePatterns(FILE* fp,
   // double W0= targetWidth; // next neighbor width
   xd[1] = X0;
   double min_x = xd[1];
-
-  for (int ii = 2; ii > 1; ii--) {
+  for (int ii = 2; ii < (n+1); ii++) {
     xd[ii] = xd[ii - 1] - min_pitch;  // next over neighbor spacing
     if (min_x > xd[ii]) {
       min_x = xd[ii];
     }
   }
-  for (int ii = 2; ii > 0; ii--) {
+  for (int ii = n; ii > 0; ii--) {
     m->writeWire3D(fp, cnt++, xd[ii], minWidth, len, height_offset, 0.0);
     max_x = xd[ii] + minWidth;
   }
@@ -530,10 +529,10 @@ double extSolverGen::writeWirePatterns(FILE* fp,
   xu[0] = x + targetPitch;  // next neighbor spacing
   m->writeWire3D(fp, cnt++, xu[0], targetWidth, len, height_offset, 0.0);
   xu[1] += xu[0] + targetWidth + minSpace;
-  for (int ii = 2; ii < n; ii++) {
+  for (int ii = 2; ii < (_wireCnt - n); ii++) {
     xu[ii] = xu[ii - 1] + min_pitch;  // context: next over neighbor spacing
   }
-  for (int ii = 1; ii < n; ii++) {
+  for (int ii = 1; ii < (_wireCnt - n - 1); ii++) {
     m->writeWire3D(fp, cnt++, xu[ii], minWidth, len, height_offset, 0.0);
     max_x = xu[ii] + minWidth;
   }


### PR DESCRIPTION
The implementation of `extSolverGen::writeWirePatterns()` had two main issues:
1. Incorrect Middle Wire Selection: The logic for identifying the middle wire was hardcoded, leading to incorrect pattern generation when the total wire count varied. (The middle wire was always the 3rd wire.) 
2. Inaccurate Wire Spacing: An error in calculating the spacing between the middle wire and its left neighbor resulted in inconsistent wire distances.

To fix these, the following changes were made:

- The x coordinate for the left neighbor's starting point (`xd[1]`) has been corrected.
- `For` loops for left and right neighbors are now dynamically adjusted to correctly account for the total number of wires. This involved using `_wireCnt` directly to calculate appropriate loop bounds.