### PR TITLE
mpl: add pass for soft blockages' generation around fixed macros

### DIFF
--- a/src/mpl/README.md
+++ b/src/mpl/README.md
@@ -153,6 +153,21 @@ set_macro_halo
 | `-macro_name` | The name of a macro of the design. |
 | `-halo` | The left, bottom, right and top halo or the width (sets both left and right) and height (sets both bottom and top), in microns. Consider the macro orientation as R0 when setting the halo. |
 
+### Block Macro Channels
+
+Creates soft placement blockages around all fixed macros in the design, based on their halos.
+Macros with soft DEF halos are skipped, as other placement-aware tools already honor them.
+
+For each macro, the halo used is resolved by this priority:
+
+1. The per-macro halo set with `set_macro_halo`, if defined.
+2. The DEF halo, floored by the base halo set with `set_macro_base_halo`.
+3. The base halo.
+
+```tcl
+block_macro_channels
+```
+
 ## Example scripts
 
 Example of a script demonstrating how to run `mpl` on a sample design of `bp_fe_top` as follows:

--- a/src/mpl/include/mpl/rtl_mp.h
+++ b/src/mpl/include/mpl/rtl_mp.h
@@ -63,7 +63,7 @@ class MacroPlacer
              float min_ar,
              const char* report_directory,
              bool keep_clustering_data);
