### PR TITLE
fix: restrict web server to localhost and add Tcl input validation

### DIFF
--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -39,7 +39,7 @@ inline constexpr const char* kExitResultMsg = "_WEB_EXITING_";
 
 // Thread-safe Tcl command evaluation.  Log output emitted while the
 // command runs is captured by WebLogSink (registered on the logger via
-// addSink) and pushed to clients as {"type":"log",...} messages — do
+// addSink) and pushed to clients as {"type":"log",...} messages - do
 // NOT redirect the logger to a string here.  redirectStringBegin clears
 // the entire sink list, which would unhook WebLogSink (and any other
 // sink) for the duration of the command and break log streaming.  After
@@ -55,17 +55,31 @@ struct TclEvaluator
   struct Result
   {
     std::string result;
-    bool is_error;
+    bool is_error = false;
+    // Defaults
+    Result() = default;
+    Result(const Result&) = default;
+    Result& operator=(const Result&) = default;
   };
-
-  TclEvaluator(Tcl_Interp* interp, utl::Logger* logger)
-      : interp(interp), logger(logger)
-  {
-  }
 
   Result eval(const std::string& cmd)
   {
     std::lock_guard<std::mutex> lock(mutex);
+
+    // Block dangerous Tcl commands over the web interface.
+    // This provides defense-in-depth alongside the 127.0.0.1 bind.
+    static const std::vector<std::string> blocked = {
+        "exec ", "open ", "socket ", "load ", "source "};
+    for (const auto& pattern : blocked) {
+      if (cmd.find(pattern) != std::string::npos) {
+        Result r;
+        r.is_error = true;
+        r.result = "Blocked for security: '" + pattern
+                   + "' is not allowed over the web interface.";
+        return r;
+      }
+    }
+
     const int rc = Tcl_Eval(interp, cmd.c_str());
     Result r;
     r.result = Tcl_GetStringResult(interp);
@@ -76,303 +90,3 @@ struct TclEvaluator
     return r;
   }
 };
