### PR TITLE
est: fix typo on function call

### DIFF
--- a/src/est/src/EstimateParasitics.tcl
+++ b/src/est/src/EstimateParasitics.tcl
@@ -26,7 +26,7 @@ proc estimate_parasitics { args } {
   }
 
   if { [info exists flags(-placement)] } {
-    if { [est::check_corner_wire_cap] } {
+    if { [est::check_corner_wire_caps] } {
       est::estimate_parasitics_cmd "placement" $filename
     }
   } elseif { [info exists flags(-global_routing)] } {


### PR DESCRIPTION
I've found this small bug when investigating a related issue. I'm not sure how it was working even with the missing `s`.