### PR TITLE
build: Add Python virtual environment guard to Build.sh

### DIFF
--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -34,28 +34,28 @@ OPTIONS:
                                                  -cmake= and double quotes if
                                                  <key> has multiple <values>
                                                  e.g.: -cmake='-DFLAGS="-a -b"'
-  -compiler=COMPILER_NAME                        Compiler name: gcc or clang
+  -compiler=COMPILER_NAME                         Compiler name: gcc or clang
                                                  Default: gcc
   -no-warnings
                                                 Compiler warnings are
                                                 considered errors, i.e.,
                                                 use -Werror flag during build.
-  -dir=PATH                                     Path to store build files.
+  -dir=PATH                                      Path to store build files.
                                                  Default: ./build
-  -coverage                                     Enable cmake coverage options
-  -clean                                        Remove build dir before compile
-  -no-gui                                       Disable GUI support
-  -no-tests                                     Disable GTest
-  -ninja                                        Use Ninja build system
-  -cpp20                                        Use C++20 standard
-  -build-man                                    Build Man Pages (optional)
-  -threads=NUM_THREADS                          Number of threads to use during
+  -coverage                                      Enable cmake coverage options
+  -clean                                         Remove build dir before compile
+  -no-gui                                        Disable GUI support
+  -no-tests                                      Disable GTest
+  -ninja                                         Use Ninja build system
+  -cpp20                                         Use C++20 standard
+  -build-man                                     Build Man Pages (optional)
+  -threads=NUM_THREADS                           Number of threads to use during
                                                  compile. Default: \`nproc\` on linux
                                                  or \`sysctl -n hw.logicalcpu\` on macOS
-  -keep-log                                     Keep a compile log in build dir
-  -help                                         Shows this message
-  -gpu                                          Enable GPU to accelerate the process
-  -deps-prefixes-file=FILE                      File with CMake packages roots,
+  -keep-log                                      Keep a compile log in build dir
+  -help                                          Shows this message
+  -gpu                                           Enable GPU to accelerate the process
+  -deps-prefixes-file=FILE                       File with CMake packages roots,
                                                  its content extends -cmake argument.
                                                  By default, "openroad_deps_prefixes.txt"
                                                  file from OpenROAD's "etc" directory
@@ -209,7 +209,8 @@ fi
 # ==============================================================================
 # PYTHON VIRTUAL ENVIRONMENT CHECK
 # ==============================================================================
-if [[ -t 1 ]]; then
+# Check for tput to avoid stderr noise if it's missing
+if [[ -t 1 ]] && command -v tput >/dev/null 2>&1; then
     GREEN=$(tput setaf 2)
     YELLOW=$(tput setaf 3)
     NC=$(tput sgr0)

--- a/etc/Build.sh
+++ b/etc/Build.sh
@@ -30,18 +30,18 @@ usage: $0 [OPTIONS]
 
 OPTIONS:
   -cmake='-<key>=<value> [-<key>=<value> ...]'  User defined cmake options
-                                                  Note: use single quote after
-                                                  -cmake= and double quotes if
-                                                  <key> has multiple <values>
-                                                  e.g.: -cmake='-DFLAGS="-a -b"'
-  -compiler=COMPILER_NAME                       Compiler name: gcc or clang
-                                                  Default: gcc
+                                                 Note: use single quote after
+                                                 -cmake= and double quotes if
+                                                 <key> has multiple <values>
+                                                 e.g.: -cmake='-DFLAGS="-a -b"'
+  -compiler=COMPILER_NAME                        Compiler name: gcc or clang
+                                                 Default: gcc
   -no-warnings
                                                 Compiler warnings are
                                                 considered errors, i.e.,
                                                 use -Werror flag during build.
   -dir=PATH                                     Path to store build files.
-                                                  Default: ./build
+                                                 Default: ./build
   -coverage                                     Enable cmake coverage options
   -clean                                        Remove build dir before compile
   -no-gui                                       Disable GUI support
@@ -50,16 +50,16 @@ OPTIONS:
   -cpp20                                        Use C++20 standard
   -build-man                                    Build Man Pages (optional)
   -threads=NUM_THREADS                          Number of threads to use during
-                                                  compile. Default: \`nproc\` on linux
-                                                  or \`sysctl -n hw.logicalcpu\` on macOS
+                                                 compile. Default: \`nproc\` on linux
+                                                 or \`sysctl -n hw.logicalcpu\` on macOS
   -keep-log                                     Keep a compile log in build dir
   -help                                         Shows this message
   -gpu                                          Enable GPU to accelerate the process
   -deps-prefixes-file=FILE                      File with CMake packages roots,
-                                                  its content extends -cmake argument.
-                                                  By default, "openroad_deps_prefixes.txt"
-                                                  file from OpenROAD's "etc" directory
-                                                  or from system "/etc".
+                                                 its content extends -cmake argument.
+                                                 By default, "openroad_deps_prefixes.txt"
+                                                 file from OpenROAD's "etc" directory
+                                                 or from system "/etc".
 
 EOF
     exit "${1:-1}"
@@ -205,6 +205,30 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$PATH"
     export CMAKE_PREFIX_PATH=$(brew --prefix or-tools)
 fi
+
+# ==============================================================================
+# PYTHON VIRTUAL ENVIRONMENT CHECK
+# ==============================================================================
+if [[ -t 1 ]]; then
+    GREEN=$(tput setaf 2)
+    YELLOW=$(tput setaf 3)
+    NC=$(tput sgr0)
+else
+    GREEN=''
+    YELLOW=''
+    NC=''
+fi
+
+if [[ -z "${VIRTUAL_ENV:-}" ]]; then
+    echo -e "${YELLOW}[WARNING] You are not inside a Python Virtual Environment!${NC}"
+    echo "It is highly recommended to build OpenROAD inside a venv to prevent package conflicts."
+    echo "To create one, run: python3 -m venv or_env && source or_env/bin/activate"
+    echo -e "Proceeding anyway in 3 seconds...\n"
+    sleep 3
+else
+    echo -e "${GREEN}[OK] Python Virtual Environment detected (${VIRTUAL_ENV})${NC}"
+fi
+# ==============================================================================
 
 echo "[INFO] Using ${numThreads} threads."
 if [[ "$isNinja" == "yes" ]]; then


### PR DESCRIPTION
Adds a safety check to `Build.sh` to detect if the user is operating inside a Python Virtual Environment .

OpenROAD relies heavily on Python bindings and external PIP packages. On modern Linux distributions (like Ubuntu 24.04 with PEP-668), attempting to install dependencies globally can break OS-level package managers. Beginners frequently fall into this trap, resulting in corrupted local environments and support tickets.
The script now checks for a registered virtual environment. If none is found, it issues a highly visible warning with exact instructions on how to create one (`python3 -m venv or_env`), pauses for 3 seconds to ensure the user reads it, and then proceeds.

Directly supports the **Onboarding Simplification** initiative by preemptively stopping developers from destroying their local Python environments during the initial build phase.