### PR TITLE
mpl: refactor to avoid future duplicated code

### DIFF
--- a/src/mpl/src/SimulatedAnnealingCore.cpp
+++ b/src/mpl/src/SimulatedAnnealingCore.cpp
@@ -263,62 +263,68 @@ void SimulatedAnnealingCore<T>::calOutlinePenalty()
 template <class T>
 void SimulatedAnnealingCore<T>::calWirelength()
 {
-  // Initialization
-  wirelength_ = 0.0;
   if (core_weights_.wirelength <= 0.0) {
     return;
   }
 
-  // calculate the total net weight
-  float tot_net_weight = 0.0;
-  for (const auto& net : nets_) {
-    tot_net_weight += net.weight;
-  }
-
-  if (tot_net_weight <= 0.0) {
-    return;
-  }
-
-  for (const auto& net : nets_) {
-    T& source = macros_[net.terminals.first];
-    T& target = macros_[net.terminals.second];
-
-    if (target.isClusterOfUnplacedIOPins()) {
-      computeWLForClusterOfUnplacedIOPins(source, target, net.weight);
-      continue;
-    }
-
-    const float x1 = source.getPinX();
-    const float y1 = source.getPinY();
-    const float x2 = target.getPinX();
-    const float y2 = target.getPinY();
-    wirelength_ += net.weight * (std::abs(x2 - x1) + std::abs(y2 - y1));
-  }
-
-  // normalization
-  wirelength_ = wirelength_ / tot_net_weight
-                / (outline_.getHeight() + outline_.getWidth());
+  wirelength_ = computeNetsWireLength(nets_);
 
   if (graphics_) {
-    graphics_->setWirelengthPenalty({"Wire Length",
-                                     core_weights_.wirelength,
-                                     wirelength_,
-                                     norm_wirelength_});
+    graphics_->setWirelengthPenalty({.name = "Wire Length",
+                                     .weight = core_weights_.wirelength,
+                                     .value = wirelength_,
+                                     .normalization_factor = norm_wirelength_});
   }
 }
 
 template <class T>
-void SimulatedAnnealingCore<T>::computeWLForClusterOfUnplacedIOPins(
+float SimulatedAnnealingCore<T>::computeNetsWireLength(
+    const std::vector<BundledNet>& nets) const
+{
+  float nets_wire_length = 0.0;
+  float nets_weight_sum = 0.0;
+
+  for (const auto& net : nets_) {
+    nets_weight_sum += net.weight;
+  }
+
+  if (nets_weight_sum != 0.0) {
+    for (const auto& net : nets) {
+      const T& source = macros_[net.terminals.first];
+      const T& target = macros_[net.terminals.second];
+
+      if (target.isClusterOfUnplacedIOPins()) {
+        nets_wire_length
+            += computeWLForClusterOfUnplacedIOPins(source, target, net.weight);
+      } else {
+        const float x1 = source.getPinX();
+        const float y1 = source.getPinY();
+        const float x2 = target.getPinX();
+        const float y2 = target.getPinY();
+
+        nets_wire_length
+            += net.weight * (std::abs(x2 - x1) + std::abs(y2 - y1));
+      }
+    }
+
+    nets_wire_length = nets_wire_length / nets_weight_sum
+                       / (outline_.getHeight() + outline_.getWidth());
+  }
+
+  return nets_wire_length;
+}
+
+template <class T>
+double SimulatedAnnealingCore<T>::computeWLForClusterOfUnplacedIOPins(
     const T& macro,
     const T& unplaced_ios,
-    const float net_weight)
+    const float net_weight) const
 {
   // To generate maximum cost.
   const float max_dist = die_area_.getPerimeter() / 2;
 
   if (isOutsideTheOutline(macro)) {
-    wirelength_ += net_weight * max_dist;
-    return;
+    return net_weight * max_dist;
   }
 
   const odb::Point macro_location(block_->micronsToDbu(macro.getPinX()),
@@ -341,7 +347,7 @@ void SimulatedAnnealingCore<T>::computeWLForClusterOfUnplacedIOPins(
         = computeDistToNearestRegion(macro_location, {constraint}, nullptr);
   }
 
-  wirelength_ += net_weight * block_->dbuToMicrons(smallest_distance);
+  return net_weight * block_->dbuToMicrons(smallest_distance);
 }
 
 // We consider the macro outside the outline based on the location of

--- a/src/mpl/src/SimulatedAnnealingCore.h
+++ b/src/mpl/src/SimulatedAnnealingCore.h
@@ -116,9 +116,10 @@ class SimulatedAnnealingCore
   virtual void calPenalty() = 0;
   void calOutlinePenalty();
   void calWirelength();
-  void computeWLForClusterOfUnplacedIOPins(const T& macro,
-                                           const T& unplaced_ios,
-                                           float net_weight);
+  float computeNetsWireLength(const std::vector<BundledNet>& nets) const;
+  double computeWLForClusterOfUnplacedIOPins(const T& macro,
+                                             const T& unplaced_ios,
+                                             float net_weight) const;
   bool isOutsideTheOutline(const T& macro) const;
   void calGuidancePenalty();
   void calFencePenalty();


### PR DESCRIPTION
For #8871.

Another wire length-based penalty will be added and the changes here are to make that easier.

I'm using `double` when computing WL for clusters of unplaced IOs to preserve identical results (using `float` causes some very subtle approximation changes that causes interference). Ideally we should probably have the annealer wire length as `int64_t` so that we get rid of this kind of problem.