### PR TITLE
mpl: rename default halo to base halo on new command for clarity

### DIFF
--- a/src/mpl/README.md
+++ b/src/mpl/README.md
@@ -57,8 +57,8 @@ rtl_macro_placer
 | `-max_num_level` | Maximum depth of physical hierarchical tree. The default value is `2`, and the allowed values are integers `[0, MAX_INT]`. |
 | `-coarsening_ratio` | The larger the coarsening_ratio, the faster the convergence process. The allowed values are floats, and the default value is `10.0`. |
 | `-large_net_threshold` | Ignore nets with many connections during clustering, such as global nets. The default value is `50`, and the allowed values are integers `[0, MAX_INT]`. |
-| `-halo_width` | **Deprecated: use `set_macro_default_halo` instead.** Horizontal halo around macros (microns). The default value is `0.0`. |
-| `-halo_height` | **Deprecated: use `set_macro_default_halo` instead.** Vertical halo around macros (microns). The default value is `0.0`. |
+| `-halo_width` | **Deprecated: use `set_macro_base_halo` instead.** Horizontal halo around macros (microns). The default value is `0.0`. |
+| `-halo_height` | **Deprecated: use `set_macro_base_halo` instead.** Vertical halo around macros (microns). The default value is `0.0`. |
 | `-fence_lx`, `-fence_ly`, `-fence_ux`, `-fence_uy` | Defines the global fence bounding box coordinates. The default values are the core area coordinates). |
 | `-target_util` | Specifies the target utilization. The allowed values are floats and the default value is `0.25`. |
 | `-min_ar` | Specifies the minimum aspect ratio $a$, or the ratio of its width to height of a `StandardCellCluster` from $[a, \frac{1}{a}]$. The allowed values are floats, and the default value is `0.33`. |
@@ -123,13 +123,13 @@ set_macro_guidance_region
 | `-region` | The lower left corner and upper right corner {lx ly ux uy} of the region in microns. |
 
 
-### Set Macro Default Halo
+### Set Macro Base Halo
 
-Command for setting the default halo around all macros. Per-macro halos set with `set_macro_halo` take precedence.
+Command for setting the base halo around all macros. Per-macro halos set with `set_macro_halo` take precedence.
 
 ```tcl
-set_macro_default_halo left bottom right top
-set_macro_default_halo width height
+set_macro_base_halo left bottom right top
+set_macro_base_halo width height
 ```
 
 #### Arguments

--- a/src/mpl/include/mpl/rtl_mp.h
+++ b/src/mpl/include/mpl/rtl_mp.h
@@ -74,7 +74,7 @@ class MacroPlacer
 
   void setMacroPlacementFile(const std::string& file_name);
   void addGuidanceRegion(odb::dbInst* macro, odb::Rect region);
-  void setDefaultHalo(int left, int bottom, int right, int top);
+  void setBaseHalo(int left, int bottom, int right, int top);
   void setMacroHalo(odb::dbInst* macro,
                     int left,
                     int bottom,

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -83,10 +83,10 @@ void ClusteringEngine::setTree(PhysicalHierarchy* tree)
 }
 
 void ClusteringEngine::setHalos(
-    const HardMacro::Halo& default_halo,
+    const HardMacro::Halo& base_halo,
     const std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo)
 {
-  default_halo_ = default_halo;
+  base_halo_ = base_halo;
   macro_to_halo_ = macro_to_halo;
 }
 
@@ -306,7 +306,7 @@ void ClusteringEngine::reportDesignData()
       "\tArea of std cell instances: {:.2f}\n"
       "\tNumber of macros: {}\n"
       "\tArea of macros: {:.2f}\n"
-      "\tDefault halo (L, B, R, T): ({:.2f}, {:.2f}, {:.2f}, {:.2f})\n"
+      "\tBase halo (L, B, R, T): ({:.2f}, {:.2f}, {:.2f}, {:.2f})\n"
       "\tArea of macros with halos: {:.2f}\n"
       "\tArea of std cell instances + Area of macros: {:.2f}\n"
       "\tFloorplan area: {:.2f}\n"
@@ -317,10 +317,10 @@ void ClusteringEngine::reportDesignData()
       block_->dbuAreaToMicrons(design_metrics_->getStdCellArea()),
       design_metrics_->getNumMacro(),
       block_->dbuAreaToMicrons(design_metrics_->getMacroArea()),
