### PR TITLE
Fix GUI crash rendering when Acess Points or Gcell grid is enabled 

### DIFF
--- a/src/gui/src/renderThread.cpp
+++ b/src/gui/src/renderThread.cpp
@@ -314,6 +314,7 @@ bool RenderThread::instanceBelowMinSize(dbInst* inst)
 
 void RenderThread::drawTracks(dbTechLayer* layer,
                               QPainter* painter,
+                              odb::dbBlock* block,
                               const Rect& bounds)
 {
   if (!viewer_->options_->arePrefTracksVisible()
@@ -321,12 +322,16 @@ void RenderThread::drawTracks(dbTechLayer* layer,
     return;
   }
 
-  dbTrackGrid* grid = viewer_->getBlock()->findTrackGrid(layer);
+  if (block == nullptr) {
+    return;
+  }
+
+  dbTrackGrid* grid = block->findTrackGrid(layer);
   if (!grid) {
     return;
   }
 
-  Rect block_bounds = viewer_->getBlock()->getDieArea();
+  Rect block_bounds = block->getDieArea();
   if (!block_bounds.intersects(bounds)) {
     return;
   }
@@ -1104,7 +1109,7 @@ void RenderThread::drawLayer(QPainter* painter,
                  io_pins);
     }
 
-    drawTracks(layer, painter, bounds);
+    drawTracks(layer, painter, block, bounds);
     drawRouteGuides(gui_painter, layer);
     drawNetTracks(gui_painter, layer);
   }
@@ -1196,7 +1201,7 @@ void RenderThread::drawChip(QPainter* painter,
     gui_painter.drawPolygon(core_area);
   }
 
