### PR TITLE
odb: dont add each polygon to set, add them in bulk

### DIFF
--- a/src/odb/src/db/dbBlock.cpp
+++ b/src/odb/src/db/dbBlock.cpp
@@ -2332,6 +2332,7 @@ const std::vector<Rect>& dbBlock::getBlockedRegionsForPins()
 Polygon dbBlock::computeCoreArea()
 {
   std::vector<odb::Rect> rows;
+  rows.reserve(getRows().size());
   for (dbRow* row : getRows()) {
     if (row->getSite()->getClass() != odb::dbSiteClass::PAD) {
       rows.push_back(row->getBBox());

--- a/src/odb/src/db/geom.cpp
+++ b/src/odb/src/db/geom.cpp
@@ -70,14 +70,15 @@ std::vector<Polygon> Polygon::merge(const std::vector<Polygon>& polys)
   using BoostPolygonSet = boost::polygon::polygon_set_data<int>;
   using boost::polygon::operators::operator+=;
 
-  // add to polygon set
-  BoostPolygonSet poly_in_set;
-
+  // convert to boost polygon
+  std::vector<BoostPolygon> boost_poly;
+  boost_poly.reserve(polys.size());
   for (const Polygon& poly : polys) {
-    // convert to boost polygon
-    const BoostPolygon polygon_in(poly.points_.begin(), poly.points_.end());
-    poly_in_set += polygon_in;
+    boost_poly.emplace_back(poly.points_.begin(), poly.points_.end());
   }
+
+  // add to polygon set
+  const BoostPolygonSet poly_in_set(boost_poly.begin(), boost_poly.end());
 
   // extract new polygons
   std::vector<BoostPolygon> output_polygons;


### PR DESCRIPTION
Turns out the merging is insanely slow, this ensures boost performs a bulk add to the polygon set avoiding long recomputing periods.

Before on design with 21481 rows:
* Merge: 200.67s

After on same design:
* Merge: 0.07s
