### PR TITLE
IWYU: fix some missing headers for symbols in abc-lib

### DIFF
--- a/src/cgt/src/ClockGating.cpp
+++ b/src/cgt/src/ClockGating.cpp
@@ -31,6 +31,7 @@
 #include "cut/logic_extractor.h"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "map/mio/mio.h"
 #include "odb/db.h"
 #include "sta/Bfs.hh"
 #include "sta/ClkNetwork.hh"

--- a/src/cut/src/abc_library_factory.cpp
+++ b/src/cut/src/abc_library_factory.cpp
@@ -13,6 +13,11 @@
 #include <vector>
 
 #include "db_sta/dbSta.hh"
+#include "misc/util/abc_global.h"
+#include "misc/vec/vecFlt.h"
+#include "misc/vec/vecInt.h"
+#include "misc/vec/vecPtr.h"
+#include "misc/vec/vecWrd.h"
 #include "rsz/Resizer.hh"
 #include "sta/TimingArc.hh"
 #include "sta/TimingModel.hh"

--- a/src/cut/src/logic_cut.cpp
+++ b/src/cut/src/logic_cut.cpp
@@ -20,6 +20,7 @@
 #include "db_sta/dbNetwork.hh"
 #include "map/mio/mio.h"
 #include "map/mio/mioInt.h"
+#include "map/scl/sclLib.h"
 #include "sta/Liberty.hh"
 #include "sta/NetworkClass.hh"
 #include "utl/Logger.h"

--- a/src/cut/test/cpp/TestAbc.cc
+++ b/src/cut/test/cpp/TestAbc.cc
@@ -25,6 +25,8 @@
 #include "db_sta/dbSta.hh"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "map/mio/mio.h"
+#include "map/scl/sclLib.h"
 #include "odb/db.h"
 #include "odb/dbSet.h"
 #include "odb/lefin.h"

--- a/src/rmp/src/annealing_strategy.cpp
+++ b/src/rmp/src/annealing_strategy.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "aig/aig/aig.h"
 #include "aig/gia/gia.h"
 #include "aig/gia/giaAig.h"
 #include "base/abc/abc.h"
@@ -22,6 +23,8 @@
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "map/if/if.h"
+#include "map/mio/mio.h"
+#include "map/scl/sclLib.h"
 #include "map/scl/sclSize.h"
 #include "misc/vec/vecPtr.h"
 #include "odb/db.h"

--- a/src/rmp/src/annealing_strategy.h
+++ b/src/rmp/src/annealing_strategy.h
@@ -10,6 +10,7 @@
 #include <random>
 #include <vector>
 
+#include "aig/gia/gia.h"
 #include "cut/abc_library_factory.h"
 #include "db_sta/dbSta.hh"
 #include "resynthesis_strategy.h"

--- a/src/rmp/src/zero_slack_strategy.cpp
+++ b/src/rmp/src/zero_slack_strategy.cpp
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include "base/abc/abc.h"
 #include "cut/abc_library_factory.h"
 #include "cut/logic_cut.h"
 #include "cut/logic_extractor.h"


### PR DESCRIPTION
Breakdown:

```
src/cgt/src/ClockGating.cpp:             #include "map/mio/mio.h" for abc::Mio_Library_t
src/cut/src/abc_library_factory.cpp:     #include "misc/util/abc_global.h" for abc::word
src/cut/src/abc_library_factory.cpp:     #include "misc/vec/vecFlt.h" for abc::Vec_Flt_t
src/cut/src/abc_library_factory.cpp:     #include "misc/vec/vecInt.h" for abc::Vec_Int_t
src/cut/src/abc_library_factory.cpp:     #include "misc/vec/vecPtr.h" for abc::Vec_Ptr_t
src/cut/src/abc_library_factory.cpp:     #include "misc/vec/vecWrd.h" for abc::Vec_Wrd_t
src/cut/src/logic_cut.cpp:               #include "map/scl/sclLib.h" for abc::SC_Cell
src/cut/test/cpp/TestAbc.cc:             #include "map/mio/mio.h" for abc::Mio_Gate_t
src/cut/test/cpp/TestAbc.cc:             #include "map/scl/sclLib.h" for abc::SC_Cell
src/rmp/src/annealing_strategy.cpp:      #include "aig/aig/aig.h" for abc::Aig_Man_t
src/rmp/src/annealing_strategy.cpp:      #include "map/mio/mio.h" for abc::Mio_Library_t
src/rmp/src/annealing_strategy.cpp:      #include "map/scl/sclLib.h" for abc::SC_SizePars
src/rmp/src/annealing_strategy.h:        #include "aig/gia/gia.h" for abc::Gia_Man_t
src/rmp/src/zero_slack_strategy.cpp:     #include "base/abc/abc.h" for abc::Abc_Ntk_t
```