### PR TITLE
gpl: expose formatted log messages to messages.txt

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -735,23 +735,22 @@ void BinGrid::initBins()
   idealBinCnt = std::max(idealBinCnt, 4);
 
   dbBlock* block = pb_->db()->getChip()->getBlock();
-  log_->info(
-      GPL, 23, format_label_float, "Placement target density:", targetDensity_);
+  log_->info(GPL,
+             23,
+             "Placement target density:   {:10.4f}",
+             targetDensity_);
   log_->info(GPL,
              24,
-             format_label_um2,
-             "Movable insts average area:",
+             "Movable insts average area: {:10.3f} um^2",
              block->dbuAreaToMicrons(averagePlaceInstArea));
   log_->info(GPL,
              25,
-             format_label_um2,
-             "Ideal bin area:",
+             "Ideal bin area:             {:10.3f} um^2",
              block->dbuAreaToMicrons(idealBinArea));
-  log_->info(GPL, 26, format_label_int, "Ideal bin count:", idealBinCnt);
+  log_->info(GPL, 26, "Ideal bin count:            {:10}", idealBinCnt);
   log_->info(GPL,
              27,
-             format_label_um2,
-             "Total bin area:",
+             "Total bin area:             {:10.3f} um^2",
              block->dbuAreaToMicrons(totalBinArea));
 
   if (!isSetBinCnt_) {
@@ -821,7 +820,7 @@ void BinGrid::initBins()
     }
   }
 
-  log_->info(GPL, 30, format_label_int, "Number of bins:", bins_.size());
+  log_->info(GPL, 30, "Number of bins:             {:10}", bins_.size());
 
   // only initialized once
   updateBinsNonPlaceArea();
@@ -3236,7 +3235,7 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
           GPL, 1001, "Global placement finished at iteration {}", final_iter);
       if (npVars_->routability_driven_mode) {
         log_->info(GPL,
-                   1003,
+                   1017,
                    "Routability mode iteration count: {}",
                    routability_gpl_iter_count);
       }
@@ -3253,14 +3252,12 @@ bool NesterovBase::checkConvergence(int gpl_iter_count,
 
     log_->info(GPL,
                1002,
-               format_label_float,
-               "Placed Cell Area",
+               "Placed Cell Area            {:10.4f}",
                block->dbuAreaToMicrons(getNesterovInstsArea()));
 
     log_->info(GPL,
                1003,
-               format_label_float,
-               "Available Free Area",
+               "Available Free Area         {:10.4f}",
                block->dbuAreaToMicrons(whiteSpaceArea_));
 
     log_->info(GPL,

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -735,10 +735,7 @@ void BinGrid::initBins()
   idealBinCnt = std::max(idealBinCnt, 4);
 
   dbBlock* block = pb_->db()->getChip()->getBlock();
-  log_->info(GPL,
-             23,
-             "Placement target density:   {:10.4f}",
-             targetDensity_);
+  log_->info(GPL, 23, "Placement target density:   {:10.4f}", targetDensity_);
   log_->info(GPL,
              24,
              "Movable insts average area: {:10.3f} um^2",

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -1259,12 +1259,11 @@ void NesterovPlace::createCbkGCell(odb::dbInst* db_inst)
       }
     }
     if (!found_nb) {
-      log_->warn(
-          GPL,
-          8,
-          "Unable to find NesterovBase for group ({}) to insert instance ({}).",
-          group->getName(),
-          db_inst->getName());
+      log_->warn(GPL,
+                 85,
+                 "Unable to find NesterovBase for group ({}) to insert instance ({}).",
+                 group->getName(),
+                 db_inst->getName());
     }
   }
 }

--- a/src/gpl/src/nesterovPlace.cpp
+++ b/src/gpl/src/nesterovPlace.cpp
@@ -1259,11 +1259,12 @@ void NesterovPlace::createCbkGCell(odb::dbInst* db_inst)
       }
     }
     if (!found_nb) {
-      log_->warn(GPL,
-                 85,
-                 "Unable to find NesterovBase for group ({}) to insert instance ({}).",
-                 group->getName(),
-                 db_inst->getName());
+      log_->warn(
+          GPL,
+          85,
+          "Unable to find NesterovBase for group ({}) to insert instance ({}).",
+          group->getName(),
+          db_inst->getName());
     }
   }
 }

--- a/src/gpl/src/placerBase.cpp
+++ b/src/gpl/src/placerBase.cpp
@@ -856,13 +856,11 @@ void PlacerBaseCommon::init()
 
   log_->info(GPL,
              36,
-             format_label_um2,
-             "Movable instances area:",
+             "Movable instances area:     {:10.3f} um^2",
              block->dbuAreaToMicrons(movable_area));
   log_->info(GPL,
              37,
-             format_label_um2,
-             "Total instances area:",
+             "Total instances area:       {:10.3f} um^2",
              block->dbuAreaToMicrons(total_area));
 
   double avg_density
@@ -909,8 +907,7 @@ void PlacerBaseCommon::init()
 
   log_->info(GPL,
              35,
-             format_label_um2,
-             "Pin density area adjust:",
+             "Pin density area adjust:    {:10.3f} um^2",
              block->dbuAreaToMicrons(total_adjustment_area));
 
   instMap_.reserve(instStor_.size());
@@ -1413,22 +1410,18 @@ void PlacerBase::printInfo(bool check_density) const
   dbBlock* block = db_->getChip()->getBlock();
   log_->info(GPL,
              6,
-             format_label_int,
-             "Number of instances:",
+             "Number of instances:        {:10}",
              placeInsts_.size() + fixedInsts_.size() + dummyInsts_.size());
