### PR TITLE
Smallish cleanups: `//:ord` references tcl: add to deps.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -253,7 +253,10 @@ cc_library(
         "include/ord",
     ],
     visibility = ["//:__subpackages__"],
-    deps = ["@abseil-cpp//absl/synchronization"],
+    deps = [
+        "@abseil-cpp//absl/synchronization",
+        "@tcl_lang//:tcl",
+    ],
 )
 
 cc_library(

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -4,7 +4,6 @@
 #include "nesterovBase.h"
 
 #include <algorithm>
-#include <boost/polygon/polygon.hpp>
 #include <cassert>
 #include <climits>
 #include <cmath>
@@ -23,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "boost/polygon/polygon.hpp"
 #include "fft.h"
 #include "gpl/Replace.h"
 #include "nesterovPlace.h"

--- a/src/tst/include/tst/nangate45_fixture.h
+++ b/src/tst/include/tst/nangate45_fixture.h
@@ -3,7 +3,6 @@
 
 #include <memory>
 
-#include "gtest/gtest.h"
 #include "odb/db.h"
 #include "tst/fixture.h"
 


### PR DESCRIPTION
The ord headers refer to the "tcl.h" header, thus this library have to depend on that.

`nangate45_fixture.h` included gtest header, but didn't need it.
