### PR TITLE
DPL: Remove extra site calls.

### DIFF
--- a/src/dpl/src/Place.cpp
+++ b/src/dpl/src/Place.cpp
@@ -871,11 +871,11 @@ bool Opendp::checkPixels(const Node* cell,
     return false;
   }
 
+  dbSite* site = cell->getSite();
   for (GridY y1 = y; y1 < y_end; y1++) {
     const bool first_row = (y1 == y);
     for (GridX x1 = x; x1 < x_end; x1++) {
       const Pixel* pixel = grid_->gridPixel(x1, y1);
-      auto site = cell->getSite();
       if (pixel == nullptr || pixel->cell || !pixel->is_valid
           || (cell->inGroup() && pixel->group != cell->getGroup())
           || (!cell->inGroup() && pixel->group)
@@ -915,7 +915,6 @@ bool Opendp::checkPixels(const Node* cell,
       }
     }
   }
-  dbSite* site = cell->getDbInst()->getMaster()->getSite();
   const auto orient = grid_->getSiteOrientation(x, y, site).value();
   return drc_engine_->checkDRC(cell, x, y, orient);
 }


### PR DESCRIPTION
Move this call to `cell->getSite()` out of the loop.  The call requires some pointer hopping and a little bit of work, so we should extract it from the loop.  Internally `cell->getSite()` is calling `getDbInst()->getMaster()->getSite();` so it should be fine to replace the later site definition with this change.