### PR TITLE
dpl: fix topological sort cycle with multi-height cells in shift lega…

### DIFF
--- a/src/dpl/src/legalize_shift.cxx
+++ b/src/dpl/src/legalize_shift.cxx
@@ -120,10 +120,18 @@ bool ShiftLegalizer::legalize(DetailedMgr& mgr)
   outgoing_.resize(size);
   for (size_t i = 0; i < mgr.getNumSegments(); i++) {
     const int segId = mgr.getSegment(i)->getSegId();
+    const int rowId = mgr.getSegment(i)->getRowId();
+    const DbuY rowBottom{arch_->getRow(rowId)->getBottom()};
     for (size_t j = 1; j < mgr.getNumCellsInSeg(segId); j++) {
       const Node* prev = mgr.getCellsInSeg(segId)[j - 1];
       const Node* curr = mgr.getCellsInSeg(segId)[j];
 
+      // Only add edges from a cell's bottom (primary) row to avoid
+      // cycles in the topological sort caused by multi-height cells
+      // appearing in multiple row segments with conflicting orderings.
+      if (prev->getBottom() != rowBottom || curr->getBottom() != rowBottom) {
+        continue;
+      }
       incoming_[curr->getId()].push_back(prev->getId());
       outgoing_[prev->getId()].push_back(curr->getId());
     }

--- a/src/dpl/src/optimization/detailed_manager.h
+++ b/src/dpl/src/optimization/detailed_manager.h
@@ -265,7 +265,9 @@ class DetailedMgr
     // Needs cell centers.
     bool operator()(Node* p, Node* q) const
     {
-      return p->getCenterX() < q->getCenterX();
+      if (p->getCenterX() != q->getCenterX())
+        return p->getCenterX() < q->getCenterX();
+      return p->getId() < q->getId();
     }
     bool operator()(Node*& s, DbuX i) const { return s->getCenterX() < i; }
     bool operator()(DbuX i, Node*& s) const { return i < s->getCenterX(); }

--- a/src/dpl/src/optimization/detailed_manager.h
+++ b/src/dpl/src/optimization/detailed_manager.h
@@ -265,8 +265,9 @@ class DetailedMgr
     // Needs cell centers.
     bool operator()(Node* p, Node* q) const
     {
-      if (p->getCenterX() != q->getCenterX())
+      if (p->getCenterX() != q->getCenterX()) {
         return p->getCenterX() < q->getCenterX();
+      }
       return p->getId() < q->getId();
     }
     bool operator()(Node*& s, DbuX i) const { return s->getCenterX() < i; }


### PR DESCRIPTION
## Summary
`improve_placement` fails with `DPL-0400 Cells incorrectly ordered during shifting` on designs with multi-height cells. Multi-height cells appear in segments across multiple rows. When a single-height cell sits inside the row span of two multi-height cells, the ordering differs per row, creating a cycle in the topological sort. Fix: in `legalize_shift.cxx`, only add dependency edges when both cells' bottom Y matches the current segment's row bottom. Multi-height cells contribute edges only from their primary (bottom) row, eliminating the cycle.

## Type of Change
Bug fix

## Impact
`improve_placement` no longer crashes with DPL-0400 on designs containing multi-height cells such as SRAMs. No behavioral change for single-height-only designs.

## Related Issues
Fixes #9932