### PR TITLE
rcx: remove logs that are created in run directory

### DIFF
--- a/src/rcx/include/rcx/extRCap.h
+++ b/src/rcx/include/rcx/extRCap.h
@@ -946,8 +946,6 @@ class extRCModel
   char* _solverFileName;
 
   FILE* _capLogFP;
-  FILE* _logFP;
-  FILE* _dbg_logFP;
 
   bool _writeFiles;
   bool _readSolver;

--- a/src/rcx/src/extRCmodel.cpp
+++ b/src/rcx/src/extRCmodel.cpp
@@ -2175,7 +2175,6 @@ extRCModel::extRCModel(uint layerCnt, const char* name, Logger* logger)
   _solverFileName = new char[1024];
   _wireFileName = new char[1024];
   _capLogFP = nullptr;
-  _logFP = nullptr;
 
   _readCapLog = false;
   _commentFlag = false;
@@ -2211,7 +2210,6 @@ extRCModel::extRCModel(const char* name, Logger* logger)
   _solverFileName = new char[1024];
   _wireFileName = new char[1024];
   _capLogFP = nullptr;
-  _logFP = nullptr;
 
   _readCapLog = false;
   _commentFlag = false;
@@ -2688,9 +2686,6 @@ void extRCModel::mkFileNames(extMeasure* m, char* wiresNameSuffix)
   } else {
     sprintf(_wireFileName, "%s", "wires");
   }
-
-  fprintf(_logFP, "PATTERN %s\n\n", _wireDirName);
-  fflush(_logFP);
 }
 
 double get_nm(extMeasure* m, double n)
@@ -2749,9 +2744,6 @@ void extRCModel::mkNet_prefix(extMeasure* m, const char* wiresNameSuffix)
   } else {
     sprintf(_wireFileName, "%s", "wires");
   }
-
-  // fprintf(_logFP, "pattern Dir %s\n\n", _wireDirName);
-  fflush(_logFP);
 }
 
 FILE* extRCModel::mkPatternFile()
