### PR TITLE
test/orfs: use /usr/bin/env bash in check_same.sh shebang

### DIFF
--- a/test/orfs/check_same.sh
+++ b/test/orfs/check_same.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Verify that pairs of ORFS output files are identical.
 # Args come in pairs: file_a file_b file_a file_b ...
 set -euo pipefail


### PR DESCRIPTION
## Summary
- Replace hard-coded `#!/bin/bash` with `#!/usr/bin/env bash` in `test/orfs/check_same.sh`.
- `/bin/bash` is not a guaranteed location (e.g. NixOS does not ship it there); `/usr/bin/env bash` works on NixOS as well as conventional FHS distros.

I also did a sweep of the rest of the `.sh` files in the tree — `check_same.sh` is the only one that hard-codes `/bin/bash`. The remaining shebangs are `/usr/bin/env bash` or `/bin/sh` (POSIX-required, present on NixOS).

Spotted in https://github.com/The-OpenROAD-Project/OpenROAD/pull/10237#issuecomment-4365715706.

## Test plan
- [ ] CI green