### PR TITLE
Add missing dependency to swig-py rules.

### DIFF
--- a/src/pdn/BUILD
+++ b/src/pdn/BUILD
@@ -103,5 +103,8 @@ python_wrap_cc(
     root_swig_src = "src/PdnGen-py.i",
     swig_includes = [
         "include",
-    ]
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
 )

--- a/src/ppl/BUILD
+++ b/src/ppl/BUILD
@@ -110,5 +110,8 @@ python_wrap_cc(
     swig_includes = [
         "include",
         "src",
-    ]
+    ],
+    deps = [
+        "//src/odb:swig-py",
+    ],
 )


### PR DESCRIPTION
Fixes #8365