### PR TITLE
pad: add check for empty call to place_io_terminals

### DIFF
--- a/src/pad/src/pad.tcl
+++ b/src/pad/src/pad.tcl
@@ -349,6 +349,10 @@ proc place_io_terminals { args } {
     keys {} \
     flags {-allow_non_top_layer}
 
+  if { [llength $args] == 0 } {
+    utl::error PAD 8 "place_io_terminals requires atleast one terminal"
+  }
+
   set iterms []
   foreach pin [get_pins {*}$args] {
     lappend iterms [sta::sta_to_db_pin $pin]

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -20,6 +20,7 @@ COMPULSORY_TESTS = [
     "non_top_layer",
     "place_bondpad",
     "place_bondpad_stagger",
+    "place_io_terminals_empty_call",
     "place_pad",
     "place_pad_hv",
     "place_pad_no_master",

--- a/src/pad/test/CMakeLists.txt
+++ b/src/pad/test/CMakeLists.txt
@@ -17,6 +17,7 @@ or_integration_tests(
     non_top_layer
     place_bondpad
     place_bondpad_stagger
+    place_io_terminals_empty_call
     place_pad
     place_pad_hv
     place_pad_no_master

--- a/src/pad/test/place_io_terminals_empty_call.ok
+++ b/src/pad/test/place_io_terminals_empty_call.ok
@@ -1,0 +1,100 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_10um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_10um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_1um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_1um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_20um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_20um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_5um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_5um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__corner_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__corner_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__disconnect_vccd_slice_5um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__disconnect_vccd_slice_5um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__disconnect_vdda_slice_5um.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__disconnect_vdda_slice_5um.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__gpiov2_pad_wrapped.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__gpiov2_pad_wrapped.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vccd_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vccd_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vccd_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vccd_lvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vdda_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vdda_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vdda_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vdda_lvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vddio_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vddio_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vddio_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vddio_lvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssa_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssa_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssa_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssa_lvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssd_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssd_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssd_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssd_lvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssio_hvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssio_hvc_pad.lef, created 1 library cells
+[WARNING ODB-0220] WARNING (LEFPARS-2008): NOWIREEXTENSIONATPIN statement is obsolete in version 5.6 or later.
+The NOWIREEXTENSIONATPIN statement will be ignored. See file skywater130_io_ef/lef/sky130_ef_io__vssio_lvc_pad.lef at line 2.
+
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_ef_io__vssio_lvc_pad.lef, created 1 library cells
+[INFO ODB-0227] LEF file: skywater130_io_ef/lef/sky130_fd_io__top_xres4v2.lef, created 1 library cells
+[WARNING ORD-2011] LEF master sky130_ef_io__gpiov2_pad_wrapped has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__corner_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vccd_lvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vdda_hvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vddio_hvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vssa_hvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vssd_lvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_ef_io__vssio_hvc_pad has no liberty cell.
+[WARNING ORD-2011] LEF master sky130_fd_io__top_xres4v2 has no liberty cell.
+[WARNING IFP-0028] Core area lower left (250.000, 250.000) snapped to (250.240, 250.240).
+[INFO IFP-0001] Added 1723 rows of 6712 site unithd.
+[ERROR PAD-0008] place_io_terminals requires atleast one terminal
+PAD-0008

--- a/src/pad/test/place_io_terminals_empty_call.tcl
+++ b/src/pad/test/place_io_terminals_empty_call.tcl
@@ -1,0 +1,42 @@
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_10um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_1um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_20um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__com_bus_slice_5um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__corner_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__disconnect_vccd_slice_5um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__disconnect_vdda_slice_5um.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__gpiov2_pad_wrapped.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vccd_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vccd_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vdda_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vdda_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vddio_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vddio_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssa_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssa_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssd_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssd_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssio_hvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_ef_io__vssio_lvc_pad.lef
+read_lef skywater130_io_ef/lef/sky130_fd_io__top_xres4v2.lef
+
+read_liberty skywater130_io_ef/lib/sky130_dummy_io.lib
+read_liberty sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib
+
+read_verilog skywater130_caravel/chip.v
+link_design chip_io
+
+initialize_floorplan \
+  -die_area "0 0 3588 5188" \
+  -core_area "250 250 3338 4938" \
+  -site unithd
+
+make_tracks
+
+catch { place_io_terminals } err
+puts $err


### PR DESCRIPTION
Changes:
- checks if the arguments are empty for `place_io_terminals`