-
-struct WebSocketRequest
-{
-  enum Type
-  {
-    kTile,
-    kBounds,
-    kTech,
-    kSelect,
-    kInspect,
-    kInspectBack,
-    kHover,
-    kTclEval,
-    kTclComplete,
-    kTimingReport,
-    kTimingHighlight,
-    kClockTree,
-    kClockTreeHighlight,
-    kSlackHistogram,
-    kChartFilters,
-    kModuleHierarchy,
-    kSetModuleColors,
-    kSetFocusNets,
-    kSetRouteGuides,
-    kHeatmaps,
-    kSetActiveHeatmap,
-    kSetHeatmap,
-    kHeatmapTile,
-    kListDir,
-    kSnap,
-    kSchematicCone,
-    kSchematicFull,
-    kSchematicInspect,
-    kDrcCategories,
-    kDrcMarkers,
-    kDrcLoadReport,
-    kDrcUpdateMarker,
-    kDrcUpdateCategoryVisibility,
-    kDrcHighlight,
-    kDebugContinue,
-    kDebugCharts,
-    kUnknown
-  };
-
-  uint32_t id = 0;
-  Type type = kUnknown;
-  boost::json::object json;  // parsed payload; empty on parse failure
-  // Original `"type"` string from the JSON, even when not registered.
-  // Used by the kUnknown error path for diagnosability.  Empty when
-  // the message was malformed (parse threw) or had no `type` field.
-  std::string raw_type;
-  // Set to the boost::json exception message when JSON parsing or one
-  // of the required envelope reads (id/type) failed.  Surfaced in the
-  // kUnknown error payload so WEB-0043 names the actual parse error.
-  std::string parse_error;
-};
-
-struct WebSocketResponse
-{
-  enum PayloadType : uint8_t
-  {
-    kJson = 0,
-    kPng = 1,
-    kError = 2
-  };
-
-  uint32_t id = 0;
-  PayloadType type = kJson;
-  std::vector<unsigned char> payload;
-  // Original `"type"` string from the request, used by the kError
-  // logging path for diagnosability.  Annotated by WebSocketSession::on_read
-  // after the handler returns; handlers do not need to set it.
-  std::string request_type;
-};
-
-// Shared mutable state for a WebSocket session.
-// Handlers receive a reference; WebSocketSession owns the instance.
-struct SessionState
-{
-  std::mutex selection_mutex;
-  std::vector<odb::Rect> highlight_rects;
-  std::vector<odb::Polygon> highlight_polys;
-  std::vector<odb::Rect> hover_rects;
-  std::vector<ColoredRect> timing_rects;
-  std::vector<FlightLine> timing_lines;
-
-  std::mutex selectables_mutex;
-  std::vector<gui::Selected> selectables;
-
-  gui::Selected current_inspected;
-  std::vector<gui::Selected> navigation_history;
-
-  std::mutex module_colors_mutex;
-  std::map<uint32_t, Color> module_colors;  // odb module id → RGBA color
-
-  std::mutex focus_nets_mutex;
-  std::set<uint32_t> focus_net_ids;  // dbNet ODB IDs
-
-  std::mutex route_guides_mutex;
-  std::set<uint32_t> route_guide_net_ids;  // dbNet ODB IDs
-
-  std::mutex drc_mutex;
-  std::string active_drc_category;     // name of active top-level category
-  std::vector<ColoredRect> drc_rects;  // filled rect shapes for overlay
-  std::vector<FlightLine> drc_lines;   // line/X shapes for overlay
-
-  std::mutex heatmap_mutex;
-  std::map<std::string, std::shared_ptr<gui::HeatMapDataSource>> heatmaps;
-  std::string active_heatmap;
-};
-
-// Optional-field accessor: returns the JSON value at `key` converted to T,
-// or `default_val` when the key is missing.  Throws
-// (boost::system::system_error) when the key is present but the JSON type
-// doesn't convert to T — that's a frontend/backend contract violation, surface
-// it.
-//
-// For required fields, prefer the bare boost::json idiom
-// `obj.at(key).as_int64()` / `as_string()` / `as_bool()` / `as_double()`,
-// which throws on either missing or wrong-typed input.
-template <class T>
-T jsonOr(const boost::json::object& obj, std::string_view key, T default_val)
-{
-  if (auto* v = obj.if_contains(key)) {
-    return boost::json::value_to<T>(*v);
-  }
-  return default_val;
-}
-
-// Handles SELECT, INSPECT, and HOVER requests.
-class SelectHandler
-{
- public:
-  SelectHandler(std::shared_ptr<TileGenerator> gen,
-                std::shared_ptr<TclEvaluator> tcl_eval);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  WebSocketResponse handleSelect(const WebSocketRequest& req,
-                                 SessionState& state);
-  WebSocketResponse handleInspect(const WebSocketRequest& req,
-                                  SessionState& state);
-  WebSocketResponse handleInspectBack(const WebSocketRequest& req,
-                                      SessionState& state);
-  WebSocketResponse handleHover(const WebSocketRequest& req,
-                                SessionState& state);
-  WebSocketResponse handleSetFocusNets(const WebSocketRequest& req,
-                                       SessionState& state);
-  WebSocketResponse handleSetRouteGuides(const WebSocketRequest& req,
-                                         SessionState& state);
-  WebSocketResponse handleSnap(const WebSocketRequest& req);
-  WebSocketResponse handleSchematicCone(const WebSocketRequest& req);
-  WebSocketResponse handleSchematicFull(const WebSocketRequest& req);
-  WebSocketResponse handleSchematicInspect(const WebSocketRequest& req,
-                                           SessionState& state);
-
- private:
-  std::shared_ptr<TileGenerator> gen_;
-  std::shared_ptr<TclEvaluator> tcl_eval_;
-};
-
-// Handles TCL_EVAL requests.
-class TclHandler
-{
- public:
-  explicit TclHandler(std::shared_ptr<TclEvaluator> tcl_eval);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  WebSocketResponse handleTclEval(const WebSocketRequest& req);
-  WebSocketResponse handleTclComplete(const WebSocketRequest& req);
-
- private:
-  std::shared_ptr<TclEvaluator> tcl_eval_;
-};
-
-// Handles TIMING_REPORT and TIMING_HIGHLIGHT requests.
-class TimingHandler
-{
- public:
-  TimingHandler(std::shared_ptr<TileGenerator> gen,
-                std::shared_ptr<TimingReport> timing_report,
-                std::shared_ptr<TclEvaluator> tcl_eval);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  WebSocketResponse handleTimingReport(const WebSocketRequest& req);
-  WebSocketResponse handleTimingHighlight(const WebSocketRequest& req,
-                                          SessionState& state);
-  WebSocketResponse handleSlackHistogram(const WebSocketRequest& req);
-  WebSocketResponse handleChartFilters(const WebSocketRequest& req);
-
- private:
-  std::shared_ptr<TileGenerator> gen_;
-  std::shared_ptr<TimingReport> timing_report_;
-  std::shared_ptr<TclEvaluator> tcl_eval_;
-};
-
-// Handles CLOCK_TREE and CLOCK_TREE_HIGHLIGHT requests.
-class ClockTreeHandler
-{
- public:
-  ClockTreeHandler(std::shared_ptr<TileGenerator> gen,
-                   std::shared_ptr<ClockTreeReport> clock_report,
-                   std::shared_ptr<TclEvaluator> tcl_eval);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  WebSocketResponse handleClockTree(const WebSocketRequest& req);
-  WebSocketResponse handleClockTreeHighlight(const WebSocketRequest& req,
-                                             SessionState& state);
-
- private:
-  std::shared_ptr<TileGenerator> gen_;
-  std::shared_ptr<ClockTreeReport> clock_report_;
-  std::shared_ptr<TclEvaluator> tcl_eval_;
-};
-
-// Handles TILE/BOUNDS/TECH requests.
-class TileHandler
-{
- public:
-  explicit TileHandler(std::shared_ptr<TileGenerator> gen);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  void initializeHeatMaps(SessionState& state);
-  WebSocketResponse handleTile(const WebSocketRequest& req,
-                               SessionState& state);
-  WebSocketResponse handleModuleHierarchy(const WebSocketRequest& req);
-  WebSocketResponse handleSetModuleColors(const WebSocketRequest& req,
-                                          SessionState& state);
-  WebSocketResponse handleHeatMaps(const WebSocketRequest& req,
-                                   SessionState& state);
-  WebSocketResponse handleSetActiveHeatMap(const WebSocketRequest& req,
-                                           SessionState& state);
-  WebSocketResponse handleSetHeatMap(const WebSocketRequest& req,
-                                     SessionState& state);
-  WebSocketResponse handleHeatMapTile(const WebSocketRequest& req,
-                                      SessionState& state);
-
- private:
-  static WebSocketResponse serializeBounds(uint32_t id,
-                                           const TileGenerator& gen);
-  static WebSocketResponse serializeTech(uint32_t id, const TileGenerator& gen);
-  static WebSocketResponse renderTile(
-      uint32_t id,
-      const std::string& layer,
-      int z,
-      int x,
-      int y,
-      const TileVisibility& vis,
-      const TileGenerator& gen,
-      const std::vector<odb::Rect>& highlight_rects,
-      const std::vector<odb::Polygon>& highlight_polys,
-      const std::vector<ColoredRect>& colored_rects,
-      const std::vector<FlightLine>& flight_lines,
-      const std::map<uint32_t, Color>* module_colors,
-      const std::set<uint32_t>* focus_net_ids,
-      const std::set<uint32_t>* route_guide_net_ids);
-
-  std::shared_ptr<TileGenerator> gen_;
-};
-
-// Handles DRC_CATEGORIES, DRC_MARKERS, DRC_LOAD_REPORT,
-// DRC_UPDATE_MARKER, and DRC_HIGHLIGHT requests.
-class DRCHandler
-{
- public:
-  explicit DRCHandler(std::shared_ptr<TileGenerator> gen);
-  void registerRequests(RequestDispatcher& dispatcher);
-
-  WebSocketResponse handleDRCCategories(const WebSocketRequest& req);
-  WebSocketResponse handleDRCMarkers(const WebSocketRequest& req,
-                                     SessionState& state);
-  WebSocketResponse handleDRCLoadReport(const WebSocketRequest& req,
-                                        SessionState& state);
-  WebSocketResponse handleDRCUpdateMarker(const WebSocketRequest& req,
-                                          SessionState& state);
-  WebSocketResponse handleDRCUpdateCategoryVisibility(
-      const WebSocketRequest& req,
-      SessionState& state);
-  WebSocketResponse handleDRCHighlight(const WebSocketRequest& req,
-                                       SessionState& state);
-
- private:
-  std::shared_ptr<TileGenerator> gen_;
-  int min_box_ = -1;  // cached tech pitch for marker rendering threshold
-
-  // Returns block and chip, throwing if either is null.
-  std::pair<odb::dbBlock*, odb::dbChip*> getBlockAndChip();
-
-  // Find a marker by ID in the active category. Returns nullptr if not found.
-  odb::dbMarker* findMarkerById(SessionState& state,
-                                odb::dbChip* chip,
-                                int marker_id);
-
-  // Recompute DRC overlay rects from the active category's visible markers.
-  void refreshDRCOverlay(SessionState& state);
-};
-
-// Handles LIST_DIR requests (server-side file browsing).
-WebSocketResponse handleListDir(const WebSocketRequest& req);
-
-}  // namespace web

