### PR TITLE
gui: return true on exception to keep GUI alive

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -1561,6 +1561,12 @@ class SafeApplication : public QApplication
       return QApplication::notify(receiver, event);
     } catch (std::exception& ex) {
       // Ignored here as the message will be logged in the GUI
+      qDebug() << "Caught exception:" << ex.what();
+
+      // Returning true indicates the event has been handled. In this case,
+      // we've "handled" it by catching the exception, so we prevent
+      // further processing that might rely on a corrupt state.
+      return true;
     }
 
     return false;


### PR DESCRIPTION
@maliberty this correctly catches and handles exceptions now (I think the return true was the "missing" piece.)
However, even if the exception is caught here it's better if we make we still catch exceptions where they occur since things like resetting the cursor and leaving other QT element in a good state still requires cleanup.
