### PR TITLE
Bump build toolchains (bison, flex, LLVM)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,9 +12,9 @@ bazel_dep(name = "abseil-cpp", version = "20260107.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "coin-or-lemon", version = "1.3.1")
 bazel_dep(name = "platforms", version = "0.0.11")
-bazel_dep(name = "rules_bison", version = "0.3.1")
+bazel_dep(name = "rules_bison", version = "0.4.bcr.1")
 bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "rules_flex", version = "0.3.1")
+bazel_dep(name = "rules_flex", version = "0.4")
 bazel_dep(name = "rules_pkg", version = "1.2.0")
 bazel_dep(name = "rules_python", version = "1.8.5")
 bazel_dep(name = "rules_shell", version = "0.6.1")
@@ -93,7 +93,7 @@ git_override(
 ## The extension and toolchain registration are dev_dependency because
 ## toolchains_llvm enforces root-module-only extension usage.
 ## Downstream consumers must configure their own C++ toolchain.
-bazel_dep(name = "toolchains_llvm", version = "1.5.0")
+bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
 # --- Dev dependencies (not propagated to downstream consumers) ---
 


### PR DESCRIPTION
rules_bison 0.3.1 → 0.4.bcr.1
rules_flex 0.3.1 → 0.4
toolchains_llvm 1.5.0 → 1.7.0

If bison/flex toolchain provider API changed in 0.4, the custom bazel/bison.bzl and bazel/flex.bzl rules may need updating.
