### PR TITLE
mpl: create and use method for connecting clusters

### DIFF
--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -241,6 +241,7 @@ class ClusteringEngine
   void clearConnections();
   void buildNetListConnections();
   void buildDataFlowConnections();
+  void connect(Cluster* a, Cluster* b, float connection_weight) const;
 
   // Methods for data flow
   void createDataFlow();

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -568,13 +568,9 @@ void Cluster::initConnection()
   connections_map_.clear();
 }
 
-void Cluster::addConnection(int cluster_id, float weight)
+void Cluster::addConnection(Cluster* cluster, const float connection_weight)
 {
-  if (connections_map_.find(cluster_id) == connections_map_.end()) {
-    connections_map_[cluster_id] = weight;
-  } else {
-    connections_map_[cluster_id] += weight;
-  }
+  connections_map_[cluster->getId()] += connection_weight;
 }
 
 void Cluster::removeConnection(int cluster_id)

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -209,7 +209,7 @@ class Cluster
 
   // Connection signature support
   void initConnection();
-  void addConnection(int cluster_id, float weight);
+  void addConnection(Cluster* cluster, float connection_weight);
   void removeConnection(int cluster_id);
   const ConnectionsMap& getConnectionsMap() const;
   bool isSameConnSignature(const Cluster& cluster, float net_threshold);


### PR DESCRIPTION
In order to merge #8375, we need to avoid adding redundant connections between clusters e.g., for a given cluster A having a connection with A itself. That might happen today due to how we create connections between clusters.

These refactoring changes are to make it easier to avoid those connections. I'll have a subsequent PR for that as I want to see if won't affect results.