### PR TITLE
rsz: Fix Coverity defects

### DIFF
--- a/src/rsz/src/DelayEstimator.cc
+++ b/src/rsz/src/DelayEstimator.cc
@@ -1154,9 +1154,11 @@ ArcDelayState collectPathStages(const Resizer& resizer,
   }
   std::ranges::reverse(fanin_stages);
 
-  context.path_stages = std::move(fanin_stages);
+  context.path_stages.reserve(fanin_stages.size() + 1 + delay_levels);
+  for (DelayStageState& stage : fanin_stages) {
+    context.path_stages.push_back(std::move(stage));
+  }
   context.target_stage_index = static_cast<int>(context.path_stages.size());
-  context.path_stages.reserve(context.path_stages.size() + 1 + delay_levels);
   context.path_stages.push_back(target_stage);
 
   int found_fanout_stages = 0;

--- a/src/rsz/src/DelayEstimatorReporter.cc
+++ b/src/rsz/src/DelayEstimatorReporter.cc
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "DelayEstimator.hh"
@@ -295,11 +296,16 @@ void DelayEstimatorReporter::reportAccuracyForSizing(
       {
         odb::dbDatabase::beginEco(reporter.block_);
       }
-      ~EcoJournalScope()
+      ~EcoJournalScope() noexcept
       {
-        reporter.resizer_.initForJournalRestore();
-        odb::dbDatabase::undoEco(reporter.block_);
-        reporter.resizer_.updateParasiticsAndTiming();
+        try {
+          reporter.resizer_.initForJournalRestore();
+          odb::dbDatabase::undoEco(reporter.block_);
+          reporter.resizer_.updateParasiticsAndTiming();
+        } catch (...) {
+          // Destructors must not throw during diagnostic ECO cleanup.
+          return;
+        }
       }
     };
 
@@ -702,25 +708,31 @@ DelayEstimatorReporter::buildLegacyProfile(const Target& target,
   }
 
   sta::PathExpanded expanded(target.endpoint_path, resizer_.staState());
-  StageProfileRow current_row{
-      .path_index = target.path_index,
-      .role = Role::kTarget,
-      .pin_name = stagePinName(expanded, target.path_index),
-      .cell_name = driver_port->libertyCell()->name(),
-      .input_slew = context->target().input_slew,
-      .cell_delay = current_cell_delay,
-      .wire_delay = pathWireDelay(expanded, target.path_index),
-      .load_cap = load_cap,
-      .output_slew = context->target().current_slew,
-      .extra_delay = current_fanin_penalty};
-  profile.current_stages.push_back(current_row);
+  const std::string target_pin_name = stagePinName(expanded, target.path_index);
+  const float target_wire_delay = pathWireDelay(expanded, target.path_index);
+  StageProfileRow current_row{.path_index = target.path_index,
+                              .role = Role::kTarget,
+                              .pin_name = target_pin_name,
+                              .cell_name = driver_port->libertyCell()->name(),
+                              .input_slew = context->target().input_slew,
+                              .cell_delay = current_cell_delay,
+                              .wire_delay = target_wire_delay,
+                              .load_cap = load_cap,
+                              .output_slew = context->target().current_slew,
+                              .extra_delay = current_fanin_penalty};
+  profile.current_stages.push_back(std::move(current_row));
 
-  StageProfileRow candidate_row = current_row;
-  candidate_row.cell_name = replacement->name();
-  candidate_row.cell_delay = candidate_cell_delay;
-  candidate_row.output_slew = kMissingValue;
-  candidate_row.extra_delay = candidate_fanin_penalty;
-  profile.candidate_stages.push_back(candidate_row);
+  StageProfileRow candidate_row{.path_index = target.path_index,
+                                .role = Role::kTarget,
+                                .pin_name = target_pin_name,
+                                .cell_name = replacement->name(),
+                                .input_slew = context->target().input_slew,
+                                .cell_delay = candidate_cell_delay,
+                                .wire_delay = target_wire_delay,
+                                .load_cap = load_cap,
+                                .output_slew = kMissingValue,
+                                .extra_delay = candidate_fanin_penalty};
+  profile.candidate_stages.push_back(std::move(candidate_row));
 
   return profile;
 }
@@ -877,7 +889,7 @@ DelayEstimatorReporter::captureFixedStages(const Target& target,
       fixed_stage.next_pin_name = network_->pathName(next_pin);
     }
 
-    fixed_stages.push_back(fixed_stage);
+    fixed_stages.push_back(std::move(fixed_stage));
   }
   return fixed_stages;
 }
