### PR TITLE
odb: allow dbWire::getShape usage in Tcl and add dbShape::isSegment

### DIFF
--- a/src/odb/include/odb/dbShape.h
+++ b/src/odb/include/odb/dbShape.h
@@ -178,6 +178,11 @@ class dbShape
   bool isVia() const;
 
   ///
+  /// Returns true if this object is a segment
+  ///
+  bool isSegment() const;
+
+  ///
   /// Returns true if this object is a via box
   ///
   bool isViaBox() const;
@@ -543,6 +548,10 @@ inline int dbShape::yMax() const
 inline bool dbShape::isVia() const
 {
   return (type_ == VIA) || (type_ == TECH_VIA);
+}
+inline bool dbShape::isSegment() const
+{
+  return type_ == SEGMENT;
 }
 inline bool dbShape::isViaBox() const
 {

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -70,6 +70,12 @@ using namespace odb;
 %include "polygon.i"
 %include "odb/db.h"
 
+// Prevent compiler problems when including dbShape.h.
+%ignore odb::dbShapeItrCallback;
+%ignore odb::dbWireShapeItr;
+
+%include "odb/dbShape.h"
+
 %include "dbhelpers.i"  
 
 %rename(getPoint_ext) odb::dbWireDecoder::getPoint(int& x, int& y, int& ext) const;

--- a/src/odb/src/swig/tcl/dbtypes.i
+++ b/src/odb/src/swig/tcl/dbtypes.i
@@ -256,6 +256,14 @@ WRAP_OBJECT_RETURN_REF(odb::dbViaParams, params_return)
     Tcl_ListObjAppendElement(interp, Tcl_GetObjResult(interp), obj);
   }
 }
+%typemap(in, numinputs=0) odb::dbShape &OUTPUT (odb::dbShape temp) {
+    $1 = new odb::dbShape(temp);
+}
+%typemap(argout) odb::dbShape &OUTPUT {
+    swig_type_info *tf = SWIG_TypeQuery("odb::dbShape" "*");
+    Tcl_Obj *obj = SWIG_NewInstanceObj($1, tf, SWIG_POINTER_OWN);
+    Tcl_SetObjResult(interp, obj);
+}
 %typemap(argout) std::vector<int> &OUTPUT {
   for(auto it = $1->begin(); it != $1->end(); it++) {
     Tcl_Obj *obj = Tcl_NewIntObj(*it);
@@ -265,5 +273,6 @@ WRAP_OBJECT_RETURN_REF(odb::dbViaParams, params_return)
 }
 
 %apply std::vector<odb::dbShape> &OUTPUT { std::vector<odb::dbShape> & shapes };
+%apply odb::dbShape &OUTPUT { odb::dbShape & shape };
 
 %include containers.i


### PR DESCRIPTION
For https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3969.

Adds SWIG implementation for using `void dbWire::getShape(int shape_id, dbShape& shape)` in Tcl. Usage example:
```
foreach rseg [$db_net getRSegs] {
  set shape [$wire getShape [$rseg getShapeId]]
}
```