### PR TITLE
gui: add descriptor for dbScanChain

### DIFF
--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -776,6 +776,24 @@ class DbScanPartitionDescriptor : public BaseDbDescriptor<odb::dbScanPartition>
       odb::dbScanPartition* scan_partition) const override;
 };
 
+class DbScanChainDescriptor : public BaseDbDescriptor<odb::dbScanChain>
+{
+ public:
+  DbScanChainDescriptor(odb::dbDatabase* db);
+
+  std::string getName(std::any object) const override;
+  std::string getTypeName() const override;
+
+  bool getBBox(std::any object, odb::Rect& bbox) const override;
+
+  void highlight(std::any object, Painter& painter) const override;
+
+  bool getAllObjects(SelectionSet& objects) const override;
+
+ protected:
+  Properties getDBProperties(odb::dbScanChain* scan_chain) const override;
+};
+
 class DbBoxDescriptor : public BaseDbDescriptor<odb::dbBox>
 {
  public:

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -565,6 +565,7 @@ void MainWindow::init(sta::dbSta* sta, const std::string& help_path)
   gui->registerDescriptor<odb::dbScanList*>(new DbScanListDescriptor(db_));
   gui->registerDescriptor<odb::dbScanPartition*>(
       new DbScanPartitionDescriptor(db_));
+  gui->registerDescriptor<odb::dbScanChain*>(new DbScanChainDescriptor(db_));
   gui->registerDescriptor<odb::dbBox*>(new DbBoxDescriptor(db_));
   gui->registerDescriptor<DbBoxDescriptor::BoxWithTransform>(
       new DbBoxDescriptor(db_));


### PR DESCRIPTION
Resolve #7740.

Obs: It looks like the Test Mode is not set for the dbScanChain object so I'm not including it as a descriptor property. Once we set it correctly we can revisit this and add it properly.