### PR TITLE
ord: Reduce memory leak

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -155,9 +155,7 @@ OpenRoad::~OpenRoad()
   }
   sta::Sta::setSta(sta_);
   sta::deleteAllMemory();
-  if (temp) {  // reinit if this isn't the last instance
-    sta::initSta();
-  }
+  sta::initSta();
   sta::Sta::setSta(temp);
   odb::dbDatabase::destroy(db_);
   delete logger_;


### PR DESCRIPTION
In OpenROAD's Python API, loading/unloading multiple designs (inside a single Python shell) results in memory leaks. I found a way to properly destruct `sta::dbSta` in `ord::OpenRoad` and delete the `sta` memory.