### PR TITLE
ord: force version to use ``XXQX``

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Get version string in OPENROAD_VERSION
 if(NOT OPENROAD_VERSION)
   include(GetGitRevisionDescription)
-  git_describe(OPENROAD_VERSION --match "v[0-9]*")
+  git_describe(OPENROAD_VERSION --tags --match "[0-9][0-9]Q[0-9]")
   string(FIND ${OPENROAD_VERSION} "NOTFOUND" GIT_DESCRIBE_NOTFOUND)
   if(${GIT_DESCRIBE_NOTFOUND} GREATER -1)
     message(WARNING "OpenROAD git describe failed, using sha1 instead")


### PR DESCRIPTION
This ensures the version openroad uses is the "right" tag format.
If we choose to change the versioning to use the quarterly ones we can fix it here to make sure it picks those correctly.