### PR TITLE
grt: add CUGR global_route_debug -st visualization support

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -269,6 +269,12 @@ class GlobalRouter
   void initDebugFastRoute(std::unique_ptr<AbstractFastRouteRenderer> renderer);
   AbstractFastRouteRenderer* getDebugFastRoute() const;
 
+  void initDebugCUGR(std::unique_ptr<AbstractFastRouteRenderer> renderer);
+  AbstractFastRouteRenderer* getDebugCUGR() const;
+  
+  bool hasCUGR() const { return cugr_ != nullptr; }
+  bool hasFastRoute() const { return fastroute_ != nullptr; }
+
   void setDebugNet(const odb::dbNet* net);
   void setDebugSteinerTree(bool steinerTree);
   void setDebugRectilinearSTree(bool rectilinearSTree);

--- a/src/grt/src/GlobalRouter-py.i
+++ b/src/grt/src/GlobalRouter-py.i
@@ -14,7 +14,9 @@ using namespace grt;
 
 %ignore grt::GlobalRouter::init;
 %ignore grt::GlobalRouter::initDebugFastRoute;
+%ignore grt::GlobalRouter::initDebugCUGR;
 %ignore grt::GlobalRouter::getDebugFastRoute;
+%ignore grt::GlobalRouter::getDebugCUGR;
 %ignore grt::GlobalRouter::setRenderer;
 %ignore grt::GlobalRouter::initGui;
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -5751,33 +5751,83 @@ void GlobalRouter::initDebugFastRoute(
 {
   fastroute_->setDebugOn(std::move(renderer));
 }
+AbstractFastRouteRenderer* GlobalRouter::getDebugCUGR() const
+{
+  if (cugr_) {
+    return cugr_->getDebugRenderer();
+  }
+  return nullptr;
+}
+
+void GlobalRouter::initDebugCUGR(
+    std::unique_ptr<AbstractFastRouteRenderer> renderer)
+{
+  if (cugr_) {
+    cugr_->setDebugOn(std::move(renderer));
+  }
+}
 AbstractFastRouteRenderer* GlobalRouter::getDebugFastRoute() const
 {
   return fastroute_->fastrouteRender();
 }
 void GlobalRouter::setDebugSteinerTree(bool steinerTree)
 {
-  fastroute_->setDebugSteinerTree(steinerTree);
+  if (fastroute_) {
+    fastroute_->setDebugSteinerTree(steinerTree);
+  }
+  if (cugr_) {
+    cugr_->setDebugSteinerTree(steinerTree);
+  }
 }
+
 void GlobalRouter::setDebugNet(const odb::dbNet* net)
 {
-  fastroute_->setDebugNet(net);
+  if (fastroute_) {
+    fastroute_->setDebugNet(net);
+  }
+  if (cugr_) {
+    cugr_->setDebugNet(net);
+  }
 }
+
 void GlobalRouter::setDebugRectilinearSTree(bool rectilinearSTree)
 {
-  fastroute_->setDebugRectilinearSTree(rectilinearSTree);
+  if (fastroute_) {
+    fastroute_->setDebugRectilinearSTree(rectilinearSTree);
+  }
+  if (cugr_) {
+    cugr_->setDebugRectilinearSTree(rectilinearSTree);
+  }
 }
+
 void GlobalRouter::setDebugTree2D(bool tree2D)
 {
-  fastroute_->setDebugTree2D(tree2D);
+  if (fastroute_) {
+    fastroute_->setDebugTree2D(tree2D);
+  }
+  if (cugr_) {
+    cugr_->setDebugTree2D(tree2D);
+  }
 }
+
 void GlobalRouter::setDebugTree3D(bool tree3D)
 {
-  fastroute_->setDebugTree3D(tree3D);
+  if (fastroute_) {
+    fastroute_->setDebugTree3D(tree3D);
+  }
+  if (cugr_) {
+    cugr_->setDebugTree3D(tree3D);
+  }
 }
+
 void GlobalRouter::setSttInputFilename(const char* file_name)
 {
-  fastroute_->setSttInputFilename(file_name);
+  if (fastroute_) {
+    fastroute_->setSttInputFilename(file_name);
+  }
+  if (cugr_) {
+    cugr_->setSttInputFilename(file_name);
+  }
 }
 
 // For rsz::makeBufferedNetGlobalRoute so Pin/Net classes do not have to be

--- a/src/grt/src/GlobalRouter.i
+++ b/src/grt/src/GlobalRouter.i
@@ -22,7 +22,9 @@ using sta::LibertyPort;
 
 %ignore grt::GlobalRouter::init;
 %ignore grt::GlobalRouter::initDebugFastRoute;
+%ignore grt::GlobalRouter::initDebugCUGR;
 %ignore grt::GlobalRouter::getDebugFastRoute;
+%ignore grt::GlobalRouter::getDebugCUGR;
 %ignore grt::GlobalRouter::setRenderer;
 
 %import <stl.i>
@@ -232,9 +234,18 @@ void set_global_route_debug_cmd(const odb::dbNet *net,
   }
 
   GlobalRouter* global_router = getGlobalRouter();
-  if (global_router->getDebugFastRoute() == nullptr) {
-    global_router->initDebugFastRoute(std::make_unique<FastRouteRenderer>(
-      global_router->db()->getTech()));
+
+  if (global_router->hasFastRoute()) {
+    if (global_router->getDebugFastRoute() == nullptr) {
+      global_router->initDebugFastRoute(
+          std::make_unique<FastRouteRenderer>(global_router->db()->getTech()));
+    }
+  }
+  if (global_router->hasCUGR()) {
+    if (global_router->getDebugCUGR() == nullptr) {
+      global_router->initDebugCUGR(
+          std::make_unique<FastRouteRenderer>(global_router->db()->getTech()));
+    }
   }
   getGlobalRouter()->setDebugNet(net);
   getGlobalRouter()->setDebugSteinerTree(steinerTree);

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -25,6 +25,7 @@ class dbNetwork;
 
 namespace stt {
 class SteinerTreeBuilder;
+struct Tree;
 }  // namespace stt
 
 namespace utl {
@@ -34,10 +35,17 @@ class CallBackHandler;
 
 namespace grt {
 
+class AbstractFastRouteRenderer;
 class Design;
 class GridGraph;
 class GRNet;
 class BoxT;
+
+struct StTree;
+struct FrNet;
+
+// DebugSetting is defined in fastroute/include/FastRoute.h
+struct DebugSetting;
 
 struct Constants
 {
@@ -95,6 +103,19 @@ class CUGR
   void updateNet(odb::dbNet* net);
   void routeIncremental();
 
+  // Debug functions 
+  void setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer); 
+  void setDebugNet(const odb::dbNet* net);
+  void setDebugSteinerTree(bool steinerTree);
+  void setDebugRectilinearSTree(bool rectilinearSTree); 
+  void setDebugTree2D(bool tree2D); 
+  void setDebugTree3D(bool tree3D);
+  void setSttInputFilename(const char* file_name);
+  std::string getSttInputFileName();
+  AbstractFastRouteRenderer* getDebugRenderer() const;
+  const odb::dbNet* getDebugNet();
+  bool hasSaveSttInput();
+
  private:
   float calculatePartialSlack();
   float getNetSlack(odb::dbNet* net);
@@ -107,6 +128,12 @@ class CUGR
   void getGuides(const GRNet* net,
                  std::vector<std::pair<int, grt::BoxT>>& guides);
   void printStatistics() const;
+
+  void steinerTreeVisualization(const stt::Tree& stree, GRNet* net);
+  void StTreeVisualization(const StTree& stree,
+                           GRNet* net,
+                           bool is3DVisualization);
+  void FrNetInit(GRNet* net, FrNet* frnet);
 
   std::unique_ptr<Design> design_;
   std::unique_ptr<GridGraph> grid_graph_;
@@ -129,6 +156,8 @@ class CUGR
   float critical_nets_percentage_ = 0;
 
   std::vector<int> nets_to_route_;
+
+  std::unique_ptr<DebugSetting> debug_;
 };
 
 }  // namespace grt

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -36,6 +36,10 @@
 #include "utl/CallBackHandler.h"
 #include "utl/Logger.h"
 
+#include "../../fastroute/include/FastRoute.h"
+#include "../../fastroute/include/AbstractFastRouteRenderer.h"
+#include "../../fastroute/include/DataType.h"
+
 using utl::GRT;
 
 namespace grt {
@@ -49,7 +53,8 @@ CUGR::CUGR(odb::dbDatabase* db,
       logger_(log),
       callback_handler_(callback_handler),
       stt_builder_(stt_builder),
-      sta_(sta)
+      sta_(sta),
+      debug_(std::make_unique<DebugSetting>())
 {
 }
 
@@ -159,6 +164,14 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
                                constants_,
                                logger_);
     pattern_route.constructSteinerTree();
+    
+    GRNet* net = gr_nets_[net_index].get();
+    if  (debug_->isOn() && debug_->steinerTree && net->getDbNet() == debug_->net && pattern_route.hasSttTree()) {
+                
+                steinerTreeVisualization(pattern_route.getSttTree(), net);
+
+        } 
+
     pattern_route.constructRoutingDAG();
     pattern_route.run();
     grid_graph_->addTreeUsage(gr_nets_[net_index]->getRoutingTree());
@@ -260,6 +273,22 @@ void CUGR::route()
     for (const auto& net : gr_nets_) {
       net_indices.push_back(net->getIndex());
     }
+  }
+
+  if (debug_->isOn()) {
+    const int x_corner = grid_graph_->getGridline(0, 0);
+    const int y_corner = grid_graph_->getGridline(1, 0);
+    int tile_size = 0;
+    if (grid_graph_->getXSize() > 0) {
+      tile_size = grid_graph_->getGridline(0, 1) - x_corner;
+    }
+    if (tile_size <= 0 && grid_graph_->getYSize() > 0) {
+      tile_size = grid_graph_->getGridline(1, 1) - y_corner;
+    }
+    if (tile_size <= 0) {
+      tile_size = std::max(1, grid_graph_->getM2Pitch());
+    }
+    debug_->renderer->setGridVariables(tile_size, x_corner, y_corner);
   }
 
   patternRoute(net_indices);
@@ -695,6 +724,124 @@ void CUGR::routeIncremental()
   }
 
   printStatistics();
+}
+//debug functions 
+void CUGR::setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer) 
+{
+  debug_->renderer = std::move(renderer);
+}
+void CUGR::setDebugNet(const odb::dbNet* net) 
+{
+  debug_->net = net;
+}
+void CUGR::setDebugSteinerTree(bool steinerTree) 
+{
+  debug_->steinerTree = steinerTree;
+}
+void CUGR::setDebugRectilinearSTree(bool rectilinearSTree)
+{
+  debug_->rectilinearSTree = rectilinearSTree;
+}
+void CUGR::setDebugTree2D(bool tree2D)
+{
+  debug_->tree2D = tree2D;
+}
+void CUGR::setDebugTree3D(bool tree3D)
+{
+  debug_->tree3D = tree3D;
+}
+void CUGR::setSttInputFilename(const char* file_name) 
+{
+  debug_->sttInputFileName = std::string(file_name);
+}
+
+AbstractFastRouteRenderer* CUGR::getDebugRenderer() const
+{
+  if (debug_ && debug_->renderer) {
+    return debug_->renderer.get();
+  }
+  return nullptr;
+}
+std::string CUGR::getSttInputFileName()
+{
+  return debug_->sttInputFileName;
+}
+const odb::dbNet* CUGR::getDebugNet()
+{
+  return debug_->net;
+}
+bool CUGR::hasSaveSttInput()
+{
+  return !debug_->sttInputFileName.empty();
+}
+
+void CUGR::steinerTreeVisualization(const stt::Tree& stree, GRNet* net) 
+{
+  if (!debug_->isOn()) {
+    return;
+  }
+
+  // Create FrNet wrapper as renderer expects FrNet*
+  FrNet frnet;
+  bool is_clock = (net->getDbNet()->getSigType() == odb::dbSigType::CLOCK);
+
+  frnet.reset(net->getDbNet(),
+              is_clock,
+              0,
+              0,
+              constants_.min_routing_layer,
+              grid_graph_->getNumLayers() - 1,
+              0.0,
+              nullptr);
+
+  FrNetInit(net, &frnet);
+  
+  debug_->renderer->highlight(&frnet);
+  debug_->renderer->setIs3DVisualization(false);
+  debug_->renderer->setSteinerTree(stree);
+  debug_->renderer->setTreeStructure(grt::TreeStructure::steinerTreeByStt);
+  debug_->renderer->redrawAndPause();
+  debug_->renderer->highlight(nullptr);
+
+}
+
+void CUGR::StTreeVisualization(const StTree& stree, GRNet* net, bool is3DVisualization)
+{
+  if (!debug_->isOn()) {
+    return;
+  }
+  
+  // Create FrNet wrapper as renderer expects FrNet*
+  FrNet frnet;
+  bool is_clock = (net->getDbNet()->getSigType() == odb::dbSigType::CLOCK);
+
+  frnet.reset(net->getDbNet(),
+              is_clock,
+              0,
+              0,
+              constants_.min_routing_layer,
+              grid_graph_->getNumLayers() - 1,
+              0.0,
+              nullptr);
+
+  FrNetInit(net, &frnet);
+
+  debug_->renderer->highlight(&frnet);
+  debug_->renderer->setIs3DVisualization(is3DVisualization);
+  debug_->renderer->setStTreeValues(stree);
+  debug_->renderer->setTreeStructure(grt::TreeStructure::steinerTreeByFastroute);
+  debug_->renderer->redrawAndPause();
+  debug_->renderer->highlight(nullptr);
+}
+
+void CUGR::FrNetInit(GRNet* net, FrNet* frnet)
+{
+  for (const auto& pin_aps : net->getPinAccessPoints()) {
+    if (!pin_aps.empty()) {
+      const auto& ap = pin_aps[0];
+      frnet->addPin(ap.x(), ap.y(), ap.getLayerIdx());
+    }
+  }
 }
 
 }  // namespace grt

--- a/src/grt/src/cugr/src/PatternRoute.cpp
+++ b/src/grt/src/cugr/src/PatternRoute.cpp
@@ -79,6 +79,8 @@ std::string PatternRoutingNode::getPythonString(
 
 void PatternRoute::constructSteinerTree()
 {
+  stt_tree_valid_ = false;
+
   auto selected_access_points = grid_graph_->selectAccessPoints(net_);
 
   const int degree = selected_access_points.size();
@@ -86,6 +88,7 @@ void PatternRoute::constructSteinerTree()
     const auto& access_point = *selected_access_points.begin();
     steiner_tree_ = std::make_shared<SteinerTreeNode>(access_point.point,
                                                       access_point.layers);
+    stt_tree_valid_ = true;
     return;
   }
 
@@ -108,6 +111,8 @@ void PatternRoute::constructSteinerTree()
   }
 
   stt::Tree flute_tree = stt_builder_->flute(xs, ys, flute_accuracy_);
+  stt_tree_ = flute_tree;
+  stt_tree_valid_ = true;
   const int num_branches = degree + degree - 2;
   std::vector<PointT> steiner_points;
   steiner_points.reserve(num_branches);

--- a/src/grt/src/cugr/src/PatternRoute.h
+++ b/src/grt/src/cugr/src/PatternRoute.h
@@ -11,6 +11,8 @@
 #include "GRTree.h"
 #include "GridGraph.h"
 #include "geo.h"
+#include "stt/SteinerTreeBuilder.h"
+
 
 namespace grt {
 
@@ -167,6 +169,9 @@ class PatternRoute
     return routing_dag_;
   }
 
