### PR TITLE
pdn: grid: limit via-repair shape extension to ring/domain boundary

### DIFF
--- a/src/pdn/src/grid.cpp
+++ b/src/pdn/src/grid.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -313,6 +314,13 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
     return !shape->belongsTo(this);
   };
 
+  // When rings are present, shapes must not be extended beyond the ring
+  // boundary.  Without this guard, extendTo() can push stripes through the
+  // padframe when a via sits right at the ring edge.  For ring-less grids the
+  // obstruction-based check inside extendTo() is sufficient.
+  const std::optional<odb::Rect> allowed_area
+      = rings_.empty() ? std::nullopt : std::make_optional(getRingArea());
+
   std::map<Shape*, std::unique_ptr<Shape>> replace_shapes;
   for (const auto& via : vias_) {
     // ensure shapes belong to something
@@ -345,7 +353,9 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
                                   obstructions[extend_test->getLayer()],
                                   lower_shape.get(),
                                   obs_filter);
-      if (new_lower != nullptr) {
+      const bool lower_in_bounds
+          = !allowed_area || allowed_area->contains(new_lower->getRect());
+      if (new_lower != nullptr && lower_in_bounds) {
         replace_shapes[lower_shape.get()] = std::move(new_lower);
       }
     }
@@ -361,7 +371,9 @@ bool Grid::repairVias(const Shape::ShapeTreeMap& global_shapes,
                                   obstructions[extend_test->getLayer()],
                                   upper_shape.get(),
                                   obs_filter);
-      if (new_upper != nullptr) {
+      const bool upper_in_bounds
+          = !allowed_area || allowed_area->contains(new_upper->getRect());
+      if (new_upper != nullptr && upper_in_bounds) {
         replace_shapes[upper_shape.get()] = std::move(new_upper);
       }
     }


### PR DESCRIPTION
## Summary
Shape::extendTo() had no awareness of the grid boundary, allowing repairVias() to extend stripes through the padframe when a via landed at the ring edge. Now the extended shape is accepted only if it stays within getRingArea() (or getDomainBoundary() for ring-less grids).

## Type of Change
- Bug fix

## Impact
Should not have any impact except correct power ring/strips.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
