### PR TITLE
RSZ: Removed redundant reference in Resizer.

### DIFF
--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5080,10 +5080,7 @@ odb::dbInst* Resizer::insertBufferBeforeLoads(
     return nullptr;
   }
 
-  // Make a non-const copy for dbNet API
-  const std::set<odb::dbObject*>& loads_copy = loads;
-
-  odb::dbInst* buffer_inst = net->insertBufferBeforeLoads(loads_copy,
+  odb::dbInst* buffer_inst = net->insertBufferBeforeLoads(loads,
                                                           buffer_cell,
                                                           loc,
                                                           new_buf_base_name,


### PR DESCRIPTION
## Summary
Removed redundant reference in Resizer.cc.  Suspect that this might have been cruft left by automated refactoring tools?

## Type of Change
- Refactoring

## Impact
N/A