### PR TITLE
rsz: clamp max fanout in pre-place gain based buffering

### DIFF
--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -191,7 +191,7 @@ void RepairDesign::performEarlySizingRound(int& repaired_net_count)
 
       bool repaired_net = false;
       if (max_fanout <= 0) {
-        max_fanout = std::numeric_limits<int>::max();
+        max_fanout = 1e9;
       }
 
       if (performGainBuffering(net, drvr_pin, max_fanout)) {


### PR DESCRIPTION
If no max_fanout constraint has been applied via SDC and the PDK has no default, sta will return -inf for the max_fanout constraint. This is implicitly converted to int in the following call to `performGainBuffering()`.

In certain environments, the compiler enforces mandatory UBSAN and this conversion out of bounds will cause runtime failures.