### PR TITLE
Use ABC fork in Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -104,7 +104,7 @@ OPENROAD_LIBRARY_DEPS = [
     "//src/upf:ui",
     "//src/utl",
     "//src/utl:ui",
-    "@edu_berkeley_abc//:abc-lib",
+    "//third-party/abc:abc-lib",
     ":ord",
 ] + select(
     {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,7 +25,6 @@ http_archive(
 # This essentially reads as a TODO list of what needs to be upstreamed to BCR
 load("@rules_hdl//dependency_support/com_github_quantamhd_lemon:com_github_quantamhd_lemon.bzl", "com_github_quantamhd_lemon")
 load("@rules_hdl//dependency_support/com_github_westes_flex:com_github_westes_flex.bzl", "com_github_westes_flex")
-load("@rules_hdl//dependency_support/edu_berkeley_abc:edu_berkeley_abc.bzl", "edu_berkeley_abc")
 load("@rules_hdl//dependency_support/net_invisible_island_ncurses:net_invisible_island_ncurses.bzl", "net_invisible_island_ncurses")
 load("@rules_hdl//dependency_support/net_zlib:net_zlib.bzl", "net_zlib")
 load("@rules_hdl//dependency_support/org_gnu_bison:org_gnu_bison.bzl", "org_gnu_bison")
@@ -36,8 +35,6 @@ load("@rules_hdl//dependency_support/tk_tcl:tk_tcl.bzl", "tk_tcl")
 
 # Direct dependencies needed in Openroad
 com_github_quantamhd_lemon()
-
-edu_berkeley_abc()
 
 tk_tcl()
 

--- a/src/cgt/BUILD
+++ b/src/cgt/BUILD
@@ -40,8 +40,8 @@ cc_library(
         "//src/odb",
         "//src/sta:opensta_lib",
         "//src/utl",
+        "//third-party/abc:abc-lib",
         "@boost.stacktrace",
-        "@edu_berkeley_abc//:abc-lib",
         "@tk_tcl//:tcl",
     ],
 )

--- a/src/cut/BUILD
+++ b/src/cut/BUILD
@@ -37,6 +37,7 @@ cc_library(
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/utl",
+        "//third-party/abc:abc-lib",
         "@boost.bind",
         "@boost.config",
         "@boost.fusion",
@@ -44,6 +45,5 @@ cc_library(
         "@boost.optional",
         "@boost.phoenix",
         "@boost.spirit",
-        "@edu_berkeley_abc//:abc-lib",
     ],
 )

--- a/src/cut/test/BUILD
+++ b/src/cut/test/BUILD
@@ -37,7 +37,7 @@ cc_test(
         "//src/sta:opensta_lib",
         "//src/tst",
         "//src/utl",
-        "@edu_berkeley_abc//:abc-lib",
+        "//third-party/abc:abc-lib",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],

--- a/src/rmp/BUILD
+++ b/src/rmp/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/utl",
+        "//third-party/abc:abc-lib",
         "@boost.bind",
         "@boost.config",
         "@boost.fusion",
@@ -51,7 +52,6 @@ cc_library(
         "@boost.optional",
         "@boost.phoenix",
         "@boost.spirit",
-        "@edu_berkeley_abc//:abc-lib",
     ],
 )
 

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -163,7 +163,7 @@ cc_test(
         "//src/sta:opensta_lib",
         "//src/tst",
         "//src/utl",
-        "@edu_berkeley_abc//:abc-lib",
+        "//third-party/abc:abc-lib",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
         "@tk_tcl//:tcl",


### PR DESCRIPTION
Currently, the Bazel build uses ABC from [bazel_rules_hdl](https://github.com/hdl/bazel_rules_hdl), whereas the CMake build uses the ABC submodule. The submodule one is older than the Bazel one.

One problem with this is that some `rmp` tests fail when built with Bazel due to producing different output.

Using one ABC for both build systems will fix that and prevent version drift in the future.

PR that adds Bazel to the ABC fork: https://github.com/The-OpenROAD-Project/abc/pull/8