### PR TITLE
gui: fix flipped negative buckets

### DIFF
--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -414,7 +414,7 @@ void HistogramView::populateBuckets(
   for (int bin = 0; bin < histogram_->getBinsCount(); bin++) {
     const auto& [bin_start, bin_end] = histogram_->getBinRange(bin);
     if ((bin_start + bin_end) / 2 < 0) {
-      buckets_.negative.push_front(pin_bins[bin]);
+      buckets_.negative.push_back(pin_bins[bin]);
     } else {
       buckets_.positive.push_back(pin_bins[bin]);
     }


### PR DESCRIPTION
Resolve #7721

The charts-based timing report is accurate in the sense that the we're getting the correct data when asking STA for the slack of a certain group of pins. The real problem seems to be that the negative part of the histogram is flipped.

What we see:
<img src="https://github.com/user-attachments/assets/a26b7724-9303-4df4-91c6-0cc203096b42" width="400">

What we should we:
<img src="https://github.com/user-attachments/assets/d989431f-164f-4847-859f-93ddf3b00674" width="400">

Apparently, some code that takes care of sorting the data when generating the bins was added to the charts, so we don't need to front push when populating the negative buckets as we used to.

Also, if we look at the `report` version of the histogram, we see that the data is logged correctly:
<img src="https://github.com/user-attachments/assets/144716cc-c4ca-4266-ad67-2a8f7ae34494" width="400">
