### PR TITLE
Fix bazel asan builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -70,8 +70,6 @@ build:asan --copt=-g
 build:asan --copt=-fno-omit-frame-pointer
 build:asan --linkopt=-fsanitize=address
 
-# Optional: Ensure ASan doesn't fail on harmless leaks inside build actions
-build:asan --action_env=ASAN_OPTIONS=detect_leaks=0
 # Flags with enough debug symbols to get useful outputs with Linux `perf`
 build:profile --strip=never
 build:profile --copt -g --host_copt -g


### PR DESCRIPTION
The build was building all of the host tools with asan as well as the targets.  Many of the hosts aren't asan clean, like `flex` or `sed`.  

This should fix #8668. 

We don't need it to fix the issue, but should we remove all the host compile flags from our .bazelrc?