### PR TITLE
grt: fix cugr memory crash on out-of-bounds grid access

### DIFF
--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -250,7 +250,9 @@ GridGraph::GridGraph(const Design* design,
 IntervalT GridGraph::rangeSearchGridlines(const int dimension,
                                           const IntervalT& loc_interval) const
 {
-  if (dimension < 0 || dimension > 1) return {0, 0};
+  if (dimension < 0 || dimension > 1) {
+    return {0, 0};
+  }
   IntervalT range;
   range.Set(lower_bound(gridlines_[dimension].begin(),
                         gridlines_[dimension].end(),
@@ -271,20 +273,28 @@ IntervalT GridGraph::rangeSearchGridlines(const int dimension,
 IntervalT GridGraph::rangeSearchRows(const int dimension,
                                      const IntervalT& loc_interval) const
 {
-  if (dimension < 0 || dimension > 1) return {0, 0};
+  if (dimension < 0 || dimension > 1) {
+    return {0, 0};
+  }
+
+  // 1. Critical Empty Check: If the grid doesn't exist, exit early
+  if (gridlines_[dimension].empty()) {
+    return {0, 0};
+  }
+
   const auto& lineRange = rangeSearchGridlines(dimension, loc_interval);
-  
-  // BOUNDARY SHIELD: Safely clamp to array boundaries
-  const int max_idx = std::max(0, (int)gridlines_[dimension].size() - 1);
+
+  // 2. BOUNDARY SHIELD: Safely clamp to array boundaries
+  const int max_idx = (int) gridlines_[dimension].size() - 1;
   const int l = std::min(lineRange.low(), max_idx);
   const int h = std::min(lineRange.high(), max_idx);
 
-  return {gridlines_[dimension][l] == loc_interval.low()
-              ? l
-              : std::max(l - 1, 0),
-          gridlines_[dimension][h] == loc_interval.high()
-              ? h - 1
-              : std::min(h, getSize(dimension) - 1)};
+  // 3. Robust Return: Ensure we never return a negative index for either bound
+  return {
+      gridlines_[dimension][l] == loc_interval.low() ? l : std::max(l - 1, 0),
+      gridlines_[dimension][h] == loc_interval.high()
+          ? std::max(0, h - 1)
+          : std::min(h, getSize(dimension) - 1)};
 }
 
 BoxT GridGraph::getCellBox(PointT point) const


### PR DESCRIPTION
This change resolves a critical `Signal 6 (SIGABRT)` crash in the CUGR global routing engine caused by a mismatch between physical design coordinates and the internally constructed virtual routing grid. In certain inconsistent designs, coordinates of pins, ports, or obstacles could fall outside the precomputed grid boundaries, leading to an out-of-bounds access in the routing grid data structures. The update introduces geometric boundary clamping to ensure safe projection of coordinates onto the grid and prevent memory access violations.

During initialization, the CUGR router constructs a discrete 3D routing structure called `GridGraph`, derived from the routing layers and track definitions specified in LEF files. Throughout routing, physical coordinates are projected onto this grid using the `GridGraph::rangeSearchRows` function.
In inconsistent configurations for example, when a design using a 13-layer metal stack is routed on a 6-layer grid, or when IO pins are located outside the defined core region,the coordinate-to-grid index calculation may generate indices larger than the size of the internal `gridlines_` vector.

Because the implementation previously accessed the vector directly (`gridlines_[dimension][index]`) without validating the computed index, the C++ standard library detected the invalid access and triggered the assertion `__n < this->size()`. This resulted in an immediate `SIGABRT` and core dump, preventing the router from reporting which design element caused the failure.

### Solution

>This change introduces a defensive boundary-clamping mechanism inside `GridGraph.cpp`. Instead of using the raw projection indices, the logic now determines the valid bounds of the `gridlines_` container and clamps the requested lookup indices into that range before performing any vector access.

This approach ensures that coordinate projections are always mapped to a valid grid boundary, eliminating the possibility of out-of-range memory access while allowing the router to continue execution and report the underlying design inconsistency.

Implementation

>The implementation computes the maximum legal index (`N-1`) of the gridline vector and constrains the computed low and high indices using `std::min` and `std::max`. This guarantees that accesses to `gridlines_` remain within valid memory boundaries.

```cpp
// Safety-hardened logic to prevent SIGABRT
const int max_idx = std::max(0, (int)gridlines_[dimension].size() - 1);
const int l = std::min(lineRange.low(), max_idx);
const int h = std::min(lineRange.high(), max_idx);

// Safe access is now physically guaranteed by the clamp
return {gridlines_[dimension][l] == loc_interval.low() ? l : std::max(l - 1, 0),
        gridlines_[dimension][h] == loc_interval.high() ? h - 1 : std::min(h, getSize(dimension) - 1)};
```

By enforcing this boundary clamping, invalid coordinate projections are safely mapped to the nearest valid grid cell. Instead of causing a memory crash, the router can now continue execution and emit a handled diagnostic such as `GRT-0286 (Failed to determine parent layer)`, which identifies the specific net responsible for the geometry mismatch.


The fix was validated using a stress-test design containing a 13-layer metal stack routed using a 6-layer routing grid.

>Prior to this change, invoking `global_route` caused an immediate crash with `Aborted (core dumped)` during grid projection. After applying the fix, the router successfully completes grid initialization, proceeds into stage 1 pattern routing, and terminates with a clear diagnostic message identifying the problematic net.

The added `std::min` and `std::max` checks are constant-time (`O(1)`) operations and introduce no measurable overhead to the routing runtime.
This update hardens the `GridGraph` coordinate projection logic against out-of-range memory access. By replacing a fatal crash with safe boundary handling and actionable diagnostics, the change improves the robustness and reliability of the OpenROAD routing pipeline and ensures predictable behavior even when encountering inconsistent design data.
