### PR TITLE
Fix web test dependencies.

### DIFF
--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -110,43 +110,55 @@ genrule(
 )
 
 cc_library(
+    name = "color",
+    srcs = ["src/color.cpp"],
+    hdrs = ["src/color.h"],
+    includes = ["src"],
+    visibility = ["//src/web/test:__pkg__"],
+)
+
+cc_library(
     name = "web",
     srcs = [
         "src/clock_tree_report.cpp",
-        "src/clock_tree_report.h",
-        "src/color.cpp",
-        "src/color.h",
         "src/font_atlas.h",
         "src/font_data.cpp",
         "src/font_data.h",
         "src/glyph_cache.cpp",
-        "src/glyph_cache.h",
         "src/hierarchy_report.cpp",
         "src/hierarchy_report.h",
         "src/module_color_palette.h",
         "src/request_dispatcher.h",
         "src/request_handler.cpp",
-        "src/request_handler.h",
         "src/search.cpp",
         "src/search.h",
         "src/tile_generator.cpp",
-        "src/tile_generator.h",
         "src/timing_report.cpp",
-        "src/timing_report.h",
         "src/web.cpp",
         "src/web_assets.h",
         "src/web_chart.cpp",
-        "src/web_chart.h",
         "src/web_painter.cpp",
-        "src/web_painter.h",
         "src/web_serve.cpp",
         "src/web_viewer_hook.cpp",
-        "src/web_viewer_hook.h",
         ":report_assets",
         ":web_assets",
     ],
     hdrs = [
         "include/web/web.h",
+        # The following are used by tests, but they are not broken
+        # out as library. So TODO: make them visible for the tests
+        # to properly depend on this library and see the includes.
+        # If these are meant to be used in tests with specific dependencies,
+        # these should be put (together with their *.cpp files) into separate
+        # libraries, with visibility for the //src/web/test path (see :color).
+        "src/glyph_cache.h",
+        "src/tile_generator.h",
+        "src/timing_report.h",
+        "src/web_chart.h",
+        "src/web_painter.h",
+        "src/web_viewer_hook.h",
+        "src/request_handler.h",
+        "src/clock_tree_report.h",
     ],
     copts = [
         "-DBOOST_ASIO_NO_DEPRECATED",
@@ -157,6 +169,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":color",
         "//src/dbSta",
         "//src/dbSta:dbNetwork",
         "//src/gui",

--- a/src/web/test/BUILD
+++ b/src/web/test/BUILD
@@ -166,19 +166,13 @@ js_test(
 cc_test(
     name = "clock_tree_report_test",
     srcs = ["cpp/TestClockTreeReport.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
-        "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
-        "//third-party/lodepng",
         "@boost.json",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
@@ -188,19 +182,14 @@ cc_test(
 cc_test(
     name = "request_handler_test",
     srcs = ["cpp/TestRequestHandler.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
         "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
-        "//third-party/lodepng",
         "@boost.json",
         "@googletest//:gtest",
         "@googletest//:gtest_main",
@@ -210,18 +199,14 @@ cc_test(
 cc_test(
     name = "tile_generator_test",
     srcs = ["cpp/TestTileGenerator.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
-        "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
+        "//src/web:color",
         "//third-party/lodepng",
         "@boost.json",
         "@googletest//:gtest",
@@ -232,17 +217,12 @@ cc_test(
 cc_test(
     name = "save_image_test",
     srcs = ["cpp/TestSaveImage.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
-        "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
         "//third-party/lodepng",
         "@googletest//:gtest",
@@ -253,17 +233,12 @@ cc_test(
 cc_test(
     name = "snap_test",
     srcs = ["cpp/TestSnap.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
-        "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
         "@boost.json",
         "@googletest//:gtest",
@@ -274,8 +249,6 @@ cc_test(
 cc_test(
     name = "glyph_cache_test",
     srcs = ["cpp/TestGlyphCache.cpp"],
-    copts = ["-Isrc/web/src"],
-    features = ["-layering_check"],
     deps = [
         "//src/web",
         "@googletest//:gtest",
@@ -286,8 +259,6 @@ cc_test(
 cc_test(
     name = "debug_graphics_test",
     srcs = ["cpp/TestDebugGraphics.cpp"],
-    copts = ["-Isrc/web/src"],
-    features = ["-layering_check"],
     deps = [
         "//src/gui",
         "//src/odb",
@@ -300,19 +271,13 @@ cc_test(
 cc_test(
     name = "save_report_test",
     srcs = ["cpp/TestSaveReport.cpp"],
-    copts = ["-Isrc/web/src"],
     data = [
         "//test:nangate45_data",
     ],
-    features = ["-layering_check"],
     deps = [
-        "//src/gui",
         "//src/odb",
-        "//src/tst",
         "//src/tst:nangate45_fixture",
-        "//src/utl",
         "//src/web",
-        "//third-party/lodepng",
         "@boost.json",
         "@googletest//:gtest",
         "@googletest//:gtest_main",


### PR DESCRIPTION
This adds the headers that are used outside the `//src/web` library in the unit tests to the public headers.

Since these do look like they are considered implementation details (`src/*` path), this will require another cleanup-step by the maintainers of this directory.
These should be changed to smaller libraries that export the headers and are only private to the web library and the tests.
I've done this for the `color` library as a starting point.

The tests previously worked by funneling the visibility of these headers behind the back of bazel and llvm; so the following hacks are not needed anymore:

```
 copts = ["-Isrc/web/src"],
 features = ["-layering_check"],
```
