### PR TITLE
chore: add CODEOWNERS and SECURITY.md for project governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,34 @@
+# CODEOWNERS — auto-request reviewers based on file paths
+# See: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default for everything
+* @The-OpenROAD-Project/maintainers
+
+# Build system
+/BUILD @The-OpenROAD-Project/maintainers
+/*.bazel @The-OpenROAD-Project/maintainers
+/MODULE.bazel @The-OpenROAD-Project/maintainers
+/cmake/ @The-OpenROAD-Project/maintainers
+
+# CI/CD
+/.github/workflows/ @The-OpenROAD-Project/maintainers
+/jenkins/ @The-OpenROAD-Project/maintainers
+
+# Core database
+/src/odb/ @The-OpenROAD-Project/maintainers
+
+# Web interface (security-sensitive)
+/src/web/ @The-OpenROAD-Project/maintainers
+
+# Documentation
+/doc/ @The-OpenROAD-Project/maintainers
+
+# Tests
+/test/ @The-OpenROAD-Project/maintainers
+
+# Packaging & Docker
+/packaging/ @The-OpenROAD-Project/maintainers
+/Dockerfile @The-OpenROAD-Project/maintainers
+
+# Supply chain (security-sensitive)
+/etc/DependencyInstaller.sh @The-OpenROAD-Project/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,7 +21,7 @@
 /src/web/ @The-OpenROAD-Project/maintainers
 
 # Documentation
-/doc/ @The-OpenROAD-Project/maintainers
+/docs/ @The-OpenROAD-Project/maintainers
 
 # Tests
 /test/ @The-OpenROAD-Project/maintainers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,14 @@
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in OpenROAD, please do NOT open a public GitHub issue.
-Instead, send details to the OpenROAD maintainers through the project's communication channels.
+Instead, report it privately using one of these methods:
+
+1. **GitHub Private Vulnerability Reporting** (recommended):
+   Use the "Report a vulnerability" button under the repository's Security tab.
+   This creates a private advisory that only maintainers can see.
+
+2. **Email**: Send details to the OpenROAD maintainers through the project's
+   communication channels listed in the repository description.
 
 ### What we need from you
 
@@ -22,9 +29,9 @@ Instead, send details to the OpenROAD maintainers through the project's communic
 
 | Version | Supported |
 |---------|-----------|
-| master  | ✅ Active development |
-| latest release | ✅ Security patches |
-| older releases | ❌ No support |
+| master  | Active development |
+| latest release | Security patches |
+| older releases | No support |
 
 ## Disclosure Policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenROAD, please do NOT open a public GitHub issue.
+Instead, send details to the OpenROAD maintainers through the project's communication channels.
+
+### What we need from you
+
+- A clear description of the vulnerability
+- Steps to reproduce (or proof-of-concept code)
+- Affected versions and components
+- Any suggested fix (optional)
+
+### What to expect
+
+- Acknowledgment within 5 business days
+- A timeline for triage and fix
+- Credit in release notes (unless you prefer anonymity)
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| master  | ✅ Active development |
+| latest release | ✅ Security patches |
+| older releases | ❌ No support |
+
+## Disclosure Policy
+
+We follow coordinated disclosure:
+
+1. Fix prepared internally or via PR
+2. Embargo period for users to patch
+3. Public disclosure with CVE assignment
+
+## Scope
+
+Security issues include, but are not limited to:
+
+- Remote code execution in any interface or component
+- Supply chain integrity (e.g., compromised dependencies)
+- Unauthorized access to design data
+- Memory corruption vulnerabilities
+- Denial of service via crafted input
+
+Non-security bugs should be filed as regular GitHub issues.


### PR DESCRIPTION
## Summary

Two governance files were missing:

1. **\.github/CODEOWNERS\** — auto-requests reviewers based on file paths
2. **\SECURITY.md\** — documents vulnerability disclosure policy

Neither file affects compilation, tests, or runtime behavior.

## Why

### CODEOWNERS
Security-critical directories (\src/web/\, \tc/\, \.github/workflows/\) have no auto-assigned reviewers.

### SECURITY.md
When a researcher discovers a vulnerability, there is no documented contact method (\curl\ to \SECURITY.md\ returns 404). This blocks responsible disclosure.

## Changes

| File | Purpose |
|------|---------|
| \.github/CODEOWNERS\ | Auto-assign reviewers by path pattern |
| \SECURITY.md\ | Vulnerability reporting process