### PR TITLE
Don't export the same header by multiple libraries.

### DIFF
--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025, The OpenROAD Authors
 
+load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
-load("//bazel:python_wrap_cc.bzl", "python_wrap_cc")
 
 package(
     default_visibility = ["//:__subpackages__"],
@@ -16,11 +16,9 @@ cc_library(
         "src/Clock.h",
         "src/Clustering.h",
         "src/CtsObserver.h",
-        "src/CtsOptions.h",
         "src/HTreeBuilder.h",
         "src/LevelBalancer.h",
         "src/SinkClustering.h",
-        "src/TechChar.h",
         "src/TreeBuilder.h",
         "src/Util.h",
     ],
@@ -51,7 +49,10 @@ cc_library(
         "src/CtsOptions.h",
         "src/TechChar.h",
     ],
-    includes = ["include", "src"],
+    includes = [
+        "include",
+        "src",
+    ],
     deps = [
         ":private_hdrs",
         "//src/dbSta",

--- a/src/odb/BUILD
+++ b/src/odb/BUILD
@@ -43,10 +43,13 @@ cc_library(
         "src/lefout/*.cpp",
         "src/swig/common/swig_common.cpp",
     ]),
-    hdrs = glob([
-        "include/odb/*.h",
-        "include/odb/*.hpp",
-    ]) + ["src/swig/common/swig_common.h"],
+    hdrs = glob(
+        include = [
+            "include/odb/*.h",
+            "include/odb/*.hpp",
+        ],
+        exclude = ["include/odb/MakeOdb.h"],
+    ) + ["src/swig/common/swig_common.h"],
     features = [
         "-use_header_modules",
     ],
@@ -116,10 +119,7 @@ cc_library(
         ":swig",
         ":tcl",
     ],
-    hdrs = glob([
-        "include/odb/*.h",
-        "include/odb/*.hpp",
-    ]),
+    hdrs = ["include/odb/MakeOdb.h"],
     copts = [
         "-Wno-missing-braces",  # from TCL swigging
         "-Isrc/odb/src/swig/common",


### PR DESCRIPTION
There is only really one library that is providing an implementation and the associated headers.