### PR TITLE
IWYU: add missing includes for files using symbols from these.

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -34,6 +34,7 @@
 #include "TreeBuilder.h"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "est/EstimateParasitics.h"
 #include "odb/db.h"
 #include "odb/dbSet.h"
 #include "odb/dbShape.h"

--- a/src/dft/src/utils/Utils.hh
+++ b/src/dft/src/utils/Utils.hh
@@ -10,6 +10,7 @@
 
 #include "db_sta/dbSta.hh"
 #include "odb/db.h"
+#include "sta/Clock.hh"
 #include "sta/Liberty.hh"
 #include "utl/Logger.h"
 

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -15,6 +15,7 @@
 #include <utility>
 #include <vector>
 
+#include "est/EstimateParasitics.h"
 #include "est/SteinerTree.h"
 #include "grt/GRoute.h"
 #include "odb/db.h"

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "BufferedNet.hh"
+#include "PreChecks.hh"
 #include "ResizerObserver.hh"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
@@ -26,6 +27,7 @@
 #include "odb/geom.h"
 #include "rsz/Resizer.hh"
 #include "sta/ClkNetwork.hh"
+#include "sta/Clock.hh"
 #include "sta/Corner.hh"
 #include "sta/DcalcAnalysisPt.hh"
 #include "sta/Delay.hh"

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -10,6 +10,7 @@
 #include "PreChecks.hh"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "est/EstimateParasitics.h"
 #include "odb/geom.h"
 #include "rsz/Resizer.hh"
 #include "sta/Corner.hh"


### PR DESCRIPTION
Adressing some clang-tidy `[misc-include-cleaner]` diagnostics.

Breakdown

```
src/cts/src/TritonCTS.cpp:               #include "est/EstimateParasitics.h" for est::ParasiticsSrc
src/dft/src/utils/Utils.hh:              #include "sta/Clock.hh" for sta::Clock
src/rsz/src/BufferedNet.cc:              #include "est/EstimateParasitics.h" for est::ParasiticsSrc
src/rsz/src/RepairDesign.cc:             #include "PreChecks.hh" for rsz::PreChecks
src/rsz/src/RepairDesign.cc:             #include "sta/Clock.hh" for sta::Clock
src/rsz/src/RepairDesign.hh:             #include "est/EstimateParasitics.h" for est::ParasiticsSrc
```