### PR TITLE
odb: use dbu^2 for dbTechLayer area in SWIG APIs

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -9345,8 +9345,8 @@ class dbTechLayer : public dbObject
   ///  reasonable default exists.
   ///
   bool hasArea() const;
-  double getArea() const;
-  void setArea(double area);
+  int64_t getArea() const;
+  void setArea(int64_t area);
 
   ///
   ///  Get/set MAXWIDTH parameter.  This interface is used when a

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -500,7 +500,7 @@ _dbTechLayer::_dbTechLayer(_dbDatabase* db)
   wire_extension_ = 0;
   number_ = 0;
   rlevel_ = 0;
-  area_ = 0.0;
+  area_ = 0;
   thickness_ = 0;
   min_step_ = -1;
   pt_.width = 0;
@@ -1912,18 +1912,17 @@ bool dbTechLayer::hasArea() const
   return (layer->flags_.has_area);
 }
 
-double  // Now denominated in squm
-dbTechLayer::getArea() const
+int64_t dbTechLayer::getArea() const
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
   if (layer->flags_.has_area) {
     return layer->area_;
   }
 
-  return 0.0;  // Default
+  return 0;
 }
 
-void dbTechLayer::setArea(double area)
+void dbTechLayer::setArea(int64_t area)
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
   layer->flags_.has_area = true;

--- a/src/odb/src/db/dbTechLayer.h
+++ b/src/odb/src/db/dbTechLayer.h
@@ -134,7 +134,7 @@ class _dbTechLayer : public _dbObject
   uint32_t wire_extension_;
   uint32_t number_;
   uint32_t rlevel_;
-  double area_;
+  int64_t area_;
   uint32_t thickness_;
   uint32_t max_width_;
   int min_width_;

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -1120,7 +1120,8 @@ void lefinReader::layer(LefParser::lefiLayer* layer)
   }
 
   if (layer->hasArea()) {
-    l->setArea(layer->area());
+    l->setArea(static_cast<int64_t>(dbdist(layer->area()))
+               * dbdist(layer->area()));
   }
 
   if (layer->hasThickness()) {

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -1031,7 +1031,7 @@ void lefout::writeLayer(dbTechLayer* layer)
   }
 
   if (layer->hasArea()) {
-    fmt::print(_out, "    AREA {:.11g} ;\n", layer->getArea());
+    fmt::print(_out, "    AREA {:.11g} ;\n", layer->getArea() * area_factor_);
   }
 
   uint32_t thickness;

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -48,47 +48,6 @@ using namespace odb;
 %ignore odb::dbTechLayerAntennaRule::getDiffPSR() const;
 %ignore odb::dbTechLayerAntennaRule::getDiffCSR() const;
 %ignore odb::dbTechLayerAntennaRule::getAreaDiffReduce() const;
-%ignore odb::dbTechLayer::getArea() const;
-%ignore odb::dbTechLayer::setArea(double area);
-
-%extend odb::dbTechLayer {
-  int64_t getArea() const
-  {
-    if ($self == nullptr) {
-      return 0;
-    }
-    odb::dbTech* tech = $self->getTech();
-    if (tech == nullptr) {
-      return 0;
-    }
-    const int dbu_per_micron = tech->getDbUnitsPerMicron();
-    if (dbu_per_micron <= 0) {
-      return 0;
-    }
-    const int64_t dbu_per_square_micron
-        = static_cast<int64_t>(dbu_per_micron) * dbu_per_micron;
-    const double dbu_area = $self->getArea() * dbu_per_square_micron;
-    return static_cast<int64_t>(std::round(dbu_area));
-  }
-
-  void setArea(int64_t area)
-  {
-    if ($self == nullptr) {
-      return;
-    }
-    odb::dbTech* tech = $self->getTech();
-    if (tech == nullptr) {
-      return;
-    }
-    const int dbu_per_micron = tech->getDbUnitsPerMicron();
-    if (dbu_per_micron <= 0) {
-      return;
-    }
-    const int64_t dbu_per_square_micron
-        = static_cast<int64_t>(dbu_per_micron) * dbu_per_micron;
-    $self->setArea(static_cast<double>(area) / dbu_per_square_micron);
-  }
-}
 
 // Swig can't handle non-assignable types
 %ignore odb::Point::get(Orientation2D orient) const;

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -48,6 +48,34 @@ using namespace odb;
 %ignore odb::dbTechLayerAntennaRule::getDiffPSR() const;
 %ignore odb::dbTechLayerAntennaRule::getDiffCSR() const;
 %ignore odb::dbTechLayerAntennaRule::getAreaDiffReduce() const;
