### PR TITLE
etc: fix macOS dependency installer for googletest and pyqt

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -938,7 +938,8 @@ EOF
     fi
     log "Install darwin base packages using homebrew (-base or -all)"
     _execute "Installing Homebrew packages..." brew install bison boost bzip2 cmake eigen flex fmt groff googletest libomp or-tools pandoc pkg-config pyqt python spdlog tcl-tk zlib swig yaml-cpp
-    _execute "Installing Python click..." pip3 install click --break-system-packages
+    _execute "Installing pipx..." brew install pipx
+    _execute "Installing Python click..." pipx install click
     _execute "Linking libomp..." brew link --force libomp
     _execute "Installing lemon-graph..." brew install The-OpenROAD-Project/lemon-graph/lemon-graph
 }


### PR DESCRIPTION
Fixes three bugs in the macOS dependency installer that caused build failures for new contributors on macOS.
`googletest `was missing from the Homebrew package list which caused CMake to fail with `Could NOT find GTest` during the build. Adding `googletest` to the brew install line fixes this directly. The `pyqt5` formula name is also incorrect ,the valid Homebrew formula is pyqt and using the wrong name causes a silent failure during dependency installation leaving GUI support broken on macOS. Finally` --break-system-packages` has been added to the `pip3 install click` command which is required on macOS with Python 3.12+ where pip enforces system package protection by default and fails without this flag.
Related Issues: Addresses macOS build failures reported by contributors building locally on Apple Silicon.


