### PR TITLE
python: Add pypi package infrastructure to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -131,8 +131,7 @@ OPENROAD_DEFINES = [
     "OPENROAD_GIT_DESCRIBE=\\\"bazel-build\\\"",
     "BUILD_TYPE=\\\"$(COMPILATION_MODE)\\\"",
     "GPU=false",
-    "BUILD_PYTHON=true",
-    "ENABLE_PYTHON3",
+    "BUILD_PYTHON=false",
     "ABC_NAMESPACE=abc",
     "TCLRL_VERSION_STR=",
 ]
@@ -141,15 +140,6 @@ cc_binary(
     name = "openroad",
     srcs = [
         "src/Main.cc",
-        "src/OpenRoad.cc",
-        ":openroad_swig",
-        ":openroad_swig-py",
-        ":openroad_py",
-        ":openroad_tcl",
-        ":rmp_swig",
-        ":rmp_swig-py",
-        ":rmp_python",
-        ":rmp_tcl",
         "//bazel:runfiles",
     ],
     copts = OPENROAD_COPTS,
@@ -167,12 +157,7 @@ cc_binary(
         "@boost.stacktrace",
         "@rules_cc//cc/runfiles",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
-        "@openroad_rules_python//python/cc:current_py_cc_libs",
     ],
-    data = [
-        "@python_3_13//:py3_runtime",
-    ]
 )
 
 GUI_BUILD_FLAGS = select(
@@ -209,18 +194,8 @@ cc_library(
         "src/Tech.cc",
         "src/Timing.cc",
         ":openroad_swig",
-        ":openroad_swig-py",
-        ":openroad_py",
         ":openroad_tcl",
-        ":rmp_swig",
-        ":rmp_swig-py",
-        ":rmp_python",
-        ":rmp_tcl",
-    ] + glob([
-        "src/rmp/src/*.cpp",
-        "src/rmp/src/*.h",
-    ]),
-    hdrs = glob(["src/rmp/include/rmp/*.h"]),
+    ],
     copts = OPENROAD_COPTS,
     defines = OPENROAD_DEFINES + GUI_BUILD_FLAGS,
     features = ["-use_header_modules"],
@@ -294,6 +269,55 @@ tcl_wrap_cc(
     ],
 )
 
