### PR TITLE
Mark bazel-orfs, rules_scala, rules_jvm_external, circt as dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -179,15 +179,9 @@ maven.install(
 )
 use_repo(maven, "maven")
 
-http_archive_dev = use_repo_rule(
-    "@bazel_tools//tools/build_defs/repo:http.bzl",
-    "http_archive",
-    dev_dependency = True,
-)
-
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive_dev(
+http_archive(
     name = "circt",
     build_file_content = """
 exports_files(glob(["bin/*"]), visibility = ["//visibility:public"])

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1217,7 +1217,7 @@
     "@@bazel-orfs+//:extension.bzl%orfs_repositories": {
       "general": {
         "bzlTransitiveDigest": "mXT67CG7L5OLVmAL21N/b1fUYtLkKfGcDS9/BHvSBuY=",
-        "usagesDigest": "/u5svVy14hyIuJ7XE6M5n59b1AjT2Jn/64tBm7ts3to=",
+        "usagesDigest": "GLZRCstEcE7XpzR6P6EefATIGUwaA/Fki/CZxEwYWYE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1763,7 +1763,7 @@
     },
     "@@rules_apple+//apple:apple.bzl%provisioning_profile_repository_extension": {
       "general": {
-        "bzlTransitiveDigest": "CUIdbxeGZ+GPvVqbCkw9HQeJLsqeG3I1pJQ+oyZr/D4=",
+        "bzlTransitiveDigest": "2cBXTE/fvClSpGce+ynwObOpFH/7oWFzmeSUGe5Pbfw=",
         "usagesDigest": "vsJl8Rw5NL+5Ag2wdUDoTeRF/5klkXO8545Iy7U1Q08=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -1812,6 +1812,16 @@
           ],
           [
             "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
             "rules_cc",
             "rules_cc+"
           ],


### PR DESCRIPTION
@hzeller FYI

These dependencies are only used for OpenROAD's own test infrastructure (ORFS integration tests, Chisel mock-array, firtool binary) and are not needed by downstream consumers of the openroad module.

Whittles away at #9629