### PR TITLE
Fix cyclic include of extRCap.h

### DIFF
--- a/src/rcx/include/rcx/grids.h
+++ b/src/rcx/include/rcx/grids.h
@@ -13,7 +13,6 @@
 #include "odb/geom.h"
 #include "rcx/array1.h"
 #include "rcx/box.h"
-#include "rcx/extRCap.h"
 #include "rcx/rcx.h"
 #include "rcx/util.h"
 


### PR DESCRIPTION
Fixes `misc-header-include-cycle` report.