### PR TITLE
gpl: rename variables for PlacerBase

### DIFF
--- a/src/gpl/src/graphics.cpp
+++ b/src/gpl/src/graphics.cpp
@@ -115,7 +115,7 @@ void Graphics::initHeatmap()
 void Graphics::drawBounds(gui::Painter& painter)
 {
   // draw core bounds
-  auto& die = pbc_->die();
+  auto& die = pbc_->getDie();
   painter.setPen(gui::Painter::kYellow, /* cosmetic */ true);
   painter.drawLine(die.coreLx(), die.coreLy(), die.coreUx(), die.coreLy());
   painter.drawLine(die.coreUx(), die.coreLy(), die.coreUx(), die.coreUy());

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -1161,7 +1161,7 @@ void NesterovPlace::createGNet(odb::dbNet* db_net)
   if (!isValidSigType(netType)) {
     return;
   }
-  nbc_->createCbkGNet(db_net, pbc_->skipIoMode());
+  nbc_->createCbkGNet(db_net, pbc_->isSkipIoMode());
 }
 
 void NesterovPlace::destroyCbkGNet(odb::dbNet* db_net)

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -755,28 +755,28 @@ void PlacerBaseCommon::init()
   dbBlock* block = db_->getChip()->getBlock();
 
   // die-core area update
-  odb::dbSite* site = nullptr;
+  odb::dbSite* db_site = nullptr;
   for (auto* row : block->getRows()) {
     if (row->getSite()->getClass() != odb::dbSiteClass::PAD) {
-      site = row->getSite();
+      db_site = row->getSite();
       break;
     }
   }
