### PR TITLE
rsz: Caching drive resistance value.

### DIFF
--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1394,7 +1394,7 @@ void Rebuffer::init()
     buffer_sizes_.push_back(BufferSize{
         cell,
         FixedDelay(out->intrinsicDelay(sta_)),
-        /*intrinsic_delay=*/0.0f,
+        /*margined_max_cap=*/0.0f,
         out->driveResistance(),
     });
   }

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -385,20 +385,10 @@ bool Rebuffer::bufferSizeCanDriveLoad(const BufferSize& size,
   size.cell->bufferPorts(inp, outp);
 
   const float extra_cap = resizer_->dbuToMeters(extra_wire_length) * wire_cap
-                          + outp->capacitance();
-
-  // Cache the value of drive resistance since it's expensive to calculate.
-  float r_drvr;
-  auto it_drive_resistance = drive_resistance_cache_.find(outp);
-  if (it_drive_resistance != drive_resistance_cache_.end()) {
-    r_drvr = it_drive_resistance->second;
-  } else {
-    r_drvr = outp->driveResistance();
-    drive_resistance_cache_[outp] = r_drvr;
-  }
+                          + outp->capacitance();  
 
   const float load_slew
-      = (r_drvr
+      = (size.driver_resistance
          + resizer_->dbuToMeters(bnet->maxLoadWireLength() + extra_wire_length)
                * wire_res)
         * (bnet->cap() + extra_cap) * elmore_skew_factor_;
@@ -1404,7 +1394,8 @@ void Rebuffer::init()
     buffer_sizes_.push_back(BufferSize{
         cell,
         FixedDelay(out->intrinsicDelay(sta_)),
-        0.0f,
+        /*intrinsic_delay=*/0.0f,
+        out->driveResistance(),
     });
   }
 

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -385,7 +385,7 @@ bool Rebuffer::bufferSizeCanDriveLoad(const BufferSize& size,
   size.cell->bufferPorts(inp, outp);
 
   const float extra_cap = resizer_->dbuToMeters(extra_wire_length) * wire_cap
-                          + outp->capacitance();  
+                          + outp->capacitance();
 
   const float load_slew
       = (size.driver_resistance

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -386,7 +386,17 @@ bool Rebuffer::bufferSizeCanDriveLoad(const BufferSize& size,
 
   const float extra_cap = resizer_->dbuToMeters(extra_wire_length) * wire_cap
                           + outp->capacitance();
-  const float r_drvr = outp->driveResistance();
+
+  // Cache the value of drive resistance since it's expensive to calculate.
+  float r_drvr;
+  auto it_drive_resistance = drive_resistance_cache_.find(outp);
+  if (it_drive_resistance != drive_resistance_cache_.end()) {
+    r_drvr = it_drive_resistance->second;
+  } else {
+    r_drvr = outp->driveResistance();
+    drive_resistance_cache_[outp] = r_drvr;
+  }
+
   const float load_slew
       = (r_drvr
          + resizer_->dbuToMeters(bnet->maxLoadWireLength() + extra_wire_length)

--- a/src/rsz/src/Rebuffer.hh
+++ b/src/rsz/src/Rebuffer.hh
@@ -138,6 +138,7 @@ class Rebuffer : public sta::dbStaState
 
   std::vector<BufferSize> buffer_sizes_;
   std::map<LibertyCell*, BufferSize*> buffer_sizes_index_;
+  std::unordered_map<LibertyPort*, float> drive_resistance_cache_;
 
   Pin* pin_;
   float fanout_limit_;

--- a/src/rsz/src/Rebuffer.hh
+++ b/src/rsz/src/Rebuffer.hh
@@ -123,6 +123,7 @@ class Rebuffer : public sta::dbStaState
     LibertyCell* cell;
     FixedDelay intrinsic_delay;
     float margined_max_cap;
+    float driver_resistance;
   };
 
   bool bufferSizeCanDriveLoad(const BufferSize& size,
@@ -138,7 +139,6 @@ class Rebuffer : public sta::dbStaState
 
   std::vector<BufferSize> buffer_sizes_;
   std::map<LibertyCell*, BufferSize*> buffer_sizes_index_;
-  std::unordered_map<LibertyPort*, float> drive_resistance_cache_;
 
   Pin* pin_;
   float fanout_limit_;


### PR DESCRIPTION
Calculating drive resistance takes about 2.8 hours of the currently 30 hour runtime of our block. It's very expensive to calculate so we should cache it.

<img width="937" height="834" alt="image" src="https://github.com/user-attachments/assets/f04bedbc-2bdd-4df6-9a00-e2f16660fea9" />
