### PR TITLE
Add Timing Python API for GUI-free timing reports

### DIFF
--- a/include/ord/Timing.h
+++ b/include/ord/Timing.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+#include <utility>
 #include <vector>
 
 #include "sta/Clock.hh"
@@ -35,6 +37,47 @@ namespace ord {
 
 class Design;
 class OpenRoad;
+
+// ── Timing report structs (top-level for SWIG compatibility) ──
+struct ClockInfo
+{
+  std::string name;
+  float period;
+  std::vector<float> waveform;
+  std::vector<std::string> sources;
+};
+
+struct TimingArcInfo
+{
+  std::string from_pin;
+  std::string to_pin;
+  std::string cell_name;
+  float delay;
+  float slew;
+  float load;
+  int fanout;
+  bool is_rising;
+  bool is_net;
+};
+
+struct TimingPathInfo
+{
+  float slack;
+  float path_delay;
+  float arrival;
+  float required;
+  float skew;
+  float logic_delay;
+  int logic_depth;
+  int fanout;
+  std::string startpoint;
+  std::string endpoint;
+  std::string start_clock;
+  std::string end_clock;
+  std::string path_group;
+  std::vector<TimingArcInfo> arcs;
+};
+
 class Timing
 {
  public:
@@ -81,6 +124,23 @@ class Timing
 
   void makeEquivCells();
   std::vector<odb::dbMaster*> equivCells(odb::dbMaster* master);
+
+  // ── Summary metrics ─────────────────────────────────────────
+  float getWorstSlack(MinMax minmax = Max);
+  float getTotalNegativeSlack(MinMax minmax = Max);
+  int getEndpointCount();
+
+  // ── Endpoint slack map (histogram data source) ──────────────
+  std::vector<std::pair<std::string, float>> getEndpointSlackMap(MinMax minmax
+                                                                 = Max);
+
+  // ── Clock domain info ───────────────────────────────────────
+  std::vector<ClockInfo> getClockInfo();
+
+  // ── Timing paths with arc detail ────────────────────────────
+  std::vector<TimingPathInfo> getTimingPaths(MinMax minmax = Max,
+                                             int max_paths = 100,
+                                             float slack_threshold = 1e30);
 
  private:
   sta::dbSta* getSta();

--- a/src/OpenRoad-py.i
+++ b/src/OpenRoad-py.i
@@ -3,6 +3,7 @@
 
 %include <std_string.i>
 %include <std_vector.i>
+%include <std_pair.i>
 %include <stdint.i>
 
 %{
@@ -52,9 +53,17 @@ get_db_block();
 %template(Corners) std::vector<sta::Scene*>;
 %template(MTerms) std::vector<odb::dbMTerm*>;
 %template(Masters) std::vector<odb::dbMaster*>;
+%template(FloatVec) std::vector<float>;
+%template(StringVec) std::vector<std::string>;
+%template(EndpointSlackPair) std::pair<std::string, float>;
+%template(EndpointSlackMap) std::vector<std::pair<std::string, float>>;
 %include "ord/Tech.h"
 %include "ord/Design.h"
+
 %include "ord/Timing.h"
+%template(ClockInfoVec) std::vector<ord::ClockInfo>;
+%template(TimingArcInfoVec) std::vector<ord::TimingArcInfo>;
+%template(TimingPathInfoVec) std::vector<ord::TimingPathInfo>;
 
 #ifdef BAZEL
 %include "src/gpl/src/replace-py.i"

--- a/src/Timing.cc
+++ b/src/Timing.cc
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstring>
 #include <set>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -20,14 +21,22 @@
 #include "sta/Clock.hh"
 #include "sta/DelayFloat.hh"
 #include "sta/Graph.hh"
+#include "sta/GraphDelayCalc.hh"
 #include "sta/Liberty.hh"
 #include "sta/LibertyClass.hh"
 #include "sta/MinMax.hh"
 #include "sta/Mode.hh"
+#include "sta/Path.hh"
+#include "sta/PathEnd.hh"
+#include "sta/PathExpanded.hh"
+#include "sta/PathGroup.hh"
 #include "sta/PowerClass.hh"
 #include "sta/Scene.hh"
+#include "sta/Sdc.hh"
 #include "sta/SdcClass.hh"
 #include "sta/Search.hh"
+#include "sta/SearchClass.hh"
+#include "sta/StringUtil.hh"
 #include "sta/TimingArc.hh"
 #include "sta/TimingRole.hh"
 #include "utl/Logger.h"
@@ -404,4 +413,232 @@ std::vector<odb::dbMaster*> Timing::equivCells(odb::dbMaster* master)
   }
   return master_seq;
 }
+float Timing::getWorstSlack(MinMax minmax)
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  return sta->worstSlack(getMinMax(minmax));
+}
+
+float Timing::getTotalNegativeSlack(MinMax minmax)
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  return sta->totalNegativeSlack(getMinMax(minmax));
+}
+
+int Timing::getEndpointCount()
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  return sta->endpoints().size();
+}
+
+std::vector<std::pair<std::string, float>> Timing::getEndpointSlackMap(
+    MinMax minmax)
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  sta::dbNetwork* network = sta->getDbNetwork();
+
+  std::vector<std::pair<std::string, float>> result;
+  for (sta::Vertex* vertex : sta->endpoints()) {
+    const sta::Pin* pin = vertex->pin();
+    float slack = sta->slack(
+        pin, sta::RiseFallBoth::riseFall(), sta->scenes(), getMinMax(minmax));
+    const char* pin_name = network->pathName(pin);
+    result.emplace_back(pin_name, slack);
+  }
+  return result;
+}
+
+std::vector<ClockInfo> Timing::getClockInfo()
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  sta::dbNetwork* network = sta->getDbNetwork();
+
+  std::vector<ClockInfo> result;
+  for (const sta::Clock* clk : sta->cmdMode()->sdc()->clocks()) {
+    ClockInfo info;
+    info.name = clk->name();
+    info.period = clk->period();
+    if (clk->waveform()) {
+      info.waveform = *clk->waveform();
+    }
+    for (const sta::Pin* pin : clk->pins()) {
+      info.sources.emplace_back(network->pathName(pin));
+    }
+    result.push_back(std::move(info));
+  }
+  return result;
+}
+
+std::vector<TimingPathInfo> Timing::getTimingPaths(MinMax minmax,
+                                                   int max_paths,
+                                                   float slack_threshold)
+{
+  sta::dbSta* sta = getSta();
+  cmdLinkedNetwork();
+  sta::dbNetwork* network = sta->getDbNetwork();
+
+  const bool is_setup = (minmax == Max);
+  sta::SceneSeq scenes = sta->scenes();
+  sta::StringSeq group_names;
+
+  sta::Search* search = sta->search();
+  sta::PathEndSeq path_ends = search->findPathEnds(
+      nullptr,  // from
+      nullptr,  // thrus
+      nullptr,  // to
+      false,    // unconstrained
+      scenes,
+      is_setup ? sta::MinMaxAll::max() : sta::MinMaxAll::min(),
+      max_paths,        // group_count
+      1,                // endpoint_count (one per endpoint)
+      true,             // unique_pins
+      true,             // unique_edges
+      -sta::INF,        // slack_min
+      slack_threshold,  // slack_max
+      true,             // sort_by_slack
+      group_names,
+      is_setup,   // setup
+      !is_setup,  // hold
+      false,      // recovery
+      false,      // removal
+      false,      // clk_gating_setup
+      false);     // clk_gating_hold
+
+  std::vector<TimingPathInfo> result;
+  auto* graph = sta->graph();
+
+  for (auto& path_end : path_ends) {
+    TimingPathInfo path_info;
+    sta::Path* path = path_end->path();
+
+    path_info.slack = path_end->slack(sta);
+    path_info.arrival = path_end->dataArrivalTime(sta);
+    path_info.required = path_end->requiredTime(sta);
+    path_info.skew = path_end->clkSkew(sta);
+
+    auto* path_delay = path_end->pathDelay();
+    path_info.path_delay = path_delay ? path_delay->delay() : 0.0f;
+
+    auto* start_clk_edge = path_end->sourceClkEdge(sta);
+    path_info.start_clock
+        = start_clk_edge ? start_clk_edge->clock()->name() : "";
+
+    auto* end_clk = path_end->targetClk(sta);
+    path_info.end_clock = end_clk ? end_clk->name() : "";
+
+    auto* path_group = path_end->pathGroup();
+    path_info.path_group = path_group ? path_group->name() : "";
+
+    // Expand path to get arc detail
+    sta::PathExpanded expand(path, sta);
+    float arrival_prev = 0.0f;
+    float logic_delay_total = 0.0f;
+    int logic_depth_count = 0;
+    int max_fanout = 0;
+    std::unordered_set<sta::Instance*> logic_insts;
+
+    for (size_t i = 0; i < expand.size(); i++) {
+      const auto* ref = expand.path(i);
+      sta::Vertex* vertex = ref->vertex(sta);
+      const sta::Pin* pin = vertex->pin();
+      const bool is_rising = ref->transition(sta) == sta::RiseFall::rise();
+      const float arr = sta::delayAsFloat(ref->arrival());
+      const float slw = sta::delayAsFloat(ref->slew(sta));
+      const float pin_delay = arr - arrival_prev;
+
+      // Compute fanout
+      int node_fanout = 0;
+      const sta::Sdc* sdc = sta->cmdScene()->sdc();
+      sta::VertexOutEdgeIterator iter(vertex, graph);
+      while (iter.hasNext()) {
+        sta::Edge* edge = iter.next();
+        if (edge->isWire()) {
+          const sta::Pin* to_pin = edge->to(graph)->pin();
+          if (network->isTopLevelPort(to_pin)) {
+            sta::Port* port = network->port(to_pin);
+            node_fanout += sdc->portExtFanout(port, sta::MinMax::max()) + 1;
+          } else {
+            node_fanout++;
+          }
+        }
+      }
+      max_fanout = std::max(node_fanout, max_fanout);
+
+      // Compute load capacitance
+      float cap = 0.0f;
+      const bool is_driver = network->isDriver(pin);
+      if (is_driver && i > 0) {
+        sta::GraphDelayCalc* gdc = sta->graphDelayCalc();
+        cap = gdc->loadCap(
+            pin, ref->transition(sta), ref->scene(sta), ref->minMax(sta));
+      }
+
+      // Determine cell name and whether this is a net arc
+      bool is_net = false;
+      std::string cell_name;
+      if (i > 0) {
+        const auto* prev_ref = expand.path(i - 1);
+        sta::Vertex* prev_vertex = prev_ref->vertex(sta);
+        const sta::Pin* prev_pin = prev_vertex->pin();
+        sta::Instance* inst = network->instance(pin);
+        sta::Instance* prev_inst = network->instance(prev_pin);
+        if (inst != prev_inst || inst == nullptr) {
+          is_net = true;
+          cell_name = "net";
+        } else {
+          sta::Cell* cell = network->cell(inst);
+          if (cell) {
+            cell_name = network->name(cell);
+          }
+        }
+
+        // Track logic depth (non-clock, non-net arcs)
+        bool pin_is_clock = sta->isClock(pin, sta->cmdScene()->mode());
+        if (!is_net && !pin_is_clock && inst) {
+          if (logic_insts.find(inst) == logic_insts.end()) {
+            logic_insts.insert(inst);
+            logic_depth_count++;
+            logic_delay_total += pin_delay;
+          }
+        }
+      }
+
+      if (i > 0) {
+        TimingArcInfo arc;
+        const auto* prev_ref = expand.path(i - 1);
+        sta::Vertex* prev_vertex = prev_ref->vertex(sta);
+        arc.from_pin = network->pathName(prev_vertex->pin());
+        arc.to_pin = network->pathName(pin);
+        arc.cell_name = cell_name;
+        arc.delay = pin_delay;
+        arc.slew = slw;
+        arc.load = cap;
+        arc.fanout = node_fanout;
+        arc.is_rising = is_rising;
+        arc.is_net = is_net;
+        path_info.arcs.push_back(std::move(arc));
+      }
+
+      arrival_prev = arr;
+    }
+
+    // Get startpoint/endpoint names
+    sta::Vertex* start_vertex = expand.path(0)->vertex(sta);
+    path_info.startpoint = network->pathName(start_vertex->pin());
+    path_info.endpoint = network->pathName(path_end->vertex(sta)->pin());
+
+    path_info.logic_delay = logic_delay_total;
+    path_info.logic_depth = logic_depth_count;
+    path_info.fanout = max_fanout;
+
+    result.push_back(std::move(path_info));
+  }
+  return result;
+}
+
 }  // namespace ord

