### PR TITLE
build: migrate chisel_binary to bazel bcr rules_chisel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,7 @@ bazel_dep(name = "rules_pkg", version = "1.2.0")
 
 # Used by chisel_binary from @bazel-orfs in test/orfs/mock-array
 bazel_dep(name = "rules_jvm_external", version = "6.4", dev_dependency = True)
+bazel_dep(name = "rules_chisel", version = "0.2.0", dev_dependency = True)
 bazel_dep(name = "rules_scala", version = "7.1.5", dev_dependency = True)
 
 bazel_dep(name = "rules_shell", version = "0.6.1")
@@ -127,7 +128,7 @@ bazel_dep(name = "bazel-orfs", dev_dependency = True)
 # To bump version, run: bazelisk run @bazel-orfs//:bump
 git_override(
     module_name = "bazel-orfs",
-    commit = "0ceb33936eba2cedc3b8d356b31f041465f526ce",
+    commit = "0818f4b9c854c3c34b1500b41840a5d4f2b6717d",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
@@ -136,15 +137,19 @@ orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories", dev_dep
 # To bump version, run: bazelisk run @bazel-orfs//:bump
 orfs.default(
     # Official image https://hub.docker.com/r/openroad/orfs/tags
-    image = "docker.io/openroad/orfs:26Q1-636-gb9f42fead",
+    image = "docker.io/openroad/orfs:26Q1-669-gbdeb18939",
     # Use OpenROAD of this repo instead of from the docker image
     openroad = "//:openroad",
-    sha256 = "6d3eaf1b44a4810ee3de7bb7c0f3aa1c5d71489a16fe011b38e8d59294c6e3d9",
+    sha256 = "812c5c543252460a9458010cdff4f851d6441e592c74d6254b15889e7ad95c6a",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")
 
 SCALA_VERSION = "2.13.17"
+
+CHISEL_VERSION = "7.2.0"
+
+FIRTOOL_RESOLVER_VERSION = "2.0.1"
 
 scala_config = use_extension(
     "@rules_scala//scala/extensions:config.bzl",
@@ -165,6 +170,14 @@ scala_deps.settings(
     fetch_sources = True,
 )
 scala_deps.scala()
+
+chisel = use_extension("@rules_chisel//chisel:extensions.bzl", "chisel")
+chisel.toolchain(
+    chisel_version = CHISEL_VERSION,
+    firtool_resolver_version = FIRTOOL_RESOLVER_VERSION,
+    scala_version = SCALA_VERSION,
+)
+use_repo(chisel, "chisel_maven")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
 maven.install(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -498,6 +498,8 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.4/MODULE.bazel": "1ff1223dfd24f3ecf8f028446d4a27608aa43c3f41e346d22838a4223980b8cc",
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_cc/0.2.9/MODULE.bazel": "34263f1dca62ea664265438cef714d7db124c03e1ed55ebb4f1dc860164308d1",
+    "https://bcr.bazel.build/modules/rules_chisel/0.2.0/MODULE.bazel": "25e67caac0df9d467c1867b46b5c2c45afd7a7ab05a8e7abb87cc1c758c37528",
+    "https://bcr.bazel.build/modules/rules_chisel/0.2.0/source.json": "e70a157e17ff14c1410a97ee1365e9abe00a7dd787830a237e1b612bcbc9a0f2",
     "https://bcr.bazel.build/modules/rules_flex/0.3.1/MODULE.bazel": "5aea738f59e47769d219f972fc8426c53693c262895787efafa71fe9795bd7e3",
     "https://bcr.bazel.build/modules/rules_flex/0.4/MODULE.bazel": "543edf994d2c044f3d723374e50eaa739ed7ee9d82b8185adb8413bce269dcf3",
     "https://bcr.bazel.build/modules/rules_flex/0.4/source.json": "98bc56c2139b6ed6387dbabd06f625e82500bed8ba1689a5f4f3c9e8c3289f82",
@@ -700,8 +702,8 @@
     },
     "@@bazel-orfs+//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "xRx9tYeqNSaibENLRqhj2OVDOepLbExZ6x8BUTsoYv4=",
-        "usagesDigest": "fhbe2ryQbHLzZf9sQcTijajGb5BD0Z54stOcWqQL1ao=",
+        "bzlTransitiveDigest": "QYKsLwaOfoRUMu1KyupRbCxEnHtHuIAr4YE3u1WzHko=",
+        "usagesDigest": "ynfBx6Q6NeumBZvRJfZV9NdfwdlUBoKAJiC5/tayX/0=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -719,8 +721,8 @@
           "docker_orfs": {
             "repoRuleId": "@@bazel-orfs+//:docker.bzl%docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:26Q1-636-gb9f42fead",
-              "sha256": "6d3eaf1b44a4810ee3de7bb7c0f3aa1c5d71489a16fe011b38e8d59294c6e3d9",
+              "image": "docker.io/openroad/orfs:26Q1-669-gbdeb18939",
+              "sha256": "812c5c543252460a9458010cdff4f851d6441e592c74d6254b15889e7ad95c6a",
               "build_file": "@@bazel-orfs+//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [
@@ -737,6 +739,7 @@
           "config": {
             "repoRuleId": "@@bazel-orfs+//:config.bzl%global_config",
             "attributes": {
+              "klayout": "@@bazel-orfs++orfs_repositories+docker_orfs//:klayout",
               "makefile": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile",
               "pdk": "@@bazel-orfs++orfs_repositories+docker_orfs//:asap7",
               "makefile_yosys": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile_yosys",
@@ -1400,6 +1403,185 @@
           "reproducible": false
         },
         "recordedRepoMappingEntries": []
+      }
+    },
+    "@@rules_chisel+//chisel:extensions.bzl%chisel": {
+      "general": {
+        "bzlTransitiveDigest": "aCXBew5jYa9d5TkWJLI5A8nWpTdanPY+PbldpTQLXr8=",
+        "usagesDigest": "cyt2rWGIn4nNGvnFMJCaFYLV5TJb2XL/KUof4xYvBYY=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "chisel_maven_internal": {
+            "repoRuleId": "@@rules_jvm_external+//private/rules:coursier.bzl%coursier_fetch",
+            "attributes": {
+              "pinned_repo_name": "",
+              "repositories": [
+                "{ \"repo_url\": \"https://repo1.maven.org/maven2\" }",
+                "{ \"repo_url\": \"https://s01.oss.sonatype.org/content/repositories/releases\" }"
+              ],
+              "artifacts": [
+                "{ \"group\": \"org.chipsalliance\", \"artifact\": \"chisel_2.13\", \"version\": \"7.2.0\" }",
+                "{ \"group\": \"org.chipsalliance\", \"artifact\": \"chisel-plugin_2.13.17\", \"version\": \"7.2.0\" }",
+                "{ \"group\": \"org.chipsalliance\", \"artifact\": \"firtool-resolver_2.13\", \"version\": \"2.0.1\" }",
+                "{ \"group\": \"org.scalatest\", \"artifact\": \"scalatest_2.13\", \"version\": \"3.2.19\" }"
+              ],
+              "boms": [],
+              "fail_on_missing_checksum": true,
+              "fetch_sources": true,
+              "fetch_javadoc": false,
+              "excluded_artifacts": [],
+              "generate_compat_repositories": false,
+              "version_conflict_policy": "default",
+              "override_targets": {},
+              "strict_visibility": false,
+              "strict_visibility_value": [
+                "@@//visibility:private"
+              ],
+              "resolve_timeout": 600,
+              "use_credentials_from_home_netrc_file": false,
+              "use_starlark_android_rules": false,
+              "aar_import_bzl_label": "@build_bazel_rules_android//android:rules.bzl",
+              "duplicate_version_warning": "warn",
+              "ignore_empty_files": false,
+              "additional_coursier_options": []
+            }
+          },
+          "chisel_maven": {
+            "repoRuleId": "@@rules_chisel+//chisel:extensions.bzl%_chisel_alias_repo",
+            "attributes": {
+              "deps_repo_name": "chisel_maven_internal",
+              "pin_repo_name": "chisel_maven_internal",
+              "scala_version": "2.13.17"
+            }
+          }
+        },
+        "moduleExtensionMetadata": {
+          "explicitRootModuleDirectDeps": [
+            "chisel_maven"
+          ],
+          "explicitRootModuleDirectDevDeps": [],
+          "useAllRepos": "NO",
+          "reproducible": false
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "bazel_features+",
+            "bazel_features_globals",
+            "bazel_features++version_extension+bazel_features_globals"
+          ],
+          [
+            "bazel_features+",
+            "bazel_features_version",
+            "bazel_features++version_extension+bazel_features_version"
+          ],
+          [
+            "protobuf+",
+            "proto_bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "protobuf+",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_cc+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_cc+",
+            "cc_compatibility_proxy",
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy"
+          ],
+          [
+            "rules_cc+",
+            "platforms",
+            "platforms"
+          ],
+          [
+            "rules_cc+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_cc++compatibility_proxy+cc_compatibility_proxy",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_chisel+",
+            "rules_jvm_external",
+            "rules_jvm_external+"
+          ],
+          [
+            "rules_java+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_java+",
+            "bazel_skylib",
+            "bazel_skylib+"
+          ],
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_java+",
+            "com_google_protobuf",
+            "protobuf+"
+          ],
+          [
+            "rules_java+",
+            "compatibility_proxy",
+            "rules_java++compatibility_proxy+compatibility_proxy"
+          ],
+          [
+            "rules_java+",
+            "rules_cc",
+            "rules_cc+"
+          ],
+          [
+            "rules_java++compatibility_proxy+compatibility_proxy",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "rules_jvm_external+",
+            "bazel_features",
+            "bazel_features+"
+          ],
+          [
+            "rules_jvm_external+",
+            "bazel_tools",
+            "bazel_tools"
+          ],
+          [
+            "rules_jvm_external+",
+            "rules_java",
+            "rules_java+"
+          ],
+          [
+            "rules_jvm_external+",
+            "rules_license",
+            "rules_license+"
+          ],
+          [
+            "rules_license+",
+            "rules_license",
+            "rules_license+"
+          ]
+        ]
       }
     },
     "@@rules_flex+//flex/internal:default_toolchain_ext.bzl%default_toolchain_ext": {

--- a/test/orfs/mock-array/BUILD
+++ b/test/orfs/mock-array/BUILD
@@ -1,5 +1,5 @@
 load("@bazel-orfs//:openroad.bzl", "orfs_run")
-load("@bazel-orfs//toolchains/scala:chisel.bzl", "chisel_binary")
+load("@rules_chisel//chisel:defs.bzl", "chisel_binary")
 load("//test/orfs/asap7:asap7.bzl", "ASAP7_REMOVE_CELLS")
 load(":mock-array.bzl", "config", "element", "mock_array", "verilog")
 


### PR DESCRIPTION
The local bazel-orfs moved chisel support from
@bazel-orfs//toolchains/scala:chisel.bzl to the standalone @rules_chisel//chisel:defs.bzl package. Add rules_chisel as a dev dependency, configure the chisel extension toolchain, and update the mock-array BUILD load path accordingly.