### PR TITLE
gui: use gcell centers for drawing routing

### DIFF
--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -1445,53 +1445,74 @@ std::set<odb::Line> DbNetDescriptor::convertGuidesToLines(
     }
   }
 
+  // Build gcell grid centers
+  std::vector<int> grid;
+  net->getBlock()->getGCellGrid()->getGridX(grid);
+  grid.push_back(net->getBlock()->getDieArea().xMax());
+  std::vector<int> x_grid;
+  x_grid.reserve(grid.size() - 1);
+  for (int i = 1; i < grid.size(); i++) {
+    x_grid.push_back((grid[i - 1] + grid[i]) / 2);
+  }
+
+  grid.clear();
+  net->getBlock()->getGCellGrid()->getGridY(grid);
+  grid.push_back(net->getBlock()->getDieArea().yMax());
+  std::vector<int> y_grid;
+  y_grid.reserve(grid.size() - 1);
+  for (int i = 1; i < grid.size(); i++) {
+    y_grid.push_back((grid[i - 1] + grid[i]) / 2);
+  }
+
   for (const auto* guide : guides) {
     const auto& box = guide->getBox();
-    const auto center = box.center();
-    const int width_half = box.minDXDY() / 2;
-    odb::Point p0, p1;
-    switch (box.getDir()) {
-      case 0: {
-        // DX < DY
-        p0 = odb::Point(center.x(), box.yMin() + width_half);
-        p1 = odb::Point(center.x(), box.yMax() - width_half);
+
+    std::vector<odb::Point> guide_pts;
+    for (const auto& x : x_grid) {
+      if (x < box.xMin()) {
+        continue;
+      }
+      if (x > box.xMax()) {
         break;
       }
-      case 1: {
-        p0 = odb::Point(box.xMin() + width_half, center.y());
-        p1 = odb::Point(box.xMax() - width_half, center.y());
-        break;
-      }
-      default: {
-        p0 = center;
-        p1 = center;
-        break;
+
+      for (const auto& y : y_grid) {
+        if (y < box.yMin()) {
+          continue;
+        }
+        if (y > box.yMax()) {
+          break;
+        }
+
+        guide_pts.emplace_back(x, y);
       }
     }
-    lines.emplace(p0, center);
-    lines.emplace(center, p1);
 
-    if (guide->isConnectedToTerm()) {
-      std::vector<odb::Point> anchors = {p0, center, p1};
+    std::sort(guide_pts.begin(), guide_pts.end());
+    for (int i = 1; i < guide_pts.size(); i++) {
+      lines.emplace(guide_pts[i - 1], guide_pts[i]);
+    }
 
-      auto find_term_connection = [&anchors, &lines, &io_map, &sources, &sinks](
-                                      odb::dbObject* dbterm,
-                                      const odb::Point& term) {
-        // draw shortest flywire
-        std::stable_sort(anchors.begin(),
-                         anchors.end(),
-                         [&term](const odb::Point& pt0, const odb::Point& pt1) {
-                           return odb::Point::manhattanDistance(term, pt0)
-                                  < odb::Point::manhattanDistance(term, pt1);
-                         });
-        lines.emplace(term, anchors[0]);
-        if (io_map[dbterm].is_sink) {
-          sinks[dbterm].insert(term);
-        }
-        if (io_map[dbterm].is_source) {
-          sources[dbterm].insert(term);
-        }
-      };
+    if (!guide_pts.empty() && guide->isConnectedToTerm()) {
+      auto find_term_connection
+          = [&guide_pts, &lines, &io_map, &sources, &sinks](
+                odb::dbObject* dbterm, const odb::Point& term) {
+              // draw shortest flywire
+              std::stable_sort(
+                  guide_pts.begin(),
+                  guide_pts.end(),
+                  [&term](const odb::Point& pt0, const odb::Point& pt1) {
+                    return odb::Point::manhattanDistance(term, pt0)
+                           < odb::Point::manhattanDistance(term, pt1);
+                  });
+              lines.emplace(term, guide_pts[0]);
+              if (io_map[dbterm].is_sink) {
+                sinks[dbterm].insert(term);
+              }
+              if (io_map[dbterm].is_source) {
+                sources[dbterm].insert(term);
+              }
+            };
 
       for (const auto& [obj, objbox] : terms[guide->getLayer()]) {
         std::vector<const odb::Rect*> candidates;


### PR DESCRIPTION
Issue:
- the code assumed the routing guides were more or less square, but that is not true at the edges and is not a requirement in the database. 
- this causes the guide routes to get drawn incorrectly.

Changes:
- use the center points of the gcells to build route of the guides.

Before:
<img width="1631" height="1408" alt="image" src="https://github.com/user-attachments/assets/ebad740e-1d08-40e5-92b5-adc83edff7b5" />

After:
<img width="1631" height="1408" alt="Pasted image" src="https://github.com/user-attachments/assets/31ebe365-7e28-4db4-9880-201a5fcee934" />
