### PR TITLE
Static web features catch-up to Qt

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -82,7 +82,7 @@ bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True)
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "df022f4ebaa4130713692fffd2f519d49e9d0b97",
+    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
@@ -110,8 +110,9 @@ single_version_override(
 bazel_dep(name = "rules_scala", version = "7.1.5", dev_dependency = True)
 bazel_dep(name = "bazel-orfs", dev_dependency = True)
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
+bazel_dep(name = "orfs", dev_dependency = True)
 
-BAZEL_ORFS_COMMIT = "f5e20547f93729a4f67929902aaa3386d933bad0"
+BAZEL_ORFS_COMMIT = "6226c2e8f66b51013df7d0df709518f85df9b63c"
 
 BAZEL_ORFS_REMOTE = "https://github.com/The-OpenROAD-Project/bazel-orfs.git"
 
@@ -127,6 +128,37 @@ git_override(
     commit = BAZEL_ORFS_COMMIT,
     remote = BAZEL_ORFS_REMOTE,
     strip_prefix = "verilog",
+)
+
+# Mirrors the override in bazel-orfs/MODULE.bazel. Needed at root because
+# overrides declared in non-root modules are ignored by Bazel. Patches are
+# copied from bazel-orfs/patches/ because git_override only accepts patches
+# from the main repository.
+git_override(
+    module_name = "orfs",
+    commit = "bdb262792fef3797730e1b8341b946426272dcdc",
+    patch_strip = 1,
+    patches = [
+        "//bazel/orfs-patches:0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch",
+        "//bazel/orfs-patches:orfs-preserve-tool-exe-env.patch",
+    ],
+    remote = "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git",
+)
+
+# Mirrors the single_version_override in bazel-orfs/MODULE.bazel: non-root
+# overrides are ignored so apply at root. Gives bazel-orfs rules access to
+# @yosys//:yosys_share and exposes the Yosys headers it needs.
+single_version_override(
+    module_name = "yosys",
+    patch_strip = 1,
+    patches = [
+        "//bazel/orfs-patches:yosys-visibility.patch",
+        "//bazel/orfs-patches:yosys-hdrs.patch",
+        # BCR yosys 0.62 ships backends/aiger2/aiger.cc but doesn't compile
+        # it, so yosys aborts on the internal write_xaiger2 call from
+        # abc_new.cc. Wire it into the binary via BUILD.bazel.
+        "//bazel/orfs-patches:yosys-backend-aiger2.patch",
+    ],
 )
 
 # --- Extensions ---
@@ -183,16 +215,11 @@ npm.npm_translate_lock(
 use_repo(npm, "npm")
 
 orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories", dev_dependency = True)
-
-# To bump version, run: bazelisk run @bazel-orfs//:bump
 orfs.default(
-    # Official image https://hub.docker.com/r/openroad/orfs/tags
-    image = "docker.io/openroad/orfs:26Q1-816-gf40d2f346",
-    # Use OpenROAD of this repo instead of from the docker image
+    # Use OpenROAD of this repo instead of from @openroad
     openroad = "//:openroad",
-    sha256 = "2b05a14ae8062b4af82b245d648e95fa0293e09b61b57468518b66578744afb8",
+    opensta = "//src/sta:opensta",
 )
-use_repo(orfs, "docker_orfs")
 
 SCALA_VERSION = "2.13.17"
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2,6 +2,7 @@
   "lockFileVersion": 24,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
+    "https://bcr.bazel.build/modules/abc/0.62-yosyshq/MODULE.bazel": "325231df11fd3480cb0eb3c9095105ccdfacf34583c3a92d8c0ae46967dbaef6",
     "https://bcr.bazel.build/modules/abc/0.64-yosyshq.bcr.1/MODULE.bazel": "d1ed5b52014c8b7cf2b8a617f1c1f6e363303c92fd84c6c426281a873d0d297a",
     "https://bcr.bazel.build/modules/abc/0.64-yosyshq.bcr.1/source.json": "6c9a69d0cabbe23d1c42d8616405c2e64eabb84e53961872ba2b9ba634c1ffdc",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -92,6 +93,8 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.9.0/source.json": "7ad77c1e8c1b84222d9b3f3cae016a76639435744c19330b0b37c0a3c9da7dc0",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.6/MODULE.bazel": "fd1f9432ca04c947e91b500df69ce7c5b6dbfe1bc45ab1820338205dae3383a6",
     "https://bcr.bazel.build/modules/bazel_worker_api/0.0.6/source.json": "5d68545f224904745a3cabd35aea6bc2b6cc5a78b7f49f3f69660eab2eeeb273",
+    "https://bcr.bazel.build/modules/bison/3.8.2.bcr.5/MODULE.bazel": "96e976881e5670bdb2461157027ed6f3e25084b727aab6b7047210da9af7f678",
+    "https://bcr.bazel.build/modules/bison/3.8.2.bcr.5/source.json": "3cde6dd5a399b67f8124e25e7c7d6eb754807ee7b5a88aab28cf593ff37587ca",
     "https://bcr.bazel.build/modules/bliss/0.73/MODULE.bazel": "26b5476884b67df20a8b87ab2806657123b439e978da76f484427a15fb552b26",
     "https://bcr.bazel.build/modules/bliss/0.73/source.json": "5cb395710670662321f492fc3d4fce3551e3d5708682e4f2320bacaadf6e5e36",
     "https://bcr.bazel.build/modules/boost.algorithm/1.87.0/MODULE.bazel": "d1c8f1466cc1a04a16eebeefe0f54a9508cc9f1a3c21d65d806acbc36593e204",
@@ -365,12 +368,16 @@
     "https://bcr.bazel.build/modules/curl/8.4.0/MODULE.bazel": "0bc250aa1cb69590049383df7a9537c809591fcf876c620f5f097c58fdc9bc10",
     "https://bcr.bazel.build/modules/curl/8.7.1/MODULE.bazel": "088221c35a2939c555e6e47cb31a81c15f8b59f4daa8009b1e9271a502d33485",
     "https://bcr.bazel.build/modules/curl/8.7.1/source.json": "bf9890e809717445b10a3ddc323b6d25c46631589c693a232df8310a25964484",
+    "https://bcr.bazel.build/modules/cxxopts/3.3.1/MODULE.bazel": "dcc6d876d0c779e0f79fb712eddc66cfed44e8b87488728c6bea52e7da9652ec",
+    "https://bcr.bazel.build/modules/cxxopts/3.3.1/source.json": "4076abfd34456e084950451f848934630f4a429cacf496c9dda132fd56980157",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/MODULE.bazel": "868b3f5c956c3657420d2302004c6bb92606bfa47e314bab7f2ba0630c7c966c",
     "https://bcr.bazel.build/modules/cython/3.0.11-1/source.json": "da318be900b8ca9c3d1018839d3bebc5a8e1645620d0848fa2c696d4ecf7c296",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/MODULE.bazel": "f6561baff0fc0035c9c1a9e2b0820de106cdb01b37bf5c81276860ccc863e5b2",
     "https://bcr.bazel.build/modules/eigen/3.4.0.bcr.3/source.json": "a8611a2b5577929ad7e1f44ded19dab21a188125a74ac6192d21d283609f280f",
     "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/MODULE.bazel": "24e05f6f52f37be63a795192848555a2c8c855e7814dbc1ed419fb04a7005464",
     "https://bcr.bazel.build/modules/envoy_api/0.0.0-20241214-918efc9/source.json": "212043ab69d87f7a04aa4f627f725b540cff5e145a3a31a9403d8b6ec2e920c9",
+    "https://bcr.bazel.build/modules/flex/2.6.4.bcr.3/MODULE.bazel": "bd03fa9fe80831cddbfbeefc1de9c14fc444e8ca395cc3d8f1069dd42a15cb65",
+    "https://bcr.bazel.build/modules/flex/2.6.4.bcr.3/source.json": "e73c3695620dc9c7251d3b1361e1d3762315537fc381242fa888f0c386038c36",
     "https://bcr.bazel.build/modules/fmt/11.1.3/MODULE.bazel": "3f422eb59fec5a54faf6d6c5b4cfbd173ad989e2ee5a2da944e19a39a8a90e00",
     "https://bcr.bazel.build/modules/fmt/11.1.3/source.json": "2cc63e28b3de6d476e2730add655af10faaf76523e2b9d72e7752a50e24eeb7d",
     "https://bcr.bazel.build/modules/freetype/2.13.3/MODULE.bazel": "9931a69ef01caba64cc7516c03c2c6c8ad0707526185d31eb81d2987163880e0",
@@ -435,7 +442,8 @@
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.3/MODULE.bazel": "2aaa0e32669002a26ffe421e98913ed70fa5ee21c36fc51d2d51053a5ed07420",
-    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.3/source.json": "fdffd7d4e35124905988e03a5f7ced705df34f5e5134445b7f17f1ecaede9df2",
+    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.4/MODULE.bazel": "adece04128b95bdfe7811a25f48341c11fdf1705a9e59c98ca007f8fc46a0822",
+    "https://bcr.bazel.build/modules/libffi/3.4.7.bcr.4/source.json": "dd63be13678c61409cbc3e821e92b78e252399618759aabbf413515c8782dfb9",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/MODULE.bazel": "e5362dadc90aab6724c83a2cc1e67cbed9c89a05d97fb1f90053c8deb1e445c8",
     "https://bcr.bazel.build/modules/libpfm/4.11.0.bcr.1/source.json": "0646414d9037f8aad148781dd760bec90b0b25ac12fda5e03f8aadbd6b9c61e6",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
@@ -445,10 +453,13 @@
     "https://bcr.bazel.build/modules/libxau/1.0.12.bcr.1/source.json": "4076a85407185883f1563210abf36e80c9636d076d7197169bb431595b3f1151",
     "https://bcr.bazel.build/modules/libxcb/1.17.0.bcr.2/MODULE.bazel": "83d6740822a296210c0c60cd429a892934bdb237f7135eaf395b370c05af32a5",
     "https://bcr.bazel.build/modules/libxcb/1.17.0.bcr.2/source.json": "58c8c30c5d0f6253c94d7a38ab95fd5174683d613d47b9114520da6acef52ae8",
+    "https://bcr.bazel.build/modules/m4/1.4.20.bcr.4/MODULE.bazel": "582008fee330b47fe8db3e786cf78f05c926d2b37fcde0178316bbc5a717e096",
+    "https://bcr.bazel.build/modules/m4/1.4.20.bcr.4/source.json": "c358c98ad1a1bb2243076b7c09b4c113dc4278320d793e343fb6a0d504b34b91",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/MODULE.bazel": "8e380e4698107c5f8766264d4df92e36766248447858db28187151d884995a09",
     "https://bcr.bazel.build/modules/mbedtls/3.6.0/source.json": "1dbe7eb5258050afcc3806b9d43050f71c6f539ce0175535c670df606790b30c",
     "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.11/MODULE.bazel": "ef03f49137ca4abaf6648c795635abb21024d74e97822016cda9dc817e1418ae",
     "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.11/source.json": "3119380662482b112a2f34769793785a10b3734f27f2bef6c778217745935efb",
+    "https://bcr.bazel.build/modules/ncurses/6.4.20221231.bcr.9/MODULE.bazel": "95b2f3dcfb1d2ecaeea67293a10b654a08206414759a761e82fa59bdfe29d0dc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/MODULE.bazel": "87023db2f55fc3a9949c7b08dc711fae4d4be339a80a99d04453c4bb3998eefc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0.bcr.1/MODULE.bazel": "a1c8bb07b5b91d971727c635f449d05623ac9608f6fe4f5f04254ea12f08e349",
     "https://bcr.bazel.build/modules/nlohmann_json/3.12.0.bcr.1/source.json": "93f82a5ae985eb935c539bfee95e04767187818189241ac956f3ccadbdb8fb02",
@@ -538,6 +549,7 @@
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/MODULE.bazel": "e09b434b122bfb786a69179f9b325e35cb1856c3f56a7a81dd61609260ed46e1",
     "https://bcr.bazel.build/modules/re2/2025-08-12.bcr.1/source.json": "a8ae7c09533bf67f9f6e5122d884d5741600b09d78dca6fc0f2f8d2ee0c2d957",
     "https://bcr.bazel.build/modules/re2/2025-08-12/MODULE.bazel": "79bf27a1b8b6834cea391794f2db0180b7b53203795497e261ccd89fe695c74f",
+    "https://bcr.bazel.build/modules/readline/8.2.bcr.3/MODULE.bazel": "800b9efaba7e9d9fdd204f459601002adb4eac33b13c4760c9e16169bf2307a8",
     "https://bcr.bazel.build/modules/readline/8.3.bcr.1/MODULE.bazel": "38dea764ad0ba793af4e6da1a9b6839922a56fe6620a0b3c42d3f0ca8cb714a4",
     "https://bcr.bazel.build/modules/readline/8.3.bcr.1/source.json": "a42bf1ff95df0203dc6f94c26ca86927bf6b2cb397b7888898666b9e57c37e78",
     "https://bcr.bazel.build/modules/readline/8.3/MODULE.bazel": "60b0062649137ab4c8a3521fd2a6976bcc65f16a5344c55b9132c80b361ddafe",
@@ -699,6 +711,8 @@
     "https://bcr.bazel.build/modules/rules_swift/2.1.1/source.json": "40fc69dfaac64deddbb75bd99cdac55f4427d9ca0afbe408576a65428427a186",
     "https://bcr.bazel.build/modules/rules_verilator/0.1.0/MODULE.bazel": "fa4c361e104dc5ebcc5606435edc0d33d7fb1a34876e090e400f1e84091c5743",
     "https://bcr.bazel.build/modules/rules_verilator/0.1.0/source.json": "f0d64b9c31f9601436a200e939df56ed322bfefeac191b891e7f9e4b7411b08d",
+    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/MODULE.bazel": "adcccf08f92e16936d6aa2e872f31a79e80712333be604de750d4b109fae1519",
+    "https://bcr.bazel.build/modules/rules_verilog/1.1.1/source.json": "32a02fe6f97e1a233cff48e0eae70243e2e25d4c57fc684f933e06ef67440d8b",
     "https://bcr.bazel.build/modules/scip/9.2.3/MODULE.bazel": "392d8e76efeab5ef5978e66d15c2ce5e2607b80ea0804163861dd721eed93121",
     "https://bcr.bazel.build/modules/scip/9.2.3/source.json": "5ffc88567e8ff0f3ef59f20364af7cf903108f137fe36420f380e38b6cc92cb1",
     "https://bcr.bazel.build/modules/sed/4.9.bcr.3/MODULE.bazel": "3aca45895b85b6ef65366cc12a45217ba6870f8931d2d62e09c99c772d9736ab",
@@ -751,6 +765,8 @@
     "https://bcr.bazel.build/modules/xorgproto/2024.1.bcr.1/source.json": "2da7b346f94c7d5bb890d8a964110b38b439bd254ad14ec3d37022a7ac9356d8",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/MODULE.bazel": "d0841e12e92973d7e4c97557198335788890dafa9487d6dc0f9b852053a6c5c0",
     "https://bcr.bazel.build/modules/yaml-cpp/0.9.0/source.json": "07a9973d6cee81c8bdb1902e8f90064a0ef9aa2262bffc4df2ed577956c08e1b",
+    "https://bcr.bazel.build/modules/yosys/0.62/MODULE.bazel": "46b664f09e4f4584b8525af5fdf380bf2c4752f31a3d28b0e82c394b822be173",
+    "https://bcr.bazel.build/modules/yosys/0.62/source.json": "bd68594213f1eb7d2298b33b4ded86d58da86d9b392e809da4c007bf0de136d1",
     "https://bcr.bazel.build/modules/yq.bzl/0.1.1/MODULE.bazel": "9039681f9bcb8958ee2c87ffc74bdafba9f4369096a2b5634b88abc0eaefa072",
     "https://bcr.bazel.build/modules/yq.bzl/0.3.2/MODULE.bazel": "0384efa70e8033d842ea73aa4b7199fa099709e236a7264345c03937166670b6",
     "https://bcr.bazel.build/modules/yq.bzl/0.3.2/source.json": "c4ec3e192477e154f08769e29d69e8fd36e8a4f0f623997f3e1f6f7d328f7d7d",
@@ -824,66 +840,67 @@
     },
     "@@bazel-orfs+//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "1T9b1AS979F7qaxyw/OjMC5ZMrWRH/7sYB76ydIETxQ=",
-        "usagesDigest": "XBFQgDjQPrBrrmKJmJEV3y0UmOjGg925SInSvHhAgIA=",
+        "bzlTransitiveDigest": "6Ivbltc2jNkRm28+htORm7l73RA1stBJbjVqGMlLH38=",
+        "usagesDigest": "NdIGqTs4OrpPDOi00oEG/hS+bXWGShN/5NZse+sT870=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "docker_orfs": {
-            "repoRuleId": "@@bazel-orfs+//:docker.bzl%docker_pkg",
-            "attributes": {
-              "image": "docker.io/openroad/orfs:26Q1-816-gf40d2f346",
-              "sha256": "2b05a14ae8062b4af82b245d648e95fa0293e09b61b57468518b66578744afb8",
-              "build_file": "@@bazel-orfs+//:docker.BUILD.bazel",
-              "timeout": 3600,
-              "patch_cmds": [
-                "find . -name BUILD.bazel -delete"
-              ],
-              "patches": [],
-              "patch_args": [
-                "-p1",
-                "-d",
-                "OpenROAD-flow-scripts"
-              ]
-            }
+          "gnumake": {
+            "repoRuleId": "@@bazel-orfs+//:gnumake.bzl%gnumake",
+            "attributes": {}
+          },
+          "mock_klayout": {
+            "repoRuleId": "@@bazel-orfs+//:mock_klayout.bzl%mock_klayout",
+            "attributes": {}
           },
           "config": {
             "repoRuleId": "@@bazel-orfs+//:config.bzl%global_config",
             "attributes": {
-              "klayout": "@@bazel-orfs++orfs_repositories+docker_orfs//:klayout",
-              "make": "@@bazel-orfs++orfs_repositories+docker_orfs//:make",
-              "makefile": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile",
-              "makefile_yosys": "@@bazel-orfs++orfs_repositories+docker_orfs//:makefile_yosys",
+              "klayout": "@@bazel-orfs++orfs_repositories+mock_klayout//:klayout",
+              "make": "@@bazel-orfs++orfs_repositories+gnumake//:make",
+              "makefile": "@@orfs+//flow:makefile",
+              "makefile_yosys": "@@orfs+//flow:makefile_yosys",
               "openroad": "@@//:openroad",
-              "opensta": "@@bazel-orfs++orfs_repositories+docker_orfs//:sta",
-              "pdk": "@@bazel-orfs++orfs_repositories+docker_orfs//:asap7",
-              "yosys": "@@bazel-orfs++orfs_repositories+docker_orfs//:yosys",
-              "yosys_abc": "@@bazel-orfs++orfs_repositories+docker_orfs//:yosys-abc"
+              "opensta": "@@//src/sta:opensta",
+              "pdk": "@@orfs+//flow:asap7",
+              "yosys": "@@yosys+//:yosys",
+              "yosys_abc": "@@abc+//:abc_bin",
+              "yosys_share": "@@yosys+//:yosys_share"
             }
           },
           "orfs_variable_metadata": {
             "repoRuleId": "@@bazel-orfs+//:load_json_file.bzl%load_json_file",
             "attributes": {
-              "src": "@@bazel-orfs++orfs_repositories+docker_orfs//:OpenROAD-flow-scripts/flow/scripts/variables.yaml"
+              "src": "@@orfs+//flow:scripts/variables.yaml"
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
             "bazel-orfs+",
-            "bazel_tools",
-            "bazel_tools"
+            "abc",
+            "abc+"
           ],
           [
             "bazel-orfs+",
-            "docker_orfs",
-            "bazel-orfs++orfs_repositories+docker_orfs"
+            "gnumake",
+            "bazel-orfs++orfs_repositories+gnumake"
           ],
           [
             "bazel-orfs+",
-            "python_3_13_host",
-            "rules_python++python+python_3_13_host"
+            "openroad",
+            ""
+          ],
+          [
+            "bazel-orfs+",
+            "orfs",
+            "orfs+"
+          ],
+          [
+            "bazel-orfs+",
+            "yosys",
+            "yosys+"
           ]
         ]
       }

