### PR TITLE
DRT: correct use of drcBox_ inside FlexGCWorker

### DIFF
--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -1639,7 +1639,7 @@ void FlexGCWorker::Impl::checkMetalShape_minArea(gcPin* pin,
   gtl::rectangle_data<frCoord> bbox;
   gtl::extents(bbox, *pin->getPolygon());
   odb::Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
-  if (!drWorker_->getDrcBox().contains(bbox2)) {
+  if (!drcBox_.contains(bbox2)) {
     return;
   }
   for (auto& edges : pin->getPolygonEdges()) {


### PR DESCRIPTION
In the case, of TritonRoute::getDRCMarkers, drWorker is null for the gc worker. This removes the incorrect use of the member drWorker_.