-      block_->dbuToMicrons(default_halo_.left),
-      block_->dbuToMicrons(default_halo_.bottom),
-      block_->dbuToMicrons(default_halo_.right),
-      block_->dbuToMicrons(default_halo_.top),
+      block_->dbuToMicrons(base_halo_.left),
+      block_->dbuToMicrons(base_halo_.bottom),
+      block_->dbuToMicrons(base_halo_.right),
+      block_->dbuToMicrons(base_halo_.top),
       block_->dbuAreaToMicrons(tree_->macro_with_halo_area),
       block_->dbuAreaToMicrons(design_metrics_->getStdCellArea()
                                + design_metrics_->getMacroArea()),
@@ -2086,13 +2086,13 @@ void ClusteringEngine::createHardMacros()
         if (inst->getHalo()->isSoft()) {
           halo = HardMacro::Halo(inst->getHalo());
         } else {
-          halo = {std::max(inst_halo.xMin(), default_halo_.left),
-                  std::max(inst_halo.yMin(), default_halo_.bottom),
-                  std::max(inst_halo.xMax(), default_halo_.right),
-                  std::max(inst_halo.yMax(), default_halo_.top)};
+          halo = {std::max(inst_halo.xMin(), base_halo_.left),
+                  std::max(inst_halo.yMin(), base_halo_.bottom),
+                  std::max(inst_halo.xMax(), base_halo_.right),
+                  std::max(inst_halo.yMax(), base_halo_.top)};
         }
       } else {
-        halo = default_halo_;
+        halo = base_halo_;
       }
 
       auto macro = std::make_unique<HardMacro>(inst, halo);

--- a/src/mpl/src/clusterEngine.h
+++ b/src/mpl/src/clusterEngine.h
@@ -103,7 +103,7 @@ class ClusteringEngine
   void run();
 
   void setTree(PhysicalHierarchy* tree);
-  void setHalos(const HardMacro::Halo& default_halo,
+  void setHalos(const HardMacro::Halo& base_halo,
                 const std::map<odb::dbInst*, HardMacro::Halo>& macro_to_halo);
 
   // Methods to update the tree as the hierarchical
@@ -252,7 +252,7 @@ class ClusteringEngine
 
   std::unordered_set<odb::dbInst*> ignorable_macros_;
 
-  HardMacro::Halo default_halo_;
+  HardMacro::Halo base_halo_;
   std::map<odb::dbInst*, HardMacro::Halo> macro_to_halo_;
 };
 

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -111,13 +111,13 @@ void HierRTLMP::setGlobalFence(odb::Rect global_fence)
   }
 }
 
