### PR TITLE
Posix-threads are not specific to Linux.

### DIFF
--- a/src/dst/BUILD
+++ b/src/dst/BUILD
@@ -43,7 +43,7 @@ cc_library(
         "@boost.system",
     ] + select({
         "@platforms//os:macos": ["@boost.thread//:thread_mac"],
-        "@platforms//os:linux": ["@boost.thread//:thread_posix"]
+         "//conditions:default": ["@boost.thread//:thread_posix"],
     }),
 )
 


### PR DESCRIPTION
Unless other implementations needed, just use it as default.