### PR TITLE
gha: overwrite files when extracting

### DIFF
--- a/.github/workflows/github-actions-clang-tidy-post.yml
+++ b/.github/workflows/github-actions-clang-tidy-post.yml
@@ -33,5 +33,5 @@ jobs:
             const fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/clang-tidy-review.zip', Buffer.from(download.data));
       - name: 'Unzip artifact'
-        run: unzip clang-tidy-review.zip
+        run: unzip -o clang-tidy-review.zip
       - uses: The-OpenROAD-Project/clang-tidy-review/post@master


### PR DESCRIPTION
Fix issue on self-hosted conflicts
