### PR TITLE
Add the import of cc_library() in openmp build rule.

### DIFF
--- a/bazel/openmp/bundled.BUILD.bazel
+++ b/bazel/openmp/bundled.BUILD.bazel
@@ -14,6 +14,7 @@
 
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "openmp",


### PR DESCRIPTION
This was implicit in the olden days, but these days we should be explicit to be compatible with future bazel versions.