### PR TITLE
Enable layering_check in test BUILD files.

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,6 +1,8 @@
 load("@openroad_rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
+package(features = ["layering_check"])
+
 compile_pip_requirements(
     name = "requirements",
     src = "requirements.in",

--- a/bazel/openmp/BUILD
+++ b/bazel/openmp/BUILD
@@ -14,6 +14,7 @@
 
 package(
     default_visibility = ["//visibility:private"],
+    features = ["layering_check"],
 )
 
 exports_files(

--- a/etc/BUILD
+++ b/etc/BUILD
@@ -1,5 +1,7 @@
 load("@openroad_rules_python//python:defs.bzl", "py_binary")
 
+package(features = ["layering_check"])
+
 py_binary(
     name = "file_to_string",
     srcs = [

--- a/openroad/BUILD
+++ b/openroad/BUILD
@@ -4,6 +4,8 @@ load("@openroad_rules_python//python:defs.bzl", "py_library")
 # Copyright (c) 2025-2025, The OpenROAD Authors
 load("@openroad_rules_python//python:packaging.bzl", "py_package", "py_wheel")
 
+package(features = ["layering_check"])
+
 py_library(
     name = "openroadpy",
     srcs = [

--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -1,5 +1,7 @@
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "ant_check",

--- a/src/cgt/test/BUILD
+++ b/src/cgt/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 TESTS = [
     "aes_nangate45",
     "countdown_asap7",

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -4,6 +4,8 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "array",
@@ -182,10 +184,10 @@ filegroup(
 cc_test(
     name = "cts_unittest",
     srcs = ["cts_unittest.cc"],
+    features = ["-layering_check"],  # TODO: accesses private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/cts",
-        "//src/grt",  # work around cyclic dependncy between rsz and grt
         "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",

--- a/src/cut/BUILD
+++ b/src/cut/BUILD
@@ -5,6 +5,7 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(
     default_visibility = ["//:__subpackages__"],
+    features = ["layering_check"],
 )
 
 cc_library(
@@ -31,6 +32,7 @@ cc_library(
     includes = ["include"],
     deps = [
         "//src/dbSta",
+        "//src/dbSta:dbNetwork",
         "//src/odb",
         "//src/rsz",
         "//src/sta:opensta_lib",

--- a/src/cut/test/BUILD
+++ b/src/cut/test/BUILD
@@ -3,6 +3,8 @@
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+package(features = ["layering_check"])
+
 cc_test(
     name = "cut_abc_test",
     srcs = ["cpp/TestAbc.cc"],
@@ -11,8 +13,13 @@ cc_test(
         "//src/cut",
         "//src/dbSta",
         "//src/dbSta:dbReadVerilog",
+        "//src/odb",
+        "//src/sta:opensta_lib",
         "//src/tst",
+        "//src/utl",
+        "@edu_berkeley_abc//:abc-lib",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@tk_tcl//:tcl",
     ],
 )

--- a/src/cut/test/cpp/TestAbc.cc
+++ b/src/cut/test/cpp/TestAbc.cc
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <tcl.h>
 #include <unistd.h>
 
 #include <array>
@@ -40,6 +39,7 @@
 #include "sta/Sta.hh"
 #include "sta/Units.hh"
 #include "sta/VerilogReader.hh"
+#include "tcl.h"
 #include "tst/fixture.h"
 #include "utl/Logger.h"
 #include "utl/deleter.h"

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "block_sta1",
@@ -177,8 +179,13 @@ cc_test(
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/dbSta",
+        "//src/dbSta:dbNetwork",
+        "//src/odb",
+        "//src/sta:opensta_lib",
         "//src/tst",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@tk_tcl//:tcl",
     ],
 )

--- a/src/dbSta/test/cpp/TestHconn.cpp
+++ b/src/dbSta/test/cpp/TestHconn.cpp
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <tcl.h>
 #include <unistd.h>
 
 #include <cstddef>
@@ -31,6 +30,7 @@
 #include "sta/Search.hh"
 #include "sta/Sta.hh"
 #include "sta/Units.hh"
+#include "tcl.h"
 #include "tst/fixture.h"
 #include "utl/Logger.h"
 #include "utl/deleter.h"

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "max_chain_count_sky130",
@@ -111,6 +113,7 @@ filegroup(
 cc_test(
     name = "dft_scan_architect_unittest",
     srcs = ["cpp/TestScanArchitect.cpp"],
+    features = ["-layering_check"],  # TODO: includes private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/dft",
@@ -126,9 +129,12 @@ cc_test(
         "cpp/ScanCellMock.hh",
         "cpp/TestScanArchitectHeuristic.cpp",
     ],
+    features = ["-layering_check"],  # TODO: includes private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/dft",
+        "//src/odb",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "aes",
@@ -255,7 +257,9 @@ cc_test(
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/dpl",
+        "//src/odb",
         "//src/tst",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "drc_test",
@@ -113,12 +115,16 @@ cc_test(
         "fixture.h",
         "gcTest.cpp",
     ],
+    features = ["-layering_check"],  # TODO: acceses private headers
     includes = [
         "../src",
     ],
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/drt",
+        "//src/drt:db_hdrs",
+        "//src/odb",
+        "//src/utl",
         "@boost.test",
     ],
 )

--- a/src/dst/test/BUILD
+++ b/src/dst/test/BUILD
@@ -4,9 +4,12 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
+package(features = ["layering_check"])
+
 cc_library(
     name = "test_helpers",
     hdrs = ["cpp/HelperCallBack.h"],
+    deps = ["//src/dst"],
 )
 
 cc_test(
@@ -14,6 +17,7 @@ cc_test(
     srcs = [
         "cpp/TestBalancer.cc",
     ],
+    features = ["-layering_check"],  # TODO: includes private headers
     includes = [
         "../src",
     ],
@@ -21,8 +25,14 @@ cc_test(
     deps = [
         ":test_helpers",
         "//src/dst",
+        "//src/utl",
+        "@boost.asio",
+        "@boost.bind",
         "@boost.test",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["@boost.thread//:thread_mac"],
+        "//conditions:default": ["@boost.thread//:thread_posix"],
+    }),
 )
 
 cc_test(
@@ -37,8 +47,14 @@ cc_test(
     deps = [
         ":test_helpers",
         "//src/dst",
+        "//src/utl",
+        "@boost.asio",
+        "@boost.bind",
         "@boost.test",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["@boost.thread//:thread_mac"],
+        "//conditions:default": ["@boost.thread//:thread_posix"],
+    }),
 )
 
 cc_test(
@@ -46,6 +62,7 @@ cc_test(
     srcs = [
         "cpp/TestWorker.cc",
     ],
+    features = ["-layering_check"],  # TODO: includes private headers
     includes = [
         "../src",
     ],
@@ -53,6 +70,13 @@ cc_test(
     deps = [
         ":test_helpers",
         "//src/dst",
+        "//src/utl",
+        "@boost.asio",
+        "@boost.bind",
+        "@boost.system",
         "@boost.test",
-    ],
+    ] + select({
+        "@platforms//os:macos": ["@boost.thread//:thread_mac"],
+        "//conditions:default": ["@boost.thread//:thread_posix"],
+    }),
 )

--- a/src/est/test/BUILD
+++ b/src/est/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 TESTS = [
     "make_parasitics1",

--- a/src/exa/test/BUILD
+++ b/src/exa/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 TESTS = [
     "basic",
 ]

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "gcd_fill",

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -2,6 +2,8 @@ load("@openroad_rules_python//python:defs.bzl", "py_library", "py_test")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 TESTS = [
     "ar01",
     "ar02",
@@ -135,10 +137,12 @@ PY_TESTS = [
 cc_test(
     name = "gpl_fft_unittest",
     srcs = ["fft_test.cc"],
+    features = ["-layering_check"],  # TODO: includes private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/gpl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@spdlog",
     ],
 )

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -1,5 +1,7 @@
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 TESTS = [
     "bus_route",
     "clock_route",

--- a/src/gui/test/BUILD
+++ b/src/gui/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 ALL_TESTS = [
     "supported",

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "hybrid_rows",

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "macro_only",
@@ -139,10 +141,13 @@ cc_test(
         "cpp/MplTest.h",
         "cpp/TestSnapper.cpp",
     ],
+    features = ["-layering_check"],  # TODO: includes private headers
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/mpl",
+        "//src/odb",
         "//src/tst",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -4,6 +4,8 @@ load("@openroad_rules_python//python:defs.bzl", "py_library", "py_test")
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 py_library(
     name = "helper",
     srcs = [

--- a/src/odb/test/data/sky130hd/BUILD
+++ b/src/odb/test/data/sky130hd/BUILD
@@ -3,6 +3,7 @@
 
 package(
     default_visibility = ["//:__subpackages__"],
+    features = ["layering_check"],
 )
 
 filegroup(

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "assign_bumps",

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "partition_gcd",

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -1,5 +1,7 @@
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "add_double_global_connection",

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "add_constraint1",

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "aes_asap7_vdd",

--- a/src/ram/test/BUILD
+++ b/src/ram/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "make_8x8",

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "45_gcd",

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "aes_nangate45",
@@ -127,15 +129,23 @@ cc_test(
     srcs = [
         "cpp/TestAbc.cc",
     ],
+    features = ["-layering_check"],  # TODO: includes private headers
     includes = [
         "../src",
     ],
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
+        "//src/cut",
+        "//src/dbSta",
         "//src/dbSta:dbReadVerilog",
+        "//src/odb",
         "//src/rmp",
+        "//src/sta:opensta_lib",
         "//src/tst",
+        "//src/utl",
+        "@edu_berkeley_abc//:abc-lib",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@tk_tcl//:tcl",
     ],
 )

--- a/src/rmp/test/cpp/TestAbc.cc
+++ b/src/rmp/test/cpp/TestAbc.cc
@@ -5,7 +5,6 @@
 // https://developers.google.com/open-source/licenses/bsd
 
 #include <string.h>
-#include <tcl.h>
 #include <unistd.h>
 
 #include <cstdlib>
@@ -34,6 +33,7 @@
 #include "sta/Sta.hh"
 #include "sta/Units.hh"
 #include "sta/VerilogReader.hh"
+#include "tcl.h"
 #include "tst/fixture.h"
 #include "utl/Logger.h"
 #include "utl/deleter.h"

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -1,6 +1,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 exports_files(
     ["hi_fanout.tcl"],
     visibility = ["//visibility:public"],
@@ -234,11 +236,19 @@ cc_test(
     ],
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
+        "//src/ant",
         "//src/dbSta",
-        "//src/dpl",
+        "//src/dbSta:dbNetwork",
+        "//src/est",
+        "//src/grt",
+        "//src/odb",
         "//src/rsz",
+        "//src/sta:opensta_lib",
+        "//src/stt",
         "//src/tst",
+        "//src/utl",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
+        "@tk_tcl//:tcl",
     ],
 )

--- a/src/rsz/test/cpp/TestBufferRemoval.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval.cc
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
-#include <tcl.h>
 #include <unistd.h>
 
 #include <filesystem>
@@ -31,6 +30,7 @@
 #include "sta/Sta.hh"
 #include "sta/Units.hh"
 #include "stt/SteinerTreeBuilder.h"
+#include "tcl.h"
 #include "tst/fixture.h"
 #include "utl/CallBackHandler.h"
 #include "utl/Logger.h"

--- a/src/stt/test/BUILD
+++ b/src/stt/test/BUILD
@@ -1,5 +1,7 @@
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 TESTS = [
     "check",
     "flute1",

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "aes_gf180",

--- a/src/tst/include/tst/fixture.h
+++ b/src/tst/include/tst/fixture.h
@@ -3,12 +3,11 @@
 
 #pragma once
 
-#include <tcl.h>
-
 #include "db_sta/dbSta.hh"
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "sta/MinMax.hh"
+#include "tcl.h"
 #include "utl/Logger.h"
 #include "utl/deleter.h"
 

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -2,6 +2,8 @@
 # Copyright (c) 2022-2025, The OpenROAD Authors
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "levelshifter",

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -4,6 +4,8 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 # From CMakeLists.txt or_integration_tests(TESTS
 COMPULSORY_TESTS = [
     "logger_max_messages",
@@ -79,6 +81,8 @@ cc_test(
     linkstatic = True,  # TODO: remove once deps define all symbols
     deps = [
         "//src/utl",
+        "@boost.asio",
+        "@boost.beast",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,6 +3,8 @@
 
 load("//test:regression.bzl", "regression_test")
 
+package(features = ["layering_check"])
+
 exports_files(
     [
         "bazel_test.sh",

--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -1,5 +1,7 @@
 load("@bazel-orfs//:openroad.bzl", "orfs_flow")
 
+package(features = ["layering_check"])
+
 orfs_flow(
     name = "gcd",
     # buildifier: disable=unsorted-dict-items

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -7,6 +7,8 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_verilator//verilator:defs.bzl", "verilator_cc_library")
 load("@rules_verilator//verilog:defs.bzl", "verilog_library")
 
+package(features = ["layering_check"])
+
 POWER_STAGES = {
     "cts": {
         "stage": "4",

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -7,7 +7,9 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("@rules_verilator//verilator:defs.bzl", "verilator_cc_library")
 load("@rules_verilator//verilog:defs.bzl", "verilog_library")
 
-package(features = ["layering_check"])
+package(
+    features = ["-layering_check"],  # TODO: enable
+)
 
 POWER_STAGES = {
     "cts": {


### PR DESCRIPTION
There were a bunch of BUILD files that didn't have layering check enabled yet. This change enables it, and fixes the reported missing dependencies.

Unfortunately, not all tests are clean and import only visible headers, so disable layering check for these for a later fix.