### PR TITLE
Don't pollute namespace w/ `using utl::Logger;` in header files.

### DIFF
--- a/src/dbSta/include/db_sta/SpefWriter.hh
+++ b/src/dbSta/include/db_sta/SpefWriter.hh
@@ -13,12 +13,10 @@
 
 namespace sta {
 
-using utl::Logger;
-
 class SpefWriter
 {
  public:
-  SpefWriter(Logger* logger,
+  SpefWriter(utl::Logger* logger,
              dbSta* sta,
              std::map<Corner*, std::ostream*>& spef_streams);
   void writeHeader();
@@ -26,7 +24,7 @@ class SpefWriter
   void writeNet(Corner* corner, const Net* net, Parasitic* parasitic);
 
  private:
-  Logger* logger_;
+  utl::Logger* logger_;
   dbSta* sta_;
   dbNetwork* network_;
   Parasitics* parasitics_;

--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -18,14 +18,9 @@
 #include "sta/Liberty.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
-
-namespace utl {
-class Logger;
-}
+#include "utl/Logger.h"
 
 namespace sta {
-
-using utl::Logger;
 
 using odb::dbBlock;
 using odb::dbBTerm;
@@ -75,7 +70,7 @@ class dbNetwork : public ConcreteNetwork
   dbNetwork();
   ~dbNetwork() override;
 
-  void init(dbDatabase* db, Logger* logger);
+  void init(dbDatabase* db, utl::Logger* logger);
   void setBlock(dbBlock* block);
   void clear() override;
   CellPortIterator* portIterator(const Cell* cell) const override;
@@ -474,7 +469,7 @@ class dbNetwork : public ConcreteNetwork
   void dumpNetDrvrPinMap() const;
 
   dbDatabase* db_ = nullptr;
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbBlock* block_ = nullptr;
   Instance* top_instance_;
   Cell* top_cell_ = nullptr;

--- a/src/dbSta/include/db_sta/dbSta.hh
+++ b/src/dbSta/include/db_sta/dbSta.hh
@@ -18,13 +18,10 @@
 #include "sta/Liberty.hh"
 #include "sta/MinMax.hh"
 #include "sta/Sta.hh"
+#include "utl/Logger.h"
 
 namespace ord {
 class OpenRoad;
-}
-
-namespace utl {
-class Logger;
 }
 
 namespace sta {
@@ -86,8 +83,6 @@ class dbStaReport;
 class dbStaCbk;
 class PatternMatch;
 class TestCell;
-
-using utl::Logger;
 
 using odb::dbBlock;
 using odb::dbBlockCallBackObj;
@@ -259,7 +254,7 @@ class dbSta : public Sta, public odb::dbDatabaseObserver
                    LibertyCell* to_lib_cell) override;
 
   dbDatabase* db_ = nullptr;
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
 
   dbNetwork* db_network_ = nullptr;
   dbStaReport* db_report_ = nullptr;

--- a/src/dbSta/src/SpefWriter.cc
+++ b/src/dbSta/src/SpefWriter.cc
@@ -25,7 +25,7 @@ namespace sta {
 using std::map;
 using utl::ORD;
 
-SpefWriter::SpefWriter(Logger* logger,
+SpefWriter::SpefWriter(utl::Logger* logger,
                        dbSta* sta,
                        std::map<Corner*, std::ostream*>& spef_streams)
     : logger_(logger),

--- a/src/dbSta/src/dbEditHierarchy.hh
+++ b/src/dbSta/src/dbEditHierarchy.hh
@@ -11,14 +11,9 @@
 
 #include "odb/db.h"
 #include "odb/dbTypes.h"
-
-namespace utl {
-class Logger;
-}
+#include "utl/Logger.h"
 
 namespace sta {
-
-using utl::Logger;
 
 using odb::dbIoType;
 using odb::dbITerm;
@@ -37,7 +32,7 @@ class Pin;
 class dbEditHierarchy
 {
  public:
-  dbEditHierarchy(dbNetwork* db_network, Logger* logger)
+  dbEditHierarchy(dbNetwork* db_network, utl::Logger* logger)
       : db_network_(db_network), logger_(logger)
   {
   }
@@ -45,7 +40,7 @@ class dbEditHierarchy
   dbEditHierarchy(const dbEditHierarchy&) = delete;
   dbEditHierarchy& operator=(const dbEditHierarchy&) = delete;
 
-  void setLogger(Logger* logger) { logger_ = logger; }
+  void setLogger(utl::Logger* logger) { logger_ = logger; }
   void getParentHierarchy(dbModule* start_module,
                           std::vector<dbModule*>& parent_hierarchy) const;
   dbModule* findLowestCommonModule(std::vector<dbModule*>& itree1,
@@ -135,7 +130,7 @@ class dbEditHierarchy
 
  private:
   dbNetwork* db_network_ = nullptr;
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
 };
 
 }  // namespace sta

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -718,7 +718,7 @@ dbNetwork::dbNetwork()
 
 dbNetwork::~dbNetwork() = default;
 
-void dbNetwork::init(dbDatabase* db, Logger* logger)
+void dbNetwork::init(dbDatabase* db, utl::Logger* logger)
 {
   db_ = db;
   logger_ = logger;
@@ -3927,20 +3927,20 @@ class ModDbNetAssociation : public PinVisitor
 {
  public:
   ModDbNetAssociation(dbNetwork* nwk,
-                      Logger* logger,
+                      utl::Logger* logger,
                       dbNet* new_flat_net,
                       dbNet* orig_flat_net);
   void operator()(const Pin* pin) override;
 
  private:
-  Logger* logger_;
+  utl::Logger* logger_;
   dbNetwork* db_network_;
   dbNet* new_flat_net_;
   dbNet* orig_flat_net_;
 };
 
 ModDbNetAssociation::ModDbNetAssociation(dbNetwork* nwk,
-                                         Logger* logger,
+                                         utl::Logger* logger,
                                          dbNet* new_flat_net,
                                          dbNet* orig_flat_net)
     : logger_(logger),
@@ -4138,21 +4138,21 @@ class PinModDbNetConnection : public PinVisitor
 {
  public:
   PinModDbNetConnection(const dbNetwork* nwk,
-                        Logger* logger,
+                        utl::Logger* logger,
                         const Net* net_to_search);
   void operator()(const Pin* pin) override;
   dbNet* getNet() const { return dbnet_; }
 
  private:
   dbNet* dbnet_;
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   bool db_net_search_ = false;
   const Net* search_net_;
   const dbNetwork* db_network_;
 };
 
 PinModDbNetConnection::PinModDbNetConnection(const dbNetwork* nwk,
-                                             Logger* logger,
+                                             utl::Logger* logger,
                                              const Net* net_to_search)
     : db_network_(nwk)
 {

--- a/src/est/src/EstimateParasitics.i
+++ b/src/est/src/EstimateParasitics.i
@@ -19,12 +19,9 @@
 
 namespace ord {
 // Defined in OpenRoad.i
-est::EstimateParasitics *
-getEstimateParasitics();
-utl::Logger*
-getLogger();
-void
-ensureLinked();
+est::EstimateParasitics* getEstimateParasitics();
+utl::Logger* getLogger();
+void ensureLinked();
 }
 
 namespace sta {
@@ -95,7 +92,7 @@ using est::ParasiticsSrc;
   else if (stringEq(arg, "detailed_routing"))
     $1 = ParasiticsSrc::detailed_routing;
   else {
-    Logger* logger = ord::getLogger();
+    utl::Logger* logger = ord::getLogger();
     try {
       logger->error(utl::EST, 19, "Unknown parasitics source '{}'.", arg);
     } catch (const std::exception &e) {
@@ -264,7 +261,7 @@ estimate_parasitics_cmd(ParasiticsSrc src, const char* path)
         if (file->is_open()) {
           spef_files[corner] = std::move(file);
         } else {
-          Logger* logger = ord::getLogger();
+          utl::Logger* logger = ord::getLogger();
           logger->error(utl::EST,
                         7,
                         "Can't open file " + file_path);

--- a/src/ifp/include/ifp/InitFloorplan.hh
+++ b/src/ifp/include/ifp/InitFloorplan.hh
@@ -13,10 +13,7 @@
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
-
-namespace utl {
-class Logger;
-}
+#include "utl/Logger.h"
 
 namespace sta {
 class dbNetwork;
@@ -26,7 +23,6 @@ class Report;
 namespace ifp {
 
 using sta::dbNetwork;
-using utl::Logger;
 
 enum class RowParity
 {
@@ -41,7 +37,9 @@ class InitFloorplan
   void makePolygonDie(const odb::Polygon& polygon);
 
   InitFloorplan() = default;  // only for swig
-  InitFloorplan(odb::dbBlock* block, Logger* logger, sta::dbNetwork* network);
+  InitFloorplan(odb::dbBlock* block,
+                utl::Logger* logger,
+                sta::dbNetwork* network);
 
   // utilization is in [0, 100]%
   // The base_site determines the single-height rows.  For hybrid rows it is
@@ -178,7 +176,7 @@ class InitFloorplan
                               const std::set<odb::dbSite*>& flipped_sites);
 
   odb::dbBlock* block_{nullptr};
-  Logger* logger_{nullptr};
+  utl::Logger* logger_{nullptr};
   sta::dbNetwork* network_{nullptr};
 
   // this is a set of sets of all constructed site ids.

--- a/src/pdn/include/pdn/PdnGen.hh
+++ b/src/pdn/include/pdn/PdnGen.hh
@@ -26,8 +26,6 @@ using odb::dbMTerm;
 using odb::dbNet;
 using odb::dbRegion;
 
-using utl::Logger;
-
 enum ExtensionMode
 {
   CORE,
@@ -58,7 +56,7 @@ class SRoute;
 class PdnGen
 {
  public:
-  PdnGen(dbDatabase* db, Logger* logger);
+  PdnGen(dbDatabase* db, utl::Logger* logger);
   ~PdnGen();
 
   void reset();

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -59,8 +59,6 @@ class SpefWriter;
 
 namespace rsz {
 
-using utl::Logger;
-
 using odb::dbBlock;
 using odb::dbDatabase;
 using odb::dbInst;
@@ -244,7 +242,7 @@ class OdbCallBack;
 class Resizer : public dbStaState, public dbNetworkObserver
 {
  public:
-  Resizer(Logger* logger,
+  Resizer(utl::Logger* logger,
           dbDatabase* db,
           dbSta* sta,
           SteinerTreeBuilder* stt_builder,
@@ -528,7 +526,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   void initBlock();
   void journalBeginTest();
   void journalRestoreTest();
-  Logger* logger() const { return logger_; }
+  utl::Logger* logger() const { return logger_; }
   void eliminateDeadLogic(bool clean_nets);
   std::optional<float> cellLeakage(LibertyCell* cell);
   // For debugging - calls getSwappableCells
@@ -829,7 +827,7 @@ class Resizer : public dbStaState, public dbNetworkObserver
   LibertyCellSet dont_use_;
   double max_area_ = 0.0;
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   est::EstimateParasitics* estimate_parasitics_ = nullptr;
   SteinerTreeBuilder* stt_builder_ = nullptr;
   GlobalRouter* global_router_ = nullptr;

--- a/src/rsz/src/BaseMove.hh
+++ b/src/rsz/src/BaseMove.hh
@@ -54,8 +54,6 @@ using odb::dbMaster;
 using odb::dbMaster;
 using odb::Point;
 
-using utl::Logger;
-
 using sta::ArcDelay;
 using sta::Cell;
 using sta::Corner;
@@ -144,7 +142,7 @@ class BaseMove : public sta::dbStaState
  protected:
   Resizer* resizer_;
   est::EstimateParasitics* estimate_parasitics_;
-  Logger* logger_;
+  utl::Logger* logger_;
   Network* network_;
   dbNetwork* db_network_;
   dbSta* sta_;

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -508,7 +508,7 @@ static BufferedNetPtr makeBufferedNetFromTree(
     const Corner* corner,
     const Resizer* resizer,
     const est::EstimateParasitics* estimate_parasitics,
-    Logger* logger,
+    utl::Logger* logger,
     const Network* network)
 {
   BufferedNetPtr bnet = nullptr;
@@ -632,7 +632,7 @@ static BufferedNetPtr makeBufferedNetFromTree2(
     const Corner* corner,
     const Resizer* resizer,
     const est::EstimateParasitics* estimate_parasitics,
-    Logger* logger,
+    utl::Logger* logger,
     const Network* network,
     std::map<Point, std::vector<BufferedNetPtr>>& sink_map)
 {
@@ -790,7 +790,7 @@ static BufferedNetPtr makeBufferedNet(
     const Corner* corner,
     const Resizer* resizer,
     const est::EstimateParasitics* estimate_parasitics,
-    Logger* logger,
+    utl::Logger* logger,
     dbNetwork* db_network,
     RoutePtSet& visited)
 {

--- a/src/rsz/src/BufferedNet.hh
+++ b/src/rsz/src/BufferedNet.hh
@@ -26,8 +26,6 @@ class EstimateParasitics;
 
 namespace rsz {
 
-using utl::Logger;
-
 using odb::Point;
 
 using sta::Corner;

--- a/src/rsz/src/PreChecks.hh
+++ b/src/rsz/src/PreChecks.hh
@@ -3,11 +3,11 @@
 
 #pragma once
 #include "db_sta/dbSta.hh"
+#include "utl/Logger.h"
 
 namespace rsz {
 
 class Resizer;
-using utl::Logger;
 using dbSta = sta::dbSta;
 
 class PreChecks
@@ -18,7 +18,7 @@ class PreChecks
   void checkCapLimit(const sta::Pin* drvr_pin);
 
  private:
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbSta* sta_ = nullptr;
   Resizer* resizer_;
 

--- a/src/rsz/src/Rebuffer.cc
+++ b/src/rsz/src/Rebuffer.cc
@@ -1653,7 +1653,7 @@ BnetPtr Rebuffer::importBufferTree(const Pin* drvr_pin, const Corner* corner)
       tree);
 }
 
-static FixedDelay criticalPathDelay(Logger* logger, const BnetPtr& root)
+static FixedDelay criticalPathDelay(utl::Logger* logger, const BnetPtr& root)
 {
   FixedDelay worst_load_slack = FixedDelay::INF;
   visitTree(

--- a/src/rsz/src/Rebuffer.hh
+++ b/src/rsz/src/Rebuffer.hh
@@ -21,14 +21,13 @@
 #include "sta/MinMax.hh"
 #include "sta/Path.hh"
 #include "sta/Transition.hh"
+#include "utl/Logger.h"
 
 namespace est {
 class EstimateParasitics;
 }
 
 namespace rsz {
-
-using utl::Logger;
 
 using odb::Point;
 using sta::Corner;
@@ -147,7 +146,7 @@ class Rebuffer : public sta::dbStaState
   bool hasTopLevelOutputPort(Net* net);
   int rebufferPin(const Pin* drvr_pin);
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbNetwork* db_network_ = nullptr;
   Resizer* resizer_ = nullptr;
   est::EstimateParasitics* estimate_parasitics_ = nullptr;

--- a/src/rsz/src/RecoverPower.hh
+++ b/src/rsz/src/RecoverPower.hh
@@ -30,8 +30,6 @@ namespace rsz {
 
 class Resizer;
 
-using utl::Logger;
-
 using sta::Corner;
 using sta::dbNetwork;
 using sta::dbSta;
@@ -94,7 +92,7 @@ class RecoverPower : public sta::dbStaState
 
   void printProgress(int iteration, bool force, bool end) const;
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbNetwork* db_network_ = nullptr;
   Resizer* resizer_;
   est::EstimateParasitics* estimate_parasitics_;

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -246,7 +246,7 @@ class RepairDesign : dbStaState
 
   void computeSlewRCFactor();
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbNetwork* db_network_ = nullptr;
   std::unique_ptr<PreChecks> pre_checks_ = nullptr;
   Resizer* resizer_;

--- a/src/rsz/src/RepairHold.hh
+++ b/src/rsz/src/RepairHold.hh
@@ -25,8 +25,6 @@ namespace rsz {
 
 class Resizer;
 
-using utl::Logger;
-
 using odb::Point;
 
 using sta::dbNetwork;
@@ -120,7 +118,7 @@ class RepairHold : public sta::dbStaState
 
   void printProgress(int iteration, bool force, bool end) const;
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbNetwork* db_network_ = nullptr;
   Resizer* resizer_;
   est::EstimateParasitics* estimate_parasitics_;

--- a/src/rsz/src/RepairSetup.hh
+++ b/src/rsz/src/RepairSetup.hh
@@ -32,7 +32,6 @@ class RemoveBuffer;
 class BaseMove;
 
 using odb::Point;
-using utl::Logger;
 
 using sta::Corner;
 using sta::dbNetwork;
@@ -146,7 +145,7 @@ class RepairSetup : public sta::dbStaState
                          const OptoParams& params);
   Slack getInstanceSlack(Instance* inst);
 
-  Logger* logger_ = nullptr;
+  utl::Logger* logger_ = nullptr;
   dbNetwork* db_network_ = nullptr;
   Resizer* resizer_;
   est::EstimateParasitics* estimate_parasitics_;

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -150,7 +150,7 @@ using sta::CLOCK;
 using sta::LeakagePower;
 using sta::LeakagePowerSeq;
 
-Resizer::Resizer(Logger* logger,
+Resizer::Resizer(utl::Logger* logger,
                  dbDatabase* db,
                  dbSta* sta,
                  SteinerTreeBuilder* stt_builder,

--- a/src/rsz/src/SwapArithModules.hh
+++ b/src/rsz/src/SwapArithModules.hh
@@ -29,10 +29,6 @@ class Pin;
 class PinSet;
 }  // namespace sta
 
-namespace utl {
-class Logger;
-}
-
 namespace rsz {
 
 class Resizer;
@@ -40,7 +36,6 @@ class Resizer;
 using odb::dbModInst;
 using sta::Instance;
 using sta::Path;
-using utl::Logger;
 
 class SwapArithModules : public sta::dbStaState
 {
@@ -76,7 +71,7 @@ class SwapArithModules : public sta::dbStaState
   // Member variables
   Resizer* resizer_;
   dbNetwork* db_network_{nullptr};
-  Logger* logger_{nullptr};
+  utl::Logger* logger_{nullptr};
   const MinMax* min_ = MinMax::min();
   const MinMax* max_ = MinMax::max();
 };


### PR DESCRIPTION
Last time I missed that there are also header files named *.hh ...