### PR TITLE
fix cmake warning "SCIP::libscip not provided" when finding ortools

### DIFF
--- a/src/gpl/CMakeLists.txt
+++ b/src/gpl/CMakeLists.txt
@@ -8,6 +8,11 @@ include("openroad")
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
+find_package(SCIP REQUIRED)
+if(TARGET libscip AND NOT TARGET SCIP::libscip)
+    add_library(SCIP::libscip ALIAS libscip)
+endif()
+
 find_package(Eigen3 REQUIRED)
 find_package(ortools REQUIRED)
 find_package(LEMON NAMES LEMON lemon REQUIRED)

--- a/src/mpl/CMakeLists.txt
+++ b/src/mpl/CMakeLists.txt
@@ -3,7 +3,10 @@
 
 include("openroad")
 
-
+find_package(SCIP REQUIRED)
+if(TARGET libscip AND NOT TARGET SCIP::libscip)
+    add_library(SCIP::libscip ALIAS libscip)
+endif()
 
 find_package(ortools REQUIRED)
 

--- a/src/par/CMakeLists.txt
+++ b/src/par/CMakeLists.txt
@@ -14,6 +14,11 @@ if (LOAD_CPLEX)
   include_directories(SYSTEM ${CPLEX_INCLUDE_DIRS})
 endif (LOAD_CPLEX)
 
+find_package(SCIP REQUIRED)
+if(TARGET libscip AND NOT TARGET SCIP::libscip)
+    add_library(SCIP::libscip ALIAS libscip)
+endif()
+
 find_package(Threads REQUIRED)
 find_package(ortools REQUIRED)
 

--- a/src/utl/test/cpp/cmake_test_discovery_7d4dd62bcb.json
+++ b/src/utl/test/cpp/cmake_test_discovery_7d4dd62bcb.json
@@ -1,0 +1,17 @@
+{
+  "tests": 1,
+  "name": "AllTests",
+  "testsuites": [
+    {
+      "name": "Utl",
+      "tests": 1,
+      "testsuite": [
+        {
+          "name": "WarningMetrics",
+          "file": "\/Users\/stefanthiede\/OpenROAD-flow-scripts\/tools\/OpenROAD\/src\/utl\/test\/cpp\/TestMetrics.cpp",
+          "line": 14
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
On MacOS homebrew cmake will issue
CMake Warning at /opt/homebrew/opt/or-tools/lib/cmake/ortools/modules/FindSCIP.cmake:49 (message):
  SCIP::libscip not provided
for gpl, mpl and par, google ai suggested to add an alias for libscip to get rid of these warnings.