### PR TITLE
histogram: rename 'Refresh filters' to 'Update'

### DIFF
--- a/src/gui/src/chartsWidget.cpp
+++ b/src/gui/src/chartsWidget.cpp
@@ -173,7 +173,7 @@ ChartsWidget::ChartsWidget(QWidget* parent)
       mode_menu_(new QComboBox(this)),
       filters_menu_(new QComboBox(this)),
       display_(new HistogramView(this)),
-      refresh_filters_button_(new QPushButton("Refresh Filters", this)),
+      refresh_filters_button_(new QPushButton("Update", this)),
       prev_filter_index_(0),  // start with no filter
       resetting_menu_(false),
       label_(new QLabel(this))


### PR DESCRIPTION
This button is useful when issuing interactive set_false_path commands or other commands that affect the timing reporting.

Normally when using dropdowns in Endpoint Slack Histogram, then there's no need to click this button. Unsure what the what 'Refresh filters' is referring to or what the use case is other than to refresh the histogram based on out of bound(not through GUI buttons) changes to the timing model.