### PR TITLE
web: mark field as no-spellcheck since commands are not words

### DIFF
--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -330,7 +330,7 @@ function createTclConsole(container) {
         '<div class="tcl-output"></div>' +
         '<div class="tcl-input-row">' +
         '  <span class="tcl-prompt">%</span>' +
-        '  <input class="tcl-input" type="text" placeholder="Enter Tcl command..." spellcheck="false" />' +
+        '  <input class="tcl-input" type="text" placeholder="Enter Tcl command..." spellcheck="false" autocomplete="off" autocapitalize="none" autocorrect="off"/>' +
         '</div>';
     container.element.appendChild(el);
 

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -330,7 +330,7 @@ function createTclConsole(container) {
         '<div class="tcl-output"></div>' +
         '<div class="tcl-input-row">' +
         '  <span class="tcl-prompt">%</span>' +
-        '  <input class="tcl-input" type="text" placeholder="Enter Tcl command..." />' +
+        '  <input class="tcl-input" type="text" placeholder="Enter Tcl command..." spellcheck="false" />' +
         '</div>';
     container.element.appendChild(el);
 


### PR DESCRIPTION
## Summary
No functional changes just prevents Chrome from generating a red line under all the commands.

## Type of Change
- Bug fix

## Impact
N/A

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
N/A