### PR TITLE
gpl: rename variables for clarity

### DIFF
--- a/src/gpl/src/graphicsImpl.cpp
+++ b/src/gpl/src/graphicsImpl.cpp
@@ -697,7 +697,7 @@ bool GraphicsImpl::populateMap()
 
       double value = std::max(0.0f,
                               static_cast<float>(bin.getInstPlacedArea())
-                                  + static_cast<float>(bin.getNonPlaceAre())
+                                  + static_cast<float>(bin.getNonPlaceArea())
                                   - scaledBinArea);
       value = block->dbuAreaToMicrons(value);
 
@@ -717,10 +717,10 @@ bool GraphicsImpl::populateMap()
       const float scaledBinArea
           = static_cast<float>(binArea * bin.getTargetDensity());
 
-      double raw_value = std::max(0.0f,
-                                  static_cast<float>(bin.getInstPlacedArea())
-                                      + static_cast<float>(bin.getNonPlaceAre())
-                                      - scaledBinArea);
+      double raw_value = std::max(
+          0.0f,
+          static_cast<float>(bin.getInstPlacedArea())
+              + static_cast<float>(bin.getNonPlaceArea()) - scaledBinArea);
       raw_value = block->dbuAreaToMicrons(raw_value);
 
       if (heatmap_type_ == OverflowMinMax && max_value > min_value) {

--- a/src/gpl/src/graphicsImpl.cpp
+++ b/src/gpl/src/graphicsImpl.cpp
@@ -695,11 +695,10 @@ bool GraphicsImpl::populateMap()
       const float scaledBinArea
           = static_cast<float>(binArea * bin.getTargetDensity());
 
-      double value
-          = std::max(0.0f,
-                     static_cast<float>(bin.getInstPlacedAreaUnscaled())
-                         + static_cast<float>(bin.getNonPlaceAreaUnscaled())
-                         - scaledBinArea);
+      double value = std::max(0.0f,
+                              static_cast<float>(bin.getInstPlacedArea())
+                                  + static_cast<float>(bin.getNonPlaceAre())
+                                  - scaledBinArea);
       value = block->dbuAreaToMicrons(value);
 
       min_value = std::min(min_value, value);
@@ -718,11 +717,10 @@ bool GraphicsImpl::populateMap()
       const float scaledBinArea
           = static_cast<float>(binArea * bin.getTargetDensity());
 
-      double raw_value
-          = std::max(0.0f,
-                     static_cast<float>(bin.getInstPlacedAreaUnscaled())
-                         + static_cast<float>(bin.getNonPlaceAreaUnscaled())
-                         - scaledBinArea);
+      double raw_value = std::max(0.0f,
+                                  static_cast<float>(bin.getInstPlacedArea())
+                                      + static_cast<float>(bin.getNonPlaceAre())
+                                      - scaledBinArea);
       raw_value = block->dbuAreaToMicrons(raw_value);
 
       if (heatmap_type_ == OverflowMinMax && max_value > min_value) {

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -255,7 +255,7 @@ bool GCell::isLargeInstance() const
   if (!isInstance()) {
     return false;
   }
-  return insts_[0]->isPbLargeInstance();
+  return insts_[0]->isLargeInstance();
 }
 
 bool GCell::isStdInstance() const
@@ -263,7 +263,7 @@ bool GCell::isStdInstance() const
   if (!isInstance()) {
     return false;
   }
-  return !insts_[0]->isPbLargeInstance();
+  return !insts_[0]->isLargeInstance();
 }
 
 void GCell::print(utl::Logger* logger, bool print_only_name = true) const
@@ -3987,7 +3987,7 @@ static int64_t getOverlapAreaBiNormal(const Bin* bin,
     return 0;
   }
 
-  if (inst->isPbLargeInstance()) {
+  if (inst->isLargeInstance()) {
     const float meanX = (inst->cx() - inst->lx()) / (float) dbu_per_micron;
     const float meanY = (inst->cy() - inst->ly()) / (float) dbu_per_micron;
 

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -938,7 +938,7 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells)
     const float overflowAreaUnscaled
         = std::max(0.0f,
                    static_cast<float>(bin.getInstPlacedArea())
-                       + static_cast<float>(bin.getNonPlaceAre())
+                       + static_cast<float>(bin.getNonPlaceArea())
                        - density_scaled_bin_area);
     sum_overflow_area_ += overflowAreaUnscaled;
 
@@ -952,7 +952,7 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells)
                    block->dbuAreaToMicrons(density_scaled_bin_area));
       log_->report("bin.getInstPlacedArea():{}, bin.getNonPlaceArea():{}",
                    block->dbuAreaToMicrons(bin.getInstPlacedArea()),
-                   block->dbuAreaToMicrons(bin.getNonPlaceAre()));
+                   block->dbuAreaToMicrons(bin.getNonPlaceArea()));
       log_->report(
           "bin.getInstPlacedAreaBiNormal():{}, "
           "bin.getNonPlaceAreaBiNormal():{}",

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -35,11 +35,11 @@ using utl::GPL;
 
 static float calculateBiVariateNormalCDF(biNormalParameters i);
 
-static int64_t getOverlapArea(const Bin* bin,
-                              const Instance* inst,
-                              int dbu_per_micron);
+static int64_t getOverlapAreaBiNormal(const Bin* bin,
+                                      const Instance* inst,
+                                      int dbu_per_micron);
 
-static int64_t getOverlapAreaUnscaled(const Bin* bin, const Instance* inst);
+static int64_t getOverlapArea(const Bin* bin, const Instance* inst);
 
 static float getDistance(const std::vector<FloatPoint>& a,
                          const std::vector<FloatPoint>& b);
@@ -218,9 +218,9 @@ void GCell::setDensitySize(int dDx, int dDy)
   dUy_ = dCenterY + dDy / 2;
 }
 
-void GCell::setDensityScale(float densityScale)
+void GCell::setDensitySmoothing(float densitySmoothing)
 {
-  densityScale_ = densityScale;
+  densitySmoothing_ = densitySmoothing;
 }
 
 void GCell::setGradientX(float gradientX)
@@ -250,12 +250,12 @@ bool GCell::isFiller() const
   return insts_.empty();
 }
 
-bool GCell::isMacroInstance() const
+bool GCell::isLargeInstance() const
 {
   if (!isInstance()) {
     return false;
   }
-  return insts_[0]->isMacro();
+  return insts_[0]->isPbLargeInstance();
 }
 
 bool GCell::isStdInstance() const
@@ -263,7 +263,7 @@ bool GCell::isStdInstance() const
   if (!isInstance()) {
     return false;
   }
-  return !insts_[0]->isMacro();
+  return !insts_[0]->isPbLargeInstance();
 }
 
 void GCell::print(utl::Logger* logger, bool print_only_name = true) const
@@ -280,8 +280,8 @@ void GCell::print(utl::Logger* logger, bool print_only_name = true) const
     logger->report("lx_: {} ly_: {} ux_: {} uy_: {}", lx_, ly_, ux_, uy_);
     logger->report(
         "dLx_: {} dLy_: {} dUx_: {} dUy_: {}", dLx_, dLy_, dUx_, dUy_);
