### PR TITLE
odb: rename RSeg capacitance getters and remove unused code

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -4563,21 +4563,22 @@ class dbRSeg : public dbObject
   bool updatedCap();
 
   ///
-  /// Get the capacitance of this RC segment for this process corner. Returns
-  /// value in FF.
+  /// Get the ground capacitance of this RC segment for this process corner.
+  /// Returns value in FF.
   ///
-  double getCapacitance(int corner = 0);
+  double getGroundCapacitance(int corner = 0);
 
   ///
-  /// Get the capacitance of this RC segment for this process corner,
-  /// plus coupling capacitance. Returns value in FF.
+  /// Get the total capacitance (ground + coupling) of this RC segment for this
+  /// process corner. Returns value in FF.
   ///
-  double getSourceCapacitance(int corner = 0);
+  double getTotalCapacitance(int corner = 0);
 
   ///
-  /// Get the first capnode capacitance of this RC segment
-  /// for this process corner, if foreign,
-  /// plus coupling capacitance. Returns value in FF.
+  /// Get ground capacitance + coupling capacitance scaled by Miller effect
+  /// multiplier of this RC segment for this process corner. This function
+  /// should only be needed when a custom Miller effect multiplier is required.
+  /// Returns value in FF.
   ///
   double getCapacitance(int corner, double miller_mult);
 

--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -1963,7 +1963,7 @@ double dbNet::getTotalCapacitance(uint32_t corner, bool cc)
     }
   } else {
     for (dbRSeg* rc : getRSegs()) {
-      cap1 = rc->getCapacitance(corner);
+      cap1 = rc->getGroundCapacitance(corner);
       cap += cap1;
     }
   }

--- a/src/odb/src/db/dbRSeg.cpp
+++ b/src/odb/src/db/dbRSeg.cpp
@@ -363,7 +363,7 @@ void dbRSeg::adjustCapacitance(float factor)
   }
 }
 
-double dbRSeg::getCapacitance(int corner)
+double dbRSeg::getGroundCapacitance(int corner)
 {
   _dbRSeg* seg = (_dbRSeg*) this;
   _dbBlock* block = (_dbBlock*) seg->getOwner();
@@ -376,6 +376,11 @@ double dbRSeg::getCapacitance(int corner)
   }
   assert((corner >= 0) && ((uint32_t) corner < cornerCnt));
   return (*block->c_val_tbl_)[((seg->getOID() - 1) * cornerCnt) + 1 + corner];
+}
+
+double dbRSeg::getTotalCapacitance(int corner)
+{
+  return getCapacitance(corner, 1.0);
 }
 
 void dbRSeg::getGndCap(double* gndcap, double* totalcap)
@@ -422,20 +427,6 @@ void dbRSeg::addGndCap(double* gndcap, double* totalcap)
   }
 }
 
-double dbRSeg::getSourceCapacitance(int corner)
-{
-  //_dbBlock * block = (_dbBlock *) getOwner();
-
-  _dbRSeg* seg = (_dbRSeg*) this;
-
-  if (seg->flags_.allocated_cap == 0) {
-    _dbBlock* block = (_dbBlock*) seg->getOwner();
-    dbCapNode* node = dbCapNode::getCapNode((dbBlock*) block, seg->source_);
-    return node->getCapacitance(corner);
-  }
-  return 0.0;
-}
-
 dbCapNode* dbRSeg::getTargetCapNode()
 {
   _dbBlock* block = (_dbBlock*) getImpl()->getOwner();
@@ -464,7 +455,7 @@ dbCapNode* dbRSeg::getSourceCapNode()
 
 double dbRSeg::getCapacitance(const int corner, const double miller_mult)
 {
-  const double cap = getCapacitance(corner);
+  const double cap = getGroundCapacitance(corner);
 
   dbCapNode* targetCapNode = getTargetCapNode();
 

--- a/src/rcx/src/extDebugPrint.cpp
+++ b/src/rcx/src/extDebugPrint.cpp
@@ -40,7 +40,7 @@ void extMeasure::printTraceNetInfo(const char* msg, uint32_t netId, int rsegId)
              shapeId,
              rsegId,
              msg,
-             rseg->getCapacitance(0, 1.0));
+             rseg->getTotalCapacitance(0));
 }
 
 double extMeasure::GetDBcoords(uint32_t coord)
@@ -176,7 +176,7 @@ void extMeasure::segInfo(const char* msg, uint32_t netId, int rsegId)
       netId,
       shapeId,
       rsegId,
-      rseg->getCapacitance(0, 1.0),
+      rseg->getTotalCapacitance(0),
       rseg->getResistance(0));
 }
 

