### PR TITLE
bazel: use stdc++ with LLVM toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -103,6 +103,20 @@ bazel_dep(name = "toolchains_llvm", version = "1.5.0")
 llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     llvm_version = "20.1.8",
+    # OpenROAD Fix: Force GNU libstdc++ on Linux to prevent ABI mismatches.
+    #
+    # Without this, the LLVM toolchain defaults to using LLVM's libc++.
+    # However, OpenROAD links against system libraries (e.g., Tcl, Python,
+    # and Bazel's internal runfiles) that are built against the system's
+    # GNU libstdc++.
+    #
+    # Mixing these two standard libraries creates a "Frankenstein" build where
+    # memory allocated by libstdc++ (e.g., inside a std::string or filebuf)
+    # is erroneously deallocated by libc++, causing "Mismatched free() / delete"
+    # crashes and undefined behavior.
+    stdlib = {
+        "linux": "stdc++",
+    },
 )
 use_repo(llvm, "llvm_toolchain")
 # use_repo(llvm, "llvm_toolchain_llvm") # if you depend on specific tools in scripts

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -3472,7 +3472,7 @@
     "@@toolchains_llvm+//toolchain/extensions:llvm.bzl%llvm": {
       "general": {
         "bzlTransitiveDigest": "i54NfnK6i34XT5yyh16sxeFE2U1s0aiixBtMQYMdAMo=",
-        "usagesDigest": "gn25Ya6Nd2hLxoG8Ksgb9RPzvoiElyTJFM/4We+5U2g=",
+        "usagesDigest": "7G8toF/AW/sk6c9g7opVXD/SzHGpTBj2cBqtMJ8qjWU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -3521,7 +3521,9 @@
               },
               "opt_compile_flags": {},
               "opt_link_flags": {},
-              "stdlib": {},
+              "stdlib": {
+                "linux": "stdc++"
+              },
               "target_settings": {},
               "unfiltered_compile_flags": {},
               "toolchain_roots": {},


### PR DESCRIPTION
fixes lots of new/free/malloc/delete mismatches in valgrind, supposedly.

@maliberty I was trying to see if valgrind would shed some light on an MPL crash. Gemini came up with this, it is outside my area of expertise.

To me this sounds plausible and I thought it was worth sharing.