--- a/bazel/orfs-patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
+++ b/bazel/orfs-patches/0035-fix-remove-non-root-overrides-from-MODULE.bazel.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Wed, 2 Apr 2026 22:00:00 +0200
+Subject: [PATCH] fix: remove non-root overrides from MODULE.bazel
+
+When ORFS is fetched as a non-root dependency, git_override and
+orfs.default() directives are ignored/illegal.  Remove them so
+the module can be used as a dependency without errors.
+
+Signed-off-by: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+---
+ MODULE.bazel | 19 -------------------
+ 1 file changed, 19 deletions(-)
+
+diff --git a/MODULE.bazel b/MODULE.bazel
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -8,13 +8,6 @@
+
+ bazel_dep(name = "bazel-orfs")
+
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-git_override(
+-    module_name = "bazel-orfs",
+-    commit = "f8a4b694b37c8f5322323eba9a9ae37f9541ee17",
+-    remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
+-)
+-
+ bazel_dep(name = "rules_python", version = "1.8.5")
+ bazel_dep(name = "rules_shell", version = "0.6.1")
+
+@@ -36,15 +29,3 @@
+ use_repo(pip, "orfs-pip")
+
+ orfs = use_extension("@bazel-orfs//:extension.bzl", "orfs_repositories")
+-
+-# To bump version, run: bazelisk run @bazel-orfs//:bump
+-orfs.default(
+-    image = "docker.io/openroad/orfs:v3.0-3273-gedf3d6bf",
+-    # Use local files instead of docker image
+-    makefile = "//flow:makefile",
+-    makefile_yosys = "//flow:makefile_yosys",
+-    pdk = "//flow:asap7",
+-    sha256 = "f5692c6325ebcf27cc348e033355ec95c82c35ace1af7e72a0d352624ada143e",
+-)
+-use_repo(orfs, "com_github_nixos_patchelf_download")
+-use_repo(orfs, "docker_orfs")
+--
+2.51.0
+

--- a/bazel/orfs-patches/BUILD.bazel
+++ b/bazel/orfs-patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(glob(["*.patch"]))

--- a/bazel/orfs-patches/orfs-preserve-tool-exe-env.patch
+++ b/bazel/orfs-patches/orfs-preserve-tool-exe-env.patch
@@ -1,0 +1,12 @@
+diff --git a/flow/scripts/variables.mk b/flow/scripts/variables.mk
+--- a/flow/scripts/variables.mk
++++ b/flow/scripts/variables.mk
+@@ -188,7 +188,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
+ export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
+ 
+ define get_variables
+-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
++$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+ endef
+ 
+ export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)

--- a/bazel/orfs-patches/yosys-backend-aiger2.patch
+++ b/bazel/orfs-patches/yosys-backend-aiger2.patch
@@ -1,0 +1,28 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1036,6 +1036,18 @@
+ )
+
+ cc_library(
++    name = "backend_aiger2",
++    srcs = ["backends/aiger2/aiger.cc"],
++    conlyopts = COMMON_COPTS,
++    cxxopts = COMMON_CXXOPTS,
++    local_defines = COMMON_DEFINES,
++    visibility = ["//visibility:public"],
++    deps = [":kernel"],
++    alwayslink = True,
++)
++
++cc_library(
+     name = "backend_json",
+     srcs = ["backends/json/json.cc"],
+     conlyopts = COMMON_COPTS,
+@@ -1087,6 +1099,7 @@
+     visibility = ["//visibility:public"],
+     deps = [
+         ":backend_aiger",
++        ":backend_aiger2",
+         ":backend_json",
+         ":backend_rtlil",
+         ":backend_verilog",

--- a/bazel/orfs-patches/yosys-hdrs.patch
+++ b/bazel/orfs-patches/yosys-hdrs.patch
@@ -1,0 +1,15 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -691,3 +691,12 @@
+         "passes/cmds/sdc/graph-stubs.sdc:sdc/graph-stubs.sdc",
+     ],
+ )
++
++# Header-only target for building out-of-tree yosys plugins.
++cc_library(
++    name = "hdrs",
++    hdrs = glob(["kernel/*.h", "kernel/*.inc"]),
++    defines = COMMON_DEFINES,
++    includes = ["."],
++    visibility = ["//visibility:public"],
++)