--- a/src/rcx/src/extmain.cpp
+++ b/src/rcx/src/extmain.cpp
@@ -446,7 +446,7 @@ void extMain::updateTotalCap(dbRSeg* rseg,
 {
   double cap = frCap + ccCap - deltaFr;
 
-  double tot = rseg->getCapacitance(modelIndex);
+  double tot = rseg->getGroundCapacitance(modelIndex);
   tot += cap;
 
   rseg->setCapacitance(tot, modelIndex);
@@ -511,7 +511,7 @@ void extMain::updateTotalCap(dbRSeg* rseg,
     }
 
     extDbIndex = getProcessCornerDbIndex(modelIndex);
-    tot = rseg->getCapacitance(extDbIndex);
+    tot = rseg->getGroundCapacitance(extDbIndex);
     tot += cap;
 
     rseg->setCapacitance(tot, extDbIndex);
@@ -520,7 +520,7 @@ void extMain::updateTotalCap(dbRSeg* rseg,
       continue;
     }
     getScaledGndC(sci, cap);
-    tot = rseg->getCapacitance(scDbIdx);
+    tot = rseg->getGroundCapacitance(scDbIdx);
     tot += cap;
     rseg->setCapacitance(tot, scDbIdx);
   }

--- a/src/rcx/src/extmain_v2.cpp
+++ b/src/rcx/src/extmain_v2.cpp
@@ -742,7 +742,7 @@ dbRSeg* extMain::addRSeg_v2(dbNet* net,
                rsid,
                srcId,
                dstId,
-               rc->getCapacitance(0));
+               rc->getGroundCapacitance(0));
   }
 
   srcId = dstId;

--- a/src/rcx/src/extmeasure.cpp
+++ b/src/rcx/src/extmeasure.cpp
@@ -1851,17 +1851,16 @@ double extMain::updateTotalCap(dbRSeg* rseg, double cap, uint32_t modelIndex)
 
   int extDbIndex, sci, scDbIndex;
   extDbIndex = getProcessCornerDbIndex(modelIndex);
-  double tot = rseg->getCapacitance(extDbIndex);
+  double tot = rseg->getGroundCapacitance(extDbIndex);
   tot += cap;
 
   rseg->setCapacitance(tot, extDbIndex);
-  // return rseg->getCapacitance(extDbIndex);
   getScaledCornerDbIndex(modelIndex, sci, scDbIndex);
   if (sci == -1) {
     return tot;
   }
   getScaledGndC(sci, cap);
-  double tots = rseg->getCapacitance(scDbIndex);
+  double tots = rseg->getGroundCapacitance(scDbIndex);
   tots += cap;
   rseg->setCapacitance(tots, scDbIndex);
   return tot;

--- a/src/rcx/src/extmeasure_flow.cpp
+++ b/src/rcx/src/extmeasure_flow.cpp
@@ -1036,13 +1036,13 @@ int extMeasureRC::computeAndStoreRC_new(dbRSeg* rseg1,
                            "FR",
                            rseg1->getId(),
                            fr,
-                           rseg1->getCapacitance());
+                           rseg1->getGroundCapacitance());
           DebugUpdateValue(_debugFP,
                            "OVER_SUB_INF",
                            "FR",
                            rseg1->getId(),
                            fr,
-                           rseg1->getCapacitance());
+                           rseg1->getGroundCapacitance());
 
           segInfo(_debugFP,
                   "\t\tOU_TOTAL_UPDATE ",

--- a/src/rcx/src/extmeasure_print.cpp
+++ b/src/rcx/src/extmeasure_print.cpp
@@ -502,7 +502,7 @@ void extMeasureRC::segInfo(FILE* fp,
             : "Wire";
   dbNet* net1 = dbNet::getNet(_block, netId);
 
-  double gndCap = rseg->getCapacitance(0);
+  double gndCap = rseg->getGroundCapacitance(0);
   double cc = getCC(rsegId);
   double totCap = gndCap + cc;
   double res = rseg->getResistance();

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -727,7 +727,7 @@ dbRSeg* extMain::addRSeg(dbNet* net,
                rsid,
                srcId,
                dstId,
-               rc->getCapacitance(0));
+               rc->getGroundCapacitance(0));
   }
 
   srcId = dstId;


### PR DESCRIPTION
Related to https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/3969.

### Context

Among other capacitance related APIs, `dbRSeg` had two `getCapacitance` methods for retrieving capacitance - one overloading the other. In order for us to know if we were using only ground or total (ground + coupling) capacitance, we'd need to rely on the parameters which makes our life harder i.e., the naming didn't help at all.

### Changes

Instead of overloading, having two distinct method names (one for ground, other for total capacitance) so that we can easily know what type of capacitance is being retrieved.

Note that I kept the `getCapacitance(corner, miller_mult)` method to maintain the possibility of retrieving a capacitance with a custom coupling scaling - see what is being called inside `getTotalCapacitance` for better understanding.

I also removed a function that wasn't being used and seemed somewhat incomplete.