### PR TITLE
ANT: avoid checking the positioning of special nets

### DIFF
--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -1095,15 +1095,28 @@ Violations AntennaChecker::getAntennaViolations(odb::dbNet* net,
 
 bool AntennaChecker::designIsPlaced()
 {
+  if (db_->getChip() == nullptr) {
+    logger_->error(
+        utl::ANT,
+        18,
+        "Load a design before running the antenna checker commands.");
+  }
+
   for (odb::dbBTerm* bterm : block_->getBTerms()) {
     if (bterm->getFirstPinPlacementStatus() == odb::dbPlacementStatus::NONE) {
       return false;
     }
   }
 
-  for (odb::dbInst* inst : block_->getInsts()) {
-    if (!inst->isPlaced()) {
-      return false;
+  for (odb::dbNet* net : block_->getNets()) {
+    if (net->isSpecial()) {
+      continue;
+    }
+    for (odb::dbITerm* iterm : net->getITerms()) {
+      odb::dbInst* inst = iterm->getInst();
+      if (!inst->isPlaced()) {
+        return false;
+      }
     }
   }
 

--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -935,7 +935,7 @@ int AntennaChecker::checkGates(odb::dbNet* db_net,
               = std::max(0, diode_count_per_gate - num_diodes_added[gate]);
           num_diodes_added[gate] += diode_count_per_gate;
           // save antenna violation
-          if (violated) {
+          if (violated && diode_count_per_gate > 0) {
             antenna_violations.push_back({layer->getRoutingLevel(),
                                           gates_for_diode_insertion,
                                           diode_count_per_gate,


### PR DESCRIPTION
This modification will avoid checking the special nets.

Fixes https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3476

It also prevents returning ant violations when the number of diodes required is 0.