### PR TITLE
psm: remove unused map

### DIFF
--- a/src/psm/src/ir_network.cpp
+++ b/src/psm/src/ir_network.cpp
@@ -367,6 +367,13 @@ void IRNetwork::processPolygonToRectangles(
     std::vector<std::unique_ptr<Node>>& new_nodes,
     std::map<Shape*, std::set<Node*>>& terminal_connections)
 {
+  const utl::DebugScopedTimer timer(
+      logger_,
+      utl::PSM,
+      "timer",
+      2,
+      fmt::format("Convert polygons to nodes {}: {{}}", layer->getName()));
+
   using boost::polygon::operators::operator+=;
 
   auto get_layer_orientation


### PR DESCRIPTION
No functional changes:
- removed an unused map
- adds a timer to track node creation time.