### PR TITLE
Resynthesis: Fix handling of memories and properly honor set_dont_touch and set_dont_use attributes

### DIFF
--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(rmp_abc_library
     OpenSTA
     dbSta_lib
     utl_lib
+    rsz_lib
     ${ABC_LIBRARY}
 )
 

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -74,7 +74,8 @@ void Restructure::reset()
 void Restructure::resynth(sta::Corner* corner)
 {
   ZeroSlackStrategy zero_slack_strategy(corner);
-  zero_slack_strategy.OptimizeDesign(open_sta_, name_generator_, logger_);
+  zero_slack_strategy.OptimizeDesign(
+      open_sta_, name_generator_, resizer_, logger_);
 }
 
 void Restructure::run(char* liberty_file_name,

--- a/src/rmp/src/abc_library_factory.h
+++ b/src/rmp/src/abc_library_factory.h
@@ -12,6 +12,7 @@
 
 #include "db_sta/dbSta.hh"
 #include "map/scl/sclLib.h"
+#include "rsz/Resizer.hh"
 #include "sta/Sta.hh"
 #include "utl/Logger.h"
 #include "utl/deleter.h"
@@ -54,6 +55,7 @@ class AbcLibraryFactory
  public:
   explicit AbcLibraryFactory(utl::Logger* logger) : logger_(logger) {}
   AbcLibraryFactory& AddDbSta(sta::dbSta* db_sta);
+  AbcLibraryFactory& AddResizer(rsz::Resizer* resizer);
   AbcLibraryFactory& SetCorner(sta::Corner* corner);
   AbcLibrary Build();
 
@@ -78,6 +80,7 @@ class AbcLibraryFactory
   utl::Logger* logger_;
   sta::dbSta* db_sta_ = nullptr;
   sta::Corner* corner_ = nullptr;
+  rsz::Resizer* resizer_ = nullptr;
 };
 
 }  // namespace rmp

--- a/src/rmp/src/resynthesis_strategy.h
+++ b/src/rmp/src/resynthesis_strategy.h
@@ -5,6 +5,7 @@
 
 #include "db_sta/dbSta.hh"
 #include "rmp/unique_name.h"
+#include "rsz/Resizer.hh"
 #include "utl/Logger.h"
 
 namespace rmp {
@@ -15,6 +16,7 @@ class ResynthesisStrategy
   virtual ~ResynthesisStrategy() = default;
   virtual void OptimizeDesign(sta::dbSta* sta,
                               rmp::UniqueName& name_generator,
+                              rsz::Resizer* resizer,
                               utl::Logger* logger)
       = 0;
 };

--- a/src/rmp/src/zero_slack_strategy.h
+++ b/src/rmp/src/zero_slack_strategy.h
@@ -6,6 +6,7 @@
 #include "db_sta/dbSta.hh"
 #include "resynthesis_strategy.h"
 #include "rmp/unique_name.h"
+#include "rsz/Resizer.hh"
 #include "sta/Corner.hh"
 #include "utl/Logger.h"
 
@@ -17,6 +18,7 @@ class ZeroSlackStrategy : public ResynthesisStrategy
   explicit ZeroSlackStrategy(sta::Corner* corner = nullptr) : corner_(corner) {}
   void OptimizeDesign(sta::dbSta* sta,
                       UniqueName& name_generator,
+                      rsz::Resizer* resizer,
                       utl::Logger* logger) override;
 
  private:

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -17,6 +17,9 @@ COMPULSORY_TESTS = [
     "gcd_restructure",
     "aes_asap7",
     "gcd_asap7",
+    "memory_nangate45",
+    "aes_dontuse_nangate45",
+    "aes_donttouch_nangate45"
 ]
 
 # Disabled in CMakeLists.txt

