### PR TITLE
fix: sort glob results in man_tcl_check tests for determinism

### DIFF
--- a/src/ant/test/ant_man_tcl_check.py
+++ b/src/ant/test/ant_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/cts/test/cts_man_tcl_check.py
+++ b/src/cts/test/cts_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/dft/test/dft_man_tcl_check.py
+++ b/src/dft/test/dft_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/dpl/test/dpl_man_tcl_check.py
+++ b/src/dpl/test/dpl_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/drt/test/drt_man_tcl_check.py
+++ b/src/drt/test/drt_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/fin/test/fin_man_tcl_check.py
+++ b/src/fin/test/fin_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/gpl/test/gpl_man_tcl_check.py
+++ b/src/gpl/test/gpl_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/grt/test/grt_man_tcl_check.py
+++ b/src/grt/test/grt_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/gui/test/gui_man_tcl_check.py
+++ b/src/gui/test/gui_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/ifp/test/ifp_man_tcl_check.py
+++ b/src/ifp/test/ifp_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/mpl/test/mpl_man_tcl_check.py
+++ b/src/mpl/test/mpl_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/odb/test/odb_man_tcl_check.py
+++ b/src/odb/test/odb_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/pad/test/pad_man_tcl_check.py
+++ b/src/pad/test/pad_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/par/test/par_man_tcl_check.py
+++ b/src/par/test/par_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/pdn/test/pdn_man_tcl_check.py
+++ b/src/pdn/test/pdn_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/ppl/test/ppl_man_tcl_check.py
+++ b/src/ppl/test/ppl_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/psm/test/psm_man_tcl_check.py
+++ b/src/psm/test/psm_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/rcx/test/rcx_man_tcl_check.py
+++ b/src/rcx/test/rcx_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/rmp/test/rmp_man_tcl_check.py
+++ b/src/rmp/test/rmp_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/rsz/test/rsz_man_tcl_check.py
+++ b/src/rsz/test/rsz_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/stt/test/stt_man_tcl_check.py
+++ b/src/stt/test/stt_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/tap/test/tap_man_tcl_check.py
+++ b/src/tap/test/tap_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/upf/test/upf_man_tcl_check.py
+++ b/src/upf/test/upf_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue

--- a/src/utl/test/utl_man_tcl_check.py
+++ b/src/utl/test/utl_man_tcl_check.py
@@ -17,7 +17,7 @@ help_dict, proc_dict, readme_dict = {}, {}, {}
 exclude = ["sta"]
 include = ["./src/odb/src/db/odb.tcl"]
 
-for path in glob.glob("./src/*/src/*tcl") + include:
+for path in sorted(glob.glob("./src/*/src/*tcl")) + include:
     # exclude all dirs other than the current dir.
     if module not in path:
         continue


### PR DESCRIPTION
Unsorted glob ordering caused rcx_man_tcl_check to produce different results on CI vs locally when multiple Tcl files exist for a module.