### PR TITLE
mpl: fix coverity issue and make code more bullet proof

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -211,6 +211,11 @@ std::vector<odb::dbInst*> ClusteringEngine::getUnfixedMacros()
 void ClusteringEngine::setFloorplanShape()
 {
   tree_->floorplan_shape = block_->getCoreArea().intersect(tree_->global_fence);
+
+  if (tree_->floorplan_shape.area() == 0) {
+    logger_->error(
+        MPL, 68, "The global fence set is completely outside the core area.");
+  }
 }
 
 Metrics* ClusteringEngine::computeModuleMetrics(odb::dbModule* module)

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1088,10 +1088,17 @@ int HierRTLMP::computePinAccessBaseDepth(const int io_span) const
     }
   }
 
-  int64_t root_area = (tree_->root->getWidth()
-                       * static_cast<int64_t>(tree_->root->getHeight()));
+  const odb::Rect root_box = tree_->root->getBBox();
+
+  if (root_box.area() == 0) {
+    logger_->error(MPL,
+                   67,
+                   "Failed computing pin access blockages' base depth: root "
+                   "area is zero.");
+  }
+
   const double macro_dominance_factor
-      = tree_->macro_with_halo_area / static_cast<double>(root_area);
+      = tree_->macro_with_halo_area / static_cast<double>(root_box.area());
 
   const int base_depth = std_cell_area / static_cast<double>(io_span)
                          * std::pow((1 - macro_dominance_factor), 2);

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -567,6 +567,15 @@ void Cluster::initConnection()
 
 void Cluster::addConnection(Cluster* cluster, const float connection_weight)
 {
+  if (connection_weight == 0.0) {
+    logger_->error(MPL,
+                   66,
+                   "Attempting to create connection with zero weight.\nCluster "
+                   "A: {}\nCluster B: {}",
+                   name_,
+                   cluster->getName());
+  }
+
   connections_map_[cluster->getId()] += connection_weight;
 }
 


### PR DESCRIPTION
Resolve #9156.

The majority of the defects found by Coverity were false positives. I'm addressing one division by zero expression here.

The other added checks are to protect the code a bit more.