-  log_->info(
-      GPL, 7, format_label_int, "Movable instances:", placeInsts_.size());
-  log_->info(GPL, 8, format_label_int, "Fixed instances:", fixedInsts_.size());
-  log_->info(GPL, 9, format_label_int, "Dummy instances:", dummyInsts_.size());
+  log_->info(GPL, 7, "Movable instances:          {:10}", placeInsts_.size());
+  log_->info(GPL, 8, "Fixed instances:            {:10}", fixedInsts_.size());
+  log_->info(GPL, 9, "Dummy instances:            {:10}", dummyInsts_.size());
   log_->info(GPL,
              10,
-             format_label_int,
-             "Number of nets:",
+             "Number of nets:             {:10}",
              pbCommon_->getNets().size());
   log_->info(GPL,
              11,
-             format_label_int,
-             "Number of pins:",
+             "Number of pins:             {:10}",
              pbCommon_->getPins().size());
 
   log_->info(GPL,
@@ -1453,8 +1446,7 @@ void PlacerBase::printInfo(bool check_density) const
 
   log_->info(GPL,
              16,
-             format_label_um2,
-             "Core area:",
+             "Core area:                  {:10.3f} um^2",
              block->dbuAreaToMicrons(die_.coreArea()));
   log_->info(GPL,
              14,
@@ -1462,32 +1454,27 @@ void PlacerBase::printInfo(bool check_density) const
              (group_ != nullptr) ? group_->getName() : "top-level");
   log_->info(GPL,
              15,
-             format_label_um2,
-             "Region area:",
+             "Region area:                {:10.3f} um^2",
              block->dbuAreaToMicrons(region_area_));
   log_->info(GPL,
              17,
-             format_label_um2,
-             "Fixed instances area:",
+             "Fixed instances area:       {:10.3f} um^2",
              block->dbuAreaToMicrons(nonPlaceInstsArea_));
 
   log_->info(GPL,
              18,
-             format_label_um2,
-             "Movable instances area:",
+             "Movable instances area:     {:10.3f} um^2",
              block->dbuAreaToMicrons(placeInstsArea_));
   log_->info(GPL, 19, "{:27} {:10.3f} %", "Utilization:", util);
 
   log_->info(GPL,
              20,
-             format_label_um2,
-             "Standard cells area:",
+             "Standard cells area:        {:10.3f} um^2",
              block->dbuAreaToMicrons(stdInstsArea_));
 
   log_->info(GPL,
              21,
-             format_label_um2,
-             "Large instances area:",
+             "Large instances area:       {:10.3f} um^2",
              block->dbuAreaToMicrons(macroInstsArea_));
 
   if (check_density && util >= 100.1) {

--- a/src/gpl/src/replace.cpp
+++ b/src/gpl/src/replace.cpp
@@ -82,7 +82,7 @@ void Replace::checkHasCoreRows()
 void Replace::doIncrementalPlace(const int threads, const PlaceOptions& options)
 {
   checkHasCoreRows();
-  log_->info(GPL, 6, "Execute incremental mode global placement.");
+  log_->info(GPL, 83, "Execute incremental mode global placement.");
   int placed_cnt = 0;
   int unplaced_cnt = 0;
   bool is_pbc_new = (pbc_ == nullptr);
@@ -317,7 +317,7 @@ int Replace::doNesterovPlace(const int threads,
     return 0;
   }
 
-  log_->info(GPL, 7, "---- Execute Nesterov Global Placement.");
+  log_->info(GPL, 84, "---- Execute Nesterov Global Placement.");
   if (options.timingDrivenMode) {
     rs_->resizeSlackPreamble();
   }

--- a/src/gpl/src/routeBase.cpp
+++ b/src/gpl/src/routeBase.cpp
@@ -682,15 +682,13 @@ std::pair<bool, bool> RouteBase::routability(
            / nbVec_[i]->getNesterovInstsArea())
           * 100.0f;
     log_->info(GPL,
-               51,
-               format_label_um2_with_delta,
-               "Inflated area:",
+               86,
+               "Inflated area:              {:10.3f} um^2 ({:+.2f}%)",
                inflated_area_delta_microns,
                inflated_area_delta_percentage);
     log_->info(GPL,
                52,
-               format_label_float,
-               "Placement target density:",
+               "Placement target density:   {:10.4f}",
                nbVec_[i]->getTargetDensity());
 
     prev_white_space_area[i] = nbVec_[i]->getWhiteSpaceArea();
@@ -762,45 +760,39 @@ std::pair<bool, bool> RouteBase::routability(
     log_->info(
         GPL,
         58,
-        format_label_um2_with_delta,
-        "White space area:",
+        "White space area:           {:10.3f} um^2 ({:+.2f}%)",
         block->dbuAreaToMicrons(nbVec_[i]->getWhiteSpaceArea()),
         percentDiff(prev_white_space_area[i], nbVec_[i]->getWhiteSpaceArea()));
 
     log_->info(GPL,
                59,
-               format_label_um2_with_delta,
-               "Movable instances area:",
+               "Movable instances area:     {:10.3f} um^2 ({:+.2f}%)",
                block->dbuAreaToMicrons(nbVec_[i]->getMovableArea()),
                percentDiff(prev_movable_area[i], nbVec_[i]->getMovableArea()));
 
     log_->info(GPL,
                60,
-               format_label_um2_with_delta,
-               "Total filler area:",
+               "Total filler area:          {:10.3f} um^2 ({:+.2f}%)",
                block->dbuAreaToMicrons(nbVec_[i]->getTotalFillerArea()),
                percentDiff(prev_total_filler_area[i],
                            nbVec_[i]->getTotalFillerArea()));
 
     log_->info(GPL,
                61,
-               format_label_um2_with_delta,
-               "Total non-inflated area:",
+               "Total non-inflated area:    {:10.3f} um^2 ({:+.2f}%)",
                block->dbuAreaToMicrons(new_total_gcells_area),
                percentDiff(prev_total_gcells_area[i], new_total_gcells_area));
 
     log_->info(
         GPL,
         62,
-        format_label_um2_with_delta,
-        "Total inflated area:",
+        "Total inflated area:        {:10.3f} um^2 ({:+.2f}%)",
         block->dbuAreaToMicrons(new_expected_gcells_area),
         percentDiff(prev_expected_gcells_area[i], new_expected_gcells_area));
 
     log_->info(GPL,
                63,
-               format_label_float,
-               "New Target Density:",
+               "New Target Density:         {:10.4f}",
                nbVec_[i]->getTargetDensity());
 
     // update densitySizes for all gCell

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -191,5 +191,6 @@ doc_check_test(
 
 doc_check_test(
     name = "gpl_messages_txt_check",
+    check_log = False,
     data = ["//src/gpl:messages_txt"],
 )

--- a/src/gpl/test/BUILD
+++ b/src/gpl/test/BUILD
@@ -188,3 +188,8 @@ doc_check_test(
     ],
     visibility = ["//visibility:public"],
 )
+
+doc_check_test(
+    name = "gpl_messages_txt_check",
+    data = ["//src/gpl:messages_txt"],
+)

--- a/src/gpl/test/ar01.ok
+++ b/src/gpl/test/ar01.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.758 *  2.538 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/ar02.ok
+++ b/src/gpl/test/ar02.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       2.684 *  1.663 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/cluster_place01.ok
+++ b/src/gpl/test/cluster_place01.ok
@@ -40,7 +40,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       2.126 *  2.100 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/convergence01.ok
+++ b/src/gpl/test/convergence01.ok
@@ -56,7 +56,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       0.689 *  0.675 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/core01.ok
+++ b/src/gpl/test/core01.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       2.126 *  2.100 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/density01.ok
+++ b/src/gpl/test/density01.ok
@@ -45,7 +45,7 @@ pad : 2 -> 1.030
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/diverge01.ok
+++ b/src/gpl/test/diverge01.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/error01.ok
+++ b/src/gpl/test/error01.ok
@@ -41,7 +41,7 @@ Automatically adjusting to uniform density 0.6500.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/gpl_messages_txt_check.py
+++ b/src/gpl/test/gpl_messages_txt_check.py
@@ -1,0 +1,26 @@
+import os
+
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+messages_path = os.path.join(cur_dir, "../messages.txt")
+
+with open(messages_path, encoding="utf-8") as messages_file:
+    messages = messages_file.read()
+
+expected_messages = [
+    "GPL 0023",
+    "Placement target density:",
+    "GPL 0036",
+    "Movable instances area:",
+    "GPL 0084",
+    "---- Execute Nesterov Global Placement.",
+    "GPL 1002",
+    "Placed Cell Area",
+    "GPL 1003",
+    "Available Free Area",
+    "GPL 1017",
+    "Routability mode iteration count:",
+]
+
+missing = [message for message in expected_messages if message not in messages]
+assert not missing, f"messages.txt missing expected GPL entries: {missing}"

--- a/src/gpl/test/gpl_messages_txt_check.py
+++ b/src/gpl/test/gpl_messages_txt_check.py
@@ -1,6 +1,5 @@
 import os
 
-
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 messages_path = os.path.join(cur_dir, "../messages.txt")
 

--- a/src/gpl/test/incremental01.ok
+++ b/src/gpl/test/incremental01.ok
@@ -3,7 +3,7 @@
 [INFO ODB-0130]     Created 54 pins.
 [INFO ODB-0131]     Created 294 components and 1656 component-terminals.
 [INFO ODB-0133]     Created 364 nets and 1068 connections.
-[INFO GPL-0006] Execute incremental mode global placement.
+[INFO GPL-0083] Execute incremental mode global placement.
 [INFO GPL-0001] ---- Initialize GPL Main Data Structures
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um

--- a/src/gpl/test/incremental02.ok
+++ b/src/gpl/test/incremental02.ok
@@ -4,7 +4,7 @@
 [INFO ODB-0131]     Created 24951 components and 119534 component-terminals.
 [INFO ODB-0132]     Created 2 special nets and 49902 connections.
 [INFO ODB-0133]     Created 21886 nets and 69632 connections.
-[INFO GPL-0006] Execute incremental mode global placement.
+[INFO GPL-0083] Execute incremental mode global placement.
 [INFO GPL-0001] ---- Initialize GPL Main Data Structures
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
@@ -48,7 +48,7 @@
 [INFO GPL-0028] Bin count (X, Y):         128 ,    128
 [INFO GPL-0029] Bin size (W * H):       7.811 *  7.011 um
 [INFO GPL-0030] Number of bins:                  16384
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -85,7 +85,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [WARNING GPL-1010] GPL reached the maximum number of iterations for nesterov 300. Placement may have failed to converge.
 [INFO GPL-1014] Final placement area: 47581.96 (+0.00%)
 [INFO GPL-0133] Unlocking all instances
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
       310 |   0.1860 |  2.120036e+06 |  +92.01% |  4.62e-08 |      
       320 |   0.2508 |  1.285716e+06 |  -39.35% |  6.80e-08 |      
       330 |   0.2150 |  1.199802e+06 |   -6.68% |  1.00e-07 |      

--- a/src/gpl/test/large01.ok
+++ b/src/gpl/test/large01.ok
@@ -64,7 +64,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       1.834 *  1.829 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/large02.ok
+++ b/src/gpl/test/large02.ok
@@ -67,7 +67,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       2.219 *  2.218 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/macro01.ok
+++ b/src/gpl/test/macro01.ok
@@ -60,7 +60,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       2.988 *  2.581 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/macro02.ok
+++ b/src/gpl/test/macro02.ok
@@ -60,7 +60,7 @@
 [INFO GPL-0028] Bin count (X, Y):         256 ,    256
 [INFO GPL-0029] Bin size (W * H):       3.827 *  3.046 um
 [INFO GPL-0030] Number of bins:                  65536
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/macro03.ok
+++ b/src/gpl/test/macro03.ok
@@ -62,7 +62,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       2.988 *  2.581 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium01.ok
+++ b/src/gpl/test/medium01.ok
@@ -45,7 +45,7 @@
 [INFO GPL-0028] Bin count (X, Y):         256 ,    256
 [INFO GPL-0029] Bin size (W * H):       1.680 *  1.673 um
 [INFO GPL-0030] Number of bins:                  65536
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium02.ok
+++ b/src/gpl/test/medium02.ok
@@ -60,7 +60,7 @@
 [INFO GPL-0028] Bin count (X, Y):         256 ,    256
 [INFO GPL-0029] Bin size (W * H):       2.265 *  2.259 um
 [INFO GPL-0030] Number of bins:                  65536
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium03.ok
+++ b/src/gpl/test/medium03.ok
@@ -60,7 +60,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       2.304 *  2.305 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium04.ok
+++ b/src/gpl/test/medium04.ok
@@ -58,7 +58,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       2.988 *  2.581 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium05.ok
+++ b/src/gpl/test/medium05.ok
@@ -61,7 +61,7 @@
 [INFO GPL-0028] Bin count (X, Y):         512 ,    512
 [INFO GPL-0029] Bin size (W * H):       1.767 *  1.523 um
 [INFO GPL-0030] Number of bins:                 262144
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/medium06.ok
+++ b/src/gpl/test/medium06.ok
@@ -47,7 +47,7 @@
 [INFO GPL-0028] Bin count (X, Y):         256 ,    256
 [INFO GPL-0029] Bin size (W * H):       2.344 *  2.341 um
 [INFO GPL-0030] Number of bins:                  65536
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/nograd01.ok
+++ b/src/gpl/test/nograd01.ok
@@ -40,7 +40,7 @@
 [INFO GPL-0028] Bin count (X, Y):         256 ,    256
 [INFO GPL-0029] Bin size (W * H):       0.390 *  0.389 um
 [INFO GPL-0030] Number of bins:                  65536
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/region01.ok
+++ b/src/gpl/test/region01.ok
@@ -111,7 +111,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):          32 ,     32
 [INFO GPL-0029] Bin size (W * H):       6.562 *  3.438 um
 [INFO GPL-0030] Number of bins:                   1024
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
         0 |   0.9827 |  5.922227e+03 |   +0.00% |  2.76e-15 |  (spm_inst_0_domain)
         0 |   0.9827 |  5.922227e+03 |   +0.00% |  2.36e-15 |  (spm_inst_1_domain)
        10 |   0.9825 |  5.884226e+03 |   -0.64% |  4.49e-15 |  (spm_inst_0_domain)

--- a/src/gpl/test/simple01-obs.ok
+++ b/src/gpl/test/simple01-obs.ok
@@ -41,7 +41,7 @@ Automatically adjusting to uniform density 0.8500.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01-rd.ok
+++ b/src/gpl/test/simple01-rd.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -107,7 +107,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
       355 |   0.0982 |  2.595415e+03 |          |  9.89e-07 |      
 ---------------------------------------------------------------
 [INFO GPL-1001] Global placement finished at iteration 355
-[INFO GPL-1003] Routability mode iteration count: 64
+[INFO GPL-1017] Routability mode iteration count: 64
 [INFO GPL-0039] Number of routing layers: 0
 [INFO GPL-1005] Routability final weighted congestion: 0.2670
 [INFO GPL-1002] Placed Cell Area              619.7347

--- a/src/gpl/test/simple01-ref.ok
+++ b/src/gpl/test/simple01-ref.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01-skip-io.ok
+++ b/src/gpl/test/simple01-skip-io.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01-td-tune.ok
+++ b/src/gpl/test/simple01-td-tune.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01-td.ok
+++ b/src/gpl/test/simple01-td.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01-uniform.ok
+++ b/src/gpl/test/simple01-uniform.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple01.ok
+++ b/src/gpl/test/simple01.ok
@@ -39,7 +39,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple02-rd.ok
+++ b/src/gpl/test/simple02-rd.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -107,7 +107,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
       355 |   0.0982 |  2.595415e+03 |          |  9.89e-07 |      
 ---------------------------------------------------------------
 [INFO GPL-1001] Global placement finished at iteration 355
-[INFO GPL-1003] Routability mode iteration count: 64
+[INFO GPL-1017] Routability mode iteration count: 64
 [INFO GPL-0039] Number of routing layers: 0
 [INFO GPL-1005] Routability final weighted congestion: 0.2670
 [INFO GPL-1002] Placed Cell Area              619.7347

--- a/src/gpl/test/simple02.ok
+++ b/src/gpl/test/simple02.ok
@@ -41,7 +41,7 @@ Automatically adjusting to uniform density 0.6500.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple03-rd.ok
+++ b/src/gpl/test/simple03-rd.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -101,7 +101,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
       355 |   0.0982 |  2.595415e+03 |          |  9.89e-07 |      
 ---------------------------------------------------------------
 [INFO GPL-1001] Global placement finished at iteration 355
-[INFO GPL-1003] Routability mode iteration count: 64
+[INFO GPL-1017] Routability mode iteration count: 64
 [INFO GPL-1005] Routability final weighted congestion: 0.2670
 [INFO GPL-1002] Placed Cell Area              619.7347
 [INFO GPL-1003] Available Free Area           953.8760

--- a/src/gpl/test/simple03.ok
+++ b/src/gpl/test/simple03.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple04-rd.ok
+++ b/src/gpl/test/simple04-rd.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -101,7 +101,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
       355 |   0.0982 |  2.595415e+03 |          |  9.89e-07 |      
 ---------------------------------------------------------------
 [INFO GPL-1001] Global placement finished at iteration 355
-[INFO GPL-1003] Routability mode iteration count: 64
+[INFO GPL-1017] Routability mode iteration count: 64
 [INFO GPL-1005] Routability final weighted congestion: 0.2670
 [INFO GPL-1002] Placed Cell Area              619.7347
 [INFO GPL-1003] Available Free Area           953.8760

--- a/src/gpl/test/simple04.ok
+++ b/src/gpl/test/simple04.ok
@@ -44,7 +44,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple05.ok
+++ b/src/gpl/test/simple05.ok
@@ -40,7 +40,7 @@
 [INFO GPL-0028] Bin count (X, Y):           2 ,      2
 [INFO GPL-0029] Bin size (W * H):       3.040 *  2.800 um
 [INFO GPL-0030] Number of bins:                      4
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple07.ok
+++ b/src/gpl/test/simple07.ok
@@ -49,7 +49,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0028] Bin count (X, Y):           8 ,      8
 [INFO GPL-0029] Bin size (W * H):       2.875 *  4.080 um
 [INFO GPL-0030] Number of bins:                     64
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple08.ok
+++ b/src/gpl/test/simple08.ok
@@ -49,7 +49,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0028] Bin count (X, Y):          64 ,     64
 [INFO GPL-0029] Bin size (W * H):       0.359 *  0.510 um
 [INFO GPL-0030] Number of bins:                   4096
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple09.ok
+++ b/src/gpl/test/simple09.ok
@@ -40,7 +40,7 @@
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       1.936 *  1.925 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/gpl/test/simple10.ok
+++ b/src/gpl/test/simple10.ok
@@ -49,7 +49,7 @@ To avoid this warning in the future, remove this statement from the LEF file wit
 [INFO GPL-0028] Bin count (X, Y):        2048 ,   2048
 [INFO GPL-0029] Bin size (W * H):       3.896 *  3.895 um
 [INFO GPL-0030] Number of bins:                4194304
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/odb/test/replace_hier_mod1.ok
+++ b/src/odb/test/replace_hier_mod1.ok
@@ -140,7 +140,7 @@ Equivalence check - pre
 Repair timing output passed/skipped equivalence test
 ### swap bc1 to inv_chain ###
 [INFO ODB-0496] swapMaster sanity check passed (0 failures)
-[INFO GPL-0006] Execute incremental mode global placement.
+[INFO GPL-0083] Execute incremental mode global placement.
 [INFO GPL-0001] ---- Initialize GPL Main Data Structures
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
@@ -184,7 +184,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0028] Bin count (X, Y):           2 ,     32
 [INFO GPL-0029] Bin size (W * H):      19.950 * 37.494 um
 [INFO GPL-0030] Number of bins:                     64
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -221,7 +221,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [WARNING GPL-1010] GPL reached the maximum number of iterations for nesterov 300. Placement may have failed to converge.
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
 [INFO GPL-0133] Unlocking all instances
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
       310 |   0.1375 |  2.608555e+02 | +142.91% |  5.67e-07 |      
       311 |   0.0997 |  2.649455e+02 |          |  6.13e-07 |      
 ---------------------------------------------------------------
