### PR TITLE
Add foundational manual placement utilities (place_row, place_column)

### DIFF
--- a/src/utl/CMakeLists.txt
+++ b/src/utl/CMakeLists.txt
@@ -9,12 +9,13 @@ swig_lib(NAME      utl
          NAMESPACE utl
          I_FILE    src/Logger.i
          SCRIPTS   src/Utl.tcl
+                   scripts/manual_place.tcl
          SWIG_INCLUDES ${PROJECT_SOURCE_DIR}/src
 )
 
 if (Python3_FOUND AND BUILD_PYTHON)
   swig_lib(NAME          utl_py
-           NAMESPACE     utl
+           NAMESPACE      utl
            LANGUAGE      python
            I_FILE        src/Logger-py.i
            SWIG_INCLUDES ${PROJECT_SOURCE_DIR}/include/utl
@@ -100,8 +101,7 @@ messages(
 
 ############################################################
 # Unit testing
-############################################################\
+############################################################
 if(ENABLE_TESTS)
   add_subdirectory(test)
 endif()
-

--- a/src/utl/scripts/manual_place.tcl
+++ b/src/utl/scripts/manual_place.tcl
@@ -1,0 +1,54 @@
+# Proc: _place_line
+# Internal helper to handle row/column placement logic.
+proc _place_line { orientation instances startX startY spacing status } {
+  set db [ord::get_db]
+  set block [[$db getChip] getBlock]
+  set currentX $startX
+  set currentY $startY
+
+  foreach instName $instances {
+    set inst [$block findInst $instName]
+    if { $inst == "NULL" } {
+      utl::warn "UTL" 4043 "Instance $instName not found. Skipping."
+      continue
+    }
+
+    $inst setOrigin $currentX $currentY
+    $inst setPlacementStatus $status
+
+    set master [$inst getMaster]
+    if { $orientation == "row" } {
+      set width [$master getWidth]
+      set currentX [expr { $currentX + $width + $spacing }]
+    } else {
+      set height [$master getHeight]
+      set currentY [expr { $currentY + $height + $spacing }]
+    }
+  }
+}
+
+# Proc: place_row
+# Description: Places a list of instances in a horizontal row.
+proc place_row { args } {
+  parse_key_args "place_row" args \
+    keys {-instances -startX -startY -spacing -status} \
+    flags {}
+
+  set spacing [expr { [info exists keys(-spacing)] ? $keys(-spacing) : 0 }]
+  set status [expr { [info exists keys(-status)] ? $keys(-status) : "FIRM" }]
+
+  _place_line "row" $keys(-instances) $keys(-startX) $keys(-startY) $spacing $status
+}
+
+# Proc: place_column
+# Description: Places a list of instances in a vertical column.
+proc place_column { args } {
+  parse_key_args "place_column" args \
+    keys {-instances -startX -startY -spacing -status} \
+    flags {}
+
+  set spacing [expr { [info exists keys(-spacing)] ? $keys(-spacing) : 0 }]
+  set status [expr { [info exists keys(-status)] ? $keys(-status) : "FIRM" }]
+
+  _place_line "column" $keys(-instances) $keys(-startX) $keys(-startY) $spacing $status
+}


### PR DESCRIPTION

Resolves #4041.
This PR introduces foundational TCL utility scripts to enable quick manual placement of instances in structured rows or columns. This is essential for building structured datapath blocks, register files, and analog-like layouts where automated placement might not meet specific density or symmetry requirements.

Places a list of instances in a vertical stack. `place_row`: Places a list of instances in a horizontal row.Automated snapping: Uses OpenDB (`odb`) to calculate cell dimensions and ensure legalized placement.Configurable spacing and placement status (`FIRM`, `PLACED`, `LOCKED`).

