### PR TITLE
odb: fix BumpMapEntry declaration mismatch

### DIFF
--- a/src/odb/include/odb/3dblox.h
+++ b/src/odb/include/odb/3dblox.h
@@ -24,13 +24,14 @@ class Connection;
 class DesignDef;
 class dbChipRegionInst;
 class dbChipInst;
-class BumpMapEntry;
 class dbChipRegion;
 class dbBlock;
 class dbBTerm;
 class dbInst;
 class dbTech;
 class dbLib;
+
+struct BumpMapEntry;
 
 class ThreeDBlox
 {


### PR DESCRIPTION
src/odb/include/odb/3dblox.h forward declared BumpMapEntry as a class while its definition is a struct. Clang warned about it.
Fixes: #9093 