### PR TITLE
odb: Fixing lef parsing error message

### DIFF
--- a/src/odb/src/lef/lef/lefrReader.cpp
+++ b/src/odb/src/lef/lef/lefrReader.cpp
@@ -1579,6 +1579,7 @@ void lefrUnsetReadFunction()
 {
   LEF_INIT;
   lefSettings->ReadFunction = nullptr;
+  init_call_func = nullptr;
 }
 
 // Set the maximum number of warnings


### PR DESCRIPTION
Fix` ERROR: Attempt to call configuration function 'lefrUnsetReadFunction' in LEF parser before lefrInit() call in session-based mode`. from lef parser when parsing multiple LEF files.

This was a fix to an interal binary that uses the OpenROAD C++ API.