### PR TITLE
odb: fix wire decoding when the target shape is connected to a colinear junction

### DIFF
--- a/src/odb/src/db/dbWire.cpp
+++ b/src/odb/src/db/dbWire.cpp
@@ -556,7 +556,8 @@ state_machine_update: {
     }
   } else if (state <= 3) {
     if ((opcode & WOP_EXTENSION) && !ignore_ext) {
-      cur_ext = wire->data_[idx + 1];
+      const WireOp wire_op = static_cast<WireOp>(opcode & WOP_OPCODE_MASK);
+      cur_ext = wire_op == kColinear ? wire->data_[idx] : wire->data_[idx + 1];
       has_cur_ext = true;
     }
   }
@@ -786,7 +787,8 @@ state_machine_update: {
     }
   } else if (state <= 3) {
     if ((opcode & WOP_EXTENSION) && !ignore_ext) {
-      cur_ext = wire->data_[idx + 1];
+      const WireOp wire_op = static_cast<WireOp>(opcode & WOP_OPCODE_MASK);
+      cur_ext = wire_op == kColinear ? wire->data_[idx] : wire->data_[idx + 1];
       has_cur_ext = true;
     }
   }

--- a/src/odb/test/cpp/TestDbWire.cc
+++ b/src/odb/test/cpp/TestDbWire.cc
@@ -150,4 +150,45 @@ TEST_F(OdbMultiPatternedTest, WireColorIsClearedOnNewPath)
   EXPECT_EQ(decoder.getColor().value(), /*mask_color=*/2);
 }
 
+// For a wire with two segments connected by a kColinear junction
+// with extensions, check if the shape of the second segment is
+// correctly computed.
+TEST_F(OdbMultiPatternedTest, GetSegmentWithColinearExtension)
+{
+  dbTech* tech = lib_->getTech();
+  dbTechLayer* metal1 = tech->findLayer("met1");
+  ASSERT_NE(metal1, nullptr);
+
+  dbNet* net = dbNet::create(block_, "net");
+  dbWire* wire = dbWire::create(net);
+  dbWireEncoder encoder;
+  encoder.begin(wire);
+
+  // Create segment A.
+  const int junction_x = 50000;
+  const int junction_y = 10000;
+  encoder.newPath(metal1, dbWireType::ROUTED);
+  encoder.addPoint(0, junction_y);
+  const int junction_id = encoder.addPoint(junction_x, junction_y);
+
+  // Create segment B.
+  const int extension = 800;
+  encoder.newPathExt(junction_id, extension);  // Inserts kColinear junction.
+  const int segment_b_length = 500;
+  const int segment_b_shape_id
+      = encoder.addPoint(junction_x + segment_b_length, junction_y);
+  encoder.end();
+
+  dbShape shape;
+  wire->getSegment(segment_b_shape_id, shape);
+
+  const int half_width = metal1->getWidth() / 2;
+  const odb::Rect expected(junction_x - extension,
+                           junction_y - half_width,
+                           junction_x + segment_b_length + half_width,
+                           junction_y + half_width);
+
+  EXPECT_EQ(shape.getBox(), expected);
+}
+
 }  // namespace odb


### PR DESCRIPTION
Related to [#3969](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3969).

### Context

While using the new segment regression from [#3989](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3989) to generate new `set_layer_rc` values for asap7, I stumbled into a behavior in which, only on `M2`, the regression coefficient of determination was  very poor for **resistance**.

This didn't seem to make any sense, because, based on the fact that the RCX extraction model computes resistance as

```
R = sheet_resistance * length / width
```

And for minimum-width segments width is constant and we'd have:

```
R = (sheet_resistance / width) * length = reg_coef * length
```

The result is literally a linear relation, so we should have `R² == 1` - which we do for all the other layers.

After some debugging I realized that in the generated RC `.csv` there was a couple of very large segments (literally the size of the entire core width) of a certain net with a much lower per-length resistance than the rest of the segments. After using the GUI to take a look at the net it became clear that the segments' shapes were being wrongly computed as it was a net with relatively short segments.

Example of a net (signal) with segments being wrongly computed by `odb::Wire::getShape` on asap7/ibex, A and B are the problematic segments:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e415ab32-f4e2-4856-9508-82b7a2a8edc3" />

| Segment | Shape (wrong coord. in bold) |
|-------|--------|
| <img width="200" alt="image" src="https://github.com/user-attachments/assets/de76287f-5d67-4d4d-851f-7f2d64df4f77" /> | (58896, 63324) (**118242**, 63342) |
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/cb706d25-08fc-4863-9849-50585e5b7814" /> | (**-792**, 65718) (61506, 65736) |

As we can see the point is wrongly computed for the colinear junctions of these segments (right junction in the first one, left junction on the second one).
### Problem

1. Colinear junctions are not correctly handled by the decoder state machine in `dbWire::getSegment`. The decoder currently treats the junction as if it were non colinear and retrieves the extension value from the wrong `data_` index. The extension value for a `kColinear` junction is stored in its own index (`data_[idx]`):

| Entry | Opcode | Data |
|-------|--------|------|
| 0 | `kJunction` | `jct_id` |
| 1 | `kColinear \| WOP_EXTENSION` | `extension` ← read from `data_[idx]` |
| 2 | `kX` | `x_coord` |

_Currently, the decoder is reading the extension value from `data_[idx+1]` and giving the wrong extension value to the function that actually computes the geometry, resulting in wrong final geometry._

### Changes

When decoding and stumbling into a kColinear junction, retrieve the extension value correctly.
