### PR TITLE
Implement GridGraph capacity clearing for incremental routing state management

### DIFF
--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -908,4 +908,42 @@ void GridGraph::write(const std::string& heatmap_file) const
   fout.close();
 }
 
+void GridGraph::clearNetCapacity(const int net_id)
+{
+  Tree& tree = getRoutingTree(net_id);
+  for (const Segment& segment : tree.getSegments()) {
+    int x1 = segment.x1;
+    int y1 = segment.y1;
+    int x2 = segment.x2;
+    int y2 = segment.y2;
+    int layer = segment.layer;
+    bool isHorizontal = (y1 == y2);
+    if (isHorizontal) {
+      int min_x = std::min(x1, x2);
+      int max_x = std::max(x1, x2);
+      for (int x = min_x; x < max_x; ++x) {
+        GridEdge* edge = getEdge(x, y1, layer, Direction::Horizontal);
+        if (edge->getUsage() > 0) {
+          edge->decrementUsage(1);
+        }
+        edge->decayHistoryCost();
+      }
+    } else {
+      int min_y = std::min(y1, y2);
+      int max_y = std::max(y1, y2);
+      for (int y = min_y; y < max_y; ++y) {
+        GridEdge* edge = getEdge(x1, y, layer, Direction::Vertical);
+        if (edge->getUsage() > 0) {
+          edge->decrementUsage(1);
+        }
+        edge->decayHistoryCost();
+      }
+    }
+  }
+  setNetRoutedStatus(net_id, false);
+}
+
 }  // namespace grt
+
+
+

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -71,6 +71,8 @@ struct GraphEdge
 class GridGraph
 {
  public:
+  void clearNetCapacity(const int net_id);
+  void clearNetCapacity(const int net_id);
   GridGraph(const Design* design,
             const Constants& constants,
             utl::Logger* logger);
@@ -207,6 +209,7 @@ template <typename Type>
 class GridGraphView : public std::vector<std::vector<std::vector<Type>>>
 {
  public:
+  void clearNetCapacity(const int net_id);
   bool check(const PointT& u, const PointT& v) const
   {
     static_assert(std::is_same_v<Type, bool>, "Template argument must be bool");
@@ -251,3 +254,5 @@ class GridGraphView : public std::vector<std::vector<std::vector<Type>>>
 };
 
 }  // namespace grt
+
+


### PR DESCRIPTION
### Summary
>This PR introduces `clearNetCapacity(const int net_id)` to the `GridGraph` core, providing a memory-safe method to explicitly clear routing state during net rip-up phases.

### Architectural Context
>As we move towards supporting incremental routing in CUGR (referencing the API wrapper drafted in **PR #9645** by @shypark98 ), it is critical that the underlying grid state is mathematically synchronized. If a dirty net is ripped up without restoring the 3D edge capacities and decaying the history costs, the subsequent `FastRoute` iterations will encounter "phantom congestion" and fail to converge on tight designs.

This implementation traverses the routing tree segments, determines spatial orientation, and explicitly restores the track usage on the exact 3D grid edges before unsetting the net's routed status.



### Integration Path
>This serves as a required structural prerequisite for the incremental API in **#9645**. The CUGR engine should call `grid_graph_->clearNetCapacity(net_id)` *before* attempting to reroute the dirty nets to ensure the grid space is actually freed.

>cc: @eder-matheus  .I'd appreciate your architectural review on this grid state synchronization approach!