### PR TITLE
gui: add path group filter to the Timing report 

### DIFF
--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -1130,7 +1130,9 @@ TimingControlsDialog::TimingControlsDialog(QWidget* parent)
       expand_clk_(new QCheckBox(this)),
       from_(new PinSetWidget(false, this)),
       thru_({}),
-      to_(new PinSetWidget(false, this))
+      to_(new PinSetWidget(false, this)),
+      scroll_(new QScrollArea(this)),
+      content_widget_(new QWidget)
 {
   setWindowTitle("Timing Controls");
 
@@ -1149,8 +1151,21 @@ TimingControlsDialog::TimingControlsDialog(QWidget* parent)
   setUnconstrained(false);
   layout_->addRow("Unconstrained:", unconstrained_);
   layout_->addRow("One path per endpoint:", one_path_per_endpoint_);
+  content_widget_->setLayout(layout_);
 
-  setLayout(layout_);
+  scroll_->setLayout(new QVBoxLayout);
+  scroll_->setWidget(content_widget_);
+  scroll_->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+  scroll_->adjustSize();
+  scroll_->setMinimumWidth(
+      scroll_->size().width()
+      + qApp->style()->pixelMetric(QStyle::PM_ScrollBarExtent));
+
+  setLayout(new QVBoxLayout);
+  layout()->addWidget(scroll_);
+  setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+  setMaximumWidth(layout()->sizeHint().width());
+  adjustSize();
 
   connect(path_count_spin_box_,
           QOverload<int>::of(&QSpinBox::valueChanged),
@@ -1180,6 +1195,24 @@ TimingControlsDialog::TimingControlsDialog(QWidget* parent)
           &TimingControlsDialog ::expandClock);
 
   sta_->setIncludeCapturePaths(true);
+}
+
+QSize TimingControlsDialog::sizeHint() const
+{
+  int width = minimumWidth();
+  int top = 0, bottom = 0;
+  if (layout())
+  {
+    layout()->getContentsMargins(nullptr, &top, nullptr, &bottom);
+  }
+  int top2 = 0, bottom2 = 0;
+  if (scroll_->layout())
+  {
+    scroll_->layout()->getContentsMargins(nullptr, &top2, nullptr, &bottom2);
+  }
+
+  int height = content_widget_->size().height()+top+bottom+top2+bottom2;
+  return QSize(width, height);
 }
 
 void TimingControlsDialog::setupPinRow(const QString& label,

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -14,6 +14,7 @@
 #include <QHBoxLayout>
 #include <QHash>
 #include <QListWidget>
+#include <QScrollArea>
 #include <QSpinBox>
 #include <map>
 #include <memory>
@@ -413,6 +414,8 @@ class TimingControlsDialog : public QDialog
   sta::Corner* getCorner() const { return sta_->getCorner(); }
   void setCorner(sta::Corner* corner) { sta_->setCorner(corner); }
 
+  QSize sizeHint() const override;
+
  signals:
   void inspect(const Selected& selected);
   void expandClock(bool expand);
@@ -440,6 +443,8 @@ class TimingControlsDialog : public QDialog
   std::vector<PinSetWidget*> thru_;
   PinSetWidget* to_;
   QHash<QString, sta::Clock*> qstring_to_clk_;
+  QScrollArea* scroll_;
+  QWidget* content_widget_;
 
   static constexpr int kThruStartRow = 4;
 

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -408,6 +408,7 @@ class TimingControlsDialog : public QDialog
   std::vector<std::set<const sta::Pin*>> getThruPins() const;
   std::set<const sta::Pin*> getToPins() const { return to_->getPins(); }
   void getClocks(sta::ClockSet* clock_set) const;
+  std::string getPathGroup() const;
 
   const sta::Pin* convertTerm(Gui::Term term) const;
 
@@ -434,6 +435,8 @@ class TimingControlsDialog : public QDialog
   QSpinBox* path_count_spin_box_;
   QComboBox* corner_box_;
   DropdownCheckboxes* clock_box_;
+  QComboBox* path_group_box_;
+  std::map<int, std::string> filter_index_to_path_group_name_;
 
   QCheckBox* unconstrained_;
   QCheckBox* one_path_per_endpoint_;
@@ -446,7 +449,7 @@ class TimingControlsDialog : public QDialog
   QScrollArea* scroll_;
   QWidget* content_widget_;
 
-  static constexpr int kThruStartRow = 4;
+  static constexpr int kThruStartRow = 5;
 
   void setPinSelections();
 

--- a/src/gui/src/timingWidget.cpp
+++ b/src/gui/src/timingWidget.cpp
@@ -634,8 +634,9 @@ void TimingWidget::populatePaths()
   const auto to = settings_->getToPins();
   sta::ClockSet* clks = new sta::ClockSet;
   settings_->getClocks(clks);
+  const auto path_group = settings_->getPathGroup();
 
-  populateAndSortModels(from, thru, to, "" /* path group name */, clks);
+  populateAndSortModels(from, thru, to, path_group, clks);
 }
 
 void TimingWidget::populateAndSortModels(


### PR DESCRIPTION
Part of #7699.

Changes:
- Add path group filter to the Timing report.
- Makes the timing report settings window resizable.
  - At lower resolutions, such as 720p, the timing report settings were bigger than the screen, making it difficult to access some settings.
