### PR TITLE
Cts: add option skip nets

### DIFF
--- a/src/cts/README.md
+++ b/src/cts/README.md
@@ -69,6 +69,7 @@ clock_tree_synthesis
     [-library liberty_library_name]
     [-repair_clock_nets]
     [-no_insertion_delay]
+    [-skip_nets <list_of_clk_nets_to_skip>]
 ```
 
 #### Options
@@ -99,6 +100,7 @@ clock_tree_synthesis
 | `-library` | This option specifies the name of Liberty library from which clock buffers will be selected, such as the LVT or uLVT library.  It is assumed that the library has already been loaded using the read_liberty command.  If this option is not specified, clock buffers will be chosen from the currently loaded libraries, which may not include LVT or uLVT cells. |
 | `-repair_clock_nets` | This option includes fixing long wires inside CTS prior to latency adjustment with delay buffers. This can lead to a more balanced clock tree.  The default is not to perform clock net repair. |
 | `-no_insertion_delay` | Ignore sink insertion delay in clock tree construction and balancing. |
+| `-skip_nets` | String containing the names of the clock nets to be skipped. If the net is a root clock net, the whole clock is skipped, otherwise only the subnet specified is skipped. |
 
 #### Instance Name Prefixes
 

--- a/src/cts/include/cts/TritonCTS.h
+++ b/src/cts/include/cts/TritonCTS.h
@@ -66,6 +66,7 @@ class TritonCTS
   CtsOptions* getParms() { return options_; }
   TechChar* getCharacterization() { return techChar_.get(); }
   int setClockNets(const char* names);
+  int setSkipNets(const char* names);
   void setBufferList(const char* buffers);
   void setRootBuffer(const char* buffers);
   void setSinkBuffer(const char* buffers);

--- a/src/cts/src/CtsOptions.h
+++ b/src/cts/src/CtsOptions.h
@@ -107,10 +107,7 @@ class CtsOptions : public odb::dbBlockCallBackObj
     clockNetsObjs_ = nets;
   }
   std::vector<odb::dbNet*> getClockNetsObjs() const { return clockNetsObjs_; }
-  void setSkipNets(const std::vector<odb::dbNet*>& nets)
-  {
-    skipNets_ = nets;
-  }
+  void setSkipNets(const std::vector<odb::dbNet*>& nets) { skipNets_ = nets; }
   std::vector<odb::dbNet*> getSkipNets() const { return skipNets_; }
   void setMetricsFile(const std::string& metricFile)
   {

--- a/src/cts/src/CtsOptions.h
+++ b/src/cts/src/CtsOptions.h
@@ -107,6 +107,11 @@ class CtsOptions : public odb::dbBlockCallBackObj
     clockNetsObjs_ = nets;
   }
   std::vector<odb::dbNet*> getClockNetsObjs() const { return clockNetsObjs_; }
+  void setSkipNets(const std::vector<odb::dbNet*>& nets)
+  {
+    skipNets_ = nets;
+  }
+  std::vector<odb::dbNet*> getSkipNets() const { return skipNets_; }
   void setMetricsFile(const std::string& metricFile)
   {
     metricFile_ = metricFile;
@@ -312,6 +317,7 @@ class CtsOptions : public odb::dbBlockCallBackObj
   unsigned numStaticLayers_ = 0;
   std::vector<std::string> bufferList_;
   std::vector<odb::dbNet*> clockNetsObjs_;
+  std::vector<odb::dbNet*> skipNets_;
   utl::Logger* logger_ = nullptr;
   stt::SteinerTreeBuilder* sttBuilder_ = nullptr;
   bool obsAware_ = true;

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -291,8 +291,12 @@ void TritonCTS::initOneClockTree(odb::dbNet* driverNet,
   if (driverNet->isSpecial()) {
     logger_->info(
         CTS, 116, "Special net \"{}\" skipped.", driverNet->getName());
-  } else if(std::find(skipNets.begin(), skipNets.end(), driverNet) != skipNets.end()) {
-    logger_->warn(CTS, 44, "Skipping net {}, specified by the user...", driverNet->getName());
+  } else if (std::find(skipNets.begin(), skipNets.end(), driverNet)
+             != skipNets.end()) {
+    logger_->warn(CTS,
+                  44,
+                  "Skipping net {}, specified by the user...",
+                  driverNet->getName());
   } else {
     clockBuilder = initClock(driverNet, clkInputNet, sdcClockName, parent);
   }
@@ -1770,8 +1774,11 @@ void TritonCTS::findClockRoots(sta::Clock* clk,
     odb::dbModITerm* moditerm;
     network_->staToDb(pin, instTerm, port, moditerm);
     odb::dbNet* net = instTerm ? instTerm->getNet() : port->getNet();
-    if(std::find(skipNets.begin(), skipNets.end(), net) != skipNets.end()) {
-      logger_->warn(CTS, 42, "Skipping root net {}, specified by the user...", net->getName());
+    if (std::find(skipNets.begin(), skipNets.end(), net) != skipNets.end()) {
+      logger_->warn(CTS,
+                    42,
+                    "Skipping root net {}, specified by the user...",
+                    net->getName());
       continue;
     }
     clockNets.insert(net);

--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -287,9 +287,12 @@ void TritonCTS::initOneClockTree(odb::dbNet* driverNet,
                                  TreeBuilder* parent)
 {
   TreeBuilder* clockBuilder = nullptr;
+  std::vector<odb::dbNet*> skipNets = options_->getSkipNets();
   if (driverNet->isSpecial()) {
     logger_->info(
         CTS, 116, "Special net \"{}\" skipped.", driverNet->getName());
+  } else if(std::find(skipNets.begin(), skipNets.end(), driverNet) != skipNets.end()) {
+    logger_->warn(CTS, 44, "Skipping net {}, specified by the user...", driverNet->getName());
   } else {
     clockBuilder = initClock(driverNet, clkInputNet, sdcClockName, parent);
   }
@@ -1768,7 +1771,7 @@ void TritonCTS::findClockRoots(sta::Clock* clk,
     network_->staToDb(pin, instTerm, port, moditerm);
     odb::dbNet* net = instTerm ? instTerm->getNet() : port->getNet();
     if(std::find(skipNets.begin(), skipNets.end(), net) != skipNets.end()) {
-      logger_->warn(CTS, 42, "Skipping net {}, specified by the user ...", net->getName());
+      logger_->warn(CTS, 42, "Skipping root net {}, specified by the user...", net->getName());
       continue;
     }
     clockNets.insert(net);

--- a/src/cts/src/TritonCTS.i
+++ b/src/cts/src/TritonCTS.i
@@ -192,6 +192,12 @@ set_clock_nets(const char* names)
   return getTritonCts()->setClockNets(names);
 }
 
+int
+set_skip_clock_nets(const char* names)
+{
+  return getTritonCts()->setSkipNets(names);
+}
+
 void
 set_buffer_list(const char* buffers)
 {

--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -62,7 +62,8 @@ sta::define_cmd_args "clock_tree_synthesis" {[-wire_unit unit]
                                              [-delay_buffer_derate] \
                                              [-library] \
                                              [-repair_clock_nets] \
-                                             [-no_insertion_delay]
+                                             [-no_insertion_delay] \
+                                             [-skip_nets]
 } ;# checker off
 
 proc clock_tree_synthesis { args } {
@@ -73,7 +74,7 @@ proc clock_tree_synthesis { args } {
           -clustering_exponent \
           -clustering_unbalance_ratio -sink_clustering_max_diameter \
           -macro_clustering_size -macro_clustering_max_diameter \
-          -sink_clustering_levels -tree_buf \
+          -sink_clustering_levels -tree_buf -skip_nets\
           -sink_buffer_max_cap_derate -delay_buffer_derate -library} \
     flags {-post_cts_disable -sink_clustering_enable -balance_levels \
            -obstruction_aware -no_obstruction_aware -apply_ndr \
@@ -162,6 +163,14 @@ proc clock_tree_synthesis { args } {
     set fail [cts::set_clock_nets $clk_nets]
     if { $fail } {
       utl::error CTS 56 "Error when finding -clk_nets in DB."
+    }
+  }
+
+  if { [info exists keys(-skip_nets)] } {
+    set clk_nets $keys(-skip_nets)
+    set fail [cts::set_skip_clock_nets $clk_nets]
+    if { $fail } {
+      utl::error CTS 57 "Error when finding -skip_nets in DB."
     }
   }
 


### PR DESCRIPTION
Fixes [#7655](https://github.com/The-OpenROAD-Project/OpenROAD/issues/7655)

Add the user option to skip clock tree synthesis for a set of nets: `skip_nets`.

The option receives a string containing the names of the nets that CTS should skip.

  1. If a specified net is the root net for the clock, it will skip the clock tree synthesis for all the sub-nets as well.
  2. If a specified net is a sub-net, it will only skip this net.