### PR TITLE
utl: Enables Logger backtrace support

### DIFF
--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -167,6 +167,7 @@ class Logger
                                        const std::string& message,
                                        const Args&... args)
   {
+    logger_->dump_backtrace();
     error_count_++;
     log(tool, spdlog::level::err, id, message, args...);
     // Exception should be caught by swig error handler.
@@ -179,6 +180,7 @@ class Logger
                                           const std::string& message,
                                           const Args&... args)
   {
+    logger_->dump_backtrace();
     log(tool, spdlog::level::level_enum::critical, id, message, args...);
     exit(EXIT_FAILURE);
   }
@@ -348,6 +350,8 @@ class Logger
 
   // Stop issuing messages of a given tool/id when this limit is hit.
   static constexpr int max_message_print = 1000;
+
+  static constexpr int kLogMessageBackTraceLimit = 128;
 
   std::vector<spdlog::sink_ptr> sinks_;
   std::shared_ptr<spdlog::logger> logger_;

--- a/src/utl/include/utl/Logger.h
+++ b/src/utl/include/utl/Logger.h
@@ -167,7 +167,9 @@ class Logger
                                        const std::string& message,
                                        const Args&... args)
   {
+    #if SPDLOG_VERSION >= 10600
     logger_->dump_backtrace();
+    #endif
     error_count_++;
     log(tool, spdlog::level::err, id, message, args...);
     // Exception should be caught by swig error handler.
@@ -180,7 +182,9 @@ class Logger
                                           const std::string& message,
                                           const Args&... args)
   {
+    #if SPDLOG_VERSION >= 10600
     logger_->dump_backtrace();
+    #endif
     log(tool, spdlog::level::level_enum::critical, id, message, args...);
     exit(EXIT_FAILURE);
   }

--- a/src/utl/src/Logger.cpp
+++ b/src/utl/src/Logger.cpp
@@ -48,9 +48,11 @@ Logger::Logger(const char* log_filename, const char* metrics_filename)
       "logger", sinks_.begin(), sinks_.end());
   setFormatter();
   logger_->set_level(spdlog::level::level_enum::debug);
-  // Saves the last kLogMessageBackTraceLimit debug logs in a ring buffer,
+  #if SPDLOG_VERSION >= 10600
+  // Saves the last max_backtrace_messages debug logs in a ring buffer,
   // and dumps them if an error or critical is logged.
-  logger_->enable_backtrace(kLogMessageBackTraceLimit);
+  logger_->enable_backtrace(max_backtrace_messages);
+  #endif
 
   if (metrics_filename) {
     addMetricsSink(metrics_filename);

--- a/src/utl/src/Logger.cpp
+++ b/src/utl/src/Logger.cpp
@@ -48,6 +48,9 @@ Logger::Logger(const char* log_filename, const char* metrics_filename)
       "logger", sinks_.begin(), sinks_.end());
   setFormatter();
   logger_->set_level(spdlog::level::level_enum::debug);
+  // Saves the last kLogMessageBackTraceLimit debug logs in a ring buffer,
+  // and dumps them if an error or critical is logged.
+  logger_->enable_backtrace(kLogMessageBackTraceLimit);
 
   if (metrics_filename) {
     addMetricsSink(metrics_filename);


### PR DESCRIPTION
This is an spdlog feature that keeps the last N debug messages in a ring buffer, and optionally allows
you to dump them.

In this case I've dumped them on error and critical.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**