-void HierRTLMP::setDefaultHalo(int left, int bottom, int right, int top)
+void HierRTLMP::setBaseHalo(int left, int bottom, int right, int top)
 {
-  if (!default_halo_.isZero()) {
-    logger_->warn(MPL, 71, "Overwriting default macro halo.");
+  if (!base_halo_.isZero()) {
+    logger_->warn(MPL, 71, "Overwriting base macro halo.");
   }
 
-  default_halo_ = {left, bottom, right, top};
+  base_halo_ = {left, bottom, right, top};
 }
 
 void HierRTLMP::setGuidanceRegions(
@@ -274,7 +274,7 @@ void HierRTLMP::runMultilevelAutoclustering()
 
   // Set target structure
   clustering_engine_->setTree(tree_.get());
-  clustering_engine_->setHalos(default_halo_, macro_to_halo_);
+  clustering_engine_->setHalos(base_halo_, macro_to_halo_);
   clustering_engine_->run();
 
   if (!tree_->has_unfixed_macros) {

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -76,7 +76,7 @@ class HierRTLMP
   // Interfaces functions for setting options
   // Hierarchical Macro Placement Related Options
   void setGlobalFence(odb::Rect global_fence);
-  void setDefaultHalo(int left, int bottom, int right, int top);
+  void setBaseHalo(int left, int bottom, int right, int top);
   void setGuidanceRegions(
       const std::map<odb::dbInst*, odb::Rect>& guidance_regions);
   void setMacroHalo(odb::dbInst* macro,
@@ -294,7 +294,7 @@ class HierRTLMP
   std::map<std::string, odb::Rect> fences_;   // macro_name, fence
   std::map<odb::dbInst*, odb::Rect> guides_;  // Macro -> Guidance Region
 
-  HardMacro::Halo default_halo_;
+  HardMacro::Halo base_halo_;
   std::map<odb::dbInst*, HardMacro::Halo> macro_to_halo_;
 
   std::vector<odb::Rect> placement_blockages_;

--- a/src/mpl/src/mpl.i
+++ b/src/mpl/src/mpl.i
@@ -132,16 +132,16 @@ add_guidance_region(odb::dbInst* macro,
 }
 
 void
-set_default_halo(float left,
-                 float bottom,
-                 float right,
-                 float top)
+set_base_halo(float left,
+              float bottom,
+              float right,
+              float top)
 {
   odb::dbBlock* block = ord::OpenRoad::openRoad()->getDb()->getChip()->getBlock();
-  getMacroPlacer()->setDefaultHalo(block->micronsToDbu(left),
-                                   block->micronsToDbu(bottom),
-                                   block->micronsToDbu(right),
-                                   block->micronsToDbu(top));
+  getMacroPlacer()->setBaseHalo(block->micronsToDbu(left),
+                                block->micronsToDbu(bottom),
+                                block->micronsToDbu(right),
+                                block->micronsToDbu(top));
 }
 
 void

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -109,7 +109,7 @@ proc rtl_macro_placer { args } {
 
   if { [info exists keys(-halo_width)] || [info exists keys(-halo_height)] } {
     utl::warn MPL 74 "-halo_width/-halo_height are deprecated, use\
-                      the set_macro_default_halo command instead."
+                      the set_macro_base_halo command instead."
     set halo_width 0.0
     set halo_height 0.0
 
@@ -125,7 +125,7 @@ proc rtl_macro_placer { args } {
       }
     }
 
-    mpl::set_default_halo $halo_width $halo_height $halo_width $halo_height
+    mpl::set_base_halo $halo_width $halo_height $halo_width $halo_height
   }
 
   if { [info exists keys(-fence_lx)] } {
@@ -298,13 +298,13 @@ proc set_macro_guidance_region { args } {
   mpl::add_guidance_region $macro $x1 $y1 $x2 $y2
 }
 
-sta::define_cmd_args "set_macro_default_halo" { halo }
-proc set_macro_default_halo { args } {
-  sta::parse_key_args "set_macro_default_halo" args \
+sta::define_cmd_args "set_macro_base_halo" { halo }
+proc set_macro_base_halo { args } {
+  sta::parse_key_args "set_macro_base_halo" args \
     keys {} flags {}
 
   lassign [mpl::parse_halo $args] left bottom right top
-  mpl::set_default_halo $left $bottom $right $top
+  mpl::set_base_halo $left $bottom $right $top
 }
 
 sta::define_cmd_args "set_macro_halo" { -macro_name macro_name \

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -307,6 +307,12 @@ proc set_macro_base_halo { args } {
   mpl::set_base_halo $left $bottom $right $top
 }
 
+proc set_macro_default_halo { args } {
+  utl::warn MPL 75 "set_macro_default_halo is deprecated, use\
+                    set_macro_base_halo instead."
+  set_macro_base_halo {*}$args
+}
+
 sta::define_cmd_args "set_macro_halo" { -macro_name macro_name \
                                         -halo halo }
 proc set_macro_halo { args } {

--- a/src/mpl/src/rtl_mp.cpp
+++ b/src/mpl/src/rtl_mp.cpp
@@ -214,9 +214,9 @@ void MacroPlacer::addGuidanceRegion(odb::dbInst* macro, odb::Rect region)
   guidance_regions_[macro] = region;
 }
 
-void MacroPlacer::setDefaultHalo(int left, int bottom, int right, int top)
+void MacroPlacer::setBaseHalo(int left, int bottom, int right, int top)
 {
-  hier_rtlmp_->setDefaultHalo(left, bottom, right, top);
+  hier_rtlmp_->setBaseHalo(left, bottom, right, top);
 }
 
 void MacroPlacer::setMacroHalo(odb::dbInst* macro,

--- a/src/mpl/test/boundary_push1.ok
+++ b/src/mpl/test/boundary_push1.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 0.00
 	Number of macros: 4
 	Area of macros: 40000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 40000.00
 	Area of std cell instances + Area of macros: 40000.00
 	Floorplan area: 48668.42

--- a/src/mpl/test/centralization1.ok
+++ b/src/mpl/test/centralization1.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (302.10, 301.00),  Floorplan Area: (0.00, 0.00) (302.10, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 91355.04

--- a/src/mpl/test/clocked_macro.ok
+++ b/src/mpl/test/clocked_macro.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 43000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 43000.00
 	Area of std cell instances + Area of macros: 43000.00
 	Floorplan area: 193441.58

--- a/src/mpl/test/fixed_covers.ok
+++ b/src/mpl/test/fixed_covers.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 678.30
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 20678.30
 	Floorplan area: 48668.42

--- a/src/mpl/test/fixed_ios1.ok
+++ b/src/mpl/test/fixed_ios1.ok
@@ -10,7 +10,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/fixed_macros1.ok
+++ b/src/mpl/test/fixed_macros1.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 678.30
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 20678.30
 	Floorplan area: 48668.42

--- a/src/mpl/test/fixed_macros2.ok
+++ b/src/mpl/test/fixed_macros2.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 15.40) (220.02,
 	Area of std cell instances: 1808.80
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 21808.80
 	Floorplan area: 45280.12

--- a/src/mpl/test/guides1.ok
+++ b/src/mpl/test/guides1.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/guides2.ok
+++ b/src/mpl/test/guides2.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Area of std cell instances: 0.00
 	Number of macros: 10
 	Area of macros: 166000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 166000.00
 	Area of std cell instances + Area of macros: 166000.00
 	Floorplan area: 193441.58

--- a/src/mpl/test/halos1.ok
+++ b/src/mpl/test/halos1.ok
@@ -7,7 +7,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 678.30
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 22650.00
 	Area of std cell instances + Area of macros: 20678.30
 	Floorplan area: 48668.42

--- a/src/mpl/test/halos2.ok
+++ b/src/mpl/test/halos2.ok
@@ -7,7 +7,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 678.30
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 22782.00
 	Area of std cell instances + Area of macros: 20678.30
 	Floorplan area: 48668.42

--- a/src/mpl/test/halos3.ok
+++ b/src/mpl/test/halos3.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (250.00, 250.00),  Floorplan Area: (9.00, 9.80) (249.92, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (12.00, 6.00, 12.00, 6.00)
+	Base halo (L, B, R, T): (12.00, 6.00, 12.00, 6.00)
 	Area of macros with halos: 13888.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 57676.25

--- a/src/mpl/test/halos3.tcl
+++ b/src/mpl/test/halos3.tcl
@@ -1,4 +1,4 @@
-# Test if default halos are correctly generated using 2 arguments.
+# Test if base halos are correctly generated using 2 arguments.
 source "helpers.tcl"
 
 read_lef "./Nangate45/Nangate45.lef"
@@ -7,7 +7,7 @@ read_lef "./testcases/orientation_improve1.lef"
 read_def "./testcases/halo3.def"
 
 set_thread_count 0
-set_macro_default_halo 12.0 6.0
+set_macro_base_halo 12.0 6.0
 rtl_macro_placer -report_directory [make_result_dir]
 
 set def_file [make_result_file halos3.def]

--- a/src/mpl/test/halos4.ok
+++ b/src/mpl/test/halos4.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (250.00, 250.00),  Floorplan Area: (9.00, 9.80) (249.92, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (16.00, 8.00, 4.00, 2.00)
+	Base halo (L, B, R, T): (16.00, 8.00, 4.00, 2.00)
 	Area of macros with halos: 13200.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 57676.25

--- a/src/mpl/test/halos4.tcl
+++ b/src/mpl/test/halos4.tcl
@@ -1,4 +1,4 @@
-# Test if default halos are correctly generated using 4 arguments.
+# Test if base halos are correctly generated using 4 arguments.
 source "helpers.tcl"
 
 read_lef "./Nangate45/Nangate45.lef"
@@ -7,7 +7,7 @@ read_lef "./testcases/orientation_improve1.lef"
 read_def "./testcases/halo3.def"
 
 set_thread_count 0
-set_macro_default_halo 16.0 8.0 4.0 2.0
+set_macro_base_halo 16.0 8.0 4.0 2.0
 rtl_macro_placer -report_directory [make_result_dir]
 
 set def_file [make_result_file halos4.def]

--- a/src/mpl/test/io_constraints1.ok
+++ b/src/mpl/test/io_constraints1.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints10.ok
+++ b/src/mpl/test/io_constraints10.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints2.ok
+++ b/src/mpl/test/io_constraints2.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints3.ok
+++ b/src/mpl/test/io_constraints3.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 904.40
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10904.40
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints4.ok
+++ b/src/mpl/test/io_constraints4.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 1808.80
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 11808.80
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints5.ok
+++ b/src/mpl/test/io_constraints5.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 1808.80
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 11808.80
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints6.ok
+++ b/src/mpl/test/io_constraints6.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints7.ok
+++ b/src/mpl/test/io_constraints7.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints8.ok
+++ b/src/mpl/test/io_constraints8.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_constraints9.ok
+++ b/src/mpl/test/io_constraints9.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/io_pads1.ok
+++ b/src/mpl/test/io_pads1.ok
@@ -10,7 +10,7 @@ Die Area: (0.00, 0.00) (290.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/keep_clustering_data.ok
+++ b/src/mpl/test/keep_clustering_data.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/macro_only.ok
+++ b/src/mpl/test/macro_only.ok
@@ -8,7 +8,7 @@ Die Area: (0.00, 0.00) (450.00, 450.00),  Floorplan Area: (4.94, 4.20) (444.98, 
 	Area of std cell instances: 0.00
 	Number of macros: 10
 	Area of macros: 166000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 166000.00
 	Area of std cell instances + Area of macros: 166000.00
 	Floorplan area: 193441.58

--- a/src/mpl/test/macros_without_pins1.ok
+++ b/src/mpl/test/macros_without_pins1.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (220.02, 221.20),  Floorplan Area: (0.00, 0.00) (220.02, 
 	Area of std cell instances: 1808.80
 	Number of macros: 2
 	Area of macros: 20000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 21808.80
 	Floorplan area: 48668.42

--- a/src/mpl/test/mixed_ios1.ok
+++ b/src/mpl/test/mixed_ios1.ok
@@ -10,7 +10,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/src/mpl/test/orientation_improve1.ok
+++ b/src/mpl/test/orientation_improve1.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 10265.47

--- a/src/mpl/test/orientation_improve2.ok
+++ b/src/mpl/test/orientation_improve2.ok
@@ -9,7 +9,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 10265.47

--- a/src/mpl/test/orientation_improve3.ok
+++ b/src/mpl/test/orientation_improve3.ok
@@ -10,7 +10,7 @@ Die Area: (0.00, 0.00) (120.00, 120.00),  Floorplan Area: (9.00, 9.80) (110.84, 
 	Area of std cell instances: 0.00
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10000.00
 	Floorplan area: 10265.47

--- a/src/mpl/test/placement_blockages1.ok
+++ b/src/mpl/test/placement_blockages1.ok
@@ -7,7 +7,7 @@ Die Area: (0.00, 0.00) (150.00, 125.00),  Floorplan Area: (0.00, 0.00) (149.91, 
 	Area of std cell instances: 678.30
 	Number of macros: 1
 	Area of macros: 10000.00
-	Default halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
 	Area of macros with halos: 10000.00
 	Area of std cell instances + Area of macros: 10678.30
 	Floorplan area: 18678.79

--- a/test/flow.tcl
+++ b/test/flow.tcl
@@ -32,7 +32,7 @@ if { $pre_placed_macros_file != "" } {
 # Macro Placement
 if { [have_macros] } {
   lassign $macro_place_halo halo_x halo_y
-  set_macro_default_halo $halo_x $halo_y
+  set_macro_base_halo $halo_x $halo_y
   set report_dir [make_result_file ${design}_${platform}_rtlmp]
   rtl_macro_placer -report_directory $report_dir
 }


### PR DESCRIPTION
## Summary
In MPL, we always floor the DEF halo to the default halo dimensions, so that makes it more of a base halo than a default halo per say.

## Type of Change
<!-- Delete items that do not apply -->
- Refactoring

## Impact
No impact.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

