### PR TITLE
pad: only collect fixed instances

### DIFF
--- a/src/pad/src/ICeWall.cpp
+++ b/src/pad/src/ICeWall.cpp
@@ -1419,7 +1419,7 @@ std::vector<odb::dbInst*> ICeWall::getPadInstsInRow(odb::dbRow* row) const
   const odb::Rect row_bbox = row->getBBox();
 
   for (auto* inst : block->getInsts()) {
-    if (!inst->isPlaced()) {
+    if (!inst->isFixed()) {
       continue;
     }
 


### PR DESCRIPTION
Changes:
- when collecting pad instances, they need to be fixed, not just placed, otherwise temporary placement results can interfere with pad placement.