@@ -1178,28 +1190,36 @@ void DelayEstimatorReporter::printStageWindowDetail(
     const bool has_golden_before = row_index < golden_before.size();
     const bool has_golden_after = row_index < golden_after.size();
 
-    const Role role = has_estimated_current     ? estimated_current_row.role
-                      : has_estimated_candidate ? estimated_candidate_row.role
-                      : has_golden_before       ? golden_before_row.role
-                                                : golden_after_row.role;
-    const int path_index
-        = has_estimated_current     ? estimated_current_row.path_index
-          : has_estimated_candidate ? estimated_candidate_row.path_index
-          : has_golden_before       ? golden_before_row.path_index
-                                    : golden_after_row.path_index;
-    const std::string& pin_name
-        = has_estimated_current     ? estimated_current_row.pin_name
-          : has_estimated_candidate ? estimated_candidate_row.pin_name
-          : has_golden_before       ? golden_before_row.pin_name
-                                    : golden_after_row.pin_name;
-    const std::string& pre_cell
-        = has_estimated_current ? estimated_current_row.cell_name
-          : has_golden_before   ? golden_before_row.cell_name
-                                : kDashCell;
-    const std::string& post_cell
-        = has_estimated_candidate ? estimated_candidate_row.cell_name
-          : has_golden_after      ? golden_after_row.cell_name
-                                  : kDashCell;
+    const StageProfileRow* reference_row = &golden_after_row;
+    if (has_golden_before) {
+      reference_row = &golden_before_row;
+    }
+    if (has_estimated_candidate) {
+      reference_row = &estimated_candidate_row;
+    }
+    if (has_estimated_current) {
+      reference_row = &estimated_current_row;
+    }
+
+    const std::string* pre_cell = &kDashCell;
+    if (has_golden_before) {
+      pre_cell = &golden_before_row.cell_name;
+    }
+    if (has_estimated_current) {
+      pre_cell = &estimated_current_row.cell_name;
+    }
+
+    const std::string* post_cell = &kDashCell;
+    if (has_golden_after) {
+      post_cell = &golden_after_row.cell_name;
+    }
+    if (has_estimated_candidate) {
+      post_cell = &estimated_candidate_row.cell_name;
+    }
+
+    const Role role = reference_row->role;
+    const int path_index = reference_row->path_index;
+    const std::string& pin_name = reference_row->pin_name;
 
     const float estimated_current_delay
         = has_estimated_current
@@ -1281,8 +1301,8 @@ void DelayEstimatorReporter::printStageWindowDetail(
     const bool post_arc_relaxed
         = has_estimated_candidate && estimated_candidate_row.arc_match_relaxed;
     logger_->report("    cell: pre={}  post={}{}",
-                    pre_cell,
-                    post_cell,
+                    *pre_cell,
+                    *post_cell,
                     post_arc_relaxed ? "  arc_match: relaxed" : "");
     logger_->report("");
     logger_->report("    {:<31} {:>10}   {:>10}   {:>10}",

--- a/src/rsz/src/RepairTargetCollector.cc
+++ b/src/rsz/src/RepairTargetCollector.cc
@@ -936,7 +936,7 @@ std::vector<Target> RepairTargetCollector::collectCritPathDriverPinTargets(
       if (visited_pins.contains(pin) || !is_valid_target(pin)) {
         continue;
       }
-      targets.push_back(target);
+      targets.push_back(std::move(target));
       visited_pins.insert(pin);
     }
   }
@@ -1472,7 +1472,7 @@ vector<const sta::Pin*> RepairTargetCollector::collectViolatorsByFaninTraversal(
     // Populate pin_data for sorting and filtering
     pinData pd;
     updatePinData(pin, pd);
-    pin_data_[pin] = pd;
+    pin_data_[pin] = std::move(pd);
   }
 
   int pins_before_filter = violating_pins_.size();
@@ -1631,7 +1631,7 @@ RepairTargetCollector::collectViolatorsByFanoutTraversal(
     // Populate pin_data for sorting and filtering
     pinData pd;
     updatePinData(pin, pd);
-    pin_data_[pin] = pd;
+    pin_data_[pin] = std::move(pd);
   }
 
   int pins_before_filter = violating_pins_.size();
@@ -1785,7 +1785,7 @@ RepairTargetCollector::collectViolatorsByFaninTraversalForEndpoint(
     // Populate pin_data for sorting and filtering
     pinData pd;
     updatePinData(pin, pd);
-    pin_data_[pin] = pd;
+    pin_data_[pin] = std::move(pd);
   }
 
   int pins_before_filter = violating_pins_.size();
@@ -2001,7 +2001,7 @@ sta::Slack RepairTargetCollector::computeAdaptiveThreshold(
                   delayAsString(chosen_threshold, 3, sta_),
                   pin_count,
                   cone_size,
-                  cone_size > 0 ? 100.0 * pin_count / cone_size : 0.0);
+                  100.0 * pin_count / cone_size);
   } else {
     chosen_threshold = -1e30;
     logger_->info(RSZ,
@@ -2027,7 +2027,7 @@ void RepairTargetCollector::collectPinsWithThreshold(
 
       pinData pd;
       updatePinData(pin_slack_pair.first, pd);
-      pin_data_[pin_slack_pair.first] = pd;
+      pin_data_[pin_slack_pair.first] = std::move(pd);
     }
   }
 }

