### PR TITLE
Fix superfluous/missing dependencies in grt.

### DIFF
--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -22,12 +22,17 @@ cc_library(
     visibility = ["//visibility:private"],
     deps = [
         "//src/stt",
+        "//src/utl",
     ],
 )
 
 cc_library(
     name = "groute",
     hdrs = ["include/grt/GRoute.h"],
+    includes = [
+        "include",
+    ],
+    deps = ["//src/odb"],
 )
 
 cc_library(
@@ -69,7 +74,6 @@ cc_library(
         "@boost.container_hash",
         "@boost.icl",
         "@boost.multi_array",
-        "@openmp",
     ],
 )
 
@@ -107,7 +111,6 @@ cc_library(
     ],
     deps = [
         ":groute",
-        "//:ord",
         "//src/dbSta",
         "//src/dbSta:dbNetwork",
         "//src/est:parasitics_service",
@@ -154,7 +157,6 @@ cc_library(
         ":groute",
         "//src/ant",
         "//src/dbSta",
-        "//src/dbSta:SpefWriter",
         "//src/dbSta:dbNetwork",
         "//src/dpl",
         "//src/drt:pin_access_service",


### PR DESCRIPTION
```
. <($(etc/get-bant-path.sh) dwyu ... -g "' //src/grt")
```
