### PR TITLE
pad: stop looping over fillers when gap is complete

### DIFF
--- a/src/pad/src/ICeWall.cpp
+++ b/src/pad/src/ICeWall.cpp
@@ -968,6 +968,10 @@ void ICeWall::placeFiller(
           break;
         }
       }
+
+      if (sites <= 0) {
+        break;
+      }
     }
 
     if (sites > 0) {

--- a/src/pad/test/skywater130_overlapping_filler.defok
+++ b/src/pad/test/skywater130_overlapping_filler.defok
@@ -1747,7 +1747,7 @@ TRACKS X 460 DO 3900 STEP 920 LAYER met4 ;
 TRACKS Y 460 DO 5639 STEP 920 LAYER met4 ;
 TRACKS X 1700 DO 1055 STEP 3400 LAYER met5 ;
 TRACKS Y 1700 DO 1526 STEP 3400 LAYER met5 ;
-COMPONENTS 763 ;
+COMPONENTS 662 ;
     - IO_CORNER_NORTH_EAST_INST sky130_ef_io__corner_pad + FIXED ( 3388000 4984000 ) N ;
     - IO_CORNER_NORTH_WEST_INST sky130_ef_io__corner_pad + FIXED ( 0 4984000 ) FN ;
     - IO_CORNER_SOUTH_EAST_INST sky130_ef_io__corner_pad + FIXED ( 3388000 0 ) FS ;
@@ -1755,8 +1755,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_0_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 204000 ) E ;
     - IO_FILL_IO_EAST_0_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 304000 ) E ;
     - IO_FILL_IO_EAST_0_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 324000 ) E ;
-    - IO_FILL_IO_EAST_0_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 344000 ) E ;
-    - IO_FILL_IO_EAST_0_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 349000 ) E ;
+    - IO_FILL_IO_EAST_0_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 344000 ) E ;
     - IO_FILL_IO_EAST_0_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 224000 ) E ;
     - IO_FILL_IO_EAST_0_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 244000 ) E ;
     - IO_FILL_IO_EAST_0_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 264000 ) E ;
@@ -1764,7 +1763,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_10_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2449000 ) E ;
     - IO_FILL_IO_EAST_10_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2549000 ) E ;
     - IO_FILL_IO_EAST_10_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2569000 ) E ;
-    - IO_FILL_IO_EAST_10_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 2589000 ) E ;
+    - IO_FILL_IO_EAST_10_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2589000 ) E ;
     - IO_FILL_IO_EAST_10_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2469000 ) E ;
     - IO_FILL_IO_EAST_10_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2489000 ) E ;
     - IO_FILL_IO_EAST_10_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2509000 ) E ;
@@ -1772,8 +1771,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_11_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2669000 ) E ;
     - IO_FILL_IO_EAST_11_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2769000 ) E ;
     - IO_FILL_IO_EAST_11_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2789000 ) E ;
-    - IO_FILL_IO_EAST_11_140 sky130_ef_io__com_bus_slice_10um + FIXED ( 3390035 2809000 ) E ;
-    - IO_FILL_IO_EAST_11_150 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 2819000 ) E ;
+    - IO_FILL_IO_EAST_11_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2809000 ) E ;
     - IO_FILL_IO_EAST_11_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2689000 ) E ;
     - IO_FILL_IO_EAST_11_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2709000 ) E ;
     - IO_FILL_IO_EAST_11_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2729000 ) E ;
@@ -1781,8 +1779,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_12_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2899000 ) E ;
     - IO_FILL_IO_EAST_12_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2999000 ) E ;
     - IO_FILL_IO_EAST_12_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3019000 ) E ;
-    - IO_FILL_IO_EAST_12_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3039000 ) E ;
-    - IO_FILL_IO_EAST_12_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3044000 ) E ;
+    - IO_FILL_IO_EAST_12_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3039000 ) E ;
     - IO_FILL_IO_EAST_12_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2919000 ) E ;
     - IO_FILL_IO_EAST_12_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2939000 ) E ;
     - IO_FILL_IO_EAST_12_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2959000 ) E ;
@@ -1790,7 +1787,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_13_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3125000 ) E ;
     - IO_FILL_IO_EAST_13_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3225000 ) E ;
     - IO_FILL_IO_EAST_13_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3245000 ) E ;
-    - IO_FILL_IO_EAST_13_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3265000 ) E ;
+    - IO_FILL_IO_EAST_13_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3265000 ) E ;
     - IO_FILL_IO_EAST_13_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3145000 ) E ;
     - IO_FILL_IO_EAST_13_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3165000 ) E ;
     - IO_FILL_IO_EAST_13_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3185000 ) E ;
@@ -1798,8 +1795,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_14_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3350000 ) E ;
     - IO_FILL_IO_EAST_14_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3450000 ) E ;
     - IO_FILL_IO_EAST_14_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3470000 ) E ;
-    - IO_FILL_IO_EAST_14_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3490000 ) E ;
-    - IO_FILL_IO_EAST_14_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3495000 ) E ;
+    - IO_FILL_IO_EAST_14_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3490000 ) E ;
     - IO_FILL_IO_EAST_14_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3370000 ) E ;
     - IO_FILL_IO_EAST_14_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3390000 ) E ;
     - IO_FILL_IO_EAST_14_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3410000 ) E ;
@@ -1807,7 +1803,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_15_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3576000 ) E ;
     - IO_FILL_IO_EAST_15_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3676000 ) E ;
     - IO_FILL_IO_EAST_15_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3696000 ) E ;
-    - IO_FILL_IO_EAST_15_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3716000 ) E ;
+    - IO_FILL_IO_EAST_15_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3716000 ) E ;
     - IO_FILL_IO_EAST_15_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3596000 ) E ;
     - IO_FILL_IO_EAST_15_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3616000 ) E ;
     - IO_FILL_IO_EAST_15_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3636000 ) E ;
@@ -1815,7 +1811,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_16_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3801000 ) E ;
     - IO_FILL_IO_EAST_16_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3901000 ) E ;
     - IO_FILL_IO_EAST_16_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3921000 ) E ;
-    - IO_FILL_IO_EAST_16_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 3941000 ) E ;
+    - IO_FILL_IO_EAST_16_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3941000 ) E ;
     - IO_FILL_IO_EAST_16_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3821000 ) E ;
     - IO_FILL_IO_EAST_16_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3841000 ) E ;
     - IO_FILL_IO_EAST_16_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 3861000 ) E ;
@@ -1823,7 +1819,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_17_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4026000 ) E ;
     - IO_FILL_IO_EAST_17_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4126000 ) E ;
     - IO_FILL_IO_EAST_17_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4146000 ) E ;
-    - IO_FILL_IO_EAST_17_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4166000 ) E ;
+    - IO_FILL_IO_EAST_17_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4166000 ) E ;
     - IO_FILL_IO_EAST_17_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4046000 ) E ;
     - IO_FILL_IO_EAST_17_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4066000 ) E ;
     - IO_FILL_IO_EAST_17_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4086000 ) E ;
@@ -1831,8 +1827,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_18_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4242000 ) E ;
     - IO_FILL_IO_EAST_18_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4342000 ) E ;
     - IO_FILL_IO_EAST_18_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4362000 ) E ;
-    - IO_FILL_IO_EAST_18_140 sky130_ef_io__com_bus_slice_10um + FIXED ( 3390035 4382000 ) E ;
-    - IO_FILL_IO_EAST_18_150 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4392000 ) E ;
+    - IO_FILL_IO_EAST_18_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4382000 ) E ;
     - IO_FILL_IO_EAST_18_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4262000 ) E ;
     - IO_FILL_IO_EAST_18_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4282000 ) E ;
     - IO_FILL_IO_EAST_18_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4302000 ) E ;
@@ -1840,7 +1835,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_19_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4472000 ) E ;
     - IO_FILL_IO_EAST_19_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4572000 ) E ;
     - IO_FILL_IO_EAST_19_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4592000 ) E ;
-    - IO_FILL_IO_EAST_19_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4612000 ) E ;
+    - IO_FILL_IO_EAST_19_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4612000 ) E ;
     - IO_FILL_IO_EAST_19_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4492000 ) E ;
     - IO_FILL_IO_EAST_19_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4512000 ) E ;
     - IO_FILL_IO_EAST_19_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4532000 ) E ;
@@ -1853,15 +1848,13 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_1_180 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 540000 ) E ;
     - IO_FILL_IO_EAST_1_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 380000 ) E ;
     - IO_FILL_IO_EAST_1_200 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 560000 ) E ;
-    - IO_FILL_IO_EAST_1_220 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 580000 ) E ;
     - IO_FILL_IO_EAST_1_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 400000 ) E ;
     - IO_FILL_IO_EAST_1_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 420000 ) E ;
     - IO_FILL_IO_EAST_1_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 440000 ) E ;
     - IO_FILL_IO_EAST_20_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4688000 ) E ;
     - IO_FILL_IO_EAST_20_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4788000 ) E ;
     - IO_FILL_IO_EAST_20_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4808000 ) E ;
-    - IO_FILL_IO_EAST_20_140 sky130_ef_io__com_bus_slice_10um + FIXED ( 3390035 4828000 ) E ;
-    - IO_FILL_IO_EAST_20_150 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4838000 ) E ;
+    - IO_FILL_IO_EAST_20_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4828000 ) E ;
     - IO_FILL_IO_EAST_20_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4708000 ) E ;
     - IO_FILL_IO_EAST_20_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4728000 ) E ;
     - IO_FILL_IO_EAST_20_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4748000 ) E ;
@@ -1869,13 +1862,11 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_21_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4918000 ) E ;
     - IO_FILL_IO_EAST_21_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4938000 ) E ;
     - IO_FILL_IO_EAST_21_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4958000 ) E ;
-    - IO_FILL_IO_EAST_21_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4978000 ) E ;
-    - IO_FILL_IO_EAST_21_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 4983000 ) E ;
+    - IO_FILL_IO_EAST_21_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 4978000 ) E ;
     - IO_FILL_IO_EAST_2_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 660000 ) E ;
     - IO_FILL_IO_EAST_2_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 760000 ) E ;
     - IO_FILL_IO_EAST_2_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 780000 ) E ;
-    - IO_FILL_IO_EAST_2_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 800000 ) E ;
-    - IO_FILL_IO_EAST_2_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 805000 ) E ;
+    - IO_FILL_IO_EAST_2_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 800000 ) E ;
     - IO_FILL_IO_EAST_2_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 680000 ) E ;
     - IO_FILL_IO_EAST_2_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 700000 ) E ;
     - IO_FILL_IO_EAST_2_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 720000 ) E ;
@@ -1883,7 +1874,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_3_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 886000 ) E ;
     - IO_FILL_IO_EAST_3_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 986000 ) E ;
     - IO_FILL_IO_EAST_3_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1006000 ) E ;
-    - IO_FILL_IO_EAST_3_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1026000 ) E ;
+    - IO_FILL_IO_EAST_3_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1026000 ) E ;
     - IO_FILL_IO_EAST_3_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 906000 ) E ;
     - IO_FILL_IO_EAST_3_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 926000 ) E ;
     - IO_FILL_IO_EAST_3_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 946000 ) E ;
@@ -1891,8 +1882,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_4_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1111000 ) E ;
     - IO_FILL_IO_EAST_4_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1211000 ) E ;
     - IO_FILL_IO_EAST_4_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1231000 ) E ;
-    - IO_FILL_IO_EAST_4_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1251000 ) E ;
-    - IO_FILL_IO_EAST_4_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1256000 ) E ;
+    - IO_FILL_IO_EAST_4_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1251000 ) E ;
     - IO_FILL_IO_EAST_4_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1131000 ) E ;
     - IO_FILL_IO_EAST_4_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1151000 ) E ;
     - IO_FILL_IO_EAST_4_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1171000 ) E ;
@@ -1900,7 +1890,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_5_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1337000 ) E ;
     - IO_FILL_IO_EAST_5_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1437000 ) E ;
     - IO_FILL_IO_EAST_5_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1457000 ) E ;
-    - IO_FILL_IO_EAST_5_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1477000 ) E ;
+    - IO_FILL_IO_EAST_5_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1477000 ) E ;
     - IO_FILL_IO_EAST_5_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1357000 ) E ;
     - IO_FILL_IO_EAST_5_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1377000 ) E ;
     - IO_FILL_IO_EAST_5_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1397000 ) E ;
@@ -1908,7 +1898,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_6_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1562000 ) E ;
     - IO_FILL_IO_EAST_6_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1662000 ) E ;
     - IO_FILL_IO_EAST_6_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1682000 ) E ;
-    - IO_FILL_IO_EAST_6_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1702000 ) E ;
+    - IO_FILL_IO_EAST_6_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1702000 ) E ;
     - IO_FILL_IO_EAST_6_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1582000 ) E ;
     - IO_FILL_IO_EAST_6_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1602000 ) E ;
     - IO_FILL_IO_EAST_6_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1622000 ) E ;
@@ -1916,8 +1906,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_7_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1787000 ) E ;
     - IO_FILL_IO_EAST_7_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1887000 ) E ;
     - IO_FILL_IO_EAST_7_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1907000 ) E ;
-    - IO_FILL_IO_EAST_7_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1927000 ) E ;
-    - IO_FILL_IO_EAST_7_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 1932000 ) E ;
+    - IO_FILL_IO_EAST_7_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1927000 ) E ;
     - IO_FILL_IO_EAST_7_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1807000 ) E ;
     - IO_FILL_IO_EAST_7_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1827000 ) E ;
     - IO_FILL_IO_EAST_7_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 1847000 ) E ;
@@ -1925,7 +1914,6 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_8_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2013000 ) E ;
     - IO_FILL_IO_EAST_8_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2113000 ) E ;
     - IO_FILL_IO_EAST_8_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2133000 ) E ;
-    - IO_FILL_IO_EAST_8_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 2153000 ) E ;
     - IO_FILL_IO_EAST_8_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2033000 ) E ;
     - IO_FILL_IO_EAST_8_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2053000 ) E ;
     - IO_FILL_IO_EAST_8_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2073000 ) E ;
@@ -1933,8 +1921,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_EAST_9_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2228000 ) E ;
     - IO_FILL_IO_EAST_9_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2328000 ) E ;
     - IO_FILL_IO_EAST_9_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2348000 ) E ;
-    - IO_FILL_IO_EAST_9_140 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 2368000 ) E ;
-    - IO_FILL_IO_EAST_9_145 sky130_ef_io__com_bus_slice_5um + FIXED ( 3390035 2373000 ) E ;
+    - IO_FILL_IO_EAST_9_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2368000 ) E ;
     - IO_FILL_IO_EAST_9_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2248000 ) E ;
     - IO_FILL_IO_EAST_9_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2268000 ) E ;
     - IO_FILL_IO_EAST_9_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3390035 2288000 ) E ;
@@ -1944,7 +1931,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_0_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 320000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_0_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 340000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_0_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 360000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_0_180 sky130_ef_io__com_bus_slice_5um + FIXED ( 380000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_0_180 sky130_ef_io__com_bus_slice_20um + FIXED ( 380000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_0_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 220000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_0_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 240000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_0_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 260000 4990035 ) FN ;
@@ -1953,9 +1940,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_10_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 2801000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_10_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 2821000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_10_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 2841000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_10_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 2861000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_10_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 2871000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_10_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 2876000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_10_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 2861000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_10_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2721000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_10_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2741000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_10_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2761000 4990035 ) FN ;
@@ -1964,9 +1949,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_11_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3053000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_11_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3073000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_11_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3093000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_11_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 3113000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_11_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 3123000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_11_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 3128000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_11_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 3113000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_11_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2973000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_11_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2993000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_11_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3013000 4990035 ) FN ;
@@ -1975,9 +1958,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_12_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 3310000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_12_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 3330000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_12_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 3350000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_12_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 3370000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_12_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 3380000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_12_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 3385000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_12_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 3370000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_12_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3230000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_12_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3250000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_12_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3270000 4990035 ) FN ;
@@ -1986,9 +1967,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_1_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 561000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_1_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 581000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_1_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 601000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_1_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 621000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_1_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 631000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_1_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 636000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_1_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 621000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_1_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 481000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_1_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 501000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_1_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 521000 4990035 ) FN ;
@@ -1997,9 +1976,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_2_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 818000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_2_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 838000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_2_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 858000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_2_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 878000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_2_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 888000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_2_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 893000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_2_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 878000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_2_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 738000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_2_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 758000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_2_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 778000 4990035 ) FN ;
@@ -2008,9 +1985,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_3_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 1075000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_3_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 1095000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_3_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 1115000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_3_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 1135000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_3_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 1145000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_3_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 1150000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_3_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 1135000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_3_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 995000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_3_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1015000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_3_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1035000 4990035 ) FN ;
@@ -2019,9 +1994,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_4_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 1332000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_4_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 1352000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_4_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 1372000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_4_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 1392000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_4_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 1402000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_4_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 1407000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_4_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 1392000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_4_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1252000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_4_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1272000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_4_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1292000 4990035 ) FN ;
@@ -2030,9 +2003,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_5_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 1590000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_5_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 1610000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_5_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 1630000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_5_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 1650000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_5_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 1660000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_5_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 1665000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_5_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 1650000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_5_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1510000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_5_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1530000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_5_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1550000 4990035 ) FN ;
@@ -2041,9 +2012,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_6_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 1842000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_6_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 1862000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_6_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 1882000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_6_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 1902000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_6_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 1912000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_6_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 1917000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_6_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 1902000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_6_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1762000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_6_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1782000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_6_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1802000 4990035 ) FN ;
@@ -2052,9 +2021,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_7_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 2099000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_7_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 2119000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_7_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 2139000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_7_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 2159000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_7_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 2169000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_7_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 2174000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_7_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 2159000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_7_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2019000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_7_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2039000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_7_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2059000 4990035 ) FN ;
@@ -2063,9 +2030,7 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_8_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 2286000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_8_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 2306000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_8_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 2326000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_8_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 2346000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_8_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 2356000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_8_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 2361000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_8_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 2346000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_8_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2206000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_8_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2226000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_8_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2246000 4990035 ) FN ;
@@ -2074,294 +2039,228 @@ COMPONENTS 763 ;
     - IO_FILL_IO_NORTH_9_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 2544000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 2564000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_140 sky130_ef_io__com_bus_slice_20um + FIXED ( 2584000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_9_160 sky130_ef_io__com_bus_slice_10um + FIXED ( 2604000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_9_170 sky130_ef_io__com_bus_slice_5um + FIXED ( 2614000 4990035 ) FN ;
-    - IO_FILL_IO_NORTH_9_175 sky130_ef_io__com_bus_slice_5um + FIXED ( 2619000 4990035 ) FN ;
+    - IO_FILL_IO_NORTH_9_160 sky130_ef_io__com_bus_slice_20um + FIXED ( 2604000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2464000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2484000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2504000 4990035 ) FN ;
     - IO_FILL_IO_NORTH_9_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 2524000 4990035 ) FN ;
     - IO_FILL_IO_SOUTH_0_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 200000 0 ) S ;
     - IO_FILL_IO_SOUTH_0_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 220000 0 ) S ;
-    - IO_FILL_IO_SOUTH_0_40 sky130_ef_io__com_bus_slice_10um + FIXED ( 240000 0 ) S ;
-    - IO_FILL_IO_SOUTH_0_50 sky130_ef_io__com_bus_slice_5um + FIXED ( 250000 0 ) S ;
-    - IO_FILL_IO_SOUTH_0_55 sky130_ef_io__com_bus_slice_5um + FIXED ( 255000 0 ) S ;
-    - IO_FILL_IO_SOUTH_10_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 1605000 0 ) S ;
-    - IO_FILL_IO_SOUTH_10_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 1610000 0 ) S ;
+    - IO_FILL_IO_SOUTH_0_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 240000 0 ) S ;
+    - IO_FILL_IO_SOUTH_10_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1605000 0 ) S ;
     - IO_FILL_IO_SOUTH_11_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1732000 0 ) S ;
     - IO_FILL_IO_SOUTH_11_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1752000 0 ) S ;
     - IO_FILL_IO_SOUTH_11_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1772000 0 ) S ;
-    - IO_FILL_IO_SOUTH_11_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 1792000 0 ) S ;
-    - IO_FILL_IO_SOUTH_11_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 1797000 0 ) S ;
-    - IO_FILL_IO_SOUTH_12_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 1879000 0 ) S ;
-    - IO_FILL_IO_SOUTH_12_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 1884000 0 ) S ;
+    - IO_FILL_IO_SOUTH_11_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1792000 0 ) S ;
+    - IO_FILL_IO_SOUTH_12_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1879000 0 ) S ;
     - IO_FILL_IO_SOUTH_13_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2006000 0 ) S ;
     - IO_FILL_IO_SOUTH_13_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2026000 0 ) S ;
     - IO_FILL_IO_SOUTH_13_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2046000 0 ) S ;
-    - IO_FILL_IO_SOUTH_13_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 2066000 0 ) S ;
-    - IO_FILL_IO_SOUTH_13_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 2071000 0 ) S ;
-    - IO_FILL_IO_SOUTH_14_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 2153000 0 ) S ;
-    - IO_FILL_IO_SOUTH_14_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 2158000 0 ) S ;
+    - IO_FILL_IO_SOUTH_13_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2066000 0 ) S ;
+    - IO_FILL_IO_SOUTH_14_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2153000 0 ) S ;
     - IO_FILL_IO_SOUTH_15_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2280000 0 ) S ;
     - IO_FILL_IO_SOUTH_15_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2300000 0 ) S ;
     - IO_FILL_IO_SOUTH_15_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2320000 0 ) S ;
-    - IO_FILL_IO_SOUTH_15_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 2340000 0 ) S ;
-    - IO_FILL_IO_SOUTH_15_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 2345000 0 ) S ;
-    - IO_FILL_IO_SOUTH_16_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 2427000 0 ) S ;
-    - IO_FILL_IO_SOUTH_16_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 2432000 0 ) S ;
+    - IO_FILL_IO_SOUTH_15_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2340000 0 ) S ;
+    - IO_FILL_IO_SOUTH_16_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2427000 0 ) S ;
     - IO_FILL_IO_SOUTH_17_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2554000 0 ) S ;
     - IO_FILL_IO_SOUTH_17_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2574000 0 ) S ;
     - IO_FILL_IO_SOUTH_17_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2594000 0 ) S ;
-    - IO_FILL_IO_SOUTH_17_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 2614000 0 ) S ;
-    - IO_FILL_IO_SOUTH_17_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 2619000 0 ) S ;
-    - IO_FILL_IO_SOUTH_18_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 2701000 0 ) S ;
-    - IO_FILL_IO_SOUTH_18_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 2706000 0 ) S ;
+    - IO_FILL_IO_SOUTH_17_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2614000 0 ) S ;
+    - IO_FILL_IO_SOUTH_18_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2701000 0 ) S ;
     - IO_FILL_IO_SOUTH_19_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2828000 0 ) S ;
     - IO_FILL_IO_SOUTH_19_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 2848000 0 ) S ;
     - IO_FILL_IO_SOUTH_19_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 2868000 0 ) S ;
-    - IO_FILL_IO_SOUTH_19_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 2888000 0 ) S ;
+    - IO_FILL_IO_SOUTH_19_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 2888000 0 ) S ;
     - IO_FILL_IO_SOUTH_1_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 377000 0 ) S ;
     - IO_FILL_IO_SOUTH_1_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 397000 0 ) S ;
     - IO_FILL_IO_SOUTH_1_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 417000 0 ) S ;
-    - IO_FILL_IO_SOUTH_1_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 437000 0 ) S ;
-    - IO_FILL_IO_SOUTH_20_0 sky130_ef_io__com_bus_slice_10um + FIXED ( 2965000 0 ) S ;
-    - IO_FILL_IO_SOUTH_20_10 sky130_ef_io__com_bus_slice_5um + FIXED ( 2975000 0 ) S ;
+    - IO_FILL_IO_SOUTH_1_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 437000 0 ) S ;
+    - IO_FILL_IO_SOUTH_20_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 2965000 0 ) S ;
     - IO_FILL_IO_SOUTH_21_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3097000 0 ) S ;
     - IO_FILL_IO_SOUTH_21_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3117000 0 ) S ;
     - IO_FILL_IO_SOUTH_21_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 3137000 0 ) S ;
-    - IO_FILL_IO_SOUTH_21_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 3157000 0 ) S ;
-    - IO_FILL_IO_SOUTH_22_0 sky130_ef_io__com_bus_slice_10um + FIXED ( 3234000 0 ) S ;
-    - IO_FILL_IO_SOUTH_22_10 sky130_ef_io__com_bus_slice_5um + FIXED ( 3244000 0 ) S ;
+    - IO_FILL_IO_SOUTH_21_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 3157000 0 ) S ;
+    - IO_FILL_IO_SOUTH_22_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3234000 0 ) S ;
     - IO_FILL_IO_SOUTH_23_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 3366000 0 ) S ;
-    - IO_FILL_IO_SOUTH_23_20 sky130_ef_io__com_bus_slice_5um + FIXED ( 3386000 0 ) S ;
-    - IO_FILL_IO_SOUTH_2_0 sky130_ef_io__com_bus_slice_10um + FIXED ( 514000 0 ) S ;
-    - IO_FILL_IO_SOUTH_2_10 sky130_ef_io__com_bus_slice_5um + FIXED ( 524000 0 ) S ;
+    - IO_FILL_IO_SOUTH_23_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 3386000 0 ) S ;
+    - IO_FILL_IO_SOUTH_2_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 514000 0 ) S ;
     - IO_FILL_IO_SOUTH_3_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 646000 0 ) S ;
     - IO_FILL_IO_SOUTH_3_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 666000 0 ) S ;
     - IO_FILL_IO_SOUTH_3_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 686000 0 ) S ;
-    - IO_FILL_IO_SOUTH_3_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 706000 0 ) S ;
-    - IO_FILL_IO_SOUTH_4_0 sky130_ef_io__com_bus_slice_10um + FIXED ( 783000 0 ) S ;
-    - IO_FILL_IO_SOUTH_4_10 sky130_ef_io__com_bus_slice_5um + FIXED ( 793000 0 ) S ;
+    - IO_FILL_IO_SOUTH_3_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 706000 0 ) S ;
+    - IO_FILL_IO_SOUTH_4_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 783000 0 ) S ;
     - IO_FILL_IO_SOUTH_5_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 915000 0 ) S ;
     - IO_FILL_IO_SOUTH_5_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 935000 0 ) S ;
     - IO_FILL_IO_SOUTH_5_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 955000 0 ) S ;
-    - IO_FILL_IO_SOUTH_5_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 975000 0 ) S ;
-    - IO_FILL_IO_SOUTH_5_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 980000 0 ) S ;
-    - IO_FILL_IO_SOUTH_6_0 sky130_ef_io__com_bus_slice_5um + FIXED ( 1062000 0 ) S ;
-    - IO_FILL_IO_SOUTH_6_5 sky130_ef_io__com_bus_slice_5um + FIXED ( 1067000 0 ) S ;
+    - IO_FILL_IO_SOUTH_5_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 975000 0 ) S ;
+    - IO_FILL_IO_SOUTH_6_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1062000 0 ) S ;
     - IO_FILL_IO_SOUTH_7_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1189000 0 ) S ;
     - IO_FILL_IO_SOUTH_7_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1209000 0 ) S ;
     - IO_FILL_IO_SOUTH_7_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1229000 0 ) S ;
-    - IO_FILL_IO_SOUTH_7_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 1249000 0 ) S ;
-    - IO_FILL_IO_SOUTH_8_0 sky130_ef_io__com_bus_slice_10um + FIXED ( 1326000 0 ) S ;
-    - IO_FILL_IO_SOUTH_8_10 sky130_ef_io__com_bus_slice_5um + FIXED ( 1336000 0 ) S ;
+    - IO_FILL_IO_SOUTH_7_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1249000 0 ) S ;
+    - IO_FILL_IO_SOUTH_8_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1326000 0 ) S ;
     - IO_FILL_IO_SOUTH_9_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 1458000 0 ) S ;
     - IO_FILL_IO_SOUTH_9_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 1478000 0 ) S ;
     - IO_FILL_IO_SOUTH_9_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 1498000 0 ) S ;
-    - IO_FILL_IO_SOUTH_9_60 sky130_ef_io__com_bus_slice_5um + FIXED ( 1518000 0 ) S ;
-    - IO_FILL_IO_SOUTH_9_65 sky130_ef_io__com_bus_slice_5um + FIXED ( 1523000 0 ) S ;
+    - IO_FILL_IO_SOUTH_9_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 1518000 0 ) S ;
     - IO_FILL_IO_WEST_0_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 204000 ) FE ;
     - IO_FILL_IO_WEST_0_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 304000 ) FE ;
-    - IO_FILL_IO_WEST_0_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 324000 ) FE ;
-    - IO_FILL_IO_WEST_0_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 334000 ) FE ;
-    - IO_FILL_IO_WEST_0_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 339000 ) FE ;
+    - IO_FILL_IO_WEST_0_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 324000 ) FE ;
     - IO_FILL_IO_WEST_0_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 224000 ) FE ;
     - IO_FILL_IO_WEST_0_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 244000 ) FE ;
     - IO_FILL_IO_WEST_0_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 264000 ) FE ;
     - IO_FILL_IO_WEST_0_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 284000 ) FE ;
     - IO_FILL_IO_WEST_10_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2279000 ) FE ;
     - IO_FILL_IO_WEST_10_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2379000 ) FE ;
-    - IO_FILL_IO_WEST_10_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 2399000 ) FE ;
-    - IO_FILL_IO_WEST_10_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2409000 ) FE ;
-    - IO_FILL_IO_WEST_10_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2414000 ) FE ;
+    - IO_FILL_IO_WEST_10_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2399000 ) FE ;
     - IO_FILL_IO_WEST_10_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2299000 ) FE ;
     - IO_FILL_IO_WEST_10_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2319000 ) FE ;
     - IO_FILL_IO_WEST_10_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2339000 ) FE ;
     - IO_FILL_IO_WEST_10_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2359000 ) FE ;
     - IO_FILL_IO_WEST_11_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2490000 ) FE ;
     - IO_FILL_IO_WEST_11_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2590000 ) FE ;
-    - IO_FILL_IO_WEST_11_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 2610000 ) FE ;
-    - IO_FILL_IO_WEST_11_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2620000 ) FE ;
-    - IO_FILL_IO_WEST_11_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2625000 ) FE ;
+    - IO_FILL_IO_WEST_11_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2610000 ) FE ;
     - IO_FILL_IO_WEST_11_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2510000 ) FE ;
     - IO_FILL_IO_WEST_11_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2530000 ) FE ;
     - IO_FILL_IO_WEST_11_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2550000 ) FE ;
     - IO_FILL_IO_WEST_11_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2570000 ) FE ;
     - IO_FILL_IO_WEST_12_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2706000 ) FE ;
     - IO_FILL_IO_WEST_12_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2806000 ) FE ;
-    - IO_FILL_IO_WEST_12_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 2826000 ) FE ;
-    - IO_FILL_IO_WEST_12_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2836000 ) FE ;
-    - IO_FILL_IO_WEST_12_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2841000 ) FE ;
+    - IO_FILL_IO_WEST_12_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2826000 ) FE ;
     - IO_FILL_IO_WEST_12_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2726000 ) FE ;
     - IO_FILL_IO_WEST_12_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2746000 ) FE ;
     - IO_FILL_IO_WEST_12_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2766000 ) FE ;
     - IO_FILL_IO_WEST_12_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2786000 ) FE ;
     - IO_FILL_IO_WEST_13_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2922000 ) FE ;
     - IO_FILL_IO_WEST_13_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3022000 ) FE ;
-    - IO_FILL_IO_WEST_13_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 3042000 ) FE ;
-    - IO_FILL_IO_WEST_13_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3052000 ) FE ;
-    - IO_FILL_IO_WEST_13_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3057000 ) FE ;
+    - IO_FILL_IO_WEST_13_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3042000 ) FE ;
     - IO_FILL_IO_WEST_13_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2942000 ) FE ;
     - IO_FILL_IO_WEST_13_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2962000 ) FE ;
     - IO_FILL_IO_WEST_13_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2982000 ) FE ;
     - IO_FILL_IO_WEST_13_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3002000 ) FE ;
     - IO_FILL_IO_WEST_14_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3138000 ) FE ;
     - IO_FILL_IO_WEST_14_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3238000 ) FE ;
-    - IO_FILL_IO_WEST_14_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 3258000 ) FE ;
-    - IO_FILL_IO_WEST_14_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3268000 ) FE ;
-    - IO_FILL_IO_WEST_14_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3273000 ) FE ;
+    - IO_FILL_IO_WEST_14_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3258000 ) FE ;
     - IO_FILL_IO_WEST_14_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3158000 ) FE ;
     - IO_FILL_IO_WEST_14_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3178000 ) FE ;
     - IO_FILL_IO_WEST_14_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3198000 ) FE ;
     - IO_FILL_IO_WEST_14_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3218000 ) FE ;
     - IO_FILL_IO_WEST_15_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3354000 ) FE ;
     - IO_FILL_IO_WEST_15_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3454000 ) FE ;
-    - IO_FILL_IO_WEST_15_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 3474000 ) FE ;
-    - IO_FILL_IO_WEST_15_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3484000 ) FE ;
-    - IO_FILL_IO_WEST_15_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3489000 ) FE ;
+    - IO_FILL_IO_WEST_15_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3474000 ) FE ;
     - IO_FILL_IO_WEST_15_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3374000 ) FE ;
     - IO_FILL_IO_WEST_15_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3394000 ) FE ;
     - IO_FILL_IO_WEST_15_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3414000 ) FE ;
     - IO_FILL_IO_WEST_15_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3434000 ) FE ;
     - IO_FILL_IO_WEST_16_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3570000 ) FE ;
     - IO_FILL_IO_WEST_16_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3670000 ) FE ;
-    - IO_FILL_IO_WEST_16_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 3690000 ) FE ;
-    - IO_FILL_IO_WEST_16_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3700000 ) FE ;
-    - IO_FILL_IO_WEST_16_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3705000 ) FE ;
+    - IO_FILL_IO_WEST_16_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3690000 ) FE ;
     - IO_FILL_IO_WEST_16_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3590000 ) FE ;
     - IO_FILL_IO_WEST_16_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3610000 ) FE ;
     - IO_FILL_IO_WEST_16_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3630000 ) FE ;
     - IO_FILL_IO_WEST_16_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3650000 ) FE ;
     - IO_FILL_IO_WEST_17_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3786000 ) FE ;
     - IO_FILL_IO_WEST_17_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3886000 ) FE ;
-    - IO_FILL_IO_WEST_17_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 3906000 ) FE ;
-    - IO_FILL_IO_WEST_17_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3916000 ) FE ;
-    - IO_FILL_IO_WEST_17_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 3921000 ) FE ;
+    - IO_FILL_IO_WEST_17_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3906000 ) FE ;
     - IO_FILL_IO_WEST_17_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3806000 ) FE ;
     - IO_FILL_IO_WEST_17_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3826000 ) FE ;
     - IO_FILL_IO_WEST_17_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3846000 ) FE ;
     - IO_FILL_IO_WEST_17_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 3866000 ) FE ;
     - IO_FILL_IO_WEST_18_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4002000 ) FE ;
     - IO_FILL_IO_WEST_18_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4102000 ) FE ;
-    - IO_FILL_IO_WEST_18_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 4122000 ) FE ;
-    - IO_FILL_IO_WEST_18_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4132000 ) FE ;
-    - IO_FILL_IO_WEST_18_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4137000 ) FE ;
+    - IO_FILL_IO_WEST_18_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4122000 ) FE ;
     - IO_FILL_IO_WEST_18_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4022000 ) FE ;
     - IO_FILL_IO_WEST_18_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4042000 ) FE ;
     - IO_FILL_IO_WEST_18_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4062000 ) FE ;
     - IO_FILL_IO_WEST_18_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4082000 ) FE ;
     - IO_FILL_IO_WEST_19_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4213000 ) FE ;
     - IO_FILL_IO_WEST_19_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4313000 ) FE ;
-    - IO_FILL_IO_WEST_19_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 4333000 ) FE ;
-    - IO_FILL_IO_WEST_19_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4343000 ) FE ;
-    - IO_FILL_IO_WEST_19_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4348000 ) FE ;
+    - IO_FILL_IO_WEST_19_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4333000 ) FE ;
     - IO_FILL_IO_WEST_19_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4233000 ) FE ;
     - IO_FILL_IO_WEST_19_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4253000 ) FE ;
     - IO_FILL_IO_WEST_19_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4273000 ) FE ;
     - IO_FILL_IO_WEST_19_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4293000 ) FE ;
     - IO_FILL_IO_WEST_1_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 415000 ) FE ;
     - IO_FILL_IO_WEST_1_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 515000 ) FE ;
-    - IO_FILL_IO_WEST_1_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 535000 ) FE ;
-    - IO_FILL_IO_WEST_1_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 545000 ) FE ;
-    - IO_FILL_IO_WEST_1_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 550000 ) FE ;
+    - IO_FILL_IO_WEST_1_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 535000 ) FE ;
     - IO_FILL_IO_WEST_1_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 435000 ) FE ;
     - IO_FILL_IO_WEST_1_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 455000 ) FE ;
     - IO_FILL_IO_WEST_1_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 475000 ) FE ;
     - IO_FILL_IO_WEST_1_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 495000 ) FE ;
     - IO_FILL_IO_WEST_20_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4424000 ) FE ;
     - IO_FILL_IO_WEST_20_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4524000 ) FE ;
