### PR TITLE
gui: add highlighting of edge types and cell spacing table

### DIFF
--- a/src/gui/src/dbDescriptors.h
+++ b/src/gui/src/dbDescriptors.h
@@ -137,12 +137,13 @@ class DbMasterDescriptor : public BaseDbDescriptor<odb::dbMaster>
                                   odb::dbMaster* master,
                                   std::set<odb::dbMaster*>& masters);
 
+  static void getInstances(odb::dbMaster* master,
+                           std::set<odb::dbInst*>& insts);
+
  protected:
   Properties getDBProperties(odb::dbMaster* master) const override;
 
  private:
-  void getInstances(odb::dbMaster* master, std::set<odb::dbInst*>& insts) const;
-
   sta::dbSta* sta_;
 };
 
@@ -880,6 +881,10 @@ class DbMasterEdgeTypeDescriptor
   bool getBBox(const std::any& object, odb::Rect& bbox) const override;
 
   void highlight(const std::any& object, Painter& painter) const override;
+  static void highlightEdge(odb::dbMaster* master,
+                            odb::dbMasterEdgeType* edge,
+                            Painter& painter,
+                            const std::optional<int>& pen_width = {});
 
   void visitAllObjects(
       const std::function<void(const Selected&)>& func) const override;


### PR DESCRIPTION
Follow on to: https://github.com/The-OpenROAD-Project/OpenROAD/pull/8648

Adds:
- highlight of the edges and pairs of cell edge spacing rules.

Notes:
- due to how to the database stores this information there are a lot of string compares, for small designs this is not a concern, but for something larger this can be fairly slow.

Edge highlighting:
<img width="909" height="645" alt="image" src="https://github.com/user-attachments/assets/42a82f65-ecdc-4bdd-8f94-865dfdfd486a" />

Rule highlighting:
<img width="2604" height="794" alt="image" src="https://github.com/user-attachments/assets/2b6b7fc9-5eb4-4a69-b506-4e79170c3893" />

The pen width on the second edge could be thicker to help distinguish between the two.