### PR TITLE
gpl,cts: replace global srand/rand with std::mt19937

### DIFF
--- a/src/cts/src/Clustering.cpp
+++ b/src/cts/src/Clustering.cpp
@@ -59,7 +59,6 @@ Clustering::Clustering(const std::vector<std::pair<float, float>>& sinks,
     : Clustering(sinks, logger)
 {
   branching_point_ = {xBranch, yBranch};
-  srand(56);
 }
 
 Clustering::~Clustering() = default;

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -1318,7 +1318,7 @@ void MBFF::GetSlots(const Point& tray,
 
 Flop MBFF::GetNewFlop(const std::vector<Flop>& prob_dist, const float tot_dist)
 {
-  const float rand_num = (float) (std::rand() % 101);
+  const float rand_num = (float) (rng_() % 101);
   float cum_sum = 0;
   Flop new_flop;
   for (size_t i = 0; i < prob_dist.size(); i++) {
@@ -1339,7 +1339,7 @@ void MBFF::GetStartTrays(std::vector<Flop> flops,
   const int num_flops = flops.size();
 
   /* pick a random flop */
-  const int rand_idx = std::rand() % (num_flops);
+  const int rand_idx = rng_() % (num_flops);
   Tray tray_zero;
   tray_zero.pt = flops[rand_idx].pt;
 
@@ -1847,7 +1847,7 @@ void MBFF::KMeansDecomp(const std::vector<Flop>& flops,
   std::vector<std::vector<int>> rand_nums(multistart_ + 7);
   for (int i = 0; i < multistart_ + 7; i++) {
     for (int j = 0; j < 20; j++) {
-      rand_nums[i].push_back(std::rand());
+      rand_nums[i].push_back(rng_());
     }
   }
 
@@ -2233,7 +2233,7 @@ void MBFF::SetTrayNames()
 
 void MBFF::Run(const int mx_sz, const float alpha, const float beta)
 {
-  std::srand(1);
+  rng_.seed(1);
   omp_set_num_threads(num_threads_);
 
   ReadFFs();

--- a/src/gpl/src/mbff.h
+++ b/src/gpl/src/mbff.h
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <memory>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
@@ -245,6 +246,7 @@ class MBFF
   int multistart_;
   int num_paths_;
   float multiplier_;
+  std::mt19937 rng_{1};  // deterministic seed, replaces global srand/rand
 
   // single-bit FF vars
   std::vector<Flop> flops_;

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -1897,8 +1897,6 @@ NesterovBase::NesterovBase(
              "---- Initialize Nesterov Region: {}",
              pb_->getGroup() ? pb_->getGroup()->getName() : "Top-level");
 
-  // Set a fixed seed
-  srand(42);
   // area update from pb
   stdInstsArea_ = pb_->stdInstsArea();
   macroInstsArea_ = pb_->macroInstsArea();
@@ -1911,9 +1909,10 @@ NesterovBase::NesterovBase(
   nb_gcells_.reserve(pb_->getInsts().size() + fillerStor_.size());
 
   // add place instances
+  std::mt19937 rng(42);  // deterministic seed, replaces global srand/rand
   for (auto& pb_inst : pb_->placeInsts()) {
-    int x_offset = rand() % (2 * dbu_per_micron) - dbu_per_micron;
-    int y_offset = rand() % (2 * dbu_per_micron) - dbu_per_micron;
+    int x_offset = rng() % (2 * dbu_per_micron) - dbu_per_micron;
+    int y_offset = rng() % (2 * dbu_per_micron) - dbu_per_micron;
 
     GCell* gCell = nbc_->pbToNb(pb_inst);
     if (pb_inst != gCell->insts()[0]) {


### PR DESCRIPTION
## Summary

- **gpl/mbff.cpp**: `std::rand()` was called from `GetNewFlop()` and `GetStartTrays()`, which are invoked inside `#pragma omp parallel for` regions (lines 1854, 1877). Since `rand()` uses global state, this is a data race (undefined behavior). Replaced with a class member `std::mt19937 rng_` seeded deterministically.
- **gpl/nesterovBase.cpp**: Replaced `srand(42)` + `rand()` with a local `std::mt19937` with the same seed.
- **cts/Clustering.cpp**: Removed dead `srand(56)` call — no `rand()` calls exist in the CTS module.

## Test plan
- [ ] Existing GPL tests pass (MBFF clustering uses the same deterministic seed)
- [ ] Verify nesterovBase initial placement offsets are unchanged (same seed value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)