### PR TITLE
Gui: fix division by 0

### DIFF
--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -1690,9 +1690,8 @@ void RenderThread::drawIOPins(Painter& painter,
   const int min_bpin_size = viewer_->options_->isDetailedVisibility()
                                 ? viewer_->fineViewableResolution()
                                 : viewer_->nominalViewableResolution();
-  const int64_t max_lin_bpins = min_bpin_size > 0
-                                    ? bounds.minDXDY() / min_bpin_size
-                                    : bounds.minDXDY();
+  const int64_t max_lin_bpins
+      = min_bpin_size > 0 ? bounds.minDXDY() / min_bpin_size : bounds.minDXDY();
   const int64_t max_bpins
       = std::min(kMaxBPinsPerLayer, max_lin_bpins * max_lin_bpins);
 


### PR DESCRIPTION
Solves issue found by @AcKoucher.

min_bpin_size can be 0, causing OR to crash.
