### PR TITLE
Removed log spam from write_verilog

### DIFF
--- a/src/dbSta/src/dbReadVerilog.tcl
+++ b/src/dbSta/src/dbReadVerilog.tcl
@@ -34,11 +34,12 @@ sta::define_cmd_args "write_verilog" {[-sort] [-include_pwr_gnd]\
 proc write_verilog { args } {
   sta::parse_key_args "write_verilog" args keys {-remove_cells} \
     flags {-sort -include_pwr_gnd}
-  if { [info exists flags(-sort)] } {
-    if { ![info exists ::_write_verilog_sort_warned] } {
-      utl::warn STA 2065 "The -sort flag is ignored."
-      set ::_write_verilog_sort_warned 1
-    }
+  if { [info exists ::write_verilog_sort_warned] == 0 } {
+    set ::write_verilog_sort_warned 0
+  }
+  if { [info exists flags(-sort)] && !$::write_verilog_sort_warned } {
+    utl::warn STA 2065 "-sort is deprecated and ignored."
+    set ::write_verilog_sort_warned 1
   }
   set remove_cells {}
   if { [info exists keys(-remove_cells)] } {


### PR DESCRIPTION
What changed

Updated write_verilog in:
src/sta/verilog/Verilog.tcl
src/dbSta/src/dbReadVerilog.tcl
Removed the warning emission for -sort ("The -sort flag is ignored."). 

Result
write_verilog still accepts -sort for compatibility. It now ignores -sort silently, so repeated calls won’t flood logs.