### PR TITLE
.gitignore: make junk visible for clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ build
 build_linux
 build_mac
 test/results
-flow
 
 docs/main
 README2.md


### PR DESCRIPTION
I think flow folders were created in OpenROAD in the distant past?