### PR TITLE
mpl: factor shared internal headers into private hdrs target

### DIFF
--- a/src/mpl/BUILD
+++ b/src/mpl/BUILD
@@ -48,10 +48,24 @@ cc_library(
     ],
 )
 
+# Headers owned by :mpl but also consumed by :ui. Kept package-private so
+# nothing outside //src/mpl can depend on them.
+cc_library(
+    name = "mpl_private_hdrs",
+    hdrs = [
+        "src/MplObserver.h",
+        "src/clusterEngine.h",
+    ],
+    visibility = ["//visibility:private"],
+    deps = [
+        ":pusher",
+        "//src/odb/src/db",
+    ],
+)
+
 cc_library(
     name = "mpl",
     srcs = [
-        "src/MplObserver.h",
         "src/SACoreHardMacro.cpp",
         "src/SACoreHardMacro.h",
         "src/SACoreSoftMacro.cpp",
@@ -59,7 +73,6 @@ cc_library(
         "src/SimulatedAnnealingCore.cpp",
         "src/SimulatedAnnealingCore.h",
         "src/clusterEngine.cpp",
-        "src/clusterEngine.h",
         "src/hier_rtlmp.cpp",
         "src/hier_rtlmp.h",
         "src/rtl_mp.cpp",
@@ -71,6 +84,7 @@ cc_library(
         "include",
     ],
     deps = [
+        ":mpl_private_hdrs",
         ":pusher",
         ":snapper",
         "//src/dbSta",
@@ -87,10 +101,7 @@ cc_library(
 cc_library(
     name = "ui",
     srcs = [
-        "include/mpl/rtl_mp.h",
         "src/MakeMacroPlacer.cpp",
-        "src/MplObserver.h",
-        "src/clusterEngine.h",
         "src/graphics.cpp",
         "src/graphics.h",
         ":swig",
@@ -105,6 +116,7 @@ cc_library(
     ],
     deps = [
         ":mpl",
+        ":mpl_private_hdrs",
         ":pusher",
         "//:ord",
         "//src/gui",


### PR DESCRIPTION
## Summary
- Move the two headers duplicated across `:mpl` and `:ui` srcs in `src/mpl/BUILD` (`MplObserver.h`, `clusterEngine.h`) into a new `:mpl_private_hdrs` `cc_library` with `//visibility:private`.
- The new target declares its own direct deps (`:pusher`, `//src/odb/src/db`) so it's self-contained rather than relying on every consumer to redeclare them.
- Drop the redundant `include/mpl/rtl_mp.h` entry from `:ui` srcs (already exposed via `:mpl`'s hdrs).

## Type of Change
- Refactoring

## Impact
Build-system only; no behavior change. Header duplication across two targets in the same package is eliminated while preserving `layering_check` semantics, and the private hdrs are unreachable from outside `//src/mpl`.

## Verification
- [x] I have verified that the local build succeeds (`bazel build //src/mpl:mpl //src/mpl:ui //src/mpl:mpl_private_hdrs`).
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
None.