+  const stt::Tree& getSttTree() const { return stt_tree_; }
+  bool hasSttTree() const { return stt_tree_valid_; }
+
  private:
   void constructPaths(std::shared_ptr<PatternRoutingNode>& start,
                       std::shared_ptr<PatternRoutingNode>& end,
@@ -183,6 +188,9 @@ class PatternRoute
   std::shared_ptr<SteinerTreeNode> steiner_tree_;
   std::shared_ptr<PatternRoutingNode> routing_dag_;
   std::vector<std::vector<int>> gridlines_;
+
+  stt::Tree stt_tree_;
+  bool stt_tree_valid_{false};
 
   Constants constants_;
   const int flute_accuracy_ = 3;

--- a/src/grt/src/cugr/tags
+++ b/src/grt/src/cugr/tags
@@ -1,0 +1,1940 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
+!_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
+!_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
+!_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
+!_TAG_PROC_CWD	/home/hans/OpenROAD/src/grt/src/cugr/	//
+!_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
+!_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
+!_TAG_PROGRAM_URL	https://ctags.io/	/official site/
+!_TAG_PROGRAM_VERSION	5.9.0	//
+1. License	README.md	/^## 1. License$/;"	s	chapter:CUGR 2.0
+ALIGNED_SIZE	src/robin_hood.h	/^  static constexpr size_t ALIGNED_SIZE$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:size_t	access:private
+ALIGNMENT	src/robin_hood.h	/^  static const size_t ALIGNMENT$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:const size_t	access:private
+ALIGNMENT	src/robin_hood.h	/^  static constexpr size_t ALIGNMENT$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:size_t	access:private
+AccessPoint	src/GridGraph.h	/^struct AccessPoint$/;"	s	namespace:grt
+AccessPointEqual	src/GridGraph.h	/^struct AccessPointEqual$/;"	s	namespace:grt
+AccessPointHash	src/GridGraph.h	/^  AccessPointHash(int y_size) : y_size_(y_size) {}$/;"	f	class:grt::AccessPointHash	access:public	signature:(int y_size)
+AccessPointHash	src/GridGraph.h	/^class AccessPointHash$/;"	c	namespace:grt
+AccessPointSet	src/GridGraph.h	/^using AccessPointSet$/;"	t	namespace:grt	typeref:typename:robin_hood::unordered_set<AccessPoint,AccessPointHash,AccessPointEqual>
+BoxOnLayer	src/GeoTypes.h	/^  BoxOnLayer(int layer_index = -1, Args... params)$/;"	f	class:grt::BoxOnLayer	access:public	signature:(int layer_index=-1,Args...params)
+BoxOnLayer	src/GeoTypes.h	/^class BoxOnLayer : public BoxT$/;"	c	namespace:grt	inherits:BoxT
+BoxT	src/geo.h	/^  BoxT() { set(); }$/;"	f	class:grt::BoxT	access:public	signature:()
+BoxT	src/geo.h	/^  BoxT(const BoxT& box) { set(box); }$/;"	f	class:grt::BoxT	access:public	signature:(const BoxT & box)
+BoxT	src/geo.h	/^  BoxT(const IntervalT& x_range, const IntervalT& y_range)$/;"	f	class:grt::BoxT	access:public	signature:(const IntervalT & x_range,const IntervalT & y_range)
+BoxT	src/geo.h	/^  BoxT(const PointT& low, const PointT& high) { set(low, high); }$/;"	f	class:grt::BoxT	access:public	signature:(const PointT & low,const PointT & high)
+BoxT	src/geo.h	/^  BoxT(const PointT& pt) { set(pt); }$/;"	f	class:grt::BoxT	access:public	signature:(const PointT & pt)
+BoxT	src/geo.h	/^  BoxT(int lx, int ly, int hx, int hy) { set(lx, ly, hx, hy); }$/;"	f	class:grt::BoxT	access:public	signature:(int lx,int ly,int hx,int hy)
+BoxT	src/geo.h	/^  BoxT(int x_val, int y_val) { set(x_val, y_val); }$/;"	f	class:grt::BoxT	access:public	signature:(int x_val,int y_val)
+BoxT	src/geo.h	/^class BoxT$/;"	c	namespace:grt
+BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator($/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:(const BulkPoolAllocator & ROBIN_HOOD_UNUSED (o))
+BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator() noexcept = default;$/;"	p	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:()
+BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator(BulkPoolAllocator&& o) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:(BulkPoolAllocator && o)
+BulkPoolAllocator	src/robin_hood.h	/^class BulkPoolAllocator$/;"	c	namespace:robin_hood::detail
+CUGR	CMakeLists.txt	/^add_library(CUGR$/;"	t
+CUGR	include/CUGR.h	/^  CUGR(odb::dbDatabase* db,$/;"	p	class:grt::CUGR	access:public	signature:(odb::dbDatabase * db,utl::Logger * log,utl::CallBackHandler * callback_handler,stt::SteinerTreeBuilder * stt_builder,sta::dbSta * sta)
+CUGR	include/CUGR.h	/^class CUGR$/;"	c	namespace:grt
+CUGR	src/CUGR.cpp	/^CUGR::CUGR(odb::dbDatabase* db,$/;"	f	class:grt::CUGR	signature:(odb::dbDatabase * db,utl::Logger * log,utl::CallBackHandler * callback_handler,stt::SteinerTreeBuilder * stt_builder,sta::dbSta * sta)
+CUGR 2.0	README.md	/^CUGR 2.0$/;"	c
+CUGRNet	src/Netlist.cpp	/^CUGRNet::CUGRNet(const int index,$/;"	f	class:grt::CUGRNet	signature:(const int index,odb::dbNet * db_net,const std::vector<CUGRPin> & pins,LayerRange layer_range)
+CUGRNet	src/Netlist.h	/^  CUGRNet(int index,$/;"	p	class:grt::CUGRNet	access:public	signature:(int index,odb::dbNet * db_net,const std::vector<CUGRPin> & pins,LayerRange layer_range)
+CUGRNet	src/Netlist.h	/^class CUGRNet$/;"	c	namespace:grt
+CUGRPin	src/Netlist.cpp	/^CUGRPin::CUGRPin(const int index,$/;"	f	class:grt::CUGRPin	signature:(const int index,odb::dbBTerm * bterm,const std::vector<BoxOnLayer> & pin_shapes)
+CUGRPin	src/Netlist.cpp	/^CUGRPin::CUGRPin(const int index,$/;"	f	class:grt::CUGRPin	signature:(const int index,odb::dbITerm * iterm,const std::vector<BoxOnLayer> & pin_shapes)
+CUGRPin	src/Netlist.h	/^  CUGRPin(int index,$/;"	p	class:grt::CUGRPin	access:public	signature:(int index,odb::dbBTerm * bterm,const std::vector<BoxOnLayer> & pin_shapes)
+CUGRPin	src/Netlist.h	/^  CUGRPin(int index,$/;"	p	class:grt::CUGRPin	access:public	signature:(int index,odb::dbITerm * iterm,const std::vector<BoxOnLayer> & pin_shapes)
+CUGRPin	src/Netlist.h	/^class CUGRPin$/;"	c	namespace:grt
+CapacityT	src/GridGraph.h	/^using CapacityT = double;$/;"	t	namespace:grt	typeref:typename:double
+Cloner	src/robin_hood.h	/^  struct Cloner<M, false>$/;"	s	class:robin_hood::detail::Table	access:private
+Cloner	src/robin_hood.h	/^  struct Cloner<M, true>$/;"	s	class:robin_hood::detail::Table	access:private
+Constants	include/CUGR.h	/^struct Constants$/;"	s	namespace:grt
+CostT	src/Design.h	/^using CostT = double;$/;"	t	namespace:grt	typeref:typename:double
+Counts	src/robin_hood.h	/^struct Counts$/;"	s	namespace:robin_hood
+DataNode	src/robin_hood.h	/^    DataNode(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),DataNode<M,false> && n)
+DataNode	src/robin_hood.h	/^    DataNode(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),DataNode<M,true> && n)
+DataNode	src/robin_hood.h	/^    explicit DataNode($/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),Args &&...args)
+DataNode	src/robin_hood.h	/^    explicit DataNode(M& map, Args&&... args) : mData(map.allocate())$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & map,Args &&...args)
+DataNode	src/robin_hood.h	/^  class DataNode$/;"	c	class:robin_hood::detail::Table	access:private
+DataNode	src/robin_hood.h	/^  class DataNode<M, false>$/;"	c	class:robin_hood::detail::Table	access:private
+DataNode	src/robin_hood.h	/^  class DataNode<M, true> final$/;"	c	class:robin_hood::detail::Table	access:private
+DataPool	src/robin_hood.h	/^  using DataPool = detail::NodeAllocator<value_type, 4, 16384, IsFlat>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:detail::NodeAllocator<value_type,4,16384,IsFlat>	access:private
+Design	src/Design.cpp	/^Design::Design(odb::dbDatabase* db,$/;"	f	class:grt::Design	signature:(odb::dbDatabase * db,utl::Logger * logger,const Constants & constants,const int min_routing_layer,const int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+Design	src/Design.h	/^  Design(odb::dbDatabase* db,$/;"	p	class:grt::Design	access:public	signature:(odb::dbDatabase * db,utl::Logger * logger,const Constants & constants,int min_routing_layer,int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+Design	src/Design.h	/^class Design$/;"	c	namespace:grt
+Destroyer	src/robin_hood.h	/^  struct Destroyer$/;"	s	class:robin_hood::detail::Table	access:private
+Destroyer	src/robin_hood.h	/^  struct Destroyer<M, false>$/;"	s	class:robin_hood::detail::Table	access:private
+Destroyer	src/robin_hood.h	/^  struct Destroyer<M, true>$/;"	s	class:robin_hood::detail::Table	access:private
+GRNet	src/GRNet.cpp	/^GRNet::GRNet(const CUGRNet& base_net, const GridGraph* grid_graph)$/;"	f	class:grt::GRNet	signature:(const CUGRNet & base_net,const GridGraph * grid_graph)
+GRNet	src/GRNet.h	/^  GRNet(const CUGRNet& base_net, const GridGraph* grid_graph);$/;"	p	class:grt::GRNet	access:public	signature:(const CUGRNet & base_net,const GridGraph * grid_graph)
+GRNet	src/GRNet.h	/^class GRNet$/;"	c	namespace:grt
+GRPoint	src/GRTree.h	/^  GRPoint(int l, int x, int y) : PointT(x, y), layer_idx_(l) {}$/;"	f	class:grt::GRPoint	access:public	signature:(int l,int x,int y)
+GRPoint	src/GRTree.h	/^class GRPoint : public PointT$/;"	c	namespace:grt	inherits:PointT
+GRTreeNode	src/GRTree.h	/^  GRTreeNode(const GRPoint& point) : GRPoint(point) {}$/;"	f	class:grt::GRTreeNode	access:public	signature:(const GRPoint & point)
+GRTreeNode	src/GRTree.h	/^  GRTreeNode(int l, int x, int y) : GRPoint(l, x, y) {}$/;"	f	class:grt::GRTreeNode	access:public	signature:(int l,int x,int y)
+GRTreeNode	src/GRTree.h	/^class GRTreeNode : public GRPoint$/;"	c	namespace:grt	inherits:GRPoint
+GraphEdge	src/GridGraph.h	/^struct GraphEdge$/;"	s	namespace:grt
+GridGraph	src/GridGraph.cpp	/^GridGraph::GridGraph(const Design* design,$/;"	f	class:grt::GridGraph	signature:(const Design * design,const Constants & constants,utl::Logger * logger)
+GridGraph	src/GridGraph.h	/^  GridGraph(const Design* design,$/;"	p	class:grt::GridGraph	access:public	signature:(const Design * design,const Constants & constants,utl::Logger * logger)
+GridGraph	src/GridGraph.h	/^class GridGraph$/;"	c	namespace:grt
+GridGraphView	src/GridGraph.h	/^class GridGraphView : public std::vector<std::vector<std::vector<Type>>>$/;"	c	namespace:grt	inherits:std::vector<std::vector<std::vector<Type>>>
+H	src/Layers.h	/^  const static int H = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:const int	access:public
+InfoMask	src/robin_hood.h	/^  static constexpr size_t InfoMask = InitialInfoInc - 1U;$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+InfoType	src/robin_hood.h	/^  using InfoType = uint32_t;$/;"	t	class:robin_hood::detail::Table	typeref:typename:uint32_t	access:private
+InitialInfoHashShift	src/robin_hood.h	/^  static constexpr uint8_t InitialInfoHashShift = 0;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t	access:private
+InitialInfoInc	src/robin_hood.h	/^  static constexpr uint8_t InitialInfoInc = 1U << InitialInfoNumBits;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t	access:private
+InitialInfoNumBits	src/robin_hood.h	/^  static constexpr uint32_t InitialInfoNumBits = 5;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint32_t	access:private
+InitialNumElements	src/robin_hood.h	/^  static constexpr size_t InitialNumElements = sizeof(uint64_t);$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+InsertionState	src/robin_hood.h	/^  enum class InsertionState$/;"	g	class:robin_hood::detail::Table	access:private
+IntervalT	src/geo.h	/^  IntervalT() { set(); }$/;"	f	class:grt::IntervalT	access:public	signature:()
+IntervalT	src/geo.h	/^  IntervalT(int lo, int hi) { set(lo, hi); }$/;"	f	class:grt::IntervalT	access:public	signature:(int lo,int hi)
+IntervalT	src/geo.h	/^  IntervalT(int val) { set(val); }$/;"	f	class:grt::IntervalT	access:public	signature:(int val)
+IntervalT	src/geo.h	/^class IntervalT$/;"	c	namespace:grt
+Iter	src/robin_hood.h	/^    Iter() = default;$/;"	p	class:robin_hood::detail::Table::Iter	access:public	signature:()
+Iter	src/robin_hood.h	/^    Iter(Iter<OtherIsConst> const& other) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(Iter<OtherIsConst> const & other)
+Iter	src/robin_hood.h	/^    Iter(NodePtr valPtr, uint8_t const* infoPtr) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(NodePtr valPtr,uint8_t const * infoPtr)
+Iter	src/robin_hood.h	/^    Iter(NodePtr valPtr,$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(NodePtr valPtr,uint8_t const * infoPtr,fast_forward_tag ROBIN_HOOD_UNUSED (tag))
+Iter	src/robin_hood.h	/^  class Iter$/;"	c	class:robin_hood::detail::Table	access:private
+LayerRange	src/Netlist.h	/^struct LayerRange$/;"	s	namespace:grt
+MazeRoute	src/MazeRoute.h	/^  MazeRoute(GRNet* net, const GridGraph* graph, utl::Logger* logger)$/;"	f	class:grt::MazeRoute	access:public	signature:(GRNet * net,const GridGraph * graph,utl::Logger * logger)
+MazeRoute	src/MazeRoute.h	/^class MazeRoute$/;"	c	namespace:grt
+MetalLayer	src/Layers.cpp	/^MetalLayer::MetalLayer(odb::dbTechLayer* tech_layer,$/;"	f	class:grt::MetalLayer	signature:(odb::dbTechLayer * tech_layer,odb::dbTrackGrid * track_grid)
+MetalLayer	src/Layers.h	/^  MetalLayer(odb::dbTechLayer* tech_layer, odb::dbTrackGrid* track_grid);$/;"	p	class:grt::MetalLayer	access:public	signature:(odb::dbTechLayer * tech_layer,odb::dbTrackGrid * track_grid)
+MetalLayer	src/Layers.h	/^class MetalLayer$/;"	c	namespace:grt
+Node	src/robin_hood.h	/^  using Node = DataNode<Self, IsFlat>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:DataNode<Self,IsFlat>	access:private
+NodeAllocator	src/robin_hood.h	/^struct NodeAllocator<T, MinSize, MaxSize, false>$/;"	s	namespace:robin_hood::detail	inherits:BulkPoolAllocator<T,MinSize,MaxSize>
+NodeAllocator	src/robin_hood.h	/^struct NodeAllocator<T, MinSize, MaxSize, true>$/;"	s	namespace:robin_hood::detail
+NodePtr	src/robin_hood.h	/^    using NodePtr = typename std::conditional_t<IsConst, Node const*, Node*>;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,Node const *,Node * >	access:private
+PatternRoute	src/PatternRoute.h	/^  PatternRoute(GRNet* net,$/;"	f	class:grt::PatternRoute	access:public	signature:(GRNet * net,const GridGraph * graph,stt::SteinerTreeBuilder * stt_builder,const Constants & constants,utl::Logger * logger)
+PatternRoute	src/PatternRoute.h	/^class PatternRoute$/;"	c	namespace:grt
+PatternRoutingNode	src/PatternRoute.h	/^  PatternRoutingNode(const PointT& point,$/;"	f	class:grt::PatternRoutingNode	access:public	signature:(const PointT & point,const IntervalT & fixed_layers,const int index=0)
+PatternRoutingNode	src/PatternRoute.h	/^  PatternRoutingNode(const PointT& point,$/;"	f	class:grt::PatternRoutingNode	access:public	signature:(const PointT & point,const int index,const bool optional=false)
+PatternRoutingNode	src/PatternRoute.h	/^class PatternRoutingNode : public PointT$/;"	c	namespace:grt	inherits:PointT
+PointT	src/geo.h	/^  PointT() = default;$/;"	p	class:grt::PointT	access:public	signature:()
+PointT	src/geo.h	/^  PointT(int x, int y) : x_(x), y_(y) {}$/;"	f	class:grt::PointT	access:public	signature:(int x,int y)
+PointT	src/geo.h	/^class PointT$/;"	c	namespace:grt
+ROBIN_HOOD	src/robin_hood.h	/^    ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) bool empty() const noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t calcNumBytesTotal(size_t numElements) const$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t calcNumElementsToAlloc() const noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:private	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t mask() const noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table	access:private	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NOINLINE) T* performAllocation()$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:private	signature:(NOINLINE)
+ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NOINLINE) void throwOverflowError() const$/;"	f	class:robin_hood::detail::Table	access:private	signature:(NOINLINE)
+ROBIN_HOOD	src/robin_hood.h	/^#define ROBIN_HOOD(/;"	d	signature:(x)
+ROBIN_HOOD	src/robin_hood.h	/^[[noreturn]] ROBIN_HOOD(NOINLINE)$/;"	f	namespace:robin_hood::detail	signature:(NOINLINE)
+ROBIN_HOOD_COUNT	src/robin_hood.h	/^#define ROBIN_HOOD_COUNT(/;"	d	signature:(x)
+ROBIN_HOOD_COUNT_LEADING_ZEROES	src/robin_hood.h	/^#define ROBIN_HOOD_COUNT_LEADING_ZEROES(/;"	d	signature:(x)
+ROBIN_HOOD_COUNT_TRAILING_ZEROES	src/robin_hood.h	/^#define ROBIN_HOOD_COUNT_TRAILING_ZEROES(/;"	d	signature:(x)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^#define ROBIN_HOOD_HASH_INT(/;"	d	signature:(T)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(bool);$/;"	p	namespace:robin_hood	signature:(bool)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char);$/;"	p	namespace:robin_hood	signature:(char)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char16_t);$/;"	p	namespace:robin_hood	signature:(char16_t)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char32_t);$/;"	p	namespace:robin_hood	signature:(char32_t)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(int);$/;"	p	namespace:robin_hood	signature:(int)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(long long);$/;"	p	namespace:robin_hood	signature:(long long)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(long);$/;"	p	namespace:robin_hood	signature:(long)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(short);$/;"	p	namespace:robin_hood	signature:(short)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(signed char);$/;"	p	namespace:robin_hood	signature:(signed char)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned char);$/;"	p	namespace:robin_hood	signature:(unsigned char)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned int);$/;"	p	namespace:robin_hood	signature:(unsigned int)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned long long);$/;"	p	namespace:robin_hood	signature:(unsigned long long)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned long);$/;"	p	namespace:robin_hood	signature:(unsigned long)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned short);$/;"	p	namespace:robin_hood	signature:(unsigned short)
+ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(wchar_t);$/;"	p	namespace:robin_hood	signature:(wchar_t)
+ROBIN_HOOD_H_INCLUDED	src/robin_hood.h	/^#define ROBIN_HOOD_H_INCLUDED$/;"	d
+ROBIN_HOOD_IS_TRIVIALLY_COPYABLE	src/robin_hood.h	/^#define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(/;"	d	signature:(...)
+ROBIN_HOOD_LIKELY	src/robin_hood.h	/^#define ROBIN_HOOD_LIKELY(/;"	d	signature:(condition)
+ROBIN_HOOD_LOG	src/robin_hood.h	/^#define ROBIN_HOOD_LOG(/;"	d	signature:(...)
+ROBIN_HOOD_LOG	src/robin_hood.h	/^#define ROBIN_HOOD_LOG(/;"	d	signature:(x)
+ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CLZ	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CLZ(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CTZ	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CXX	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CXX11	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX11(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CXX14	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX14(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CXX17	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX17(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_CXX98	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX98(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD(/;"	d	signature:()
+ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE	src/robin_hood.h	/^#define ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE(/;"	d	signature:()
+ROBIN_HOOD_STD	src/robin_hood.h	/^#define ROBIN_HOOD_STD /;"	d
+ROBIN_HOOD_TRACE	src/robin_hood.h	/^#define ROBIN_HOOD_TRACE(/;"	d	signature:(...)
+ROBIN_HOOD_TRACE	src/robin_hood.h	/^#define ROBIN_HOOD_TRACE(/;"	d	signature:(x)
+ROBIN_HOOD_UNLIKELY	src/robin_hood.h	/^#define ROBIN_HOOD_UNLIKELY(/;"	d	signature:(condition)
+ROBIN_HOOD_UNUSED	src/robin_hood.h	/^#define ROBIN_HOOD_UNUSED(/;"	d	signature:(identifier)
+ROBIN_HOOD_VERSION_MAJOR	src/robin_hood.h	/^#define ROBIN_HOOD_VERSION_MAJOR /;"	d
+ROBIN_HOOD_VERSION_MINOR	src/robin_hood.h	/^#define ROBIN_HOOD_VERSION_MINOR /;"	d
+ROBIN_HOOD_VERSION_PATCH	src/robin_hood.h	/^#define ROBIN_HOOD_VERSION_PATCH /;"	d
+ScaffoldNode	src/PatternRoute.cpp	/^    ScaffoldNode(std::shared_ptr<PatternRoutingNode> n) : node(std::move(n)) {}$/;"	f	struct:grt::PatternRoute::constructDetours::ScaffoldNode	file:	access:public	signature:(std::shared_ptr<PatternRoutingNode> n)
+ScaffoldNode	src/PatternRoute.cpp	/^  struct ScaffoldNode$/;"	s	function:grt::PatternRoute::constructDetours	file:
+Self	src/robin_hood.h	/^  using Self = Table<IsFlat,$/;"	t	class:robin_hood::detail::Table	typeref:typename:Table<IsFlat,MaxLoadFactor100,key_type,mapped_type,hasher,key_equal>	access:public
+SizeT	src/robin_hood.h	/^using SizeT = uint64_t;$/;"	t	namespace:robin_hood::detail	typeref:typename:uint64_t
+Solution	src/MazeRoute.h	/^  Solution(CostT c, int v, const std::shared_ptr<Solution>& p)$/;"	f	struct:grt::Solution	access:public	signature:(CostT c,int v,const std::shared_ptr<Solution> & p)
+Solution	src/MazeRoute.h	/^struct Solution$/;"	s	namespace:grt
+SparseGraph	src/MazeRoute.h	/^  SparseGraph(GRNet* net, const GridGraph* graph)$/;"	f	class:grt::SparseGraph	access:public	signature:(GRNet * net,const GridGraph * graph)
+SparseGraph	src/MazeRoute.h	/^class SparseGraph$/;"	c	namespace:grt
+SparseGrid	src/MazeRoute.h	/^  SparseGrid(int x_interval, int y_interval, int x_offset, int y_offset)$/;"	f	struct:grt::SparseGrid	access:public	signature:(int x_interval,int y_interval,int x_offset,int y_offset)
+SparseGrid	src/MazeRoute.h	/^struct SparseGrid$/;"	s	namespace:grt
+StTreeVisualization	include/CUGR.h	/^  void StTreeVisualization(const StTree& stree, GRNet* net, bool is3DVisualization);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const StTree & stree,GRNet * net,bool is3DVisualization)
+StTreeVisualization	src/CUGR.cpp	/^void CUGR::StTreeVisualization(const StTree& stree, GRNet* net, bool is3DVisualization)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const StTree & stree,GRNet * net,bool is3DVisualization)
+SteinerTreeNode	src/PatternRoute.h	/^  SteinerTreeNode(const PointT& point) : PointT(point) {}$/;"	f	class:grt::SteinerTreeNode	access:public	signature:(const PointT & point)
+SteinerTreeNode	src/PatternRoute.h	/^  SteinerTreeNode(const PointT& point, const IntervalT& fixed_layers)$/;"	f	class:grt::SteinerTreeNode	access:public	signature:(const PointT & point,const IntervalT & fixed_layers)
+SteinerTreeNode	src/PatternRoute.h	/^class SteinerTreeNode : public PointT$/;"	c	namespace:grt	inherits:PointT
+Table	src/robin_hood.h	/^  Table() noexcept(noexcept(Hash()) && noexcept(KeyEqual()))$/;"	f	class:robin_hood::detail::Table	access:public	signature:()
+Table	src/robin_hood.h	/^  Table(Iter first,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(Iter first,Iter last,size_t ROBIN_HOOD_UNUSED (bucket_count)=0,const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+Table	src/robin_hood.h	/^  Table(Table&& o) noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(Table && o)
+Table	src/robin_hood.h	/^  Table(const Table& o)$/;"	f	class:robin_hood::detail::Table	access:public	signature:(const Table & o)
+Table	src/robin_hood.h	/^  Table(std::initializer_list<value_type> initlist,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(std::initializer_list<value_type> initlist,size_t ROBIN_HOOD_UNUSED (bucket_count)=0,const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+Table	src/robin_hood.h	/^  explicit Table(size_t ROBIN_HOOD_UNUSED(bucket_count) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(size_t ROBIN_HOOD_UNUSED (bucket_count),const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+Table	src/robin_hood.h	/^class Table$/;"	c	namespace:robin_hood::detail	inherits:WrapHash<Hash>,WrapKeyEqual<KeyEqual>,detail::NodeAllocator<typenamestd::conditional_t<std::is_void_v<T>,Key,robin_hood::pair<typenamestd::conditional_t<IsFlat,Key,Keyconst>,T>>,4,16384,IsFlat>
+Underlying	src/robin_hood.h	/^    using Underlying = typename std::underlying_type_t<Enum>;$/;"	t	function:robin_hood::hash::operator ()	typeref:typename:std::underlying_type_t<Enum>
+V	src/Layers.h	/^  const static int V = 1;$/;"	m	class:grt::MetalLayer	typeref:typename:const int	access:public
+WHash	src/robin_hood.h	/^  using WHash = WrapHash<Hash>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:WrapHash<Hash>	access:private
+WKeyEqual	src/robin_hood.h	/^  using WKeyEqual = WrapKeyEqual<KeyEqual>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:WrapKeyEqual<KeyEqual>	access:private
+WrapHash	src/robin_hood.h	/^  WrapHash() = default;$/;"	p	struct:robin_hood::detail::WrapHash	access:public	signature:()
+WrapHash	src/robin_hood.h	/^  explicit WrapHash(T const& o) noexcept(noexcept(T(std::declval<T const&>())))$/;"	f	struct:robin_hood::detail::WrapHash	access:public	signature:(T const & o)
+WrapHash	src/robin_hood.h	/^struct WrapHash : public T$/;"	s	namespace:robin_hood::detail	inherits:T
+WrapKeyEqual	src/robin_hood.h	/^  WrapKeyEqual() = default;$/;"	p	struct:robin_hood::detail::WrapKeyEqual	access:public	signature:()
+WrapKeyEqual	src/robin_hood.h	/^  explicit WrapKeyEqual(T const& o) noexcept($/;"	f	struct:robin_hood::detail::WrapKeyEqual	access:public	signature:(T const & o)
+WrapKeyEqual	src/robin_hood.h	/^struct WrapKeyEqual : public T$/;"	s	namespace:robin_hood::detail	inherits:T
+__anon1880909a0102	src/PatternRoute.cpp	/^  preorder(node, [&](const std::shared_ptr<SteinerTreeNode>& node) {$/;"	f	function:grt::SteinerTreeNode::getPythonString	file:	signature:(const std::shared_ptr<SteinerTreeNode>& node) 
+__anon1880909a0202	src/PatternRoute.cpp	/^      = [&](const std::shared_ptr<PatternRoutingNode>& node) {$/;"	f	function:grt::PatternRoutingNode::getPythonString	file:	signature:(const std::shared_ptr<PatternRoutingNode>& node) 
+__anon1880909a0302	src/PatternRoute.cpp	/^                           int cur_index) {$/;"	f	function:grt::PatternRoute::constructSteinerTree	file:	signature:(std::shared_ptr<SteinerTreeNode>& parent, int prev_index, int cur_index) 
+__anon1880909a0402	src/PatternRoute.cpp	/^  std::function<bool(int)> has_degree1 = [&](int index) {$/;"	f	function:grt::PatternRoute::constructSteinerTree	file:	signature:(int index) 
+__anon1880909a0502	src/PatternRoute.cpp	/^                          std::shared_ptr<SteinerTreeNode>& steiner) {$/;"	f	function:grt::PatternRoute::constructRoutingDAG	file:	signature:(std::shared_ptr<PatternRoutingNode>& dst_node, std::shared_ptr<SteinerTreeNode>& steiner) 
+__anon1880909a0602	src/PatternRoute.cpp	/^      [&](const std::shared_ptr<PatternRoutingNode>& node) {$/;"	f	function:grt::PatternRoute::constructDetours	file:	signature:(const std::shared_ptr<PatternRoutingNode>& node) 
+__anon1880909a0702	src/PatternRoute.cpp	/^            bool starting) {$/;"	f	function:grt::PatternRoute::constructDetours	file:	signature:(const std::shared_ptr<ScaffoldNode>& scaffold_node, IntervalT& trunk, std::vector<int>& stems, int direction, bool starting) 
+__anon1880909a0802	src/PatternRoute.cpp	/^      = [&](const std::vector<int>& stems, const int pos) {$/;"	f	function:grt::PatternRoute::constructDetours	file:	signature:(const std::vector<int>& stems, const int pos) 
+__anon1880909a0902	src/PatternRoute.cpp	/^                         int shift_amount) {$/;"	f	function:grt::PatternRoute::constructDetours	file:	signature:(const std::shared_ptr<ScaffoldNode>& scaffold_node, int direction, int shift_amount) 
+__anon7af0f0690102	src/MazeRoute.cpp	/^                           [](const AccessPoint& a, const AccessPoint& b) {$/;"	f	function:grt::SparseGraph::init	file:	signature:(const AccessPoint& a, const AccessPoint& b) 
+__anon7af0f0690202	src/MazeRoute.cpp	/^      = [&](const int direction, const int xi, const int yi) {$/;"	f	function:grt::SparseGraph::init	file:	signature:(const int direction, const int xi, const int yi) 
+__anon7af0f0690302	src/MazeRoute.cpp	/^  auto add_diff_layer_edge = [&](const int xi, const int yi) {$/;"	f	function:grt::SparseGraph::init	file:	signature:(const int xi, const int yi) 
+__anon7af0f0690402	src/MazeRoute.cpp	/^                              const std::shared_ptr<Solution>& rhs) {$/;"	f	function:grt::MazeRoute::run	file:	signature:(const std::shared_ptr<Solution>& lhs, const std::shared_ptr<Solution>& rhs) 
+__anon7af0f0690502	src/MazeRoute.cpp	/^  auto update_solution = [&](const std::shared_ptr<Solution>& solution) {$/;"	f	function:grt::MazeRoute::run	file:	signature:(const std::shared_ptr<Solution>& solution) 
+__anon7af0f0690602	src/MazeRoute.cpp	/^      tree, [&](const std::shared_ptr<SteinerTreeNode>& node) {$/;"	f	function:grt::MazeRoute::getSteinerTree	file:	signature:(const std::shared_ptr<SteinerTreeNode>& node) 
+__anon7af0f0690702	src/MazeRoute.cpp	/^      tree, [&](const std::shared_ptr<SteinerTreeNode>& node) {$/;"	f	function:grt::MazeRoute::getSteinerTree	file:	signature:(const std::shared_ptr<SteinerTreeNode>& node) 
+__anon7af0f0690802	src/MazeRoute.cpp	/^      tree, [&](const std::shared_ptr<SteinerTreeNode>& node) {$/;"	f	function:grt::MazeRoute::getSteinerTree	file:	signature:(const std::shared_ptr<SteinerTreeNode>& node) 
+__anon9b5f76160102	src/GRTree.cpp	/^  preorder(node, [logger](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::GRTreeNode::print	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonb66edbe50102	src/GridGraph.cpp	/^  GRTreeNode::preorder(tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::GridGraph::commitTree	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonb66edbe50202	src/GridGraph.cpp	/^  GRTreeNode::preorder(tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::GridGraph::checkOverflow	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonb66edbe50302	src/GridGraph.cpp	/^      routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::GridGraph::getPythonString	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonb66edbe50402	src/GridGraph.cpp	/^  auto update = [&](int direction, int x, int y) {$/;"	f	function:grt::GridGraph::updateWireCostView	file:	signature:(int direction, int x, int y) 
+__anonb66edbe50502	src/GridGraph.cpp	/^      routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::GridGraph::updateWireCostView	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonbc033b5e0102	src/CUGR.cpp	/^        routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::CUGR::getRoutes	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonbc033b5e0202	src/CUGR.cpp	/^  std::ranges::stable_sort(net_indices, [&](int lhs, int rhs) {$/;"	f	function:grt::CUGR::sortNetIndices	file:	signature:(int lhs, int rhs) 
+__anonbc033b5e0302	src/CUGR.cpp	/^      routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::CUGR::getGuides	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonbc033b5e0402	src/CUGR.cpp	/^  auto get_spare_resource = [&](const GRPoint& point) {$/;"	f	function:grt::CUGR::getGuides	file:	signature:(const GRPoint& point) 
+__anonbc033b5e0502	src/CUGR.cpp	/^      routing_tree, [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::CUGR::getGuides	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anonbc033b5e0602	src/CUGR.cpp	/^        net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {$/;"	f	function:grt::CUGR::printStatistics	file:	signature:(const std::shared_ptr<GRTreeNode>& node) 
+__anoncab81335010a	src/Netlist.h	/^  {$/;"	u	class:grt::CUGRPin	access:private
+__has_cpp_attribute	src/robin_hood.h	/^#define __has_cpp_attribute(/;"	d	signature:(x)
+add	src/robin_hood.h	/^  void add(void* ptr, const size_t numBytes) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:private	signature:(void * ptr,const size_t numBytes)
+addBTermAccessPoint	src/GRNet.cpp	/^void GRNet::addBTermAccessPoint(odb::dbBTerm* bterm, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(odb::dbBTerm * bterm,const AccessPoint & ap)
+addBTermAccessPoint	src/GRNet.h	/^  void addBTermAccessPoint(odb::dbBTerm* bterm, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(odb::dbBTerm * bterm,const AccessPoint & ap)
+addChild	src/GRTree.h	/^  void addChild(std::shared_ptr<GRTreeNode> child)$/;"	f	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(std::shared_ptr<GRTreeNode> child)
+addChild	src/PatternRoute.h	/^  void addChild(const std::shared_ptr<PatternRoutingNode>& child)$/;"	f	class:grt::PatternRoutingNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<PatternRoutingNode> & child)
+addChild	src/PatternRoute.h	/^  void addChild(const std::shared_ptr<SteinerTreeNode>& child)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & child)
+addDirtyNet	include/CUGR.h	/^  void addDirtyNet(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net)
+addDirtyNet	src/CUGR.cpp	/^void CUGR::addDirtyNet(odb::dbNet* net)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net)
+addITermAccessPoint	src/GRNet.cpp	/^void GRNet::addITermAccessPoint(odb::dbITerm* iterm, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(odb::dbITerm * iterm,const AccessPoint & ap)
+addITermAccessPoint	src/GRNet.h	/^  void addITermAccessPoint(odb::dbITerm* iterm, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(odb::dbITerm * iterm,const AccessPoint & ap)
+addOrFree	src/robin_hood.h	/^  void addOrFree(void* ptr, const size_t numBytes) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(void * ptr,const size_t numBytes)
+addOrFree	src/robin_hood.h	/^  void addOrFree(void* ptr,$/;"	f	struct:robin_hood::detail::NodeAllocator	typeref:typename:void	access:public	signature:(void * ptr,size_t ROBIN_HOOD_UNUSED (numBytes))
+addPreferredAccessPoint	src/GRNet.cpp	/^void GRNet::addPreferredAccessPoint(int pin_index, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(int pin_index,const AccessPoint & ap)
+addPreferredAccessPoint	src/GRNet.h	/^  void addPreferredAccessPoint(int pin_index, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(int pin_index,const AccessPoint & ap)
+addToHigh	src/geo.h	/^  void addToHigh(const int increment) { high_ += increment; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int increment)
+addToLow	src/geo.h	/^  void addToLow(const int increment) { low_ += increment; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int increment)
+addTreeUsage	src/GridGraph.cpp	/^void GridGraph::addTreeUsage(const std::shared_ptr<GRTreeNode>& tree)$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree)
+addTreeUsage	src/GridGraph.h	/^  void addTreeUsage(const std::shared_ptr<GRTreeNode>& tree);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree)
+adjustment_	src/Layers.h	/^  float adjustment_ = 0.0;$/;"	m	class:grt::MetalLayer	typeref:typename:float	access:private
+allocate	src/robin_hood.h	/^  T* allocate()$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T *	access:public	signature:()
+area	src/geo.h	/^  int area() const { return width() * height(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+area_of_pin_patches_	include/CUGR.h	/^  int area_of_pin_patches_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:int	access:private
+area_of_wire_patches_	include/CUGR.h	/^  int area_of_wire_patches_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:int	access:private
+at	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q const&> at($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q const &>	access:public	signature:(key_type const & key) const
+at	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> at(key_type const& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(key_type const & key)
+begin	src/robin_hood.h	/^  const_iterator begin() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+begin	src/robin_hood.h	/^  iterator begin()$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:()
+best_paths_	src/PatternRoute.h	/^  std::vector<std::vector<std::pair<int, int>>> best_paths_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::pair<int,int>>>	access:private
+block_	src/Design.h	/^  odb::dbBlock* block_;$/;"	m	class:grt::Design	typeref:typename:odb::dbBlock *	access:private
+bounding_box_	src/GRNet.h	/^  BoxT bounding_box_;$/;"	m	class:grt::GRNet	typeref:typename:BoxT	access:private
+bterm	src/Netlist.h	/^    odb::dbBTerm* bterm;$/;"	m	union:grt::CUGRPin::__anoncab81335010a	typeref:typename:odb::dbBTerm *	access:public
+bterm_to_ap_	src/GRNet.h	/^  std::map<odb::dbBTerm*, AccessPoint> bterm_to_ap_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<odb::dbBTerm *,AccessPoint>	access:private
+calculatePartialSlack	include/CUGR.h	/^  float calculatePartialSlack();$/;"	p	class:grt::CUGR	typeref:typename:float	access:private	signature:()
+calculatePartialSlack	src/CUGR.cpp	/^float CUGR::calculatePartialSlack()$/;"	f	class:grt::CUGR	typeref:typename:float	signature:()
+calculateRoutingCosts	src/PatternRoute.cpp	/^void PatternRoute::calculateRoutingCosts($/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(std::shared_ptr<PatternRoutingNode> & node)
+calculateRoutingCosts	src/PatternRoute.h	/^  void calculateRoutingCosts(std::shared_ptr<PatternRoutingNode>& node);$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:private	signature:(std::shared_ptr<PatternRoutingNode> & node)
+callback_handler_	include/CUGR.h	/^  utl::CallBackHandler* callback_handler_;$/;"	m	class:grt::CUGR	typeref:typename:utl::CallBackHandler *	access:private
+capacity	src/GridGraph.h	/^  CapacityT capacity{0};$/;"	m	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public
+cbegin	src/robin_hood.h	/^  const_iterator cbegin() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+cend	src/robin_hood.h	/^  const_iterator cend() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+center	src/geo.h	/^  int center() const { return (high_ + low_) \/ 2; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+check	src/GridGraph.h	/^  bool check(const PointT& u, const PointT& v) const$/;"	f	class:grt::GridGraphView	typeref:typename:bool	access:public	signature:(const PointT & u,const PointT & v) const
+checkOverflow	src/GridGraph.cpp	/^int GridGraph::checkOverflow(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(const int layer_index,const PointT u,const PointT v) const
+checkOverflow	src/GridGraph.cpp	/^int GridGraph::checkOverflow(const std::shared_ptr<GRTreeNode>& tree) const$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(const std::shared_ptr<GRTreeNode> & tree) const
+checkOverflow	src/GridGraph.h	/^  bool checkOverflow(int layer_index, int x, int y) const$/;"	f	class:grt::GridGraph	typeref:typename:bool	access:public	signature:(int layer_index,int x,int y) const
+checkOverflow	src/GridGraph.h	/^  int checkOverflow(const std::shared_ptr<GRTreeNode>& tree)$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree) const
+checkOverflow	src/GridGraph.h	/^  int checkOverflow(int layer_index,$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int layer_index,PointT u,PointT v) const
+children	src/PatternRoute.cpp	/^    std::vector<std::shared_ptr<ScaffoldNode>> children;$/;"	m	struct:grt::PatternRoute::constructDetours::ScaffoldNode	typeref:typename:std::vector<std::shared_ptr<ScaffoldNode>>	file:	access:public
+children_	src/GRTree.h	/^  std::vector<std::shared_ptr<GRTreeNode>> children_;$/;"	m	class:grt::GRTreeNode	typeref:typename:std::vector<std::shared_ptr<GRTreeNode>>	access:private
+children_	src/PatternRoute.h	/^  std::vector<std::shared_ptr<PatternRoutingNode>> children_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::shared_ptr<PatternRoutingNode>>	access:private
+children_	src/PatternRoute.h	/^  std::vector<std::shared_ptr<SteinerTreeNode>> children_;$/;"	m	class:grt::SteinerTreeNode	typeref:typename:std::vector<std::shared_ptr<SteinerTreeNode>>	access:private
+clear	src/robin_hood.h	/^  void clear()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:()
+clearRoutingTree	src/GRNet.h	/^  void clearRoutingTree() { routing_tree_ = nullptr; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:()
+clock_nets_	src/Design.h	/^  std::set<odb::dbNet*> clock_nets_;$/;"	m	class:grt::Design	typeref:typename:std::set<odb::dbNet * >	access:private
+cloneData	src/robin_hood.h	/^  void cloneData(const Table& o)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(const Table & o)
+commit	src/GridGraph.cpp	/^void GridGraph::commit(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT lower,const CapacityT demand)
+commit	src/GridGraph.h	/^  void commit(int layer_index, PointT lower, CapacityT demand);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT lower,CapacityT demand)
+commitTree	src/GridGraph.cpp	/^void GridGraph::commitTree(const std::shared_ptr<GRTreeNode>& tree,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree,const bool rip_up)
+commitTree	src/GridGraph.h	/^  void commitTree(const std::shared_ptr<GRTreeNode>& tree, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(const std::shared_ptr<GRTreeNode> & tree,bool rip_up=false)
+commitVia	src/GridGraph.cpp	/^void GridGraph::commitVia(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT loc,const bool rip_up)
+commitVia	src/GridGraph.h	/^  void commitVia(int layer_index, PointT loc, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT loc,bool rip_up=false)
+commitWire	src/GridGraph.cpp	/^void GridGraph::commitWire(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT lower,const bool rip_up)
+commitWire	src/GridGraph.h	/^  void commitWire(int layer_index, PointT lower, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT lower,bool rip_up=false)
+compact	src/robin_hood.h	/^  void compact()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:()
+computeGrid	src/Design.cpp	/^void Design::computeGrid()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+computeGrid	src/Design.h	/^  void computeGrid();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+const_iterator	src/robin_hood.h	/^  using const_iterator = Iter<true>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Iter<true>	access:public
+constants_	include/CUGR.h	/^  Constants constants_;$/;"	m	class:grt::CUGR	typeref:typename:Constants	access:private
+constants_	src/Design.h	/^  const Constants constants_;$/;"	m	class:grt::Design	typeref:typename:const Constants	access:private
+constants_	src/GridGraph.h	/^  const Constants constants_;$/;"	m	class:grt::GridGraph	typeref:typename:const Constants	access:private
+constants_	src/PatternRoute.h	/^  Constants constants_;$/;"	m	class:grt::PatternRoute	typeref:typename:Constants	access:private
+constructDetours	src/PatternRoute.cpp	/^void PatternRoute::constructDetours(GridGraphView<bool>& congestion_view)$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(GridGraphView<bool> & congestion_view)
+constructDetours	src/PatternRoute.h	/^  void constructDetours(GridGraphView<bool>& congestion_view);$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:(GridGraphView<bool> & congestion_view)
+constructPaths	src/PatternRoute.cpp	/^void PatternRoute::constructPaths(std::shared_ptr<PatternRoutingNode>& start,$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(std::shared_ptr<PatternRoutingNode> & start,std::shared_ptr<PatternRoutingNode> & end,int child_index)
+constructPaths	src/PatternRoute.h	/^  void constructPaths(std::shared_ptr<PatternRoutingNode>& start,$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:private	signature:(std::shared_ptr<PatternRoutingNode> & start,std::shared_ptr<PatternRoutingNode> & end,int child_index=-1)
+constructRoutingDAG	src/PatternRoute.cpp	/^void PatternRoute::constructRoutingDAG()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+constructRoutingDAG	src/PatternRoute.h	/^  void constructRoutingDAG();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+constructSparsifiedGraph	src/MazeRoute.h	/^  void constructSparsifiedGraph(const GridGraphView<CostT>& wire_cost_view,$/;"	f	class:grt::MazeRoute	typeref:typename:void	access:public	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+constructSteinerTree	src/PatternRoute.cpp	/^void PatternRoute::constructSteinerTree()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+constructSteinerTree	src/PatternRoute.h	/^  void constructSteinerTree();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+contain	src/geo.h	/^  bool contain(const PointT& pt) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const PointT & pt) const
+contain	src/geo.h	/^  bool contain(int val) const { return val >= low_ && val <= high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(int val) const
+contains	src/robin_hood.h	/^  bool contains(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const key_type & key) const
+contains	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, bool> contains($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,bool>	access:public	signature:(const OtherKey & key) const
+cost	src/MazeRoute.h	/^  const CostT cost;$/;"	m	struct:grt::Solution	typeref:typename:const CostT	access:public
+cost_logistic_slope	include/CUGR.h	/^  double cost_logistic_slope = 1.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+costs_	src/MazeRoute.h	/^  std::vector<std::array<CostT, 3>> costs_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<std::array<CostT,3>>	access:private
+costs_	src/PatternRoute.h	/^  std::vector<CostT> costs_;  \/\/ layerIndex -> cost$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<CostT>	access:private
+count	src/robin_hood.h	/^  size_t count(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_t	access:public	signature:(const key_type & key) const
+count	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, size_t> count($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,size_t>	access:public	signature:(const OtherKey & key) const
+counts	src/robin_hood.h	/^static Counts& counts()$/;"	f	namespace:robin_hood	typeref:typename:Counts &	signature:()
+critical_nets_percentage_	include/CUGR.h	/^  float critical_nets_percentage_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:float	access:private
+cx	src/geo.h	/^  int cx() const { return x_.center(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+cy	src/geo.h	/^  int cy() const { return y_.center(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+db_	include/CUGR.h	/^  odb::dbDatabase* db_;$/;"	m	class:grt::CUGR	typeref:typename:odb::dbDatabase *	access:private
+db_net_	src/GRNet.h	/^  odb::dbNet* db_net_;$/;"	m	class:grt::GRNet	typeref:typename:odb::dbNet *	access:private
+db_net_	src/Netlist.h	/^  odb::dbNet* db_net_;$/;"	m	class:grt::CUGRNet	typeref:typename:odb::dbNet *	access:private
+db_net_map_	include/CUGR.h	/^  std::map<odb::dbNet*, GRNet*> db_net_map_;$/;"	m	class:grt::CUGR	typeref:typename:std::map<odb::dbNet *,GRNet * >	access:private
+db_net_to_id_	src/Design.h	/^  std::unordered_map<odb::dbNet*, int> db_net_to_id_;$/;"	m	class:grt::Design	typeref:typename:std::unordered_map<odb::dbNet *,int>	access:private
+deallocate	src/robin_hood.h	/^  void deallocate(T* obj) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(T * obj)
+debug_	include/CUGR.h	/^  std::unique_ptr<DebugSetting> debug_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<DebugSetting>	access:private
+default_gridline_spacing_	src/Design.h	/^  int default_gridline_spacing_;$/;"	m	class:grt::Design	typeref:typename:int	access:private
+default_spacing_	src/Layers.h	/^  int default_spacing_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+demand	src/GridGraph.h	/^  CapacityT demand{0};$/;"	m	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public
+design_	include/CUGR.h	/^  std::unique_ptr<Design> design_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<Design>	access:private
+design_	src/GridGraph.h	/^  const Design* design_;$/;"	m	class:grt::GridGraph	typeref:typename:const Design *	access:private
+destroy	src/robin_hood.h	/^    void destroy(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/) noexcept {}$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(M & ROBIN_HOOD_UNUSED (map))
+destroy	src/robin_hood.h	/^    void destroy(M& map) noexcept$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(M & map)
+destroy	src/robin_hood.h	/^  void destroy()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+destroyDoNotDeallocate	src/robin_hood.h	/^    void destroyDoNotDeallocate() noexcept { mData->~value_type(); }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:()
+destroyDoNotDeallocate	src/robin_hood.h	/^    void destroyDoNotDeallocate() noexcept {}$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:()
+detail	src/robin_hood.h	/^namespace detail {$/;"	n	namespace:robin_hood
+die_region_	src/Design.h	/^  BoxT die_region_;$/;"	m	class:grt::Design	typeref:typename:BoxT	access:private
+difference_type	src/robin_hood.h	/^    using difference_type = std::ptrdiff_t;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::ptrdiff_t	access:public
+direction_	src/Layers.h	/^  int direction_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+edges_	src/MazeRoute.h	/^  std::vector<std::array<int, 3>> edges_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<std::array<int,3>>	access:private
+emplace	src/robin_hood.h	/^  std::pair<iterator, bool> emplace(Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(Args &&...args)
+end	src/robin_hood.h	/^  const_iterator end() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+end	src/robin_hood.h	/^  iterator end()$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:()
+erase	src/robin_hood.h	/^  iterator erase(const_iterator pos)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const_iterator pos)
+erase	src/robin_hood.h	/^  iterator erase(iterator pos)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(iterator pos)
+erase	src/robin_hood.h	/^  size_t erase(const key_type& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_t	access:public	signature:(const key_type & key)
+extractBlockageView	src/GridGraph.cpp	/^void GridGraph::extractBlockageView(GridGraphView<bool>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<bool> & view) const
+extractBlockageView	src/GridGraph.h	/^  void extractBlockageView(GridGraphView<bool>& view) const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<bool> & view) const
+extractCongestionView	src/GridGraph.cpp	/^void GridGraph::extractCongestionView(GridGraphView<bool>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<bool> & view) const
+extractCongestionView	src/GridGraph.h	/^  void extractCongestionView($/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<bool> & view) const
+extractWireCostView	src/GridGraph.cpp	/^void GridGraph::extractWireCostView(GridGraphView<CostT>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<CostT> & view) const
+extractWireCostView	src/GridGraph.h	/^  void extractWireCostView(GridGraphView<CostT>& view) const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<CostT> & view) const
+fastForward	src/robin_hood.h	/^    void fastForward() noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:void	access:private	signature:()
+fastUpdate	src/geo.h	/^  void fastUpdate(const PointT& pt) { fastUpdate(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+fastUpdate	src/geo.h	/^  void fastUpdate(int new_val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int new_val)
+fastUpdate	src/geo.h	/^  void fastUpdate(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+fast_forward_tag	src/robin_hood.h	/^  struct fast_forward_tag$/;"	s	class:robin_hood::detail::Table	access:private
+find	src/robin_hood.h	/^  const_iterator find(const OtherKey& key, is_transparent_tag \/*unused*\/) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:(const OtherKey & key,is_transparent_tag) const
+find	src/robin_hood.h	/^  const_iterator find(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:(const key_type & key) const
+find	src/robin_hood.h	/^  find(const OtherKey& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,const_iterator>	access:public	signature:(const OtherKey & key) const
+find	src/robin_hood.h	/^  iterator find(const OtherKey& key, is_transparent_tag \/*unused*\/)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const OtherKey & key,is_transparent_tag)
+find	src/robin_hood.h	/^  iterator find(const key_type& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const key_type & key)
+find	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, iterator> find($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,iterator>	access:public	signature:(const OtherKey & key)
+findODBAccessPoints	src/GridGraph.cpp	/^bool GridGraph::findODBAccessPoints($/;"	f	class:grt::GridGraph	typeref:typename:bool	signature:(GRNet * net,AccessPointSet & selected_access_points) const
+findODBAccessPoints	src/GridGraph.h	/^  bool findODBAccessPoints(GRNet* net,$/;"	p	class:grt::GridGraph	typeref:typename:bool	access:private	signature:(GRNet * net,AccessPointSet & selected_access_points) const
+first	src/robin_hood.h	/^  T1 first;   \/\/ NOLINT(misc-non-private-member-variables-in-classes)$/;"	m	struct:robin_hood::pair	typeref:typename:T1	access:public
+first_track_loc_	src/Layers.h	/^  int first_track_loc_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+first_type	src/robin_hood.h	/^  using first_type = T1;$/;"	t	struct:robin_hood::pair	typeref:typename:T1	access:public
+fixed_layers_	src/PatternRoute.h	/^  IntervalT fixed_layers_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:IntervalT	access:private
+fixed_layers_	src/PatternRoute.h	/^  IntervalT fixed_layers_;$/;"	m	class:grt::SteinerTreeNode	typeref:typename:IntervalT	access:private
+flute_accuracy_	src/PatternRoute.h	/^  const int flute_accuracy_ = 3;$/;"	m	class:grt::PatternRoute	typeref:typename:const int	access:private
+getAdjustment	src/Layers.h	/^  float getAdjustment() const { return adjustment_; }$/;"	f	class:grt::MetalLayer	typeref:typename:float	access:public	signature:() const
+getAllNets	src/Design.h	/^  const std::vector<CUGRNet>& getAllNets() const { return nets_; }$/;"	f	class:grt::Design	typeref:typename:const std::vector<CUGRNet> &	access:public	signature:() const
+getAllObstacles	src/Design.cpp	/^void Design::getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,$/;"	f	class:grt::Design	typeref:typename:void	signature:(std::vector<std::vector<BoxT>> & all_obstacles,const bool skip_m1) const
+getAllObstacles	src/Design.h	/^  void getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,$/;"	p	class:grt::Design	typeref:typename:void	access:public	signature:(std::vector<std::vector<BoxT>> & all_obstacles,bool skip_m1=true) const
+getBTerm	src/Netlist.cpp	/^odb::dbBTerm* CUGRPin::getBTerm() const$/;"	f	class:grt::CUGRPin	typeref:typename:odb::dbBTerm *	signature:() const
+getBTerm	src/Netlist.h	/^  odb::dbBTerm* getBTerm() const;$/;"	p	class:grt::CUGRPin	typeref:typename:odb::dbBTerm *	access:public	signature:() const
+getBTermAccessPoints	src/GRNet.h	/^  const std::map<odb::dbBTerm*, AccessPoint>& getBTermAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::map<odb::dbBTerm *,AccessPoint> &	access:public	signature:() const
+getBTermsAccessPoints	include/CUGR.h	/^  void getBTermsAccessPoints($/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net,std::map<odb::dbBTerm *,odb::Point3D> & access_points)
+getBTermsAccessPoints	src/CUGR.cpp	/^void CUGR::getBTermsAccessPoints($/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net,std::map<odb::dbBTerm *,odb::Point3D> & access_points)
+getBestPaths	src/PatternRoute.h	/^  std::vector<std::vector<std::pair<int, int>>>& getBestPaths()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::pair<int,int>>> &	access:public	signature:()
+getBoundingBox	src/GRNet.h	/^  const BoxT& getBoundingBox() const { return bounding_box_; }$/;"	f	class:grt::GRNet	typeref:typename:const BoxT &	access:public	signature:() const
+getBoxFromRect	src/GeoTypes.cpp	/^BoxT getBoxFromRect(const odb::Rect& bounds)$/;"	f	namespace:grt	typeref:typename:BoxT	signature:(const odb::Rect & bounds)
+getBoxFromRect	src/GeoTypes.h	/^BoxT getBoxFromRect(const odb::Rect& bounds);$/;"	p	namespace:grt	typeref:typename:BoxT	signature:(const odb::Rect & bounds)
+getCellBox	src/GridGraph.cpp	/^BoxT GridGraph::getCellBox(PointT point) const$/;"	f	class:grt::GridGraph	typeref:typename:BoxT	signature:(PointT point) const
+getCellBox	src/GridGraph.h	/^  BoxT getCellBox(PointT point) const;$/;"	p	class:grt::GridGraph	typeref:typename:BoxT	access:public	signature:(PointT point) const
+getChildren	src/GRTree.h	/^  const std::vector<std::shared_ptr<GRTreeNode>>& getChildren() const$/;"	f	class:grt::GRTreeNode	typeref:typename:const std::vector<std::shared_ptr<GRTreeNode>> &	access:public	signature:() const
+getChildren	src/PatternRoute.h	/^  std::vector<std::shared_ptr<PatternRoutingNode>>& getChildren()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::shared_ptr<PatternRoutingNode>> &	access:public	signature:()
+getChildren	src/PatternRoute.h	/^  std::vector<std::shared_ptr<SteinerTreeNode>>& getChildren()$/;"	f	class:grt::SteinerTreeNode	typeref:typename:std::vector<std::shared_ptr<SteinerTreeNode>> &	access:public	signature:()
+getCosts	src/PatternRoute.h	/^  std::vector<CostT>& getCosts() { return costs_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<CostT> &	access:public	signature:()
+getDbNet	src/GRNet.h	/^  odb::dbNet* getDbNet() const { return db_net_; }$/;"	f	class:grt::GRNet	typeref:typename:odb::dbNet *	access:public	signature:() const
+getDbNet	src/Netlist.h	/^  odb::dbNet* getDbNet() const { return db_net_; }$/;"	f	class:grt::CUGRNet	typeref:typename:odb::dbNet *	access:public	signature:() const
+getDebugNet	include/CUGR.h	/^  const odb::dbNet* getDebugNet();$/;"	p	class:grt::CUGR	typeref:typename:const odb::dbNet *	access:public	signature:()
+getDebugNet	src/CUGR.cpp	/^const odb::dbNet* CUGR::getDebugNet()$/;"	f	class:grt::CUGR	typeref:typename:const odb::dbNet *	signature:()
+getDebugRenderer	include/CUGR.h	/^  AbstractFastRouteRenderer* getDebugRenderer() const;$/;"	p	class:grt::CUGR	typeref:typename:AbstractFastRouteRenderer *	access:public	signature:() const
+getDebugRenderer	src/CUGR.cpp	/^AbstractFastRouteRenderer* CUGR::getDebugRenderer() const$/;"	f	class:grt::CUGR	typeref:typename:AbstractFastRouteRenderer *	signature:() const
+getDefaultSpacing	src/Layers.h	/^  int getDefaultSpacing() const { return default_spacing_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getDieRegion	src/Design.h	/^  BoxT getDieRegion() const { return die_region_; }$/;"	f	class:grt::Design	typeref:typename:BoxT	access:public	signature:() const
+getDirection	src/Layers.h	/^  int getDirection() const { return direction_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getEdge	src/GridGraph.h	/^  GraphEdge getEdge(const int layer_index, const int x, const int y) const$/;"	f	class:grt::GridGraph	typeref:typename:GraphEdge	access:public	signature:(const int layer_index,const int x,const int y) const
+getEdgeCost	src/MazeRoute.h	/^  CostT getEdgeCost(const int vertex, const int edge_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:CostT	access:public	signature:(const int vertex,const int edge_index) const
+getEdgeLength	src/GridGraph.cpp	/^int GridGraph::getEdgeLength(int direction, int edge_index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(int direction,int edge_index) const
+getEdgeLength	src/GridGraph.h	/^  int getEdgeLength(int direction, int edge_index) const;$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int direction,int edge_index) const
+getFirstConst	src/robin_hood.h	/^  key_type&& getFirstConst(key_type&& k) const noexcept { return std::move(k); }$/;"	f	class:robin_hood::detail::Table	typeref:typename:key_type &&	access:private	signature:(key_type && k) const
+getFixedLayers	src/PatternRoute.h	/^  IntervalT& getFixedLayers() { return fixed_layers_; }$/;"	f	class:grt::SteinerTreeNode	typeref:typename:IntervalT &	access:public	signature:()
+getFixedLayers	src/PatternRoute.h	/^  const IntervalT& getFixedLayers() const { return fixed_layers_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:const IntervalT &	access:public	signature:() const
+getGridGraph	src/PatternRoute.h	/^  const GridGraph* getGridGraph() const { return grid_graph_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const GridGraph *	access:public	signature:() const
+getGridline	src/GridGraph.h	/^  int getGridline(const int dimension, const int index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(const int dimension,const int index) const
+getGridlineSize	src/Design.h	/^  int getGridlineSize() const { return default_gridline_spacing_; }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+getGridlines	src/Design.h	/^  const std::vector<std::vector<int>>& getGridlines() const$/;"	f	class:grt::Design	typeref:typename:const std::vector<std::vector<int>> &	access:public	signature:() const
+getGuides	include/CUGR.h	/^  void getGuides(const GRNet* net,$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const GRNet * net,std::vector<std::pair<int,grt::BoxT>> & guides)
+getGuides	src/CUGR.cpp	/^void CUGR::getGuides(const GRNet* net,$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const GRNet * net,std::vector<std::pair<int,BoxT>> & guides)
+getITerm	src/Netlist.cpp	/^odb::dbITerm* CUGRPin::getITerm() const$/;"	f	class:grt::CUGRPin	typeref:typename:odb::dbITerm *	signature:() const
+getITerm	src/Netlist.h	/^  odb::dbITerm* getITerm() const;$/;"	p	class:grt::CUGRPin	typeref:typename:odb::dbITerm *	access:public	signature:() const
+getITermAccessPoints	src/GRNet.h	/^  const std::map<odb::dbITerm*, AccessPoint>& getITermAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::map<odb::dbITerm *,AccessPoint> &	access:public	signature:() const
+getITermsAccessPoints	include/CUGR.h	/^  void getITermsAccessPoints($/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net,std::map<odb::dbITerm *,odb::Point3D> & access_points)
+getITermsAccessPoints	src/CUGR.cpp	/^void CUGR::getITermsAccessPoints($/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net,std::map<odb::dbITerm *,odb::Point3D> & access_points)
+getIndex	src/GRNet.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::GRNet	typeref:typename:int	access:public	signature:() const
+getIndex	src/Layers.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getIndex	src/Netlist.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::CUGRNet	typeref:typename:int	access:public	signature:() const
+getIndex	src/Netlist.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::CUGRPin	typeref:typename:int	access:public	signature:() const
+getIndex	src/PatternRoute.h	/^  const int& getIndex() const { return index_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:const int &	access:public	signature:() const
+getLayer	src/Design.h	/^  const MetalLayer& getLayer(int layer_index) const$/;"	f	class:grt::Design	typeref:typename:const MetalLayer &	access:public	signature:(int layer_index) const
+getLayerDirection	src/GridGraph.h	/^  int getLayerDirection(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int layer_index) const
+getLayerIdx	src/GRTree.h	/^  int getLayerIdx() const { return layer_idx_; }$/;"	f	class:grt::GRPoint	typeref:typename:int	access:public	signature:() const
+getLayerIdx	src/GeoTypes.h	/^  int getLayerIdx() const { return layer_idx_; }$/;"	f	class:grt::BoxOnLayer	typeref:typename:int	access:public	signature:() const
+getLayerName	src/GridGraph.h	/^  std::string getLayerName(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:std::string	access:public	signature:(int layer_index) const
+getLayerRange	src/Netlist.h	/^  LayerRange getLayerRange() const { return layer_range_; }$/;"	f	class:grt::CUGRNet	typeref:typename:LayerRange	access:public	signature:() const
+getLibDBU	src/Design.h	/^  int getLibDBU() const { return lib_dbu_; }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+getLibDBU	src/GridGraph.h	/^  int getLibDBU() const { return lib_dbu_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+getM2Pitch	src/GridGraph.h	/^  int getM2Pitch() const { return m2_pitch_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+getMaxEolSpacing	src/Layers.h	/^  int getMaxEolSpacing() const { return max_eol_spacing_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getMinLength	src/Layers.h	/^  int getMinLength() const { return min_length_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getName	src/GRNet.h	/^  std::string getName() const { return db_net_->getName(); }$/;"	f	class:grt::GRNet	typeref:typename:std::string	access:public	signature:() const
+getName	src/Layers.h	/^  std::string getName() const { return name_; }$/;"	f	class:grt::MetalLayer	typeref:typename:std::string	access:public	signature:() const
+getName	src/Netlist.cpp	/^std::string CUGRPin::getName() const$/;"	f	class:grt::CUGRPin	typeref:typename:std::string	signature:() const
+getName	src/Netlist.h	/^  std::string getName() const { return db_net_->getName(); }$/;"	f	class:grt::CUGRNet	typeref:typename:std::string	access:public	signature:() const
+getName	src/Netlist.h	/^  std::string getName() const;$/;"	p	class:grt::CUGRPin	typeref:typename:std::string	access:public	signature:() const
+getNearestPointTo	src/geo.h	/^  PointT getNearestPointTo(const PointT& pt)$/;"	f	class:grt::BoxT	typeref:typename:PointT	access:public	signature:(const PointT & pt)
+getNearestPointTo	src/geo.h	/^  int getNearestPointTo(int val) const$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:(int val) const
+getNearestPointsTo	src/geo.h	/^  BoxT getNearestPointsTo(const BoxT& val) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & val) const
+getNearestPointsTo	src/geo.h	/^  IntervalT getNearestPointsTo(IntervalT val) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(IntervalT val) const
+getNet	src/PatternRoute.h	/^  const GRNet* getNet() const { return net_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const GRNet *	access:public	signature:() const
+getNetSlack	include/CUGR.h	/^  float getNetSlack(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:float	access:private	signature:(odb::dbNet * net)
+getNetSlack	src/CUGR.cpp	/^float CUGR::getNetSlack(odb::dbNet* net)$/;"	f	class:grt::CUGR	typeref:typename:float	signature:(odb::dbNet * net)
+getNextVertex	src/MazeRoute.h	/^  int getNextVertex(const int vertex, const int edge_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int vertex,const int edge_index) const
+getNumChildren	src/PatternRoute.h	/^  int getNumChildren() const { return children_.size(); }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:int	access:public	signature:() const
+getNumChildren	src/PatternRoute.h	/^  int getNumChildren() const { return children_.size(); }$/;"	f	class:grt::SteinerTreeNode	typeref:typename:int	access:public	signature:() const
+getNumDAGNodes	src/PatternRoute.h	/^  int getNumDAGNodes() const { return num_dag_nodes_; }$/;"	f	class:grt::PatternRoute	typeref:typename:int	access:public	signature:() const
+getNumLayers	src/Design.h	/^  int getNumLayers() const { return layers_.size(); }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+getNumLayers	src/GridGraph.h	/^  int getNumLayers() const { return num_layers_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+getNumPins	src/GRNet.h	/^  int getNumPins() const { return pin_access_points_.size(); }$/;"	f	class:grt::GRNet	typeref:typename:int	access:public	signature:() const
+getNumPins	src/Netlist.h	/^  int getNumPins() const { return pins_.size(); }$/;"	f	class:grt::CUGRNet	typeref:typename:int	access:public	signature:() const
+getNumPseudoPins	src/MazeRoute.h	/^  int getNumPseudoPins() const { return pseudo_pins_.size(); }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:() const
+getNumVertices	src/MazeRoute.h	/^  int getNumVertices() const { return vertices_.size(); }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:() const
+getParallelSpacing	src/Layers.cpp	/^int MetalLayer::getParallelSpacing(const int width, const int length) const$/;"	f	class:grt::MetalLayer	typeref:typename:int	signature:(const int width,const int length) const
+getParallelSpacing	src/Layers.h	/^  int getParallelSpacing(int width, int length = 0) const;$/;"	p	class:grt::MetalLayer	typeref:typename:int	access:public	signature:(int width,int length=0) const
+getPaths	src/PatternRoute.h	/^  std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>>& getPaths()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>> &	access:public	signature:()
+getPinAccessPoints	src/GRNet.h	/^  const std::vector<std::vector<GRPoint>>& getPinAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::vector<std::vector<GRPoint>> &	access:public	signature:() const
+getPinShapes	src/Netlist.h	/^  std::vector<BoxOnLayer> getPinShapes() const { return pin_shapes_; }$/;"	f	class:grt::CUGRPin	typeref:typename:std::vector<BoxOnLayer>	access:public	signature:() const
+getPinVertex	src/MazeRoute.h	/^  int getPinVertex(const int pin_index) const { return pin_vertex_[pin_index]; }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int pin_index) const
+getPins	src/Netlist.h	/^  std::vector<CUGRPin> getPins() const { return pins_; }$/;"	f	class:grt::CUGRNet	typeref:typename:std::vector<CUGRPin>	access:public	signature:() const
+getPitch	src/Layers.h	/^  int getPitch() const { return pitch_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getPoint	src/MazeRoute.h	/^  GRPoint getPoint(const int vertex) const { return vertices_[vertex]; }$/;"	f	class:grt::SparseGraph	typeref:typename:GRPoint	access:public	signature:(const int vertex) const
+getPseudoPin	src/MazeRoute.h	/^  AccessPoint getPseudoPin(int pin_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:AccessPoint	access:public	signature:(int pin_index) const
+getPythonString	src/GridGraph.cpp	/^std::string GridGraph::getPythonString($/;"	f	class:grt::GridGraph	typeref:typename:std::string	signature:(const std::shared_ptr<GRTreeNode> & routing_tree) const
+getPythonString	src/GridGraph.h	/^  std::string getPythonString($/;"	p	class:grt::GridGraph	typeref:typename:std::string	access:public	signature:(const std::shared_ptr<GRTreeNode> & routing_tree) const
+getPythonString	src/PatternRoute.cpp	/^std::string PatternRoutingNode::getPythonString($/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::string	signature:(std::shared_ptr<PatternRoutingNode> routing_dag_)
+getPythonString	src/PatternRoute.cpp	/^std::string SteinerTreeNode::getPythonString($/;"	f	class:grt::SteinerTreeNode	typeref:typename:std::string	signature:(const std::shared_ptr<SteinerTreeNode> & node)
+getPythonString	src/PatternRoute.h	/^  static std::string getPythonString($/;"	p	class:grt::PatternRoutingNode	typeref:typename:std::string	access:public	signature:(std::shared_ptr<PatternRoutingNode> routing_dag)
+getPythonString	src/PatternRoute.h	/^  static std::string getPythonString($/;"	p	class:grt::SteinerTreeNode	typeref:typename:std::string	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & node)
+getResource	src/GridGraph.h	/^  CapacityT getResource() const { return capacity - demand; }$/;"	f	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public	signature:() const
+getRoutes	include/CUGR.h	/^  NetRouteMap getRoutes();$/;"	p	class:grt::CUGR	typeref:typename:NetRouteMap	access:public	signature:()
+getRoutes	src/CUGR.cpp	/^NetRouteMap CUGR::getRoutes()$/;"	f	class:grt::CUGR	typeref:typename:NetRouteMap	signature:()
+getRoutingDAG	src/PatternRoute.h	/^  std::shared_ptr<PatternRoutingNode> getRoutingDAG() const$/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<PatternRoutingNode>	access:public	signature:() const
+getRoutingTree	src/GRNet.h	/^  const std::shared_ptr<GRTreeNode>& getRoutingTree() const$/;"	f	class:grt::GRNet	typeref:typename:const std::shared_ptr<GRTreeNode> &	access:public	signature:() const
+getRoutingTree	src/PatternRoute.cpp	/^std::shared_ptr<GRTreeNode> PatternRoute::getRoutingTree($/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<GRTreeNode>	signature:(std::shared_ptr<PatternRoutingNode> & node,int parent_layer_index)
+getRoutingTree	src/PatternRoute.h	/^  std::shared_ptr<GRTreeNode> getRoutingTree($/;"	p	class:grt::PatternRoute	typeref:typename:std::shared_ptr<GRTreeNode>	access:private	signature:(std::shared_ptr<PatternRoutingNode> & node,int parent_layer_index=-1)
+getSize	src/GridGraph.h	/^  int getSize(int dimension) const { return (dimension ? y_size_ : x_size_); }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int dimension) const
+getSlack	src/GRNet.h	/^  float getSlack() const { return slack_; }$/;"	f	class:grt::GRNet	typeref:typename:float	access:public	signature:() const
+getSteinerTree	src/MazeRoute.cpp	/^std::shared_ptr<SteinerTreeNode> MazeRoute::getSteinerTree() const$/;"	f	class:grt::MazeRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	signature:() const
+getSteinerTree	src/MazeRoute.h	/^  std::shared_ptr<SteinerTreeNode> getSteinerTree() const;$/;"	p	class:grt::MazeRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:public	signature:() const
+getSteinerTree	src/PatternRoute.h	/^  std::shared_ptr<SteinerTreeNode> getSteinerTree() const$/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:public	signature:() const
+getSttInputFileName	include/CUGR.h	/^  std::string getSttInputFileName();$/;"	p	class:grt::CUGR	typeref:typename:std::string	access:public	signature:()
+getSttInputFileName	src/CUGR.cpp	/^std::string CUGR::getSttInputFileName()$/;"	f	class:grt::CUGR	typeref:typename:std::string	signature:()
+getSttTree	src/PatternRoute.h	/^  const stt::Tree& getSttTree() const { return stt_tree_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const stt::Tree &	access:public	signature:() const
+getTrackLocation	src/Layers.cpp	/^int MetalLayer::getTrackLocation(const int track_index) const$/;"	f	class:grt::MetalLayer	typeref:typename:int	signature:(const int track_index) const
+getTrackLocation	src/Layers.h	/^  int getTrackLocation(int track_index) const;$/;"	p	class:grt::MetalLayer	typeref:typename:int	access:public	signature:(int track_index) const
+getUnitLengthShortCost	src/Design.h	/^  CostT getUnitLengthShortCost(const int layer_index) const$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:(const int layer_index) const
+getUnitLengthShortCost	src/GridGraph.h	/^  CostT getUnitLengthShortCost(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:(int layer_index) const
+getUnitLengthWireCost	src/Design.h	/^  CostT getUnitLengthWireCost() const { return unit_length_wire_cost_; }$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:() const
+getUnitLengthWireCost	src/GridGraph.h	/^  CostT getUnitLengthWireCost() const { return unit_length_wire_cost_; }$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:() const
+getUnitViaCost	src/Design.h	/^  CostT getUnitViaCost() const { return unit_via_cost_; }$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:() const
+getUnitViaCost	src/GridGraph.h	/^  CostT getUnitViaCost() const { return unit_via_cost_; }$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:() const
+getVertexIndex	src/MazeRoute.h	/^  int getVertexIndex(int direction, int xi, int yi) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:private	signature:(int direction,int xi,int yi) const
+getVertexPin	src/MazeRoute.h	/^  int getVertexPin(const int vertex) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int vertex) const
+getViaCost	src/GridGraph.cpp	/^CostT GridGraph::getViaCost(const int layer_index, const PointT loc) const$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT loc) const
+getViaCost	src/GridGraph.h	/^  CostT getViaCost(int layer_index, PointT loc) const;$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:(int layer_index,PointT loc) const
+getWidth	src/Layers.h	/^  int getWidth() const { return width_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+getWireCost	src/GridGraph.cpp	/^CostT GridGraph::getWireCost(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT lower,const CapacityT demand) const
+getWireCost	src/GridGraph.cpp	/^CostT GridGraph::getWireCost(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT u,const PointT v) const
+getWireCost	src/GridGraph.h	/^  CostT getWireCost(int layer_index, PointT u, PointT v) const;$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:(int layer_index,PointT u,PointT v) const
+getWireCost	src/GridGraph.h	/^  CostT getWireCost(int layer_index,$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:(int layer_index,PointT lower,CapacityT demand=1.0) const
+getXSize	src/GridGraph.h	/^  int getXSize() const { return x_size_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+getYSize	src/GridGraph.h	/^  int getYSize() const { return y_size_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+gr_nets_	include/CUGR.h	/^  std::vector<std::unique_ptr<GRNet>> gr_nets_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<std::unique_ptr<GRNet>>	access:private
+graph_	src/MazeRoute.h	/^  SparseGraph graph_;$/;"	m	class:grt::MazeRoute	typeref:typename:SparseGraph	access:private
+graph_edges_	src/GridGraph.h	/^  std::vector<std::vector<std::vector<GraphEdge>>> graph_edges_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::vector<std::vector<GraphEdge>>>	access:private
+grid_centers_	src/GridGraph.h	/^  std::vector<std::vector<int>> grid_centers_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::vector<int>>	access:private
+grid_graph_	include/CUGR.h	/^  std::unique_ptr<GridGraph> grid_graph_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<GridGraph>	access:private
+grid_graph_	src/MazeRoute.h	/^  const GridGraph* grid_graph_;$/;"	m	class:grt::SparseGraph	typeref:typename:const GridGraph *	access:private
+grid_graph_	src/PatternRoute.h	/^  const GridGraph* grid_graph_;$/;"	m	class:grt::PatternRoute	typeref:typename:const GridGraph *	access:private
+gridlines_	src/Design.h	/^  std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::Design	typeref:typename:std::vector<std::vector<int>>	access:private
+gridlines_	src/GridGraph.h	/^  const std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::GridGraph	typeref:typename:const std::vector<std::vector<int>>	access:private
+gridlines_	src/PatternRoute.h	/^  std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::vector<std::vector<int>>	access:private
+grt	include/CUGR.h	/^namespace grt {$/;"	n
+grt	src/CUGR.cpp	/^namespace grt {$/;"	n	file:
+grt	src/Design.cpp	/^namespace grt {$/;"	n	file:
+grt	src/Design.h	/^namespace grt {$/;"	n
+grt	src/GRNet.cpp	/^namespace grt {$/;"	n	file:
+grt	src/GRNet.h	/^namespace grt {$/;"	n
+grt	src/GRTree.cpp	/^namespace grt {$/;"	n	file:
+grt	src/GRTree.h	/^namespace grt {$/;"	n
+grt	src/GeoTypes.cpp	/^namespace grt {$/;"	n	file:
+grt	src/GeoTypes.h	/^namespace grt {$/;"	n
+grt	src/GridGraph.cpp	/^namespace grt {$/;"	n	file:
+grt	src/GridGraph.h	/^namespace grt {$/;"	n
+grt	src/Layers.cpp	/^namespace grt {$/;"	n	file:
+grt	src/Layers.h	/^namespace grt {$/;"	n
+grt	src/MazeRoute.cpp	/^namespace grt {$/;"	n	file:
+grt	src/MazeRoute.h	/^namespace grt {$/;"	n
+grt	src/Netlist.cpp	/^namespace grt {$/;"	n	file:
+grt	src/Netlist.h	/^namespace grt {$/;"	n
+grt	src/PatternRoute.cpp	/^namespace grt {$/;"	n	file:
+grt	src/PatternRoute.h	/^namespace grt {$/;"	n
+grt	src/geo.h	/^namespace grt {$/;"	n
+grt::AccessPoint	src/GridGraph.h	/^struct AccessPoint$/;"	s	namespace:grt
+grt::AccessPoint::layers	src/GridGraph.h	/^  IntervalT layers;$/;"	m	struct:grt::AccessPoint	typeref:typename:IntervalT	access:public
+grt::AccessPoint::operator ==	src/GridGraph.h	/^  bool operator==(const AccessPoint& ap) const$/;"	f	struct:grt::AccessPoint	typeref:typename:bool	access:public	signature:(const AccessPoint & ap) const
+grt::AccessPoint::point	src/GridGraph.h	/^  PointT point;$/;"	m	struct:grt::AccessPoint	typeref:typename:PointT	access:public
+grt::AccessPointEqual	src/GridGraph.h	/^struct AccessPointEqual$/;"	s	namespace:grt
+grt::AccessPointEqual::operator ()	src/GridGraph.h	/^  bool operator()(const AccessPoint& lhs, const AccessPoint& rhs) const$/;"	f	struct:grt::AccessPointEqual	typeref:typename:bool	access:public	signature:(const AccessPoint & lhs,const AccessPoint & rhs) const
+grt::AccessPointHash	src/GridGraph.h	/^class AccessPointHash$/;"	c	namespace:grt
+grt::AccessPointHash::AccessPointHash	src/GridGraph.h	/^  AccessPointHash(int y_size) : y_size_(y_size) {}$/;"	f	class:grt::AccessPointHash	access:public	signature:(int y_size)
+grt::AccessPointHash::operator ()	src/GridGraph.h	/^  std::size_t operator()(const AccessPoint& ap) const$/;"	f	class:grt::AccessPointHash	typeref:typename:std::size_t	access:public	signature:(const AccessPoint & ap) const
+grt::AccessPointHash::y_size_	src/GridGraph.h	/^  const uint64_t y_size_;$/;"	m	class:grt::AccessPointHash	typeref:typename:const uint64_t	access:private
+grt::AccessPointSet	src/GridGraph.h	/^using AccessPointSet$/;"	t	namespace:grt	typeref:typename:robin_hood::unordered_set<AccessPoint,AccessPointHash,AccessPointEqual>
+grt::BoxOnLayer	src/GeoTypes.h	/^class BoxOnLayer : public BoxT$/;"	c	namespace:grt	inherits:BoxT
+grt::BoxOnLayer::BoxOnLayer	src/GeoTypes.h	/^  BoxOnLayer(int layer_index = -1, Args... params)$/;"	f	class:grt::BoxOnLayer	access:public	signature:(int layer_index=-1,Args...params)
+grt::BoxOnLayer::getLayerIdx	src/GeoTypes.h	/^  int getLayerIdx() const { return layer_idx_; }$/;"	f	class:grt::BoxOnLayer	typeref:typename:int	access:public	signature:() const
+grt::BoxOnLayer::isConnected	src/GeoTypes.cpp	/^bool BoxOnLayer::isConnected(const BoxOnLayer& rhs) const$/;"	f	class:grt::BoxOnLayer	typeref:typename:bool	signature:(const BoxOnLayer & rhs) const
+grt::BoxOnLayer::isConnected	src/GeoTypes.h	/^  bool isConnected(const BoxOnLayer& rhs) const;$/;"	p	class:grt::BoxOnLayer	typeref:typename:bool	access:public	signature:(const BoxOnLayer & rhs) const
+grt::BoxOnLayer::layer_idx_	src/GeoTypes.h	/^  int layer_idx_;$/;"	m	class:grt::BoxOnLayer	typeref:typename:int	access:private
+grt::BoxOnLayer::set	src/GeoTypes.h	/^  void set(int layer_index = -1, Args... params)$/;"	f	class:grt::BoxOnLayer	typeref:typename:void	access:public	signature:(int layer_index=-1,Args...params)
+grt::BoxT	src/geo.h	/^class BoxT$/;"	c	namespace:grt
+grt::BoxT::BoxT	src/geo.h	/^  BoxT() { set(); }$/;"	f	class:grt::BoxT	access:public	signature:()
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(const BoxT& box) { set(box); }$/;"	f	class:grt::BoxT	access:public	signature:(const BoxT & box)
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(const IntervalT& x_range, const IntervalT& y_range)$/;"	f	class:grt::BoxT	access:public	signature:(const IntervalT & x_range,const IntervalT & y_range)
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(const PointT& low, const PointT& high) { set(low, high); }$/;"	f	class:grt::BoxT	access:public	signature:(const PointT & low,const PointT & high)
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(const PointT& pt) { set(pt); }$/;"	f	class:grt::BoxT	access:public	signature:(const PointT & pt)
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(int lx, int ly, int hx, int hy) { set(lx, ly, hx, hy); }$/;"	f	class:grt::BoxT	access:public	signature:(int lx,int ly,int hx,int hy)
+grt::BoxT::BoxT	src/geo.h	/^  BoxT(int x_val, int y_val) { set(x_val, y_val); }$/;"	f	class:grt::BoxT	access:public	signature:(int x_val,int y_val)
+grt::BoxT::area	src/geo.h	/^  int area() const { return width() * height(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::contain	src/geo.h	/^  bool contain(const PointT& pt) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const PointT & pt) const
+grt::BoxT::cx	src/geo.h	/^  int cx() const { return x_.center(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::cy	src/geo.h	/^  int cy() const { return y_.center(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::fastUpdate	src/geo.h	/^  void fastUpdate(const PointT& pt) { fastUpdate(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+grt::BoxT::fastUpdate	src/geo.h	/^  void fastUpdate(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+grt::BoxT::getNearestPointTo	src/geo.h	/^  PointT getNearestPointTo(const PointT& pt)$/;"	f	class:grt::BoxT	typeref:typename:PointT	access:public	signature:(const PointT & pt)
+grt::BoxT::getNearestPointsTo	src/geo.h	/^  BoxT getNearestPointsTo(const BoxT& val) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & val) const
+grt::BoxT::hasIntersectWith	src/geo.h	/^  bool hasIntersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::hasStrictIntersectWith	src/geo.h	/^  bool hasStrictIntersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::height	src/geo.h	/^  int height() const { return y_.range(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::hp	src/geo.h	/^  int hp() const { return width() + height(); }  \/\/ half perimeter$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::hx	src/geo.h	/^  int hx() const { return x_.high(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::hy	src/geo.h	/^  int hy() const { return y_.high(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::intersectWith	src/geo.h	/^  BoxT intersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::isStrictValid	src/geo.h	/^  bool isStrictValid() const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:() const
+grt::BoxT::isValid	src/geo.h	/^  bool isValid() const { return x_.isValid() && y_.isValid(); }$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:() const
+grt::BoxT::lx	src/geo.h	/^  int lx() const { return x_.low(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::ly	src/geo.h	/^  int ly() const { return y_.low(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::operator !=	src/geo.h	/^  bool operator!=(const BoxT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::operator ==	src/geo.h	/^  bool operator==(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::operator []	src/geo.h	/^  IntervalT& operator[](int i)$/;"	f	class:grt::BoxT	typeref:typename:IntervalT &	access:public	signature:(int i)
+grt::BoxT::operator []	src/geo.h	/^  const IntervalT& operator[](int i) const$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:(int i) const
+grt::BoxT::set	src/geo.h	/^  void set()$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:()
+grt::BoxT::set	src/geo.h	/^  void set(const BoxT& box) { set(box.x(), box.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const BoxT & box)
+grt::BoxT::set	src/geo.h	/^  void set(const IntervalT& x_range, const IntervalT& y_range)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const IntervalT & x_range,const IntervalT & y_range)
+grt::BoxT::set	src/geo.h	/^  void set(const PointT& low, const PointT& high)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & low,const PointT & high)
+grt::BoxT::set	src/geo.h	/^  void set(const PointT& pt) { set(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+grt::BoxT::set	src/geo.h	/^  void set(int lx, int ly, int hx, int hy)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int lx,int ly,int hx,int hy)
+grt::BoxT::set	src/geo.h	/^  void set(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+grt::BoxT::shiftBy	src/geo.h	/^  void shiftBy(const PointT& rhs)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & rhs)
+grt::BoxT::strictlyContain	src/geo.h	/^  bool strictlyContain(const PointT& pt) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const PointT & pt) const
+grt::BoxT::unionWith	src/geo.h	/^  BoxT unionWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & rhs) const
+grt::BoxT::update	src/geo.h	/^  void update(const PointT& pt) { update(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+grt::BoxT::update	src/geo.h	/^  void update(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+grt::BoxT::width	src/geo.h	/^  int width() const { return x_.range(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+grt::BoxT::x	src/geo.h	/^  const IntervalT& x() const { return x_; }$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:() const
+grt::BoxT::x_	src/geo.h	/^  IntervalT x_;$/;"	m	class:grt::BoxT	typeref:typename:IntervalT	access:private
+grt::BoxT::y	src/geo.h	/^  const IntervalT& y() const { return y_; }$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:() const
+grt::BoxT::y_	src/geo.h	/^  IntervalT y_;$/;"	m	class:grt::BoxT	typeref:typename:IntervalT	access:private
+grt::CUGR	include/CUGR.h	/^class CUGR$/;"	c	namespace:grt
+grt::CUGR::CUGR	include/CUGR.h	/^  CUGR(odb::dbDatabase* db,$/;"	p	class:grt::CUGR	access:public	signature:(odb::dbDatabase * db,utl::Logger * log,utl::CallBackHandler * callback_handler,stt::SteinerTreeBuilder * stt_builder,sta::dbSta * sta)
+grt::CUGR::CUGR	src/CUGR.cpp	/^CUGR::CUGR(odb::dbDatabase* db,$/;"	f	class:grt::CUGR	signature:(odb::dbDatabase * db,utl::Logger * log,utl::CallBackHandler * callback_handler,stt::SteinerTreeBuilder * stt_builder,sta::dbSta * sta)
+grt::CUGR::StTreeVisualization	include/CUGR.h	/^  void StTreeVisualization(const StTree& stree, GRNet* net, bool is3DVisualization);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const StTree & stree,GRNet * net,bool is3DVisualization)
+grt::CUGR::StTreeVisualization	src/CUGR.cpp	/^void CUGR::StTreeVisualization(const StTree& stree, GRNet* net, bool is3DVisualization)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const StTree & stree,GRNet * net,bool is3DVisualization)
+grt::CUGR::addDirtyNet	include/CUGR.h	/^  void addDirtyNet(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net)
+grt::CUGR::addDirtyNet	src/CUGR.cpp	/^void CUGR::addDirtyNet(odb::dbNet* net)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net)
+grt::CUGR::area_of_pin_patches_	include/CUGR.h	/^  int area_of_pin_patches_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:int	access:private
+grt::CUGR::area_of_wire_patches_	include/CUGR.h	/^  int area_of_wire_patches_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:int	access:private
+grt::CUGR::calculatePartialSlack	include/CUGR.h	/^  float calculatePartialSlack();$/;"	p	class:grt::CUGR	typeref:typename:float	access:private	signature:()
+grt::CUGR::calculatePartialSlack	src/CUGR.cpp	/^float CUGR::calculatePartialSlack()$/;"	f	class:grt::CUGR	typeref:typename:float	signature:()
+grt::CUGR::callback_handler_	include/CUGR.h	/^  utl::CallBackHandler* callback_handler_;$/;"	m	class:grt::CUGR	typeref:typename:utl::CallBackHandler *	access:private
+grt::CUGR::constants_	include/CUGR.h	/^  Constants constants_;$/;"	m	class:grt::CUGR	typeref:typename:Constants	access:private
+grt::CUGR::critical_nets_percentage_	include/CUGR.h	/^  float critical_nets_percentage_ = 0;$/;"	m	class:grt::CUGR	typeref:typename:float	access:private
+grt::CUGR::db_	include/CUGR.h	/^  odb::dbDatabase* db_;$/;"	m	class:grt::CUGR	typeref:typename:odb::dbDatabase *	access:private
+grt::CUGR::db_net_map_	include/CUGR.h	/^  std::map<odb::dbNet*, GRNet*> db_net_map_;$/;"	m	class:grt::CUGR	typeref:typename:std::map<odb::dbNet *,GRNet * >	access:private
+grt::CUGR::debug_	include/CUGR.h	/^  std::unique_ptr<DebugSetting> debug_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<DebugSetting>	access:private
+grt::CUGR::design_	include/CUGR.h	/^  std::unique_ptr<Design> design_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<Design>	access:private
+grt::CUGR::getBTermsAccessPoints	include/CUGR.h	/^  void getBTermsAccessPoints($/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net,std::map<odb::dbBTerm *,odb::Point3D> & access_points)
+grt::CUGR::getBTermsAccessPoints	src/CUGR.cpp	/^void CUGR::getBTermsAccessPoints($/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net,std::map<odb::dbBTerm *,odb::Point3D> & access_points)
+grt::CUGR::getDebugNet	include/CUGR.h	/^  const odb::dbNet* getDebugNet();$/;"	p	class:grt::CUGR	typeref:typename:const odb::dbNet *	access:public	signature:()
+grt::CUGR::getDebugNet	src/CUGR.cpp	/^const odb::dbNet* CUGR::getDebugNet()$/;"	f	class:grt::CUGR	typeref:typename:const odb::dbNet *	signature:()
+grt::CUGR::getDebugRenderer	include/CUGR.h	/^  AbstractFastRouteRenderer* getDebugRenderer() const;$/;"	p	class:grt::CUGR	typeref:typename:AbstractFastRouteRenderer *	access:public	signature:() const
+grt::CUGR::getDebugRenderer	src/CUGR.cpp	/^AbstractFastRouteRenderer* CUGR::getDebugRenderer() const$/;"	f	class:grt::CUGR	typeref:typename:AbstractFastRouteRenderer *	signature:() const
+grt::CUGR::getGuides	include/CUGR.h	/^  void getGuides(const GRNet* net,$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const GRNet * net,std::vector<std::pair<int,grt::BoxT>> & guides)
+grt::CUGR::getGuides	src/CUGR.cpp	/^void CUGR::getGuides(const GRNet* net,$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const GRNet * net,std::vector<std::pair<int,BoxT>> & guides)
+grt::CUGR::getITermsAccessPoints	include/CUGR.h	/^  void getITermsAccessPoints($/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net,std::map<odb::dbITerm *,odb::Point3D> & access_points)
+grt::CUGR::getITermsAccessPoints	src/CUGR.cpp	/^void CUGR::getITermsAccessPoints($/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * net,std::map<odb::dbITerm *,odb::Point3D> & access_points)
+grt::CUGR::getNetSlack	include/CUGR.h	/^  float getNetSlack(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:float	access:private	signature:(odb::dbNet * net)
+grt::CUGR::getNetSlack	src/CUGR.cpp	/^float CUGR::getNetSlack(odb::dbNet* net)$/;"	f	class:grt::CUGR	typeref:typename:float	signature:(odb::dbNet * net)
+grt::CUGR::getRoutes	include/CUGR.h	/^  NetRouteMap getRoutes();$/;"	p	class:grt::CUGR	typeref:typename:NetRouteMap	access:public	signature:()
+grt::CUGR::getRoutes	src/CUGR.cpp	/^NetRouteMap CUGR::getRoutes()$/;"	f	class:grt::CUGR	typeref:typename:NetRouteMap	signature:()
+grt::CUGR::getSttInputFileName	include/CUGR.h	/^  std::string getSttInputFileName();$/;"	p	class:grt::CUGR	typeref:typename:std::string	access:public	signature:()
+grt::CUGR::getSttInputFileName	src/CUGR.cpp	/^std::string CUGR::getSttInputFileName()$/;"	f	class:grt::CUGR	typeref:typename:std::string	signature:()
+grt::CUGR::gr_nets_	include/CUGR.h	/^  std::vector<std::unique_ptr<GRNet>> gr_nets_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<std::unique_ptr<GRNet>>	access:private
+grt::CUGR::grid_graph_	include/CUGR.h	/^  std::unique_ptr<GridGraph> grid_graph_;$/;"	m	class:grt::CUGR	typeref:typename:std::unique_ptr<GridGraph>	access:private
+grt::CUGR::hasSaveSttInput	include/CUGR.h	/^  bool hasSaveSttInput();$/;"	p	class:grt::CUGR	typeref:typename:bool	access:public	signature:()
+grt::CUGR::hasSaveSttInput	src/CUGR.cpp	/^bool CUGR::hasSaveSttInput()$/;"	f	class:grt::CUGR	typeref:typename:bool	signature:()
+grt::CUGR::init	include/CUGR.h	/^  void init(int min_routing_layer,$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(int min_routing_layer,int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+grt::CUGR::init	src/CUGR.cpp	/^void CUGR::init(const int min_routing_layer,$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const int min_routing_layer,const int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+grt::CUGR::logger_	include/CUGR.h	/^  utl::Logger* logger_;$/;"	m	class:grt::CUGR	typeref:typename:utl::Logger *	access:private
+grt::CUGR::mazeRoute	include/CUGR.h	/^  void mazeRoute(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+grt::CUGR::mazeRoute	src/CUGR.cpp	/^void CUGR::mazeRoute(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+grt::CUGR::net_indices_	include/CUGR.h	/^  std::vector<int> net_indices_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<int>	access:private
+grt::CUGR::nets_to_route_	include/CUGR.h	/^  std::vector<int> nets_to_route_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<int>	access:private
+grt::CUGR::patternRoute	include/CUGR.h	/^  void patternRoute(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+grt::CUGR::patternRoute	src/CUGR.cpp	/^void CUGR::patternRoute(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+grt::CUGR::patternRouteWithDetours	include/CUGR.h	/^  void patternRouteWithDetours(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+grt::CUGR::patternRouteWithDetours	src/CUGR.cpp	/^void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+grt::CUGR::printStatistics	include/CUGR.h	/^  void printStatistics() const;$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:() const
+grt::CUGR::printStatistics	src/CUGR.cpp	/^void CUGR::printStatistics() const$/;"	f	class:grt::CUGR	typeref:typename:void	signature:() const
+grt::CUGR::route	include/CUGR.h	/^  void route();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+grt::CUGR::route	src/CUGR.cpp	/^void CUGR::route()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+grt::CUGR::routeIncremental	include/CUGR.h	/^  void routeIncremental();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+grt::CUGR::routeIncremental	src/CUGR.cpp	/^void CUGR::routeIncremental()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+grt::CUGR::routes_	include/CUGR.h	/^  NetRouteMap routes_;$/;"	m	class:grt::CUGR	typeref:typename:NetRouteMap	access:private
+grt::CUGR::setCriticalNetsPercentage	include/CUGR.h	/^  void setCriticalNetsPercentage(float percentage)$/;"	f	class:grt::CUGR	typeref:typename:void	access:public	signature:(float percentage)
+grt::CUGR::setDebugNet	include/CUGR.h	/^  void setDebugNet(const odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const odb::dbNet * net)
+grt::CUGR::setDebugNet	src/CUGR.cpp	/^void CUGR::setDebugNet(const odb::dbNet* net) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const odb::dbNet * net)
+grt::CUGR::setDebugOn	include/CUGR.h	/^  void setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(std::unique_ptr<AbstractFastRouteRenderer> renderer)
+grt::CUGR::setDebugOn	src/CUGR.cpp	/^void CUGR::setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::unique_ptr<AbstractFastRouteRenderer> renderer)
+grt::CUGR::setDebugRectilinearSTree	include/CUGR.h	/^  void setDebugRectilinearSTree(bool rectilinearSTree); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool rectilinearSTree)
+grt::CUGR::setDebugRectilinearSTree	src/CUGR.cpp	/^void CUGR::setDebugRectilinearSTree(bool rectilinearSTree)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool rectilinearSTree)
+grt::CUGR::setDebugSteinerTree	include/CUGR.h	/^  void setDebugSteinerTree(bool steinerTree);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool steinerTree)
+grt::CUGR::setDebugSteinerTree	src/CUGR.cpp	/^void CUGR::setDebugSteinerTree(bool steinerTree) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool steinerTree)
+grt::CUGR::setDebugTree2D	include/CUGR.h	/^  void setDebugTree2D(bool tree2D); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool tree2D)
+grt::CUGR::setDebugTree2D	src/CUGR.cpp	/^void CUGR::setDebugTree2D(bool tree2D)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool tree2D)
+grt::CUGR::setDebugTree3D	include/CUGR.h	/^  void setDebugTree3D(bool tree3D);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool tree3D)
+grt::CUGR::setDebugTree3D	src/CUGR.cpp	/^void CUGR::setDebugTree3D(bool tree3D)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool tree3D)
+grt::CUGR::setInitialNetSlacks	include/CUGR.h	/^  void setInitialNetSlacks();$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:()
+grt::CUGR::setInitialNetSlacks	src/CUGR.cpp	/^void CUGR::setInitialNetSlacks()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+grt::CUGR::setSttInputFilename	include/CUGR.h	/^  void setSttInputFilename(const char* file_name);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const char * file_name)
+grt::CUGR::setSttInputFilename	src/CUGR.cpp	/^void CUGR::setSttInputFilename(const char* file_name) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const char * file_name)
+grt::CUGR::sortNetIndices	include/CUGR.h	/^  void sortNetIndices(std::vector<int>& net_indices) const;$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices) const
+grt::CUGR::sortNetIndices	src/CUGR.cpp	/^void CUGR::sortNetIndices(std::vector<int>& net_indices) const$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices) const
+grt::CUGR::sta_	include/CUGR.h	/^  sta::dbSta* sta_;$/;"	m	class:grt::CUGR	typeref:typename:sta::dbSta *	access:private
+grt::CUGR::steinerTreeVisualization	include/CUGR.h	/^  void steinerTreeVisualization(const stt::Tree& stree, GRNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const stt::Tree & stree,GRNet * net)
+grt::CUGR::steinerTreeVisualization	src/CUGR.cpp	/^void CUGR::steinerTreeVisualization(const stt::Tree& stree, GRNet* net) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const stt::Tree & stree,GRNet * net)
+grt::CUGR::stt_builder_	include/CUGR.h	/^  stt::SteinerTreeBuilder* stt_builder_;$/;"	m	class:grt::CUGR	typeref:typename:stt::SteinerTreeBuilder *	access:private
+grt::CUGR::updateDbCongestion	include/CUGR.h	/^  void updateDbCongestion();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+grt::CUGR::updateDbCongestion	src/CUGR.cpp	/^void CUGR::updateDbCongestion()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+grt::CUGR::updateNet	include/CUGR.h	/^  void updateNet(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net)
+grt::CUGR::updateNet	src/CUGR.cpp	/^void CUGR::updateNet(odb::dbNet* db_net)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * db_net)
+grt::CUGR::updateOverflowNets	include/CUGR.h	/^  void updateOverflowNets(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+grt::CUGR::updateOverflowNets	src/CUGR.cpp	/^void CUGR::updateOverflowNets(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+grt::CUGR::write	include/CUGR.h	/^  void write(const std::string& guide_file);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const std::string & guide_file)
+grt::CUGR::write	src/CUGR.cpp	/^void CUGR::write(const std::string& guide_file)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const std::string & guide_file)
+grt::CUGR::~CUGR	include/CUGR.h	/^  ~CUGR();$/;"	p	class:grt::CUGR	access:public	signature:()
+grt::CUGR::~CUGR	src/CUGR.cpp	/^CUGR::~CUGR() = default;$/;"	p	class:grt::CUGR	file:	signature:()
+grt::CUGRNet	src/Netlist.h	/^class CUGRNet$/;"	c	namespace:grt
+grt::CUGRNet::CUGRNet	src/Netlist.cpp	/^CUGRNet::CUGRNet(const int index,$/;"	f	class:grt::CUGRNet	signature:(const int index,odb::dbNet * db_net,const std::vector<CUGRPin> & pins,LayerRange layer_range)
+grt::CUGRNet::CUGRNet	src/Netlist.h	/^  CUGRNet(int index,$/;"	p	class:grt::CUGRNet	access:public	signature:(int index,odb::dbNet * db_net,const std::vector<CUGRPin> & pins,LayerRange layer_range)
+grt::CUGRNet::db_net_	src/Netlist.h	/^  odb::dbNet* db_net_;$/;"	m	class:grt::CUGRNet	typeref:typename:odb::dbNet *	access:private
+grt::CUGRNet::getDbNet	src/Netlist.h	/^  odb::dbNet* getDbNet() const { return db_net_; }$/;"	f	class:grt::CUGRNet	typeref:typename:odb::dbNet *	access:public	signature:() const
+grt::CUGRNet::getIndex	src/Netlist.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::CUGRNet	typeref:typename:int	access:public	signature:() const
+grt::CUGRNet::getLayerRange	src/Netlist.h	/^  LayerRange getLayerRange() const { return layer_range_; }$/;"	f	class:grt::CUGRNet	typeref:typename:LayerRange	access:public	signature:() const
+grt::CUGRNet::getName	src/Netlist.h	/^  std::string getName() const { return db_net_->getName(); }$/;"	f	class:grt::CUGRNet	typeref:typename:std::string	access:public	signature:() const
+grt::CUGRNet::getNumPins	src/Netlist.h	/^  int getNumPins() const { return pins_.size(); }$/;"	f	class:grt::CUGRNet	typeref:typename:int	access:public	signature:() const
+grt::CUGRNet::getPins	src/Netlist.h	/^  std::vector<CUGRPin> getPins() const { return pins_; }$/;"	f	class:grt::CUGRNet	typeref:typename:std::vector<CUGRPin>	access:public	signature:() const
+grt::CUGRNet::index_	src/Netlist.h	/^  const int index_;$/;"	m	class:grt::CUGRNet	typeref:typename:const int	access:private
+grt::CUGRNet::layer_range_	src/Netlist.h	/^  LayerRange layer_range_;$/;"	m	class:grt::CUGRNet	typeref:typename:LayerRange	access:private
+grt::CUGRNet::pins_	src/Netlist.h	/^  std::vector<CUGRPin> pins_;$/;"	m	class:grt::CUGRNet	typeref:typename:std::vector<CUGRPin>	access:private
+grt::CUGRNet::setLayerRange	src/Netlist.h	/^  void setLayerRange(LayerRange layer_range) { layer_range_ = layer_range; }$/;"	f	class:grt::CUGRNet	typeref:typename:void	access:public	signature:(LayerRange layer_range)
+grt::CUGRNet::setPins	src/Netlist.h	/^  void setPins(std::vector<CUGRPin> pins) { pins_ = std::move(pins); }$/;"	f	class:grt::CUGRNet	typeref:typename:void	access:public	signature:(std::vector<CUGRPin> pins)
+grt::CUGRPin	src/Netlist.h	/^class CUGRPin$/;"	c	namespace:grt
+grt::CUGRPin::CUGRPin	src/Netlist.cpp	/^CUGRPin::CUGRPin(const int index,$/;"	f	class:grt::CUGRPin	signature:(const int index,odb::dbBTerm * bterm,const std::vector<BoxOnLayer> & pin_shapes)
+grt::CUGRPin::CUGRPin	src/Netlist.cpp	/^CUGRPin::CUGRPin(const int index,$/;"	f	class:grt::CUGRPin	signature:(const int index,odb::dbITerm * iterm,const std::vector<BoxOnLayer> & pin_shapes)
+grt::CUGRPin::CUGRPin	src/Netlist.h	/^  CUGRPin(int index,$/;"	p	class:grt::CUGRPin	access:public	signature:(int index,odb::dbBTerm * bterm,const std::vector<BoxOnLayer> & pin_shapes)
+grt::CUGRPin::CUGRPin	src/Netlist.h	/^  CUGRPin(int index,$/;"	p	class:grt::CUGRPin	access:public	signature:(int index,odb::dbITerm * iterm,const std::vector<BoxOnLayer> & pin_shapes)
+grt::CUGRPin::__anoncab81335010a	src/Netlist.h	/^  {$/;"	u	class:grt::CUGRPin	access:private
+grt::CUGRPin::__anoncab81335010a::bterm	src/Netlist.h	/^    odb::dbBTerm* bterm;$/;"	m	union:grt::CUGRPin::__anoncab81335010a	typeref:typename:odb::dbBTerm *	access:public
+grt::CUGRPin::__anoncab81335010a::iterm	src/Netlist.h	/^    odb::dbITerm* iterm;$/;"	m	union:grt::CUGRPin::__anoncab81335010a	typeref:typename:odb::dbITerm *	access:public
+grt::CUGRPin::getBTerm	src/Netlist.cpp	/^odb::dbBTerm* CUGRPin::getBTerm() const$/;"	f	class:grt::CUGRPin	typeref:typename:odb::dbBTerm *	signature:() const
+grt::CUGRPin::getBTerm	src/Netlist.h	/^  odb::dbBTerm* getBTerm() const;$/;"	p	class:grt::CUGRPin	typeref:typename:odb::dbBTerm *	access:public	signature:() const
+grt::CUGRPin::getITerm	src/Netlist.cpp	/^odb::dbITerm* CUGRPin::getITerm() const$/;"	f	class:grt::CUGRPin	typeref:typename:odb::dbITerm *	signature:() const
+grt::CUGRPin::getITerm	src/Netlist.h	/^  odb::dbITerm* getITerm() const;$/;"	p	class:grt::CUGRPin	typeref:typename:odb::dbITerm *	access:public	signature:() const
+grt::CUGRPin::getIndex	src/Netlist.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::CUGRPin	typeref:typename:int	access:public	signature:() const
+grt::CUGRPin::getName	src/Netlist.cpp	/^std::string CUGRPin::getName() const$/;"	f	class:grt::CUGRPin	typeref:typename:std::string	signature:() const
+grt::CUGRPin::getName	src/Netlist.h	/^  std::string getName() const;$/;"	p	class:grt::CUGRPin	typeref:typename:std::string	access:public	signature:() const
+grt::CUGRPin::getPinShapes	src/Netlist.h	/^  std::vector<BoxOnLayer> getPinShapes() const { return pin_shapes_; }$/;"	f	class:grt::CUGRPin	typeref:typename:std::vector<BoxOnLayer>	access:public	signature:() const
+grt::CUGRPin::index_	src/Netlist.h	/^  const int index_;$/;"	m	class:grt::CUGRPin	typeref:typename:const int	access:private
+grt::CUGRPin::isPort	src/Netlist.h	/^  bool isPort() const { return is_port_; }$/;"	f	class:grt::CUGRPin	typeref:typename:bool	access:public	signature:() const
+grt::CUGRPin::is_port_	src/Netlist.h	/^  const bool is_port_;$/;"	m	class:grt::CUGRPin	typeref:typename:const bool	access:private
+grt::CUGRPin::pin_shapes_	src/Netlist.h	/^  std::vector<BoxOnLayer> pin_shapes_;$/;"	m	class:grt::CUGRPin	typeref:typename:std::vector<BoxOnLayer>	access:private
+grt::CapacityT	src/GridGraph.h	/^using CapacityT = double;$/;"	t	namespace:grt	typeref:typename:double
+grt::Constants	include/CUGR.h	/^struct Constants$/;"	s	namespace:grt
+grt::Constants::cost_logistic_slope	include/CUGR.h	/^  double cost_logistic_slope = 1.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::max_detour_ratio	include/CUGR.h	/^  double max_detour_ratio = 0.25;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::maze_logistic_slope	include/CUGR.h	/^  double maze_logistic_slope = 0.5;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::min_routing_layer	include/CUGR.h	/^  int min_routing_layer = 1;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+grt::Constants::pin_patch_padding	include/CUGR.h	/^  int pin_patch_padding = 1;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+grt::Constants::pin_patch_threshold	include/CUGR.h	/^  double pin_patch_threshold = 20.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::target_detour_count	include/CUGR.h	/^  int target_detour_count = 20;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+grt::Constants::via_multiplier	include/CUGR.h	/^  double via_multiplier = 2.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::weight_short_area	include/CUGR.h	/^  double weight_short_area = 500.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::weight_via_number	include/CUGR.h	/^  double weight_via_number = 4.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::weight_wire_length	include/CUGR.h	/^  double weight_wire_length = 0.5;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::wire_patch_inflation_rate	include/CUGR.h	/^  double wire_patch_inflation_rate = 1.2;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::wire_patch_threshold	include/CUGR.h	/^  double wire_patch_threshold = 2.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+grt::Constants::write_heatmap	include/CUGR.h	/^  bool write_heatmap = false;$/;"	m	struct:grt::Constants	typeref:typename:bool	access:public
+grt::CostT	src/Design.h	/^using CostT = double;$/;"	t	namespace:grt	typeref:typename:double
+grt::Design	src/Design.h	/^class Design$/;"	c	namespace:grt
+grt::Design::Design	src/Design.cpp	/^Design::Design(odb::dbDatabase* db,$/;"	f	class:grt::Design	signature:(odb::dbDatabase * db,utl::Logger * logger,const Constants & constants,const int min_routing_layer,const int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+grt::Design::Design	src/Design.h	/^  Design(odb::dbDatabase* db,$/;"	p	class:grt::Design	access:public	signature:(odb::dbDatabase * db,utl::Logger * logger,const Constants & constants,int min_routing_layer,int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+grt::Design::block_	src/Design.h	/^  odb::dbBlock* block_;$/;"	m	class:grt::Design	typeref:typename:odb::dbBlock *	access:private
+grt::Design::clock_nets_	src/Design.h	/^  std::set<odb::dbNet*> clock_nets_;$/;"	m	class:grt::Design	typeref:typename:std::set<odb::dbNet * >	access:private
+grt::Design::computeGrid	src/Design.cpp	/^void Design::computeGrid()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::computeGrid	src/Design.h	/^  void computeGrid();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::constants_	src/Design.h	/^  const Constants constants_;$/;"	m	class:grt::Design	typeref:typename:const Constants	access:private
+grt::Design::db_net_to_id_	src/Design.h	/^  std::unordered_map<odb::dbNet*, int> db_net_to_id_;$/;"	m	class:grt::Design	typeref:typename:std::unordered_map<odb::dbNet *,int>	access:private
+grt::Design::default_gridline_spacing_	src/Design.h	/^  int default_gridline_spacing_;$/;"	m	class:grt::Design	typeref:typename:int	access:private
+grt::Design::die_region_	src/Design.h	/^  BoxT die_region_;$/;"	m	class:grt::Design	typeref:typename:BoxT	access:private
+grt::Design::getAllNets	src/Design.h	/^  const std::vector<CUGRNet>& getAllNets() const { return nets_; }$/;"	f	class:grt::Design	typeref:typename:const std::vector<CUGRNet> &	access:public	signature:() const
+grt::Design::getAllObstacles	src/Design.cpp	/^void Design::getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,$/;"	f	class:grt::Design	typeref:typename:void	signature:(std::vector<std::vector<BoxT>> & all_obstacles,const bool skip_m1) const
+grt::Design::getAllObstacles	src/Design.h	/^  void getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,$/;"	p	class:grt::Design	typeref:typename:void	access:public	signature:(std::vector<std::vector<BoxT>> & all_obstacles,bool skip_m1=true) const
+grt::Design::getDieRegion	src/Design.h	/^  BoxT getDieRegion() const { return die_region_; }$/;"	f	class:grt::Design	typeref:typename:BoxT	access:public	signature:() const
+grt::Design::getGridlineSize	src/Design.h	/^  int getGridlineSize() const { return default_gridline_spacing_; }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+grt::Design::getGridlines	src/Design.h	/^  const std::vector<std::vector<int>>& getGridlines() const$/;"	f	class:grt::Design	typeref:typename:const std::vector<std::vector<int>> &	access:public	signature:() const
+grt::Design::getLayer	src/Design.h	/^  const MetalLayer& getLayer(int layer_index) const$/;"	f	class:grt::Design	typeref:typename:const MetalLayer &	access:public	signature:(int layer_index) const
+grt::Design::getLibDBU	src/Design.h	/^  int getLibDBU() const { return lib_dbu_; }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+grt::Design::getNumLayers	src/Design.h	/^  int getNumLayers() const { return layers_.size(); }$/;"	f	class:grt::Design	typeref:typename:int	access:public	signature:() const
+grt::Design::getUnitLengthShortCost	src/Design.h	/^  CostT getUnitLengthShortCost(const int layer_index) const$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:(const int layer_index) const
+grt::Design::getUnitLengthWireCost	src/Design.h	/^  CostT getUnitLengthWireCost() const { return unit_length_wire_cost_; }$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:() const
+grt::Design::getUnitViaCost	src/Design.h	/^  CostT getUnitViaCost() const { return unit_via_cost_; }$/;"	f	class:grt::Design	typeref:typename:CostT	access:public	signature:() const
+grt::Design::gridlines_	src/Design.h	/^  std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::Design	typeref:typename:std::vector<std::vector<int>>	access:private
+grt::Design::layers_	src/Design.h	/^  std::vector<MetalLayer> layers_;$/;"	m	class:grt::Design	typeref:typename:std::vector<MetalLayer>	access:private
+grt::Design::lib_dbu_	src/Design.h	/^  int lib_dbu_;$/;"	m	class:grt::Design	typeref:typename:int	access:private
+grt::Design::logger_	src/Design.h	/^  utl::Logger* logger_;$/;"	m	class:grt::Design	typeref:typename:utl::Logger *	access:private
+grt::Design::makeNetPins	src/Design.cpp	/^std::vector<CUGRPin> Design::makeNetPins(odb::dbNet* db_net)$/;"	f	class:grt::Design	typeref:typename:std::vector<CUGRPin>	signature:(odb::dbNet * db_net)
+grt::Design::makeNetPins	src/Design.h	/^  std::vector<CUGRPin> makeNetPins(odb::dbNet* db_net);$/;"	p	class:grt::Design	typeref:typename:std::vector<CUGRPin>	access:private	signature:(odb::dbNet * db_net)
+grt::Design::max_routing_layer_	src/Design.h	/^  const int max_routing_layer_;$/;"	m	class:grt::Design	typeref:typename:const int	access:private
+grt::Design::min_routing_layer_	src/Design.h	/^  const int min_routing_layer_;$/;"	m	class:grt::Design	typeref:typename:const int	access:private
+grt::Design::nets_	src/Design.h	/^  std::vector<CUGRNet> nets_;$/;"	m	class:grt::Design	typeref:typename:std::vector<CUGRNet>	access:private
+grt::Design::obstacles_	src/Design.h	/^  std::vector<BoxOnLayer> obstacles_;$/;"	m	class:grt::Design	typeref:typename:std::vector<BoxOnLayer>	access:private
+grt::Design::printBlockages	src/Design.cpp	/^void Design::printBlockages() const$/;"	f	class:grt::Design	typeref:typename:void	signature:() const
+grt::Design::printBlockages	src/Design.h	/^  void printBlockages() const;$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:() const
+grt::Design::printNets	src/Design.cpp	/^void Design::printNets() const$/;"	f	class:grt::Design	typeref:typename:void	signature:() const
+grt::Design::printNets	src/Design.h	/^  void printNets() const;$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:() const
+grt::Design::read	src/Design.cpp	/^void Design::read()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::read	src/Design.h	/^  void read();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::readDesignObstructions	src/Design.cpp	/^void Design::readDesignObstructions()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::readDesignObstructions	src/Design.h	/^  void readDesignObstructions();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::readInstanceObstructions	src/Design.cpp	/^void Design::readInstanceObstructions()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::readInstanceObstructions	src/Design.h	/^  void readInstanceObstructions();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::readLayers	src/Design.cpp	/^void Design::readLayers()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::readLayers	src/Design.h	/^  void readLayers();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::readNetlist	src/Design.cpp	/^void Design::readNetlist()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::readNetlist	src/Design.h	/^  void readNetlist();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::readSpecialNetObstructions	src/Design.cpp	/^int Design::readSpecialNetObstructions()$/;"	f	class:grt::Design	typeref:typename:int	signature:()
+grt::Design::readSpecialNetObstructions	src/Design.h	/^  int readSpecialNetObstructions();$/;"	p	class:grt::Design	typeref:typename:int	access:private	signature:()
+grt::Design::setUnitCosts	src/Design.cpp	/^void Design::setUnitCosts()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+grt::Design::setUnitCosts	src/Design.h	/^  void setUnitCosts();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+grt::Design::tech_	src/Design.h	/^  odb::dbTech* tech_;$/;"	m	class:grt::Design	typeref:typename:odb::dbTech *	access:private
+grt::Design::unit_length_short_costs_	src/Design.h	/^  std::vector<CostT> unit_length_short_costs_;$/;"	m	class:grt::Design	typeref:typename:std::vector<CostT>	access:private
+grt::Design::unit_length_wire_cost_	src/Design.h	/^  CostT unit_length_wire_cost_;$/;"	m	class:grt::Design	typeref:typename:CostT	access:private
+grt::Design::unit_via_cost_	src/Design.h	/^  CostT unit_via_cost_;$/;"	m	class:grt::Design	typeref:typename:CostT	access:private
+grt::Design::updateNet	src/Design.cpp	/^void Design::updateNet(odb::dbNet* db_net)$/;"	f	class:grt::Design	typeref:typename:void	signature:(odb::dbNet * db_net)
+grt::Design::updateNet	src/Design.h	/^  void updateNet(odb::dbNet* db_net);$/;"	p	class:grt::Design	typeref:typename:void	access:public	signature:(odb::dbNet * db_net)
+grt::GRNet	src/GRNet.h	/^class GRNet$/;"	c	namespace:grt
+grt::GRNet::GRNet	src/GRNet.cpp	/^GRNet::GRNet(const CUGRNet& base_net, const GridGraph* grid_graph)$/;"	f	class:grt::GRNet	signature:(const CUGRNet & base_net,const GridGraph * grid_graph)
+grt::GRNet::GRNet	src/GRNet.h	/^  GRNet(const CUGRNet& base_net, const GridGraph* grid_graph);$/;"	p	class:grt::GRNet	access:public	signature:(const CUGRNet & base_net,const GridGraph * grid_graph)
+grt::GRNet::addBTermAccessPoint	src/GRNet.cpp	/^void GRNet::addBTermAccessPoint(odb::dbBTerm* bterm, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(odb::dbBTerm * bterm,const AccessPoint & ap)
+grt::GRNet::addBTermAccessPoint	src/GRNet.h	/^  void addBTermAccessPoint(odb::dbBTerm* bterm, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(odb::dbBTerm * bterm,const AccessPoint & ap)
+grt::GRNet::addITermAccessPoint	src/GRNet.cpp	/^void GRNet::addITermAccessPoint(odb::dbITerm* iterm, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(odb::dbITerm * iterm,const AccessPoint & ap)
+grt::GRNet::addITermAccessPoint	src/GRNet.h	/^  void addITermAccessPoint(odb::dbITerm* iterm, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(odb::dbITerm * iterm,const AccessPoint & ap)
+grt::GRNet::addPreferredAccessPoint	src/GRNet.cpp	/^void GRNet::addPreferredAccessPoint(int pin_index, const AccessPoint& ap)$/;"	f	class:grt::GRNet	typeref:typename:void	signature:(int pin_index,const AccessPoint & ap)
+grt::GRNet::addPreferredAccessPoint	src/GRNet.h	/^  void addPreferredAccessPoint(int pin_index, const AccessPoint& ap);$/;"	p	class:grt::GRNet	typeref:typename:void	access:public	signature:(int pin_index,const AccessPoint & ap)
+grt::GRNet::bounding_box_	src/GRNet.h	/^  BoxT bounding_box_;$/;"	m	class:grt::GRNet	typeref:typename:BoxT	access:private
+grt::GRNet::bterm_to_ap_	src/GRNet.h	/^  std::map<odb::dbBTerm*, AccessPoint> bterm_to_ap_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<odb::dbBTerm *,AccessPoint>	access:private
+grt::GRNet::clearRoutingTree	src/GRNet.h	/^  void clearRoutingTree() { routing_tree_ = nullptr; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:()
+grt::GRNet::db_net_	src/GRNet.h	/^  odb::dbNet* db_net_;$/;"	m	class:grt::GRNet	typeref:typename:odb::dbNet *	access:private
+grt::GRNet::getBTermAccessPoints	src/GRNet.h	/^  const std::map<odb::dbBTerm*, AccessPoint>& getBTermAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::map<odb::dbBTerm *,AccessPoint> &	access:public	signature:() const
+grt::GRNet::getBoundingBox	src/GRNet.h	/^  const BoxT& getBoundingBox() const { return bounding_box_; }$/;"	f	class:grt::GRNet	typeref:typename:const BoxT &	access:public	signature:() const
+grt::GRNet::getDbNet	src/GRNet.h	/^  odb::dbNet* getDbNet() const { return db_net_; }$/;"	f	class:grt::GRNet	typeref:typename:odb::dbNet *	access:public	signature:() const
+grt::GRNet::getITermAccessPoints	src/GRNet.h	/^  const std::map<odb::dbITerm*, AccessPoint>& getITermAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::map<odb::dbITerm *,AccessPoint> &	access:public	signature:() const
+grt::GRNet::getIndex	src/GRNet.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::GRNet	typeref:typename:int	access:public	signature:() const
+grt::GRNet::getName	src/GRNet.h	/^  std::string getName() const { return db_net_->getName(); }$/;"	f	class:grt::GRNet	typeref:typename:std::string	access:public	signature:() const
+grt::GRNet::getNumPins	src/GRNet.h	/^  int getNumPins() const { return pin_access_points_.size(); }$/;"	f	class:grt::GRNet	typeref:typename:int	access:public	signature:() const
+grt::GRNet::getPinAccessPoints	src/GRNet.h	/^  const std::vector<std::vector<GRPoint>>& getPinAccessPoints() const$/;"	f	class:grt::GRNet	typeref:typename:const std::vector<std::vector<GRPoint>> &	access:public	signature:() const
+grt::GRNet::getRoutingTree	src/GRNet.h	/^  const std::shared_ptr<GRTreeNode>& getRoutingTree() const$/;"	f	class:grt::GRNet	typeref:typename:const std::shared_ptr<GRTreeNode> &	access:public	signature:() const
+grt::GRNet::getSlack	src/GRNet.h	/^  float getSlack() const { return slack_; }$/;"	f	class:grt::GRNet	typeref:typename:float	access:public	signature:() const
+grt::GRNet::index_	src/GRNet.h	/^  int index_;$/;"	m	class:grt::GRNet	typeref:typename:int	access:private
+grt::GRNet::isCritical	src/GRNet.h	/^  bool isCritical() const { return is_critical_; }$/;"	f	class:grt::GRNet	typeref:typename:bool	access:public	signature:() const
+grt::GRNet::isInsideLayerRange	src/GRNet.cpp	/^bool GRNet::isInsideLayerRange(int layer_index) const$/;"	f	class:grt::GRNet	typeref:typename:bool	signature:(int layer_index) const
+grt::GRNet::isInsideLayerRange	src/GRNet.h	/^  bool isInsideLayerRange(int layer_index) const;$/;"	p	class:grt::GRNet	typeref:typename:bool	access:public	signature:(int layer_index) const
+grt::GRNet::isLocal	src/GRNet.cpp	/^bool GRNet::isLocal() const$/;"	f	class:grt::GRNet	typeref:typename:bool	signature:() const
+grt::GRNet::isLocal	src/GRNet.h	/^  bool isLocal() const;$/;"	p	class:grt::GRNet	typeref:typename:bool	access:public	signature:() const
+grt::GRNet::is_critical_	src/GRNet.h	/^  bool is_critical_;$/;"	m	class:grt::GRNet	typeref:typename:bool	access:private
+grt::GRNet::iterm_to_ap_	src/GRNet.h	/^  std::map<odb::dbITerm*, AccessPoint> iterm_to_ap_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<odb::dbITerm *,AccessPoint>	access:private
+grt::GRNet::layer_range_	src/GRNet.h	/^  LayerRange layer_range_;$/;"	m	class:grt::GRNet	typeref:typename:LayerRange	access:private
+grt::GRNet::pin_access_points_	src/GRNet.h	/^  std::vector<std::vector<GRPoint>> pin_access_points_;$/;"	m	class:grt::GRNet	typeref:typename:std::vector<std::vector<GRPoint>>	access:private
+grt::GRNet::pin_index_to_bterm_	src/GRNet.h	/^  std::map<int, odb::dbBTerm*> pin_index_to_bterm_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<int,odb::dbBTerm * >	access:private
+grt::GRNet::pin_index_to_iterm_	src/GRNet.h	/^  std::map<int, odb::dbITerm*> pin_index_to_iterm_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<int,odb::dbITerm * >	access:private
+grt::GRNet::routing_tree_	src/GRNet.h	/^  std::shared_ptr<GRTreeNode> routing_tree_;$/;"	m	class:grt::GRNet	typeref:typename:std::shared_ptr<GRTreeNode>	access:private
+grt::GRNet::setCritical	src/GRNet.h	/^  void setCritical(bool is_critical) { is_critical_ = is_critical; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(bool is_critical)
+grt::GRNet::setRoutingTree	src/GRNet.h	/^  void setRoutingTree(std::shared_ptr<GRTreeNode> tree)$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(std::shared_ptr<GRTreeNode> tree)
+grt::GRNet::setSlack	src/GRNet.h	/^  void setSlack(float slack) { slack_ = slack; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(float slack)
+grt::GRNet::slack_	src/GRNet.h	/^  float slack_;$/;"	m	class:grt::GRNet	typeref:typename:float	access:private
+grt::GRPoint	src/GRTree.h	/^class GRPoint : public PointT$/;"	c	namespace:grt	inherits:PointT
+grt::GRPoint::GRPoint	src/GRTree.h	/^  GRPoint(int l, int x, int y) : PointT(x, y), layer_idx_(l) {}$/;"	f	class:grt::GRPoint	access:public	signature:(int l,int x,int y)
+grt::GRPoint::getLayerIdx	src/GRTree.h	/^  int getLayerIdx() const { return layer_idx_; }$/;"	f	class:grt::GRPoint	typeref:typename:int	access:public	signature:() const
+grt::GRPoint::layer_idx_	src/GRTree.h	/^  int layer_idx_;$/;"	m	class:grt::GRPoint	typeref:typename:int	access:private
+grt::GRTreeNode	src/GRTree.h	/^class GRTreeNode : public GRPoint$/;"	c	namespace:grt	inherits:GRPoint
+grt::GRTreeNode::GRTreeNode	src/GRTree.h	/^  GRTreeNode(const GRPoint& point) : GRPoint(point) {}$/;"	f	class:grt::GRTreeNode	access:public	signature:(const GRPoint & point)
+grt::GRTreeNode::GRTreeNode	src/GRTree.h	/^  GRTreeNode(int l, int x, int y) : GRPoint(l, x, y) {}$/;"	f	class:grt::GRTreeNode	access:public	signature:(int l,int x,int y)
+grt::GRTreeNode::addChild	src/GRTree.h	/^  void addChild(std::shared_ptr<GRTreeNode> child)$/;"	f	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(std::shared_ptr<GRTreeNode> child)
+grt::GRTreeNode::children_	src/GRTree.h	/^  std::vector<std::shared_ptr<GRTreeNode>> children_;$/;"	m	class:grt::GRTreeNode	typeref:typename:std::vector<std::shared_ptr<GRTreeNode>>	access:private
+grt::GRTreeNode::getChildren	src/GRTree.h	/^  const std::vector<std::shared_ptr<GRTreeNode>>& getChildren() const$/;"	f	class:grt::GRTreeNode	typeref:typename:const std::vector<std::shared_ptr<GRTreeNode>> &	access:public	signature:() const
+grt::GRTreeNode::preorder	src/GRTree.cpp	/^void GRTreeNode::preorder($/;"	f	class:grt::GRTreeNode	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & node,const std::function<void (const std::shared_ptr<GRTreeNode> &)> & visit)
+grt::GRTreeNode::preorder	src/GRTree.h	/^  static void preorder($/;"	p	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & node,const std::function<void (const std::shared_ptr<GRTreeNode> &)> & visit)
+grt::GRTreeNode::print	src/GRTree.cpp	/^void GRTreeNode::print(const std::shared_ptr<GRTreeNode>& node,$/;"	f	class:grt::GRTreeNode	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & node,utl::Logger * logger)
+grt::GRTreeNode::print	src/GRTree.h	/^  static void print(const std::shared_ptr<GRTreeNode>& node,$/;"	p	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & node,utl::Logger * logger)
+grt::GraphEdge	src/GridGraph.h	/^struct GraphEdge$/;"	s	namespace:grt
+grt::GraphEdge::capacity	src/GridGraph.h	/^  CapacityT capacity{0};$/;"	m	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public
+grt::GraphEdge::demand	src/GridGraph.h	/^  CapacityT demand{0};$/;"	m	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public
+grt::GraphEdge::getResource	src/GridGraph.h	/^  CapacityT getResource() const { return capacity - demand; }$/;"	f	struct:grt::GraphEdge	typeref:typename:CapacityT	access:public	signature:() const
+grt::GridGraph	src/GridGraph.h	/^class GridGraph$/;"	c	namespace:grt
+grt::GridGraph::GridGraph	src/GridGraph.cpp	/^GridGraph::GridGraph(const Design* design,$/;"	f	class:grt::GridGraph	signature:(const Design * design,const Constants & constants,utl::Logger * logger)
+grt::GridGraph::GridGraph	src/GridGraph.h	/^  GridGraph(const Design* design,$/;"	p	class:grt::GridGraph	access:public	signature:(const Design * design,const Constants & constants,utl::Logger * logger)
+grt::GridGraph::addTreeUsage	src/GridGraph.cpp	/^void GridGraph::addTreeUsage(const std::shared_ptr<GRTreeNode>& tree)$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree)
+grt::GridGraph::addTreeUsage	src/GridGraph.h	/^  void addTreeUsage(const std::shared_ptr<GRTreeNode>& tree);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree)
+grt::GridGraph::checkOverflow	src/GridGraph.cpp	/^int GridGraph::checkOverflow(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(const int layer_index,const PointT u,const PointT v) const
+grt::GridGraph::checkOverflow	src/GridGraph.cpp	/^int GridGraph::checkOverflow(const std::shared_ptr<GRTreeNode>& tree) const$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(const std::shared_ptr<GRTreeNode> & tree) const
+grt::GridGraph::checkOverflow	src/GridGraph.h	/^  bool checkOverflow(int layer_index, int x, int y) const$/;"	f	class:grt::GridGraph	typeref:typename:bool	access:public	signature:(int layer_index,int x,int y) const
+grt::GridGraph::checkOverflow	src/GridGraph.h	/^  int checkOverflow(const std::shared_ptr<GRTreeNode>& tree)$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree) const
+grt::GridGraph::checkOverflow	src/GridGraph.h	/^  int checkOverflow(int layer_index,$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int layer_index,PointT u,PointT v) const
+grt::GridGraph::commit	src/GridGraph.cpp	/^void GridGraph::commit(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT lower,const CapacityT demand)
+grt::GridGraph::commit	src/GridGraph.h	/^  void commit(int layer_index, PointT lower, CapacityT demand);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT lower,CapacityT demand)
+grt::GridGraph::commitTree	src/GridGraph.cpp	/^void GridGraph::commitTree(const std::shared_ptr<GRTreeNode>& tree,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree,const bool rip_up)
+grt::GridGraph::commitTree	src/GridGraph.h	/^  void commitTree(const std::shared_ptr<GRTreeNode>& tree, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(const std::shared_ptr<GRTreeNode> & tree,bool rip_up=false)
+grt::GridGraph::commitVia	src/GridGraph.cpp	/^void GridGraph::commitVia(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT loc,const bool rip_up)
+grt::GridGraph::commitVia	src/GridGraph.h	/^  void commitVia(int layer_index, PointT loc, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT loc,bool rip_up=false)
+grt::GridGraph::commitWire	src/GridGraph.cpp	/^void GridGraph::commitWire(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const int layer_index,const PointT lower,const bool rip_up)
+grt::GridGraph::commitWire	src/GridGraph.h	/^  void commitWire(int layer_index, PointT lower, bool rip_up = false);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:private	signature:(int layer_index,PointT lower,bool rip_up=false)
+grt::GridGraph::constants_	src/GridGraph.h	/^  const Constants constants_;$/;"	m	class:grt::GridGraph	typeref:typename:const Constants	access:private
+grt::GridGraph::design_	src/GridGraph.h	/^  const Design* design_;$/;"	m	class:grt::GridGraph	typeref:typename:const Design *	access:private
+grt::GridGraph::extractBlockageView	src/GridGraph.cpp	/^void GridGraph::extractBlockageView(GridGraphView<bool>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<bool> & view) const
+grt::GridGraph::extractBlockageView	src/GridGraph.h	/^  void extractBlockageView(GridGraphView<bool>& view) const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<bool> & view) const
+grt::GridGraph::extractCongestionView	src/GridGraph.cpp	/^void GridGraph::extractCongestionView(GridGraphView<bool>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<bool> & view) const
+grt::GridGraph::extractCongestionView	src/GridGraph.h	/^  void extractCongestionView($/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<bool> & view) const
+grt::GridGraph::extractWireCostView	src/GridGraph.cpp	/^void GridGraph::extractWireCostView(GridGraphView<CostT>& view) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<CostT> & view) const
+grt::GridGraph::extractWireCostView	src/GridGraph.h	/^  void extractWireCostView(GridGraphView<CostT>& view) const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<CostT> & view) const
+grt::GridGraph::findODBAccessPoints	src/GridGraph.cpp	/^bool GridGraph::findODBAccessPoints($/;"	f	class:grt::GridGraph	typeref:typename:bool	signature:(GRNet * net,AccessPointSet & selected_access_points) const
+grt::GridGraph::findODBAccessPoints	src/GridGraph.h	/^  bool findODBAccessPoints(GRNet* net,$/;"	p	class:grt::GridGraph	typeref:typename:bool	access:private	signature:(GRNet * net,AccessPointSet & selected_access_points) const
+grt::GridGraph::getCellBox	src/GridGraph.cpp	/^BoxT GridGraph::getCellBox(PointT point) const$/;"	f	class:grt::GridGraph	typeref:typename:BoxT	signature:(PointT point) const
+grt::GridGraph::getCellBox	src/GridGraph.h	/^  BoxT getCellBox(PointT point) const;$/;"	p	class:grt::GridGraph	typeref:typename:BoxT	access:public	signature:(PointT point) const
+grt::GridGraph::getEdge	src/GridGraph.h	/^  GraphEdge getEdge(const int layer_index, const int x, const int y) const$/;"	f	class:grt::GridGraph	typeref:typename:GraphEdge	access:public	signature:(const int layer_index,const int x,const int y) const
+grt::GridGraph::getEdgeLength	src/GridGraph.cpp	/^int GridGraph::getEdgeLength(int direction, int edge_index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	signature:(int direction,int edge_index) const
+grt::GridGraph::getEdgeLength	src/GridGraph.h	/^  int getEdgeLength(int direction, int edge_index) const;$/;"	p	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int direction,int edge_index) const
+grt::GridGraph::getGridline	src/GridGraph.h	/^  int getGridline(const int dimension, const int index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(const int dimension,const int index) const
+grt::GridGraph::getLayerDirection	src/GridGraph.h	/^  int getLayerDirection(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int layer_index) const
+grt::GridGraph::getLayerName	src/GridGraph.h	/^  std::string getLayerName(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:std::string	access:public	signature:(int layer_index) const
+grt::GridGraph::getLibDBU	src/GridGraph.h	/^  int getLibDBU() const { return lib_dbu_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+grt::GridGraph::getM2Pitch	src/GridGraph.h	/^  int getM2Pitch() const { return m2_pitch_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+grt::GridGraph::getNumLayers	src/GridGraph.h	/^  int getNumLayers() const { return num_layers_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+grt::GridGraph::getPythonString	src/GridGraph.cpp	/^std::string GridGraph::getPythonString($/;"	f	class:grt::GridGraph	typeref:typename:std::string	signature:(const std::shared_ptr<GRTreeNode> & routing_tree) const
+grt::GridGraph::getPythonString	src/GridGraph.h	/^  std::string getPythonString($/;"	p	class:grt::GridGraph	typeref:typename:std::string	access:public	signature:(const std::shared_ptr<GRTreeNode> & routing_tree) const
+grt::GridGraph::getSize	src/GridGraph.h	/^  int getSize(int dimension) const { return (dimension ? y_size_ : x_size_); }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:(int dimension) const
+grt::GridGraph::getUnitLengthShortCost	src/GridGraph.h	/^  CostT getUnitLengthShortCost(int layer_index) const$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:(int layer_index) const
+grt::GridGraph::getUnitLengthWireCost	src/GridGraph.h	/^  CostT getUnitLengthWireCost() const { return unit_length_wire_cost_; }$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:() const
+grt::GridGraph::getUnitViaCost	src/GridGraph.h	/^  CostT getUnitViaCost() const { return unit_via_cost_; }$/;"	f	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:() const
+grt::GridGraph::getViaCost	src/GridGraph.cpp	/^CostT GridGraph::getViaCost(const int layer_index, const PointT loc) const$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT loc) const
+grt::GridGraph::getViaCost	src/GridGraph.h	/^  CostT getViaCost(int layer_index, PointT loc) const;$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:(int layer_index,PointT loc) const
+grt::GridGraph::getWireCost	src/GridGraph.cpp	/^CostT GridGraph::getWireCost(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT lower,const CapacityT demand) const
+grt::GridGraph::getWireCost	src/GridGraph.cpp	/^CostT GridGraph::getWireCost(const int layer_index,$/;"	f	class:grt::GridGraph	typeref:typename:CostT	signature:(const int layer_index,const PointT u,const PointT v) const
+grt::GridGraph::getWireCost	src/GridGraph.h	/^  CostT getWireCost(int layer_index, PointT u, PointT v) const;$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:public	signature:(int layer_index,PointT u,PointT v) const
+grt::GridGraph::getWireCost	src/GridGraph.h	/^  CostT getWireCost(int layer_index,$/;"	p	class:grt::GridGraph	typeref:typename:CostT	access:private	signature:(int layer_index,PointT lower,CapacityT demand=1.0) const
+grt::GridGraph::getXSize	src/GridGraph.h	/^  int getXSize() const { return x_size_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+grt::GridGraph::getYSize	src/GridGraph.h	/^  int getYSize() const { return y_size_; }$/;"	f	class:grt::GridGraph	typeref:typename:int	access:public	signature:() const
+grt::GridGraph::graph_edges_	src/GridGraph.h	/^  std::vector<std::vector<std::vector<GraphEdge>>> graph_edges_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::vector<std::vector<GraphEdge>>>	access:private
+grt::GridGraph::grid_centers_	src/GridGraph.h	/^  std::vector<std::vector<int>> grid_centers_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::vector<int>>	access:private
+grt::GridGraph::gridlines_	src/GridGraph.h	/^  const std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::GridGraph	typeref:typename:const std::vector<std::vector<int>>	access:private
+grt::GridGraph::hashCell	src/GridGraph.h	/^  uint64_t hashCell(const GRPoint& point) const$/;"	f	class:grt::GridGraph	typeref:typename:uint64_t	access:public	signature:(const GRPoint & point) const
+grt::GridGraph::layer_directions_	src/GridGraph.h	/^  std::vector<int> layer_directions_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<int>	access:private
+grt::GridGraph::layer_min_lengths_	src/GridGraph.h	/^  std::vector<int> layer_min_lengths_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<int>	access:private
+grt::GridGraph::layer_names_	src/GridGraph.h	/^  std::vector<std::string> layer_names_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::string>	access:private
+grt::GridGraph::lib_dbu_	src/GridGraph.h	/^  const int lib_dbu_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+grt::GridGraph::logger_	src/GridGraph.h	/^  utl::Logger* logger_;$/;"	m	class:grt::GridGraph	typeref:typename:utl::Logger *	access:private
+grt::GridGraph::logistic	src/GridGraph.cpp	/^double GridGraph::logistic(const CapacityT& input, const double slope) const$/;"	f	class:grt::GridGraph	typeref:typename:double	signature:(const CapacityT & input,const double slope) const
+grt::GridGraph::logistic	src/GridGraph.h	/^  double logistic(const CapacityT& input, double slope) const;$/;"	p	class:grt::GridGraph	typeref:typename:double	access:private	signature:(const CapacityT & input,double slope) const
+grt::GridGraph::m2_pitch_	src/GridGraph.h	/^  const int m2_pitch_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+grt::GridGraph::num_layers_	src/GridGraph.h	/^  const int num_layers_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+grt::GridGraph::rangeSearchCells	src/GridGraph.cpp	/^BoxT GridGraph::rangeSearchCells(const BoxT& box) const$/;"	f	class:grt::GridGraph	typeref:typename:BoxT	signature:(const BoxT & box) const
+grt::GridGraph::rangeSearchCells	src/GridGraph.h	/^  BoxT rangeSearchCells(const BoxT& box) const;$/;"	p	class:grt::GridGraph	typeref:typename:BoxT	access:public	signature:(const BoxT & box) const
+grt::GridGraph::rangeSearchGridlines	src/GridGraph.cpp	/^IntervalT GridGraph::rangeSearchGridlines(const int dimension,$/;"	f	class:grt::GridGraph	typeref:typename:IntervalT	signature:(const int dimension,const IntervalT & loc_interval) const
+grt::GridGraph::rangeSearchGridlines	src/GridGraph.h	/^  IntervalT rangeSearchGridlines(int dimension,$/;"	p	class:grt::GridGraph	typeref:typename:IntervalT	access:private	signature:(int dimension,const IntervalT & loc_interval) const
+grt::GridGraph::rangeSearchRows	src/GridGraph.cpp	/^IntervalT GridGraph::rangeSearchRows(const int dimension,$/;"	f	class:grt::GridGraph	typeref:typename:IntervalT	signature:(const int dimension,const IntervalT & loc_interval) const
+grt::GridGraph::rangeSearchRows	src/GridGraph.h	/^  IntervalT rangeSearchRows(int dimension, const IntervalT& loc_interval) const;$/;"	p	class:grt::GridGraph	typeref:typename:IntervalT	access:private	signature:(int dimension,const IntervalT & loc_interval) const
+grt::GridGraph::removeTreeUsage	src/GridGraph.cpp	/^void GridGraph::removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree)$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree)
+grt::GridGraph::removeTreeUsage	src/GridGraph.h	/^  void removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree)
+grt::GridGraph::selectAccessPoint	src/GridGraph.cpp	/^AccessPoint GridGraph::selectAccessPoint($/;"	f	class:grt::GridGraph	typeref:typename:AccessPoint	signature:(const std::vector<AccessPoint> & access_points) const
+grt::GridGraph::selectAccessPoint	src/GridGraph.h	/^  AccessPoint selectAccessPoint($/;"	p	class:grt::GridGraph	typeref:typename:AccessPoint	access:private	signature:(const std::vector<AccessPoint> & access_points) const
+grt::GridGraph::selectAccessPoints	src/GridGraph.cpp	/^AccessPointSet GridGraph::selectAccessPoints(GRNet* net) const$/;"	f	class:grt::GridGraph	typeref:typename:AccessPointSet	signature:(GRNet * net) const
+grt::GridGraph::selectAccessPoints	src/GridGraph.h	/^  AccessPointSet selectAccessPoints(GRNet* net) const;$/;"	p	class:grt::GridGraph	typeref:typename:AccessPointSet	access:public	signature:(GRNet * net) const
+grt::GridGraph::total_length_	src/GridGraph.h	/^  int total_length_ = 0;$/;"	m	class:grt::GridGraph	typeref:typename:int	access:private
+grt::GridGraph::total_num_vias_	src/GridGraph.h	/^  int total_num_vias_ = 0;$/;"	m	class:grt::GridGraph	typeref:typename:int	access:private
+grt::GridGraph::translateAccessPointsToGrid	src/GridGraph.cpp	/^std::vector<AccessPoint> GridGraph::translateAccessPointsToGrid($/;"	f	class:grt::GridGraph	typeref:typename:std::vector<AccessPoint>	signature:(const std::vector<odb::dbAccessPoint * > & aps,const odb::Point & inst_location) const
+grt::GridGraph::translateAccessPointsToGrid	src/GridGraph.h	/^  std::vector<AccessPoint> translateAccessPointsToGrid($/;"	p	class:grt::GridGraph	typeref:typename:std::vector<AccessPoint>	access:private	signature:(const std::vector<odb::dbAccessPoint * > & ap,const odb::Point & inst_location) const
+grt::GridGraph::unit_length_short_costs_	src/GridGraph.h	/^  std::vector<CostT> unit_length_short_costs_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<CostT>	access:private
+grt::GridGraph::unit_length_wire_cost_	src/GridGraph.h	/^  CostT unit_length_wire_cost_;$/;"	m	class:grt::GridGraph	typeref:typename:CostT	access:private
+grt::GridGraph::unit_via_cost_	src/GridGraph.h	/^  CostT unit_via_cost_;$/;"	m	class:grt::GridGraph	typeref:typename:CostT	access:private
+grt::GridGraph::updateWireCostView	src/GridGraph.cpp	/^void GridGraph::updateWireCostView($/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<CostT> & view,const std::shared_ptr<GRTreeNode> & routing_tree) const
+grt::GridGraph::updateWireCostView	src/GridGraph.h	/^  void updateWireCostView($/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<CostT> & view,const std::shared_ptr<GRTreeNode> & routing_tree) const
+grt::GridGraph::write	src/GridGraph.cpp	/^void GridGraph::write(const std::string& heatmap_file) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::string & heatmap_file) const
+grt::GridGraph::write	src/GridGraph.h	/^  void write(const std::string& heatmap_file = "heatmap.txt") const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::string & heatmap_file="heatmap.txt") const
+grt::GridGraph::x_size_	src/GridGraph.h	/^  const int x_size_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+grt::GridGraph::y_size_	src/GridGraph.h	/^  const int y_size_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+grt::GridGraphView	src/GridGraph.h	/^class GridGraphView : public std::vector<std::vector<std::vector<Type>>>$/;"	c	namespace:grt	inherits:std::vector<std::vector<std::vector<Type>>>
+grt::GridGraphView::check	src/GridGraph.h	/^  bool check(const PointT& u, const PointT& v) const$/;"	f	class:grt::GridGraphView	typeref:typename:bool	access:public	signature:(const PointT & u,const PointT & v) const
+grt::GridGraphView::sum	src/GridGraph.h	/^  Type sum(const PointT& u, const PointT& v) const$/;"	f	class:grt::GridGraphView	typeref:typename:Type	access:public	signature:(const PointT & u,const PointT & v) const
+grt::IntervalT	src/geo.h	/^class IntervalT$/;"	c	namespace:grt
+grt::IntervalT::IntervalT	src/geo.h	/^  IntervalT() { set(); }$/;"	f	class:grt::IntervalT	access:public	signature:()
+grt::IntervalT::IntervalT	src/geo.h	/^  IntervalT(int lo, int hi) { set(lo, hi); }$/;"	f	class:grt::IntervalT	access:public	signature:(int lo,int hi)
+grt::IntervalT::IntervalT	src/geo.h	/^  IntervalT(int val) { set(val); }$/;"	f	class:grt::IntervalT	access:public	signature:(int val)
+grt::IntervalT::addToHigh	src/geo.h	/^  void addToHigh(const int increment) { high_ += increment; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int increment)
+grt::IntervalT::addToLow	src/geo.h	/^  void addToLow(const int increment) { low_ += increment; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int increment)
+grt::IntervalT::center	src/geo.h	/^  int center() const { return (high_ + low_) \/ 2; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+grt::IntervalT::contain	src/geo.h	/^  bool contain(int val) const { return val >= low_ && val <= high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(int val) const
+grt::IntervalT::fastUpdate	src/geo.h	/^  void fastUpdate(int new_val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int new_val)
+grt::IntervalT::getNearestPointTo	src/geo.h	/^  int getNearestPointTo(int val) const$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:(int val) const
+grt::IntervalT::getNearestPointsTo	src/geo.h	/^  IntervalT getNearestPointsTo(IntervalT val) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(IntervalT val) const
+grt::IntervalT::hasIntersectWith	src/geo.h	/^  bool hasIntersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::hasStrictIntersectWith	src/geo.h	/^  bool hasStrictIntersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::high	src/geo.h	/^  int high() const { return high_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+grt::IntervalT::high_	src/geo.h	/^  int high_;$/;"	m	class:grt::IntervalT	typeref:typename:int	access:private
+grt::IntervalT::intersectWith	src/geo.h	/^  IntervalT intersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::isStrictValid	src/geo.h	/^  bool isStrictValid() const { return low_ < high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:() const
+grt::IntervalT::isValid	src/geo.h	/^  bool isValid() const { return low_ <= high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:() const
+grt::IntervalT::low	src/geo.h	/^  int low() const { return low_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+grt::IntervalT::low_	src/geo.h	/^  int low_;$/;"	m	class:grt::IntervalT	typeref:typename:int	access:private
+grt::IntervalT::operator !=	src/geo.h	/^  bool operator!=(const IntervalT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::operator ==	src/geo.h	/^  bool operator==(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::range	src/geo.h	/^  int range() const { return high_ - low_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+grt::IntervalT::set	src/geo.h	/^  void set()$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:()
+grt::IntervalT::set	src/geo.h	/^  void set(int lo, int hi)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int lo,int hi)
+grt::IntervalT::set	src/geo.h	/^  void set(int val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+grt::IntervalT::setHigh	src/geo.h	/^  void setHigh(int val) { high_ = val; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+grt::IntervalT::setLow	src/geo.h	/^  void setLow(int val) { low_ = val; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+grt::IntervalT::shiftBy	src/geo.h	/^  void shiftBy(const int& rhs)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int & rhs)
+grt::IntervalT::strictlyContain	src/geo.h	/^  bool strictlyContain(int val) const { return val > low_ && val < high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(int val) const
+grt::IntervalT::unionWith	src/geo.h	/^  IntervalT unionWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(const IntervalT & rhs) const
+grt::IntervalT::update	src/geo.h	/^  void update(int new_val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int new_val)
+grt::LayerRange	src/Netlist.h	/^struct LayerRange$/;"	s	namespace:grt
+grt::LayerRange::max_layer	src/Netlist.h	/^  int max_layer;$/;"	m	struct:grt::LayerRange	typeref:typename:int	access:public
+grt::LayerRange::min_layer	src/Netlist.h	/^  int min_layer;$/;"	m	struct:grt::LayerRange	typeref:typename:int	access:public
+grt::MazeRoute	src/MazeRoute.h	/^class MazeRoute$/;"	c	namespace:grt
+grt::MazeRoute::MazeRoute	src/MazeRoute.h	/^  MazeRoute(GRNet* net, const GridGraph* graph, utl::Logger* logger)$/;"	f	class:grt::MazeRoute	access:public	signature:(GRNet * net,const GridGraph * graph,utl::Logger * logger)
+grt::MazeRoute::constructSparsifiedGraph	src/MazeRoute.h	/^  void constructSparsifiedGraph(const GridGraphView<CostT>& wire_cost_view,$/;"	f	class:grt::MazeRoute	typeref:typename:void	access:public	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+grt::MazeRoute::getSteinerTree	src/MazeRoute.cpp	/^std::shared_ptr<SteinerTreeNode> MazeRoute::getSteinerTree() const$/;"	f	class:grt::MazeRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	signature:() const
+grt::MazeRoute::getSteinerTree	src/MazeRoute.h	/^  std::shared_ptr<SteinerTreeNode> getSteinerTree() const;$/;"	p	class:grt::MazeRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:public	signature:() const
+grt::MazeRoute::graph_	src/MazeRoute.h	/^  SparseGraph graph_;$/;"	m	class:grt::MazeRoute	typeref:typename:SparseGraph	access:private
+grt::MazeRoute::logger_	src/MazeRoute.h	/^  utl::Logger* logger_;$/;"	m	class:grt::MazeRoute	typeref:typename:utl::Logger *	access:private
+grt::MazeRoute::net_	src/MazeRoute.h	/^  const GRNet* net_;$/;"	m	class:grt::MazeRoute	typeref:typename:const GRNet *	access:private
+grt::MazeRoute::run	src/MazeRoute.cpp	/^void MazeRoute::run()$/;"	f	class:grt::MazeRoute	typeref:typename:void	signature:()
+grt::MazeRoute::run	src/MazeRoute.h	/^  void run();$/;"	p	class:grt::MazeRoute	typeref:typename:void	access:public	signature:()
+grt::MazeRoute::solutions_	src/MazeRoute.h	/^  std::vector<std::shared_ptr<Solution>> solutions_;$/;"	m	class:grt::MazeRoute	typeref:typename:std::vector<std::shared_ptr<Solution>>	access:private
+grt::MetalLayer	src/Layers.h	/^class MetalLayer$/;"	c	namespace:grt
+grt::MetalLayer::H	src/Layers.h	/^  const static int H = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:const int	access:public
+grt::MetalLayer::MetalLayer	src/Layers.cpp	/^MetalLayer::MetalLayer(odb::dbTechLayer* tech_layer,$/;"	f	class:grt::MetalLayer	signature:(odb::dbTechLayer * tech_layer,odb::dbTrackGrid * track_grid)
+grt::MetalLayer::MetalLayer	src/Layers.h	/^  MetalLayer(odb::dbTechLayer* tech_layer, odb::dbTrackGrid* track_grid);$/;"	p	class:grt::MetalLayer	access:public	signature:(odb::dbTechLayer * tech_layer,odb::dbTrackGrid * track_grid)
+grt::MetalLayer::V	src/Layers.h	/^  const static int V = 1;$/;"	m	class:grt::MetalLayer	typeref:typename:const int	access:public
+grt::MetalLayer::adjustment_	src/Layers.h	/^  float adjustment_ = 0.0;$/;"	m	class:grt::MetalLayer	typeref:typename:float	access:private
+grt::MetalLayer::default_spacing_	src/Layers.h	/^  int default_spacing_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::direction_	src/Layers.h	/^  int direction_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::first_track_loc_	src/Layers.h	/^  int first_track_loc_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::getAdjustment	src/Layers.h	/^  float getAdjustment() const { return adjustment_; }$/;"	f	class:grt::MetalLayer	typeref:typename:float	access:public	signature:() const
+grt::MetalLayer::getDefaultSpacing	src/Layers.h	/^  int getDefaultSpacing() const { return default_spacing_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getDirection	src/Layers.h	/^  int getDirection() const { return direction_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getIndex	src/Layers.h	/^  int getIndex() const { return index_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getMaxEolSpacing	src/Layers.h	/^  int getMaxEolSpacing() const { return max_eol_spacing_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getMinLength	src/Layers.h	/^  int getMinLength() const { return min_length_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getName	src/Layers.h	/^  std::string getName() const { return name_; }$/;"	f	class:grt::MetalLayer	typeref:typename:std::string	access:public	signature:() const
+grt::MetalLayer::getParallelSpacing	src/Layers.cpp	/^int MetalLayer::getParallelSpacing(const int width, const int length) const$/;"	f	class:grt::MetalLayer	typeref:typename:int	signature:(const int width,const int length) const
+grt::MetalLayer::getParallelSpacing	src/Layers.h	/^  int getParallelSpacing(int width, int length = 0) const;$/;"	p	class:grt::MetalLayer	typeref:typename:int	access:public	signature:(int width,int length=0) const
+grt::MetalLayer::getPitch	src/Layers.h	/^  int getPitch() const { return pitch_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::getTrackLocation	src/Layers.cpp	/^int MetalLayer::getTrackLocation(const int track_index) const$/;"	f	class:grt::MetalLayer	typeref:typename:int	signature:(const int track_index) const
+grt::MetalLayer::getTrackLocation	src/Layers.h	/^  int getTrackLocation(int track_index) const;$/;"	p	class:grt::MetalLayer	typeref:typename:int	access:public	signature:(int track_index) const
+grt::MetalLayer::getWidth	src/Layers.h	/^  int getWidth() const { return width_; }$/;"	f	class:grt::MetalLayer	typeref:typename:int	access:public	signature:() const
+grt::MetalLayer::index_	src/Layers.h	/^  int index_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::last_track_loc_	src/Layers.h	/^  int last_track_loc_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::max_eol_spacing_	src/Layers.h	/^  int max_eol_spacing_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::max_eol_width_	src/Layers.h	/^  int max_eol_width_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::max_eol_within_	src/Layers.h	/^  int max_eol_within_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::min_length_	src/Layers.h	/^  int min_length_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::min_width_	src/Layers.h	/^  int min_width_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::name_	src/Layers.h	/^  std::string name_;$/;"	m	class:grt::MetalLayer	typeref:typename:std::string	access:private
+grt::MetalLayer::num_tracks_	src/Layers.h	/^  int num_tracks_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::parallel_length_	src/Layers.h	/^  std::vector<int> parallel_length_ = {0};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<int>	access:private
+grt::MetalLayer::parallel_spacing_	src/Layers.h	/^  std::vector<std::vector<int>> parallel_spacing_ = {{0}};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<std::vector<int>>	access:private
+grt::MetalLayer::parallel_width_	src/Layers.h	/^  std::vector<int> parallel_width_ = {0};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<int>	access:private
+grt::MetalLayer::pitch_	src/Layers.h	/^  int pitch_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::MetalLayer::rangeSearchTracks	src/Layers.cpp	/^IntervalT MetalLayer::rangeSearchTracks(const IntervalT& loc_range,$/;"	f	class:grt::MetalLayer	typeref:typename:IntervalT	signature:(const IntervalT & loc_range,const bool include_bound) const
+grt::MetalLayer::rangeSearchTracks	src/Layers.h	/^  IntervalT rangeSearchTracks(const IntervalT& loc_range,$/;"	p	class:grt::MetalLayer	typeref:typename:IntervalT	access:public	signature:(const IntervalT & loc_range,bool include_bound=true) const
+grt::MetalLayer::setAdjustment	src/Layers.h	/^  void setAdjustment(float adjustment) { adjustment_ = adjustment; }$/;"	f	class:grt::MetalLayer	typeref:typename:void	access:public	signature:(float adjustment)
+grt::MetalLayer::width_	src/Layers.h	/^  int width_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+grt::PatternRoute	src/PatternRoute.h	/^class PatternRoute$/;"	c	namespace:grt
+grt::PatternRoute::PatternRoute	src/PatternRoute.h	/^  PatternRoute(GRNet* net,$/;"	f	class:grt::PatternRoute	access:public	signature:(GRNet * net,const GridGraph * graph,stt::SteinerTreeBuilder * stt_builder,const Constants & constants,utl::Logger * logger)
+grt::PatternRoute::calculateRoutingCosts	src/PatternRoute.cpp	/^void PatternRoute::calculateRoutingCosts($/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(std::shared_ptr<PatternRoutingNode> & node)
+grt::PatternRoute::calculateRoutingCosts	src/PatternRoute.h	/^  void calculateRoutingCosts(std::shared_ptr<PatternRoutingNode>& node);$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:private	signature:(std::shared_ptr<PatternRoutingNode> & node)
+grt::PatternRoute::constants_	src/PatternRoute.h	/^  Constants constants_;$/;"	m	class:grt::PatternRoute	typeref:typename:Constants	access:private
+grt::PatternRoute::constructDetours	src/PatternRoute.cpp	/^void PatternRoute::constructDetours(GridGraphView<bool>& congestion_view)$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(GridGraphView<bool> & congestion_view)
+grt::PatternRoute::constructDetours	src/PatternRoute.h	/^  void constructDetours(GridGraphView<bool>& congestion_view);$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:(GridGraphView<bool> & congestion_view)
+grt::PatternRoute::constructDetours::ScaffoldNode::ScaffoldNode	src/PatternRoute.cpp	/^    ScaffoldNode(std::shared_ptr<PatternRoutingNode> n) : node(std::move(n)) {}$/;"	f	struct:grt::PatternRoute::constructDetours::ScaffoldNode	file:	access:public	signature:(std::shared_ptr<PatternRoutingNode> n)
+grt::PatternRoute::constructDetours::ScaffoldNode::children	src/PatternRoute.cpp	/^    std::vector<std::shared_ptr<ScaffoldNode>> children;$/;"	m	struct:grt::PatternRoute::constructDetours::ScaffoldNode	typeref:typename:std::vector<std::shared_ptr<ScaffoldNode>>	file:	access:public
+grt::PatternRoute::constructDetours::ScaffoldNode::node	src/PatternRoute.cpp	/^    std::shared_ptr<PatternRoutingNode> node;$/;"	m	struct:grt::PatternRoute::constructDetours::ScaffoldNode	typeref:typename:std::shared_ptr<PatternRoutingNode>	file:	access:public
+grt::PatternRoute::constructPaths	src/PatternRoute.cpp	/^void PatternRoute::constructPaths(std::shared_ptr<PatternRoutingNode>& start,$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:(std::shared_ptr<PatternRoutingNode> & start,std::shared_ptr<PatternRoutingNode> & end,int child_index)
+grt::PatternRoute::constructPaths	src/PatternRoute.h	/^  void constructPaths(std::shared_ptr<PatternRoutingNode>& start,$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:private	signature:(std::shared_ptr<PatternRoutingNode> & start,std::shared_ptr<PatternRoutingNode> & end,int child_index=-1)
+grt::PatternRoute::constructRoutingDAG	src/PatternRoute.cpp	/^void PatternRoute::constructRoutingDAG()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+grt::PatternRoute::constructRoutingDAG	src/PatternRoute.h	/^  void constructRoutingDAG();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+grt::PatternRoute::constructSteinerTree	src/PatternRoute.cpp	/^void PatternRoute::constructSteinerTree()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+grt::PatternRoute::constructSteinerTree	src/PatternRoute.h	/^  void constructSteinerTree();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+grt::PatternRoute::flute_accuracy_	src/PatternRoute.h	/^  const int flute_accuracy_ = 3;$/;"	m	class:grt::PatternRoute	typeref:typename:const int	access:private
+grt::PatternRoute::getGridGraph	src/PatternRoute.h	/^  const GridGraph* getGridGraph() const { return grid_graph_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const GridGraph *	access:public	signature:() const
+grt::PatternRoute::getNet	src/PatternRoute.h	/^  const GRNet* getNet() const { return net_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const GRNet *	access:public	signature:() const
+grt::PatternRoute::getNumDAGNodes	src/PatternRoute.h	/^  int getNumDAGNodes() const { return num_dag_nodes_; }$/;"	f	class:grt::PatternRoute	typeref:typename:int	access:public	signature:() const
+grt::PatternRoute::getRoutingDAG	src/PatternRoute.h	/^  std::shared_ptr<PatternRoutingNode> getRoutingDAG() const$/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<PatternRoutingNode>	access:public	signature:() const
+grt::PatternRoute::getRoutingTree	src/PatternRoute.cpp	/^std::shared_ptr<GRTreeNode> PatternRoute::getRoutingTree($/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<GRTreeNode>	signature:(std::shared_ptr<PatternRoutingNode> & node,int parent_layer_index)
+grt::PatternRoute::getRoutingTree	src/PatternRoute.h	/^  std::shared_ptr<GRTreeNode> getRoutingTree($/;"	p	class:grt::PatternRoute	typeref:typename:std::shared_ptr<GRTreeNode>	access:private	signature:(std::shared_ptr<PatternRoutingNode> & node,int parent_layer_index=-1)
+grt::PatternRoute::getSteinerTree	src/PatternRoute.h	/^  std::shared_ptr<SteinerTreeNode> getSteinerTree() const$/;"	f	class:grt::PatternRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:public	signature:() const
+grt::PatternRoute::getSttTree	src/PatternRoute.h	/^  const stt::Tree& getSttTree() const { return stt_tree_; }$/;"	f	class:grt::PatternRoute	typeref:typename:const stt::Tree &	access:public	signature:() const
+grt::PatternRoute::grid_graph_	src/PatternRoute.h	/^  const GridGraph* grid_graph_;$/;"	m	class:grt::PatternRoute	typeref:typename:const GridGraph *	access:private
+grt::PatternRoute::gridlines_	src/PatternRoute.h	/^  std::vector<std::vector<int>> gridlines_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::vector<std::vector<int>>	access:private
+grt::PatternRoute::hasSttTree	src/PatternRoute.h	/^  bool hasSttTree() const { return stt_tree_valid_; }$/;"	f	class:grt::PatternRoute	typeref:typename:bool	access:public	signature:() const
+grt::PatternRoute::logger_	src/PatternRoute.h	/^  utl::Logger* logger_;$/;"	m	class:grt::PatternRoute	typeref:typename:utl::Logger *	access:private
+grt::PatternRoute::net_	src/PatternRoute.h	/^  GRNet* net_;$/;"	m	class:grt::PatternRoute	typeref:typename:GRNet *	access:private
+grt::PatternRoute::num_dag_nodes_	src/PatternRoute.h	/^  int num_dag_nodes_{0};$/;"	m	class:grt::PatternRoute	typeref:typename:int	access:private
+grt::PatternRoute::routing_dag_	src/PatternRoute.h	/^  std::shared_ptr<PatternRoutingNode> routing_dag_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::shared_ptr<PatternRoutingNode>	access:private
+grt::PatternRoute::run	src/PatternRoute.cpp	/^void PatternRoute::run()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+grt::PatternRoute::run	src/PatternRoute.h	/^  void run();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+grt::PatternRoute::setSteinerTree	src/PatternRoute.h	/^  void setSteinerTree(const std::shared_ptr<SteinerTreeNode>& tree)$/;"	f	class:grt::PatternRoute	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & tree)
+grt::PatternRoute::steiner_tree_	src/PatternRoute.h	/^  std::shared_ptr<SteinerTreeNode> steiner_tree_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:private
+grt::PatternRoute::stt_builder_	src/PatternRoute.h	/^  stt::SteinerTreeBuilder* stt_builder_;$/;"	m	class:grt::PatternRoute	typeref:typename:stt::SteinerTreeBuilder *	access:private
+grt::PatternRoute::stt_tree_	src/PatternRoute.h	/^  stt::Tree stt_tree_;$/;"	m	class:grt::PatternRoute	typeref:typename:stt::Tree	access:private
+grt::PatternRoute::stt_tree_valid_	src/PatternRoute.h	/^  bool stt_tree_valid_{false};$/;"	m	class:grt::PatternRoute	typeref:typename:bool	access:private
+grt::PatternRoutingNode	src/PatternRoute.h	/^class PatternRoutingNode : public PointT$/;"	c	namespace:grt	inherits:PointT
+grt::PatternRoutingNode::PatternRoutingNode	src/PatternRoute.h	/^  PatternRoutingNode(const PointT& point,$/;"	f	class:grt::PatternRoutingNode	access:public	signature:(const PointT & point,const IntervalT & fixed_layers,const int index=0)
+grt::PatternRoutingNode::PatternRoutingNode	src/PatternRoute.h	/^  PatternRoutingNode(const PointT& point,$/;"	f	class:grt::PatternRoutingNode	access:public	signature:(const PointT & point,const int index,const bool optional=false)
+grt::PatternRoutingNode::addChild	src/PatternRoute.h	/^  void addChild(const std::shared_ptr<PatternRoutingNode>& child)$/;"	f	class:grt::PatternRoutingNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<PatternRoutingNode> & child)
+grt::PatternRoutingNode::best_paths_	src/PatternRoute.h	/^  std::vector<std::vector<std::pair<int, int>>> best_paths_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::pair<int,int>>>	access:private
+grt::PatternRoutingNode::children_	src/PatternRoute.h	/^  std::vector<std::shared_ptr<PatternRoutingNode>> children_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::shared_ptr<PatternRoutingNode>>	access:private
+grt::PatternRoutingNode::costs_	src/PatternRoute.h	/^  std::vector<CostT> costs_;  \/\/ layerIndex -> cost$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<CostT>	access:private
+grt::PatternRoutingNode::fixed_layers_	src/PatternRoute.h	/^  IntervalT fixed_layers_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:IntervalT	access:private
+grt::PatternRoutingNode::getBestPaths	src/PatternRoute.h	/^  std::vector<std::vector<std::pair<int, int>>>& getBestPaths()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::pair<int,int>>> &	access:public	signature:()
+grt::PatternRoutingNode::getChildren	src/PatternRoute.h	/^  std::vector<std::shared_ptr<PatternRoutingNode>>& getChildren()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::shared_ptr<PatternRoutingNode>> &	access:public	signature:()
+grt::PatternRoutingNode::getCosts	src/PatternRoute.h	/^  std::vector<CostT>& getCosts() { return costs_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<CostT> &	access:public	signature:()
+grt::PatternRoutingNode::getFixedLayers	src/PatternRoute.h	/^  const IntervalT& getFixedLayers() const { return fixed_layers_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:const IntervalT &	access:public	signature:() const
+grt::PatternRoutingNode::getIndex	src/PatternRoute.h	/^  const int& getIndex() const { return index_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:const int &	access:public	signature:() const
+grt::PatternRoutingNode::getNumChildren	src/PatternRoute.h	/^  int getNumChildren() const { return children_.size(); }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:int	access:public	signature:() const
+grt::PatternRoutingNode::getPaths	src/PatternRoute.h	/^  std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>>& getPaths()$/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>> &	access:public	signature:()
+grt::PatternRoutingNode::getPythonString	src/PatternRoute.cpp	/^std::string PatternRoutingNode::getPythonString($/;"	f	class:grt::PatternRoutingNode	typeref:typename:std::string	signature:(std::shared_ptr<PatternRoutingNode> routing_dag_)
+grt::PatternRoutingNode::getPythonString	src/PatternRoute.h	/^  static std::string getPythonString($/;"	p	class:grt::PatternRoutingNode	typeref:typename:std::string	access:public	signature:(std::shared_ptr<PatternRoutingNode> routing_dag)
+grt::PatternRoutingNode::index_	src/PatternRoute.h	/^  const int index_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:const int	access:private
+grt::PatternRoutingNode::isOptional	src/PatternRoute.h	/^  bool isOptional() const { return optional_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:bool	access:public	signature:() const
+grt::PatternRoutingNode::optional_	src/PatternRoute.h	/^  bool optional_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:bool	access:private
+grt::PatternRoutingNode::paths_	src/PatternRoute.h	/^  std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>> paths_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>>	access:private
+grt::PatternRoutingNode::removeChild	src/PatternRoute.h	/^  void removeChild(int index) { children_.erase(children_.begin() + index); }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:void	access:public	signature:(int index)
+grt::PointT	src/geo.h	/^class PointT$/;"	c	namespace:grt
+grt::PointT::PointT	src/geo.h	/^  PointT() = default;$/;"	p	class:grt::PointT	access:public	signature:()
+grt::PointT::PointT	src/geo.h	/^  PointT(int x, int y) : x_(x), y_(y) {}$/;"	f	class:grt::PointT	access:public	signature:(int x,int y)
+grt::PointT::isValid	src/geo.h	/^  bool isValid() { return *this != PointT(); }$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:()
+grt::PointT::operator !=	src/geo.h	/^  bool operator!=(const PointT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:(const PointT & rhs) const
+grt::PointT::operator +	src/geo.h	/^  PointT operator+(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT	access:public	signature:(const PointT & rhs)
+grt::PointT::operator +=	src/geo.h	/^  PointT& operator+=(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT &	access:public	signature:(const PointT & rhs)
+grt::PointT::operator -=	src/geo.h	/^  PointT& operator-=(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT &	access:public	signature:(const PointT & rhs)
+grt::PointT::operator /	src/geo.h	/^  PointT operator\/(int divisor) { return PointT(x_ \/ divisor, y_ \/ divisor); }$/;"	f	class:grt::PointT	typeref:typename:PointT	access:public	signature:(int divisor)
+grt::PointT::operator ==	src/geo.h	/^  bool operator==(const PointT& rhs) const$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:(const PointT & rhs) const
+grt::PointT::operator []	src/geo.h	/^  const int& operator[](const int d) const$/;"	f	class:grt::PointT	typeref:typename:const int &	access:public	signature:(const int d) const
+grt::PointT::operator []	src/geo.h	/^  int& operator[](const int d)$/;"	f	class:grt::PointT	typeref:typename:int &	access:public	signature:(const int d)
+grt::PointT::x	src/geo.h	/^  int x() const { return x_; }$/;"	f	class:grt::PointT	typeref:typename:int	access:public	signature:() const
+grt::PointT::x_	src/geo.h	/^  int x_{std::numeric_limits<int>::max()};$/;"	m	class:grt::PointT	typeref:typename:int	access:private
+grt::PointT::y	src/geo.h	/^  int y() const { return y_; }$/;"	f	class:grt::PointT	typeref:typename:int	access:public	signature:() const
+grt::PointT::y_	src/geo.h	/^  int y_{std::numeric_limits<int>::max()};$/;"	m	class:grt::PointT	typeref:typename:int	access:private
+grt::Solution	src/MazeRoute.h	/^struct Solution$/;"	s	namespace:grt
+grt::Solution::Solution	src/MazeRoute.h	/^  Solution(CostT c, int v, const std::shared_ptr<Solution>& p)$/;"	f	struct:grt::Solution	access:public	signature:(CostT c,int v,const std::shared_ptr<Solution> & p)
+grt::Solution::cost	src/MazeRoute.h	/^  const CostT cost;$/;"	m	struct:grt::Solution	typeref:typename:const CostT	access:public
+grt::Solution::prev	src/MazeRoute.h	/^  const std::shared_ptr<Solution> prev;$/;"	m	struct:grt::Solution	typeref:typename:const std::shared_ptr<Solution>	access:public
+grt::Solution::vertex	src/MazeRoute.h	/^  const int vertex;$/;"	m	struct:grt::Solution	typeref:typename:const int	access:public
+grt::SparseGraph	src/MazeRoute.h	/^class SparseGraph$/;"	c	namespace:grt
+grt::SparseGraph::SparseGraph	src/MazeRoute.h	/^  SparseGraph(GRNet* net, const GridGraph* graph)$/;"	f	class:grt::SparseGraph	access:public	signature:(GRNet * net,const GridGraph * graph)
+grt::SparseGraph::costs_	src/MazeRoute.h	/^  std::vector<std::array<CostT, 3>> costs_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<std::array<CostT,3>>	access:private
+grt::SparseGraph::edges_	src/MazeRoute.h	/^  std::vector<std::array<int, 3>> edges_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<std::array<int,3>>	access:private
+grt::SparseGraph::getEdgeCost	src/MazeRoute.h	/^  CostT getEdgeCost(const int vertex, const int edge_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:CostT	access:public	signature:(const int vertex,const int edge_index) const
+grt::SparseGraph::getNextVertex	src/MazeRoute.h	/^  int getNextVertex(const int vertex, const int edge_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int vertex,const int edge_index) const
+grt::SparseGraph::getNumPseudoPins	src/MazeRoute.h	/^  int getNumPseudoPins() const { return pseudo_pins_.size(); }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:() const
+grt::SparseGraph::getNumVertices	src/MazeRoute.h	/^  int getNumVertices() const { return vertices_.size(); }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:() const
+grt::SparseGraph::getPinVertex	src/MazeRoute.h	/^  int getPinVertex(const int pin_index) const { return pin_vertex_[pin_index]; }$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int pin_index) const
+grt::SparseGraph::getPoint	src/MazeRoute.h	/^  GRPoint getPoint(const int vertex) const { return vertices_[vertex]; }$/;"	f	class:grt::SparseGraph	typeref:typename:GRPoint	access:public	signature:(const int vertex) const
+grt::SparseGraph::getPseudoPin	src/MazeRoute.h	/^  AccessPoint getPseudoPin(int pin_index) const$/;"	f	class:grt::SparseGraph	typeref:typename:AccessPoint	access:public	signature:(int pin_index) const
+grt::SparseGraph::getVertexIndex	src/MazeRoute.h	/^  int getVertexIndex(int direction, int xi, int yi) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:private	signature:(int direction,int xi,int yi) const
+grt::SparseGraph::getVertexPin	src/MazeRoute.h	/^  int getVertexPin(const int vertex) const$/;"	f	class:grt::SparseGraph	typeref:typename:int	access:public	signature:(const int vertex) const
+grt::SparseGraph::grid_graph_	src/MazeRoute.h	/^  const GridGraph* grid_graph_;$/;"	m	class:grt::SparseGraph	typeref:typename:const GridGraph *	access:private
+grt::SparseGraph::init	src/MazeRoute.cpp	/^void SparseGraph::init(const GridGraphView<CostT>& wire_cost_view,$/;"	f	class:grt::SparseGraph	typeref:typename:void	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+grt::SparseGraph::init	src/MazeRoute.h	/^  void init(const GridGraphView<CostT>& wire_cost_view, const SparseGrid& grid);$/;"	p	class:grt::SparseGraph	typeref:typename:void	access:public	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+grt::SparseGraph::net_	src/MazeRoute.h	/^  GRNet* net_;$/;"	m	class:grt::SparseGraph	typeref:typename:GRNet *	access:private
+grt::SparseGraph::pin_vertex_	src/MazeRoute.h	/^  std::vector<int> pin_vertex_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+grt::SparseGraph::pseudo_pins_	src/MazeRoute.h	/^  std::vector<AccessPoint> pseudo_pins_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<AccessPoint>	access:private
+grt::SparseGraph::vertex_pin_	src/MazeRoute.h	/^  robin_hood::unordered_map<int, int> vertex_pin_;$/;"	m	class:grt::SparseGraph	typeref:typename:robin_hood::unordered_map<int,int>	access:private
+grt::SparseGraph::vertices_	src/MazeRoute.h	/^  std::vector<GRPoint> vertices_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<GRPoint>	access:private
+grt::SparseGraph::xs_	src/MazeRoute.h	/^  std::vector<int> xs_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+grt::SparseGraph::ys_	src/MazeRoute.h	/^  std::vector<int> ys_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+grt::SparseGrid	src/MazeRoute.h	/^struct SparseGrid$/;"	s	namespace:grt
+grt::SparseGrid::SparseGrid	src/MazeRoute.h	/^  SparseGrid(int x_interval, int y_interval, int x_offset, int y_offset)$/;"	f	struct:grt::SparseGrid	access:public	signature:(int x_interval,int y_interval,int x_offset,int y_offset)
+grt::SparseGrid::interval	src/MazeRoute.h	/^  PointT interval;$/;"	m	struct:grt::SparseGrid	typeref:typename:PointT	access:public
+grt::SparseGrid::offset	src/MazeRoute.h	/^  PointT offset;$/;"	m	struct:grt::SparseGrid	typeref:typename:PointT	access:public
+grt::SparseGrid::reset	src/MazeRoute.h	/^  void reset(int x_interval, int y_interval)$/;"	f	struct:grt::SparseGrid	typeref:typename:void	access:public	signature:(int x_interval,int y_interval)
+grt::SparseGrid::step	src/MazeRoute.h	/^  void step()$/;"	f	struct:grt::SparseGrid	typeref:typename:void	access:public	signature:()
+grt::SteinerTreeNode	src/PatternRoute.h	/^class SteinerTreeNode : public PointT$/;"	c	namespace:grt	inherits:PointT
+grt::SteinerTreeNode::SteinerTreeNode	src/PatternRoute.h	/^  SteinerTreeNode(const PointT& point) : PointT(point) {}$/;"	f	class:grt::SteinerTreeNode	access:public	signature:(const PointT & point)
+grt::SteinerTreeNode::SteinerTreeNode	src/PatternRoute.h	/^  SteinerTreeNode(const PointT& point, const IntervalT& fixed_layers)$/;"	f	class:grt::SteinerTreeNode	access:public	signature:(const PointT & point,const IntervalT & fixed_layers)
+grt::SteinerTreeNode::addChild	src/PatternRoute.h	/^  void addChild(const std::shared_ptr<SteinerTreeNode>& child)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & child)
+grt::SteinerTreeNode::children_	src/PatternRoute.h	/^  std::vector<std::shared_ptr<SteinerTreeNode>> children_;$/;"	m	class:grt::SteinerTreeNode	typeref:typename:std::vector<std::shared_ptr<SteinerTreeNode>>	access:private
+grt::SteinerTreeNode::fixed_layers_	src/PatternRoute.h	/^  IntervalT fixed_layers_;$/;"	m	class:grt::SteinerTreeNode	typeref:typename:IntervalT	access:private
+grt::SteinerTreeNode::getChildren	src/PatternRoute.h	/^  std::vector<std::shared_ptr<SteinerTreeNode>>& getChildren()$/;"	f	class:grt::SteinerTreeNode	typeref:typename:std::vector<std::shared_ptr<SteinerTreeNode>> &	access:public	signature:()
+grt::SteinerTreeNode::getFixedLayers	src/PatternRoute.h	/^  IntervalT& getFixedLayers() { return fixed_layers_; }$/;"	f	class:grt::SteinerTreeNode	typeref:typename:IntervalT &	access:public	signature:()
+grt::SteinerTreeNode::getNumChildren	src/PatternRoute.h	/^  int getNumChildren() const { return children_.size(); }$/;"	f	class:grt::SteinerTreeNode	typeref:typename:int	access:public	signature:() const
+grt::SteinerTreeNode::getPythonString	src/PatternRoute.cpp	/^std::string SteinerTreeNode::getPythonString($/;"	f	class:grt::SteinerTreeNode	typeref:typename:std::string	signature:(const std::shared_ptr<SteinerTreeNode> & node)
+grt::SteinerTreeNode::getPythonString	src/PatternRoute.h	/^  static std::string getPythonString($/;"	p	class:grt::SteinerTreeNode	typeref:typename:std::string	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & node)
+grt::SteinerTreeNode::preorder	src/PatternRoute.cpp	/^void SteinerTreeNode::preorder($/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	signature:(const std::shared_ptr<SteinerTreeNode> & node,const std::function<void (std::shared_ptr<SteinerTreeNode>)> & visit)
+grt::SteinerTreeNode::preorder	src/PatternRoute.h	/^  static void preorder($/;"	p	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & node,const std::function<void (std::shared_ptr<SteinerTreeNode>)> & visit)
+grt::SteinerTreeNode::removeChild	src/PatternRoute.h	/^  void removeChild(const int index)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const int index)
+grt::SteinerTreeNode::setFixedLayers	src/PatternRoute.h	/^  void setFixedLayers(const IntervalT& fixed_layers)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const IntervalT & fixed_layers)
+grt::getBoxFromRect	src/GeoTypes.cpp	/^BoxT getBoxFromRect(const odb::Rect& bounds)$/;"	f	namespace:grt	typeref:typename:BoxT	signature:(const odb::Rect & bounds)
+grt::getBoxFromRect	src/GeoTypes.h	/^BoxT getBoxFromRect(const odb::Rect& bounds);$/;"	p	namespace:grt	typeref:typename:BoxT	signature:(const odb::Rect & bounds)
+grt::operator <<	src/GRTree.h	/^  friend std::ostream& operator<<(std::ostream& os, const GRPoint& pt)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const GRPoint & pt)
+grt::operator <<	src/GeoTypes.cpp	/^std::ostream& operator<<(std::ostream& os, const BoxOnLayer& box)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const BoxOnLayer & box)
+grt::operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const BoxT& box)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const BoxT & box)
+grt::operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const IntervalT& interval)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const IntervalT & interval)
+grt::operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const PointT& pt)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const PointT & pt)
+hasIntersectWith	src/geo.h	/^  bool hasIntersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+hasIntersectWith	src/geo.h	/^  bool hasIntersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+hasSaveSttInput	include/CUGR.h	/^  bool hasSaveSttInput();$/;"	p	class:grt::CUGR	typeref:typename:bool	access:public	signature:()
+hasSaveSttInput	src/CUGR.cpp	/^bool CUGR::hasSaveSttInput()$/;"	f	class:grt::CUGR	typeref:typename:bool	signature:()
+hasStrictIntersectWith	src/geo.h	/^  bool hasStrictIntersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+hasStrictIntersectWith	src/geo.h	/^  bool hasStrictIntersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+hasSttTree	src/PatternRoute.h	/^  bool hasSttTree() const { return stt_tree_valid_; }$/;"	f	class:grt::PatternRoute	typeref:typename:bool	access:public	signature:() const
+has_is_transparent	src/robin_hood.h	/^struct has_is_transparent : public std::false_type$/;"	s	namespace:robin_hood::detail	inherits:std::false_type
+has_is_transparent	src/robin_hood.h	/^struct has_is_transparent<T,$/;"	s	namespace:robin_hood::detail	inherits:std::true_type
+hash	src/robin_hood.h	/^struct hash : public std::hash<T>$/;"	s	namespace:robin_hood	inherits:std::hash<T>
+hash	src/robin_hood.h	/^struct hash<Enum, typename std::enable_if_t<std::is_enum_v<Enum>>>$/;"	s	namespace:robin_hood
+hash	src/robin_hood.h	/^struct hash<T*>$/;"	s	namespace:robin_hood
+hash	src/robin_hood.h	/^struct hash<std::basic_string<CharT>>$/;"	s	namespace:robin_hood
+hash	src/robin_hood.h	/^struct hash<std::basic_string_view<CharT>>$/;"	s	namespace:robin_hood
+hash	src/robin_hood.h	/^struct hash<std::shared_ptr<T>>$/;"	s	namespace:robin_hood
+hash	src/robin_hood.h	/^struct hash<std::unique_ptr<T>>$/;"	s	namespace:robin_hood
+hashCell	src/GridGraph.h	/^  uint64_t hashCell(const GRPoint& point) const$/;"	f	class:grt::GridGraph	typeref:typename:uint64_t	access:public	signature:(const GRPoint & point) const
+hash_bytes	src/robin_hood.h	/^inline size_t hash_bytes(void const* ptr, size_t len) noexcept$/;"	f	namespace:robin_hood	typeref:typename:size_t	signature:(void const * ptr,size_t len)
+hash_int	src/robin_hood.h	/^inline size_t hash_int(uint64_t x) noexcept$/;"	f	namespace:robin_hood	typeref:typename:size_t	signature:(uint64_t x)
+hasher	src/robin_hood.h	/^  using hasher = Hash;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Hash	access:public
+height	src/geo.h	/^  int height() const { return y_.range(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+high	src/geo.h	/^  int high() const { return high_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+high_	src/geo.h	/^  int high_;$/;"	m	class:grt::IntervalT	typeref:typename:int	access:private
+hp	src/geo.h	/^  int hp() const { return width() + height(); }  \/\/ half perimeter$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+hx	src/geo.h	/^  int hx() const { return x_.high(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+hy	src/geo.h	/^  int hy() const { return y_.high(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+increase_size	src/robin_hood.h	/^  bool increase_size()$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:private	signature:()
+index_	src/GRNet.h	/^  int index_;$/;"	m	class:grt::GRNet	typeref:typename:int	access:private
+index_	src/Layers.h	/^  int index_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+index_	src/Netlist.h	/^  const int index_;$/;"	m	class:grt::CUGRNet	typeref:typename:const int	access:private
+index_	src/Netlist.h	/^  const int index_;$/;"	m	class:grt::CUGRPin	typeref:typename:const int	access:private
+index_	src/PatternRoute.h	/^  const int index_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:const int	access:private
+init	include/CUGR.h	/^  void init(int min_routing_layer,$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(int min_routing_layer,int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+init	src/CUGR.cpp	/^void CUGR::init(const int min_routing_layer,$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const int min_routing_layer,const int max_routing_layer,const std::set<odb::dbNet * > & clock_nets)
+init	src/MazeRoute.cpp	/^void SparseGraph::init(const GridGraphView<CostT>& wire_cost_view,$/;"	f	class:grt::SparseGraph	typeref:typename:void	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+init	src/MazeRoute.h	/^  void init(const GridGraphView<CostT>& wire_cost_view, const SparseGrid& grid);$/;"	p	class:grt::SparseGraph	typeref:typename:void	access:public	signature:(const GridGraphView<CostT> & wire_cost_view,const SparseGrid & grid)
+init	src/robin_hood.h	/^  void init() noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+initData	src/robin_hood.h	/^  void initData(size_t max_elements)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t max_elements)
+insert	src/robin_hood.h	/^  std::pair<iterator, bool> insert(const value_type& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const value_type & keyval)
+insert	src/robin_hood.h	/^  std::pair<iterator, bool> insert(value_type&& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(value_type && keyval)
+insert	src/robin_hood.h	/^  void insert(Iter first, Iter last)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(Iter first,Iter last)
+insert	src/robin_hood.h	/^  void insert(std::initializer_list<value_type> ilist)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(std::initializer_list<value_type> ilist)
+insertKeyPrepareEmptySpot	src/robin_hood.h	/^  std::pair<size_t, InsertionState> insertKeyPrepareEmptySpot(OtherKey&& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<size_t,InsertionState>	access:private	signature:(OtherKey && key)
+insertOrAssignImpl	src/robin_hood.h	/^  std::pair<iterator, bool> insertOrAssignImpl(OtherKey&& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:private	signature:(OtherKey && key,Mapped && obj)
+insert_move	src/robin_hood.h	/^  void insert_move(Node&& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(Node && keyval)
+insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const key_type& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const key_type & key,Mapped && obj)
+insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,const key_type & key,Mapped && obj)
+insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,key_type && key,Mapped && obj)
+insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(key_type&& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(key_type && key,Mapped && obj)
+intersectWith	src/geo.h	/^  BoxT intersectWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & rhs) const
+intersectWith	src/geo.h	/^  IntervalT intersectWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(const IntervalT & rhs) const
+interval	src/MazeRoute.h	/^  PointT interval;$/;"	m	struct:grt::SparseGrid	typeref:typename:PointT	access:public
+isConnected	src/GeoTypes.cpp	/^bool BoxOnLayer::isConnected(const BoxOnLayer& rhs) const$/;"	f	class:grt::BoxOnLayer	typeref:typename:bool	signature:(const BoxOnLayer & rhs) const
+isConnected	src/GeoTypes.h	/^  bool isConnected(const BoxOnLayer& rhs) const;$/;"	p	class:grt::BoxOnLayer	typeref:typename:bool	access:public	signature:(const BoxOnLayer & rhs) const
+isCritical	src/GRNet.h	/^  bool isCritical() const { return is_critical_; }$/;"	f	class:grt::GRNet	typeref:typename:bool	access:public	signature:() const
+isInsideLayerRange	src/GRNet.cpp	/^bool GRNet::isInsideLayerRange(int layer_index) const$/;"	f	class:grt::GRNet	typeref:typename:bool	signature:(int layer_index) const
+isInsideLayerRange	src/GRNet.h	/^  bool isInsideLayerRange(int layer_index) const;$/;"	p	class:grt::GRNet	typeref:typename:bool	access:public	signature:(int layer_index) const
+isLocal	src/GRNet.cpp	/^bool GRNet::isLocal() const$/;"	f	class:grt::GRNet	typeref:typename:bool	signature:() const
+isLocal	src/GRNet.h	/^  bool isLocal() const;$/;"	p	class:grt::GRNet	typeref:typename:bool	access:public	signature:() const
+isOptional	src/PatternRoute.h	/^  bool isOptional() const { return optional_; }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:bool	access:public	signature:() const
+isPort	src/Netlist.h	/^  bool isPort() const { return is_port_; }$/;"	f	class:grt::CUGRPin	typeref:typename:bool	access:public	signature:() const
+isStrictValid	src/geo.h	/^  bool isStrictValid() const { return low_ < high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:() const
+isStrictValid	src/geo.h	/^  bool isStrictValid() const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:() const
+isValid	src/geo.h	/^  bool isValid() const { return low_ <= high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:() const
+isValid	src/geo.h	/^  bool isValid() const { return x_.isValid() && y_.isValid(); }$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:() const
+isValid	src/geo.h	/^  bool isValid() { return *this != PointT(); }$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:()
+is_critical_	src/GRNet.h	/^  bool is_critical_;$/;"	m	class:grt::GRNet	typeref:typename:bool	access:private
+is_flat	src/robin_hood.h	/^  static constexpr bool is_flat = IsFlat;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+is_map	src/robin_hood.h	/^  static constexpr bool is_map = !std::is_void_v<T>;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+is_port_	src/Netlist.h	/^  const bool is_port_;$/;"	m	class:grt::CUGRPin	typeref:typename:const bool	access:private
+is_set	src/robin_hood.h	/^  static constexpr bool is_set = !is_map;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+is_transparent	src/robin_hood.h	/^  static constexpr bool is_transparent$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+is_transparent_tag	src/robin_hood.h	/^struct is_transparent_tag$/;"	s	namespace:robin_hood
+iterator	src/robin_hood.h	/^  using iterator = Iter<false>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Iter<false>	access:public
+iterator_category	src/robin_hood.h	/^    using iterator_category = std::forward_iterator_tag;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::forward_iterator_tag	access:public
+iterm	src/Netlist.h	/^    odb::dbITerm* iterm;$/;"	m	union:grt::CUGRPin::__anoncab81335010a	typeref:typename:odb::dbITerm *	access:public
+iterm_to_ap_	src/GRNet.h	/^  std::map<odb::dbITerm*, AccessPoint> iterm_to_ap_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<odb::dbITerm *,AccessPoint>	access:private
+keyToIdx	src/robin_hood.h	/^  void keyToIdx(HashKey&& key, size_t* idx, InfoType* info) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(HashKey && key,size_t * idx,InfoType * info) const
+key_equal	src/robin_hood.h	/^  using key_equal = KeyEqual;$/;"	t	class:robin_hood::detail::Table	typeref:typename:KeyEqual	access:public
+key_found	src/robin_hood.h	/^    key_found,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+key_type	src/robin_hood.h	/^  using key_type = Key;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Key	access:public
+last_track_loc_	src/Layers.h	/^  int last_track_loc_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+layer_directions_	src/GridGraph.h	/^  std::vector<int> layer_directions_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<int>	access:private
+layer_idx_	src/GRTree.h	/^  int layer_idx_;$/;"	m	class:grt::GRPoint	typeref:typename:int	access:private
+layer_idx_	src/GeoTypes.h	/^  int layer_idx_;$/;"	m	class:grt::BoxOnLayer	typeref:typename:int	access:private
+layer_min_lengths_	src/GridGraph.h	/^  std::vector<int> layer_min_lengths_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<int>	access:private
+layer_names_	src/GridGraph.h	/^  std::vector<std::string> layer_names_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<std::string>	access:private
+layer_range_	src/GRNet.h	/^  LayerRange layer_range_;$/;"	m	class:grt::GRNet	typeref:typename:LayerRange	access:private
+layer_range_	src/Netlist.h	/^  LayerRange layer_range_;$/;"	m	class:grt::CUGRNet	typeref:typename:LayerRange	access:private
+layers	src/GridGraph.h	/^  IntervalT layers;$/;"	m	struct:grt::AccessPoint	typeref:typename:IntervalT	access:public
+layers_	src/Design.h	/^  std::vector<MetalLayer> layers_;$/;"	m	class:grt::Design	typeref:typename:std::vector<MetalLayer>	access:private
+lib_dbu_	src/Design.h	/^  int lib_dbu_;$/;"	m	class:grt::Design	typeref:typename:int	access:private
+lib_dbu_	src/GridGraph.h	/^  const int lib_dbu_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+load_factor	src/robin_hood.h	/^  float load_factor() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:float	access:public	signature:() const
+logger_	include/CUGR.h	/^  utl::Logger* logger_;$/;"	m	class:grt::CUGR	typeref:typename:utl::Logger *	access:private
+logger_	src/Design.h	/^  utl::Logger* logger_;$/;"	m	class:grt::Design	typeref:typename:utl::Logger *	access:private
+logger_	src/GridGraph.h	/^  utl::Logger* logger_;$/;"	m	class:grt::GridGraph	typeref:typename:utl::Logger *	access:private
+logger_	src/MazeRoute.h	/^  utl::Logger* logger_;$/;"	m	class:grt::MazeRoute	typeref:typename:utl::Logger *	access:private
+logger_	src/PatternRoute.h	/^  utl::Logger* logger_;$/;"	m	class:grt::PatternRoute	typeref:typename:utl::Logger *	access:private
+logistic	src/GridGraph.cpp	/^double GridGraph::logistic(const CapacityT& input, const double slope) const$/;"	f	class:grt::GridGraph	typeref:typename:double	signature:(const CapacityT & input,const double slope) const
+logistic	src/GridGraph.h	/^  double logistic(const CapacityT& input, double slope) const;$/;"	p	class:grt::GridGraph	typeref:typename:double	access:private	signature:(const CapacityT & input,double slope) const
+low	src/geo.h	/^  int low() const { return low_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+low_	src/geo.h	/^  int low_;$/;"	m	class:grt::IntervalT	typeref:typename:int	access:private
+lx	src/geo.h	/^  int lx() const { return x_.low(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+ly	src/geo.h	/^  int ly() const { return y_.low(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+m2_pitch_	src/GridGraph.h	/^  const int m2_pitch_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+mData	src/robin_hood.h	/^    value_type mData;$/;"	m	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type	access:private
+mData	src/robin_hood.h	/^    value_type* mData;$/;"	m	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:private
+mHashMultiplier	src/robin_hood.h	/^  uint64_t mHashMultiplier = UINT64_C(0xc4ceb9fe1a85ec53);  \/\/ 8 byte  8$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint64_t	access:private
+mHead	src/robin_hood.h	/^  T* mHead{nullptr};$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T *	access:private
+mInfo	src/robin_hood.h	/^    uint8_t const* mInfo{nullptr};$/;"	m	class:robin_hood::detail::Table::Iter	typeref:typename:uint8_t const *	access:private
+mInfo	src/robin_hood.h	/^  uint8_t* mInfo = reinterpret_cast<uint8_t*>(&mMask);          \/\/ 8 byte 24$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t *	access:private
+mInfoHashShift	src/robin_hood.h	/^  InfoType mInfoHashShift$/;"	m	class:robin_hood::detail::Table	typeref:typename:InfoType	access:private
+mInfoInc	src/robin_hood.h	/^  InfoType mInfoInc = InitialInfoInc;                           \/\/ 4 byte 52$/;"	m	class:robin_hood::detail::Table	typeref:typename:InfoType	access:private
+mKeyVals	src/robin_hood.h	/^    NodePtr mKeyVals{nullptr};$/;"	m	class:robin_hood::detail::Table::Iter	typeref:typename:NodePtr	access:private
+mKeyVals	src/robin_hood.h	/^  Node* mKeyVals$/;"	m	class:robin_hood::detail::Table	typeref:typename:Node *	access:private
+mListForFree	src/robin_hood.h	/^  T** mListForFree{nullptr};$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T **	access:private
+mMask	src/robin_hood.h	/^  size_t mMask = 0;                                             \/\/ 8 byte 40$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+mMaxNumElementsAllowed	src/robin_hood.h	/^  size_t mMaxNumElementsAllowed = 0;                            \/\/ 8 byte 48$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+mNumElements	src/robin_hood.h	/^  size_t mNumElements = 0;                                      \/\/ 8 byte 32$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+makeNetPins	src/Design.cpp	/^std::vector<CUGRPin> Design::makeNetPins(odb::dbNet* db_net)$/;"	f	class:grt::Design	typeref:typename:std::vector<CUGRPin>	signature:(odb::dbNet * db_net)
+makeNetPins	src/Design.h	/^  std::vector<CUGRPin> makeNetPins(odb::dbNet* db_net);$/;"	p	class:grt::Design	typeref:typename:std::vector<CUGRPin>	access:private	signature:(odb::dbNet * db_net)
+mapped_type	src/robin_hood.h	/^  using mapped_type = T;$/;"	t	class:robin_hood::detail::Table	typeref:typename:T	access:public
+max_detour_ratio	include/CUGR.h	/^  double max_detour_ratio = 0.25;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+max_eol_spacing_	src/Layers.h	/^  int max_eol_spacing_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+max_eol_width_	src/Layers.h	/^  int max_eol_width_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+max_eol_within_	src/Layers.h	/^  int max_eol_within_ = 0;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+max_layer	src/Netlist.h	/^  int max_layer;$/;"	m	struct:grt::LayerRange	typeref:typename:int	access:public
+max_load_factor	src/robin_hood.h	/^  float max_load_factor() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:float	access:public	signature:() const
+max_routing_layer_	src/Design.h	/^  const int max_routing_layer_;$/;"	m	class:grt::Design	typeref:typename:const int	access:private
+max_size	src/robin_hood.h	/^  size_type max_size() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_type	access:public	signature:() const
+mazeRoute	include/CUGR.h	/^  void mazeRoute(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+mazeRoute	src/CUGR.cpp	/^void CUGR::mazeRoute(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+maze_logistic_slope	include/CUGR.h	/^  double maze_logistic_slope = 0.5;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+min_layer	src/Netlist.h	/^  int min_layer;$/;"	m	struct:grt::LayerRange	typeref:typename:int	access:public
+min_length_	src/Layers.h	/^  int min_length_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+min_routing_layer	include/CUGR.h	/^  int min_routing_layer = 1;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+min_routing_layer_	src/Design.h	/^  const int min_routing_layer_;$/;"	m	class:grt::Design	typeref:typename:const int	access:private
+min_width_	src/Layers.h	/^  int min_width_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+name_	src/Layers.h	/^  std::string name_;$/;"	m	class:grt::MetalLayer	typeref:typename:std::string	access:private
+net_	src/MazeRoute.h	/^  GRNet* net_;$/;"	m	class:grt::SparseGraph	typeref:typename:GRNet *	access:private
+net_	src/MazeRoute.h	/^  const GRNet* net_;$/;"	m	class:grt::MazeRoute	typeref:typename:const GRNet *	access:private
+net_	src/PatternRoute.h	/^  GRNet* net_;$/;"	m	class:grt::PatternRoute	typeref:typename:GRNet *	access:private
+net_indices_	include/CUGR.h	/^  std::vector<int> net_indices_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<int>	access:private
+nets_	src/Design.h	/^  std::vector<CUGRNet> nets_;$/;"	m	class:grt::Design	typeref:typename:std::vector<CUGRNet>	access:private
+nets_to_route_	include/CUGR.h	/^  std::vector<int> nets_to_route_;$/;"	m	class:grt::CUGR	typeref:typename:std::vector<int>	access:private
+new_node	src/robin_hood.h	/^    new_node,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+next	src/robin_hood.h	/^  void next(InfoType* info, size_t* idx) const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(InfoType * info,size_t * idx) const
+nextHashMultiplier	src/robin_hood.h	/^  void nextHashMultiplier()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+nextWhileLess	src/robin_hood.h	/^  void nextWhileLess(InfoType* info, size_t* idx) const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(InfoType * info,size_t * idx) const
+node	src/PatternRoute.cpp	/^    std::shared_ptr<PatternRoutingNode> node;$/;"	m	struct:grt::PatternRoute::constructDetours::ScaffoldNode	typeref:typename:std::shared_ptr<PatternRoutingNode>	file:	access:public
+nodes	src/robin_hood.h	/^    void nodes(M& m) const noexcept { m.mNumElements = 0; }$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+nodes	src/robin_hood.h	/^    void nodes(M& m) const noexcept$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+nodesDoNotDeallocate	src/robin_hood.h	/^    void nodesDoNotDeallocate(M& m) const noexcept { m.mNumElements = 0; }$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+nodesDoNotDeallocate	src/robin_hood.h	/^    void nodesDoNotDeallocate(M& m) const noexcept$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+nothrow	src/robin_hood.h	/^struct nothrow$/;"	s	namespace:robin_hood::detail::swappable
+num_dag_nodes_	src/PatternRoute.h	/^  int num_dag_nodes_{0};$/;"	m	class:grt::PatternRoute	typeref:typename:int	access:private
+num_layers_	src/GridGraph.h	/^  const int num_layers_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+num_tracks_	src/Layers.h	/^  int num_tracks_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+obstacles_	src/Design.h	/^  std::vector<BoxOnLayer> obstacles_;$/;"	m	class:grt::Design	typeref:typename:std::vector<BoxOnLayer>	access:private
+odb	include/CUGR.h	/^namespace odb {$/;"	n
+odb	src/Design.h	/^namespace odb {$/;"	n
+offset	src/MazeRoute.h	/^  PointT offset;$/;"	m	struct:grt::SparseGrid	typeref:typename:PointT	access:public
+operator !=	src/geo.h	/^  bool operator!=(const BoxT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+operator !=	src/geo.h	/^  bool operator!=(const IntervalT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+operator !=	src/geo.h	/^  bool operator!=(const PointT& rhs) const { return !(*this == rhs); }$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:(const PointT & rhs) const
+operator !=	src/robin_hood.h	/^    bool operator!=(Iter<O> const& o) const noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:bool	access:public	signature:(Iter<O> const & o) const
+operator !=	src/robin_hood.h	/^  bool operator!=(const Table& other) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const Table & other) const
+operator !=	src/robin_hood.h	/^constexpr bool operator!=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator ()	src/GridGraph.h	/^  bool operator()(const AccessPoint& lhs, const AccessPoint& rhs) const$/;"	f	struct:grt::AccessPointEqual	typeref:typename:bool	access:public	signature:(const AccessPoint & lhs,const AccessPoint & rhs) const
+operator ()	src/GridGraph.h	/^  std::size_t operator()(const AccessPoint& ap) const$/;"	f	class:grt::AccessPointHash	typeref:typename:std::size_t	access:public	signature:(const AccessPoint & ap) const
+operator ()	src/robin_hood.h	/^    void operator()(M const& s, M& t) const$/;"	f	struct:robin_hood::detail::Table::Cloner	typeref:typename:void	access:public	signature:(M const & s,M & t) const
+operator ()	src/robin_hood.h	/^    void operator()(M const& source, M& target) const$/;"	f	struct:robin_hood::detail::Table::Cloner	typeref:typename:void	access:public	signature:(M const & source,M & target) const
+operator ()	src/robin_hood.h	/^  size_t operator()(Enum e) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(Enum e) const
+operator ()	src/robin_hood.h	/^  size_t operator()(T const& obj) const noexcept(noexcept($/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(T const & obj) const
+operator ()	src/robin_hood.h	/^  size_t operator()(T* ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(T * ptr) const
+operator ()	src/robin_hood.h	/^  size_t operator()(std::basic_string<CharT> const& str) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::basic_string<CharT> const & str) const
+operator ()	src/robin_hood.h	/^  size_t operator()(std::basic_string_view<CharT> const& sv) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::basic_string_view<CharT> const & sv) const
+operator ()	src/robin_hood.h	/^  size_t operator()(std::shared_ptr<T> const& ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::shared_ptr<T> const & ptr) const
+operator ()	src/robin_hood.h	/^  size_t operator()(std::unique_ptr<T> const& ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::unique_ptr<T> const & ptr) const
+operator *	src/robin_hood.h	/^    const value_type& operator*() const noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:const value_type &	access:public	signature:() const
+operator *	src/robin_hood.h	/^    const value_type& operator*() const { return *mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:const value_type &	access:public	signature:() const
+operator *	src/robin_hood.h	/^    reference operator*() const { return **mKeyVals; }$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:reference	access:public	signature:() const
+operator *	src/robin_hood.h	/^    value_type& operator*() noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type &	access:public	signature:()
+operator *	src/robin_hood.h	/^    value_type& operator*() { return *mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type &	access:public	signature:()
+operator +	src/geo.h	/^  PointT operator+(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT	access:public	signature:(const PointT & rhs)
+operator ++	src/robin_hood.h	/^    Iter operator++(int) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter	access:public	signature:(int)
+operator ++	src/robin_hood.h	/^    Iter& operator++() noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter &	access:public	signature:()
+operator +=	src/geo.h	/^  PointT& operator+=(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT &	access:public	signature:(const PointT & rhs)
+operator -=	src/geo.h	/^  PointT& operator-=(const PointT& rhs)$/;"	f	class:grt::PointT	typeref:typename:PointT &	access:public	signature:(const PointT & rhs)
+operator ->	src/robin_hood.h	/^    pointer operator->() const { return &**mKeyVals; }$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:pointer	access:public	signature:() const
+operator ->	src/robin_hood.h	/^    value_type const* operator->() const noexcept { return &mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type const *	access:public	signature:() const
+operator ->	src/robin_hood.h	/^    value_type const* operator->() const noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type const *	access:public	signature:() const
+operator ->	src/robin_hood.h	/^    value_type* operator->() noexcept { return &mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:public	signature:()
+operator ->	src/robin_hood.h	/^    value_type* operator->() noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:public	signature:()
+operator /	src/geo.h	/^  PointT operator\/(int divisor) { return PointT(x_ \/ divisor, y_ \/ divisor); }$/;"	f	class:grt::PointT	typeref:typename:PointT	access:public	signature:(int divisor)
+operator <	src/robin_hood.h	/^constexpr bool operator<(pair<A, B> const& x, pair<A, B> const& y) noexcept($/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator <<	src/GRTree.h	/^  friend std::ostream& operator<<(std::ostream& os, const GRPoint& pt)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const GRPoint & pt)
+operator <<	src/GeoTypes.cpp	/^std::ostream& operator<<(std::ostream& os, const BoxOnLayer& box)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const BoxOnLayer & box)
+operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const BoxT& box)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const BoxT & box)
+operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const IntervalT& interval)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const IntervalT & interval)
+operator <<	src/geo.h	/^  friend std::ostream& operator<<(std::ostream& os, const PointT& pt)$/;"	f	namespace:grt	typeref:typename:std::ostream &	signature:(std::ostream & os,const PointT & pt)
+operator <<	src/robin_hood.h	/^inline std::ostream& operator<<(std::ostream& os, Counts const& c)$/;"	f	namespace:robin_hood	typeref:typename:std::ostream &	signature:(std::ostream & os,Counts const & c)
+operator <=	src/robin_hood.h	/^constexpr bool operator<=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator =	src/robin_hood.h	/^    Iter& operator=(Iter<OtherIsConst> const& other) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter &	access:public	signature:(Iter<OtherIsConst> const & other)
+operator =	src/robin_hood.h	/^  BulkPoolAllocator& operator=(BulkPoolAllocator&& o) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:BulkPoolAllocator &	access:public	signature:(BulkPoolAllocator && o)
+operator =	src/robin_hood.h	/^  Table& operator=(Table const& o)$/;"	f	class:robin_hood::detail::Table	typeref:typename:Table &	access:public	signature:(Table const & o)
+operator =	src/robin_hood.h	/^  Table& operator=(Table&& o) noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:Table &	access:public	signature:(Table && o)
+operator =	src/robin_hood.h	/^  operator=(const BulkPoolAllocator & ROBIN_HOOD_UNUSED(o) \/*unused*\/) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:BulkPoolAllocator &	access:public	signature:(const BulkPoolAllocator & ROBIN_HOOD_UNUSED (o))
+operator ==	src/GridGraph.h	/^  bool operator==(const AccessPoint& ap) const$/;"	f	struct:grt::AccessPoint	typeref:typename:bool	access:public	signature:(const AccessPoint & ap) const
+operator ==	src/geo.h	/^  bool operator==(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const BoxT & rhs) const
+operator ==	src/geo.h	/^  bool operator==(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(const IntervalT & rhs) const
+operator ==	src/geo.h	/^  bool operator==(const PointT& rhs) const$/;"	f	class:grt::PointT	typeref:typename:bool	access:public	signature:(const PointT & rhs) const
+operator ==	src/robin_hood.h	/^    bool operator==(Iter<O> const& o) const noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:bool	access:public	signature:(Iter<O> const & o) const
+operator ==	src/robin_hood.h	/^  bool operator==(const Table& other) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const Table & other) const
+operator ==	src/robin_hood.h	/^constexpr bool operator==(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator >	src/robin_hood.h	/^constexpr bool operator>(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator >=	src/robin_hood.h	/^constexpr bool operator>=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+operator []	src/geo.h	/^  IntervalT& operator[](int i)$/;"	f	class:grt::BoxT	typeref:typename:IntervalT &	access:public	signature:(int i)
+operator []	src/geo.h	/^  const IntervalT& operator[](int i) const$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:(int i) const
+operator []	src/geo.h	/^  const int& operator[](const int d) const$/;"	f	class:grt::PointT	typeref:typename:const int &	access:public	signature:(const int d) const
+operator []	src/geo.h	/^  int& operator[](const int d)$/;"	f	class:grt::PointT	typeref:typename:int &	access:public	signature:(const int d)
+operator []	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> operator[]($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(const key_type & key)
+operator []	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> operator[](key_type&& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(key_type && key)
+optional_	src/PatternRoute.h	/^  bool optional_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:bool	access:private
+overflow_error	src/robin_hood.h	/^    overflow_error,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+overwrite_node	src/robin_hood.h	/^    overwrite_node$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+pair	src/robin_hood.h	/^      pair(std::piecewise_construct_t \/*unused*\/,$/;"	f	struct:robin_hood::pair	access:public	signature:(std::piecewise_construct_t,std::tuple<U1...> a,std::tuple<U2...> b)
+pair	src/robin_hood.h	/^  constexpr pair() noexcept(noexcept(U1()) && noexcept(U2()))$/;"	f	struct:robin_hood::pair	access:public	signature:()
+pair	src/robin_hood.h	/^  constexpr pair(T1&& a, T2&& b) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(T1 && a,T2 && b)
+pair	src/robin_hood.h	/^  constexpr pair(U1&& a, U2&& b) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(U1 && a,U2 && b)
+pair	src/robin_hood.h	/^  explicit constexpr pair(std::pair<T1, T2> const& o) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(std::pair<T1,T2> const & o)
+pair	src/robin_hood.h	/^  explicit constexpr pair(std::pair<T1, T2>&& o) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(std::pair<T1,T2> && o)
+pair	src/robin_hood.h	/^  pair($/;"	f	struct:robin_hood::pair	access:public	signature:(std::tuple<U1...> & a,std::tuple<U2...> & b,ROBIN_HOOD_STD::index_sequence<I1...>,ROBIN_HOOD_STD::index_sequence<I2...>)
+pair	src/robin_hood.h	/^struct pair$/;"	s	namespace:robin_hood
+parallel_length_	src/Layers.h	/^  std::vector<int> parallel_length_ = {0};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<int>	access:private
+parallel_spacing_	src/Layers.h	/^  std::vector<std::vector<int>> parallel_spacing_ = {{0}};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<std::vector<int>>	access:private
+parallel_width_	src/Layers.h	/^  std::vector<int> parallel_width_ = {0};$/;"	m	class:grt::MetalLayer	typeref:typename:std::vector<int>	access:private
+paths_	src/PatternRoute.h	/^  std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>> paths_;$/;"	m	class:grt::PatternRoutingNode	typeref:typename:std::vector<std::vector<std::shared_ptr<PatternRoutingNode>>>	access:private
+patternRoute	include/CUGR.h	/^  void patternRoute(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+patternRoute	src/CUGR.cpp	/^void CUGR::patternRoute(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+patternRouteWithDetours	include/CUGR.h	/^  void patternRouteWithDetours(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+patternRouteWithDetours	src/CUGR.cpp	/^void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+pin_access_points_	src/GRNet.h	/^  std::vector<std::vector<GRPoint>> pin_access_points_;$/;"	m	class:grt::GRNet	typeref:typename:std::vector<std::vector<GRPoint>>	access:private
+pin_index_to_bterm_	src/GRNet.h	/^  std::map<int, odb::dbBTerm*> pin_index_to_bterm_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<int,odb::dbBTerm * >	access:private
+pin_index_to_iterm_	src/GRNet.h	/^  std::map<int, odb::dbITerm*> pin_index_to_iterm_;$/;"	m	class:grt::GRNet	typeref:typename:std::map<int,odb::dbITerm * >	access:private
+pin_patch_padding	include/CUGR.h	/^  int pin_patch_padding = 1;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+pin_patch_threshold	include/CUGR.h	/^  double pin_patch_threshold = 20.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+pin_shapes_	src/Netlist.h	/^  std::vector<BoxOnLayer> pin_shapes_;$/;"	m	class:grt::CUGRPin	typeref:typename:std::vector<BoxOnLayer>	access:private
+pin_vertex_	src/MazeRoute.h	/^  std::vector<int> pin_vertex_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+pins_	src/Netlist.h	/^  std::vector<CUGRPin> pins_;$/;"	m	class:grt::CUGRNet	typeref:typename:std::vector<CUGRPin>	access:private
+pitch_	src/Layers.h	/^  int pitch_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+point	src/GridGraph.h	/^  PointT point;$/;"	m	struct:grt::AccessPoint	typeref:typename:PointT	access:public
+pointer	src/robin_hood.h	/^    using pointer =$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,value_type const *,value_type * >	access:public
+preorder	src/GRTree.cpp	/^void GRTreeNode::preorder($/;"	f	class:grt::GRTreeNode	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & node,const std::function<void (const std::shared_ptr<GRTreeNode> &)> & visit)
+preorder	src/GRTree.h	/^  static void preorder($/;"	p	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & node,const std::function<void (const std::shared_ptr<GRTreeNode> &)> & visit)
+preorder	src/PatternRoute.cpp	/^void SteinerTreeNode::preorder($/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	signature:(const std::shared_ptr<SteinerTreeNode> & node,const std::function<void (std::shared_ptr<SteinerTreeNode>)> & visit)
+preorder	src/PatternRoute.h	/^  static void preorder($/;"	p	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & node,const std::function<void (std::shared_ptr<SteinerTreeNode>)> & visit)
+prev	src/MazeRoute.h	/^  const std::shared_ptr<Solution> prev;$/;"	m	struct:grt::Solution	typeref:typename:const std::shared_ptr<Solution>	access:public
+print	src/GRTree.cpp	/^void GRTreeNode::print(const std::shared_ptr<GRTreeNode>& node,$/;"	f	class:grt::GRTreeNode	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & node,utl::Logger * logger)
+print	src/GRTree.h	/^  static void print(const std::shared_ptr<GRTreeNode>& node,$/;"	p	class:grt::GRTreeNode	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & node,utl::Logger * logger)
+printBlockages	src/Design.cpp	/^void Design::printBlockages() const$/;"	f	class:grt::Design	typeref:typename:void	signature:() const
+printBlockages	src/Design.h	/^  void printBlockages() const;$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:() const
+printNets	src/Design.cpp	/^void Design::printNets() const$/;"	f	class:grt::Design	typeref:typename:void	signature:() const
+printNets	src/Design.h	/^  void printNets() const;$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:() const
+printStatistics	include/CUGR.h	/^  void printStatistics() const;$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:() const
+printStatistics	src/CUGR.cpp	/^void CUGR::printStatistics() const$/;"	f	class:grt::CUGR	typeref:typename:void	signature:() const
+pseudo_pins_	src/MazeRoute.h	/^  std::vector<AccessPoint> pseudo_pins_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<AccessPoint>	access:private
+range	src/geo.h	/^  int range() const { return high_ - low_; }$/;"	f	class:grt::IntervalT	typeref:typename:int	access:public	signature:() const
+rangeSearchCells	src/GridGraph.cpp	/^BoxT GridGraph::rangeSearchCells(const BoxT& box) const$/;"	f	class:grt::GridGraph	typeref:typename:BoxT	signature:(const BoxT & box) const
+rangeSearchCells	src/GridGraph.h	/^  BoxT rangeSearchCells(const BoxT& box) const;$/;"	p	class:grt::GridGraph	typeref:typename:BoxT	access:public	signature:(const BoxT & box) const
+rangeSearchGridlines	src/GridGraph.cpp	/^IntervalT GridGraph::rangeSearchGridlines(const int dimension,$/;"	f	class:grt::GridGraph	typeref:typename:IntervalT	signature:(const int dimension,const IntervalT & loc_interval) const
+rangeSearchGridlines	src/GridGraph.h	/^  IntervalT rangeSearchGridlines(int dimension,$/;"	p	class:grt::GridGraph	typeref:typename:IntervalT	access:private	signature:(int dimension,const IntervalT & loc_interval) const
+rangeSearchRows	src/GridGraph.cpp	/^IntervalT GridGraph::rangeSearchRows(const int dimension,$/;"	f	class:grt::GridGraph	typeref:typename:IntervalT	signature:(const int dimension,const IntervalT & loc_interval) const
+rangeSearchRows	src/GridGraph.h	/^  IntervalT rangeSearchRows(int dimension, const IntervalT& loc_interval) const;$/;"	p	class:grt::GridGraph	typeref:typename:IntervalT	access:private	signature:(int dimension,const IntervalT & loc_interval) const
+rangeSearchTracks	src/Layers.cpp	/^IntervalT MetalLayer::rangeSearchTracks(const IntervalT& loc_range,$/;"	f	class:grt::MetalLayer	typeref:typename:IntervalT	signature:(const IntervalT & loc_range,const bool include_bound) const
+rangeSearchTracks	src/Layers.h	/^  IntervalT rangeSearchTracks(const IntervalT& loc_range,$/;"	p	class:grt::MetalLayer	typeref:typename:IntervalT	access:public	signature:(const IntervalT & loc_range,bool include_bound=true) const
+read	src/Design.cpp	/^void Design::read()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+read	src/Design.h	/^  void read();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+readDesignObstructions	src/Design.cpp	/^void Design::readDesignObstructions()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+readDesignObstructions	src/Design.h	/^  void readDesignObstructions();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+readInstanceObstructions	src/Design.cpp	/^void Design::readInstanceObstructions()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+readInstanceObstructions	src/Design.h	/^  void readInstanceObstructions();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+readLayers	src/Design.cpp	/^void Design::readLayers()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+readLayers	src/Design.h	/^  void readLayers();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+readNetlist	src/Design.cpp	/^void Design::readNetlist()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+readNetlist	src/Design.h	/^  void readNetlist();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+readSpecialNetObstructions	src/Design.cpp	/^int Design::readSpecialNetObstructions()$/;"	f	class:grt::Design	typeref:typename:int	signature:()
+readSpecialNetObstructions	src/Design.h	/^  int readSpecialNetObstructions();$/;"	p	class:grt::Design	typeref:typename:int	access:private	signature:()
+reference	src/robin_hood.h	/^    using reference =$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,value_type const &,value_type &>	access:public
+rehash	src/robin_hood.h	/^  void rehash(size_t c)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(size_t c)
+rehashPowerOfTwo	src/robin_hood.h	/^  void rehashPowerOfTwo(size_t numBuckets, bool forceFree)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t numBuckets,bool forceFree)
+reinterpret_cast_no_cast_align_warning	src/robin_hood.h	/^inline T reinterpret_cast_no_cast_align_warning(void const* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void const * ptr)
+reinterpret_cast_no_cast_align_warning	src/robin_hood.h	/^inline T reinterpret_cast_no_cast_align_warning(void* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void * ptr)
+removeChild	src/PatternRoute.h	/^  void removeChild(const int index)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const int index)
+removeChild	src/PatternRoute.h	/^  void removeChild(int index) { children_.erase(children_.begin() + index); }$/;"	f	class:grt::PatternRoutingNode	typeref:typename:void	access:public	signature:(int index)
+removeTreeUsage	src/GridGraph.cpp	/^void GridGraph::removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree)$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::shared_ptr<GRTreeNode> & tree)
+removeTreeUsage	src/GridGraph.h	/^  void removeTreeUsage(const std::shared_ptr<GRTreeNode>& tree);$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::shared_ptr<GRTreeNode> & tree)
+reserve	src/robin_hood.h	/^  void reserve(size_t c)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(size_t c)
+reserve	src/robin_hood.h	/^  void reserve(size_t c, bool forceRehash)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t c,bool forceRehash)
+reset	src/MazeRoute.h	/^  void reset(int x_interval, int y_interval)$/;"	f	struct:grt::SparseGrid	typeref:typename:void	access:public	signature:(int x_interval,int y_interval)
+reset	src/robin_hood.h	/^  void reset() noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:()
+robin_hood	src/robin_hood.h	/^namespace robin_hood {$/;"	n
+robin_hood::Counts	src/robin_hood.h	/^struct Counts$/;"	s	namespace:robin_hood
+robin_hood::Counts::shiftDown	src/robin_hood.h	/^  uint64_t shiftDown{};$/;"	m	struct:robin_hood::Counts	typeref:typename:uint64_t	access:public
+robin_hood::Counts::shiftUp	src/robin_hood.h	/^  uint64_t shiftUp{};$/;"	m	struct:robin_hood::Counts	typeref:typename:uint64_t	access:public
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(bool);$/;"	p	namespace:robin_hood	signature:(bool)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char);$/;"	p	namespace:robin_hood	signature:(char)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char16_t);$/;"	p	namespace:robin_hood	signature:(char16_t)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(char32_t);$/;"	p	namespace:robin_hood	signature:(char32_t)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(int);$/;"	p	namespace:robin_hood	signature:(int)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(long long);$/;"	p	namespace:robin_hood	signature:(long long)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(long);$/;"	p	namespace:robin_hood	signature:(long)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(short);$/;"	p	namespace:robin_hood	signature:(short)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(signed char);$/;"	p	namespace:robin_hood	signature:(signed char)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned char);$/;"	p	namespace:robin_hood	signature:(unsigned char)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned int);$/;"	p	namespace:robin_hood	signature:(unsigned int)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned long long);$/;"	p	namespace:robin_hood	signature:(unsigned long long)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned long);$/;"	p	namespace:robin_hood	signature:(unsigned long)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(unsigned short);$/;"	p	namespace:robin_hood	signature:(unsigned short)
+robin_hood::ROBIN_HOOD_HASH_INT	src/robin_hood.h	/^ROBIN_HOOD_HASH_INT(wchar_t);$/;"	p	namespace:robin_hood	signature:(wchar_t)
+robin_hood::counts	src/robin_hood.h	/^static Counts& counts()$/;"	f	namespace:robin_hood	typeref:typename:Counts &	signature:()
+robin_hood::detail	src/robin_hood.h	/^namespace detail {$/;"	n	namespace:robin_hood
+robin_hood::detail::BulkPoolAllocator	src/robin_hood.h	/^class BulkPoolAllocator$/;"	c	namespace:robin_hood::detail
+robin_hood::detail::BulkPoolAllocator::ALIGNED_SIZE	src/robin_hood.h	/^  static constexpr size_t ALIGNED_SIZE$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:size_t	access:private
+robin_hood::detail::BulkPoolAllocator::ALIGNMENT	src/robin_hood.h	/^  static const size_t ALIGNMENT$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:const size_t	access:private
+robin_hood::detail::BulkPoolAllocator::ALIGNMENT	src/robin_hood.h	/^  static constexpr size_t ALIGNMENT$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:size_t	access:private
+robin_hood::detail::BulkPoolAllocator::BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator($/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:(const BulkPoolAllocator & ROBIN_HOOD_UNUSED (o))
+robin_hood::detail::BulkPoolAllocator::BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator() noexcept = default;$/;"	p	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:()
+robin_hood::detail::BulkPoolAllocator::BulkPoolAllocator	src/robin_hood.h	/^  BulkPoolAllocator(BulkPoolAllocator&& o) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:(BulkPoolAllocator && o)
+robin_hood::detail::BulkPoolAllocator::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t calcNumElementsToAlloc() const noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:private	signature:(NODISCARD)
+robin_hood::detail::BulkPoolAllocator::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NOINLINE) T* performAllocation()$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:private	signature:(NOINLINE)
+robin_hood::detail::BulkPoolAllocator::add	src/robin_hood.h	/^  void add(void* ptr, const size_t numBytes) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:private	signature:(void * ptr,const size_t numBytes)
+robin_hood::detail::BulkPoolAllocator::addOrFree	src/robin_hood.h	/^  void addOrFree(void* ptr, const size_t numBytes) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(void * ptr,const size_t numBytes)
+robin_hood::detail::BulkPoolAllocator::allocate	src/robin_hood.h	/^  T* allocate()$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T *	access:public	signature:()
+robin_hood::detail::BulkPoolAllocator::deallocate	src/robin_hood.h	/^  void deallocate(T* obj) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(T * obj)
+robin_hood::detail::BulkPoolAllocator::mHead	src/robin_hood.h	/^  T* mHead{nullptr};$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T *	access:private
+robin_hood::detail::BulkPoolAllocator::mListForFree	src/robin_hood.h	/^  T** mListForFree{nullptr};$/;"	m	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:T **	access:private
+robin_hood::detail::BulkPoolAllocator::operator =	src/robin_hood.h	/^  BulkPoolAllocator& operator=(BulkPoolAllocator&& o) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:BulkPoolAllocator &	access:public	signature:(BulkPoolAllocator && o)
+robin_hood::detail::BulkPoolAllocator::operator =	src/robin_hood.h	/^  operator=(const BulkPoolAllocator & ROBIN_HOOD_UNUSED(o) \/*unused*\/) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:BulkPoolAllocator &	access:public	signature:(const BulkPoolAllocator & ROBIN_HOOD_UNUSED (o))
+robin_hood::detail::BulkPoolAllocator::reset	src/robin_hood.h	/^  void reset() noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:()
+robin_hood::detail::BulkPoolAllocator::swap	src/robin_hood.h	/^  void swap(BulkPoolAllocator<T, MinNumAllocs, MaxNumAllocs>& other) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(BulkPoolAllocator<T,MinNumAllocs,MaxNumAllocs> & other)
+robin_hood::detail::BulkPoolAllocator::~BulkPoolAllocator	src/robin_hood.h	/^  ~BulkPoolAllocator() noexcept { reset(); }$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:()
+robin_hood::detail::NodeAllocator	src/robin_hood.h	/^struct NodeAllocator<T, MinSize, MaxSize, false>$/;"	s	namespace:robin_hood::detail	inherits:BulkPoolAllocator<T,MinSize,MaxSize>
+robin_hood::detail::NodeAllocator	src/robin_hood.h	/^struct NodeAllocator<T, MinSize, MaxSize, true>$/;"	s	namespace:robin_hood::detail
+robin_hood::detail::NodeAllocator::addOrFree	src/robin_hood.h	/^  void addOrFree(void* ptr,$/;"	f	struct:robin_hood::detail::NodeAllocator	typeref:typename:void	access:public	signature:(void * ptr,size_t ROBIN_HOOD_UNUSED (numBytes))
+robin_hood::detail::ROBIN_HOOD	src/robin_hood.h	/^[[noreturn]] ROBIN_HOOD(NOINLINE)$/;"	f	namespace:robin_hood::detail	signature:(NOINLINE)
+robin_hood::detail::SizeT	src/robin_hood.h	/^using SizeT = uint64_t;$/;"	t	namespace:robin_hood::detail	typeref:typename:uint64_t
+robin_hood::detail::Table	src/robin_hood.h	/^class Table$/;"	c	namespace:robin_hood::detail	inherits:WrapHash<Hash>,WrapKeyEqual<KeyEqual>,detail::NodeAllocator<typenamestd::conditional_t<std::is_void_v<T>,Key,robin_hood::pair<typenamestd::conditional_t<IsFlat,Key,Keyconst>,T>>,4,16384,IsFlat>
+robin_hood::detail::Table::Cloner	src/robin_hood.h	/^  struct Cloner<M, false>$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Cloner	src/robin_hood.h	/^  struct Cloner<M, true>$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Cloner::operator ()	src/robin_hood.h	/^    void operator()(M const& s, M& t) const$/;"	f	struct:robin_hood::detail::Table::Cloner	typeref:typename:void	access:public	signature:(M const & s,M & t) const
+robin_hood::detail::Table::Cloner::operator ()	src/robin_hood.h	/^    void operator()(M const& source, M& target) const$/;"	f	struct:robin_hood::detail::Table::Cloner	typeref:typename:void	access:public	signature:(M const & source,M & target) const
+robin_hood::detail::Table::DataNode	src/robin_hood.h	/^  class DataNode$/;"	c	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::DataNode	src/robin_hood.h	/^  class DataNode<M, false>$/;"	c	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::DataNode	src/robin_hood.h	/^  class DataNode<M, true> final$/;"	c	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::DataNode::DataNode	src/robin_hood.h	/^    DataNode(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),DataNode<M,false> && n)
+robin_hood::detail::Table::DataNode::DataNode	src/robin_hood.h	/^    DataNode(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),DataNode<M,true> && n)
+robin_hood::detail::Table::DataNode::DataNode	src/robin_hood.h	/^    explicit DataNode($/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & ROBIN_HOOD_UNUSED (map),Args &&...args)
+robin_hood::detail::Table::DataNode::DataNode	src/robin_hood.h	/^    explicit DataNode(M& map, Args&&... args) : mData(map.allocate())$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(M & map,Args &&...args)
+robin_hood::detail::Table::DataNode::ROBIN_HOOD	src/robin_hood.h	/^    ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table::DataNode	access:public	signature:(NODISCARD)
+robin_hood::detail::Table::DataNode::destroy	src/robin_hood.h	/^    void destroy(M& ROBIN_HOOD_UNUSED(map) \/*unused*\/) noexcept {}$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(M & ROBIN_HOOD_UNUSED (map))
+robin_hood::detail::Table::DataNode::destroy	src/robin_hood.h	/^    void destroy(M& map) noexcept$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(M & map)
+robin_hood::detail::Table::DataNode::destroyDoNotDeallocate	src/robin_hood.h	/^    void destroyDoNotDeallocate() noexcept { mData->~value_type(); }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:()
+robin_hood::detail::Table::DataNode::destroyDoNotDeallocate	src/robin_hood.h	/^    void destroyDoNotDeallocate() noexcept {}$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:()
+robin_hood::detail::Table::DataNode::mData	src/robin_hood.h	/^    value_type mData;$/;"	m	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type	access:private
+robin_hood::detail::Table::DataNode::mData	src/robin_hood.h	/^    value_type* mData;$/;"	m	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:private
+robin_hood::detail::Table::DataNode::operator *	src/robin_hood.h	/^    const value_type& operator*() const noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:const value_type &	access:public	signature:() const
+robin_hood::detail::Table::DataNode::operator *	src/robin_hood.h	/^    const value_type& operator*() const { return *mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:const value_type &	access:public	signature:() const
+robin_hood::detail::Table::DataNode::operator *	src/robin_hood.h	/^    value_type& operator*() noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type &	access:public	signature:()
+robin_hood::detail::Table::DataNode::operator *	src/robin_hood.h	/^    value_type& operator*() { return *mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type &	access:public	signature:()
+robin_hood::detail::Table::DataNode::operator ->	src/robin_hood.h	/^    value_type const* operator->() const noexcept { return &mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type const *	access:public	signature:() const
+robin_hood::detail::Table::DataNode::operator ->	src/robin_hood.h	/^    value_type const* operator->() const noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type const *	access:public	signature:() const
+robin_hood::detail::Table::DataNode::operator ->	src/robin_hood.h	/^    value_type* operator->() noexcept { return &mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:public	signature:()
+robin_hood::detail::Table::DataNode::operator ->	src/robin_hood.h	/^    value_type* operator->() noexcept { return mData; }$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:value_type *	access:public	signature:()
+robin_hood::detail::Table::DataNode::swap	src/robin_hood.h	/^    void swap(DataNode<M, false>& o) noexcept$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(DataNode<M,false> & o)
+robin_hood::detail::Table::DataNode::swap	src/robin_hood.h	/^    void swap(DataNode<M, true>& o) noexcept($/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(DataNode<M,true> & o)
+robin_hood::detail::Table::DataPool	src/robin_hood.h	/^  using DataPool = detail::NodeAllocator<value_type, 4, 16384, IsFlat>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:detail::NodeAllocator<value_type,4,16384,IsFlat>	access:private
+robin_hood::detail::Table::Destroyer	src/robin_hood.h	/^  struct Destroyer$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Destroyer	src/robin_hood.h	/^  struct Destroyer<M, false>$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Destroyer	src/robin_hood.h	/^  struct Destroyer<M, true>$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Destroyer::nodes	src/robin_hood.h	/^    void nodes(M& m) const noexcept { m.mNumElements = 0; }$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+robin_hood::detail::Table::Destroyer::nodes	src/robin_hood.h	/^    void nodes(M& m) const noexcept$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+robin_hood::detail::Table::Destroyer::nodesDoNotDeallocate	src/robin_hood.h	/^    void nodesDoNotDeallocate(M& m) const noexcept { m.mNumElements = 0; }$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+robin_hood::detail::Table::Destroyer::nodesDoNotDeallocate	src/robin_hood.h	/^    void nodesDoNotDeallocate(M& m) const noexcept$/;"	f	struct:robin_hood::detail::Table::Destroyer	typeref:typename:void	access:public	signature:(M & m) const
+robin_hood::detail::Table::InfoMask	src/robin_hood.h	/^  static constexpr size_t InfoMask = InitialInfoInc - 1U;$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+robin_hood::detail::Table::InfoType	src/robin_hood.h	/^  using InfoType = uint32_t;$/;"	t	class:robin_hood::detail::Table	typeref:typename:uint32_t	access:private
+robin_hood::detail::Table::InitialInfoHashShift	src/robin_hood.h	/^  static constexpr uint8_t InitialInfoHashShift = 0;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t	access:private
+robin_hood::detail::Table::InitialInfoInc	src/robin_hood.h	/^  static constexpr uint8_t InitialInfoInc = 1U << InitialInfoNumBits;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t	access:private
+robin_hood::detail::Table::InitialInfoNumBits	src/robin_hood.h	/^  static constexpr uint32_t InitialInfoNumBits = 5;$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint32_t	access:private
+robin_hood::detail::Table::InitialNumElements	src/robin_hood.h	/^  static constexpr size_t InitialNumElements = sizeof(uint64_t);$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+robin_hood::detail::Table::InsertionState	src/robin_hood.h	/^  enum class InsertionState$/;"	g	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Iter	src/robin_hood.h	/^  class Iter$/;"	c	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::Iter::Iter	src/robin_hood.h	/^    Iter() = default;$/;"	p	class:robin_hood::detail::Table::Iter	access:public	signature:()
+robin_hood::detail::Table::Iter::Iter	src/robin_hood.h	/^    Iter(Iter<OtherIsConst> const& other) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(Iter<OtherIsConst> const & other)
+robin_hood::detail::Table::Iter::Iter	src/robin_hood.h	/^    Iter(NodePtr valPtr, uint8_t const* infoPtr) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(NodePtr valPtr,uint8_t const * infoPtr)
+robin_hood::detail::Table::Iter::Iter	src/robin_hood.h	/^    Iter(NodePtr valPtr,$/;"	f	class:robin_hood::detail::Table::Iter	access:public	signature:(NodePtr valPtr,uint8_t const * infoPtr,fast_forward_tag ROBIN_HOOD_UNUSED (tag))
+robin_hood::detail::Table::Iter::NodePtr	src/robin_hood.h	/^    using NodePtr = typename std::conditional_t<IsConst, Node const*, Node*>;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,Node const *,Node * >	access:private
+robin_hood::detail::Table::Iter::difference_type	src/robin_hood.h	/^    using difference_type = std::ptrdiff_t;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::ptrdiff_t	access:public
+robin_hood::detail::Table::Iter::fastForward	src/robin_hood.h	/^    void fastForward() noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:void	access:private	signature:()
+robin_hood::detail::Table::Iter::iterator_category	src/robin_hood.h	/^    using iterator_category = std::forward_iterator_tag;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::forward_iterator_tag	access:public
+robin_hood::detail::Table::Iter::mInfo	src/robin_hood.h	/^    uint8_t const* mInfo{nullptr};$/;"	m	class:robin_hood::detail::Table::Iter	typeref:typename:uint8_t const *	access:private
+robin_hood::detail::Table::Iter::mKeyVals	src/robin_hood.h	/^    NodePtr mKeyVals{nullptr};$/;"	m	class:robin_hood::detail::Table::Iter	typeref:typename:NodePtr	access:private
+robin_hood::detail::Table::Iter::operator !=	src/robin_hood.h	/^    bool operator!=(Iter<O> const& o) const noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:bool	access:public	signature:(Iter<O> const & o) const
+robin_hood::detail::Table::Iter::operator *	src/robin_hood.h	/^    reference operator*() const { return **mKeyVals; }$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:reference	access:public	signature:() const
+robin_hood::detail::Table::Iter::operator ++	src/robin_hood.h	/^    Iter operator++(int) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter	access:public	signature:(int)
+robin_hood::detail::Table::Iter::operator ++	src/robin_hood.h	/^    Iter& operator++() noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter &	access:public	signature:()
+robin_hood::detail::Table::Iter::operator ->	src/robin_hood.h	/^    pointer operator->() const { return &**mKeyVals; }$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:pointer	access:public	signature:() const
+robin_hood::detail::Table::Iter::operator =	src/robin_hood.h	/^    Iter& operator=(Iter<OtherIsConst> const& other) noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:Iter &	access:public	signature:(Iter<OtherIsConst> const & other)
+robin_hood::detail::Table::Iter::operator ==	src/robin_hood.h	/^    bool operator==(Iter<O> const& o) const noexcept$/;"	f	class:robin_hood::detail::Table::Iter	typeref:typename:bool	access:public	signature:(Iter<O> const & o) const
+robin_hood::detail::Table::Iter::pointer	src/robin_hood.h	/^    using pointer =$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,value_type const *,value_type * >	access:public
+robin_hood::detail::Table::Iter::reference	src/robin_hood.h	/^    using reference =$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:std::conditional_t<IsConst,value_type const &,value_type &>	access:public
+robin_hood::detail::Table::Iter::value_type	src/robin_hood.h	/^    using value_type = typename Self::value_type;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:Self::value_type	access:public
+robin_hood::detail::Table::Node	src/robin_hood.h	/^  using Node = DataNode<Self, IsFlat>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:DataNode<Self,IsFlat>	access:private
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) bool empty() const noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t calcNumBytesTotal(size_t numElements) const$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD) size_t mask() const noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table	access:private	signature:(NODISCARD)
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NODISCARD)$/;"	f	class:robin_hood::detail::Table	access:public	signature:(NODISCARD)
+robin_hood::detail::Table::ROBIN_HOOD	src/robin_hood.h	/^  ROBIN_HOOD(NOINLINE) void throwOverflowError() const$/;"	f	class:robin_hood::detail::Table	access:private	signature:(NOINLINE)
+robin_hood::detail::Table::Self	src/robin_hood.h	/^  using Self = Table<IsFlat,$/;"	t	class:robin_hood::detail::Table	typeref:typename:Table<IsFlat,MaxLoadFactor100,key_type,mapped_type,hasher,key_equal>	access:public
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  Table() noexcept(noexcept(Hash()) && noexcept(KeyEqual()))$/;"	f	class:robin_hood::detail::Table	access:public	signature:()
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  Table(Iter first,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(Iter first,Iter last,size_t ROBIN_HOOD_UNUSED (bucket_count)=0,const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  Table(Table&& o) noexcept$/;"	f	class:robin_hood::detail::Table	access:public	signature:(Table && o)
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  Table(const Table& o)$/;"	f	class:robin_hood::detail::Table	access:public	signature:(const Table & o)
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  Table(std::initializer_list<value_type> initlist,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(std::initializer_list<value_type> initlist,size_t ROBIN_HOOD_UNUSED (bucket_count)=0,const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+robin_hood::detail::Table::Table	src/robin_hood.h	/^  explicit Table(size_t ROBIN_HOOD_UNUSED(bucket_count) \/*unused*\/,$/;"	f	class:robin_hood::detail::Table	access:public	signature:(size_t ROBIN_HOOD_UNUSED (bucket_count),const Hash & h=Hash{},const KeyEqual & equal=KeyEqual{})
+robin_hood::detail::Table::WHash	src/robin_hood.h	/^  using WHash = WrapHash<Hash>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:WrapHash<Hash>	access:private
+robin_hood::detail::Table::WKeyEqual	src/robin_hood.h	/^  using WKeyEqual = WrapKeyEqual<KeyEqual>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:WrapKeyEqual<KeyEqual>	access:private
+robin_hood::detail::Table::at	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q const&> at($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q const &>	access:public	signature:(key_type const & key) const
+robin_hood::detail::Table::at	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> at(key_type const& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(key_type const & key)
+robin_hood::detail::Table::begin	src/robin_hood.h	/^  const_iterator begin() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+robin_hood::detail::Table::begin	src/robin_hood.h	/^  iterator begin()$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:()
+robin_hood::detail::Table::cbegin	src/robin_hood.h	/^  const_iterator cbegin() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+robin_hood::detail::Table::cend	src/robin_hood.h	/^  const_iterator cend() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+robin_hood::detail::Table::clear	src/robin_hood.h	/^  void clear()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:()
+robin_hood::detail::Table::cloneData	src/robin_hood.h	/^  void cloneData(const Table& o)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(const Table & o)
+robin_hood::detail::Table::compact	src/robin_hood.h	/^  void compact()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:()
+robin_hood::detail::Table::const_iterator	src/robin_hood.h	/^  using const_iterator = Iter<true>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Iter<true>	access:public
+robin_hood::detail::Table::contains	src/robin_hood.h	/^  bool contains(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const key_type & key) const
+robin_hood::detail::Table::contains	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, bool> contains($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,bool>	access:public	signature:(const OtherKey & key) const
+robin_hood::detail::Table::count	src/robin_hood.h	/^  size_t count(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_t	access:public	signature:(const key_type & key) const
+robin_hood::detail::Table::count	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, size_t> count($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,size_t>	access:public	signature:(const OtherKey & key) const
+robin_hood::detail::Table::destroy	src/robin_hood.h	/^  void destroy()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+robin_hood::detail::Table::emplace	src/robin_hood.h	/^  std::pair<iterator, bool> emplace(Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(Args &&...args)
+robin_hood::detail::Table::end	src/robin_hood.h	/^  const_iterator end() const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:() const
+robin_hood::detail::Table::end	src/robin_hood.h	/^  iterator end()$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:()
+robin_hood::detail::Table::erase	src/robin_hood.h	/^  iterator erase(const_iterator pos)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const_iterator pos)
+robin_hood::detail::Table::erase	src/robin_hood.h	/^  iterator erase(iterator pos)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(iterator pos)
+robin_hood::detail::Table::erase	src/robin_hood.h	/^  size_t erase(const key_type& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_t	access:public	signature:(const key_type & key)
+robin_hood::detail::Table::fast_forward_tag	src/robin_hood.h	/^  struct fast_forward_tag$/;"	s	class:robin_hood::detail::Table	access:private
+robin_hood::detail::Table::find	src/robin_hood.h	/^  const_iterator find(const OtherKey& key, is_transparent_tag \/*unused*\/) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:(const OtherKey & key,is_transparent_tag) const
+robin_hood::detail::Table::find	src/robin_hood.h	/^  const_iterator find(const key_type& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:const_iterator	access:public	signature:(const key_type & key) const
+robin_hood::detail::Table::find	src/robin_hood.h	/^  find(const OtherKey& key) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,const_iterator>	access:public	signature:(const OtherKey & key) const
+robin_hood::detail::Table::find	src/robin_hood.h	/^  iterator find(const OtherKey& key, is_transparent_tag \/*unused*\/)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const OtherKey & key,is_transparent_tag)
+robin_hood::detail::Table::find	src/robin_hood.h	/^  iterator find(const key_type& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:iterator	access:public	signature:(const key_type & key)
+robin_hood::detail::Table::find	src/robin_hood.h	/^  typename std::enable_if_t<Self_::is_transparent, iterator> find($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<Self_::is_transparent,iterator>	access:public	signature:(const OtherKey & key)
+robin_hood::detail::Table::getFirstConst	src/robin_hood.h	/^  key_type&& getFirstConst(key_type&& k) const noexcept { return std::move(k); }$/;"	f	class:robin_hood::detail::Table	typeref:typename:key_type &&	access:private	signature:(key_type && k) const
+robin_hood::detail::Table::hasher	src/robin_hood.h	/^  using hasher = Hash;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Hash	access:public
+robin_hood::detail::Table::increase_size	src/robin_hood.h	/^  bool increase_size()$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:private	signature:()
+robin_hood::detail::Table::init	src/robin_hood.h	/^  void init() noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+robin_hood::detail::Table::initData	src/robin_hood.h	/^  void initData(size_t max_elements)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t max_elements)
+robin_hood::detail::Table::insert	src/robin_hood.h	/^  std::pair<iterator, bool> insert(const value_type& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const value_type & keyval)
+robin_hood::detail::Table::insert	src/robin_hood.h	/^  std::pair<iterator, bool> insert(value_type&& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(value_type && keyval)
+robin_hood::detail::Table::insert	src/robin_hood.h	/^  void insert(Iter first, Iter last)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(Iter first,Iter last)
+robin_hood::detail::Table::insert	src/robin_hood.h	/^  void insert(std::initializer_list<value_type> ilist)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(std::initializer_list<value_type> ilist)
+robin_hood::detail::Table::insertKeyPrepareEmptySpot	src/robin_hood.h	/^  std::pair<size_t, InsertionState> insertKeyPrepareEmptySpot(OtherKey&& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<size_t,InsertionState>	access:private	signature:(OtherKey && key)
+robin_hood::detail::Table::insertOrAssignImpl	src/robin_hood.h	/^  std::pair<iterator, bool> insertOrAssignImpl(OtherKey&& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:private	signature:(OtherKey && key,Mapped && obj)
+robin_hood::detail::Table::insert_move	src/robin_hood.h	/^  void insert_move(Node&& keyval)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(Node && keyval)
+robin_hood::detail::Table::insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const key_type& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const key_type & key,Mapped && obj)
+robin_hood::detail::Table::insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,const key_type & key,Mapped && obj)
+robin_hood::detail::Table::insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,key_type && key,Mapped && obj)
+robin_hood::detail::Table::insert_or_assign	src/robin_hood.h	/^  std::pair<iterator, bool> insert_or_assign(key_type&& key, Mapped&& obj)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(key_type && key,Mapped && obj)
+robin_hood::detail::Table::is_flat	src/robin_hood.h	/^  static constexpr bool is_flat = IsFlat;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+robin_hood::detail::Table::is_map	src/robin_hood.h	/^  static constexpr bool is_map = !std::is_void_v<T>;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+robin_hood::detail::Table::is_set	src/robin_hood.h	/^  static constexpr bool is_set = !is_map;$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+robin_hood::detail::Table::is_transparent	src/robin_hood.h	/^  static constexpr bool is_transparent$/;"	m	class:robin_hood::detail::Table	typeref:typename:bool	access:public
+robin_hood::detail::Table::iterator	src/robin_hood.h	/^  using iterator = Iter<false>;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Iter<false>	access:public
+robin_hood::detail::Table::keyToIdx	src/robin_hood.h	/^  void keyToIdx(HashKey&& key, size_t* idx, InfoType* info) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(HashKey && key,size_t * idx,InfoType * info) const
+robin_hood::detail::Table::key_equal	src/robin_hood.h	/^  using key_equal = KeyEqual;$/;"	t	class:robin_hood::detail::Table	typeref:typename:KeyEqual	access:public
+robin_hood::detail::Table::key_found	src/robin_hood.h	/^    key_found,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+robin_hood::detail::Table::key_type	src/robin_hood.h	/^  using key_type = Key;$/;"	t	class:robin_hood::detail::Table	typeref:typename:Key	access:public
+robin_hood::detail::Table::load_factor	src/robin_hood.h	/^  float load_factor() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:float	access:public	signature:() const
+robin_hood::detail::Table::mHashMultiplier	src/robin_hood.h	/^  uint64_t mHashMultiplier = UINT64_C(0xc4ceb9fe1a85ec53);  \/\/ 8 byte  8$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint64_t	access:private
+robin_hood::detail::Table::mInfo	src/robin_hood.h	/^  uint8_t* mInfo = reinterpret_cast<uint8_t*>(&mMask);          \/\/ 8 byte 24$/;"	m	class:robin_hood::detail::Table	typeref:typename:uint8_t *	access:private
+robin_hood::detail::Table::mInfoHashShift	src/robin_hood.h	/^  InfoType mInfoHashShift$/;"	m	class:robin_hood::detail::Table	typeref:typename:InfoType	access:private
+robin_hood::detail::Table::mInfoInc	src/robin_hood.h	/^  InfoType mInfoInc = InitialInfoInc;                           \/\/ 4 byte 52$/;"	m	class:robin_hood::detail::Table	typeref:typename:InfoType	access:private
+robin_hood::detail::Table::mKeyVals	src/robin_hood.h	/^  Node* mKeyVals$/;"	m	class:robin_hood::detail::Table	typeref:typename:Node *	access:private
+robin_hood::detail::Table::mMask	src/robin_hood.h	/^  size_t mMask = 0;                                             \/\/ 8 byte 40$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+robin_hood::detail::Table::mMaxNumElementsAllowed	src/robin_hood.h	/^  size_t mMaxNumElementsAllowed = 0;                            \/\/ 8 byte 48$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+robin_hood::detail::Table::mNumElements	src/robin_hood.h	/^  size_t mNumElements = 0;                                      \/\/ 8 byte 32$/;"	m	class:robin_hood::detail::Table	typeref:typename:size_t	access:private
+robin_hood::detail::Table::mapped_type	src/robin_hood.h	/^  using mapped_type = T;$/;"	t	class:robin_hood::detail::Table	typeref:typename:T	access:public
+robin_hood::detail::Table::max_load_factor	src/robin_hood.h	/^  float max_load_factor() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:float	access:public	signature:() const
+robin_hood::detail::Table::max_size	src/robin_hood.h	/^  size_type max_size() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_type	access:public	signature:() const
+robin_hood::detail::Table::new_node	src/robin_hood.h	/^    new_node,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+robin_hood::detail::Table::next	src/robin_hood.h	/^  void next(InfoType* info, size_t* idx) const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(InfoType * info,size_t * idx) const
+robin_hood::detail::Table::nextHashMultiplier	src/robin_hood.h	/^  void nextHashMultiplier()$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:()
+robin_hood::detail::Table::nextWhileLess	src/robin_hood.h	/^  void nextWhileLess(InfoType* info, size_t* idx) const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(InfoType * info,size_t * idx) const
+robin_hood::detail::Table::operator !=	src/robin_hood.h	/^  bool operator!=(const Table& other) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const Table & other) const
+robin_hood::detail::Table::operator =	src/robin_hood.h	/^  Table& operator=(Table const& o)$/;"	f	class:robin_hood::detail::Table	typeref:typename:Table &	access:public	signature:(Table const & o)
+robin_hood::detail::Table::operator =	src/robin_hood.h	/^  Table& operator=(Table&& o) noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:Table &	access:public	signature:(Table && o)
+robin_hood::detail::Table::operator ==	src/robin_hood.h	/^  bool operator==(const Table& other) const$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:public	signature:(const Table & other) const
+robin_hood::detail::Table::operator []	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> operator[]($/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(const key_type & key)
+robin_hood::detail::Table::operator []	src/robin_hood.h	/^  typename std::enable_if_t<!std::is_void_v<Q>, Q&> operator[](key_type&& key)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::enable_if_t<!std::is_void_v<Q>,Q &>	access:public	signature:(key_type && key)
+robin_hood::detail::Table::overflow_error	src/robin_hood.h	/^    overflow_error,$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+robin_hood::detail::Table::overwrite_node	src/robin_hood.h	/^    overwrite_node$/;"	e	enum:robin_hood::detail::Table::InsertionState	access:public
+robin_hood::detail::Table::rehash	src/robin_hood.h	/^  void rehash(size_t c)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(size_t c)
+robin_hood::detail::Table::rehashPowerOfTwo	src/robin_hood.h	/^  void rehashPowerOfTwo(size_t numBuckets, bool forceFree)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t numBuckets,bool forceFree)
+robin_hood::detail::Table::reserve	src/robin_hood.h	/^  void reserve(size_t c)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(size_t c)
+robin_hood::detail::Table::reserve	src/robin_hood.h	/^  void reserve(size_t c, bool forceRehash)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t c,bool forceRehash)
+robin_hood::detail::Table::shiftDown	src/robin_hood.h	/^  void shiftDown(size_t idx) noexcept(std::is_nothrow_move_assignable_v<Node>)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t idx)
+robin_hood::detail::Table::shiftUp	src/robin_hood.h	/^  void shiftUp(size_t startIdx, size_t const insertion_idx) noexcept($/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t startIdx,size_t const insertion_idx)
+robin_hood::detail::Table::size	src/robin_hood.h	/^  size_type size() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_type	access:public	signature:() const
+robin_hood::detail::Table::size_type	src/robin_hood.h	/^  using size_type = size_t;$/;"	t	class:robin_hood::detail::Table	typeref:typename:size_t	access:public
+robin_hood::detail::Table::swap	src/robin_hood.h	/^  void swap(Table& o) noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(Table & o)
+robin_hood::detail::Table::try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const key_type& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const key_type & key,Args &&...args)
+robin_hood::detail::Table::try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,const key_type & key,Args &&...args)
+robin_hood::detail::Table::try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,key_type && key,Args &&...args)
+robin_hood::detail::Table::try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(key_type&& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(key_type && key,Args &&...args)
+robin_hood::detail::Table::try_emplace_impl	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace_impl(OtherKey&& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:private	signature:(OtherKey && key,Args &&...args)
+robin_hood::detail::Table::try_increase_info	src/robin_hood.h	/^  bool try_increase_info()$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:private	signature:()
+robin_hood::detail::Table::value_type	src/robin_hood.h	/^  using value_type = typename std::conditional_t<$/;"	t	class:robin_hood::detail::Table	typeref:typename:std::conditional_t<is_set,Key,robin_hood::pair<typename std::conditional_t<is_flat,Key,Key const>,T>>	access:public
+robin_hood::detail::Table::~Table	src/robin_hood.h	/^  ~Table()$/;"	f	class:robin_hood::detail::Table	access:public	signature:()
+robin_hood::detail::WrapHash	src/robin_hood.h	/^struct WrapHash : public T$/;"	s	namespace:robin_hood::detail	inherits:T
+robin_hood::detail::WrapHash::WrapHash	src/robin_hood.h	/^  WrapHash() = default;$/;"	p	struct:robin_hood::detail::WrapHash	access:public	signature:()
+robin_hood::detail::WrapHash::WrapHash	src/robin_hood.h	/^  explicit WrapHash(T const& o) noexcept(noexcept(T(std::declval<T const&>())))$/;"	f	struct:robin_hood::detail::WrapHash	access:public	signature:(T const & o)
+robin_hood::detail::WrapKeyEqual	src/robin_hood.h	/^struct WrapKeyEqual : public T$/;"	s	namespace:robin_hood::detail	inherits:T
+robin_hood::detail::WrapKeyEqual::WrapKeyEqual	src/robin_hood.h	/^  WrapKeyEqual() = default;$/;"	p	struct:robin_hood::detail::WrapKeyEqual	access:public	signature:()
+robin_hood::detail::WrapKeyEqual::WrapKeyEqual	src/robin_hood.h	/^  explicit WrapKeyEqual(T const& o) noexcept($/;"	f	struct:robin_hood::detail::WrapKeyEqual	access:public	signature:(T const & o)
+robin_hood::detail::has_is_transparent	src/robin_hood.h	/^struct has_is_transparent : public std::false_type$/;"	s	namespace:robin_hood::detail	inherits:std::false_type
+robin_hood::detail::has_is_transparent	src/robin_hood.h	/^struct has_is_transparent<T,$/;"	s	namespace:robin_hood::detail	inherits:std::true_type
+robin_hood::detail::reinterpret_cast_no_cast_align_warning	src/robin_hood.h	/^inline T reinterpret_cast_no_cast_align_warning(void const* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void const * ptr)
+robin_hood::detail::reinterpret_cast_no_cast_align_warning	src/robin_hood.h	/^inline T reinterpret_cast_no_cast_align_warning(void* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void * ptr)
+robin_hood::detail::rotr	src/robin_hood.h	/^T rotr(T x, unsigned k)$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(T x,unsigned k)
+robin_hood::detail::swappable	src/robin_hood.h	/^namespace swappable {$/;"	n	namespace:robin_hood::detail
+robin_hood::detail::swappable::nothrow	src/robin_hood.h	/^struct nothrow$/;"	s	namespace:robin_hood::detail::swappable
+robin_hood::detail::swappable::nothrow::value	src/robin_hood.h	/^  static const bool value$/;"	m	struct:robin_hood::detail::swappable::nothrow	typeref:typename:const bool	access:public
+robin_hood::detail::unaligned_load	src/robin_hood.h	/^inline T unaligned_load(void const* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void const * ptr)
+robin_hood::detail::void_type	src/robin_hood.h	/^struct void_type$/;"	s	namespace:robin_hood::detail
+robin_hood::detail::void_type::type	src/robin_hood.h	/^  using type = void;$/;"	t	struct:robin_hood::detail::void_type	typeref:typename:void	access:public
+robin_hood::hash	src/robin_hood.h	/^struct hash : public std::hash<T>$/;"	s	namespace:robin_hood	inherits:std::hash<T>
+robin_hood::hash	src/robin_hood.h	/^struct hash<Enum, typename std::enable_if_t<std::is_enum_v<Enum>>>$/;"	s	namespace:robin_hood
+robin_hood::hash	src/robin_hood.h	/^struct hash<T*>$/;"	s	namespace:robin_hood
+robin_hood::hash	src/robin_hood.h	/^struct hash<std::basic_string<CharT>>$/;"	s	namespace:robin_hood
+robin_hood::hash	src/robin_hood.h	/^struct hash<std::basic_string_view<CharT>>$/;"	s	namespace:robin_hood
+robin_hood::hash	src/robin_hood.h	/^struct hash<std::shared_ptr<T>>$/;"	s	namespace:robin_hood
+robin_hood::hash	src/robin_hood.h	/^struct hash<std::unique_ptr<T>>$/;"	s	namespace:robin_hood
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(Enum e) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(Enum e) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(T const& obj) const noexcept(noexcept($/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(T const & obj) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(T* ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(T * ptr) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(std::basic_string<CharT> const& str) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::basic_string<CharT> const & str) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(std::basic_string_view<CharT> const& sv) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::basic_string_view<CharT> const & sv) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(std::shared_ptr<T> const& ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::shared_ptr<T> const & ptr) const
+robin_hood::hash::operator ()	src/robin_hood.h	/^  size_t operator()(std::unique_ptr<T> const& ptr) const noexcept$/;"	f	struct:robin_hood::hash	typeref:typename:size_t	access:public	signature:(std::unique_ptr<T> const & ptr) const
+robin_hood::hash_bytes	src/robin_hood.h	/^inline size_t hash_bytes(void const* ptr, size_t len) noexcept$/;"	f	namespace:robin_hood	typeref:typename:size_t	signature:(void const * ptr,size_t len)
+robin_hood::hash_int	src/robin_hood.h	/^inline size_t hash_int(uint64_t x) noexcept$/;"	f	namespace:robin_hood	typeref:typename:size_t	signature:(uint64_t x)
+robin_hood::is_transparent_tag	src/robin_hood.h	/^struct is_transparent_tag$/;"	s	namespace:robin_hood
+robin_hood::operator !=	src/robin_hood.h	/^constexpr bool operator!=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::operator <	src/robin_hood.h	/^constexpr bool operator<(pair<A, B> const& x, pair<A, B> const& y) noexcept($/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::operator <<	src/robin_hood.h	/^inline std::ostream& operator<<(std::ostream& os, Counts const& c)$/;"	f	namespace:robin_hood	typeref:typename:std::ostream &	signature:(std::ostream & os,Counts const & c)
+robin_hood::operator <=	src/robin_hood.h	/^constexpr bool operator<=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::operator ==	src/robin_hood.h	/^constexpr bool operator==(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::operator >	src/robin_hood.h	/^constexpr bool operator>(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::operator >=	src/robin_hood.h	/^constexpr bool operator>=(pair<A, B> const& x, pair<A, B> const& y)$/;"	f	namespace:robin_hood	typeref:typename:bool	signature:(pair<A,B> const & x,pair<A,B> const & y)
+robin_hood::pair	src/robin_hood.h	/^struct pair$/;"	s	namespace:robin_hood
+robin_hood::pair::first	src/robin_hood.h	/^  T1 first;   \/\/ NOLINT(misc-non-private-member-variables-in-classes)$/;"	m	struct:robin_hood::pair	typeref:typename:T1	access:public
+robin_hood::pair::first_type	src/robin_hood.h	/^  using first_type = T1;$/;"	t	struct:robin_hood::pair	typeref:typename:T1	access:public
+robin_hood::pair::pair	src/robin_hood.h	/^      pair(std::piecewise_construct_t \/*unused*\/,$/;"	f	struct:robin_hood::pair	access:public	signature:(std::piecewise_construct_t,std::tuple<U1...> a,std::tuple<U2...> b)
+robin_hood::pair::pair	src/robin_hood.h	/^  constexpr pair() noexcept(noexcept(U1()) && noexcept(U2()))$/;"	f	struct:robin_hood::pair	access:public	signature:()
+robin_hood::pair::pair	src/robin_hood.h	/^  constexpr pair(T1&& a, T2&& b) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(T1 && a,T2 && b)
+robin_hood::pair::pair	src/robin_hood.h	/^  constexpr pair(U1&& a, U2&& b) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(U1 && a,U2 && b)
+robin_hood::pair::pair	src/robin_hood.h	/^  explicit constexpr pair(std::pair<T1, T2> const& o) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(std::pair<T1,T2> const & o)
+robin_hood::pair::pair	src/robin_hood.h	/^  explicit constexpr pair(std::pair<T1, T2>&& o) noexcept($/;"	f	struct:robin_hood::pair	access:public	signature:(std::pair<T1,T2> && o)
+robin_hood::pair::pair	src/robin_hood.h	/^  pair($/;"	f	struct:robin_hood::pair	access:public	signature:(std::tuple<U1...> & a,std::tuple<U2...> & b,ROBIN_HOOD_STD::index_sequence<I1...>,ROBIN_HOOD_STD::index_sequence<I2...>)
+robin_hood::pair::second	src/robin_hood.h	/^  T2 second;  \/\/ NOLINT(misc-non-private-member-variables-in-classes)$/;"	m	struct:robin_hood::pair	typeref:typename:T2	access:public
+robin_hood::pair::second_type	src/robin_hood.h	/^  using second_type = T2;$/;"	t	struct:robin_hood::pair	typeref:typename:T2	access:public
+robin_hood::pair::swap	src/robin_hood.h	/^  void swap(pair<T1, T2>& o) noexcept($/;"	f	struct:robin_hood::pair	typeref:typename:void	access:public	signature:(pair<T1,T2> & o)
+robin_hood::swap	src/robin_hood.h	/^inline void swap(pair<A, B>& a, pair<A, B>& b) noexcept($/;"	f	namespace:robin_hood	typeref:typename:void	signature:(pair<A,B> & a,pair<A,B> & b)
+robin_hood::unordered_flat_map	src/robin_hood.h	/^using unordered_flat_map$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<true,MaxLoadFactor100,Key,T,Hash,KeyEqual>
+robin_hood::unordered_flat_set	src/robin_hood.h	/^using unordered_flat_set$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<true,MaxLoadFactor100,Key,void,Hash,KeyEqual>
+robin_hood::unordered_map	src/robin_hood.h	/^using unordered_map = detail::Table<$/;"	t	namespace:robin_hood
+robin_hood::unordered_node_map	src/robin_hood.h	/^using unordered_node_map$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<false,MaxLoadFactor100,Key,T,Hash,KeyEqual>
+robin_hood::unordered_node_set	src/robin_hood.h	/^using unordered_node_set$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<false,MaxLoadFactor100,Key,void,Hash,KeyEqual>
+robin_hood::unordered_set	src/robin_hood.h	/^using unordered_set$/;"	t	namespace:robin_hood
+rotr	src/robin_hood.h	/^T rotr(T x, unsigned k)$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(T x,unsigned k)
+route	include/CUGR.h	/^  void route();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+route	src/CUGR.cpp	/^void CUGR::route()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+routeIncremental	include/CUGR.h	/^  void routeIncremental();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+routeIncremental	src/CUGR.cpp	/^void CUGR::routeIncremental()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+routes_	include/CUGR.h	/^  NetRouteMap routes_;$/;"	m	class:grt::CUGR	typeref:typename:NetRouteMap	access:private
+routing_dag_	src/PatternRoute.h	/^  std::shared_ptr<PatternRoutingNode> routing_dag_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::shared_ptr<PatternRoutingNode>	access:private
+routing_tree_	src/GRNet.h	/^  std::shared_ptr<GRTreeNode> routing_tree_;$/;"	m	class:grt::GRNet	typeref:typename:std::shared_ptr<GRTreeNode>	access:private
+run	src/MazeRoute.cpp	/^void MazeRoute::run()$/;"	f	class:grt::MazeRoute	typeref:typename:void	signature:()
+run	src/MazeRoute.h	/^  void run();$/;"	p	class:grt::MazeRoute	typeref:typename:void	access:public	signature:()
+run	src/PatternRoute.cpp	/^void PatternRoute::run()$/;"	f	class:grt::PatternRoute	typeref:typename:void	signature:()
+run	src/PatternRoute.h	/^  void run();$/;"	p	class:grt::PatternRoute	typeref:typename:void	access:public	signature:()
+second	src/robin_hood.h	/^  T2 second;  \/\/ NOLINT(misc-non-private-member-variables-in-classes)$/;"	m	struct:robin_hood::pair	typeref:typename:T2	access:public
+second_type	src/robin_hood.h	/^  using second_type = T2;$/;"	t	struct:robin_hood::pair	typeref:typename:T2	access:public
+selectAccessPoint	src/GridGraph.cpp	/^AccessPoint GridGraph::selectAccessPoint($/;"	f	class:grt::GridGraph	typeref:typename:AccessPoint	signature:(const std::vector<AccessPoint> & access_points) const
+selectAccessPoint	src/GridGraph.h	/^  AccessPoint selectAccessPoint($/;"	p	class:grt::GridGraph	typeref:typename:AccessPoint	access:private	signature:(const std::vector<AccessPoint> & access_points) const
+selectAccessPoints	src/GridGraph.cpp	/^AccessPointSet GridGraph::selectAccessPoints(GRNet* net) const$/;"	f	class:grt::GridGraph	typeref:typename:AccessPointSet	signature:(GRNet * net) const
+selectAccessPoints	src/GridGraph.h	/^  AccessPointSet selectAccessPoints(GRNet* net) const;$/;"	p	class:grt::GridGraph	typeref:typename:AccessPointSet	access:public	signature:(GRNet * net) const
+set	src/GeoTypes.h	/^  void set(int layer_index = -1, Args... params)$/;"	f	class:grt::BoxOnLayer	typeref:typename:void	access:public	signature:(int layer_index=-1,Args...params)
+set	src/geo.h	/^  void set()$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:()
+set	src/geo.h	/^  void set()$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:()
+set	src/geo.h	/^  void set(const BoxT& box) { set(box.x(), box.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const BoxT & box)
+set	src/geo.h	/^  void set(const IntervalT& x_range, const IntervalT& y_range)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const IntervalT & x_range,const IntervalT & y_range)
+set	src/geo.h	/^  void set(const PointT& low, const PointT& high)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & low,const PointT & high)
+set	src/geo.h	/^  void set(const PointT& pt) { set(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+set	src/geo.h	/^  void set(int lo, int hi)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int lo,int hi)
+set	src/geo.h	/^  void set(int lx, int ly, int hx, int hy)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int lx,int ly,int hx,int hy)
+set	src/geo.h	/^  void set(int val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+set	src/geo.h	/^  void set(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+setAdjustment	src/Layers.h	/^  void setAdjustment(float adjustment) { adjustment_ = adjustment; }$/;"	f	class:grt::MetalLayer	typeref:typename:void	access:public	signature:(float adjustment)
+setCritical	src/GRNet.h	/^  void setCritical(bool is_critical) { is_critical_ = is_critical; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(bool is_critical)
+setCriticalNetsPercentage	include/CUGR.h	/^  void setCriticalNetsPercentage(float percentage)$/;"	f	class:grt::CUGR	typeref:typename:void	access:public	signature:(float percentage)
+setDebugNet	include/CUGR.h	/^  void setDebugNet(const odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const odb::dbNet * net)
+setDebugNet	src/CUGR.cpp	/^void CUGR::setDebugNet(const odb::dbNet* net) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const odb::dbNet * net)
+setDebugOn	include/CUGR.h	/^  void setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(std::unique_ptr<AbstractFastRouteRenderer> renderer)
+setDebugOn	src/CUGR.cpp	/^void CUGR::setDebugOn(std::unique_ptr<AbstractFastRouteRenderer> renderer) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::unique_ptr<AbstractFastRouteRenderer> renderer)
+setDebugRectilinearSTree	include/CUGR.h	/^  void setDebugRectilinearSTree(bool rectilinearSTree); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool rectilinearSTree)
+setDebugRectilinearSTree	src/CUGR.cpp	/^void CUGR::setDebugRectilinearSTree(bool rectilinearSTree)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool rectilinearSTree)
+setDebugSteinerTree	include/CUGR.h	/^  void setDebugSteinerTree(bool steinerTree);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool steinerTree)
+setDebugSteinerTree	src/CUGR.cpp	/^void CUGR::setDebugSteinerTree(bool steinerTree) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool steinerTree)
+setDebugTree2D	include/CUGR.h	/^  void setDebugTree2D(bool tree2D); $/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool tree2D)
+setDebugTree2D	src/CUGR.cpp	/^void CUGR::setDebugTree2D(bool tree2D)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool tree2D)
+setDebugTree3D	include/CUGR.h	/^  void setDebugTree3D(bool tree3D);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(bool tree3D)
+setDebugTree3D	src/CUGR.cpp	/^void CUGR::setDebugTree3D(bool tree3D)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(bool tree3D)
+setFixedLayers	src/PatternRoute.h	/^  void setFixedLayers(const IntervalT& fixed_layers)$/;"	f	class:grt::SteinerTreeNode	typeref:typename:void	access:public	signature:(const IntervalT & fixed_layers)
+setHigh	src/geo.h	/^  void setHigh(int val) { high_ = val; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+setInitialNetSlacks	include/CUGR.h	/^  void setInitialNetSlacks();$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:()
+setInitialNetSlacks	src/CUGR.cpp	/^void CUGR::setInitialNetSlacks()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+setLayerRange	src/Netlist.h	/^  void setLayerRange(LayerRange layer_range) { layer_range_ = layer_range; }$/;"	f	class:grt::CUGRNet	typeref:typename:void	access:public	signature:(LayerRange layer_range)
+setLow	src/geo.h	/^  void setLow(int val) { low_ = val; }$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int val)
+setPins	src/Netlist.h	/^  void setPins(std::vector<CUGRPin> pins) { pins_ = std::move(pins); }$/;"	f	class:grt::CUGRNet	typeref:typename:void	access:public	signature:(std::vector<CUGRPin> pins)
+setRoutingTree	src/GRNet.h	/^  void setRoutingTree(std::shared_ptr<GRTreeNode> tree)$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(std::shared_ptr<GRTreeNode> tree)
+setSlack	src/GRNet.h	/^  void setSlack(float slack) { slack_ = slack; }$/;"	f	class:grt::GRNet	typeref:typename:void	access:public	signature:(float slack)
+setSteinerTree	src/PatternRoute.h	/^  void setSteinerTree(const std::shared_ptr<SteinerTreeNode>& tree)$/;"	f	class:grt::PatternRoute	typeref:typename:void	access:public	signature:(const std::shared_ptr<SteinerTreeNode> & tree)
+setSttInputFilename	include/CUGR.h	/^  void setSttInputFilename(const char* file_name);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const char * file_name)
+setSttInputFilename	src/CUGR.cpp	/^void CUGR::setSttInputFilename(const char* file_name) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const char * file_name)
+setUnitCosts	src/Design.cpp	/^void Design::setUnitCosts()$/;"	f	class:grt::Design	typeref:typename:void	signature:()
+setUnitCosts	src/Design.h	/^  void setUnitCosts();$/;"	p	class:grt::Design	typeref:typename:void	access:private	signature:()
+shiftBy	src/geo.h	/^  void shiftBy(const PointT& rhs)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & rhs)
+shiftBy	src/geo.h	/^  void shiftBy(const int& rhs)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(const int & rhs)
+shiftDown	src/robin_hood.h	/^  uint64_t shiftDown{};$/;"	m	struct:robin_hood::Counts	typeref:typename:uint64_t	access:public
+shiftDown	src/robin_hood.h	/^  void shiftDown(size_t idx) noexcept(std::is_nothrow_move_assignable_v<Node>)$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t idx)
+shiftUp	src/robin_hood.h	/^  uint64_t shiftUp{};$/;"	m	struct:robin_hood::Counts	typeref:typename:uint64_t	access:public
+shiftUp	src/robin_hood.h	/^  void shiftUp(size_t startIdx, size_t const insertion_idx) noexcept($/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:private	signature:(size_t startIdx,size_t const insertion_idx)
+size	src/robin_hood.h	/^  size_type size() const noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:size_type	access:public	signature:() const
+size_type	src/robin_hood.h	/^  using size_type = size_t;$/;"	t	class:robin_hood::detail::Table	typeref:typename:size_t	access:public
+slack_	src/GRNet.h	/^  float slack_;$/;"	m	class:grt::GRNet	typeref:typename:float	access:private
+solutions_	src/MazeRoute.h	/^  std::vector<std::shared_ptr<Solution>> solutions_;$/;"	m	class:grt::MazeRoute	typeref:typename:std::vector<std::shared_ptr<Solution>>	access:private
+sortNetIndices	include/CUGR.h	/^  void sortNetIndices(std::vector<int>& net_indices) const;$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices) const
+sortNetIndices	src/CUGR.cpp	/^void CUGR::sortNetIndices(std::vector<int>& net_indices) const$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices) const
+sta	include/CUGR.h	/^namespace sta {$/;"	n
+sta	src/Design.h	/^namespace sta {$/;"	n
+sta_	include/CUGR.h	/^  sta::dbSta* sta_;$/;"	m	class:grt::CUGR	typeref:typename:sta::dbSta *	access:private
+steinerTreeVisualization	include/CUGR.h	/^  void steinerTreeVisualization(const stt::Tree& stree, GRNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(const stt::Tree & stree,GRNet * net)
+steinerTreeVisualization	src/CUGR.cpp	/^void CUGR::steinerTreeVisualization(const stt::Tree& stree, GRNet* net) $/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const stt::Tree & stree,GRNet * net)
+steiner_tree_	src/PatternRoute.h	/^  std::shared_ptr<SteinerTreeNode> steiner_tree_;$/;"	m	class:grt::PatternRoute	typeref:typename:std::shared_ptr<SteinerTreeNode>	access:private
+step	src/MazeRoute.h	/^  void step()$/;"	f	struct:grt::SparseGrid	typeref:typename:void	access:public	signature:()
+strictlyContain	src/geo.h	/^  bool strictlyContain(const PointT& pt) const$/;"	f	class:grt::BoxT	typeref:typename:bool	access:public	signature:(const PointT & pt) const
+strictlyContain	src/geo.h	/^  bool strictlyContain(int val) const { return val > low_ && val < high_; }$/;"	f	class:grt::IntervalT	typeref:typename:bool	access:public	signature:(int val) const
+stt	include/CUGR.h	/^namespace stt {$/;"	n
+stt_builder_	include/CUGR.h	/^  stt::SteinerTreeBuilder* stt_builder_;$/;"	m	class:grt::CUGR	typeref:typename:stt::SteinerTreeBuilder *	access:private
+stt_builder_	src/PatternRoute.h	/^  stt::SteinerTreeBuilder* stt_builder_;$/;"	m	class:grt::PatternRoute	typeref:typename:stt::SteinerTreeBuilder *	access:private
+stt_tree_	src/PatternRoute.h	/^  stt::Tree stt_tree_;$/;"	m	class:grt::PatternRoute	typeref:typename:stt::Tree	access:private
+stt_tree_valid_	src/PatternRoute.h	/^  bool stt_tree_valid_{false};$/;"	m	class:grt::PatternRoute	typeref:typename:bool	access:private
+sum	src/GridGraph.h	/^  Type sum(const PointT& u, const PointT& v) const$/;"	f	class:grt::GridGraphView	typeref:typename:Type	access:public	signature:(const PointT & u,const PointT & v) const
+swap	src/robin_hood.h	/^    void swap(DataNode<M, false>& o) noexcept$/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(DataNode<M,false> & o)
+swap	src/robin_hood.h	/^    void swap(DataNode<M, true>& o) noexcept($/;"	f	class:robin_hood::detail::Table::DataNode	typeref:typename:void	access:public	signature:(DataNode<M,true> & o)
+swap	src/robin_hood.h	/^  void swap(BulkPoolAllocator<T, MinNumAllocs, MaxNumAllocs>& other) noexcept$/;"	f	class:robin_hood::detail::BulkPoolAllocator	typeref:typename:void	access:public	signature:(BulkPoolAllocator<T,MinNumAllocs,MaxNumAllocs> & other)
+swap	src/robin_hood.h	/^  void swap(Table& o) noexcept$/;"	f	class:robin_hood::detail::Table	typeref:typename:void	access:public	signature:(Table & o)
+swap	src/robin_hood.h	/^  void swap(pair<T1, T2>& o) noexcept($/;"	f	struct:robin_hood::pair	typeref:typename:void	access:public	signature:(pair<T1,T2> & o)
+swap	src/robin_hood.h	/^inline void swap(pair<A, B>& a, pair<A, B>& b) noexcept($/;"	f	namespace:robin_hood	typeref:typename:void	signature:(pair<A,B> & a,pair<A,B> & b)
+swappable	src/robin_hood.h	/^namespace swappable {$/;"	n	namespace:robin_hood::detail
+target_detour_count	include/CUGR.h	/^  int target_detour_count = 20;$/;"	m	struct:grt::Constants	typeref:typename:int	access:public
+tech_	src/Design.h	/^  odb::dbTech* tech_;$/;"	m	class:grt::Design	typeref:typename:odb::dbTech *	access:private
+total_length_	src/GridGraph.h	/^  int total_length_ = 0;$/;"	m	class:grt::GridGraph	typeref:typename:int	access:private
+total_num_vias_	src/GridGraph.h	/^  int total_num_vias_ = 0;$/;"	m	class:grt::GridGraph	typeref:typename:int	access:private
+translateAccessPointsToGrid	src/GridGraph.cpp	/^std::vector<AccessPoint> GridGraph::translateAccessPointsToGrid($/;"	f	class:grt::GridGraph	typeref:typename:std::vector<AccessPoint>	signature:(const std::vector<odb::dbAccessPoint * > & aps,const odb::Point & inst_location) const
+translateAccessPointsToGrid	src/GridGraph.h	/^  std::vector<AccessPoint> translateAccessPointsToGrid($/;"	p	class:grt::GridGraph	typeref:typename:std::vector<AccessPoint>	access:private	signature:(const std::vector<odb::dbAccessPoint * > & ap,const odb::Point & inst_location) const
+try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const key_type& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const key_type & key,Args &&...args)
+try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,const key_type & key,Args &&...args)
+try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(const_iterator hint,$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(const_iterator hint,key_type && key,Args &&...args)
+try_emplace	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace(key_type&& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:public	signature:(key_type && key,Args &&...args)
+try_emplace_impl	src/robin_hood.h	/^  std::pair<iterator, bool> try_emplace_impl(OtherKey&& key, Args&&... args)$/;"	f	class:robin_hood::detail::Table	typeref:typename:std::pair<iterator,bool>	access:private	signature:(OtherKey && key,Args &&...args)
+try_increase_info	src/robin_hood.h	/^  bool try_increase_info()$/;"	f	class:robin_hood::detail::Table	typeref:typename:bool	access:private	signature:()
+type	src/robin_hood.h	/^  using type = void;$/;"	t	struct:robin_hood::detail::void_type	typeref:typename:void	access:public
+unaligned_load	src/robin_hood.h	/^inline T unaligned_load(void const* ptr) noexcept$/;"	f	namespace:robin_hood::detail	typeref:typename:T	signature:(void const * ptr)
+unionWith	src/geo.h	/^  BoxT unionWith(const BoxT& rhs) const$/;"	f	class:grt::BoxT	typeref:typename:BoxT	access:public	signature:(const BoxT & rhs) const
+unionWith	src/geo.h	/^  IntervalT unionWith(const IntervalT& rhs) const$/;"	f	class:grt::IntervalT	typeref:typename:IntervalT	access:public	signature:(const IntervalT & rhs) const
+unit_length_short_costs_	src/Design.h	/^  std::vector<CostT> unit_length_short_costs_;$/;"	m	class:grt::Design	typeref:typename:std::vector<CostT>	access:private
+unit_length_short_costs_	src/GridGraph.h	/^  std::vector<CostT> unit_length_short_costs_;$/;"	m	class:grt::GridGraph	typeref:typename:std::vector<CostT>	access:private
+unit_length_wire_cost_	src/Design.h	/^  CostT unit_length_wire_cost_;$/;"	m	class:grt::Design	typeref:typename:CostT	access:private
+unit_length_wire_cost_	src/GridGraph.h	/^  CostT unit_length_wire_cost_;$/;"	m	class:grt::GridGraph	typeref:typename:CostT	access:private
+unit_via_cost_	src/Design.h	/^  CostT unit_via_cost_;$/;"	m	class:grt::Design	typeref:typename:CostT	access:private
+unit_via_cost_	src/GridGraph.h	/^  CostT unit_via_cost_;$/;"	m	class:grt::GridGraph	typeref:typename:CostT	access:private
+unordered_flat_map	src/robin_hood.h	/^using unordered_flat_map$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<true,MaxLoadFactor100,Key,T,Hash,KeyEqual>
+unordered_flat_set	src/robin_hood.h	/^using unordered_flat_set$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<true,MaxLoadFactor100,Key,void,Hash,KeyEqual>
+unordered_map	src/robin_hood.h	/^using unordered_map = detail::Table<$/;"	t	namespace:robin_hood
+unordered_node_map	src/robin_hood.h	/^using unordered_node_map$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<false,MaxLoadFactor100,Key,T,Hash,KeyEqual>
+unordered_node_set	src/robin_hood.h	/^using unordered_node_set$/;"	t	namespace:robin_hood	typeref:typename:detail::Table<false,MaxLoadFactor100,Key,void,Hash,KeyEqual>
+unordered_set	src/robin_hood.h	/^using unordered_set$/;"	t	namespace:robin_hood
+update	src/geo.h	/^  void update(const PointT& pt) { update(pt.x(), pt.y()); }$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(const PointT & pt)
+update	src/geo.h	/^  void update(int new_val)$/;"	f	class:grt::IntervalT	typeref:typename:void	access:public	signature:(int new_val)
+update	src/geo.h	/^  void update(int x_val, int y_val)$/;"	f	class:grt::BoxT	typeref:typename:void	access:public	signature:(int x_val,int y_val)
+updateDbCongestion	include/CUGR.h	/^  void updateDbCongestion();$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:()
+updateDbCongestion	src/CUGR.cpp	/^void CUGR::updateDbCongestion()$/;"	f	class:grt::CUGR	typeref:typename:void	signature:()
+updateNet	include/CUGR.h	/^  void updateNet(odb::dbNet* net);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(odb::dbNet * net)
+updateNet	src/CUGR.cpp	/^void CUGR::updateNet(odb::dbNet* db_net)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(odb::dbNet * db_net)
+updateNet	src/Design.cpp	/^void Design::updateNet(odb::dbNet* db_net)$/;"	f	class:grt::Design	typeref:typename:void	signature:(odb::dbNet * db_net)
+updateNet	src/Design.h	/^  void updateNet(odb::dbNet* db_net);$/;"	p	class:grt::Design	typeref:typename:void	access:public	signature:(odb::dbNet * db_net)
+updateOverflowNets	include/CUGR.h	/^  void updateOverflowNets(std::vector<int>& net_indices);$/;"	p	class:grt::CUGR	typeref:typename:void	access:private	signature:(std::vector<int> & net_indices)
+updateOverflowNets	src/CUGR.cpp	/^void CUGR::updateOverflowNets(std::vector<int>& net_indices)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(std::vector<int> & net_indices)
+updateWireCostView	src/GridGraph.cpp	/^void GridGraph::updateWireCostView($/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(GridGraphView<CostT> & view,const std::shared_ptr<GRTreeNode> & routing_tree) const
+updateWireCostView	src/GridGraph.h	/^  void updateWireCostView($/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(GridGraphView<CostT> & view,const std::shared_ptr<GRTreeNode> & routing_tree) const
+utl	include/CUGR.h	/^namespace utl {$/;"	n
+utl	src/Design.h	/^namespace utl {$/;"	n
+value	src/robin_hood.h	/^  static const bool value$/;"	m	struct:robin_hood::detail::swappable::nothrow	typeref:typename:const bool	access:public
+value_type	src/robin_hood.h	/^    using value_type = typename Self::value_type;$/;"	t	class:robin_hood::detail::Table::Iter	typeref:typename:Self::value_type	access:public
+value_type	src/robin_hood.h	/^  using value_type = typename std::conditional_t<$/;"	t	class:robin_hood::detail::Table	typeref:typename:std::conditional_t<is_set,Key,robin_hood::pair<typename std::conditional_t<is_flat,Key,Key const>,T>>	access:public
+vertex	src/MazeRoute.h	/^  const int vertex;$/;"	m	struct:grt::Solution	typeref:typename:const int	access:public
+vertex_pin_	src/MazeRoute.h	/^  robin_hood::unordered_map<int, int> vertex_pin_;$/;"	m	class:grt::SparseGraph	typeref:typename:robin_hood::unordered_map<int,int>	access:private
+vertices_	src/MazeRoute.h	/^  std::vector<GRPoint> vertices_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<GRPoint>	access:private
+via_multiplier	include/CUGR.h	/^  double via_multiplier = 2.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+void_type	src/robin_hood.h	/^struct void_type$/;"	s	namespace:robin_hood::detail
+weight_short_area	include/CUGR.h	/^  double weight_short_area = 500.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+weight_via_number	include/CUGR.h	/^  double weight_via_number = 4.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+weight_wire_length	include/CUGR.h	/^  double weight_wire_length = 0.5;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+width	src/geo.h	/^  int width() const { return x_.range(); }$/;"	f	class:grt::BoxT	typeref:typename:int	access:public	signature:() const
+width_	src/Layers.h	/^  int width_;$/;"	m	class:grt::MetalLayer	typeref:typename:int	access:private
+wire_patch_inflation_rate	include/CUGR.h	/^  double wire_patch_inflation_rate = 1.2;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+wire_patch_threshold	include/CUGR.h	/^  double wire_patch_threshold = 2.0;$/;"	m	struct:grt::Constants	typeref:typename:double	access:public
+write	include/CUGR.h	/^  void write(const std::string& guide_file);$/;"	p	class:grt::CUGR	typeref:typename:void	access:public	signature:(const std::string & guide_file)
+write	src/CUGR.cpp	/^void CUGR::write(const std::string& guide_file)$/;"	f	class:grt::CUGR	typeref:typename:void	signature:(const std::string & guide_file)
+write	src/GridGraph.cpp	/^void GridGraph::write(const std::string& heatmap_file) const$/;"	f	class:grt::GridGraph	typeref:typename:void	signature:(const std::string & heatmap_file) const
+write	src/GridGraph.h	/^  void write(const std::string& heatmap_file = "heatmap.txt") const;$/;"	p	class:grt::GridGraph	typeref:typename:void	access:public	signature:(const std::string & heatmap_file="heatmap.txt") const
+write_heatmap	include/CUGR.h	/^  bool write_heatmap = false;$/;"	m	struct:grt::Constants	typeref:typename:bool	access:public
+x	src/geo.h	/^  const IntervalT& x() const { return x_; }$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:() const
+x	src/geo.h	/^  int x() const { return x_; }$/;"	f	class:grt::PointT	typeref:typename:int	access:public	signature:() const
+x_	src/geo.h	/^  IntervalT x_;$/;"	m	class:grt::BoxT	typeref:typename:IntervalT	access:private
+x_	src/geo.h	/^  int x_{std::numeric_limits<int>::max()};$/;"	m	class:grt::PointT	typeref:typename:int	access:private
+x_size_	src/GridGraph.h	/^  const int x_size_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+xs_	src/MazeRoute.h	/^  std::vector<int> xs_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+y	src/geo.h	/^  const IntervalT& y() const { return y_; }$/;"	f	class:grt::BoxT	typeref:typename:const IntervalT &	access:public	signature:() const
+y	src/geo.h	/^  int y() const { return y_; }$/;"	f	class:grt::PointT	typeref:typename:int	access:public	signature:() const
+y_	src/geo.h	/^  IntervalT y_;$/;"	m	class:grt::BoxT	typeref:typename:IntervalT	access:private
+y_	src/geo.h	/^  int y_{std::numeric_limits<int>::max()};$/;"	m	class:grt::PointT	typeref:typename:int	access:private
+y_size_	src/GridGraph.h	/^  const int y_size_;$/;"	m	class:grt::GridGraph	typeref:typename:const int	access:private
+y_size_	src/GridGraph.h	/^  const uint64_t y_size_;$/;"	m	class:grt::AccessPointHash	typeref:typename:const uint64_t	access:private
+ys_	src/MazeRoute.h	/^  std::vector<int> ys_;$/;"	m	class:grt::SparseGraph	typeref:typename:std::vector<int>	access:private
+~BulkPoolAllocator	src/robin_hood.h	/^  ~BulkPoolAllocator() noexcept { reset(); }$/;"	f	class:robin_hood::detail::BulkPoolAllocator	access:public	signature:()
+~CUGR	include/CUGR.h	/^  ~CUGR();$/;"	p	class:grt::CUGR	access:public	signature:()
+~CUGR	src/CUGR.cpp	/^CUGR::~CUGR() = default;$/;"	p	class:grt::CUGR	file:	signature:()
+~Table	src/robin_hood.h	/^  ~Table()$/;"	f	class:robin_hood::detail::Table	access:public	signature:()


### PR DESCRIPTION
 ## Summary
 This PR adds `global_route_debug -st` visualization support for 
CUGR, aligned with the existing FastRoute debug flow in GUI.
 
 Main updates:
 - Enabled `global_route_debug -st` when running with `global_route
 -use_cugr`.
 - Implemented CUGR debug infrastructure 
 - Added the debug visualization trigger during CUGR Stage 1 
(pattern routing).

 
 ## Type of Change
 - New feature
 
 ## Impact
 Users can now visualize the Stage-1 Steiner tree for CUGR in GUI 
using:
 1. `global_route_debug -net <net_name> -st`
 2. `global_route -use_cugr`
 
 FastRoute debug behavior remains available.
 
 ## Verification
 - [x] I have verified that the local build succeeds 
(`./etc/Build.sh`).
 - [ ] I have run the relevant tests and they pass.
 - [x] My code follows the repository's formatting guidelines.
 - [x] **I have signed my commits (DCO).**
 
 ## Visual Evidence
  ## Visual Evidence
 ### FastRoute (`global_route_debug -net "net1707" -st` + `global_route`)

<img width="696" height="678" alt="debug-fr" src="https://github.com/user-attachments/assets/0b5956f3-7c1d-40a1-bb0d-d2cae93363cc" />

 
 ### CUGR (`global_route_debug -net "net1707" -st` + `global_route -use_cugr`)

<img width="1290" height="969" alt="debug-cugr" src="https://github.com/user-attachments/assets/868f9dc2-b7d5-4ff6-bdd0-89d7b4418af0" />

 
 ## Related Issues
 N/A