### PR TITLE
dpl: factor shared internal headers into private hdrs target

### DIFF
--- a/src/dpl/BUILD
+++ b/src/dpl/BUILD
@@ -12,6 +12,28 @@ package(
     features = ["layering_check"],
 )
 
+# Headers owned by :dpl but also consumed by :ui. Kept package-private so
+# nothing outside //src/dpl can depend on them.
+cc_library(
+    name = "dpl_private_hdrs",
+    hdrs = [
+        "src/graphics/DplObserver.h",
+        "src/infrastructure/Coordinates.h",
+        "src/infrastructure/Grid.h",
+        "src/infrastructure/Objects.h",
+        "src/infrastructure/architecture.h",
+        "src/infrastructure/network.h",
+    ],
+    includes = ["src"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/odb/src/db",
+        "//src/utl",
+        "@boost.icl",
+        "@boost.utility",
+    ],
+)
+
 cc_library(
     name = "dpl",
     srcs = [
@@ -28,20 +50,14 @@ cc_library(
         "src/PlacementDRC.cpp",
         "src/PlacementDRC.h",
         "src/dbToOpendp.cpp",
-        "src/graphics/DplObserver.h",
-        "src/infrastructure/Coordinates.h",
         "src/infrastructure/DecapObjects.h",
         "src/infrastructure/Grid.cpp",
-        "src/infrastructure/Grid.h",
         "src/infrastructure/Objects.cpp",
-        "src/infrastructure/Objects.h",
         "src/infrastructure/Padding.cpp",
         "src/infrastructure/Padding.h",
         "src/infrastructure/architecture.cxx",
-        "src/infrastructure/architecture.h",
         "src/infrastructure/detailed_segment.h",
         "src/infrastructure/network.cxx",
-        "src/infrastructure/network.h",
         "src/legalize_shift.cxx",
         "src/legalize_shift.h",
         "src/objective/detailed_abu.cxx",
@@ -87,6 +103,7 @@ cc_library(
         "src",
     ],
     deps = [
+        ":dpl_private_hdrs",
         "//src/odb/src/db",
         "//src/utl",
         "@boost.format",
@@ -105,14 +122,8 @@ cc_library(
     name = "ui",
     srcs = [
         "src/MakeOpendp.cpp",
-        "src/graphics/DplObserver.h",
         "src/graphics/Graphics.cpp",
         "src/graphics/Graphics.h",
-        "src/infrastructure/Coordinates.h",
-        "src/infrastructure/Grid.h",
-        "src/infrastructure/Objects.h",
-        "src/infrastructure/architecture.h",
-        "src/infrastructure/network.h",
         ":swig",
         ":tcl",
     ],
@@ -125,6 +136,7 @@ cc_library(
     ],
     deps = [
         ":dpl",
+        ":dpl_private_hdrs",
         "//:ord",
         "//src/gui",
         "//src/odb/src/db",


### PR DESCRIPTION
## Summary
Move the six headers that were duplicated across `:dpl` and `:ui` srcs in `src/dpl/BUILD` (`DplObserver.h`, `Coordinates.h`, `Grid.h`, `Objects.h`, `architecture.h`, `network.h`) into a new `:dpl_private_hdrs` `cc_library` with `//visibility:private`. Both `:dpl` and `:ui` now depend on it, so the headers are owned in one place and unreachable from outside `//src/dpl`.

## Type of Change
- Refactoring

## Impact
Build-system only; no behavior change. Removes header duplication across two targets in the same package while preserving `layering_check` semantics and keeping the headers package-private.

## Verification
- [x] I have verified that the local build succeeds (`bazel build //src/dpl:dpl //src/dpl:ui`).
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
None.