--- a/src/rmp/test/CMakeLists.txt
+++ b/src/rmp/test/CMakeLists.txt
@@ -14,6 +14,9 @@ or_integration_tests(
     gcd_restructure
     aes_asap7
     gcd_asap7
+    memory_nangate45
+    aes_dontuse_nangate45
+    aes_donttouch_nangate45
 )
 
 # Skipped

--- a/src/rmp/test/aes_donttouch_nangate45.ok
+++ b/src/rmp/test/aes_donttouch_nangate45.ok
@@ -1,0 +1,126 @@
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45_stdcell.lef, created 135 library cells
+[WARNING STA-0441] set_input_delay relative to a clock defined on the same port/pin not allowed.
+-- Before --
+
+Cell type report:                       Count       Area
+  Buffer                                 1908    2138.64
+  Inverter                                225     139.92
+  Sequential cell                         530    2396.66
+  Multi-Input combinational cell        14095   17315.54
+  Total                                 16758   21990.75
+[-0.369, -0.296): ********************************************** (127)
+[-0.296, -0.223): ************************* (69)
+[-0.223, -0.150): ********************* (57)
+[-0.150, -0.076): ********************************************** (129)
+[-0.076, -0.003): * (2)
+[-0.003,  0.070):  (0)
+[ 0.070,  0.143): * (2)
+[ 0.143,  0.217): ************************************************** (139)
+[ 0.217,  0.290): * (4)
+[ 0.290,  0.363]: *********************************************** (130)
+Startpoint: _33243_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _33122_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _33243_/CK (DFF_X1)
+   0.09    0.09 ^ _33243_/Q (DFF_X1)
+   0.03    0.12 ^ _29829_/Z (BUF_X2)
+   0.03    0.15 ^ _29921_/ZN (OR2_X1)
+   0.03    0.18 ^ _29922_/Z (BUF_X4)
+   0.02    0.20 v _29923_/ZN (NOR3_X2)
+   0.09    0.28 ^ _30031_/ZN (AOI222_X2)
+   0.04    0.33 v _30041_/ZN (OAI221_X1)
+   0.08    0.41 v _32345_/ZN (OR4_X2)
+   0.08    0.49 ^ _32346_/ZN (NOR4_X2)
+   0.05    0.54 v _32347_/ZN (NAND4_X2)
+   0.07    0.61 v _32588_/Z (XOR2_X2)
+   0.06    0.67 v _32661_/Z (XOR2_X1)
+   0.04    0.71 v _32662_/ZN (XNOR2_X1)
+   0.06    0.77 v _32663_/Z (MUX2_X1)
+   0.05    0.83 v _32664_/Z (XOR2_X1)
+   0.00    0.83 v _33122_/D (DFF_X1)
+           0.83   data arrival time
+
+   0.50    0.50   clock core_clock (rise edge)
+   0.00    0.50   clock network delay (ideal)
+   0.00    0.50   clock reconvergence pessimism
+           0.50 ^ _33122_/CK (DFF_X1)
+  -0.04    0.46   library setup time
+           0.46   data required time
+---------------------------------------------------------
+           0.46   data required time
+          -0.83   data arrival time
+---------------------------------------------------------
+          -0.37   slack (VIOLATED)
+
+
+wns max -0.37
+tns max -83.81
+-- After --
+
+[INFO RMP-1030] All candidate endpoints have positive slack, nothing to do.
+[-0.369, -0.296): ********************************************** (127)
+[-0.296, -0.223): ************************* (69)
+[-0.223, -0.150): ********************* (57)
+[-0.150, -0.076): ********************************************** (129)
+[-0.076, -0.003): * (2)
+[-0.003,  0.070):  (0)
+[ 0.070,  0.143): * (2)
+[ 0.143,  0.217): ************************************************** (139)
+[ 0.217,  0.290): * (4)
+[ 0.290,  0.363]: *********************************************** (130)
+Cell type report:                       Count       Area
+  Buffer                                 1908    2138.64
+  Inverter                                225     139.92
+  Sequential cell                         530    2396.66
+  Multi-Input combinational cell        14095   17315.54
+  Total                                 16758   21990.75
+Startpoint: _33243_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _33122_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _33243_/CK (DFF_X1)
+   0.09    0.09 ^ _33243_/Q (DFF_X1)
+   0.03    0.12 ^ _29829_/Z (BUF_X2)
+   0.03    0.15 ^ _29921_/ZN (OR2_X1)
+   0.03    0.18 ^ _29922_/Z (BUF_X4)
+   0.02    0.20 v _29923_/ZN (NOR3_X2)
+   0.09    0.28 ^ _30031_/ZN (AOI222_X2)
+   0.04    0.33 v _30041_/ZN (OAI221_X1)
+   0.08    0.41 v _32345_/ZN (OR4_X2)
+   0.08    0.49 ^ _32346_/ZN (NOR4_X2)
+   0.05    0.54 v _32347_/ZN (NAND4_X2)
+   0.07    0.61 v _32588_/Z (XOR2_X2)
+   0.06    0.67 v _32661_/Z (XOR2_X1)
+   0.04    0.71 v _32662_/ZN (XNOR2_X1)
+   0.06    0.77 v _32663_/Z (MUX2_X1)
+   0.05    0.83 v _32664_/Z (XOR2_X1)
+   0.00    0.83 v _33122_/D (DFF_X1)
+           0.83   data arrival time
+
+   0.50    0.50   clock core_clock (rise edge)
+   0.00    0.50   clock network delay (ideal)
+   0.00    0.50   clock reconvergence pessimism
+           0.50 ^ _33122_/CK (DFF_X1)
+  -0.04    0.46   library setup time
+           0.46   data required time
+---------------------------------------------------------
+           0.46   data required time
+          -0.83   data arrival time
+---------------------------------------------------------
+          -0.37   slack (VIOLATED)
+
+
+wns max -0.37
+tns max -83.81

