### PR TITLE
gui: add option to force drawing of flywires even when routing it present

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -515,6 +515,7 @@ DisplayControls::DisplayControls(QWidget* parent)
   makeLeafItem(
       misc_.manufacturing_grid, "Manufacturing grid", misc, Qt::Unchecked);
   makeLeafItem(misc_.gcell_grid, "GCell grid", misc, Qt::Unchecked);
+  makeLeafItem(misc_.flywires_only, "Flywires only", misc, Qt::Unchecked);
   makeLeafItem(misc_.labels, "Labels", misc, Qt::Checked, true);
   setNameItemDoubleClickAction(misc_.labels, [this]() {
     label_font_
@@ -1858,6 +1859,11 @@ bool DisplayControls::isModuleView() const
 bool DisplayControls::isGCellGridVisible() const
 {
   return isModelRowVisible(&misc_.gcell_grid);
+}
+
+bool DisplayControls::isFlywireHighlightOnly() const
+{
+  return isModelRowVisible(&misc_.flywires_only);
 }
 
 bool DisplayControls::areIOPinsVisible() const

--- a/src/gui/src/displayControls.h
+++ b/src/gui/src/displayControls.h
@@ -243,6 +243,7 @@ class DisplayControls : public QDockWidget,
   bool isModuleView() const override;
 
   bool isGCellGridVisible() const override;
+  bool isFlywireHighlightOnly() const override;
 
   // API from dbNetworkObserver
   void postReadLiberty() override;
@@ -378,6 +379,7 @@ class DisplayControls : public QDockWidget,
     ModelRow module;
     ModelRow manufacturing_grid;
     ModelRow gcell_grid;
+    ModelRow flywires_only;
     ModelRow labels;
     ModelRow background;
   };

--- a/src/gui/src/options.h
+++ b/src/gui/src/options.h
@@ -87,6 +87,7 @@ class Options
   virtual bool isModuleView() const = 0;
 
   virtual bool isGCellGridVisible() const = 0;
+  virtual bool isFlywireHighlightOnly() const = 0;
 };
 
 }  // namespace gui


### PR DESCRIPTION
Adds:
- option to show flywires instead of routing during highlighting (while working on #7833 I found this useful).

No functional changes.