### PR TITLE
fix(web): guard theme.js against missing browser globals (#9912)

### DIFF
--- a/src/web/src/theme.js
+++ b/src/web/src/theme.js
@@ -9,8 +9,20 @@ if (typeof localStorage !== 'undefined') {
     document.documentElement.dataset.theme = savedTheme;
 }
 
+// Dark-theme defaults for non-browser environments (e.g. Node.js tests).
+// Values must match the dark theme in style.css.
+const DARK_THEME_DEFAULTS = {
+    canvasBg: '#1a1a1a', canvasText: '#666', canvasAxis: '#555',
+    canvasLabel: '#aaa', canvasGrid: '#333', canvasTitle: '#888',
+    fgPrimary: '#ccc', fgMuted: '#888', bgPanel: '#252525',
+    bgMap: '#111',
+};
+
 // Read current CSS custom property values for canvas-based widgets.
 export function getThemeColors() {
+    if (typeof document === 'undefined') {
+        return { ...DARK_THEME_DEFAULTS };
+    }
     const s = getComputedStyle(document.documentElement);
     const v = (name) => s.getPropertyValue(name).trim();
     return {


### PR DESCRIPTION
## Problem
After ca12251 added the light/dark theme toggle, clock-tree-widget.js started importing getThemeColors() from theme.js. This function calls getComputedStyle(document.documentElement), which doesn't exist in Node.js. Any js_test that transitively imports clock-tree-widget.js now crashes with ReferenceError: document is not defined before a single test case runs.

##  What does this PR do?
Fixes #9912 
Added a typeof document === 'undefined' guard at the top of getThemeColors(). In Node.js environments, it returns hardcoded dark-theme defaults instead of reading CSS custom properties. These values are only used by canvas rendering code that never runs in tests, so the fallback is safe.

Changes Made
src/web/src/theme.js — added typeof document check with dark-theme fallback values in getThemeColors()

## Testing & Verification
```bash
bazelisk test //src/web/test:clock_tree_widget_test 
``` 
**Expected output:**
```bash
alokkumardalei@Aloks-MacBook-Air OpenROAD % bazelisk test //src/web/test:clock_tree_widget_test  
INFO: Invocation ID: 4c68bbc6-aa16-4fe6-ad16-c102cba097f8
INFO: Analyzed target //src/web/test:clock_tree_widget_test (119 packages loaded, 11108 targets configured).
INFO: Found 1 test target...
Target //src/web/test:clock_tree_widget_test up-to-date:
  bazel-bin/src/web/test/clock_tree_widget_test_/clock_tree_widget_test
INFO: Elapsed time: 0.808s, Critical Path: 0.41s
INFO: 1 process: 26 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//src/web/test:clock_tree_widget_test                           (cached) PASSED in 1.6s

Executed 0 out of 1 test: 1 test passes.
```
```bash
bazelisk test //src/web/test:charts_widget_test 
```
**Expected output:**
```bash
alokkumardalei@Aloks-MacBook-Air OpenROAD % bazelisk test //src/web/test:charts_widget_test      
INFO: Invocation ID: 6c6f5d0f-d680-4b03-9709-37db5ced7ba4
INFO: Analyzed target //src/web/test:charts_widget_test (0 packages loaded, 2 targets configured).
INFO: Found 1 test target...
Target //src/web/test:charts_widget_test up-to-date:
  bazel-bin/src/web/test/charts_widget_test_/charts_widget_test
INFO: Elapsed time: 0.454s, Critical Path: 0.26s
INFO: 1 process: 8 action cache hit, 1 internal.
INFO: Build completed successfully, 1 total action
//src/web/test:charts_widget_test                               (cached) PASSED in 0.9s

Executed 0 out of 1 test: 1 test passes.
```

 