### PR TITLE
mpl: consider root cluster location in coarse shaping

### DIFF
--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -440,7 +440,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
   const float action_sum = pos_swap_prob_ + neg_swap_prob_ + double_swap_prob_
                            + exchange_swap_prob_ + resize_prob_;
 
-  const Rect outline(0, 0, tree_->root->getWidth(), tree_->root->getHeight());
+  const Rect outline = tree_->root->getBBox();
 
   const int num_perturb_per_step = (macros.size() > num_perturb_per_step_ / 10)
                                        ? macros.size()
@@ -462,10 +462,10 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
     const int run_thread
         = graphics_ ? 1 : std::min(remaining_runs, num_threads_);
     for (int i = 0; i < run_thread; i++) {
-      const Rect new_outline(0,
-                             0,
-                             outline.getWidth() * vary_factor_list[run_id++],
-                             outline.getHeight());
+      Rect new_outline = outline;
+      const float new_width = outline.getWidth() * vary_factor_list[run_id++];
+      new_outline.setXMax(new_outline.xMin() + new_width);
+
       if (graphics_) {
         graphics_->setOutline(micronsToDbu(block_, new_outline));
       }
@@ -520,10 +520,10 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
     const int run_thread
         = graphics_ ? 1 : std::min(remaining_runs, num_threads_);
     for (int i = 0; i < run_thread; i++) {
-      const Rect new_outline(0,
-                             0,
-                             outline.getWidth(),
-                             outline.getHeight() * vary_factor_list[run_id++]);
+      Rect new_outline = outline;
+      const float new_height = outline.getHeight() * vary_factor_list[run_id++];
+      new_outline.setYMax(new_outline.yMin() + new_height);
+
       if (graphics_) {
         graphics_->setOutline(micronsToDbu(block_, new_outline));
       }


### PR DESCRIPTION
Needed for partial automated macro placement support.

The idea is that the fixed macros will also have to be considered at the root-level annealing we performing coarse shaping. (the root-level annealing prevents moving on to cluster placement with a set of macros that we can't fit in the core area).