### PR TITLE
bazel-orfs: bump and migrate to source-built tools

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,7 +82,7 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True)
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
@@ -110,8 +110,9 @@ single_version_override(
 bazel_dep(name = "rules_scala", version = "7.1.5", dev_dependency = True)
 bazel_dep(name = "bazel-orfs", dev_dependency = True)
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
+bazel_dep(name = "orfs", dev_dependency = True)
 
-BAZEL_ORFS_COMMIT = "f5e20547f93729a4f67929902aaa3386d933bad0"
+BAZEL_ORFS_COMMIT = "6226c2e8f66b51013df7d0df709518f85df9b63c"
 
 BAZEL_ORFS_REMOTE = "https://github.com/The-OpenROAD-Project/bazel-orfs.git"
 
@@ -127,6 +128,37 @@ git_override(
     commit = BAZEL_ORFS_COMMIT,
     remote = BAZEL_ORFS_REMOTE,
     strip_prefix = "verilog",
+)
+
+# Mirrors the override in bazel-orfs/MODULE.bazel. Needed at root because
+# overrides declared in non-root modules are ignored by Bazel. Patches are
+# copied from bazel-orfs/patches/ because git_override only accepts patches
+# from the main repository.
+git_override(
+    module_name = "orfs",
+    commit = "bdb262792fef3797730e1b8341b946426272dcdc",
+    patch_strip = 1,
+    patches = [
+        "//bazel/orfs-patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
+        "//bazel/orfs-patches:orfs-preserve-tool-exe-env.patch",
+    ],
+    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+)
+
+# Mirrors the single_version_override in bazel-orfs/MODULE.bazel: non-root
+# overrides are ignored so apply at root. Gives bazel-orfs rules access to
+# @yosys//:yosys_share and exposes the Yosys headers it needs.
+single_version_override(
+    module_name = "yosys",
+    patch_strip = 1,
+    patches = [
+        "//bazel/orfs-patches:yosys-visibility.patch",
+        "//bazel/orfs-patches:yosys-hdrs.patch",
+        # BCR yosys 0.62 ships backends/aiger2/aiger.cc but doesn't compile
+        # it, so yosys aborts on the internal write_xaiger2 call from
+        # abc_new.cc. Wire it into the binary via BUILD.bazel.
+        "//bazel/orfs-patches:yosys-backend-aiger2.patch",
+    ],
 )
 
 # --- Extensions ---
@@ -183,16 +215,11 @@ npm.npm_translate_lock(
 use_repo(npm, "npm")
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories", dev_dependency = True)
-
-# To bump version, run: bazelisk run @bazel-orfs//:bump
 orfs.default(
-    # Official image https://hub.docker.com/r/openroad/orfs/tags
-    image = "docker.io/openroad/orfs:26Q1-816-gf40d2f346",
-    # Use OpenROAD of this repo instead of from the docker image
+    # Use OpenROAD of this repo instead of from @openroad
     openroad = "//:openroad",
-    sha256 = "2b05a14ae8062b4af82b245d648e95fa0293e09b61b57468518b66578744afb8",
+    opensta = "//src/sta:opensta",
 )
-use_repo(orfs, "docker_orfs")
 
 SCALA_VERSION = "2.13.17"
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2,6 +2,7 @@
   "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abc/0.62-yosyshq/MODULE.bazel": "325231df11fd3480cb0eb3c9095105ccdfacf34583c3a92d8c0ae46967dbaef6",
     "https://bcr.bazel.build/modules/abc/0.64-yosyshq.bcr.1/MODULE.bazel": "d1ed5b52014c8b7cf2b8a617f1c1f6e363303c92fd84c6c426281a873d0d297a",
     "https://bcr.bazel.build/modules/abc/0.64-yosyshq.bcr.1/source.json": "6c9a69d0cabbe23d1c42d8616405c2e64eabb84e53961872ba2b9ba634c1ffdc",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -92,6 +93,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.6/MODULE.bazel": "fd1f9432ca04c947e91b500df69ce7c5b6dbfe1bc45ab1820338205dae3383a6",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.6/source.json": "5d68545f224904745a3cabd35aea6bc2b6cc5a78b7f49f3f69660eab2eeeb273",
+    "https://bcr.bazel.build/modules/bison/3.8.2.bcr.5/MODULE.bazel": "96e976881e5670bdb2461157027ed6f3e25084b727aab6b7047210da9af7f678",
+    "https://bcr.bazel.build/modules/bison/3.8.2.bcr.5/source.json": "3cde6dd5a399b67f8124e25e7c7d6eb754807ee7b5a88aab28cf593ff37587ca",
     "https://bcr.bazel.build/modules/bliss/0.73/MODULE.bazel": "26b5476884b67df20a8b87ab2806657123b439e978da76f484427a15fb552b26",
     "https://bcr.bazel.build/modules/bliss/0.73/source.json": "5cb395710670662321f492fc3d4fce3551e3d5708682e4f2320bacaadf6e5e36",
     "https://bcr.bazel.build/modules/boost.algorithm/1.87.0/MODULE.bazel": "d1c8f1466cc1a04a16eebeefe0f54a9508cc9f1a3c21d65d806acbc36593e204",
@@ -365,12 +368,16 @@
     "https://bcr.bazel.build/modules/curl/8.4.0/MODULE.bazel": "0bc250aa1cb69590049383df7a9537c809591fcf876c620f5f097c58fdc9bc10",
     "https://bcr.bazel.build/modules/curl/8.7.1/MODULE.bazel": "088221c35a2939c555e6e47cb31a81c15f8b59f4daa8009b1e9271a502d33485",
     "https://bcr.bazel.build/modules/curl/8.7.1/source.json": "bf9890e809717445b10a3ddc323b6d25c46631589c693a232df8310a25964484",
+    "https://bcr.bazel.build/modules/cxxopts/3.3.1/MODULE.bazel": "dcc6d876d0c779e0f79fb712eddc66cfed44e8b87488728c6bea52e7da9652ec",
+    "https://bcr.bazel.build/modules/cxxopts/3.3.1/source.json": "4076abfd34456e084950451f848934630f4a429cacf496c9dda132fd56980157",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/MODULE.bazel": "868b3f5c956c3657420d2302004c6bb92606bfa47e314bab7f2ba0630c7c966c",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/source.json": "da318be900b8ca9c3d1018839d3bebc5a8e1645620d0848fa2c696d4ecf7c296",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/MODULE.bazel": "f6561baff0fc0035c9c1a9e2b0820de106cdb01b37bf5c81276860ccc863e5b2",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/source.json": "a8611a2b5577929ad7e1f44ded19dab21a188125a74ac6192d21d283609f280f",
     "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/MODULE.bazel": "24e05f6f52f37be63a795192848555a2c8c855e7814dbc1ed419fb04a7005464",
     "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/source.json": "212043ab69d87f7a04aa4f627f725b540cff5e145a3a31a9403d8b6ec2e920c9",
+    "https://bcr.bazel.build/modules/flex/2.6.4.bcr.3/MODULE.bazel": "bd03fa9fe80831cddbfbeefc1de9c14fc444e8ca395cc3d8f1069dd42a15cb65",
+    "https://bcr.bazel.build/modules/flex/2.6.4.bcr.3/source.json": "e73c3695620dc9c7251d3b1361e1d3762315537fc381242fa888f0c386038c36",
     "https://bcr.bazel.build/modules/fmt/11.1.3/MODULE.bazel": "3f422eb59fec5a54faf6d6c5b4cfbd173ad989e2ee5a2da944e19a39a8a90e00",
     "https://bcr.bazel.build/modules/fmt/11.1.3/source.json": "2cc63e28b3de6d476e2730add655af10faaf76523e2b9d72e7752a50e24eeb7d",
     "https://bcr.bazel.build/modules/freetype/2.13.3/MODULE.bazel": "9931a69ef01caba64cc7516c03c2c6c8ad0707526185d31eb81d2987163880e0",
@@ -435,7 +442,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.3/MODULE.bazel": "2aaa0e32669002a26ffe421e98913ed70fa5ee21c36fc51d2d51053a5ed07420",
-    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.3/source.json": "fdffd7d4e35124905988e03a5f7ced705df34f5e5134445b7f17f1ecaede9df2",
+    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.4/MODULE.bazel": "adece04128b95bdfe7811a25f48341c11fdf1705a9e59c98ca007f8fc46a0822",
+    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.4/source.json": "dd63be13678c61409cbc3e821e92b78e252399618759aabbf413515c8782dfb9",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "e5362dadc90aab6724c83a2cc1e67cbed9c89a05d97fb1f90053c8deb1e445c8",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/source.json": "0646414d9037f8aad148781dd760bec90b0b25ac12fda5e03f8aadbd6b9c61e6",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -445,10 +453,13 @@
     "https://bcr.bazel.build/modules/libxau/1.0.12.bcr.1/source.json": "4076a85407185883f1563210abf36e80c9636d076d7197169bb431595b3f1151",
     "https://bcr.bazel.build/modules/libxcb/1.17.0.bcr.2/MODULE.bazel": "83d6740822a296210c0c60cd429a892934bdb237f7135eaf395b370c05af32a5",
     "https://bcr.bazel.build/modules/libxcb/1.17.0.bcr.2/source.json": "58c8c30c5d0f6253c94d7a38ab95fd5174683d613d47b9114520da6acef52ae8",
+    "https://bcr.bazel.build/modules/m4/1.4.20.bcr.4/MODULE.bazel": "582008fee330b47fe8db3e786cf78f05c926d2b37fcde0178316bbc5a717e096",
+    "https://bcr.bazel.build/modules/m4/1.4.20.bcr.4/source.json": "c358c98ad1a1bb2243076b7c09b4c113dc4278320d793e343fb6a0d504b34b91",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/MODULE.bazel": "8e380e4698107c5f8766264d4df92e36766248447858db28187151d884995a09",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/source.json": "1dbe7eb5258050afcc3806b9d43050f71c6f539ce0175535c670df606790b30c",
     "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.11/MODULE.bazel": "ef03f49137ca4abaf6648c795635abb21024d74e97822016cda9dc817e1418ae",
     "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.11/source.json": "3119380662482b112a2f34769793785a10b3734f27f2bef6c778217745935efb",
+    "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.9/MODULE.bazel": "95b2f3dcfb1d2ecaeea67293a10b654a08206414759a761e82fa59bdfe29d0dc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/MODULE.bazel": "87023db2f55fc3a9949c7b08dc711fae4d4be339a80a99d04453c4bb3998eefc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0.bcr.1/MODULE.bazel": "a1c8bb07b5b91d971727c635f449d05623ac9608f6fe4f5f04254ea12f08e349",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0.bcr.1/source.json": "93f82a5ae985eb935c539bfee95e04767187818189241ac956f3ccadbdb8fb02",
@@ -538,6 +549,7 @@
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/MODULE.bazel": "e09b434b122bfb786a69179f9b325e35cb1856c3f56a7a81dd61609260ed46e1",
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/source.json": "a8ae7c09533bf67f9f6e5122d884d5741600b09d78dca6fc0f2f8d2ee0c2d957",
     "https://bcr.bazel.build/modules/re2/2025-08-12/MODULE.bazel": "79bf27a1b8b6834cea391794f2db0180b7b53203795497e261ccd89fe695c74f",
+    "https://bcr.bazel.build/modules/readline/8.2.bcr.3/MODULE.bazel": "800b9efaba7e9d9fdd204f459601002adb4eac33b13c4760c9e16169bf2307a8",
     "https://bcr.bazel.build/modules/readline/8.3.bcr.1/MODULE.bazel": "38dea764ad0ba793af4e6da1a9b6839922a56fe6620a0b3c42d3f0ca8cb714a4",
     "https://bcr.bazel.build/modules/readline/8.3.bcr.1/source.json": "a42bf1ff95df0203dc6f94c26ca86927bf6b2cb397b7888898666b9e57c37e78",
     "https://bcr.bazel.build/modules/readline/8.3/MODULE.bazel": "60b0062649137ab4c8a3521fd2a6976bcc65f16a5344c55b9132c80b361ddafe",
@@ -699,6 +711,8 @@
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
     "https://bcr.bazel.build/modules/rules_verilator/0.1.0/MODULE.bazel": "fa4c361e104dc5ebcc5606435edc0d33d7fb1a34876e090e400f1e84091c5743",
     "https://bcr.bazel.build/modules/rules_verilator/0.1.0/source.json": "f0d64b9c31f9601436a200e939df56ed322bfefeac191b891e7f9e4b7411b08d",
+    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/MODULE.bazel": "adcccf08f92e16936d6aa2e872f31a79e80712333be604de750d4b109fae1519",
+    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/source.json": "32a02fe6f97e1a233cff48e0eae70243e2e25d4c57fc684f933e06ef67440d8b",
     "https://bcr.bazel.build/modules/scip/9.2.3/MODULE.bazel": "392d8e76efeab5ef5978e66d15c2ce5e2607b80ea0804163861dd721eed93121",
     "https://bcr.bazel.build/modules/scip/9.2.3/source.json": "5ffc88567e8ff0f3ef59f20364af7cf903108f137fe36420f380e38b6cc92cb1",
     "https://bcr.bazel.build/modules/sed/4.9.bcr.3/MODULE.bazel": "3aca45895b85b6ef65366cc12a45217ba6870f8931d2d62e09c99c772d9736ab",
@@ -751,6 +765,8 @@
     "https://bcr.bazel.build/modules/xorgproto/2024.1.bcr.1/source.json": "2da7b346f94c7d5bb890d8a964110b38b439bd254ad14ec3d37022a7ac9356d8",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/MODULE.bazel": "d0841e12e92973d7e4c97557198335788890dafa9487d6dc0f9b852053a6c5c0",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/source.json": "07a9973d6cee81c8bdb1902e8f90064a0ef9aa2262bffc4df2ed577956c08e1b",
+    "https://bcr.bazel.build/modules/yosys/0.62/MODULE.bazel": "46b664f09e4f4584b8525af5fdf380bf2c4752f31a3d28b0e82c394b822be173",
+    "https://bcr.bazel.build/modules/yosys/0.62/source.json": "bd68594213f1eb7d2298b33b4ded86d58da86d9b392e809da4c007bf0de136d1",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
     "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
@@ -824,66 +840,67 @@
     },
     "@@bazel-orfs+//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "1T9b1AS979F7qaxyw/OjMC5ZMrWRH/7sYB76ydIETxQ=",
-        "usagesDigest": "XBFQgDjQPrBrrmKJmJEV3y0UmOjGg925SInSvHhAgIA=",
+        "bzlTransitiveDigest": "6Ivbltc2jNkRm28+htORm7l73RA1stBJbjVqGMlLH38=",
+        "usagesDigest": "NdIGqTs4OrpPDOi00oEG/hS+bXWGShN/5NZse+sT870=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "docker_orfs": {
-            "repoRuleId": "@@bazel-orfs+//:docker.bzl%docker_pkg",
-            "attributes": {
-              "image": "docker.io/openroad/orfs:26Q1-816-gf40d2f346",
-              "sha256": "2b05a14ae8062b4af82b245d648e95fa0293e09b61b57468518b66578744afb8",
-              "build_file": "@@bazel-orfs+//:docker.BUILD.bazel",
-              "timeout": 3600,
-              "patch_cmds": [
-                "find . -name BUILD.bazel -delete"
-              ],
-              "patches": [],
-              "patch_args": [
-                "-p1",
-                "-d",
-                "OpenROAD-flow-scripts"
-              ]
-            }
+          "gnumake": {
+            "repoRuleId": "@@bazel-orfs+//:gnumake.bzl%gnumake",
+            "attributes": {}
+          },
+          "mock_klayout": {
+            "repoRuleId": "@@bazel-orfs+//:mock_klayout.bzl%mock_klayout",
+            "attributes": {}
           },
           "config": {
             "repoRuleId": "@@bazel-orfs+//:config.bzl%global_config",
             "attributes": {
-              "klayout": "@@bazel-orfs++orfs_repositories+docker_orfs//:klayout",
-              "make": "@@bazel-orfs++orfs_repositories+docker_orfs//:make",
-              "makefile": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile",
-              "makefile_yosys": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile_yosys",
+              "klayout": "@@bazel-orfs++orfs_repositories+mock_klayout//:klayout",
+              "make": "@@bazel-orfs++orfs_repositories+gnumake//:make",
+              "makefile": "@@orfs+//flow:makefile",
+              "makefile_yosys": "@@orfs+//flow:makefile_yosys",
               "openroad": "@@//:openroad",
-              "opensta": "@@bazel-orfs++orfs_repositories+docker_orfs//:sta",
-              "pdk": "@@bazel-orfs++orfs_repositories+docker_orfs//:asap7",
-              "yosys": "@@bazel-orfs++orfs_repositories+docker_orfs//:yosys",
-              "yosys_abc": "@@bazel-orfs++orfs_repositories+docker_orfs//:yosys-abc"
+              "opensta": "@@//src/sta:opensta",
+              "pdk": "@@orfs+//flow:asap7",
+              "yosys": "@@yosys+//:yosys",
+              "yosys_abc": "@@abc+//:abc_bin",
+              "yosys_share": "@@yosys+//:yosys_share"
             }
           },
           "orfs_variable_metadata": {
             "repoRuleId": "@@bazel-orfs+//:load_json_file.bzl%load_json_file",
             "attributes": {
-              "src": "@@bazel-orfs++orfs_repositories+docker_orfs//:OpenROAD-flow-scripts/flow/scripts/variables.yaml"
+              "src": "@@orfs+//flow:scripts/variables.yaml"
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
             "bazel-orfs+",
-            "bazel_tools",
-            "bazel_tools"
+            "abc",
+            "abc+"
           ],
           [
             "bazel-orfs+",
-            "docker_orfs",
-            "bazel-orfs++orfs_repositories+docker_orfs"
+            "gnumake",
+            "bazel-orfs++orfs_repositories+gnumake"
           ],
           [
             "bazel-orfs+",
-            "python_3_13_host",
-            "rules_python++python+python_3_13_host"
+            "openroad",
+            ""
+          ],
+          [
+            "bazel-orfs+",
+            "orfs",
+            "orfs+"
+          ],
+          [
+            "bazel-orfs+",
+            "yosys",
+            "yosys+"
           ]
         ]
       }

