### PR TITLE
chore: add Pull Request template to standardize contributor onboarding

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,21 @@
 ## Summary
+[Describe your changes here]
+
+## Type of Change
+- [ ] Bug Fix
+- [ ] New Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other
+
 ## Impact
+[How does this change the tool's behavior?]
+
 ## Verification
 - [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
 - [ ] I have run the relevant tests and they pass.
 - [ ] My code follows the repository's formatting guidelines.
+- [ ] **I have signed my commits (DCO).**
 
 ## Related Issues
+[Link issues here]


### PR DESCRIPTION
First-time contributors often do not know what information maintainers need to properly review a PR. This leads to empty descriptions, missing context, and skipped local testing, which slows down the review process and creates friction for new developers.
When a user opens a new Pull Request, this template will now automatically populate the text box, guiding them to provide a Summary, note the Impact, check off Verification steps, and link Related Issues.
This acts as a "guardrail" for new contributors, ensuring they provide high-quality context for the core maintainers. This directly aligns with the **Onboarding Simplification** initiative by creating a structured, welcoming path for code submissions.