### PR TITLE
dft: implement scan_opt using the 2-Opt algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build
 build_linux
 build_mac
 test/results
+/sandbox
 
 docs/main
 README2.md

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ build
 build_linux
 build_mac
 test/results
-/sandbox
 
 docs/main
 README2.md

--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -337,7 +337,7 @@ proc global_connect { args } {
     keys {} \
     flags {-force -verbose}
 
-  sta::check_argc_eq0 "add_global_connection" $args
+  sta::check_argc_eq0 "global_connect" $args
   [ord::get_db_block] globalConnect [info exists flags(-force)] [info exists flags(-verbose)]
 }
 

--- a/src/OpenRoad.tcl
+++ b/src/OpenRoad.tcl
@@ -354,7 +354,7 @@ proc global_connect { args } {
     keys {} \
     flags {-force -verbose}
 
-  sta::check_argc_eq0 "add_global_connection" $args
+  sta::check_argc_eq0 "global_connect" $args
   [ord::get_db_block] globalConnect [info exists flags(-force)] [info exists flags(-verbose)]
 }
 

--- a/src/dft/include/dft/Dft.hh
+++ b/src/dft/include/dft/Dft.hh
@@ -97,6 +97,8 @@ class Dft
   // Resets the internal state
   void reset();
 
+  void writeToOdb();
+
   // Common function to perform scan replace and scan architect. Shared between
   // report_dft_plan and execute_dft_plan
   std::vector<std::unique_ptr<ScanChain>> scanArchitect();
@@ -109,6 +111,7 @@ class Dft
   // Internal state
   std::unique_ptr<ScanReplace> scan_replace_;
   std::unique_ptr<DftConfig> dft_config_;
+  std::vector<std::unique_ptr<ScanChain>> scan_chains_;
 };
 
 }  // namespace dft

--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -11,6 +11,7 @@
 
 #include "ClockDomain.hh"
 #include "DftConfig.hh"
+#include "Opt.hh"
 #include "ScanArchitect.hh"
 #include "ScanArchitectConfig.hh"
 #include "ScanCell.hh"
@@ -84,21 +85,15 @@ void Dft::scanReplace()
   scan_replace_->scanReplace();
 }
 
-void Dft::executeDftPlan()
+void Dft::writeToOdb()
 {
-  if (need_to_run_pre_dft_) {
-    pre_dft();
-  }
-  std::vector<std::unique_ptr<ScanChain>> scan_chains = scanArchitect();
-
-  ScanStitch stitch(db_, logger_, dft_config_->getScanStitchConfig());
-  stitch.Stitch(scan_chains);
-
   // Write scan chains to odb
   odb::dbBlock* db_block = db_->getChip()->getBlock();
   odb::dbDft* db_dft = db_block->getDft();
 
-  for (const auto& chain : scan_chains) {
+  db_dft->reset();
+
+  for (const auto& chain : scan_chains_) {
     odb::dbScanChain* db_sc = odb::dbScanChain::create(db_dft);
     db_sc->setName(chain->getName());
     odb::dbScanPartition* db_part = odb::dbScanPartition::create(db_sc);
@@ -148,6 +143,22 @@ void Dft::executeDftPlan()
                  sc_out_load.value().getValue());
     }
   }
+
+  db_dft->setScanInserted(true);
+}
+
+void Dft::executeDftPlan()
+{
+  if (need_to_run_pre_dft_) {
+    pre_dft();
+  }
+
+  scan_chains_ = scanArchitect();
+
+  ScanStitch stitch(db_, logger_, dft_config_->getScanStitchConfig());
+  stitch.Stitch(scan_chains_);
+
+  writeToOdb();
 }
 
 DftConfig* Dft::getMutableDftConfig()
@@ -189,7 +200,107 @@ std::vector<std::unique_ptr<ScanChain>> Dft::scanArchitect()
 
 void Dft::scanOpt()
 {
-  logger_->warn(utl::DFT, 14, "Scan Opt is not currently implemented");
+  for (const auto& chain : scan_chains_) {
+    auto src_pin = chain->getScanIn();
+    auto sink_pin = chain->getScanOut();
+    int src_x, src_y, sink_x, sink_y;
+    if (!src_pin.has_value() || !src_pin->getLocation(src_x, src_y)
+        || !sink_pin.has_value() || !sink_pin->getLocation(sink_x, sink_y)) {
+      logger_->warn(utl::DFT,
+                    14,
+                    "Cannot optimize: source/sink pins don't exist or have no "
+                    "placement.");
+      return;
+    }
+
+    odb::Point src = odb::Point(src_x, src_y);
+    odb::Point sink = odb::Point(sink_x, sink_y);
+
+    int64_t twl_internal = chain->estimateInternalTWL();
+    int64_t twl = twl_internal;
+    const auto& scan_cells = chain->getScanCells();
+    if (scan_cells.size() > 0) {
+      twl += odb::Point::manhattanDistance(src, scan_cells[0]->getOrigin());
+      twl += odb::Point::manhattanDistance(
+          scan_cells[scan_cells.size() - 1]->getOrigin(), sink);
+    }
+    logger_->info(utl::DFT,
+                  15,
+                  "Starting 2-Opt with initial total chain wire length {}",
+                  twl);
+
+    logger_->metric(fmt::format("dft__chain_twl_internal__init__chain:{}",
+                                chain->getName()),
+                    twl_internal);
+    logger_->metric(
+        fmt::format("dft__chain_twl__init__chain:{}", chain->getName()), twl);
+
+    auto twl_opt = chain->sortScanCells(
+        [&](std::vector<std::unique_ptr<ScanCell>>& falling,
+            std::vector<std::unique_ptr<ScanCell>>& rising,
+            std::vector<std::unique_ptr<ScanCell>>& sorted) {
+          sorted.reserve(falling.size() + rising.size());
+          // Sort to reduce wire length
+          odb::Point f_src(src_x, src_y);
+          odb::Point f_sink(sink_x, sink_y);
+          if (rising.size() > 0) {
+            f_sink = rising[0]->getOrigin();
+          }
+          auto falling_wire_length
+              = OptimizeScanWirelength2Opt(f_src, f_sink, falling, logger_);
+
+          odb::Point r_src(src_x, src_y);
+          if (falling.size() > 0) {
+            r_src = falling[falling.size() - 1]->getOrigin();
+          }
+          odb::Point r_sink(sink_x, sink_y);
+          auto rising_wire_length
+              = OptimizeScanWirelength2Opt(r_src, r_sink, rising, logger_);
+
+          int64_t distance_between_falling_and_rising = 0;
+          if (rising.size() > 0 && falling.size() > 0) {
+            distance_between_falling_and_rising = odb::Point::manhattanDistance(
+                falling[falling.size() - 1]->getOrigin(),
+                rising[0]->getOrigin());
+          }
+
+          std::ranges::move(falling, std::back_inserter(sorted));
+          std::ranges::move(rising, std::back_inserter(sorted));
+
+          // distance between falling and rising is double-counted by both
+          // optimization algorithms
+          return falling_wire_length + rising_wire_length
+                 - distance_between_falling_and_rising;
+        });
+
+    logger_->info(utl::DFT,
+                  16,
+                  "Concluded 2-Opt with total chain wire length {}.",
+                  twl_opt);
+
+    int64_t twl_internal_opt = chain->estimateInternalTWL();
+    logger_->metric(fmt::format("dft__chain_twl_internal__post_opt__chain:{}",
+                                chain->getName()),
+                    twl_internal_opt);
+
+    const auto& scan_cells_opt = chain->getScanCells();
+    int64_t twl_opt_confirm = twl_internal_opt;
+    if (scan_cells_opt.size() > 0) {
+      twl_opt_confirm
+          += odb::Point::manhattanDistance(src, scan_cells_opt[0]->getOrigin());
+      twl_opt_confirm += odb::Point::manhattanDistance(
+          scan_cells_opt[scan_cells_opt.size() - 1]->getOrigin(), sink);
+    }
+    assert(twl_opt == twl_opt_confirm);
+
+    logger_->metric(
+        fmt::format("dft__chain_twl__post_opt__chain:{}", chain->getName()),
+        twl_opt);
+  }
+
+  ScanStitch stitch(db_, logger_, dft_config_->getScanStitchConfig());
+  stitch.Stitch(scan_chains_);
+  writeToOdb();
 }
 
 }  // namespace dft

