### PR TITLE
Add additional flags needed by clangd/clang-tidy to understand code.

### DIFF
--- a/etc/bazel-make-compilation-db.sh
+++ b/etc/bazel-make-compilation-db.sh
@@ -49,8 +49,16 @@ done >> compile_flags.txt
 # Qt include files check for this
 echo '-fPIC' >> compile_flags.txt
 
-# Main.cc attemps to access this one.
-echo '-DBUILD_TYPE="opt"' >> compile_flags.txt
+# Since we don't do per-file define extraction in compile_flag.txt,
+# add them here globally
+cat >> compile_flags.txt <<EOF
+-DABC_USE_STDINT_H=1
+-DABC_NAMESPACE=abc
+-DGPU=false
+-DBUILD_TYPE="opt"
+-DBUILD_PYTHON=false
+-DBUILD_GUI=true
+EOF
 
 # If there are two styles of comp-dbs, tools might have issues. Warn user.
 if [ -r compile_commands.json ]; then

--- a/src/cgt/src/ClockGating.cpp
+++ b/src/cgt/src/ClockGating.cpp
@@ -3,6 +3,8 @@
 
 #include "cgt/ClockGating.h"
 
+#include <string.h>  // NOLINT(modernize-deprecated-headers): for strdup()
+
 #include <algorithm>
 #include <cassert>
 #include <cstdio>

--- a/src/cut/src/abc_library_factory.cpp
+++ b/src/cut/src/abc_library_factory.cpp
@@ -3,6 +3,8 @@
 
 #include "cut/abc_library_factory.h"
 
+#include <string.h>  // NOLINT(modernize-deprecated-headers): for strdup()
+
 #include <cmath>
 #include <cstring>
 #include <optional>
@@ -12,6 +14,8 @@
 
 #include "db_sta/dbSta.hh"
 #include "rsz/Resizer.hh"
+#include "sta/TimingArc.hh"
+#include "sta/TimingModel.hh"
 #include "utl/Logger.h"
 // Poor include definitions in ABC
 // clang-format off

--- a/src/cut/src/logic_cut.cpp
+++ b/src/cut/src/logic_cut.cpp
@@ -3,6 +3,8 @@
 
 #include "cut/logic_cut.h"
 
+#include <string.h>  // NOLINT(modernize-deprecated-headers): for strdup()
+
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>

--- a/src/cut/test/cpp/TestAbc.cc
+++ b/src/cut/test/cpp/TestAbc.cc
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2023-2025, The OpenROAD Authors
 
+#include <string.h>  // NOLINT(modernize-deprecated-headers): for strdup()
 #include <unistd.h>
 
 #include <array>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring>
-#include <filesystem>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <set>
 #include <string>
@@ -26,8 +25,6 @@
 #include "db_sta/dbSta.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "map/mio/mio.h"
-#include "map/scl/sclLib.h"
 #include "odb/db.h"
 #include "odb/dbSet.h"
 #include "odb/lefin.h"
@@ -39,7 +36,6 @@
 #include "sta/Units.hh"
 #include "sta/VerilogReader.hh"
 #include "tst/fixture.h"
-#include "utl/Logger.h"
 #include "utl/deleter.h"
 #include "utl/unique_name.h"
 

--- a/src/rmp/src/Restructure.cpp
+++ b/src/rmp/src/Restructure.cpp
@@ -33,6 +33,7 @@
 #include "sta/Graph.hh"
 #include "sta/Liberty.hh"
 #include "sta/NetworkClass.hh"
+#include "sta/Path.hh"
 #include "sta/PathEnd.hh"
 #include "sta/PathExpanded.hh"
 #include "sta/PatternMatch.hh"

--- a/src/rmp/src/annealing_strategy.cpp
+++ b/src/rmp/src/annealing_strategy.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdio>
+#include <utility>
 #include <vector>
 
 #include "aig/gia/gia.h"

--- a/src/rmp/src/annealing_strategy.h
+++ b/src/rmp/src/annealing_strategy.h
@@ -5,8 +5,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <optional>
 #include <random>
+#include <vector>
 
 #include "cut/abc_library_factory.h"
 #include "db_sta/dbSta.hh"
@@ -14,6 +16,7 @@
 #include "rsz/Resizer.hh"
 #include "sta/Corner.hh"
 #include "sta/Delay.hh"
+#include "sta/Graph.hh"
 #include "utl/Logger.h"
 #include "utl/unique_name.h"
 

--- a/src/rmp/src/delay_optimization_strategy.cpp
+++ b/src/rmp/src/delay_optimization_strategy.cpp
@@ -3,6 +3,8 @@
 
 #include "delay_optimization_strategy.h"
 
+#include <string.h>  // NOLINT(modernize-deprecated-headers): for strdup()
+
 #include <cstring>
 #include <mutex>
 

--- a/src/rmp/src/utils.cpp
+++ b/src/rmp/src/utils.cpp
@@ -14,6 +14,8 @@
 #include "db_sta/dbSta.hh"
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
+#include "sta/Graph.hh"
+#include "sta/MinMax.hh"
 #include "sta/PortDirection.hh"
 #include "utl/deleter.h"
 

--- a/src/rmp/src/utils.h
+++ b/src/rmp/src/utils.h
@@ -4,12 +4,14 @@
 #pragma once
 
 #include <random>
+#include <vector>
 
 #include "base/abc/abc.h"
 #include "db_sta/dbSta.hh"
 #include "resynthesis_strategy.h"
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
+#include "sta/Graph.hh"
 #include "utl/Logger.h"
 #include "utl/deleter.h"
 

--- a/src/rmp/src/zero_slack_strategy.cpp
+++ b/src/rmp/src/zero_slack_strategy.cpp
@@ -12,6 +12,7 @@
 #include "db_sta/dbSta.hh"
 #include "delay_optimization_strategy.h"
 #include "rsz/Resizer.hh"
+#include "sta/Graph.hh"
 #include "sta/GraphDelayCalc.hh"
 #include "sta/Search.hh"
 #include "utils.h"


### PR DESCRIPTION
In particualr the missing abc namespace resulted in clang-tidy getting a lot of `clang-diagnostic-errors`

Fix IWYU issues that were now becoming visible.