### PR TITLE
fix replace deprecated swig $function by new $action

### DIFF
--- a/src/Exception-py.i
+++ b/src/Exception-py.i
@@ -23,7 +23,7 @@
 #endif
 
 %exception {
-  try { $function }
+  try { $action }
   catch (std::bad_alloc &) {
     fprintf(stderr, "Error: out of memory.");
     abort();

--- a/src/Exception.i
+++ b/src/Exception.i
@@ -25,7 +25,7 @@
 %}
 
 %exception {
-  try { $function }
+  try { $action }
   catch (std::bad_alloc &) {
     fprintf(stderr, "Error: out of memory.");
     abort();


### PR DESCRIPTION
swig 4.4 removed the long deprecated $function, switch to $action instead.