--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -205,6 +205,8 @@ std::vector<std::unique_ptr<ScanChain>> Dft::scanArchitect()
 
 void Dft::scanOpt()
 {
+  odb::dbBlock* db_block = db_->getChip()->getBlock();
+
   for (const auto& chain : scan_chains_) {
     auto src_pin = chain->getScanIn();
     auto sink_pin = chain->getScanOut();
@@ -231,14 +233,15 @@ void Dft::scanOpt()
     }
     logger_->info(utl::DFT,
                   15,
-                  "Starting 2-Opt with initial total chain wire length {}",
-                  twl);
+                  "Starting 2-Opt with initial total chain wire length {}um",
+                  db_block->dbuToMicrons(twl));
 
     logger_->metric(fmt::format("dft__chain_twl_internal__init__chain:{}",
                                 chain->getName()),
-                    twl_internal);
+                    db_block->dbuToMicrons(twl));
     logger_->metric(
-        fmt::format("dft__chain_twl__init__chain:{}", chain->getName()), twl);
+        fmt::format("dft__chain_twl__init__chain:{}", chain->getName()),
+        db_block->dbuToMicrons(twl));
 
     auto twl_opt = chain->sortScanCells(
         [&](std::vector<std::unique_ptr<ScanCell>>& falling,
@@ -280,13 +283,13 @@ void Dft::scanOpt()
 
     logger_->info(utl::DFT,
                   16,
-                  "Concluded 2-Opt with total chain wire length {}.",
-                  twl_opt);
+                  "Concluded 2-Opt with total chain wire length {}um.",
+                  db_block->dbuToMicrons(twl_opt));
 
     int64_t twl_internal_opt = chain->estimateInternalTotalWireLength();
     logger_->metric(fmt::format("dft__chain_twl_internal__post_opt__chain:{}",
                                 chain->getName()),
-                    twl_internal_opt);
+                    db_block->dbuToMicrons(twl_internal_opt));
 
     const auto& scan_cells_opt = chain->getScanCells();
     int64_t twl_opt_confirm = twl_internal_opt;
@@ -300,7 +303,7 @@ void Dft::scanOpt()
 
     logger_->metric(
         fmt::format("dft__chain_twl__post_opt__chain:{}", chain->getName()),
-        twl_opt);
+        db_block->dbuToMicrons(twl_opt));
   }
 
   ScanStitch stitch(db_, logger_, dft_config_->getScanStitchConfig());

--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -3,6 +3,10 @@
 
 #include "dft/Dft.hh"
 
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <iterator>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -23,6 +27,7 @@
 #include "boost/property_tree/ptree.hpp"
 #include "db_sta/dbSta.hh"
 #include "odb/db.h"
+#include "odb/geom.h"
 #include "utl/Logger.h"
 
 namespace {
@@ -210,16 +215,16 @@ void Dft::scanOpt()
                     14,
                     "Cannot optimize: source/sink pins don't exist or have no "
                     "placement.");
-      return;
+      continue;
     }
 
     odb::Point src = odb::Point(src_x, src_y);
     odb::Point sink = odb::Point(sink_x, sink_y);
 
-    int64_t twl_internal = chain->estimateInternalTWL();
+    int64_t twl_internal = chain->estimateInternalTotalWireLength();
     int64_t twl = twl_internal;
     const auto& scan_cells = chain->getScanCells();
