### PR TITLE
bazel/macos-gui: STATIC_QPA_PLUGIN_XCB=1 only on linux

### DIFF
--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -63,9 +63,10 @@ QT_GUI_PLATFORMS = {
             "include/gui/gui.h",
             "include/gui/heatMap.h",
         ],
-        defines = [
-            "STATIC_QPA_PLUGIN_XCB=1",
-        ],
+        defines = select({
+            "@platforms//os:linux": ["STATIC_QPA_PLUGIN_XCB=1"],
+            "//conditions:default": [],
+        }),
         includes = [
             "include",
             "src",


### PR DESCRIPTION
This is a change to the bazel build on MacOS to support the MacOS gui. This can be merged and it will not harm, but it requires changes in the qt_bazel_prebuilts repository to actually work. The PR there is

https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts/pull/7

Then you can start openroad on MacOS with gui with
<code>bazelisk run --//:platform=gui //:openroad -- -gui</code>

