### PR TITLE
Fix lint source discovery without git

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -584,10 +584,14 @@ sh_test(
 sh_binary(
     name = "tidy_tcl",
     srcs = ["//bazel:tcl_tidy.sh"],
-    args = ["$(rootpath //bazel:tclfmt)"],
+    args = [
+        "$(rootpath //bazel:tclfmt)",
+        "$(rootpath @git)",
+    ],
     data = [
         "tclint.toml",
         "//bazel:tclfmt",
+        "@git",
     ],
 )
 
@@ -633,9 +637,13 @@ sh_test(
 sh_binary(
     name = "tidy_bzl",
     srcs = ["//bazel:bzl_tidy.sh"],
-    args = ["$(rootpath @buildifier_prebuilt//:buildifier)"],
+    args = [
+        "$(rootpath @buildifier_prebuilt//:buildifier)",
+        "$(rootpath @git)",
+    ],
     data = [
         "@buildifier_prebuilt//:buildifier",
+        "@git",
     ],
 )
 

--- a/bazel/bzl_tidy.sh
+++ b/bazel/bzl_tidy.sh
@@ -5,12 +5,13 @@
 # Auto-format all Bazel files in-place using buildifier.
 set -euo pipefail
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+GIT="$(realpath "$2")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
 # `-c submodule.recurse=false` keeps git ls-files from descending into
 # submodules (src/sta, third-party/abc, third-party/slang-elab and the
 # fmt sub-submodule nested in it) — we never want to rewrite files
 # owned by another repo. The override is needed because CI sets
 # submodule.recurse=true globally.
-git -c submodule.recurse=false ls-files \
+"${GIT}" -c submodule.recurse=false ls-files \
         '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' -z \
     | xargs -0 "$TOOL" -mode=fix -lint=fix

--- a/bazel/fix_lint.sh
+++ b/bazel/fix_lint.sh
@@ -17,13 +17,12 @@ BZL_LINT_BUILDIFIER="$8"
 GIT="$9"
 
 export BUILD_WORKSPACE_DIRECTORY="${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
-
 # TCL: auto-format then lint
-"${TCL_TIDY_SH}" "${TCLFMT}"
+"${TCL_TIDY_SH}" "${TCLFMT}" "${GIT}"
 "${TCL_LINT_SH}" "${TCLINT}" "${GIT}" || rc=$?
 
 # Bazel: auto-format then lint
-"${BZL_TIDY_SH}" "${BZL_FMT_BUILDIFIER}"
+"${BZL_TIDY_SH}" "${BZL_FMT_BUILDIFIER}" "${GIT}"
 "${BZL_LINT_SH}" "${BZL_LINT_BUILDIFIER}" "${GIT}" || rc=$?
 
 "${GIT}" -C "$BUILD_WORKSPACE_DIRECTORY" status

--- a/bazel/tcl_lint_test.sh
+++ b/bazel/tcl_lint_test.sh
@@ -6,7 +6,7 @@
 
 set -euo pipefail
 
-TOOL="$(realpath "$1")"
+TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 GIT="$(realpath "$2")"
 
 WORKSPACE="$(dirname "$(readlink -f tclint.toml)")"

--- a/bazel/tcl_tidy.sh
+++ b/bazel/tcl_tidy.sh
@@ -5,5 +5,6 @@
 # Auto-format all TCL files in-place.
 set -euo pipefail
 TOOL="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+GIT="$(realpath "$2")"
 cd "${BUILD_WORKSPACE_DIRECTORY:-$PWD}"
-git ls-files '*.tcl' -z | xargs -0 "$TOOL" --in-place
+"${GIT}" ls-files '*.tcl' -z | xargs -0 "$TOOL" --in-place


### PR DESCRIPTION
Fixes #10311.

This removes the `git ls-files` dependency from the Bazel lint/format scripts by adding a shared `bazel/list_sources.sh` helper that uses `find` instead. The helper keeps the old behavior of skipping OpenROAD's upstream-owned submodule directories explicitly (`src/sta`, `third-party/abc`) and also skips VCS/build output directories.

The Tcl and Bazel lint/format entrypoints now use the helper from Bazel runfiles, and `fix_lint.sh` skips its final workspace status report when `git` is unavailable.

Verification performed in a clean WSL-native checkout:

- `diff -u <(git ls-files '*.tcl' '*.sdc' '*.upf' | sort) <(./bazel/list_sources.sh '*.tcl' '*.sdc' '*.upf' | sort)`
- `diff -u <(git ls-files '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' | sort) <(./bazel/list_sources.sh '*.bazel' '*.bzl' '**/BUILD' 'BUILD' '**/WORKSPACE' 'WORKSPACE' | sort)`
- `! ./bazel/list_sources.sh '*' | grep -E '^(src/sta|third-party/abc)/'`
- `npx --yes @bazel/bazelisk@latest test -c opt --test_output=errors //:fmt_bzl_test //:fmt_tcl_test //:lint_bzl_test //:lint_tcl_test`
- Same Bazel test command again with a fake broken `git` first in `PATH`, using `--nocache_test_results --action_env=PATH`