### PR TITLE
mpl: update connections after merging clusters

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -1849,14 +1849,21 @@ void ClusteringEngine::mergeChildrenBelowThresholds(
 
 bool ClusteringEngine::attemptMerge(Cluster* receiver, Cluster* incomer)
 {
-  // The incomer might be deleted so we need to cache
-  // its id in order to erase it from the map if so.
+  // Cache incomer data in case it is deleted.
   const int incomer_id = incomer->getId();
+  const ConnectionsMap incomer_connections = incomer->getConnectionsMap();
 
   bool incomer_deleted = false;
   if (receiver->attemptMerge(incomer, incomer_deleted)) {
     if (incomer_deleted) {
       tree_->maps.id_to_cluster.erase(incomer_id);
+
+      // Update connections of clusters connected to the deleted cluster.
+      for (const auto& [cluster_id, connection_weight] : incomer_connections) {
+        Cluster* cluster = tree_->maps.id_to_cluster.at(cluster_id);
+        cluster->removeConnection(incomer_id);
+        cluster->addConnection(receiver->getId(), connection_weight);
+      }
     }
 
     updateInstancesAssociation(receiver);
@@ -2194,7 +2201,7 @@ void ClusteringEngine::classifyMacrosByConnSignature(
     logger_->report("\nPrint Connection Signature\n");
     for (Cluster* cluster : macro_clusters) {
       logger_->report("Macro Signature: {}", cluster->getName());
-      for (auto& [cluster_id, weight] : cluster->getConnection()) {
+      for (auto& [cluster_id, weight] : cluster->getConnectionsMap()) {
         logger_->report(" {} {} ",
                         tree_->maps.id_to_cluster[cluster_id]->getName(),
                         weight);

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1486,7 +1486,7 @@ void HierRTLMP::placeChildren(Cluster* parent, bool ignore_std_cell_area)
   for (auto& cluster : parent->getChildren()) {
     const int src_id = cluster->getId();
     const std::string src_name = cluster->getName();
-    for (auto& [cluster_id, weight] : cluster->getConnection()) {
+    for (auto& [cluster_id, weight] : cluster->getConnectionsMap()) {
       debugPrint(logger_,
                  MPL,
                  "hierarchical_macro_placement",
@@ -2296,7 +2296,7 @@ void HierRTLMP::createFixedTerminals(const Rect& outline,
   std::set<int> clusters_ids;
 
   for (auto& macro_cluster : macro_clusters) {
-    for (auto [cluster_id, weight] : macro_cluster->getConnection()) {
+    for (auto [cluster_id, weight] : macro_cluster->getConnectionsMap()) {
       clusters_ids.insert(cluster_id);
     }
   }
@@ -2323,7 +2323,7 @@ std::vector<BundledNet> HierRTLMP::computeBundledNets(
   for (auto& macro_cluster : macro_clusters) {
     const int src_id = macro_cluster->getId();
 
-    for (auto [cluster_id, weight] : macro_cluster->getConnection()) {
+    for (auto [cluster_id, weight] : macro_cluster->getConnectionsMap()) {
       BundledNet net(
           cluster_to_macro.at(src_id), cluster_to_macro.at(cluster_id), weight);
 

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -37,6 +37,7 @@ class HardMacro;
 class SoftMacro;
 class Cluster;
 
+using ConnectionsMap = std::map<int, float>;
 using IntervalList = std::vector<Interval>;
 using TilingList = std::vector<Tiling>;
 using TilingSet = std::set<Tiling>;
@@ -209,9 +210,8 @@ class Cluster
   // Connection signature support
   void initConnection();
   void addConnection(int cluster_id, float weight);
-  // TODO: this should return a const reference iff callers don't implicitly
-  // modify it. See comment in Cluster.
-  std::map<int, float> getConnection() const;
+  void removeConnection(int cluster_id);
+  const ConnectionsMap& getConnectionsMap() const;
   bool isSameConnSignature(const Cluster& cluster, float net_threshold);
   bool hasMacroConnectionWith(const Cluster& cluster, float net_threshold);
   int getCloseCluster(const std::vector<int>& candidate_clusters,
@@ -255,7 +255,7 @@ class Cluster
   Cluster* parent_{nullptr};
   UniqueClusterVector children_;
 
-  std::map<int, float> connection_map_;  // id -> connection weight
+  ConnectionsMap connections_map_;  // cluster id -> connection weight
   std::vector<std::pair<int, int>> virtual_connections_;  // id -> id
 
   utl::Logger* logger_;


### PR DESCRIPTION
Found this bug when working on #8343.

The only reason nothing blows up nowadays is because, when we use the clusters' connection maps, we don't retrieve the `Cluster*`. Trying to do that with `std::map::at()` results in an invalid map access without the changes here.

Also some subtle renaming and code improvements.