### PR TITLE
DRT: Support LEF58_SPACING ADJACENTCUTS EXCEPTSAMEPGNET branch

### DIFF
--- a/src/drt/src/db/tech/frLayer.h
+++ b/src/drt/src/db/tech/frLayer.h
@@ -621,7 +621,15 @@ class frLayer
   }
   void addLef58AreaConstraint(frLef58AreaConstraint* in)
   {
-    lef58AreaConstraints_.push_back(in);
+    // This vector should be sorted by area in a descending order
+    auto area = in->getODBRule()->getArea();
+    auto it = std::lower_bound(lef58AreaConstraints_.begin(),
+                               lef58AreaConstraints_.end(),
+                               area,
+                               [](const frLef58AreaConstraint* a, frCoord b) {
+                                 return a->getODBRule()->getArea() > b;
+                               });
+    lef58AreaConstraints_.insert(it, in);
   }
 
   const std::vector<frLef58AreaConstraint*>& getLef58AreaConstraints() const
@@ -629,7 +637,30 @@ class frLayer
     return lef58AreaConstraints_;
   }
 
-  bool hasLef58AreaConstraint() const { return !lef58AreaConstraints_.empty(); }
+  bool hasLef58AreaConstraint() const
+  {
+    return !lef58AreaConstraints_.empty()
+           || !lef58AreaConstraintsRectWidth_.empty();
+  }
+
+  void addLef58AreaConstraintRectWidth(frLef58AreaConstraint* in)
+  {
+    // This vector should be sorted by rectwidth in an ascending order
+    auto rectwidth = in->getODBRule()->getRectWidth();
+    auto it = std::lower_bound(lef58AreaConstraintsRectWidth_.begin(),
+                               lef58AreaConstraintsRectWidth_.end(),
+                               rectwidth,
+                               [](const frLef58AreaConstraint* a, frCoord b) {
+                                 return a->getODBRule()->getRectWidth() < b;
+                               });
+    lef58AreaConstraintsRectWidth_.insert(it, in);
+  }
+
+  const std::vector<frLef58AreaConstraint*>& getLef58AreaConstraintsRectWidth()
+      const
+  {
+    return lef58AreaConstraintsRectWidth_;
+  }
 
   void addKeepOutZoneConstraint(frLef58KeepOutZoneConstraint* in)
   {
@@ -929,6 +960,7 @@ class frLayer
   std::vector<frLef58EolKeepOutConstraint*> lef58EolKeepOutConstraints_;
   std::vector<frMetalWidthViaConstraint*> metalWidthViaConstraints_;
   std::vector<frLef58AreaConstraint*> lef58AreaConstraints_;
+  std::vector<frLef58AreaConstraint*> lef58AreaConstraintsRectWidth_;
   std::vector<frLef58KeepOutZoneConstraint*> keepOutZoneConstraints_;
   std::vector<frSpacingRangeConstraint*> spacingRangeConstraints_;
   std::vector<frLef58TwoWiresForbiddenSpcConstraint*>

--- a/src/drt/src/gc/FlexGC_impl.h
+++ b/src/drt/src/gc/FlexGC_impl.h
@@ -539,8 +539,7 @@ class FlexGCWorker::Impl
       gcPolygon* poly,
       odb::dbTechLayerAreaRule* db_rule);
   bool checkMetalShape_lef58Area_rectWidth(gcPolygon* poly,
-                                           odb::dbTechLayerAreaRule* db_rule,
-                                           bool& check_rect_width);
+                                           odb::dbTechLayerAreaRule* db_rule);
   void checkMetalShape_addPatch(gcPin* pin, int min_area);
   void checkMetalShape_patchOwner_helper(drPatchWire* patch,
                                          const std::vector<drNet*>* dr_nets);

--- a/src/drt/src/gc/FlexGC_main.cpp
+++ b/src/drt/src/gc/FlexGC_main.cpp
@@ -2101,87 +2101,48 @@ void FlexGCWorker::Impl::checkMetalShape_lef58Area(gcPin* pin)
   }
 
   auto poly = pin->getPolygon();
