### PR TITLE
gui: use guides for net highlighting when available

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -216,6 +216,7 @@ class Painter
 
   // Draw a line with coordinates in DBU with the current pen
   virtual void drawLine(const odb::Point& p1, const odb::Point& p2) = 0;
+  void drawLine(const odb::Line& line) { drawLine(line.pt0(), line.pt1()); }
 
   // Draw a circle with coordinates in DBU with the current pen
   virtual void drawCircle(int x, int y, int r) = 0;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1430,10 +1430,13 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
           }
         }
 
+        std::vector<odb::Rect> guide_rects;
+        guide_rects.reserve(guides.size());
         for (const auto* guide : guides) {
           const auto& box = guide->getBox();
           const auto center = box.center();
           const int width_half = box.minDXDY() / 2;
+          guide_rects.push_back(box);
           odb::Point p0, p1;
           switch (box.getDir()) {
             case 0: {
@@ -1494,6 +1497,11 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
         }
 
         painter.restoreState();
+
+        // draw outlines of guides
+        for (const odb::Polygon& outline : odb::Polygon::merge(guide_rects)) {
+          painter.drawPolygon(outline);
+        }
       }
     }
   }

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1114,9 +1114,9 @@ void DbNetDescriptor::findSourcesAndSinksInGraph(
   sink_nodes.insert(sinks_nodes.begin(), sinks_nodes.end());
 }
 
-void DbNetDescriptor::drawPathSegment(odb::dbNet* net,
-                                      const odb::dbObject* sink,
-                                      Painter& painter) const
+void DbNetDescriptor::drawPathSegmentWithGraph(odb::dbNet* net,
+                                               const odb::dbObject* sink,
+                                               Painter& painter) const
 {
   odb::dbWireGraph graph;
   graph.decode(net->getWire());
@@ -1482,7 +1482,7 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
     if (wire) {
       draw_flywires = false;
       if (sink_object != nullptr) {
-        drawPathSegment(net, sink_object, painter);
+        drawPathSegmentWithGraph(net, sink_object, painter);
       }
 
       odb::dbWireShapeItr it;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1657,7 +1657,7 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
         painter.saveState();
         Painter::Color highlight_color = painter.getPenColor();
         highlight_color.a = 255;
-        painter.setPen(highlight_color, true, 4);
+        painter.setPen(highlight_color, true, 2);
 
         DbTargets sources;
         DbTargets sinks;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1499,9 +1499,12 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
         painter.restoreState();
 
         // draw outlines of guides
+        painter.saveState();
+        painter.setBrush(painter.getPenColor(), gui::Painter::Brush::kNone);
         for (const odb::Polygon& outline : odb::Polygon::merge(guide_rects)) {
           painter.drawPolygon(outline);
         }
+        painter.restoreState();
       }
     }
   }

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -180,6 +180,8 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
   using NodeMap = std::map<const Node*, NodeList>;
   using GraphTarget = std::pair<const odb::Rect, const odb::dbTechLayer*>;
 
+  std::set<odb::Line> convertGuidesToLines(odb::dbNet* net) const;
+
   void drawPathSegment(odb::dbNet* net,
                        const odb::dbObject* sink,
                        Painter& painter) const;

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -178,13 +178,23 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
   using Node = odb::dbWireGraph::Node;
   using NodeList = std::set<const Node*>;
   using NodeMap = std::map<const Node*, NodeList>;
+  using PointList = std::set<odb::Point>;
+  using PointMap = std::map<odb::Point, PointList>;
   using GraphTarget = std::pair<const odb::Rect, const odb::dbTechLayer*>;
+  using DbTargets = std::map<const odb::dbObject*, std::set<odb::Point>>;
 
-  std::set<odb::Line> convertGuidesToLines(odb::dbNet* net) const;
+  std::set<odb::Line> convertGuidesToLines(odb::dbNet* net,
+                                           DbTargets& sources,
+                                           DbTargets& sinks) const;
 
   void drawPathSegmentWithGraph(odb::dbNet* net,
                                 const odb::dbObject* sink,
                                 Painter& painter) const;
