### PR TITLE
grt: Fix integer overflow (UB) on inverted net rects

### DIFF
--- a/src/grt/src/Rudy.cpp
+++ b/src/grt/src/Rudy.cpp
@@ -4,6 +4,7 @@
 #include "grt/Rudy.h"
 
 #include <algorithm>
+#include <climits>
 #include <cstdint>
 #include <optional>
 #include <set>
@@ -147,6 +148,9 @@ void Rudy::processNet(odb::dbNet* net)
 
 void Rudy::processIntersectionSignalNet(const odb::Rect net_rect)
 {
+  if (net_rect.isMergeInit()) {
+    return;
+  }
   const auto net_area = net_rect.area();
   if (net_area == 0) {
     // TODO: handle nets with 0 area from getTermBBox()

--- a/src/grt/src/Rudy.cpp
+++ b/src/grt/src/Rudy.cpp
@@ -148,7 +148,7 @@ void Rudy::processNet(odb::dbNet* net)
 
 void Rudy::processIntersectionSignalNet(const odb::Rect net_rect)
 {
-  if (net_rect.isMergeInit()) {
+  if (net_rect.isInverted()) {
     return;
   }
   const auto net_area = net_rect.area();

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -356,6 +356,9 @@ class Rect
   // Indicates if the box has a negative width or height
   bool isInverted() const;
 
+  // Indicates if the box is unmerged after mergeInit()
+  bool isMergeInit() const;
+
   int minDXDY() const;
   int maxDXDY() const;
   Orientation2D getDir() const;
@@ -894,6 +897,12 @@ inline void Rect::mergeInit()
 inline bool Rect::isInverted() const
 {
   return xlo_ > xhi_ || ylo_ > yhi_;
+}
+
+inline bool Rect::isMergeInit() const
+{
+  return xlo_ == INT_MAX && ylo_ == INT_MAX && xhi_ == INT_MIN
+         && yhi_ == INT_MIN;
 }
 
 inline void Rect::printf(FILE* fp, const char* prefix)

--- a/src/odb/include/odb/geom.h
+++ b/src/odb/include/odb/geom.h
@@ -356,9 +356,6 @@ class Rect
   // Indicates if the box has a negative width or height
   bool isInverted() const;
 
-  // Indicates if the box is unmerged after mergeInit()
-  bool isMergeInit() const;
-
   int minDXDY() const;
   int maxDXDY() const;
   Orientation2D getDir() const;
@@ -897,12 +894,6 @@ inline void Rect::mergeInit()
 inline bool Rect::isInverted() const
 {
   return xlo_ > xhi_ || ylo_ > yhi_;
-}
-
-inline bool Rect::isMergeInit() const
-{
-  return xlo_ == INT_MAX && ylo_ == INT_MAX && xhi_ == INT_MIN
-         && yhi_ == INT_MIN;
 }
 
 inline void Rect::printf(FILE* fp, const char* prefix)


### PR DESCRIPTION
If the Rect is in the default state calling `area` (and probably other methods) will lead to integer overflow triggering UB.   This was detected by internal fuzz testing with the following verilog (the flow is a bit complicated so I'm not sure how this actually triggers the empty Rect).
```
    module dut(
      input wire clk,
      output wire out
    );
      wire p0_literal_263_comb;
      assign p0_literal_263_comb = 1'h0;
      assign out = p0_literal_263_comb;
    endmodule
```