### PR TITLE
bazel: make GUI the default build

### DIFF
--- a/.github/workflows/github-actions-macos-bazel.yml
+++ b/.github/workflows/github-actions-macos-bazel.yml
@@ -38,7 +38,7 @@ jobs:
           bazelisk build \
             --disk_cache=~/.cache/bazel-disk-cache \
             --experimental_disk_cache_gc_max_size=5G \
-            --//:platform=gui //:openroad
+            //:openroad
 
       # 2. SAVE: Only executes if this is a push/merge directly to the master branch
       - name: Save Bazel Disk Cache

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -48,7 +48,7 @@ exports_files([
 
 string_flag(
     name = "platform",
-    build_setting_default = "cli",
+    build_setting_default = "gui",
     values = [
         "cli",
         "gui",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -80,6 +80,21 @@ bazel_dep(name = "qt-bazel")
 git_override(
     module_name = "qt-bazel",
     commit = "886104974c2fd72439f2c33b5deebf0fe4649df7",
+    # Build xcb-util-cursor from source so the Qt xcb platform plugin
+    # doesn't depend on the host having libxcb-cursor0 installed.
+    # qt-bazel upstream ships it as system_provided = True; we replace
+    # that with a static cc_library compiled from xcb-util-cursor 0.1.5.
+    patch_cmds = [
+        # Retry + --fail so transient xorg.freedesktop.org hiccups don't
+        # feed a truncated/HTML response into tar (seen in CI as "xz:
+        # File format not recognized"). Stage to a file first for a
+        # clearer error if extraction fails.
+        "curl -sSfL --retry 5 --retry-all-errors --retry-delay 5 -o xcb-util-cursor-0.1.5.tar.xz https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz && tar xJf xcb-util-cursor-0.1.5.tar.xz --strip-components=1 -C interface_libs/xcb xcb-util-cursor-0.1.5/cursor && rm xcb-util-cursor-0.1.5.tar.xz",
+    ],
+    patch_strip = 1,
+    patches = [
+        "//bazel:qt-bazel-xcb-cursor-from-source.patch",
+    ],
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 

--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -25,6 +25,20 @@ RUN apt-get -y update \
       docker-buildx-plugin \
       docker-ce \
       docker-ce-cli \
+      libdbus-1-3 \
+      libfontconfig1 \
+      libsm6 \
+      libx11-xcb1 \
+      libxcb-icccm4 \
+      libxcb-keysyms1 \
+      libxcb-randr0 \
+      libxcb-shape0 \
+      libxcb-sync1 \
+      libxcb-xfixes0 \
+      libxcb-xkb1 \
+      libxcb1-dev \
+      libxkbcommon-x11-0 \
+      libxkbcommon0 \
       openjdk-21-jre-headless \
       python3 \
       python3-yaml \

--- a/bazel/qt-bazel-xcb-cursor-from-source.patch
+++ b/bazel/qt-bazel-xcb-cursor-from-source.patch
@@ -1,0 +1,59 @@
+diff --git a/interface_libs/xcb/BUILD.bazel b/interface_libs/xcb/BUILD.bazel
+index c1c5b6b6..3a659170 100644
+--- a/interface_libs/xcb/BUILD.bazel
++++ b/interface_libs/xcb/BUILD.bazel
+@@ -67,10 +67,41 @@ cc_import(
+     system_provided = True,
+ )
+ 
+-cc_import(
+-    name = "xcb_cursor_ifso",
+-    interface_library = "libxcb-cursor.ifso",
+-    system_provided = True,
++# Headers-only target for xcb utility headers.  Used by :xcb_cursor to
++# get xcb_renderutil.h, xcb_image.h, render.h etc. without depending on
++# the full :xcb target (which would create a circular dependency).
++cc_library(
++    name = "xcb_hdrs",
++    hdrs = glob(["xcb/*.h"]),
++    includes = ["."],
++    strip_include_prefix = ".",
++)
++
++# Build xcb-util-cursor from source instead of relying on a system-provided
++# shared library.  The source is downloaded into cursor/ by patch_cmds in
++# the consumer's MODULE.bazel.  This makes the Qt xcb platform plugin
++# self-contained — no host libxcb-cursor0 package required.
++cc_library(
++    name = "xcb_cursor",
++    srcs = [
++        "cursor/cursor.c",
++        "cursor/cursor.h",
++        "cursor/load_cursor.c",
++        "cursor/parse_cursor_file.c",
++        "cursor/shape_to_id.c",
++    ],
++    hdrs = ["cursor/xcb_cursor.h"],
++    copts = [
++        # asprintf() is a GNU extension; glibc gates it behind _GNU_SOURCE.
++        "-D_GNU_SOURCE",
++        "-DXCURSORPATH='\"~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons\"'",
++    ],
++    include_prefix = "xcb",
++    strip_include_prefix = "cursor",
++    deps = [
++        ":xcb_hdrs",
++        "@libxcb",
++    ],
+ )
+ 
+ cc_import(
+@@ -94,7 +125,7 @@ cc_library(
+     deps = select({
+         "@platforms//cpu:aarch64": [],
+         "//conditions:default": [
+-            ":xcb_cursor_ifso",
++            ":xcb_cursor",
+             ":xcb_icccm_ifso",
+             ":xcb_ifso",
+             ":xcb_image_ifso",

--- a/docs/user/Build.md
+++ b/docs/user/Build.md
@@ -17,23 +17,23 @@ There are three methods for building OpenROAD (in order of recommendation): preb
 
 ## Build and install with Bazel
 
-Build OpenROAD with GUI support and install into ../install/OpenROAD/bin
+Build OpenROAD and install into ../install/OpenROAD/bin
 
-    bazelisk run --//:platform=gui //:install
+    bazelisk run //:install
 
 To install to a custom location, e.g. /tmp/myinstall
 
-    bazelisk run --//:platform=gui //:install -- /tmp/myinstall
+    bazelisk run //:install -- /tmp/myinstall
 
 To produce an openroad.tar file with install files
 
-    bazelisk build --//:platform=gui //:tarfile
+    bazelisk build //:tarfile
 
 The tarfile is located at bazel-bin/packaging/openroad.tar.
 
 To embed the real git version string, add `--config=release`:
 
-    bazelisk run --config=release --//:platform=gui //:install
+    bazelisk run --config=release //:install
 
 The install process will install the binary "openroad" and the runfile directory
 "openroad.runfiles" which contains runtime data needed by the binary.

--- a/src/gui/README.md
+++ b/src/gui/README.md
@@ -958,7 +958,7 @@ timing groups display the internal clock latency inline:
 To view this, run the MockArray example and look at reg2reg paths:
 
 ```
-bazelisk run --//:platform=gui //test/orfs/mock-array:MockArray_4x4_base_synth gui_synth
+bazelisk run //test/orfs/mock-array:MockArray_4x4_base_synth gui_synth
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Flips `BUILD.bazel`'s `platform` `string_flag` from
`build_setting_default = "cli"` to `"gui"`, so
`bazelisk build //:openroad` now produces the Qt-linked binary
without needing `--//:platform=gui` on the command line. Users
who specifically want a CLI-only binary can still pass
`--//:platform=cli`.

Picks up where #8532 left off.

## Stacked on #10412

The `libxcb-cursor0` runtime blocker reported by @gadfort on
#8532 is fixed by #10412, which builds `xcb-util-cursor` from
source in `qt-bazel`. **Please merge #10412 first**; this PR
will then be a clean single-commit diff against master.

## Files changed

- `BUILD.bazel`: `build_setting_default = "cli"` → `"gui"`.
  Everything else (`platform_cli` / `platform_gui`
  `config_setting`s, the `select()` over `//src/gui` vs
  `//src/gui:gui_qt`, `:openroad`'s deps, the standalone
  `:openroad-qt` target) keeps working — the flag mechanism is
  already in place, we're only changing the picked-by-default
  value.
- `bazel/Dockerfile`: add the runtime xcb/X11/Qt libs that the
  Qt-linked binary loads at startup, so `bazel test
  //src/gui/test:supported` can exec the binary inside the
  Bazel-CI container. **`libxcb-cursor0` is intentionally not
  in this list** — after #10412 it is no longer in `DT_NEEDED`.
  This file is the Bazel CI image consumed by Jenkins; the
  cmake path (root `Dockerfile` + `etc/DependencyInstaller.sh`)
  already installs its own xcb deps and is untouched.
- `.github/workflows/github-actions-macos-bazel.yml`: drop the
  now-redundant `--//:platform=gui` flag from the build
  command.
- `docs/user/Build.md`: drop the flag from the four bazelisk
  command examples — users should not have to care.
- `src/gui/README.md`: same cleanup for the MockArray example.

`etc/Build.sh` already passes `--//:platform=cli` /
`--//:platform=gui` explicitly based on `--no-gui` and is left
alone (internal script, not user-facing).

## Test plan

- [ ] `bazelisk build //:openroad` (no flag) produces a
      Qt-linked binary; `ldd bazel-bin/openroad` shows the
      Qt/xcb libraries.
- [ ] `bazelisk build --//:platform=cli //:openroad` (explicit
      opt-out) still produces a CLI-only binary with no Qt
      deps in `ldd`.
- [ ] `bazel test //src/gui/test:supported` passes inside the
      updated `bazel/Dockerfile` image
      (`docker build -f bazel/Dockerfile -t test-bazel-ci .`
      locally to reproduce).
- [ ] `bazelisk run //:openroad -- -gui` launches the GUI on a
      clean machine without manual `apt-get install` of any
      xcb package (end-to-end check of #10412 + this PR).
- [ ] `bazelisk build //:openroad-qt` still works (separate
      target is untouched).
- [ ] macOS CI workflow goes green with the flag removed.