### PR TITLE
grt: add resources and congestion reports for CUGR runs

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -5575,9 +5575,9 @@ void GlobalRouter::reportCongestion()
   const std::vector<int>& resources
       = use_cugr_ ? cugr_->getTotalCapacityPerLayer()
                   : fastroute_->getTotalCapacityPerLayer();
-  const std::vector<int>& demands
-      = use_cugr_ ? cugr_->getTotalUsagePerLayer()
-                  : fastroute_->getTotalUsagePerLayer();
+  const std::vector<int>& demands = use_cugr_
+                                        ? cugr_->getTotalUsagePerLayer()
+                                        : fastroute_->getTotalUsagePerLayer();
   const std::vector<int>& overflows
       = use_cugr_ ? cugr_->getTotalOverflowPerLayer()
                   : fastroute_->getTotalOverflowPerLayer();

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -397,6 +397,9 @@ void GlobalRouter::globalRoute(bool save_guides)
       std::set<odb::dbNet*> clock_nets;
       findClockNets(nets, clock_nets);
       cugr_->init(min_layer, max_layer, clock_nets);
+      if (verbose_) {
+        reportResources();
+      }
       cugr_->route();
       routes_ = cugr_->getRoutes();
       updatePinAccessPoints();
@@ -432,7 +435,7 @@ void GlobalRouter::finishGlobalRouting(bool save_guides)
   updateDbCongestion();
   saveCongestion();
 
