### PR TITLE
test: diff_file elsewhere takes OK as first parameter

### DIFF
--- a/src/gpl/test/incremental02.tcl
+++ b/src/gpl/test/incremental02.tcl
@@ -9,4 +9,4 @@ read_def ./$test_name.def
 global_placement -incremental -density 0.3 -pad_left 2 -pad_right 2
 set def_file [make_result_file $test_name.def]
 write_def $def_file
-diff_file $def_file $test_name.defok
+diff_file $test_name.defok $def_file


### PR DESCRIPTION
Small nit I saw when I examined the test.