### PR TITLE
refactor docs_check

### DIFF
--- a/docs/src/doc_check_tests.md
+++ b/docs/src/doc_check_tests.md
@@ -64,7 +64,20 @@ When adding documentation tests for a new module:
 1. Add `filegroup(name = "doc_files")` and `messages_txt()` macro call
    to `src/{module}/BUILD` (load `messages_txt` from
    `//test:regression.bzl`)
-2. Add `doc_check_test` entries to `src/{module}/test/BUILD`
+2. Create symlinks in `src/{module}/test/` pointing to the shared scripts:
+   ```bash
+   cd src/{module}/test
+   ln -s ../../../docs/src/scripts/readme_msgs_check.py {module}_readme_msgs_check.py
+   ln -s ../../../docs/src/scripts/man_tcl_check.py {module}_man_tcl_check.py
+   ln -s ../../../docs/src/scripts/extract_utils.py extract_utils.py
+   ln -s ../../../docs/src/scripts/manpage.py manpage.py
+   ln -s ../../../docs/src/scripts/md_roff_compat.py md_roff_compat.py
+   ```
+3. Add `{module}_readme_msgs_check.ok` (expected output) to
+   `src/{module}/test/`
+4. Add test targets to `src/{module}/test/BUILD`:
+   - `doc_check_test` for `{module}_readme_msgs_check`
+   - `py_test` for `{module}_man_tcl_check`
 
 The `doc_check` tag is automatically added by the macro, so
 `--test_tag_filters=doc_check` picks up new tests without any changes

--- a/docs/src/doc_check_tests.md
+++ b/docs/src/doc_check_tests.md
@@ -35,12 +35,11 @@ Each module has two documentation tests:
 
 ## How it works
 
-The tests use the `doc_check_test` Bazel macro defined in
-`test/regression.bzl`. This is a lightweight variant of
-`regression_test` that does not depend on `//:openroad`, so no C++
-compilation is triggered. All doc check tests are automatically tagged
-with `doc_check`, which allows tag-based discovery via
-`--test_tag_filters=doc_check`.
+Both test types (`readme_msgs_check` and `man_tcl_check`) use the
+standard `py_test` rule from `@rules_python`. They are tagged with
+`doc_check`, which allows tag-based discovery via
+`--test_tag_filters=doc_check`. Neither test depends on `//:openroad`,
+so no C++ compilation is triggered.
 
 Each module's `messages.txt` is generated on-demand by the
 `messages_txt` macro (also in `test/regression.bzl`) that runs
