### PR TITLE
mock-array: fix naming consistency

### DIFF
--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -493,7 +493,7 @@ def mock_array(name, config):
                 )
 
                 sh_test(
-                    name = "MockArray_{variant}_{power_test}_{stage}_test".format(
+                    name = "MockArray_{variant}_{stage}_{power_test}_test".format(
                         variant = variant,
                         power_test = power_test,
                         stage = stage,


### PR DESCRIPTION
Consistent naming of _test with the input to the test.