### PR TITLE
drt: suppress DRT-0349 warning on PDKs without CUTCLASS support

### DIFF
--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -2061,11 +2061,13 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
       continue;
     }
     if (!rule->isCutClassValid()) {
-      logger_->warn(DRT,
-                    349,
-                    "LEF58_ENCLOSURE with no CUTCLASS is not supported. "
-                    "Skipping for layer {}",
-                    layer->getName());
+      if (!layer->getTechLayerCutClassRules().empty()) {
+        logger_->warn(DRT,
+                      349,
+                      "LEF58_ENCLOSURE with no CUTCLASS is not supported. "
+                      "Skipping for layer {}",
+                      layer->getName());
+      }
       continue;
     }
     std::unique_ptr<frConstraint> uCon

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -2127,11 +2127,14 @@ void io::Parser::setCutLayerProperties(odb::dbTechLayer* layer,
       continue;
     }
     if (!rule->isCutClassValid()) {
-      logger_->warn(DRT,
-                    349,
-                    "LEF58_ENCLOSURE with no CUTCLASS is not supported. "
-                    "Skipping for layer {}",
-                    layer->getName());
+      if (!layer->getTechLayerCutClassRules().empty()) {
+        logger_->warn(DRT,
+                      349,
+                      "LEF58_ENCLOSURE without CUTCLASS qualifier is not "
+                      "supported on layer {} which defines CUTCLASS rules; "
+                      "skipping this rule.",
+                      layer->getName());
+      }
       continue;
     }
     std::unique_ptr<frConstraint> uCon

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -11,6 +11,7 @@ load("//test:regression.bzl", "doc_check_test", "regression_rule_test", "regress
 package(features = ["layering_check"])
 
 COMPULSORY_TESTS = [
+    "cutclass_enclosure",
     "down_access_term",
     "drc_test",
     "ispd18_sample",

--- a/src/drt/test/CMakeLists.txt
+++ b/src/drt/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 or_integration_tests(
   "drt"
   TESTS
+    cutclass_enclosure
     down_access_term
     drc_test
     ispd18_sample

--- a/src/drt/test/cutclass_enclosure.ok
+++ b/src/drt/test/cutclass_enclosure.ok
@@ -1,10 +1,12 @@
-[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
-[INFO ODB-0227] LEF file: sky130hd/sky130hd_std_cell.lef, created 437 library cells
+[INFO ODB-0227] LEF file: sky130hs/sky130hs.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hs/sky130hs_std_cell.lef, created 390 library cells
 [INFO ODB-0128] Design: gcd
 [INFO ODB-0130]     Created 1 pins.
-[INFO ODB-0131]     Created 66 components and 347 component-terminals.
-[INFO ODB-0133]     Created 8 nets and 54 connections.
+[INFO ODB-0131]     Created 4 components and 24 component-terminals.
+[INFO ODB-0133]     Created 1 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
+[WARNING DRT-0349] LEF58_ENCLOSURE without CUTCLASS qualifier is not supported on layer mcon which defines CUTCLASS rules; skipping this rule.
+[WARNING DRT-0349] LEF58_ENCLOSURE without CUTCLASS qualifier is not supported on layer mcon which defines CUTCLASS rules; skipping this rule.
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR
@@ -17,30 +19,29 @@
 [INFO DRT-0168] Init region query.
 [INFO DRT-0033] FR_MASTERSLICE shape region query size = 0.
 [INFO DRT-0033] FR_VIA shape region query size = 0.
-[INFO DRT-0033] li1 shape region query size = 2928.
-[INFO DRT-0033] mcon shape region query size = 210.
-[INFO DRT-0033] met1 shape region query size = 412.
+[INFO DRT-0033] li1 shape region query size = 56.
+[INFO DRT-0033] mcon shape region query size = 32.
+[INFO DRT-0033] met1 shape region query size = 17.
 [INFO DRT-0033] via shape region query size = 0.
-[INFO DRT-0033] met2 shape region query size = 1.
+[INFO DRT-0033] met2 shape region query size = 0.
 [INFO DRT-0033] via2 shape region query size = 0.
 [INFO DRT-0033] met3 shape region query size = 0.
 [INFO DRT-0033] via3 shape region query size = 0.
 [INFO DRT-0033] met4 shape region query size = 0.
 [INFO DRT-0033] via4 shape region query size = 0.
-[INFO DRT-0033] met5 shape region query size = 0.
+[INFO DRT-0033] met5 shape region query size = 1.
 [INFO DRT-0178] Init guide query.
 [INFO DRT-0036] FR_MASTERSLICE guide region query size = 0.
 [INFO DRT-0036] FR_VIA guide region query size = 0.
-[INFO DRT-0036] li1 guide region query size = 51.
+[INFO DRT-0036] li1 guide region query size = 4.
 [INFO DRT-0036] mcon guide region query size = 0.
-[INFO DRT-0036] met1 guide region query size = 56.
+[INFO DRT-0036] met1 guide region query size = 3.
 [INFO DRT-0036] via guide region query size = 0.
-[INFO DRT-0036] met2 guide region query size = 32.
+[INFO DRT-0036] met2 guide region query size = 2.
 [INFO DRT-0036] via2 guide region query size = 0.
-[INFO DRT-0036] met3 guide region query size = 0.
+[INFO DRT-0036] met3 guide region query size = 1.
 [INFO DRT-0036] via3 guide region query size = 0.
-[INFO DRT-0036] met4 guide region query size = 0.
+[INFO DRT-0036] met4 guide region query size = 1.
 [INFO DRT-0036] via4 guide region query size = 0.
-[INFO DRT-0036] met5 guide region query size = 0.
+[INFO DRT-0036] met5 guide region query size = 1.
 [INFO DRT-0179] Init gr pin query.
-No differences found.

--- a/src/drt/test/cutclass_enclosure.tcl
+++ b/src/drt/test/cutclass_enclosure.tcl
@@ -1,0 +1,19 @@
+# Test DRT-0349: LEF58_ENCLOSURE without CUTCLASS qualifier on a layer
+# that defines CUTCLASS rules should warn, not silently skip.
+source "helpers.tcl"
+read_lef "sky130hs/sky130hs.tlef"
+read_lef "sky130hs/sky130hs_std_cell.lef"
+read_def "obstruction.def"
+read_guides "obstruction.guide"
+
+# Add a CUTCLASS rule to mcon via ODB API.
+# The existing plain ENCLOSURE rules on mcon (from sky130hs.tlef)
+# lack a CUTCLASS qualifier, which should trigger DRT-0349.
+set tech [ord::get_db_tech]
+set mcon [$tech findLayer mcon]
+odb::dbTechLayerCutClassRule_create $mcon VA
+set cut_class [$mcon findTechLayerCutClassRule VA]
+$cut_class setWidth 170
+
+set_routing_layers -signal met1-met5
+detailed_route -verbose 0

--- a/src/drt/test/down_access_term.ok
+++ b/src/drt/test/down_access_term.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/ndr_vias1.ok
+++ b/src/drt/test/ndr_vias1.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 66 components and 347 component-terminals.
 [INFO ODB-0133]     Created 8 nets and 54 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/ndr_vias2.ok
+++ b/src/drt/test/ndr_vias2.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 66 components and 347 component-terminals.
 [INFO ODB-0133]     Created 8 nets and 54 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/ndr_vias3.ok
+++ b/src/drt/test/ndr_vias3.ok
@@ -11,16 +11,6 @@
 [WARNING ODB-1003] (met3) layer's width from (NDR_3W_3S) NDR is not defined. Using the default value 0.3
 [WARNING ODB-1003] (met4) layer's width from (NDR_3W_3S) NDR is not defined. Using the default value 0.3
 [WARNING ODB-1003] (met5) layer's width from (NDR_3W_3S) NDR is not defined. Using the default value 1.6
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/obstruction.ok
+++ b/src/drt/test/obstruction.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/top_level_term.ok
+++ b/src/drt/test/top_level_term.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/top_level_term2.ok
+++ b/src/drt/test/top_level_term2.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 4 components and 24 component-terminals.
 [INFO ODB-0133]     Created 1 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/drt/test/via_access_layer.ok
+++ b/src/drt/test/via_access_layer.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 4 components and 12 component-terminals.
 [INFO ODB-0133]     Created 2 nets and 4 connections.
 [WARNING GRT-0008] The read_guides command does not allow parasitics estimation from the guides file.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via3
     default via: M3M4_PR

--- a/src/grt/test/pin_access1.ok
+++ b/src/grt/test/pin_access1.ok
@@ -4,16 +4,6 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 170 components and 1258 component-terminals.
 [INFO ODB-0133]     Created 15 nets and 72 connections.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/grt/test/pin_access1_cugr.ok
+++ b/src/grt/test/pin_access1_cugr.ok
@@ -4,16 +4,6 @@
 [INFO ODB-0130]     Created 1 pins.
 [INFO ODB-0131]     Created 170 components and 1258 component-terminals.
 [INFO ODB-0133]     Created 15 nets and 72 connections.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/grt/test/pin_access2.ok
+++ b/src/grt/test/pin_access2.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 1360 components and 6650 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 411 nets and 1210 connections.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/grt/test/pin_access2_cugr.ok
+++ b/src/grt/test/pin_access2_cugr.ok
@@ -5,16 +5,6 @@
 [INFO ODB-0131]     Created 1360 components and 6650 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 0 connections.
 [INFO ODB-0133]     Created 411 nets and 1210 connections.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/ram/test/make_8x8_sky130.ok
+++ b/src/ram/test/make_8x8_sky130.ok
@@ -19,16 +19,6 @@
 [INFO PPL-0008] Successfully assigned pins to sections.
 [INFO PPL-0012] I/O nets HPWL: 330.99 um.
 [INFO DPL-0001] Placed 48 filler instances.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR

--- a/src/ram/test/make_8x8_sky130.ok
+++ b/src/ram/test/make_8x8_sky130.ok
@@ -17,16 +17,6 @@
 [INFO PPL-0008] Successfully assigned pins to sections.
 [INFO PPL-0012] I/O nets HPWL: 331.91 um.
 [INFO DPL-0001] Placed 48 filler instances.
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer mcon
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via2
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via3
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
-[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer via4
 [INFO DRT-0167] List of default vias:
   Layer via
     default via: M1M2_PR


### PR DESCRIPTION
## Summary
LEF58_ENCLOSURE rules without a CUTCLASS are skipped regardless, but the warning was firing unconditionally. On PDKs that define no cut classes at all, the warning is expected and not actionable. Guard it so it only fires when the layer actually has cut class rules defined.

## Type of Change
- Bug fix

## Impact
No

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

