### PR TITLE
[multi] convert raw DBU to microns in error/warning messages

### DIFF
--- a/src/drt/src/io/GuideProcessor.cpp
+++ b/src/drt/src/io/GuideProcessor.cpp
@@ -1611,12 +1611,13 @@ void GuidePathFinder::clipGuides(std::vector<frRect>& rects)
     }
     const auto idx = *(indices.begin());
     if (isPinIdx(idx)) {
+      const double dbu_per_uu = design_->getTopBlock()->getDBUPerUU();
       logger_->error(DRT,
                      223,
-                     "Pin dangling id {} ({},{}) {}.",
+                     "Pin dangling id {} ({:.3f}um,{:.3f}um) {}.",
                      idx,
-                     pt.x(),
-                     pt.y(),
+                     pt.x() / (double) dbu_per_uu,
+                     pt.y() / (double) dbu_per_uu,
                      pt.z());
     }
     // no upper/lower guide

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -3345,9 +3345,10 @@ void GlobalRouter::checkPinPlacement()
           logger_->warn(
               GRT,
               31,
-              "At least 2 pins in position ({}, {}), layer {}, port {}.",
-              pos.x(),
-              pos.y(),
+              "At least 2 pins in position ({:.2f}um, {:.2f}um), layer {}, "
+              "port {}.",
+              dbuToMicrons(pos.x()),
+              dbuToMicrons(pos.y()),
               tech_layer->getName(),
               port->getName().c_str());
           invalid = true;

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -121,12 +121,13 @@ void ClusteringEngine::init()
       = tree_->macro_with_halo_area + design_metrics_->getStdCellArea();
 
   if (inst_area_with_halos > tree_->floorplan_shape.area()) {
-    logger_->error(MPL,
-                   16,
-                   "The instance area considering the macros' halos {} exceeds "
-                   "the floorplan area {}",
-                   inst_area_with_halos,
-                   tree_->floorplan_shape.area());
+    logger_->error(
+        MPL,
+        16,
+        "The instance area considering the macros' halos {:.2f}um^2 exceeds "
+        "the floorplan area {:.2f}um^2",
+        block_->dbuAreaToMicrons(static_cast<int64_t>(inst_area_with_halos)),
+        block_->dbuAreaToMicrons(tree_->floorplan_shape.area()));
   }
 
   tree_->io_pads = getIOPads();

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -679,14 +679,15 @@ void HierRTLMP::calculateMacroTilings(Cluster* cluster)
   }
 
   if (tilings.empty()) {
-    logger_->error(MPL,
-                   4,
-                   "Unable to fit cluster {} within outline. Macro height: {}, "
-                   "width: {}, number of macros: {}.",
-                   cluster->getName(),
-                   macro_width,
-                   macro_height,
-                   number_of_macros);
+    logger_->error(
+        MPL,
+        4,
+        "Unable to fit cluster {} within outline. Macro height: {:.2f}um, "
+        "width: {:.2f}um, number of macros: {}.",
+        cluster->getName(),
+        block_->dbuToMicrons(macro_width),
+        block_->dbuToMicrons(macro_height),
+        number_of_macros);
   }
 
   cluster->setTilings(tilings);

--- a/src/ppl/src/HungarianMatching.cpp
+++ b/src/ppl/src/HungarianMatching.cpp
@@ -164,14 +164,15 @@ void HungarianMatching::assignMirroredPins(IOPin& io_pin,
   if (slot_index < 0 || slots_[slot_index].used) {
     odb::dbTechLayer* layer
         = db_->getTech()->findRoutingLayer(mirrored_pin.getLayer());
-    logger_->error(utl::PPL,
-                   82,
-                   "Mirrored position ({}, {}) at layer {} is not a "
-                   "valid position for pin {} placement.",
-                   mirrored_pos.getX(),
-                   mirrored_pos.getY(),
-                   layer ? layer->getName() : "NA",
-                   mirrored_pin.getName());
+    logger_->error(
+        utl::PPL,
+        82,
+        "Mirrored position ({:.2f}um, {:.2f}um) at layer {} is not "
+        "a valid position for pin {} placement.",
+        db_->getChip()->getBlock()->dbuToMicrons(mirrored_pos.getX()),
+        db_->getChip()->getBlock()->dbuToMicrons(mirrored_pos.getY()),
+        layer ? layer->getName() : "NA",
+        mirrored_pin.getName());
   }
   slots_[slot_index].used = true;
 }

