### PR TITLE
Avoid leaking odb::Rect into different namespaces.

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -36,7 +36,6 @@ using odb::dbMaster;
 using odb::dbMasterType;
 using odb::dbTechLayer;
 using odb::Point;
-using odb::Rect;
 
 class Node;
 class Group;
@@ -168,7 +167,7 @@ class Opendp
                       const std::string& violation_type = "") const;
   void importDb();
   void importClear();
-  Rect getBbox(dbInst* inst);
+  odb::Rect getBbox(dbInst* inst);
   void createNetwork();
   void createArchitecture();
   void setUpPlacementGroups();
@@ -183,11 +182,11 @@ class Opendp
   std::string printBgBox(const boost::geometry::model::box<bgPoint>& queryBox);
   void detailedPlacement();
   DbuPt nearestPt(const Node* cell, const DbuRect& rect) const;
-  int distToRect(const Node* cell, const Rect& rect) const;
-  static bool checkOverlap(const Rect& cell, const Rect& box);
+  int distToRect(const Node* cell, const odb::Rect& rect) const;
+  static bool checkOverlap(const odb::Rect& cell, const odb::Rect& box);
   bool checkOverlap(const Node* cell, const DbuRect& rect) const;
-  static bool isInside(const Rect& cell, const Rect& box);
-  bool isInside(const Node* cell, const Rect& rect) const;
+  static bool isInside(const odb::Rect& cell, const odb::Rect& box);
+  bool isInside(const Node* cell, const odb::Rect& rect) const;
   PixelPt searchNearestSite(const Node* cell, GridX x, GridY y) const;
   int calcDist(GridPt p0, GridPt p1) const;
   bool canBePlaced(const Node* cell, GridX bin_x, GridY bin_y) const;
@@ -214,7 +213,7 @@ class Opendp
   GridPt legalGridPt(const Node* cell, bool padded) const;
   DbuPt nearestBlockEdge(const Node* cell,
                          const DbuPt& legal_pt,
-                         const Rect& block_bbox) const;
+                         const odb::Rect& block_bbox) const;
 
   void findOverlapInRtree(const bgBox& queryBox,
                           std::vector<bgBox>& overlaps) const;
@@ -266,11 +265,11 @@ class Opendp
   void writeJsonReport(const std::string& filename);
 
   void rectDist(const Node* cell,
-                const Rect& rect,
+                const odb::Rect& rect,
                 // Return values.
                 int* x,
                 int* y) const;
-  int rectDist(const Node* cell, const Rect& rect) const;
+  int rectDist(const Node* cell, const odb::Rect& rect) const;
   void deleteGrid();
   // Cell initial location wrt core origin.
 

--- a/src/dpl/include/dpl/OptMirror.h
+++ b/src/dpl/include/dpl/OptMirror.h
@@ -18,7 +18,6 @@ namespace dpl {
 
 using odb::dbInst;
 using odb::dbNet;
-using odb::Rect;
 
 using utl::Logger;
 
@@ -26,20 +25,20 @@ class NetBox
 {
  public:
   NetBox() = default;
-  NetBox(dbNet* net, const Rect& box, bool ignore);
+  NetBox(dbNet* net, const odb::Rect& box, bool ignore);
   int64_t hpwl();
   void saveBox();
   void restoreBox();
   bool isIgnore() const { return ignore_; }
   dbNet* getNet() const { return net_; }
-  const Rect& getBox() const { return box_; }
+  const odb::Rect& getBox() const { return box_; }
 
-  void setBox(const Rect& box) { box_ = box; }
+  void setBox(const odb::Rect& box) { box_ = box; }
 
  private:
   dbNet* net_ = nullptr;
-  Rect box_;
-  Rect box_saved_;
+  odb::Rect box_;
+  odb::Rect box_saved_;
   bool ignore_ = false;
 };
 

--- a/src/dpl/src/CheckPlacement.cpp
+++ b/src/dpl/src/CheckPlacement.cpp
@@ -177,7 +177,7 @@ void Opendp::saveViolations(const std::vector<Node*>& failures,
 
       marker->addSource(o_cell->getDbInst());
     }
-    marker->addShape(Rect{xMin, yMin, xMax, yMax});
+    marker->addShape(odb::Rect{xMin, yMin, xMax, yMax});
     marker->addSource(failure->getDbInst());
   }
 }

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -26,7 +26,7 @@ using odb::dbOrientType;
 
 static dbOrientType orientMirrorY(const dbOrientType& orient);
 
-NetBox::NetBox(dbNet* net, const Rect& box, bool ignore)
+NetBox::NetBox(dbNet* net, const odb::Rect& box, bool ignore)
     : net_(net), box_(box), ignore_(ignore)
 {
 }
