### PR TITLE
odb: Replace CDL <> to [] to match master term name when exporting CDL file.

### DIFF
--- a/src/odb/src/cdl/cdl.cpp
+++ b/src/odb/src/cdl/cdl.cpp
@@ -129,6 +129,9 @@ readMasters(utl::Logger* logger, dbBlock* block, const char* fileName)
           }
           mterms = &mtermMap[master];
         } else {
+          // Replace CDL <> to []
+          std::replace(token.begin(), token.end(), '<', '[');
+          std::replace(token.begin(), token.end(), '>', ']');
           dbMTerm* mterm = master->findMTerm(token.c_str());
           if (!mterm) {
             logger->warn(utl::ODB,


### PR DESCRIPTION
Issue seen with:
[WARNING ODB-0286] Terminal OP_REG<2> of CDL master NVM_IP not found in LEF.