--- a/bazel/orfs-patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
+++ b/bazel/orfs-patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 2 Apr 2026 22:00:00 +0200
+Subject: [PATCH] fix: remove non-root overrides from MODULE.bazel
+
+When ORFS is fetched as a non-root dependency, git_override and
+orfs.default() directives are ignored/illegal.  Remove them so
+the module can be used as a dependency without errors.
+
+Signed-off-by: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+---
+ MODULE.bazel | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -8,13 +8,6 @@
+
+ bazel_dep(name = "bazel-orfs")
+
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-git_override(
+-    module_name = "bazel-orfs",
+-    commit = "f8a4b694b37c8f5322323eba9a9ae37f9541ee17",
+-    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
+-)
+-
+ bazel_dep(name = "rules_python", version = "1.8.5")
+ bazel_dep(name = "rules_shell", version = "0.6.1")
+
+@@ -36,15 +29,3 @@
+ use_repo(pip, "orfs-pip")
+
+ orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+-
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-orfs.default(
+-    image = "docker.io/openroad/orfs:v3.0-3273-gedf3d6bf",
+-    # Use local files instead of docker image
+-    makefile = "//flow:makefile",
+-    makefile_yosys = "//flow:makefile_yosys",
+-    pdk = "//flow:asap7",
+-    sha256 = "f5692c6325ebcf27cc348e033355ec95c82c35ace1af7e72a0d352624ada143e",
+-)
+-use_repo(orfs, "com_github_nixos_patchelf_download")
+-use_repo(orfs, "docker_orfs")
+--
+2.51.0
+

