### PR TITLE
rmp: fix link targets to correctly point at the absl namespaces

### DIFF
--- a/src/rmp/src/CMakeLists.txt
+++ b/src/rmp/src/CMakeLists.txt
@@ -55,7 +55,6 @@ target_include_directories(rmp_lib
 
 target_link_libraries(rmp_lib
   PUBLIC
-    absl::synchronization
     odb
     dbSta_lib
     OpenSTA
@@ -63,8 +62,9 @@ target_link_libraries(rmp_lib
     utl_lib
     cut
     ${ABC_LIBRARY}
-    absl_hash
-    absl_city
+    absl::synchronization
+    absl::hash
+    absl::city
 )
 
 target_link_libraries(rmp


### PR DESCRIPTION
This ensures the link is to the found ABSL library and not whatever happens to be in the default system libraries.
