### PR TITLE
est: fix coverity issue

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -2223,6 +2223,8 @@ void TritonCTS::balanceMacroRegisterLatencies()
       }
     }
   }
+
+  parasitics_guard.end();
 }
 
 float TritonCTS::getVertexClkArrival(sta::Vertex* sinkVertex,

--- a/src/est/include/est/EstimateParasitics.h
+++ b/src/est/include/est/EstimateParasitics.h
@@ -293,10 +293,11 @@ class IncrementalParasiticsGuard
 {
  public:
   IncrementalParasiticsGuard(est::EstimateParasitics* estimate_parasitics);
-  ~IncrementalParasiticsGuard();
+  ~IncrementalParasiticsGuard() = default;
 
   // calls estimate_parasitics_->updateParasitics()
   void update();
+  void end();
 
  private:
   est::EstimateParasitics* estimate_parasitics_;

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -1114,7 +1114,7 @@ void IncrementalParasiticsGuard::update()
   estimate_parasitics_->updateParasitics();
 }
 
-IncrementalParasiticsGuard::~IncrementalParasiticsGuard()
+void IncrementalParasiticsGuard::end()
 {
   if (need_unregister_) {
     estimate_parasitics_->removeDbCbkOwner();

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -2394,6 +2394,8 @@ void Rebuffer::fullyRebuffer(Pin* user_pin)
   debugPrint(
       logger_, RSZ, "rebuffer", 1, "Buffer for timing {:.2f}", bft_runtime);
   debugPrint(logger_, RSZ, "rebuffer", 1, "Recover area {:.2f}", ra_runtime);
+
+  guard.end();
 }
 
 bool Rebuffer::hasTopLevelOutputPort(Net* net)
@@ -2566,6 +2568,7 @@ void BufferMove::rebufferNet(const Pin* drvr_pin)
   est::IncrementalParasiticsGuard guard(estimate_parasitics_);
   int inserted_buffer_count_ = rebuffer->rebufferPin(drvr_pin);
   logger_->report("Inserted {} buffers.", inserted_buffer_count_);
+  guard.end();
 }
 
 };  // namespace rsz

--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -210,6 +210,7 @@ bool RecoverPower::recoverPower(const float recover_power_percent, bool verbose)
     logger_->error(RSZ, 125, "max utilization reached.");
   }
 
+  guard.end();
   return recovered;
 }
 
@@ -227,11 +228,13 @@ Vertex* RecoverPower::recoverPower(const Pin* end_pin)
   {
     est::IncrementalParasiticsGuard guard(estimate_parasitics_);
     drvr_vertex = recoverPower(path, slack);
+    guard.end();
   }
 
   if (resize_count_ > 0) {
     logger_->info(RSZ, 3111, "Resized {} instances.", resize_count_);
   }
+
   return drvr_vertex;
 }
 

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -307,6 +307,7 @@ void RepairDesign::repairDesign(
     }
     estimate_parasitics_->updateParasitics();
     printProgress(print_iteration, true, true, repaired_net_count);
+    guard.end();
   }
 
   if (inserted_buffer_count_ > 0) {
@@ -378,6 +379,7 @@ void RepairDesign::repairClkNets(double max_wire_length)
         }
       }
     }
+    guard.end();
   }
 
   if (length_violations > 0) {
@@ -442,6 +444,7 @@ void RepairDesign::repairNet(Net* net,
                 fanout_violations,
                 length_violations);
     }
+    guard.end();
   }
 
   reportViolationCounters(true,

--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -93,6 +93,7 @@ bool RepairHold::repairHold(
                           max_buffer_count,
                           max_passes,
                           verbose);
+    guard.end();
   }
 
   return repaired;
@@ -128,6 +129,7 @@ void RepairHold::repairHold(const Pin* end_pin,
                max_buffer_count,
                max_passes,
                false);
+    guard.end();
   }
 }
 

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -500,6 +500,7 @@ bool RepairSetup::repairSetup(const float setup_slack_margin,
     logger_->error(RSZ, 25, "max utilization reached.");
   }
 
+  guard.end();
   return repaired;
 }
 
@@ -525,6 +526,7 @@ void RepairSetup::repairSetup(const Pin* end_pin)
   {
     est::IncrementalParasiticsGuard guard(estimate_parasitics_);
     repairPath(path, slack, 0.0);
+    guard.end();
   }
 
   int unbuffer_moves_ = resizer_->unbuffer_move_->numCommittedMoves();

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -388,6 +388,7 @@ void Resizer::removeBuffers(sta::InstanceSeq insts)
   unbuffer_move_->commitMoves();
   level_drvr_vertices_valid_ = false;
   logger_->info(RSZ, 26, "Removed {} buffers.", unbuffer_move_->numMoves());
+  guard.end();
 }
 
 void Resizer::unbufferNet(Net* net)
@@ -1006,6 +1007,7 @@ void Resizer::bufferInputs(LibertyCell* buffer_cell, bool verbose)
         bufferInput(pin, selected_buffer_cell, verbose);
       }
     }
+    guard.end();
   }
 
   logger_->info(RSZ,
@@ -1249,6 +1251,7 @@ void Resizer::bufferOutputs(LibertyCell* buffer_cell, bool verbose)
         bufferOutput(pin, selected_buffer_cell, verbose);
       }
     }
+    guard.end();
   }
 
   logger_->info(RSZ,
@@ -2476,6 +2479,7 @@ void Resizer::findResizeSlacks(bool run_journal_restore)
     journalRestore();
     level_drvr_vertices_valid_ = false;
   }
+  guard.end();
 }
 
 void Resizer::findResizeSlacks1()


### PR DESCRIPTION
Coverity complains about the possibility of having a `throw std::runtime_error` inside the `IncrementalParasiticsGuard` destructor. It happens because the destructor calls the `EstimateParasitics::updateParasitics` function, which can fall into a case where a Logger::error would be generated.

In practice, is very unlikely that it would happen, but Coverity complains about it anyway. My approach to fix it is to add a `IncrementalParasiticsGuard::end` function, which needs to be explicitly called at the end of the escope of which use of this class.