### PR TITLE
Copy bison and flex.bzl from bazel_rules_hdl locally.

### DIFF
--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2026, The OpenROAD Authors
+
+"""Build rule for generating C or C++ sources with Bison.
+"""
+
+def correct_bison_env_for_action(env, bison):
+    """Modify the Bison environment variables to work in an action that doesn't a have built bison runfiles directory.
+
+    The `bison_toolchain.bison_env` parameter assumes that Bison will provided via an executable attribute
+    and thus have built runfiles available to it. This is not the case for this action and any other actions
+    trying to use bison as a tool via the toolchain. This function transforms existing environment variables
+    to support running Bison as desired.
+
+    Args:
+        env (dict): The existing bison environment variables
+        bison (File): The Bison executable
+
+    Returns:
+        Dict: Environment variables required for running Bison.
+    """
+    bison_env = dict(env)
+
+    # Convert the environment variables to non-runfiles forms
+    bison_runfiles_dir = "{}.runfiles/{}".format(
+        bison.path,
+        bison.owner.workspace_name,
+    )
+
+    bison_env["BISON_PKGDATADIR"] = bison_env["BISON_PKGDATADIR"].replace(
+        bison_runfiles_dir,
+        "external/{}".format(bison.owner.workspace_name),
+    )
+    bison_env["M4"] = bison_env["M4"].replace(
+        bison_runfiles_dir,
+        "{}/external/{}".format(bison.root.path, bison.owner.workspace_name),
+    )
+
+    return bison_env
+
+def _genyacc_impl(ctx):
+    """Implementation for genyacc rule."""
+
+    bison_toolchain = ctx.toolchains["@rules_bison//bison:toolchain_type"].bison_toolchain
+
+    # Argument list
+    args = ctx.actions.args()
+    args.add(ctx.outputs.header_out.path, format = "--defines=%s")
+    args.add(ctx.outputs.source_out.path, format = "--output-file=%s")
+    if ctx.attr.prefix:
+        args.add(ctx.attr.prefix, format = "--name-prefix=%s")
+    args.add_all([ctx.expand_location(opt) for opt in ctx.attr.extra_options])
+    args.add(ctx.file.src.path)
+
+    # Output files
+    outputs = ctx.outputs.extra_outs + [
+        ctx.outputs.header_out,
+        ctx.outputs.source_out,
+    ]
+
+    ctx.actions.run(
+        executable = bison_toolchain.bison_tool.executable,
+        env = correct_bison_env_for_action(
+            env = bison_toolchain.bison_env,
+            bison = bison_toolchain.bison_tool.executable,
+        ),
+        arguments = [args],
+        inputs = ctx.files.src,
+        tools = [bison_toolchain.all_files],
+        outputs = outputs,
+        mnemonic = "Yacc",
+        progress_message = "Generating %s and %s from %s" %
+                           (
+                               ctx.outputs.source_out.short_path,
+                               ctx.outputs.header_out.short_path,
+                               ctx.file.src.short_path,
+                           ),
+    )
+
+genyacc = rule(
+    implementation = _genyacc_impl,
+    doc = "Generate C/C++-language sources from a Yacc file using Bison.",
+    attrs = {
+        "extra_options": attr.string_list(
+            doc = "A list of extra options to pass to Bison.  These are " +
+                  "subject to $(location ...) expansion.",
+        ),
+        "extra_outs": attr.output_list(
+            doc = "A list of extra generated output files.",
+        ),
+        "header_out": attr.output(
+            mandatory = True,
+            doc = "The generated 'defines' header file",
+        ),
+        "prefix": attr.string(
+            doc = "External symbol prefix for Bison. This string is " +
+                  "passed to bison as the -p option, causing the resulting C " +
+                  "file to define external functions named 'prefix'parse, " +
+                  "'prefix'lex, etc. instead of yyparse, yylex, etc.",
+        ),
+        "source_out": attr.output(
+            mandatory = True,
+            doc = "The generated source file",
+        ),
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = [".y", ".yy", ".yc", ".ypp", ".yxx"],
+            doc = "The .y, .yy, or .yc source file for this rule",
+        ),
+    },
+    toolchains = [
+        "@rules_bison//bison:toolchain_type",
+    ],
+)

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2026, The OpenROAD Authors
+
+"""Build rule for generating C or C++ sources with Flex."""
+
+def _correct_flex_env_for_action(env, flex):
+    """Modify the flex environment variables to work in an action that doesn't a have built flex runfiles directory.
+
+    The `flex_toolchain.flex_env` parameter assumes that flex will provided via an executable attribute
+    and thus have built runfiles available to it. This is not the case for this action and any other actions
+    trying to use flex as a tool via the toolchain. This function transforms existing environment variables
+    to support running Flex as desired.
+
+    Args:
+        env (dict): The existing Flex environment variables
+        flex (File): The Flex executable
+
+    Returns:
+        Dict: Environment variables required for running Flex.
+    """
+    flex_env = dict(env)
+
+    # Convert the environment variables to non-runfiles forms
+    flex_runfiles_dir = "{}.runfiles/{}".format(
+        flex.path,
+        flex.owner.workspace_name,
+    )
+
+    actual = "{}/external/{}".format(flex.root.path, flex.owner.workspace_name)
+
+    for key, value in flex_env.items():
+        flex_env[key] = value.replace(flex_runfiles_dir, actual)
+
+    return flex_env
+
+def _genlex_impl(ctx):
+    """Implementation for genlex rule."""
+
+    flex_toolchain = ctx.toolchains["@rules_flex//flex:toolchain_type"].flex_toolchain
+
+    # Compute the prefix, if not specified.
+    if ctx.attr.prefix:
+        prefix = ctx.attr.prefix
+    else:
+        prefix = ctx.file.src.basename.partition(".")[0]
+
+    # Construct the arguments.
+    args = ctx.actions.args()
+    args.add("-o", ctx.outputs.out)
+    outputs = [ctx.outputs.out]
+    if ctx.outputs.header_out:
+        args.add(ctx.outputs.header_out.path, format = "--header-file=%s")
+        outputs.append(ctx.outputs.header_out)
+    args.add("-P", prefix)
+    args.add_all(ctx.attr.lexopts)
+    args.add(ctx.file.src)
+
+    flex_env = _correct_flex_env_for_action(
+        env = flex_toolchain.flex_env,
+        flex = flex_toolchain.flex_tool.executable,
+    )
+
+    ctx.actions.run(
+        executable = flex_toolchain.flex_tool.executable,
+        env = flex_env,
+        arguments = [args],
+        inputs = ctx.files.src + ctx.files.includes,
+        tools = [flex_toolchain.all_files],
+        outputs = outputs,
+        mnemonic = "Flex",
+        progress_message = "Generating %s from %s" % (
+            ctx.outputs.out.short_path,
+            ctx.file.src.short_path,
+        ),
+    )
+
+genlex = rule(
+    implementation = _genlex_impl,
+    doc = """\
+Generate C/C++-language sources from a lex file using Flex.
+
+IMPORTANT: we _strongly recommend_ that you include a unique and project-
+specific `%option prefix="myproject"` directive in your scanner spec to avoid
+very hard-to-debug symbol name conflict problems if two scanners are linked
+into the same dynamically-linked executable.  Consider using ANTLR for new
+projects.
+By default, flex includes the definition of a static function `yyunput` in its
+output. If you never use the lex `unput` function in your lex rules, however,
+`yyunput` will never be called. This causes problems building the output file,
+as llvm issues warnings about static functions that are never called. To avoid
+this problem, use `%option nounput` in the declarations section if your lex
+rules never use `unput`.
+Note that if you use the c++ mode of flex, you will need to include the
+boilerplate header `FlexLexer.h` file in any `cc_library` which includes the
+generated flex scanner directly.  This is typically done by
+`#include <FlexLexer.h>` with a declared BUILD dependency on
+`@com_github_westes_flex//:FlexLexer`.
+Flex invokes m4 behind the scenes to generate the output scanner.  As such,
+all genlex rules have an implicit dependency on `@org_gnu_m4//:m4`.  Note
+also that certain M4 control sequences (notably exactly the strings `"[["` and
+`"]]"`) are not correctly handled by flex as a result.
+
+Examples
+--------
+This is a simple example.
+```python
+genlex(
+    name = "html_lex_lex",
+    src = "html.lex",
+    out = "html_lexer.c",
+)
+```
+
+This example uses a `.tab.hh` file.
+```python
+genlex(
+    name = "rules_l",
+    src = "rules.lex",
+    includes = [
+        "rules.tab.hh",
+    ],
+    out = "rules.yy.cc",
+)
+```
+""",
+    attrs = {
+        "header_out": attr.output(
+            mandatory = False,
+            doc = "The generated header file",
+        ),
+        "includes": attr.label_list(
+            allow_files = True,
+            doc = "A list of headers that are included by the .lex file",
+        ),
+        "lexopts": attr.string_list(
+            doc = "A list of options to be added to the flex command line.",
+        ),
+        "out": attr.output(
+            doc = "The generated source file",
+            mandatory = True,
+        ),
+        "prefix": attr.string(
+            doc = "External symbol prefix for Flex. This string is " +
+                  "passed to flex as the -P option, causing the resulting C " +
+                  "file to define external functions named 'prefix'text, " +
+                  "'prefix'in, etc.  The default is the basename of the source" +
+                  "file without the .lex extension.",
+            default = "yy",
+        ),
+        "src": attr.label(
+            mandatory = True,
+            allow_single_file = [".l", ".ll", ".lex", ".lpp"],
+            doc = "The .lex source file for this rule",
+        ),
+    },
+    toolchains = [
+        "@rules_flex//flex:toolchain_type",
+    ],
+)

--- a/src/odb/src/def/BUILD
+++ b/src/odb/src/def/BUILD
@@ -2,7 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
+load("//bazel:bison.bzl", "genyacc")
 
 package(
     default_visibility = ["//:__subpackages__"],

--- a/src/odb/src/lef/BUILD
+++ b/src/odb/src/lef/BUILD
@@ -2,7 +2,7 @@
 # Copyright (c) 2025, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
-load("@rules_hdl//dependency_support/org_gnu_bison:bison.bzl", "genyacc")
+load("//bazel:bison.bzl", "genyacc")
 
 package(
     default_visibility = ["//:__subpackages__"],


### PR DESCRIPTION
Step 1 from 2.

That way, we can use it from here and remove the reference in `WORKSPACE`.

After
https://github.com/The-OpenROAD-Project/OpenSTA/pull/296 is merged, we can (step 2) update that submodule, and with it remove the WORKSPACE reference.