### PR TITLE
clang-tidy: ignore boost headers for now.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,7 +64,7 @@ CheckOptions:
   - key:             google-runtime-int.TypeSuffix
     value:           _t
   - key:             misc-include-cleaner.IgnoreHeaders
-    value:           '.*/QtCore/.*;.*/QtGui/.*;.*/QtWidgets/.*;.*/spdlog/fmt/bundled/.*'
+    value:           '.*/QtCore/.*;.*/QtGui/.*;.*/QtWidgets/.*;.*/spdlog/fmt/bundled/.*;boost/.*'
   
 # All modules but sta
 # Exclude build as there is too much noise from swig generated code


### PR DESCRIPTION
They are often meant to be included as a single
header that then internally includes all the
internal headers.

However, the single headers don't provide the necessary IWYU annotations for `misc-include-cleaner` to give proper guidance. So for now, misc-include-cleaner warnings w.r.t. boost are more noise than useful.

I have a few boost upstream PRs open, but it either goes slow to review, or they require met to show that it is helping, which I didn't have time to yet.
Even once all these are merged, we need to wait for them to show up in a released version.

(e.g.
  https://github.com/boostorg/geometry/pull/1427
  https://github.com/boostorg/beast/pull/3027
)