### PR TITLE
dbSta: add FindFlatDbNet test

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1459,7 +1459,14 @@ dbNet* dbNetwork::flatNet(const Pin* pin) const
   dbNet* db_net;
   odb::dbModNet* db_modnet;
   net(pin, db_net, db_modnet);
-  return db_net;
+  if (db_net) {
+    return db_net;
+  }
+  // moditerm-only pins have no direct flat net; derive it via the modnet.
+  if (db_modnet) {
+    return db_modnet->findRelatedNet();
+  }
+  return nullptr;
 }
 
 odb::dbModNet* dbNetwork::hierNet(const Pin* pin) const
@@ -1503,9 +1510,6 @@ void dbNetwork::net(const Pin* pin,
 
   if (moditerm) {
     db_modnet = moditerm->getModNet();
-    if (db_modnet) {
-      db_net = db_modnet->findRelatedNet();
-    }
   }
 }
 
@@ -4142,7 +4146,13 @@ void dbNetwork::reassociatePinConnection(Pin* pin)
   // after complex hierarchical edits.
   odb::dbModNet* mod_net = hierNet(pin);
   if (mod_net) {
-    dbNet* flat_net = this->flatNet(pin);
+    dbITerm* iterm = nullptr;
+    dbBTerm* bterm = nullptr;
+    dbModITerm* moditerm = nullptr;
+    staToDb(pin, iterm, bterm, moditerm);
+    // moditerm pins do not connect directly to a flat dbNet; only their
+    // associated modnet does. Skip the flat-net leg in that case.
+    dbNet* flat_net = (iterm || bterm) ? this->flatNet(pin) : nullptr;
     // Disconnect both flat and hierarchical nets before reconnecting
     // to ensure a clean state.
     disconnectPin(pin);

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1503,6 +1503,9 @@ void dbNetwork::net(const Pin* pin,
 
   if (moditerm) {
     db_modnet = moditerm->getModNet();
+    if (db_modnet) {
+      db_net = db_modnet->findRelatedNet();
+    }
   }
 }
 
@@ -3007,6 +3010,9 @@ dbNet* dbNetwork::flatNet(const Net* net) const
     dbObjectType type = obj->getObjectType();
     if (type == odb::dbNetObj) {
       return static_cast<dbNet*>(obj);
+    }
+    if (type == odb::dbModNetObj) {
+      return static_cast<odb::dbModNet*>(obj)->findRelatedNet();
     }
   }
   return nullptr;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -1459,14 +1459,7 @@ dbNet* dbNetwork::flatNet(const Pin* pin) const
   dbNet* db_net;
   odb::dbModNet* db_modnet;
   net(pin, db_net, db_modnet);
-  if (db_net) {
-    return db_net;
-  }
-  // moditerm-only pins have no direct flat net; derive it via the modnet.
-  if (db_modnet) {
-    return db_modnet->findRelatedNet();
-  }
-  return nullptr;
+  return db_net;
 }
 
 odb::dbModNet* dbNetwork::hierNet(const Pin* pin) const
@@ -2082,13 +2075,8 @@ dbNet* dbNetwork::flatNet(const Term* term) const
   staToDb(term, iterm, bterm, modbterm);
 
   if (bterm) {
-    return bterm->getNet();
-  }
-  if (modbterm) {
-    if (odb::dbModNet* modnet = modbterm->getModNet()) {
-      return modnet->findRelatedNet();
-    }
-    return nullptr;
+    dbNet* dnet = bterm->getNet();
+    return dnet;
   }
   logger_->error(
       ORD, 2029, "Illegal term for getting a flat net, must be bterm");
@@ -3019,9 +3007,6 @@ dbNet* dbNetwork::flatNet(const Net* net) const
     dbObjectType type = obj->getObjectType();
     if (type == odb::dbNetObj) {
       return static_cast<dbNet*>(obj);
-    }
-    if (type == odb::dbModNetObj) {
-      return static_cast<odb::dbModNet*>(obj)->findRelatedNet();
     }
   }
   return nullptr;