+  void drawPathSegmentWithGuides(const std::set<odb::Line>& lines,
+                                 DbTargets& sources,
+                                 DbTargets& sinks,
+                                 const odb::dbObject* sink,
+                                 Painter& painter) const;
   void findSourcesAndSinksInGraph(odb::dbNet* net,
                                   const odb::dbObject* sink,
                                   odb::dbWireGraph* graph,
@@ -197,6 +207,10 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
   void findPath(NodeMap& graph,
                 const Node* source,
                 const Node* sink,
+                std::vector<odb::Point>& path) const;
+  void findPath(PointMap& graph,
+                const odb::Point& source,
+                const odb::Point& sink,
                 std::vector<odb::Point>& path) const;
 
   void buildNodeMap(odb::dbWireGraph* graph, NodeMap& node_map) const;

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -182,9 +182,9 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
 
   std::set<odb::Line> convertGuidesToLines(odb::dbNet* net) const;
 
-  void drawPathSegment(odb::dbNet* net,
-                       const odb::dbObject* sink,
-                       Painter& painter) const;
+  void drawPathSegmentWithGraph(odb::dbNet* net,
+                                const odb::dbObject* sink,
+                                Painter& painter) const;
   void findSourcesAndSinksInGraph(odb::dbNet* net,
                                   const odb::dbObject* sink,
                                   odb::dbWireGraph* graph,

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -327,9 +327,10 @@ class Polygon
   // returns a corrected Polygon with a closed form and counter-clockwise points
   Polygon bloat(int margin) const;
 
-  // Merge a collection of vectors
+  // Merge a collection of shapes
   static std::vector<Polygon> merge(const std::vector<Polygon>& polys);
   static std::vector<Polygon> merge(const std::vector<Rect>& rects);
+  static std::vector<Polygon> merge(const std::vector<Oct>& octs);
 
   // Returns the geometric difference between this polygon "a" and polygon "b"
   // results in a vector of polygons.

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -327,6 +327,10 @@ class Polygon
   // returns a corrected Polygon with a closed form and counter-clockwise points
   Polygon bloat(int margin) const;
 
+  // Merge a collection of vectors
+  static std::vector<Polygon> merge(const std::vector<Polygon>& polys);
+  static std::vector<Polygon> merge(const std::vector<Rect>& rects);
+
   // Returns the geometric difference between this polygon "a" and polygon "b"
   // results in a vector of polygons.
   std::vector<Polygon> difference(Polygon b) const;

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -48,6 +48,47 @@ Polygon Polygon::bloat(int margin) const
   return Polygon(new_coord);
 }
 
+std::vector<Polygon> Polygon::merge(const std::vector<Rect>& rects)
+{
+  std::vector<Polygon> polys(rects.begin(), rects.end());
+  return Polygon::merge(polys);
+}
+
+std::vector<Polygon> Polygon::merge(const std::vector<Polygon>& polys)
+{
+  // convert to native boost types to avoid needed a mutable access
+  // to odb::Polygon
+  using BoostPolygon = boost::polygon::polygon_data<int>;
+  using BoostPolygonSet = boost::polygon::polygon_set_data<int>;
+  using boost::polygon::operators::operator+=;
+  using boost::polygon::operators::operator+;
+
+  // add to polygon set
+  BoostPolygonSet poly_in_set;
+
+  for (const Polygon& poly : polys) {
+    // convert to boost polygon
+    const BoostPolygon polygon_in(poly.points_.begin(), poly.points_.end());
+    poly_in_set += polygon_in;
+  }
+
+  // extract new polygons
+  std::vector<BoostPolygon> output_polygons;
+  poly_in_set.get(output_polygons);
+
+  std::vector<Polygon> out_polys;
+  for (const BoostPolygon& out_poly : output_polygons) {
+    std::vector<odb::Point> new_coord;
+    new_coord.reserve(out_poly.coords_.size());
+    for (const auto& pt : out_poly.coords_) {
+      new_coord.emplace_back(pt.x(), pt.y());
+    }
+    out_polys.emplace_back(new_coord);
+  }
+
+  return out_polys;
+}
+
 std::vector<Polygon> Polygon::difference(Polygon b) const
 {
   // convert to native boost types to avoid needed a mutable access

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -82,6 +82,7 @@ std::vector<Polygon> Polygon::merge(const std::vector<Polygon>& polys)
   poly_in_set.get(output_polygons);
 
   std::vector<Polygon> out_polys;
+  out_polys.reserve(output_polygons.size());
   for (const BoostPolygon& out_poly : output_polygons) {
     std::vector<odb::Point> new_coord;
     new_coord.reserve(out_poly.coords_.size());

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -61,7 +61,6 @@ std::vector<Polygon> Polygon::merge(const std::vector<Polygon>& polys)
   using BoostPolygon = boost::polygon::polygon_data<int>;
   using BoostPolygonSet = boost::polygon::polygon_set_data<int>;
   using boost::polygon::operators::operator+=;
-  using boost::polygon::operators::operator+;
 
   // add to polygon set
   BoostPolygonSet poly_in_set;

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -48,6 +48,12 @@ Polygon Polygon::bloat(int margin) const
   return Polygon(new_coord);
 }
 
+std::vector<Polygon> Polygon::merge(const std::vector<Oct>& octs)
+{
+  std::vector<Polygon> polys(octs.begin(), octs.end());
+  return Polygon::merge(polys);
+}
+
 std::vector<Polygon> Polygon::merge(const std::vector<Rect>& rects)
 {
   std::vector<Polygon> polys(rects.begin(), rects.end());


### PR DESCRIPTION
Closes #7833

Adds:
- odb::Polygon merge functions to merge sets of shapes into a set of polygons
- gui::Painter add drawLine to take in a odb::Line.

Changes:
- when detailed routing information is available it will be used for highlighting, when guides are available it will be used, and finally flywires will be used if neither is available (in that order)

Notes:
- This code will draw the outline of the guide boxes and use the centerline of the box to represent the routing with a "flywire" connecting the center line to the iterm or bpins.
- The center line is drawn with two pixels (or 4 seemed like good numbers, 4 is a more clear, but I left it 2 for now), 1 pixel was nearly impossible to see what was going on.
- The "fatness" of the routing in the examples stem from the routing box outlines and don't seem to be impacted by the centerline with that much.

Examples:
Clock routing before for cva6:
<img width="1099" height="1099" alt="cva6 core_clock_before" src="https://github.com/user-attachments/assets/2c6ea8ee-a73d-4738-a684-cec2373d0da1" />
After for cva6:
<img width="1099" height="1099" alt="cva6 core_clock" src="https://github.com/user-attachments/assets/e1da5b5f-058c-4dff-a6b8-5e87824eecd3" />


Clock routing before for ethmac:
<img width="1099" height="1099" alt="ethmac wb_clk_i" src="https://github.com/user-attachments/assets/15652d67-d4f9-4b6d-b6fe-e68d531da6bb" />
After for ethmac:
<img width="1099" height="1099" alt="ethmac wb_clk_i" src="https://github.com/user-attachments/assets/96b1f98e-71bd-4ff9-957a-8bbdb22f3997" />

Timepath drawing:
<img width="1564" height="1253" alt="image" src="https://github.com/user-attachments/assets/bffe32bc-7c6e-42ba-9d8b-7dc9b6281817" />

Selecting a single net:
<img width="1564" height="1253" alt="image" src="https://github.com/user-attachments/assets/e2e665d5-c7ca-432e-a705-5646e8848b62" />

