### PR TITLE
fix(grt): generate via for co-located pins on different routing layers

### DIFF
--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -288,7 +288,12 @@ void FastRouteCore::fillVIA()
           treeedge.route.type = RouteType::MazeRoute;
           treeedge.route.routelen = newCNT - 1;
         }
-      } else if (treeedge.len == 0) {
+      } else if ((treenodes[treeedge.n1].hID == BIG_INT
+                  && treenodes[treeedge.n1].lID == BIG_INT)
+                 || (treenodes[treeedge.n2].hID == BIG_INT
+                     && treenodes[treeedge.n2].lID == BIG_INT)
+                 || (treeedge.len == 0 && treeedge.n1 < num_terminals
+                     && treeedge.n2 < num_terminals)) {
         int node1 = treeedge.n1;
         int node2 = treeedge.n2;
         if ((treenodes[node1].botL == num_layers_


### PR DESCRIPTION
## Summary
Fixes #9919 
In FastRouteCore::fillVIA(), the condition for generating a via on a zero-length Steiner tree edge (len == 0) only triggered when at least one endpoint had no other connections (hID == BIG_INT && lID == BIG_INT). For multi-pin nets where both co-located pins also connect to the rest of the tree via non-zero edges, layerAssignmentV4() sets their hID to actual edge IDs, causing the via generation to be silently skipped. The fix changes the condition to treeedge.len == 0, which correctly handles all zero-length edges.

## Type of Change
- Bug fix


## Impact
When two pins in a net occupy the same global routing cell (gcell) but on different routing layers, GRT now correctly generates an inter-layer via between them. Previously, the missing via caused a disconnected route topology that manifested as RSZ-0074: failed to build load tree from global routes: found route to N pins, expected M.




