### PR TITLE
utl: Fix crash for write_db ""

### DIFF
--- a/src/utl/src/ScopedTemporaryFile.cpp
+++ b/src/utl/src/ScopedTemporaryFile.cpp
@@ -68,7 +68,7 @@ OutStreamHandler::OutStreamHandler(const char* filename, bool binary)
     : filename_(filename)
 {
   if (filename_.empty()) {
-    std::runtime_error("filename is empty");
+    throw std::runtime_error("filename is empty");
   }
   tmp_filename_ = generate_unused_filename(filename_);
 


### PR DESCRIPTION
`write_db ""` will crash openroad. In practice this happens for a misconfigured flow in which the command `write_db $output` is used when output is "".