### PR TITLE
Remove cyclic backward include dbTable.inc -> dbTable.h

### DIFF
--- a/src/odb/include/odb/dbMap.h
+++ b/src/odb/include/odb/dbMap.h
@@ -85,4 +85,4 @@ class dbMap
 
 }  // namespace odb
 
-#include "odb/dbMap.inc"
+#include "odb/dbMap.inc"  // IWYU pragma: export

--- a/src/odb/src/db/dbTable.h
+++ b/src/odb/src/db/dbTable.h
@@ -135,4 +135,4 @@ dbOStream& operator<<(dbOStream& stream,
 
 }  // namespace odb
 
-#include "dbTable.inc"
+#include "dbTable.inc"  // IWYU pragma: export

--- a/src/odb/src/db/dbTable.inc
+++ b/src/odb/src/db/dbTable.inc
@@ -12,7 +12,6 @@
 #include "dbCommon.h"
 #include "dbCore.h"
 #include "dbDatabase.h"
-#include "dbTable.h"
 #include "odb/dbId.h"
 #include "odb/dbObject.h"
 #include "odb/dbStream.h"


### PR DESCRIPTION
Also, add IWYU export pragmas to make sure users see the symbols.