### PR TITLE
gui: do nothing on show setup when block is not defined

### DIFF
--- a/src/gui/src/heatMap.cpp
+++ b/src/gui/src/heatMap.cpp
@@ -224,6 +224,10 @@ Painter::Color HeatMapDataSource::getColor(double value) const
 
 void HeatMapDataSource::showSetup()
 {
+  if (block_ == nullptr) {
+    return;
+  }
+
   if (setup_ == nullptr) {
     setup_ = new HeatMapSetup(*this,
                               QString::fromStdString(name_),


### PR DESCRIPTION
Fixes:
* segfault when opening heatmap setup before a design has been loaded.