### PR TITLE
mpl: make default halo live in HierRTLMP

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -83,8 +83,10 @@ void ClusteringEngine::setTree(PhysicalHierarchy* tree)
 }
 
 void ClusteringEngine::setHalos(
-    std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo)
+    const HardMacro::Halo& default_halo,
+    const std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo)
 {
+  default_halo_ = default_halo;
   macro_to_halo_ = macro_to_halo;
 }
 
@@ -315,10 +317,10 @@ void ClusteringEngine::reportDesignData()
       block_->dbuAreaToMicrons(design_metrics_->getStdCellArea()),
       design_metrics_->getNumMacro(),
       block_->dbuAreaToMicrons(design_metrics_->getMacroArea()),
-      block_->dbuToMicrons(tree_->default_halo.left),
-      block_->dbuToMicrons(tree_->default_halo.bottom),
-      block_->dbuToMicrons(tree_->default_halo.right),
-      block_->dbuToMicrons(tree_->default_halo.top),
+      block_->dbuToMicrons(default_halo_.left),
+      block_->dbuToMicrons(default_halo_.bottom),
+      block_->dbuToMicrons(default_halo_.right),
+      block_->dbuToMicrons(default_halo_.top),
       block_->dbuAreaToMicrons(tree_->macro_with_halo_area),
       block_->dbuAreaToMicrons(design_metrics_->getStdCellArea()
                                + design_metrics_->getMacroArea()),
@@ -2084,13 +2086,13 @@ void ClusteringEngine::createHardMacros()
         if (inst->getHalo()->isSoft()) {
           halo = HardMacro::Halo(inst->getHalo());
         } else {
-          halo = {std::max(inst_halo.xMin(), tree_->default_halo.left),
-                  std::max(inst_halo.yMin(), tree_->default_halo.bottom),
-                  std::max(inst_halo.xMax(), tree_->default_halo.right),
-                  std::max(inst_halo.yMax(), tree_->default_halo.top)};
+          halo = {std::max(inst_halo.xMin(), default_halo_.left),
+                  std::max(inst_halo.yMin(), default_halo_.bottom),
+                  std::max(inst_halo.xMax(), default_halo_.right),
+                  std::max(inst_halo.yMax(), default_halo_.top)};
         }
       } else {
-        halo = tree_->default_halo;
+        halo = default_halo_;
       }
 
       auto macro = std::make_unique<HardMacro>(inst, halo);

--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -57,7 +57,6 @@ struct PhysicalHierarchy
   BoundaryRegionList available_regions_for_unconstrained_pins;
   ClusterToBoundaryRegionMap io_cluster_to_constraint;
 
-  HardMacro::Halo default_halo;
   int64_t macro_with_halo_area{0};
 
   // The constraint set by the user.
@@ -104,7 +103,8 @@ class ClusteringEngine
   void run();
 
   void setTree(PhysicalHierarchy* tree);
-  void setHalos(std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo);
+  void setHalos(const HardMacro::Halo& default_halo,
+                const std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo);
 
   // Methods to update the tree as the hierarchical
   // macro placement runs.
@@ -251,6 +251,8 @@ class ClusteringEngine
   IOBundleSpans io_bundle_spans_;
 
   std::unordered_set<odb::dbInst*> ignorable_macros_;
+
+  HardMacro::Halo default_halo_;
   std::map<odb::dbInst*, HardMacro::Halo> macro_to_halo_;
 };
 

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -113,7 +113,7 @@ void HierRTLMP::setGlobalFence(odb::Rect global_fence)
 
 void HierRTLMP::setDefaultHalo(int halo_width, int halo_height)
 {
-  tree_->default_halo = {halo_width, halo_height, halo_width, halo_height};
+  default_halo_ = {halo_width, halo_height, halo_width, halo_height};
 }
 
 void HierRTLMP::setGuidanceRegions(
@@ -270,7 +270,7 @@ void HierRTLMP::runMultilevelAutoclustering()
 
   // Set target structure
   clustering_engine_->setTree(tree_.get());
-  clustering_engine_->setHalos(macro_to_halo_);
+  clustering_engine_->setHalos(default_halo_, macro_to_halo_);
   clustering_engine_->run();
 
   if (!tree_->has_unfixed_macros) {

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -293,7 +293,10 @@ class HierRTLMP
 
   std::map<std::string, odb::Rect> fences_;   // macro_name, fence
   std::map<odb::dbInst*, odb::Rect> guides_;  // Macro -> Guidance Region
+
+  HardMacro::Halo default_halo_;
   std::map<odb::dbInst*, HardMacro::Halo> macro_to_halo_;
+
   std::vector<odb::Rect> placement_blockages_;
   std::vector<odb::Rect> io_blockages_;
 


### PR DESCRIPTION
## Summary
Default halo is not stored inside the tree struct anymore.

## Type of Change
<!-- Delete items that do not apply -->
- New feature

## Impact
The halo information will be available outside the scope of HierRTLMP flow which will allows us to have a separate pass only for blockage generation.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
