### PR TITLE
bazel: update qt_bazel_prebuilds for aarch64 gui support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -89,7 +89,7 @@ bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "970b93291b28ecb23f10abde796584ecbf904818",
+    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 


### PR DESCRIPTION
With merged PR

https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts/pull/8

qt_bazel supports linux aarch64. This commit updates to that version such that OpenROAD can be build with gui on aarch64 linux systems. Tested in Debian 13 aarch64 vm on Macbook.