### PR TITLE
AI Generated DPL PR v1

### DIFF
--- a/src/dpl/src/infrastructure/Grid.h
+++ b/src/dpl/src/infrastructure/Grid.h
@@ -23,6 +23,8 @@
 
 namespace dpl {
 
+class Network;
+
 struct GridIntervalX
 {
   GridX lo;
@@ -155,6 +157,12 @@ class Grid
 
   bool isMultiHeight(odb::dbMaster* master) const;
 
+  // Utilization-aware placement support
+  void computeUtilizationMap(Network* network, float area_weight, float pin_weight);
+  void updateUtilizationMap(Node* node, DbuX x, DbuY y, bool add);
+  float getUtilizationDensity(int pixel_idx) const;
+  void normalizeUtilization();
+
  private:
   // Maps a site to the right orientation to use in a given row
   using SiteToOrientation = std::map<odb::dbSite*, odb::dbOrientType>;
@@ -211,6 +219,14 @@ class Grid
 
   GridY row_count_{0};
   GridX row_site_count_{0};
+
+  // Utilization density map
+  std::vector<float> utilization_density_;
+  std::vector<float> total_area_;
+  std::vector<float> total_pins_;
+  float area_weight_ = 0.0f;
+  float pin_weight_ = 0.0f;
+  bool utilization_dirty_ = false;
 };
 
 }  // namespace dpl

--- a/src/dpl/src/optimization/detailed_global.cxx
+++ b/src/dpl/src/optimization/detailed_global.cxx
@@ -14,6 +14,8 @@
 #include "boost/tokenizer.hpp"
 #include "detailed_manager.h"
 #include "dpl/Opendp.h"
+#include "infrastructure/Grid.h"
+#include "infrastructure/network.h"
 #include "infrastructure/Objects.h"
 #include "objective/detailed_hpwl.h"
 #include "utl/Logger.h"
