### PR TITLE
fix: man_tcl_check tests fail on count mismatch

### DIFF
--- a/src/ant/test/ant_man_tcl_check.py
+++ b/src/ant/test/ant_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/cts/test/cts_man_tcl_check.py
+++ b/src/cts/test/cts_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/dft/test/dft_man_tcl_check.py
+++ b/src/dft/test/dft_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/dpl/test/dpl_man_tcl_check.py
+++ b/src/dpl/test/dpl_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/drt/test/drt_man_tcl_check.py
+++ b/src/drt/test/drt_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/fin/test/fin_man_tcl_check.py
+++ b/src/fin/test/fin_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/gpl/test/gpl_man_tcl_check.py
+++ b/src/gpl/test/gpl_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/grt/test/grt_man_tcl_check.py
+++ b/src/grt/test/grt_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/gui/test/gui_man_tcl_check.py
+++ b/src/gui/test/gui_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/ifp/test/ifp_man_tcl_check.py
+++ b/src/ifp/test/ifp_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/mpl/test/mpl_man_tcl_check.py
+++ b/src/mpl/test/mpl_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/odb/test/odb_man_tcl_check.py
+++ b/src/odb/test/odb_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/pad/test/pad_man_tcl_check.py
+++ b/src/pad/test/pad_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/par/test/par_man_tcl_check.py
+++ b/src/par/test/par_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/pdn/test/pdn_man_tcl_check.py
+++ b/src/pdn/test/pdn_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/ppl/test/ppl_man_tcl_check.py
+++ b/src/ppl/test/ppl_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/psm/test/psm_man_tcl_check.py
+++ b/src/psm/test/psm_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/rcx/test/rcx_man_tcl_check.py
+++ b/src/rcx/test/rcx_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/rmp/test/rmp_man_tcl_check.py
+++ b/src/rmp/test/rmp_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/rsz/test/rsz_man_tcl_check.py
+++ b/src/rsz/test/rsz_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/stt/test/stt_man_tcl_check.py
+++ b/src/stt/test/stt_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/tap/test/tap_man_tcl_check.py
+++ b/src/tap/test/tap_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/upf/test/upf_man_tcl_check.py
+++ b/src/upf/test/upf_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/src/utl/test/utl_man_tcl_check.py
+++ b/src/utl/test/utl_man_tcl_check.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import glob
 import re
 from extract_utils import extract_tcl_code, extract_help, extract_proc
@@ -75,3 +76,4 @@ for path in help_dict:
         print("Command counts match.")
     else:
         print("Command counts do not match.")
+        sys.exit(1)

--- a/test/regression_test.sh
+++ b/test/regression_test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -o pipefail
 
 RESULTS_DIR="${RESULTS_DIR:-results}"
 LOG_FILE="${RESULTS_DIR}/$TEST_NAME-$TEST_EXT.log"


### PR DESCRIPTION
## Summary

- Add `sys.exit(1)` to all 24 `*_man_tcl_check.py` scripts when help/proc/readme counts don't match
- Add `set -o pipefail` to `test/regression_test.sh` so non-zero exit codes propagate through the `tee` pipe

Previously these tests passed even with mismatched counts because the `.ok` golden files encoded the broken state, and the pipe to `tee` swallowed the exit code.

## Test plan

- [x] `bazelisk test //src/drt/test:drt_man_tcl_check-py_test` — PASSES (counts match)
- [x] `bazelisk test //src/ant/test:ant_man_tcl_check-py_test` — FAILS (counts don't match, as expected)
- [ ] Existing regression tests still pass (pipefail should not affect passing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)