### PR TITLE
mbff: Consider leakage instead of cell area for MBFF tray identification.

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -2374,9 +2374,8 @@ void MBFF::ReadLibs()
                  cur_area,
                  cur_leakage);
 
-      if (tray_power_[array_mask][idx] > cur_leakage
-          || (tray_power_[array_mask][idx] == cur_leakage
-              && tray_area_[array_mask][idx] > cur_area)) {
+      if (std::tie(tray_power_[array_mask][idx], tray_area_[array_mask][idx])
+          > std::tie(cur_leakage, cur_area)) {
         tray_area_[array_mask][idx] = cur_area;
         tray_power_[array_mask][idx] = cur_leakage;
         best_master_[array_mask][idx] = master;


### PR DESCRIPTION
Using leakage over cell area seems to perform better on private PDKs with realistically characterized MBFFs.
