### PR TITLE
test/orfs/gcd: SWAP_ARITH_OPERATORS smoketest

### DIFF
--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -15,6 +15,8 @@ orfs_flow(
         # Demonstrate clock period specified in arguments, useful
         # for Optuna scripts.
         "ABC_CLOCK_PERIOD_IN_PS": "310.001",
+        # Smoketest
+        "SWAP_ARITH_OPERATORS": "1",
     },
     sources = {
         "RULES_JSON": [":rules-base.json"],


### PR DESCRIPTION
ORFS doesn't test out of ORFS folder builds, which we can do here easily and with zero extract running time.
