### PR TITLE
qt_bazel_prebuilts have now refreshed glpk+harfbuzz.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -89,16 +89,9 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "2b450c5d0b84e0a48e0e7797486e62d24f65c78b",
+    commit = "970b93291b28ecb23f10abde796584ecbf904818",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
-
-# Updated dependencies of qt_bazel_prebuilts. Once the updated versions
-# have been added to qt_bazel_prebuilts, they can be removed here.
-# (But CAVE, right now that would result in cyclic dependencies with,
-# WORKSPACE so that also has to go first).
-bazel_dep(name = "harfbuzz", version = "11.0.1.bcr.1")
-bazel_dep(name = "glib", version = "2.82.2.bcr.8")
 
 ## Lock the compiler version and avoid any local compiler
 bazel_dep(name = "toolchains_llvm", version = "1.5.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -349,7 +349,6 @@
     "https://bcr.bazel.build/modules/grpc/1.69.0/source.json": "82e5cd0eeed569909ff42fd6946b813c8b69fc71a6b075ccebef224937e19215",
     "https://bcr.bazel.build/modules/harfbuzz/11.0.1.bcr.1/MODULE.bazel": "4b0942d58350d56889a7b84348dd9b83ed02845a301c1197c55e1be16a97779b",
     "https://bcr.bazel.build/modules/harfbuzz/11.0.1.bcr.1/source.json": "91f26cabe47d52379cf596809c66e3238f53fb417d5b9e237ee999cc93d7956f",
-    "https://bcr.bazel.build/modules/harfbuzz/11.0.1/MODULE.bazel": "e004bec52244a7b7b5946c6e9d231e7349c67c5722211348ea25ece3614f47ec",
     "https://bcr.bazel.build/modules/highs/1.11.0/MODULE.bazel": "f820e7fc99bd332d5133502c49f3ff35c754566ae593b4cf5c91931c8d122f9b",
     "https://bcr.bazel.build/modules/highs/1.11.0/source.json": "122976647568ee73c10d15078f4554624ce9c390ee3d9f2a5dcb0b95b63a782b",
     "https://bcr.bazel.build/modules/highwayhash/0.0.0-20240305-5ad3bf8/MODULE.bazel": "5c7f29d5bd70feff14b0f65b39584957e18e4a8d555e5a29a4c36019afbb44b9",


### PR DESCRIPTION
They have been updated in
https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts/pull/9

So we don't need these locally anymore.