### PR TITLE
mpl: fix performance inefficiencies from coverity scan

### DIFF
--- a/src/mpl/src/SACoreSoftMacro.cpp
+++ b/src/mpl/src/SACoreSoftMacro.cpp
@@ -871,7 +871,7 @@ void SACoreSoftMacro::fillDeadSpace()
   const int num_y = y_grid.size() - 1;
   for (int j = 0; j < num_y; j++) {
     std::vector<int> macro_ids(num_x, -1);
-    grids.push_back(macro_ids);
+    grids.push_back(std::move(macro_ids));
   }
 
   for (int macro_id = 0; macro_id < pos_seq_.size(); macro_id++) {

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -871,7 +871,7 @@ DataFlowHypergraph ClusteringEngine::computeHypergraph(
     for (int i = 1; i < hyperedge.size(); i++) {
       graph.backward_vertices[hyperedge[i]].push_back(graph.hyperedges.size());
     }
-    graph.hyperedges.push_back(hyperedge);
+    graph.hyperedges.push_back(std::move(hyperedge));
   }
 
   return graph;
@@ -1600,7 +1600,7 @@ void ClusteringEngine::breakLargeFlatCluster(Cluster* parent)
         && loads_id.size() < tree_->large_net_threshold) {
       std::vector<int> hyperedge;
       hyperedge.insert(hyperedge.end(), loads_id.begin(), loads_id.end());
-      hyperedges.push_back(hyperedge);
+      hyperedges.push_back(std::move(hyperedge));
     }
   }
 
@@ -2105,7 +2105,7 @@ void ClusteringEngine::fetchMixedLeaves(
   // We push the leaves after finishing searching the children so
   // that each vector of clusters represents the children of one
   // parent.
-  mixed_leaves.push_back(sister_mixed_leaves);
+  mixed_leaves.push_back(std::move(sister_mixed_leaves));
 }
 
 void ClusteringEngine::breakMixedLeaves(

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -416,7 +416,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
         macro.setShapes(width_intervals, tilings.front().area());
       }
 
-      macros.push_back(macro);
+      macros.push_back(std::move(macro));
     }
   }
   // if there is only one soft macro


### PR DESCRIPTION
Occurrences of COPY_INSTEAD_OF_MOVE.

CIDs:
- 1618880
- 1618896
- 1618954
- 1618957
- 1618961