### PR TITLE
doc: Remove duplicate Gemini command definitions

### DIFF
--- a/.gemini/commands/add-test.toml
+++ b/.gemini/commands/add-test.toml
@@ -1,2 +1,0 @@
-description = "Add integration or unit tests to an OpenROAD module. Handles test creation, golden file generation, and dual CMake/Bazel registration."
-prompt = "Activate the add-test skill and add tests for: {{args}}"

--- a/.gemini/commands/fix-bug.toml
+++ b/.gemini/commands/fix-bug.toml
@@ -1,2 +1,0 @@
-description = "Fix an OpenROAD bug from a GitHub issue. Analyzes the issue, traces root cause, implements fix, creates tests (CMake + Bazel), and prepares a signed-off commit."
-prompt = "Activate the fix-bug skill and fix the following: {{args}}"

--- a/.gemini/commands/review-pr.toml
+++ b/.gemini/commands/review-pr.toml
@@ -1,2 +1,0 @@
-description = "Review an OpenROAD pull request following the project's review priority order: correctness > QoR impact > testing > architecture > style > process. Prints draft notes locally; the human reviewer posts comments themselves."
-prompt = "Activate the review-pr skill and review the following PR: {{args}}"

--- a/.gemini/commands/triage-issue.toml
+++ b/.gemini/commands/triage-issue.toml
@@ -1,2 +1,0 @@
-description = "Triage an OpenROAD GitHub issue by reproducing the bug and minimizing the test case with whittle.py. Use when an issue has an attached tarball artifact (.tar.gz) from `make *_issue`."
-prompt = "Activate the triage-issue skill and triage the following issue: {{args}}"


### PR DESCRIPTION
Remove the redundant .gemini/commands entries because Gemini CLI already loads the shared Codex/Claude skills. Keeping both definitions causes duplicate skill loading errors.


**Gemini-CLI errors**
```
ℹ Conflicts detected for command '/triage-issue':
  - Workspace command '/triage-issue' was renamed to '/workspace.triage-issue'
  - Skill command '/triage-issue' was renamed to '/triage-issue1'

ℹ Conflicts detected for command '/review-pr':
  - Workspace command '/review-pr' was renamed to '/workspace.review-pr'
  - Skill command '/review-pr' was renamed to '/review-pr1'

ℹ Conflicts detected for command '/fix-bug':
  - Workspace command '/fix-bug' was renamed to '/workspace.fix-bug'
  - Skill command '/fix-bug' was renamed to '/fix-bug1'

ℹ Conflicts detected for command '/add-test':
  - Workspace command '/add-test' was renamed to '/workspace.add-test'
  - Skill command '/add-test' was renamed to '/add-test1'
```
