### PR TITLE
rsz: check max cap/slew across all timing corners

### DIFF
--- a/src/rsz/src/BaseMove.cc
+++ b/src/rsz/src/BaseMove.cc
@@ -836,11 +836,11 @@ bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
 {
   // Check capacitance limit across all corners (not just one).
   float cap1, max_cap1, cap_slack1;
-  const sta::Scene* corner1;
+  const sta::Scene* scene1;
   const sta::RiseFall* tr1;
   sta_->checkCapacitance(
       output_pin, sta_->scenes(), resizer_->max_,
-      cap1, max_cap1, cap_slack1, tr1, corner1);
+      cap1, max_cap1, cap_slack1, tr1, scene1);
 
   debugPrint(logger_,
              RSZ,
@@ -851,7 +851,7 @@ bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
              max_cap1,
              output_cap);
 
-  if (max_cap1 > 0.0 && corner1 && output_cap > max_cap1) {
+  if (max_cap1 > 0.0 && scene1 && output_cap > max_cap1) {
     debugPrint(logger_,
                RSZ,
                "opt_moves",
@@ -875,12 +875,12 @@ bool BaseMove::checkMaxSlewViolation(const sta::Pin* output_pin,
   float output_res = output_port->driveResistance();
   float output_slew = output_slew_factor * output_res * output_cap;
 
-  // Check slew limit across all corners (not just one).
-  for (const sta::Scene* corner : sta_->scenes()) {
+  // Check slew limit across all scenes (not just one).
+  for (const sta::Scene* scene : sta_->scenes()) {
     float max_slew;
     bool slew_limit_exists;
     sta_->findSlewLimit(
-        output_port, corner, resizer_->max_, max_slew, slew_limit_exists);
+        output_port, scene, resizer_->max_, max_slew, slew_limit_exists);
 
     if (slew_limit_exists && output_slew > max_slew) {
       debugPrint(logger_,

--- a/src/rsz/src/BaseMove.cc
+++ b/src/rsz/src/BaseMove.cc
@@ -827,18 +827,20 @@ vector<const sta::Pin*> BaseMove::getOutputPins(const sta::Instance* inst)
       outputs.push_back(pin);
     }
   }
-
   return outputs;
 }
 
 bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
-                                    sta::LibertyPort* output_port,
-                                    float output_cap)
+                                     sta::LibertyPort* output_port,
+                                     float output_cap)
 {
-  float max_cap;
-  bool cap_limit_exists;
-  // FIXME: Can we update to consider multiple corners?
-  output_port->capacitanceLimit(resizer_->max_, max_cap, cap_limit_exists);
+  // Check capacitance limit across all corners (not just one).
+  float cap1, max_cap1, cap_slack1;
+  const sta::Scene* corner1;
+  const sta::RiseFall* tr1;
+  sta_->checkCapacitance(
+      output_pin, sta_->scenes(), resizer_->max_,
+      cap1, max_cap1, cap_slack1, tr1, corner1);
 
   debugPrint(logger_,
              RSZ,
@@ -846,10 +848,10 @@ bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
              3,
              " fanout pin {} cap {} output_cap {} ",
              output_port->name(),
-             max_cap,
+             max_cap1,
              output_cap);
 
-  if (cap_limit_exists && max_cap > 0.0 && output_cap > max_cap) {
+  if (max_cap1 > 0.0 && corner1 && output_cap > max_cap1) {
     debugPrint(logger_,
                RSZ,
                "opt_moves",
@@ -858,7 +860,7 @@ bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
                network_->pathName(output_pin),
                output_port->libertyCell()->name(),
                output_cap,
-               max_cap);
+               max_cap1);
     return true;
   }
 
@@ -866,30 +868,32 @@ bool BaseMove::checkMaxCapViolation(const sta::Pin* output_pin,
 }
 
 bool BaseMove::checkMaxSlewViolation(const sta::Pin* output_pin,
-                                     sta::LibertyPort* output_port,
-                                     float output_slew_factor,
-                                     float output_cap,
-                                     const sta::Scene* scene)
+                                      sta::LibertyPort* output_port,
+                                      float output_slew_factor,
+                                      float output_cap)
 {
   float output_res = output_port->driveResistance();
   float output_slew = output_slew_factor * output_res * output_cap;
-  float max_slew;
-  bool slew_limit_exists;
 
-  sta_->findSlewLimit(
-      output_port, scene, resizer_->max_, max_slew, slew_limit_exists);
+  // Check slew limit across all corners (not just one).
+  for (const sta::Scene* corner : sta_->scenes()) {
+    float max_slew;
+    bool slew_limit_exists;
+    sta_->findSlewLimit(
+        output_port, corner, resizer_->max_, max_slew, slew_limit_exists);
 
-  if (output_slew > max_slew) {
-    debugPrint(logger_,
-               RSZ,
-               "opt_moves",
-               2,
-               "  skip based on max slew {} gate={} slew={} max_slew={}",
-               network_->pathName(output_pin),
-               output_port->libertyCell()->name(),
-               output_slew,
-               max_slew);
-    return true;
+    if (slew_limit_exists && output_slew > max_slew) {
+      debugPrint(logger_,
+                 RSZ,
+                 "opt_moves",
+                 2,
+                 "  skip based on max slew {} gate={} slew={} max_slew={}",
+                 network_->pathName(output_pin),
+                 output_port->libertyCell()->name(),
+                 output_slew,
+                 max_slew);
+      return true;
+    }
   }
 
   return false;

--- a/src/rsz/src/BaseMove.hh
+++ b/src/rsz/src/BaseMove.hh
@@ -187,8 +187,7 @@ class BaseMove : public sta::dbStaState
   bool checkMaxSlewViolation(const sta::Pin* output_pin,
                              sta::LibertyPort* output_port,
                              float output_slew_factor,
-                             float output_cap,
-                             const sta::Scene* corner);
+                             float output_cap);
   float computeElmoreSlewFactor(const sta::Pin* output_pin,
                                 sta::LibertyPort* output_port,
                                 float output_load_cap);

--- a/src/rsz/src/SizeDownMove.cc
+++ b/src/rsz/src/SizeDownMove.cc
@@ -330,7 +330,6 @@ sta::LibertyCell* SizeDownMove::downSizeGate(const sta::LibertyPort* drvr_port,
       sta::LibertyPort* output_port
           = swappable->findLibertyPort(output_port_names[i]);
 
-      // FIXME: Only applies to current corner
       if (checkMaxCapViolation(output_pins[i], output_port, output_caps[i])) {
         skip_cell = true;
         break;
@@ -339,8 +338,7 @@ sta::LibertyCell* SizeDownMove::downSizeGate(const sta::LibertyPort* drvr_port,
       if (checkMaxSlewViolation(output_pins[i],
                                 output_port,
                                 output_slew_factors[i],
-                                output_caps[i],
-                                scene)) {
+                                output_caps[i])) {
         skip_cell = true;
         break;
       }


### PR DESCRIPTION
Fixes #9793
### Problem
`BaseMove::checkMaxCapViolation()` and [checkMaxSlewViolation()](cci:1://file:///c:/Users/smsha/Desktop/OpenROAD/src/rsz/src/BaseMove.cc:869:0-899:1) only checked against a **single timing corner**, as noted by two FIXMEs:
- `BaseMove.cc:L840`  `// FIXME: Can we update to consider multiple corners?`
- `SizeDownMove.cc:L333`  `// FIXME: Only applies to current corner`
In multi-corner/multi-mode (MCMM) designs, a cell swap passing checks at the current corner may violate limits at another corner (e.g., slow corner has different `max_cap`).
### Changes
**`BaseMove::checkMaxCapViolation()`** replaced single-corner `output_port->capacitanceLimit()` with `sta_->checkCapacitance(pin, sta_->scenes(), ...)` which queries across all corners and returns the worst violation. Follows the pattern used by `RepairDesign::needRepairCap()`.
**`BaseMove::checkMaxSlewViolation()`** replaced single `scene` parameter with iteration over `sta_->scenes()`, checking the slew limit at every corner. Removed the `scene` parameter from the function signature.
**[SizeDownMove.cc](cci:7://file:///c:/Users/smsha/Desktop/OpenROAD/src/rsz/src/SizeDownMove.cc:0:0-0:0)** removed both FIXME comments, updated the call site.
### Testing
All existing [rsz](cci:1://file:///c:/Users/smsha/Desktop/OpenROAD/src/rsz/src/Resizer.cc:227:0-236:1) regression tests pass. The change is conservative (more checking = more restrictive), so no golden file updates needed.
