### PR TITLE
gui: add a 'headless' qt6_library variant

### DIFF
--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -36,7 +36,7 @@ cc_library(
 
 # A Qt 'headless' build is added for environments that require GUI features
 # but do not have an attached display. This requires setting 'qt_gui_platform'
-# to `headless`, and subsituting the depedency in the top-level BUILD.
+# to `headless`, and subsituting the dependency in the top-level BUILD.
 QT_GUI_PLATFORMS = {
     "headless": "_headless",
     "native": "",


### PR DESCRIPTION
This supports building OpenROAD with GUI enabled and using some GUI features (e.g., `save_image`), in environments that do not have an attached display (but can support Qt).

Using this would require substituting out the dependency in OpenROAD's top level BUILD file.