@@ -325,7 +325,7 @@ Equivalence check - swap (buffer_chain -> inv_chain)
 Repair timing output passed/skipped equivalence test
 ### swap bc1 back to buffer_chain ###
 [INFO ODB-0496] swapMaster sanity check passed (0 failures)
-[INFO GPL-0006] Execute incremental mode global placement.
+[INFO GPL-0083] Execute incremental mode global placement.
 [INFO GPL-0001] ---- Initialize GPL Main Data Structures
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
@@ -369,7 +369,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0028] Bin count (X, Y):           2 ,     32
 [INFO GPL-0029] Bin size (W * H):      19.950 * 37.494 um
 [INFO GPL-0030] Number of bins:                     64
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -386,7 +386,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 55.08 (+0.00%)
 [INFO GPL-0133] Unlocking all instances
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
        10 |   0.4272 |  3.684500e+01 |  -86.41% |  1.18e-12 |      
        20 |   0.4163 |  2.992050e+01 |  -18.79% |  1.58e-12 |      
        30 |   0.4015 |  2.609400e+01 |  -12.79% |  2.10e-12 |      
@@ -535,7 +535,7 @@ Equivalence check - swap for rollback (inv_chain -> buffer_chain)
 Repair timing output passed/skipped equivalence test
 ### swap bc1 back to inv_chain ###
 [INFO ODB-0496] swapMaster sanity check passed (0 failures)
