### PR TITLE
Add yaml-cpp to nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,6 +38,7 @@
   stdenv,
   overrideSDK,
   git,
+  yaml-cpp,
 }: let
   or-tools' =
     (or-tools.override {
@@ -111,6 +112,7 @@
       cbc
       re2
       gtest
+      yaml-cpp
     ];
 
     nativeBuildInputs = [


### PR DESCRIPTION
Followup to #8295. This fixes the nix build as tested with `nix build '.?submodules=1#'`