### PR TITLE
Fix use of abs() meant to be used in floating point context

### DIFF
--- a/src/gui/src/staDescriptors.cpp
+++ b/src/gui/src/staDescriptors.cpp
@@ -665,7 +665,8 @@ Descriptor::Properties StaInstanceDescriptor::getProperties(
   auto is_inf = [](double value) -> bool {
     // mirrored from:
     // https://github.com/The-OpenROAD-Project/OpenSTA/blob/20925bb00965c1199c45aca0318c2baeb4042c5a/liberty/Units.cc#L153
-    return abs(value) >= 0.1 * sta::INF;
+    // ^ and apparently, that is broken, as abs() only does int. Use std::abs()
+    return std::abs(value) >= 0.1 * sta::INF;
   };
 
   bool has_sdc_constraint = false;


### PR DESCRIPTION
And it looks like it is a copy of a bug in OpenSTA, but not addressing that here.

## Summary
[Describe your changes here]

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Impact
[How does this change the tool's behavior?]

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [ ] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]