### PR TITLE
test/orfs/gcd: remove SWAP_ARITH_OPERATORS smoketest

### DIFF
--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -17,11 +17,6 @@ orfs_sweep(
         # Demonstrate clock period specified in arguments, useful
         # for Optuna scripts.
         "ABC_CLOCK_PERIOD_IN_PS": "310.001",
-        # SWAP_ARITH_OPERATORS=1 was set as a smoketest but triggers a
-        # non-deterministic bug in yosys 0.62 WRAPCELL that occasionally
-        # emits a control character (0x1d) inside the generated
-        # *_KOGGE_STONE module name and aborts synthesis. Re-enable once
-        # the upstream yosys bug is fixed.
     },
     sources = {
         "RULES_JSON": [":rules-base.json"],
@@ -76,12 +71,7 @@ sh_test(
 check_same(
     name = "gcd_idempotent_test",
     flow = "gcd",
-    # Non-deterministic yosys wrapcell output under SWAP_ARITH_OPERATORS makes
-    # this flaky; keep manual until the upstream bug is fixed.
-    tags = [
-        "manual",
-        "orfs",
-    ],
+    tags = ["orfs"],
     variant_a = "base",
     variant_b = "b",
 )

--- a/test/orfs/gcd/BUILD
+++ b/test/orfs/gcd/BUILD
@@ -17,8 +17,11 @@ orfs_sweep(
         # Demonstrate clock period specified in arguments, useful
         # for Optuna scripts.
         "ABC_CLOCK_PERIOD_IN_PS": "310.001",
-        # Smoketest
-        "SWAP_ARITH_OPERATORS": "1",
+        # SWAP_ARITH_OPERATORS=1 was set as a smoketest but triggers a
+        # non-deterministic bug in yosys 0.62 WRAPCELL that occasionally
+        # emits a control character (0x1d) inside the generated
+        # *_KOGGE_STONE module name and aborts synthesis. Re-enable once
+        # the upstream yosys bug is fixed.
     },
     sources = {
         "RULES_JSON": [":rules-base.json"],
@@ -73,7 +76,12 @@ sh_test(
 check_same(
     name = "gcd_idempotent_test",
     flow = "gcd",
-    tags = ["orfs"],
+    # Non-deterministic yosys wrapcell output under SWAP_ARITH_OPERATORS makes
+    # this flaky; keep manual until the upstream bug is fixed.
+    tags = [
+        "manual",
+        "orfs",
+    ],
     variant_a = "base",
     variant_b = "b",
 )


### PR DESCRIPTION
## Summary

yosys 0.62 `WRAPCELL` non-deterministically emits a `0x1d` control character inside the generated `*_KOGGE_STONE` module name when `SWAP_ARITH_OPERATORS=1`, aborting synthesis. The original `gcd` flow set `SWAP_ARITH_OPERATORS=1` as a smoketest — that has been silently failing intermittently.

Per [maliberty review feedback](https://github.com/The-OpenROAD-Project/OpenROAD/pull/10309#discussion_r2152): rather than leaving the flag disabled with a "re-enable once the upstream yosys bug is fixed" comment that nobody is tracking, just remove it. With the flag gone, `gcd_idempotent_test` no longer needs the manual tag either.

Split out of #10237 — pure behavioral test change, unrelated to docker removal.

## Test plan

- [x] `bazelisk test //test/orfs/gcd:all` passes locally.
- [ ] CI green.