### PR TITLE
cmake: unset BUILD_GUI when Qt5 is not found

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -153,6 +153,7 @@ messages(
 else()
   if(BUILD_GUI)
     message(STATUS "QT5 not found. GUI is disabled")
+    set(BUILD_GUI OFF CACHE BOOL "Build the GUI" FORCE)
   else()
     message(STATUS "GUI is not enabled")
   endif()


### PR DESCRIPTION
## What does this PR do?
When BUILD_GUI is ON but Qt5 is not found, the build silently falls back to a stub library. However, the top-level CMakeLists.txt still sets the BUILD_GUI=1 compile definition based on the option alone, causing openroad_gui_compiled to return true at runtime even though gui::show was never registered. This leads to "invalid command name gui::show" errors in batch mode.

Fix by unsetting BUILD_GUI in the cache when Qt5 is not found, so the compile definition correctly reflects the actual build state.

Resolves The-OpenROAD-Project/OpenROAD-flow-scripts#4134

## Type of Change
- Bug fix
- Breaking change
- Refactoring

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**


