### PR TITLE
Changed incorrect yosys command option from --version to -V

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -141,7 +141,7 @@ _install_yosys() {
     local yosys_prefix=${PREFIX:-"/usr/local"}
     local yosys_installed_version="none"
     if _command_exists "yosys"; then
-        yosys_installed_version=$(yosys --version | awk '{print $2}')
+        yosys_installed_version=$(yosys -V | awk '{print $2}')
     fi
 
     local required_version="${YOSYS_VERSION#v}"


### PR DESCRIPTION
This pull request addresses issue #9117 (https://github.com/The-OpenROAD-Project/OpenROAD/issues/9117). Unsure whether test cases are necessary since this is rather straightforward. 