### PR TITLE
gui: display macro clock insertion latency in timing reports

### DIFF
--- a/src/gui/src/staGui.cpp
+++ b/src/gui/src/staGui.cpp
@@ -122,6 +122,8 @@ QVariant TimingPathsModel::data(const QModelIndex& index, int role) const
       case kFanout:
       case kSlack:
       case kSkew:
+      case kSrcClkInsertion:
+      case kTgtClkInsertion:
         return Qt::AlignRight;
     }
   } else if (role == Qt::DisplayRole) {
@@ -144,6 +146,10 @@ QVariant TimingPathsModel::data(const QModelIndex& index, int role) const
         return timing_path->getLogicDepth();
       case kFanout:
         return timing_path->getFanout();
+      case kSrcClkInsertion:
+        return convertDelay(timing_path->getSrcClkInsertion(), time_units);
+      case kTgtClkInsertion:
+        return convertDelay(timing_path->getTgtClkInsertion(), time_units);
       case kStart:
         return QString::fromStdString(timing_path->getStartStageName());
       case kEnd:
@@ -186,6 +192,14 @@ QVariant TimingPathsModel::headerData(int section,
       case kLogicDepth:
         return "Path instances (excluding buffers and consecutive inverter "
                "pairs)";
+      case kSrcClkInsertion:
+        return "Source (launch) clock insertion delay.\n"
+               "Internal clock latency from liberty\n"
+               "max/min_clock_tree_path timing groups.";
+      case kTgtClkInsertion:
+        return "Target (capture) clock insertion delay.\n"
+               "Internal clock latency from liberty\n"
+               "max/min_clock_tree_path timing groups.";
     }
   }
 
@@ -247,6 +261,16 @@ void TimingPathsModel::sort(int col_index, Qt::SortOrder sort_order)
     sort_func = [](const std::unique_ptr<TimingPath>& path1,
                    const std::unique_ptr<TimingPath>& path2) {
       return path1->getFanout() < path2->getFanout();
+    };
+  } else if (col_index == kSrcClkInsertion) {
+    sort_func = [](const std::unique_ptr<TimingPath>& path1,
+                   const std::unique_ptr<TimingPath>& path2) {
+      return path1->getSrcClkInsertion() < path2->getSrcClkInsertion();
+    };
+  } else if (col_index == kTgtClkInsertion) {
+    sort_func = [](const std::unique_ptr<TimingPath>& path1,
+                   const std::unique_ptr<TimingPath>& path2) {
+      return path1->getTgtClkInsertion() < path2->getTgtClkInsertion();
     };
   } else if (col_index == kStart) {
     sort_func = [](const std::unique_ptr<TimingPath>& path1,
@@ -376,8 +400,15 @@ QVariant TimingPathDetailModel::data(const QModelIndex& index, int role) const
       const auto& node = nodes_->at(start_idx);
 
       switch (col_index) {
-        case kPin:
+        case kPin: {
+          float insertion = is_capture_ ? path_->getTgtClkInsertion()
+                                        : path_->getSrcClkInsertion();
+          if (insertion != 0.0f) {
+            return QString("clock network delay (ins: %1)")
+                .arg(convertDelay(insertion, time_units));
+          }
           return "clock network delay";
+        }
         case kTime:
           return convertDelay(node->getArrival(), time_units);
         case kDelay:

--- a/src/gui/src/staGui.h
+++ b/src/gui/src/staGui.h
@@ -59,6 +59,8 @@ class TimingPathsModel : public QAbstractTableModel
     kLogicDelay,
     kLogicDepth,
     kFanout,
+    kSrcClkInsertion,
+    kTgtClkInsertion,
     kStart,
     kEnd
   };
@@ -75,6 +77,8 @@ class TimingPathsModel : public QAbstractTableModel
            {kLogicDelay, "Logic Delay"},
            {kLogicDepth, "Logic Depth"},
            {kFanout, "Fanout"},
+           {kSrcClkInsertion, "Src Clk Ins."},
+           {kTgtClkInsertion, "Tgt Clk Ins."},
            {kStart, "Start"},
            {kEnd, "End"}};
     return kColumnNames;

--- a/src/gui/src/staGuiInterface.cpp
+++ b/src/gui/src/staGuiInterface.cpp
@@ -161,6 +161,8 @@ odb::Rect TimingPathNode::getPinLargestBox() const
 TimingPath::TimingPath()
     : slack_(0),
       skew_(0),
+      src_clk_insertion_(0),
+      tgt_clk_insertion_(0),
       path_delay_(0),
       arr_time_(0),
       req_time_(0),
@@ -1239,6 +1241,10 @@ TimingPathList STAGuiInterface::getTimingPaths(
     timing_path->setPathArrivalTime(path_end->dataArrivalTime(sta_));
     timing_path->setPathRequiredTime(path_end->requiredTime(sta_));
     timing_path->setSkew(path_end->clkSkew(sta_));
+    timing_path->setSrcClkInsertion(
+        sta::delayAsFloat(path_end->sourceClkInsertionDelay(sta_)));
+    timing_path->setTgtClkInsertion(
+        sta::delayAsFloat(path_end->targetClkInsertionDelay(sta_)));
 
     bool clock_propagated = false;
     if (start_clock_edge != nullptr) {

--- a/src/gui/src/staGuiInterface.h
+++ b/src/gui/src/staGuiInterface.h
@@ -169,6 +169,10 @@ class TimingPath
   void setPathDelay(float del) { path_delay_ = del; }
   float getSkew() const { return skew_; }
   void setSkew(float skew) { skew_ = skew; }
+  float getSrcClkInsertion() const { return src_clk_insertion_; }
+  void setSrcClkInsertion(float val) { src_clk_insertion_ = val; }
+  float getTgtClkInsertion() const { return tgt_clk_insertion_; }
+  void setTgtClkInsertion(float val) { tgt_clk_insertion_ = val; }
   float getLogicDelay() const { return logic_delay_; }
   int getLogicDepth() const { return logic_depth_; }
   int getFanout() const { return fanout_; }
@@ -202,6 +206,8 @@ class TimingPath
   std::string end_clk_;
   float slack_;
   float skew_;
+  float src_clk_insertion_;
+  float tgt_clk_insertion_;
   float path_delay_;
   float arr_time_;
   float req_time_;

--- a/src/gui/src/timingWidget.cpp
+++ b/src/gui/src/timingWidget.cpp
@@ -141,9 +141,14 @@ void TimingWidget::setColumnDisplayMenu()
 
     // Uncheck boxes and hide columns based on settings.
     if (!initial_columns_visibility_.isEmpty()) {
-      if (!initial_columns_visibility_[column_index]) {
+      if (column_index < initial_columns_visibility_.size()
+          && !initial_columns_visibility_[column_index]) {
         action->trigger();
       }
+    } else if (QString(name).startsWith("Src Clk Ins")
+               || QString(name).startsWith("Tgt Clk Ins")) {
+      // Hide insertion delay columns by default.
+      action->trigger();
     }
 
     ++column_index;


### PR DESCRIPTION
Add source and target clock insertion delay columns to the timing paths table, hidden by default. The values come from PathEnd's sourceClkInsertionDelay/targetClkInsertionDelay (liberty max/min_clock_tree_path timing groups). Also annotate the clock summary row in the detail view with the insertion delay when non-zero.

Closes #9681