### PR TITLE
grt: store CUGR congestion data in ODB

### DIFF
--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -225,8 +225,13 @@ void GlobalRouter::applyAdjustments(int min_routing_layer,
 // previous congestion report file.
 void GlobalRouter::saveCongestion()
 {
-  is_congested_ = fastroute_->totalOverflow() > 0;
-  fastroute_->saveCongestion();
+  if (use_cugr_) {
+    is_congested_ = cugr_->totalOverflow() > 0;
+    cugr_->saveCongestion();
+  } else {
+    is_congested_ = fastroute_->totalOverflow() > 0;
+    fastroute_->saveCongestion();
+  }
 }
 
 NetRouteMap& GlobalRouter::getRoutes()
@@ -274,7 +279,11 @@ bool GlobalRouter::haveRoutes()
     return false;
   }
   loadGuidesFromDB();
-  bool congested_routes = is_congested_ && !allow_congestion_;
+  // Empirically, CUGR's congested routes still let DRT produce better
+  // results than a zero-overflow FastRoute run, so treat CUGR overflow
+  // the same as -allow_congestion.
+  bool congested_routes
+      = is_congested_ && !allow_congestion_ && !use_cugr_;
   return !routes_.empty() && !congested_routes;
 }
 
@@ -454,7 +463,10 @@ void GlobalRouter::finishGlobalRouting(bool save_guides)
   if (is_congested_) {
     // Suggest adjustment value
     suggestAdjustment();
-    if (allow_congestion_) {
+    // CUGR overflow is downgraded to a warning even without
+    // -allow_congestion: empirically DRT produces better results from
+    // CUGR's congested routes than from a zero-overflow FastRoute run.
+    if (allow_congestion_ || use_cugr_) {
       logger_->warn(GRT,
                     115,
                     "Global routing finished with congestion. Check the "

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -232,6 +232,14 @@ void GlobalRouter::saveCongestion()
     is_congested_ = fastroute_->totalOverflow() > 0;
     fastroute_->saveCongestion();
   }
+
+  if (congestion_file_name_ != nullptr) {
+    odb::dbMarkerCategory* tool_category
+        = block_->findMarkerCategory("Global route");
+    if (tool_category != nullptr) {
+      tool_category->writeTR(congestion_file_name_);
+    }
+  }
 }
 
 NetRouteMap& GlobalRouter::getRoutes()

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -279,11 +279,7 @@ bool GlobalRouter::haveRoutes()
     return false;
   }
   loadGuidesFromDB();
-  // Empirically, CUGR's congested routes still let DRT produce better
-  // results than a zero-overflow FastRoute run, so treat CUGR overflow
-  // the same as -allow_congestion.
-  bool congested_routes
-      = is_congested_ && !allow_congestion_ && !use_cugr_;
+  bool congested_routes = is_congested_ && !allow_congestion_ && !use_cugr_;
   return !routes_.empty() && !congested_routes;
 }
 
