### PR TITLE
web: mirror GUI title in browser tab

### DIFF
--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -40,6 +40,7 @@ genrule(
         "src/tcl-completer.js",
         "src/hierarchy-browser.js",
         "src/menu-bar.js",
+        "src/title.js",
         "src/clock-tree-widget.js",
         "src/schematic-widget.js",
         "src/charts-widget.js",
@@ -64,6 +65,7 @@ genrule(
           " $(location src/tcl-completer.js)" +
           " $(location src/hierarchy-browser.js)" +
           " $(location src/menu-bar.js)" +
+          " $(location src/title.js)" +
           " $(location src/clock-tree-widget.js)" +
           " $(location src/schematic-widget.js)" +
           " $(location src/charts-widget.js)" +
@@ -89,6 +91,7 @@ _WEB_ASSET_FILES = [
     "src/tcl-completer.js",
     "src/hierarchy-browser.js",
     "src/menu-bar.js",
+    "src/title.js",
     "src/clock-tree-widget.js",
     "src/schematic-widget.js",
     "src/charts-widget.js",

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -28,6 +28,7 @@ set(WEB_ASSET_FILES
     src/tcl-completer.js
     src/hierarchy-browser.js
     src/menu-bar.js
+    src/title.js
     src/clock-tree-widget.js
     src/schematic-widget.js
     src/charts-widget.js
@@ -61,6 +62,7 @@ add_custom_command(
         ${CMAKE_CURRENT_SOURCE_DIR}/src/tcl-completer.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/hierarchy-browser.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/menu-bar.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/title.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/clock-tree-widget.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/schematic-widget.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/charts-widget.js

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -17,6 +17,7 @@ import { SchematicWidget } from './schematic-widget.js';
 import { DrcWidget } from './drc-widget.js';
 import { TclCompleter } from './tcl-completer.js';
 import { setCookie } from './theme.js';
+import { updateDocumentTitle } from './title.js';
 
 // ─── Status Indicator ───────────────────────────────────────────────────────
 
@@ -744,6 +745,7 @@ app.websocketManager.readyPromise.then(async () => {
         ]);
         app.hasLiberty = techData.has_liberty;
         app.techData = techData;
+        updateDocumentTitle(techData.block_name);
 
         // --- Set Bounds ---
         const designBounds = boundsData.bounds;

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -2842,6 +2842,9 @@ void serializeTechResponse(JsonBuilder& b, const TileGenerator& gen)
   b.field("has_liberty", gen.hasSta());
   if (gen.getBlock()) {
     b.field("dbu_per_micron", gen.getBlock()->getDbUnitsPerMicron());
+    b.field("block_name", gen.getBlock()->getName());
+  } else {
+    b.field("block_name", std::string());
   }
   b.endObject();
 }

--- a/src/web/src/title.js
+++ b/src/web/src/title.js
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+// Mirrors the GUI's window title (mainWindow.cpp::updateTitle):
+//   "OpenROAD - <block name>"   when a design is loaded
+//   "OpenROAD"                  when no design is loaded
+export function updateDocumentTitle(blockName, doc = (typeof document !== 'undefined' ? document : null)) {
+    const base = 'OpenROAD';
+    const title = blockName ? `${base} - ${blockName}` : base;
+    if (doc) doc.title = title;
+    return title;
+}

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -149,6 +149,13 @@ js_test(
     no_copy_to_bin = JS_FILES,
 )
 
+js_test(
+    name = "title_test",
+    data = JS_FILES,
+    entry_point = "js/test-title.js",
+    no_copy_to_bin = JS_FILES,
+)
+
 cc_test(
     name = "clock_tree_report_test",
     srcs = ["cpp/TestClockTreeReport.cpp"],

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
+#include "json_builder.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
@@ -543,6 +544,26 @@ TEST_F(RowRenderingTest, RowsDefaultOff)
 {
   TileVisibility vis;
   EXPECT_FALSE(vis.rows);
+}
+
+//------------------------------------------------------------------------------
+// serializeTechResponse — exercises the contract main.js relies on for the
+// document title (techData.block_name).
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, SerializeTechResponseContainsBlockName)
+{
+  // Nangate45Fixture creates the block with name "top".
+  makeTileGen();
+  JsonBuilder b;
+  serializeTechResponse(b, *tile_gen_);
+  const std::string json = b.str();
+  // Field name and value should both appear.  Looser than a full JSON
+  // parse but sufficient: this is the contract main.js consumes.
+  EXPECT_NE(json.find("\"block_name\""), std::string::npos)
+      << "tech response missing block_name key; got: " << json;
+  EXPECT_NE(json.find("\"top\""), std::string::npos)
+      << "tech response missing block name value \"top\"; got: " << json;
 }
 
 }  // namespace

--- a/src/web/test/js/test-title.js
+++ b/src/web/test/js/test-title.js
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { updateDocumentTitle } from '../../src/title.js';
+
+describe('updateDocumentTitle', () => {
+    it('uses bare "OpenROAD" when no block name given', () => {
+        const doc = { title: '' };
+        const out = updateDocumentTitle('', doc);
+        assert.equal(out, 'OpenROAD');
+        assert.equal(doc.title, 'OpenROAD');
+    });
+
+    it('uses bare "OpenROAD" when block name is null', () => {
+        const doc = { title: '' };
+        const out = updateDocumentTitle(null, doc);
+        assert.equal(out, 'OpenROAD');
+        assert.equal(doc.title, 'OpenROAD');
+    });
+
+    it('uses bare "OpenROAD" when block name is undefined', () => {
+        const doc = { title: '' };
+        const out = updateDocumentTitle(undefined, doc);
+        assert.equal(out, 'OpenROAD');
+        assert.equal(doc.title, 'OpenROAD');
+    });
+
+    it('mirrors GUI format with " - " separator when block name present', () => {
+        // GUI uses "{window_title} - {block_name}" (mainWindow.cpp:540).
+        const doc = { title: '' };
+        const out = updateDocumentTitle('gcd', doc);
+        assert.equal(out, 'OpenROAD - gcd');
+        assert.equal(doc.title, 'OpenROAD - gcd');
+    });
+
+    it('handles block names with special characters verbatim', () => {
+        const doc = { title: '' };
+        const out = updateDocumentTitle('top_module/foo', doc);
+        assert.equal(out, 'OpenROAD - top_module/foo');
+    });
+
+    it('overwrites a previously set title', () => {
+        const doc = { title: 'old' };
+        updateDocumentTitle('design1', doc);
+        assert.equal(doc.title, 'OpenROAD - design1');
+        updateDocumentTitle('', doc);
+        assert.equal(doc.title, 'OpenROAD');
+    });
+
+    it('returns the formatted title without a doc', () => {
+        // Useful for callers that only need the string.
+        const out = updateDocumentTitle('myblock', null);
+        assert.equal(out, 'OpenROAD - myblock');
+    });
+});


### PR DESCRIPTION
## Summary
Mirror title in GUI, now the web will show the top block name making the tabs easier to identify.

## Type of Change
- New feature

## Impact
N/A

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
N/A
