### PR TITLE
gui: use const& for std::any in gui interface

### DIFF
--- a/src/drt/src/dr/FlexDR_graphics.cpp
+++ b/src/drt/src/dr/FlexDR_graphics.cpp
@@ -28,21 +28,21 @@ class GridGraphDescriptor : public gui::Descriptor
     const frDesign* design;
   };
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, gui::Painter& painter) const override;
+  void highlight(const std::any& object, gui::Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  gui::Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  gui::Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const gui::Selected&)>& func) const override;
 };
 
-std::string GridGraphDescriptor::getName(std::any object) const
+std::string GridGraphDescriptor::getName(const std::any& object) const
 {
   auto data = std::any_cast<Data>(object);
   return "<" + std::to_string(data.x) + ", " + std::to_string(data.y) + ", "
@@ -54,7 +54,7 @@ std::string GridGraphDescriptor::getTypeName() const
   return "Grid Graph Node";
 }
 
-bool GridGraphDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool GridGraphDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto data = std::any_cast<Data>(object);
   auto* graph = data.graph;
@@ -64,7 +64,7 @@ bool GridGraphDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void GridGraphDescriptor::highlight(std::any object,
+void GridGraphDescriptor::highlight(const std::any& object,
                                     gui::Painter& painter) const
 {
   odb::Rect bbox;
@@ -76,7 +76,7 @@ void GridGraphDescriptor::highlight(std::any object,
 }
 
 gui::Descriptor::Properties GridGraphDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto data = std::any_cast<Data>(object);
   auto* graph = data.graph;
@@ -169,7 +169,7 @@ gui::Descriptor::Properties GridGraphDescriptor::getProperties(
   return props;
 }
 
-gui::Selected GridGraphDescriptor::makeSelected(std::any object) const
+gui::Selected GridGraphDescriptor::makeSelected(const std::any& object) const
 {
   if (auto data = std::any_cast<Data>(&object)) {
     return gui::Selected(*data, this);
@@ -177,7 +177,7 @@ gui::Selected GridGraphDescriptor::makeSelected(std::any object) const
   return gui::Selected();
 }
 
-bool GridGraphDescriptor::lessThan(std::any l, std::any r) const
+bool GridGraphDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_grid = std::any_cast<Data>(l);
   auto r_grid = std::any_cast<Data>(r);

--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -297,20 +297,20 @@ class Descriptor
 {
  public:
   virtual ~Descriptor() = default;
-  virtual std::string getName(std::any object) const = 0;
-  virtual std::string getShortName(std::any object) const
+  virtual std::string getName(const std::any& object) const = 0;
+  virtual std::string getShortName(const std::any& object) const
   {
     return getName(std::move(object));
   }
   virtual std::string getTypeName() const = 0;
-  virtual std::string getTypeName(std::any /* object */) const
+  virtual std::string getTypeName(const std::any& /* object */) const
   {
     return getTypeName();
   }
-  virtual bool getBBox(std::any object, odb::Rect& bbox) const = 0;
+  virtual bool getBBox(const std::any& object, odb::Rect& bbox) const = 0;
 
-  virtual bool isInst(std::any /* object */) const { return false; }
-  virtual bool isNet(std::any /* object */) const { return false; }
+  virtual bool isInst(const std::any& /* object */) const { return false; }
+  virtual bool isNet(const std::any& /* object */) const { return false; }
 
   virtual void visitAllObjects(
       const std::function<void(const Selected&)>& func) const
@@ -358,13 +358,19 @@ class Descriptor
   };
   using Editors = std::map<std::string, Editor>;
 
-  virtual Properties getProperties(std::any object) const = 0;
-  virtual Actions getActions(std::any /* object */) const { return Actions(); }
-  virtual Editors getEditors(std::any /* object */) const { return Editors(); }
+  virtual Properties getProperties(const std::any& object) const = 0;
+  virtual Actions getActions(const std::any& /* object */) const
+  {
+    return Actions();
+  }
+  virtual Editors getEditors(const std::any& /* object */) const
+  {
+    return Editors();
+  }
 
-  virtual Selected makeSelected(std::any object) const = 0;
+  virtual Selected makeSelected(const std::any& object) const = 0;
 
-  virtual bool lessThan(std::any l, std::any r) const = 0;
+  virtual bool lessThan(const std::any& l, const std::any& r) const = 0;
 
   static Editor makeEditor(const EditorCallback& func,
                            const std::vector<EditorOption>& options)
@@ -378,8 +384,11 @@ class Descriptor
 
   // The caller (Selected and Renderers) will pre-configure the Painter's pen
   // and brush before calling.
-  virtual void highlight(std::any object, Painter& painter) const = 0;
-  virtual bool isSlowHighlight(std::any /* object */) const { return false; }
+  virtual void highlight(const std::any& object, Painter& painter) const = 0;
+  virtual bool isSlowHighlight(const std::any& /* object */) const
+  {
+    return false;
+  }
 
   static std::string convertUnits(double value,
                                   bool area = false,
@@ -414,7 +423,7 @@ class Selected
 
   bool isInst() const { return descriptor_->isInst(object_); }
   bool isNet() const { return descriptor_->isNet(object_); }
-  std::any getObject() const { return object_; }
+  const std::any& getObject() const { return object_; }
 
   // If the select_flag is false, the drawing will happen in highlight mode.
   // Highlight shapes are persistent which will not get removed from

--- a/src/gui/src/bufferTreeDescriptor.cpp
+++ b/src/gui/src/bufferTreeDescriptor.cpp
@@ -115,9 +115,9 @@ BufferTreeDescriptor::BufferTreeDescriptor(
   BufferTree::setSTA(sta);
 }
 
-std::string BufferTreeDescriptor::getName(std::any object) const
+std::string BufferTreeDescriptor::getName(const std::any& object) const
 {
-  BufferTree* bnet = std::any_cast<BufferTree>(&object);
+  const BufferTree* bnet = std::any_cast<BufferTree>(&object);
   return bnet->getName();
 }
 
@@ -126,9 +126,10 @@ std::string BufferTreeDescriptor::getTypeName() const
   return "Buffer Tree";
 }
 
-bool BufferTreeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool BufferTreeDescriptor::getBBox(const std::any& object,
+                                   odb::Rect& bbox) const
 {
-  BufferTree* bnet = std::any_cast<BufferTree>(&object);
+  const BufferTree* bnet = std::any_cast<BufferTree>(&object);
   bbox.mergeInit();
   for (auto* net : bnet->getNets()) {
     odb::Rect box;
@@ -139,9 +140,10 @@ bool BufferTreeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void BufferTreeDescriptor::highlight(std::any object, Painter& painter) const
+void BufferTreeDescriptor::highlight(const std::any& object,
+                                     Painter& painter) const
 {
-  BufferTree* bnet = std::any_cast<BufferTree>(&object);
+  const BufferTree* bnet = std::any_cast<BufferTree>(&object);
 
   ColorGenerator generator;
   painter.saveState();
@@ -153,9 +155,9 @@ void BufferTreeDescriptor::highlight(std::any object, Painter& painter) const
 }
 
 Descriptor::Properties BufferTreeDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
-  BufferTree* bnet = std::any_cast<BufferTree>(&object);
+  const BufferTree* bnet = std::any_cast<BufferTree>(&object);
   Properties props;
 
   auto gui = Gui::get();
@@ -184,7 +186,7 @@ Descriptor::Properties BufferTreeDescriptor::getProperties(
   return props;
 }
 
-Selected BufferTreeDescriptor::makeSelected(std::any object) const
+Selected BufferTreeDescriptor::makeSelected(const std::any& object) const
 {
   if (auto* bnet = std::any_cast<BufferTree>(&object)) {
     return Selected(*bnet, this);
@@ -192,10 +194,10 @@ Selected BufferTreeDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool BufferTreeDescriptor::lessThan(std::any l, std::any r) const
+bool BufferTreeDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
-  BufferTree* l_bnet = std::any_cast<BufferTree>(&l);
-  BufferTree* r_bnet = std::any_cast<BufferTree>(&r);
+  const BufferTree* l_bnet = std::any_cast<BufferTree>(&l);
+  const BufferTree* r_bnet = std::any_cast<BufferTree>(&r);
   return l_bnet->getName() < r_bnet->getName();
 }
 
@@ -218,7 +220,8 @@ void BufferTreeDescriptor::visitAllObjects(
   }
 }
 
-Descriptor::Actions BufferTreeDescriptor::getActions(std::any object) const
+Descriptor::Actions BufferTreeDescriptor::getActions(
+    const std::any& object) const
 {
   BufferTree bnet = *std::any_cast<BufferTree>(&object);
 

--- a/src/gui/src/bufferTreeDescriptor.h
+++ b/src/gui/src/bufferTreeDescriptor.h
@@ -57,16 +57,16 @@ class BufferTreeDescriptor : public Descriptor
                        const std::set<odb::dbNet*>& guide_nets,
                        const std::set<odb::dbNet*>& tracks_nets);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Actions getActions(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -164,7 +164,7 @@ template <typename T>
 static void addRenameEditor(T obj, Descriptor::Editors& editor)
 {
   editor.insert(
-      {"Name", Descriptor::makeEditor([obj](std::any value) {
+      {"Name", Descriptor::makeEditor([obj](const std::any& value) {
          const std::string new_name = std::any_cast<std::string>(value);
          // check if empty
          if (new_name.empty()) {
@@ -264,7 +264,8 @@ BaseDbDescriptor<T>::BaseDbDescriptor(odb::dbDatabase* db) : db_(db)
 }
 
 template <typename T>
-Descriptor::Properties BaseDbDescriptor<T>::getProperties(std::any object) const
+Descriptor::Properties BaseDbDescriptor<T>::getProperties(
+    const std::any& object) const
 {
   T* obj = getObject(object);
 
@@ -276,7 +277,7 @@ Descriptor::Properties BaseDbDescriptor<T>::getProperties(std::any object) const
 }
 
 template <typename T>
-Selected BaseDbDescriptor<T>::makeSelected(std::any object) const
+Selected BaseDbDescriptor<T>::makeSelected(const std::any& object) const
 {
   if (auto obj = std::any_cast<T*>(&object)) {
     return Selected(*obj, this);
@@ -285,7 +286,7 @@ Selected BaseDbDescriptor<T>::makeSelected(std::any object) const
 }
 
 template <typename T>
-bool BaseDbDescriptor<T>::lessThan(std::any l, std::any r) const
+bool BaseDbDescriptor<T>::lessThan(const std::any& l, const std::any& r) const
 {
   T* l_obj = std::any_cast<T*>(l);
   T* r_obj = std::any_cast<T*>(r);
@@ -305,7 +306,7 @@ DbTechDescriptor::DbTechDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechDescriptor::getName(std::any object) const
+std::string DbTechDescriptor::getName(const std::any& object) const
 {
   return "Default";
 }
@@ -315,12 +316,12 @@ std::string DbTechDescriptor::getTypeName() const
   return "Tech";
 }
 
-bool DbTechDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechDescriptor::highlight(std::any object, Painter& painter) const
+void DbTechDescriptor::highlight(const std::any& object, Painter& painter) const
 {
 }
 
@@ -403,7 +404,7 @@ DbBlockDescriptor::DbBlockDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbBlockDescriptor::getName(std::any object) const
+std::string DbBlockDescriptor::getName(const std::any& object) const
 {
   auto block = std::any_cast<odb::dbBlock*>(object);
   return block->getName();
@@ -414,14 +415,15 @@ std::string DbBlockDescriptor::getTypeName() const
   return "Block";
 }
 
-bool DbBlockDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbBlockDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto block = std::any_cast<odb::dbBlock*>(object);
   bbox = block->getBBox()->getBox();
   return !bbox.isInverted();
 }
 
-void DbBlockDescriptor::highlight(std::any object, Painter& painter) const
+void DbBlockDescriptor::highlight(const std::any& object,
+                                  Painter& painter) const
 {
   auto block = std::any_cast<odb::dbBlock*>(object);
 
@@ -532,7 +534,7 @@ DbInstDescriptor::DbInstDescriptor(odb::dbDatabase* db, sta::dbSta* sta)
 {
 }
 
-std::string DbInstDescriptor::getName(std::any object) const
+std::string DbInstDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<odb::dbInst*>(object)->getName();
 }
@@ -542,14 +544,14 @@ std::string DbInstDescriptor::getTypeName() const
   return "Inst";
 }
 
-bool DbInstDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbInstDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto inst = std::any_cast<odb::dbInst*>(object);
   bbox = inst->getBBox()->getBox();
   return !bbox.isInverted();
 }
 
-void DbInstDescriptor::highlight(std::any object, Painter& painter) const
+void DbInstDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto inst = std::any_cast<odb::dbInst*>(object);
   if (!inst->getPlacementStatus().isPlaced()) {
@@ -561,7 +563,7 @@ void DbInstDescriptor::highlight(std::any object, Painter& painter) const
   painter.drawRect(rect);
 }
 
-bool DbInstDescriptor::isInst(std::any object) const
+bool DbInstDescriptor::isInst(const std::any& object) const
 {
   return true;
 }
@@ -645,7 +647,7 @@ Descriptor::Properties DbInstDescriptor::getDBProperties(
   return props;
 }
 
-Descriptor::Actions DbInstDescriptor::getActions(std::any object) const
+Descriptor::Actions DbInstDescriptor::getActions(const std::any& object) const
 {
   auto inst = std::any_cast<odb::dbInst*>(object);
   return Actions(
@@ -655,7 +657,7 @@ Descriptor::Actions DbInstDescriptor::getActions(std::any object) const
         }}});
 }
 
-Descriptor::Editors DbInstDescriptor::getEditors(std::any object) const
+Descriptor::Editors DbInstDescriptor::getEditors(const std::any& object) const
 {
   auto inst = std::any_cast<odb::dbInst*>(object);
 
@@ -673,7 +675,7 @@ Descriptor::Editors DbInstDescriptor::getEditors(std::any object) const
   if (!master_options.empty()) {
     editors.insert({"Master",
                     makeEditor(
-                        [inst](std::any value) {
+                        [inst](const std::any& value) {
                           inst->swapMaster(
                               std::any_cast<odb::dbMaster*>(value));
                           return true;
@@ -682,7 +684,7 @@ Descriptor::Editors DbInstDescriptor::getEditors(std::any object) const
   }
   editors.insert({"Orientation",
                   makeEditor(
-                      [inst](std::any value) {
+                      [inst](const std::any& value) {
                         inst->setLocationOrient(
                             std::any_cast<odb::dbOrientType>(value));
                         return true;
@@ -690,7 +692,7 @@ Descriptor::Editors DbInstDescriptor::getEditors(std::any object) const
                       orient_options)});
   editors.insert({"Placement status",
                   makeEditor(
-                      [inst](std::any value) {
+                      [inst](const std::any& value) {
                         inst->setPlacementStatus(
                             std::any_cast<odb::dbPlacementStatus>(value));
                         return true;
@@ -799,7 +801,7 @@ DbMasterDescriptor::DbMasterDescriptor(odb::dbDatabase* db, sta::dbSta* sta)
 {
 }
 
-std::string DbMasterDescriptor::getName(std::any object) const
+std::string DbMasterDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<odb::dbMaster*>(object)->getName();
 }
@@ -809,14 +811,15 @@ std::string DbMasterDescriptor::getTypeName() const
   return "Master";
 }
 
-bool DbMasterDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbMasterDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto master = std::any_cast<odb::dbMaster*>(object);
   master->getPlacementBoundary(bbox);
   return true;
 }
 
-void DbMasterDescriptor::highlight(std::any object, Painter& painter) const
+void DbMasterDescriptor::highlight(const std::any& object,
+                                   Painter& painter) const
 {
   auto master = std::any_cast<odb::dbMaster*>(object);
   std::set<odb::dbInst*> insts;
@@ -965,7 +968,7 @@ DbNetDescriptor::DbNetDescriptor(odb::dbDatabase* db,
 {
 }
 
-std::string DbNetDescriptor::getName(std::any object) const
+std::string DbNetDescriptor::getName(const std::any& object) const
 {
   return getObject(object)->getName();
 }
@@ -975,7 +978,7 @@ std::string DbNetDescriptor::getTypeName() const
   return "Net";
 }
 
-bool DbNetDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbNetDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto net = getObject(object);
   auto wire = net->getWire();
@@ -1603,7 +1606,7 @@ void DbNetDescriptor::drawPathSegmentWithGuides(
 // additional_data is used define the related sink for this net
 // this will limit the fly-wires to just those related to that sink
 // if nullptr, all flywires will be drawn
-void DbNetDescriptor::highlight(std::any object, Painter& painter) const
+void DbNetDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   odb::dbObject* sink_object = getSink(object);
   auto net = getObject(object);
@@ -1800,13 +1803,13 @@ void DbNetDescriptor::highlight(std::any object, Painter& painter) const
   }
 }
 
-bool DbNetDescriptor::isSlowHighlight(std::any object) const
+bool DbNetDescriptor::isSlowHighlight(const std::any& object) const
 {
   auto net = getObject(object);
   return net->getSigType().isSupply();
 }
 
-bool DbNetDescriptor::isNet(std::any object) const
+bool DbNetDescriptor::isNet(const std::any& object) const
 {
   return true;
 }
@@ -1850,12 +1853,12 @@ Descriptor::Properties DbNetDescriptor::getDBProperties(odb::dbNet* net) const
   return props;
 }
 
-Descriptor::Editors DbNetDescriptor::getEditors(std::any object) const
+Descriptor::Editors DbNetDescriptor::getEditors(const std::any& object) const
 {
   auto net = getObject(object);
   Editors editors;
   addRenameEditor(net, editors);
-  editors.insert({"Special", makeEditor([net](std::any value) {
+  editors.insert({"Special", makeEditor([net](const std::any& value) {
                     const bool new_special = std::any_cast<bool>(value);
                     if (new_special) {
                       net->setSpecial();
@@ -1871,14 +1874,14 @@ Descriptor::Editors DbNetDescriptor::getEditors(std::any object) const
                     }
                     return true;
                   })});
-  editors.insert({"Dont Touch", makeEditor([net](std::any value) {
+  editors.insert({"Dont Touch", makeEditor([net](const std::any& value) {
                     net->setDoNotTouch(std::any_cast<bool>(value));
                     return true;
                   })});
   return editors;
 }
 
-Descriptor::Actions DbNetDescriptor::getActions(std::any object) const
+Descriptor::Actions DbNetDescriptor::getActions(const std::any& object) const
 {
   auto net = getObject(object);
 
@@ -1954,7 +1957,7 @@ Descriptor::Actions DbNetDescriptor::getActions(std::any object) const
   return actions;
 }
 
-Selected DbNetDescriptor::makeSelected(std::any object) const
+Selected DbNetDescriptor::makeSelected(const std::any& object) const
 {
   Selected net_selected = BaseDbDescriptor::makeSelected(object);
   if (net_selected) {
@@ -1967,7 +1970,7 @@ Selected DbNetDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool DbNetDescriptor::lessThan(std::any l, std::any r) const
+bool DbNetDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_net = getObject(l);
   auto r_net = getObject(r);
@@ -2019,13 +2022,13 @@ DbITermDescriptor::DbITermDescriptor(
 {
 }
 
-std::string DbITermDescriptor::getName(std::any object) const
+std::string DbITermDescriptor::getName(const std::any& object) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
   return iterm->getName();
 }
 
-std::string DbITermDescriptor::getShortName(std::any object) const
+std::string DbITermDescriptor::getShortName(const std::any& object) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
   return iterm->getMTerm()->getName();
@@ -2036,7 +2039,7 @@ std::string DbITermDescriptor::getTypeName() const
   return "ITerm";
 }
 
-bool DbITermDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbITermDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
   if (iterm->getInst()->getPlacementStatus().isPlaced()) {
@@ -2046,7 +2049,8 @@ bool DbITermDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return false;
 }
 
-void DbITermDescriptor::highlight(std::any object, Painter& painter) const
+void DbITermDescriptor::highlight(const std::any& object,
+                                  Painter& painter) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
 
@@ -2106,7 +2110,7 @@ Descriptor::Properties DbITermDescriptor::getDBProperties(
   return props;
 }
 
-Descriptor::Actions DbITermDescriptor::getActions(std::any object) const
+Descriptor::Actions DbITermDescriptor::getActions(const std::any& object) const
 {
   auto iterm = std::any_cast<odb::dbITerm*>(object);
 
@@ -2140,7 +2144,7 @@ DbBTermDescriptor::DbBTermDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbBTermDescriptor::getName(std::any object) const
+std::string DbBTermDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<odb::dbBTerm*>(object)->getName();
 }
@@ -2150,14 +2154,15 @@ std::string DbBTermDescriptor::getTypeName() const
   return "BTerm";
 }
 
-bool DbBTermDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbBTermDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* bterm = std::any_cast<odb::dbBTerm*>(object);
   bbox = bterm->getBBox();
   return !bbox.isInverted();
 }
 
-void DbBTermDescriptor::highlight(std::any object, Painter& painter) const
+void DbBTermDescriptor::highlight(const std::any& object,
+                                  Painter& painter) const
 {
   auto* bterm = std::any_cast<odb::dbBTerm*>(object);
   for (auto bpin : bterm->getBPins()) {
@@ -2206,7 +2211,7 @@ Descriptor::Properties DbBTermDescriptor::getDBProperties(
   return props;
 }
 
-Descriptor::Editors DbBTermDescriptor::getEditors(std::any object) const
+Descriptor::Editors DbBTermDescriptor::getEditors(const std::any& object) const
 {
   auto bterm = std::any_cast<odb::dbBTerm*>(object);
   Editors editors;
@@ -2214,7 +2219,7 @@ Descriptor::Editors DbBTermDescriptor::getEditors(std::any object) const
   return editors;
 }
 
-Descriptor::Actions DbBTermDescriptor::getActions(std::any object) const
+Descriptor::Actions DbBTermDescriptor::getActions(const std::any& object) const
 {
   auto bterm = std::any_cast<odb::dbBTerm*>(object);
 
@@ -2248,7 +2253,7 @@ DbBPinDescriptor::DbBPinDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbBPinDescriptor::getName(std::any object) const
+std::string DbBPinDescriptor::getName(const std::any& object) const
 {
   odb::dbBPin* pin = std::any_cast<odb::dbBPin*>(object);
   return pin->getBTerm()->getName();
@@ -2259,14 +2264,14 @@ std::string DbBPinDescriptor::getTypeName() const
   return "BPin";
 }
 
-bool DbBPinDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbBPinDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* bpin = std::any_cast<odb::dbBPin*>(object);
   bbox = bpin->getBBox();
   return !bbox.isInverted();
 }
 
-void DbBPinDescriptor::highlight(std::any object, Painter& painter) const
+void DbBPinDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto* bpin = std::any_cast<odb::dbBPin*>(object);
   for (auto box : bpin->getBoxes()) {
@@ -2338,13 +2343,13 @@ DbMTermDescriptor::DbMTermDescriptor(
 {
 }
 
-std::string DbMTermDescriptor::getName(std::any object) const
+std::string DbMTermDescriptor::getName(const std::any& object) const
 {
   auto mterm = std::any_cast<odb::dbMTerm*>(object);
   return mterm->getMaster()->getName() + "/" + mterm->getName();
 }
 
-std::string DbMTermDescriptor::getShortName(std::any object) const
+std::string DbMTermDescriptor::getShortName(const std::any& object) const
 {
   auto mterm = std::any_cast<odb::dbMTerm*>(object);
   return mterm->getName();
@@ -2355,14 +2360,15 @@ std::string DbMTermDescriptor::getTypeName() const
   return "MTerm";
 }
 
-bool DbMTermDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbMTermDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto mterm = std::any_cast<odb::dbMTerm*>(object);
   bbox = mterm->getBBox();
   return true;
 }
 
-void DbMTermDescriptor::highlight(std::any object, Painter& painter) const
+void DbMTermDescriptor::highlight(const std::any& object,
+                                  Painter& painter) const
 {
   auto mterm = std::any_cast<odb::dbMTerm*>(object);
 
@@ -2447,7 +2453,7 @@ DbViaDescriptor::DbViaDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbViaDescriptor::getName(std::any object) const
+std::string DbViaDescriptor::getName(const std::any& object) const
 {
   auto via = std::any_cast<odb::dbVia*>(object);
   return via->getName();
@@ -2458,12 +2464,12 @@ std::string DbViaDescriptor::getTypeName() const
   return "Block Via";
 }
 
-bool DbViaDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbViaDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbViaDescriptor::highlight(std::any object, Painter& painter) const
+void DbViaDescriptor::highlight(const std::any& object, Painter& painter) const
 {
 }
 
@@ -2587,7 +2593,7 @@ DbBlockageDescriptor::DbBlockageDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbBlockageDescriptor::getName(std::any object) const
+std::string DbBlockageDescriptor::getName(const std::any& object) const
 {
   return "Blockage";
 }
@@ -2597,7 +2603,8 @@ std::string DbBlockageDescriptor::getTypeName() const
   return "Blockage";
 }
 
-bool DbBlockageDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbBlockageDescriptor::getBBox(const std::any& object,
+                                   odb::Rect& bbox) const
 {
   auto* blockage = std::any_cast<odb::dbBlockage*>(object);
   odb::dbBox* box = blockage->getBBox();
@@ -2605,7 +2612,8 @@ bool DbBlockageDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void DbBlockageDescriptor::highlight(std::any object, Painter& painter) const
+void DbBlockageDescriptor::highlight(const std::any& object,
+                                     Painter& painter) const
 {
   odb::Rect rect;
   getBBox(std::move(object), rect);
@@ -2637,7 +2645,8 @@ Descriptor::Properties DbBlockageDescriptor::getDBProperties(
   return props;
 }
 
-Descriptor::Actions DbBlockageDescriptor::getActions(std::any object) const
+Descriptor::Actions DbBlockageDescriptor::getActions(
+    const std::any& object) const
 {
   auto blk = std::any_cast<odb::dbBlockage*>(object);
   return Actions(
@@ -2647,31 +2656,32 @@ Descriptor::Actions DbBlockageDescriptor::getActions(std::any object) const
         }}});
 }
 
-Descriptor::Editors DbBlockageDescriptor::getEditors(std::any object) const
+Descriptor::Editors DbBlockageDescriptor::getEditors(
+    const std::any& object) const
 {
   auto blockage = std::any_cast<odb::dbBlockage*>(object);
   Editors editors;
-  editors.insert({"Max density", makeEditor([blockage](std::any any_value) {
-                    std::string value = std::any_cast<std::string>(any_value);
-                    std::regex density_regex(
-                        "(1?[0-9]?[0-9]?(\\.[0-9]*)?)\\s*%?");
-                    std::smatch base_match;
-                    if (std::regex_match(value, base_match, density_regex)) {
-                      try {
-                        // try to convert to float
-                        float density = std::stof(base_match[0]);
-                        if (0 <= density && density <= 100) {
-                          blockage->setMaxDensity(density);
-                          return true;
-                        }
-                      } catch (std::out_of_range&) {
-                        // catch poorly formatted string
-                      } catch (std::logic_error&) {
-                        // catch poorly formatted string
-                      }
-                    }
-                    return false;
-                  })});
+  editors.insert(
+      {"Max density", makeEditor([blockage](const std::any& any_value) {
+         std::string value = std::any_cast<std::string>(any_value);
+         std::regex density_regex("(1?[0-9]?[0-9]?(\\.[0-9]*)?)\\s*%?");
+         std::smatch base_match;
+         if (std::regex_match(value, base_match, density_regex)) {
+           try {
+             // try to convert to float
+             float density = std::stof(base_match[0]);
+             if (0 <= density && density <= 100) {
+               blockage->setMaxDensity(density);
+               return true;
+             }
+           } catch (std::out_of_range&) {
+             // catch poorly formatted string
+           } catch (std::logic_error&) {
+             // catch poorly formatted string
+           }
+         }
+         return false;
+       })});
   return editors;
 }
 
@@ -2699,7 +2709,7 @@ DbObstructionDescriptor::DbObstructionDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbObstructionDescriptor::getName(std::any object) const
+std::string DbObstructionDescriptor::getName(const std::any& object) const
 {
   auto obs = std::any_cast<odb::dbObstruction*>(object);
   return "Obstruction: " + obs->getBBox()->getTechLayer()->getName();
@@ -2710,7 +2720,8 @@ std::string DbObstructionDescriptor::getTypeName() const
   return "Obstruction";
 }
 
-bool DbObstructionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbObstructionDescriptor::getBBox(const std::any& object,
+                                      odb::Rect& bbox) const
 {
   auto obs = std::any_cast<odb::dbObstruction*>(object);
   odb::dbBox* box = obs->getBBox();
@@ -2718,7 +2729,8 @@ bool DbObstructionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void DbObstructionDescriptor::highlight(std::any object, Painter& painter) const
+void DbObstructionDescriptor::highlight(const std::any& object,
+                                        Painter& painter) const
 {
   odb::Rect rect;
   getBBox(std::move(object), rect);
@@ -2760,7 +2772,8 @@ Descriptor::Properties DbObstructionDescriptor::getDBProperties(
   return props;
 }
 
-Descriptor::Actions DbObstructionDescriptor::getActions(std::any object) const
+Descriptor::Actions DbObstructionDescriptor::getActions(
+    const std::any& object) const
 {
   auto obs = std::any_cast<odb::dbObstruction*>(object);
   return Actions(
@@ -2813,7 +2826,7 @@ DbTechLayerDescriptor::DbTechLayerDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechLayerDescriptor::getName(std::any object) const
+std::string DbTechLayerDescriptor::getName(const std::any& object) const
 {
   auto layer = std::any_cast<odb::dbTechLayer*>(object);
   return layer->getConstName();
@@ -2824,12 +2837,14 @@ std::string DbTechLayerDescriptor::getTypeName() const
   return "Tech layer";
 }
 
-bool DbTechLayerDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechLayerDescriptor::getBBox(const std::any& object,
+                                    odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechLayerDescriptor::highlight(std::any object, Painter& painter) const
+void DbTechLayerDescriptor::highlight(const std::any& object,
+                                      Painter& painter) const
 {
 }
 
@@ -3073,7 +3088,7 @@ DbTermAccessPointDescriptor::DbTermAccessPointDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTermAccessPointDescriptor::getName(std::any object) const
+std::string DbTermAccessPointDescriptor::getName(const std::any& object) const
 {
   auto iterm_ap = std::any_cast<DbTermAccessPoint>(object);
   auto ap = iterm_ap.ap;
@@ -3087,7 +3102,7 @@ std::string DbTermAccessPointDescriptor::getTypeName() const
   return "Access Point";
 }
 
-bool DbTermAccessPointDescriptor::getBBox(std::any object,
+bool DbTermAccessPointDescriptor::getBBox(const std::any& object,
                                           odb::Rect& bbox) const
 {
   auto iterm_ap = std::any_cast<DbTermAccessPoint>(object);
@@ -3102,7 +3117,7 @@ bool DbTermAccessPointDescriptor::getBBox(std::any object,
   return true;
 }
 
-void DbTermAccessPointDescriptor::highlight(std::any object,
+void DbTermAccessPointDescriptor::highlight(const std::any& object,
                                             Painter& painter) const
 {
   auto iterm_ap = std::any_cast<DbTermAccessPoint>(object);
@@ -3118,7 +3133,7 @@ void DbTermAccessPointDescriptor::highlight(std::any object,
 }
 
 Descriptor::Properties DbTermAccessPointDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto iterm_ap = std::any_cast<DbTermAccessPoint>(object);
   auto ap = iterm_ap.ap;
@@ -3160,7 +3175,7 @@ Descriptor::Properties DbTermAccessPointDescriptor::getProperties(
   return props;
 }
 
-Selected DbTermAccessPointDescriptor::makeSelected(std::any object) const
+Selected DbTermAccessPointDescriptor::makeSelected(const std::any& object) const
 {
   if (object.type() == typeid(DbTermAccessPoint)) {
     auto iterm_ap = std::any_cast<DbTermAccessPoint>(object);
@@ -3169,7 +3184,8 @@ Selected DbTermAccessPointDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool DbTermAccessPointDescriptor::lessThan(std::any l, std::any r) const
+bool DbTermAccessPointDescriptor::lessThan(const std::any& l,
+                                           const std::any& r) const
 {
   auto l_term_ap = std::any_cast<DbTermAccessPoint>(l);
   auto r_term_ap = std::any_cast<DbTermAccessPoint>(r);
@@ -3220,7 +3236,7 @@ DbGroupDescriptor::DbGroupDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbGroupDescriptor::getName(std::any object) const
+std::string DbGroupDescriptor::getName(const std::any& object) const
 {
   auto* group = std::any_cast<odb::dbGroup*>(object);
   return group->getName();
@@ -3231,7 +3247,7 @@ std::string DbGroupDescriptor::getTypeName() const
   return "Group";
 }
 
-bool DbGroupDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbGroupDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* group = std::any_cast<odb::dbGroup*>(object);
   auto* region = group->getRegion();
@@ -3242,7 +3258,8 @@ bool DbGroupDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return false;
 }
 
-void DbGroupDescriptor::highlight(std::any object, Painter& painter) const
+void DbGroupDescriptor::highlight(const std::any& object,
+                                  Painter& painter) const
 {
   auto* group = std::any_cast<odb::dbGroup*>(object);
   auto* inst_descriptor = Gui::get()->getDescriptor<odb::dbInst*>();
@@ -3325,7 +3342,7 @@ DbRegionDescriptor::DbRegionDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbRegionDescriptor::getName(std::any object) const
+std::string DbRegionDescriptor::getName(const std::any& object) const
 {
   auto* region = std::any_cast<odb::dbRegion*>(object);
   return region->getName();
@@ -3336,7 +3353,7 @@ std::string DbRegionDescriptor::getTypeName() const
   return "Region";
 }
 
-bool DbRegionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbRegionDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* region = std::any_cast<odb::dbRegion*>(object);
   auto boxes = region->getBoundaries();
@@ -3351,7 +3368,8 @@ bool DbRegionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void DbRegionDescriptor::highlight(std::any object, Painter& painter) const
+void DbRegionDescriptor::highlight(const std::any& object,
+                                   Painter& painter) const
 {
   auto* region = std::any_cast<odb::dbRegion*>(object);
 
@@ -3418,13 +3436,13 @@ DbModuleDescriptor::DbModuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbModuleDescriptor::getShortName(std::any object) const
+std::string DbModuleDescriptor::getShortName(const std::any& object) const
 {
   auto* module = std::any_cast<odb::dbModule*>(object);
   return module->getName();
 }
 
-std::string DbModuleDescriptor::getName(std::any object) const
+std::string DbModuleDescriptor::getName(const std::any& object) const
 {
   auto* module = std::any_cast<odb::dbModule*>(object);
   return module->getHierarchicalName();
@@ -3435,7 +3453,7 @@ std::string DbModuleDescriptor::getTypeName() const
   return "Module";
 }
 
-bool DbModuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbModuleDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* module = std::any_cast<odb::dbModule*>(object);
   bbox.mergeInit();
@@ -3455,7 +3473,8 @@ bool DbModuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return !bbox.isInverted();
 }
 
-void DbModuleDescriptor::highlight(std::any object, Painter& painter) const
+void DbModuleDescriptor::highlight(const std::any& object,
+                                   Painter& painter) const
 {
   auto* module = std::any_cast<odb::dbModule*>(object);
 
@@ -3549,7 +3568,7 @@ DbTechViaDescriptor::DbTechViaDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechViaDescriptor::getName(std::any object) const
+std::string DbTechViaDescriptor::getName(const std::any& object) const
 {
   auto* via = std::any_cast<odb::dbTechVia*>(object);
   return via->getName();
@@ -3560,12 +3579,13 @@ std::string DbTechViaDescriptor::getTypeName() const
   return "Tech Via";
 }
 
-bool DbTechViaDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechViaDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechViaDescriptor::highlight(std::any object, Painter& painter) const
+void DbTechViaDescriptor::highlight(const std::any& object,
+                                    Painter& painter) const
 {
 }
 
@@ -3637,7 +3657,7 @@ DbTechViaRuleDescriptor::DbTechViaRuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechViaRuleDescriptor::getName(std::any object) const
+std::string DbTechViaRuleDescriptor::getName(const std::any& object) const
 {
   auto via_rule = std::any_cast<odb::dbTechViaRule*>(object);
   return via_rule->getName();
@@ -3648,12 +3668,14 @@ std::string DbTechViaRuleDescriptor::getTypeName() const
   return "Tech Via Rule";
 }
 
-bool DbTechViaRuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechViaRuleDescriptor::getBBox(const std::any& object,
+                                      odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechViaRuleDescriptor::highlight(std::any object, Painter& painter) const
+void DbTechViaRuleDescriptor::highlight(const std::any& object,
+                                        Painter& painter) const
 {
 }
 
@@ -3698,7 +3720,7 @@ DbTechViaLayerRuleDescriptor::DbTechViaLayerRuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechViaLayerRuleDescriptor::getName(std::any object) const
+std::string DbTechViaLayerRuleDescriptor::getName(const std::any& object) const
 {
   auto via_layer_rule = std::any_cast<odb::dbTechViaLayerRule*>(object);
   std::string rule_name = via_layer_rule->getLayer()->getName() + "_rule";
@@ -3710,13 +3732,13 @@ std::string DbTechViaLayerRuleDescriptor::getTypeName() const
   return "Tech Via-Layer Rule";
 }
 
-bool DbTechViaLayerRuleDescriptor::getBBox(std::any object,
+bool DbTechViaLayerRuleDescriptor::getBBox(const std::any& object,
                                            odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechViaLayerRuleDescriptor::highlight(std::any object,
+void DbTechViaLayerRuleDescriptor::highlight(const std::any& object,
                                              Painter& painter) const
 {
 }
@@ -3817,7 +3839,7 @@ DbMetalWidthViaMapDescriptor::DbMetalWidthViaMapDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbMetalWidthViaMapDescriptor::getName(std::any object) const
+std::string DbMetalWidthViaMapDescriptor::getName(const std::any& object) const
 {
   auto via_map = std::any_cast<odb::dbMetalWidthViaMap*>(object);
   std::string map_name = via_map->getViaName() + "_width_map";
@@ -3829,13 +3851,13 @@ std::string DbMetalWidthViaMapDescriptor::getTypeName() const
   return "Metal Width Via Map Rule";
 }
 
-bool DbMetalWidthViaMapDescriptor::getBBox(std::any object,
+bool DbMetalWidthViaMapDescriptor::getBBox(const std::any& object,
                                            odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbMetalWidthViaMapDescriptor::highlight(std::any object,
+void DbMetalWidthViaMapDescriptor::highlight(const std::any& object,
                                              Painter& painter) const
 {
 }
@@ -3874,7 +3896,7 @@ DbGenerateViaDescriptor::DbGenerateViaDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbGenerateViaDescriptor::getName(std::any object) const
+std::string DbGenerateViaDescriptor::getName(const std::any& object) const
 {
   auto* via = std::any_cast<odb::dbTechViaGenerateRule*>(object);
   return via->getName();
@@ -3885,12 +3907,14 @@ std::string DbGenerateViaDescriptor::getTypeName() const
   return "Generate Via Rule";
 }
 
-bool DbGenerateViaDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbGenerateViaDescriptor::getBBox(const std::any& object,
+                                      odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbGenerateViaDescriptor::highlight(std::any object, Painter& painter) const
+void DbGenerateViaDescriptor::highlight(const std::any& object,
+                                        Painter& painter) const
 {
 }
 
@@ -3950,7 +3974,7 @@ DbNonDefaultRuleDescriptor::DbNonDefaultRuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbNonDefaultRuleDescriptor::getName(std::any object) const
+std::string DbNonDefaultRuleDescriptor::getName(const std::any& object) const
 {
   auto* rule = std::any_cast<odb::dbTechNonDefaultRule*>(object);
   return rule->getName();
@@ -3961,12 +3985,13 @@ std::string DbNonDefaultRuleDescriptor::getTypeName() const
   return "Non-default Rule";
 }
 
-bool DbNonDefaultRuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbNonDefaultRuleDescriptor::getBBox(const std::any& object,
+                                         odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbNonDefaultRuleDescriptor::highlight(std::any object,
+void DbNonDefaultRuleDescriptor::highlight(const std::any& object,
                                            Painter& painter) const
 {
 }
@@ -4035,7 +4060,7 @@ DbTechLayerRuleDescriptor::DbTechLayerRuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechLayerRuleDescriptor::getName(std::any object) const
+std::string DbTechLayerRuleDescriptor::getName(const std::any& object) const
 {
   auto* rule = std::any_cast<odb::dbTechLayerRule*>(object);
   return rule->getLayer()->getName();
@@ -4046,12 +4071,13 @@ std::string DbTechLayerRuleDescriptor::getTypeName() const
   return "Tech layer rule";
 }
 
-bool DbTechLayerRuleDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbTechLayerRuleDescriptor::getBBox(const std::any& object,
+                                        odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechLayerRuleDescriptor::highlight(std::any object,
+void DbTechLayerRuleDescriptor::highlight(const std::any& object,
                                           Painter& painter) const
 {
 }
@@ -4086,7 +4112,7 @@ DbTechSameNetRuleDescriptor::DbTechSameNetRuleDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbTechSameNetRuleDescriptor::getName(std::any object) const
+std::string DbTechSameNetRuleDescriptor::getName(const std::any& object) const
 {
   auto* rule = std::any_cast<odb::dbTechSameNetRule*>(object);
   return rule->getLayer1()->getName() + " - " + rule->getLayer2()->getName();
@@ -4097,13 +4123,13 @@ std::string DbTechSameNetRuleDescriptor::getTypeName() const
   return "Tech same net rule";
 }
 
-bool DbTechSameNetRuleDescriptor::getBBox(std::any object,
+bool DbTechSameNetRuleDescriptor::getBBox(const std::any& object,
                                           odb::Rect& bbox) const
 {
   return false;
 }
 
-void DbTechSameNetRuleDescriptor::highlight(std::any object,
+void DbTechSameNetRuleDescriptor::highlight(const std::any& object,
                                             Painter& painter) const
 {
 }
@@ -4136,7 +4162,7 @@ DbSiteDescriptor::DbSiteDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbSiteDescriptor::getName(std::any object) const
+std::string DbSiteDescriptor::getName(const std::any& object) const
 {
   return getObject(object)->getName();
 }
@@ -4146,7 +4172,7 @@ std::string DbSiteDescriptor::getTypeName() const
   return "Site";
 }
 
-bool DbSiteDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbSiteDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   if (isSpecificSite(object)) {
     bbox = getRect(object);
@@ -4156,14 +4182,15 @@ bool DbSiteDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return false;
 }
 
-void DbSiteDescriptor::highlight(std::any object, Painter& painter) const
+void DbSiteDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   if (isSpecificSite(object)) {
     painter.drawRect(getRect(object));
   }
 }
 
-Descriptor::Properties DbSiteDescriptor::getProperties(std::any object) const
+Descriptor::Properties DbSiteDescriptor::getProperties(
+    const std::any& object) const
 {
   Properties props = BaseDbDescriptor::getProperties(object);
 
@@ -4212,7 +4239,7 @@ Descriptor::Properties DbSiteDescriptor::getDBProperties(
   return props;
 }
 
-Selected DbSiteDescriptor::makeSelected(std::any object) const
+Selected DbSiteDescriptor::makeSelected(const std::any& object) const
 {
   Selected site_selected = BaseDbDescriptor::makeSelected(object);
   if (site_selected) {
@@ -4225,7 +4252,7 @@ Selected DbSiteDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool DbSiteDescriptor::lessThan(std::any l, std::any r) const
+bool DbSiteDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   if (!isSpecificSite(l) && !isSpecificSite(r)) {
     return BaseDbDescriptor::lessThan(l, r);
@@ -4277,7 +4304,7 @@ DbRowDescriptor::DbRowDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbRowDescriptor::getName(std::any object) const
+std::string DbRowDescriptor::getName(const std::any& object) const
 {
   auto* row = std::any_cast<odb::dbRow*>(object);
   return row->getName();
@@ -4288,14 +4315,14 @@ std::string DbRowDescriptor::getTypeName() const
   return "Row";
 }
 
-bool DbRowDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbRowDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* row = std::any_cast<odb::dbRow*>(object);
   bbox = row->getBBox();
   return true;
 }
 
-void DbRowDescriptor::highlight(std::any object, Painter& painter) const
+void DbRowDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto* row = std::any_cast<odb::dbRow*>(object);
   painter.drawRect(row->getBBox());
@@ -4340,7 +4367,7 @@ DbMarkerCategoryDescriptor::DbMarkerCategoryDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbMarkerCategoryDescriptor::getName(std::any object) const
+std::string DbMarkerCategoryDescriptor::getName(const std::any& object) const
 {
   auto* category = std::any_cast<odb::dbMarkerCategory*>(object);
   return category->getName();
@@ -4351,7 +4378,8 @@ std::string DbMarkerCategoryDescriptor::getTypeName() const
   return "Marker Category";
 }
 
-bool DbMarkerCategoryDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbMarkerCategoryDescriptor::getBBox(const std::any& object,
+                                         odb::Rect& bbox) const
 {
   auto* category = std::any_cast<odb::dbMarkerCategory*>(object);
   bbox.mergeInit();
@@ -4363,7 +4391,7 @@ bool DbMarkerCategoryDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return has_bbox;
 }
 
-void DbMarkerCategoryDescriptor::highlight(std::any object,
+void DbMarkerCategoryDescriptor::highlight(const std::any& object,
                                            Painter& painter) const
 {
   auto* category = std::any_cast<odb::dbMarkerCategory*>(object);
@@ -4438,7 +4466,7 @@ DbMarkerDescriptor::DbMarkerDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbMarkerDescriptor::getName(std::any object) const
+std::string DbMarkerDescriptor::getName(const std::any& object) const
 {
   auto* marker = std::any_cast<odb::dbMarker*>(object);
   return marker->getName();
@@ -4449,14 +4477,15 @@ std::string DbMarkerDescriptor::getTypeName() const
   return "Marker";
 }
 
-bool DbMarkerDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbMarkerDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto* marker = std::any_cast<odb::dbMarker*>(object);
   bbox = marker->getBBox();
   return true;
 }
 
-void DbMarkerDescriptor::highlight(std::any object, Painter& painter) const
+void DbMarkerDescriptor::highlight(const std::any& object,
+                                   Painter& painter) const
 {
   auto* marker = std::any_cast<odb::dbMarker*>(object);
   paintMarker(marker, painter);
@@ -4568,7 +4597,7 @@ DbScanInstDescriptor::DbScanInstDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbScanInstDescriptor::getName(std::any object) const
+std::string DbScanInstDescriptor::getName(const std::any& object) const
 {
   auto* scan_inst = std::any_cast<odb::dbScanInst*>(object);
   auto* inst = scan_inst->getInst();
@@ -4580,7 +4609,8 @@ std::string DbScanInstDescriptor::getTypeName() const
   return "Scan Inst";
 }
 
-bool DbScanInstDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbScanInstDescriptor::getBBox(const std::any& object,
+                                   odb::Rect& bbox) const
 {
   auto* scan_inst = std::any_cast<odb::dbScanInst*>(object);
   auto* inst = scan_inst->getInst();
@@ -4588,7 +4618,8 @@ bool DbScanInstDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-void DbScanInstDescriptor::highlight(std::any object, Painter& painter) const
+void DbScanInstDescriptor::highlight(const std::any& object,
+                                     Painter& painter) const
 {
   auto* scan_inst = std::any_cast<odb::dbScanInst*>(object);
   auto* inst_descriptor = Gui::get()->getDescriptor<odb::dbInst*>();
@@ -4657,7 +4688,7 @@ DbScanListDescriptor::DbScanListDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbScanListDescriptor::getName(std::any object) const
+std::string DbScanListDescriptor::getName(const std::any& object) const
 {
   return "Scan List";
 }
@@ -4667,7 +4698,8 @@ std::string DbScanListDescriptor::getTypeName() const
   return "Scan List";
 }
 
-bool DbScanListDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbScanListDescriptor::getBBox(const std::any& object,
+                                   odb::Rect& bbox) const
 {
   auto scan_list = getObject(object);
   bbox.mergeInit();
@@ -4682,7 +4714,8 @@ bool DbScanListDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return !bbox.isInverted();
 }
 
-void DbScanListDescriptor::highlight(std::any object, Painter& painter) const
+void DbScanListDescriptor::highlight(const std::any& object,
+                                     Painter& painter) const
 {
   auto scan_list = getObject(object);
 
@@ -4733,7 +4766,7 @@ DbScanPartitionDescriptor::DbScanPartitionDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbScanPartitionDescriptor::getName(std::any object) const
+std::string DbScanPartitionDescriptor::getName(const std::any& object) const
 {
   auto scan_partition = getObject(object);
   return scan_partition->getName();
@@ -4744,7 +4777,8 @@ std::string DbScanPartitionDescriptor::getTypeName() const
   return "Scan Partition";
 }
 
-bool DbScanPartitionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbScanPartitionDescriptor::getBBox(const std::any& object,
+                                        odb::Rect& bbox) const
 {
   auto scan_partition = getObject(object);
   auto* scan_list_descriptor = Gui::get()->getDescriptor<odb::dbScanList*>();
@@ -4760,7 +4794,7 @@ bool DbScanPartitionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return !bbox.isInverted();
 }
 
-void DbScanPartitionDescriptor::highlight(std::any object,
+void DbScanPartitionDescriptor::highlight(const std::any& object,
                                           Painter& painter) const
 {
   auto scan_partition = getObject(object);
@@ -4807,7 +4841,7 @@ DbScanChainDescriptor::DbScanChainDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbScanChainDescriptor::getName(std::any object) const
+std::string DbScanChainDescriptor::getName(const std::any& object) const
 {
   auto scan_chain = getObject(object);
   return scan_chain->getName();
@@ -4818,7 +4852,8 @@ std::string DbScanChainDescriptor::getTypeName() const
   return "Scan Chain";
 }
 
-bool DbScanChainDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbScanChainDescriptor::getBBox(const std::any& object,
+                                    odb::Rect& bbox) const
 {
   auto scan_chain = getObject(object);
   auto* scan_partition_descriptor
@@ -4836,7 +4871,8 @@ bool DbScanChainDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return !bbox.isInverted();
 }
 
-void DbScanChainDescriptor::highlight(std::any object, Painter& painter) const
+void DbScanChainDescriptor::highlight(const std::any& object,
+                                      Painter& painter) const
 {
   auto scan_chain = getObject(object);
 
@@ -4888,7 +4924,7 @@ DbBoxDescriptor::DbBoxDescriptor(odb::dbDatabase* db)
 {
 }
 
-std::string DbBoxDescriptor::getName(std::any object) const
+std::string DbBoxDescriptor::getName(const std::any& object) const
 {
   odb::Rect box;
   getBBox(object, box);
@@ -4910,7 +4946,7 @@ std::string DbBoxDescriptor::getTypeName() const
   return "Box";
 }
 
-bool DbBoxDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool DbBoxDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   bbox = getObject(object)->getBox();
   const auto xform = getTransform(object);
@@ -4918,7 +4954,7 @@ bool DbBoxDescriptor::getBBox(std::any object, odb::Rect& bbox) const
   return true;
 }
 
-Selected DbBoxDescriptor::makeSelected(std::any object) const
+Selected DbBoxDescriptor::makeSelected(const std::any& object) const
 {
   Selected box_selected = BaseDbDescriptor::makeSelected(object);
   if (box_selected) {
@@ -4931,7 +4967,7 @@ Selected DbBoxDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-void DbBoxDescriptor::highlight(std::any object, Painter& painter) const
+void DbBoxDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   odb::Rect bbox = getObject(object)->getBox();
   const auto xform = getTransform(object);
@@ -4945,7 +4981,7 @@ void DbBoxDescriptor::visitAllObjects(
 {
 }
 
-bool DbBoxDescriptor::lessThan(std::any l, std::any r) const
+bool DbBoxDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_net = getObject(l);
   auto r_net = getObject(r);

--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -33,10 +33,10 @@ class BaseDbDescriptor : public Descriptor
  public:
   BaseDbDescriptor(odb::dbDatabase* db);
 
-  Properties getProperties(std::any object) const override;
+  Properties getProperties(const std::any& object) const override;
 
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
  protected:
   odb::dbDatabase* db_;
@@ -50,11 +50,11 @@ class DbTechDescriptor : public BaseDbDescriptor<odb::dbTech>
  public:
   DbTechDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -68,11 +68,11 @@ class DbBlockDescriptor : public BaseDbDescriptor<odb::dbBlock>
  public:
   DbBlockDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -86,16 +86,16 @@ class DbInstDescriptor : public BaseDbDescriptor<odb::dbInst>
  public:
   DbInstDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  bool isInst(std::any object) const override;
+  bool isInst(const std::any& object) const override;
 
-  Actions getActions(std::any object) const override;
-  Editors getEditors(std::any object) const override;
+  Actions getActions(const std::any& object) const override;
+  Editors getEditors(const std::any& object) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -120,11 +120,11 @@ class DbMasterDescriptor : public BaseDbDescriptor<odb::dbMaster>
  public:
   DbMasterDescriptor(odb::dbDatabase* db, sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -157,19 +157,19 @@ class DbNetDescriptor : public BaseDbDescriptor<odb::dbNet>
                   const std::set<odb::dbNet*>& guide_nets,
                   const std::set<odb::dbNet*>& tracks_nets);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
-  bool isSlowHighlight(std::any object) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
+  bool isSlowHighlight(const std::any& object) const override;
 
-  bool isNet(std::any object) const override;
+  bool isNet(const std::any& object) const override;
 
-  Editors getEditors(std::any object) const override;
-  Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any obj) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Editors getEditors(const std::any& object) const override;
+  Actions getActions(const std::any& object) const override;
+  Selected makeSelected(const std::any& obj) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -237,14 +237,14 @@ class DbITermDescriptor : public BaseDbDescriptor<odb::dbITerm>
   DbITermDescriptor(odb::dbDatabase* db,
                     std::function<bool()> using_poly_decomp_view);
 
-  std::string getName(std::any object) const override;
-  std::string getShortName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
+  std::string getShortName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Actions getActions(std::any object) const override;
+  Actions getActions(const std::any& object) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -261,14 +261,14 @@ class DbBTermDescriptor : public BaseDbDescriptor<odb::dbBTerm>
  public:
   DbBTermDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Editors getEditors(std::any object) const override;
-  Actions getActions(std::any object) const override;
+  Editors getEditors(const std::any& object) const override;
+  Actions getActions(const std::any& object) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -282,11 +282,11 @@ class DbBPinDescriptor : public BaseDbDescriptor<odb::dbBPin>
  public:
   DbBPinDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -301,12 +301,12 @@ class DbMTermDescriptor : public BaseDbDescriptor<odb::dbMTerm>
   DbMTermDescriptor(odb::dbDatabase* db,
                     std::function<bool()> using_poly_decomp_view);
 
-  std::string getName(std::any object) const override;
-  std::string getShortName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
+  std::string getShortName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -323,11 +323,11 @@ class DbViaDescriptor : public BaseDbDescriptor<odb::dbVia>
  public:
   DbViaDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -341,14 +341,14 @@ class DbBlockageDescriptor : public BaseDbDescriptor<odb::dbBlockage>
  public:
   DbBlockageDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Actions getActions(std::any object) const override;
-  Editors getEditors(std::any object) const override;
+  Actions getActions(const std::any& object) const override;
+  Editors getEditors(const std::any& object) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -362,13 +362,13 @@ class DbObstructionDescriptor : public BaseDbDescriptor<odb::dbObstruction>
  public:
   DbObstructionDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Actions getActions(std::any object) const override;
+  Actions getActions(const std::any& object) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -382,11 +382,11 @@ class DbTechLayerDescriptor : public BaseDbDescriptor<odb::dbTechLayer>
  public:
   DbTechLayerDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -417,15 +417,15 @@ class DbTermAccessPointDescriptor : public Descriptor
  public:
   DbTermAccessPointDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -439,11 +439,11 @@ class DbGroupDescriptor : public BaseDbDescriptor<odb::dbGroup>
  public:
   DbGroupDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -457,11 +457,11 @@ class DbRegionDescriptor : public BaseDbDescriptor<odb::dbRegion>
  public:
   DbRegionDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -475,12 +475,12 @@ class DbModuleDescriptor : public BaseDbDescriptor<odb::dbModule>
  public:
   DbModuleDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
-  std::string getShortName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
+  std::string getShortName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -498,12 +498,12 @@ class DbTechViaDescriptor : public BaseDbDescriptor<odb::dbTechVia>
  public:
   DbTechViaDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -517,12 +517,12 @@ class DbTechViaRuleDescriptor : public BaseDbDescriptor<odb::dbTechViaRule>
  public:
   DbTechViaRuleDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -537,12 +537,12 @@ class DbTechViaLayerRuleDescriptor
  public:
   DbTechViaLayerRuleDescriptor(odb::dbDatabase*);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -558,12 +558,12 @@ class DbMetalWidthViaMapDescriptor
  public:
   DbMetalWidthViaMapDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -578,12 +578,12 @@ class DbGenerateViaDescriptor
  public:
   DbGenerateViaDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -598,12 +598,13 @@ class DbNonDefaultRuleDescriptor
  public:
   DbNonDefaultRuleDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any /* object */, odb::Rect& /* bbox */) const override;
+  bool getBBox(const std::any& /* object */,
+               odb::Rect& /* bbox */) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -617,12 +618,13 @@ class DbTechLayerRuleDescriptor : public BaseDbDescriptor<odb::dbTechLayerRule>
  public:
   DbTechLayerRuleDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any /* object */, odb::Rect& /* bbox */) const override;
+  bool getBBox(const std::any& /* object */,
+               odb::Rect& /* bbox */) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -637,12 +639,13 @@ class DbTechSameNetRuleDescriptor
  public:
   DbTechSameNetRuleDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any /* object */, odb::Rect& /* bbox */) const override;
+  bool getBBox(const std::any& /* object */,
+               odb::Rect& /* bbox */) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -663,16 +666,16 @@ class DbSiteDescriptor : public BaseDbDescriptor<odb::dbSite>
 
   DbSiteDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -692,12 +695,12 @@ class DbRowDescriptor : public BaseDbDescriptor<odb::dbRow>
  public:
   DbRowDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -712,12 +715,12 @@ class DbMarkerCategoryDescriptor
  public:
   DbMarkerCategoryDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -731,12 +734,12 @@ class DbMarkerDescriptor : public BaseDbDescriptor<odb::dbMarker>
  public:
   DbMarkerDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -752,12 +755,12 @@ class DbScanInstDescriptor : public BaseDbDescriptor<odb::dbScanInst>
  public:
   DbScanInstDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -775,12 +778,12 @@ class DbScanListDescriptor : public BaseDbDescriptor<odb::dbScanList>
  public:
   DbScanListDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -794,12 +797,12 @@ class DbScanPartitionDescriptor : public BaseDbDescriptor<odb::dbScanPartition>
  public:
   DbScanPartitionDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -814,12 +817,12 @@ class DbScanChainDescriptor : public BaseDbDescriptor<odb::dbScanChain>
  public:
   DbScanChainDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -839,19 +842,19 @@ class DbBoxDescriptor : public BaseDbDescriptor<odb::dbBox>
 
   DbBoxDescriptor(odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
 
-  Selected makeSelected(std::any obj) const override;
+  Selected makeSelected(const std::any& obj) const override;
 
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
 
-  bool lessThan(std::any l, std::any r) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
  protected:
   Properties getDBProperties(odb::dbBox* box) const override;

--- a/src/gui/src/label.cpp
+++ b/src/gui/src/label.cpp
@@ -42,7 +42,7 @@ LabelDescriptor::LabelDescriptor(
 {
 }
 
-std::string LabelDescriptor::getName(std::any object) const
+std::string LabelDescriptor::getName(const std::any& object) const
 {
   auto label = std::any_cast<Label*>(object);
   return label->getName();
@@ -53,12 +53,12 @@ std::string LabelDescriptor::getTypeName() const
   return "Label";
 }
 
-bool LabelDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool LabelDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void LabelDescriptor::highlight(std::any object, Painter& painter) const
+void LabelDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto label = std::any_cast<Label*>(object);
 
@@ -69,7 +69,8 @@ void LabelDescriptor::highlight(std::any object, Painter& painter) const
   painter.drawRect(label->getOutline());
 }
 
-Descriptor::Properties LabelDescriptor::getProperties(std::any object) const
+Descriptor::Properties LabelDescriptor::getProperties(
+    const std::any& object) const
 {
   auto label = std::any_cast<Label*>(object);
 
@@ -85,7 +86,7 @@ Descriptor::Properties LabelDescriptor::getProperties(std::any object) const
   return props;
 }
 
-Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
+Descriptor::Editors LabelDescriptor::getEditors(const std::any& object) const
 {
   auto label = std::any_cast<Label*>(object);
 
@@ -94,7 +95,7 @@ Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
     anchor_options.push_back({name, anchor});
   }
 
-  return {{"Name", makeEditor([this, label](std::any value) {
+  return {{"Name", makeEditor([this, label](const std::any& value) {
              auto new_name = std::any_cast<const std::string>(value);
              if (new_name.empty()) {
                return false;
@@ -107,7 +108,7 @@ Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
              label->setName(new_name);
              return true;
            })},
-          {"Text", makeEditor([label](std::any value) {
+          {"Text", makeEditor([label](const std::any& value) {
              auto new_text = std::any_cast<const std::string>(value);
              if (new_text.empty()) {
                return false;
@@ -115,7 +116,7 @@ Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
              label->setText(new_text);
              return true;
            })},
-          {"Size", makeEditor([label](std::any value) {
+          {"Size", makeEditor([label](const std::any& value) {
              try {
                auto new_size = static_cast<int>(std::any_cast<double>(value));
                if (new_size <= 0) {
@@ -129,13 +130,13 @@ Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
            })},
           {"Anchor",
            makeEditor(
-               [label](std::any value) {
+               [label](const std::any& value) {
                  auto anchor = std::any_cast<Painter::Anchor>(value);
                  label->setAnchor(anchor);
                  return true;
                },
                anchor_options)},
-          {"Color", makeEditor([this, label](std::any value) {
+          {"Color", makeEditor([this, label](const std::any& value) {
              label->setColor(Painter::stringToColor(
                  std::any_cast<const std::string>(value), logger_));
              return true;
@@ -148,7 +149,9 @@ Descriptor::Editors LabelDescriptor::getEditors(std::any object) const
            })}};
 }
 
-bool LabelDescriptor::editPoint(std::any value, odb::Point& pt, bool is_x)
+bool LabelDescriptor::editPoint(const std::any& value,
+                                odb::Point& pt,
+                                bool is_x)
 {
   bool accept;
   const int new_val = Descriptor::Property::convert_string(
@@ -164,7 +167,7 @@ bool LabelDescriptor::editPoint(std::any value, odb::Point& pt, bool is_x)
   return true;
 }
 
-Descriptor::Actions LabelDescriptor::getActions(std::any object) const
+Descriptor::Actions LabelDescriptor::getActions(const std::any& object) const
 {
   auto label = std::any_cast<Label*>(object);
 
@@ -174,7 +177,7 @@ Descriptor::Actions LabelDescriptor::getActions(std::any object) const
            }}};
 }
 
-Selected LabelDescriptor::makeSelected(std::any object) const
+Selected LabelDescriptor::makeSelected(const std::any& object) const
 {
   if (auto label = std::any_cast<Label*>(&object)) {
     return Selected(*label, this);
@@ -182,7 +185,7 @@ Selected LabelDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool LabelDescriptor::lessThan(std::any l, std::any r) const
+bool LabelDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_label = std::any_cast<Label*>(l);
   auto r_label = std::any_cast<Label*>(r);

--- a/src/gui/src/label.h
+++ b/src/gui/src/label.h
@@ -67,23 +67,23 @@ class LabelDescriptor : public Descriptor
                   odb::dbDatabase* db,
                   utl::Logger* logger);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Editors getEditors(std::any object) const override;
-  Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Editors getEditors(const std::any& object) const override;
+  Actions getActions(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
 
  private:
-  static bool editPoint(std::any value, odb::Point& pt, bool is_x);
+  static bool editPoint(const std::any& value, odb::Point& pt, bool is_x);
 
   const Labels& labels_;
   odb::dbDatabase* db_;

--- a/src/gui/src/ruler.cpp
+++ b/src/gui/src/ruler.cpp
@@ -99,7 +99,7 @@ RulerDescriptor::RulerDescriptor(
 {
 }
 
-std::string RulerDescriptor::getName(std::any object) const
+std::string RulerDescriptor::getName(const std::any& object) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
   return ruler->getName();
@@ -110,14 +110,14 @@ std::string RulerDescriptor::getTypeName() const
   return "Ruler";
 }
 
-bool RulerDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool RulerDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
   bbox = odb::Rect(ruler->getPt0(), ruler->getPt1());
   return true;
 }
 
-void RulerDescriptor::highlight(std::any object, Painter& painter) const
+void RulerDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
   if (ruler->isEuclidian()) {
@@ -129,7 +129,8 @@ void RulerDescriptor::highlight(std::any object, Painter& painter) const
   }
 }
 
-Descriptor::Properties RulerDescriptor::getProperties(std::any object) const
+Descriptor::Properties RulerDescriptor::getProperties(
+    const std::any& object) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
   return {{"Label", ruler->getLabel()},
@@ -147,10 +148,10 @@ Descriptor::Properties RulerDescriptor::getProperties(std::any object) const
           {"Euclidian", ruler->isEuclidian()}};
 }
 
-Descriptor::Editors RulerDescriptor::getEditors(std::any object) const
+Descriptor::Editors RulerDescriptor::getEditors(const std::any& object) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
-  return {{"Name", makeEditor([this, ruler](std::any value) {
+  return {{"Name", makeEditor([this, ruler](const std::any& value) {
              auto new_name = std::any_cast<const std::string>(value);
              if (new_name.empty()) {
                return false;
@@ -163,7 +164,7 @@ Descriptor::Editors RulerDescriptor::getEditors(std::any object) const
              ruler->setName(new_name);
              return true;
            })},
-          {"Label", makeEditor([ruler](std::any value) {
+          {"Label", makeEditor([ruler](const std::any& value) {
              ruler->setLabel(std::any_cast<const std::string>(value));
              return true;
            })},
@@ -186,7 +187,9 @@ Descriptor::Editors RulerDescriptor::getEditors(std::any object) const
            })}};
 }
 
-bool RulerDescriptor::editPoint(std::any value, odb::Point& pt, bool is_x)
+bool RulerDescriptor::editPoint(const std::any& value,
+                                odb::Point& pt,
+                                bool is_x)
 {
   bool accept;
   const int new_val = Descriptor::Property::convert_string(
@@ -202,7 +205,7 @@ bool RulerDescriptor::editPoint(std::any value, odb::Point& pt, bool is_x)
   return true;
 }
 
-Descriptor::Actions RulerDescriptor::getActions(std::any object) const
+Descriptor::Actions RulerDescriptor::getActions(const std::any& object) const
 {
   auto ruler = std::any_cast<Ruler*>(object);
 
@@ -212,7 +215,7 @@ Descriptor::Actions RulerDescriptor::getActions(std::any object) const
            }}};
 }
 
-Selected RulerDescriptor::makeSelected(std::any object) const
+Selected RulerDescriptor::makeSelected(const std::any& object) const
 {
   if (auto ruler = std::any_cast<Ruler*>(&object)) {
     return Selected(*ruler, this);
@@ -220,7 +223,7 @@ Selected RulerDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool RulerDescriptor::lessThan(std::any l, std::any r) const
+bool RulerDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_ruler = std::any_cast<Ruler*>(l);
   auto r_ruler = std::any_cast<Ruler*>(r);

--- a/src/gui/src/ruler.h
+++ b/src/gui/src/ruler.h
@@ -63,23 +63,23 @@ class RulerDescriptor : public Descriptor
   RulerDescriptor(const std::vector<std::unique_ptr<Ruler>>& rulers,
                   odb::dbDatabase* db);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Editors getEditors(std::any object) const override;
-  Actions getActions(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Editors getEditors(const std::any& object) const override;
+  Actions getActions(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
 
  private:
-  static bool editPoint(std::any value, odb::Point& pt, bool is_x);
+  static bool editPoint(const std::any& value, odb::Point& pt, bool is_x);
 
   const std::vector<std::unique_ptr<Ruler>>& rulers_;
   odb::dbDatabase* db_;

--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -74,7 +74,7 @@ LibertyLibraryDescriptor::LibertyLibraryDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string LibertyLibraryDescriptor::getName(std::any object) const
+std::string LibertyLibraryDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::LibertyLibrary*>(object)->name();
 }
@@ -84,12 +84,13 @@ std::string LibertyLibraryDescriptor::getTypeName() const
   return "Liberty library";
 }
 
-bool LibertyLibraryDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool LibertyLibraryDescriptor::getBBox(const std::any& object,
+                                       odb::Rect& bbox) const
 {
   return false;
 }
 
-void LibertyLibraryDescriptor::highlight(std::any object,
+void LibertyLibraryDescriptor::highlight(const std::any& object,
                                          Painter& painter) const
 {
   auto library = std::any_cast<sta::LibertyLibrary*>(object);
@@ -111,7 +112,7 @@ void LibertyLibraryDescriptor::highlight(std::any object,
 }
 
 Descriptor::Properties LibertyLibraryDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto library = std::any_cast<sta::LibertyLibrary*>(object);
 
@@ -195,7 +196,7 @@ Descriptor::Properties LibertyLibraryDescriptor::getProperties(
   return props;
 }
 
-Selected LibertyLibraryDescriptor::makeSelected(std::any object) const
+Selected LibertyLibraryDescriptor::makeSelected(const std::any& object) const
 {
   if (auto library = std::any_cast<sta::LibertyLibrary*>(&object)) {
     return Selected(*library, this);
@@ -203,7 +204,8 @@ Selected LibertyLibraryDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool LibertyLibraryDescriptor::lessThan(std::any l, std::any r) const
+bool LibertyLibraryDescriptor::lessThan(const std::any& l,
+                                        const std::any& r) const
 {
   auto l_library = std::any_cast<sta::LibertyLibrary*>(l);
   auto r_library = std::any_cast<sta::LibertyLibrary*>(r);
@@ -229,7 +231,7 @@ LibertyCellDescriptor::LibertyCellDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string LibertyCellDescriptor::getName(std::any object) const
+std::string LibertyCellDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::LibertyCell*>(object)->name();
 }
@@ -239,12 +241,14 @@ std::string LibertyCellDescriptor::getTypeName() const
   return "Liberty cell";
 }
 
-bool LibertyCellDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool LibertyCellDescriptor::getBBox(const std::any& object,
+                                    odb::Rect& bbox) const
 {
   return false;
 }
 
-void LibertyCellDescriptor::highlight(std::any object, Painter& painter) const
+void LibertyCellDescriptor::highlight(const std::any& object,
+                                      Painter& painter) const
 {
   auto cell = std::any_cast<sta::LibertyCell*>(object);
   auto* network = sta_->getDbNetwork();
@@ -255,7 +259,7 @@ void LibertyCellDescriptor::highlight(std::any object, Painter& painter) const
 }
 
 Descriptor::Properties LibertyCellDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto cell = std::any_cast<sta::LibertyCell*>(object);
 
@@ -330,7 +334,7 @@ Descriptor::Properties LibertyCellDescriptor::getProperties(
   return props;
 }
 
-Selected LibertyCellDescriptor::makeSelected(std::any object) const
+Selected LibertyCellDescriptor::makeSelected(const std::any& object) const
 {
   if (auto cell = std::any_cast<sta::LibertyCell*>(&object)) {
     return Selected(*cell, this);
@@ -338,7 +342,7 @@ Selected LibertyCellDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool LibertyCellDescriptor::lessThan(std::any l, std::any r) const
+bool LibertyCellDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_cell = std::any_cast<sta::LibertyCell*>(l);
   auto r_cell = std::any_cast<sta::LibertyCell*>(r);
@@ -368,7 +372,7 @@ LibertyPortDescriptor::LibertyPortDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string LibertyPortDescriptor::getName(std::any object) const
+std::string LibertyPortDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::LibertyPort*>(object)->name();
 }
@@ -378,12 +382,14 @@ std::string LibertyPortDescriptor::getTypeName() const
   return "Liberty port";
 }
 
-bool LibertyPortDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool LibertyPortDescriptor::getBBox(const std::any& object,
+                                    odb::Rect& bbox) const
 {
   return false;
 }
 
-void LibertyPortDescriptor::highlight(std::any object, Painter& painter) const
+void LibertyPortDescriptor::highlight(const std::any& object,
+                                      Painter& painter) const
 {
   auto port = std::any_cast<sta::LibertyPort*>(object);
   auto* network = sta_->getDbNetwork();
@@ -396,7 +402,7 @@ void LibertyPortDescriptor::highlight(std::any object, Painter& painter) const
 }
 
 Descriptor::Properties LibertyPortDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto port = std::any_cast<sta::LibertyPort*>(object);
   auto* network = sta_->getDbNetwork();
@@ -489,7 +495,7 @@ Descriptor::Properties LibertyPortDescriptor::getProperties(
   return props;
 }
 
-Selected LibertyPortDescriptor::makeSelected(std::any object) const
+Selected LibertyPortDescriptor::makeSelected(const std::any& object) const
 {
   if (auto port = std::any_cast<sta::LibertyPort*>(&object)) {
     return Selected(*port, this);
@@ -497,7 +503,7 @@ Selected LibertyPortDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool LibertyPortDescriptor::lessThan(std::any l, std::any r) const
+bool LibertyPortDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_port = std::any_cast<sta::LibertyPort*>(l);
   auto r_port = std::any_cast<sta::LibertyPort*>(r);
@@ -560,7 +566,7 @@ LibertyPgPortDescriptor::LibertyPgPortDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string LibertyPgPortDescriptor::getName(std::any object) const
+std::string LibertyPgPortDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::LibertyPgPort*>(object)->name();
 }
@@ -570,12 +576,14 @@ std::string LibertyPgPortDescriptor::getTypeName() const
   return "Liberty PG port";
 }
 
-bool LibertyPgPortDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool LibertyPgPortDescriptor::getBBox(const std::any& object,
+                                      odb::Rect& bbox) const
 {
   return false;
 }
 
-void LibertyPgPortDescriptor::highlight(std::any object, Painter& painter) const
+void LibertyPgPortDescriptor::highlight(const std::any& object,
+                                        Painter& painter) const
 {
   odb::dbMTerm* mterm = getMTerm(object);
 
@@ -586,7 +594,7 @@ void LibertyPgPortDescriptor::highlight(std::any object, Painter& painter) const
 }
 
 Descriptor::Properties LibertyPgPortDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto port = std::any_cast<sta::LibertyPgPort*>(object);
 
@@ -605,7 +613,7 @@ Descriptor::Properties LibertyPgPortDescriptor::getProperties(
   return props;
 }
 
-Selected LibertyPgPortDescriptor::makeSelected(std::any object) const
+Selected LibertyPgPortDescriptor::makeSelected(const std::any& object) const
 {
   if (auto port = std::any_cast<sta::LibertyPgPort*>(&object)) {
     return Selected(*port, this);
@@ -613,7 +621,8 @@ Selected LibertyPgPortDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool LibertyPgPortDescriptor::lessThan(std::any l, std::any r) const
+bool LibertyPgPortDescriptor::lessThan(const std::any& l,
+                                       const std::any& r) const
 {
   auto l_port = std::any_cast<sta::LibertyPgPort*>(l);
   auto r_port = std::any_cast<sta::LibertyPgPort*>(r);
@@ -654,7 +663,7 @@ CornerDescriptor::CornerDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string CornerDescriptor::getName(std::any object) const
+std::string CornerDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::Corner*>(object)->name();
 }
@@ -664,16 +673,17 @@ std::string CornerDescriptor::getTypeName() const
   return "Timing corner";
 }
 
-bool CornerDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool CornerDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void CornerDescriptor::highlight(std::any object, Painter& painter) const
+void CornerDescriptor::highlight(const std::any& object, Painter& painter) const
 {
 }
 
-Descriptor::Properties CornerDescriptor::getProperties(std::any object) const
+Descriptor::Properties CornerDescriptor::getProperties(
+    const std::any& object) const
 {
   auto corner = std::any_cast<sta::Corner*>(object);
 
@@ -692,7 +702,7 @@ Descriptor::Properties CornerDescriptor::getProperties(std::any object) const
   return props;
 }
 
-Selected CornerDescriptor::makeSelected(std::any object) const
+Selected CornerDescriptor::makeSelected(const std::any& object) const
 {
   if (auto corner = std::any_cast<sta::Corner*>(&object)) {
     return Selected(*corner, this);
@@ -700,7 +710,7 @@ Selected CornerDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool CornerDescriptor::lessThan(std::any l, std::any r) const
+bool CornerDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_corner = std::any_cast<sta::Corner*>(l);
   auto r_corner = std::any_cast<sta::Corner*>(r);
@@ -719,7 +729,7 @@ StaInstanceDescriptor::StaInstanceDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string StaInstanceDescriptor::getName(std::any object) const
+std::string StaInstanceDescriptor::getName(const std::any& object) const
 {
   return sta_->network()->name(std::any_cast<sta::Instance*>(object));
 }
@@ -729,12 +739,14 @@ std::string StaInstanceDescriptor::getTypeName() const
   return "Timing/Power";
 }
 
-bool StaInstanceDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool StaInstanceDescriptor::getBBox(const std::any& object,
+                                    odb::Rect& bbox) const
 {
   return false;
 }
 
-void StaInstanceDescriptor::highlight(std::any object, Painter& painter) const
+void StaInstanceDescriptor::highlight(const std::any& object,
+                                      Painter& painter) const
 {
   auto inst = std::any_cast<sta::Instance*>(object);
   odb::dbInst* db_inst = sta_->getDbNetwork()->staToDb(inst);
@@ -744,7 +756,7 @@ void StaInstanceDescriptor::highlight(std::any object, Painter& painter) const
 }
 
 Descriptor::Properties StaInstanceDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto inst = std::any_cast<sta::Instance*>(object);
   auto* network = sta_->getDbNetwork();
@@ -851,7 +863,7 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
   return props;
 }
 
-Selected StaInstanceDescriptor::makeSelected(std::any object) const
+Selected StaInstanceDescriptor::makeSelected(const std::any& object) const
 {
   if (auto inst = std::any_cast<sta::Instance*>(object)) {
     return Selected(inst, this);
@@ -859,7 +871,7 @@ Selected StaInstanceDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool StaInstanceDescriptor::lessThan(std::any l, std::any r) const
+bool StaInstanceDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto* network = sta_->getDbNetwork();
   auto l_inst = std::any_cast<sta::Instance*>(l);
@@ -883,7 +895,7 @@ ClockDescriptor::ClockDescriptor(sta::dbSta* sta) : sta_(sta)
 {
 }
 
-std::string ClockDescriptor::getName(std::any object) const
+std::string ClockDescriptor::getName(const std::any& object) const
 {
   return std::any_cast<sta::Clock*>(object)->name();
 }
@@ -893,12 +905,12 @@ std::string ClockDescriptor::getTypeName() const
   return "Clock";
 }
 
-bool ClockDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool ClockDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   return false;
 }
 
-void ClockDescriptor::highlight(std::any object, Painter& painter) const
+void ClockDescriptor::highlight(const std::any& object, Painter& painter) const
 {
   auto clock = std::any_cast<sta::Clock*>(object);
   auto* network = sta_->getDbNetwork();
@@ -954,7 +966,8 @@ std::set<const sta::Pin*> ClockDescriptor::getClockPins(sta::Clock* clock) const
   return pins;
 }
 
-Descriptor::Properties ClockDescriptor::getProperties(std::any object) const
+Descriptor::Properties ClockDescriptor::getProperties(
+    const std::any& object) const
 {
   auto clock = std::any_cast<sta::Clock*>(object);
   auto* network = sta_->getDbNetwork();
@@ -1043,7 +1056,7 @@ Descriptor::Properties ClockDescriptor::getProperties(std::any object) const
   return props;
 }
 
-Selected ClockDescriptor::makeSelected(std::any object) const
+Selected ClockDescriptor::makeSelected(const std::any& object) const
 {
   if (auto clock = std::any_cast<sta::Clock*>(&object)) {
     return Selected(*clock, this);
@@ -1051,7 +1064,7 @@ Selected ClockDescriptor::makeSelected(std::any object) const
   return Selected();
 }
 
-bool ClockDescriptor::lessThan(std::any l, std::any r) const
+bool ClockDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_clock = std::any_cast<sta::Clock*>(l);
   auto r_clock = std::any_cast<sta::Clock*>(r);

--- a/src/gui/src/staDescriptors.h
+++ b/src/gui/src/staDescriptors.h
@@ -25,15 +25,15 @@ class LibertyLibraryDescriptor : public Descriptor
  public:
   LibertyLibraryDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -47,15 +47,15 @@ class LibertyCellDescriptor : public Descriptor
  public:
   LibertyCellDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -69,15 +69,15 @@ class LibertyPortDescriptor : public Descriptor
  public:
   LibertyPortDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -91,15 +91,15 @@ class LibertyPgPortDescriptor : public Descriptor
  public:
   LibertyPgPortDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -115,15 +115,15 @@ class CornerDescriptor : public Descriptor
  public:
   CornerDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -137,15 +137,15 @@ class StaInstanceDescriptor : public Descriptor
  public:
   StaInstanceDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;
@@ -161,15 +161,15 @@ class ClockDescriptor : public Descriptor
  public:
   ClockDescriptor(sta::dbSta* sta);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override;
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  void highlight(std::any object, Painter& painter) const override;
+  void highlight(const std::any& object, Painter& painter) const override;
 
-  Properties getProperties(std::any object) const override;
-  Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  Properties getProperties(const std::any& object) const override;
+  Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;

--- a/src/psm/src/debug_gui.cpp
+++ b/src/psm/src/debug_gui.cpp
@@ -54,20 +54,21 @@ NodeDescriptor::NodeDescriptor(
 {
 }
 
-std::string NodeDescriptor::getName(std::any object) const
+std::string NodeDescriptor::getName(const std::any& object) const
 {
   auto node = std::any_cast<Node*>(object);
   return node->getName();
 }
 
-bool NodeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool NodeDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto node = std::any_cast<Node*>(object);
   bbox = odb::Rect(node->getPoint(), node->getPoint());
   return true;
 }
 
-gui::Descriptor::Properties NodeDescriptor::getProperties(std::any object) const
+gui::Descriptor::Properties NodeDescriptor::getProperties(
+    const std::any& object) const
 {
   auto node = std::any_cast<Node*>(object);
 
@@ -120,7 +121,7 @@ gui::Descriptor::Properties NodeDescriptor::getProperties(std::any object) const
   return props;
 }
 
-gui::Selected NodeDescriptor::makeSelected(std::any object) const
+gui::Selected NodeDescriptor::makeSelected(const std::any& object) const
 {
   if (auto node = std::any_cast<Node*>(&object)) {
     return gui::Selected(*node, this);
@@ -128,14 +129,15 @@ gui::Selected NodeDescriptor::makeSelected(std::any object) const
   return gui::Selected();
 }
 
-bool NodeDescriptor::lessThan(std::any l, std::any r) const
+bool NodeDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_node = std::any_cast<Node*>(l);
   auto r_node = std::any_cast<Node*>(r);
   return l_node->compare(r_node);
 }
 
-void NodeDescriptor::highlight(std::any object, gui::Painter& painter) const
+void NodeDescriptor::highlight(const std::any& object,
+                               gui::Painter& painter) const
 {
   auto node = std::any_cast<Node*>(object);
   auto& pt = node->getPoint();
@@ -150,13 +152,13 @@ ITermNodeDescriptor::ITermNodeDescriptor(
 {
 }
 
-std::string ITermNodeDescriptor::getName(std::any object) const
+std::string ITermNodeDescriptor::getName(const std::any& object) const
 {
   auto node = std::any_cast<ITermNode*>(object);
   return node->getName();
 }
 
-bool ITermNodeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool ITermNodeDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto node = std::any_cast<ITermNode*>(object);
   bbox = node->getShape();
@@ -164,7 +166,7 @@ bool ITermNodeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
 }
 
 gui::Descriptor::Properties ITermNodeDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto node = std::any_cast<ITermNode*>(object);
 
@@ -176,7 +178,7 @@ gui::Descriptor::Properties ITermNodeDescriptor::getProperties(
   return props;
 }
 
-gui::Selected ITermNodeDescriptor::makeSelected(std::any object) const
+gui::Selected ITermNodeDescriptor::makeSelected(const std::any& object) const
 {
   if (auto node = std::any_cast<ITermNode*>(&object)) {
     return gui::Selected(*node, this);
@@ -184,14 +186,14 @@ gui::Selected ITermNodeDescriptor::makeSelected(std::any object) const
   return gui::Selected();
 }
 
-bool ITermNodeDescriptor::lessThan(std::any l, std::any r) const
+bool ITermNodeDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_node = std::any_cast<ITermNode*>(l);
   auto r_node = std::any_cast<ITermNode*>(r);
   return l_node->compare(r_node);
 }
 
-void ITermNodeDescriptor::highlight(std::any object,
+void ITermNodeDescriptor::highlight(const std::any& object,
                                     gui::Painter& painter) const
 {
   auto node = std::any_cast<ITermNode*>(object);
@@ -206,13 +208,13 @@ BPinNodeDescriptor::BPinNodeDescriptor(
 {
 }
 
-std::string BPinNodeDescriptor::getName(std::any object) const
+std::string BPinNodeDescriptor::getName(const std::any& object) const
 {
   auto node = std::any_cast<BPinNode*>(object);
   return node->getName();
 }
 
-bool BPinNodeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool BPinNodeDescriptor::getBBox(const std::any& object, odb::Rect& bbox) const
 {
   auto node = std::any_cast<BPinNode*>(object);
   bbox = node->getShape();
@@ -220,7 +222,7 @@ bool BPinNodeDescriptor::getBBox(std::any object, odb::Rect& bbox) const
 }
 
 gui::Descriptor::Properties BPinNodeDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto node = std::any_cast<BPinNode*>(object);
 
@@ -232,7 +234,7 @@ gui::Descriptor::Properties BPinNodeDescriptor::getProperties(
   return props;
 }
 
-gui::Selected BPinNodeDescriptor::makeSelected(std::any object) const
+gui::Selected BPinNodeDescriptor::makeSelected(const std::any& object) const
 {
   if (auto node = std::any_cast<BPinNode*>(&object)) {
     return gui::Selected(*node, this);
@@ -240,14 +242,15 @@ gui::Selected BPinNodeDescriptor::makeSelected(std::any object) const
   return gui::Selected();
 }
 
-bool BPinNodeDescriptor::lessThan(std::any l, std::any r) const
+bool BPinNodeDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_node = std::any_cast<BPinNode*>(l);
   auto r_node = std::any_cast<BPinNode*>(r);
   return l_node->compare(r_node);
 }
 
-void BPinNodeDescriptor::highlight(std::any object, gui::Painter& painter) const
+void BPinNodeDescriptor::highlight(const std::any& object,
+                                   gui::Painter& painter) const
 {
   auto node = std::any_cast<BPinNode*>(object);
   NodeDescriptor::highlight(static_cast<Node*>(node), painter);
@@ -261,13 +264,14 @@ ConnectionDescriptor::ConnectionDescriptor(
 {
 }
 
-std::string ConnectionDescriptor::getName(std::any object) const
+std::string ConnectionDescriptor::getName(const std::any& object) const
 {
   auto conn = std::any_cast<Connection*>(object);
   return conn->getNode0()->getName() + "->" + conn->getNode1()->getName();
 }
 
-bool ConnectionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
+bool ConnectionDescriptor::getBBox(const std::any& object,
+                                   odb::Rect& bbox) const
 {
   auto conn = std::any_cast<Connection*>(object);
   bbox = odb::Rect(conn->getNode0()->getPoint(), conn->getNode1()->getPoint());
@@ -275,7 +279,7 @@ bool ConnectionDescriptor::getBBox(std::any object, odb::Rect& bbox) const
 }
 
 gui::Descriptor::Properties ConnectionDescriptor::getProperties(
-    std::any object) const
+    const std::any& object) const
 {
   auto conn = std::any_cast<Connection*>(object);
 
@@ -328,7 +332,7 @@ gui::Descriptor::Properties ConnectionDescriptor::getProperties(
   return props;
 }
 
-gui::Selected ConnectionDescriptor::makeSelected(std::any object) const
+gui::Selected ConnectionDescriptor::makeSelected(const std::any& object) const
 {
   if (auto conn = std::any_cast<Connection*>(&object)) {
     return gui::Selected(*conn, this);
@@ -336,14 +340,14 @@ gui::Selected ConnectionDescriptor::makeSelected(std::any object) const
   return gui::Selected();
 }
 
-bool ConnectionDescriptor::lessThan(std::any l, std::any r) const
+bool ConnectionDescriptor::lessThan(const std::any& l, const std::any& r) const
 {
   auto l_conn = std::any_cast<Connection*>(l);
   auto r_conn = std::any_cast<Connection*>(r);
   return l_conn->compare(r_conn);
 }
 
-void ConnectionDescriptor::highlight(std::any object,
+void ConnectionDescriptor::highlight(const std::any& object,
                                      gui::Painter& painter) const
 {
   auto conn = std::any_cast<Connection*>(object);

--- a/src/psm/src/debug_gui.h
+++ b/src/psm/src/debug_gui.h
@@ -46,19 +46,20 @@ class NodeDescriptor : public SolverDescriptor
   NodeDescriptor(
       const std::map<odb::dbNet*, std::unique_ptr<IRSolver>>& solvers);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override { return "PSM Node"; }
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
   void visitAllObjects(
       const std::function<void(const gui::Selected&)>&) const override
   {
   }
-  gui::Descriptor::Properties getProperties(std::any object) const override;
-  gui::Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  gui::Descriptor::Properties getProperties(
+      const std::any& object) const override;
+  gui::Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
-  void highlight(std::any object, gui::Painter& painter) const override;
+  void highlight(const std::any& object, gui::Painter& painter) const override;
 };
 
 class ITermNodeDescriptor : public NodeDescriptor
@@ -67,15 +68,16 @@ class ITermNodeDescriptor : public NodeDescriptor
   ITermNodeDescriptor(
       const std::map<odb::dbNet*, std::unique_ptr<IRSolver>>& solvers);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override { return "PSM ITerm Node"; }
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  gui::Descriptor::Properties getProperties(std::any object) const override;
-  gui::Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  gui::Descriptor::Properties getProperties(
+      const std::any& object) const override;
+  gui::Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
-  void highlight(std::any object, gui::Painter& painter) const override;
+  void highlight(const std::any& object, gui::Painter& painter) const override;
 };
 
 class BPinNodeDescriptor : public NodeDescriptor
@@ -84,15 +86,16 @@ class BPinNodeDescriptor : public NodeDescriptor
   BPinNodeDescriptor(
       const std::map<odb::dbNet*, std::unique_ptr<IRSolver>>& solvers);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override { return "PSM BPin Node"; }
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
-  gui::Descriptor::Properties getProperties(std::any object) const override;
-  gui::Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  gui::Descriptor::Properties getProperties(
+      const std::any& object) const override;
+  gui::Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
-  void highlight(std::any object, gui::Painter& painter) const override;
+  void highlight(const std::any& object, gui::Painter& painter) const override;
 };
 
 class ConnectionDescriptor : public SolverDescriptor
@@ -101,19 +104,20 @@ class ConnectionDescriptor : public SolverDescriptor
   ConnectionDescriptor(
       const std::map<odb::dbNet*, std::unique_ptr<IRSolver>>& solvers);
 
-  std::string getName(std::any object) const override;
+  std::string getName(const std::any& object) const override;
   std::string getTypeName() const override { return "PSM Connection"; }
-  bool getBBox(std::any object, odb::Rect& bbox) const override;
+  bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
   void visitAllObjects(
       const std::function<void(const gui::Selected&)>&) const override
   {
   }
-  gui::Descriptor::Properties getProperties(std::any object) const override;
-  gui::Selected makeSelected(std::any object) const override;
-  bool lessThan(std::any l, std::any r) const override;
+  gui::Descriptor::Properties getProperties(
+      const std::any& object) const override;
+  gui::Selected makeSelected(const std::any& object) const override;
+  bool lessThan(const std::any& l, const std::any& r) const override;
 
-  void highlight(std::any object, gui::Painter& painter) const override;
+  void highlight(const std::any& object, gui::Painter& painter) const override;
 };
 
 class DebugGui : public gui::Renderer


### PR DESCRIPTION
No functional changes, just switches descriptors to use `const &` for `std::any`'s