### PR TITLE
More completely add qt include paths.

### DIFF
--- a/etc/bazel-make-compilation-db.sh
+++ b/etc/bazel-make-compilation-db.sh
@@ -36,7 +36,18 @@ BAZEL_OPTS="${BAZEL_OPTS:--c opt ${BAZEL_REMOTE_MATERIALIZE}}"
 "${BANT}" compile-flags -o compile_flags.txt
 
 # The QT headers are not properly picked up; add them manually.
-for f in bazel-out/../../../external/qt-bazel*/qt_source/qtbase*/build/include/Q* ; do echo "-I$f" ; done >> compile_flags.txt
+for f in bazel-out/../../../external/qt-bazel*/qt_source/qtbase*/build/include \
+  bazel-out/../../../external/qt-bazel*/qt_source/qtbase*/build/include/Q* \
+  bazel-out/../../../external/qt-bazel*/qt_source/qtcharts*/include/QtCharts
+do
+  echo "-I$f"
+  # There is a bug in clangd that does not properly follow symbolic links.
+  # So expand them here as well for interactive use.
+  echo "-I$(realpath $f)"
+done >> compile_flags.txt
+
+# Qt include files check for this
+echo '-fPIC' >> compile_flags.txt
 
 # Main.cc attemps to access this one.
 echo '-DBUILD_TYPE="opt"' >> compile_flags.txt


### PR DESCRIPTION
Also, resolve symbolic links, as there is a bug in clangd that does not follow them correctly...