### PR TITLE
Fix issue with `openroad_deps_prefixes.txt` permissions & add case for AlmaLinux 9

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -1021,7 +1021,7 @@ if [[ ! -z ${saveDepsPrefixes} ]]; then
     mkdir -p "$(dirname $saveDepsPrefixes)"
     echo "$CMAKE_PACKAGE_ROOT_ARGS" > $saveDepsPrefixes
     # Fix permissions if running as root to allow user access
-    if [[ $(id -u) == 0 && ! -z "$SUDO_USER" ]]; then
+    if [[ $(id -u) == 0 && ! -z "${SUDO_USER+x}" ]]; then
         chown "$SUDO_USER:$(id -gn "$SUDO_USER")" "$saveDepsPrefixes" 2>/dev/null || true
     fi
 fi

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -933,11 +933,13 @@ case "${os}" in
             _installOrTools "ubuntu" "${ubuntuVersion}" "amd64"
         fi
         ;;
-    "Red Hat Enterprise Linux" | "Rocky Linux")
+    "Red Hat Enterprise Linux" | "Rocky Linux" | "AlmaLinux")
     if [[ "${os}" == "Red Hat Enterprise Linux" ]]; then
         rhelVersion=$(rpm -q --queryformat '%{VERSION}' redhat-release | cut -d. -f1)
     elif  [[ "${os}" == "Rocky Linux" ]]; then
         rhelVersion=$(rpm -q --queryformat '%{VERSION}' rocky-release | cut -d. -f1)
+    elif [[ "${os}" == "AlmaLinux" ]]; then
+        rhelVersion=$(rpm -q --queryformat '%{VERSION}' almalinux-release | cut -d. -f1)
     fi
         if [[ "${rhelVersion}" != "8" ]] && [[ "${rhelVersion}" != "9" ]]; then
             echo "ERROR: Unsupported ${rhelVersion} version. Versions '8' and '9' are supported."
@@ -1018,4 +1020,8 @@ esac
 if [[ ! -z ${saveDepsPrefixes} ]]; then
     mkdir -p "$(dirname $saveDepsPrefixes)"
     echo "$CMAKE_PACKAGE_ROOT_ARGS" > $saveDepsPrefixes
+    # Fix permissions if running as root to allow user access
+    if [[ $(id -u) == 0 && ! -z "$SUDO_USER" ]]; then
+        chown "$SUDO_USER:$(id -gn "$SUDO_USER")" "$saveDepsPrefixes" 2>/dev/null || true
+    fi
 fi


### PR DESCRIPTION
Hi there, thanks for this awesome project. Just managed to build from source. :)

This PR addresses two issues found when trying to build OpenROAD via the OpenROAD flow scripts repo on AlmaLinux 9. (binary-compatible with RHEL9 & RockyLinux 9). AlmaLinux 9 gets lots of use at universities here in Germany, and is used now by scientific institutions like CERN, so I guess it's worth adding this.

## Fix 1
The first issues, was basically that a case for AlmaLinux when checking the `os-release` variable didn't exist in the `etc/DependencyInstaller.sh`. So I simply added a match:

```bash
# etc/DependencyInstaller.sh
elif [[ "${os}" == "AlmaLinux" ]]; then
    rhelVersion=$(rpm -q --queryformat '%{VERSION}' almalinux-release | cut -d. -f1)
```


## Fix 2
The second change I'm a bit more unsure of, but essentially the docs recommend the higher-level flow scripts repo `setup.sh` script be run with `sudo`, but this causes the `openroad_deps_prefixes.txt` to be owned by `root`. During setup, within the main `OpenROAD` submodule this causes the error:

```bash
line 954: $HOME/OpenROAD-flow-scripts/tools/OpenROAD/etc/openroad_deps_prefixes.txt: Permission denied
```

I tested the flow script `setup.sh` build on AlmaLinux 9, Ubuntu 24.04, and Ubuntu 20.04 and this issue appears to exist regardless of platform.

Would hopefully resolves several related issues:
[#2904](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2904) - Permission denied error on Ubuntu 24 during install
[#3137](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3137) - Permission denied accessing openroad_deps_prefixes.txt
[#2505](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2505) - Permission denied error when running setup.sh (was inside Docker container)

My fix is to essentially `chmod` the file permissions if the user is running as `root`:

```bash
# etc/DependencyInstaller.sh

 1020    if [[ ! -z ${saveDepsPrefixes} ]]; then
 1021        mkdir -p "$(dirname $saveDepsPrefixes)"
 1022        echo "$CMAKE_PACKAGE_ROOT_ARGS" > $saveDepsPrefixes
 1023 +      # Fix permissions if running as root to allow user access
 1024 +      if [[ $(id -u) == 0 && ! -z "$SUDO_USER" ]]; then
 1025 +          chown "$SUDO_USER:$(id -gn "$SUDO_USER")" "$saveDepsPrefixes" 2>/dev/null || true
 1026 +      fi
 1027    fi

```
If this is a bit too much of a "hack", I'm open to feedback and can modify my pull request. Just hoping to get the build working in upstream so others in my group can more easily install OpenROAD. :+1: 