### PR TITLE
mpl: adjust regression test to new IO Pads handling approach

### DIFF
--- a/src/mpl/test/io_pads1.ok
+++ b/src/mpl/test/io_pads1.ok
@@ -19,4 +19,5 @@ Die Area: (0.00, 0.00) (290.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Floorplan Utilization: 0.21
 	Manufacturing Grid: 10
 
+[WARNING MPL-0014] No Liberty data found for std cells. Continuing without dataflow.
 No differences found.

--- a/src/mpl/test/io_pads1.tcl
+++ b/src/mpl/test/io_pads1.tcl
@@ -5,13 +5,6 @@ read_lef Nangate45/Nangate45.lef
 read_lef Nangate45_io/dummy_pads.lef
 read_lef testcases/macro_only.lef
 
-# libs are needed, because the IO PADs are created based on the
-# internal MPL dataflow data structure and, while creating this
-# structure, if no std cell has liberty data, the dataflow creation
-# is skipped.
-read_liberty Nangate45/Nangate45_fast.lib
-read_liberty Nangate45_io/dummy_pads.lib
-
 read_def testcases/io_pads1.def
 
 set_thread_count 0


### PR DESCRIPTION
IO Pad clusters don't depend on the data flow to exist since #6894.