### PR TITLE
mpl: consolidate cluster type booleans into ClusterType enum

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -2144,18 +2144,20 @@ void dbNetwork::readDbAfter(odb::dbDatabase* db)
   dbChip* chip = db_->getChip();
   if (chip) {
     block_ = chip->getBlock();
-    for (dbLib* lib : db_->getLibs()) {
-      makeLibrary(lib);
-    }
-
-    for (dbModule* module : block_->getModules()) {
-      // top_module is not a hierarchical module in this context.
-      if (module != block_->getTopModule()) {
-        registerHierModule(dbToSta(module));
+    if (block_) {
+      for (dbLib* lib : db_->getLibs()) {
+        makeLibrary(lib);
       }
-    }
 
-    readDbNetlistAfter();
+      for (dbModule* module : block_->getModules()) {
+        // top_module is not a hierarchical module in this context.
+        if (module != block_->getTopModule()) {
+          registerHierModule(dbToSta(module));
+        }
+      }
+
+      readDbNetlistAfter();
+    }
   }
 
   for (dbNetworkObserver* observer : observers_) {

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -742,8 +742,7 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
 {
   const int cluster_id = cluster->getId();
   const Cluster::Type cluster_type = cluster->getType();
-  if (cluster_type == Cluster::Type::Macro
-      || cluster_type == Cluster::Type::Mixed) {
+  if (cluster->isAnyMacroCluster() || cluster_type == Cluster::Type::Mixed) {
     for (odb::dbInst* inst : cluster->getLeafMacros()) {
       if (isIgnoredInst(inst)) {
         continue;
@@ -1801,7 +1800,6 @@ void ClusteringEngine::breakMixedLeaf(Cluster* mixed_leaf)
       movable_macro_cluster->setAsArrayOfInterconnectedMacros();
     }
 
-    movable_macro_cluster->setType(Cluster::Type::Macro);
     setClusterMetrics(movable_macro_cluster);
     virtual_conn_clusters.push_back(movable_macro_cluster->getId());
   }

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -700,7 +700,7 @@ void ClusteringEngine::treatEachMacroAsSingleCluster()
       const std::string cluster_name = inst->getName();
       auto cluster = std::make_unique<Cluster>(id_, cluster_name, logger_);
       cluster->addLeafMacro(inst);
-      cluster->setClusterType(HardMacroCluster);
+      cluster->setClusterType(ClusterType::Macro);
       incorporateNewCluster(std::move(cluster), tree_->root.get());
 
       debugPrint(logger_,
@@ -742,7 +742,8 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
 {
   const int cluster_id = cluster->getId();
   const ClusterType cluster_type = cluster->getClusterType();
-  if (cluster_type == HardMacroCluster || cluster_type == MixedCluster) {
+  if (cluster_type == ClusterType::Macro
+      || cluster_type == ClusterType::Mixed) {
     for (odb::dbInst* inst : cluster->getLeafMacros()) {
       if (isIgnoredInst(inst)) {
         continue;
@@ -752,7 +753,8 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
     }
   }
 
-  if (cluster_type == StdCellCluster || cluster_type == MixedCluster) {
+  if (cluster_type == ClusterType::StdCell
+      || cluster_type == ClusterType::Mixed) {
     for (odb::dbInst* inst : cluster->getLeafStdCells()) {
       if (isIgnoredInst(inst)) {
         continue;
@@ -763,11 +765,11 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
   }
 
   // Note: macro clusters have no module.
-  if (cluster_type == StdCellCluster) {
+  if (cluster_type == ClusterType::StdCell) {
     for (odb::dbModule* module : cluster->getDbModules()) {
       updateInstancesAssociation(module, cluster_id, false);
     }
-  } else if (cluster_type == MixedCluster) {
+  } else if (cluster_type == ClusterType::Mixed) {
     for (odb::dbModule* module : cluster->getDbModules()) {
       updateInstancesAssociation(module, cluster_id, true);
     }
@@ -1688,11 +1690,11 @@ void ClusteringEngine::fetchMixedLeaves(
     updateInstancesAssociation(child.get());
 
     if (child->getNumMacro() == 0) {
-      child->setClusterType(StdCellCluster);
+      child->setClusterType(ClusterType::StdCell);
     }
 
     if (child->getChildren().empty()) {
-      if (child->getClusterType() != StdCellCluster) {
+      if (child->getClusterType() != ClusterType::StdCell) {
         sister_mixed_leaves.push_back(child.get());
       }
     } else {
@@ -1799,14 +1801,14 @@ void ClusteringEngine::breakMixedLeaf(Cluster* mixed_leaf)
       movable_macro_cluster->setAsArrayOfInterconnectedMacros();
     }
 
-    movable_macro_cluster->setClusterType(HardMacroCluster);
+    movable_macro_cluster->setClusterType(ClusterType::Macro);
     setClusterMetrics(movable_macro_cluster);
     virtual_conn_clusters.push_back(movable_macro_cluster->getId());
   }
 
   // Deal with the fixed macros.
   for (Cluster* fixed_macro_cluster : fixed_macro_clusters) {
-    fixed_macro_cluster->setClusterType(HardMacroCluster);
+    fixed_macro_cluster->setClusterType(ClusterType::Macro);
     setClusterMetrics(fixed_macro_cluster);
     virtual_conn_clusters.push_back(fixed_macro_cluster->getId());
   }
@@ -1823,7 +1825,7 @@ void ClusteringEngine::breakMixedLeaf(Cluster* mixed_leaf)
 // Map all the macros into their HardMacro objects for all the clusters
 void ClusteringEngine::mapMacroInCluster2HardMacro(Cluster* cluster)
 {
-  if (cluster->getClusterType() == StdCellCluster) {
+  if (cluster->getClusterType() == ClusterType::StdCell) {
     return;
   }
 
@@ -2032,7 +2034,7 @@ void ClusteringEngine::replaceByStdCellCluster(
     std::vector<int>& virtual_conn_clusters)
 {
   mixed_leaf->clearLeafMacros();
-  mixed_leaf->setClusterType(StdCellCluster);
+  mixed_leaf->setClusterType(ClusterType::StdCell);
 
   setClusterMetrics(mixed_leaf);
 

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -700,7 +700,7 @@ void ClusteringEngine::treatEachMacroAsSingleCluster()
       const std::string cluster_name = inst->getName();
       auto cluster = std::make_unique<Cluster>(id_, cluster_name, logger_);
       cluster->addLeafMacro(inst);
-      cluster->setClusterType(ClusterType::Macro);
+      cluster->setType(Cluster::Type::Macro);
       incorporateNewCluster(std::move(cluster), tree_->root.get());
 
       debugPrint(logger_,
@@ -741,9 +741,9 @@ void ClusteringEngine::incorporateNewCluster(std::unique_ptr<Cluster> cluster,
 void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
 {
   const int cluster_id = cluster->getId();
-  const ClusterType cluster_type = cluster->getClusterType();
-  if (cluster_type == ClusterType::Macro
-      || cluster_type == ClusterType::Mixed) {
+  const Cluster::Type cluster_type = cluster->getType();
+  if (cluster_type == Cluster::Type::Macro
+      || cluster_type == Cluster::Type::Mixed) {
     for (odb::dbInst* inst : cluster->getLeafMacros()) {
       if (isIgnoredInst(inst)) {
         continue;
@@ -753,8 +753,8 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
     }
   }
 
-  if (cluster_type == ClusterType::StdCell
-      || cluster_type == ClusterType::Mixed) {
+  if (cluster_type == Cluster::Type::StdCell
+      || cluster_type == Cluster::Type::Mixed) {
     for (odb::dbInst* inst : cluster->getLeafStdCells()) {
       if (isIgnoredInst(inst)) {
         continue;
@@ -765,11 +765,11 @@ void ClusteringEngine::updateInstancesAssociation(Cluster* cluster)
   }
 
   // Note: macro clusters have no module.
-  if (cluster_type == ClusterType::StdCell) {
+  if (cluster_type == Cluster::Type::StdCell) {
     for (odb::dbModule* module : cluster->getDbModules()) {
       updateInstancesAssociation(module, cluster_id, false);
     }
-  } else if (cluster_type == ClusterType::Mixed) {
+  } else if (cluster_type == Cluster::Type::Mixed) {
     for (odb::dbModule* module : cluster->getDbModules()) {
       updateInstancesAssociation(module, cluster_id, true);
     }
@@ -1690,11 +1690,11 @@ void ClusteringEngine::fetchMixedLeaves(
     updateInstancesAssociation(child.get());
 
     if (child->getNumMacro() == 0) {
-      child->setClusterType(ClusterType::StdCell);
+      child->setType(Cluster::Type::StdCell);
     }
 
     if (child->getChildren().empty()) {
-      if (child->getClusterType() != ClusterType::StdCell) {
+      if (child->getType() != Cluster::Type::StdCell) {
         sister_mixed_leaves.push_back(child.get());
       }
     } else {
@@ -1801,14 +1801,14 @@ void ClusteringEngine::breakMixedLeaf(Cluster* mixed_leaf)
       movable_macro_cluster->setAsArrayOfInterconnectedMacros();
     }
 
-    movable_macro_cluster->setClusterType(ClusterType::Macro);
+    movable_macro_cluster->setType(Cluster::Type::Macro);
     setClusterMetrics(movable_macro_cluster);
     virtual_conn_clusters.push_back(movable_macro_cluster->getId());
   }
 
   // Deal with the fixed macros.
   for (Cluster* fixed_macro_cluster : fixed_macro_clusters) {
-    fixed_macro_cluster->setClusterType(ClusterType::Macro);
+    fixed_macro_cluster->setType(Cluster::Type::Macro);
     setClusterMetrics(fixed_macro_cluster);
     virtual_conn_clusters.push_back(fixed_macro_cluster->getId());
   }
@@ -1825,7 +1825,7 @@ void ClusteringEngine::breakMixedLeaf(Cluster* mixed_leaf)
 // Map all the macros into their HardMacro objects for all the clusters
 void ClusteringEngine::mapMacroInCluster2HardMacro(Cluster* cluster)
 {
-  if (cluster->getClusterType() == ClusterType::StdCell) {
+  if (cluster->getType() == Cluster::Type::StdCell) {
     return;
   }
 
@@ -2034,7 +2034,7 @@ void ClusteringEngine::replaceByStdCellCluster(
     std::vector<int>& virtual_conn_clusters)
 {
   mixed_leaf->clearLeafMacros();
-  mixed_leaf->setClusterType(ClusterType::StdCell);
+  mixed_leaf->setType(Cluster::Type::StdCell);
 
   setClusterMetrics(mixed_leaf);
 
@@ -2179,7 +2179,7 @@ void ClusteringEngine::printPhysicalHierarchyTree(Cluster* parent, int level)
   line += fmt::format("{}  ({}) Type: {}",
                       parent->getName(),
                       parent->getId(),
-                      parent->getClusterTypeString());
+                      parent->getTypeString());
 
   if (parent->isClusterOfUnplacedIOPins() || parent->isIOBundle()) {
     line += fmt::format(" Pins: {}", getNumberOfIOs(parent));

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -178,14 +178,14 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
 
   for (auto& child : parent->getChildren()) {
     switch (child->getClusterType()) {
-      case HardMacroCluster: {
+      case ClusterType::Macro: {
         std::vector<mpl::HardMacro*> hard_macros = child->getHardMacros();
         for (HardMacro* hard_macro : hard_macros) {
           hard.push_back(*hard_macro);
         }
         break;
       }
-      case StdCellCluster: {
+      case ClusterType::StdCell: {
         if (child->isLeaf()) {
           soft.push_back(*child->getSoftMacro());
         } else {
@@ -193,10 +193,12 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
         }
         break;
       }
-      case MixedCluster: {
+      case ClusterType::Mixed: {
         fetchSoftAndHard(child.get(), hard, soft, outlines, (level + 1));
         break;
       }
+      default:
+        break;
     }
   }
 }
@@ -682,9 +684,9 @@ void Graphics::setSoftMacroBrush(gui::Painter& painter,
     return;
   }
 
-  if (soft_macro.getCluster()->getClusterType() == StdCellCluster) {
+  if (soft_macro.getCluster()->getClusterType() == ClusterType::StdCell) {
     painter.setBrush(gui::Painter::kDarkBlue);
-  } else if (soft_macro.getCluster()->getClusterType() == HardMacroCluster) {
+  } else if (soft_macro.getCluster()->getClusterType() == ClusterType::Macro) {
     // dark red
     painter.setBrush(gui::Painter::Color(0x80, 0x00, 0x00, 150));
   } else {

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -177,15 +177,15 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
   outlines[level].push_back(outline);
 
   for (auto& child : parent->getChildren()) {
-    switch (child->getClusterType()) {
-      case ClusterType::Macro: {
+    switch (child->getType()) {
+      case Cluster::Type::Macro: {
         std::vector<mpl::HardMacro*> hard_macros = child->getHardMacros();
         for (HardMacro* hard_macro : hard_macros) {
           hard.push_back(*hard_macro);
         }
         break;
       }
-      case ClusterType::StdCell: {
+      case Cluster::Type::StdCell: {
         if (child->isLeaf()) {
           soft.push_back(*child->getSoftMacro());
         } else {
@@ -193,12 +193,18 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
         }
         break;
       }
-      case ClusterType::Mixed: {
+      case Cluster::Type::Mixed: {
         fetchSoftAndHard(child.get(), hard, soft, outlines, (level + 1));
         break;
       }
-      default:
+      case Cluster::Type::ConstrainedIOs:
+      case Cluster::Type::UnconstrainedIOs:
+      case Cluster::Type::IOBundle:
+      case Cluster::Type::PAD:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray:
         break;
+
     }
   }
 }
@@ -684,9 +690,9 @@ void Graphics::setSoftMacroBrush(gui::Painter& painter,
     return;
   }
 
-  if (soft_macro.getCluster()->getClusterType() == ClusterType::StdCell) {
+  if (soft_macro.getCluster()->getType() == Cluster::Type::StdCell) {
     painter.setBrush(gui::Painter::kDarkBlue);
-  } else if (soft_macro.getCluster()->getClusterType() == ClusterType::Macro) {
+  } else if (soft_macro.getCluster()->getType() == Cluster::Type::Macro) {
     // dark red
     painter.setBrush(gui::Painter::Color(0x80, 0x00, 0x00, 150));
   } else {

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -178,7 +178,9 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
 
   for (auto& child : parent->getChildren()) {
     switch (child->getType()) {
-      case Cluster::Type::Macro: {
+      case Cluster::Type::Macro:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray: {
         std::vector<mpl::HardMacro*> hard_macros = child->getHardMacros();
         for (HardMacro* hard_macro : hard_macros) {
           hard.push_back(*hard_macro);
@@ -201,8 +203,6 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
       case Cluster::Type::UnconstrainedIOs:
       case Cluster::Type::IOBundle:
       case Cluster::Type::PAD:
-      case Cluster::Type::MacroArray:
-      case Cluster::Type::InterconnectedMacrosArray:
         break;
     }
   }
@@ -691,7 +691,7 @@ void Graphics::setSoftMacroBrush(gui::Painter& painter,
 
   if (soft_macro.getCluster()->getType() == Cluster::Type::StdCell) {
     painter.setBrush(gui::Painter::kDarkBlue);
-  } else if (soft_macro.getCluster()->getType() == Cluster::Type::Macro) {
+  } else if (soft_macro.getCluster()->isAnyMacroCluster()) {
     // dark red
     painter.setBrush(gui::Painter::Color(0x80, 0x00, 0x00, 150));
   } else {

--- a/src/mpl/src/graphics.cpp
+++ b/src/mpl/src/graphics.cpp
@@ -204,7 +204,6 @@ void Graphics::fetchSoftAndHard(Cluster* parent,
       case Cluster::Type::MacroArray:
       case Cluster::Type::InterconnectedMacrosArray:
         break;
-
     }
   }
 }

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1673,7 +1673,6 @@ bool HierRTLMP::validUtilization(
       case Cluster::Type::MacroArray:
       case Cluster::Type::InterconnectedMacrosArray:
         break;
-
     }
   }
 
@@ -2705,7 +2704,6 @@ bool Pusher::designHasSingleCentralizedMacroArray()
       case Cluster::Type::MacroArray:
       case Cluster::Type::InterconnectedMacrosArray:
         break;
-
     }
 
     if (macro_cluster_count > 1) {

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -1672,8 +1672,6 @@ bool HierRTLMP::validUtilization(
       case Cluster::Type::UnconstrainedIOs:
       case Cluster::Type::IOBundle:
       case Cluster::Type::PAD:
-      case Cluster::Type::MacroArray:
-      case Cluster::Type::InterconnectedMacrosArray:
         break;
     }
   }

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -340,7 +340,7 @@ void HierRTLMP::runCoarseShaping()
 
   if (tree_->has_only_macros) {
     logger_->warn(MPL, 27, "Design has only macros!");
-    tree_->root->setClusterType(ClusterType::Macro);
+    tree_->root->setType(Cluster::Type::Macro);
     return;
   }
 
@@ -391,7 +391,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
              parent->getName());
 
   // Current cluster is a hard macro cluster
-  if (parent->getClusterType() == ClusterType::Macro) {
+  if (parent->getType() == Cluster::Type::Macro) {
     debugPrint(logger_,
                MPL,
                "coarse_shaping",
@@ -1084,14 +1084,14 @@ int HierRTLMP::computePinAccessBaseDepth(const int io_span) const
 {
   int64_t std_cell_area = 0;
   for (auto& cluster : tree_->root->getChildren()) {
-    if (cluster->getClusterType() == ClusterType::StdCell) {
+    if (cluster->getType() == Cluster::Type::StdCell) {
       std_cell_area += cluster->getArea();
     }
   }
 
   if (std_cell_area == 0) {
     for (auto& cluster : tree_->root->getChildren()) {
-      if (cluster->getClusterType() == ClusterType::Mixed) {
+      if (cluster->getType() == Cluster::Type::Mixed) {
         std_cell_area += cluster->getArea();
       }
     }
@@ -1194,7 +1194,7 @@ void HierRTLMP::adjustMacroBlockageWeight()
 
 void HierRTLMP::placeChildren(Cluster* parent)
 {
-  if (parent->getClusterType() == ClusterType::Macro) {
+  if (parent->getType() == Cluster::Type::Macro) {
     placeMacros(parent);
     return;
   }
@@ -1261,7 +1261,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
     cluster->setSoftMacro(std::move(soft_macro));
 
     // merge fences and guides for hard macros within cluster
-    if (cluster->getClusterType() == ClusterType::StdCell) {
+    if (cluster->getType() == Cluster::Type::StdCell) {
       continue;
     }
     odb::Rect fence, guide;
@@ -1650,24 +1650,30 @@ bool HierRTLMP::validUtilization(
       continue;
     }
 
-    switch (cluster->getClusterType()) {
-      case ClusterType::StdCell: {
+    switch (cluster->getType()) {
+      case Cluster::Type::StdCell: {
         std_cell_cluster_area += cluster->getStdCellArea();
         break;
       }
-      case ClusterType::Macro: {
+      case Cluster::Type::Macro: {
         const TilingList& tilings = cluster->getTilings();
         macro_cluster_area += tilings.front().area();
         break;
       }
-      case ClusterType::Mixed: {
+      case Cluster::Type::Mixed: {
         const TilingList& tilings = cluster->getTilings();
         mixed_cluster_macro_area += tilings.front().area();
         mixed_cluster_std_cell_area += cluster->getStdCellArea();
         break;
       }
-      default:
+      case Cluster::Type::ConstrainedIOs:
+      case Cluster::Type::UnconstrainedIOs:
+      case Cluster::Type::IOBundle:
+      case Cluster::Type::PAD:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray:
         break;
+
     }
   }
 
@@ -2617,14 +2623,14 @@ void Pusher::fetchMacroClusters(Cluster* parent,
                                 std::vector<Cluster*>& macro_clusters)
 {
   for (auto& child : parent->getChildren()) {
-    if (child->getClusterType() == ClusterType::Macro) {
+    if (child->getType() == Cluster::Type::Macro) {
       macro_clusters.push_back(child.get());
 
       for (HardMacro* hard_macro : child->getHardMacros()) {
         hard_macros_.push_back(hard_macro);
       }
 
-    } else if (child->getClusterType() == ClusterType::Mixed) {
+    } else if (child->getType() == Cluster::Type::Mixed) {
       fetchMacroClusters(child.get(), macro_clusters);
     }
   }
@@ -2633,7 +2639,7 @@ void Pusher::fetchMacroClusters(Cluster* parent,
 void Pusher::pushMacrosToCoreBoundaries()
 {
   // Case in which the design has nothing but macros.
-  if (root_->getClusterType() == ClusterType::Macro) {
+  if (root_->getType() == Cluster::Type::Macro) {
     return;
   }
 
@@ -2676,13 +2682,13 @@ bool Pusher::designHasSingleCentralizedMacroArray()
   int macro_cluster_count = 0;
 
   for (auto& child : root_->getChildren()) {
-    switch (child->getClusterType()) {
-      case ClusterType::Mixed:
+    switch (child->getType()) {
+      case Cluster::Type::Mixed:
         return false;
-      case ClusterType::Macro:
+      case Cluster::Type::Macro:
         ++macro_cluster_count;
         break;
-      case ClusterType::StdCell: {
+      case Cluster::Type::StdCell: {
         // Note: to check whether or not a std cell cluster is "tiny"
         // we use the area of its SoftMacro abstraction, because the
         // Cluster::getArea() will give us the actual std cell area
@@ -2692,8 +2698,14 @@ bool Pusher::designHasSingleCentralizedMacroArray()
         }
         break;
       }
-      default:
+      case Cluster::Type::ConstrainedIOs:
+      case Cluster::Type::UnconstrainedIOs:
+      case Cluster::Type::IOBundle:
+      case Cluster::Type::PAD:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray:
         break;
+
     }
 
     if (macro_cluster_count > 1) {

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -391,7 +391,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
              parent->getName());
 
   // Current cluster is a hard macro cluster
-  if (parent->getType() == Cluster::Type::Macro) {
+  if (parent->isAnyMacroCluster()) {
     debugPrint(logger_,
                MPL,
                "coarse_shaping",
@@ -1194,7 +1194,7 @@ void HierRTLMP::adjustMacroBlockageWeight()
 
 void HierRTLMP::placeChildren(Cluster* parent)
 {
-  if (parent->getType() == Cluster::Type::Macro) {
+  if (parent->isAnyMacroCluster()) {
     placeMacros(parent);
     return;
   }
@@ -1655,7 +1655,9 @@ bool HierRTLMP::validUtilization(
         std_cell_cluster_area += cluster->getStdCellArea();
         break;
       }
-      case Cluster::Type::Macro: {
+      case Cluster::Type::Macro:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray: {
         const TilingList& tilings = cluster->getTilings();
         macro_cluster_area += tilings.front().area();
         break;
@@ -2622,7 +2624,7 @@ void Pusher::fetchMacroClusters(Cluster* parent,
                                 std::vector<Cluster*>& macro_clusters)
 {
   for (auto& child : parent->getChildren()) {
-    if (child->getType() == Cluster::Type::Macro) {
+    if (child->isAnyMacroCluster()) {
       macro_clusters.push_back(child.get());
 
       for (HardMacro* hard_macro : child->getHardMacros()) {
@@ -2638,7 +2640,7 @@ void Pusher::fetchMacroClusters(Cluster* parent,
 void Pusher::pushMacrosToCoreBoundaries()
 {
   // Case in which the design has nothing but macros.
-  if (root_->getType() == Cluster::Type::Macro) {
+  if (root_->isAnyMacroCluster()) {
     return;
   }
 
@@ -2685,6 +2687,8 @@ bool Pusher::designHasSingleCentralizedMacroArray()
       case Cluster::Type::Mixed:
         return false;
       case Cluster::Type::Macro:
+      case Cluster::Type::MacroArray:
+      case Cluster::Type::InterconnectedMacrosArray:
         ++macro_cluster_count;
         break;
       case Cluster::Type::StdCell: {
@@ -2701,8 +2705,6 @@ bool Pusher::designHasSingleCentralizedMacroArray()
       case Cluster::Type::UnconstrainedIOs:
       case Cluster::Type::IOBundle:
       case Cluster::Type::PAD:
-      case Cluster::Type::MacroArray:
-      case Cluster::Type::InterconnectedMacrosArray:
         break;
     }
 

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -340,7 +340,7 @@ void HierRTLMP::runCoarseShaping()
 
   if (tree_->has_only_macros) {
     logger_->warn(MPL, 27, "Design has only macros!");
-    tree_->root->setClusterType(HardMacroCluster);
+    tree_->root->setClusterType(ClusterType::Macro);
     return;
   }
 
@@ -391,7 +391,7 @@ void HierRTLMP::calculateChildrenTilings(Cluster* parent)
              parent->getName());
 
   // Current cluster is a hard macro cluster
-  if (parent->getClusterType() == HardMacroCluster) {
+  if (parent->getClusterType() == ClusterType::Macro) {
     debugPrint(logger_,
                MPL,
                "coarse_shaping",
@@ -1084,14 +1084,14 @@ int HierRTLMP::computePinAccessBaseDepth(const int io_span) const
 {
   int64_t std_cell_area = 0;
   for (auto& cluster : tree_->root->getChildren()) {
-    if (cluster->getClusterType() == StdCellCluster) {
+    if (cluster->getClusterType() == ClusterType::StdCell) {
       std_cell_area += cluster->getArea();
     }
   }
 
   if (std_cell_area == 0) {
     for (auto& cluster : tree_->root->getChildren()) {
-      if (cluster->getClusterType() == MixedCluster) {
+      if (cluster->getClusterType() == ClusterType::Mixed) {
         std_cell_area += cluster->getArea();
       }
     }
@@ -1194,7 +1194,7 @@ void HierRTLMP::adjustMacroBlockageWeight()
 
 void HierRTLMP::placeChildren(Cluster* parent)
 {
-  if (parent->getClusterType() == HardMacroCluster) {
+  if (parent->getClusterType() == ClusterType::Macro) {
     placeMacros(parent);
     return;
   }
@@ -1261,7 +1261,7 @@ void HierRTLMP::placeChildren(Cluster* parent)
     cluster->setSoftMacro(std::move(soft_macro));
 
     // merge fences and guides for hard macros within cluster
-    if (cluster->getClusterType() == StdCellCluster) {
+    if (cluster->getClusterType() == ClusterType::StdCell) {
       continue;
     }
     odb::Rect fence, guide;
@@ -1651,20 +1651,23 @@ bool HierRTLMP::validUtilization(
     }
 
     switch (cluster->getClusterType()) {
-      case StdCellCluster: {
+      case ClusterType::StdCell: {
         std_cell_cluster_area += cluster->getStdCellArea();
         break;
       }
-      case HardMacroCluster: {
+      case ClusterType::Macro: {
         const TilingList& tilings = cluster->getTilings();
         macro_cluster_area += tilings.front().area();
         break;
       }
-      case MixedCluster: {
+      case ClusterType::Mixed: {
         const TilingList& tilings = cluster->getTilings();
         mixed_cluster_macro_area += tilings.front().area();
         mixed_cluster_std_cell_area += cluster->getStdCellArea();
+        break;
       }
+      default:
+        break;
     }
   }
 
@@ -2614,14 +2617,14 @@ void Pusher::fetchMacroClusters(Cluster* parent,
                                 std::vector<Cluster*>& macro_clusters)
 {
   for (auto& child : parent->getChildren()) {
-    if (child->getClusterType() == HardMacroCluster) {
+    if (child->getClusterType() == ClusterType::Macro) {
       macro_clusters.push_back(child.get());
 
       for (HardMacro* hard_macro : child->getHardMacros()) {
         hard_macros_.push_back(hard_macro);
       }
 
-    } else if (child->getClusterType() == MixedCluster) {
+    } else if (child->getClusterType() == ClusterType::Mixed) {
       fetchMacroClusters(child.get(), macro_clusters);
     }
   }
@@ -2630,7 +2633,7 @@ void Pusher::fetchMacroClusters(Cluster* parent,
 void Pusher::pushMacrosToCoreBoundaries()
 {
   // Case in which the design has nothing but macros.
-  if (root_->getClusterType() == HardMacroCluster) {
+  if (root_->getClusterType() == ClusterType::Macro) {
     return;
   }
 
@@ -2674,12 +2677,12 @@ bool Pusher::designHasSingleCentralizedMacroArray()
 
   for (auto& child : root_->getChildren()) {
     switch (child->getClusterType()) {
-      case MixedCluster:
+      case ClusterType::Mixed:
         return false;
-      case HardMacroCluster:
+      case ClusterType::Macro:
         ++macro_cluster_count;
         break;
-      case StdCellCluster: {
+      case ClusterType::StdCell: {
         // Note: to check whether or not a std cell cluster is "tiny"
         // we use the area of its SoftMacro abstraction, because the
         // Cluster::getArea() will give us the actual std cell area
@@ -2687,7 +2690,10 @@ bool Pusher::designHasSingleCentralizedMacroArray()
         if (child->getSoftMacro()->getArea() != 0) {
           return false;
         }
+        break;
       }
+      default:
+        break;
     }
 
     if (macro_cluster_count > 1) {

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -299,8 +299,8 @@ void Cluster::setAsFixedMacro(const HardMacro* hard_macro)
 bool Cluster::isIOCluster() const
 {
   return type_ == Cluster::Type::ConstrainedIOs
-         || type_ == Cluster::Type::UnconstrainedIOs || type_ == Cluster::Type::PAD
-         || type_ == Cluster::Type::IOBundle;
+         || type_ == Cluster::Type::UnconstrainedIOs
+         || type_ == Cluster::Type::PAD || type_ == Cluster::Type::IOBundle;
 }
 
 bool Cluster::isClusterOfUnconstrainedIOPins() const
@@ -1052,8 +1052,7 @@ void SoftMacro::setArea(int64_t area)
 {
   if (area_ == 0 || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getType() == Cluster::Type::Macro
-      || cluster_->isIOCluster()
+      || cluster_->getType() == Cluster::Type::Macro || cluster_->isIOCluster()
       || area <= (width_intervals_.front().min
                   * static_cast<int64_t>(height_intervals_.front().max))) {
     return;

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -197,41 +197,32 @@ void Cluster::clearHardMacros()
 
 std::string Cluster::getClusterTypeString() const
 {
-  std::string cluster_type;
-
-  if (is_io_bundle_) {
-    return "IO Bundle";
-  }
-
-  if (is_cluster_of_unconstrained_io_pins_) {
-    return "Unconstrained IOs";
-  }
-
-  if (is_cluster_of_unplaced_io_pins_) {
-    return "Unplaced IOs";
-  }
-
-  if (is_io_pad_cluster_) {
-    return "IO Pad";
-  }
-
   if (is_fixed_macro_) {
     return "Fixed Macro";
   }
 
   switch (type_) {
-    case StdCellCluster:
-      cluster_type = "StdCell";
-      break;
-    case MixedCluster:
-      cluster_type = "Mixed";
-      break;
-    case HardMacroCluster:
-      cluster_type = "Macro";
-      break;
+    case ClusterType::IOBundle:
+      return "IO Bundle";
+    case ClusterType::UnconstrainedIOs:
+      return "Unconstrained IOs";
+    case ClusterType::ConstrainedIOs:
+      return "Constrained IOs";
+    case ClusterType::PAD:
+      return "IO Pad";
+    case ClusterType::StdCell:
+      return "StdCell";
+    case ClusterType::Mixed:
+      return "Mixed";
+    case ClusterType::Macro:
+      return "Macro";
+    case ClusterType::MacroArray:
+      return "Macro Array";
+    case ClusterType::InterconnectedMacrosArray:
+      return "Interconnected Macros Array";
   }
 
-  return cluster_type;
+  return "Unknown";
 }
 
 std::string Cluster::getIsLeafString() const
@@ -252,11 +243,11 @@ void Cluster::copyInstances(const Cluster& cluster)
   leaf_macros_.clear();
   hard_macros_.clear();
 
-  if (type_ == HardMacroCluster) {
+  if (type_ == ClusterType::Macro) {
     leaf_macros_.insert(leaf_macros_.end(),
                         cluster.leaf_macros_.begin(),
                         cluster.leaf_macros_.end());
-  } else if (type_ == StdCellCluster) {
+  } else if (type_ == ClusterType::StdCell) {
     leaf_std_cells_.insert(leaf_std_cells_.end(),
                            cluster.leaf_std_cells_.begin(),
                            cluster.leaf_std_cells_.end());
@@ -282,20 +273,20 @@ void Cluster::setAsClusterOfUnplacedIOPins(
     const int height,
     const bool is_cluster_of_unconstrained_io_pins)
 {
-  is_cluster_of_unplaced_io_pins_ = true;
-  is_cluster_of_unconstrained_io_pins_ = is_cluster_of_unconstrained_io_pins;
+  is_cluster_of_unconstrained_io_pins ? type_ = ClusterType::UnconstrainedIOs
+                                      : type_ = ClusterType::ConstrainedIOs;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
 void Cluster::setAsIOPadCluster(const odb::Point& pos, int width, int height)
 {
-  is_io_pad_cluster_ = true;
+  type_ = ClusterType::PAD;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
 void Cluster::setAsIOBundle(const odb::Point& pos, int width, int height)
 {
-  is_io_bundle_ = true;
+  type_ = ClusterType::IOBundle;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
@@ -307,27 +298,30 @@ void Cluster::setAsFixedMacro(const HardMacro* hard_macro)
 
 bool Cluster::isIOCluster() const
 {
-  return is_cluster_of_unplaced_io_pins_ || is_io_pad_cluster_ || is_io_bundle_;
+  return type_ == ClusterType::ConstrainedIOs
+         || type_ == ClusterType::UnconstrainedIOs || type_ == ClusterType::PAD
+         || type_ == ClusterType::IOBundle;
 }
 
 bool Cluster::isClusterOfUnconstrainedIOPins() const
 {
-  return is_cluster_of_unconstrained_io_pins_;
+  return type_ == ClusterType::UnconstrainedIOs;
 }
 
 bool Cluster::isClusterOfUnplacedIOPins() const
 {
-  return is_cluster_of_unplaced_io_pins_;
+  return type_ == ClusterType::ConstrainedIOs
+         || type_ == ClusterType::UnconstrainedIOs;
 }
 
 void Cluster::setAsArrayOfInterconnectedMacros()
 {
-  is_array_of_interconnected_macros_ = true;
+  type_ = ClusterType::InterconnectedMacrosArray;
 }
 
 bool Cluster::isArrayOfInterconnectedMacros() const
 {
-  return is_array_of_interconnected_macros_;
+  return type_ == ClusterType::InterconnectedMacrosArray;
 }
 
 bool Cluster::isEmpty() const
@@ -354,7 +348,7 @@ const Metrics& Cluster::getMetrics() const
 
 int Cluster::getNumStdCell() const
 {
-  if (type_ == HardMacroCluster) {
+  if (type_ == ClusterType::Macro) {
     return 0;
   }
   return metrics_.getNumStdCell();
@@ -362,7 +356,7 @@ int Cluster::getNumStdCell() const
 
 int Cluster::getNumMacro() const
 {
-  if (type_ == StdCellCluster) {
+  if (type_ == ClusterType::StdCell) {
     return 0;
   }
   return metrics_.getNumMacro();
@@ -379,7 +373,7 @@ int64_t Cluster::getArea() const
 
 int64_t Cluster::getStdCellArea() const
 {
-  if (type_ == HardMacroCluster) {
+  if (type_ == ClusterType::Macro) {
     return 0;
   }
 
@@ -388,7 +382,7 @@ int64_t Cluster::getStdCellArea() const
 
 int64_t Cluster::getMacroArea() const
 {
-  if (type_ == StdCellCluster) {
+  if (type_ == ClusterType::StdCell) {
     return 0;
   }
 
@@ -1003,7 +997,7 @@ void SoftMacro::setWidth(int width)
   if (width <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == HardMacroCluster
+      || cluster_->getClusterType() == ClusterType::Macro
       || cluster_->isIOCluster()) {
     return;
   }
@@ -1031,7 +1025,7 @@ void SoftMacro::setHeight(int height)
   if (height <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == HardMacroCluster
+      || cluster_->getClusterType() == ClusterType::Macro
       || cluster_->isIOCluster()) {
     return;
   }
@@ -1058,7 +1052,7 @@ void SoftMacro::setArea(int64_t area)
 {
   if (area_ == 0 || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == HardMacroCluster
+      || cluster_->getClusterType() == ClusterType::Macro
       || cluster_->isIOCluster()
       || area <= (width_intervals_.front().min
                   * static_cast<int64_t>(height_intervals_.front().max))) {
@@ -1095,7 +1089,7 @@ void SoftMacro::setShapes(const TilingList& tilings, bool force)
 {
   if (!force
       && (tilings.empty() || cluster_ == nullptr
-          || cluster_->getClusterType() != HardMacroCluster)) {
+          || cluster_->getClusterType() != ClusterType::Macro)) {
     return;
   }
 
@@ -1119,7 +1113,7 @@ void SoftMacro::setShapes(const IntervalList& width_intervals, int64_t area)
 {
   if (width_intervals.empty() || area <= 0 || cluster_ == nullptr
       || cluster_->isIOCluster()
-      || cluster_->getClusterType() == HardMacroCluster) {
+      || cluster_->getClusterType() == ClusterType::Macro) {
     return;
   }
 
@@ -1168,7 +1162,7 @@ bool SoftMacro::isMacroCluster() const
   if (cluster_ == nullptr) {
     return false;
   }
-  return (cluster_->getClusterType() == HardMacroCluster);
+  return (cluster_->getClusterType() == ClusterType::Macro);
 }
 
 bool SoftMacro::isStdCellCluster() const
@@ -1177,7 +1171,7 @@ bool SoftMacro::isStdCellCluster() const
     return false;
   }
 
-  return (cluster_->getClusterType() == StdCellCluster);
+  return (cluster_->getClusterType() == ClusterType::StdCell);
 }
 
 int SoftMacro::getNumMacro() const
@@ -1225,11 +1219,11 @@ float SoftMacro::getMacroUtil() const
     return 0.0;
   }
 
-  if (cluster_->getClusterType() == HardMacroCluster) {
+  if (cluster_->getClusterType() == ClusterType::Macro) {
     return 1.0;
   }
 
-  if (cluster_->getClusterType() == MixedCluster) {
+  if (cluster_->getClusterType() == ClusterType::Mixed) {
     return cluster_->getMacroArea() / static_cast<float>(area_);
   }
 
@@ -1242,7 +1236,7 @@ bool SoftMacro::isMixedCluster() const
     return false;
   }
 
-  return (cluster_->getClusterType() == MixedCluster);
+  return (cluster_->getClusterType() == ClusterType::Mixed);
 }
 
 // Cluster support to identify if a fixed terminal correponds

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -243,7 +243,7 @@ void Cluster::copyInstances(const Cluster& cluster)
   leaf_macros_.clear();
   hard_macros_.clear();
 
-  if (type_ == Cluster::Type::Macro) {
+  if (isAnyMacroCluster()) {
     leaf_macros_.insert(leaf_macros_.end(),
                         cluster.leaf_macros_.begin(),
                         cluster.leaf_macros_.end());
@@ -348,7 +348,7 @@ const Metrics& Cluster::getMetrics() const
 
 int Cluster::getNumStdCell() const
 {
-  if (type_ == Cluster::Type::Macro) {
+  if (isAnyMacroCluster()) {
     return 0;
   }
   return metrics_.getNumStdCell();
@@ -373,7 +373,7 @@ int64_t Cluster::getArea() const
 
 int64_t Cluster::getStdCellArea() const
 {
-  if (type_ == Cluster::Type::Macro) {
+  if (isAnyMacroCluster()) {
     return 0;
   }
 
@@ -997,8 +997,7 @@ void SoftMacro::setWidth(int width)
   if (width <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getType() == Cluster::Type::Macro
-      || cluster_->isIOCluster()) {
+      || cluster_->isAnyMacroCluster() || cluster_->isIOCluster()) {
     return;
   }
 
@@ -1025,8 +1024,7 @@ void SoftMacro::setHeight(int height)
   if (height <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getType() == Cluster::Type::Macro
-      || cluster_->isIOCluster()) {
+      || cluster_->isAnyMacroCluster() || cluster_->isIOCluster()) {
     return;
   }
 
@@ -1052,7 +1050,7 @@ void SoftMacro::setArea(int64_t area)
 {
   if (area_ == 0 || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getType() == Cluster::Type::Macro || cluster_->isIOCluster()
+      || cluster_->isAnyMacroCluster() || cluster_->isIOCluster()
       || area <= (width_intervals_.front().min
                   * static_cast<int64_t>(height_intervals_.front().max))) {
     return;
@@ -1088,7 +1086,7 @@ void SoftMacro::setShapes(const TilingList& tilings, bool force)
 {
   if (!force
       && (tilings.empty() || cluster_ == nullptr
-          || cluster_->getType() != Cluster::Type::Macro)) {
+          || !cluster_->isAnyMacroCluster())) {
     return;
   }
 
@@ -1111,8 +1109,7 @@ void SoftMacro::setShapes(const TilingList& tilings, bool force)
 void SoftMacro::setShapes(const IntervalList& width_intervals, int64_t area)
 {
   if (width_intervals.empty() || area <= 0 || cluster_ == nullptr
-      || cluster_->isIOCluster()
-      || cluster_->getType() == Cluster::Type::Macro) {
+      || cluster_->isIOCluster() || cluster_->isAnyMacroCluster()) {
     return;
   }
 
@@ -1161,7 +1158,7 @@ bool SoftMacro::isMacroCluster() const
   if (cluster_ == nullptr) {
     return false;
   }
-  return (cluster_->getType() == Cluster::Type::Macro);
+  return cluster_->isAnyMacroCluster();
 }
 
 bool SoftMacro::isStdCellCluster() const
@@ -1218,7 +1215,7 @@ float SoftMacro::getMacroUtil() const
     return 0.0;
   }
 
-  if (cluster_->getType() == Cluster::Type::Macro) {
+  if (cluster_->isAnyMacroCluster()) {
     return 1.0;
   }
 

--- a/src/mpl/src/object.cpp
+++ b/src/mpl/src/object.cpp
@@ -116,12 +116,12 @@ void Cluster::setName(const std::string& name)
   name_ = name;
 }
 
-void Cluster::setClusterType(const ClusterType& cluster_type)
+void Cluster::setType(const Cluster::Type& cluster_type)
 {
   type_ = cluster_type;
 }
 
-ClusterType Cluster::getClusterType() const
+Cluster::Type Cluster::getType() const
 {
   return type_;
 }
@@ -195,30 +195,30 @@ void Cluster::clearHardMacros()
   hard_macros_.clear();
 }
 
-std::string Cluster::getClusterTypeString() const
+std::string Cluster::getTypeString() const
 {
   if (is_fixed_macro_) {
     return "Fixed Macro";
   }
 
   switch (type_) {
-    case ClusterType::IOBundle:
+    case Cluster::Type::IOBundle:
       return "IO Bundle";
-    case ClusterType::UnconstrainedIOs:
+    case Cluster::Type::UnconstrainedIOs:
       return "Unconstrained IOs";
-    case ClusterType::ConstrainedIOs:
+    case Cluster::Type::ConstrainedIOs:
       return "Constrained IOs";
-    case ClusterType::PAD:
+    case Cluster::Type::PAD:
       return "IO Pad";
-    case ClusterType::StdCell:
+    case Cluster::Type::StdCell:
       return "StdCell";
-    case ClusterType::Mixed:
+    case Cluster::Type::Mixed:
       return "Mixed";
-    case ClusterType::Macro:
+    case Cluster::Type::Macro:
       return "Macro";
-    case ClusterType::MacroArray:
+    case Cluster::Type::MacroArray:
       return "Macro Array";
-    case ClusterType::InterconnectedMacrosArray:
+    case Cluster::Type::InterconnectedMacrosArray:
       return "Interconnected Macros Array";
   }
 
@@ -243,11 +243,11 @@ void Cluster::copyInstances(const Cluster& cluster)
   leaf_macros_.clear();
   hard_macros_.clear();
 
-  if (type_ == ClusterType::Macro) {
+  if (type_ == Cluster::Type::Macro) {
     leaf_macros_.insert(leaf_macros_.end(),
                         cluster.leaf_macros_.begin(),
                         cluster.leaf_macros_.end());
-  } else if (type_ == ClusterType::StdCell) {
+  } else if (type_ == Cluster::Type::StdCell) {
     leaf_std_cells_.insert(leaf_std_cells_.end(),
                            cluster.leaf_std_cells_.begin(),
                            cluster.leaf_std_cells_.end());
@@ -273,20 +273,20 @@ void Cluster::setAsClusterOfUnplacedIOPins(
     const int height,
     const bool is_cluster_of_unconstrained_io_pins)
 {
-  is_cluster_of_unconstrained_io_pins ? type_ = ClusterType::UnconstrainedIOs
-                                      : type_ = ClusterType::ConstrainedIOs;
+  is_cluster_of_unconstrained_io_pins ? type_ = Cluster::Type::UnconstrainedIOs
+                                      : type_ = Cluster::Type::ConstrainedIOs;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
 void Cluster::setAsIOPadCluster(const odb::Point& pos, int width, int height)
 {
-  type_ = ClusterType::PAD;
+  type_ = Cluster::Type::PAD;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
 void Cluster::setAsIOBundle(const odb::Point& pos, int width, int height)
 {
-  type_ = ClusterType::IOBundle;
+  type_ = Cluster::Type::IOBundle;
   soft_macro_ = std::make_unique<SoftMacro>(pos, name_, width, height, this);
 }
 
@@ -298,30 +298,30 @@ void Cluster::setAsFixedMacro(const HardMacro* hard_macro)
 
 bool Cluster::isIOCluster() const
 {
-  return type_ == ClusterType::ConstrainedIOs
-         || type_ == ClusterType::UnconstrainedIOs || type_ == ClusterType::PAD
-         || type_ == ClusterType::IOBundle;
+  return type_ == Cluster::Type::ConstrainedIOs
+         || type_ == Cluster::Type::UnconstrainedIOs || type_ == Cluster::Type::PAD
+         || type_ == Cluster::Type::IOBundle;
 }
 
 bool Cluster::isClusterOfUnconstrainedIOPins() const
 {
-  return type_ == ClusterType::UnconstrainedIOs;
+  return type_ == Cluster::Type::UnconstrainedIOs;
 }
 
 bool Cluster::isClusterOfUnplacedIOPins() const
 {
-  return type_ == ClusterType::ConstrainedIOs
-         || type_ == ClusterType::UnconstrainedIOs;
+  return type_ == Cluster::Type::ConstrainedIOs
+         || type_ == Cluster::Type::UnconstrainedIOs;
 }
 
 void Cluster::setAsArrayOfInterconnectedMacros()
 {
-  type_ = ClusterType::InterconnectedMacrosArray;
+  type_ = Cluster::Type::InterconnectedMacrosArray;
 }
 
 bool Cluster::isArrayOfInterconnectedMacros() const
 {
-  return type_ == ClusterType::InterconnectedMacrosArray;
+  return type_ == Cluster::Type::InterconnectedMacrosArray;
 }
 
 bool Cluster::isEmpty() const
@@ -348,7 +348,7 @@ const Metrics& Cluster::getMetrics() const
 
 int Cluster::getNumStdCell() const
 {
-  if (type_ == ClusterType::Macro) {
+  if (type_ == Cluster::Type::Macro) {
     return 0;
   }
   return metrics_.getNumStdCell();
@@ -356,7 +356,7 @@ int Cluster::getNumStdCell() const
 
 int Cluster::getNumMacro() const
 {
-  if (type_ == ClusterType::StdCell) {
+  if (type_ == Cluster::Type::StdCell) {
     return 0;
   }
   return metrics_.getNumMacro();
@@ -373,7 +373,7 @@ int64_t Cluster::getArea() const
 
 int64_t Cluster::getStdCellArea() const
 {
-  if (type_ == ClusterType::Macro) {
+  if (type_ == Cluster::Type::Macro) {
     return 0;
   }
 
@@ -382,7 +382,7 @@ int64_t Cluster::getStdCellArea() const
 
 int64_t Cluster::getMacroArea() const
 {
-  if (type_ == ClusterType::StdCell) {
+  if (type_ == Cluster::Type::StdCell) {
     return 0;
   }
 
@@ -997,7 +997,7 @@ void SoftMacro::setWidth(int width)
   if (width <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == ClusterType::Macro
+      || cluster_->getType() == Cluster::Type::Macro
       || cluster_->isIOCluster()) {
     return;
   }
@@ -1025,7 +1025,7 @@ void SoftMacro::setHeight(int height)
   if (height <= 0 || area_ == 0
       || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == ClusterType::Macro
+      || cluster_->getType() == Cluster::Type::Macro
       || cluster_->isIOCluster()) {
     return;
   }
@@ -1052,7 +1052,7 @@ void SoftMacro::setArea(int64_t area)
 {
   if (area_ == 0 || width_intervals_.size() != height_intervals_.size()
       || width_intervals_.empty() || cluster_ == nullptr
-      || cluster_->getClusterType() == ClusterType::Macro
+      || cluster_->getType() == Cluster::Type::Macro
       || cluster_->isIOCluster()
       || area <= (width_intervals_.front().min
                   * static_cast<int64_t>(height_intervals_.front().max))) {
@@ -1089,7 +1089,7 @@ void SoftMacro::setShapes(const TilingList& tilings, bool force)
 {
   if (!force
       && (tilings.empty() || cluster_ == nullptr
-          || cluster_->getClusterType() != ClusterType::Macro)) {
+          || cluster_->getType() != Cluster::Type::Macro)) {
     return;
   }
 
@@ -1113,7 +1113,7 @@ void SoftMacro::setShapes(const IntervalList& width_intervals, int64_t area)
 {
   if (width_intervals.empty() || area <= 0 || cluster_ == nullptr
       || cluster_->isIOCluster()
-      || cluster_->getClusterType() == ClusterType::Macro) {
+      || cluster_->getType() == Cluster::Type::Macro) {
     return;
   }
 
@@ -1162,7 +1162,7 @@ bool SoftMacro::isMacroCluster() const
   if (cluster_ == nullptr) {
     return false;
   }
-  return (cluster_->getClusterType() == ClusterType::Macro);
+  return (cluster_->getType() == Cluster::Type::Macro);
 }
 
 bool SoftMacro::isStdCellCluster() const
@@ -1171,7 +1171,7 @@ bool SoftMacro::isStdCellCluster() const
     return false;
   }
 
-  return (cluster_->getClusterType() == ClusterType::StdCell);
+  return (cluster_->getType() == Cluster::Type::StdCell);
 }
 
 int SoftMacro::getNumMacro() const
@@ -1219,11 +1219,11 @@ float SoftMacro::getMacroUtil() const
     return 0.0;
   }
 
-  if (cluster_->getClusterType() == ClusterType::Macro) {
+  if (cluster_->getType() == Cluster::Type::Macro) {
     return 1.0;
   }
 
-  if (cluster_->getClusterType() == ClusterType::Mixed) {
+  if (cluster_->getType() == Cluster::Type::Mixed) {
     return cluster_->getMacroArea() / static_cast<float>(area_);
   }
 
@@ -1236,7 +1236,7 @@ bool SoftMacro::isMixedCluster() const
     return false;
   }
 
-  return (cluster_->getClusterType() == ClusterType::Mixed);
+  return (cluster_->getType() == Cluster::Type::Mixed);
 }
 
 // Cluster support to identify if a fixed terminal correponds
@@ -1283,7 +1283,7 @@ void SoftMacro::reportShapeCurve(utl::Logger* logger) const
   logger->report("Name: {}", name_);
   logger->report("Has Cluster: {}", cluster_ != nullptr);
   if (cluster_) {
-    logger->report("Type: {}", cluster_->getClusterTypeString());
+    logger->report("Type: {}", cluster_->getTypeString());
   }
 
   std::string widths_text, heights_text;

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -73,8 +73,6 @@ using BundledNetList = std::vector<BundledNet>;
 // we do not accept pre-placed std cells as our inputs.
 //*****************************************************************************
 
-
-
 // Metrics class for logical modules and clusters
 class Metrics
 {

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -162,7 +162,16 @@ class Cluster
   void setAsArrayOfInterconnectedMacros();
   bool isArrayOfInterconnectedMacros() const;
   void setAsMacroArray() { type_ = Type::MacroArray; }
-  bool isMacroArray() const { return type_ == Type::MacroArray; }
+  bool isMacroArray() const
+  {
+    return type_ == Type::MacroArray
+           || type_ == Type::InterconnectedMacrosArray;
+  }
+  bool isAnyMacroCluster() const
+  {
+    return type_ == Type::Macro || type_ == Type::MacroArray
+           || type_ == Type::InterconnectedMacrosArray;
+  }
   bool isEmpty() const;
   bool correspondsToLogicalModule() const;
 

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -73,11 +73,17 @@ using BundledNetList = std::vector<BundledNet>;
 // we do not accept pre-placed std cells as our inputs.
 //*****************************************************************************
 
-enum ClusterType
+enum class ClusterType
 {
-  StdCellCluster,
-  HardMacroCluster,
-  MixedCluster
+  StdCell,
+  Macro,
+  Mixed,
+  ConstrainedIOs,
+  UnconstrainedIOs,
+  IOBundle,
+  PAD,
+  MacroArray,
+  InterconnectedMacrosArray
 };
 
 // Metrics class for logical modules and clusters
@@ -145,9 +151,9 @@ class Cluster
                                     int width,
                                     int height,
                                     bool is_cluster_of_unconstrained_io_pins);
-  bool isIOPadCluster() const { return is_io_pad_cluster_; }
+  bool isIOPadCluster() const { return type_ == ClusterType::PAD; }
   void setAsIOPadCluster(const odb::Point& pos, int width, int height);
-  bool isIOBundle() const { return is_io_bundle_; }
+  bool isIOBundle() const { return type_ == ClusterType::IOBundle; }
   void setAsIOBundle(const odb::Point& pos, int width, int height);
 
   bool isFixedMacro() const { return is_fixed_macro_; }
@@ -155,8 +161,8 @@ class Cluster
 
   void setAsArrayOfInterconnectedMacros();
   bool isArrayOfInterconnectedMacros() const;
-  void setAsMacroArray() { is_macro_array_ = true; }
-  bool isMacroArray() const { return is_macro_array_; }
+  void setAsMacroArray() { type_ = ClusterType::MacroArray; }
+  bool isMacroArray() const { return type_ == ClusterType::MacroArray; }
   bool isEmpty() const;
   bool correspondsToLogicalModule() const;
 
@@ -213,7 +219,7 @@ class Cluster
   int id_{-1};
   std::string name_;
 
-  ClusterType type_{MixedCluster};
+  ClusterType type_{ClusterType::Mixed};
   Metrics metrics_;
 
   std::vector<odb::dbModule*> db_modules_;
@@ -221,12 +227,6 @@ class Cluster
   std::vector<odb::dbInst*> leaf_macros_;
   std::vector<HardMacro*> hard_macros_;
 
-  bool is_cluster_of_unplaced_io_pins_{false};
-  bool is_cluster_of_unconstrained_io_pins_{false};
-  bool is_io_pad_cluster_{false};
-  bool is_io_bundle_{false};
-  bool is_array_of_interconnected_macros_{false};
-  bool is_macro_array_{false};
   bool is_fixed_macro_{false};
 
   std::unique_ptr<SoftMacro> soft_macro_;

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -73,18 +73,7 @@ using BundledNetList = std::vector<BundledNet>;
 // we do not accept pre-placed std cells as our inputs.
 //*****************************************************************************
 
-enum class ClusterType
-{
-  StdCell,
-  Macro,
-  Mixed,
-  ConstrainedIOs,
-  UnconstrainedIOs,
-  IOBundle,
-  PAD,
-  MacroArray,
-  InterconnectedMacrosArray
-};
+
 
 // Metrics class for logical modules and clusters
 class Metrics
@@ -116,15 +105,28 @@ class Metrics
 class Cluster
 {
  public:
+  enum class Type
+  {
+    StdCell,
+    Macro,
+    Mixed,
+    ConstrainedIOs,
+    UnconstrainedIOs,
+    IOBundle,
+    PAD,
+    MacroArray,
+    InterconnectedMacrosArray
+  };
+
   Cluster(int cluster_id, utl::Logger* logger);
   Cluster(int cluster_id, const std::string& cluster_name, utl::Logger* logger);
 
   int getId() const;
   const std::string& getName() const;
   void setName(const std::string& name);
-  void setClusterType(const ClusterType& cluster_type);
-  ClusterType getClusterType() const;
-  std::string getClusterTypeString() const;
+  void setType(const Type& type);
+  Type getType() const;
+  std::string getTypeString() const;
 
   void addDbModule(odb::dbModule* db_module);
   void addLeafStdCell(odb::dbInst* leaf_std_cell);
@@ -151,9 +153,9 @@ class Cluster
                                     int width,
                                     int height,
                                     bool is_cluster_of_unconstrained_io_pins);
-  bool isIOPadCluster() const { return type_ == ClusterType::PAD; }
+  bool isIOPadCluster() const { return type_ == Type::PAD; }
   void setAsIOPadCluster(const odb::Point& pos, int width, int height);
-  bool isIOBundle() const { return type_ == ClusterType::IOBundle; }
+  bool isIOBundle() const { return type_ == Type::IOBundle; }
   void setAsIOBundle(const odb::Point& pos, int width, int height);
 
   bool isFixedMacro() const { return is_fixed_macro_; }
@@ -161,8 +163,8 @@ class Cluster
 
   void setAsArrayOfInterconnectedMacros();
   bool isArrayOfInterconnectedMacros() const;
-  void setAsMacroArray() { type_ = ClusterType::MacroArray; }
-  bool isMacroArray() const { return type_ == ClusterType::MacroArray; }
+  void setAsMacroArray() { type_ = Type::MacroArray; }
+  bool isMacroArray() const { return type_ == Type::MacroArray; }
   bool isEmpty() const;
   bool correspondsToLogicalModule() const;
 
@@ -219,7 +221,7 @@ class Cluster
   int id_{-1};
   std::string name_;
 
-  ClusterType type_{ClusterType::Mixed};
+  Type type_{Type::Mixed};
   Metrics metrics_;
 
   std::vector<odb::dbModule*> db_modules_;

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+wq# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2025, The OpenROAD Authors
 
 """Instantiate a regression test based on .py or .tcl
@@ -45,19 +45,13 @@ exec "{bazel_test_sh}" "$@"
     return DefaultInfo(
         executable = test_script,
         runfiles = ctx.runfiles(
-            transitive_files = depset(
-                ctx.files.data + [
-                    ctx.file.test_file,
-                    ctx.file.bazel_test_sh,
-                    ctx.file.regression_test,
-                    ctx.executable.openroad,
-                ],
-                transitive = [
-                    ctx.attr.openroad[DefaultInfo].default_runfiles.files,
-                    ctx.attr.openroad[DefaultInfo].default_runfiles.symlinks,
-                ],
-            ),
-        ),
+            files = ctx.files.data + [
+                ctx.file.test_file,
+                ctx.file.bazel_test_sh,
+                ctx.file.regression_test,
+                ctx.executable.openroad,
+            ],
+        ).merge(ctx.attr.openroad[DefaultInfo].default_runfiles),
     )
 
 regression_rule_test = rule(


### PR DESCRIPTION
## What does this PR do?
Fixes #9463
Consolidate the many implicit cluster types under the ClusterType enum instead of relying on isSomething methods, as suggested in #9463.
The new enum class ClusterType has 9 values: StdCell, Macro, Mixed, ConstrainedIOs, UnconstrainedIOs, IOBundle, PAD, MacroArray, InterconnectedMacrosArray.

## Impact
This change improves type safety (scoped enum class vs plain enum), reduces the number of member variables in Cluster, and makes cluster categorization explicit and centralized.




