### PR TITLE
IWYU for pdn headers: add missing headers

### DIFF
--- a/src/dpl/src/DecapPlacement.cpp
+++ b/src/dpl/src/DecapPlacement.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2024-2025, The OpenROAD Authors
 
 #include <algorithm>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/dpl/src/infrastructure/architecture.cxx
+++ b/src/dpl/src/infrastructure/architecture.cxx
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <functional>
 #include <limits>
 #include <stack>
 #include <utility>

--- a/src/odb/include/odb/dbId.h
+++ b/src/odb/include/odb/dbId.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 
 #include "odb/dbStream.h"
 

--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -23,10 +23,12 @@
 #include "power_cells.h"
 #include "renderer.h"
 #include "rings.h"
+#include "shape.h"
 #include "sroute.h"
 #include "straps.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
+#include "via.h"
 #include "via_repair.h"
 
 namespace pdn {

--- a/src/pdn/src/connect.cpp
+++ b/src/pdn/src/connect.cpp
@@ -22,6 +22,7 @@
 #include "shape.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
+#include "via.h"
 
 namespace pdn {
 

--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -24,9 +24,11 @@
 #include "odb/isotropy.h"
 #include "power_cells.h"
 #include "rings.h"
+#include "shape.h"
 #include "straps.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
+#include "via.h"
 
 namespace pdn {
 

--- a/src/pdn/src/power_cells.cpp
+++ b/src/pdn/src/power_cells.cpp
@@ -14,6 +14,8 @@
 #include "domain.h"
 #include "grid.h"
 #include "odb/db.h"
+#include "pdn/PdnGen.hh"
+#include "shape.h"
 #include "straps.h"
 #include "utl/Logger.h"
 

--- a/src/pdn/src/renderer.cpp
+++ b/src/pdn/src/renderer.cpp
@@ -13,7 +13,9 @@
 #include "gui/gui.h"
 #include "odb/dbTypes.h"
 #include "pdn/PdnGen.hh"
+#include "shape.h"
 #include "straps.h"
+#include "via.h"
 
 namespace pdn {
 

--- a/src/pdn/src/rings.cpp
+++ b/src/pdn/src/rings.cpp
@@ -13,6 +13,7 @@
 #include "grid.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "shape.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
 

--- a/src/pdn/src/rings.h
+++ b/src/pdn/src/rings.h
@@ -8,6 +8,7 @@
 
 #include "grid_component.h"
 #include "odb/geom.h"
+#include "shape.h"
 
 namespace odb {
 class dbTechLayer;

--- a/src/pdn/src/straps.cpp
+++ b/src/pdn/src/straps.cpp
@@ -23,6 +23,7 @@
 #include "odb/db.h"
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
+#include "pdn/PdnGen.hh"
 #include "renderer.h"
 #include "shape.h"
 #include "techlayer.h"

--- a/src/pdn/src/straps.h
+++ b/src/pdn/src/straps.h
@@ -15,6 +15,7 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "pdn/PdnGen.hh"
+#include "shape.h"
 
 namespace pdn {
 class Grid;

--- a/src/pdn/src/via.cpp
+++ b/src/pdn/src/via.cpp
@@ -25,6 +25,7 @@
 #include "odb/dbTransform.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
+#include "shape.h"
 #include "techlayer.h"
 #include "utl/Logger.h"
 

--- a/src/rmp/src/annealing_strategy.cpp
+++ b/src/rmp/src/annealing_strategy.cpp
@@ -7,8 +7,11 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdio>
+#include <cstdlib>
+#include <random>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Mostly, also one or two files with some missing std::-headers.

Breakdown:

```
src/dpl/src/DecapPlacement.cpp:          #include <functional> for std::less
src/dpl/src/infrastructure/architecture.cxx: #include <functional> for std::less
src/odb/include/odb/dbId.h:              #include <functional> for std::hash
src/pdn/src/PdnGen.cc:                   #include "shape.h" for pdn::Shape
src/pdn/src/PdnGen.cc:                   #include "via.h" for pdn::ViaPtr
src/pdn/src/connect.cpp:                 #include "via.h" for pdn::DbGenerateDummyVia
src/pdn/src/grid.cpp:                    #include "shape.h" for pdn::GridObsShape
src/pdn/src/grid.cpp:                    #include "via.h" for pdn::Via
src/pdn/src/power_cells.cpp:             #include "pdn/PdnGen.hh" for pdn::PowerSwitchNetworkType
src/pdn/src/power_cells.cpp:             #include "shape.h" for pdn::Shape
src/pdn/src/renderer.cpp:                #include "shape.h" for pdn::Shape
src/pdn/src/renderer.cpp:                #include "via.h" for pdn::Via
src/pdn/src/rings.cpp:                   #include "shape.h" for pdn::Shape
src/pdn/src/rings.h:                     #include "shape.h" for pdn::Shape
src/pdn/src/straps.cpp:                  #include "pdn/PdnGen.hh" for pdn::ExtensionMode
src/pdn/src/straps.h:                    #include "shape.h" for pdn::Shape
src/pdn/src/via.cpp:                     #include "shape.h" for pdn::ShapePtr
src/rmp/src/annealing_strategy.cpp:      #include <cmath> for std::exp
src/rmp/src/annealing_strategy.cpp:      #include <cstdlib> for std::abort
src/rmp/src/annealing_strategy.cpp:      #include <random> for std::uniform_real_distribution
```