### PR TITLE
clang-tidy: don't use `modernize-use-constraints`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -48,6 +48,7 @@ Checks: >
   -modernize-raw-string-literal,
   -modernize-return-braced-init-list,
   -modernize-use-auto,
+  -modernize-use-constraints,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -modernize-use-transparent-functors,


### PR DESCRIPTION
This check crashes `clang-tidy` on some files and
with the changes in #10185, that takes down the whole run-clang-tidy-cached.cc.
