### PR TITLE
test/orfs/mock-array: test IO_CONSTRAINTS and MACRO_PLACEMENT_TCL

### DIFF
--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -1,24 +1,10 @@
+load("@bazel-orfs//:openroad.bzl", "orfs_run")
 load("@bazel-orfs//toolchains/scala:chisel.bzl", "chisel_binary")
 load(":mock-array.bzl", "config", "element", "mock_array", "verilog")
 
 package(
     features = ["-layering_check"],  # TODO: enable
 )
-
-# mock_array(
-#     name = "base",
-#     verilog = ":4x4",
-# )
-
-# mock_array(
-#     name = "flat",
-#     verilog = ":4x4",
-# )
-
-# mock_array(
-#     name = "8x8",
-#     verilog = ":8x8",
-# )
 
 chisel_binary(
     name = "generate_verilog",
@@ -93,3 +79,23 @@ CONFIGS = {name: config(name, rows, cols) for name, rows, cols in [
     name = name,
     config = config,
 ) for name, config in CONFIGS.items()]
+
+orfs_run(
+    name = "write_macro_placement",
+    src = ":MockArray_4x4_base_floorplan",
+    outs = [
+        ":macro-placement.tcl",
+    ],
+    script = ":write_macros.tcl",
+    tags = ["manual"],
+)
+
+orfs_run(
+    name = "write_pin_placement",
+    src = ":MockArray_4x4_base_floorplan",
+    outs = [
+        ":io-placement.tcl",
+    ],
+    script = ":write_pin_placement.tcl",
+    tags = ["manual"],
+)

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -276,7 +276,10 @@ def mock_array(name, config):
                 "IO_CONSTRAINTS": [":mock-array-io"],
                 "RULES_JSON": [":rules-{variant}.json".format(variant = variant)],
                 "SDC_FILE": [":mock-array-constraints"],
-            },
+            } | ({
+                "IO_CONSTRAINTS": [":write_pin_placement"],
+                "MACRO_PLACEMENT_TCL": [":write_macro_placement"],
+            } if variant == "4x4_flat" else {}),
             tags = ["manual"],
             test_kwargs = {
                 "tags": ["orfs"],

--- a/test/orfs/mock-array/write_macros.tcl
+++ b/test/orfs/mock-array/write_macros.tcl
@@ -1,0 +1,19 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+
+set filename [file join $::env(WORK_HOME) "macro-placement.tcl"]
+puts "Macro placement written to $filename"
+
+# good 'nuf for pin placement for now
+load_design 2_floorplan.odb 2_floorplan.sdc
+
+write_macro_placement $filename.tmp
+set f [open $filename.tmp r]
+set content [read $f]
+# Uncomment when using this in a SYNTH_HIERARCHICAL=0 context
+#
+# set content [string map {"/" "."} $content]
+close $f
+
+set f [open $filename w]
+puts -nonewline $f $content
+close $f

--- a/test/orfs/mock-array/write_pin_placement.tcl
+++ b/test/orfs/mock-array/write_pin_placement.tcl
@@ -1,0 +1,8 @@
+source $::env(SCRIPTS_DIR)/global_place_skip_io.tcl
+
+log_cmd place_pins \
+  -hor_layers $::env(IO_PLACER_H) \
+  -ver_layers $::env(IO_PLACER_V) \
+  {*}[env_var_or_empty PLACE_PINS_ARGS]
+
+write_pin_placement [file join $::env(WORK_HOME) "io-placement.tcl"]


### PR DESCRIPTION
There's no other live test that does this and since 8x8 takes substantially longer, this won't increase the max running time and will reduce the total workload for CI:

    bazelisk run test/orfs/mock-array:MockArray_4x4_flat_floorplan /tmp/floorplan print-IO_CONSTRAINTS

Outputs:

    IO_CONSTRAINTS=...

Then:

    bazelisk run test/orfs/mock-array:MockArray_4x4_flat_place_deps /tmp/place do-3_1_place_gp_skip_io

Outputs:

    All pins are placed. Skipping global placement without IOs

Macro placement similarly outputs.

    [INFO MPL-0017] No unfixed macros.