### PR TITLE
fix(gui): remove orphaned HeatMapRenderer from stub file

### DIFF
--- a/src/gui/src/stub_heatMap.cpp
+++ b/src/gui/src/stub_heatMap.cpp
@@ -35,6 +35,7 @@ HeatMapDataSource::HeatMapDataSource(utl::Logger* logger,
       reverse_log_(false),
       show_numbers_(false),
       show_legend_(false),
+      use_selected_only_(false),
       color_generator_(SpectrumGenerator(100.0))
 {
 }


### PR DESCRIPTION
## What does this PR  do?
Fixes #10004
This PR cleans up orphaned HeatMapRenderer logic from `src/gui/src/stub_heatMap.cpp.`

Recently, the HeatMapRenderer interface and its associated pointers were removed from heatMap.h, but the `GUI=0` stub implementation file was inadvertently skipped. This PR simply removes the obsolete method stubs and constructor initializer list assignments (`renderer_`and `setup_`) from the stub file, fixing the clang-tidy diagnostic errors that were crashing non-GUI builds.


