### PR TITLE
gui: add propertytable and add renderer to inspector

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -397,6 +397,58 @@ class Descriptor
                                   int digits = 3);
 };
 
+class PropertyTable
+{
+ public:
+  PropertyTable(int rows, int columns)
+  {
+    row_header_.resize(rows);
+    column_header_.resize(columns);
+    data_.resize(rows);
+    for (auto& row : data_) {
+      row.resize(columns);
+    }
+  };
+
+  void setRowHeader(int row, const std::string& header)
+  {
+    row_header_.at(row) = header;
+  }
+  const std::vector<std::string>& getRowHeaders() const { return row_header_; }
+
+  void setColumnHeader(int column, const std::string& header)
+  {
+    column_header_.at(column) = header;
+  }
+  const std::vector<std::string>& getColumnHeaders() const
+  {
+    return column_header_;
+  }
+
+  void setData(int row, int column, const std::string& value)
+  {
+    data_.at(row).at(column) = value;
+  }
+  const std::vector<std::vector<std::string>>& getData() const { return data_; }
+
+  bool empty() const
+  {
+    for (const auto& row : data_) {
+      for (const auto& item : row) {
+        if (!item.empty()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+ private:
+  std::vector<std::string> column_header_;
+  std::vector<std::string> row_header_;
+  std::vector<std::vector<std::string>> data_;
+};
+
 // An object selected in the gui.  The object is stored as a
 // std::any to allow any client objects to be stored.  The descriptor
 // is the API for the object as described above.  This doesn't

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -2951,32 +2951,28 @@ Descriptor::Properties DbTechLayerDescriptor::getDBProperties(
   if (layer->hasTwoWidthsSpacingRules()) {
     const int widths = layer->getTwoWidthsSpacingTableNumWidths();
 
-    PropertyList spacing_rules;
+    PropertyTable table(widths, widths);
     for (int i = 0; i < widths; i++) {
       const std::string prefix_title = Property::convert_dbu(
           layer->getTwoWidthsSpacingTableWidth(i), true);
       const std::string prl_title
           = layer->getTwoWidthsSpacingTableHasPRL(i)
-                ? " - PRL "
+                ? "\nPRL "
                       + Property::convert_dbu(
                           layer->getTwoWidthsSpacingTablePRL(i), true)
                 : "";
-
+      table.setRowHeader(i, prefix_title + prl_title);
+      table.setColumnHeader(i, prefix_title + prl_title);
       for (int j = 0; j < widths; j++) {
-        std::string title = prefix_title;
-        title += " - ";
-        title += Property::convert_dbu(layer->getTwoWidthsSpacingTableWidth(j),
-                                       true);
-        title += prl_title;
-        spacing_rules.emplace_back(
-            title,
-            Property::convert_dbu(layer->getTwoWidthsSpacingTableEntry(i, j),
-                                  true));
+        table.setData(i,
+                      j,
+                      Property::convert_dbu(
+                          layer->getTwoWidthsSpacingTableEntry(i, j), true));
       }
     }
 
-    if (!spacing_rules.empty()) {
-      props.push_back({"Two width spacing rules", spacing_rules});
+    if (!table.empty()) {
+      props.push_back({"Two width spacing rules", table});
     }
   }
 

--- a/src/gui/src/inspector.cpp
+++ b/src/gui/src/inspector.cpp
@@ -11,8 +11,11 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPainter>
 #include <QPushButton>
 #include <QString>
+#include <QStyleOptionViewItem>
+#include <QTextDocument>
 #include <QVariant>
 #include <QWidget>
 #include <algorithm>
@@ -134,6 +137,8 @@ void SelectedItemModel::makePropertyItem(const Descriptor::Property& property,
   // as children rows
   if (auto sel_set = std::any_cast<Descriptor::PropertyList>(&value)) {
     value_item = makePropertyList(name_item, sel_set->begin(), sel_set->end());
+  } else if (auto sel_set = std::any_cast<PropertyTable>(&value)) {
+    value_item = makePropertyTable(name_item, *sel_set);
   } else if (auto sel_set = std::any_cast<SelectionSet>(&value)) {
     value_item = makeList(name_item, sel_set->begin(), sel_set->end());
   } else if (auto v_list = std::any_cast<std::vector<std::any>>(&value)) {
@@ -189,9 +194,7 @@ QStandardItem* SelectedItemModel::makeList(QStandardItem* name_item,
     name_item->appendRow({index_item, selected_item});
   }
 
-  QString items = QString::number(index) + " items";
-
-  return makeItem(items);
+  return makeItem(QString::number(index) + " items");
 }
 
 template <typename Iterator>
@@ -204,9 +207,50 @@ QStandardItem* SelectedItemModel::makePropertyList(QStandardItem* name_item,
     name_item->appendRow({makeItem(name, true), makeItem(value)});
   }
 
-  QString items = QString::number(name_item->rowCount()) + " items";
+  return makeItem(QString::number(name_item->rowCount()) + " items");
+}
 
-  return makeItem(items);
+QStandardItem* SelectedItemModel::makePropertyTable(QStandardItem* name_item,
+                                                    const PropertyTable& table)
+{
+  const int rows = table.getData().size();
+  const int columns = table.getColumnHeaders().size();
+
+  QStandardItem* table_item = makeItem(QString());
+
+  QString html;
+  html += "<style>th, td {padding: 2px; border: 1px solid black; text-align: center; vertical-align: middle;}</style>";
+  html += "<table>";
+  // setup column headers
+  html += "<tr><th />";
+  for (int col = 0; col < columns; col++) {
+    html += "<th>";
+    html += QString::fromStdString(table.getColumnHeaders().at(col))
+                .replace("\n", "<br>");
+    html += "</th>";
+  }
+  html += "</tr>";
+  // add rows
+  for (int row = 0; row < rows; row++) {
+    html += "<tr>";
+    html += "<th>";
+    html += QString::fromStdString(table.getRowHeaders().at(row))
+                .replace("\n", "<br>");
+    html += "</th>";
+    for (int col = 0; col < columns; col++) {
+      html += "<td>";
+      html += QString::fromStdString(table.getData().at(row).at(col))
+                  .replace("\n", "<br>");
+      html += "</td>";
+    }
+    html += "</tr>";
+  }
+  html += "</table>";
+  table_item->setData(html, EditorItemDelegate::kHtml);
+
+  name_item->appendRow({nullptr, table_item});
+
+  return makeItem(QString::number(rows * columns) + " items");
 }
 
 void SelectedItemModel::makeItemEditor(const std::string& name,
@@ -240,7 +284,7 @@ void SelectedItemModel::makeItemEditor(const std::string& name,
 
 EditorItemDelegate::EditorItemDelegate(SelectedItemModel* model,
                                        QObject* parent)
-    : QItemDelegate(parent),
+    : QStyledItemDelegate(parent),
       model_(model),
       background_(model->getEditableColor())
 {
@@ -381,6 +425,51 @@ EditorItemDelegate::EditType EditorItemDelegate::getEditorType(
     return EditorItemDelegate::kBool;
   }
   return EditorItemDelegate::kString;
+}
+
+void EditorItemDelegate::paint(QPainter* painter,
+                               const QStyleOptionViewItem& option,
+                               const QModelIndex& index) const
+{
+  if (index.model()->data(index, kHtml).toString().isEmpty()) {
+    QStyledItemDelegate::paint(painter, option, index);
+    return;
+  }
+
+  QStyleOptionViewItem options(option);
+  initStyleOption(&options, index);
+
+  painter->save();
+
+  QTextDocument doc;
+  doc.setHtml(index.model()->data(index, kHtml).toString());
+
+  /* Call this to get the focus rect and selection background. */
+  options.text = "";
+  options.widget->style()->drawControl(
+      QStyle::CE_ItemViewItem, &options, painter);
+
+  /* Draw using text document. */
+  painter->translate(options.rect.left(), options.rect.top());
+  const QRectF clip(0, 0, options.rect.width(), options.rect.height());
+  doc.drawContents(painter, clip);
+
+  painter->restore();
+}
+
+QSize EditorItemDelegate::sizeHint(const QStyleOptionViewItem& option,
+                                   const QModelIndex& index) const
+{
+  if (index.model()->data(index, kHtml).toString().isEmpty()) {
+    return QStyledItemDelegate::sizeHint(option, index);
+  }
+  QStyleOptionViewItem options(option);
+  initStyleOption(&options, index);
+
+  QTextDocument doc;
+  doc.setHtml(index.model()->data(index, kHtml).toString());
+  doc.setTextWidth(options.rect.width());
+  return QSize(doc.idealWidth(), doc.size().height());
 }
 
 ////////

--- a/src/gui/src/inspector.h
+++ b/src/gui/src/inspector.h
@@ -5,12 +5,12 @@
 
 #include <QColor>
 #include <QDockWidget>
-#include <QItemDelegate>
 #include <QLabel>
 #include <QMenu>
 #include <QPushButton>
 #include <QStandardItemModel>
 #include <QString>
+#include <QStyledItemDelegate>
 #include <QTimer>
 #include <QTreeView>
 #include <QVBoxLayout>
@@ -27,7 +27,7 @@
 namespace gui {
 class SelectedItemModel;
 
-class EditorItemDelegate : public QItemDelegate
+class EditorItemDelegate : public QStyledItemDelegate
 {
   Q_OBJECT
 
@@ -38,6 +38,7 @@ class EditorItemDelegate : public QItemDelegate
   static const int kEditorType = Qt::UserRole + 2;
   static const int kEditorSelect = Qt::UserRole + 3;
   static const int kSelected = Qt::UserRole + 4;
+  static const int kHtml = Qt::UserRole + 5;
 
   enum EditType
   {
@@ -59,6 +60,13 @@ class EditorItemDelegate : public QItemDelegate
                     const QModelIndex& index) const override;
 
   static EditType getEditorType(const std::any& value);
+
+ protected:
+  void paint(QPainter* painter,
+             const QStyleOptionViewItem& option,
+             const QModelIndex& index) const override;
+  QSize sizeHint(const QStyleOptionViewItem& option,
+                 const QModelIndex& index) const override;
 
  private:
   SelectedItemModel* model_;
@@ -102,6 +110,8 @@ class SelectedItemModel : public QStandardItemModel
   QStandardItem* makePropertyList(QStandardItem* name_item,
                                   const Iterator& begin,
                                   const Iterator& end);
+  QStandardItem* makePropertyTable(QStandardItem* name_item,
+                                   const PropertyTable& table);
 
   void makeItemEditor(const std::string& name,
                       QStandardItem* item,


### PR DESCRIPTION
Changes:
- add table rendering to inspector.
- switch two width information to use table.

<img width="1361" height="438" alt="image" src="https://github.com/user-attachments/assets/4347be4d-7f15-440d-b4df-c3c649e4adf0" />
