### PR TITLE
pdn: check extention against new obs box for possible violations

### DIFF
--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -286,6 +286,24 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
              getLongName());
   // find vias that do not overlap completely
   // attempt to extend straps to fit (if owned by grid)
+  Shape::ShapeTreeMap search_shapes = getShapes();
+
+  odb::Rect search_area = getDomainBoundary();
+  for (const auto& [layer, shapes] : search_shapes) {
+    for (const auto& shape : shapes) {
+      search_area.merge(shape->getRect());
+    }
+  }
+
+  // populate shapes and obstructions
+  for (auto& [layer, layer_global_shape] : global_shapes) {
+    auto& shapes = search_shapes[layer];
+    for (auto it = layer_global_shape.qbegin(bgi::intersects(search_area));
+         it != layer_global_shape.qend();
+         it++) {
+      shapes.insert(*it);
+    }
+  }
 
   auto obs_filter = [this](const ShapePtr& other) -> bool {
     if (other->shapeType() != Shape::GRID_OBS) {
@@ -323,6 +341,7 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
       }
       auto new_lower
           = extend_test->extendTo(upper_shape->getRect(),
+                                  search_shapes[extend_test->getLayer()],
                                   obstructions[extend_test->getLayer()],
                                   lower_shape.get(),
                                   obs_filter);
@@ -338,6 +357,7 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
       }
       auto new_upper
           = extend_test->extendTo(lower_shape->getRect(),
+                                  search_shapes[extend_test->getLayer()],
                                   obstructions[extend_test->getLayer()],
                                   upper_shape.get(),
                                   obs_filter);

--- a/src/pdn/src/shape.cpp
+++ b/src/pdn/src/shape.cpp
@@ -675,34 +675,51 @@ std::string Shape::getRectText(const odb::Rect& rect, double dbu_to_micron)
 
 std::unique_ptr<Shape> Shape::extendTo(
     const odb::Rect& rect,
+    const ShapeTree& shapes,
     const ObstructionTree& obstructions,
     Shape* orig_shape,
     const std::function<bool(const ShapePtr&)>& obs_filter) const
 {
-  std::unique_ptr<Shape> new_shape = copy();
+  odb::Rect new_rect = rect_;
 
   if (isHorizontal()) {
-    new_shape->rect_.set_xlo(std::min(rect_.xMin(), rect.xMin()));
-    new_shape->rect_.set_xhi(std::max(rect_.xMax(), rect.xMax()));
+    new_rect.set_xlo(std::min(rect_.xMin(), rect.xMin()));
+    new_rect.set_xhi(std::max(rect_.xMax(), rect.xMax()));
   } else if (isVertical()) {
-    new_shape->rect_.set_ylo(std::min(rect_.yMin(), rect.yMin()));
-    new_shape->rect_.set_yhi(std::max(rect_.yMax(), rect.yMax()));
+    new_rect.set_ylo(std::min(rect_.yMin(), rect.yMin()));
+    new_rect.set_yhi(std::max(rect_.yMax(), rect.yMax()));
   } else {
     return nullptr;
   }
 
-  if (rect_ == new_shape->rect_) {
+  if (rect_ == new_rect) {
     // shape did not change
     return nullptr;
   }
 
-  if (obstructions.qbegin(bgi::intersects(new_shape->getRect())
+  if (obstructions.qbegin(bgi::intersects(new_rect)
                           && bgi::satisfies([&orig_shape](const auto& other) {
                                // ignore violations that results from itself
                                return other.get() != orig_shape;
                              })
                           && bgi::satisfies(obs_filter))
       != obstructions.qend()) {
+    // extension not possible
+    return nullptr;
+  }
+
+  std::unique_ptr<Shape> new_shape(copy());
+  new_shape->rect_ = new_rect;
+  new_shape->generateObstruction();
+  odb::Rect new_obs_rect;
+  new_shape->getObstruction().bloat(-1, new_obs_rect);
+
+  if (shapes.qbegin(bgi::intersects(new_obs_rect)
+                    && bgi::satisfies([&orig_shape](const auto& other) {
+                         // ignore violations that results from itself
+                         return other.get() != orig_shape;
+                       }))
+      != shapes.qend()) {
     // extension not possible
     return nullptr;
   }

--- a/src/pdn/src/shape.h
+++ b/src/pdn/src/shape.h
@@ -177,7 +177,8 @@ class Shape
 
   std::unique_ptr<Shape> extendTo(
       const odb::Rect& rect,
-      const ObstructionTree& obstructions,
+      const Shape::ShapeTree& shapes,
+      const Shape::ObstructionTree& obstructions,
       Shape* orig_shape,
       const std::function<bool(const ShapePtr&)>& obs_filter
       = [](const ShapePtr&) { return true; }) const;


### PR DESCRIPTION
Changes:
- when extensions are applied, it was possible to create a violation based on the new shape, this ensures we check the new bounding box for violations as well.