-    - IO_FILL_IO_WEST_20_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 4544000 ) FE ;
-    - IO_FILL_IO_WEST_20_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4554000 ) FE ;
-    - IO_FILL_IO_WEST_20_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4559000 ) FE ;
+    - IO_FILL_IO_WEST_20_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4544000 ) FE ;
     - IO_FILL_IO_WEST_20_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4444000 ) FE ;
     - IO_FILL_IO_WEST_20_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4464000 ) FE ;
     - IO_FILL_IO_WEST_20_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4484000 ) FE ;
     - IO_FILL_IO_WEST_20_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4504000 ) FE ;
     - IO_FILL_IO_WEST_21_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4635000 ) FE ;
     - IO_FILL_IO_WEST_21_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4735000 ) FE ;
-    - IO_FILL_IO_WEST_21_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 4755000 ) FE ;
-    - IO_FILL_IO_WEST_21_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4765000 ) FE ;
-    - IO_FILL_IO_WEST_21_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4770000 ) FE ;
+    - IO_FILL_IO_WEST_21_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4755000 ) FE ;
     - IO_FILL_IO_WEST_21_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4655000 ) FE ;
     - IO_FILL_IO_WEST_21_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4675000 ) FE ;
     - IO_FILL_IO_WEST_21_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4695000 ) FE ;
     - IO_FILL_IO_WEST_21_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4715000 ) FE ;
     - IO_FILL_IO_WEST_22_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4851000 ) FE ;
     - IO_FILL_IO_WEST_22_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4951000 ) FE ;
-    - IO_FILL_IO_WEST_22_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 4971000 ) FE ;
-    - IO_FILL_IO_WEST_22_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 4981000 ) FE ;
+    - IO_FILL_IO_WEST_22_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4971000 ) FE ;
     - IO_FILL_IO_WEST_22_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4871000 ) FE ;
     - IO_FILL_IO_WEST_22_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4891000 ) FE ;
     - IO_FILL_IO_WEST_22_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4911000 ) FE ;
     - IO_FILL_IO_WEST_22_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 4931000 ) FE ;
     - IO_FILL_IO_WEST_2_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 626000 ) FE ;
     - IO_FILL_IO_WEST_2_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 726000 ) FE ;
-    - IO_FILL_IO_WEST_2_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 746000 ) FE ;
-    - IO_FILL_IO_WEST_2_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 756000 ) FE ;
-    - IO_FILL_IO_WEST_2_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 761000 ) FE ;
+    - IO_FILL_IO_WEST_2_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 746000 ) FE ;
     - IO_FILL_IO_WEST_2_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 646000 ) FE ;
     - IO_FILL_IO_WEST_2_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 666000 ) FE ;
     - IO_FILL_IO_WEST_2_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 686000 ) FE ;
     - IO_FILL_IO_WEST_2_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 706000 ) FE ;
     - IO_FILL_IO_WEST_3_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 772000 ) FE ;
     - IO_FILL_IO_WEST_3_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 872000 ) FE ;
-    - IO_FILL_IO_WEST_3_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 892000 ) FE ;
-    - IO_FILL_IO_WEST_3_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 902000 ) FE ;
-    - IO_FILL_IO_WEST_3_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 907000 ) FE ;
+    - IO_FILL_IO_WEST_3_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 892000 ) FE ;
     - IO_FILL_IO_WEST_3_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 792000 ) FE ;
     - IO_FILL_IO_WEST_3_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 812000 ) FE ;
     - IO_FILL_IO_WEST_3_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 832000 ) FE ;
     - IO_FILL_IO_WEST_3_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 852000 ) FE ;
     - IO_FILL_IO_WEST_4_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 988000 ) FE ;
     - IO_FILL_IO_WEST_4_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1088000 ) FE ;
-    - IO_FILL_IO_WEST_4_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 1108000 ) FE ;
-    - IO_FILL_IO_WEST_4_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1118000 ) FE ;
-    - IO_FILL_IO_WEST_4_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1123000 ) FE ;
+    - IO_FILL_IO_WEST_4_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1108000 ) FE ;
     - IO_FILL_IO_WEST_4_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1008000 ) FE ;
     - IO_FILL_IO_WEST_4_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1028000 ) FE ;
     - IO_FILL_IO_WEST_4_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1048000 ) FE ;
     - IO_FILL_IO_WEST_4_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1068000 ) FE ;
     - IO_FILL_IO_WEST_5_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1204000 ) FE ;
     - IO_FILL_IO_WEST_5_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1304000 ) FE ;
-    - IO_FILL_IO_WEST_5_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 1324000 ) FE ;
-    - IO_FILL_IO_WEST_5_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1334000 ) FE ;
-    - IO_FILL_IO_WEST_5_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1339000 ) FE ;
+    - IO_FILL_IO_WEST_5_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1324000 ) FE ;
     - IO_FILL_IO_WEST_5_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1224000 ) FE ;
     - IO_FILL_IO_WEST_5_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1244000 ) FE ;
     - IO_FILL_IO_WEST_5_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1264000 ) FE ;
     - IO_FILL_IO_WEST_5_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1284000 ) FE ;
     - IO_FILL_IO_WEST_6_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1420000 ) FE ;
     - IO_FILL_IO_WEST_6_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1520000 ) FE ;
-    - IO_FILL_IO_WEST_6_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 1540000 ) FE ;
-    - IO_FILL_IO_WEST_6_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1550000 ) FE ;
-    - IO_FILL_IO_WEST_6_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1555000 ) FE ;
+    - IO_FILL_IO_WEST_6_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1540000 ) FE ;
     - IO_FILL_IO_WEST_6_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1440000 ) FE ;
     - IO_FILL_IO_WEST_6_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1460000 ) FE ;
     - IO_FILL_IO_WEST_6_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1480000 ) FE ;
     - IO_FILL_IO_WEST_6_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1500000 ) FE ;
     - IO_FILL_IO_WEST_7_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1636000 ) FE ;
     - IO_FILL_IO_WEST_7_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1736000 ) FE ;
-    - IO_FILL_IO_WEST_7_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 1756000 ) FE ;
-    - IO_FILL_IO_WEST_7_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1766000 ) FE ;
-    - IO_FILL_IO_WEST_7_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1771000 ) FE ;
+    - IO_FILL_IO_WEST_7_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1756000 ) FE ;
     - IO_FILL_IO_WEST_7_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1656000 ) FE ;
     - IO_FILL_IO_WEST_7_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1676000 ) FE ;
     - IO_FILL_IO_WEST_7_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1696000 ) FE ;
     - IO_FILL_IO_WEST_7_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1716000 ) FE ;
     - IO_FILL_IO_WEST_8_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1852000 ) FE ;
     - IO_FILL_IO_WEST_8_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1952000 ) FE ;
-    - IO_FILL_IO_WEST_8_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 1972000 ) FE ;
-    - IO_FILL_IO_WEST_8_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1982000 ) FE ;
-    - IO_FILL_IO_WEST_8_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 1987000 ) FE ;
+    - IO_FILL_IO_WEST_8_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1972000 ) FE ;
     - IO_FILL_IO_WEST_8_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1872000 ) FE ;
     - IO_FILL_IO_WEST_8_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1892000 ) FE ;
     - IO_FILL_IO_WEST_8_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1912000 ) FE ;
     - IO_FILL_IO_WEST_8_80 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 1932000 ) FE ;
     - IO_FILL_IO_WEST_9_0 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2068000 ) FE ;
     - IO_FILL_IO_WEST_9_100 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2168000 ) FE ;
-    - IO_FILL_IO_WEST_9_120 sky130_ef_io__com_bus_slice_10um + FIXED ( 0 2188000 ) FE ;
-    - IO_FILL_IO_WEST_9_130 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2198000 ) FE ;
-    - IO_FILL_IO_WEST_9_135 sky130_ef_io__com_bus_slice_5um + FIXED ( 0 2203000 ) FE ;
+    - IO_FILL_IO_WEST_9_120 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2188000 ) FE ;
     - IO_FILL_IO_WEST_9_20 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2088000 ) FE ;
     - IO_FILL_IO_WEST_9_40 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2108000 ) FE ;
     - IO_FILL_IO_WEST_9_60 sky130_ef_io__com_bus_slice_20um + FIXED ( 0 2128000 ) FE ;
@@ -3356,22 +3255,22 @@ PINS 722 ;
         + LAYER met5 ( -6147 -9255 ) ( 6148 9255 )
         + FIXED ( 747157 63630 ) N ;
     - resetb_core_h + NET resetb_core_h + DIRECTION OUTPUT + USE SIGNAL ;
-    - vccd + NET vccd + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vccd1 + NET vccd1 + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vccd2 + NET vccd2 + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vdda + NET vdda + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vdda1 + NET vdda1 + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vdda2 + NET vdda2 + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vddio + NET vddio + SPECIAL + DIRECTION INOUT + USE POWER ;
-    - vssa + NET vssa + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssa1 + NET vssa1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssa2 + NET vssa2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssd + NET vssd + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssd1 + NET vssd1 + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssd2 + NET vssd2 + SPECIAL + DIRECTION INOUT + USE GROUND ;
-    - vssio + NET vssio + SPECIAL + DIRECTION INOUT + USE GROUND ;
+    - vccd + NET vccd + DIRECTION INOUT + USE SIGNAL ;
+    - vccd1 + NET vccd1 + DIRECTION INOUT + USE SIGNAL ;
+    - vccd2 + NET vccd2 + DIRECTION INOUT + USE SIGNAL ;
+    - vdda + NET vdda + DIRECTION INOUT + USE SIGNAL ;
+    - vdda1 + NET vdda1 + DIRECTION INOUT + USE SIGNAL ;
+    - vdda2 + NET vdda2 + DIRECTION INOUT + USE SIGNAL ;
+    - vddio + NET vddio + DIRECTION INOUT + USE SIGNAL ;
+    - vssa + NET vssa + DIRECTION INOUT + USE SIGNAL ;
+    - vssa1 + NET vssa1 + DIRECTION INOUT + USE SIGNAL ;
+    - vssa2 + NET vssa2 + DIRECTION INOUT + USE SIGNAL ;
+    - vssd + NET vssd + DIRECTION INOUT + USE SIGNAL ;
+    - vssd1 + NET vssd1 + DIRECTION INOUT + USE SIGNAL ;
+    - vssd2 + NET vssd2 + DIRECTION INOUT + USE SIGNAL ;
+    - vssio + NET vssio + DIRECTION INOUT + USE SIGNAL ;
 END PINS
-SPECIALNETS 63 ;
+SPECIALNETS 45 ;
     - clock ( PIN clock ) ( clock_pad PAD ) + USE SIGNAL ;
     - flash_clk ( PIN flash_clk ) ( flash_clk_pad PAD ) + USE SIGNAL ;
     - flash_csb ( PIN flash_csb ) ( flash_csb_pad PAD ) + USE SIGNAL ;
@@ -3416,421 +3315,9 @@ SPECIALNETS 63 ;
     - mprj_io[7] ( PIN mprj_io[7] ) ( mprj_pads.area1_io_pad\[7\] PAD ) + USE SIGNAL ;
     - mprj_io[8] ( PIN mprj_io[8] ) ( mprj_pads.area1_io_pad\[8\] PAD ) + USE SIGNAL ;
     - mprj_io[9] ( PIN mprj_io[9] ) ( mprj_pads.area1_io_pad\[9\] PAD ) + USE SIGNAL ;
-    - mprj_pads.analog_a ( * AMUXBUS_A ) + USE SIGNAL ;
-    - mprj_pads.analog_b ( * AMUXBUS_B ) + USE SIGNAL ;
-    - mprj_pads.vddio_q ( * VDDIO_Q ) + USE POWER ;
-    - mprj_pads.vssio_q ( * VSSIO_Q ) + USE GROUND ;
     - resetb ( PIN resetb ) ( resetb_pad PAD ) + USE SIGNAL ;
