### PR TITLE
Don't manually use copts, use bazel way to point to includes.

### DIFF
--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -84,10 +84,10 @@ cc_library(
     hdrs = [
         "include/cts/MakeTritoncts.h",
     ],
-    copts = [
-        "-Isrc/cts/src",
+    includes = [
+        "include",
+        "src",
     ],
-    includes = ["include"],
     deps = [
         ":cts",
         ":private_hdrs",

--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -144,11 +144,11 @@ cc_library(
         "include/db_sta/MakeDbSta.hh",
     ],
     copts = [
-        "-Isrc/dbSta/src",
         "-Wno-missing-braces",  # from TCL swigging
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":IpChecker",

--- a/src/dft/BUILD
+++ b/src/dft/BUILD
@@ -48,11 +48,9 @@ cc_library(
     hdrs = [
         "include/dft/MakeDft.hh",
     ],
-    copts = [
-        "-Isrc/dft/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":dft",

--- a/src/dpl/BUILD
+++ b/src/dpl/BUILD
@@ -79,11 +79,9 @@ cc_library(
         "include/dpl/Opendp.h",
         "include/dpl/OptMirror.h",
     ],
-    copts = [
-        "-Isrc/dpl/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//src/odb",

--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -199,11 +199,11 @@ cc_library(
         "include/drt/TritonRoute.h",
     ],
     copts = [
-        "-Isrc/drt/src",
         "-fopenmp",
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":db_hdrs",
@@ -262,11 +262,11 @@ cc_library(
         "include/drt/MakeTritonRoute.h",
     ],
     copts = [
-        "-Isrc/drt/src",
         "-Wno-missing-braces",  # from TCL swigging
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":db_hdrs",

--- a/src/est/BUILD
+++ b/src/est/BUILD
@@ -71,12 +71,12 @@ cc_library(
         "include/est/MakeEstimateParasitics.h",
     ],
     copts = [
-        "-Isrc/est/src",
         "-Wno-missing-braces",  # from TCL swigging
         "-fopenmp",
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":est",

--- a/src/exa/BUILD
+++ b/src/exa/BUILD
@@ -43,11 +43,9 @@ cc_library(
     hdrs = [
         "include/exa/MakeExample.h",
     ],
-    copts = [
-        "-Isrc/exa/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":exa",

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -185,12 +185,12 @@ cc_library(
         "include/grt/MakeGlobalRouter.h",
     ],
     copts = [
-        "-Isrc/grt/src",
         "-Wno-missing-braces",  # from TCL swigging
         "-fopenmp",
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":abstract-fastroute",

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -39,8 +39,10 @@ cc_library(
         "include/gui/gui.h",
         "include/gui/heatMap.h",
     ],
-    copts = ["-Isrc/gui/src"],
-    includes = ["include"],
+    includes = [
+        "include",
+        "src",
+    ],
     deps = [
         "//src/dbSta",
         "//src/dbSta:dbNetwork",

--- a/src/ifp/BUILD
+++ b/src/ifp/BUILD
@@ -44,11 +44,9 @@ cc_library(
     hdrs = [
         "include/ifp/MakeInitFloorplan.hh",
     ],
-    copts = [
-        "-Isrc/ifp/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//:ord",

--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -68,11 +68,9 @@ cc_library(
     hdrs = [
         "include/mpl/MakeMacroPlacer.h",
     ],
-    copts = [
-        "-Isrc/mpl/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":mpl",

--- a/src/odb/BUILD
+++ b/src/odb/BUILD
@@ -138,11 +138,13 @@ cc_library(
     hdrs = ["include/odb/MakeOdb.h"],
     copts = [
         "-Wno-missing-braces",  # from TCL swigging
-        "-Isrc/odb/src/swig/common",
-        "-Isrc/odb/include",
     ],
     features = [
         "-use_header_modules",
+    ],
+    includes = [
+        "include",
+        "src/swig/common",
     ],
     deps = [
         ":odb",

--- a/src/ppl/BUILD
+++ b/src/ppl/BUILD
@@ -38,11 +38,9 @@ cc_library(
         "include/ppl/MakeIoplacer.h",
         "include/ppl/Parameters.h",
     ],
-    copts = [
-        "-Isrc/ppl/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":munkres",

--- a/src/rcx/BUILD
+++ b/src/rcx/BUILD
@@ -106,11 +106,9 @@ cc_library(
     hdrs = [
         "include/rcx/MakeOpenRCX.h",
     ],
-    copts = [
-        "-Isrc/rcx/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":rcx",

--- a/src/rmp/BUILD
+++ b/src/rmp/BUILD
@@ -35,12 +35,10 @@ cc_library(
     hdrs = [
         "include/rmp/Restructure.h",
     ],
-    copts = [
-        "-Isrc/rmp/src",
-    ],
     defines = ["ABC_NAMESPACE=abc"],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//:ord",
@@ -76,11 +74,9 @@ cc_library(
     hdrs = [
         "include/rmp/MakeRestructure.h",
     ],
-    copts = [
-        "-Isrc/rmp/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":rmp",

--- a/src/rsz/BUILD
+++ b/src/rsz/BUILD
@@ -93,11 +93,9 @@ cc_library(
     hdrs = [
         "include/rsz/MakeResizer.hh",
     ],
-    copts = [
-        "-Isrc/rsz/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":rsz",

--- a/src/utl/BUILD
+++ b/src/utl/BUILD
@@ -139,10 +139,10 @@ cc_library(
     hdrs = [
         "include/utl/MakeLogger.h",
     ],
-    copts = [
-        "-Isrc/utl/src",
+    includes = [
+        "include",
+        "src",
     ],
-    includes = ["include"],
     deps = [
         ":utl",
         "//:ord",

--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -39,10 +39,10 @@ cc_library(
     ],
     copts = [
         "-DBOOST_ASIO_NO_DEPRECATED",
-        "-Isrc/web/src",
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//src/dbSta",
@@ -69,11 +69,9 @@ cc_library(
     hdrs = [
         "include/web/MakeWeb.h",
     ],
-    copts = [
-        "-Isrc/web/src",
-    ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         ":web",


### PR DESCRIPTION
This makes it more compatible with use as external dependency. Issues: #9937
