### PR TITLE
mpl: update one usage of odb to src/db in bzl

### DIFF
--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -42,7 +42,7 @@ cc_library(
         "src/shapes.h",
     ],
     deps = [
-        "//src/odb",
+        "//src/odb/src/db",
         "//src/utl",
         "@boost.random",
     ],


### PR DESCRIPTION
## Summary
update one usage of odb to src/db in bzl

## Type of Change
- Bug fix

## Impact
Fixes
```
ERROR: /Users/runner/work/OpenROAD/OpenROAD/src/mpl/BUILD:31:11: no such target '//src/odb:odb': target 'odb' not declared in package 'src/odb' defined by /Users/runner/work/OpenROAD/OpenROAD/src/odb/BUILD and referenced by '//src/mpl:pusher'
```
## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [ x My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
