### PR TITLE
Remove useless _update field and add CHECKBLOCK for units

### DIFF
--- a/src/odb/src/defin/definReader.cpp
+++ b/src/odb/src/defin/definReader.cpp
@@ -250,8 +250,6 @@ void definReader::init()
   make(_non_default_ruleR);
   make(_prop_defsR);
   make(_pin_propsR);
-
-  _update = false;
 }
 
 void definReader::setTech(dbTech* tech)
@@ -1491,6 +1489,7 @@ int definReader::unitsCallback(DefParser::defrCallbackType_e type,
                                DefParser::defiUserData data)
 {
   definReader* reader = (definReader*) data;
+  CHECKBLOCK
 
   // Truncation error
   if (d > reader->_tech->getDbUnitsPerMicron()) {
@@ -1509,9 +1508,7 @@ int definReader::unitsCallback(DefParser::defrCallbackType_e type,
     (*itr)->units(d);
   }
 
-  if (!reader->_update) {
-    reader->_block->setDefUnits(d);
-  }
+  reader->_block->setDefUnits(d);
   return PARSE_OK;
 }
 

--- a/src/odb/src/defin/definReader.h
+++ b/src/odb/src/defin/definReader.h
@@ -242,7 +242,6 @@ class definReader : public definBase
   std::unique_ptr<definPropDefs> _prop_defsR;
   std::unique_ptr<definPinProps> _pin_propsR;
   std::vector<definBase*> _interfaces;
-  bool _update{false};
   bool _continue_on_errors{false};
   std::string _block_name;
   std::string version_;


### PR DESCRIPTION
The `_update` field of the reader is never updated and can thus be safely removed.

The `setTech` callback doesn't have a CHECKBLOCK and thus segfaults if called before the design is set