### PR TITLE
Add a `-port` flag to webserver

### DIFF
--- a/src/web/include/web/web.h
+++ b/src/web/include/web/web.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -31,7 +32,7 @@ class WebServer
             Tcl_Interp* interp);
   ~WebServer();
 
-  void serve(const std::string& doc_root = "");
+  void serve(uint16_t port = 8080, const std::string& doc_root = "");
 
  private:
   odb::dbDatabase* db_ = nullptr;

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -527,7 +527,7 @@ createMenuBar(app);
 
 // ─── WebSocket Init ─────────────────────────────────────────────────────────
 
-const websocketUrl = `ws://${window.location.hostname || 'localhost'}:8080/ws`;
+const websocketUrl = `ws://${window.location.hostname || 'localhost'}:${window.location.port}/ws`;
 app.websocketManager = new WebSocketManager(websocketUrl, updateStatus);
 
 // Handle server-push notifications (e.g. search indices ready)

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -957,7 +957,7 @@ WebServer::WebServer(odb::dbDatabase* db,
 
 WebServer::~WebServer() = default;
 
-void WebServer::serve(const std::string& doc_root)
+void WebServer::serve(uint16_t port, const std::string& doc_root)
 {
   try {
     generator_ = std::make_shared<TileGenerator>(db_, sta_, logger_);
@@ -968,7 +968,6 @@ void WebServer::serve(const std::string& doc_root)
     auto tcl_eval = std::make_shared<TclEvaluator>(interp_, logger_);
 
     auto const address = net::ip::make_address("127.0.0.1");
-    uint16_t const port = 8080;
     int const num_threads = 32;
 
     if (!doc_root.empty()) {

--- a/src/web/src/web.i
+++ b/src/web/src/web.i
@@ -2,6 +2,7 @@
 // Copyright (c) 2026, The OpenROAD Authors
 
 %{
+#include <cstdint>
 #include "ord/OpenRoad.hh"
 #include "web/web.h"
 %}
@@ -13,10 +14,10 @@
 namespace web {
 
 void
-web_server_cmd(const char* doc_root)
+web_server_cmd(int port, const char* doc_root)
 {
   web::WebServer *server = ord::OpenRoad::openRoad()->getWebServer();
-  server->serve(doc_root);
+  server->serve((uint16_t) port, doc_root);
 }
 
 } // namespace web

--- a/src/web/src/web.tcl
+++ b/src/web/src/web.tcl
@@ -1,18 +1,26 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019-2026, The OpenROAD Authors
 
-sta::define_cmd_args "web_server" { [-dir dir] }
+sta::define_cmd_args "web_server" { [-dir dir] [-port port] }
 
 proc web_server { args } {
   sta::parse_key_args "web_server" args \
-    keys {-dir} flags {}
+    keys {-dir -port} flags {}
 
   sta::check_argc_eq0 "web_server" $args
 
+  set port 8080
   set doc_root ""
   if { [info exists keys(-dir)] } {
     set doc_root $keys(-dir)
   }
+  if { [info exists keys(-port)] } {
+    set p $keys(-port)
+    if { ![string is integer -strict $p] || $p < 1 || $p > 65535 } {
+      error "Invalid port number: $p. Must be an integer between 1 and 65535."
+    }
+    set port $p
+  }
 
-  web::web_server_cmd $doc_root
+  web::web_server_cmd $port $doc_root
 }


### PR DESCRIPTION
## Summary

Allow `web_server` to be invoked with `-port` to choose a different port than 8080.
