### PR TITLE
Fix some multi-chip issues.

### DIFF
--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -284,7 +284,8 @@ void dbSta::postReadLef(dbTech* tech, dbLib* library)
 
 void dbSta::postReadDef(dbBlock* block)
 {
-  if (!block->getParent()) {
+  // If this is the top block of the main chip:
+  if (!block->getParent() && block->getChip() == block->getDb()->getChip()) {
     db_network_->readDefAfter(block);
     db_cbk_->addOwner(block);
     db_cbk_->setNetwork(db_network_);

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -662,7 +662,6 @@ void dbChip::destroy(dbChip* chip_)
   dbProperty::destroyProperties(chip);
   db->chip_hash_.remove(chip);
   db->chip_tbl_->destroy(chip);
-  db->_chip = 0;
 }
 // User Code End dbChipPublicMethods
 }  // namespace odb


### PR DESCRIPTION
dbChip::destroy: the dbDatabase's stored main chip ID should not be cleared when the chip being destroyed is not the main chip.

dbSta::postReadDef: reading a DEF for a chip that isn't the main chip should not update which block STA considers the main block.