### PR TITLE
rsz: reportFastBufferSizes() now sorts its cells before reporting.

### DIFF
--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -234,7 +234,6 @@ MANUAL_FOR_BAZEL_TESTS = [
     "repair_fanout3_hier",
     "repair_setup4_flat",
     "repair_setup4_hier",
-    "report_buffers_asap7",
     "report_dont_use",
     "report_dont_use_corners",
     "split_load_hier",

--- a/src/rsz/test/report_buffers_asap7.ok
+++ b/src/rsz/test/report_buffers_asap7.ok
@@ -122,10 +122,10 @@ There are 4 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-BUFx10_ASAP7_75t_L                            0.2 1.3e-15 1.3e-11   848.3
-BUFx24_ASAP7_75t_L                            0.4 2.4e-15 1.6e-11   507.0
 BUFx3_ASAP7_75t_L                             0.1 6.5e-16 1.0e-11  2546.9
 BUFx8_ASAP7_75t_L                             0.2 8.8e-16 1.6e-11  1029.8
+BUFx10_ASAP7_75t_L                            0.2 1.3e-15 1.3e-11   848.3
+BUFx24_ASAP7_75t_L                            0.4 2.4e-15 1.6e-11   507.0
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
 ********************************************************************************
@@ -261,10 +261,10 @@ There are 4 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-BUFx10_ASAP7_75t_L                            0.2 1.3e-15 1.3e-11   848.3
-BUFx24_ASAP7_75t_L                            0.4 2.4e-15 1.6e-11   507.0
 BUFx3_ASAP7_75t_L                             0.1 6.5e-16 1.0e-11  2546.9
 BUFx8_ASAP7_75t_L                             0.2 8.8e-16 1.6e-11  1029.8
+BUFx10_ASAP7_75t_L                            0.2 1.3e-15 1.3e-11   848.3
+BUFx24_ASAP7_75t_L                            0.4 2.4e-15 1.6e-11   507.0
 --------------------------------------------------------------------------------
 The following 3 cells are equivalent to BUFx2_ASAP7_75t_R:
 =============================================================================

--- a/src/rsz/test/report_buffers_gf180.ok
+++ b/src/rsz/test/report_buffers_gf180.ok
@@ -72,8 +72,8 @@ There are 2 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
 gf180mcu_fd_sc_mcu9t5v0__buf_8               73.4 2.8e-14 1.3e-10  1378.8
+gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
 ********************************************************************************
@@ -151,6 +151,6 @@ There are 2 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
 gf180mcu_fd_sc_mcu9t5v0__buf_8               73.4 2.8e-14 1.3e-10  1378.8
+gf180mcu_fd_sc_mcu9t5v0__buf_12             107.3 4.1e-14 1.3e-10   920.5
 --------------------------------------------------------------------------------

--- a/src/rsz/test/report_buffers_sky130hd.ok
+++ b/src/rsz/test/report_buffers_sky130hd.ok
@@ -79,8 +79,8 @@ There are 2 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 sky130_fd_sc_hd__buf_4                        7.5 2.5e-15 9.8e-11  2675.4
+sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
 ********************************************************************************
@@ -171,6 +171,6 @@ There are 2 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
-sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 sky130_fd_sc_hd__buf_4                        7.5 2.5e-15 9.8e-11  2675.4
+sky130_fd_sc_hd__buf_12                      20.0 9.6e-15 9.0e-11  1076.6
 --------------------------------------------------------------------------------

--- a/src/rsz/test/report_buffers_sky130hs.ok
+++ b/src/rsz/test/report_buffers_sky130hs.ok
@@ -63,12 +63,12 @@ There are 6 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+sky130_fd_sc_hs__bufbuf_8                    24.0 2.3e-15 1.6e-10  1267.8
 sky130_fd_sc_hs__buf_1                        6.4 2.5e-15 4.6e-11  6567.8
-sky130_fd_sc_hs__buf_16                      35.2 1.6e-14 6.5e-11   532.1
 sky130_fd_sc_hs__buf_2                        8.0 2.7e-15 5.8e-11  4229.3
 sky130_fd_sc_hs__buf_4                       11.2 3.7e-15 6.0e-11  1981.3
 sky130_fd_sc_hs__buf_8                       19.2 8.6e-15 6.5e-11  1090.2
-sky130_fd_sc_hs__bufbuf_8                    24.0 2.3e-15 1.6e-10  1267.8
+sky130_fd_sc_hs__buf_16                      35.2 1.6e-14 6.5e-11   532.1
 --------------------------------------------------------------------------------
 [INFO RSZ-0165] Buffer pruning will be disabled to enable all buffers for repair_design and repair_timing
 ********************************************************************************
@@ -135,10 +135,10 @@ There are 6 fast buffers
 Cell                                        Area  Input  Intrinsic Drive 
                                                    Cap    Delay    Res
 --------------------------------------------------------------------------------
+sky130_fd_sc_hs__bufbuf_8                    24.0 2.3e-15 1.6e-10  1267.8
 sky130_fd_sc_hs__buf_1                        6.4 2.5e-15 4.6e-11  6567.8
-sky130_fd_sc_hs__buf_16                      35.2 1.6e-14 6.5e-11   532.1
 sky130_fd_sc_hs__buf_2                        8.0 2.7e-15 5.8e-11  4229.3
 sky130_fd_sc_hs__buf_4                       11.2 3.7e-15 6.0e-11  1981.3
 sky130_fd_sc_hs__buf_8                       19.2 8.6e-15 6.5e-11  1090.2
-sky130_fd_sc_hs__bufbuf_8                    24.0 2.3e-15 1.6e-10  1267.8
+sky130_fd_sc_hs__buf_16                      35.2 1.6e-14 6.5e-11   532.1
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Progress towards resolving https://github.com/The-OpenROAD-Project/OpenROAD/issues/8698