### PR TITLE
Use `inline constexpr` uniformly for constants in headers.

### DIFF
--- a/src/dpl/src/util/symmetry.h
+++ b/src/dpl/src/util/symmetry.h
@@ -5,9 +5,9 @@
 
 namespace dpl {
 
-const unsigned Symmetry_UNKNOWN = 0x00000000;
-const unsigned Symmetry_X = 0x00000001;
-const unsigned Symmetry_Y = 0x00000002;
-const unsigned Symmetry_ROT90 = 0x00000004;
+inline constexpr unsigned Symmetry_UNKNOWN = 0x00000000;
+inline constexpr unsigned Symmetry_X = 0x00000001;
+inline constexpr unsigned Symmetry_Y = 0x00000002;
+inline constexpr unsigned Symmetry_ROT90 = 0x00000004;
 
 }  // namespace dpl

--- a/src/dst/src/LoadBalancer.h
+++ b/src/dst/src/LoadBalancer.h
@@ -24,8 +24,9 @@ namespace dst {
 
 namespace ip = asio::ip;
 
-const int kWorkersDiscoveryPeriod = 15;  // time in seconds between retrying to
-                                         // find new workers on the network
+// time in seconds between retrying to find new workers on the network
+inline constexpr int kWorkersDiscoveryPeriod = 15;
+
 class Distributed;
 class LoadBalancer
 {

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -31,7 +31,7 @@
 #include "odb/isotropy.h"
 #include "odb/odb.h"
 
-constexpr int ADS_MAX_CORNER = 10;
+inline constexpr int ADS_MAX_CORNER = 10;
 
 namespace utl {
 class Logger;

--- a/src/odb/include/odb/dbTypes.h
+++ b/src/odb/include/odb/dbTypes.h
@@ -1289,15 +1289,15 @@ class dbSourceType
 };
 
 // TODO: shouldn't these come from <climits> ?
-static inline constexpr uint64_t MAX_UINT64 = 0xffffffffffffffffLL;
-static inline constexpr uint64_t MIN_UINT64 = 0;
-static inline constexpr uint MAX_UINT = 0xffffffff;
-static inline constexpr uint MIN_UINT = 0;
+inline constexpr uint64_t MAX_UINT64 = 0xffffffffffffffffLL;
+inline constexpr uint64_t MIN_UINT64 = 0;
+inline constexpr uint MAX_UINT = 0xffffffff;
+inline constexpr uint MIN_UINT = 0;
 
-static inline constexpr int64_t MAX_INT64 = 0x7fffffffffffffffLL;
-static inline constexpr int64_t MIN_INT64 = 0x8000000000000000LL;
-static inline constexpr int MAX_INT = 0x7fffffff;
-static inline constexpr int MIN_INT = 0x80000000;
+inline constexpr int64_t MAX_INT64 = 0x7fffffffffffffffLL;
+inline constexpr int64_t MIN_INT64 = 0x8000000000000000LL;
+inline constexpr int MAX_INT = 0x7fffffff;
+inline constexpr int MIN_INT = 0x80000000;
 
 ///
 /// Defines the type of shapes.

--- a/src/odb/include/odb/gdsUtil.h
+++ b/src/odb/include/odb/gdsUtil.h
@@ -136,7 +136,7 @@ enum class DataType : uint8_t
 };
 
 /** dataType sizes in number of bytes */
-static const size_t dataTypeSize[(int) DataType::INVALID_DT]
+inline constexpr size_t dataTypeSize[(int) DataType::INVALID_DT]
     = {1, 1, 2, 4, 4, 8, 1};
 
 /**

--- a/src/odb/include/odb/isotropy.h
+++ b/src/odb/include/odb/isotropy.h
@@ -274,20 +274,20 @@ std::ostream& operator<<(std::ostream& os, const Direction2D& dir);
 std::ostream& operator<<(std::ostream& os, const Direction3D& dir);
 
 // Convenience objects that will be commonly used.
-constexpr Orientation2D horizontal{Orientation2D::Horizontal};
-constexpr Orientation2D vertical{Orientation2D::Vertical};
-constexpr Orientation3D proximal{Orientation3D::Proximal};
+inline constexpr Orientation2D horizontal{Orientation2D::Horizontal};
+inline constexpr Orientation2D vertical{Orientation2D::Vertical};
+inline constexpr Orientation3D proximal{Orientation3D::Proximal};
 
-constexpr Direction1D low{Direction1D::Low};
-constexpr Direction1D high{Direction1D::High};
+inline constexpr Direction1D low{Direction1D::Low};
+inline constexpr Direction1D high{Direction1D::High};
 
-constexpr Direction2D west{Direction2D::West};
-constexpr Direction2D east{Direction2D::East};
-constexpr Direction2D south{Direction2D::South};
-constexpr Direction2D north{Direction2D::North};
+inline constexpr Direction2D west{Direction2D::West};
+inline constexpr Direction2D east{Direction2D::East};
+inline constexpr Direction2D south{Direction2D::South};
+inline constexpr Direction2D north{Direction2D::North};
 
-constexpr Direction3D down{Direction3D::Down};
-constexpr Direction3D up{Direction3D::Up};
+inline constexpr Direction3D down{Direction3D::Down};
+inline constexpr Direction3D up{Direction3D::Up};
 
 using utl::format_as;
 

--- a/src/odb/src/lef/clef/lefrReader.h
+++ b/src/odb/src/lef/clef/lefrReader.h
@@ -37,7 +37,7 @@
 
 #include "lefiTypedefs.h"
 
-constexpr int MAX_LEF_MSGS = 4701;
+inline constexpr int MAX_LEF_MSGS = 4701;
 
 /* The reader initialization.  Must be called before lefrRead().              */
 EXTERN int lefrInit();

--- a/src/odb/src/lef/lef/lefrReader.hpp
+++ b/src/odb/src/lef/lef/lefrReader.hpp
@@ -38,7 +38,7 @@
 #include "lefiUser.hpp"
 #include "lefiUtil.hpp"
 
-constexpr int MAX_LEF_MSGS = 4701;
+inline constexpr int MAX_LEF_MSGS = 4701;
 
 BEGIN_LEF_PARSER_NAMESPACE
 


### PR DESCRIPTION
Adressing `clang-diagnostic-unused-const-variable` clang-tidy warning.