### PR TITLE
[rsz,dbSta] eliminate_dead_logic: skip per-disconnect modnet DFS

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -428,6 +428,17 @@ class dbNetwork : public ConcreteNetwork
   void removeDriverFromCache(const Net* net);
   void removeDriverFromCache(const Net* net, const Pin* drvr);
 
+  // Suspend per-disconnect driver-cache maintenance for the duration of a
+  // bulk netlist edit (e.g. eliminate_dead_logic). While this mode is
+  // active, disconnectPinBefore is a no-op: the caller promises to
+  // invalidate the entire driver cache via endBulkDelete() once finished.
+  // Avoids quadratic-shaped findRelatedModNets DFS work on hierarchical
+  // designs (each call would otherwise re-walk the modnet hierarchy from
+  // scratch).
+  void beginBulkDelete();
+  void endBulkDelete();
+  bool inBulkDelete() const { return bulk_delete_mode_; }
+
   using Network::cell;
   using Network::direction;
   using Network::findCellsMatching;
@@ -488,6 +499,7 @@ class dbNetwork : public ConcreteNetwork
   std::set<const Cell*> hier_modules_;
   std::set<const Port*> concrete_ports_;
   std::unique_ptr<dbEditHierarchy> hierarchy_editor_;
+  bool bulk_delete_mode_ = false;
 };
 
 }  // namespace sta

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -2793,6 +2793,15 @@ void dbNetwork::disconnectPinBefore(const Pin* pin)
   //    dbNet to maintain cache consistency between multiple hierarchical nets
   //    corresponding to a single physical net.
 
+  // 0. Bulk-delete mode: caller will invalidate the cache wholesale in
+  //    endBulkDelete(). Skipping per-pin maintenance avoids the
+  //    findRelatedModNets DFS, which dominates eliminate_dead_logic on
+  //    hierarchical designs because every disconnect re-walks the modnet
+  //    hierarchy from scratch.
+  if (bulk_delete_mode_) {
+    return;
+  }
+
   // 1. Load pin case
   if (isLoad(pin)) {
     return;  // No need to update net_drvr_pin_map_ cache.
@@ -5150,6 +5159,19 @@ void dbNetwork::removeDriverFromCache(const Net* net)
     delete entry->second;
     net_drvr_pin_map_.erase(entry);
   }
+}
+
+void dbNetwork::beginBulkDelete()
+{
+  bulk_delete_mode_ = true;
+}
+
+void dbNetwork::endBulkDelete()
+{
+  bulk_delete_mode_ = false;
+  // Per-disconnect cache maintenance was suppressed; the cache may now
+  // reference deleted pins. Drop it; lazy rebuild on next drivers() query.
+  clearNetDrvrPinMap();
 }
 
 void dbNetwork::removeDriverFromCache(const Net* net, const Pin* drvr)

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5394,12 +5394,19 @@ void Resizer::eliminateDeadLogic(bool clean_nets)
   }
 
   int remove_inst_count = 0, remove_net_count = 0;
+  // Suspend per-disconnect driver-cache maintenance during the sweep.
+  // Without this, every dead pin disconnect runs a fresh DFS through the
+  // modnet hierarchy (findRelatedModNets), which dominates runtime on
+  // hierarchical / keep_hierarchy designs and grows with design size.
+  // endBulkDelete() invalidates the cache once, after the sweep.
+  db_network_->beginBulkDelete();
   for (auto inst : network_->leafInstances()) {
     if (!kept_instances.contains(inst)) {
       sta_->deleteInstance((sta::Instance*) inst);
       remove_inst_count++;
     }
   }
+  db_network_->endBulkDelete();
 
   if (clean_nets) {
     auto nets = db_network_->block()->getNets();


### PR DESCRIPTION
## Summary

`Resizer::eliminateDeadLogic` deletes every dead leaf instance one by one via `sta_->deleteInstance`. Each pin disconnect routes through `dbStaCbk` → `dbNetwork::disconnectPinBefore`, which calls `dbNet::findRelatedModNets` (and, for hierarchical pins, `dbModNet::findRelatedNet`). Both are fresh DFS walks through the modnet hierarchy that start over on every call and allocate a fresh `std::set<dbModNet*>` each time.

On a real hierarchical design built with `SYNTH_KEEP_MODULES` (parallel synthesis, many `keep_hierarchy` boundaries) this is the dominant cost in `synth_odb`. Measured on a hierarchical design (asap7) at four sizes:

| size | removed objs | EDL wall | obj/s |
| ---: | -----------: | -------: | ----: |
|    S |       87,982 |    753 s |   117 (system contention) |
|    M |      129,738 |    384 s |   338 |
|    L |      574,352 |  1,675 s |   343 |

`eliminate_dead_logic` is ~88–93% of `synth_odb` wall time across all sizes; ~3 ms per dead object is implausibly slow for a netlist transform.

## Change

Add `beginBulkDelete()` / `endBulkDelete()` on `dbNetwork` that suspend per-disconnect driver-cache maintenance and invalidate the entire `net→drivers` cache once at end of the bulk edit. Wrap the sweep in `eliminateDeadLogic` with these.

The driver cache is invalidated as before — just in O(1) at the end instead of O(related modnets) per pin disconnect.

Public API addition; no caller-visible behaviour change for code that doesn't opt in. Build verified locally (`bazelisk build //src/dbSta:dbSta //src/rsz:rsz`); benchmark numbers from a follow-up run will be posted in a comment when available.

## Test plan
- [ ] Existing rsz `eliminate_dead_logic{1,2}.tcl` unit tests pass unchanged
- [ ] Large hierarchical design `synth_odb` wall time drops materially vs. master
- [ ] No regression in repair_design / repair_timing flows that don't opt into bulk mode