-  if (verbose_ && !use_cugr_) {
+  if (verbose_) {
     reportCongestion();
   }
   computeWirelength();
@@ -5513,9 +5516,17 @@ void GlobalRouter::reportLayerSettings(int min_routing_layer,
 
 void GlobalRouter::reportResources()
 {
-  fastroute_->computeCongestionInformation();
-  std::vector<int> original_resources = fastroute_->getOriginalResources();
-  std::vector<int> derated_resources = fastroute_->getTotalCapacityPerLayer();
+  std::vector<int> original_resources;
+  std::vector<int> derated_resources;
+  if (use_cugr_) {
+    cugr_->computeCongestionInformation();
+    original_resources = cugr_->getOriginalResources();
+    derated_resources = cugr_->getTotalCapacityPerLayer();
+  } else {
+    fastroute_->computeCongestionInformation();
+    original_resources = fastroute_->getOriginalResources();
+    derated_resources = fastroute_->getTotalCapacityPerLayer();
+  }
 
   logger_->report("");
   logger_->info(GRT, 53, "Routing resources analysis:");
@@ -5554,14 +5565,26 @@ void GlobalRouter::reportResources()
 
 void GlobalRouter::reportCongestion()
 {
-  fastroute_->computeCongestionInformation();
-  const std::vector<int>& resources = fastroute_->getTotalCapacityPerLayer();
-  const std::vector<int>& demands = fastroute_->getTotalUsagePerLayer();
-  const std::vector<int>& overflows = fastroute_->getTotalOverflowPerLayer();
-  const std::vector<int>& max_h_overflows
-      = fastroute_->getMaxHorizontalOverflows();
-  const std::vector<int>& max_v_overflows
-      = fastroute_->getMaxVerticalOverflows();
+  std::vector<int> resources;
+  std::vector<int> demands;
+  std::vector<int> overflows;
+  std::vector<int> max_h_overflows;
+  std::vector<int> max_v_overflows;
+  if (use_cugr_) {
+    cugr_->computeCongestionInformation();
+    resources = cugr_->getTotalCapacityPerLayer();
+    demands = cugr_->getTotalUsagePerLayer();
+    overflows = cugr_->getTotalOverflowPerLayer();
+    max_h_overflows = cugr_->getMaxHorizontalOverflows();
+    max_v_overflows = cugr_->getMaxVerticalOverflows();
+  } else {
+    fastroute_->computeCongestionInformation();
+    resources = fastroute_->getTotalCapacityPerLayer();
+    demands = fastroute_->getTotalUsagePerLayer();
+    overflows = fastroute_->getTotalOverflowPerLayer();
+    max_h_overflows = fastroute_->getMaxHorizontalOverflows();
+    max_v_overflows = fastroute_->getMaxVerticalOverflows();
+  }
 
   int total_resource = 0;
   int total_demand = 0;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -5516,17 +5516,18 @@ void GlobalRouter::reportLayerSettings(int min_routing_layer,
 
 void GlobalRouter::reportResources()
 {
-  std::vector<int> original_resources;
-  std::vector<int> derated_resources;
   if (use_cugr_) {
     cugr_->computeCongestionInformation();
-    original_resources = cugr_->getOriginalResources();
-    derated_resources = cugr_->getTotalCapacityPerLayer();
   } else {
     fastroute_->computeCongestionInformation();
-    original_resources = fastroute_->getOriginalResources();
-    derated_resources = fastroute_->getTotalCapacityPerLayer();
   }
+
+  const std::vector<int>& original_resources
+      = use_cugr_ ? cugr_->getOriginalResources()
+                  : fastroute_->getOriginalResources();
+  const std::vector<int>& derated_resources
+      = use_cugr_ ? cugr_->getTotalCapacityPerLayer()
+                  : fastroute_->getTotalCapacityPerLayer();
 
   logger_->report("");
   logger_->info(GRT, 53, "Routing resources analysis:");
@@ -5565,26 +5566,27 @@ void GlobalRouter::reportResources()
 
 void GlobalRouter::reportCongestion()
 {
-  std::vector<int> resources;
-  std::vector<int> demands;
-  std::vector<int> overflows;
-  std::vector<int> max_h_overflows;
-  std::vector<int> max_v_overflows;
   if (use_cugr_) {
     cugr_->computeCongestionInformation();
-    resources = cugr_->getTotalCapacityPerLayer();
-    demands = cugr_->getTotalUsagePerLayer();
-    overflows = cugr_->getTotalOverflowPerLayer();
-    max_h_overflows = cugr_->getMaxHorizontalOverflows();
-    max_v_overflows = cugr_->getMaxVerticalOverflows();
   } else {
     fastroute_->computeCongestionInformation();
-    resources = fastroute_->getTotalCapacityPerLayer();
-    demands = fastroute_->getTotalUsagePerLayer();
-    overflows = fastroute_->getTotalOverflowPerLayer();
-    max_h_overflows = fastroute_->getMaxHorizontalOverflows();
-    max_v_overflows = fastroute_->getMaxVerticalOverflows();
   }
+
+  const std::vector<int>& resources
+      = use_cugr_ ? cugr_->getTotalCapacityPerLayer()
+                  : fastroute_->getTotalCapacityPerLayer();
+  const std::vector<int>& demands
+      = use_cugr_ ? cugr_->getTotalUsagePerLayer()
+                  : fastroute_->getTotalUsagePerLayer();
+  const std::vector<int>& overflows
+      = use_cugr_ ? cugr_->getTotalOverflowPerLayer()
+                  : fastroute_->getTotalOverflowPerLayer();
+  const std::vector<int>& max_h_overflows
+      = use_cugr_ ? cugr_->getMaxHorizontalOverflows()
+                  : fastroute_->getMaxHorizontalOverflows();
+  const std::vector<int>& max_v_overflows
+      = use_cugr_ ? cugr_->getMaxVerticalOverflows()
+                  : fastroute_->getMaxVerticalOverflows();
 
   int total_resource = 0;
   int total_demand = 0;

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -95,6 +95,27 @@ class CUGR
   void updateNet(odb::dbNet* net);
   void routeIncremental();
 
+  // Per-layer routing resources (for resource and congestion reporting).
+  // Returns one value per CUGR layer (0-based; layer i corresponds to
+  // routing-level i+1 in OpenDB). The accessors that are not Original
+  // require a prior call to computeCongestionInformation().
+  std::vector<int> getOriginalResources() const;
+  void computeCongestionInformation();
+  std::vector<int> getTotalCapacityPerLayer() const;
+  std::vector<int> getTotalUsagePerLayer() const;
+  std::vector<int> getTotalOverflowPerLayer() const;
+  std::vector<int> getMaxHorizontalOverflows() const;
+  std::vector<int> getMaxVerticalOverflows() const;
+
+  // Total overflow summed across all layers. Mirrors FastRoute's
+  // totalOverflow() so GlobalRouter can decide whether to mark the run
+  // as congested.
+  int totalOverflow();
+  // Creates DRC marker categories ("Global route" → "Horizontal/Vertical
+  // congestion") for every congested 2D tile in the grid graph,
+  // mirroring FastRoute's saveCongestion behaviour.
+  void saveCongestion();
+
  private:
   float calculatePartialSlack();
   float getNetSlack(odb::dbNet* net);

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -95,10 +95,6 @@ class CUGR
   void updateNet(odb::dbNet* net);
   void routeIncremental();
 
-  // Per-layer routing resources (for resource and congestion reporting).
-  // Returns one value per CUGR layer (0-based; layer i corresponds to
-  // routing-level i+1 in OpenDB). The accessors that are not Original
-  // require a prior call to computeCongestionInformation().
   std::vector<int> getOriginalResources() const;
   void computeCongestionInformation();
   std::vector<int> getTotalCapacityPerLayer() const;
@@ -106,15 +102,6 @@ class CUGR
   std::vector<int> getTotalOverflowPerLayer() const;
   std::vector<int> getMaxHorizontalOverflows() const;
   std::vector<int> getMaxVerticalOverflows() const;
-
-  // Total overflow summed across all layers. Mirrors FastRoute's
-  // totalOverflow() so GlobalRouter can decide whether to mark the run
-  // as congested.
-  int totalOverflow();
-  // Creates DRC marker categories ("Global route" → "Horizontal/Vertical
-  // congestion") for every congested 2D tile in the grid graph,
-  // mirroring FastRoute's saveCongestion behaviour.
-  void saveCongestion();
 
  private:
   float calculatePartialSlack();

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -95,13 +95,13 @@ class CUGR
   void updateNet(odb::dbNet* net);
   void routeIncremental();
 
-  std::vector<int> getOriginalResources() const;
+  const std::vector<int>& getOriginalResources() const;
   void computeCongestionInformation();
-  std::vector<int> getTotalCapacityPerLayer() const;
-  std::vector<int> getTotalUsagePerLayer() const;
-  std::vector<int> getTotalOverflowPerLayer() const;
-  std::vector<int> getMaxHorizontalOverflows() const;
-  std::vector<int> getMaxVerticalOverflows() const;
+  const std::vector<int>& getTotalCapacityPerLayer() const;
+  const std::vector<int>& getTotalUsagePerLayer() const;
+  const std::vector<int>& getTotalOverflowPerLayer() const;
+  const std::vector<int>& getMaxHorizontalOverflows() const;
+  const std::vector<int>& getMaxVerticalOverflows() const;
 
  private:
   float calculatePartialSlack();

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -505,11 +505,6 @@ void CUGR::printStatistics() const
   // wire length and via count
   uint64_t wire_length = 0;
   int via_count = 0;
-  std::vector<std::vector<std::vector<int>>> wire_usage;
-  wire_usage.assign(grid_graph_->getNumLayers(),
-                    std::vector<std::vector<int>>(
-                        grid_graph_->getSize(0),
-                        std::vector<int>(grid_graph_->getSize(1), 0)));
   for (const auto& net : gr_nets_) {
     GRTreeNode::preorder(
         net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {
@@ -519,12 +514,8 @@ void CUGR::printStatistics() const
                   = grid_graph_->getLayerDirection(node->getLayerIdx());
               const int l = std::min((*node)[direction], (*child)[direction]);
               const int h = std::max((*node)[direction], (*child)[direction]);
-              const int r = (*node)[1 - direction];
               for (int c = l; c < h; c++) {
                 wire_length += grid_graph_->getEdgeLength(direction, c);
-                const int x = direction == MetalLayer::H ? c : r;
-                const int y = direction == MetalLayer::H ? r : c;
-                wire_usage[node->getLayerIdx()][x][y] += 1;
               }
             } else {
               via_count += abs(node->getLayerIdx() - child->getLayerIdx());
@@ -533,9 +524,11 @@ void CUGR::printStatistics() const
         });
   }
 
-  // resource
-  CapacityT overflow = 0;
-
+  // Overflow is computed from edge.demand (which includes via-stub
+  // demand). This is the metric CUGR's own checkOverflow,
+  // updateOverflowNets, and extractCongestionView use, and it agrees
+  // with Min resource below and with the GRT-0096 table.
+  CapacityT total_overflow = 0;
   CapacityT min_resource = std::numeric_limits<CapacityT>::max();
   GRPoint bottleneck(-1, -1, -1);
   for (int layer_index = constants_.min_routing_layer;
@@ -544,17 +537,15 @@ void CUGR::printStatistics() const
     const int direction = grid_graph_->getLayerDirection(layer_index);
     for (int x = 0; x < grid_graph_->getSize(0) - 1 + direction; x++) {
       for (int y = 0; y < grid_graph_->getSize(1) - direction; y++) {
-        const CapacityT resource
-            = grid_graph_->getEdge(layer_index, x, y).getResource();
+        const auto& edge = grid_graph_->getEdge(layer_index, x, y);
+        const CapacityT resource = edge.getResource();
         if (resource < min_resource) {
           min_resource = resource;
           bottleneck = {layer_index, x, y};
         }
-        const CapacityT usage = wire_usage[layer_index][x][y];
-        const CapacityT capacity
-            = std::max(grid_graph_->getEdge(layer_index, x, y).capacity, 0.0);
-        if (usage > 0.0 && usage > capacity) {
-          overflow += usage - capacity;
+        const CapacityT capacity = std::max(edge.capacity, 0.0);
+        if (edge.demand > capacity) {
+          total_overflow += edge.demand - capacity;
         }
       }
     }
@@ -563,7 +554,7 @@ void CUGR::printStatistics() const
   logger_->report("Wire length:           {}",
                   wire_length / grid_graph_->getM2Pitch());
   logger_->report("Total via count:       {}", via_count);
-  logger_->report("Total wire overflow:   {}", (int) overflow);
+  logger_->report("Total overflow:        {}", (int) total_overflow);
   logger_->report("Min resource:          {}", min_resource);
   logger_->report("Bottleneck:            {}", bottleneck);
 }

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -660,59 +660,41 @@ void CUGR::updateNet(odb::dbNet* db_net)
   }
 }
 
-std::vector<int> CUGR::getOriginalResources() const
+// The accessors below are only called after init() has constructed
+// grid_graph_, so we rely on the GridGraph's cached vectors directly
+// without extra null-checks (matching the rest of the file).
+const std::vector<int>& CUGR::getOriginalResources() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getOriginalResources();
 }
 
 void CUGR::computeCongestionInformation()
 {
-  if (!grid_graph_) {
-    return;
-  }
   grid_graph_->computeCongestionInformation();
 }
 
-std::vector<int> CUGR::getTotalCapacityPerLayer() const
+const std::vector<int>& CUGR::getTotalCapacityPerLayer() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getTotalCapacityPerLayer();
 }
 
-std::vector<int> CUGR::getTotalUsagePerLayer() const
+const std::vector<int>& CUGR::getTotalUsagePerLayer() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getTotalUsagePerLayer();
 }
 
-std::vector<int> CUGR::getTotalOverflowPerLayer() const
+const std::vector<int>& CUGR::getTotalOverflowPerLayer() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getTotalOverflowPerLayer();
 }
 
-std::vector<int> CUGR::getMaxHorizontalOverflows() const
+const std::vector<int>& CUGR::getMaxHorizontalOverflows() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getMaxHorizontalOverflows();
 }
 
-std::vector<int> CUGR::getMaxVerticalOverflows() const
+const std::vector<int>& CUGR::getMaxVerticalOverflows() const
 {
-  if (!grid_graph_) {
-    return {};
-  }
   return grid_graph_->getMaxVerticalOverflows();
 }
 

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -526,8 +526,7 @@ void CUGR::printStatistics() const
 
   // Overflow is computed from edge.demand (which includes via-stub
   // demand). This is the metric CUGR's own checkOverflow,
-  // updateOverflowNets, and extractCongestionView use, and it agrees
-  // with Min resource below and with the GRT-0096 table.
+  // updateOverflowNets, and extractCongestionView use
   CapacityT total_overflow = 0;
   CapacityT min_resource = std::numeric_limits<CapacityT>::max();
   GRPoint bottleneck(-1, -1, -1);
@@ -717,18 +716,6 @@ std::vector<int> CUGR::getMaxVerticalOverflows() const
   return grid_graph_->getMaxVerticalOverflows();
 }
 
