### PR TITLE
drt: use relative paths to the respective implementation headers.

### DIFF
--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -196,12 +196,6 @@ cc_library(
     ],
     copts = [
         "-Isrc/drt/src",
-        "-Isrc/drt/src/dr",
-        "-Isrc/drt/src/gc",
-        "-Isrc/drt/src/io",
-        "-Isrc/drt/src/pa",
-        "-Isrc/drt/src/rp",
-        "-Isrc/drt/src/ta",
         "-fopenmp",
     ],
     includes = [

--- a/src/drt/src/db/infra/frTime.cpp
+++ b/src/drt/src/db/infra/frTime.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "frTime.h"
+#include "db/infra/frTime.h"
 
 #include <chrono>
 #include <iomanip>

--- a/src/drt/src/db/obj/frAccess.h
+++ b/src/drt/src/db/obj/frAccess.h
@@ -13,7 +13,7 @@
 
 #include "db/infra/frPoint.h"
 #include "db/obj/frBlockObject.h"
-#include "frShape.h"
+#include "db/obj/frShape.h"
 
 namespace drt {
 class frViaDef;

--- a/src/drt/src/db/obj/frInst.cpp
+++ b/src/drt/src/db/obj/frInst.cpp
@@ -3,8 +3,8 @@
 
 #include "db/obj/frInst.h"
 
-#include "frBlock.h"
-#include "frMaster.h"
+#include "db/obj/frBlock.h"
+#include "db/obj/frMaster.h"
 namespace drt {
 
 Rect frInst::getBBox() const

--- a/src/drt/src/db/obj/frRPin.cpp
+++ b/src/drt/src/db/obj/frRPin.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "frRPin.h"
+#include "db/obj/frRPin.h"
 
 #include <iostream>
 

--- a/src/drt/src/db/tech/frConstraint.cc
+++ b/src/drt/src/db/tech/frConstraint.cc
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022-2025, The OpenROAD Authors
 
-#include "frConstraint.h"
+#include "db/tech/frConstraint.h"
 
 #include <string>
 
-#include "frLayer.h"
+#include "db/tech/frLayer.h"
 #include "utl/Logger.h"
 namespace drt {
 

--- a/src/drt/src/db/tech/frConstraint.h
+++ b/src/drt/src/db/tech/frConstraint.h
@@ -13,9 +13,9 @@
 #include <vector>
 
 #include "db/tech/frLookupTbl.h"
+#include "db/tech/frViaDef.h"
+#include "db/tech/frViaRuleGenerate.h"
 #include "frBaseTypes.h"
-#include "frViaDef.h"
-#include "frViaRuleGenerate.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
 

--- a/src/drt/src/distributed/PinAccessJobDescription.h
+++ b/src/drt/src/distributed/PinAccessJobDescription.h
@@ -6,8 +6,8 @@
 #include <vector>
 
 #include "boost/serialization/base_object.hpp"
+#include "distributed/paUpdate.h"
 #include "dst/JobMessage.h"
-#include "paUpdate.h"
 namespace boost::serialization {
 class access;
 }

--- a/src/drt/src/distributed/frArchive.cpp
+++ b/src/drt/src/distributed/frArchive.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2021-2025, The OpenROAD Authors
 
-#include "frArchive.h"
+#include "distributed/frArchive.h"
 
 #include <istream>
 #include <ostream>

--- a/src/drt/src/dr/FlexDR_graphics.cpp
+++ b/src/drt/src/dr/FlexDR_graphics.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2020-2025, The OpenROAD Authors
 
-#include "FlexDR_graphics.h"
+#include "dr/FlexDR_graphics.h"
 
 #include <algorithm>
 #include <any>
@@ -15,7 +15,7 @@
 #include <vector>
 
 #include "../gc/FlexGC.h"
-#include "FlexDR.h"
+#include "dr/FlexDR.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 

--- a/src/drt/src/dr/FlexDR_graphics.h
+++ b/src/drt/src/dr/FlexDR_graphics.h
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "AbstractDRGraphics.h"
+#include "dr/AbstractDRGraphics.h"
 #include "frBaseTypes.h"
 #include "gui/gui.h"
 #include "odb/db.h"

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -15,11 +15,11 @@
 #include <utility>
 #include <vector>
 
-#include "FlexMazeTypes.h"
 #include "boost/container/flat_map.hpp"
 #include "boost/container/flat_set.hpp"
 #include "db/drObj/drPin.h"
 #include "db/infra/frBox.h"
+#include "dr/FlexMazeTypes.h"
 #include "dr/FlexWavefront.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"

--- a/src/drt/src/gr/FlexGR.cpp
+++ b/src/drt/src/gr/FlexGR.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexGR.h"
+#include "gr/FlexGR.h"
 
 #include <omp.h>
 

--- a/src/drt/src/gr/FlexGR.h
+++ b/src/drt/src/gr/FlexGR.h
@@ -9,12 +9,12 @@
 #include <utility>
 #include <vector>
 
-#include "FlexGRCMap.h"
 #include "boost/icl/interval_map.hpp"
 #include "boost/icl/interval_set.hpp"
 #include "db/grObj/grNet.h"
 #include "frDesign.h"
 #include "frRTree.h"
+#include "gr/FlexGRCMap.h"
 #include "gr/FlexGRGridGraph.h"
 namespace odb {
 class dbDatabase;

--- a/src/drt/src/gr/FlexGRCMap.cpp
+++ b/src/drt/src/gr/FlexGRCMap.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexGRCMap.h"
+#include "gr/FlexGRCMap.h"
 
 #include <algorithm>
 #include <fstream>

--- a/src/drt/src/gr/FlexGR_init.cpp
+++ b/src/drt/src/gr/FlexGR_init.cpp
@@ -11,8 +11,8 @@
 #include <utility>
 #include <vector>
 
-#include "FlexGR.h"
-#include "FlexGRCMap.h"
+#include "gr/FlexGR.h"
+#include "gr/FlexGRCMap.h"
 
 namespace drt {
 

--- a/src/drt/src/gr/FlexGR_topo.cpp
+++ b/src/drt/src/gr/FlexGR_topo.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-#include "FlexGR.h"
+#include "gr/FlexGR.h"
 #include "stt/SteinerTreeBuilder.h"
 
 namespace drt {

--- a/src/drt/src/io/GuideProcessor.cpp
+++ b/src/drt/src/io/GuideProcessor.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024-2025, The OpenROAD Authors
 
-#include "GuideProcessor.h"
+#include "io/GuideProcessor.h"
 
 #include <omp.h>
 

--- a/src/drt/src/io/io_pin.cpp
+++ b/src/drt/src/io/io_pin.cpp
@@ -5,7 +5,7 @@
 #include <tuple>
 #include <vector>
 
-#include "io.h"
+#include "io/io.h"
 
 namespace drt {
 

--- a/src/drt/src/pa/AbstractPAGraphics.h
+++ b/src/drt/src/pa/AbstractPAGraphics.h
@@ -7,9 +7,9 @@
 #include <utility>
 #include <vector>
 
-#include "FlexPA.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "pa/FlexPA.h"
 
 namespace drt {
 

--- a/src/drt/src/pa/FlexPA.cpp
+++ b/src/drt/src/pa/FlexPA.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexPA.h"
+#include "pa/FlexPA.h"
 
 #include <omp.h>
 
@@ -16,7 +16,6 @@
 #include <utility>
 #include <vector>
 
-#include "AbstractPAGraphics.h"
 #include "boost/archive/text_iarchive.hpp"
 #include "boost/archive/text_oarchive.hpp"
 #include "boost/io/ios_state.hpp"
@@ -30,6 +29,7 @@
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
 #include "odb/db.h"
+#include "pa/AbstractPAGraphics.h"
 #include "serialization.h"
 #include "utl/exception.h"
 

--- a/src/drt/src/pa/FlexPA.h
+++ b/src/drt/src/pa/FlexPA.h
@@ -14,11 +14,11 @@
 #include <utility>
 #include <vector>
 
-#include "FlexPA_unique.h"
 #include "boost/polygon/polygon.hpp"
 #include "boost/serialization/unordered_map.hpp"
 #include "frDesign.h"
 #include "odb/db.h"
+#include "pa/FlexPA_unique.h"
 namespace gtl = boost::polygon;
 
 namespace odb {

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -18,8 +18,6 @@
 #include <utility>
 #include <vector>
 
-#include "AbstractPAGraphics.h"
-#include "FlexPA.h"
 #include "db/infra/frTime.h"
 #include "distributed/PinAccessJobDescription.h"
 #include "distributed/frArchive.h"
@@ -27,6 +25,8 @@
 #include "dst/JobMessage.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "pa/AbstractPAGraphics.h"
+#include "pa/FlexPA.h"
 #include "serialization.h"
 #include "utl/exception.h"
 

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -12,11 +12,11 @@
 #include <utility>
 #include <vector>
 
-#include "AbstractPAGraphics.h"
-#include "FlexPA.h"
 #include "boost/polygon/polygon.hpp"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "pa/AbstractPAGraphics.h"
+#include "pa/FlexPA.h"
 #include "utl/exception.h"
 
 namespace drt {

--- a/src/drt/src/pa/FlexPA_graphics.cpp
+++ b/src/drt/src/pa/FlexPA_graphics.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2020-2025, The OpenROAD Authors
 
-#include "FlexPA_graphics.h"
+#include "pa/FlexPA_graphics.h"
 
 #include <algorithm>
 #include <cstdio>
@@ -11,7 +11,7 @@
 #include <utility>
 #include <vector>
 
-#include "FlexPA.h"
+#include "pa/FlexPA.h"
 
 namespace drt {
 

--- a/src/drt/src/pa/FlexPA_graphics.h
+++ b/src/drt/src/pa/FlexPA_graphics.h
@@ -8,11 +8,11 @@
 #include <utility>
 #include <vector>
 
-#include "AbstractPAGraphics.h"
-#include "FlexPA.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
 #include "gui/gui.h"
+#include "pa/AbstractPAGraphics.h"
+#include "pa/FlexPA.h"
 
 namespace odb {
 class dbDatabase;

--- a/src/drt/src/pa/FlexPA_init.cpp
+++ b/src/drt/src/pa/FlexPA_init.cpp
@@ -9,10 +9,10 @@
 #include <tuple>
 #include <vector>
 
-#include "FlexPA.h"
 #include "boost/polygon/polygon.hpp"
 #include "db/infra/frTime.h"
 #include "gc/FlexGC.h"
+#include "pa/FlexPA.h"
 
 namespace drt {
 

--- a/src/drt/src/pa/FlexPA_row_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_row_pattern.cpp
@@ -15,7 +15,6 @@
 #include <utility>
 #include <vector>
 
-#include "FlexPA.h"
 #include "db/infra/frTime.h"
 #include "distributed/PinAccessJobDescription.h"
 #include "distributed/frArchive.h"
@@ -23,6 +22,7 @@
 #include "dst/JobMessage.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "pa/FlexPA.h"
 #include "serialization.h"
 #include "utl/exception.h"
 

--- a/src/drt/src/pa/FlexPA_unique.cpp
+++ b/src/drt/src/pa/FlexPA_unique.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023-2025, The OpenROAD Authors
 
-#include "FlexPA_unique.h"
+#include "pa/FlexPA_unique.h"
 
 #include <algorithm>
 #include <limits>

--- a/src/drt/src/rp/FlexRP.cpp
+++ b/src/drt/src/rp/FlexRP.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexRP.h"
+#include "rp/FlexRP.h"
 
 #include "frProfileTask.h"
 

--- a/src/drt/src/rp/FlexRP_init.cpp
+++ b/src/drt/src/rp/FlexRP_init.cpp
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexRP.h"
 #include "frProfileTask.h"
+#include "rp/FlexRP.h"
 
 namespace drt {
 

--- a/src/drt/src/rp/FlexRP_prep.cpp
+++ b/src/drt/src/rp/FlexRP_prep.cpp
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "FlexRP.h"
 #include "boost/polygon/polygon.hpp"
 #include "db/gcObj/gcNet.h"
 #include "db/gcObj/gcPin.h"
@@ -19,6 +18,7 @@
 #include "gc/FlexGC.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "rp/FlexRP.h"
 
 namespace drt {
 

--- a/src/drt/src/ta/AbstractTAGraphics.h
+++ b/src/drt/src/ta/AbstractTAGraphics.h
@@ -6,9 +6,9 @@
 #include <memory>
 #include <vector>
 
-#include "FlexTA.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "ta/FlexTA.h"
 
 namespace drt {
 class AbstractTAGraphics

--- a/src/drt/src/ta/FlexTA.cpp
+++ b/src/drt/src/ta/FlexTA.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#include "FlexTA.h"
+#include "ta/FlexTA.h"
 
 #include <omp.h>
 
@@ -14,10 +14,10 @@
 #include <utility>
 #include <vector>
 
-#include "AbstractTAGraphics.h"
 #include "db/infra/frTime.h"
 #include "frProfileTask.h"
 #include "global.h"
+#include "ta/AbstractTAGraphics.h"
 #include "utl/exception.h"
 
 namespace drt {

--- a/src/drt/src/ta/FlexTA_graphics.cpp
+++ b/src/drt/src/ta/FlexTA_graphics.cpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2020-2025, The OpenROAD Authors
 
-#include "FlexTA_graphics.h"
+#include "ta/FlexTA_graphics.h"
 
 #include <string>
 
-#include "FlexTA.h"
+#include "ta/FlexTA.h"
 
 namespace drt {
 

--- a/src/drt/src/ta/FlexTA_graphics.h
+++ b/src/drt/src/ta/FlexTA_graphics.h
@@ -7,10 +7,10 @@
 #include <string>
 #include <vector>
 
-#include "AbstractTAGraphics.h"
-#include "FlexTA.h"
 #include "frBaseTypes.h"
 #include "gui/gui.h"
+#include "ta/AbstractTAGraphics.h"
+#include "ta/FlexTA.h"
 
 namespace odb {
 class dbDatabase;


### PR DESCRIPTION
This makes it easier to follow where things are, as well as reduces the proliferation of needed `-I` include search paths.