### PR TITLE
Make sure downstream is compiling with c++20

### DIFF
--- a/test/downstream/.bazelrc
+++ b/test/downstream/.bazelrc
@@ -1,2 +1,3 @@
 # Required because OpenROAD's MODULE.bazel uses isolate = True on use_extension
 common --experimental_isolated_extension_usages
+build --cxxopt "-std=c++20" --host_cxxopt "-std=c++20"


### PR DESCRIPTION
... openroad is not compatible with older versions and the default compilers resort to is c++17.
