### PR TITLE
Fix uses of `/bin/bash` to use `/usr/bin/env bash` instead.

### DIFF
--- a/bazel/install.sh
+++ b/bazel/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Install binary and runfiles from bazel build

--- a/docs/src/scripts/link_readmes.sh
+++ b/docs/src/scripts/link_readmes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## SPDX-License-Identifier: BSD-3-Clause
 ## Copyright (c) 2024-2026, The OpenROAD Authors

--- a/etc/docker-entrypoint.sh
+++ b/etc/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ ! -z ${CUSTOM_USER+x} ]; then
         if [ -z ${CUSTOM_USER_ID+x} ] || [ -z ${CUSTOM_GROUP_ID+x} ]; then
                 echo "You need to set CUSTOM_USER_ID and CUSTOM_GROUP_ID"

--- a/etc/whittle.sh
+++ b/etc/whittle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper for whittle.py that sets OPENROAD_EXE from Bazel runfiles.
 # Usage: bazelisk run //:whittle -- <whittle.py args>
 set -euo pipefail

--- a/src/rcx/calibration/fasterCap/scripts/create_rcx_model_gen_tcl_script.bash
+++ b/src/rcx/calibration/fasterCap/scripts/create_rcx_model_gen_tcl_script.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 5 ] 
 then

--- a/src/rcx/calibration/fasterCap/scripts/gen_patterns.bash
+++ b/src/rcx/calibration/fasterCap/scripts/gen_patterns.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 6 ] 
 then

--- a/src/rcx/calibration/fasterCap/scripts/limit_kill.bash
+++ b/src/rcx/calibration/fasterCap/scripts/limit_kill.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/calibration/fasterCap/scripts/makeGold.bash
+++ b/src/rcx/calibration/fasterCap/scripts/makeGold.bash
@@ -1,4 +1,7 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
+
 if [ $# -lt 1 ] 
 then
 	echo "Usage <dir>"

--- a/src/rcx/calibration/fasterCap/scripts/parse_fasterCap.bash
+++ b/src/rcx/calibration/fasterCap/scripts/parse_fasterCap.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 5 ] 
 then

--- a/src/rcx/calibration/fasterCap/scripts/run_fasterCap.bash
+++ b/src/rcx/calibration/fasterCap/scripts/run_fasterCap.bash
@@ -1,9 +1,11 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
 # python_script=~/z/72424/scripts/UniversalFormat2FasterCap.py
 # works python_script=~/z/72424/scripts/UniversalFormat2FasterCap_923.py
 # works fasterCap=/home/dimitris-ic/fasterCap/920/FasterCAP_v2/FasterCap_v2/build_fasterCap_920/FasterCap
 
 #README - DKF - 092524 : change ext_y and ext_z from 0 to ext_x
+
+set -o noglob
 
 if [ $# -lt 7 ] 
 then

--- a/src/rcx/calibration/fasterCap/scripts/run_patterns.bash
+++ b/src/rcx/calibration/fasterCap/scripts/run_patterns.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 4 ] 
 then

--- a/src/rcx/rule_scripts/run_fasterCap.bash
+++ b/src/rcx/rule_scripts/run_fasterCap.bash
@@ -1,9 +1,11 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
 # python_script=~/z/72424/scripts/UniversalFormat2FasterCap.py
 # works python_script=~/z/72424/scripts/UniversalFormat2FasterCap_923.py
 # works fasterCap=/home/dimitris-ic/fasterCap/920/FasterCAP_v2/FasterCap_v2/build_fasterCap_920/FasterCap
 
 #README - DKF - 092524 : change ext_y and ext_z from 0 to ext_x
+
+set -o noglob
 
 if [ $# -lt 7 ] 
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/create_rcx_model_gen_tcl_script.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/create_rcx_model_gen_tcl_script.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 5 ] 
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/gen_patterns.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/gen_patterns.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 7 ] 
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/limit_kill.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/limit_kill.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/makeGold.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/makeGold.bash
@@ -1,4 +1,7 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
+
 if [ $# -lt 1 ] 
 then
 	echo "Usage <dir>"

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/parse_fasterCap.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/parse_fasterCap.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 6 ] 
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/run_fasterCap.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/run_fasterCap.bash
@@ -1,9 +1,11 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
 # python_script=~/z/72424/scripts/UniversalFormat2FasterCap.py
 # works python_script=~/z/72424/scripts/UniversalFormat2FasterCap_923.py
 # works fasterCap=/home/dimitris-ic/fasterCap/920/FasterCAP_v2/FasterCap_v2/build_fasterCap_920/FasterCap
 
 #README - DKF - 092524 : change ext_y and ext_z from 0 to ext_x
+
+set -o noglob
 
 if [ $# -lt 7 ] 
 then

--- a/src/rcx/test/rcx_v2/FasterCapModel/scripts/run_patterns.bash
+++ b/src/rcx/test/rcx_v2/FasterCapModel/scripts/run_patterns.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 4 ] 
 then

--- a/src/rcx/test/rcx_v2/flow/corners/scripts/run_rcx.bash
+++ b/src/rcx/test/rcx_v2/flow/corners/scripts/run_rcx.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/test/rcx_v2/flow/gcd/scripts/run_rcx_dir.bash
+++ b/src/rcx/test/rcx_v2/flow/gcd/scripts/run_rcx_dir.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/test/rcx_v2/flow/scripts/run_rcx.bash
+++ b/src/rcx/test/rcx_v2/flow/scripts/run_rcx.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/test/rcx_v2/model/scripts/run_rcx.bash
+++ b/src/rcx/test/rcx_v2/model/scripts/run_rcx.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 3 ]
 then

--- a/src/rcx/test/rcx_v2/model/scripts/run_rcx_gen_model.bash
+++ b/src/rcx/test/rcx_v2/model/scripts/run_rcx_gen_model.bash
@@ -1,4 +1,6 @@
-#!/bin/bash -f
+#!/usr/bin/env bash
+
+set -o noglob
 
 if [ $# -lt 3 ]
 then

--- a/test/orfs/README.md
+++ b/test/orfs/README.md
@@ -217,7 +217,7 @@ Let's say that `bazelisk test test/orfs/gcd:eqy_synth_test` fails, first create 
 After compiling sv-bugpoint, we create a check.sh script:
 
 ```bash
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 cp $1 test/orfs/gcd/
 (bazelisk test test/orfs/gcd:eqy_synth_test --test_timeout=30 --test_output=streamed || error=$?) | tee /dev/tty | grep "Failed to prove equivalence of partition gcd.req_rdy"

--- a/test/orfs/gcd/test_whittle.sh
+++ b/test/orfs/gcd/test_whittle.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Whittle integration smoke-test for bazel.
 # Adapted from flow/test/test_whittle.sh.

--- a/test/regression.bzl
+++ b/test/regression.bzl
@@ -18,7 +18,7 @@ def _regression_test_impl(ctx):
     ctx.actions.write(
         output = test_script,
         content = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 export TEST_NAME_BAZEL={TEST_NAME_BAZEL}
 export TEST_FILE={TEST_FILE}


### PR DESCRIPTION
The only Posix compatible way to call bash is via `/usr/bin/env` as bash might be installed in different locations on the system. `/bin/bash` is not a Posix-required location for that binary (only `/bin/sh` is).

Use `set -o noglob` instead of `bash -f` for improved readability.

## Summary
[Describe your changes here]

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Impact
Makes OpenROAD compatible with more systems.

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [ ] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**