### PR TITLE
spdlog is vendored: always use `"`-includes not bracket.

### DIFF
--- a/src/dbSta/src/dbSdcNetwork.cc
+++ b/src/dbSta/src/dbSdcNetwork.cc
@@ -3,14 +3,13 @@
 
 #include "dbSdcNetwork.hh"
 
-#include <spdlog/fmt/fmt.h>
-
 #include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
 
+#include "spdlog/fmt/fmt.h"
 #include "sta/ParseBus.hh"
 #include "sta/PatternMatch.hh"
 

--- a/src/dft/src/utils/BUILD
+++ b/src/dft/src/utils/BUILD
@@ -29,5 +29,6 @@ cc_library(
         "//src/odb",
         "//src/sta:opensta_lib",
         "//src/utl",
+        "@spdlog",
     ],
 )

--- a/src/dft/src/utils/Formatting.hh
+++ b/src/dft/src/utils/Formatting.hh
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023-2025, The OpenROAD Authors
 
-#include <spdlog/fmt/fmt.h>
-
 #include <optional>
 #include <string>
+
+#include "spdlog/fmt/fmt.h"
 
 namespace dft::utils {
 

--- a/src/odb/src/db/dbMTerm.cpp
+++ b/src/odb/src/db/dbMTerm.cpp
@@ -3,7 +3,6 @@
 
 #include "dbMTerm.h"
 
-#include <spdlog/fmt/ostr.h>
 #include <string.h>
 
 #include <cstdlib>
@@ -26,6 +25,7 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "odb/lefout.h"
+#include "spdlog/fmt/ostr.h"
 
 namespace odb {
 

--- a/src/odb/src/db/dbProperty.cpp
+++ b/src/odb/src/db/dbProperty.cpp
@@ -21,9 +21,9 @@
 #include "dbTech.h"
 #include "odb/db.h"
 // User Code Begin Includes
-#include <spdlog/fmt/ostr.h>
-
 #include <sstream>
+
+#include "spdlog/fmt/ostr.h"
 // User Code End Includes
 namespace odb {
 template class dbTable<_dbProperty>;

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -35,14 +35,13 @@
 #include "odb/db.h"
 #include "odb/dbSet.h"
 // User Code Begin Includes
-#include <spdlog/fmt/ostr.h>
-
 #include "dbHashTable.hpp"
 #include "dbTech.h"
 #include "dbTechLayerAntennaRule.h"
 #include "dbTechLayerSpacingRule.h"
 #include "dbTechMinCutOrAreaRule.h"
 #include "odb/lefout.h"
+#include "spdlog/fmt/ostr.h"
 #include "utl/Logger.h"
 // User Code End Includes
 namespace odb {

--- a/src/odb/src/db/dbTechLayerAntennaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAntennaRule.cpp
@@ -3,8 +3,6 @@
 
 #include "dbTechLayerAntennaRule.h"
 
-#include <spdlog/fmt/ostr.h>
-
 #include <cassert>
 #include <utility>
 #include <vector>
@@ -19,6 +17,7 @@
 #include "dbVector.h"
 #include "odb/db.h"
 #include "odb/lefout.h"
+#include "spdlog/fmt/ostr.h"
 
 namespace odb {
 

--- a/src/odb/src/db/dbTechLayerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingRule.cpp
@@ -3,8 +3,6 @@
 
 #include "dbTechLayerSpacingRule.h"
 
-#include <spdlog/fmt/ostr.h>
-
 #include <cassert>
 
 #include "dbCore.h"
@@ -15,6 +13,7 @@
 #include "dbTechLayer.h"
 #include "odb/db.h"
 #include "odb/lefout.h"
+#include "spdlog/fmt/ostr.h"
 
 namespace odb {
 

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -3,8 +3,6 @@
 
 #include "odb/lefout.h"
 
-#include <spdlog/fmt/ostr.h>
-
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
@@ -21,6 +19,7 @@
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "spdlog/fmt/ostr.h"
 #include "utl/scope.h"
 
 using namespace boost::polygon::operators;

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -18,8 +18,7 @@
 #include "odb/geom.h"
 #include "rsz/Resizer.hh"
 // Use spdlog fmt::format until c++20 that supports std::format.
-#include <spdlog/fmt/fmt.h>
-
+#include "spdlog/fmt/fmt.h"
 #include "sta/Fuzzy.hh"
 #include "sta/Liberty.hh"
 #include "sta/Units.hh"


### PR DESCRIPTION
Partially that was already done, but not throughout.