### PR TITLE
web: mirror GUI colors

### DIFF
--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -16,8 +16,8 @@ export function layerRangeSet(center, lower, upper, count) {
     return indices;
 }
 
-// Layer color palette (must match server-side palette in web.cpp)
-const layerPalette = [
+// Fallback color used when the server didn't supply a layer color.
+const fallbackLayerPalette = [
     [70, 130, 210],  // moderate blue
     [200, 50, 50],   // red
     [50, 180, 80],   // green
@@ -146,7 +146,8 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
 
         const colorSwatch = document.createElement('span');
         colorSwatch.className = 'layer-color';
-        const c = layerPalette[index % layerPalette.length];
+        const c = (techData.layer_colors && techData.layer_colors[index])
+            || fallbackLayerPalette[index % fallbackLayerPalette.length];
         colorSwatch.style.backgroundColor = `rgb(${c[0]},${c[1]},${c[2]})`;
         label.appendChild(colorSwatch);
 

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <random>
 #include <set>
 #include <string>
@@ -298,6 +299,14 @@ void TileGenerator::eagerInit()
     search_->eagerInit(block);
   }
   computePinLabelMargin();
+
+  // A reload can replace the dbTech and reuse its memory address, which would
+  // make stale entries in the cache compare equal to a freshly allocated tech.
+  // Clearing here ties cache lifetime to design loading.
+  {
+    std::lock_guard lock(layer_colors_mutex_);
+    layer_colors_by_tech_.clear();
+  }
 }
 
 void TileGenerator::computePinLabelMargin()
