### PR TITLE
abseil-cpp: use canonical name directly.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,7 @@ module(
 )
 
 bazel_dep(name = "abc", version = "0.62-yosyshq")
+bazel_dep(name = "abseil-cpp", version = "20260107.0")
 bazel_dep(name = "coin-or-lemon", version = "1.3.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -23,9 +24,6 @@ git_override(
 
 bazel_dep(name = "rules_verilator", version = "0.1.0")
 bazel_dep(name = "verilator", version = "5.036.bcr.3")
-
-# TODO: fix uses of @com_google_absl and use @abseil-cpp directly
-bazel_dep(name = "abseil-cpp", version = "20260107.0", repo_name = "com_google_absl")
 
 BOOST_VERSION = "1.89.0.bcr.2"
 

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -165,7 +165,7 @@ cc_test(
         "//src/stt",
         "//src/tst",
         "//src/utl",
-        "@com_google_absl//absl/strings",
+        "@abseil-cpp//absl/strings",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
     ],


### PR DESCRIPTION
... the com_google_absl name was probably from an earlier `WORKSPACE` dependency.