--- a/bazel/orfs-patches/BUILD.bazel
+++ b/bazel/orfs-patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/bazel/orfs-patches/orfs-preserve-tool-exe-env.patch
+++ b/bazel/orfs-patches/orfs-preserve-tool-exe-env.patch
@@ -1,0 +1,12 @@
+diff --git a/flow/scripts/variables.mk b/flow/scripts/variables.mk
+--- a/flow/scripts/variables.mk
++++ b/flow/scripts/variables.mk
+@@ -188,7 +188,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
+ export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
+ 
+ define get_variables
+-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
++$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+ endef
+ 
+ export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)

--- a/bazel/orfs-patches/yosys-backend-aiger2.patch
+++ b/bazel/orfs-patches/yosys-backend-aiger2.patch
@@ -1,0 +1,28 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1036,6 +1036,18 @@
+ )
+
+ cc_library(
++    name = "backend_aiger2",
++    srcs = ["backends/aiger2/aiger.cc"],
++    conlyopts = COMMON_COPTS,
++    cxxopts = COMMON_CXXOPTS,
++    local_defines = COMMON_DEFINES,
++    visibility = ["//visibility:public"],
++    deps = [":kernel"],
++    alwayslink = True,
++)
++
++cc_library(
+     name = "backend_json",
+     srcs = ["backends/json/json.cc"],
+     conlyopts = COMMON_COPTS,
+@@ -1087,6 +1099,7 @@
+     visibility = ["//visibility:public"],
+     deps = [
+         ":backend_aiger",
++        ":backend_aiger2",
+         ":backend_json",
+         ":backend_rtlil",
+         ":backend_verilog",

--- a/bazel/orfs-patches/yosys-hdrs.patch
+++ b/bazel/orfs-patches/yosys-hdrs.patch
@@ -1,0 +1,15 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -691,3 +691,12 @@
+         "passes/cmds/sdc/graph-stubs.sdc:sdc/graph-stubs.sdc",
+     ],
+ )
++
++# Header-only target for building out-of-tree yosys plugins.
++cc_library(
++    name = "hdrs",
++    hdrs = glob(["kernel/*.h", "kernel/*.inc"]),
++    defines = COMMON_DEFINES,
++    includes = ["."],
++    visibility = ["//visibility:public"],
++)

