### PR TITLE
odb: Fix odb iterator invalidation

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7611,17 +7611,23 @@ class dbGroup : public dbObject
 
   dbSet<dbModInst> getModInsts();
 
+  void clearModInsts();
+
   void addInst(dbInst* inst);
 
   void removeInst(dbInst* inst);
 
   dbSet<dbInst> getInsts();
 
+  void clearInsts();
+
   void addGroup(dbGroup* group);
 
   void removeGroup(dbGroup* group);
 
   dbSet<dbGroup> getGroups();
+
+  void clearGroups();
 
   void addPowerNet(dbNet* net);
 

--- a/src/odb/test/cpp/TestGroup.cpp
+++ b/src/odb/test/cpp/TestGroup.cpp
@@ -113,6 +113,17 @@ BOOST_AUTO_TEST_CASE(test_group_modinst)
   dbGroup::destroy(group);
   BOOST_TEST(i1->getGroup() == nullptr);
 }
+
+BOOST_AUTO_TEST_CASE(test_group_clear_modinst) {
+  auto insts = group->getModInsts();
+  BOOST_TEST(insts.size() == 3);
+  group->clearModInsts();
+  BOOST_TEST(group->getModInsts().size() == 0);
+  BOOST_TEST(i1->getGroup() == nullptr);
+  BOOST_TEST(i2->getGroup() == nullptr);
+  BOOST_TEST(i3->getGroup() == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(test_group_inst)
 {
   auto insts = group->getInsts();
@@ -129,6 +140,17 @@ BOOST_AUTO_TEST_CASE(test_group_inst)
   dbGroup::destroy(group);
   BOOST_TEST(inst1->getGroup() == nullptr);
 }
+
+BOOST_AUTO_TEST_CASE(test_group_clear_inst) {
+  auto insts = group->getInsts();
+  BOOST_TEST(insts.size() == 3);
+  group->clearInsts();
+  BOOST_TEST(group->getInsts().size() == 0);
+  BOOST_TEST(inst1->getGroup() == nullptr);
+  BOOST_TEST(inst2->getGroup() == nullptr);
+  BOOST_TEST(inst3->getGroup() == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(test_group_net)
 {
   auto power_nets = domain->getPowerNets();
@@ -163,6 +185,17 @@ BOOST_AUTO_TEST_CASE(test_group_group)
   dbGroup::destroy(group);
   BOOST_TEST(child1->getParentGroup() == nullptr);
 }
+
+BOOST_AUTO_TEST_CASE(test_group_clear_group) {
+  auto groups = group->getGroups();
+  BOOST_TEST(groups.size() == 3);
+  group->clearGroups();
+  BOOST_TEST(group->getGroups().size() == 0);
+  BOOST_TEST(child1->getParentGroup() == nullptr);
+  BOOST_TEST(child2->getParentGroup() == nullptr);
+  BOOST_TEST(child3->getParentGroup() == nullptr);
+}
+
 BOOST_AUTO_TEST_CASE(test_group_modinst_iterator)
 {
   dbSet<dbModInst> modinsts = group->getModInsts();
@@ -249,6 +282,26 @@ BOOST_AUTO_TEST_CASE(test_group_group_iterator)
     }
   }
 }
+
+BOOST_AUTO_TEST_CASE(test_group_destroy) {
+  auto insts = group->getInsts();
+  auto modInsts = group->getModInsts();
+  auto groups = group->getGroups();
+  BOOST_TEST(insts.size() == 3);
+  BOOST_TEST(modInsts.size() == 3);
+  BOOST_TEST(groups.size() == 3);
+  dbGroup::destroy(group);
+  BOOST_TEST(i1->getGroup() == nullptr);
+  BOOST_TEST(i2->getGroup() == nullptr);
+  BOOST_TEST(i3->getGroup() == nullptr);
+  BOOST_TEST(inst1->getGroup() == nullptr);
+  BOOST_TEST(inst2->getGroup() == nullptr);
+  BOOST_TEST(inst3->getGroup() == nullptr);
+  BOOST_TEST(child1->getParentGroup() == nullptr);
+  BOOST_TEST(child2->getParentGroup() == nullptr);
+  BOOST_TEST(child3->getParentGroup() == nullptr);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 }  // namespace


### PR DESCRIPTION
## Problem

In `dbGroup::destroy()`, the code uses a range-based for loop to iterate over the instances and calls `removeInst()` one by one:

```c++
@@ -489,18 +529,12 @@ void dbGroup::destroy(dbGroup* group)
{
  _dbGroup* _group = (_dbGroup*) group;
  _dbBlock* block = (_dbBlock*) _group->getOwner();
  for (auto inst : group->getInsts()) {
    group->removeInst(inst);
  }
```

Because the iterator is invalidated after the first instance is removed, only the first instance is actually erased.

The existing unit test hides this bug—there happens to be only the last instance left when `destroy()` is called—so the issue is never triggered. However, the following test case would deterministically crash before the fix:

```c++
BOOST_AUTO_TEST_CASE(test_group_destroy) {
  ...
  dbGroup::destroy(group);
  // crash before fix: i1->getGroup() dereferences freed pointer
  BOOST_TEST(i1->getGroup() == nullptr);
  ...
}
```

## Solution

1. Add new cleanup methods
2. Fix the `destroy` method

## Testing

New unit tests Verify the new clear method and confirm the correct behavior after `destroy` is invoked.