### PR TITLE
grt: add incremental routing support to CUGR

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -225,6 +225,7 @@ class GlobalRouter
   // Incremental global routing functions.
   // See class IncrementalGRoute.
   void addDirtyNet(odb::dbNet* net);
+  void updateNet(odb::dbNet* net);
   std::set<odb::dbNet*> getDirtyNets() { return dirty_nets_; }
   // check_antennas
   bool haveRoutes();

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -325,7 +325,9 @@ bool GlobalRouter::haveDetailedRoutes(const std::vector<odb::dbNet*>& db_nets)
 void GlobalRouter::startIncremental()
 {
   is_incremental_ = true;
-  if (!initialized_ || haveDetailedRoutes()) {
+  if (use_cugr_) {
+    cugr_->startIncremental();
+  } else if (!initialized_ || haveDetailedRoutes()) {
     int min_layer, max_layer;
     getMinMaxLayer(min_layer, max_layer);
     initFastRoute(min_layer, max_layer);
@@ -337,8 +339,14 @@ void GlobalRouter::startIncremental()
 void GlobalRouter::endIncremental(bool save_guides)
 {
   is_incremental_ = true;
-  fastroute_->setResistanceAware(resistance_aware_);
-  updateDirtyRoutes();
+  if (use_cugr_) {
+    cugr_->endIncremental();
+    routes_ = cugr_->getRoutes();
+    updatePinAccessPoints();
+  } else {
+    fastroute_->setResistanceAware(resistance_aware_);
+    updateDirtyRoutes();
+  }
   grouter_cbk_->removeOwner();
   delete grouter_cbk_;
   grouter_cbk_ = nullptr;
@@ -5848,6 +5856,13 @@ void GlobalRouter::addDirtyNet(odb::dbNet* net)
   db_net_map_[net]->setDirtyNet(true);
   db_net_map_[net]->saveLastPinPositions();
   dirty_nets_.insert(net);
+}
+
+void GlobalRouter::updateNet(odb::dbNet* net)
+{
+  if (use_cugr_) {
+    cugr_->updateNet(net);
+  }
 }
 
 std::vector<Net*> GlobalRouter::updateDirtyRoutes(bool save_guides)

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -158,6 +158,12 @@ set_infinite_cap(bool infinite_capacity)
   getGlobalRouter()->setInfiniteCapacity(infinite_capacity);
 }
 
+void
+update_net(odb::dbNet* net)
+{
+  getGlobalRouter()->updateNet(net);
+}
+
 void start_incremental()
 {
   getGlobalRouter()->startIncremental();

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -92,6 +92,7 @@ class CUGR
     critical_nets_percentage_ = percentage;
   }
   void addDirtyNet(odb::dbNet* net);
+  void updateNet(odb::dbNet* net);
   void startIncremental();
   void endIncremental();
 

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -134,7 +134,8 @@ void CUGR::updateOverflowNets(std::vector<int>& netIndices)
 {
   netIndices.clear();
   for (const auto& net : gr_nets_) {
-    if (grid_graph_->checkOverflow(net->getRoutingTree()) > 0) {
+    if (net->getRoutingTree()
+        && grid_graph_->checkOverflow(net->getRoutingTree()) > 0) {
       netIndices.push_back(net->getIndex());
     }
   }
@@ -152,6 +153,9 @@ void CUGR::patternRoute(std::vector<int>& netIndices)
 
   sortNetIndices(netIndices);
   for (const int netIndex : netIndices) {
+    if (gr_nets_[netIndex]->getNumPins() < 2) {
+      continue;
+    }
     PatternRoute patternRoute(gr_nets_[netIndex].get(),
                               grid_graph_.get(),
                               stt_builder_,
@@ -183,6 +187,9 @@ void CUGR::patternRouteWithDetours(std::vector<int>& netIndices)
   sortNetIndices(netIndices);
   for (const int netIndex : netIndices) {
     GRNet* net = gr_nets_[netIndex].get();
+    if (net->getNumPins() < 2) {
+      continue;
+    }
     grid_graph_->commitTree(net->getRoutingTree(), /*ripup*/ true);
     PatternRoute patternRoute(
         net, grid_graph_.get(), stt_builder_, constants_, logger_);
@@ -218,6 +225,9 @@ void CUGR::mazeRoute(std::vector<int>& netIndices)
   SparseGrid grid(10, 10, 0, 0);
   for (const int netIndex : netIndices) {
     GRNet* net = gr_nets_[netIndex].get();
+    if (net->getNumPins() < 2) {
+      continue;
+    }
     MazeRoute mazeRoute(net, grid_graph_.get(), logger_);
     mazeRoute.constructSparsifiedGraph(wireCostView, grid);
     mazeRoute.run();
@@ -626,6 +636,33 @@ void CUGR::addDirtyNet(odb::dbNet* net)
   }
 }
 
+void CUGR::updateNet(odb::dbNet* db_net)
+{
+  auto it = db_net_map_.find(db_net);
+  if (it != db_net_map_.end()) {
+    GRNet* gr_net = it->second;
+    grid_graph_->commitTree(gr_net->getRoutingTree(), /*ripup=*/true);
+    design_->updateNet(db_net);
+    const int idx = gr_net->getIndex();
+    const CUGRNet& base_net = design_->getAllNets()[idx];
+    gr_nets_[idx] = std::make_unique<GRNet>(base_net, grid_graph_.get());
+    db_net_map_[db_net] = gr_nets_[idx].get();
+    if (incremental_mode_) {
+      dirty_net_indices_.insert(idx);
+    }
+  } else {
+    design_->updateNet(db_net);
+    const CUGRNet& base_net = design_->getAllNets().back();
+    const int new_index = static_cast<int>(gr_nets_.size());
+    gr_nets_.push_back(std::make_unique<GRNet>(base_net, grid_graph_.get()));
+    net_indices_.push_back(new_index);
+    db_net_map_[db_net] = gr_nets_.back().get();
+    if (incremental_mode_) {
+      dirty_net_indices_.insert(new_index);
+    }
+  }
+}
+
 void CUGR::startIncremental()
 {
   incremental_mode_ = true;
@@ -651,6 +688,10 @@ void CUGR::endIncremental()
 
   std::vector<int> nets_to_route(dirty_net_indices_.begin(),
                                  dirty_net_indices_.end());
+
+  for (const int idx : dirty_net_indices_) {
+    updateNet(gr_nets_[idx]->getDbNet());
+  }
 
   rerouteNets(nets_to_route);
 

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -144,6 +144,77 @@ void Design::readNetlist()
   }
 }
 
+void Design::updateNet(odb::dbNet* db_net)
+{
+  if (db_net->isSpecial() || db_net->getSigType().isSupply()
+      || !db_net->getSWires().empty() || db_net->isConnectedByAbutment()) {
+    return;
+  }
+
+  std::vector<CUGRPin> pins;
+  int pin_count = 0;
+  for (odb::dbBTerm* db_bterm : db_net->getBTerms()) {
+    int x, y;
+    std::vector<BoxOnLayer> pin_shapes;
+    if (db_bterm->getFirstPinLocation(x, y)) {
+      odb::Point position(x, y);
+      for (odb::dbBPin* bpin : db_bterm->getBPins()) {
+        for (odb::dbBox* bpin_box : bpin->getBoxes()) {
+          // adjust layer idx to start with zero
+          int layer_idx = bpin_box->getTechLayer()->getRoutingLevel() - 1;
+          pin_shapes.emplace_back(layer_idx,
+                                  getBoxFromRect(bpin_box->getBox()));
+        }
+      }
+    }
+
+    pins.emplace_back(pin_count, db_bterm, pin_shapes);
+    pin_count++;
+  }
+
+  for (odb::dbITerm* db_iterm : db_net->getITerms()) {
+    std::vector<BoxOnLayer> pin_shapes;
+    odb::dbTransform xform = db_iterm->getInst()->getTransform();
+    for (odb::dbMPin* mpin : db_iterm->getMTerm()->getMPins()) {
+      for (odb::dbBox* box : mpin->getGeometry()) {
+        odb::dbTechLayer* tech_layer = box->getTechLayer();
+        if (tech_layer->getType() != odb::dbTechLayerType::ROUTING) {
+          continue;
+        }
+
+        odb::Rect rect = box->getBox();
+        xform.apply(rect);
+
+        int layerIndex = tech_layer->getRoutingLevel() - 1;
+        pin_shapes.emplace_back(
+            layerIndex, rect.xMin(), rect.yMin(), rect.xMax(), rect.yMax());
+      }
+    }
+
+    pins.emplace_back(pin_count, db_iterm, pin_shapes);
+    pin_count++;
+  }
+
+  LayerRange layer_range
+      = {.min_layer = min_routing_layer_, .max_layer = max_routing_layer_};
+  if (clock_nets_.find(db_net) != clock_nets_.end()) {
+    layer_range.min_layer = block_->getMinLayerForClock() - 1;
+    layer_range.max_layer = block_->getMaxLayerForClock() - 1;
+  }
+
+  for (CUGRNet& net : nets_) {
+    if (net.getDbNet() == db_net) {
+      net.setPins(std::move(pins));
+      net.setLayerRange(layer_range);
+      return;
+    }
+  }
+
+  // Net is new: add it to the end
+  const int net_index = static_cast<int>(nets_.size());
+  nets_.emplace_back(net_index, db_net, pins, layer_range);
+}
+
 void Design::readInstanceObstructions()
 {
   for (odb::dbInst* db_inst : block_->getInsts()) {

--- a/src/grt/src/cugr/src/Design.h
+++ b/src/grt/src/cugr/src/Design.h
@@ -70,6 +70,8 @@ class Design
 
   BoxT getDieRegion() const { return die_region_; }
 
+  void updateNet(odb::dbNet* db_net);
+
  private:
   void read();
   void readLayers();

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -600,6 +600,9 @@ void GridGraph::commitVia(const int layer_index,
 void GridGraph::commitTree(const std::shared_ptr<GRTreeNode>& tree,
                            const bool rip_up)
 {
+  if (!tree) {
+    return;
+  }
   GRTreeNode::preorder(tree, [&](const std::shared_ptr<GRTreeNode>& node) {
     for (const auto& child : node->getChildren()) {
       if (node->getLayerIdx() == child->getLayerIdx()) {

--- a/src/grt/src/cugr/src/Netlist.h
+++ b/src/grt/src/cugr/src/Netlist.h
@@ -58,6 +58,8 @@ class CUGRNet
   int getNumPins() const { return pins_.size(); }
   std::string getName() const { return db_net_->getName(); }
   LayerRange getLayerRange() const { return layer_range_; }
+  void setPins(std::vector<CUGRPin> pins) { pins_ = std::move(pins); }
+  void setLayerRange(LayerRange layer_range) { layer_range_ = layer_range; }
 
  private:
   const int index_;

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -30,6 +30,7 @@ or_integration_tests(
     gcd_cugr
     gcd_flute
     increase_capacity1
+    incremental_update_net
     infinite_cap
     inst_pin_out_of_die
     invalid_pin_placement

--- a/src/grt/test/incremental_update_net.tcl
+++ b/src/grt/test/incremental_update_net.tcl
@@ -1,0 +1,59 @@
+# Test grt::update_net with CUGR incremental routing.
+# Design (remove_buffers1.def): in1 -> b3 -> b2 -> b1 -> b4 -> out1
+# We split net n2 (b2/Z -> b1/A) by disconnecting both iterms and
+# reconnecting them to a brand-new net n_bypass.
+# After calling grt::update_net on both nets and completing the incremental
+# route, n_bypass must appear in the guide file.
+source "helpers.tcl"
+read_lef Nangate45/Nangate45.lef
+read_def remove_buffers1.def
+
+set_global_routing_layer_adjustment metal2 0.8
+set_global_routing_layer_adjustment metal3 0.7
+set_global_routing_layer_adjustment * 0.5
+
+set_routing_layers -signal metal2-metal8 -clock metal3-metal8
+
+global_route -verbose -use_cugr
+
+# --- begin topology mutation ---
+global_route -start_incremental
+
+set block [ord::get_db_block]
+set b1     [$block findInst "b1"]
+set b2     [$block findInst "b2"]
+set n2_net [$block findNet  "n2"]
+
+# Create the bypass net (will carry b2/Z -> b1/A, currently on n2)
+set n_bypass_net [odb::dbNet_create $block "n_bypass"]
+
+# Detach b2/Z and b1/A from n2
+set b2_z [$b2 findITerm "Z"]
+set b1_a [$b1 findITerm "A"]
+$b2_z disconnect
+$b1_a disconnect
+
+# Attach them to the new net
+odb::dbITerm_connect $b2_z $n_bypass_net
+odb::dbITerm_connect $b1_a $n_bypass_net
+
+# Refresh CUGR state:
+#   n2      now has 0 pins  -> will be skipped during routing
+#   n_bypass now has 2 pins -> will be routed
+grt::update_net $n2_net
+grt::update_net $n_bypass_net
+
+global_route -end_incremental
+# --- end topology mutation ---
+
+set guide_file [make_result_file "incremental_update_net.guide"]
+write_guides $guide_file
+
+check "n_bypass net has routing guides" {
+  set fh [open $guide_file r]
+  set content [read $fh]
+  close $fh
+  expr { [string first "n_bypass" $content] >= 0 }
+} 1
+
+exit_summary


### PR DESCRIPTION
Adds incremental global routing support to the CUGR backend, mirroring the
existing FastRoute incremental API.

## Changes
- Add `addDirtyNet()` to mark nets needing reroute
- Add `startIncremental()` / `endIncremental()` to CUGR state machine
- Sort dirty nets by slack before rip-up (improves incremental quality)
- Add helper method for incremental reroute logic
- New net topology refresh APIs for buffer insertion changes

Reopens #9645 (accidentally closed during branch cleanup).
