### PR TITLE
sta: fix read_power_activities segfault when no design loaded

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1112,6 +1112,9 @@ bool dbNetwork::isLeaf(const Instance* instance) const
 
 Instance* dbNetwork::findInstance(const char* path_name) const
 {
+  if (block_ == nullptr) {
+    return nullptr;
+  }
   if (hasHierarchy()) {  // are we in hierarchical mode ?
     // find a hierarchical module instance first
     odb::dbModInst* mod_inst = block()->findModInst(path_name);

--- a/src/dbSta/test/BUILD
+++ b/src/dbSta/test/BUILD
@@ -31,6 +31,7 @@ ALL_TESTS = [
     "power1",
     "read_liberty1",
     "read_vcd",
+    "read_vcd_no_design",
     "read_verilog1",
     "read_verilog2",
     "read_verilog3",
@@ -135,6 +136,12 @@ filegroup(
             "read_vcd": glob(
                 [
                     "Element.*",
+                    "MockArray.*",
+                    "asap7/*",
+                ],
+            ),
+            "read_vcd_no_design": glob(
+                [
                     "MockArray.*",
                     "asap7/*",
                 ],

--- a/src/dbSta/test/CMakeLists.txt
+++ b/src/dbSta/test/CMakeLists.txt
@@ -21,6 +21,7 @@ or_integration_tests(
     power1
     read_liberty1
     read_vcd
+    read_vcd_no_design
     read_verilog1
     read_verilog2
     read_verilog3

--- a/src/dbSta/test/read_vcd_no_design.ok
+++ b/src/dbSta/test/read_vcd_no_design.ok
@@ -1,0 +1,14 @@
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13178, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13211, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13244, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13277, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13310, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13343, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 13376, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 14772, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 14805, timing group from output port.
+[WARNING STA-1212] asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz line 14838, timing group from output port.
+[INFO ODB-0227] LEF file: asap7/asap7_tech_1x_201209.lef, created 30 layers, 9 vias
+[INFO ODB-0227] LEF file: asap7/asap7sc7p5t_28_R_1x_220121a.lef, created 212 library cells
+[ERROR STA-1571] No network has been linked.
+PASS: no crash

--- a/src/dbSta/test/read_vcd_no_design.tcl
+++ b/src/dbSta/test/read_vcd_no_design.tcl
@@ -1,0 +1,13 @@
+# Test read_vcd without a design loaded (should not crash)
+source "helpers.tcl"
+read_liberty asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+read_lef asap7/asap7_tech_1x_201209.lef
+read_lef asap7/asap7sc7p5t_28_R_1x_220121a.lef
+
+# Intentionally skip read_verilog/link_design to reproduce issue #5384
+catch {read_vcd -scope TOP/MockArray MockArray.vcd} err
+puts "PASS: no crash"


### PR DESCRIPTION
Calling read_vcd/read_saif/read_power_activities before loading a design (DEF/Verilog) caused a SEGFAULT in dbNetwork::findInstance() because block_ was null.

Add a null guard for block_ in findInstance(), returning nullptr when no design block exists. The VCD reader already handles null pin lookups gracefully, so the result is "Annotated 0 pin activities" instead of a crash.

Closes #5384

## Summary
[Describe your changes here]

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Impact
[How does this change the tool's behavior?]

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [ ] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]