### PR TITLE
Work towards more clean build rule include definitions.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -80,7 +80,6 @@ OPENROAD_LIBRARY_DEPS = [
     "//src/dbSta",
     "//src/dbSta:dbNetwork",
     "//src/dbSta:dbReadVerilog",
-    "//src/dbSta:dbSdcNetwork",
     "//src/dbSta:IpChecker",
     "//src/dbSta:SpefWriter",
     "//src/dbSta:ui",

--- a/src/cts/BUILD
+++ b/src/cts/BUILD
@@ -24,6 +24,9 @@ cc_library(
         "src/TreeBuilder.h",
         "src/Util.h",
     ],
+    includes = [
+        "src",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         "//src/sta:opensta_lib",

--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -84,7 +84,7 @@ cc_library(
         "src/dbSdcNetwork.hh",
     ],
     includes = [
-        "include",
+        "src",
     ],
     deps = [
         "//src/sta:opensta_lib",

--- a/src/dbSta/BUILD
+++ b/src/dbSta/BUILD
@@ -86,6 +86,7 @@ cc_library(
     includes = [
         "src",
     ],
+    visibility = ["//visibility:private"],
     deps = [
         "//src/sta:opensta_lib",
         "@spdlog",

--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -91,6 +91,7 @@ cc_library(
         "src/db/tech/frTechObject.h",
         "src/db/tech/frViaDef.h",
         "src/db/tech/frViaRuleGenerate.h",
+        "src/dr/FlexMazeTypes.h",
     ],
     deps = [
         ":base_types",
@@ -146,7 +147,6 @@ cc_library(
         "src/dr/FlexGridGraph.cpp",
         "src/dr/FlexGridGraph.h",
         "src/dr/FlexGridGraph_maze.cpp",
-        "src/dr/FlexMazeTypes.h",
         "src/dr/FlexWavefront.h",
         "src/frDesign.h",
         "src/frProfileTask.h",
@@ -239,7 +239,6 @@ cc_library(
         "src/dr/FlexDR_graphics.cpp",
         "src/dr/FlexDR_graphics.h",
         "src/dr/FlexGridGraph.h",
-        "src/dr/FlexMazeTypes.h",
         "src/dr/FlexWavefront.h",
         "src/frDesign.h",
         "src/frRegionQuery.h",

--- a/src/drt/src/db/infra/KDTree.cpp
+++ b/src/drt/src/db/infra/KDTree.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2024-2025, The OpenROAD Authors
 
-#include "KDTree.hpp"
+#include "db/infra/KDTree.hpp"
 
 #include <algorithm>
 #include <cmath>

--- a/src/dst/test/BUILD
+++ b/src/dst/test/BUILD
@@ -9,7 +9,11 @@ package(features = ["layering_check"])
 
 cc_library(
     name = "test_helpers",
+    testonly = True,
     hdrs = ["cpp/HelperCallBack.h"],
+    includes = [
+        "cpp",
+    ],
     deps = ["//src/dst"],
 )
 
@@ -43,6 +47,7 @@ cc_test(
 # without making it part of `bazel test //src/...`.
 cc_binary(
     name = "dst_distributed_test",
+    testonly = True,
     srcs = [
         "cpp/TestDistributed.cc",
         "cpp/stubs.cpp",

--- a/src/est/BUILD
+++ b/src/est/BUILD
@@ -18,6 +18,9 @@ cc_library(
         "src/OdbCallBack.h",
         "src/SteinerRenderer.h",
     ],
+    includes = [
+        "src",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         "//src/grt:groute",

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "src/heatMapPlacementDensity.cpp",
         "src/heatMapPlacementDensity.h",
         "src/init_descriptors.cpp",
+        "src/insertBufferDialog.h",
         "src/staDescriptors.cpp",
         "src/staDescriptors.h",
         "src/stub.cpp",

--- a/src/odb/src/swig/BUILD
+++ b/src/odb/src/swig/BUILD
@@ -29,6 +29,9 @@ cc_library(
     name = "swig_common",
     srcs = ["common/swig_common.cpp"],
     hdrs = ["common/swig_common.h"],
+    includes = [
+        "common",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/odb/src/defin",


### PR DESCRIPTION
Many libraries have src/foo.h headers, but the places that include it only do the non-prefixed `#include "foo.h"`. So we need to provide the `includes = [ "src" ]` in the library.

This worked accidentally in many places as there was probably already a `-Isrc` lingering around from other libs So even though bazel did not provide the path, the compiler found the header anyway. This works towards making each library and the files they provide self-contained.

In one case, there was a header missing from the list of header; added them.
