### PR TITLE
pdn: add missing guards for -layers and -cut_pitch in add_sroute_connect

### DIFF
--- a/src/pdn/src/pdn.tcl
+++ b/src/pdn/src/pdn.tcl
@@ -670,6 +670,19 @@ proc add_sroute_connect { args } {
       -metalspaces -ongrid -insts} \
     flags {}
 
+  if { ![info exists keys(-layers)] } {
+    utl::error PDN 1193 "The -layers argument is required."
+  }
+  if { [llength $keys(-layers)] != 2 } {
+    utl::error PDN 1195 "The -layers argument must be a list of 2 layers."
+  }
+  if { ![info exists keys(-cut_pitch)] } {
+    utl::error PDN 1194 "The -cut_pitch argument is required."
+  }
+  if { [llength $keys(-cut_pitch)] != 2 } {
+    utl::error PDN 1196 "The -cut_pitch argument must be a list of 2 pitch values."
+  }
+
   set l0 [pdn::get_layer [lindex $keys(-layers) 0]]
   set l1 [pdn::get_layer [lindex $keys(-layers) 1]]
 


### PR DESCRIPTION
## SUMMARY

This PR improves validation in `add_sroute_connect` by checking that required arguments `-layers` and `-cut_pitch` are present and correctly formed. It also ensures both are lists of exactly two values, avoiding confusing runtime errors.

---

## FIX

* Add checks for missing `-layers` and `-cut_pitch`
* Validate both arguments have exactly 2 elements
* Return clear error messages instead of Tcl crashes

**Errors:**

* PDN 1193: The -layers argument is required.
* PDN 1194: The -cut_pitch argument is required.
* PDN 1195: The -layers argument must be a list of 2 layers.
* PDN 1196: The -cut_pitch argument must be a list of 2 pitch values.

---

## VERIFICATION

Before, missing or invalid inputs caused unclear errors.
Now, errors clearly tell what’s wrong, and valid inputs behave the same as before.
