### PR TITLE
[dbSta] driver cache: key by canonical flat dbNet (root-cause fix for #10327)

### DIFF
--- a/src/dbSta/include/db_sta/dbNetwork.hh
+++ b/src/dbSta/include/db_sta/dbNetwork.hh
@@ -7,6 +7,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "odb/db.h"
@@ -428,6 +429,11 @@ class dbNetwork : public ConcreteNetwork
   void removeDriverFromCache(const Net* net);
   void removeDriverFromCache(const Net* net, const Pin* drvr);
 
+  // Drop the cached dbModNet -> flat dbNet mapping used by findFlatDbNet.
+  // The mapping depends only on the modnet hierarchy structure; callers in
+  // dbStaCbk invoke this on any event that can change that structure.
+  void invalidateModnetFlatNetCache() { modnet_to_flat_net_cache_.clear(); }
+
   using Network::cell;
   using Network::direction;
   using Network::findCellsMatching;
@@ -484,6 +490,14 @@ class dbNetwork : public ConcreteNetwork
   // hierarchy separators.  Used to recover an in-module name from a
   // path-qualified one stored in ODB.
   static std::string stripParentPrefix(const std::string& name);
+
+  // Memoize dbModNet::findRelatedNet() per modnet. Mapping is hierarchy-only;
+  // dbStaCbk clears this whenever a modnet, modITerm or modBTerm is created,
+  // destroyed, connected, or disconnected (including flat iterm/bterm
+  // disconnects from a modnet). Sentinel nullptr is cached for dangling
+  // modnets to avoid repeating the DFS.
+  mutable std::unordered_map<const odb::dbModNet*, odb::dbNet*>
+      modnet_to_flat_net_cache_;
 
   std::set<const Cell*> hier_modules_;
   std::set<const Port*> concrete_ports_;

--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -703,6 +703,7 @@ void dbNetwork::setBlock(dbBlock* block)
 void dbNetwork::clear()
 {
   ConcreteNetwork::clear();
+  modnet_to_flat_net_cache_.clear();
   db_ = nullptr;
 }
 
@@ -2781,24 +2782,17 @@ void dbNetwork::disconnectPin(Pin* pin)
 
 void dbNetwork::disconnectPinBefore(const Pin* pin)
 {
-  // This function is called before a pin is disconnected to update (invalidate)
-  // the internal driver cache (net_drvr_pin_map_).
-  // 1. If load pin, nop because it is not managed by the driver cache
-  // 2. If hierarchical pin:
-  //    Find the associated physical net (dbNet) and all hierarchical nets
-  //    (odb::dbModNet) and remove the driver information from the cache.
-  // 3. If driver pin:
-  //    Find the dbNet and odb::dbModNet driven by this pin and remove the
-  //    cache. Also, clean up the cache for all dbModNets associated with the
-  //    dbNet to maintain cache consistency between multiple hierarchical nets
-  //    corresponding to a single physical net.
+  // Called before a pin is disconnected to update (invalidate) the inherited
+  // driver cache (net_drvr_pin_map_). The cache is keyed by the canonical
+  // flat dbNet (see drivers(const Net*)), so a single per-flat-net eviction
+  // is sufficient -- no DFS through the modnet hierarchy is needed.
 
-  // 1. Load pin case
+  // 1. Load pin: not tracked by the driver cache.
   if (isLoad(pin)) {
-    return;  // No need to update net_drvr_pin_map_ cache.
+    return;
   }
 
-  // 2. Hierarchical pin case
+  // 2. Hierarchical pin (moditerm).
   if (isHierarchical(pin)) {
     dbITerm* iterm;
     dbBTerm* bterm;
@@ -2807,51 +2801,23 @@ void dbNetwork::disconnectPinBefore(const Pin* pin)
     if (moditerm == nullptr) {
       return;
     }
-
     odb::dbModNet* modnet = moditerm->getModNet();
     if (modnet == nullptr) {
       return;
     }
-
-    dbNet* db_net = modnet->findRelatedNet();
-    if (db_net == nullptr) {
-      return;
-    }
-
-    // Remove flat net from cache
-    removeDriverFromCache(dbToSta(db_net));
-
-    // Remove all related hier nets from cache
-    std::set<odb::dbModNet*> modnet_set;
-    db_net->findRelatedModNets(modnet_set);
-    for (odb::dbModNet* modnet : modnet_set) {
-      removeDriverFromCache(dbToSta(modnet));
+    if (dbNet* db_net = findFlatDbNet(dbToSta(modnet))) {
+      removeDriverFromCache(dbToSta(db_net), pin);
     }
     return;
   }
 
-  // 3. Driver pin case
-
-  // Get all the related dbNet & odb::dbModNet with the pin.
-  // Incrementally update the net-drvr cache.
+  // 3. Driver pin (flat iterm or bterm). The pin's flat dbNet is available
+  //    directly via iterm/bterm; no hierarchy walk required.
   dbNet* db_net;
   odb::dbModNet* mod_net;
   net(pin, db_net, mod_net);
-
   if (db_net) {
-    // A dbNet can be associated with multiple dbModNets.
-    // We need to update the cache for all of them.
-    std::set<odb::dbModNet*> related_mod_nets;
-    db_net->findRelatedModNets(related_mod_nets);
-    for (odb::dbModNet* related_mod_net : related_mod_nets) {
-      removeDriverFromCache(dbToSta(related_mod_net), pin);
-    }
-
     removeDriverFromCache(dbToSta(db_net), pin);
-  }
-
-  if (mod_net) {
-    removeDriverFromCache(dbToSta(mod_net), pin);
   }
 }
 
@@ -4398,6 +4364,13 @@ Net* dbNetwork::findFlatNet(const Net* net) const
 // Given a net that may be hierarchical, find the corresponding flat dbNet.
 // If the net is already a flat net (dbNet), it is returned as is.
 // If the net is a hierarchical net (odb::dbModNet), find the associated dbNet.
+//
+// The dbModNet -> dbNet translation walks the modnet hierarchy via
+// findRelatedNet() and is memoized here: the mapping depends only on
+// hierarchy structure (modnet/modITerm/modBTerm wiring plus the modnet's
+// flat iterm/bterm reach), so dbStaCbk invalidates the cache only on
+// structural changes. Inside hot loops like Resizer::eliminateDeadLogic
+// this turns repeated translations into hash lookups.
 dbNet* dbNetwork::findFlatDbNet(const Net* net) const
 {
   if (!net) {
@@ -4414,9 +4387,12 @@ dbNet* dbNetwork::findFlatDbNet(const Net* net) const
   }
 
   if (db_mod_net) {
-    // If it's a hierarchical net, find the associated dbNet
-    // by traversing the hierarchy.
+    auto entry = modnet_to_flat_net_cache_.find(db_mod_net);
+    if (entry != modnet_to_flat_net_cache_.end()) {
+      return entry->second;
+    }
     db_net = db_mod_net->findRelatedNet();
+    modnet_to_flat_net_cache_.emplace(db_mod_net, db_net);
   }
   return db_net;
 }
@@ -5120,25 +5096,27 @@ PinSet* dbNetwork::drivers(const Net* net)
     return nullptr;
   }
 
-  // Get or create drvrs pin set
-  auto drvrs_entry = net_drvr_pin_map_.find(net);
-  if (drvrs_entry == net_drvr_pin_map_.end()) {
-    std::tie(drvrs_entry, std::ignore)
-        = net_drvr_pin_map_.insert({net, new PinSet(this)});
-  }
-
-  PinSet* drvrs = drvrs_entry->second;
-
-  // Insert the driver pin of the net
+  // Cache by canonical flat dbNet*. Multiple dbModNets can name the same
+  // physical net; keying on the flat net deduplicates entries and removes
+  // the need for findRelatedModNets()-driven eviction in disconnectPinBefore.
   dbNet* db_net = findFlatDbNet(net);
   if (db_net == nullptr) {
-    return drvrs;
+    // Dangling modnet (no flat net reachable). Return a shared empty set
+    // rather than inserting under the modnet pointer.
+    static PinSet empty(this);
+    return &empty;
   }
-
-  dbObject* drvr = db_net->getFirstDriverTerm();
-  Pin* drvr_pin = dbToSta(drvr);
-  if (drvr_pin) {
-    drvrs->insert(drvr_pin);
+  const Net* key = dbToSta(db_net);
+  auto drvrs_entry = net_drvr_pin_map_.find(key);
+  if (drvrs_entry == net_drvr_pin_map_.end()) {
+    std::tie(drvrs_entry, std::ignore)
+        = net_drvr_pin_map_.insert({key, new PinSet(this)});
+  }
+  PinSet* drvrs = drvrs_entry->second;
+  if (dbObject* drvr = db_net->getFirstDriverTerm()) {
+    if (Pin* drvr_pin = dbToSta(drvr)) {
+      drvrs->insert(drvr_pin);
+    }
   }
   return drvrs;
 }

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -1159,16 +1159,23 @@ void dbStaCbk::inDbNetDestroy(odb::dbNet* db_net)
   Net* net = network_->dbToSta(db_net);
   sta_->deleteNetBefore(net);
   network_->deleteNetBefore(net);
+  // The modnet -> flat dbNet memo may hold a pointer to db_net that
+  // would dangle after destruction; drop it.
+  network_->invalidateModnetFlatNetCache();
 }
 
 void dbStaCbk::inDbModNetDestroy(odb::dbModNet* modnet)
 {
   Net* net = network_->dbToSta(modnet);
   network_->deleteNetBefore(net);
+  network_->invalidateModnetFlatNetCache();
 }
 
 void dbStaCbk::inDbITermPostConnect(odb::dbITerm* iterm)
 {
+  if (iterm->getModNet()) {
+    network_->invalidateModnetFlatNetCache();
+  }
   Pin* pin = network_->dbToSta(iterm);
   network_->connectPinAfter(pin);
   sta_->connectPinAfter(pin);
@@ -1176,6 +1183,11 @@ void dbStaCbk::inDbITermPostConnect(odb::dbITerm* iterm)
 
 void dbStaCbk::inDbITermPreDisconnect(odb::dbITerm* iterm)
 {
+  // Disconnecting a flat iterm that also names a modnet can change which
+  // flat dbNet that modnet's hierarchy reaches; drop the memo conservatively.
+  if (iterm->getModNet()) {
+    network_->invalidateModnetFlatNetCache();
+  }
   Pin* pin = network_->dbToSta(iterm);
   sta_->disconnectPinBefore(pin);
   network_->disconnectPinBefore(pin);
@@ -1188,6 +1200,7 @@ void dbStaCbk::inDbITermDestroy(odb::dbITerm* iterm)
 
 void dbStaCbk::inDbModITermPostConnect(odb::dbModITerm* moditerm)
 {
+  network_->invalidateModnetFlatNetCache();
   Pin* pin = network_->dbToSta(moditerm);
   network_->connectPinAfter(pin);
   // Connection is made by odb::dbITerm callbacks. Calling this causes problem.
@@ -1196,6 +1209,7 @@ void dbStaCbk::inDbModITermPostConnect(odb::dbModITerm* moditerm)
 
 void dbStaCbk::inDbModITermPreDisconnect(odb::dbModITerm* moditerm)
 {
+  network_->invalidateModnetFlatNetCache();
   Pin* pin = network_->dbToSta(moditerm);
   // Connection is made by odb::dbITerm callbacks. Calling this causes problem.
   // sta_->disconnectPinBefore(pin);
@@ -1204,11 +1218,15 @@ void dbStaCbk::inDbModITermPreDisconnect(odb::dbModITerm* moditerm)
 
 void dbStaCbk::inDbModITermDestroy(odb::dbModITerm* moditerm)
 {
+  network_->invalidateModnetFlatNetCache();
   sta_->deletePinBefore(network_->dbToSta(moditerm));
 }
 
 void dbStaCbk::inDbBTermPostConnect(odb::dbBTerm* bterm)
 {
+  if (bterm->getModNet()) {
+    network_->invalidateModnetFlatNetCache();
+  }
   Pin* pin = network_->dbToSta(bterm);
   network_->connectPinAfter(pin);
   sta_->connectPinAfter(pin);
@@ -1216,6 +1234,9 @@ void dbStaCbk::inDbBTermPostConnect(odb::dbBTerm* bterm)
 
 void dbStaCbk::inDbBTermPreDisconnect(odb::dbBTerm* bterm)
 {
+  if (bterm->getModNet()) {
+    network_->invalidateModnetFlatNetCache();
+  }
   Pin* pin = network_->dbToSta(bterm);
   sta_->disconnectPinBefore(pin);
   network_->disconnectPinBefore(pin);
@@ -1263,10 +1284,12 @@ void dbStaCbk::inDbModInstDestroy(odb::dbModInst* modinst)
 
 void dbStaCbk::inDbModBTermPostConnect(odb::dbModBTerm* modbterm)
 {
+  network_->invalidateModnetFlatNetCache();
 }
 
 void dbStaCbk::inDbModBTermPreDisconnect(odb::dbModBTerm* modbterm)
 {
+  network_->invalidateModnetFlatNetCache();
 }
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Follow-up to #10327, addressing review feedback from @povik:

> Would Claude be able to find and fix the root cause of needing to do the
> quadratic-shaped work? Without introducing specialized APIs and while
> maintaining correctness of the existing APIs.

This PR fixes the root cause in `dbNetwork::disconnectPinBefore` so plain
`sta::deleteInstance` is fast on hierarchical designs without any new
"begin/end bulk delete" API. Closes #10329.

## Root cause

Each `sta_->deleteInstance(leaf)` triggers, per pin disconnect, the
callback chain `dbStaCbk::inDbITermPreDisconnect` →
`dbNetwork::disconnectPinBefore(pin)` (`src/dbSta/src/dbNetwork.cc:2782`).

For driver pins, `disconnectPinBefore` previously called
`dbNet::findRelatedModNets` (`src/odb/src/db/dbNet.cpp:2486`) — an
unmemoized DFS through the modnet hierarchy graph allocating a fresh
`std::set<dbModNet*>` per call. For hierarchical pins it additionally
called `dbModNet::findRelatedNet`.

Why those DFS calls existed: the inherited driver cache
`net_drvr_pin_map_` (declared in upstream OpenSTA `src/sta/network/Network.cc`
— must NOT be modified per CLAUDE.md rule #1) was keyed by raw `Net*`
pointer, accepting both `dbNet*` (flat) and `dbModNet*` (hier) keys. A
single physical net named by N modnets in the hierarchy had up to N
**redundant** entries with identical content (each populated by
`findFlatDbNet(net)->getFirstDriverTerm()`); evicting them all required
walking the modnet graph.

Per-disconnect work was O(reachable modnets); across an
`eliminate_dead_logic` sweep deleting M leaf instances with ~P pins each,
total cost was O(M × P × reachable_modnets). On the hierarchical asap7
design measured in #10327, this dominated `synth_odb` wall time.

## Change

**Canonicalize the cache key to flat `dbNet*`.**

- `dbNetwork::drivers(const Net* net)` translates any input net to its
  flat `dbNet` via `findFlatDbNet()` and uses that as the cache key.
  Modnet inputs converge on the same canonical entry; the cache holds
  at most one entry per flat net.
- `dbNetwork::disconnectPinBefore` evicts one flat-net entry per pin —
  no DFS through the modnet hierarchy. The `findRelatedModNets` calls
  are removed.
- `findFlatDbNet` memoizes the `dbModNet → dbNet` translation
  (`modnet_to_flat_net_cache_`); `dbStaCbk` invalidates it on the events
  that can change a modnet's flat-net mapping (modnet/modITerm/modBTerm
  create/destroy/connect/disconnect, plus `dbNet` destroy and flat
  iterm/bterm connects/disconnects that touch a modnet).

**No new public API. No specialized "begin/end bulk delete" mode. Every
caller of `sta::deleteInstance` benefits, not just `eliminateDeadLogic`.**

## Why this is safe

- All in-tree callers of `drivers()` consume the returned `PinSet*`
  immediately and do not rely on per-modnet cache identity (verified
  across rsz, dbSta, est, gui, drt, and upstream sta callers).
- The `PinSet` content for a modnet was always equal to the flat net's
  content; sharing one entry produces identical observable behavior.
- `removeDriverFromCache(net, pin)` (the two-arg form) erases a single
  Pin and composes correctly with multi-driver flat nets.
- `dbNet::findRelatedModNets` itself is unchanged — sanity checks, dump,
  GUI, and `dbInsertBuffer` continue to use it.

## Test plan

- [x] Existing `eliminate_dead_logic{1,2}.tcl` regressions pass.
- [x] Full \`bazelisk test //src/...\` (1547 targets) passes.

## Performance

Measured on \`asap7/swerv_wrapper\` (\`OPENROAD_HIERARCHICAL=1\`,
\`SYNTH_KEEP_MODULES\` per design config), one run each:

| Variant | \`eliminate_dead_logic\` wall (ms) | dead insts removed |
| ------- | --------------------------------: | -----------------: |
| \`origin/master\` baseline       | 2941 | 1264 |
| #10327 (\`dbsta-bulk-delete-mode\`) | 2959 | 1264 |
| this PR                          | 2888 | 1264 |

**Honest caveat:** at this scale (1264 dead instances, ~70× smaller than
the S size in #10327's reported benchmark) the modnet DFS is *not* the
dominant cost — even #10327's specialized bulk-delete path doesn't
move the needle here. The savings show up at larger scale (per #10327:
S=87k objs/753s → L=574k objs/1675s on a hierarchical design with many
\`keep_hierarchy\` boundaries). Could a maintainer with access to such a
workload re-time on this branch? The structural change should match
#10327's gains by construction (same DFS calls eliminated) without
adding the specialized API.

## Out of scope

- Upstream OpenSTA \`EdgesThruHierPinIterator\` /
  \`levelize_->relevelizeFrom\` cost in \`Sta::disconnectPinBefore\`
  (issue #10329's "STA cache update" theory, @jhkim-pii Theory B).
  Touching \`src/sta/\` is forbidden per CLAUDE.md rule #1; would need
  a separate upstream conversation.
- ODB schema change to store \`related_flat_net\` directly on
  \`dbModNet\`. Cleaner long-term but not needed for this PR's gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)