### PR TITLE
fix: null dereference before guard in repairEndHold

### DIFF
--- a/src/rsz/src/RepairHold.cc
+++ b/src/rsz/src/RepairHold.cc
@@ -542,8 +542,8 @@ void RepairHold::repairEndHold(sta::Vertex* end_vertex,
                                const bool allow_setup_violations)
 {
   sta::Path* end_path = sta_->vertexWorstSlackPath(end_vertex, min_);
-  sta::Mode* mode = end_path->mode(sta_);
   if (end_path) {
+    sta::Mode* mode = end_path->mode(sta_);
     debugPrint(logger_,
                RSZ,
                "repair_hold",


### PR DESCRIPTION
### SUMMARY

Fixes a crash in `RepairHold::repairEndHold()` caused by using `end_path` before checking if it’s null. The issue is in `src/rsz/src/RepairHold.cc`, and the fix simply makes the existing guard actually work. 

---

### FIX

**Before:**

```cpp
sta::Path* end_path = sta_->vertexWorstSlackPath(end_vertex, min_);
sta::Mode* mode = end_path->mode(sta_);  // crash if null
if (end_path) {
```

**After:**

```cpp
sta::Path* end_path = sta_->vertexWorstSlackPath(end_vertex, min_);
if (end_path) {
    sta::Mode* mode = end_path->mode(sta_);  // safe
```

---

### VERIFICATION

Run `repair_hold` on a design with missing/partial constraints. Before, this could segfault when no path exists. After the fix, it skips safely and completes without crashing.
