### PR TITLE
gpl: always create new instances from TD mode in top-level

### DIFF
--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -1211,7 +1211,7 @@ void NesterovPlace::createCbkGCell(odb::dbInst* db_inst)
   auto gcell_index = nbc_->createCbkGCell(db_inst);
   // Always create gcell on top-level
   nbVec_[0]->createCbkGCell(db_inst, gcell_index);
-  // TODO: properly create new gcell in each region
+  // TODO: create new gcell in its proper region
   // for (auto& nesterov : nbVec_) {
   //   nesterov->createCbkGCell(db_inst, gcell_index);
   // }


### PR DESCRIPTION
The existing code was incorrect. I remember just throwing a sketch loop to be refined afterwards regarding the region behavior and it was left incorrect.

I just modified it so we always create new instances from callbacks in the top-level region of gpl. This would be the first step mentioned in issue #8838. The actual desired behavior might be to set the actual region a buffer may belong to.