### PR TITLE
rsz: Support nested journals' move result tracking

### DIFF
--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -67,7 +67,7 @@ void MoveCommitter::init()
   std::ranges::fill(committed_by_type_, 0);
   for (size_t index = 0; index < pending_instances_by_type_.size(); ++index) {
     pending_instances_by_type_[index].clear();
-    all_instances_by_type_[index].clear();
+    committed_instances_by_type_[index].clear();
   }
 
   const bool report_enabled
@@ -375,7 +375,7 @@ void MoveCommitter::recordAcceptedResult(const MoveResult& result)
     // Preserve legacy BaseMove semantics: once a move type touched an
     // instance in this repair session, later guards still see it even if the
     // journal branch is restored.
-    all_instances_by_type_[index].insert(inst);
+    committed_instances_by_type_[index].insert(inst);
   }
 }
 
@@ -527,7 +527,7 @@ void MoveCommitter::acceptPendingMoves()
     }
     committed_by_type_[index] += pending_by_type_[index];
     pending_by_type_[index] = 0;
-    all_instances_by_type_[index].insert(
+    committed_instances_by_type_[index].insert(
         pending_instances_by_type_[index].begin(),
         pending_instances_by_type_[index].end());
     pending_instances_by_type_[index].clear();
@@ -585,7 +585,7 @@ bool MoveCommitter::hasPendingMoves(const MoveType type,
 bool MoveCommitter::hasMoves(const MoveType type, sta::Instance* inst) const
 {
   const size_t index = typeIndex(type);
-  return all_instances_by_type_[index].contains(inst)
+  return committed_instances_by_type_[index].contains(inst)
          || pending_instances_by_type_[index].contains(inst);
 }
 

--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -59,7 +59,7 @@ MoveCommitter::MoveCommitter(Resizer& resizer) : resizer_(resizer)
 
 void MoveCommitter::init()
 {
-  journal_open_ = false;
+  pending_move_results_ = std::stack<std::vector<MoveResult>>{};
   std::ranges::fill(summary_carried_by_type_, 0);
   summary_carried_by_type_[typeIndex(MoveType::kSizeUpMatch)]
       = persisted_summary_by_type_[typeIndex(MoveType::kSizeUpMatch)];
@@ -90,6 +90,12 @@ MoveResult MoveCommitter::commit(MoveCandidate& candidate)
   MoveResult result = candidate.apply();
   if (result.accepted) {
     recordAcceptedResult(result);
+    // Only the journaled path needs the per-level result trail; non-journaled
+    // commits (e.g. MeasuredVtSwapPolicy) flush via acceptPendingMoves and
+    // never restore.
+    if (!pending_move_results_.empty()) {
+      pending_move_results_.top().push_back(result);
+    }
   }
   return result;
 }
@@ -366,8 +372,7 @@ bool MoveCommitter::canManageJournal() const
 
 void MoveCommitter::recordAcceptedResult(const MoveResult& result)
 {
-  // Track committed instances by move type so later passes can avoid
-  // conflicts.
+  // Track committed instances by move type so later passes can avoid conflicts
   const size_t index = typeIndex(result.type);
   pending_by_type_[index] += result.move_count;
   for (sta::Instance* inst : result.touched_instances) {
@@ -375,7 +380,20 @@ void MoveCommitter::recordAcceptedResult(const MoveResult& result)
     // Preserve legacy BaseMove semantics: once a move type touched an
     // instance in this repair session, later guards still see it even if the
     // journal branch is restored.
+    // FIXME: This should be removed after policies start using the nested
+    // journaling capability.
     committed_instances_by_type_[index].insert(inst);
+  }
+}
+
+void MoveCommitter::unrecordAcceptedResult(const MoveResult& result)
+{
+  // Remove the reverted move results
+  const size_t index = typeIndex(result.type);
+  pending_by_type_[index] -= result.move_count;
+  for (sta::Instance* inst : result.touched_instances) {
+    pending_instances_by_type_[index].erase(
+        pending_instances_by_type_[index].find(inst));
   }
 }
 
@@ -463,29 +481,54 @@ void MoveCommitter::beginJournal()
   if (!canManageJournal()) {
     return;
   }
-  // Start one reversible ECO batch for the current search branch.
+  // Start one reversible ECO batch for the current search branch. Stacks
+  // naturally: odb's beginEco pushes the current journal aside, and we mirror
+  // that with a fresh per-level result vector here.
   beginEcoJournal();
-  journal_open_ = true;
+  pending_move_results_.emplace();
 }
 
 void MoveCommitter::commitJournal()
 {
-  if (!canManageJournal() || !journal_open_) {
+  if (!canManageJournal() || pending_move_results_.empty()) {
     return;
   }
-  // Refresh timing only once after a batch of ECO edits becomes permanent.
+  // Refresh timing only once after a batch of ECO edits becomes permanent
   if (ecoHasPendingChanges()) {
     resizer_.updateParasiticsAndTiming();
   }
-  // Close the reversible batch and fold the accepted moves into the totals.
+  // Close the reversible batch. odb::commitEco appends the inner journal to its
+  // parent when one exists, otherwise the changes become permanent.
   commitEcoJournal();
-  acceptPendingMoves();
-  journal_open_ = false;
+
+  std::vector<MoveResult> top = std::move(pending_move_results_.top());
+  pending_move_results_.pop();
+
+  if (pending_move_results_.empty()) {
+    // Outermost commit: fold the accumulated pending counters into the
+    // committed totals and flush the tracker.
+    acceptPendingMoves();
+  } else {
+    // Nested commit: the moves remain pending against the parent journal,
+    // so the parent restore can still undo them. Merge our results into
+    // the parent's vector; pending_by_type_ / pending_instances_by_type_
+    // already reflect the cumulative state and stay untouched.
+    debugPrint(resizer_.logger(),
+               RSZ,
+               "journal",
+               2,
+               "nested journal commit: merged {} results into parent",
+               top.size());
+    auto& parent = pending_move_results_.top();
+    for (MoveResult& result : top) {
+      parent.push_back(std::move(result));
+    }
+  }
 }
 
 void MoveCommitter::restoreJournal()
 {
-  if (!canManageJournal() || !journal_open_) {
+  if (!canManageJournal() || pending_move_results_.empty()) {
     return;
   }
   // Undo both database edits and in-memory accounting for the rejected branch
@@ -495,21 +538,43 @@ void MoveCommitter::restoreJournal()
 
   const bool had_eco_changes = ecoHasPendingChanges();
   restoreEcoJournal();
-  if (!had_eco_changes) {
-    rejectPendingMoves();
-    journal_open_ = false;
+
+  // Unrecord just this level's accepted results; the parent's accumulated
+  // pending state (if any) must survive.
+  std::vector<MoveResult> top = std::move(pending_move_results_.top());
+  pending_move_results_.pop();
+  int reverted_moves = 0;
+  for (const MoveResult& result : top) {
+    reverted_moves += result.move_count;
+  }
+  resizer_.addRejectedLegacyMoveCount(reverted_moves);
+  if (pending_move_results_.empty()) {
+    // pending_by_type_ still holds the about-to-be-reverted counts at this
+    // point; log the per-type breakdown before draining them.
+    logPendingMoves("UNDO", reverted_moves);
+  } else {
     debugPrint(resizer_.logger(),
                RSZ,
                "journal",
-               1,
-               "journal restore ends due to empty ECO >>>");
-    return;
+               2,
+               "nested journal restore: reverted {} moves",
+               reverted_moves);
+  }
+  for (const MoveResult& result : top) {
+    unrecordAcceptedResult(result);
   }
 
-  resizer_.updateParasiticsAndTiming();
-  resizer_.invalidateVertexOrdering();
-  rejectPendingMoves();
-  journal_open_ = false;
+  if (had_eco_changes) {
+    resizer_.updateParasiticsAndTiming();
+    resizer_.invalidateVertexOrdering();
+  }
+
+  if (pending_move_results_.empty()) {
+    // Outermost restore: the tracker's pending entries are no longer
+    // load-bearing. Flush them and emit the totals snapshot.
+    rejectTrackedMoves();
+    logCommittedTotals();
+  }
 
   debugPrint(resizer_.logger(), RSZ, "journal", 1, "journal restore ends <<<");
 }
@@ -543,7 +608,7 @@ void MoveCommitter::rejectPendingMoves()
   resizer_.addRejectedLegacyMoveCount(move_count);
 
   std::ranges::fill(pending_by_type_, 0);
-  for (std::unordered_set<sta::Instance*>& pending_instances :
+  for (std::unordered_multiset<sta::Instance*>& pending_instances :
        pending_instances_by_type_) {
     pending_instances.clear();
   }

--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <cstddef>
 #include <memory>
+#include <stack>
 #include <string>
 #include <unordered_set>
 #include <utility>

--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -392,16 +392,13 @@ void MoveCommitter::beginEcoJournal() const
 
 void MoveCommitter::commitEcoJournal() const
 {
-  debugPrint(resizer_.logger(), RSZ, "journal", 1, "journal end");
-  // Refresh timing only once after a batch of ECO edits becomes permanent.
-  if (ecoHasPendingChanges()) {
-    resizer_.updateParasiticsAndTiming();
-  }
+  debugPrint(resizer_.logger(), RSZ, "journal", 1, "journal commit");
   odb::dbDatabase::commitEco(resizer_.block());
 }
 
 void MoveCommitter::restoreEcoJournal() const
 {
+  debugPrint(resizer_.logger(), RSZ, "journal", 1, "journal restore");
   odb::dbDatabase::undoEco(resizer_.block());
 }
 
@@ -466,7 +463,6 @@ void MoveCommitter::beginJournal()
   if (!canManageJournal()) {
     return;
   }
-
   // Start one reversible ECO batch for the current search branch.
   beginEcoJournal();
   journal_open_ = true;
@@ -477,7 +473,10 @@ void MoveCommitter::commitJournal()
   if (!canManageJournal() || !journal_open_) {
     return;
   }
-
+  // Refresh timing only once after a batch of ECO edits becomes permanent.
+  if (ecoHasPendingChanges()) {
+    resizer_.updateParasiticsAndTiming();
+  }
   // Close the reversible batch and fold the accepted moves into the totals.
   commitEcoJournal();
   acceptPendingMoves();
@@ -489,8 +488,7 @@ void MoveCommitter::restoreJournal()
   if (!canManageJournal() || !journal_open_) {
     return;
   }
-
-  // Undo both database edits and in-memory accounting for the rejected branch.
+  // Undo both database edits and in-memory accounting for the rejected branch
   debugPrint(
       resizer_.logger(), RSZ, "journal", 1, "journal restore starts >>>");
   resizer_.initForJournalRestore();
@@ -509,6 +507,7 @@ void MoveCommitter::restoreJournal()
   }
 
   resizer_.updateParasiticsAndTiming();
+  resizer_.invalidateVertexOrdering();
   rejectPendingMoves();
   journal_open_ = false;
 

--- a/src/rsz/src/MoveCommitter.cc
+++ b/src/rsz/src/MoveCommitter.cc
@@ -487,6 +487,11 @@ void MoveCommitter::beginJournal()
   // that with a fresh per-level result vector here.
   beginEcoJournal();
   pending_move_results_.emplace();
+  // Mirror the journal level in the tracker so a nested restore rejects only
+  // its own moves.
+  if (move_tracker_) {
+    move_tracker_->beginJournal();
+  }
 }
 
 void MoveCommitter::commitJournal()
@@ -501,6 +506,11 @@ void MoveCommitter::commitJournal()
   // Close the reversible batch. odb::commitEco appends the inner journal to its
   // parent when one exists, otherwise the changes become permanent.
   commitEcoJournal();
+  // Mirror the journal commit in the tracker: an outermost commit finalizes
+  // the tracked moves, a nested commit merges them into the parent level.
+  if (move_tracker_) {
+    move_tracker_->commitJournal();
+  }
 
   std::vector<MoveResult> top = std::move(pending_move_results_.top());
   pending_move_results_.pop();
@@ -539,6 +549,11 @@ void MoveCommitter::restoreJournal()
 
   const bool had_eco_changes = ecoHasPendingChanges();
   restoreEcoJournal();
+  // Mirror the journal restore in the tracker so its moves are rejected,
+  // whether this is an outermost or a nested restore.
+  if (move_tracker_) {
+    move_tracker_->restoreJournal();
+  }
 
   // Unrecord just this level's accepted results; the parent's accumulated
   // pending state (if any) must survive.

--- a/src/rsz/src/MoveCommitter.hh
+++ b/src/rsz/src/MoveCommitter.hh
@@ -168,7 +168,7 @@ class MoveCommitter
   std::array<int, kTypeCount> summary_carried_by_type_{};
   std::array<std::unordered_multiset<sta::Instance*>, kTypeCount>
       pending_instances_by_type_{};
-  std::array<std::unordered_multiset<sta::Instance*>, kTypeCount>
+  std::array<std::unordered_set<sta::Instance*>, kTypeCount>
       committed_instances_by_type_{};
 
   // === MoveTracker state ====================================================

--- a/src/rsz/src/MoveCommitter.hh
+++ b/src/rsz/src/MoveCommitter.hh
@@ -163,7 +163,7 @@ class MoveCommitter
   std::array<std::unordered_set<sta::Instance*>, kTypeCount>
       pending_instances_by_type_{};
   std::array<std::unordered_set<sta::Instance*>, kTypeCount>
-      all_instances_by_type_{};
+      committed_instances_by_type_{};
 
   // === MoveTracker state ====================================================
   std::unique_ptr<MoveTracker> move_tracker_;

--- a/src/rsz/src/MoveCommitter.hh
+++ b/src/rsz/src/MoveCommitter.hh
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <stack>
 #include <string>
 #include <unordered_set>
 #include <utility>
@@ -137,6 +138,7 @@ class MoveCommitter
   // === Commit result handling ==============================================
   bool canManageJournal() const;
   void recordAcceptedResult(const MoveResult& result);
+  void unrecordAcceptedResult(const MoveResult& result);
   int pendingMoveCount() const;
 
   // === ECO journal internals ===============================================
@@ -156,13 +158,17 @@ class MoveCommitter
   Resizer& resizer_;
 
   // === Journal and move accounting state ===================================
-  bool journal_open_{false};
+  // Stack depth equals the number of currently open ECO journals. Each vector
+  // holds the results accepted at that nesting level so a nested restore can
+  // unrecord just its own moves and a nested commit can merge its results into
+  // the parent's vector (mirroring odb's commitEco append-to-parent semantics).
+  std::stack<std::vector<MoveResult>> pending_move_results_;
   std::array<int, kTypeCount> pending_by_type_{};
   std::array<int, kTypeCount> committed_by_type_{};
   std::array<int, kTypeCount> summary_carried_by_type_{};
-  std::array<std::unordered_set<sta::Instance*>, kTypeCount>
+  std::array<std::unordered_multiset<sta::Instance*>, kTypeCount>
       pending_instances_by_type_{};
-  std::array<std::unordered_set<sta::Instance*>, kTypeCount>
+  std::array<std::unordered_multiset<sta::Instance*>, kTypeCount>
       committed_instances_by_type_{};
 
   // === MoveTracker state ====================================================

--- a/src/rsz/src/MoveTracker.cc
+++ b/src/rsz/src/MoveTracker.cc
@@ -11,6 +11,7 @@
 #include <limits>
 #include <map>
 #include <sstream>
+#include <stack>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -187,6 +188,7 @@ void MoveTracker::clear()
   visit_count_.clear();
   moves_.clear();
   pending_moves_.clear();
+  pending_move_levels_ = {};
   current_endpoint_ = nullptr;
 }
 
@@ -263,53 +265,84 @@ void MoveTracker::trackMove(const sta::Pin* pin,
 {
   assert(visit_count_.contains(pin)
          && "Pin must be visited before tracking moves.");
-  pending_moves_.emplace_back(pin, move_type, state);
+  // A move recorded while an ECO journal is open belongs to the innermost
+  // journal level, so a nested restore can reject exactly that level. With
+  // no open journal it goes to the flat bucket commitMoves()/rejectMoves()
+  // drain.
+  if (pending_move_levels_.empty()) {
+    pending_moves_.emplace_back(pin, move_type, state);
+  } else {
+    pending_move_levels_.top().emplace_back(pin, move_type, state);
+  }
+}
+
+void MoveTracker::finalizeMoves(const std::vector<MoveStateData>& level,
+                                const MoveStateType final_state)
+{
+  for (const MoveStateData& move : level) {
+    moves_.emplace_back(move.pin, move_count_++, move.move_type, final_state);
+    // Store in move event list for detailed reports
+    pin_move_events_[move.pin].emplace_back(move.move_type, final_state);
+  }
+
+  // Track per-endpoint statistics
+  if (current_endpoint_ && !level.empty()) {
+    auto& counts = endpoint_move_counts_[current_endpoint_];
+    std::get<0>(counts) += level.size();  // attempts
+    if (final_state == MoveStateType::ATTEMPT_COMMIT) {
+      std::get<2>(counts) += level.size();  // commits
+    } else {
+      std::get<1>(counts) += level.size();  // rejects
+    }
+  }
 }
 
 void MoveTracker::commitMoves()
 {
-  for (const auto& pending_move : pending_moves_) {
-    moves_.emplace_back(pending_move.pin,
-                        move_count_++,
-                        pending_move.move_type,
-                        MoveStateType::ATTEMPT_COMMIT);
-
-    // Store in move event list for detailed reports
-    pin_move_events_[pending_move.pin].emplace_back(
-        pending_move.move_type, MoveStateType::ATTEMPT_COMMIT);
-  }
-
-  // Track per-endpoint statistics
-  if (current_endpoint_ && !pending_moves_.empty()) {
-    auto& counts = endpoint_move_counts_[current_endpoint_];
-    std::get<0>(counts) += pending_moves_.size();  // attempts
-    std::get<2>(counts) += pending_moves_.size();  // commits
-  }
-
+  finalizeMoves(pending_moves_, MoveStateType::ATTEMPT_COMMIT);
   pending_moves_.clear();
 }
 
 void MoveTracker::rejectMoves()
 {
-  for (const auto& pending_move : pending_moves_) {
-    moves_.emplace_back(pending_move.pin,
-                        move_count_++,
-                        pending_move.move_type,
-                        MoveStateType::ATTEMPT_REJECT);
-
-    // Store in move event list for detailed reports
-    pin_move_events_[pending_move.pin].emplace_back(
-        pending_move.move_type, MoveStateType::ATTEMPT_REJECT);
-  }
-
-  // Track per-endpoint statistics
-  if (current_endpoint_ && !pending_moves_.empty()) {
-    auto& counts = endpoint_move_counts_[current_endpoint_];
-    std::get<0>(counts) += pending_moves_.size();  // attempts
-    std::get<1>(counts) += pending_moves_.size();  // rejects
-  }
-
+  finalizeMoves(pending_moves_, MoveStateType::ATTEMPT_REJECT);
   pending_moves_.clear();
+}
+
+void MoveTracker::beginJournal()
+{
+  pending_move_levels_.emplace();
+}
+
+void MoveTracker::commitJournal()
+{
+  if (pending_move_levels_.empty()) {
+    return;
+  }
+  std::vector<MoveStateData> level = std::move(pending_move_levels_.top());
+  pending_move_levels_.pop();
+  if (pending_move_levels_.empty()) {
+    // Outermost commit: the moves are now permanent.
+    finalizeMoves(level, MoveStateType::ATTEMPT_COMMIT);
+  } else {
+    // Nested commit: the moves stay pending against the parent journal so a
+    // later parent restore can still reject them.
+    std::vector<MoveStateData>& parent = pending_move_levels_.top();
+    for (MoveStateData& move : level) {
+      parent.push_back(std::move(move));
+    }
+  }
+}
+
+void MoveTracker::restoreJournal()
+{
+  if (pending_move_levels_.empty()) {
+    return;
+  }
+  // The journal's database edits were undone, so its moves are rejected
+  std::vector<MoveStateData> level = std::move(pending_move_levels_.top());
+  pending_move_levels_.pop();
+  finalizeMoves(level, MoveStateType::ATTEMPT_REJECT);
 }
 
 int MoveTracker::getVisitCount(const sta::Pin* pin) const

--- a/src/rsz/src/MoveTracker.hh
+++ b/src/rsz/src/MoveTracker.hh
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <set>
+#include <stack>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -159,6 +160,16 @@ class MoveTracker : public odb::dbBlockCallBackObj
   // Reject all pending moves (mark them as failed)
   void rejectMoves();
 
+  // === Nested ECO journal support ==========================================
+  // MoveCommitter mirrors its ECO journal stack here. A move recorded with
+  // trackMove() while a journal is open lands in the innermost level;
+  // restoreJournal() rejects exactly that level's moves, and commitJournal()
+  // either finalizes them (outermost journal) or merges them into the parent
+  // level (nested journal) so a later parent restore can still reject them.
+  void beginJournal();
+  void commitJournal();
+  void restoreJournal();
+
   // === Phase and final reports =============================================
   // Print statistics summary for current pass and cumulative totals
   void printMoveSummary(const std::string& title);
@@ -202,9 +213,17 @@ class MoveTracker : public odb::dbBlockCallBackObj
   int getTotalCommits() const { return total_commit_count_; }
   int getTotalRejects() const { return total_reject_count_; }
 
+  // Terminal-state log of every finalized move (committed or rejected),
+  // in finalize order.
+  const std::vector<MoveStateData>& moveLog() const { return moves_; }
+
  private:
   // === Summary maintenance ==================================================
   void clearMoveSummary();
+  // Migrate a level of pending moves into the committed move log with the given
+  // terminal state, updating per-pin and per-endpoint statistics.
+  void finalizeMoves(const std::vector<MoveStateData>& level,
+                     MoveStateType final_state);
   std::string pinPathName(const sta::Pin* pin) const;
 
   // === Report helpers =======================================================
@@ -236,7 +255,13 @@ class MoveTracker : public odb::dbBlockCallBackObj
   int move_count_;
   std::map<const sta::Pin*, int> visit_count_;
   std::vector<MoveStateData> moves_;
+  // Moves tracked outside any ECO journal (e.g. MeasuredVtSwapPolicy);
+  // flushed directly by commitMoves() / rejectMoves().
   std::vector<MoveStateData> pending_moves_;
+  // One pending-move level per open ECO journal, innermost on top. Mirrors
+  // MoveCommitter's journal stack; see beginJournal()/commitJournal()/
+  // restoreJournal().
+  std::stack<std::vector<MoveStateData>> pending_move_levels_;
 
   // === Cumulative move statistics ==========================================
   // Cumulative statistics across all passes

--- a/src/rsz/src/policy/SetupLegacyBase.cc
+++ b/src/rsz/src/policy/SetupLegacyBase.cc
@@ -268,9 +268,7 @@ void SetupLegacyBase::acceptEndpointState(
   if (!endpoint_state.journal_open) {
     return;
   }
-
   committer_.commitJournal();
-  committer_.acceptPendingMoves();
   endpoint_state.journal_open = false;
 }
 
@@ -280,9 +278,7 @@ void SetupLegacyBase::restoreEndpointState(
   if (!endpoint_state.journal_open) {
     return;
   }
-
   committer_.restoreJournal();
-  committer_.rejectPendingMoves();
   endpoint_state.journal_open = false;
 }
 

--- a/src/rsz/src/policy/SetupLegacyBase.cc
+++ b/src/rsz/src/policy/SetupLegacyBase.cc
@@ -247,7 +247,7 @@ bool SetupLegacyBase::beginJournaledEndpointSearch(
   endpoint_state.pass = 1;
   endpoint_state.decreasing_slack_passes = 0;
   endpoint_state.force_single_repair = false;
-  resizer_.journalBegin();
+  committer_.beginJournal();
   endpoint_state.journal_open = true;
   return true;
 }
@@ -269,7 +269,7 @@ void SetupLegacyBase::acceptEndpointState(
     return;
   }
 
-  resizer_.journalEnd();
+  committer_.commitJournal();
   committer_.acceptPendingMoves();
   endpoint_state.journal_open = false;
 }
@@ -281,7 +281,7 @@ void SetupLegacyBase::restoreEndpointState(
     return;
   }
 
-  resizer_.journalRestore();
+  committer_.restoreJournal();
   committer_.rejectPendingMoves();
   endpoint_state.journal_open = false;
 }