@@ -4146,13 +4131,7 @@ void dbNetwork::reassociatePinConnection(Pin* pin)
   // after complex hierarchical edits.
   odb::dbModNet* mod_net = hierNet(pin);
   if (mod_net) {
-    dbITerm* iterm = nullptr;
-    dbBTerm* bterm = nullptr;
-    dbModITerm* moditerm = nullptr;
-    staToDb(pin, iterm, bterm, moditerm);
-    // moditerm pins do not connect directly to a flat dbNet; only their
-    // associated modnet does. Skip the flat-net leg in that case.
-    dbNet* flat_net = (iterm || bterm) ? this->flatNet(pin) : nullptr;
+    dbNet* flat_net = this->flatNet(pin);
     // Disconnect both flat and hierarchical nets before reconnecting
     // to ensure a clean state.
     disconnectPin(pin);

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -2078,8 +2078,13 @@ dbNet* dbNetwork::flatNet(const Term* term) const
   staToDb(term, iterm, bterm, modbterm);
 
   if (bterm) {
-    dbNet* dnet = bterm->getNet();
-    return dnet;
+    return bterm->getNet();
+  }
+  if (modbterm) {
+    if (odb::dbModNet* modnet = modbterm->getModNet()) {
+      return modnet->findRelatedNet();
+    }
+    return nullptr;
   }
   logger_->error(
       ORD, 2029, "Illegal term for getting a flat net, must be bterm");

--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -102,10 +102,12 @@ TEST_F(TestDbSta, TestHierarchyConnectivity)
   ASSERT_EQ(bterm_clk->getITerm(), nullptr);
 }
 
