### PR TITLE
mpl: fix stale //src/odb refs after aggregate target removal

### DIFF
--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -42,7 +42,7 @@ cc_library(
         "src/shapes.h",
     ],
     deps = [
-        "//src/odb",
+        "//src/odb/src/db",
         "//src/utl",
         "@boost.random",
     ],

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -288,7 +288,7 @@ cc_test(
     ],
     deps = [
         "//src/mpl:pusher",
-        "//src/odb",
+        "//src/odb/src/db",
         "//src/tst",
         "//src/utl",
         "@googletest//:gtest",


### PR DESCRIPTION
## Summary
Update stale references to odb on Bazel files for MPL.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
Fix macOS build.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
