### PR TITLE
Fix header ambiguously exported by two targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -142,7 +142,7 @@ cc_binary(
     deps = [
         ":openroad_lib",
         ":openroad_version",
-        "//:ord",
+        ":ord",
         "//src/cut",
         "//src/gui",
         "//src/sta:opensta_lib",

--- a/src/par/BUILD
+++ b/src/par/BUILD
@@ -60,7 +60,7 @@ cc_library(
         "@boost.range",
         "@boost.tokenizer",
         "@boost.utility",
-        "@or-tools//ortools/linear_solver:linear_solver",
+        "@or-tools//ortools/linear_solver",
     ],
 )
 

--- a/src/rmp/BUILD
+++ b/src/rmp/BUILD
@@ -58,7 +58,6 @@ cc_library(
     ],
     hdrs = [
         "include/rmp/MakeRestructure.h",
-        "include/rmp/Restructure.h",
     ],
     copts = [
         "-Isrc/rmp/src",
@@ -67,11 +66,11 @@ cc_library(
         "include",
     ],
     deps = [
+        ":rmp",
         "//:ord",
         "//src/cut",
         "//src/dbSta",
         "//src/odb",
-        "//src/rmp",
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/utl",


### PR DESCRIPTION
`rmp/Restructure.h` was exported by two targets.

Found with:

```
bant lib-headers | awk '{print $1}' | sort | uniq -cd
```

While at it, canonicalize all targets:

```
. <(bant canonicalize ...)
```