### PR TITLE
fix: path for multi-stage built binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY --chmod=775 --chown=user:user etc/docker-entrypoint.sh /usr/local/bin/.
 
 FROM $devImage AS final
 
-COPY --from=builder /OpenROAD/build/src/openroad /usr/bin/.
+COPY --from=builder /OpenROAD/build/bin/openroad /usr/bin/.
 ENV OPENROAD_EXE=/usr/bin/openroad
 
 RUN <<EOF


### PR DESCRIPTION
Fixes issue from #9150 . As its a one-line fix, merge should be fairly simple