### PR TITLE
add an openroad-qt as an alternative to GUI Qt config to reduce build times

### DIFF
--- a/.github/workflows/github-actions-macos-bazel.yml
+++ b/.github/workflows/github-actions-macos-bazel.yml
@@ -38,7 +38,7 @@ jobs:
           bazelisk build \
             --disk_cache=~/.cache/bazel-disk-cache \
             --experimental_disk_cache_gc_max_size=5G \
-            //:openroad-qt
+            --//:platform=gui //:openroad
 
       # 2. SAVE: Only executes if this is a push/merge directly to the master branch
       - name: Save Bazel Disk Cache

--- a/.github/workflows/github-actions-macos-bazel.yml
+++ b/.github/workflows/github-actions-macos-bazel.yml
@@ -38,7 +38,7 @@ jobs:
           bazelisk build \
             --disk_cache=~/.cache/bazel-disk-cache \
             --experimental_disk_cache_gc_max_size=5G \
-            --//:platform=gui //:openroad
+            //:openroad-qt
 
       # 2. SAVE: Only executes if this is a push/merge directly to the master branch
       - name: Save Bazel Disk Cache

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,6 +2,7 @@
 # Copyright (c) 2025-2025, The OpenROAD Authors
 
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_library")
@@ -45,6 +46,29 @@ exports_files([
     "src/Exception.i",
     "src/options.i",
 ])
+
+string_flag(
+    name = "platform",
+    build_setting_default = "cli",
+    values = [
+        "cli",
+        "gui",
+    ],
+)
+
+config_setting(
+    name = "platform_cli",
+    flag_values = {
+        ":platform": "cli",
+    },
+)
+
+config_setting(
+    name = "platform_gui",
+    flag_values = {
+        ":platform": "gui",
+    },
+)
 
 OPENROAD_LIBRARY_DEPS = [
     ":openroad_version",
@@ -160,27 +184,37 @@ cc_binary(
     }),
     visibility = ["//visibility:public"],
     deps = [
-        ":openroad_lib",
         ":openroad_version",
         ":opt_notification",
         ":ord",
         ":tcl_readline_setup",
         "//bazel:tcl_library_init",
         "//src/cut",
-        "//src/gui",
         "//src/sta:opensta_lib",
         "//src/utl",
         "//src/web",
         "@boost.stacktrace",
         "@rules_cc//cc/runfiles",  # sets BAZEL_CURRENT_REPOSITORY
         "@tcl_lang//:tcl",
-    ],
+    ] + select(
+        {
+            ":platform_cli": [
+                ":openroad_lib",
+                "//src/gui",
+            ],
+            ":platform_gui": [
+                ":openroad_lib_qt",
+                "//src/gui:gui_qt",
+            ],
+        },
+    ),
 )
 
 # Qt GUI variant. Build explicitly when the interactive GUI is wanted:
 #   bazelisk build //:openroad-qt