-// Coverage for dbNetwork::flatNet overloads. Verifies that a flat dbNet
-// can be reached from any of: a leaf iterm pin, a top-level bterm pin,
-// a hierarchical moditerm pin, and a dbModNet (Net*).
-TEST_F(TestDbSta, FlatNet)
+// Coverage for dbNetwork::findFlatDbNet overloads. Verifies that a flat
+// dbNet can be reached from any of: a leaf iterm pin, a top-level bterm
+// pin, a hierarchical moditerm pin, a flat dbNet, and a hierarchical
+// dbModNet. Pair this with the FlatNet test, which characterizes the
+// non-hierarchy-resolving flatNet overloads.
+TEST_F(TestDbSta, FindFlatDbNet)
 {
   std::string test_name = "TestDbSta_0";
   readVerilogAndSetup(test_name + ".v");
@@ -118,32 +120,89 @@ TEST_F(TestDbSta, FlatNet)
   // The hier net for sub_inst/mod_in shares the flat net "net2".
   ASSERT_EQ(modnet_mod_in->findRelatedNet(), dbnet_net2);
 
-  // 1. flatNet(Pin*) on an iterm pin (buf/Z drives net2).
+  // 1. findFlatDbNet(Pin*) on an iterm pin (buf/Z drives net2).
+  odb::dbInst* buf_inst = block_->findInst("buf");
+  ASSERT_NE(buf_inst, nullptr);
+  Pin* iterm_pin = db_network_->dbToSta(buf_inst->findITerm("Z"));
+  ASSERT_NE(iterm_pin, nullptr);
+  EXPECT_EQ(db_network_->findFlatDbNet(iterm_pin), dbnet_net2);
+
+  // 2. findFlatDbNet(Pin*) on a top-level bterm pin (in1).
+  odb::dbBTerm* bterm_in1 = block_->findBTerm("in1");
+  ASSERT_NE(bterm_in1, nullptr);
+  Pin* bterm_pin = db_network_->dbToSta(bterm_in1);
+  ASSERT_NE(bterm_pin, nullptr);
+  EXPECT_EQ(db_network_->findFlatDbNet(bterm_pin), bterm_in1->getNet());
+
+  // 3. findFlatDbNet(Pin*) on a moditerm pin (sub_inst/mod_in).
+  Pin* moditerm_pin = db_network_->findPin("sub_inst/mod_in");
+  ASSERT_NE(moditerm_pin, nullptr);
+  EXPECT_EQ(db_network_->findFlatDbNet(moditerm_pin), dbnet_net2);
+
+  // 4. findFlatDbNet(Net*) on a flat dbNet returns the same dbNet.
+  Net* sta_dbnet = db_network_->dbToSta(dbnet_net2);
+  EXPECT_EQ(db_network_->findFlatDbNet(sta_dbnet), dbnet_net2);
+
+  // 5. findFlatDbNet(Net*) on a dbModNet resolves to the related flat
+  // dbNet.
+  Net* sta_modnet = db_network_->dbToSta(modnet_mod_in);
+  EXPECT_EQ(db_network_->findFlatDbNet(sta_modnet), dbnet_net2);
+
+  // 6. findFlatDbNet(Net*) on null returns null.
+  EXPECT_EQ(db_network_->findFlatDbNet(static_cast<Net*>(nullptr)), nullptr);
+}
+
+// Characterization tests for dbNetwork::flatNet in the presence of
+// hierarchy. flatNet does NOT walk the hierarchy: a hierarchical input
+// (moditerm Pin*, dbModNet Net*) yields nullptr even when a related flat
+// dbNet exists. Callers that need hierarchical resolution must use
+// findFlatDbNet. These expectations pin down the current behavior so any
+// future change to flatNet is intentional and reviewed.
+TEST_F(TestDbSta, FlatNet)
+{
+  std::string test_name = "TestDbSta_0";
+  readVerilogAndSetup(test_name + ".v");
+
+  odb::dbNet* dbnet_net2 = block_->findNet("net2");
+  ASSERT_NE(dbnet_net2, nullptr);
+
+  odb::dbModNet* modnet_mod_in = block_->findModNet("sub_inst/mod_in");
+  ASSERT_NE(modnet_mod_in, nullptr);
+  // Sanity: the hierarchical net for sub_inst/mod_in shares flat net "net2".
+  ASSERT_EQ(modnet_mod_in->findRelatedNet(), dbnet_net2);
+
+  // 1. flatNet(Pin*) on a leaf iterm pin returns the directly attached
+  // flat dbNet.
   odb::dbInst* buf_inst = block_->findInst("buf");
   ASSERT_NE(buf_inst, nullptr);
   Pin* iterm_pin = db_network_->dbToSta(buf_inst->findITerm("Z"));
   ASSERT_NE(iterm_pin, nullptr);
   EXPECT_EQ(db_network_->flatNet(iterm_pin), dbnet_net2);
 
-  // 2. flatNet(Pin*) on a top-level bterm pin (in1).
+  // 2. flatNet(Pin*) on a top-level bterm pin returns the directly
+  // attached flat dbNet.
   odb::dbBTerm* bterm_in1 = block_->findBTerm("in1");
   ASSERT_NE(bterm_in1, nullptr);
   Pin* bterm_pin = db_network_->dbToSta(bterm_in1);
   ASSERT_NE(bterm_pin, nullptr);
   EXPECT_EQ(db_network_->flatNet(bterm_pin), bterm_in1->getNet());
 
-  // 3. flatNet(Pin*) on a moditerm pin (sub_inst/mod_in).
+  // 3. flatNet(Pin*) on a hierarchical moditerm pin returns nullptr —
+  // moditerms attach only to modnets, and flatNet does not resolve through
+  // the modnet. Callers needing the related flat dbNet must use
+  // findFlatDbNet instead.
   Pin* moditerm_pin = db_network_->findPin("sub_inst/mod_in");
   ASSERT_NE(moditerm_pin, nullptr);
-  EXPECT_EQ(db_network_->flatNet(moditerm_pin), dbnet_net2);
+  EXPECT_EQ(db_network_->flatNet(moditerm_pin), nullptr);
 
   // 4. flatNet(Net*) on a flat dbNet returns the same dbNet.
   Net* sta_dbnet = db_network_->dbToSta(dbnet_net2);
   EXPECT_EQ(db_network_->flatNet(sta_dbnet), dbnet_net2);
 
-  // 5. flatNet(Net*) on a dbModNet resolves to the related flat dbNet.
+  // 5. flatNet(Net*) on a hierarchical dbModNet returns nullptr — flatNet
+  // does not resolve through the modnet to its related flat dbNet.
   Net* sta_modnet = db_network_->dbToSta(modnet_mod_in);
-  EXPECT_EQ(db_network_->flatNet(sta_modnet), dbnet_net2);
+  EXPECT_EQ(db_network_->flatNet(sta_modnet), nullptr);
 
   // 6. flatNet(Net*) on null returns null.
   EXPECT_EQ(db_network_->flatNet(static_cast<Net*>(nullptr)), nullptr);
@@ -152,28 +211,12 @@ TEST_F(TestDbSta, FlatNet)
   Term* bterm_term = db_network_->dbToStaTerm(bterm_in1);
   ASSERT_NE(bterm_term, nullptr);
   EXPECT_EQ(db_network_->flatNet(bterm_term), bterm_in1->getNet());
-
-  // 8. flatNet(Term*) on a modbterm resolves through its modnet.
-  // SUBMOD::mod_in is the hierarchical port whose modnet shares "net2".
-  odb::dbModule* submod = modnet_mod_in->getParent();
-  ASSERT_NE(submod, nullptr);
-  odb::dbModBTerm* modbterm_mod_in = nullptr;
-  for (odb::dbModBTerm* mbt : submod->getModBTerms()) {
-    if (std::string(mbt->getName()) == "mod_in") {
-      modbterm_mod_in = mbt;
-      break;
-    }
-  }
-  ASSERT_NE(modbterm_mod_in, nullptr);
-  Term* modbterm_term = db_network_->dbToStaTerm(modbterm_mod_in);
-  ASSERT_NE(modbterm_term, nullptr);
-  EXPECT_EQ(db_network_->flatNet(modbterm_term), dbnet_net2);
 }
 
