### PR TITLE
Improve initial placement solver convergence and exit criteria

### DIFF
--- a/src/gpl/include/gpl/Replace.h
+++ b/src/gpl/include/gpl/Replace.h
@@ -65,6 +65,8 @@ class Replace
 
   // Initial Place param settings
   void setInitialPlaceMaxIter(int iter);
+  void setInitialResidualThreshold(double threshold);
+  void setInitialHpwlPctChangeThreshold(double threshold);
   void setInitialPlaceMinDiffLength(int length);
   void setInitialPlaceMaxSolverIter(int iter);
   void setInitialPlaceMaxFanout(int fanout);
@@ -142,6 +144,8 @@ class Replace
   std::unique_ptr<NesterovPlace> np_;
 
   int initialPlaceMaxIter_ = 20;
+  double initialResidualThreshold_ = 1.0e-5;
+  double initialPlaceHpwlPctChangeThreshold_ = 1.0;
   int initialPlaceMinDiffLength_ = 1500;
   int initialPlaceMaxSolverIter_ = 100;
   int initialPlaceMaxFanout_ = 200;

--- a/src/gpl/src/initialPlace.cpp
+++ b/src/gpl/src/initialPlace.cpp
@@ -4,14 +4,17 @@
 #include "initialPlace.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
 
+#include "graphics.h"
 #include "placerBase.h"
 #include "solver.h"
