### PR TITLE
Add setup-orfs Bazel target for ORFS flow dependency setup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -423,3 +423,8 @@ pkg_tar(
     include_runfiles = True,
     package_file_name = "openroad.tar",
 )
+
+alias(
+    name = "setup-orfs",
+    actual = "//etc:setup-orfs",
+)

--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -40,6 +40,36 @@ The install process will install the binary "openroad" and the runfile directory
 
 See [Bazel](Bazel.md) for more details on testing, profiling and build configurations.
 
+### Setup ORFS flow dependencies
+
+When using Bazel to build OpenROAD, the remaining ORFS flow dependencies
+(Yosys, eqy, sby, KLayout, etc.) can be installed with a single command:
+
+    bazelisk run //:setup-orfs
+
+If system packages are missing (compilers, dev libraries), the command
+prints the exact `sudo` command to run and exits. This design is
+intentional:
+
+- The user sees exactly what will be installed with root privileges
+  before it happens — no silent modifications to `/usr/local` or system
+  directories.
+- In educational and corporate environments, `sudo` is often controlled
+  by IT policy. Printing the command lets the user hand it off to an
+  administrator or request approval.
+- Running `sudo` separately benefits from the system's apt cache,
+  so repeated runs are fast.
+- User-level tools (Yosys, eqy, sby) are built and installed into the
+  project's `dependencies/` directory with user permissions only.
+
+After installing system packages, re-run `bazelisk run //:setup-orfs` to
+complete the user-level setup.
+
+This sets up the minimum tooling that Bazel does not yet provide. Over
+time, more of these tools may be built and managed by Bazel directly,
+but that is an implementation detail — `bazelisk run //:setup-orfs` will
+remain the single entry point for developers.
+
 ## Build with Prebuilt Binaries
 
 Courtesy of [Precision Innovations](https://precisioninno.com/), there are prebuilt binaries

--- a/etc/BUILD
+++ b/etc/BUILD
@@ -1,4 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 package(features = ["layering_check"])
 
@@ -9,4 +10,10 @@ py_binary(
     ],
     main = "file_to_string.py",
     visibility = ["//visibility:public"],
+)
+
+sh_binary(
+    name = "setup-orfs",
+    srcs = ["setup_orfs_bazel.sh"],
+    visibility = ["//:__pkg__"],
 )

--- a/etc/setup_orfs_bazel.sh
+++ b/etc/setup_orfs_bazel.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Setup ORFS dependencies for developers using Bazel for OpenROAD.
+#
+# Invoked via: bazelisk run //:setup-orfs
+#   (from the tools/OpenROAD directory)
+#
+# This script:
+#   1. Checks if system packages are installed
+#   2. If not, prints the sudo command to run and exits
+#   3. If yes, builds Yosys/eqy/sby and installs pip packages with
+#      user permissions into $ORFS_DIR/dependencies
+#
+# Shares code with ORFS etc/DependencyInstaller.sh via the -bazel flag.
+
+set -euo pipefail
+
+OR_DIR="${BUILD_WORKSPACE_DIRECTORY:?Must be run via bazelisk run}"
+
+# Navigate from tools/OpenROAD to the ORFS root
+ORFS_DIR="$(cd "${OR_DIR}/../.." && pwd)"
+
+if [[ ! -f "${ORFS_DIR}/etc/DependencyInstaller.sh" ]]; then
+    echo "ERROR: Cannot find ORFS root at ${ORFS_DIR}"
+    echo "This script expects OpenROAD to be at tools/OpenROAD within ORFS."
+    exit 1
+fi
+
+cd "${ORFS_DIR}"
+
+# Check for key system packages needed to build Yosys and run the flow.
+# These are installed by: sudo ./etc/DependencyInstaller.sh -base -bazel
+missing=()
+for cmd in gcc g++ bison flex pkg-config tclsh python3; do
+    if ! command -v "$cmd" &>/dev/null; then
+        missing+=("$cmd")
+    fi
+done
+
+# Also check for key dev libraries via pkg-config
+for lib in tcl libffi zlib; do
+    if ! pkg-config --exists "$lib" 2>/dev/null; then
+        missing+=("$lib (dev)")
+    fi
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "Missing system dependencies: ${missing[*]}"
+    echo ""
+    echo "Run the following command first to install system packages:"
+    echo ""
+    echo "  sudo ${ORFS_DIR}/etc/DependencyInstaller.sh -base -bazel"
+    echo ""
+    exit 1
+fi
+
+PREFIX="${ORFS_DIR}/dependencies"
+
+echo "Installing ORFS flow dependencies into ${PREFIX}"
+echo ""
+
+# Build Yosys/eqy/sby using the shared DependencyInstaller.sh with -bazel.
+# The -common flag triggers the Yosys/eqy/sby build (not the full OpenROAD
+# dependency chain).
+"${ORFS_DIR}/etc/DependencyInstaller.sh" -common -bazel "-prefix=${PREFIX}"
+
+echo ""
+echo "ORFS flow dependencies installed to ${PREFIX}"
+echo ""
+echo "To use, source the environment or add to PATH:"
+echo ""
+echo "  export PATH=${PREFIX}/bin:\$PATH"
+echo ""


### PR DESCRIPTION
Add `bazelisk run //:setup-orfs` as the single entry point for developers to install ORFS flow dependencies (Yosys, eqy, sby, KLayout, etc.) when building OpenROAD with Bazel. The target checks for system packages, prints the sudo command if needed, and builds user-level tools into the ORFS dependencies directory.

This sets up the minimum tooling that Bazel does not yet provide. Over time more tools may move into Bazel, but this command remains the stable developer interface.

needs https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3977