### PR TITLE
utl: Fixes memory leak false positive with Google heap checker

### DIFF
--- a/src/utl/src/decode.cpp
+++ b/src/utl/src/decode.cpp
@@ -116,12 +116,15 @@ std::string base64_decode(const char* encoded_strings[])
 void evalTclInit(Tcl_Interp* interp, const char* inits[])
 {
   std::string unencoded = base64_decode(inits);
-  if (Tcl_Eval(interp, unencoded.c_str()) != TCL_OK) {
+  Tcl_Obj* obj = Tcl_NewStringObj(unencoded.c_str(), unencoded.size());
+  Tcl_IncrRefCount(obj);
+  if (Tcl_EvalObjEx(interp, obj, 0) != TCL_OK) {
     Tcl_Eval(interp, "$errorInfo");
     const char* tcl_err = Tcl_GetStringResult(interp);
     fprintf(stderr, "Error: TCL init script: %s.\n", tcl_err);
     exit(1);
   }
+  Tcl_DecrRefCount(obj);
 }
 
 }  // namespace utl


### PR DESCRIPTION
This is a weird one, but it seems like on ARM machines something about how TCL runs its arena allocator triggers false positive memory leak violations on internal presubmits. Not sure what the exact reason is, but the TCL docs say the old Tcl_Eval function is not preferred anyways.

It seems to only be triggered for large TCL scripts as none of the other Tcl_Eval functions trigger it. Would appreciate a merge here since it is identical functionality. 