### PR TITLE
Revert "jenkins: bazelisk, not bazel should be used" until bazelisk is installed.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ def getParallelTests(String image) {
                     stage('Bazel Build') {
                         withCredentials([file(credentialsId: 'bazel-cache-sa', variable: 'GCS_SA_KEY')]) {
                             timeout(time: 120, unit: 'MINUTES') {
-                                def bazelCommand = 'bazelisk test --config=ci --show_timestamps --test_output=errors --curses=no --force_pic'
+                                def bazelCommand = 'bazel test --config=ci --show_timestamps --test_output=errors --curses=no --force_pic'
 
                                 if (env.BRANCH_NAME != 'master') {
                                     bazelCommand += ' --remote_upload_local_results=false'


### PR DESCRIPTION
Reverts The-OpenROAD-Project/OpenROAD#7723