### PR TITLE
web: theme tab overflow dropdown and light-mode header icons

### DIFF
--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -393,6 +393,65 @@ html, body {
     background: var(--border-subtle);
 }
 
+/* Header window controls (popout, maximise/minimise, close) ship as white
+ * PNGs in goldenlayout-dark-theme.css.  In light mode they're invisible
+ * against the pale header — invert the already-loaded PNGs rather than
+ * fetching black variants. */
+html[data-theme="light"] .lm_controls .lm_popout,
+html[data-theme="light"] .lm_controls .lm_maximise,
+html[data-theme="light"] .lm_controls .lm_close,
+html[data-theme="light"] .lm_header .lm_tab .lm_close_tab {
+    filter: invert(1);
+}
+
+/* Tab overflow dropdown — Golden Layout shows a chevron when tabs don't
+ * fit; the dark theme ships no styling for the dropdown list itself, so
+ * by default it's transparent and effectively unusable.  Style it here so
+ * overflowed tabs are visible and clickable. */
+.lm_header .lm_controls .lm_tabdropdown {
+    /* Make the chevron visible against the header background. */
+    color: var(--fg-bright);
+}
+.lm_header .lm_controls .lm_tabdropdown:before {
+    border-top-color: var(--fg-bright) !important;
+}
+.lm_header .lm_tabdropdown_list {
+    background: var(--bg-context);
+    border: 1px solid var(--border-strong);
+    box-shadow: 0 4px 12px var(--shadow);
+    min-width: 160px;
+    max-width: 320px;
+    max-height: 60vh;
+    overflow-y: auto !important;
+    overflow-x: hidden;
+    padding: 2px 0;
+    border-radius: 0 0 4px 4px;
+}
+.lm_header .lm_tabdropdown_list .lm_tab {
+    display: flex;
+    align-items: center;
+    width: auto;
+    height: auto;
+    padding: 4px 12px;
+    margin: 0;
+    background: transparent;
+    color: var(--fg-primary);
+    float: none;
+}
+.lm_header .lm_tabdropdown_list .lm_tab:hover {
+    background: var(--bg-hover);
+    color: var(--fg-bright);
+}
+.lm_header .lm_tabdropdown_list .lm_tab.lm_active {
+    background: var(--bg-selected);
+    color: var(--fg-white);
+}
+.lm_header .lm_tabdropdown_list .lm_tab .lm_title {
+    width: auto;
+    flex: 1;
+    color: inherit;
+}
+
 /* Leaflet map cursor */
 .leaflet-container {
     cursor: default !important;

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -450,6 +450,14 @@ html[data-theme="light"] .lm_header .lm_tab .lm_close_tab {
     width: auto;
     flex: 1;
     color: inherit;
+    /* min-width: 0 is required so the flex item can shrink below its
+     * intrinsic content width — without it, white-space: nowrap +
+     * overflow: hidden + text-overflow: ellipsis don't trigger and
+     * long titles blow past the dropdown's max-width. */
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 /* Leaflet map cursor */


### PR DESCRIPTION
## Summary
Invert the color of the "buttons" in the web view and add dropdown support for overflowing tabs
<img width="412" height="53" alt="image" src="https://github.com/user-attachments/assets/f52b6957-74f8-48b1-a91e-9863ed96652e" />

<img width="355" height="161" alt="image" src="https://github.com/user-attachments/assets/b0c4ed85-7a39-4d7c-a3ba-79657e433d5d" />


## Type of Change
- Bug fix
- New feature

## Impact
Easier to use

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
Closes https://github.com/The-OpenROAD-Project/OpenROAD/issues/10221
