### PR TITLE
bazel: add Qt corelib bootstrap headers for hermetic builds

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -87,6 +87,8 @@ bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
     commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    patch_strip = 1,
+    patches = ["//bazel:qt_bazel_bootstrap_headers.patch"],
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/bazel/qt_bazel_bootstrap_headers.patch
+++ b/bazel/qt_bazel_bootstrap_headers.patch
@@ -1,0 +1,17 @@
+--- a/qt_source/BUILD.bazel
++++ b/qt_source/BUILD.bazel
+@@ -776,6 +776,14 @@
+     hdrs = glob([
+         QT_BASE + "/build/include/QtCore/**/Q*",
+         QT_BASE + "/build/include/QtCore/**/*.h",
++        QT_BASE + "/src/corelib/global/*.h",
++        QT_BASE + "/src/corelib/io/*.h",
++        QT_BASE + "/src/corelib/kernel/*.h",
++        QT_BASE + "/src/corelib/plugin/*.h",
++        QT_BASE + "/src/corelib/serialization/*.h",
++        QT_BASE + "/src/corelib/text/*.h",
++        QT_BASE + "/src/corelib/time/*.h",
++        QT_BASE + "/src/corelib/tools/*.h",
+     ]) + select({
+         "@platforms//os:osx": [
+         ] + glob([


### PR DESCRIPTION
@hzeller Thoughts?

Qt public headers in build/include/QtCore/ internally include bootstrap headers from src/corelib/ subdirectories. Under strict Bazel sandboxing, these transitive includes are undeclared and cause build failures. Add a patch to the qt-bazel git_override that explicitly declares the corelib bootstrap headers in the QtCore target's hdrs.

Test: bazelisk query on @qt-bazel//qt_source:bootstrap hdrs

Before (without patch): 2 src/corelib headers declared
  src/corelib/text/qlocale_data_p.h
  src/corelib/time/qromancalendar_data_p.h

After (with patch): 383 src/corelib headers declared across
  src/corelib/global/*.h
  src/corelib/io/*.h
  src/corelib/kernel/*.h
  src/corelib/plugin/*.h
  src/corelib/serialization/*.h
  src/corelib/text/*.h
  src/corelib/time/*.h
  src/corelib/tools/*.h