### PR TITLE
test/gcd: bump rules.json

### DIFF
--- a/test/orfs/gcd/rules-base.json
+++ b/test/orfs/gcd/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 43.38,
+        "value": 43.11,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 55,
+        "value": 50,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 543,
+        "value": 509,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 47,
+        "value": 45,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 47,
+        "value": 44,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1334,
+        "value": 1222,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -83.68,
+        "value": -58.49,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 59,
+        "value": 55,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 24,
+        "value": 22,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -35.87,
+        "value": -27.72,
         "compare": ">="
     }
 }


### PR DESCRIPTION
There's been some sightings of generates rules.json files not passing tests, so checking that master doesn't have this problem.

Ran:

    bazelisk run test/orfs/gcd:gcd_update

And the tests still pass:

    bazelisk test test/orfs/gcd:gcd_test