### PR TITLE
Use snake_case for LEF58 area rule parser variables (#2275)

### DIFF
--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -104,7 +104,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
 {
   odb::dbTechLayerAreaRule* rule = odb::dbTechLayerAreaRule::create(layer);
 
-  qi::rule<std::string::const_iterator, space_type> EXCEPT_EDGE_LENGTH
+  qi::rule<std::string::const_iterator, space_type> except_edge_length
       = ((lit("EXCEPTEDGELENGTH") >> double_ >> double_)[boost::bind(
              &lefTechLayerAreaRuleParser::setExceptEdgeLengths, this, _1, rule)]
          | lit("EXCEPTEDGELENGTH") >> double_[boost::bind(
@@ -114,15 +114,15 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
                rule,
                &dbTechLayerAreaRule::setExceptEdgeLength)]);
 
-  qi::rule<std::string::const_iterator, space_type> EXCEPT_MIN_SIZE
+  qi::rule<std::string::const_iterator, space_type> except_min_size
       = (lit("EXCEPTMINSIZE") >> double_ >> double_)[boost::bind(
           &lefTechLayerAreaRuleParser::setExceptMinSize, this, _1, rule)];
 
-  qi::rule<std::string::const_iterator, space_type> EXCEPT_STEP
+  qi::rule<std::string::const_iterator, space_type> except_step
       = (lit("EXCEPTSTEP") >> double_ >> double_)[boost::bind(
           &lefTechLayerAreaRuleParser::setExceptStep, this, _1, rule)];
 
-  qi::rule<std::string::const_iterator, space_type> LAYER
+  qi::rule<std::string::const_iterator, space_type> layer_rule
       = ((lit("LAYER")
           >> _string[boost::bind(&lefTechLayerAreaRuleParser::setTrimLayer,
                                  this,
@@ -133,7 +133,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
          >> lit("OVERLAP")
          >> int_[boost::bind(&odb::dbTechLayerAreaRule::setOverlap, rule, _1)]);
 
-  qi::rule<std::string::const_iterator, space_type> AREA
+  qi::rule<std::string::const_iterator, space_type> area_rule
       = (lit("AREA") >> double_[boost::bind(&lefTechLayerAreaRuleParser::setInt,
                                             this,
                                             _1,
@@ -148,7 +148,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
                   _1,
                   rule,
                   &odb::dbTechLayerAreaRule::setExceptMinWidth)])
-         >> -EXCEPT_EDGE_LENGTH >> -EXCEPT_MIN_SIZE >> -EXCEPT_STEP
+         >> -except_edge_length >> -except_min_size >> -except_step
          >> -(lit("RECTWIDTH")
               >> double_[boost::bind(&lefTechLayerAreaRuleParser::setInt,
                                      this,
@@ -157,10 +157,10 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
                                      &odb::dbTechLayerAreaRule::setRectWidth)])
          >> -(lit("EXCEPTRECTANGLE")[boost::bind(
              &dbTechLayerAreaRule::setExceptRectangle, rule, true)])
-         >> -LAYER >> lit(";"));
+         >> -layer_rule >> lit(";"));
   auto first = s.begin();
   auto last = s.end();
-  bool valid = qi::phrase_parse(first, last, AREA, space) && first == last;
+  bool valid = qi::phrase_parse(first, last, area_rule, space) && first == last;
   if (!valid) {
     if (!incomplete_props.empty() && incomplete_props.back().first == rule) {
       incomplete_props.pop_back();


### PR DESCRIPTION
Hey team! This PR tackles issue #2275 regarding the naming conventions in the LEF58 area rule parser.

While looking into the parser logic in` lefTechLayerAreaRuleParser.cpp`, I noticed that several local `qi::rule` variables were defined using `SCREAMING_SNAKE_CASE` (specifically `EXCEPT_EDGE_LENGTH`, `EXCEPT_MIN_SIZE, EXCEPT_STEP`, `LAYER, and AREA`). Since OpenROAD follows the Google C++ Style Guide, S`CREAMING_SNAKE_CASE` is strictly reserved for macros, so these local variables needed to be updated to standard `snake_case.`

**Logic & Changes Made:**

>Converted `EXCEPT_EDGE_LENGTH`, `EXCEPT_MIN_SIZE`, and `EXCEPT_STEP` directly to `snake_case`.

For the `LAYER` and` AREA `rules, I specifically renamed them to` layer_rule` and `area_rule`. I noticed there is already an `odb::dbTechLayer`* layer parameter being passed into the `parseSubRule` function, so I did this to intentionally prevent any variable shadowing or scope confusion!

**Testing**
>[x] Compiled locally without issues (`make`).

>[x] Ran the OpenDB test suite `(ctest -R odb`), and all 85/85 tests passed, confirming the Boost.Spirit parser still maps the LEF file strings correctly.