### PR TITLE
gcd: add eqy_test for floorplan

### DIFF
--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -1,4 +1,5 @@
-load("@bazel-orfs//:openroad.bzl", "orfs_flow")
+load("@bazel-orfs//:eqy.bzl", "eqy_test")
+load("@bazel-orfs//:openroad.bzl", "orfs_flow", "orfs_run")
 
 package(features = ["layering_check"])
 
@@ -24,4 +25,40 @@ orfs_flow(
         "tags": ["orfs"],
     },
     verilog_files = ["gcd.v"],
+)
+
+orfs_run(
+    name = "gcd_floorplan_verilog",
+    src = ":gcd_floorplan",
+    outs = [
+        "gcd_floorplan.v",
+    ],
+    arguments = {
+        "OUTPUT": "$(location :gcd_floorplan.v)",
+    },
+    script = "//test/orfs/mock-array:write_verilog.tcl",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "gcd_synth_files",
+    srcs = [
+        ":gcd_synth",
+    ],
+    output_group = "1_synth.v",
+)
+
+eqy_test(
+    name = "eqy_test",
+    depth = 1,
+    gate_verilog_files = [
+        ":gcd_floorplan.v",
+        "//test/orfs/mock-array:asap7_files",
+    ],
+    gold_verilog_files = [
+        ":gcd_synth_files",
+        "//test/orfs/mock-array:asap7_files",
+    ],
+    module_top = "gcd",
+    tags = ["manual"],
 )

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -7,6 +7,8 @@ package(
     features = ["-layering_check"],  # TODO: enable
 )
 
+exports_files(["write_verilog.tcl"])
+
 chisel_binary(
     name = "generate_verilog",
     srcs = glob(["src/main/scala/**/*.scala"]),
@@ -120,14 +122,18 @@ orfs_run(
     ]
 ]
 
-ASAP7_DEPS = [
-    "asap7/asap7sc7p5t_AO_RVT_TT_201020.v",
-    "asap7/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-    "asap7/asap7sc7p5t_OA_RVT_TT_201020.v",
-    "asap7/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
-    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v",
-]
+filegroup(
+    name = "asap7_files",
+    srcs = [
+        "asap7/asap7sc7p5t_AO_RVT_TT_201020.v",
+        "asap7/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+        "asap7/asap7sc7p5t_OA_RVT_TT_201020.v",
+        "asap7/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
+        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v",
+    ],
+    visibility = ["//visibility:public"],
+)
 
 eqy_test(
     name = "MockArray_4x4_eqy_test",
@@ -136,11 +142,13 @@ eqy_test(
         ":MockArray_4x4_floorplan.v",
         ":Element_4x4_floorplan.v",
         "src/main/resources/multiplier.v",
-    ] + ASAP7_DEPS,
+        ":asap7_files",
+    ],
     gold_verilog_files = [
         ":4x4_array.sv",
         "src/main/resources/multiplier.v",
-    ] + ASAP7_DEPS,
+        ":asap7_files",
+    ],
     module_top = "MockArray",
     tags = ["manual"],
 )


### PR DESCRIPTION
mock-array takes a long time, eqy for gcd is MUCH faster, so better place to start investigating and collaborating.

Ca. 40 seconds for this step:

    bazelisk test test/orfs/gcd:eqy_test --test_output=streamed

```
test/orfs/gcd:eqy_test --test_output=streamed
INFO: Invocation ID: f7eec9a7-d42b-4ca4-b5fd-7501267eea86
WARNING: Streamed test output requested. All tests will be run locally, without sharding, one at a time
INFO: Analyzed target //test/orfs/gcd:eqy_test (0 packages loaded, 0 targets configured).
EQY 21:27:12 [eqy_test] read_gold: starting process "yosys -ql eqy_test/gold.log eqy_test/gold.ys"
EQY 21:27:12 [eqy_test] read_gold: finished (returncode=0)
EQY 21:27:12 [eqy_test] read_gate: starting process "yosys -ql eqy_test/gate.log eqy_test/gate.ys"
EQY 21:27:13 [eqy_test] read_gate: finished (returncode=0)
EQY 21:27:13 [eqy_test] combine: starting process "yosys -ql eqy_test/combine.log eqy_test/combine.ys"
EQY 21:27:13 [eqy_test] combine: Warning: Ignoring boxed module TAPCELL_ASAP7_75t_R.
[deleted more of these]
EQY 21:27:13 [eqy_test] combine: Warning: Ignoring boxed module DECAPx10_ASAP7_75t_R.
EQY 21:27:13 [eqy_test] combine: finished (returncode=0)
EQY 21:27:13 [eqy_test] Warning: Cannot find entity *.
[deleted more of these]
EQY 21:27:13 [eqy_test] Warning: Cannot find entity *.
EQY 21:27:13 [eqy_test] partition: starting process "cd eqy_test; yosys -ql partition.log partition.ys"
EQY 21:27:13 [eqy_test] partition: ERROR: conflicting matches for gold bit \_052_: \_052_ vs \_050_
EQY 21:27:13 [eqy_test] partition: finished (returncode=1)
ERROR: Failed to partition design. For details see 'eqy_test/partition.log'.
Copying 7238 files to bazel-testlogs/test/orfs/gcd/eqy_test/test.outputs for inspection.
FAIL: //test/orfs/gcd:eqy_test (Exit 1) (see /home/oyvind/.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/execroot/_main/bazel-out/k8-fastbuild/testlogs/test/orfs/gcd/eqy_test/test.log)
INFO: Found 1 test target...
Target //test/orfs/gcd:eqy_test up-to-date:
  bazel-bin/test/orfs/gcd/eqy_test.run.sh
INFO: Elapsed time: 38.424s, Critical Path: 38.06s
INFO: 2 processes: 2 processwrapper-sandbox.
INFO: Build completed, 1 test FAILED, 2 total actions
//test/orfs/gcd:eqy_test                                                 FAILED in 37.1s
  /home/oyvind/.cache/bazel/_bazel_oyvind/896cc02f64446168f604c13ad7b60f8b/execroot/_main/bazel-out/k8-fastbuild/testlogs/test/orfs/gcd/eqy_test/test.log

Executed 1 out of 1 test: 1 fails locally.
```