### PR TITLE
docs: update bazel-orfs deploy paths to use default tmp/ location

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -4,3 +4,4 @@ src/sta/build/
 src/sta/debug/
 # we use abc from MODULE.bazel
 third-party/abc/
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ user.bazelrc
 # Limit ignore to these files, so we see and clean out other cruft that pollutes grep
 /bazel-*
 
+tmp/
+
 projectview.bazelproject
 .bsp/
 .bazelbsp/

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -178,28 +178,23 @@ Consider a failure in `//test/orfs/mock-array:MockArray_floorplan` as one can fi
 
 To create an ORFS `make issue`, follow these steps:
 
-    rm -rf /tmp/floorplan
-    bazelisk run //test/orfs/mock-array:MockArray_floorplan_deps /tmp/floorplan
+    bazelisk run //test/orfs/mock-array:MockArray_floorplan_deps
 
 - In Bazel `//test/orfs/mock-array:MockArray_floorplan` failed and will leave behind no files, unless one uses `--sandbox_debug`
 - bazel-orfs adds a `//test/orfs/mock-array:MockArray_floorplan_deps` target that sets up all the dependencies for running `make do-floorplan`, similarly for `_synth/place/cts/grt/route/final`.
-- `tmp/floorplan` folder that contains a `make` script that is very nearly the same as `make DESIGN_CONFIG=...` with ORFS
+- Files are placed in `tmp/test/orfs/mock-array/MockArray_floorplan_deps/` with a `make` script that is very nearly the same as `make DESIGN_CONFIG=...` with ORFS
 
 First run `do-floorplan` until the failure, notice that the `do-` prefix is used to disable the dependency checking in ORFS as bazel-orfs handles dependencies:
 
-    /tmp/floorplan/make do-floorplan
+    tmp/test/orfs/mock-array/MockArray_floorplan_deps/make do-floorplan
 
 Now create an issue for e.g. `macro_place.tcl`:
 
-    $ /tmp/floorplan/make macro_place_issue
-    ++ dirname /tmp/floorplan/make
-    + cd /tmp/floorplan/_main
-    + exec ./make_MockArray_floorplan_base_2_floorplan floorplan_issue
-    [deleted]
+    tmp/test/orfs/mock-array/MockArray_floorplan_deps/make macro_place_issue
 
-The generated file is placed into /tmp/floorplan/_main:
+The generated file is placed into the `_main` subfolder:
 
-    /tmp/floorplan/_main/macro_place_MockArray_asap7_base_2025-06-19_21-50.tar.gz
+    tmp/test/orfs/mock-array/MockArray_floorplan_deps/_main/macro_place_MockArray_asap7_base_2025-06-19_21-50.tar.gz
 
 ## Creating an ORFS issue with bazel-orfs targets using `--sandbox_debug`
 
@@ -356,7 +351,7 @@ To test a PR with the GUI on gcd, run:
 ```
     $ git fetch origin pull/7856/head
     $ git checkout FETCH_HEAD
-    $ bazelisk run test/orfs/gcd:gcd_final /tmp/gcd -- gui_final
+    $ bazelisk run test/orfs/gcd:gcd_final gui_final
 ```
 
 This will:
@@ -364,20 +359,20 @@ This will:
 - fetch and checkout pull request 7856
 - build OpenROAD
 - run bazel-orfs flow on gcd
-- create a /tmp/gcd folder with the ORFS project
+- set up ORFS project in `tmp/test/orfs/gcd/gcd_final/`
 - launch the GUI opening gui_final gcd
 
-`bazelisk run test/orfs/gcd:gcd_final` run alone would create the `/tmp/gcd` folder and the arguments. The arguments after `--` are forwarded to the `/tmp/gcd/make` script that invokes make with the gcd ORFS project set up in `/tmp/gcd/_main/config.mk`.
+`bazelisk run test/orfs/gcd:gcd_final` run alone would set up the project. Additional arguments are forwarded to the `tmp/test/orfs/gcd/gcd_final/make` script.
 
 ## Hacking ORFS with `//test/orfs/gcd:gcd_test` test case
 
-First create a local work folder with all dependencies for the step that you want to work on:
+First set up a local work folder with all dependencies for the step that you want to work on:
 
-    bazelisk run //test/orfs/gcd:gcd_floorplan_deps /tmp/floorplan
+    bazelisk run //test/orfs/gcd:gcd_floorplan_deps
 
-Now run make directly with the `/tmp/floorplan/_main` work folder, but be sure to use the `do-` targets that side-step ORFS make dependency checking:
+Now run make directly with the work folder, but be sure to use the `do-` targets that side-step ORFS make dependency checking:
 
-    make --file ~/OpenROAD-flow-scripts/flow/Makefile --dir /tmp/floorplan/_main DESIGN_CONFIG=config.mk do-floorplan
+    make --file ~/OpenROAD-flow-scripts/flow/Makefile --dir tmp/test/orfs/gcd/gcd_floorplan_deps/_main DESIGN_CONFIG=config.mk do-floorplan
 
 ## Whittling down .odb files with deltaDebug.py
 
@@ -387,14 +382,14 @@ Consider an error such as:
 
     [ERROR GPL-0305] RePlAce diverged during gradient descent calculation, resulting in an invalid step length (Inf or NaN). This is often caused by numerical instability or high placement density. Consider reducing placement density to potentially resolve the issue.
 
