### PR TITLE
pdn: store obstructions in renderer to avoid rebuilding

### DIFF
--- a/src/pdn/include/pdn/PdnGen.hh
+++ b/src/pdn/include/pdn/PdnGen.hh
@@ -193,7 +193,7 @@ class PdnGen
   VoltageDomain* getCoreDomain() const;
   void ensureCoreDomain();
 
-  void updateRenderer() const;
+  void updateRenderer(bool reset) const;
 
   bool importUPF(VoltageDomain* domain);
   bool importUPF(Grid* grid, PowerSwitchNetworkType type) const;

--- a/src/pdn/src/PdnGen.cc
+++ b/src/pdn/src/PdnGen.cc
@@ -47,7 +47,7 @@ void PdnGen::reset()
 {
   core_domain_ = nullptr;
   domains_.clear();
-  updateRenderer();
+  updateRenderer(true);
 }
 
 void PdnGen::resetShapes()
@@ -55,7 +55,7 @@ void PdnGen::resetShapes()
   for (auto* grid : getGrids()) {
     grid->resetShapes();
   }
-  updateRenderer();
+  updateRenderer(true);
 }
 
 void PdnGen::buildGrids(bool trim)
@@ -102,6 +102,9 @@ void PdnGen::buildGrids(bool trim)
     block_obs[layer] = Shape::ObstructionTree(shapes.begin(), shapes.end());
   }
   block_obs_vec.clear();
+  if (debug_renderer_ != nullptr) {
+    debug_renderer_->setInitialObstructions(block_obs);
+  }
 
   Shape::ShapeTreeMap all_shapes;
   for (const auto& [layer, shapes] : all_shapes_vec) {
@@ -145,7 +148,7 @@ void PdnGen::buildGrids(bool trim)
     failed = true;
   }
 
-  updateRenderer();
+  updateRenderer(false);
 
   if (failed) {
     logger_->error(utl::PDN, 233, "Failed to generate full power grid.");
@@ -694,9 +697,12 @@ void PdnGen::rendererRedraw()
   }
 }
 
-void PdnGen::updateRenderer() const
+void PdnGen::updateRenderer(bool reset) const
 {
   if (debug_renderer_ != nullptr) {
+    if (reset) {
+      debug_renderer_->setInitialObstructions({});
+    }
     debug_renderer_->update();
   }
 }

--- a/src/pdn/src/renderer.cpp
+++ b/src/pdn/src/renderer.cpp
@@ -53,19 +53,9 @@ PDNRenderer::PDNRenderer(PdnGen* pdn) : pdn_(pdn)
 void PDNRenderer::update()
 {
   shapes_.clear();
-  initial_obstructions_.clear();
   grid_obstructions_.clear();
   vias_.clear();
   repair_.clear();
-
-  if (!pdn_->getDomains().empty()) {
-    auto* domain = pdn_->getDomains()[0];
-    ShapeVectorMap initial_shapes;
-    Grid::makeInitialObstructions(
-        domain->getBlock(), initial_shapes, {}, {}, domain->getLogger());
-    initial_obstructions_
-        = Shape::convertVectorToObstructionTree(initial_shapes);
-  }
 
   ShapeVectorMap shapes;
   ShapeVectorMap obs;

--- a/src/pdn/src/renderer.h
+++ b/src/pdn/src/renderer.h
@@ -32,6 +32,12 @@ class PDNRenderer : public gui::Renderer
 
   const char* getDisplayControlGroupName() override { return "Power Grid"; }
 
+  void setInitialObstructions(
+      const Shape::ObstructionTreeMap& initial_obstructions)
+  {
+    initial_obstructions_ = initial_obstructions;
+  }
+
   void pause();
 
  private:


### PR DESCRIPTION
No functional changes, just ensures the obstructions match what buildGrid sees.