### PR TITLE
Add `includes = []` to libraries exporting headers that are used with…

### DIFF
--- a/src/drt/BUILD
+++ b/src/drt/BUILD
@@ -93,6 +93,9 @@ cc_library(
         "src/db/tech/frViaRuleGenerate.h",
         "src/dr/FlexMazeTypes.h",
     ],
+    includes = [
+        "src",
+    ],
     deps = [
         ":base_types",
         "//src/odb",

--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -19,6 +19,9 @@ cc_library(
     hdrs = [
         "src/snapper.h",
     ],
+    includes = [
+        "src",
+    ],
     deps = [
         "//src/odb",
         "//src/utl",

--- a/src/mpl/CMakeLists.txt
+++ b/src/mpl/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(mpl_snapper
 
 target_include_directories(mpl_snapper
   PUBLIC
-    include
+    src
 )
 
 target_link_libraries(mpl_snapper

--- a/src/mpl/test/cpp/TestSnapper.cpp
+++ b/src/mpl/test/cpp/TestSnapper.cpp
@@ -5,11 +5,11 @@
 #include <memory>
 #include <string>
 
-#include "../../src/snapper.h"
 #include "MplTest.h"
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "snapper.h"
 
 namespace mpl {
 namespace {

--- a/src/tst/BUILD
+++ b/src/tst/BUILD
@@ -15,7 +15,7 @@ cc_library(
     data = [
         "//test:nangate45_data",
     ],
-    includes = ["."],
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":tst"],
 )
@@ -27,7 +27,7 @@ cc_library(
     data = [
         "//test:sky130hd_data",
     ],
-    includes = ["."],
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [":tst"],
 )
@@ -66,7 +66,7 @@ cc_library(
         "//test:nangate45_data",
         "//test:sky130hd_data",
     ],
-    includes = ["."],
+    includes = ["include"],
     visibility = ["//visibility:public"],
     deps = [
         ":tst",


### PR DESCRIPTION
… shortened path.

Libraries that provide headers in subdirectories (e.g. `src/foo.h`), but then are used by users of the library as `"foo.h"` need to have the `includes = ["src"]` added.
(longer term, this should be converted to `include_prefix` for slightly cleaner ways of doing this, or we go to relative-to-project-root including for the best way)