@@ -3022,7 +3014,6 @@ void extRCModel::setOptions(const char* topDir,
                             const char* pattern,
                             bool writeFiles)
 {
-  _logFP = openFile("./", "rulesGen", ".log", "w");
   _filesFP = openFile("./", "patternFiles.", pattern, "w");
   // strcpy(_topDir, topDir);
   strcpy(_topDir, pattern);
@@ -3035,7 +3026,6 @@ void extRCModel::setOptions(const char* topDir,
 
 void extRCModel::setOptions(const char* topDir, const char* pattern)
 {
-  _logFP = openFile("./", "rulesGen", ".log", "w");
   strcpy(_topDir, topDir);
   strcpy(_patternName, pattern);
 
@@ -3046,11 +3036,6 @@ void extRCModel::setOptions(const char* topDir, const char* pattern)
 
 void extRCModel::closeFiles()
 {
-  fflush(_logFP);
-
-  if (_logFP != nullptr) {
-    fclose(_logFP);
-  }
   fflush(_filesFP);
   if (_filesFP != nullptr) {
     fclose(_filesFP);
@@ -3819,9 +3804,6 @@ bool extRCModel::measurePatternVar(extMeasure* m,
   mkFileNames(m, wiresNameSuffix);
 
   printCommentLine('$', m);
-  fprintf(_logFP, "%s\n", _commentLine);
-  fprintf(_logFP, "%c %g thicknessChange\n", '$', thicknessChange);
-  fflush(_logFP);
 
   if (_writeFiles) {
     FILE* wfp = mkPatternFile();

--- a/src/rcx/src/extRCmodel_process.cpp
+++ b/src/rcx/src/extRCmodel_process.cpp
@@ -520,7 +520,6 @@ void extRCModel::setOptions(const char* topDir,
                             bool keepFile,
                             uint metLevel)
 {
-  _logFP = openFile("./", "rulesGen", ".log", "w");
   strcpy(_topDir, topDir);
   strcpy(_patternName, pattern);
 
@@ -1054,9 +1053,6 @@ bool extRCModel::measurePatternVar_3D(extMeasure* m,
   mkFileNames(m, wiresNameSuffix);
 
   printCommentLine('#', m);
-  fprintf(_logFP, "%s\n", _commentLine);
-  fprintf(_logFP, "%c %g thicknessChange\n", '$', thicknessChange);
-  fflush(_logFP);
 
   FILE* wfp = mkPatternFile();
 

--- a/src/rcx/src/extRCmodel_solver.cpp
+++ b/src/rcx/src/extRCmodel_solver.cpp
@@ -79,8 +79,6 @@ uint extRCModel::getCorners(std::list<std::string>& corners)
 uint extRCModel::initModel(std::list<std::string>& corners, int met_cnt)
 {
   int cornerCnt = defineCorners(corners);
-  _logFP = openFile("./", "corners", ".log", "w");
-  _dbg_logFP = openFile("./", "corners", ".debug.log", "w");
   createModelTable(cornerCnt, (uint) (met_cnt + 1));
   for (uint m = 0; m < cornerCnt; m++) {
     for (uint ii = 1; ii < _layerCnt; ii++) {
@@ -194,16 +192,6 @@ uint extRCModel::readRCvalues(const char* corner,
     sprintf(buff, "%s.debug.log", corner);
     FILE* dbg_logFP = fopen(buff, "w");
   */
-  FILE* logFP = _logFP;
-  FILE* dbg_logFP = _dbg_logFP;
-  fprintf(logFP,
-          "REading corner %s File: %s -------------------------\n\n",
-          corner,
-          filename);
-  fprintf(dbg_logFP,
-          "REading corner %s File: %s ----------------------\n\n",
-          corner,
-          filename);
 
   free(_ruleFileName);
   _ruleFileName = strdup(filename);
@@ -258,37 +246,6 @@ uint extRCModel::readRCvalues(const char* corner,
       R *= 2;
     }
 
-    if (m._res) {
-      fprintf(
-          logFP,
-          "M%2d OVER %2d UNDER %2d W %.3f S1 %.3f S2 %.3f R %g LEN %g %g  %s\n",
-          m._met,
-          m._underMet,
-          m._overMet,
-          m._w_m,
-          m._s_m,
-          m._s2_m,
-          res,
-          wLen,
-          R,
-          fullPatternName);
-    } else {
-      fprintf(logFP,
-              "M%2d OVER %2d UNDER %2d W %.3f S %.3f CC %.6f GND %.6f TC %.6f "
-              "x %.6f R %g LEN %g  %s\n",
-              m._met,
-              m._underMet,
-              m._overMet,
-              m._w_m,
-              m._s_m,
-              totCC,
-              totGnd,
-              totCC + totGnd,
-              contextCoupling,
-              res,
-              wLen,
-              fullPatternName);
-    }
     // if (strstr(netName, "cntxM") != nullptr)
     //  continue;
 
@@ -302,39 +259,6 @@ uint extRCModel::readRCvalues(const char* corner,
       //  m._s_nm = prev_sep + prev_width;
       rc->set(m._s_nm, cc, gnd, 0.0, R);
     }
-
-    if (m._res) {
-      fprintf(dbg_logFP,
-              "M%2d OVER %2d UNDER %2d W %.3f S1 %.3f S2 %.3f R %g LEN %g %g  "
-              "%s --- ",
-              m._met,
-              m._underMet,
-              m._overMet,
-              m._w_m,
-              m._s_m,
-              m._s2_m,
-              res,
-              wLen,
-              R,
-              fullPatternName);
-    } else {
-      fprintf(dbg_logFP,
-              "M%2d OVER %2d UNDER %2d W %.3f S %.3f CC %.6f GND %.6f TC %.6f "
-              "x %.6f R %g LEN %g  %s --- ",
-              m._met,
-              m._underMet,
-              m._overMet,
-              m._w_m,
-              m._s_m,
-              totCC,
-              totGnd,
-              totCC + totGnd,
-              contextCoupling,
-              res,
-              wLen,
-              fullPatternName);
-    }
-    rc->writeRC(dbg_logFP, false);
 
     m._tmpRC = rc;
     met_rc->addRCw(&m);


### PR DESCRIPTION
Removes ./corners.log and ./corners.debug.log files that appear in run directory.

There should be no functional changes just deleting the two file pointers and associated code.