### PR TITLE
IWYU: fix some missing includes.

### DIFF
--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "AntennaCheckerImpl.hh"
+#include "PinType.hh"
 #include "Polygon.hh"
 #include "WireBuilder.hh"
 #include "absl/synchronization/mutex.h"

--- a/src/ant/src/Polygon.cc
+++ b/src/ant/src/Polygon.cc
@@ -6,6 +6,7 @@
 #include <map>
 #include <vector>
 
+#include "AntennaCheckerImpl.hh"
 #include "boost/polygon/polygon.hpp"
 #include "odb/db.h"
 #include "odb/dbShape.h"

--- a/src/cts/src/TechChar.cpp
+++ b/src/cts/src/TechChar.cpp
@@ -20,6 +20,7 @@
 
 #include "CtsOptions.h"
 #include "db_sta/dbSta.hh"
+#include "est/EstimateParasitics.h"
 #include "odb/db.h"
 #include "odb/dbSet.h"
 #include "rsz/Resizer.hh"

--- a/src/dbSta/src/SpefWriter.cc
+++ b/src/dbSta/src/SpefWriter.cc
@@ -4,6 +4,7 @@
 #include "db_sta/SpefWriter.hh"
 
 #include <algorithm>
+#include <cctype>
 #include <cstddef>
 #include <iostream>
 #include <map>

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -72,6 +72,7 @@ Recommended conclusion: use map for concrete cells. They are invariant.
 #include "sta/Liberty.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
+#include "sta/ObjectId.hh"
 #include "sta/PatternMatch.hh"
 #include "sta/PortDirection.hh"
 #include "sta/Search.hh"

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -46,6 +46,7 @@
 #include "sta/MinMax.hh"
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
+#include "sta/ObjectId.hh"
 #include "sta/Parasitics.hh"
 #include "sta/ParasiticsClass.hh"
 #include "sta/Path.hh"

--- a/src/grt/src/RepairAntennas.cpp
+++ b/src/grt/src/RepairAntennas.cpp
@@ -14,6 +14,7 @@
 
 #include "Net.h"
 #include "Pin.h"
+#include "ant/AntennaChecker.hh"
 #include "boost/geometry/geometry.hpp"
 #include "boost/pending/disjoint_sets.hpp"
 #include "grt/GRoute.h"

--- a/src/gui/src/layoutViewer.h
+++ b/src/gui/src/layoutViewer.h
@@ -37,6 +37,7 @@
 #include "odb/geom.h"
 #include "options.h"
 #include "renderThread.h"