-
+  void blockMacroChannels();
   void placeMacro(odb::dbInst* inst,
                   const float& x_origin,
                   const float& y_origin,

--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -2082,14 +2082,10 @@ void ClusteringEngine::createHardMacros()
       if (macro_to_halo_.contains(inst)) {
         halo = macro_to_halo_.at(inst);
       } else if (inst->getHalo() != nullptr) {
-        odb::Rect inst_halo = inst->getHalo()->getBox();
-        if (inst->getHalo()->isSoft()) {
-          halo = HardMacro::Halo(inst->getHalo());
-        } else {
-          halo = {std::max(inst_halo.xMin(), base_halo_.left),
-                  std::max(inst_halo.yMin(), base_halo_.bottom),
-                  std::max(inst_halo.xMax(), base_halo_.right),
-                  std::max(inst_halo.yMax(), base_halo_.top)};
+        const HardMacro::Halo inst_halo(inst->getHalo());
+        halo = inst_halo;
+        if (!inst->getHalo()->isSoft()) {
+          halo = inst_halo.floorTo(base_halo_);
         }
       } else {
         halo = base_halo_;

--- a/src/mpl/src/hier_rtlmp.cpp
+++ b/src/mpl/src/hier_rtlmp.cpp
@@ -252,6 +252,50 @@ void HierRTLMP::run()
   computeWireLength();
 }
 
+void HierRTLMP::blockMacroChannels()
+{
+  if (!block_) {
+    block_ = db_->getChip()->getBlock();
+  }
+
+  int blockage_count = 0;
+  for (odb::dbInst* inst : block_->getInsts()) {
+    if (!inst->isBlock() || !inst->isFixed()) {
+      continue;
+    }
+
+    // There is no need to create blockages for soft halos since other
+    // tools capable of placement are aware of them.
+    if (inst->getHalo() != nullptr && inst->getHalo()->isSoft()) {
+      continue;
+    }
+
+    HardMacro::Halo halo;
+    if (macro_to_halo_.contains(inst)) {
+      halo = macro_to_halo_.at(inst);
+    } else if (inst->getHalo() != nullptr) {
+      const HardMacro::Halo inst_halo(inst->getHalo());
+      halo = inst_halo.floorTo(base_halo_);
+    } else {
+      halo = base_halo_;
+    }
+
+    HardMacro hard_macro(inst, halo);
+    hard_macro.setOrientation(inst->getOrient());
+    hard_macro.setRealLocation(inst->getLocation());
+
+    const odb::Rect box = hard_macro.getBBox();
+    odb::dbBlockage* blockage = odb::dbBlockage::create(
+        block_, box.xMin(), box.yMin(), box.xMax(), box.yMax(), inst);
+    blockage->setSoft();
+
+    ++blockage_count;
+  }
+
+  logger_->info(
+      MPL, 76, "Created {} soft blockages around macros.", blockage_count);
+}
+
 void HierRTLMP::init()
 {
   block_ = db_->getChip()->getBlock();

--- a/src/mpl/src/hier_rtlmp.h
+++ b/src/mpl/src/hier_rtlmp.h
@@ -72,6 +72,7 @@ class HierRTLMP
 
   void init();
   void run();
+  void blockMacroChannels();
 
   // Interfaces functions for setting options
   // Hierarchical Macro Placement Related Options

--- a/src/mpl/src/mpl.i
+++ b/src/mpl/src/mpl.i
@@ -167,6 +167,12 @@ set_macro_placement_file(std::string file_name)
   getMacroPlacer()->setMacroPlacementFile(file_name);
 }
 
+void
+block_macro_channels()
+{
+  getMacroPlacer()->blockMacroChannels();
+}
+
 } // namespace
 
 %} // inline

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -341,7 +341,15 @@ proc set_macro_halo { args } {
 
 sta::define_cmd_args "block_macro_channels" {}
 proc block_macro_channels { args } {
+  sta::parse_key_args "block_macro_channels" args \
+    keys {} flags {}
+
   sta::check_argc_eq0 "block_macro_channels" $args
+
+  if { [ord::get_db_block] == "NULL" } {
+    utl::error MPL 77 "Could not block macro channels. No block found."
+  }
+
   mpl::block_macro_channels
 }
 

--- a/src/mpl/src/mpl.tcl
+++ b/src/mpl/src/mpl.tcl
@@ -339,6 +339,12 @@ proc set_macro_halo { args } {
   mpl::set_macro_halo $macro $left $bottom $right $top
 }
 
+sta::define_cmd_args "block_macro_channels" {}
+proc block_macro_channels { args } {
+  sta::check_argc_eq0 "block_macro_channels" $args
+  mpl::block_macro_channels
+}
+
 namespace eval mpl {
 proc parse_halo { halo } {
   set length [llength $halo]

--- a/src/mpl/src/object.h
+++ b/src/mpl/src/object.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -264,6 +265,14 @@ class HardMacro
       bottom = halo->yMin();
       right = halo->xMax();
       top = halo->yMax();
+    }
+
+    Halo floorTo(const Halo& minimum) const
+    {
+      return {std::max(left, minimum.left),
+              std::max(bottom, minimum.bottom),
+              std::max(right, minimum.right),
+              std::max(top, minimum.top)};
     }
 
     bool isZero() const

--- a/src/mpl/src/rtl_mp.cpp
+++ b/src/mpl/src/rtl_mp.cpp
@@ -228,6 +228,11 @@ void MacroPlacer::setMacroHalo(odb::dbInst* macro,
   hier_rtlmp_->setMacroHalo(macro, left, bottom, right, top);
 }
 
+void MacroPlacer::blockMacroChannels()
+{
+  hier_rtlmp_->blockMacroChannels();
+}
+
 void MacroPlacer::setMacroPlacementFile(const std::string& file_name)
 {
   hier_rtlmp_->setMacroPlacementFile(file_name);

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -264,6 +264,22 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "mpl_block_macro_channels_unittest",
+    srcs = [
+        "cpp/MplTest.h",
+        "cpp/TestBlockMacroChannels.cpp",
+    ],
+    deps = [
+        "//src/mpl",
+        "//src/odb",
+        "//src/tst",
+        "//src/utl",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
 py_test(
     name = "mpl_man_tcl_check",
     srcs = ["mpl_man_tcl_check.py"],

--- a/src/mpl/test/cpp/CMakeLists.txt
+++ b/src/mpl/test/cpp/CMakeLists.txt
@@ -16,6 +16,13 @@ add_executable(TestSnapper TestSnapper.cpp)
 target_link_libraries(TestSnapper ${TEST_LIBS})
 gtest_discover_tests(TestSnapper WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_executable(TestBlockMacroChannels TestBlockMacroChannels.cpp)
+target_link_libraries(TestBlockMacroChannels ${TEST_LIBS})
+gtest_discover_tests(TestBlockMacroChannels
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 add_dependencies(build_and_test
   TestSnapper
+  TestBlockMacroChannels
 )

--- a/src/mpl/test/cpp/MplTest.h
+++ b/src/mpl/test/cpp/MplTest.h
@@ -3,7 +3,6 @@
 
 #include <memory>
 
-#include "../../src/snapper.h"
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "tst/fixture.h"

--- a/src/mpl/test/cpp/TestBlockMacroChannels.cpp
+++ b/src/mpl/test/cpp/TestBlockMacroChannels.cpp
@@ -146,8 +146,8 @@ TEST_F(TestBlockMacroChannels, UnplacedMacroSkipped)
 // Placed macros are ignored: MPL can still move them as they're not fixed.
 TEST_F(TestBlockMacroChannels, PlacedMacroSkipped)
 {
-  odb::dbInst* instance = odb::dbInst::create(
-      db_->getChip()->getBlock(), macro_master_, "macro");
+  odb::dbInst* instance
+      = odb::dbInst::create(db_->getChip()->getBlock(), macro_master_, "macro");
   instance->setLocation(macro_x_, macro_y_);
   instance->setPlacementStatus(odb::dbPlacementStatus::PLACED);
 

--- a/src/mpl/test/cpp/TestBlockMacroChannels.cpp
+++ b/src/mpl/test/cpp/TestBlockMacroChannels.cpp
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "MplTest.h"
+#include "gtest/gtest.h"
+#include "mpl/rtl_mp.h"
+#include "odb/db.h"
+#include "odb/dbTypes.h"
+#include "odb/geom.h"
+
+namespace mpl {
+namespace {
+
+class TestBlockMacroChannels : public MplTest
+{
+ protected:
+  void SetUp() override
+  {
+    MplTest::SetUp();
+
+    macro_placer_ = std::make_unique<MacroPlacer>(db_.get(),
+                                                  /*sta=*/nullptr,
+                                                  &logger_,
+                                                  /*tritonpart=*/nullptr);
+
+    odb::dbLib* library = db_->findLib("lib");
+
+    macro_master_ = odb::dbMaster::create(library, "block_master");
+    macro_master_->setType(odb::dbMasterType::BLOCK);
+    macro_master_->setWidth(master_width_);
+    macro_master_->setHeight(master_height_);
+    macro_master_->setFrozen();
+  }
+
+  odb::dbInst* createFixedMacro(const std::string& name,
+                                const int origin_x,
+                                const int origin_y)
+  {
+    odb::dbInst* instance = odb::dbInst::create(
+        db_->getChip()->getBlock(), macro_master_, name.c_str());
+    instance->setLocation(origin_x, origin_y);
+    instance->setPlacementStatus(odb::dbPlacementStatus::FIRM);
+    return instance;
+  }
+
+  std::vector<odb::Rect> getBlockages() const
+  {
+    std::vector<odb::Rect> rectangles;
+    for (odb::dbBlockage* blockage :
+         db_->getChip()->getBlock()->getBlockages()) {
+      rectangles.push_back(blockage->getBBox()->getBox());
+    }
+    return rectangles;
+  }
+
+  const int master_width_ = 100000;
+  const int master_height_ = 100000;
+  const int macro_x_ = 50000;
+  const int macro_y_ = 50000;
+  std::unique_ptr<MacroPlacer> macro_placer_;
+  odb::dbMaster* macro_master_ = nullptr;
+};
+
+// DEF halo only: blockage equals master bbox expanded by the DEF halo.
+TEST_F(TestBlockMacroChannels, DefHaloOnly)
+{
+  odb::dbInst* instance = createFixedMacro("macro", macro_x_, macro_y_);
+  instance->setHalo(5000, 5000, 5000, 5000, /*is_soft=*/false);
+
+  macro_placer_->blockMacroChannels();
+
+  const std::vector<odb::Rect> blockages = getBlockages();
+  ASSERT_EQ(blockages.size(), 1);
+  EXPECT_EQ(blockages[0], odb::Rect(45000, 45000, 155000, 155000));
+}
+
+// Base halo is floored by the DEF halo per side: the larger of the two wins.
+TEST_F(TestBlockMacroChannels, BaseHaloFloorsDefHalo)
+{
+  odb::dbInst* instance = createFixedMacro("macro", macro_x_, macro_y_);
+  instance->setHalo(5000, 5000, 5000, 5000, /*is_soft=*/false);
+  macro_placer_->setBaseHalo(10000, 1000, 10000, 1000);
+
+  macro_placer_->blockMacroChannels();
+
+  const std::vector<odb::Rect> blockages = getBlockages();
+  ASSERT_EQ(blockages.size(), 1);
+  // Horizontal: base 10000 > DEF 5000. Vertical: DEF 5000 > base 1000.
+  EXPECT_EQ(blockages[0], odb::Rect(40000, 45000, 160000, 155000));
+}
+
+// Per-macro halo has top priority over both the base halo and the DEF halo.
+TEST_F(TestBlockMacroChannels, PerMacroHaloOverrides)
+{
+  odb::dbInst* instance = createFixedMacro("macro", macro_x_, macro_y_);
+  instance->setHalo(5000, 5000, 5000, 5000, /*is_soft=*/false);
+  macro_placer_->setBaseHalo(10000, 10000, 10000, 10000);
+  macro_placer_->setMacroHalo(instance, 20000, 20000, 20000, 20000);
+
+  macro_placer_->blockMacroChannels();
+
+  const std::vector<odb::Rect> blockages = getBlockages();
+  ASSERT_EQ(blockages.size(), 1);
+  EXPECT_EQ(blockages[0], odb::Rect(30000, 30000, 170000, 170000));
+}
+
+// Macros with a soft DEF halo are skipped even when a base halo is set.
+TEST_F(TestBlockMacroChannels, SoftDefHaloSkipped)
+{
+  odb::dbInst* instance = createFixedMacro("macro", macro_x_, macro_y_);
+  instance->setHalo(5000, 5000, 5000, 5000, /*is_soft=*/true);
+  macro_placer_->setBaseHalo(10000, 10000, 10000, 10000);
+
+  macro_placer_->blockMacroChannels();
+
+  EXPECT_TRUE(getBlockages().empty());
+}
+
+// When the macro has no DEF halo, the base halo alone defines the blockage.
+TEST_F(TestBlockMacroChannels, BaseHaloOnly)
+{
+  createFixedMacro("macro", macro_x_, macro_y_);
+  macro_placer_->setBaseHalo(8000, 4000, 6000, 2000);
+
+  macro_placer_->blockMacroChannels();
+
+  const std::vector<odb::Rect> blockages = getBlockages();
+  ASSERT_EQ(blockages.size(), 1);
+  EXPECT_EQ(blockages[0], odb::Rect(42000, 46000, 156000, 152000));
+}
+
+// Unplaced macros are ignored.
+TEST_F(TestBlockMacroChannels, UnplacedMacroSkipped)
+{
+  odb::dbInst::create(db_->getChip()->getBlock(), macro_master_, "macro");
+
+  macro_placer_->blockMacroChannels();
+
+  EXPECT_TRUE(getBlockages().empty());
+}
+
+// Placed macros are ignored: MPL can still move them as they're not fixed.
+TEST_F(TestBlockMacroChannels, PlacedMacroSkipped)
+{
+  odb::dbInst* instance = odb::dbInst::create(
+      db_->getChip()->getBlock(), macro_master_, "macro");
+  instance->setLocation(macro_x_, macro_y_);
+  instance->setPlacementStatus(odb::dbPlacementStatus::PLACED);
+
+  macro_placer_->blockMacroChannels();
+
+  EXPECT_TRUE(getBlockages().empty());
+}
+
+}  // namespace
+}  // namespace mpl

--- a/src/mpl/test/mpl_readme_msgs_check.ok
+++ b/src/mpl/test/mpl_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 5,        Desc: 5,        Syn: 5,        Options: 5,        Args: 5
+Names: 6,        Desc: 6,        Syn: 6,        Options: 6,        Args: 6
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.


### PR DESCRIPTION
## Summary
The idea is to use this new pass in the future to decouple the blockages' generation from MPL flow.
There's some minor refactoring going on in these changes.
This PR also removes a weird include in the C++ test header.
All tests of the new pass in C++ :)

## Type of Change
- New feature
- Refactoring
- Documentation update

## Impact
Currently no impact as it's just a new pass.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**