### PR TITLE
Fix headless gui::dump_heatmap

### DIFF
--- a/src/gui/include/gui/gui.h
+++ b/src/gui/include/gui/gui.h
@@ -1045,7 +1045,7 @@ class Gui
 
   void registerHeatMap(HeatMapDataSource* heatmap);
   void unregisterHeatMap(HeatMapDataSource* heatmap);
-  const std::set<HeatMapDataSource*>& getHeatMaps() { return heat_maps_; }
+  const std::set<HeatMapDataSource*>& getHeatMaps();
   HeatMapDataSource* getHeatMap(const std::string& name);
 
   // returns the Gui singleton
@@ -1082,6 +1082,7 @@ class Gui
 
  private:
   Gui();
+  void syncHeatMapChips();
 
   void registerDescriptor(const std::type_info& type,
                           const Descriptor* descriptor);

--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -30,6 +30,7 @@
 #endif
 #include <cmath>
 #include <optional>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -1171,8 +1172,32 @@ void Gui::unregisterHeatMap(HeatMapDataSource* heatmap)
   heat_maps_.erase(heatmap);
 }
 
+void Gui::syncHeatMapChips()
+{
+  if (hasUI() || db_ == nullptr) {
+    return;
+  }
+
+  // Console and headless sessions do not receive MainWindow::setBlock().
+  auto* chip = db_->getChip();
+  for (auto* heat_map : heat_maps_) {
+    if (heat_map->getChip() != chip) {
+      heat_map->setChip(chip);
+      heat_map->destroyMap();
+    }
+  }
+}
+
+const std::set<HeatMapDataSource*>& Gui::getHeatMaps()
+{
+  syncHeatMapChips();
+  return heat_maps_;
+}
+
 HeatMapDataSource* Gui::getHeatMap(const std::string& name)
 {
+  syncHeatMapChips();
+
   HeatMapDataSource* source = nullptr;
 
   for (auto* heat_map : heat_maps_) {

--- a/src/gui/test/CMakeLists.txt
+++ b/src/gui/test/CMakeLists.txt
@@ -1,6 +1,22 @@
-or_integration_tests(
-  "gui"
-  TESTS
-    supported
-)
+set(GUI_TESTS supported)
+set(GUI_PASSFAIL_TESTS)
 
+if (Qt5_FOUND AND BUILD_GUI)
+  list(APPEND GUI_PASSFAIL_TESTS dump_heatmap_headless)
+endif()
+
+if (GUI_PASSFAIL_TESTS)
+  or_integration_tests(
+    "gui"
+    TESTS
+      ${GUI_TESTS}
+    PASSFAIL_TESTS
+      ${GUI_PASSFAIL_TESTS}
+  )
+else()
+  or_integration_tests(
+    "gui"
+    TESTS
+      ${GUI_TESTS}
+  )
+endif()

--- a/src/gui/test/dump_heatmap_headless.tcl
+++ b/src/gui/test/dump_heatmap_headless.tcl
@@ -1,0 +1,35 @@
+set script_dir [file dirname [info script]]
+set openroad_test_dir [file normalize [file join $script_dir .. .. .. test]]
+
+source [file join $openroad_test_dir helpers.tcl]
+
+if { ![gui::supported] } {
+  puts "fail"
+  exit 1
+}
+
+suppress_message ODB 128
+suppress_message ODB 130
+suppress_message ODB 131
+suppress_message ODB 132
+suppress_message ODB 133
+suppress_message ODB 227
+
+read_lef [file join $openroad_test_dir Nangate45 Nangate45.lef]
+read_def [file join $openroad_test_dir gcd_nangate45.def]
+
+set heatmap_file [make_result_file dump_heatmap_headless.csv]
+gui::dump_heatmap Placement $heatmap_file
+
+set heatmap [open $heatmap_file r]
+set contents [read $heatmap]
+close $heatmap
+
+if {
+  [string first "value (%)" $contents] >= 0
+  && [regexp -line {^[0-9.-]+,[0-9.-]+,[0-9.-]+,[0-9.-]+,} $contents]
+} {
+  puts "pass"
+} else {
+  puts "fail"
+}


### PR DESCRIPTION
## Summary

Headless Tcl sessions could leave the built-in heatmap sources attached to an old or null database chip. The Qt main window normally updates those sources, but it is not created when OpenROAD runs without `-gui`, so `gui::dump_heatmap` could fail with `GUI-0072` after `read_def`.

This change syncs the heatmap sources with the active chip before headless access. It also drops a cached map when the chip changes. The Qt path is unchanged because the main window keeps ownership while the UI is active.

The regression reads Nangate45 LEF/DEF without `-gui`, dumps the Placement heatmap, and checks that the CSV contains real map data.

## Type of Change

Bug fix

## Verification

Run on a Debian 11 GCP VM after rebasing onto current master:

- `bazelisk build --config=release --//:platform=gui //:openroad //src/gui:gui_qt_headless //src/gui:gui`
- `xvfb-run -a ./bazel-bin/openroad -no_splash -exit src/gui/test/dump_heatmap_headless.tcl` (`pass`, 435-byte CSV)
- `bazelisk test --config=release --//:platform=gui //src/gui/test:supported-tcl_test`
- `bazelisk build --config=lint --//:platform=gui //src/gui:gui_qt_headless`
- clang-format 18, buildifier 8.2.1, and `git diff --check`

Fixes #5897