-    if (scan_cells.size() > 0) {
+    if (!scan_cells.empty()) {
       twl += odb::Point::manhattanDistance(src, scan_cells[0]->getOrigin());
       twl += odb::Point::manhattanDistance(
           scan_cells[scan_cells.size() - 1]->getOrigin(), sink);
@@ -243,14 +248,14 @@ void Dft::scanOpt()
           // Sort to reduce wire length
           odb::Point f_src(src_x, src_y);
           odb::Point f_sink(sink_x, sink_y);
-          if (rising.size() > 0) {
+          if (!rising.empty()) {
             f_sink = rising[0]->getOrigin();
           }
           auto falling_wire_length
               = OptimizeScanWirelength2Opt(f_src, f_sink, falling, logger_);
 
           odb::Point r_src(src_x, src_y);
-          if (falling.size() > 0) {
+          if (!falling.empty()) {
             r_src = falling[falling.size() - 1]->getOrigin();
           }
           odb::Point r_sink(sink_x, sink_y);
@@ -258,7 +263,7 @@ void Dft::scanOpt()
               = OptimizeScanWirelength2Opt(r_src, r_sink, rising, logger_);
 
           int64_t distance_between_falling_and_rising = 0;
-          if (rising.size() > 0 && falling.size() > 0) {
+          if (!rising.empty() && !falling.empty()) {
             distance_between_falling_and_rising = odb::Point::manhattanDistance(
                 falling[falling.size() - 1]->getOrigin(),
                 rising[0]->getOrigin());
@@ -278,14 +283,14 @@ void Dft::scanOpt()
                   "Concluded 2-Opt with total chain wire length {}.",
                   twl_opt);
 
-    int64_t twl_internal_opt = chain->estimateInternalTWL();
+    int64_t twl_internal_opt = chain->estimateInternalTotalWireLength();
     logger_->metric(fmt::format("dft__chain_twl_internal__post_opt__chain:{}",
                                 chain->getName()),
                     twl_internal_opt);
 
     const auto& scan_cells_opt = chain->getScanCells();
     int64_t twl_opt_confirm = twl_internal_opt;
-    if (scan_cells_opt.size() > 0) {
+    if (!scan_cells_opt.empty()) {
       twl_opt_confirm
           += odb::Point::manhattanDistance(src, scan_cells_opt[0]->getOrigin());
       twl_opt_confirm += odb::Point::manhattanDistance(

--- a/src/dft/src/Dft.cpp
+++ b/src/dft/src/Dft.cpp
@@ -96,7 +96,13 @@ void Dft::writeToOdb()
   odb::dbBlock* db_block = db_->getChip()->getBlock();
   odb::dbDft* db_dft = db_block->getDft();
 
-  db_dft->reset();
+  // Remove all existing scan-chains and pins from database
+  for (auto chain : db_dft->getScanChains()) {
+    odb::dbScanChain::destroy(chain);
+  }
+  for (auto pin : db_dft->getScanPins()) {
+    odb::dbScanPin::destroy(pin);
+  }
 
   for (const auto& chain : scan_chains_) {
     odb::dbScanChain* db_sc = odb::dbScanChain::create(db_dft);

--- a/src/dft/src/architect/BUILD
+++ b/src/dft/src/architect/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//src/dft/src/clock_domain",
         "//src/dft/src/config",
         "//src/dft/src/utils",
+        "//src/odb/src/db",
         "//src/utl",
         "@boost.geometry",
     ],

--- a/src/dft/src/architect/Opt.cpp
+++ b/src/dft/src/architect/Opt.cpp
@@ -3,6 +3,7 @@
 
 #include "Opt.hh"
 
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -14,8 +15,7 @@
 #include "ScanCell.hh"
 #include "boost/geometry/geometries/register/point.hpp"
 #include "boost/geometry/geometry.hpp"
-#include "boost/geometry/index/rtree.hpp"
-#include "utl/Logger.h"
+#include "odb/geom.h"
 
 namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
@@ -28,17 +28,17 @@ namespace {
 constexpr int kMaxCellsToSearch = 10;
 }  // namespace
 
-void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
-                            utl::Logger* logger)
+int64_t OptimizeScanWirelengthNN(std::vector<std::unique_ptr<ScanCell>>& cells,
+                                 utl::Logger* logger)
 {
   // Nothing to order
   if (cells.empty()) {
-    return;
+    return 0;
   }
   // No point running this if the cells aren't placed yet
   for (const auto& cell : cells) {
     if (!cell->isPlaced()) {
-      return;
+      return 0;
     }
   }
   // Define the starting node as the lower leftmost, so we don't accidentally
@@ -68,6 +68,7 @@ void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
   // Search nearest neighbours
   std::vector<std::unique_ptr<ScanCell>> result;
   result.emplace_back(std::move(cells[cursor.second]));
+  int64_t twl = 0;
   while (result.size() < cells.size()) {
     // Search for next nearest
     auto next = cursor;
@@ -85,6 +86,10 @@ void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
           10,
           "Couldn't find nearest neighbor, too many overlapping cells");
     }
+    twl += std::llabs(boost::geometry::get<0>(cursor.first)
+                      - boost::geometry::get<0>(next.first))
+           + std::llabs(boost::geometry::get<1>(cursor.first)
+                        - boost::geometry::get<1>(next.first));
     // Make sure we only visit things once
     rtree.remove(cursor);
     cursor = std::move(next);
@@ -92,6 +97,102 @@ void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
   }
   // Replace with sorted vector
   std::swap(cells, result);
+
+  return twl;
+}
+
+int64_t OptimizeScanWirelength2Opt(
+    const odb::Point source,
+    const odb::Point sink,
+    std::vector<std::unique_ptr<ScanCell>>& cells,
+    utl::Logger* logger,
+    size_t max_iters)
+{
+  // Nothing to order
+  if (cells.empty()) {
+    return 0;
+  }
+
+  size_t N = cells.size() + 2;
+
+  std::vector<odb::Point> points(N);
+  size_t i = -1;
+  points[++i] = source;
+
+  int64_t score = 0;
+  odb::Point last = points[i];
+  for (const auto& cell : cells) {
+    if (!cell->isPlaced()) {
+      // No point running this if the cells aren't placed yet
+      return 0;
+    }
+
+    points[++i] = cell->getOrigin();
+    score += odb::Point::manhattanDistance(last, points[i]);
+    last = points[i];
+  }
+  points[++i] = sink;
+  score += odb::Point::manhattanDistance(last, sink);
+  assert(++i == N);
+
+  int64_t best_score = score;
+
+  // Already "optimal" (unplaced)
+  if (best_score == 0) {
+    return 0;
+  }
+
+  size_t iters = 0;
+  bool improved_last_iter = true;
+  while (improved_last_iter && iters < max_iters) {
+    iters += 1;
+    debugPrint(logger,
+               utl::DFT,
+               "2opt",
+               1,
+               "Starting iteration {} (TWL: {})...",
+               iters,
+               best_score);
+    improved_last_iter = false;
+    for (size_t i = 0; i < N - 2; i += 1) {
+      for (size_t j = i + 2; j < N - 1; j += 1) {
+        auto&& x = points[i];
+        auto&& y = points[j];
+        auto&& u = points[i + 1];
+        auto&& v = points[j + 1];
+        auto score_d = -odb::Point::manhattanDistance(x, u)
+                       - odb::Point::manhattanDistance(y, v)
+                       + odb::Point::manhattanDistance(x, y)
+                       + odb::Point::manhattanDistance(u, v);
+        if (score_d < 0) {
+          improved_last_iter = true;
+          best_score += score_d;
+          for (size_t k = 0; k < (j - i) / 2; k += 1) {
+            std::swap(points[i + 1 + k], points[j - k]);
+            std::swap(cells[i + k], cells[j - k - 1]);
+          }
+        }
+      }
+    }
+  }
+
+  if (improved_last_iter) {
+    debugPrint(logger,
+               utl::DFT,
+               "2opt",
+               1,
+               "Stopping because the max iteration count ({}) was reached.",
+               iters);
+  } else {
+    debugPrint(logger,
+               utl::DFT,
+               "2opt",
+               1,
+               "Stopping after {} iterations because of a lack of improvement.",
+               iters);
+  }
+
+  return best_score;
 }
 
 }  // namespace dft

--- a/src/dft/src/architect/Opt.cpp
+++ b/src/dft/src/architect/Opt.cpp
@@ -117,7 +117,7 @@ int64_t OptimizeScanWirelength2Opt(
 
   std::vector<odb::Point> points(node_count);
   size_t i = 0;
-  points[i++] = source;
+  points[i] = source;
 
   int64_t score = 0;
   odb::Point last = points[i];

--- a/src/dft/src/architect/Opt.cpp
+++ b/src/dft/src/architect/Opt.cpp
@@ -3,9 +3,8 @@
 
 #include "Opt.hh"
 
-#include <cinttypes>
-#include <cstddef>
-#include <cstdint>
+#include <cassert>
+#include <cstdlib>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -16,6 +15,7 @@
 #include "boost/geometry/geometries/register/point.hpp"
 #include "boost/geometry/geometry.hpp"
 #include "odb/geom.h"
+#include "utl/Logger.h"
 
 namespace bg = boost::geometry;
 namespace bgi = boost::geometry::index;
@@ -106,18 +106,18 @@ int64_t OptimizeScanWirelength2Opt(
     const odb::Point sink,
     std::vector<std::unique_ptr<ScanCell>>& cells,
     utl::Logger* logger,
-    size_t max_iters)
+    const size_t max_iters)
 {
   // Nothing to order
   if (cells.empty()) {
     return 0;
   }
 
-  size_t N = cells.size() + 2;
+  size_t node_count = cells.size() + 2;
 
-  std::vector<odb::Point> points(N);
-  size_t i = -1;
-  points[++i] = source;
+  std::vector<odb::Point> points(node_count);
+  size_t i = 0;
+  points[i++] = source;
 
   int64_t score = 0;
   odb::Point last = points[i];
@@ -133,14 +133,12 @@ int64_t OptimizeScanWirelength2Opt(
   }
   points[++i] = sink;
   score += odb::Point::manhattanDistance(last, sink);
-  assert(++i == N);
+
+  // Awkward but avoid side effect in assert
+  ++i;
+  assert(i == node_count);
 
   int64_t best_score = score;
-
-  // Already "optimal" (unplaced)
-  if (best_score == 0) {
-    return 0;
-  }
 
   size_t iters = 0;
   bool improved_last_iter = true;
@@ -154,8 +152,8 @@ int64_t OptimizeScanWirelength2Opt(
                iters,
                best_score);
     improved_last_iter = false;
-    for (size_t i = 0; i < N - 2; i += 1) {
-      for (size_t j = i + 2; j < N - 1; j += 1) {
+    for (size_t i = 0; i < node_count - 2; i += 1) {
+      for (size_t j = i + 2; j < node_count - 1; j += 1) {
         auto&& x = points[i];
         auto&& y = points[j];
         auto&& u = points[i + 1];

--- a/src/dft/src/architect/Opt.hh
+++ b/src/dft/src/architect/Opt.hh
@@ -13,7 +13,14 @@
 namespace dft {
 
 // Order scan cells to reduce wirelength
-void OptimizeScanWirelength(std::vector<std::unique_ptr<ScanCell>>& cells,
-                            utl::Logger* logger);
+int64_t OptimizeScanWirelengthNN(std::vector<std::unique_ptr<ScanCell>>& cells,
+                                 utl::Logger* logger);
+
+int64_t OptimizeScanWirelength2Opt(
+    const odb::Point source,
+    const odb::Point sink,
+    std::vector<std::unique_ptr<ScanCell>>& cells,
+    utl::Logger* logger,
+    size_t max_iters = 30);
 
 }  // namespace dft

--- a/src/dft/src/architect/Opt.hh
+++ b/src/dft/src/architect/Opt.hh
@@ -3,11 +3,14 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <vector>
 
 #include "ScanArchitect.hh"
 #include "ScanCell.hh"
+#include "odb/geom.h"
 #include "utl/Logger.h"
 
 namespace dft {
@@ -17,8 +20,8 @@ int64_t OptimizeScanWirelengthNN(std::vector<std::unique_ptr<ScanCell>>& cells,
                                  utl::Logger* logger);
 
 int64_t OptimizeScanWirelength2Opt(
-    const odb::Point source,
-    const odb::Point sink,
+    odb::Point source,
+    odb::Point sink,
     std::vector<std::unique_ptr<ScanCell>>& cells,
     utl::Logger* logger,
     size_t max_iters = 30);

--- a/src/dft/src/architect/ScanArchitectHeuristic.cpp
+++ b/src/dft/src/architect/ScanArchitectHeuristic.cpp
@@ -41,18 +41,43 @@ void ScanArchitectHeuristic::architect()
         current_chain->add(std::move(scan_cell));
       }
 
-      current_chain->sortScanCells(
-          [this](std::vector<std::unique_ptr<ScanCell>>& falling,
-                 std::vector<std::unique_ptr<ScanCell>>& rising,
-                 std::vector<std::unique_ptr<ScanCell>>& sorted) {
+      debugPrint(logger_,
+                 utl::DFT,
+                 "scan_architect",
+                 1,
+                 "Starting nearest-neighbor sort for chain {}",
+                 current_chain->getName());
+
+      auto total_wire_length = current_chain->sortScanCells(
+          [&](std::vector<std::unique_ptr<ScanCell>>& falling,
+              std::vector<std::unique_ptr<ScanCell>>& rising,
+              std::vector<std::unique_ptr<ScanCell>>& sorted) {
             sorted.reserve(falling.size() + rising.size());
             // Sort to reduce wire length
-            OptimizeScanWirelength(falling, logger_);
-            OptimizeScanWirelength(rising, logger_);
-            // Falling edge first
+            auto falling_wire_length
+                = OptimizeScanWirelengthNN(falling, logger_);
+            auto rising_wire_length = OptimizeScanWirelengthNN(rising, logger_);
+            int64_t distance_between_falling_and_rising = 0;
+            if (rising.size() && falling.size()) {
+              distance_between_falling_and_rising
+                  = odb::Point::manhattanDistance(
+                      falling[falling.size() - 1]->getOrigin(),
+                      rising[0]->getOrigin());
+            }
+            // Falling edges first
             std::ranges::move(falling, std::back_inserter(sorted));
             std::ranges::move(rising, std::back_inserter(sorted));
+            return falling_wire_length + distance_between_falling_and_rising
+                   + rising_wire_length;
           });
+
+      debugPrint(logger_,
+                 utl::DFT,
+                 "scan_architect",
+                 1,
+                 "Concluded nearest-neighbor sort for chain {} with TWL {}",
+                 current_chain->getName(),
+                 total_wire_length);
     }
   }
 }

--- a/src/dft/src/architect/ScanArchitectHeuristic.cpp
+++ b/src/dft/src/architect/ScanArchitectHeuristic.cpp
@@ -58,7 +58,7 @@ void ScanArchitectHeuristic::architect()
                 = OptimizeScanWirelengthNN(falling, logger_);
             auto rising_wire_length = OptimizeScanWirelengthNN(rising, logger_);
             int64_t distance_between_falling_and_rising = 0;
-            if (rising.size() && falling.size()) {
+            if (!rising.empty() && !falling.empty()) {
               distance_between_falling_and_rising
                   = odb::Point::manhattanDistance(
                       falling[falling.size() - 1]->getOrigin(),

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -46,12 +46,23 @@ uint64_t ScanChain::getBits() const
   return bits_;
 }
 
-void ScanChain::sortScanCells(
-    const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
-                             std::vector<std::unique_ptr<ScanCell>>&,
-                             std::vector<std::unique_ptr<ScanCell>>&)>& sort_fn)
+int64_t ScanChain::sortScanCells(
+    const std::function<int64_t(std::vector<std::unique_ptr<ScanCell>>&,
+                                std::vector<std::unique_ptr<ScanCell>>&,
+                                std::vector<std::unique_ptr<ScanCell>>&)>&
+        sort_fn)
 {
-  sort_fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
+  if (!empty()) {
+    bits_ = 0;
+    for (auto& cell : scan_cells_) {
+      add(std::move(cell));
+    }
+    scan_cells_.clear();
+    scan_cells_.shrink_to_fit();
+  }
+
+  auto total_wire_length
+      = sort_fn(falling_edge_scan_cells_, rising_edge_scan_cells_, scan_cells_);
   // At this point, falling_edge_scan_cells_ and rising_edge_scan_cells_ will be
   // with just null, we clear and reduce the memory of the vectors
 
@@ -60,6 +71,23 @@ void ScanChain::sortScanCells(
 
   falling_edge_scan_cells_.shrink_to_fit();
   rising_edge_scan_cells_.shrink_to_fit();
+
+  return total_wire_length;
+}
+
+int64_t ScanChain::estimateInternalTWL()
+{
+  if (scan_cells_.size() == 0) {
+    return 0;
+  }
+  int64_t twl = 0;
+  auto last = scan_cells_[0]->getOrigin();
+  for (const auto& cell : scan_cells_) {
+    auto current = cell->getOrigin();
+    twl += odb::Point::manhattanDistance(last, current);
+    last = current;
+  }
+  return twl;
 }
 
 const std::vector<std::unique_ptr<ScanCell>>& ScanChain::getScanCells() const

--- a/src/dft/src/architect/ScanChain.cpp
+++ b/src/dft/src/architect/ScanChain.cpp
@@ -75,7 +75,7 @@ int64_t ScanChain::sortScanCells(
   return total_wire_length;
 }
 
-int64_t ScanChain::estimateInternalTWL()
+int64_t ScanChain::estimateInternalTotalWireLength()
 {
   if (scan_cells_.size() == 0) {
     return 0;

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -46,11 +46,13 @@ class ScanChain
 
   // Sorts the scan cells of this chain.  This function has 3 arguments: falling
   // cells, rising cells and the output vector with the sorted cells
-  void sortScanCells(
-      const std::function<void(std::vector<std::unique_ptr<ScanCell>>&,
-                               std::vector<std::unique_ptr<ScanCell>>&,
-                               std::vector<std::unique_ptr<ScanCell>>&)>&
+  int64_t sortScanCells(
+      const std::function<int64_t(std::vector<std::unique_ptr<ScanCell>>&,
+                                  std::vector<std::unique_ptr<ScanCell>>&,
+                                  std::vector<std::unique_ptr<ScanCell>>&)>&
           sort_fn);
+
+  int64_t estimateInternalTWL();
 
   // Returns a reference to a vector containing all the scan cells of the chain
   const std::vector<std::unique_ptr<ScanCell>>& getScanCells() const;

--- a/src/dft/src/architect/ScanChain.hh
+++ b/src/dft/src/architect/ScanChain.hh
@@ -52,7 +52,7 @@ class ScanChain
                                   std::vector<std::unique_ptr<ScanCell>>&)>&
           sort_fn);
 
-  int64_t estimateInternalTWL();
+  int64_t estimateInternalTotalWireLength();
 
   // Returns a reference to a vector containing all the scan cells of the chain
   const std::vector<std::unique_ptr<ScanCell>>& getScanCells() const;

--- a/src/dft/src/config/ScanArchitectConfig.hh
+++ b/src/dft/src/config/ScanArchitectConfig.hh
@@ -22,6 +22,7 @@ class ScanArchitectConfig
   };
 
   void setClockMixing(ClockMixing clock_mixing);
+  ClockMixing getClockMixing() const;
 
   // The max length in bits that a scan chain can have
   void setMaxLength(uint64_t max_length);
@@ -30,8 +31,6 @@ class ScanArchitectConfig
   // The max number of scan chains (per clock in NoMixe mode) to generate
   void setMaxChains(uint64_t max_chains);
   const std::optional<uint64_t>& getMaxChains() const;
-
-  ClockMixing getClockMixing() const;
 
   // Prints using logger->report the config used by Scan Architect
   void report(utl::Logger* logger) const;

--- a/src/dft/src/replace/ScanReplace.hh
+++ b/src/dft/src/replace/ScanReplace.hh
@@ -103,6 +103,8 @@ class ScanReplace
                           odb::dbMaster* master_scan_cell,
                           const std::unique_ptr<ScanCandidate>& scan_candidate);
 
+  void writeToOdb(odb::dbMaster* master);
+
   odb::dbDatabase* db_;
   sta::dbSta* sta_;
   utl::Logger* logger_;

--- a/src/dft/src/utils/ScanPin.cpp
+++ b/src/dft/src/utils/ScanPin.cpp
@@ -18,7 +18,7 @@ odb::dbNet* ScanPin::getNet() const
 {
   return std::visit(
       overloaded{[](odb::dbITerm* iterm) { return iterm->getNet(); },
-                 [](odb::dbBTerm* iterm) { return iterm->getNet(); }},
+                 [](odb::dbBTerm* bterm) { return bterm->getNet(); }},
       value_);
 }
 
@@ -27,13 +27,23 @@ std::string_view ScanPin::getName() const
   return std::visit(
       overloaded{
           [](odb::dbITerm* iterm) { return iterm->getMTerm()->getConstName(); },
-          [](odb::dbBTerm* iterm) { return iterm->getConstName(); }},
+          [](odb::dbBTerm* bterm) { return bterm->getConstName(); }},
       value_);
 }
 
 const std::variant<odb::dbBTerm*, odb::dbITerm*>& ScanPin::getValue() const
 {
   return value_;
+}
+
+bool ScanPin::getLocation(int& x, int& y) const
+{
+  return std::visit(
+      overloaded{[&](odb::dbITerm* iterm) { return iterm->getAvgXY(&x, &y); },
+                 [&](odb::dbBTerm* bterm) {
+                   return bterm->getFirstPinLocation(x, y);
+                 }},
+      value_);
 }
 
 ScanLoad::ScanLoad(std::variant<odb::dbBTerm*, odb::dbITerm*> term)

--- a/src/dft/src/utils/ScanPin.hh
+++ b/src/dft/src/utils/ScanPin.hh
@@ -29,6 +29,7 @@ class ScanPin
   odb::dbNet* getNet() const;
   std::string_view getName() const;
   const std::variant<odb::dbBTerm*, odb::dbITerm*>& getValue() const;
+  bool getLocation(int& x, int& y) const;
 
  protected:
   std::variant<odb::dbBTerm*, odb::dbITerm*> value_;

--- a/src/dft/test/BUILD
+++ b/src/dft/test/BUILD
@@ -18,6 +18,7 @@ COMPULSORY_TESTS = [
     "scan_architect_clock_mix_sky130",
     "scan_architect_no_mix_sky130",
     "scan_architect_register_bank_no_clock_mix_sky130",
+    "scan_opt_sky130",
     "scandef_core_sky130",
     "scandef_sky130",
     "sub_modules_sky130",

--- a/src/dft/test/CMakeLists.txt
+++ b/src/dft/test/CMakeLists.txt
@@ -7,6 +7,7 @@ or_integration_tests(
     scan_architect_clock_mix_sky130
     scan_architect_no_mix_sky130
     scan_architect_register_bank_no_clock_mix_sky130
+    scan_opt_sky130
     scandef_core_sky130
     scandef_sky130
     sub_modules_sky130

--- a/src/dft/test/scan_opt_sky130.def
+++ b/src/dft/test/scan_opt_sky130.def
@@ -1,0 +1,154 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN _4bitadder ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 18800 18800 ) ;
+ROW ROW_0 unithd 0 0 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_1 unithd 0 2720 FS DO 40 BY 1 STEP 460 0 ;
+ROW ROW_2 unithd 0 5440 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_3 unithd 0 8160 FS DO 40 BY 1 STEP 460 0 ;
+ROW ROW_4 unithd 0 10880 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_5 unithd 0 13600 FS DO 40 BY 1 STEP 460 0 ;
+TRACKS X 230 DO 41 STEP 460 LAYER li1 ;
+TRACKS Y 170 DO 55 STEP 340 LAYER li1 ;
+TRACKS X 170 DO 55 STEP 340 LAYER met1 ;
+TRACKS Y 170 DO 55 STEP 340 LAYER met1 ;
+TRACKS X 230 DO 41 STEP 460 LAYER met2 ;
+TRACKS Y 230 DO 41 STEP 460 LAYER met2 ;
+TRACKS X 340 DO 27 STEP 680 LAYER met3 ;
+TRACKS Y 340 DO 27 STEP 680 LAYER met3 ;
+TRACKS X 460 DO 20 STEP 920 LAYER met4 ;
+TRACKS Y 460 DO 20 STEP 920 LAYER met4 ;
+TRACKS X 1700 DO 5 STEP 3400 LAYER met5 ;
+TRACKS Y 1700 DO 5 STEP 3400 LAYER met5 ;
+COMPONENTS 19 ;
+    - _10_ sky130_fd_sc_hd__nand2_2 + PLACED ( 15180 8160 ) FS ;
+    - _11_ sky130_fd_sc_hd__and2_2 + PLACED ( 7820 5440 ) N ;
+    - _12_ sky130_fd_sc_hd__xor2_2 + PLACED ( 9200 8160 ) FS ;
+    - _13_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 11040 5440 ) N ;
+    - _14_ sky130_fd_sc_hd__a31o_2 + PLACED ( 14720 0 ) N ;
+    - _15_ sky130_fd_sc_hd__and2_2 + PLACED ( 0 0 ) N ;
+    - _16_ sky130_fd_sc_hd__or2_2 + PLACED ( 5060 5440 ) N ;
+    - _17_ sky130_fd_sc_hd__nand2b_2 + PLACED ( 1840 5440 ) N ;
+    - _18_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 460 10880 ) N ;
+    - _19_ sky130_fd_sc_hd__a21o_2 + PLACED ( 0 8160 ) FS ;
+    - _20_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 3220 8160 ) FS ;
+    - _21_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 460 2720 ) FS ;
+    - _22_ sky130_fd_sc_hd__or2_2 + PLACED ( 11960 13600 ) FS ;
+    - _23_ sky130_fd_sc_hd__and2_2 + PLACED ( 14260 13600 ) FS ;
+    - _24_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 6440 2720 ) FS ;
+    - _25_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 6440 10880 ) N ;
+    - _26_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 0 13600 ) FS ;
+    - _27_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 2760 0 ) N ;
+    - _28_ sky130_fd_sc_hd__conb_1 + PLACED ( 460 5440 ) N ;
+END COMPONENTS
+PINS 18 ;
+    - a[0] + NET a[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 15870 242 ) N ;
+    - a[1] + NET a[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 9430 242 ) N ;
+    - a[2] + NET a[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 8510 242 ) N ;
+    - a[3] + NET a[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 13110 242 ) N ;
+    - b[0] + NET b[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 10350 242 ) N ;
+    - b[1] + NET b[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 11270 242 ) N ;
+    - b[2] + NET b[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 5750 242 ) N ;
+    - b[3] + NET b[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 4830 242 ) N ;
+    - c[0] + NET c[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 6670 242 ) N ;
+    - c[1] + NET c[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 14950 242 ) N ;
+    - c[2] + NET c[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 7590 242 ) N ;
+    - c[3] + NET c[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 14030 242 ) N ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 3910 242 ) N ;
+    - rstn + NET rstn + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 12190 242 ) N ;
+    - sce + NET sce + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 2070 242 ) N ;
+    - sci + NET sci + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 16790 242 ) N ;
+    - sco + NET sco + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 2990 242 ) N ;
+    - tm + NET tm + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met1 ( -297 -70 ) ( 298 70 )
+        + PLACED ( 18502 1530 ) N ;
+END PINS
+NETS 32 ;
+    - _00_ ( _23_ A ) ( _13_ A ) ( _10_ Y ) + USE SIGNAL ;
+    - _01_ ( _14_ B1 ) ( _11_ X ) + USE SIGNAL ;
+    - _02_ ( _14_ A3 ) ( _13_ B ) ( _12_ X ) + USE SIGNAL ;
+    - _03_ ( _19_ A1 ) ( _18_ A ) ( _14_ X ) + USE SIGNAL ;
+    - _04_ ( _19_ B1 ) ( _17_ A_N ) ( _15_ X ) + USE SIGNAL ;
+    - _05_ ( _19_ A2 ) ( _17_ B ) ( _16_ X ) + USE SIGNAL ;
+    - _06_ ( _18_ B ) ( _17_ Y ) + USE SIGNAL ;
+    - _07_ ( _21_ A ) ( _19_ X ) + USE SIGNAL ;
+    - _08_ ( _21_ B ) ( _20_ Y ) + USE SIGNAL ;
+    - _09_ ( _23_ B ) ( _22_ X ) + USE SIGNAL ;
+    - a[0] ( PIN a[0] ) ( _22_ B ) ( _14_ A2 ) ( _10_ B ) + USE SIGNAL ;
+    - a[1] ( PIN a[1] ) ( _12_ B ) ( _11_ B ) + USE SIGNAL ;
+    - a[2] ( PIN a[2] ) ( _16_ B ) ( _15_ B ) + USE SIGNAL ;
+    - a[3] ( PIN a[3] ) ( _20_ B ) + USE SIGNAL ;
+    - b[0] ( PIN b[0] ) ( _22_ A ) ( _14_ A1 ) ( _10_ A ) + USE SIGNAL ;
+    - b[1] ( PIN b[1] ) ( _12_ A ) ( _11_ A ) + USE SIGNAL ;
+    - b[2] ( PIN b[2] ) ( _16_ A ) ( _15_ A ) + USE SIGNAL ;
+    - b[3] ( PIN b[3] ) ( _20_ A ) + USE SIGNAL ;
+    - c[0] ( PIN c[0] ) ( _24_ Q ) + USE SIGNAL ;
+    - c[1] ( PIN c[1] ) ( _25_ Q ) + USE SIGNAL ;
+    - c[2] ( PIN c[2] ) ( _26_ Q ) + USE SIGNAL ;
+    - c[3] ( PIN c[3] ) ( _27_ Q ) + USE SIGNAL ;
+    - clk ( PIN clk ) ( _27_ CLK ) ( _26_ CLK ) ( _25_ CLK ) ( _24_ CLK ) + USE SIGNAL ;
+    - delay_next\[0\] ( _24_ D ) ( _23_ X ) + USE SIGNAL ;
+    - delay_next\[1\] ( _25_ D ) ( _13_ Y ) + USE SIGNAL ;
+    - delay_next\[2\] ( _26_ D ) ( _18_ Y ) + USE SIGNAL ;
+    - delay_next\[3\] ( _27_ D ) ( _21_ Y ) + USE SIGNAL ;
+    - rstn ( PIN rstn ) ( _27_ RESET_B ) ( _26_ RESET_B ) ( _25_ RESET_B ) ( _24_ RESET_B ) + USE SIGNAL ;
+    - sce ( PIN sce ) + USE SIGNAL ;
+    - sci ( PIN sci ) + USE SIGNAL ;
+    - sco ( PIN sco ) ( _28_ LO ) + USE SIGNAL ;
+    - tm ( PIN tm ) + USE SIGNAL ;
+END NETS
+END DESIGN

