### PR TITLE
mock-array: less noisy .v files generated

### DIFF
--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -226,6 +226,15 @@ chisel_binary(
     ],
 )
 
+FIRTOOL_OPTIONS = [
+    "-disable-all-randomization",
+    "-strip-debug-info",
+    "-enable-layers=Verification",
+    "-enable-layers=Verification.Assert",
+    "-enable-layers=Verification.Assume",
+    "-enable-layers=Verification.Cover",
+]
+
 fir_library(
     name = "generate_fir",
     data = [
@@ -238,19 +247,14 @@ fir_library(
         "--",
         # Imagine Chisel arguments here
         "--",
-        "-disable-all-randomization",
-        "-strip-debug-info",
-        "-enable-layers=Verification",
-        "-enable-layers=Verification.Assert",
-        "-enable-layers=Verification.Assume",
-        "-enable-layers=Verification.Cover",
-    ],
+    ] + FIRTOOL_OPTIONS,
     tags = ["manual"],
 )
 
 verilog_directory(
     name = "generate_split",
     srcs = [":generate_fir"],
+    opts = FIRTOOL_OPTIONS,
     tags = ["manual"],
 )
 


### PR DESCRIPTION
Should have no effect. Only thing is that yosys is sensitive to initial conditions, so even adding whitespace can result in slightly different synthesis results...