--- a/src/rmp/test/aes_donttouch_nangate45.tcl
+++ b/src/rmp/test/aes_donttouch_nangate45.tcl
@@ -7,6 +7,8 @@ read_verilog ./aes_nangate45.v
 link_design aes_cipher_top
 read_sdc ./aes_nangate45.sdc
 
+set_dont_touch *
+
 # Unset dont use for tie cells
 unset_dont_use *LOGIC*
 
@@ -18,13 +20,6 @@ report_wns
 report_tns
 
 puts "-- After --\n"
-
-resynth
-report_timing_histogram
-report_cell_usage
-report_checks
-report_wns
-report_tns
 
 resynth
 report_timing_histogram

--- a/src/rmp/test/aes_dontuse_nangate45.ok
+++ b/src/rmp/test/aes_dontuse_nangate45.ok
@@ -1,0 +1,241 @@
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45_stdcell.lef, created 135 library cells
+[WARNING STA-0441] set_input_delay relative to a clock defined on the same port/pin not allowed.
+-- Before --
+
+Cell type report:                       Count       Area
+  Buffer                                 1908    2138.64
+  Inverter                                225     139.92
+  Sequential cell                         530    2396.66
+  Multi-Input combinational cell        14095   17315.54
+  Total                                 16758   21990.75
+[-0.369, -0.296): ********************************************** (127)
+[-0.296, -0.223): ************************* (69)
+[-0.223, -0.150): ********************* (57)
+[-0.150, -0.076): ********************************************** (129)
+[-0.076, -0.003): * (2)
+[-0.003,  0.070):  (0)
+[ 0.070,  0.143): * (2)
+[ 0.143,  0.217): ************************************************** (139)
+[ 0.217,  0.290): * (4)
+[ 0.290,  0.363]: *********************************************** (130)
+Startpoint: _33243_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _33122_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _33243_/CK (DFF_X1)
+   0.09    0.09 ^ _33243_/Q (DFF_X1)
+   0.03    0.12 ^ _29829_/Z (BUF_X2)
+   0.03    0.15 ^ _29921_/ZN (OR2_X1)
+   0.03    0.18 ^ _29922_/Z (BUF_X4)
+   0.02    0.20 v _29923_/ZN (NOR3_X2)
+   0.09    0.28 ^ _30031_/ZN (AOI222_X2)
+   0.04    0.33 v _30041_/ZN (OAI221_X1)
+   0.08    0.41 v _32345_/ZN (OR4_X2)
+   0.08    0.49 ^ _32346_/ZN (NOR4_X2)
+   0.05    0.54 v _32347_/ZN (NAND4_X2)
+   0.07    0.61 v _32588_/Z (XOR2_X2)
+   0.06    0.67 v _32661_/Z (XOR2_X1)
+   0.04    0.71 v _32662_/ZN (XNOR2_X1)
+   0.06    0.77 v _32663_/Z (MUX2_X1)
+   0.05    0.83 v _32664_/Z (XOR2_X1)
+   0.00    0.83 v _33122_/D (DFF_X1)
+           0.83   data arrival time
+
+   0.50    0.50   clock core_clock (rise edge)
+   0.00    0.50   clock network delay (ideal)
+   0.00    0.50   clock reconvergence pessimism
+           0.50 ^ _33122_/CK (DFF_X1)
+  -0.04    0.46   library setup time
+           0.46   data required time
+---------------------------------------------------------
+           0.46   data required time
+          -0.83   data arrival time
+---------------------------------------------------------
+          -0.37   slack (VIOLATED)
+
+
+wns max -0.37
+tns max -83.81
+-- After --
+
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC0_X1
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC1_X1
+Derived GENLIB library "NangateOpenCellLibrary" with 61 gates.
+The number of nodes on the critical paths =      6  (100.00 %)
+The cell delays are multiplied by the factor: <num_fanins> ^ (2.50).
+Cannot meet the target required times (1.00). Continue anyway.
+[-0.369, -0.296): ********************************************** (127)
+[-0.296, -0.223): ************************* (69)
+[-0.223, -0.150): ********************* (57)
+[-0.150, -0.076): ********************************************** (129)
+[-0.076, -0.003): * (2)
+[-0.003,  0.070):  (0)
+[ 0.070,  0.143): * (2)
+[ 0.143,  0.217): ************************************************** (139)
+[ 0.217,  0.290): * (4)
+[ 0.290,  0.363]: *********************************************** (130)
+Cell type report:                       Count       Area
+  Buffer                                 1908    2138.64
+  Inverter                                227     141.51
+  Sequential cell                         530    2396.66
+  Multi-Input combinational cell        14100   17320.06
+  Total                                 16765   21996.87
+Startpoint: _33243_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _33122_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _33243_/CK (DFF_X1)
+   0.09    0.09 ^ _33243_/Q (DFF_X1)
+   0.03    0.12 ^ _29829_/Z (BUF_X2)
+   0.03    0.15 ^ _29921_/ZN (OR2_X1)
+   0.03    0.18 ^ _29922_/Z (BUF_X4)
+   0.02    0.20 v _29923_/ZN (NOR3_X2)
+   0.09    0.28 ^ _30031_/ZN (AOI222_X2)
+   0.04    0.33 v _30041_/ZN (OAI221_X1)
+   0.08    0.41 v _32345_/ZN (OR4_X2)
+   0.08    0.49 ^ _32346_/ZN (NOR4_X2)
+   0.05    0.54 v _32347_/ZN (NAND4_X2)
+   0.07    0.61 v _32588_/Z (XOR2_X2)
+   0.06    0.67 v _32661_/Z (XOR2_X1)
+   0.04    0.71 v _32662_/ZN (XNOR2_X1)
+   0.06    0.77 v _32663_/Z (MUX2_X1)
+   0.05    0.83 v _32664_/Z (XOR2_X1)
+   0.00    0.83 v _33122_/D (DFF_X1)
+           0.83   data arrival time
+
+   0.50    0.50   clock core_clock (rise edge)
+   0.00    0.50   clock network delay (ideal)
+   0.00    0.50   clock reconvergence pessimism
+           0.50 ^ _33122_/CK (DFF_X1)
+  -0.04    0.46   library setup time
+           0.46   data required time
+---------------------------------------------------------
+           0.46   data required time
+          -0.83   data arrival time
+---------------------------------------------------------
+          -0.37   slack (VIOLATED)
+
+
+wns max -0.37
+tns max -83.83
+Used RMP cells:
+  AND2_X2
+  INV_X2
+  NOR2_X2
+  OR2_X2
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC0_X1
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC1_X1
+Derived GENLIB library "NangateOpenCellLibrary" with 92 gates.
+The number of nodes on the critical paths =    411  ( 1.47 %)
+The cell delays are multiplied by the factor: <num_fanins> ^ (2.50).
+Cannot meet the target required times (1.00). Continue anyway.
+[-0.333, -0.263): ************** (36)
+[-0.263, -0.194): ****************************************** (109)
+[-0.194, -0.124): ********************************** (89)
+[-0.124, -0.054): ********************************** (89)
+[-0.054,  0.015): *********************** (61)
+[ 0.015,  0.085):  (0)
+[ 0.085,  0.154): ************************************************ (125)
+[ 0.154,  0.224): ******* (17)
+[ 0.224,  0.294): * (3)
+[ 0.294,  0.363]: ************************************************** (130)
+Cell type report:                       Count       Area
+  Buffer                                 1772    1909.88
+  Inverter                               3429    1824.23
+  Sequential cell                         530    2396.66
+  Multi-Input combinational cell        30518   27218.18
+  Total                                 36249   33348.95
+Startpoint: _33201_ (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: _33128_ (rising edge-triggered flip-flop clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ _33201_/CK (DFF_X1)
+   0.08    0.08 ^ _33201_/Q (DFF_X1)
+   0.04    0.12 ^ rmp_20/Z (CLKBUF_X2)
+   0.02    0.14 v rmp_68/ZN (INV_X1)
+   0.05    0.19 ^ rmp_69/ZN (NAND2_X1)
+   0.02    0.21 v rmp_70/ZN (NOR2_X1)
+   0.04    0.25 ^ rmp_71/ZN (INV_X1)
+   0.02    0.27 v rmp_2497/ZN (NOR2_X1)
+   0.03    0.31 ^ rmp_2498/ZN (NOR2_X1)
+   0.03    0.34 ^ rmp_3756/ZN (AND2_X1)
+   0.01    0.35 v rmp_3757/ZN (INV_X1)
+   0.03    0.37 ^ rmp_3758/ZN (NOR2_X1)
+   0.01    0.38 v rmp_3759/ZN (INV_X1)
+   0.03    0.41 ^ rmp_3760/ZN (NOR2_X1)
+   0.01    0.42 v rmp_3761/ZN (NAND2_X1)
+   0.03    0.45 ^ rmp_3762/ZN (NOR2_X1)
+   0.01    0.46 v rmp_3789/ZN (NAND2_X1)
+   0.07    0.53 ^ rmp_3824/ZN (NOR2_X1)
+   0.02    0.55 v rmp_3825/ZN (INV_X1)
+   0.07    0.62 v rmp_3826/Z (XOR2_X1)
+   0.06    0.68 v rmp_24482/Z (XOR2_X1)
+   0.06    0.74 v rmp_24483/Z (XOR2_X1)
+   0.02    0.76 ^ rmp_24485/ZN (NAND2_X1)
+   0.01    0.77 v rmp_24486/ZN (NAND2_X1)
+   0.01    0.78 ^ rmp_24488/ZN (NAND2_X1)
+   0.01    0.79 v rmp_24491/ZN (NAND2_X1)
+   0.00    0.79 v _33128_/D (DFF_X1)
+           0.79   data arrival time
+
+   0.50    0.50   clock core_clock (rise edge)
+   0.00    0.50   clock network delay (ideal)
+   0.00    0.50   clock reconvergence pessimism
+           0.50 ^ _33128_/CK (DFF_X1)
+  -0.04    0.46   library setup time
+           0.46   data required time
+---------------------------------------------------------
+           0.46   data required time
+          -0.79   data arrival time
+---------------------------------------------------------
+          -0.33   slack (VIOLATED)
+
+
+wns max -0.33
+tns max -59.40
+Used RMP cells:
+  AND2_X1
+  AND2_X2
+  AND3_X1
+  AND4_X1
+  AOI211_X1
+  AOI21_X1
+  AOI22_X1
+  BUF_X2
+  CLKBUF_X1
+  CLKBUF_X2
+  CLKBUF_X3
+  INV_X1
+  MUX2_X1
+  NAND2_X1
+  NAND2_X2
+  NAND3_X1
+  NAND4_X1
+  NOR2_X1
+  NOR3_X1
+  NOR4_X1
+  OAI211_X1
+  OAI21_X1
+  OAI22_X1
+  OR2_X1
+  OR2_X2
+  OR3_X1
+  OR4_X1
+  XNOR2_X1
+  XOR2_X1

--- a/src/rmp/test/aes_dontuse_nangate45.tcl
+++ b/src/rmp/test/aes_dontuse_nangate45.tcl
@@ -1,0 +1,65 @@
+source "helpers.tcl"
+
+read_liberty ./Nangate45/Nangate45_typ.lib
+read_lef ./Nangate45/Nangate45.lef
+read_lef ./Nangate45/Nangate45_stdcell.lef
+read_verilog ./aes_nangate45.v
+link_design aes_cipher_top
+read_sdc ./aes_nangate45.sdc
+
+# Set dont use for all X1 cells
+set_dont_use *_X1
+
+# Unset dont use for tie cells
+unset_dont_use *LOGIC*
+
+puts "-- Before --\n"
+report_cell_usage
+report_timing_histogram
+report_checks
+report_wns
+report_tns
+
+puts "-- After --\n"
+
+resynth
+report_timing_histogram
+report_cell_usage
+report_checks
+report_wns
+report_tns
+
+proc list_rmp_cells { } {
+  set insts [odb::dbBlock_getInsts [ord::get_db_block]]
+  set used_rmp_cells {}
+  foreach inst $insts {
+    set name [odb::dbInst_getName $inst]
+    if { [string match "*rmp*" $name] } {
+      set master [odb::dbInst_getMaster $inst]
+      set master_name [odb::dbMaster_getName $master]
+      lappend used_rmp_cells $master_name
+    }
+  }
+  set used_rmp_cells [lsort -unique $used_rmp_cells]
+  puts "Used RMP cells:"
+  foreach cell $used_rmp_cells {
+    puts "  $cell"
+  }
+}
+
+# Check that no X1 cell was used by RMP on first pass
+list_rmp_cells
+
+# Reset dont use
+reset_dont_use
+unset_dont_use *LOGIC*
+
+resynth
+report_timing_histogram
+report_cell_usage
+report_checks
+report_wns
+report_tns
+
+# Check that X1 cells are used again
+list_rmp_cells

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -685,7 +685,7 @@ TEST_F(AbcTest, ResynthesisStrategyDoesNotThrow)
   UniqueName name_generator;
   ZeroSlackStrategy zero_slack;
   EXPECT_NO_THROW(
-      zero_slack.OptimizeDesign(sta_.get(), name_generator, &logger_));
+      zero_slack.OptimizeDesign(sta_.get(), name_generator, nullptr, &logger_));
 }
 
 TEST_F(AbcTestSky130, EnsureThatSky130MultiOutputConstCellsAreMapped)

