### PR TITLE
IWYU fixes for uses of `rcx::`-symbols

### DIFF
--- a/src/rcx/include/rcx/extMeasureRC.h
+++ b/src/rcx/include/rcx/extMeasureRC.h
@@ -11,6 +11,9 @@
 #include "odb/util.h"
 #include "rcx/array1.h"
 #include "rcx/extRCap.h"
+#include "rcx/extSegment.h"
+#include "rcx/grids.h"
+#include "rcx/util.h"
 
 namespace rcx {
 

--- a/src/rcx/src/ext.cpp
+++ b/src/rcx/src/ext.cpp
@@ -13,7 +13,9 @@
 #include "odb/wOrder.h"
 #include "parse.h"
 #include "rcx/extMeasureRC.h"
+#include "rcx/extModelGen.h"
 #include "rcx/extPattern.h"
+#include "rcx/extRCap.h"
 #include "utl/Logger.h"
 
 namespace rcx {

--- a/src/rcx/src/extSolverGen.cpp
+++ b/src/rcx/src/extSolverGen.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024-2025, The OpenROAD Authors
 
+#include "rcx/extSolverGen.h"
+
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -12,6 +14,7 @@
 
 #include "parse.h"
 #include "rcx/extModelGen.h"
+#include "rcx/extprocess.h"
 #include "utl/Logger.h"
 
 namespace rcx {

--- a/src/rcx/src/extmeasure.cpp
+++ b/src/rcx/src/extmeasure.cpp
@@ -15,6 +15,7 @@
 #include "odb/dbTypes.h"
 #include "rcx/array1.h"
 #include "rcx/dbUtil.h"
+#include "rcx/ext2dBox.h"
 #include "rcx/extRCap.h"
 #include "utl/Logger.h"
 

--- a/src/rcx/src/extmeasure_calc.cpp
+++ b/src/rcx/src/extmeasure_calc.cpp
@@ -8,6 +8,7 @@
 #include "rcx/array1.h"
 #include "rcx/dbUtil.h"
 #include "rcx/extMeasureRC.h"
+#include "rcx/extRCap.h"
 #include "rcx/extSegment.h"
 #include "utl/Logger.h"
 

--- a/src/rcx/src/extmeasure_couple.cpp
+++ b/src/rcx/src/extmeasure_couple.cpp
@@ -14,6 +14,7 @@
 #include "rcx/extMeasureRC.h"
 #include "rcx/extRCap.h"
 #include "rcx/extSegment.h"
+#include "rcx/grids.h"
 #include "utl/Logger.h"
 
 #ifdef HI_ACC_1

--- a/src/rcx/src/extmeasure_diag.cpp
+++ b/src/rcx/src/extmeasure_diag.cpp
@@ -11,6 +11,7 @@
 #include "rcx/dbUtil.h"
 #include "rcx/extMeasureRC.h"
 #include "rcx/extRCap.h"
+#include "rcx/grids.h"
 #include "utl/Logger.h"
 
 #ifdef HI_ACC_1

--- a/src/rcx/src/extmeasure_diag_opt.cpp
+++ b/src/rcx/src/extmeasure_diag_opt.cpp
@@ -9,6 +9,8 @@
 #include "rcx/dbUtil.h"
 #include "rcx/extMeasureRC.h"
 #include "rcx/extRCap.h"
+#include "rcx/extSegment.h"
+#include "rcx/grids.h"
 #include "utl/Logger.h"
 
 #ifdef HI_ACC_1

--- a/src/rcx/src/extmeasure_flow.cpp
+++ b/src/rcx/src/extmeasure_flow.cpp
@@ -11,6 +11,7 @@
 #include "rcx/extMeasureRC.h"
 #include "rcx/extRCap.h"
 #include "rcx/extSegment.h"
+#include "rcx/grids.h"
 #include "utl/Logger.h"
 
 #ifdef HI_ACC_1

--- a/src/rcx/src/grids.cpp
+++ b/src/rcx/src/grids.cpp
@@ -12,6 +12,7 @@
 #include "odb/db.h"
 #include "odb/isotropy.h"
 #include "rcx/array1.h"
+#include "rcx/box.h"
 #include "rcx/util.h"
 
 namespace rcx {

--- a/src/rcx/src/process_ext.cpp
+++ b/src/rcx/src/process_ext.cpp
@@ -9,6 +9,7 @@
 
 #include "odb/wOrder.h"
 #include "rcx/ext.h"
+#include "rcx/extRCap.h"
 #include "rcx/extSolverGen.h"
 #include "utl/Logger.h"
 


### PR DESCRIPTION
Breakdown:

```
src/rcx/include/rcx/extMeasureRC.h:      #include "rcx/extSegment.h" for rcx::extSegment
src/rcx/include/rcx/extMeasureRC.h:      #include "rcx/grids.h" for rcx::Grid
src/rcx/include/rcx/extMeasureRC.h:      #include "rcx/util.h" for rcx::AthPool
src/rcx/src/ext.cpp:                     #include "rcx/extModelGen.h" for rcx::extModelGen
src/rcx/src/ext.cpp:                     #include "rcx/extRCap.h" for rcx::extMain
src/rcx/src/extSolverGen.cpp:            #include "rcx/extSolverGen.h" for rcx::extSolverGen
src/rcx/src/extSolverGen.cpp:            #include "rcx/extprocess.h" for rcx::extConductor
src/rcx/src/extmeasure.cpp:              #include "rcx/ext2dBox.h" for rcx::ext2dBox
src/rcx/src/extmeasure_calc.cpp:         #include "rcx/extRCap.h" for rcx::extDistRC
src/rcx/src/extmeasure_couple.cpp:       #include "rcx/grids.h" for rcx::Grid
src/rcx/src/extmeasure_diag.cpp:         #include "rcx/grids.h" for rcx::Grid
src/rcx/src/extmeasure_diag_opt.cpp:     #include "rcx/extSegment.h" for rcx::extSegment
src/rcx/src/extmeasure_diag_opt.cpp:     #include "rcx/grids.h" for rcx::Grid
src/rcx/src/extmeasure_flow.cpp:         #include "rcx/grids.h" for rcx::Grid
src/rcx/src/grids.cpp:                   #include "rcx/box.h" for rcx::Box
src/rcx/src/process_ext.cpp:             #include "rcx/extRCap.h" for rcx::extRCModel
```