-  auto layer_idx = poly->getLayerNum();
+  const auto layer_idx = poly->getLayerNum();
   auto layer = getTech()->getLayer(layer_idx);
 
   if (!layer->hasLef58AreaConstraint()) {
     return;
   }
 
-  auto constraints = layer->getLef58AreaConstraints();
-
-  auto sort_cmp
-      = [](const frLef58AreaConstraint* a, const frLef58AreaConstraint* b) {
-          auto a_rule = a->getODBRule();
-          auto b_rule = b->getODBRule();
-
-          return a_rule->getRectWidth() < b_rule->getRectWidth();
-        };
-
-  // sort constraints to ensure the smallest rect width will have
-  // preference above other rect width statements
-  std::ranges::sort(constraints, sort_cmp);
-
-  bool check_rect_width = true;
-
-  for (auto con : constraints) {
+  gtl::rectangle_data<frCoord> bbox;
+  gtl::extents(bbox, *pin->getPolygon());
+  const odb::Rect bbox2(
+      gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
+  if (!drWorker_->getDrcBox().contains(bbox2)) {
+    return;
+  }
+  const frCoord width = bbox2.minDXDY();
+  const auto curr_area = gtl::area(*poly);
+  // iterate through rectwidth constraints first
+  for (auto con : layer->getLef58AreaConstraintsRectWidth()) {
+    odb::dbTechLayerAreaRule* db_rule = con->getODBRule();
+    if (width < db_rule->getRectWidth()) {
+      auto min_area = db_rule->getArea();
+      if (curr_area < min_area
+          && checkMetalShape_lef58Area_rectWidth(poly, db_rule)) {
+        checkMetalShape_addPatch(pin, min_area);
+      }
+      // if any rectwidth constraint is satisfied, return
+      return;
+    }
+  }
+  // Iterate through area constraints which are sorted by area in a descending
+  // order
+  for (auto con : layer->getLef58AreaConstraints()) {
     odb::dbTechLayerAreaRule* db_rule = con->getODBRule();
     auto min_area = db_rule->getArea();
-    auto curr_area = gtl::area(*poly);
 
     if (curr_area >= min_area) {
-      continue;
+      break;
     }
-
-    gtl::rectangle_data<frCoord> bbox;
-    gtl::extents(bbox, *pin->getPolygon());
-    odb::Rect bbox2(gtl::xl(bbox), gtl::yl(bbox), gtl::xh(bbox), gtl::yh(bbox));
-    if (!drWorker_->getDrcBox().contains(bbox2)) {
-      continue;
-    }
-    for (auto& edges : pin->getPolygonEdges()) {
-      for (auto& edge : edges) {
-        if (edge->isFixed()) {
-          continue;
-        }
-      }
-    }
-
-    if (checkMetalShape_lef58Area_exceptRectangle(poly, db_rule)) {
-      // add patch only when the poly is not a rect
+    if (!db_rule->isExceptRectangle()
+        || checkMetalShape_lef58Area_exceptRectangle(poly, db_rule)) {
       checkMetalShape_addPatch(pin, min_area);
-    } else if (check_rect_width
-               && checkMetalShape_lef58Area_rectWidth(
-                   poly, db_rule, check_rect_width)) {
-      // add patch only if poly is rect and its width is less than or equal to
-      // rectWidth value on constraint
-      checkMetalShape_addPatch(pin, min_area);
-    } else if (db_rule->getExceptMinWidth() != 0) {
-      logger_->warn(
-          DRT,
-          311,
-          "Unsupported branch EXCEPTMINWIDTH in PROPERTY LEF58_AREA.");
-    } else if (db_rule->getExceptEdgeLength() != 0
-               || db_rule->getExceptEdgeLengths()
-                      != std::pair<int, int>(0, 0)) {
-      logger_->warn(
-          DRT,
-          312,
-          "Unsupported branch EXCEPTEDGELENGTH in PROPERTY LEF58_AREA.");
-    } else if (db_rule->getExceptMinSize() != std::pair<int, int>(0, 0)) {
-      logger_->warn(
-          DRT, 313, "Unsupported branch EXCEPTMINSIZE in PROPERTY LEF58_AREA.");
-    } else if (db_rule->getExceptStep() != std::pair<int, int>(0, 0)) {
-      logger_->warn(
-          DRT, 314, "Unsupported branch EXCEPTSTEP in PROPERTY LEF58_AREA.");
-    } else if (db_rule->getMask() != 0) {
-      logger_->warn(
-          DRT, 315, "Unsupported branch MASK in PROPERTY LEF58_AREA.");
-    } else if (db_rule->getTrimLayer() != nullptr) {
-      logger_->warn(
-          DRT, 316, "Unsupported branch LAYER in PROPERTY LEF58_AREA.");
-    } else {
-      checkMetalShape_addPatch(pin, min_area);
+      break;
     }
   }
 }
@@ -2207,8 +2168,7 @@ bool FlexGCWorker::Impl::checkMetalShape_lef58Area_exceptRectangle(
 
 bool FlexGCWorker::Impl::checkMetalShape_lef58Area_rectWidth(
     gcPolygon* poly,
-    odb::dbTechLayerAreaRule* db_rule,
-    bool& check_rect_width)
+    odb::dbTechLayerAreaRule* db_rule)
 {
   if (db_rule->getRectWidth() > 0) {
     std::vector<gtl::rectangle_data<frCoord>> rects;
@@ -2223,10 +2183,7 @@ bool FlexGCWorker::Impl::checkMetalShape_lef58Area_rectWidth(
       const auto& rect = rects.back();
       auto xLen = gtl::delta(rect, gtl::HORIZONTAL);
       auto yLen = gtl::delta(rect, gtl::VERTICAL);
-      bool apply_rect_width_area = false;
-      apply_rect_width_area = std::min(xLen, yLen) <= min_width;
-      check_rect_width = !apply_rect_width_area;
-      return apply_rect_width_area;
+      return std::min(xLen, yLen) < min_width;
     }
     return false;
   }
@@ -2952,76 +2909,6 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_adjCut(
     return;
   }
 
-  if (con->hasExactAligned()) {
-    logger_->warn(
-        DRT,
-        45,
-        " Unsupported branch EXACTALIGNED in checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->isExceptSamePGNet()) {
-    logger_->warn(DRT,
-                  46,
-                  " Unsupported branch EXCEPTSAMEPGNET in "
-                  "checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->hasExceptAllWithin()) {
-    logger_->warn(DRT,
-                  47,
-                  " Unsupported branch EXCEPTALLWITHIN in "
-                  "checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->isToAll()) {
-    logger_->warn(
-        DRT,
-        48,
-        " Unsupported branch TO ALL in checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->hasEnclosure()) {
-    logger_->warn(
-        DRT,
-        50,
-        " Unsupported branch ENCLOSURE in checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->isSideParallelOverlap()) {
-    logger_->warn(DRT,
-                  51,
-                  " Unsupported branch SIDEPARALLELOVERLAP in "
-                  "checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-  if (con->isSameMask()) {
-    logger_->warn(
-        DRT,
-        52,
-        " Unsupported branch SAMEMASK in checkLef58CutSpacing_spc_adjCut.");
-    return;
-  }
-
-  // start checking
-  if (con->hasExactAligned()) {
-    ;
-  }
-  if (con->isExceptSamePGNet()) {
-    ;
-  }
-  if (con->hasExceptAllWithin()) {
-    ;
-  }
-  if (con->hasEnclosure()) {
-    ;
-  }
-  if (con->isNoPrl()) {
-    ;
-  }
-  if (con->isSameMask()) {
-    ;
-  }
-
   frSquaredDistance reqSpcValSquare = con->getCutSpacing();
   reqSpcValSquare *= reqSpcValSquare;
 
@@ -3083,75 +2970,8 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
   auto reqSpcVal = con->getCutSpacing();
   frSquaredDistance reqSpcValSquare = (frSquaredDistance) reqSpcVal * reqSpcVal;
 
-  // skip unsupported rule branch
-  if (con->isStack()) {
-    logger_->warn(
-        DRT, 54, "Unsupported branch STACK in checkLef58CutSpacing_spc_layer.");
-    return;
-  }
-  if (con->hasOrthogonalSpacing()) {
-    logger_->warn(DRT,
-                  55,
-                  "Unsupported branch ORTHOGONALSPACING in "
-                  "checkLef58CutSpacing_spc_layer.");
-    return;
-  }
-  if (con->hasCutClass()) {
-    if (con->isShortEdgeOnly()) {
-      logger_->warn(DRT,
-                    56,
-                    "Unsupported branch SHORTEDGEONLY in "
-                    "checkLef58CutSpacing_spc_layer.");
-      return;
-    }
-    if (con->isConcaveCorner()) {
-      if (con->hasWidth()) {
-        logger_->warn(
-            DRT,
-            57,
-            "Unsupported branch WIDTH in checkLef58CutSpacing_spc_layer.");
-      } else if (con->hasParallel()) {
-        logger_->warn(
-            DRT,
-            58,
-            "Unsupported branch PARALLEL in checkLef58CutSpacing_spc_layer.");
-      } else if (con->hasEdgeLength()) {
-        logger_->warn(
-            DRT,
-            59,
-            "Unsupported branch EDGELENGTH in checkLef58CutSpacing_spc_layer.");
-      }
-    } else if (con->hasExtension()) {
-      logger_->warn(
-          DRT,
-          60,
-          "Unsupported branch EXTENSION in checkLef58CutSpacing_spc_layer.");
-    } else if (con->hasNonEolConvexCorner()) {
-      ;
-    } else if (con->hasAboveWidth()) {
-      logger_->warn(
-          DRT,
-          61,
-          "Unsupported branch ABOVEWIDTH in checkLef58CutSpacing_spc_layer.");
-    } else if (con->isMaskOverlap()) {
-      logger_->warn(
-          DRT,
-          62,
-          "Unsupported branch MASKOVERLAP in checkLef58CutSpacing_spc_layer.");
-    } else if (con->isWrongDirection()) {
-      logger_->warn(DRT,
-                    63,
-                    "Unsupported branch WRONGDIRECTION in "
-                    "checkLef58CutSpacing_spc_layer.");
-    }
-  }
-
   // start checking
-  if (con->isStack()) {
-    ;
-  } else if (con->hasOrthogonalSpacing()) {
-    ;
-  } else if (con->hasCutClass()) {
+  if (con->hasCutClass()) {
     auto conCutClassIdx = con->getCutClassIdx();
     auto cutClassIdx = getTech()->getLayer(layerNum)->getCutClassIdx(
         rect1->width(), rect1->length());
@@ -3159,9 +2979,7 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
       return;
     }
 
-    if (con->isShortEdgeOnly()) {
-      ;
-    } else if (con->isConcaveCorner()) {
+    if (con->isConcaveCorner()) {
       // skip if rect2 does not contains rect1
       if (!gtl::contains(*rect2, *rect1)) {
         return;
@@ -3230,8 +3048,6 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
                 corner->isFixed()));
         addMarker(std::move(marker));
       }
-    } else if (con->hasExtension()) {
-      ;
     } else if (con->hasNonEolConvexCorner()) {
       // skip if rect2 does not contains rect1
       if (!gtl::contains(*rect2, *rect1)) {
@@ -3344,12 +3160,6 @@ void FlexGCWorker::Impl::checkLef58CutSpacing_spc_layer(
                 corner->isFixed()));
         addMarker(std::move(marker));
       }
-    } else if (con->hasAboveWidth()) {
-      ;
-    } else if (con->isMaskOverlap()) {
-      ;
-    } else if (con->isWrongDirection()) {
-      ;
     }
   }
 }

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1621,8 +1621,64 @@ void io::Parser::setRoutingLayerProperties(odb::dbTechLayer* layer,
     getTech()->addUConstraint(std::move(con));
   }
   for (auto rule : layer->getTechLayerAreaRules()) {
+    if (rule->getExceptMinWidth() != 0) {
+      logger_->warn(
+          DRT,
+          311,
+          "Unsupported branch EXCEPTMINWIDTH in PROPERTY LEF58_AREA for "
+          "layer {}, skipping rule.",
+          layer->getName());
+      continue;
+    }
+    if (rule->getExceptEdgeLength() != 0
+        || rule->getExceptEdgeLengths() != std::pair<int, int>(0, 0)) {
+      logger_->warn(
+          DRT,
+          312,
+          "Unsupported branch EXCEPTEDGELENGTH in PROPERTY LEF58_AREA for "
+          "layer {}, skipping rule.",
+          layer->getName());
+      continue;
+    }
+    if (rule->getExceptMinSize() != std::pair<int, int>(0, 0)) {
+      logger_->warn(
+          DRT,
+          313,
+          "Unsupported branch EXCEPTMINSIZE in PROPERTY LEF58_AREA for "
+          "layer {}, skipping rule.",
+          layer->getName());
+      continue;
+    }
+    if (rule->getExceptStep() != std::pair<int, int>(0, 0)) {
+      logger_->warn(DRT,
+                    314,
+                    "Unsupported branch EXCEPTSTEP in PROPERTY LEF58_AREA for "
+                    "layer {}, skipping rule.",
+                    layer->getName());
+      continue;
+    }
+    if (rule->getMask() != 0) {
+      logger_->warn(DRT,
+                    315,
+                    "Unsupported branch MASK in PROPERTY LEF58_AREA for "
+                    "layer {}, skipping rule.",
+                    layer->getName());
+      continue;
+    }
+    if (rule->getTrimLayer() != nullptr) {
+      logger_->warn(DRT,
+                    316,
+                    "Unsupported branch LAYER in PROPERTY LEF58_AREA for "
+                    "layer {}, skipping rule.",
+                    layer->getName());
+      continue;
+    }
     auto con = std::make_unique<frLef58AreaConstraint>(rule);
-    tmpLayer->addLef58AreaConstraint(con.get());
+    if (rule->getRectWidth() > 0) {
+      tmpLayer->addLef58AreaConstraintRectWidth(con.get());
+    } else {
+      tmpLayer->addLef58AreaConstraint(con.get());
+    }
     getTech()->addUConstraint(std::move(con));
   }
   for (auto rule : layer->getTechLayerTwoWiresForbiddenSpcRules()) {
@@ -1726,6 +1782,50 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
   for (auto rule : layer->getTechLayerCutSpacingRules()) {
     switch (rule->getType()) {
       case odb::dbTechLayerCutSpacingRule::CutSpacingType::ADJACENTCUTS: {
+        if (rule->isExactAligned()) {
+          logger_->warn(
+              DRT,
+              45,
+              "Unsupported branch EXACTALIGNED in LEF58_SPACING ADJACENTCUTS "
+              "for layer {}, skipping rule.",
+              layer->getName());
+          break;
+        }
+        if (rule->isExceptSamePgnet()) {
+          logger_->warn(DRT,
+                        46,
+                        "Unsupported branch EXCEPTSAMEPGNET in LEF58_SPACING "
+                        "ADJACENTCUTS for layer {}, skipping rule.",
+                        layer->getName());
+          break;
+        }
+        if (rule->isCutClassToAll()) {
+          logger_->warn(
+              DRT,
+              48,
+              "Unsupported branch TO ALL in LEF58_SPACING ADJACENTCUTS "
+              "for layer {}, skipping rule.",
+              layer->getName());
+          break;
+        }
+        if (rule->isSideParallelOverlap()) {
+          logger_->warn(
+              DRT,
+              51,
+              "Unsupported branch SIDEPARALLELOVERLAP in LEF58_SPACING "
+              "ADJACENTCUTS for layer {}, skipping rule.",
+              layer->getName());
+          break;
+        }
+        if (rule->isSameMask()) {
+          logger_->warn(
+              DRT,
+              52,
+              "Unsupported branch SAMEMASK in LEF58_SPACING ADJACENTCUTS "
+              "for layer {}, skipping rule.",
+              layer->getName());
+          break;
+        }
         auto con = std::make_unique<frLef58CutSpacingConstraint>();
         con->setCutSpacing(rule->getCutSpacing());
         con->setCenterToCenter(rule->isCenterToCenter());
@@ -1733,15 +1833,11 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
         con->setSameMetal(rule->isSameMetal());
         con->setSameVia(rule->isSameVia());
         con->setAdjacentCuts(rule->getAdjacentCuts());
-        if (rule->isExactAligned()) {
-          con->setExactAlignedCut(rule->getNumCuts());
-        }
         if (rule->isTwoCutsValid()) {
           con->setTwoCuts(rule->getTwoCuts());
         }
         con->setSameCut(rule->isSameCut());
         con->setCutWithin(rule->getWithin());
-        con->setExceptSamePGNet(rule->isExceptSamePgnet());
         if (rule->getCutClass() != nullptr) {
           std::string className = rule->getCutClass()->getName();
           con->setCutClassName(className);
@@ -1751,11 +1847,8 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
           } else {
             continue;
           }
-          con->setToAll(rule->isCutClassToAll());
         }
         con->setNoPrl(rule->isNoPrl());
-        con->setSideParallelOverlap(rule->isSideParallelOverlap());
-        con->setSameMask(rule->isSameMask());
 
         tmpLayer->addLef58CutSpacingConstraint(con.get());
         getTech()->addUConstraint(std::move(con));
@@ -1776,6 +1869,97 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
                         rule->getSecondLayer()->getName());
           continue;
         }
+        if (rule->isStack()) {
+          logger_->warn(DRT,
+                        54,
+                        "Unsupported branch STACK in LEF58_SPACING LAYER "
+                        "for layer {}, skipping rule.",
+                        layer->getName());
+          break;
+        }
+        if (rule->isOrthogonalSpacingValid()) {
+          logger_->warn(
+              DRT,
+              55,
+              "Unsupported branch ORTHOGONALSPACING in LEF58_SPACING LAYER "
+              "for layer {}, skipping rule.",
+              layer->getName());
+          break;
+        }
+        if (rule->getCutClass() != nullptr) {
+          if (rule->isShortEdgeOnly()) {
+            logger_->warn(
+                DRT,
+                56,
+                "Unsupported branch SHORTEDGEONLY in LEF58_SPACING LAYER "
+                "for layer {}, skipping rule.",
+                layer->getName());
+            break;
+          }
+          if (rule->isConcaveCorner()) {
+            if (rule->isConcaveCornerWidth()) {
+              logger_->warn(DRT,
+                            57,
+                            "Unsupported branch WIDTH in LEF58_SPACING LAYER "
+                            "for layer {}, skipping rule.",
+                            layer->getName());
+              break;
+            }
+            if (rule->isConcaveCornerParallel()) {
+              logger_->warn(
+                  DRT,
+                  58,
+                  "Unsupported branch PARALLEL in LEF58_SPACING LAYER "
+                  "for layer {}, skipping rule.",
+                  layer->getName());
+              break;
+            }
+            if (rule->isConcaveCornerEdgeLength()) {
+              logger_->warn(
+                  DRT,
+                  59,
+                  "Unsupported branch EDGELENGTH in LEF58_SPACING LAYER "
+                  "for layer {}, skipping rule.",
+                  layer->getName());
+              break;
+            }
+          }
+          if (rule->isExtensionValid()) {
+            logger_->warn(DRT,
+                          60,
+                          "Unsupported branch EXTENSION in LEF58_SPACING LAYER "
+                          "for layer {}, skipping rule.",
+                          layer->getName());
+            break;
+          }
+          if (rule->isAboveWidthValid()) {
+            logger_->warn(
+                DRT,
+                61,
+                "Unsupported branch ABOVEWIDTH in LEF58_SPACING LAYER "
+                "for layer {}, skipping rule.",
+                layer->getName());
+            break;
+          }
+          if (rule->isMaskOverlap()) {
+            logger_->warn(
+                DRT,
+                62,
+                "Unsupported branch MASKOVERLAP in LEF58_SPACING LAYER "
+                "for layer {}, skipping rule.",
+                layer->getName());
+            break;
+          }
+          if (rule->isWrongDirection()) {
+            logger_->warn(
+                DRT,
+                63,
+                "Unsupported branch WRONGDIRECTION in LEF58_SPACING LAYER "
+                "for layer {}, skipping rule.",
+                layer->getName());
+            break;
+          }
+        }
         auto con = std::make_unique<frLef58CutSpacingConstraint>();
         con->setCutSpacing(rule->getCutSpacing());
         con->setCenterToCenter(rule->isCenterToCenter());
@@ -1783,10 +1967,6 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
         con->setSameMetal(rule->isSameMetal());
         con->setSameVia(rule->isSameVia());
         con->setSecondLayerName(rule->getSecondLayer()->getName());
-        con->setStack(rule->isStack());
-        if (rule->isOrthogonalSpacingValid()) {
-          con->setOrthogonalSpacing(rule->getOrthogonalSpacing());
-        }
         if (rule->getCutClass() != nullptr) {
           std::string className = rule->getCutClass()->getName();
           con->setCutClassName(className);
@@ -1796,41 +1976,16 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
           } else {
             continue;
           }
-          con->setShortEdgeOnly(rule->isShortEdgeOnly());
           if (rule->isPrlValid()) {
             con->setPrl(rule->getPrl());
           }
           con->setConcaveCorner(rule->isConcaveCorner());
-          if (rule->isConcaveCornerWidth()) {
-            con->setWidth(rule->getWidth());
-            con->setEnclosure(rule->getEnclosure());
-            con->setEdgeLength(rule->getEdgeLength());
-          } else if (rule->isConcaveCornerParallel()) {
-            con->setParLength(rule->getParLength());
-            con->setParWithin(rule->getParWithin());
-            con->setEnclosure(rule->getParEnclosure());
-          } else if (rule->isConcaveCornerEdgeLength()) {
-            con->setEdgeLength(rule->getEdgeLength());
-            con->setEdgeEnclosure(rule->getEdgeEnclosure());
-            con->setAdjEnclosure(rule->getAdjEnclosure());
-          }
-          if (rule->isExtensionValid()) {
-            con->setExtension(rule->getExtension());
-          }
           if (rule->isNonEolConvexCorner()) {
             con->setEolWidth(rule->getEolWidth());
             if (rule->isMinLengthValid()) {
               con->setMinLength(rule->getMinLength());
             }
           }
-          if (rule->isAboveWidthValid()) {
-            rule->setWidth(rule->getAboveWidth());
-            if (rule->isAboveWidthEnclosureValid()) {
-              rule->setEnclosure(rule->getAboveEnclosure());
-            }
-          }
-          con->setMaskOverlap(rule->isMaskOverlap());
-          con->setWrongDirection(rule->isWrongDirection());
         }
         tmpLayer->addLef58CutSpacingConstraint(con.get());
         getTech()->addUConstraint(std::move(con));

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -1791,14 +1791,6 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
               layer->getName());
           break;
         }
-        if (rule->isExceptSamePgnet()) {
-          logger_->warn(DRT,
-                        46,
-                        "Unsupported branch EXCEPTSAMEPGNET in LEF58_SPACING "
-                        "ADJACENTCUTS for layer {}, skipping rule.",
-                        layer->getName());
-          break;
-        }
         if (rule->isCutClassToAll()) {
           logger_->warn(
               DRT,


### PR DESCRIPTION
## Summary
Support EXCEPTSAMEPGNET branch in LEF58_SPACING ADJACENTCUTS rule.

## Type of Change
<!-- Delete items that do not apply -->
- New feature

## Impact
None on the current designs

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

