### PR TITLE
fix: make fix_lint run tclint after tclfmt (POLA)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -435,8 +435,8 @@ pkg_tar(
 # ---------------------------------------------------------------------------
 # Lint & tidy targets
 #
-# bazelisk test //:lint_test   — run all linters (currently: tclint + tclfmt)
-# bazelisk run  //:fix_lint    — auto-fix what can be fixed  (currently: tclfmt)
+# bazelisk test //:lint_test   — run all lint checks
+# bazelisk run  //:fix_lint    — auto-fix then lint
 # ---------------------------------------------------------------------------
 
 # --- TCL linting (tclint) -------------------------------------------------
@@ -465,7 +465,7 @@ sh_test(
     tags = ["local"],
 )
 
-# --- TCL auto-format (tclfmt --in-place) ----------------------------------
+# --- TCL auto-format only (tclfmt --in-place) -----------------------------
 
 sh_binary(
     name = "tidy_tcl",
@@ -487,7 +487,22 @@ test_suite(
     ],
 )
 
-alias(
+# Linting is done here (not just formatting) because not all lint violations
+# are auto-fixable — fix_lint fixes what it can, then reports the rest.
+sh_binary(
     name = "fix_lint",
-    actual = ":tidy_tcl",
+    srcs = ["//bazel:fix_lint.sh"],
+    args = [
+        "$(rootpath //bazel:tcl_tidy.sh)",
+        "$(rootpath //bazel:tclfmt)",
+        "$(rootpath //bazel:tcl_lint_test.sh)",
+        "$(rootpath //bazel:tclint)",
+    ],
+    data = [
+        "tclint.toml",
+        "//bazel:tcl_lint_test.sh",
+        "//bazel:tcl_tidy.sh",
+        "//bazel:tclfmt",
+        "//bazel:tclint",
+    ],
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -7,6 +7,7 @@ package(features = ["layering_check"])
 
 exports_files(
     [
+        "fix_lint.sh",
         "install.sh",
         "tcl_lint_test.sh",
         "tcl_fmt_test.sh",

--- a/bazel/fix_lint.sh
+++ b/bazel/fix_lint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+#
+# Auto-fix then lint. Delegates to tcl_tidy.sh and tcl_lint_test.sh
+# so that file-discovery logic is not duplicated (DRY).
+set -euo pipefail
+
+export BUILD_WORKSPACE_DIRECTORY="${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
+
+# TCL: auto-format then lint
+"$1" "$2"
+"$3" "$4" || rc=$?
+
+git -C "$BUILD_WORKSPACE_DIRECTORY" status
+
+if [ "${rc:-0}" -ne 0 ]; then
+    echo "Error: lint violations remain that require manual fixes." >&2
+fi
+exit "${rc:-0}"

--- a/docs/contrib/LintTargets.md
+++ b/docs/contrib/LintTargets.md
@@ -27,16 +27,37 @@ works identically on every developer's machine and in CI. No virtualenvs, no
 # Run all lint checks (~0.3s, no C++ build)
 bazelisk test //:lint_test
 
-# Auto-fix formatting
+# Auto-fix then lint
 bazelisk run //:fix_lint
 ```
+
+## Target naming convention
+
+The `_test` suffix is a Bazel convention: `bazelisk test` discovers and runs
+targets whose name ends in `_test`. `//:lint_test` is the top-level test suite
+that aggregates all per-language lint checks — running `bazelisk test //:lint_test`
+checks every language supported by this framework.
+
+Targets follow a consistent `{verb}_{language}` pattern so that adding a new
+language is mechanical and the naming is predictable:
+
+| Pattern | Scope | Purpose |
+|---------|-------|---------|
+| `//:fix_lint` | all languages | Umbrella: auto-fix then lint everything |
+| `//:lint_test` | all languages | Umbrella: run all lint checks (read-only) |
+| `//:lint_{lang}_test` | one language | Lint check (read-only) |
+| `//:fmt_{lang}_test` | one language | Format check (read-only) |
+| `//:tidy_{lang}` | one language | Auto-format only |
+
+Adding a new language means adding per-language targets and wiring them into
+the two umbrella targets.
 
 ## Available targets
 
 | Target | Type | What it does |
 |--------|------|-------------|
 | `//:lint_test` | `test_suite` | Umbrella: runs all lint checks |
-| `//:fix_lint` | `alias` | Umbrella: auto-fixes what can be fixed |
+| `//:fix_lint` | `sh_binary` | Umbrella: auto-fixes what can be fixed, then lints |
 | `//:lint_tcl_test` | `sh_test` | Runs `tclint .` (lint rules) |
 | `//:fmt_tcl_test` | `sh_test` | Runs `tclfmt --check .` (formatting) |
 | `//:tidy_tcl` | `sh_binary` | Runs `tclfmt --in-place .` (auto-format) |
@@ -47,6 +68,14 @@ TCL linting and formatting are controlled by `tclint.toml` at the repository
 root. See the [tclint documentation](https://tclint.readthedocs.io/) for
 available options.
 
+## POLA
+
+`//:fix_lint` follows the
+[Principle of Least Astonishment](https://en.wikipedia.org/wiki/Principle_of_least_astonishment):
+it fixes what it can (e.g. `tclfmt --in-place`) and exits with an error if
+any lint violations remain that require manual intervention (e.g. `line-length`).
+A developer who runs `fix_lint` before pushing should never be surprised by
+a CI lint failure.
 
 ## Adding new linters
 
@@ -57,7 +86,9 @@ To add a new linter (e.g., C++ tidy):
    module dependency
 2. Create a wrapper script in `bazel/` (e.g., `bazel/cpp_tidy.sh`)
 3. Add `sh_test` / `sh_binary` targets in `BUILD.bazel`
-4. Add the new test to the `//:lint_test` `test_suite`
+4. Wire into umbrellas:
+   - Add the new test to the `//:lint_test` `test_suite`
+   - Add a call in `bazel/fix_lint.sh`
 
 ## Planned additions
 


### PR DESCRIPTION
fix_lint was an alias for tidy_tcl (tclfmt only), so developers who ran it before pushing were still surprised by tclint CI failures like line-length.

Replace the alias with a script that delegates to tcl_tidy.sh and tcl_lint_test.sh (DRY), shows git status, and exits with a clear error if lint violations remain unfixed.

Update docs with POLA rationale and naming convention for umbrella and per-language targets.
