### PR TITLE
odb: implement wire bbox test in test_block (Python + TCL)

### DIFF
--- a/src/odb/test/test_block.py
+++ b/src/odb/test/test_block.py
@@ -92,8 +92,16 @@ class TestBlock(odbUnitTest.TestCase):
                 swire, self.lib.getTech().findLayer("L1"), 0, 4000, 100, 4100, "NONE"
             )
         if (flag and test_num == 5) or (not flag and test_num >= 5):
-            pass
-            # TODO ADD WIRE
+            L1 = self.lib.getTech().findLayer("L1")
+            L1.setWidth(200)
+            n_w = odb.dbNet_create(self.block, "n_w")
+            wire = odb.dbWire_create(n_w)
+            encoder = odb.dbWireEncoder()
+            encoder.begin(wire)
+            encoder.newPath(L1, "ROUTED")
+            encoder.addPoint(0, 4500)
+            encoder.addPoint(3000, 4500)
+            encoder.end()
 
     def test_bbox0(self):
         box = self.block.getBBox()
@@ -134,6 +142,12 @@ class TestBlock(odbUnitTest.TestCase):
         box = self.block.getBBox()
         self.block_placement(4, False)
         self.check_box_rect(-1580, -1000, 2550, 4100)
+
+    def test_bbox5(self):
+        box = self.block.getBBox()
+        self.block_placement(5, False)
+        # xMax is 3100 (not 3000): wire endpoint is extended by half-width (100).
+        self.check_box_rect(-1580, -1000, 3100, 4600)
 
 
 if __name__ == "__main__":

--- a/src/odb/test/test_block.tcl
+++ b/src/odb/test/test_block.tcl
@@ -95,7 +95,16 @@ proc block_placement { block lib test_num flag } {
       0 4000 100 4100 "NONE"
   }
   if { ($flag && $test_num == 5) || (!$flag && $test_num >= 5) } {
-    # TODO ADD WIRE
+    set L1 [[$lib getTech] findLayer "L1"]
+    $L1 setWidth 200
+    set n_w [odb::dbNet_create $block "n_w"]
+    set wire [odb::dbWire_create $n_w]
+    set encoder [odb::dbWireEncoder]
+    $encoder begin $wire
+    $encoder newPath $L1 "ROUTED"
+    $encoder addPoint 0 4500
+    $encoder addPoint 3000 4500
+    $encoder end
   }
 }
 
@@ -147,11 +156,21 @@ proc test_bbox4 { } {
   tearDown $db
 }
 
+proc test_bbox5 { } {
+  lassign [setUp] db lib block parentBlock
+  set box [$block getBBox]
+  block_placement $block $lib 5 false
+  # xMax is 3100 (not 3000): wire endpoint is extended by half-width (100).
+  check_box_rect $block -1580 -1000 3100 4600
+  tearDown $db
+}
+
 test_find
 test_bbox0
 test_bbox1
 test_bbox2
 test_bbox3
 test_bbox4
+test_bbox5
 puts "pass"
 exit 0


### PR DESCRIPTION
## Summary

Fill in the `# TODO ADD WIRE` stub that has been present in `block_placement`
step 5 of both `test_block.py` and `test_block.tcl`. Add the corresponding
`test_bbox5` test in both files to verify that a `dbWire` correctly expands
the block bounding box.

- Creates a net and encodes a horizontal wire from `(0, 4500)` to `(3000, 4500)`
  on layer L1 (width 200) using `dbWireEncoder`
- `xMax` in `test_bbox5` is 3100, not 3000: each wire endpoint is extended by
  half the wire width (100) in the direction of travel

## Test plan

- [ ] `ctest -R "odb\.test_block" -V` — 7 Python tests pass, TCL test passes
- [ ] `ctest -R "odb\.test_destroy" -V` — existing tests unaffected

AI tools were used to assist with code generation. All technical decisions and implementation details are my own.