-    - vccd ( PIN vccd ) ( IO_FILL_IO_SOUTH_0_40 VCCD ) ( * VCCHIB ) ( IO_FILL_IO_SOUTH_0_20 VCCD ) ( IO_FILL_IO_SOUTH_0_0 VCCD ) ( IO_FILL_IO_SOUTH_0_50 VCCD ) ( IO_FILL_IO_SOUTH_0_55 VCCD )
-      ( connect_0 VCCD ) ( IO_CORNER_SOUTH_WEST_INST VCCD ) ( IO_FILL_IO_WEST_0_0 VCCD ) ( connect_1 VCCD ) ( IO_FILL_IO_WEST_0_20 VCCD ) ( connect_2 VCCD ) ( IO_FILL_IO_WEST_0_40 VCCD ) ( connect_3 VCCD )
-      ( IO_FILL_IO_WEST_0_60 VCCD ) ( connect_4 VCCD ) ( brk_vdda_0 VCCD ) ( IO_FILL_IO_WEST_0_80 VCCD ) ( connect_5 VCCD ) ( IO_FILL_IO_EAST_0_145 VCCD ) ( IO_FILL_IO_EAST_0_140 VCCD ) ( IO_FILL_IO_EAST_0_120 VCCD )
-      ( IO_FILL_IO_EAST_0_100 VCCD ) ( IO_FILL_IO_EAST_0_80 VCCD ) ( IO_FILL_IO_EAST_0_60 VCCD ) ( IO_FILL_IO_EAST_0_40 VCCD ) ( IO_FILL_IO_EAST_0_20 VCCD ) ( IO_FILL_IO_EAST_0_0 VCCD ) ( IO_CORNER_SOUTH_EAST_INST VCCD ) ( IO_FILL_IO_WEST_0_100 VCCD )
-      ( IO_FILL_IO_SOUTH_23_20 VCCD ) ( IO_FILL_IO_SOUTH_17_20 VCCD ) ( IO_FILL_IO_SOUTH_15_20 VCCD ) ( IO_FILL_IO_SOUTH_13_20 VCCD ) ( IO_FILL_IO_SOUTH_11_20 VCCD ) ( IO_FILL_IO_SOUTH_9_20 VCCD ) ( IO_FILL_IO_SOUTH_5_20 VCCD ) ( IO_FILL_IO_SOUTH_1_0 VCCD )
-      ( IO_FILL_IO_SOUTH_23_0 VCCD ) ( connect_71 VCCD ) ( connect_70 VCCD ) ( connect_69 VCCD ) ( connect_68 VCCD ) ( connect_67 VCCD ) ( IO_FILL_IO_SOUTH_21_0 VCCD ) ( connect_65 VCCD )
-      ( connect_64 VCCD ) ( connect_63 VCCD ) ( connect_62 VCCD ) ( connect_61 VCCD ) ( IO_FILL_IO_SOUTH_19_0 VCCD ) ( connect_59 VCCD ) ( connect_58 VCCD ) ( connect_57 VCCD )
-      ( connect_56 VCCD ) ( connect_55 VCCD ) ( IO_FILL_IO_SOUTH_17_0 VCCD ) ( connect_53 VCCD ) ( connect_52 VCCD ) ( connect_51 VCCD ) ( connect_50 VCCD ) ( connect_49 VCCD )
-      ( IO_FILL_IO_SOUTH_15_0 VCCD ) ( connect_47 VCCD ) ( connect_46 VCCD ) ( connect_45 VCCD ) ( connect_44 VCCD ) ( connect_43 VCCD ) ( IO_FILL_IO_SOUTH_13_0 VCCD ) ( connect_41 VCCD )
-      ( connect_40 VCCD ) ( connect_39 VCCD ) ( connect_38 VCCD ) ( connect_37 VCCD ) ( IO_FILL_IO_SOUTH_11_0 VCCD ) ( connect_35 VCCD ) ( connect_34 VCCD ) ( connect_33 VCCD )
-      ( connect_32 VCCD ) ( connect_31 VCCD ) ( IO_FILL_IO_SOUTH_9_0 VCCD ) ( connect_29 VCCD ) ( connect_28 VCCD ) ( connect_27 VCCD ) ( connect_26 VCCD ) ( connect_25 VCCD )
-      ( IO_FILL_IO_SOUTH_7_0 VCCD ) ( connect_23 VCCD ) ( connect_22 VCCD ) ( connect_21 VCCD ) ( connect_20 VCCD ) ( connect_19 VCCD ) ( IO_FILL_IO_SOUTH_5_0 VCCD ) ( connect_17 VCCD )
-      ( connect_16 VCCD ) ( connect_15 VCCD ) ( connect_14 VCCD ) ( connect_13 VCCD ) ( IO_FILL_IO_SOUTH_3_0 VCCD ) ( connect_11 VCCD ) ( connect_10 VCCD ) ( connect_9 VCCD )
-      ( connect_8 VCCD ) ( connect_7 VCCD ) ( IO_FILL_IO_WEST_0_120 VCCD ) ( brk_vdda_2 VCCD ) ( IO_FILL_IO_SOUTH_21_20 VCCD ) ( IO_FILL_IO_SOUTH_19_20 VCCD ) ( IO_FILL_IO_SOUTH_17_40 VCCD ) ( IO_FILL_IO_SOUTH_15_40 VCCD )
-      ( IO_FILL_IO_SOUTH_13_40 VCCD ) ( IO_FILL_IO_SOUTH_11_40 VCCD ) ( IO_FILL_IO_SOUTH_9_40 VCCD ) ( IO_FILL_IO_SOUTH_7_20 VCCD ) ( IO_FILL_IO_SOUTH_5_40 VCCD ) ( IO_FILL_IO_SOUTH_3_20 VCCD ) ( IO_FILL_IO_SOUTH_1_20 VCCD ) ( connect_66 VCCD )
-      ( connect_60 VCCD ) ( connect_54 VCCD ) ( connect_48 VCCD ) ( connect_42 VCCD ) ( connect_36 VCCD ) ( connect_30 VCCD ) ( connect_24 VCCD ) ( connect_18 VCCD )
-      ( connect_12 VCCD ) ( connect_6 VCCD ) ( IO_FILL_IO_WEST_2_135 VCCD ) ( IO_FILL_IO_WEST_2_130 VCCD ) ( IO_FILL_IO_WEST_2_120 VCCD ) ( IO_FILL_IO_WEST_2_100 VCCD ) ( IO_FILL_IO_WEST_2_80 VCCD ) ( IO_FILL_IO_WEST_2_60 VCCD )
-      ( IO_FILL_IO_WEST_2_40 VCCD ) ( IO_FILL_IO_WEST_2_20 VCCD ) ( IO_FILL_IO_WEST_1_130 VCCD ) ( IO_FILL_IO_WEST_1_120 VCCD ) ( IO_FILL_IO_WEST_1_100 VCCD ) ( IO_FILL_IO_WEST_1_80 VCCD ) ( IO_FILL_IO_WEST_1_60 VCCD ) ( IO_FILL_IO_WEST_1_40 VCCD )
-      ( IO_FILL_IO_WEST_1_20 VCCD ) ( IO_FILL_IO_WEST_0_130 VCCD ) ( IO_FILL_IO_WEST_2_0 VCCD ) ( IO_FILL_IO_WEST_1_135 VCCD ) ( IO_FILL_IO_WEST_1_0 VCCD ) ( IO_FILL_IO_WEST_0_135 VCCD ) ( IO_FILL_IO_SOUTH_22_10 VCCD ) ( IO_FILL_IO_SOUTH_21_40 VCCD )
-      ( IO_FILL_IO_SOUTH_20_10 VCCD ) ( IO_FILL_IO_SOUTH_19_40 VCCD ) ( IO_FILL_IO_SOUTH_18_5 VCCD ) ( IO_FILL_IO_SOUTH_17_60 VCCD ) ( IO_FILL_IO_SOUTH_16_5 VCCD ) ( IO_FILL_IO_SOUTH_15_60 VCCD ) ( IO_FILL_IO_SOUTH_14_5 VCCD ) ( IO_FILL_IO_SOUTH_13_60 VCCD )
-      ( IO_FILL_IO_SOUTH_12_5 VCCD ) ( IO_FILL_IO_SOUTH_11_60 VCCD ) ( IO_FILL_IO_SOUTH_10_5 VCCD ) ( IO_FILL_IO_SOUTH_9_60 VCCD ) ( IO_FILL_IO_SOUTH_8_10 VCCD ) ( IO_FILL_IO_SOUTH_7_40 VCCD ) ( IO_FILL_IO_SOUTH_6_5 VCCD ) ( IO_FILL_IO_SOUTH_5_60 VCCD )
-      ( IO_FILL_IO_SOUTH_4_10 VCCD ) ( IO_FILL_IO_SOUTH_3_40 VCCD ) ( IO_FILL_IO_SOUTH_2_10 VCCD ) ( IO_FILL_IO_SOUTH_1_40 VCCD ) ( IO_FILL_IO_SOUTH_4_0 VCCD ) ( IO_FILL_IO_SOUTH_3_60 VCCD ) ( IO_FILL_IO_SOUTH_20_0 VCCD ) ( IO_FILL_IO_SOUTH_19_60 VCCD )
-      ( IO_FILL_IO_SOUTH_8_0 VCCD ) ( IO_FILL_IO_SOUTH_7_60 VCCD ) ( IO_FILL_IO_SOUTH_2_0 VCCD ) ( IO_FILL_IO_SOUTH_1_60 VCCD ) ( IO_FILL_IO_SOUTH_22_0 VCCD ) ( IO_FILL_IO_SOUTH_21_60 VCCD ) ( IO_FILL_IO_SOUTH_18_0 VCCD ) ( IO_FILL_IO_SOUTH_17_65 VCCD )
-      ( IO_FILL_IO_SOUTH_16_0 VCCD ) ( IO_FILL_IO_SOUTH_15_65 VCCD ) ( IO_FILL_IO_SOUTH_14_0 VCCD ) ( IO_FILL_IO_SOUTH_13_65 VCCD ) ( IO_FILL_IO_SOUTH_10_0 VCCD ) ( IO_FILL_IO_SOUTH_9_65 VCCD ) ( IO_FILL_IO_SOUTH_12_0 VCCD ) ( IO_FILL_IO_SOUTH_11_65 VCCD )
-      ( IO_FILL_IO_SOUTH_6_0 VCCD ) ( IO_FILL_IO_SOUTH_5_65 VCCD ) ( resetb_pad VCCD ) ( * ENABLE_VDDIO ) ( mgmt_vssio_hvclamp_pad\[0\] VCCD ) ( mgmt_vssd_lvclmap_pad VCCD ) ( mgmt_vssd_lvclmap_pad DRN_LVC2 ) ( mgmt_vssd_lvclmap_pad DRN_LVC1 )
-      ( mgmt_vssa_hvclamp_pad VCCD ) ( mgmt_vddio_hvclamp_pad\[0\] VCCD ) ( mgmt_vdda_hvclamp_pad VCCD ) ( mgmt_vccd_lvclamp_pad VCCD ) ( mgmt_vccd_lvclamp_pad DRN_LVC2 ) ( mgmt_vccd_lvclamp_pad DRN_LVC1 ) ( mgmt_corner\[1\] VCCD ) ( mgmt_corner\[0\] VCCD )
-      ( gpio_pad VCCD ) ( flash_io1_pad VCCD ) ( flash_io0_pad VCCD ) ( flash_csb_pad VCCD ) ( flash_csb_pad DM[2] ) ( flash_csb_pad DM[1] ) ( flash_clk_pad VCCD ) ( flash_clk_pad DM[2] )
-      ( flash_clk_pad DM[1] ) ( clock_pad VCCD ) ( clock_pad OE_N ) ( clock_pad DM[0] ) + USE POWER ;
-    - vccd1 ( PIN vccd1 ) ( IO_FILL_IO_EAST_1_0 VCCD ) ( IO_FILL_IO_NORTH_8_0 VCCD ) ( IO_FILL_IO_EAST_1_20 VCCD ) ( IO_FILL_IO_NORTH_8_20 VCCD ) ( IO_FILL_IO_EAST_1_40 VCCD ) ( IO_FILL_IO_NORTH_8_40 VCCD )
-      ( IO_FILL_IO_EAST_1_60 VCCD ) ( IO_FILL_IO_NORTH_8_60 VCCD ) ( IO_FILL_IO_EAST_1_80 VCCD ) ( IO_FILL_IO_NORTH_8_80 VCCD ) ( IO_FILL_IO_EAST_1_100 VCCD ) ( IO_FILL_IO_NORTH_8_100 VCCD ) ( IO_FILL_IO_EAST_1_120 VCCD ) ( IO_FILL_IO_NORTH_8_120 VCCD )
-      ( IO_FILL_IO_EAST_1_140 VCCD ) ( IO_FILL_IO_NORTH_8_140 VCCD ) ( IO_FILL_IO_EAST_1_160 VCCD ) ( IO_FILL_IO_NORTH_8_160 VCCD ) ( IO_CORNER_NORTH_EAST_INST VCCD ) ( IO_FILL_IO_EAST_21_65 VCCD ) ( IO_FILL_IO_EAST_21_60 VCCD ) ( IO_FILL_IO_EAST_21_40 VCCD )
-      ( IO_FILL_IO_EAST_21_20 VCCD ) ( IO_FILL_IO_EAST_20_120 VCCD ) ( IO_FILL_IO_EAST_20_100 VCCD ) ( IO_FILL_IO_EAST_20_80 VCCD ) ( IO_FILL_IO_EAST_20_60 VCCD ) ( IO_FILL_IO_EAST_20_40 VCCD ) ( IO_FILL_IO_EAST_20_20 VCCD ) ( IO_FILL_IO_EAST_19_120 VCCD )
-      ( IO_FILL_IO_EAST_19_100 VCCD ) ( IO_FILL_IO_EAST_19_80 VCCD ) ( IO_FILL_IO_EAST_19_60 VCCD ) ( IO_FILL_IO_EAST_19_40 VCCD ) ( IO_FILL_IO_EAST_19_20 VCCD ) ( IO_FILL_IO_EAST_18_120 VCCD ) ( IO_FILL_IO_EAST_18_100 VCCD ) ( IO_FILL_IO_EAST_18_80 VCCD )
-      ( IO_FILL_IO_EAST_18_60 VCCD ) ( IO_FILL_IO_EAST_18_40 VCCD ) ( IO_FILL_IO_EAST_18_20 VCCD ) ( IO_FILL_IO_EAST_17_120 VCCD ) ( IO_FILL_IO_EAST_17_100 VCCD ) ( IO_FILL_IO_EAST_17_80 VCCD ) ( IO_FILL_IO_EAST_17_60 VCCD ) ( IO_FILL_IO_EAST_17_40 VCCD )
-      ( IO_FILL_IO_EAST_17_20 VCCD ) ( IO_FILL_IO_EAST_16_120 VCCD ) ( IO_FILL_IO_EAST_16_100 VCCD ) ( IO_FILL_IO_EAST_16_80 VCCD ) ( IO_FILL_IO_EAST_16_60 VCCD ) ( IO_FILL_IO_EAST_16_40 VCCD ) ( IO_FILL_IO_EAST_16_20 VCCD ) ( IO_FILL_IO_EAST_15_120 VCCD )
-      ( IO_FILL_IO_EAST_15_100 VCCD ) ( IO_FILL_IO_EAST_15_80 VCCD ) ( IO_FILL_IO_EAST_15_60 VCCD ) ( IO_FILL_IO_EAST_15_40 VCCD ) ( IO_FILL_IO_EAST_15_20 VCCD ) ( IO_FILL_IO_EAST_14_140 VCCD ) ( IO_FILL_IO_EAST_14_120 VCCD ) ( IO_FILL_IO_EAST_14_100 VCCD )
-      ( IO_FILL_IO_EAST_14_80 VCCD ) ( IO_FILL_IO_EAST_14_60 VCCD ) ( IO_FILL_IO_EAST_14_40 VCCD ) ( IO_FILL_IO_EAST_14_20 VCCD ) ( IO_FILL_IO_EAST_13_120 VCCD ) ( IO_FILL_IO_EAST_13_100 VCCD ) ( IO_FILL_IO_EAST_13_80 VCCD ) ( IO_FILL_IO_EAST_13_60 VCCD )
-      ( IO_FILL_IO_EAST_13_40 VCCD ) ( IO_FILL_IO_EAST_13_20 VCCD ) ( IO_FILL_IO_EAST_12_140 VCCD ) ( IO_FILL_IO_EAST_12_120 VCCD ) ( IO_FILL_IO_EAST_12_100 VCCD ) ( IO_FILL_IO_EAST_12_80 VCCD ) ( IO_FILL_IO_EAST_12_60 VCCD ) ( IO_FILL_IO_EAST_12_40 VCCD )
-      ( IO_FILL_IO_EAST_12_20 VCCD ) ( IO_FILL_IO_EAST_11_120 VCCD ) ( IO_FILL_IO_EAST_11_100 VCCD ) ( IO_FILL_IO_EAST_11_80 VCCD ) ( IO_FILL_IO_EAST_11_60 VCCD ) ( IO_FILL_IO_EAST_11_40 VCCD ) ( IO_FILL_IO_EAST_11_20 VCCD ) ( IO_FILL_IO_EAST_10_120 VCCD )
-      ( IO_FILL_IO_EAST_10_100 VCCD ) ( IO_FILL_IO_EAST_10_80 VCCD ) ( IO_FILL_IO_EAST_10_60 VCCD ) ( IO_FILL_IO_EAST_10_40 VCCD ) ( IO_FILL_IO_EAST_10_20 VCCD ) ( IO_FILL_IO_EAST_9_140 VCCD ) ( IO_FILL_IO_EAST_9_120 VCCD ) ( IO_FILL_IO_EAST_9_100 VCCD )
-      ( IO_FILL_IO_EAST_9_80 VCCD ) ( IO_FILL_IO_EAST_9_60 VCCD ) ( IO_FILL_IO_EAST_9_40 VCCD ) ( IO_FILL_IO_EAST_9_20 VCCD ) ( IO_FILL_IO_EAST_8_100 VCCD ) ( IO_FILL_IO_EAST_8_80 VCCD ) ( IO_FILL_IO_EAST_8_60 VCCD ) ( IO_FILL_IO_EAST_8_40 VCCD )
-      ( IO_FILL_IO_EAST_8_20 VCCD ) ( IO_FILL_IO_EAST_7_140 VCCD ) ( IO_FILL_IO_EAST_7_120 VCCD ) ( IO_FILL_IO_EAST_7_100 VCCD ) ( IO_FILL_IO_EAST_7_80 VCCD ) ( IO_FILL_IO_EAST_7_60 VCCD ) ( IO_FILL_IO_EAST_7_40 VCCD ) ( IO_FILL_IO_EAST_7_20 VCCD )
-      ( IO_FILL_IO_EAST_6_120 VCCD ) ( IO_FILL_IO_EAST_6_100 VCCD ) ( IO_FILL_IO_EAST_6_80 VCCD ) ( IO_FILL_IO_EAST_6_60 VCCD ) ( IO_FILL_IO_EAST_6_40 VCCD ) ( IO_FILL_IO_EAST_6_20 VCCD ) ( IO_FILL_IO_EAST_5_120 VCCD ) ( IO_FILL_IO_EAST_5_100 VCCD )
-      ( IO_FILL_IO_EAST_5_80 VCCD ) ( IO_FILL_IO_EAST_5_60 VCCD ) ( IO_FILL_IO_EAST_5_40 VCCD ) ( IO_FILL_IO_EAST_5_20 VCCD ) ( IO_FILL_IO_EAST_4_140 VCCD ) ( IO_FILL_IO_EAST_4_120 VCCD ) ( IO_FILL_IO_EAST_4_100 VCCD ) ( IO_FILL_IO_EAST_4_80 VCCD )
-      ( IO_FILL_IO_EAST_4_60 VCCD ) ( IO_FILL_IO_EAST_4_40 VCCD ) ( IO_FILL_IO_EAST_4_20 VCCD ) ( IO_FILL_IO_EAST_3_120 VCCD ) ( IO_FILL_IO_EAST_3_100 VCCD ) ( IO_FILL_IO_EAST_3_80 VCCD ) ( IO_FILL_IO_EAST_3_60 VCCD ) ( IO_FILL_IO_EAST_3_40 VCCD )
-      ( IO_FILL_IO_EAST_3_20 VCCD ) ( IO_FILL_IO_EAST_2_140 VCCD ) ( IO_FILL_IO_EAST_2_120 VCCD ) ( IO_FILL_IO_EAST_2_100 VCCD ) ( IO_FILL_IO_EAST_2_80 VCCD ) ( IO_FILL_IO_EAST_2_60 VCCD ) ( IO_FILL_IO_EAST_2_40 VCCD ) ( IO_FILL_IO_EAST_2_20 VCCD )
-      ( IO_FILL_IO_EAST_1_180 VCCD ) ( IO_FILL_IO_EAST_10_0 VCCD ) ( IO_FILL_IO_EAST_9_145 VCCD ) ( IO_FILL_IO_EAST_9_0 VCCD ) ( IO_FILL_IO_EAST_8_140 VCCD ) ( IO_FILL_IO_EAST_8_120 VCCD ) ( IO_FILL_IO_EAST_11_0 VCCD ) ( IO_FILL_IO_EAST_10_140 VCCD )
-      ( IO_FILL_IO_EAST_18_0 VCCD ) ( IO_FILL_IO_EAST_17_140 VCCD ) ( IO_FILL_IO_EAST_20_0 VCCD ) ( IO_FILL_IO_EAST_19_140 VCCD ) ( IO_FILL_IO_EAST_14_0 VCCD ) ( IO_FILL_IO_EAST_13_140 VCCD ) ( IO_FILL_IO_EAST_13_0 VCCD ) ( IO_FILL_IO_EAST_12_145 VCCD )
-      ( IO_FILL_IO_EAST_12_0 VCCD ) ( IO_FILL_IO_EAST_11_150 VCCD ) ( IO_FILL_IO_EAST_11_140 VCCD ) ( IO_FILL_IO_EAST_8_0 VCCD ) ( IO_FILL_IO_EAST_7_145 VCCD ) ( IO_FILL_IO_EAST_7_0 VCCD ) ( IO_FILL_IO_EAST_6_140 VCCD ) ( IO_FILL_IO_EAST_6_0 VCCD )
-      ( IO_FILL_IO_EAST_5_140 VCCD ) ( IO_FILL_IO_EAST_5_0 VCCD ) ( IO_FILL_IO_EAST_4_145 VCCD ) ( IO_FILL_IO_EAST_4_0 VCCD ) ( IO_FILL_IO_EAST_3_140 VCCD ) ( IO_FILL_IO_EAST_3_0 VCCD ) ( IO_FILL_IO_EAST_2_145 VCCD ) ( IO_FILL_IO_EAST_21_0 VCCD )
-      ( IO_FILL_IO_EAST_20_150 VCCD ) ( IO_FILL_IO_EAST_20_140 VCCD ) ( IO_FILL_IO_EAST_19_0 VCCD ) ( IO_FILL_IO_EAST_18_150 VCCD ) ( IO_FILL_IO_EAST_18_140 VCCD ) ( IO_FILL_IO_EAST_17_0 VCCD ) ( IO_FILL_IO_EAST_16_140 VCCD ) ( IO_FILL_IO_EAST_16_0 VCCD )
-      ( IO_FILL_IO_EAST_15_140 VCCD ) ( IO_FILL_IO_EAST_15_0 VCCD ) ( IO_FILL_IO_EAST_14_145 VCCD ) ( IO_FILL_IO_EAST_2_0 VCCD ) ( IO_FILL_IO_EAST_1_220 VCCD ) ( IO_FILL_IO_EAST_1_200 VCCD ) ( IO_FILL_IO_NORTH_12_175 VCCD ) ( IO_FILL_IO_NORTH_12_170 VCCD )
-      ( IO_FILL_IO_NORTH_12_160 VCCD ) ( IO_FILL_IO_NORTH_12_140 VCCD ) ( IO_FILL_IO_NORTH_12_120 VCCD ) ( IO_FILL_IO_NORTH_12_100 VCCD ) ( IO_FILL_IO_NORTH_12_80 VCCD ) ( IO_FILL_IO_NORTH_12_60 VCCD ) ( IO_FILL_IO_NORTH_12_40 VCCD ) ( IO_FILL_IO_NORTH_12_20 VCCD )
-      ( IO_FILL_IO_NORTH_11_170 VCCD ) ( IO_FILL_IO_NORTH_11_160 VCCD ) ( IO_FILL_IO_NORTH_11_140 VCCD ) ( IO_FILL_IO_NORTH_11_120 VCCD ) ( IO_FILL_IO_NORTH_11_100 VCCD ) ( IO_FILL_IO_NORTH_11_80 VCCD ) ( IO_FILL_IO_NORTH_11_60 VCCD ) ( IO_FILL_IO_NORTH_11_40 VCCD )
-      ( IO_FILL_IO_NORTH_11_20 VCCD ) ( IO_FILL_IO_NORTH_10_170 VCCD ) ( IO_FILL_IO_NORTH_10_160 VCCD ) ( IO_FILL_IO_NORTH_10_140 VCCD ) ( IO_FILL_IO_NORTH_10_120 VCCD ) ( IO_FILL_IO_NORTH_10_100 VCCD ) ( IO_FILL_IO_NORTH_10_80 VCCD ) ( IO_FILL_IO_NORTH_10_60 VCCD )
-      ( IO_FILL_IO_NORTH_10_40 VCCD ) ( IO_FILL_IO_NORTH_10_20 VCCD ) ( IO_FILL_IO_NORTH_9_170 VCCD ) ( IO_FILL_IO_NORTH_9_160 VCCD ) ( IO_FILL_IO_NORTH_9_140 VCCD ) ( IO_FILL_IO_NORTH_9_120 VCCD ) ( IO_FILL_IO_NORTH_9_100 VCCD ) ( IO_FILL_IO_NORTH_9_80 VCCD )
-      ( IO_FILL_IO_NORTH_9_60 VCCD ) ( IO_FILL_IO_NORTH_9_40 VCCD ) ( IO_FILL_IO_NORTH_9_20 VCCD ) ( IO_FILL_IO_NORTH_8_170 VCCD ) ( IO_FILL_IO_NORTH_11_0 VCCD ) ( IO_FILL_IO_NORTH_10_175 VCCD ) ( IO_FILL_IO_NORTH_9_0 VCCD ) ( IO_FILL_IO_NORTH_8_175 VCCD )
-      ( IO_FILL_IO_NORTH_10_0 VCCD ) ( IO_FILL_IO_NORTH_9_175 VCCD ) ( IO_FILL_IO_NORTH_12_0 VCCD ) ( IO_FILL_IO_NORTH_11_175 VCCD ) ( user1_vssd_lvclmap_pad VCCD ) ( user1_vssd_lvclmap_pad DRN_LVC2 ) ( user1_vssd_lvclmap_pad DRN_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VCCD )
-      ( user1_vssa_hvclamp_pad\[0\] VCCD ) ( user1_vdda_hvclamp_pad\[1\] VCCD ) ( user1_vdda_hvclamp_pad\[0\] VCCD ) ( user1_vccd_lvclamp_pad VCCD ) ( user1_vccd_lvclamp_pad DRN_LVC2 ) ( user1_vccd_lvclamp_pad DRN_LVC1 ) ( user1_corner VCCD ) ( mprj_pads.area1_io_pad\[9\] VCCD )
-      ( mprj_pads.area1_io_pad\[8\] VCCD ) ( mprj_pads.area1_io_pad\[7\] VCCD ) ( mprj_pads.area1_io_pad\[6\] VCCD ) ( mprj_pads.area1_io_pad\[5\] VCCD ) ( mprj_pads.area1_io_pad\[4\] VCCD ) ( mprj_pads.area1_io_pad\[3\] VCCD ) ( mprj_pads.area1_io_pad\[2\] VCCD ) ( mprj_pads.area1_io_pad\[1\] VCCD )
-      ( mprj_pads.area1_io_pad\[17\] VCCD ) ( mprj_pads.area1_io_pad\[16\] VCCD ) ( mprj_pads.area1_io_pad\[15\] VCCD ) ( mprj_pads.area1_io_pad\[14\] VCCD ) ( mprj_pads.area1_io_pad\[13\] VCCD ) ( mprj_pads.area1_io_pad\[12\] VCCD ) ( mprj_pads.area1_io_pad\[11\] VCCD ) ( mprj_pads.area1_io_pad\[10\] VCCD )
-      ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE POWER ;
-    - vccd2 ( PIN vccd2 ) ( IO_FILL_IO_WEST_3_0 VCCD ) ( IO_FILL_IO_WEST_3_20 VCCD ) ( IO_FILL_IO_WEST_3_40 VCCD ) ( IO_FILL_IO_WEST_3_60 VCCD ) ( IO_FILL_IO_WEST_3_80 VCCD ) ( IO_FILL_IO_WEST_3_100 VCCD )
-      ( IO_FILL_IO_WEST_3_120 VCCD ) ( IO_FILL_IO_NORTH_0_140 VCCD ) ( IO_FILL_IO_NORTH_0_120 VCCD ) ( IO_FILL_IO_NORTH_0_100 VCCD ) ( IO_FILL_IO_NORTH_0_80 VCCD ) ( IO_FILL_IO_NORTH_0_60 VCCD ) ( IO_FILL_IO_NORTH_0_40 VCCD ) ( IO_FILL_IO_NORTH_0_20 VCCD )
-      ( brk_vdda_1 VCCD ) ( IO_FILL_IO_NORTH_0_0 VCCD ) ( IO_CORNER_NORTH_WEST_INST VCCD ) ( IO_FILL_IO_WEST_22_130 VCCD ) ( IO_FILL_IO_WEST_22_120 VCCD ) ( IO_FILL_IO_WEST_22_100 VCCD ) ( IO_FILL_IO_WEST_22_80 VCCD ) ( IO_FILL_IO_WEST_22_60 VCCD )
-      ( IO_FILL_IO_WEST_22_40 VCCD ) ( IO_FILL_IO_WEST_22_20 VCCD ) ( IO_FILL_IO_WEST_21_130 VCCD ) ( IO_FILL_IO_WEST_21_120 VCCD ) ( IO_FILL_IO_WEST_21_100 VCCD ) ( IO_FILL_IO_WEST_21_80 VCCD ) ( IO_FILL_IO_WEST_21_60 VCCD ) ( IO_FILL_IO_WEST_21_40 VCCD )
-      ( IO_FILL_IO_WEST_21_20 VCCD ) ( IO_FILL_IO_WEST_20_130 VCCD ) ( IO_FILL_IO_WEST_20_120 VCCD ) ( IO_FILL_IO_WEST_20_100 VCCD ) ( IO_FILL_IO_WEST_20_80 VCCD ) ( IO_FILL_IO_WEST_20_60 VCCD ) ( IO_FILL_IO_WEST_20_40 VCCD ) ( IO_FILL_IO_WEST_20_20 VCCD )
-      ( IO_FILL_IO_WEST_19_130 VCCD ) ( IO_FILL_IO_WEST_19_120 VCCD ) ( IO_FILL_IO_WEST_19_100 VCCD ) ( IO_FILL_IO_WEST_19_80 VCCD ) ( IO_FILL_IO_WEST_19_60 VCCD ) ( IO_FILL_IO_WEST_19_40 VCCD ) ( IO_FILL_IO_WEST_19_20 VCCD ) ( IO_FILL_IO_WEST_18_130 VCCD )
-      ( IO_FILL_IO_WEST_18_120 VCCD ) ( IO_FILL_IO_WEST_18_100 VCCD ) ( IO_FILL_IO_WEST_18_80 VCCD ) ( IO_FILL_IO_WEST_18_60 VCCD ) ( IO_FILL_IO_WEST_18_40 VCCD ) ( IO_FILL_IO_WEST_18_20 VCCD ) ( IO_FILL_IO_WEST_17_130 VCCD ) ( IO_FILL_IO_WEST_17_120 VCCD )
-      ( IO_FILL_IO_WEST_17_100 VCCD ) ( IO_FILL_IO_WEST_17_80 VCCD ) ( IO_FILL_IO_WEST_17_60 VCCD ) ( IO_FILL_IO_WEST_17_40 VCCD ) ( IO_FILL_IO_WEST_17_20 VCCD ) ( IO_FILL_IO_WEST_16_130 VCCD ) ( IO_FILL_IO_WEST_16_120 VCCD ) ( IO_FILL_IO_WEST_16_100 VCCD )
-      ( IO_FILL_IO_WEST_16_80 VCCD ) ( IO_FILL_IO_WEST_16_60 VCCD ) ( IO_FILL_IO_WEST_16_40 VCCD ) ( IO_FILL_IO_WEST_16_20 VCCD ) ( IO_FILL_IO_WEST_15_130 VCCD ) ( IO_FILL_IO_WEST_15_120 VCCD ) ( IO_FILL_IO_WEST_15_100 VCCD ) ( IO_FILL_IO_WEST_15_80 VCCD )
-      ( IO_FILL_IO_WEST_15_60 VCCD ) ( IO_FILL_IO_WEST_15_40 VCCD ) ( IO_FILL_IO_WEST_15_20 VCCD ) ( IO_FILL_IO_WEST_14_130 VCCD ) ( IO_FILL_IO_WEST_14_120 VCCD ) ( IO_FILL_IO_WEST_14_100 VCCD ) ( IO_FILL_IO_WEST_14_80 VCCD ) ( IO_FILL_IO_WEST_14_60 VCCD )
-      ( IO_FILL_IO_WEST_14_40 VCCD ) ( IO_FILL_IO_WEST_14_20 VCCD ) ( IO_FILL_IO_WEST_13_130 VCCD ) ( IO_FILL_IO_WEST_13_120 VCCD ) ( IO_FILL_IO_WEST_13_100 VCCD ) ( IO_FILL_IO_WEST_13_80 VCCD ) ( IO_FILL_IO_WEST_13_60 VCCD ) ( IO_FILL_IO_WEST_13_40 VCCD )
-      ( IO_FILL_IO_WEST_13_20 VCCD ) ( IO_FILL_IO_WEST_12_130 VCCD ) ( IO_FILL_IO_WEST_12_120 VCCD ) ( IO_FILL_IO_WEST_12_100 VCCD ) ( IO_FILL_IO_WEST_12_80 VCCD ) ( IO_FILL_IO_WEST_12_60 VCCD ) ( IO_FILL_IO_WEST_12_40 VCCD ) ( IO_FILL_IO_WEST_12_20 VCCD )
-      ( IO_FILL_IO_WEST_11_130 VCCD ) ( IO_FILL_IO_WEST_11_120 VCCD ) ( IO_FILL_IO_WEST_11_100 VCCD ) ( IO_FILL_IO_WEST_11_80 VCCD ) ( IO_FILL_IO_WEST_11_60 VCCD ) ( IO_FILL_IO_WEST_11_40 VCCD ) ( IO_FILL_IO_WEST_11_20 VCCD ) ( IO_FILL_IO_WEST_10_130 VCCD )
-      ( IO_FILL_IO_WEST_10_120 VCCD ) ( IO_FILL_IO_WEST_10_100 VCCD ) ( IO_FILL_IO_WEST_10_80 VCCD ) ( IO_FILL_IO_WEST_10_60 VCCD ) ( IO_FILL_IO_WEST_10_40 VCCD ) ( IO_FILL_IO_WEST_10_20 VCCD ) ( IO_FILL_IO_WEST_9_130 VCCD ) ( IO_FILL_IO_WEST_9_120 VCCD )
-      ( IO_FILL_IO_WEST_9_100 VCCD ) ( IO_FILL_IO_WEST_9_80 VCCD ) ( IO_FILL_IO_WEST_9_60 VCCD ) ( IO_FILL_IO_WEST_9_40 VCCD ) ( IO_FILL_IO_WEST_9_20 VCCD ) ( IO_FILL_IO_WEST_8_130 VCCD ) ( IO_FILL_IO_WEST_8_120 VCCD ) ( IO_FILL_IO_WEST_8_100 VCCD )
-      ( IO_FILL_IO_WEST_8_80 VCCD ) ( IO_FILL_IO_WEST_8_60 VCCD ) ( IO_FILL_IO_WEST_8_40 VCCD ) ( IO_FILL_IO_WEST_8_20 VCCD ) ( IO_FILL_IO_WEST_7_130 VCCD ) ( IO_FILL_IO_WEST_7_120 VCCD ) ( IO_FILL_IO_WEST_7_100 VCCD ) ( IO_FILL_IO_WEST_7_80 VCCD )
-      ( IO_FILL_IO_WEST_7_60 VCCD ) ( IO_FILL_IO_WEST_7_40 VCCD ) ( IO_FILL_IO_WEST_7_20 VCCD ) ( IO_FILL_IO_WEST_6_130 VCCD ) ( IO_FILL_IO_WEST_6_120 VCCD ) ( IO_FILL_IO_WEST_6_100 VCCD ) ( IO_FILL_IO_WEST_6_80 VCCD ) ( IO_FILL_IO_WEST_6_60 VCCD )
-      ( IO_FILL_IO_WEST_6_40 VCCD ) ( IO_FILL_IO_WEST_6_20 VCCD ) ( IO_FILL_IO_WEST_5_130 VCCD ) ( IO_FILL_IO_WEST_5_120 VCCD ) ( IO_FILL_IO_WEST_5_100 VCCD ) ( IO_FILL_IO_WEST_5_80 VCCD ) ( IO_FILL_IO_WEST_5_60 VCCD ) ( IO_FILL_IO_WEST_5_40 VCCD )
-      ( IO_FILL_IO_WEST_5_20 VCCD ) ( IO_FILL_IO_WEST_4_130 VCCD ) ( IO_FILL_IO_WEST_4_120 VCCD ) ( IO_FILL_IO_WEST_4_100 VCCD ) ( IO_FILL_IO_WEST_4_80 VCCD ) ( IO_FILL_IO_WEST_4_60 VCCD ) ( IO_FILL_IO_WEST_4_40 VCCD ) ( IO_FILL_IO_WEST_4_20 VCCD )
-      ( IO_FILL_IO_WEST_3_130 VCCD ) ( IO_FILL_IO_WEST_10_0 VCCD ) ( IO_FILL_IO_WEST_9_135 VCCD ) ( IO_FILL_IO_WEST_19_0 VCCD ) ( IO_FILL_IO_WEST_18_135 VCCD ) ( IO_FILL_IO_WEST_11_0 VCCD ) ( IO_FILL_IO_WEST_10_135 VCCD ) ( IO_FILL_IO_WEST_21_0 VCCD )
-      ( IO_FILL_IO_WEST_20_135 VCCD ) ( IO_FILL_IO_WEST_16_0 VCCD ) ( IO_FILL_IO_WEST_15_135 VCCD ) ( IO_FILL_IO_WEST_17_0 VCCD ) ( IO_FILL_IO_WEST_16_135 VCCD ) ( IO_FILL_IO_WEST_18_0 VCCD ) ( IO_FILL_IO_WEST_17_135 VCCD ) ( IO_FILL_IO_WEST_22_0 VCCD )
-      ( IO_FILL_IO_WEST_21_135 VCCD ) ( IO_FILL_IO_WEST_4_0 VCCD ) ( IO_FILL_IO_WEST_3_135 VCCD ) ( IO_FILL_IO_WEST_5_0 VCCD ) ( IO_FILL_IO_WEST_4_135 VCCD ) ( IO_FILL_IO_WEST_6_0 VCCD ) ( IO_FILL_IO_WEST_5_135 VCCD ) ( IO_FILL_IO_WEST_7_0 VCCD )
-      ( IO_FILL_IO_WEST_6_135 VCCD ) ( IO_FILL_IO_WEST_8_0 VCCD ) ( IO_FILL_IO_WEST_7_135 VCCD ) ( IO_FILL_IO_WEST_9_0 VCCD ) ( IO_FILL_IO_WEST_8_135 VCCD ) ( IO_FILL_IO_WEST_12_0 VCCD ) ( IO_FILL_IO_WEST_11_135 VCCD ) ( IO_FILL_IO_WEST_13_0 VCCD )
-      ( IO_FILL_IO_WEST_12_135 VCCD ) ( IO_FILL_IO_WEST_14_0 VCCD ) ( IO_FILL_IO_WEST_13_135 VCCD ) ( IO_FILL_IO_WEST_15_0 VCCD ) ( IO_FILL_IO_WEST_14_135 VCCD ) ( IO_FILL_IO_WEST_20_0 VCCD ) ( IO_FILL_IO_WEST_19_135 VCCD ) ( IO_FILL_IO_NORTH_7_175 VCCD )
-      ( IO_FILL_IO_NORTH_7_170 VCCD ) ( IO_FILL_IO_NORTH_7_160 VCCD ) ( IO_FILL_IO_NORTH_7_140 VCCD ) ( IO_FILL_IO_NORTH_7_120 VCCD ) ( IO_FILL_IO_NORTH_7_100 VCCD ) ( IO_FILL_IO_NORTH_7_80 VCCD ) ( IO_FILL_IO_NORTH_7_60 VCCD ) ( IO_FILL_IO_NORTH_7_40 VCCD )
-      ( IO_FILL_IO_NORTH_7_20 VCCD ) ( IO_FILL_IO_NORTH_6_170 VCCD ) ( IO_FILL_IO_NORTH_6_160 VCCD ) ( IO_FILL_IO_NORTH_6_140 VCCD ) ( IO_FILL_IO_NORTH_6_120 VCCD ) ( IO_FILL_IO_NORTH_6_100 VCCD ) ( IO_FILL_IO_NORTH_6_80 VCCD ) ( IO_FILL_IO_NORTH_6_60 VCCD )
-      ( IO_FILL_IO_NORTH_6_40 VCCD ) ( IO_FILL_IO_NORTH_6_20 VCCD ) ( IO_FILL_IO_NORTH_5_170 VCCD ) ( IO_FILL_IO_NORTH_5_160 VCCD ) ( IO_FILL_IO_NORTH_5_140 VCCD ) ( IO_FILL_IO_NORTH_5_120 VCCD ) ( IO_FILL_IO_NORTH_5_100 VCCD ) ( IO_FILL_IO_NORTH_5_80 VCCD )
-      ( IO_FILL_IO_NORTH_5_60 VCCD ) ( IO_FILL_IO_NORTH_5_40 VCCD ) ( IO_FILL_IO_NORTH_5_20 VCCD ) ( IO_FILL_IO_NORTH_4_170 VCCD ) ( IO_FILL_IO_NORTH_4_160 VCCD ) ( IO_FILL_IO_NORTH_4_140 VCCD ) ( IO_FILL_IO_NORTH_4_120 VCCD ) ( IO_FILL_IO_NORTH_4_100 VCCD )
-      ( IO_FILL_IO_NORTH_4_80 VCCD ) ( IO_FILL_IO_NORTH_4_60 VCCD ) ( IO_FILL_IO_NORTH_4_40 VCCD ) ( IO_FILL_IO_NORTH_4_20 VCCD ) ( IO_FILL_IO_NORTH_3_170 VCCD ) ( IO_FILL_IO_NORTH_3_160 VCCD ) ( IO_FILL_IO_NORTH_3_140 VCCD ) ( IO_FILL_IO_NORTH_3_120 VCCD )
-      ( IO_FILL_IO_NORTH_3_100 VCCD ) ( IO_FILL_IO_NORTH_3_80 VCCD ) ( IO_FILL_IO_NORTH_3_60 VCCD ) ( IO_FILL_IO_NORTH_3_40 VCCD ) ( IO_FILL_IO_NORTH_3_20 VCCD ) ( IO_FILL_IO_NORTH_2_170 VCCD ) ( IO_FILL_IO_NORTH_2_160 VCCD ) ( IO_FILL_IO_NORTH_2_140 VCCD )
-      ( IO_FILL_IO_NORTH_2_120 VCCD ) ( IO_FILL_IO_NORTH_2_100 VCCD ) ( IO_FILL_IO_NORTH_2_80 VCCD ) ( IO_FILL_IO_NORTH_2_60 VCCD ) ( IO_FILL_IO_NORTH_2_40 VCCD ) ( IO_FILL_IO_NORTH_2_20 VCCD ) ( IO_FILL_IO_NORTH_1_170 VCCD ) ( IO_FILL_IO_NORTH_1_160 VCCD )
-      ( IO_FILL_IO_NORTH_1_140 VCCD ) ( IO_FILL_IO_NORTH_1_120 VCCD ) ( IO_FILL_IO_NORTH_1_100 VCCD ) ( IO_FILL_IO_NORTH_1_80 VCCD ) ( IO_FILL_IO_NORTH_1_60 VCCD ) ( IO_FILL_IO_NORTH_1_40 VCCD ) ( IO_FILL_IO_NORTH_1_20 VCCD ) ( IO_FILL_IO_NORTH_0_160 VCCD )
-      ( IO_FILL_IO_NORTH_1_0 VCCD ) ( IO_FILL_IO_NORTH_0_180 VCCD ) ( IO_FILL_IO_NORTH_2_0 VCCD ) ( IO_FILL_IO_NORTH_1_175 VCCD ) ( IO_FILL_IO_NORTH_3_0 VCCD ) ( IO_FILL_IO_NORTH_2_175 VCCD ) ( IO_FILL_IO_NORTH_4_0 VCCD ) ( IO_FILL_IO_NORTH_3_175 VCCD )
-      ( IO_FILL_IO_NORTH_5_0 VCCD ) ( IO_FILL_IO_NORTH_4_175 VCCD ) ( IO_FILL_IO_NORTH_7_0 VCCD ) ( IO_FILL_IO_NORTH_6_175 VCCD ) ( IO_FILL_IO_NORTH_6_0 VCCD ) ( IO_FILL_IO_NORTH_5_175 VCCD ) ( user2_vssd_lvclmap_pad VCCD ) ( user2_vssd_lvclmap_pad DRN_LVC2 )
-      ( user2_vssd_lvclmap_pad DRN_LVC1 ) ( user2_vssa_hvclamp_pad VCCD ) ( user2_vdda_hvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad DRN_LVC2 ) ( user2_vccd_lvclamp_pad DRN_LVC1 ) ( user2_corner VCCD ) ( mprj_pads.area2_io_pad\[9\] VCCD )
-      ( mprj_pads.area2_io_pad\[8\] VCCD ) ( mprj_pads.area2_io_pad\[7\] VCCD ) ( mprj_pads.area2_io_pad\[6\] VCCD ) ( mprj_pads.area2_io_pad\[5\] VCCD ) ( mprj_pads.area2_io_pad\[4\] VCCD ) ( mprj_pads.area2_io_pad\[3\] VCCD ) ( mprj_pads.area2_io_pad\[2\] VCCD ) ( mprj_pads.area2_io_pad\[1\] VCCD )
-      ( mprj_pads.area2_io_pad\[19\] VCCD ) ( mprj_pads.area2_io_pad\[18\] VCCD ) ( mprj_pads.area2_io_pad\[17\] VCCD ) ( mprj_pads.area2_io_pad\[16\] VCCD ) ( mprj_pads.area2_io_pad\[15\] VCCD ) ( mprj_pads.area2_io_pad\[14\] VCCD ) ( mprj_pads.area2_io_pad\[13\] VCCD ) ( mprj_pads.area2_io_pad\[12\] VCCD )
-      ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE POWER ;
-    - vdda ( PIN vdda ) ( IO_FILL_IO_SOUTH_0_40 VDDA ) ( IO_FILL_IO_SOUTH_0_20 VDDA ) ( IO_FILL_IO_SOUTH_0_0 VDDA ) ( IO_FILL_IO_SOUTH_0_50 VDDA ) ( IO_FILL_IO_SOUTH_0_55 VDDA ) ( connect_0 VDDA )
-      ( IO_CORNER_SOUTH_WEST_INST VDDA ) ( IO_FILL_IO_WEST_0_0 VDDA ) ( connect_1 VDDA ) ( IO_FILL_IO_WEST_0_20 VDDA ) ( connect_2 VDDA ) ( IO_FILL_IO_WEST_0_40 VDDA ) ( connect_3 VDDA ) ( IO_FILL_IO_WEST_0_60 VDDA )
-      ( connect_4 VDDA ) ( IO_FILL_IO_WEST_0_80 VDDA ) ( connect_5 VDDA ) ( IO_FILL_IO_EAST_0_145 VDDA ) ( IO_FILL_IO_EAST_0_140 VDDA ) ( IO_FILL_IO_EAST_0_120 VDDA ) ( IO_FILL_IO_EAST_0_100 VDDA ) ( IO_FILL_IO_EAST_0_80 VDDA )
-      ( IO_FILL_IO_EAST_0_60 VDDA ) ( IO_FILL_IO_EAST_0_40 VDDA ) ( IO_FILL_IO_EAST_0_20 VDDA ) ( IO_FILL_IO_EAST_0_0 VDDA ) ( IO_CORNER_SOUTH_EAST_INST VDDA ) ( IO_FILL_IO_WEST_0_100 VDDA ) ( IO_FILL_IO_SOUTH_23_20 VDDA ) ( IO_FILL_IO_SOUTH_17_20 VDDA )
-      ( IO_FILL_IO_SOUTH_15_20 VDDA ) ( IO_FILL_IO_SOUTH_13_20 VDDA ) ( IO_FILL_IO_SOUTH_11_20 VDDA ) ( IO_FILL_IO_SOUTH_9_20 VDDA ) ( IO_FILL_IO_SOUTH_5_20 VDDA ) ( IO_FILL_IO_SOUTH_1_0 VDDA ) ( IO_FILL_IO_SOUTH_23_0 VDDA ) ( connect_71 VDDA )
-      ( connect_70 VDDA ) ( connect_69 VDDA ) ( connect_68 VDDA ) ( connect_67 VDDA ) ( IO_FILL_IO_SOUTH_21_0 VDDA ) ( connect_65 VDDA ) ( connect_64 VDDA ) ( connect_63 VDDA )
-      ( connect_62 VDDA ) ( connect_61 VDDA ) ( IO_FILL_IO_SOUTH_19_0 VDDA ) ( connect_59 VDDA ) ( connect_58 VDDA ) ( connect_57 VDDA ) ( connect_56 VDDA ) ( connect_55 VDDA )
-      ( IO_FILL_IO_SOUTH_17_0 VDDA ) ( connect_53 VDDA ) ( connect_52 VDDA ) ( connect_51 VDDA ) ( connect_50 VDDA ) ( connect_49 VDDA ) ( IO_FILL_IO_SOUTH_15_0 VDDA ) ( connect_47 VDDA )
-      ( connect_46 VDDA ) ( connect_45 VDDA ) ( connect_44 VDDA ) ( connect_43 VDDA ) ( IO_FILL_IO_SOUTH_13_0 VDDA ) ( connect_41 VDDA ) ( connect_40 VDDA ) ( connect_39 VDDA )
-      ( connect_38 VDDA ) ( connect_37 VDDA ) ( IO_FILL_IO_SOUTH_11_0 VDDA ) ( connect_35 VDDA ) ( connect_34 VDDA ) ( connect_33 VDDA ) ( connect_32 VDDA ) ( connect_31 VDDA )
-      ( IO_FILL_IO_SOUTH_9_0 VDDA ) ( connect_29 VDDA ) ( connect_28 VDDA ) ( connect_27 VDDA ) ( connect_26 VDDA ) ( connect_25 VDDA ) ( IO_FILL_IO_SOUTH_7_0 VDDA ) ( connect_23 VDDA )
-      ( connect_22 VDDA ) ( connect_21 VDDA ) ( connect_20 VDDA ) ( connect_19 VDDA ) ( IO_FILL_IO_SOUTH_5_0 VDDA ) ( connect_17 VDDA ) ( connect_16 VDDA ) ( connect_15 VDDA )
-      ( connect_14 VDDA ) ( connect_13 VDDA ) ( IO_FILL_IO_SOUTH_3_0 VDDA ) ( connect_11 VDDA ) ( connect_10 VDDA ) ( connect_9 VDDA ) ( connect_8 VDDA ) ( connect_7 VDDA )
-      ( IO_FILL_IO_WEST_0_120 VDDA ) ( IO_FILL_IO_SOUTH_21_20 VDDA ) ( IO_FILL_IO_SOUTH_19_20 VDDA ) ( IO_FILL_IO_SOUTH_17_40 VDDA ) ( IO_FILL_IO_SOUTH_15_40 VDDA ) ( IO_FILL_IO_SOUTH_13_40 VDDA ) ( IO_FILL_IO_SOUTH_11_40 VDDA ) ( IO_FILL_IO_SOUTH_9_40 VDDA )
-      ( IO_FILL_IO_SOUTH_7_20 VDDA ) ( IO_FILL_IO_SOUTH_5_40 VDDA ) ( IO_FILL_IO_SOUTH_3_20 VDDA ) ( IO_FILL_IO_SOUTH_1_20 VDDA ) ( connect_66 VDDA ) ( connect_60 VDDA ) ( connect_54 VDDA ) ( connect_48 VDDA )
-      ( connect_42 VDDA ) ( connect_36 VDDA ) ( connect_30 VDDA ) ( connect_24 VDDA ) ( connect_18 VDDA ) ( connect_12 VDDA ) ( connect_6 VDDA ) ( IO_FILL_IO_WEST_2_135 VDDA )
-      ( IO_FILL_IO_WEST_2_130 VDDA ) ( IO_FILL_IO_WEST_2_120 VDDA ) ( IO_FILL_IO_WEST_2_100 VDDA ) ( IO_FILL_IO_WEST_2_80 VDDA ) ( IO_FILL_IO_WEST_2_60 VDDA ) ( IO_FILL_IO_WEST_2_40 VDDA ) ( IO_FILL_IO_WEST_2_20 VDDA ) ( IO_FILL_IO_WEST_1_130 VDDA )
-      ( IO_FILL_IO_WEST_1_120 VDDA ) ( IO_FILL_IO_WEST_1_100 VDDA ) ( IO_FILL_IO_WEST_1_80 VDDA ) ( IO_FILL_IO_WEST_1_60 VDDA ) ( IO_FILL_IO_WEST_1_40 VDDA ) ( IO_FILL_IO_WEST_1_20 VDDA ) ( IO_FILL_IO_WEST_0_130 VDDA ) ( IO_FILL_IO_WEST_2_0 VDDA )
-      ( IO_FILL_IO_WEST_1_135 VDDA ) ( IO_FILL_IO_WEST_1_0 VDDA ) ( IO_FILL_IO_WEST_0_135 VDDA ) ( IO_FILL_IO_SOUTH_22_10 VDDA ) ( IO_FILL_IO_SOUTH_21_40 VDDA ) ( IO_FILL_IO_SOUTH_20_10 VDDA ) ( IO_FILL_IO_SOUTH_19_40 VDDA ) ( IO_FILL_IO_SOUTH_18_5 VDDA )
-      ( IO_FILL_IO_SOUTH_17_60 VDDA ) ( IO_FILL_IO_SOUTH_16_5 VDDA ) ( IO_FILL_IO_SOUTH_15_60 VDDA ) ( IO_FILL_IO_SOUTH_14_5 VDDA ) ( IO_FILL_IO_SOUTH_13_60 VDDA ) ( IO_FILL_IO_SOUTH_12_5 VDDA ) ( IO_FILL_IO_SOUTH_11_60 VDDA ) ( IO_FILL_IO_SOUTH_10_5 VDDA )
-      ( IO_FILL_IO_SOUTH_9_60 VDDA ) ( IO_FILL_IO_SOUTH_8_10 VDDA ) ( IO_FILL_IO_SOUTH_7_40 VDDA ) ( IO_FILL_IO_SOUTH_6_5 VDDA ) ( IO_FILL_IO_SOUTH_5_60 VDDA ) ( IO_FILL_IO_SOUTH_4_10 VDDA ) ( IO_FILL_IO_SOUTH_3_40 VDDA ) ( IO_FILL_IO_SOUTH_2_10 VDDA )
-      ( IO_FILL_IO_SOUTH_1_40 VDDA ) ( IO_FILL_IO_SOUTH_4_0 VDDA ) ( IO_FILL_IO_SOUTH_3_60 VDDA ) ( IO_FILL_IO_SOUTH_20_0 VDDA ) ( IO_FILL_IO_SOUTH_19_60 VDDA ) ( IO_FILL_IO_SOUTH_8_0 VDDA ) ( IO_FILL_IO_SOUTH_7_60 VDDA ) ( IO_FILL_IO_SOUTH_2_0 VDDA )
-      ( IO_FILL_IO_SOUTH_1_60 VDDA ) ( IO_FILL_IO_SOUTH_22_0 VDDA ) ( IO_FILL_IO_SOUTH_21_60 VDDA ) ( IO_FILL_IO_SOUTH_18_0 VDDA ) ( IO_FILL_IO_SOUTH_17_65 VDDA ) ( IO_FILL_IO_SOUTH_16_0 VDDA ) ( IO_FILL_IO_SOUTH_15_65 VDDA ) ( IO_FILL_IO_SOUTH_14_0 VDDA )
-      ( IO_FILL_IO_SOUTH_13_65 VDDA ) ( IO_FILL_IO_SOUTH_10_0 VDDA ) ( IO_FILL_IO_SOUTH_9_65 VDDA ) ( IO_FILL_IO_SOUTH_12_0 VDDA ) ( IO_FILL_IO_SOUTH_11_65 VDDA ) ( IO_FILL_IO_SOUTH_6_0 VDDA ) ( IO_FILL_IO_SOUTH_5_65 VDDA ) ( resetb_pad VDDA )
-      ( mgmt_vssio_hvclamp_pad\[0\] VDDA ) ( mgmt_vssd_lvclmap_pad VDDA ) ( mgmt_vssa_hvclamp_pad VDDA ) ( mgmt_vssa_hvclamp_pad DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VDDA ) ( mgmt_vdda_hvclamp_pad VDDA ) ( mgmt_vdda_hvclamp_pad DRN_HVC ) ( mgmt_vccd_lvclamp_pad VDDA )
-      ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA ) ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE POWER ;
-    - vdda1 ( PIN vdda1 ) ( brk_vccd_0 VDDA ) ( brk_vccd_1 VDDA ) ( IO_FILL_IO_EAST_1_0 VDDA ) ( IO_FILL_IO_NORTH_8_0 VDDA ) ( IO_FILL_IO_EAST_1_20 VDDA ) ( IO_FILL_IO_NORTH_8_20 VDDA )
-      ( IO_FILL_IO_EAST_1_40 VDDA ) ( IO_FILL_IO_NORTH_8_40 VDDA ) ( IO_FILL_IO_EAST_1_60 VDDA ) ( IO_FILL_IO_NORTH_8_60 VDDA ) ( IO_FILL_IO_EAST_1_80 VDDA ) ( IO_FILL_IO_NORTH_8_80 VDDA ) ( IO_FILL_IO_EAST_1_100 VDDA ) ( IO_FILL_IO_NORTH_8_100 VDDA )
-      ( IO_FILL_IO_EAST_1_120 VDDA ) ( IO_FILL_IO_NORTH_8_120 VDDA ) ( IO_FILL_IO_EAST_1_140 VDDA ) ( IO_FILL_IO_NORTH_8_140 VDDA ) ( IO_FILL_IO_EAST_1_160 VDDA ) ( IO_FILL_IO_NORTH_8_160 VDDA ) ( IO_CORNER_NORTH_EAST_INST VDDA ) ( IO_FILL_IO_EAST_21_65 VDDA )
-      ( IO_FILL_IO_EAST_21_60 VDDA ) ( IO_FILL_IO_EAST_21_40 VDDA ) ( IO_FILL_IO_EAST_21_20 VDDA ) ( IO_FILL_IO_EAST_20_120 VDDA ) ( IO_FILL_IO_EAST_20_100 VDDA ) ( IO_FILL_IO_EAST_20_80 VDDA ) ( IO_FILL_IO_EAST_20_60 VDDA ) ( IO_FILL_IO_EAST_20_40 VDDA )
-      ( IO_FILL_IO_EAST_20_20 VDDA ) ( IO_FILL_IO_EAST_19_120 VDDA ) ( IO_FILL_IO_EAST_19_100 VDDA ) ( IO_FILL_IO_EAST_19_80 VDDA ) ( IO_FILL_IO_EAST_19_60 VDDA ) ( IO_FILL_IO_EAST_19_40 VDDA ) ( IO_FILL_IO_EAST_19_20 VDDA ) ( IO_FILL_IO_EAST_18_120 VDDA )
-      ( IO_FILL_IO_EAST_18_100 VDDA ) ( IO_FILL_IO_EAST_18_80 VDDA ) ( IO_FILL_IO_EAST_18_60 VDDA ) ( IO_FILL_IO_EAST_18_40 VDDA ) ( IO_FILL_IO_EAST_18_20 VDDA ) ( IO_FILL_IO_EAST_17_120 VDDA ) ( IO_FILL_IO_EAST_17_100 VDDA ) ( IO_FILL_IO_EAST_17_80 VDDA )
-      ( IO_FILL_IO_EAST_17_60 VDDA ) ( IO_FILL_IO_EAST_17_40 VDDA ) ( IO_FILL_IO_EAST_17_20 VDDA ) ( IO_FILL_IO_EAST_16_120 VDDA ) ( IO_FILL_IO_EAST_16_100 VDDA ) ( IO_FILL_IO_EAST_16_80 VDDA ) ( IO_FILL_IO_EAST_16_60 VDDA ) ( IO_FILL_IO_EAST_16_40 VDDA )
-      ( IO_FILL_IO_EAST_16_20 VDDA ) ( IO_FILL_IO_EAST_15_120 VDDA ) ( IO_FILL_IO_EAST_15_100 VDDA ) ( IO_FILL_IO_EAST_15_80 VDDA ) ( IO_FILL_IO_EAST_15_60 VDDA ) ( IO_FILL_IO_EAST_15_40 VDDA ) ( IO_FILL_IO_EAST_15_20 VDDA ) ( IO_FILL_IO_EAST_14_140 VDDA )
-      ( IO_FILL_IO_EAST_14_120 VDDA ) ( IO_FILL_IO_EAST_14_100 VDDA ) ( IO_FILL_IO_EAST_14_80 VDDA ) ( IO_FILL_IO_EAST_14_60 VDDA ) ( IO_FILL_IO_EAST_14_40 VDDA ) ( IO_FILL_IO_EAST_14_20 VDDA ) ( IO_FILL_IO_EAST_13_120 VDDA ) ( IO_FILL_IO_EAST_13_100 VDDA )
-      ( IO_FILL_IO_EAST_13_80 VDDA ) ( IO_FILL_IO_EAST_13_60 VDDA ) ( IO_FILL_IO_EAST_13_40 VDDA ) ( IO_FILL_IO_EAST_13_20 VDDA ) ( IO_FILL_IO_EAST_12_140 VDDA ) ( IO_FILL_IO_EAST_12_120 VDDA ) ( IO_FILL_IO_EAST_12_100 VDDA ) ( IO_FILL_IO_EAST_12_80 VDDA )
-      ( IO_FILL_IO_EAST_12_60 VDDA ) ( IO_FILL_IO_EAST_12_40 VDDA ) ( IO_FILL_IO_EAST_12_20 VDDA ) ( IO_FILL_IO_EAST_11_120 VDDA ) ( IO_FILL_IO_EAST_11_100 VDDA ) ( IO_FILL_IO_EAST_11_80 VDDA ) ( IO_FILL_IO_EAST_11_60 VDDA ) ( IO_FILL_IO_EAST_11_40 VDDA )
-      ( IO_FILL_IO_EAST_11_20 VDDA ) ( IO_FILL_IO_EAST_10_120 VDDA ) ( IO_FILL_IO_EAST_10_100 VDDA ) ( IO_FILL_IO_EAST_10_80 VDDA ) ( IO_FILL_IO_EAST_10_60 VDDA ) ( IO_FILL_IO_EAST_10_40 VDDA ) ( IO_FILL_IO_EAST_10_20 VDDA ) ( IO_FILL_IO_EAST_9_140 VDDA )
-      ( IO_FILL_IO_EAST_9_120 VDDA ) ( IO_FILL_IO_EAST_9_100 VDDA ) ( IO_FILL_IO_EAST_9_80 VDDA ) ( IO_FILL_IO_EAST_9_60 VDDA ) ( IO_FILL_IO_EAST_9_40 VDDA ) ( IO_FILL_IO_EAST_9_20 VDDA ) ( IO_FILL_IO_EAST_8_100 VDDA ) ( IO_FILL_IO_EAST_8_80 VDDA )
-      ( IO_FILL_IO_EAST_8_60 VDDA ) ( IO_FILL_IO_EAST_8_40 VDDA ) ( IO_FILL_IO_EAST_8_20 VDDA ) ( IO_FILL_IO_EAST_7_140 VDDA ) ( IO_FILL_IO_EAST_7_120 VDDA ) ( IO_FILL_IO_EAST_7_100 VDDA ) ( IO_FILL_IO_EAST_7_80 VDDA ) ( IO_FILL_IO_EAST_7_60 VDDA )
-      ( IO_FILL_IO_EAST_7_40 VDDA ) ( IO_FILL_IO_EAST_7_20 VDDA ) ( IO_FILL_IO_EAST_6_120 VDDA ) ( IO_FILL_IO_EAST_6_100 VDDA ) ( IO_FILL_IO_EAST_6_80 VDDA ) ( IO_FILL_IO_EAST_6_60 VDDA ) ( IO_FILL_IO_EAST_6_40 VDDA ) ( IO_FILL_IO_EAST_6_20 VDDA )
-      ( IO_FILL_IO_EAST_5_120 VDDA ) ( IO_FILL_IO_EAST_5_100 VDDA ) ( IO_FILL_IO_EAST_5_80 VDDA ) ( IO_FILL_IO_EAST_5_60 VDDA ) ( IO_FILL_IO_EAST_5_40 VDDA ) ( IO_FILL_IO_EAST_5_20 VDDA ) ( IO_FILL_IO_EAST_4_140 VDDA ) ( IO_FILL_IO_EAST_4_120 VDDA )
-      ( IO_FILL_IO_EAST_4_100 VDDA ) ( IO_FILL_IO_EAST_4_80 VDDA ) ( IO_FILL_IO_EAST_4_60 VDDA ) ( IO_FILL_IO_EAST_4_40 VDDA ) ( IO_FILL_IO_EAST_4_20 VDDA ) ( IO_FILL_IO_EAST_3_120 VDDA ) ( IO_FILL_IO_EAST_3_100 VDDA ) ( IO_FILL_IO_EAST_3_80 VDDA )
-      ( IO_FILL_IO_EAST_3_60 VDDA ) ( IO_FILL_IO_EAST_3_40 VDDA ) ( IO_FILL_IO_EAST_3_20 VDDA ) ( IO_FILL_IO_EAST_2_140 VDDA ) ( IO_FILL_IO_EAST_2_120 VDDA ) ( IO_FILL_IO_EAST_2_100 VDDA ) ( IO_FILL_IO_EAST_2_80 VDDA ) ( IO_FILL_IO_EAST_2_60 VDDA )
-      ( IO_FILL_IO_EAST_2_40 VDDA ) ( IO_FILL_IO_EAST_2_20 VDDA ) ( IO_FILL_IO_EAST_1_180 VDDA ) ( IO_FILL_IO_EAST_10_0 VDDA ) ( IO_FILL_IO_EAST_9_145 VDDA ) ( IO_FILL_IO_EAST_9_0 VDDA ) ( IO_FILL_IO_EAST_8_140 VDDA ) ( IO_FILL_IO_EAST_8_120 VDDA )
-      ( IO_FILL_IO_EAST_11_0 VDDA ) ( IO_FILL_IO_EAST_10_140 VDDA ) ( IO_FILL_IO_EAST_18_0 VDDA ) ( IO_FILL_IO_EAST_17_140 VDDA ) ( IO_FILL_IO_EAST_20_0 VDDA ) ( IO_FILL_IO_EAST_19_140 VDDA ) ( IO_FILL_IO_EAST_14_0 VDDA ) ( IO_FILL_IO_EAST_13_140 VDDA )
-      ( IO_FILL_IO_EAST_13_0 VDDA ) ( IO_FILL_IO_EAST_12_145 VDDA ) ( IO_FILL_IO_EAST_12_0 VDDA ) ( IO_FILL_IO_EAST_11_150 VDDA ) ( IO_FILL_IO_EAST_11_140 VDDA ) ( IO_FILL_IO_EAST_8_0 VDDA ) ( IO_FILL_IO_EAST_7_145 VDDA ) ( IO_FILL_IO_EAST_7_0 VDDA )
-      ( IO_FILL_IO_EAST_6_140 VDDA ) ( IO_FILL_IO_EAST_6_0 VDDA ) ( IO_FILL_IO_EAST_5_140 VDDA ) ( IO_FILL_IO_EAST_5_0 VDDA ) ( IO_FILL_IO_EAST_4_145 VDDA ) ( IO_FILL_IO_EAST_4_0 VDDA ) ( IO_FILL_IO_EAST_3_140 VDDA ) ( IO_FILL_IO_EAST_3_0 VDDA )
-      ( IO_FILL_IO_EAST_2_145 VDDA ) ( IO_FILL_IO_EAST_21_0 VDDA ) ( IO_FILL_IO_EAST_20_150 VDDA ) ( IO_FILL_IO_EAST_20_140 VDDA ) ( IO_FILL_IO_EAST_19_0 VDDA ) ( IO_FILL_IO_EAST_18_150 VDDA ) ( IO_FILL_IO_EAST_18_140 VDDA ) ( IO_FILL_IO_EAST_17_0 VDDA )
-      ( IO_FILL_IO_EAST_16_140 VDDA ) ( IO_FILL_IO_EAST_16_0 VDDA ) ( IO_FILL_IO_EAST_15_140 VDDA ) ( IO_FILL_IO_EAST_15_0 VDDA ) ( IO_FILL_IO_EAST_14_145 VDDA ) ( IO_FILL_IO_EAST_2_0 VDDA ) ( IO_FILL_IO_EAST_1_220 VDDA ) ( IO_FILL_IO_EAST_1_200 VDDA )
-      ( IO_FILL_IO_NORTH_12_175 VDDA ) ( IO_FILL_IO_NORTH_12_170 VDDA ) ( IO_FILL_IO_NORTH_12_160 VDDA ) ( IO_FILL_IO_NORTH_12_140 VDDA ) ( IO_FILL_IO_NORTH_12_120 VDDA ) ( IO_FILL_IO_NORTH_12_100 VDDA ) ( IO_FILL_IO_NORTH_12_80 VDDA ) ( IO_FILL_IO_NORTH_12_60 VDDA )
-      ( IO_FILL_IO_NORTH_12_40 VDDA ) ( IO_FILL_IO_NORTH_12_20 VDDA ) ( IO_FILL_IO_NORTH_11_170 VDDA ) ( IO_FILL_IO_NORTH_11_160 VDDA ) ( IO_FILL_IO_NORTH_11_140 VDDA ) ( IO_FILL_IO_NORTH_11_120 VDDA ) ( IO_FILL_IO_NORTH_11_100 VDDA ) ( IO_FILL_IO_NORTH_11_80 VDDA )
-      ( IO_FILL_IO_NORTH_11_60 VDDA ) ( IO_FILL_IO_NORTH_11_40 VDDA ) ( IO_FILL_IO_NORTH_11_20 VDDA ) ( IO_FILL_IO_NORTH_10_170 VDDA ) ( IO_FILL_IO_NORTH_10_160 VDDA ) ( IO_FILL_IO_NORTH_10_140 VDDA ) ( IO_FILL_IO_NORTH_10_120 VDDA ) ( IO_FILL_IO_NORTH_10_100 VDDA )
-      ( IO_FILL_IO_NORTH_10_80 VDDA ) ( IO_FILL_IO_NORTH_10_60 VDDA ) ( IO_FILL_IO_NORTH_10_40 VDDA ) ( IO_FILL_IO_NORTH_10_20 VDDA ) ( IO_FILL_IO_NORTH_9_170 VDDA ) ( IO_FILL_IO_NORTH_9_160 VDDA ) ( IO_FILL_IO_NORTH_9_140 VDDA ) ( IO_FILL_IO_NORTH_9_120 VDDA )
-      ( IO_FILL_IO_NORTH_9_100 VDDA ) ( IO_FILL_IO_NORTH_9_80 VDDA ) ( IO_FILL_IO_NORTH_9_60 VDDA ) ( IO_FILL_IO_NORTH_9_40 VDDA ) ( IO_FILL_IO_NORTH_9_20 VDDA ) ( IO_FILL_IO_NORTH_8_170 VDDA ) ( IO_FILL_IO_NORTH_11_0 VDDA ) ( IO_FILL_IO_NORTH_10_175 VDDA )
-      ( IO_FILL_IO_NORTH_9_0 VDDA ) ( IO_FILL_IO_NORTH_8_175 VDDA ) ( IO_FILL_IO_NORTH_10_0 VDDA ) ( IO_FILL_IO_NORTH_9_175 VDDA ) ( IO_FILL_IO_NORTH_12_0 VDDA ) ( IO_FILL_IO_NORTH_11_175 VDDA ) ( user1_vssd_lvclmap_pad VDDA ) ( user1_vssa_hvclamp_pad\[1\] VDDA )
-      ( user1_vssa_hvclamp_pad\[1\] DRN_HVC ) ( user1_vssa_hvclamp_pad\[0\] VDDA ) ( user1_vssa_hvclamp_pad\[0\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[1\] VDDA ) ( user1_vdda_hvclamp_pad\[1\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[0\] VDDA ) ( user1_vdda_hvclamp_pad\[0\] DRN_HVC ) ( user1_vccd_lvclamp_pad VDDA )
-      ( user1_corner VDDA ) ( mprj_pads.area1_io_pad\[9\] VDDA ) ( mprj_pads.area1_io_pad\[8\] VDDA ) ( mprj_pads.area1_io_pad\[7\] VDDA ) ( mprj_pads.area1_io_pad\[6\] VDDA ) ( mprj_pads.area1_io_pad\[5\] VDDA ) ( mprj_pads.area1_io_pad\[4\] VDDA ) ( mprj_pads.area1_io_pad\[3\] VDDA )
-      ( mprj_pads.area1_io_pad\[2\] VDDA ) ( mprj_pads.area1_io_pad\[1\] VDDA ) ( mprj_pads.area1_io_pad\[17\] VDDA ) ( mprj_pads.area1_io_pad\[16\] VDDA ) ( mprj_pads.area1_io_pad\[15\] VDDA ) ( mprj_pads.area1_io_pad\[14\] VDDA ) ( mprj_pads.area1_io_pad\[13\] VDDA ) ( mprj_pads.area1_io_pad\[12\] VDDA )
-      ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE POWER ;
-    - vdda2 ( PIN vdda2 ) ( brk_vccd_2 VDDA ) ( IO_FILL_IO_WEST_3_0 VDDA ) ( IO_FILL_IO_WEST_3_20 VDDA ) ( IO_FILL_IO_WEST_3_40 VDDA ) ( IO_FILL_IO_WEST_3_60 VDDA ) ( IO_FILL_IO_WEST_3_80 VDDA )
-      ( IO_FILL_IO_WEST_3_100 VDDA ) ( IO_FILL_IO_WEST_3_120 VDDA ) ( IO_FILL_IO_NORTH_0_140 VDDA ) ( IO_FILL_IO_NORTH_0_120 VDDA ) ( IO_FILL_IO_NORTH_0_100 VDDA ) ( IO_FILL_IO_NORTH_0_80 VDDA ) ( IO_FILL_IO_NORTH_0_60 VDDA ) ( IO_FILL_IO_NORTH_0_40 VDDA )
-      ( IO_FILL_IO_NORTH_0_20 VDDA ) ( IO_FILL_IO_NORTH_0_0 VDDA ) ( IO_CORNER_NORTH_WEST_INST VDDA ) ( IO_FILL_IO_WEST_22_130 VDDA ) ( IO_FILL_IO_WEST_22_120 VDDA ) ( IO_FILL_IO_WEST_22_100 VDDA ) ( IO_FILL_IO_WEST_22_80 VDDA ) ( IO_FILL_IO_WEST_22_60 VDDA )
-      ( IO_FILL_IO_WEST_22_40 VDDA ) ( IO_FILL_IO_WEST_22_20 VDDA ) ( IO_FILL_IO_WEST_21_130 VDDA ) ( IO_FILL_IO_WEST_21_120 VDDA ) ( IO_FILL_IO_WEST_21_100 VDDA ) ( IO_FILL_IO_WEST_21_80 VDDA ) ( IO_FILL_IO_WEST_21_60 VDDA ) ( IO_FILL_IO_WEST_21_40 VDDA )
-      ( IO_FILL_IO_WEST_21_20 VDDA ) ( IO_FILL_IO_WEST_20_130 VDDA ) ( IO_FILL_IO_WEST_20_120 VDDA ) ( IO_FILL_IO_WEST_20_100 VDDA ) ( IO_FILL_IO_WEST_20_80 VDDA ) ( IO_FILL_IO_WEST_20_60 VDDA ) ( IO_FILL_IO_WEST_20_40 VDDA ) ( IO_FILL_IO_WEST_20_20 VDDA )
-      ( IO_FILL_IO_WEST_19_130 VDDA ) ( IO_FILL_IO_WEST_19_120 VDDA ) ( IO_FILL_IO_WEST_19_100 VDDA ) ( IO_FILL_IO_WEST_19_80 VDDA ) ( IO_FILL_IO_WEST_19_60 VDDA ) ( IO_FILL_IO_WEST_19_40 VDDA ) ( IO_FILL_IO_WEST_19_20 VDDA ) ( IO_FILL_IO_WEST_18_130 VDDA )
-      ( IO_FILL_IO_WEST_18_120 VDDA ) ( IO_FILL_IO_WEST_18_100 VDDA ) ( IO_FILL_IO_WEST_18_80 VDDA ) ( IO_FILL_IO_WEST_18_60 VDDA ) ( IO_FILL_IO_WEST_18_40 VDDA ) ( IO_FILL_IO_WEST_18_20 VDDA ) ( IO_FILL_IO_WEST_17_130 VDDA ) ( IO_FILL_IO_WEST_17_120 VDDA )
-      ( IO_FILL_IO_WEST_17_100 VDDA ) ( IO_FILL_IO_WEST_17_80 VDDA ) ( IO_FILL_IO_WEST_17_60 VDDA ) ( IO_FILL_IO_WEST_17_40 VDDA ) ( IO_FILL_IO_WEST_17_20 VDDA ) ( IO_FILL_IO_WEST_16_130 VDDA ) ( IO_FILL_IO_WEST_16_120 VDDA ) ( IO_FILL_IO_WEST_16_100 VDDA )
-      ( IO_FILL_IO_WEST_16_80 VDDA ) ( IO_FILL_IO_WEST_16_60 VDDA ) ( IO_FILL_IO_WEST_16_40 VDDA ) ( IO_FILL_IO_WEST_16_20 VDDA ) ( IO_FILL_IO_WEST_15_130 VDDA ) ( IO_FILL_IO_WEST_15_120 VDDA ) ( IO_FILL_IO_WEST_15_100 VDDA ) ( IO_FILL_IO_WEST_15_80 VDDA )
-      ( IO_FILL_IO_WEST_15_60 VDDA ) ( IO_FILL_IO_WEST_15_40 VDDA ) ( IO_FILL_IO_WEST_15_20 VDDA ) ( IO_FILL_IO_WEST_14_130 VDDA ) ( IO_FILL_IO_WEST_14_120 VDDA ) ( IO_FILL_IO_WEST_14_100 VDDA ) ( IO_FILL_IO_WEST_14_80 VDDA ) ( IO_FILL_IO_WEST_14_60 VDDA )
-      ( IO_FILL_IO_WEST_14_40 VDDA ) ( IO_FILL_IO_WEST_14_20 VDDA ) ( IO_FILL_IO_WEST_13_130 VDDA ) ( IO_FILL_IO_WEST_13_120 VDDA ) ( IO_FILL_IO_WEST_13_100 VDDA ) ( IO_FILL_IO_WEST_13_80 VDDA ) ( IO_FILL_IO_WEST_13_60 VDDA ) ( IO_FILL_IO_WEST_13_40 VDDA )
-      ( IO_FILL_IO_WEST_13_20 VDDA ) ( IO_FILL_IO_WEST_12_130 VDDA ) ( IO_FILL_IO_WEST_12_120 VDDA ) ( IO_FILL_IO_WEST_12_100 VDDA ) ( IO_FILL_IO_WEST_12_80 VDDA ) ( IO_FILL_IO_WEST_12_60 VDDA ) ( IO_FILL_IO_WEST_12_40 VDDA ) ( IO_FILL_IO_WEST_12_20 VDDA )
-      ( IO_FILL_IO_WEST_11_130 VDDA ) ( IO_FILL_IO_WEST_11_120 VDDA ) ( IO_FILL_IO_WEST_11_100 VDDA ) ( IO_FILL_IO_WEST_11_80 VDDA ) ( IO_FILL_IO_WEST_11_60 VDDA ) ( IO_FILL_IO_WEST_11_40 VDDA ) ( IO_FILL_IO_WEST_11_20 VDDA ) ( IO_FILL_IO_WEST_10_130 VDDA )
-      ( IO_FILL_IO_WEST_10_120 VDDA ) ( IO_FILL_IO_WEST_10_100 VDDA ) ( IO_FILL_IO_WEST_10_80 VDDA ) ( IO_FILL_IO_WEST_10_60 VDDA ) ( IO_FILL_IO_WEST_10_40 VDDA ) ( IO_FILL_IO_WEST_10_20 VDDA ) ( IO_FILL_IO_WEST_9_130 VDDA ) ( IO_FILL_IO_WEST_9_120 VDDA )
-      ( IO_FILL_IO_WEST_9_100 VDDA ) ( IO_FILL_IO_WEST_9_80 VDDA ) ( IO_FILL_IO_WEST_9_60 VDDA ) ( IO_FILL_IO_WEST_9_40 VDDA ) ( IO_FILL_IO_WEST_9_20 VDDA ) ( IO_FILL_IO_WEST_8_130 VDDA ) ( IO_FILL_IO_WEST_8_120 VDDA ) ( IO_FILL_IO_WEST_8_100 VDDA )
-      ( IO_FILL_IO_WEST_8_80 VDDA ) ( IO_FILL_IO_WEST_8_60 VDDA ) ( IO_FILL_IO_WEST_8_40 VDDA ) ( IO_FILL_IO_WEST_8_20 VDDA ) ( IO_FILL_IO_WEST_7_130 VDDA ) ( IO_FILL_IO_WEST_7_120 VDDA ) ( IO_FILL_IO_WEST_7_100 VDDA ) ( IO_FILL_IO_WEST_7_80 VDDA )
-      ( IO_FILL_IO_WEST_7_60 VDDA ) ( IO_FILL_IO_WEST_7_40 VDDA ) ( IO_FILL_IO_WEST_7_20 VDDA ) ( IO_FILL_IO_WEST_6_130 VDDA ) ( IO_FILL_IO_WEST_6_120 VDDA ) ( IO_FILL_IO_WEST_6_100 VDDA ) ( IO_FILL_IO_WEST_6_80 VDDA ) ( IO_FILL_IO_WEST_6_60 VDDA )
-      ( IO_FILL_IO_WEST_6_40 VDDA ) ( IO_FILL_IO_WEST_6_20 VDDA ) ( IO_FILL_IO_WEST_5_130 VDDA ) ( IO_FILL_IO_WEST_5_120 VDDA ) ( IO_FILL_IO_WEST_5_100 VDDA ) ( IO_FILL_IO_WEST_5_80 VDDA ) ( IO_FILL_IO_WEST_5_60 VDDA ) ( IO_FILL_IO_WEST_5_40 VDDA )
-      ( IO_FILL_IO_WEST_5_20 VDDA ) ( IO_FILL_IO_WEST_4_130 VDDA ) ( IO_FILL_IO_WEST_4_120 VDDA ) ( IO_FILL_IO_WEST_4_100 VDDA ) ( IO_FILL_IO_WEST_4_80 VDDA ) ( IO_FILL_IO_WEST_4_60 VDDA ) ( IO_FILL_IO_WEST_4_40 VDDA ) ( IO_FILL_IO_WEST_4_20 VDDA )
-      ( IO_FILL_IO_WEST_3_130 VDDA ) ( IO_FILL_IO_WEST_10_0 VDDA ) ( IO_FILL_IO_WEST_9_135 VDDA ) ( IO_FILL_IO_WEST_19_0 VDDA ) ( IO_FILL_IO_WEST_18_135 VDDA ) ( IO_FILL_IO_WEST_11_0 VDDA ) ( IO_FILL_IO_WEST_10_135 VDDA ) ( IO_FILL_IO_WEST_21_0 VDDA )
-      ( IO_FILL_IO_WEST_20_135 VDDA ) ( IO_FILL_IO_WEST_16_0 VDDA ) ( IO_FILL_IO_WEST_15_135 VDDA ) ( IO_FILL_IO_WEST_17_0 VDDA ) ( IO_FILL_IO_WEST_16_135 VDDA ) ( IO_FILL_IO_WEST_18_0 VDDA ) ( IO_FILL_IO_WEST_17_135 VDDA ) ( IO_FILL_IO_WEST_22_0 VDDA )
-      ( IO_FILL_IO_WEST_21_135 VDDA ) ( IO_FILL_IO_WEST_4_0 VDDA ) ( IO_FILL_IO_WEST_3_135 VDDA ) ( IO_FILL_IO_WEST_5_0 VDDA ) ( IO_FILL_IO_WEST_4_135 VDDA ) ( IO_FILL_IO_WEST_6_0 VDDA ) ( IO_FILL_IO_WEST_5_135 VDDA ) ( IO_FILL_IO_WEST_7_0 VDDA )
-      ( IO_FILL_IO_WEST_6_135 VDDA ) ( IO_FILL_IO_WEST_8_0 VDDA ) ( IO_FILL_IO_WEST_7_135 VDDA ) ( IO_FILL_IO_WEST_9_0 VDDA ) ( IO_FILL_IO_WEST_8_135 VDDA ) ( IO_FILL_IO_WEST_12_0 VDDA ) ( IO_FILL_IO_WEST_11_135 VDDA ) ( IO_FILL_IO_WEST_13_0 VDDA )
-      ( IO_FILL_IO_WEST_12_135 VDDA ) ( IO_FILL_IO_WEST_14_0 VDDA ) ( IO_FILL_IO_WEST_13_135 VDDA ) ( IO_FILL_IO_WEST_15_0 VDDA ) ( IO_FILL_IO_WEST_14_135 VDDA ) ( IO_FILL_IO_WEST_20_0 VDDA ) ( IO_FILL_IO_WEST_19_135 VDDA ) ( IO_FILL_IO_NORTH_7_175 VDDA )
-      ( IO_FILL_IO_NORTH_7_170 VDDA ) ( IO_FILL_IO_NORTH_7_160 VDDA ) ( IO_FILL_IO_NORTH_7_140 VDDA ) ( IO_FILL_IO_NORTH_7_120 VDDA ) ( IO_FILL_IO_NORTH_7_100 VDDA ) ( IO_FILL_IO_NORTH_7_80 VDDA ) ( IO_FILL_IO_NORTH_7_60 VDDA ) ( IO_FILL_IO_NORTH_7_40 VDDA )
-      ( IO_FILL_IO_NORTH_7_20 VDDA ) ( IO_FILL_IO_NORTH_6_170 VDDA ) ( IO_FILL_IO_NORTH_6_160 VDDA ) ( IO_FILL_IO_NORTH_6_140 VDDA ) ( IO_FILL_IO_NORTH_6_120 VDDA ) ( IO_FILL_IO_NORTH_6_100 VDDA ) ( IO_FILL_IO_NORTH_6_80 VDDA ) ( IO_FILL_IO_NORTH_6_60 VDDA )
-      ( IO_FILL_IO_NORTH_6_40 VDDA ) ( IO_FILL_IO_NORTH_6_20 VDDA ) ( IO_FILL_IO_NORTH_5_170 VDDA ) ( IO_FILL_IO_NORTH_5_160 VDDA ) ( IO_FILL_IO_NORTH_5_140 VDDA ) ( IO_FILL_IO_NORTH_5_120 VDDA ) ( IO_FILL_IO_NORTH_5_100 VDDA ) ( IO_FILL_IO_NORTH_5_80 VDDA )
-      ( IO_FILL_IO_NORTH_5_60 VDDA ) ( IO_FILL_IO_NORTH_5_40 VDDA ) ( IO_FILL_IO_NORTH_5_20 VDDA ) ( IO_FILL_IO_NORTH_4_170 VDDA ) ( IO_FILL_IO_NORTH_4_160 VDDA ) ( IO_FILL_IO_NORTH_4_140 VDDA ) ( IO_FILL_IO_NORTH_4_120 VDDA ) ( IO_FILL_IO_NORTH_4_100 VDDA )
-      ( IO_FILL_IO_NORTH_4_80 VDDA ) ( IO_FILL_IO_NORTH_4_60 VDDA ) ( IO_FILL_IO_NORTH_4_40 VDDA ) ( IO_FILL_IO_NORTH_4_20 VDDA ) ( IO_FILL_IO_NORTH_3_170 VDDA ) ( IO_FILL_IO_NORTH_3_160 VDDA ) ( IO_FILL_IO_NORTH_3_140 VDDA ) ( IO_FILL_IO_NORTH_3_120 VDDA )
-      ( IO_FILL_IO_NORTH_3_100 VDDA ) ( IO_FILL_IO_NORTH_3_80 VDDA ) ( IO_FILL_IO_NORTH_3_60 VDDA ) ( IO_FILL_IO_NORTH_3_40 VDDA ) ( IO_FILL_IO_NORTH_3_20 VDDA ) ( IO_FILL_IO_NORTH_2_170 VDDA ) ( IO_FILL_IO_NORTH_2_160 VDDA ) ( IO_FILL_IO_NORTH_2_140 VDDA )
-      ( IO_FILL_IO_NORTH_2_120 VDDA ) ( IO_FILL_IO_NORTH_2_100 VDDA ) ( IO_FILL_IO_NORTH_2_80 VDDA ) ( IO_FILL_IO_NORTH_2_60 VDDA ) ( IO_FILL_IO_NORTH_2_40 VDDA ) ( IO_FILL_IO_NORTH_2_20 VDDA ) ( IO_FILL_IO_NORTH_1_170 VDDA ) ( IO_FILL_IO_NORTH_1_160 VDDA )
-      ( IO_FILL_IO_NORTH_1_140 VDDA ) ( IO_FILL_IO_NORTH_1_120 VDDA ) ( IO_FILL_IO_NORTH_1_100 VDDA ) ( IO_FILL_IO_NORTH_1_80 VDDA ) ( IO_FILL_IO_NORTH_1_60 VDDA ) ( IO_FILL_IO_NORTH_1_40 VDDA ) ( IO_FILL_IO_NORTH_1_20 VDDA ) ( IO_FILL_IO_NORTH_0_160 VDDA )
-      ( IO_FILL_IO_NORTH_1_0 VDDA ) ( IO_FILL_IO_NORTH_0_180 VDDA ) ( IO_FILL_IO_NORTH_2_0 VDDA ) ( IO_FILL_IO_NORTH_1_175 VDDA ) ( IO_FILL_IO_NORTH_3_0 VDDA ) ( IO_FILL_IO_NORTH_2_175 VDDA ) ( IO_FILL_IO_NORTH_4_0 VDDA ) ( IO_FILL_IO_NORTH_3_175 VDDA )
-      ( IO_FILL_IO_NORTH_5_0 VDDA ) ( IO_FILL_IO_NORTH_4_175 VDDA ) ( IO_FILL_IO_NORTH_7_0 VDDA ) ( IO_FILL_IO_NORTH_6_175 VDDA ) ( IO_FILL_IO_NORTH_6_0 VDDA ) ( IO_FILL_IO_NORTH_5_175 VDDA ) ( user2_vssd_lvclmap_pad VDDA ) ( user2_vssa_hvclamp_pad VDDA )
-      ( user2_vssa_hvclamp_pad DRN_HVC ) ( user2_vdda_hvclamp_pad VDDA ) ( user2_vdda_hvclamp_pad DRN_HVC ) ( user2_vccd_lvclamp_pad VDDA ) ( user2_corner VDDA ) ( mprj_pads.area2_io_pad\[9\] VDDA ) ( mprj_pads.area2_io_pad\[8\] VDDA ) ( mprj_pads.area2_io_pad\[7\] VDDA )
-      ( mprj_pads.area2_io_pad\[6\] VDDA ) ( mprj_pads.area2_io_pad\[5\] VDDA ) ( mprj_pads.area2_io_pad\[4\] VDDA ) ( mprj_pads.area2_io_pad\[3\] VDDA ) ( mprj_pads.area2_io_pad\[2\] VDDA ) ( mprj_pads.area2_io_pad\[1\] VDDA ) ( mprj_pads.area2_io_pad\[19\] VDDA ) ( mprj_pads.area2_io_pad\[18\] VDDA )
-      ( mprj_pads.area2_io_pad\[17\] VDDA ) ( mprj_pads.area2_io_pad\[16\] VDDA ) ( mprj_pads.area2_io_pad\[15\] VDDA ) ( mprj_pads.area2_io_pad\[14\] VDDA ) ( mprj_pads.area2_io_pad\[13\] VDDA ) ( mprj_pads.area2_io_pad\[12\] VDDA ) ( mprj_pads.area2_io_pad\[11\] VDDA ) ( mprj_pads.area2_io_pad\[10\] VDDA )
-      ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE POWER ;
-    - vddio ( PIN vddio ) ( * VDDIO ) ( * VSWITCH ) ( mgmt_vssio_hvclamp_pad\[1\] DRN_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[1\] DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] DRN_HVC )
-      ( gpio_pad HLD_H_N ) ( flash_io1_pad HLD_H_N ) ( flash_io0_pad HLD_H_N ) ( flash_csb_pad HLD_H_N ) ( flash_clk_pad HLD_H_N ) ( clock_pad HLD_H_N ) + USE POWER ;
-    - vssa ( PIN vssa ) ( IO_FILL_IO_SOUTH_0_40 VSSA ) ( IO_FILL_IO_SOUTH_0_20 VSSA ) ( IO_FILL_IO_SOUTH_0_0 VSSA ) ( IO_FILL_IO_SOUTH_0_50 VSSA ) ( IO_FILL_IO_SOUTH_0_55 VSSA ) ( connect_0 VSSA )
-      ( IO_CORNER_SOUTH_WEST_INST VSSA ) ( IO_FILL_IO_WEST_0_0 VSSA ) ( connect_1 VSSA ) ( IO_FILL_IO_WEST_0_20 VSSA ) ( connect_2 VSSA ) ( IO_FILL_IO_WEST_0_40 VSSA ) ( connect_3 VSSA ) ( IO_FILL_IO_WEST_0_60 VSSA )
-      ( connect_4 VSSA ) ( IO_FILL_IO_WEST_0_80 VSSA ) ( connect_5 VSSA ) ( IO_FILL_IO_EAST_0_145 VSSA ) ( IO_FILL_IO_EAST_0_140 VSSA ) ( IO_FILL_IO_EAST_0_120 VSSA ) ( IO_FILL_IO_EAST_0_100 VSSA ) ( IO_FILL_IO_EAST_0_80 VSSA )
-      ( IO_FILL_IO_EAST_0_60 VSSA ) ( IO_FILL_IO_EAST_0_40 VSSA ) ( IO_FILL_IO_EAST_0_20 VSSA ) ( IO_FILL_IO_EAST_0_0 VSSA ) ( IO_CORNER_SOUTH_EAST_INST VSSA ) ( IO_FILL_IO_WEST_0_100 VSSA ) ( IO_FILL_IO_SOUTH_23_20 VSSA ) ( IO_FILL_IO_SOUTH_17_20 VSSA )
-      ( IO_FILL_IO_SOUTH_15_20 VSSA ) ( IO_FILL_IO_SOUTH_13_20 VSSA ) ( IO_FILL_IO_SOUTH_11_20 VSSA ) ( IO_FILL_IO_SOUTH_9_20 VSSA ) ( IO_FILL_IO_SOUTH_5_20 VSSA ) ( IO_FILL_IO_SOUTH_1_0 VSSA ) ( IO_FILL_IO_SOUTH_23_0 VSSA ) ( connect_71 VSSA )
-      ( connect_70 VSSA ) ( connect_69 VSSA ) ( connect_68 VSSA ) ( connect_67 VSSA ) ( IO_FILL_IO_SOUTH_21_0 VSSA ) ( connect_65 VSSA ) ( connect_64 VSSA ) ( connect_63 VSSA )
-      ( connect_62 VSSA ) ( connect_61 VSSA ) ( IO_FILL_IO_SOUTH_19_0 VSSA ) ( connect_59 VSSA ) ( connect_58 VSSA ) ( connect_57 VSSA ) ( connect_56 VSSA ) ( connect_55 VSSA )
-      ( IO_FILL_IO_SOUTH_17_0 VSSA ) ( connect_53 VSSA ) ( connect_52 VSSA ) ( connect_51 VSSA ) ( connect_50 VSSA ) ( connect_49 VSSA ) ( IO_FILL_IO_SOUTH_15_0 VSSA ) ( connect_47 VSSA )
-      ( connect_46 VSSA ) ( connect_45 VSSA ) ( connect_44 VSSA ) ( connect_43 VSSA ) ( IO_FILL_IO_SOUTH_13_0 VSSA ) ( connect_41 VSSA ) ( connect_40 VSSA ) ( connect_39 VSSA )
-      ( connect_38 VSSA ) ( connect_37 VSSA ) ( IO_FILL_IO_SOUTH_11_0 VSSA ) ( connect_35 VSSA ) ( connect_34 VSSA ) ( connect_33 VSSA ) ( connect_32 VSSA ) ( connect_31 VSSA )
-      ( IO_FILL_IO_SOUTH_9_0 VSSA ) ( connect_29 VSSA ) ( connect_28 VSSA ) ( connect_27 VSSA ) ( connect_26 VSSA ) ( connect_25 VSSA ) ( IO_FILL_IO_SOUTH_7_0 VSSA ) ( connect_23 VSSA )
-      ( connect_22 VSSA ) ( connect_21 VSSA ) ( connect_20 VSSA ) ( connect_19 VSSA ) ( IO_FILL_IO_SOUTH_5_0 VSSA ) ( connect_17 VSSA ) ( connect_16 VSSA ) ( connect_15 VSSA )
-      ( connect_14 VSSA ) ( connect_13 VSSA ) ( IO_FILL_IO_SOUTH_3_0 VSSA ) ( connect_11 VSSA ) ( connect_10 VSSA ) ( connect_9 VSSA ) ( connect_8 VSSA ) ( connect_7 VSSA )
-      ( IO_FILL_IO_WEST_0_120 VSSA ) ( IO_FILL_IO_SOUTH_21_20 VSSA ) ( IO_FILL_IO_SOUTH_19_20 VSSA ) ( IO_FILL_IO_SOUTH_17_40 VSSA ) ( IO_FILL_IO_SOUTH_15_40 VSSA ) ( IO_FILL_IO_SOUTH_13_40 VSSA ) ( IO_FILL_IO_SOUTH_11_40 VSSA ) ( IO_FILL_IO_SOUTH_9_40 VSSA )
-      ( IO_FILL_IO_SOUTH_7_20 VSSA ) ( IO_FILL_IO_SOUTH_5_40 VSSA ) ( IO_FILL_IO_SOUTH_3_20 VSSA ) ( IO_FILL_IO_SOUTH_1_20 VSSA ) ( connect_66 VSSA ) ( connect_60 VSSA ) ( connect_54 VSSA ) ( connect_48 VSSA )
-      ( connect_42 VSSA ) ( connect_36 VSSA ) ( connect_30 VSSA ) ( connect_24 VSSA ) ( connect_18 VSSA ) ( connect_12 VSSA ) ( connect_6 VSSA ) ( IO_FILL_IO_WEST_2_135 VSSA )
-      ( IO_FILL_IO_WEST_2_130 VSSA ) ( IO_FILL_IO_WEST_2_120 VSSA ) ( IO_FILL_IO_WEST_2_100 VSSA ) ( IO_FILL_IO_WEST_2_80 VSSA ) ( IO_FILL_IO_WEST_2_60 VSSA ) ( IO_FILL_IO_WEST_2_40 VSSA ) ( IO_FILL_IO_WEST_2_20 VSSA ) ( IO_FILL_IO_WEST_1_130 VSSA )
-      ( IO_FILL_IO_WEST_1_120 VSSA ) ( IO_FILL_IO_WEST_1_100 VSSA ) ( IO_FILL_IO_WEST_1_80 VSSA ) ( IO_FILL_IO_WEST_1_60 VSSA ) ( IO_FILL_IO_WEST_1_40 VSSA ) ( IO_FILL_IO_WEST_1_20 VSSA ) ( IO_FILL_IO_WEST_0_130 VSSA ) ( IO_FILL_IO_WEST_2_0 VSSA )
-      ( IO_FILL_IO_WEST_1_135 VSSA ) ( IO_FILL_IO_WEST_1_0 VSSA ) ( IO_FILL_IO_WEST_0_135 VSSA ) ( IO_FILL_IO_SOUTH_22_10 VSSA ) ( IO_FILL_IO_SOUTH_21_40 VSSA ) ( IO_FILL_IO_SOUTH_20_10 VSSA ) ( IO_FILL_IO_SOUTH_19_40 VSSA ) ( IO_FILL_IO_SOUTH_18_5 VSSA )
-      ( IO_FILL_IO_SOUTH_17_60 VSSA ) ( IO_FILL_IO_SOUTH_16_5 VSSA ) ( IO_FILL_IO_SOUTH_15_60 VSSA ) ( IO_FILL_IO_SOUTH_14_5 VSSA ) ( IO_FILL_IO_SOUTH_13_60 VSSA ) ( IO_FILL_IO_SOUTH_12_5 VSSA ) ( IO_FILL_IO_SOUTH_11_60 VSSA ) ( IO_FILL_IO_SOUTH_10_5 VSSA )
-      ( IO_FILL_IO_SOUTH_9_60 VSSA ) ( IO_FILL_IO_SOUTH_8_10 VSSA ) ( IO_FILL_IO_SOUTH_7_40 VSSA ) ( IO_FILL_IO_SOUTH_6_5 VSSA ) ( IO_FILL_IO_SOUTH_5_60 VSSA ) ( IO_FILL_IO_SOUTH_4_10 VSSA ) ( IO_FILL_IO_SOUTH_3_40 VSSA ) ( IO_FILL_IO_SOUTH_2_10 VSSA )
-      ( IO_FILL_IO_SOUTH_1_40 VSSA ) ( IO_FILL_IO_SOUTH_4_0 VSSA ) ( IO_FILL_IO_SOUTH_3_60 VSSA ) ( IO_FILL_IO_SOUTH_20_0 VSSA ) ( IO_FILL_IO_SOUTH_19_60 VSSA ) ( IO_FILL_IO_SOUTH_8_0 VSSA ) ( IO_FILL_IO_SOUTH_7_60 VSSA ) ( IO_FILL_IO_SOUTH_2_0 VSSA )
-      ( IO_FILL_IO_SOUTH_1_60 VSSA ) ( IO_FILL_IO_SOUTH_22_0 VSSA ) ( IO_FILL_IO_SOUTH_21_60 VSSA ) ( IO_FILL_IO_SOUTH_18_0 VSSA ) ( IO_FILL_IO_SOUTH_17_65 VSSA ) ( IO_FILL_IO_SOUTH_16_0 VSSA ) ( IO_FILL_IO_SOUTH_15_65 VSSA ) ( IO_FILL_IO_SOUTH_14_0 VSSA )
-      ( IO_FILL_IO_SOUTH_13_65 VSSA ) ( IO_FILL_IO_SOUTH_10_0 VSSA ) ( IO_FILL_IO_SOUTH_9_65 VSSA ) ( IO_FILL_IO_SOUTH_12_0 VSSA ) ( IO_FILL_IO_SOUTH_11_65 VSSA ) ( IO_FILL_IO_SOUTH_6_0 VSSA ) ( IO_FILL_IO_SOUTH_5_65 VSSA ) ( resetb_pad VSSA )
-      ( mgmt_vssio_hvclamp_pad\[0\] VSSA ) ( mgmt_vssd_lvclmap_pad VSSA ) ( mgmt_vssd_lvclmap_pad BDY2_B2B ) ( mgmt_vssa_hvclamp_pad VSSA ) ( mgmt_vssa_hvclamp_pad SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSA ) ( mgmt_vdda_hvclamp_pad VSSA ) ( mgmt_vdda_hvclamp_pad SRC_BDY_HVC )
-      ( mgmt_vccd_lvclamp_pad VSSA ) ( mgmt_vccd_lvclamp_pad BDY2_B2B ) ( mgmt_corner\[1\] VSSA ) ( mgmt_corner\[0\] VSSA ) ( gpio_pad VSSA ) ( gpio_pad ENABLE_VSWITCH_H ) ( flash_io1_pad VSSA ) ( flash_io1_pad ENABLE_VSWITCH_H )
-      ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA ) ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE GROUND ;
-    - vssa1 ( PIN vssa1 ) ( brk_vccd_0 VSSA ) ( brk_vccd_1 VSSA ) ( IO_FILL_IO_EAST_1_0 VSSA ) ( IO_FILL_IO_NORTH_8_0 VSSA ) ( IO_FILL_IO_EAST_1_20 VSSA ) ( IO_FILL_IO_NORTH_8_20 VSSA )
-      ( IO_FILL_IO_EAST_1_40 VSSA ) ( IO_FILL_IO_NORTH_8_40 VSSA ) ( IO_FILL_IO_EAST_1_60 VSSA ) ( IO_FILL_IO_NORTH_8_60 VSSA ) ( IO_FILL_IO_EAST_1_80 VSSA ) ( IO_FILL_IO_NORTH_8_80 VSSA ) ( IO_FILL_IO_EAST_1_100 VSSA ) ( IO_FILL_IO_NORTH_8_100 VSSA )
-      ( IO_FILL_IO_EAST_1_120 VSSA ) ( IO_FILL_IO_NORTH_8_120 VSSA ) ( IO_FILL_IO_EAST_1_140 VSSA ) ( IO_FILL_IO_NORTH_8_140 VSSA ) ( IO_FILL_IO_EAST_1_160 VSSA ) ( IO_FILL_IO_NORTH_8_160 VSSA ) ( IO_CORNER_NORTH_EAST_INST VSSA ) ( IO_FILL_IO_EAST_21_65 VSSA )
-      ( IO_FILL_IO_EAST_21_60 VSSA ) ( IO_FILL_IO_EAST_21_40 VSSA ) ( IO_FILL_IO_EAST_21_20 VSSA ) ( IO_FILL_IO_EAST_20_120 VSSA ) ( IO_FILL_IO_EAST_20_100 VSSA ) ( IO_FILL_IO_EAST_20_80 VSSA ) ( IO_FILL_IO_EAST_20_60 VSSA ) ( IO_FILL_IO_EAST_20_40 VSSA )
-      ( IO_FILL_IO_EAST_20_20 VSSA ) ( IO_FILL_IO_EAST_19_120 VSSA ) ( IO_FILL_IO_EAST_19_100 VSSA ) ( IO_FILL_IO_EAST_19_80 VSSA ) ( IO_FILL_IO_EAST_19_60 VSSA ) ( IO_FILL_IO_EAST_19_40 VSSA ) ( IO_FILL_IO_EAST_19_20 VSSA ) ( IO_FILL_IO_EAST_18_120 VSSA )
-      ( IO_FILL_IO_EAST_18_100 VSSA ) ( IO_FILL_IO_EAST_18_80 VSSA ) ( IO_FILL_IO_EAST_18_60 VSSA ) ( IO_FILL_IO_EAST_18_40 VSSA ) ( IO_FILL_IO_EAST_18_20 VSSA ) ( IO_FILL_IO_EAST_17_120 VSSA ) ( IO_FILL_IO_EAST_17_100 VSSA ) ( IO_FILL_IO_EAST_17_80 VSSA )
-      ( IO_FILL_IO_EAST_17_60 VSSA ) ( IO_FILL_IO_EAST_17_40 VSSA ) ( IO_FILL_IO_EAST_17_20 VSSA ) ( IO_FILL_IO_EAST_16_120 VSSA ) ( IO_FILL_IO_EAST_16_100 VSSA ) ( IO_FILL_IO_EAST_16_80 VSSA ) ( IO_FILL_IO_EAST_16_60 VSSA ) ( IO_FILL_IO_EAST_16_40 VSSA )
-      ( IO_FILL_IO_EAST_16_20 VSSA ) ( IO_FILL_IO_EAST_15_120 VSSA ) ( IO_FILL_IO_EAST_15_100 VSSA ) ( IO_FILL_IO_EAST_15_80 VSSA ) ( IO_FILL_IO_EAST_15_60 VSSA ) ( IO_FILL_IO_EAST_15_40 VSSA ) ( IO_FILL_IO_EAST_15_20 VSSA ) ( IO_FILL_IO_EAST_14_140 VSSA )
-      ( IO_FILL_IO_EAST_14_120 VSSA ) ( IO_FILL_IO_EAST_14_100 VSSA ) ( IO_FILL_IO_EAST_14_80 VSSA ) ( IO_FILL_IO_EAST_14_60 VSSA ) ( IO_FILL_IO_EAST_14_40 VSSA ) ( IO_FILL_IO_EAST_14_20 VSSA ) ( IO_FILL_IO_EAST_13_120 VSSA ) ( IO_FILL_IO_EAST_13_100 VSSA )
-      ( IO_FILL_IO_EAST_13_80 VSSA ) ( IO_FILL_IO_EAST_13_60 VSSA ) ( IO_FILL_IO_EAST_13_40 VSSA ) ( IO_FILL_IO_EAST_13_20 VSSA ) ( IO_FILL_IO_EAST_12_140 VSSA ) ( IO_FILL_IO_EAST_12_120 VSSA ) ( IO_FILL_IO_EAST_12_100 VSSA ) ( IO_FILL_IO_EAST_12_80 VSSA )
-      ( IO_FILL_IO_EAST_12_60 VSSA ) ( IO_FILL_IO_EAST_12_40 VSSA ) ( IO_FILL_IO_EAST_12_20 VSSA ) ( IO_FILL_IO_EAST_11_120 VSSA ) ( IO_FILL_IO_EAST_11_100 VSSA ) ( IO_FILL_IO_EAST_11_80 VSSA ) ( IO_FILL_IO_EAST_11_60 VSSA ) ( IO_FILL_IO_EAST_11_40 VSSA )
-      ( IO_FILL_IO_EAST_11_20 VSSA ) ( IO_FILL_IO_EAST_10_120 VSSA ) ( IO_FILL_IO_EAST_10_100 VSSA ) ( IO_FILL_IO_EAST_10_80 VSSA ) ( IO_FILL_IO_EAST_10_60 VSSA ) ( IO_FILL_IO_EAST_10_40 VSSA ) ( IO_FILL_IO_EAST_10_20 VSSA ) ( IO_FILL_IO_EAST_9_140 VSSA )
-      ( IO_FILL_IO_EAST_9_120 VSSA ) ( IO_FILL_IO_EAST_9_100 VSSA ) ( IO_FILL_IO_EAST_9_80 VSSA ) ( IO_FILL_IO_EAST_9_60 VSSA ) ( IO_FILL_IO_EAST_9_40 VSSA ) ( IO_FILL_IO_EAST_9_20 VSSA ) ( IO_FILL_IO_EAST_8_100 VSSA ) ( IO_FILL_IO_EAST_8_80 VSSA )
-      ( IO_FILL_IO_EAST_8_60 VSSA ) ( IO_FILL_IO_EAST_8_40 VSSA ) ( IO_FILL_IO_EAST_8_20 VSSA ) ( IO_FILL_IO_EAST_7_140 VSSA ) ( IO_FILL_IO_EAST_7_120 VSSA ) ( IO_FILL_IO_EAST_7_100 VSSA ) ( IO_FILL_IO_EAST_7_80 VSSA ) ( IO_FILL_IO_EAST_7_60 VSSA )
-      ( IO_FILL_IO_EAST_7_40 VSSA ) ( IO_FILL_IO_EAST_7_20 VSSA ) ( IO_FILL_IO_EAST_6_120 VSSA ) ( IO_FILL_IO_EAST_6_100 VSSA ) ( IO_FILL_IO_EAST_6_80 VSSA ) ( IO_FILL_IO_EAST_6_60 VSSA ) ( IO_FILL_IO_EAST_6_40 VSSA ) ( IO_FILL_IO_EAST_6_20 VSSA )
-      ( IO_FILL_IO_EAST_5_120 VSSA ) ( IO_FILL_IO_EAST_5_100 VSSA ) ( IO_FILL_IO_EAST_5_80 VSSA ) ( IO_FILL_IO_EAST_5_60 VSSA ) ( IO_FILL_IO_EAST_5_40 VSSA ) ( IO_FILL_IO_EAST_5_20 VSSA ) ( IO_FILL_IO_EAST_4_140 VSSA ) ( IO_FILL_IO_EAST_4_120 VSSA )
-      ( IO_FILL_IO_EAST_4_100 VSSA ) ( IO_FILL_IO_EAST_4_80 VSSA ) ( IO_FILL_IO_EAST_4_60 VSSA ) ( IO_FILL_IO_EAST_4_40 VSSA ) ( IO_FILL_IO_EAST_4_20 VSSA ) ( IO_FILL_IO_EAST_3_120 VSSA ) ( IO_FILL_IO_EAST_3_100 VSSA ) ( IO_FILL_IO_EAST_3_80 VSSA )
-      ( IO_FILL_IO_EAST_3_60 VSSA ) ( IO_FILL_IO_EAST_3_40 VSSA ) ( IO_FILL_IO_EAST_3_20 VSSA ) ( IO_FILL_IO_EAST_2_140 VSSA ) ( IO_FILL_IO_EAST_2_120 VSSA ) ( IO_FILL_IO_EAST_2_100 VSSA ) ( IO_FILL_IO_EAST_2_80 VSSA ) ( IO_FILL_IO_EAST_2_60 VSSA )
-      ( IO_FILL_IO_EAST_2_40 VSSA ) ( IO_FILL_IO_EAST_2_20 VSSA ) ( IO_FILL_IO_EAST_1_180 VSSA ) ( IO_FILL_IO_EAST_10_0 VSSA ) ( IO_FILL_IO_EAST_9_145 VSSA ) ( IO_FILL_IO_EAST_9_0 VSSA ) ( IO_FILL_IO_EAST_8_140 VSSA ) ( IO_FILL_IO_EAST_8_120 VSSA )
-      ( IO_FILL_IO_EAST_11_0 VSSA ) ( IO_FILL_IO_EAST_10_140 VSSA ) ( IO_FILL_IO_EAST_18_0 VSSA ) ( IO_FILL_IO_EAST_17_140 VSSA ) ( IO_FILL_IO_EAST_20_0 VSSA ) ( IO_FILL_IO_EAST_19_140 VSSA ) ( IO_FILL_IO_EAST_14_0 VSSA ) ( IO_FILL_IO_EAST_13_140 VSSA )
-      ( IO_FILL_IO_EAST_13_0 VSSA ) ( IO_FILL_IO_EAST_12_145 VSSA ) ( IO_FILL_IO_EAST_12_0 VSSA ) ( IO_FILL_IO_EAST_11_150 VSSA ) ( IO_FILL_IO_EAST_11_140 VSSA ) ( IO_FILL_IO_EAST_8_0 VSSA ) ( IO_FILL_IO_EAST_7_145 VSSA ) ( IO_FILL_IO_EAST_7_0 VSSA )
-      ( IO_FILL_IO_EAST_6_140 VSSA ) ( IO_FILL_IO_EAST_6_0 VSSA ) ( IO_FILL_IO_EAST_5_140 VSSA ) ( IO_FILL_IO_EAST_5_0 VSSA ) ( IO_FILL_IO_EAST_4_145 VSSA ) ( IO_FILL_IO_EAST_4_0 VSSA ) ( IO_FILL_IO_EAST_3_140 VSSA ) ( IO_FILL_IO_EAST_3_0 VSSA )
-      ( IO_FILL_IO_EAST_2_145 VSSA ) ( IO_FILL_IO_EAST_21_0 VSSA ) ( IO_FILL_IO_EAST_20_150 VSSA ) ( IO_FILL_IO_EAST_20_140 VSSA ) ( IO_FILL_IO_EAST_19_0 VSSA ) ( IO_FILL_IO_EAST_18_150 VSSA ) ( IO_FILL_IO_EAST_18_140 VSSA ) ( IO_FILL_IO_EAST_17_0 VSSA )
-      ( IO_FILL_IO_EAST_16_140 VSSA ) ( IO_FILL_IO_EAST_16_0 VSSA ) ( IO_FILL_IO_EAST_15_140 VSSA ) ( IO_FILL_IO_EAST_15_0 VSSA ) ( IO_FILL_IO_EAST_14_145 VSSA ) ( IO_FILL_IO_EAST_2_0 VSSA ) ( IO_FILL_IO_EAST_1_220 VSSA ) ( IO_FILL_IO_EAST_1_200 VSSA )
-      ( IO_FILL_IO_NORTH_12_175 VSSA ) ( IO_FILL_IO_NORTH_12_170 VSSA ) ( IO_FILL_IO_NORTH_12_160 VSSA ) ( IO_FILL_IO_NORTH_12_140 VSSA ) ( IO_FILL_IO_NORTH_12_120 VSSA ) ( IO_FILL_IO_NORTH_12_100 VSSA ) ( IO_FILL_IO_NORTH_12_80 VSSA ) ( IO_FILL_IO_NORTH_12_60 VSSA )
-      ( IO_FILL_IO_NORTH_12_40 VSSA ) ( IO_FILL_IO_NORTH_12_20 VSSA ) ( IO_FILL_IO_NORTH_11_170 VSSA ) ( IO_FILL_IO_NORTH_11_160 VSSA ) ( IO_FILL_IO_NORTH_11_140 VSSA ) ( IO_FILL_IO_NORTH_11_120 VSSA ) ( IO_FILL_IO_NORTH_11_100 VSSA ) ( IO_FILL_IO_NORTH_11_80 VSSA )
-      ( IO_FILL_IO_NORTH_11_60 VSSA ) ( IO_FILL_IO_NORTH_11_40 VSSA ) ( IO_FILL_IO_NORTH_11_20 VSSA ) ( IO_FILL_IO_NORTH_10_170 VSSA ) ( IO_FILL_IO_NORTH_10_160 VSSA ) ( IO_FILL_IO_NORTH_10_140 VSSA ) ( IO_FILL_IO_NORTH_10_120 VSSA ) ( IO_FILL_IO_NORTH_10_100 VSSA )
-      ( IO_FILL_IO_NORTH_10_80 VSSA ) ( IO_FILL_IO_NORTH_10_60 VSSA ) ( IO_FILL_IO_NORTH_10_40 VSSA ) ( IO_FILL_IO_NORTH_10_20 VSSA ) ( IO_FILL_IO_NORTH_9_170 VSSA ) ( IO_FILL_IO_NORTH_9_160 VSSA ) ( IO_FILL_IO_NORTH_9_140 VSSA ) ( IO_FILL_IO_NORTH_9_120 VSSA )
-      ( IO_FILL_IO_NORTH_9_100 VSSA ) ( IO_FILL_IO_NORTH_9_80 VSSA ) ( IO_FILL_IO_NORTH_9_60 VSSA ) ( IO_FILL_IO_NORTH_9_40 VSSA ) ( IO_FILL_IO_NORTH_9_20 VSSA ) ( IO_FILL_IO_NORTH_8_170 VSSA ) ( IO_FILL_IO_NORTH_11_0 VSSA ) ( IO_FILL_IO_NORTH_10_175 VSSA )
-      ( IO_FILL_IO_NORTH_9_0 VSSA ) ( IO_FILL_IO_NORTH_8_175 VSSA ) ( IO_FILL_IO_NORTH_10_0 VSSA ) ( IO_FILL_IO_NORTH_9_175 VSSA ) ( IO_FILL_IO_NORTH_12_0 VSSA ) ( IO_FILL_IO_NORTH_11_175 VSSA ) ( user1_vssd_lvclmap_pad VSSA ) ( user1_vssa_hvclamp_pad\[1\] VSSA )
-      ( user1_vssa_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vssa_hvclamp_pad\[0\] VSSA ) ( user1_vssa_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[1\] VSSA ) ( user1_vdda_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[0\] VSSA ) ( user1_vdda_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vccd_lvclamp_pad VSSA )
-      ( user1_corner VSSA ) ( mprj_pads.area1_io_pad\[9\] VSSA ) ( mprj_pads.area1_io_pad\[8\] VSSA ) ( mprj_pads.area1_io_pad\[7\] VSSA ) ( mprj_pads.area1_io_pad\[6\] VSSA ) ( mprj_pads.area1_io_pad\[5\] VSSA ) ( mprj_pads.area1_io_pad\[4\] VSSA ) ( mprj_pads.area1_io_pad\[3\] VSSA )
-      ( mprj_pads.area1_io_pad\[2\] VSSA ) ( mprj_pads.area1_io_pad\[1\] VSSA ) ( mprj_pads.area1_io_pad\[17\] VSSA ) ( mprj_pads.area1_io_pad\[16\] VSSA ) ( mprj_pads.area1_io_pad\[15\] VSSA ) ( mprj_pads.area1_io_pad\[14\] VSSA ) ( mprj_pads.area1_io_pad\[13\] VSSA ) ( mprj_pads.area1_io_pad\[12\] VSSA )
-      ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE GROUND ;
-    - vssa2 ( PIN vssa2 ) ( brk_vccd_2 VSSA ) ( IO_FILL_IO_WEST_3_0 VSSA ) ( IO_FILL_IO_WEST_3_20 VSSA ) ( IO_FILL_IO_WEST_3_40 VSSA ) ( IO_FILL_IO_WEST_3_60 VSSA ) ( IO_FILL_IO_WEST_3_80 VSSA )
-      ( IO_FILL_IO_WEST_3_100 VSSA ) ( IO_FILL_IO_WEST_3_120 VSSA ) ( IO_FILL_IO_NORTH_0_140 VSSA ) ( IO_FILL_IO_NORTH_0_120 VSSA ) ( IO_FILL_IO_NORTH_0_100 VSSA ) ( IO_FILL_IO_NORTH_0_80 VSSA ) ( IO_FILL_IO_NORTH_0_60 VSSA ) ( IO_FILL_IO_NORTH_0_40 VSSA )
-      ( IO_FILL_IO_NORTH_0_20 VSSA ) ( IO_FILL_IO_NORTH_0_0 VSSA ) ( IO_CORNER_NORTH_WEST_INST VSSA ) ( IO_FILL_IO_WEST_22_130 VSSA ) ( IO_FILL_IO_WEST_22_120 VSSA ) ( IO_FILL_IO_WEST_22_100 VSSA ) ( IO_FILL_IO_WEST_22_80 VSSA ) ( IO_FILL_IO_WEST_22_60 VSSA )
-      ( IO_FILL_IO_WEST_22_40 VSSA ) ( IO_FILL_IO_WEST_22_20 VSSA ) ( IO_FILL_IO_WEST_21_130 VSSA ) ( IO_FILL_IO_WEST_21_120 VSSA ) ( IO_FILL_IO_WEST_21_100 VSSA ) ( IO_FILL_IO_WEST_21_80 VSSA ) ( IO_FILL_IO_WEST_21_60 VSSA ) ( IO_FILL_IO_WEST_21_40 VSSA )
-      ( IO_FILL_IO_WEST_21_20 VSSA ) ( IO_FILL_IO_WEST_20_130 VSSA ) ( IO_FILL_IO_WEST_20_120 VSSA ) ( IO_FILL_IO_WEST_20_100 VSSA ) ( IO_FILL_IO_WEST_20_80 VSSA ) ( IO_FILL_IO_WEST_20_60 VSSA ) ( IO_FILL_IO_WEST_20_40 VSSA ) ( IO_FILL_IO_WEST_20_20 VSSA )
-      ( IO_FILL_IO_WEST_19_130 VSSA ) ( IO_FILL_IO_WEST_19_120 VSSA ) ( IO_FILL_IO_WEST_19_100 VSSA ) ( IO_FILL_IO_WEST_19_80 VSSA ) ( IO_FILL_IO_WEST_19_60 VSSA ) ( IO_FILL_IO_WEST_19_40 VSSA ) ( IO_FILL_IO_WEST_19_20 VSSA ) ( IO_FILL_IO_WEST_18_130 VSSA )
-      ( IO_FILL_IO_WEST_18_120 VSSA ) ( IO_FILL_IO_WEST_18_100 VSSA ) ( IO_FILL_IO_WEST_18_80 VSSA ) ( IO_FILL_IO_WEST_18_60 VSSA ) ( IO_FILL_IO_WEST_18_40 VSSA ) ( IO_FILL_IO_WEST_18_20 VSSA ) ( IO_FILL_IO_WEST_17_130 VSSA ) ( IO_FILL_IO_WEST_17_120 VSSA )
-      ( IO_FILL_IO_WEST_17_100 VSSA ) ( IO_FILL_IO_WEST_17_80 VSSA ) ( IO_FILL_IO_WEST_17_60 VSSA ) ( IO_FILL_IO_WEST_17_40 VSSA ) ( IO_FILL_IO_WEST_17_20 VSSA ) ( IO_FILL_IO_WEST_16_130 VSSA ) ( IO_FILL_IO_WEST_16_120 VSSA ) ( IO_FILL_IO_WEST_16_100 VSSA )
-      ( IO_FILL_IO_WEST_16_80 VSSA ) ( IO_FILL_IO_WEST_16_60 VSSA ) ( IO_FILL_IO_WEST_16_40 VSSA ) ( IO_FILL_IO_WEST_16_20 VSSA ) ( IO_FILL_IO_WEST_15_130 VSSA ) ( IO_FILL_IO_WEST_15_120 VSSA ) ( IO_FILL_IO_WEST_15_100 VSSA ) ( IO_FILL_IO_WEST_15_80 VSSA )
-      ( IO_FILL_IO_WEST_15_60 VSSA ) ( IO_FILL_IO_WEST_15_40 VSSA ) ( IO_FILL_IO_WEST_15_20 VSSA ) ( IO_FILL_IO_WEST_14_130 VSSA ) ( IO_FILL_IO_WEST_14_120 VSSA ) ( IO_FILL_IO_WEST_14_100 VSSA ) ( IO_FILL_IO_WEST_14_80 VSSA ) ( IO_FILL_IO_WEST_14_60 VSSA )
-      ( IO_FILL_IO_WEST_14_40 VSSA ) ( IO_FILL_IO_WEST_14_20 VSSA ) ( IO_FILL_IO_WEST_13_130 VSSA ) ( IO_FILL_IO_WEST_13_120 VSSA ) ( IO_FILL_IO_WEST_13_100 VSSA ) ( IO_FILL_IO_WEST_13_80 VSSA ) ( IO_FILL_IO_WEST_13_60 VSSA ) ( IO_FILL_IO_WEST_13_40 VSSA )
-      ( IO_FILL_IO_WEST_13_20 VSSA ) ( IO_FILL_IO_WEST_12_130 VSSA ) ( IO_FILL_IO_WEST_12_120 VSSA ) ( IO_FILL_IO_WEST_12_100 VSSA ) ( IO_FILL_IO_WEST_12_80 VSSA ) ( IO_FILL_IO_WEST_12_60 VSSA ) ( IO_FILL_IO_WEST_12_40 VSSA ) ( IO_FILL_IO_WEST_12_20 VSSA )
-      ( IO_FILL_IO_WEST_11_130 VSSA ) ( IO_FILL_IO_WEST_11_120 VSSA ) ( IO_FILL_IO_WEST_11_100 VSSA ) ( IO_FILL_IO_WEST_11_80 VSSA ) ( IO_FILL_IO_WEST_11_60 VSSA ) ( IO_FILL_IO_WEST_11_40 VSSA ) ( IO_FILL_IO_WEST_11_20 VSSA ) ( IO_FILL_IO_WEST_10_130 VSSA )
-      ( IO_FILL_IO_WEST_10_120 VSSA ) ( IO_FILL_IO_WEST_10_100 VSSA ) ( IO_FILL_IO_WEST_10_80 VSSA ) ( IO_FILL_IO_WEST_10_60 VSSA ) ( IO_FILL_IO_WEST_10_40 VSSA ) ( IO_FILL_IO_WEST_10_20 VSSA ) ( IO_FILL_IO_WEST_9_130 VSSA ) ( IO_FILL_IO_WEST_9_120 VSSA )
-      ( IO_FILL_IO_WEST_9_100 VSSA ) ( IO_FILL_IO_WEST_9_80 VSSA ) ( IO_FILL_IO_WEST_9_60 VSSA ) ( IO_FILL_IO_WEST_9_40 VSSA ) ( IO_FILL_IO_WEST_9_20 VSSA ) ( IO_FILL_IO_WEST_8_130 VSSA ) ( IO_FILL_IO_WEST_8_120 VSSA ) ( IO_FILL_IO_WEST_8_100 VSSA )
-      ( IO_FILL_IO_WEST_8_80 VSSA ) ( IO_FILL_IO_WEST_8_60 VSSA ) ( IO_FILL_IO_WEST_8_40 VSSA ) ( IO_FILL_IO_WEST_8_20 VSSA ) ( IO_FILL_IO_WEST_7_130 VSSA ) ( IO_FILL_IO_WEST_7_120 VSSA ) ( IO_FILL_IO_WEST_7_100 VSSA ) ( IO_FILL_IO_WEST_7_80 VSSA )
-      ( IO_FILL_IO_WEST_7_60 VSSA ) ( IO_FILL_IO_WEST_7_40 VSSA ) ( IO_FILL_IO_WEST_7_20 VSSA ) ( IO_FILL_IO_WEST_6_130 VSSA ) ( IO_FILL_IO_WEST_6_120 VSSA ) ( IO_FILL_IO_WEST_6_100 VSSA ) ( IO_FILL_IO_WEST_6_80 VSSA ) ( IO_FILL_IO_WEST_6_60 VSSA )
-      ( IO_FILL_IO_WEST_6_40 VSSA ) ( IO_FILL_IO_WEST_6_20 VSSA ) ( IO_FILL_IO_WEST_5_130 VSSA ) ( IO_FILL_IO_WEST_5_120 VSSA ) ( IO_FILL_IO_WEST_5_100 VSSA ) ( IO_FILL_IO_WEST_5_80 VSSA ) ( IO_FILL_IO_WEST_5_60 VSSA ) ( IO_FILL_IO_WEST_5_40 VSSA )
-      ( IO_FILL_IO_WEST_5_20 VSSA ) ( IO_FILL_IO_WEST_4_130 VSSA ) ( IO_FILL_IO_WEST_4_120 VSSA ) ( IO_FILL_IO_WEST_4_100 VSSA ) ( IO_FILL_IO_WEST_4_80 VSSA ) ( IO_FILL_IO_WEST_4_60 VSSA ) ( IO_FILL_IO_WEST_4_40 VSSA ) ( IO_FILL_IO_WEST_4_20 VSSA )
-      ( IO_FILL_IO_WEST_3_130 VSSA ) ( IO_FILL_IO_WEST_10_0 VSSA ) ( IO_FILL_IO_WEST_9_135 VSSA ) ( IO_FILL_IO_WEST_19_0 VSSA ) ( IO_FILL_IO_WEST_18_135 VSSA ) ( IO_FILL_IO_WEST_11_0 VSSA ) ( IO_FILL_IO_WEST_10_135 VSSA ) ( IO_FILL_IO_WEST_21_0 VSSA )
-      ( IO_FILL_IO_WEST_20_135 VSSA ) ( IO_FILL_IO_WEST_16_0 VSSA ) ( IO_FILL_IO_WEST_15_135 VSSA ) ( IO_FILL_IO_WEST_17_0 VSSA ) ( IO_FILL_IO_WEST_16_135 VSSA ) ( IO_FILL_IO_WEST_18_0 VSSA ) ( IO_FILL_IO_WEST_17_135 VSSA ) ( IO_FILL_IO_WEST_22_0 VSSA )
-      ( IO_FILL_IO_WEST_21_135 VSSA ) ( IO_FILL_IO_WEST_4_0 VSSA ) ( IO_FILL_IO_WEST_3_135 VSSA ) ( IO_FILL_IO_WEST_5_0 VSSA ) ( IO_FILL_IO_WEST_4_135 VSSA ) ( IO_FILL_IO_WEST_6_0 VSSA ) ( IO_FILL_IO_WEST_5_135 VSSA ) ( IO_FILL_IO_WEST_7_0 VSSA )
-      ( IO_FILL_IO_WEST_6_135 VSSA ) ( IO_FILL_IO_WEST_8_0 VSSA ) ( IO_FILL_IO_WEST_7_135 VSSA ) ( IO_FILL_IO_WEST_9_0 VSSA ) ( IO_FILL_IO_WEST_8_135 VSSA ) ( IO_FILL_IO_WEST_12_0 VSSA ) ( IO_FILL_IO_WEST_11_135 VSSA ) ( IO_FILL_IO_WEST_13_0 VSSA )
-      ( IO_FILL_IO_WEST_12_135 VSSA ) ( IO_FILL_IO_WEST_14_0 VSSA ) ( IO_FILL_IO_WEST_13_135 VSSA ) ( IO_FILL_IO_WEST_15_0 VSSA ) ( IO_FILL_IO_WEST_14_135 VSSA ) ( IO_FILL_IO_WEST_20_0 VSSA ) ( IO_FILL_IO_WEST_19_135 VSSA ) ( IO_FILL_IO_NORTH_7_175 VSSA )
-      ( IO_FILL_IO_NORTH_7_170 VSSA ) ( IO_FILL_IO_NORTH_7_160 VSSA ) ( IO_FILL_IO_NORTH_7_140 VSSA ) ( IO_FILL_IO_NORTH_7_120 VSSA ) ( IO_FILL_IO_NORTH_7_100 VSSA ) ( IO_FILL_IO_NORTH_7_80 VSSA ) ( IO_FILL_IO_NORTH_7_60 VSSA ) ( IO_FILL_IO_NORTH_7_40 VSSA )
-      ( IO_FILL_IO_NORTH_7_20 VSSA ) ( IO_FILL_IO_NORTH_6_170 VSSA ) ( IO_FILL_IO_NORTH_6_160 VSSA ) ( IO_FILL_IO_NORTH_6_140 VSSA ) ( IO_FILL_IO_NORTH_6_120 VSSA ) ( IO_FILL_IO_NORTH_6_100 VSSA ) ( IO_FILL_IO_NORTH_6_80 VSSA ) ( IO_FILL_IO_NORTH_6_60 VSSA )
-      ( IO_FILL_IO_NORTH_6_40 VSSA ) ( IO_FILL_IO_NORTH_6_20 VSSA ) ( IO_FILL_IO_NORTH_5_170 VSSA ) ( IO_FILL_IO_NORTH_5_160 VSSA ) ( IO_FILL_IO_NORTH_5_140 VSSA ) ( IO_FILL_IO_NORTH_5_120 VSSA ) ( IO_FILL_IO_NORTH_5_100 VSSA ) ( IO_FILL_IO_NORTH_5_80 VSSA )
-      ( IO_FILL_IO_NORTH_5_60 VSSA ) ( IO_FILL_IO_NORTH_5_40 VSSA ) ( IO_FILL_IO_NORTH_5_20 VSSA ) ( IO_FILL_IO_NORTH_4_170 VSSA ) ( IO_FILL_IO_NORTH_4_160 VSSA ) ( IO_FILL_IO_NORTH_4_140 VSSA ) ( IO_FILL_IO_NORTH_4_120 VSSA ) ( IO_FILL_IO_NORTH_4_100 VSSA )
-      ( IO_FILL_IO_NORTH_4_80 VSSA ) ( IO_FILL_IO_NORTH_4_60 VSSA ) ( IO_FILL_IO_NORTH_4_40 VSSA ) ( IO_FILL_IO_NORTH_4_20 VSSA ) ( IO_FILL_IO_NORTH_3_170 VSSA ) ( IO_FILL_IO_NORTH_3_160 VSSA ) ( IO_FILL_IO_NORTH_3_140 VSSA ) ( IO_FILL_IO_NORTH_3_120 VSSA )
-      ( IO_FILL_IO_NORTH_3_100 VSSA ) ( IO_FILL_IO_NORTH_3_80 VSSA ) ( IO_FILL_IO_NORTH_3_60 VSSA ) ( IO_FILL_IO_NORTH_3_40 VSSA ) ( IO_FILL_IO_NORTH_3_20 VSSA ) ( IO_FILL_IO_NORTH_2_170 VSSA ) ( IO_FILL_IO_NORTH_2_160 VSSA ) ( IO_FILL_IO_NORTH_2_140 VSSA )
-      ( IO_FILL_IO_NORTH_2_120 VSSA ) ( IO_FILL_IO_NORTH_2_100 VSSA ) ( IO_FILL_IO_NORTH_2_80 VSSA ) ( IO_FILL_IO_NORTH_2_60 VSSA ) ( IO_FILL_IO_NORTH_2_40 VSSA ) ( IO_FILL_IO_NORTH_2_20 VSSA ) ( IO_FILL_IO_NORTH_1_170 VSSA ) ( IO_FILL_IO_NORTH_1_160 VSSA )
-      ( IO_FILL_IO_NORTH_1_140 VSSA ) ( IO_FILL_IO_NORTH_1_120 VSSA ) ( IO_FILL_IO_NORTH_1_100 VSSA ) ( IO_FILL_IO_NORTH_1_80 VSSA ) ( IO_FILL_IO_NORTH_1_60 VSSA ) ( IO_FILL_IO_NORTH_1_40 VSSA ) ( IO_FILL_IO_NORTH_1_20 VSSA ) ( IO_FILL_IO_NORTH_0_160 VSSA )
-      ( IO_FILL_IO_NORTH_1_0 VSSA ) ( IO_FILL_IO_NORTH_0_180 VSSA ) ( IO_FILL_IO_NORTH_2_0 VSSA ) ( IO_FILL_IO_NORTH_1_175 VSSA ) ( IO_FILL_IO_NORTH_3_0 VSSA ) ( IO_FILL_IO_NORTH_2_175 VSSA ) ( IO_FILL_IO_NORTH_4_0 VSSA ) ( IO_FILL_IO_NORTH_3_175 VSSA )
-      ( IO_FILL_IO_NORTH_5_0 VSSA ) ( IO_FILL_IO_NORTH_4_175 VSSA ) ( IO_FILL_IO_NORTH_7_0 VSSA ) ( IO_FILL_IO_NORTH_6_175 VSSA ) ( IO_FILL_IO_NORTH_6_0 VSSA ) ( IO_FILL_IO_NORTH_5_175 VSSA ) ( user2_vssd_lvclmap_pad VSSA ) ( user2_vssa_hvclamp_pad VSSA )
-      ( user2_vssa_hvclamp_pad SRC_BDY_HVC ) ( user2_vdda_hvclamp_pad VSSA ) ( user2_vdda_hvclamp_pad SRC_BDY_HVC ) ( user2_vccd_lvclamp_pad VSSA ) ( user2_corner VSSA ) ( mprj_pads.area2_io_pad\[9\] VSSA ) ( mprj_pads.area2_io_pad\[8\] VSSA ) ( mprj_pads.area2_io_pad\[7\] VSSA )
-      ( mprj_pads.area2_io_pad\[6\] VSSA ) ( mprj_pads.area2_io_pad\[5\] VSSA ) ( mprj_pads.area2_io_pad\[4\] VSSA ) ( mprj_pads.area2_io_pad\[3\] VSSA ) ( mprj_pads.area2_io_pad\[2\] VSSA ) ( mprj_pads.area2_io_pad\[1\] VSSA ) ( mprj_pads.area2_io_pad\[19\] VSSA ) ( mprj_pads.area2_io_pad\[18\] VSSA )
-      ( mprj_pads.area2_io_pad\[17\] VSSA ) ( mprj_pads.area2_io_pad\[16\] VSSA ) ( mprj_pads.area2_io_pad\[15\] VSSA ) ( mprj_pads.area2_io_pad\[14\] VSSA ) ( mprj_pads.area2_io_pad\[13\] VSSA ) ( mprj_pads.area2_io_pad\[12\] VSSA ) ( mprj_pads.area2_io_pad\[11\] VSSA ) ( mprj_pads.area2_io_pad\[10\] VSSA )
-      ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE GROUND ;
-    - vssd ( PIN vssd ) ( IO_FILL_IO_SOUTH_0_40 VSSD ) ( IO_FILL_IO_SOUTH_0_20 VSSD ) ( IO_FILL_IO_SOUTH_0_0 VSSD ) ( IO_FILL_IO_SOUTH_0_50 VSSD ) ( IO_FILL_IO_SOUTH_0_55 VSSD ) ( connect_0 VSSD )
-      ( IO_CORNER_SOUTH_WEST_INST VSSD ) ( IO_FILL_IO_WEST_0_0 VSSD ) ( connect_1 VSSD ) ( IO_FILL_IO_WEST_0_20 VSSD ) ( connect_2 VSSD ) ( IO_FILL_IO_WEST_0_40 VSSD ) ( connect_3 VSSD ) ( IO_FILL_IO_WEST_0_60 VSSD )
-      ( connect_4 VSSD ) ( brk_vdda_0 VSSD ) ( IO_FILL_IO_WEST_0_80 VSSD ) ( connect_5 VSSD ) ( IO_FILL_IO_EAST_0_145 VSSD ) ( IO_FILL_IO_EAST_0_140 VSSD ) ( IO_FILL_IO_EAST_0_120 VSSD ) ( IO_FILL_IO_EAST_0_100 VSSD )
-      ( IO_FILL_IO_EAST_0_80 VSSD ) ( IO_FILL_IO_EAST_0_60 VSSD ) ( IO_FILL_IO_EAST_0_40 VSSD ) ( IO_FILL_IO_EAST_0_20 VSSD ) ( IO_FILL_IO_EAST_0_0 VSSD ) ( IO_CORNER_SOUTH_EAST_INST VSSD ) ( IO_FILL_IO_WEST_0_100 VSSD ) ( IO_FILL_IO_SOUTH_23_20 VSSD )
-      ( IO_FILL_IO_SOUTH_17_20 VSSD ) ( IO_FILL_IO_SOUTH_15_20 VSSD ) ( IO_FILL_IO_SOUTH_13_20 VSSD ) ( IO_FILL_IO_SOUTH_11_20 VSSD ) ( IO_FILL_IO_SOUTH_9_20 VSSD ) ( IO_FILL_IO_SOUTH_5_20 VSSD ) ( IO_FILL_IO_SOUTH_1_0 VSSD ) ( IO_FILL_IO_SOUTH_23_0 VSSD )
-      ( connect_71 VSSD ) ( connect_70 VSSD ) ( connect_69 VSSD ) ( connect_68 VSSD ) ( connect_67 VSSD ) ( IO_FILL_IO_SOUTH_21_0 VSSD ) ( connect_65 VSSD ) ( connect_64 VSSD )
-      ( connect_63 VSSD ) ( connect_62 VSSD ) ( connect_61 VSSD ) ( IO_FILL_IO_SOUTH_19_0 VSSD ) ( connect_59 VSSD ) ( connect_58 VSSD ) ( connect_57 VSSD ) ( connect_56 VSSD )
-      ( connect_55 VSSD ) ( IO_FILL_IO_SOUTH_17_0 VSSD ) ( connect_53 VSSD ) ( connect_52 VSSD ) ( connect_51 VSSD ) ( connect_50 VSSD ) ( connect_49 VSSD ) ( IO_FILL_IO_SOUTH_15_0 VSSD )
-      ( connect_47 VSSD ) ( connect_46 VSSD ) ( connect_45 VSSD ) ( connect_44 VSSD ) ( connect_43 VSSD ) ( IO_FILL_IO_SOUTH_13_0 VSSD ) ( connect_41 VSSD ) ( connect_40 VSSD )
-      ( connect_39 VSSD ) ( connect_38 VSSD ) ( connect_37 VSSD ) ( IO_FILL_IO_SOUTH_11_0 VSSD ) ( connect_35 VSSD ) ( connect_34 VSSD ) ( connect_33 VSSD ) ( connect_32 VSSD )
-      ( connect_31 VSSD ) ( IO_FILL_IO_SOUTH_9_0 VSSD ) ( connect_29 VSSD ) ( connect_28 VSSD ) ( connect_27 VSSD ) ( connect_26 VSSD ) ( connect_25 VSSD ) ( IO_FILL_IO_SOUTH_7_0 VSSD )
-      ( connect_23 VSSD ) ( connect_22 VSSD ) ( connect_21 VSSD ) ( connect_20 VSSD ) ( connect_19 VSSD ) ( IO_FILL_IO_SOUTH_5_0 VSSD ) ( connect_17 VSSD ) ( connect_16 VSSD )
-      ( connect_15 VSSD ) ( connect_14 VSSD ) ( connect_13 VSSD ) ( IO_FILL_IO_SOUTH_3_0 VSSD ) ( connect_11 VSSD ) ( connect_10 VSSD ) ( connect_9 VSSD ) ( connect_8 VSSD )
-      ( connect_7 VSSD ) ( IO_FILL_IO_WEST_0_120 VSSD ) ( brk_vdda_2 VSSD ) ( IO_FILL_IO_SOUTH_21_20 VSSD ) ( IO_FILL_IO_SOUTH_19_20 VSSD ) ( IO_FILL_IO_SOUTH_17_40 VSSD ) ( IO_FILL_IO_SOUTH_15_40 VSSD ) ( IO_FILL_IO_SOUTH_13_40 VSSD )
-      ( IO_FILL_IO_SOUTH_11_40 VSSD ) ( IO_FILL_IO_SOUTH_9_40 VSSD ) ( IO_FILL_IO_SOUTH_7_20 VSSD ) ( IO_FILL_IO_SOUTH_5_40 VSSD ) ( IO_FILL_IO_SOUTH_3_20 VSSD ) ( IO_FILL_IO_SOUTH_1_20 VSSD ) ( connect_66 VSSD ) ( connect_60 VSSD )
-      ( connect_54 VSSD ) ( connect_48 VSSD ) ( connect_42 VSSD ) ( connect_36 VSSD ) ( connect_30 VSSD ) ( connect_24 VSSD ) ( connect_18 VSSD ) ( connect_12 VSSD )
-      ( connect_6 VSSD ) ( IO_FILL_IO_WEST_2_135 VSSD ) ( IO_FILL_IO_WEST_2_130 VSSD ) ( IO_FILL_IO_WEST_2_120 VSSD ) ( IO_FILL_IO_WEST_2_100 VSSD ) ( IO_FILL_IO_WEST_2_80 VSSD ) ( IO_FILL_IO_WEST_2_60 VSSD ) ( IO_FILL_IO_WEST_2_40 VSSD )
-      ( IO_FILL_IO_WEST_2_20 VSSD ) ( IO_FILL_IO_WEST_1_130 VSSD ) ( IO_FILL_IO_WEST_1_120 VSSD ) ( IO_FILL_IO_WEST_1_100 VSSD ) ( IO_FILL_IO_WEST_1_80 VSSD ) ( IO_FILL_IO_WEST_1_60 VSSD ) ( IO_FILL_IO_WEST_1_40 VSSD ) ( IO_FILL_IO_WEST_1_20 VSSD )
-      ( IO_FILL_IO_WEST_0_130 VSSD ) ( IO_FILL_IO_WEST_2_0 VSSD ) ( IO_FILL_IO_WEST_1_135 VSSD ) ( IO_FILL_IO_WEST_1_0 VSSD ) ( IO_FILL_IO_WEST_0_135 VSSD ) ( IO_FILL_IO_SOUTH_22_10 VSSD ) ( IO_FILL_IO_SOUTH_21_40 VSSD ) ( IO_FILL_IO_SOUTH_20_10 VSSD )
-      ( IO_FILL_IO_SOUTH_19_40 VSSD ) ( IO_FILL_IO_SOUTH_18_5 VSSD ) ( IO_FILL_IO_SOUTH_17_60 VSSD ) ( IO_FILL_IO_SOUTH_16_5 VSSD ) ( IO_FILL_IO_SOUTH_15_60 VSSD ) ( IO_FILL_IO_SOUTH_14_5 VSSD ) ( IO_FILL_IO_SOUTH_13_60 VSSD ) ( IO_FILL_IO_SOUTH_12_5 VSSD )
-      ( IO_FILL_IO_SOUTH_11_60 VSSD ) ( IO_FILL_IO_SOUTH_10_5 VSSD ) ( IO_FILL_IO_SOUTH_9_60 VSSD ) ( IO_FILL_IO_SOUTH_8_10 VSSD ) ( IO_FILL_IO_SOUTH_7_40 VSSD ) ( IO_FILL_IO_SOUTH_6_5 VSSD ) ( IO_FILL_IO_SOUTH_5_60 VSSD ) ( IO_FILL_IO_SOUTH_4_10 VSSD )
-      ( IO_FILL_IO_SOUTH_3_40 VSSD ) ( IO_FILL_IO_SOUTH_2_10 VSSD ) ( IO_FILL_IO_SOUTH_1_40 VSSD ) ( IO_FILL_IO_SOUTH_4_0 VSSD ) ( IO_FILL_IO_SOUTH_3_60 VSSD ) ( IO_FILL_IO_SOUTH_20_0 VSSD ) ( IO_FILL_IO_SOUTH_19_60 VSSD ) ( IO_FILL_IO_SOUTH_8_0 VSSD )
-      ( IO_FILL_IO_SOUTH_7_60 VSSD ) ( IO_FILL_IO_SOUTH_2_0 VSSD ) ( IO_FILL_IO_SOUTH_1_60 VSSD ) ( IO_FILL_IO_SOUTH_22_0 VSSD ) ( IO_FILL_IO_SOUTH_21_60 VSSD ) ( IO_FILL_IO_SOUTH_18_0 VSSD ) ( IO_FILL_IO_SOUTH_17_65 VSSD ) ( IO_FILL_IO_SOUTH_16_0 VSSD )
-      ( IO_FILL_IO_SOUTH_15_65 VSSD ) ( IO_FILL_IO_SOUTH_14_0 VSSD ) ( IO_FILL_IO_SOUTH_13_65 VSSD ) ( IO_FILL_IO_SOUTH_10_0 VSSD ) ( IO_FILL_IO_SOUTH_9_65 VSSD ) ( IO_FILL_IO_SOUTH_12_0 VSSD ) ( IO_FILL_IO_SOUTH_11_65 VSSD ) ( IO_FILL_IO_SOUTH_6_0 VSSD )
-      ( IO_FILL_IO_SOUTH_5_65 VSSD ) ( * SRC_BDY_LVC2 ) ( resetb_pad VSSD ) ( mgmt_vssio_hvclamp_pad\[0\] VSSD ) ( mgmt_vssd_lvclmap_pad VSSD ) ( mgmt_vssa_hvclamp_pad VSSD ) ( mgmt_vddio_hvclamp_pad\[0\] VSSD ) ( mgmt_vdda_hvclamp_pad VSSD )
-      ( mgmt_vccd_lvclamp_pad VSSD ) ( mgmt_corner\[1\] VSSD ) ( mgmt_corner\[0\] VSSD ) ( gpio_pad VTRIP_SEL ) ( gpio_pad VSSD ) ( gpio_pad SLOW ) ( gpio_pad IB_MODE_SEL ) ( gpio_pad HLD_OVR )
-      ( gpio_pad ANALOG_SEL ) ( gpio_pad ANALOG_POL ) ( gpio_pad ANALOG_EN ) ( flash_io1_pad VTRIP_SEL ) ( flash_io1_pad VSSD ) ( flash_io1_pad SLOW ) ( flash_io1_pad IB_MODE_SEL ) ( flash_io1_pad HLD_OVR )
-      ( flash_io1_pad ANALOG_SEL ) ( flash_io1_pad ANALOG_POL ) ( flash_io1_pad ANALOG_EN ) ( flash_io0_pad VTRIP_SEL ) ( flash_io0_pad VSSD ) ( flash_io0_pad SLOW ) ( flash_io0_pad IB_MODE_SEL ) ( flash_io0_pad HLD_OVR )
-      ( flash_io0_pad ANALOG_SEL ) ( flash_io0_pad ANALOG_POL ) ( flash_io0_pad ANALOG_EN ) ( flash_csb_pad VTRIP_SEL ) ( flash_csb_pad VSSD ) ( flash_csb_pad SLOW ) ( flash_csb_pad IB_MODE_SEL ) ( flash_csb_pad HLD_OVR )
-      ( flash_csb_pad DM[0] ) ( flash_csb_pad ANALOG_SEL ) ( flash_csb_pad ANALOG_POL ) ( flash_csb_pad ANALOG_EN ) ( flash_clk_pad VTRIP_SEL ) ( flash_clk_pad VSSD ) ( flash_clk_pad SLOW ) ( flash_clk_pad IB_MODE_SEL )
-      ( flash_clk_pad HLD_OVR ) ( flash_clk_pad DM[0] ) ( flash_clk_pad ANALOG_SEL ) ( flash_clk_pad ANALOG_POL ) ( flash_clk_pad ANALOG_EN ) ( clock_pad VTRIP_SEL ) ( clock_pad VSSD ) ( clock_pad SLOW )
-      ( clock_pad OUT ) ( clock_pad IB_MODE_SEL ) ( clock_pad HLD_OVR ) ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE GROUND ;
-    - vssd1 ( PIN vssd1 ) ( IO_FILL_IO_EAST_1_0 VSSD ) ( IO_FILL_IO_NORTH_8_0 VSSD ) ( IO_FILL_IO_EAST_1_20 VSSD ) ( IO_FILL_IO_NORTH_8_20 VSSD ) ( IO_FILL_IO_EAST_1_40 VSSD ) ( IO_FILL_IO_NORTH_8_40 VSSD )
-      ( IO_FILL_IO_EAST_1_60 VSSD ) ( IO_FILL_IO_NORTH_8_60 VSSD ) ( IO_FILL_IO_EAST_1_80 VSSD ) ( IO_FILL_IO_NORTH_8_80 VSSD ) ( IO_FILL_IO_EAST_1_100 VSSD ) ( IO_FILL_IO_NORTH_8_100 VSSD ) ( IO_FILL_IO_EAST_1_120 VSSD ) ( IO_FILL_IO_NORTH_8_120 VSSD )
-      ( IO_FILL_IO_EAST_1_140 VSSD ) ( IO_FILL_IO_NORTH_8_140 VSSD ) ( IO_FILL_IO_EAST_1_160 VSSD ) ( IO_FILL_IO_NORTH_8_160 VSSD ) ( IO_CORNER_NORTH_EAST_INST VSSD ) ( IO_FILL_IO_EAST_21_65 VSSD ) ( IO_FILL_IO_EAST_21_60 VSSD ) ( IO_FILL_IO_EAST_21_40 VSSD )
-      ( IO_FILL_IO_EAST_21_20 VSSD ) ( IO_FILL_IO_EAST_20_120 VSSD ) ( IO_FILL_IO_EAST_20_100 VSSD ) ( IO_FILL_IO_EAST_20_80 VSSD ) ( IO_FILL_IO_EAST_20_60 VSSD ) ( IO_FILL_IO_EAST_20_40 VSSD ) ( IO_FILL_IO_EAST_20_20 VSSD ) ( IO_FILL_IO_EAST_19_120 VSSD )
-      ( IO_FILL_IO_EAST_19_100 VSSD ) ( IO_FILL_IO_EAST_19_80 VSSD ) ( IO_FILL_IO_EAST_19_60 VSSD ) ( IO_FILL_IO_EAST_19_40 VSSD ) ( IO_FILL_IO_EAST_19_20 VSSD ) ( IO_FILL_IO_EAST_18_120 VSSD ) ( IO_FILL_IO_EAST_18_100 VSSD ) ( IO_FILL_IO_EAST_18_80 VSSD )
-      ( IO_FILL_IO_EAST_18_60 VSSD ) ( IO_FILL_IO_EAST_18_40 VSSD ) ( IO_FILL_IO_EAST_18_20 VSSD ) ( IO_FILL_IO_EAST_17_120 VSSD ) ( IO_FILL_IO_EAST_17_100 VSSD ) ( IO_FILL_IO_EAST_17_80 VSSD ) ( IO_FILL_IO_EAST_17_60 VSSD ) ( IO_FILL_IO_EAST_17_40 VSSD )
-      ( IO_FILL_IO_EAST_17_20 VSSD ) ( IO_FILL_IO_EAST_16_120 VSSD ) ( IO_FILL_IO_EAST_16_100 VSSD ) ( IO_FILL_IO_EAST_16_80 VSSD ) ( IO_FILL_IO_EAST_16_60 VSSD ) ( IO_FILL_IO_EAST_16_40 VSSD ) ( IO_FILL_IO_EAST_16_20 VSSD ) ( IO_FILL_IO_EAST_15_120 VSSD )
-      ( IO_FILL_IO_EAST_15_100 VSSD ) ( IO_FILL_IO_EAST_15_80 VSSD ) ( IO_FILL_IO_EAST_15_60 VSSD ) ( IO_FILL_IO_EAST_15_40 VSSD ) ( IO_FILL_IO_EAST_15_20 VSSD ) ( IO_FILL_IO_EAST_14_140 VSSD ) ( IO_FILL_IO_EAST_14_120 VSSD ) ( IO_FILL_IO_EAST_14_100 VSSD )
-      ( IO_FILL_IO_EAST_14_80 VSSD ) ( IO_FILL_IO_EAST_14_60 VSSD ) ( IO_FILL_IO_EAST_14_40 VSSD ) ( IO_FILL_IO_EAST_14_20 VSSD ) ( IO_FILL_IO_EAST_13_120 VSSD ) ( IO_FILL_IO_EAST_13_100 VSSD ) ( IO_FILL_IO_EAST_13_80 VSSD ) ( IO_FILL_IO_EAST_13_60 VSSD )
-      ( IO_FILL_IO_EAST_13_40 VSSD ) ( IO_FILL_IO_EAST_13_20 VSSD ) ( IO_FILL_IO_EAST_12_140 VSSD ) ( IO_FILL_IO_EAST_12_120 VSSD ) ( IO_FILL_IO_EAST_12_100 VSSD ) ( IO_FILL_IO_EAST_12_80 VSSD ) ( IO_FILL_IO_EAST_12_60 VSSD ) ( IO_FILL_IO_EAST_12_40 VSSD )
-      ( IO_FILL_IO_EAST_12_20 VSSD ) ( IO_FILL_IO_EAST_11_120 VSSD ) ( IO_FILL_IO_EAST_11_100 VSSD ) ( IO_FILL_IO_EAST_11_80 VSSD ) ( IO_FILL_IO_EAST_11_60 VSSD ) ( IO_FILL_IO_EAST_11_40 VSSD ) ( IO_FILL_IO_EAST_11_20 VSSD ) ( IO_FILL_IO_EAST_10_120 VSSD )
-      ( IO_FILL_IO_EAST_10_100 VSSD ) ( IO_FILL_IO_EAST_10_80 VSSD ) ( IO_FILL_IO_EAST_10_60 VSSD ) ( IO_FILL_IO_EAST_10_40 VSSD ) ( IO_FILL_IO_EAST_10_20 VSSD ) ( IO_FILL_IO_EAST_9_140 VSSD ) ( IO_FILL_IO_EAST_9_120 VSSD ) ( IO_FILL_IO_EAST_9_100 VSSD )
-      ( IO_FILL_IO_EAST_9_80 VSSD ) ( IO_FILL_IO_EAST_9_60 VSSD ) ( IO_FILL_IO_EAST_9_40 VSSD ) ( IO_FILL_IO_EAST_9_20 VSSD ) ( IO_FILL_IO_EAST_8_100 VSSD ) ( IO_FILL_IO_EAST_8_80 VSSD ) ( IO_FILL_IO_EAST_8_60 VSSD ) ( IO_FILL_IO_EAST_8_40 VSSD )
-      ( IO_FILL_IO_EAST_8_20 VSSD ) ( IO_FILL_IO_EAST_7_140 VSSD ) ( IO_FILL_IO_EAST_7_120 VSSD ) ( IO_FILL_IO_EAST_7_100 VSSD ) ( IO_FILL_IO_EAST_7_80 VSSD ) ( IO_FILL_IO_EAST_7_60 VSSD ) ( IO_FILL_IO_EAST_7_40 VSSD ) ( IO_FILL_IO_EAST_7_20 VSSD )
-      ( IO_FILL_IO_EAST_6_120 VSSD ) ( IO_FILL_IO_EAST_6_100 VSSD ) ( IO_FILL_IO_EAST_6_80 VSSD ) ( IO_FILL_IO_EAST_6_60 VSSD ) ( IO_FILL_IO_EAST_6_40 VSSD ) ( IO_FILL_IO_EAST_6_20 VSSD ) ( IO_FILL_IO_EAST_5_120 VSSD ) ( IO_FILL_IO_EAST_5_100 VSSD )
-      ( IO_FILL_IO_EAST_5_80 VSSD ) ( IO_FILL_IO_EAST_5_60 VSSD ) ( IO_FILL_IO_EAST_5_40 VSSD ) ( IO_FILL_IO_EAST_5_20 VSSD ) ( IO_FILL_IO_EAST_4_140 VSSD ) ( IO_FILL_IO_EAST_4_120 VSSD ) ( IO_FILL_IO_EAST_4_100 VSSD ) ( IO_FILL_IO_EAST_4_80 VSSD )
-      ( IO_FILL_IO_EAST_4_60 VSSD ) ( IO_FILL_IO_EAST_4_40 VSSD ) ( IO_FILL_IO_EAST_4_20 VSSD ) ( IO_FILL_IO_EAST_3_120 VSSD ) ( IO_FILL_IO_EAST_3_100 VSSD ) ( IO_FILL_IO_EAST_3_80 VSSD ) ( IO_FILL_IO_EAST_3_60 VSSD ) ( IO_FILL_IO_EAST_3_40 VSSD )
-      ( IO_FILL_IO_EAST_3_20 VSSD ) ( IO_FILL_IO_EAST_2_140 VSSD ) ( IO_FILL_IO_EAST_2_120 VSSD ) ( IO_FILL_IO_EAST_2_100 VSSD ) ( IO_FILL_IO_EAST_2_80 VSSD ) ( IO_FILL_IO_EAST_2_60 VSSD ) ( IO_FILL_IO_EAST_2_40 VSSD ) ( IO_FILL_IO_EAST_2_20 VSSD )
-      ( IO_FILL_IO_EAST_1_180 VSSD ) ( IO_FILL_IO_EAST_10_0 VSSD ) ( IO_FILL_IO_EAST_9_145 VSSD ) ( IO_FILL_IO_EAST_9_0 VSSD ) ( IO_FILL_IO_EAST_8_140 VSSD ) ( IO_FILL_IO_EAST_8_120 VSSD ) ( IO_FILL_IO_EAST_11_0 VSSD ) ( IO_FILL_IO_EAST_10_140 VSSD )
-      ( IO_FILL_IO_EAST_18_0 VSSD ) ( IO_FILL_IO_EAST_17_140 VSSD ) ( IO_FILL_IO_EAST_20_0 VSSD ) ( IO_FILL_IO_EAST_19_140 VSSD ) ( IO_FILL_IO_EAST_14_0 VSSD ) ( IO_FILL_IO_EAST_13_140 VSSD ) ( IO_FILL_IO_EAST_13_0 VSSD ) ( IO_FILL_IO_EAST_12_145 VSSD )
-      ( IO_FILL_IO_EAST_12_0 VSSD ) ( IO_FILL_IO_EAST_11_150 VSSD ) ( IO_FILL_IO_EAST_11_140 VSSD ) ( IO_FILL_IO_EAST_8_0 VSSD ) ( IO_FILL_IO_EAST_7_145 VSSD ) ( IO_FILL_IO_EAST_7_0 VSSD ) ( IO_FILL_IO_EAST_6_140 VSSD ) ( IO_FILL_IO_EAST_6_0 VSSD )
-      ( IO_FILL_IO_EAST_5_140 VSSD ) ( IO_FILL_IO_EAST_5_0 VSSD ) ( IO_FILL_IO_EAST_4_145 VSSD ) ( IO_FILL_IO_EAST_4_0 VSSD ) ( IO_FILL_IO_EAST_3_140 VSSD ) ( IO_FILL_IO_EAST_3_0 VSSD ) ( IO_FILL_IO_EAST_2_145 VSSD ) ( IO_FILL_IO_EAST_21_0 VSSD )
-      ( IO_FILL_IO_EAST_20_150 VSSD ) ( IO_FILL_IO_EAST_20_140 VSSD ) ( IO_FILL_IO_EAST_19_0 VSSD ) ( IO_FILL_IO_EAST_18_150 VSSD ) ( IO_FILL_IO_EAST_18_140 VSSD ) ( IO_FILL_IO_EAST_17_0 VSSD ) ( IO_FILL_IO_EAST_16_140 VSSD ) ( IO_FILL_IO_EAST_16_0 VSSD )
-      ( IO_FILL_IO_EAST_15_140 VSSD ) ( IO_FILL_IO_EAST_15_0 VSSD ) ( IO_FILL_IO_EAST_14_145 VSSD ) ( IO_FILL_IO_EAST_2_0 VSSD ) ( IO_FILL_IO_EAST_1_220 VSSD ) ( IO_FILL_IO_EAST_1_200 VSSD ) ( IO_FILL_IO_NORTH_12_175 VSSD ) ( IO_FILL_IO_NORTH_12_170 VSSD )
-      ( IO_FILL_IO_NORTH_12_160 VSSD ) ( IO_FILL_IO_NORTH_12_140 VSSD ) ( IO_FILL_IO_NORTH_12_120 VSSD ) ( IO_FILL_IO_NORTH_12_100 VSSD ) ( IO_FILL_IO_NORTH_12_80 VSSD ) ( IO_FILL_IO_NORTH_12_60 VSSD ) ( IO_FILL_IO_NORTH_12_40 VSSD ) ( IO_FILL_IO_NORTH_12_20 VSSD )
-      ( IO_FILL_IO_NORTH_11_170 VSSD ) ( IO_FILL_IO_NORTH_11_160 VSSD ) ( IO_FILL_IO_NORTH_11_140 VSSD ) ( IO_FILL_IO_NORTH_11_120 VSSD ) ( IO_FILL_IO_NORTH_11_100 VSSD ) ( IO_FILL_IO_NORTH_11_80 VSSD ) ( IO_FILL_IO_NORTH_11_60 VSSD ) ( IO_FILL_IO_NORTH_11_40 VSSD )
-      ( IO_FILL_IO_NORTH_11_20 VSSD ) ( IO_FILL_IO_NORTH_10_170 VSSD ) ( IO_FILL_IO_NORTH_10_160 VSSD ) ( IO_FILL_IO_NORTH_10_140 VSSD ) ( IO_FILL_IO_NORTH_10_120 VSSD ) ( IO_FILL_IO_NORTH_10_100 VSSD ) ( IO_FILL_IO_NORTH_10_80 VSSD ) ( IO_FILL_IO_NORTH_10_60 VSSD )
-      ( IO_FILL_IO_NORTH_10_40 VSSD ) ( IO_FILL_IO_NORTH_10_20 VSSD ) ( IO_FILL_IO_NORTH_9_170 VSSD ) ( IO_FILL_IO_NORTH_9_160 VSSD ) ( IO_FILL_IO_NORTH_9_140 VSSD ) ( IO_FILL_IO_NORTH_9_120 VSSD ) ( IO_FILL_IO_NORTH_9_100 VSSD ) ( IO_FILL_IO_NORTH_9_80 VSSD )
-      ( IO_FILL_IO_NORTH_9_60 VSSD ) ( IO_FILL_IO_NORTH_9_40 VSSD ) ( IO_FILL_IO_NORTH_9_20 VSSD ) ( IO_FILL_IO_NORTH_8_170 VSSD ) ( IO_FILL_IO_NORTH_11_0 VSSD ) ( IO_FILL_IO_NORTH_10_175 VSSD ) ( IO_FILL_IO_NORTH_9_0 VSSD ) ( IO_FILL_IO_NORTH_8_175 VSSD )
-      ( IO_FILL_IO_NORTH_10_0 VSSD ) ( IO_FILL_IO_NORTH_9_175 VSSD ) ( IO_FILL_IO_NORTH_12_0 VSSD ) ( IO_FILL_IO_NORTH_11_175 VSSD ) ( user1_vssd_lvclmap_pad VSSD ) ( user1_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VSSD ) ( user1_vssa_hvclamp_pad\[0\] VSSD )
-      ( user1_vdda_hvclamp_pad\[1\] VSSD ) ( user1_vdda_hvclamp_pad\[0\] VSSD ) ( user1_vccd_lvclamp_pad VSSD ) ( user1_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user1_corner VSSD ) ( mprj_pads.area1_io_pad\[9\] VSSD ) ( mprj_pads.area1_io_pad\[8\] VSSD ) ( mprj_pads.area1_io_pad\[7\] VSSD )
-      ( mprj_pads.area1_io_pad\[6\] VSSD ) ( mprj_pads.area1_io_pad\[5\] VSSD ) ( mprj_pads.area1_io_pad\[4\] VSSD ) ( mprj_pads.area1_io_pad\[3\] VSSD ) ( mprj_pads.area1_io_pad\[2\] VSSD ) ( mprj_pads.area1_io_pad\[1\] VSSD ) ( mprj_pads.area1_io_pad\[17\] VSSD ) ( mprj_pads.area1_io_pad\[16\] VSSD )
-      ( mprj_pads.area1_io_pad\[15\] VSSD ) ( mprj_pads.area1_io_pad\[14\] VSSD ) ( mprj_pads.area1_io_pad\[13\] VSSD ) ( mprj_pads.area1_io_pad\[12\] VSSD ) ( mprj_pads.area1_io_pad\[11\] VSSD ) ( mprj_pads.area1_io_pad\[10\] VSSD ) ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE GROUND ;
-    - vssd2 ( PIN vssd2 ) ( IO_FILL_IO_WEST_3_0 VSSD ) ( IO_FILL_IO_WEST_3_20 VSSD ) ( IO_FILL_IO_WEST_3_40 VSSD ) ( IO_FILL_IO_WEST_3_60 VSSD ) ( IO_FILL_IO_WEST_3_80 VSSD ) ( IO_FILL_IO_WEST_3_100 VSSD )
-      ( IO_FILL_IO_WEST_3_120 VSSD ) ( IO_FILL_IO_NORTH_0_140 VSSD ) ( IO_FILL_IO_NORTH_0_120 VSSD ) ( IO_FILL_IO_NORTH_0_100 VSSD ) ( IO_FILL_IO_NORTH_0_80 VSSD ) ( IO_FILL_IO_NORTH_0_60 VSSD ) ( IO_FILL_IO_NORTH_0_40 VSSD ) ( IO_FILL_IO_NORTH_0_20 VSSD )
-      ( brk_vdda_1 VSSD ) ( IO_FILL_IO_NORTH_0_0 VSSD ) ( IO_CORNER_NORTH_WEST_INST VSSD ) ( IO_FILL_IO_WEST_22_130 VSSD ) ( IO_FILL_IO_WEST_22_120 VSSD ) ( IO_FILL_IO_WEST_22_100 VSSD ) ( IO_FILL_IO_WEST_22_80 VSSD ) ( IO_FILL_IO_WEST_22_60 VSSD )
-      ( IO_FILL_IO_WEST_22_40 VSSD ) ( IO_FILL_IO_WEST_22_20 VSSD ) ( IO_FILL_IO_WEST_21_130 VSSD ) ( IO_FILL_IO_WEST_21_120 VSSD ) ( IO_FILL_IO_WEST_21_100 VSSD ) ( IO_FILL_IO_WEST_21_80 VSSD ) ( IO_FILL_IO_WEST_21_60 VSSD ) ( IO_FILL_IO_WEST_21_40 VSSD )
-      ( IO_FILL_IO_WEST_21_20 VSSD ) ( IO_FILL_IO_WEST_20_130 VSSD ) ( IO_FILL_IO_WEST_20_120 VSSD ) ( IO_FILL_IO_WEST_20_100 VSSD ) ( IO_FILL_IO_WEST_20_80 VSSD ) ( IO_FILL_IO_WEST_20_60 VSSD ) ( IO_FILL_IO_WEST_20_40 VSSD ) ( IO_FILL_IO_WEST_20_20 VSSD )
-      ( IO_FILL_IO_WEST_19_130 VSSD ) ( IO_FILL_IO_WEST_19_120 VSSD ) ( IO_FILL_IO_WEST_19_100 VSSD ) ( IO_FILL_IO_WEST_19_80 VSSD ) ( IO_FILL_IO_WEST_19_60 VSSD ) ( IO_FILL_IO_WEST_19_40 VSSD ) ( IO_FILL_IO_WEST_19_20 VSSD ) ( IO_FILL_IO_WEST_18_130 VSSD )
-      ( IO_FILL_IO_WEST_18_120 VSSD ) ( IO_FILL_IO_WEST_18_100 VSSD ) ( IO_FILL_IO_WEST_18_80 VSSD ) ( IO_FILL_IO_WEST_18_60 VSSD ) ( IO_FILL_IO_WEST_18_40 VSSD ) ( IO_FILL_IO_WEST_18_20 VSSD ) ( IO_FILL_IO_WEST_17_130 VSSD ) ( IO_FILL_IO_WEST_17_120 VSSD )
-      ( IO_FILL_IO_WEST_17_100 VSSD ) ( IO_FILL_IO_WEST_17_80 VSSD ) ( IO_FILL_IO_WEST_17_60 VSSD ) ( IO_FILL_IO_WEST_17_40 VSSD ) ( IO_FILL_IO_WEST_17_20 VSSD ) ( IO_FILL_IO_WEST_16_130 VSSD ) ( IO_FILL_IO_WEST_16_120 VSSD ) ( IO_FILL_IO_WEST_16_100 VSSD )
-      ( IO_FILL_IO_WEST_16_80 VSSD ) ( IO_FILL_IO_WEST_16_60 VSSD ) ( IO_FILL_IO_WEST_16_40 VSSD ) ( IO_FILL_IO_WEST_16_20 VSSD ) ( IO_FILL_IO_WEST_15_130 VSSD ) ( IO_FILL_IO_WEST_15_120 VSSD ) ( IO_FILL_IO_WEST_15_100 VSSD ) ( IO_FILL_IO_WEST_15_80 VSSD )
-      ( IO_FILL_IO_WEST_15_60 VSSD ) ( IO_FILL_IO_WEST_15_40 VSSD ) ( IO_FILL_IO_WEST_15_20 VSSD ) ( IO_FILL_IO_WEST_14_130 VSSD ) ( IO_FILL_IO_WEST_14_120 VSSD ) ( IO_FILL_IO_WEST_14_100 VSSD ) ( IO_FILL_IO_WEST_14_80 VSSD ) ( IO_FILL_IO_WEST_14_60 VSSD )
-      ( IO_FILL_IO_WEST_14_40 VSSD ) ( IO_FILL_IO_WEST_14_20 VSSD ) ( IO_FILL_IO_WEST_13_130 VSSD ) ( IO_FILL_IO_WEST_13_120 VSSD ) ( IO_FILL_IO_WEST_13_100 VSSD ) ( IO_FILL_IO_WEST_13_80 VSSD ) ( IO_FILL_IO_WEST_13_60 VSSD ) ( IO_FILL_IO_WEST_13_40 VSSD )
-      ( IO_FILL_IO_WEST_13_20 VSSD ) ( IO_FILL_IO_WEST_12_130 VSSD ) ( IO_FILL_IO_WEST_12_120 VSSD ) ( IO_FILL_IO_WEST_12_100 VSSD ) ( IO_FILL_IO_WEST_12_80 VSSD ) ( IO_FILL_IO_WEST_12_60 VSSD ) ( IO_FILL_IO_WEST_12_40 VSSD ) ( IO_FILL_IO_WEST_12_20 VSSD )
-      ( IO_FILL_IO_WEST_11_130 VSSD ) ( IO_FILL_IO_WEST_11_120 VSSD ) ( IO_FILL_IO_WEST_11_100 VSSD ) ( IO_FILL_IO_WEST_11_80 VSSD ) ( IO_FILL_IO_WEST_11_60 VSSD ) ( IO_FILL_IO_WEST_11_40 VSSD ) ( IO_FILL_IO_WEST_11_20 VSSD ) ( IO_FILL_IO_WEST_10_130 VSSD )
-      ( IO_FILL_IO_WEST_10_120 VSSD ) ( IO_FILL_IO_WEST_10_100 VSSD ) ( IO_FILL_IO_WEST_10_80 VSSD ) ( IO_FILL_IO_WEST_10_60 VSSD ) ( IO_FILL_IO_WEST_10_40 VSSD ) ( IO_FILL_IO_WEST_10_20 VSSD ) ( IO_FILL_IO_WEST_9_130 VSSD ) ( IO_FILL_IO_WEST_9_120 VSSD )
-      ( IO_FILL_IO_WEST_9_100 VSSD ) ( IO_FILL_IO_WEST_9_80 VSSD ) ( IO_FILL_IO_WEST_9_60 VSSD ) ( IO_FILL_IO_WEST_9_40 VSSD ) ( IO_FILL_IO_WEST_9_20 VSSD ) ( IO_FILL_IO_WEST_8_130 VSSD ) ( IO_FILL_IO_WEST_8_120 VSSD ) ( IO_FILL_IO_WEST_8_100 VSSD )
-      ( IO_FILL_IO_WEST_8_80 VSSD ) ( IO_FILL_IO_WEST_8_60 VSSD ) ( IO_FILL_IO_WEST_8_40 VSSD ) ( IO_FILL_IO_WEST_8_20 VSSD ) ( IO_FILL_IO_WEST_7_130 VSSD ) ( IO_FILL_IO_WEST_7_120 VSSD ) ( IO_FILL_IO_WEST_7_100 VSSD ) ( IO_FILL_IO_WEST_7_80 VSSD )
-      ( IO_FILL_IO_WEST_7_60 VSSD ) ( IO_FILL_IO_WEST_7_40 VSSD ) ( IO_FILL_IO_WEST_7_20 VSSD ) ( IO_FILL_IO_WEST_6_130 VSSD ) ( IO_FILL_IO_WEST_6_120 VSSD ) ( IO_FILL_IO_WEST_6_100 VSSD ) ( IO_FILL_IO_WEST_6_80 VSSD ) ( IO_FILL_IO_WEST_6_60 VSSD )
-      ( IO_FILL_IO_WEST_6_40 VSSD ) ( IO_FILL_IO_WEST_6_20 VSSD ) ( IO_FILL_IO_WEST_5_130 VSSD ) ( IO_FILL_IO_WEST_5_120 VSSD ) ( IO_FILL_IO_WEST_5_100 VSSD ) ( IO_FILL_IO_WEST_5_80 VSSD ) ( IO_FILL_IO_WEST_5_60 VSSD ) ( IO_FILL_IO_WEST_5_40 VSSD )
-      ( IO_FILL_IO_WEST_5_20 VSSD ) ( IO_FILL_IO_WEST_4_130 VSSD ) ( IO_FILL_IO_WEST_4_120 VSSD ) ( IO_FILL_IO_WEST_4_100 VSSD ) ( IO_FILL_IO_WEST_4_80 VSSD ) ( IO_FILL_IO_WEST_4_60 VSSD ) ( IO_FILL_IO_WEST_4_40 VSSD ) ( IO_FILL_IO_WEST_4_20 VSSD )
-      ( IO_FILL_IO_WEST_3_130 VSSD ) ( IO_FILL_IO_WEST_10_0 VSSD ) ( IO_FILL_IO_WEST_9_135 VSSD ) ( IO_FILL_IO_WEST_19_0 VSSD ) ( IO_FILL_IO_WEST_18_135 VSSD ) ( IO_FILL_IO_WEST_11_0 VSSD ) ( IO_FILL_IO_WEST_10_135 VSSD ) ( IO_FILL_IO_WEST_21_0 VSSD )
-      ( IO_FILL_IO_WEST_20_135 VSSD ) ( IO_FILL_IO_WEST_16_0 VSSD ) ( IO_FILL_IO_WEST_15_135 VSSD ) ( IO_FILL_IO_WEST_17_0 VSSD ) ( IO_FILL_IO_WEST_16_135 VSSD ) ( IO_FILL_IO_WEST_18_0 VSSD ) ( IO_FILL_IO_WEST_17_135 VSSD ) ( IO_FILL_IO_WEST_22_0 VSSD )
-      ( IO_FILL_IO_WEST_21_135 VSSD ) ( IO_FILL_IO_WEST_4_0 VSSD ) ( IO_FILL_IO_WEST_3_135 VSSD ) ( IO_FILL_IO_WEST_5_0 VSSD ) ( IO_FILL_IO_WEST_4_135 VSSD ) ( IO_FILL_IO_WEST_6_0 VSSD ) ( IO_FILL_IO_WEST_5_135 VSSD ) ( IO_FILL_IO_WEST_7_0 VSSD )
-      ( IO_FILL_IO_WEST_6_135 VSSD ) ( IO_FILL_IO_WEST_8_0 VSSD ) ( IO_FILL_IO_WEST_7_135 VSSD ) ( IO_FILL_IO_WEST_9_0 VSSD ) ( IO_FILL_IO_WEST_8_135 VSSD ) ( IO_FILL_IO_WEST_12_0 VSSD ) ( IO_FILL_IO_WEST_11_135 VSSD ) ( IO_FILL_IO_WEST_13_0 VSSD )
-      ( IO_FILL_IO_WEST_12_135 VSSD ) ( IO_FILL_IO_WEST_14_0 VSSD ) ( IO_FILL_IO_WEST_13_135 VSSD ) ( IO_FILL_IO_WEST_15_0 VSSD ) ( IO_FILL_IO_WEST_14_135 VSSD ) ( IO_FILL_IO_WEST_20_0 VSSD ) ( IO_FILL_IO_WEST_19_135 VSSD ) ( IO_FILL_IO_NORTH_7_175 VSSD )
-      ( IO_FILL_IO_NORTH_7_170 VSSD ) ( IO_FILL_IO_NORTH_7_160 VSSD ) ( IO_FILL_IO_NORTH_7_140 VSSD ) ( IO_FILL_IO_NORTH_7_120 VSSD ) ( IO_FILL_IO_NORTH_7_100 VSSD ) ( IO_FILL_IO_NORTH_7_80 VSSD ) ( IO_FILL_IO_NORTH_7_60 VSSD ) ( IO_FILL_IO_NORTH_7_40 VSSD )
-      ( IO_FILL_IO_NORTH_7_20 VSSD ) ( IO_FILL_IO_NORTH_6_170 VSSD ) ( IO_FILL_IO_NORTH_6_160 VSSD ) ( IO_FILL_IO_NORTH_6_140 VSSD ) ( IO_FILL_IO_NORTH_6_120 VSSD ) ( IO_FILL_IO_NORTH_6_100 VSSD ) ( IO_FILL_IO_NORTH_6_80 VSSD ) ( IO_FILL_IO_NORTH_6_60 VSSD )
-      ( IO_FILL_IO_NORTH_6_40 VSSD ) ( IO_FILL_IO_NORTH_6_20 VSSD ) ( IO_FILL_IO_NORTH_5_170 VSSD ) ( IO_FILL_IO_NORTH_5_160 VSSD ) ( IO_FILL_IO_NORTH_5_140 VSSD ) ( IO_FILL_IO_NORTH_5_120 VSSD ) ( IO_FILL_IO_NORTH_5_100 VSSD ) ( IO_FILL_IO_NORTH_5_80 VSSD )
-      ( IO_FILL_IO_NORTH_5_60 VSSD ) ( IO_FILL_IO_NORTH_5_40 VSSD ) ( IO_FILL_IO_NORTH_5_20 VSSD ) ( IO_FILL_IO_NORTH_4_170 VSSD ) ( IO_FILL_IO_NORTH_4_160 VSSD ) ( IO_FILL_IO_NORTH_4_140 VSSD ) ( IO_FILL_IO_NORTH_4_120 VSSD ) ( IO_FILL_IO_NORTH_4_100 VSSD )
-      ( IO_FILL_IO_NORTH_4_80 VSSD ) ( IO_FILL_IO_NORTH_4_60 VSSD ) ( IO_FILL_IO_NORTH_4_40 VSSD ) ( IO_FILL_IO_NORTH_4_20 VSSD ) ( IO_FILL_IO_NORTH_3_170 VSSD ) ( IO_FILL_IO_NORTH_3_160 VSSD ) ( IO_FILL_IO_NORTH_3_140 VSSD ) ( IO_FILL_IO_NORTH_3_120 VSSD )
-      ( IO_FILL_IO_NORTH_3_100 VSSD ) ( IO_FILL_IO_NORTH_3_80 VSSD ) ( IO_FILL_IO_NORTH_3_60 VSSD ) ( IO_FILL_IO_NORTH_3_40 VSSD ) ( IO_FILL_IO_NORTH_3_20 VSSD ) ( IO_FILL_IO_NORTH_2_170 VSSD ) ( IO_FILL_IO_NORTH_2_160 VSSD ) ( IO_FILL_IO_NORTH_2_140 VSSD )
-      ( IO_FILL_IO_NORTH_2_120 VSSD ) ( IO_FILL_IO_NORTH_2_100 VSSD ) ( IO_FILL_IO_NORTH_2_80 VSSD ) ( IO_FILL_IO_NORTH_2_60 VSSD ) ( IO_FILL_IO_NORTH_2_40 VSSD ) ( IO_FILL_IO_NORTH_2_20 VSSD ) ( IO_FILL_IO_NORTH_1_170 VSSD ) ( IO_FILL_IO_NORTH_1_160 VSSD )
-      ( IO_FILL_IO_NORTH_1_140 VSSD ) ( IO_FILL_IO_NORTH_1_120 VSSD ) ( IO_FILL_IO_NORTH_1_100 VSSD ) ( IO_FILL_IO_NORTH_1_80 VSSD ) ( IO_FILL_IO_NORTH_1_60 VSSD ) ( IO_FILL_IO_NORTH_1_40 VSSD ) ( IO_FILL_IO_NORTH_1_20 VSSD ) ( IO_FILL_IO_NORTH_0_160 VSSD )
-      ( IO_FILL_IO_NORTH_1_0 VSSD ) ( IO_FILL_IO_NORTH_0_180 VSSD ) ( IO_FILL_IO_NORTH_2_0 VSSD ) ( IO_FILL_IO_NORTH_1_175 VSSD ) ( IO_FILL_IO_NORTH_3_0 VSSD ) ( IO_FILL_IO_NORTH_2_175 VSSD ) ( IO_FILL_IO_NORTH_4_0 VSSD ) ( IO_FILL_IO_NORTH_3_175 VSSD )
-      ( IO_FILL_IO_NORTH_5_0 VSSD ) ( IO_FILL_IO_NORTH_4_175 VSSD ) ( IO_FILL_IO_NORTH_7_0 VSSD ) ( IO_FILL_IO_NORTH_6_175 VSSD ) ( IO_FILL_IO_NORTH_6_0 VSSD ) ( IO_FILL_IO_NORTH_5_175 VSSD ) ( user2_vssd_lvclmap_pad VSSD ) ( user2_vssd_lvclmap_pad SRC_BDY_LVC1 )
-      ( user2_vssa_hvclamp_pad VSSD ) ( user2_vdda_hvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user2_corner VSSD ) ( mprj_pads.area2_io_pad\[9\] VSSD ) ( mprj_pads.area2_io_pad\[8\] VSSD ) ( mprj_pads.area2_io_pad\[7\] VSSD )
-      ( mprj_pads.area2_io_pad\[6\] VSSD ) ( mprj_pads.area2_io_pad\[5\] VSSD ) ( mprj_pads.area2_io_pad\[4\] VSSD ) ( mprj_pads.area2_io_pad\[3\] VSSD ) ( mprj_pads.area2_io_pad\[2\] VSSD ) ( mprj_pads.area2_io_pad\[1\] VSSD ) ( mprj_pads.area2_io_pad\[19\] VSSD ) ( mprj_pads.area2_io_pad\[18\] VSSD )
-      ( mprj_pads.area2_io_pad\[17\] VSSD ) ( mprj_pads.area2_io_pad\[16\] VSSD ) ( mprj_pads.area2_io_pad\[15\] VSSD ) ( mprj_pads.area2_io_pad\[14\] VSSD ) ( mprj_pads.area2_io_pad\[13\] VSSD ) ( mprj_pads.area2_io_pad\[12\] VSSD ) ( mprj_pads.area2_io_pad\[11\] VSSD ) ( mprj_pads.area2_io_pad\[10\] VSSD )
-      ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE GROUND ;
-    - vssio ( PIN vssio ) ( * VSSIO ) ( user2_vssd_lvclmap_pad BDY2_B2B ) ( user2_vccd_lvclamp_pad BDY2_B2B ) ( user1_vssd_lvclmap_pad BDY2_B2B ) ( user1_vccd_lvclamp_pad BDY2_B2B ) ( * PULLUP_H ) ( * INP_SEL_H ) ( * FILT_IN_H ) ( * EN_VDDIO_SIG_H ) ( * DISABLE_PULLUP_H ) ( mprj_pads.area2_io_pad\[9\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[8\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[7\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[6\] ENABLE_VSWITCH_H )
-      ( mprj_pads.area2_io_pad\[5\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[4\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[3\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[2\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[1\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[19\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[18\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[17\] ENABLE_VSWITCH_H )
-      ( mprj_pads.area2_io_pad\[16\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[15\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[14\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[13\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[12\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[11\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[0\] ENABLE_VSWITCH_H )
-      ( mprj_pads.area1_io_pad\[9\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[8\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[7\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[6\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[5\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[4\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[3\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[2\] ENABLE_VSWITCH_H )
-      ( mprj_pads.area1_io_pad\[1\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[17\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[16\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[15\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[14\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[13\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[12\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[11\] ENABLE_VSWITCH_H )
-      ( mprj_pads.area1_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[0\] ENABLE_VSWITCH_H ) ( mgmt_vssio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( mgmt_vddio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vccd_lvclamp_pad SRC_BDY_LVC1 ) + USE GROUND ;
 END SPECIALNETS
-NETS 715 ;
+NETS 733 ;
     - clock_core ( PIN clock_core ) ( clock_pad IN ) + USE SIGNAL ;
     - flash_clk_core ( PIN flash_clk_core ) ( flash_clk_pad OUT ) + USE SIGNAL ;
     - flash_clk_ieb_core ( PIN flash_clk_ieb_core ) ( flash_clk_pad INP_DIS ) + USE SIGNAL ;
@@ -4459,6 +3946,24 @@ NETS 715 ;
     - mprj_io_vtrip_sel[7] ( PIN mprj_io_vtrip_sel[7] ) ( mprj_pads.area1_io_pad\[7\] VTRIP_SEL ) + USE SIGNAL ;
     - mprj_io_vtrip_sel[8] ( PIN mprj_io_vtrip_sel[8] ) ( mprj_pads.area1_io_pad\[8\] VTRIP_SEL ) + USE SIGNAL ;
     - mprj_io_vtrip_sel[9] ( PIN mprj_io_vtrip_sel[9] ) ( mprj_pads.area1_io_pad\[9\] VTRIP_SEL ) + USE SIGNAL ;
+    - mprj_pads.analog_a ( user2_vssd_lvclmap_pad AMUXBUS_A ) ( user2_vssa_hvclamp_pad AMUXBUS_A ) ( user2_vdda_hvclamp_pad AMUXBUS_A ) ( user2_vccd_lvclamp_pad AMUXBUS_A ) ( user2_corner AMUXBUS_A ) ( user1_vssd_lvclmap_pad AMUXBUS_A ) ( user1_vssa_hvclamp_pad\[1\] AMUXBUS_A )
+      ( user1_vssa_hvclamp_pad\[0\] AMUXBUS_A ) ( user1_vdda_hvclamp_pad\[1\] AMUXBUS_A ) ( user1_vdda_hvclamp_pad\[0\] AMUXBUS_A ) ( user1_vccd_lvclamp_pad AMUXBUS_A ) ( user1_corner AMUXBUS_A ) ( resetb_pad AMUXBUS_A ) ( mprj_pads.area2_io_pad\[9\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[8\] AMUXBUS_A )
+      ( mprj_pads.area2_io_pad\[7\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[6\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[5\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[4\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[3\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[2\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[1\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[19\] AMUXBUS_A )
+      ( mprj_pads.area2_io_pad\[18\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[17\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[16\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[15\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[14\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[13\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[12\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[11\] AMUXBUS_A )
+      ( mprj_pads.area2_io_pad\[10\] AMUXBUS_A ) ( mprj_pads.area2_io_pad\[0\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[9\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[8\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[7\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[6\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[5\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[4\] AMUXBUS_A )
+      ( mprj_pads.area1_io_pad\[3\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[2\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[1\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[17\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[16\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[15\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[14\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[13\] AMUXBUS_A )
+      ( mprj_pads.area1_io_pad\[12\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[11\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[10\] AMUXBUS_A ) ( mprj_pads.area1_io_pad\[0\] AMUXBUS_A ) ( mgmt_vssio_hvclamp_pad\[1\] AMUXBUS_A ) ( mgmt_vssio_hvclamp_pad\[0\] AMUXBUS_A ) ( mgmt_vssd_lvclmap_pad AMUXBUS_A ) ( mgmt_vssa_hvclamp_pad AMUXBUS_A )
+      ( mgmt_vddio_hvclamp_pad\[1\] AMUXBUS_A ) ( mgmt_vddio_hvclamp_pad\[0\] AMUXBUS_A ) ( mgmt_vdda_hvclamp_pad AMUXBUS_A ) ( mgmt_vccd_lvclamp_pad AMUXBUS_A ) ( mgmt_corner\[1\] AMUXBUS_A ) ( mgmt_corner\[0\] AMUXBUS_A ) ( gpio_pad AMUXBUS_A ) ( flash_io1_pad AMUXBUS_A )
+      ( flash_io0_pad AMUXBUS_A ) ( flash_csb_pad AMUXBUS_A ) ( flash_clk_pad AMUXBUS_A ) ( clock_pad AMUXBUS_A ) + USE SIGNAL ;
+    - mprj_pads.analog_b ( user2_vssd_lvclmap_pad AMUXBUS_B ) ( user2_vssa_hvclamp_pad AMUXBUS_B ) ( user2_vdda_hvclamp_pad AMUXBUS_B ) ( user2_vccd_lvclamp_pad AMUXBUS_B ) ( user2_corner AMUXBUS_B ) ( user1_vssd_lvclmap_pad AMUXBUS_B ) ( user1_vssa_hvclamp_pad\[1\] AMUXBUS_B )
+      ( user1_vssa_hvclamp_pad\[0\] AMUXBUS_B ) ( user1_vdda_hvclamp_pad\[1\] AMUXBUS_B ) ( user1_vdda_hvclamp_pad\[0\] AMUXBUS_B ) ( user1_vccd_lvclamp_pad AMUXBUS_B ) ( user1_corner AMUXBUS_B ) ( resetb_pad AMUXBUS_B ) ( mprj_pads.area2_io_pad\[9\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[8\] AMUXBUS_B )
+      ( mprj_pads.area2_io_pad\[7\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[6\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[5\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[4\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[3\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[2\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[1\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[19\] AMUXBUS_B )
+      ( mprj_pads.area2_io_pad\[18\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[17\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[16\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[15\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[14\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[13\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[12\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[11\] AMUXBUS_B )
+      ( mprj_pads.area2_io_pad\[10\] AMUXBUS_B ) ( mprj_pads.area2_io_pad\[0\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[9\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[8\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[7\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[6\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[5\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[4\] AMUXBUS_B )
+      ( mprj_pads.area1_io_pad\[3\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[2\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[1\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[17\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[16\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[15\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[14\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[13\] AMUXBUS_B )
+      ( mprj_pads.area1_io_pad\[12\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[11\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[10\] AMUXBUS_B ) ( mprj_pads.area1_io_pad\[0\] AMUXBUS_B ) ( mgmt_vssio_hvclamp_pad\[1\] AMUXBUS_B ) ( mgmt_vssio_hvclamp_pad\[0\] AMUXBUS_B ) ( mgmt_vssd_lvclmap_pad AMUXBUS_B ) ( mgmt_vssa_hvclamp_pad AMUXBUS_B )
+      ( mgmt_vddio_hvclamp_pad\[1\] AMUXBUS_B ) ( mgmt_vddio_hvclamp_pad\[0\] AMUXBUS_B ) ( mgmt_vdda_hvclamp_pad AMUXBUS_B ) ( mgmt_vccd_lvclamp_pad AMUXBUS_B ) ( mgmt_corner\[1\] AMUXBUS_B ) ( mgmt_corner\[0\] AMUXBUS_B ) ( gpio_pad AMUXBUS_B ) ( flash_io1_pad AMUXBUS_B )
+      ( flash_io0_pad AMUXBUS_B ) ( flash_csb_pad AMUXBUS_B ) ( flash_clk_pad AMUXBUS_B ) ( clock_pad AMUXBUS_B ) + USE SIGNAL ;
     - mprj_pads.io_in\[0\] ( PIN mprj_io_in[0] ) ( mprj_pads.area1_io_pad\[0\] IN ) + USE SIGNAL ;
     - mprj_pads.io_in\[10\] ( PIN mprj_io_in[10] ) ( mprj_pads.area1_io_pad\[10\] IN ) + USE SIGNAL ;
     - mprj_pads.io_in\[11\] ( PIN mprj_io_in[11] ) ( mprj_pads.area1_io_pad\[11\] IN ) + USE SIGNAL ;
@@ -4542,6 +4047,24 @@ NETS 715 ;
     - mprj_pads.no_connect\[4\] ( mprj_pads.area1_io_pad\[4\] PAD_A_ESD_0_H ) + USE SIGNAL ;
     - mprj_pads.no_connect\[5\] ( mprj_pads.area1_io_pad\[5\] PAD_A_ESD_0_H ) + USE SIGNAL ;
     - mprj_pads.no_connect\[6\] ( mprj_pads.area1_io_pad\[6\] PAD_A_ESD_0_H ) + USE SIGNAL ;
+    - mprj_pads.vddio_q ( user2_vssd_lvclmap_pad VDDIO_Q ) ( user2_vssa_hvclamp_pad VDDIO_Q ) ( user2_vdda_hvclamp_pad VDDIO_Q ) ( user2_vccd_lvclamp_pad VDDIO_Q ) ( user2_corner VDDIO_Q ) ( user1_vssd_lvclmap_pad VDDIO_Q ) ( user1_vssa_hvclamp_pad\[1\] VDDIO_Q )
+      ( user1_vssa_hvclamp_pad\[0\] VDDIO_Q ) ( user1_vdda_hvclamp_pad\[1\] VDDIO_Q ) ( user1_vdda_hvclamp_pad\[0\] VDDIO_Q ) ( user1_vccd_lvclamp_pad VDDIO_Q ) ( user1_corner VDDIO_Q ) ( resetb_pad VDDIO_Q ) ( mprj_pads.area2_io_pad\[9\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[8\] VDDIO_Q )
+      ( mprj_pads.area2_io_pad\[7\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[6\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[5\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[4\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[3\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[2\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[1\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[19\] VDDIO_Q )
+      ( mprj_pads.area2_io_pad\[18\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[17\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[16\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[15\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[14\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[13\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[12\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[11\] VDDIO_Q )
+      ( mprj_pads.area2_io_pad\[10\] VDDIO_Q ) ( mprj_pads.area2_io_pad\[0\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[9\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[8\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[7\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[6\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[5\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[4\] VDDIO_Q )
+      ( mprj_pads.area1_io_pad\[3\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[2\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[1\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[17\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[16\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[15\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[14\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[13\] VDDIO_Q )
+      ( mprj_pads.area1_io_pad\[12\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[11\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[10\] VDDIO_Q ) ( mprj_pads.area1_io_pad\[0\] VDDIO_Q ) ( mgmt_vssio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vssd_lvclmap_pad VDDIO_Q ) ( mgmt_vssa_hvclamp_pad VDDIO_Q )
+      ( mgmt_vddio_hvclamp_pad\[1\] VDDIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VDDIO_Q ) ( mgmt_vdda_hvclamp_pad VDDIO_Q ) ( mgmt_vccd_lvclamp_pad VDDIO_Q ) ( mgmt_corner\[1\] VDDIO_Q ) ( mgmt_corner\[0\] VDDIO_Q ) ( gpio_pad VDDIO_Q ) ( flash_io1_pad VDDIO_Q )
+      ( flash_io0_pad VDDIO_Q ) ( flash_csb_pad VDDIO_Q ) ( flash_clk_pad VDDIO_Q ) ( clock_pad VDDIO_Q ) + USE SIGNAL ;
+    - mprj_pads.vssio_q ( user2_vssd_lvclmap_pad VSSIO_Q ) ( user2_vssa_hvclamp_pad VSSIO_Q ) ( user2_vdda_hvclamp_pad VSSIO_Q ) ( user2_vccd_lvclamp_pad VSSIO_Q ) ( user2_corner VSSIO_Q ) ( user1_vssd_lvclmap_pad VSSIO_Q ) ( user1_vssa_hvclamp_pad\[1\] VSSIO_Q )
+      ( user1_vssa_hvclamp_pad\[0\] VSSIO_Q ) ( user1_vdda_hvclamp_pad\[1\] VSSIO_Q ) ( user1_vdda_hvclamp_pad\[0\] VSSIO_Q ) ( user1_vccd_lvclamp_pad VSSIO_Q ) ( user1_corner VSSIO_Q ) ( resetb_pad VSSIO_Q ) ( mprj_pads.area2_io_pad\[9\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[8\] VSSIO_Q )
+      ( mprj_pads.area2_io_pad\[7\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[6\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[5\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[4\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[3\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[2\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[1\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[19\] VSSIO_Q )
+      ( mprj_pads.area2_io_pad\[18\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[17\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[16\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[15\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[14\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[13\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[12\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[11\] VSSIO_Q )
+      ( mprj_pads.area2_io_pad\[10\] VSSIO_Q ) ( mprj_pads.area2_io_pad\[0\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[9\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[8\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[7\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[6\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[5\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[4\] VSSIO_Q )
+      ( mprj_pads.area1_io_pad\[3\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[2\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[1\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[17\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[16\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[15\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[14\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[13\] VSSIO_Q )
+      ( mprj_pads.area1_io_pad\[12\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[11\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[10\] VSSIO_Q ) ( mprj_pads.area1_io_pad\[0\] VSSIO_Q ) ( mgmt_vssio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vssd_lvclmap_pad VSSIO_Q ) ( mgmt_vssa_hvclamp_pad VSSIO_Q )
+      ( mgmt_vddio_hvclamp_pad\[1\] VSSIO_Q ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO_Q ) ( mgmt_vdda_hvclamp_pad VSSIO_Q ) ( mgmt_vccd_lvclamp_pad VSSIO_Q ) ( mgmt_corner\[1\] VSSIO_Q ) ( mgmt_corner\[0\] VSSIO_Q ) ( gpio_pad VSSIO_Q ) ( flash_io1_pad VSSIO_Q )
+      ( flash_io0_pad VSSIO_Q ) ( flash_csb_pad VSSIO_Q ) ( flash_clk_pad VSSIO_Q ) ( clock_pad VSSIO_Q ) + USE SIGNAL ;
     - por ( PIN por ) ( clock_pad INP_DIS ) + USE SIGNAL ;
     - porb_h ( PIN porb_h ) ( resetb_pad ENABLE_H ) ( mprj_pads.area2_io_pad\[9\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[8\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[7\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[6\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[5\] ENABLE_VDDA_H )
       ( mprj_pads.area2_io_pad\[4\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[3\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[2\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[1\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[19\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[18\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[17\] ENABLE_VDDA_H ) ( mprj_pads.area2_io_pad\[16\] ENABLE_VDDA_H )
@@ -4551,6 +4074,108 @@ NETS 715 ;
       ( mprj_pads.area1_io_pad\[0\] ENABLE_VDDA_H ) ( gpio_pad ENABLE_VDDA_H ) ( gpio_pad ENABLE_H ) ( flash_io1_pad ENABLE_VDDA_H ) ( flash_io1_pad ENABLE_H ) ( flash_io0_pad ENABLE_VDDA_H ) ( flash_io0_pad ENABLE_H ) ( flash_csb_pad ENABLE_VDDA_H )
       ( flash_csb_pad ENABLE_H ) ( flash_clk_pad ENABLE_VDDA_H ) ( flash_clk_pad ENABLE_H ) ( clock_pad ENABLE_VDDA_H ) ( clock_pad ENABLE_H ) + USE SIGNAL ;
     - resetb_core_h ( PIN resetb_core_h ) ( resetb_pad XRES_H_N ) + USE SIGNAL ;
+    - vccd ( PIN vccd ) ( user2_vssd_lvclmap_pad VCCHIB ) ( user2_vssa_hvclamp_pad VCCHIB ) ( user2_vdda_hvclamp_pad VCCHIB ) ( user2_vccd_lvclamp_pad VCCHIB ) ( user2_corner VCCHIB ) ( user1_vssd_lvclmap_pad VCCHIB )
+      ( user1_vssa_hvclamp_pad\[1\] VCCHIB ) ( user1_vssa_hvclamp_pad\[0\] VCCHIB ) ( user1_vdda_hvclamp_pad\[1\] VCCHIB ) ( user1_vdda_hvclamp_pad\[0\] VCCHIB ) ( user1_vccd_lvclamp_pad VCCHIB ) ( user1_corner VCCHIB ) ( resetb_pad VCCHIB ) ( resetb_pad VCCD )
+      ( resetb_pad ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[9\] VCCHIB ) ( mprj_pads.area2_io_pad\[9\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[8\] VCCHIB ) ( mprj_pads.area2_io_pad\[8\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[7\] VCCHIB ) ( mprj_pads.area2_io_pad\[7\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[6\] VCCHIB )
+      ( mprj_pads.area2_io_pad\[6\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[5\] VCCHIB ) ( mprj_pads.area2_io_pad\[5\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[4\] VCCHIB ) ( mprj_pads.area2_io_pad\[4\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[3\] VCCHIB ) ( mprj_pads.area2_io_pad\[3\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[2\] VCCHIB )
+      ( mprj_pads.area2_io_pad\[2\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[1\] VCCHIB ) ( mprj_pads.area2_io_pad\[1\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[19\] VCCHIB ) ( mprj_pads.area2_io_pad\[19\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[18\] VCCHIB ) ( mprj_pads.area2_io_pad\[18\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[17\] VCCHIB )
+      ( mprj_pads.area2_io_pad\[17\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[16\] VCCHIB ) ( mprj_pads.area2_io_pad\[16\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[15\] VCCHIB ) ( mprj_pads.area2_io_pad\[15\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[14\] VCCHIB ) ( mprj_pads.area2_io_pad\[14\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[13\] VCCHIB )
+      ( mprj_pads.area2_io_pad\[13\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[12\] VCCHIB ) ( mprj_pads.area2_io_pad\[12\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[11\] VCCHIB ) ( mprj_pads.area2_io_pad\[11\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[10\] VCCHIB ) ( mprj_pads.area2_io_pad\[10\] ENABLE_VDDIO ) ( mprj_pads.area2_io_pad\[0\] VCCHIB )
+      ( mprj_pads.area2_io_pad\[0\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[9\] VCCHIB ) ( mprj_pads.area1_io_pad\[9\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[8\] VCCHIB ) ( mprj_pads.area1_io_pad\[8\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[7\] VCCHIB ) ( mprj_pads.area1_io_pad\[7\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[6\] VCCHIB )
+      ( mprj_pads.area1_io_pad\[6\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[5\] VCCHIB ) ( mprj_pads.area1_io_pad\[5\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[4\] VCCHIB ) ( mprj_pads.area1_io_pad\[4\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[3\] VCCHIB ) ( mprj_pads.area1_io_pad\[3\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[2\] VCCHIB )
+      ( mprj_pads.area1_io_pad\[2\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[1\] VCCHIB ) ( mprj_pads.area1_io_pad\[1\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[17\] VCCHIB ) ( mprj_pads.area1_io_pad\[17\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[16\] VCCHIB ) ( mprj_pads.area1_io_pad\[16\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[15\] VCCHIB )
+      ( mprj_pads.area1_io_pad\[15\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[14\] VCCHIB ) ( mprj_pads.area1_io_pad\[14\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[13\] VCCHIB ) ( mprj_pads.area1_io_pad\[13\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[12\] VCCHIB ) ( mprj_pads.area1_io_pad\[12\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[11\] VCCHIB )
+      ( mprj_pads.area1_io_pad\[11\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[10\] VCCHIB ) ( mprj_pads.area1_io_pad\[10\] ENABLE_VDDIO ) ( mprj_pads.area1_io_pad\[0\] VCCHIB ) ( mprj_pads.area1_io_pad\[0\] ENABLE_VDDIO ) ( mgmt_vssio_hvclamp_pad\[1\] VCCHIB ) ( mgmt_vssio_hvclamp_pad\[0\] VCCHIB ) ( mgmt_vssio_hvclamp_pad\[0\] VCCD )
+      ( mgmt_vssd_lvclmap_pad VCCHIB ) ( mgmt_vssd_lvclmap_pad VCCD ) ( mgmt_vssd_lvclmap_pad DRN_LVC2 ) ( mgmt_vssd_lvclmap_pad DRN_LVC1 ) ( mgmt_vssa_hvclamp_pad VCCHIB ) ( mgmt_vssa_hvclamp_pad VCCD ) ( mgmt_vddio_hvclamp_pad\[1\] VCCHIB ) ( mgmt_vddio_hvclamp_pad\[0\] VCCHIB )
+      ( mgmt_vddio_hvclamp_pad\[0\] VCCD ) ( mgmt_vdda_hvclamp_pad VCCHIB ) ( mgmt_vdda_hvclamp_pad VCCD ) ( mgmt_vccd_lvclamp_pad VCCHIB ) ( mgmt_vccd_lvclamp_pad VCCD ) ( mgmt_vccd_lvclamp_pad DRN_LVC2 ) ( mgmt_vccd_lvclamp_pad DRN_LVC1 ) ( mgmt_corner\[1\] VCCHIB )
+      ( mgmt_corner\[1\] VCCD ) ( mgmt_corner\[0\] VCCHIB ) ( mgmt_corner\[0\] VCCD ) ( gpio_pad VCCHIB ) ( gpio_pad VCCD ) ( gpio_pad ENABLE_VDDIO ) ( flash_io1_pad VCCHIB ) ( flash_io1_pad VCCD )
+      ( flash_io1_pad ENABLE_VDDIO ) ( flash_io0_pad VCCHIB ) ( flash_io0_pad VCCD ) ( flash_io0_pad ENABLE_VDDIO ) ( flash_csb_pad VCCHIB ) ( flash_csb_pad VCCD ) ( flash_csb_pad ENABLE_VDDIO ) ( flash_csb_pad DM[2] )
+      ( flash_csb_pad DM[1] ) ( flash_clk_pad VCCHIB ) ( flash_clk_pad VCCD ) ( flash_clk_pad ENABLE_VDDIO ) ( flash_clk_pad DM[2] ) ( flash_clk_pad DM[1] ) ( clock_pad VCCHIB ) ( clock_pad VCCD )
+      ( clock_pad OE_N ) ( clock_pad ENABLE_VDDIO ) ( clock_pad DM[0] ) + USE SIGNAL ;
+    - vccd1 ( PIN vccd1 ) ( user1_vssd_lvclmap_pad VCCD ) ( user1_vssd_lvclmap_pad DRN_LVC2 ) ( user1_vssd_lvclmap_pad DRN_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VCCD ) ( user1_vssa_hvclamp_pad\[0\] VCCD ) ( user1_vdda_hvclamp_pad\[1\] VCCD )
+      ( user1_vdda_hvclamp_pad\[0\] VCCD ) ( user1_vccd_lvclamp_pad VCCD ) ( user1_vccd_lvclamp_pad DRN_LVC2 ) ( user1_vccd_lvclamp_pad DRN_LVC1 ) ( user1_corner VCCD ) ( mprj_pads.area1_io_pad\[9\] VCCD ) ( mprj_pads.area1_io_pad\[8\] VCCD ) ( mprj_pads.area1_io_pad\[7\] VCCD )
+      ( mprj_pads.area1_io_pad\[6\] VCCD ) ( mprj_pads.area1_io_pad\[5\] VCCD ) ( mprj_pads.area1_io_pad\[4\] VCCD ) ( mprj_pads.area1_io_pad\[3\] VCCD ) ( mprj_pads.area1_io_pad\[2\] VCCD ) ( mprj_pads.area1_io_pad\[1\] VCCD ) ( mprj_pads.area1_io_pad\[17\] VCCD ) ( mprj_pads.area1_io_pad\[16\] VCCD )
+      ( mprj_pads.area1_io_pad\[15\] VCCD ) ( mprj_pads.area1_io_pad\[14\] VCCD ) ( mprj_pads.area1_io_pad\[13\] VCCD ) ( mprj_pads.area1_io_pad\[12\] VCCD ) ( mprj_pads.area1_io_pad\[11\] VCCD ) ( mprj_pads.area1_io_pad\[10\] VCCD ) ( mprj_pads.area1_io_pad\[0\] VCCD ) + USE SIGNAL ;
+    - vccd2 ( PIN vccd2 ) ( user2_vssd_lvclmap_pad VCCD ) ( user2_vssd_lvclmap_pad DRN_LVC2 ) ( user2_vssd_lvclmap_pad DRN_LVC1 ) ( user2_vssa_hvclamp_pad VCCD ) ( user2_vdda_hvclamp_pad VCCD ) ( user2_vccd_lvclamp_pad VCCD )
+      ( user2_vccd_lvclamp_pad DRN_LVC2 ) ( user2_vccd_lvclamp_pad DRN_LVC1 ) ( user2_corner VCCD ) ( mprj_pads.area2_io_pad\[9\] VCCD ) ( mprj_pads.area2_io_pad\[8\] VCCD ) ( mprj_pads.area2_io_pad\[7\] VCCD ) ( mprj_pads.area2_io_pad\[6\] VCCD ) ( mprj_pads.area2_io_pad\[5\] VCCD )
+      ( mprj_pads.area2_io_pad\[4\] VCCD ) ( mprj_pads.area2_io_pad\[3\] VCCD ) ( mprj_pads.area2_io_pad\[2\] VCCD ) ( mprj_pads.area2_io_pad\[1\] VCCD ) ( mprj_pads.area2_io_pad\[19\] VCCD ) ( mprj_pads.area2_io_pad\[18\] VCCD ) ( mprj_pads.area2_io_pad\[17\] VCCD ) ( mprj_pads.area2_io_pad\[16\] VCCD )
+      ( mprj_pads.area2_io_pad\[15\] VCCD ) ( mprj_pads.area2_io_pad\[14\] VCCD ) ( mprj_pads.area2_io_pad\[13\] VCCD ) ( mprj_pads.area2_io_pad\[12\] VCCD ) ( mprj_pads.area2_io_pad\[11\] VCCD ) ( mprj_pads.area2_io_pad\[10\] VCCD ) ( mprj_pads.area2_io_pad\[0\] VCCD ) ( mgmt_vssio_hvclamp_pad\[1\] VCCD )
+      ( mgmt_vddio_hvclamp_pad\[1\] VCCD ) + USE SIGNAL ;
+    - vdda ( PIN vdda ) ( resetb_pad VDDA ) ( mgmt_vssio_hvclamp_pad\[0\] VDDA ) ( mgmt_vssd_lvclmap_pad VDDA ) ( mgmt_vssa_hvclamp_pad VDDA ) ( mgmt_vssa_hvclamp_pad DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VDDA )
+      ( mgmt_vdda_hvclamp_pad VDDA ) ( mgmt_vdda_hvclamp_pad DRN_HVC ) ( mgmt_vccd_lvclamp_pad VDDA ) ( mgmt_corner\[1\] VDDA ) ( mgmt_corner\[0\] VDDA ) ( gpio_pad VDDA ) ( flash_io1_pad VDDA ) ( flash_io0_pad VDDA )
+      ( flash_csb_pad VDDA ) ( flash_clk_pad VDDA ) ( clock_pad VDDA ) + USE SIGNAL ;
+    - vdda1 ( PIN vdda1 ) ( user1_vssd_lvclmap_pad VDDA ) ( user1_vssa_hvclamp_pad\[1\] VDDA ) ( user1_vssa_hvclamp_pad\[1\] DRN_HVC ) ( user1_vssa_hvclamp_pad\[0\] VDDA ) ( user1_vssa_hvclamp_pad\[0\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[1\] VDDA )
+      ( user1_vdda_hvclamp_pad\[1\] DRN_HVC ) ( user1_vdda_hvclamp_pad\[0\] VDDA ) ( user1_vdda_hvclamp_pad\[0\] DRN_HVC ) ( user1_vccd_lvclamp_pad VDDA ) ( user1_corner VDDA ) ( mprj_pads.area1_io_pad\[9\] VDDA ) ( mprj_pads.area1_io_pad\[8\] VDDA ) ( mprj_pads.area1_io_pad\[7\] VDDA )
+      ( mprj_pads.area1_io_pad\[6\] VDDA ) ( mprj_pads.area1_io_pad\[5\] VDDA ) ( mprj_pads.area1_io_pad\[4\] VDDA ) ( mprj_pads.area1_io_pad\[3\] VDDA ) ( mprj_pads.area1_io_pad\[2\] VDDA ) ( mprj_pads.area1_io_pad\[1\] VDDA ) ( mprj_pads.area1_io_pad\[17\] VDDA ) ( mprj_pads.area1_io_pad\[16\] VDDA )
+      ( mprj_pads.area1_io_pad\[15\] VDDA ) ( mprj_pads.area1_io_pad\[14\] VDDA ) ( mprj_pads.area1_io_pad\[13\] VDDA ) ( mprj_pads.area1_io_pad\[12\] VDDA ) ( mprj_pads.area1_io_pad\[11\] VDDA ) ( mprj_pads.area1_io_pad\[10\] VDDA ) ( mprj_pads.area1_io_pad\[0\] VDDA ) + USE SIGNAL ;
+    - vdda2 ( PIN vdda2 ) ( user2_vssd_lvclmap_pad VDDA ) ( user2_vssa_hvclamp_pad VDDA ) ( user2_vssa_hvclamp_pad DRN_HVC ) ( user2_vdda_hvclamp_pad VDDA ) ( user2_vdda_hvclamp_pad DRN_HVC ) ( user2_vccd_lvclamp_pad VDDA )
+      ( user2_corner VDDA ) ( mprj_pads.area2_io_pad\[9\] VDDA ) ( mprj_pads.area2_io_pad\[8\] VDDA ) ( mprj_pads.area2_io_pad\[7\] VDDA ) ( mprj_pads.area2_io_pad\[6\] VDDA ) ( mprj_pads.area2_io_pad\[5\] VDDA ) ( mprj_pads.area2_io_pad\[4\] VDDA ) ( mprj_pads.area2_io_pad\[3\] VDDA )
+      ( mprj_pads.area2_io_pad\[2\] VDDA ) ( mprj_pads.area2_io_pad\[1\] VDDA ) ( mprj_pads.area2_io_pad\[19\] VDDA ) ( mprj_pads.area2_io_pad\[18\] VDDA ) ( mprj_pads.area2_io_pad\[17\] VDDA ) ( mprj_pads.area2_io_pad\[16\] VDDA ) ( mprj_pads.area2_io_pad\[15\] VDDA ) ( mprj_pads.area2_io_pad\[14\] VDDA )
+      ( mprj_pads.area2_io_pad\[13\] VDDA ) ( mprj_pads.area2_io_pad\[12\] VDDA ) ( mprj_pads.area2_io_pad\[11\] VDDA ) ( mprj_pads.area2_io_pad\[10\] VDDA ) ( mprj_pads.area2_io_pad\[0\] VDDA ) ( mgmt_vssio_hvclamp_pad\[1\] VDDA ) ( mgmt_vddio_hvclamp_pad\[1\] VDDA ) + USE SIGNAL ;
+    - vddio ( PIN vddio ) ( user2_vssd_lvclmap_pad VSWITCH ) ( user2_vssd_lvclmap_pad VDDIO ) ( user2_vssa_hvclamp_pad VSWITCH ) ( user2_vssa_hvclamp_pad VDDIO ) ( user2_vdda_hvclamp_pad VSWITCH ) ( user2_vdda_hvclamp_pad VDDIO )
+      ( user2_vccd_lvclamp_pad VSWITCH ) ( user2_vccd_lvclamp_pad VDDIO ) ( user2_corner VSWITCH ) ( user2_corner VDDIO ) ( user1_vssd_lvclmap_pad VSWITCH ) ( user1_vssd_lvclmap_pad VDDIO ) ( user1_vssa_hvclamp_pad\[1\] VSWITCH ) ( user1_vssa_hvclamp_pad\[1\] VDDIO )
+      ( user1_vssa_hvclamp_pad\[0\] VSWITCH ) ( user1_vssa_hvclamp_pad\[0\] VDDIO ) ( user1_vdda_hvclamp_pad\[1\] VSWITCH ) ( user1_vdda_hvclamp_pad\[1\] VDDIO ) ( user1_vdda_hvclamp_pad\[0\] VSWITCH ) ( user1_vdda_hvclamp_pad\[0\] VDDIO ) ( user1_vccd_lvclamp_pad VSWITCH ) ( user1_vccd_lvclamp_pad VDDIO )
+      ( user1_corner VSWITCH ) ( user1_corner VDDIO ) ( resetb_pad VSWITCH ) ( resetb_pad VDDIO ) ( mprj_pads.area2_io_pad\[9\] VSWITCH ) ( mprj_pads.area2_io_pad\[9\] VDDIO ) ( mprj_pads.area2_io_pad\[8\] VSWITCH ) ( mprj_pads.area2_io_pad\[8\] VDDIO )
+      ( mprj_pads.area2_io_pad\[7\] VSWITCH ) ( mprj_pads.area2_io_pad\[7\] VDDIO ) ( mprj_pads.area2_io_pad\[6\] VSWITCH ) ( mprj_pads.area2_io_pad\[6\] VDDIO ) ( mprj_pads.area2_io_pad\[5\] VSWITCH ) ( mprj_pads.area2_io_pad\[5\] VDDIO ) ( mprj_pads.area2_io_pad\[4\] VSWITCH ) ( mprj_pads.area2_io_pad\[4\] VDDIO )
+      ( mprj_pads.area2_io_pad\[3\] VSWITCH ) ( mprj_pads.area2_io_pad\[3\] VDDIO ) ( mprj_pads.area2_io_pad\[2\] VSWITCH ) ( mprj_pads.area2_io_pad\[2\] VDDIO ) ( mprj_pads.area2_io_pad\[1\] VSWITCH ) ( mprj_pads.area2_io_pad\[1\] VDDIO ) ( mprj_pads.area2_io_pad\[19\] VSWITCH ) ( mprj_pads.area2_io_pad\[19\] VDDIO )
+      ( mprj_pads.area2_io_pad\[18\] VSWITCH ) ( mprj_pads.area2_io_pad\[18\] VDDIO ) ( mprj_pads.area2_io_pad\[17\] VSWITCH ) ( mprj_pads.area2_io_pad\[17\] VDDIO ) ( mprj_pads.area2_io_pad\[16\] VSWITCH ) ( mprj_pads.area2_io_pad\[16\] VDDIO ) ( mprj_pads.area2_io_pad\[15\] VSWITCH ) ( mprj_pads.area2_io_pad\[15\] VDDIO )
+      ( mprj_pads.area2_io_pad\[14\] VSWITCH ) ( mprj_pads.area2_io_pad\[14\] VDDIO ) ( mprj_pads.area2_io_pad\[13\] VSWITCH ) ( mprj_pads.area2_io_pad\[13\] VDDIO ) ( mprj_pads.area2_io_pad\[12\] VSWITCH ) ( mprj_pads.area2_io_pad\[12\] VDDIO ) ( mprj_pads.area2_io_pad\[11\] VSWITCH ) ( mprj_pads.area2_io_pad\[11\] VDDIO )
+      ( mprj_pads.area2_io_pad\[10\] VSWITCH ) ( mprj_pads.area2_io_pad\[10\] VDDIO ) ( mprj_pads.area2_io_pad\[0\] VSWITCH ) ( mprj_pads.area2_io_pad\[0\] VDDIO ) ( mprj_pads.area1_io_pad\[9\] VSWITCH ) ( mprj_pads.area1_io_pad\[9\] VDDIO ) ( mprj_pads.area1_io_pad\[8\] VSWITCH ) ( mprj_pads.area1_io_pad\[8\] VDDIO )
+      ( mprj_pads.area1_io_pad\[7\] VSWITCH ) ( mprj_pads.area1_io_pad\[7\] VDDIO ) ( mprj_pads.area1_io_pad\[6\] VSWITCH ) ( mprj_pads.area1_io_pad\[6\] VDDIO ) ( mprj_pads.area1_io_pad\[5\] VSWITCH ) ( mprj_pads.area1_io_pad\[5\] VDDIO ) ( mprj_pads.area1_io_pad\[4\] VSWITCH ) ( mprj_pads.area1_io_pad\[4\] VDDIO )
+      ( mprj_pads.area1_io_pad\[3\] VSWITCH ) ( mprj_pads.area1_io_pad\[3\] VDDIO ) ( mprj_pads.area1_io_pad\[2\] VSWITCH ) ( mprj_pads.area1_io_pad\[2\] VDDIO ) ( mprj_pads.area1_io_pad\[1\] VSWITCH ) ( mprj_pads.area1_io_pad\[1\] VDDIO ) ( mprj_pads.area1_io_pad\[17\] VSWITCH ) ( mprj_pads.area1_io_pad\[17\] VDDIO )
+      ( mprj_pads.area1_io_pad\[16\] VSWITCH ) ( mprj_pads.area1_io_pad\[16\] VDDIO ) ( mprj_pads.area1_io_pad\[15\] VSWITCH ) ( mprj_pads.area1_io_pad\[15\] VDDIO ) ( mprj_pads.area1_io_pad\[14\] VSWITCH ) ( mprj_pads.area1_io_pad\[14\] VDDIO ) ( mprj_pads.area1_io_pad\[13\] VSWITCH ) ( mprj_pads.area1_io_pad\[13\] VDDIO )
+      ( mprj_pads.area1_io_pad\[12\] VSWITCH ) ( mprj_pads.area1_io_pad\[12\] VDDIO ) ( mprj_pads.area1_io_pad\[11\] VSWITCH ) ( mprj_pads.area1_io_pad\[11\] VDDIO ) ( mprj_pads.area1_io_pad\[10\] VSWITCH ) ( mprj_pads.area1_io_pad\[10\] VDDIO ) ( mprj_pads.area1_io_pad\[0\] VSWITCH ) ( mprj_pads.area1_io_pad\[0\] VDDIO )
+      ( mgmt_vssio_hvclamp_pad\[1\] VSWITCH ) ( mgmt_vssio_hvclamp_pad\[1\] VDDIO ) ( mgmt_vssio_hvclamp_pad\[1\] DRN_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] VSWITCH ) ( mgmt_vssio_hvclamp_pad\[0\] VDDIO ) ( mgmt_vssio_hvclamp_pad\[0\] DRN_HVC ) ( mgmt_vssd_lvclmap_pad VSWITCH ) ( mgmt_vssd_lvclmap_pad VDDIO )
+      ( mgmt_vssa_hvclamp_pad VSWITCH ) ( mgmt_vssa_hvclamp_pad VDDIO ) ( mgmt_vddio_hvclamp_pad\[1\] VSWITCH ) ( mgmt_vddio_hvclamp_pad\[1\] VDDIO ) ( mgmt_vddio_hvclamp_pad\[1\] DRN_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSWITCH ) ( mgmt_vddio_hvclamp_pad\[0\] VDDIO ) ( mgmt_vddio_hvclamp_pad\[0\] DRN_HVC )
+      ( mgmt_vdda_hvclamp_pad VSWITCH ) ( mgmt_vdda_hvclamp_pad VDDIO ) ( mgmt_vccd_lvclamp_pad VSWITCH ) ( mgmt_vccd_lvclamp_pad VDDIO ) ( mgmt_corner\[1\] VSWITCH ) ( mgmt_corner\[1\] VDDIO ) ( mgmt_corner\[0\] VSWITCH ) ( mgmt_corner\[0\] VDDIO )
+      ( gpio_pad VSWITCH ) ( gpio_pad VDDIO ) ( gpio_pad HLD_H_N ) ( flash_io1_pad VSWITCH ) ( flash_io1_pad VDDIO ) ( flash_io1_pad HLD_H_N ) ( flash_io0_pad VSWITCH ) ( flash_io0_pad VDDIO )
+      ( flash_io0_pad HLD_H_N ) ( flash_csb_pad VSWITCH ) ( flash_csb_pad VDDIO ) ( flash_csb_pad HLD_H_N ) ( flash_clk_pad VSWITCH ) ( flash_clk_pad VDDIO ) ( flash_clk_pad HLD_H_N ) ( clock_pad VSWITCH )
+      ( clock_pad VDDIO ) ( clock_pad HLD_H_N ) + USE SIGNAL ;
+    - vssa ( PIN vssa ) ( resetb_pad VSSA ) ( mgmt_vssio_hvclamp_pad\[0\] VSSA ) ( mgmt_vssd_lvclmap_pad VSSA ) ( mgmt_vssd_lvclmap_pad BDY2_B2B ) ( mgmt_vssa_hvclamp_pad VSSA ) ( mgmt_vssa_hvclamp_pad SRC_BDY_HVC )
+      ( mgmt_vddio_hvclamp_pad\[0\] VSSA ) ( mgmt_vdda_hvclamp_pad VSSA ) ( mgmt_vdda_hvclamp_pad SRC_BDY_HVC ) ( mgmt_vccd_lvclamp_pad VSSA ) ( mgmt_vccd_lvclamp_pad BDY2_B2B ) ( mgmt_corner\[1\] VSSA ) ( mgmt_corner\[0\] VSSA ) ( gpio_pad VSSA )
+      ( gpio_pad ENABLE_VSWITCH_H ) ( flash_io1_pad VSSA ) ( flash_io1_pad ENABLE_VSWITCH_H ) ( flash_io0_pad VSSA ) ( flash_io0_pad ENABLE_VSWITCH_H ) ( flash_csb_pad VSSA ) ( flash_csb_pad ENABLE_VSWITCH_H ) ( flash_clk_pad VSSA )
+      ( flash_clk_pad ENABLE_VSWITCH_H ) ( clock_pad VSSA ) ( clock_pad ENABLE_VSWITCH_H ) + USE SIGNAL ;
+    - vssa1 ( PIN vssa1 ) ( user1_vssd_lvclmap_pad VSSA ) ( user1_vssa_hvclamp_pad\[1\] VSSA ) ( user1_vssa_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vssa_hvclamp_pad\[0\] VSSA ) ( user1_vssa_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[1\] VSSA )
+      ( user1_vdda_hvclamp_pad\[1\] SRC_BDY_HVC ) ( user1_vdda_hvclamp_pad\[0\] VSSA ) ( user1_vdda_hvclamp_pad\[0\] SRC_BDY_HVC ) ( user1_vccd_lvclamp_pad VSSA ) ( user1_corner VSSA ) ( mprj_pads.area1_io_pad\[9\] VSSA ) ( mprj_pads.area1_io_pad\[8\] VSSA ) ( mprj_pads.area1_io_pad\[7\] VSSA )
+      ( mprj_pads.area1_io_pad\[6\] VSSA ) ( mprj_pads.area1_io_pad\[5\] VSSA ) ( mprj_pads.area1_io_pad\[4\] VSSA ) ( mprj_pads.area1_io_pad\[3\] VSSA ) ( mprj_pads.area1_io_pad\[2\] VSSA ) ( mprj_pads.area1_io_pad\[1\] VSSA ) ( mprj_pads.area1_io_pad\[17\] VSSA ) ( mprj_pads.area1_io_pad\[16\] VSSA )
+      ( mprj_pads.area1_io_pad\[15\] VSSA ) ( mprj_pads.area1_io_pad\[14\] VSSA ) ( mprj_pads.area1_io_pad\[13\] VSSA ) ( mprj_pads.area1_io_pad\[12\] VSSA ) ( mprj_pads.area1_io_pad\[11\] VSSA ) ( mprj_pads.area1_io_pad\[10\] VSSA ) ( mprj_pads.area1_io_pad\[0\] VSSA ) + USE SIGNAL ;
+    - vssa2 ( PIN vssa2 ) ( user2_vssd_lvclmap_pad VSSA ) ( user2_vssa_hvclamp_pad VSSA ) ( user2_vssa_hvclamp_pad SRC_BDY_HVC ) ( user2_vdda_hvclamp_pad VSSA ) ( user2_vdda_hvclamp_pad SRC_BDY_HVC ) ( user2_vccd_lvclamp_pad VSSA )
+      ( user2_corner VSSA ) ( mprj_pads.area2_io_pad\[9\] VSSA ) ( mprj_pads.area2_io_pad\[8\] VSSA ) ( mprj_pads.area2_io_pad\[7\] VSSA ) ( mprj_pads.area2_io_pad\[6\] VSSA ) ( mprj_pads.area2_io_pad\[5\] VSSA ) ( mprj_pads.area2_io_pad\[4\] VSSA ) ( mprj_pads.area2_io_pad\[3\] VSSA )
+      ( mprj_pads.area2_io_pad\[2\] VSSA ) ( mprj_pads.area2_io_pad\[1\] VSSA ) ( mprj_pads.area2_io_pad\[19\] VSSA ) ( mprj_pads.area2_io_pad\[18\] VSSA ) ( mprj_pads.area2_io_pad\[17\] VSSA ) ( mprj_pads.area2_io_pad\[16\] VSSA ) ( mprj_pads.area2_io_pad\[15\] VSSA ) ( mprj_pads.area2_io_pad\[14\] VSSA )
+      ( mprj_pads.area2_io_pad\[13\] VSSA ) ( mprj_pads.area2_io_pad\[12\] VSSA ) ( mprj_pads.area2_io_pad\[11\] VSSA ) ( mprj_pads.area2_io_pad\[10\] VSSA ) ( mprj_pads.area2_io_pad\[0\] VSSA ) ( mgmt_vssio_hvclamp_pad\[1\] VSSA ) ( mgmt_vddio_hvclamp_pad\[1\] VSSA ) + USE SIGNAL ;
+    - vssd ( PIN vssd ) ( user2_vssd_lvclmap_pad SRC_BDY_LVC2 ) ( user2_vccd_lvclamp_pad SRC_BDY_LVC2 ) ( user1_vssd_lvclmap_pad SRC_BDY_LVC2 ) ( user1_vccd_lvclamp_pad SRC_BDY_LVC2 ) ( resetb_pad VSSD ) ( mgmt_vssio_hvclamp_pad\[0\] VSSD )
+      ( mgmt_vssd_lvclmap_pad VSSD ) ( mgmt_vssd_lvclmap_pad SRC_BDY_LVC2 ) ( mgmt_vssa_hvclamp_pad VSSD ) ( mgmt_vddio_hvclamp_pad\[0\] VSSD ) ( mgmt_vdda_hvclamp_pad VSSD ) ( mgmt_vccd_lvclamp_pad VSSD ) ( mgmt_vccd_lvclamp_pad SRC_BDY_LVC2 ) ( mgmt_corner\[1\] VSSD )
+      ( mgmt_corner\[0\] VSSD ) ( gpio_pad VTRIP_SEL ) ( gpio_pad VSSD ) ( gpio_pad SLOW ) ( gpio_pad IB_MODE_SEL ) ( gpio_pad HLD_OVR ) ( gpio_pad ANALOG_SEL ) ( gpio_pad ANALOG_POL )
+      ( gpio_pad ANALOG_EN ) ( flash_io1_pad VTRIP_SEL ) ( flash_io1_pad VSSD ) ( flash_io1_pad SLOW ) ( flash_io1_pad IB_MODE_SEL ) ( flash_io1_pad HLD_OVR ) ( flash_io1_pad ANALOG_SEL ) ( flash_io1_pad ANALOG_POL )
+      ( flash_io1_pad ANALOG_EN ) ( flash_io0_pad VTRIP_SEL ) ( flash_io0_pad VSSD ) ( flash_io0_pad SLOW ) ( flash_io0_pad IB_MODE_SEL ) ( flash_io0_pad HLD_OVR ) ( flash_io0_pad ANALOG_SEL ) ( flash_io0_pad ANALOG_POL )
+      ( flash_io0_pad ANALOG_EN ) ( flash_csb_pad VTRIP_SEL ) ( flash_csb_pad VSSD ) ( flash_csb_pad SLOW ) ( flash_csb_pad IB_MODE_SEL ) ( flash_csb_pad HLD_OVR ) ( flash_csb_pad DM[0] ) ( flash_csb_pad ANALOG_SEL )
+      ( flash_csb_pad ANALOG_POL ) ( flash_csb_pad ANALOG_EN ) ( flash_clk_pad VTRIP_SEL ) ( flash_clk_pad VSSD ) ( flash_clk_pad SLOW ) ( flash_clk_pad IB_MODE_SEL ) ( flash_clk_pad HLD_OVR ) ( flash_clk_pad DM[0] )
+      ( flash_clk_pad ANALOG_SEL ) ( flash_clk_pad ANALOG_POL ) ( flash_clk_pad ANALOG_EN ) ( clock_pad VTRIP_SEL ) ( clock_pad VSSD ) ( clock_pad SLOW ) ( clock_pad OUT ) ( clock_pad IB_MODE_SEL )
+      ( clock_pad HLD_OVR ) ( clock_pad DM[2] ) ( clock_pad DM[1] ) ( clock_pad ANALOG_SEL ) ( clock_pad ANALOG_POL ) ( clock_pad ANALOG_EN ) + USE SIGNAL ;
+    - vssd1 ( PIN vssd1 ) ( user1_vssd_lvclmap_pad VSSD ) ( user1_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( user1_vssa_hvclamp_pad\[1\] VSSD ) ( user1_vssa_hvclamp_pad\[0\] VSSD ) ( user1_vdda_hvclamp_pad\[1\] VSSD ) ( user1_vdda_hvclamp_pad\[0\] VSSD )
+      ( user1_vccd_lvclamp_pad VSSD ) ( user1_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( user1_corner VSSD ) ( mprj_pads.area1_io_pad\[9\] VSSD ) ( mprj_pads.area1_io_pad\[8\] VSSD ) ( mprj_pads.area1_io_pad\[7\] VSSD ) ( mprj_pads.area1_io_pad\[6\] VSSD ) ( mprj_pads.area1_io_pad\[5\] VSSD )
+      ( mprj_pads.area1_io_pad\[4\] VSSD ) ( mprj_pads.area1_io_pad\[3\] VSSD ) ( mprj_pads.area1_io_pad\[2\] VSSD ) ( mprj_pads.area1_io_pad\[1\] VSSD ) ( mprj_pads.area1_io_pad\[17\] VSSD ) ( mprj_pads.area1_io_pad\[16\] VSSD ) ( mprj_pads.area1_io_pad\[15\] VSSD ) ( mprj_pads.area1_io_pad\[14\] VSSD )
+      ( mprj_pads.area1_io_pad\[13\] VSSD ) ( mprj_pads.area1_io_pad\[12\] VSSD ) ( mprj_pads.area1_io_pad\[11\] VSSD ) ( mprj_pads.area1_io_pad\[10\] VSSD ) ( mprj_pads.area1_io_pad\[0\] VSSD ) + USE SIGNAL ;
+    - vssd2 ( PIN vssd2 ) ( user2_vssd_lvclmap_pad VSSD ) ( user2_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( user2_vssa_hvclamp_pad VSSD ) ( user2_vdda_hvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad VSSD ) ( user2_vccd_lvclamp_pad SRC_BDY_LVC1 )
+      ( user2_corner VSSD ) ( mprj_pads.area2_io_pad\[9\] VSSD ) ( mprj_pads.area2_io_pad\[8\] VSSD ) ( mprj_pads.area2_io_pad\[7\] VSSD ) ( mprj_pads.area2_io_pad\[6\] VSSD ) ( mprj_pads.area2_io_pad\[5\] VSSD ) ( mprj_pads.area2_io_pad\[4\] VSSD ) ( mprj_pads.area2_io_pad\[3\] VSSD )
+      ( mprj_pads.area2_io_pad\[2\] VSSD ) ( mprj_pads.area2_io_pad\[1\] VSSD ) ( mprj_pads.area2_io_pad\[19\] VSSD ) ( mprj_pads.area2_io_pad\[18\] VSSD ) ( mprj_pads.area2_io_pad\[17\] VSSD ) ( mprj_pads.area2_io_pad\[16\] VSSD ) ( mprj_pads.area2_io_pad\[15\] VSSD ) ( mprj_pads.area2_io_pad\[14\] VSSD )
+      ( mprj_pads.area2_io_pad\[13\] VSSD ) ( mprj_pads.area2_io_pad\[12\] VSSD ) ( mprj_pads.area2_io_pad\[11\] VSSD ) ( mprj_pads.area2_io_pad\[10\] VSSD ) ( mprj_pads.area2_io_pad\[0\] VSSD ) ( mgmt_vssio_hvclamp_pad\[1\] VSSD ) ( mgmt_vddio_hvclamp_pad\[1\] VSSD ) + USE SIGNAL ;
+    - vssio ( PIN vssio ) ( user2_vssd_lvclmap_pad VSSIO ) ( user2_vssd_lvclmap_pad BDY2_B2B ) ( user2_vssa_hvclamp_pad VSSIO ) ( user2_vdda_hvclamp_pad VSSIO ) ( user2_vccd_lvclamp_pad VSSIO ) ( user2_vccd_lvclamp_pad BDY2_B2B )
+      ( user2_corner VSSIO ) ( user1_vssd_lvclmap_pad VSSIO ) ( user1_vssd_lvclmap_pad BDY2_B2B ) ( user1_vssa_hvclamp_pad\[1\] VSSIO ) ( user1_vssa_hvclamp_pad\[0\] VSSIO ) ( user1_vdda_hvclamp_pad\[1\] VSSIO ) ( user1_vdda_hvclamp_pad\[0\] VSSIO ) ( user1_vccd_lvclamp_pad VSSIO )
+      ( user1_vccd_lvclamp_pad BDY2_B2B ) ( user1_corner VSSIO ) ( resetb_pad VSSIO ) ( resetb_pad PULLUP_H ) ( resetb_pad INP_SEL_H ) ( resetb_pad FILT_IN_H ) ( resetb_pad EN_VDDIO_SIG_H ) ( resetb_pad DISABLE_PULLUP_H )
+      ( mprj_pads.area2_io_pad\[9\] VSSIO ) ( mprj_pads.area2_io_pad\[9\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[8\] VSSIO ) ( mprj_pads.area2_io_pad\[8\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[7\] VSSIO ) ( mprj_pads.area2_io_pad\[7\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[6\] VSSIO ) ( mprj_pads.area2_io_pad\[6\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area2_io_pad\[5\] VSSIO ) ( mprj_pads.area2_io_pad\[5\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[4\] VSSIO ) ( mprj_pads.area2_io_pad\[4\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[3\] VSSIO ) ( mprj_pads.area2_io_pad\[3\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[2\] VSSIO ) ( mprj_pads.area2_io_pad\[2\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area2_io_pad\[1\] VSSIO ) ( mprj_pads.area2_io_pad\[1\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[19\] VSSIO ) ( mprj_pads.area2_io_pad\[19\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[18\] VSSIO ) ( mprj_pads.area2_io_pad\[18\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[17\] VSSIO ) ( mprj_pads.area2_io_pad\[17\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area2_io_pad\[16\] VSSIO ) ( mprj_pads.area2_io_pad\[16\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[15\] VSSIO ) ( mprj_pads.area2_io_pad\[15\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[14\] VSSIO ) ( mprj_pads.area2_io_pad\[14\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[13\] VSSIO ) ( mprj_pads.area2_io_pad\[13\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area2_io_pad\[12\] VSSIO ) ( mprj_pads.area2_io_pad\[12\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[11\] VSSIO ) ( mprj_pads.area2_io_pad\[11\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[10\] VSSIO ) ( mprj_pads.area2_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area2_io_pad\[0\] VSSIO ) ( mprj_pads.area2_io_pad\[0\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area1_io_pad\[9\] VSSIO ) ( mprj_pads.area1_io_pad\[9\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[8\] VSSIO ) ( mprj_pads.area1_io_pad\[8\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[7\] VSSIO ) ( mprj_pads.area1_io_pad\[7\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[6\] VSSIO ) ( mprj_pads.area1_io_pad\[6\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area1_io_pad\[5\] VSSIO ) ( mprj_pads.area1_io_pad\[5\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[4\] VSSIO ) ( mprj_pads.area1_io_pad\[4\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[3\] VSSIO ) ( mprj_pads.area1_io_pad\[3\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[2\] VSSIO ) ( mprj_pads.area1_io_pad\[2\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area1_io_pad\[1\] VSSIO ) ( mprj_pads.area1_io_pad\[1\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[17\] VSSIO ) ( mprj_pads.area1_io_pad\[17\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[16\] VSSIO ) ( mprj_pads.area1_io_pad\[16\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[15\] VSSIO ) ( mprj_pads.area1_io_pad\[15\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area1_io_pad\[14\] VSSIO ) ( mprj_pads.area1_io_pad\[14\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[13\] VSSIO ) ( mprj_pads.area1_io_pad\[13\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[12\] VSSIO ) ( mprj_pads.area1_io_pad\[12\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[11\] VSSIO ) ( mprj_pads.area1_io_pad\[11\] ENABLE_VSWITCH_H )
+      ( mprj_pads.area1_io_pad\[10\] VSSIO ) ( mprj_pads.area1_io_pad\[10\] ENABLE_VSWITCH_H ) ( mprj_pads.area1_io_pad\[0\] VSSIO ) ( mprj_pads.area1_io_pad\[0\] ENABLE_VSWITCH_H ) ( mgmt_vssio_hvclamp_pad\[1\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vssio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vssio_hvclamp_pad\[0\] SRC_BDY_HVC )
+      ( mgmt_vssd_lvclmap_pad VSSIO ) ( mgmt_vssd_lvclmap_pad SRC_BDY_LVC1 ) ( mgmt_vssa_hvclamp_pad VSSIO ) ( mgmt_vddio_hvclamp_pad\[1\] VSSIO ) ( mgmt_vddio_hvclamp_pad\[1\] SRC_BDY_HVC ) ( mgmt_vddio_hvclamp_pad\[0\] VSSIO ) ( mgmt_vddio_hvclamp_pad\[0\] SRC_BDY_HVC ) ( mgmt_vdda_hvclamp_pad VSSIO )
+      ( mgmt_vccd_lvclamp_pad VSSIO ) ( mgmt_vccd_lvclamp_pad SRC_BDY_LVC1 ) ( mgmt_corner\[1\] VSSIO ) ( mgmt_corner\[0\] VSSIO ) ( gpio_pad VSSIO ) ( flash_io1_pad VSSIO ) ( flash_io0_pad VSSIO ) ( flash_csb_pad VSSIO )
+      ( flash_clk_pad VSSIO ) ( clock_pad VSSIO ) + USE SIGNAL ;
     - xresloop ( resetb_pad TIE_WEAK_HI_H ) ( resetb_pad PAD_A_ESD_H ) + USE SIGNAL ;
 END NETS
 END DESIGN

--- a/src/pad/test/skywater130_overlapping_filler.tcl
+++ b/src/pad/test/skywater130_overlapping_filler.tcl
@@ -620,22 +620,21 @@ place_corners sky130_ef_io__corner_pad
 
 place_io_fill \
   -row IO_NORTH \
-  -permit_overlaps sky130_ef_io__com_bus_slice_5um \
-  sky130_ef_io__com_bus_slice_20um sky130_ef_io__com_bus_slice_10um sky130_ef_io__com_bus_slice_5um
+  -permit_overlaps sky130_ef_io__com_bus_slice_20um \
+  sky130_ef_io__com_bus_slice_20um
 place_io_fill \
   -row IO_SOUTH \
-  -permit_overlaps sky130_ef_io__com_bus_slice_5um \
-  sky130_ef_io__com_bus_slice_20um sky130_ef_io__com_bus_slice_10um sky130_ef_io__com_bus_slice_5um
+  -permit_overlaps sky130_ef_io__com_bus_slice_20um \
+  sky130_ef_io__com_bus_slice_20um
 place_io_fill \
   -row IO_WEST \
-  -permit_overlaps sky130_ef_io__com_bus_slice_5um \
-  sky130_ef_io__com_bus_slice_20um sky130_ef_io__com_bus_slice_10um sky130_ef_io__com_bus_slice_5um
+  -permit_overlaps sky130_ef_io__com_bus_slice_20um \
+  sky130_ef_io__com_bus_slice_20um
 place_io_fill \
   -row IO_EAST \
-  -permit_overlaps sky130_ef_io__com_bus_slice_5um \
-  sky130_ef_io__com_bus_slice_20um sky130_ef_io__com_bus_slice_10um sky130_ef_io__com_bus_slice_5um
+  -permit_overlaps sky130_ef_io__com_bus_slice_20um \
+  sky130_ef_io__com_bus_slice_20um
 
-connect_by_abutment
 place_io_terminals */PAD
 
 set def_file [make_result_file "skywater130_overlapping_filler.def"]


### PR DESCRIPTION
Changes:
- Dont continue through the filler loop once gap is filled, otherwise the cells marked as overlap permitted will get added even when they are not needed.
- Correct the test to actually cause overlaps and check for them