+#include "ruler.h"
 #include "search.h"
 
 namespace utl {

--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -34,6 +34,7 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "painter.h"
+#include "ruler.h"
 #include "utl/Logger.h"
 #include "utl/timer.h"
 

--- a/src/pad/src/RDLRoute.cpp
+++ b/src/pad/src/RDLRoute.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "RDLRouter.h"
 #include "boost/geometry/geometry.hpp"
 #include "boost/polygon/polygon_90_set_data.hpp"
 #include "boost/polygon/polygon_90_with_holes_data.hpp"

--- a/src/psm/src/debug_gui.h
+++ b/src/psm/src/debug_gui.h
@@ -16,6 +16,7 @@
 #include "boost/polygon/polygon.hpp"
 #include "gui/gui.h"
 #include "ir_network.h"
+#include "node.h"
 #include "odb/db.h"
 #include "odb/geom.h"
 #include "odb/geom_boost.h"

--- a/src/psm/src/shape.h
+++ b/src/psm/src/shape.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "boost/geometry/geometry.hpp"
+#include "connection.h"
 #include "ir_network.h"
 #include "odb/geom.h"
 #include "odb/geom_boost.h"

--- a/src/rmp/src/delay_optimization_strategy.h
+++ b/src/rmp/src/delay_optimization_strategy.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/abc/abc.h"
+#include "cut/abc_library_factory.h"
 #include "logic_optimization_strategy.h"
 #include "utl/Logger.h"
 #include "utl/deleter.h"

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -22,6 +22,7 @@
 #include "db_sta/dbSta.hh"
 #include "dpl/Opendp.h"
 #include "est/EstimateParasitics.h"
+#include "est/SteinerTree.h"
 #include "grt/GlobalRouter.h"
 #include "odb/db.h"
 #include "odb/dbObject.h"

--- a/src/rsz/src/BufferedNet.cc
+++ b/src/rsz/src/BufferedNet.cc
@@ -27,6 +27,7 @@
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/Transition.hh"
+#include "stt/SteinerTreeBuilder.h"
 // Use spdlog fmt::format until c++20 that supports std::format.
 #include "spdlog/fmt/fmt.h"
 #include "sta/Fuzzy.hh"

--- a/src/rsz/src/RecoverPower.cc
+++ b/src/rsz/src/RecoverPower.cc
@@ -13,6 +13,7 @@
 
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "est/EstimateParasitics.h"
 #include "odb/db.h"
 #include "rsz/Resizer.hh"
 #include "sta/Corner.hh"

--- a/src/rsz/src/RepairSetup.cc
+++ b/src/rsz/src/RepairSetup.cc
@@ -20,6 +20,7 @@
 #include "Rebuffer.hh"
 #include "SizeDownMove.hh"
 #include "db_sta/dbSta.hh"
+#include "est/EstimateParasitics.h"
 #include "sta/Delay.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/Path.hh"

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -265,6 +265,7 @@ cc_test(
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/stt",
+        "//src/tst",
         "//src/tst:nangate45_fixture",
         "//src/utl",
         "@googletest//:gtest",

--- a/src/rsz/test/cpp/TestBufferRemoval.cc
+++ b/src/rsz/test/cpp/TestBufferRemoval.cc
@@ -30,6 +30,7 @@
 #include "sta/SearchClass.hh"
 #include "sta/Sta.hh"
 #include "stt/SteinerTreeBuilder.h"
+#include "tst/fixture.h"
 #include "tst/nangate45_fixture.h"
 #include "utl/CallBackHandler.h"
 #include "utl/Logger.h"

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -3,6 +3,7 @@
 
 #include "upf/upf.h"
 
+#include <cctype>
 #include <cmath>
 #include <limits>
 #include <map>


### PR DESCRIPTION
Breakdown:
```
src/ant/src/AntennaChecker.cc:           #include "PinType.hh" for ant::PinType
src/ant/src/Polygon.cc:                  #include "AntennaCheckerImpl.hh" for ant::GraphNodes
src/cts/src/TechChar.cpp:                #include "est/EstimateParasitics.h" for est::EstimateParasitics
src/dbSta/src/SpefWriter.cc:             #include <cctype> for (std::)?toupper
src/dbSta/src/dbNetwork.cc:              #include "sta/ObjectId.hh" for sta::object_id_null
src/dbSta/src/dbSta.cc:                  #include "sta/ObjectId.hh" for sta::object_id_null
src/grt/src/RepairAntennas.cpp:          #include "ant/AntennaChecker.hh" for ant::Violation
src/gui/src/layoutViewer.h:              #include "ruler.h" for gui::Rulers
src/gui/src/renderThread.cpp:            #include "ruler.h" for gui::Rulers
src/pad/src/RDLRoute.cpp:                #include "RDLRouter.h" for pad::RDLRouter
src/psm/src/debug_gui.h:                 #include "node.h" for psm::SourceNodes
src/psm/src/shape.h:                     #include "connection.h" for psm::Connections
src/rmp/src/delay_optimization_strategy.h: #include "cut/abc_library_factory.h" for cut::AbcLibrary
src/rsz/include/rsz/Resizer.hh:          #include "est/SteinerTree.h" for est::SteinerTree
src/rsz/src/BufferedNet.cc:              #include "stt/SteinerTreeBuilder.h" for stt::Branch
src/rsz/src/RecoverPower.cc:             #include "est/EstimateParasitics.h" for est::IncrementalParasiticsGuard
src/rsz/src/RepairSetup.cc:              #include "est/EstimateParasitics.h" for est::IncrementalParasiticsGuard
src/rsz/test/cpp/TestBufferRemoval.cc:   #include "tst/fixture.h" for tst::Fixture
src/upf/src/upf.cpp:                     #include <cctype> for (std::)?toupper
```
