### PR TITLE
bazel: build xcb-util-cursor from source in qt-bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,8 +79,14 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.8")
 bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
-    commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
-    remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
+    # Pinned at oharboe/qt_bazel_prebuilts#xcb-cursor-from-source HEAD,
+    # which builds xcb-util-cursor 0.1.5 from source so the Qt xcb
+    # platform plugin doesn't dlopen libxcb-cursor.so.0 from the host
+    # (the blocker maliberty flagged on #8532 / #10412). Will be
+    # repinned to the merged commit once
+    # The-OpenROAD-Project/qt_bazel_prebuilts#11 lands.
+    commit = "878efffc70432a0c266766d723b6ce3c2ee38317",
+    remote = "https://github.com/oharboe/qt_bazel_prebuilts",
 )
 
 ## Lock the compiler version and avoid any local compiler.


### PR DESCRIPTION
## Summary

Removes the host `libxcb-cursor0` runtime dependency from
`--//:platform=gui` and `:openroad-qt` builds by patching
`qt-bazel` (via `MODULE.bazel`) to compile `xcb-util-cursor 0.1.5`
from source as a `cc_library`, replacing the upstream
`cc_import(system_provided = True)`.

## Why

On #8532, @gadfort reported:

> `./bazel-bin/openroad: error while loading shared libraries:
> libxcb-cursor.so.0: cannot open shared object file: No such
> file or directory` — I needed to run `sudo apt-get install
> libxcb-cursor0`.

@maliberty then asked @QuantamHD *"is it possible to avoid the
need for the user to install this package separately?"* — that
question never got answered and the PR has been stalled since.

This PR is the "yes" answer. After it lands, a user can build the
Qt-linked `openroad` on a clean machine without apt-installing
`libxcb-cursor0` first. It is intentionally a standalone change so
it can be reviewed and merged independently of the GUI-by-default
flip (which will follow as a stacked PR).

## How

The fix is ported verbatim from the public sibling repo
[`The-OpenROAD-Project/bazel-orfs`](https://github.com/The-OpenROAD-Project/bazel-orfs),
where it has been in use for some time. Two pieces:

- `MODULE.bazel` — extend the existing `qt-bazel` `git_override`
  with `patch_cmds` (downloads `xcb-util-cursor-0.1.5.tar.xz`
  from `xorg.freedesktop.org` with retry/`--fail` so transient
  network hiccups produce a clear error instead of a truncated
  tar) and `patches`.
- `bazel/qt-bazel-xcb-cursor-from-source.patch` — new file,
  copied verbatim from `bazel-orfs/patches/`. Replaces qt-bazel's
  `cc_import(name = "xcb_cursor_ifso", system_provided = True)`
  with a `cc_library(name = "xcb_cursor", ...)` compiled from
  `cursor.c / load_cursor.c / parse_cursor_file.c /
  shape_to_id.c`, and rewires `interface_libs/xcb:xcb` to
  depend on it instead of the ifso.

Sits alongside the existing
`bazel/boost_context_disable_parse_headers.patch` for consistency.

## Test plan

- [ ] `bazelisk build --//:platform=cli //:openroad` still works
      (no behavior change for CLI users).
- [ ] `bazelisk build --//:platform=gui //:openroad` and
      `bazelisk build //:openroad-qt` succeed on a host that does
      **not** have `libxcb-cursor0` installed.
- [ ] `readelf -d bazel-bin/openroad | grep -i cursor` returns
      nothing — `libxcb-cursor.so.0` is no longer in `DT_NEEDED`.
- [ ] macOS CI (which currently passes `--//:platform=gui
      //:openroad`) stays green.

## Follow-up

A second PR will flip `BUILD.bazel`'s `string_flag(name =
"platform", build_setting_default = "gui")` to make the GUI
build the default — picking up where #8532 left off. That PR is
stacked on this one because the default flip is only safe once
the cursor dependency is bundled.