### PR TITLE
power: -hier fixed warnings in .v with verilator

### DIFF
--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -130,10 +130,10 @@ orfs_flow(
         ),
         "MACRO_PLACE_HALO": "0 2.16",
         "RTLMP_BOUNDARY_WT": "0",
-        "RTLMP_MAX_INST" :"250",
-        "RTLMP_MIN_INST" :"50",
-        "RTLMP_MAX_MACRO" :"64",
-        "RTLMP_MIN_MACRO" :"8",
+        "RTLMP_MAX_INST": "250",
+        "RTLMP_MIN_INST": "50",
+        "RTLMP_MAX_MACRO": "64",
+        "RTLMP_MIN_MACRO": "8",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
         "MACRO_ROWS_HALO_X": "0.5",
         "MACRO_ROWS_HALO_Y": "0.5",
@@ -306,10 +306,6 @@ verilator_cc_library(
         "-Wno-DECLFILENAME",
         "-Wno-UNUSEDSIGNAL",
         "-Wno-PINMISSING",
-        # OpenROAD write_verilog uses implicit wires
-        "-Wno-IMPLICIT",
-        # FIXME remove after https://github.com/The-OpenROAD-Project/OpenROAD/issues/8108 fixed
-        "-Wno-UNDRIVEN",
         "--trace-underscore",
     ],
 )


### PR DESCRIPTION
No warnings to be seen below.

```
$ bazelisk build test/orfs/mock-array:simulator
[deleted]
INFO: From [Verilator] Compiling @@//test/orfs/mock-array:array_verilator:
- V e r i l a t i o n   R e p o r t: Verilator v5.034 rev v5.034
- Verilator: Built from 13.172 MB sources in 163 modules, into 59.041 MB in 61 C++ files needing 0.000 MB
- Verilator: Walltime 23.065 s (elab=1.551, cvt=19.385, bld=0.000); cpu 21.316 s on 1 threads; alloced 464.305 MB
INFO: Found 1 target...
[deleted]
```