--- a/src/rsz/src/move/RerouteGenerator.cc
+++ b/src/rsz/src/move/RerouteGenerator.cc
@@ -114,9 +114,10 @@ std::vector<std::unique_ptr<MoveCandidate>> RerouteGenerator::generate(
   const float resistance = global_router->getFRNetResistance(db_net);
   const float estimated_resistance
       = global_router->getFRNetResistanceOnMinClockLayer(db_net);
-  const float reduction_ratio
-      = (resistance > 0.0f) ? (resistance - estimated_resistance) / resistance
-                            : 0.0f;
+  float reduction_ratio = 0.0f;
+  if (resistance > 0.0f) {
+    reduction_ratio = (resistance - estimated_resistance) / resistance;
+  }
   if (reduction_ratio < kMinResistanceReduction) {
     debugPrint(resizer_.logger(),
                RSZ,

--- a/src/rsz/src/move/SizeDownGenerator.cc
+++ b/src/rsz/src/move/SizeDownGenerator.cc
@@ -271,9 +271,11 @@ float computeElmoreSlewFactor(const SizeDownContext& ctx,
                                 ctx.resizer.sta()->scenes(),
                                 ctx.resizer.maxAnalysisMode());
   const float output_res = output_port->driveResistance();
-  return output_res > 0.0f && output_load_cap > 0.0f
-             ? slew / (output_res * output_load_cap)
-             : 0.0f;
+  if (output_res <= 0.0f || output_load_cap <= 0.0f) {
+    return 0.0f;
+  }
+  const float elmore_denominator = output_res * output_load_cap;
+  return slew / elmore_denominator;
 }
 
 bool checkMaxSlewViolation(const SizeDownContext& ctx,

--- a/src/rsz/src/policy/SetupLastGaspPolicy.cc
+++ b/src/rsz/src/policy/SetupLastGaspPolicy.cc
@@ -3,34 +3,21 @@
 
 #include "SetupLastGaspPolicy.hh"
 
-#include <algorithm>
 #include <cmath>
-#include <cstddef>
-#include <limits>
-#include <map>
-#include <queue>
-#include <set>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
-#include "MoveCandidate.hh"
 #include "MoveCommitter.hh"
 #include "MoveGenerator.hh"
 #include "OptimizerTypes.hh"
 #include "RepairTargetCollector.hh"
-#include "VtSwapGenerator.hh"
 #include "est/EstimateParasitics.h"
 #include "policy/OptimizationPolicy.hh"
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
 #include "sta/Fuzzy.hh"
 #include "sta/GraphClass.hh"
-#include "sta/Network.hh"
-#include "sta/NetworkClass.hh"
 #include "sta/Path.hh"
-#include "sta/PortDirection.hh"
 #include "utl/Logger.h"
 #include "utl/timer.h"
 
@@ -296,12 +283,11 @@ void SetupLastGaspPolicy::repairLastGaspEndpoint(
       acceptEndpointState(endpoint_state);
       break;
     }
-    if (last_gasp_state.end_index == 1) {
+    if (last_gasp_state.end_index == 1
+        && endpoint_state.worst_vertex != nullptr) {
       endpoint_state.end = endpoint_state.worst_vertex;
-      if (endpoint_state.end != nullptr) {
-        target_collector_->useWorstEndpoint(endpoint_state.end);
-        committer_.setCurrentEndpoint(endpoint_state.end->pin());
-      }
+      target_collector_->useWorstEndpoint(endpoint_state.end);
+      committer_.setCurrentEndpoint(endpoint_state.end->pin());
     }
 
     ++endpoint_state.pass;

--- a/src/rsz/src/policy/SetupLegacyBase.cc
+++ b/src/rsz/src/policy/SetupLegacyBase.cc
@@ -5,13 +5,10 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <cstdlib>
 #include <limits>
-#include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -32,7 +29,6 @@
 #include "est/EstimateParasitics.h"
 #include "rsz/Resizer.hh"
 #include "sta/Delay.hh"
-#include "sta/Fuzzy.hh"
 #include "sta/Graph.hh"
 #include "sta/GraphClass.hh"
 #include "sta/Liberty.hh"
@@ -40,7 +36,6 @@
 #include "sta/NetworkClass.hh"
 #include "sta/Path.hh"
 #include "sta/PathExpanded.hh"
-#include "sta/PortDirection.hh"
 #include "sta/Sdc.hh"
 #include "sta/Search.hh"
 #include "sta/SearchClass.hh"
@@ -524,7 +519,7 @@ bool SetupLegacyBase::repairPins(
                       driver_pin, focus_path, focus_slack, target)
                 : makePinTarget(driver_pin, focus_slack, target);
       if (has_target) {
-        prewarm_targets.push_back(target);
+        prewarm_targets.push_back(std::move(target));
       }
     }
     prewarmTargets(prewarm_targets);
@@ -761,7 +756,7 @@ bool SetupLegacyBase::repairPath(sta::Path* path,
     static_cast<void>(ignored);
     Target target;
     makePathDriverTarget(path, expanded, drvr_index, path_slack, target);
-    targets.push_back(target);
+    targets.push_back(std::move(target));
   }
 
   // Prewarm for legacy MT policy

--- a/src/rsz/src/policy/SetupLegacyPolicy.cc
+++ b/src/rsz/src/policy/SetupLegacyPolicy.cc
@@ -5,22 +5,12 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
-#include <limits>
-#include <map>
-#include <queue>
-#include <set>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
-#include <vector>
 
-#include "MoveCandidate.hh"
 #include "MoveCommitter.hh"
 #include "MoveGenerator.hh"
 #include "OptimizerTypes.hh"
 #include "RepairTargetCollector.hh"
-#include "VtSwapGenerator.hh"
 #include "est/EstimateParasitics.h"
 #include "policy/OptimizationPolicy.hh"
 #include "rsz/Resizer.hh"
@@ -30,7 +20,6 @@
 #include "sta/Network.hh"
 #include "sta/NetworkClass.hh"
 #include "sta/Path.hh"
-#include "sta/PortDirection.hh"
 #include "utl/Logger.h"
 #include "utl/timer.h"
 
@@ -335,12 +324,10 @@ void SetupLegacyPolicy::repairEndpoint(EndpointRepairState& endpoint_state,
       acceptEndpointState(endpoint_state);
       break;
     }
-    if (main_state.end_index == 1) {
+    if (main_state.end_index == 1 && endpoint_state.worst_vertex != nullptr) {
       endpoint_state.end = endpoint_state.worst_vertex;
-      if (endpoint_state.end != nullptr) {
-        target_collector_->useWorstEndpoint(endpoint_state.end);
-        committer_.setCurrentEndpoint(endpoint_state.end->pin());
-      }
+      target_collector_->useWorstEndpoint(endpoint_state.end);
+      committer_.setCurrentEndpoint(endpoint_state.end->pin());
     }
 
     ++endpoint_state.pass;

--- a/src/utl/include/utl/ThreadPool.h
+++ b/src/utl/include/utl/ThreadPool.h
@@ -120,7 +120,7 @@ class ThreadPool
     // get() patterns without manually handling worker starvation.
     {
       std::lock_guard<std::mutex> lock(lock_);
-      tasks_.push([packaged_task]() { (*packaged_task)(); });
+      tasks_.emplace([task = std::move(packaged_task)]() { (*task)(); });
     }
     cv_.notify_one();
     return ThreadPoolFuture<Result>(this, lifetime_, std::move(future));

--- a/src/utl/src/ThreadPool.cpp
+++ b/src/utl/src/ThreadPool.cpp
@@ -3,6 +3,7 @@
 
 #include "utl/ThreadPool.h"
 
+#include <atomic>
 #include <cstddef>
 #include <functional>
 #include <memory>
@@ -75,19 +76,23 @@ void ThreadPool::workerLoop()
   active_pool_ = this;
   while (true) {
     std::function<void()> task;
+    bool exit_worker = false;
     {
       std::unique_lock<std::mutex> lock(lock_);
       cv_.wait(lock, [this]() { return stop_ || !tasks_.empty(); });
       if (stop_ && tasks_.empty()) {
-        active_pool_ = previous_pool;
-        return;
+        exit_worker = true;
+      } else {
+        task = std::move(tasks_.front());
+        tasks_.pop();
       }
-
-      task = std::move(tasks_.front());
-      tasks_.pop();
+    }
+    if (exit_worker) {
+      break;
     }
     task();
   }
+  active_pool_ = previous_pool;
 }
 
 }  // namespace utl


### PR DESCRIPTION
## Summary
- Fix Coverity defects reported in the rsz2 repair setup and ThreadPool code.
- Keep behavior unchanged except for preventing a possible null endpoint overwrite in legacy setup phases.

## Impact
- No user-facing UI changes.
- Expected behavior is unchanged for valid flows.
- Minor performance improvement from avoiding avoidable copies and reallocations.

## Related
- Coverity CIDs: 1659635, 1659633, 1659631, 1659629, 1659628, 1659627, 1659626, 1659625, 1659624, 1659623, 1659622, 1659621, 1659620, 1659619, 1659618, 1659617, 1659616, 1659614, 1659613, 1659612.