-[INFO GPL-0006] Execute incremental mode global placement.
+[INFO GPL-0083] Execute incremental mode global placement.
 [INFO GPL-0001] ---- Initialize GPL Main Data Structures
 [INFO GPL-0002] DBU: 2000
 [INFO GPL-0003] SiteSize: (  0.190  1.400 ) um
@@ -579,7 +579,7 @@ Repair timing output passed/skipped equivalence test
 [INFO GPL-0028] Bin count (X, Y):           2 ,     32
 [INFO GPL-0029] Bin size (W * H):      19.950 * 37.494 um
 [INFO GPL-0030] Number of bins:                     64
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -596,7 +596,7 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-1009]     - For 50% usage of free space: 0.0023
 [INFO GPL-1014] Final placement area: 54.55 (+0.00%)
 [INFO GPL-0133] Unlocking all instances
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
        10 |   0.3890 |  3.538500e+01 |  -76.44% |  1.18e-12 |      
        20 |   0.3919 |  2.646600e+01 |  -25.21% |  1.57e-12 |      
        30 |   0.3934 |  2.313500e+01 |  -12.59% |  2.09e-12 |      

--- a/src/rsz/test/buffer_ports10.ok
+++ b/src/rsz/test/buffer_ports10.ok
@@ -57,7 +57,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       4.987 *  4.900 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/rsz/test/buffer_ports8.ok
+++ b/src/rsz/test/buffer_ports8.ok
@@ -57,7 +57,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       4.987 *  4.900 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/src/rsz/test/buffer_ports9.ok
+++ b/src/rsz/test/buffer_ports9.ok
@@ -57,7 +57,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):          16 ,     16
 [INFO GPL-0029] Bin size (W * H):       4.987 *  4.900 um
 [INFO GPL-0030] Number of bins:                    256
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------