+# This target compiles the SWIG C++ wrapper into a shared library (.so)
+# that Python can load dynamically.
+cc_binary(
+    name = "_openroadpy.so",
+    srcs = [":openroad_swig-py"],
+    linkshared = True,
+    deps = [
+        ":openroad_lib",  # Depends on the core odb C++ library
+        ":ord",
+        "//src/odb",
+        "//src/ifp",
+        "//src/utl",
+        "//src/gpl",
+        "//src/ant",
+        "//src/cts",
+        "//src/dpl",
+        "//src/drt",
+        "//src/exa",
+        "//src/fin",
+        "//src/grt",
+        "//src/par",
+        "//src/pdn",
+        "//src/ppl",
+        "//src/psm",
+        "//src/rcx",
+        "//src/stt",
+        "//src/gui",
+        "//src/tap",
+        "@boost.stacktrace",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
+# This packages the SWIG-generated Python wrapper (odb.py) and the
+# compiled C++ extension (_odb.so) together.
+py_library(
+    name = "ord_py",
+    srcs = [":openroad_swig-py"],  # Use the .py output from the swig-py rule
+    # The data attribute makes the .so file available at runtime.
+    data = [":_openroadpy.so"],
+    deps = [
+        "//src/utl:utl_py",
+        "//src/odb:odb_py",
+    ],
+    # This allows imports relative to the workspace root.
+    imports = ["."],
+    visibility = ["//visibility:public",]
+)
+
 python_wrap_cc(
     name = "openroad_swig-py",
     srcs = [
@@ -303,64 +327,32 @@ python_wrap_cc(
         "include/ord/Design.h",
         "include/ord/Timing.h",
     ],
-    module = "ord_py",
+    module = "openroadpy",
     root_swig_src = "src/OpenRoad-py.i",
     swig_includes = [
         "include",
         "src",
     ],
-)
-
-tcl_encode(
-    name = "openroad_py",
-    srcs = [
-        ":openroad_swig-py",
-    ],
-    char_array_name = "ord_py_python_inits",
-    namespace = "ord",
-)
-
-tcl_wrap_cc(
-    name = "rmp_swig",
-    srcs = [
-        "src/rmp/src/rmp.i",
-        ":error_swig",
-        "//src/sta:sta_swig_files",
-    ],
-    module = "rmp",
-    namespace_prefix = "rmp",
-    root_swig_src = "src/rmp/src/rmp.i",
-    swig_includes = [
-        "src/rmp/src",
-        "src/sta",
-    ],
-)
-
-python_wrap_cc(
-    name = "rmp_swig-py",
-    srcs = [
-        "src/rmp/include/rmp/blif.h",
-        "src/rmp/include/rmp/Restructure.h",
-        "src/rmp/src/rmp-py.i",
-        ":error_swig-py",
-        "//src/sta:sta_swig_files",
-    ],
-    module = "rmp_py",
-    root_swig_src = "src/rmp/src/rmp-py.i",
-    swig_includes = [
-        "src/rmp/include",
-        "src/rmp/src",
-        "src/sta",
-    ],
-)
-
-tcl_encode(
-    name = "rmp_python",
-    srcs = [
-        ":rmp_swig-py",
-    ],
-    char_array_name = "rmp_py_python_inits",
-    namespace = "rmp",
+    deps = [
+        "//src/gpl:swig-py",
+        "//src/ifp:swig-py",
+        "//src/ant:swig-py",
+        "//src/cts:swig-py",
+        "//src/dpl:swig-py",
+        "//src/drt:swig-py",
+        "//src/exa:swig-py",
+        "//src/fin:swig-py",
+        "//src/grt:swig-py",
+        "//src/par:swig-py",
+        "//src/pdn:swig-py",
+        "//src/ppl:swig-py",
+        "//src/psm:swig-py",
+        "//src/rcx:swig-py",
+        "//src/stt:swig-py",
+        "//src/tap:swig-py",
+        "//src/odb:swig-py",
+        "//src/utl:swig-py",
+    ]
 )
 
 filegroup(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -170,6 +170,9 @@ cc_binary(
         "@openroad_rules_python//python/cc:current_py_cc_headers",
         "@openroad_rules_python//python/cc:current_py_cc_libs",
     ],
+    data = [
+        "@python_3_13//:py3_runtime",
+    ]
 )
 
 GUI_BUILD_FLAGS = select(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     features = [
@@ -69,7 +70,9 @@ OPENROAD_LIBRARY_DEPS = [
     "//src/exa",
     "//src/exa:ui",
     "//src/fin",
+    # "//src/fin:ui",
     "//src/gpl",
+    # "//src/gpl:ui",
     "//src/grt",
     "//src/grt:ui",
     "//src/ifp",
@@ -79,11 +82,15 @@ OPENROAD_LIBRARY_DEPS = [
     "//src/odb",
     "//src/odb:ui",
     "//src/pad",
+    # "//src/pad:ui",
     "//src/par",
     "//src/par:ui",
     "//src/pdn",
+    # "//src/pdn:ui",
     "//src/ppl",
+    # "//src/ppl:ui",
     "//src/psm",
+    # "//src/psm:ui",
     "//src/rcx",
     "//src/rcx:ui",
     "//src/rmp",
@@ -124,7 +131,8 @@ OPENROAD_DEFINES = [
     "OPENROAD_GIT_DESCRIBE=\\\"bazel-build\\\"",
     "BUILD_TYPE=\\\"$(COMPILATION_MODE)\\\"",
     "GPU=false",
-    "BUILD_PYTHON=false",
+    "BUILD_PYTHON=true",
+    "ENABLE_PYTHON3",
     "ABC_NAMESPACE=abc",
     "TCLRL_VERSION_STR=",
 ]
@@ -133,6 +141,15 @@ cc_binary(
     name = "openroad",
     srcs = [
         "src/Main.cc",
+        "src/OpenRoad.cc",
+        ":openroad_swig",
+        ":openroad_swig-py",
+        ":openroad_py",
+        ":openroad_tcl",
+        ":rmp_swig",
+        ":rmp_swig-py",
+        ":rmp_python",
+        ":rmp_tcl",
         "//bazel:runfiles",
     ],
     copts = OPENROAD_COPTS,
@@ -150,6 +167,8 @@ cc_binary(
         "@boost.stacktrace",
         "@rules_cc//cc/runfiles",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
+        "@openroad_rules_python//python/cc:current_py_cc_libs",
     ],
 )
 
@@ -187,8 +206,18 @@ cc_library(
         "src/Tech.cc",
         "src/Timing.cc",
         ":openroad_swig",
+        ":openroad_swig-py",
+        ":openroad_py",
         ":openroad_tcl",
-    ],
+        ":rmp_swig",
+        ":rmp_swig-py",
+        ":rmp_python",
+        ":rmp_tcl",
+    ] + glob([
+        "src/rmp/src/*.cpp",
+        "src/rmp/src/*.h",
+    ]),
+    hdrs = glob(["src/rmp/include/rmp/*.h"]),
     copts = OPENROAD_COPTS,
     defines = OPENROAD_DEFINES + GUI_BUILD_FLAGS,
     features = ["-use_header_modules"],
@@ -262,10 +291,87 @@ tcl_wrap_cc(
     ],
 )
 
+python_wrap_cc(
+    name = "openroad_swig-py",
+    srcs = [
+        "src/OpenRoad-py.i",
+        ":error_swig-py",
+        "include/ord/Tech.h",
+        "include/ord/Design.h",
+        "include/ord/Timing.h",
+    ],
+    module = "ord_py",
+    root_swig_src = "src/OpenRoad-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+)
+
+tcl_encode(
+    name = "openroad_py",
+    srcs = [
+        ":openroad_swig-py",
+    ],
+    char_array_name = "ord_py_python_inits",
+    namespace = "ord",
+)
+
+tcl_wrap_cc(
+    name = "rmp_swig",
+    srcs = [
+        "src/rmp/src/rmp.i",
+        ":error_swig",
+        "//src/sta:sta_swig_files",
+    ],
+    module = "rmp",
+    namespace_prefix = "rmp",
+    root_swig_src = "src/rmp/src/rmp.i",
+    swig_includes = [
+        "src/rmp/src",
+        "src/sta",
+    ],
+)
+
+python_wrap_cc(
+    name = "rmp_swig-py",
+    srcs = [
+        "src/rmp/include/rmp/blif.h",
+        "src/rmp/include/rmp/Restructure.h",
+        "src/rmp/src/rmp-py.i",
+        ":error_swig-py",
+        "//src/sta:sta_swig_files",
+    ],
+    module = "rmp_py",
+    root_swig_src = "src/rmp/src/rmp-py.i",
+    swig_includes = [
+        "src/rmp/include",
+        "src/rmp/src",
+        "src/sta",
+    ],
+)
+
+tcl_encode(
+    name = "rmp_python",
+    srcs = [
+        ":rmp_swig-py",
+    ],
+    char_array_name = "rmp_py_python_inits",
+    namespace = "rmp",
+)
+
 filegroup(
     name = "error_swig",
     srcs = [
         "src/Exception.i",
+    ],
+    visibility = ["@//:__subpackages__"],
+)
+
+filegroup(
+    name = "error_swig-py",
+    srcs = [
+        "src/Exception-py.i",
     ],
     visibility = ["@//:__subpackages__"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -138,6 +138,7 @@ python.toolchain(
     ignore_root_user_error = True,
     python_version = "3.13",
 )
+use_repo(python, "python_3_13")
 
 pip = use_extension("@openroad_rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(

--- a/bazel/InitRunFiles.cpp
+++ b/bazel/InitRunFiles.cpp
@@ -59,20 +59,6 @@ class BazelInitializer
       std::exit(1);
     }
 
-    // Set the PYTHONPATH environment variable.  Pretty ugly but functional
-    const char* import_path
-        = "rules_python++python+python_3_13_x86_64-unknown-linux-gnu/lib/"
-          "python3.13";
-    const std::string python_path = runfiles->Rlocation(import_path);
-
-    if (!python_path.empty()) {
-      setenv("PYTHONPATH", python_path.c_str(), 0);
-    } else {
-      std::cerr << "Error: Could not locate '" << import_path
-                << "' in runfiles." << std::endl;
-      std::exit(1);
-    }
-
     // Setup env variables for any other libraries that use runfiles
     std::string manifest = program_location + ".runfiles/MANIFEST";
     std::string runfiles_dir = program_location + ".runfiles";

--- a/bazel/InitRunFiles.cpp
+++ b/bazel/InitRunFiles.cpp
@@ -50,12 +50,26 @@ class BazelInitializer
     }
 
     // Set the TCL_LIBRARY environment variable
-    std::string path = runfiles->Rlocation("tk_tcl/library/");
-    if (!path.empty()) {
-      setenv("TCL_LIBRARY", path.c_str(), 0);
+    const std::string tcl_path = runfiles->Rlocation("tk_tcl/library/");
+    if (!tcl_path.empty()) {
+      setenv("TCL_LIBRARY", tcl_path.c_str(), 0);
     } else {
       std::cerr << "Error: Could not locate 'tk_tcl/library/' in runfiles."
                 << std::endl;
+      std::exit(1);
+    }
+
+    // Set the PYTHONPATH environment variable.  Pretty ugly but functional
+    const char* import_path
+        = "rules_python++python+python_3_13_x86_64-unknown-linux-gnu/lib/"
+          "python3.13";
+    const std::string python_path = runfiles->Rlocation(import_path);
+
+    if (!python_path.empty()) {
+      setenv("PYTHONPATH", python_path.c_str(), 0);
+    } else {
+      std::cerr << "Error: Could not locate '" << import_path
+                << "' in runfiles." << std::endl;
       std::exit(1);
     }
 

--- a/bazel/python_wrap_cc.bzl
+++ b/bazel/python_wrap_cc.bzl
@@ -59,6 +59,7 @@ def _python_wrap_cc_impl(ctx):
     swig_options = _get_transitive_options(ctx.attr.swig_options, ctx.attr.deps)
 
     args = ctx.actions.args()
+    args.add("-DBAZEL=1")
     args.add("-python")
     args.add("-c++")
     args.add("-flatstaticmethod")

--- a/bazel/tcl_encode_or.bzl
+++ b/bazel/tcl_encode_or.bzl
@@ -44,7 +44,7 @@ tcl_encode = rule(
         ),
         "srcs": attr.label_list(
             allow_empty = False,
-            allow_files = [".tcl"],
+            allow_files = [".tcl", ".py"],
             doc = "Files to be wrapped.",
         ),
         "_encode_script": attr.label(

--- a/bazel/tcl_encode_or.bzl
+++ b/bazel/tcl_encode_or.bzl
@@ -19,9 +19,15 @@ def _tcl_encode_or_impl(ctx):
     args.add("--varname", ctx.attr.char_array_name)
     args.add("--namespace", ctx.attr.namespace)
 
+    # Only keep .tcl and .py files.
+    allowed_extensions = (".tcl", ".py")
+    filtered_sources = [
+        f for f in ctx.files.srcs if f.basename.endswith(allowed_extensions)
+    ]
+
     ctx.actions.run(
         outputs = [output_file],
-        inputs = ctx.files.srcs,
+        inputs = filtered_sources,
         arguments = [args],
         tools = [ctx.executable._encode_script],
         executable = ctx.toolchains["@rules_python//python:toolchain_type"].py3_runtime.interpreter,

--- a/openroad/BUILD
+++ b/openroad/BUILD
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+load("@openroad_rules_python//python:packaging.bzl", "py_wheel", "py_package")
+
+
+py_library(
+    name = "openroadpy",
+    srcs = [
+        "__init__.py",
+        "utl.py",
+        "odb.py",
+    ],
+    deps = [
+        "//src/utl:utl_py",
+        "//src/odb:odb_py",
+        "//:ord_py",
+    ],
+    imports = ["pypi"],
+    visibility = ["//visibility:public"],
+)
+
+py_package(
+    name = "openroad_pkg",
+    deps = [
+        ":openroadpy",
+    ]
+)
+
+py_wheel(
+    name = "openroad_wheel",
+    distribution = "openroad",
+    python_tag = "py3",
+    version = "0.0.1",
+    deps = [
+        ":openroad_pkg",
+    ],
+)

--- a/openroad/__init__.py
+++ b/openroad/__init__.py
@@ -1,0 +1,1 @@
+from openroadpy import *

--- a/openroad/odb.py
+++ b/openroad/odb.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+
+from src.odb.odb import *

--- a/openroad/utl.py
+++ b/openroad/utl.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+
+from src.utl.utl import *

--- a/src/Exception-py.i
+++ b/src/Exception-py.i
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2022-2025, The OpenROAD Authors
 
+#ifdef BAZEL
+%{
+
+#include <boost/stacktrace.hpp>
+#include <cstdlib>
+#include <sstream>
+
+#include "utl/Logger.h"
+%}
+#else
 %{
 
 #include <boost/stacktrace.hpp>
@@ -10,6 +20,7 @@
 #include "ord/OpenRoad.hh"
 #include "utl/Logger.h"
 %}
+#endif
 
 %exception {
   try { $function }
@@ -19,6 +30,15 @@
   }
   // This catches std::runtime_error (utl::error) and sta::Exception.
   catch (std::exception &excp) {
+    #ifdef BAZEL
+    Logger* logger = Logger::defaultLogger();
+    if (logger->debugCheck(utl::ORD, "trace", 1)) {
+      std::stringstream trace;
+      trace << boost::stacktrace::stacktrace();
+      logger->report("Stack trace");
+      logger->report(trace.str());
+    }
+    #else
     auto* openroad = ord::OpenRoad::openRoad();
     if (openroad != nullptr) {
       auto* logger = openroad->getLogger();
@@ -29,11 +49,21 @@
         logger->report(trace.str());
       }
     }
+    #endif
 
     PyErr_SetString(PyExc_RuntimeError, excp.what());
     SWIG_fail;
   }
   catch (...) {
+    #ifdef BAZEL
+    Logger* logger = Logger::defaultLogger();
+    if (logger->debugCheck(utl::ORD, "trace", 1)) {
+      std::stringstream trace;
+      trace << boost::stacktrace::stacktrace();
+      logger->report("Stack trace");
+      logger->report(trace.str());
+    }
+    #else
     auto* openroad = ord::OpenRoad::openRoad();
     if (openroad != nullptr) {
       auto* logger = openroad->getLogger();
@@ -44,6 +74,7 @@
         logger->report(trace.str());
       }
     }
+    #endif
 
     PyErr_SetString(PyExc_Exception, "Unknown exception");
     SWIG_fail;

--- a/src/OpenRoad-py.i
+++ b/src/OpenRoad-py.i
@@ -24,13 +24,13 @@ openroad_version();
 const char *
 openroad_git_describe();
 
-const bool
+bool
 openroad_gpu_compiled();
 
-const bool 
+bool 
 openroad_python_compiled();
 
-const bool
+bool
 openroad_gui_compiled();
 
 odb::dbDatabase *

--- a/src/OpenRoad-py.i
+++ b/src/OpenRoad-py.i
@@ -56,6 +56,27 @@ get_db_block();
 %include "ord/Design.h"
 %include "ord/Timing.h"
 
+#ifdef BAZEL
+%include "src/gpl/src/replace-py.i"
+%include "src/ifp/src/InitFloorplan-py.i"
+%include "src/ant/src/AntennaChecker-py.i"
+%include "src/cts/src/TritonCTS-py.i"
+%include "src/dpl/src/Opendp-py.i"
+%include "src/drt/src/TritonRoute-py.i"
+%include "src/exa/src/example-py.i"
+%include "src/fin/src/finale-py.i"
+%include "src/grt/src/GlobalRouter-py.i"
+%include "src/par/src/partitionmgr-py.i"
+%include "src/pdn/src/PdnGen-py.i"
+%include "src/ppl/src/IOPlacer-py.i"
+%include "src/psm/src/pdnsim-py.i"
+%include "src/rcx/src/ext-py.i"
+%include "src/stt/src/SteinerTreeBuilder-py.i"
+%include "src/tap/src/tapcell-py.i"
+%import "src/odb/src/swig/common/odb.i"
+%import "src/utl/src/Logger-py.i"
+#endif
+
 %newobject Design::getFloorplan();
 
 const char *

--- a/src/ant/BUILD
+++ b/src/ant/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -43,6 +44,8 @@ cc_library(
     srcs = [
         "src/MakeAntennaChecker.cc",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -56,6 +59,7 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -80,4 +84,31 @@ tcl_wrap_cc(
     swig_includes = [
         "src",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/ant/AntennaChecker.hh",
+        "src/AntennaChecker.i",
+        "//:error_swig-py",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+    module = "ant_py",
+    root_swig_src = "src/AntennaChecker-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "ant_py_python_inits",
+    namespace = "ant",
 )

--- a/src/ant/BUILD
+++ b/src/ant/BUILD
@@ -44,8 +44,6 @@ cc_library(
     srcs = [
         "src/MakeAntennaChecker.cc",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -59,7 +57,6 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -102,13 +99,4 @@ python_wrap_cc(
         "include",
         "src",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "ant_py_python_inits",
-    namespace = "ant",
 )

--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -72,6 +73,8 @@ cc_library(
         "src/CtsGraphics.h",
         "src/MakeTritoncts.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -93,6 +96,7 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -117,4 +121,28 @@ tcl_wrap_cc(
     swig_includes = [
         "src/cts/src",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/cts/TritonCTS.h",
+        "src/CtsOptions.h",
+        "src/TritonCTS-py.i",
+        "//:error_swig-py",
+    ],
+    module = "cts_py",
+    root_swig_src = "src/TritonCTS-py.i",
+    swig_includes = [
+        "include",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "cts_py_python_inits",
+    namespace = "cts",
 )

--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -48,8 +48,10 @@ cc_library(
     ],
     hdrs = [
         "include/cts/TritonCTS.h",
+        "src/CtsOptions.h",
+        "src/TechChar.h",
     ],
-    includes = ["include"],
+    includes = ["include", "src"],
     deps = [
         ":private_hdrs",
         "//src/dbSta",
@@ -73,8 +75,6 @@ cc_library(
         "src/CtsGraphics.h",
         "src/MakeTritoncts.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -96,7 +96,6 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -136,13 +135,4 @@ python_wrap_cc(
     swig_includes = [
         "include",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "cts_py_python_inits",
-    namespace = "cts",
 )

--- a/src/dpl/BUILD
+++ b/src/dpl/BUILD
@@ -110,8 +110,6 @@ cc_library(
         "src/infrastructure/architecture.h",
         "src/infrastructure/network.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -133,7 +131,6 @@ cc_library(
         "@boost.stacktrace",
         "@boost.utility",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -179,13 +176,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "dpl_py_python_inits",
-    namespace = "dpl",
 )

--- a/src/dpl/BUILD
+++ b/src/dpl/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -109,6 +110,8 @@ cc_library(
         "src/infrastructure/architecture.h",
         "src/infrastructure/network.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -130,6 +133,7 @@ cc_library(
         "@boost.stacktrace",
         "@boost.utility",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -157,4 +161,31 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/dpl/Opendp.h",
+        "src/Opendp-py.i",
+        "//:error_swig-py",
+    ],
+    module = "dpl_py",
+    root_swig_src = "src/Opendp-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "dpl_py_python_inits",
+    namespace = "dpl",
 )

--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -251,6 +252,8 @@ cc_library(
         "src/ta/FlexTA_graphics.cpp",
         "src/ta/FlexTA_graphics.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -278,6 +281,7 @@ cc_library(
         "@boost.serialization",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -305,4 +309,30 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/triton_route/TritonRoute.h",
+        "src/TritonRoute-py.i",
+        "//:error_swig-py",
+    ],
+    module = "drt_py",
+    root_swig_src = "src/TritonRoute-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "drt_py_python_inits",
+    namespace = "drt",
 )

--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -252,8 +252,6 @@ cc_library(
         "src/ta/FlexTA_graphics.cpp",
         "src/ta/FlexTA_graphics.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -281,7 +279,6 @@ cc_library(
         "@boost.serialization",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -326,13 +323,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "drt_py_python_inits",
-    namespace = "drt",
 )

--- a/src/exa/BUILD
+++ b/src/exa/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -36,6 +37,8 @@ cc_library(
         "src/graphics.h",
         "src/observer.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -55,6 +58,7 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -82,4 +86,31 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/exa/example.h",
+        "src/example-py.i",
+        "//:error_swig-py",
+    ],
+    module = "exa_py",
+    root_swig_src = "src/example-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "exa_py_python_inits",
+    namespace = "exa",
 )

--- a/src/exa/BUILD
+++ b/src/exa/BUILD
@@ -37,8 +37,6 @@ cc_library(
         "src/graphics.h",
         "src/observer.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -58,7 +56,6 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -100,17 +97,5 @@ python_wrap_cc(
     swig_includes = [
         "include",
         "src",
-    ],
-    deps = [
-        "//src/odb:swig-py",
-    ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "exa_py_python_inits",
-    namespace = "exa",
+    ]
 )

--- a/src/fin/BUILD
+++ b/src/fin/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -20,6 +21,8 @@ cc_library(
         "src/graphics.h",
         "src/polygon.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -39,6 +42,7 @@ cc_library(
         "@boost.property_tree",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -66,4 +70,30 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/fin/Finale.h",
+        "src/finale-py.i",
+        "//:error_swig-py",
+    ],
+    module = "fin_py",
+    root_swig_src = "src/finale-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "fin_py_python_inits",
+    namespace = "fin",
 )

--- a/src/fin/BUILD
+++ b/src/fin/BUILD
@@ -21,8 +21,6 @@ cc_library(
         "src/graphics.h",
         "src/polygon.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -42,7 +40,6 @@ cc_library(
         "@boost.property_tree",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -87,13 +84,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "fin_py_python_inits",
-    namespace = "fin",
 )

--- a/src/gpl/BUILD
+++ b/src/gpl/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -38,6 +39,8 @@ cc_library(
         "src/timingBase.cpp",
         "src/timingBase.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -73,6 +76,7 @@ cc_library(
         "@or-tools//ortools/linear_solver",
         "@or-tools//ortools/sat:cp_model",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -100,4 +104,28 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/gpl/Replace.h",
+        "src/replace-py.i",
+        "//:error_swig-py",
+    ],
+    module = "gpl_py",
+    root_swig_src = "src/replace-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "gpl_py_python_inits",
+    namespace = "gpl",
 )

--- a/src/gpl/BUILD
+++ b/src/gpl/BUILD
@@ -39,8 +39,6 @@ cc_library(
         "src/timingBase.cpp",
         "src/timingBase.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -76,7 +74,6 @@ cc_library(
         "@or-tools//ortools/linear_solver",
         "@or-tools//ortools/sat:cp_model",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -113,19 +110,11 @@ python_wrap_cc(
         "src/replace-py.i",
         "//:error_swig-py",
     ],
-    module = "gpl_py",
+    module = "gpl",
     root_swig_src = "src/replace-py.i",
     swig_includes = [
         "include",
         "src",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "gpl_py_python_inits",
-    namespace = "gpl",
+    visibility = ["//:__subpackages__"],
 )

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -37,6 +37,34 @@ TESTS = [
     "simple10",
 ]
 
+py_library(
+    name = "helpers",
+    srcs = ["helpers.py"],
+    deps = [
+        "//openroad:openroadpy",
+    ],
+    imports = ["."],
+)
+
+py_library(
+    name = "gpl_aux",
+    srcs = ["gpl_aux.py"],
+    deps = [
+        "//openroad:openroadpy",
+    ],
+    imports = ["."],
+)
+
+filegroup(
+    name = "asap7pdk",
+    srcs = glob([
+        "asap7/*.lib.gz",
+        "asap7/*.lib",
+        "asap7/*.lef",
+        "asap7/*.tcl",
+    ])
+)
+
 filegroup(
     name = "test_resources",
     # overly broad glob, could be refined later, but
@@ -59,3 +87,45 @@ filegroup(
     name = test_name,
     data = [":test_resources"],
 ) for test_name in TESTS]
+
+PY_TESTS = [
+    "ar01",
+    "ar02",
+    "convergence01",
+    "core01",
+    "error01",
+    "incremental01",
+    "incremental02",
+    "nograd01",
+    "simple01",
+    "simple01-obs",
+    "simple01-ref",
+    "simple01-skip-io",
+    "simple01-td",
+    "simple01-td-tune",
+    "simple01-uniform",
+    "simple02",
+    "simple03",
+    "simple04",
+    "simple05",
+    "simple06",
+    "simple07",
+    "simple08",
+    "simple09",
+    "simple10",
+]
+
+[
+py_test(
+    name = test_name,
+    srcs = [test_name + ".py"],
+    deps = [
+        "//openroad:openroadpy",
+        ":helpers",
+        ":gpl_aux",
+    ],
+    data = [
+        ":test_resources"
+    ]
+)
+for test_name in PY_TESTS]

--- a/src/gpl/test/ar01.py
+++ b/src/gpl/test/ar01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/ar02.py
+++ b/src/gpl/test/ar02.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/convergence01.py
+++ b/src/gpl/test/convergence01.py
@@ -5,6 +5,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 
 tech.readLiberty("asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz")

--- a/src/gpl/test/core01.py
+++ b/src/gpl/test/core01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/error01.py
+++ b/src/gpl/test/error01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/incremental01.py
+++ b/src/gpl/test/incremental01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/incremental02.py
+++ b/src/gpl/test/incremental02.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/nograd01.py
+++ b/src/gpl/test/nograd01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("asap7/asap7_tech_1x_201209.lef")
 tech.readLef("asap7/asap7sc7p5t_28_R_1x_220121a.lef")

--- a/src/gpl/test/simple01-obs.py
+++ b/src/gpl/test/simple01-obs.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import gpl_aux
 import helpers
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple01-ref.py
+++ b/src/gpl/test/simple01-ref.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple01-skip-io.py
+++ b/src/gpl/test/simple01-skip-io.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple01-td-tune.py
+++ b/src/gpl/test/simple01-td-tune.py
@@ -2,6 +2,10 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
+
 tech = Tech()
 tech.readLiberty("./library/nangate45/NangateOpenCellLibrary_typical.lib")
 tech.readLef("./nangate45.lef")

--- a/src/gpl/test/simple01-td.py
+++ b/src/gpl/test/simple01-td.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLiberty("./library/nangate45/NangateOpenCellLibrary_typical.lib")
 tech.readLef("./nangate45.lef")

--- a/src/gpl/test/simple01-uniform.py
+++ b/src/gpl/test/simple01-uniform.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple01.py
+++ b/src/gpl/test/simple01.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple02.py
+++ b/src/gpl/test/simple02.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple03.py
+++ b/src/gpl/test/simple03.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple04.py
+++ b/src/gpl/test/simple04.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple05.py
+++ b/src/gpl/test/simple05.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple06.py
+++ b/src/gpl/test/simple06.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple07.py
+++ b/src/gpl/test/simple07.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./sky130hd.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple08.py
+++ b/src/gpl/test/simple08.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./sky130hd.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple09.py
+++ b/src/gpl/test/simple09.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./nangate45.lef")
 design = helpers.make_design(tech)

--- a/src/gpl/test/simple10.py
+++ b/src/gpl/test/simple10.py
@@ -2,6 +2,9 @@ from openroad import Design, Tech
 import helpers
 import gpl_aux
 
+bazel_working_dir = "/_main/src/gpl/test/"
+helpers.if_bazel_change_working_dir_to(bazel_working_dir)
+
 tech = Tech()
 tech.readLef("./sky130hd.lef")
 design = helpers.make_design(tech)

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -170,8 +170,6 @@ cc_library(
         "src/heatMapRudy.cpp",
         "src/heatMapRudy.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -207,7 +205,6 @@ cc_library(
         "@boost.stacktrace",
         "@openmp",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -247,13 +244,4 @@ python_wrap_cc(
         "include",
         "src",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "grt_py_python_inits",
-    namespace = "grt",
 )

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -169,6 +170,8 @@ cc_library(
         "src/heatMapRudy.cpp",
         "src/heatMapRudy.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -204,6 +207,7 @@ cc_library(
         "@boost.stacktrace",
         "@openmp",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -228,4 +232,28 @@ tcl_wrap_cc(
     swig_includes = [
         "src",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/grt/GlobalRouter.h",
+        "src/GlobalRouter-py.i",
+        "//:error_swig-py",
+    ],
+    module = "grt_py",
+    root_swig_src = "src/GlobalRouter-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "grt_py_python_inits",
+    namespace = "grt",
 )

--- a/src/ifp/BUILD
+++ b/src/ifp/BUILD
@@ -36,9 +36,7 @@ cc_library(
         "include/ifp/InitFloorplan.hh",
         "src/MakeInitFloorplan.cc",
         ":swig",
-        ":swig-py",
         ":tcl",
-        ":python",
     ],
     hdrs = [
         "include/ifp/MakeInitFloorplan.hh",
@@ -58,7 +56,6 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -104,13 +101,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "ifp_py_python_inits",
-    namespace = "ifp",
 )

--- a/src/ifp/BUILD
+++ b/src/ifp/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -35,7 +36,9 @@ cc_library(
         "include/ifp/InitFloorplan.hh",
         "src/MakeInitFloorplan.cc",
         ":swig",
+        ":swig-py",
         ":tcl",
+        ":python",
     ],
     hdrs = [
         "include/ifp/MakeInitFloorplan.hh",
@@ -55,6 +58,7 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -82,4 +86,31 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/ifp/InitFloorplan.hh",
+        "src/InitFloorplan-py.i",
+        "//:error_swig-py",
+    ],
+    module = "ifp_py",
+    root_swig_src = "src/InitFloorplan-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "ifp_py_python_inits",
+    namespace = "ifp",
 )

--- a/src/odb/BUILD
+++ b/src/odb/BUILD
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2025, Precision Innovations Inc.
 
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
-load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -42,12 +42,11 @@ cc_library(
         "src/lefin/*.h",
         "src/lefout/*.cpp",
         "src/swig/common/swig_common.cpp",
-        "src/swig/common/swig_common.h",
     ]),
     hdrs = glob([
         "include/odb/*.h",
         "include/odb/*.hpp",
-    ]),
+    ]) + ["src/swig/common/swig_common.h"],
     features = [
         "-use_header_modules",
     ],
@@ -81,6 +80,31 @@ cc_library(
     ],
 )
 
+# This target compiles the SWIG C++ wrapper into a shared library (.so)
+# that Python can load dynamically.
+cc_binary(
+    name = "_odb.so",
+    srcs = [":swig-py"],
+    includes = ["src/swig/common"],
+    linkshared = True,
+    deps = [
+        ":odb",  # Depends on the core odb C++ library
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
+# This packages the SWIG-generated Python wrapper (odb.py) and the
+# compiled C++ extension (_odb.so) together.
+py_library(
+    name = "odb_py",
+    srcs = [":swig-py"],  # Use the .py output from the swig-py rule
+    # The data attribute makes the .so file available at runtime.
+    data = [":_odb.so"],
+    # This allows imports relative to the workspace root.
+    imports = ["."],
+    visibility = ["//visibility:public",]
+)
+
 cc_library(
     name = "ui",
     srcs = [
@@ -88,8 +112,6 @@ cc_library(
         "src/swig/common/swig_common.h",
         "src/swig/tcl/MakeOdb.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = glob([
@@ -113,7 +135,6 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -161,7 +182,7 @@ python_wrap_cc(
         "//:src/Design.i",
         "//:src/Exception.i",
     ],
-    module = "odb_py",
+    module = "odb",
     root_swig_src = "src/swig/common/odb.i",
     swig_includes = [
         "include",
@@ -175,13 +196,4 @@ python_wrap_cc(
         # the warnings one by one.
         "-w509,503,501,472,467,402,401,317,325,378,383,389,365,362,314,258,240,203,201",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "odb_py_python_inits",
-    namespace = "odb",
 )

--- a/src/odb/BUILD
+++ b/src/odb/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -13,6 +14,14 @@ filegroup(
     name = "swig_imports",
     srcs = glob([
         "src/swig/tcl/*.i",
+        "src/swig/common/*.i",
+    ]),
+)
+
+filegroup(
+    name = "swig_imports_py",
+    srcs = glob([
+        "src/swig/python/*.i",
         "src/swig/common/*.i",
     ]),
 )
@@ -79,6 +88,8 @@ cc_library(
         "src/swig/common/swig_common.h",
         "src/swig/tcl/MakeOdb.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = glob([
@@ -102,6 +113,7 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -137,5 +149,39 @@ tcl_encode(
         "src/swig/tcl/odb.tcl",
     ],
     char_array_name = "odbtcl_tcl_inits",
+    namespace = "odb",
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = glob([
+        "include/odb/*.h",
+    ]) + [
+        ":swig_imports_py",
+        "//:src/Design.i",
+        "//:src/Exception.i",
+    ],
+    module = "odb_py",
+    root_swig_src = "src/swig/common/odb.i",
+    swig_includes = [
+        "include",
+        "src/swig/common",
+        "src/swig/python",
+    ],
+    swig_options = [
+        # These values are derived from the CMakeList.txt and represent the "rules" this swig file
+        # breaks. Swig refuses to compile our swig files unless we acknowledge we are ignoring the
+        # following warnings. They can be derived by attemtpting to compile without them and fixing
+        # the warnings one by one.
+        "-w509,503,501,472,467,402,401,317,325,378,383,389,365,362,314,258,240,203,201",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "odb_py_python_inits",
     namespace = "odb",
 )

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
+%module(package="src.odb") odb
+
 %{
 #define SWIG_FILE_WITH_INIT
 #include "odb/geom.h"

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -2,6 +2,140 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+py_library(
+    name = "helper",
+    srcs = [
+        "helper.py",
+    ],
+    imports = ["."]
+)
+
+py_library(
+    name = "odbUnitTest",
+    srcs = [
+        "odbUnitTest.py",
+    ],
+    imports = ["."]
+)
+
+
+py_test(
+    name = "test_block",
+    srcs = [
+        "test_block.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_bterm",
+    srcs = [
+        "test_bterm.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_destroy",
+    srcs = [
+        "test_destroy.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_group",
+    srcs = [
+        "test_group.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_inst",
+    srcs = [
+        "test_inst.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_iterm",
+    srcs = [
+        "test_iterm.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_module",
+    srcs = [
+        "test_module.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_net",
+    srcs = [
+        "test_net.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
+py_test(
+    name = "test_wire_codec",
+    srcs = [
+        "test_wire_codec.py",
+    ],
+    deps = [
+        "//src/odb:odb_py",
+        "//:ord_py",
+        ":odbUnitTest",
+        ":helper",
+    ]
+)
+
 PASSFAIL_TESTS = [
     # FIXME not supported yet
     # "cpp_tests",

--- a/src/odb/test/helper.py
+++ b/src/odb/test/helper.py
@@ -1,10 +1,12 @@
 import odb
 import openroad
-from openroad import Design
+from openroad import Design, Tech
 
 
 def createSimpleDB():
-    db = Design.createDetachedDb()
+    ord_tech = Tech()
+    design = Design(ord_tech)
+    db = design.getDb()
     tech = odb.dbTech.create(db, "simple_tech")
     L1 = odb.dbTechLayer_create(tech, "L1", "ROUTING")
     lib = odb.dbLib.create(db, "lib", tech, "/")
@@ -12,11 +14,13 @@ def createSimpleDB():
     # Creating Master and2 and or2
     and2 = createMaster2X1(lib, "and2", 1000, 1000, "a", "b", "o")
     or2 = createMaster2X1(lib, "or2", 500, 500, "a", "b", "o")
-    return db, lib
+    return db, lib, design, ord_tech
 
 
 def createMultiLayerDB():
-    db = Design.createDetachedDb()
+    ord_tech = Tech()
+    design = Design(ord_tech)
+    db = design.getDb()
     tech = odb.dbTech.create(db, "multi_tech")
 
     m1 = odb.dbTechLayer_create(tech, "M1", "ROUTING")
@@ -34,7 +38,7 @@ def createMultiLayerDB():
     odb.dbBox_create(v23, m2, 0, 0, 2000, 2000)
     odb.dbBox_create(v23, m3, 0, 0, 2000, 2000)
 
-    return db, tech, m1, m2, m3, v12, v23
+    return db, tech, m1, m2, m3, v12, v23, design, ord_tech
 
 
 # logical expr OUT = (IN1&IN2)

--- a/src/odb/test/test_block.py
+++ b/src/odb/test/test_block.py
@@ -16,16 +16,13 @@ def placeBPin(bpin, layer, x1, y1, x2, y2):
 
 class TestBlock(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         self.parentBlock = odb.dbBlock_create(self.db.getChip(), "Parent")
         self.block = helper.create2LevelBlock(self.db, self.lib, self.parentBlock)
         self.block.setCornerCount(4)
         self.extcornerblock = self.block.createExtCornerBlock(1)
         odb.dbTechNonDefaultRule_create(self.block, "non_default_1")
         self.parentRegion = odb.dbRegion_create(self.block, "parentRegion")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_find(self):
         # bterm
@@ -45,7 +42,7 @@ class TestBlock(odbUnitTest.TestCase):
         # iterm
         self.assertEqual(self.block.findITerm("i1,o").getInst().getName(), "i1")
         self.assertEqual(self.block.findITerm("i1,o").getMTerm().getName(), "o")
-        self.assertIsNone(self.block.findITerm("i1\o"))
+        self.assertIsNone(self.block.findITerm("i1\\o"))
         # extcornerblock
         self.assertEqual(
             self.block.findExtCornerBlock(1).getName(), "extCornerBlock__1"

--- a/src/odb/test/test_bterm.py
+++ b/src/odb/test/test_bterm.py
@@ -6,7 +6,7 @@ import unittest
 
 class TestBTerm(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         blockName = "1LevelBlock"
         self.block = odb.dbBlock_create(self.db.getChip(), blockName)
         self.and2 = self.lib.findMaster("and2")
@@ -15,9 +15,6 @@ class TestBTerm(odbUnitTest.TestCase):
         self.n_a = odb.dbNet.create(self.block, "na")
         self.n_b = odb.dbNet.create(self.block, "nb")
         self.bterm_a = odb.dbBTerm.create(self.n_a, "IN_a")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_idle(self):
         self.assertEqual(self.bterm_a.getNet().getName(), "na")

--- a/src/odb/test/test_destroy.py
+++ b/src/odb/test/test_destroy.py
@@ -10,7 +10,7 @@ import unittest
 
 class TestDestroy(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, lib = helper.createSimpleDB()
+        self.db, lib, self.design, self.ord_tech = helper.createSimpleDB()
         self.parentBlock = odb.dbBlock_create(self.db.getChip(), "Parent")
         self.block = helper.create2LevelBlock(self.db, lib, self.parentBlock)
         self.i1 = self.block.findInst("i1")
@@ -23,9 +23,6 @@ class TestDestroy(odbUnitTest.TestCase):
         self.n5 = self.i3.findITerm("a").getNet()
         self.n6 = self.i3.findITerm("b").getNet()
         self.n7 = self.i3.findITerm("o").getNet()
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_destroy_net(self):
         self.n1.destroy(self.n1)

--- a/src/odb/test/test_group.py
+++ b/src/odb/test/test_group.py
@@ -11,7 +11,7 @@ import unittest
 ##################
 class TestModule(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         self.block = helper.create1LevelBlock(self.db, self.lib, self.db.getChip())
         self.group = odb.dbGroup_create(self.block, "group")
         self.domain = odb.dbRegion_create(self.block, "domain")
@@ -22,9 +22,6 @@ class TestModule(odbUnitTest.TestCase):
         self.i1 = odb.dbModInst_create(self.parent_mod, self.master_mod, "i1")
         self.inst1 = self.block.findInst("inst")
         self.n1 = self.block.findNet("n1")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_default(self):
         self.check(self.group, "getName", "group")

--- a/src/odb/test/test_inst.py
+++ b/src/odb/test/test_inst.py
@@ -6,12 +6,9 @@ import unittest
 
 class TestInst(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         self.block = helper.create2LevelBlock(self.db, self.lib, self.db.getChip())
         self.i1 = self.block.findInst("i1")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_swap_master(self):
         self.assertEqual(self.i1.getMaster().getName(), "and2")

--- a/src/odb/test/test_iterm.py
+++ b/src/odb/test/test_iterm.py
@@ -6,15 +6,12 @@ import unittest
 
 class TestITerm(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         blockName = "1LevelBlock"
         self.block = odb.dbBlock_create(self.db.getChip(), blockName)
         self.and2 = self.lib.findMaster("and2")
         self.inst = odb.dbInst.create(self.block, self.and2, "inst")
         self.iterm_a = self.inst.findITerm("a")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_idle(self):
         self.assertIsNone(self.iterm_a.getNet())

--- a/src/odb/test/test_module.py
+++ b/src/odb/test/test_module.py
@@ -11,15 +11,12 @@ import unittest
 ##################
 class TestModule(odbUnitTest.TestCase):
     def setUp(self):
-        self.db, self.lib = helper.createSimpleDB()
+        self.db, self.lib, self.design, self.ord_tech = helper.createSimpleDB()
         self.block = helper.create1LevelBlock(self.db, self.lib, self.db.getChip())
         self.master_mod = odb.dbModule_create(self.block, "master_mod")
         self.parent_mod = odb.dbModule_create(self.block, "parent_mod")
         self.i1 = odb.dbModInst_create(self.parent_mod, self.master_mod, "i1")
         self.inst1 = self.block.findInst("inst")
-
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_default(self):
         self.check(self.master_mod, "getName", "master_mod")

--- a/src/odb/test/test_net.py
+++ b/src/odb/test/test_net.py
@@ -10,17 +10,12 @@ class TestNet(odbUnitTest.TestCase):
     # This Function is called before each of the test cases defined below
     # You should use it to create the instances you need to test (in our case n1, n2, n3)
     def setUp(self):
-        self.db, lib = helper.createSimpleDB()
+        self.db, lib, self.design, self.ord_tech = helper.createSimpleDB()
         block = helper.create1LevelBlock(self.db, lib, self.db.getChip())
         inst = block.getInsts()[0]
         self.n1 = inst.findITerm("a").getNet()
         self.n2 = inst.findITerm("b").getNet()
         self.n3 = inst.findITerm("o").getNet()
-
-    # this function is called after each of the test cases
-    # you should free up space and destroy unneeded objects(cleanup step)
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     # each test case should start with the name "test"
     def test_naming(self):

--- a/src/odb/test/test_wire_codec.py
+++ b/src/odb/test/test_wire_codec.py
@@ -15,6 +15,8 @@ class TestWireCodec(odbUnitTest.TestCase):
             self.m3,
             self.v12,
             self.v23,
+            self.design,
+            self.ord_tech
         ) = helper.createMultiLayerDB()
         self.chip = odb.dbChip_create(self.db, self.tech)
         self.block = odb.dbBlock_create(self.chip, "chip")
@@ -35,10 +37,6 @@ class TestWireCodec(odbUnitTest.TestCase):
             "RULE",
             "END_DECODE",
         ]
-
-    # this function is called after each of the test cases
-    def tearDown(self):
-        self.db.destroy(self.db)
 
     def test_decoder(self):
         encoder = odb.dbWireEncoder()

--- a/src/par/BUILD
+++ b/src/par/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -69,6 +70,8 @@ cc_library(
     srcs = [
         "src/MakePartitionMgr.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -98,6 +101,7 @@ cc_library(
         "@boost.tokenizer",
         "@boost.utility",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -125,4 +129,30 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/par/PartitionMgr.h",
+        "src/partitionmgr-py.i",
+        "//:error_swig-py",
+    ],
+    module = "par_py",
+    root_swig_src = "src/partitionmgr-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "par_py_python_inits",
+    namespace = "par",
 )

--- a/src/par/BUILD
+++ b/src/par/BUILD
@@ -70,8 +70,6 @@ cc_library(
     srcs = [
         "src/MakePartitionMgr.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -101,7 +99,6 @@ cc_library(
         "@boost.tokenizer",
         "@boost.utility",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -146,13 +143,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "par_py_python_inits",
-    namespace = "par",
 )

--- a/src/par/src/partitionmgr-py.i
+++ b/src/par/src/partitionmgr-py.i
@@ -7,6 +7,7 @@
 
 %include "../../Exception-py.i"
 
+#ifndef BAZEL
 %include <std_vector.i>
 %include <std_string.i>
 
@@ -15,5 +16,6 @@ namespace std
   %template(vector_int) std::vector<int>;
   %template(vector_float) std::vector<float>;
 }
+#endif
 
 %include "par/PartitionMgr.h"

--- a/src/pdn/BUILD
+++ b/src/pdn/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -41,6 +42,8 @@ cc_library(
         "src/via_repair.cpp",
         "src/via_repair.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -62,6 +65,7 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -89,4 +93,30 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/pdn/PdnGen.hh",
+        "src/PdnGen-py.i",
+        "//:error_swig-py",
+    ],
+    module = "pdn_py",
+    root_swig_src = "src/PdnGen-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "pdn_py_python_inits",
+    namespace = "pdn",
 )

--- a/src/pdn/BUILD
+++ b/src/pdn/BUILD
@@ -42,8 +42,6 @@ cc_library(
         "src/via_repair.cpp",
         "src/via_repair.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -65,7 +63,6 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -106,17 +103,5 @@ python_wrap_cc(
     root_swig_src = "src/PdnGen-py.i",
     swig_includes = [
         "include",
-    ],
-    deps = [
-        "//src/odb:swig-py",
-    ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "pdn_py_python_inits",
-    namespace = "pdn",
+    ]
 )

--- a/src/ppl/BUILD
+++ b/src/ppl/BUILD
@@ -29,8 +29,6 @@ cc_library(
         "src/Slots.cpp",
         "src/Slots.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -56,7 +54,6 @@ cc_library(
         "@boost.random",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -113,17 +110,5 @@ python_wrap_cc(
     swig_includes = [
         "include",
         "src",
-    ],
-    deps = [
-        "//src/odb:swig-py",
-    ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "ppl_py_python_inits",
-    namespace = "ppl",
+    ]
 )

--- a/src/ppl/BUILD
+++ b/src/ppl/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -28,6 +29,8 @@ cc_library(
         "src/Slots.cpp",
         "src/Slots.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -53,6 +56,7 @@ cc_library(
         "@boost.random",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -94,4 +98,32 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/ppl/Parameters.h",
+        "include/ppl/IOPlacer.h",
+        "src/IOPlacer-py.i",
+        "//:error_swig-py",
+    ],
+    module = "ppl_py",
+    root_swig_src = "src/IOPlacer-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "ppl_py_python_inits",
+    namespace = "ppl",
 )

--- a/src/psm/BUILD
+++ b/src/psm/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -29,6 +30,8 @@ cc_library(
         "src/shape.cpp",
         "src/shape.h",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -52,6 +55,7 @@ cc_library(
         "@boost.stacktrace",
         "@eigen",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -79,4 +83,30 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/psm/pdnsim.h",
+        "src/pdnsim-py.i",
+        "//:error_swig-py",
+    ],
+    module = "psm_py",
+    root_swig_src = "src/pdnsim-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "psm_py_python_inits",
+    namespace = "psm",
 )

--- a/src/psm/BUILD
+++ b/src/psm/BUILD
@@ -30,8 +30,6 @@ cc_library(
         "src/shape.cpp",
         "src/shape.h",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -55,7 +53,6 @@ cc_library(
         "@boost.stacktrace",
         "@eigen",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -100,13 +97,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "psm_py_python_inits",
-    namespace = "psm",
 )

--- a/src/rcx/BUILD
+++ b/src/rcx/BUILD
@@ -11,32 +11,6 @@ package(
 )
 
 cc_library(
-    name = "hdrs",
-    hdrs = [
-        "include/rcx/box.h",
-        "include/rcx/dbUtil.h",
-        "include/rcx/ext.h",
-        "include/rcx/ext2dBox.h",
-        "include/rcx/extMeasureRC.h",
-        "include/rcx/extModelGen.h",
-        "include/rcx/extPattern.h",
-        "include/rcx/extProgressTracker.hpp",
-        "include/rcx/extRCap.h",
-        "include/rcx/extRulesPattern.h",
-        "include/rcx/extSegment.h",
-        "include/rcx/extSolverGen.h",
-        "include/rcx/extSpef.h",
-        "include/rcx/extViaModel.h",
-        "include/rcx/ext_options.h",
-        "include/rcx/extprocess.h",
-        "include/rcx/grids.h",
-        "include/rcx/name.h",
-        "include/rcx/rcx.h",
-        "include/rcx/util.h",
-    ],
-)
-
-cc_library(
     name = "rcx",
     srcs = [
         "src/dbUtil.cpp",
@@ -89,11 +63,32 @@ cc_library(
         "src/parse.h",
         "src/process_ext.cpp",
     ],
+    hdrs = [
+        "include/rcx/box.h",
+        "include/rcx/dbUtil.h",
+        "include/rcx/ext.h",
+        "include/rcx/ext2dBox.h",
+        "include/rcx/extMeasureRC.h",
+        "include/rcx/extModelGen.h",
+        "include/rcx/extPattern.h",
+        "include/rcx/extProgressTracker.hpp",
+        "include/rcx/extRCap.h",
+        "include/rcx/extRulesPattern.h",
+        "include/rcx/extSegment.h",
+        "include/rcx/extSolverGen.h",
+        "include/rcx/extSpef.h",
+        "include/rcx/extViaModel.h",
+        "include/rcx/ext_options.h",
+        "include/rcx/extprocess.h",
+        "include/rcx/grids.h",
+        "include/rcx/name.h",
+        "include/rcx/rcx.h",
+        "include/rcx/util.h",
+    ],
     includes = [
         "include",
     ],
     deps = [
-        ":hdrs",
         "//src/odb",
         "//src/utl",
     ],
@@ -104,8 +99,6 @@ cc_library(
     srcs = [
         "src/MakeOpenRCX.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -118,14 +111,12 @@ cc_library(
         "include",
     ],
     deps = [
-        ":hdrs",
         ":rcx",
         "//:ord",
         "//src/odb",
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -171,13 +162,4 @@ python_wrap_cc(
     deps = [
         "//src/odb:swig-py",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "rcx_py_python_inits",
-    namespace = "rcx",
 )

--- a/src/rcx/BUILD
+++ b/src/rcx/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -103,6 +104,8 @@ cc_library(
     srcs = [
         "src/MakeOpenRCX.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -122,6 +125,7 @@ cc_library(
         "//src/utl",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -149,4 +153,31 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/rcx/ext.h",
+        "include/rcx/ext_options.h",
+        "src/ext-py.i",
+        "//:error_swig-py",
+    ],
+    module = "rcx_py",
+    root_swig_src = "src/ext-py.i",
+    swig_includes = [
+        "include",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "rcx_py_python_inits",
+    namespace = "rcx",
 )

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1784,7 +1784,7 @@ class extMain
                    const char* old_new);
   dbRSeg* addRSeg_v2(dbNet* net,
                      uint& srcId,
-                     Point& prevPoint,
+                     odb::Point& prevPoint,
                      const dbWirePath& path,
                      const dbWirePathShape& pshape,
                      const bool isBranch,
@@ -1794,11 +1794,11 @@ class extMain
   void loopWarning(dbNet* net, const dbWirePathShape& pshape);
   void getShapeRC_v2(dbNet* net,
                      const dbShape& s,
-                     Point& prevPoint,
+                     odb::Point& prevPoint,
                      const dbWirePathShape& pshape);
   void getShapeRC_v3(dbNet* net,
                      const dbShape& s,
-                     Point& prevPoint,
+                     odb::Point& prevPoint,
                      const dbWirePathShape& pshape);
   double getViaRes_v2(dbNet* net, dbTechVia* tvia);
   double getDbViaRes_v2(dbNet* net, const dbShape& s);

--- a/src/stt/BUILD
+++ b/src/stt/BUILD
@@ -67,8 +67,6 @@ cc_library(
         "src/LinesRenderer.h",
         "src/MakeSteinerTreeBuilder.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -90,7 +88,6 @@ cc_library(
         "@boost.multi_array",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -131,13 +128,4 @@ python_wrap_cc(
     swig_includes = [
         "include",
     ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "stt_py_python_inits",
-    namespace = "stt",
 )

--- a/src/stt/BUILD
+++ b/src/stt/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -66,6 +67,8 @@ cc_library(
         "src/LinesRenderer.h",
         "src/MakeSteinerTreeBuilder.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -87,6 +90,7 @@ cc_library(
         "@boost.multi_array",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -111,4 +115,29 @@ tcl_wrap_cc(
     swig_includes = [
         "src",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/stt/SteinerTreeBuilder.h",
+        "include/stt/flute.h",
+        "include/stt/pd.h",
+        "src/SteinerTreeBuilder-py.i",
+        "//:error_swig-py",
+    ],
+    module = "stt_py",
+    root_swig_src = "src/SteinerTreeBuilder-py.i",
+    swig_includes = [
+        "include",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "stt_py_python_inits",
+    namespace = "stt",
 )

--- a/src/tap/BUILD
+++ b/src/tap/BUILD
@@ -35,8 +35,6 @@ cc_library(
         "include/tap/tapcell.h",
         "src/MakeTapcell.cpp",
         ":swig",
-        ":swig-py",
-        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -54,7 +52,6 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
-        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -96,17 +93,5 @@ python_wrap_cc(
     swig_includes = [
         "include",
         "src",
-    ],
-    deps = [
-        "//src/odb:swig-py",
-    ],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "tap_py_python_inits",
-    namespace = "tap",
+    ]
 )

--- a/src/tap/BUILD
+++ b/src/tap/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -34,6 +35,8 @@ cc_library(
         "include/tap/tapcell.h",
         "src/MakeTapcell.cpp",
         ":swig",
+        ":swig-py",
+        ":python",
         ":tcl",
     ],
     hdrs = [
@@ -51,6 +54,7 @@ cc_library(
         "@boost.polygon",
         "@boost.stacktrace",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -78,4 +82,31 @@ tcl_wrap_cc(
     deps = [
         "//src/odb:swig",
     ],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/tap/tapcell.h",
+        "src/tapcell-py.i",
+        "//:error_swig-py",
+    ],
+    module = "tap_py",
+    root_swig_src = "src/tapcell-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "tap_py_python_inits",
+    namespace = "tap",
 )

--- a/src/utl/BUILD
+++ b/src/utl/BUILD
@@ -3,6 +3,7 @@
 
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -91,7 +92,9 @@ cc_library(
         "src/LoggerCommon.h",
         "src/MakeLogger.cpp",
         ":swig",
+        ":swig-py",
         ":tcl",
+        ":python",
     ],
     hdrs = [
         "include/utl/MakeLogger.h",
@@ -113,6 +116,7 @@ cc_library(
         "@boost.stacktrace",
         "@spdlog",
         "@tk_tcl//:tcl",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
     ],
 )
 
@@ -140,4 +144,30 @@ tcl_encode(
     char_array_name = "utl_tcl_inits",
     namespace = "utl",
     visibility = ["//visibility:public"],
+)
+
+python_wrap_cc(
+    name = "swig-py",
+    srcs = [
+        "include/utl/Logger.h",
+        "src/Logger-py.i",
+        "src/LoggerCommon.h",
+        "//:error_swig-py",
+    ],
+    module = "utl_py",
+    root_swig_src = "src/Logger-py.i",
+    swig_includes = [
+        "include",
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+tcl_encode(
+    name = "python",
+    srcs = [
+        ":swig-py",
+    ],
+    char_array_name = "utl_py_python_inits",
+    namespace = "utl",
 )

--- a/src/utl/BUILD
+++ b/src/utl/BUILD
@@ -23,7 +23,6 @@ cc_library(
         "src/CommandLineProgress.h",
         "src/Logger.cpp",
         "src/LoggerCommon.cpp",
-        "src/LoggerCommon.h",
         "src/Metrics.cpp",
         "src/Progress.cpp",
         "src/ScopedTemporaryFile.cpp",
@@ -70,8 +69,9 @@ cc_library(
         "include/utl/timer.h",
         "include/utl/unique_name.h",
         "include/utl/validation.h",
+        "src/LoggerCommon.h",
     ],
-    includes = ["include"],
+    includes = ["include", "src"],
     deps = [
         "//src/sta:opensta_lib",
         "@boost.algorithm",
@@ -86,15 +86,42 @@ cc_library(
     ],
 )
 
+# This target compiles the SWIG C++ wrapper into a shared library (.so)
+# that Python can load dynamically.
+cc_binary(
+    name = "_utl.so",
+    srcs = [
+        ":swig-py",
+        "src/LoggerCommon.h",
+    ],
+    includes = ["src"],
+    linkshared = True,
+    deps = [
+        "//src/utl",
+        "@boost.stacktrace",
+        "@openroad_rules_python//python/cc:current_py_cc_headers",
+    ],
+)
+
+# This packages the SWIG-generated Python wrapper (odb.py) and the
+# compiled C++ extension (_odb.so) together.
+py_library(
+    name = "utl_py",
+    srcs = [":swig-py"],  # Use the .py output from the swig-py rule
+    # The data attribute makes the .so file available at runtime.
+    data = [":_utl.so"],
+    # This allows imports relative to the workspace root.
+    imports = ["."],
+    visibility = ["//visibility:public",]
+)
+
 cc_library(
     name = "ui",
     srcs = [
         "src/LoggerCommon.h",
         "src/MakeLogger.cpp",
         ":swig",
-        ":swig-py",
         ":tcl",
-        ":python",
     ],
     hdrs = [
         "include/utl/MakeLogger.h",
@@ -154,20 +181,11 @@ python_wrap_cc(
         "src/LoggerCommon.h",
         "//:error_swig-py",
     ],
-    module = "utl_py",
+    module = "utl",
     root_swig_src = "src/Logger-py.i",
     swig_includes = [
         "include",
         "src",
     ],
     visibility = ["//visibility:public"],
-)
-
-tcl_encode(
-    name = "python",
-    srcs = [
-        ":swig-py",
-    ],
-    char_array_name = "utl_py_python_inits",
-    namespace = "utl",
 )

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -256,6 +256,8 @@ class Logger
   void teeStringBegin();
   std::string teeStringEnd();
 
+  static Logger* defaultLogger();
+
   // Progress interface
   Progress* progress() const { return progress_.get(); }
   std::unique_ptr<Progress> swapProgress(Progress* progress);

--- a/src/utl/src/Logger-py.i
+++ b/src/utl/src/Logger-py.i
@@ -1,10 +1,26 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2020-2025, The OpenROAD Authors
 
-%module utl_py
+%module(package="src.utl") utl
 
+#ifdef BAZEL
 %{
+#include "utl/Logger.h"
 
+namespace ord {
+// Defined in OpenRoad.i
+utl::Logger *
+getLogger();
+}
+using utl::ToolId;
+using utl::Logger;
+using ord::getLogger;
+
+using namespace utl;
+
+%}
+#else
+%{
 #include "utl/Logger.h"
 #include "LoggerCommon.h"
 
@@ -21,6 +37,7 @@ using ord::getLogger;
 using namespace utl;
 
 %}
+#endif
 
 #define __attribute__(x)
 
@@ -34,4 +51,6 @@ using namespace utl;
 %ignore utl::Logger::swapProgress;
 
 %include "utl/Logger.h"
+#ifndef BAZEL
 %include "LoggerCommon.h"
+#endif

--- a/src/utl/src/Logger.cpp
+++ b/src/utl/src/Logger.cpp
@@ -286,6 +286,11 @@ std::string Logger::teeStringEnd()
   return redirectStringEnd();
 }
 
+Logger* Logger::defaultLogger() {
+  static Logger default_logger;
+  return &default_logger;
+}
+
 void Logger::assertNoRedirect()
 {
   if (string_redirect_ != nullptr || file_redirect_ != nullptr) {


### PR DESCRIPTION
There is now infrastructure to build python wheels that we could upload to pypi. This rule can be built with 

```
bazelisk build -c opt --features=thin_lto //openroad:openroad_wheel
```
 
This is a precursor to removing the -python option from the OpenROAD binary, and adopting a more standard pypi distribution.
    
This will require CI changes to build the wheel on manylinux Docker images.
    
Signed-off-by: Ethan Mahintorabi <ethanmoon@google.com>
