### PR TITLE
gui: add physical insts controls to hierarchy browser

### DIFF
--- a/src/gui/src/browserWidget.h
+++ b/src/gui/src/browserWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QCheckBox>
 #include <QColor>
 #include <QDockWidget>
 #include <QMenu>
@@ -95,11 +96,11 @@ class BrowserWidget : public QDockWidget,
   void itemExpanded(const QModelIndex& index);
   void updateModuleColorIcon(odb::dbModule* module, const QColor& color);
   void enableModuleView();
+  void markModelModified();
 
  private:
   void updateModel();
   void clearModel();
-  void markModelModified();
 
   void makeMenu();
 
@@ -112,6 +113,7 @@ class BrowserWidget : public QDockWidget,
   DbInstDescriptor* inst_descriptor_;
   DisplayControls* display_controls_;
   QPushButton* display_controls_warning_;
+  QCheckBox* include_physical_cells_;
 
   const std::map<odb::dbModule*, LayoutViewer::ModuleSettings>& modulesettings_;
 


### PR DESCRIPTION
Closes #8837

Adds controls for physical cells in hierarchy browser
<img width="1520" height="240" alt="Pasted image" src="https://github.com/user-attachments/assets/96c3a0c1-9eab-4f8b-bf4e-80209814ed74" />
<img width="1520" height="240" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/0d2c88d3-47a7-4368-aab2-8036119ccece" />
