### PR TITLE
Log Tcl commands to -log output and add regression test

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -18,6 +18,7 @@
 
 #include "boost/stacktrace/stacktrace.hpp"
 #include "tcl.h"
+#include "utl/Logger.h"
 #ifdef ENABLE_READLINE
 // If you get an error on this include be sure you have
 //   the package tcl-tclreadline-devel installed
@@ -40,7 +41,6 @@
 #include "ord/Tech.h"
 #include "sta/StaMain.hh"
 #include "sta/StringUtil.hh"
-#include "utl/Logger.h"
 #include "utl/decode.h"
 
 using sta::findCmdLineFlag;
@@ -92,6 +92,16 @@ static bool no_settings = false;
 static bool minimize = false;
 
 static const char* init_filename = ".openroad";
+
+static int logCommandCallback(ClientData client_data,
+                              Tcl_Interp* interp,
+                              int level,
+                              const char* command,
+                              Tcl_Command command_info,
+                              int objc,
+                              Tcl_Obj* const objv[]);
+static void deleteCommandTrace(ClientData client_data);
+static Tcl_Trace command_trace = nullptr;
 
 static void showUsage(const char* prog, const char* init_filename);
 static void showSplash();
@@ -170,6 +180,32 @@ static void initPython()
 #endif
 
 static volatile sig_atomic_t fatal_error_in_progress = 0;
+
+static int logCommandCallback(ClientData client_data,
+                              Tcl_Interp* interp,
+                              int level,
+                              const char* command,
+                              Tcl_Command command_info,
+                              int objc,
+                              Tcl_Obj* const objv[])
+{
+  if (level != 0 || command == nullptr) {
+    return TCL_OK;
+  }
+
+  auto* logger = static_cast<utl::Logger*>(client_data);
+  if (logger != nullptr && log_filename != nullptr) {
+    logger->redirectFileAppendBegin(log_filename);
+    logger->report("cmd: {}", command);
+    logger->redirectFileEnd();
+  }
+
+  return TCL_OK;
+}
+
+static void deleteCommandTrace(ClientData client_data)
+{
+}
 
 // When we enter through main() we have a single tech and design.
 // Custom applications using OR as a library might define multiple.
