### PR TITLE
UPF: Add -supply option to create_power_domain

### DIFF
--- a/src/upf/include/upf/upf.h
+++ b/src/upf/include/upf/upf.h
@@ -24,6 +24,11 @@ bool update_power_domain(utl::Logger* logger,
                          const std::string& name,
                          const std::string& element);
 
+bool update_power_domain_supply(utl::Logger* logger,
+                                 odb::dbBlock* block,
+                                 const std::string& name,
+                                 const std::string& supply);
+
 bool create_logic_port(utl::Logger* logger,
                        odb::dbBlock* block,
                        const std::string& name,

--- a/src/upf/src/upf.cpp
+++ b/src/upf/src/upf.cpp
@@ -54,6 +54,23 @@ bool update_power_domain(utl::Logger* logger,
   return true;
 }
 
+static std::unordered_map<std::string, std::string> power_domain_supply_map;
+
+bool update_power_domain_supply(utl::Logger* logger,
+                                odb::dbBlock* block,
+                                const std::string& name,
+                                const std::string& supply)
+{
+  if (odb::dbPowerDomain::create(block, name.c_str()) == nullptr) {
+    logger->warn(utl::UPF, 62,
+                 "Power domain {} not found",
+                 name);
+    return false;
+  }
+  power_domain_supply_map[name] = supply;
+  return true;
+}
+
 bool create_logic_port(utl::Logger* logger,
                        odb::dbBlock* block,
                        const std::string& name,

--- a/src/upf/src/upf.i
+++ b/src/upf/src/upf.i
@@ -30,6 +30,13 @@
         getOpenRoad()->getLogger(), db->getChip()->getBlock(), name, element); 
   }
 
+  void update_power_domain_supply_cmd(const char* name,
+                                    const char* supply)
+  {
+    odb::dbDatabase* db = getOpenRoad()->getDb();
+    update_power_domain_supply(getOpenRoad()->getLogger(),db->getChip()->getBlock(),name,supply);
+  }
+
   void create_logic_port_cmd(const char* name, const char* direction)
   {
     odb::dbDatabase* db = getOpenRoad()->getDb();

--- a/src/upf/src/upf.tcl
+++ b/src/upf/src/upf.tcl
@@ -46,6 +46,38 @@ proc create_power_domain { args } {
   }
 }
 
+sta::define_cmd_args "create_power_domain" { [-elements elements] [-supply supply] name }
+proc create_power_domain { args } {
+  upf::check_block_exists
+
+  sta::parse_key_args "create_power_domain" args \
+    keys {-elements -supply} flags {}
+
+  sta::check_argc_eq1 "create_power_domain" $args
+
+  set domain_name [lindex $args 0]
+  set elements {}
+  set supply ""
+
+  if { [info exists keys(-elements)] } {
+    set elements $keys(-elements)
+  }
+
+  if { [info exists keys(-supply)] } {
+    set supply $keys(-supply)
+  }
+
+  upf::create_power_domain_cmd $domain_name
+
+  foreach {el} $elements {
+    upf::update_power_domain_cmd $domain_name $el
+  }
+
+  if { $supply ne "" } {
+    upf::update_power_domain_supply_cmd $domain_name $supply
+  }
+}
+
 # Create a logic port to be used within defined domains
 #
 # Arguments:


### PR DESCRIPTION
This PR adds support for the `-supply` option in the `create_power_domain` command in the UPF flow.

### Summary
The `create_power_domain` command is extended to accept an optional `-supply` argument, allowing users to associate a supply set with a power domain during creation.Resolving issue #5617 

### Changes
- Updated Tcl interface to parse `-supply` argument in `create_power_domain`
- Added SWIG binding `update_power_domain_supply_cmd`
- Implemented `update_power_domain_supply` in C++ to store the mapping
- Maintained existing design pattern: create → update (no changes to core create function)

### Implementation Details
- Supply information is currently stored in a UPF-layer mapping (`std::unordered_map<std::string, std::string>`) since `dbPowerDomain` does not yet support supply attributes
- This keeps the change non-intrusive and avoids modifying the OpenDB schema

### Example Usage
create_power_domain PD1 -supply ss_GNDD_VDDD

### Notes
- This PR focuses on parsing and storing supply association
- Integration with OpenDB can be extended in future once native support is available

### Impact
- Improves UPF command coverage
- Enables more complete power intent specification in OpenROAD
- Keeps implementation consistent with existing UPF command structure