### PR TITLE
Move JS dependencies in the dev-dependency section.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,10 +70,6 @@ bazel_dep(name = "tcmalloc", version = "0.0.0-20250927-12f2552")
 bazel_dep(name = "yaml-cpp", version = "0.9.0")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.8")
 
-# JavaScript / web UI — only used for JS unit tests in src/web/test
-bazel_dep(name = "aspect_rules_js", version = "3.0.2", dev_dependency = True)
-bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True)
-
 # A from source build of QT that allows it to link into OpenROAD.
 # Building like any other bazel project. scripts in the docker folder
 # of this project generate stubs .ifso for things like X11 that will
@@ -97,6 +93,12 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = Tr
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2", dev_dependency = True)
 bazel_dep(name = "rules_verilator", version = "0.1.0", dev_dependency = True)
 bazel_dep(name = "verilator", version = "5.036.bcr.3", dev_dependency = True)
+
+# JavaScript / web UI — only used for JS unit tests in src/web/test
+bazel_dep(name = "aspect_rules_js", version = "3.0.2", dev_dependency = True)
+bazel_dep(name = "rules_nodejs", version = "6.7.3", dev_dependency = True)
+
+# ORFS
 bazel_dep(name = "bazel-orfs", dev_dependency = True)
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
 
@@ -131,7 +133,7 @@ llvm.toolchain(
 use_repo(llvm, "llvm_toolchain")
 # use_repo(llvm, "llvm_toolchain_llvm") # if you depend on specific tools in scripts
 
-# FYI: Comment out on NixOS where you'd like to use the local clang toolchain.
+# FYI: Comment out @llvm_toolchain//:all on NixOS and use the local clang toolchain instead.
 register_toolchains(
     "@llvm_toolchain//:all",
     "@rules_verilator//verilator:verilator_toolchain",


### PR DESCRIPTION
The are already marked dev dependency, just not in the right sectionn according to our file organization.
