### PR TITLE
gpl: include the consideration of debug group,

### DIFF
--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -1015,7 +1015,9 @@ void PlacerBase::init()
       continue;
     }
 
-    if (inst->dbInst() && inst->dbInst()->getGroup() != group_) {
+    if ((inst->dbInst() && inst->dbInst()->getGroup() != group_)
+        && inst->dbInst()->getGroup()->getType()
+               != odb::dbGroupType::VISUAL_DEBUG) {
       continue;
     }
 
@@ -1196,7 +1198,9 @@ void PlacerBase::initInstsForUnusableSites()
     if (!inst->isFixed()) {
       continue;
     }
-    if (inst->dbInst() && inst->dbInst()->getGroup() != group_) {
+    if ((inst->dbInst() && inst->dbInst()->getGroup() != group_)
+        && inst->dbInst()->getGroup()->getType()
+               != odb::dbGroupType::VISUAL_DEBUG) {
       continue;
     }
     std::pair<int, int> pairX = getMinMaxIdx(


### PR DESCRIPTION
when this group is present, instances will be placed together with the set of instances that belong to no group, associated with no region.

I tested with an example provided by @AcKoucher at branch `mpl-keep-clustering`, and it seems to work as intended:
![placement(3)(1)](https://github.com/user-attachments/assets/f3012f0f-0ea4-4be7-9927-2a392da50d9f)

without the changes in the current PR gpl was setting all instances participating in the debug group as not movable.

I triggered a secure-CI at: [secure-gpl-consider-debug-group](https://jenkins.openroad.tools/blue/organizations/jenkins/OpenROAD-flow-scripts-Private/detail/secure-gpl-consider-debug-group/1/pipeline)