### PR TITLE
fix: add validation for missing -solution_file in evaluate_hypergraph_solution

### DIFF
--- a/src/par/src/partitionmgr.tcl
+++ b/src/par/src/partitionmgr.tcl
@@ -318,6 +318,9 @@ proc evaluate_hypergraph_solution { args } {
     utl::error PAR 0925 "Missing mandatory argument -hypergraph_file."
   }
   set hypergraph_file $keys(-hypergraph_file)
+  if { ![info exists keys(-solution_file)] } {
+    utl::error PAR 0926 "Missing mandatory argument -solution_file."
+  }
   set solution_file $keys(-solution_file)
   set num_parts 2
   set base_balance { 1.0 }


### PR DESCRIPTION
## SUMMARY

This PR adds a simple check for the `-solution_file` argument in `evaluate_hypergraph_solution`. If the argument is missing, the command now shows a clear OpenROAD error instead of a confusing Tcl array error.

Affected file: **`src/par/src/partitionmgr.tcl`**

---

## FIX

**Problem**

`-solution_file` was accessed without checking if it exists.

**Before**

```tcl
set solution_file $keys(-solution_file)
```

If the argument was missing, Tcl produced:

```
can't read "keys(-solution_file)": no such element in array
```

**After**

A guard check was added:

```tcl
if { ![info exists keys(-solution_file)] } {
  utl::error PAR 0926 "Missing mandatory argument -solution_file."
}
set solution_file $keys(-solution_file)
```

Now users get a clear error message.

---

## VERIFICATION

Run the command without `-solution_file`:

```
evaluate_hypergraph_solution -hypergraph_file design.hgr
```

**Before:** Tcl array error
**After:** `PAR 0926 Missing mandatory argument -solution_file.`

Running the command with both arguments works the same as before.
