### PR TITLE
docs: Add DependencyInstaller.sh functionalities(-local and -prefix) to Build.md

### DIFF
--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -97,37 +97,18 @@ it can be uploaded in the "Relevant log output" section of OpenROAD
 
 ### Install Dependencies
 
-You may follow our helper script to install dependencies as follows:
+We recommend using the `setup.sh` script located in the [OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) repository to install all dependencies. `setup.sh` encapsulates the calls to `DependencyInstaller.sh` and ensures the entire flow environment is configured correctly.
+
+Alternatively, if you are building OpenROAD standalone, you may use our helper script:
 ``` shell
 sudo ./etc/DependencyInstaller.sh -base
 ./etc/DependencyInstaller.sh -common -local
 ```
 
-
 ```{warning}
 `sudo ./etc/DependencyInstaller.sh [-all|-common]` defaults to
 installing packages on /usr/local.
 To avoid this bahavior use -local flag or -prefix <PATH> argument.
-```
-
-The installer script natively supports the following arguments:
-```shell
-Options:
-  -all                        Install all dependencies (base and common). Requires privileged access.
-  -base                       Install base dependencies using package managers. Requires privileged access.
-  -common                     Install common dependencies.
-  -eqy                        Install equivalence dependencies (yosys, eqy, sby).
-  -prefix=DIR                 Install common dependencies in a user-specified directory.
-  -local                      Install common dependencies in ${HOME}/.local.
-  -ci                         Install dependencies required for CI.
-  -nocert                     Disable certificate checks for downloads.
-  -skip-system-or-tools       Skip searching for a system-installed or-tools library.
-  -save-deps-prefixes=FILE    Save OpenROAD build arguments to FILE.
-  -constant-build-dir         Use a constant build directory instead of a random one.
-  -threads=<N>                Limit the number of compiling threads.
-  -yosys-ver=<VERSION>        Specify a custom Yosys version. Used for ORFS.
-  -verbose                    Show all output from build commands.
-  -h, -help                   Show this help message.
 ```
 
 ### Build OpenROAD

--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -102,7 +102,9 @@ while [ "$#" -gt 0 ]; do
             cmakeOptions+=("-DENABLE_TESTS=OFF")
             ;;
         -ninja)
-            cmakeOptions+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache" "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache" "-GNinja")
+            cmakeOptions+=("-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+            cmakeOptions+=("-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+            cmakeOptions+=("-GNinja")
             isNinja=yes
             ;;
         -cpp20)
@@ -118,10 +120,12 @@ while [ "$#" -gt 0 ]; do
             cmakeOptions+=("-DALLOW_WARNINGS=OFF")
             ;;
         -coverage )
-            cmakeOptions+=("-DCMAKE_BUILD_TYPE=Debug" "-DCMAKE_CXX_FLAGS=-fprofile-arcs -ftest-coverage" "-DCMAKE_EXE_LINKER_FLAGS=-lgcov")
+            cmakeOptions+=("-DCMAKE_BUILD_TYPE=Debug")
+            cmakeOptions+=("-DCMAKE_CXX_FLAGS=-fprofile-arcs -ftest-coverage")
+            cmakeOptions+=("-DCMAKE_EXE_LINKER_FLAGS=-lgcov")
             ;;
         -cmake=*)
-            eval "temp_arr=(${1#*=})"
+            read -ra temp_arr <<< "${1#*=}"
             cmakeOptions+=("${temp_arr[@]}")
             ;;
         -clean )
@@ -167,11 +171,8 @@ if [[ -z "$depsPrefixesFile" ]]; then
     fi
 fi
 if [[ -f "$depsPrefixesFile" ]]; then
