### PR TITLE
ODB: Fix test datarace on writing results

### DIFF
--- a/src/odb/test/write_3dbv.tcl
+++ b/src/odb/test/write_3dbv.tcl
@@ -4,7 +4,7 @@ set db [ord::get_db]
 set tech [odb::dbTech_create $db "tech"]
 
 read_3dbx "data/example.3dbx"
-set out_3dbv [make_result_file "write_3dbv.3dbv"]
+set out_3dbv [make_result_file "write_3dbv/write_3dbv.3dbv"]
 set 3dbv_write_result [write_3dbv $out_3dbv]
 
 diff_files $out_3dbv "write_3dbv.3dbvok"

--- a/src/odb/test/write_3dbx.tcl
+++ b/src/odb/test/write_3dbx.tcl
@@ -4,7 +4,7 @@ set db [ord::get_db]
 set tech [odb::dbTech_create $db "tech"]
 
 read_3dbx "data/example.3dbx"
-set out_3dbx [make_result_file "write_3dbx.3dbx"]
+set out_3dbx [make_result_file "write_3dbx/write_3dbx.3dbx"]
 set 3dbx_write_result [write_3dbx $out_3dbx]
 
 diff_files $out_3dbx "write_3dbx.3dbxok"

--- a/test/helpers.tcl
+++ b/test/helpers.tcl
@@ -20,12 +20,23 @@ proc make_result_dir { } {
   return $result_dir
 }
 
+proc make_result_test_dir { subdir } {
+  variable result_dir
+  set full_path [file join $result_dir $subdir]
+  if { ![file exists $full_path] } {
+    file mkdir $full_path
+  }
+  return $full_path
+}
+
 proc make_result_file { filename } {
   variable result_dir
 
   make_result_dir
 
   set root [file rootname $filename]
+  set dir [file dirname $filename]
+  make_result_test_dir $dir
   set ext [file extension $filename]
   set filename "$root-tcl$ext"
   return [file join $result_dir $filename]


### PR DESCRIPTION
Because write_3dbv.tcl and write_3dbx.tcl write common results file, a datarace condition occurs when both are run in parallel. To fix this, the PR writes the results of each test in a dedicated sub-directory inside the results directory.