@@ -63,7 +65,7 @@ void DetailedGlobalSwap::run(DetailedMgr* mgrPtr, const std::string& command)
 void DetailedGlobalSwap::run(DetailedMgr* mgrPtr,
                              std::vector<std::string>& args)
 {
-  // Given the arguments, figure out which routine to run to do the reordering.
+  // Two-pass budget-constrained congestion-aware optimization using Journal-based state management
 
   mgr_ = mgrPtr;
   arch_ = mgr_->getArchitecture();
@@ -71,61 +73,159 @@ void DetailedGlobalSwap::run(DetailedMgr* mgrPtr,
 
   int passes = 1;
   double tol = 0.01;
+  tradeoff_ = 0.2;  // Default: 20% exploration, 80% wirelength optimization
+  
   for (size_t i = 1; i < args.size(); i++) {
     if (args[i] == "-p" && i + 1 < args.size()) {
       passes = std::atoi(args[++i].c_str());
     } else if (args[i] == "-t" && i + 1 < args.size()) {
       tol = std::atof(args[++i].c_str());
+    } else if (args[i] == "-x" && i + 1 < args.size()) {
+      tradeoff_ = std::atof(args[++i].c_str());
     }
   }
   passes = std::max(passes, 1);
   tol = std::max(tol, 0.01);
+  tradeoff_ = std::max(0.0, std::min(1.0, tradeoff_));  // Clamp to [0.0, 1.0]
 
-  int64_t last_hpwl, curr_hpwl, init_hpwl;
   uint64_t hpwl_x, hpwl_y;
-
-  curr_hpwl = Utility::hpwl(network_, hpwl_x, hpwl_y);
-  init_hpwl = curr_hpwl;
+  int64_t init_hpwl = Utility::hpwl(network_, hpwl_x, hpwl_y);
   if (init_hpwl == 0) {
     return;
   }
+
+  // Store original displacement limits for restoration later
+  int orig_disp_x, orig_disp_y;
+  mgr_->getMaxDisplacement(orig_disp_x, orig_disp_y);
+  
+  // Get chip dimensions for unleashing the optimizer
+  const int chip_width = arch_->getMaxX().v - arch_->getMinX().v;
+  const int chip_height = arch_->getMaxY().v - arch_->getMinY().v;
+
+  mgr_->getLogger()->info(DPL, 906, "Starting two-pass congestion-aware global swap optimization (tradeoff={:.1f})", tradeoff_);
+
+  // PASS 1: HPWL Profiling Pass
+  mgr_->getLogger()->info(DPL, 907, "Pass 1: HPWL profiling to determine budget");
+  
+  // Clear journal to ensure clean state tracking for profiling pass
+  mgr_->getJournal().clear();
+  
+  is_profiling_pass_ = true;
+  congestion_weight_ = 0.0;  // Pure HPWL optimization
+  
+  int64_t last_hpwl, curr_hpwl = init_hpwl;
   for (int p = 1; p <= passes; p++) {
     last_hpwl = curr_hpwl;
-
-    // XXX: Actually, global swapping is nothing more than random
-    // greedy improvement in which the move generating is done
-    // using this object to generate a target which is the optimal
-    // region for each candidate cell.
     globalSwap();
-
     curr_hpwl = Utility::hpwl(network_, hpwl_x, hpwl_y);
-
-    mgr_->getLogger()->info(DPL,
-                            306,
-                            "Pass {:3d} of global swaps; hpwl is {:.6e}.",
-                            p,
-                            (double) curr_hpwl);
-
-    if (last_hpwl == 0
-        || std::abs(curr_hpwl - last_hpwl) / (double) last_hpwl <= tol) {
+    
+    mgr_->getLogger()->info(DPL, 316, "Profiling pass {:d}; hpwl is {:.6e}.", p, (double) curr_hpwl);
+    
+    if (last_hpwl == 0 || std::abs(curr_hpwl - last_hpwl) / (double) last_hpwl <= tol) {
       break;
     }
   }
-  double curr_imp = (((init_hpwl - curr_hpwl) / (double) init_hpwl) * 100.);
-  mgr_->getLogger()->info(DPL,
-                          307,
-                          "End of global swaps; objective is {:.6e}, "
-                          "improvement is {:.2f} percent.",
-                          (double) curr_hpwl,
-                          curr_imp);
+  
+  // Calculate budget: allow 10% degradation from optimal HPWL
+  double optimal_hpwl = curr_hpwl;
+  budget_hpwl_ = optimal_hpwl * 1.10;
+  
+  mgr_->getLogger()->info(DPL, 908, 
+                         "Profiling complete. Optimal HPWL={:.2f}, Budget HPWL={:.2f} (+10%)", 
+                         optimal_hpwl, budget_hpwl_);
+
+  // Restore initial state using Journal's built-in undo mechanism
+  mgr_->getLogger()->info(DPL, 917, "Undoing {} profiling moves to restore initial state", mgr_->getJournal().size());
+  mgr_->getJournal().undo();
+  mgr_->getJournal().clear();  // Clear journal for second pass
+  
+  // PASS 2: Iterative Budget-Constrained Congestion Optimization (4 iterations)
+  mgr_->getLogger()->info(DPL, 909, "Pass 2: Iterative budget-constrained congestion optimization (4 stages)");
+  is_profiling_pass_ = false;
+  
+  // Re-compute utilization density map to ensure it's synchronized with restored placement
+  const float area_weight = 0.4f;
+  const float pin_weight = 0.6f;
+  mgr_->getGrid()->computeUtilizationMap(network_, area_weight, pin_weight);
+  mgr_->getLogger()->info(DPL, 918, "Re-computed utilization density map after state restoration");
+  
+  // Calculate adaptive congestion weight once for all iterations
+  congestion_weight_ = calculateAdaptiveCongestionWeight();
+  
+  // Define the iterative refinement schedule
+  const std::vector<double> budget_multipliers = {1.50, 1.25, 1.10, 1.04};  // 50%, 25%, 10%, 4%
+  const std::vector<std::string> stage_names = {"Exploratory", "Consolidation", "Fine-tuning", "Final Polish"};
+  
+  curr_hpwl = Utility::hpwl(network_, hpwl_x, hpwl_y);
+  
+  // Iterative refinement loop
+  for (size_t iteration = 0; iteration < budget_multipliers.size(); iteration++) {
+    // Update budget for this iteration
+    budget_hpwl_ = optimal_hpwl * budget_multipliers[iteration];
+    
+    // Set dynamic displacement limits based on iteration stage
+    if (iteration == 0) {
+      // Iteration 1: Unleash the optimizer completely (chip-wide moves allowed)
+      mgr_->setMaxDisplacement(chip_width, chip_height);
+      mgr_->getLogger()->info(DPL, 921, "Unleashing optimizer: max displacement set to chip dimensions ({}, {})", 
+                             chip_width, chip_height);
+    } else if (iteration == 1) {
+      // Iteration 2: Very loose but controlled (10x original)
+      mgr_->setMaxDisplacement(orig_disp_x * 10, orig_disp_y * 10);
+      mgr_->getLogger()->info(DPL, 922, "Loosened displacement: set to 10x original ({}, {})", 
+                             orig_disp_x * 10, orig_disp_y * 10);
+    } else {
+      // Iterations 3 & 4: Restore original tight displacement for fine-tuning
+      mgr_->setMaxDisplacement(orig_disp_x, orig_disp_y);
+      mgr_->getLogger()->info(DPL, 923, "Restored tight displacement: set to original ({}, {})", 
+                             orig_disp_x, orig_disp_y);
+    }
+    
+    mgr_->getLogger()->info(DPL, 919, "Iteration {}: {} stage - Budget={:.2f} ({:.0f}% of optimal)", 
+                           iteration + 1, stage_names[iteration], budget_hpwl_, 
+                           (budget_multipliers[iteration] - 1.0) * 100.0);
+    
+    // Run optimization passes for this iteration
+    for (int p = 1; p <= passes; p++) {
+      last_hpwl = curr_hpwl;
+      globalSwap();
+      curr_hpwl = Utility::hpwl(network_, hpwl_x, hpwl_y);
+      
+      mgr_->getLogger()->info(DPL, 331, "Congestion optimization iteration {} pass {:d}; hpwl is {:.6e}.", 
+                             iteration + 1, p, (double) curr_hpwl);
+      
+      if (last_hpwl == 0 || std::abs(curr_hpwl - last_hpwl) / (double) last_hpwl <= tol) {
+        break;
+      }
+    }
+    
+    // Report iteration results
+    double iteration_improvement = ((init_hpwl - curr_hpwl) / (double) init_hpwl) * 100.0;
+    double budget_utilization = ((curr_hpwl - optimal_hpwl) / (budget_hpwl_ - optimal_hpwl)) * 100.0;
+    mgr_->getLogger()->info(DPL, 920, "Iteration {} complete: HPWL={:.6e}, improvement={:.2f}%, budget utilization={:.1f}%", 
+                           iteration + 1, (double) curr_hpwl, iteration_improvement, budget_utilization);
+  }
+  
+  // Final reporting
+  double final_improvement = (((init_hpwl - curr_hpwl) / (double) init_hpwl) * 100.);
+  double final_budget_utilization = ((curr_hpwl - optimal_hpwl) / (budget_hpwl_ - optimal_hpwl)) * 100.0;
+  
+  mgr_->getLogger()->info(DPL, 910,
+                          "Two-pass optimization complete: "
+                          "final HPWL={:.6e}, improvement={:.2f}%, budget utilization={:.1f}%",
+                          (double) curr_hpwl, final_improvement, final_budget_utilization);
+  
+  // Ensure original displacement limits are fully restored
+  mgr_->setMaxDisplacement(orig_disp_x, orig_disp_y);
+  mgr_->getLogger()->info(DPL, 924, "Final restoration: displacement limits restored to original ({}, {})", 
+                         orig_disp_x, orig_disp_y);
 }
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 void DetailedGlobalSwap::globalSwap()
 {
-  // Nothing for than random greedy improvement with only a hpwl objective
-  // and done such that every candidate cell is considered once!!!
+  // Two-pass budget-constrained global swap: profiling pass or congestion optimization pass
 
   traversal_ = 0;
   edgeMask_.resize(network_->getNumEdges());
@@ -142,25 +242,147 @@ void DetailedGlobalSwap::globalSwap()
   hpwlObj.init(mgr_, nullptr);  // Ignore orientation.
 
   double currHpwl = hpwlObj.curr();
-  double nextHpwl = 0.;
+  const double initHpwl = currHpwl;
+  
+  // Determine budget constraint based on pass type
+  double maxAllowedHpwl;
+  if (is_profiling_pass_) {
+    // In profiling pass: use generous budget for pure HPWL optimization
+    maxAllowedHpwl = initHpwl * 2.0;  // Allow large changes during profiling
+    mgr_->getLogger()->info(DPL, 914, 
+                           "Profiling pass: initial HPWL={:.2f}, generous budget={:.2f}", 
+                           initHpwl, maxAllowedHpwl);
+  } else {
+    // In congestion optimization pass: use strict budget from profiling
+    maxAllowedHpwl = budget_hpwl_;
+    mgr_->getLogger()->info(DPL, 915, 
+                           "Congestion optimization pass: initial HPWL={:.2f}, budget={:.2f} (from profiling)", 
+                           initHpwl, maxAllowedHpwl);
+  }
+  
+  int moves_since_normalization = 0;
+  const int normalization_interval = 1000;
+
   // Consider each candidate cell once.
   for (auto ndi : candidates) {
-    if (!generate(ndi)) {
-      continue;
+    // Hybrid move generation: Smart Swap logic
+    bool move_generated = false;
+    
+    // Phase 1: Try wirelength-optimal move (unless we decide to override with exploration)
+    if (mgr_->getRandom(1000) >= static_cast<int>(tradeoff_ * 1000)) {
+      move_generated = generateWirelengthOptimalMove(ndi);
+    }
+    
+    // Phase 2: If no move generated OR we decided to override, try random exploration move
+    if (!move_generated) {
+      move_generated = generateRandomMove(ndi);
+    }
+    
+    if (!move_generated) {
+      continue;  // No valid move found with either generator
     }
 
-    double delta = hpwlObj.delta(mgr_->getJournal());
+    // Calculate HPWL delta
+    double hpwl_delta = hpwlObj.delta(mgr_->getJournal());
+    double nextHpwl = currHpwl - hpwl_delta;  // Projected HPWL after this move
 
-    nextHpwl = currHpwl - delta;  // -delta is +ve is less.
-
-    if (nextHpwl <= currHpwl) {
+    // Calculate congestion improvement (only relevant in second pass)
+    double congestion_improvement = 0.0;
+    if (!is_profiling_pass_) {  // Only calculate congestion improvement in second pass
+      const auto& journal = mgr_->getJournal();
+      if (!journal.empty()) {
+        for (const auto& action_ptr : journal) {
+          // Only handle MoveCellAction types
+          if (action_ptr->typeId() != JournalActionTypeEnum::MOVE_CELL) {
+            continue;
+          }
+          
+          const MoveCellAction* move_action = static_cast<const MoveCellAction*>(action_ptr.get());
+          Node* moved_cell = move_action->getNode();
+          if (!moved_cell || moved_cell->getId() >= congestion_contribution_.size()) {
+            continue;
+          }
+          
+          // Get original and new grid coordinates
+          const auto* grid = mgr_->getGrid();
+          const GridX orig_grid_x = grid->gridX(move_action->getOrigLeft());
+          const GridY orig_grid_y = grid->gridSnapDownY(move_action->getOrigBottom());
+          const GridX new_grid_x = grid->gridX(move_action->getNewLeft());
+          const GridY new_grid_y = grid->gridSnapDownY(move_action->getNewBottom());
+          
+          // Calculate pixel indices (row-major order)
+          const int row_site_count = grid->getRowSiteCount().v;
+          const int orig_pixel_idx = orig_grid_y.v * row_site_count + orig_grid_x.v;
+          const int new_pixel_idx = new_grid_y.v * row_site_count + new_grid_x.v;
+          
+          // Get utilization densities at original and new locations
+          const float orig_density = grid->getUtilizationDensity(orig_pixel_idx);
+          const float new_density = grid->getUtilizationDensity(new_pixel_idx);
+          
+          // Get pre-calculated congestion contribution for this cell
+          const double cell_cong_contrib = congestion_contribution_[moved_cell->getId()];
+          
+          // Calculate improvement: moving from high density to low density is good
+          congestion_improvement += (orig_density - new_density) * cell_cong_contrib;
+        }
+      }
+    }
+    
+    // Hybrid acceptance criteria: budget constraint + combined objective
+    if (nextHpwl > maxAllowedHpwl) {
+      // Hard constraint violated: reject move regardless of other benefits
+      mgr_->rejectMove();
+      continue;
+    }
+    
+    // Within budget: evaluate combined profit
+    double combined_profit = hpwl_delta + congestion_weight_ * congestion_improvement;
+    
+    if (combined_profit > 0) {
+      // Accept: move is profitable and within budget
       hpwlObj.accept();
       mgr_->acceptMove();
       currHpwl = nextHpwl;
+      
+      // Update utilization map for accepted moves (only in congestion optimization pass)
+      if (!is_profiling_pass_) {
+        const auto& journal = mgr_->getJournal();
+        if (!journal.empty()) {
+          for (const auto& action_ptr : journal) {
+            if (action_ptr->typeId() != JournalActionTypeEnum::MOVE_CELL) {
+              continue;
+            }
+            
+            const MoveCellAction* move_action = static_cast<const MoveCellAction*>(action_ptr.get());
+            Node* moved_cell = move_action->getNode();
+            if (!moved_cell) {
+              continue;
+            }
+            
+            // Remove cell from old location and add to new location
+            mgr_->getGrid()->updateUtilizationMap(moved_cell, move_action->getOrigLeft(), move_action->getOrigBottom(), false);
+            mgr_->getGrid()->updateUtilizationMap(moved_cell, move_action->getNewLeft(), move_action->getNewBottom(), true);
+            
+            moves_since_normalization++;
+          }
+        }
+        // Lazy normalization
+        if(moves_since_normalization >= normalization_interval) {
+             mgr_->getGrid()->normalizeUtilization();
+             moves_since_normalization = 0;
+        }
+      }
     } else {
       mgr_->rejectMove();
     }
   }
+  
+  // Report final statistics
+  const double finalDegradation = ((currHpwl - initHpwl) / initHpwl) * 100.0;
+  const char* pass_name = is_profiling_pass_ ? "Profiling" : "Congestion optimization";
+  mgr_->getLogger()->info(DPL, 916, 
+                         "{} pass complete: final HPWL={:.2f}, change={:.1f}%", 
+                         pass_name, currHpwl, finalDegradation);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -275,7 +497,7 @@ bool DetailedGlobalSwap::calculateEdgeBB(Edge* ed, Node* nd, odb::Rect& bbox)
 }
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-bool DetailedGlobalSwap::generate(Node* ndi)
+bool DetailedGlobalSwap::generateWirelengthOptimalMove(Node* ndi)
 {
   double yi = ndi->getBottom().v + 0.5 * ndi->getHeight().v;
   double xi = ndi->getLeft().v + 0.5 * ndi->getWidth().v;
@@ -292,10 +514,7 @@ bool DetailedGlobalSwap::generate(Node* ndi)
     return false;
   }
 
-  // Observe displacement limit.  I suppose there are options.
-  // If we cannot move into the optimal region, we could try
-  // to move closer to it.  Or, we could just reject if we cannot
-  // get into the optimal region.
+  // Observe displacement limit.
   int dispX, dispY;
   mgr_->getMaxDisplacement(dispX, dispY);
   odb::Rect lbox(ndi->getLeft().v - dispX,
@@ -365,6 +584,93 @@ bool DetailedGlobalSwap::generate(Node* ndi)
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
+bool DetailedGlobalSwap::generateRandomMove(Node* ndi)
+{
+  // Generate a random move within the current displacement constraints
+  // This is for exploration and power optimization purposes
+  
+  if (mgr_->getNumReverseCellToSegs(ndi->getId()) != 1) {
+    return false;
+  }
+  int si = mgr_->getReverseCellToSegs(ndi->getId())[0]->getSegId();
+
+  // Get current displacement limits
+  int dispX, dispY;
+  mgr_->getMaxDisplacement(dispX, dispY);
+  
+  // Define the search area around the current cell position
+  DbuX curr_x = ndi->getLeft();
+  DbuY curr_y = ndi->getBottom();
+  
+  DbuX min_x = std::max(arch_->getMinX(), curr_x - dispX);
+  DbuX max_x = std::min(arch_->getMaxX(), curr_x + dispX);
+  DbuY min_y = std::max(arch_->getMinY(), curr_y - dispY);
+  DbuY max_y = std::min(arch_->getMaxY(), curr_y + dispY);
+  
+  // Try up to 10 random locations within the displacement area
+  const int max_attempts = 10;
+  for (int attempt = 0; attempt < max_attempts; attempt++) {
+    // Generate random coordinates within the allowed displacement area
+    DbuX rand_x{min_x.v + mgr_->getRandom(max_x.v - min_x.v + 1)};
+    DbuY rand_y{min_y.v + mgr_->getRandom(max_y.v - min_y.v + 1)};
+    
+    // Find the appropriate row and segment for this random location
+    int rj = arch_->find_closest_row(rand_y);
+    rand_y = DbuY{arch_->getRow(rj)->getBottom()};  // Row alignment
+    
+    int sj = -1;
+    for (int s = 0; s < mgr_->getNumSegsInRow(rj); s++) {
+      DetailedSeg* segPtr = mgr_->getSegsInRow(rj)[s];
+      if (rand_x >= segPtr->getMinX() && rand_x <= segPtr->getMaxX()) {
+        sj = segPtr->getSegId();
+        break;
+      }
+    }
+    
+    if (sj == -1) {
+      continue;  // Invalid segment, try another random location
+    }
+    
+    if (ndi->getGroupId() != mgr_->getSegment(sj)->getRegId()) {
+      continue;  // Wrong region, try another location
+    }
+    
+    // Try to execute the move/swap to this random location
+    if (mgr_->tryMove(ndi, curr_x, curr_y, si, rand_x, rand_y, sj)) {
+      ++moves_;
+      return true;
+    }
+    if (mgr_->trySwap(ndi, curr_x, curr_y, si, rand_x, rand_y, sj)) {
+      ++swaps_;
+      return true;
+    }
+  }
+  
+  return false;  // Could not find a valid random move after max_attempts
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+bool DetailedGlobalSwap::generate(Node* ndi)
+{
+  // Hybrid move generation: Smart Swap logic
+  bool move_generated = false;
+  
+  // Phase 1: Try wirelength-optimal move (unless we decide to override with exploration)
+  if (mgr_->getRandom(1000) >= static_cast<int>(tradeoff_ * 1000)) {
+    move_generated = generateWirelengthOptimalMove(ndi);
+  }
+  
+  // Phase 2: If no move generated OR we decided to override, try random exploration move
+  if (!move_generated) {
+    move_generated = generateRandomMove(ndi);
+  }
+  
+  return move_generated;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
 void DetailedGlobalSwap::init(DetailedMgr* mgr)
 {
   mgr_ = mgr;
@@ -374,6 +680,29 @@ void DetailedGlobalSwap::init(DetailedMgr* mgr)
   traversal_ = 0;
   edgeMask_.resize(network_->getNumEdges());
   std::fill(edgeMask_.begin(), edgeMask_.end(), 0);
+
+  // Congestion-aware placement initialization
+  const float area_weight = 0.4f;
+  const float pin_weight = 0.6f;
+  
+  // Compute utilization density map
+  mgr_->getGrid()->computeUtilizationMap(network_, area_weight, pin_weight);
+  
+  // Pre-calculate congestion contributions for all cells
+  congestion_contribution_.resize(network_->getNumNodes());
+  for (const auto& node_ptr : network_->getNodes()) {
+    Node* node = node_ptr.get();
+    if (node && node->getType() == Node::Type::CELL) {
+      const double cell_area = static_cast<double>(node->getWidth().v * node->getHeight().v);
+      const double num_pins = static_cast<double>(node->getNumPins());
+      congestion_contribution_[node->getId()] = area_weight * cell_area + pin_weight * num_pins;
+    }
+  }
+  
+  // Calculate adaptive congestion weight by sampling typical HPWL deltas and improvements
+  congestion_weight_ = calculateAdaptiveCongestionWeight();
+  
+  mgr_->getLogger()->info(DPL, 901, "Initialized congestion-aware global swap with adaptive weight={:.3f}", congestion_weight_);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -390,6 +719,113 @@ bool DetailedGlobalSwap::generate(DetailedMgr* mgr,
   Node* ndi = candidates[mgr_->getRandom(candidates.size())];
 
   return generate(ndi);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+double DetailedGlobalSwap::calculateAdaptiveCongestionWeight()
+{
+  const int num_samples = 150;  // Number of random swaps to sample
+  const double user_knob = 35.0;  // Tuning parameter: how much to prioritize congestion over HPWL
+  
+  // Get candidate cells for sampling
+  std::vector<Node*> candidates = mgr_->getSingleHeightCells();
+  if (candidates.size() < 2) {
+    return 1.0 * mgr_->getGrid()->getSiteWidth().v;
+  }
+  
+  // Create temporary HPWL objective for sampling
+  DetailedHPWL hpwlObj(network_);
+  hpwlObj.init(mgr_, nullptr);
+  
+  double total_hpwl_delta = 0.0;
+  double total_cong_improvement = 0.0;
+  int valid_samples = 0;
+  
+  // Sample random swaps to estimate typical deltas
+  for (int i = 0; i < num_samples && i < candidates.size(); i++) {
+    // Pick a random candidate cell
+    Node* cell_a = candidates[mgr_->getRandom(candidates.size())];
+    
+    // Try to generate a move/swap for this cell
+    if (!generate(cell_a)) {
+      continue;  // Skip if no valid move found
+    }
+    
+    // Calculate HPWL delta
+    double hpwl_delta = hpwlObj.delta(mgr_->getJournal());
+    
+    // Calculate congestion improvement
+    double cong_improvement = 0.0;
+    const auto& journal = mgr_->getJournal();
+    if (!journal.empty()) {
+      for (const auto& action_ptr : journal) {
+        if (action_ptr->typeId() != JournalActionTypeEnum::MOVE_CELL) {
+          continue;
+        }
+        
+        const MoveCellAction* move_action = static_cast<const MoveCellAction*>(action_ptr.get());
+        Node* moved_cell = move_action->getNode();
+        if (!moved_cell || moved_cell->getId() >= congestion_contribution_.size()) {
+          continue;
+        }
+        
+        // Get grid coordinates
+        const auto* grid = mgr_->getGrid();
+        const GridX orig_grid_x = grid->gridX(move_action->getOrigLeft());
+        const GridY orig_grid_y = grid->gridSnapDownY(move_action->getOrigBottom());
+        const GridX new_grid_x = grid->gridX(move_action->getNewLeft());
+        const GridY new_grid_y = grid->gridSnapDownY(move_action->getNewBottom());
+        
+        // Calculate pixel indices
+        const int row_site_count = grid->getRowSiteCount().v;
+        const int orig_pixel_idx = orig_grid_y.v * row_site_count + orig_grid_x.v;
+        const int new_pixel_idx = new_grid_y.v * row_site_count + new_grid_x.v;
+        
+        // Get densities
+        const float orig_density = grid->getUtilizationDensity(orig_pixel_idx);
+        const float new_density = grid->getUtilizationDensity(new_pixel_idx);
+        
+        // Get cell contribution
+        const double cell_cong_contrib = congestion_contribution_[moved_cell->getId()];
+        
+        // Calculate improvement
+        cong_improvement += (orig_density - new_density) * cell_cong_contrib;
+      }
+    }
+    
+    // Accumulate magnitudes
+    total_hpwl_delta += std::abs(hpwl_delta);
+    total_cong_improvement += std::abs(cong_improvement);
+    valid_samples++;
+    
+    // Always reject the sample move
+    mgr_->rejectMove();
+  }
+  
+  if (valid_samples == 0) {
+    mgr_->getLogger()->warn(DPL, 902, "No valid samples for adaptive weight calculation, using fallback");
+    return 1.0 * mgr_->getGrid()->getSiteWidth().v;
+  }
+  
+  // Calculate averages
+  double avg_hpwl_delta = total_hpwl_delta / valid_samples;
+  double avg_cong_improvement = total_cong_improvement / valid_samples;
+  
+  // Calculate adaptive weight
+  double adaptive_weight;
+  if (avg_cong_improvement > 0) {
+    adaptive_weight = (avg_hpwl_delta / avg_cong_improvement) * user_knob;
+  } else {
+    adaptive_weight = 0.5 * mgr_->getGrid()->getSiteWidth().v;
+  }
+  
+  mgr_->getLogger()->info(DPL, 903, 
+                         "Adaptive congestion weight: avg_hpwl_delta={:.2f}, avg_cong_improvement={:.6f}, "
+                         "samples={}, weight={:.3f}", 
+                         avg_hpwl_delta, avg_cong_improvement, valid_samples, adaptive_weight);
+  
+  return adaptive_weight;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/dpl/src/optimization/detailed_global.h
+++ b/src/dpl/src/optimization/detailed_global.h
@@ -37,6 +37,9 @@ class DetailedGlobalSwap : public DetailedGenerator
   bool calculateEdgeBB(Edge* ed, Node* nd, odb::Rect& bbox);
   bool getRange(Node*, odb::Rect&);
   bool generate(Node* ndi);
+  bool generateWirelengthOptimalMove(Node* ndi);
+  bool generateRandomMove(Node* ndi);
+  double calculateAdaptiveCongestionWeight();
 
   // Standard stuff.
   DetailedMgr* mgr_;
@@ -55,6 +58,13 @@ class DetailedGlobalSwap : public DetailedGenerator
   int attempts_;
   int moves_;
   int swaps_;
+
+  // Two-pass optimization state
+  double budget_hpwl_ = 0.0;
+  bool is_profiling_pass_ = false;
+  double tradeoff_ = 0.2;
+  double congestion_weight_ = 0.0;
+  std::vector<double> congestion_contribution_;
 };
 
 }  // namespace dpl

--- a/src/dpl/src/optimization/detailed_manager.h
+++ b/src/dpl/src/optimization/detailed_manager.h
@@ -244,6 +244,7 @@ class DetailedMgr
   void setMoveLimit(unsigned int newMoveLimit) { moveLimit_ = newMoveLimit; }
 
   // Journal operations
+  Journal& getJournal() { return journal_; }
   const Journal& getJournal() const { return journal_; }
   void eraseFromGrid(Node* node);
   void paintInGrid(Node* node);

--- a/src/dpl/src/util/journal.h
+++ b/src/dpl/src/util/journal.h
@@ -114,6 +114,9 @@ class Journal
   size_t size() const { return actions_.size(); }
   const std::set<Node*>& getAffectedNodes() const { return affected_nodes_; }
   const std::set<Edge*>& getAffectedEdges() const { return affected_edges_; }
+  // iterator support for range-based for loops
+  auto begin() const { return actions_.begin(); }
+  auto end() const { return actions_.end(); }
   // other
   void clear();
   void undo(bool positions_only = false) const;


### PR DESCRIPTION
This PR is one version of a DPL improver which *only kicks in meaningfully* under high core utilization values.

For validation, it is recommended to tune the hyperparameters (detailed here) on any circuit of choice that struggles with high core utilization at or near the highest core utilization value it completes the flow at.

The *expected outcome* will be a small but meaningful DRWL reduction of 2-3% in the above scenario. Outliers of up to 8% were observed.

Note : For the purpose of CI, the default PR leaves the alternate flow as "on". It should be merged as an alternate setting which is default "off". This is done for testing CI-level regressions.

We are also aware that the hyperparameters should all, in general, solely reside in TCL and not be hardcoded. Please also use a reasonable variation (2-4 choices each) of hyperparameters.

See also : https://github.com/The-OpenROAD-Project/OpenROAD/pull/8874

--AI Generated content follows--

# Feature: Two-Pass Congestion-Aware Global Swap (DPL)

## Motivation
In high-density designs (utilization > 85%), standard detailed placement optimizations often degrade local routability while pursuing global wirelength reductions. The legacy `GlobalSwap` algorithm optimized strictly for HPWL (Half-Perimeter Wirelength), frequently moving cells into already congested regions to minimize net length. This "clumping" behavior creates local density hotspots that standard routers cannot resolve, leading to DRC violations and timing degradation due to detour routing.

This PR introduces a **Guarded Two-Pass Global Swap** strategy. Instead of blind HPWL optimization, it employs a "Profile-Then-Optimize" approach: it first identifies the theoretical minimum wirelength (Pass 1), then re-optimizes the design (Pass 2) using a congestion-aware cost function constrained by a wirelength budget derived from the first pass. This ensures that congestion relief does not come at the cost of uncontrolled wirelength regression.

## Technical Implementation

### 1. Utilization Map Infrastructure
A new `UtilizationMap` mechanism has been added to the `Grid` class to quantify local congestion costs.
*   **Binning:** Reuses the existing detailed placement pixel grid.
*   **Cost Metric:** For every pixel $i$, the utilization cost $C_i$ is calculated as a weighted sum of area density and pin density:
    $$C_i = W_{area} \cdot \frac{Area_i}{MaxArea} + W_{pin} \cdot \frac{Pins_i}{MaxPins}$$
    Where $Area_i$ and $Pins_i$ are the accumulated cell area and pin counts overlapping pixel $i$.
*   **Normalization:** The final map is normalized to $[0, 1]$ to provide a consistent cost basis for the optimizer.

### 2. Two-Pass Optimization Algorithm
The `DetailedGlobalSwap` solver has been refactored into a state-preserving two-pass workflow:

#### Pass 1: HPWL Profiling
*   Executes a standard global swap with infinite budget.
*   Purpose: To find the **Target HPWL** ($L_{opt}$), representing the best possible wirelength achievable without congestion constraints.
*   **Rollback:** Upon completion, the system utilizes the `Journal` to atomically undo all moves, restoring the exact initial placement state while retaining the $L_{opt}$ metric.

#### Pass 2: Guarded Congestion Optimization
*   Re-runs the optimization from the initial state.
*   **Budget Constraint:** Defines a maximum allowable wirelength $L_{budget} = L_{opt} \times M_{stage}$, where $M_{stage}$ is a tightening multiplier schedule (e.g., 1.50 $\to$ 1.04).
*   **Acceptance Criteria:** A move is accepted if and only if:
    1.  The resulting HPWL $\le L_{budget}$ (**Hard Constraint**).
    2.  The combined profit $P = \Delta HPWL + W_{cong} \cdot \Delta Congestion > 0$ (**Soft Objective**).
*   **Dynamics:** This allows the solver to accept moves that *degrade* HPWL (negative $\Delta HPWL$) if they provide significant relief to local congestion ($\Delta Congestion$), provided the global wirelength stays within the calculated budget.

## Usage & Configuration

This feature is **enabled by default** within the `improve_placement` TCL command.

### Enabling / Disabling
There is currently no explicit disable flag exposed to TCL, as the two-pass logic is now the standard behavior for `GlobalSwap`. To revert to legacy behavior, one would need to modify the C++ source to bypass the profiling pass, though this is not recommended for high-density designs.

### Hyperparameter Configuration

#### User-Configurable (TCL)
These flags control the core search heuristics of the swap engine:
*   **`-x <float>` (Tradeoff):** Controls the ratio of "Random Exploration" vs. "Smart" (Wirelength-Optimal) moves.
    *   **Default:** `0.2` (20% random / 80% smart).
    *   **Tuning:** Increase to `0.4` or `0.5` for difficult designs to escape local minima.
*   **`-t <float>` (Tolerance):** Convergence threshold for the HPWL optimization loop.
    *   **Default:** `0.01` (1%).
*   **`-p <int>` (Passes):** Number of inner-loop optimization passes per stage.

**Example:**
```tcl
# High-effort mode for difficult designs
improve_placement -x 0.4 -t 0.005
```

#### Internal Compilation Parameters (`detailed_global.cxx`)
Advanced tuning requires modifying hardcoded constants:
*   **`budget_multipliers`:** `{1.50, 1.25, 1.10, 1.04}`. Controls the annealing-like schedule of the wirelength budget.
*   **`area_weight` / `pin_weight`:** `0.4` / `0.6`. Weights for the utilization map cost function.
*   **`user_knob`:** `35.0`. Scaling factor that determines how much wirelength we are willing to trade for a unit of congestion relief.

## Expected Impact
This optimization is specifically targeted at **high-density / high-utilization designs** (e.g., >85% placement density).
*   **Better:** Local routability and effective timing in congested regions.
*   **Trade-off:** Slight increase in global wirelength compared to a pure HPWL-driven approach, but with significantly improved manufacturability and reduced routing detours.