--- a/src/dft/test/scan_opt_sky130.defok
+++ b/src/dft/test/scan_opt_sky130.defok
@@ -1,0 +1,169 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN _4bitadder ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 18800 18800 ) ;
+ROW ROW_0 unithd 0 0 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_1 unithd 0 2720 FS DO 40 BY 1 STEP 460 0 ;
+ROW ROW_2 unithd 0 5440 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_3 unithd 0 8160 FS DO 40 BY 1 STEP 460 0 ;
+ROW ROW_4 unithd 0 10880 N DO 40 BY 1 STEP 460 0 ;
+ROW ROW_5 unithd 0 13600 FS DO 40 BY 1 STEP 460 0 ;
+TRACKS X 230 DO 41 STEP 460 LAYER li1 ;
+TRACKS Y 170 DO 55 STEP 340 LAYER li1 ;
+TRACKS X 170 DO 55 STEP 340 LAYER met1 ;
+TRACKS Y 170 DO 55 STEP 340 LAYER met1 ;
+TRACKS X 230 DO 41 STEP 460 LAYER met2 ;
+TRACKS Y 230 DO 41 STEP 460 LAYER met2 ;
+TRACKS X 340 DO 27 STEP 680 LAYER met3 ;
+TRACKS Y 340 DO 27 STEP 680 LAYER met3 ;
+TRACKS X 460 DO 20 STEP 920 LAYER met4 ;
+TRACKS Y 460 DO 20 STEP 920 LAYER met4 ;
+TRACKS X 1700 DO 5 STEP 3400 LAYER met5 ;
+TRACKS Y 1700 DO 5 STEP 3400 LAYER met5 ;
+COMPONENTS 19 ;
+    - _10_ sky130_fd_sc_hd__nand2_2 + PLACED ( 15180 8160 ) FS ;
+    - _11_ sky130_fd_sc_hd__and2_2 + PLACED ( 7820 5440 ) N ;
+    - _12_ sky130_fd_sc_hd__xor2_2 + PLACED ( 9200 8160 ) FS ;
+    - _13_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 11040 5440 ) N ;
+    - _14_ sky130_fd_sc_hd__a31o_2 + PLACED ( 14720 0 ) N ;
+    - _15_ sky130_fd_sc_hd__and2_2 + PLACED ( 0 0 ) N ;
+    - _16_ sky130_fd_sc_hd__or2_2 + PLACED ( 5060 5440 ) N ;
+    - _17_ sky130_fd_sc_hd__nand2b_2 + PLACED ( 1840 5440 ) N ;
+    - _18_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 460 10880 ) N ;
+    - _19_ sky130_fd_sc_hd__a21o_2 + PLACED ( 0 8160 ) FS ;
+    - _20_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 3220 8160 ) FS ;
+    - _21_ sky130_fd_sc_hd__xnor2_2 + PLACED ( 460 2720 ) FS ;
+    - _22_ sky130_fd_sc_hd__or2_2 + PLACED ( 11960 13600 ) FS ;
+    - _23_ sky130_fd_sc_hd__and2_2 + PLACED ( 14260 13600 ) FS ;
+    - _24_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 6440 2720 ) FS ;
+    - _25_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 6440 10880 ) N ;
+    - _26_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 0 13600 ) FS ;
+    - _27_ sky130_fd_sc_hd__sdfrtp_2 + PLACED ( 2760 0 ) N ;
+    - _28_ sky130_fd_sc_hd__conb_1 + PLACED ( 460 5440 ) N ;
+END COMPONENTS
+PINS 18 ;
+    - a[0] + NET a[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 15870 242 ) N ;
+    - a[1] + NET a[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 9430 242 ) N ;
+    - a[2] + NET a[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 8510 242 ) N ;
+    - a[3] + NET a[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 13110 242 ) N ;
+    - b[0] + NET b[0] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 10350 242 ) N ;
+    - b[1] + NET b[1] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 11270 242 ) N ;
+    - b[2] + NET b[2] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 5750 242 ) N ;
+    - b[3] + NET b[3] + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 4830 242 ) N ;
+    - c[0] + NET c[0] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 6670 242 ) N ;
+    - c[1] + NET c[1] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 14950 242 ) N ;
+    - c[2] + NET c[2] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 7590 242 ) N ;
+    - c[3] + NET c[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 14030 242 ) N ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 3910 242 ) N ;
+    - rstn + NET rstn + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 12190 242 ) N ;
+    - sce + NET sce + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 2070 242 ) N ;
+    - sci + NET sci + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 16790 242 ) N ;
+    - sco + NET c[3] + DIRECTION OUTPUT + USE SIGNAL
+      + PORT
+        + LAYER met2 ( -70 -242 ) ( 70 243 )
+        + PLACED ( 2990 242 ) N ;
+    - tm + NET tm + DIRECTION INPUT + USE SIGNAL
+      + PORT
+        + LAYER met1 ( -297 -70 ) ( 298 70 )
+        + PLACED ( 18502 1530 ) N ;
+END PINS
+NETS 32 ;
+    - _00_ ( _23_ A ) ( _13_ A ) ( _10_ Y ) + USE SIGNAL ;
+    - _01_ ( _14_ B1 ) ( _11_ X ) + USE SIGNAL ;
+    - _02_ ( _14_ A3 ) ( _13_ B ) ( _12_ X ) + USE SIGNAL ;
+    - _03_ ( _19_ A1 ) ( _18_ A ) ( _14_ X ) + USE SIGNAL ;
+    - _04_ ( _19_ B1 ) ( _17_ A_N ) ( _15_ X ) + USE SIGNAL ;
+    - _05_ ( _19_ A2 ) ( _17_ B ) ( _16_ X ) + USE SIGNAL ;
+    - _06_ ( _18_ B ) ( _17_ Y ) + USE SIGNAL ;
+    - _07_ ( _21_ A ) ( _19_ X ) + USE SIGNAL ;
+    - _08_ ( _21_ B ) ( _20_ Y ) + USE SIGNAL ;
+    - _09_ ( _23_ B ) ( _22_ X ) + USE SIGNAL ;
+    - a[0] ( PIN a[0] ) ( _22_ B ) ( _14_ A2 ) ( _10_ B ) + USE SIGNAL ;
+    - a[1] ( PIN a[1] ) ( _12_ B ) ( _11_ B ) + USE SIGNAL ;
+    - a[2] ( PIN a[2] ) ( _16_ B ) ( _15_ B ) + USE SIGNAL ;
+    - a[3] ( PIN a[3] ) ( _20_ B ) + USE SIGNAL ;
+    - b[0] ( PIN b[0] ) ( _22_ A ) ( _14_ A1 ) ( _10_ A ) + USE SIGNAL ;
+    - b[1] ( PIN b[1] ) ( _12_ A ) ( _11_ A ) + USE SIGNAL ;
+    - b[2] ( PIN b[2] ) ( _16_ A ) ( _15_ A ) + USE SIGNAL ;
+    - b[3] ( PIN b[3] ) ( _20_ A ) + USE SIGNAL ;
+    - c[0] ( PIN c[0] ) ( _25_ SCD ) ( _24_ Q ) + USE SIGNAL ;
+    - c[1] ( PIN c[1] ) ( _26_ SCD ) ( _25_ Q ) + USE SIGNAL ;
+    - c[2] ( PIN c[2] ) ( _27_ SCD ) ( _26_ Q ) + USE SIGNAL ;
+    - c[3] ( PIN sco ) ( PIN c[3] ) ( _27_ Q ) + USE SIGNAL ;
+    - clk ( PIN clk ) ( _27_ CLK ) ( _26_ CLK ) ( _25_ CLK ) ( _24_ CLK ) + USE SIGNAL ;
+    - delay_next\[0\] ( _24_ D ) ( _23_ X ) + USE SIGNAL ;
+    - delay_next\[1\] ( _25_ D ) ( _13_ Y ) + USE SIGNAL ;
+    - delay_next\[2\] ( _26_ D ) ( _18_ Y ) + USE SIGNAL ;
+    - delay_next\[3\] ( _27_ D ) ( _21_ Y ) + USE SIGNAL ;
+    - rstn ( PIN rstn ) ( _27_ RESET_B ) ( _26_ RESET_B ) ( _25_ RESET_B ) ( _24_ RESET_B ) + USE SIGNAL ;
+    - sce ( PIN sce ) ( _26_ SCE ) ( _25_ SCE ) ( _24_ SCE ) ( _27_ SCE ) + USE SIGNAL ;
+    - sci ( PIN sci ) ( _24_ SCD ) + USE SIGNAL ;
+    - sco ( _28_ LO ) + USE SIGNAL ;
+    - tm ( PIN tm ) + USE SIGNAL ;
+END NETS
+
+SCANCHAINS 1 ;
+
+- chain_0
++ START PIN sci
++ ORDERED
+  _27_ ( IN SCD ) ( OUT Q )
+  _26_ ( IN SCD ) ( OUT Q )
+  _25_ ( IN SCD ) ( OUT Q )
+  _24_ ( IN SCD ) ( OUT Q )
++ PARTITION default
++ STOP PIN sco ;
+
+END SCANCHAINS
+
+END DESIGN

