### PR TITLE
dst: fix thread-safety warnings in LoadBalancer::removeWorker

### DIFF
--- a/src/dst/BUILD
+++ b/src/dst/BUILD
@@ -37,7 +37,6 @@ cc_library(
     deps = [
         "//src/odb",
         "//src/utl",
-        "@abseil-cpp//absl/base:core_headers",
         "@abseil-cpp//absl/synchronization",
         "@boost.asio",
         "@boost.bind",

--- a/src/dst/src/BalancerConnection.cc
+++ b/src/dst/src/BalancerConnection.cc
@@ -186,7 +186,7 @@ void BalancerConnection::handle_read(boost::system::error_code const& err,
             = owner_->workers_.size() - failed_workers.size();
         if (!failed_workers.empty()) {
           for (const auto& worker : failed_workers) {
-            owner_->removeWorkerLocked(worker.first, worker.second);
+            owner_->removeWorker(worker.first, worker.second);
           }
           logger_->warn(utl::DST,
                         207,

--- a/src/dst/src/LoadBalancer.cc
+++ b/src/dst/src/LoadBalancer.cc
@@ -150,12 +150,6 @@ void LoadBalancer::punishWorker(const ip::address& ip, uint16_t port)
 
 void LoadBalancer::removeWorker(const ip::address& ip, uint16_t port)
 {
-  absl::MutexLock lock(&workers_mutex_);
-  removeWorkerLocked(ip, port);
-}
-
-void LoadBalancer::removeWorkerLocked(const ip::address& ip, uint16_t port)
-{
   std::priority_queue<Worker, std::vector<Worker>, CompareWorker> new_queue;
   while (!workers_.empty()) {
     auto worker = workers_.top();

--- a/src/dst/src/LoadBalancer.h
+++ b/src/dst/src/LoadBalancer.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "BalancerConnection.h"
-#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "boost/asio.hpp"
 #include "boost/asio/ip/address.hpp"
@@ -83,8 +82,6 @@ class LoadBalancer
   boost::thread workers_lookup_thread_;
   std::vector<std::string> broadcastData_;
 
-  void removeWorkerLocked(const ip::address& ip, uint16_t port)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(workers_mutex_);
   void start_accept();
   void handle_accept(const BalancerConnection::Pointer& connection,
                      const boost::system::error_code& err);


### PR DESCRIPTION
@maliberty Reviewing, not coding, is the bottleneck... Is this useful? Fixes a warning.

Split removeWorker into two functions to eliminate the conditional lock/unlock pattern that Clang's thread-safety analyzer cannot reason about. The new removeWorkerLocked is annotated with ABSL_EXCLUSIVE_LOCKS_REQUIRED for callers that already hold the mutex.