### PR TITLE
dpl: add multi-height placement regression test

### DIFF
--- a/test/orfs/multi-height/BUILD.bazel
+++ b/test/orfs/multi-height/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+package(features = ["layering_check"])
+
+sh_test(
+    name = "multi_height_test",
+    srcs = ["test_multi_height.sh"],
+    args = [
+        "$(rootpath //:openroad)",
+        "$(rootpath :multi_height.lef)",
+        "$(rootpath :multi_height.def)",
+        "$(rootpath :multi_height.tcl)",
+    ],
+    data = [
+        ":multi_height.def",
+        ":multi_height.lef",
+        ":multi_height.tcl",
+        "//:openroad",
+    ],
+    tags = ["orfs"],
+)

--- a/test/orfs/multi-height/README.md
+++ b/test/orfs/multi-height/README.md
@@ -1,0 +1,64 @@
+# Multi-Height Cell Placement Test
+
+Regression test for [#9932](https://github.com/The-OpenROAD-Project/OpenROAD/issues/9932):
+DPL-0400 topological sort cycle in the shift legalizer when multi-height
+cells coexist with single-height cells during `improve_placement`.
+
+## What are multi-height cells?
+
+Standard cells normally occupy a single row (1x height). Multi-height cells
+span 2, 3, 4 or more rows. Examples include double-height flip-flops, wide
+I/O drivers, and SRAM macros that span dozens of rows. These cells appear in
+multiple row segments simultaneously, which makes placement legalization more
+complex.
+
+## What this test covers
+
+| Use case | Cell |
+|----------|------|
+| Single-height (baseline) | `SINGLE_BUF` (s1, s2) |
+| Double-height (2 rows) | `DOUBLE_BUF` (d1, d2) |
+| Quad-height (4 rows) | `QUAD_BUF` (q1) |
+| Mixed heights in one design | All 5 cells together |
+| Movable multi-height placement | All cells are `+ PLACED` (not FIXED) |
+
+All cells are **movable** (`+ PLACED` in DEF, not `+ FIXED`), which is
+critical: the DPL-0400 bug only affects movable multi-height cells.
+
+## Synthetic PDK
+
+Multi-height PDKs are typically under NDA. This test uses a self-contained
+synthetic PDK defined in `multi_height.lef`:
+
+- Row height: 1.4 um, site width: 0.19 um (Nangate45 geometry)
+- Three sites: `CoreSite` (1x), `DoubleSite` (2x), `QuadSite` (4x)
+- Three cell types: `SINGLE_BUF`, `DOUBLE_BUF`, `QUAD_BUF`
+
+## Running the test
+
+```bash
+bazelisk test //test/orfs/multi-height:multi_height_test
+```
+
+With streamed output for debugging:
+
+```bash
+bazelisk test //test/orfs/multi-height:multi_height_test --test_output=streamed
+```
+
+## Adding new test scenarios
+
+1. Add new cells to `multi_height.lef` (e.g., a `TRIPLE_BUF` with
+   SIZE 0.76 BY 4.2 and a `TripleSite` of SIZE 0.19 BY 4.2).
+2. Add corresponding rows and component instances to `multi_height.def`.
+3. The test automatically covers any new cells through `improve_placement`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `multi_height.lef` | Synthetic PDK: technology layers, sites, cell definitions |
+| `multi_height.def` | Design: rows, placed cells, pins, nets |
+| `multi_height.tcl` | OpenROAD script: read LEF/DEF, run `improve_placement` |
+| `test_multi_height.sh` | Shell driver: run OpenROAD, check for DPL-0400 errors |
+| `BUILD.bazel` | Bazel test definition |

--- a/test/orfs/multi-height/multi_height.def
+++ b/test/orfs/multi-height/multi_height.def
@@ -1,0 +1,61 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN multi_height ;
+UNITS DISTANCE MICRONS 2000 ;
+
+DIEAREA ( 0 0 ) ( 13000 16800 ) ;
+
+ROW ROW_0 CoreSite 0 0 N DO 34 BY 1 STEP 380 0 ;
+ROW ROW_1 CoreSite 0 2800 FS DO 34 BY 1 STEP 380 0 ;
+ROW ROW_2 CoreSite 0 5600 N DO 34 BY 1 STEP 380 0 ;
+ROW ROW_3 CoreSite 0 8400 FS DO 34 BY 1 STEP 380 0 ;
+ROW ROW_4 CoreSite 0 11200 N DO 34 BY 1 STEP 380 0 ;
+ROW ROW_5 CoreSite 0 14000 FS DO 34 BY 1 STEP 380 0 ;
+
+ROW ROW_D0 DoubleSite 0 0 N DO 34 BY 1 STEP 380 0 ;
+ROW ROW_D1 DoubleSite 0 5600 N DO 34 BY 1 STEP 380 0 ;
+ROW ROW_D2 DoubleSite 0 11200 N DO 34 BY 1 STEP 380 0 ;
+
+ROW ROW_Q0 QuadSite 0 0 N DO 34 BY 1 STEP 380 0 ;
+
+COMPONENTS 5 ;
+    - s1 SINGLE_BUF + PLACED ( 6840 14000 ) FS ;
+    - s2 SINGLE_BUF + PLACED ( 5320 14000 ) FS ;
+    - d1 DOUBLE_BUF + PLACED ( 9880 11200 ) N ;
+    - d2 DOUBLE_BUF + PLACED ( 8360 11200 ) N ;
+    - q1 QUAD_BUF   + PLACED ( 11400 8400 ) FS ;
+END COMPONENTS
+
+PINS 5 ;
+    - in1 + NET in1 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 2470 70 ) N ;
+    - in2 + NET in2 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 3230 70 ) N ;
+    - in3 + NET in3 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 3990 70 ) N ;
+    - in4 + NET in4 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 4750 70 ) N ;
+    - in5 + NET in5 + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER metal2 ( -70 -70 ) ( 70 70 )
+        + PLACED ( 5510 70 ) N ;
+END PINS
+
+NETS 5 ;
+    - in1 ( PIN in1 ) ( s1 A ) + USE SIGNAL ;
+    - in2 ( PIN in2 ) ( s2 A ) + USE SIGNAL ;
+    - in3 ( PIN in3 ) ( d1 A ) + USE SIGNAL ;
+    - in4 ( PIN in4 ) ( d2 A ) + USE SIGNAL ;
+    - in5 ( PIN in5 ) ( q1 A ) + USE SIGNAL ;
+END NETS
+
+END DESIGN

