### PR TITLE
odb: add min area parsing to implants

### DIFF
--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -747,6 +747,13 @@ void lefinReader::layer(LefParser::lefiLayer* layer)
       } else {
         supported = false;
       }
+    } else if (type.getValue() == dbTechLayerType::IMPLANT) {
+      if (!strcmp(layer->propName(iii), "LEF58_AREA")) {
+        lefTechLayerAreaRuleParser parser(this);
+        parser.parse(layer->propValue(iii), l, incomplete_props_);
+      } else {
+        supported = false;
+      }
     } else {
       supported = false;
     }


### PR DESCRIPTION
Adds:
- MINAREA to implants, no functional changes, just ensures this property get added to the database.