### PR TITLE
dpl: eeq initial patch

### DIFF
--- a/src/dpl/include/dpl/Opendp.h
+++ b/src/dpl/include/dpl/Opendp.h
@@ -221,6 +221,9 @@ class Opendp
   void prePlace();
   void prePlaceGroups();
   void place();
+  void fixParity();
+  void eeqSwap(odb::dbInst* db_inst);
+  bool M1Missaligned(Node* cell);
   void placeGroups2();
   void brickPlace1(const Group* group);
   void brickPlace2(const Group* group);

--- a/src/dpl/src/Opendp.cpp
+++ b/src/dpl/src/Opendp.cpp
@@ -133,6 +133,7 @@ void Opendp::detailedPlacement(const int max_displacement_x,
   // Save displacement stats before updating instance DB locations.
   findDisplacementStats();
   updateDbInstLocations();
+  // fixParity();
   if (!placement_failures_.empty()) {
     logger_->info(DPL,
                   34,


### PR DESCRIPTION
Ignore this for now, this is the most draftiests draft I have ever made, I'm opening this in this state only to have the PR to link to.

### The EEQ Feature
Some PDKs use the LEF58 EEQ Feature. Essentially multiple equivalent LEFs of the same cells in the same sizing are provided. Each one has a different alignment with the tracks of metal:
<img width="430" height="251" alt="Outlook-vfm5bwxw" src="https://github.com/user-attachments/assets/90e3a567-0e15-42a6-b914-9aa6b4711991" />
 This essentially ensures that no matter where the instance is placed, if there are default you have a LEF that has all pins aligned in tracks, so every access is guaranteed to be on grid.
### This Patch
This PR contains a VERY simple solution for the EEQ problem used for a specific advanced PDK. In this case misalignment can only happen at the M1 tracks and it is possible to determine the correct version only by name. Please do not pay mind to the name of the functions.

I intend on formalizing this PR later to bring it up to standard. Currently the solution is janky.