### PR TITLE
mpl: initialize global fence in cpp to allow changing ORFS defaults

### DIFF
--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -106,7 +106,11 @@ void HierRTLMP::setGlobalFence(float fence_lx,
                                float fence_ux,
                                float fence_uy)
 {
-  tree_->global_fence = Rect(fence_lx, fence_ly, fence_ux, fence_uy);
+  const float x_max
+      = fence_ux == 0.0 ? std::numeric_limits<float>::max() : fence_ux;
+  const float y_max
+      = fence_uy == 0.0 ? std::numeric_limits<float>::max() : fence_uy;
+  tree_->global_fence = Rect(fence_lx, fence_ly, x_max, y_max);
 }
 
 void HierRTLMP::setHaloWidth(float halo_width)

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -66,8 +66,8 @@ proc rtl_macro_placer { args } {
   set halo_height 0.0
   set fence_lx 0.0
   set fence_ly 0.0
-  set fence_ux 100000000.0
-  set fence_uy 100000000.0
+  set fence_ux 0.0
+  set fence_uy 0.0
 
   set area_weight 0.1
   set outline_weight 100.0


### PR DESCRIPTION
This is temporary and will be corrected subsequently by #8950.