### PR TITLE
rsz: remove unused resizer_ in MoveTracker

### DIFF
--- a/src/rsz/src/MoveTracker.cc
+++ b/src/rsz/src/MoveTracker.cc
@@ -62,8 +62,7 @@ std::string histogramBar(const int count, const int count_per_hash)
 }  // namespace
 
 MoveTracker::MoveTracker(Resizer& resizer, const bool report_enabled)
-    : resizer_(resizer),
-      logger_(resizer.logger()),
+    : logger_(resizer.logger()),
       sta_(resizer.sta()),
       db_network_(resizer.dbNetwork()),
       report_enabled_(report_enabled),

--- a/src/rsz/src/MoveTracker.hh
+++ b/src/rsz/src/MoveTracker.hh
@@ -222,7 +222,6 @@ class MoveTracker : public odb::dbBlockCallBackObj
                      const std::string& count_label = "Count");
 
   // === Shared services ======================================================
-  Resizer& resizer_;
   utl::Logger* logger_;
   sta::Sta* sta_;
   sta::dbNetwork* db_network_;


### PR DESCRIPTION
## Summary
Remove unused resizer_ in MoveTracker

## Type of Change
- Refactoring

## Impact
Removes compiler warning

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