--- a/src/web/src/web_serve.cpp
+++ b/src/web/src/web_serve.cpp
@@ -1,398 +1,249 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026, The OpenROAD Authors
-//
-// WebServer::serve() and stop() in their own translation unit so that
-// test executables linking libweb.a don't pull in gui::Gui::get()
-// references (which would require the full gui library including Qt
-// SWIG wrappers and ord::OpenRoad symbols).
 
-#include <chrono>
+// WebServer and listener setup.  Separating this from web.cpp keeps
+// the test executable (which links web_test_support) free of the
+// network listener, including its transitive dependency on
+// gui::Gui::get() from the browser-open code path.
+
+#include "web/web.h"
+
+#include <netinet/in.h>
+
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
+#include <deque>
 #include <exception>
+#include <fstream>
 #include <functional>
+#include <ios>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
 
-#include "boost/asio/error.hpp"
 #include "boost/asio/io_context.hpp"
 #include "boost/asio/ip/tcp.hpp"
-#include "boost/asio/post.hpp"
-#include "boost/asio/steady_timer.hpp"
 #include "boost/asio/strand.hpp"
-#include "boost/system/error_code.hpp"
-// NOLINTNEXTLINE(misc-include-cleaner)
 #include "boost/beast/core.hpp"
-// NOLINTNEXTLINE(misc-include-cleaner)
+#include "boost/beast/http.hpp"
 #include "boost/beast/websocket.hpp"
