### PR TITLE
gui: expose clock depth to swig interface

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -691,7 +691,8 @@ class Gui
                           const std::string& corner = "",
                           int width_px = 0,
                           int height_px = 0);
-  void selectClockviewerClock(const std::string& clock_name);
+  void selectClockviewerClock(const std::string& clock_name,
+                              std::optional<int> depth);
 
   // Save histogram view
   void saveHistogramImage(const std::string& filename,

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -152,6 +152,10 @@ void ClockTreeRenderer::resetTree()
 
 void ClockTreeRenderer::setMaxColorDepth(int depth)
 {
+  if (max_depth_ < 1) {
+    return;
+  }
+
   max_depth_ = depth;
   redraw();
 }
@@ -1651,7 +1655,8 @@ void ClockWidget::postReadLiberty()
   }
 }
 
-void ClockWidget::selectClock(const std::string& clock_name)
+void ClockWidget::selectClock(const std::string& clock_name,
+                              std::optional<int> depth)
 {
   setVisible(true);
 
@@ -1662,6 +1667,9 @@ void ClockWidget::selectClock(const std::string& clock_name)
   for (auto& view : views_) {
     if (view->getClockName() == clock_name) {
       clocks_tab_->setCurrentWidget(view.get());
+      if (depth) {
+        view->updateColorDepth(*depth);
+      }
 
       return;
     }

--- a/src/gui/src/clockWidget.cpp
+++ b/src/gui/src/clockWidget.cpp
@@ -152,7 +152,7 @@ void ClockTreeRenderer::resetTree()
 
 void ClockTreeRenderer::setMaxColorDepth(int depth)
 {
-  if (max_depth_ < 1) {
+  if (depth < 1) {
     return;
   }
 

--- a/src/gui/src/clockWidget.h
+++ b/src/gui/src/clockWidget.h
@@ -404,12 +404,12 @@ class ClockTreeView : public QGraphicsView
   void setRendererState(RendererState state);
   void fit();
   void save(const QString& path = "");
+  void updateColorDepth(int depth);
 
  private slots:
   void selectionChanged();
   void highlightTo(odb::dbITerm* term);
   void clearHighlightTo();
-  void updateColorDepth(int depth);
 
  protected:
   void wheelEvent(QWheelEvent* event) override;
@@ -516,7 +516,8 @@ class ClockWidget : public QDockWidget, sta::dbNetworkObserver
                  const std::string& corner,
                  const std::optional<int>& width_px,
                  const std::optional<int>& height_px);
-  void selectClock(const std::string& clock_name);
+  void selectClock(const std::string& clock_name,
+                   std::optional<int> depth = {});
 
   void postReadLiberty() override;
 

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -832,12 +832,13 @@ void Gui::saveHistogramImage(const std::string& filename,
       filename, chart_mode, width, height);
 }
 
-void Gui::selectClockviewerClock(const std::string& clock_name)
+void Gui::selectClockviewerClock(const std::string& clock_name,
+                                 std::optional<int> depth)
 {
   if (!enabled()) {
     return;
   }
-  main_window->getClockViewer()->selectClock(clock_name);
+  main_window->getClockViewer()->selectClock(clock_name, depth);
 }
 
 static QWidget* findWidget(const std::string& name)

--- a/src/gui/src/gui.i
+++ b/src/gui/src/gui.i
@@ -310,13 +310,17 @@ void save_clocktree_image(const char* filename, const char* clock_name, const ch
   gui->saveClockTreeImage(clock_name, filename, corner, width_px, height_px);
 }
 
-void select_clockviewer_clock(const char* clock_name)
+void select_clockviewer_clock(const char* clock_name, int depth = 0)
 {
   if (!check_gui("select_clockviewer_clock")) {
     return;
   }
   auto gui = gui::Gui::get();
-  gui->selectClockviewerClock(clock_name);
+  std::optional<int> clock_depth;
+  if (depth > 0) {
+    clock_depth = depth;
+  }
+  gui->selectClockviewerClock(clock_name, clock_depth);
 }
 
 void save_histogram_image(const char* filename, const char* mode, int width_px = 0, int height_px = 0)


### PR DESCRIPTION
Adds:
- clock tree depth to the swig interface, this proved useful when working on the guide routing drawing.

Notes:
- there is no tcl interface to this functionality at this time, if we want to add that we can do it in a separate PR.