### PR TITLE
UPF: Added create_supply_net command

### DIFF
--- a/src/upf/include/upf/upf.h
+++ b/src/upf/include/upf/upf.h
@@ -26,8 +26,9 @@ bool update_power_domain(utl::Logger* logger,
                          
 bool create_supply_net(utl::Logger* logger,
                        odb::dbBlock* block,
-                       const std::string& name);
-
+                       const std::string& name,
+                       odb::dbSigType type = odb::dbSigType::POWER);
+                       
 bool create_logic_port(utl::Logger* logger,
                        odb::dbBlock* block,
                        const std::string& name,

--- a/src/upf/include/upf/upf.h
+++ b/src/upf/include/upf/upf.h
@@ -23,6 +23,10 @@ bool update_power_domain(utl::Logger* logger,
                          odb::dbBlock* block,
                          const std::string& name,
                          const std::string& element);
+                         
+bool create_supply_net(utl::Logger* logger,
+                       odb::dbBlock* block,
+                       const std::string& name);
 
 bool create_logic_port(utl::Logger* logger,
                        odb::dbBlock* block,

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -56,7 +56,8 @@ bool update_power_domain(utl::Logger* logger,
 
 bool create_supply_net(utl::Logger* logger,
                        odb::dbBlock* block,
-                       const std::string& name)
+                       const std::string& name,
+                       odb::dbSigType type = odb::dbSigType::POWER)
 {
     odb::dbNet* net = block->findNet(name.c_str());
     if (net) {
@@ -66,12 +67,12 @@ bool create_supply_net(utl::Logger* logger,
 
     net = odb::dbNet::create(block, name.c_str());
     if (!net) {
-        logger->error(utl::UPF, 62, "Failed to create net '{}'", name);
+        logger->error(utl::UPF, 63, "Failed to create net '{}'", name);
         return false;
     }
 
-    logger->info(utl::UPF, 62, "Created supply net '{}'", name);
-
+    net->setSigType(type);
+    logger->info(utl::UPF, 64, "Created supply net '{}'", name);
     return true;
 }
 

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -54,6 +54,28 @@ bool update_power_domain(utl::Logger* logger,
   return true;
 }
 
+bool create_supply_net(utl::Logger* logger,
+                       odb::dbBlock* block,
+                       const std::string& name)
+{
+    odb::dbNet* net = block->findNet(name.c_str());
+    if (net) {
+        logger->warn(utl::UPF, 62, "Supply net '{}' already exists", name);
+        return false;
+    }
+
+    net = odb::dbNet::create(block, name.c_str());
+    if (!net) {
+        logger->error(utl::UPF, 62, "Failed to create net '{}'", name);
+        return false;
+    }
+
+    logger->info(utl::UPF, 62, "Created supply net '{}'", name);
+
+    return true;
+}
+
+
 bool create_logic_port(utl::Logger* logger,
                        odb::dbBlock* block,
                        const std::string& name,

--- a/src/upf/src/upf.i
+++ b/src/upf/src/upf.i
@@ -30,6 +30,12 @@
         getOpenRoad()->getLogger(), db->getChip()->getBlock(), name, element); 
   }
 
+  void create_supply_net_cmd(const char* name)
+  {
+      odb::dbDatabase* db = getOpenRoad()->getDb();
+      create_supply_net(getOpenRoad()->getLogger(), db->getChip()->getBlock(), name);
+  }
+
   void create_logic_port_cmd(const char* name, const char* direction)
   {
     odb::dbDatabase* db = getOpenRoad()->getDb();

--- a/src/upf/src/upf.i
+++ b/src/upf/src/upf.i
@@ -30,10 +30,16 @@
         getOpenRoad()->getLogger(), db->getChip()->getBlock(), name, element); 
   }
 
-  void create_supply_net_cmd(const char* name)
+ void create_supply_net_cmd(const char* name, const char* type_str = "POWER")
   {
       odb::dbDatabase* db = getOpenRoad()->getDb();
-      create_supply_net(getOpenRoad()->getLogger(), db->getChip()->getBlock(), name);
+      odb::dbBlock* block = db->getChip()->getBlock();
+
+      odb::dbSigType type = odb::dbSigType::POWER;
+      if (strcasecmp(type_str, "GROUND") == 0)
+          type = odb::dbSigType::GROUND;
+
+      create_supply_net(getOpenRoad()->getLogger(), block, name, type);
   }
 
   void create_logic_port_cmd(const char* name, const char* direction)

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -46,6 +46,20 @@ proc create_power_domain { args } {
   }
 }
 
+sta::define_cmd_args "create_supply_net" { name }
+proc create_supply_net { args } {
+    upf::check_block_exists
+
+    sta::parse_key_args "create_supply_net" args \
+        keys {} flags {}
+
+    sta::check_argc_eq1 "create_supply_net" $args
+
+    set net_name [lindex $args 0]
+
+    upf::create_supply_net_cmd $net_name
+}
+
 # Create a logic port to be used within defined domains
 #
 # Arguments:

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -46,19 +46,26 @@ proc create_power_domain { args } {
   }
 }
 
-sta::define_cmd_args "create_supply_net" { name }
+sta::define_cmd_args "create_supply_net" { [-type type] name }
 proc create_supply_net { args } {
     upf::check_block_exists
 
     sta::parse_key_args "create_supply_net" args \
-        keys {} flags {}
+        keys {-type} flags {}
 
     sta::check_argc_eq1 "create_supply_net" $args
 
     set net_name [lindex $args 0]
 
-    upf::create_supply_net_cmd $net_name
+    # Default to POWER if not provided
+    set net_type [dict get keys -type]
+    if { $net_type eq "" } {
+        set net_type "POWER"
+    }
+
+    upf::create_supply_net_cmd $net_name $net_type
 }
+
 
 # Create a logic port to be used within defined domains
 #


### PR DESCRIPTION
Description:
This draft PR adds internal support for creating supply nets in the UPF module. Supply nets are important for power distribution in designs and can be used in future UPF commands.

Changes include:

src/upf/src/upf.cpp: Added create_supply_net function that creates a new net in the current block, checks for duplicates, and logs success/failure.

src/upf/include/upf/upf.h: Declared create_supply_net function for internal use.

src/upf/src/upf.i: Added SWIG binding create_supply_net_cmd for possible Tcl access.

src/upf/src/upf.tcl: Added Tcl wrapper procedure create_supply_net for future scripting support.

Notes:

No changes to existing UPF commands or APIs.

Logging ID 62 follows the pattern in upf.cpp.

This PR is submitted as a draft for review; testing and further integration will be added in future PRs.Will be updated soon maybe ..

Motivation:

Addresses the missing internal UPF option for supply nets as discussed in Issue #5617.

Lays the groundwork for future UPF commands that require supply nets.