--- a/src/rmp/test/memory_nangate45.ok
+++ b/src/rmp/test/memory_nangate45.ok
@@ -1,0 +1,33 @@
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0227] LEF file: ./Nangate45/fakeram45_64x7.lef, created 1 library cells
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45_stdcell.lef, created 135 library cells
+[WARNING STA-0441] set_input_delay relative to a clock defined on the same port/pin not allowed.
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC0_X1
+[WARNING RMP-0022] Leakage power doesn't exist for cell LOGIC1_X1
+[WARNING RMP-1032] Logic cut is empty after extraction, nothing to do.
+Startpoint: i_memory (rising edge-triggered flip-flop clocked by core_clock)
+Endpoint: d_o[0] (output port clocked by core_clock)
+Path Group: core_clock
+Path Type: max
+
+  Delay    Time   Description
+---------------------------------------------------------
+   0.00    0.00   clock core_clock (rise edge)
+   0.00    0.00   clock network delay (ideal)
+   0.00    0.00 ^ i_memory/clk (fakeram45_64x7)
+   0.21    0.21 ^ i_memory/rd_out[0] (fakeram45_64x7)
+   0.00    0.21 ^ d_o[0] (out)
+           0.21   data arrival time
+
+   0.10    0.10   clock core_clock (rise edge)
+   0.00    0.10   clock network delay (ideal)
+   0.00    0.10   clock reconvergence pessimism
+  -0.10    0.00   output external delay
+           0.00   data required time
+---------------------------------------------------------
+           0.00   data required time
+          -0.21   data arrival time
+---------------------------------------------------------
+          -0.21   slack (VIOLATED)
+
+

