### PR TITLE
ord: Set Tech name when using Tech API programmatically

### DIFF
--- a/src/Tech.cc
+++ b/src/Tech.cc
@@ -65,8 +65,9 @@ void Tech::readLef(const std::string& file_name)
     lib_name.erase(lib_name.begin() + dot_pos, lib_name.end());
   }
 
+  const char* tech_name = make_tech ? lib_name.c_str() : "";
   app_->readLef(
-      file_name.c_str(), lib_name.c_str(), "", make_tech, make_library);
+      file_name.c_str(), lib_name.c_str(), tech_name, make_tech, make_library);
 }
 
 void Tech::readLiberty(const std::string& file_name)

--- a/test/timing_api.py
+++ b/test/timing_api.py
@@ -5,8 +5,6 @@ tech.readLiberty("Nangate45/Nangate45_typ.lib")
 tech.readLef("Nangate45/Nangate45_tech.lef")
 tech.readLef("Nangate45/Nangate45_stdcell.lef")
 
-assert tech.getTech().getName() != ""
-
 design = Design(tech)
 design.readDef("get_core_die_areas.def")
 timing = Timing(design)

--- a/test/timing_api.py
+++ b/test/timing_api.py
@@ -5,6 +5,8 @@ tech.readLiberty("Nangate45/Nangate45_typ.lib")
 tech.readLef("Nangate45/Nangate45_tech.lef")
 tech.readLef("Nangate45/Nangate45_stdcell.lef")
 
+assert tech.getTech().getName() != ""
+
 design = Design(tech)
 design.readDef("get_core_die_areas.def")
 timing = Timing(design)

--- a/test/timing_report_api.py
+++ b/test/timing_report_api.py
@@ -16,6 +16,8 @@ tech.readLiberty("Nangate45/Nangate45_typ.lib")
 tech.readLef("Nangate45/Nangate45_tech.lef")
 tech.readLef("Nangate45/Nangate45_stdcell.lef")
 
+assert tech.getTech().getName() != ""
+
 design = Design(tech)
 design.readDef("gcd_nangate45.def")
 design.evalTclString("read_sdc timing_api_3.sdc")


### PR DESCRIPTION
## Summary
When using the Tech API programmatically, the tech lef name will not be set when creating a tech. This change aligns the API with the tcl proc, which passes the tech name when creating the tech. Extend the existing Tech API test to verify this.

https://github.com/The-OpenROAD-Project/OpenROAD/blob/f6aef4a0cca61f457a94c351399a6b49af0a1cc5/src/OpenRoad.tcl#L30-L38

## Type of Change
- Bug fix

## Impact
Tech name can now be set when using Tech API.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**