### PR TITLE
Break out frBaseTypes.h into separate library.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -163,6 +163,7 @@ cc_library(
     name = "tcl_readline_setup",
     srcs = ["src/tcl_readline_setup.cc"],
     hdrs = ["src/tcl_readline_setup.h"],
+    includes = ["src"],
     visibility = ["//src/sta:__pkg__"],
     deps = [
         "@tcl_lang//:tcl",

--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -22,6 +22,19 @@ cc_library(
 )
 
 cc_library(
+    name = "base_types",
+    srcs = ["src/frBaseTypes.cpp"],
+    hdrs = ["src/frBaseTypes.h"],
+    includes = ["src"],
+    deps = [
+        "//src/odb",
+        "//src/utl",
+        "@boost.geometry",
+        "@boost.serialization",
+    ],
+)
+
+cc_library(
     name = "db_hdrs",
     hdrs = [
         "src/db/drObj/drAccessPattern.h",
@@ -79,7 +92,12 @@ cc_library(
         "src/db/tech/frViaDef.h",
         "src/db/tech/frViaRuleGenerate.h",
     ],
-    deps = ["@boost.polygon"],
+    deps = [
+        ":base_types",
+        "//src/odb",
+        "//src/utl",
+        "@boost.polygon",
+    ],
 )
 
 cc_library(
@@ -130,8 +148,6 @@ cc_library(
         "src/dr/FlexGridGraph_maze.cpp",
         "src/dr/FlexMazeTypes.h",
         "src/dr/FlexWavefront.h",
-        "src/frBaseTypes.cpp",
-        "src/frBaseTypes.h",
         "src/frDesign.h",
         "src/frProfileTask.h",
         "src/frRTree.h",
@@ -188,6 +204,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":base_types",
         ":db_hdrs",
         ":pin_access_service",
         "//src/dst",
@@ -224,7 +241,6 @@ cc_library(
         "src/dr/FlexGridGraph.h",
         "src/dr/FlexMazeTypes.h",
         "src/dr/FlexWavefront.h",
-        "src/frBaseTypes.h",
         "src/frDesign.h",
         "src/frRegionQuery.h",
         "src/gc/FlexGC.h",
@@ -252,6 +268,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":base_types",
         ":db_hdrs",
         ":drt",
         ":pin_access_service",

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -168,6 +168,7 @@ cc_test(
     ],
     deps = [
         "//src/drt",
+        "//src/drt:base_types",
         "//src/drt:db_hdrs",
         "//src/odb",
         "//src/utl",

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "src/fastroute/include/AbstractFastRouteRenderer.h",
         "src/fastroute/include/DataType.h",
     ],
+    includes = ["src/fastroute/include"],
     visibility = ["//visibility:private"],
     deps = [
         "//src/stt",


### PR DESCRIPTION
Multiple libraries claimed the header, but of course there should only ever be one library providing a particular header.

fastroute: add the include to properly find the provided headers.

tcl_readline_setup: is also included without the proper prefix, so add the includes = [] to its lib.