@@ -122,7 +122,7 @@ std::vector<dbInst*> OptimizeMirroring::findMirrorCandidates(
   for (NetBox* net_box : net_boxes) {
     if (!net_box->isIgnore()) {
       dbNet* net = net_box->getNet();
-      const Rect& box = net_box->getBox();
+      const odb::Rect& box = net_box->getBox();
       for (dbITerm* iterm : net->getITerms()) {
         dbInst* inst = iterm->getInst();
         int x, y;

--- a/src/dpl/src/Place.cpp
+++ b/src/dpl/src/Place.cpp
@@ -27,6 +27,7 @@
 #include "infrastructure/Padding.h"
 #include "infrastructure/network.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 #include "util/journal.h"
 #include "utl/Logger.h"
 // #define ODP_DEBUG
@@ -108,10 +109,10 @@ void Opendp::prePlace()
     if (cell->getType() != Node::CELL) {
       continue;
     }
-    const Rect* group_rect = nullptr;
+    const odb::Rect* group_rect = nullptr;
     if (!cell->inGroup() && !cell->isPlaced()) {
       for (auto& group : arch_->getRegions()) {
-        for (const Rect& rect : group->getRects()) {
+        for (const odb::Rect& rect : group->getRects()) {
           if (checkOverlap(cell.get(), rect)) {
             group_rect = &rect;
           }
@@ -192,8 +193,8 @@ void Opendp::prePlaceGroups()
       if (!cell->isFixed() && !cell->isPlaced()) {
         int dist = numeric_limits<int>::max();
         bool in_group = false;
-        const Rect* nearest_rect = nullptr;
-        for (const Rect& rect : group->getRects()) {
+        const odb::Rect* nearest_rect = nullptr;
+        for (const odb::Rect& rect : group->getRects()) {
           if (isInside(cell, rect)) {
             in_group = true;
           }
@@ -218,7 +219,7 @@ void Opendp::prePlaceGroups()
   }
 }
 
-bool Opendp::isInside(const Node* cell, const Rect& rect) const
+bool Opendp::isInside(const Node* cell, const odb::Rect& rect) const
 {
   const DbuPt init = initialLocation(cell, false);
   const DbuX x = init.x;
@@ -227,7 +228,7 @@ bool Opendp::isInside(const Node* cell, const Rect& rect) const
          && y >= rect.yMin() && y + cell->getHeight() <= rect.yMax();
 }
 
-int Opendp::distToRect(const Node* cell, const Rect& rect) const
+int Opendp::distToRect(const Node* cell, const odb::Rect& rect) const
 {
   const DbuPt init = initialLocation(cell, true);
   const DbuX x = init.x;
@@ -253,7 +254,7 @@ int Opendp::distToRect(const Node* cell, const Rect& rect) const
 class CellPlaceOrderLess
 {
  public:
-  explicit CellPlaceOrderLess(const Rect& core);
+  explicit CellPlaceOrderLess(const odb::Rect& core);
   bool operator()(const Node* cell1, const Node* cell2) const;
 
  private:
@@ -263,7 +264,7 @@ class CellPlaceOrderLess
   const int center_y_;
 };
 
-CellPlaceOrderLess::CellPlaceOrderLess(const Rect& core)
+CellPlaceOrderLess::CellPlaceOrderLess(const odb::Rect& core)
     : center_x_((core.xMin() + core.xMax()) / 2),
       center_y_((core.yMin() + core.yMax()) / 2)
 {
@@ -397,7 +398,7 @@ void Opendp::placeGroups2()
 // Place cells in group toward edges.
 void Opendp::brickPlace1(const Group* group)
 {
-  const Rect& boundary = group->getBBox();
+  const odb::Rect& boundary = group->getBBox();
   vector<Node*> sorted_cells(group->getCells());
 
   sort(sorted_cells.begin(), sorted_cells.end(), [&](Node* cell1, Node* cell2) {
@@ -419,7 +420,7 @@ void Opendp::brickPlace1(const Group* group)
 }
 
 void Opendp::rectDist(const Node* cell,
-                      const Rect& rect,
+                      const odb::Rect& rect,
                       // Return values.
                       int* x,
                       int* y) const
@@ -441,7 +442,7 @@ void Opendp::rectDist(const Node* cell,
   }
 }
 
-int Opendp::rectDist(const Node* cell, const Rect& rect) const
+int Opendp::rectDist(const Node* cell, const odb::Rect& rect) const
 {
   int x, y;
   rectDist(cell, rect, &x, &y);
@@ -952,7 +953,7 @@ GridPt Opendp::legalGridPt(const Node* cell, const DbuPt& pt) const
 
 DbuPt Opendp::nearestBlockEdge(const Node* cell,
                                const DbuPt& legal_pt,
-                               const Rect& block_bbox) const
+                               const odb::Rect& block_bbox) const
 {
   const DbuX legal_x = legal_pt.x;
   const DbuY legal_y = legal_pt.y;
@@ -1056,7 +1057,7 @@ void Opendp::convertDbToCell(dbInst* db_inst, Node& cell)
 {
   cell.setType(Node::CELL);
   cell.setDbInst(db_inst);
-  Rect bbox = getBbox(db_inst);
+  odb::Rect bbox = getBbox(db_inst);
   cell.setWidth(DbuX{bbox.dx()});
   cell.setHeight(DbuY{bbox.dy()});
   cell.setLeft(DbuX{bbox.xMin()});
@@ -1068,10 +1069,10 @@ DbuPt Opendp::pointOffMacro(const Node& cell)
 {
   // Get cell position
   const DbuPt init = initialLocation(&cell, false);
-  const Rect bbox(init.x.v,
-                  init.y.v,
-                  init.x.v + cell.getWidth().v,
-                  init.y.v + cell.getHeight().v);
+  const odb::Rect bbox(init.x.v,
+                       init.y.v,
+                       init.x.v + cell.getWidth().v,
+                       init.y.v + cell.getHeight().v);
 
   const GridRect grid_box = grid_->gridCovering(bbox);
 
@@ -1093,10 +1094,10 @@ DbuPt Opendp::pointOffMacro(const Node& cell)
 
   if (block && block->isBlock()) {
     // Get new legal position
-    const Rect block_bbox(block->getLeft().v,
-                          block->getBottom().v,
-                          block->getLeft().v + block->getWidth().v,
-                          block->getBottom().v + block->getHeight().v);
+    const odb::Rect block_bbox(block->getLeft().v,
+                               block->getBottom().v,
+                               block->getLeft().v + block->getWidth().v,
+                               block->getBottom().v + block->getHeight().v);
     return nearestBlockEdge(&cell, init, block_bbox);
   }
   return init;
@@ -1171,10 +1172,10 @@ DbuPt Opendp::legalPt(const Node* cell, const bool padded) const
     // edge strategy.  This doesn't consider site availability at the
     // end used so it is secondary.
     if (block && block->isBlock()) {
-      const Rect block_bbox(block->getLeft().v,
-                            block->getBottom().v,
-                            block->getLeft().v + block->getWidth().v,
-                            block->getBottom().v + block->getHeight().v);
+      const odb::Rect block_bbox(block->getLeft().v,
+                                 block->getBottom().v,
+                                 block->getLeft().v + block->getWidth().v,
+                                 block->getBottom().v + block->getHeight().v);
       if ((legal_pt.x + cell->getWidth()) >= block_bbox.xMin()
           && legal_pt.x <= block_bbox.xMax()
           && (legal_pt.y + cell->getHeight()) >= block_bbox.yMin()

--- a/src/dpl/src/PlacementDRC.cpp
+++ b/src/dpl/src/PlacementDRC.cpp
@@ -10,29 +10,30 @@
 #include "infrastructure/Padding.h"
 #include "odb/db.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace dpl {
 
 namespace cell_edges {
-Rect transformEdgeRect(const Rect& edge_rect,
-                       const Node* cell,
-                       const DbuX x,
-                       const DbuY y,
-                       const odb::dbOrientType& orient)
+odb::Rect transformEdgeRect(const odb::Rect& edge_rect,
+                            const Node* cell,
+                            const DbuX x,
+                            const DbuY y,
+                            const odb::dbOrientType& orient)
 {
-  Rect bbox;
+  odb::Rect bbox;
   cell->getDbInst()->getMaster()->getPlacementBoundary(bbox);
   odb::dbTransform transform(orient);
   transform.apply(bbox);
   Point offset(x.v - bbox.xMin(), y.v - bbox.yMin());
   transform.setOffset(offset);
-  Rect result(edge_rect);
+  odb::Rect result(edge_rect);
   transform.apply(result);
   return result;
 }
-Rect getQueryRect(const Rect& edge_box, const int spc)
+odb::Rect getQueryRect(const odb::Rect& edge_box, const int spc)
 {
-  Rect query_rect(edge_box);
+  odb::Rect query_rect(edge_box);
   bool is_vertical_edge = edge_box.getDir() == 0;
   if (is_vertical_edge) {
     // vertical edge
@@ -84,10 +85,10 @@ bool PlacementDRC::checkEdgeSpacing(const Node* cell,
   for (const auto& edge1 : master->getEdges()) {
     int max_spc = getMaxSpacing(edge1.getEdgeType())
                   + 1;  // +1 to account for EXACT rules
-    Rect edge1_box = cell_edges::transformEdgeRect(
+    odb::Rect edge1_box = cell_edges::transformEdgeRect(
         edge1.getBBox(), cell, x_real, y_real, orient);
     bool is_vertical_edge = edge1_box.getDir() == 0;
-    Rect query_rect = cell_edges::getQueryRect(edge1_box, max_spc);
+    odb::Rect query_rect = cell_edges::getQueryRect(edge1_box, max_spc);
     GridX xMin = grid_->gridX(DbuX(query_rect.xMin()));
     GridX xMax = grid_->gridEndX(DbuX(query_rect.xMax()));
     GridY yMin = grid_->gridEndY(DbuY(query_rect.yMin())) - 1;
@@ -116,11 +117,12 @@ bool PlacementDRC::checkEdgeSpacing(const Node* cell,
           auto spc_entry
               = edge_spacing_table_[edge1.getEdgeType()][edge2.getEdgeType()];
           int spc = spc_entry.spc;
-          Rect edge2_box = cell_edges::transformEdgeRect(edge2.getBBox(),
-                                                         cell2,
-                                                         cell2->getLeft(),
-                                                         cell2->getBottom(),
-                                                         cell2->getOrient());
+          odb::Rect edge2_box
+              = cell_edges::transformEdgeRect(edge2.getBBox(),
+                                              cell2,
+                                              cell2->getLeft(),
+                                              cell2->getBottom(),
+                                              cell2->getOrient());
           if (edge1_box.getDir() != edge2_box.getDir()) {
             // Skip if edges are not parallel.
             continue;
@@ -129,7 +131,7 @@ bool PlacementDRC::checkEdgeSpacing(const Node* cell,
             // Skip if there is no PRL between the edges.
             continue;
           }
-          Rect test_rect(edge1_box);
+          odb::Rect test_rect(edge1_box);
           // Generalized intersection between the two edges.
           test_rect.merge(edge2_box);
           int dist = is_vertical_edge ? test_rect.dx() : test_rect.dy();

--- a/src/dpl/src/graphics/Graphics.cpp
+++ b/src/dpl/src/graphics/Graphics.cpp
@@ -52,7 +52,7 @@ void Graphics::binSearch(const Node* cell,
   if (!debug_instance_ || cell->getDbInst() != debug_instance_) {
     return;
   }
-  Rect core = dp_->grid_->getCore();
+  odb::Rect core = dp_->grid_->getCore();
   int xl_dbu = core.xMin() + gridToDbu(xl, dp_->grid_->getSiteWidth()).v;
   int yl_dbu = core.yMin() + dp_->grid_->gridYToDbu(yl).v;
   int xh_dbu = core.xMin() + gridToDbu(xh, dp_->grid_->getSiteWidth()).v;
@@ -88,7 +88,7 @@ void Graphics::drawObjects(gui::Painter& painter)
     auto color = cell->getDbInst() ? gui::Painter::kGray : gui::Painter::kRed;
     painter.setPen(color);
     painter.setBrush(color);
-    painter.drawRect(Rect(
+    painter.drawRect(odb::Rect(
         lx.v, ly.v, lx.v + cell->getWidth().v, ly.v + cell->getHeight().v));
 
     if (!cell->getDbInst()) {

--- a/src/dpl/src/graphics/Graphics.h
+++ b/src/dpl/src/graphics/Graphics.h
@@ -15,7 +15,6 @@ namespace dpl {
 using odb::dbBlock;
 using odb::dbInst;
 using odb::Point;
-using odb::Rect;
 
 class Opendp;
 class Node;
@@ -44,7 +43,7 @@ class Graphics : public gui::Renderer, public DplObserver
   const dbInst* debug_instance_;
   dbBlock* block_ = nullptr;
   float min_displacement_;  // in row height
-  std::vector<Rect> searched_;
+  std::vector<odb::Rect> searched_;
 };
 
 }  // namespace dpl

--- a/src/dpl/src/infrastructure/Coordinates.h
+++ b/src/dpl/src/infrastructure/Coordinates.h
@@ -13,6 +13,7 @@
 
 #include "boost/operators.hpp"
 #include "dpl/Opendp.h"
+#include "odb/geom.h"
 
 namespace dpl {
 
@@ -140,12 +141,12 @@ struct GridRect
   GridY yhi;
   GridRect intersect(const GridRect& r) const;
   GridPt closestPtInside(GridPt pt) const;
-  Rect toRect() const;
+  odb::Rect toRect() const;
 };
 
-inline Rect GridRect::toRect() const
+inline odb::Rect GridRect::toRect() const
 {
-  return Rect(xlo.v, ylo.v, xhi.v, yhi.v);
+  return odb::Rect(xlo.v, ylo.v, xhi.v, yhi.v);
 }
 
 inline GridPt GridRect::closestPtInside(GridPt pt) const
@@ -174,7 +175,7 @@ struct DbuPt
 
 struct DbuRect
 {
-  DbuRect(const Rect& rect)
+  DbuRect(const odb::Rect& rect)
       : xl(rect.xMin()), yl(rect.yMin()), xh(rect.xMax()), yh(rect.yMax())
   {
   }

--- a/src/dpl/src/infrastructure/Grid.cpp
+++ b/src/dpl/src/infrastructure/Grid.cpp
@@ -98,7 +98,7 @@ void Grid::markHopeless(dbBlock* block,
   gtl::polygon_90_set_data<int> hopeless;
   hopeless += gtl::rectangle_data<int>{0, 0, row_site_count_.v, row_count_.v};
 
-  const Rect core = getCore();
+  const odb::Rect core = getCore();
 
   // Fragmented row support; mark valid sites.
   visitDbRows(block, [&](odb::dbRow* db_row) {
@@ -138,7 +138,7 @@ void Grid::markHopeless(dbBlock* block,
 
 void Grid::markBlocked(dbBlock* block)
 {
-  const Rect core = getCore();
+  const odb::Rect core = getCore();
   auto addBlockedLayers
       = [&](odb::Rect wire_rect, odb::dbTechLayer* tech_layer) {
           if (tech_layer->getType() != odb::dbTechLayerType::Value::ROUTING) {
@@ -186,7 +186,7 @@ void Grid::markBlocked(dbBlock* block)
     if (blockage->isSoft()) {
       continue;
     }
-    Rect bbox = blockage->getBBox()->getBox();
+    odb::Rect bbox = blockage->getBBox()->getBox();
     bbox.moveDelta(-core.xMin(), -core.yMin());
     GridRect grid_rect = gridCovering(bbox);
 
@@ -282,14 +282,14 @@ void Grid::visitCellPixels(
   dbInst* inst = cell.getDbInst();
   auto obstructions = inst->getMaster()->getObstructions();
   bool have_obstructions = false;
-  const Rect core = getCore();
+  const odb::Rect core = getCore();
 
   for (dbBox* obs : obstructions) {
     if (obs->getTechLayer()->getType()
         == odb::dbTechLayerType::Value::OVERLAP) {
       have_obstructions = true;
 
-      Rect rect = obs->getBox();
+      odb::Rect rect = obs->getBox();
       inst->getTransform().apply(rect);
       rect.moveDelta(-core.xMin(), -core.yMin());
       GridRect grid_rect = gridCovering(rect);
@@ -361,13 +361,13 @@ void Grid::visitCellBoundaryPixels(
   dbMaster* master = inst->getMaster();
   auto obstructions = master->getObstructions();
   bool have_obstructions = false;
-  const Rect core = getCore();
+  const odb::Rect core = getCore();
   for (dbBox* obs : obstructions) {
     if (obs->getTechLayer()->getType()
         == odb::dbTechLayerType::Value::OVERLAP) {
       have_obstructions = true;
 
-      Rect rect = obs->getBox();
+      odb::Rect rect = obs->getBox();
       inst->getTransform().apply(rect);
       rect.moveDelta(-core.xMin(), -core.yMin());
 
@@ -512,7 +512,7 @@ GridX Grid::gridWidth(const Node* cell) const
 
 GridY Grid::gridHeight(odb::dbMaster* master) const
 {
-  Rect bbox;
+  odb::Rect bbox;
   master->getPlacementBoundary(bbox);
   if (uniform_row_height_) {
     DbuY row_height = uniform_row_height_.value();
@@ -569,7 +569,7 @@ GridY Grid::getRowCount(DbuY row_height) const
   return GridY{divFloor(core_.dy(), row_height.v)};
 }
 
-GridRect Grid::gridCovering(const Rect& rect) const
+GridRect Grid::gridCovering(const odb::Rect& rect) const
 {
   return {.xlo = gridX(DbuX{rect.xMin()}),
           .ylo = gridSnapDownY(DbuY{rect.yMin()}),

--- a/src/dpl/src/infrastructure/Grid.h
+++ b/src/dpl/src/infrastructure/Grid.h
@@ -17,6 +17,7 @@
 #include "boost/icl/interval_map.hpp"
 #include "dpl/Opendp.h"
 #include "odb/db.h"
+#include "odb/geom.h"
 
 namespace dpl {
 
@@ -66,7 +67,7 @@ class Grid
 {
  public:
   void init(Logger* logger) { logger_ = logger; }
-  void setCore(const Rect& core) { core_ = core; }
+  void setCore(const odb::Rect& core) { core_ = core; }
   void initGrid(dbDatabase* db,
                 dbBlock* block,
                 std::shared_ptr<Padding> padding,
@@ -89,7 +90,7 @@ class Grid
   GridY gridEndY(DbuY y) const;
 
   // Snap outwards to fully contain
-  GridRect gridCovering(const Rect& rect) const;
+  GridRect gridCovering(const odb::Rect& rect) const;
   GridRect gridCovering(const Node* cell) const;
   GridRect gridCoveringPadded(const Node* cell) const;
 
@@ -149,7 +150,7 @@ class Grid
 
   GridY getRowCount(DbuY row_height) const;
 
-  Rect getCore() const { return core_; }
+  odb::Rect getCore() const { return core_; }
   bool cellFitsInCore(Node* cell) const;
 
   bool isMultiHeight(dbMaster* master) const;
@@ -203,7 +204,7 @@ class Grid
   std::vector<RowSitesMap> row_sites_;
 
   bool has_hybrid_rows_ = false;
-  Rect core_;
+  odb::Rect core_;
 
   std::optional<DbuY> uniform_row_height_;  // unset if hybrid
   DbuX site_width_{0};

--- a/src/dpl/src/infrastructure/Objects.cpp
+++ b/src/dpl/src/infrastructure/Objects.cpp
@@ -13,7 +13,7 @@
 namespace dpl {
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-MasterEdge::MasterEdge(unsigned int type, const Rect& box)
+MasterEdge::MasterEdge(unsigned int type, const odb::Rect& box)
     : edge_type_idx_(type), bbox_(box)
 {
 }
@@ -22,7 +22,7 @@ unsigned int MasterEdge::getEdgeType() const
 {
   return edge_type_idx_;
 }
-const Rect& MasterEdge::getBBox() const
+const odb::Rect& MasterEdge::getBBox() const
 {
   return bbox_;
 }
@@ -37,7 +37,7 @@ const std::vector<MasterEdge>& Master::getEdges() const
 {
   return edges_;
 }
-Rect Master::getBBox() const
+odb::Rect Master::getBBox() const
 {
   return boundary_box_;
 }
@@ -61,7 +61,7 @@ void Master::clearEdges()
 {
   edges_.clear();
 }
-void Master::setBBox(const Rect box)
+void Master::setBBox(const odb::Rect box)
 {
   boundary_box_ = box;
 }
@@ -241,7 +241,7 @@ Group* Node::getGroup() const
 {
   return group_;
 }
-const Rect* Node::getRegion() const
+const odb::Rect* Node::getRegion() const
 {
   return region_;
 }
@@ -265,9 +265,10 @@ int Node::getGroupId() const
 {
   return group_id_;
 }
-Rect Node::getBBox() const
+odb::Rect Node::getBBox() const
 {
-  return Rect(left_.v, bottom_.v, left_.v + width_.v, bottom_.v + height_.v);
+  return odb::Rect(
+      left_.v, bottom_.v, left_.v + width_.v, bottom_.v + height_.v);
 }
 uint8_t Node::getUsedLayers() const
 {
@@ -341,7 +342,7 @@ void Node::setGroup(Group* in)
 {
   group_ = in;
 }
-void Node::setRegion(const Rect* in)
+void Node::setRegion(const odb::Rect* in)
 {
   region_ = in;
 }
@@ -474,7 +475,7 @@ std::string Group::getName() const
 {
   return name_;
 }
-const std::vector<Rect>& Group::getRects() const
+const std::vector<odb::Rect>& Group::getRects() const
 {
   return region_boundaries_;
 }
@@ -482,7 +483,7 @@ std::vector<Node*> Group::getCells() const
 {
   return cells_;
 }
-const Rect& Group::getBBox() const
+const odb::Rect& Group::getBBox() const
 {
   return boundary_;
 }
@@ -502,7 +503,7 @@ void Group::setName(const std::string& in)
 {
   name_ = in;
 }
-void Group::addRect(const Rect& in)
+void Group::addRect(const odb::Rect& in)
 {
   region_boundaries_.emplace_back(in);
 }
@@ -510,7 +511,7 @@ void Group::addCell(Node* cell)
 {
   cells_.emplace_back(cell);
 }
-void Group::setBoundary(const Rect& in)
+void Group::setBoundary(const odb::Rect& in)
 {
   boundary_ = in;
 }

--- a/src/dpl/src/infrastructure/Objects.h
+++ b/src/dpl/src/infrastructure/Objects.h
@@ -26,18 +26,17 @@ using odb::dbInst;
 using odb::dbMaster;
 using odb::dbOrientType;
 using odb::dbSite;
-using odb::Rect;
 
 class MasterEdge
 {
  public:
-  MasterEdge(unsigned int type, const Rect& box);
+  MasterEdge(unsigned int type, const odb::Rect& box);
   unsigned int getEdgeType() const;
-  const Rect& getBBox() const;
+  const odb::Rect& getBBox() const;
 
  private:
   unsigned int edge_type_idx_{0};
-  Rect bbox_;
+  odb::Rect bbox_;
 };
 
 class Master
@@ -45,13 +44,13 @@ class Master
  public:
   bool isMultiRow() const;
   const std::vector<MasterEdge>& getEdges() const;
-  Rect getBBox() const;
+  odb::Rect getBBox() const;
   int getBottomPowerType() const;
   int getTopPowerType() const;
   void setMultiRow(bool in);
   void addEdge(const MasterEdge& edge);
   void clearEdges();
-  void setBBox(Rect box);
+  void setBBox(odb::Rect box);
   void setBottomPowerType(int bottom_pwr);
   void setTopPowerType(int top_pwr);
   void setDbMaster(dbMaster* db_master);
@@ -59,7 +58,7 @@ class Master
 
  private:
   dbMaster* db_master_{nullptr};
-  Rect boundary_box_;
+  odb::Rect boundary_box_;
   bool is_multi_row_{false};
   std::vector<MasterEdge> edges_;
   int bottom_pwr_{0};
@@ -111,13 +110,13 @@ class Node
   bool isStdCell() const;
   bool isBlock() const;
   Group* getGroup() const;
-  const Rect* getRegion() const;
+  const odb::Rect* getRegion() const;
   Master* getMaster() const;
   bool inGroup() const;
   int getNumPins() const;
   const std::vector<Pin*>& getPins() const;
   int getGroupId() const;
-  Rect getBBox() const;
+  odb::Rect getBBox() const;
   dbBTerm* getBTerm() const;
   uint8_t getUsedLayers() const;
 
@@ -139,7 +138,7 @@ class Node
   void setOrigLeft(DbuX left);
   void setType(Type type);
   void setGroup(Group* in);
-  void setRegion(const Rect* in);
+  void setRegion(const odb::Rect* in);
   void setMaster(Master* in);
   void addPin(Pin* pin);
   void setGroupId(int id);
@@ -172,7 +171,7 @@ class Node
   // Master and edges
   Master* master_{nullptr};
   Group* group_{nullptr};
-  const Rect* region_{nullptr};  // group rect
+  const odb::Rect* region_{nullptr};  // group rect
   // // Regions.
   int group_id_{-1};
   // Pins.
@@ -186,25 +185,25 @@ class Group
  public:
   // getters
   std::string getName() const;
-  const std::vector<Rect>& getRects() const;
+  const std::vector<odb::Rect>& getRects() const;
   std::vector<Node*> getCells() const;
-  const Rect& getBBox() const;
+  const odb::Rect& getBBox() const;
   double getUtil() const;
   int getId() const;
   // setters
   void setId(int id);
   void setName(const std::string& in);
-  void addRect(const Rect& in);
+  void addRect(const odb::Rect& in);
   void addCell(Node* cell);
-  void setBoundary(const Rect& in);
+  void setBoundary(const odb::Rect& in);
   void setUtil(double in);
 
  private:
   int id_{0};
   std::string name_;
-  std::vector<Rect> region_boundaries_;
+  std::vector<odb::Rect> region_boundaries_;
   std::vector<Node*> cells_;
-  Rect boundary_;
+  odb::Rect boundary_;
   double util_{0.0};
 };
 

--- a/src/dpl/src/infrastructure/network.cxx
+++ b/src/dpl/src/infrastructure/network.cxx
@@ -159,19 +159,19 @@ namespace {
  * child segments. It first sorts the segs vector and merges intersecting ones.
  * Then it calculates the difference and returns a list of segments.
  */
-std::vector<Rect> difference(const Rect& parent_segment,
-                             const std::vector<Rect>& segs)
+std::vector<odb::Rect> difference(const odb::Rect& parent_segment,
+                                  const std::vector<odb::Rect>& segs)
 {
   if (segs.empty()) {
     return {parent_segment};
   }
   bool is_horizontal = parent_segment.yMin() == parent_segment.yMax();
-  std::vector<Rect> sorted_segs = segs;
+  std::vector<odb::Rect> sorted_segs = segs;
   // Sort segments by start coordinate
   std::sort(
       sorted_segs.begin(),
       sorted_segs.end(),
-      [is_horizontal](const Rect& a, const Rect& b) {
+      [is_horizontal](const odb::Rect& a, const odb::Rect& b) {
         return (is_horizontal ? a.xMin() < b.xMin() : a.yMin() < b.yMin());
       });
   // Merge overlapping segments
@@ -190,8 +190,8 @@ std::vector<Rect> difference(const Rect& parent_segment,
       = is_horizontal ? parent_segment.xMin() : parent_segment.yMin();
   const int end = is_horizontal ? parent_segment.xMax() : parent_segment.yMax();
   int current_pos = start;
-  std::vector<Rect> result;
-  for (const Rect& seg : sorted_segs) {
+  std::vector<odb::Rect> result;
+  for (const odb::Rect& seg : sorted_segs) {
     int seg_start = is_horizontal ? seg.xMin() : seg.yMin();
     int seg_end = is_horizontal ? seg.xMax() : seg.yMax();
     if (seg_start > current_pos) {
@@ -223,10 +223,10 @@ std::vector<Rect> difference(const Rect& parent_segment,
   return result;
 }
 
-Rect getBoundarySegment(const Rect& bbox,
-                        const odb::dbMasterEdgeType::EdgeDir dir)
+odb::Rect getBoundarySegment(const odb::Rect& bbox,
+                             const odb::dbMasterEdgeType::EdgeDir dir)
 {
-  Rect segment(bbox);
+  odb::Rect segment(bbox);
   switch (dir) {
     case odb::dbMasterEdgeType::RIGHT:
       segment.set_xlo(bbox.xMax());
@@ -299,7 +299,7 @@ Master* Network::addMaster(odb::dbMaster* db_master,
   masters_.emplace_back(std::move(umaster));
   master_to_idx_[db_master] = id;
   master->setDbMaster(db_master);
-  Rect bbox;
+  odb::Rect bbox;
   db_master->getPlacementBoundary(bbox);
   master->setBBox(bbox);
   master->setMultiRow(grid->isMultiHeight(db_master));
@@ -314,11 +314,11 @@ Master* Network::addMaster(odb::dbMaster* db_master,
       == odb::dbMasterType::CORE_SPACER) {  // Skip fillcells
     return master;
   }
-  std::map<odb::dbMasterEdgeType::EdgeDir, std::vector<Rect>> typed_segs;
+  std::map<odb::dbMasterEdgeType::EdgeDir, std::vector<odb::Rect>> typed_segs;
   int num_rows = grid->gridHeight(db_master).v;
   for (auto edge : db_master->getEdgeTypes()) {
     auto dir = edge->getEdgeDir();
-    Rect edge_rect = getBoundarySegment(bbox, dir);
+    odb::Rect edge_rect = getBoundarySegment(bbox, dir);
     if (dir == odb::dbMasterEdgeType::TOP
         || dir == odb::dbMasterEdgeType::BOTTOM) {
       if (edge->getRangeBegin() != -1) {

--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -1132,7 +1132,7 @@ void TritonRoute::fixMaxSpacing(int num_threads)
 }
 
 void TritonRoute::getDRCMarkers(frList<std::unique_ptr<frMarker>>& markers,
-                                const Rect& requiredDrcBox)
+                                const odb::Rect& requiredDrcBox)
 {
   std::vector<std::vector<std::unique_ptr<FlexGCWorker>>> workersBatches(1);
   auto size = 7;
@@ -1142,16 +1142,17 @@ void TritonRoute::getDRCMarkers(frList<std::unique_ptr<frMarker>>& markers,
   auto& ygp = gCellPatterns.at(1);
   for (int i = offset; i < (int) xgp.getCount(); i += size) {
     for (int j = offset; j < (int) ygp.getCount(); j += size) {
-      Rect routeBox1 = design_->getTopBlock()->getGCellBox(Point(i, j));
+      odb::Rect routeBox1 = design_->getTopBlock()->getGCellBox(Point(i, j));
       const int max_i = std::min((int) xgp.getCount() - 1, i + size - 1);
       const int max_j = std::min((int) ygp.getCount(), j + size - 1);
-      Rect routeBox2 = design_->getTopBlock()->getGCellBox(Point(max_i, max_j));
-      Rect routeBox(routeBox1.xMin(),
-                    routeBox1.yMin(),
-                    routeBox2.xMax(),
-                    routeBox2.yMax());
-      Rect extBox;
-      Rect drcBox;
+      odb::Rect routeBox2
+          = design_->getTopBlock()->getGCellBox(Point(max_i, max_j));
+      odb::Rect routeBox(routeBox1.xMin(),
+                         routeBox1.yMin(),
+                         routeBox2.xMax(),
+                         routeBox2.yMax());
+      odb::Rect extBox;
+      odb::Rect drcBox;
       routeBox.bloat(router_cfg_->DRCSAFEDIST, drcBox);
       routeBox.bloat(router_cfg_->MTSAFEDIST, extBox);
       if (!drcBox.intersects(requiredDrcBox)) {
@@ -1177,7 +1178,7 @@ void TritonRoute::getDRCMarkers(frList<std::unique_ptr<frMarker>>& markers,
     }
     for (const auto& worker : workers) {
       for (auto& marker : worker->getMarkers()) {
-        Rect bbox = marker->getBBox();
+        odb::Rect bbox = marker->getBBox();
         if (!bbox.intersects(requiredDrcBox)) {
           continue;
         }
@@ -1218,7 +1219,7 @@ void TritonRoute::checkDRC(const char* filename,
   } else if (!initGuide()) {
     logger_->error(DRT, 1, "GCELLGRID is undefined");
   }
-  Rect requiredDrcBox(x1, y1, x2, y2);
+  odb::Rect requiredDrcBox(x1, y1, x2, y2);
   if (requiredDrcBox.area() == 0) {
     requiredDrcBox = design_->getTopBlock()->getBBox();
   }
@@ -1328,7 +1329,7 @@ int TritonRoute::getWorkerResultsSize()
 void TritonRoute::reportDRC(const std::string& file_name,
                             const frList<std::unique_ptr<frMarker>>& markers,
                             const std::string& marker_name,
-                            Rect drcBox) const
+                            odb::Rect drcBox) const
 {
   odb::dbBlock* block = db_->getChip()->getBlock();
   odb::dbMarkerCategory* tool_category
@@ -1346,8 +1347,8 @@ void TritonRoute::reportDRC(const std::string& file_name,
 
   for (const auto& marker : markers) {
     // get violation bbox
-    Rect bbox = marker->getBBox();
-    if (drcBox != Rect() && !drcBox.intersects(bbox)) {
+    odb::Rect bbox = marker->getBBox();
+    if (drcBox != odb::Rect() && !drcBox.intersects(bbox)) {
       continue;
     }
     auto tech = getDesign()->getTech();

--- a/src/drt/src/db/drObj/drFig.h
+++ b/src/drt/src/db/drObj/drFig.h
@@ -7,12 +7,13 @@
 
 #include "db/drObj/drBlockObject.h"
 #include "db/infra/frBox.h"
+#include "odb/geom.h"
 
 namespace drt {
 class drFig : public drBlockObject
 {
  public:
-  virtual Rect getBBox() const = 0;
+  virtual odb::Rect getBBox() const = 0;
 
  protected:
   template <class Archive>

--- a/src/drt/src/db/drObj/drNet.h
+++ b/src/drt/src/db/drObj/drNet.h
@@ -64,7 +64,7 @@ class drNet : public drBlockObject
   int getNumPinsIn() const { return numPinsIn_; }
   bool hasMarkerDist() const { return (markerDist_ == -1); }
   frCoord getMarkerDist() const { return markerDist_; }
-  Rect getPinBox() { return pinBox_; }
+  odb::Rect getPinBox() { return pinBox_; }
   bool isRipup() const { return allowRipup_ ? ripup_ : false; }
   int getNumReroutes() const { return numReroutes_; }
   bool isInQueue() const { return inQueue_; }
@@ -125,7 +125,7 @@ class drNet : public drBlockObject
   void setNumPinsIn(int in) { numPinsIn_ = in; }
   void updateMarkerDist(frCoord in) { markerDist_ = std::min(markerDist_, in); }
   void resetMarkerDist() { markerDist_ = std::numeric_limits<frCoord>::max(); }
-  void setPinBox(const Rect& in) { pinBox_ = in; }
+  void setPinBox(const odb::Rect& in) { pinBox_ = in; }
   void setRipup() { ripup_ = true; }
   void resetRipup() { ripup_ = false; }
   void setAllowRipup(bool in) { allowRipup_ = in; }
@@ -215,7 +215,7 @@ class drNet : public drBlockObject
   int numPinsIn_{0};
   frCoord markerDist_{std::numeric_limits<frCoord>::max()};
   bool allowRipup_{true};
-  Rect pinBox_;
+  odb::Rect pinBox_;
   bool ripup_{false};
   // new
   int numReroutes_{0};

--- a/src/drt/src/db/drObj/drShape.cpp
+++ b/src/drt/src/db/drObj/drShape.cpp
@@ -7,10 +7,11 @@
 
 #include "db/drObj/drNet.h"
 #include "db/obj/frShape.h"
+#include "odb/geom.h"
 
 namespace drt {
 
-Rect drPathSeg::getBBox() const
+odb::Rect drPathSeg::getBBox() const
 {
   bool isHorizontal = true;
   if (begin_.x() == end_.x()) {
@@ -20,15 +21,15 @@ Rect drPathSeg::getBBox() const
   const auto beginExt = style_.getBeginExt();
   const auto endExt = style_.getEndExt();
   if (isHorizontal) {
-    return Rect(begin_.x() - beginExt,
-                begin_.y() - width / 2,
-                end_.x() + endExt,
-                end_.y() + width / 2);
+    return odb::Rect(begin_.x() - beginExt,
+                     begin_.y() - width / 2,
+                     end_.x() + endExt,
+                     end_.y() + width / 2);
   }
-  return Rect(begin_.x() - width / 2,
-              begin_.y() - beginExt,
-              end_.x() + width / 2,
-              end_.y() + endExt);
+  return odb::Rect(begin_.x() - width / 2,
+                   begin_.y() - beginExt,
+                   end_.x() + width / 2,
+                   end_.y() + endExt);
 }
 
 drPathSeg::drPathSeg(const frPathSeg& in) : layer_(in.getLayerNum())

--- a/src/drt/src/db/drObj/drShape.h
+++ b/src/drt/src/db/drObj/drShape.h
@@ -10,6 +10,7 @@
 #include "dr/FlexMazeTypes.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -173,7 +174,7 @@ class drPathSeg : public drShape
    * overlaps, in .cpp
    */
   // needs to be updated
-  Rect getBBox() const override;
+  odb::Rect getBBox() const override;
 
   bool hasMazeIdx() const { return (!beginMazeIdx_.empty()); }
   std::pair<FlexMazeIdx, FlexMazeIdx> getMazeIdx() const
@@ -291,22 +292,22 @@ class drPatchWire : public drShape
    * getBBox
    * setBBox
    */
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     odb::dbTransform xform(origin_);
-    Rect box = offsetBox_;
+    odb::Rect box = offsetBox_;
     xform.apply(box);
     return box;
   }
 
-  Rect getOffsetBox() const { return offsetBox_; }
-  void setOffsetBox(const Rect& boxIn) { offsetBox_ = boxIn; }
+  odb::Rect getOffsetBox() const { return offsetBox_; }
+  void setOffsetBox(const odb::Rect& boxIn) { offsetBox_ = boxIn; }
 
   Point getOrigin() const { return origin_; }
   void setOrigin(const Point& in) { origin_ = in; }
 
  protected:
-  Rect offsetBox_;
+  odb::Rect offsetBox_;
   Point origin_;
   frLayerNum layer_{0};
   drBlockObject* owner_{nullptr};

--- a/src/drt/src/db/drObj/drVia.cpp
+++ b/src/drt/src/db/drObj/drVia.cpp
@@ -9,6 +9,7 @@
 #include "db/obj/frVia.h"
 #include "distributed/frArchive.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -22,7 +23,7 @@ drVia::drVia(const frVia& in)
 {
 }
 
-Rect drVia::getBBox() const
+odb::Rect drVia::getBBox() const
 {
   auto& layer1Figs = viaDef_->getLayer1Figs();
   auto& layer2Figs = viaDef_->getLayer2Figs();
@@ -33,7 +34,7 @@ Rect drVia::getBBox() const
   frCoord xh = 0;
   frCoord yh = 0;
   for (auto& fig : layer1Figs) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     if (isFirst) {
       xl = box.xMin();
       yl = box.yMin();
@@ -48,7 +49,7 @@ Rect drVia::getBBox() const
     }
   }
   for (auto& fig : layer2Figs) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     if (isFirst) {
       xl = box.xMin();
       yl = box.yMin();
@@ -63,7 +64,7 @@ Rect drVia::getBBox() const
     }
   }
   for (auto& fig : cutFigs) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     if (isFirst) {
       xl = box.xMin();
       yl = box.yMin();
@@ -77,7 +78,7 @@ Rect drVia::getBBox() const
       yh = std::max(yh, box.yMax());
     }
   }
-  Rect box(xl, yl, xh, yh);
+  odb::Rect box(xl, yl, xh, yh);
   getTransform().apply(box);
   return box;
 }

--- a/src/drt/src/db/drObj/drVia.h
+++ b/src/drt/src/db/drObj/drVia.h
@@ -10,6 +10,7 @@
 #include "db/tech/frViaDef.h"
 #include "dr/FlexMazeTypes.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -26,9 +27,9 @@ class drVia : public drRef
   drVia(const frVia& in);
   // getters
   const frViaDef* getViaDef() const { return viaDef_; }
-  Rect getLayer1BBox() const
+  odb::Rect getLayer1BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
@@ -36,9 +37,9 @@ class drVia : public drRef
     getTransform().apply(box);
     return box;
   }
-  Rect getCutBBox() const
+  odb::Rect getCutBBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
@@ -46,9 +47,9 @@ class drVia : public drRef
     getTransform().apply(box);
     return box;
   }
-  Rect getLayer2BBox() const
+  odb::Rect getLayer2BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
@@ -120,7 +121,7 @@ class drVia : public drRef
    * overlaps
    */
 
-  Rect getBBox() const override;
+  odb::Rect getBBox() const override;
   bool hasMazeIdx() const { return (!beginMazeIdx_.empty()); }
   std::pair<FlexMazeIdx, FlexMazeIdx> getMazeIdx() const
   {

--- a/src/drt/src/db/gcObj/gcNet.h
+++ b/src/drt/src/db/gcObj/gcNet.h
@@ -15,6 +15,7 @@
 #include "db/obj/frInstBlockage.h"
 #include "db/obj/frNet.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -33,7 +34,9 @@ class gcNet : public gcBlockObject
   {
   }
   // setters
-  void addPolygon(const Rect& box, frLayerNum layerNum, bool isFixed = false)
+  void addPolygon(const odb::Rect& box,
+                  frLayerNum layerNum,
+                  bool isFixed = false)
   {
     gtl::rectangle_data<frCoord> rect(
         box.xMin(), box.yMin(), box.xMax(), box.yMax());
@@ -44,7 +47,9 @@ class gcNet : public gcBlockObject
       routePolygons_[layerNum] += rect;
     }
   }
-  void addRectangle(const Rect& box, frLayerNum layerNum, bool isFixed = false)
+  void addRectangle(const odb::Rect& box,
+                    frLayerNum layerNum,
+                    bool isFixed = false)
   {
     gtl::rectangle_data<frCoord> rect(
         box.xMin(), box.yMin(), box.xMax(), box.yMax());
@@ -171,23 +176,23 @@ class gcNet : public gcBlockObject
   {
     return getFrNet() && getFrNet()->getNondefaultRule();
   }
-  void addTaperedRect(const Rect& bx, int zIdx)
+  void addTaperedRect(const odb::Rect& bx, int zIdx)
   {
     taperedRects_[zIdx].push_back(bx);
   }
-  const std::vector<Rect>& getTaperedRects(int z) const
+  const std::vector<odb::Rect>& getTaperedRects(int z) const
   {
     return taperedRects_[z];
   }
-  void addNonTaperedRect(const Rect& bx, int zIdx)
+  void addNonTaperedRect(const odb::Rect& bx, int zIdx)
   {
     nonTaperedRects_[zIdx].push_back(bx);
   }
-  const std::vector<Rect>& getNonTaperedRects(int z) const
+  const std::vector<odb::Rect>& getNonTaperedRects(int z) const
   {
     return nonTaperedRects_[z];
   }
-  void addSpecialSpcRect(const Rect& bx,
+  void addSpecialSpcRect(const odb::Rect& bx,
                          frLayerNum lNum,
                          gcPin* pin,
                          gcNet* net)
@@ -241,8 +246,8 @@ class gcNet : public gcBlockObject
       routeRectangles_;  // only cut layer
   std::vector<std::vector<std::unique_ptr<gcPin>>> pins_;
   frBlockObject* owner_{nullptr};
-  std::vector<std::vector<Rect>> taperedRects_;     //(only routing layer)
-  std::vector<std::vector<Rect>> nonTaperedRects_;  //(only routing layer)
+  std::vector<std::vector<odb::Rect>> taperedRects_;     //(only routing layer)
+  std::vector<std::vector<odb::Rect>> nonTaperedRects_;  //(only routing layer)
   // A non-tapered rect within a tapered max rectangle still require nondefault
   // spacing. This list hold these rectangles
   std::vector<std::unique_ptr<gcRect>> specialSpacingRects_;

--- a/src/drt/src/db/gcObj/gcShape.h
+++ b/src/drt/src/db/gcObj/gcShape.h
@@ -9,6 +9,7 @@
 #include "boost/polygon/polygon.hpp"
 #include "db/gcObj/gcFig.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace gtl = boost::polygon;
 
@@ -258,7 +259,7 @@ class gcRect : public gtl::rectangle_data<frCoord>, public gcShape
     gtl::yl((*this), bp.y());
     gtl::yh((*this), ep.y());
   }
-  void setRect(const Rect& in)
+  void setRect(const odb::Rect& in)
   {
     gtl::xl((*this), in.xMin());
     gtl::xh((*this), in.xMax());
@@ -320,7 +321,7 @@ class gcRect : public gtl::rectangle_data<frCoord>, public gcShape
 
   void setTapered(bool t) { tapered_ = t; }
 
-  bool intersects(const Rect& bx)
+  bool intersects(const odb::Rect& bx)
   {
     return gtl::xl(*this) <= bx.xMax() && gtl::xh(*this) >= bx.xMin()
            && gtl::yl(*this) <= bx.yMax() && gtl::yh(*this) >= bx.yMin();

--- a/src/drt/src/db/grObj/grFig.h
+++ b/src/drt/src/db/grObj/grFig.h
@@ -8,13 +8,14 @@
 #include "db/grObj/grBlockObject.h"
 #include "db/infra/frBox.h"
 #include "db/obj/frBlockObject.h"
+#include "odb/geom.h"
 
 namespace drt {
 
 class grFig : public grBlockObject
 {
  public:
-  virtual Rect getBBox() const = 0;
+  virtual odb::Rect getBBox() const = 0;
 };
 
 class frNet;

--- a/src/drt/src/db/grObj/grNet.h
+++ b/src/drt/src/db/grObj/grNet.h
@@ -15,6 +15,7 @@
 #include "db/grObj/grVia.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -82,7 +83,7 @@ class grNet : public grBlockObject
   bool isModified() const { return modified_; }
   int getNumOverConGCells() const { return numOverConGCells_; }
   int getNumPinsIn() const { return numPinsIn_; }
-  Rect getPinBox() { return pinBox_; }
+  odb::Rect getPinBox() { return pinBox_; }
   bool isRipup() const { return ripup_; }
   int getNumReroutes() const { return numReroutes_; }
   bool isInQueue() const { return inQueue_; }
@@ -155,7 +156,7 @@ class grNet : public grBlockObject
   void setNumOverConGCell(int in) { numOverConGCells_ = in; }
   void setNumPinsIn(int in) { numPinsIn_ = in; }
   void setAllowRipup(bool in) { allowRipup_ = in; }
-  void setPinBox(const Rect& in) { pinBox_ = in; }
+  void setPinBox(const odb::Rect& in) { pinBox_ = in; }
   void setRipup(bool in) { ripup_ = in; }
   void addNumReroutes() { numReroutes_++; }
   void resetNumReroutes() { numReroutes_ = 0; }
@@ -207,7 +208,7 @@ class grNet : public grBlockObject
   int numOverConGCells_{0};
   int numPinsIn_{0};
   bool allowRipup_{true};
-  Rect pinBox_;
+  odb::Rect pinBox_;
   bool ripup_{false};
 
   int numReroutes_{0};

--- a/src/drt/src/db/grObj/grShape.h
+++ b/src/drt/src/db/grObj/grShape.h
@@ -9,6 +9,7 @@
 #include "db/grObj/grFig.h"
 #include "db/infra/frSegStyle.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -156,9 +157,9 @@ class grPathSeg : public grShape
    * getBBox
    */
   // needs to be updated
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
-    return Rect(begin_.x(), begin_.y(), end_.x(), end_.y());
+    return odb::Rect(begin_.x(), begin_.y(), end_.x(), end_.y());
   }
 
   void setIter(frListIter<std::unique_ptr<grShape>>& in) override

--- a/src/drt/src/db/grObj/grVia.h
+++ b/src/drt/src/db/grObj/grVia.h
@@ -9,6 +9,7 @@
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -120,7 +121,7 @@ class grVia : public grRef
    * overlaps
    */
 
-  Rect getBBox() const override { return Rect(origin_, origin_); }
+  odb::Rect getBBox() const override { return odb::Rect(origin_, origin_); }
 
   void setIter(frListIter<std::unique_ptr<grVia>>& in) { iter_ = in; }
   frListIter<std::unique_ptr<grVia>> getIter() const { return iter_; }

--- a/src/drt/src/db/infra/frBox.h
+++ b/src/drt/src/db/infra/frBox.h
@@ -11,14 +11,13 @@
 namespace drt {
 
 using odb::dbOrientType;
-using odb::Rect;
 
-class frBox3D : public Rect
+class frBox3D : public odb::Rect
 {
  public:
   frBox3D() = default;
   frBox3D(int llx, int lly, int urx, int ury, int zl, int zh)
-      : Rect(llx, lly, urx, ury), zl_(zl), zh_(zh)
+      : odb::Rect(llx, lly, urx, ury), zl_(zl), zh_(zh)
   {
   }
   frBox3D(const frBox3D& in) = default;
@@ -42,7 +41,7 @@ class frBox3D : public Rect
   template <class Archive>
   void serialize(Archive& ar, const unsigned int version)
   {
-    (ar) & boost::serialization::base_object<Rect>(*this);
+    (ar) & boost::serialization::base_object<odb::Rect>(*this);
     (ar) & zl_;
     (ar) & zh_;
   }

--- a/src/drt/src/db/obj/frBlock.h
+++ b/src/drt/src/db/obj/frBlock.h
@@ -22,6 +22,7 @@
 #include "db/obj/frTrackPattern.h"
 #include "frBaseTypes.h"
 #include "odb/db.h"
+#include "odb/geom.h"
 
 namespace drt {
 namespace io {
@@ -35,9 +36,9 @@ class frBlock : public frBlockObject
   frBlock(const frString& name) : name_(name) {}
   // getters
   frUInt4 getDBUPerUU() const { return dbUnit_; }
-  Rect getBBox() const
+  odb::Rect getBBox() const
   {
-    Rect box;
+    odb::Rect box;
     if (!boundaries_.empty()) {
       box = boundaries_.begin()->getBBox();
     }
@@ -46,14 +47,14 @@ class frBlock : public frBlockObject
     frCoord urx = box.xMax();
     frCoord ury = box.yMax();
     for (auto& boundary : boundaries_) {
-      Rect tmpBox = boundary.getBBox();
+      odb::Rect tmpBox = boundary.getBBox();
       llx = llx < tmpBox.xMin() ? llx : tmpBox.xMin();
       lly = lly < tmpBox.yMin() ? lly : tmpBox.yMin();
       urx = urx > tmpBox.xMax() ? urx : tmpBox.xMax();
       ury = ury > tmpBox.yMax() ? ury : tmpBox.yMax();
     }
     for (auto& inst : getInsts()) {
-      Rect tmpBox = inst->getBBox();
+      odb::Rect tmpBox = inst->getBBox();
       llx = llx < tmpBox.xMin() ? llx : tmpBox.xMin();
       lly = lly < tmpBox.yMin() ? lly : tmpBox.yMin();
       urx = urx > tmpBox.xMax() ? urx : tmpBox.xMax();
@@ -62,7 +63,7 @@ class frBlock : public frBlockObject
     for (auto& term : getTerms()) {
       for (auto& pin : term->getPins()) {
         for (auto& fig : pin->getFigs()) {
-          Rect tmpBox = fig->getBBox();
+          odb::Rect tmpBox = fig->getBBox();
           llx = llx < tmpBox.xMin() ? llx : tmpBox.xMin();
           lly = lly < tmpBox.yMin() ? lly : tmpBox.yMin();
           urx = urx > tmpBox.xMax() ? urx : tmpBox.xMax();
@@ -70,7 +71,7 @@ class frBlock : public frBlockObject
         }
       }
     }
-    return Rect(llx, lly, urx, ury);
+    return odb::Rect(llx, lly, urx, ury);
   }
   const std::vector<frBoundary>& getBoundaries() const { return boundaries_; }
   const std::vector<std::unique_ptr<frBlockage>>& getBlockages() const
@@ -183,10 +184,10 @@ class frBlock : public frBlockObject
   }
   frCoord getGCellSizeVertical() { return getGCellPatterns()[1].getSpacing(); }
   // idx must be legal
-  Rect getGCellBox(const Point& idx1) const
+  odb::Rect getGCellBox(const Point& idx1) const
   {
     Point idx(idx1);
-    Rect dieBox = getDieBox();
+    odb::Rect dieBox = getDieBox();
     auto& gp = getGCellPatterns();
     auto& xgp = gp[0];
     auto& ygp = gp[1];
@@ -220,11 +221,11 @@ class frBlock : public frBlockObject
     if (idx.y() >= (int) ygp.getCount() - 1) {
       yh = dieBox.yMax();
     }
-    return Rect(xl, yl, xh, yh);
+    return odb::Rect(xl, yl, xh, yh);
   }
   Point getGCellCenter(const Point& idx) const
   {
-    Rect dieBox = getDieBox();
+    odb::Rect dieBox = getDieBox();
     auto& gp = getGCellPatterns();
     auto& xgp = gp[0];
     auto& ygp = gp[1];
@@ -343,7 +344,7 @@ class frBlock : public frBlockObject
     name2snet_[in->getName()] = in.get();
     snets_.push_back(std::move(in));
   }
-  const Rect& getDieBox() const { return dieBox_; }
+  const odb::Rect& getDieBox() const { return dieBox_; }
   void setBoundaries(const std::vector<frBoundary>& in)
   {
     boundaries_ = in;
@@ -355,7 +356,7 @@ class frBlock : public frBlockObject
     frCoord urx = dieBox_.xMax();
     frCoord ury = dieBox_.yMax();
     for (auto& boundary : boundaries_) {
-      Rect tmpBox = boundary.getBBox();
+      odb::Rect tmpBox = boundary.getBBox();
       llx = std::min(llx, tmpBox.xMin());
       lly = std::min(lly, tmpBox.yMin());
       urx = std::max(urx, tmpBox.xMax());
@@ -423,7 +424,7 @@ class frBlock : public frBlockObject
 
   std::vector<std::unique_ptr<frNet>>
       fakeSNets_;  // 0 is floating VSS, 1 is floating VDD
-  Rect dieBox_;
+  odb::Rect dieBox_;
 
   frUInt4 upcoming_inst_id_{0};
   frUInt4 upcoming_term_id_{0};

--- a/src/drt/src/db/obj/frBoundary.h
+++ b/src/drt/src/db/obj/frBoundary.h
@@ -9,6 +9,7 @@
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frBoundary : public frFig
@@ -22,7 +23,7 @@ class frBoundary : public frFig
   // others
   frBlockObjectEnum typeId() const override { return frcBoundary; }
 
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     frCoord llx = 0;
     frCoord lly = 0;
@@ -48,7 +49,7 @@ class frBoundary : public frFig
       xform.apply(point);
     }
   }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
 
  protected:
   std::vector<Point> points_;

--- a/src/drt/src/db/obj/frFig.h
+++ b/src/drt/src/db/obj/frFig.h
@@ -8,17 +8,18 @@
 #include "db/infra/frBox.h"
 #include "db/obj/frBlockObject.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frFig : public frBlockObject
 {
  public:
   // getters
-  virtual Rect getBBox() const = 0;
+  virtual odb::Rect getBBox() const = 0;
   // setters
   // others
   virtual void move(const odb::dbTransform& xform) = 0;
-  virtual bool intersects(const Rect& box) const = 0;
+  virtual bool intersects(const odb::Rect& box) const = 0;
 
  protected:
   frFig() = default;

--- a/src/drt/src/db/obj/frGuide.h
+++ b/src/drt/src/db/obj/frGuide.h
@@ -10,6 +10,7 @@
 #include "db/obj/frFig.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -68,9 +69,9 @@ class frGuide : public frConnFig
    * intersects, incomplete
    */
   // needs to be updated
-  Rect getBBox() const override { return Rect(begin_, end_); }
+  odb::Rect getBBox() const override { return odb::Rect(begin_, end_); }
   void move(const odb::dbTransform& xform) override { ; }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
   void setIndexInOwner(const int& val) { index_in_owner_ = val; }
 
  private:

--- a/src/drt/src/db/obj/frInst.cpp
+++ b/src/drt/src/db/obj/frInst.cpp
@@ -6,19 +6,20 @@
 #include "db/obj/frBlock.h"
 #include "db/obj/frMaster.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 namespace drt {
 
-Rect frInst::getBBox() const
+odb::Rect frInst::getBBox() const
 {
-  Rect box = getMaster()->getBBox();
+  odb::Rect box = getMaster()->getBBox();
   odb::dbTransform xform = getDBTransform();
   xform.apply(box);
   return box;
 }
 
-Rect frInst::getBoundaryBBox() const
+odb::Rect frInst::getBoundaryBBox() const
 {
-  Rect box = getMaster()->getDieBox();
+  odb::Rect box = getMaster()->getDieBox();
   odb::dbTransform xform = getDBTransform();
   xform.apply(box);
   return box;

--- a/src/drt/src/db/obj/frInst.h
+++ b/src/drt/src/db/obj/frInst.h
@@ -13,6 +13,7 @@
 #include "db/obj/frRef.h"
 #include "frBaseTypes.h"
 #include "odb/db.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frBlock;
@@ -115,13 +116,13 @@ class frInst : public frRef
    * intersects
    */
 
-  Rect getBBox() const override;
+  odb::Rect getBBox() const override;
 
   void move(const odb::dbTransform& xform) override { ; }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
   // others
   odb::dbTransform getNoRotationTransform() const;
-  Rect getBoundaryBBox() const;
+  odb::Rect getBoundaryBBox() const;
 
   frInstTerm* getInstTerm(int index);
 

--- a/src/drt/src/db/obj/frInstTerm.cpp
+++ b/src/drt/src/db/obj/frInstTerm.cpp
@@ -8,6 +8,7 @@
 #include "db/obj/frInst.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -40,9 +41,9 @@ void frInstTerm::getShapes(std::vector<frRect>& outShapes) const
   }
 }
 
-Rect frInstTerm::getBBox() const
+odb::Rect frInstTerm::getBBox() const
 {
-  Rect bbox(term_->getBBox());
+  odb::Rect bbox(term_->getBBox());
   odb::dbTransform trans = getInst()->getDBTransform();
   trans.apply(bbox);
   return bbox;

--- a/src/drt/src/db/obj/frInstTerm.h
+++ b/src/drt/src/db/obj/frInstTerm.h
@@ -11,6 +11,7 @@
 #include "db/obj/frMTerm.h"
 #include "db/obj/frNet.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -43,7 +44,7 @@ class frInstTerm : public frBlockObject
   frAccessPoint* getAccessPoint(frCoord x, frCoord y, frLayerNum lNum);
   bool hasAccessPoint(frCoord x, frCoord y, frLayerNum lNum);
   void getShapes(std::vector<frRect>& outShapes) const;
-  Rect getBBox() const;
+  odb::Rect getBBox() const;
   void setIndexInOwner(int in) { index_in_owner_ = in; }
   int getIndexInOwner() const { return index_in_owner_; }
 

--- a/src/drt/src/db/obj/frMarker.cpp
+++ b/src/drt/src/db/obj/frMarker.cpp
@@ -10,6 +10,7 @@
 #include "distributed/frArchive.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -44,7 +45,7 @@ void frMarker::serialize(Archive& ar, const unsigned int version)
     while (sz--) {
       frBlockObject* obj;
       serializeBlockObject(ar, obj);
-      std::tuple<frLayerNum, Rect, bool> tup;
+      std::tuple<frLayerNum, odb::Rect, bool> tup;
       (ar) & tup;
       victims_.emplace_back(obj, tup);
     }
@@ -52,7 +53,7 @@ void frMarker::serialize(Archive& ar, const unsigned int version)
     while (sz--) {
       frBlockObject* obj;
       serializeBlockObject(ar, obj);
-      std::tuple<frLayerNum, Rect, bool> tup;
+      std::tuple<frLayerNum, odb::Rect, bool> tup;
       (ar) & tup;
       aggressors_.emplace_back(obj, tup);
     }

--- a/src/drt/src/db/obj/frMarker.h
+++ b/src/drt/src/db/obj/frMarker.h
@@ -34,7 +34,7 @@ class frMarker : public frFig
   // setters
   void setConstraint(frConstraint* constraintIn) { constraint_ = constraintIn; }
 
-  void setBBox(const Rect& bboxIn) { bbox_ = bboxIn; }
+  void setBBox(const odb::Rect& bboxIn) { bbox_ = bboxIn; }
 
   void setLayerNum(const frLayerNum& layerNumIn) { layerNum_ = layerNumIn; }
 
@@ -44,12 +44,12 @@ class frMarker : public frFig
 
   void addSrc(frBlockObject* srcIn) { srcs_.insert(srcIn); }
   void addAggressor(frBlockObject* obj,
-                    const std::tuple<frLayerNum, Rect, bool>& tupleIn)
+                    const std::tuple<frLayerNum, odb::Rect, bool>& tupleIn)
   {
     aggressors_.emplace_back(obj, tupleIn);
   }
   void addVictim(frBlockObject* obj,
-                 const std::tuple<frLayerNum, Rect, bool>& tupleIn)
+                 const std::tuple<frLayerNum, odb::Rect, bool>& tupleIn)
   {
     victims_.emplace_back(obj, tupleIn);
   }
@@ -61,20 +61,22 @@ class frMarker : public frFig
    * intersects in .cpp
    */
 
-  Rect getBBox() const override { return bbox_; }
+  odb::Rect getBBox() const override { return bbox_; }
   frLayerNum getLayerNum() const { return layerNum_; }
 
   const std::set<frBlockObject*>& getSrcs() const { return srcs_; }
 
   void setSrcs(const std::set<frBlockObject*>& srcs) { srcs_ = srcs; }
 
-  std::vector<std::pair<frBlockObject*, std::tuple<frLayerNum, Rect, bool>>>&
+  std::vector<
+      std::pair<frBlockObject*, std::tuple<frLayerNum, odb::Rect, bool>>>&
   getAggressors()
   {
     return aggressors_;
   }
 
-  std::vector<std::pair<frBlockObject*, std::tuple<frLayerNum, Rect, bool>>>&
+  std::vector<
+      std::pair<frBlockObject*, std::tuple<frLayerNum, odb::Rect, bool>>>&
   getVictims()
   {
     return victims_;
@@ -88,7 +90,7 @@ class frMarker : public frFig
 
   void move(const odb::dbTransform& xform) override {}
 
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
 
   // others
   frBlockObjectEnum typeId() const override { return frcMarker; }
@@ -100,12 +102,14 @@ class frMarker : public frFig
 
  private:
   frConstraint* constraint_{nullptr};
-  Rect bbox_;
+  odb::Rect bbox_;
   frLayerNum layerNum_{0};
   std::set<frBlockObject*> srcs_;
-  std::vector<std::pair<frBlockObject*, std::tuple<frLayerNum, Rect, bool>>>
+  std::vector<
+      std::pair<frBlockObject*, std::tuple<frLayerNum, odb::Rect, bool>>>
       victims_;  // obj, isFixed
-  std::vector<std::pair<frBlockObject*, std::tuple<frLayerNum, Rect, bool>>>
+  std::vector<
+      std::pair<frBlockObject*, std::tuple<frLayerNum, odb::Rect, bool>>>
       aggressors_;  // obj, isFixed
   frListIter<std::unique_ptr<frMarker>> iter_;
   bool vioHasDir_{false};

--- a/src/drt/src/db/obj/frMaster.h
+++ b/src/drt/src/db/obj/frMaster.h
@@ -14,6 +14,7 @@
 #include "db/obj/frBoundary.h"
 #include "db/obj/frMTerm.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 namespace io {
@@ -25,9 +26,9 @@ class frMaster : public frBlockObject
   // constructors
   frMaster(const frString& name) : name_(name) {}
   // getters
-  Rect getBBox() const
+  odb::Rect getBBox() const
   {
-    Rect box;
+    odb::Rect box;
     if (!boundaries_.empty()) {
       box = boundaries_.begin()->getBBox();
     }
@@ -36,7 +37,7 @@ class frMaster : public frBlockObject
     frCoord urx = box.xMax();
     frCoord ury = box.yMax();
     for (auto& boundary : boundaries_) {
-      Rect tmpBox = boundary.getBBox();
+      odb::Rect tmpBox = boundary.getBBox();
       llx = llx < tmpBox.xMin() ? llx : tmpBox.xMin();
       lly = lly < tmpBox.yMin() ? lly : tmpBox.yMin();
       urx = urx > tmpBox.xMax() ? urx : tmpBox.xMax();
@@ -45,7 +46,7 @@ class frMaster : public frBlockObject
     for (auto& term : getTerms()) {
       for (auto& pin : term->getPins()) {
         for (auto& fig : pin->getFigs()) {
-          Rect tmpBox = fig->getBBox();
+          odb::Rect tmpBox = fig->getBBox();
           llx = llx < tmpBox.xMin() ? llx : tmpBox.xMin();
           lly = lly < tmpBox.yMin() ? lly : tmpBox.yMin();
           urx = urx > tmpBox.xMax() ? urx : tmpBox.xMax();
@@ -53,9 +54,9 @@ class frMaster : public frBlockObject
         }
       }
     }
-    return Rect(llx, lly, urx, ury);
+    return odb::Rect(llx, lly, urx, ury);
   }
-  Rect getDieBox() const { return dieBox_; }
+  odb::Rect getDieBox() const { return dieBox_; }
   const std::vector<frBoundary>& getBoundaries() const { return boundaries_; }
   const std::vector<std::unique_ptr<frBlockage>>& getBlockages() const
   {
@@ -95,7 +96,7 @@ class frMaster : public frBlockObject
     frCoord urx = dieBox_.xMax();
     frCoord ury = dieBox_.yMax();
     for (auto& boundary : boundaries_) {
-      Rect tmpBox = boundary.getBBox();
+      odb::Rect tmpBox = boundary.getBBox();
       llx = std::min(llx, tmpBox.xMin());
       lly = std::min(lly, tmpBox.yMin());
       urx = std::max(urx, tmpBox.xMax());
@@ -121,7 +122,7 @@ class frMaster : public frBlockObject
   std::vector<std::unique_ptr<frMTerm>> terms_;
   std::vector<std::unique_ptr<frBlockage>> blockages_;
   std::vector<frBoundary> boundaries_;
-  Rect dieBox_;
+  odb::Rect dieBox_;
   frString name_;
   dbMasterType masterType_{dbMasterType::CORE};
 

--- a/src/drt/src/db/obj/frRPin.cpp
+++ b/src/drt/src/db/obj/frRPin.cpp
@@ -9,10 +9,11 @@
 #include "db/obj/frInstTerm.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
-Rect frRPin::getBBox()
+odb::Rect frRPin::getBBox()
 {
   Point pt;
 
@@ -33,7 +34,7 @@ Rect frRPin::getBBox()
       break;
   }
 
-  return Rect(pt.x(), pt.y(), pt.x(), pt.y());
+  return odb::Rect(pt.x(), pt.y(), pt.x(), pt.y());
 }
 
 frLayerNum frRPin::getLayerNum()

--- a/src/drt/src/db/obj/frRPin.h
+++ b/src/drt/src/db/obj/frRPin.h
@@ -6,6 +6,7 @@
 #include "db/infra/frBox.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -27,7 +28,7 @@ class frRPin : public frBlockObject
   frNet* getNet() const { return net_; }
 
   // utility
-  Rect getBBox();
+  odb::Rect getBBox();
   frLayerNum getLayerNum();
 
   // others

--- a/src/drt/src/db/obj/frShape.h
+++ b/src/drt/src/db/obj/frShape.h
@@ -85,7 +85,7 @@ class frRect : public frShape
   }
 
   // setters
-  void setBBox(const Rect& boxIn) { box_ = boxIn; }
+  void setBBox(const odb::Rect& boxIn) { box_ = boxIn; }
   // getters
   // others
   bool isHor() const
@@ -159,9 +159,9 @@ class frRect : public frShape
    * move, in .cpp
    * intersects in .cpp
    */
-  Rect getBBox() const override { return box_; }
+  odb::Rect getBBox() const override { return box_; }
   void move(const odb::dbTransform& xform) override { xform.apply(box_); }
-  bool intersects(const Rect& box) const override
+  bool intersects(const odb::Rect& box) const override
   {
     return getBBox().intersects(box);
   }
@@ -181,7 +181,7 @@ class frRect : public frShape
   void setBottom(frCoord v) { box_.set_ylo(v); }
 
  protected:
-  Rect box_;
+  odb::Rect box_;
   frLayerNum layer_{0};
   frListIter<std::unique_ptr<frShape>> iter_;
 
@@ -211,7 +211,7 @@ class frPatchWire : public frShape
   }
   frPatchWire(const drPatchWire& in);
   // setters
-  void setOffsetBox(const Rect& in) { offsetBox_ = in; }
+  void setOffsetBox(const odb::Rect& in) { offsetBox_ = in; }
   void setOrigin(const Point& in) { origin_ = in; }
   // getters
   // others
@@ -268,17 +268,17 @@ class frPatchWire : public frShape
    * move, in .cpp
    * intersects in .cpp
    */
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     odb::dbTransform xform(origin_);
-    Rect box = offsetBox_;
+    odb::Rect box = offsetBox_;
     xform.apply(box);
     return box;
   }
-  Rect getOffsetBox() const { return offsetBox_; }
+  odb::Rect getOffsetBox() const { return offsetBox_; }
   Point getOrigin() const { return origin_; }
   void move(const odb::dbTransform& xform) override {}
-  bool intersects(const Rect& box) const override
+  bool intersects(const odb::Rect& box) const override
   {
     return getBBox().intersects(box);
   }
@@ -293,7 +293,7 @@ class frPatchWire : public frShape
   }
 
  protected:
-  Rect offsetBox_;
+  odb::Rect offsetBox_;
   Point origin_;
   frLayerNum layer_{0};
   frListIter<std::unique_ptr<frShape>> iter_;
@@ -378,7 +378,7 @@ class frPolygon : public frShape
    * move, in .cpp
    * intersects, in .cpp
    */
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     frCoord llx = 0;
     frCoord lly = 0;
@@ -396,7 +396,7 @@ class frPolygon : public frShape
       urx = (urx > point.x()) ? urx : point.x();
       ury = (ury > point.y()) ? ury : point.y();
     }
-    return Rect(llx, lly, urx, ury);
+    return odb::Rect(llx, lly, urx, ury);
   }
   void move(const odb::dbTransform& xform) override
   {
@@ -404,7 +404,7 @@ class frPolygon : public frShape
       xform.apply(point);
     }
   }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
 
   void setIter(frListIter<std::unique_ptr<frShape>>& in) override
   {
@@ -564,7 +564,7 @@ class frPathSeg : public frShape
    * intersects, in .cpp
    */
   // needs to be updated
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     bool isHorizontal = true;
     if (begin_.x() == end_.x()) {
@@ -574,22 +574,22 @@ class frPathSeg : public frShape
     auto beginExt = style_.getBeginExt();
     auto endExt = style_.getEndExt();
     if (isHorizontal) {
-      return Rect(begin_.x() - beginExt,
-                  begin_.y() - width / 2,
-                  end_.x() + endExt,
-                  end_.y() + width / 2);
+      return odb::Rect(begin_.x() - beginExt,
+                       begin_.y() - width / 2,
+                       end_.x() + endExt,
+                       end_.y() + width / 2);
     }
-    return Rect(begin_.x() - width / 2,
-                begin_.y() - beginExt,
-                end_.x() + width / 2,
-                end_.y() + endExt);
+    return odb::Rect(begin_.x() - width / 2,
+                     begin_.y() - beginExt,
+                     end_.x() + width / 2,
+                     end_.y() + endExt);
   }
   void move(const odb::dbTransform& xform) override
   {
     xform.apply(begin_);
     xform.apply(end_);
   }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
 
   void setIter(frListIter<std::unique_ptr<frShape>>& in) override
   {

--- a/src/drt/src/db/obj/frTerm.h
+++ b/src/drt/src/db/obj/frTerm.h
@@ -10,6 +10,7 @@
 #include "db/obj/frBlockObject.h"
 #include "db/obj/frNet.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frTerm : public frBlockObject
@@ -38,7 +39,7 @@ class frTerm : public frBlockObject
   }
   // fills outShapes with copies of the pinFigs
   virtual void getShapes(std::vector<frRect>& outShapes) const = 0;
-  Rect getBBox() const { return bbox_; }
+  odb::Rect getBBox() const { return bbox_; }
 
  protected:
   // constructors
@@ -49,7 +50,7 @@ class frTerm : public frBlockObject
   dbSigType type_{dbSigType::SIGNAL};
   dbIoType direction_{dbIoType::INPUT};
   int index_in_owner_{0};
-  Rect bbox_;
+  odb::Rect bbox_;
 };
 
 }  // namespace drt

--- a/src/drt/src/db/obj/frVia.h
+++ b/src/drt/src/db/obj/frVia.h
@@ -10,6 +10,7 @@
 #include "db/obj/frShape.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -38,9 +39,9 @@ class frVia : public frRef
   frVia(const drVia& in);
   // getters
   const frViaDef* getViaDef() const { return viaDef_; }
-  Rect getLayer1BBox() const
+  odb::Rect getLayer1BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
@@ -48,9 +49,9 @@ class frVia : public frRef
     getTransform().apply(box);
     return box;
   }
-  Rect getCutBBox() const
+  odb::Rect getCutBBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
@@ -58,9 +59,9 @@ class frVia : public frRef
     getTransform().apply(box);
     return box;
   }
-  Rect getLayer2BBox() const
+  odb::Rect getLayer2BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
@@ -137,7 +138,7 @@ class frVia : public frRef
    * intersects
    */
 
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     auto& layer1Figs = viaDef_->getLayer1Figs();
     auto& layer2Figs = viaDef_->getLayer2Figs();
@@ -148,7 +149,7 @@ class frVia : public frRef
     frCoord xh = 0;
     frCoord yh = 0;
     for (auto& fig : layer1Figs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -163,7 +164,7 @@ class frVia : public frRef
       }
     }
     for (auto& fig : layer2Figs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -178,7 +179,7 @@ class frVia : public frRef
       }
     }
     for (auto& fig : cutFigs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -192,12 +193,12 @@ class frVia : public frRef
         yh = std::max(yh, box.yMax());
       }
     }
-    Rect box(xl, yl, xh, yh);
+    odb::Rect box(xl, yl, xh, yh);
     getTransform().apply(box);
     return box;
   }
   void move(const odb::dbTransform& xform) override { ; }
-  bool intersects(const Rect& box) const override { return false; }
+  bool intersects(const odb::Rect& box) const override { return false; }
 
   void setIter(frListIter<std::unique_ptr<frVia>>& in) { iter_ = in; }
   frListIter<std::unique_ptr<frVia>> getIter() const { return iter_; }

--- a/src/drt/src/db/taObj/taFig.h
+++ b/src/drt/src/db/taObj/taFig.h
@@ -8,14 +8,15 @@
 #include "db/infra/frBox.h"
 #include "db/taObj/taBlockObject.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 class taFig : public taBlockObject
 {
  public:
-  virtual Rect getBBox() const = 0;
+  virtual odb::Rect getBBox() const = 0;
   virtual void move(const odb::dbTransform& xform) = 0;
-  virtual bool overlaps(const Rect& box) const = 0;
+  virtual bool overlaps(const odb::Rect& box) const = 0;
 };
 
 class frNet;

--- a/src/drt/src/db/taObj/taShape.h
+++ b/src/drt/src/db/taObj/taShape.h
@@ -9,6 +9,7 @@
 #include "db/taObj/taFig.h"
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -121,7 +122,7 @@ class taPathSeg : public taShape
    * overlaps, in .cpp
    */
   // needs to be updated
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     bool isHorizontal = true;
     if (begin_.x() == end_.x()) {
@@ -131,22 +132,22 @@ class taPathSeg : public taShape
     auto beginExt = style_.getBeginExt();
     auto endExt = style_.getEndExt();
     if (isHorizontal) {
-      return Rect(begin_.x() - beginExt,
-                  begin_.y() - width / 2,
-                  end_.x() + endExt,
-                  end_.y() + width / 2);
+      return odb::Rect(begin_.x() - beginExt,
+                       begin_.y() - width / 2,
+                       end_.x() + endExt,
+                       end_.y() + width / 2);
     }
-    return Rect(begin_.x() - width / 2,
-                begin_.y() - beginExt,
-                end_.x() + width / 2,
-                end_.y() + endExt);
+    return odb::Rect(begin_.x() - width / 2,
+                     begin_.y() - beginExt,
+                     end_.x() + width / 2,
+                     end_.y() + endExt);
   }
   void move(const odb::dbTransform& xform) override
   {
     xform.apply(begin_);
     xform.apply(end_);
   }
-  bool overlaps(const Rect& box) const override { return false; }
+  bool overlaps(const odb::Rect& box) const override { return false; }
 
  protected:
   Point begin_;  // begin always smaller than end, assumed

--- a/src/drt/src/db/taObj/taVia.h
+++ b/src/drt/src/db/taObj/taVia.h
@@ -12,6 +12,7 @@
 #include "frBaseTypes.h"
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frNet;
@@ -36,9 +37,9 @@ class taVia : public taRef
   taVia(const frViaDef* in) : viaDef_(in) {}
   // getters
   const frViaDef* getViaDef() const { return viaDef_; }
-  Rect getLayer1BBox() const
+  odb::Rect getLayer1BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer1Figs()) {
       box.merge(fig->getBBox());
@@ -46,9 +47,9 @@ class taVia : public taRef
     getTransform().apply(box);
     return box;
   }
-  Rect getCutBBox() const
+  odb::Rect getCutBBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getCutFigs()) {
       box.merge(fig->getBBox());
@@ -56,9 +57,9 @@ class taVia : public taRef
     getTransform().apply(box);
     return box;
   }
-  Rect getLayer2BBox() const
+  odb::Rect getLayer2BBox() const
   {
-    Rect box;
+    odb::Rect box;
     box.mergeInit();
     for (auto& fig : viaDef_->getLayer2Figs()) {
       box.merge(fig->getBBox());
@@ -130,7 +131,7 @@ class taVia : public taRef
    * overlaps
    */
 
-  Rect getBBox() const override
+  odb::Rect getBBox() const override
   {
     auto& layer1Figs = viaDef_->getLayer1Figs();
     auto& layer2Figs = viaDef_->getLayer2Figs();
@@ -141,7 +142,7 @@ class taVia : public taRef
     frCoord xh = 0;
     frCoord yh = 0;
     for (auto& fig : layer1Figs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -156,7 +157,7 @@ class taVia : public taRef
       }
     }
     for (auto& fig : layer2Figs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -171,7 +172,7 @@ class taVia : public taRef
       }
     }
     for (auto& fig : cutFigs) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       if (isFirst) {
         xl = box.xMin();
         yl = box.yMin();
@@ -185,12 +186,12 @@ class taVia : public taRef
         yh = std::max(yh, box.yMax());
       }
     }
-    Rect box(xl, yl, xh, yh);
+    odb::Rect box(xl, yl, xh, yh);
     getTransform().apply(box);
     return box;
   }
   void move(const odb::dbTransform& xform) override { ; }
-  bool overlaps(const Rect& box) const override { return false; }
+  bool overlaps(const odb::Rect& box) const override { return false; }
 
  protected:
   Point origin_;

--- a/src/drt/src/db/tech/frViaDef.h
+++ b/src/drt/src/db/tech/frViaDef.h
@@ -168,19 +168,19 @@ class frViaDef
   // setters
   void addLayer1Fig(std::unique_ptr<frShape> figIn)
   {
-    Rect box = figIn->getBBox();
+    odb::Rect box = figIn->getBBox();
     layer1ShapeBox_.merge(box);
     layer1Figs_.push_back(std::move(figIn));
   }
   void addLayer2Fig(std::unique_ptr<frShape> figIn)
   {
-    Rect box = figIn->getBBox();
+    odb::Rect box = figIn->getBBox();
     layer2ShapeBox_.merge(box);
     layer2Figs_.push_back(std::move(figIn));
   }
   void addCutFig(std::unique_ptr<frShape> figIn)
   {
-    Rect box = figIn->getBBox();
+    odb::Rect box = figIn->getBBox();
     cutShapeBox_.merge(box);
     cutFigs_.push_back(std::move(figIn));
   }
@@ -188,10 +188,10 @@ class frViaDef
   void setCutClass(frLef58CutClass* in) { cutClass_ = in; }
   void setCutClassIdx(int in) { cutClassIdx_ = in; }
   void setAddedByRouter(bool in) { addedByRouter_ = in; }
-  const Rect& getLayer1ShapeBox() const { return layer1ShapeBox_; }
-  const Rect& getLayer2ShapeBox() const { return layer2ShapeBox_; }
-  const Rect& getCutShapeBox() const { return cutShapeBox_; }
-  const Rect& getShapeBox(frLayerNum lNum)
+  const odb::Rect& getLayer1ShapeBox() const { return layer1ShapeBox_; }
+  const odb::Rect& getLayer2ShapeBox() const { return layer2ShapeBox_; }
+  const odb::Rect& getCutShapeBox() const { return cutShapeBox_; }
+  const odb::Rect& getShapeBox(frLayerNum lNum)
   {
     if (lNum == getLayer1Num()) {
       return layer1ShapeBox_;
@@ -216,9 +216,9 @@ class frViaDef
   int cutClassIdx_{-1};
   bool addedByRouter_{false};
 
-  Rect layer1ShapeBox_;
-  Rect layer2ShapeBox_;
-  Rect cutShapeBox_;
+  odb::Rect layer1ShapeBox_;
+  odb::Rect layer2ShapeBox_;
+  odb::Rect cutShapeBox_;
 };
 struct frViaDefComp
 {

--- a/src/drt/src/db/tech/frViaRuleGenerate.h
+++ b/src/drt/src/db/tech/frViaRuleGenerate.h
@@ -7,6 +7,7 @@
 
 #include "db/infra/frBox.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 class frViaRuleGenerate
@@ -18,7 +19,7 @@ class frViaRuleGenerate
   const frString& getName() const { return name_; }
   bool getDefault() const { return isDefault_; }
   const Point& getLayer1Enc() const { return botEnc_; }
-  const Rect& getCutRect() const { return cutRect_; }
+  const odb::Rect& getCutRect() const { return cutRect_; }
   const Point& getCutSpacing() const { return cutSpacing_; }
   const Point& getLayer2Enc() const { return topEnc_; }
   frLayerNum getLayer1Num() const { return botLayerNum_; }
@@ -27,7 +28,7 @@ class frViaRuleGenerate
   // setters
   void setDefault(bool in) { isDefault_ = in; }
   void setLayer1Enc(const Point& in) { botEnc_ = in; }
-  void setCutRect(const Rect& in) { cutRect_ = in; }
+  void setCutRect(const odb::Rect& in) { cutRect_ = in; }
   void setCutSpacing(const Point& in) { cutSpacing_ = in; }
   void setLayer2Enc(const Point& in) { topEnc_ = in; }
   void setLayer1Num(frLayerNum in) { botLayerNum_ = in; }
@@ -38,7 +39,7 @@ class frViaRuleGenerate
   frString name_;
   bool isDefault_{false};
   Point botEnc_;
-  Rect cutRect_;
+  odb::Rect cutRect_;
   Point cutSpacing_;
   Point topEnc_;
   frLayerNum botLayerNum_{0};

--- a/src/drt/src/distributed/drUpdate.h
+++ b/src/drt/src/distributed/drUpdate.h
@@ -8,6 +8,7 @@
 #include "db/obj/frVia.h"
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 namespace drt {
 
 class frNet;
@@ -55,7 +56,7 @@ class drUpdate
   Point begin_;
   Point end_;
   frSegStyle style_;
-  Rect offsetBox_;
+  odb::Rect offsetBox_;
   frLayerNum layer_{0};
   bool bottomConnected_{false};
   bool topConnected_{false};

--- a/src/drt/src/dr/FlexDR.cpp
+++ b/src/drt/src/dr/FlexDR.cpp
@@ -216,7 +216,7 @@ int FlexDRWorker::main(frDesign* design)
     skipRouting_ = true;
   }
   if (debugSettings_->debugDumpDR
-      && (debugSettings_->box == Rect(-1, -1, -1, -1)
+      && (debugSettings_->box == odb::Rect(-1, -1, -1, -1)
           || routeBox_.intersects(debugSettings_->box))
       && !skipRouting_
       && (debugSettings_->iter == getDRIter()
@@ -380,7 +380,7 @@ void FlexDR::initGCell2BoundaryPin()
             int x2 = idx2.x();
             int y = idx1.y();
             for (auto x = x1; x <= x2; ++x) {
-              Rect gcellBox = topBlock->getGCellBox(Point(x, y));
+              odb::Rect gcellBox = topBlock->getGCellBox(Point(x, y));
               frCoord leftBound = gcellBox.xMin();
               frCoord rightBound = gcellBox.xMax();
               const bool hasLeftBound = bp.x() < leftBound;
@@ -399,7 +399,7 @@ void FlexDR::initGCell2BoundaryPin()
             int y1 = idx1.y();
             int y2 = idx2.y();
             for (auto y = y1; y <= y2; ++y) {
-              Rect gcellBox = topBlock->getGCellBox(Point(x, y));
+              odb::Rect gcellBox = topBlock->getGCellBox(Point(x, y));
               frCoord bottomBound = gcellBox.yMin();
               frCoord topBound = gcellBox.yMax();
               const bool hasBottomBound = bp.y() < bottomBound;
@@ -437,8 +437,8 @@ void FlexDR::init_halfViaEncArea()
       auto viaDef = getTech()->getLayer(i + 1)->getDefaultViaDef();
       if (viaDef) {
         frVia via(viaDef);
-        Rect layer1Box = via.getLayer1BBox();
-        Rect layer2Box = via.getLayer2BBox();
+        odb::Rect layer1Box = via.getLayer1BBox();
+        odb::Rect layer2Box = via.getLayer2BBox();
         auto layer1HalfArea = layer1Box.area() / 2;
         auto layer2HalfArea = layer2Box.area() / 2;
         halfViaEncArea.emplace_back(layer1HalfArea, layer2HalfArea);
@@ -525,7 +525,7 @@ frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>>
 FlexDR::initDR_mergeBoundaryPin(int startX,
                                 int startY,
                                 int size,
-                                const Rect& routeBox) const
+                                const odb::Rect& routeBox) const
 {
   frOrderedIdMap<frNet*, std::set<std::pair<Point, frLayerNum>>> bp;
   auto gCellPatterns = getDesign()->getTopBlock()->getGCellPatterns();
@@ -556,27 +556,27 @@ void FlexDR::getBatchInfo(int& batchStepX, int& batchStepY)
 std::unique_ptr<FlexDRWorker> FlexDR::createWorker(const int x_offset,
                                                    const int y_offset,
                                                    const SearchRepairArgs& args,
-                                                   const Rect& routeBoxIn)
+                                                   const odb::Rect& routeBoxIn)
 {
   auto worker = std::make_unique<FlexDRWorker>(
       &via_data_, getDesign(), logger_, router_cfg_);
-  Rect route_box(routeBoxIn);
-  if (route_box == Rect(0, 0, 0, 0)) {
+  odb::Rect route_box(routeBoxIn);
+  if (route_box == odb::Rect(0, 0, 0, 0)) {
     auto gCellPatterns = getDesign()->getTopBlock()->getGCellPatterns();
     auto& xgp = gCellPatterns.at(0);
     auto& ygp = gCellPatterns.at(1);
-    Rect routeBox1
+    odb::Rect routeBox1
         = getDesign()->getTopBlock()->getGCellBox(Point(x_offset, y_offset));
     const int max_i
         = std::min((int) xgp.getCount() - 1, x_offset + args.size - 1);
     const int max_j = std::min((int) ygp.getCount(), y_offset + args.size - 1);
-    Rect routeBox2
+    odb::Rect routeBox2
         = getDesign()->getTopBlock()->getGCellBox(Point(max_i, max_j));
     route_box.init(
         routeBox1.xMin(), routeBox1.yMin(), routeBox2.xMax(), routeBox2.yMax());
   }
-  Rect extBox;
-  Rect drcBox;
+  odb::Rect extBox;
+  odb::Rect drcBox;
   route_box.bloat(router_cfg_->MTSAFEDIST, extBox);
   route_box.bloat(router_cfg_->DRCSAFEDIST, drcBox);
   worker->setRouteBox(route_box);
@@ -806,9 +806,9 @@ void FlexDR::endWorkersBatch(
   workers_batch.clear();
 }
 
-Rect FlexDR::getDRVBBox(const Rect& drv_rect) const
+odb::Rect FlexDR::getDRVBBox(const odb::Rect& drv_rect) const
 {
-  Rect route_box = drv_rect;
+  odb::Rect route_box = drv_rect;
   auto min_idx = getDesign()->getTopBlock()->getGCellIdx(route_box.ll());
   auto max_idx = getDesign()->getTopBlock()->getGCellIdx(route_box.ur());
   return {min_idx, max_idx};
@@ -827,15 +827,15 @@ namespace stub_tiles {
  * the violations.
  * @returns a list of merged boxes.
  */
-std::vector<Rect> mergeBoxes(std::vector<Rect>& drv_boxes)
+std::vector<odb::Rect> mergeBoxes(std::vector<odb::Rect>& drv_boxes)
 {
-  std::vector<Rect> merge_boxes{drv_boxes};
+  std::vector<odb::Rect> merge_boxes{drv_boxes};
   bool merged;
   do {
     merged = false;
     for (auto it1 = merge_boxes.begin(); it1 != merge_boxes.end(); ++it1) {
       for (auto it2 = it1 + 1; it2 != merge_boxes.end(); ++it2) {
-        Rect merge_box = (*it1);
+        odb::Rect merge_box = (*it1);
         merge_box.merge((*it2));
         if (merge_box.dx() > 4 || merge_box.dy() > 4) {
           continue;
@@ -863,7 +863,7 @@ std::vector<Rect> mergeBoxes(std::vector<Rect>& drv_boxes)
  * rectangle.
  */
 bool hasOtherRect(const std::vector<std::vector<int>>& grid,
-                  const Rect& rect,
+                  const odb::Rect& rect,
                   const int rect_id)
 {
   return std::any_of(grid.begin() + rect.xMin(),
@@ -891,7 +891,7 @@ bool hasOtherRect(const std::vector<std::vector<int>>& grid,
  * @param dir The direction of the expansion (East, West, North, South).
  * @return The number of expanded gcells (less than or equal to max_expansion)
  */
-int expandBox(Rect& box,
+int expandBox(odb::Rect& box,
               const int id,
               const std::vector<std::vector<int>>& grid,
               const frDirEnum dir,
@@ -922,7 +922,7 @@ int expandBox(Rect& box,
       default:
         break;
     }
-    Rect expanded_box = {min_idx, max_idx};
+    odb::Rect expanded_box = {min_idx, max_idx};
     if (hasOtherRect(grid, expanded_box, id)) {
       return i - 1;
     }
@@ -932,7 +932,7 @@ int expandBox(Rect& box,
 }
 
 void populateGrid(std::vector<std::vector<int>>& grid,
-                  const Rect& box,
+                  const odb::Rect& box,
                   const int id)
 {
   for (auto x = box.xMin(); x <= box.xMax(); x++) {
@@ -971,7 +971,8 @@ struct Wavefront
  * way we try to balance the resulting boxes so that each DRV box optimally has
  * the same number of expanded boxes.
  */
-std::vector<std::set<Rect>> expandBoxes(std::vector<Rect>& merged_boxes)
+std::vector<std::set<odb::Rect>> expandBoxes(
+    std::vector<odb::Rect>& merged_boxes)
 {
   frUInt4 min_x_idx = std::numeric_limits<frUInt4>::max();
   frUInt4 min_y_idx = std::numeric_limits<frUInt4>::max();
@@ -994,7 +995,7 @@ std::vector<std::set<Rect>> expandBoxes(std::vector<Rect>& merged_boxes)
     populateGrid(grid, box, id++);
   }
 
-  std::vector<std::set<Rect>> expanded_boxes;
+  std::vector<std::set<odb::Rect>> expanded_boxes;
   std::priority_queue<Wavefront> expansions;
   // first we create route boxes centering the violations
   id = 0;
@@ -1053,21 +1054,21 @@ std::vector<std::set<Rect>> expandBoxes(std::vector<Rect>& merged_boxes)
  */
 std::vector<std::vector<int>> getWorkerBatchesBoxes(
     frDesign* design,
-    std::vector<std::set<Rect>>& expanded_boxes,
+    std::vector<std::set<odb::Rect>>& expanded_boxes,
     const frCoord bloating_dist)
 {
   if (expanded_boxes.empty()) {
     return {};
   }
-  std::vector<Rect> boxes_max;
+  std::vector<odb::Rect> boxes_max;
   int id = 0;
   for (auto& boxes : expanded_boxes) {
     bool first = true;
     for (auto& box : boxes) {
       auto min_idx = box.ll();
       auto max_idx = box.ur();
-      Rect rect(design->getTopBlock()->getGCellBox(min_idx).ll(),
-                design->getTopBlock()->getGCellBox(max_idx).ur());
+      odb::Rect rect(design->getTopBlock()->getGCellBox(min_idx).ll(),
+                     design->getTopBlock()->getGCellBox(max_idx).ur());
       rect.bloat(bloating_dist, rect);
       if (first) {
         boxes_max.emplace_back(rect);
@@ -1111,7 +1112,7 @@ void FlexDR::stubbornTilesFlow(const SearchRepairArgs& args,
   if (graphics_) {
     graphics_->startIter(iter_, router_cfg_);
   }
-  std::vector<Rect> drv_boxes;
+  std::vector<odb::Rect> drv_boxes;
   for (const auto& marker : getDesign()->getTopBlock()->getMarkers()) {
     auto box = marker->getBBox();
     drv_boxes.push_back(getDRVBBox(box));
@@ -1134,8 +1135,9 @@ void FlexDR::stubbornTilesFlow(const SearchRepairArgs& args,
       for (auto gcell_box : expanded_boxes[worker_id]) {
         auto min_idx = gcell_box.ll();
         auto max_idx = gcell_box.ur();
-        Rect route_box(getDesign()->getTopBlock()->getGCellBox(min_idx).ll(),
-                       getDesign()->getTopBlock()->getGCellBox(max_idx).ur());
+        odb::Rect route_box(
+            getDesign()->getTopBlock()->getGCellBox(min_idx).ll(),
+            getDesign()->getTopBlock()->getGCellBox(max_idx).ur());
         for (auto drc_cost : drc_costs) {
           for (auto marker_cost : marker_costs) {
             auto worker_args = args;
@@ -1539,7 +1541,8 @@ std::vector<FlexDR::SearchRepairArgs> strategy(const frUInt4 shapeCost,
   // clang-format on
 }
 
-void addRectToPolySet(gtl::polygon_90_set_data<frCoord>& polySet, Rect rect)
+void addRectToPolySet(gtl::polygon_90_set_data<frCoord>& polySet,
+                      odb::Rect rect)
 {
   gtl::polygon_90_data<frCoord> poly;
   std::vector<gtl::point_data<frCoord>> points;
@@ -1686,7 +1689,7 @@ void FlexDR::fixMaxSpacing()
       }
     }
   }
-  std::vector<Rect> lonely_vias_regions;
+  std::vector<odb::Rect> lonely_vias_regions;
   lonely_vias_regions.reserve(lonely_vias.size());
   for (const auto& via : lonely_vias) {
     // Create LEF58_MAXSPACING Markers for the lonely vias
@@ -1709,7 +1712,7 @@ void FlexDR::fixMaxSpacing()
     auto origin = via->getOrigin();
     auto block = getDesign()->getTopBlock();
     auto gcell_idx = block->getGCellIdx(origin);
-    Rect region, tmp_box;
+    odb::Rect region, tmp_box;
     tmp_box = block->getGCellBox({gcell_idx.x() - 1, gcell_idx.y() - 1});
     region.set_xlo(tmp_box.xMin());
     region.set_ylo(tmp_box.yMin());
@@ -1721,8 +1724,10 @@ void FlexDR::fixMaxSpacing()
   // merge intersecting regions
   std::sort(lonely_vias_regions.begin(),
             lonely_vias_regions.end(),
-            [](const Rect& a, const Rect& b) { return a.xMin() < b.xMin(); });
-  std::vector<Rect> merged_regions;
+            [](const odb::Rect& a, const odb::Rect& b) {
+              return a.xMin() < b.xMin();
+            });
+  std::vector<odb::Rect> merged_regions;
   for (const auto& region : lonely_vias_regions) {
     bool found = false;
     for (auto& merged_region : merged_regions) {
@@ -1743,8 +1748,8 @@ void FlexDR::fixMaxSpacing()
     auto route_box = merged_regions.at(i);
     auto worker = std::make_unique<FlexDRWorker>(
         &via_data_, design_, logger_, router_cfg_);
-    Rect ext_box;
-    Rect drc_box;
+    odb::Rect ext_box;
+    odb::Rect drc_box;
     route_box.bloat(router_cfg_->MTSAFEDIST, ext_box);
     route_box.bloat(router_cfg_->DRCSAFEDIST, drc_box);
     worker->setRouteBox(route_box);

--- a/src/drt/src/dr/FlexDR_conn.cpp
+++ b/src/drt/src/dr/FlexDR_conn.cpp
@@ -29,6 +29,7 @@
 #include "frProfileTask.h"
 #include "frRegionQuery.h"
 #include "io/io.h"
+#include "odb/geom.h"
 #include "triton_route/TritonRoute.h"
 #include "utl/exception.h"
 
@@ -59,7 +60,7 @@ void FlexDRConnectivityChecker::pin2epMap_helper(
 {
   auto regionQuery = getRegionQuery();
   frRegionQuery::Objects<frBlockObject> result;
-  Rect query_box(pt.x(), pt.y(), pt.x(), pt.y());
+  odb::Rect query_box(pt.x(), pt.y(), pt.x(), pt.y());
   regionQuery->query(query_box, lNum, result);
   for (auto& [bx, rqObj] : result) {
     switch (rqObj->typeId()) {
@@ -468,7 +469,7 @@ void FlexDRConnectivityChecker::finish(
       } else if (netRouteObjs[i]->typeId() == frcVia) {
         auto victimVia = static_cast<frVia*>(netRouteObjs[i]);
         // negative rule
-        Rect bbox = victimVia->getLayer1BBox();
+        odb::Rect bbox = victimVia->getLayer1BBox();
         addMarker(net, victimVia->getViaDef()->getLayer1Num(), bbox);
 
         frVia* via = static_cast<frVia*>(netRouteObjs[i]);
@@ -1148,7 +1149,7 @@ void FlexDRConnectivityChecker::merge_commit(
 }
 void FlexDRConnectivityChecker::addMarker(frNet* net,
                                           frLayerNum lNum,
-                                          const Rect& bbox)
+                                          const odb::Rect& bbox)
 {
   auto regionQuery = getRegionQuery();
   auto marker = std::make_unique<frMarker>();

--- a/src/drt/src/dr/FlexDR_conn.h
+++ b/src/drt/src/dr/FlexDR_conn.h
@@ -16,6 +16,7 @@
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "frRegionQuery.h"
+#include "odb/geom.h"
 
 namespace odb {
 class dbDatabase;
@@ -133,7 +134,7 @@ class FlexDRConnectivityChecker
                              const PathSegsByLayerAndTrackId& vertVictims,
                              const SpansByLayerAndTrackId& horzNewSegSpans,
                              const SpansByLayerAndTrackId& vertNewSegSpans);
-  void addMarker(frNet* net, frLayerNum lNum, const Rect& bbox);
+  void addMarker(frNet* net, frLayerNum lNum, const odb::Rect& bbox);
   void handleOverlaps_perform(NetRouteObjs& netRouteObjs,
                               const std::vector<int>& indices,
                               std::vector<int>& victims,

--- a/src/drt/src/dr/FlexDR_end.cpp
+++ b/src/drt/src/dr/FlexDR_end.cpp
@@ -362,7 +362,7 @@ void FlexDRWorker::endAddNets_merge(
     hasPatchMetal = false;
     bool skip = false;
     result.clear();
-    regionQuery->query(Rect(pt, pt), lNum, result);
+    regionQuery->query(odb::Rect(pt, pt), lNum, result);
     for (auto& [bx, obj] : result) {
       auto type = obj->typeId();
       if (type == frcInstTerm) {
@@ -392,7 +392,7 @@ void FlexDRWorker::endAddNets_merge(
     drObjs.clear();
     horzPathSegs.clear();
     vertPathSegs.clear();
-    regionQuery->queryDRObj(Rect(pt, pt), lNum, drObjs);
+    regionQuery->queryDRObj(odb::Rect(pt, pt), lNum, drObjs);
     for (auto& obj : drObjs) {
       if (obj->typeId() == frcPathSeg) {
         auto ps = static_cast<frPathSeg*>(obj);

--- a/src/drt/src/dr/FlexDR_graphics.cpp
+++ b/src/drt/src/dr/FlexDR_graphics.cpp
@@ -286,14 +286,14 @@ void FlexDRGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
       = checkDisplayControl(current_net_only_visible_);
   if (checkDisplayControl(routing_objs_visible_)) {
     if (drawWholeDesign_) {
-      Rect box = design_->getTopBlock()->getDieBox();
+      odb::Rect box = design_->getTopBlock()->getDieBox();
       frRegionQuery::Objects<frBlockObject> figs;
       design_->getRegionQuery()->queryDRObj(box, layerNum, figs);
       for (auto& fig : figs) {
         drawObj(fig.second, painter, layerNum);
       }
     } else if (worker_) {
-      Rect box;
+      odb::Rect box;
       worker_->getExtBox(box);
       std::vector<drConnFig*> figs;
       worker_->getWorkerRegionQuery().query(box, layerNum, figs);
@@ -311,7 +311,7 @@ void FlexDRGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
     painter.setBrush(layer, /* alpha */ 90);
     for (auto& rect : net_->getOrigGuides()) {
       if (rect.getLayerNum() == layerNum) {
-        Rect box = rect.getBBox();
+        odb::Rect box = rect.getBBox();
         painter.drawRect({box.xMin(), box.yMin(), box.xMax(), box.yMax()});
       }
     }
@@ -420,14 +420,14 @@ void FlexDRGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
   painter.setPen(gui::Painter::kGreen, /* cosmetic */ true);
   for (auto& marker : design_->getTopBlock()->getMarkers()) {
     if (marker->getLayerNum() == layerNum) {
-      Rect box = marker->getBBox();
+      odb::Rect box = marker->getBBox();
       drawMarker(box.xMin(), box.yMin(), box.xMax(), box.yMax(), painter);
     }
   }
   painter.setPen(gui::Painter::kYellow, /* cosmetic */ true);
   for (auto& marker : worker_->getGCWorker()->getMarkers()) {
     if (marker->getLayerNum() == layerNum) {
-      Rect box = marker->getBBox();
+      odb::Rect box = marker->getBBox();
       drawMarker(box.xMin(), box.yMin(), box.xMax(), box.yMax(), painter);
     }
   }
@@ -437,7 +437,7 @@ void FlexDRGraphics::drawObj(frBlockObject* fig,
                              gui::Painter& painter,
                              int layerNum)
 {
-  Rect box;
+  odb::Rect box;
   switch (fig->typeId()) {
     case frcPathSeg: {
       auto seg = (frPathSeg*) fig;
@@ -520,7 +520,7 @@ void FlexDRGraphics::show(bool checkStopConditions)
             && (!net_ || net_->getFrNet()->getName() != settings_->netName))) {
       return;
     }
-    const Rect& rBox = worker_->getRouteBox();
+    const odb::Rect& rBox = worker_->getRouteBox();
     if (settings_->box != odb::Rect(-1, -1, -1, -1)
         && !rBox.intersects(settings_->box)) {
       return;
@@ -566,7 +566,7 @@ void FlexDRGraphics::drawObjects(gui::Painter& painter)
   painter.setBrush(gui::Painter::kTransparent);
   painter.setPen(gui::Painter::kYellow, /* cosmetic */ true);
 
-  Rect box;
+  odb::Rect box;
   worker_->getRouteBox(box);
   painter.drawRect({box.xMin(), box.yMin(), box.xMax(), box.yMax()});
 
@@ -593,7 +593,7 @@ void FlexDRGraphics::startWorker(FlexDRWorker* worker)
   if (current_iter_ < settings_->iter) {
     return;
   }
-  const Rect& rBox = worker->getRouteBox();
+  const odb::Rect& rBox = worker->getRouteBox();
   if (settings_->box != odb::Rect(-1, -1, -1, -1)
       && !rBox.intersects(settings_->box)) {
     return;
@@ -608,7 +608,7 @@ void FlexDRGraphics::startWorker(FlexDRWorker* worker)
   points_by_layer_.resize(worker->getTech()->getLayers().size());
 
   if (settings_->netName.empty()) {
-    Rect box;
+    odb::Rect box;
     worker_->getExtBox(box);
     gui_->zoomTo({box.xMin(), box.yMin(), box.xMax(), box.yMax()});
     if (settings_->draw) {
@@ -686,7 +686,7 @@ void FlexDRGraphics::startNet(drNet* net)
   net_ = net;
   last_pt_layer_ = -1;
 
-  Rect box;
+  odb::Rect box;
   worker_->getExtBox(box);
   gui_->zoomTo({box.xMin(), box.yMin(), box.xMax(), box.yMax()});
   if (settings_->allowPause) {

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -293,8 +293,8 @@ void FlexDRWorker::initNetObjs(
       auto [bp, ep] = guide->getPoints();
       Point bpIdx = design_->getTopBlock()->getGCellIdx(bp);
       Point epIdx = design_->getTopBlock()->getGCellIdx(ep);
-      Rect bbox = design_->getTopBlock()->getGCellBox(bpIdx);
-      Rect ebox = design_->getTopBlock()->getGCellBox(epIdx);
+      odb::Rect bbox = design_->getTopBlock()->getGCellBox(bpIdx);
+      odb::Rect ebox = design_->getTopBlock()->getGCellBox(epIdx);
       frLayerNum bNum = guide->getBeginLayerNum();
       frLayerNum eNum = guide->getEndLayerNum();
       frRect rect;
@@ -308,7 +308,7 @@ void FlexDRWorker::initNetObjs(
   }
 }
 
-static bool segOnBorder(const Rect& routeBox,
+static bool segOnBorder(const odb::Rect& routeBox,
                         const Point& begin,
                         const Point& end)
 {
@@ -375,7 +375,7 @@ void dfs(const int start,
   }
 }
 
-frSquaredDistance getSqrdDist(const Rect& rect1, const Rect& rect2)
+frSquaredDistance getSqrdDist(const odb::Rect& rect1, const odb::Rect& rect2)
 {
   frSquaredDistance dist = gtl::square_euclidean_distance(
       gtl::rectangle_data<frCoord>(
@@ -480,8 +480,8 @@ void FlexDRWorker::initNets_initDR_helper(
     };
     Type type;
     int idx;
-    Rect rect;
-    Node(Type typeIn, int idxIn, Rect rectIn)
+    odb::Rect rect;
+    Node(Type typeIn, int idxIn, odb::Rect rectIn)
         : type(typeIn), idx(idxIn), rect(rectIn)
     {
     }
@@ -492,7 +492,7 @@ void FlexDRWorker::initNets_initDR_helper(
     nodes.emplace_back(Node::GUIDE, i, netGuides.at(i).getBBox());
   }
   for (int i = 0; i < netTerms.size(); i++) {
-    Rect rect;
+    odb::Rect rect;
     if (netTerms.at(i)->typeId() == frcInstTerm) {
       auto iterm = static_cast<frInstTerm*>(netTerms.at(i));
       rect = iterm->getBBox();
@@ -562,7 +562,7 @@ void FlexDRWorker::initNets_initDR_helper(
   std::vector<std::vector<std::pair<Point, frLayerNum>>> bounds(
       connectedComponents.size());
   for (int i = 0; i < netTerms.size(); i++) {
-    Rect rect;
+    odb::Rect rect;
     if (netTerms.at(i)->typeId() == frcInstTerm) {
       auto iterm = static_cast<frInstTerm*>(netTerms.at(i));
       rect = iterm->getBBox();
@@ -1370,14 +1370,14 @@ void FlexDRWorker::initNets_numPinsIn()
         }
         if (ap->getPinCost() == 0) {
           const Point pt = ap->getPoint();
-          allPins.emplace_back(Rect(pt, pt), pin.get());
+          allPins.emplace_back(odb::Rect(pt, pt), pin.get());
           hasPrefAP = true;
           break;
         }
       }
       if (!hasPrefAP && firstAP != nullptr) {
         const Point pt = firstAP->getPoint();
-        allPins.emplace_back(Rect(pt, pt), pin.get());
+        allPins.emplace_back(odb::Rect(pt, pt), pin.get());
       }
     }
   }
@@ -1411,7 +1411,7 @@ void FlexDRWorker::initNets_numPinsIn()
       y2 = std::max(y2, pt.getY());
     }
     if (x1 <= x2 && y1 <= y2) {
-      const Rect box = Rect(x1, y1, x2, y2);
+      const odb::Rect box = odb::Rect(x1, y1, x2, y2);
       allPins.clear();
       pinRegionQuery.query(bgi::intersects(box), back_inserter(allPins));
       net->setNumPinsIn(allPins.size());
@@ -1442,7 +1442,7 @@ void FlexDRWorker::initNets_boundaryArea()
 
         const Point bp = ap->getPoint();
         const frLayerNum lNum = ap->getBeginLayerNum();
-        const Rect queryBox = Rect(bp, bp);
+        const odb::Rect queryBox = odb::Rect(bp, bp);
         workerRegionQuery.query(queryBox, lNum, results);
         for (auto& [ignored, connFig] : results) {
           if (connFig->getNet() != net) {
@@ -2040,7 +2040,7 @@ void FlexDRWorker::initMazeCost_marker_route_queue_addHistoryCost(
   std::set<drNet*> vioNets;  // for self-violation, only add cost for one side
                              // (experiment with self cut spacing)
 
-  const Rect mBox = marker.getBBox();
+  const odb::Rect mBox = marker.getBBox();
   const auto lNum = marker.getLayerNum();
 
   std::vector<rq_box_value_t<drConnFig*>> results;
@@ -2059,7 +2059,7 @@ void FlexDRWorker::initMazeCost_marker_route_queue_addHistoryCost(
       // right of pathseg
       const frSegStyle segStyle = obj->getStyle();
       const frCoord width = segStyle.getWidth();
-      Rect bloatBox;
+      odb::Rect bloatBox;
       mBox.bloat(width, bloatBox);
       FlexMazeIdx mIdx1, mIdx2;
       gridGraph_.getIdxBox(mIdx1, mIdx2, bloatBox);
@@ -2112,7 +2112,7 @@ void FlexDRWorker::initMazeCost_marker_route_queue_addHistoryCost(
             }
             std::cout << "\n";
             // get violation bbox
-            const Rect bbox = marker.getBBox();
+            const odb::Rect bbox = marker.getBBox();
             const double dbu = getTech()->getDBUPerUU();
             std::cout << "    bbox = ( " << bbox.xMin() / dbu << ", "
                       << bbox.yMin() / dbu << " ) - ( " << bbox.xMax() / dbu
@@ -2187,7 +2187,7 @@ void FlexDRWorker::initMazeCost_marker_route_queue_addHistoryCost(
       }
       // add history cost
       // gridGraph_.getMazeIdx(objMIdx1, bp, lNum);
-      Rect patchBBox = obj->getBBox();
+      odb::Rect patchBBox = obj->getBBox();
       Point patchLL = patchBBox.ll();
       Point patchUR = patchBBox.ur();
       FlexMazeIdx startIdx, endIdx;
@@ -2640,7 +2640,7 @@ void FlexDRWorker::route_queue_update_queue(
 void FlexDRWorker::initMazeCost_guide_helper(drNet* net, const bool isAdd)
 {
   for (auto& rect : net->getOrigGuides()) {
-    const Rect box = rect.getBBox();
+    const odb::Rect box = rect.getBBox();
     const frLayerNum lNum = rect.getLayerNum();
     const frMIdx z = gridGraph_.getMazeZIdx(lNum);
     FlexMazeIdx mIdx1, mIdx2;
@@ -2839,7 +2839,7 @@ void FlexDRWorker::initMazeCost_terms(const std::set<frBlockObject*>& objs,
             }
             frMIdx zIdx;
             const frRect instPinRect(*rpinRect);
-            const Rect box = instPinRect.getBBox();
+            const odb::Rect box = instPinRect.getBBox();
 
             bool isRoutingLayer = true;
             if (getTech()->getLayer(layerNum)->getType()
@@ -2915,7 +2915,7 @@ void FlexDRWorker::initMazeCost_terms(const std::set<frBlockObject*>& objs,
             frMIdx zIdx;
             frRect instPinRect(*rpinRect);
             instPinRect.move(xform);
-            const Rect box = instPinRect.getBBox();
+            const odb::Rect box = instPinRect.getBBox();
 
             // add cost
             bool isRoutingLayer = true;
@@ -3128,7 +3128,7 @@ void FlexDRWorker::initMazeCost_minCut_helper(drNet* net, bool isAddPathCost)
 
       const auto l1Num = via->getViaDef()->getLayer1Num();
       const auto l1Fig = (via->getViaDef()->getLayer1Figs()[0].get());
-      Rect l1Box = l1Fig->getBBox();
+      odb::Rect l1Box = l1Fig->getBBox();
       xform.apply(l1Box);
       modMinimumcutCostVia(l1Box, gridGraph_.getMazeZIdx(l1Num), modType, true);
       modMinimumcutCostVia(
@@ -3136,7 +3136,7 @@ void FlexDRWorker::initMazeCost_minCut_helper(drNet* net, bool isAddPathCost)
 
       const auto l2Num = via->getViaDef()->getLayer2Num();
       const auto l2Fig = (via->getViaDef()->getLayer2Figs()[0].get());
-      Rect l2Box = l2Fig->getBBox();
+      odb::Rect l2Box = l2Fig->getBBox();
       xform.apply(l2Box);
       modMinimumcutCostVia(l2Box, gridGraph_.getMazeZIdx(l2Num), modType, true);
       modMinimumcutCostVia(

--- a/src/drt/src/dr/FlexDR_rq.cpp
+++ b/src/drt/src/dr/FlexDR_rq.cpp
@@ -13,6 +13,7 @@
 #include "frBaseTypes.h"
 #include "frRTree.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -53,7 +54,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
   if (connFig->typeId() == drcPathSeg || connFig->typeId() == frcRect
       || connFig->typeId() == drcPatchWire) {
     auto obj = static_cast<drShape*>(connFig);
-    Rect frb = obj->getBBox();
+    odb::Rect frb = obj->getBBox();
     impl_->shapes.at(obj->getLayerNum()).insert(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
@@ -61,7 +62,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getLayer1Num())
             .insert(std::make_pair(frb, via));
@@ -72,7 +73,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getLayer2Num())
             .insert(std::make_pair(frb, via));
@@ -83,7 +84,7 @@ void FlexDRWorkerRegionQuery::add(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getCutLayerNum())
             .insert(std::make_pair(frb, via));
@@ -103,7 +104,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
   if (connFig->typeId() == drcPathSeg || connFig->typeId() == frcRect
       || connFig->typeId() == drcPatchWire) {
     auto obj = static_cast<drShape*>(connFig);
-    Rect frb = obj->getBBox();
+    odb::Rect frb = obj->getBBox();
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
@@ -111,7 +112,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getLayer1Num())
             .push_back(std::make_pair(frb, via));
@@ -122,7 +123,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getLayer2Num())
             .push_back(std::make_pair(frb, via));
@@ -133,7 +134,7 @@ void FlexDRWorkerRegionQuery::Impl::add(
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getCutLayerNum())
             .push_back(std::make_pair(frb, via));
@@ -151,7 +152,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
   if (connFig->typeId() == drcPathSeg || connFig->typeId() == frcRect
       || connFig->typeId() == drcPatchWire) {
     auto obj = static_cast<drShape*>(connFig);
-    Rect frb = obj->getBBox();
+    odb::Rect frb = obj->getBBox();
     impl_->shapes.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == drcVia) {
     auto via = static_cast<drVia*>(connFig);
@@ -159,7 +160,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getLayer1Num())
             .remove(std::make_pair(frb, via));
@@ -170,7 +171,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getLayer2Num())
             .remove(std::make_pair(frb, via));
@@ -181,7 +182,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         impl_->shapes.at(via->getViaDef()->getCutLayerNum())
             .remove(std::make_pair(frb, via));
@@ -194,7 +195,7 @@ void FlexDRWorkerRegionQuery::remove(drConnFig* connFig)
   }
 }
 
-void FlexDRWorkerRegionQuery::query(const Rect& box,
+void FlexDRWorkerRegionQuery::query(const odb::Rect& box,
                                     const frLayerNum layerNum,
                                     std::vector<drConnFig*>& result) const
 {
@@ -207,7 +208,7 @@ void FlexDRWorkerRegionQuery::query(const Rect& box,
 }
 
 void FlexDRWorkerRegionQuery::query(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<rq_box_value_t<drConnFig*>>& result) const
 {

--- a/src/drt/src/dr/FlexGridGraph.cpp
+++ b/src/drt/src/dr/FlexGridGraph.cpp
@@ -16,6 +16,7 @@
 #include "dr/FlexDR.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
+#include "odb/geom.h"
 
 namespace drt {
 void FlexGridGraph::addAccessPointLocation(frLayerNum layer_num,
@@ -105,7 +106,7 @@ void FlexGridGraph::initGrids(const frLayerCoordTrackPatternMap& xMap,
 bool FlexGridGraph::outOfDieVia(frMIdx x,
                                 frMIdx y,
                                 frMIdx z,
-                                const Rect& dieBox)
+                                const odb::Rect& dieBox)
 {
   frLayerNum lNum = getLayerNum(z) + 1;
   if (lNum > getTech()->getTopLayerNum()) {
@@ -115,7 +116,7 @@ bool FlexGridGraph::outOfDieVia(frMIdx x,
   if (!via) {
     return true;
   }
-  Rect viaBox(via->getLayer1ShapeBox());
+  odb::Rect viaBox(via->getLayer1ShapeBox());
   viaBox.merge(via->getLayer2ShapeBox());
   viaBox.moveDelta(xCoords_[x], yCoords_[y]);
   return !dieBox.contains(viaBox);
@@ -126,7 +127,7 @@ bool FlexGridGraph::hasOutOfDieViol(frMIdx x, frMIdx y, frMIdx z)
   if (!getTech()->getLayer(lNum)->isUnidirectional()) {
     return false;
   }
-  Rect testBoxUp;
+  odb::Rect testBoxUp;
   if (lNum + 1 <= getTech()->getTopLayerNum()) {
     const frViaDef* via = getTech()->getLayer(lNum + 1)->getDefaultViaDef();
     if (via) {
@@ -138,7 +139,7 @@ bool FlexGridGraph::hasOutOfDieViol(frMIdx x, frMIdx y, frMIdx z)
       dieBox_.bloat(1, testBoxUp);
     }
   }
-  Rect testBoxDown;
+  odb::Rect testBoxDown;
   if (lNum - 1 >= getTech()->getBottomLayerNum()) {
     const frViaDef* via = getTech()->getLayer(lNum - 1)->getDefaultViaDef();
     if (via) {
@@ -200,7 +201,7 @@ void FlexGridGraph::initEdges(const frDesign* design,
                               frLayerCoordTrackPatternMap& xMap,
                               frLayerCoordTrackPatternMap& yMap,
                               const frLayerDirMap& zMap,
-                              const Rect& bbox,
+                              const odb::Rect& bbox,
                               bool initDR)
 {
   frMIdx xDim, yDim, zDim;
@@ -429,8 +430,8 @@ void FlexGridGraph::initEdges(const frDesign* design,
 
 // initialization: update grid graph topology, does not assign edge cost
 void FlexGridGraph::init(const frDesign* design,
-                         const Rect& routeBBox,
-                         const Rect& extBBox,
+                         const odb::Rect& routeBBox,
+                         const odb::Rect& extBBox,
                          frLayerCoordTrackPatternMap& xMap,
                          frLayerCoordTrackPatternMap& yMap,
                          bool initDR,
@@ -458,7 +459,7 @@ void FlexGridGraph::initTracks(
     frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
     frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
     frLayerDirMap& layerNum2PreRouteDir,
-    const Rect& bbox)
+    const odb::Rect& bbox)
 {
   for (auto& layer : getTech()->getLayers()) {
     if (layer->getType() != dbTechLayerType::ROUTING) {
@@ -532,7 +533,7 @@ void FlexGridGraph::print() const
   std::ofstream mazeLog(router_cfg_->OUT_MAZE_FILE.c_str());
   if (mazeLog.is_open()) {
     // print edges
-    Rect gridBBox;
+    odb::Rect gridBBox;
     getBBox(gridBBox);
     mazeLog << "printing Maze grid (" << gridBBox.xMin() << ", "
             << gridBBox.yMin() << ") -- (" << gridBBox.xMax() << ", "

--- a/src/drt/src/dr/FlexGridGraph.h
+++ b/src/drt/src/dr/FlexGridGraph.h
@@ -98,7 +98,7 @@ class FlexGridGraph
     return nodes_[getIdx(x, y, z)].hasGridCostUp;
   }
 
-  void getBBox(Rect& in) const
+  void getBBox(odb::Rect& in) const
   {
     if (!xCoords_.empty() && !yCoords_.empty()) {
       in.init(
@@ -178,7 +178,7 @@ class FlexGridGraph
 
   void getIdxBox(FlexMazeIdx& mIdx1,
                  FlexMazeIdx& mIdx2,
-                 const Rect& box,
+                 const odb::Rect& box,
                  getIdxBox_EnclosureType enclosureOption = uncertain) const
   {
     mIdx1.set(std::lower_bound(xCoords_.begin(), xCoords_.end(), box.xMin())
@@ -391,7 +391,7 @@ class FlexGridGraph
                    frMIdx y,
                    frMIdx z,
                    frDirEnum dir,
-                   const Rect& box,
+                   const odb::Rect& box,
                    bool initDR) const
   {
     bool sol = false;
@@ -416,7 +416,7 @@ class FlexGridGraph
                frMIdx y,
                frMIdx z,
                frDirEnum dir,
-               const Rect& box,
+               const odb::Rect& box,
                bool initDR)
   {
     bool sol = false;
@@ -895,8 +895,8 @@ class FlexGridGraph
   const frBox3D* getDstTaperBox() const { return dstTaperBox_; }
   // functions
   void init(const frDesign* design,
-            const Rect& routeBBox,
-            const Rect& extBBox,
+            const odb::Rect& routeBBox,
+            const odb::Rect& extBBox,
             frLayerCoordTrackPatternMap& xMap,
             frLayerCoordTrackPatternMap& yMap,
             bool initDR,
@@ -1060,7 +1060,7 @@ class FlexGridGraph
   frVector<frLayerNum> zCoords_;
   frVector<frCoord> zHeights_;  // accumulated Z diff
   std::vector<dbTechLayerDir> layerRouteDirections_;
-  Rect dieBox_;
+  odb::Rect dieBox_;
   frUInt4 ggDRCCost_ = 0;
   frUInt4 ggMarkerCost_ = 0;
   frUInt4 ggFixedShapeCost_ = 0;
@@ -1244,7 +1244,7 @@ class FlexGridGraph
                   frLayerCoordTrackPatternMap& horLoc2TrackPatterns,
                   frLayerCoordTrackPatternMap& vertLoc2TrackPatterns,
                   frLayerDirMap& layerNum2PreRouteDir,
-                  const Rect& bbox);
+                  const odb::Rect& bbox);
   void initGrids(const frLayerCoordTrackPatternMap& xMap,
                  const frLayerCoordTrackPatternMap& yMap,
                  const frLayerDirMap& zMap,
@@ -1253,7 +1253,7 @@ class FlexGridGraph
                  frLayerCoordTrackPatternMap& xMap,
                  frLayerCoordTrackPatternMap& yMap,
                  const frLayerDirMap& zMap,
-                 const Rect& bbox,
+                 const odb::Rect& bbox,
                  bool initDR);
   frCost getEstCost(const FlexMazeIdx& src,
                     const FlexMazeIdx& dstMazeIdx1,
@@ -1288,7 +1288,7 @@ class FlexGridGraph
       const std::map<frLayerNum, frTrackPattern*>& ySubMap) const;
 
  private:
-  bool outOfDieVia(frMIdx x, frMIdx y, frMIdx z, const Rect& dieBox);
+  bool outOfDieVia(frMIdx x, frMIdx y, frMIdx z, const odb::Rect& dieBox);
   bool hasOutOfDieViol(frMIdx x, frMIdx y, frMIdx z);
   bool isWorkerBorder(frMIdx v, bool isVert);
 

--- a/src/drt/src/frRTree.h
+++ b/src/drt/src/frRTree.h
@@ -18,7 +18,7 @@
 
 namespace bgi = boost::geometry::index;
 
-// Enable Point & Rect to be used with boost geometry
+// Enable Point & odb::Rect to be used with boost geometry
 BOOST_GEOMETRY_REGISTER_POINT_2D_GET_SET(odb::Point,
                                          drt::frCoord,
                                          cs::cartesian,
@@ -31,7 +31,7 @@ BOOST_GEOMETRY_REGISTER_BOX(odb::Rect, odb::Point, ll(), ur())
 
 namespace drt {
 
-template <typename T, typename Key = Rect>
+template <typename T, typename Key = odb::Rect>
 using RTree = bgi::rtree<std::pair<Key, T>, bgi::quadratic<16>>;
 
 }  // namespace drt

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -104,7 +104,7 @@ void frRegionQuery::Impl::add(frShape* shape,
                               ObjectsByLayer<frBlockObject>& allShapes)
 {
   if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     allShapes.at(shape->getLayerNum()).push_back(std::make_pair(frb, shape));
   } else {
     logger->error(DRT, 5, "Unsupported region query add.");
@@ -115,7 +115,7 @@ void frRegionQuery::addDRObj(frShape* shape)
 {
   if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect
       || shape->typeId() == frcPatchWire) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     impl_->drObjs.at(shape->getLayerNum()).insert(std::make_pair(frb, shape));
   } else {
     impl_->logger->error(DRT, 6, "Unsupported region query add.");
@@ -124,7 +124,7 @@ void frRegionQuery::addDRObj(frShape* shape)
 
 void frRegionQuery::addMarker(frMarker* in)
 {
-  Rect frb = in->getBBox();
+  odb::Rect frb = in->getBBox();
   impl_->markers.at(in->getLayerNum()).insert(std::make_pair(frb, in));
 }
 
@@ -133,7 +133,7 @@ void frRegionQuery::Impl::addDRObj(frShape* shape,
 {
   if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect
       || shape->typeId() == frcPatchWire) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     allShapes.at(shape->getLayerNum()).push_back(std::make_pair(frb, shape));
   } else {
     logger->error(DRT, 7, "Unsupported region query add.");
@@ -144,17 +144,17 @@ void frRegionQuery::removeDRObj(frShape* shape)
 {
   if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect
       || shape->typeId() == frcPatchWire) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     impl_->drObjs.at(shape->getLayerNum()).remove(std::make_pair(frb, shape));
   } else {
     impl_->logger->error(DRT, 31, "Unsupported region query add.");
   }
 }
 
-std::vector<std::pair<frBlockObject*, Rect>> frRegionQuery::getVias(
+std::vector<std::pair<frBlockObject*, odb::Rect>> frRegionQuery::getVias(
     frLayerNum layer_num)
 {
-  std::vector<std::pair<frBlockObject*, Rect>> result;
+  std::vector<std::pair<frBlockObject*, odb::Rect>> result;
   result.reserve(impl_->shapes.at(layer_num).size()
                  + impl_->drObjs.at(layer_num).size());
   for (auto [box, obj] : impl_->shapes.at(layer_num)) {
@@ -175,7 +175,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
       for (auto& pin : instTerm->getTerm()->getPins()) {
         for (auto& uFig : pin->getFigs()) {
           auto shape = uFig.get();
-          Rect frb = shape->getBBox();
+          odb::Rect frb = shape->getBBox();
           xform.apply(frb);
           impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
               .insert(std::make_pair(frb, instTerm));
@@ -191,7 +191,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
       for (auto& uFig : pin->getFigs()) {
         auto shape = uFig.get();
         if (shape->typeId() == frcRect) {
-          Rect frb = shape->getBBox();
+          odb::Rect frb = shape->getBBox();
           xform.apply(frb);
           impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
               .insert(std::make_pair(frb, instBlk));
@@ -216,7 +216,7 @@ void frRegionQuery::addBlockObj(frBlockObject* obj)
           polySet.get_rectangles(rects);
           // Store the rectangles with this blockage
           for (auto& rect : rects) {
-            Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
+            odb::Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
             impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
                 .insert(std::make_pair(box, instBlk));
           }
@@ -248,7 +248,7 @@ void frRegionQuery::removeBlockObj(frBlockObject* obj)
       for (auto& pin : instTerm->getTerm()->getPins()) {
         for (auto& uFig : pin->getFigs()) {
           auto shape = uFig.get();
-          Rect frb = shape->getBBox();
+          odb::Rect frb = shape->getBBox();
           xform.apply(frb);
           impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
               .remove(std::make_pair(frb, instTerm));
@@ -264,7 +264,7 @@ void frRegionQuery::removeBlockObj(frBlockObject* obj)
       for (auto& uFig : pin->getFigs()) {
         auto shape = uFig.get();
         if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-          Rect frb = shape->getBBox();
+          odb::Rect frb = shape->getBBox();
           xform.apply(frb);
           impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
               .remove(std::make_pair(frb, instBlk));
@@ -289,7 +289,7 @@ void frRegionQuery::removeBlockObj(frBlockObject* obj)
           polySet.get_rectangles(rects);
           // Store the rectangles with this blockage
           for (auto& rect : rects) {
-            Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
+            odb::Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
             impl_->shapes.at(static_cast<frShape*>(shape)->getLayerNum())
                 .remove(std::make_pair(box, instBlk));
           }
@@ -320,7 +320,7 @@ void frRegionQuery::addGRObj(grShape* shape)
 void frRegionQuery::Impl::addGRObj(grShape* shape)
 {
   if (shape->typeId() == grcPathSeg) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     grObjs.at(shape->getLayerNum()).insert(std::make_pair(frb, shape));
   } else {
     logger->error(DRT, 8, "Unsupported region query add.");
@@ -330,14 +330,14 @@ void frRegionQuery::Impl::addGRObj(grShape* shape)
 void frRegionQuery::Impl::addGRObj(grVia* via,
                                    ObjectsByLayer<grBlockObject>& allShapes)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   allShapes.at(via->getViaDef()->getCutLayerNum())
       .push_back(std::make_pair(frb, via));
 }
 
 void frRegionQuery::removeGRObj(grVia* via)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   impl_->grObjs.at(via->getViaDef()->getCutLayerNum())
       .remove(std::make_pair(frb, via));
 }
@@ -346,7 +346,7 @@ void frRegionQuery::Impl::addGRObj(grShape* shape,
                                    ObjectsByLayer<grBlockObject>& allShapes)
 {
   if (shape->typeId() == grcPathSeg) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     allShapes.at(shape->getLayerNum()).push_back(std::make_pair(frb, shape));
   } else {
     logger->error(DRT, 9, "Unsupported region query add.");
@@ -356,7 +356,7 @@ void frRegionQuery::Impl::addGRObj(grShape* shape,
 void frRegionQuery::removeGRObj(grShape* shape)
 {
   if (shape->typeId() == grcPathSeg) {
-    Rect frb = shape->getBBox();
+    odb::Rect frb = shape->getBBox();
     impl_->grObjs.at(shape->getLayerNum()).remove(std::make_pair(frb, shape));
   } else {
     impl_->logger->error(DRT, 10, "Unsupported region query add.");
@@ -365,7 +365,7 @@ void frRegionQuery::removeGRObj(grShape* shape)
 
 void frRegionQuery::removeMarker(frMarker* in)
 {
-  Rect frb = in->getBBox();
+  odb::Rect frb = in->getBBox();
   impl_->markers.at(in->getLayerNum()).remove(std::make_pair(frb, in));
 }
 
@@ -376,7 +376,7 @@ void frRegionQuery::Impl::add(frVia* via,
   for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
     auto shape = uShape.get();
     if (shape->typeId() == frcRect) {
-      Rect frb = shape->getBBox();
+      odb::Rect frb = shape->getBBox();
       xform.apply(frb);
       allShapes.at(via->getViaDef()->getLayer1Num())
           .push_back(std::make_pair(frb, via));
@@ -387,7 +387,7 @@ void frRegionQuery::Impl::add(frVia* via,
   for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
     auto shape = uShape.get();
     if (shape->typeId() == frcRect) {
-      Rect frb = shape->getBBox();
+      odb::Rect frb = shape->getBBox();
       xform.apply(frb);
       allShapes.at(via->getViaDef()->getLayer2Num())
           .push_back(std::make_pair(frb, via));
@@ -398,7 +398,7 @@ void frRegionQuery::Impl::add(frVia* via,
   for (auto& uShape : via->getViaDef()->getCutFigs()) {
     auto shape = uShape.get();
     if (shape->typeId() == frcRect) {
-      Rect frb = shape->getBBox();
+      odb::Rect frb = shape->getBBox();
       xform.apply(frb);
       allShapes.at(via->getViaDef()->getCutLayerNum())
           .push_back(std::make_pair(frb, via));
@@ -410,7 +410,7 @@ void frRegionQuery::Impl::add(frVia* via,
 
 void frRegionQuery::addDRObj(frVia* via)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   impl_->drObjs.at(via->getViaDef()->getCutLayerNum())
       .insert(std::make_pair(frb, via));
 }
@@ -418,21 +418,21 @@ void frRegionQuery::addDRObj(frVia* via)
 void frRegionQuery::Impl::addDRObj(frVia* via,
                                    ObjectsByLayer<frBlockObject>& allShapes)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   allShapes.at(via->getViaDef()->getCutLayerNum())
       .push_back(std::make_pair(frb, via));
 }
 
 void frRegionQuery::removeDRObj(frVia* via)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   impl_->drObjs.at(via->getViaDef()->getCutLayerNum())
       .remove(std::make_pair(frb, via));
 }
 
 void frRegionQuery::addGRObj(grVia* via)
 {
-  Rect frb = via->getBBox();
+  odb::Rect frb = via->getBBox();
   impl_->grObjs.at(via->getViaDef()->getCutLayerNum())
       .insert(std::make_pair(frb, via));
 }
@@ -446,7 +446,7 @@ void frRegionQuery::Impl::add(frInstTerm* instTerm,
     for (auto& uFig : pin->getFigs()) {
       auto shape = uFig.get();
       if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(static_cast<frShape*>(shape)->getLayerNum())
             .push_back(std::make_pair(frb, instTerm));
@@ -464,7 +464,7 @@ void frRegionQuery::Impl::add(frBTerm* term,
     for (auto& uFig : pin->getFigs()) {
       auto shape = uFig.get();
       if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         allShapes.at(static_cast<frShape*>(shape)->getLayerNum())
             .push_back(std::make_pair(frb, term));
       } else {
@@ -483,7 +483,7 @@ void frRegionQuery::Impl::add(frInstBlockage* instBlk,
   for (auto& uFig : pin->getFigs()) {
     auto shape = uFig.get();
     if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-      Rect frb = shape->getBBox();
+      odb::Rect frb = shape->getBBox();
       xform.apply(frb);
       allShapes.at(static_cast<frShape*>(shape)->getLayerNum())
           .push_back(std::make_pair(frb, instBlk));
@@ -508,7 +508,7 @@ void frRegionQuery::Impl::add(frInstBlockage* instBlk,
       polySet.get_rectangles(rects);
       // Store the rectangles with this blockage
       for (auto& rect : rects) {
-        Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
+        odb::Rect box(xl(rect), yl(rect), xh(rect), yh(rect));
         allShapes.at(static_cast<frShape*>(shape)->getLayerNum())
             .push_back(std::make_pair(box, instBlk));
       }
@@ -528,7 +528,7 @@ void frRegionQuery::Impl::add(frBlockage* blk,
   for (auto& uFig : pin->getFigs()) {
     auto shape = uFig.get();
     if (shape->typeId() == frcPathSeg || shape->typeId() == frcRect) {
-      Rect frb = shape->getBBox();
+      odb::Rect frb = shape->getBBox();
       allShapes.at(static_cast<frShape*>(shape)->getLayerNum())
           .push_back(std::make_pair(frb, blk));
     } else {
@@ -540,7 +540,7 @@ void frRegionQuery::Impl::add(frBlockage* blk,
 void frRegionQuery::Impl::addGuide(frGuide* guide,
                                    ObjectsByLayer<frGuide>& allShapes)
 {
-  Rect frb = guide->getBBox();
+  odb::Rect frb = guide->getBBox();
   for (int i = guide->getBeginLayerNum(); i <= guide->getEndLayerNum(); i++) {
     allShapes.at(i).push_back(std::make_pair(frb, guide));
   }
@@ -550,7 +550,7 @@ void frRegionQuery::Impl::addRPin(frRPin* rpin,
                                   ObjectsByLayer<frRPin>& allRPins)
 {
   frLayerNum layerNum = rpin->getLayerNum();
-  Rect frb = rpin->getBBox();
+  odb::Rect frb = rpin->getBBox();
   allRPins.at(layerNum).push_back(std::make_pair(frb, rpin));
 }
 
@@ -558,7 +558,7 @@ void frRegionQuery::Impl::addOrigGuide(frNet* net,
                                        const frRect& rect,
                                        ObjectsByLayer<frNet>& allShapes)
 {
-  Rect frb = rect.getBBox();
+  odb::Rect frb = rect.getBBox();
   allShapes.at(rect.getLayerNum()).push_back(std::make_pair(frb, net));
 }
 
@@ -570,28 +570,28 @@ void frRegionQuery::query(const box_t& boostb,
                                    back_inserter(result));
 }
 
-void frRegionQuery::query(const Rect& box,
+void frRegionQuery::query(const odb::Rect& box,
                           const frLayerNum layerNum,
                           Objects<frBlockObject>& result) const
 {
   impl_->shapes.at(layerNum).query(bgi::intersects(box), back_inserter(result));
 }
 
-void frRegionQuery::queryRPin(const Rect& box,
+void frRegionQuery::queryRPin(const odb::Rect& box,
                               const frLayerNum layerNum,
                               Objects<frRPin>& result) const
 {
   impl_->rpins.at(layerNum).query(bgi::intersects(box), back_inserter(result));
 }
 
-void frRegionQuery::queryGuide(const Rect& box,
+void frRegionQuery::queryGuide(const odb::Rect& box,
                                const frLayerNum layerNum,
                                Objects<frGuide>& result) const
 {
   impl_->guides.at(layerNum).query(bgi::intersects(box), back_inserter(result));
 }
 
-void frRegionQuery::queryGuide(const Rect& box,
+void frRegionQuery::queryGuide(const odb::Rect& box,
                                const frLayerNum layerNum,
                                std::vector<frGuide*>& result) const
 {
@@ -602,7 +602,7 @@ void frRegionQuery::queryGuide(const Rect& box,
   });
 }
 
-void frRegionQuery::queryGuide(const Rect& box,
+void frRegionQuery::queryGuide(const odb::Rect& box,
                                std::vector<frGuide*>& result) const
 {
   Objects<frGuide> temp;
@@ -614,7 +614,7 @@ void frRegionQuery::queryGuide(const Rect& box,
   });
 }
 
-void frRegionQuery::queryOrigGuide(const Rect& box,
+void frRegionQuery::queryOrigGuide(const odb::Rect& box,
                                    const frLayerNum layerNum,
                                    Objects<frNet>& result) const
 {
@@ -622,7 +622,7 @@ void frRegionQuery::queryOrigGuide(const Rect& box,
                                        back_inserter(result));
 }
 
-void frRegionQuery::queryGRPin(const Rect& box,
+void frRegionQuery::queryGRPin(const odb::Rect& box,
                                std::vector<frBlockObject*>& result) const
 {
   Objects<frBlockObject> temp;
@@ -640,14 +640,14 @@ void frRegionQuery::queryDRObj(const box_t& boostb,
                                    back_inserter(result));
 }
 
-void frRegionQuery::queryDRObj(const Rect& box,
+void frRegionQuery::queryDRObj(const odb::Rect& box,
                                const frLayerNum layerNum,
                                Objects<frBlockObject>& result) const
 {
   impl_->drObjs.at(layerNum).query(bgi::intersects(box), back_inserter(result));
 }
 
-void frRegionQuery::queryDRObj(const Rect& box,
+void frRegionQuery::queryDRObj(const odb::Rect& box,
                                const frLayerNum layerNum,
                                std::vector<frBlockObject*>& result) const
 {
@@ -658,7 +658,7 @@ void frRegionQuery::queryDRObj(const Rect& box,
   });
 }
 
-void frRegionQuery::queryDRObj(const Rect& box,
+void frRegionQuery::queryDRObj(const odb::Rect& box,
                                std::vector<frBlockObject*>& result) const
 {
   Objects<frBlockObject> temp;
@@ -670,7 +670,7 @@ void frRegionQuery::queryDRObj(const Rect& box,
   });
 }
 
-void frRegionQuery::queryGRObj(const Rect& box,
+void frRegionQuery::queryGRObj(const odb::Rect& box,
                                std::vector<grBlockObject*>& result) const
 {
   Objects<grBlockObject> temp;
@@ -682,7 +682,7 @@ void frRegionQuery::queryGRObj(const Rect& box,
   });
 }
 
-void frRegionQuery::queryMarker(const Rect& box,
+void frRegionQuery::queryMarker(const odb::Rect& box,
                                 const frLayerNum layerNum,
                                 std::vector<frMarker*>& result) const
 {
@@ -693,7 +693,7 @@ void frRegionQuery::queryMarker(const Rect& box,
   });
 }
 
-void frRegionQuery::queryMarker(const Rect& box,
+void frRegionQuery::queryMarker(const odb::Rect& box,
                                 std::vector<frMarker*>& result) const
 {
   Objects<frMarker> temp;
@@ -894,7 +894,7 @@ void frRegionQuery::Impl::initGRPin(
   grPins.clear();
   Objects<frBlockObject> allGRPins;
   for (auto& [obj, pt] : in) {
-    Rect frb(pt.x(), pt.y(), pt.x(), pt.y());
+    odb::Rect frb(pt.x(), pt.y(), pt.x(), pt.y());
     allGRPins.push_back(std::make_pair(frb, obj));
   }
   in.clear();

--- a/src/drt/src/frRegionQuery.h
+++ b/src/drt/src/frRegionQuery.h
@@ -9,15 +9,10 @@
 
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 #include "utl/Logger.h"
 
-namespace odb {
-class Point;
-class Rect;
-}  // namespace odb
-
 namespace drt {
-using odb::Rect;
 class frBlockObject;
 class frDesign;
 class frGuide;
@@ -58,41 +53,44 @@ class frRegionQuery
   void query(const box_t& boostb,
              frLayerNum layerNum,
              Objects<frBlockObject>& result) const;
-  void query(const Rect& box,
+  void query(const odb::Rect& box,
              frLayerNum layerNum,
              Objects<frBlockObject>& result) const;
-  void queryGuide(const Rect& box,
+  void queryGuide(const odb::Rect& box,
                   frLayerNum layerNum,
                   Objects<frGuide>& result) const;
-  void queryGuide(const Rect& box,
+  void queryGuide(const odb::Rect& box,
                   frLayerNum layerNum,
                   std::vector<frGuide*>& result) const;
-  void queryGuide(const Rect& box, std::vector<frGuide*>& result) const;
-  void queryOrigGuide(const Rect& box,
+  void queryGuide(const odb::Rect& box, std::vector<frGuide*>& result) const;
+  void queryOrigGuide(const odb::Rect& box,
                       frLayerNum layerNum,
                       Objects<frNet>& result) const;
-  void queryRPin(const Rect& box,
+  void queryRPin(const odb::Rect& box,
                  frLayerNum layerNum,
                  Objects<frRPin>& result) const;
-  void queryGRPin(const Rect& box, std::vector<frBlockObject*>& result) const;
+  void queryGRPin(const odb::Rect& box,
+                  std::vector<frBlockObject*>& result) const;
   void queryDRObj(const box_t& boostb,
                   frLayerNum layerNum,
                   Objects<frBlockObject>& result) const;
-  void queryDRObj(const Rect& box,
+  void queryDRObj(const odb::Rect& box,
                   frLayerNum layerNum,
                   Objects<frBlockObject>& result) const;
-  void queryDRObj(const Rect& box,
+  void queryDRObj(const odb::Rect& box,
                   frLayerNum layerNum,
                   std::vector<frBlockObject*>& result) const;
-  void queryDRObj(const Rect& box, std::vector<frBlockObject*>& result) const;
-  void queryGRObj(const Rect& box,
+  void queryDRObj(const odb::Rect& box,
+                  std::vector<frBlockObject*>& result) const;
+  void queryGRObj(const odb::Rect& box,
                   frLayerNum layerNum,
                   Objects<grBlockObject>& result) const;
-  void queryGRObj(const Rect& box, std::vector<grBlockObject*>& result) const;
-  void queryMarker(const Rect& box,
+  void queryGRObj(const odb::Rect& box,
+                  std::vector<grBlockObject*>& result) const;
+  void queryMarker(const odb::Rect& box,
                    frLayerNum layerNum,
                    std::vector<frMarker*>& result) const;
-  void queryMarker(const Rect& box, std::vector<frMarker*>& result) const;
+  void queryMarker(const odb::Rect& box, std::vector<frMarker*>& result) const;
 
   void clearGuides();
   void removeDRObj(frShape* shape);
@@ -122,7 +120,8 @@ class frRegionQuery
   std::unique_ptr<Impl> impl_;
 
   frRegionQuery();
-  std::vector<std::pair<frBlockObject*, Rect>> getVias(frLayerNum layer_num);
+  std::vector<std::pair<frBlockObject*, odb::Rect>> getVias(
+      frLayerNum layer_num);
 
   friend class FlexDR;
 };

--- a/src/drt/src/gc/FlexGC.cpp
+++ b/src/drt/src/gc/FlexGC.cpp
@@ -58,7 +58,7 @@ FlexGCWorker::Impl::Impl(frTechObject* techIn,
 
 void FlexGCWorker::Impl::addMarker(std::unique_ptr<frMarker> in)
 {
-  Rect bbox = in->getBBox();
+  odb::Rect bbox = in->getBBox();
   auto layerNum = in->getLayerNum();
   auto con = in->getConstraint();
   if (mapMarkers_.find({bbox, layerNum, con, in->getSrcs()})
@@ -104,12 +104,12 @@ void FlexGCWorker::initPA1()
   impl_->initPA1();
 }
 
-void FlexGCWorker::setExtBox(const Rect& in)
+void FlexGCWorker::setExtBox(const odb::Rect& in)
 {
   impl_->extBox_ = in;
 }
 
-void FlexGCWorker::setDrcBox(const Rect& in)
+void FlexGCWorker::setDrcBox(const odb::Rect& in)
 {
   impl_->drcBox_ = in;
 }

--- a/src/drt/src/gc/FlexGC.h
+++ b/src/drt/src/gc/FlexGC.h
@@ -33,8 +33,8 @@ class FlexGCWorker
                FlexDRWorker* drWorkerIn = nullptr);
   ~FlexGCWorker();
   // setters
-  void setExtBox(const Rect& in);
-  void setDrcBox(const Rect& in);
+  void setExtBox(const odb::Rect& in);
+  void setDrcBox(const odb::Rect& in);
   bool setTargetNet(frBlockObject* in);
   bool setTargetNet(drNet* in);
   gcNet* getTargetNet();
@@ -71,7 +71,7 @@ class FlexGCWorker
 };
 struct MarkerId
 {
-  Rect box;
+  odb::Rect box;
   frLayerNum lNum;
   frConstraint* con;
   std::set<frBlockObject*> srcs;

--- a/src/drt/src/gc/FlexGC_cut.cpp
+++ b/src/drt/src/gc/FlexGC_cut.cpp
@@ -330,10 +330,10 @@ void FlexGCWorker::Impl::checkLef58CutSpacingTbl_main(
     auto net1 = viaRect1->getNet();
     auto net2 = viaRect2->getNet();
     auto marker = std::make_unique<frMarker>();
-    Rect box(gtl::xl(markerRect),
-             gtl::yl(markerRect),
-             gtl::xh(markerRect),
-             gtl::yh(markerRect));
+    odb::Rect box(gtl::xl(markerRect),
+                  gtl::yl(markerRect),
+                  gtl::xh(markerRect),
+                  gtl::yh(markerRect));
     marker->setBBox(box);
     marker->setLayerNum(layerNum1);
     marker->setConstraint(con);
@@ -346,7 +346,7 @@ void FlexGCWorker::Impl::checkLef58CutSpacingTbl_main(
     marker->addVictim(
         net1->getOwner(),
         std::make_tuple(
-            layerNum1, Rect(llx, lly, urx, ury), viaRect1->isFixed()));
+            layerNum1, odb::Rect(llx, lly, urx, ury), viaRect1->isFixed()));
     marker->addSrc(net2->getOwner());
     llx = gtl::xl(*viaRect2);
     lly = gtl::yl(*viaRect2);
@@ -355,7 +355,7 @@ void FlexGCWorker::Impl::checkLef58CutSpacingTbl_main(
     marker->addAggressor(
         net2->getOwner(),
         std::make_tuple(
-            layerNum2, Rect(llx, lly, urx, ury), viaRect2->isFixed()));
+            layerNum2, odb::Rect(llx, lly, urx, ury), viaRect2->isFixed()));
     addMarker(std::move(marker));
   }
 }
@@ -457,8 +457,9 @@ void FlexGCWorker::Impl::checKeepOutZone_main(gcRect* rect,
     return;
   }
   auto dbRule = con->getODBRule();
-  Rect viaBox(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
-  Rect sideQueryBox(viaBox), endQueryBox(viaBox);
+  odb::Rect viaBox(
+      gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect sideQueryBox(viaBox), endQueryBox(viaBox);
   auto viaCutClass = layer->getCutClass(rect->width(), rect->length());
   if (viaCutClass == nullptr
       || viaCutClass->getName() != dbRule->getFirstCutClass()) {
@@ -524,10 +525,10 @@ void FlexGCWorker::Impl::checKeepOutZone_main(gcRect* rect,
     }
     gtl::rectangle_data<frCoord> markerRect(*rect);
     gtl::generalized_intersect(markerRect, *ptr);
-    Rect markerBox(gtl::xl(markerRect),
-                   gtl::yl(markerRect),
-                   gtl::xh(markerRect),
-                   gtl::yh(markerRect));
+    odb::Rect markerBox(gtl::xl(markerRect),
+                        gtl::yl(markerRect),
+                        gtl::xh(markerRect),
+                        gtl::yh(markerRect));
     auto marker = std::make_unique<frMarker>();
     marker->setBBox(markerBox);
     marker->setLayerNum(layer->getLayerNum());
@@ -599,7 +600,7 @@ void FlexGCWorker::Impl::checkMetalWidthViaTable_main(gcRect* rect)
     if (below_rect->isFixed() && above_rect->isFixed() && rect->isFixed()) {
       continue;
     }
-    Rect markerBox(
+    odb::Rect markerBox(
         gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
     auto net1 = above_rect->getNet();
     auto net2 = below_rect->getNet();
@@ -614,7 +615,7 @@ void FlexGCWorker::Impl::checkMetalWidthViaTable_main(gcRect* rect)
     frCoord ury = gtl::xh(*above_rect);
     marker->addAggressor(net1->getOwner(),
                          std::make_tuple(above_rect->getLayerNum(),
-                                         Rect(llx, lly, urx, ury),
+                                         odb::Rect(llx, lly, urx, ury),
                                          above_rect->isFixed()));
     marker->addSrc(net2->getOwner());
     llx = gtl::xl(*below_rect);
@@ -623,7 +624,7 @@ void FlexGCWorker::Impl::checkMetalWidthViaTable_main(gcRect* rect)
     ury = gtl::xh(*below_rect);
     marker->addAggressor(net2->getOwner(),
                          std::make_tuple(below_rect->getLayerNum(),
-                                         Rect(llx, lly, urx, ury),
+                                         odb::Rect(llx, lly, urx, ury),
                                          below_rect->isFixed()));
 
     marker->addSrc(rect->getNet()->getOwner());
@@ -705,10 +706,10 @@ void FlexGCWorker::Impl::checkLef58Enclosure_main(gcRect* viaRect,
       return;  // valid overhangs
     }
   }
-  Rect markerBox(gtl::xl(*viaRect),
-                 gtl::yl(*viaRect),
-                 gtl::xh(*viaRect),
-                 gtl::yh(*viaRect));
+  odb::Rect markerBox(gtl::xl(*viaRect),
+                      gtl::yl(*viaRect),
+                      gtl::xh(*viaRect),
+                      gtl::yh(*viaRect));
   auto net = viaRect->getNet();
   auto marker = std::make_unique<frMarker>();
   marker->setBBox(markerBox);
@@ -721,7 +722,7 @@ void FlexGCWorker::Impl::checkLef58Enclosure_main(gcRect* viaRect,
   frCoord ury = gtl::xh(*encRect);
   marker->addAggressor(net->getOwner(),
                        std::make_tuple(encRect->getLayerNum(),
-                                       Rect(llx, lly, urx, ury),
+                                       odb::Rect(llx, lly, urx, ury),
                                        encRect->isFixed()));
   llx = gtl::xl(*viaRect);
   lly = gtl::yl(*viaRect);
@@ -729,7 +730,7 @@ void FlexGCWorker::Impl::checkLef58Enclosure_main(gcRect* viaRect,
   ury = gtl::xh(*viaRect);
   marker->addVictim(net->getOwner(),
                     std::make_tuple(viaRect->getLayerNum(),
-                                    Rect(llx, lly, urx, ury),
+                                    odb::Rect(llx, lly, urx, ury),
                                     viaRect->isFixed()));
   marker->addSrc(net->getOwner());
   addMarker(std::move(marker));
@@ -856,10 +857,10 @@ void FlexGCWorker::Impl::checkCutSpacingTableOrthogonal_helper(
     // create violation
     gtl::rectangle_data<frCoord> marker_rect(prl_rect);
     gtl::generalized_intersect(marker_rect, *rect3);
-    Rect marker_box(gtl::xl(marker_rect),
-                    gtl::yl(marker_rect),
-                    gtl::xh(marker_rect),
-                    gtl::yh(marker_rect));
+    odb::Rect marker_box(gtl::xl(marker_rect),
+                         gtl::yl(marker_rect),
+                         gtl::xh(marker_rect),
+                         gtl::yh(marker_rect));
     auto net = rect3->getNet();
     auto marker = std::make_unique<frMarker>();
     marker->setBBox(marker_box);
@@ -875,10 +876,10 @@ void FlexGCWorker::Impl::checkCutSpacingTableOrthogonal_helper(
     frCoord urx = gtl::xh(*rect1);
     frCoord ury = gtl::xh(*rect1);
     net = rect1->getNet();
-    marker->addVictim(
-        net->getOwner(),
-        std::make_tuple(
-            rect1->getLayerNum(), Rect(llx, lly, urx, ury), rect1->isFixed()));
+    marker->addVictim(net->getOwner(),
+                      std::make_tuple(rect1->getLayerNum(),
+                                      odb::Rect(llx, lly, urx, ury),
+                                      rect1->isFixed()));
     marker->addSrc(net->getOwner());
 
     llx = gtl::xl(*rect2);
@@ -886,10 +887,10 @@ void FlexGCWorker::Impl::checkCutSpacingTableOrthogonal_helper(
     urx = gtl::xh(*rect2);
     ury = gtl::xh(*rect2);
     net = rect2->getNet();
-    marker->addVictim(
-        net->getOwner(),
-        std::make_tuple(
-            rect2->getLayerNum(), Rect(llx, lly, urx, ury), rect2->isFixed()));
+    marker->addVictim(net->getOwner(),
+                      std::make_tuple(rect2->getLayerNum(),
+                                      odb::Rect(llx, lly, urx, ury),
+                                      rect2->isFixed()));
     marker->addSrc(net->getOwner());
 
     addMarker(std::move(marker));

--- a/src/drt/src/gc/FlexGC_eol.cpp
+++ b/src/drt/src/gc/FlexGC_eol.cpp
@@ -15,6 +15,7 @@
 #include "frProfileTask.h"
 #include "gc/FlexGC_impl.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -543,10 +544,10 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_eol_hasEol_helper(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(constraint);
@@ -559,19 +560,19 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_eol_hasEol_helper(
       = std::max(edge1->getLowCorner()->x(), edge1->getHighCorner()->x());
   frCoord ury
       = std::max(edge1->getLowCorner()->y(), edge1->getHighCorner()->y());
-  marker->addVictim(
-      net1->getOwner(),
-      std::make_tuple(
-          edge1->getLayerNum(), Rect(llx, lly, urx, ury), edge1->isFixed()));
+  marker->addVictim(net1->getOwner(),
+                    std::make_tuple(edge1->getLayerNum(),
+                                    odb::Rect(llx, lly, urx, ury),
+                                    edge1->isFixed()));
   marker->addSrc(net2->getOwner());
   llx = std::min(edge2->getLowCorner()->x(), edge2->getHighCorner()->x());
   lly = std::min(edge2->getLowCorner()->y(), edge2->getHighCorner()->y());
   urx = std::max(edge2->getLowCorner()->x(), edge2->getHighCorner()->x());
   ury = std::max(edge2->getLowCorner()->y(), edge2->getHighCorner()->y());
-  marker->addAggressor(
-      net2->getOwner(),
-      std::make_tuple(
-          edge2->getLayerNum(), Rect(llx, lly, urx, ury), edge2->isFixed()));
+  marker->addAggressor(net2->getOwner(),
+                       std::make_tuple(edge2->getLayerNum(),
+                                       odb::Rect(llx, lly, urx, ury),
+                                       edge2->isFixed()));
   addMarker(std::move(marker));
 }
 
@@ -1002,10 +1003,10 @@ void FlexGCWorker::Impl::checkMetalEOLkeepout_helper(
   gtl::generalized_intersect(markerRect, rect2);
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(edge->getLayerNum());
   marker->setConstraint(constraint);
@@ -1014,12 +1015,12 @@ void FlexGCWorker::Impl::checkMetalEOLkeepout_helper(
   marker->addVictim(
       net1->getOwner(),
       std::make_tuple(
-          edge->getLayerNum(), Rect(llx, lly, urx, ury), edge->isFixed()));
+          edge->getLayerNum(), odb::Rect(llx, lly, urx, ury), edge->isFixed()));
   marker->addSrc(net2->getOwner());
-  marker->addAggressor(
-      net2->getOwner(),
-      std::make_tuple(
-          rect->getLayerNum(), Rect(llx2, lly2, urx2, ury2), rect->isFixed()));
+  marker->addAggressor(net2->getOwner(),
+                       std::make_tuple(rect->getLayerNum(),
+                                       odb::Rect(llx2, lly2, urx2, ury2),
+                                       rect->isFixed()));
   addMarker(std::move(marker));
 }
 void FlexGCWorker::Impl::checkMetalEOLkeepout_main(
@@ -1199,10 +1200,10 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_ext_helper(
   gtl::set_points(edgeRect, edge1->low(), edge1->high());
   gtl::generalized_intersect(markerRect, edgeRect);
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(edge1->getLayerNum());
   marker->setConstraint(constraint);
@@ -1215,19 +1216,19 @@ void FlexGCWorker::Impl::checkMetalEndOfLine_ext_helper(
       = std::max(edge1->getLowCorner()->x(), edge1->getHighCorner()->x());
   frCoord ury
       = std::max(edge1->getLowCorner()->y(), edge1->getHighCorner()->y());
-  marker->addVictim(
-      edge1->getNet()->getOwner(),
-      std::make_tuple(
-          edge1->getLayerNum(), Rect(llx, lly, urx, ury), edge1->isFixed()));
+  marker->addVictim(edge1->getNet()->getOwner(),
+                    std::make_tuple(edge1->getLayerNum(),
+                                    odb::Rect(llx, lly, urx, ury),
+                                    edge1->isFixed()));
   marker->addSrc(edge2->getNet()->getOwner());
   llx = std::min(edge2->getLowCorner()->x(), edge2->getHighCorner()->x());
   lly = std::min(edge2->getLowCorner()->y(), edge2->getHighCorner()->y());
   urx = std::max(edge2->getLowCorner()->x(), edge2->getHighCorner()->x());
   ury = std::max(edge2->getLowCorner()->y(), edge2->getHighCorner()->y());
-  marker->addAggressor(
-      edge2->getNet()->getOwner(),
-      std::make_tuple(
-          edge2->getLayerNum(), Rect(llx, lly, urx, ury), edge2->isFixed()));
+  marker->addAggressor(edge2->getNet()->getOwner(),
+                       std::make_tuple(edge2->getLayerNum(),
+                                       odb::Rect(llx, lly, urx, ury),
+                                       edge2->isFixed()));
   addMarker(std::move(marker));
 }
 

--- a/src/drt/src/gc/FlexGC_impl.h
+++ b/src/drt/src/gc/FlexGC_impl.h
@@ -46,7 +46,7 @@ class FlexGCWorkerRegionQuery
       frLayerNum layerNum,
       std::vector<std::pair<segment_t, gcSegment*>>& result) const;
   void queryPolygonEdge(
-      const Rect& box,
+      const odb::Rect& box,
       frLayerNum layerNum,
       std::vector<std::pair<segment_t, gcSegment*>>& result) const;
   void queryMaxRectangle(const box_t& box,
@@ -55,7 +55,7 @@ class FlexGCWorkerRegionQuery
   void querySpcRectangle(const box_t& box,
                          frLayerNum layerNum,
                          std::vector<rq_box_value_t<gcRect>>& result) const;
-  void queryMaxRectangle(const Rect& box,
+  void queryMaxRectangle(const odb::Rect& box,
                          frLayerNum layerNum,
                          std::vector<rq_box_value_t<gcRect*>>& result) const;
   void queryMaxRectangle(const gtl::rectangle_data<frCoord>& box,
@@ -111,7 +111,7 @@ class FlexGCWorker::Impl
   // getters
   frTechObject* getTech() const { return tech_; }
   FlexDRWorker* getDRWorker() const { return drWorker_; }
-  const Rect& getExtBox() const { return extBox_; }
+  const odb::Rect& getExtBox() const { return extBox_; }
   std::vector<std::unique_ptr<gcNet>>& getNets() { return nets_; }
   // others
   void init(const frDesign* design);
@@ -130,8 +130,8 @@ class FlexGCWorker::Impl
   RouterConfiguration* router_cfg_;
   FlexDRWorker* drWorker_;
 
-  Rect extBox_;
-  Rect drcBox_;
+  odb::Rect extBox_;
+  odb::Rect drcBox_;
 
   std::map<frBlockObject*, gcNet*> owner2nets_;  // no order is assumed
   std::vector<std::unique_ptr<gcNet>> nets_;
@@ -166,7 +166,7 @@ class FlexGCWorker::Impl
   // init
   gcNet* getNet(frBlockObject* obj);
   gcNet* getNet(frNet* net);
-  void initObj(const Rect& box,
+  void initObj(const odb::Rect& box,
                frLayerNum layerNum,
                frBlockObject* obj,
                bool isFixed);
@@ -272,11 +272,11 @@ class FlexGCWorker::Impl
                               gcRect* rect2,
                               frLef58ForbiddenSpcConstraint* con,
                               bool isH);
-  Rect checkForbiddenSpc_queryBox(gcRect* rect,
-                                  frCoord minSpc,
-                                  frCoord maxSpc,
-                                  bool isH,
-                                  bool right);
+  odb::Rect checkForbiddenSpc_queryBox(gcRect* rect,
+                                       frCoord minSpc,
+                                       frCoord maxSpc,
+                                       bool isH,
+                                       bool right);
   bool checkForbiddenSpc_twoedges(gcRect* rect,
                                   frLef58ForbiddenSpcConstraint* con,
                                   bool isH);
@@ -308,7 +308,7 @@ class FlexGCWorker::Impl
   void checkMetalShape_offGrid(gcPin* pin);
   void checkMetalShape_minEnclosedArea(gcPin* pin);
   void checkMetalShape_minStep(gcPin* pin);
-  void checkMetalShape_minStep_helper(const Rect& markerBox,
+  void checkMetalShape_minStep_helper(const odb::Rect& markerBox,
                                       frLayerNum layerNum,
                                       gcNet* net,
                                       frMinStepConstraint* con,
@@ -546,7 +546,7 @@ class FlexGCWorker::Impl
   void patchMetalShape_cornerSpacing();
 
   // utility
-  bool isCornerOverlap(gcCorner* corner, const Rect& box);
+  bool isCornerOverlap(gcCorner* corner, const odb::Rect& box);
   bool isCornerOverlap(gcCorner* corner,
                        const gtl::rectangle_data<frCoord>& rect);
   bool isOppositeDir(gcCorner* corner, gcSegment* seg);

--- a/src/drt/src/gc/FlexGC_inf.cpp
+++ b/src/drt/src/gc/FlexGC_inf.cpp
@@ -14,6 +14,7 @@
 #include "frBaseTypes.h"
 #include "frProfileTask.h"
 #include "gc/FlexGC_impl.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -89,10 +90,10 @@ void FlexGCWorker::Impl::checkOrthRectsMetSpcTblInf(
         gtl::rectangle_data<frCoord> markerRect(rect1);
         gtl::generalized_intersect(markerRect, rect2);
         auto marker = std::make_unique<frMarker>();
-        Rect box(gtl::xl(markerRect),
-                 gtl::yl(markerRect),
-                 gtl::xh(markerRect),
-                 gtl::yh(markerRect));
+        odb::Rect box(gtl::xl(markerRect),
+                      gtl::yl(markerRect),
+                      gtl::xh(markerRect),
+                      gtl::yh(markerRect));
         marker->setBBox(box);
         marker->setLayerNum(lNum);
         marker->setConstraint(
@@ -100,18 +101,18 @@ void FlexGCWorker::Impl::checkOrthRectsMetSpcTblInf(
         marker->addSrc(rects[i]->getNet()->getOwner());
         marker->addVictim(rects[i]->getNet()->getOwner(),
                           std::make_tuple(lNum,
-                                          Rect(gtl::xl(rect1),
-                                               gtl::yl(rect1),
-                                               gtl::xh(rect1),
-                                               gtl::yh(rect1)),
+                                          odb::Rect(gtl::xl(rect1),
+                                                    gtl::yl(rect1),
+                                                    gtl::xh(rect1),
+                                                    gtl::yh(rect1)),
                                           rects[i]->isFixed()));
         marker->addSrc(rects[j]->getNet()->getOwner());
         marker->addAggressor(rects[j]->getNet()->getOwner(),
                              std::make_tuple(lNum,
-                                             Rect(gtl::xl(rect2),
-                                                  gtl::yl(rect2),
-                                                  gtl::xh(rect2),
-                                                  gtl::yh(rect2)),
+                                             odb::Rect(gtl::xl(rect2),
+                                                       gtl::yl(rect2),
+                                                       gtl::xh(rect2),
+                                                       gtl::yh(rect2)),
                                              rects[j]->isFixed()));
         addMarker(std::move(marker));
       } else {

--- a/src/drt/src/gc/FlexGC_init.cpp
+++ b/src/drt/src/gc/FlexGC_init.cpp
@@ -26,6 +26,7 @@
 #include "gc/FlexGC_impl.h"
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -123,7 +124,7 @@ gcNet* FlexGCWorker::Impl::getNet(frNet* net)
   return it->second;
 }
 
-void FlexGCWorker::Impl::initObj(const Rect& box,
+void FlexGCWorker::Impl::initObj(const odb::Rect& box,
                                  frLayerNum layerNum,
                                  frBlockObject* obj,
                                  bool isFixed)
@@ -226,21 +227,21 @@ void FlexGCWorker::Impl::addPAObj(frConnFig* obj, frBlockObject* owner)
     layerNum = via->getViaDef()->getLayer1Num();
     odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       currNet->addPolygon(box, layerNum, false);
     }
     // push cut layer rect
     layerNum = via->getViaDef()->getCutLayerNum();
     for (auto& fig : via->getViaDef()->getCutFigs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       currNet->addRectangle(box, layerNum, false);
     }
     // push layer2 rect
     layerNum = via->getViaDef()->getLayer2Num();
     for (auto& fig : via->getViaDef()->getLayer2Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       currNet->addPolygon(box, layerNum, false);
     }
@@ -255,7 +256,7 @@ void addNonTaperedPatches(gcNet* gNet,
   for (auto& obj : figs) {
     if (obj->typeId() == drcPatchWire) {
       auto pwire = static_cast<drPatchWire*>(obj.get());
-      Rect box = pwire->getBBox();
+      odb::Rect box = pwire->getBBox();
       int z = pwire->getLayerNum() / 2 - 1;
       for (auto& nt : gNet->getNonTaperedRects(z)) {
         if (nt.intersects(box)) {
@@ -280,7 +281,7 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
   frLayerNum layerNum;
   if (obj->typeId() == drcPathSeg) {
     auto pathSeg = static_cast<drPathSeg*>(obj);
-    Rect box = pathSeg->getBBox();
+    odb::Rect box = pathSeg->getBBox();
     currNet->addPolygon(
         box, pathSeg->getLayerNum(), pathSeg->getNet()->isFixed());
     if (pathSeg->isTapered()) {
@@ -294,7 +295,7 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
     layerNum = via->getViaDef()->getLayer1Num();
     odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       if (via->isTapered()) {
         currNet->addTaperedRect(box, layerNum / 2 - 1);
@@ -307,14 +308,14 @@ gcNet* FlexGCWorker::Impl::initDRObj(drConnFig* obj, gcNet* currNet)
     // push cut layer rect
     layerNum = via->getViaDef()->getCutLayerNum();
     for (auto& fig : via->getViaDef()->getCutFigs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       currNet->addRectangle(box, layerNum, via->getNet()->isFixed());
     }
     // push layer2 rect
     layerNum = via->getViaDef()->getLayer2Num();
     for (auto& fig : via->getViaDef()->getLayer2Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       if (via->isTapered()) {
         currNet->addTaperedRect(box, layerNum / 2 - 1);
@@ -339,7 +340,7 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
   frLayerNum layerNum;
   if (obj->typeId() == frcPathSeg) {
     auto pathSeg = static_cast<frPathSeg*>(obj);
-    Rect box = pathSeg->getBBox();
+    odb::Rect box = pathSeg->getBBox();
     currNet->addPolygon(box, pathSeg->getLayerNum());
     if (pathSeg->isTapered()) {
       currNet->addTaperedRect(box, pathSeg->getLayerNum() / 2 - 1);
@@ -352,7 +353,7 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
     layerNum = via->getViaDef()->getLayer1Num();
     odb::dbTransform xform = via->getTransform();
     for (auto& fig : via->getViaDef()->getLayer1Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       if (via->isTapered()) {
         currNet->addTaperedRect(box, layerNum / 2 - 1);
@@ -365,14 +366,14 @@ gcNet* FlexGCWorker::Impl::initRouteObj(frBlockObject* obj, gcNet* currNet)
     // push cut layer rect
     layerNum = via->getViaDef()->getCutLayerNum();
     for (auto& fig : via->getViaDef()->getCutFigs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       currNet->addRectangle(box, layerNum);
     }
     // push layer2 rect
     layerNum = via->getViaDef()->getLayer2Num();
     for (auto& fig : via->getViaDef()->getLayer2Figs()) {
-      Rect box = fig->getBBox();
+      odb::Rect box = fig->getBBox();
       xform.apply(box);
       if (via->isTapered()) {
         currNet->addTaperedRect(box, layerNum / 2 - 1);
@@ -437,7 +438,7 @@ void FlexGCWorker::Impl::initNetsFromDesign(const frDesign* design)
   }
   for (const auto& [gNet, patches] : pwires) {
     for (auto pwire : patches) {
-      Rect box = pwire->getBBox();
+      odb::Rect box = pwire->getBBox();
       int z = pwire->getLayerNum() / 2 - 1;
       for (auto& nt : gNet->getNonTaperedRects(z)) {
         if (nt.intersects(box)) {

--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -20,13 +20,14 @@
 #include "frProfileTask.h"
 #include "gc/FlexGC_impl.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
 using polygon_t = bg::model::polygon<point_t>;
 using mpolygon_t = bg::model::multi_polygon<polygon_t>;
 
-bool FlexGCWorker::Impl::isCornerOverlap(gcCorner* corner, const Rect& box)
+bool FlexGCWorker::Impl::isCornerOverlap(gcCorner* corner, const odb::Rect& box)
 {
   frCoord cornerX = corner->getNextEdge()->low().x();
   frCoord cornerY = corner->getNextEdge()->low().y();
@@ -524,10 +525,10 @@ void FlexGCWorker::Impl::checkMetalSpacing_prl(
     }
   }
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   if (isSpcRange) {
@@ -539,18 +540,18 @@ void FlexGCWorker::Impl::checkMetalSpacing_prl(
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -748,10 +749,10 @@ void FlexGCWorker::Impl::checkMetalSpacing_short(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   if (net1 == net2) {
@@ -763,18 +764,18 @@ void FlexGCWorker::Impl::checkMetalSpacing_short(
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -1095,10 +1096,10 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
               gtl::rectangle_data<frCoord> markerRect(rect1);
               gtl::generalized_intersect(markerRect, rect2);
               auto marker = std::make_unique<frMarker>();
-              Rect box(gtl::xl(markerRect),
-                       gtl::yl(markerRect),
-                       gtl::xh(markerRect),
-                       gtl::yh(markerRect));
+              odb::Rect box(gtl::xl(markerRect),
+                            gtl::yl(markerRect),
+                            gtl::xh(markerRect),
+                            gtl::yh(markerRect));
               marker->setBBox(box);
               marker->setLayerNum(layerNum);
               marker->setConstraint(con);
@@ -1113,7 +1114,7 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
                                      edge->getHighCorner()->y());
               marker->addVictim(net1->getOwner(),
                                 std::make_tuple(edge->getLayerNum(),
-                                                Rect(llx, lly, urx, ury),
+                                                odb::Rect(llx, lly, urx, ury),
                                                 edge->isFixed()));
               marker->addSrc(net2->getOwner());
               llx = std::min(ptr->getLowCorner()->x(),
@@ -1124,10 +1125,11 @@ void FlexGCWorker::Impl::checkMetalSpacing_wrongDir(gcPin* pin, frLayer* layer)
                              ptr->getHighCorner()->x());
               ury = std::max(ptr->getLowCorner()->y(),
                              ptr->getHighCorner()->y());
-              marker->addAggressor(net2->getOwner(),
-                                   std::make_tuple(ptr->getLayerNum(),
-                                                   Rect(llx, lly, urx, ury),
-                                                   ptr->isFixed()));
+              marker->addAggressor(
+                  net2->getOwner(),
+                  std::make_tuple(ptr->getLayerNum(),
+                                  odb::Rect(llx, lly, urx, ury),
+                                  ptr->isFixed()));
               addMarker(std::move(marker));
             }
           }
@@ -1310,10 +1312,10 @@ void FlexGCWorker::Impl::checkMetalCornerSpacing_main(
 
       // real violation
       auto marker = std::make_unique<frMarker>();
-      Rect box(gtl::xl(markerRect),
-               gtl::yl(markerRect),
-               gtl::xh(markerRect),
-               gtl::yh(markerRect));
+      odb::Rect box(gtl::xl(markerRect),
+                    gtl::yl(markerRect),
+                    gtl::xh(markerRect),
+                    gtl::yh(markerRect));
       marker->setBBox(box);
       marker->setLayerNum(layerNum);
       marker->setConstraint(con);
@@ -1322,15 +1324,15 @@ void FlexGCWorker::Impl::checkMetalCornerSpacing_main(
           net->getOwner(),
           std::make_tuple(
               layerNum,
-              Rect(corner->x(), corner->y(), corner->x(), corner->y()),
+              odb::Rect(corner->x(), corner->y(), corner->x(), corner->y()),
               corner->isFixed()));
       marker->addSrc(rect->getNet()->getOwner());
       marker->addAggressor(rect->getNet()->getOwner(),
                            std::make_tuple(rect->getLayerNum(),
-                                           Rect(gtl::xl(*rect),
-                                                gtl::yl(*rect),
-                                                gtl::xh(*rect),
-                                                gtl::yh(*rect)),
+                                           odb::Rect(gtl::xl(*rect),
+                                                     gtl::yl(*rect),
+                                                     gtl::xh(*rect),
+                                                     gtl::yh(*rect)),
                                            rect->isFixed()));
       addMarker(std::move(marker));
       return;
@@ -1444,7 +1446,7 @@ void FlexGCWorker::Impl::checkWidthTableOrth_main(gcCorner* corner1,
   const frCoord horz_spc = con->getHorzSpc();
   const frCoord vert_spc = con->getVertSpc();
 
-  Rect marker_rect(corner1->x(), corner1->y(), corner2->x(), corner2->y());
+  odb::Rect marker_rect(corner1->x(), corner1->y(), corner2->x(), corner2->y());
   if (marker_rect.dx() >= horz_spc || marker_rect.dy() >= vert_spc) {
     return;
   }
@@ -1458,13 +1460,13 @@ void FlexGCWorker::Impl::checkWidthTableOrth_main(gcCorner* corner1,
       owner,
       std::make_tuple(
           layer_num,
-          Rect(corner1->x(), corner1->y(), corner1->x(), corner1->y()),
+          odb::Rect(corner1->x(), corner1->y(), corner1->x(), corner1->y()),
           corner1->isFixed()));
   marker->addAggressor(
       owner,
       std::make_tuple(
           layer_num,
-          Rect(corner2->x(), corner2->y(), corner2->x(), corner2->y()),
+          odb::Rect(corner2->x(), corner2->y(), corner2->x(), corner2->y()),
           corner2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -1480,10 +1482,10 @@ void FlexGCWorker::Impl::checkWidthTableOrth(gcCorner* corner)
   auto con = layer->getWidthTblOrthCon();
   const frCoord horz_spc = con->getHorzSpc();
   const frCoord vert_spc = con->getVertSpc();
-  Rect query_rect(corner->x() - horz_spc,
-                  corner->y() - vert_spc,
-                  corner->x() + horz_spc,
-                  corner->y() + vert_spc);
+  odb::Rect query_rect(corner->x() - horz_spc,
+                       corner->y() - vert_spc,
+                       corner->x() + horz_spc,
+                       corner->y() + vert_spc);
   std::vector<std::pair<segment_t, gcSegment*>> result;
   getWorkerRegionQuery().queryPolygonEdge(query_rect, layer_num, result);
   for (auto [_, edge] : result) {
@@ -1522,7 +1524,7 @@ void FlexGCWorker::Impl::checkMetalShape_minWidth(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(rect), gtl::yl(rect), gtl::xh(rect), gtl::yh(rect));
+  odb::Rect box(gtl::xl(rect), gtl::yl(rect), gtl::xh(rect), gtl::yh(rect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(getTech()->getLayer(layerNum)->getMinWidthConstraint());
@@ -1533,7 +1535,7 @@ void FlexGCWorker::Impl::checkMetalShape_minWidth(
 }
 
 void FlexGCWorker::Impl::checkMetalShape_minStep_helper(
-    const Rect& markerBox,
+    const odb::Rect& markerBox,
     frLayerNum layerNum,
     gcNet* net,
     frMinStepConstraint* con,
@@ -1634,7 +1636,7 @@ void FlexGCWorker::Impl::checkMetalShape_minArea(gcPin* pin,
   }
   gtl::rectangle_data<frCoord> bbox;
   gtl::extents(bbox, *pin->getPolygon());
-  Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
+  odb::Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
   if (!drWorker_->getDrcBox().contains(bbox2)) {
     return;
   }
@@ -1730,7 +1732,7 @@ void FlexGCWorker::Impl::checkMetalShape_lef58MinStep_noBetweenEol(
     ury = std::max(ury, startEdge->getNextEdge()->getNextEdge()->high().y());
 
     auto marker = std::make_unique<frMarker>();
-    Rect box(llx, lly, urx, ury);
+    odb::Rect box(llx, lly, urx, ury);
     marker->setBBox(box);
     marker->setLayerNum(layerNum);
     marker->setConstraint(con);
@@ -1819,7 +1821,7 @@ void FlexGCWorker::Impl::checkMetalShape_lef58MinStep_minAdjLength(
     joinSegmentCoords(prevEdge, llx, lly, urx, ury);
 
     auto marker = std::make_unique<frMarker>();
-    Rect box(llx, lly, urx, ury);
+    odb::Rect box(llx, lly, urx, ury);
     marker->setBBox(box);
     marker->setLayerNum(layerNum);
     marker->setConstraint(con);
@@ -1869,7 +1871,7 @@ void FlexGCWorker::Impl::checkMetalShape_minStep(gcPin* pin)
   frCoord lly = 0;
   frCoord urx = 0;
   frCoord ury = 0;
-  Rect markerBox;
+  odb::Rect markerBox;
   bool hasInsideCorner = false;
   bool hasOutsideCorner = false;
   auto minStepLength = con->getMinStepLength();
@@ -2001,10 +2003,10 @@ void FlexGCWorker::Impl::checkMetalShape_rectOnly(gcPin* pin)
       gtl::get_max_rectangles(maxRects, intersectionPolySet);
       for (auto& markerRect : maxRects) {
         auto marker = std::make_unique<frMarker>();
-        Rect box(gtl::xl(markerRect),
-                 gtl::yl(markerRect),
-                 gtl::xh(markerRect),
-                 gtl::yh(markerRect));
+        odb::Rect box(gtl::xl(markerRect),
+                      gtl::yl(markerRect),
+                      gtl::xh(markerRect),
+                      gtl::yh(markerRect));
         marker->setBBox(box);
         marker->setLayerNum(layerNum);
         marker->setConstraint(con);
@@ -2040,10 +2042,10 @@ void FlexGCWorker::Impl::checkMetalShape_offGrid(gcPin* pin)
         continue;
       }
       auto marker = std::make_unique<frMarker>();
-      Rect box(gtl::xl(markerRect),
-               gtl::yl(markerRect),
-               gtl::xh(markerRect),
-               gtl::yh(markerRect));
+      odb::Rect box(gtl::xl(markerRect),
+                    gtl::yl(markerRect),
+                    gtl::xh(markerRect),
+                    gtl::yh(markerRect));
       marker->setBBox(box);
       marker->setLayerNum(layerNum);
       marker->setConstraint(
@@ -2081,10 +2083,10 @@ void FlexGCWorker::Impl::checkMetalShape_minEnclosedArea(gcPin* pin)
           gtl::extents(markerRect, hole_poly);
 
           auto marker = std::make_unique<frMarker>();
-          Rect box(gtl::xl(markerRect),
-                   gtl::yl(markerRect),
-                   gtl::xh(markerRect),
-                   gtl::yh(markerRect));
+          odb::Rect box(gtl::xl(markerRect),
+                        gtl::yl(markerRect),
+                        gtl::xh(markerRect),
+                        gtl::yh(markerRect));
           marker->setBBox(box);
           marker->setLayerNum(layerNum);
           marker->setConstraint(con);
@@ -2141,7 +2143,7 @@ void FlexGCWorker::Impl::checkMetalShape_lef58Area(gcPin* pin)
 
     gtl::rectangle_data<frCoord> bbox;
     gtl::extents(bbox, *pin->getPolygon());
-    Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
+    odb::Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
     if (!drWorker_->getDrcBox().contains(bbox2)) {
       continue;
     }
@@ -2244,7 +2246,7 @@ bool FlexGCWorker::Impl::checkMetalShape_lef58Area_rectWidth(
 }
 
 namespace gc_patch {
-bool isPatchValid(drPatchWire* pwire, const Rect& boundary_box)
+bool isPatchValid(drPatchWire* pwire, const odb::Rect& boundary_box)
 {
   return pwire->getBBox().intersects(boundary_box)
          || boundary_box.intersects(pwire->getOrigin());
@@ -2273,7 +2275,7 @@ void FlexGCWorker::Impl::checkMetalShape_addPatch(gcPin* pin, int min_area)
   frCoord length = ceil((float) gapArea / chosenEdg->length()
                         / getTech()->getManufacturingGrid())
                    * getTech()->getManufacturingGrid();
-  Rect patchBx;
+  odb::Rect patchBx;
   Point offset;  // the lower left corner of the patch box
   if (prefDirIsVert) {
     patchBx.set_xlo(-chosenEdg->length() / 2);
@@ -2338,7 +2340,7 @@ void FlexGCWorker::Impl::checkMetalShape_patchOwner_helper(
     drPatchWire* patch,
     const std::vector<drNet*>* dr_nets)
 {
-  Rect patch_box = patch->getOffsetBox();
+  odb::Rect patch_box = patch->getOffsetBox();
   for (drNet* dr_net : *dr_nets) {
     // check if patch overlaps with some rect of dr_net
     if (patch_box.overlaps(dr_net->getPinBox())) {
@@ -2490,28 +2492,28 @@ void FlexGCWorker::Impl::checkCutSpacing_short(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(getTech()->getLayer(layerNum)->getShortConstraint());
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
 
   addMarker(std::move(marker));
@@ -2576,11 +2578,11 @@ void FlexGCWorker::Impl::checkCutSpacing_spc(
       workerRegionQuery.queryMaxRectangle(queryBox, secondLayerNum, result);
     }
     for (auto& [objBox, objPtr] : result) {
-      // TODO why isn't this auto-converted from Rect to box_t?
-      Rect queryRect(queryBox.min_corner().get<0>(),
-                     queryBox.min_corner().get<1>(),
-                     queryBox.max_corner().get<0>(),
-                     queryBox.max_corner().get<1>());
+      // TODO why isn't this auto-converted from odb::Rect to box_t?
+      odb::Rect queryRect(queryBox.min_corner().get<0>(),
+                          queryBox.min_corner().get<1>(),
+                          queryBox.max_corner().get<0>(),
+                          queryBox.max_corner().get<1>());
       if ((objPtr->getNet() == net1 || objPtr->getNet() == net2)
           && objBox.contains(queryRect)) {
         return;
@@ -2615,28 +2617,28 @@ void FlexGCWorker::Impl::checkCutSpacing_spc(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(con);
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -2685,28 +2687,28 @@ void FlexGCWorker::Impl::checkCutSpacing_spc_diff_layer(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(con);
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -2749,11 +2751,11 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_parallelOverlap(
     workerRegionQuery.queryMaxRectangle(queryBox, secondLayerNum, result);
   }
   for (auto& [objBox, objPtr] : result) {
-    // TODO why isn't this auto-converted from Rect to box_t?
-    Rect queryRect(queryBox.min_corner().get<0>(),
-                   queryBox.min_corner().get<1>(),
-                   queryBox.max_corner().get<0>(),
-                   queryBox.max_corner().get<1>());
+    // TODO why isn't this auto-converted from odb::Rect to box_t?
+    odb::Rect queryRect(queryBox.min_corner().get<0>(),
+                        queryBox.min_corner().get<1>(),
+                        queryBox.max_corner().get<0>(),
+                        queryBox.max_corner().get<1>());
     // skip if parallel overlap but shares the same above/below metal
     if ((objPtr->getNet() == net1 || objPtr->getNet() == net2)
         && objBox.contains(queryRect)) {
@@ -2780,28 +2782,28 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_parallelOverlap(
 
   auto marker = std::make_unique<frMarker>();
   auto layerNum = rect1->getLayerNum();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(con);
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -3065,28 +3067,28 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_adjCut(
   }
 
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(layerNum);
   marker->setConstraint(con);
   marker->addSrc(net1->getOwner());
   marker->addVictim(net1->getOwner(),
                     std::make_tuple(rect1->getLayerNum(),
-                                    Rect(gtl::xl(*rect1),
-                                         gtl::yl(*rect1),
-                                         gtl::xh(*rect1),
-                                         gtl::yh(*rect1)),
+                                    odb::Rect(gtl::xl(*rect1),
+                                              gtl::yl(*rect1),
+                                              gtl::xh(*rect1),
+                                              gtl::yh(*rect1)),
                                     rect1->isFixed()));
   marker->addSrc(net2->getOwner());
   marker->addAggressor(net2->getOwner(),
                        std::make_tuple(rect2->getLayerNum(),
-                                       Rect(gtl::xl(*rect2),
-                                            gtl::yl(*rect2),
-                                            gtl::xh(*rect2),
-                                            gtl::yh(*rect2)),
+                                       odb::Rect(gtl::xl(*rect2),
+                                                 gtl::yl(*rect2),
+                                                 gtl::xh(*rect2),
+                                                 gtl::yh(*rect2)),
                                        rect2->isFixed()));
   addMarker(std::move(marker));
 }
@@ -3228,27 +3230,27 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
         }
         // this should only happen between samenet
         auto marker = std::make_unique<frMarker>();
-        Rect box(gtl::xl(markerRect),
-                 gtl::yl(markerRect),
-                 gtl::xh(markerRect),
-                 gtl::yh(markerRect));
+        odb::Rect box(gtl::xl(markerRect),
+                      gtl::yl(markerRect),
+                      gtl::xh(markerRect),
+                      gtl::yh(markerRect));
         marker->setBBox(box);
         marker->setLayerNum(layerNum);
         marker->setConstraint(con);
         marker->addSrc(net1->getOwner());
         marker->addVictim(net1->getOwner(),
                           std::make_tuple(layerNum,
-                                          Rect(gtl::xl(*rect1),
-                                               gtl::yl(*rect1),
-                                               gtl::xh(*rect1),
-                                               gtl::yh(*rect1)),
+                                          odb::Rect(gtl::xl(*rect1),
+                                                    gtl::yl(*rect1),
+                                                    gtl::xh(*rect1),
+                                                    gtl::yh(*rect1)),
                                           rect1->isFixed()));
         marker->addSrc(net2->getOwner());
         marker->addAggressor(
             net2->getOwner(),
             std::make_tuple(
                 secondLayerNum,
-                Rect(corner->x(), corner->y(), corner->x(), corner->y()),
+                odb::Rect(corner->x(), corner->y(), corner->x(), corner->y()),
                 corner->isFixed()));
         addMarker(std::move(marker));
       }
@@ -3348,27 +3350,27 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
 
         // this should only happen between samenet
         auto marker = std::make_unique<frMarker>();
-        Rect box(gtl::xl(markerRect),
-                 gtl::yl(markerRect),
-                 gtl::xh(markerRect),
-                 gtl::yh(markerRect));
+        odb::Rect box(gtl::xl(markerRect),
+                      gtl::yl(markerRect),
+                      gtl::xh(markerRect),
+                      gtl::yh(markerRect));
         marker->setBBox(box);
         marker->setLayerNum(layerNum);
         marker->setConstraint(con);
         marker->addSrc(net1->getOwner());
         marker->addVictim(net1->getOwner(),
                           std::make_tuple(layerNum,
-                                          Rect(gtl::xl(*rect1),
-                                               gtl::yl(*rect1),
-                                               gtl::xh(*rect1),
-                                               gtl::yh(*rect1)),
+                                          odb::Rect(gtl::xl(*rect1),
+                                                    gtl::yl(*rect1),
+                                                    gtl::xh(*rect1),
+                                                    gtl::yh(*rect1)),
                                           rect1->isFixed()));
         marker->addSrc(net2->getOwner());
         marker->addAggressor(
             net2->getOwner(),
             std::make_tuple(
                 secondLayerNum,
-                Rect(corner->x(), corner->y(), corner->x(), corner->y()),
+                odb::Rect(corner->x(), corner->y(), corner->x(), corner->y()),
                 corner->isFixed()));
         addMarker(std::move(marker));
       }
@@ -3702,12 +3704,12 @@ void FlexGCWorker::Impl::patchMetalShape_cornerSpacing()
     const auto layer = tech_->getLayer(lNum);
 
     Point origin;
-    Rect fig_bbox;
+    odb::Rect fig_bbox;
     drNet* net = nullptr;
-    Rect markerBBox = marker->getBBox();
+    odb::Rect markerBBox = marker->getBBox();
     workerRegionQuery.query(markerBBox, lNum, results);
     auto& sourceNets = marker->getSrcs();
-    const Rect routeBox = getDRWorker()->getRouteBox();
+    const odb::Rect routeBox = getDRWorker()->getRouteBox();
     drConnFig* obj = nullptr;
     for (auto connFig : results) {
       net = connFig->getNet();
@@ -3817,7 +3819,7 @@ void FlexGCWorker::Impl::patchMetalShape_minStep()
     Point origin;
     drNet* net = nullptr;
     auto& workerRegionQuery = getDRWorker()->getWorkerRegionQuery();
-    Rect markerBBox = marker->getBBox();
+    odb::Rect markerBBox = marker->getBBox();
     if ((int) markerBBox.maxDXDY() < (frCoord) layer->getWidth()) {
       continue;
     }
@@ -3857,7 +3859,7 @@ void FlexGCWorker::Impl::patchMetalShape_minStep()
         }
         if (obj->isLonely() && getDRWorker()
             && getDRWorker()->getRipupMode() == RipUpMode::VIASWAP) {
-          Rect enc_box;
+          odb::Rect enc_box;
           if (obj->getViaDef()->getLayer1Num() == lNum) {
             enc_box = obj->getLayer1BBox();
           } else {
@@ -3927,28 +3929,28 @@ void FlexGCWorker::Impl::checkMinimumCut_marker(gcRect* wideRect,
   gtl::rectangle_data<frCoord> markerRect(*wideRect);
   gtl::generalized_intersect(markerRect, *viaRect);
   auto marker = std::make_unique<frMarker>();
-  Rect box(gtl::xl(markerRect),
-           gtl::yl(markerRect),
-           gtl::xh(markerRect),
-           gtl::yh(markerRect));
+  odb::Rect box(gtl::xl(markerRect),
+                gtl::yl(markerRect),
+                gtl::xh(markerRect),
+                gtl::yh(markerRect));
   marker->setBBox(box);
   marker->setLayerNum(wideRect->getLayerNum());
   marker->setConstraint(con);
   marker->addSrc(net->getOwner());
   marker->addVictim(net->getOwner(),
                     std::make_tuple(wideRect->getLayerNum(),
-                                    Rect(gtl::xl(*wideRect),
-                                         gtl::yl(*wideRect),
-                                         gtl::xh(*wideRect),
-                                         gtl::yh(*wideRect)),
+                                    odb::Rect(gtl::xl(*wideRect),
+                                              gtl::yl(*wideRect),
+                                              gtl::xh(*wideRect),
+                                              gtl::yh(*wideRect)),
                                     wideRect->isFixed()));
   marker->addSrc(net->getOwner());
   marker->addAggressor(net->getOwner(),
                        std::make_tuple(viaRect->getLayerNum(),
-                                       Rect(gtl::xl(*viaRect),
-                                            gtl::yl(*viaRect),
-                                            gtl::xh(*viaRect),
-                                            gtl::yh(*viaRect)),
+                                       odb::Rect(gtl::xl(*viaRect),
+                                                 gtl::yl(*viaRect),
+                                                 gtl::xh(*viaRect),
+                                                 gtl::yh(*viaRect)),
                                        viaRect->isFixed()));
   addMarker(std::move(marker));
 }
@@ -3985,7 +3987,7 @@ void FlexGCWorker::Impl::checkMinimumCut_main(gcRect* rect)
       result.insert(result.end(), above_result.begin(), above_result.end());
     }
 
-    Rect wideRect(
+    odb::Rect wideRect(
         gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
     for (auto [viaBox, via] : result) {
       if (via->getNet() != rect->getNet()) {
@@ -4143,10 +4145,10 @@ void FlexGCWorker::Impl::checkTwoWiresForbiddenSpc_main(
     }
     // add violation
     auto marker = std::make_unique<frMarker>();
-    Rect box(gtl::xl(markerRect),
-             gtl::yl(markerRect),
-             gtl::xh(markerRect),
-             gtl::yh(markerRect));
+    odb::Rect box(gtl::xl(markerRect),
+                  gtl::yl(markerRect),
+                  gtl::xh(markerRect),
+                  gtl::yh(markerRect));
     marker->setBBox(box);
     marker->setLayerNum(rect->getLayerNum());
     marker->setConstraint(con);
@@ -4155,7 +4157,7 @@ void FlexGCWorker::Impl::checkTwoWiresForbiddenSpc_main(
         rect->getNet()->getOwner(),
         std::make_tuple(
             rect->getLayerNum(),
-            Rect(
+            odb::Rect(
                 gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect)),
             rect->isFixed()));
     marker->addSrc(ptr->getNet()->getOwner());
@@ -4163,7 +4165,8 @@ void FlexGCWorker::Impl::checkTwoWiresForbiddenSpc_main(
         ptr->getNet()->getOwner(),
         std::make_tuple(
             ptr->getLayerNum(),
-            Rect(gtl::xl(*ptr), gtl::yl(*ptr), gtl::xh(*ptr), gtl::yh(*ptr)),
+            odb::Rect(
+                gtl::xl(*ptr), gtl::yl(*ptr), gtl::xh(*ptr), gtl::yh(*ptr)),
             ptr->isFixed()));
     addMarker(std::move(marker));
   }
@@ -4194,7 +4197,7 @@ void FlexGCWorker::Impl::modifyMarkers()
         continue;
       }
       auto bbox = marker->getBBox();
-      bbox.merge(Rect(origin, origin));
+      bbox.merge(odb::Rect(origin, origin));
       marker->setBBox(bbox);
     }
   }

--- a/src/drt/src/gc/FlexGC_metspc.cpp
+++ b/src/drt/src/gc/FlexGC_metspc.cpp
@@ -11,16 +11,18 @@
 #include "frBaseTypes.h"
 #include "gc/FlexGC_impl.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
-Rect FlexGCWorker::Impl::checkForbiddenSpc_queryBox(gcRect* rect,
-                                                    frCoord minSpc,
-                                                    frCoord maxSpc,
-                                                    bool isH,
-                                                    bool right)
+odb::Rect FlexGCWorker::Impl::checkForbiddenSpc_queryBox(gcRect* rect,
+                                                         frCoord minSpc,
+                                                         frCoord maxSpc,
+                                                         bool isH,
+                                                         bool right)
 {
-  Rect queryBox(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect queryBox(
+      gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   if (isH) {
     if (right) {
       queryBox.set_ylo(gtl::yh(*rect) + minSpc);
@@ -97,35 +99,36 @@ void FlexGCWorker::Impl::checkForbiddenSpc_main(
     }
     // add violation
     auto marker = std::make_unique<frMarker>();
-    Rect box(gtl::xl(markerRect),
-             gtl::yl(markerRect),
-             gtl::xh(markerRect),
-             gtl::yh(markerRect));
+    odb::Rect box(gtl::xl(markerRect),
+                  gtl::yl(markerRect),
+                  gtl::xh(markerRect),
+                  gtl::yh(markerRect));
     marker->setBBox(box);
     marker->setLayerNum(rect1->getLayerNum());
     marker->setConstraint(con);
     marker->addSrc(rect1->getNet()->getOwner());
     marker->addVictim(rect1->getNet()->getOwner(),
                       std::make_tuple(rect1->getLayerNum(),
-                                      Rect(gtl::xl(*rect1),
-                                           gtl::yl(*rect1),
-                                           gtl::xh(*rect1),
-                                           gtl::yh(*rect1)),
+                                      odb::Rect(gtl::xl(*rect1),
+                                                gtl::yl(*rect1),
+                                                gtl::xh(*rect1),
+                                                gtl::yh(*rect1)),
                                       rect1->isFixed()));
     marker->addSrc(rect2->getNet()->getOwner());
     marker->addAggressor(rect2->getNet()->getOwner(),
                          std::make_tuple(rect2->getLayerNum(),
-                                         Rect(gtl::xl(*rect2),
-                                              gtl::yl(*rect2),
-                                              gtl::xh(*rect2),
-                                              gtl::yh(*rect2)),
+                                         odb::Rect(gtl::xl(*rect2),
+                                                   gtl::yl(*rect2),
+                                                   gtl::xh(*rect2),
+                                                   gtl::yh(*rect2)),
                                          rect2->isFixed()));
     marker->addSrc(ptr->getNet()->getOwner());
     marker->addAggressor(
         ptr->getNet()->getOwner(),
         std::make_tuple(
             ptr->getLayerNum(),
-            Rect(gtl::xl(*ptr), gtl::yl(*ptr), gtl::xh(*ptr), gtl::yh(*ptr)),
+            odb::Rect(
+                gtl::xl(*ptr), gtl::yl(*ptr), gtl::xh(*ptr), gtl::yh(*ptr)),
             ptr->isFixed()));
     addMarker(std::move(marker));
   }
@@ -136,7 +139,7 @@ bool FlexGCWorker::Impl::checkForbiddenSpc_twoedges(
     frLef58ForbiddenSpcConstraint* con,
     bool isH)
 {
-  Rect queryBox;
+  odb::Rect queryBox;
   auto hasWireInWithin
       = [](gcRect* rect, const std::vector<rq_box_value_t<gcRect*>>& result) {
           for (auto& [objBox, ptr] : result) {
@@ -178,7 +181,7 @@ void FlexGCWorker::Impl::checkForbiddenSpc_main(
   if (!checkForbiddenSpc_twoedges(rect, con, isH)) {
     return;
   }
-  Rect queryBox;
+  odb::Rect queryBox;
   std::vector<rq_box_value_t<gcRect*>> result;
   auto& workerRegionQuery = getWorkerRegionQuery();
 

--- a/src/drt/src/gc/FlexGC_rq.cpp
+++ b/src/drt/src/gc/FlexGC_rq.cpp
@@ -11,6 +11,7 @@
 #include "frBaseTypes.h"
 #include "frRTree.h"
 #include "gc/FlexGC_impl.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -68,13 +69,13 @@ void FlexGCWorkerRegionQuery::Impl::addPolygonEdge(
 
 void FlexGCWorkerRegionQuery::addMaxRectangle(gcRect* rect)
 {
-  Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   impl_->max_rectangles[rect->getLayerNum()].insert(std::make_pair(r, rect));
 }
 
 void FlexGCWorkerRegionQuery::addSpcRectangle(gcRect* rect)
 {
-  Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   impl_->spc_rectangles[rect->getLayerNum()].insert(std::make_pair(r, *rect));
 }
 
@@ -82,7 +83,8 @@ void FlexGCWorkerRegionQuery::Impl::addMaxRectangle(
     gcRect* rect,
     std::vector<std::vector<rq_box_value_t<gcRect*>>>& allShapes)
 {
-  Rect boostr(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect boostr(
+      gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   allShapes[rect->getLayerNum()].push_back(std::make_pair(boostr, rect));
 }
 
@@ -90,7 +92,7 @@ void FlexGCWorkerRegionQuery::Impl::addSpcRectangle(
     gcRect* rect,
     std::vector<std::vector<rq_box_value_t<gcRect>>>& allShapes)
 {
-  Rect box(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect box(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   allShapes[rect->getLayerNum()].push_back(std::make_pair(box, *rect));
 }
 
@@ -104,13 +106,13 @@ void FlexGCWorkerRegionQuery::removePolygonEdge(gcSegment* edge)
 
 void FlexGCWorkerRegionQuery::removeMaxRectangle(gcRect* rect)
 {
-  Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   impl_->max_rectangles[rect->getLayerNum()].remove(std::make_pair(r, rect));
 }
 
 void FlexGCWorkerRegionQuery::removeSpcRectangle(gcRect* rect)
 {
-  Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
+  odb::Rect r(gtl::xl(*rect), gtl::yl(*rect), gtl::xh(*rect), gtl::yh(*rect));
   impl_->spc_rectangles[rect->getLayerNum()].remove(std::make_pair(r, *rect));
 }
 
@@ -124,7 +126,7 @@ void FlexGCWorkerRegionQuery::queryPolygonEdge(
 }
 
 void FlexGCWorkerRegionQuery::queryPolygonEdge(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<std::pair<segment_t, gcSegment*>>& result) const
 {
@@ -152,7 +154,7 @@ void FlexGCWorkerRegionQuery::querySpcRectangle(
 }
 
 void FlexGCWorkerRegionQuery::queryMaxRectangle(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<rq_box_value_t<gcRect*>>& result) const
 {

--- a/src/drt/src/global.cpp
+++ b/src/drt/src/global.cpp
@@ -25,7 +25,7 @@ std::ostream& operator<<(std::ostream& os, const frRect& pinFigIn)
   //    pinFigIn.getPin()->getTerm()->getName()
   //       << " " << pinFigIn.getLayerNum() << std::endl;
   //  }
-  Rect tmpBox = pinFigIn.getBBox();
+  odb::Rect tmpBox = pinFigIn.getBBox();
   os << "  RECT " << tmpBox.xMin() << " " << tmpBox.yMin() << " "
      << tmpBox.xMax() << " " << tmpBox.yMax();
   return os;
@@ -131,7 +131,7 @@ std::ostream& operator<<(std::ostream& os, const frViaDef& viaDefIn)
 
 std::ostream& operator<<(std::ostream& os, const frBlock& blockIn)
 {
-  Rect box = blockIn.getBBox();
+  odb::Rect box = blockIn.getBBox();
   os << "MACRO " << blockIn.getName() << std::endl
      << "  ORIGIN " << box.xMin() << " " << box.yMin() << std::endl
      << "  SIZE " << box.xMax() << " " << box.yMax();

--- a/src/drt/src/gr/FlexGR.h
+++ b/src/drt/src/gr/FlexGR.h
@@ -21,16 +21,14 @@
 #include "global.h"
 #include "gr/FlexGRCMap.h"
 #include "gr/FlexGRGridGraph.h"
+#include "odb/db.h"
+#include "odb/geom.h"
 #include "utl/Logger.h"
-namespace odb {
-class dbDatabase;
-class Rect;
-}  // namespace odb
+
 namespace stt {
 class SteinerTreeBuilder;
 }
 namespace drt {
-using odb::Rect;
 
 class FlexGR
 {
@@ -236,10 +234,10 @@ class FlexGRWorkerRegionQuery
   void add(grConnFig* connFig,
            std::vector<std::vector<rq_box_value_t<grConnFig*>>>& allShapes);
   void remove(grConnFig* connFig);
-  void query(const Rect& box,
+  void query(const odb::Rect& box,
              frLayerNum layerNum,
              std::vector<grConnFig*>& result) const;
-  void query(const Rect& box,
+  void query(const odb::Rect& box,
              frLayerNum layerNum,
              std::vector<rq_box_value_t<grConnFig*>>& result) const;
   void init(bool includeExt = false);
@@ -276,8 +274,8 @@ class FlexGRWorker
   // setters
   void setRouteGCellIdxLL(const Point& in) { routeGCellIdxLL_ = in; }
   void setRouteGCellIdxUR(const Point& in) { routeGCellIdxUR_ = in; }
-  void setExtBox(const Rect& in) { extBox_ = in; }
-  void setRouteBox(const Rect& in) { routeBox_ = in; }
+  void setExtBox(const odb::Rect& in) { extBox_ = in; }
+  void setRouteBox(const odb::Rect& in) { routeBox_ = in; }
   void setGRIter(int in) { grIter_ = in; }
   void setMazeEndIter(int in) { mazeEndIter_ = in; }
   void setCongCost(int in) { workerCongCost_ = in; }
@@ -294,12 +292,12 @@ class FlexGRWorker
   Point& getRouteGCellIdxLL() { return routeGCellIdxLL_; }
   const Point& getRouteGCellIdxUR() const { return routeGCellIdxUR_; }
   Point& getRouteGCellIdxUR() { return routeGCellIdxUR_; }
-  void getExtBox(Rect& in) const { in = extBox_; }
-  const Rect& getExtBox() const { return extBox_; }
-  Rect& getExtBox() { return extBox_; }
-  void getRouteBox(Rect& in) const { in = routeBox_; }
-  const Rect& getRouteBox() const { return routeBox_; }
-  Rect& getRouteBox() { return routeBox_; }
+  void getExtBox(odb::Rect& in) const { in = extBox_; }
+  const odb::Rect& getExtBox() const { return extBox_; }
+  odb::Rect& getExtBox() { return extBox_; }
+  void getRouteBox(odb::Rect& in) const { in = routeBox_; }
+  const odb::Rect& getRouteBox() const { return routeBox_; }
+  odb::Rect& getRouteBox() { return routeBox_; }
   int getGRIter() const { return grIter_; }
   int getMazeEndIter() const { return mazeEndIter_; }
   double getCongThresh() const { return congThresh_; }
@@ -330,8 +328,8 @@ class FlexGRWorker
   FlexGR* gr_{nullptr};
   Point routeGCellIdxLL_;
   Point routeGCellIdxUR_;
-  Rect extBox_;
-  Rect routeBox_;
+  odb::Rect extBox_;
+  odb::Rect routeBox_;
   int grIter_{0};
   int mazeEndIter_{1};
   int workerCongCost_{0};

--- a/src/drt/src/gr/FlexGRCMap.cpp
+++ b/src/drt/src/gr/FlexGRCMap.cpp
@@ -13,6 +13,7 @@
 #include "db/obj/frBTerm.h"
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -110,7 +111,7 @@ void FlexGRCMap::init()
   for (auto& [layerIdx, dir] : zMap_) {
     if (dir == dbTechLayerDir::HORIZONTAL) {
       for (unsigned yIdx = 0; yIdx < ygp_->getCount(); yIdx++) {
-        Rect startGCellBox
+        odb::Rect startGCellBox
             = design_->getTopBlock()->getGCellBox(Point(0, yIdx));
         frCoord low = startGCellBox.yMin();
         frCoord high = startGCellBox.yMax();
@@ -138,7 +139,7 @@ void FlexGRCMap::init()
       }
     } else if (dir == dbTechLayerDir::VERTICAL) {
       for (unsigned xIdx = 0; xIdx < xgp_->getCount(); xIdx++) {
-        Rect startGCellBox
+        odb::Rect startGCellBox
             = design_->getTopBlock()->getGCellBox(Point(xIdx, 0));
         frCoord low = startGCellBox.xMin();
         frCoord high = startGCellBox.xMax();
@@ -182,7 +183,7 @@ void FlexGRCMap::init()
     if (dir == dbTechLayerDir::HORIZONTAL) {
       for (unsigned yIdx = 0; yIdx < ygp_->getCount(); yIdx++) {
         trackLocs.clear();
-        Rect startGCellBox
+        odb::Rect startGCellBox
             = design_->getTopBlock()->getGCellBox(Point(0, yIdx));
         frCoord low = startGCellBox.yMin();
         frCoord high = startGCellBox.yMax();
@@ -196,7 +197,7 @@ void FlexGRCMap::init()
           // add initial demand
           // addRawDemand(xIdx, yIdx, cmapLayerIdx, frDirEnum::E, 1);
           // add blocked track demand
-          Rect currGCellBox
+          odb::Rect currGCellBox
               = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
           queryResult.clear();
           regionQuery->query(currGCellBox, layerIdx, queryResult);
@@ -209,7 +210,7 @@ void FlexGRCMap::init()
     } else if (dir == dbTechLayerDir::VERTICAL) {
       for (unsigned xIdx = 0; xIdx < xgp_->getCount(); xIdx++) {
         trackLocs.clear();
-        Rect startGCellBox
+        odb::Rect startGCellBox
             = design_->getTopBlock()->getGCellBox(Point(xIdx, 0));
         frCoord low = startGCellBox.xMin();
         frCoord high = startGCellBox.xMax();
@@ -223,7 +224,7 @@ void FlexGRCMap::init()
           // add initial demand
           // addRawDemand(xIdx, yIdx, cmapLayerIdx, frDirEnum::N, 1);
           // add blocked track demand
-          Rect currGCellBox
+          odb::Rect currGCellBox
               = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
           queryResult.clear();
           regionQuery->query(currGCellBox, layerIdx, queryResult);
@@ -245,7 +246,7 @@ void FlexGRCMap::init()
     if (dir == dbTechLayerDir::HORIZONTAL) {
       for (unsigned yIdx = 0; yIdx < ygp_->getCount(); yIdx++) {
         for (unsigned xIdx = 0; xIdx < xgp_->getCount(); xIdx++) {
-          Rect currGCellBox
+          odb::Rect currGCellBox
               = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
           rpinQueryResult.clear();
           regionQuery->queryRPin(currGCellBox, layerIdx, rpinQueryResult);
@@ -262,7 +263,7 @@ void FlexGRCMap::init()
     } else if (dir == dbTechLayerDir::VERTICAL) {
       for (unsigned xIdx = 0; xIdx < xgp_->getCount(); xIdx++) {
         for (unsigned yIdx = 0; yIdx < ygp_->getCount(); yIdx++) {
-          Rect currGCellBox
+          odb::Rect currGCellBox
               = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
           rpinQueryResult.clear();
           regionQuery->queryRPin(currGCellBox, layerIdx, rpinQueryResult);
@@ -357,7 +358,7 @@ unsigned FlexGRCMap::getNumBlkTracks(
 
 frCoord FlexGRCMap::calcBloatDist(frBlockObject* obj,
                                   const frLayerNum lNum,
-                                  const Rect& box,
+                                  const odb::Rect& box,
                                   bool isOBS)
 {
   auto layer = getDesign()->getTech()->getLayer(lNum);
@@ -564,7 +565,8 @@ void FlexGRCMap::print(bool isAll)
     }
     for (unsigned yIdx = 0; yIdx < ygp_->getCount(); yIdx++) {
       for (unsigned xIdx = 0; xIdx < xgp_->getCount(); xIdx++) {
-        Rect gcellBox = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
+        odb::Rect gcellBox
+            = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
         unsigned demandV = getDemand(xIdx, yIdx, layerIdx, frDirEnum::N);
         unsigned demandH = getDemand(xIdx, yIdx, layerIdx, frDirEnum::E);
         unsigned supplyV = getSupply(xIdx, yIdx, layerIdx, frDirEnum::N);
@@ -620,7 +622,8 @@ void FlexGRCMap::print2D(bool isAll)
         supplyV += getSupply(xIdx, yIdx, layerIdx, frDirEnum::N);
       }
 
-      Rect gcellBox = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
+      odb::Rect gcellBox
+          = design_->getTopBlock()->getGCellBox(Point(xIdx, yIdx));
       if (isAll || (demandV > supplyV) || (demandH > supplyH)) {
         if (congMap.is_open()) {
           congMap << "(" << gcellBox.xMin() << ", " << gcellBox.yMin() << ") ("

--- a/src/drt/src/gr/FlexGRCMap.h
+++ b/src/drt/src/gr/FlexGRCMap.h
@@ -643,7 +643,7 @@ class FlexGRCMap
       const std::vector<rq_box_value_t<frBlockObject*>>& results);
   frCoord calcBloatDist(frBlockObject* obj,
                         frLayerNum lNum,
-                        const Rect& box,
+                        const odb::Rect& box,
                         bool isOBS);
 };
 }  // namespace drt

--- a/src/drt/src/gr/FlexGRGridGraph.cpp
+++ b/src/drt/src/gr/FlexGRGridGraph.cpp
@@ -7,6 +7,7 @@
 
 #include "frBaseTypes.h"
 #include "gr/FlexGR.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -28,12 +29,14 @@ void FlexGRGridGraph::initCoords()
   Point gcellIdxUR = getGRWorker()->getRouteGCellIdxUR();
   // xCoords
   for (int xIdx = gcellIdxLL.x(); xIdx <= gcellIdxUR.x(); xIdx++) {
-    Rect gcellBox = getDesign()->getTopBlock()->getGCellBox(Point(xIdx, 0));
+    odb::Rect gcellBox
+        = getDesign()->getTopBlock()->getGCellBox(Point(xIdx, 0));
     xCoords_.push_back((gcellBox.xMin() + gcellBox.xMax()) / 2);
   }
   // yCoords
   for (int yIdx = gcellIdxLL.y(); yIdx <= gcellIdxUR.y(); yIdx++) {
-    Rect gcellBox = getDesign()->getTopBlock()->getGCellBox(Point(0, yIdx));
+    odb::Rect gcellBox
+        = getDesign()->getTopBlock()->getGCellBox(Point(0, yIdx));
     yCoords_.push_back((gcellBox.yMin() + gcellBox.yMax()) / 2);
   }
   // z

--- a/src/drt/src/gr/FlexGR_init.cpp
+++ b/src/drt/src/gr/FlexGR_init.cpp
@@ -17,6 +17,7 @@
 #include "frBaseTypes.h"
 #include "gr/FlexGR.h"
 #include "gr/FlexGRCMap.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -83,7 +84,7 @@ void FlexGR::initLayerPitch()
 
     if (downVia) {
       frVia via(downVia);
-      Rect viaBox = via.getLayer2BBox();
+      odb::Rect viaBox = via.getLayer2BBox();
       frCoord enclosureWidth = viaBox.minDXDY();
       frCoord prl = isLayerHorz ? (viaBox.xMax() - viaBox.xMin())
                                 : (viaBox.yMax() - viaBox.yMin());
@@ -126,7 +127,7 @@ void FlexGR::initLayerPitch()
 
     if (upVia) {
       frVia via(upVia);
-      Rect viaBox = via.getLayer1BBox();
+      odb::Rect viaBox = via.getLayer1BBox();
       frCoord enclosureWidth = viaBox.minDXDY();
       frCoord prl = isLayerHorz ? (viaBox.xMax() - viaBox.xMin())
                                 : (viaBox.yMax() - viaBox.yMin());
@@ -211,7 +212,7 @@ void FlexGR::initGCell()
               << layer->getName() << " pitch  = "
               << pitch / (double) (design_->getTopBlock()->getDBUPerUU())
               << "\n";
-    Rect dieBox = design_->getTopBlock()->getDieBox();
+    odb::Rect dieBox = design_->getTopBlock()->getDieBox();
 
     frGCellPattern xgp, ygp;
     // set xgp

--- a/src/drt/src/gr/FlexGR_maze.cpp
+++ b/src/drt/src/gr/FlexGR_maze.cpp
@@ -14,6 +14,7 @@
 #include "db/obj/frBlockObject.h"
 #include "frBaseTypes.h"
 #include "gr/FlexGR.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -113,7 +114,7 @@ void FlexGRWorker::route_mazeIterInit()
             // this gcell
             Point gcellCenter;
             gridGraph_.getPoint(xIdx, yIdx, gcellCenter);
-            Rect gcellCenterBox(gcellCenter, gcellCenter);
+            odb::Rect gcellCenterBox(gcellCenter, gcellCenter);
             result.clear();
             workerRegionQuery.query(gcellCenterBox, lNum, result);
             for (auto rptr : result) {
@@ -754,7 +755,7 @@ void FlexGRWorker::routeNet_postAstarWritePath(
       Point srcLoc;
       gridGraph_.getPoint(points.back().x(), points.back().y(), srcLoc);
       frLayerNum srcLNum = (points.back().z() + 1) * 2;
-      Rect srcBox(srcLoc, srcLoc);
+      odb::Rect srcBox(srcLoc, srcLoc);
       std::vector<grConnFig*> result;
       workerRegionQuery.query(srcBox, srcLNum, result);
       for (auto rptr : result) {

--- a/src/drt/src/gr/FlexGR_rq.cpp
+++ b/src/drt/src/gr/FlexGR_rq.cpp
@@ -12,6 +12,7 @@
 #include "frDesign.h"
 #include "gr/FlexGR.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -24,8 +25,9 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
 {
   if (connFig->typeId() == grcPathSeg) {
     auto obj = static_cast<grShape*>(connFig);
-    Rect frb = obj->getBBox();
-    Rect boostr = Rect(frb.xMin(), frb.yMin(), frb.xMax(), frb.yMax());
+    odb::Rect frb = obj->getBBox();
+    odb::Rect boostr
+        = odb::Rect(frb.xMin(), frb.yMin(), frb.xMax(), frb.yMax());
     shapes_.at(obj->getLayerNum()).insert(std::make_pair(boostr, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
@@ -33,7 +35,7 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getLayer1Num())
             .insert(std::make_pair(frb, via));
@@ -44,7 +46,7 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getLayer2Num())
             .insert(std::make_pair(frb, via));
@@ -55,7 +57,7 @@ void FlexGRWorkerRegionQuery::add(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getCutLayerNum())
             .insert(std::make_pair(frb, via));
@@ -74,7 +76,7 @@ void FlexGRWorkerRegionQuery::add(
 {
   if (connFig->typeId() == grcPathSeg) {
     auto obj = static_cast<grShape*>(connFig);
-    Rect frb = obj->getBBox();
+    odb::Rect frb = obj->getBBox();
     allShapes.at(obj->getLayerNum()).push_back(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
@@ -82,7 +84,7 @@ void FlexGRWorkerRegionQuery::add(
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getLayer1Num())
             .push_back(std::make_pair(frb, via));
@@ -93,7 +95,7 @@ void FlexGRWorkerRegionQuery::add(
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getLayer2Num())
             .push_back(std::make_pair(frb, via));
@@ -104,7 +106,7 @@ void FlexGRWorkerRegionQuery::add(
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         allShapes.at(via->getViaDef()->getCutLayerNum())
             .push_back(std::make_pair(frb, via));
@@ -121,7 +123,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
 {
   if (connFig->typeId() == grcPathSeg) {
     auto obj = static_cast<grShape*>(connFig);
-    Rect frb = obj->getBBox();
+    odb::Rect frb = obj->getBBox();
     shapes_.at(obj->getLayerNum()).remove(std::make_pair(frb, obj));
   } else if (connFig->typeId() == grcVia) {
     auto via = static_cast<grVia*>(connFig);
@@ -129,7 +131,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer1Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getLayer1Num())
             .remove(std::make_pair(frb, via));
@@ -140,7 +142,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getLayer2Figs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getLayer2Num())
             .remove(std::make_pair(frb, via));
@@ -151,7 +153,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
     for (auto& uShape : via->getViaDef()->getCutFigs()) {
       auto shape = uShape.get();
       if (shape->typeId() == frcRect) {
-        Rect frb = shape->getBBox();
+        odb::Rect frb = shape->getBBox();
         xform.apply(frb);
         shapes_.at(via->getViaDef()->getCutLayerNum())
             .remove(std::make_pair(frb, via));
@@ -164,7 +166,7 @@ void FlexGRWorkerRegionQuery::remove(grConnFig* connFig)
   }
 }
 
-void FlexGRWorkerRegionQuery::query(const Rect& box,
+void FlexGRWorkerRegionQuery::query(const odb::Rect& box,
                                     const frLayerNum layerNum,
                                     std::vector<grConnFig*>& result) const
 {
@@ -178,7 +180,7 @@ void FlexGRWorkerRegionQuery::query(const Rect& box,
 }
 
 void FlexGRWorkerRegionQuery::query(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<rq_box_value_t<grConnFig*>>& result) const
 {

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -186,7 +186,7 @@ void io::Parser::setObstructions(odb::dbBlock* block)
     frCoord yh = blockage->getBBox()->yMax();
     // pinFig
     std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-    pinFig->setBBox(Rect(xl, yl, xh, yh));
+    pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
     pinFig->addToPin(pinIn.get());
     pinFig->setLayerNum(layerNum);
     // pinFig completed
@@ -281,7 +281,7 @@ void io::Parser::setVias(odb::dbBlock* block)
         currX = 0;
         for (int j = 0; j < params.getNumCutCols(); j++) {
           auto rect = std::make_unique<frRect>();
-          Rect tmpBox(currX, currY, currX + xSize, currY + ySize);
+          odb::Rect tmpBox(currX, currY, currX + xSize, currY + ySize);
           rect->setBBox(tmpBox);
           rect->setLayerNum(cutLayerNum);
           cutFigs.push_back(std::move(rect));
@@ -302,8 +302,10 @@ void io::Parser::setVias(odb::dbBlock* block)
       std::unique_ptr<frShape> uTopFig = std::make_unique<frRect>();
       auto topFig = static_cast<frRect*>(uTopFig.get());
 
-      Rect botBox(0 - xBotEnc, 0 - yBotEnc, currX + xBotEnc, currY + yBotEnc);
-      Rect topBox(0 - xTopEnc, 0 - yTopEnc, currX + xTopEnc, currY + yTopEnc);
+      odb::Rect botBox(
+          0 - xBotEnc, 0 - yBotEnc, currX + xBotEnc, currY + yBotEnc);
+      odb::Rect topBox(
+          0 - xTopEnc, 0 - yTopEnc, currX + xTopEnc, currY + yTopEnc);
 
       odb::dbTransform botXform(Point(-currX / 2 + xOffset + xBotOffset,
                                       -currY / 2 + yOffset + yBotOffset));
@@ -327,7 +329,7 @@ void io::Parser::setVias(odb::dbBlock* block)
       int cutClassIdx = -1;
       frLef58CutClass* cutClass = nullptr;
       for (auto& cutFig : viaDef->getCutFigs()) {
-        Rect box = cutFig->getBBox();
+        odb::Rect box = cutFig->getBBox();
         auto width = box.minDXDY();
         auto length = box.maxDXDY();
         cutClassIdx = cutLayer->getCutClassIdx(width, length);
@@ -369,7 +371,7 @@ void io::Parser::setVias(odb::dbBlock* block)
         for (auto box : boxes) {
           std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
           pinFig->setBBox(
-              Rect(box->xMin(), box->yMin(), box->xMax(), box->yMax()));
+              odb::Rect(box->xMin(), box->yMin(), box->xMax(), box->yMax()));
           pinFig->setLayerNum(layerNum);
           switch (cnt) {
             case 0:
@@ -825,7 +827,7 @@ void io::Parser::updateNetRouting(frNet* netIn, odb::dbNet* net)
         auto tmpPWire = std::make_unique<frPatchWire>();
         tmpPWire->setLayerNum(layerNum);
         tmpPWire->setOrigin({beginX, beginY});
-        tmpPWire->setOffsetBox(Rect(left, bottom, right, top));
+        tmpPWire->setOffsetBox(odb::Rect(left, bottom, right, top));
         netIn->addPatchWire(std::move(tmpPWire));
       }
       if (hasEndPoint) {
@@ -1312,9 +1314,9 @@ void io::Parser::readDesign(odb::dbDatabase* db)
   auto numLefVia = getTech()->vias_.size();
   if (router_cfg_->VERBOSE > 0) {
     logger_->report("");
-    Rect dieBox = getBlock()->getDieBox();
+    odb::Rect dieBox = getBlock()->getDieBox();
     logger_->report("Design:                   {}", getBlock()->getName());
-    // TODO Rect can't be logged directly
+    // TODO odb::Rect can't be logged directly
     std::stringstream dieBoxSStream;
     dieBoxSStream << dieBox;
     logger_->report("Die area:                 {}", dieBoxSStream.str());
@@ -2605,7 +2607,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
   std::vector<RTree<frMPin*>> pin_shapes;
   pin_shapes.resize(numLayers);
   auto addPinFig
-      = [&pin_shapes](const Rect& box, frLayerNum lNum, frMPin* pinIn) {
+      = [&pin_shapes](const odb::Rect& box, frLayerNum lNum, frMPin* pinIn) {
           std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
           pinFig->setBBox(box);
           pinFig->addToPin(pinIn);
@@ -2699,7 +2701,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
               frCoord yl = box->yMin();
               frCoord xh = box->xMax();
               frCoord yh = box->yMax();
-              addPinFig(Rect(xl, yl, xh, yh), layerNum, pinIn.get());
+              addPinFig(odb::Rect(xl, yl, xh, yh), layerNum, pinIn.get());
             }
           }
           term->addPin(std::move(pinIn));
@@ -2740,7 +2742,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
           std::vector<rq_box_value_t<frMPin*>> containing_pins;
           if (layerNum + 1 < pin_shapes.size()) {
             pin_shapes[layerNum + 1].query(
-                bgi::intersects(Rect{xl, yl, xh, yh}),
+                bgi::intersects(odb::Rect{xl, yl, xh, yh}),
                 back_inserter(containing_pins));
           }
           if (!containing_pins.empty()) {
@@ -2755,7 +2757,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
             }
             if (pin) {
               std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-              pinFig->setBBox(Rect(xl, yl, xh, yh));
+              pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
               pinFig->addToPin(pin);
               pinFig->setLayerNum(layerNum);
               std::unique_ptr<frPinFig> uptr(std::move(pinFig));
@@ -2776,7 +2778,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
           pinIn->setId(0);
           // pinFig
           std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-          pinFig->setBBox(Rect(xl, yl, xh, yh));
+          pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
           pinFig->addToPin(pinIn.get());
           pinFig->setLayerNum(layerNum);
           std::unique_ptr<frPinFig> uptr(std::move(pinFig));
@@ -2803,7 +2805,7 @@ void io::Parser::setMasters(odb::dbDatabase* db)
             pinIn->setId(0);
             // pinFig
             std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-            pinFig->setBBox(Rect(xl, yl, xh, yh));
+            pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
             pinFig->addToPin(pinIn.get());
             pinFig->setLayerNum(lNum);
             std::unique_ptr<frPinFig> uptr(std::move(pinFig));
@@ -2889,7 +2891,7 @@ void io::Parser::setTechViaRules(odb::dbTech* db_tech)
         frCoord yl = rect.yMin();
         frCoord xh = rect.xMax();
         frCoord yh = rect.yMax();
-        Rect box(xl, yl, xh, yh);
+        odb::Rect box(xl, yl, xh, yh);
         switch (lNum2Int[layerNum]) {
           case 1:
             logger_->warn(
@@ -3002,7 +3004,7 @@ void io::Parser::setTechVias(odb::dbTech* db_tech)
       frCoord xh = box->xMax();
       frCoord yh = box->yMax();
       std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-      pinFig->setBBox(Rect(xl, yl, xh, yh));
+      pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
       pinFig->setLayerNum(layerNum);
       if (lNum2Int[layerNum] == 1) {
         viaDef->addLayer1Fig(std::move(pinFig));
@@ -3018,7 +3020,7 @@ void io::Parser::setTechVias(odb::dbTech* db_tech)
     frLef58CutClass* cutClass = nullptr;
 
     for (auto& cutFig : viaDef->getCutFigs()) {
-      Rect box = cutFig->getBBox();
+      odb::Rect box = cutFig->getBBox();
       auto width = box.minDXDY();
       auto length = box.maxDXDY();
       cutClassIdx = cutLayer->getCutClassIdx(width, length);
@@ -3521,18 +3523,18 @@ void io::Writer::writeViaDefToODB(odb::dbBlock* block,
   odb::dbVia* _db_via = odb::dbVia::create(block, via->getName().c_str());
   _db_via->setDefault(true);
   for (auto& fig : via->getLayer2Figs()) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     odb::dbBox::create(
         _db_via, _layer2, box.xMin(), box.yMin(), box.xMax(), box.yMax());
   }
   for (auto& fig : via->getCutFigs()) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     odb::dbBox::create(
         _db_via, _cut_layer, box.xMin(), box.yMin(), box.xMax(), box.yMax());
   }
 
   for (auto& fig : via->getLayer1Figs()) {
-    Rect box = fig->getBBox();
+    odb::Rect box = fig->getBBox();
     odb::dbBox::create(
         _db_via, _layer1, box.xMin(), box.yMin(), box.xMax(), box.yMax());
   }
@@ -3640,7 +3642,7 @@ void io::Writer::updateDbConn(odb::dbBlock* block,
             auto layer = db_tech->findLayer(layerName.c_str());
             _wire_encoder.newPath(layer, odb::dbWireType("ROUTED"));
             Point origin = pwire->getOrigin();
-            Rect offsetBox = pwire->getOffsetBox();
+            odb::Rect offsetBox = pwire->getOffsetBox();
             _wire_encoder.addPoint(origin.x(), origin.y());
             _wire_encoder.addRect(offsetBox.xMin(),
                                   offsetBox.yMin(),
@@ -3708,7 +3710,8 @@ void io::Writer::updateDbAccessPoint(odb::dbAccessPoint* db_ap,
   }
   auto path_segs = ap->getPathSegs();
   for (const auto& path_seg : path_segs) {
-    Rect db_rect = Rect(path_seg.getBeginPoint(), path_seg.getEndPoint());
+    odb::Rect db_rect
+        = odb::Rect(path_seg.getBeginPoint(), path_seg.getEndPoint());
     bool begin_style_trunc = (path_seg.getBeginStyle() == frcTruncateEndStyle);
     bool end_style_trunc = (path_seg.getEndStyle() == frcTruncateEndStyle);
     db_ap->addSegment(db_rect, begin_style_trunc, end_style_trunc);
@@ -3913,7 +3916,7 @@ std::vector<int> getTracksInRange(const frTrackPattern* tp,
  * the passed pin_rect and chooses the one that is closest to the center. If no
  * tracks are found, it chooses the pin center point as the via location.
  */
-Point io::TopLayerBTermHandler::getBestViaPosition(Rect pin_rect)
+Point io::TopLayerBTermHandler::getBestViaPosition(odb::Rect pin_rect)
 {
   Point center_pt = pin_rect.center();
   const auto top_routing_layer

--- a/src/drt/src/io/io.h
+++ b/src/drt/src/io/io.h
@@ -238,7 +238,7 @@ class TopLayerBTermHandler
    * @returns The chosen via location for stacking the vias up to the
    * TOP_ROUTING_LAYER
    */
-  Point getBestViaPosition(Rect pin_rect);
+  Point getBestViaPosition(odb::Rect pin_rect);
   frDesign* design_;
   odb::dbDatabase* db_;
   utl::Logger* logger_;

--- a/src/drt/src/io/io_parser_helper.cpp
+++ b/src/drt/src/io/io_parser_helper.cpp
@@ -130,8 +130,8 @@ void io::Parser::initDefaultVias()
       auto techDefautlViaDef
           = getTech()->getLayer(layerNum)->getDefaultViaDef();
       frVia via(techDefautlViaDef);
-      Rect layer1Box = via.getLayer1BBox();
-      Rect layer2Box = via.getLayer2BBox();
+      odb::Rect layer1Box = via.getLayer1BBox();
+      odb::Rect layer2Box = via.getLayer2BBox();
       frLayerNum layer1Num = techDefautlViaDef->getLayer1Num();
       frLayerNum layer2Num = techDefautlViaDef->getLayer2Num();
       bool isLayer1Square = layer1Box.dx() == layer1Box.dy();
@@ -189,7 +189,7 @@ void io::Parser::initDefaultVias()
         // cut layer shape
         std::unique_ptr<frShape> uCutFig = std::make_unique<frRect>();
         auto cutFig = static_cast<frRect*>(uCutFig.get());
-        Rect cutBox = via.getCutBBox();
+        odb::Rect cutBox = via.getCutBBox();
         cutFig->setBBox(cutBox);
         cutFig->setLayerNum(techDefautlViaDef->getCutLayerNum());
 
@@ -292,8 +292,8 @@ void io::Parser::initSecondaryVias()
             auto botfig = static_cast<frRect*>(u_botfig.get());
             std::unique_ptr<frShape> u_topfig = std::make_unique<frRect>();
             auto topfig = static_cast<frRect*>(u_topfig.get());
-            Rect layer1_box = secondary_via.getLayer1BBox();
-            Rect layer2_box = secondary_via.getLayer2BBox();
+            odb::Rect layer1_box = secondary_via.getLayer1BBox();
+            odb::Rect layer2_box = secondary_via.getLayer2BBox();
             layer1_box = layer1_box.bloat(layer1_bloats.first,
                                           odb::Orientation2D::Vertical);
             layer1_box = layer1_box.bloat(layer1_bloats.second,
@@ -313,7 +313,7 @@ void io::Parser::initSecondaryVias()
             // cut layer shape
             std::unique_ptr<frShape> u_cutfig = std::make_unique<frRect>();
             auto cutfig = static_cast<frRect*>(u_cutfig.get());
-            Rect cut_box = secondary_via.getCutBBox();
+            odb::Rect cut_box = secondary_via.getCutBBox();
             cut_box.moveDelta(-dx, -dy);
             cutfig->setBBox(cut_box);
             cutfig->setLayerNum(viadef->getCutLayerNum());
@@ -494,7 +494,7 @@ void io::Parser::getViaRawPriority(const frViaDef* viaDef,
 
   using boost::polygon::operators::operator+=;
   for (auto& fig : viaDef->getLayer1Figs()) {
-    Rect bbox = fig->getBBox();
+    odb::Rect bbox = fig->getBBox();
     Rectangle bboxRect(bbox.xMin(), bbox.yMin(), bbox.xMax(), bbox.yMax());
     viaLayerPS1 += bboxRect;
   }
@@ -514,7 +514,7 @@ void io::Parser::getViaRawPriority(const frViaDef* viaDef,
 
   PolygonSet viaLayerPS2;
   for (auto& fig : viaDef->getLayer2Figs()) {
-    Rect bbox = fig->getBBox();
+    odb::Rect bbox = fig->getBBox();
     Rectangle bboxRect(bbox.xMin(), bbox.yMin(), bbox.xMax(), bbox.yMax());
     viaLayerPS2 += bboxRect;
   }
@@ -768,7 +768,7 @@ void io::Parser::checkFig(frPinFig* uFig,
   int grid = getTech()->getManufacturingGrid();
   if (uFig->typeId() == frcRect) {
     frRect* shape = static_cast<frRect*>(uFig);
-    Rect box = shape->getBBox();
+    odb::Rect box = shape->getBBox();
     xform.apply(box);
     if (box.xMin() % grid || box.yMin() % grid || box.xMax() % grid
         || box.yMax() % grid) {

--- a/src/drt/src/pa/FlexPA_acc_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_acc_pattern.cpp
@@ -29,6 +29,7 @@
 #include "frProfileTask.h"
 #include "gc/FlexGC.h"
 #include "odb/dbTransform.h"
+#include "odb/geom.h"
 #include "pa/AbstractPAGraphics.h"
 #include "pa/FlexPA.h"
 #include "serialization.h"
@@ -326,13 +327,13 @@ bool FlexPA::genPatternsGC(
   frCoord urx = std::numeric_limits<frCoord>::min();
   frCoord ury = std::numeric_limits<frCoord>::min();
   for (auto& [connFig, owner] : objs) {
-    Rect bbox = connFig->getBBox();
+    odb::Rect bbox = connFig->getBBox();
     llx = std::min(llx, bbox.xMin());
     lly = std::min(lly, bbox.yMin());
     urx = std::max(urx, bbox.xMax());
     ury = std::max(ury, bbox.yMax());
   }
-  const Rect ext_box(llx - 3000, lly - 3000, urx + 3000, ury + 3000);
+  const odb::Rect ext_box(llx - 3000, lly - 3000, urx + 3000, ury + 3000);
   design_rule_checker.setExtBox(ext_box);
   design_rule_checker.setDrcBox(ext_box);
 

--- a/src/drt/src/pa/FlexPA_graphics.cpp
+++ b/src/drt/src/pa/FlexPA_graphics.cpp
@@ -101,7 +101,7 @@ void FlexPAGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
 
   for (auto via : pa_vias_) {
     auto* via_def = via->getViaDef();
-    Rect bbox;
+    odb::Rect bbox;
     bool skip = false;
     if (via_def->getLayer1Num() == layer_num) {
       bbox = via->getLayer1BBox();
@@ -119,7 +119,7 @@ void FlexPAGraphics::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
 
   for (auto seg : pa_segs_) {
     if (seg->getLayerNum() == layer_num) {
-      Rect bbox = seg->getBBox();
+      odb::Rect bbox = seg->getBBox();
       painter.setPen(layer, /* cosmetic */ true);
       painter.setBrush(layer);
       painter.drawRect({bbox.xMin(), bbox.yMin(), bbox.xMax(), bbox.yMax()});
@@ -198,7 +198,7 @@ void FlexPAGraphics::startPin(frBPin* pin,
   pin_ = pin;
   inst_term_ = nullptr;
 
-  Rect box = term->getBBox();
+  odb::Rect box = term->getBBox();
   gui_->zoomTo({box.xMin(), box.yMin(), box.xMax(), box.yMax()});
   gui_->pause();
 }
@@ -256,7 +256,7 @@ void FlexPAGraphics::setViaAP(
   pa_segs_.clear();
   pa_markers_ = &markers;
   for (auto& marker : markers) {
-    Rect bbox = marker->getBBox();
+    odb::Rect bbox = marker->getBBox();
     std::string layer_name;
     for (auto& layer : layer_map_) {
       if (layer.first == marker->getLayerNum()) {
@@ -298,7 +298,7 @@ void FlexPAGraphics::setPlanarAP(
   pa_segs_ = {seg};
   pa_markers_ = &markers;
   for (auto& marker : markers) {
-    Rect bbox = marker->getBBox();
+    odb::Rect bbox = marker->getBBox();
     logger_->info(DRT,
                   292,
                   "Marker {} at ({}, {}) ({}, {}).",
@@ -342,7 +342,7 @@ void FlexPAGraphics::setObjsAndMakers(
   }
   pa_markers_ = &markers;
   for (auto& marker : markers) {
-    Rect bbox = marker->getBBox();
+    odb::Rect bbox = marker->getBBox();
     logger_->info(DRT,
                   281,
                   "Marker {} at ({}, {}) ({}, {}).",

--- a/src/drt/src/pa/FlexPA_graphics.h
+++ b/src/drt/src/pa/FlexPA_graphics.h
@@ -98,7 +98,7 @@ class FlexPAGraphics : public gui::Renderer, public AbstractPAGraphics
   std::vector<const frVia*> pa_vias_;
   std::vector<const frPathSeg*> pa_segs_;
   const std::vector<std::unique_ptr<frMarker>>* pa_markers_;
-  std::vector<std::pair<Rect, frLayerNum>> shapes_;
+  std::vector<std::pair<odb::Rect, frLayerNum>> shapes_;
 };
 
 }  // namespace drt

--- a/src/drt/src/pa/FlexPA_init.cpp
+++ b/src/drt/src/pa/FlexPA_init.cpp
@@ -11,6 +11,7 @@
 #include "db/obj/frInst.h"
 #include "frBaseTypes.h"
 #include "gc/FlexGC.h"
+#include "odb/geom.h"
 #include "pa/FlexPA.h"
 
 namespace drt {
@@ -39,7 +40,7 @@ ViaRawPriorityTuple FlexPA::getViaRawPriority(const frViaDef* via_def)
   gtl::polygon_90_set_data<frCoord> via_layer_ps1;
 
   for (auto& fig : via_def->getLayer1Figs()) {
-    const Rect bbox = fig->getBBox();
+    const odb::Rect bbox = fig->getBBox();
     gtl::rectangle_data<frCoord> bbox_rect(
         bbox.xMin(), bbox.yMin(), bbox.xMax(), bbox.yMax());
     using boost::polygon::operators::operator+=;
@@ -62,7 +63,7 @@ ViaRawPriorityTuple FlexPA::getViaRawPriority(const frViaDef* via_def)
 
   gtl::polygon_90_set_data<frCoord> via_layer_PS2;
   for (auto& fig : via_def->getLayer2Figs()) {
-    const Rect bbox = fig->getBBox();
+    const odb::Rect bbox = fig->getBBox();
     const gtl::rectangle_data<frCoord> bbox_rect(
         bbox.xMin(), bbox.yMin(), bbox.xMax(), bbox.yMax());
     using boost::polygon::operators::operator+=;

--- a/src/drt/src/pa/FlexPA_row_pattern.cpp
+++ b/src/drt/src/pa/FlexPA_row_pattern.cpp
@@ -62,7 +62,7 @@ std::vector<std::vector<frInst*>> FlexPA::computeInstRows()
     }
     row_insts.push_back(inst);
     prev_y_coord = origin.y();
-    Rect inst_boundary_box = inst->getBoundaryBBox();
+    odb::Rect inst_boundary_box = inst->getBoundaryBBox();
     prev_x_end_coord = inst_boundary_box.xMax();
   }
   if (!row_insts.empty()) {

--- a/src/drt/src/pa/FlexPA_unique.cpp
+++ b/src/drt/src/pa/FlexPA_unique.cpp
@@ -136,7 +136,8 @@ void UniqueInsts::initMasterToPinLayerRange()
   }
 }
 
-bool UniqueInsts::hasTrackPattern(frTrackPattern* tp, const Rect& box) const
+bool UniqueInsts::hasTrackPattern(frTrackPattern* tp,
+                                  const odb::Rect& box) const
 {
   const bool is_vertical_track = tp->isHorizontal();
   const frCoord low = tp->getStartCoord();
@@ -160,7 +161,7 @@ bool UniqueInsts::isNDRInst(frInst* inst) const
 UniqueClassKey UniqueInsts::computeUniqueClassKey(frInst* inst) const
 {
   const Point origin = inst->getOrigin();
-  const Rect boundary_bbox = inst->getBoundaryBBox();
+  const odb::Rect boundary_bbox = inst->getBoundaryBBox();
   const dbOrientType orient = inst->getOrient();
   auto it = master_to_pin_layer_range_.find(inst->getMaster());
   if (it == master_to_pin_layer_range_.end()) {

--- a/src/drt/src/pa/FlexPA_unique.h
+++ b/src/drt/src/pa/FlexPA_unique.h
@@ -176,7 +176,7 @@ class UniqueInsts
    * terminal.
    */
   bool isNDRInst(frInst* inst) const;
-  bool hasTrackPattern(frTrackPattern* tp, const Rect& box) const;
+  bool hasTrackPattern(frTrackPattern* tp, const odb::Rect& box) const;
 
   /**
    * @brief Creates a vector of preferred track patterns.
@@ -215,7 +215,7 @@ class UniqueInsts
    * @brief Raises an error if pin shape is illegal.
    *
    * @throws DRT 320/321 if the term has offgrid pin shape
-   * @throws DRT 322 if the pin figure is unsuported (not Rect of Polygon)
+   * @throws DRT 322 if the pin figure is unsuported (not odb::Rect of Polygon)
    *
    * @param pin Pin to be checked.
    */

--- a/src/drt/src/rp/FlexRP.h
+++ b/src/drt/src/rp/FlexRP.h
@@ -34,7 +34,9 @@ class FlexRP
   // functions
   void prep_viaForbiddenThrough();
   void prep_minStepViasCheck();
-  bool hasMinStepViol(const Rect& r1, const Rect& r2, frLayerNum lNum);
+  bool hasMinStepViol(const odb::Rect& r1,
+                      const odb::Rect& r2,
+                      frLayerNum lNum);
   void prep_viaForbiddenThrough_helper(const frLayerNum& lNum,
                                        const int& tableLayerIdx,
                                        const int& tableEntryIdx,
@@ -134,9 +136,9 @@ class FlexRP
       ForbiddenRanges& forbiddenRanges);
 
   void prep_via2viaForbiddenLen_lef58CutSpc_helper(
-      const Rect& enclosureBox1,
-      const Rect& enclosureBox2,
-      const Rect& cutBox,
+      const odb::Rect& enclosureBox1,
+      const odb::Rect& enclosureBox2,
+      const odb::Rect& cutBox,
       frCoord reqSpcVal,
       std::pair<frCoord, frCoord>& range);
 

--- a/src/drt/src/rp/FlexRP_prep.cpp
+++ b/src/drt/src/rp/FlexRP_prep.cpp
@@ -20,6 +20,7 @@
 #include "gc/FlexGC.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "odb/geom.h"
 #include "rp/FlexRP.h"
 #include "utl/Logger.h"
 
@@ -64,8 +65,8 @@ void FlexRP::prep_minStepViasCheck()
       continue;
     }
 
-    const Rect upViaBox = upVia->getLayer1ShapeBox();
-    const Rect downViaBox = downVia->getLayer2ShapeBox();
+    const odb::Rect upViaBox = upVia->getLayer1ShapeBox();
+    const odb::Rect downViaBox = downVia->getLayer2ShapeBox();
     const gtl::rectangle_data<frCoord> upViaRect(
         upViaBox.xMin(), upViaBox.yMin(), upViaBox.xMax(), upViaBox.yMax());
     const gtl::rectangle_data<frCoord> downViaRect(downViaBox.xMin(),
@@ -307,7 +308,7 @@ void FlexRP::prep_cutSpcTbl()
         continue;
       }
       frVia via(viaDef);
-      Rect tmpBx = via.getCutBBox();
+      odb::Rect tmpBx = via.getCutBBox();
       frString cutClass1;
       const auto cutClassIdx1
           = layer->getCutClassIdx(tmpBx.minDXDY(), tmpBx.maxDXDY());
@@ -601,7 +602,7 @@ void FlexRP::prep_viaForbiddenTurnLen_minSpc(const frLayerNum& lNum,
   }
 
   const frVia via1(viaDef);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
   } else {
@@ -735,8 +736,8 @@ void FlexRP::prep_via2viaForbiddenLen_helper(const frLayerNum& lNum,
   }
 }
 
-bool FlexRP::hasMinStepViol(const Rect& r1,
-                            const Rect& r2,
+bool FlexRP::hasMinStepViol(const odb::Rect& r1,
+                            const odb::Rect& r2,
                             const frLayerNum lNum)
 {
   const gtl::rectangle_data<frCoord> rect1(
@@ -821,7 +822,7 @@ void FlexRP::prep_via2viaForbiddenLen_minStep(const frLayerNum& lNum,
   if (viaDef1->getLayer1Num() == viaDef2->getLayer1Num()) {
     return;
   }
-  Rect enclosureBox1, enclosureBox2;
+  odb::Rect enclosureBox1, enclosureBox2;
   const frVia via1(viaDef1);
   const frVia via2(viaDef2);
   if (viaDef1->getLayer1Num() == lNum) {
@@ -831,7 +832,7 @@ void FlexRP::prep_via2viaForbiddenLen_minStep(const frLayerNum& lNum,
     enclosureBox1 = via1.getLayer2BBox();
     enclosureBox2 = via2.getLayer1BBox();
   }
-  Rect *shifting, *other;
+  odb::Rect *shifting, *other;
   // get the rect with lesser width (the shifting one)
   if (isVertical) {
     if (enclosureBox1.dx() < enclosureBox2.dx()) {
@@ -1001,7 +1002,7 @@ void FlexRP::prep_via2viaForbiddenLen_lef58CutSpc(
     return;
   }
 
-  Rect enclosureBox1;
+  odb::Rect enclosureBox1;
   const frVia via1(viaDef1);
   const frVia via2(viaDef2);
   if (viaDef1->getLayer1Num() == lNum) {
@@ -1009,14 +1010,14 @@ void FlexRP::prep_via2viaForbiddenLen_lef58CutSpc(
   } else {
     enclosureBox1 = via1.getLayer2BBox();
   }
-  Rect enclosureBox2;
+  odb::Rect enclosureBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     enclosureBox2 = via2.getLayer1BBox();
   } else {
     enclosureBox2 = via2.getLayer2BBox();
   }
-  const Rect cutBox1 = via1.getCutBBox();
-  const Rect cutBox2 = via2.getCutBBox();
+  const odb::Rect cutBox1 = via1.getCutBBox();
+  const odb::Rect cutBox2 = via2.getCutBBox();
   std::pair<frCoord, frCoord> range;
   frCoord reqSpcVal = 0;
   // check via1 cut layer to lNum
@@ -1104,7 +1105,7 @@ void FlexRP::prep_via2viaForbiddenLen_lef58CutSpcTbl(
   }
   const bool isCurrDirY = !isCurrDirX;
   const frVia via1(viaDef1);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef1->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
   } else {
@@ -1112,14 +1113,14 @@ void FlexRP::prep_via2viaForbiddenLen_lef58CutSpcTbl(
   }
 
   const frVia via2(viaDef2);
-  Rect viaBox2;
+  odb::Rect viaBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     viaBox2 = via2.getLayer1BBox();
   } else {
     viaBox2 = via2.getLayer2BBox();
   }
-  const Rect cutBox1 = via1.getCutBBox();
-  const Rect cutBox2 = via2.getCutBBox();
+  const odb::Rect cutBox1 = via1.getCutBBox();
+  const odb::Rect cutBox2 = via2.getCutBBox();
   const auto layer1 = tech_->getLayer(viaDef1->getCutLayerNum());
   const auto layer2 = tech_->getLayer(viaDef2->getCutLayerNum());
   const auto cutClassIdx1
@@ -1198,9 +1199,9 @@ void FlexRP::prep_via2viaForbiddenLen_lef58CutSpcTbl(
 }
 
 void FlexRP::prep_via2viaForbiddenLen_lef58CutSpc_helper(
-    const Rect& enclosureBox1,
-    const Rect& enclosureBox2,
-    const Rect& cutBox,
+    const odb::Rect& enclosureBox1,
+    const odb::Rect& enclosureBox2,
+    const odb::Rect& cutBox,
     const frCoord reqSpcVal,
     std::pair<frCoord, frCoord>& range)
 {
@@ -1233,7 +1234,7 @@ void FlexRP::prep_via2viaForbiddenLen_minimumCut(
 
   bool isVia1Above = false;
   const frVia via1(viaDef1);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef1->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
     isVia1Above = true;
@@ -1241,13 +1242,13 @@ void FlexRP::prep_via2viaForbiddenLen_minimumCut(
     viaBox1 = via1.getLayer2BBox();
     isVia1Above = false;
   }
-  const Rect cutBox1 = via1.getCutBBox();
+  const odb::Rect cutBox1 = via1.getCutBBox();
   const int width1 = viaBox1.minDXDY();
   const int length1 = viaBox1.maxDXDY();
 
   bool isVia2Above = false;
   const frVia via2(viaDef2);
-  Rect viaBox2;
+  odb::Rect viaBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     viaBox2 = via2.getLayer1BBox();
     isVia2Above = true;
@@ -1255,7 +1256,7 @@ void FlexRP::prep_via2viaForbiddenLen_minimumCut(
     viaBox2 = via2.getLayer2BBox();
     isVia2Above = false;
   }
-  const Rect cutBox2 = via2.getCutBBox();
+  const odb::Rect cutBox2 = via2.getCutBBox();
   const int width2 = viaBox2.minDXDY();
   const int length2 = viaBox2.maxDXDY();
 
@@ -1345,11 +1346,11 @@ void FlexRP::prep_via2viaForbiddenLen_widthViaMap(
   const bool isVia2Above = (viaDef2->getLayer1Num() == lNum);
   assert(isVia1Above != isVia2Above);
 
-  const Rect viaBox1(isVia1Above ? viaDef1->getLayer1ShapeBox()
-                                 : viaDef1->getLayer2ShapeBox());
+  const odb::Rect viaBox1(isVia1Above ? viaDef1->getLayer1ShapeBox()
+                                      : viaDef1->getLayer2ShapeBox());
 
-  const Rect viaBox2(isVia2Above ? viaDef2->getLayer1ShapeBox()
-                                 : viaDef2->getLayer2ShapeBox());
+  const odb::Rect viaBox2(isVia2Above ? viaDef2->getLayer1ShapeBox()
+                                      : viaDef2->getLayer2ShapeBox());
 
   int lower_width;
   int upper_width;
@@ -1384,8 +1385,8 @@ void FlexRP::prep_via2viaForbiddenLen_widthViaMap(
     return;
   }
 
-  const Rect cutBox1 = viaDef1->getCutShapeBox();
-  const Rect cutBox2 = viaDef2->getCutShapeBox();
+  const odb::Rect cutBox1 = viaDef1->getCutShapeBox();
+  const odb::Rect cutBox2 = viaDef2->getCutShapeBox();
 
   frCoord minReqDist;
   if (isCurrDirX) {
@@ -1424,22 +1425,22 @@ void FlexRP::prep_via2viaForbiddenLen_cutSpc(const frLayerNum& lNum,
   const bool isCurrDirY = !isCurrDirX;
 
   const frVia via1(viaDef1);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef1->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
   } else {
     viaBox1 = via1.getLayer2BBox();
   }
-  const Rect cutBox1 = via1.getCutBBox();
+  const odb::Rect cutBox1 = via1.getCutBBox();
 
   const frVia via2(viaDef2);
-  Rect viaBox2;
+  odb::Rect viaBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     viaBox2 = via2.getLayer1BBox();
   } else {
     viaBox2 = via2.getLayer2BBox();
   }
-  const Rect cutBox2 = via2.getCutBBox();
+  const odb::Rect cutBox2 = via2.getCutBBox();
 
   // same layer (use samenet rule if exist, otherwise use diffnet rule)
   if (viaDef1->getCutLayerNum() == viaDef2->getCutLayerNum()) {
@@ -1554,7 +1555,7 @@ void FlexRP::prep_via2viaForbiddenLen_minSpc(frLayerNum lNum,
   const frCoord defaultWidth = tech_->getLayer(lNum)->getWidth();
 
   const frVia via1(viaDef1);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef1->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
   } else {
@@ -1566,7 +1567,7 @@ void FlexRP::prep_via2viaForbiddenLen_minSpc(frLayerNum lNum,
   auto prl1 = isCurrDirX ? viaBox1.dy() : viaBox1.dx();
 
   const frVia via2(viaDef2);
-  Rect viaBox2;
+  odb::Rect viaBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     viaBox2 = via2.getLayer1BBox();
   } else {
@@ -1660,14 +1661,14 @@ void FlexRP::prep_via2viaPRL(const frLayerNum lNum,
     return;
   }
   const frVia via1(viaDef1);
-  Rect viaBox1;
+  odb::Rect viaBox1;
   if (viaDef1->getLayer1Num() == lNum) {
     viaBox1 = via1.getLayer1BBox();
   } else {
     viaBox1 = via1.getLayer2BBox();
   }
   const frVia via2(viaDef2);
-  Rect viaBox2;
+  odb::Rect viaBox2;
   if (viaDef2->getLayer1Num() == lNum) {
     viaBox2 = via2.getLayer1BBox();
   } else {

--- a/src/drt/src/ta/FlexTA.cpp
+++ b/src/drt/src/ta/FlexTA.cpp
@@ -109,13 +109,13 @@ int FlexTA::initTA_helper(int iter,
       auto uworker = std::make_unique<FlexTAWorker>(
           getDesign(), logger_, router_cfg_, save_updates_);
       auto& worker = *(uworker.get());
-      Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(0, i));
-      Rect endBox = getDesign()->getTopBlock()->getGCellBox(
+      odb::Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(0, i));
+      odb::Rect endBox = getDesign()->getTopBlock()->getGCellBox(
           Point((int) xgp.getCount() - 1,
                 std::min(i + size - 1, (int) ygp.getCount() - 1)));
-      Rect routeBox(
+      odb::Rect routeBox(
           beginBox.xMin(), beginBox.yMin(), endBox.xMax(), endBox.yMax());
-      Rect extBox;
+      odb::Rect extBox;
       routeBox.bloat(ygp.getSpacing() / 2, extBox);
       worker.setRouteBox(routeBox);
       worker.setExtBox(extBox);
@@ -132,13 +132,13 @@ int FlexTA::initTA_helper(int iter,
       auto uworker = std::make_unique<FlexTAWorker>(
           getDesign(), logger_, router_cfg_, save_updates_);
       auto& worker = *(uworker.get());
-      Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(i, 0));
-      Rect endBox = getDesign()->getTopBlock()->getGCellBox(
+      odb::Rect beginBox = getDesign()->getTopBlock()->getGCellBox(Point(i, 0));
+      odb::Rect endBox = getDesign()->getTopBlock()->getGCellBox(
           Point(std::min(i + size - 1, (int) xgp.getCount() - 1),
                 (int) ygp.getCount() - 1));
-      Rect routeBox(
+      odb::Rect routeBox(
           beginBox.xMin(), beginBox.yMin(), endBox.xMax(), endBox.yMax());
-      Rect extBox;
+      odb::Rect extBox;
       routeBox.bloat(xgp.getSpacing() / 2, extBox);
       worker.setRouteBox(routeBox);
       worker.setExtBox(extBox);

--- a/src/drt/src/ta/FlexTA.h
+++ b/src/drt/src/ta/FlexTA.h
@@ -65,33 +65,33 @@ class FlexTAWorkerRegionQuery
 
   void add(taPinFig* fig);
   void remove(taPinFig* fig);
-  void query(const Rect& box,
+  void query(const odb::Rect& box,
              frLayerNum layerNum,
              frOrderedIdSet<taPin*>& result) const;
 
-  void addCost(const Rect& box,
+  void addCost(const odb::Rect& box,
                frLayerNum layerNum,
                frBlockObject* obj,
                frConstraint* con);
-  void removeCost(const Rect& box,
+  void removeCost(const odb::Rect& box,
                   frLayerNum layerNum,
                   frBlockObject* obj,
                   frConstraint* con);
   void queryCost(
-      const Rect& box,
+      const odb::Rect& box,
       frLayerNum layerNum,
       std::vector<rq_box_value_t<std::pair<frBlockObject*, frConstraint*>>>&
           result) const;
-  void addViaCost(const Rect& box,
+  void addViaCost(const odb::Rect& box,
                   frLayerNum layerNum,
                   frBlockObject* obj,
                   frConstraint* con);
-  void removeViaCost(const Rect& box,
+  void removeViaCost(const odb::Rect& box,
                      frLayerNum layerNum,
                      frBlockObject* obj,
                      frConstraint* con);
   void queryViaCost(
-      const Rect& box,
+      const odb::Rect& box,
       frLayerNum layerNum,
       std::vector<rq_box_value_t<std::pair<frBlockObject*, frConstraint*>>>&
           result) const;
@@ -125,8 +125,8 @@ class FlexTAWorker
   {
   }
   // setters
-  void setRouteBox(const Rect& boxIn) { routeBox_ = boxIn; }
-  void setExtBox(const Rect& boxIn) { extBox_ = boxIn; }
+  void setRouteBox(const odb::Rect& boxIn) { routeBox_ = boxIn; }
+  void setExtBox(const odb::Rect& boxIn) { extBox_ = boxIn; }
   void setDir(const dbTechLayerDir& in) { dir_ = in; }
   void setTAIter(int in) { taIter_ = in; }
   void addIroute(std::unique_ptr<taPin> in, bool isExt = false)
@@ -159,8 +159,8 @@ class FlexTAWorker
   // getters
   frTechObject* getTech() const { return design_->getTech(); }
   frDesign* getDesign() const { return design_; }
-  const Rect& getRouteBox() const { return routeBox_; }
-  const Rect& getExtBox() const { return extBox_; }
+  const odb::Rect& getRouteBox() const { return routeBox_; }
+  const odb::Rect& getExtBox() const { return extBox_; }
   dbTechLayerDir getDir() const { return dir_; }
   int getTAIter() const { return taIter_; }
   bool isInitTA() const { return (taIter_ == 0); }
@@ -194,8 +194,8 @@ class FlexTAWorker
   utl::Logger* logger_;
   RouterConfiguration* router_cfg_;
   bool save_updates_;
-  Rect routeBox_;
-  Rect extBox_;
+  odb::Rect routeBox_;
+  odb::Rect extBox_;
   dbTechLayerDir dir_;
   int taIter_;
   FlexTAWorkerRegionQuery rq_;
@@ -215,12 +215,12 @@ class FlexTAWorker
   void initFixedObjs();
   frCoord initFixedObjs_calcBloatDist(frBlockObject* obj,
                                       frLayerNum lNum,
-                                      const Rect& box);
+                                      const odb::Rect& box);
   frCoord initFixedObjs_calcOBSBloatDistVia(const frViaDef* viaDef,
                                             frLayerNum lNum,
-                                            const Rect& box,
+                                            const odb::Rect& box,
                                             bool isOBS = true);
-  void initFixedObjs_helper(const Rect& box,
+  void initFixedObjs_helper(const odb::Rect& box,
                             frCoord bloatDist,
                             frLayerNum lNum,
                             frNet* net,
@@ -254,11 +254,11 @@ class FlexTAWorker
   void sortIroutes();
   bool outOfDieVia(frLayerNum layer_num,
                    const Point& pt,
-                   const Rect& die_box) const;
+                   const odb::Rect& die_box) const;
 
   // quick drc
-  frSquaredDistance box2boxDistSquare(const Rect& box1,
-                                      const Rect& box2,
+  frSquaredDistance box2boxDistSquare(const odb::Rect& box1,
+                                      const odb::Rect& box2,
                                       frCoord& dx,
                                       frCoord& dy);
   void addCost(taPinFig* fig, frOrderedIdSet<taPin*>* pinS = nullptr);
@@ -266,19 +266,19 @@ class FlexTAWorker
   void modCost(taPinFig* fig,
                bool isAddCost,
                frOrderedIdSet<taPin*>* pinS = nullptr);
-  void modMinSpacingCostPlanar(const Rect& box,
+  void modMinSpacingCostPlanar(const odb::Rect& box,
                                frLayerNum lNum,
                                taPinFig* fig,
                                bool isAddCost,
                                frOrderedIdSet<taPin*>* pinS = nullptr);
-  void modMinSpacingCostVia(const Rect& box,
+  void modMinSpacingCostVia(const odb::Rect& box,
                             frLayerNum lNum,
                             taPinFig* fig,
                             bool isAddCost,
                             bool isUpperVia,
                             bool isCurrPs,
                             frOrderedIdSet<taPin*>* pinS = nullptr);
-  void modCutSpacingCost(const Rect& box,
+  void modCutSpacingCost(const odb::Rect& box,
                          frLayerNum lNum,
                          taPinFig* fig,
                          bool isAddCost,
@@ -311,7 +311,7 @@ class FlexTAWorker
   frUInt4 assignIroute_getAlignCost(taPin* iroute, frCoord trackLoc);
   frUInt4 assignIroute_getDRCCost(taPin* iroute, frCoord trackLoc);
   frUInt4 assignIroute_getDRCCost_helper(taPin* iroute,
-                                         Rect& box,
+                                         odb::Rect& box,
                                          frLayerNum lNum);
   void assignIroute_updateIroute(taPin* iroute,
                                  frCoord bestTrackLoc,

--- a/src/drt/src/ta/FlexTA_rq.cpp
+++ b/src/drt/src/ta/FlexTA_rq.cpp
@@ -13,6 +13,7 @@
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "frRTree.h"
+#include "odb/geom.h"
 #include "ta/FlexTA.h"
 
 namespace drt {
@@ -46,16 +47,16 @@ frDesign* FlexTAWorkerRegionQuery::getDesign() const
 
 void FlexTAWorkerRegionQuery::add(taPinFig* fig)
 {
-  Rect box;
+  odb::Rect box;
   if (fig->typeId() == tacPathSeg) {
     auto obj = static_cast<taPathSeg*>(fig);
     auto [bp, ep] = obj->getPoints();
-    box = Rect(bp, ep);
+    box = odb::Rect(bp, ep);
     impl_->shapes.at(obj->getLayerNum()).insert(std::make_pair(box, obj));
   } else if (fig->typeId() == tacVia) {
     auto obj = static_cast<taVia*>(fig);
     auto bp = obj->getOrigin();
-    box = Rect(bp, bp);
+    box = odb::Rect(bp, bp);
     impl_->shapes.at(obj->getViaDef()->getCutLayerNum())
         .insert(std::make_pair(box, obj));
   } else {
@@ -65,16 +66,16 @@ void FlexTAWorkerRegionQuery::add(taPinFig* fig)
 
 void FlexTAWorkerRegionQuery::remove(taPinFig* fig)
 {
-  Rect box;
+  odb::Rect box;
   if (fig->typeId() == tacPathSeg) {
     auto obj = static_cast<taPathSeg*>(fig);
     auto [bp, ep] = obj->getPoints();
-    box = Rect(bp, ep);
+    box = odb::Rect(bp, ep);
     impl_->shapes.at(obj->getLayerNum()).remove(std::make_pair(box, obj));
   } else if (fig->typeId() == tacVia) {
     auto obj = static_cast<taVia*>(fig);
     auto bp = obj->getOrigin();
-    box = Rect(bp, bp);
+    box = odb::Rect(bp, bp);
     impl_->shapes.at(obj->getViaDef()->getCutLayerNum())
         .remove(std::make_pair(box, obj));
   } else {
@@ -82,7 +83,7 @@ void FlexTAWorkerRegionQuery::remove(taPinFig* fig)
   }
 }
 
-void FlexTAWorkerRegionQuery::query(const Rect& box,
+void FlexTAWorkerRegionQuery::query(const odb::Rect& box,
                                     const frLayerNum layerNum,
                                     frOrderedIdSet<taPin*>& result) const
 {
@@ -105,7 +106,7 @@ void FlexTAWorkerRegionQuery::init()
   impl_->via_costs.resize(numLayers);
 }
 
-void FlexTAWorkerRegionQuery::addCost(const Rect& box,
+void FlexTAWorkerRegionQuery::addCost(const odb::Rect& box,
                                       const frLayerNum layerNum,
                                       frBlockObject* obj,
                                       frConstraint* con)
@@ -114,7 +115,7 @@ void FlexTAWorkerRegionQuery::addCost(const Rect& box,
       std::make_pair(box, std::make_pair(obj, con)));
 }
 
-void FlexTAWorkerRegionQuery::removeCost(const Rect& box,
+void FlexTAWorkerRegionQuery::removeCost(const odb::Rect& box,
                                          const frLayerNum layerNum,
                                          frBlockObject* obj,
                                          frConstraint* con)
@@ -124,7 +125,7 @@ void FlexTAWorkerRegionQuery::removeCost(const Rect& box,
 }
 
 void FlexTAWorkerRegionQuery::queryCost(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<rq_box_value_t<std::pair<frBlockObject*, frConstraint*>>>&
         result) const
@@ -133,7 +134,7 @@ void FlexTAWorkerRegionQuery::queryCost(
                                         back_inserter(result));
 }
 
-void FlexTAWorkerRegionQuery::addViaCost(const Rect& box,
+void FlexTAWorkerRegionQuery::addViaCost(const odb::Rect& box,
                                          const frLayerNum layerNum,
                                          frBlockObject* obj,
                                          frConstraint* con)
@@ -142,7 +143,7 @@ void FlexTAWorkerRegionQuery::addViaCost(const Rect& box,
       std::make_pair(box, std::make_pair(obj, con)));
 }
 
-void FlexTAWorkerRegionQuery::removeViaCost(const Rect& box,
+void FlexTAWorkerRegionQuery::removeViaCost(const odb::Rect& box,
                                             const frLayerNum layerNum,
                                             frBlockObject* obj,
                                             frConstraint* con)
@@ -152,7 +153,7 @@ void FlexTAWorkerRegionQuery::removeViaCost(const Rect& box,
 }
 
 void FlexTAWorkerRegionQuery::queryViaCost(
-    const Rect& box,
+    const odb::Rect& box,
     const frLayerNum layerNum,
     std::vector<rq_box_value_t<std::pair<frBlockObject*, frConstraint*>>>&
         result) const

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -163,7 +163,7 @@ frBlockage* Fixture::makeMacroObs(frMaster* master,
   pinIn->setId(0);
   // pinFig
   std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-  pinFig->setBBox(Rect(xl, yl, xh, yh));
+  pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
   pinFig->addToPin(pinIn.get());
   pinFig->setLayerNum(lNum);
   std::unique_ptr<frPinFig> uptr(std::move(pinFig));
@@ -194,7 +194,7 @@ frTerm* Fixture::makeMacroPin(frMaster* master,
   auto pinIn = std::make_unique<frMPin>();
   pinIn->setId(0);
   std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-  pinFig->setBBox(Rect(xl, yl, xh, yh));
+  pinFig->setBBox(odb::Rect(xl, yl, xh, yh));
   pinFig->addToPin(pinIn.get());
   pinFig->setLayerNum(lNum);
   std::unique_ptr<frPinFig> uptr(std::move(pinFig));
@@ -737,7 +737,7 @@ frViaDef* Fixture::makeViaDef(const char* name,
   auto via_p = std::make_unique<frViaDef>(name);
   for (frLayerNum l = layer_num - 1; l <= layer_num + 1; l++) {
     std::unique_ptr<frRect> pinFig = std::make_unique<frRect>();
-    pinFig->setBBox(Rect(ll, ur));
+    pinFig->setBBox(odb::Rect(ll, ur));
     pinFig->setLayerNum(l);
     switch (l - layer_num) {
       case -1:

--- a/src/drt/test/gcTest.cpp
+++ b/src/drt/test/gcTest.cpp
@@ -50,6 +50,7 @@
 #include "frDesign.h"
 #include "gc/FlexGC.h"
 #include "odb/db.h"
+#include "odb/geom.h"
 
 namespace drt {
 
@@ -63,9 +64,9 @@ struct GCFixture : public Fixture
   void testMarker(frMarker* marker,
                   frLayerNum layer_num,
                   frConstraintTypeEnum type,
-                  const Rect& expected_bbox)
+                  const odb::Rect& expected_bbox)
   {
-    Rect bbox = marker->getBBox();
+    odb::Rect bbox = marker->getBBox();
 
     BOOST_TEST(marker->getLayerNum() == layer_num);
     BOOST_TEST(marker->getConstraint());
@@ -80,7 +81,7 @@ struct GCFixture : public Fixture
     initRegionQuery();
 
     // Run the GC engine
-    const Rect work(0, 0, 2000, 2000);
+    const odb::Rect work(0, 0, 2000, 2000);
     worker.setExtBox(work);
     worker.setDrcBox(work);
 
@@ -112,7 +113,7 @@ BOOST_AUTO_TEST_CASE(metal_short)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcShortConstraint,
-             Rect(499, -50, 501, 50));
+             odb::Rect(499, -50, 501, 50));
 }
 
 /*
@@ -161,7 +162,7 @@ BOOST_AUTO_TEST_CASE(metal_short_obs)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcShortConstraint,
-             Rect(450, -50, 550, 40));
+             odb::Rect(450, -50, 550, 40));
 
   // shorts of net (0,-50), (600,50)
   // with obs (450,-50), (750,200)
@@ -169,11 +170,11 @@ BOOST_AUTO_TEST_CASE(metal_short_obs)
   testMarker(markers[1].get(),
              2,
              frConstraintTypeEnum::frcShortConstraint,
-             Rect(550, -50, 600, 50));
+             odb::Rect(550, -50, 600, 50));
   testMarker(markers[2].get(),
              2,
              frConstraintTypeEnum::frcShortConstraint,
-             Rect(450, -50, 600, 40));
+             odb::Rect(450, -50, 600, 40));
 }
 
 // Two touching metal shape from the same net must have sufficient
@@ -195,7 +196,7 @@ BOOST_AUTO_TEST_CASE(metal_non_sufficient)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcNonSufficientMetalConstraint,
-             Rect(0, 0, 50, 50));
+             odb::Rect(0, 0, 50, 50));
 }
 
 // Path seg less than min width flags a violation
@@ -226,7 +227,7 @@ BOOST_DATA_TEST_CASE(min_cut,
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcMinimumcutConstraint,
-               Rect(200, 50, 400, 150));
+               odb::Rect(200, 50, 400, 150));
   }
 }
 
@@ -247,7 +248,7 @@ BOOST_AUTO_TEST_CASE(min_width)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcMinWidthConstraint,
-             Rect(0, -30, 500, 30));
+             odb::Rect(0, -30, 500, 30));
 }
 
 // Abutting Path seg less than min width don't flag a violation
@@ -283,7 +284,7 @@ BOOST_AUTO_TEST_CASE(off_grid)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcOffGridConstraint,
-             Rect(1, -49, 501, 51));
+             odb::Rect(1, -49, 501, 51));
 }
 
 // Check violation for corner spacing
@@ -306,7 +307,7 @@ BOOST_AUTO_TEST_CASE(corner_basic)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58CornerSpacingConstraint,
-             Rect(500, 50, 500, 150));
+             odb::Rect(500, 50, 500, 150));
 }
 
 // Check no violation for corner spacing with EOL spacing
@@ -382,7 +383,7 @@ BOOST_AUTO_TEST_CASE(corner_concave, *boost::unit_test::disabled())
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58CornerSpacingConstraint,
-             Rect(50, 50, 200, 200));
+             odb::Rect(50, 50, 200, 200));
 }
 
 // Check violation for parallel-run-length (PRL) spacing tables
@@ -423,7 +424,7 @@ BOOST_DATA_TEST_CASE(spacing_prl,
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcSpacingTablePrlConstraint,
-               Rect(0, 50, prl, y - width / 2));
+               odb::Rect(0, 50, prl, y - width / 2));
   }
 }
 
@@ -471,7 +472,7 @@ BOOST_DATA_TEST_CASE(design_rule_width, bdata::make({true, false}), legal)
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcSpacingTableTwConstraint,
-               Rect(0, 100, 500, 140));
+               odb::Rect(0, 100, 500, 140));
   }
 }
 
@@ -513,7 +514,7 @@ BOOST_AUTO_TEST_CASE(min_step58_nobetweeneol)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58MinStepConstraint,
-             Rect(200, 50, 300, 70));
+             odb::Rect(200, 50, 300, 70));
 }
 
 // Check for a lef58 style min step violation.  The checker is very
@@ -539,11 +540,11 @@ BOOST_AUTO_TEST_CASE(min_step58_minadjlength)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58MinStepConstraint,
-             Rect(150, 50, 500, 70));
+             odb::Rect(150, 50, 500, 70));
   testMarker(markers[1].get(),
              2,
              frConstraintTypeEnum::frcLef58MinStepConstraint,
-             Rect(0, 50, 250, 70));
+             odb::Rect(0, 50, 250, 70));
 }
 
 // Check for a lef58 rect only violation.  The markers are
@@ -567,15 +568,15 @@ BOOST_AUTO_TEST_CASE(rect_only)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58RectOnlyConstraint,
-             Rect(150, -50, 250, 100));
+             odb::Rect(150, -50, 250, 100));
   testMarker(markers[1].get(),
              2,
              frConstraintTypeEnum::frcLef58RectOnlyConstraint,
-             Rect(150, -50, 350, 50));
+             odb::Rect(150, -50, 350, 50));
   testMarker(markers[2].get(),
              2,
              frConstraintTypeEnum::frcLef58RectOnlyConstraint,
-             Rect(50, -50, 250, 50));
+             odb::Rect(50, -50, 250, 50));
 }
 
 // Check for a min enclosed area violation.
@@ -599,7 +600,7 @@ BOOST_AUTO_TEST_CASE(min_enclosed_area)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcMinEnclosedAreaConstraint,
-             Rect(50, 50, 150, 150));
+             odb::Rect(50, 50, 150, 150));
 }
 
 // Check for a spacing table influence violation.
@@ -623,7 +624,7 @@ BOOST_AUTO_TEST_CASE(spacing_table_infl_vertical)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcSpacingTableInfluenceConstraint,
-             Rect(100, 150, 300, 200));
+             odb::Rect(100, 150, 300, 200));
 }
 // Check for a spacing table influence violation.
 BOOST_AUTO_TEST_CASE(spacing_table_infl_horizontal)
@@ -645,7 +646,7 @@ BOOST_AUTO_TEST_CASE(spacing_table_infl_horizontal)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcSpacingTableInfluenceConstraint,
-             Rect(150, 250, 250, 450));
+             odb::Rect(150, 250, 250, 450));
 }
 
 // Check for a spacing table twowidths violation.
@@ -676,7 +677,7 @@ BOOST_AUTO_TEST_CASE(spacing_table_twowidth)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcSpacingTableTwConstraint,
-             Rect(0, 100, 500, 140));
+             odb::Rect(0, 100, 500, 140));
 }
 
 // Check for a SPACING RANGE violation.
@@ -711,7 +712,7 @@ BOOST_DATA_TEST_CASE(spacing_range,
       testMarker(markers[0].get(),
                  2,
                  frConstraintTypeEnum::frcSpacingRangeConstraint,
-                 Rect(0, 100, 1000, y - 50));
+                 odb::Rect(0, 100, 1000, y - 50));
     }
   }
 }
@@ -745,7 +746,7 @@ BOOST_DATA_TEST_CASE(spacing_range_same_diff_net,
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcSpacingRangeConstraint,
-               Rect(0, 100, 1000, 150));
+               odb::Rect(0, 100, 1000, 150));
   }
 }
 
@@ -773,7 +774,7 @@ BOOST_DATA_TEST_CASE(eol_basic, (bdata::make({true, false})), lef58)
              2,
              lef58 ? frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint
                    : frConstraintTypeEnum::frcSpacingEndOfLineConstraint,
-             Rect(450, 500, 550, 650));
+             odb::Rect(450, 500, 550, 650));
 }
 
 // Check for a basic end-of-line (EOL) spacing violation.
@@ -800,7 +801,7 @@ BOOST_AUTO_TEST_CASE(eol_endtoend)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-             Rect(100, 0, 350, 100));
+             odb::Rect(100, 0, 350, 100));
 }
 // Check for a basic end-of-line (EOL) spacing violation with extension.
 BOOST_AUTO_TEST_CASE(eol_endtoend_ext)
@@ -826,7 +827,7 @@ BOOST_AUTO_TEST_CASE(eol_endtoend_ext)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-             Rect(100, 100, 350, 150));
+             odb::Rect(100, 100, 350, 150));
 }
 
 BOOST_AUTO_TEST_CASE(eol_wrongdirspc)
@@ -872,7 +873,7 @@ BOOST_DATA_TEST_CASE(eol_ext_basic,
       testMarker(markers[0].get(),
                  2,
                  frConstraintTypeEnum::frcLef58EolExtensionConstraint,
-                 Rect(500, 50, 690, 150));
+                 odb::Rect(500, 50, 690, 150));
     }
   }
 }
@@ -910,11 +911,11 @@ BOOST_AUTO_TEST_CASE(eol_prlend)
   testMarker(markers[0].get(),
              2,
              frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-             Rect(100, 50, 320, 100));
+             odb::Rect(100, 50, 320, 100));
   testMarker(markers[1].get(),
              2,
              frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-             Rect(100, 950, 220, 1050));
+             odb::Rect(100, 950, 220, 1050));
 }
 
 BOOST_DATA_TEST_CASE(eol_ext_paronly, (bdata::make({true, false})), parOnly)
@@ -937,7 +938,7 @@ BOOST_DATA_TEST_CASE(eol_ext_paronly, (bdata::make({true, false})), parOnly)
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcLef58EolExtensionConstraint,
-               Rect(500, 150, 520, 240));
+               odb::Rect(500, 150, 520, 240));
   }
 }
 // Check for eol keepout violation.
@@ -966,7 +967,7 @@ BOOST_DATA_TEST_CASE(eol_keepout, (bdata::make({true, false})), legal)
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcLef58EolKeepOutConstraint,
-               Rect(450, 500, 550, 650));
+               odb::Rect(450, 500, 550, 650));
   }
 }
 
@@ -1018,7 +1019,7 @@ BOOST_DATA_TEST_CASE(eol_keepout_corner,
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcLef58EolKeepOutConstraint,
-               Rect(410, 500, 450, 650));
+               odb::Rect(410, 500, 450, 650));
   }
 }
 
@@ -1050,7 +1051,7 @@ BOOST_DATA_TEST_CASE(eol_parallel_edge, (bdata::make({true, false})), lef58)
              2,
              lef58 ? frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint
                    : frConstraintTypeEnum::frcSpacingEndOfLineConstraint,
-             Rect(450, 500, 550, 650));
+             odb::Rect(450, 500, 550, 650));
 }
 
 // Check for an end-of-line (EOL) spacing violation involving two
@@ -1084,7 +1085,7 @@ BOOST_DATA_TEST_CASE(eol_parallel_two_edge, (bdata::make({true, false})), lef58)
              2,
              lef58 ? frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint
                    : frConstraintTypeEnum::frcSpacingEndOfLineConstraint,
-             Rect(450, 500, 550, 650));
+             odb::Rect(450, 500, 550, 650));
 }
 
 BOOST_DATA_TEST_CASE(eol_min_max,
@@ -1133,7 +1134,7 @@ BOOST_DATA_TEST_CASE(eol_min_max,
       testMarker(markers[0].get(),
                  2,
                  frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-                 Rect(450, y, 550, 650));
+                 odb::Rect(450, y, 550, 650));
     }
   }
 }
@@ -1161,7 +1162,7 @@ BOOST_DATA_TEST_CASE(eol_enclose_cut,
       testMarker(markers[0].get(),
                  4,
                  frConstraintTypeEnum::frcLef58SpacingEndOfLineConstraint,
-                 Rect(450, 500, 550, 650));
+                 odb::Rect(450, 500, 550, 650));
     }
   }
 }
@@ -1270,7 +1271,7 @@ BOOST_AUTO_TEST_CASE(metal_width_via_map)
   testMarker(markers[0].get(),
              3,
              frConstraintTypeEnum::frcMetalWidthViaConstraint,
-             Rect(100, 0, 200, 100));
+             odb::Rect(100, 0, 200, 100));
 }
 
 BOOST_DATA_TEST_CASE(cut_spc_parallel_overlap,
@@ -1302,7 +1303,7 @@ BOOST_DATA_TEST_CASE(cut_spc_parallel_overlap,
     testMarker(markers[0].get(),
                3,
                frConstraintTypeEnum::frcLef58CutSpacingConstraint,
-               Rect(100, 0, 150, 100));
+               odb::Rect(100, 0, 150, 100));
   }
 }
 
@@ -1362,7 +1363,7 @@ BOOST_AUTO_TEST_CASE(cut_keepoutzone)
   testMarker(markers[0].get(),
              3,
              frConstraintTypeEnum::frcLef58KeepOutZoneConstraint,
-             Rect(150, 150, 200, 200));
+             odb::Rect(150, 150, 200, 200));
 }
 
 BOOST_DATA_TEST_CASE(route_wrong_direction_spc,
@@ -1414,7 +1415,7 @@ BOOST_DATA_TEST_CASE(route_wrong_direction_spc,
     testMarker(markers[0].get(),
                2,
                frConstraintTypeEnum::frcLef58SpacingWrongDirConstraint,
-               Rect(0, 100, 100, 150));
+               odb::Rect(0, 100, 100, 150));
   }
 }
 
@@ -1486,7 +1487,7 @@ BOOST_AUTO_TEST_CASE(lef58_enclosure)
     testMarker(markers[0].get(),
                4,
                frConstraintTypeEnum::frcLef58EnclosureConstraint,
-               Rect(0, 0, 200, 100));
+               odb::Rect(0, 0, 200, 100));
   }
 }
 

--- a/src/ppl/include/ppl/IOPlacer.h
+++ b/src/ppl/include/ppl/IOPlacer.h
@@ -40,7 +40,6 @@ struct Section;
 struct Slot;
 
 using odb::Point;
-using odb::Rect;
 
 using utl::Logger;
 
@@ -220,8 +219,8 @@ class IOPlacer
                       int layer,
                       int width,
                       int height,
-                      const Rect& die_boundary);
-  Interval getIntervalFromPin(IOPin& io_pin, const Rect& die_boundary);
+                      const odb::Rect& die_boundary);
+  Interval getIntervalFromPin(IOPin& io_pin, const odb::Rect& die_boundary);
   bool checkBlocked(Edge edge, odb::Line, const odb::Point& pos, int layer);
   std::vector<Interval> findBlockedIntervals(const odb::Rect& die_area,
                                              const odb::Rect& box);
@@ -237,8 +236,8 @@ class IOPlacer
 
   // db functions
   void findConstraintRegion(const Interval& interval,
-                            const Rect& constraint_box,
-                            Rect& region);
+                            const odb::Rect& constraint_box,
+                            odb::Rect& region);
   void commitIOPlacementToDB(std::vector<IOPin>& assignment);
   void commitIOPinToDB(const IOPin& pin);
   void initCore(const std::set<int>& hor_layer_idxs,

--- a/src/ppl/src/Core.h
+++ b/src/ppl/src/Core.h
@@ -11,7 +11,6 @@
 namespace ppl {
 
 using odb::Point;
-using odb::Rect;
 
 using LayerToVector = std::map<int, std::vector<int>>;
 
@@ -19,7 +18,7 @@ class Core
 {
  public:
   Core();
-  Core(const Rect& boundary,
+  Core(const odb::Rect& boundary,
        const LayerToVector& min_dst_pins_x,
        const LayerToVector& min_dst_pins_y,
        const LayerToVector& init_tracks_x,
@@ -48,7 +47,7 @@ class Core
   {
   }
 
-  Rect getBoundary() const { return boundary_; }
+  odb::Rect getBoundary() const { return boundary_; }
   const LayerToVector& getMinDstPinsX() const { return min_dst_pins_x_; }
   const LayerToVector& getMinDstPinsY() const { return min_dst_pins_y_; }
   const LayerToVector& getInitTracksX() const { return init_tracks_x_; }
@@ -65,7 +64,7 @@ class Core
   std::vector<odb::Line> getDieAreaEdges();
 
  private:
-  Rect boundary_;
+  odb::Rect boundary_;
   LayerToVector min_dst_pins_x_;
   LayerToVector min_dst_pins_y_;
   LayerToVector init_tracks_x_;

--- a/src/ppl/src/HungarianMatching.h
+++ b/src/ppl/src/HungarianMatching.h
@@ -22,7 +22,6 @@ class Logger;
 namespace ppl {
 
 using odb::Point;
-using odb::Rect;
 using utl::Logger;
 
 class HungarianMatching

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -1915,14 +1915,14 @@ Interval IOPlacer::findIntervalFromRect(const odb::Rect& rect)
 void IOPlacer::getConstraintsFromDB()
 {
   std::map<Interval, PinSet> pins_per_interval;
-  std::map<Rect, PinSet> pins_per_rect;
+  std::map<odb::Rect, PinSet> pins_per_rect;
   for (odb::dbBTerm* bterm : getBlock()->getBTerms()) {
     auto constraint_region = bterm->getConstraintRegion();
     // Constraints derived from mirrored pins are not taken into account here.
     // Only pins with constraints directly assigned by the user should be
     // considered.
     if (constraint_region && !bterm->isMirrored()) {
-      Rect region = constraint_region.value();
+      odb::Rect region = constraint_region.value();
       if (region.xMin() == region.xMax() || region.yMin() == region.yMax()) {
         Interval interval = findIntervalFromRect(constraint_region.value());
         pins_per_interval[interval].insert(bterm);
@@ -1932,7 +1932,8 @@ void IOPlacer::getConstraintsFromDB()
           logger_->error(utl::PPL, 121, "Top layer grid not found.");
         }
         if (top_grid_->region.isRect()) {
-          const Rect& top_grid_region = top_grid_->region.getEnclosingRect();
+          const odb::Rect& top_grid_region
+              = top_grid_->region.getEnclosingRect();
           if (!top_grid_region.contains(region)) {
             logger_->error(utl::PPL,
                            25,
@@ -2618,7 +2619,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
 
   odb::Point pos = odb::Point(x, y);
 
-  Rect die_boundary = getBlock()->getDieArea();
+  odb::Rect die_boundary = getBlock()->getDieArea();
   Point lb = die_boundary.ll();
   Point ub = die_boundary.ur();
 
@@ -2755,7 +2756,7 @@ void IOPlacer::movePinToTrack(odb::Point& pos,
                               int layer,
                               int width,
                               int height,
-                              const Rect& die_boundary)
+                              const odb::Rect& die_boundary)
 {
   Point lb = die_boundary.ll();
   Point ub = die_boundary.ur();
@@ -2794,7 +2795,8 @@ void IOPlacer::movePinToTrack(odb::Point& pos,
   }
 }
 
-Interval IOPlacer::getIntervalFromPin(IOPin& io_pin, const Rect& die_boundary)
+Interval IOPlacer::getIntervalFromPin(IOPin& io_pin,
+                                      const odb::Rect& die_boundary)
 {
   Edge edge;
   int begin, end, layer;
@@ -2831,7 +2833,7 @@ void IOPlacer::initCore(const std::set<int>& hor_layer_idxs,
 {
   int database_unit = getTech()->getLefUnits();
 
-  Rect boundary = getBlock()->getDieArea();
+  odb::Rect boundary = getBlock()->getDieArea();
 
   LayerToVector min_spacings_x;
   LayerToVector min_spacings_y;
@@ -2939,7 +2941,7 @@ void IOPlacer::findSlotsForTopLayer()
     if (top_grid_->region.isRect()) {
       const int half_width = top_grid_->pin_width / 2;
       const int half_height = top_grid_->pin_height / 2;
-      const Rect& top_grid_region = top_grid_->region.getEnclosingRect();
+      const odb::Rect& top_grid_region = top_grid_->region.getEnclosingRect();
       for (int x = top_grid_region.xMin(); x < top_grid_region.xMax();
            x += top_grid_->x_step) {
         for (int y = top_grid_region.yMin(); y < top_grid_region.yMax();
@@ -3056,7 +3058,7 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
 
   std::vector<Section> sections;
   if (top_grid_->region.isRect()) {
-    const Rect& top_grid_region = top_grid_->region.getEnclosingRect();
+    const odb::Rect& top_grid_region = top_grid_->region.getEnclosingRect();
     for (int x = top_grid_region.xMin(); x < top_grid_region.xMax();
          x += top_grid_->x_step) {
       if (x < lb_x || x > ub_x) {
@@ -3110,7 +3112,7 @@ std::vector<Section> IOPlacer::findSectionsForTopLayer(const odb::Rect& region)
 void IOPlacer::initNetlist()
 {
   netlist_->reset();
-  const Rect& coreBoundary = core_->getBoundary();
+  const odb::Rect& coreBoundary = core_->getBoundary();
   int x_center = (coreBoundary.xMin() + coreBoundary.xMax()) / 2;
   int y_center = (coreBoundary.yMin() + coreBoundary.yMax()) / 2;
 
@@ -3195,30 +3197,30 @@ void IOPlacer::initNetlist()
 }
 
 void IOPlacer::findConstraintRegion(const Interval& interval,
-                                    const Rect& constraint_box,
-                                    Rect& region)
+                                    const odb::Rect& constraint_box,
+                                    odb::Rect& region)
 {
-  const Rect& die_bounds = getBlock()->getDieArea();
+  const odb::Rect& die_bounds = getBlock()->getDieArea();
   if (interval.getEdge() == Edge::bottom) {
-    region = Rect(interval.getBegin(),
-                  die_bounds.yMin(),
-                  interval.getEnd(),
-                  die_bounds.yMin());
+    region = odb::Rect(interval.getBegin(),
+                       die_bounds.yMin(),
+                       interval.getEnd(),
+                       die_bounds.yMin());
   } else if (interval.getEdge() == Edge::top) {
-    region = Rect(interval.getBegin(),
-                  die_bounds.yMax(),
-                  interval.getEnd(),
-                  die_bounds.yMax());
+    region = odb::Rect(interval.getBegin(),
+                       die_bounds.yMax(),
+                       interval.getEnd(),
+                       die_bounds.yMax());
   } else if (interval.getEdge() == Edge::left) {
-    region = Rect(die_bounds.xMin(),
-                  interval.getBegin(),
-                  die_bounds.xMin(),
-                  interval.getEnd());
+    region = odb::Rect(die_bounds.xMin(),
+                       interval.getBegin(),
+                       die_bounds.xMin(),
+                       interval.getEnd());
   } else if (interval.getEdge() == Edge::right) {
-    region = Rect(die_bounds.xMax(),
-                  interval.getBegin(),
-                  die_bounds.xMax(),
-                  interval.getEnd());
+    region = odb::Rect(die_bounds.xMax(),
+                       interval.getBegin(),
+                       die_bounds.xMax(),
+                       interval.getEnd());
   } else {
     region = constraint_box;
   }

--- a/src/ppl/src/Netlist.cpp
+++ b/src/ppl/src/Netlist.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 #include <vector>
 
+#include "odb/geom.h"
 #include "ppl/IOPlacer.h"
 
 namespace ppl {
@@ -72,7 +73,7 @@ int Netlist::numIOPins()
   return io_pins_.size();
 }
 
-Rect Netlist::getBB(int idx, const Point& slot_pos)
+odb::Rect Netlist::getBB(int idx, const Point& slot_pos)
 {
   int net_start = net_pointer_[idx];
   int net_end = net_pointer_[idx + 1];
@@ -93,7 +94,7 @@ Rect Netlist::getBB(int idx, const Point& slot_pos)
   Point upper_bounds = Point(max_x, max_y);
   Point lower_bounds = Point(min_x, min_y);
 
-  Rect net_b_box(lower_bounds, upper_bounds);
+  odb::Rect net_b_box(lower_bounds, upper_bounds);
   return net_b_box;
 }
 

--- a/src/ppl/src/Netlist.h
+++ b/src/ppl/src/Netlist.h
@@ -15,7 +15,6 @@
 namespace ppl {
 
 using odb::Point;
-using odb::Rect;
 
 struct Constraint;
 struct Section;

--- a/src/ppl/src/Slots.cpp
+++ b/src/ppl/src/Slots.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "boost/container_hash/hash.hpp"
+#include "odb/geom.h"
 #include "ppl/IOPlacer.h"
 
 namespace ppl {
@@ -64,7 +65,7 @@ std::size_t IntervalHash::operator()(const Interval& interval) const
                                                          interval.getLayer()});
 }
 
-std::size_t RectHash::operator()(const Rect& rect) const
+std::size_t RectHash::operator()(const odb::Rect& rect) const
 {
   return boost::hash<std::tuple<int, int, int, int>>()(
       {rect.xMin(), rect.yMin(), rect.xMax(), rect.yMax()});

--- a/src/ppl/src/Slots.h
+++ b/src/ppl/src/Slots.h
@@ -43,7 +43,7 @@ struct IntervalHash
 
 struct RectHash
 {
-  std::size_t operator()(const Rect& rect) const;
+  std::size_t operator()(const odb::Rect& rect) const;
 };
 
 // Slot: an on-track position in the die boundary where a pin

--- a/src/rcx/include/rcx/dbUtil.h
+++ b/src/rcx/include/rcx/dbUtil.h
@@ -36,7 +36,6 @@ using odb::dbTechLayerDir;
 using odb::dbTechLayerRule;
 using odb::dbTechNonDefaultRule;
 using odb::dbTechVia;
-using odb::Rect;
 
 //
 // This class creates a new net along with a wire.
@@ -67,9 +66,12 @@ class dbCreateNetUtil
                              dbTechLayerDir dir,
                              bool skipBterms = false);
 
-  dbNet* createNetSingleWire(Rect& r, uint level, uint netId, uint shapeId);
+  dbNet* createNetSingleWire(odb::Rect& r,
+                             uint level,
+                             uint netId,
+                             uint shapeId);
   dbSBox* createSpecialWire(dbNet* mainNet,
-                            Rect& r,
+                            odb::Rect& r,
                             dbTechLayer* layer,
                             uint sboxId);
   void setCurrentNet(dbNet* net);
@@ -80,7 +82,7 @@ class dbCreateNetUtil
   uint getFirstShape(dbNet* net, dbShape& s);
   bool setFirstShapeProperty(dbNet* net, uint prop);
   dbTechLayerRule* getRule(int routingLayer, int width);
-  dbTechVia* getVia(int l1, int l2, Rect& bbox);
+  dbTechVia* getVia(int l1, int l2, odb::Rect& bbox);
   std::pair<dbBTerm*, dbBTerm*> createTerms4SingleNet(dbNet* net,
                                                       int x1,
                                                       int y1,

--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -1666,7 +1666,7 @@ struct BoundaryData
   int lo_search_limit;
   int lo_gs_limit;
 
-  void setBBox(const Rect& extRect)
+  void setBBox(const odb::Rect& extRect)
   {
     ll[0] = extRect.xMin();
     ll[1] = extRect.yMin();
@@ -1738,13 +1738,15 @@ class extMain
 
   uint getPeakMemory(const char* msg, int n = -1);
 
-  void setupBoundaries(BoundaryData& bounds, const Rect& extRect);
+  void setupBoundaries(BoundaryData& bounds, const odb::Rect& extRect);
   void updateBoundaries(BoundaryData& bounds,
                         uint dir,
                         uint ccDist,
                         uint maxPitch);
   void initializeLayerTables(LayerDimensionData& tables);
-  int initSearch(LayerDimensionData& tables, Rect& extRect, uint& totWireCnt);
+  int initSearch(LayerDimensionData& tables,
+                 odb::Rect& extRect,
+                 uint& totWireCnt);
 
   // CLEANUP dkf 10242024 ----------------------------------
   void makeBlockRCsegs_v2(const char* netNames, const char* extRules);
@@ -1871,8 +1873,8 @@ class extMain
   // v2 ------------------------------------------------------------
   uint _debug_net_id = 0;
 
-  uint couplingFlow_v2_opt(Rect& extRect, uint ccFlag, extMeasure* m);
-  uint couplingFlow_v2(Rect& extRect, uint ccFlag, extMeasure* m);
+  uint couplingFlow_v2_opt(odb::Rect& extRect, uint ccFlag, extMeasure* m);
+  uint couplingFlow_v2(odb::Rect& extRect, uint ccFlag, extMeasure* m);
   void setBranchCapNodeId(dbNet* net, uint junction);
   void markPathHeadTerm(dbWirePath& path);
 

--- a/src/rcx/include/rcx/grids.h
+++ b/src/rcx/include/rcx/grids.h
@@ -22,7 +22,6 @@ using odb::AthPool;
 using odb::dbBlock;
 using odb::dbBox;
 using odb::dbNet;
-using odb::Rect;
 
 enum OverlapAdjust
 {
@@ -513,7 +512,7 @@ class GridTable
                         AthPool<SEQ>* seqPool);
 
   // -------------------------------------------------------------
-  GridTable(Rect* bb,
+  GridTable(odb::Rect* bb,
             uint rowCnt,
             uint colCnt,
             uint* pitch,
@@ -680,7 +679,7 @@ class GridTable
   Box _bbox;
   Box _maxSearchBox;
   bool _setMaxArea;
-  Rect _rectBB;
+  odb::Rect _rectBB;
   uint _rowCnt;
   uint _colCnt;
   uint _rowSize;

--- a/src/rcx/src/dbUtil.cpp
+++ b/src/rcx/src/dbUtil.cpp
@@ -218,7 +218,7 @@ dbTechLayerRule* dbCreateNetUtil::getRule(int routingLayer, int width)
   return rule;
 }
 
-dbTechVia* dbCreateNetUtil::getVia(int l1, int l2, Rect& bbox)
+dbTechVia* dbCreateNetUtil::getVia(int l1, int l2, odb::Rect& bbox)
 {
   int bot, top;
 
@@ -288,7 +288,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
     return nullptr;
   }
 
-  Rect r(x1, y1, x2, y2);
+  odb::Rect r(x1, y1, x2, y2);
   int width;
   Point p0, p1;
 
@@ -297,7 +297,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
 
     // This is dangerous!
     if (dx & 1) {
-      r = Rect(x1, y1, x2 + 1, y2);
+      r = odb::Rect(x1, y1, x2 + 1, y2);
       dx = r.dx();
     }
 
@@ -312,7 +312,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
 
     // This is dangerous!
     if (dy & 1) {
-      r = Rect(x1, y1, x2, y2 + 1);
+      r = odb::Rect(x1, y1, x2, y2 + 1);
       dy = r.dy();
     }
 
@@ -395,7 +395,7 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
   return net;
 }
 dbSBox* dbCreateNetUtil::createSpecialWire(dbNet* mainNet,
-                                           Rect& r,
+                                           odb::Rect& r,
                                            dbTechLayer* layer,
                                            uint /* unused: sboxId */)
 {
@@ -447,7 +447,7 @@ bool dbCreateNetUtil::setFirstShapeProperty(dbNet* net, uint prop)
   return true;
 }
 
-dbNet* dbCreateNetUtil::createNetSingleWire(Rect& r,
+dbNet* dbCreateNetUtil::createNetSingleWire(odb::Rect& r,
                                             uint level,
                                             uint netId,
                                             uint shapeId)
@@ -524,13 +524,13 @@ dbNet* dbCreateNetUtil::createNetSingleWire(const char* netName,
   }
 
   dbTechLayer* layer = _routingLayers[routingLayer];
-  Rect r(x1, y1, x2, y2);
+  odb::Rect r(x1, y1, x2, y2);
   uint dx = r.dx();
   uint dy = r.dy();
 
   // This is dangerous!
   if ((dx & 1) && (dy & 1)) {
-    r = Rect(x1, y1, x2, y2 + 1);
+    r = odb::Rect(x1, y1, x2, y2 + 1);
     dx = r.dx();
     dy = r.dy();
   }

--- a/src/rcx/src/extDefPatterns.cpp
+++ b/src/rcx/src/extDefPatterns.cpp
@@ -3,6 +3,7 @@
 
 #include "odb/db.h"
 #include "odb/dbWireCodec.h"
+#include "odb/geom.h"
 #include "rcx/extRCap.h"
 #include "rcx/extRulesPattern.h"
 #include "rcx/extSpef.h"

--- a/src/rcx/src/extFlow_v2.cpp
+++ b/src/rcx/src/extFlow_v2.cpp
@@ -12,6 +12,7 @@
 #include "odb/db.h"
 #include "odb/dbSet.h"
 #include "odb/dbShape.h"
+#include "odb/geom.h"
 #include "parse.h"
 #include "rcx/dbUtil.h"
 #include "rcx/extMeasureRC.h"

--- a/src/rcx/src/extPatterns.cpp
+++ b/src/rcx/src/extPatterns.cpp
@@ -12,6 +12,7 @@
 
 #include "odb/db.h"
 #include "odb/dbSet.h"
+#include "odb/geom.h"
 #include "rcx/extPattern.h"
 #include "rcx/extRCap.h"
 #include "rcx/extSpef.h"

--- a/src/rcx/src/grids.cpp
+++ b/src/rcx/src/grids.cpp
@@ -2312,7 +2312,7 @@ void GridTable::dumpTrackCounts(FILE* fp)
           texpand,
           ttsubtn);
 }
-GridTable::GridTable(Rect* bb,
+GridTable::GridTable(odb::Rect* bb,
                      uint rowCnt,
                      uint colCnt,
                      uint* pitch,

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -42,7 +42,6 @@ using odb::dbMaster;
 using odb::dbNet;
 using odb::dbTechLayer;
 using odb::Point;
-using odb::Rect;
 
 using stt::SteinerTreeBuilder;
 
@@ -725,7 +724,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   int dbu_ = 0;
   const Pin* debug_pin_ = nullptr;
 
-  Rect core_;
+  odb::Rect core_;
   bool core_exists_ = false;
 
   double design_area_ = 0.0;

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -1713,7 +1713,7 @@ void RepairDesign::repairNetLoad(
 
 LoadRegion::LoadRegion() = default;
 
-LoadRegion::LoadRegion(PinSeq& pins, Rect& bbox) : pins_(pins), bbox_(bbox)
+LoadRegion::LoadRegion(PinSeq& pins, odb::Rect& bbox) : pins_(pins), bbox_(bbox)
 {
 }
 
@@ -1722,7 +1722,7 @@ LoadRegion RepairDesign::findLoadRegions(const Net* net,
                                          int max_fanout)
 {
   PinSeq loads = findLoads(drvr_pin);
-  Rect bbox = findBbox(loads);
+  odb::Rect bbox = findBbox(loads);
   LoadRegion region(loads, bbox);
   if (graphics_) {
     odb::dbNet* db_net = db_network_->staToDb(net);
@@ -1749,13 +1749,13 @@ void RepairDesign::subdivideRegion(LoadRegion& region, int max_fanout)
     bool horz_partition;
     odb::Line cut;
     if (region.bbox_.dx() > region.bbox_.dy()) {
-      region.regions_[0].bbox_ = Rect(x_min, y_min, x_mid, y_max);
-      region.regions_[1].bbox_ = Rect(x_mid, y_min, x_max, y_max);
+      region.regions_[0].bbox_ = odb::Rect(x_min, y_min, x_mid, y_max);
+      region.regions_[1].bbox_ = odb::Rect(x_mid, y_min, x_max, y_max);
       cut = odb::Line{x_mid, y_min, x_mid, y_max};
       horz_partition = true;
     } else {
-      region.regions_[0].bbox_ = Rect(x_min, y_min, x_max, y_mid);
-      region.regions_[1].bbox_ = Rect(x_min, y_mid, x_max, y_max);
+      region.regions_[0].bbox_ = odb::Rect(x_min, y_min, x_max, y_mid);
+      region.regions_[1].bbox_ = odb::Rect(x_min, y_mid, x_max, y_max);
       horz_partition = false;
       cut = odb::Line{x_min, y_mid, x_max, y_mid};
     }
@@ -1862,7 +1862,7 @@ void RepairDesign::makeRegionRepeaters(LoadRegion& region,
 
 void RepairDesign::makeFanoutRepeater(PinSeq& repeater_loads,
                                       PinSeq& repeater_inputs,
-                                      const Rect& bbox,
+                                      const odb::Rect& bbox,
                                       const Point& loc,
                                       bool check_slew,
                                       bool check_cap,
@@ -1909,13 +1909,13 @@ void RepairDesign::makeFanoutRepeater(PinSeq& repeater_loads,
   repeater_loads.clear();
 }
 
-Rect RepairDesign::findBbox(PinSeq& pins)
+odb::Rect RepairDesign::findBbox(PinSeq& pins)
 {
-  Rect bbox;
+  odb::Rect bbox;
   bbox.mergeInit();
   for (const Pin* pin : pins) {
     Point loc = db_network_->location(pin);
-    Rect r(loc.x(), loc.y(), loc.x(), loc.y());
+    odb::Rect r(loc.x(), loc.y(), loc.x(), loc.y());
     bbox.merge(r);
   }
   return bbox;

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -37,17 +37,15 @@ using sta::Slew;
 using sta::StaState;
 using sta::Vertex;
 
-using odb::Rect;
-
 // Region for partioning fanout pins.
 class LoadRegion
 {
  public:
   LoadRegion();
-  LoadRegion(PinSeq& pins, Rect& bbox);
+  LoadRegion(PinSeq& pins, odb::Rect& bbox);
 
   PinSeq pins_;
-  Rect bbox_;  // dbu
+  odb::Rect bbox_;  // dbu
   std::vector<LoadRegion> regions_;
 };
 
@@ -179,14 +177,14 @@ class RepairDesign : dbStaState
                            bool resize_drvr);
   void makeFanoutRepeater(PinSeq& repeater_loads,
                           PinSeq& repeater_inputs,
-                          const Rect& bbox,
+                          const odb::Rect& bbox,
                           const Point& loc,
                           bool check_slew,
                           bool check_cap,
                           int max_length,
                           bool resize_drvr);
   PinSeq findLoads(const Pin* drvr_pin);
-  Rect findBbox(PinSeq& pins);
+  odb::Rect findBbox(PinSeq& pins);
   Point findClosedPinLoc(const Pin* drvr_pin, PinSeq& pins);
   bool isRepeater(const Pin* load_pin);
   bool makeRepeater(const char* reason,


### PR DESCRIPTION
Fix some uses of `using odb::Rect` in header files.