### PR TITLE
warn if gui was not built due to not finding qt5 explicitly

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -89,7 +89,11 @@ messages(
 )
 
 else()
-  message(STATUS "GUI is not enabled")
+  if(BUILD_GUI)
+    message(STATUS "QT5 not found. GUI is disabled")
+  else()
+    message(STATUS "GUI is not enabled")
+  endif()
   add_library(gui 
     src/stub.cpp 
     src/stub_heatMap.cpp


### PR DESCRIPTION
`etc/Build.sh` has an explicit option to disable the GUI. The message "GUI is not enabled" happening due to not having QT5 installed can be misleading (own experience). Warning the GUI was disabled due to the absence of QT5 makes the problem clearer. 