-    logger->report("densityScale_: {} gradientX_: {} gradientY_: {}",
-                   densityScale_,
+    logger->report("densitySmoothing_: {} gradientX_: {} gradientY_: {}",
+                   densitySmoothing_,
                    gradientX_,
                    gradientY_);
   }
@@ -292,7 +292,7 @@ void GCell::writeAttributesToCSV(std::ostream& out) const
   out << "," << insts_.size() << "," << gPins_.size();
   out << "," << lx_ << "," << ly_ << "," << ux_ << "," << uy_;
   out << "," << dLx_ << "," << dLy_ << "," << dUx_ << "," << dUy_;
-  out << "," << densityScale_ << "," << gradientX_ << "," << gradientY_;
+  out << "," << densitySmoothing_ << "," << gradientX_ << "," << gradientY_;
 }
 
 ////////////////////////////////////////////////
@@ -684,14 +684,14 @@ double BinGrid::getBinSizeY() const
   return binSizeY_;
 }
 
-int64_t BinGrid::getOverflowArea() const
+int64_t BinGrid::getOverflowAreaBiNormal() const
 {
-  return sumOverflowArea_;
+  return sum_overflow_area_binormal_;
 }
 
-int64_t BinGrid::getOverflowAreaUnscaled() const
+int64_t BinGrid::getOverflowArea() const
 {
-  return sumOverflowAreaUnscaled_;
+  return sum_overflow_area_;
 }
 
 static unsigned int roundDownToPowerOfTwo(unsigned int x)
@@ -825,8 +825,8 @@ void BinGrid::initBins()
 void BinGrid::updateBinsNonPlaceArea()
 {
   for (auto& bin : bins_) {
+    bin.setNonPlaceAreaBiNormal(0);
     bin.setNonPlaceArea(0);
-    bin.setNonPlaceAreaUnscaled(0);
   }
 
   for (auto& inst : pb_->nonPlaceInsts()) {
@@ -840,14 +840,14 @@ void BinGrid::updateBinsNonPlaceArea()
         // target density.
         // See MS-replace paper
         //
-        bin.addNonPlaceArea(
-            getOverlapArea(
+        bin.addNonPlaceAreaBiNormal(
+            getOverlapAreaBiNormal(
                 &bin,
                 inst,
                 pb_->db()->getChip()->getBlock()->getDbUnitsPerMicron())
             * bin.getTargetDensity());
-        bin.addNonPlaceAreaUnscaled(getOverlapAreaUnscaled(&bin, inst)
-                                    * bin.getTargetDensity());
+        bin.addNonPlaceArea(getOverlapArea(&bin, inst)
+                            * bin.getTargetDensity());
       }
     }
   }
@@ -858,7 +858,7 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells)
 {
   // clear the Bin-area info
   for (Bin& bin : bins_) {
-    bin.setInstPlacedAreaUnscaled(0);
+    bin.setInstPlacedArea(0);
     bin.setFillerArea(0);
   }
 
@@ -872,15 +872,16 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells)
     if (cell->isInstance()) {
       // macro should have
       // scale-down with target-density
-      if (cell->isMacroInstance()) {
+      if (cell->isLargeInstance()) {
         for (int y = pairY.first; y < pairY.second; y++) {
           for (int x = pairX.first; x < pairX.second; x++) {
-            Bin& bin = bins_[y * binCntX_ + x];
+            Bin& bin = bins_[(y * binCntX_) + x];
 
-            const float scaledAvea = getOverlapDensityArea(bin, cell)
-                                     * cell->getDensityScale()
-                                     * bin.getTargetDensity();
-            bin.addInstPlacedAreaUnscaled(scaledAvea);
+            // Large instances (macros) are scaled by target density
+            const float smoothed_cell_area = getOverlapDensityArea(bin, cell)
+                                             * cell->getDensitySmoothing()
+                                             * bin.getTargetDensity();
+            bin.addInstPlacedArea(smoothed_cell_area);
           }
         }
       }
@@ -888,81 +889,75 @@ void BinGrid::updateBinsGCellDensityArea(const std::vector<GCellHandle>& cells)
       else if (cell->isStdInstance()) {
         for (int y = pairY.first; y < pairY.second; y++) {
           for (int x = pairX.first; x < pairX.second; x++) {
-            Bin& bin = bins_[y * binCntX_ + x];
-            const float scaledArea
-                = getOverlapDensityArea(bin, cell) * cell->getDensityScale();
-            bin.addInstPlacedAreaUnscaled(scaledArea);
+            Bin& bin = bins_[(y * binCntX_) + x];
+            const float smoothed_cell_area = getOverlapDensityArea(bin, cell)
+                                             * cell->getDensitySmoothing();
+            bin.addInstPlacedArea(smoothed_cell_area);
           }
         }
       }
     } else if (cell->isFiller()) {
       for (int y = pairY.first; y < pairY.second; y++) {
         for (int x = pairX.first; x < pairX.second; x++) {
-          Bin& bin = bins_[y * binCntX_ + x];
+          Bin& bin = bins_[(y * binCntX_) + x];
           bin.addFillerArea(getOverlapDensityArea(bin, cell)
-                            * cell->getDensityScale());
+                            * cell->getDensitySmoothing());
         }
       }
     }
   }
 
   odb::dbBlock* block = pb_->db()->getChip()->getBlock();
-  sumOverflowArea_ = 0;
-  sumOverflowAreaUnscaled_ = 0;
+  sum_overflow_area_binormal_ = 0;
+  sum_overflow_area_ = 0;
   // update density and overflowArea
   // for nesterov use and FFT library
 #pragma omp parallel for num_threads(num_threads_) \