+#include "utl/timer.h"
 
 namespace gpl {
 
@@ -25,8 +28,9 @@ InitialPlaceVars::InitialPlaceVars()
 void InitialPlaceVars::reset()
 {
   maxIter = 20;
+  residualThreshold = 1e-5;
   minDiffLength = 1500;
-  maxSolverIter = 100;
+  maxSolverIter = 30;
   maxFanout = 200;
   netWeightScale = 800.0;
   debug = false;
@@ -40,9 +44,8 @@ InitialPlace::InitialPlace(InitialPlaceVars ipVars,
 {
 }
 
-void InitialPlace::doBicgstabPlace(int threads)
-{
-  ResidualError error;
+void InitialPlace::doPlace(int threads) {
+  ResidualError residual;
 
   std::unique_ptr<Graphics> graphics;
   if (ipVars_.debug && Graphics::guiActive()) {
@@ -58,19 +61,15 @@ void InitialPlace::doBicgstabPlace(int threads)
     graphics->getGuiObjectFromGraphics()->gifStart("initPlacement.gif");
   }
 
+  auto init_hpwl = pbc_->getHpwl();
   for (size_t iter = 1; iter <= ipVars_.maxIter; iter++) {
+    utl::Timer iter_timer;
     updatePinInfo();
     createSparseMatrix();
-    error = cpuSparseSolve(ipVars_.maxSolverIter,
-                           iter,
-                           placeInstForceMatrixX_,
-                           fixedInstForceVecX_,
-                           instLocVecX_,
-                           placeInstForceMatrixY_,
-                           fixedInstForceVecY_,
-                           instLocVecY_,
-                           log_,
-                           threads);
+    residual = cpuSparseSolve(ipVars_.maxSolverIter, ipVars_.residualThreshold,
+                              placeInstForceMatrixX_, fixedInstForceVecX_,
+                              instLocVecX_, placeInstForceMatrixY_,
+                              fixedInstForceVecY_, instLocVecY_, log_, threads);
 
     if (graphics) {
       graphics->cellPlot(true);
@@ -83,7 +82,7 @@ void InitialPlace::doBicgstabPlace(int threads)
       gui->gifAddFrame(region, 500, dbu_per_pixel, 20);
     }
 
-    if (std::isnan(error.x) || std::isnan(error.y)) {
+    if (std::isnan(residual.x) || std::isnan(residual.y)) {
       log_->warn(GPL,
                  154,
                  "Conjugate gradient initial placement solver failed at "
@@ -92,16 +91,21 @@ void InitialPlace::doBicgstabPlace(int threads)
       break;
     }
 
-    float error_max = std::max(error.x, error.y);
-    log_->report(
-        "[InitialPlace]  Iter: {} conjugate gradient residual: {:0.8f} HPWL: "
-        "{}",
-        iter,
-        error_max,
-        pbc_->getHpwl());
     updateCoordi();
+    float residual_max = std::max(residual.x, residual.y);
+    const auto current_hpwl = pbc_->getHpwl();
+    const double hpwl_pct_change =
+        100.0 * static_cast<double>(std::abs(init_hpwl - current_hpwl)) /
+        init_hpwl;
+    init_hpwl = current_hpwl;
+    log_->report(
+        "[InitialPlace]  Iter: {} residual: {:0.8f} HPWL: "
+        "{}, abs percent change: {} time: {:.2f}s",
+        iter, residual_max, current_hpwl, hpwl_pct_change,
+        iter_timer.elapsed());
 
-    if (error_max <= 1e-5 && iter >= 5) {
+    if (residual_max < ipVars_.residualThreshold &&
+        hpwl_pct_change < ipVars_.hpwlPctChangeThreshold) {
       break;
     }
   }

--- a/src/gpl/src/initialPlace.h
+++ b/src/gpl/src/initialPlace.h
@@ -26,6 +26,8 @@ class InitialPlaceVars
   int maxIter;
   int minDiffLength;
   int maxSolverIter;
+  double residualThreshold;
+  double hpwlPctChangeThreshold;
   int maxFanout;
   float netWeightScale;
   bool debug;
@@ -43,7 +45,7 @@ class InitialPlace
                std::shared_ptr<PlacerBaseCommon> pbc,
                std::vector<std::shared_ptr<PlacerBase>>& pbVec,
                utl::Logger* logger);
-  void doBicgstabPlace(int threads);
+  void doPlace(int threads);
 
  private:
   InitialPlaceVars ipVars_;

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -61,8 +61,10 @@ void Replace::reset()
   rb_.reset();
 
   initialPlaceMaxIter_ = 20;
+  initialResidualThreshold_ = 1.0e-5;
+  initialPlaceHpwlPctChangeThreshold_ = 1.0;
   initialPlaceMinDiffLength_ = 1500;
-  initialPlaceMaxSolverIter_ = 100;
+  initialPlaceMaxSolverIter_ = 30;
   initialPlaceMaxFanout_ = 200;
   initialPlaceNetWeightScale_ = 800;
 
@@ -216,6 +218,8 @@ void Replace::doInitialPlace(int threads)
 
   InitialPlaceVars ipVars;
   ipVars.maxIter = initialPlaceMaxIter_;
+  ipVars.residualThreshold = initialResidualThreshold_;
+  ipVars.hpwlPctChangeThreshold = initialPlaceHpwlPctChangeThreshold_;
   ipVars.minDiffLength = initialPlaceMinDiffLength_;
   ipVars.maxSolverIter = initialPlaceMaxSolverIter_;
   ipVars.maxFanout = initialPlaceMaxFanout_;
@@ -225,7 +229,7 @@ void Replace::doInitialPlace(int threads)
   std::unique_ptr<InitialPlace> ip(
       new InitialPlace(ipVars, pbc_, pbVec_, log_));
   ip_ = std::move(ip);
-  ip_->doBicgstabPlace(threads);
+  ip_->doPlace(threads);
 }
 
 void Replace::runMBFF(int max_sz,
@@ -382,6 +386,14 @@ int Replace::doNesterovPlace(int threads, int start_iter)
 void Replace::setInitialPlaceMaxIter(int iter)
 {
   initialPlaceMaxIter_ = iter;
+}
+
+void Replace::setInitialResidualThreshold(double threshold) {
+  initialResidualThreshold_ = threshold;
+}
+
+void Replace::setInitialHpwlPctChangeThreshold(double threshold) {
+  initialPlaceHpwlPctChangeThreshold_ = threshold;
 }
 
 void Replace::setInitialPlaceMinDiffLength(int length)

--- a/src/gpl/src/solver.cpp
+++ b/src/gpl/src/solver.cpp
@@ -5,24 +5,21 @@
 
 #include <omp.h>
 
+#include <Eigen/IterativeLinearSolvers>
+
 namespace gpl {
 
-ResidualError cpuSparseSolve(int maxSolverIter,
-                             int iter,
-                             SMatrix& placeInstForceMatrixX,
-                             Eigen::VectorXf& fixedInstForceVecX,
-                             Eigen::VectorXf& instLocVecX,
-                             SMatrix& placeInstForceMatrixY,
-                             Eigen::VectorXf& fixedInstForceVecY,
-                             Eigen::VectorXf& instLocVecY,
-                             utl::Logger* logger,
-                             int threads)
-{
+ResidualError cpuSparseSolve(
+    int maxSolverIter, float errorThreshold, SMatrix& placeInstForceMatrixX,
+    Eigen::VectorXf& fixedInstForceVecX, Eigen::VectorXf& instLocVecX,
+    SMatrix& placeInstForceMatrixY, Eigen::VectorXf& fixedInstForceVecY,
+    Eigen::VectorXf& instLocVecY, utl::Logger* logger, int threads) {
   omp_set_num_threads(threads);
 
   ResidualError residual_error;
-  BiCGSTAB<SMatrix, IdentityPreconditioner> solver;
+  Eigen::BiCGSTAB<SMatrix> solver;
   solver.setMaxIterations(maxSolverIter);
+  solver.setTolerance(errorThreshold);
 
   solver.compute(placeInstForceMatrixX);
   instLocVecX = solver.solveWithGuess(fixedInstForceVecX, instLocVecX);

--- a/src/gpl/src/solver.h
+++ b/src/gpl/src/solver.h
@@ -3,11 +3,9 @@
 
 #pragma once
 
-#include <Eigen/IterativeLinearSolvers>
+#include <Eigen/Core>
 #include <Eigen/SparseCore>
-#include <memory>
 
-#include "graphics.h"
 #include "odb/db.h"
 #include "placerBase.h"
 #include "utl/Logger.h"
@@ -24,20 +22,13 @@ struct ResidualError
   float y;  // The relative residual error for Y
 };
 
-using Eigen::BiCGSTAB;
-using Eigen::IdentityPreconditioner;
 using utl::GPL;
 
 using SMatrix = Eigen::SparseMatrix<float, Eigen::RowMajor>;
 
-ResidualError cpuSparseSolve(int maxSolverIter,
-                             int iter,
-                             SMatrix& placeInstForceMatrixX,
-                             Eigen::VectorXf& fixedInstForceVecX,
-                             Eigen::VectorXf& instLocVecX,
-                             SMatrix& placeInstForceMatrixY,
-                             Eigen::VectorXf& fixedInstForceVecY,
-                             Eigen::VectorXf& instLocVecY,
-                             utl::Logger* logger,
-                             int threads);
+ResidualError cpuSparseSolve(
+    int maxSolverIter, float errorThreshold, SMatrix& placeInstForceMatrixX,
+    Eigen::VectorXf& fixedInstForceVecX, Eigen::VectorXf& instLocVecX,
+    SMatrix& placeInstForceMatrixY, Eigen::VectorXf& fixedInstForceVecY,
+    Eigen::VectorXf& instLocVecY, utl::Logger* logger, int threads);
 }  // namespace gpl


### PR DESCRIPTION
This commit introduces several improvements to the initial placement solver to enhance convergence, runtime, and the reliability of the exit condition.
- **Refactor Method Name:** Renamed the primary method to `doPlace` to decouple it from a specific implementation. This will avoid a name mismatch if swapping in other solvers (e.g., `MINRES`) in the future.
- **Improve Solver Convergence:** Switched the `BiCGSTAB` solver to use its default diagonal preconditioner. This offers better convergence with negligible performance overhead.
- **Refine Exit Condition:** The solver now terminates based on the stabilization of HPWL. This replaces the previous ad-hoc method of using the solver residual with a fixed minimum of 5 iterations.
- **Reduce Time in Solver:** The maximum number of solver iterations has been reduced. This is justified by the faster convergence from the new preconditioner and because the previous high iteration count was often adding noise to the solution rather than improving it.