### PR TITLE
gpl: fix bug related to snapshot saving

### DIFF
--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -580,7 +580,7 @@ bool NesterovPlace::isDiverged(float& diverge_snapshot_WlCoefX,
   }
 
   if (!npVars_.disableRevertIfDiverge && num_region_diverged_ == 0
-      && !is_routability_need_) {
+      && (!npVars_.routability_driven_mode || !is_routability_need_)) {
     if (is_min_hpwl_) {
       diverge_snapshot_WlCoefX = wireLengthCoefX_;
       diverge_snapshot_WlCoefY = wireLengthCoefY_;


### PR DESCRIPTION
Bug inserted at https://github.com/The-OpenROAD-Project/OpenROAD/pull/9021, small oversight.

With the new parameter for user setting of routability snapshot overflow it required a checking if routability was finished, but the added check did not consider when routability is disabled at all.

The issue would only be reproducible  in 3-1 if a divergence happens.