### PR TITLE
Cts optimize tech char iterations

### DIFF
--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -1699,7 +1699,8 @@ void TechChar::create()
         if (!solution.isPureWire && buffersCombinations > 1) {
           updateBufferTopologies(solution);
         }
-        // For pure-wire solution buffersCombinations == 1, so it only runs once.
+        // For pure-wire solution buffersCombinations == 1, so it only runs
+        // once.
         buffersCombinations--;
       } while (buffersCombinations != 0);
     }


### PR DESCRIPTION
Tech Char was performing unnecessary operations in 2 cases:

1. For pure wire topologies it was testing all slew and input cap combinations for each of the available buffers, even though there is no buffers in the topology and it doesn't change the results.
2. For the first combination of buffers it was repeating the slew and input cap combinations at the last iteration.


This PR prevents these unnecessary operations and does not impact QoR