-  if (site == nullptr) {
+  if (db_site == nullptr) {
     log_->error(GPL, 305, "Unable to find a site");
   }
-  odb::Rect coreRect = block->getCoreArea();
-  odb::Rect dieRect = block->getDieArea();
+  odb::Rect core_rect = block->getCoreArea();
+  odb::Rect die_rect = block->getDieArea();
 
-  if (!dieRect.contains(coreRect)) {
+  if (!die_rect.contains(core_rect)) {
     log_->error(GPL, 118, "core area outside of die.");
   }
 
-  die_ = Die(dieRect, coreRect);
+  die_ = Die(die_rect, core_rect);
 
   // siteSize update
-  siteSizeX_ = site->getWidth();
-  siteSizeY_ = site->getHeight();
+  siteSizeX_ = db_site->getWidth();
+  siteSizeY_ = db_site->getHeight();
 
   log_->info(GPL,
              3,
@@ -803,7 +803,7 @@ void PlacerBaseCommon::init()
       continue;
     }
 
-    Instance myInst(db_inst, this, log_);
+    Instance temp_inst(db_inst, this, log_);
     odb::dbBox* inst_bbox = db_inst->getBBox();
     if (inst_bbox->getDY() > die_.coreDy()) {
       log_->error(GPL,
@@ -821,53 +821,53 @@ void PlacerBaseCommon::init()
     // Fixed instaces need to be snapped outwards to the nearest site
     // boundary.  A partially overlapped site is unusable and this
     // is the simplest way to ensure it is counted as fully used.
-    if (myInst.isFixed()) {
-      myInst.snapOutward(coreRect.ll(), siteSizeX_, siteSizeY_);
+    if (temp_inst.isFixed()) {
+      temp_inst.snapOutward(core_rect.ll(), siteSizeX_, siteSizeY_);
     }
 
-    instStor_.push_back(myInst);
+    instStor_.push_back(temp_inst);
 
-    if (myInst.dy() > siteSizeY_ * 6) {
-      macroInstsArea_ += myInst.area();
+    if (temp_inst.dy() > siteSizeY_ * 6) {
+      macroInstsArea_ += temp_inst.area();
     }
   }
 
-  for (auto& inst : instStor_) {
-    instMap_[inst.dbInst()] = &inst;
-    insts_.push_back(&inst);
+  for (auto& pb_inst : instStor_) {
+    instMap_[pb_inst.dbInst()] = &pb_inst;
+    insts_.push_back(&pb_inst);
 
-    if (!inst.isFixed()) {
-      placeInsts_.push_back(&inst);
+    if (!pb_inst.isFixed()) {
+      placeInsts_.push_back(&pb_inst);
     }
   }
 
   // nets fill
-  dbSet<dbNet> nets = block->getNets();
-  netStor_.reserve(nets.size());
-  for (dbNet* net : nets) {
-    dbSigType netType = net->getSigType();
+  dbSet<dbNet> db_nets = block->getNets();
+  netStor_.reserve(db_nets.size());
+  for (dbNet* db_net : db_nets) {
+    dbSigType net_type = db_net->getSigType();
 
     // escape nets with VDD/VSS/reset nets
-    if (netType == dbSigType::SIGNAL || netType == dbSigType::CLOCK) {
-      Net myNet(net, pbVars_.skipIoMode);
-      netStor_.push_back(myNet);
+    if (net_type == dbSigType::SIGNAL || net_type == dbSigType::CLOCK) {
+      Net temp_net(db_net, pbVars_.skipIoMode);
+      netStor_.push_back(temp_net);
 
       // this is safe because of "reserve"
-      Net* myNetPtr = &netStor_[netStor_.size() - 1];
-      netMap_[net] = myNetPtr;
+      Net* temp_net_ptr = &netStor_[netStor_.size() - 1];
+      netMap_[db_net] = temp_net_ptr;
 
-      for (dbITerm* iTerm : net->getITerms()) {
-        Pin myPin(iTerm);
-        myPin.setNet(myNetPtr);
-        myPin.setInstance(dbToPb(iTerm->getInst()));
-        pinStor_.push_back(myPin);
+      for (dbITerm* iTerm : db_net->getITerms()) {
+        Pin temp_pin(iTerm);
+        temp_pin.setNet(temp_net_ptr);
+        temp_pin.setInstance(dbToPb(iTerm->getInst()));
+        pinStor_.push_back(temp_pin);
       }
 
       if (pbVars_.skipIoMode == false) {
-        for (dbBTerm* bTerm : net->getBTerms()) {
-          Pin myPin(bTerm, log_);
-          myPin.setNet(myNetPtr);
-          pinStor_.push_back(myPin);
+        for (dbBTerm* bTerm : db_net->getBTerms()) {
+          Pin temp_pin(bTerm, log_);
+          temp_pin.setNet(temp_net_ptr);
+          pinStor_.push_back(temp_pin);
         }
       }
     }
@@ -875,44 +875,44 @@ void PlacerBaseCommon::init()
 
   // pinMap_ and pins_ update
   pins_.reserve(pinStor_.size());
-  for (auto& pin : pinStor_) {
-    if (pin.isITerm()) {
-      pinMap_[pin.getDbITerm()] = &pin;
-    } else if (pin.isBTerm()) {
-      pinMap_[pin.getDbBTerm()] = &pin;
+  for (auto& pb_pin : pinStor_) {
+    if (pb_pin.isITerm()) {
+      pinMap_[pb_pin.getDbITerm()] = &pb_pin;
+    } else if (pb_pin.isBTerm()) {
+      pinMap_[pb_pin.getDbBTerm()] = &pb_pin;
     }
-    pins_.push_back(&pin);
+    pins_.push_back(&pb_pin);
   }
 
   // instStor_'s pins_ fill
-  for (auto& inst : instStor_) {
-    if (!inst.isInstance()) {
+  for (auto& pb_inst : instStor_) {
+    if (!pb_inst.isInstance()) {
       continue;
     }
-    for (dbITerm* iTerm : inst.dbInst()->getITerms()) {
+    for (dbITerm* iTerm : pb_inst.dbInst()->getITerms()) {
       // note that, DB's ITerm can have
       // VDD/VSS pins.
       //
       // Escape those pins
-      Pin* curPin = dbToPb(iTerm);
-      if (curPin) {
-        inst.addPin(curPin);
+      Pin* cur_pin = dbToPb(iTerm);
+      if (cur_pin) {
+        pb_inst.addPin(cur_pin);
       }
     }
   }
 
   // nets' pin update
   nets_.reserve(netStor_.size());
-  for (auto& net : netStor_) {
-    for (dbITerm* iTerm : net.getDbNet()->getITerms()) {
-      net.addPin(dbToPb(iTerm));
+  for (auto& pb_net : netStor_) {
+    for (dbITerm* iTerm : pb_net.getDbNet()->getITerms()) {
+      pb_net.addPin(dbToPb(iTerm));
     }
     if (pbVars_.skipIoMode == false) {
-      for (dbBTerm* bTerm : net.getDbNet()->getBTerms()) {
-        net.addPin(dbToPb(bTerm));
+      for (dbBTerm* bTerm : pb_net.getDbNet()->getBTerms()) {
+        pb_net.addPin(dbToPb(bTerm));
       }
     }
-    nets_.push_back(&net);
+    nets_.push_back(&pb_net);
   }
 }
 

--- a/src/gpl/src/placerBase.h
+++ b/src/gpl/src/placerBase.h
@@ -92,10 +92,10 @@ class Instance
   int64_t area() const;
 
   void setExtId(int extId);
-  int extId() const { return extId_; }
+  int getExtId() const { return extId_; }
 
   void addPin(Pin* pin);
-  const std::vector<Pin*>& pins() const { return pins_; }
+  const std::vector<Pin*>& getPins() const { return pins_; }
   void snapOutward(const odb::Point& origin, int step_x, int step_y);
 
  private:
@@ -118,8 +118,8 @@ class Pin
   Pin(odb::dbBTerm* bTerm, utl::Logger* logger);
   ~Pin();
 
-  odb::dbITerm* dbITerm() const;
-  odb::dbBTerm* dbBTerm() const;
+  odb::dbITerm* getDbITerm() const;
+  odb::dbBTerm* getDbBTerm() const;
 
   bool isITerm() const;
   bool isBTerm() const;
@@ -142,8 +142,8 @@ class Pin
   int cx() const;
   int cy() const;
 
-  int offsetCx() const;
-  int offsetCy() const;
+  int getOffsetCx() const;
+  int getOffsetCy() const;
 
   void updateLocation(const Instance* inst);
 
@@ -152,8 +152,8 @@ class Pin
 
   bool isPlaceInstConnected() const;
 
-  Instance* instance() const { return inst_; }
-  Net* net() const { return net_; }
+  Instance* getInstance() const { return inst_; }
+  Net* getNet() const { return net_; }
   std::string getName() const;
 
   void updateCoordi(odb::dbITerm* iTerm);
@@ -200,13 +200,13 @@ class Net
   int cy() const;
 
   // HPWL: half-parameter-wire-length
-  int64_t hpwl() const;
+  int64_t getHpwl() const;
 
   void updateBox(bool skipIoMode = false);
 
-  const std::vector<Pin*>& pins() const { return pins_; }
+  const std::vector<Pin*>& getPins() const { return pins_; }
 
-  odb::dbNet* dbNet() const { return net_; }
+  odb::dbNet* getDbNet() const { return net_; }
   odb::dbSigType getSigType() const;
 
   void addPin(Pin* pin);
@@ -286,11 +286,11 @@ class PlacerBaseCommon
   ~PlacerBaseCommon();
 
   const std::vector<Instance*>& placeInsts() const { return placeInsts_; }
-  const std::vector<Instance*>& insts() const { return insts_; }
-  const std::vector<Pin*>& pins() const { return pins_; }
-  const std::vector<Net*>& nets() const { return nets_; }
+  const std::vector<Instance*>& getInsts() const { return insts_; }
+  const std::vector<Pin*>& getPins() const { return pins_; }
+  const std::vector<Net*>& getNets() const { return nets_; }
 
-  Die& die() { return die_; }
+  Die& getDie() { return die_; }
 
   // Pb : PlacerBase
   Instance* dbToPb(odb::dbInst* inst) const;
@@ -301,14 +301,14 @@ class PlacerBaseCommon
   int siteSizeX() const { return siteSizeX_; }
   int siteSizeY() const { return siteSizeY_; }
 
-  int padLeft() const { return pbVars_.padLeft; }
-  int padRight() const { return pbVars_.padRight; }
-  bool skipIoMode() const { return pbVars_.skipIoMode; }
+  int getPadLeft() const { return pbVars_.padLeft; }
+  int getPadRight() const { return pbVars_.padRight; }
+  bool isSkipIoMode() const { return pbVars_.skipIoMode; }
 
-  int64_t hpwl() const;
+  int64_t getHpwl() const;
   void printInfo() const;
 
-  int64_t macroInstsArea() const { return macroInstsArea_; }
+  int64_t getMacroInstsArea() const { return macroInstsArea_; }
 
   odb::dbDatabase* db() const { return db_; }
 
@@ -357,7 +357,7 @@ class PlacerBase
              odb::dbGroup* group = nullptr);
   ~PlacerBase();
 
-  const std::vector<Instance*>& insts() const { return insts_; }
+  const std::vector<Instance*>& getInsts() const { return insts_; }
 
   //
   // placeInsts : a real instance that need to be placed
@@ -371,12 +371,12 @@ class PlacerBase
   const std::vector<Instance*>& dummyInsts() const { return dummyInsts_; }
   const std::vector<Instance*>& nonPlaceInsts() const { return nonPlaceInsts_; }
 
-  Die& die() { return die_; }
+  Die& getDie() { return die_; }
 
-  int siteSizeX() const { return siteSizeX_; }
-  int siteSizeY() const { return siteSizeY_; }
+  int getSiteSizeX() const { return siteSizeX_; }
+  int getSiteSizeY() const { return siteSizeY_; }
 
-  int64_t hpwl() const;
+  int64_t getHpwl() const;
   void printInfo() const;
 
   int64_t placeInstsArea() const { return placeInstsArea_; }

--- a/src/gpl/src/timingBase.cpp
+++ b/src/gpl/src/timingBase.cpp
@@ -154,7 +154,7 @@ bool TimingBase::executeTimingDriven(bool run_journal_restore)
     // default weight
     gNet->setTimingWeight(1.0);
     if (gNet->gPins().size() > 1) {
-      auto net_slack_opt = rs_->resizeNetSlack(gNet->net()->dbNet());
+      auto net_slack_opt = rs_->resizeNetSlack(gNet->net()->getDbNet());
       if (!net_slack_opt) {
         continue;
       }
@@ -177,7 +177,7 @@ bool TimingBase::executeTimingDriven(bool run_journal_restore)
                  "timing",
                  1,
                  "net:{} slack:{} weight:{}",
-                 gNet->net()->dbNet()->getConstName(),
+                 gNet->net()->getDbNet()->getConstName(),
                  net_slack,
                  gNet->totalWeight());
     }


### PR DESCRIPTION
Include the `get` prefix for some member functions of classes in PlacerBase.h. Also rename some internal variables at constructor `PlacerBaseCommon::PlacerBaseCommon()`