### PR TITLE
test/orfs/gcd: command line adjustable clock period

### DIFF
--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -12,6 +12,9 @@ orfs_flow(
         "DIE_AREA": "0 0 16.2 16.2",
         "PLACE_DENSITY": "0.35",
         "OPENROAD_HIERARCHICAL": "1",
+        # Demonstrate clock period specified in arguments, useful
+        # for Optuna scripts.
+        "ABC_CLOCK_PERIOD_IN_PS": "310.001",
     },
     sources = {
         "RULES_JSON": [":rules-base.json"],

--- a/test/orfs/gcd/constraint.sdc
+++ b/test/orfs/gcd/constraint.sdc
@@ -2,7 +2,7 @@ current_design gcd
 
 set clk_name core_clock
 set clk_port_name clk
-set clk_period 310
+set clk_period $::env(ABC_CLOCK_PERIOD_IN_PS)
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]


### PR DESCRIPTION
First build:

    bazelisk build test/orfs/gcd:gcd_synth

Observe that clock period is picked up from variable and written out by write_sdc after synthesis, hence no further dependency on ABC_CLOCK_PERIOD_IN_PS variable:

    $ grep create_clock $(bazelisk info bazel-bin)/test/orfs/gcd/results/asap7/gcd/base/1_synth.sdc
    create_clock -name core_clock -period 310.0010 [get_ports {clk}]