### PR TITLE
Fix a `utl::Logger` leaking into the cut namespace.

### DIFF
--- a/src/cut/include/cut/blif.h
+++ b/src/cut/include/cut/blif.h
@@ -17,22 +17,17 @@ namespace ord {
 class OpenRoad;
 }  // namespace ord
 
-namespace utl {
-class Logger;
-}
-
 namespace sta {
 class dbSta;
 class Pin;
 }  // namespace sta
 
 namespace cut {
-using utl::Logger;
 
 class Blif
 {
  public:
-  Blif(Logger* logger,
+  Blif(utl::Logger* logger,
        sta::dbSta* sta,
        const std::string& const0_cell_,
        const std::string& const0_cell_port_,
@@ -51,7 +46,7 @@ class Blif
 
  private:
   std::set<odb::dbInst*> instances_to_optimize_;
-  Logger* logger_;
+  utl::Logger* logger_;
   sta::dbSta* open_sta_ = nullptr;
   std::string const0_cell_;
   std::string const0_cell_port_;

--- a/src/cut/src/blif.cpp
+++ b/src/cut/src/blif.cpp
@@ -30,7 +30,7 @@ using utl::CUT;
 
 namespace cut {
 
-Blif::Blif(Logger* logger,
+Blif::Blif(utl::Logger* logger,
            sta::dbSta* sta,
            const std::string& const0_cell,
            const std::string& const0_cell_port,


### PR DESCRIPTION
Remove `using utl::Logger` in blif.h