--- a/bazel/orfs-patches/yosys-visibility.patch
+++ b/bazel/orfs-patches/yosys-visibility.patch
@@ -1,0 +1,11 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,5 +1,8 @@
++# Techlib cell definitions, plugins and other runtime data needed by the
++# synthesis flow.
+ share_tree(
+     name = "yosys_share",
++    visibility = ["//visibility:public"],
+     file_map = {f: share_dst(f) for f in _TECHLIBS_SHARE_SRCS},
+     renames = [
+         # lattice files also appear under ecp5/ with renamed destinations

--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -5,7 +5,18 @@ filegroup(
         "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
         "asap7sc7p5t_OA_RVT_TT_201020.v",
         "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
+        "dff.v",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "asap7sc7p5t_AO_RVT_TT_201020.v",
+        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+        "dff.v",
+        "empty.v",
     ],
     visibility = ["//visibility:public"],
 )

--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -1,22 +1,19 @@
+ASAP7_VERILOG = [
+    "asap7sc7p5t_AO_RVT_TT_201020.v",
+    "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+    "asap7sc7p5t_OA_RVT_TT_201020.v",
+    "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+    "dff.v",
+    "empty.v",
+]
+
 filegroup(
     name = "asap7_files",
-    srcs = [
-        "asap7sc7p5t_AO_RVT_TT_201020.v",
-        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-        "asap7sc7p5t_OA_RVT_TT_201020.v",
-        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "dff.v",
-    ],
+    srcs = ASAP7_VERILOG,
     visibility = ["//visibility:public"],
 )
 
 exports_files(
-    [
-        "asap7sc7p5t_AO_RVT_TT_201020.v",
-        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "dff.v",
-        "empty.v",
-    ],
+    ASAP7_VERILOG,
     visibility = ["//visibility:public"],
 )

--- a/test/orfs/asap7/dff.v
+++ b/test/orfs/asap7/dff.v
@@ -1,0 +1,32 @@
+// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R because
+// Verialtor doesn't support and has no plans to support 1995 UDP
+// tables.
+//
+// https://github.com/verilator/verilator/issues/5243
+
+module DFFHQNx1_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx2_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx3_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule

--- a/test/orfs/asap7/empty.v
+++ b/test/orfs/asap7/empty.v
@@ -1,0 +1,17 @@
+// Used to silence warnings.
+module TAPCELL_ASAP7_75t_R;
+endmodule
+module FILLERxp5_ASAP7_75t_R;
+endmodule
+module FILLER_ASAP7_75t_R;
+endmodule
+module DECAPx1_ASAP7_75t_R;
+endmodule
+module DECAPx2_ASAP7_75t_R;
+endmodule
+module DECAPx4_ASAP7_75t_R;
+endmodule
+module DECAPx6_ASAP7_75t_R;
+endmodule
+module DECAPx10_ASAP7_75t_R;
+endmodule

--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -20,6 +20,7 @@ orfs_sweep(
         # Smoketest
         "SWAP_ARITH_OPERATORS": "1",
     },
+    html = True,
     sources = {
         "RULES_JSON": [":rules-base.json"],
         "SDC_FILE": [":constraint.sdc"],

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -367,11 +367,11 @@ def mock_array(name, config):
                     ))
                     for macro in MACROS
                 ] + [
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_AO_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v",
+                    "//test/orfs/asap7:asap7sc7p5t_AO_RVT_TT_201020.v",
+                    "//test/orfs/asap7:asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+                    "//test/orfs/asap7:asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+                    "//test/orfs/asap7:dff.v",
+                    "//test/orfs/asap7:empty.v",
                 ],
                 tags = ["manual"],
             )

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -99,6 +99,7 @@ def element(name, config):
             # builds, so we want to keep this exact module.
             "SYNTH_KEEP_MODULES": "Multiplier",
         },