-int CUGR::totalOverflow()
-{
-  if (!grid_graph_) {
-    return 0;
-  }
-  grid_graph_->computeCongestionInformation();
-  int total = 0;
-  for (int layer_overflow : grid_graph_->getTotalOverflowPerLayer()) {
-    total += layer_overflow;
-  }
-  return total;
-}
 void CUGR::routeIncremental()
 {
   if (nets_to_route_.empty()) {

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -670,6 +670,74 @@ void CUGR::updateNet(odb::dbNet* db_net)
   }
 }
 
+std::vector<int> CUGR::getOriginalResources() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getOriginalResources();
+}
+
+void CUGR::computeCongestionInformation()
+{
+  if (!grid_graph_) {
+    return;
+  }
+  grid_graph_->computeCongestionInformation();
+}
+
+std::vector<int> CUGR::getTotalCapacityPerLayer() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getTotalCapacityPerLayer();
+}
+
+std::vector<int> CUGR::getTotalUsagePerLayer() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getTotalUsagePerLayer();
+}
+
+std::vector<int> CUGR::getTotalOverflowPerLayer() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getTotalOverflowPerLayer();
+}
+
+std::vector<int> CUGR::getMaxHorizontalOverflows() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getMaxHorizontalOverflows();
+}
+
+std::vector<int> CUGR::getMaxVerticalOverflows() const
+{
+  if (!grid_graph_) {
+    return {};
+  }
+  return grid_graph_->getMaxVerticalOverflows();
+}
+
+int CUGR::totalOverflow()
+{
+  if (!grid_graph_) {
+    return 0;
+  }
+  grid_graph_->computeCongestionInformation();
+  int total = 0;
+  for (int layer_overflow : grid_graph_->getTotalOverflowPerLayer()) {
+    total += layer_overflow;
+  }
+  return total;
+}
 void CUGR::routeIncremental()
 {
   if (nets_to_route_.empty()) {

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -72,7 +72,7 @@ GridGraph::GridGraph(const Design* design,
   }
 
   // Init grid graph edges
-  std::vector<std::vector<int>> grid_tracks(num_layers_);
+  grid_tracks_.assign(num_layers_, std::vector<int>());
   graph_edges_.assign(num_layers_,
                       std::vector<std::vector<GraphEdge>>(
                           x_size_, std::vector<GraphEdge>(y_size_)));
@@ -81,34 +81,34 @@ GridGraph::GridGraph(const Design* design,
     const int direction = layer.getDirection();
 
     const int n_grids = gridlines_[1 - direction].size() - 1;
-    grid_tracks[layer_index].resize(n_grids);
+    grid_tracks_[layer_index].assign(n_grids, 0);
     for (size_t grid_index = 0; grid_index < n_grids; grid_index++) {
       IntervalT loc_range(gridlines_[1 - direction][grid_index],
                           gridlines_[1 - direction][grid_index + 1]);
       auto track_range = layer.rangeSearchTracks(loc_range);
       if (track_range.isValid()) {
-        grid_tracks[layer_index][grid_index] = track_range.range() + 1;
+        grid_tracks_[layer_index][grid_index] = track_range.range() + 1;
         // exclude the track on the higher gridline
         if (grid_index != n_grids - 1
             && layer.getTrackLocation(track_range.high()) == loc_range.high()) {
-          grid_tracks[layer_index][grid_index]--;
+          grid_tracks_[layer_index][grid_index]--;
         }
       } else {
-        grid_tracks[layer_index][grid_index] = 0;
+        grid_tracks_[layer_index][grid_index] = 0;
       }
     }
 
     // Initialize edges' capacity to the number of tracks
     if (direction == MetalLayer::V) {
       for (size_t x = 0; x < x_size_; x++) {
-        const CapacityT n_tracks = grid_tracks[layer_index][x];
+        const CapacityT n_tracks = grid_tracks_[layer_index][x];
         for (size_t y = 0; y + 1 < y_size_; y++) {
           graph_edges_[layer_index][x][y].capacity = n_tracks;
         }
       }
     } else {
       for (size_t y = 0; y < y_size_; y++) {
-        const CapacityT n_tracks = grid_tracks[layer_index][y];
+        const CapacityT n_tracks = grid_tracks_[layer_index][y];
         for (size_t x = 0; x + 1 < x_size_; x++) {
           graph_edges_[layer_index][x][y].capacity = n_tracks;
         }
@@ -161,10 +161,10 @@ GridGraph::GridGraph(const Design* design,
     IntervalT grid_track_range;
     for (int grid_index = 0; grid_index < n_grids; grid_index++) {
       if (grid_index == 0) {
-        grid_track_range.set(0, grid_tracks[layer_index][grid_index] - 1);
+        grid_track_range.set(0, grid_tracks_[layer_index][grid_index] - 1);
       } else {
         grid_track_range.setLow(grid_track_range.high() + 1);
-        grid_track_range.addToHigh(grid_tracks[layer_index][grid_index]);
+        grid_track_range.addToHigh(grid_tracks_[layer_index][grid_index]);
       }
       if (!grid_track_range.isValid()) {
         continue;
@@ -234,6 +234,30 @@ GridGraph::GridGraph(const Design* design,
     }
   }
 
+  // Snapshot per-layer capacity sums BEFORE applying user-defined
+  // adjustments. This mirrors FastRoute's real_cap, which is captured at
+  // the equivalent point in its initialization flow.
+  original_resources_per_layer_.assign(num_layers_, 0);
+  for (int layer_index = 0; layer_index < num_layers_; layer_index++) {
+    const int direction = layer_directions_[layer_index];
+    CapacityT sum = 0;
+    if (direction == MetalLayer::H) {
+      for (int y = 0; y < y_size_; y++) {
+        for (int x = 0; x + 1 < x_size_; x++) {
+          sum += graph_edges_[layer_index][x][y].capacity;
+        }
+      }
+    } else {
+      for (int x = 0; x < x_size_; x++) {
+        for (int y = 0; y + 1 < y_size_; y++) {
+          sum += graph_edges_[layer_index][x][y].capacity;
+        }
+      }
+    }
+    original_resources_per_layer_[layer_index]
+        = static_cast<int>(std::round(sum));
+  }
+
   // Apply user-defined capacity adjustment
   for (int layer_index = 0; layer_index < num_layers_; layer_index++) {
     const float adjustment = design->getLayer(layer_index).getAdjustment();
@@ -243,6 +267,59 @@ GridGraph::GridGraph(const Design* design,
           graph_edges_[layer_index][x][y].capacity *= (1.0 - adjustment);
         }
       }
+    }
+  }
+}
+
+void GridGraph::computeCongestionInformation()
+{
+  cap_per_layer_.assign(num_layers_, 0);
+  usage_per_layer_.assign(num_layers_, 0);
+  overflow_per_layer_.assign(num_layers_, 0);
+  max_h_overflow_.assign(num_layers_, 0);
+  max_v_overflow_.assign(num_layers_, 0);
+
+  for (int layer_index = 0; layer_index < num_layers_; layer_index++) {
+    const int direction = layer_directions_[layer_index];
+    CapacityT cap_sum = 0;
+    CapacityT usage_sum = 0;
+    CapacityT overflow_sum = 0;
+    CapacityT max_overflow = 0;
+
+    auto accumulate = [&](int x, int y) {
+      const auto& edge = graph_edges_[layer_index][x][y];
+      cap_sum += edge.capacity;
+      usage_sum += edge.demand;
+      const CapacityT overflow = edge.demand - edge.capacity;
+      if (overflow > 0) {
+        overflow_sum += overflow;
+        max_overflow = std::max(max_overflow, overflow);
+      }
+    };
+
+    if (direction == MetalLayer::H) {
+      for (int y = 0; y < y_size_; y++) {
+        for (int x = 0; x + 1 < x_size_; x++) {
+          accumulate(x, y);
+        }
+      }
+    } else {
+      for (int x = 0; x < x_size_; x++) {
+        for (int y = 0; y + 1 < y_size_; y++) {
+          accumulate(x, y);
+        }
+      }
+    }
+
+    cap_per_layer_[layer_index] = static_cast<int>(std::round(cap_sum));
+    usage_per_layer_[layer_index] = static_cast<int>(std::round(usage_sum));
+    overflow_per_layer_[layer_index]
+        = static_cast<int>(std::round(overflow_sum));
+    const int max_overflow_int = static_cast<int>(std::round(max_overflow));
+    if (direction == MetalLayer::H) {
+      max_h_overflow_[layer_index] = max_overflow_int;
+    } else {
+      max_v_overflow_[layer_index] = max_overflow_int;
     }
   }
 }

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -234,9 +234,6 @@ GridGraph::GridGraph(const Design* design,
     }
   }
 
-  // Snapshot per-layer capacity sums BEFORE applying user-defined
-  // adjustments. This mirrors FastRoute's real_cap, which is captured at
-  // the equivalent point in its initialization flow.
   original_resources_per_layer_.assign(num_layers_, 0);
   for (int layer_index = 0; layer_index < num_layers_; layer_index++) {
     const int direction = layer_directions_[layer_index];

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -112,7 +112,7 @@ class GridGraph
     return grid_tracks_[layer_index][perp];
   }
 
-  std::vector<int> getOriginalResources() const
+  const std::vector<int>& getOriginalResources() const
   {
     return original_resources_per_layer_;
   }

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -105,6 +105,46 @@ class GridGraph
     return graph_edges_[layer_index][x][y];
   }
 
+  // Initial (pre-blockage, pre-adjustment) per-edge capacity in tracks.
+  // For horizontal layers indexed by row y; for vertical by column x.
+  CapacityT getInitialEdgeCapacity(int layer_index, int x, int y) const
+  {
+    const int direction = layer_directions_[layer_index];
+    const int perp = (direction == MetalLayer::H) ? y : x;
+    return grid_tracks_[layer_index][perp];
+  }
+
+  // Per-layer routing-resource accessors. "Original" is the capacity
+  // before user-defined adjustments (but after blockages). The remaining
+  // accessors return values populated by computeCongestionInformation()
+  // and require a prior call to that method. Indexed by routing-layer-index
+  // (CUGR's 0-based layer index, matching routing_level - 1).
+  std::vector<int> getOriginalResources() const
+  {
+    return original_resources_per_layer_;
+  }
+  void computeCongestionInformation();
+  const std::vector<int>& getTotalCapacityPerLayer() const
+  {
+    return cap_per_layer_;
+  }
+  const std::vector<int>& getTotalUsagePerLayer() const
+  {
+    return usage_per_layer_;
+  }
+  const std::vector<int>& getTotalOverflowPerLayer() const
+  {
+    return overflow_per_layer_;
+  }
+  const std::vector<int>& getMaxHorizontalOverflows() const
+  {
+    return max_h_overflow_;
+  }
+  const std::vector<int>& getMaxVerticalOverflows() const
+  {
+    return max_v_overflow_;
+  }
+
   // Costs
   int getEdgeLength(int direction, int edge_index) const;
   CostT getWireCost(int layer_index, PointT u, PointT v) const;
@@ -202,6 +242,21 @@ class GridGraph
   // gridEdges[l][x][y] stores the edge {(l, x, y), (l, x+1, y)} or {(l, x, y),
   // (l, x, y+1)} depending on the routing direction of the layer
   std::vector<std::vector<std::vector<GraphEdge>>> graph_edges_;
+  // Per-layer initial track count keyed by perpendicular index
+  // (row for H layers, column for V layers). Used to recover the
+  // pre-blockage / pre-adjustment capacity of each edge.
+  std::vector<std::vector<int>> grid_tracks_;
+  // Per-layer capacity sums captured before user-defined adjustments are
+  // applied (i.e. only blockage reductions are accounted for). Used by
+  // resource reporting so that the report can show the reduction from
+  // user adjustments analogous to FastRoute's real_cap vs cap.
+  std::vector<int> original_resources_per_layer_;
+  // Per-layer caches populated by computeCongestionInformation().
+  std::vector<int> cap_per_layer_;
+  std::vector<int> usage_per_layer_;
+  std::vector<int> overflow_per_layer_;
+  std::vector<int> max_h_overflow_;
+  std::vector<int> max_v_overflow_;
   const Constants constants_;
 };
 

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -105,8 +105,6 @@ class GridGraph
     return graph_edges_[layer_index][x][y];
   }
 
