### PR TITLE
Fix non-deterministic failures of `cgt` tests

### DIFF
--- a/src/cgt/test/aes_nangate45.py
+++ b/src/cgt/test/aes_nangate45.py
@@ -15,5 +15,6 @@ design.evalTclString("create_clock [get_ports clk] -name core_clock -period 0.5"
 
 design.getClockGating().run()
 
-design.evalTclString("write_verilog results/aes_nangate45_gated.v")
-helpers.diff_files("aes_nangate45_gated.vok", "results/aes_nangate45_gated.v")
+verilog_file = helpers.make_result_file("aes_nangate45_gated.v")
+design.evalTclString(f"write_verilog {verilog_file}")
+helpers.diff_files("aes_nangate45_gated.vok", verilog_file)

--- a/src/cgt/test/aes_nangate45.tcl
+++ b/src/cgt/test/aes_nangate45.tcl
@@ -6,5 +6,6 @@ read_verilog aes_nangate45.v
 link_design aes_cipher_top
 create_clock [get_ports clk] -name core_clock -period 0.5
 clock_gating
-write_verilog results/aes_nangate45_gated.v
-diff_file aes_nangate45_gated.vok results/aes_nangate45_gated.v
+set verilog_file [make_result_file aes_nangate45_gated.v]
+write_verilog $verilog_file
+diff_file aes_nangate45_gated.vok $verilog_file

--- a/src/cgt/test/countdown_asap7.py
+++ b/src/cgt/test/countdown_asap7.py
@@ -21,5 +21,6 @@ cgt = design.getClockGating()
 cgt.setMinInstances(1)
 cgt.run()
 
-design.evalTclString("write_verilog results/countdown_asap7_gated.v")
-helpers.diff_files("countdown_asap7_gated.vok", "results/countdown_asap7_gated.v")
+verilog_file = helpers.make_result_file("countdown_asap7_gated.v")
+design.evalTclString(f"write_verilog {verilog_file}")
+helpers.diff_files("countdown_asap7_gated.vok", verilog_file)

--- a/src/cgt/test/countdown_asap7.tcl
+++ b/src/cgt/test/countdown_asap7.tcl
@@ -10,5 +10,6 @@ read_verilog countdown_asap7.v
 link_design countdown
 create_clock [get_ports clk] -name clock -period 0.5
 clock_gating -min_instances 1
-write_verilog results/countdown_asap7_gated.v
-diff_file countdown_asap7_gated.vok results/countdown_asap7_gated.v
+set verilog_file [make_result_file countdown_asap7_gated.v]
+write_verilog $verilog_file
+diff_file countdown_asap7_gated.vok $verilog_file

--- a/src/cgt/test/ibex_sky130hd.py
+++ b/src/cgt/test/ibex_sky130hd.py
@@ -17,5 +17,6 @@ cgt = design.getClockGating()
 cgt.setMaxCover(50)
 cgt.run()
 
-design.evalTclString("write_verilog results/ibex_sky130hd_gated.v")
-helpers.diff_files("ibex_sky130hd_gated.vok", "results/ibex_sky130hd_gated.v")
+verilog_file = helpers.make_result_file("ibex_sky130hd_gated.v")
+design.evalTclString(f"write_verilog {verilog_file}")
+helpers.diff_files("ibex_sky130hd_gated.vok", verilog_file)

--- a/src/cgt/test/ibex_sky130hd.tcl
+++ b/src/cgt/test/ibex_sky130hd.tcl
@@ -6,5 +6,6 @@ read_verilog ibex_sky130hd.v
 link_design ibex_core
 create_clock [get_ports clk_i] -name core_clock -period 10
 clock_gating -max_cover 50
-write_verilog results/ibex_sky130hd_gated.v
-diff_file ibex_sky130hd_gated.vok results/ibex_sky130hd_gated.v
+set verilog_file [make_result_file ibex_sky130hd_gated.v]
+write_verilog $verilog_file
+diff_file ibex_sky130hd_gated.vok $verilog_file


### PR DESCRIPTION
Gives different names to the result of each (Python, Tcl) variant of each `cgt` test.
Hopefully this resolves the non-deterministic failues (sorry!).