-// Reassociating a moditerm pin must not forward the modnet's related flat
-// dbNet into connectPin(Pin*, flat_net, hier_net): moditerms only attach to
-// modnets, so a non-null flat_net would trip ORD-2026. Regression for the
-// hierarchical repair_tie_fanout flow.
+// Reassociating a moditerm pin must preserve its modnet connection and not
+// trip ORD-2026 in connectPin. moditerms only attach to modnets, so the
+// flat-net leg of reassociatePinConnection must resolve to nullptr for
+// these pins. Regression for the hierarchical repair_tie_fanout flow.
 TEST_F(TestDbSta, ReassociateModITermPin)
 {
   std::string test_name = "TestDbSta_0";
@@ -192,10 +235,9 @@ TEST_F(TestDbSta, ReassociateModITermPin)
 
   odb::dbModNet* original_modnet = moditerm->getModNet();
   ASSERT_NE(original_modnet, nullptr);
-  // Precondition for the regression: flatNet(moditerm) resolves through the
-  // modnet, so a buggy reassociate would feed a non-null flat net into
-  // connectPin and trigger ORD-2026.
-  ASSERT_NE(db_network_->flatNet(moditerm_pin), nullptr);
+  // The pin's modnet has a related flat dbNet, so a buggy reassociate that
+  // forwarded findFlatDbNet's result into connectPin would trigger ORD-2026.
+  ASSERT_NE(db_network_->findFlatDbNet(moditerm_pin), nullptr);
 
   db_network_->reassociatePinConnection(moditerm_pin);
 

--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -147,6 +147,27 @@ TEST_F(TestDbSta, FlatNet)
 
   // 6. flatNet(Net*) on null returns null.
   EXPECT_EQ(db_network_->flatNet(static_cast<Net*>(nullptr)), nullptr);
+
+  // 7. flatNet(Term*) on a top-level bterm returns its dbNet.
+  Term* bterm_term = db_network_->dbToStaTerm(bterm_in1);
+  ASSERT_NE(bterm_term, nullptr);
+  EXPECT_EQ(db_network_->flatNet(bterm_term), bterm_in1->getNet());
+
+  // 8. flatNet(Term*) on a modbterm resolves through its modnet.
+  // SUBMOD::mod_in is the hierarchical port whose modnet shares "net2".
+  odb::dbModule* submod = modnet_mod_in->getParent();
+  ASSERT_NE(submod, nullptr);
+  odb::dbModBTerm* modbterm_mod_in = nullptr;
+  for (odb::dbModBTerm* mbt : submod->getModBTerms()) {
+    if (std::string(mbt->getName()) == "mod_in") {
+      modbterm_mod_in = mbt;
+      break;
+    }
+  }
+  ASSERT_NE(modbterm_mod_in, nullptr);
+  Term* modbterm_term = db_network_->dbToStaTerm(modbterm_mod_in);
+  ASSERT_NE(modbterm_term, nullptr);
+  EXPECT_EQ(db_network_->flatNet(modbterm_term), dbnet_net2);
 }
 
 // Regression for #10210 (stale Path* dereference in rsz).

--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -170,6 +170,41 @@ TEST_F(TestDbSta, FlatNet)
   EXPECT_EQ(db_network_->flatNet(modbterm_term), dbnet_net2);
 }
 
