### PR TITLE
bazel-orfs: bump, avoid picking up semanticdb bazel toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -146,7 +146,7 @@ bazel_dep(name = "bazel-orfs")
 # To bump version, run: bazelisk run @bazel-orfs//:bump
 git_override(
     module_name = "bazel-orfs",
-    commit = "e96d7d2a4405a99fc689b4f2f676d3bda7b9430b",
+    commit = "1e862b169d97dc0fec5db106559640886e7fd7d0",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
@@ -155,10 +155,10 @@ orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
 # To bump version, run: bazelisk run @bazel-orfs//:bump
 orfs.default(
     # Official image https://hub.docker.com/r/openroad/orfs/tags
-    image = "docker.io/openroad/orfs:v3.0-4362-gaec1d8d35",
+    image = "docker.io/openroad/orfs:v3.0-4367-g79b6a48ab",
     # Use OpenROAD of this repo instead of from the docker image
     openroad = "//:openroad",
-    sha256 = "5f94f0481d1339493918208060be116da101405251bce22691ac4b2d662d276e",
+    sha256 = "0d0dd3d8d346360a71f6325ce776a984c5a6296fc6e51956b53f136e1dd13462",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1047,7 +1047,7 @@
     "@@bazel-orfs+//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "mXT67CG7L5OLVmAL21N/b1fUYtLkKfGcDS9/BHvSBuY=",
-        "usagesDigest": "kfWei6B/Kh2icsOQdtUiHUjML0lX4Y7EQZc30VWPlMQ=",
+        "usagesDigest": "4SoJ3Uh9OA7BCbTABuk/iAKa6RXwwFDlK7SKCqtKTgs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1065,8 +1065,8 @@
           "docker_orfs": {
             "repoRuleId": "@@bazel-orfs+//:docker.bzl%docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-4362-gaec1d8d35",
-              "sha256": "5f94f0481d1339493918208060be116da101405251bce22691ac4b2d662d276e",
+              "image": "docker.io/openroad/orfs:v3.0-4367-g79b6a48ab",
+              "sha256": "0d0dd3d8d346360a71f6325ce776a984c5a6296fc6e51956b53f136e1dd13462",
               "build_file": "@@bazel-orfs+//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [
@@ -4730,7 +4730,7 @@
     "@@rules_scala+//scala/extensions:config.bzl%scala_config": {
       "general": {
         "bzlTransitiveDigest": "TYEDBdoN7s4wE8er7JwzFt7+3iw57BHsTSLyWmxbgZo=",
-        "usagesDigest": "uliesOoMg751pSX5T2zzlIvJ584BZtCMn+lyizgjFQ4=",
+        "usagesDigest": "kIa14GxlFzFPszaJsUwGJ6HiTDEgyEIJ3PoO9RCzoSw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {
@@ -4755,7 +4755,7 @@
     "@@rules_scala+//scala/extensions:deps.bzl%scala_deps": {
       "general": {
         "bzlTransitiveDigest": "YsA4jOMweScag0E8uduDscdeffQYq2QvIZVzNUfcFug=",
-        "usagesDigest": "6e/wlT46JXlimBfSzfvDdhkNBat2824OdqmJ+kpuGqg=",
+        "usagesDigest": "BEkppMsG8BB85MjwSlCQl05N70CRaJ7aQeS0cea4zUs=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
should fix false dependencies on docker.

I can't reproduce the problem(mac & nix), but from the error message, this is the main suspect. I've weeded out this unecessary dependency.