### PR TITLE
grt: Refactor CUGR GridGraph API to resolve boolean blindness in tree rip-up

### DIFF
--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -162,7 +162,7 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
     pattern_route.constructSteinerTree();
     pattern_route.constructRoutingDAG();
     pattern_route.run();
-    grid_graph_->commitTree(gr_nets_[net_index]->getRoutingTree());
+    grid_graph_->addTreeUsage(gr_nets_[net_index]->getRoutingTree());
   }
 
   updateOverflowNets(net_indices);
@@ -188,7 +188,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
     if (net->getNumPins() < 2) {
       continue;
     }
-    grid_graph_->commitTree(net->getRoutingTree(), /*ripup*/ true);
+    grid_graph_->removeTreeUsage(net->getRoutingTree());
     PatternRoute pattern_route(
         net, grid_graph_.get(), stt_builder_, constants_, logger_);
     pattern_route.constructSteinerTree();
@@ -196,7 +196,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
     // KEY DIFFERENCE compared to stage 1 (patternRoute)
     pattern_route.constructDetours(congestion_view);
     pattern_route.run();
-    grid_graph_->commitTree(net->getRoutingTree());
+    grid_graph_->addTreeUsage(net->getRoutingTree());
   }
 
   updateOverflowNets(net_indices);
@@ -214,8 +214,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
   }
 
   for (const int net_index : net_indices) {
-    grid_graph_->commitTree(gr_nets_[net_index]->getRoutingTree(),
-                            /*ripup*/ true);
+    grid_graph_->removeTreeUsage(gr_nets_[net_index]->getRoutingTree());
   }
   GridGraphView<CostT> wire_cost_view;
   grid_graph_->extractWireCostView(wire_cost_view);
@@ -238,7 +237,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
     pattern_route.constructRoutingDAG();
     pattern_route.run();
 
-    grid_graph_->commitTree(net->getRoutingTree());
+    grid_graph_->addTreeUsage(net->getRoutingTree());
     grid_graph_->updateWireCostView(wire_cost_view, net->getRoutingTree());
     grid.step();
   }
@@ -630,7 +629,7 @@ void CUGR::updateNet(odb::dbNet* db_net)
   if (it != db_net_map_.end()) {
     GRNet* gr_net = it->second;
     if (gr_net->getRoutingTree()) {
-      grid_graph_->commitTree(gr_net->getRoutingTree(), /*rip_up=*/true);
+      grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
     }
     design_->updateNet(db_net);
     const int idx = gr_net->getIndex();
@@ -667,7 +666,7 @@ void CUGR::rerouteNets(std::vector<int>& net_indices)
 {
   for (const int idx : net_indices) {
     if (gr_nets_[idx]->getRoutingTree()) {
-      grid_graph_->commitTree(gr_nets_[idx]->getRoutingTree(), /*rip_up=*/true);
+      grid_graph_->removeTreeUsage(gr_nets_[idx]->getRoutingTree());
     }
   }
   patternRoute(net_indices);

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -920,4 +920,18 @@ void GridGraph::write(const std::string& heatmap_file) const
   fout.close();
 }
 
+void GridGraph::addTreeUsage(const std::shared_ptr<GRTreeNode>& tree)
+{
+  if (tree) {
+    commitTree(tree, false);
+  }
+}
+
+void GridGraph::removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree)
+{
+  if (tree) {
+    commitTree(tree, true);
+  }
+}
+
 }  // namespace grt

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -114,8 +114,9 @@ class GridGraph
   // Misc
   AccessPointSet selectAccessPoints(GRNet* net) const;
 
-  // Methods for updating demands
-  void commitTree(const std::shared_ptr<GRTreeNode>& tree, bool rip_up = false);
+  // Methods for updating demands - Public API
+  void addTreeUsage(const std::shared_ptr<GRTreeNode>& tree);
+  void removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree);
 
   // Checks
   bool checkOverflow(int layer_index, int x, int y) const
@@ -169,10 +170,11 @@ class GridGraph
                     PointT lower,
                     CapacityT demand = 1.0) const;
 
-  // Methods for updating demands
+  // Methods for updating demands - Internal Implementation
   void commit(int layer_index, PointT lower, CapacityT demand);
   void commitWire(int layer_index, PointT lower, bool rip_up = false);
   void commitVia(int layer_index, PointT loc, bool rip_up = false);
+  void commitTree(const std::shared_ptr<GRTreeNode>& tree, bool rip_up = false);
 
   utl::Logger* logger_;
   const std::vector<std::vector<int>> gridlines_;


### PR DESCRIPTION
Currently, `GridGraph::commitTree` utilizes a boolean flag to handle both capacity additions and rip-ups. This leads to boolean blindness at the call site (e.g., `commitTree(tree, /*ripup*/ true)`) and creates semantic confusion where a function named "commit" is used to remove data. 
Moves the boolean-flagged `commit*` functions to the `private` scope.Exposes clean, self-documenting public APIs: `addTreeUsage()` and `removeTreeUsage()`.Refactors `CUGR.cpp` to use these explicit calls, cleanly separating capacity allocation from rip-up mechanics.
This API modernization aligns with recent CUGR state management refactors and paves the way for deterministic history-cost preservation during incremental timing ECOs.

### Related Issues
Supports the architectural prep for Incremental CUGR .

