### PR TITLE
Propagate Tcl app initialization failures

### DIFF
--- a/src/Main.cc
+++ b/src/Main.cc
@@ -500,6 +500,14 @@ static int tclAppInit(int& argc,
   return TCL_OK;
 }
 
+[[noreturn]] static void exitTclAppInitError(Tcl_Interp* interp)
+{
+  fprintf(stderr,
+          "application-specific initialization failed: %s\n",
+          Tcl_GetStringResult(interp));
+  exit(EXIT_FAILURE);
+}
+
 int ord::tclAppInit(Tcl_Interp* interp)
 {
   the_tech_and_design.tech = std::make_unique<ord::Tech>(interp);
@@ -513,7 +521,11 @@ int ord::tclAppInit(Tcl_Interp* interp)
   // This should replace the use of the singleton OpenRoad::openRoad().
   Tcl_SetAssocData(interp, "design", nullptr, the_tech_and_design.design.get());
 
-  return ord::tclInit(interp);
+  const int result = ord::tclInit(interp);
+  if (result != TCL_OK) {
+    exitTclAppInitError(interp);
+  }
+  return TCL_OK;
 }
 
 int ord::tclInit(Tcl_Interp* interp)


### PR DESCRIPTION
Fixes #6971.

## Summary
- Exit with `EXIT_FAILURE` when OpenROAD's Tcl application initialization fails.
- Preserve the familiar `application-specific initialization failed: ...` diagnostic before exiting.
- Keep `ord::tclInit()` returning `TCL_ERROR` for internal/GUI callers; only the CLI `Tcl_Main` app-init wrapper exits.

## Testing
- `git diff --check --cached` before commit
- Applied the patch in a fresh WSL clone with normalized line endings and ran `git diff --check`
- `bazel build --nobuild //:openroad`

I also attempted `bazel build --compile_one_dependency src/Main.cc`, but the local WSL image is missing standard C/C++ system headers (`locale.h`, `wchar.h`) and no passwordless sudo is available to install them, so the compile stopped in external dependencies before compiling OpenROAD sources.