### PR TITLE
grt: fix is_incremental_ flag not reset in endIncremental()

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -333,7 +333,7 @@ void GlobalRouter::startIncremental()
 
 void GlobalRouter::endIncremental(bool save_guides)
 {
-  is_incremental_ = true;
+  is_incremental_ = false;
   fastroute_->setResistanceAware(resistance_aware_);
   updateDirtyRoutes(save_guides);
   grouter_cbk_->removeOwner();


### PR DESCRIPTION
`endIncremental()` was setting` is_incremental_ = true` instead of false. This means the router never actually exits incremental mode after the session ends, which can cause incorrect behavior in subsequent routing calls that check this flag.
 `is_incremental_ = false` in `endIncremental()`, which is the correct behavior since the function's purpose is to terminate the 
incremental routing session.