### PR TITLE
Fix cyclic inclusion of db.h <-> dbCompare.h

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#pragma once
+#ifndef OPENROAD_ODB_DB_H
+#define OPENROAD_ODB_DB_H
 
 #include <cstdint>
 #include <cstdio>
@@ -10990,6 +10991,8 @@ class dbDoubleProperty : public dbProperty
 };
 
 }  // namespace odb
+
+#endif  // OPENROAD_ODB_DB_H
 
 // Overload std::less for these types
 #include "odb/dbCompare.h"

--- a/src/odb/include/odb/dbCompare.h
+++ b/src/odb/include/odb/dbCompare.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2019-2025, The OpenROAD Authors
 
-#pragma once
+#ifndef OPENROAD_ODB_DBCOMPARE_H
+#define OPENROAD_ODB_DBCOMPARE_H
 
 // IWYU pragma: private, include "db.h"
 
@@ -1079,3 +1080,4 @@ struct less<odb::dbTechLayerWrongDirSpacingRule*>
 // Generator Code End Less
 
 }  // namespace std
+#endif  // OPENROAD_ODB_DBCOMPARE_H


### PR DESCRIPTION
Both used `#pragma once` so could not express what they needed to express. Replace with regular header guards.