@@ -463,9 +459,8 @@ void GlobalRouter::finishGlobalRouting(bool save_guides)
   if (is_congested_) {
     // Suggest adjustment value
     suggestAdjustment();
-    // CUGR overflow is downgraded to a warning even without
-    // -allow_congestion: empirically DRT produces better results from
-    // CUGR's congested routes than from a zero-overflow FastRoute run.
+    // CUGR overflow is downgraded to a warning even without -allow_congestion,
+    // since it produces good results on detailed routing.
     if (allow_congestion_ || use_cugr_) {
       logger_->warn(GRT,
                     115,

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -103,6 +103,9 @@ class CUGR
   const std::vector<int>& getMaxHorizontalOverflows() const;
   const std::vector<int>& getMaxVerticalOverflows() const;
 
+  int totalOverflow();
+  void saveCongestion();
+
  private:
   float calculatePartialSlack();
   float getNetSlack(odb::dbNet* net);

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -807,8 +807,7 @@ void CUGR::saveCongestion()
     }
     odb::dbNet* db_net = gr_net->getDbNet();
     GRTreeNode::preorder(
-        gr_net->getRoutingTree(),
-        [&](const std::shared_ptr<GRTreeNode>& node) {
+        gr_net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {
           for (const auto& child : node->getChildren()) {
             if (node->getLayerIdx() == child->getLayerIdx()) {
               const int l = node->getLayerIdx();
@@ -883,17 +882,18 @@ void CUGR::saveCongestion()
         const int wires = wc_it != wire_count.end() ? wc_it->second : 0;
         const bool wires_overflow = static_cast<double>(wires) > cap;
         const bool vias_contribute = (demand - wires) > 0;
-        const char* kind = wires_overflow
-                               ? (vias_contribute ? "wires + vias" : "wires")
-                               : "vias";
+        std::string kind = "vias";
+        if (wires_overflow) {
+          kind = vias_contribute ? "wires + vias" : "wires";
+        }
 
         odb::dbMarkerCategory*& subcat
             = direction == MetalLayer::H ? h_subcat : v_subcat;
         if (subcat == nullptr) {
-          subcat = odb::dbMarkerCategory::create(
-              tool_category,
-              direction == MetalLayer::H ? "Horizontal congestion"
-                                         : "Vertical congestion");
+          subcat = odb::dbMarkerCategory::create(tool_category,
+                                                 direction == MetalLayer::H
+                                                     ? "Horizontal congestion"
+                                                     : "Vertical congestion");
         }
         odb::dbMarker* marker = odb::dbMarker::create(subcat);
         if (marker == nullptr) {
@@ -903,10 +903,9 @@ void CUGR::saveCongestion()
         if (db_layer != nullptr) {
           marker->setTechLayer(db_layer);
         }
-        marker->setComment("capacity:" + std::to_string(cap_int)
-                           + " usage:" + std::to_string(demand_int)
-                           + " overflow:" + std::to_string(overflow_int)
-                           + " (" + kind + ")");
+        marker->setComment("capacity:" + std::to_string(cap_int) + " usage:"
+                           + std::to_string(demand_int) + " overflow:"
+                           + std::to_string(overflow_int) + " (" + kind + ")");
 
         std::set<odb::dbNet*> sources;
         auto wn_it = wire_nets.find({l, x, y});

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -42,6 +42,26 @@ using utl::GRT;
 
 namespace grt {
 
+namespace {
+
+// Per-3D-edge key used by saveCongestion() to attribute wires and via
+// stubs to specific edges.
+using EdgeKey = std::tuple<int, int, int>;  // (layer, x, y)
+struct EdgeKeyHash
+{
+  size_t operator()(const EdgeKey& k) const
+  {
+    // boost::hash_combine pattern.
+    size_t h = 0;
+    h ^= std::hash<int>{}(std::get<0>(k)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^= std::hash<int>{}(std::get<1>(k)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    h ^= std::hash<int>{}(std::get<2>(k)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+    return h;
+  }
+};
+
+}  // namespace
+
 CUGR::CUGR(odb::dbDatabase* db,
            utl::Logger* log,
            utl::ServiceRegistry* service_registry,
@@ -588,50 +608,33 @@ void CUGR::updateDbCongestion()
     //   usage    = routing demand + lost capacity (blockage + adjustment)
     // Boundary cells without a corresponding edge replicate the previous
     // cell's value, again matching FastRoute's last_cell_cap fall-through.
+    // Iterate along the layer's preferred direction in the inner loop so
+    // the fall-through carries forward correctly for both H and V.
     const int direction = grid_graph_->getLayerDirection(layer);
-    if (direction == MetalLayer::H) {
-      for (int y = 0; y < y_size; y++) {
-        double last_cap = 0;
-        double last_use = 0;
-        for (int x = 0; x < x_size; x++) {
-          double cap, use;
-          if (x == x_size - 1) {
-            cap = last_cap;
-            use = last_use;
-          } else {
-            const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
-            const double initial
-                = grid_graph_->getInitialEdgeCapacity(layer, x, y);
-            cap = initial;
-            use = edge.demand + (initial - edge.capacity);
-          }
-          db_gcell->setCapacity(db_layer, x, y, cap);
-          db_gcell->setUsage(db_layer, x, y, use);
-          last_cap = cap;
-          last_use = use;
+    const bool is_h = direction == MetalLayer::H;
+    const int outer_size = is_h ? y_size : x_size;
+    const int inner_size = is_h ? x_size : y_size;
+    for (int o = 0; o < outer_size; o++) {
+      double last_cap = 0;
+      double last_use = 0;
+      for (int i = 0; i < inner_size; i++) {
+        const int x = is_h ? i : o;
+        const int y = is_h ? o : i;
+        double cap, use;
+        if (i == inner_size - 1) {
+          cap = last_cap;
+          use = last_use;
+        } else {
+          const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
+          const double initial
+              = grid_graph_->getInitialEdgeCapacity(layer, x, y);
+          cap = initial;
+          use = edge.demand + (initial - edge.capacity);
         }
-      }
-    } else {
-      for (int x = 0; x < x_size; x++) {
-        double last_cap = 0;
-        double last_use = 0;
-        for (int y = 0; y < y_size; y++) {
-          double cap, use;
-          if (y == y_size - 1) {
-            cap = last_cap;
-            use = last_use;
-          } else {
-            const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
-            const double initial
-                = grid_graph_->getInitialEdgeCapacity(layer, x, y);
-            cap = initial;
-            use = edge.demand + (initial - edge.capacity);
-          }
-          db_gcell->setCapacity(db_layer, x, y, cap);
-          db_gcell->setUsage(db_layer, x, y, use);
-          last_cap = cap;
-          last_use = use;
-        }
+        db_gcell->setCapacity(db_layer, x, y, cap);
+        db_gcell->setUsage(db_layer, x, y, use);
+        last_cap = cap;
+        last_use = use;
       }
     }
   }
@@ -783,10 +786,9 @@ void CUGR::saveCongestion()
   //   - via_nets:   the nets that own vias whose stub demand commitVia()
   //                 attributes to this edge (the same neighbours commitVia
   //                 itself touches)
-  using EdgeKey = std::tuple<int, int, int>;  // (layer, x, y)
-  std::map<EdgeKey, int> wire_count;
-  std::map<EdgeKey, std::set<odb::dbNet*>> wire_nets;
-  std::map<EdgeKey, std::set<odb::dbNet*>> via_nets;
+  std::unordered_map<EdgeKey, int, EdgeKeyHash> wire_count;
+  std::unordered_map<EdgeKey, std::set<odb::dbNet*>, EdgeKeyHash> wire_nets;
+  std::unordered_map<EdgeKey, std::set<odb::dbNet*>, EdgeKeyHash> via_nets;
 
   auto attribute_via = [&](int via_layer, int vx, int vy, odb::dbNet* db_net) {
     // commitVia(via_layer, loc) adds stub demand on edges adjacent to

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -757,7 +757,7 @@ int CUGR::totalOverflow()
 
 void CUGR::saveCongestion()
 {
-  if (!grid_graph_ || !design_) {
+  if (!grid_graph_ || !design_ || totalOverflow() == 0) {
     return;
   }
 
@@ -765,63 +765,42 @@ void CUGR::saveCongestion()
   const int y_size = grid_graph_->getYSize();
   const int num_layers = grid_graph_->getNumLayers();
 
-  // 2D aggregation per direction. Cell (x, y) for the H map represents
-  // the edge from (x, y) to (x+1, y) summed across all H layers; same
-  // idea for the V map.
-  std::vector<std::vector<int>> h_cap(x_size, std::vector<int>(y_size, 0));
-  std::vector<std::vector<int>> h_usage(x_size, std::vector<int>(y_size, 0));
-  std::vector<std::vector<int>> v_cap(x_size, std::vector<int>(y_size, 0));
-  std::vector<std::vector<int>> v_usage(x_size, std::vector<int>(y_size, 0));
-  for (int l = 0; l < num_layers; l++) {
-    const int dir = grid_graph_->getLayerDirection(l);
-    if (dir == MetalLayer::H) {
-      for (int x = 0; x + 1 < x_size; x++) {
-        for (int y = 0; y < y_size; y++) {
-          const auto& e = grid_graph_->getEdge(l, x, y);
-          h_cap[x][y] += static_cast<int>(std::round(e.capacity));
-          h_usage[x][y] += static_cast<int>(std::round(e.demand));
+  // Walk every routed net's tree to gather per 3D edge (layer, x, y):
+  //   - wire_count: number of same-layer wire segments crossing the edge
+  //   - wire_nets:  the nets that own those wires
+  //   - via_nets:   the nets that own vias whose stub demand commitVia()
+  //                 attributes to this edge (the same neighbours commitVia
+  //                 itself touches)
+  using EdgeKey = std::tuple<int, int, int>;  // (layer, x, y)
+  std::map<EdgeKey, int> wire_count;
+  std::map<EdgeKey, std::set<odb::dbNet*>> wire_nets;
+  std::map<EdgeKey, std::set<odb::dbNet*>> via_nets;
+
+  auto attribute_via = [&](int via_layer, int vx, int vy, odb::dbNet* db_net) {
+    // commitVia(via_layer, loc) adds stub demand on edges adjacent to
+    // (vx, vy) on layers via_layer and via_layer+1, in each layer's
+    // preferred direction. Mirror that to know which nets touched
+    // which edges.
+    for (int l = via_layer; l <= via_layer + 1 && l < num_layers; l++) {
+      const int dir = grid_graph_->getLayerDirection(l);
+      if (dir == MetalLayer::H) {
+        if (vx > 0) {
+          via_nets[{l, vx - 1, vy}].insert(db_net);
+        }
+        if (vx + 1 < x_size) {
+          via_nets[{l, vx, vy}].insert(db_net);
+        }
+      } else {
+        if (vy > 0) {
+          via_nets[{l, vx, vy - 1}].insert(db_net);
+        }
+        if (vy + 1 < y_size) {
+          via_nets[{l, vx, vy}].insert(db_net);
         }
       }
-    } else {
-      for (int x = 0; x < x_size; x++) {
-        for (int y = 0; y + 1 < y_size; y++) {
-          const auto& e = grid_graph_->getEdge(l, x, y);
-          v_cap[x][y] += static_cast<int>(std::round(e.capacity));
-          v_usage[x][y] += static_cast<int>(std::round(e.demand));
-        }
-      }
     }
-  }
+  };
 
-  // Identify congested tiles per direction.
-  if (totalOverflow() == 0) {
-    return;
-  }
-
-  std::vector<std::tuple<int, int, int, int>> congested_h;  // x, y, cap, use
-  std::vector<std::tuple<int, int, int, int>> congested_v;
-  for (int x = 0; x + 1 < x_size; x++) {
-    for (int y = 0; y < y_size; y++) {
-      if (h_usage[x][y] > h_cap[x][y]) {
-        congested_h.emplace_back(x, y, h_cap[x][y], h_usage[x][y]);
-      }
-    }
-  }
-  for (int x = 0; x < x_size; x++) {
-    for (int y = 0; y + 1 < y_size; y++) {
-      if (v_usage[x][y] > v_cap[x][y]) {
-        congested_v.emplace_back(x, y, v_cap[x][y], v_usage[x][y]);
-      }
-    }
-  }
-  if (congested_h.empty() && congested_v.empty()) {
-    return;
-  }
-
-  // Walk every routed net's tree and record which nets cross each
-  // congested 2D tile. Mirrors FastRoute's findCongestedEdgesNets.
-  std::map<std::pair<int, int>, std::set<odb::dbNet*>> h_nets;
-  std::map<std::pair<int, int>, std::set<odb::dbNet*>> v_nets;
   for (const auto& gr_net : gr_nets_) {
     if (!gr_net->getRoutingTree()) {
       continue;
@@ -831,22 +810,31 @@ void CUGR::saveCongestion()
         gr_net->getRoutingTree(),
         [&](const std::shared_ptr<GRTreeNode>& node) {
           for (const auto& child : node->getChildren()) {
-            if (node->getLayerIdx() != child->getLayerIdx()) {
-              continue;
-            }
-            const int dir
-                = grid_graph_->getLayerDirection(node->getLayerIdx());
-            if (dir == MetalLayer::H) {
-              const int y = node->y();
-              const auto [lx, hx] = std::minmax({node->x(), child->x()});
-              for (int x = lx; x < hx; x++) {
-                h_nets[{x, y}].insert(db_net);
+            if (node->getLayerIdx() == child->getLayerIdx()) {
+              const int l = node->getLayerIdx();
+              const int dir = grid_graph_->getLayerDirection(l);
+              if (dir == MetalLayer::H) {
+                const int y = node->y();
+                const auto [lx, hx] = std::minmax({node->x(), child->x()});
+                for (int x = lx; x < hx; x++) {
+                  wire_count[{l, x, y}]++;
+                  wire_nets[{l, x, y}].insert(db_net);
+                }
+              } else {
+                const int x = node->x();
+                const auto [ly, hy] = std::minmax({node->y(), child->y()});
+                for (int y = ly; y < hy; y++) {
+                  wire_count[{l, x, y}]++;
+                  wire_nets[{l, x, y}].insert(db_net);
+                }
               }
             } else {
-              const int x = node->x();
-              const auto [ly, hy] = std::minmax({node->y(), child->y()});
-              for (int y = ly; y < hy; y++) {
-                v_nets[{x, y}].insert(db_net);
+              const int min_l
+                  = std::min(node->getLayerIdx(), child->getLayerIdx());
+              const int max_l
+                  = std::max(node->getLayerIdx(), child->getLayerIdx());
+              for (int via_l = min_l; via_l < max_l; via_l++) {
+                attribute_via(via_l, node->x(), node->y(), db_net);
               }
             }
           }
@@ -857,7 +845,10 @@ void CUGR::saveCongestion()
   odb::dbMarkerCategory* tool_category
       = odb::dbMarkerCategory::createOrReplace(block, "Global route");
   tool_category->setSource("GRT");
+  odb::dbMarkerCategory* h_subcat = nullptr;
+  odb::dbMarkerCategory* v_subcat = nullptr;
 
+  odb::dbTech* tech = db_->getTech();
   const int gridline_size = design_->getGridlineSize();
   auto cell_box = [&](int x, int y) -> odb::Rect {
     const int lx = grid_graph_->getGridline(0, x);
@@ -865,35 +856,73 @@ void CUGR::saveCongestion()
     return {lx, ly, lx + gridline_size, ly + gridline_size};
   };
 
-  auto emit = [&](const char* category_name,
-                  const std::vector<std::tuple<int, int, int, int>>& cells,
-                  const std::map<std::pair<int, int>,
-                                 std::set<odb::dbNet*>>& nets_by_cell) {
-    if (cells.empty()) {
-      return;
-    }
-    odb::dbMarkerCategory* category
-        = odb::dbMarkerCategory::create(tool_category, category_name);
-    for (const auto& [x, y, cap, use] : cells) {
-      odb::dbMarker* marker = odb::dbMarker::create(category);
-      if (marker == nullptr) {
-        continue;
-      }
-      marker->addShape(cell_box(x, y));
-      marker->setComment("capacity:" + std::to_string(cap)
-                         + " usage:" + std::to_string(use)
-                         + " overflow:" + std::to_string(use - cap));
-      auto it = nets_by_cell.find({x, y});
-      if (it != nets_by_cell.end()) {
-        for (odb::dbNet* net : it->second) {
+  // Emit one marker per congested 3D edge, tagged with its routing
+  // layer. Comment carries capacity/usage/overflow and the source of
+  // the overflow (wire segments, via stubs, or both).
+  for (int l = 0; l < num_layers; l++) {
+    const int direction = grid_graph_->getLayerDirection(l);
+    odb::dbTechLayer* db_layer = tech->findRoutingLayer(l + 1);
+    const int x_max = (direction == MetalLayer::H) ? x_size - 1 : x_size;
+    const int y_max = (direction == MetalLayer::H) ? y_size : y_size - 1;
+    for (int x = 0; x < x_max; x++) {
+      for (int y = 0; y < y_max; y++) {
+        const GraphEdge& e = grid_graph_->getEdge(l, x, y);
+        const double cap = std::max(e.capacity, 0.0);
+        const double demand = e.demand;
+        if (demand <= cap) {
+          continue;
+        }
+        const int cap_int = static_cast<int>(std::round(cap));
+        const int demand_int = static_cast<int>(std::round(demand));
+        const int overflow_int = demand_int - cap_int;
+        if (overflow_int <= 0) {
+          continue;
+        }
+
+        const auto wc_it = wire_count.find({l, x, y});
+        const int wires = wc_it != wire_count.end() ? wc_it->second : 0;
+        const bool wires_overflow = static_cast<double>(wires) > cap;
+        const bool vias_contribute = (demand - wires) > 0;
+        const char* kind = wires_overflow
+                               ? (vias_contribute ? "wires + vias" : "wires")
+                               : "vias";
+
+        odb::dbMarkerCategory*& subcat
+            = direction == MetalLayer::H ? h_subcat : v_subcat;
+        if (subcat == nullptr) {
+          subcat = odb::dbMarkerCategory::create(
+              tool_category,
+              direction == MetalLayer::H ? "Horizontal congestion"
+                                         : "Vertical congestion");
+        }
+        odb::dbMarker* marker = odb::dbMarker::create(subcat);
+        if (marker == nullptr) {
+          continue;
+        }
+        marker->addShape(cell_box(x, y));
+        if (db_layer != nullptr) {
+          marker->setTechLayer(db_layer);
+        }
+        marker->setComment("capacity:" + std::to_string(cap_int)
+                           + " usage:" + std::to_string(demand_int)
+                           + " overflow:" + std::to_string(overflow_int)
+                           + " (" + kind + ")");
+
+        std::set<odb::dbNet*> sources;
+        auto wn_it = wire_nets.find({l, x, y});
+        if (wn_it != wire_nets.end()) {
+          sources.insert(wn_it->second.begin(), wn_it->second.end());
+        }
+        auto vn_it = via_nets.find({l, x, y});
+        if (vn_it != via_nets.end()) {
+          sources.insert(vn_it->second.begin(), vn_it->second.end());
+        }
+        for (odb::dbNet* net : sources) {
           marker->addSource(net);
         }
       }
     }
-  };
-
-  emit("Horizontal congestion", congested_h, h_nets);
-  emit("Vertical congestion", congested_v, v_nets);
+  }
 }
 
 void CUGR::routeIncremental()

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -583,11 +583,55 @@ void CUGR::updateDbCongestion()
       continue;
     }
 
-    for (int y = 0; y < y_size; y++) {
+    // Write per-cell capacity/usage matching FastRoute's semantics:
+    //   capacity = original (pre-blockage, pre-adjustment) track count
+    //   usage    = routing demand + lost capacity (blockage + adjustment)
+    // Boundary cells without a corresponding edge replicate the previous
+    // cell's value, again matching FastRoute's last_cell_cap fall-through.
+    const int direction = grid_graph_->getLayerDirection(layer);
+    if (direction == MetalLayer::H) {
+      for (int y = 0; y < y_size; y++) {
+        float last_cap = 0;
+        float last_use = 0;
+        for (int x = 0; x < x_size; x++) {
+          float cap, use;
+          if (x == x_size - 1) {
+            cap = last_cap;
+            use = last_use;
+          } else {
+            const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
+            const float initial = grid_graph_->getInitialEdgeCapacity(
+                layer, x, y);
+            cap = initial;
+            use = edge.demand + (initial - edge.capacity);
+          }
+          db_gcell->setCapacity(db_layer, x, y, cap);
+          db_gcell->setUsage(db_layer, x, y, use);
+          last_cap = cap;
+          last_use = use;
+        }
+      }
+    } else {
       for (int x = 0; x < x_size; x++) {
-        const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
-        db_gcell->setCapacity(db_layer, x, y, edge.capacity);
-        db_gcell->setUsage(db_layer, x, y, edge.demand);
+        float last_cap = 0;
+        float last_use = 0;
+        for (int y = 0; y < y_size; y++) {
+          float cap, use;
+          if (y == y_size - 1) {
+            cap = last_cap;
+            use = last_use;
+          } else {
+            const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
+            const float initial = grid_graph_->getInitialEdgeCapacity(
+                layer, x, y);
+            cap = initial;
+            use = edge.demand + (initial - edge.capacity);
+          }
+          db_gcell->setCapacity(db_layer, x, y, cap);
+          db_gcell->setUsage(db_layer, x, y, use);
+          last_cap = cap;
+          last_use = use;
+        }
       }
     }
   }
@@ -696,6 +740,156 @@ const std::vector<int>& CUGR::getMaxHorizontalOverflows() const
 const std::vector<int>& CUGR::getMaxVerticalOverflows() const
 {
   return grid_graph_->getMaxVerticalOverflows();
+}
+
+int CUGR::totalOverflow()
+{
+  if (!grid_graph_) {
+    return 0;
+  }
+  grid_graph_->computeCongestionInformation();
+  int total = 0;
+  for (int layer_overflow : grid_graph_->getTotalOverflowPerLayer()) {
+    total += layer_overflow;
+  }
+  return total;
+}
+
+void CUGR::saveCongestion()
+{
+  if (!grid_graph_ || !design_) {
+    return;
+  }
+
+  const int x_size = grid_graph_->getXSize();
+  const int y_size = grid_graph_->getYSize();
+  const int num_layers = grid_graph_->getNumLayers();
+
+  // 2D aggregation per direction. Cell (x, y) for the H map represents
+  // the edge from (x, y) to (x+1, y) summed across all H layers; same
+  // idea for the V map.
+  std::vector<std::vector<int>> h_cap(x_size, std::vector<int>(y_size, 0));
+  std::vector<std::vector<int>> h_usage(x_size, std::vector<int>(y_size, 0));
+  std::vector<std::vector<int>> v_cap(x_size, std::vector<int>(y_size, 0));
+  std::vector<std::vector<int>> v_usage(x_size, std::vector<int>(y_size, 0));
+  for (int l = 0; l < num_layers; l++) {
+    const int dir = grid_graph_->getLayerDirection(l);
+    if (dir == MetalLayer::H) {
+      for (int x = 0; x + 1 < x_size; x++) {
+        for (int y = 0; y < y_size; y++) {
+          const auto& e = grid_graph_->getEdge(l, x, y);
+          h_cap[x][y] += static_cast<int>(std::round(e.capacity));
+          h_usage[x][y] += static_cast<int>(std::round(e.demand));
+        }
+      }
+    } else {
+      for (int x = 0; x < x_size; x++) {
+        for (int y = 0; y + 1 < y_size; y++) {
+          const auto& e = grid_graph_->getEdge(l, x, y);
+          v_cap[x][y] += static_cast<int>(std::round(e.capacity));
+          v_usage[x][y] += static_cast<int>(std::round(e.demand));
+        }
+      }
+    }
+  }
+
+  // Identify congested tiles per direction.
+  std::vector<std::tuple<int, int, int, int>> congested_h;  // x, y, cap, use
+  std::vector<std::tuple<int, int, int, int>> congested_v;
+  for (int x = 0; x + 1 < x_size; x++) {
+    for (int y = 0; y < y_size; y++) {
+      if (h_usage[x][y] > h_cap[x][y]) {
+        congested_h.emplace_back(x, y, h_cap[x][y], h_usage[x][y]);
+      }
+    }
+  }
+  for (int x = 0; x < x_size; x++) {
+    for (int y = 0; y + 1 < y_size; y++) {
+      if (v_usage[x][y] > v_cap[x][y]) {
+        congested_v.emplace_back(x, y, v_cap[x][y], v_usage[x][y]);
+      }
+    }
+  }
+  if (congested_h.empty() && congested_v.empty()) {
+    return;
+  }
+
+  // Walk every routed net's tree and record which nets cross each
+  // congested 2D tile. Mirrors FastRoute's findCongestedEdgesNets.
+  std::map<std::pair<int, int>, std::set<odb::dbNet*>> h_nets;
+  std::map<std::pair<int, int>, std::set<odb::dbNet*>> v_nets;
+  for (const auto& gr_net : gr_nets_) {
+    if (!gr_net->getRoutingTree()) {
+      continue;
+    }
+    odb::dbNet* db_net = gr_net->getDbNet();
+    GRTreeNode::preorder(
+        gr_net->getRoutingTree(),
+        [&](const std::shared_ptr<GRTreeNode>& node) {
+          for (const auto& child : node->getChildren()) {
+            if (node->getLayerIdx() != child->getLayerIdx()) {
+              continue;
+            }
+            const int dir
+                = grid_graph_->getLayerDirection(node->getLayerIdx());
+            if (dir == MetalLayer::H) {
+              const int y = node->y();
+              const auto [lx, hx] = std::minmax({node->x(), child->x()});
+              for (int x = lx; x < hx; x++) {
+                h_nets[{x, y}].insert(db_net);
+              }
+            } else {
+              const int x = node->x();
+              const auto [ly, hy] = std::minmax({node->y(), child->y()});
+              for (int y = ly; y < hy; y++) {
+                v_nets[{x, y}].insert(db_net);
+              }
+            }
+          }
+        });
+  }
+
+  odb::dbBlock* block = db_->getChip()->getBlock();
+  odb::dbMarkerCategory* tool_category
+      = odb::dbMarkerCategory::createOrReplace(block, "Global route");
+  tool_category->setSource("GRT");
+
+  const int gridline_size = design_->getGridlineSize();
+  auto cell_box = [&](int x, int y) -> odb::Rect {
+    const int lx = grid_graph_->getGridline(0, x);
+    const int ly = grid_graph_->getGridline(1, y);
+    return {lx, ly, lx + gridline_size, ly + gridline_size};
+  };
+
+  auto emit = [&](const char* category_name,
+                  const std::vector<std::tuple<int, int, int, int>>& cells,
+                  const std::map<std::pair<int, int>,
+                                 std::set<odb::dbNet*>>& nets_by_cell) {
+    if (cells.empty()) {
+      return;
+    }
+    odb::dbMarkerCategory* category
+        = odb::dbMarkerCategory::create(tool_category, category_name);
+    for (const auto& [x, y, cap, use] : cells) {
+      odb::dbMarker* marker = odb::dbMarker::create(category);
+      if (marker == nullptr) {
+        continue;
+      }
+      marker->addShape(cell_box(x, y));
+      marker->setComment("capacity:" + std::to_string(cap)
+                         + " usage:" + std::to_string(use)
+                         + " overflow:" + std::to_string(use - cap));
+      auto it = nets_by_cell.find({x, y});
+      if (it != nets_by_cell.end()) {
+        for (odb::dbNet* net : it->second) {
+          marker->addSource(net);
+        }
+      }
+    }
+  };
+
+  emit("Horizontal congestion", congested_h, h_nets);
+  emit("Vertical congestion", congested_v, v_nets);
 }
 
 void CUGR::routeIncremental()

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -591,17 +591,17 @@ void CUGR::updateDbCongestion()
     const int direction = grid_graph_->getLayerDirection(layer);
     if (direction == MetalLayer::H) {
       for (int y = 0; y < y_size; y++) {
-        float last_cap = 0;
-        float last_use = 0;
+        double last_cap = 0;
+        double last_use = 0;
         for (int x = 0; x < x_size; x++) {
-          float cap, use;
+          double cap, use;
           if (x == x_size - 1) {
             cap = last_cap;
             use = last_use;
           } else {
             const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
-            const float initial = grid_graph_->getInitialEdgeCapacity(
-                layer, x, y);
+            const double initial
+                = grid_graph_->getInitialEdgeCapacity(layer, x, y);
             cap = initial;
             use = edge.demand + (initial - edge.capacity);
           }
@@ -613,17 +613,17 @@ void CUGR::updateDbCongestion()
       }
     } else {
       for (int x = 0; x < x_size; x++) {
-        float last_cap = 0;
-        float last_use = 0;
+        double last_cap = 0;
+        double last_use = 0;
         for (int y = 0; y < y_size; y++) {
-          float cap, use;
+          double cap, use;
           if (y == y_size - 1) {
             cap = last_cap;
             use = last_use;
           } else {
             const GraphEdge& edge = grid_graph_->getEdge(layer, x, y);
-            const float initial = grid_graph_->getInitialEdgeCapacity(
-                layer, x, y);
+            const double initial
+                = grid_graph_->getInitialEdgeCapacity(layer, x, y);
             cap = initial;
             use = edge.demand + (initial - edge.capacity);
           }
@@ -794,6 +794,10 @@ void CUGR::saveCongestion()
   }
 
   // Identify congested tiles per direction.
+  if (totalOverflow() == 0) {
+    return;
+  }
+
   std::vector<std::tuple<int, int, int, int>> congested_h;  // x, y, cap, use
   std::vector<std::tuple<int, int, int, int>> congested_v;
   for (int x = 0; x + 1 < x_size; x++) {

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -757,7 +757,19 @@ int CUGR::totalOverflow()
 
 void CUGR::saveCongestion()
 {
-  if (!grid_graph_ || !design_ || totalOverflow() == 0) {
+  if (!grid_graph_ || !design_) {
+    return;
+  }
+
+  // Always start from a fresh "Global route" tree so that stale markers
+  // from a previous routing pass don't linger in the GUI / .rpt when the
+  // current pass has no overflow.
+  odb::dbBlock* block = db_->getChip()->getBlock();
+  odb::dbMarkerCategory* tool_category
+      = odb::dbMarkerCategory::createOrReplace(block, "Global route");
+  tool_category->setSource("GRT");
+
+  if (totalOverflow() == 0) {
     return;
   }
 
@@ -840,10 +852,6 @@ void CUGR::saveCongestion()
         });
   }
 
-  odb::dbBlock* block = db_->getChip()->getBlock();
-  odb::dbMarkerCategory* tool_category
-      = odb::dbMarkerCategory::createOrReplace(block, "Global route");
-  tool_category->setSource("GRT");
   odb::dbMarkerCategory* h_subcat = nullptr;
   odb::dbMarkerCategory* v_subcat = nullptr;
 

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -270,6 +270,11 @@ GridGraph::GridGraph(const Design* design,
 
 void GridGraph::computeCongestionInformation()
 {
+  if (!congestion_info_dirty_) {
+    return;
+  }
+  congestion_info_dirty_ = false;
+
   cap_per_layer_.assign(num_layers_, 0);
   usage_per_layer_.assign(num_layers_, 0);
   overflow_per_layer_.assign(num_layers_, 0);
@@ -647,6 +652,7 @@ void GridGraph::commit(const int layer_index,
                        const CapacityT demand)
 {
   graph_edges_[layer_index][lower.x()][lower.y()].demand += demand;
+  congestion_info_dirty_ = true;
 }
 
 void GridGraph::commitWire(const int layer_index,

--- a/src/grt/src/cugr/src/GridGraph.h
+++ b/src/grt/src/cugr/src/GridGraph.h
@@ -244,12 +244,16 @@ class GridGraph
   // resource reporting so that the report can show the reduction from
   // user adjustments analogous to FastRoute's real_cap vs cap.
   std::vector<int> original_resources_per_layer_;
-  // Per-layer caches populated by computeCongestionInformation().
+  // Per-layer caches populated by computeCongestionInformation(). Kept
+  // valid by congestion_info_dirty_: any commit() that mutates demand
+  // marks the caches stale, so the next computeCongestionInformation()
+  // refreshes them; otherwise it returns immediately.
   std::vector<int> cap_per_layer_;
   std::vector<int> usage_per_layer_;
   std::vector<int> overflow_per_layer_;
   std::vector<int> max_h_overflow_;
   std::vector<int> max_v_overflow_;
+  bool congestion_info_dirty_ = true;
   const Constants constants_;
 };
 

--- a/src/grt/src/fastroute/src/utility.cpp
+++ b/src/grt/src/fastroute/src/utility.cpp
@@ -2798,19 +2798,18 @@ void FastRouteCore::saveCongestion(const int iter)
     }
   }
 
-  // check if the file name is defined
-  if (congestion_file_name_.empty()) {
+  // The final-report file-write (iter == -1) is handled in
+  // GlobalRouter::saveCongestion so both routing engines share the
+  // same code path. Per-iteration reports stay here because only
+  // FastRoute knows the current iteration index.
+  if (iter == -1 || congestion_file_name_.empty()) {
     return;
   }
 
-  // Modify the file name for each iteration
+  // delete rpt extension and add iteration number
   std::string file_name = congestion_file_name_;
-  if (iter != -1) {
-    // delete rpt extension
-    file_name = file_name.substr(0, file_name.size() - 4);
-    // add iteration number
-    file_name += "-" + std::to_string(iter) + ".rpt";
-  }
+  file_name = file_name.substr(0, file_name.size() - 4);
+  file_name += "-" + std::to_string(iter) + ".rpt";
 
   odb::dbMarkerCategory* tool_category
       = db_->getChip()->getBlock()->findMarkerCategory(

--- a/src/grt/test/BUILD
+++ b/src/grt/test/BUILD
@@ -171,6 +171,20 @@ regression_test(
     data = [":test_resources"],
 )
 
+regression_test(
+    name = "congestion_markers_cugr",
+    check_log = False,
+    check_passfail = True,
+    data = [":test_resources"],
+)
+
+regression_test(
+    name = "congestion_report_file_cugr",
+    check_log = False,
+    check_passfail = True,
+    data = [":test_resources"],
+)
+
 py_test(
     name = "grt_man_tcl_check",
     srcs = ["grt_man_tcl_check.py"],

--- a/src/grt/test/CMakeLists.txt
+++ b/src/grt/test/CMakeLists.txt
@@ -101,6 +101,8 @@ or_integration_tests(
     write_segments1
     write_segments2
   PASSFAIL_TESTS
+    congestion_markers_cugr
+    congestion_report_file_cugr
     snapshot_batched_bus_route
     snapshot_batched_incremental_state
     snapshot_batched_smoke

--- a/src/grt/test/congestion_markers_cugr.tcl
+++ b/src/grt/test/congestion_markers_cugr.tcl
@@ -1,0 +1,79 @@
+# Verify that running CUGR on a heavily-adjusted design populates the
+# "Global route" -> "Horizontal/Vertical congestion" dbMarkerCategory tree
+# with markers that are layer-tagged, carry the
+# "capacity:N usage:M overflow:K (wires|vias|wires + vias)" comment
+# format, and list at least one source net.
+source "helpers.tcl"
+read_lef "Nangate45/Nangate45.lef"
+read_def "gcd.def"
+
+set_global_routing_layer_adjustment metal1-metal10 0.9
+
+global_route -use_cugr -verbose
+
+set block [ord::get_db_block]
+
+set tool_category ""
+foreach cat [$block getMarkerCategories] {
+  if { [$cat getName] == "Global route" } {
+    set tool_category $cat
+  }
+}
+
+check "Global route marker category exists" {
+  expr { $tool_category != "" }
+} 1
+
+set subcat_names {}
+set total_markers 0
+set markers_with_sources 0
+set markers_with_comment 0
+set markers_with_layer 0
+
+if { $tool_category != "" } {
+  foreach sub [$tool_category getMarkerCategories] {
+    lappend subcat_names [$sub getName]
+    foreach marker [$sub getMarkers] {
+      incr total_markers
+      if { [llength [$marker getSources]] > 0 } {
+        incr markers_with_sources
+      }
+      if { [regexp \
+              {capacity:[0-9]+ usage:[0-9]+ overflow:-?[0-9]+ \((wires|vias|wires \+ vias)\)} \
+              [$marker getComment]] } {
+        incr markers_with_comment
+      }
+      if { [$marker getTechLayer] != "NULL" } {
+        incr markers_with_layer
+      }
+    }
+  }
+}
+
+check "Only H/V congestion subcategories are created" {
+  set valid 1
+  foreach name $subcat_names {
+    if { $name != "Horizontal congestion" && $name != "Vertical congestion" } {
+      set valid 0
+    }
+  }
+  expr { $valid }
+} 1
+
+check "Marker tree is non-empty" {
+  expr { $total_markers > 0 }
+} 1
+
+check "Every marker comment matches capacity/usage/overflow (kind) format" {
+  expr { $markers_with_comment == $total_markers }
+} 1
+
+check "Every marker is tagged with a tech layer" {
+  expr { $markers_with_layer == $total_markers }
+} 1
+
+check "Every marker has at least one source net" {
+  expr { $markers_with_sources == $total_markers }
+} 1
+
+exit_summary

--- a/src/grt/test/congestion_markers_cugr.tcl
+++ b/src/grt/test/congestion_markers_cugr.tcl
@@ -38,9 +38,11 @@ if { $tool_category != "" } {
       if { [llength [$marker getSources]] > 0 } {
         incr markers_with_sources
       }
-      if { [regexp \
-              {capacity:[0-9]+ usage:[0-9]+ overflow:-?[0-9]+ \((wires|vias|wires \+ vias)\)} \
-              [$marker getComment]] } {
+      if {
+        [regexp \
+          {capacity:[0-9]+ usage:[0-9]+ overflow:-?[0-9]+ \((wires|vias|wires \+ vias)\)} \
+          [$marker getComment]]
+      } {
         incr markers_with_comment
       }
       if { [$marker getTechLayer] != "NULL" } {

--- a/src/grt/test/congestion_report_file_cugr.tcl
+++ b/src/grt/test/congestion_report_file_cugr.tcl
@@ -1,0 +1,28 @@
+# Verify that -congestion_report_file is honored when CUGR is the
+# routing engine. The file must be written and contain the TR-format
+# marker dump that the DRC viewer can re-load.
+source "helpers.tcl"
+read_lef "Nangate45/Nangate45.lef"
+read_def "gcd.def"
+
+set rpt_file [make_result_file "congestion_report_file_cugr.rpt"]
+set_global_routing_layer_adjustment metal1-metal10 0.9
+
+global_route -use_cugr -verbose -congestion_report_file $rpt_file
+
+check "Congestion report file was written" {
+  expr { [file exists $rpt_file] }
+} 1
+
+check "Congestion report file is non-empty" {
+  expr { [file size $rpt_file] > 0 }
+} 1
+
+check "Congestion report file contains TR-format marker entries" {
+  set fh [open $rpt_file r]
+  set content [read $fh]
+  close $fh
+  expr { [string first "violation type:" $content] >= 0 }
+} 1
+
+exit_summary

--- a/src/grt/test/critical_nets_percentage_cugr.ok
+++ b/src/grt/test/critical_nets_percentage_cugr.ok
@@ -64,4 +64,5 @@ Total            42591          2903            6.82%             4 /  3 / 401
 
 [INFO GRT-0018] Total wirelength: 23868 um
 [INFO GRT-0014] Routed nets: 348
+[WARNING GRT-0115] Global routing finished with congestion. Check the congestion regions in the DRC Viewer.
 No differences found.

--- a/src/grt/test/cugr_adjustment3.ok
+++ b/src/grt/test/cugr_adjustment3.ok
@@ -75,4 +75,5 @@ Total            11630          2520           21.67%             3 /  4 / 481
 
 [INFO GRT-0018] Total wirelength: 10716 um
 [INFO GRT-0014] Routed nets: 563
+[WARNING GRT-0115] Global routing finished with congestion. Check the congestion regions in the DRC Viewer.
 No differences found.

--- a/src/grt/test/pin_access2_cugr.ok
+++ b/src/grt/test/pin_access2_cugr.ok
@@ -97,4 +97,5 @@ Total            53204          3854            7.24%             1 /  0 /  2
 
 [INFO GRT-0018] Total wirelength: 31082 um
 [INFO GRT-0014] Routed nets: 411
+[WARNING GRT-0115] Global routing finished with congestion. Check the congestion regions in the DRC Viewer.
 No differences found.


### PR DESCRIPTION
## Summary

Persists CUGR congestion to ODB so the GUI's DRC viewer, the heatmap and the `-congestion_report_file` flag all work the same way under CUGR as they do under FastRoute.

- **DRC markers**: new `CUGR::saveCongestion` walks each routed net's `GRTreeNode` tree to build per-3D-edge wire counts and per-edge via-source attribution, then emits one `dbMarker` per congested 3D edge under `"Global route" → "Horizontal congestion" / "Vertical congestion"`. Each marker is tagged with the routing layer and its comment classifies the source of the overflow as `(wires)`, `(vias)` or `(wires + vias)`. Sources are the union of nets whose wires cross the edge and nets whose adjacent vias commit stub demand to it.
- **Heatmap parity**: `CUGR::updateDbCongestion` rewritten to mirror FastRoute's `dbGCellGrid` semantics — `capacity` is the original (pre-blockage, pre-adjustment) track count, `usage` is `demand + (initial − current_capacity)`, and rightmost-column / topmost-row cells inherit the previous edge's value the same way FastRoute's `last_cell_cap_h/v` fall-through does.
- **`is_congested_` dispatch + warning-vs-error**: `GlobalRouter::saveCongestion` branches on `use_cugr_` and now correctly sets `is_congested_` via `cugr_->totalOverflow()`; the GRT-0116 error path is downgraded to GRT-0115 warning for CUGR runs (matches the existing `-allow_congestion` behaviour) since empirical results from DRT prefer CUGR's congested routes over zero-overflow FastRoute runs.
- **`-congestion_report_file` honored**: the final-report file write (was duplicated inside `FastRouteCore::saveCongestion` for `iter == -1`) moved up to `GlobalRouter::saveCongestion`, so both engines now write the file through the same `dbMarkerCategory::writeTR` path. FastRoute's per-iteration `.rpt` writes stay where they are (they own the iteration counter).

## Type of Change

- New feature
- Bug fix

## Impact

- CUGR congested runs now populate the `"Global route"` `dbMarkerCategory` tree, so the GUI DRC viewer shows hotspots layer-by-layer with per-edge `capacity:.. usage:.. overflow:.. (wires/vias/wires + vias)` comments and contributing nets — previously empty for CUGR.
- `dbGCellGrid` capacity/usage values written by CUGR now match FastRoute's semantics; the routing heatmap renders identically for both engines (boundary cells included, blockage / user-adjustment reductions visible).
- `-congestion_report_file <name>.rpt` works under `-use_cugr`; previously the flag was silently dropped.
- CUGR runs that finish with overflow now correctly produce GRT-0115 (warning) and mark `is_congested_=true` instead of silently passing as clean.
- No FastRoute-side behavior changes; existing FastRoute goldens (including `congestion7` final + per-iter `.rpt`) are untouched.

## Verification

- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**