### PR TITLE
ord: forward debug level to STA when STA is requested

### DIFF
--- a/src/OpenRoad.i
+++ b/src/OpenRoad.i
@@ -417,6 +417,9 @@ set_debug_level(const char* tool_name,
   if (id == utl::UKN) {
     logger->error(utl::ORD, 15, "Unknown tool name {}", tool_name);
   }
+  if (id == utl::STA) {
+    getSta()->setDebugLevel(group, level);
+  }
   logger->setDebugLevel(id, group, level);
 }
 


### PR DESCRIPTION
Closes #8749

@maliberty I couldn't find a place where this is handed in the python swig wrapper, let me know if it's there and I missed it.