--- a/bazel/orfs-patches/yosys-visibility.patch
+++ b/bazel/orfs-patches/yosys-visibility.patch
@@ -1,0 +1,11 @@
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -1,5 +1,8 @@
++# Techlib cell definitions, plugins and other runtime data needed by the
++# synthesis flow.
+ share_tree(
+     name = "yosys_share",
++    visibility = ["//visibility:public"],
+     file_map = {f: share_dst(f) for f in _TECHLIBS_SHARE_SRCS},
+     renames = [
+         # lattice files also appear under ecp5/ with renamed destinations

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -503,24 +503,20 @@ export class ChartsWidget {
         const bar = this._hitTestBar(e);
         if (!bar || bar.count === 0) return;
 
-        try {
-            const resp = await this._app.websocketManager.request({
-                type: 'timing_report',
-                is_setup: this._currentTab === 'setup' ? 1 : 0,
-                max_paths: 50,
-                slack_min: bar.lower,
-                slack_max: bar.upper,
-            });
+        const resp = await this._app.websocketManager.request({
+            type: 'timing_report',
+            is_setup: this._currentTab === 'setup' ? 1 : 0,
+            max_paths: 50,
+            slack_min: bar.lower,
+            slack_max: bar.upper,
+        });
 
-            if (this._app.timingWidget) {
-                this._app.timingWidget.showPaths(
-                    this._currentTab, resp.paths || []);
-                if (this._app.focusComponent) {
-                    this._app.focusComponent('TimingWidget');
-                }
+        if (this._app.timingWidget) {
+            this._app.timingWidget.showPaths(
+                this._currentTab, resp.paths || []);
+            if (this._app.focusComponent) {
+                this._app.focusComponent('TimingWidget');
             }
-        } catch (err) {
-            console.error('Charts bar click error:', err);
         }
     }
 }

--- a/src/web/src/charts-widget.js
+++ b/src/web/src/charts-widget.js
@@ -70,6 +70,21 @@ export function computeHistogramLayout(histogramData, canvasWidth, canvasHeight)
     return { bars, yMax, yTicks, chartArea };
 }
 
+// Hit-test a histogram click/hover: a click anywhere in the column strip
+// above the x-axis for a bin counts as a hit, so low-count bins remain
+// reachable.  Bins with zero count never match.
+export function hitTestColumn(bars, chartArea, mx, my) {
+    if (!bars || !chartArea) return null;
+    if (my < chartArea.top || my > chartArea.bottom) return null;
+    for (const bar of bars) {
+        if (bar.count === 0) continue;
+        if (mx >= bar.x && mx <= bar.x + bar.width) {
+            return bar;
+        }
+    }
+    return null;
+}
+
 // Compute nice Y-axis max and tick values.
 function computeYAxis(maxCount) {
     if (maxCount <= 10) {
@@ -452,17 +467,10 @@ export class ChartsWidget {
     }
 
     _hitTestBar(e) {
-        if (!this._bars) return null;
         const rect = this._canvas.getBoundingClientRect();
         const mx = e.clientX - rect.left;
         const my = e.clientY - rect.top;
-        for (const bar of this._bars) {
-            if (mx >= bar.x && mx <= bar.x + bar.width &&
-                my >= bar.y && my <= bar.y + bar.height) {
-                return bar;
-            }
-        }
-        return null;
+        return hitTestColumn(this._bars, this._chartArea, mx, my);
     }
 
     _handleHover(e) {

--- a/src/web/src/clock-tree-widget.js
+++ b/src/web/src/clock-tree-widget.js
@@ -4,6 +4,7 @@
 // Canvas-based clock tree viewer widget.
 
 import { getThemeColors } from './theme.js';
+import { buildUnavailableStub } from './ui-utils.js';
 
 export const kNodeSpacing = 24;    // pixels between adjacent leaf bins
 export const kNodeSize = 10;       // base node shape size in pixels
@@ -162,6 +163,15 @@ export class ClockTreeWidget {
         this._dragStartY = 0;
         this._dragStartTx = 0;
         this._dragStartTy = 0;
+
+        if (app.websocketManager.isStaticMode) {
+            const stub = buildUnavailableStub(
+                'clock-tree-widget',
+                'Clock tree viewing requires the live OpenROAD server.',
+            );
+            container.appendChild(stub);
+            return;
+        }
 
         this._build(container);
     }

--- a/src/web/src/clock-tree-widget.js
+++ b/src/web/src/clock-tree-widget.js
@@ -309,8 +309,8 @@ export class ClockTreeWidget {
                 this._clockData.length + ' clock' +
                 (this._clockData.length !== 1 ? 's' : '');
         } catch (err) {
-            console.error('Clock tree error:', err);
             this._statusLabel.textContent = 'Error: ' + err.message;
+            throw err;
         }
     }
 

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -377,7 +377,7 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
             if (app.updateHeatMaps) {
                 app.updateHeatMaps(data);
             }
-        }).catch(err => console.error('Heat map update failed', err));
+        });
     }
 
     function renderMapLegend(active) {

--- a/src/web/src/drc-widget.js
+++ b/src/web/src/drc-widget.js
@@ -5,6 +5,7 @@
 // Matches the capabilities of the Qt GUI DRCWidget.
 
 import { dbuRectToBounds } from './coordinates.js';
+import { buildUnavailableStub } from './ui-utils.js';
 
 export class DrcWidget {
     constructor(app, redrawAllLayers) {
@@ -14,6 +15,14 @@ export class DrcWidget {
         this._activeCategory = '';
         this._markerTree = null;  // server response for current category
         this._expandedNodes = new Set();
+
+        if (app.websocketManager.isStaticMode) {
+            this.element = buildUnavailableStub(
+                'drc-widget',
+                'DRC viewing requires the live OpenROAD server.',
+            );
+            return;
+        }
 
         this._build();
         this._loadCategories();

--- a/src/web/src/drc-widget.js
+++ b/src/web/src/drc-widget.js
@@ -83,9 +83,6 @@ export class DrcWidget {
             .then(data => {
                 this._categories = data.categories || [];
                 this._renderCategorySelect();
-            })
-            .catch(err => {
-                console.error('Failed to load DRC categories:', err);
             });
     }
 
@@ -141,7 +138,7 @@ export class DrcWidget {
             errDiv.className = 'drc-error';
             errDiv.textContent = `Error: ${err}`;
             this._treeContainer.appendChild(errDiv);
-            console.error('Failed to load DRC markers:', err);
+            throw err;
         });
     }
 
@@ -320,8 +317,6 @@ export class DrcWidget {
                     this._app.focusComponent('Inspector');
                 }
             }
-        }).catch(err => {
-            console.error('Failed to highlight DRC marker:', err);
         });
     }
 
@@ -357,8 +352,6 @@ export class DrcWidget {
             value: value ? 1 : 0
         }).then(() => {
             this._redrawAllLayers();
-        }).catch(err => {
-            console.error('Failed to update DRC marker:', err);
         });
     }
 
@@ -393,8 +386,6 @@ export class DrcWidget {
                 cb.checked = visible;
             }
             this._redrawAllLayers();
-        }).catch(err => {
-            console.error('Failed to update category visibility:', err);
         });
     }
 

--- a/src/web/src/error-banner.js
+++ b/src/web/src/error-banner.js
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// Paint an unmissable red banner at the top of the document for an
+// unhandled error. Intended for bugs — anything that reaches here is
+// something a developer should fix. Static-mode feature gaps must be
+// surfaced as calm inline messages, not banners; see the widget stubs.
+
+export function installGlobalErrorHandlers(doc = document, win = window) {
+    win.addEventListener('unhandledrejection', (ev) => {
+        showErrorBanner(ev.reason, doc);
+    });
+    win.addEventListener('error', (ev) => {
+        showErrorBanner(ev.error || ev.message, doc);
+    });
+}
+
+export function showErrorBanner(err, doc = document) {
+    const container = getOrCreateContainer(doc);
+    const banner = doc.createElement('div');
+    banner.className = 'error-banner';
+
+    const summary = errorSummary(err);
+    const summaryEl = doc.createElement('div');
+    summaryEl.className = 'error-banner-summary';
+    summaryEl.textContent = summary;
+    banner.appendChild(summaryEl);
+
+    const stack = errorStack(err);
+    if (stack) {
+        const details = doc.createElement('details');
+        const summaryBtn = doc.createElement('summary');
+        summaryBtn.textContent = 'Details';
+        details.appendChild(summaryBtn);
+        const pre = doc.createElement('pre');
+        pre.className = 'error-banner-stack';
+        pre.textContent = stack;
+        details.appendChild(pre);
+        banner.appendChild(details);
+    }
+
+    const close = doc.createElement('button');
+    close.className = 'error-banner-close';
+    close.setAttribute('aria-label', 'Dismiss');
+    close.textContent = '×';
+    close.addEventListener('click', () => banner.remove());
+    banner.appendChild(close);
+
+    container.appendChild(banner);
+    return banner;
+}
+
+function getOrCreateContainer(doc) {
+    let c = doc.getElementById('error-banner-container');
+    if (!c) {
+        c = doc.createElement('div');
+        c.id = 'error-banner-container';
+        doc.body.appendChild(c);
+    }
+    return c;
+}
+
+function errorSummary(err) {
+    if (err instanceof Error) return err.message || String(err);
+    if (err && typeof err === 'object' && err.message) return String(err.message);
+    return String(err);
+}
+
+function errorStack(err) {
+    if (err instanceof Error && err.stack) return err.stack;
+    return null;
+}

