### PR TITLE
grt: Add HPWL and Detour Ratio metrics to CUGR statistics

### DIFF
--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -94,6 +94,7 @@ class CUGR
   }
   void addDirtyNet(odb::dbNet* net);
   void updateNet(odb::dbNet* net);
+  void removeRouteUsage(odb::dbNet* net);
   void startIncremental();
   void endIncremental();
 

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -489,7 +489,7 @@ void CUGR::printStatistics() const
 
   // wire length and via count
   uint64_t wire_length = 0;
-  uint64_t total_hpwl = 0; // Added for detour metric
+  uint64_t total_hpwl = 0;  // Added for detour metric
   int via_count = 0;
   std::vector<std::vector<std::vector<int>>> wire_usage;
   wire_usage.assign(grid_graph_->getNumLayers(),
@@ -549,7 +549,8 @@ void CUGR::printStatistics() const
     }
   }
 
-  double detour_ratio = total_hpwl > 0 ? (double) wire_length / total_hpwl : 1.0;
+  double detour_ratio
+      = total_hpwl > 0 ? (double) wire_length / total_hpwl : 1.0;
 
   logger_->report("Wire length:           {}",
                   wire_length / grid_graph_->getM2Pitch());
@@ -674,8 +675,10 @@ void CUGR::removeRouteUsage(odb::dbNet* db_net)
       grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
     }
   } else {
-    logger_->warn(
-        GRT, 601, "Net {} not found in CUGR for rip-up.", db_net->getConstName());
+    logger_->warn(GRT,
+                  601,
+                  "Net {} not found in CUGR for rip-up.",
+                  db_net->getConstName());
   }
 }
 
@@ -747,4 +750,3 @@ void CUGR::endIncremental()
 }
 
 }  // namespace grt
-

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -489,6 +489,7 @@ void CUGR::printStatistics() const
 
   // wire length and via count
   uint64_t wire_length = 0;
+  uint64_t total_hpwl = 0; // Added for detour metric
   int via_count = 0;
   std::vector<std::vector<std::vector<int>>> wire_usage;
   wire_usage.assign(grid_graph_->getNumLayers(),
@@ -496,6 +497,9 @@ void CUGR::printStatistics() const
                         grid_graph_->getSize(0),
                         std::vector<int>(grid_graph_->getSize(1), 0)));
   for (const auto& net : gr_nets_) {
+    // Calculate Ideal Length (HPWL) for the net
+    total_hpwl += net->getBoundingBox().hp();
+
     GRTreeNode::preorder(
         net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {
           for (const auto& child : node->getChildren()) {
@@ -545,8 +549,13 @@ void CUGR::printStatistics() const
     }
   }
 
+  double detour_ratio = total_hpwl > 0 ? (double) wire_length / total_hpwl : 1.0;
+
   logger_->report("Wire length:           {}",
                   wire_length / grid_graph_->getM2Pitch());
+  logger_->report("Total HPWL:            {}",
+                  total_hpwl / grid_graph_->getM2Pitch());
+  logger_->report("Average Detour Ratio:  {:.2f}", detour_ratio);
   logger_->report("Total via count:       {}", via_count);
   logger_->report("Total wire overflow:   {}", (int) overflow);
   logger_->report("Min resource:          {}", min_resource);
@@ -656,6 +665,20 @@ void CUGR::updateNet(odb::dbNet* db_net)
   updated_nets_.insert(db_net);
 }
 
+void CUGR::removeRouteUsage(odb::dbNet* db_net)
+{
+  auto it = db_net_map_.find(db_net);
+  if (it != db_net_map_.end()) {
+    GRNet* gr_net = it->second;
+    if (gr_net->getRoutingTree()) {
+      grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
+    }
+  } else {
+    logger_->warn(
+        GRT, 601, "Net {} not found in CUGR for rip-up.", db_net->getConstName());
+  }
+}
+
 void CUGR::startIncremental()
 {
   incremental_mode_ = true;
@@ -664,11 +687,25 @@ void CUGR::startIncremental()
 
 void CUGR::rerouteNets(std::vector<int>& net_indices)
 {
+  // 1. Rip up all dirty nets to free up congestion
   for (const int idx : net_indices) {
     if (gr_nets_[idx]->getRoutingTree()) {
       grid_graph_->removeTreeUsage(gr_nets_[idx]->getRoutingTree());
     }
   }
+
+  // 2. Query STA for fresh slacks if timing is available
+  if (sta_ != nullptr) {
+    for (const int idx : net_indices) {
+      odb::dbNet* db_net = gr_nets_[idx]->getDbNet();
+      float slack = getNetSlack(db_net);
+      gr_nets_[idx]->setSlack(slack);
+    }
+    // 3. Sort: Most negative slack (critical) nets go FIRST
+    sortNetIndices(net_indices);
+  }
+
+  // 4. Run the routing stages in prioritized order
   patternRoute(net_indices);
   patternRouteWithDetours(net_indices);
   mazeRoute(net_indices);
@@ -710,3 +747,4 @@ void CUGR::endIncremental()
 }
 
 }  // namespace grt
+


### PR DESCRIPTION
This PR introduces new observability metrics to the` CUGR` engine by tracking the Half-Parameter Wire Length (HPWL) and reporting the Average Detour Ratio in the routing statistics.MotivationWhile the router currently reports wire length, it lacks a baseline to quantify routing quality. By calculating the HPWL (the ideal Manhattan distance) for every net, we can now derive the Detour Ratio.
This metric is essential for quantifying the impact of congestion on routing detours.Measuring the effectiveness of timing-driven sorting heuristics.Benchmarking routing quality across different design sizes.
Updated `CUGR::printStatistics` to aggregate HPWL for all nets using `net->getBoundingBox().hp()`.Implemented logic to compute and report the `Average Detour Ratio` alongside existing wire length and via count statistics.(Included from previous branch) Refreshes timing data and sorts critical nets during the` rerouteNets `incremental pass.