### PR TITLE
Fix:Tcl error in configure_cts_characterization step arguments

### DIFF
--- a/src/cts/src/TritonCTS.tcl
+++ b/src/cts/src/TritonCTS.tcl
@@ -26,13 +26,13 @@ proc configure_cts_characterization { args } {
   if { [info exists keys(-slew_steps)] } {
     set steps $keys(-slew_steps)
     sta::check_cardinal "-slew_steps" $steps
-    cts::set_slew_steps $slew
+    cts::set_slew_steps $steps
   }
 
   if { [info exists keys(-cap_steps)] } {
     set steps $keys(-cap_steps)
     sta::check_cardinal "-cap_steps" $steps
-    cts::set_cap_steps $cap
+    cts::set_cap_steps $steps
   }
 }
 


### PR DESCRIPTION
## Summary

Fix a Tcl error in `configure_cts_characterization` (`src/cts/src/TritonCTS.tcl`) where `-slew_steps` and `-cap_steps` referenced undefined variables, causing a runtime failure.

---

## Fix

The procedure parsed values into `steps` but incorrectly used `$slew` and `$cap`, which are not defined in this scope.
Replace them with the correct `$steps` variable.

**Before**

```tcl id="1"
cts::set_slew_steps $slew
cts::set_cap_steps $cap
```

**After**

```tcl id="2"
cts::set_slew_steps $steps
cts::set_cap_steps $steps
```

---

## Verification

* Before:

  ```
  configure_cts_characterization -slew_steps 5
  ```

  → `can't read "slew": no such variable`

* After:

  ```
  configure_cts_characterization -slew_steps 5
  ```

  → Executes without error