@@ -721,6 +730,11 @@ odb::dbBlock* TileGenerator::getBlock() const
 odb::dbChip* TileGenerator::getChip() const
 {
   return db_->getChip();
+}
+
+odb::dbTech* TileGenerator::getTech() const
+{
+  return db_->getTech();
 }
 
 std::vector<unsigned char> TileGenerator::generateTile(
@@ -2780,12 +2794,7 @@ void serializeTechResponse(JsonBuilder& b, const TileGenerator& gen)
 {
   b.beginObject();
   const auto& layer_colors = gen.getLayerColorMap();
-  // Look up rendered layers' colors by name without depending on iteration
-  // order.  Names are unique within a tech.
-  std::map<std::string, Color> color_by_name;
-  for (const auto& [layer, color] : layer_colors) {
-    color_by_name[layer->getName()] = color;
-  }
+  odb::dbTech* tech = gen.getTech();
   b.beginArray("layers");
   for (const auto& name : gen.getLayers()) {
     b.value(name);
@@ -2793,10 +2802,15 @@ void serializeTechResponse(JsonBuilder& b, const TileGenerator& gen)
   b.endArray();
   b.beginArray("layer_colors");
   for (const auto& name : gen.getLayers()) {
-    const auto it = color_by_name.find(name);
-    const Color c = (it != color_by_name.end())
-                        ? it->second
-                        : Color{.r = 200, .g = 200, .b = 200, .a = 180};
+    Color c{.r = 200, .g = 200, .b = 200, .a = 180};
+    if (tech) {
+      if (odb::dbTechLayer* layer = tech->findLayer(name.c_str())) {
+        const auto it = layer_colors.find(layer);
+        if (it != layer_colors.end()) {
+          c = it->second;
+        }
+      }
+    }
     b.beginArray();
     b.value(static_cast<int>(c.r));
     b.value(static_cast<int>(c.g));

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <random>
 #include <set>
 #include <string>
 #include <string_view>
@@ -458,6 +459,97 @@ std::vector<std::string> TileGenerator::getLayers() const
   return layers;
 }
 
+// Build per-layer colors that match gui::DisplayControls::techInit.  The two
+// must stay in sync so the GUI and web frontend show the same colors for the
+// same design.  Walks every dbTechLayer in tech order (not just routing/cut)
+// because the random fallback shares one PRNG and the iteration order is what
+// determines which layer gets which random color.
+static std::map<odb::dbTechLayer*, Color> buildLayerColorMap(odb::dbTech* tech)
+{
+  std::map<odb::dbTechLayer*, Color> colors;
+  if (!tech) {
+    return colors;
+  }
+
+  // From http://vrl.cs.brown.edu/color seeded with #00F, #F00, #0D0
+  static constexpr std::array<Color, 14> kMetalColors = {{
+      // NOLINTBEGIN(modernize-use-designated-initializers)
+      {0, 0, 254, 180},
+      {254, 0, 0, 180},
+      {9, 221, 0, 180},
+      {190, 244, 81, 180},
+      {222, 33, 96, 180},  // Metal 5
+      {32, 216, 253, 180},
+      {253, 108, 160, 180},
+      {117, 63, 194, 180},
+      {128, 155, 49, 180},
+      {234, 63, 252, 180},  // Metal 10
+      {9, 96, 19, 180},
+      {214, 120, 239, 180},
+      {192, 222, 164, 180},
+      {110, 68, 107, 180},  // Metal 14
+                            // NOLINTEND(modernize-use-designated-initializers)
+  }};
+  static constexpr std::array<Color, 14> kCutColors = {{
+      // NOLINTBEGIN(modernize-use-designated-initializers)
+      {126, 126, 255, 180},
+      {255, 126, 126, 180},
+      {4, 110, 0, 180},
+      {95, 122, 40, 180},
+      {111, 17, 48, 180},  // Cut 5
+      {16, 108, 126, 180},
+      {126, 54, 80, 180},
+      {58, 32, 97, 180},
+      {225, 255, 136, 180},
+      {117, 32, 126, 180},  // Cut 10
+      {18, 192, 38, 180},
+      {107, 60, 119, 180},
+      {96, 111, 82, 180},
+      {220, 136, 214, 180},  // Cut 14
+                             // NOLINTEND(modernize-use-designated-initializers)
+  }};
+
+  std::mt19937 rng(1);
+  auto random_color = [&rng]() {
+    return Color{.r = static_cast<unsigned char>(50 + rng() % 200),
+                 .g = static_cast<unsigned char>(50 + rng() % 200),
+                 .b = static_cast<unsigned char>(50 + rng() % 200),
+                 .a = 180};
+  };
+
+  size_t metal = 0;
+  size_t via = 0;
+  for (odb::dbTechLayer* layer : tech->getLayers()) {
+    Color c;
+    const odb::dbTechLayerType type = layer->getType();
+    if (type == odb::dbTechLayerType::ROUTING) {
+      c = (metal < kMetalColors.size()) ? kMetalColors[metal++]
+                                        : random_color();
+    } else if (type == odb::dbTechLayerType::CUT) {
+      // GUI: a CUT layer that appears before any ROUTING layer gets a random
+      // color so cuts don't claim the metal palette slots.
+      c = (via < kCutColors.size() && metal != 0) ? kCutColors[via++]
+                                                  : random_color();
+    } else {
+      c = random_color();
+    }
+    colors[layer] = c;
+  }
+  return colors;
+}
+
+const std::map<odb::dbTechLayer*, Color>& TileGenerator::getLayerColorMap()
+    const
+{
+  std::lock_guard lock(layer_colors_mutex_);
+  odb::dbTech* tech = db_->getTech();
+  auto [it, inserted] = layer_colors_by_tech_.try_emplace(tech);
+  if (inserted) {
+    it->second = buildLayerColorMap(tech);
+  }
+  return it->second;
+}
+
 std::vector<std::string> TileGenerator::getSites() const
 {
   std::set<std::string> seen;
@@ -700,35 +792,20 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
     return png_data;
   }
 
-  // Per-layer colors: routing level 1=blue, 2=red, then distinct hues
-  static const Color kPalette[] = {
-      // clang-format off
-      // NOLINTBEGIN(modernize-use-designated-initializers)
-      { 70, 130, 210, 180},  // moderate blue
-      {200,  50,  50, 180},   // red
-      { 50, 180,  80, 180},   // green
-      {200, 160,  40, 180},  // amber
-      {160,  60, 200, 180},  // purple
-      { 40, 190, 190, 180},  // teal
-      {220, 120,  50, 180},  // orange
-      {180,  70, 150, 180},  // magenta
-      // NOLINTEND(modernize-use-designated-initializers)
-      // clang-format on
-  };
-  static constexpr int kPaletteSize = sizeof(kPalette) / sizeof(kPalette[0]);
+  // Per-layer colors mirror gui::DisplayControls so the GUI and web frontend
+  // agree on which color belongs to which layer.
+  const auto& layer_colors = getLayerColorMap();
 
   odb::dbTech* tech = db_->getTech();
   odb::dbTechLayer* tech_layer = tech->findLayer(layer.c_str());
 
-  int layer_index = 0;
+  Color color{.r = 200, .g = 200, .b = 200, .a = 180};
   if (tech_layer) {
-    const auto all_layers = getLayers();
-    const auto it = std::ranges::find(all_layers, layer);
-    if (it != all_layers.end()) {
-      layer_index = std::distance(all_layers.begin(), it);
+    const auto it = layer_colors.find(tech_layer);
+    if (it != layer_colors.end()) {
+      color = it->second;
     }
   }
-  const Color color = kPalette[layer_index % kPaletteSize];
   const Color obs_color = color.lighter();
 
   // Determine our tile's bounding box in dbu coordinates.
@@ -830,9 +907,6 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
                           {qw, pin_max_size / 2},
                           {0, 0}};
 
-      // Determine layer colors for per-layer coloring of markers.
-      const auto all_layers = getLayers();
-
       // Iterate per-box like the GUI (each dbBox gets its own marker).
       for (odb::dbBTerm* term : block->getBTerms()) {
         for (odb::dbBPin* pin : term->getBPins()) {
@@ -852,11 +926,9 @@ std::vector<unsigned char> TileGenerator::renderTileBuffer(
             Color marker_color{.r = 200, .g = 200, .b = 200, .a = 220};
             odb::dbTechLayer* pin_layer = box->getTechLayer();
             if (pin_layer) {
-              const auto it = std::ranges::find(
-                  all_layers, std::string(pin_layer->getName()));
-              if (it != all_layers.end()) {
-                const int idx = std::distance(all_layers.begin(), it);
-                marker_color = kPalette[idx % kPaletteSize];
+              const auto it = layer_colors.find(pin_layer);
+              if (it != layer_colors.end()) {
+                marker_color = it->second;
                 marker_color.a = 220;
               }
             }
@@ -2707,9 +2779,29 @@ void collectTimingPathShapes(odb::dbBlock* block,
 void serializeTechResponse(JsonBuilder& b, const TileGenerator& gen)
 {
   b.beginObject();
+  const auto& layer_colors = gen.getLayerColorMap();
+  // Look up rendered layers' colors by name without depending on iteration
+  // order.  Names are unique within a tech.
+  std::map<std::string, Color> color_by_name;
+  for (const auto& [layer, color] : layer_colors) {
+    color_by_name[layer->getName()] = color;
+  }
   b.beginArray("layers");
   for (const auto& name : gen.getLayers()) {
     b.value(name);
+  }
+  b.endArray();
+  b.beginArray("layer_colors");
+  for (const auto& name : gen.getLayers()) {
+    const auto it = color_by_name.find(name);
+    const Color c = (it != color_by_name.end())
+                        ? it->second
+                        : Color{.r = 200, .g = 200, .b = 200, .a = 180};
+    b.beginArray();
+    b.value(static_cast<int>(c.r));
+    b.value(static_cast<int>(c.g));
+    b.value(static_cast<int>(c.b));
+    b.endArray();
   }
   b.endArray();
   b.beginArray("sites");

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 #include <string_view>
@@ -162,6 +163,10 @@ class TileGenerator
 
   std::vector<std::string> getLayers() const;
   std::vector<std::string> getSites() const;
+
+  // Per-layer colors matching gui::DisplayControls layer palette.  Computed
+  // lazily and cached; the cache is rebuilt only if the tech changes.
+  const std::map<odb::dbTechLayer*, Color>& getLayerColorMap() const;
 
   std::vector<SelectionResult> selectAt(
       int dbu_x,
@@ -362,6 +367,14 @@ class TileGenerator
   utl::Logger* logger_;
   std::unique_ptr<Search> search_;
   int pin_label_margin_dbu_ = 0;  // cached by computePinLabelMargin()
+
+  // Cached layer-color map keyed by tech (see getLayerColorMap).  Each tech is
+  // computed once and kept; std::map reference stability means a returned ref
+  // stays valid even if another tech is added later.
+  mutable std::mutex layer_colors_mutex_;
+  mutable std::map<odb::dbTech*, std::map<odb::dbTechLayer*, Color>>
+      layer_colors_by_tech_;
+
   static constexpr int kTileSizeInPixel = 256;
 };
 

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -193,6 +193,7 @@ class TileGenerator
 
   odb::dbBlock* getBlock() const;
   odb::dbChip* getChip() const;
+  odb::dbTech* getTech() const;
 
   std::vector<unsigned char> generateTile(
       const std::string& layer,

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -135,6 +135,82 @@ TEST_F(TileGeneratorTest, GetLayers)
   EXPECT_EQ(layers.back(), "metal10");
 }
 
+// Layer colors must mirror gui::DisplayControls::techInit so the GUI and the
+// web frontend show the same color for the same layer.  Spot-check the first
+// few entries of each palette and exercise the type-based assignment rules.
+TEST_F(TileGeneratorTest, GetLayerColorMapMatchesGuiPalette)
+{
+  makeTileGen();
+  const auto& colors = tile_gen_->getLayerColorMap();
+
+  odb::dbTech* tech = getDb()->getTech();
+  ASSERT_NE(tech, nullptr);
+
+  odb::dbTechLayer* metal1 = tech->findLayer("metal1");
+  odb::dbTechLayer* metal2 = tech->findLayer("metal2");
+  odb::dbTechLayer* metal3 = tech->findLayer("metal3");
+  odb::dbTechLayer* via1 = tech->findLayer("via1");
+  odb::dbTechLayer* via2 = tech->findLayer("via2");
+  ASSERT_NE(metal1, nullptr);
+  ASSERT_NE(metal2, nullptr);
+  ASSERT_NE(metal3, nullptr);
+  ASSERT_NE(via1, nullptr);
+  ASSERT_NE(via2, nullptr);
+
+  // First three metals match the GUI's seeded #00F, #F00, #0D0 entries.
+  const Color m1 = colors.at(metal1);
+  EXPECT_EQ(m1.r, 0);
+  EXPECT_EQ(m1.g, 0);
+  EXPECT_EQ(m1.b, 254);
+  EXPECT_EQ(m1.a, 180);
+
+  const Color m2 = colors.at(metal2);
+  EXPECT_EQ(m2.r, 254);
+  EXPECT_EQ(m2.g, 0);
+  EXPECT_EQ(m2.b, 0);
+
+  const Color m3 = colors.at(metal3);
+  EXPECT_EQ(m3.r, 9);
+  EXPECT_EQ(m3.g, 221);
+  EXPECT_EQ(m3.b, 0);
+
+  // First two cuts match the GUI's cut palette (light blue, light red).
+  const Color v1 = colors.at(via1);
+  EXPECT_EQ(v1.r, 126);
+  EXPECT_EQ(v1.g, 126);
+  EXPECT_EQ(v1.b, 255);
+  EXPECT_EQ(v1.a, 180);
+
+  const Color v2 = colors.at(via2);
+  EXPECT_EQ(v2.r, 255);
+  EXPECT_EQ(v2.g, 126);
+  EXPECT_EQ(v2.b, 126);
+}
+
+TEST_F(TileGeneratorTest, GetLayerColorMapIsCached)
+{
+  makeTileGen();
+  // Identity check: same tech ⇒ same map object.  This is the contract that
+  // makes caching observable to callers (no rebuild between tile renders).
+  const auto& first = tile_gen_->getLayerColorMap();
+  const auto& second = tile_gen_->getLayerColorMap();
+  EXPECT_EQ(&first, &second);
+}
+
+TEST_F(TileGeneratorTest, SerializeTechResponseIncludesLayerColors)
+{
+  makeTileGen();
+  JsonBuilder b;
+  serializeTechResponse(b, *tile_gen_);
+  const std::string json = b.str();
+
+  EXPECT_NE(json.find("\"layer_colors\""), std::string::npos)
+      << "tech response missing layer_colors key; got: " << json;
+  // The metal1 color [0, 0, 254] should appear since metal1 is layers[0].
+  EXPECT_NE(json.find("[0, 0, 254]"), std::string::npos)
+      << "tech response missing metal1 color [0, 0, 254]; got: " << json;
+}
+
 TEST_F(TileGeneratorTest, GenerateTileReturnsValidPng)
 {
   placeInst("BUF_X16", "buf1", 0, 0);

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "color.h"
 #include "gtest/gtest.h"
 #include "json_builder.h"
 #include "odb/db.h"
@@ -195,6 +196,23 @@ TEST_F(TileGeneratorTest, GetLayerColorMapIsCached)
   const auto& first = tile_gen_->getLayerColorMap();
   const auto& second = tile_gen_->getLayerColorMap();
   EXPECT_EQ(&first, &second);
+}
+
+TEST_F(TileGeneratorTest, EagerInitClearsLayerColorCache)
+{
+  makeTileGen();
+  // Prime the cache.
+  tile_gen_->getLayerColorMap();
+  // eagerInit must drop cached entries so a reloaded design with a new
+  // dbTech allocated at the same address can't read stale colors.
+  tile_gen_->eagerInit();
+  // Recomputing still produces correct values.
+  const auto& colors = tile_gen_->getLayerColorMap();
+  odb::dbTechLayer* metal1 = getDb()->getTech()->findLayer("metal1");
+  ASSERT_NE(metal1, nullptr);
+  EXPECT_EQ(colors.at(metal1).r, 0);
+  EXPECT_EQ(colors.at(metal1).g, 0);
+  EXPECT_EQ(colors.at(metal1).b, 254);
 }
 
 TEST_F(TileGeneratorTest, SerializeTechResponseIncludesLayerColors)


### PR DESCRIPTION
## Summary
Make the web view have the same layer coloring as the GUI

## Type of Change
- Bug fix?
- Refactoring?

## Impact
No impact except the web coloring is now consistent with GUI view.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**

## Related Issues
N/A
