### PR TITLE
Mark libraries that are used for testing as `testonly=1`

### DIFF
--- a/src/odb/test/cpp/helper/BUILD
+++ b/src/odb/test/cpp/helper/BUILD
@@ -9,6 +9,7 @@ package(
 
 cc_library(
     name = "helper",
+    testonly = 1,
     srcs = [
         "helper.cpp",
     ],

--- a/src/tst/BUILD
+++ b/src/tst/BUILD
@@ -10,6 +10,7 @@ package(
 
 cc_library(
     name = "nangate45_fixture",
+    testonly = 1,
     hdrs = ["include/tst/nangate45_fixture.h"],
     data = [
         "//test:nangate45_data",
@@ -21,6 +22,7 @@ cc_library(
 
 cc_library(
     name = "sky130_fixture",
+    testonly = 1,
     hdrs = ["include/tst/sky130_fixture.h"],
     data = [
         "//test:sky130hd_data",
@@ -32,6 +34,7 @@ cc_library(
 
 cc_library(
     name = "tst",
+    testonly = 1,
     srcs = [
         "src/fixture.cpp",
     ],
@@ -56,6 +59,7 @@ cc_library(
 
 cc_library(
     name = "integrated_fixture",
+    testonly = 1,
     srcs = ["src/IntegratedFixture.cpp"],
     hdrs = ["include/tst/IntegratedFixture.h"],
     data = [

--- a/src/tst/src/IntegratedFixture.cpp
+++ b/src/tst/src/IntegratedFixture.cpp
@@ -3,8 +3,6 @@
 
 #include "tst/IntegratedFixture.h"
 
-#include <gtest/gtest.h>
-
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -13,6 +11,7 @@
 
 #include "db_sta/dbReadVerilog.hh"
 #include "db_sta/dbSta.hh"
+#include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "sta/Clock.hh"

--- a/test/orfs/ram_8x7/ram_8x7_sim.cpp
+++ b/test/orfs/ram_8x7/ram_8x7_sim.cpp
@@ -1,7 +1,7 @@
-#include <gtest/gtest.h>
-
 #include <cstdlib>
 #include <string>
+
+#include "gtest/gtest.h"
 
 // NOLINTNEXTLINE
 #include "Vram_8x7.h"


### PR DESCRIPTION
That prevents that we accidentally have (possibly less performant) code only to be used in tests (and depending on `gtest`) end up in final binaries.

While at it, fix the vendored include for gtest from `<>` to `""`.