### PR TITLE
odb: Use snake_case for LEF58 parser variables in multiple files (#2275)

### DIFF
--- a/src/odb/src/lefin/ArraySpacingParser.cpp
+++ b/src/odb/src/lefin/ArraySpacingParser.cpp
@@ -73,7 +73,7 @@ bool ArraySpacingParser::parse(const std::string& s)
       = (lit("WITHIN") >> double_ >> lit("ARRAYWIDTH")
          >> double_)[boost::bind(&ArraySpacingParser::setWithin, this, _1)];
 
-  qi::rule<std::string::const_iterator, space_type> lef58_arrayspacing_rule
+  qi::rule<std::string::const_iterator, space_type> lef58_array_spacing_rule
       = (lit("ARRAYSPACING") >> -(cut_class_rule)
          >> -lit("PARALLELOVERLAP")[boost::bind(
              &dbTechLayerArraySpacingRule::setParallelOverlap, rule_, true)]
@@ -84,7 +84,7 @@ bool ArraySpacingParser::parse(const std::string& s)
          >> +array_cuts_rule >> lit(";"));
   auto first = s.begin();
   auto last = s.end();
-  bool valid = qi::phrase_parse(first, last, lef58_arrayspacing_rule, space)
+  bool valid = qi::phrase_parse(first, last, lef58_array_spacing_rule, space)
                && first == last;
 
   if (!valid && rule_ != nullptr) {  // fail if we did not get a full match

--- a/src/odb/src/lefin/KeepOutZoneParser.cpp
+++ b/src/odb/src/lefin/KeepOutZoneParser.cpp
@@ -96,7 +96,7 @@ bool KeepOutZoneParser::parseSubRule(const std::string& s)
               _1,
               &odb::dbTechLayerKeepOutZoneRule::setSpiralExtension)]));
 
-  qi::rule<std::string::const_iterator, space_type> lef58_keepoutzone_rule
+  qi::rule<std::string::const_iterator, space_type> lef58_keepout_zone_rule
       = (lit("KEEPOUTZONE") >> lit("CUTCLASS") >> _string[boost::bind(
              &dbTechLayerKeepOutZoneRule::setFirstCutClass, rule_, _1)]
          >> -(lit("TO") >> _string[boost::bind(
@@ -105,7 +105,7 @@ bool KeepOutZoneParser::parseSubRule(const std::string& s)
          >> spiral_extension_rule >> lit(";"));
   auto first = s.begin();
   auto last = s.end();
-  bool valid = qi::phrase_parse(first, last, lef58_keepoutzone_rule, space)
+  bool valid = qi::phrase_parse(first, last, lef58_keepout_zone_rule, space)
                && first == last;
 
   if (!valid && rule_ != nullptr) {  // fail if we did not get a full match


### PR DESCRIPTION
Following up on my previous PR #9702 and @maliberty's feedback, this PR continues the broader naming convention cleanup for issue #2275. 

I have refactored the local `Boost.Spirit` `qi::rule` variables from `SCREAMING_SNAKE_CASE` to standard `snake_case` in the following parsers to comply with the Google C++ Style Guide:
* `ArraySpacingParser.cpp`
* `KeepOutZoneParser.cpp`
* `AntennaGateParser.cpp`

**Testing:**
 Built successfully locally (`make`).And ran the OpenDB test suite (`ctest -R odb`) and all 86/86 tests passed, confirming the parsers still map the LEF file strings correctly.