### PR TITLE
Use thread annotations in LoadBalancer

### DIFF
--- a/src/dst/BUILD
+++ b/src/dst/BUILD
@@ -37,6 +37,7 @@ cc_library(
     deps = [
         "//src/odb",
         "//src/utl",
+        "@abseil-cpp//absl/base:core_headers",
         "@abseil-cpp//absl/synchronization",
         "@boost.asio",
         "@boost.bind",

--- a/src/dst/src/BalancerConnection.cc
+++ b/src/dst/src/BalancerConnection.cc
@@ -186,7 +186,7 @@ void BalancerConnection::handle_read(boost::system::error_code const& err,
             = owner_->workers_.size() - failed_workers.size();
         if (!failed_workers.empty()) {
           for (const auto& worker : failed_workers) {
-            owner_->removeWorker(worker.first, worker.second, false);
+            owner_->removeWorkerLocked(worker.first, worker.second);
           }
           logger_->warn(utl::DST,
                         207,

--- a/src/dst/src/LoadBalancer.cc
+++ b/src/dst/src/LoadBalancer.cc
@@ -27,7 +27,11 @@ void LoadBalancer::start_accept()
 {
   if (jobs_ != 0 && jobs_ % 100 == 0) {
     logger_->info(utl::DST, 7, "Processed {} jobs", jobs_);
-    auto copy = workers_;
+    WorkerQueue copy;
+    {
+      absl::MutexLock lock(&workers_mutex_);
+      copy = workers_;
+    }
     while (!copy.empty()) {
       auto worker = copy.top();
       logger_->report("Worker {}/{} handled {} jobs",
@@ -107,7 +111,7 @@ bool LoadBalancer::addWorker(const std::string& ip, unsigned short port)
 void LoadBalancer::updateWorker(const ip::address& ip, unsigned short port)
 {
   absl::MutexLock lock(&workers_mutex_);
-  std::priority_queue<Worker, std::vector<Worker>, CompareWorker> new_queue;
+  WorkerQueue new_queue;
   while (!workers_.empty()) {
     auto worker = workers_.top();
     workers_.pop();
@@ -136,7 +140,7 @@ void LoadBalancer::getNextWorker(ip::address& ip, uint16_t& port)
 void LoadBalancer::punishWorker(const ip::address& ip, uint16_t port)
 {
   absl::MutexLock lock(&workers_mutex_);
-  std::priority_queue<Worker, std::vector<Worker>, CompareWorker> new_queue;
+  WorkerQueue new_queue;
   while (!workers_.empty()) {
     auto worker = workers_.top();
     workers_.pop();
@@ -148,12 +152,9 @@ void LoadBalancer::punishWorker(const ip::address& ip, uint16_t port)
   workers_.swap(new_queue);
 }
 
-void LoadBalancer::removeWorker(const ip::address& ip, uint16_t port, bool lock)
+void LoadBalancer::removeWorkerLocked(const ip::address& ip, uint16_t port)
 {
-  if (lock) {
-    workers_mutex_.Lock();
-  }
-  std::priority_queue<Worker, std::vector<Worker>, CompareWorker> new_queue;
+  WorkerQueue new_queue;
   while (!workers_.empty()) {
     auto worker = workers_.top();
     workers_.pop();
@@ -163,9 +164,6 @@ void LoadBalancer::removeWorker(const ip::address& ip, uint16_t port, bool lock)
     new_queue.push(worker);
   }
   workers_.swap(new_queue);
-  if (lock) {
-    workers_mutex_.Unlock();
-  }
 }
 
 void LoadBalancer::lookUpWorkers(const char* domain, uint16_t port)

--- a/src/dst/src/LoadBalancer.h
+++ b/src/dst/src/LoadBalancer.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "BalancerConnection.h"
+#include "absl/base/thread_annotations.h"
 #include "absl/synchronization/mutex.h"
 #include "boost/asio.hpp"
 #include "boost/asio/ip/address.hpp"
@@ -43,7 +44,8 @@ class LoadBalancer
   bool addWorker(const std::string& ip, uint16_t port);
   void updateWorker(const ip::address& ip, uint16_t port);
   void getNextWorker(ip::address& ip, uint16_t& port);
-  void removeWorker(const ip::address& ip, uint16_t port, bool lock = true);
+  void removeWorkerLocked(const ip::address& ip, uint16_t port)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(workers_mutex_);
   void punishWorker(const ip::address& ip, uint16_t port);
 
  private:
@@ -73,7 +75,9 @@ class LoadBalancer
   tcp::acceptor acceptor_;
   asio::io_context* service_;
   utl::Logger* logger_;
-  std::priority_queue<Worker, std::vector<Worker>, CompareWorker> workers_;
+  using WorkerQueue
+      = std::priority_queue<Worker, std::vector<Worker>, CompareWorker>;
+  WorkerQueue workers_ ABSL_GUARDED_BY(workers_mutex_);
   absl::Mutex workers_mutex_;
   std::unique_ptr<asio::thread_pool> pool_;
   absl::Mutex pool_mutex_;


### PR DESCRIPTION
This helps the static analysis of the compiler to find places where thread locking was forgotten.

And in fact, it found a missing mutex lock in `start_accept()`

(Follow-up to #9587)