@@ -300,7 +300,7 @@ void SetupLegacyBase::saveImprovedCheckpoint(
     SetupLegacyBase::EndpointRepairState& endpoint_state)
 {
   acceptEndpointState(endpoint_state);
-  resizer_.journalBegin();
+  committer_.beginJournal();
   endpoint_state.journal_open = true;
 }
 

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -532,7 +532,7 @@ cc_test(
     features = ["-layering_check"],
     deps = [
         "//src/dbSta",
-        "//src/odb",
+        "//src/odb/src/db",
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/tst:integrated_fixture",

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -518,6 +518,31 @@ cc_test(
 )
 
 cc_test(
+    name = "TestNestedJournal",
+    srcs = ["cpp/TestNestedJournal.cc"],
+    copts = [
+        "-Isrc/rsz/src",
+        "-Isrc/rsz/src/move",
+    ],
+    data = [
+        "Nangate45/Nangate45.lef",
+        "Nangate45/Nangate45_typ.lib",
+        "cpp/TestBufferRemoval3_0.v",
+    ],
+    features = ["-layering_check"],
+    deps = [
+        "//src/dbSta",
+        "//src/odb",
+        "//src/rsz",
+        "//src/sta:opensta_lib",
+        "//src/tst:integrated_fixture",
+        "//src/utl",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "TestResizerMt",
     srcs = ["cpp/TestResizerMt.cc"],
     args = ["--gtest_filter=TestResizerMtThreadPool.*"],

--- a/src/rsz/test/cpp/CMakeLists.txt
+++ b/src/rsz/test/cpp/CMakeLists.txt
@@ -143,6 +143,36 @@ gtest_discover_tests(TestInsertBuffer
 add_dependencies(build_and_test TestInsertBuffer
 )
 
+add_executable(TestNestedJournal TestNestedJournal.cc)
+target_link_libraries(TestNestedJournal
+        OpenSTA
+        GTest::gtest
+        GTest::gtest_main
+        GTest::gmock
+        dbSta_lib
+        utl_lib
+        rsz_lib
+        grt_lib
+        dpl_lib
+        stt_lib
+        odb
+        tst
+        ${TCL_LIBRARY}
+)
+
+target_include_directories(TestNestedJournal
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/rsz/src
+      ${PROJECT_SOURCE_DIR}/src/rsz/src/move
+)
+
+gtest_discover_tests(TestNestedJournal
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/..
+)
+
+add_dependencies(build_and_test TestNestedJournal
+)
+
 add_executable(TestResizerMt TestResizerMt.cc)
 target_link_libraries(TestResizerMt
         OpenSTA

--- a/src/rsz/test/cpp/TestNestedJournal.cc
+++ b/src/rsz/test/cpp/TestNestedJournal.cc
@@ -29,6 +29,7 @@
 #include "db_sta/dbSta.hh"
 #include "gtest/gtest.h"
 #include "odb/db.h"
+#include "odb/dbSet.h"
 #include "rsz/Resizer.hh"
 #include "tst/IntegratedFixture.h"
 

--- a/src/rsz/test/cpp/TestNestedJournal.cc
+++ b/src/rsz/test/cpp/TestNestedJournal.cc
@@ -24,6 +24,7 @@
 
 #include "MoveCandidate.hh"
 #include "MoveCommitter.hh"
+#include "MoveTracker.hh"
 #include "OptimizerTypes.hh"
 #include "db_sta/dbSta.hh"
 #include "gtest/gtest.h"
@@ -105,6 +106,19 @@ class NestedJournalTest : public tst::IntegratedFixture
                                                sta::Instance* inst)
   {
     return std::make_unique<FakeCandidate>(resizer_, target_, type, inst);
+  }
+
+  // First leaf-instance pin in the loaded design. MoveTracker::trackMove()
+  // asserts the pin was visited first, so the tracker tests need a real pin.
+  const sta::Pin* firstPin() const
+  {
+    for (odb::dbInst* db_inst : block_->getInsts()) {
+      odb::dbSet<odb::dbITerm> iterms = db_inst->getITerms();
+      if (iterms.begin() != iterms.end()) {
+        return db_network_->dbToSta(*iterms.begin());
+      }
+    }
+    return nullptr;
   }
 
   std::unique_ptr<MoveCommitter> committer_;
@@ -277,6 +291,76 @@ TEST_F(NestedJournalTest, CommitOutsideAnyJournalIsSafe)
   committer_->acceptPendingMoves();
   EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
   EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+}
+
+// === MoveTracker nested journal support ====================================
+
+// MoveCommitter mirrors its ECO journal stack into MoveTracker so a nested
+// restore rejects only its own moves. Without that, the sequence below reports
+// the reverted BufferMove as committed.
+TEST_F(NestedJournalTest, MoveTrackerNestedRestoreRejectsInnerMove)
+{
+  MoveTracker tracker(resizer_, /*report_enabled=*/true);
+  const sta::Pin* pin = firstPin();
+  ASSERT_NE(pin, nullptr);
+  tracker.trackViolator(pin);
+
+  // beginJournal / commit A / beginJournal / commit B / restoreJournal /
+  // commitJournal: the nested restore reverts B in ODB, so only A commits.
+  tracker.beginJournal();
+  tracker.trackMove(pin, "SizeUpMove", MoveStateType::ATTEMPT);
+  tracker.beginJournal();
+  tracker.trackMove(pin, "BufferMove", MoveStateType::ATTEMPT);
+  tracker.restoreJournal();
+  tracker.commitJournal();
+
+  int committed = 0;
+  int rejected = 0;
+  std::string committed_move;
+  std::string rejected_move;
+  for (const MoveStateData& move : tracker.moveLog()) {
+    if (move.state == MoveStateType::ATTEMPT_COMMIT) {
+      ++committed;
+      committed_move = move.move_type;
+    } else if (move.state == MoveStateType::ATTEMPT_REJECT) {
+      ++rejected;
+      rejected_move = move.move_type;
+    }
+  }
+  EXPECT_EQ(committed, 1);
+  EXPECT_EQ(rejected, 1);
+  EXPECT_EQ(committed_move, "SizeUpMove");
+  EXPECT_EQ(rejected_move, "BufferMove");
+}
+
+// A nested commit keeps its moves pending against the parent journal; the outer
+// commit then finalizes both.
+TEST_F(NestedJournalTest, MoveTrackerNestedCommitFinalizesAtOuterCommit)
+{
+  MoveTracker tracker(resizer_, /*report_enabled=*/true);
+  const sta::Pin* pin = firstPin();
+  ASSERT_NE(pin, nullptr);
+  tracker.trackViolator(pin);
+
+  tracker.beginJournal();
+  tracker.trackMove(pin, "SizeUpMove", MoveStateType::ATTEMPT);
+  tracker.beginJournal();
+  tracker.trackMove(pin, "BufferMove", MoveStateType::ATTEMPT);
+  tracker.commitJournal();  // nested: moves stay pending against the parent
+  EXPECT_TRUE(tracker.moveLog().empty());
+
+  tracker.commitJournal();  // outer: both moves are now committed
+  int committed = 0;
+  int rejected = 0;
+  for (const MoveStateData& move : tracker.moveLog()) {
+    if (move.state == MoveStateType::ATTEMPT_COMMIT) {
+      ++committed;
+    } else if (move.state == MoveStateType::ATTEMPT_REJECT) {
+      ++rejected;
+    }
+  }
+  EXPECT_EQ(committed, 2);
+  EXPECT_EQ(rejected, 0);
 }
 
 }  // namespace rsz

--- a/src/rsz/test/cpp/TestNestedJournal.cc
+++ b/src/rsz/test/cpp/TestNestedJournal.cc
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026-2026, The OpenROAD Authors
+
+// Regression for MoveCommitter's nested ECO journal accounting.
+//
+// Background: odb's beginEco/commitEco/undoEco support nesting natively
+// (commitEco appends an inner journal to its parent; undoEco only unwinds
+// the innermost level). MoveCommitter mirrors that for its in-memory
+// pending/committed move accounting via a stack of per-level result vectors.
+//
+// Each test would fail on a flat (non-nested) MoveCommitter:
+//   - NestedCommitMergesIntoParent: the old code finalized on every commit,
+//     so pending counts would jump to zero halfway through.
+//   - NestedRestoreUnwindsInnerOnly: the old code's rejectPendingMoves
+//     would clear the parent's pending counts as well.
+//   - MultisetMembershipSurvivesPartialUndo: with std::unordered_set the
+//     parent's touch on the same instance would be erased when the inner
+//     restore removed the inner touch.
+//   - CommitOutsideAnyJournalIsSafe: an unguarded push onto an empty
+//     pending_move_results_ stack would be UB.
+
+#include <memory>
+#include <string>
+
+#include "MoveCandidate.hh"
+#include "MoveCommitter.hh"
+#include "OptimizerTypes.hh"
+#include "db_sta/dbSta.hh"
+#include "gtest/gtest.h"
+#include "odb/db.h"
+#include "rsz/Resizer.hh"
+#include "tst/IntegratedFixture.h"
+
+namespace rsz {
+
+namespace {
+
+// MoveCandidate stub that returns a fixed accepted result. apply() does not
+// touch the database - the open ECO journal stays empty, which odb handles
+// correctly on commit/undo. All we need from the candidate is to drive
+// recordAcceptedResult / unrecordAcceptedResult through commit().
+class FakeCandidate : public MoveCandidate
+{
+ public:
+  FakeCandidate(Resizer& resizer,
+                const Target& target,
+                const MoveType type,
+                sta::Instance* touched_inst)
+      : MoveCandidate(resizer, target), type_(type), touched_inst_(touched_inst)
+  {
+  }
+
+  MoveResult apply() override
+  {
+    MoveResult result;
+    result.accepted = true;
+    result.type = type_;
+    result.move_count = 1;
+    if (touched_inst_ != nullptr) {
+      result.touched_instances.push_back(touched_inst_);
+    }
+    return result;
+  }
+
+  MoveType type() const override { return type_; }
+
+ private:
+  MoveType type_;
+  sta::Instance* touched_inst_;
+};
+
+}  // namespace
+
+class NestedJournalTest : public tst::IntegratedFixture
+{
+ protected:
+  NestedJournalTest()
+      : tst::IntegratedFixture(tst::IntegratedFixture::Technology::kNangate45,
+                               "_main/src/rsz/test/")
+  {
+  }
+
+  void SetUp() override
+  {
+    readVerilogAndSetup("TestBufferRemoval3_0.v");
+    committer_ = std::make_unique<MoveCommitter>(resizer_);
+    committer_->init();
+
+    // Pick any two instances from the loaded design as targets for the fake
+    // moves. We need real sta::Instance pointers because MoveCommitter inserts
+    // them into its touched-instance multisets.
+    auto inst_iter = block_->getInsts().begin();
+    ASSERT_NE(inst_iter, block_->getInsts().end());
+    inst_a_ = db_network_->dbToSta(*inst_iter);
+    ASSERT_NE(inst_a_, nullptr);
+    ++inst_iter;
+    if (inst_iter != block_->getInsts().end()) {
+      inst_b_ = db_network_->dbToSta(*inst_iter);
+    } else {
+      inst_b_ = inst_a_;
+    }
+  }
+
+  std::unique_ptr<FakeCandidate> makeCandidate(const MoveType type,
+                                               sta::Instance* inst)
+  {
+    return std::make_unique<FakeCandidate>(resizer_, target_, type, inst);
+  }
+
+  std::unique_ptr<MoveCommitter> committer_;
+  Target target_;  // Default-constructed; FakeCandidate::apply ignores it
+  sta::Instance* inst_a_{nullptr};
+  sta::Instance* inst_b_{nullptr};
+};
+
+// === Outermost journal - should commit/revert all pending moves ============
+
+TEST_F(NestedJournalTest, OuterCommitFinalizesPendingMoves)
+{
+  ASSERT_EQ(committer_->totalMoves(MoveType::kSizeUp), 0);
+
+  committer_->beginJournal();
+  auto cand = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand).accepted);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 0);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+
+  committer_->commitJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+}
+
+TEST_F(NestedJournalTest, OuterRestoreUnwindsPendingMoves)
+{
+  committer_->beginJournal();
+  auto cand = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand).accepted);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+
+  committer_->restoreJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 0);
+  EXPECT_FALSE(committer_->hasPendingMoves(MoveType::kSizeUp, inst_a_));
+  // hasMoves() still returns true: recordAcceptedResult inserts into
+  // committed_instances_by_type_ on the spot to preserve the legacy
+  // "once touched, always touched" guard semantics until policies start
+  // using nested journals. Tracked by the FIXME in
+  // MoveCommitter::recordAcceptedResult; flip this expectation when that
+  // FIXME is removed.
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+}
+
+// === Nested journal - should handle the nested journals ====================
+
+TEST_F(NestedJournalTest, NestedCommitMergesIntoParent)
+{
+  committer_->beginJournal();
+  auto cand_a = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand_a).accepted);
+
+  committer_->beginJournal();  // nested
+  auto cand_b = makeCandidate(MoveType::kSizeUp, inst_b_);
+  ASSERT_TRUE(committer_->commit(*cand_b).accepted);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 2);
+
+  // Inner commit must not finalize - both moves stay pending against
+  // the parent journal
+  committer_->commitJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 2);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 0);
+
+  // Outer commit folds the accumulated pending into committed totals
+  committer_->commitJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 2);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_b_));
+}
+
+TEST_F(NestedJournalTest, NestedRestoreUnwindsInnerOnly)
+{
+  committer_->beginJournal();
+  auto cand_a = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand_a).accepted);
+
+  committer_->beginJournal();  // nested
+  auto cand_b = makeCandidate(MoveType::kClone, inst_b_);
+  ASSERT_TRUE(committer_->commit(*cand_b).accepted);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kClone), 1);
+
+  // Restoring the inner journal must drop B's pending touch but leave A
+  // intact. hasMoves() on inst_b_/Clone still returns true because of the
+  // legacy "once touched, always touched" insert in recordAcceptedResult
+  // (see FIXME in MoveCommitter); use hasPendingMoves to assert the actual
+  // restore behaviour.
+  committer_->restoreJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kClone), 0);
+  EXPECT_TRUE(committer_->hasPendingMoves(MoveType::kSizeUp, inst_a_));
+  EXPECT_FALSE(committer_->hasPendingMoves(MoveType::kClone, inst_b_));
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kClone, inst_b_));  // FIXME
+
+  // Outer commit then folds A into committed totals
+  committer_->commitJournal();
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kClone), 0);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kClone, inst_b_));  // FIXME
+}
+
+TEST_F(NestedJournalTest, MultisetMembershipSurvivesPartialUndo)
+{
+  // Same instance touched at two levels. Restoring the inner level must remove
+  // only its touch; the parent's still counts.
+  committer_->beginJournal();
+  auto cand_outer = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand_outer).accepted);
+
+  committer_->beginJournal();
+  auto cand_inner = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand_inner).accepted);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 2);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+
+  committer_->restoreJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+
+  committer_->commitJournal();
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+  EXPECT_TRUE(committer_->hasMoves(MoveType::kSizeUp, inst_a_));
+}
+
+TEST_F(NestedJournalTest, NestedRestoreLeavesParentJournalRecoverable)
+{
+  // After the inner journal is restored, the outer journal must still be
+  // operable: another nested begin/commit, then outer commit, should fold
+  // both surviving moves into the committed totals.
+  committer_->beginJournal();
+  auto cand_a = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand_a).accepted);
+
+  committer_->beginJournal();
+  auto cand_bad = makeCandidate(MoveType::kBuffer, inst_b_);
+  ASSERT_TRUE(committer_->commit(*cand_bad).accepted);
+  committer_->restoreJournal();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kBuffer), 0);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+
+  committer_->beginJournal();
+  auto cand_c = makeCandidate(MoveType::kSwapPins, inst_b_);
+  ASSERT_TRUE(committer_->commit(*cand_c).accepted);
+  committer_->commitJournal();  // nested commit: merges into outer
+
+  committer_->commitJournal();  // outer commit: finalizes
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSwapPins), 1);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kBuffer), 0);
+}
+
+// === Defensive guard for non-journaled callers =============================
+
+TEST_F(NestedJournalTest, CommitOutsideAnyJournalIsSafe)
+{
+  // Several policies (MeasuredVtSwapPolicy, SetupCritVtSwapPolicy, ...)
+  // call commit() without a surrounding beginJournal() and follow up with
+  // acceptPendingMoves() directly. The committer must not crash on the empty
+  // pending_move_results_ stack and must still account for the move.
+  ASSERT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
+  auto cand = makeCandidate(MoveType::kSizeUp, inst_a_);
+  ASSERT_TRUE(committer_->commit(*cand).accepted);
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 1);
+
+  committer_->acceptPendingMoves();
+  EXPECT_EQ(committer_->pendingMoves(MoveType::kSizeUp), 0);
+  EXPECT_EQ(committer_->committedMoves(MoveType::kSizeUp), 1);
+}
+
+}  // namespace rsz


### PR DESCRIPTION
## Summary
`MoveCommitter` doesn't exactly use nested journaling and can leave footprints of unrolled changes behind (`hasMoves()` sees moves on instances that were reverted). This PR doesn't fix it yet since it will change the resizer behavior but I will fix it during the refactor. After this PR is merged, that fix is just a one-liner.

## Type of Change
- Bug fix

## Impact
It doesn't change the behavior just yet.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**