### PR TITLE
ram: add PDN strap pitch vs die size error check in ramPdngen() to prevent segfault

### DIFF
--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -466,7 +466,7 @@ void RamGen::ramPdngen(const char* power_pin,
                        int hor_pitch)
 {
   const odb::Rect& die = block_->getDieArea();
-  const double dbu_per_um = block_->getDb()->getTech()->getDbUnitsPerMicron();
+  const double dbu_per_um = block_->getDb()->getDbuPerMicron();
 
   if (die.dy() < hor_pitch) {
     logger_->error(RAM,


### PR DESCRIPTION
## Summary
When the die area is smaller than the PDN strap pitch, calling RamGen::ramPdngen() can result in a segfault. This adds a check at the top of ramPdngen() to compare die dimensions against the strap pitch and give an error instead

## Type of Change
- Bug fix

## Impact
Instead of a segfault when PDN strap pitch is larger than the die size, user will get a clear error message indicating which dimension is too small and suggesting they use a smaller pitch 

Before Fix Sample Error Message:
```
[INFO PDN-0001] Inserting grid: ram_grid
Signal 11 received
 2# odb::dbTrackGrid::getGridY() in openroad
 3# pdn::TechLayer::populateGrid(odb::dbBlock*, odb::dbTechLayerDir) in openroad
 4# pdn::Straps::makeShapes(...) in openroad
 8# pdn::PdnGen::buildGrids(bool) in openroad
 9# ram::RamGen::ramPdngen(...) in openroad
Segmentation fault (core dumped)
```

After Fix Sample Error Message:
```
[ERROR RAM-0031] Die height (13600 DBU) is less than horizontal strap pitch (20000 DBU). Use a smaller -hor_layer pitch.
```

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
#9961 

@rovinski 
@gadfort 