### PR TITLE
nix: fetch lemon-graph from ORP fork

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -62,6 +62,15 @@
     url = "https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip";
     sha256 = "sha256-t0RchAHTJbuI5YW4uyBPykTvcjy90JW9AOPNjIhwh6U=";
   };
+  lemon-graph' =
+    lemon-graph.overrideAttrs (finalAttrs: previousAttrs: {
+      src = fetchFromGitHub {
+        owner = "The-OpenROAD-Project";
+        repo = "lemon-graph";
+        rev = "f871b10396270cfd09ffddc4b6ead07722e9c232";
+        sha256 = "snqjc82vtgKC5uGu7V6Hhcf7YzRk0xHJDEOCN91iywI=";
+      };
+  });
   self = clangStdenv.mkDerivation (finalAttrs: {
     name = "openroad";
 
@@ -104,7 +113,7 @@
       libffi
       llvmPackages.openmp
 
-      lemon-graph
+      lemon-graph'
       or-tools'
       glpk
       zlib


### PR DESCRIPTION
After upgrade to C++ 20, got the following compilation error from the lemon library:

```
In file included from src/stt/src/pdr/src/pd.cpp:18:                                                                                                             
In file included from /nix/store/r1mv3p44qva9pci3rpw810pnmp6izvyg-lemon-graph-1.3.1/include/lemon/list_graph.h:28:
In file included from /nix/store/r1mv3p44qva9pci3rpw810pnmp6izvyg-lemon-graph-1.3.1/include/lemon/bits/graph_extender.h:25:
In file included from /nix/store/r1mv3p44qva9pci3rpw810pnmp6izvyg-lemon-graph-1.3.1/include/lemon/bits/default_map.h:23:
/nix/store/r1mv3p44qva9pci3rpw810pnmp6izvyg-lemon-graph-1.3.1/include/lemon/bits/array_map.h:221:23: error: no member named 'construct' in 'std::allocator<odb::Point>'
  221 |             allocator.construct(&(new_values[jd]), values[jd]);
      |             ~~~~~~~~~ ^
```

The nix flake uses 24.05, where lemon-graph is not yet upgraded to C++ 20: https://github.com/The-OpenROAD-Project/lemon-graph/commit/f871b10396270cfd09ffddc4b6ead07722e9c232

As a current solution I propose changing fetching location from the default one:

https://github.com/NixOS/nixpkgs/blob/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce/pkgs/by-name/le/lemon-graph/package.nix#L13-L16

to https://github.com/The-OpenROAD-Project/lemon-graph/

The main caveat is that each lemon upgrade would require manual commit hash changes until https://github.com/NixOS/nixpkgs/ updates package or adds a patch.
