### PR TITLE
mpl: rename sa method used just in shaping to avoid confusion

### DIFF
--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -158,7 +158,7 @@ bool SimulatedAnnealingCore<T>::isValid() const
 }
 
 template <class T>
-bool SimulatedAnnealingCore<T>::isValid(const Rect& outline) const
+bool SimulatedAnnealingCore<T>::fitsIn(const Rect& outline) const
 {
   return (width_ <= std::ceil(outline.getWidth()))
          && (height_ <= std::ceil(outline.getHeight()));

--- a/src/mpl/src/SimulatedAnnealingCore.h
+++ b/src/mpl/src/SimulatedAnnealingCore.h
@@ -69,7 +69,7 @@ class SimulatedAnnealingCore
   void setInitialSequencePair(const SequencePair& sequence_pair);
 
   bool isValid() const;
-  bool isValid(const Rect& outline) const;
+  bool fitsIn(const Rect& outline) const;
   void writeCostFile(const std::string& file_name) const;
   float getNormCost() const;
   float getWidth() const;

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -507,7 +507,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
     }
     // add macro tilings
     for (auto& sa : sa_batch) {
-      if (sa->isValid(outline)) {
+      if (sa->fitsIn(outline)) {
         tilings_set.insert({sa->getWidth(), sa->getHeight()});
       }
     }
@@ -565,7 +565,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
     }
     // add macro tilings
     for (auto& sa : sa_batch) {
-      if (sa->isValid(outline)) {
+      if (sa->fitsIn(outline)) {
         tilings_set.insert({sa->getWidth(), sa->getHeight()});
       }
     }
@@ -748,7 +748,7 @@ void HierRTLMP::calculateMacroTilings(Cluster* cluster)
     }
     // add macro tilings
     for (auto& sa : sa_batch) {
-      if (sa->isValid(outline)) {
+      if (sa->fitsIn(outline)) {
         tilings_set.insert({sa->getWidth(), sa->getHeight()});
       }
     }
@@ -803,7 +803,7 @@ void HierRTLMP::calculateMacroTilings(Cluster* cluster)
     }
     // add macro tilings
     for (auto& sa : sa_batch) {
-      if (sa->isValid(outline)) {
+      if (sa->fitsIn(outline)) {
         tilings_set.insert({sa->getWidth(), sa->getHeight()});
       }
     }
@@ -2553,7 +2553,7 @@ void HierRTLMP::placeMacros(Cluster* cluster)
       // Reset weights so we can compare the final costs.
       sa->setWeights(placement_core_weights_);
 
-      if (sa->isValid(outline) && sa->getNormCost() < best_cost) {
+      if (sa->isValid() && sa->getNormCost() < best_cost) {
         best_cost = sa->getNormCost();
         best_sa = sa.get();
       }


### PR DESCRIPTION
The strategy in shaping is to generate different tilings for cluster with macros by annealing with different outlines (starting from the original and making it smaller) and, at the end, checking to see if they fit in the actual outline. However, I don't think that the concept of "validity" applies for this situation as, from the annealer perspective, the outline is an external parameter.

With these changes, the polymorphism needed for the partial macro placement support will get much less confusing (Soft SA will rely of more than just the outline fitting check).