--- a/src/dft/test/scan_opt_sky130.ok
+++ b/src/dft/test/scan_opt_sky130.ok
@@ -1,0 +1,9 @@
+[INFO ODB-0227] LEF file: sky130hd/sky130hd.tlef, created 13 layers, 25 vias
+[INFO ODB-0227] LEF file: sky130hd/sky130_fd_sc_hd_merged.lef, created 437 library cells
+[INFO ODB-0128] Design: _4bitadder
+[INFO ODB-0130]     Created 18 pins.
+[INFO ODB-0131]     Created 19 components and 109 component-terminals.
+[INFO ODB-0133]     Created 32 nets and 62 connections.
+[INFO DFT-0015] Starting 2-Opt with initial total chain wire length 59.78um
+[INFO DFT-0016] Concluded 2-Opt with total chain wire length 52.42um.
+No differences found.

--- a/src/dft/test/scan_opt_sky130.tcl
+++ b/src/dft/test/scan_opt_sky130.tcl
@@ -1,0 +1,19 @@
+source "helpers.tcl"
+
+read_lef sky130hd/sky130hd.tlef
+read_lef sky130hd/sky130_fd_sc_hd_merged.lef
+read_liberty sky130hd/sky130_fd_sc_hd__tt_025C_1v80.lib
+
+read_def scan_opt_sky130.def
+set_dft_config \
+  -max_chains 1 \
+  -scan_enable_name_pattern sce \
+  -scan_in_name_pattern sci \
+  -scan_out_name_pattern sco
+create_clock [get_ports clk] -name clk -period 130
+execute_dft_plan
+scan_opt
+
+set def_file [make_result_file scan_opt_sky130.out.def]
+write_def $def_file
+diff_files $def_file scan_opt_sky130.defok

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7744,6 +7744,8 @@ class dbDft : public dbObject
   bool isScanInserted() const;
 
   dbSet<dbScanChain> getScanChains() const;
