### PR TITLE
cts: fix unitilized variables

### DIFF
--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -393,6 +393,8 @@ void TechChar::createFakeEntries(unsigned length, unsigned fakeLength)
             const unsigned delay = seg.getDelay();
             const unsigned inputCap = seg.getInputCap();
             const unsigned inputSlew = seg.getInputSlew();
+            const int wl2FirstBuffer = seg.getInputCap();
+            const int lastWl = seg.getInputSlew();
 
             WireSegment& fakeSeg = createWireSegment(
                 fakeLength, load, outSlew, power, delay, inputCap, inputSlew);
@@ -401,6 +403,8 @@ void TechChar::createFakeEntries(unsigned length, unsigned fakeLength)
               fakeSeg.addBuffer(seg.getBufferLocation(buf));
               fakeSeg.addBufferMaster(seg.getBufferMaster(buf));
             }
+            fakeSeg.setWl2FirstBuffer(wl2FirstBuffer);
+            fakeSeg.setLastWl(lastWl);
           });
     }
   }

--- a/src/cts/src/TechChar.h
+++ b/src/cts/src/TechChar.h
@@ -123,8 +123,8 @@ class WireSegment
 
   std::vector<double> bufferLocations_;
   std::vector<std::string> bufferMasters_;
-  int wl2FirstBuffer_;
-  int lastWl_;
+  int wl2FirstBuffer_ = 0;
+  int lastWl_ = 0;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Initialize `WireSegment::wl2FirstBuffer_`  and `WireSegment::lastWl_` for fake LUT entries.