### PR TITLE
gpl:l debug avoid issue

### DIFF
--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -75,6 +75,7 @@ class Replace
   void setBinGridCnt(int binGridCntX, int binGridCntY);
 
   void setTargetDensity(float density);
+  // Execute gpl with uniform density as target density
   void setUniformTargetDensityMode(bool mode);
   void setTargetOverflow(float overflow);
   void setInitDensityPenalityFactor(float penaltyFactor);
@@ -82,6 +83,7 @@ class Replace
   void setMinPhiCoef(float minPhiCoef);
   void setMaxPhiCoef(float maxPhiCoef);
 
+  // Query for uniform density value
   float getUniformTargetDensity(int threads);
 
   // HPWL: half-parameter wire length.

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -98,12 +98,6 @@ void Replace::reset()
   timingNetWeightOverflows_.clear();
   timingNetWeightOverflows_.shrink_to_fit();
   timingNetWeightMax_ = 5;
-
-  gui_debug_ = false;
-  gui_debug_pause_iterations_ = 10;
-  gui_debug_update_iterations_ = 10;
-  gui_debug_draw_bins_ = false;
-  gui_debug_initial_ = false;
 }
 
 void Replace::addPlacementCluster(const Cluster& cluster)
@@ -440,6 +434,7 @@ void Replace::setUniformTargetDensityMode(bool mode)
 
 float Replace::getUniformTargetDensity(int threads)
 {
+  log_->info(GPL, 22, "Initialize gpl and calculate uniform density.");
   // TODO: update to be compatible with multiple target densities
   if (initNesterovPlace(threads)) {
     return nbVec_[0]->uniformTargetDensity();

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -435,11 +435,15 @@ void Replace::setUniformTargetDensityMode(bool mode)
 float Replace::getUniformTargetDensity(int threads)
 {
   log_->info(GPL, 22, "Initialize gpl and calculate uniform density.");
-  // TODO: update to be compatible with multiple target densities
+  log_->redirectStringBegin();
+
+  float density = 1.0f;
   if (initNesterovPlace(threads)) {
-    return nbVec_[0]->uniformTargetDensity();
+    density = nbVec_[0]->uniformTargetDensity();
   }
-  return 1;
+
+  std::string _ = log_->redirectStringEnd();
+  return density;
 }
 
 void Replace::setInitDensityPenalityFactor(float penaltyFactor)

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -3,7 +3,7 @@
 [INFO ODB-0130]     Created 54 pins.
 [INFO ODB-0131]     Created 294 components and 1656 component-terminals.
 [INFO ODB-0133]     Created 364 nets and 1068 connections.
-[INFO GPL-0022] Calculating uniform density.
+[INFO GPL-0022] Initialize gpl and calculate uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
@@ -30,7 +30,7 @@
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
 pad : 0 -> 0.600
-[INFO GPL-0022] Calculating uniform density.
+[INFO GPL-0022] Initialize gpl and calculate uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
@@ -57,7 +57,7 @@ pad : 0 -> 0.600
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
 pad : 1 -> 0.770
-[INFO GPL-0022] Calculating uniform density.
+[INFO GPL-0022] Initialize gpl and calculate uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -4,85 +4,10 @@
 [INFO ODB-0131]     Created 294 components and 1656 component-terminals.
 [INFO ODB-0133]     Created 364 nets and 1068 connections.
 [INFO GPL-0022] Initialize gpl and calculate uniform density.
-[INFO GPL-0002] DBU: 2000
-[INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
-[INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0006] Number of instances:               294
-[INFO GPL-0007] Movable instances:                 294
-[INFO GPL-0008] Fixed instances:                     0
-[INFO GPL-0009] Dummy instances:                     0
-[INFO GPL-0010] Number of nets:                    364
-[INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
-[INFO GPL-0017] Fixed instances area:            0.000 um^2
-[INFO GPL-0018] Movable instances area:        569.772 um^2
-[INFO GPL-0019] Utilization:                    59.732 %
-[INFO GPL-0020] Standard cells area:           569.772 um^2
-[INFO GPL-0021] Large instances area:            0.000 um^2
-[INFO GPL-0023] Placement target density:       1.0000
-[INFO GPL-0024] Movable insts average area:      1.938 um^2
-[INFO GPL-0025] Ideal bin area:                  1.938 um^2
-[INFO GPL-0026] Ideal bin count:                   492
-[INFO GPL-0027] Total bin area:                953.876 um^2
-[INFO GPL-0028] Bin count (X, Y):          16 ,     16
-[INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
-[INFO GPL-0030] Number of bins:                    256
 pad : 0 -> 0.600
 [INFO GPL-0022] Initialize gpl and calculate uniform density.
-[INFO GPL-0002] DBU: 2000
-[INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
-[INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0006] Number of instances:               294
-[INFO GPL-0007] Movable instances:                 294
-[INFO GPL-0008] Fixed instances:                     0
-[INFO GPL-0009] Dummy instances:                     0
-[INFO GPL-0010] Number of nets:                    364
-[INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
-[INFO GPL-0017] Fixed instances area:            0.000 um^2
-[INFO GPL-0018] Movable instances area:        726.180 um^2
-[INFO GPL-0019] Utilization:                    76.129 %
-[INFO GPL-0020] Standard cells area:           726.180 um^2
-[INFO GPL-0021] Large instances area:            0.000 um^2
-[INFO GPL-0023] Placement target density:       1.0000
-[INFO GPL-0024] Movable insts average area:      2.470 um^2
-[INFO GPL-0025] Ideal bin area:                  2.470 um^2
-[INFO GPL-0026] Ideal bin count:                   386
-[INFO GPL-0027] Total bin area:                953.876 um^2
-[INFO GPL-0028] Bin count (X, Y):          16 ,     16
-[INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
-[INFO GPL-0030] Number of bins:                    256
 pad : 1 -> 0.770
 [INFO GPL-0022] Initialize gpl and calculate uniform density.
-[INFO GPL-0002] DBU: 2000
-[INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
-[INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0006] Number of instances:               294
-[INFO GPL-0007] Movable instances:                 294
-[INFO GPL-0008] Fixed instances:                     0
-[INFO GPL-0009] Dummy instances:                     0
-[INFO GPL-0010] Number of nets:                    364
-[INFO GPL-0011] Number of pins:                   1122
-[INFO GPL-0012] Die BBox:  (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0013] Core BBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
-[INFO GPL-0016] Core area:                     953.876 um^2
-[INFO GPL-0017] Fixed instances area:            0.000 um^2
-[INFO GPL-0018] Movable instances area:        882.588 um^2
-[INFO GPL-0019] Utilization:                    92.526 %
-[INFO GPL-0020] Standard cells area:           882.588 um^2
-[INFO GPL-0021] Large instances area:            0.000 um^2
-[INFO GPL-0023] Placement target density:       1.0000
-[INFO GPL-0024] Movable insts average area:      3.002 um^2
-[INFO GPL-0025] Ideal bin area:                  3.002 um^2
-[INFO GPL-0026] Ideal bin count:                   317
-[INFO GPL-0027] Total bin area:                953.876 um^2
-[INFO GPL-0028] Bin count (X, Y):          16 ,     16
-[INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
-[INFO GPL-0030] Number of bins:                    256
 pad : 2 -> 0.930
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -3,6 +3,7 @@
 [INFO ODB-0130]     Created 54 pins.
 [INFO ODB-0131]     Created 294 components and 1656 component-terminals.
 [INFO ODB-0133]     Created 364 nets and 1068 connections.
+[INFO GPL-0022] Calculating uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
@@ -29,6 +30,7 @@
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
 pad : 0 -> 0.600
+[INFO GPL-0022] Calculating uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um
@@ -55,6 +57,7 @@ pad : 0 -> 0.600
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
 pad : 1 -> 0.770
+[INFO GPL-0022] Calculating uniform density.
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
 [INFO GPL-0004] CoreBBox: (  0.000  0.000 ) ( 30.970 30.800 ) um


### PR DESCRIPTION
This PR addresses issue https://github.com/The-OpenROAD-Project/OpenROAD/issues/6619, where gui debug mode was not stopping for some designs. 

The cause of the issue was the usage of TCL command `place_density_with_lb_addon`, which calls `Replace::getUniformTargetDensity()` (side note: this function is interesting because it constructs gpl objects only to calculate the uniform density). I understand objects will be reconstructed for the "normal" gpl call afterwards, so there is no point printing all initialization log messages for the uniform density query.

The debug issue was avoided by not reseting the replace debug attributes at `Replace::reset()`.