--- a/test/orfs/multi-height/multi_height.lef
+++ b/test/orfs/multi-height/multi_height.lef
@@ -1,0 +1,140 @@
+VERSION 5.8 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+# Synthetic minimal PDK for multi-height placement testing.
+# Row height: 1.4 um, site width: 0.19 um (matches Nangate45 geometry).
+# See src/dpl/test/Nangate45_data/fake_macros.lef for the original pattern.
+
+UNITS
+  DATABASE MICRONS 2000 ;
+END UNITS
+
+LAYER metal1
+  TYPE ROUTING ;
+  DIRECTION HORIZONTAL ;
+  PITCH 0.28 ;
+  WIDTH 0.065 ;
+END metal1
+
+LAYER metal2
+  TYPE ROUTING ;
+  DIRECTION VERTICAL ;
+  PITCH 0.28 ;
+  WIDTH 0.07 ;
+END metal2
+
+SITE CoreSite
+  CLASS CORE ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY Y ;
+END CoreSite
+
+SITE DoubleSite
+  SYMMETRY X Y ;
+  CLASS CORE ;
+  SIZE 0.19 BY 2.8 ;
+END DoubleSite
+
+SITE QuadSite
+  CLASS CORE ;
+  SIZE 0.19 BY 5.6 ;
+END QuadSite
+
+MACRO SINGLE_BUF
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE CoreSite ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.100 0.200 0.170 0.700 ;
+    END
+  END A
+  PIN Y
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.500 0.200 0.570 0.700 ;
+    END
+  END Y
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+  END VSS
+END SINGLE_BUF
+
+MACRO DOUBLE_BUF
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  SIZE 0.76 BY 2.8 ;
+  SYMMETRY X Y ;
+  SITE DoubleSite ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.100 0.200 0.170 1.400 ;
+    END
+  END A
+  PIN Y
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.500 0.200 0.570 1.400 ;
+    END
+  END Y
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+  END VSS
+END DOUBLE_BUF
+
+MACRO QUAD_BUF
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  SIZE 0.76 BY 5.6 ;
+  SYMMETRY X Y ;
+  SITE QuadSite ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.100 0.200 0.170 2.800 ;
+    END
+  END A
+  PIN Y
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+      RECT 0.500 0.200 0.570 2.800 ;
+    END
+  END Y
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+  END VSS
+END QUAD_BUF
+
+END LIBRARY

--- a/test/orfs/multi-height/multi_height.tcl
+++ b/test/orfs/multi-height/multi_height.tcl
@@ -1,0 +1,5 @@
+# Regression test for issue #9932: DPL-0400 topological sort cycle
+# in shift legalizer with multi-height cells.
+read_lef $::env(MULTI_HEIGHT_LEF)
+read_def $::env(MULTI_HEIGHT_DEF)
+improve_placement

--- a/test/orfs/multi-height/test_multi_height.sh
+++ b/test/orfs/multi-height/test_multi_height.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Regression test for DPL-0400: topological sort cycle in the shift
+# legalizer when multi-height cells coexist with single-height cells.
+#
+# improve_placement must complete without DPL-0400 or bad_optional_access.
+set -euo pipefail
+
+OPENROAD="$(readlink -f "$1")"
+export MULTI_HEIGHT_LEF="$(readlink -f "$2")"
+export MULTI_HEIGHT_DEF="$(readlink -f "$3")"
+TCL_SCRIPT="$(readlink -f "$4")"
+
+"$OPENROAD" -exit "$TCL_SCRIPT" 2>&1 | tee "$TEST_TMPDIR/output.log"
+
+if grep -q "DPL-0400\|bad_optional_access\|Cells incorrectly ordered" "$TEST_TMPDIR/output.log"; then
+    echo "FAIL: DPL-0400 or related error detected"
+    exit 1
+fi


### PR DESCRIPTION
Add bazel-orfs test for DPL-0400 (topological sort cycle in shift legalizer with multi-height cells, issue #9932). Uses a self-contained synthetic PDK with single-height, double-height, and quad-height cells to exercise improve_placement without requiring NDA-protected libraries.

@stefanottili shot in the dark...