### PR TITLE
abc: Enable usage of rmp library for custom implementations.

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -89,7 +89,6 @@ static const char* log_filename = nullptr;
 static const char* metrics_filename = nullptr;
 static bool no_settings = false;
 static bool minimize = false;
-static bool abc_initialized = false;
 
 static const char* init_filename = ".openroad";
 
@@ -168,12 +167,6 @@ static void initPython()
   }
 }
 #endif
-
-namespace abc {
-// Forward declare instead of including to avoid warnings from ABC
-void Abc_Start();
-void Abc_Stop();
-}  // namespace abc
 
 static volatile sig_atomic_t fatal_error_in_progress = 0;
 
@@ -310,9 +303,6 @@ int main(int argc, char* argv[])
   // Tcl_Main never returns.
   Tcl_Main(1, argv, ord::tclAppInit);
 
-  if (abc_initialized) {
-    abc::Abc_Stop();
-  }
   return 0;
 }
 
@@ -526,14 +516,6 @@ int ord::tclAppInit(Tcl_Interp* interp)
 int ord::tclInit(Tcl_Interp* interp)
 {
   return tclAppInit(cmd_argc, cmd_argv, init_filename, interp);
-}
-
-void ord::abcInit()
-{
-  if (!abc_initialized) {
-    abc::Abc_Start();
-    abc_initialized = true;
-  }
 }
 
 static void showUsage(const char* prog, const char* init_filename)

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -133,6 +133,11 @@ OpenRoad::~OpenRoad()
   delete logger_;
   delete verilog_reader_;
   delete callback_handler_;
+
+  if (abc_initialized) {
+    abc::Abc_Stop();
+  }
+}
 }
 
 sta::dbNetwork* OpenRoad::getDbNetwork()

--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -77,6 +77,13 @@ extern "C" {
 extern int Ord_Init(Tcl_Interp* interp);
 }
 
+static bool abc_initialized = false;
+namespace abc {
+// Forward declare instead of including to avoid warnings from ABC
+void Abc_Start();
+void Abc_Stop();
+}  // namespace abc
+
 namespace ord {
 
 using odb::dbBlock;
@@ -147,6 +154,14 @@ void OpenRoad::setOpenRoad(OpenRoad* app, bool reinit_ok)
     exit(1);
   }
   app_ = app;
+}
+
+void ord::abcInit()
+{
+  if (!abc_initialized) {
+    abc::Abc_Start();
+    abc_initialized = true;
+  }
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/rmp/BUILD
+++ b/src/rmp/BUILD
@@ -14,14 +14,14 @@ cc_library(
     srcs = [
         "src/Restructure.cpp",
         "src/delay_optimization_strategy.cpp",
-        "src/delay_optimization_strategy.h",
-        "src/logic_optimization_strategy.h",
-        "src/resynthesis_strategy.h",
         "src/zero_slack_strategy.cpp",
-        "src/zero_slack_strategy.h",
     ],
     hdrs = [
         "include/rmp/Restructure.h",
+        "src/delay_optimization_strategy.h",
+        "src/logic_optimization_strategy.h",
+        "src/resynthesis_strategy.h",
+        "src/zero_slack_strategy.h",
     ],
     copts = [
         "-Isrc/rmp/src",


### PR DESCRIPTION
`abcInit()` needs to be called in rmp implementations. However, abcInit() is defined in Main.cc, so it is not possible to link the openroad_lib and :rmp libraries that exclude Main.cc in a different binary with a custom rmp implementation.

This PR moves the abc start and stop logic to OpenRoad.cc. abc already carries statics so the abc initialized static is not a new limitation for binaries that use multiple OpenRoad objects.

The PR also exposes some public rmp headers needed for 3rd party implementations.