### PR TITLE
Fix segfault when parsing a corrupt def file

### DIFF
--- a/src/odb/src/def/def/defrData.hpp
+++ b/src/odb/src/def/def/defrData.hpp
@@ -128,7 +128,7 @@ class defrData
   int componentWarnings{0};
   int constraintWarnings{0};
   int cover_is_keyword{0};
-  int defMsgCnt{0};
+  int defMsgCnt{5500};
   int defMsgPrinted{0};  // number of msgs output so far
   int defRetVal{0};
   int def_warnings{0};


### PR DESCRIPTION
DEF error numbers are handled by the defError function with an offset of 5000.

However, the defyyerror function uses the `defMsgCnt` attribute, which is initialized at 0, causing an out-of-bounds access.

According to the `def.y` file, yyerror error codes start at 5500, so the fix is imply to initialize the `defMsgCnt` variable to this value