### PR TITLE
gui: minor fixes to guide code

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1642,18 +1642,22 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
       if (!guides.empty()) {
         draw_flywires = false;
 
-        // draw outlines of guides
-        std::vector<odb::Rect> guide_rects;
-        guide_rects.reserve(guides.size());
-        for (const auto* guide : guides) {
-          guide_rects.push_back(guide->getBox());
+        if (guides.begin()->getBox().minDXDY() * painter.getPixelsPerDBU()
+            >= kMinGuidePixelWidth) {
+          // draw outlines of guides, dont draw if less that kMinGuidePixelWidth
+          // pixels
+          std::vector<odb::Rect> guide_rects;
+          guide_rects.reserve(guides.size());
+          for (const auto* guide : guides) {
+            guide_rects.push_back(guide->getBox());
+          }
+          painter.saveState();
+          painter.setBrush(painter.getPenColor(), gui::Painter::Brush::kNone);
+          for (const odb::Polygon& outline : odb::Polygon::merge(guide_rects)) {
+            painter.drawPolygon(outline);
+          }
+          painter.restoreState();
         }
-        painter.saveState();
-        painter.setBrush(painter.getPenColor(), gui::Painter::Brush::kNone);
-        for (const odb::Polygon& outline : odb::Polygon::merge(guide_rects)) {
-          painter.drawPolygon(outline);
-        }
-        painter.restoreState();
 
         painter.saveState();
         Painter::Color highlight_color = painter.getPenColor();

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -222,6 +222,7 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
   odb::dbObject* getSink(const std::any& object) const;
 
   static const int kMaxIterms = 10000;
+  static constexpr double kMinGuidePixelWidth = 10.0;
 };
 
 class DbITermDescriptor : public BaseDbDescriptor<odb::dbITerm>


### PR DESCRIPTION
Changes:
- avoids missing segments when attempting to draw the timing path that were occurring when the flywire snapped to the center.
- Dont draw guide outlines when less than 10 pixels wide (mentioned in #7852 )

Before:
<img width="1631" height="1408" alt="image" src="https://github.com/user-attachments/assets/2cdf0f33-7dc3-423b-aa92-921f21059cd2" />

After:
<img width="1631" height="1408" alt="image" src="https://github.com/user-attachments/assets/5fc4a310-b6a9-4ca5-8bdc-29e66ea70350" />
