### PR TITLE
mpl: group soft annealing weights in a struct

### DIFF
--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -29,9 +29,7 @@ SACoreSoftMacro::SACoreSoftMacro(PhysicalHierarchy* tree,
                                  const Rect& outline,
                                  const std::vector<SoftMacro>& macros,
                                  const SACoreWeights& core_weights,
-                                 float boundary_weight,
-                                 float macro_blockage_weight,
-                                 float notch_weight,
+                                 const SASoftWeights& soft_weights,
                                  // notch threshold
                                  float notch_h_threshold,
                                  float notch_v_threshold,
@@ -66,9 +64,9 @@ SACoreSoftMacro::SACoreSoftMacro(PhysicalHierarchy* tree,
                                         block),
       root_(tree->root.get())
 {
-  boundary_weight_ = boundary_weight;
-  macro_blockage_weight_ = macro_blockage_weight;
-  original_notch_weight_ = notch_weight;
+  boundary_weight_ = soft_weights.boundary;
+  macro_blockage_weight_ = soft_weights.macro_blockage;
+  original_notch_weight_ = soft_weights.notch;
   resize_prob_ = resize_prob;
   notch_h_th_ = notch_h_threshold;
   notch_v_th_ = notch_v_threshold;

--- a/src/mpl/src/SACoreSoftMacro.h
+++ b/src/mpl/src/SACoreSoftMacro.h
@@ -27,9 +27,7 @@ class SACoreSoftMacro : public SimulatedAnnealingCore<SoftMacro>
                   const Rect& outline,
                   const std::vector<SoftMacro>& macros,
                   const SACoreWeights& core_weights,
-                  float boundary_weight,
-                  float macro_blockage_weight,
-                  float notch_weight,
+                  const SASoftWeights& soft_weights,
                   // notch threshold
                   float notch_h_threshold,
                   float notch_v_threshold,

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -93,17 +93,17 @@ void HierRTLMP::setFenceWeight(float weight)
 
 void HierRTLMP::setBoundaryWeight(float weight)
 {
-  boundary_weight_ = weight;
+  cluster_placement_weights_.boundary = weight;
 }
 
 void HierRTLMP::setNotchWeight(float weight)
 {
-  notch_weight_ = weight;
+  cluster_placement_weights_.notch = weight;
 }
 
 void HierRTLMP::setMacroBlockageWeight(float weight)
 {
-  macro_blockage_weight_ = weight;
+  cluster_placement_weights_.macro_blockage = weight;
 }
 
 void HierRTLMP::setGlobalFence(float fence_lx,
@@ -304,9 +304,9 @@ void HierRTLMP::resetSAParameters()
 
   placement_core_weights_.fence = 0.0;
 
-  boundary_weight_ = 0.0;
-  notch_weight_ = 0.0;
-  macro_blockage_weight_ = 0.0;
+  cluster_placement_weights_.boundary = 0.0;
+  cluster_placement_weights_.notch = 0.0;
+  cluster_placement_weights_.macro_blockage = 0.0;
 }
 
 void HierRTLMP::runCoarseShaping()
@@ -475,9 +475,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
                                               new_outline,
                                               macros,
                                               shaping_core_weights_,
-                                              0.0,  // boundary weight
-                                              0.0,  // macro blockage
-                                              0.0,  // notch weight
+                                              SASoftWeights(),
                                               0.0,  // no notch size
                                               0.0,  // no notch size
                                               pos_swap_prob_ / action_sum,
@@ -535,9 +533,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
                                               new_outline,
                                               macros,
                                               shaping_core_weights_,
-                                              0.0,  // boundary weight
-                                              0.0,  // macro blockage
-                                              0.0,  // notch weight
+                                              SASoftWeights(),
                                               0.0,  // no notch size
                                               0.0,  // no notch size
                                               pos_swap_prob_ / action_sum,
@@ -1320,9 +1316,9 @@ void HierRTLMP::adjustMacroBlockageWeight()
                "Tree max level is {}, Changing macro blockage weight from {} "
                "to {} (half of the outline weight)",
                tree_->max_level,
-               macro_blockage_weight_,
+               cluster_placement_weights_.macro_blockage,
                new_macro_blockage_weight);
-    macro_blockage_weight_ = new_macro_blockage_weight;
+    cluster_placement_weights_.macro_blockage = new_macro_blockage_weight;
   }
 }
 
@@ -1603,9 +1599,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               placement_core_weights_,
-                                              boundary_weight_,
-                                              macro_blockage_weight_,
-                                              notch_weight_,
+                                              cluster_placement_weights_,
                                               notch_h_th_,
                                               notch_v_th_,
                                               pos_swap_prob_ / action_sum,
@@ -1991,9 +1985,7 @@ void HierRTLMP::placeChildrenUsingMinimumTargetUtil(Cluster* parent)
                                               outline,
                                               shaped_macros,
                                               placement_core_weights_,
-                                              boundary_weight_,
-                                              macro_blockage_weight_,
-                                              notch_weight_,
+                                              cluster_placement_weights_,
                                               notch_h_th_,
                                               notch_v_th_,
                                               pos_swap_prob_ / action_sum,

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -269,8 +269,8 @@ class HierRTLMP
   float notch_v_th_ = 10.0;
   float notch_h_th_ = 10.0;
 
-  // For cluster and macro placement.
-  SACoreWeights placement_core_weights_;
+  SACoreWeights placement_core_weights_;  // For cluster and macro placement.
+  SASoftWeights cluster_placement_weights_;
 
   // For generation of the coarse shape (tiling) of clusters with macros.
   const SACoreWeights shaping_core_weights_{1.0f /* area */,
@@ -278,11 +278,6 @@ class HierRTLMP
                                             0.0f /* wirelength */,
                                             0.0f /* guidance */,
                                             0.0f /* fence */};
-
-  // Soft-Especific Weights
-  float boundary_weight_ = 5.0;
-  float notch_weight_ = 1.0;  // Used inside Core, but only for Soft.
-  float macro_blockage_weight_ = 1.0;
 
   std::map<std::string, Rect> fences_;   // macro_name, fence
   std::map<odb::dbInst*, Rect> guides_;  // Macro -> Guidance Region

--- a/src/mpl/src/util.h
+++ b/src/mpl/src/util.h
@@ -72,6 +72,13 @@ struct SACoreWeights
   float fence{0.0f};
 };
 
+struct SASoftWeights
+{
+  float boundary{0.0f};
+  float notch{0.0f};
+  float macro_blockage{0.0f};
+};
+
 // The cost of a certain penalty is:
 //   cost = weight * normalized_penalty
 //


### PR DESCRIPTION
No changes in functionality.

The idea is to make the code less bug prone for adding/removing penalties.