### PR TITLE
psm: merge all nodes on shapes during floorplanning

### DIFF
--- a/src/psm/src/ir_network.cpp
+++ b/src/psm/src/ir_network.cpp
@@ -367,13 +367,6 @@ void IRNetwork::processPolygonToRectangles(
     std::vector<std::unique_ptr<Node>>& new_nodes,
     std::map<Shape*, std::set<Node*>>& terminal_connections)
 {
-  const utl::DebugScopedTimer timer(
-      logger_,
-      utl::PSM,
-      "timer",
-      2,
-      fmt::format("Convert polygons to nodes {}: {{}}", layer->getName()));
-
   using boost::polygon::operators::operator+=;
 
   auto get_layer_orientation
@@ -588,7 +581,8 @@ void IRNetwork::generateCutNodesForSBox(
   }
 
   const int min_pitch = std::min(min_node_pitch_[bottom], min_node_pitch_[top]);
-  const bool use_single_via = box->getBox().maxDXDY() < min_pitch;
+  const bool use_single_via
+      = floorplanning_ || box->getBox().maxDXDY() < min_pitch;
 
   if (single_via || use_single_via) {
     const odb::Point via_center = box->getViaXY();
@@ -689,6 +683,11 @@ void IRNetwork::generateCutLayerNodes()
 
 void IRNetwork::generateTopLayerFillerNodes()
 {
+  if (floorplanning_) {
+    // these are only needed if running for IR drop.
+    return;
+  }
+
   const utl::DebugScopedTimer timer(
       logger_, utl::PSM, "timer", 1, "Generate top layer filler nodes: {}");
   // needed in case of vsrc
@@ -747,7 +746,9 @@ void IRNetwork::mergeNodes(NodePtrMap<Connection>& connection_map)
 
     const auto node_trees = getNodeTree(layer);
     for (const auto& shape : shapes) {
-      const int min_distance = min_node_pitch_[shape->getLayer()];
+      const int min_distance = floorplanning_
+                                   ? (2 * shape->getShape().maxDXDY())
+                                   : min_node_pitch_[shape->getLayer()];
       const auto shape_remove = shape->cleanupNodes(
           min_distance,
           node_trees,


### PR DESCRIPTION
Changes:
- when running check power grid with floorplanning each shape really only needs 1 node and not all nodes. This changes to ensure all nodes are merged on a single shape to minimize the total number of nodes (and thus runtime).

Notes:
- on large design, the peak memory before this is ~200GB and takes about 2 hours to run, with this change the same design drops to 20GB and takes about 10 minutes.
- when running IR drop, the floorplanning flag will be changed and network rebuilt, so there should be no functional changes to IR drop.