### PR TITLE
cmake: link CUDD with system OpenSTA

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,8 @@ else()
 endif()
 
 if(USE_SYSTEM_OPENSTA)
+  find_package(CUDD REQUIRED)
+
   if(NOT OPENSTA_LIBRARY)
     find_library(OPENSTA_LIBRARY NAMES OpenSTA
                  PATHS
@@ -65,12 +67,9 @@ if(USE_SYSTEM_OPENSTA)
   add_library(OpenSTA STATIC IMPORTED)
   set_target_properties(OpenSTA PROPERTIES
     IMPORTED_LOCATION "${OPENSTA_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "${OPENSTA_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES CUDD::CUDD
   )
-  if(CUDD_LIB)
-    set_target_properties(OpenSTA PROPERTIES
-      INTERFACE_LINK_LIBRARIES "${CUDD_LIB}"
-    )
-  endif()
 else()
   # local build of opensta
   set(OPENSTA_LIBRARY "sta_swig")
@@ -391,7 +390,9 @@ if (ZLIB_FOUND)
 endif()
 
 # Optional CUDD library for OpenSTA
-if (CUDD_LIB)
+if (TARGET CUDD::CUDD)
+  target_link_libraries(openroad CUDD::CUDD)
+elseif (CUDD_LIB)
   target_link_libraries(openroad ${CUDD_LIB})
 endif()
 

--- a/src/cmake/FindCUDD.cmake
+++ b/src/cmake/FindCUDD.cmake
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, The OpenROAD Authors
+
+include(FindPackageHandleStandardArgs)
+
+set(_CUDD_HINTS)
+
+foreach(_cudd_root_var CUDD_ROOT cudd_ROOT)
+  if(DEFINED ${_cudd_root_var} AND NOT "${${_cudd_root_var}}" STREQUAL "")
+    list(APPEND _CUDD_HINTS "${${_cudd_root_var}}")
+  endif()
+endforeach()
+
+foreach(_cudd_root_env CUDD_ROOT cudd_ROOT)
+  if(DEFINED ENV{${_cudd_root_env}} AND NOT "$ENV{${_cudd_root_env}}" STREQUAL "")
+    list(APPEND _CUDD_HINTS "$ENV{${_cudd_root_env}}")
+  endif()
+endforeach()
+
+if(CUDD_LIB AND NOT CUDD_LIBRARY)
+  set(CUDD_LIBRARY "${CUDD_LIB}" CACHE FILEPATH "Path to the CUDD library")
+endif()
+
+if(CUDD_INCLUDE AND NOT CUDD_INCLUDE_DIR)
+  if(IS_DIRECTORY "${CUDD_INCLUDE}")
+    set(CUDD_INCLUDE_DIR "${CUDD_INCLUDE}" CACHE PATH "Path to the CUDD include directory")
+  else()
+    get_filename_component(_cudd_include_dir "${CUDD_INCLUDE}" DIRECTORY)
+    set(CUDD_INCLUDE_DIR "${_cudd_include_dir}" CACHE PATH "Path to the CUDD include directory")
+  endif()
+endif()
+
+if(CUDD_LIBRARY)
+  get_filename_component(_cudd_lib_dir "${CUDD_LIBRARY}" DIRECTORY)
+  get_filename_component(_cudd_prefix "${_cudd_lib_dir}" DIRECTORY)
+  list(APPEND _CUDD_HINTS "${_cudd_prefix}")
+endif()
+
+find_library(CUDD_LIBRARY
+  NAMES cudd
+  HINTS ${_CUDD_HINTS}
+  PATH_SUFFIXES lib lib64
+)
+
+find_path(CUDD_INCLUDE_DIR
+  NAMES cudd.h
+  HINTS ${_CUDD_HINTS}
+  PATH_SUFFIXES include include/cudd
+)
+
+find_package_handle_standard_args(CUDD
+  REQUIRED_VARS CUDD_LIBRARY CUDD_INCLUDE_DIR
+)
+
+if(CUDD_FOUND)
+  set(CUDD_LIB "${CUDD_LIBRARY}" CACHE FILEPATH "Path to the CUDD library")
+  set(CUDD_INCLUDE "${CUDD_INCLUDE_DIR}" CACHE PATH "Path to the CUDD include directory")
+
+  if(NOT TARGET CUDD::CUDD)
+    add_library(CUDD::CUDD UNKNOWN IMPORTED)
+    set_target_properties(CUDD::CUDD PROPERTIES
+      IMPORTED_LOCATION "${CUDD_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${CUDD_INCLUDE_DIR}"
+    )
+  endif()
+endif()
+
+mark_as_advanced(CUDD_LIBRARY CUDD_INCLUDE_DIR CUDD_LIB CUDD_INCLUDE)


### PR DESCRIPTION
## Summary
Adds a CMake `FindCUDD` module and wires the imported `OpenSTA` target used by `USE_SYSTEM_OPENSTA` to link against `CUDD::CUDD`.

This lets OpenROAD pick up CUDD from `cudd_ROOT` (as emitted by `etc/DependencyInstaller.sh`) or from the existing `CUDD_LIB`/`CUDD_INCLUDE` override variables, then propagate the dependency through OpenSTA when a static system OpenSTA is used.

## Type of Change
- Bug fix

## Impact
Fixes system/static OpenSTA builds where OpenSTA references CUDD symbols but OpenROAD does not link CUDD explicitly.

## Verification
- [ ] I have verified that the local build succeeds (`./etc/Build.sh`). Not run: local checkout is on Windows/MSVC without the OpenROAD Linux dependency stack.
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions. Not added: this is CMake dependency wiring; covered with targeted CMake smoke checks instead.
- [x] **I have signed my commits (DCO).**

Verification run locally with CMake 3.31.6:
- Configure smoke project with fake CUDD install via `-D cudd_ROOT=...`: passed.
- Configure smoke project with fake CUDD install via `-D CUDD_LIB=... -D CUDD_INCLUDE=...`: passed.
- Configure smoke project that imports `OpenSTA` and verifies `INTERFACE_LINK_LIBRARIES=CUDD::CUDD`: passed.
- `git diff --cached --check`: passed.

## Related Issues
Closes #5603
