### PR TITLE
CTS: Add inverters in register tree

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -1239,8 +1239,12 @@ bool TritonCTS::separateMacroRegSinks(
 
     if (iterm->isInputSignal() && inst->isPlaced()) {
       odb::dbMTerm* mterm = iterm->getMTerm();
+      sta::Cell* masterCell = network_->dbToSta(mterm->getMaster());
+      sta::LibertyCell* libertyCell = network_->libertyCell(masterCell);
       // Treat clock gaters like macro sink
-      if (hasInsertionDelay(inst, mterm) || !isSink(iterm) || inst->isBlock()) {
+      if (hasInsertionDelay(inst, mterm)
+          || (!isSink(iterm) && !libertyCell->isInverter())
+          || inst->isBlock()) {
         macroSinks.emplace_back(inst, mterm);
       } else {
         registerSinks.emplace_back(inst, mterm);


### PR DESCRIPTION
Currently in CTS, inverters are part of the macro tree. Results, however results are beter when they are in the register tree.

eg.: sky130hd/uw:
master:
![master_uw_cts_jtag_tck](https://github.com/user-attachments/assets/e1e08c3b-3fef-49c2-b058-ffadd904d574)

inverters in register tree:
![my_uw_cts_jtag_tck](https://github.com/user-attachments/assets/31f0ca54-3c9e-4205-8365-e9b09728bae7)

