### PR TITLE
Bump Bazel infrastructure rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,15 +9,15 @@ module(
 
 bazel_dep(name = "abc", version = "0.62-yosyshq")
 bazel_dep(name = "abseil-cpp", version = "20260107.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "coin-or-lemon", version = "1.3.1")
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_bison", version = "0.3.1")
 bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "rules_flex", version = "0.3.1")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
-bazel_dep(name = "rules_python", version = "1.8.5")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "rules_python", version = "1.9.0")
+bazel_dep(name = "rules_shell", version = "0.7.1")
 bazel_dep(name = "swig", version = "4.3.0.bcr.2")
 
 BOOST_VERSION = "1.89.0.bcr.2"
@@ -72,7 +72,7 @@ bazel_dep(name = "yaml-cpp", version = "0.9.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 
 # JavaScript / web UI (src/web uses @npm for bundled assets)
-bazel_dep(name = "aspect_rules_js", version = "3.0.2")
+bazel_dep(name = "aspect_rules_js", version = "3.0.3")
 bazel_dep(name = "rules_nodejs", version = "6.7.3")
 
 # A from source build of QT that allows it to link into OpenROAD.


### PR DESCRIPTION
bazel_skylib 1.7.1 → 1.9.0
platforms 0.0.11 → 1.0.0
rules_python 1.8.5 → 1.9.0
rules_shell 0.6.1 → 0.7.1
aspect_rules_js 3.0.2 → 3.0.3

Pure build-rule upgrades with no C++ code or CMake impact. Reduces downstream MVS version conflicts.