+
+  void reset();
 };
 
 class dbGCellGrid : public dbObject

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7894,6 +7894,8 @@ class dbDft : public dbObject
   bool isScanInserted() const;
 
   dbSet<dbScanChain> getScanChains() const;
+
+  void reset();
 };
 
 class dbGCellGrid : public dbObject

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7893,9 +7893,9 @@ class dbDft : public dbObject
 
   bool isScanInserted() const;
 
-  dbSet<dbScanChain> getScanChains() const;
+  dbSet<dbScanPin> getScanPins() const;
 
-  void reset();
+  dbSet<dbScanChain> getScanChains() const;
 };
 
 class dbGCellGrid : public dbObject
@@ -9148,6 +9148,7 @@ class dbScanChain : public dbObject
  public:
   dbSet<dbScanPartition> getScanPartitions() const;
 
+  static void destroy(dbScanChain* obj);
   // User Code Begin dbScanChain
   const std::string& getName() const;
 
@@ -9235,6 +9236,7 @@ class dbScanInst : public dbObject
 class dbScanList : public dbObject
 {
  public:
+  static void destroy(dbScanList* obj);
   // User Code Begin dbScanList
   dbSet<dbScanInst> getScanInsts() const;
   dbScanInst* add(dbInst* inst);
@@ -9253,6 +9255,7 @@ class dbScanPartition : public dbObject
  public:
   dbSet<dbScanList> getScanLists() const;
 
+  static void destroy(dbScanPartition* obj);
   // User Code Begin dbScanPartition
   const std::string& getName() const;
   void setName(const std::string& name);
@@ -9269,6 +9272,7 @@ class dbScanPartition : public dbObject
 class dbScanPin : public dbObject
 {
  public:
+  static void destroy(dbScanPin* obj);
   // User Code Begin dbScanPin
   std::variant<dbBTerm*, dbITerm*> getPin() const;
   void setPin(dbBTerm* bterm);

--- a/src/odb/src/codeGenerator/schema.json
+++ b/src/odb/src/codeGenerator/schema.json
@@ -420,25 +420,28 @@
       "child": "dbScanPin",
       "type": "1_n",
       "tbl_name": "scan_pins_",
-      "flags": ["no-get"]
+      "destroy": true
     },
     {
       "parent": "dbScanChain",
       "child": "dbScanPartition",
       "type": "1_n",
-      "tbl_name": "scan_partitions_"
+      "tbl_name": "scan_partitions_",
+      "destroy": true
     },
     {
       "parent": "dbScanPartition",
       "child": "dbScanList",
       "type": "1_n",
-      "tbl_name": "scan_lists_"
+      "tbl_name": "scan_lists_",
+      "destroy": true
     },
     {
       "parent": "dbDft",
       "child": "dbScanChain",
       "type": "1_n",
-      "tbl_name": "scan_chains_"
+      "tbl_name": "scan_chains_",
+      "destroy": true
     },
     {
       "parent": "dbGDSStructure",

--- a/src/odb/src/db/dbDft.cpp
+++ b/src/odb/src/db/dbDft.cpp
@@ -124,5 +124,14 @@ dbSet<dbScanChain> dbDft::getScanChains() const
   return dbSet<dbScanChain>(obj, obj->scan_chains_);
 }
 
+void dbDft::reset()
+{
+  _dbDft* obj = (_dbDft*) this;
+  obj->scan_inserted_ = false;
+
+  obj->scan_pins_->clear();
+  obj->scan_chains_->clear();
+}
+
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbDft.cpp
+++ b/src/odb/src/db/dbDft.cpp
@@ -123,5 +123,14 @@ dbSet<dbScanChain> dbDft::getScanChains() const
   return dbSet<dbScanChain>(obj, obj->scan_chains_);
 }
 
