### PR TITLE
gui: ensure renderer settings can load after data type changes

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -545,7 +545,11 @@ class Renderer
                          T& value)
   {
     if (settings.count(key) == 1) {
-      value = std::get<T>(settings.at(key));
+      try {
+        value = std::get<T>(settings.at(key));
+      } catch (const std::bad_variant_access&) {
+        // Stay with current value
+      }
     }
   }
 


### PR DESCRIPTION
Fixes:
- periodically when the heatmap datatypes change the loading of the old configuration file will cause a `std::bad_variant_access`, this ensures that the error it caught and ignored to avoid the gui segfaulting.