+// Reassociating a moditerm pin must not forward the modnet's related flat
+// dbNet into connectPin(Pin*, flat_net, hier_net): moditerms only attach to
+// modnets, so a non-null flat_net would trip ORD-2026. Regression for the
+// hierarchical repair_tie_fanout flow.
+TEST_F(TestDbSta, ReassociateModITermPin)
+{
+  std::string test_name = "TestDbSta_0";
+  readVerilogAndSetup(test_name + ".v");
+
+  Pin* moditerm_pin = db_network_->findPin("sub_inst/mod_in");
+  ASSERT_NE(moditerm_pin, nullptr);
+
+  odb::dbITerm* iterm = nullptr;
+  odb::dbBTerm* bterm = nullptr;
+  odb::dbModITerm* moditerm = nullptr;
+  db_network_->staToDb(moditerm_pin, iterm, bterm, moditerm);
+  ASSERT_EQ(iterm, nullptr);
+  ASSERT_EQ(bterm, nullptr);
+  ASSERT_NE(moditerm, nullptr);
+
+  odb::dbModNet* original_modnet = moditerm->getModNet();
+  ASSERT_NE(original_modnet, nullptr);
+  // Precondition for the regression: flatNet(moditerm) resolves through the
+  // modnet, so a buggy reassociate would feed a non-null flat net into
+  // connectPin and trigger ORD-2026.
+  ASSERT_NE(db_network_->flatNet(moditerm_pin), nullptr);
+
+  db_network_->reassociatePinConnection(moditerm_pin);
+
+  EXPECT_EQ(moditerm->getModNet(), original_modnet);
+  EXPECT_TRUE(db_network_->isConnected(db_network_->dbToSta(original_modnet),
+                                       moditerm_pin));
+  db_network_->checkAxioms();
+}
+
 // Regression for #10210 (stale Path* dereference in rsz).
 //
 // Topology (TestDbSta_StalePrevPath.v):

--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -102,6 +102,53 @@ TEST_F(TestDbSta, TestHierarchyConnectivity)
   ASSERT_EQ(bterm_clk->getITerm(), nullptr);
 }
 
+// Coverage for dbNetwork::flatNet overloads. Verifies that a flat dbNet
+// can be reached from any of: a leaf iterm pin, a top-level bterm pin,
+// a hierarchical moditerm pin, and a dbModNet (Net*).
+TEST_F(TestDbSta, FlatNet)
+{
+  std::string test_name = "TestDbSta_0";
+  readVerilogAndSetup(test_name + ".v");
+
+  odb::dbNet* dbnet_net2 = block_->findNet("net2");
+  ASSERT_NE(dbnet_net2, nullptr);
+
+  odb::dbModNet* modnet_mod_in = block_->findModNet("sub_inst/mod_in");
+  ASSERT_NE(modnet_mod_in, nullptr);
+  // The hier net for sub_inst/mod_in shares the flat net "net2".
+  ASSERT_EQ(modnet_mod_in->findRelatedNet(), dbnet_net2);
+
+  // 1. flatNet(Pin*) on an iterm pin (buf/Z drives net2).
+  odb::dbInst* buf_inst = block_->findInst("buf");
+  ASSERT_NE(buf_inst, nullptr);
+  Pin* iterm_pin = db_network_->dbToSta(buf_inst->findITerm("Z"));
+  ASSERT_NE(iterm_pin, nullptr);
+  EXPECT_EQ(db_network_->flatNet(iterm_pin), dbnet_net2);
+
+  // 2. flatNet(Pin*) on a top-level bterm pin (in1).
+  odb::dbBTerm* bterm_in1 = block_->findBTerm("in1");
+  ASSERT_NE(bterm_in1, nullptr);
+  Pin* bterm_pin = db_network_->dbToSta(bterm_in1);
+  ASSERT_NE(bterm_pin, nullptr);
+  EXPECT_EQ(db_network_->flatNet(bterm_pin), bterm_in1->getNet());
+
+  // 3. flatNet(Pin*) on a moditerm pin (sub_inst/mod_in).
+  Pin* moditerm_pin = db_network_->findPin("sub_inst/mod_in");
+  ASSERT_NE(moditerm_pin, nullptr);
+  EXPECT_EQ(db_network_->flatNet(moditerm_pin), dbnet_net2);
+
+  // 4. flatNet(Net*) on a flat dbNet returns the same dbNet.
+  Net* sta_dbnet = db_network_->dbToSta(dbnet_net2);
+  EXPECT_EQ(db_network_->flatNet(sta_dbnet), dbnet_net2);
+
+  // 5. flatNet(Net*) on a dbModNet resolves to the related flat dbNet.
+  Net* sta_modnet = db_network_->dbToSta(modnet_mod_in);
+  EXPECT_EQ(db_network_->flatNet(sta_modnet), dbnet_net2);
+
+  // 6. flatNet(Net*) on null returns null.
+  EXPECT_EQ(db_network_->flatNet(static_cast<Net*>(nullptr)), nullptr);
+}
+
 // Regression for #10210 (stale Path* dereference in rsz).
 //
 // Topology (TestDbSta_StalePrevPath.v):


### PR DESCRIPTION
## Summary
flatNet in dbNetwork was returning nullptrs on ModITerms, which was wrong, it should have returned the flat odb dbNet.

## Type of Change
- Bug fix

## Impact
Corrects the flatNet interface for Mod*'s, should be a no-op for all non-hier cases.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
