### PR TITLE
build: add configuration summary output to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,3 +225,19 @@ endif()
 # Add a configuration for ReleaseWithAsserts
 set(CMAKE_CXX_FLAGS_RELEASEWITHASSERTS "${CMAKE_CXX_FLAGS_RELEASE} -UNDEBUG" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELEASEWITHASSERTS "${CMAKE_C_FLAGS_RELEASE} -UNDEBUG" CACHE STRING "" FORCE)
+
+# ==============================================================================
+# OPENROAD BUILD CONFIGURATION SUMMARY
+# ==============================================================================
+message(STATUS "")
+message(STATUS "=========================================================")
+message(STATUS " OpenROAD Configuration Summary ")
+message(STATUS "=========================================================")
+message(STATUS " C++ Standard   : ${CMAKE_CXX_STANDARD}")
+message(STATUS " Build Type     : ${CMAKE_BUILD_TYPE}")
+message(STATUS " GUI Support    : ${BUILD_GUI}")
+message(STATUS " Python Bindings: ${BUILD_PYTHON}")
+message(STATUS " Tests Enabled  : ${ENABLE_TESTS}")
+message(STATUS "=========================================================")
+message(STATUS " Configuration complete. You can now run 'make' or 'ninja'.")
+message(STATUS "")


### PR DESCRIPTION
Adds a clean `message(STATUS)` summary block to the very end of the `CMakeLists.txt` execution. 

Currently, running the CMake configuration step generates a massive amount of verbose terminal output. If a new developer is building from source, they might easily miss whether optional features (like the GUI, GPU acceleration, or Python bindings) were successfully enabled or silently skipped. 
By adding a consolidated summary box at the end of the script, we provide immediate, readable feedback about the state of their build environment. 
This prevents downstream confusion (e.g., a user running `make` for 20 minutes only to realize the GUI flag wasn't set properly). Providing clear, fast feedback directly supports the goals of the **Onboarding Simplification** project by making the local build process much more transparent for first-time contributors.