### PR TITLE
fix: add missing space in DPL warn call in improve_placement

### DIFF
--- a/src/dpl/src/Opendp.tcl
+++ b/src/dpl/src/Opendp.tcl
@@ -175,7 +175,7 @@ proc improve_placement { args } {
   }
 
   if { [info exists flags(-disallow_one_site_gaps)] } {
-    utl::warn DPL 343"-disallow_one_site_gaps is deprecated"
+    utl::warn DPL 343 "-disallow_one_site_gaps is deprecated"
   }
   set seed 1
   if { [info exists keys(-random_seed)] } {


### PR DESCRIPTION
### SUMMARY

This PR fixes a small Tcl typo in `improve_placement` that made a deprecation warning crash the command instead of printing a warning. The change is confined to **`src/dpl/src/Opendp.tcl`** and only affects how the warning is emitted.

---

### FIX

* **Root cause:** A missing space between the warning ID and the quoted message caused Tcl to parse the arguments incorrectly.
* **Approach:** Add the missing space so `utl::warn` receives the expected arguments.

**Before:**

```tcl
utl::warn DPL 343"-disallow_one_site_gaps is deprecated"
```

**After:**

```tcl
utl::warn DPL 343 "-disallow_one_site_gaps is deprecated"
```

---
### VERIFICATION

1. Run:

   ```tcl
   improve_placement -disallow_one_site_gaps
   ```
2. **Before:** Fails with `wrong # args`.
3. **After:** Prints the deprecation warning and continues normally.