### PR TITLE
bazel: use pkg_tar for the install procedure

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@
 load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//bazel:notification.bzl", "notification_rule")
@@ -411,5 +412,14 @@ sh_binary(
     name = "install",
     srcs = ["//bazel:install.sh"],
     args = [],
-    data = [":openroad"],
+    data = [":tarfile"],
+)
+
+pkg_tar(
+    name = "tarfile",
+    srcs = [
+        ":openroad",
+    ],
+    include_runfiles = True,
+    package_file_name = "openroad.tar",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,7 @@ bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_flex", version = "0.3.1")
 bazel_dep(name = "rules_jvm_external", version = "6.4")
 bazel_dep(name = "rules_python", version = "1.8.5")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
 
 # Used by chisel_binary from @bazel-orfs in test/orfs/mock-array
 bazel_dep(name = "rules_scala", version = "7.1.5")

--- a/bazel/install.sh
+++ b/bazel/install.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 set -e
-SOURCE_BINARY=$(cd $BUILD_WORKSPACE_DIRECTORY; bazelisk info bazel-bin)/openroad
 
-DEST_DIR="$BUILD_WORKSPACE_DIRECTORY/../install/OpenROAD/bin"
-DEST_FILE="$DEST_DIR/openroad"
+# Install binary and runfiles from bazel build
+
+TARFILE=$(cd $BUILD_WORKSPACE_DIRECTORY; bazelisk info bazel-bin)/openroad.tar
+
+DEST_DIR=${1:-${BUILD_WORKSPACE_DIRECTORY}/../install/OpenROAD/bin}
 
 mkdir -p "$DEST_DIR"
-cp -f -L "$SOURCE_BINARY" "$DEST_FILE"
-# runfiles
-mkdir -p "$DEST_DIR/openroad.runfiles"
-cp -f -L -r "$SOURCE_BINARY.runfiles/." "$DEST_DIR/openroad.runfiles/"
-chmod +x "$DEST_FILE"
+cp -f "$TARFILE" "$DEST_DIR"
+cd "$DEST_DIR"
+tar -xf openroad.tar
+rm -f openroad.tar
 
-echo "OpenROAD binary installed to $(realpath "$DEST_FILE")"
+# Remove useless files from pkg_tar from bazel
+if [ -e openroad.repo_mapping ]; then
+    chmod u+w openroad.repo_mapping
+    rm -rf openroad.repo_mapping
+fi
+rm -rf openroad.runfiles/_main
+
+echo "OpenROAD binary installed to $(realpath "$DEST_DIR")"

--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -21,9 +21,22 @@ Build OpenROAD with GUI support and install into ../install/OpenROAD/bin
 
     bazelisk run --//:platform=gui //:install
 
+To install to a custom location, e.g. /tmp/myinstall
+
+    bazelisk run --//:platform=gui //:install -- /tmp/myinstall
+
+To produce an openroad.tar file with install files
+
+    bazelisk build --//:platform=gui //:tarfile
+
+The tarfile is located at bazel-bin/openroad.tar.
+
 To embed the real git version string, add `--config=release`:
 
     bazelisk run --config=release --//:platform=gui //:install
+
+The install process will install the binary "openroad" and the runfile directory
+"openroad.runfiles" which contains runtime data needed by the binary.
 
 See [Bazel](Bazel.md) for more details on testing, profiling and build configurations.
 


### PR DESCRIPTION
I updated the install procedure to use the pkg_tar module. The install works as before, but now you
can also install optionally to another location.

Closes: #9635