### PR TITLE
gui: add .gz and .db to allowed extension for open db

### DIFF
--- a/src/gui/src/mainWindow.cpp
+++ b/src/gui/src/mainWindow.cpp
@@ -1914,7 +1914,7 @@ void MainWindow::openDesign()
 
 void MainWindow::saveDesign()
 {
-  const std::vector<QString> exts{".odb", ".odb.gz", ".db", ".db.gz"};
+  const std::vector<QString> exts{".odb", ".odb.gz"};
 
   QString filefilter = "OpenDB (";
   for (const auto& ext : exts) {


### PR DESCRIPTION
No functional changes expected.

Changes:
- adds `.db` to allowed extension in open/save dialogs in gui. The command to write is `write_db` so it's natural to just use the `.db` file extension.
- adds `.gz` to allowed extensions as well.
