### PR TITLE
cgt: cut: Cleanup/lint fixes

### DIFF
--- a/src/cgt/include/cgt/ClockGating.h
+++ b/src/cgt/include/cgt/ClockGating.h
@@ -143,8 +143,8 @@ class ClockGating
   // Helper for inserting new instances/nets into a network.
   NetworkBuilder network_builder_;
 
-  Logger* logger_;
-  sta::dbSta* sta_;
+  Logger* logger_ = nullptr;
+  sta::dbSta* sta_ = nullptr;
   std::unique_ptr<cut::AbcLibraryFactory> abc_factory_;
   std::unique_ptr<cut::AbcLibrary> abc_library_;
 };

--- a/src/cgt/src/ClockGating.cpp
+++ b/src/cgt/src/ClockGating.cpp
@@ -512,7 +512,7 @@ void ClockGating::run()
         continue;
       }
 
-      correct_conds = gate_cond_cover;
+      correct_conds = std::move(gate_cond_cover);
       searchClockGates(instance,
                        correct_conds,
                        correct_conds.begin(),
@@ -657,10 +657,11 @@ void ClockGating::searchClockGates(sta::Instance* const instance,
                                    abc::Abc_Ntk_t& abc_network,
                                    const bool clk_enable)
 {
-  if (end - begin < 2) {
+  size_t half_len = (end - begin) / 2;
+  if (half_len == 0) {
     return;
   }
-  auto mid = begin + (end - begin) / 2;
+  auto mid = begin + half_len;
   auto combined_candidate_names
       = combinedGatingCondNames(sta_->getDbNetwork(), mid, end, clk_enable);
   debugPrint(
@@ -684,6 +685,7 @@ void ClockGating::searchClockGates(sta::Instance* const instance,
                "Clock gating signals: '{}' can be dropped",
                combined_candidate_names);
     good_gate_conds.erase(mid, end);
+    mid = begin + half_len;
   } else if (end - mid > 1) {
     debugPrint(logger_,
                CGT,
@@ -825,6 +827,8 @@ static abc::Abc_Obj_t* regDataFunctionToAbc(sta::dbNetwork* const network,
       case sta::FuncExpr::op_or:
       case sta::FuncExpr::op_xor:
         expr_stack.push_back(expr->right());
+        expr_stack.push_back(expr->left());
+        break;
       case sta::FuncExpr::op_not:
         expr_stack.push_back(expr->left());
         break;

--- a/src/cgt/src/ClockGating.cpp
+++ b/src/cgt/src/ClockGating.cpp
@@ -375,13 +375,6 @@ void ClockGating::run()
   abc_factory_->AddDbSta(sta_);
   abc_library_ = std::make_unique<cut::AbcLibrary>(abc_factory_->Build());
 
-  abc::Abc_SclInstallGenlib(abc_library_->abc_library(),
-                            /*Slew=*/0,
-                            /*Gain=*/0,
-                            /*fUseAll=*/0,
-                            /*nGatesMin=*/0);
-  abc::Mio_LibraryTransferCellIds();
-
   dump("pre");
 
   std::vector<sta::Instance*> instances;

--- a/src/cgt/test/aes_nangate45.ok
+++ b/src/cgt/test/aes_nangate45.ok
@@ -3,8 +3,6 @@
 [WARNING CUT-0021] Leakage power doesn't exist for cell LOGIC0_X1
 [WARNING CUT-0021] Leakage power doesn't exist for cell LOGIC1_X1
 Derived GENLIB library "NangateOpenCellLibrary" with 92 gates.
-Warning: Detected 2 multi-output gates (for example, "FA_X1").
-SC library cannot be found.
 [INFO CGT-0003] Clock gating instance 0/562
 [INFO CGT-0004] Accepted clock enable '_13148_ | _04712_ | _04712_ | _00499_ | _05106_ | _05208_' for instance dcnt\[0\]$_SDFFE_PN0P_
 [INFO CGT-0004] Accepted clock enable '_13151_ | _11055_ | _07150_ | _09231_ | _11144_ | _05152_ | _07152_ | _04670_' for instance ld_r$_DFF_P_

--- a/src/cgt/test/countdown_asap7.ok
+++ b/src/cgt/test/countdown_asap7.ok
@@ -11,8 +11,6 @@
 [INFO ODB-0227] LEF file: asap7/asap7_tech_1x_201209.lef, created 30 layers, 9 vias
 [INFO ODB-0227] LEF file: asap7/asap7sc7p5t_28_R_1x_220121a.lef, created 212 library cells
 Derived GENLIB library "asap7sc7p5t_AO_RVT_FF_nldm_211120" with 169 gates.
-Warning: Detected 2 multi-output gates (for example, "FAx1_ASAP7_75t_R").
-SC library cannot be found.
 [INFO CGT-0003] Clock gating instance 0/3
 [INFO CGT-0004] Accepted clock enable '_05_ | _02_ | _01_ | _10_ | _03_' for instance val\[0\]$_DFF_PP1_
 No differences found.

--- a/src/cgt/test/ibex_sky130hd.ok
+++ b/src/cgt/test/ibex_sky130hd.ok
@@ -1,8 +1,6 @@
 [INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
 [INFO ODB-0227] LEF file: sky130hd/sky130hd_std_cell.lef, created 437 library cells
 Derived GENLIB library "sky130_fd_sc_hd__ss_n40C_1v40" with 317 gates.
-Warning: Detected 9 multi-output gates (for example, "sky130_fd_sc_hd__fa_1").
-SC library cannot be found.
 [INFO CGT-0003] Clock gating instance 0/946
 [INFO CGT-0004] Accepted clock enable 'ex_block_i.gen_multdiv_fast.multdiv_i.md_state_q\[5\] | _03749_ | _03000_ | _04094_ | _03636_ | _04093_' for instance _20290_
 [INFO CGT-0004] Accepted clock enable 'cs_registers_i.mcountinhibit_q\[0\] | _05037_ | _04531_ | _04533_ | _04495_ | _04405_ | _05854_ | _04404_' for instance cs_registers_i.mcountinhibit_q\[0\]$_DFFE_PN0P_

--- a/src/cut/include/cut/logic_cut.h
+++ b/src/cut/include/cut/logic_cut.h
@@ -18,9 +18,9 @@ namespace cut {
 class LogicCut
 {
  public:
-  LogicCut(std::vector<sta::Net*>& primary_inputs,
-           std::vector<sta::Net*>& primary_outputs,
-           sta::InstanceSet& cut_instances)
+  LogicCut(std::vector<sta::Net*>&& primary_inputs,
+           std::vector<sta::Net*>&& primary_outputs,
+           sta::InstanceSet&& cut_instances)
       : primary_inputs_(std::move(primary_inputs)),
         primary_outputs_(std::move(primary_outputs)),
         cut_instances_(std::move(cut_instances))

--- a/src/cut/src/blif.cpp
+++ b/src/cut/src/blif.cpp
@@ -534,7 +534,7 @@ bool Blif::readBlif(const char* file_name, odb::dbBlock* block)
           auto port_ = network_->libertyPort(pin_);
           if (port_->isClock()) {
             mtermName = mTerm->getName();
-            netName = connection;
+            netName = std::move(connection);
             break;
           }
         }

--- a/src/cut/src/logic_extractor.cpp
+++ b/src/cut/src/logic_extractor.cpp
@@ -385,7 +385,9 @@ LogicCut LogicExtractorFactory::BuildLogicCut(AbcLibrary& abc_network)
   std::vector<sta::Net*> primary_output_nets
       = ConvertIoPinsToNets(filtered_primary_outputs);
 
-  return LogicCut(primary_input_nets, primary_output_nets, cut_instances);
+  return LogicCut(std::move(primary_input_nets),
+                  std::move(primary_output_nets),
+                  std::move(cut_instances));
 }
 
 }  // namespace cut

--- a/src/cut/test/cpp/TestAbc.cc
+++ b/src/cut/test/cpp/TestAbc.cc
@@ -75,7 +75,7 @@ class AbcTest : public ::testing::Test
     sta_ = std::unique_ptr<sta::dbSta>(sta::makeDbSta());
     sta_->initVars(Tcl_CreateInterp(), db_.get(), &logger_);
     auto path = std::filesystem::canonical("./Nangate45/Nangate45_typ.lib");
-    library_ = sta_->readLiberty(path.string().c_str(),
+    library_ = sta_->readLiberty(path.c_str(),
                                  sta_->findCorner("default"),
                                  /*min_max=*/sta::MinMaxAll::all(),
                                  /*infer_latches=*/false);
@@ -87,10 +87,9 @@ class AbcTest : public ::testing::Test
         = std::filesystem::canonical("./Nangate45/Nangate45_tech.lef");
     auto stdcell_lef
         = std::filesystem::canonical("./Nangate45/Nangate45_stdcell.lef");
-    odb::dbTech* tech
-        = lef_reader.createTech("nangate45", tech_lef.string().c_str());
+    odb::dbTech* tech = lef_reader.createTech("nangate45", tech_lef.c_str());
     odb::dbLib* lib
-        = lef_reader.createLib(tech, "nangate45", stdcell_lef.string().c_str());
+        = lef_reader.createLib(tech, "nangate45", stdcell_lef.c_str());
 
     sta_->postReadLef(/*tech=*/nullptr, lib);
 
@@ -174,7 +173,7 @@ class AbcTestSky130 : public AbcTest
     sta_->initVars(Tcl_CreateInterp(), db_.get(), &logger_);
     auto path = std::filesystem::canonical(
         "./sky130/sky130_fd_sc_hd__ss_n40C_1v40.lib");
-    library_ = sta_->readLiberty(path.string().c_str(),
+    library_ = sta_->readLiberty(path.c_str(),
                                  sta_->findCorner("default"),
                                  /*min_max=*/sta::MinMaxAll::all(),
                                  /*infer_latches=*/false);
@@ -185,10 +184,8 @@ class AbcTestSky130 : public AbcTest
     auto tech_lef = std::filesystem::canonical("./sky130/sky130hd.tlef");
     auto stdcell_lef
         = std::filesystem::canonical("./sky130/sky130hd_std_cell.lef");
-    odb::dbTech* tech
-        = lef_reader.createTech("sky130", tech_lef.string().c_str());
-    odb::dbLib* lib
-        = lef_reader.createLib(tech, "sky130", stdcell_lef.string().c_str());
+    odb::dbTech* tech = lef_reader.createTech("sky130", tech_lef.c_str());
+    odb::dbLib* lib = lef_reader.createLib(tech, "sky130", stdcell_lef.c_str());
 
     sta_->postReadLef(/*tech=*/nullptr, lib);
 
@@ -220,7 +217,7 @@ class AbcTestAsap7 : public AbcTest
 
     for (const std::string& liberty_path : liberty_paths) {
       auto path = std::filesystem::canonical(liberty_path);
-      library_ = sta_->readLiberty(path.string().c_str(),
+      library_ = sta_->readLiberty(path.c_str(),
                                    sta_->findCorner("default"),
                                    /*min_max=*/sta::MinMaxAll::all(),
                                    /*infer_latches=*/false);
@@ -233,10 +230,8 @@ class AbcTestAsap7 : public AbcTest
         = std::filesystem::canonical("./asap7/asap7_tech_1x_201209.lef");
     auto stdcell_lef
         = std::filesystem::canonical("./asap7/asap7sc7p5t_28_R_1x_220121a.lef");
-    odb::dbTech* tech
-        = lef_reader.createTech("asap7", tech_lef.string().c_str());
-    odb::dbLib* lib
-        = lef_reader.createLib(tech, "asap7", stdcell_lef.string().c_str());
+    odb::dbTech* tech = lef_reader.createTech("asap7", tech_lef.c_str());
+    odb::dbLib* lib = lef_reader.createLib(tech, "asap7", stdcell_lef.c_str());
 
     sta_->postReadLef(/*tech=*/nullptr, lib);
 
@@ -667,7 +662,9 @@ TEST_F(AbcTestSky130, EnsureThatSky130MultiOutputConstCellsAreMapped)
   std::vector<sta::Net*> primary_outputs = {flop_net};
   sta::InstanceSet cut_instances(network);
   cut_instances.insert(flop_input_instance);
-  LogicCut cut(primary_inputs, primary_outputs, cut_instances);
+  LogicCut cut(std::move(primary_inputs),
+               std::move(primary_outputs),
+               std::move(cut_instances));
 
   // Create abc network that matches the underlying LogicCut
   utl::UniquePtrWithDeleter<abc::Abc_Ntk_t> abc_network(


### PR DESCRIPTION
Fixes memory leak (and removes redundant calls to ABC) and resolves Coverity lints.