+        html = True,
         sources = {
             "IO_CONSTRAINTS": [":mock-array-element-io"],
             "SDC_FILE": [":mock-array-constraints"],
@@ -286,6 +287,7 @@ def mock_array(name, config):
                 "RTLMP_MIN_MACRO": "8",
                 "RTLMP_NOTCH_WT": "0",
             },
+            html = True,
             macros = ["Element_{name}_base_generate_abstract".format(name = name)],
             sources = {
                 "IO_CONSTRAINTS": [":mock-array-io"],

--- a/test/orfs/ram_8x7/BUILD
+++ b/test/orfs/ram_8x7/BUILD
@@ -23,6 +23,7 @@ orfs_flow(
         "SETUP_SLACK_MARGIN": "-4000",
         "TAPCELL_TCL": "",
     },
+    html = True,
     sources = {
         "RULES_JSON": [":rules-base.json"],
         "SDC_FILE": [":constraint.sdc"],


### PR DESCRIPTION
Upstream bazel-orfs dropped the @docker_orfs image extraction in favour of source-built tools (OpenROAD/OpenSTA from `@openroad`, yosys/abc from BCR, GNU Make from source) and gained a non-dev bazel_dep on the orfs module. Overrides declared in non-root modules are ignored, so mirror bazel-orfs's orfs git_override and the yosys single_version_override at root. Patches are copied into bazel/orfs-patches/ because git_override only accepts patches from the main repo.

BCR yosys 0.62 ships backends/aiger2/aiger.cc but doesn't compile it, so the internal write_xaiger2 call from abc_new.cc aborts synthesis. Add yosys-backend-aiger2.patch to wire backends/aiger2 into the yosys binary.

test/orfs references the asap7 stdcell dff.v/empty.v that used to come from @docker_orfs; copy them next to the existing per-test .v files.

One of the patches will clear up when https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4159 is merged