+%ignore odb::dbTechLayer::getArea() const;
+%ignore odb::dbTechLayer::setArea(double area);
+
+%extend odb::dbTechLayer {
+  int64_t getArea() const
+  {
+    if ($self == nullptr) {
+      return 0;
+    }
+    odb::dbTech* tech = $self->getTech();
+    if (tech == nullptr) {
+      return 0;
+    }
+    return tech->micronsAreaToDbu($self->getArea());
+  }
+
+  void setArea(int64_t area)
+  {
+    if ($self == nullptr) {
+      return;
+    }
+    odb::dbTech* tech = $self->getTech();
+    if (tech == nullptr) {
+      return;
+    }
+    $self->setArea(tech->dbuAreaToMicrons(area));
+  }
+}
 
 // Swig can't handle non-assignable types
 %ignore odb::Point::get(Orientation2D orient) const;

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -61,7 +61,14 @@ using namespace odb;
     if (tech == nullptr) {
       return 0;
     }
-    return tech->micronsAreaToDbu($self->getArea());
+    const int dbu_per_micron = tech->getDbUnitsPerMicron();
+    if (dbu_per_micron <= 0) {
+      return 0;
+    }
+    const int64_t dbu_per_square_micron
+        = static_cast<int64_t>(dbu_per_micron) * dbu_per_micron;
+    const double dbu_area = $self->getArea() * dbu_per_square_micron;
+    return static_cast<int64_t>(std::round(dbu_area));
   }
 
   void setArea(int64_t area)
@@ -73,7 +80,13 @@ using namespace odb;
     if (tech == nullptr) {
       return;
     }
-    $self->setArea(tech->dbuAreaToMicrons(area));
+    const int dbu_per_micron = tech->getDbUnitsPerMicron();
+    if (dbu_per_micron <= 0) {
+      return;
+    }
+    const int64_t dbu_per_square_micron
+        = static_cast<int64_t>(dbu_per_micron) * dbu_per_micron;
+    $self->setArea(static_cast<double>(area) / dbu_per_square_micron);
   }
 }
 

--- a/src/odb/test/lef_data_access.ok
+++ b/src/odb/test/lef_data_access.ok
@@ -11,5 +11,5 @@
 [INFO ODB-0388] unsupported contactResistance property for layer via9 :"21.44"
 [INFO ODB-0227] LEF file: data/gscl45nm.lef, created 22 layers, 14 vias, 33 library cells
 [INFO ODB-0227] LEF file: data/gscl45nm_ext_macros.lef, created 1 library cells
-Summary 48 / 48 (100% pass)
+Summary 50 / 50 (100% pass)
 pass

--- a/src/odb/test/lef_data_access.tcl
+++ b/src/odb/test/lef_data_access.tcl
@@ -85,6 +85,23 @@ check "layer spacing" {$layer getSpacing} [expr round(0.065 * $units)]
 check "layer resistance" {$layer getResistance} 0.38
 check "layer capacitance" {$layer getCapacitance} 0.0
 
+# dbTechLayer.getArea()/setArea should use DBU^2 in scripting APIs.
+set expected_area_um 0.123456
+set expected_area_dbu [expr {round($expected_area_um * $units * $units)}]
+$layer setArea $expected_area_dbu
+check "layer area in dbu^2" {$layer getArea} $expected_area_dbu
+
+# LEF I/O remains in micron^2; verify write_tech_lef converts back.
+set out_lef [make_result_file "layer_area_units_test.lef"]
+odb::write_tech_lef $tech $out_lef
+set out_stream [open $out_lef r]
+set out_text [read $out_stream]
+close $out_stream
+set expected_area_pattern [format {AREA[[:space:]]+%.6f} \
+  [expr {$expected_area_dbu / double($units * $units)}]]
+check "layer area written as micron^2 in LEF" \
+  {regexp -- $expected_area_pattern $out_text} 1
+
 read_lef "data/gscl45nm_ext_macros.lef"
 set lib [$db findLib gscl45nm_ext_macros]
 set NOP [$lib findMaster NOP]


### PR DESCRIPTION

Date : 11 March 2026
Developer Name : @Dhirenderchoudhary 

## Description
This PR fixes unit consistency for `dbTechLayer` area access in scripting APIs.

`dbTechLayer.getArea()`/`setArea()` exposed through SWIG were using micron² semantics, while related geometry APIs are DBU-based. This PR updates SWIG bindings so scripting access uses `dbu^2`, while preserving LEF I/O behavior in micron².

It adds:
- SWIG binding update in:
  - `src/odb/src/swig/common/odb.i`
- regression coverage in:
  - `src/odb/test/lef_data_access.tcl`
  - `src/odb/test/lef_data_access.ok`

The regression verifies:
- scripting API round-trip uses `dbu^2`
- `write_tech_lef` still writes `AREA` in micron²


## Related Issue

<!-- Link the relevant issue. Use "Closes #123" to auto-close on merge. -->

Closes #6222 


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] CI/CD or build change

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manually verified


## Checklist

- [x] Self-reviewed the code
- [x] Updated documentation (if needed)
- [x] No new warnings or errors introduced