### PR TITLE
bazel: add top-level aliases for install and tarfile

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -434,11 +434,13 @@ filegroup(
 alias(
     name = "install",
     actual = "//packaging:install",
+    visibility = ["//visibility:public"],
 )
 
 alias(
     name = "tarfile",
     actual = "//packaging:tarfile",
+    visibility = ["//visibility:public"],
 )
 
 # Lightweight test suites that run without building OpenROAD.

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -424,6 +424,23 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
+# ---------------------------------------------------------------------------
+# Packaging aliases
+#
+# The implementation lives in //packaging/ to isolate @rules_pkg loads from
+# downstream consumers, but the user-facing targets stay at the top level.
+# ---------------------------------------------------------------------------
+
+alias(
+    name = "install",
+    actual = "//packaging:install",
+)
+
+alias(
+    name = "tarfile",
+    actual = "//packaging:tarfile",
+)
+
 # Lightweight test suites that run without building OpenROAD.
 # Usage:
 #   bazelisk test --test_tag_filters=doc_check //src/... # all documentation checks

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -117,7 +117,7 @@ register_toolchains("@llvm_toolchain//:all")
 The following are `dev_dependency` in OpenROAD and will not be forced
 on downstream projects via MVS:
 
-- `rules_shell`, `rules_pkg` — only needed for `//packaging:install`
+- `rules_pkg` — only needed for `//packaging:install`
 - `rules_verilator`, `verilator` — only needed for test/orfs simulation
 - `toolchains_llvm` extension and toolchain registration
 
@@ -461,7 +461,7 @@ Run up to the failing stage and stop with ctrl-c on the step that you want to ru
 
 Now run the whittler with stock `python3` — no extra packages needed beyond
 the standard library. You are responsible for having `openroad` on your
-`PATH` first (e.g. after `bazelisk run //packaging:install` and `source env.sh` in
+`PATH` first (e.g. after `bazelisk run //:install` and `source env.sh` in
 an ORFS checkout):
 
     python3 etc/whittle.py --error_string GPL-0305 --base_db_path 3_2_place_iop.odb --use_stdout --exit_early_on_error --step "make --file=$FLOW_HOME/Makefile do-3_3_place_gp"

--- a/docs/user/Bazel.md
+++ b/docs/user/Bazel.md
@@ -117,7 +117,7 @@ register_toolchains("@llvm_toolchain//:all")
 The following are `dev_dependency` in OpenROAD and will not be forced
 on downstream projects via MVS:
 
-- `rules_pkg` — only needed for `//packaging:install`
+- rules_pkg — only needed for //:install
 - `rules_verilator`, `verilator` — only needed for test/orfs simulation
 - `toolchains_llvm` extension and toolchain registration
 

--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -19,21 +19,21 @@ There are three methods for building OpenROAD (in order of recommendation): preb
 
 Build OpenROAD with GUI support and install into ../install/OpenROAD/bin
 
-    bazelisk run --//:platform=gui //packaging:install
+    bazelisk run --//:platform=gui //:install
 
 To install to a custom location, e.g. /tmp/myinstall
 
-    bazelisk run --//:platform=gui //packaging:install -- /tmp/myinstall
+    bazelisk run --//:platform=gui //:install -- /tmp/myinstall
 
 To produce an openroad.tar file with install files
 
-    bazelisk build --//:platform=gui //packaging:tarfile
+    bazelisk build --//:platform=gui //:tarfile
 
 The tarfile is located at bazel-bin/packaging/openroad.tar.
 
 To embed the real git version string, add `--config=release`:
 
-    bazelisk run --config=release --//:platform=gui //packaging:install
+    bazelisk run --config=release --//:platform=gui //:install
 
 The install process will install the binary "openroad" and the runfile directory
 "openroad.runfiles" which contains runtime data needed by the binary.


### PR DESCRIPTION
The install and tarfile targets were moved to //packaging/ to isolate @rules_pkg loads from downstream consumers, but this broke the user-facing //:install and //:tarfile targets. Add alias() rules at the top level to restore the public API while keeping the implementation in the packaging/ subdirectory.

Update documentation to use //:install and //:tarfile. Also fix docs/user/Bazel.md which incorrectly listed rules_shell as a dev_dependency (it is loaded in the root BUILD.bazel).

## Summary

## Type of Change

- Refactoring
- Documentation update
