### PR TITLE
Fix duplicate use of header in srcs instead of depending on lib.

### DIFF
--- a/src/odb/src/swig/BUILD
+++ b/src/odb/src/swig/BUILD
@@ -84,7 +84,6 @@ filegroup(
 cc_library(
     name = "ui",
     srcs = [
-        "common/swig_common.h",
         "tcl/MakeOdb.cpp",
         ":swig",
         ":tcl",
@@ -99,6 +98,7 @@ cc_library(
         "common",
     ],
     deps = [
+        ":swig_common",
         "//:ord",
         "//src/odb/src/db",
         "//src/odb/src/defout",


### PR DESCRIPTION
Not depending on the library providing the symbols results in undefined symbols.

Issues: #10409