### PR TITLE
grt/odb: add db callback for access point update

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -541,6 +541,7 @@ class GRouteDbCbk : public odb::dbBlockCallBackObj
 
   void inDbITermPreDisconnect(odb::dbITerm* iterm) override;
   void inDbITermPostConnect(odb::dbITerm* iterm) override;
+  void inDbITermPostSetAccessPoints(odb::dbITerm* iterm) override;
 
   void inDbBTermPostConnect(odb::dbBTerm* bterm) override;
   void inDbBTermPreDisconnect(odb::dbBTerm* bterm) override;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -5199,6 +5199,14 @@ void GRouteDbCbk::inDbITermPostConnect(odb::dbITerm* iterm)
   }
 }
 
+void GRouteDbCbk::inDbITermPostSetAccessPoints(odb::dbITerm* iterm)
+{
+  odb::dbNet* net = iterm->getNet();
+  if (net != nullptr && !net->isSpecial()) {
+    grouter_->addDirtyNet(iterm->getNet());
+  }
+}
+
 void GRouteDbCbk::inDbBTermPostConnect(odb::dbBTerm* bterm)
 {
   // missing net pin update

--- a/src/odb/include/odb/dbBlockCallBackObj.h
+++ b/src/odb/include/odb/dbBlockCallBackObj.h
@@ -83,7 +83,7 @@ class dbBlockCallBackObj
   virtual void inDbITermPostDisconnect(dbITerm*, dbNet*) {}
   virtual void inDbITermPreConnect(dbITerm*, dbNet*) {}
   virtual void inDbITermPostConnect(dbITerm*) {}
-  virtual void inDbITermPostSetAccessPoints(dbITerm* iterm) {}
+  virtual void inDbITermPostSetAccessPoints(dbITerm*) {}
   // dbITerm End
 
   // dbModITerm Start

--- a/src/odb/include/odb/dbBlockCallBackObj.h
+++ b/src/odb/include/odb/dbBlockCallBackObj.h
@@ -83,6 +83,7 @@ class dbBlockCallBackObj
   virtual void inDbITermPostDisconnect(dbITerm*, dbNet*) {}
   virtual void inDbITermPreConnect(dbITerm*, dbNet*) {}
   virtual void inDbITermPostConnect(dbITerm*) {}
+  virtual void inDbITermPostSetAccessPoints(dbITerm* iterm) {}
   // dbITerm End
 
   // dbModITerm Start

--- a/src/odb/src/db/dbITerm.cpp
+++ b/src/odb/src/db/dbITerm.cpp
@@ -792,6 +792,11 @@ void dbITerm::setAccessPoint(dbMPin* pin, dbAccessPoint* ap)
   } else {
     iterm->aps_[pin->getImpl()->getOID()] = dbId<_dbAccessPoint>();
   }
+
+  _dbBlock* block = (_dbBlock*) iterm->getOwner();
+  for (auto callback : block->_callbacks) {
+    callback->inDbITermPostSetAccessPoints(this);
+  }
 }
 
 std::map<dbMPin*, std::vector<dbAccessPoint*>> dbITerm::getAccessPoints() const


### PR DESCRIPTION
This new ODB callback will be necessary for incremental pin access.

Calling pin access in each iteration of incremental GRT might be prohibitive regarding runtime. This PR introduces a new callback that will track instance terms that had their access points modified by PA, and add their nets to the list of nets to reroute. This way, we can run incremental iterations and only update the access points at the end of it, leaving GRT to reroute only the nets with modified APs.