### PR TITLE
Avoid a stack use after scope

### DIFF
--- a/src/ant/src/WireBuilder.cc
+++ b/src/ant/src/WireBuilder.cc
@@ -331,8 +331,12 @@ bool WireBuilder::pinOverlapsGSegment(const odb::Point& pin_position,
     for (const GuideSegment& seg : route) {
       if (seg.pt1.layer == seg.pt2.layer &&  // ignore vias
           seg.pt1.layer == pin_layer) {
-        auto [x0, x1] = std::minmax(seg.pt1.pos.getX(), seg.pt2.pos.getX());
-        auto [y0, y1] = std::minmax(seg.pt1.pos.getY(), seg.pt2.pos.getY());
+        auto pt1_x = seg.pt1.pos.getX();
+        auto pt1_y = seg.pt1.pos.getY();
+        auto pt2_x = seg.pt2.pos.getX();
+        auto pt2_y = seg.pt2.pos.getY();
+        auto [x0, x1] = std::minmax(pt1_x, pt2_x);
+        auto [y0, y1] = std::minmax(pt1_y, pt2_y);
         odb::Rect seg_rect(x0, y0, x1, y1);
 
         if (box.intersects(seg_rect)) {

--- a/src/ant/src/WireBuilder.cc
+++ b/src/ant/src/WireBuilder.cc
@@ -331,12 +331,8 @@ bool WireBuilder::pinOverlapsGSegment(const odb::Point& pin_position,
     for (const GuideSegment& seg : route) {
       if (seg.pt1.layer == seg.pt2.layer &&  // ignore vias
           seg.pt1.layer == pin_layer) {
-        auto pt1_x = seg.pt1.pos.getX();
-        auto pt1_y = seg.pt1.pos.getY();
-        auto pt2_x = seg.pt2.pos.getX();
-        auto pt2_y = seg.pt2.pos.getY();
-        auto [x0, x1] = std::minmax(pt1_x, pt2_x);
-        auto [y0, y1] = std::minmax(pt1_y, pt2_y);
+        auto [x0, x1] = std::minmax({seg.pt1.pos.getX(), seg.pt2.pos.getX()});
+        auto [y0, y1] = std::minmax({seg.pt1.pos.getY(), seg.pt2.pos.getY()});
         odb::Rect seg_rect(x0, y0, x1, y1);
 
         if (box.intersects(seg_rect)) {

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -761,17 +761,15 @@ void GlobalRouter::deleteSegment(Net* net, GRoute& segments, const int seg_id)
     bool is_horizontal = (seg.init_x != seg.final_x);
     bool is_vertical = (seg.init_y != seg.final_y);
     const int tile_size = grid_->getTileSize();
-    // For some reason I do not understand using [auto min_x, min_y] sometimes
-    // break here
-    std::pair<int, int> x_bound
-        = std::minmax((int) ((seg.init_x - grid_->getXMin()) / tile_size),
-                      (int) ((seg.final_x - grid_->getXMin()) / tile_size));
-    std::pair<int, int> y_bound
-        = std::minmax((int) ((seg.init_y - grid_->getYMin()) / tile_size),
-                      (int) ((seg.final_y - grid_->getYMin()) / tile_size));
-    int x0 = x_bound.first, y0 = y_bound.first;
+    auto [x0, max_x]
+        = std::minmax({(int) ((seg.init_x - grid_->getXMin()) / tile_size),
+                       (int) ((seg.final_x - grid_->getXMin()) / tile_size)});
 
-    while (x0 <= x_bound.second && y0 <= y_bound.second) {
+    auto [y0, max_y]
+        = std::minmax({(int) ((seg.init_y - grid_->getYMin()) / tile_size),
+                       (int) ((seg.final_y - grid_->getYMin()) / tile_size)});
+
+    while (x0 <= max_x && y0 <= max_y) {
       const int x1 = x0 + (is_horizontal ? 1 : 0);
       const int y1 = y0 + (is_vertical ? 1 : 0);
       const int edge_cap


### PR DESCRIPTION
std::minmax returns references, so the arguments need to have a valid allocation