### PR TITLE
gui: fix the charts view hold with path_group filter

### DIFF
--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -907,8 +907,7 @@ StaPins STAGuiInterface::getEndPoints() const
 
 float STAGuiInterface::getPinSlack(const sta::Pin* pin) const
 {
-  return sta_->pinSlack(pin,
-                        use_max_ ? sta::MinMax::max() : sta::MinMax::min());
+  return sta_->pinSlack(pin, minMax());
 }
 
 std::set<std::string> STAGuiInterface::getGroupPathsNames() const
@@ -951,7 +950,7 @@ EndPointSlackMap STAGuiInterface::getEndPointToSlackMap(
   sta::VisitPathEnds visit_ends(sta_);
   sta::Search* search = sta_->search();
   sta::PathGroup* path_group
-      = search->findPathGroup(path_group_name.c_str(), sta::MinMax::max());
+      = search->findPathGroup(path_group_name.c_str(), minMax());
   PathGroupSlackEndVisitor path_group_visitor(path_group, sta_);
   for (sta::Vertex* vertex : *sta_->endpoints()) {
     visit_ends.visitPathEnds(vertex, &path_group_visitor);
@@ -1048,7 +1047,7 @@ TimingPathList STAGuiInterface::getTimingPaths(
           include_unconstrained_,
           // corner, min_max,
           corner_,
-          use_max_ ? sta::MinMaxAll::max() : sta::MinMaxAll::min(),
+          minMaxAll(),
           // group_count, endpoint_count, unique_pins
           max_path_count_,
           one_path_per_endpoint_ ? 1 : max_path_count_,

--- a/src/gui/src/staGuiInterface.h
+++ b/src/gui/src/staGuiInterface.h
@@ -321,6 +321,14 @@ class STAGuiInterface
 
   bool isUseMax() const { return use_max_; }
   void setUseMax(bool use_max) { use_max_ = use_max; }
+  const sta::MinMaxAll* minMaxAll() const
+  {
+    return use_max_ ? sta::MinMaxAll::max() : sta::MinMaxAll::min();
+  }
+  const sta::MinMax* minMax() const
+  {
+    return use_max_ ? sta::MinMax::max() : sta::MinMax::min();
+  }
 
   int getMaxPathCount() const { return max_path_count_; }
   void setMaxPathCount(int max_paths) { max_path_count_ = max_paths; }


### PR DESCRIPTION
The Charts View was always displaying the setup slack histogram when filtering by path_group.

Changes:
- Sends the correct argument to findPathGroup
  - sta::MinMax::max() when displaying setup slack
  - sta::MinMax::min() when displaying hold slack