-    reduction(+ : sumOverflowArea_, sumOverflowAreaUnscaled_)
+    reduction(+ : sum_overflow_area_binormal_, sum_overflow_area_)
   for (auto it = bins_.begin(); it < bins_.end(); ++it) {
     Bin& bin = *it;  // old-style loop for old OpenMP
 
-    // Copy unscaled to scaled
-    bin.setInstPlacedArea(bin.getInstPlacedAreaUnscaled());
+    // Copy unscaled to scaled (birnormal scaling)
+    bin.setInstPlacedAreaBiNormal(bin.getInstPlacedArea());
 
     int64_t binArea = bin.getBinArea();
-    const float scaledBinArea
+    const float density_scaled_bin_area
         = static_cast<float>(binArea * bin.getTargetDensity());
-    bin.setDensity((static_cast<float>(bin.instPlacedArea())
+    bin.setDensity((static_cast<float>(bin.getInstPlacedAreaBiNormal())
                     + static_cast<float>(bin.getFillerArea())
-                    + static_cast<float>(bin.getNonPlaceArea()))
-                   / scaledBinArea);
+                    + static_cast<float>(bin.getNonPlaceAreaBiNormal()))
+                   / density_scaled_bin_area);
 
-    const float overflowArea = std::max(
-        0.0f,
-        static_cast<float>(bin.instPlacedArea())
-            + static_cast<float>(bin.getNonPlaceArea()) - scaledBinArea);
-    sumOverflowArea_ += overflowArea;  // NOLINT
+    const float overflowArea
+        = std::max(0.0f,
+                   static_cast<float>(bin.getInstPlacedAreaBiNormal())
+                       + static_cast<float>(bin.getNonPlaceAreaBiNormal())
+                       - density_scaled_bin_area);
+    sum_overflow_area_binormal_ += overflowArea;  // NOLINT
 
     const float overflowAreaUnscaled
         = std::max(0.0f,
-                   static_cast<float>(bin.getInstPlacedAreaUnscaled())
-                       + static_cast<float>(bin.getNonPlaceAreaUnscaled())
-                       - scaledBinArea);
-    sumOverflowAreaUnscaled_ += overflowAreaUnscaled;
-    if (overflowAreaUnscaled > 0) {
-      debugPrint(log_,
-                 GPL,
-                 "overflow",
-                 1,
-                 "overflow:{}, bin:{},{}",
-                 block->dbuAreaToMicrons(overflowAreaUnscaled),
-                 block->dbuToMicrons(bin.lx()),
-                 block->dbuToMicrons(bin.ly()));
-      debugPrint(log_,
-                 GPL,
-                 "overflow",
-                 1,
-                 "binArea:{}, scaledBinArea:{}",
-                 block->dbuAreaToMicrons(binArea),
-                 block->dbuAreaToMicrons(scaledBinArea));
-      debugPrint(
-          log_,
-          GPL,
-          "overflow",
-          1,
-          "bin.instPlacedAreaUnscaled():{}, bin.nonPlaceAreaUnscaled():{}",
-          block->dbuAreaToMicrons(bin.getInstPlacedAreaUnscaled()),
-          block->dbuAreaToMicrons(bin.getNonPlaceAreaUnscaled()));
+                   static_cast<float>(bin.getInstPlacedArea())
+                       + static_cast<float>(bin.getNonPlaceAre())
+                       - density_scaled_bin_area);
+    sum_overflow_area_ += overflowAreaUnscaled;
+
+    if (overflowAreaUnscaled > 0 && log_->debugCheck(GPL, "overflow", 1)) {
+      log_->report("overflow:{}, bin:{},{}",
+                   block->dbuAreaToMicrons(overflowAreaUnscaled),
+                   block->dbuToMicrons(bin.lx()),
+                   block->dbuToMicrons(bin.ly()));
+      log_->report("binArea:{}, density_scaled_bin_area:{}",
+                   block->dbuAreaToMicrons(binArea),
+                   block->dbuAreaToMicrons(density_scaled_bin_area));
+      log_->report("bin.getInstPlacedArea():{}, bin.getNonPlaceArea():{}",
+                   block->dbuAreaToMicrons(bin.getInstPlacedArea()),
+                   block->dbuAreaToMicrons(bin.getNonPlaceAre()));
+      log_->report(
+          "bin.getInstPlacedAreaBiNormal():{}, "
+          "bin.getNonPlaceAreaBiNormal():{}",
+          block->dbuAreaToMicrons(bin.getInstPlacedAreaBiNormal()),
+          block->dbuAreaToMicrons(bin.getNonPlaceAreaBiNormal()));
     }
   }
 }
@@ -1773,7 +1768,7 @@ NesterovBase::NesterovBase(NesterovBaseVars nbVars,
 
   fft_ = std::move(fft);
 
-  // update densitySize and densityScale in each gCell
+  // update densitySize and densitySmoothing in each gCell
   updateDensitySize();
 
   checkConsistency();
@@ -2106,14 +2101,14 @@ double NesterovBase::getBinSizeY() const
   return bg_.getBinSizeY();
 }
 
+int64_t NesterovBase::getOverflowAreaBiNormal() const
+{
+  return bg_.getOverflowAreaBiNormal();
+}
+
 int64_t NesterovBase::getOverflowArea() const
 {
   return bg_.getOverflowArea();
-}
-
-int64_t NesterovBase::getOverflowAreaUnscaled() const
-{
-  return bg_.getOverflowAreaUnscaled();
 }
 
 int NesterovBase::getFillerDx() const
@@ -2191,7 +2186,9 @@ float NesterovBase::getTargetDensity() const
   return targetDensity_;
 }
 
-// update densitySize and densityScale in each gCell
+// update densitySize and densitySmoothing in each gCell
+// Density smoothing from eplace paper: "4.5. Local Smoothness Over Discrete
+// Grids"
 void NesterovBase::updateDensitySize()
 {
   assert(omp_get_thread_num() == 0);
@@ -2219,7 +2216,7 @@ void NesterovBase::updateDensitySize()
     }
 
     gCell->setDensitySize(densitySizeX, densitySizeY);
-    gCell->setDensityScale(scaleX * scaleY);
+    gCell->setDensitySmoothing(scaleX * scaleY);
   }
 }
 
@@ -2233,7 +2230,7 @@ void NesterovBase::updateAreas()
     if (!gCell) {
       continue;
     }
-    if (gCell->isMacroInstance()) {
+    if (gCell->isLargeInstance()) {
       macroInstsArea_ += static_cast<int64_t>(gCell->dx())
                          * static_cast<int64_t>(gCell->dy());
     } else if (gCell->isStdInstance()) {
@@ -2318,7 +2315,7 @@ FloatPoint NesterovBase::getDensityGradient(const GCell* gCell) const
     for (int j = pairY.first; j < pairY.second; j++) {
       const Bin& bin = bg_.getBinsConst()[j * getBinCntX() + i];
       float overlapArea
-          = getOverlapDensityArea(bin, gCell) * gCell->getDensityScale();
+          = getOverlapDensityArea(bin, gCell) * gCell->getDensitySmoothing();
 
       electroForce.x += overlapArea * bin.electroForceX();
       electroForce.y += overlapArea * bin.electroForceY();
@@ -2356,7 +2353,8 @@ void NesterovBase::updateDensityForceBin()
     bin.setElectroPhi(electroPhi);
 
     sumPhi_ += electroPhi
-               * static_cast<float>(bin.getNonPlaceArea() + bin.instPlacedArea()
+               * static_cast<float>(bin.getNonPlaceAreaBiNormal()
+                                    + bin.getInstPlacedAreaBiNormal()
                                     + bin.getFillerArea());
   }
 }
@@ -2396,7 +2394,7 @@ void NesterovBase::initDensity1()
     std::string type = "Uknown";
     if (gCell->isInstance()) {
       type = "StdCell";
-    } else if (gCell->isMacroInstance()) {
+    } else if (gCell->isLargeInstance()) {
       type = "Macro";
     } else if (gCell->isFiller()) {
       type = "Filler";
@@ -2415,11 +2413,11 @@ void NesterovBase::initDensity1()
       = npVars_->initWireLengthCoef
         / (static_cast<float>(getBinSizeX() + getBinSizeY()) * 0.5);
 
+  sum_overflow_binormal_ = static_cast<float>(getOverflowAreaBiNormal())
+                           / static_cast<float>(getNesterovInstsArea());
+
   sum_overflow_ = static_cast<float>(getOverflowArea())
                   / static_cast<float>(getNesterovInstsArea());
-
-  sum_overflow_unscaled_ = static_cast<float>(getOverflowAreaUnscaled())
-                           / static_cast<float>(getNesterovInstsArea());
 }
 
 float NesterovBase::initDensity2(float wlCoeffX, float wlCoeffY)
@@ -2434,11 +2432,11 @@ float NesterovBase::initDensity2(float wlCoeffX, float wlCoeffY)
         = (wireLengthGradSum_ / densityGradSum_) * npVars_->initDensityPenalty;
   }
 
+  sum_overflow_binormal_ = static_cast<float>(getOverflowAreaBiNormal())
+                           / static_cast<float>(getNesterovInstsArea());
+
   sum_overflow_ = static_cast<float>(getOverflowArea())
                   / static_cast<float>(getNesterovInstsArea());
-
-  sum_overflow_unscaled_ = static_cast<float>(getOverflowAreaUnscaled())
-                           / static_cast<float>(getNesterovInstsArea());
 
   stepLength_ = getStepLength(
       prevSLPCoordi_, prevSLPSumGrads_, curSLPCoordi_, curSLPSumGrads_);
@@ -2736,8 +2734,8 @@ void NesterovBase::updateNextIter(const int iter)
       = std::max(static_cast<float>(getNesterovInstsArea()),
                  fractionOfMaxIters * pb_->nonPlaceInstsArea() * 0.05f);
 
+  sum_overflow_binormal_ = getOverflowAreaBiNormal() / overflowDenominator;
   sum_overflow_ = getOverflowArea() / overflowDenominator;
-  sum_overflow_unscaled_ = getOverflowAreaUnscaled() / overflowDenominator;
 
   int64_t hpwl = nbc_->getHpwl();
 
@@ -2749,7 +2747,7 @@ void NesterovBase::updateNextIter(const int iter)
                             * 100.0;
     }
     prev_reported_hpwl_ = hpwl;
