### PR TITLE
IWYU: Fix a few missing includes

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <memory>
 #include <typeindex>
+#include <typeinfo>
 #include <utility>
 #include <variant>
 

--- a/src/gui/src/heatMapCore.cpp
+++ b/src/gui/src/heatMapCore.cpp
@@ -8,6 +8,8 @@
 #include <fstream>
 #include <functional>
 #include <iomanip>
+#include <ios>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -22,6 +24,7 @@
 #include "absl/synchronization/mutex.h"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
+#include "gui/gui.h"
 #include "gui/heatMap.h"
 #include "heatMapPinDensity.h"
 #include "heatMapPlacementDensity.h"

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -5,13 +5,6 @@
 
 #include <netinet/in.h>
 
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/ip/tcp.hpp>
-#include <boost/asio/signal_set.hpp>
-#include <boost/asio/strand.hpp>
-#include <boost/beast/core.hpp>
-#include <boost/beast/http.hpp>
-#include <boost/beast/websocket.hpp>
 #include <csignal>
 #include <cstdint>
 #include <cstring>
@@ -30,6 +23,13 @@
 #include <utility>
 #include <vector>
 
+#include "boost/asio/io_context.hpp"
+#include "boost/asio/ip/tcp.hpp"
+#include "boost/asio/signal_set.hpp"
+#include "boost/asio/strand.hpp"
+#include "boost/beast/core.hpp"
+#include "boost/beast/http.hpp"
+#include "boost/beast/websocket.hpp"
 #include "clock_tree_report.h"
 #include "gui/heatMap.h"
 #include "odb/db.h"

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <any>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 
 #include "gtest/gtest.h"
+#include "gui/gui.h"
 #include "gui/heatMap.h"
 #include "json_builder.h"
 #include "odb/db.h"


### PR DESCRIPTION
Breakdown:

```
src/gui/src/gui.cpp:                     #include <typeinfo> for std::type_info
src/gui/src/heatMapCore.cpp:             #include "gui/gui.h" for gui::Painter
src/gui/src/heatMapCore.cpp:             #include <ios> for std::defaultfloat
src/gui/src/heatMapCore.cpp:             #include <iterator> for std::distance
src/web/test/cpp/TestRequestHandler.cpp: #include "gui/gui.h" for gui::Painter
src/web/test/cpp/TestRequestHandler.cpp: #include <any> for std::any
src/web/test/cpp/TestRequestHandler.cpp: #include <functional> for std::function
```

Also, use vendeored boost headers not system headers.
