### PR TITLE
test/orfs/mock-array: check for read_spef warnings in OpenSTA

### DIFF
--- a/test/orfs/mock-array/load_power.tcl
+++ b/test/orfs/mock-array/load_power.tcl
@@ -17,11 +17,18 @@ proc check_log_for_warning { logfile } {
   # Also list unexpected warnings here as they are found.
   set unexpected_warnings {}
   foreach line [split $log_contents "\n"] {
-    if {[string match "*Warning:*" $line]} {
-      if {![string match "*pin .*? not found*" $line]} {
+    if { [string match "*Warning:*" $line] } {
+      if { ![string match "*pin * not found*" $line] } {
         lappend unexpected_warnings $line
       }
     }
+  }
+  if { [llength $unexpected_warnings] > 0 } {
+    puts "Error: Unexpected warnings found in log file $logfile:"
+    foreach warning $unexpected_warnings {
+      puts $warning
+    }
+    exit 1
   }
 }
 


### PR DESCRIPTION
@jhkim-pii Warning checking at home. We have this sort of warning checking code in ORFS, but this is good 'nuf for our current purposes.