### PR TITLE
test/orfs: vendor asap7 stdcell verilog files

### DIFF
--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -5,7 +5,16 @@ filegroup(
         "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
         "asap7sc7p5t_OA_RVT_TT_201020.v",
         "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
+        "dff.v",
     ],
     visibility = ["//visibility:public"],
 )
+
+exports_files([
+    "asap7sc7p5t_AO_RVT_TT_201020.v",
+    "asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+    "asap7sc7p5t_OA_RVT_TT_201020.v",
+    "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+    "dff.v",
+    "empty.v",
+])

--- a/test/orfs/asap7/BUILD
+++ b/test/orfs/asap7/BUILD
@@ -6,6 +6,7 @@ filegroup(
         "asap7sc7p5t_OA_RVT_TT_201020.v",
         "asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
         "dff.v",
+        "empty.v",
     ],
     visibility = ["//visibility:public"],
 )

--- a/test/orfs/asap7/dff.v
+++ b/test/orfs/asap7/dff.v
@@ -1,0 +1,32 @@
+// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R because
+// Verialtor doesn't support and has no plans to support 1995 UDP
+// tables.
+//
+// https://github.com/verilator/verilator/issues/5243
+
+module DFFHQNx1_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx2_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule
+
+module DFFHQNx3_ASAP7_75t_R (QN, D, CLK);
+    output reg QN;
+    input D, CLK;
+
+    always @(posedge CLK) begin
+        QN <= ~D;
+    end
+endmodule

--- a/test/orfs/asap7/dff.v
+++ b/test/orfs/asap7/dff.v
@@ -1,5 +1,5 @@
-// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R because
-// Verialtor doesn't support and has no plans to support 1995 UDP
+// Quick and dirty reimplementation of DFFHQNx{1,2,3}_ASAP7_75t_R because
+// Verilator doesn't support and has no plans to support 1995 UDP
 // tables.
 //
 // https://github.com/verilator/verilator/issues/5243

--- a/test/orfs/asap7/empty.v
+++ b/test/orfs/asap7/empty.v
@@ -1,0 +1,17 @@
+// Used to silence warnings.
+module TAPCELL_ASAP7_75t_R;
+endmodule
+module FILLERxp5_ASAP7_75t_R;
+endmodule
+module FILLER_ASAP7_75t_R;
+endmodule
+module DECAPx1_ASAP7_75t_R;
+endmodule
+module DECAPx2_ASAP7_75t_R;
+endmodule
+module DECAPx4_ASAP7_75t_R;
+endmodule
+module DECAPx6_ASAP7_75t_R;
+endmodule
+module DECAPx10_ASAP7_75t_R;
+endmodule

--- a/test/orfs/mock-array/mock-array.bzl
+++ b/test/orfs/mock-array/mock-array.bzl
@@ -462,11 +462,11 @@ def mock_array(name, config):
                         ))
                         for macro in MACROS
                     ] + [
-                        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_AO_RVT_TT_201020.v",
-                        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_INVBUF_RVT_TT_201020.v",
-                        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
-                        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/dff.v",
-                        "@docker_orfs//:OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v",
+                        "//test/orfs/asap7:asap7sc7p5t_AO_RVT_TT_201020.v",
+                        "//test/orfs/asap7:asap7sc7p5t_INVBUF_RVT_TT_201020.v",
+                        "//test/orfs/asap7:asap7sc7p5t_SIMPLE_RVT_TT_201020.v",
+                        "//test/orfs/asap7:dff.v",
+                        "//test/orfs/asap7:empty.v",
                     ],
                     tags = ["manual"],
                 )


### PR DESCRIPTION
Longer term I have a plan to generate behavioral verilog from the .lib file rather than handcoding this, but for now keep this here to reduce dependencies before we circle back and delete them.

## Summary

Replace \`@docker_orfs\` references with files committed to the tree:

- **\`test/orfs/asap7/dff.v\`** — minimal Verilator-friendly \`DFFHQNx{1,2,3}_ASAP7_75t_R\` reimplementation. The original ASAP7 \`dff.v\` uses 1995 UDP tables, which Verilator does not support and has no plans to support ([verilator/verilator#5243](https://github.com/verilator/verilator/issues/5243)). Without this rewrite, the mock-array Verilator sim can't elaborate.
- **\`test/orfs/asap7/empty.v\`** — empty stub modules for TAPCELL / FILLER / DECAP cells, to silence Verilator warnings about unimplemented gates that don't matter for functional simulation.
- Switch the four other ASAP7 stdcell verilog references in \`mock-array.bzl\` to local labels (they were always shadow copies of the same files).

Step toward dropping docker (#10237). Splitting it out leaves only the MODULE.bazel docker plumbing and the yosys/slang plugin work in the parent PR.

Note: the \`exports_files\` block in \`asap7/BUILD\` is what @hzeller flagged as a code-smell; addressing it as a follow-up since per-file filegroups would conflict with the \`.v\` filenames. Will revisit.

## Test plan

- [x] \`bazelisk build //test/orfs/asap7:all\` succeeds.
- [x] \`bazelisk query //test/orfs/mock-array:MockArray_4x4_base_test\` parses cleanly.
- [ ] CI green.