### PR TITLE
rsz: Improve error message for RSZ-0074

### DIFF
--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -1138,8 +1138,13 @@ BufferedNetPtr Resizer::makeBufferedNetGroute(const sta::Pin* drvr_pin,
         // tree
         logger_->error(RSZ,
                        74,
-                       "failed to build tree from gloubal routes: found route "
-                       "to {} pins, expected {}",
+                       "Failed to build tree from global routes for pin '{}' "
+                       "and net '{}' at grid ({}, {}): found route to {} "
+                       "pins, expected {}",
+                       db_network_->pathName(drvr_pin),
+                       db_net->getName(),
+                       drvr_route_pt.x(),
+                       drvr_route_pt.y(),
                        bnet->loadCount(),
                        pin_grid_locs.size() - 1);
         return nullptr;


### PR DESCRIPTION
The currently printed error message is not really helpful for debugging:

  failed to build tree from gloubal routes: found route to 1 pins, expected 0

Add the pin name and grid x + y values to the error message. Also fix a typo.