### PR TITLE
dpl: fix debug mode, two stage stop (for DPL and DPO)

### DIFF
--- a/src/dpl/src/Optdp.cpp
+++ b/src/dpl/src/Optdp.cpp
@@ -8,6 +8,7 @@
 #include "utl/Logger.h"
 
 // My stuff.
+#include "graphics/DplObserver.h"
 #include "legalize_shift.h"
 #include "optimization/detailed.h"
 #include "optimization/detailed_manager.h"
@@ -115,6 +116,10 @@ void Opendp::improvePlacement(const int seed,
   // Run the script.
   Detailed dt(dtParams);
   dt.improve(mgr);
+
+  if (debug_observer_) {
+    debug_observer_->endPlacement();
+  }
 
   // Write solution back.
   updateDbInstLocations();


### PR DESCRIPTION
Introduce a two-stage stop: first before DPL modifications, and then again before DPO modifications are applied to the db.

Previously, DPL modifications were hidden, so debugging only showed positions either before all DPL/DPO modifications or after both. With this change, we can now see DPL and DPO modifications separately.