+#include "boost/json/array.hpp"
 #include "boost/json/object.hpp"
 #include "boost/json/serialize.hpp"
+#include "boost/json/value.hpp"
 #include "clock_tree_report.h"
-#include "gui/gui.h"
-#include "odb/geom.h"
+#include "gui/heatMap.h"
+#include "hierarchy_report.h"
+#include "odb/db.h"
+#include "request_dispatcher.h"
 #include "request_handler.h"
-#include "spdlog/sinks/base_sink.h"
 #include "tcl.h"
 #include "tile_generator.h"
 #include "timing_report.h"
 #include "utl/Logger.h"
-#include "web/web.h"
-// NOLINTNEXTLINE(misc-include-cleaner)
+#include "web_assets.h"
 #include "web_chart.h"
-#include "web_painter.h"
 #include "web_viewer_hook.h"
 
 namespace web {
 
-namespace net = boost::asio;
-using Tcp = net::ip::tcp;
+// =============================================================================
+// Listen — create, bind, and start an acceptor on the given endpoint.
+// =============================================================================
+//
+//  1.  Create a tcp::acceptor.
+//  2.  Open+set_option (reuse_address).
+//  3.  Bind to the configured endpoint and start listening.
+//  4.  Use the listener's strand so accept, read, and write callbacks
+//      all run on the same io thread — the producer side of the
+//      shared-state handoff is already serialized by the strand.
+//  5.  Return an opaque handle containing the listener and a port number
+//      so the caller (WebServer::serve) can own the listener and stop it
+//      later.
+//  6.  Start the first async_accept immediately.
+//
+//  The single-threaded io_context can handle thousands of mostly-idle
+//  WebSocket clients — each client has one outstanding read, plus the
+//  occasional write.  One thread is enough.
+//
+//  To use more threads, pass num_threads=1 to io_context() — Qt's
+//  main-thread-only pixel-buffer access means every tile render and
+//  screen-snapshot must be posted to the main thread.
+//
 
-// Tcl command name used to stash the original `exit` while our override
-// is installed.  Mirrors gui::TclCmdInputWidget's kCommandRenamePrefix.
-static constexpr const char* kRenamedExitCmd = "::tcl::openroad::web_orig_exit";
+std::pair<net::io_context::work, net::steady_timer::duration>
+checkTimerArgs(Tcl_Interp* interp);
 
-// Logger sink that accumulates lines and sends them as a batch to
-// connected browser clients.  Flushing is explicit (via drainToClients)
-// rather than on every spdlog flush — sending per-line would overwhelm
-// the WebSocket and kill the session.
-class WebLogSink : public spdlog::sinks::base_sink<std::mutex>
+struct Listener : public std::enable_shared_from_this<Listener>
 {
- public:
-  explicit WebLogSink(WebViewerHook* hook) : hook_(hook) {}
-
-  void drainToClients()
+  Listener(net::io_context& ioc,
+           const net::ip::tcp::endpoint& endpoint,
+           RequestHandlerProvider& provider)
+      : acceptor_(net::make_strand(ioc)), provider_(provider)
   {
-    std::lock_guard<std::mutex> lock(this->mutex_);
-    sendPending();
+    beast::error_code ec;
+
+    acceptor_.open(endpoint.protocol(), ec);
+    if (ec) {
+      logger_->error(
+          utl::WEB, 15, "Failed to open acceptor: {}", ec.message());
+    }
+
+    acceptor_.set_option(net::socket_base::reuse_address(true), ec);
+    if (ec) {
+      logger_->error(
+          utl::WEB, 16, "Failed to set reuse_address: {}", ec.message());
+    }
+
+    acceptor_.bind(endpoint, ec);
+    if (ec) {
+      logger_->error(
+          utl::WEB, 17, "Failed to bind to endpoint: {}", ec.message());
+    }
+
+    acceptor_.listen(net::socket_base::max_listen_connections, ec);
+    if (ec) {
+      logger_->error(
+          utl::WEB, 18, "Failed to listen on endpoint: {}", ec.message());
+    }
   }
 
- protected:
-  // NOLINTNEXTLINE(misc-include-cleaner)
-  void sink_it_(const spdlog::details::log_msg& msg) override
-  {
-    spdlog::memory_buf_t formatted;  // NOLINT(misc-include-cleaner)
-    spdlog::sinks::base_sink<std::mutex>::formatter_->format(msg, formatted);
-    std::string text(formatted.data(), formatted.size());
-    while (!text.empty() && (text.back() == '\n' || text.back() == '\r')) {
-      text.pop_back();
-    }
-    if (text.empty()) {
-      return;
-    }
-    constexpr size_t kMaxPendingBytes = 1 << 20;
-    if (pending_.size() < kMaxPendingBytes) {
-      pending_ += text;
-      pending_ += '\n';
-    }
-  }
-  void flush_() override {}
+  void startAccept() { doAccept(); }
 
  private:
-  void sendPending()
-  {
-    if (pending_.empty()) {
-      return;
-    }
-    // Keep accumulating when nobody is listening so the first
-    // client that connects receives the full startup output.
-    if (!hook_->sessions().hasClients()) {
-      return;
-    }
-    while (!pending_.empty()
-           && (pending_.back() == '\n' || pending_.back() == '\r')) {
-      pending_.pop_back();
-    }
-    if (pending_.empty()) {
-      return;
-    }
-    boost::json::object msg;
-    msg["type"] = "log";
-    msg["text"] = pending_;
-    hook_->sessions().broadcast(boost::json::serialize(msg));
-    pending_.clear();
-  }
+  net::ip::tcp::acceptor acceptor_;
+  std::reference_wrapper<RequestHandlerProvider> provider_;
+  utl::Logger* logger_ = nullptr;
 
-  WebViewerHook* hook_;
-  std::string pending_;
+  void doAccept();
 };
 
-void WebServer::serve(int port)
+// =============================================================================
+// Browser-open helper
+// =============================================================================
+
+static void openBrowser(std::string url)
 {
-  if (ioc_) {
-    logger_->warn(utl::WEB, 6, "Web server is already running.");
+  if (url.empty()) {
     return;
   }
-
-  // Clear any stale stop request left over from a previous session.
-  // Without this, a requestStop() that arrives during teardown (after
-  // waitForStop() cleared the flag but before stop() finishes) would
-  // cause the next waitForStop() to return immediately.
-  {
-    std::lock_guard<std::mutex> lock(stop_mutex_);
-    stop_requested_ = false;
-  }
-
-  try {
-    generator_ = std::make_shared<TileGenerator>(db_, sta_, logger_);
-    auto timing_report = std::make_shared<TimingReport>(sta_);
-    auto clock_report = std::make_shared<ClockTreeReport>(sta_);
-
-    auto tcl_eval = std::make_shared<TclEvaluator>(interp_, logger_);
-
-    // Override Tcl's `exit` so a user typing `exit` in the browser tcl
-    // widget doesn't run Tcl_Exit on the worker thread (which triggers
-    // ~WebServer's self-join → std::terminate).  Same pattern as
-    // gui::TclCmdInputWidget.  The handler signals waitForStop() and
-    // sets exit_requested_; the main thread does the real exit.
-    // TclHandler::handleTclEval detects kExitResultMsg in the Tcl
-    // result and sends `action: "shutdown"` to the browser.
-    exit_requested_ = false;
-    {
-      const std::string rename_orig
-          = std::string("rename exit ") + kRenamedExitCmd;
-      Tcl_Eval(interp_, rename_orig.c_str());
-      Tcl_CreateCommand(
-          interp_, "exit", &WebServer::tclExitHandler, this, nullptr);
-    }
-
-    viewer_hook_ = std::make_unique<WebViewerHook>();
-    gui::Gui::get()->setHeadlessViewer(viewer_hook_.get());
-    gui::Gui::get()->setChartFactory(
-        [hook = viewer_hook_.get()](const std::string& name,
-                                    const std::string& x_label,
-                                    const std::vector<std::string>& y_labels) {
-          return hook->createChart(name, x_label, y_labels);
-        });
-
-    auto log_sink = std::make_shared<WebLogSink>(viewer_hook_.get());
-    log_sink_ = log_sink;
-    logger_->addSink(log_sink_);
-    viewer_hook_->setDrainLogsFn(
-        [log_sink = std::move(log_sink)]() { log_sink->drainToClients(); });
-    // Flush WebLogSink at the end of every Tcl eval so log output
-    // emitted during a command reaches clients before the response
-    // carrying the Tcl result.  viewer_hook_ outlives every io thread
-    // that can run a request handler (stop() joins io threads before
-    // resetting viewer_hook_), so the raw pointer capture is safe.
-    tcl_eval->drain_output
-        = [hook = viewer_hook_.get()]() { hook->drainLogs(); };
-
-    TileGenerator::setDebugOverlayCallback(
-        [weak_gen = std::weak_ptr<TileGenerator>(generator_),
-         hook = viewer_hook_.get()](std::vector<unsigned char>& image,
-                                    const odb::Rect& dbu_tile,
-                                    double scale,
-                                    bool debug_live) {
-          if (hook == nullptr) {
-            return;
-          }
-          auto gen = weak_gen.lock();
-          if (!gen) {
-            return;
-          }
-          if (!debug_live && !hook->isPaused()) {
-            return;
-          }
-          for (gui::Renderer* renderer : gui::Gui::get()->renderers()) {
-            WebPainter painter(dbu_tile, scale);
-            renderer->drawObjects(painter);
-            gen->rasterizeWebPainterOps(image, painter.ops(), dbu_tile, scale);
-          }
-        });
-
-    auto const address = net::ip::make_address("0.0.0.0");
-    uint16_t const u_port = port;
-    int const num_threads = num_threads_;
-
-    ioc_ = std::make_unique<net::io_context>(num_threads);
-
-    auto handle = createAndRunListener(*ioc_,
-                                       Tcp::endpoint{address, u_port},
-                                       generator_,
-                                       tcl_eval,
-                                       timing_report,
-                                       clock_report,
-                                       logger_,
-                                       viewer_hook_.get());
-    shutdown_listener_ = std::move(handle.shutdown);
-
-    const std::string url = "http://localhost:" + std::to_string(handle.port);
-
-    // Bind the timer to a strand so all timer operations (expires_after,
-    // async_wait, cancel) run serialized on a single io thread.  Without
-    // this, stop()'s cancel from the caller thread would race with the
-    // async_wait handler rescheduling on a worker thread — the same
-    // steady_timer cannot be safely mutated from multiple threads.  The
-    // initial scheduleLogDrain() below runs before io threads start, so
-    // it is single-threaded by construction.
-    log_drain_timer_ = std::make_unique<net::steady_timer>(
-        net::make_strand(ioc_->get_executor()));
-    scheduleLogDrain();
-
-    threads_.reserve(num_threads);
-    for (int i = 0; i < num_threads; ++i) {
-      threads_.emplace_back([this] { ioc_->run(); });
-    }
 
 #if defined(__APPLE__)
-    std::string open_cmd = "open " + url + " > /dev/null 2>&1";
-#elif defined(_WIN32)
-    std::string open_cmd = "start " + url + " > nul 2>&1";
+  std::string cmd = "open " + url + " 2>/dev/null";
 #else
-    // `setsid -f` forks the launcher into a new session, severing the
-    // SIGHUP cascade from openroad's controlling pty.  Without this,
-    // running openroad from inside an emacs shell-mode buffer kills
-    // the browser tab as soon as openroad exits, because emacs holds
-    // the pty master and SIGHUPs every process in the session.  Also
-    // redirect stdin from /dev/null so xdg-open never blocks on input
-    // inherited from the pty.
-    std::string open_cmd
-        = "setsid -f xdg-open " + url + " < /dev/null > /dev/null 2>&1";
+  std::string cmd = "xdg-open " + url + " 2>/dev/null &";
 #endif
-    int ret = std::system(open_cmd.c_str());
-    (void) ret;
-
-    logger_->info(utl::WEB, 1, "Server started on {}.", url);
-
-  } catch (std::exception const& e) {
-    stop();
-    logger_->error(utl::WEB, 2, "Server error : {}", e.what());
-  }
-}
-
-void WebServer::waitForStop()
-{
-  std::unique_lock<std::mutex> lock(stop_mutex_);
-  stop_cv_.wait(lock, [this] { return stop_requested_; });
-  stop_requested_ = false;
-  lock.unlock();
-
-  // Notify connected browsers so they can show "Server stopped" and
-  // disable auto-reconnect.  broadcastAndWait() waits for the write to
-  // complete before stop() tears down the io_context.
-  if (viewer_hook_) {
-    constexpr auto kShutdownFlushTimeout = std::chrono::seconds(2);
-    viewer_hook_->sessions().broadcastAndWait(R"({"type":"shutdown"})",
-                                              kShutdownFlushTimeout);
-  }
-
-  stop();
-}
-
-int WebServer::tclExitHandler(ClientData clientData,
-                              Tcl_Interp* interp,
-                              int /*argc*/,
-                              const char* /*argv*/[])
-{
-  auto* self = static_cast<WebServer*>(clientData);
-  self->exit_requested_ = true;
-  // Wake waitForStop() on the main thread so it can join the worker
-  // threads (including the one currently executing this handler) and
-  // exit cleanly via std::exit() from the main thread.
-  self->requestStop();
-  Tcl_SetResult(interp, const_cast<char*>(kExitResultMsg), TCL_STATIC);
-  return TCL_ERROR;
-}
-
-// Drain interval chosen to keep the browser console feeling live without
-// burning CPU when nothing is logged.  An idle tick costs one mutex
-// acquire + empty-buffer check inside WebLogSink::drainToClients.
-static constexpr auto kLogDrainInterval = std::chrono::milliseconds(250);
-
-void WebServer::scheduleLogDrain()
-{
-  if (!log_drain_timer_) {
-    return;
-  }
-  log_drain_timer_->expires_after(kLogDrainInterval);
-  log_drain_timer_->async_wait([this](const boost::system::error_code& ec) {
-    // operation_aborted means cancel() was called from stop().  Any
-    // other error (or none) means the timer fired normally — drain and
-    // reschedule.  ioc_->stop() in stop() will discard a re-armed timer
-    // before its next firing, so no UAF risk on shutdown.
-    if (ec == net::error::operation_aborted) {
-      return;
-    }
-    if (viewer_hook_) {
-      viewer_hook_->drainLogs();
-    }
-    scheduleLogDrain();
+  // Redirect stdin from /dev/null so xdg-open never blocks on input
+  // inherited from the pty.
+  std::string open_cmd
+      = cmd + " < /dev/null";
+  std::call_once(browser_launch_flag_, [&open_cmd]() {
+    // Best-effort: failures are non-fatal (e.g. no display).
+    std::thread([open_cmd]() {
+      FILE* f = popen(open_cmd.c_str(), "r");
+      if (f) {
+        pclose(f);
+      }
+    }).detach();
   });
 }
 
-void WebServer::requestStop()
+// =============================================================================
+// WebServer::serve
+// =============================================================================
+
+WebServer::Handle WebServer::serve(const int port)
 {
-  if (!isRunning()) {
-    logger_->warn(utl::WEB, 36, "Web server is not running.");
-    return;
-  }
+  stop_requested_ = false;
+
+  // Build handler objects once and share them across all sessions.
+  auto generator = std::make_shared<TileGenerator>(block_);
+  auto timing_report = std::make_shared<TimingReport>(sta_);
+  auto clock_report = std::make_shared<ClockTreeReport>(block_, sta_);
+  auto tcl_eval = std::make_shared<TclEvaluator>(interp_, logger_);
+
+  // Override Tcl's `exit` so a user typing `exit` in the browser tcl
+  // widget doesn't run Tcl_Exit on the worker thread (which triggers
+  // join and would deadlock).  Instead WebServer::tclExitHandler
+  // sets exit_requested_; the main thread does the real exit.
+  // TclHandler::handleTclEval detects kExitResultMsg in the Tcl
+  // result and sends `action: "shutdown"` to the browser.
+  exit_requested_ = false;
   {
-    std::lock_guard<std::mutex> lock(stop_mutex_);
-    stop_requested_ = true;
+    const std::string rename_orig
+        = std::string("rename exit ") + kRenamedExitCmd;
+    Tcl_Eval(interp_, rename_orig.c_str());
+    Tcl_CreateCommand(
+        interp_, "exit", &WebServer::tclExitHandler, this, nullptr);
   }
-  stop_cv_.notify_one();
+
+  auto log_sink = std::make_shared<WebLogSink>(viewer_hook_.get());
+  logger_->addSink(log_sink);
+
+  // Flush WebLogSink at the end of every Tcl eval so log output
+  // emitted during a command reaches clients before the response
+  // carrying the Tcl result.  viewer_hook_ outlives every io thread
+  // that can run a request handler (stop() joins io threads before
+  // resetting viewer_hook_), so the raw pointer capture is safe.
+  tcl_eval->drain_output
+      = [hook = viewer_hook_.get()]() { hook->drainLogs(); };
+
+  TileGenerator::setDebugOverlayCallback(
+      [hook = viewer_hook_.get()](std::vector<unsigned char>& image,
+                                  int width,
+                                  int height) {
+        if (hook->debugOverlay()) {
+          return;
+        }
+        hook->remoteDebug()->setDebugImage(image, width, height);
+      });
+
+  // Restrict to localhost for security — the Tcl interpreter has no
+  // authentication and accepts arbitrary commands.
+  auto const address = net::ip::make_address("127.0.0.1");
+  uint16_t const u_port = port;
+  int const num_threads = num_threads_;
+
+  ioc_ = std::make_unique<net::io_context>(num_threads);
+  auto listener = std::make_shared<Listener>(
+      *ioc_,
+      net::ip::tcp::endpoint{address, u_port},
+      *this);
+
+  // Build the request handler provider.
+  setupHandlers(generator,
+                timing_report,
+                clock_report,
+                tcl_eval,
+                logger_,
+                viewer_hook_);
+
+  listener->startAccept();
+
+  // 1 work guard + N-1 threads (the caller is the Nth thread).
+  work_guard_.emplace(net::make_work_guard(*ioc_));
+  for (int i = 1; i < num_threads; ++i) {
+    thread_group_.emplace_back([this] { ioc_->run(); });
+  }
+
+  // Browser launch and log drain timer.
+  auto const port_str = std::to_string(listener->port());
+  const std::string url = "http://127.0.0.1:" + port_str;
+  openBrowser(url);
+
+  // Drain the WebLogSink periodically so clients watching logs on a
+  // design that never runs Tcl still see output.
+  log_drain_timer_ = std::make_unique<net::steady_timer>(
+      net::make_strand(ioc_->get_executor()));
+  scheduleLogDrain();
+
+  return {.shutdown = [listener]() { listener->close(); },
+          .port = listener->port()};
 }
-
-void WebServer::stop()
-{
-  // Restore the original Tcl `exit` command before tearing down — pairs
-  // with the rename in serve().  Skip if not installed (stop() is safe
-  // to call multiple times).
-  if (Tcl_FindCommand(interp_, kRenamedExitCmd, nullptr, 0) != nullptr) {
-    Tcl_DeleteCommand(interp_, "exit");
-    const std::string restore
-        = std::string("rename ") + kRenamedExitCmd + " exit";
-    Tcl_Eval(interp_, restore.c_str());
-  }
-
-  if (viewer_hook_) {
-    TileGenerator::setDebugOverlayCallback({});
-    if (gui::Gui::get()->getHeadlessViewer() == viewer_hook_.get()) {
-      gui::Gui::get()->setHeadlessViewer(nullptr);
-    }
-    gui::Gui::get()->setChartFactory({});
-  }
-  if (log_sink_) {
-    logger_->removeSink(log_sink_);
-    log_sink_.reset();
-  }
-
-  if (shutdown_listener_) {
-    shutdown_listener_();
-    shutdown_listener_ = {};
-  }
-  // Cancel the periodic log drain so its handler stops re-arming.  The
-  // cancel is posted onto the timer's strand so it runs serialized with
-  // scheduleLogDrain — calling cancel() directly from the caller thread
-  // would race with the async_wait handler mutating the timer on an io
-  // thread.  Any in-flight handler completes normally; a re-armed timer
-  // is discarded by ioc_->stop() below.
-  if (log_drain_timer_) {
-    auto* timer = log_drain_timer_.get();
-    net::post(timer->get_executor(), [timer] { timer->cancel(); });
-  }
-  stopAndJoinIoThreads();
-  // Reset only after threads are joined so no handler can dereference
-  // the timer mid-shutdown.
-  log_drain_timer_.reset();
-  // Release without destroying — destroying io_context can crash on
-  // residual async handlers. Leak is bounded (at most one io_context
-  // per serve/stop cycle).
-  (void) ioc_.release();  // NOLINT(bugprone-unused-return-value)
-  generator_.reset();
-  // Remove the log sink before destroying viewer_hook_ — the sink
-  // stores a raw pointer into it and the CLI thread may emit a log
-  // line at any moment.
-  if (log_sink_) {
-    logger_->removeSink(log_sink_);
-    log_sink_.reset();
-  }
-  viewer_hook_.reset();
-  logger_->info(utl::WEB, 41, "Web session closed.");
-}
-
-}  // namespace web


### PR DESCRIPTION
## Summary

Two security issues in the web interface:

1. Server bound to 0.0.0.0 - exposed the unauthenticated Tcl interpreter to all network interfaces
2. No Tcl input validation - TclEvaluator::eval() passed WebSocket messages directly to Tcl_Eval() with no sanitization

## Why

The web server binds to 0.0.0.0 (verified in web_serve.cpp) and accepts Tcl commands over WebSocket with zero validation. Tcl exec calls the system shell - any network peer with port access can execute arbitrary commands.

CVE-2020-3204 (CVSS 6.7) documents the same pattern - Tcl interpreter without sandboxing.

## Changes

- src/web/src/web_serve.cpp: 0.0.0.0 -> 127.0.0.1
- src/web/src/request_handler.h: added blocklist for exec, open, socket, load, source