### PR TITLE
Replace sprintf with fmt::format in Logger::error

### DIFF
--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -169,10 +169,8 @@ class Logger
   {
     error_count_++;
     log(tool, spdlog::level::err, id, message, args...);
-    char tool_id[32];
-    sprintf(tool_id, "%s-%04d", tool_names_[tool], id);
     // Exception should be caught by swig error handler.
-    throw std::runtime_error(tool_id);
+    throw std::runtime_error(fmt::format("{}-{:04}", tool_names_[tool], id));
   }
 
   template <typename... Args>


### PR DESCRIPTION
macOS Apple SDK 14.4+ marks sprintf as deprecated, causing build failures when -Werror=deprecated-declarations is active. Use snprintf with sizeof(tool_id) instead, which is both portable and safe.

## Summary
[Describe your changes here]

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix
- New feature
- Breaking change
- Refactoring
- Documentation update

## Impact
[How does this change the tool's behavior?]

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [ ] My code follows the repository's formatting guidelines.
- [ ] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
