### PR TITLE
gpl: Implement momentum resetting in GPL

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2203,6 +2203,27 @@ void NesterovBase::initFillerGCells()
 
 NesterovBase::~NesterovBase() = default;
 
+float NesterovBase::getGradientMomentumStoppingHeuristic() const
+{
+  float dot_product = 0.0f;
+
+  // Iterate over all instances (standard cells and macros) in this region
+  for (int i = 0; i < nb_gcells_.size(); i++) {
+    FloatPoint grad = curSLPSumGrads_[i];
+
+    // The Step (Next Coordinate - Prev Coordinate)
+    // curSLPCoordi_ holds the current position (x^k)
+    // prevSLPCoordi_ holds the previous position (x^{k-1})
+    FloatPoint step;
+    step.x = curSLPCoordi_[i].x - prevSLPCoordi_[i].x;
+    step.y = curSLPCoordi_[i].y - prevSLPCoordi_[i].y;
+
+    dot_product += (grad.x * step.x) + (grad.y * step.y);
+  }
+
+  return dot_product;
+}
+
 // gcell update
 void NesterovBase::updateGCellCenterLocation(
     const std::vector<FloatPoint>& coordis)

--- a/src/gpl/src/nesterovBase.h
+++ b/src/gpl/src/nesterovBase.h
@@ -954,6 +954,13 @@ class NesterovBase
   float getBaseWireLengthCoef() const { return baseWireLengthCoef_; }
   float getDensityPenalty() const { return densityPenalty_; }
 
+  // Calculate the dot product of the gradient with the step vector.
+  // This is used to calculate the reset condition. If this value
+  // is greater than 0 you should zero out your momentum for the
+  // gradient.
+  // See https://arxiv.org/abs/1204.3982
+  float getGradientMomentumStoppingHeuristic() const;
+
   float getWireLengthGradSum() const { return wireLengthGradSum_; }
   float getDensityGradSum() const { return densityGradSum_; }
 

--- a/src/gpl/src/nesterovPlace.h
+++ b/src/gpl/src/nesterovPlace.h
@@ -120,6 +120,7 @@ class NesterovPlace
   void reportResults(int nesterov_iter,
                      int64_t original_area,
                      int64_t td_accumulated_delta_area);
+  bool shouldResetMomentumTerm(int nesterov_iter);
 
   std::shared_ptr<PlacerBaseCommon> pbc_;
   std::shared_ptr<NesterovBaseCommon> nbc_;


### PR DESCRIPTION
We noticed on our internal designs with high congestion or density GPL has a hard time converging on 0.1 overflow. What instead happens is that the overflow oscillates around some value until it runs out of iterations.

After implementing this paper https://arxiv.org/abs/1204.3982 we see much better convergance and PPA.