@@ -426,6 +462,13 @@ static int tclAppInit(int& argc,
 
     ord::initOpenRoad(
         interp, log_filename, metrics_filename, exit_after_cmd_file);
+
+    command_trace = Tcl_CreateObjTrace(interp,
+                                       0,
+                                       0,
+                                       logCommandCallback,
+                                       ord::OpenRoad::openRoad()->getLogger(),
+                                       deleteCommandTrace);
 
     bool no_splash = findCmdLineFlag(argc, argv, "-no_splash");
     if (!no_splash) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -465,7 +465,7 @@ static int tclAppInit(int& argc,
 
     Tcl_CreateObjTrace(interp,
                        0,
-                       0,
+                       1,
                        logCommandCallback,
                        ord::OpenRoad::openRoad()->getLogger(),
                        deleteCommandTrace);

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -10,6 +10,7 @@
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <memory>
@@ -188,10 +189,7 @@ static int logCommandCallback(ClientData client_data,
                               int objc,
                               Tcl_Obj* const objv[])
 {
-  (void) interp;
   (void) command_info;
-  (void) objc;
-  (void) objv;
   // Tcl levels are 1-based: 1 is top-level, 2+ are nested (e.g. sourced body).
   if (level != 1 || command == nullptr) {
     return TCL_OK;
@@ -200,7 +198,34 @@ static int logCommandCallback(ClientData client_data,
   auto* logger = static_cast<utl::Logger*>(client_data);
   if (logger != nullptr && log_filename != nullptr) {
     logger->redirectFileAppendBegin(log_filename);
-    logger->report("cmd: {}", command);
+    
+    // Reconstruct command with expanded variables from objv[]
+    if (objc > 0 && objv != nullptr) {
+      std::string expanded_cmd;
+      for (int i = 0; i < objc; i++) {
+        if (i > 0) {
+          expanded_cmd += " ";
+        }
+        const char* arg = Tcl_GetString(objv[i]);
+        // Quote arguments that contain spaces or special characters
+        if (arg != nullptr && (strchr(arg, ' ') != nullptr || 
+                               strchr(arg, '\t') != nullptr ||
+                               strchr(arg, '\n') != nullptr ||
+                               strchr(arg, '{') != nullptr ||
+                               strchr(arg, '}') != nullptr)) {
+          expanded_cmd += "{";
+          expanded_cmd += arg;
+          expanded_cmd += "}";
+        } else if (arg != nullptr) {
+          expanded_cmd += arg;
+        }
+      }
+      logger->report("cmd: {}", expanded_cmd);
+    } else {
+      // Fallback to original command string if objv is not available
+      logger->report("cmd: {}", command);
+    }
+    
     logger->redirectFileEnd();
   }
 
@@ -468,8 +493,7 @@ static int tclAppInit(int& argc,
     ord::initOpenRoad(
         interp, log_filename, metrics_filename, exit_after_cmd_file);
 
-    // NOLINTNEXTLINE(misc-include-cleaner): Tcl_CreateObjTrace is provided by tcl.h
-    Tcl_CreateObjTrace(interp,
+    Tcl_CreateObjTrace(interp,  // NOLINT(misc-include-cleaner)
                        0,
                        1,
                        logCommandCallback,

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -101,7 +101,7 @@ static int logCommandCallback(ClientData client_data,
                               int objc,
                               Tcl_Obj* const objv[]);
 static void deleteCommandTrace(ClientData client_data);
-static Tcl_Trace command_trace = nullptr;
+
 
 static void showUsage(const char* prog, const char* init_filename);
 static void showSplash();
@@ -463,12 +463,12 @@ static int tclAppInit(int& argc,
     ord::initOpenRoad(
         interp, log_filename, metrics_filename, exit_after_cmd_file);
 
-    command_trace = Tcl_CreateObjTrace(interp,
-                                       0,
-                                       0,
-                                       logCommandCallback,
-                                       ord::OpenRoad::openRoad()->getLogger(),
-                                       deleteCommandTrace);
+    Tcl_CreateObjTrace(interp,
+                       0,
+                       0,
+                       logCommandCallback,
+                       ord::OpenRoad::openRoad()->getLogger(),
+                       deleteCommandTrace);
 
     bool no_splash = findCmdLineFlag(argc, argv, "-no_splash");
     if (!no_splash) {

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -18,7 +18,6 @@
 
 #include "boost/stacktrace/stacktrace.hpp"
 #include "tcl.h"
-#include "utl/Logger.h"
 #ifdef ENABLE_READLINE
 // If you get an error on this include be sure you have
 //   the package tcl-tclreadline-devel installed
@@ -41,6 +40,7 @@
 #include "ord/Tech.h"
 #include "sta/StaMain.hh"
 #include "sta/StringUtil.hh"
+#include "utl/Logger.h"
 #include "utl/decode.h"
 
 using sta::findCmdLineFlag;
@@ -101,7 +101,6 @@ static int logCommandCallback(ClientData client_data,
                               int objc,
                               Tcl_Obj* const objv[]);
 static void deleteCommandTrace(ClientData client_data);
-
 
 static void showUsage(const char* prog, const char* init_filename);
 static void showSplash();

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -468,6 +468,7 @@ static int tclAppInit(int& argc,
     ord::initOpenRoad(
         interp, log_filename, metrics_filename, exit_after_cmd_file);
 
+    // NOLINTNEXTLINE(misc-include-cleaner): Tcl_CreateObjTrace is provided by tcl.h
     Tcl_CreateObjTrace(interp,
                        0,
                        1,

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -191,42 +191,44 @@ static int logCommandCallback(ClientData client_data,
 {
   (void) interp;
   (void) command_info;
-  // Tcl levels are 1-based: 1 is top-level, 2+ are nested (e.g. sourced body).
-  if (level != 1 || command == nullptr) {
+  (void) level;
+  if (command == nullptr || objc <= 0 || objv == nullptr) {
+    return TCL_OK;
+  }
+
+  // Skip internal implementation commands that aren't user-visible
+  const char* cmd_name = Tcl_GetString(objv[0]);
+  if (cmd_name == nullptr) {
+    return TCL_OK;
+  }
+  const std::string name(cmd_name);
+  if (name == "sta::include_file" || name == "::sta::include_file") {
     return TCL_OK;
   }
 
   auto* logger = static_cast<utl::Logger*>(client_data);
   if (logger != nullptr && log_filename != nullptr) {
-    logger->redirectFileAppendBegin(log_filename);
-    
     // Reconstruct command with expanded variables from objv[]
-    if (objc > 0 && objv != nullptr) {
-      std::string expanded_cmd;
-      for (int i = 0; i < objc; i++) {
-        if (i > 0) {
-          expanded_cmd += " ";
-        }
-        const char* arg = Tcl_GetString(objv[i]);
-        // Quote arguments that contain spaces or special characters
-        if (arg != nullptr && (strchr(arg, ' ') != nullptr || 
-                               strchr(arg, '\t') != nullptr ||
-                               strchr(arg, '\n') != nullptr ||
-                               strchr(arg, '{') != nullptr ||
-                               strchr(arg, '}') != nullptr)) {
-          expanded_cmd += "{";
-          expanded_cmd += arg;
-          expanded_cmd += "}";
-        } else if (arg != nullptr) {
-          expanded_cmd += arg;
-        }
+    std::string expanded_cmd;
+    for (int i = 0; i < objc; i++) {
+      if (i > 0) {
+        expanded_cmd += " ";
       }
-      logger->report("cmd: {}", expanded_cmd);
-    } else {
-      // Fallback to original command string if objv is not available
-      logger->report("cmd: {}", command);
+      const char* arg = Tcl_GetString(objv[i]);
+      if (arg == nullptr) {
+        continue;
+      }
+      if (strchr(arg, ' ') != nullptr || strchr(arg, '\t') != nullptr
+          || strchr(arg, '\n') != nullptr) {
+        expanded_cmd += "{";
+        expanded_cmd += arg;
+        expanded_cmd += "}";
+      } else {
+        expanded_cmd += arg;
+      }
     }
-    
+    logger->redirectFileAppendBegin(log_filename);
+    logger->report("cmd: {}", expanded_cmd);
     logger->redirectFileEnd();
   }
 

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -189,7 +189,12 @@ static int logCommandCallback(ClientData client_data,
                               int objc,
                               Tcl_Obj* const objv[])
 {
-  if (level != 0 || command == nullptr) {
+  (void) interp;
+  (void) command_info;
+  (void) objc;
+  (void) objv;
+  // Tcl levels are 1-based: 1 is top-level, 2+ are nested (e.g. sourced body).
+  if (level != 1 || command == nullptr) {
     return TCL_OK;
   }
 
@@ -205,6 +210,7 @@ static int logCommandCallback(ClientData client_data,
 
 static void deleteCommandTrace(ClientData client_data)
 {
+  (void) client_data;
 }
 
 // When we enter through main() we have a single tech and design.

--- a/src/Main.cc
+++ b/src/Main.cc
@@ -189,6 +189,7 @@ static int logCommandCallback(ClientData client_data,
                               int objc,
                               Tcl_Obj* const objv[])
 {
+  (void) interp;
   (void) command_info;
   // Tcl levels are 1-based: 1 is top-level, 2+ are nested (e.g. sourced body).
   if (level != 1 || command == nullptr) {

--- a/test/cmd_log_trace.ok
+++ b/test/cmd_log_trace.ok
@@ -1,0 +1,3 @@
+TEST: Verifying command tracing in log
+PASS: Found traced command lines in log
+PASS: Command log trace test completed successfully

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -1,0 +1,61 @@
+# Test command tracing into the OpenROAD log file.
+# Expected invocation (from regression):
+#   openroad -no_init -no_splash -exit -log <result_log> cmd_log_trace.tcl
+#
+# The regression harness redirects stdout/stderr to the same <result_log> file.
+# This script verifies that command tracing appended command lines to that file.
+
+source "helpers.tcl"
+
+puts "TEST: Verifying command tracing in log"
+
+# Find the log path from argv: ... -log <file> ...
+set log_file ""
+set argc [llength $argv]
+for {set i 0} {$i < $argc} {incr i} {
+  if {[lindex $argv $i] == "-log"} {
+    if {$i + 1 < $argc} {
+      set log_file [lindex $argv [expr {$i + 1}]]
+    }
+    break
+  }
+}
+
+if {$log_file == ""} {
+  puts "FAIL: Could not find -log file argument"
+  exit 1
+}
+
+if {![file exists $log_file]} {
+  puts "FAIL: Log file does not exist: $log_file"
+  exit 1
+}
+
+set fp [open $log_file r]
+set log_text [read $fp]
+close $fp
+
+# Look for traced commands emitted by Main.cc callback:
+#   cmd: <command>
+set expected_cmds {
+  {cmd: source {helpers.tcl}}
+  {cmd: puts {TEST: Verifying command tracing in log}}
+}
+
+set missing {}
+foreach pat $expected_cmds {
+  if {[string first $pat $log_text] == -1} {
+    lappend missing $pat
+  }
+}
+
+if {[llength $missing] > 0} {
+  puts "FAIL: Missing traced command lines:"
+  foreach m $missing {
+    puts "  $m"
+  }
+  exit 1
+}
+
+puts "PASS: Found traced command lines in log"
+puts "PASS: Command log trace test completed successfully"

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -46,20 +46,22 @@ close $fp
 
 # Look for traced commands emitted by Main.cc callback:
 #   cmd: <command>
-set expected_cmds {
-  {cmd: source {helpers.tcl}}
-  {cmd: puts {TEST: Verifying command tracing in log}}
+# Match with regex to avoid Tcl-version-specific formatting differences
+# in command rendering (quotes vs braces, spacing, etc.).
+set expected_patterns {
+  {cmd:[[:space:]]+source.*helpers\.tcl}
+  {cmd:[[:space:]]+puts[[:space:]].*TEST: Verifying command tracing in log}
 }
 
 set missing {}
-foreach pat $expected_cmds {
-  if {[string first $pat $log_text] == -1} {
+foreach pat $expected_patterns {
+  if {![regexp -nocase -- $pat $log_text]} {
     lappend missing $pat
   }
 }
 
 if {[llength $missing] > 0} {
-  puts "FAIL: Missing traced command lines:"
+  puts "FAIL: Missing traced command lines (regex):"
   foreach m $missing {
     puts "  $m"
   }
@@ -67,7 +69,7 @@ if {[llength $missing] > 0} {
 }
 
 # Ensure command tracing does not include commands executed inside sourced files.
-if {[string first {cmd: set ::nested_trace_marker 1} $log_text] != -1} {
+if {[regexp -nocase -- {cmd:[[:space:]]+set[[:space:]]+::nested_trace_marker[[:space:]]+1} $log_text]} {
   puts "FAIL: Nested sourced command should not be traced"
   exit 1
 }

--- a/test/cmd_log_trace.tcl
+++ b/test/cmd_log_trace.tcl
@@ -9,6 +9,15 @@ source "helpers.tcl"
 
 puts "TEST: Verifying command tracing in log"
 
+# Create and source a nested script with a simple command so this test can
+# verify that only the top-level source command is traced.
+make_result_dir
+set nested_script [file join $result_dir "cmd_log_trace_nested.tcl"]
+set nested_stream [open $nested_script w]
+puts $nested_stream {set ::nested_trace_marker 1}
+close $nested_stream
+source $nested_script
+
 # Find the log path from argv: ... -log <file> ...
 set log_file ""
 set argc [llength $argv]
@@ -54,6 +63,12 @@ if {[llength $missing] > 0} {
   foreach m $missing {
     puts "  $m"
   }
+  exit 1
+}
+
+# Ensure command tracing does not include commands executed inside sourced files.
+if {[string first {cmd: set ::nested_trace_marker 1} $log_text] != -1} {
+  puts "FAIL: Nested sourced command should not be traced"
   exit 1
 }
 

--- a/test/regression_tests.tcl
+++ b/test/regression_tests.tcl
@@ -24,3 +24,4 @@ record_flow_tests {
 record_test open_db $test_dir "compare_logfile" "-db gcd_sky130hd.odb"
 # For invalid DB, allow non-zero exit but require log to match ok
 record_test open_db_invalid $test_dir "compare_logfile_allow_error" "-db nonexistent_file.odb"
+record_test cmd_log_trace $test_dir "compare_logfile"

--- a/test/regression_tests.tcl
+++ b/test/regression_tests.tcl
@@ -24,4 +24,4 @@ record_flow_tests {
 record_test open_db $test_dir "compare_logfile" "-db gcd_sky130hd.odb"
 # For invalid DB, allow non-zero exit but require log to match ok
 record_test open_db_invalid $test_dir "compare_logfile_allow_error" "-db nonexistent_file.odb"
-record_test cmd_log_trace $test_dir "compare_logfile"
+record_test cmd_log_trace $test_dir "compare_logfile" "-log [file join $result_dir cmd_log_trace-tcl.log]"


### PR DESCRIPTION
Date : 10 March 2026
Developer Name : @Dhirenderchoudhary 

## Description
OpenROAD was not writing executed Tcl commands into the `-log` file.  
This PR adds Tcl command tracing during startup so every executed Tcl command is appended to the log as:

`cmd: <command>`

This improves log usefulness for debugging and reproducibility of previous runs.

Also adds a regression test for this behavior:
- `test/cmd_log_trace.tcl`
- `test/cmd_log_trace.ok`
- registered in `test/regression_tests.tcl

## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #3539 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified


## Checklist

- [x] Self-reviewed the code
- [ ] Updated documentation (if needed)
- [x] No new warnings or errors introduced
