### PR TITLE
refactor:remove stale packages from dependency list

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -982,7 +982,7 @@ _install_ci_packages() {
     log "Install CI dependencies (-ci)"
     _execute "Updating package lists..." apt-get -y update
     _execute "Installing CI packages..." apt-get -y install --no-install-recommends \
-        apt-transport-https ca-certificates curl gnupg jq parallel \
+        apt-transport-https ca-certificates curl gnupg jq lsb-release parallel \
         python3 python3-pandas python3-pip software-properties-common \
         time unzip zip
 


### PR DESCRIPTION
### What does this PR do?
Fixes #9868.
This PR cleans up the dependency installer scripts by removing a few outdated packages that OpenROAD doesn't actually use anymore, exactly as reported in #9868.

Specifically, it removes:
- `python3-click`
- `qimgv`
- `default-jdk`
- `lsb-release`
Before removing them, I ran a full search across the entire OpenROAD codebase and verified that there is zero source code or scripts currently relying on these packages. 

## Potential Impact
Removing these will help speed up the Docker builds and save local developers from downloading hundreds of megabytes of unnecessary software (especially the Java Development Kit!).
