### PR TITLE
grt: change draw_route_guides to draw_route_segments

### DIFF
--- a/src/grt/src/AbstractGrouteRenderer.h
+++ b/src/grt/src/AbstractGrouteRenderer.h
@@ -12,10 +12,7 @@ class AbstractGrouteRenderer
  public:
   virtual ~AbstractGrouteRenderer() = default;
 
-  virtual void highlightRoute(odb::dbNet* net,
-                              bool show_segments,
-                              bool show_pin_locations)
-      = 0;
+  virtual void highlightRoute(odb::dbNet* net, bool show_pin_locations) = 0;
 
   virtual void clearRoute() = 0;
 };

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -178,7 +178,7 @@ add_net_to_route(odb::dbNet* net)
 }
 
 void
-highlight_net_route(odb::dbNet *net, bool show_segments, bool show_pin_locations)
+highlight_net_route(odb::dbNet *net, bool show_pin_locations)
 {
   if (!gui::Gui::enabled()) {
     return;
@@ -189,7 +189,7 @@ highlight_net_route(odb::dbNet *net, bool show_segments, bool show_pin_locations
     router->setRenderer(std::make_unique<GrouteRenderer>(router, router->db()->getTech()));
   }
 
-  router->getRenderer()->highlightRoute(net, show_segments, show_pin_locations);
+  router->getRenderer()->highlightRoute(net, show_pin_locations);
 }
 
 void

--- a/src/grt/src/GlobalRouter.tcl
+++ b/src/grt/src/GlobalRouter.tcl
@@ -343,15 +343,14 @@ proc read_guides { args } {
   grt::read_guides $file_name
 }
 
-sta::define_cmd_args "draw_route_guides" { net_names \
-                                           [-show_segments]
+sta::define_cmd_args "draw_route_segments" { net_names \
                                            [-show_pin_locations] }
 
-proc draw_route_guides { args } {
-  sta::parse_key_args "draw_route_guides" args \
+proc draw_route_segments { args } {
+  sta::parse_key_args "draw_route_segments" args \
     keys {} \
-    flags {-show_pin_locations -show_segments}
-  sta::check_argc_eq1 "draw_route_guides" $args
+    flags {-show_pin_locations}
+  sta::check_argc_eq1 "draw_route_segments" $args
   set net_names [lindex $args 0]
   set block [ord::get_db_block]
   if { $block == "NULL" } {
@@ -360,10 +359,9 @@ proc draw_route_guides { args } {
 
   grt::clear_route_guides
   set show_pins [info exists flags(-show_pin_locations)]
-  set show_segments [info exists flags(-show_segments)]
   foreach net [get_nets $net_names] {
     if { $net != "NULL" } {
-      grt::highlight_net_route [sta::sta_to_db_net $net] $show_segments $show_pins
+      grt::highlight_net_route [sta::sta_to_db_net $net] $show_pins
     }
   }
 }

--- a/src/grt/src/GrouteRenderer.cpp
+++ b/src/grt/src/GrouteRenderer.cpp
@@ -17,12 +17,9 @@ GrouteRenderer::GrouteRenderer(GlobalRouter* groute, odb::dbTech* tech)
   gui::Gui::get()->registerRenderer(this);
 }
 
-void GrouteRenderer::highlightRoute(odb::dbNet* net,
-                                    bool show_segments,
-                                    bool show_pin_locations)
+void GrouteRenderer::highlightRoute(odb::dbNet* net, bool show_pin_locations)
 {
   nets_.insert(net);
-  show_segments_[net] = show_segments;
   show_pin_locations_[net] = show_pin_locations;
   redraw();
 }
@@ -53,16 +50,12 @@ void GrouteRenderer::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
       int layer1 = seg.init_layer;
       int layer2 = seg.final_layer;
       if (layer1 != layer2) {
-        if (show_segments_[net]) {
-          odb::dbTechLayer* via_layer1 = tech_->findRoutingLayer(layer1);
-          odb::dbTechLayer* via_layer2 = tech_->findRoutingLayer(layer2);
-          if (via_layer1 == layer) {
-            drawViaRect(seg, via_layer1, painter);
-          } else if (via_layer2 == layer) {
-            drawViaRect(seg, via_layer2, painter);
-          } else {
-            continue;
-          }
+        odb::dbTechLayer* via_layer1 = tech_->findRoutingLayer(layer1);
+        odb::dbTechLayer* via_layer2 = tech_->findRoutingLayer(layer2);
+        if (via_layer1 == layer) {
+          drawViaRect(seg, via_layer1, painter);
+        } else if (via_layer2 == layer) {
+          drawViaRect(seg, via_layer2, painter);
         } else {
           continue;
         }
@@ -71,17 +64,10 @@ void GrouteRenderer::drawLayer(odb::dbTechLayer* layer, gui::Painter& painter)
       if (seg_layer != layer) {
         continue;
       }
-      if (show_segments_[net]) {
-        odb::Point pt1(seg.init_x, seg.init_y);
-        odb::Point pt2(seg.final_x, seg.final_y);
-        painter.setPenWidth(layer->getMinWidth() * 2);
-        painter.drawLine(pt1, pt2);
-      } else {
-        // Draw rect because drawLine does not have a way to set the pen
-        // thickness.
-        odb::Rect rect = groute_->globalRoutingToBox(seg);
-        painter.drawRect(rect);
-      }
+      odb::Point pt1(seg.init_x, seg.init_y);
+      odb::Point pt2(seg.final_x, seg.final_y);
+      painter.setPenWidth(layer->getMinWidth() * 2);
+      painter.drawLine(pt1, pt2);
     }
   }
 }

--- a/src/grt/src/GrouteRenderer.h
+++ b/src/grt/src/GrouteRenderer.h
@@ -18,9 +18,7 @@ class GrouteRenderer : public gui::Renderer, public AbstractGrouteRenderer
  public:
   GrouteRenderer(GlobalRouter* groute, odb::dbTech* tech);
 
-  void highlightRoute(odb::dbNet* net,
-                      bool show_segments,
-                      bool show_pin_locations) override;
+  void highlightRoute(odb::dbNet* net, bool show_pin_locations) override;
 
   void clearRoute() override;
 


### PR DESCRIPTION
### Summary

Changes the draw_route_guides command from grt to draw_route_segments. The new command is the same as draw_route_guides -show_segments. The -show_pin_locations flag still exists to highlight the pins with circles.
 
Closes #8825 