### PR TITLE
GUI: Fixes for 3dblox

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -496,6 +496,7 @@ void OpenRoad::read3Dbx(const std::string& filename)
   odb::ThreeDBlox parser(logger_, db_, sta_);
   parser.readDbx(filename);
   parser.check();
+  db_->triggerPostRead3Dbx(db_->getChip());
 }
 
 void OpenRoad::read3DBloxBMap(const std::string& filename)

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -226,7 +226,14 @@ void RenderThread::draw(QImage& image,
   }
 
   drawChips(&painter, viewer_->getChip(), dbu_bounds, 0);
-
+  for (auto* renderer : Gui::get()->renderers()) {
+    if (restart_) {
+      break;
+    }
+    gui_painter.saveState();
+    renderer->drawObjects(gui_painter);
+    gui_painter.restoreState();
+  }
   // draw selected and over top level and fast painting events
   drawSelected(gui_painter, selected);
   // Always last so on top
@@ -1273,17 +1280,6 @@ void RenderThread::drawChip(QPainter* painter,
   utl::Timer inst_cell_grid;
   drawGCellGrid(painter, bounds);
   debugPrint(logger_, GUI, "draw", 1, "save cell grid {}", inst_cell_grid);
-
-  utl::Timer inst_save_restore;
-  for (auto* renderer : Gui::get()->renderers()) {
-    if (restart_) {
-      break;
-    }
-    gui_painter.saveState();
-    renderer->drawObjects(gui_painter);
-    gui_painter.restoreState();
-  }
-  debugPrint(logger_, GUI, "draw", 1, "renderers {}", inst_save_restore);
 
   debugPrint(logger_, GUI, "draw", 1, "total render {}", timer);
 }

--- a/src/odb/src/3dblox/3dblox.cpp
+++ b/src/odb/src/3dblox/3dblox.cpp
@@ -88,8 +88,7 @@ void ThreeDBlox::readDbx(const std::string& dbx_file)
   for (const auto& [_, connection] : data.connections) {
     createConnection(connection);
   }
-  calculateSize(db_->getChip());
-  db_->triggerPostRead3Dbx(chip);
+  calculateSize(chip);
 }
 
 void ThreeDBlox::check()


### PR DESCRIPTION
- trigger postRead3Dbx callback for the top 3dbx referenced in the read_3dbx command only instead of doing it for all nested 3dbx files.
- invoke the renderers once for multi-chip designs.

This fixes the gui view when openroad starts with gui and fixes the markers drawing.