### PR TITLE
docker: Optimize image size by purging apt cache in dev stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,24 @@ ARG INSTALLER_ARGS=""
 COPY etc/DependencyInstaller.sh /tmp/.
 RUN <<EOF
 set -e
+# 1. Install dependencies via script
 /tmp/DependencyInstaller.sh -ci -base
 /tmp/DependencyInstaller.sh -ci -common -save-deps-prefixes=/etc/openroad_deps_prefixes.txt $INSTALLER_ARGS
+
+# 2. Optimization: Strip libQt5Core if on Ubuntu
 if echo "$fromImage" | grep -q "ubuntu"; then
     echo "fromImage contains 'ubuntu' — stripping section from libQt5Core.so"
     strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so || true
-else
-    echo "Skipping strip command as fromImage does not contain 'ubuntu'"
 fi
+
+# 3. THE DOCKER DIET: Purge apt cache to shrink image size
+# This prevents temporary package lists from being saved into the image layer.
+if command -v apt-get &> /dev/null; then
+    apt-get clean
+    rm -rf /var/lib/apt/lists/*
+fi
+
+# 4. Cleanup temporary files
 rm -f /tmp/DependencyInstaller.sh
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,24 +18,18 @@ ARG INSTALLER_ARGS=""
 COPY etc/DependencyInstaller.sh /tmp/.
 RUN <<EOF
 set -e
-# 1. Install dependencies via script
 /tmp/DependencyInstaller.sh -ci -base
 /tmp/DependencyInstaller.sh -ci -common -save-deps-prefixes=/etc/openroad_deps_prefixes.txt $INSTALLER_ARGS
-
-# 2. Optimization: Strip libQt5Core if on Ubuntu
 if echo "$fromImage" | grep -q "ubuntu"; then
     echo "fromImage contains 'ubuntu' — stripping section from libQt5Core.so"
     strip --remove-section=.note.ABI-tag /usr/lib/x86_64-linux-gnu/libQt5Core.so || true
+else
+    echo "Skipping strip command as fromImage does not contain 'ubuntu'"
 fi
-
-# 3. THE DOCKER DIET: Purge apt cache to shrink image size
-# This prevents temporary package lists from being saved into the image layer.
-if command -v apt-get &> /dev/null; then
-    apt-get clean
+# Purge apt lists (~39MB on Ubuntu/Debian; no-op on RHEL/Rocky).
+if command -v apt-get >/dev/null 2>&1; then
     rm -rf /var/lib/apt/lists/*
 fi
-
-# 4. Cleanup temporary files
 rm -f /tmp/DependencyInstaller.sh
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ if echo "$fromImage" | grep -q "ubuntu"; then
 else
     echo "Skipping strip command as fromImage does not contain 'ubuntu'"
 fi
-# Purge apt lists (~39MB on Ubuntu/Debian; no-op on RHEL/Rocky).
 if command -v apt-get >/dev/null 2>&1; then
     rm -rf /var/lib/apt/lists/*
 fi


### PR DESCRIPTION
It's optimizes the main Dockerfile by cleaning up the `apt` package cache within the `dev` stage. 

 Added `apt-get clean` and `rm -rf /var/lib/apt/lists/*` to the `dev` stage `RUN` block.Ensures that temporary package lists are not persisted in the Docker layers, resulting in a smaller base image for the `builder` and `final` stages.

Reduces the overall footprint of the OpenROAD development and release images, leading to faster CI/CD build times and quicker downloads for end-users. This directly supports the **Onboarding Simplification** project's goal of making installation options more robust and efficient.