### PR TITLE
Using guards to prevent re-definitions of std::vector<int> 

### DIFF
--- a/src/gpl/src/replace-py.i
+++ b/src/gpl/src/replace-py.i
@@ -28,5 +28,8 @@ using gpl::Replace;
 %include "gpl/Replace.h"
 
 namespace std {
+#ifndef SWIG_VECTOR_INT
+#define SWIG_VECTOR_INT
     %template(IntVector) vector<int>;
+#endif
 }


### PR DESCRIPTION
One last remaining vector<int> defintion that we should guard.