### PR TITLE
rmp/cut: various build fixes

### DIFF
--- a/src/cut/src/CMakeLists.txt
+++ b/src/cut/src/CMakeLists.txt
@@ -27,12 +27,11 @@ target_sources(cut
 target_link_libraries(cut
   PUBLIC
     rsz_lib
-    libabc
+    ${ABC_LIBRARY}
   PRIVATE
     odb
     dbSta
     OpenSTA
     dbSta_lib
     utl_lib
-    ${ABC_LIBRARY}
  )

--- a/src/cut/test/cpp/CMakeLists.txt
+++ b/src/cut/test/cpp/CMakeLists.txt
@@ -8,7 +8,7 @@ target_link_libraries(CutGTests
         GTest::gmock
         dbSta_lib
         utl_lib
-        libabc
+        ${ABC_LIBRARY}
         cut
         tst
         ${TCL_LIBRARY}

--- a/src/rmp/src/annealing_strategy.h
+++ b/src/rmp/src/annealing_strategy.h
@@ -34,7 +34,8 @@ class AnnealingStrategy : public ResynthesisStrategy
         initial_ops_(initial_ops)
   {
     if (seed) {
-      random_ = decltype(random_){*seed};
+      const uint32_t seed_32 = *seed;
+      random_ = decltype(random_){seed_32};
     }
   }
   void OptimizeDesign(sta::dbSta* sta,


### PR DESCRIPTION
- explicitly cast rmp::AnnealingStrategy::random_'s seed to 32-bit

  `rmp::AnnealingStrategy::random_` is `std::mt19937` which is 32-bit: https://en.cppreference.com/w/cpp/numeric/random/mersenne_twister_engine.html

  This in turn causes the constructor for `AnnealingStrategy` to be ill-formed according to the C++17 standard:

  > List-initialization of an object or reference of type T is defined as follows:

  > ...

  > (3.7) Otherwise, if T is a class type, constructors are considered. The applicable constructors are enumerated and the best one is chosen through overload resolution (16.3, 16.3.1.7). If a narrowing conversion (see below) is required to convert any of the arguments, the program is ill-formed.

  As the seed is `uint64_t` and `mt19937` uses `uint32_t`, this is a narrowing conversion that fails to compile on at least Darwin. This is the solution that probably causes the least amount of surprises.

  * I also considered changing the RNG to mt19937_64 but was weary of possible ramifications in other parts of the codebase, so I decided against it.

- fix cut's linkage for out-of-tree-abc builds
  - Basically https://github.com/The-OpenROAD-Project/OpenROAD/pull/7652 but for `cut` as well