+void dbDft::reset()
+{
+  _dbDft* obj = (_dbDft*) this;
+  obj->scan_inserted_ = false;
+
+  obj->scan_pins_->clear();
+  obj->scan_chains_->clear();
+}
+
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbDft.cpp
+++ b/src/odb/src/db/dbDft.cpp
@@ -117,19 +117,16 @@ bool dbDft::isScanInserted() const
   return obj->scan_inserted_;
 }
 
+dbSet<dbScanPin> dbDft::getScanPins() const
+{
+  _dbDft* obj = (_dbDft*) this;
+  return dbSet<dbScanPin>(obj, obj->scan_pins_);
+}
+
 dbSet<dbScanChain> dbDft::getScanChains() const
 {
   _dbDft* obj = (_dbDft*) this;
   return dbSet<dbScanChain>(obj, obj->scan_chains_);
-}
-
-void dbDft::reset()
-{
-  _dbDft* obj = (_dbDft*) this;
-  obj->scan_inserted_ = false;
-
-  obj->scan_pins_->clear();
-  obj->scan_chains_->clear();
 }
 
 }  // namespace odb

--- a/src/odb/src/db/dbScanChain.cpp
+++ b/src/odb/src/db/dbScanChain.cpp
@@ -10,6 +10,7 @@
 #include "dbCore.h"
 #include "dbDatabase.h"
 #include "dbDft.h"