@@ -73,12 +72,10 @@ When adding documentation tests for a new module:
    ln -s ../../../docs/src/scripts/manpage.py manpage.py
    ln -s ../../../docs/src/scripts/md_roff_compat.py md_roff_compat.py
    ```
-3. Add `{module}_readme_msgs_check.ok` (expected output) to
-   `src/{module}/test/`
-4. Add test targets to `src/{module}/test/BUILD`:
-   - `doc_check_test` for `{module}_readme_msgs_check`
+3. Add `py_test` targets to `src/{module}/test/BUILD`:
    - `py_test` for `{module}_man_tcl_check`
+   - `py_test` for `{module}_readme_msgs_check`
 
-The `doc_check` tag is automatically added by the macro, so
-`--test_tag_filters=doc_check` picks up new tests without any changes
-to the root `BUILD.bazel`.
+Both `py_test` targets must include `tags = ["doc_check"]` so that
+`--test_tag_filters=doc_check` picks them up without any changes to
+the root `BUILD.bazel`.

--- a/docs/src/scripts/BUILD
+++ b/docs/src/scripts/BUILD
@@ -10,6 +10,22 @@ py_library(
     visibility = ["//visibility:public"],
 )
 
+py_library(
+    name = "manpage",
+    srcs = ["manpage.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "md_roff_compat",
+    srcs = ["md_roff_compat.py"],
+    deps = [
+        ":extract_utils",
+        ":manpage",
+    ],
+    visibility = ["//visibility:public"],
+)
+
 py_test(
     name = "test_extract_utils",
     srcs = ["test_extract_utils.py"],

--- a/docs/src/scripts/BUILD
+++ b/docs/src/scripts/BUILD
@@ -19,11 +19,11 @@ py_library(
 py_library(
     name = "md_roff_compat",
     srcs = ["md_roff_compat.py"],
+    visibility = ["//visibility:public"],
     deps = [
         ":extract_utils",
         ":manpage",
     ],
-    visibility = ["//visibility:public"],
 )
 
 py_test(

--- a/docs/src/scripts/readme_msgs_check.py
+++ b/docs/src/scripts/readme_msgs_check.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 import unittest
 
 from md_roff_compat import man2_translate, man3_translate
@@ -11,7 +12,8 @@ class TestReadmeMsgsCheck(unittest.TestCase):
         test_dir = os.path.dirname(os.path.abspath(__file__))
         self.readme_path = os.path.join(test_dir, "../README.md")
         self.messages_path = os.path.join(test_dir, "../messages.txt")
-        self.save_dir = os.path.join(os.getcwd(), "results/docs")
+        tmp_base = os.environ.get("TEST_TMPDIR") or tempfile.mkdtemp()
+        self.save_dir = os.path.join(tmp_base, "results/docs")
         os.makedirs(self.save_dir, exist_ok=True)
 
     def test_man2_translate(self):

--- a/docs/src/scripts/readme_msgs_check.py
+++ b/docs/src/scripts/readme_msgs_check.py
@@ -1,14 +1,25 @@
 import os
+import unittest
+
 from md_roff_compat import man2_translate, man3_translate
 
-# Test objective: Check man2/man3 items parsed.
 
-cur_dir = os.getcwd()
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
+class TestReadmeMsgsCheck(unittest.TestCase):
+    """Test that README.md and messages.txt parse correctly into man page formats."""
 
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
+    def setUp(self):
+        test_dir = os.path.dirname(os.path.abspath(__file__))
+        self.readme_path = os.path.join(test_dir, "../README.md")
+        self.messages_path = os.path.join(test_dir, "../messages.txt")
+        self.save_dir = os.path.join(os.getcwd(), "results/docs")
+        os.makedirs(self.save_dir, exist_ok=True)
 
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+    def test_man2_translate(self):
+        man2_translate(self.readme_path, self.save_dir)
+
+    def test_man3_translate(self):
+        man3_translate(self.messages_path, self.save_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -74,8 +74,8 @@ py_test(
     name = "ant_man_tcl_check",
     srcs = ["ant_man_tcl_check.py"],
     data = ["//src/ant:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -78,11 +78,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "ant_readme_msgs_check",
+    srcs = ["ant_readme_msgs_check.py"],
     data = [
         "//src/ant:doc_files",
         "//src/ant:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/ant/test/BUILD
+++ b/src/ant/test/BUILD
@@ -74,8 +74,8 @@ py_test(
     name = "ant_man_tcl_check",
     srcs = ["ant_man_tcl_check.py"],
     data = ["//src/ant:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -85,7 +85,7 @@ py_test(
         "//src/ant:doc_files",
         "//src/ant:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/ant/test/ant_readme_msgs_check.ok
+++ b/src/ant/test/ant_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 1,        Desc: 1,        Syn: 1,        Options: 1,        Args: 1
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/ant/test/ant_readme_msgs_check.py
+++ b/src/ant/test/ant_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -247,8 +247,8 @@ py_test(
     name = "cts_man_tcl_check",
     srcs = ["cts_man_tcl_check.py"],
     data = ["//src/cts:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -247,8 +247,8 @@ py_test(
     name = "cts_man_tcl_check",
     srcs = ["cts_man_tcl_check.py"],
     data = ["//src/cts:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -258,7 +258,7 @@ py_test(
         "//src/cts:doc_files",
         "//src/cts:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/cts/test/BUILD
+++ b/src/cts/test/BUILD
@@ -3,7 +3,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -251,11 +251,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "cts_readme_msgs_check",
+    srcs = ["cts_readme_msgs_check.py"],
     data = [
         "//src/cts:doc_files",
         "//src/cts:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/cts/test/cts_readme_msgs_check.ok
+++ b/src/cts/test/cts_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 6,        Desc: 6,        Syn: 6,        Options: 6,        Args: 6
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/cts/test/cts_readme_msgs_check.py
+++ b/src/cts/test/cts_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -141,11 +141,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "dft_readme_msgs_check",
+    srcs = ["dft_readme_msgs_check.py"],
     data = [
         "//src/dft:doc_files",
         "//src/dft:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -137,8 +137,8 @@ py_test(
     name = "dft_man_tcl_check",
     srcs = ["dft_man_tcl_check.py"],
     data = ["//src/dft:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -148,7 +148,7 @@ py_test(
         "//src/dft:doc_files",
         "//src/dft:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -137,8 +137,8 @@ py_test(
     name = "dft_man_tcl_check",
     srcs = ["dft_man_tcl_check.py"],
     data = ["//src/dft:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/dft/test/dft_readme_msgs_check.ok
+++ b/src/dft/test/dft_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 6,        Desc: 6,        Syn: 6,        Options: 6,        Args: 6
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/dft/test/dft_readme_msgs_check.py
+++ b/src/dft/test/dft_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -301,8 +301,8 @@ py_test(
     name = "dpl_man_tcl_check",
     srcs = ["dpl_man_tcl_check.py"],
     data = ["//src/dpl:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -3,7 +3,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
 
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -305,11 +305,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "dpl_readme_msgs_check",
+    srcs = ["dpl_readme_msgs_check.py"],
     data = [
         "//src/dpl:doc_files",
         "//src/dpl:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/dpl/test/BUILD
+++ b/src/dpl/test/BUILD
@@ -301,8 +301,8 @@ py_test(
     name = "dpl_man_tcl_check",
     srcs = ["dpl_man_tcl_check.py"],
     data = ["//src/dpl:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -312,7 +312,7 @@ py_test(
         "//src/dpl:doc_files",
         "//src/dpl:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/dpl/test/dpl_readme_msgs_check.ok
+++ b/src/dpl/test/dpl_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 7,        Desc: 7,        Syn: 7,        Options: 7,        Args: 7
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/dpl/test/dpl_readme_msgs_check.py
+++ b/src/dpl/test/dpl_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -157,11 +157,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "drt_readme_msgs_check",
+    srcs = ["drt_readme_msgs_check.py"],
     data = [
         "//src/drt:doc_files",
         "//src/drt:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -153,8 +153,8 @@ py_test(
     name = "drt_man_tcl_check",
     srcs = ["drt_man_tcl_check.py"],
     data = ["//src/drt:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -153,8 +153,8 @@ py_test(
     name = "drt_man_tcl_check",
     srcs = ["drt_man_tcl_check.py"],
     data = ["//src/drt:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -164,7 +164,7 @@ py_test(
         "//src/drt:doc_files",
         "//src/drt:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/drt/test/drt_readme_msgs_check.ok
+++ b/src/drt/test/drt_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 3,        Desc: 3,        Syn: 3,        Options: 3,        Args: 3
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/drt/test/drt_readme_msgs_check.py
+++ b/src/drt/test/drt_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -71,11 +71,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "fin_readme_msgs_check",
+    srcs = ["fin_readme_msgs_check.py"],
     data = [
         "//src/fin:doc_files",
         "//src/fin:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -67,8 +67,8 @@ py_test(
     name = "fin_man_tcl_check",
     srcs = ["fin_man_tcl_check.py"],
     data = ["//src/fin:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/fin/test/BUILD
+++ b/src/fin/test/BUILD
@@ -67,8 +67,8 @@ py_test(
     name = "fin_man_tcl_check",
     srcs = ["fin_man_tcl_check.py"],
     data = ["//src/fin:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -78,7 +78,7 @@ py_test(
         "//src/fin:doc_files",
         "//src/fin:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/fin/test/fin_readme_msgs_check.ok
+++ b/src/fin/test/fin_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 1,        Desc: 1,        Syn: 1,        Options: 1,        Args: 1
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/fin/test/fin_readme_msgs_check.py
+++ b/src/fin/test/fin_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -175,8 +175,8 @@ py_test(
     name = "gpl_man_tcl_check",
     srcs = ["gpl_man_tcl_check.py"],
     data = ["//src/gpl:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -175,8 +175,8 @@ py_test(
     name = "gpl_man_tcl_check",
     srcs = ["gpl_man_tcl_check.py"],
     data = ["//src/gpl:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -186,7 +186,7 @@ py_test(
         "//src/gpl:doc_files",
         "//src/gpl:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -1,6 +1,6 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("@rules_python//python:defs.bzl", "py_library", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -179,11 +179,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "gpl_readme_msgs_check",
+    srcs = ["gpl_readme_msgs_check.py"],
     data = [
         "//src/gpl:doc_files",
         "//src/gpl:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/gpl/test/gpl_readme_msgs_check.ok
+++ b/src/gpl/test/gpl_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 4,        Desc: 4,        Syn: 4,        Options: 4,        Args: 4
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/gpl/test/gpl_readme_msgs_check.py
+++ b/src/gpl/test/gpl_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -136,8 +136,8 @@ py_test(
     name = "grt_man_tcl_check",
     srcs = ["grt_man_tcl_check.py"],
     data = ["//src/grt:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -136,8 +136,8 @@ py_test(
     name = "grt_man_tcl_check",
     srcs = ["grt_man_tcl_check.py"],
     data = ["//src/grt:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -147,7 +147,7 @@ py_test(
         "//src/grt:doc_files",
         "//src/grt:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -140,11 +140,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "grt_readme_msgs_check",
+    srcs = ["grt_readme_msgs_check.py"],
     data = [
         "//src/grt:doc_files",
         "//src/grt:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/grt/test/grt_readme_msgs_check.ok
+++ b/src/grt/test/grt_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 15,        Desc: 15,        Syn: 15,        Options: 15,        Args: 15
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/grt/test/grt_readme_msgs_check.py
+++ b/src/grt/test/grt_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/gui/test/BUILD
+++ b/src/gui/test/BUILD
@@ -42,8 +42,8 @@ py_test(
     name = "gui_man_tcl_check",
     srcs = ["gui_man_tcl_check.py"],
     data = ["//src/gui:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -53,7 +53,7 @@ py_test(
         "//src/gui:doc_files",
         "//src/gui:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/gui/test/BUILD
+++ b/src/gui/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -46,11 +46,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "gui_readme_msgs_check",
+    srcs = ["gui_readme_msgs_check.py"],
     data = [
         "//src/gui:doc_files",
         "//src/gui:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/gui/test/BUILD
+++ b/src/gui/test/BUILD
@@ -42,8 +42,8 @@ py_test(
     name = "gui_man_tcl_check",
     srcs = ["gui_man_tcl_check.py"],
     data = ["//src/gui:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/gui/test/gui_readme_msgs_check.ok
+++ b/src/gui/test/gui_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 60,        Desc: 60,        Syn: 60,        Options: 60,        Args: 60
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/gui/test/gui_readme_msgs_check.py
+++ b/src/gui/test/gui_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -147,11 +147,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "ifp_readme_msgs_check",
+    srcs = ["ifp_readme_msgs_check.py"],
     data = [
         "//src/ifp:doc_files",
         "//src/ifp:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -143,8 +143,8 @@ py_test(
     name = "ifp_man_tcl_check",
     srcs = ["ifp_man_tcl_check.py"],
     data = ["//src/ifp:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -154,7 +154,7 @@ py_test(
         "//src/ifp:doc_files",
         "//src/ifp:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/ifp/test/BUILD
+++ b/src/ifp/test/BUILD
@@ -143,8 +143,8 @@ py_test(
     name = "ifp_man_tcl_check",
     srcs = ["ifp_man_tcl_check.py"],
     data = ["//src/ifp:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/ifp/test/ifp_readme_msgs_check.ok
+++ b/src/ifp/test/ifp_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 4,        Desc: 4,        Syn: 4,        Options: 4,        Args: 4
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/ifp/test/ifp_readme_msgs_check.py
+++ b/src/ifp/test/ifp_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -267,11 +267,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "mpl_readme_msgs_check",
+    srcs = ["mpl_readme_msgs_check.py"],
     data = [
         "//src/mpl:doc_files",
         "//src/mpl:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -263,8 +263,8 @@ py_test(
     name = "mpl_man_tcl_check",
     srcs = ["mpl_man_tcl_check.py"],
     data = ["//src/mpl:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -263,8 +263,8 @@ py_test(
     name = "mpl_man_tcl_check",
     srcs = ["mpl_man_tcl_check.py"],
     data = ["//src/mpl:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -274,7 +274,7 @@ py_test(
         "//src/mpl:doc_files",
         "//src/mpl:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/mpl/test/mpl_readme_msgs_check.ok
+++ b/src/mpl/test/mpl_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 4,        Desc: 4,        Syn: 4,        Options: 4,        Args: 4
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/mpl/test/mpl_readme_msgs_check.py
+++ b/src/mpl/test/mpl_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -401,8 +401,8 @@ py_test(
     name = "odb_man_tcl_check",
     srcs = ["odb_man_tcl_check.py"],
     data = ["//src/odb:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -401,8 +401,8 @@ py_test(
     name = "odb_man_tcl_check",
     srcs = ["odb_man_tcl_check.py"],
     data = ["//src/odb:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -412,7 +412,7 @@ py_test(
         "//src/odb:doc_files",
         "//src/odb:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/odb/test/BUILD
+++ b/src/odb/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_library", "py_test")
 # Test Parity Note: All tests from CMakeLists.txt are included in this BUILD file.
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -405,11 +405,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "odb_readme_msgs_check",
+    srcs = ["odb_readme_msgs_check.py"],
     data = [
         "//src/odb:doc_files",
         "//src/odb:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/odb/test/odb_readme_msgs_check.ok
+++ b/src/odb/test/odb_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 21,        Desc: 21,        Syn: 21,        Options: 21,        Args: 21
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/odb/test/odb_readme_msgs_check.py
+++ b/src/odb/test/odb_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -228,8 +228,8 @@ py_test(
     name = "pad_man_tcl_check",
     srcs = ["pad_man_tcl_check.py"],
     data = ["//src/pad:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -228,8 +228,8 @@ py_test(
     name = "pad_man_tcl_check",
     srcs = ["pad_man_tcl_check.py"],
     data = ["//src/pad:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -239,7 +239,7 @@ py_test(
         "//src/pad:doc_files",
         "//src/pad:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/pad/test/BUILD
+++ b/src/pad/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -232,11 +232,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "pad_readme_msgs_check",
+    srcs = ["pad_readme_msgs_check.py"],
     data = [
         "//src/pad:doc_files",
         "//src/pad:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/pad/test/pad_readme_msgs_check.ok
+++ b/src/pad/test/pad_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 16,        Desc: 16,        Syn: 16,        Options: 16,        Args: 16
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/pad/test/pad_readme_msgs_check.py
+++ b/src/pad/test/pad_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -92,8 +92,8 @@ py_test(
     name = "par_man_tcl_check",
     srcs = ["par_man_tcl_check.py"],
     data = ["//src/par:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -103,7 +103,7 @@ py_test(
         "//src/par:doc_files",
         "//src/par:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -96,11 +96,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "par_readme_msgs_check",
+    srcs = ["par_readme_msgs_check.py"],
     data = [
         "//src/par:doc_files",
         "//src/par:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/par/test/BUILD
+++ b/src/par/test/BUILD
@@ -92,8 +92,8 @@ py_test(
     name = "par_man_tcl_check",
     srcs = ["par_man_tcl_check.py"],
     data = ["//src/par:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/par/test/par_readme_msgs_check.ok
+++ b/src/par/test/par_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 7,        Desc: 7,        Syn: 7,        Options: 7,        Args: 7
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/par/test/par_readme_msgs_check.py
+++ b/src/par/test/par_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -304,8 +304,8 @@ py_test(
     name = "pdn_man_tcl_check",
     srcs = ["pdn_man_tcl_check.py"],
     data = ["//src/pdn:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -315,7 +315,7 @@ py_test(
         "//src/pdn:doc_files",
         "//src/pdn:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -304,8 +304,8 @@ py_test(
     name = "pdn_man_tcl_check",
     srcs = ["pdn_man_tcl_check.py"],
     data = ["//src/pdn:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/pdn/test/BUILD
+++ b/src/pdn/test/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -308,11 +308,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "pdn_readme_msgs_check",
+    srcs = ["pdn_readme_msgs_check.py"],
     data = [
         "//src/pdn:doc_files",
         "//src/pdn:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/pdn/test/pdn_readme_msgs_check.ok
+++ b/src/pdn/test/pdn_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 9,        Desc: 9,        Syn: 9,        Options: 9,        Args: 9
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/pdn/test/pdn_readme_msgs_check.py
+++ b/src/pdn/test/pdn_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -196,11 +196,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "ppl_readme_msgs_check",
+    srcs = ["ppl_readme_msgs_check.py"],
     data = [
         "//src/ppl:doc_files",
         "//src/ppl:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -192,8 +192,8 @@ py_test(
     name = "ppl_man_tcl_check",
     srcs = ["ppl_man_tcl_check.py"],
     data = ["//src/ppl:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/ppl/test/BUILD
+++ b/src/ppl/test/BUILD
@@ -192,8 +192,8 @@ py_test(
     name = "ppl_man_tcl_check",
     srcs = ["ppl_man_tcl_check.py"],
     data = ["//src/ppl:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -203,7 +203,7 @@ py_test(
         "//src/ppl:doc_files",
         "//src/ppl:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/ppl/test/ppl_readme_msgs_check.ok
+++ b/src/ppl/test/ppl_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 12,        Desc: 12,        Syn: 12,        Options: 12,        Args: 12
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/ppl/test/ppl_readme_msgs_check.py
+++ b/src/ppl/test/ppl_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -178,8 +178,8 @@ py_test(
     name = "psm_man_tcl_check",
     srcs = ["psm_man_tcl_check.py"],
     data = ["//src/psm:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -182,11 +182,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "psm_readme_msgs_check",
+    srcs = ["psm_readme_msgs_check.py"],
     data = [
         "//src/psm:doc_files",
         "//src/psm:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -178,8 +178,8 @@ py_test(
     name = "psm_man_tcl_check",
     srcs = ["psm_man_tcl_check.py"],
     data = ["//src/psm:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -189,7 +189,7 @@ py_test(
         "//src/psm:doc_files",
         "//src/psm:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/psm/test/psm_readme_msgs_check.ok
+++ b/src/psm/test/psm_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 8,        Desc: 8,        Syn: 8,        Options: 8,        Args: 8
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/psm/test/psm_readme_msgs_check.py
+++ b/src/psm/test/psm_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -135,8 +135,8 @@ py_test(
     name = "rcx_man_tcl_check",
     srcs = ["rcx_man_tcl_check.py"],
     data = ["//src/rcx:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -135,8 +135,8 @@ py_test(
     name = "rcx_man_tcl_check",
     srcs = ["rcx_man_tcl_check.py"],
     data = ["//src/rcx:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -146,7 +146,7 @@ py_test(
         "//src/rcx:doc_files",
         "//src/rcx:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/rcx/test/BUILD
+++ b/src/rcx/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -139,11 +139,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "rcx_readme_msgs_check",
+    srcs = ["rcx_readme_msgs_check.py"],
     data = [
         "//src/rcx:doc_files",
         "//src/rcx:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/rcx/test/rcx_readme_msgs_check.ok
+++ b/src/rcx/test/rcx_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 17,        Desc: 17,        Syn: 17,        Options: 17,        Args: 17
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/rcx/test/rcx_readme_msgs_check.py
+++ b/src/rcx/test/rcx_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -197,8 +197,8 @@ py_test(
     name = "rmp_man_tcl_check",
     srcs = ["rmp_man_tcl_check.py"],
     data = ["//src/rmp:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -208,7 +208,7 @@ py_test(
         "//src/rmp:doc_files",
         "//src/rmp:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -197,8 +197,8 @@ py_test(
     name = "rmp_man_tcl_check",
     srcs = ["rmp_man_tcl_check.py"],
     data = ["//src/rmp:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/rmp/test/BUILD
+++ b/src/rmp/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -201,11 +201,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "rmp_readme_msgs_check",
+    srcs = ["rmp_readme_msgs_check.py"],
     data = [
         "//src/rmp:doc_files",
         "//src/rmp:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/rmp/test/rmp_readme_msgs_check.ok
+++ b/src/rmp/test/rmp_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 4,        Desc: 4,        Syn: 4,        Options: 4,        Args: 4
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/rmp/test/rmp_readme_msgs_check.py
+++ b/src/rmp/test/rmp_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -447,8 +447,8 @@ py_test(
     name = "rsz_man_tcl_check",
     srcs = ["rsz_man_tcl_check.py"],
     data = ["//src/rsz:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -458,7 +458,7 @@ py_test(
         "//src/rsz:doc_files",
         "//src/rsz:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -447,8 +447,8 @@ py_test(
     name = "rsz_man_tcl_check",
     srcs = ["rsz_man_tcl_check.py"],
     data = ["//src/rsz:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -3,7 +3,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # Test Parity Note: All tests from CMakeLists.txt are included in this BUILD file.
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -451,11 +451,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "rsz_readme_msgs_check",
+    srcs = ["rsz_readme_msgs_check.py"],
     data = [
         "//src/rsz:doc_files",
         "//src/rsz:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/rsz/test/rsz_readme_msgs_check.ok
+++ b/src/rsz/test/rsz_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 25,        Desc: 25,        Syn: 25,        Options: 25,        Args: 25
-Global Examples: Found
-Global See Also: Found
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/rsz/test/rsz_readme_msgs_check.py
+++ b/src/rsz/test/rsz_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/stt/test/BUILD
+++ b/src/stt/test/BUILD
@@ -40,8 +40,8 @@ py_test(
     name = "stt_man_tcl_check",
     srcs = ["stt_man_tcl_check.py"],
     data = ["//src/stt:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -51,7 +51,7 @@ py_test(
         "//src/stt:doc_files",
         "//src/stt:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/stt/test/BUILD
+++ b/src/stt/test/BUILD
@@ -40,8 +40,8 @@ py_test(
     name = "stt_man_tcl_check",
     srcs = ["stt_man_tcl_check.py"],
     data = ["//src/stt:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/stt/test/BUILD
+++ b/src/stt/test/BUILD
@@ -1,5 +1,5 @@
 load("@rules_python//python:defs.bzl", "py_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -44,11 +44,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "stt_readme_msgs_check",
+    srcs = ["stt_readme_msgs_check.py"],
     data = [
         "//src/stt:doc_files",
         "//src/stt:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/stt/test/stt_readme_msgs_check.ok
+++ b/src/stt/test/stt_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 1,        Desc: 1,        Syn: 1,        Options: 1,        Args: 1
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/stt/test/stt_readme_msgs_check.py
+++ b/src/stt/test/stt_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -185,11 +185,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "tap_readme_msgs_check",
+    srcs = ["tap_readme_msgs_check.py"],
     data = [
         "//src/tap:doc_files",
         "//src/tap:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -181,8 +181,8 @@ py_test(
     name = "tap_man_tcl_check",
     srcs = ["tap_man_tcl_check.py"],
     data = ["//src/tap:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/tap/test/BUILD
+++ b/src/tap/test/BUILD
@@ -181,8 +181,8 @@ py_test(
     name = "tap_man_tcl_check",
     srcs = ["tap_man_tcl_check.py"],
     data = ["//src/tap:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -192,7 +192,7 @@ py_test(
         "//src/tap:doc_files",
         "//src/tap:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/tap/test/tap_readme_msgs_check.ok
+++ b/src/tap/test/tap_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 5,        Desc: 5,        Syn: 5,        Options: 5,        Args: 5
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/tap/test/tap_readme_msgs_check.py
+++ b/src/tap/test/tap_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -62,8 +62,8 @@ py_test(
     name = "upf_man_tcl_check",
     srcs = ["upf_man_tcl_check.py"],
     data = ["//src/upf:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -62,8 +62,8 @@ py_test(
     name = "upf_man_tcl_check",
     srcs = ["upf_man_tcl_check.py"],
     data = ["//src/upf:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -73,7 +73,7 @@ py_test(
         "//src/upf:doc_files",
         "//src/upf:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/upf/test/BUILD
+++ b/src/upf/test/BUILD
@@ -2,7 +2,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2025, The OpenROAD Authors
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -66,11 +66,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "upf_readme_msgs_check",
+    srcs = ["upf_readme_msgs_check.py"],
     data = [
         "//src/upf:doc_files",
         "//src/upf:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/upf/test/upf_readme_msgs_check.ok
+++ b/src/upf/test/upf_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 12,        Desc: 12,        Syn: 12,        Options: 12,        Args: 12
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/upf/test/upf_readme_msgs_check.py
+++ b/src/upf/test/upf_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -143,8 +143,8 @@ py_test(
     name = "utl_man_tcl_check",
     srcs = ["utl_man_tcl_check.py"],
     data = ["//src/utl:doc_files"],
-    deps = ["//docs/src/scripts:extract_utils"],
     tags = ["doc_check"],
+    deps = ["//docs/src/scripts:extract_utils"],
 )
 
 py_test(
@@ -154,7 +154,7 @@ py_test(
         "//src/utl:doc_files",
         "//src/utl:messages_txt",
     ],
-    deps = ["//docs/src/scripts:md_roff_compat"],
     tags = ["doc_check"],
     visibility = ["//visibility:public"],
+    deps = ["//docs/src/scripts:md_roff_compat"],
 )

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -6,7 +6,7 @@ load("@rules_python//python:defs.bzl", "py_test")
 # No tests are intentionally excluded. See .kiro/specs/bazel-cmake-test-parity/intentional_exclusions.md
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//test:regression.bzl", "doc_check_test", "regression_test")
+load("//test:regression.bzl", "regression_test")
 
 package(features = ["layering_check"])
 
@@ -147,11 +147,14 @@ py_test(
     deps = ["//docs/src/scripts:extract_utils"],
 )
 
-doc_check_test(
+py_test(
     name = "utl_readme_msgs_check",
+    srcs = ["utl_readme_msgs_check.py"],
     data = [
         "//src/utl:doc_files",
         "//src/utl:messages_txt",
     ],
+    deps = ["//docs/src/scripts:md_roff_compat"],
+    tags = ["doc_check"],
     visibility = ["//visibility:public"],
 )

--- a/src/utl/test/BUILD
+++ b/src/utl/test/BUILD
@@ -143,8 +143,8 @@ py_test(
     name = "utl_man_tcl_check",
     srcs = ["utl_man_tcl_check.py"],
     data = ["//src/utl:doc_files"],
-    tags = ["doc_check"],
     deps = ["//docs/src/scripts:extract_utils"],
+    tags = ["doc_check"],
 )
 
 py_test(

--- a/src/utl/test/utl_readme_msgs_check.ok
+++ b/src/utl/test/utl_readme_msgs_check.ok
@@ -1,6 +1,0 @@
-README.md
-Names: 3,        Desc: 3,        Syn: 3,        Options: 3,        Args: 3
-Global Examples: None
-Global See Also: None
-Man2 successfully compiled.
-Man3 successfully compiled.

--- a/src/utl/test/utl_readme_msgs_check.py
+++ b/src/utl/test/utl_readme_msgs_check.py
@@ -1,18 +1,1 @@
-import os
-import sys
-from md_roff_compat import man2_translate, man3_translate
-
-# Test objective: Check man2/man3 items parsed.
-
-cur_dir = os.getcwd()
-doc_dir = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(cur_dir))), "docs"
-)
-save_dir = os.path.join(cur_dir, "results/docs")
-os.makedirs(save_dir, exist_ok=True)
-
-readme_path = os.path.join(cur_dir, "../README.md")
-messages_path = os.path.join(cur_dir, "../messages.txt")
-
-man2_translate(readme_path, save_dir)
-man3_translate(messages_path, save_dir)
+../../../docs/src/scripts/readme_msgs_check.py


### PR DESCRIPTION
## Summary
- Reduce readme_msgs_check single source of truth.
- Rewrite readme_msgs_check to unittest -> eliminate `.ok` files
- Remove fragile os.chdir actio

## Type of Change
<!-- Delete items that do not apply -->
- Reducing LOC, repeated code

## Impact
Maintains doc tests behavior 

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
n/a