### PR TITLE
WIP: Ubuntu CI build and .deb packaging workflow - Stable Build

### DIFF
--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - ubuntu-build
   workflow_dispatch:
+
 jobs:
   build:
     name: Compile OpenROAD
@@ -42,12 +43,16 @@ jobs:
           mkdir -p package/usr/lib/openroad
           mkdir -p package/DEBIAN
 
+          # copy binary
           cp build/bin/openroad package/usr/bin/
 
-          # copy OR-Tools runtime library
-          cp ~/.local/lib/libortools.so* package/usr/lib/openroad/ || true
+          # copy runtime libraries
+          cp ~/.local/lib/*.so* package/usr/lib/openroad/ || true
 
-          # set runtime path
+          # reduce binary size
+          strip package/usr/bin/openroad || true
+
+          # set runtime path so binary finds local libs
           patchelf --set-rpath '$ORIGIN/../lib/openroad' package/usr/bin/openroad
 
       - name: Create Control File

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -1,0 +1,35 @@
+name: Ubuntu Stable Build
+
+on:
+  push:
+    branches:
+      - ubuntu-build
+jobs:
+  build:
+    name: Compile OpenROAD
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update System
+        run: |
+          sudo apt update
+          sudo apt upgrade -y
+
+      - name: Install Dependencies
+        run: |
+          sudo ./etc/DependencyInstaller.sh -base
+          ./etc/DependencyInstaller.sh -common -local
+
+      - name: Build OpenROAD
+        run: |
+          ./etc/Build.sh
+
+      - name: Check Binary
+        run: |
+          ls build/bin
+          ./build/bin/openroad -version

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -59,8 +59,6 @@ jobs:
           cat <<EOF > package/DEBIAN/control
           Package: openroad
           Version: 1.0
-          Section: electronics
-          Priority: optional
           Architecture: amd64
           Maintainer: Hemant Kumar
           Description: OpenROAD physical design automation tool

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - ubuntu-build
+
 jobs:
   build:
     name: Compile OpenROAD
@@ -29,7 +30,41 @@ jobs:
         run: |
           ./etc/Build.sh
 
-      - name: Check Binary
+      - name: Verify Binary
         run: |
           ls build/bin
           ./build/bin/openroad -version
+
+      - name: Create Debian Package
+        run: |
+          mkdir -p package/usr/bin
+          cp build/bin/openroad package/usr/bin/
+
+          mkdir -p package/DEBIAN
+          cat <<EOF > package/DEBIAN/control
+          Package: openroad
+          Version: 1.0
+          Section: electronics
+          Priority: optional
+          Architecture: amd64
+          Maintainer: Hemant Kumar
+          Description: OpenROAD physical design automation tool
+          EOF
+
+          dpkg-deb --build package openroad_amd64.deb
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openroad-deb
+          path: openroad_amd64.deb
+
+      - name: Create Pre Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ubuntu-build-${{ github.run_number }}
+          name: OpenROAD Pre-release
+          prerelease: true
+          files: openroad_amd64.deb
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -3,7 +3,7 @@ name: Ubuntu Stable Build
 on:
   push:
     branches:
-      - ubuntu-build
+      - master
 
 jobs:
   build:

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - ubuntu-build
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - ubuntu-build
-
+  workflow_dispatch:
 jobs:
   build:
     name: Compile OpenROAD

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -61,7 +61,7 @@ jobs:
           Version: 1.0
           Architecture: amd64
           Maintainer: Hemant Kumar
-          Description: OpenROAD physical design automation tool
+          Description: OpenROAD is an integrated chip physical design tool that takes a design from synthesized Verilog to routed layout.
           EOF
 
       - name: Build Debian Package

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt upgrade -y
+          sudo apt install -y patchelf
 
       - name: Install Dependencies
         run: |
@@ -35,12 +36,22 @@ jobs:
           ls build/bin
           ./build/bin/openroad -version
 
-      - name: Create Debian Package
+      - name: Prepare Package Structure
         run: |
           mkdir -p package/usr/bin
+          mkdir -p package/usr/lib/openroad
+          mkdir -p package/DEBIAN
+
           cp build/bin/openroad package/usr/bin/
 
-          mkdir -p package/DEBIAN
+          # copy OR-Tools runtime library
+          cp ~/.local/lib/libortools.so* package/usr/lib/openroad/ || true
+
+          # set runtime path
+          patchelf --set-rpath '$ORIGIN/../lib/openroad' package/usr/bin/openroad
+
+      - name: Create Control File
+        run: |
           cat <<EOF > package/DEBIAN/control
           Package: openroad
           Version: 1.0
@@ -51,6 +62,8 @@ jobs:
           Description: OpenROAD physical design automation tool
           EOF
 
+      - name: Build Debian Package
+        run: |
           dpkg-deb --build package openroad_amd64.deb
 
       - name: Upload Artifact
@@ -67,4 +80,4 @@ jobs:
           prerelease: true
           files: openroad_amd64.deb
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -74,14 +74,14 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: openroad-deb
-          path: openroad_amd64.deb
+          path: openroad_stable-release-${{ github.run_number }}.deb
 
       - name: Create Pre Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ubuntu-build-${{ github.run_number }}
+          tag_name: ubuntu-stable-release-${{ github.run_number }}
           name: OpenROAD Pre-release
           prerelease: true
-          files: openroad_amd64.deb
+          files: openroad_stable-release-${{ github.run_number }}.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-stable-ubuntu-build.yaml
+++ b/.github/workflows/github-actions-stable-ubuntu-build.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build Debian Package
         run: |
-          dpkg-deb --build package openroad_amd64.deb
+          dpkg-deb --build package openroad_stable-release-${{ github.run_number }}.deb
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR adds a **GitHub Actions CI workflow** ([github-actions-stable-ubuntu-build.yaml](cci:7://file:///home/hemant-kumar/Developer/OpenROAD/.github/workflows/github-actions-stable-ubuntu-build.yaml:0:0-0:0)) that automatically builds OpenROAD from source on Ubuntu and packages it as a ready-to-install `.deb` file.

### Workflow Steps

1. **Checkout** — Clones the repo with all submodules
2. **System Update** — Updates packages and installs `patchelf`
3. **Install Dependencies** — Runs `DependencyInstaller.sh` for base and common dependencies
4. **Build** — Compiles OpenROAD using [Build.sh](cci:7://file:///home/hemant-kumar/Developer/OpenROAD/etc/Build.sh:0:0-0:0)
5. **Verify** — Confirms the binary was built successfully
6. **Package** — Creates a Debian package (`openroad_amd64.deb`) with:
   - Binary at [/usr/bin/openroad](cci:7://file:///usr/bin/openroad:0:0-0:0)
   - Runtime libraries bundled under `/usr/lib/openroad/`
   - `RPATH` patched via `patchelf` so the binary finds its bundled libs
   - Binary stripped to reduce size
7. **Upload Artifact** — Attaches the `.deb` as a downloadable build artifact
8. **Create Pre-Release** — Publishes a GitHub pre-release with the `.deb` file

### Trigger

- Push to `master` branch

### Prerequisites

> [!IMPORTANT]
> This workflow uses `${{ secrets.GITHUB_TOKEN }}` to create GitHub releases. The token is automatically provided by GitHub Actions, but ensure your repository has **Settings → Actions → General → Workflow permissions** set to **"Read and write permissions"**.

### How to Install

```bash
sudo apt install ./openroad_amd64.deb
openroad -version
openroad -gui
```