-    while read -r dep; do
-        if [[ -n "$dep" && "$dep" != \#* ]]; then
-            cmakeOptions+=("$dep")
-        fi
-    done < <(xargs -n1 < "$depsPrefixesFile")
+    read -ra newOpts <<< "$(cat "$depsPrefixesFile")"
+    cmakeOptions+=("${newOpts[@]}")
     echo "[INFO] Using additional CMake parameters from $depsPrefixesFile"
 else
     echo "[INFO] Auto-generated prefix file does not exist - CMake will choose the dependencies automatically"
@@ -223,6 +224,57 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
     export CMAKE_PREFIX_PATH=$(brew --prefix or-tools)
 fi
+
+# ==============================================================================
+# PRE-COMPILATION SYSTEM CHECKS
+# ==============================================================================
+if [[ -t 1 ]]; then
+    RED=$(tput setaf 1)
+    GREEN=$(tput setaf 2)
+    YELLOW=$(tput setaf 3)
+    NC=$(tput sgr0) # No Color
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    NC=''
+fi
+
+echo -e "${YELLOW}Running pre-compilation system checks...${NC}"
+
+check_command() {
+    if ! command -v "$1" &> /dev/null; then
+        echo -e "${RED}[ERROR] Required dependency '$1' is missing!${NC}"
+        echo "Please install it using 'sudo ./etc/DependencyInstaller.sh' before building."
+        exit 1
+    else
+        echo -e "${GREEN}[OK] Found $1${NC}"
+    fi
+}
+
+# Essential build tools required for OpenROAD
+check_command "cmake"
+check_command "bison"
+check_command "flex"
+check_command "swig"
+
+# Compiler check based on user selection
+if [[ "${compiler:-gcc}" == "gcc" ]]; then
+    check_command "gcc"
+    check_command "g++"
+elif [[ "${compiler}" == "clang" ]]; then
+    check_command "clang"
+    check_command "clang++"
+elif [[ "${compiler}" == "clang-16" ]]; then
+    check_command "clang-16"
+    check_command "clang++-16"
+else
+    # Handle unknown compilers gracefully - suggested by gemini-bot
+    echo -e "${YELLOW}[WARNING] Unsupported compiler '${compiler}' specified. Skipping compiler pre-compilation check.${NC}"
+fi
+
+echo -e "${GREEN}All pre-compilation checks passed! Proceeding...${NC}\n"
+# ==============================================================================
 
 echo "[INFO] Using ${numThreads} threads."
 if [[ "$isNinja" == "yes" ]]; then


### PR DESCRIPTION
## What does this PR do?
Fixes #4044.
In this PR we have:
- Documented all the functionality of DependencyInstaller.sh script (like able to do a local install without using sudo) in Build.md.
- Put the --help output  into Build.md
- Added the setup instructions as proposed by @mithro into Build.md.
```text
   # Install dependencies which come from the operating system (precompiled packages)
sudo ./etc/DependencyInstaller.sh -base  
# Install dependencies which are unavailable from the operating system into ~/.local (alternatively used --prefix=<preferred directory>. These can be removed with `rm -rf ~/.local`.
./etc/DependencyInstaller.sh -common -local
```
With these instructions if users follow they 
will install the **OpenRoad** dependencies to ~/.local 
rather directly into /usr/local which will make difficult for users to uninstall things later.

-  Now etc/build.sh also support -local and -prefix arguments that etc/DependencyInstaller.sh supports.
   Verification for build.sh script support for -local and -prefix arguments:
   1. verify -local argument:
   Run this command in your terminal:
```bash
   ./etc/Build.sh -local -cmake="-DRUN_CMAKE=OFF"
```
Output:
if you found the line saying  **-- Install prefix: /Users/username/.local**  ,you are good to go.


<img width="1376" height="1466" alt="image (3)" src="https://github.com/user-attachments/assets/fa290389-f286-4cc1-840a-e605fefb153d" />


2. verify -prefix argument:
Run this command on your terminal providing a custom OpenRoad folder .
```bash
./etc/Build.sh -prefix=/tmp/my_custom_openroad_folder -cmake="-DRUN_CMAKE=OFF"
```
Output:
if you see the line saying  **-- Install prefix: /tmp/my_custom_openroad_folder** ,then you are good to go.


<img width="1376" height="1518" alt="image (4)" src="https://github.com/user-attachments/assets/ff0fe159-186c-43d9-8e4a-7449539c0bf6" />