-  drawManufacturingGrid(painter, bounds);
+  drawManufacturingGrid(painter, block, bounds);
   debugPrint(logger_,
              GUI,
              "draw",
@@ -1240,28 +1245,30 @@ void RenderThread::drawChip(QPainter* painter,
   debugPrint(logger_, GUI, "draw", 1, "blockages {}", inst_blockages);
 
   dbTech* tech = block->getTech();
-  std::set<dbTech*> child_techs;
-  for (auto child : block->getChildren()) {
-    dbTech* child_tech = child->getTech();
-    if (child_tech != tech) {
-      child_techs.insert(child_tech);
+  if (tech != nullptr) {
+    std::set<dbTech*> child_techs;
+    for (auto child : block->getChildren()) {
+      dbTech* child_tech = child->getTech();
+      if (child_tech != tech) {
+        child_techs.insert(child_tech);
+      }
     }
-  }
 
-  for (dbTech* child_tech : child_techs) {
-    for (dbTechLayer* layer : child_tech->getLayers()) {
+    for (dbTech* child_tech : child_techs) {
+      for (dbTechLayer* layer : child_tech->getLayers()) {
+        if (restart_) {
+          break;
+        }
+        drawLayer(painter, block, layer, insts, bounds, gui_painter);
+      }
+    }
+
+    for (dbTechLayer* layer : tech->getLayers()) {
       if (restart_) {
         break;
       }
       drawLayer(painter, block, layer, insts, bounds, gui_painter);
     }
-  }
-
-  for (dbTechLayer* layer : tech->getLayers()) {
-    if (restart_) {
-      break;
-    }
-    drawLayer(painter, block, layer, insts, bounds, gui_painter);
   }
 
   utl::Timer inst_names;
@@ -1291,25 +1298,31 @@ void RenderThread::drawChip(QPainter* painter,
   debugPrint(logger_, GUI, "draw", 1, "regions {}", inst_regions);
 
   utl::Timer inst_cell_grid;
-  drawGCellGrid(painter, bounds);
+  drawGCellGrid(painter, block, bounds);
   debugPrint(logger_, GUI, "draw", 1, "save cell grid {}", inst_cell_grid);
 
   debugPrint(logger_, GUI, "draw", 1, "total render {}", timer);
 }
 
-void RenderThread::drawGCellGrid(QPainter* painter, const odb::Rect& bounds)
+void RenderThread::drawGCellGrid(QPainter* painter,
+                                 odb::dbBlock* block,
+                                 const odb::Rect& bounds)
 {
   if (!viewer_->options_->isGCellGridVisible()) {
     return;
   }
 
-  odb::dbGCellGrid* grid = viewer_->getBlock()->getGCellGrid();
+  if (block == nullptr) {
+    return;
+  }
+
+  odb::dbGCellGrid* grid = block->getGCellGrid();
 
   if (grid == nullptr) {
     return;
   }
 
-  const auto die_area = viewer_->getBlock()->getDieArea();
+  const auto die_area = block->getDieArea();
 
   if (!bounds.intersects(die_area)) {
     return;
@@ -1347,14 +1360,19 @@ void RenderThread::drawGCellGrid(QPainter* painter, const odb::Rect& bounds)
 }
 
 void RenderThread::drawManufacturingGrid(QPainter* painter,
+                                         odb::dbBlock* block,
                                          const odb::Rect& bounds)
 {
   if (!viewer_->options_->isManufacturingGridVisible()) {
     return;
   }
 
-  odb::dbTech* tech = viewer_->getBlock()->getDb()->getTech();
-  if (!tech->hasManufacturingGrid()) {
+  if (block == nullptr) {
+    return;
+  }
+
+  odb::dbTech* tech = block->getTech();
+  if (tech == nullptr || !tech->hasManufacturingGrid()) {
     return;
   }
 
@@ -1514,6 +1532,9 @@ void RenderThread::drawAccessPoints(Painter& painter,
   }
 
   odb::dbTech* tech = block->getTech();
+  if (tech == nullptr) {
+    return;
+  }
   for (odb::dbTechLayer* layer : tech->getLayers()) {
     for (const auto& [box, pin] : viewer_->search_.searchBPins(block,
                                                                layer,

--- a/src/gui/src/renderThread.h
+++ b/src/gui/src/renderThread.h
@@ -83,6 +83,7 @@ class RenderThread : public QThread
   void drawRegions(QPainter* painter, odb::dbBlock* block);
   void drawTracks(odb::dbTechLayer* layer,
                   QPainter* painter,
+                  odb::dbBlock* block,
                   const odb::Rect& bounds);
 
   void drawInstanceOutlines(QPainter* painter,
@@ -120,8 +121,12 @@ class RenderThread : public QThread
                      odb::dbTechLayer* draw_layer,
                      const odb::Rect& bounds,
                      int shape_limit);
-  void drawManufacturingGrid(QPainter* painter, const odb::Rect& bounds);
-  void drawGCellGrid(QPainter* painter, const odb::Rect& bounds);
+  void drawManufacturingGrid(QPainter* painter,
+                             odb::dbBlock* block,
+                             const odb::Rect& bounds);
+  void drawGCellGrid(QPainter* painter,
+                     odb::dbBlock* block,
+                     const odb::Rect& bounds);
   void drawSelected(Painter& painter, const SelectionSet& selected);
   void drawHighlighted(Painter& painter, const HighlightSet& highlighted);
   void drawIOPins(Painter& painter,


### PR DESCRIPTION
## What does this PR resolves?
Fixes #8927

Resolves GUI crash that occurred when enabling Access Points or GCell grid display options after reading a 3DBX chiplet design.

## What have caused this issue?
The rendering functions `drawTracks`, `drawManufacturingGrid`, and `drawGCellGrid` used `viewer_->getBlock()`, which returns the top-level HIER chip's block (nullptr in 3DBX designs) instead of the per-chiplet block being rendered. This caused null pointer dereference crashes.

Additionally, `drawAccessPoints` and `drawChip` lacked nullptr guards for `block->getTech()` before iterating technology layers.

## Changes made to resolve this
- **renderThread.h / renderThread.cpp**: 
  - Added `odb::dbBlock* block` parameter to `drawTracks`, `drawManufacturingGrid`, and `drawGCellGrid`
  - Replaced all `viewer_->getBlock()` calls with the passed-in `block` parameter
  - Added nullptr guards for `block` and `block->getTech()` before dereferencing
  - Wrapped layer iteration in `drawChip` with `if (tech != nullptr)` check





