### PR TITLE
gui: pass object not Selected object to getProperties

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -504,7 +504,6 @@ int Gui::select(const std::string& type,
           if (
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
               !reg_filter.match(QString::fromStdString(sel_name)).hasMatch()
-
 #else
               !reg_filter.exactMatch(QString::fromStdString(sel_name))
 #endif
@@ -516,7 +515,8 @@ int Gui::select(const std::string& type,
 
       if (!attribute.empty()) {
         bool is_valid_attribute = false;
-        Descriptor::Properties properties = descriptor->getProperties(sel);
+        Descriptor::Properties properties
+            = descriptor->getProperties(sel.getObject());
         if (filterSelectionProperties(
                 properties, attribute, value, is_valid_attribute)) {
           return;  // doesn't match the attribute filter


### PR DESCRIPTION
Fixes the `std::bad_cast` which was attempting to convert a Selected to a dbInst

FYI: @gudeh 