### PR TITLE
bazel: disable ABC warnings by default via build flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -64,6 +64,9 @@ build --copt "-Wno-dangling"  --host_copt "-Wno-dangling"
 build --per_file_copt=.*external/.*@-w
 build --host_per_file_copt=.*external/.*@-w
 
+# Opt-in config to surface warnings from the vendored ABC library.
+build:abc_warnings --//bazel/build_settings:abc_enable_warnings=true
+
 ##### Platform-specific configs (auto-selected) #############
 # --enable_platform_specific_config makes bazel automatically apply
 # build:macos on macOS, build:linux on Linux, etc.

--- a/bazel/build_settings/BUILD
+++ b/bazel/build_settings/BUILD
@@ -1,0 +1,7 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "abc_enable_warnings",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
During Bazel builds of OpenROAD, the vendored ABC sources emit several compiler warnings (e.g., -Wmissing-field-initializers, -Wimplicit-int-float-conversion). Because these originate from third-party code, they tend to drown out warnings produced by OpenROAD itself, making actionable warnings harder to identify.

This change suppresses warnings from the vendored ABC sources by default while still allowing developers to enable them when needed.

Implementation

Introduced a global Bazel build setting
//bazel/build_settings:abc_enable_warnings (default: false).

When the flag is disabled (default), -w is appended to ABC compilation options to silence warnings from the vendored sources.

When the flag is enabled, the suppression is removed and ABC warnings are emitted normally.

Added a convenience Bazel config in .bazelrc:

--config=abc_warnings

which enables the flag for developers who want to inspect ABC warnings.

The build setting is defined in bazel/build_settings rather than third-party/abc because the latter is excluded from direct Bazel package resolution via --deleted_packages.

No modifications were made to the ABC source code.