+#include "dbProperty.h"
 #include "dbScanInst.h"
 #include "dbScanPartition.h"
 #include "dbScanPin.h"
@@ -129,6 +130,12 @@ dbSet<dbScanPartition> dbScanChain::getScanPartitions() const
   return dbSet<dbScanPartition>(obj, obj->scan_partitions_);
 }
 
+void dbScanChain::destroy(dbScanChain* obj)
+{
+  _dbDft* _parent = (_dbDft*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->scan_chains_->destroy((_dbScanChain*) obj);
+}
 // User Code Begin dbScanChainPublicMethods
 
 const std::string& dbScanChain::getName() const

--- a/src/odb/src/db/dbScanList.cpp
+++ b/src/odb/src/db/dbScanList.cpp
@@ -9,6 +9,7 @@
 #include "dbCore.h"
 #include "dbDatabase.h"
 #include "dbDft.h"
+#include "dbProperty.h"
 #include "dbScanChain.h"
 #include "dbScanListScanInstItr.h"
 #include "dbScanPartition.h"
@@ -75,6 +76,12 @@ void _dbScanList::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
+void dbScanList::destroy(dbScanList* obj)
+{
+  _dbScanPartition* _parent = (_dbScanPartition*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->scan_lists_->destroy((_dbScanList*) obj);
+}
 // User Code Begin dbScanListPublicMethods
 dbSet<dbScanInst> dbScanList::getScanInsts() const
 {

--- a/src/odb/src/db/dbScanPartition.cpp
+++ b/src/odb/src/db/dbScanPartition.cpp
@@ -9,6 +9,7 @@
 #include "dbCore.h"
 #include "dbDatabase.h"
 #include "dbDft.h"
+#include "dbProperty.h"
 #include "dbScanChain.h"
 #include "dbScanList.h"
 #include "dbScanPin.h"
@@ -96,6 +97,12 @@ dbSet<dbScanList> dbScanPartition::getScanLists() const
   return dbSet<dbScanList>(obj, obj->scan_lists_);
 }
 
+void dbScanPartition::destroy(dbScanPartition* obj)
+{
+  _dbScanChain* _parent = (_dbScanChain*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->scan_partitions_->destroy((_dbScanPartition*) obj);
+}
 // User Code Begin dbScanPartitionPublicMethods
 
 const std::string& dbScanPartition::getName() const

--- a/src/odb/src/db/dbScanPin.cpp
+++ b/src/odb/src/db/dbScanPin.cpp
@@ -10,6 +10,7 @@
 #include "dbCore.h"
 #include "dbDatabase.h"
 #include "dbDft.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "odb/db.h"
 // User Code Begin Includes
@@ -76,6 +77,12 @@ void _dbScanPin::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
+void dbScanPin::destroy(dbScanPin* obj)
+{
+  _dbDft* _parent = (_dbDft*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->scan_pins_->destroy((_dbScanPin*) obj);
+}
 // User Code Begin dbScanPinPublicMethods
 std::variant<dbBTerm*, dbITerm*> dbScanPin::getPin() const
 {


### PR DESCRIPTION
## Summary
- dft::Dft:
  - isolate writing the data to odb to its own function
  - store scan chains for later optimization after stitching
- dft::Dft::scanOpt(): use scan chain driver/sink information plus instance placements to optimize the total scan chain length using the 2Opt algorithm
- dft::ScanChain:
 - add estimateInternalTWL() to return an estimated total wire length for the scan chain based on cell origins (for verification/testing purposes)
 - sortScanCells now returns an estimated total wire length (and requires lambdas passed to it to do so as well)
- dft::ScanPin: add getLocation() as a a method to get terminal locations whether it's a bterm or an iterm
- odb::dbDft: Add reset() method to clear all existing info

## Type of Change
- New feature
- Refactoring

## Impact

Measurable reduction in routing time versus the unoptimized scan chains.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

