### PR TITLE
Fix missing comma in `.clang-tidy` config.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,7 +8,7 @@ Checks: >
   -clang-analyzer-cplusplus.NewDeleteLeaks,
   -clang-analyzer-optin.performance.Padding,
   readability-*,
-  -readability-identifier-naming
+  -readability-identifier-naming,
   -readability-braces-around-statements,
   -readability-convert-member-functions-to-static,
   -readability-function-cognitive-complexity,


### PR DESCRIPTION
`clang-tidy --dump-config` shows that it had trouble around that line and the next and thus was not properly processing these.