### PR TITLE
qt/gui: update qt_bazel_prebuilts to version with MacOS support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -92,7 +92,7 @@ git_override(
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "e1d5b0b4725d045a03d18e02c54bdebe73d07384",
+    commit = "2b450c5d0b84e0a48e0e7797486e62d24f65c78b",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 


### PR DESCRIPTION
After the MacOS changes are merged to qt_bazel_prebuilts, the version is switched in MODULE.bazel. Only then the MacOS gui build works with

  `bazelisk run --//:platform=gui //:openroad -- -gui`