### PR TITLE
gui: avoid pre-filling with (0,0) points

### DIFF
--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1102,7 +1102,7 @@ void RenderThread::drawBlock(QPainter* painter,
   odb::Polygon die_area = block->getDieAreaPolygon();
 
   if (die_area.getEnclosingRect().area() > 0) {
-    QPolygon die_area_qpoly(die_area.getPoints().size());
+    QPolygon die_area_qpoly;
     for (const odb::Point& point : die_area.getPoints()) {
       die_area_qpoly << QPoint(point.getX(), point.getY());
     }


### PR DESCRIPTION
GSOC intern @gs-chaitanya is working on implementing rectlinear floorplans. [During his work we noticed a bug](https://github.com/gs-chaitanya/OpenROAD/tree/scanline_based_rows), we get a DIE horizontal line going to the origin (0,0) even though the die does not touch the origin:
<img width="672" height="485" alt="Screenshot from 2025-07-14 12-48-50" src="https://github.com/user-attachments/assets/f1bffb62-f70b-463d-bb87-818a868f0ca0" />


This PR fixes this issue. I noticed QPolygon initialization is pre-filling its values with multiple (0,0) values, we end up getting double the objects we would need: 
```
  QPolygon[0]: (0, 0)
  QPolygon[1]: (0, 0)
  QPolygon[2]: (0, 0)
  QPolygon[3]: (0, 0)
  QPolygon[4]: (0, 0)
  QPolygon[5]: (0, 0)
  QPolygon[6]: (0, 0)
  QPolygon[7]: (0, 0)
  QPolygon[8]: (0, 0)
  QPolygon[9]: (300000, 20000)
  QPolygon[10]: (300000, 400000)
  QPolygon[11]: (20000, 400000)
  QPolygon[12]: (20000, 600000)
  QPolygon[13]: (800000, 600000)
  QPolygon[14]: (800000, 400000)
  QPolygon[15]: (500000, 400000)
  QPolygon[16]: (500000, 20000)
  QPolygon[17]: (300000, 20000)
```

Changing the constructor we use, we get the expected values only:
```
  QPolygonF[0]: (300000.000, 20000.000)
  QPolygonF[1]: (300000.000, 400000.000)
  QPolygonF[2]: (20000.000, 400000.000)
  QPolygonF[3]: (20000.000, 600000.000)
  QPolygonF[4]: (800000.000, 600000.000)
  QPolygonF[5]: (800000.000, 400000.000)
  QPolygonF[6]: (500000.000, 400000.000)
  QPolygonF[7]: (500000.000, 20000.000)
  QPolygonF[8]: (300000.000, 20000.000)
```
Finally, with the fix we get:
<img width="672" height="485" alt="Screenshot from 2025-07-14 13-36-43" src="https://github.com/user-attachments/assets/7dd96300-6284-433f-a103-d62c9d1f6690" />
