### PR TITLE
odb: use new/delete consistently instead of mixing in malloc/free

### DIFF
--- a/src/odb/src/db/dbPagedVector.h
+++ b/src/odb/src/db/dbPagedVector.h
@@ -160,15 +160,12 @@ void dbPagedVector<T, P, S>::clear()
 {
   if (pages_) {
     unsigned int i;
-
     for (i = 0; i < page_cnt_; ++i) {
       delete[] pages_[i];
     }
-
     delete[] pages_;
+    pages_ = nullptr;
   }
-
-  pages_ = nullptr;
   page_cnt_ = 0;
   page_tbl_size_ = 0;
   next_idx_ = 0;

--- a/src/odb/src/db/dbTable.hpp
+++ b/src/odb/src/db/dbTable.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <new>
 
 #include "dbCommon.h"
 #include "dbCore.h"
@@ -103,7 +104,7 @@ void dbTable<T, page_size>::clear()
       }
     }
 
-    free(page);
+    operator delete(page);
   }
 
   delete[] pages_;
@@ -164,7 +165,7 @@ template <class T, uint32_t page_size>
 void dbTable<T, page_size>::newPage()
 {
   const uint32_t size = (pageSize() * sizeof(T)) + sizeof(dbObjectPage);
-  dbTablePage* page = (dbTablePage*) safe_malloc(size);
+  dbTablePage* page = (dbTablePage*) operator new(size);
   memset(page, 0, size);
 
   const uint32_t page_id = page_cnt_;
@@ -588,7 +589,7 @@ dbIStream& operator>>(dbIStream& stream, dbTable<T, page_size>& table)
   uint32_t i;
   for (i = 0; i < table.page_cnt_; ++i) {
     uint32_t size = (table.pageSize() * sizeof(T)) + sizeof(dbObjectPage);
-    dbTablePage* page = (dbTablePage*) safe_malloc(size);
+    dbTablePage* page = (dbTablePage*) operator new(size);
     memset(page, 0, size);
     page->page_addr_ = i << table.kPageShift;
     page->table_ = &table;


### PR DESCRIPTION
malloc had to be amended with a wafer thin wrapper to throw an exception, new/delete does this out of the box.

Motivated by valgrind errors