-    prev_reported_overflow_unscaled_ = sum_overflow_unscaled_;
+    prev_reported_overflow_ = sum_overflow_;
 
     std::string group_name;
     if (pb_->group()) {
@@ -2780,7 +2778,7 @@ void NesterovBase::updateNextIter(const int iter)
     dbBlock* block = pb_->db()->getChip()->getBlock();
     log_->report("{:9d} | {:8.4f} | {:13.6e} | {:+7.2f}% | {:9.2e} | {:>5}",
                  iter,
-                 sum_overflow_unscaled_,
+                 sum_overflow_,
                  block->dbuToMicrons(hpwl),
                  hpwl_percent_change,
                  densityPenalty_,
@@ -2800,14 +2798,13 @@ void NesterovBase::updateNextIter(const int iter)
              "Gradient: {:g}",
              getSecondNorm(curSLPSumGrads_));
   debugPrint(log_, GPL, "updateNextIter", 1, "Phi: {:g}", getSumPhi());
-  debugPrint(
-      log_, GPL, "updateNextIter", 1, "Overflow: {:g}", sum_overflow_unscaled_);
+  debugPrint(log_, GPL, "updateNextIter", 1, "Overflow: {:g}", sum_overflow_);
 
   densityPenalty_ *= phiCoef;
   prev_hpwl_ = hpwl;
 
-  if (iter > 50 && minSumOverflow_ > sum_overflow_unscaled_) {
-    minSumOverflow_ = sum_overflow_unscaled_;
+  if (iter > 50 && minSumOverflow_ > sum_overflow_) {
+    minSumOverflow_ = sum_overflow_;
     hpwlWithMinSumOverflow_ = prev_hpwl_;
   }
 }
@@ -2883,7 +2880,7 @@ void NesterovBase::nesterovAdjustPhi()
   // dynamic adjustment for
   // better convergence with
   // large designs
-  if (!nbVars_.isMaxPhiCoefChanged && sum_overflow_unscaled_ < 0.35f) {
+  if (!nbVars_.isMaxPhiCoefChanged && sum_overflow_ < 0.35f) {
     nbVars_.isMaxPhiCoefChanged = true;
     nbVars_.maxPhiCoef *= 0.99;
   }
@@ -2914,7 +2911,7 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
   if (isConverged_) {
     return true;
   }
-  if (sum_overflow_unscaled_ <= npVars_->targetOverflow) {
+  if (sum_overflow_ <= npVars_->targetOverflow) {
     const bool has_group = pb_->group();
     const std::string group_name = has_group ? pb_->group()->getName() : "";
     const int final_iter = gpl_iter_count;
@@ -2922,7 +2919,7 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
 
     log_->report("{:9d} | {:8.4f} | {:13.6e} | {:>8} | {:9.2e} | {:>5}",
                  final_iter,
-                 sum_overflow_unscaled_,
+                 sum_overflow_,
                  block->dbuToMicrons(nbc_->getHpwl()),
                  "",  // No % delta
                  densityPenalty_,
@@ -3027,18 +3024,16 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
 
 bool NesterovBase::checkDivergence()
 {
-  if (sum_overflow_unscaled_ < 0.2f
-      && sum_overflow_unscaled_ - minSumOverflow_ >= 0.02f
+  if (sum_overflow_ < 0.2f && sum_overflow_ - minSumOverflow_ >= 0.02f
       && hpwlWithMinSumOverflow_ * 1.2f < prev_hpwl_) {
     isDiverged_ = true;
     log_->warn(GPL, 323, "Divergence detected between consecutive iterations");
   }
 
   // Check if both overflow and HPWL increase
-  if (minSumOverflow_ < 0.2f && prev_reported_overflow_unscaled_ > 0
+  if (minSumOverflow_ < 0.2f && prev_reported_overflow_ > 0
       && prev_reported_hpwl_ > 0) {
-    float overflow_change
-        = sum_overflow_unscaled_ - prev_reported_overflow_unscaled_;
+    float overflow_change = sum_overflow_ - prev_reported_overflow_;
     float hpwl_increase = (static_cast<float>(prev_hpwl_ - prev_reported_hpwl_))
                           / static_cast<float>(prev_reported_hpwl_);
 
@@ -3175,7 +3170,7 @@ void NesterovBase::updateGCellState(float wlCoeffX, float wlCoeffY)
       }
 
       gcell->setDensitySize(densitySizeX, densitySizeY);
-      gcell->setDensityScale(scaleX * scaleY);
+      gcell->setDensitySmoothing(scaleX * scaleY);
 
       // analogous to NesterovBase::initDensity1()
       updateDensityCoordiLayoutInside(gcell);
@@ -3889,7 +3884,7 @@ void NesterovBase::writeGCellVectorsToCSV(const std::string& filename,
     file << ",insts_size,gPins_size";
     file << ",lx,ly,ux,uy";
     file << ",dLx,dLy,dUx,dUy";
-    file << ",densityScale,gradientX,gradientY";
+    file << ",densitySmoothing,gradientX,gradientY";
 
     auto add_header = [&](const std::string& name) {
       file << "," << name << "_x" << "," << name << "_y";
@@ -3979,9 +3974,9 @@ static float getOverlapDensityArea(const Bin& bin, const GCell* cell)
          * static_cast<float>(rectUy - rectLy);
 }
 
-static int64_t getOverlapArea(const Bin* bin,
-                              const Instance* inst,
-                              int dbu_per_micron)
+static int64_t getOverlapAreaBiNormal(const Bin* bin,
+                                      const Instance* inst,
+                                      int dbu_per_micron)
 {
   int rectLx = std::max(bin->lx(), inst->lx()),
       rectLy = std::max(bin->ly(), inst->ly()),
@@ -3992,7 +3987,7 @@ static int64_t getOverlapArea(const Bin* bin,
     return 0;
   }
 
-  if (inst->isMacro()) {
+  if (inst->isPbLargeInstance()) {
     const float meanX = (inst->cx() - inst->lx()) / (float) dbu_per_micron;
     const float meanY = (inst->cy() - inst->ly()) / (float) dbu_per_micron;
 
@@ -4031,7 +4026,7 @@ static int64_t getOverlapArea(const Bin* bin,
          * static_cast<float>(rectUy - rectLy);
 }
 
-static int64_t getOverlapAreaUnscaled(const Bin* bin, const Instance* inst)
+static int64_t getOverlapArea(const Bin* bin, const Instance* inst)
 {
   const int rectLx = std::max(bin->lx(), inst->lx());
   const int rectLy = std::max(bin->ly(), inst->ly());

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -1685,7 +1685,7 @@ NesterovBase::NesterovBase(NesterovBaseVars nbVars,
   srand(42);
   // area update from pb
   stdInstsArea_ = pb_->stdInstsArea();
-  macroInstsArea_ = pb_->macroInstsArea();
+  large_insts_area_ = pb_->largeInstsArea();
 
   int dbu_per_micron = pb_->db()->getChip()->getBlock()->getDbUnitsPerMicron();
 
@@ -1838,7 +1838,7 @@ void NesterovBase::initFillerGCells()
 
   float tmp_targetDensity
       = static_cast<float>(stdInstsArea_)
-            / static_cast<float>(whiteSpaceArea_ - macroInstsArea_)
+            / static_cast<float>(whiteSpaceArea_ - large_insts_area_)
         + 0.01;
   // targetDensity initialize
   if (nbVars_.useUniformTargetDensity) {
@@ -2163,7 +2163,7 @@ int64_t NesterovBase::getNesterovInstsArea() const
 {
   return stdInstsArea_
          + static_cast<int64_t>(
-             std::round(pb_->macroInstsArea() * targetDensity_));
+             std::round(pb_->largeInstsArea() * targetDensity_));
 }
 
 float NesterovBase::getSumPhi() const
@@ -2224,15 +2224,15 @@ void NesterovBase::updateAreas()
 {
   // bloating can change the following :
   // stdInstsArea and macroInstsArea
-  stdInstsArea_ = macroInstsArea_ = 0;
+  stdInstsArea_ = large_insts_area_ = 0;
   for (auto it = nb_gcells_.begin(); it < nb_gcells_.end(); ++it) {
     auto& gCell = *it;  // old-style loop for old OpenMP
     if (!gCell) {
       continue;
     }
     if (gCell->isLargeInstance()) {
-      macroInstsArea_ += static_cast<int64_t>(gCell->dx())
-                         * static_cast<int64_t>(gCell->dy());
+      large_insts_area_ += static_cast<int64_t>(gCell->dx())
+                           * static_cast<int64_t>(gCell->dy());
     } else if (gCell->isStdInstance()) {
       stdInstsArea_ += static_cast<int64_t>(gCell->dx())
                        * static_cast<int64_t>(gCell->dy());

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -564,7 +564,7 @@ class Bin
   {
     return inst_placed_area_binormal_;
   }
-  int64_t getNonPlaceAre() const { return non_place_area_; }
+  int64_t getNonPlaceArea() const { return non_place_area_; }
   int64_t getInstPlacedArea() const { return inst_placed_area_; }
 
   int64_t getFillerArea() const { return filler_area_; }

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -112,17 +112,17 @@ class GCell
   void setDensityCenterLocation(int dCx, int dCy);
   void setDensitySize(int dDx, int dDy);
 
-  void setDensityScale(float densityScale);
+  void setDensitySmoothing(float densitySmoothing);
   void setGradientX(float gradientX);
   void setGradientY(float gradientY);
 
   float getGradientX() const { return gradientX_; }
   float getGradientY() const { return gradientY_; }
-  float getDensityScale() const { return densityScale_; }
+  float getDensitySmoothing() const { return densitySmoothing_; }
 
   bool isInstance() const;
   bool isFiller() const;
-  bool isMacroInstance() const;
+  bool isLargeInstance() const;
   bool isStdInstance() const;
   bool contains(odb::dbInst* db_inst) const;
 
@@ -142,7 +142,7 @@ class GCell
   int dUx_ = 0;
   int dUy_ = 0;
 
-  float densityScale_ = 0;
+  float densitySmoothing_ = 0;
   float gradientX_ = 0;
   float gradientY_ = 0;
 
@@ -545,27 +545,30 @@ class Bin
   void setElectroForce(float electroForceX, float electroForceY);
   void setElectroPhi(float phi);
 
-  void setNonPlaceArea(int64_t area);
-  void setInstPlacedArea(int64_t area);
+  void setNonPlaceAreaBiNormal(int64_t area);
+  void setInstPlacedAreaBiNormal(int64_t area);
   void setFillerArea(int64_t area);
 
-  void setNonPlaceAreaUnscaled(int64_t area);
-  void setInstPlacedAreaUnscaled(int64_t area);
+  void setNonPlaceArea(int64_t area);
+  void setInstPlacedArea(int64_t area);
+
+  void addNonPlaceAreaBiNormal(int64_t area);
+  // void addInstPlacedArea(int64_t area);
+  void addFillerArea(int64_t area);
 
   void addNonPlaceArea(int64_t area);
   void addInstPlacedArea(int64_t area);
-  void addFillerArea(int64_t area);
-
-  void addNonPlaceAreaUnscaled(int64_t area);
-  void addInstPlacedAreaUnscaled(int64_t area);
 
   int64_t getBinArea() const;
-  int64_t getNonPlaceArea() const { return nonPlaceArea_; }
-  int64_t instPlacedArea() const { return instPlacedArea_; }
-  int64_t getNonPlaceAreaUnscaled() const { return nonPlaceAreaUnscaled_; }
-  int64_t getInstPlacedAreaUnscaled() const { return instPlacedAreaUnscaled_; }
+  int64_t getNonPlaceAreaBiNormal() const { return non_place_area_binormal_; }
+  int64_t getInstPlacedAreaBiNormal() const
+  {
+    return inst_placed_area_binormal_;
+  }
+  int64_t getNonPlaceAre() const { return non_place_area_; }
+  int64_t getInstPlacedArea() const { return inst_placed_area_; }
 
-  int64_t getFillerArea() const { return fillerArea_; }
+  int64_t getFillerArea() const { return filler_area_; }
 
  private:
   // index
@@ -578,12 +581,12 @@ class Bin
   int ux_ = 0;
   int uy_ = 0;
 
-  int64_t nonPlaceArea_ = 0;
-  int64_t instPlacedArea_ = 0;
+  int64_t non_place_area_binormal_ = 0;
+  int64_t inst_placed_area_binormal_ = 0;
 
-  int64_t instPlacedAreaUnscaled_ = 0;
-  int64_t nonPlaceAreaUnscaled_ = 0;
-  int64_t fillerArea_ = 0;
+  int64_t inst_placed_area_ = 0;
+  int64_t non_place_area_ = 0;
+  int64_t filler_area_ = 0;
 
   float density_ = 0;
   float targetDensity_ = 0;  // will enable bin-wise density screening
@@ -612,54 +615,54 @@ inline int Bin::dy() const
   return (uy_ - ly_);
 }
 
-inline void Bin::setNonPlaceArea(int64_t area)
+inline void Bin::setNonPlaceAreaBiNormal(int64_t area)
 {
-  nonPlaceArea_ = area;
+  non_place_area_binormal_ = area;
 }
 
-inline void Bin::setNonPlaceAreaUnscaled(int64_t area)
+inline void Bin::setNonPlaceArea(int64_t area)
 {
-  nonPlaceAreaUnscaled_ = area;
+  non_place_area_ = area;
+}
+
+inline void Bin::setInstPlacedAreaBiNormal(int64_t area)
+{
+  inst_placed_area_binormal_ = area;
 }
 
 inline void Bin::setInstPlacedArea(int64_t area)
 {
-  instPlacedArea_ = area;
-}
-
-inline void Bin::setInstPlacedAreaUnscaled(int64_t area)
-{
-  instPlacedAreaUnscaled_ = area;
+  inst_placed_area_ = area;
 }
 
 inline void Bin::setFillerArea(int64_t area)
 {
-  fillerArea_ = area;
+  filler_area_ = area;
 }
+
+inline void Bin::addNonPlaceAreaBiNormal(int64_t area)
+{
+  non_place_area_binormal_ += area;
+}
+
+// inline void Bin::addInstPlacedArea(int64_t area)
+// {
+//   instPlacedArea_ += area;
+// }
 
 inline void Bin::addNonPlaceArea(int64_t area)
 {
-  nonPlaceArea_ += area;
+  non_place_area_ += area;
 }
 
 inline void Bin::addInstPlacedArea(int64_t area)
 {
-  instPlacedArea_ += area;
-}
-
-inline void Bin::addNonPlaceAreaUnscaled(int64_t area)
-{
-  nonPlaceAreaUnscaled_ += area;
-}
-
-inline void Bin::addInstPlacedAreaUnscaled(int64_t area)
-{
-  instPlacedAreaUnscaled_ += area;
+  inst_placed_area_ += area;
 }
 
 inline void Bin::addFillerArea(int64_t area)
 {
-  fillerArea_ += area;
+  filler_area_ += area;
 }
 
 //
@@ -697,8 +700,8 @@ class BinGrid
   double getBinSizeX() const;
   double getBinSizeY() const;
 
+  int64_t getOverflowAreaBiNormal() const;
   int64_t getOverflowArea() const;
-  int64_t getOverflowAreaUnscaled() const;
 
   // return bins_ index with given gcell
   std::pair<int, int> getDensityMinMaxIdxX(const GCell* gcell) const;
@@ -725,8 +728,8 @@ class BinGrid
   double binSizeX_ = 0;
   double binSizeY_ = 0;
   float targetDensity_ = 0;
-  int64_t sumOverflowArea_ = 0;
-  int64_t sumOverflowAreaUnscaled_ = 0;
+  int64_t sum_overflow_area_binormal_ = 0;
+  int64_t sum_overflow_area_ = 0;
   bool isSetBinCnt_ = false;
   int num_threads_ = 1;
 };
@@ -936,8 +939,8 @@ class NesterovBase
 
   const std::vector<GCellHandle>& getGCells() const { return nb_gcells_; }
 
+  float getSumOverflowBiNormal() const { return sum_overflow_binormal_; }
   float getSumOverflow() const { return sum_overflow_; }
-  float getSumOverflowUnscaled() const { return sum_overflow_unscaled_; }
   float getBaseWireLengthCoef() const { return baseWireLengthCoef_; }
   float getDensityPenalty() const { return densityPenalty_; }
 
@@ -953,8 +956,8 @@ class NesterovBase
   int getBinCntY() const;
   double getBinSizeX() const;
   double getBinSizeY() const;
+  int64_t getOverflowAreaBiNormal() const;
   int64_t getOverflowArea() const;
-  int64_t getOverflowAreaUnscaled() const;
 
   std::vector<Bin>& getBins();
   const std::vector<Bin>& getBinsConst() const { return bg_.getBinsConst(); };
@@ -1237,9 +1240,9 @@ class NesterovBase
   float baseWireLengthCoef_ = 0;
 
   // phi is described in ePlace paper.
+  float sum_overflow_binormal_ = 0;
   float sum_overflow_ = 0;
-  float sum_overflow_unscaled_ = 0;
-  float prev_reported_overflow_unscaled_ = 0;
+  float prev_reported_overflow_ = 0;
 
   // half-parameter-wire-length
   int64_t prev_hpwl_ = 0;

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -553,7 +553,6 @@ class Bin
   void setInstPlacedArea(int64_t area);
 
   void addNonPlaceAreaBiNormal(int64_t area);
-  // void addInstPlacedArea(int64_t area);
   void addFillerArea(int64_t area);
 
   void addNonPlaceArea(int64_t area);
@@ -644,11 +643,6 @@ inline void Bin::addNonPlaceAreaBiNormal(int64_t area)
 {
   non_place_area_binormal_ += area;
 }
-
-// inline void Bin::addInstPlacedArea(int64_t area)
-// {
-//   instPlacedArea_ += area;
-// }
 
 inline void Bin::addNonPlaceArea(int64_t area)
 {
@@ -986,7 +980,7 @@ class NesterovBase
   // This is mainly used for NesterovLoop
   int64_t getNesterovInstsArea() const;
   int64_t getStdInstArea() const { return this->stdInstsArea_; }
-  int64_t getMacroInstArea() const { return this->macroInstsArea_; }
+  int64_t getLargeInstArea() const { return this->large_insts_area_; }
 
   // sum phi and target density
   // used in NesterovPlace
@@ -1144,7 +1138,7 @@ class NesterovBase
   int64_t initial_filler_area_ = 0;
 
   int64_t stdInstsArea_ = 0;
-  int64_t macroInstsArea_ = 0;
+  int64_t large_insts_area_ = 0;
 
   std::vector<GCell> fillerStor_;
   std::vector<GCellHandle> nb_gcells_;

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -174,12 +174,12 @@ void NesterovPlace::npUpdateNextGradient(
 void NesterovPlace::init()
 {
   // foreach nesterovbase call init
-  total_sum_overflow_ = 0;
+  total_sum_overflow_binormal_ = 0;
   float totalBaseWireLengthCoeff = 0;
   for (auto& nb : nbVec_) {
     nb->setNpVars(&npVars_);
     nb->initDensity1();
-    total_sum_overflow_ += nb->getSumOverflow();
+    total_sum_overflow_binormal_ += nb->getSumOverflowBiNormal();
     totalBaseWireLengthCoeff += nb->getBaseWireLengthCoef();
   }
 
@@ -192,9 +192,9 @@ void NesterovPlace::init()
   auto& hpwl_gauge = hpwl_gauge_family.Add({});
   hpwl_gauge_ = &hpwl_gauge;
 
-  average_overflow_ = total_sum_overflow_ / nbVec_.size();
+  average_overflow_binormal_ = total_sum_overflow_binormal_ / nbVec_.size();
   baseWireLengthCoef_ = totalBaseWireLengthCoeff / nbVec_.size();
-  updateWireLengthCoef(average_overflow_);
+  updateWireLengthCoef(average_overflow_binormal_);
 
   nbc_->updateWireLengthForceWA(wireLengthCoefX_, wireLengthCoefY_);
 
@@ -287,7 +287,7 @@ void NesterovPlace::updateIterGraphics(
 
   int debug_start_iter = npVars_.debug_start_iter;
   if (debug_start_iter == 0 || iter + 1 >= debug_start_iter) {
-    graphics_->addIter(iter, average_overflow_unscaled_);
+    graphics_->addIter(iter, average_overflow_);
     bool update
         = (iter == 0 || (iter + 1) % npVars_.debug_update_iterations == 0);
     if (update) {
@@ -322,7 +322,7 @@ void NesterovPlace::updateIterGraphics(
 
   // Save image once if routability not needed and below routability overflow
   if (npVars_.routability_driven_mode && !is_routability_need_
-      && average_overflow_unscaled_ <= npVars_.routability_end_overflow
+      && average_overflow_ <= npVars_.routability_end_overflow
       && !final_routability_image_saved) {
     if (npVars_.debug_generate_images) {
       const std::string label = fmt::format("Iter {} |R: {} |T: {}",
@@ -378,7 +378,7 @@ void NesterovPlace::runTimingDriven(int iter,
   // if virtual, do reweight on timing-critical nets,
   // otherwise keep all modifications by rsz.
   if (npVars_.timingDrivenMode
-      && tb_->isTimingNetWeightOverflow(average_overflow_unscaled_)
+      && tb_->isTimingNetWeightOverflow(average_overflow_)
       && (!is_routability_gpl_iter || !npVars_.routability_driven_mode)) {
     // update db's instance location from current density coordinates
     updateDb();
@@ -403,7 +403,7 @@ void NesterovPlace::runTimingDriven(int iter,
     //
     // See timingBase.cpp in detail
     bool virtual_td_iter
-        = (average_overflow_unscaled_ > npVars_.keepResizeBelowOverflow);
+        = (average_overflow_ > npVars_.keepResizeBelowOverflow);
 
     log_->info(GPL,
                100,
@@ -417,7 +417,7 @@ void NesterovPlace::runTimingDriven(int iter,
                "   Iter: {}, overflow: {:.3f}, keep resizer changes at: {}, "
                "HPWL: {}",
                iter + 1,
-               average_overflow_unscaled_,
+               average_overflow_,
                npVars_.keepResizeBelowOverflow,
                nbc_->getHpwl());
 
@@ -536,10 +536,9 @@ void NesterovPlace::runTimingDriven(int iter,
 
       // update snapshot after non-virtual TD
       int64_t hpwl = nbc_->getHpwl();
-      if (average_overflow_unscaled_ <= 0.25) {
+      if (average_overflow_ <= 0.25) {
         min_hpwl_ = hpwl;
-        diverge_snapshot_average_overflow_unscaled_
-            = average_overflow_unscaled_;
+        diverge_snapshot_average_overflow_ = average_overflow_;
         diverge_snapshot_iter_ = iter + 1;
         is_min_hpwl_ = true;
       }
@@ -620,7 +619,7 @@ bool NesterovPlace::isDiverged(float& diverge_snapshot_WlCoefX,
                  999,
                  "Revert to iter: {:4d} overflow: {:.3f} HPWL: {}",
                  diverge_snapshot_iter_,
-                 diverge_snapshot_average_overflow_unscaled_,
+                 diverge_snapshot_average_overflow_,
                  min_hpwl_);
       wireLengthCoefX_ = diverge_snapshot_WlCoefX;
       wireLengthCoefY_ = diverge_snapshot_WlCoefY;
@@ -654,7 +653,7 @@ void NesterovPlace::routabilitySnapshot(
     float& route_snapshotA)
 {
   if (!is_routability_snapshot_saved && npVars_.routability_driven_mode
-      && routability_save_snapshot_ >= average_overflow_unscaled_) {
+      && routability_save_snapshot_ >= average_overflow_) {
     route_snapshot_WlCoefX = wireLengthCoefX_;
     route_snapshot_WlCoefY = wireLengthCoefY_;
     route_snapshotA = curA;
@@ -669,7 +668,7 @@ void NesterovPlace::routabilitySnapshot(
     const int64_t hpwl = nbc_->getHpwl();
     log_->report("{:9d} | {:8.4f} | {:13.6e} | {:8} | {:9} | {:>5}",
                  iter,
-                 average_overflow_unscaled_,
+                 average_overflow_,
                  block->dbuToMicrons(hpwl),
                  " ",
                  " ",
@@ -705,7 +704,7 @@ void NesterovPlace::runRoutability(int iter,
 {
   // check routability using RUDY or GR
   if (npVars_.routability_driven_mode && is_routability_need_
-      && average_overflow_unscaled_ <= npVars_.routability_end_overflow) {
+      && average_overflow_ <= npVars_.routability_end_overflow) {
     nbVec_[0]->setTrueReprintIterHeader();
     ++routability_driven_revert_count;
 
@@ -1056,7 +1055,7 @@ int NesterovPlace::doNesterovPlace(int start_iter)
 
     bool is_routability_gpl_iter
         = is_routability_snapshot_saved
-          && average_overflow_unscaled_ > npVars_.routability_end_overflow;
+          && average_overflow_ > npVars_.routability_end_overflow;
     if (is_routability_gpl_iter) {
       ++routability_gpl_iter_count_;
       ++npVars_.maxNesterovIter;
@@ -1154,28 +1153,28 @@ void NesterovPlace::updateWireLengthCoef(float overflow)
 
 void NesterovPlace::updateNextIter(int iter)
 {
+  total_sum_overflow_binormal_ = 0;
   total_sum_overflow_ = 0;
-  total_sum_overflow_unscaled_ = 0;
 
   for (auto& nb : nbVec_) {
     nb->updateNextIter(iter);
+    total_sum_overflow_binormal_ += nb->getSumOverflowBiNormal();
     total_sum_overflow_ += nb->getSumOverflow();
-    total_sum_overflow_unscaled_ += nb->getSumOverflowUnscaled();
   }
 
+  average_overflow_binormal_ = total_sum_overflow_binormal_ / nbVec_.size();
   average_overflow_ = total_sum_overflow_ / nbVec_.size();
-  average_overflow_unscaled_ = total_sum_overflow_unscaled_ / nbVec_.size();
 
   // For coefficient, using average regions' overflow
-  updateWireLengthCoef(average_overflow_);
+  updateWireLengthCoef(average_overflow_binormal_);
 
   // Update divergence snapshot
   if (!npVars_.disableRevertIfDiverge) {
     int64_t hpwl = nbc_->getHpwl();
     hpwl_gauge_->Set(hpwl);
-    if (hpwl < min_hpwl_ && average_overflow_unscaled_ <= 0.25) {
+    if (hpwl < min_hpwl_ && average_overflow_ <= 0.25) {
       min_hpwl_ = hpwl;
-      diverge_snapshot_average_overflow_unscaled_ = average_overflow_unscaled_;
+      diverge_snapshot_average_overflow_ = average_overflow_;
       diverge_snapshot_iter_ = iter + 1;
       is_min_hpwl_ = true;
     } else {

--- a/src/gpl/src/nesterovPlace.h
+++ b/src/gpl/src/nesterovPlace.h
@@ -133,14 +133,14 @@ class NesterovPlace
   NesterovPlaceVars npVars_;
   std::unique_ptr<AbstractGraphics> graphics_;
 
+  float total_sum_overflow_binormal_ = 0;
   float total_sum_overflow_ = 0;
-  float total_sum_overflow_unscaled_ = 0;
   // The average here is between regions (NB objects)
+  float average_overflow_binormal_ = 0;
   float average_overflow_ = 0;
-  float average_overflow_unscaled_ = 0;
 
   // Snapshot saving for revert if diverge
-  float diverge_snapshot_average_overflow_unscaled_ = 0;
+  float diverge_snapshot_average_overflow_ = 0;
   int64_t min_hpwl_ = INT64_MAX;
   int diverge_snapshot_iter_ = 0;
   bool is_min_hpwl_ = false;

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -246,7 +246,7 @@ void Instance::setExtId(int extId)
   extId_ = extId;
 }
 
-bool Instance::isPbLargeInstance() const
+bool Instance::isLargeInstance() const
 {
   return is_large_instance_;
 }

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -246,7 +246,6 @@ void Instance::setExtId(int extId)
   extId_ = extId;
 }
 
-// ePlace macro definition
 bool Instance::isPbLargeInstance() const
 {
   return is_large_instance_;
@@ -814,7 +813,7 @@ void PlacerBaseCommon::init()
     instStor_.push_back(temp_inst);
 
     if (temp_inst.dy() > siteSizeY_ * 6) {
-      macroInstsArea_ += temp_inst.area();
+      large_insts_area_ += temp_inst.area();
     }
   }
 
@@ -1056,10 +1055,9 @@ void PlacerBase::init()
       placeInsts_.push_back(inst);
       int64_t instArea = inst->area();
       placeInstsArea_ += instArea;
-      // macro cells should be
-      // macroInstsArea_
+      // ePlace macros are defined as taller than 6 rows
       if (inst->dy() > siteSizeY_ * 6) {
-        macroInstsArea_ += instArea;
+        large_insts_area_ += instArea;
       }
       // smaller or equal height cells should be
       // stdInstArea_
@@ -1358,7 +1356,7 @@ void PlacerBase::printInfo() const
              21,
              format_label_um2,
              "Large instances area:",
-             block->dbuAreaToMicrons(macroInstsArea_));
+             block->dbuAreaToMicrons(large_insts_area_));
 
   if (util >= 100.1) {
     log_->error(GPL, 301, "Utilization {:.3f} % exceeds 100%.", util);
@@ -1372,9 +1370,9 @@ void PlacerBase::unlockAll()
   }
 }
 
-int64_t PlacerBase::macroInstsArea() const
+int64_t PlacerBase::largeInstsArea() const
 {
-  return macroInstsArea_;
+  return large_insts_area_;
 }
 
 // https://stackoverflow.com/questions/33333363/built-in-mod-vs-custom-mod-function-improve-the-performance-of-modulus-op

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -67,9 +67,9 @@ Instance::Instance(odb::dbInst* inst,
   dbBox* bbox = inst->getBBox();
 
   if (inst->getMaster()->getType().isBlock()) {
-    is_macro_ = true;
+    is_large_instance_ = true;
   } else if (bbox->getDY() > row_limit * pbc->siteSizeY()) {
-    is_macro_ = true;
+    is_large_instance_ = true;
     logger->warn(GPL,
                  134,
                  "Master {} is not marked as a BLOCK in LEF but is more "
@@ -246,9 +246,10 @@ void Instance::setExtId(int extId)
   extId_ = extId;
 }
 
-bool Instance::isMacro() const
+// ePlace macro definition
+bool Instance::isPbLargeInstance() const
 {
-  return is_macro_;
+  return is_large_instance_;
 }
 
 bool Instance::isLocked() const

--- a/src/gpl/src/placerBase.h
+++ b/src/gpl/src/placerBase.h
@@ -61,7 +61,7 @@ class Instance
 
   bool isPlaceInstance() const;
 
-  bool isPbLargeInstance() const;
+  bool isLargeInstance() const;
 
   // A placeable instance may be fixed during part of incremental placement.
   // It remains in the set of placeable objects though so as to simplify

--- a/src/gpl/src/placerBase.h
+++ b/src/gpl/src/placerBase.h
@@ -109,6 +109,7 @@ class Instance
   int ux_ = 0;
   int uy_ = 0;
   int extId_ = INT_MIN;
+  // ePlace macro definition (instances larger than 6 row height)
   bool is_large_instance_ = false;
   bool is_locked_ = false;
 };
@@ -311,7 +312,7 @@ class PlacerBaseCommon
   int64_t getHpwl() const;
   void printInfo() const;
 
-  int64_t getMacroInstsArea() const { return macroInstsArea_; }
+  int64_t getLargeInstsArea() const { return large_insts_area_; }
 
   odb::dbDatabase* db() const { return db_; }
 
@@ -343,7 +344,7 @@ class PlacerBaseCommon
   int siteSizeX_ = 0;
   int siteSizeY_ = 0;
 
-  int64_t macroInstsArea_ = 0;
+  int64_t large_insts_area_ = 0;
 
   void init();
   void reset();
@@ -386,7 +387,7 @@ class PlacerBase
 
   int64_t placeInstsArea() const { return placeInstsArea_; }
   int64_t nonPlaceInstsArea() const { return nonPlaceInstsArea_; }
-  int64_t macroInstsArea() const;
+  int64_t largeInstsArea() const;
   int64_t stdInstsArea() const { return stdInstsArea_; }
 
   odb::dbDatabase* db() const { return db_; }
@@ -417,10 +418,10 @@ class PlacerBase
   int64_t placeInstsArea_ = 0;
   int64_t nonPlaceInstsArea_ = 0;
 
-  // macroInstsArea_ + stdInstsArea_ = placeInstsArea_;
-  // macroInstsArea_ should be separated
+  // large_insts_area_ + stdInstsArea_ = placeInstsArea_;
+  // large_insts_area_ should be separated
   // because of target_density tuning
-  int64_t macroInstsArea_ = 0;
+  int64_t large_insts_area_ = 0;
   int64_t stdInstsArea_ = 0;
 
   std::shared_ptr<PlacerBaseCommon> pbCommon_;

--- a/src/gpl/src/placerBase.h
+++ b/src/gpl/src/placerBase.h
@@ -61,7 +61,7 @@ class Instance
 
   bool isPlaceInstance() const;
 
-  bool isMacro() const;
+  bool isPbLargeInstance() const;
 
   // A placeable instance may be fixed during part of incremental placement.
   // It remains in the set of placeable objects though so as to simplify
@@ -109,7 +109,7 @@ class Instance
   int ux_ = 0;
   int uy_ = 0;
   int extId_ = INT_MIN;
-  bool is_macro_ = false;
+  bool is_large_instance_ = false;
   bool is_locked_ = false;
 };
 


### PR DESCRIPTION
These changes are no-op.

renamings are related to the scalings gpl uses:
  -target density
  -cell smoothing
  -binormal distribution for macros

This PR removes the "unscaled" suffix from variables, the unscaled variables versions now have no suffix.  The scaling versions relate to the type os scaling performed, for example, scaling performed from binormal distribution will have the suffix "binormal".