--- a/src/web/src/hierarchy-browser.js
+++ b/src/web/src/hierarchy-browser.js
@@ -4,7 +4,7 @@
 // Hierarchy browser widget — module tree with coloring.
 
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
-import { makeResizableHeaders } from './ui-utils.js';
+import { makeResizableHeaders, buildUnavailableStub } from './ui-utils.js';
 
 const COLS = [
     'Instance', 'Module', 'Instances', 'Macros', 'Modules',
@@ -39,6 +39,16 @@ export class HierarchyBrowser {
 
         // Checkbox tree model for module visibility (tri-state propagation).
         this._checkModel = null;
+
+        if (app.websocketManager.isStaticMode) {
+            const stub = buildUnavailableStub(
+                'hierarchy-widget',
+                'Module hierarchy requires the live OpenROAD server.',
+            );
+            container.element.appendChild(stub);
+            app.hierarchyBrowser = this;
+            return;
+        }
 
         this._build(container);
 

--- a/src/web/src/hierarchy-browser.js
+++ b/src/web/src/hierarchy-browser.js
@@ -248,16 +248,10 @@ export class HierarchyBrowser {
             parts.push(`${odbId}:${r},${g},${b},100`);
         }
         const colors = parts.join(';');
-        try {
-            const resp = await this._app.websocketManager.request({
-                type: 'set_module_colors',
-                colors,
-            });
-            console.log('set_module_colors:', resp.count, 'modules,',
-                         parts.length, 'sent');
-        } catch (err) {
-            console.error('set_module_colors failed:', err);
-        }
+        await this._app.websocketManager.request({
+            type: 'set_module_colors',
+            colors,
+        });
 
         // Refresh the modules layer if it exists
         if (this._app.modulesLayer && this._app.map.hasLayer(this._app.modulesLayer)) {

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -70,26 +70,18 @@ export function createInspectorPanel(app, redrawAllLayers) {
         const action = app.focusNets.has(name) ? 'remove' : 'add';
         if (action === 'add') app.focusNets.add(name);
         else app.focusNets.delete(name);
-        try {
-            await app.websocketManager.request({
-                type: 'set_focus_nets', action, net_name: name,
-            });
-        } catch (err) {
-            console.error('set_focus_nets failed:', err);
-        }
+        await app.websocketManager.request({
+            type: 'set_focus_nets', action, net_name: name,
+        });
         redrawAllLayers();
         if (lastInspectData) updateInspector(lastInspectData);
     }
 
     async function clearFocusNets() {
         app.focusNets.clear();
-        try {
-            await app.websocketManager.request({
-                type: 'set_focus_nets', action: 'clear', net_name: '',
-            });
-        } catch (err) {
-            console.error('set_focus_nets clear failed:', err);
-        }
+        await app.websocketManager.request({
+            type: 'set_focus_nets', action: 'clear', net_name: '',
+        });
         redrawAllLayers();
         if (lastInspectData) updateInspector(lastInspectData);
     }
@@ -98,13 +90,9 @@ export function createInspectorPanel(app, redrawAllLayers) {
         const action = app.routeGuideNets.has(name) ? 'remove' : 'add';
         if (action === 'add') app.routeGuideNets.add(name);
         else app.routeGuideNets.delete(name);
-        try {
-            await app.websocketManager.request({
-                type: 'set_route_guides', action, net_name: name,
-            });
-        } catch (err) {
-            console.error('set_route_guides failed:', err);
-        }
+        await app.websocketManager.request({
+            type: 'set_route_guides', action, net_name: name,
+        });
         redrawAllLayers();
         if (lastInspectData) updateInspector(lastInspectData);
     }
@@ -118,6 +106,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
 
     function clearHoverHighlight() {
         clearClientHoverHighlight();
+        // Hover is fire-and-forget; stale rejections on unmount are expected.
         app.websocketManager.request({ type: 'hover', select_id: -1 })
             .then(() => {})
             .catch(() => {});
@@ -190,6 +179,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
             navigateInspector(selectId);
         });
         el.addEventListener('mouseenter', () => {
+            // Hover is fire-and-forget; stale rejections on unmount are expected.
             app.websocketManager.request({ type: 'hover', select_id: selectId })
                 .then(data => {
                     renderHoverRects(data.rects || []);
@@ -221,8 +211,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
             .then(data => {
                 pendingInspectId = null;
                 if (data.error) {
-                    console.error('Inspect error:', data.error);
-                    return;
+                    throw new Error('Inspect: ' + data.error);
                 }
                 updateInspector(data);
 
@@ -242,10 +231,6 @@ export function createInspectorPanel(app, redrawAllLayers) {
                 }
                 // Redraw tiles to update instance highlight
                 redrawAllLayers();
-            })
-            .catch(err => {
-                pendingInspectId = null;
-                console.error('Inspect failed:', err);
             });
     }
 
@@ -264,8 +249,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
             .then(data => {
                 pendingInspectId = null;
                 if (data.error) {
-                    console.error('Inspect back error:', data.error);
-                    return;
+                    throw new Error('Inspect back: ' + data.error);
                 }
                 updateInspector(data);
 
@@ -280,10 +264,6 @@ export function createInspectorPanel(app, redrawAllLayers) {
                     highlightBBox(x1, y1, x2, y2);
                 }
                 redrawAllLayers();
-            })
-            .catch(err => {
-                pendingInspectId = null;
-                console.error('Inspect back failed:', err);
             });
     }
 

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -16,7 +16,10 @@ import { RulerManager } from './ruler.js';
 import { SchematicWidget } from './schematic-widget.js';
 import { DrcWidget } from './drc-widget.js';
 import { TclCompleter } from './tcl-completer.js';
+import { installGlobalErrorHandlers } from './error-banner.js';
 import './theme.js';
+
+installGlobalErrorHandlers();
 
 // ─── Status Indicator ───────────────────────────────────────────────────────
 

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -329,16 +329,24 @@ function tclAppend(text, className) {
 function createTclConsole(container) {
     const el = document.createElement('div');
     el.className = 'tcl-console';
+    const staticMode = app.websocketManager.isStaticMode;
+    const placeholder = staticMode
+        ? 'Tcl console requires the live OpenROAD server.'
+        : 'Enter Tcl command...';
     el.innerHTML =
         '<div class="tcl-output"></div>' +
         '<div class="tcl-input-row">' +
         '  <span class="tcl-prompt">%</span>' +
-        '  <input class="tcl-input" type="text" placeholder="Enter Tcl command..." />' +
+        `  <input class="tcl-input" type="text" placeholder="${placeholder}" />` +
         '</div>';
     container.element.appendChild(el);
 
     app.tclOutputEl = el.querySelector('.tcl-output');
     const input = el.querySelector('.tcl-input');
+    if (staticMode) {
+        input.disabled = true;
+        return;
+    }
     const completer = new TclCompleter(input, app.websocketManager);
 
     input.addEventListener('keydown', (e) => {

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -178,6 +178,9 @@ const HeatMapTileLayer = L.GridLayer.extend({
         }).then(blob => {
             tile.src = URL.createObjectURL(blob);
         }).catch(() => {
+            // Blank tile on failure is the intended UX — the server
+            // reports empty regions by rejecting, and a gap in the
+            // grid would be more confusing than a transparent square.
             tile.src = BLANK_TILE;
         });
 
@@ -208,6 +211,7 @@ const HeatMapTileLayer = L.GridLayer.extend({
                 }
                 tile.src = URL.createObjectURL(blob);
             }).catch(() => {
+                // See _createTile: blank tiles on failure are intended.
                 tile.src = BLANK_TILE;
             });
         }
@@ -646,191 +650,183 @@ app.websocketManager.onPush = (msg) => {
 };
 
 app.websocketManager.readyPromise.then(async () => {
-    try {
-        const [techData, boundsData, heatMapData] = await Promise.all([
-            app.websocketManager.request({ type: 'tech' }),
-            app.websocketManager.request({ type: 'bounds' }),
-            app.websocketManager.request({ type: 'heatmaps' }),
-        ]);
-        app.hasLiberty = techData.has_liberty;
-        app.techData = techData;
+    const [techData, boundsData, heatMapData] = await Promise.all([
+        app.websocketManager.request({ type: 'tech' }),
+        app.websocketManager.request({ type: 'bounds' }),
+        app.websocketManager.request({ type: 'heatmaps' }),
+    ]);
+    app.hasLiberty = techData.has_liberty;
+    app.techData = techData;
 
-        // --- Set Bounds ---
-        const designBounds = boundsData.bounds;
+    // --- Set Bounds ---
+    const designBounds = boundsData.bounds;
 
-        const minY = designBounds[0][0];
-        const minX = designBounds[0][1];
-        const maxY = designBounds[1][0];
-        const maxX = designBounds[1][1];
+    const minY = designBounds[0][0];
+    const minX = designBounds[0][1];
+    const maxY = designBounds[1][0];
+    const maxX = designBounds[1][1];
 
-        const designWidth = maxX - minX;
-        const designHeight = maxY - minY;
+    const designWidth = maxX - minX;
+    const designHeight = maxY - minY;
 
-        // No design loaded — skip map setup, let user open a DB via menu.
-        const hasDesign = designWidth > 0 && designHeight > 0;
-        if (hasDesign) {
-            const tileSize = 256;
-            const maxDXDY = Math.max(designWidth, designHeight);
-            const scale = tileSize / maxDXDY;
-            app.designScale = scale;
-            app.designMaxDXDY = maxDXDY;
-            app.designOriginX = minX;
-            app.designOriginY = minY;
+    // No design loaded — skip map setup, let user open a DB via menu.
+    const hasDesign = designWidth > 0 && designHeight > 0;
+    if (hasDesign) {
+        const tileSize = 256;
+        const maxDXDY = Math.max(designWidth, designHeight);
+        const scale = tileSize / maxDXDY;
+        app.designScale = scale;
+        app.designMaxDXDY = maxDXDY;
+        app.designOriginX = minX;
+        app.designOriginY = minY;
 
-            app.fitBounds = [
-                [-maxDXDY * scale, 0],
-                [(designHeight - maxDXDY) * scale, designWidth * scale]
-            ];
-            app.map.fitBounds(app.fitBounds);
+        app.fitBounds = [
+            [-maxDXDY * scale, 0],
+            [(designHeight - maxDXDY) * scale, designWidth * scale]
+        ];
+        app.map.fitBounds(app.fitBounds);
 
-            if (staticCache) {
-                // Lock to the pre-rendered tile zoom level and fit.
-                const cacheZoom = staticCache.zoom;
-                app.map.setMinZoom(cacheZoom);
-                app.map.setMaxZoom(cacheZoom);
-                app.map.fitBounds(app.fitBounds);
-                app.map.scrollWheelZoom.disable();
-                app.map.touchZoom.disable();
-                app.map.boxZoom.disable();
-                app.map.doubleClickZoom.disable();
-
-                // Path highlight overlay image.
-                app.pathOverlay = L.imageOverlay('', app.fitBounds, {
-                    opacity: 1, interactive: false, zIndex: 1000,
-                });
-                staticCache.setPathOverlay = (src) => {
-                    if (src) {
-                        app.pathOverlay.setUrl(src);
-                        app.pathOverlay.addTo(app.map);
-                    } else {
-                        app.map.removeLayer(app.pathOverlay);
-                    }
-                };
-            }
-        }
-
-        // Click-to-select: convert click position to DBU and query server
         if (staticCache) {
-            // Hide loading overlay — shapes are always ready in static mode.
-            document.getElementById('loading-overlay').style.display = 'none';
-        }
-        if (!staticCache) app.map.on('click', (e) => {
-            if (!app.designScale) return;
-            if (app.rulerManager && app.rulerManager.isActive()) return;
-            const { dbuX: dbu_x, dbuY: dbu_y } = latLngToDbu(
-                e.latlng.lat, e.latlng.lng, app.designScale, app.designMaxDXDY,
-                app.designOriginX, app.designOriginY);
+            // Lock to the pre-rendered tile zoom level and fit.
+            const cacheZoom = staticCache.zoom;
+            app.map.setMinZoom(cacheZoom);
+            app.map.setMaxZoom(cacheZoom);
+            app.map.fitBounds(app.fitBounds);
+            app.map.scrollWheelZoom.disable();
+            app.map.touchZoom.disable();
+            app.map.boxZoom.disable();
+            app.map.doubleClickZoom.disable();
 
-            const vf = {};
-            for (const [k, v] of Object.entries(visibility)) {
-                vf[k] = v ? 1 : 0;
-            }
-            app.websocketManager.request({ type: 'select', dbu_x, dbu_y, zoom: app.map.getZoom(), visible_layers: [...app.visibleLayers], ...vf })
-                .then(data => {
-                    console.log('Select response:', data, 'at dbu', dbu_x, dbu_y);
-                    app.map.closePopup();
-                    if (data.selected && data.selected.length > 0) {
-                        const inst = data.selected[0];
-                        if (inst.type === 'Inst') {
-                            app.selectedInstanceName = inst.name;
-                            if (app.schematicWidget) {
-                                app.schematicWidget.refresh();
-                            }
-                        }
-                        updateInspector(data);
-                        focusComponent('Inspector');
-                        // Highlight selected instance bbox
-                        if (inst.bbox) {
-                            highlightBBox(inst.bbox[0], inst.bbox[1],
-                                          inst.bbox[2], inst.bbox[3]);
-                        }
-                    } else {
-                        updateInspector(null);
-                        if (app.highlightRect) {
-                            app.map.removeLayer(app.highlightRect);
-                            app.highlightRect = null;
+            // Path highlight overlay image.
+            app.pathOverlay = L.imageOverlay('', app.fitBounds, {
+                opacity: 1, interactive: false, zIndex: 1000,
+            });
+            staticCache.setPathOverlay = (src) => {
+                if (src) {
+                    app.pathOverlay.setUrl(src);
+                    app.pathOverlay.addTo(app.map);
+                } else {
+                    app.map.removeLayer(app.pathOverlay);
+                }
+            };
+        }
+    }
+
+    // Click-to-select: convert click position to DBU and query server
+    if (staticCache) {
+        // Hide loading overlay — shapes are always ready in static mode.
+        document.getElementById('loading-overlay').style.display = 'none';
+    }
+    if (!staticCache) app.map.on('click', (e) => {
+        if (!app.designScale) return;
+        if (app.rulerManager && app.rulerManager.isActive()) return;
+        const { dbuX: dbu_x, dbuY: dbu_y } = latLngToDbu(
+            e.latlng.lat, e.latlng.lng, app.designScale, app.designMaxDXDY,
+            app.designOriginX, app.designOriginY);
+
+        const vf = {};
+        for (const [k, v] of Object.entries(visibility)) {
+            vf[k] = v ? 1 : 0;
+        }
+        app.websocketManager.request({ type: 'select', dbu_x, dbu_y, zoom: app.map.getZoom(), visible_layers: [...app.visibleLayers], ...vf })
+            .then(data => {
+                app.map.closePopup();
+                if (data.selected && data.selected.length > 0) {
+                    const inst = data.selected[0];
+                    if (inst.type === 'Inst') {
+                        app.selectedInstanceName = inst.name;
+                        if (app.schematicWidget) {
+                            app.schematicWidget.refresh();
                         }
                     }
-                    redrawAllLayers();
-                })
-                .catch(err => {
-                    console.error('Select failed:', err);
-                });
+                    updateInspector(data);
+                    focusComponent('Inspector');
+                    // Highlight selected instance bbox
+                    if (inst.bbox) {
+                        highlightBBox(inst.bbox[0], inst.bbox[1],
+                                      inst.bbox[2], inst.bbox[3]);
+                    }
+                } else {
+                    updateInspector(null);
+                    if (app.highlightRect) {
+                        app.map.removeLayer(app.highlightRect);
+                        app.highlightRect = null;
+                    }
+                }
+                redrawAllLayers();
+            });
+    });
+
+    // ─── Right-click rubber-band zoom ──────────────────────────────
+    if (!staticCache) {
+        const container = app.map.getContainer();
+        let rbStart = null;   // {x, y} in client coords
+        let rbDiv = null;     // overlay element
+
+        container.addEventListener('contextmenu', (e) => {
+            e.preventDefault();
         });
 
-        // ─── Right-click rubber-band zoom ──────────────────────────────
-        if (!staticCache) {
-            const container = app.map.getContainer();
-            let rbStart = null;   // {x, y} in client coords
-            let rbDiv = null;     // overlay element
+        container.addEventListener('mousedown', (e) => {
+            if (e.button !== 2) return;
+            rbStart = { x: e.clientX, y: e.clientY };
+            app.map.dragging.disable();
+        });
 
-            container.addEventListener('contextmenu', (e) => {
-                e.preventDefault();
-            });
+        window.addEventListener('mousemove', (e) => {
+            if (!rbStart) return;
+            const dx = e.clientX - rbStart.x;
+            const dy = e.clientY - rbStart.y;
+            if (!rbDiv && Math.abs(dx) >= 4 && Math.abs(dy) >= 4) {
+                rbDiv = document.createElement('div');
+                rbDiv.className = 'rubber-band';
+                document.body.appendChild(rbDiv);
+            }
+            if (rbDiv) {
+                const left = Math.min(rbStart.x, e.clientX);
+                const top = Math.min(rbStart.y, e.clientY);
+                rbDiv.style.left = left + 'px';
+                rbDiv.style.top = top + 'px';
+                rbDiv.style.width = Math.abs(dx) + 'px';
+                rbDiv.style.height = Math.abs(dy) + 'px';
+            }
+        });
 
-            container.addEventListener('mousedown', (e) => {
-                if (e.button !== 2) return;
-                rbStart = { x: e.clientX, y: e.clientY };
-                app.map.dragging.disable();
-            });
+        window.addEventListener('mouseup', (e) => {
+            if (!rbStart) return;
+            const wasShowing = !!rbDiv;
+            if (rbDiv) {
+                rbDiv.remove();
+                rbDiv = null;
+            }
+            const start = rbStart;
+            rbStart = null;
+            app.map.dragging.enable();
 
-            window.addEventListener('mousemove', (e) => {
-                if (!rbStart) return;
-                const dx = e.clientX - rbStart.x;
-                const dy = e.clientY - rbStart.y;
-                if (!rbDiv && Math.abs(dx) >= 4 && Math.abs(dy) >= 4) {
-                    rbDiv = document.createElement('div');
-                    rbDiv.className = 'rubber-band';
-                    document.body.appendChild(rbDiv);
-                }
-                if (rbDiv) {
-                    const left = Math.min(rbStart.x, e.clientX);
-                    const top = Math.min(rbStart.y, e.clientY);
-                    rbDiv.style.left = left + 'px';
-                    rbDiv.style.top = top + 'px';
-                    rbDiv.style.width = Math.abs(dx) + 'px';
-                    rbDiv.style.height = Math.abs(dy) + 'px';
-                }
-            });
+            if (!wasShowing) return;
 
-            window.addEventListener('mouseup', (e) => {
-                if (!rbStart) return;
-                const wasShowing = !!rbDiv;
-                if (rbDiv) {
-                    rbDiv.remove();
-                    rbDiv = null;
-                }
-                const start = rbStart;
-                rbStart = null;
-                app.map.dragging.enable();
+            // Convert the two screen corners to lat/lng and zoom
+            const rect = container.getBoundingClientRect();
+            const p1 = app.map.containerPointToLatLng([
+                start.x - rect.left, start.y - rect.top]);
+            const p2 = app.map.containerPointToLatLng([
+                e.clientX - rect.left, e.clientY - rect.top]);
+            app.map.fitBounds([
+                [Math.min(p1.lat, p2.lat), Math.min(p1.lng, p2.lng)],
+                [Math.max(p1.lat, p2.lat), Math.max(p1.lng, p2.lng)],
+            ]);
+        });
+    }
 
-                if (!wasShowing) return;
+    populateDisplayControls(app, visibility, WebSocketTileLayer,
+                            techData, redrawAllLayers, HeatMapTileLayer);
+    updateHeatMaps(heatMapData);
 
-                // Convert the two screen corners to lat/lng and zoom
-                const rect = container.getBoundingClientRect();
-                const p1 = app.map.containerPointToLatLng([
-                    start.x - rect.left, start.y - rect.top]);
-                const p2 = app.map.containerPointToLatLng([
-                    e.clientX - rect.left, e.clientY - rect.top]);
-                app.map.fitBounds([
-                    [Math.min(p1.lat, p2.lat), Math.min(p1.lng, p2.lng)],
-                    [Math.max(p1.lat, p2.lat), Math.max(p1.lng, p2.lng)],
-                ]);
-            });
-        }
-
-        populateDisplayControls(app, visibility, WebSocketTileLayer,
-                                techData, redrawAllLayers, HeatMapTileLayer);
-        updateHeatMaps(heatMapData);
-
-        // Only show the loading overlay if a design is loaded but shapes
-        // aren't ready yet.  On browser reload (without server restart),
-        // shapes are already built so we skip the overlay.
-        if (hasDesign && !boundsData.shapes_ready) {
-            document.getElementById('loading-overlay').style.display = 'flex';
-        }
-    } catch (err) {
-        console.error('Failed to load initial data from server:', err);
+    // Only show the loading overlay if a design is loaded but shapes
+    // aren't ready yet.  On browser reload (without server restart),
+    // shapes are already built so we skip the overlay.
+    if (hasDesign && !boundsData.shapes_ready) {
+        document.getElementById('loading-overlay').style.display = 'flex';
     }
 });
 

--- a/src/web/src/menu-bar.js
+++ b/src/web/src/menu-bar.js
@@ -6,9 +6,11 @@ export function createMenuBar(app) {
     const menus = [
         { label: 'File', items: [
             { label: 'Open DB...', action: () => showPathDialog(app, 'Open DB', 'read_db'),
-              enabledWhen: () => !app.designScale },
+              enabledWhen: () => !app.designScale
+                                 && !app.websocketManager.isStaticMode },
             { label: 'Save DB...', action: () => showPathDialog(app, 'Save DB', 'write_db'),
-              enabledWhen: () => !!app.designScale },
+              enabledWhen: () => !!app.designScale
+                                 && !app.websocketManager.isStaticMode },
         ]},
         { label: 'View', items: [
             { label: 'Fit', shortcut: 'F', action: () => { if (app.fitBounds) app.map.fitBounds(app.fitBounds); } },

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -210,7 +210,6 @@ export class SchematicWidget {
     _fetchInspect(instName) {
         const wm = this.appState.websocketManager;
         if (!wm) return;
-        console.log('[Schematic] inspect:', instName);
         wm.request({ type: 'schematic_inspect', inst_name: instName })
             .then(data => {
                 if (this.appState.updateInspector) {
@@ -225,8 +224,8 @@ export class SchematicWidget {
                 }
             })
             .catch(err => {
-                console.error('schematic_inspect failed:', err);
                 this.setStatus(`Inspect error: ${err}`);
+                throw err;
             });
     }
 
@@ -303,10 +302,9 @@ export class SchematicWidget {
             }
             this.skin = skin;
             this._netlistsvgReady = true;
-            console.log('NetlistSVG ready.');
         } catch (err) {
-            console.error('NetlistSVG init failed:', err);
             this.setStatus(`Init error: ${err.message}`);
+            throw err;
         }
     }
 
@@ -425,8 +423,8 @@ export class SchematicWidget {
             const cellCount = Object.keys(yosysJson.modules.top.cells).length;
             this.setStatus(`${cellCount} cell${cellCount !== 1 ? 's' : ''}`);
         } catch (err) {
-            console.error('NetlistSVG render failed:', err);
             this.setStatus(`Render error: ${err.message || err}`);
+            throw err;
         }
     }
 }

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -4,10 +4,22 @@
 // NetlistsVG is used to render a Yosys-compatible JSON netlist into an SVG.
 // It is loaded via <script> tags in index.html and exposed as window.netlistsvg.
 
+import { buildUnavailableStub } from './ui-utils.js';
+
 export class SchematicWidget {
     constructor(container, appState) {
         this.container = container;
         this.appState = appState;
+
+        if (appState.websocketManager && appState.websocketManager.isStaticMode) {
+            this.element = buildUnavailableStub(
+                'schematic-widget',
+                'Schematic viewing requires the live OpenROAD server.',
+            );
+            this.container.element.appendChild(this.element);
+            appState.schematicWidget = this;
+            return;
+        }
 
         this.element = document.createElement('div');
         this.element.className = 'schematic-widget';

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -1443,6 +1443,15 @@ html[data-theme="dark"] .schematic-widget svg {
     color: var(--fg-secondary);
     text-align: center;
 }
+
+/* Neutral "feature not available in this mode" stub. */
+.widget-unavailable {
+    padding: 24px 16px;
+    color: var(--fg-secondary);
+    text-align: center;
+    font-size: 13px;
+    line-height: 1.5;
+}
 .drc-error {
     color: var(--error);
 }

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -973,7 +973,7 @@ html, body {
     right: 12px;
     min-width: 260px;
     max-width: 420px;
-    background: var(--bg-primary);
+    background: var(--bg-panel);
     border: 1px solid var(--border);
     border-radius: 4px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -976,7 +976,7 @@ html, body {
     background: var(--bg-panel);
     border: 1px solid var(--border);
     border-radius: 4px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    box-shadow: 0 4px 12px var(--shadow);
     padding: 10px 12px 12px;
     z-index: 10;
 }

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -1446,3 +1446,74 @@ html[data-theme="dark"] .schematic-widget svg {
 .drc-error {
     color: var(--error);
 }
+
+/* ─── Error Banner ─────────────────────────────────────────────────────── */
+
+/* Fixed container for stacked error banners. Appears above GoldenLayout. */
+#error-banner-container {
+    position: fixed;
+    top: 24px;
+    left: 0;
+    right: 0;
+    z-index: 100000;
+    display: flex;
+    flex-direction: column;
+    pointer-events: none;
+}
+
+.error-banner {
+    pointer-events: auto;
+    background: var(--error);
+    color: var(--fg-white);
+    padding: 10px 40px 10px 16px;
+    font: 13px/1.4 monospace;
+    box-shadow: 0 2px 8px var(--shadow-strong);
+    position: relative;
+    border-bottom: 1px solid var(--shadow-strong);
+}
+
+.error-banner-summary {
+    font-weight: bold;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.error-banner details {
+    margin-top: 4px;
+}
+
+.error-banner summary {
+    cursor: pointer;
+    font-weight: normal;
+    opacity: 0.85;
+}
+
+.error-banner-stack {
+    margin: 6px 0 0 0;
+    padding: 8px;
+    background: rgba(0, 0, 0, 0.25);
+    max-height: 240px;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 12px;
+}
+
+.error-banner-close {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    width: 26px;
+    height: 26px;
+    border: none;
+    background: transparent;
+    color: var(--fg-white);
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.error-banner-close:hover {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 3px;
+}

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -902,6 +902,12 @@ html, body {
     border-top: 1px solid var(--border);
 }
 
+.timing-path-table-container:focus-visible,
+.timing-detail-table-container:focus-visible {
+    outline: 2px solid var(--accent-tab);
+    outline-offset: -2px;
+}
+
 .timing-table {
     width: 100%;
     border-collapse: collapse;

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -836,6 +836,7 @@ html, body {
     font-size: 13px;
     font-family: monospace;
     overflow: hidden;
+    position: relative;
 }
 
 .timing-toolbar {
@@ -964,6 +965,65 @@ html, body {
     white-space: normal;
     word-break: break-all;
     overflow-wrap: break-word;
+}
+
+.timing-inspector-popover {
+    position: absolute;
+    top: 40px;
+    right: 12px;
+    min-width: 260px;
+    max-width: 420px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    padding: 10px 12px 12px;
+    z-index: 10;
+}
+
+.timing-inspector-popover .close-btn {
+    position: absolute;
+    top: 4px;
+    right: 6px;
+    width: 22px;
+    height: 22px;
+    border: none;
+    background: transparent;
+    color: var(--fg-primary);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.timing-inspector-popover .close-btn:hover {
+    background: var(--bg-hover);
+    border-radius: 2px;
+}
+
+.timing-inspector-title {
+    font-weight: bold;
+    margin-bottom: 6px;
+    padding-right: 20px;
+}
+
+.timing-inspector-popover table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.timing-inspector-popover th,
+.timing-inspector-popover td {
+    text-align: left;
+    vertical-align: top;
+    padding: 2px 6px;
+    word-break: break-all;
+}
+
+.timing-inspector-popover th {
+    color: var(--fg-muted);
+    font-weight: normal;
+    white-space: nowrap;
+    width: 7em;
 }
 
 /* ─── Hierarchy Browser ──────────────────────────────────────────────── */

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -57,6 +57,8 @@ html[data-theme="dark"] {
     --spinner-head: #ccc;
 
     --ruler-label-bg: rgba(0, 0, 0, 0.75);
+
+    --hover-pulse: #ffe85c;
 }
 
 html[data-theme="light"] {
@@ -116,6 +118,8 @@ html[data-theme="light"] {
     --spinner-head: #333;
 
     --ruler-label-bg: rgba(255, 255, 255, 0.85);
+
+    --hover-pulse: #d97706;
 }
 
 /* ─── Ruler overlay ──────────────────────────────────────────────────────── */
@@ -798,29 +802,26 @@ html, body {
 
 /* Hover highlight pulse animation */
 .hover-highlight {
-    stroke: #ffe85c;
+    stroke: var(--hover-pulse);
     stroke-width: 3px;
     stroke-opacity: 1;
-    fill: #fff27a;
+    fill: var(--hover-pulse);
     fill-opacity: 0.14;
     vector-effect: non-scaling-stroke;
     animation: hover-pulse 0.9s ease-out 3;
 }
 @keyframes hover-pulse {
     0% {
-        stroke: #fff6b0;
         stroke-width: 7px;
         stroke-opacity: 1;
         fill-opacity: 0.28;
     }
     55% {
-        stroke: #ffffff;
         stroke-width: 5px;
         stroke-opacity: 1;
         fill-opacity: 0.06;
     }
     100% {
-        stroke: #ffe85c;
         stroke-width: 3px;
         stroke-opacity: 0.95;
         fill-opacity: 0.14;

--- a/src/web/src/tcl-completer.js
+++ b/src/web/src/tcl-completer.js
@@ -183,7 +183,8 @@ export class TclCompleter {
                 this._commandCache = data.completions;
             }
             if (data.mode === 'commands' && !this._commandCache) {
-                // Request full list for caching on first non-empty prefix
+                // Request full list for caching on first non-empty prefix.
+                // Cache refresh is opportunistic; next keystroke retries.
                 this._ws.request({
                     type: 'tcl_complete',
                     line: '',
@@ -200,6 +201,7 @@ export class TclCompleter {
                 data.replace_end
             );
         }).catch(() => {
+            // Hide popup when suggestions unavailable.
             this._hidePopup();
         });
     }

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -193,11 +193,10 @@ export class TimingWidget {
             this._renderPathTable();
             this._renderDetailTable();
             this._clearTimingHighlight();
-        } catch (e) {
-            console.error('Timing fetch failed:', e);
+        } finally {
+            this._updateBtn.disabled = false;
+            this._updateBtn.textContent = 'Update';
         }
-        this._updateBtn.disabled = false;
-        this._updateBtn.textContent = 'Update';
     }
 
     _clearTimingHighlight() {
@@ -222,8 +221,7 @@ export class TimingWidget {
             type: 'timing_highlight',
             path_index: highlightIdx,
             is_setup: this._currentTab === 'setup' ? 1 : 0,
-        }).then(() => this._redrawAllLayers())
-          .catch(err => console.error('timing_highlight error:', err));
+        }).then(() => this._redrawAllLayers());
     }
 
     _renderPathTable() {

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -128,7 +128,6 @@ export class TimingWidget {
 
         // Keyboard navigation — path table
         this._pathTableContainer.setAttribute('tabindex', '0');
-        this._pathTableContainer.style.outline = 'none';
         this._pathTableContainer.addEventListener('keydown', (e) => {
             if (e.key === 'ArrowDown') {
                 e.preventDefault();
@@ -146,7 +145,6 @@ export class TimingWidget {
 
         // Keyboard navigation — detail table
         this._detailTableContainer.setAttribute('tabindex', '0');
-        this._detailTableContainer.style.outline = 'none';
         this._detailTableContainer.addEventListener('keydown', (e) => {
             if (e.key === 'ArrowDown') {
                 e.preventDefault();

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -16,6 +16,8 @@ export class TimingWidget {
         this._selectedPathIndex = -1;
         this._detailTab = 'data';
         this._selectedDetailIndex = -1;
+        this._inspectorPopover = null;
+        this._inspectorCloseHandlers = null;
 
         this._build();
     }
@@ -309,6 +311,85 @@ export class TimingWidget {
         }).then(() => this._redrawAllLayers());
     }
 
+    _showInspector(idx) {
+        this._closeInspector();
+
+        const paths = this._currentTab === 'setup' ? this._setupPaths : this._holdPaths;
+        const path = paths[this._selectedPathIndex];
+        if (!path) return;
+        const nodes = this._detailTab === 'data' ? path.data_nodes : path.capture_nodes;
+        const n = nodes?.[idx];
+        if (!n) return;
+
+        const popover = document.createElement('div');
+        popover.className = 'timing-inspector-popover';
+
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'close-btn';
+        closeBtn.textContent = '×';
+        closeBtn.addEventListener('click', () => this._closeInspector());
+        popover.appendChild(closeBtn);
+
+        const title = document.createElement('div');
+        title.className = 'timing-inspector-title';
+        title.textContent = 'Pin Inspector';
+        popover.appendChild(title);
+
+        const rows = [
+            ['Pin', n.pin],
+            ['Direction', n.direction],
+            ['Instance', n.instance],
+            ['Master', n.master],
+            ['Net', n.net],
+            ['Fanout', n.fanout],
+            ['Time', fmtTime(n.time)],
+            ['Delay', fmtTime(n.delay)],
+            ['Slew', fmtTime(n.slew)],
+            ['Load', fmtTime(n.load)],
+        ];
+        const table = document.createElement('table');
+        for (const [k, v] of rows) {
+            if (v === undefined || v === null || v === '') continue;
+            const tr = document.createElement('tr');
+            const kth = document.createElement('th');
+            kth.textContent = k;
+            const vtd = document.createElement('td');
+            vtd.textContent = String(v);
+            tr.appendChild(kth);
+            tr.appendChild(vtd);
+            table.appendChild(tr);
+        }
+        popover.appendChild(table);
+
+        this.element.appendChild(popover);
+        this._inspectorPopover = popover;
+
+        const onKeyDown = (e) => {
+            if (e.key === 'Escape') this._closeInspector();
+        };
+        const onMouseDown = (e) => {
+            if (!popover.contains(e.target)) this._closeInspector();
+        };
+        document.addEventListener('keydown', onKeyDown);
+        // Defer outside-click listener so the dblclick that opened us
+        // doesn't instantly close us.
+        setTimeout(() => {
+            document.addEventListener('mousedown', onMouseDown, true);
+        }, 0);
+        this._inspectorCloseHandlers = { onKeyDown, onMouseDown };
+    }
+
+    _closeInspector() {
+        if (!this._inspectorPopover) return;
+        this._inspectorPopover.remove();
+        this._inspectorPopover = null;
+        if (this._inspectorCloseHandlers) {
+            document.removeEventListener('keydown', this._inspectorCloseHandlers.onKeyDown);
+            document.removeEventListener('mousedown', this._inspectorCloseHandlers.onMouseDown, true);
+            this._inspectorCloseHandlers = null;
+        }
+    }
+
     _renderDetailTable() {
         // Preserve column widths across re-renders.
         const oldHeaders = this._detailTable.querySelectorAll('thead th');
@@ -352,6 +433,10 @@ export class TimingWidget {
             }
             tr.style.cursor = 'pointer';
             tr.addEventListener('click', () => this._selectDetailRow(idx));
+            tr.addEventListener('dblclick', (e) => {
+                e.preventDefault();
+                this._showInspector(idx);
+            });
             tbody.appendChild(tr);
         });
         this._detailTable.appendChild(tbody);

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -323,15 +323,8 @@ export class TimingWidget {
         }).then(() => this._redrawAllLayers());
     }
 
-    _showInspector(idx) {
+    _showInspector(n) {
         this._closeInspector();
-
-        const paths = this._currentTab === 'setup' ? this._setupPaths : this._holdPaths;
-        const path = paths[this._selectedPathIndex];
-        if (!path) return;
-        const nodes = this._detailTab === 'data' ? path.data_nodes : path.capture_nodes;
-        const n = nodes?.[idx];
-        if (!n) return;
 
         const popover = document.createElement('div');
         popover.className = 'timing-inspector-popover';
@@ -385,10 +378,10 @@ export class TimingWidget {
         document.addEventListener('keydown', onKeyDown);
         // Defer outside-click listener so the dblclick that opened us
         // doesn't instantly close us.
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
             document.addEventListener('mousedown', onMouseDown, true);
         }, 0);
-        this._inspectorCloseHandlers = { onKeyDown, onMouseDown };
+        this._inspectorCloseHandlers = { onKeyDown, onMouseDown, timeoutId };
     }
 
     _togglePathSort(key) {
@@ -415,6 +408,7 @@ export class TimingWidget {
         this._inspectorPopover.remove();
         this._inspectorPopover = null;
         if (this._inspectorCloseHandlers) {
+            clearTimeout(this._inspectorCloseHandlers.timeoutId);
             document.removeEventListener('keydown', this._inspectorCloseHandlers.onKeyDown);
             document.removeEventListener('mousedown', this._inspectorCloseHandlers.onMouseDown, true);
             this._inspectorCloseHandlers = null;
@@ -470,7 +464,7 @@ export class TimingWidget {
             tr.addEventListener('click', () => this._selectDetailRow(idx));
             tr.addEventListener('dblclick', (e) => {
                 e.preventDefault();
-                this._showInspector(idx);
+                this._showInspector(n);
             });
             tbody.appendChild(tr);
         });
@@ -501,6 +495,7 @@ export function fmtTime(v) {
 
 // Numeric-aware comparison honoring sort direction.
 export function compareValues(a, b, dir) {
+    if (a === b) return 0;
     const mul = dir === 'desc' ? -1 : 1;
     const na = typeof a === 'number';
     const nb = typeof b === 'number';

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -18,6 +18,8 @@ export class TimingWidget {
         this._selectedDetailIndex = -1;
         this._inspectorPopover = null;
         this._inspectorCloseHandlers = null;
+        this._pathSort = { key: 'slack', dir: 'asc' };
+        this._detailSort = null;
 
         this._build();
     }
@@ -234,13 +236,23 @@ export class TimingWidget {
         const oldHeaders = this._pathTable.querySelectorAll('thead th');
         const savedWidths = Array.from(oldHeaders, th => th.style.width);
 
+        // Sort in place, tracking the selected path by object identity
+        // so its row index follows the re-sort.
+        const selectedPath = this._selectedPathIndex >= 0
+            ? paths[this._selectedPathIndex] : null;
+        sortRowsInPlace(paths, this._pathSort);
+        if (selectedPath) {
+            this._selectedPathIndex = paths.indexOf(selectedPath);
+        }
+
         this._pathTable.innerHTML = '';
 
         const thead = document.createElement('thead');
         const hr = document.createElement('tr');
         for (const col of TimingWidget.PATH_COLS) {
-            const th = document.createElement('th');
-            th.textContent = col;
+            const th = makeSortableHeader(col, this._pathSort, () => {
+                this._togglePathSort(col.key);
+            });
             hr.appendChild(th);
         }
         thead.appendChild(hr);
@@ -379,6 +391,25 @@ export class TimingWidget {
         this._inspectorCloseHandlers = { onKeyDown, onMouseDown };
     }
 
+    _togglePathSort(key) {
+        if (this._pathSort && this._pathSort.key === key) {
+            this._pathSort = { key, dir: this._pathSort.dir === 'asc' ? 'desc' : 'asc' };
+        } else {
+            this._pathSort = { key, dir: 'asc' };
+        }
+        this._renderPathTable();
+        this._renderDetailTable();
+    }
+
+    _toggleDetailSort(key) {
+        if (this._detailSort && this._detailSort.key === key) {
+            this._detailSort = { key, dir: this._detailSort.dir === 'asc' ? 'desc' : 'asc' };
+        } else {
+            this._detailSort = { key, dir: 'asc' };
+        }
+        this._renderDetailTable();
+    }
+
     _closeInspector() {
         if (!this._inspectorPopover) return;
         this._inspectorPopover.remove();
@@ -401,13 +432,17 @@ export class TimingWidget {
         if (this._selectedPathIndex < 0 || this._selectedPathIndex >= paths.length) return;
 
         const path = paths[this._selectedPathIndex];
-        const nodes = this._detailTab === 'data' ? path.data_nodes : path.capture_nodes;
+        const nodesSrc = this._detailTab === 'data' ? path.data_nodes : path.capture_nodes;
+        const nodes = this._detailSort
+            ? sortRowsInPlace([...nodesSrc], this._detailSort)
+            : nodesSrc;
 
         const thead = document.createElement('thead');
         const hr = document.createElement('tr');
         for (const col of TimingWidget.DETAIL_COLS) {
-            const th = document.createElement('th');
-            th.textContent = col;
+            const th = makeSortableHeader(col, this._detailSort, () => {
+                this._toggleDetailSort(col.key);
+            });
             hr.appendChild(th);
         }
         thead.appendChild(hr);
@@ -464,6 +499,80 @@ export function fmtTime(v) {
     return typeof v === 'number' ? v.toFixed(4) : String(v);
 }
 
-TimingWidget.PATH_COLS = ['Clock', 'Required', 'Arrival', 'Slack', 'Skew',
-                          'Logic Delay', 'Logic Depth', 'Fanout', 'Start', 'End'];
-TimingWidget.DETAIL_COLS = ['Pin', 'Fanout', 'R/F', 'Time', 'Delay', 'Slew', 'Load'];
+// Numeric-aware comparison honoring sort direction.
+export function compareValues(a, b, dir) {
+    const mul = dir === 'desc' ? -1 : 1;
+    const na = typeof a === 'number';
+    const nb = typeof b === 'number';
+    if (na && nb) return (a - b) * mul;
+    // Missing values sort last regardless of direction.
+    if (a === undefined || a === null || a === '') return 1;
+    if (b === undefined || b === null || b === '') return -1;
+    return String(a).localeCompare(String(b)) * mul;
+}
+
+// Stable sort of `rows` by `sort = {key, dir}`.  Array.prototype.sort
+// is stable since ES2019 (Node 12+); we rely on that.
+export function sortRowsInPlace(rows, sort) {
+    if (!sort) return rows;
+    rows.sort((a, b) => compareValues(a[sort.key], b[sort.key], sort.dir));
+    return rows;
+}
+
+// Build a <th> with label, click-to-sort, optional tooltip, and sort
+// indicator.  Clicks on the resize grip are ignored so resizing and
+// sorting do not conflict.
+export function makeSortableHeader(col, activeSort, onClick) {
+    const th = document.createElement('th');
+    th.textContent = col.label;
+    if (col.tooltip) th.title = col.tooltip;
+    if (activeSort && activeSort.key === col.key) {
+        const ind = document.createElement('span');
+        ind.className = 'sort-indicator';
+        ind.textContent = activeSort.dir === 'asc' ? ' ▲' : ' ▼';
+        th.appendChild(ind);
+    }
+    th.style.cursor = 'pointer';
+    th.addEventListener('click', (e) => {
+        if (e.target && e.target.classList
+            && e.target.classList.contains('col-resize-grip')) {
+            return;
+        }
+        onClick();
+    });
+    return th;
+}
+
+// Column descriptors: {label, key, tooltip?}.  `key` points at the row
+// object field used for sorting; the Skew / Logic Delay / Logic Depth
+// tooltips mirror staGui.cpp:183–196 for parity with the Qt GUI.
+TimingWidget.PATH_COLS = [
+    { label: 'Clock', key: 'end_clk' },
+    { label: 'Required', key: 'required' },
+    { label: 'Arrival', key: 'arrival' },
+    { label: 'Slack', key: 'slack' },
+    { label: 'Skew', key: 'skew',
+      tooltip: 'The difference in arrival times between\n'
+             + 'source and destination clock pins of a macro/register,\n'
+             + 'adjusted for CRPR and subtracting a clock period.\n'
+             + 'Setup and hold times account for internal clock delays.' },
+    { label: 'Logic Delay', key: 'path_delay',
+      tooltip: 'Path delay from instances (excluding buffers and consecutive '
+             + 'inverter pairs)' },
+    { label: 'Logic Depth', key: 'logic_depth',
+      tooltip: 'Path instances (excluding buffers and consecutive inverter '
+             + 'pairs)' },
+    { label: 'Fanout', key: 'fanout' },
+    { label: 'Start', key: 'start_pin' },
+    { label: 'End', key: 'end_pin' },
+];
+
+TimingWidget.DETAIL_COLS = [
+    { label: 'Pin', key: 'pin' },
+    { label: 'Fanout', key: 'fanout' },
+    { label: 'R/F', key: 'rise' },
+    { label: 'Time', key: 'time' },
+    { label: 'Delay', key: 'delay' },
+    { label: 'Slew', key: 'slew' },
+    { label: 'Load', key: 'load' },
+];

--- a/src/web/src/timing_report.cpp
+++ b/src/web/src/timing_report.cpp
@@ -27,6 +27,7 @@
 #include "sta/PathEnd.hh"
 #include "sta/PathExpanded.hh"
 #include "sta/PathGroup.hh"
+#include "sta/PortDirection.hh"
 #include "sta/Scene.hh"
 #include "sta/Sdc.hh"
 #include "sta/Search.hh"
@@ -107,10 +108,30 @@ void TimingReport::expandPath(sta::Path* path,
     sta_->getDbNetwork()->staToDb(pin, term, port, moditerm);
 
     std::string pin_name;
+    std::string inst_name;
+    std::string master_name;
+    std::string net_name;
     if (term) {
       pin_name = term->getName();
+      if (auto* inst = term->getInst()) {
+        inst_name = inst->getName();
+        if (auto* master = inst->getMaster()) {
+          master_name = master->getName();
+        }
+      }
+      if (auto* n = term->getNet()) {
+        net_name = n->getName();
+      }
     } else if (port) {
       pin_name = port->getName();
+      if (auto* n = port->getNet()) {
+        net_name = n->getName();
+      }
+    }
+
+    std::string direction;
+    if (auto* dir = network->direction(pin)) {
+      direction = std::string(dir->name());
     }
 
     // Arrival and slew
@@ -140,7 +161,11 @@ void TimingReport::expandPath(sta::Path* path,
                                .time = (arrival_cur + offset) / time_scale,
                                .delay = pin_delay / time_scale,
                                .slew = slew / time_scale,
-                               .load = cap / cap_scale});
+                               .load = cap / cap_scale,
+                               .direction = std::move(direction),
+                               .inst_name = std::move(inst_name),
+                               .master_name = std::move(master_name),
+                               .net_name = std::move(net_name)});
 
     arrival_prev = arrival_cur;
   }
@@ -556,6 +581,18 @@ void serializeTimingNode(JsonBuilder& b, const TimingNode& n)
   b.field("delay", n.delay);
   b.field("slew", n.slew);
   b.field("load", n.load);
+  if (!n.direction.empty()) {
+    b.field("direction", n.direction);
+  }
+  if (!n.inst_name.empty()) {
+    b.field("instance", n.inst_name);
+  }
+  if (!n.master_name.empty()) {
+    b.field("master", n.master_name);
+  }
+  if (!n.net_name.empty()) {
+    b.field("net", n.net_name);
+  }
   b.endObject();
 }
 

--- a/src/web/src/timing_report.h
+++ b/src/web/src/timing_report.h
@@ -26,6 +26,10 @@ struct TimingNode
   float delay = 0.0f;  // incremental
   float slew = 0.0f;
   float load = 0.0f;
+  std::string direction;    // "input" / "output" / "inout" / ""
+  std::string inst_name;    // populated for ITerm pins
+  std::string master_name;  // populated for ITerm pins
+  std::string net_name;     // populated when the pin has a connected net
 };
 
 struct TimingPathSummary

--- a/src/web/src/ui-utils.js
+++ b/src/web/src/ui-utils.js
@@ -3,6 +3,20 @@
 
 // Shared UI utilities.
 
+// Build a neutral "not available" stub for a widget whose core data
+// the server cannot provide in the current mode (typically static
+// reports). Static-mode feature gaps are deliberate, not errors, so
+// this uses the muted secondary color rather than the error color.
+export function buildUnavailableStub(className, message) {
+    const el = document.createElement('div');
+    el.className = className;
+    const inner = document.createElement('div');
+    inner.className = 'widget-unavailable';
+    inner.textContent = message;
+    el.appendChild(inner);
+    return el;
+}
+
 // Make table column headers resizable by dragging.
 export function makeResizableHeaders(table) {
     // Reset to auto layout so browser computes natural column widths

--- a/src/web/src/websocket-manager.js
+++ b/src/web/src/websocket-manager.js
@@ -5,6 +5,21 @@
 // Supports a cache mode for static reports where pre-computed responses
 // are served from window.__STATIC_CACHE__ without a WebSocket connection.
 
+// Request types that _cacheRequest knows how to answer from the
+// embedded cache. Anything else rejects with "Not available in
+// static mode: <type>"; widgets should check supportsInStatic and
+// render a disabled stub rather than issue doomed requests.
+const STATIC_REQUEST_TYPES = new Set([
+    'tile',
+    'timing_highlight',
+    'timing_report',
+    'slack_histogram',
+    'tech',
+    'bounds',
+    'heatmaps',
+    'chart_filters',
+]);
+
 export class WebSocketManager {
     constructor(url, onStatusChange) {
         this.url = url;
@@ -38,6 +53,14 @@ export class WebSocketManager {
 
     get isStaticMode() {
         return !!this._cache;
+    }
+
+    // Whether a request type is serviceable in static mode. Mirrors
+    // the whitelist inside _cacheRequest, so widgets can check up
+    // front and render a disabled stub rather than firing a doomed
+    // request and catching the rejection.
+    supportsInStatic(type) {
+        return STATIC_REQUEST_TYPES.has(type);
     }
 
     connect() {

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -80,7 +80,7 @@ js_test(
 
 js_test(
     name = "clock_tree_widget_test",
-    data = JS_FILES,
+    data = DOM_TEST_DATA,
     entry_point = "js/test-clock-tree-widget.js",
     no_copy_to_bin = JS_FILES,
 )

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -127,6 +127,13 @@ js_test(
     no_copy_to_bin = JS_FILES,
 )
 
+js_test(
+    name = "error_banner_test",
+    data = DOM_TEST_DATA,
+    entry_point = "js/test-error-banner.js",
+    no_copy_to_bin = JS_FILES,
+)
+
 cc_test(
     name = "clock_tree_report_test",
     srcs = ["cpp/TestClockTreeReport.cpp"],

--- a/src/web/test/js/test-charts-widget.js
+++ b/src/web/test/js/test-charts-widget.js
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
     computeHistogramLayout,
+    hitTestColumn,
     kLeftMargin, kRightMargin, kTopMargin, kBottomMargin,
 } from '../../src/charts-widget.js';
 
@@ -131,5 +132,60 @@ describe('computeHistogramLayout', () => {
         }, 500, 400);
         assert.ok(result.yMax >= 350);
         assert.ok(result.yTicks.length >= 2);
+    });
+});
+
+describe('hitTestColumn', () => {
+    // Two bars of unequal heights inside a 500x400 chart.
+    const chartArea = { left: 60, right: 480, top: 30, bottom: 350 };
+    const bars = [
+        // Tall bar: covers much of the column height.
+        { x: 100, y: 60, width: 40, height: 290, count: 100,
+          lower: 0, upper: 0.1, negative: false },
+        // Short bar: sits near the bottom, tiny rect.
+        { x: 160, y: 340, width: 40, height: 10, count: 2,
+          lower: 0.1, upper: 0.2, negative: false },
+        // Empty bar: no count, should never match.
+        { x: 220, y: 350, width: 40, height: 0, count: 0,
+          lower: 0.2, upper: 0.3, negative: false },
+    ];
+
+    it('hits when the click lands inside the bar rect (existing behavior)', () => {
+        const hit = hitTestColumn(bars, chartArea, 120, 300);
+        assert.ok(hit);
+        assert.equal(hit.count, 100);
+    });
+
+    it('hits the short bar when clicking above it in the column strip', () => {
+        // Y well above the short bar's top (340), but inside chart area.
+        const hit = hitTestColumn(bars, chartArea, 180, 100);
+        assert.ok(hit);
+        assert.equal(hit.count, 2);
+    });
+
+    it('misses when the click is below the chart area', () => {
+        assert.equal(hitTestColumn(bars, chartArea, 180, 360), null);
+    });
+
+    it('misses when the click is above the chart area', () => {
+        assert.equal(hitTestColumn(bars, chartArea, 180, 20), null);
+    });
+
+    it('misses when the click falls in the x-gap between bars', () => {
+        // x=150 lands between bar 0 (100..140) and bar 1 (160..200).
+        assert.equal(hitTestColumn(bars, chartArea, 150, 200), null);
+    });
+
+    it('never matches a zero-count column', () => {
+        assert.equal(hitTestColumn(bars, chartArea, 240, 200), null);
+    });
+
+    it('returns null when chartArea is null', () => {
+        assert.equal(hitTestColumn(bars, null, 120, 200), null);
+    });
+
+    it('returns null when bars is empty or null', () => {
+        assert.equal(hitTestColumn([], chartArea, 120, 200), null);
+        assert.equal(hitTestColumn(null, chartArea, 120, 200), null);
     });
 });

--- a/src/web/test/js/test-clock-tree-widget.js
+++ b/src/web/test/js/test-clock-tree-widget.js
@@ -1,12 +1,32 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
 
+import './setup-dom.js';
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
     computeClockTreeLayout,
+    ClockTreeWidget,
     kNodeSpacing, kTopMargin, kBottomMargin, kLeftMargin, kRightMargin,
 } from '../../src/clock-tree-widget.js';
+
+describe('ClockTreeWidget static mode', () => {
+    it('renders a disabled stub and makes no requests', () => {
+        const requests = [];
+        const app = {
+            websocketManager: {
+                isStaticMode: true,
+                request(msg) { requests.push(msg); return Promise.resolve({}); },
+            },
+        };
+        const container = document.createElement('div');
+        new ClockTreeWidget(container, app, () => {});
+        const stub = container.querySelector('.widget-unavailable');
+        assert.ok(stub, 'unavailable stub is rendered');
+        assert.match(stub.textContent, /live OpenROAD server/);
+        assert.equal(requests.length, 0);
+    });
+});
 
 describe('computeClockTreeLayout', () => {
     it('returns empty layout for empty nodes', () => {

--- a/src/web/test/js/test-drc-widget.js
+++ b/src/web/test/js/test-drc-widget.js
@@ -30,6 +30,26 @@ function createMockApp(responses = {}) {
 }
 
 describe('DrcWidget', () => {
+    describe('static mode', () => {
+        it('renders a disabled stub and makes no requests', () => {
+            const requests = [];
+            const app = {
+                websocketManager: {
+                    isStaticMode: true,
+                    request(msg) { requests.push(msg); return Promise.resolve({}); },
+                },
+            };
+            const widget = new DrcWidget(app, () => {});
+
+            assert.ok(widget.element);
+            assert.ok(widget.element.classList.contains('drc-widget'));
+            const stub = widget.element.querySelector('.widget-unavailable');
+            assert.ok(stub, 'unavailable stub is rendered');
+            assert.match(stub.textContent, /live OpenROAD server/);
+            assert.equal(requests.length, 0, 'no request was fired');
+        });
+    });
+
     describe('construction', () => {
         it('creates the expected DOM structure', () => {
             const app = createMockApp({

--- a/src/web/test/js/test-error-banner.js
+++ b/src/web/test/js/test-error-banner.js
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import './setup-dom.js';
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { showErrorBanner, installGlobalErrorHandlers } from '../../src/error-banner.js';
+
+describe('showErrorBanner', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('renders a banner with the error message', () => {
+        showErrorBanner(new Error('boom'));
+        const banner = document.querySelector('.error-banner');
+        assert.ok(banner);
+        assert.equal(banner.querySelector('.error-banner-summary').textContent, 'boom');
+    });
+
+    it('includes the stack in collapsible details', () => {
+        const err = new Error('kaboom');
+        showErrorBanner(err);
+        const stack = document.querySelector('.error-banner-stack');
+        assert.ok(stack);
+        assert.ok(stack.textContent.includes('kaboom'));
+    });
+
+    it('omits details for non-Error values without a stack', () => {
+        showErrorBanner('plain string reason');
+        assert.equal(document.querySelector('.error-banner-stack'), null);
+        assert.equal(
+            document.querySelector('.error-banner-summary').textContent,
+            'plain string reason',
+        );
+    });
+
+    it('stacks multiple banners in one container', () => {
+        showErrorBanner(new Error('first'));
+        showErrorBanner(new Error('second'));
+        const container = document.getElementById('error-banner-container');
+        assert.equal(container.querySelectorAll('.error-banner').length, 2);
+    });
+
+    it('dismisses when the close button is clicked', () => {
+        showErrorBanner(new Error('nope'));
+        const banner = document.querySelector('.error-banner');
+        banner.querySelector('.error-banner-close').click();
+        assert.equal(document.querySelector('.error-banner'), null);
+    });
+});
+
+describe('installGlobalErrorHandlers', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('paints a banner on an error event', () => {
+        installGlobalErrorHandlers(document, window);
+        window.dispatchEvent(new window.ErrorEvent('error', {
+            error: new Error('global kaboom'),
+            message: 'global kaboom',
+        }));
+        const banner = document.querySelector('.error-banner');
+        assert.ok(banner);
+        assert.equal(banner.querySelector('.error-banner-summary').textContent, 'global kaboom');
+    });
+
+    it('paints a banner on an unhandledrejection event', () => {
+        installGlobalErrorHandlers(document, window);
+        // jsdom does not ship PromiseRejectionEvent; synthesize a compatible event.
+        const ev = new window.Event('unhandledrejection');
+        ev.reason = new Error('async kaboom');
+        window.dispatchEvent(ev);
+        const banner = document.querySelector('.error-banner');
+        assert.ok(banner);
+        assert.equal(banner.querySelector('.error-banner-summary').textContent, 'async kaboom');
+    });
+});

--- a/src/web/test/js/test-timing-widget.js
+++ b/src/web/test/js/test-timing-widget.js
@@ -109,3 +109,106 @@ describe('TimingWidget._selectPathRow', () => {
             app.requests.filter(r => r.type === 'timing_highlight').length, 0);
     });
 });
+
+describe('TimingWidget._showInspector', () => {
+    function pathWithNode(node) {
+        return makePath(0.0, 'e0', { data_nodes: [node] });
+    }
+
+    const FULL_NODE = {
+        pin: 'U1/A',
+        fanout: 3,
+        rise: true,
+        clk: false,
+        time: 0.12,
+        delay: 0.03,
+        slew: 0.05,
+        load: 0.002,
+        direction: 'input',
+        instance: 'U1',
+        master: 'AND2_X1',
+        net: 'n5',
+    };
+
+    it('renders a popover populated from the node', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
+        widget._selectPathRow(0);
+
+        widget._showInspector(0);
+
+        const pop = widget.element.querySelector('.timing-inspector-popover');
+        assert.ok(pop, 'popover was created');
+        const text = pop.textContent;
+        assert.ok(text.includes('U1/A'), 'shows pin');
+        assert.ok(text.includes('input'), 'shows direction');
+        assert.ok(text.includes('U1'), 'shows instance');
+        assert.ok(text.includes('AND2_X1'), 'shows master');
+        assert.ok(text.includes('n5'), 'shows net');
+    });
+
+    it('omits rows whose value is empty or missing', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        const minimal = {
+            pin: 'TOP_IN', fanout: 0, rise: true, clk: false,
+            time: 0, delay: 0, slew: 0, load: 0,
+            // no direction, instance, master, net
+        };
+        widget.showPaths('setup', [pathWithNode(minimal)]);
+        widget._selectPathRow(0);
+
+        widget._showInspector(0);
+
+        const pop = widget.element.querySelector('.timing-inspector-popover');
+        const headers = Array.from(pop.querySelectorAll('th'), th => th.textContent);
+        assert.ok(!headers.includes('Direction'));
+        assert.ok(!headers.includes('Instance'));
+        assert.ok(!headers.includes('Master'));
+        assert.ok(!headers.includes('Net'));
+        assert.ok(headers.includes('Pin'));
+    });
+
+    it('closes on Escape', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
+        widget._selectPathRow(0);
+        widget._showInspector(0);
+        assert.ok(widget.element.querySelector('.timing-inspector-popover'));
+
+        document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
+
+        assert.equal(widget.element.querySelector('.timing-inspector-popover'), null);
+    });
+
+    it('closes on the × button', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
+        widget._selectPathRow(0);
+        widget._showInspector(0);
+
+        const btn = widget.element.querySelector('.timing-inspector-popover .close-btn');
+        btn.click();
+
+        assert.equal(widget.element.querySelector('.timing-inspector-popover'), null);
+    });
+
+    it('closes when opening a new inspector (replaces existing)', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.0, 'e0', { data_nodes: [FULL_NODE, { ...FULL_NODE, pin: 'U2/A' }] }),
+        ]);
+        widget._selectPathRow(0);
+
+        widget._showInspector(0);
+        widget._showInspector(1);
+
+        const popovers = widget.element.querySelectorAll('.timing-inspector-popover');
+        assert.equal(popovers.length, 1);
+        assert.ok(popovers[0].textContent.includes('U2/A'));
+    });
+});

--- a/src/web/test/js/test-timing-widget.js
+++ b/src/web/test/js/test-timing-widget.js
@@ -136,7 +136,7 @@ describe('TimingWidget._showInspector', () => {
         widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
         widget._selectPathRow(0);
 
-        widget._showInspector(0);
+        widget._showInspector(FULL_NODE);
 
         const pop = widget.element.querySelector('.timing-inspector-popover');
         assert.ok(pop, 'popover was created');
@@ -159,7 +159,7 @@ describe('TimingWidget._showInspector', () => {
         widget.showPaths('setup', [pathWithNode(minimal)]);
         widget._selectPathRow(0);
 
-        widget._showInspector(0);
+        widget._showInspector(minimal);
 
         const pop = widget.element.querySelector('.timing-inspector-popover');
         const headers = Array.from(pop.querySelectorAll('th'), th => th.textContent);
@@ -175,7 +175,7 @@ describe('TimingWidget._showInspector', () => {
         const widget = new TimingWidget(app, () => {});
         widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
         widget._selectPathRow(0);
-        widget._showInspector(0);
+        widget._showInspector(FULL_NODE);
         assert.ok(widget.element.querySelector('.timing-inspector-popover'));
 
         document.dispatchEvent(new window.KeyboardEvent('keydown', { key: 'Escape' }));
@@ -188,7 +188,7 @@ describe('TimingWidget._showInspector', () => {
         const widget = new TimingWidget(app, () => {});
         widget.showPaths('setup', [pathWithNode(FULL_NODE)]);
         widget._selectPathRow(0);
-        widget._showInspector(0);
+        widget._showInspector(FULL_NODE);
 
         const btn = widget.element.querySelector('.timing-inspector-popover .close-btn');
         btn.click();
@@ -199,13 +199,14 @@ describe('TimingWidget._showInspector', () => {
     it('closes when opening a new inspector (replaces existing)', () => {
         const app = createMockApp();
         const widget = new TimingWidget(app, () => {});
+        const NODE_U2 = { ...FULL_NODE, pin: 'U2/A' };
         widget.showPaths('setup', [
-            makePath(0.0, 'e0', { data_nodes: [FULL_NODE, { ...FULL_NODE, pin: 'U2/A' }] }),
+            makePath(0.0, 'e0', { data_nodes: [FULL_NODE, NODE_U2] }),
         ]);
         widget._selectPathRow(0);
 
-        widget._showInspector(0);
-        widget._showInspector(1);
+        widget._showInspector(FULL_NODE);
+        widget._showInspector(NODE_U2);
 
         const popovers = widget.element.querySelectorAll('.timing-inspector-popover');
         assert.equal(popovers.length, 1);

--- a/src/web/test/js/test-timing-widget.js
+++ b/src/web/test/js/test-timing-widget.js
@@ -212,3 +212,104 @@ describe('TimingWidget._showInspector', () => {
         assert.ok(popovers[0].textContent.includes('U2/A'));
     });
 });
+
+describe('TimingWidget path-table sorting', () => {
+    function endPins(widget) {
+        const rows = widget._pathTable.querySelectorAll('tbody tr');
+        return Array.from(rows, tr => tr.querySelectorAll('td')[9].textContent);
+    }
+
+    it('defaults to Slack ascending', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.5, 'pos'),
+            makePath(-0.2, 'worst'),
+            makePath(0.1, 'small'),
+        ]);
+        assert.deepEqual(endPins(widget), ['worst', 'small', 'pos']);
+    });
+
+    it('clicking the Slack header toggles to descending', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.5, 'pos'),
+            makePath(-0.2, 'worst'),
+            makePath(0.1, 'small'),
+        ]);
+
+        const slackTh = widget._pathTable.querySelectorAll('thead th')[3];
+        slackTh.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+        assert.deepEqual(endPins(widget), ['pos', 'small', 'worst']);
+        // Re-query the header after the re-render triggered by the click.
+        const slackThAfter = widget._pathTable.querySelectorAll('thead th')[3];
+        assert.ok(slackThAfter.textContent.includes('▼'));
+    });
+
+    it('sorts by a different column when its header is clicked', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.0, 'charlie'),
+            makePath(0.0, 'alpha'),
+            makePath(0.0, 'bravo'),
+        ]);
+        const endTh = widget._pathTable.querySelectorAll('thead th')[9];
+        endTh.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+        assert.deepEqual(endPins(widget), ['alpha', 'bravo', 'charlie']);
+    });
+
+    it('ignores clicks on the resize grip', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.5, 'pos'),
+            makePath(-0.2, 'worst'),
+        ]);
+
+        // Simulate a click whose target is the grip span.
+        const slackTh = widget._pathTable.querySelectorAll('thead th')[3];
+        const grip = document.createElement('span');
+        grip.className = 'col-resize-grip';
+        slackTh.appendChild(grip);
+        grip.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+        // Still ascending.
+        assert.deepEqual(endPins(widget), ['worst', 'pos']);
+    });
+
+    it('preserves selection across re-sorts (by path object identity)', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [
+            makePath(0.5, 'pos'),
+            makePath(-0.2, 'worst'),
+            makePath(0.1, 'small'),
+        ]);
+        // Default ascending: index 0 → 'worst'.  Select 'small' (row index 1).
+        widget._selectPathRow(1);
+        assert.equal(widget._selectedPathIndex, 1);
+
+        // Click End header: alphabetical ascending → pos, small, worst.
+        const endTh = widget._pathTable.querySelectorAll('thead th')[9];
+        endTh.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+
+        // 'small' now sits at row index 1 (p < s < w).
+        const rows = widget._pathTable.querySelectorAll('tbody tr');
+        assert.equal(rows[widget._selectedPathIndex].querySelectorAll('td')[9].textContent, 'small');
+    });
+
+    it('header tooltips match Qt wording for Skew / Logic Delay / Logic Depth', () => {
+        const app = createMockApp();
+        const widget = new TimingWidget(app, () => {});
+        widget.showPaths('setup', [makePath(0.0, 'a')]);
+        const ths = widget._pathTable.querySelectorAll('thead th');
+        // Columns: Clock(0) Required(1) Arrival(2) Slack(3) Skew(4)
+        //          Logic Delay(5) Logic Depth(6) Fanout(7) Start(8) End(9)
+        assert.ok(ths[4].title.includes('CRPR'), 'skew tooltip');
+        assert.ok(ths[5].title.includes('excluding buffers'), 'logic delay tooltip');
+        assert.ok(ths[6].title.includes('excluding buffers'), 'logic depth tooltip');
+    });
+});

--- a/src/web/test/js/test-websocket-manager.js
+++ b/src/web/test/js/test-websocket-manager.js
@@ -142,6 +142,20 @@ describe('WebSocketManager.fromCache', () => {
         assert.equal(mgr.socket, null);
     });
 
+    it('supportsInStatic matches the cache allowlist', () => {
+        const mgr = WebSocketManager.fromCache(makeCache());
+        for (const type of ['tile', 'timing_highlight', 'timing_report',
+                            'slack_histogram', 'heatmaps', 'tech', 'bounds',
+                            'chart_filters']) {
+            assert.equal(mgr.supportsInStatic(type), true, type);
+        }
+        for (const type of ['drc_categories', 'drc_markers',
+                            'clock_tree', 'schematic_inspect',
+                            'set_focus_nets', 'select', 'tcl_eval']) {
+            assert.equal(mgr.supportsInStatic(type), false, type);
+        }
+    });
+
     it('readyPromise resolves immediately', async () => {
         const mgr = WebSocketManager.fromCache(makeCache());
         await mgr.readyPromise; // Should not hang.

--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -5,7 +5,18 @@ filegroup(
         "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
         "asap7sc7p5t_OA_RVT_TT_201020.v",
         "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
+        "dff.v",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+exports_files(
+    [
+        "asap7sc7p5t_AO_RVT_TT_201020.v",
+        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+        "dff.v",
+        "empty.v",
     ],
     visibility = ["//visibility:public"],
 )

--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -1,22 +1,19 @@
+ASAP7_VERILOG = [
+    "asap7sc7p5t_AO_RVT_TT_201020.v",
+    "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+    "asap7sc7p5t_OA_RVT_TT_201020.v",
+    "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+    "dff.v",
+    "empty.v",
+]
+
 filegroup(
     name = "asap7_files",
-    srcs = [
-        "asap7sc7p5t_AO_RVT_TT_201020.v",
-        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-        "asap7sc7p5t_OA_RVT_TT_201020.v",
-        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "dff.v",
-    ],
+    srcs = ASAP7_VERILOG,
     visibility = ["//visibility:public"],
 )
 
 exports_files(
-    [
-        "asap7sc7p5t_AO_RVT_TT_201020.v",
-        "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-        "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "dff.v",
-        "empty.v",
-    ],
+    ASAP7_VERILOG,
     visibility = ["//visibility:public"],
 )

--- a/test/orfs/asap7/dff.v
+++ b/test/orfs/asap7/dff.v
@@ -1,0 +1,32 @@
+// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R because
+// Verialtor doesn't support and has no plans to support 1995 UDP
+// tables.
+//
+// https://github.com/verilator/verilator/issues/5243
+
+module DFFHQNx1_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx2_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx3_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule

--- a/test/orfs/asap7/empty.v
+++ b/test/orfs/asap7/empty.v
@@ -1,0 +1,17 @@
+// Used to silence warnings.
+module TAPCELL_ASAP7_75t_R;
+endmodule
+module FILLERxp5_ASAP7_75t_R;
+endmodule
+module FILLER_ASAP7_75t_R;
+endmodule
+module DECAPx1_ASAP7_75t_R;
+endmodule
+module DECAPx2_ASAP7_75t_R;
+endmodule
+module DECAPx4_ASAP7_75t_R;
+endmodule
+module DECAPx6_ASAP7_75t_R;
+endmodule
+module DECAPx10_ASAP7_75t_R;
+endmodule

--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -20,6 +20,7 @@ orfs_sweep(
         # Smoketest
         "SWAP_ARITH_OPERATORS": "1",
     },
+    html = True,
     sources = {
         "RULES_JSON": [":rules-base.json"],
         "SDC_FILE": [":constraint.sdc"],

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -367,11 +367,11 @@ def mock_array(name, config):
                     ))
                     for macro in MACROS
                 ] + [
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_AO_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
-                    "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v",
+                    "//test/orfs/asap7:asap7sc7p5t_AO_RVT_TT_201020.v",
+                    "//test/orfs/asap7:asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+                    "//test/orfs/asap7:asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+                    "//test/orfs/asap7:dff.v",
+                    "//test/orfs/asap7:empty.v",
                 ],
                 tags = ["manual"],
             )

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -99,6 +99,7 @@ def element(name, config):
             # builds, so we want to keep this exact module.
             "SYNTH_KEEP_MODULES": "Multiplier",
         },
+        html = True,
         sources = {
             "IO_CONSTRAINTS": [":mock-array-element-io"],
             "SDC_FILE": [":mock-array-constraints"],
@@ -286,6 +287,7 @@ def mock_array(name, config):
                 "RTLMP_MIN_MACRO": "8",
                 "RTLMP_NOTCH_WT": "0",
             },
+            html = True,
             macros = ["Element_{name}_base_generate_abstract".format(name = name)],
             sources = {
                 "IO_CONSTRAINTS": [":mock-array-io"],

--- a/test/orfs/ram_8x7/BUILD
+++ b/test/orfs/ram_8x7/BUILD
@@ -23,6 +23,7 @@ orfs_flow(
         "SETUP_SLACK_MARGIN": "-4000",
         "TAPCELL_TCL": "",
     },
+    html = True,
     sources = {
         "RULES_JSON": [":rules-base.json"],
         "SDC_FILE": [":constraint.sdc"],


### PR DESCRIPTION
Please pick whatever is useful here for the static web GUI and close this PR.

To test new features, run:

    bazelisk run test/orfs/gcd:gcd_synth_html

- Click above the green bucket and you can still go to the timing report for that bucket <img width="277" height="299" alt="image" src="https://github.com/user-attachments/assets/0878ed34-ca67-4f66-829c-64ba6f15f9a2" />
- Pin inspector 
<img width="375" height="315" alt="image" src="https://github.com/user-attachments/assets/a1601da5-9fe3-4d5e-ae63-619a49acde60" />
- Sortable columns 
<img width="145" height="192" alt="image" src="https://github.com/user-attachments/assets/2f2d04d7-181d-4a52-9212-af2513fc0e8a" />
