### PR TITLE
Use quote for vendored yaml-cpp dependency.

### DIFF
--- a/src/odb/src/3dblox/baseParser.cpp
+++ b/src/odb/src/3dblox/baseParser.cpp
@@ -12,6 +12,7 @@
 
 #include "objects.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/yaml.h"
 namespace odb {
 
 BaseParser::BaseParser(utl::Logger* logger) : logger_(logger)

--- a/src/odb/src/3dblox/baseParser.h
+++ b/src/odb/src/3dblox/baseParser.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>
+
+#include "yaml-cpp/yaml.h"
 
 namespace utl {
 class Logger;

--- a/src/odb/src/3dblox/dbvParser.cpp
+++ b/src/odb/src/3dblox/dbvParser.cpp
@@ -14,6 +14,7 @@
 #include "objects.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/yaml.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbvParser.h
+++ b/src/odb/src/3dblox/dbvParser.h
@@ -9,6 +9,7 @@
 
 #include "baseParser.h"
 #include "objects.h"
+#include "yaml-cpp/yaml.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbxParser.cpp
+++ b/src/odb/src/3dblox/dbxParser.cpp
@@ -13,6 +13,7 @@
 #include "objects.h"
 #include "odb/db.h"
 #include "utl/Logger.h"
+#include "yaml-cpp/yaml.h"
 
 namespace odb {
 

--- a/src/odb/src/3dblox/dbxParser.h
+++ b/src/odb/src/3dblox/dbxParser.h
@@ -8,6 +8,7 @@
 
 #include "baseParser.h"
 #include "objects.h"
+#include "yaml-cpp/yaml.h"
 
 namespace odb {
 


### PR DESCRIPTION
This will trigger a new `misc-include-cleaner` warning as the yaml-header does not have IWYU annotations. So we should ignore such clang-tidy warning for now.

I am upstreaming the necessary IWYU pragmas in
https://github.com/jbeder/yaml-cpp/pull/1378