### PR TITLE
Fix needed omp header in TritonRoute

### DIFF
--- a/src/drt/src/TritonRoute.cpp
+++ b/src/drt/src/TritonRoute.cpp
@@ -50,6 +50,7 @@
 #include "odb/dbId.h"
 #include "odb/dbShape.h"
 #include "odb/dbTypes.h"
+#include "omp.h"
 #include "pa/AbstractPAGraphics.h"
 #include "pa/FlexPA.h"
 #include "rp/FlexRP.h"


### PR DESCRIPTION
```
src/drt/src/TritonRoute.cpp:             #include "omp.h" for omp_(set|get)_num_threads
```