### PR TITLE
gui: Switch to inspector view only when double clicking on violation in drc viewer.

### DIFF
--- a/src/gui/src/drcWidget.cpp
+++ b/src/gui/src/drcWidget.cpp
@@ -77,6 +77,7 @@ DRCWidget::DRCWidget(QWidget* parent)
   setWidget(container);
 
   connect(view_, &ObjectTree::clicked, this, &DRCWidget::clicked);
+  connect(view_, &ObjectTree::doubleClicked, this, &DRCWidget::doubleClicked);
   connect(view_->selectionModel(),
           &QItemSelectionModel::selectionChanged,
           this,
@@ -189,7 +190,7 @@ bool DRCWidget::setVisibleDRC(QStandardItem* item,
   return false;
 }
 
-void DRCWidget::clicked(const QModelIndex& index)
+void DRCWidget::showMarker(const QModelIndex& index, bool open_inspector)
 {
   QStandardItem* item = model_->itemFromIndex(index);
   QVariant data = item->data();
@@ -202,7 +203,7 @@ void DRCWidget::clicked(const QModelIndex& index)
       marker->setVisited(false);
     } else {
       Selected t = Gui::get()->makeSelected(marker);
-      emit selectDRC(t);
+      emit selectDRC(t, open_inspector);
       focusIndex(index);
     }
   } else {
@@ -214,6 +215,16 @@ void DRCWidget::clicked(const QModelIndex& index)
       }
     }
   }
+}
+
+void DRCWidget::clicked(const QModelIndex& index)
+{
+  showMarker(index, false);
+}
+
+void DRCWidget::doubleClicked(const QModelIndex& index)
+{
+  showMarker(index, true);
 }
 
 void DRCWidget::setBlock(odb::dbBlock* block)

--- a/src/gui/src/drcWidget.h
+++ b/src/gui/src/drcWidget.h
@@ -67,13 +67,14 @@ class DRCWidget : public QDockWidget, public odb::dbBlockCallBackObj
   void inDbMarkerDestroy(odb::dbMarker* marker) override;
 
  signals:
-  void selectDRC(const Selected& selected);
+  void selectDRC(const Selected& selected, bool open_inspector);
   void focus(const Selected& selected);
 
  public slots:
   void loadReport(const QString& filename);
   void setBlock(odb::dbBlock* block);
   void clicked(const QModelIndex& index);
+  void doubleClicked(const QModelIndex& index);
   void selectReport();
   void toggleRenderer(bool visible);
   void updateSelection(const Selected& selection);
@@ -112,6 +113,8 @@ class DRCWidget : public QDockWidget, public odb::dbBlockCallBackObj
   void toggleParent(QStandardItem* child);
   bool setVisibleDRC(QStandardItem* item, bool visible, bool announce_parent);
   void populateCategory(odb::dbMarkerCategory* category, QStandardItem* model);
+
+  void showMarker(const QModelIndex& index, bool open_inspector);
 };
 
 }  // namespace gui

--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -365,27 +365,31 @@ MainWindow::MainWindow(bool load_settings, QWidget* parent)
   connect(this, &MainWindow::blockLoaded, drc_viewer_, &DRCWidget::setBlock);
   connect(
       this, &MainWindow::blockLoaded, clock_viewer_, &ClockWidget::setBlock);
-  connect(drc_viewer_, &DRCWidget::selectDRC, [this](const Selected& selected) {
-    setSelected(selected, false);
-    odb::Rect bbox;
-    selected.getBBox(bbox);
+  connect(drc_viewer_,
+          &DRCWidget::selectDRC,
+          [this](const Selected& selected, const bool open_inspector) {
+            if (open_inspector) {
+              setSelected(selected, false);
+            }
+            odb::Rect bbox;
+            selected.getBBox(bbox);
 
-    auto* block = getBlock();
-    int zoomout_dist = std::numeric_limits<int>::max();
-    if (block != nullptr) {
-      // 10 microns
-      zoomout_dist = 10 * block->getDbUnitsPerMicron();
-    }
-    // twice the largest dimension of bounding box
-    const int zoomout_box = 2 * std::max(bbox.dx(), bbox.dy());
-    // pick smallest
-    const int zoomout_margin = std::min(zoomout_dist, zoomout_box);
-    bbox.set_xlo(bbox.xMin() - zoomout_margin);
-    bbox.set_ylo(bbox.yMin() - zoomout_margin);
-    bbox.set_xhi(bbox.xMax() + zoomout_margin);
-    bbox.set_yhi(bbox.yMax() + zoomout_margin);
-    zoomTo(bbox);
-  });
+            auto* block = getBlock();
+            int zoomout_dist = std::numeric_limits<int>::max();
+            if (block != nullptr) {
+              // 10 microns
+              zoomout_dist = 10 * block->getDbUnitsPerMicron();
+            }
+            // twice the largest dimension of bounding box
+            const int zoomout_box = 2 * std::max(bbox.dx(), bbox.dy());
+            // pick smallest
+            const int zoomout_margin = std::min(zoomout_dist, zoomout_box);
+            bbox.set_xlo(bbox.xMin() - zoomout_margin);
+            bbox.set_ylo(bbox.yMin() - zoomout_margin);
+            bbox.set_xhi(bbox.xMax() + zoomout_margin);
+            bbox.set_yhi(bbox.yMax() + zoomout_margin);
+            zoomTo(bbox);
+          });
   connect(this, &MainWindow::selectionChanged, [this]() {
     if (!selected_.empty()) {
       drc_viewer_->updateSelection(*selected_.begin());


### PR DESCRIPTION
Currently clicking on a violation in the drc viewer zooms to the violation in the renderer and switch to the inspector.
When quickly browsing several violations, we always have to switch back to the drc viewer for the next violation which is annoying.

This PR makes the changes:
- single click : Only zooms to the violation
- double click : Zooms to the violation and switch to the inspector