--- a/test/upf_aes.ok
+++ b/test/upf_aes.ok
@@ -106,7 +106,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):         128 ,    128
 [INFO GPL-0029] Bin size (W * H):       4.844 *  3.594 um
 [INFO GPL-0030] Number of bins:                  16384
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------
@@ -272,17 +272,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9880
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.1117
 [INFO GPL-0048] Routing congestion (1.1117) lower than previous minimum (1e+30). Updating minimum.
-[INFO GPL-0051] Inflated area:                 107.928 um^2 (+0.08%)
+[INFO GPL-0086] Inflated area:                 107.928 um^2 (+0.08%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 364, After: 351 (-3.57%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2836.413, After: 2727.714 (-3.83%)
 [INFO GPL-0078] Removed fillers count: 13, area removed: 101.026 um^2. Remaining area to be compensated by modifying density: 6.902 um^2
-[INFO GPL-0051] Inflated area:                 732.365 um^2 (+0.59%)
+[INFO GPL-0086] Inflated area:                 732.365 um^2 (+0.59%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 365, After: 272 (-25.48%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2851.990, After: 2122.816 (-25.57%)
 [INFO GPL-0078] Removed fillers count: 93, area removed: 725.816 um^2. Remaining area to be compensated by modifying density: 6.549 um^2
-[INFO GPL-0051] Inflated area:                1474.452 um^2 (+1.19%)
+[INFO GPL-0086] Inflated area:                1474.452 um^2 (+1.19%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 365, After: 177 (-51.51%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2851.990, After: 1381.392 (-51.56%)
@@ -338,17 +338,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9757
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0844
 [INFO GPL-0048] Routing congestion (1.0844) lower than previous minimum (1.112). Updating minimum.
-[INFO GPL-0051] Inflated area:                  49.657 um^2 (+0.04%)
+[INFO GPL-0086] Inflated area:                  49.657 um^2 (+0.04%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 351, After: 345 (-1.71%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2727.714, After: 2681.086 (-1.71%)
 [INFO GPL-0078] Removed fillers count: 6, area removed: 46.628 um^2. Remaining area to be compensated by modifying density: 3.029 um^2
-[INFO GPL-0051] Inflated area:                 345.814 um^2 (+0.28%)
+[INFO GPL-0086] Inflated area:                 345.814 um^2 (+0.28%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 272, After: 228 (-16.18%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2122.816, After: 1779.420 (-16.18%)
 [INFO GPL-0078] Removed fillers count: 44, area removed: 343.397 um^2. Remaining area to be compensated by modifying density: 2.417 um^2
-[INFO GPL-0051] Inflated area:                 950.002 um^2 (+0.75%)
+[INFO GPL-0086] Inflated area:                 950.002 um^2 (+0.75%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 177, After: 56 (-68.36%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 1381.392, After: 437.050 (-68.36%)
@@ -404,17 +404,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9636
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0640
 [INFO GPL-0048] Routing congestion (1.0640) lower than previous minimum (1.084). Updating minimum.
-[INFO GPL-0051] Inflated area:                  27.779 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  27.779 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 345, After: 342 (-0.87%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2681.086, After: 2657.773 (-0.87%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 4.465 um^2
-[INFO GPL-0051] Inflated area:                 251.764 um^2 (+0.20%)
+[INFO GPL-0086] Inflated area:                 251.764 um^2 (+0.20%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 228, After: 196 (-14.04%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 1779.420, After: 1529.677 (-14.04%)
 [INFO GPL-0078] Removed fillers count: 32, area removed: 249.743 um^2. Remaining area to be compensated by modifying density: 2.021 um^2
-[INFO GPL-0051] Inflated area:                 534.277 um^2 (+0.42%)
+[INFO GPL-0086] Inflated area:                 534.277 um^2 (+0.42%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 56, After: 0 (-100.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 437.050, After: 0.000 (-100.00%)
@@ -471,17 +471,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9506
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0460
 [INFO GPL-0048] Routing congestion (1.0460) lower than previous minimum (1.064). Updating minimum.
-[INFO GPL-0051] Inflated area:                  15.246 um^2 (+0.01%)
+[INFO GPL-0086] Inflated area:                  15.246 um^2 (+0.01%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 342, After: 341 (-0.29%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2657.773, After: 2650.001 (-0.29%)
 [INFO GPL-0078] Removed fillers count: 1, area removed: 7.771 um^2. Remaining area to be compensated by modifying density: 7.474 um^2
-[INFO GPL-0051] Inflated area:                 180.657 um^2 (+0.14%)
+[INFO GPL-0086] Inflated area:                 180.657 um^2 (+0.14%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 196, After: 173 (-11.73%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 1529.677, After: 1350.174 (-11.73%)
 [INFO GPL-0078] Removed fillers count: 23, area removed: 179.503 um^2. Remaining area to be compensated by modifying density: 1.154 um^2
-[INFO GPL-0051] Inflated area:                 310.277 um^2 (+0.24%)
+[INFO GPL-0086] Inflated area:                 310.277 um^2 (+0.24%)
 [INFO GPL-0052] Placement target density:       0.4465
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -538,17 +538,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9493
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0449
 [INFO GPL-0048] Routing congestion (1.0449) lower than previous minimum (1.046). Updating minimum.
-[INFO GPL-0051] Inflated area:                  26.365 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  26.365 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 341, After: 338 (-0.88%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2650.001, After: 2626.688 (-0.88%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 3.052 um^2
-[INFO GPL-0051] Inflated area:                 221.882 um^2 (+0.18%)
+[INFO GPL-0086] Inflated area:                 221.882 um^2 (+0.18%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 173, After: 145 (-16.18%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 1350.174, After: 1131.648 (-16.18%)
 [INFO GPL-0078] Removed fillers count: 28, area removed: 218.525 um^2. Remaining area to be compensated by modifying density: 3.357 um^2
-[INFO GPL-0051] Inflated area:                 272.722 um^2 (+0.21%)
+[INFO GPL-0086] Inflated area:                 272.722 um^2 (+0.21%)
 [INFO GPL-0052] Placement target density:       0.4476
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -605,17 +605,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9478
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0413
 [INFO GPL-0048] Routing congestion (1.0413) lower than previous minimum (1.045). Updating minimum.
-[INFO GPL-0051] Inflated area:                  28.572 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  28.572 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 338, After: 335 (-0.89%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2626.688, After: 2603.374 (-0.89%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 5.258 um^2
-[INFO GPL-0051] Inflated area:                 171.419 um^2 (+0.14%)
+[INFO GPL-0086] Inflated area:                 171.419 um^2 (+0.14%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 145, After: 124 (-14.48%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 1131.648, After: 967.755 (-14.48%)
 [INFO GPL-0078] Removed fillers count: 21, area removed: 163.894 um^2. Remaining area to be compensated by modifying density: 7.525 um^2
-[INFO GPL-0051] Inflated area:                 252.055 um^2 (+0.20%)
+[INFO GPL-0086] Inflated area:                 252.055 um^2 (+0.20%)
 [INFO GPL-0052] Placement target density:       0.4486
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -672,17 +672,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9436
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0366
 [INFO GPL-0048] Routing congestion (1.0366) lower than previous minimum (1.041). Updating minimum.
-[INFO GPL-0051] Inflated area:                  28.552 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  28.552 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 335, After: 332 (-0.90%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2603.374, After: 2580.060 (-0.90%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 5.238 um^2
-[INFO GPL-0051] Inflated area:                 196.016 um^2 (+0.16%)
+[INFO GPL-0086] Inflated area:                 196.016 um^2 (+0.16%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 124, After: 99 (-20.16%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 967.755, After: 772.643 (-20.16%)
 [INFO GPL-0078] Removed fillers count: 25, area removed: 195.112 um^2. Remaining area to be compensated by modifying density: 0.904 um^2
-[INFO GPL-0051] Inflated area:                 202.959 um^2 (+0.16%)
+[INFO GPL-0086] Inflated area:                 202.959 um^2 (+0.16%)
 [INFO GPL-0052] Placement target density:       0.4494
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -739,17 +739,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9426
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0363
 [INFO GPL-0049] Routing congestion (1.0363) higher than minimum (1.0366). Consecutive non-improvement count: 1.
-[INFO GPL-0051] Inflated area:                  29.748 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  29.748 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 332, After: 329 (-0.90%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2580.060, After: 2556.746 (-0.90%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 6.434 um^2
-[INFO GPL-0051] Inflated area:                 149.913 um^2 (+0.12%)
+[INFO GPL-0086] Inflated area:                 149.913 um^2 (+0.12%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 99, After: 80 (-19.19%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 772.643, After: 624.358 (-19.19%)
 [INFO GPL-0078] Removed fillers count: 19, area removed: 148.285 um^2. Remaining area to be compensated by modifying density: 1.628 um^2
-[INFO GPL-0051] Inflated area:                 237.745 um^2 (+0.19%)
+[INFO GPL-0086] Inflated area:                 237.745 um^2 (+0.19%)
 [INFO GPL-0052] Placement target density:       0.4502
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -806,17 +806,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9415
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0305
 [INFO GPL-0048] Routing congestion (1.0305) lower than previous minimum (1.037). Updating minimum.
-[INFO GPL-0051] Inflated area:                  10.229 um^2 (+0.01%)
+[INFO GPL-0086] Inflated area:                  10.229 um^2 (+0.01%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 329, After: 328 (-0.30%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2556.746, After: 2548.975 (-0.30%)
 [INFO GPL-0078] Removed fillers count: 1, area removed: 7.771 um^2. Remaining area to be compensated by modifying density: 2.458 um^2
-[INFO GPL-0051] Inflated area:                 113.350 um^2 (+0.09%)
+[INFO GPL-0086] Inflated area:                 113.350 um^2 (+0.09%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 80, After: 66 (-17.50%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 624.358, After: 515.095 (-17.50%)
 [INFO GPL-0078] Removed fillers count: 14, area removed: 109.263 um^2. Remaining area to be compensated by modifying density: 4.087 um^2
-[INFO GPL-0051] Inflated area:                 193.201 um^2 (+0.15%)
+[INFO GPL-0086] Inflated area:                 193.201 um^2 (+0.15%)
 [INFO GPL-0052] Placement target density:       0.4510
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -873,17 +873,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9415
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0321
 [INFO GPL-0049] Routing congestion (1.0321) higher than minimum (1.0305). Consecutive non-improvement count: 1.
-[INFO GPL-0051] Inflated area:                  25.674 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  25.674 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 328, After: 325 (-0.91%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2548.975, After: 2525.661 (-0.91%)
 [INFO GPL-0078] Removed fillers count: 3, area removed: 23.314 um^2. Remaining area to be compensated by modifying density: 2.360 um^2
-[INFO GPL-0051] Inflated area:                 137.812 um^2 (+0.11%)
+[INFO GPL-0086] Inflated area:                 137.812 um^2 (+0.11%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 66, After: 49 (-25.76%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 515.095, After: 382.419 (-25.76%)
 [INFO GPL-0078] Removed fillers count: 17, area removed: 132.676 um^2. Remaining area to be compensated by modifying density: 5.136 um^2
-[INFO GPL-0051] Inflated area:                 177.211 um^2 (+0.14%)
+[INFO GPL-0086] Inflated area:                 177.211 um^2 (+0.14%)
 [INFO GPL-0052] Placement target density:       0.4517
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -940,17 +940,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9424
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0304
 [INFO GPL-0049] Routing congestion (1.0304) higher than minimum (1.0305). Consecutive non-improvement count: 2.
-[INFO GPL-0051] Inflated area:                  22.673 um^2 (+0.02%)
+[INFO GPL-0086] Inflated area:                  22.673 um^2 (+0.02%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 325, After: 323 (-0.62%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2525.661, After: 2510.119 (-0.62%)
 [INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 7.130 um^2
-[INFO GPL-0051] Inflated area:                 149.942 um^2 (+0.12%)
+[INFO GPL-0086] Inflated area:                 149.942 um^2 (+0.12%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 49, After: 30 (-38.78%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 382.419, After: 234.134 (-38.78%)
 [INFO GPL-0078] Removed fillers count: 19, area removed: 148.285 um^2. Remaining area to be compensated by modifying density: 1.657 um^2
-[INFO GPL-0051] Inflated area:                 164.561 um^2 (+0.13%)
+[INFO GPL-0086] Inflated area:                 164.561 um^2 (+0.13%)
 [INFO GPL-0052] Placement target density:       0.4523
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)
@@ -1007,17 +1007,17 @@ Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 [INFO GPL-0046] Average top 5.0% routing congestion: 0.9427
 [INFO GPL-0047] Routability iteration weighted routing congestion: 1.0355
 [INFO GPL-0049] Routing congestion (1.0355) higher than minimum (1.0305). Consecutive non-improvement count: 3.
-[INFO GPL-0051] Inflated area:                  15.550 um^2 (+0.01%)
+[INFO GPL-0086] Inflated area:                  15.550 um^2 (+0.01%)
 [INFO GPL-0052] Placement target density:       0.3968
 [INFO GPL-0076] Removing fillers, count: Before: 323, After: 321 (-0.62%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 2510.119, After: 2494.576 (-0.62%)
 [INFO GPL-0078] Removed fillers count: 2, area removed: 15.543 um^2. Remaining area to be compensated by modifying density: 0.007 um^2
-[INFO GPL-0051] Inflated area:                 130.375 um^2 (+0.10%)
+[INFO GPL-0086] Inflated area:                 130.375 um^2 (+0.10%)
 [INFO GPL-0052] Placement target density:       0.4938
 [INFO GPL-0076] Removing fillers, count: Before: 30, After: 14 (-53.33%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 234.134, After: 109.263 (-53.33%)
 [INFO GPL-0078] Removed fillers count: 16, area removed: 124.872 um^2. Remaining area to be compensated by modifying density: 5.503 um^2
-[INFO GPL-0051] Inflated area:                 225.097 um^2 (+0.17%)
+[INFO GPL-0086] Inflated area:                 225.097 um^2 (+0.17%)
 [INFO GPL-0052] Placement target density:       0.4529
 [INFO GPL-0076] Removing fillers, count: Before: 0, After: 0 (+0.00%)
 [INFO GPL-0077] Filler area (um^2)     : Before: 0.000, After: 0.000 (+0.00%)

--- a/test/upf_test.ok
+++ b/test/upf_test.ok
@@ -106,7 +106,7 @@ Using 2 tracks default min distance between IO pins.
 [INFO GPL-0028] Bin count (X, Y):           8 ,      4
 [INFO GPL-0029] Bin size (W * H):       6.900 *  4.080 um
 [INFO GPL-0030] Number of bins:                     32
-[INFO GPL-0007] ---- Execute Nesterov Global Placement.
+[INFO GPL-0084] ---- Execute Nesterov Global Placement.
 [INFO GPL-0031] HPWL: Half-Perimeter Wirelength
 Iteration | Overflow |     HPWL (um) |  HPWL(%) |   Penalty | Group
 ---------------------------------------------------------------


### PR DESCRIPTION
Fixes #7797.

This updates GPL logger calls that used shared format-string constants so the generated `messages.txt` can see both the message IDs and useful message text. Exposing those calls revealed a few duplicate GPL IDs, so this also renumbers the duplicate phase/status messages and updates the GPL golden logs.

Tests run:
- `python etc/find_messages.py -d src/gpl`
- inline assertion that generated GPL messages include `GPL 0023`, `GPL 0036`, `GPL 0084`, `GPL 1002`, `GPL 1003`, and `GPL 1017`
- `python -m py_compile src/gpl/test/gpl_messages_txt_check.py`
- `git diff --cached --check` using a temporary index for this branch commit

Not run: Bazel/OpenROAD regressions; `bazel`, `bazelisk`, `cmake`, and an `openroad` binary are not available on this Windows PATH.