### PR TITLE
mpl: remove unused member variables in BundledNet object

### DIFF
--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1478,8 +1478,6 @@ void HierRTLMP::placeChildren(Cluster* parent, bool ignore_std_cell_area)
         soft_macro_id_map[tree_->maps.id_to_cluster[cluster1]->getName()],
         soft_macro_id_map[tree_->maps.id_to_cluster[cluster2]->getName()],
         tree_->virtual_weight);
-    net.src_cluster_id = cluster1;
-    net.target_cluster_id = cluster2;
     nets.push_back(net);
   }
 
@@ -1500,8 +1498,6 @@ void HierRTLMP::placeChildren(Cluster* parent, bool ignore_std_cell_area)
       if (src_id > cluster_id) {
         BundledNet net(
             soft_macro_id_map[src_name], soft_macro_id_map[name], weight);
-        net.src_cluster_id = src_id;
-        net.target_cluster_id = cluster_id;
         nets.push_back(net);
       }
     }
@@ -2329,9 +2325,6 @@ std::vector<BundledNet> HierRTLMP::computeBundledNets(
     for (auto [cluster_id, weight] : macro_cluster->getConnectionsMap()) {
       BundledNet net(
           cluster_to_macro.at(src_id), cluster_to_macro.at(cluster_id), weight);
-
-      net.src_cluster_id = src_id;
-      net.target_cluster_id = cluster_id;
       nets.push_back(net);
     }
   }

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -489,18 +489,11 @@ class SoftMacro
   bool align_flag_ = false;
 };
 
-// In our netlist model, we only have two-pin nets
 struct BundledNet
 {
   BundledNet(int src, int target, float weight)
   {
     this->terminals = std::pair<int, int>(src, target);
-    this->weight = weight;
-  }
-
-  BundledNet(const std::pair<int, int>& terminals, float weight)
-  {
-    this->terminals = terminals;
     this->weight = weight;
   }
 
@@ -512,11 +505,6 @@ struct BundledNet
 
   std::pair<int, int> terminals;  // source_id <--> target_id (undirected)
   float weight;  // Number of bundled connections (can be timing-related)
-
-  // In our framework, we only bundled connections between clusters.
-  // Thus each net must have both src_cluster_id and target_cluster_id
-  int src_cluster_id = -1;
-  int target_cluster_id = -1;
 };
 
 struct SequencePair


### PR DESCRIPTION
And unused ctor.