### PR TITLE
jenkins: bazelisk, not bazel should be used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ def getParallelTests(String image) {
                     stage('Bazel Build') {
                         withCredentials([file(credentialsId: 'bazel-cache-sa', variable: 'GCS_SA_KEY')]) {
                             timeout(time: 120, unit: 'MINUTES') {
-                                def bazelCommand = 'bazel test --config=ci --show_timestamps --test_output=errors --curses=no --force_pic'
+                                def bazelCommand = 'bazelisk test --config=ci --show_timestamps --test_output=errors --curses=no --force_pic'
 
                                 if (env.BRANCH_NAME != 'master') {
                                     bazelCommand += ' --remote_upload_local_results=false'


### PR DESCRIPTION
This makes it more obvious that bazelisk is used, which will read in .bazelversion and use the right version.

As it happens, bazel seems to be mapped to bazelisk in this server setup, but I can't know that from reading the local code, so I think using bazelisk is an improvement: it leaves me with fewer questions.

@QuantamHD @hzeller Thoughts?

I came across this as I was trying to figure out why a test [works locally and fails in CI](https://github.com/The-OpenROAD-Project/OpenROAD/pull/7722#issuecomment-3038635102)