-# `:openroad` (CLI) is what build-time tool consumers (rule libraries
-# pulling OpenROAD via cfg = "exec") should depend on.
+# Additive to the existing `--//:platform=gui //:openroad` flag path —
+# this target is preferable for ad-hoc GUI builds because it does not
+# invalidate `:openroad`'s cache the way flipping the flag does.
 cc_binary(
     name = "openroad-qt",
     srcs = [
@@ -242,8 +276,8 @@ cc_library(
 )
 
 # Qt variant: same sources, linked against the Qt GUI implementation.
-# Used only by :openroad-qt. Compiled separately (different `BUILD_GUI`
-# define + different gui dep) when that target is requested.
+# Used by :openroad-qt, and by :openroad when --//:platform=gui is set.
+# Compiled separately (different `BUILD_GUI` define + different gui dep).
 cc_library(
     name = "openroad_lib_qt",
     srcs = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -212,28 +212,18 @@ cc_binary(
     ],
 )
 
-OPENROAD_LIB_SRCS = [
-    "src/Design.cc",
-    "src/OpenRoad.cc",
-    "src/Tech.cc",
-    "src/Timing.cc",
-    ":openroad_swig",
-    ":openroad_tcl",
-]
-
-OPENROAD_LIB_COMMON_DEPS = [
-    "//src/sta:opensta_lib",
-    "@abseil-cpp//absl/base:core_headers",
-    "@abseil-cpp//absl/synchronization",
-    "@boost.stacktrace",
-    "@tcl_lang//:tcl",
-] + OPENROAD_LIBRARY_DEPS
-
 # CLI variant: the default. What downstream rule libraries pull as a
 # build-time tool, and what `bazelisk build //:openroad` produces.
 cc_library(
     name = "openroad_lib",
-    srcs = OPENROAD_LIB_SRCS,
+    srcs = [
+        "src/Design.cc",
+        "src/OpenRoad.cc",
+        "src/Tech.cc",
+        "src/Timing.cc",
+        ":openroad_swig",
+        ":openroad_tcl",
+    ],
     copts = OPENROAD_COPTS,
     defines = OPENROAD_DEFINES + ["BUILD_GUI=false"],
     features = ["-use_header_modules"],
@@ -241,7 +231,14 @@ cc_library(
         "include",
     ],
     visibility = ["//:__subpackages__"],
-    deps = OPENROAD_LIB_COMMON_DEPS + ["//src/gui"],
+    deps = [
+        "//src/gui",
+        "//src/sta:opensta_lib",
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/synchronization",
+        "@boost.stacktrace",
+        "@tcl_lang//:tcl",
+    ] + OPENROAD_LIBRARY_DEPS,
 )
 
 # Qt variant: same sources, linked against the Qt GUI implementation.
@@ -249,7 +246,14 @@ cc_library(
 # define + different gui dep) when that target is requested.
 cc_library(
     name = "openroad_lib_qt",
-    srcs = OPENROAD_LIB_SRCS,
+    srcs = [
+        "src/Design.cc",
+        "src/OpenRoad.cc",
+        "src/Tech.cc",
+        "src/Timing.cc",
+        ":openroad_swig",
+        ":openroad_tcl",
+    ],
     copts = OPENROAD_COPTS,
     defines = OPENROAD_DEFINES + ["BUILD_GUI=true"],
     features = ["-use_header_modules"],
@@ -257,7 +261,14 @@ cc_library(
         "include",
     ],
     visibility = ["//:__subpackages__"],
-    deps = OPENROAD_LIB_COMMON_DEPS + ["//src/gui:gui_qt"],
+    deps = [
+        "//src/gui:gui_qt",
+        "//src/sta:opensta_lib",
+        "@abseil-cpp//absl/base:core_headers",
+        "@abseil-cpp//absl/synchronization",
+        "@boost.stacktrace",
+        "@tcl_lang//:tcl",
+    ] + OPENROAD_LIBRARY_DEPS,
 )
 
 cc_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2025, The OpenROAD Authors
 
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_library")
@@ -478,6 +479,14 @@ sh_test(
     srcs = ["//etc:find_dup_ids.sh"],
     data = ["//etc:find_messages.py"],
     tags = ["local"],
+)
+
+# Make sure the Qt GUI variant keeps building. :openroad is exercised by
+# downstream rule libraries that pull it as a tool; :openroad-qt has no
+# such consumer in CI, so a build_test pins its compilability.
+build_test(
+    name = "openroad_qt_build_test",
+    targets = [":openroad-qt"],
 )
 
 # ---------------------------------------------------------------------------

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2025-2025, The OpenROAD Authors
 
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_python//python:defs.bzl", "py_library")
@@ -45,29 +44,6 @@ exports_files([
     "src/Exception.i",
     "src/options.i",
 ])
-
-string_flag(
-    name = "platform",
-    build_setting_default = "cli",
-    values = [
-        "cli",
-        "gui",
-    ],
-)
-
-config_setting(
-    name = "platform_cli",
-    flag_values = {
-        ":platform": "cli",
-    },
-)
-
-config_setting(
-    name = "platform_gui",
-    flag_values = {
-        ":platform": "gui",
-    },
-)
 
 OPENROAD_LIBRARY_DEPS = [
     ":openroad_version",
@@ -130,12 +106,7 @@ OPENROAD_LIBRARY_DEPS = [
     "//src/web:ui",
     "@abc",
     ":ord",
-] + select(
-    {
-        ":platform_cli": ["//src/gui"],
-        ":platform_gui": ["//src/gui:gui_qt"],
-    },
-)
+]
 
 # Flags applied to top-level OpenROAD targets only. Flags that apply
 # globally to every cc_* target (-Wall, -Wextra, -Wno-sign-compare,
@@ -204,37 +175,86 @@ cc_binary(
     ],
 )
 
-GUI_BUILD_FLAGS = select(
-    {
-        ":platform_cli": ["BUILD_GUI=false"],
-        ":platform_gui": ["BUILD_GUI=true"],
-    },
-)
-
-cc_library(
-    name = "openroad_lib",
+# Qt GUI variant. Build explicitly when the interactive GUI is wanted:
+#   bazelisk build //:openroad-qt
+# `:openroad` (CLI) is what build-time tool consumers (rule libraries
+# pulling OpenROAD via cfg = "exec") should depend on.
+cc_binary(
+    name = "openroad-qt",
     srcs = [
-        "src/Design.cc",
-        "src/OpenRoad.cc",
-        "src/Tech.cc",
-        "src/Timing.cc",
-        ":openroad_swig",
-        ":openroad_tcl",
+        "src/Main.cc",
     ],
     copts = OPENROAD_COPTS,
-    defines = OPENROAD_DEFINES + GUI_BUILD_FLAGS,
+    features = ["-use_header_modules"],
+    malloc = select({
+        "@platforms//os:linux": "@tcmalloc//tcmalloc",
+        "@platforms//os:macos": "@bazel_tools//tools/cpp:malloc",
+    }),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":openroad_lib_qt",
+        ":openroad_version",
+        ":opt_notification",
+        ":ord",
+        ":tcl_readline_setup",
+        "//bazel:tcl_library_init",
+        "//src/cut",
+        "//src/gui:gui_qt",
+        "//src/sta:opensta_lib",
+        "//src/utl",
+        "//src/web",
+        "@boost.stacktrace",
+        "@rules_cc//cc/runfiles",
+        "@tcl_lang//:tcl",
+    ],
+)
+
+OPENROAD_LIB_SRCS = [
+    "src/Design.cc",
+    "src/OpenRoad.cc",
+    "src/Tech.cc",
+    "src/Timing.cc",
+    ":openroad_swig",
+    ":openroad_tcl",
+]
+
+OPENROAD_LIB_COMMON_DEPS = [
+    "//src/sta:opensta_lib",
+    "@abseil-cpp//absl/base:core_headers",
+    "@abseil-cpp//absl/synchronization",
+    "@boost.stacktrace",
+    "@tcl_lang//:tcl",
+] + OPENROAD_LIBRARY_DEPS
+
+# CLI variant: the default. What downstream rule libraries pull as a
+# build-time tool, and what `bazelisk build //:openroad` produces.
+cc_library(
+    name = "openroad_lib",
+    srcs = OPENROAD_LIB_SRCS,
+    copts = OPENROAD_COPTS,
+    defines = OPENROAD_DEFINES + ["BUILD_GUI=false"],
     features = ["-use_header_modules"],
     includes = [
         "include",
     ],
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//src/sta:opensta_lib",
-        "@abseil-cpp//absl/base:core_headers",
-        "@abseil-cpp//absl/synchronization",
-        "@boost.stacktrace",
-        "@tcl_lang//:tcl",
-    ] + OPENROAD_LIBRARY_DEPS,
+    deps = OPENROAD_LIB_COMMON_DEPS + ["//src/gui"],
+)
+
+# Qt variant: same sources, linked against the Qt GUI implementation.
+# Used only by :openroad-qt. Compiled separately (different `BUILD_GUI`
+# define + different gui dep) when that target is requested.
+cc_library(
+    name = "openroad_lib_qt",
+    srcs = OPENROAD_LIB_SRCS,
+    copts = OPENROAD_COPTS,
+    defines = OPENROAD_DEFINES + ["BUILD_GUI=true"],
+    features = ["-use_header_modules"],
+    includes = [
+        "include",
+    ],
+    visibility = ["//:__subpackages__"],
+    deps = OPENROAD_LIB_COMMON_DEPS + ["//src/gui:gui_qt"],
 )
 
 cc_library(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -170,6 +170,26 @@ cc_library(
     ],
 )
 
+# Deps shared by :openroad and :openroad-qt. Kept as a Starlark list
+# rather than a cc_library wrapper because layering_check is enabled
+# package-wide: a deps-only cc_library does not re-export its deps'
+# headers to consumers, so direct binary deps are what each Main.cc
+# include needs to see.
+OPENROAD_MAIN_DEPS = [
+    ":openroad_version",
+    ":opt_notification",
+    ":ord",
+    ":tcl_readline_setup",
+    "//bazel:tcl_library_init",
+    "//src/cut",
+    "//src/sta:opensta_lib",
+    "//src/utl",
+    "//src/web",
+    "@boost.stacktrace",
+    "@rules_cc//cc/runfiles",  # sets BAZEL_CURRENT_REPOSITORY
+    "@tcl_lang//:tcl",
+]
+
 cc_binary(
     name = "openroad",
     srcs = [
@@ -183,20 +203,7 @@ cc_binary(
         "@platforms//os:macos": "@bazel_tools//tools/cpp:malloc",
     }),
     visibility = ["//visibility:public"],
-    deps = [
-        ":openroad_version",
-        ":opt_notification",
-        ":ord",
-        ":tcl_readline_setup",
-        "//bazel:tcl_library_init",
-        "//src/cut",
-        "//src/sta:opensta_lib",
-        "//src/utl",
-        "//src/web",
-        "@boost.stacktrace",
-        "@rules_cc//cc/runfiles",  # sets BAZEL_CURRENT_REPOSITORY
-        "@tcl_lang//:tcl",
-    ] + select(
+    deps = OPENROAD_MAIN_DEPS + select(
         {
             ":platform_cli": [
                 ":openroad_lib",
@@ -228,21 +235,9 @@ cc_binary(
         "@platforms//os:macos": "@bazel_tools//tools/cpp:malloc",
     }),
     visibility = ["//visibility:public"],
-    deps = [
+    deps = OPENROAD_MAIN_DEPS + [
         ":openroad_lib_qt",
-        ":openroad_version",
-        ":opt_notification",
-        ":ord",
-        ":tcl_readline_setup",
-        "//bazel:tcl_library_init",
-        "//src/cut",
         "//src/gui:gui_qt",
-        "//src/sta:opensta_lib",
-        "//src/utl",
-        "//src/web",
-        "@boost.stacktrace",
-        "@rules_cc//cc/runfiles",
-        "@tcl_lang//:tcl",
     ],
 )
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -152,6 +152,7 @@ cc_binary(
         "src/Main.cc",
     ],
     copts = OPENROAD_COPTS,
+    defines = OPENROAD_DEFINES,
     features = ["-use_header_modules"],
     malloc = select({
         "@platforms//os:linux": "@tcmalloc//tcmalloc",
@@ -186,6 +187,7 @@ cc_binary(
         "src/Main.cc",
     ],
     copts = OPENROAD_COPTS,
+    defines = OPENROAD_DEFINES,
     features = ["-use_header_modules"],
     malloc = select({
         "@platforms//os:linux": "@tcmalloc//tcmalloc",


### PR DESCRIPTION
Add an openroad-qt binary for users who prefer that over config.

Leave `--//:platform=gui`  use-case unchanged.

openroad-qt fixes the following use-case, [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment):

1. Run a build `bazelisk foo_final` for 16 hours. This artifact is placed in a remote cache and it is built in CI.
2. Issue `bazelisk --//:platform=gui run foo_final gui_final` locally to open design in GUI; this would take another 16 hours as the final artifact has to be rebuilt because the Qt GUI is now an accidental dependency of the build artifact.
3. In a followon PR to bazel-orfs, I'll make `bazelisk run foo_final gui_final` use openroad-qt rather than openroad, No need to re-build for 16 hours due to config change.
4. GUI opens

webgui will eventually sunset Qt, but meanwhile we need a better way to handle this use-case.

I'm already ditching the config flag in bazel-orfs to avoid multi-rebuilds of openroad https://github.com/The-OpenROAD-Project/bazel-orfs/pull/722

