### PR TITLE
mpl: remove unneeded reset of macros' positions in SA

### DIFF
--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -444,11 +444,6 @@ void SimulatedAnnealingCore<T>::calGuidancePenalty()
 template <class T>
 void SimulatedAnnealingCore<T>::packFloorplan()
 {
-  for (auto& macro_id : pos_seq_) {
-    macros_[macro_id].setX(0.0);
-    macros_[macro_id].setY(0.0);
-  }
-
   // Each index corresponds to a macro id whose pair is:
   // <Position in Positive Sequence , Position in Negative Sequence>
   std::vector<std::pair<int, int>> sequence_pair_pos(pos_seq_.size());


### PR DESCRIPTION
I'm not sure about the rationale behind this reset, but it doesn't seem to make sense as the new positions don't rely on resetting the old ones.

This change will be useful in the implementation for #6033.