### PR TITLE
bazel: use master upstream yaml-cpp

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -91,11 +91,11 @@ bazel_dep(name = "tcmalloc", version = "0.0.0-20250331-43fcf6e")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 bazel_dep(name = "yaml-cpp", version = "0.8.0")
 
-# fix missing stdint include https://github.com/stonier/yaml-cpp/pull/1
+# Use HEAD of master upstream to fix bugs such as missing stdint include
 git_override(
     module_name = "yaml-cpp",
     commit = "a83cd31548b19d50f3f983b069dceb4f4d50756d",
-    remote = "https://github.com/stonier/yaml-cpp.git",
+    remote = "https://github.com/jbeder/yaml-cpp.git",
 )
 
 # A from source build of QT that allows it to link into OpenROAD.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -607,8 +607,6 @@
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/source.json": "b2150404947339e8b947c6b16baa39fa75657f4ddec5e37272c7b11c7ab533bc",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.1/MODULE.bazel": "c037f75fa1b7e1ff15fbd15d807a8ce545e9b02f02df0a9777aa9aa7d8b268bb",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.1/source.json": "766f28499a16fa9ed8dc94382d50e80ceda0d0ab80b79b7b104a67074ab10e1f",
-    "https://bcr.bazel.build/modules/yaml-cpp/0.8.0/MODULE.bazel": "879443fbbf128457a187bea6f278d05789f3fc465bb22c2e0fe7fdb52e45eef0",
-    "https://bcr.bazel.build/modules/yaml-cpp/0.8.0/source.json": "8571372713f5030dbe517fb0cec549cef82aa5b76b4a178f902b95673ab5841c",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
     "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.2.13/MODULE.bazel": "aa6deb1b83c18ffecd940c4119aff9567cd0a671d7bba756741cb2ef043a29d5",


### PR DESCRIPTION
No need to faff around with pull requests or the fork that bazel bcr points to, just use upstream master.

@hzeller FYI