### PR TITLE
gui: call resize once

### DIFF
--- a/src/gui/src/browserWidget.cpp
+++ b/src/gui/src/browserWidget.cpp
@@ -100,6 +100,7 @@ BrowserWidget::BrowserWidget(
       view_(new QTreeView(this)),
       model_(new QStandardItemModel(this)),
       model_modified_(false),
+      initial_load_(true),
       ignore_selection_(false),
       menu_(new QMenu(this))
 {
@@ -382,7 +383,10 @@ void BrowserWidget::updateModel()
   }
   addInstanceItems(insts, "Physical only", root);
 
-  view_->header()->resizeSections(QHeaderView::ResizeToContents);
+  if (initial_load_) {
+    view_->header()->resizeSections(QHeaderView::ResizeToContents);
+    initial_load_ = false;
+  }
   model_modified_ = false;
   setUpdatesEnabled(true);
   view_->setSortingEnabled(true);

--- a/src/gui/src/browserWidget.h
+++ b/src/gui/src/browserWidget.h
@@ -114,6 +114,7 @@ class BrowserWidget : public QDockWidget,
   QTreeView* view_;
   QStandardItemModel* model_;
   bool model_modified_;
+  bool initial_load_;
 
   bool ignore_selection_;
 


### PR DESCRIPTION
Changes:
- only resizeColumns on first load.

Should solve: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3342

@jeffng-or please check if this resolves your issue. In my testing it seems to handle correctly.