### PR TITLE
Set current design as associated data for Tcl commands

### DIFF
--- a/src/Design.cc
+++ b/src/Design.cc
@@ -20,6 +20,7 @@
 #include "ord/OpenRoad.hh"
 #include "ord/Tech.h"
 #include "tcl.h"
+#include "tclDecls.h"
 #include "utl/Logger.h"
 
 namespace ord {


### PR DESCRIPTION
This is a fix for a crash that happens when calling initialize_floorplan from python. In a normal OpenROAD run, we associate the design with Tcl_SetAssocData in src/Main.cc but this function is not called if OpenROAD is being used as a library.