### PR TITLE
Use quote-include for vendored dependencies.

### DIFF
--- a/src/odb/src/3dblox/baseParser.cpp
+++ b/src/odb/src/3dblox/baseParser.cpp
@@ -12,6 +12,8 @@
 
 #include "objects.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/exceptions.h"
+#include "yaml-cpp/node/node.h"
 namespace odb {
 
 BaseParser::BaseParser(utl::Logger* logger) : logger_(logger)

--- a/src/odb/src/3dblox/baseParser.h
+++ b/src/odb/src/3dblox/baseParser.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>
+
+#include "yaml-cpp/node/node.h"
 
 namespace utl {
 class Logger;

--- a/src/odb/src/3dblox/dbvParser.cpp
+++ b/src/odb/src/3dblox/dbvParser.cpp
@@ -14,6 +14,9 @@
 #include "objects.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/exceptions.h"
+#include "yaml-cpp/node/node.h"
+#include "yaml-cpp/node/parse.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbvParser.h
+++ b/src/odb/src/3dblox/dbvParser.h
@@ -9,6 +9,7 @@
 
 #include "baseParser.h"
 #include "objects.h"
+#include "yaml-cpp/node/node.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbxParser.cpp
+++ b/src/odb/src/3dblox/dbxParser.cpp
@@ -13,6 +13,9 @@
 #include "objects.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/exceptions.h"
+#include "yaml-cpp/node/node.h"
+#include "yaml-cpp/node/parse.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbxParser.h
+++ b/src/odb/src/3dblox/dbxParser.h
@@ -8,6 +8,7 @@
 
 #include "baseParser.h"
 #include "objects.h"
+#include "yaml-cpp/node/node.h"
 
 namespace odb {
 


### PR DESCRIPTION
We prefer to include the vendored dependency
to system-provided headers.