### PR TITLE
grt: fix checking NDR net cost per layer

### DIFF
--- a/src/grt/src/fastroute/include/Graph2D.h
+++ b/src/grt/src/fastroute/include/Graph2D.h
@@ -65,11 +65,7 @@ class Graph2D
 
   void addCapH(int x, int y, int cap);
   void addCapV(int x, int y, int cap);
-  void addEstUsageH(const Interval& xi, int y, double usage);
-  void addEstUsageH(int x, int y, double usage);
   void addEstUsageToUsage();
-  void addEstUsageV(int x, const Interval& yi, double usage);
-  void addEstUsageV(int x, int y, double usage);
   void addRedH(int x, int y, int red);
   void addRedV(int x, int y, int red);
   void addUsageH(const Interval& xi, int y, int used);


### PR DESCRIPTION
This PR fixes a problem that can occurs when we have a NDR net with different edge cost for each metal layer.
During 2D phases, we need to check if there is 3D capacity available in a single layer considering the NDR net layer edge cost.