### PR TITLE
Don't use `&container[0]i` but `container.data()` instead.

### DIFF
--- a/src/ant/src/AntennaChecker.cc
+++ b/src/ant/src/AntennaChecker.cc
@@ -318,7 +318,7 @@ void AntennaChecker::Impl::saveGates(odb::dbNet* db_net,
     dsu_parent[i] = i;
   }
 
-  boost::disjoint_sets<int*, int*> dsu(&dsu_size[0], &dsu_parent[0]);
+  boost::disjoint_sets<int*, int*> dsu(dsu_size.data(), dsu_parent.data());
 
   odb::dbTech* tech = db_->getTech();
   odb::dbTechLayer* iter = tech->findRoutingLayer(1);

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -1110,7 +1110,7 @@ NesterovBaseCommon::NesterovBaseCommon(
     nbc_gcells_.push_back(&gCell);
     for (Instance* inst : gCell.insts()) {
       gCellMap_[inst] = &gCell;
-      db_inst_to_nbc_index_map_[inst->dbInst()] = &gCell - &gCellStor_[0];
+      db_inst_to_nbc_index_map_[inst->dbInst()] = &gCell - gCellStor_.data();
     }
   }
 
@@ -1575,7 +1575,7 @@ void NesterovBaseCommon::fixPointers()
     nbc_gcells_.push_back(&gCell);
     for (Instance* inst : gCell.insts()) {
       gCellMap_[inst] = &gCell;
-      db_inst_to_nbc_index_map_[inst->dbInst()] = &gCell - &gCellStor_[0];
+      db_inst_to_nbc_index_map_[inst->dbInst()] = &gCell - gCellStor_.data();
     }
   }
 


### PR DESCRIPTION
Readability improvement. Done automatically by clang-tidy:

```
etc/run-clang-tidy.sh --checks=-*,readability-container-data-pointer --fix
```