### PR TITLE
gpl: Update doc with current code for -timing_driven_net_reweight_overflow.

### DIFF
--- a/src/gpl/README.md
+++ b/src/gpl/README.md
@@ -141,7 +141,7 @@ global_placement
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-timing_driven_net_reweight_overflow` | Set overflow threshold for timing-driven net reweighting. Allowed value is a Tcl list of integers where each number is `[0, 100]`. Default values are [79, 64, 49, 29, 21, 15] |
+| `-timing_driven_net_reweight_overflow` | Set overflow threshold for timing-driven net reweighting. Allowed value is a Tcl list of integers where each number is `[0, 100]`. Default values are [64, 20] |
 | `-timing_driven_net_weight_max` | Set the multiplier for the most timing-critical nets. The default value is `5`, and the allowed values are floats. |
 | `-timing_driven_nets_percentage` | Set the reweighted percentage of nets in timing-driven mode. The default value is 10. Allowed values are floats `[0, 100]`. |
 | `-keep_resize_below_overflow` | When the overflow is below the set value, timing-driven iterations will retain the resizer changes instead of reverting them. The default value is 0.3. Allowed values are floats `[0, 1]`. |


### PR DESCRIPTION
To match changes in 24688077181.