--- a/src/rmp/test/memory_nangate45.sdc
+++ b/src/rmp/test/memory_nangate45.sdc
@@ -1,0 +1,3 @@
+create_clock [get_ports clk_i] -name core_clock -period 0.1
+set_input_delay 0.1 [all_inputs] -clock core_clock
+set_output_delay 0.1 [all_outputs] -clock core_clock

--- a/src/rmp/test/memory_nangate45.tcl
+++ b/src/rmp/test/memory_nangate45.tcl
@@ -1,0 +1,16 @@
+source "helpers.tcl"
+
+read_liberty ./Nangate45/fakeram45_64x7.lib
+read_liberty ./Nangate45/Nangate45_typ.lib
+read_lef ./Nangate45/Nangate45.lef
+read_lef ./Nangate45/fakeram45_64x7.lef
+read_lef ./Nangate45/Nangate45_stdcell.lef
+read_verilog ./memory_nangate45.v
+link_design memory_nangate45
+read_sdc ./memory_nangate45.sdc
+
+# Unset dont use for tie cells
+unset_dont_use *LOGIC*
+
+resynth
+report_checks

--- a/src/rmp/test/memory_nangate45.v
+++ b/src/rmp/test/memory_nangate45.v
@@ -1,0 +1,21 @@
+module memory_nangate45(
+    input  wire clk_i,
+    input  wire we_i,
+    input  wire ce_i,
+    input  wire [5:0] addr_i,
+    input  wire [6:0] d_i,
+    input  wire [6:0] wmask_i,
+    output wire [6:0] d_o
+);
+
+    fakeram45_64x7 i_memory (
+        .clk(clk_i),
+        .we_in(we_i),
+        .ce_in(ce_i),
+        .addr_in(addr_i),
+        .wd_in(d_i),
+        .w_mask_in(wmask_i),
+        .rd_out(d_o)
+    );
+
+endmodule


### PR DESCRIPTION
This fixes the following issues:

- Memories: IsCombinational didn't check for memories, but memories can not be used for resynthesis
- set_dont_use: Resynthesis did not check if cells are marked as dont-use
- set_dont_touch: Resynthesis did not check if instances/pins/nets are marked as dont-toch

Each feature has its own testcase.