### PR TITLE
bazel: make toolchains_llvm a dev_dependency

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,12 +88,8 @@ git_override(
 )
 
 ## Lock the compiler version and avoid any local compiler.
-## The bazel_dep stays non-dev because llvm_prebuilt's build_file
-## references @toolchains_llvm//toolchain:BUILD.llvm_repo.
-## The extension and toolchain registration are dev_dependency because
-## toolchains_llvm enforces root-module-only extension usage.
 ## Downstream consumers must configure their own C++ toolchain.
-bazel_dep(name = "toolchains_llvm", version = "1.5.0")
+bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 
 # --- Dev dependencies (not propagated to downstream consumers) ---
 


### PR DESCRIPTION
The bazel_dep was non-dev, forcing downstream Bazel consumers to inherit OpenROAD's pinned LLVM toolchain. This conflicts when consumers configure their own C++ toolchain.

The extension and toolchain registration were already dev_dependency. Making the bazel_dep dev_dependency too keeps it consistent and invisible to downstream modules. The llvm_prebuilt build_file reference works because dev deps are still resolved for the declaring module's own build.
