### PR TITLE
odb: use snake_case for variables in LEF58 cut spacing parser

### DIFF
--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -43,7 +43,7 @@ class lefTechLayerMinStepParser
   bool parse(const std::string&, dbTechLayer*, lefinReader*);
 
  private:
-  odb::dbTechLayerMinStepRule* rule;
+  odb::dbTechLayerMinStepRule* rule = nullptr;
   void createSubRule(odb::dbTechLayer* layer);
   void setMinAdjacentLength1(double length, odb::lefinReader* l);
   void setMinAdjacentLength2(double length, odb::lefinReader* l);
@@ -103,7 +103,7 @@ class lefTechLayerCutClassParser
 class lefTechLayerCutSpacingParser
 {
  public:
-  odb::dbTechLayerCutSpacingRule* rule;
+  odb::dbTechLayerCutSpacingRule* rule = nullptr;
   bool parse(const std::string&,
              dbTechLayer*,
              lefinReader*,

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -43,7 +43,7 @@ class lefTechLayerMinStepParser
   bool parse(const std::string&, dbTechLayer*, lefinReader*);
 
  private:
-  odb::dbTechLayerMinStepRule* curRule;
+  odb::dbTechLayerMinStepRule* rule;
   void createSubRule(odb::dbTechLayer* layer);
   void setMinAdjacentLength1(double length, odb::lefinReader* l);
   void setMinAdjacentLength2(double length, odb::lefinReader* l);
@@ -103,7 +103,7 @@ class lefTechLayerCutClassParser
 class lefTechLayerCutSpacingParser
 {
  public:
-  odb::dbTechLayerCutSpacingRule* curRule;
+  odb::dbTechLayerCutSpacingRule* rule;
   bool parse(const std::string&,
              dbTechLayer*,
              lefinReader*,
@@ -113,7 +113,7 @@ class lefTechLayerCutSpacingParser
 class lefTechLayerCutSpacingTableParser
 {
  public:
-  odb::dbTechLayerCutSpacingTableDefRule* curRule = nullptr;
+  odb::dbTechLayerCutSpacingTableDefRule* rule = nullptr;
   odb::dbTechLayer* layer;
   lefTechLayerCutSpacingTableParser(odb::dbTechLayer* inly) { layer = inly; };
   bool parse(const std::string&,

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -114,9 +114,10 @@ void addAdjacentCutsSubRule(
   }
   if (class_name.is_initialized()) {
     const auto& cut_class_name = class_name.value();
-    auto cut_class = layer->findTechLayerCutClassRule(cut_class_name.c_str());
-    if (cut_class != nullptr) {
-      parser->rule->setCutClass(cut_class);
+    auto cut_class_rule
+        = layer->findTechLayerCutClassRule(cut_class_name.c_str());
+    if (cut_class_rule != nullptr) {
+      parser->rule->setCutClass(cut_class_rule);
     }
   }
   if (side_parallel_no_prl.is_initialized()) {
@@ -176,18 +177,19 @@ void addSameMetalSharedEdgeSubRule(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::SAMEMETALSHAREDEDGE);
   auto within = at_c<0>(params);
   auto above = at_c<1>(params);
-  auto cutclass = at_c<2>(params);
+  auto cut_class = at_c<2>(params);
   auto except_two_edges = at_c<3>(params);
   auto except_same_via = at_c<4>(params);
   parser->rule->setWithin(lefinReader->dbdist(within));
   if (above.is_initialized()) {
     parser->rule->setAbove(true);
   }
-  if (cutclass.is_initialized()) {
-    const auto& cut_class_name = cutclass.value();
-    auto cut_class = layer->findTechLayerCutClassRule(cut_class_name.c_str());
-    if (cut_class != nullptr) {
-      parser->rule->setCutClass(cut_class);
+  if (cut_class.is_initialized()) {
+    const auto& cut_class_name = cut_class.value();
+    auto cut_class_rule
+        = layer->findTechLayerCutClassRule(cut_class_name.c_str());
+    if (cut_class_rule != nullptr) {
+      parser->rule->setCutClass(cut_class_rule);
     }
   }
   if (except_two_edges.is_initialized()) {
@@ -310,9 +312,9 @@ void setCutClass(const std::string& value,
                  odb::lefTechLayerCutSpacingParser* parser,
                  odb::dbTechLayer* layer)
 {
-  auto cut_class = layer->findTechLayerCutClassRule(value.c_str());
-  if (cut_class != nullptr) {
-    parser->rule->setCutClass(cut_class);
+  auto cut_class_rule = layer->findTechLayerCutClassRule(value.c_str());
+  if (cut_class_rule != nullptr) {
+    parser->rule->setCutClass(cut_class_rule);
   }
 }
 template <typename Iterator>

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -19,41 +19,39 @@ void setCutSpacing(double value,
                    odb::dbTechLayer* layer,
                    odb::lefinReader* lefinReader)
 {
-  parser->curRule = odb::dbTechLayerCutSpacingRule::create(layer);
-  parser->curRule->setCutSpacing(lefinReader->dbdist(value));
-  parser->curRule->setType(
-      odb::dbTechLayerCutSpacingRule::CutSpacingType::NONE);
+  parser->rule = odb::dbTechLayerCutSpacingRule::create(layer);
+  parser->rule->setCutSpacing(lefinReader->dbdist(value));
+  parser->rule->setType(odb::dbTechLayerCutSpacingRule::CutSpacingType::NONE);
 }
 void setBool(odb::lefTechLayerCutSpacingParser* parser,
              void (odb::dbTechLayerCutSpacingRule::*func)(bool),
              bool val)
 {
-  (parser->curRule->*func)(val);
+  (parser->rule->*func)(val);
 }
 void setCenterToCenter(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setCenterToCenter(true);
+  parser->rule->setCenterToCenter(true);
 }
 void setSameMetal(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setSameMetal(true);
+  parser->rule->setSameMetal(true);
 }
 void setSameNet(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setSameNet(true);
+  parser->rule->setSameNet(true);
 }
 void setSameVia(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setSameVia(true);
+  parser->rule->setSameVia(true);
 }
 void addMaxXYSubRule(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setType(
-      odb::dbTechLayerCutSpacingRule::CutSpacingType::MAXXY);
+  parser->rule->setType(odb::dbTechLayerCutSpacingRule::CutSpacingType::MAXXY);
 }
 void addSameMaskSubRule(odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setType(
+  parser->rule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::SAMEMASK);
 }
 void addLayerSubRule(
@@ -62,13 +60,12 @@ void addLayerSubRule(
     odb::dbTechLayer* layer,
     std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props)
 {
-  parser->curRule->setType(
-      odb::dbTechLayerCutSpacingRule::CutSpacingType::LAYER);
-  auto secondLayer = layer->getTech()->findLayer(name.c_str());
-  if (secondLayer != nullptr) {
-    parser->curRule->setSecondLayer(secondLayer);
+  parser->rule->setType(odb::dbTechLayerCutSpacingRule::CutSpacingType::LAYER);
+  auto second_layer = layer->getTech()->findLayer(name.c_str());
+  if (second_layer != nullptr) {
+    parser->rule->setSecondLayer(second_layer);
   } else {
-    incomplete_props.emplace_back(parser->curRule, name);
+    incomplete_props.emplace_back(parser->rule, name);
   }
 }
 
@@ -86,69 +83,69 @@ void addAdjacentCutsSubRule(
     odb::dbTechLayer* layer,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setType(
+  parser->rule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::ADJACENTCUTS);
   // auto var = at_c<0>(params);
   auto cuts = at_c<0>(params);
   auto aligned = at_c<1>(params);
-  auto twocuts = at_c<2>(params);
+  auto two_cuts = at_c<2>(params);
   auto within = at_c<3>(params);
   auto within2 = at_c<4>(params);
   auto except_same_pgnet = at_c<5>(params);
-  auto className = at_c<6>(params);
-  auto sideParallelNoPrl = at_c<7>(params);
-  auto sameMask = at_c<8>(params);
+  auto class_name = at_c<6>(params);
+  auto side_parallel_no_prl = at_c<7>(params);
+  auto same_mask = at_c<8>(params);
   uint32_t cuts_int = (uint32_t) cuts[0] - (uint32_t) '0';
-  parser->curRule->setAdjacentCuts(cuts_int);
+  parser->rule->setAdjacentCuts(cuts_int);
   if (aligned.is_initialized()) {
-    parser->curRule->setExactAligned(true);
-    parser->curRule->setNumCuts(aligned.value());
+    parser->rule->setExactAligned(true);
+    parser->rule->setNumCuts(aligned.value());
   }
-  if (twocuts.is_initialized()) {
-    parser->curRule->setTwoCutsValid(true);
-    parser->curRule->setTwoCuts(twocuts.value());
+  if (two_cuts.is_initialized()) {
+    parser->rule->setTwoCutsValid(true);
+    parser->rule->setTwoCuts(two_cuts.value());
   }
-  parser->curRule->setWithin(lefinReader->dbdist(within));
+  parser->rule->setWithin(lefinReader->dbdist(within));
   if (within2.is_initialized()) {
-    parser->curRule->setSecondWithin(lefinReader->dbdist(within2.value()));
+    parser->rule->setSecondWithin(lefinReader->dbdist(within2.value()));
   }
   if (except_same_pgnet.is_initialized()) {
-    parser->curRule->setExceptSamePgnet(true);
+    parser->rule->setExceptSamePgnet(true);
   }
-  if (className.is_initialized()) {
-    const auto& cutClassName = className.value();
-    auto cutClass = layer->findTechLayerCutClassRule(cutClassName.c_str());
-    if (cutClass != nullptr) {
-      parser->curRule->setCutClass(cutClass);
+  if (class_name.is_initialized()) {
+    const auto& cut_class_name = class_name.value();
+    auto cut_class = layer->findTechLayerCutClassRule(cut_class_name.c_str());
+    if (cut_class != nullptr) {
+      parser->rule->setCutClass(cut_class);
     }
   }
-  if (sideParallelNoPrl.is_initialized()) {
-    const auto& option = sideParallelNoPrl.value();
+  if (side_parallel_no_prl.is_initialized()) {
+    const auto& option = side_parallel_no_prl.value();
     if (option == "NOPRL") {
-      parser->curRule->setNoPrl(true);
+      parser->rule->setNoPrl(true);
     } else {
-      parser->curRule->setSideParallelOverlap(true);
+      parser->rule->setSideParallelOverlap(true);
     }
   }
-  if (sameMask.is_initialized()) {
-    parser->curRule->setSameMask(true);
+  if (same_mask.is_initialized()) {
+    parser->rule->setSameMask(true);
   }
 }
 void addParallelOverlapSubRule(boost::optional<std::string> except,
                                odb::lefTechLayerCutSpacingParser* parser)
 {
-  parser->curRule->setType(
+  parser->rule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::PARALLELOVERLAP);
   if (except.is_initialized()) {
-    const auto& exceptWhat = except.value();
-    if (exceptWhat == "EXCEPTSAMENET") {
-      parser->curRule->setExceptSameNet(true);
-    } else if (exceptWhat == "EXCEPTSAMEMETAL") {
-      parser->curRule->setExceptSameMetal(true);
-    } else if (exceptWhat == "EXCEPTSAMEVIA") {
-      parser->curRule->setExceptSameVia(true);
-    } else if (exceptWhat == "EXCEPTSAMEMETALOVERLAP") {
-      parser->curRule->setExceptSameMetalOverlap(true);
+    const auto& except_what = except.value();
+    if (except_what == "EXCEPTSAMENET") {
+      parser->rule->setExceptSameNet(true);
+    } else if (except_what == "EXCEPTSAMEMETAL") {
+      parser->rule->setExceptSameMetal(true);
+    } else if (except_what == "EXCEPTSAMEVIA") {
+      parser->rule->setExceptSameVia(true);
+    } else if (except_what == "EXCEPTSAMEMETALOVERLAP") {
+      parser->rule->setExceptSameMetalOverlap(true);
     }
   }
 }
@@ -157,12 +154,12 @@ void addParallelWithinSubRule(
     odb::lefTechLayerCutSpacingParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setType(
+  parser->rule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::PARALLELWITHIN);
-  parser->curRule->setWithin(lefinReader->dbdist(at_c<0>(params)));
+  parser->rule->setWithin(lefinReader->dbdist(at_c<0>(params)));
   auto except = at_c<1>(params);
   if (except.is_initialized()) {
-    parser->curRule->setExceptSameNet(true);
+    parser->rule->setExceptSameNet(true);
   }
 }
 void addSameMetalSharedEdgeSubRule(
@@ -175,40 +172,39 @@ void addSameMetalSharedEdgeSubRule(
     odb::dbTechLayer* layer,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setType(
+  parser->rule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::SAMEMETALSHAREDEDGE);
   auto within = at_c<0>(params);
-  auto ABOVE = at_c<1>(params);
-  auto CUTCLASS = at_c<2>(params);
-  auto EXCEPTTWOEDGES = at_c<3>(params);
-  auto EXCEPTSAMEVIA = at_c<4>(params);
-  parser->curRule->setWithin(lefinReader->dbdist(within));
-  if (ABOVE.is_initialized()) {
-    parser->curRule->setAbove(true);
+  auto above = at_c<1>(params);
+  auto cutclass = at_c<2>(params);
+  auto except_two_edges = at_c<3>(params);
+  auto except_same_via = at_c<4>(params);
+  parser->rule->setWithin(lefinReader->dbdist(within));
+  if (above.is_initialized()) {
+    parser->rule->setAbove(true);
   }
-  if (CUTCLASS.is_initialized()) {
-    const auto& cutClassName = CUTCLASS.value();
-    auto cutClass = layer->findTechLayerCutClassRule(cutClassName.c_str());
-    if (cutClass != nullptr) {
-      parser->curRule->setCutClass(cutClass);
+  if (cutclass.is_initialized()) {
+    const auto& cut_class_name = cutclass.value();
+    auto cut_class = layer->findTechLayerCutClassRule(cut_class_name.c_str());
+    if (cut_class != nullptr) {
+      parser->rule->setCutClass(cut_class);
     }
   }
-  if (EXCEPTTWOEDGES.is_initialized()) {
-    parser->curRule->setExceptTwoEdges(true);
+  if (except_two_edges.is_initialized()) {
+    parser->rule->setExceptTwoEdges(true);
   }
-  if (EXCEPTSAMEVIA.is_initialized()) {
-    parser->curRule->setExceptSameVia(true);
-    auto numCut = EXCEPTSAMEVIA.value();
-    parser->curRule->setNumCuts(numCut);
+  if (except_same_via.is_initialized()) {
+    parser->rule->setExceptSameVia(true);
+    auto num_cut = except_same_via.value();
+    parser->rule->setNumCuts(num_cut);
   }
 }
 void addAreaSubRule(double value,
                     odb::lefTechLayerCutSpacingParser* parser,
                     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setType(
-      odb::dbTechLayerCutSpacingRule::CutSpacingType::AREA);
-  parser->curRule->setCutArea(lefinReader->dbdist(value));
+  parser->rule->setType(odb::dbTechLayerCutSpacingRule::CutSpacingType::AREA);
+  parser->rule->setCutArea(lefinReader->dbdist(value));
 }
 
 void setConcaveCornerWidth(
@@ -216,10 +212,10 @@ void setConcaveCornerWidth(
     odb::lefTechLayerCutSpacingParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setConcaveCornerWidth(true);
-  parser->curRule->setWidth(lefinReader->dbdist(at_c<0>(params)));
-  parser->curRule->setEnclosure(lefinReader->dbdist(at_c<1>(params)));
-  parser->curRule->setEdgeLength(lefinReader->dbdist(at_c<2>(params)));
+  parser->rule->setConcaveCornerWidth(true);
+  parser->rule->setWidth(lefinReader->dbdist(at_c<0>(params)));
+  parser->rule->setEnclosure(lefinReader->dbdist(at_c<1>(params)));
+  parser->rule->setEdgeLength(lefinReader->dbdist(at_c<2>(params)));
 }
 
 void setConcaveCornerParallel(
@@ -227,17 +223,17 @@ void setConcaveCornerParallel(
     odb::lefTechLayerCutSpacingParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setConcaveCornerParallel(true);
-  parser->curRule->setParLength(lefinReader->dbdist(at_c<0>(params)));
-  parser->curRule->setParWithin(lefinReader->dbdist(at_c<1>(params)));
-  parser->curRule->setEnclosure(lefinReader->dbdist(at_c<2>(params)));
+  parser->rule->setConcaveCornerParallel(true);
+  parser->rule->setParLength(lefinReader->dbdist(at_c<0>(params)));
+  parser->rule->setParWithin(lefinReader->dbdist(at_c<1>(params)));
+  parser->rule->setEnclosure(lefinReader->dbdist(at_c<2>(params)));
 }
 void setPrl(double value,
             odb::lefTechLayerCutSpacingParser* parser,
             odb::lefinReader* lefinReader)
 {
-  parser->curRule->setPrlValid(true);
-  parser->curRule->setPrl(lefinReader->dbdist(value));
+  parser->rule->setPrlValid(true);
+  parser->rule->setPrl(lefinReader->dbdist(value));
 }
 
 void setConcaveCornerEdgeLength(
@@ -245,10 +241,10 @@ void setConcaveCornerEdgeLength(
     odb::lefTechLayerCutSpacingParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setConcaveCornerEdgeLength(true);
-  parser->curRule->setEdgeLength(lefinReader->dbdist(at_c<0>(params)));
-  parser->curRule->setEdgeEnclosure(lefinReader->dbdist(at_c<1>(params)));
-  parser->curRule->setAdjEnclosure(lefinReader->dbdist(at_c<2>(params)));
+  parser->rule->setConcaveCornerEdgeLength(true);
+  parser->rule->setEdgeLength(lefinReader->dbdist(at_c<0>(params)));
+  parser->rule->setEdgeEnclosure(lefinReader->dbdist(at_c<1>(params)));
+  parser->rule->setAdjEnclosure(lefinReader->dbdist(at_c<2>(params)));
 }
 
 void setParWithinEnclosure(
@@ -256,67 +252,67 @@ void setParWithinEnclosure(
     odb::lefTechLayerCutSpacingParser* parser,
     odb::lefinReader* lefinReader)
 {
-  auto aboveBelow = at_c<1>(params);
-  if (aboveBelow == "ABOVE") {
-    parser->curRule->setAbove(true);
+  auto above_below = at_c<1>(params);
+  if (above_below == "ABOVE") {
+    parser->rule->setAbove(true);
   } else {
-    parser->curRule->setBelow(true);
+    parser->rule->setBelow(true);
   }
-  parser->curRule->setParWithinEnclosureValid(true);
-  parser->curRule->setParEnclosure(lefinReader->dbdist(at_c<0>(params)));
-  parser->curRule->setParLength(lefinReader->dbdist(at_c<2>(params)));
-  parser->curRule->setParWithin(lefinReader->dbdist(at_c<3>(params)));
+  parser->rule->setParWithinEnclosureValid(true);
+  parser->rule->setParEnclosure(lefinReader->dbdist(at_c<0>(params)));
+  parser->rule->setParLength(lefinReader->dbdist(at_c<2>(params)));
+  parser->rule->setParWithin(lefinReader->dbdist(at_c<3>(params)));
 }
 
 void setCutClassExtension(double value,
                           odb::lefTechLayerCutSpacingParser* parser,
                           odb::lefinReader* lefinReader)
 {
-  parser->curRule->setExtensionValid(true);
-  parser->curRule->setExtension(lefinReader->dbdist(value));
+  parser->rule->setExtensionValid(true);
+  parser->rule->setExtension(lefinReader->dbdist(value));
 }
 void setCutClassNonEolConvexCorner(double value,
                                    odb::lefTechLayerCutSpacingParser* parser,
                                    odb::lefinReader* lefinReader)
 {
-  parser->curRule->setNonEolConvexCorner(true);
-  parser->curRule->setEolWidth(lefinReader->dbdist(value));
+  parser->rule->setNonEolConvexCorner(true);
+  parser->rule->setEolWidth(lefinReader->dbdist(value));
 }
 void setMinLength(double value,
                   odb::lefTechLayerCutSpacingParser* parser,
                   odb::lefinReader* lefinReader)
 {
-  parser->curRule->setMinLengthValid(true);
-  parser->curRule->setMinLength(lefinReader->dbdist(value));
+  parser->rule->setMinLengthValid(true);
+  parser->rule->setMinLength(lefinReader->dbdist(value));
 }
 void setAboveWidth(double value,
                    odb::lefTechLayerCutSpacingParser* parser,
                    odb::lefinReader* lefinReader)
 {
-  parser->curRule->setAboveWidthValid(true);
-  parser->curRule->setAboveWidth(lefinReader->dbdist(value));
+  parser->rule->setAboveWidthValid(true);
+  parser->rule->setAboveWidth(lefinReader->dbdist(value));
 }
 void setAboveWidthEnclosure(double value,
                             odb::lefTechLayerCutSpacingParser* parser,
                             odb::lefinReader* lefinReader)
 {
-  parser->curRule->setAboveWidthEnclosureValid(true);
-  parser->curRule->setAboveEnclosure(lefinReader->dbdist(value));
+  parser->rule->setAboveWidthEnclosureValid(true);
+  parser->rule->setAboveEnclosure(lefinReader->dbdist(value));
 }
 void setOrthogonalSpacing(double value,
                           odb::lefTechLayerCutSpacingParser* parser,
                           odb::lefinReader* lefinReader)
 {
-  parser->curRule->setOrthogonalSpacingValid(true);
-  parser->curRule->setOrthogonalSpacingValid(lefinReader->dbdist(value));
+  parser->rule->setOrthogonalSpacingValid(true);
+  parser->rule->setOrthogonalSpacingValid(lefinReader->dbdist(value));
 }
 void setCutClass(const std::string& value,
                  odb::lefTechLayerCutSpacingParser* parser,
                  odb::dbTechLayer* layer)
 {
-  auto cutClass = layer->findTechLayerCutClassRule(value.c_str());
-  if (cutClass != nullptr) {
-    parser->curRule->setCutClass(cutClass);
+  auto cut_class = layer->findTechLayerCutClassRule(value.c_str());
+  if (cut_class != nullptr) {
+    parser->rule->setCutClass(cut_class);
   }
 }
 template <typename Iterator>
@@ -458,12 +454,12 @@ bool parse(
   bool valid = qi::phrase_parse(first, last, lef58_spacing_rule, space)
                && first == last;
 
-  if (!valid && parser->curRule != nullptr) {
+  if (!valid && parser->rule != nullptr) {
     if (!incomplete_props.empty()
-        && incomplete_props.back().first == parser->curRule) {
+        && incomplete_props.back().first == parser->rule) {
       incomplete_props.pop_back();
     }
-    odb::dbTechLayerCutSpacingRule::destroy(parser->curRule);
+    odb::dbTechLayerCutSpacingRule::destroy(parser->rule);
   }
   return valid;
 }

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -304,7 +304,7 @@ void setOrthogonalSpacing(double value,
                           odb::lefinReader* lefinReader)
 {
   parser->rule->setOrthogonalSpacingValid(true);
-  parser->rule->setOrthogonalSpacingValid(lefinReader->dbdist(value));
+  parser->rule->setOrthogonalSpacing(lefinReader->dbdist(value));
 }
 void setCutClass(const std::string& value,
                  odb::lefTechLayerCutSpacingParser* parser,

--- a/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
@@ -18,7 +18,7 @@
 
 namespace odb::lefTechLayerCutSpacingTable {
 
-void createOrthogonalSubRule(
+static void createOrthogonalSubRule(
     const std::vector<boost::fusion::vector<double, double>>& params,
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)

--- a/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
@@ -23,7 +23,7 @@ void createOrthongonalSubRule(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  odb::dbTechLayerCutSpacingTableOrthRule* rule
+  odb::dbTechLayerCutSpacingTableOrthRule* orth_rule
       = odb::dbTechLayerCutSpacingTableOrthRule::create(parser->layer);
   std::vector<std::pair<int, int>> table;
   table.reserve(params.size());
@@ -31,19 +31,18 @@ void createOrthongonalSubRule(
     table.emplace_back(lefinReader->dbdist(at_c<0>(item)),
                        lefinReader->dbdist(at_c<1>(item)));
   }
-  rule->setSpacingTable(table);
+  orth_rule->setSpacingTable(table);
 }
 void createDefSubRule(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule
-      = odb::dbTechLayerCutSpacingTableDefRule::create(parser->layer);
+  parser->rule = odb::dbTechLayerCutSpacingTableDefRule::create(parser->layer);
 }
 void setDefault(double value,
                 odb::lefTechLayerCutSpacingTableParser* parser,
                 odb::lefinReader* lefinReader)
 {
-  parser->curRule->setDefaultValid(true);
-  parser->curRule->setDefault(lefinReader->dbdist(value));
+  parser->rule->setDefaultValid(true);
+  parser->rule->setDefault(lefinReader->dbdist(value));
 }
 void setLayer(
     const std::string& value,
@@ -52,44 +51,44 @@ void setLayer(
 {
   odb::dbTech* tech = parser->layer->getTech();
   auto secondLayer = tech->findLayer(value.c_str());
-  parser->curRule->setLayerValid(true);
+  parser->rule->setLayerValid(true);
   if (secondLayer == nullptr) {
-    incomplete_props.emplace_back(parser->curRule, value);
+    incomplete_props.emplace_back(parser->rule, value);
   } else {
-    parser->curRule->setSecondLayer(secondLayer);
+    parser->rule->setSecondLayer(secondLayer);
   }
 }
 void setPrlForAlignedCut(
     const std::vector<boost::fusion::vector<std::string, std::string>>& params,
     odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setPrlForAlignedCut(true);
+  parser->rule->setPrlForAlignedCut(true);
   for (const auto& item : params) {
     auto from = at_c<0>(item).c_str();
     auto to = at_c<1>(item).c_str();
-    parser->curRule->addPrlForAlignedCutEntry(from, to);
+    parser->rule->addPrlForAlignedCutEntry(from, to);
   }
 }
 void setCenterToCenter(
     const std::vector<boost::fusion::vector<std::string, std::string>>& params,
     odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setCenterToCenterValid(true);
+  parser->rule->setCenterToCenterValid(true);
   for (const auto& item : params) {
     auto from = at_c<0>(item).c_str();
     auto to = at_c<1>(item).c_str();
-    parser->curRule->addCenterToCenterEntry(from, to);
+    parser->rule->addCenterToCenterEntry(from, to);
   }
 }
 void setCenterAndEdge(
     const std::vector<boost::fusion::vector<std::string, std::string>>& params,
     odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setCenterAndEdgeValid(true);
+  parser->rule->setCenterAndEdgeValid(true);
   for (const auto& item : params) {
     auto from = at_c<0>(item).c_str();
     auto to = at_c<1>(item).c_str();
-    parser->curRule->addCenterAndEdgeEntry(from, to);
+    parser->rule->addCenterAndEdgeEntry(from, to);
   }
 }
 void setPRL(
@@ -102,28 +101,28 @@ void setPRL(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setPrlValid(true);
+  parser->rule->setPrlValid(true);
   auto prl = at_c<0>(params);
   auto dir = at_c<1>(params);
   auto maxxy = at_c<2>(params);
   auto items = at_c<3>(params);
-  parser->curRule->setPrl(lefinReader->dbdist(prl));
+  parser->rule->setPrl(lefinReader->dbdist(prl));
   if (dir.is_initialized()) {
     if (dir.value() == "HORIZONTAL") {
-      parser->curRule->setPrlHorizontal(true);
+      parser->rule->setPrlHorizontal(true);
     } else {
-      parser->curRule->setPrlVertical(true);
+      parser->rule->setPrlVertical(true);
     }
   }
   if (maxxy.is_initialized()) {
-    parser->curRule->setMaxXY(true);
+    parser->rule->setMaxXY(true);
   }
 
   for (const auto& item : items) {
     auto from = at_c<0>(item).c_str();
     auto to = at_c<1>(item).c_str();
     auto ccPrl = lefinReader->dbdist(at_c<2>(item));
-    parser->curRule->addPrlEntry(from, to, ccPrl);
+    parser->rule->addPrlEntry(from, to, ccPrl);
   }
 }
 void setExactAlignedSpacing(
@@ -133,21 +132,21 @@ void setExactAlignedSpacing(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setExactAlignedSpacingValid(true);
+  parser->rule->setExactAlignedSpacingValid(true);
   auto dir = at_c<0>(params);
   auto items = at_c<1>(params);
   if (dir.is_initialized()) {
     if (dir.value() == "HORIZONTAL") {
-      parser->curRule->setHorizontal(true);
+      parser->rule->setHorizontal(true);
     } else {
-      parser->curRule->setVertical(true);
+      parser->rule->setVertical(true);
     }
   }
 
   for (const auto& item : items) {
     auto cls = at_c<0>(item).c_str();
     auto ext = lefinReader->dbdist(at_c<1>(item));
-    parser->curRule->addExactElignedEntry(cls, ext);
+    parser->rule->addExactElignedEntry(cls, ext);
   }
 }
 
@@ -156,11 +155,11 @@ void setNonOppositeEnclosureSpacing(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setNonOppositeEnclosureSpacingValid(true);
+  parser->rule->setNonOppositeEnclosureSpacingValid(true);
   for (const auto& item : params) {
     auto cls = at_c<0>(item).c_str();
     auto ext = lefinReader->dbdist(at_c<1>(item));
-    parser->curRule->addNonOppEncSpacingEntry(cls, ext);
+    parser->rule->addNonOppEncSpacingEntry(cls, ext);
   }
 }
 
@@ -170,14 +169,14 @@ void setOppositeEnclosureResizeSpacing(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setOppositeEnclosureResizeSpacingValid(true);
+  parser->rule->setOppositeEnclosureResizeSpacingValid(true);
   std::vector<std::tuple<char*, int, int, int>> table;
   for (const auto& item : params) {
     auto cls = at_c<0>(item).c_str();
     auto rsz1 = lefinReader->dbdist(at_c<1>(item));
     auto rsz2 = lefinReader->dbdist(at_c<2>(item));
     auto spacing = lefinReader->dbdist(at_c<3>(item));
-    parser->curRule->addOppEncSpacingEntry(cls, rsz1, rsz2, spacing);
+    parser->rule->addOppEncSpacingEntry(cls, rsz1, rsz2, spacing);
   }
 }
 
@@ -188,14 +187,14 @@ void setEndExtension(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setEndExtensionValid(true);
+  parser->rule->setEndExtensionValid(true);
   auto ext = at_c<0>(params);
   auto items = at_c<1>(params);
-  parser->curRule->setExtension(lefinReader->dbdist(ext));
+  parser->rule->setExtension(lefinReader->dbdist(ext));
   for (const auto& item : items) {
     auto cls = at_c<0>(item).c_str();
     auto ext = lefinReader->dbdist(at_c<1>(item));
-    parser->curRule->addEndExtensionEntry(cls, ext);
+    parser->rule->addEndExtensionEntry(cls, ext);
   }
 }
 void setSideExtension(
@@ -203,41 +202,41 @@ void setSideExtension(
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
 {
-  parser->curRule->setSideExtensionValid(true);
+  parser->rule->setSideExtensionValid(true);
   for (const auto& item : params) {
     auto cls = at_c<0>(item).c_str();
     auto ext = lefinReader->dbdist(at_c<1>(item));
-    parser->curRule->addSideExtensionEntry(cls, ext);
+    parser->rule->addSideExtensionEntry(cls, ext);
   }
 }
 
 void setSameMask(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setSameMask(true);
+  parser->rule->setSameMask(true);
 }
 void setSameNet(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setSameNet(true);
+  parser->rule->setSameNet(true);
 }
 void setSameMetal(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setSameMetal(true);
+  parser->rule->setSameMetal(true);
 }
 void setSameVia(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setSameVia(true);
+  parser->rule->setSameVia(true);
 }
 void setNoStack(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setNoStack(true);
+  parser->rule->setNoStack(true);
 }
 void setNonZeroEnclosure(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setNonZeroEnclosure(true);
+  parser->rule->setNonZeroEnclosure(true);
 }
 void setNoPrl(odb::lefTechLayerCutSpacingTableParser* parser)
 {
-  parser->curRule->setNoPrl(true);
+  parser->rule->setNoPrl(true);
 }
 
 void setCutClass(
@@ -296,12 +295,12 @@ void setCutClass(
       auto spacing2 = at_c<1>(item);
       int sp1, sp2;
       if (spacing1.which() == 0) {
-        sp1 = parser->curRule->getDefault();
+        sp1 = parser->rule->getDefault();
       } else {
         sp1 = lefinReader->dbdist(boost::get<double>(spacing1));
       }
       if (spacing2.which() == 0) {
-        sp2 = parser->curRule->getDefault();
+        sp2 = parser->rule->getDefault();
       } else {
         sp2 = lefinReader->dbdist(boost::get<double>(spacing2));
       }
@@ -348,7 +347,7 @@ void setCutClass(
       ++it;
     }
   }
-  parser->curRule->setSpacingTable(table, rows, cols);
+  parser->rule->setSpacingTable(table, rows, cols);
 }
 void print(const std::string& str)
 {
@@ -449,12 +448,12 @@ bool parse(
       = (+(orthogonal_rule | default_rule));
   bool valid = qi::phrase_parse(first, last, lef58_spacing_table_rule, space)
                && first == last;
-  if (!valid && parser->curRule != nullptr) {
+  if (!valid && parser->rule != nullptr) {
     if (!incomplete_props.empty()
-        && incomplete_props.back().first == parser->curRule) {
+        && incomplete_props.back().first == parser->rule) {
       incomplete_props.pop_back();
     }
-    odb::dbTechLayerCutSpacingTableDefRule::destroy(parser->curRule);
+    odb::dbTechLayerCutSpacingTableDefRule::destroy(parser->rule);
   }
 
   return valid;

--- a/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingTableParser.cpp
@@ -18,7 +18,7 @@
 
 namespace odb::lefTechLayerCutSpacingTable {
 
-void createOrthongonalSubRule(
+void createOrthogonalSubRule(
     const std::vector<boost::fusion::vector<double, double>>& params,
     odb::lefTechLayerCutSpacingTableParser* parser,
     odb::lefinReader* lefinReader)
@@ -366,7 +366,7 @@ bool parse(
       = (lit("SPACINGTABLE") >> lit("ORTHOGONAL")
          >> +(lit("WITHIN") >> double_ >> lit("SPACING") >> double_)
          >> lit(";"))[boost::bind(
-          &createOrthongonalSubRule, _1, parser, lefinReader)];
+          &createOrthogonalSubRule, _1, parser, lefinReader)];
 
   qi::rule<std::string::const_iterator, space_type> layer_rule
       = (lit("LAYER") >> _string[boost::bind(

--- a/src/odb/src/lefin/lefTechLayerMinStepParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerMinStepParser.cpp
@@ -13,69 +13,69 @@ namespace odb {
 
 void lefTechLayerMinStepParser::createSubRule(odb::dbTechLayer* layer)
 {
-  curRule = odb::dbTechLayerMinStepRule::create(layer);
+  rule = odb::dbTechLayerMinStepRule::create(layer);
 }
 void lefTechLayerMinStepParser::setMinAdjacentLength1(double length,
                                                       odb::lefinReader* l)
 {
-  curRule->setMinAdjLength1(l->dbdist(length));
-  curRule->setMinAdjLength1Valid(true);
+  rule->setMinAdjLength1(l->dbdist(length));
+  rule->setMinAdjLength1Valid(true);
 }
 void lefTechLayerMinStepParser::setMinAdjacentLength2(double length,
                                                       odb::lefinReader* l)
 {
-  curRule->setMinAdjLength2(l->dbdist(length));
-  curRule->setMinAdjLength2Valid(true);
+  rule->setMinAdjLength2(l->dbdist(length));
+  rule->setMinAdjLength2Valid(true);
 }
 void lefTechLayerMinStepParser::minBetweenLengthParser(double length,
                                                        odb::lefinReader* l)
 {
-  curRule->setMinBetweenLength(l->dbdist(length));
-  curRule->setMinBetweenLengthValid(true);
+  rule->setMinBetweenLength(l->dbdist(length));
+  rule->setMinBetweenLengthValid(true);
 }
 void lefTechLayerMinStepParser::noBetweenEolParser(double width,
                                                    odb::lefinReader* l)
 {
-  curRule->setEolWidth(l->dbdist(width));
-  curRule->setNoBetweenEol(true);
+  rule->setEolWidth(l->dbdist(width));
+  rule->setNoBetweenEol(true);
 }
 
 void lefTechLayerMinStepParser::noAdjacentEolParser(double width,
                                                     odb::lefinReader* l)
 {
-  curRule->setEolWidth(l->dbdist(width));
-  curRule->setNoAdjacentEol(true);
+  rule->setEolWidth(l->dbdist(width));
+  rule->setNoAdjacentEol(true);
 }
 
 void lefTechLayerMinStepParser::minStepLengthParser(double length,
                                                     odb::lefinReader* l)
 {
-  curRule->setMinStepLength(l->dbdist(length));
+  rule->setMinStepLength(l->dbdist(length));
 }
 void lefTechLayerMinStepParser::maxEdgesParser(int edges, odb::lefinReader* l)
 {
-  curRule->setMaxEdges(edges);
-  curRule->setMaxEdgesValid(true);
+  rule->setMaxEdges(edges);
+  rule->setMaxEdgesValid(true);
 }
 
 void lefTechLayerMinStepParser::setExceptRectangle()
 {
-  curRule->setExceptRectangle(true);
+  rule->setExceptRectangle(true);
 }
 
 void lefTechLayerMinStepParser::setConvexCorner()
 {
-  curRule->setConvexCorner(true);
+  rule->setConvexCorner(true);
 }
 
 void lefTechLayerMinStepParser::setConcaveCorner()
 {
-  curRule->setConcaveCorner(true);
+  rule->setConcaveCorner(true);
 }
 
 void lefTechLayerMinStepParser::setExceptSameCorners()
 {
-  curRule->setExceptSameCorners(true);
+  rule->setExceptSameCorners(true);
 }
 
 bool lefTechLayerMinStepParser::parse(const std::string& s,
@@ -130,8 +130,8 @@ bool lefTechLayerMinStepParser::parse(const std::string& s,
   bool valid
       = qi::phrase_parse(first, last, minstepRule, space) && first == last;
 
-  if (!valid && curRule != nullptr) {  // fail if we did not get a full match
-    odb::dbTechLayerMinStepRule::destroy(curRule);
+  if (!valid && rule != nullptr) {  // fail if we did not get a full match
+    odb::dbTechLayerMinStepRule::destroy(rule);
   }
   return valid;
 }


### PR DESCRIPTION
## Summary

Rename variables to snake_case in the LEF58 cut spacing parser files per #2275, and clean up the `curRule` member naming per [Coding Practice #6](docs/contrib/CodingPractices.md) ("Don't name variables `theThingy`, `curThingy` or `myThingy`").

## Changes

**Commit 1 — rename (pure refactor, no behavior change):**
- `curRule` member renamed to `rule` in three classes:
  - `lefTechLayerMinStepParser`
  - `lefTechLayerCutSpacingParser`
  - `lefTechLayerCutSpacingTableParser`
- Local variables in `lefTechLayerCutSpacingParser.cpp` renamed to snake_case:
  - camelCase: `secondLayer`, `twocuts`, `className`, `sideParallelNoPrl`, `sameMask`, `cutClassName`, `cutClass`, `exceptWhat`, `numCut`, `aboveBelow`
  - ALL_CAPS locals that matched LEF keyword names: `ABOVE`, `CUTCLASS`, `EXCEPTTWOEDGES`, `EXCEPTSAMEVIA`
- In `lefTechLayerCutSpacingTableParser::createOrthogonalSubRule`, the local variable `rule` (an `OrthRule`) renamed to `orth_rule` to avoid shadowing the newly renamed `rule` member.

**Commit 2 — fix pre-existing bugs (behavior change):**
- `setOrthogonalSpacing()` was calling `setOrthogonalSpacingValid()` twice. The second call should have been `setOrthogonalSpacing()`. The implicit int→bool conversion masked the error: the validity flag was set but the actual orthogonal spacing distance was never stored.
- `lefTechLayerMinStepParser::rule` and `lefTechLayerCutSpacingParser::rule` were declared without initialization. Both `parse()` paths have an `if (!valid && rule != nullptr)` check that is undefined behavior if `parse()` fails before the member is assigned. Default-initialized both to `nullptr`, matching the pattern already used by `lefTechLayerCutSpacingTableParser`.

**Commit 3 — fix typo:**
- `createOrthongonalSubRule` → `createOrthogonalSubRule` (transposed 'n' in "Orthongonal").

**Commit 4 — address Gemini re-review:**
- Rename `cut_class` → `cut_class_rule` for the rule-pointer local variable (3 sites), resolving ambiguity with class-name strings.
- Rename `cutclass` → `cut_class` in `addSameMetalSharedEdgeSubRule` for proper snake_case.

## Notes

- `clang-format` applied to all touched `.cpp` files; diff is clean.
- Bug fixes and typo fix are in separate commits from the rename to keep history clean for `git bisect`.

Fixes #2275