### PR TITLE
bazel: use stamp=1 to avoid global --stamp cache pollution

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,9 @@
 common --enable_bzlmod
 build --workspace_status_command=tools/workspace_status.sh
 
-# Release builds embed real git version info; dev builds use cache-safe placeholders.
-# Usage: bazel build --config=release //...
-build:release --stamp
+# Version stamping is handled by stamp = 1 on the OpenRoadVersion genrule,
+# so there is no need for a global --stamp flag (which would change the build
+# configuration for every target and prevent cache sharing).
 common --enable_workspace  # explicitly currently still needing this
 
 # suppress distracting warning about newer module

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -252,15 +252,18 @@ genrule(
             VERSION=$$(grep '^STABLE_GIT_VERSION ' bazel-out/stable-status.txt \
                         | cut -d' ' -f2-) || true
         fi
-        [ -z "$$VERSION" ] && VERSION="bazel-nostamp"
+        [ -z "$$VERSION" ] && VERSION="unknown"
         printf '#define OPENROAD_VERSION "%s"\\n' "$$VERSION" > $@
         printf '#define OPENROAD_GIT_DESCRIBE ""\\n' >> $@
     """,
-    # stamp = -1 means "stamp when --stamp is set" (via --config=release).
-    # Without --stamp (the default), STABLE_GIT_VERSION is empty and
-    # the output is deterministic, so the Bazel cache is not invalidated
-    # on every commit.
-    stamp = -1,
+    # stamp = 1: always embed the real git version from workspace_status.sh.
+    #
+    # This avoids needing the global --stamp flag, which would change the
+    # build configuration for every target and destroy cache sharing between
+    # stamped and unstamped builds.  With stamp = 1 only this genrule (and
+    # the small openroad_version library) re-executes when STABLE_GIT_VERSION
+    # changes; all other .o files keep their cache hits.
+    stamp = 1,
 )
 
 tcl_encode(

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Outputs key-value pairs consumed by Bazel workspace stamping.
 # Keys prefixed with STABLE_ cause downstream rebuilds when their value changes.
-# With --nostamp (default), Bazel substitutes empty strings, keeping the cache intact.
+# The OpenRoadVersion genrule uses stamp = 1, so these values are always
+# embedded.  No global --stamp flag is needed.
 GIT_VERSION=$(git describe --tags --match '[0-9][0-9]Q[0-9]' --always 2>/dev/null \
   || echo "unknown")
 echo "STABLE_GIT_VERSION ${GIT_VERSION}"


### PR DESCRIPTION
The global --stamp flag changes the build configuration for every target, preventing cache sharing between stamped and unstamped builds. Switch the OpenRoadVersion genrule to stamp = 1 (unconditional) so it always embeds the real git version without needing --stamp on the command line.  This lets all .o files share a single cache regardless of whether version stamping is desired.