--- a/src/ppl/src/SimulatedAnnealing.cpp
+++ b/src/ppl/src/SimulatedAnnealing.cpp
@@ -835,13 +835,14 @@ int SimulatedAnnealing::getMirroredSlotIdx(int slot_idx) const
 
   if (mirrored_idx < 0) {
     odb::dbTechLayer* tech_layer = db_->getTech()->findRoutingLayer(layer);
-    logger_->error(utl::PPL,
-                   112,
-                   "Mirrored position ({}, {}) at layer {} is not a "
-                   "valid position.",
-                   mirrored_pos.getX(),
-                   mirrored_pos.getY(),
-                   tech_layer ? tech_layer->getName() : "NA");
+    logger_->error(
+        utl::PPL,
+        112,
+        "Mirrored position ({:.2f}um, {:.2f}um) at layer {} is not "
+        "a valid position.",
+        db_->getChip()->getBlock()->dbuToMicrons(mirrored_pos.getX()),
+        db_->getChip()->getBlock()->dbuToMicrons(mirrored_pos.getY()),
+        tech_layer ? tech_layer->getName() : "NA");
   }
 
   return mirrored_idx;

--- a/src/rcx/src/extmain_v2.cpp
+++ b/src/rcx/src/extmain_v2.cpp
@@ -785,11 +785,11 @@ void extMain::loopWarning(dbNet* net, const dbWirePathShape& pshape)
   }
   logger_->warn(RCX,
                 117,
-                "Net {} {} has a loop at x={} y={} {}.",
+                "Net {} {} has a loop at x={:.2f}um y={:.2f}um {}.",
                 net->getId(),
                 net->getConstName(),
-                pshape.point.getX(),
-                pshape.point.getY(),
+                _block->dbuToMicrons(pshape.point.getX()),
+                _block->dbuToMicrons(pshape.point.getY()),
                 tname);
 }
 void extMain::initJunctionIdMaps(dbNet* net)

--- a/src/rcx/src/netRC.cpp
+++ b/src/rcx/src/netRC.cpp
@@ -676,11 +676,11 @@ dbRSeg* extMain::addRSeg(dbNet* net,
     }
     logger_->warn(RCX,
                   111,
-                  "Net {} {} has a loop at x={} y={} {}.",
+                  "Net {} {} has a loop at x={:.2f}um y={:.2f}um {}.",
                   net->getId(),
                   net->getConstName(),
-                  pshape.point.getX(),
-                  pshape.point.getY(),
+                  _block->dbuToMicrons(pshape.point.getX()),
+                  _block->dbuToMicrons(pshape.point.getY()),
                   tname);
     return nullptr;
   }


### PR DESCRIPTION
Several error and warning messages print coordinates and areas as raw database units (giant integers) instead of human-readable microns. The conversion functions already exist and are used correctly in nearby code — these messages were simply missed.

Messages fixed:
- MPL-16: area values (dbuAreaToMicrons)
- MPL-4: macro width/height (dbuToMicrons)
- PPL-82: mirrored pin position (dbuToMicrons)
- PPL-112: mirrored position (dbuToMicrons)
- DRT-223: pin dangling coordinates (DBUPerUU)
- GRT-31: duplicate pin position (dbuToMicrons)
- RCX-111: net loop coordinates (dbuToMicrons)
- RCX-117: net loop coordinates (dbuToMicrons)

Closes #9239

## Summary
[Describe your changes here]

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Impact
[How does this change the tool's behavior?]

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]