### PR TITLE
pdn: correct via count in log

### DIFF
--- a/src/pdn/test/core_grid_with_single_edge_pins.ok
+++ b/src/pdn/test/core_grid_with_single_edge_pins.ok
@@ -5,8 +5,8 @@
 [INFO ODB-0133]     Created 385 nets and 1110 connections.
 [INFO IFP-0001] Added 72 rows of 527 site FreePDK45_38x28_10R_NP_162NW_34O.
 [INFO PDN-0001] Inserting grid: Core
-[WARNING PDN-0195] Removing 3 via(s) between metal1 and metal4 at (2.0000 um, 0.0050 um) for VSS
-[WARNING PDN-0195] Removing 3 via(s) between metal1 and metal4 at (42.0000 um, 0.0050 um) for VSS
-[WARNING PDN-0195] Removing 3 via(s) between metal1 and metal4 at (62.0000 um, 0.0050 um) for VSS
-[WARNING PDN-0195] Removing 3 via(s) between metal1 and metal4 at (82.0000 um, 0.0050 um) for VSS
+[WARNING PDN-0195] Removing 9 via(s) between metal1 and metal4 at (2.0000 um, 0.0050 um) for VSS
+[WARNING PDN-0195] Removing 9 via(s) between metal1 and metal4 at (42.0000 um, 0.0050 um) for VSS
+[WARNING PDN-0195] Removing 9 via(s) between metal1 and metal4 at (62.0000 um, 0.0050 um) for VSS
+[WARNING PDN-0195] Removing 9 via(s) between metal1 and metal4 at (82.0000 um, 0.0050 um) for VSS
 No differences found.

--- a/src/pdn/test/pads_black_parrot_flipchip.ok
+++ b/src/pdn/test/pads_black_parrot_flipchip.ok
@@ -6,11 +6,11 @@
 [INFO ODB-0132]     Created 143 special nets and 883 connections.
 [INFO ODB-0133]     Created 219 nets and 267 connections.
 [INFO PDN-0001] Inserting grid: Core
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (181.7350 um, 1349.6200 um) for VSS
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (181.7350 um, 1829.6200 um) for VSS
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (185.2350 um, 2464.6200 um) for VDD
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (2814.7200 um, 1660.3800 um) for VDD
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (2814.7200 um, 2295.3800 um) for VDD
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (2818.2200 um, 535.3800 um) for VSS
-[WARNING PDN-0195] Removing 1 via(s) between metal9 and metal10 at (2818.2200 um, 1175.3800 um) for VSS
+[WARNING PDN-0195] Removing 8 via(s) between metal9 and metal10 at (181.7350 um, 1349.6200 um) for VSS
+[WARNING PDN-0195] Removing 8 via(s) between metal9 and metal10 at (181.7350 um, 1829.6200 um) for VSS
+[WARNING PDN-0195] Removing 12 via(s) between metal9 and metal10 at (185.2350 um, 2464.6200 um) for VDD
+[WARNING PDN-0195] Removing 12 via(s) between metal9 and metal10 at (2814.7200 um, 1660.3800 um) for VDD
+[WARNING PDN-0195] Removing 12 via(s) between metal9 and metal10 at (2814.7200 um, 2295.3800 um) for VDD
+[WARNING PDN-0195] Removing 8 via(s) between metal9 and metal10 at (2818.2200 um, 535.3800 um) for VSS
+[WARNING PDN-0195] Removing 8 via(s) between metal9 and metal10 at (2818.2200 um, 1175.3800 um) for VSS
 No differences found.


### PR DESCRIPTION
I noticed that the number of vias was incorrect in the log, this corrects that to correctly reflect the number of vias removed.