### PR TITLE
gpl: fix issues with debug mode for initial place

### DIFF
--- a/src/gpl/src/graphicsImpl.cpp
+++ b/src/gpl/src/graphicsImpl.cpp
@@ -479,6 +479,10 @@ void GraphicsImpl::drawMBFF(gui::Painter& painter)
 
 void GraphicsImpl::drawObjects(gui::Painter& painter)
 {
+  if (!enabled()) {
+    return;
+  }
+
   switch (mode_) {
     case Mbff:
       drawMBFF(painter);

--- a/src/gpl/src/initialPlace.cpp
+++ b/src/gpl/src/initialPlace.cpp
@@ -50,12 +50,11 @@ void InitialPlace::doBicgstabPlace(int threads)
 {
   ResidualError error;
 
-  // Initial place only uses graphics if debug is enabled
-  const bool graphics_enabled
-      = ipVars_.debug && graphics_ && graphics_->enabled();
-
+  if (graphics_) {
+    graphics_->setDebugOn(ipVars_.debug);
+  }
+  const bool graphics_enabled = graphics_ && graphics_->enabled();
   if (graphics_enabled) {
-    graphics_->setDebugOn(true);
     graphics_->debugForInitialPlace(pbc_, pbVec_);
   }
 
@@ -117,6 +116,8 @@ void InitialPlace::doBicgstabPlace(int threads)
 
   if (graphics_enabled) {
     graphics_->gifEnd(gif_key_);
+    graphics_->setDebugOn(false);
+    graphics_->cellPlot(false);
   }
 }
 


### PR DESCRIPTION
Previously debug mode for initial place wasn't working. Also, it was leaving residue on the gui even after finishing initial place.