### PR TITLE
Remove using declaration that spilled a symbol into different namespace.

### DIFF
--- a/src/drt/src/db/drObj/drRef.h
+++ b/src/drt/src/db/drObj/drRef.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "db/drObj/drFig.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 
 namespace drt {
@@ -14,11 +15,11 @@ class drRef : public drPinFig
   // getters
   virtual dbOrientType getOrient() const = 0;
   virtual Point getOrigin() const = 0;
-  virtual dbTransform getTransform() const = 0;
+  virtual odb::dbTransform getTransform() const = 0;
   // setters
   virtual void setOrient(const dbOrientType& tmpOrient) = 0;
   virtual void setOrigin(const Point& tmpPoint) = 0;
-  virtual void setTransform(const dbTransform& xform) = 0;
+  virtual void setTransform(const odb::dbTransform& xform) = 0;
 
  protected:
   template <class Archive>

--- a/src/drt/src/db/drObj/drShape.h
+++ b/src/drt/src/db/drObj/drShape.h
@@ -9,6 +9,7 @@
 #include "db/infra/frSegStyle.h"
 #include "dr/FlexMazeTypes.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -292,7 +293,7 @@ class drPatchWire : public drShape
    */
   Rect getBBox() const override
   {
-    dbTransform xform(origin_);
+    odb::dbTransform xform(origin_);
     Rect box = offsetBox_;
     xform.apply(box);
     return box;

--- a/src/drt/src/db/drObj/drVia.h
+++ b/src/drt/src/db/drObj/drVia.h
@@ -74,8 +74,11 @@ class drVia : public drRef
   void setOrient(const dbOrientType& tmpOrient) override { ; }
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& tmpPoint) override { origin_ = tmpPoint; }
-  dbTransform getTransform() const override { return dbTransform(origin_); }
-  void setTransform(const dbTransform& xformIn) override {}
+  odb::dbTransform getTransform() const override
+  {
+    return odb::dbTransform(origin_);
+  }
+  void setTransform(const odb::dbTransform& xformIn) override {}
 
   /* from frPinFig
    * hasPin

--- a/src/drt/src/db/grObj/grRef.h
+++ b/src/drt/src/db/grObj/grRef.h
@@ -5,6 +5,7 @@
 
 #include "db/grObj/grFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 
 namespace drt {
@@ -15,11 +16,11 @@ class grRef : public grPinFig
   // getters
   virtual dbOrientType getOrient() const = 0;
   virtual Point getOrigin() const = 0;
-  virtual dbTransform getTransform() const = 0;
+  virtual odb::dbTransform getTransform() const = 0;
   // setters
   virtual void setOrient(const dbOrientType& tmpOrient) = 0;
   virtual void setOrigin(const Point& tmpPoint) = 0;
-  virtual void setTransform(const dbTransform& xform) = 0;
+  virtual void setTransform(const odb::dbTransform& xform) = 0;
   frBlockObjectEnum typeId() const override { return grcRef; }
 };
 

--- a/src/drt/src/db/grObj/grVia.h
+++ b/src/drt/src/db/grObj/grVia.h
@@ -8,6 +8,7 @@
 #include "db/grObj/grRef.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -49,8 +50,11 @@ class grVia : public grRef
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& in) override { origin_ = in; }
 
-  dbTransform getTransform() const override { return dbTransform(origin_); }
-  void setTransform(const dbTransform& in) override { ; }
+  odb::dbTransform getTransform() const override
+  {
+    return odb::dbTransform(origin_);
+  }
+  void setTransform(const odb::dbTransform& in) override { ; }
 
   /* from gfrPinFig
    * hasPin

--- a/src/drt/src/db/infra/frBox.h
+++ b/src/drt/src/db/infra/frBox.h
@@ -11,7 +11,6 @@
 namespace drt {
 
 using odb::dbOrientType;
-using odb::dbTransform;
 using odb::Rect;
 
 class frBox3D : public Rect

--- a/src/drt/src/db/obj/frBoundary.h
+++ b/src/drt/src/db/obj/frBoundary.h
@@ -8,6 +8,7 @@
 
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frBoundary : public frFig
@@ -41,7 +42,7 @@ class frBoundary : public frFig
     }
     return {llx, lly, urx, ury};
   }
-  void move(const dbTransform& xform) override
+  void move(const odb::dbTransform& xform) override
   {
     for (auto& point : points_) {
       xform.apply(point);

--- a/src/drt/src/db/obj/frFig.h
+++ b/src/drt/src/db/obj/frFig.h
@@ -7,6 +7,7 @@
 
 #include "db/infra/frBox.h"
 #include "db/obj/frBlockObject.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frFig : public frBlockObject
@@ -16,7 +17,7 @@ class frFig : public frBlockObject
   virtual Rect getBBox() const = 0;
   // setters
   // others
-  virtual void move(const dbTransform& xform) = 0;
+  virtual void move(const odb::dbTransform& xform) = 0;
   virtual bool intersects(const Rect& box) const = 0;
 
  protected:

--- a/src/drt/src/db/obj/frGuide.h
+++ b/src/drt/src/db/obj/frGuide.h
@@ -9,6 +9,7 @@
 
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frNet;
@@ -68,7 +69,7 @@ class frGuide : public frConnFig
    */
   // needs to be updated
   Rect getBBox() const override { return Rect(begin_, end_); }
-  void move(const dbTransform& xform) override { ; }
+  void move(const odb::dbTransform& xform) override { ; }
   bool intersects(const Rect& box) const override { return false; }
   void setIndexInOwner(const int& val) { index_in_owner_ = val; }
 

--- a/src/drt/src/db/obj/frInst.cpp
+++ b/src/drt/src/db/obj/frInst.cpp
@@ -5,12 +5,13 @@
 
 #include "db/obj/frBlock.h"
 #include "db/obj/frMaster.h"
+#include "odb/dbTransform.h"
 namespace drt {
 
 Rect frInst::getBBox() const
 {
   Rect box = getMaster()->getBBox();
-  dbTransform xform = getDBTransform();
+  odb::dbTransform xform = getDBTransform();
   xform.apply(box);
   return box;
 }
@@ -18,14 +19,14 @@ Rect frInst::getBBox() const
 Rect frInst::getBoundaryBBox() const
 {
   Rect box = getMaster()->getDieBox();
-  dbTransform xform = getDBTransform();
+  odb::dbTransform xform = getDBTransform();
   xform.apply(box);
   return box;
 }
 
-dbTransform frInst::getNoRotationTransform() const
+odb::dbTransform frInst::getNoRotationTransform() const
 {
-  dbTransform xfm = getTransform();
+  odb::dbTransform xfm = getTransform();
   xfm.setOrient(dbOrientType(dbOrientType::R0));
   return xfm;
 }

--- a/src/drt/src/db/obj/frInst.h
+++ b/src/drt/src/db/obj/frInst.h
@@ -76,10 +76,13 @@ class frInst : public frRef
   }
   Point getOrigin() const override { return xform_.getOffset(); }
   void setOrigin(const Point& tmpPoint) override { xform_.setOffset(tmpPoint); }
-  dbTransform getTransform() const override { return xform_; }
-  void setTransform(const dbTransform& xformIn) override { xform_ = xformIn; }
+  odb::dbTransform getTransform() const override { return xform_; }
+  void setTransform(const odb::dbTransform& xformIn) override
+  {
+    xform_ = xformIn;
+  }
   odb::dbInst* getDBInst() const { return db_inst_; }
-  dbTransform getDBTransform() const { return db_inst_->getTransform(); }
+  odb::dbTransform getDBTransform() const { return db_inst_->getTransform(); }
 
   /* from frPinFig
    * hasPin
@@ -114,10 +117,10 @@ class frInst : public frRef
 
   Rect getBBox() const override;
 
-  void move(const dbTransform& xform) override { ; }
+  void move(const odb::dbTransform& xform) override { ; }
   bool intersects(const Rect& box) const override { return false; }
   // others
-  dbTransform getNoRotationTransform() const;
+  odb::dbTransform getNoRotationTransform() const;
   Rect getBoundaryBBox() const;
 
   frInstTerm* getInstTerm(int index);
@@ -128,7 +131,7 @@ class frInst : public frRef
   std::vector<std::unique_ptr<frInstTerm>> instTerms_;
   std::vector<std::unique_ptr<frInstBlockage>> instBlockages_;
   odb::dbInst* db_inst_;
-  dbTransform xform_;
+  odb::dbTransform xform_;
   int pinAccessIdx_{-1};
   bool toBeDeleted_{false};
 };

--- a/src/drt/src/db/obj/frInstTerm.cpp
+++ b/src/drt/src/db/obj/frInstTerm.cpp
@@ -7,6 +7,7 @@
 
 #include "db/obj/frInst.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -18,7 +19,7 @@ frString frInstTerm::getName() const
 frAccessPoint* frInstTerm::getAccessPoint(frCoord x, frCoord y, frLayerNum lNum)
 {
   auto inst = getInst();
-  dbTransform shiftXform = inst->getTransform();
+  odb::dbTransform shiftXform = inst->getTransform();
   Point offset(shiftXform.getOffset());
   x = x - offset.getX();
   y = y - offset.getY();
@@ -34,7 +35,7 @@ void frInstTerm::getShapes(std::vector<frRect>& outShapes) const
 {
   term_->getShapes(outShapes);
   for (auto& shape : outShapes) {
-    dbTransform trans = getInst()->getDBTransform();
+    odb::dbTransform trans = getInst()->getDBTransform();
     shape.move(trans);
   }
 }
@@ -42,7 +43,7 @@ void frInstTerm::getShapes(std::vector<frRect>& outShapes) const
 Rect frInstTerm::getBBox() const
 {
   Rect bbox(term_->getBBox());
-  dbTransform trans = getInst()->getDBTransform();
+  odb::dbTransform trans = getInst()->getDBTransform();
   trans.apply(bbox);
   return bbox;
 }

--- a/src/drt/src/db/obj/frMarker.h
+++ b/src/drt/src/db/obj/frMarker.h
@@ -12,6 +12,7 @@
 #include "db/obj/frBlockObject.h"
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frConstraint;
@@ -85,7 +86,7 @@ class frMarker : public frFig
 
   bool isH() const { return vioIsH_; }
 
-  void move(const dbTransform& xform) override {}
+  void move(const odb::dbTransform& xform) override {}
 
   bool intersects(const Rect& box) const override { return false; }
 

--- a/src/drt/src/db/obj/frRPin.cpp
+++ b/src/drt/src/db/obj/frRPin.cpp
@@ -8,6 +8,7 @@
 #include "db/obj/frInst.h"
 #include "db/obj/frInstTerm.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -18,7 +19,7 @@ Rect frRPin::getBBox()
   switch (term_->typeId()) {
     case frcInstTerm: {
       auto inst = static_cast<frInstTerm*>(term_)->getInst();
-      dbTransform shiftXform = inst->getNoRotationTransform();
+      odb::dbTransform shiftXform = inst->getNoRotationTransform();
 
       pt = accessPoint_->getPoint();
       shiftXform.apply(pt);

--- a/src/drt/src/db/obj/frRef.h
+++ b/src/drt/src/db/obj/frRef.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "db/obj/frFig.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 
 namespace drt {
@@ -13,11 +14,11 @@ class frRef : public frPinFig
   // getters
   virtual dbOrientType getOrient() const = 0;
   virtual Point getOrigin() const = 0;
-  virtual dbTransform getTransform() const = 0;
+  virtual odb::dbTransform getTransform() const = 0;
   // setters
   virtual void setOrient(const dbOrientType& tmpOrient) = 0;
   virtual void setOrigin(const Point& tmpPoint) = 0;
-  virtual void setTransform(const dbTransform& xform) = 0;
+  virtual void setTransform(const odb::dbTransform& xform) = 0;
 
  protected:
   // constructors

--- a/src/drt/src/db/obj/frShape.h
+++ b/src/drt/src/db/obj/frShape.h
@@ -10,6 +10,7 @@
 #include "db/infra/frSegStyle.h"
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frNet;
@@ -159,7 +160,7 @@ class frRect : public frShape
    * intersects in .cpp
    */
   Rect getBBox() const override { return box_; }
-  void move(const dbTransform& xform) override { xform.apply(box_); }
+  void move(const odb::dbTransform& xform) override { xform.apply(box_); }
   bool intersects(const Rect& box) const override
   {
     return getBBox().intersects(box);
@@ -269,14 +270,14 @@ class frPatchWire : public frShape
    */
   Rect getBBox() const override
   {
-    dbTransform xform(origin_);
+    odb::dbTransform xform(origin_);
     Rect box = offsetBox_;
     xform.apply(box);
     return box;
   }
   Rect getOffsetBox() const { return offsetBox_; }
   Point getOrigin() const { return origin_; }
-  void move(const dbTransform& xform) override {}
+  void move(const odb::dbTransform& xform) override {}
   bool intersects(const Rect& box) const override
   {
     return getBBox().intersects(box);
@@ -397,7 +398,7 @@ class frPolygon : public frShape
     }
     return Rect(llx, lly, urx, ury);
   }
-  void move(const dbTransform& xform) override
+  void move(const odb::dbTransform& xform) override
   {
     for (auto& point : points_) {
       xform.apply(point);
@@ -583,7 +584,7 @@ class frPathSeg : public frShape
                 end_.x() + width / 2,
                 end_.y() + endExt);
   }
-  void move(const dbTransform& xform) override
+  void move(const odb::dbTransform& xform) override
   {
     xform.apply(begin_);
     xform.apply(end_);

--- a/src/drt/src/db/obj/frVia.h
+++ b/src/drt/src/db/obj/frVia.h
@@ -86,8 +86,11 @@ class frVia : public frRef
   void setOrient(const dbOrientType& tmpOrient) override { ; }
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& tmpPoint) override { origin_ = tmpPoint; }
-  dbTransform getTransform() const override { return dbTransform(origin_); }
-  void setTransform(const dbTransform& xformIn) override {}
+  odb::dbTransform getTransform() const override
+  {
+    return odb::dbTransform(origin_);
+  }
+  void setTransform(const odb::dbTransform& xformIn) override {}
 
   /* from frPinFig
    * hasPin
@@ -193,7 +196,7 @@ class frVia : public frRef
     getTransform().apply(box);
     return box;
   }
-  void move(const dbTransform& xform) override { ; }
+  void move(const odb::dbTransform& xform) override { ; }
   bool intersects(const Rect& box) const override { return false; }
 
   void setIter(frListIter<std::unique_ptr<frVia>>& in) { iter_ = in; }

--- a/src/drt/src/db/taObj/taFig.h
+++ b/src/drt/src/db/taObj/taFig.h
@@ -7,13 +7,14 @@
 
 #include "db/infra/frBox.h"
 #include "db/taObj/taBlockObject.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class taFig : public taBlockObject
 {
  public:
   virtual Rect getBBox() const = 0;
-  virtual void move(const dbTransform& xform) = 0;
+  virtual void move(const odb::dbTransform& xform) = 0;
   virtual bool overlaps(const Rect& box) const = 0;
 };
 

--- a/src/drt/src/db/taObj/taShape.h
+++ b/src/drt/src/db/taObj/taShape.h
@@ -8,6 +8,7 @@
 #include "db/infra/frSegStyle.h"
 #include "db/taObj/taFig.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 class frNet;
@@ -140,7 +141,7 @@ class taPathSeg : public taShape
                 end_.x() + width / 2,
                 end_.y() + endExt);
   }
-  void move(const dbTransform& xform) override
+  void move(const odb::dbTransform& xform) override
   {
     xform.apply(begin_);
     xform.apply(end_);

--- a/src/drt/src/db/taObj/taVia.h
+++ b/src/drt/src/db/taObj/taVia.h
@@ -10,6 +10,7 @@
 #include "db/taObj/taFig.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 
 namespace drt {
@@ -20,11 +21,11 @@ class taRef : public taPinFig
   // getters
   virtual dbOrientType getOrient() const = 0;
   virtual Point getOrigin() const = 0;
-  virtual dbTransform getTransform() const = 0;
+  virtual odb::dbTransform getTransform() const = 0;
   // setters
   virtual void setOrient(const dbOrientType& tmpOrient) = 0;
   virtual void setOrigin(const Point& tmpPoint) = 0;
-  virtual void setTransform(const dbTransform& xform) = 0;
+  virtual void setTransform(const odb::dbTransform& xform) = 0;
 };
 
 class taVia : public taRef
@@ -83,8 +84,11 @@ class taVia : public taRef
   void setOrient(const dbOrientType& tmpOrient) override { ; }
   Point getOrigin() const override { return origin_; }
   void setOrigin(const Point& tmpPoint) override { origin_ = tmpPoint; }
-  dbTransform getTransform() const override { return dbTransform(origin_); }
-  void setTransform(const dbTransform& xformIn) override {}
+  odb::dbTransform getTransform() const override
+  {
+    return odb::dbTransform(origin_);
+  }
+  void setTransform(const odb::dbTransform& xformIn) override {}
 
   /* from frPinFig
    * hasPin
@@ -185,7 +189,7 @@ class taVia : public taRef
     getTransform().apply(box);
     return box;
   }
-  void move(const dbTransform& xform) override { ; }
+  void move(const odb::dbTransform& xform) override { ; }
   bool overlaps(const Rect& box) const override { return false; }
 
  protected:

--- a/src/drt/src/dr/FlexDR.h
+++ b/src/drt/src/dr/FlexDR.h
@@ -37,6 +37,7 @@
 #include "frDesign.h"
 #include "frRegionQuery.h"
 #include "gc/FlexGC.h"
+#include "odb/dbTransform.h"
 
 using Rectangle = boost::polygon::rectangle_data<int>;
 namespace dst {
@@ -680,7 +681,7 @@ class FlexDRWorker
                            frInst* inst,
                            drNet* dNet,
                            const std::string& name,
-                           const dbTransform& shiftXform);
+                           const odb::dbTransform& shiftXform);
   bool isRestrictedRouting(frLayerNum lNum);
   void initNet_addNet(std::unique_ptr<drNet> in);
   void getTrackLocs(bool isHorzTracks,
@@ -721,7 +722,7 @@ class FlexDRWorker
                           bool isAddPathCost,
                           bool isSkipVia = false);
   void modBlockedEdgesForMacroPin(frInstTerm* instTerm,
-                                  const dbTransform& xForm,
+                                  const odb::dbTransform& xForm,
                                   bool isAddCost);
   void initMazeCost_ap();  // disable maze edge
   void initMazeCost_marker_route_queue(const frMarker& marker);

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -30,6 +30,7 @@
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "frRTree.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -1170,8 +1171,8 @@ void FlexDRWorker::initNet_term(const frDesign* design,
   for (auto term : terms) {
     // ap
     // TODO is instXform used properly here?
-    dbTransform instXform;  // (0,0), R0
-    dbTransform shiftXform;
+    odb::dbTransform instXform;  // (0,0), R0
+    odb::dbTransform shiftXform;
     switch (term->typeId()) {
       case frcInstTerm: {
         auto instTerm = static_cast<frInstTerm*>(term);
@@ -1205,7 +1206,7 @@ void FlexDRWorker::initNet_term_helper(const frDesign* design,
                                        frInst* inst,
                                        drNet* dNet,
                                        const std::string& name,
-                                       const dbTransform& shiftXform)
+                                       const odb::dbTransform& shiftXform)
 {
   dNet->addFrNetTerm(term);
   auto dPin = std::make_unique<drPin>();
@@ -2789,7 +2790,7 @@ void FlexDRWorker::initMazeCost_fixedObj(const frDesign* design)
 }
 
 void FlexDRWorker::modBlockedEdgesForMacroPin(frInstTerm* instTerm,
-                                              const dbTransform& xform,
+                                              const odb::dbTransform& xform,
                                               const bool isAddCost)
 {
   const frDirEnum dirs[4]{
@@ -2881,8 +2882,8 @@ void FlexDRWorker::initMazeCost_terms(const std::set<frBlockObject*>& objs,
     } else if (obj->typeId() == frcInstTerm) {
       auto instTerm = static_cast<frInstTerm*>(obj);
       auto inst = instTerm->getInst();
-      const dbTransform xform = inst->getDBTransform();
-      const dbTransform shiftXform = inst->getNoRotationTransform();
+      const odb::dbTransform xform = inst->getDBTransform();
+      const odb::dbTransform shiftXform = inst->getNoRotationTransform();
       const dbMasterType masterType = inst->getMaster()->getMasterType();
       bool accessHorz = false;
       bool accessVert = false;
@@ -3123,7 +3124,7 @@ void FlexDRWorker::initMazeCost_minCut_helper(drNet* net, bool isAddPathCost)
   for (auto& connFig : net->getExtConnFigs()) {
     if (connFig->typeId() == drcVia) {
       auto via = static_cast<drVia*>(connFig.get());
-      const dbTransform xform = via->getTransform();
+      const odb::dbTransform xform = via->getTransform();
 
       const auto l1Num = via->getViaDef()->getLayer1Num();
       const auto l1Fig = (via->getViaDef()->getLayer1Figs()[0].get());

--- a/src/drt/src/dr/FlexDR_maze.cpp
+++ b/src/drt/src/dr/FlexDR_maze.cpp
@@ -36,6 +36,7 @@
 #include "frProfileTask.h"
 #include "frRegionQuery.h"
 #include "gc/FlexGC.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -578,7 +579,7 @@ void FlexDRWorker::modMinimumcutCostVia(const Rect& box,
       for (int i = mIdx1.x(); i <= mIdx2.x(); i++) {
         for (int j = mIdx1.y(); j <= mIdx2.y(); j++) {
           gridGraph_.getPoint(pt, i, j);
-          dbTransform xform(pt);
+          odb::dbTransform xform(pt);
           tmpBx = viaBox;
           frMIdx idx = gridGraph_.getIdx(i, j, zIdx);
           if (gridGraph_.isSVia(idx)) {
@@ -784,7 +785,7 @@ void FlexDRWorker::modMinSpacingCostViaHelper(const Rect& box,
   for (int i = mIdx1.x(); i <= mIdx2.x(); i++) {
     for (int j = mIdx1.y(); j <= mIdx2.y(); j++) {
       gridGraph_.getPoint(pt, i, j);
-      dbTransform xform(pt);
+      odb::dbTransform xform(pt);
       tmpBx = viaBox;
       frMIdx idx = gridGraph_.getIdx(i, j, zIdx);
       if (gridGraph_.isSVia(idx)) {
@@ -1218,7 +1219,7 @@ void FlexDRWorker::modAdjCutSpacingCost_fixedObj(const frDesign* design,
       for (auto& uFig : via.getViaDef()->getCutFigs()) {
         auto obj = static_cast<frRect*>(uFig.get());
         gridGraph_.getPoint(pt, i, j);
-        dbTransform xform(pt);
+        odb::dbTransform xform(pt);
         Rect tmpBx = obj->getBBox();
         xform.apply(tmpBx);
         tmpBxCenter = {(tmpBx.xMin() + tmpBx.xMax()) / 2,
@@ -1405,7 +1406,7 @@ void FlexDRWorker::modInterLayerCutSpacingCost(const Rect& box,
       for (auto& uFig : via.getViaDef()->getCutFigs()) {
         auto obj = static_cast<frRect*>(uFig.get());
         gridGraph_.getPoint(pt, i, j);
-        dbTransform xform(pt);
+        odb::dbTransform xform(pt);
         Rect tmpBx = obj->getBBox();
         xform.apply(tmpBx);
         tmpBxCenter = {(tmpBx.xMin() + tmpBx.xMax()) / 2,
@@ -1543,7 +1544,7 @@ void FlexDRWorker::modPathCost(drConnFig* connFig,
     }
 
     Point pt = obj->getOrigin();
-    dbTransform xform(pt);
+    odb::dbTransform xform(pt);
     for (auto& uFig : obj->getViaDef()->getCutFigs()) {
       auto rect = static_cast<frRect*>(uFig.get());
       box = rect->getBBox();
@@ -2757,7 +2758,7 @@ bool FlexDRWorker::addApPathSegs(const FlexMazeIdx& apIdx, drNet* net)
       connecting = &end;
     }
     if (inst) {
-      dbTransform trans = inst->getNoRotationTransform();
+      odb::dbTransform trans = inst->getNoRotationTransform();
       trans.apply(begin);
       trans.apply(end);
       if (end < begin) {  // if rotation swapped order, correct it
@@ -3165,7 +3166,7 @@ void FlexDRWorker::routeNet_AddCutSpcCost(std::vector<FlexMazeIdx>& path)
                                    ->getDefaultViaDef();
       int x = gridGraph_.xCoord(path[i].x());
       int y = gridGraph_.yCoord(path[i].y());
-      dbTransform xform(Point(x, y));
+      odb::dbTransform xform(Point(x, y));
       for (auto& uFig : viaDef->getCutFigs()) {
         auto rect = static_cast<frRect*>(uFig.get());
         Rect box = rect->getBBox();

--- a/src/drt/src/dr/FlexDR_rq.cpp
+++ b/src/drt/src/dr/FlexDR_rq.cpp
@@ -12,6 +12,7 @@
 #include "dr/FlexDR.h"
 #include "frBaseTypes.h"
 #include "frRTree.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -56,7 +57,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
     impl_->shapes.at(obj->getLayerNum()).insert(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -106,7 +107,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -154,7 +155,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
     impl_->shapes.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -17,6 +17,7 @@
 #include "frDesign.h"
 #include "frRTree.h"
 #include "global.h"
+#include "odb/dbTransform.h"
 #include "utl/Logger.h"
 #include "utl/algorithms.h"
 
@@ -170,7 +171,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
   switch (obj->typeId()) {
     case frcInstTerm: {
       auto instTerm = static_cast<frInstTerm*>(obj);
-      dbTransform xform = instTerm->getInst()->getDBTransform();
+      odb::dbTransform xform = instTerm->getInst()->getDBTransform();
       for (auto& pin : instTerm->getTerm()->getPins()) {
         for (auto& uFig : pin->getFigs()) {
           auto shape = uFig.get();
@@ -184,7 +185,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
     }
     case frcInstBlockage: {
       auto instBlk = static_cast<frInstBlockage*>(obj);
-      dbTransform xform = instBlk->getInst()->getDBTransform();
+      odb::dbTransform xform = instBlk->getInst()->getDBTransform();
       auto blk = instBlk->getBlockage();
       auto pin = blk->getPin();
       for (auto& uFig : pin->getFigs()) {
@@ -243,7 +244,7 @@ void frRegionQuery::removeBlockObj(frBlockObject* obj)
   switch (obj->typeId()) {
     case frcInstTerm: {
       auto instTerm = static_cast<frInstTerm*>(obj);
-      dbTransform xform = instTerm->getInst()->getDBTransform();
+      odb::dbTransform xform = instTerm->getInst()->getDBTransform();
       for (auto& pin : instTerm->getTerm()->getPins()) {
         for (auto& uFig : pin->getFigs()) {
           auto shape = uFig.get();
@@ -257,7 +258,7 @@ void frRegionQuery::removeBlockObj(frBlockObject* obj)
     }
     case frcInstBlockage: {
       auto instBlk = static_cast<frInstBlockage*>(obj);
-      dbTransform xform = instBlk->getInst()->getDBTransform();
+      odb::dbTransform xform = instBlk->getInst()->getDBTransform();
       auto blk = instBlk->getBlockage();
       auto pin = blk->getPin();
       for (auto& uFig : pin->getFigs()) {
@@ -371,7 +372,7 @@ void frRegionQuery::removeMarker(frMarker* in)
 void frRegionQuery::Impl::add(frVia* via,
                               ObjectsByLayer<frBlockObject>& allShapes)
 {
-  dbTransform xform = via->getTransform();
+  odb::dbTransform xform = via->getTransform();
   for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
     auto shape = uShape.get();
     if (shape->typeId() == frcRect) {
@@ -439,7 +440,7 @@ void frRegionQuery::addGRObj(grVia* via)
 void frRegionQuery::Impl::add(frInstTerm* instTerm,
                               ObjectsByLayer<frBlockObject>& allShapes)
 {
-  dbTransform xform = instTerm->getInst()->getDBTransform();
+  odb::dbTransform xform = instTerm->getInst()->getDBTransform();
 
   for (auto& pin : instTerm->getTerm()->getPins()) {
     for (auto& uFig : pin->getFigs()) {
@@ -476,7 +477,7 @@ void frRegionQuery::Impl::add(frBTerm* term,
 void frRegionQuery::Impl::add(frInstBlockage* instBlk,
                               ObjectsByLayer<frBlockObject>& allShapes)
 {
-  dbTransform xform = instBlk->getInst()->getDBTransform();
+  odb::dbTransform xform = instBlk->getInst()->getDBTransform();
   auto blk = instBlk->getBlockage();
   auto pin = blk->getPin();
   for (auto& uFig : pin->getFigs()) {

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -24,6 +24,7 @@
 #include "frProfileTask.h"
 #include "frRegionQuery.h"
 #include "gc/FlexGC_impl.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 
 namespace drt {
@@ -223,7 +224,7 @@ void FlexGCWorker::Impl::addPAObj(frConnFig* obj, frBlockObject* owner)
   } else if (obj->typeId() == frcVia) {
     auto via = static_cast<frVia*>(obj);
     layerNum = via->getViaDef()->getLayer1Num();
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
       Rect box = fig->getBBox();
       xform.apply(box);
@@ -291,7 +292,7 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
   } else if (obj->typeId() == drcVia) {
     auto via = static_cast<drVia*>(obj);
     layerNum = via->getViaDef()->getLayer1Num();
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
       Rect box = fig->getBBox();
       xform.apply(box);
@@ -349,7 +350,7 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
   } else if (obj->typeId() == frcVia) {
     auto via = static_cast<frVia*>(obj);
     layerNum = via->getViaDef()->getLayer1Num();
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
       Rect box = fig->getBBox();
       xform.apply(box);

--- a/src/drt/src/gr/FlexGR.cpp
+++ b/src/drt/src/gr/FlexGR.cpp
@@ -1631,7 +1631,7 @@ void FlexGR::initGR_genTopology_net(frNet* net)
       Point pt;
       if (rpin->getFrTerm()->typeId() == frcInstTerm) {
         auto inst = static_cast<frInstTerm*>(rpin->getFrTerm())->getInst();
-        dbTransform shiftXform = inst->getNoRotationTransform();
+        odb::dbTransform shiftXform = inst->getNoRotationTransform();
         pt = rpin->getAccessPoint()->getPoint();
         shiftXform.apply(pt);
       } else {

--- a/src/drt/src/gr/FlexGR_rq.cpp
+++ b/src/drt/src/gr/FlexGR_rq.cpp
@@ -11,6 +11,7 @@
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "gr/FlexGR.h"
+#include "odb/dbTransform.h"
 
 namespace drt {
 
@@ -28,7 +29,7 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
     shapes_.at(obj->getLayerNum()).insert(std::make_pair(boostr, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -77,7 +78,7 @@ void FlexGRWorkerRegionQuery::add(
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
@@ -124,7 +125,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
     shapes_.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
-    dbTransform xform = via->getTransform();
+    odb::dbTransform xform = via->getTransform();
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {

--- a/src/drt/src/io/GuideProcessor.cpp
+++ b/src/drt/src/io/GuideProcessor.cpp
@@ -1348,7 +1348,7 @@ void GuideProcessor::genGuides_addCoverGuide_helper(frInstTerm* iterm,
 {
   const frInst* inst = iterm->getInst();
   const size_t num_pins = iterm->getTerm()->getPins().size();
-  dbTransform transform = inst->getNoRotationTransform();
+  odb::dbTransform transform = inst->getNoRotationTransform();
   for (int pin_idx = 0; pin_idx < num_pins; pin_idx++) {
     const frAccessPoint* pref_ap = getPrefAp(iterm, pin_idx);
     if (pref_ap) {

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -291,7 +291,8 @@ void io::Parser::setVias(odb::dbBlock* block)
       }
       currX -= xCutSpacing;  // max cut X
       currY -= yCutSpacing;  // max cut Y
-      dbTransform cutXform(Point(-currX / 2 + xOffset, -currY / 2 + yOffset));
+      odb::dbTransform cutXform(
+          Point(-currX / 2 + xOffset, -currY / 2 + yOffset));
       for (auto& uShape : cutFigs) {
         auto rect = static_cast<frRect*>(uShape.get());
         rect->move(cutXform);
@@ -304,10 +305,10 @@ void io::Parser::setVias(odb::dbBlock* block)
       Rect botBox(0 - xBotEnc, 0 - yBotEnc, currX + xBotEnc, currY + yBotEnc);
       Rect topBox(0 - xTopEnc, 0 - yTopEnc, currX + xTopEnc, currY + yTopEnc);
 
-      dbTransform botXform(Point(-currX / 2 + xOffset + xBotOffset,
-                                 -currY / 2 + yOffset + yBotOffset));
-      dbTransform topXform(Point(-currX / 2 + xOffset + xTopOffset,
-                                 -currY / 2 + yOffset + yTopOffset));
+      odb::dbTransform botXform(Point(-currX / 2 + xOffset + xBotOffset,
+                                      -currY / 2 + yOffset + yBotOffset));
+      odb::dbTransform topXform(Point(-currX / 2 + xOffset + xTopOffset,
+                                      -currY / 2 + yOffset + yTopOffset));
       botXform.apply(botBox);
       topXform.apply(topBox);
 

--- a/src/drt/src/io/io.h
+++ b/src/drt/src/io/io.h
@@ -125,7 +125,7 @@ class Parser
   // postProcess functions
   void checkFig(frPinFig* uFig,
                 const frString& term_name,
-                const dbTransform& xform,
+                const odb::dbTransform& xform,
                 bool& foundTracks,
                 bool& foundCenterTracks,
                 bool& hasPolys);

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -18,6 +18,7 @@
 #include "frProfileTask.h"
 #include "global.h"
 #include "io/io.h"
+#include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 #include "utl/Logger.h"
 
@@ -759,7 +760,7 @@ inline void getTrackLocs(bool isHorzTracks,
 
 void io::Parser::checkFig(frPinFig* uFig,
                           const frString& term_name,
-                          const dbTransform& xform,
+                          const odb::dbTransform& xform,
                           bool& foundTracks,
                           bool& foundCenterTracks,
                           bool& hasPolys)
@@ -868,7 +869,7 @@ void io::Parser::checkPins()
       for (auto& uFig : pin->getFigs()) {
         checkFig(uFig.get(),
                  bTerm->getName(),
-                 dbTransform(),
+                 odb::dbTransform(),
                  foundTracks,
                  foundCenterTracks,
                  hasPolys);
@@ -889,7 +890,7 @@ void io::Parser::checkPins()
     if (!inst->getMaster()->getMasterType().isBlock()) {
       continue;
     }
-    dbTransform xform = inst->getDBTransform();
+    odb::dbTransform xform = inst->getDBTransform();
     for (auto& iTerm : inst->getInstTerms()) {
       if (!iTerm->hasNet() || iTerm->getNet()->isSpecial()) {
         continue;

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -28,6 +28,7 @@
 #include "frBaseTypes.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "odb/dbTransform.h"
 #include "pa/AbstractPAGraphics.h"
 #include "pa/FlexPA.h"
 #include "serialization.h"
@@ -435,7 +436,7 @@ int FlexPA::getEdgeCost(
   if (vio_edges[edge_idx] != -1) {
     has_vio = (vio_edges[edge_idx] == 1);
   } else {
-    dbTransform xform = unique_inst->getNoRotationTransform();
+    odb::dbTransform xform = unique_inst->getNoRotationTransform();
     // check DRC
     std::vector<std::pair<frConnFig*, frBlockObject*>> objs;
     const auto& [pin_1, inst_term_1] = pins[prev_pin_idx];
@@ -605,7 +606,7 @@ bool FlexPA::genPatternsCommit(
       auto rvia = via.get();
       temp_vias.push_back(std::move(via));
 
-      dbTransform xform = unique_inst->getNoRotationTransform();
+      odb::dbTransform xform = unique_inst->getNoRotationTransform();
       Point pt(access_point->getPoint());
       xform.apply(pt);
       rvia->setOrigin(pt);
@@ -689,7 +690,7 @@ void FlexPA::genPatternsPrintDebug(
   FlexDPNode* curr_node = sink_node;
   int pin_cnt = pins.size();
 
-  dbTransform xform;
+  odb::dbTransform xform;
   auto& [pin, inst_term] = pins[0];
   if (inst_term) {
     frInst* unique_inst = inst_term->getInst();

--- a/src/drt/src/pa/FlexPA_acc_point.cpp
+++ b/src/drt/src/pa/FlexPA_acc_point.cpp
@@ -23,6 +23,7 @@
 #include "frBaseTypes.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "odb/dbTransform.h"
 #include "pa/AbstractPAGraphics.h"
 #include "pa/FlexPA.h"
 #include "utl/Logger.h"
@@ -1287,7 +1288,7 @@ FlexPA::mergePinShapes(T* pin, frInstTerm* inst_term, const bool is_shrink)
     inst = inst_term->getInst();
   }
 
-  dbTransform xform;
+  odb::dbTransform xform;
   if (inst) {
     xform = inst->getDBTransform();
   }
@@ -1554,9 +1555,9 @@ void FlexPA::revertAccessPoints()
   const auto& unique = unique_insts_.getUniqueClasses();
   for (const auto& unique_class : unique) {
     auto candidate_inst = unique_class->getFirstInst();
-    const dbTransform xform = candidate_inst->getTransform();
+    const odb::dbTransform xform = candidate_inst->getTransform();
     const Point offset(xform.getOffset());
-    dbTransform revertXform(Point(-offset.getX(), -offset.getY()));
+    odb::dbTransform revertXform(Point(-offset.getX(), -offset.getY()));
 
     const auto pin_access_idx = candidate_inst->getPinAccessIdx();
     for (auto& inst_term : candidate_inst->getInstTerms()) {

--- a/src/drt/src/pa/FlexPA_row_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_row_pattern.cpp
@@ -23,6 +23,7 @@
 #include "dst/JobMessage.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
+#include "odb/dbTransform.h"
 #include "pa/FlexPA.h"
 #include "serialization.h"
 #include "utl/exception.h"
@@ -476,7 +477,7 @@ void FlexPA::addAccessPatternObj(
     std::vector<std::unique_ptr<frVia>>& vias,
     const bool isPrev)
 {
-  const dbTransform xform = inst->getNoRotationTransform();
+  const odb::dbTransform xform = inst->getNoRotationTransform();
   int access_point_idx = 0;
   auto& access_points = access_pattern->getPattern();
 

--- a/src/drt/src/ta/FlexTA_assign.cpp
+++ b/src/drt/src/ta/FlexTA_assign.cpp
@@ -13,6 +13,7 @@
 #include "db/obj/frVia.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 #include "ta/FlexTA.h"
 
 namespace drt {
@@ -78,7 +79,7 @@ void FlexTAWorker::modMinSpacingCostPlanar(const Rect& box,
   auto& workerRegionQuery = getWorkerRegionQuery();
   for (int i = idx1; i <= idx2; i++) {
     auto trackLoc = trackLocs[i];
-    dbTransform xform(Point(boxLeft, trackLoc));
+    odb::dbTransform xform(Point(boxLeft, trackLoc));
     xform.apply(box2);
     box2boxDistSquare(box1, box2, dx, dy);
     if (dy >= bloatDist) {
@@ -203,7 +204,7 @@ void FlexTAWorker::modMinSpacingCostVia(const Rect& box,
   auto& trackLocs = getTrackLocs(followTrackLNum);
   auto& workerRegionQuery = getWorkerRegionQuery();
   Rect tmpBx;
-  dbTransform xform;
+  odb::dbTransform xform;
   frCoord dx, dy, prl;
   frCoord maxX, blockLeft, blockRight;
   Rect blockBox;
@@ -359,7 +360,7 @@ void FlexTAWorker::modCutSpacingCost(const Rect& box,
   auto& trackLocs = getTrackLocs(followTrackLNum);
   auto& workerRegionQuery = getWorkerRegionQuery();
   Rect tmpBx;
-  dbTransform xform;
+  odb::dbTransform xform;
   frCoord dx, dy, c2ctrackdist;
   frCoord reqDist = 0;
   frCoord maxX, blockLeft, blockRight;
@@ -544,7 +545,7 @@ void FlexTAWorker::modCost(taPinFig* fig,
     modMinSpacingCostVia(box, layerNum, obj, isAddCost, false, false, pinS);
 
     Point pt = obj->getOrigin();
-    dbTransform xform(pt);
+    odb::dbTransform xform(pt);
     for (auto& uFig : obj->getViaDef()->getCutFigs()) {
       auto rect = static_cast<frRect*>(uFig.get());
       box = rect->getBBox();

--- a/src/drt/src/ta/FlexTA_init.cpp
+++ b/src/drt/src/ta/FlexTA_init.cpp
@@ -19,6 +19,7 @@
 #include "db/obj/frShape.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/dbTransform.h"
 #include "ta/FlexTA.h"
 
 namespace drt {
@@ -177,7 +178,7 @@ bool FlexTAWorker::initIroute_helper_pin(frGuide* guide,
           continue;
         }
         frInst* inst = iterm->getInst();
-        dbTransform shiftXform = inst->getNoRotationTransform();
+        odb::dbTransform shiftXform = inst->getNoRotationTransform();
         frMTerm* mterm = iterm->getTerm();
         int pinIdx = 0;
         for (auto& pin : mterm->getPins()) {
@@ -298,7 +299,7 @@ void FlexTAWorker::initIroute_helper_generic_helper(frGuide* guide,
           continue;
         }
         frInst* inst = iterm->getInst();
-        dbTransform shiftXform = inst->getNoRotationTransform();
+        odb::dbTransform shiftXform = inst->getNoRotationTransform();
         frMTerm* mterm = iterm->getTerm();
         int pinIdx = 0;
         for (auto& pin : mterm->getPins()) {

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -210,7 +210,7 @@ frInst* Fixture::makeInst(const char* name,
   auto ptr_db_inst = std::make_unique<odb::dbInst>();
   odb::dbInst* db_inst
       = ptr_db_inst->create(db_->getChip()->getBlock(), db_master, "dummy");
-  dbTransform trans;
+  odb::dbTransform trans;
   db_inst->setTransform(trans);
   auto uInst = std::make_unique<frInst>(name, master, db_inst);
   auto tmpInst = uInst.get();


### PR DESCRIPTION
First step in fixing `using` declarations in header files. In this case, the `odb::dbTransform` was using-declared in a different namespace in a header file which then spilled this symbol into `drt::` namespace. Unless in very special circumstances this is of course never desirable.

(using declaration was in src/drt/src/db/infra/frBox.h)

This is the first step in cleaning up `using` declarations that spill symbols globally into different namespaces.