### PR TITLE
bazel: fix bzl lint tests and surface suppressed external-path warnings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -512,6 +512,7 @@ sh_test(
     srcs = ["//bazel:bzl_lint_test.sh"],
     args = ["$(rootpath @buildifier_prebuilt//:buildifier)"],
     data = [
+        "MODULE.bazel",
         "@buildifier_prebuilt//:buildifier",
     ],
     tags = ["local"],
@@ -525,6 +526,7 @@ sh_test(
     srcs = ["//bazel:bzl_fmt_test.sh"],
     args = ["$(rootpath @buildifier_prebuilt//:buildifier)"],
     data = [
+        "MODULE.bazel",
         "@buildifier_prebuilt//:buildifier",
     ],
     tags = ["local"],
@@ -571,6 +573,7 @@ sh_binary(
         "$(rootpath @buildifier_prebuilt//:buildifier)",
     ],
     data = [
+        "MODULE.bazel",
         "tclint.toml",
         "//bazel:bzl_lint_test.sh",
         "//bazel:bzl_tidy.sh",

--- a/bazel/bison.bzl
+++ b/bazel/bison.bzl
@@ -29,11 +29,11 @@ def correct_bison_env_for_action(env, bison):
 
     bison_env["BISON_PKGDATADIR"] = bison_env["BISON_PKGDATADIR"].replace(
         bison_runfiles_dir,
-        "external/{}".format(bison.owner.workspace_name),
+        "external/{}".format(bison.owner.workspace_name),  # buildifier: disable=external-path
     )
     bison_env["M4"] = bison_env["M4"].replace(
         bison_runfiles_dir,
-        "{}/external/{}".format(bison.root.path, bison.owner.workspace_name),
+        "{}/external/{}".format(bison.root.path, bison.owner.workspace_name),  # buildifier: disable=external-path
     )
 
     return bison_env

--- a/bazel/bzl_fmt_test.sh
+++ b/bazel/bzl_fmt_test.sh
@@ -6,10 +6,10 @@
 set -euo pipefail
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 # MODULE.bazel must be in the sh_test `data` deps so it appears as a
-# runfiles symlink; readlink -f then resolves it to the real workspace.
-# Without the data dep, readlink -f silently returns a bogus path.
-[ -e MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
-WORKSPACE="$(cd "$(dirname "$(readlink -f MODULE.bazel)")" && pwd)"
+# runfiles symlink pointing at the real workspace. `readlink` (no -f,
+# for macOS portability) resolves the absolute path Bazel wrote.
+[ -L MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
+WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 # `git ls-files` skips submodule contents (src/sta, third-party/abc).
 # Explicit -mode=check -lint=off separates format errors from lint warnings,

--- a/bazel/bzl_fmt_test.sh
+++ b/bazel/bzl_fmt_test.sh
@@ -4,8 +4,12 @@
 #
 # Check that all Bazel files are properly formatted (no lint warnings).
 set -euo pipefail
-TOOL="$(readlink -f "$1")"
-WORKSPACE="$(dirname "$(readlink -f MODULE.bazel)")"
+TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+# MODULE.bazel must be in the sh_test `data` deps so it appears as a
+# runfiles symlink; readlink -f then resolves it to the real workspace.
+# Without the data dep, readlink -f silently returns a bogus path.
+[ -e MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
+WORKSPACE="$(cd "$(dirname "$(readlink -f MODULE.bazel)")" && pwd)"
 cd "$WORKSPACE"
 # `git ls-files` skips submodule contents (src/sta, third-party/abc).
 # Explicit -mode=check -lint=off separates format errors from lint warnings,

--- a/bazel/bzl_lint_test.sh
+++ b/bazel/bzl_lint_test.sh
@@ -4,8 +4,12 @@
 #
 # Lint all Bazel files using buildifier (check-only, with lint warnings).
 set -euo pipefail
-TOOL="$(readlink -f "$1")"
-WORKSPACE="$(dirname "$(readlink -f MODULE.bazel)")"
+TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+# MODULE.bazel must be in the sh_test `data` deps so it appears as a
+# runfiles symlink; readlink -f then resolves it to the real workspace.
+# Without the data dep, readlink -f silently returns a bogus path.
+[ -e MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
+WORKSPACE="$(cd "$(dirname "$(readlink -f MODULE.bazel)")" && pwd)"
 cd "$WORKSPACE"
 # `git ls-files` skips submodule contents (src/sta, third-party/abc), so
 # we never try to reformat files owned by another repo.

--- a/bazel/bzl_lint_test.sh
+++ b/bazel/bzl_lint_test.sh
@@ -6,10 +6,10 @@
 set -euo pipefail
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 # MODULE.bazel must be in the sh_test `data` deps so it appears as a
-# runfiles symlink; readlink -f then resolves it to the real workspace.
-# Without the data dep, readlink -f silently returns a bogus path.
-[ -e MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
-WORKSPACE="$(cd "$(dirname "$(readlink -f MODULE.bazel)")" && pwd)"
+# runfiles symlink pointing at the real workspace. `readlink` (no -f,
+# for macOS portability) resolves the absolute path Bazel wrote.
+[ -L MODULE.bazel ] || { echo "MODULE.bazel missing from runfiles" >&2; exit 1; }
+WORKSPACE="$(dirname "$(readlink MODULE.bazel)")"
 cd "$WORKSPACE"
 # `git ls-files` skips submodule contents (src/sta, third-party/abc), so
 # we never try to reformat files owned by another repo.

--- a/bazel/flex.bzl
+++ b/bazel/flex.bzl
@@ -26,7 +26,7 @@ def _correct_flex_env_for_action(env, flex):
         flex.owner.workspace_name,
     )
 
-    actual = "{}/external/{}".format(flex.root.path, flex.owner.workspace_name)
+    actual = "{}/external/{}".format(flex.root.path, flex.owner.workspace_name)  # buildifier: disable=external-path
 
     for key, value in flex_env.items():
         flex_env[key] = value.replace(flex_runfiles_dir, actual)


### PR DESCRIPTION
lint_bzl_test and fmt_bzl_test used `readlink -f MODULE.bazel` to locate the workspace, but MODULE.bazel was not in their `data` deps so it was missing from the runfiles. `readlink -f` silently returns a path for a non-existent file, so WORKSPACE resolved to the runfiles directory (not a git repo) and the scripts failed with "fatal: not a git repository".

Add MODULE.bazel to the `data` of lint_bzl_test, fmt_bzl_test, and fix_lint so the runfiles symlink is present. Switch the scripts to the same `cd ... && pwd` pattern used by the tcl lint scripts, and fail loudly with a clear message if the marker is ever missing again.

With the tests now actually running, buildifier flagged two legitimate uses of the literal "external/<repo>" path in bison.bzl and flex.bzl; these strings deliberately rewrite runfiles paths back to the non- runfiles execroot layout so Bison/Flex can locate their data files when invoked as toolchain tools. Annotate with `# buildifier: disable=external-path`.