--- a/test/BUILD
+++ b/test/BUILD
@@ -87,6 +87,7 @@ PYTHON_TESTS = [
     "timing_api_2",
     "timing_api_3",
     "timing_api_4",
+    "timing_report_api",
     "two_designs",
 ]
 

--- a/test/timing_report_api.py
+++ b/test/timing_report_api.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+
+from openroad import Tech, Design, Timing
+
+tech = Tech()
+tech.readLiberty("Nangate45/Nangate45_typ.lib")
+tech.readLef("Nangate45/Nangate45_tech.lef")
+tech.readLef("Nangate45/Nangate45_stdcell.lef")
+
+design = Design(tech)
+design.readDef("gcd_nangate45.def")
+design.evalTclString("read_sdc timing_api_3.sdc")
+timing = Timing(design)
+
+# Test getWorstSlack
+setup_wns = timing.getWorstSlack(Timing.Max)
+hold_wns = timing.getWorstSlack(Timing.Min)
+print(f"setup_wns_finite: {not timing.isTimeInf(setup_wns)}")
+print(f"hold_wns_finite: {not timing.isTimeInf(hold_wns)}")
+
+# Test getTotalNegativeSlack
+setup_tns = timing.getTotalNegativeSlack(Timing.Max)
+hold_tns = timing.getTotalNegativeSlack(Timing.Min)
+print(f"setup_tns_type: {type(setup_tns).__name__}")
+print(f"hold_tns_type: {type(hold_tns).__name__}")
+
+# Test getEndpointCount
+count = timing.getEndpointCount()
+print(f"endpoint_count_positive: {count > 0}")
+
+# Test getEndpointSlackMap
+slack_map = timing.getEndpointSlackMap(Timing.Max)
+print(f"slack_map_nonempty: {len(slack_map) > 0}")
+print(f"slack_map_matches_count: {len(slack_map) == count}")
+# Check that entries have string names and float slacks
+first_name, first_slack = slack_map[0]
+print(f"slack_map_name_type: {type(first_name).__name__}")
+print(f"slack_map_slack_type: {type(first_slack).__name__}")
+
+# Test getClockInfo
+clocks = timing.getClockInfo()
+print(f"clocks_nonempty: {len(clocks) > 0}")
+for clk in clocks:
+    print(
+        f"clock: {clk.name} period={clk.period:.3f} "
+        f"waveform_len={len(clk.waveform)} sources_len={len(clk.sources)}"
+    )
+
+# Test getTimingPaths
+paths = timing.getTimingPaths(Timing.Max, 5)
+print(f"paths_returned: {len(paths)}")
+for i, path in enumerate(paths):
+    print(
+        f"path[{i}]: slack={path.slack:.4f} "
+        f"start={path.startpoint[:30]} "
+        f"end={path.endpoint[:30]} "
+        f"arcs={len(path.arcs)} "
+        f"depth={path.logic_depth}"
+    )
+
+# Test that arcs have expected structure
+if len(paths) > 0 and len(paths[0].arcs) > 0:
+    arc = paths[0].arcs[0]
+    print(f"arc_has_from_pin: {len(arc.from_pin) > 0}")
+    print(f"arc_has_to_pin: {len(arc.to_pin) > 0}")
+    print(f"arc_delay_type: {type(arc.delay).__name__}")
+    print(f"arc_slew_type: {type(arc.slew).__name__}")
+    print(f"arc_is_net_type: {type(arc.is_net).__name__}")
+
+# Test hold paths
+hold_paths = timing.getTimingPaths(Timing.Min, 3)
+print(f"hold_paths_returned: {len(hold_paths)}")
+
+print("timing_report_api: PASS")


### PR DESCRIPTION
Expose timing path data (slack, skew, fanout, delays, slews) through the Python/SWIG API so that external scripts can generate reports without requiring the Qt GUI.

New files:
- include/ord/Timing.h: C++ timing data extraction API
- src/Timing.cc: Implementation using STA internals
- src/OpenRoad-py.i: SWIG bindings for Python access
- test/timing_report_api.py: Basic API smoke test