-First create a folder with all the dependencies to run global placement:
+First set up a folder with all the dependencies to run global placement:
 
-    bazelisk run //test/orfs/gcd:gcd_deps /tmp/bug
+    bazelisk run //test/orfs/gcd:gcd_place_deps
 
 Drop into a shell that has the build environment set up:
 
-    $ /tmp/bug/make bash
-    Makefile Environment  /tmp/bug/_main
+    $ tmp/test/orfs/gcd/gcd_place_deps/make bash
+    Makefile Environment  tmp/test/orfs/gcd/gcd_place_deps/_main
 
 Run up to the failing stage and stop with ctrl-c on the step that you want to run the whittling down on:
 
@@ -406,4 +401,4 @@ Now run deltaDebug.py:
 
 This should eventually leave you with a whittled down .odb file. Copy the whittled down .odb file into the correct place for 3_2_place_iop.odb, then create a bug report:
 
-    /tmp/bug/make global_place_issue
+    tmp/test/orfs/gcd/gcd_place_deps/make global_place_issue

--- a/test/orfs/README.md
+++ b/test/orfs/README.md
@@ -47,24 +47,20 @@ From bottom you again find "error executing Action" and the relevant action:
 
 Debugging using the Bazel `--sandbox_debug` is possible, but not terribly convenient. bazel-orfs has a debug feature specifically to debug stages and create standalone issues.
 
-First set up a /tmp/place folder with the necessary dependencies:
+First set up a folder with the necessary dependencies:
 
-    bazelisk run //test/orfs/mock-array:Element_place_deps /tmp/place
+    bazelisk run //test/orfs/mock-array:Element_place_deps
 
-This sets up a `/tmp/place/make` script that is a small shell script that calls `make` on the ORFS setup in /tmp/place, but since the place stage failed, we have to build all place sub-stages up to the failing stage:
+This sets up a `tmp/test/orfs/mock-array/Element_place_deps/make` script that calls `make` on the ORFS setup. Since the place stage failed, build all place sub-stages up to the failing stage:
 
-    /tmp/place/make do-place
+    tmp/test/orfs/mock-array/Element_place_deps/make do-place
 
 Now create a standalone issue:
 
-    /tmp/place/make global_place_skip_io_issue
+    tmp/test/orfs/mock-array/Element_place_deps/make global_place_skip_io_issue
 
-The `WORK_HOME` is in `/tmp/place/_main`:
+The `WORK_HOME` is in `tmp/test/orfs/mock-array/Element_place_deps/_main`:
 
-    $ ls /tmp/place/_main/
-    ++ dirname /tmp/place/make
-    + cd /tmp/place/_main
-    [deleted]
     Archiving issue to global_place_skip_io_Element_asap7_base_2025-07-16_08-44.tar.gz
     Using pigz to compress tar file
 
@@ -76,19 +72,19 @@ NOTE! keep in mind that these local ORFS design files have the depndencies `_dep
 
 If you're interested in some other stage, replace `place` with `synth`, `floorplan`, `cts`, `grt`, `route` or `final` below.
 
-The `/tmp/place/make` script, if `FLOW_HOME` is set, will use a local ORFS and OpenROAD built by CMake:
+The `make` script, if `FLOW_HOME` is set, will use a local ORFS and OpenROAD built by CMake:
 
     $ . ~/OpenROAD-flow-scripts/env.sh
-    $ /tmp/place/make print-FLOW_HOME print-OPENROAD_EXE
+    $ tmp/test/orfs/mock-array/Element_place_deps/make print-FLOW_HOME print-OPENROAD_EXE
     [deleted]
     FLOW_HOME = /home/<username>/OpenROAD-flow-scripts/flow
     OPENROAD_EXE = /home/<username>/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 
-More explictly ORFS only:
+More explicitly ORFS only:
 
-    make --file=~/OpenROAD-flow-scripts/flow/Makefile -C /tmp/place/_main WORK_HOME=test/orfs/mock-array DESIGN_CONFIG=config.mk do-place
+    make --file=~/OpenROAD-flow-scripts/flow/Makefile -C tmp/test/orfs/mock-array/Element_place_deps/_main WORK_HOME=test/orfs/mock-array DESIGN_CONFIG=config.mk do-place
 
-This is a bit more verbose, but eliminates any concerns about what the `/tmp/place/make` might be doing differently than ORFS only.
+This is more verbose, but eliminates any concerns about what the `make` script might be doing differently than ORFS only.
 
 ## Running a `make issue` with `cfg=exec` configuration
 


### PR DESCRIPTION
Background:

In recent versions of Ubunut, gigabytes into /tmp will cause out of memory errors, so bazel-orfs no longer encourages the user to use /tmp for multi-giga-byte purposes, happens easily with larger designs and filling up /tmp sneaks up on you and causes strange behaviors with out of memory.

Fix:

bazel-orfs deploy.tpl no longer accepts a positional path argument. Files are now always placed in tmp/<package>/<name>/ under the workspace root and deploy.tpl checks that tmp/ is in .gitignore and tmp is in .bazelignore.

Update all documentation examples from the old syntax:

    bazelisk run foo_deps /tmp/place

to the current syntax:

    bazelisk run foo_deps
    tmp/<package>/foo_deps/make do-place

Also fix non-existent gcd_deps target to gcd_place_deps.