### PR TITLE
Don't use stdio.h remove(), but std::filesystem::remove() instead.

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -14,6 +14,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <system_error>
 
 #include "boost/stacktrace.hpp"
 #ifdef ENABLE_READLINE
@@ -228,12 +229,14 @@ int main(int argc, char* argv[])
 
   log_filename = findCmdLineKey(argc, argv, "-log");
   if (log_filename) {
-    remove(log_filename);
+    std::error_code err_ignore;
+    std::filesystem::remove(log_filename, err_ignore);
   }
 
   metrics_filename = findCmdLineKey(argc, argv, "-metrics");
   if (metrics_filename) {
-    remove(metrics_filename);
+    std::error_code err_ignored;
+    std::filesystem::remove(metrics_filename, err_ignored);
   }
 
   no_settings = findCmdLineFlag(argc, argv, "-no_settings");

--- a/src/odb/src/def/def/defrReader.cpp
+++ b/src/odb/src/def/def/defrReader.cpp
@@ -29,14 +29,14 @@
 
 #include "defrReader.hpp"
 
-#include <sys/stat.h>
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 #include "defiDebug.hpp"
 #include "defiMisc.hpp"
@@ -1109,14 +1109,15 @@ int defrRead(FILE* f, const char* fName, defiUserData uData, int case_sensitive)
   defContext.data = defData;
 
   // lex_init
-  struct stat statbuf;
 
   /* 4/11/2003 - Remove file lefrRWarning.log from directory if it exist */
   /* pcr 569729 */
-  if (stat("defRWarning.log", &statbuf) != -1) {
+  std::error_code err_ignored;
+  const auto warning_file = std::filesystem::path("defRWarning.log");
+  if (std::filesystem::exists(warning_file, err_ignored)) {
     /* file exist, remove it */
     if (!defContext.settings->LogFileAppend) {
-      remove("defRWarning.log");
+      std::filesystem::remove(warning_file, err_ignored);
     }
   }
 

--- a/src/odb/src/lef/lef/lefrData.cpp
+++ b/src/odb/src/lef/lef/lefrData.cpp
@@ -28,11 +28,11 @@
 // *****************************************************************************
 #include "lefrData.hpp"
 
-#include <sys/stat.h>
-
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
+#include <filesystem>
+#include <system_error>
 
 #include "lefrSettings.hpp"
 
@@ -62,7 +62,6 @@ lefrData::lefrData()
   current_token[0] = '\0';
 
   // lef_lex_init()
-  struct stat statbuf;
 
   // initRingBuffer();
   int i;
@@ -95,10 +94,12 @@ lefrData::lefrData()
 
   // 4/11/2003 - Remove file lefrRWarning.log from directory if it exist
   // pcr 569729
-  if (stat("lefRWarning.log", &statbuf) != -1) {
+  std::error_code err_ignored;
+  const auto warning_file = std::filesystem::path("lefRWarning.log");
+  if (std::filesystem::exists(warning_file, err_ignored)) {
     // file exist, remove it
     if (!lefSettings->LogFileAppend) {
-      remove("lefRWarning.log");
+      std::filesystem::remove(warning_file, err_ignored);
     }
   }
 


### PR DESCRIPTION
Follow-up change to #8154 : use modern `std::filesystem::remove()` instead of old-school `remove()` from stdio.h