### PR TITLE
power: hierarchical .odb testing

### DIFF
--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -19,17 +19,11 @@ POWER_STAGE_STEM = {
 MOCK_ARRAY_TABLE = [
     8,
     8,
-    20,
-    20,
-    20,
-    22,
+    30,
+    30,
+    30,
+    32,
 ]
-
-# Element'd data width
-MOCK_ARRAY_DATAWIDTH = 64
-
-# Must be zero for routing by abutment
-MACRO_BLOCKAGE_HALO = 0
 
 MOCK_ARRAY_SCALE = 45
 
@@ -76,10 +70,6 @@ ce_margin_y = placement_grid_y * 0.5
 array_spacing_x = margin_x * 2
 
 array_spacing_y = margin_y * 2
-
-array_offset_x = array_spacing_x + margin_x
-
-array_offset_y = array_spacing_y + margin_y
 
 # top level core and die size
 core_width = (
@@ -191,7 +181,10 @@ orfs_flow(
             ce_height,
         ),
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
+        # We want to report power per module using hierarhical .odb
         "OPENROAD_HIERARCHICAL": "1",
+        "SYNTH_HIERARCHICAL": "1",
+        "SYNTH_MINIMUM_KEEP_SIZE": "0",
     },
     sources = {
         "IO_CONSTRAINTS": [":mock-array-element-io"],
@@ -339,6 +332,8 @@ genrule(
     ],
 )
 
+# If we want to measure power after final, instead of with estimated parasitics,
+# we'll need this.
 SPEFS_AND_NETLISTS = [
     ":results/asap7/{macro}/{stem}.{ext}".format(
         ext = ext,

--- a/test/orfs/mock-array/rules-base.json
+++ b/test/orfs/mock-array/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 7635.06,
+        "value": 207152.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 138015,
+        "value": 309743,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 12335,
+        "value": 15802,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1073,
+        "value": 1374,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1073,
+        "value": 1374,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 77761,
+        "value": 79678,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,23 +48,23 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -351.636,
+        "value": -8.52,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 138064,
+        "value": 309774,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 536,
+        "value": 687,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 108,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -107.06,
+        "value": -10.0,
         "compare": ">="
     }
 }


### PR DESCRIPTION
mock-array/Element now has submodules, which is useful for power testing.

More testing to come, as hierarhical .odb gets better, this is just the prerequisites on top of which I can add more tests.

The design is bigger because more kept modules means less efficient synthesis.