-  // Initial (pre-blockage, pre-adjustment) per-edge capacity in tracks.
-  // For horizontal layers indexed by row y; for vertical by column x.
   CapacityT getInitialEdgeCapacity(int layer_index, int x, int y) const
   {
     const int direction = layer_directions_[layer_index];
@@ -114,11 +112,6 @@ class GridGraph
     return grid_tracks_[layer_index][perp];
   }
 
-  // Per-layer routing-resource accessors. "Original" is the capacity
-  // before user-defined adjustments (but after blockages). The remaining
-  // accessors return values populated by computeCongestionInformation()
-  // and require a prior call to that method. Indexed by routing-layer-index
-  // (CUGR's 0-based layer index, matching routing_level - 1).
   std::vector<int> getOriginalResources() const
   {
     return original_resources_per_layer_;

--- a/src/grt/test/clock_route_cugr.ok
+++ b/src/grt/test/clock_route_cugr.ok
@@ -23,14 +23,40 @@ Design statistics
 Nets:                15
 Special nets:        0
 Routing layers:      6
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+li1        Vertical        21571         21571          0.00%
+met1       Horizontal      27555         27555          0.00%
+met2       Vertical        21571         21571          0.00%
+met3       Horizontal      14023         14023          0.00%
+met4       Vertical        10804         10804          0.00%
+met5       Horizontal       3108          3108          0.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           2918
 Total via count:       203
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          2
 Bottleneck:            (5, 0, 0)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+li1              21571             3            0.01%             0 /  0 /  0
+met1             27555            17            0.06%             0 /  0 /  0
+met2             21571            70            0.32%             0 /  0 /  0
+met3             14023            90            0.64%             0 /  0 /  0
+met4             10804            13            0.12%             0 /  0 /  0
+met5              3108             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            98632           193            0.20%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15
 No differences found.

--- a/src/grt/test/clock_route_cugr2.ok
+++ b/src/grt/test/clock_route_cugr2.ok
@@ -23,14 +23,40 @@ Design statistics
 Nets:                15
 Special nets:        0
 Routing layers:      6
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+li1        Vertical        21571         21571          0.00%
+met1       Horizontal      27555          5511          80.00%
+met2       Vertical        21571          6471          70.00%
+met3       Horizontal      14023          7012          50.00%
+met4       Vertical        10804          5402          50.00%
+met5       Horizontal       3108          1554          50.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           2918
 Total via count:       207
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          1
 Bottleneck:            (5, 0, 0)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+li1              21571             3            0.01%             0 /  0 /  0
+met1              5511            17            0.31%             0 /  0 /  0
+met2              6471            67            1.04%             0 /  0 /  0
+met3              7012            91            1.30%             0 /  0 /  0
+met4              5402            16            0.30%             0 /  0 /  0
+met5              1554             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            47521           194            0.41%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15
 No differences found.

--- a/src/grt/test/critical_nets_percentage_cugr.ok
+++ b/src/grt/test/critical_nets_percentage_cugr.ok
@@ -24,6 +24,19 @@ Design statistics
 Nets:                348
 Special nets:        0
 Routing layers:      6
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+li1        Vertical        25000         25000          0.00%
+met1       Horizontal      30634          6127          80.00%
+met2       Vertical        25000          5000          80.00%
+met3       Horizontal      16240          3248          80.00%
+met4       Vertical        12480          2496          80.00%
+met5       Horizontal       3600           720          80.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 293.
 Stage 2: Pattern routing with detours.
@@ -33,9 +46,22 @@ Nets with overflow: 296.
 Routing statistics
 Wire length:           45938
 Total via count:       2656
-Total wire overflow:   244
+Total overflow:        400
 Min resource:          -3.5555556747648467
 Bottleneck:            (3, 14, 15)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+li1              25000            39            0.16%             0 /  0 /  0
+met1              6127           222            3.62%             0 /  0 /  0
+met2              5000          1190           23.80%             0 /  3 / 88
+met3              3248          1420           43.72%             4 /  0 / 313
+met4              2496            32            1.28%             0 /  0 /  0
+met5               720             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            42591          2903            6.82%             4 /  3 / 401
+
 [INFO GRT-0018] Total wirelength: 23868 um
 [INFO GRT-0014] Routed nets: 348
 No differences found.

--- a/src/grt/test/cugr_adjustment1.ok
+++ b/src/grt/test/cugr_adjustment1.ok
@@ -27,14 +27,48 @@ Design statistics
 Nets:                579
 Special nets:        0
 Routing layers:      10
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal      24480          4896          80.00%
+metal2     Vertical        17918          5375          70.00%
+metal3     Horizontal      24480         12240          50.00%
+metal4     Vertical        12172          6086          50.00%
+metal5     Horizontal      12240          6120          50.00%
+metal6     Vertical        12172          6086          50.00%
+metal7     Horizontal       4284          2142          50.00%
+metal8     Vertical         4284          2142          50.00%
+metal9     Horizontal       2142          1071          50.00%
+metal10    Vertical         2142          1071          50.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           36727
 Total via count:       4413
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          0.5
 Bottleneck:            (8, 0, 4)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1            4896             0            0.00%             0 /  0 /  0
+metal2            5375             0            0.00%             0 /  0 /  0
+metal3           12240          1263           10.32%             0 /  0 /  0
+metal4            6086           692           11.37%             0 /  0 /  0
+metal5            6120             0            0.00%             0 /  0 /  0
+metal6            6086           490            8.05%             0 /  0 /  0
+metal7            2142             0            0.00%             0 /  0 /  0
+metal8            2142             0            0.00%             0 /  0 /  0
+metal9            1071             0            0.00%             0 /  0 /  0
+metal10           1071             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            47229          2445            5.18%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563
 No differences found.

--- a/src/grt/test/cugr_adjustment2.ok
+++ b/src/grt/test/cugr_adjustment2.ok
@@ -27,6 +27,23 @@ Design statistics
 Nets:                579
 Special nets:        0
 Routing layers:      10
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal      24480          9792          60.00%
+metal2     Vertical        17918          7167          60.00%
+metal3     Horizontal      24480          9792          60.00%
+metal4     Vertical        12172          4869          60.00%
+metal5     Horizontal      12240          4896          60.00%
+metal6     Vertical        12172          4869          60.00%
+metal7     Horizontal       4284          1714          59.99%
+metal8     Vertical         4284          1714          59.99%
+metal9     Horizontal       2142           857          59.99%
+metal10    Vertical         2142           857          59.99%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 4.
 Stage 2: Pattern routing with detours.
@@ -34,9 +51,26 @@ Nets with overflow: 0.
 Routing statistics
 Wire length:           36817
 Total via count:       4420
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          0.3999999761581421
 Bottleneck:            (8, 0, 4)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1            9792             0            0.00%             0 /  0 /  0
+metal2            7167             0            0.00%             0 /  0 /  0
+metal3            9792          1247           12.73%             0 /  0 /  0
+metal4            4869           711           14.60%             0 /  0 /  0
+metal5            4896            22            0.45%             0 /  0 /  0
+metal6            4869           471            9.67%             0 /  0 /  0
+metal7            1714             0            0.00%             0 /  0 /  0
+metal8            1714             0            0.00%             0 /  0 /  0
+metal9             857             0            0.00%             0 /  0 /  0
+metal10            857             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            46527          2451            5.27%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 10374 um
 [INFO GRT-0014] Routed nets: 563
 No differences found.

--- a/src/grt/test/cugr_adjustment3.ok
+++ b/src/grt/test/cugr_adjustment3.ok
@@ -27,6 +27,23 @@ Design statistics
 Nets:                579
 Special nets:        0
 Routing layers:      10
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal      24480          2448          90.00%
+metal2     Vertical        17918          1792          90.00%
+metal3     Horizontal      24480          2448          90.00%
+metal4     Vertical        12172          1217          90.00%
+metal5     Horizontal      12240          1224          90.00%
+metal6     Vertical        12172          1217          90.00%
+metal7     Horizontal       4284           428          90.01%
+metal8     Vertical         4284           428          90.01%
+metal9     Horizontal       2142           214          90.01%
+metal10    Vertical         2142           214          90.01%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 332.
 Stage 2: Pattern routing with detours.
@@ -36,9 +53,26 @@ Nets with overflow: 317.
 Routing statistics
 Wire length:           37852
 Total via count:       4648
-Total wire overflow:   481
+Total overflow:        481
 Min resource:          -2.999999523162842
 Bottleneck:            (2, 14, 8)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1            2448             0            0.00%             0 /  0 /  0
+metal2            1792             0            0.00%             0 /  0 /  0
+metal3            2448          1194           48.77%             3 /  0 / 193
+metal4            1217           720           59.16%             0 /  2 / 162
+metal5            1224            71            5.80%             0 /  0 /  0
+metal6            1217           535           43.96%             0 /  2 / 126
+metal7             428             0            0.00%             0 /  0 /  0
+metal8             428             0            0.00%             0 /  0 /  0
+metal9             214             0            0.00%             0 /  0 /  0
+metal10            214             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            11630          2520           21.67%             3 /  4 / 481
+
 [INFO GRT-0018] Total wirelength: 10716 um
 [INFO GRT-0014] Routed nets: 563
 No differences found.

--- a/src/grt/test/est_rc_cugr1.ok
+++ b/src/grt/test/est_rc_cugr1.ok
@@ -26,14 +26,48 @@ Design statistics
 Nets:                579
 Special nets:        0
 Routing layers:      10
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal      24480         24480          0.00%
+metal2     Vertical        17918         17918          0.00%
+metal3     Horizontal      24480         24480          0.00%
+metal4     Vertical        12172         12172          0.00%
+metal5     Horizontal      12240         12240          0.00%
+metal6     Vertical        12172         12172          0.00%
+metal7     Horizontal       4284          4284          0.00%
+metal8     Vertical         4284          4284          0.00%
+metal9     Horizontal       2142          2142          0.00%
+metal10    Vertical         2142          2142          0.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           36727
 Total via count:       3748
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          1
 Bottleneck:            (8, 0, 4)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1           24480             0            0.00%             0 /  0 /  0
+metal2           17918             0            0.00%             0 /  0 /  0
+metal3           24480          1250            5.11%             0 /  0 /  0
+metal4           12172          1046            8.59%             0 /  0 /  0
+metal5           12240            13            0.11%             0 /  0 /  0
+metal6           12172           136            1.12%             0 /  0 /  0
+metal7            4284             0            0.00%             0 /  0 /  0
+metal8            4284             0            0.00%             0 /  0 /  0
+metal9            2142             0            0.00%             0 /  0 /  0
+metal10           2142             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total           116314          2445            2.10%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563
 Net clk

--- a/src/grt/test/gcd_cugr.ok
+++ b/src/grt/test/gcd_cugr.ok
@@ -27,14 +27,48 @@ Design statistics
 Nets:                579
 Special nets:        0
 Routing layers:      10
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal      24480         24480          0.00%
+metal2     Vertical        17918         17918          0.00%
+metal3     Horizontal      24480         24480          0.00%
+metal4     Vertical        12172         12172          0.00%
+metal5     Horizontal      12240         12240          0.00%
+metal6     Vertical        12172         12172          0.00%
+metal7     Horizontal       4284          4284          0.00%
+metal8     Vertical         4284          4284          0.00%
+metal9     Horizontal       2142          2142          0.00%
+metal10    Vertical         2142          2142          0.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           36727
 Total via count:       3748
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          1
 Bottleneck:            (8, 0, 4)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1           24480             0            0.00%             0 /  0 /  0
+metal2           17918             0            0.00%             0 /  0 /  0
+metal3           24480          1250            5.11%             0 /  0 /  0
+metal4           12172          1046            8.59%             0 /  0 /  0
+metal5           12240            13            0.11%             0 /  0 /  0
+metal6           12172           136            1.12%             0 /  0 /  0
+metal7            4284             0            0.00%             0 /  0 /  0
+metal8            4284             0            0.00%             0 /  0 /  0
+metal9            2142             0            0.00%             0 /  0 /  0
+metal10           2142             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total           116314          2445            2.10%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563
 No differences found.

--- a/src/grt/test/incremental_update_net.ok
+++ b/src/grt/test/incremental_update_net.ok
@@ -26,14 +26,44 @@ Design statistics
 Nets:                5
 Special nets:        0
 Routing layers:      8
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+metal1     Horizontal       5712          5712          0.00%
+metal2     Vertical         4208           842          79.99%
+metal3     Horizontal       5712          1714          69.99%
+metal4     Vertical         2848          1424          50.00%
+metal5     Horizontal       2864          1432          50.00%
+metal6     Vertical         2848          1424          50.00%
+metal7     Horizontal        992           496          50.00%
+metal8     Vertical          992           496          50.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           709
 Total via count:       28
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          1.5
 Bottleneck:            (6, 0, 0)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+metal1            5712             0            0.00%             0 /  0 /  0
+metal2             842             0            0.00%             0 /  0 /  0
+metal3            1714            27            1.58%             0 /  0 /  0
+metal4            1424            12            0.84%             0 /  0 /  0
+metal5            1432             0            0.00%             0 /  0 /  0
+metal6            1424             8            0.56%             0 /  0 /  0
+metal7             496             0            0.00%             0 /  0 /  0
+metal8             496             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            13540            47            0.35%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 319 um
 [INFO GRT-0014] Routed nets: 5
 Summary 1 / 1 (100% pass)

--- a/src/grt/test/pin_access1_cugr.ok
+++ b/src/grt/test/pin_access1_cugr.ok
@@ -56,14 +56,40 @@ Design statistics
 Nets:                15
 Special nets:        0
 Routing layers:      6
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+li1        Vertical        21571         21571          0.00%
+met1       Horizontal      27555          5511          80.00%
+met2       Vertical        21571          6471          70.00%
+met3       Horizontal      14023          7012          50.00%
+met4       Vertical        10804          5402          50.00%
+met5       Horizontal       3108          1554          50.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 0.
 Routing statistics
 Wire length:           2841
 Total via count:       193
-Total wire overflow:   0
+Total overflow:        0
 Min resource:          1
 Bottleneck:            (5, 0, 0)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+li1              21571             3            0.01%             0 /  0 /  0
+met1              5511            16            0.29%             0 /  0 /  0
+met2              6471            72            1.11%             0 /  0 /  0
+met3              7012            81            1.16%             0 /  0 /  0
+met4              5402            15            0.28%             0 /  0 /  0
+met5              1554             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            47521           187            0.39%             0 /  0 /  0
+
 [INFO GRT-0018] Total wirelength: 1584 um
 [INFO GRT-0014] Routed nets: 15
 No differences found.

--- a/src/grt/test/pin_access2_cugr.ok
+++ b/src/grt/test/pin_access2_cugr.ok
@@ -57,6 +57,19 @@ Design statistics
 Nets:                411
 Special nets:        2
 Routing layers:      6
+
+[INFO GRT-0053] Routing resources analysis:
+          Routing      Original      Derated      Resource
+Layer     Direction    Resources     Resources    Reduction (%)
+---------------------------------------------------------------
+li1        Vertical        25000         25000          0.00%
+met1       Horizontal      25777          5155          80.00%
+met2       Vertical        24693          7408          70.00%
+met3       Horizontal      15984          7992          50.00%
+met4       Vertical        11697          5849          50.00%
+met5       Horizontal       3600          1800          50.00%
+---------------------------------------------------------------
+
 Stage 1: Pattern routing.
 Nets with overflow: 108.
 Stage 2: Pattern routing with detours.
@@ -66,9 +79,22 @@ Nets with overflow: 20.
 Routing statistics
 Wire length:           62020
 Total via count:       3233
-Total wire overflow:   0
+Total overflow:        2
 Min resource:          -0.5555555555555571
 Bottleneck:            (3, 13, 14)
+
+[INFO GRT-0096] Final congestion report:
+Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Overflow
+---------------------------------------------------------------------------------------
+li1              25000            47            0.19%             0 /  0 /  0
+met1              5155           268            5.20%             0 /  0 /  0
+met2              7408          1494           20.17%             0 /  0 /  0
+met3              7992          1755           21.96%             1 /  0 /  2
+met4              5849           290            4.96%             0 /  0 /  0
+met5              1800             0            0.00%             0 /  0 /  0
+---------------------------------------------------------------------------------------
+Total            53204          3854            7.24%             1 /  0 /  2
+
 [INFO GRT-0018] Total wirelength: 31082 um
 [INFO GRT-0014] Routed nets: 411
 No differences found.


### PR DESCRIPTION
## Summary

Adds the `GRT-0053` (resource analysis) and `GRT-0096` (final congestion) reports when running CUGR. Mirrors FastRoute's existing report layout 1:1, including matching column structure and per-layer accessor pattern.

- New `GridGraph` machinery: `computeCongestionInformation` plus cached per-layer capacity / usage / overflow / max-H / max-V accessors. Original (pre-blockage / pre-adjustment) capacity is captured at construction time, mirroring FastRoute's `real_cap`.
- New `CUGR` pass-through accessors expose the same data via the public engine interface.
- `GlobalRouter::reportResources` and `GlobalRouter::reportCongestion` branch on `use_cugr_`; the CUGR branch of `globalRoute()` now invokes `reportResources()`, and `finishGlobalRouting()` no longer gates `reportCongestion()` on `!use_cugr_`.
- `CUGR::printStatistics` switched from wire-only to via-inclusive overflow so its `Total overflow` agrees with `Min resource` printed two lines below it (and with the new GRT-0096 table).

## Type of Change

- New feature
- Bug fix

## Impact

- `global_route -use_cugr -verbose` now prints the GRT-0053 routing-resources analysis (after init) and the GRT-0096 final congestion report (after finishing). Previously these only fired for FastRoute; CUGR runs were silent.
- `CUGR::printStatistics` now reports the via-inclusive overflow that the engine actually uses for routing decisions, fixing a long-standing inconsistency where the printed "Total wire overflow" disagreed with the negative `Min resource` printed on the next line.
- No FastRoute-side behavior changes; existing FastRoute goldens are untouched.

## Verification

- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**