### PR TITLE
Use effective diff for CODEOWNERS reviewers

### DIFF
--- a/.github/workflows/github-actions-on-label-create.yml
+++ b/.github/workflows/github-actions-on-label-create.yml
@@ -101,17 +101,43 @@ jobs:
         python3 -m venv /tmp/codeowners-venv
         /tmp/codeowners-venv/bin/pip install --quiet pathspec
         /tmp/codeowners-venv/bin/python <<'PY'
-        import base64, json, os, subprocess, sys
+        import base64, json, os, subprocess, sys, time
         from pathspec import GitIgnoreSpec
 
         pr = os.environ["PR"]
         upstream = os.environ["UPSTREAM"]
 
-        pr_json = subprocess.check_output(
-            ["gh", "api", f"repos/{upstream}/pulls/{pr}"], text=True)
-        pr_data = json.loads(pr_json)
+        # GitHub computes PR mergeability asynchronously, so `mergeable` and
+        # `merge_commit_sha` are often null on the first read after PR
+        # creation. Poll until the background job finishes.
+        attempts = 10
+        delay = 3
+        for attempt in range(1, attempts + 1):
+            pr_json = subprocess.check_output(
+                ["gh", "api", f"repos/{upstream}/pulls/{pr}"], text=True)
+            pr_data = json.loads(pr_json)
+            if pr_data.get("mergeable") is not None \
+                    and pr_data.get("merge_commit_sha"):
+                break
+            print(f"Mergeability not yet computed "
+                  f"(attempt {attempt}/{attempts}); sleeping {delay}s")
+            time.sleep(delay)
+        else:
+            raise RuntimeError(
+                "PR merge commit SHA is unavailable after polling; refusing "
+                "to request CODEOWNERS reviewers from an incomplete "
+                "effective diff.")
+
         author = pr_data["user"]["login"]
         base_ref = pr_data["base"]["ref"]
+        base_repo = pr_data["base"]["repo"]["full_name"]
+        base_sha = pr_data["base"]["sha"]
+        head_repo = pr_data["head"]["repo"]["full_name"]
+        head_sha = pr_data["head"]["sha"]
+        merge_sha = pr_data["merge_commit_sha"]
+
+        print(f"Computing effective PR merge diff: {base_repo}@{base_sha}.."
+              f"{base_repo}@{merge_sha} (head {head_repo}@{head_sha})")
 
         # Authoritative CODEOWNERS is the one on the PR base branch.
         raw = subprocess.check_output(
@@ -128,11 +154,46 @@ jobs:
             pattern, *rule_owners = line.split()
             rules.append((GitIgnoreSpec.from_lines([pattern]), rule_owners))
 
-        # GitHub caps /pulls/{n}/files at 3000 even with --paginate; truly
-        # enormous PRs will under-request owners for the overflow.
-        files = subprocess.check_output(
-            ["gh", "api", f"repos/{upstream}/pulls/{pr}/files", "--paginate",
-             "--jq", ".[].filename"], text=True).splitlines()
+        def commit_tree(repo, sha):
+            commit_json = subprocess.check_output(
+                ["gh", "api", f"repos/{repo}/git/commits/{sha}"],
+                text=True)
+            commit_data = json.loads(commit_json)
+            tree_sha = commit_data["tree"]["sha"]
+            tree_json = subprocess.check_output(
+                ["gh", "api",
+                 f"repos/{repo}/git/trees/{tree_sha}?recursive=1"],
+                text=True)
+            tree_data = json.loads(tree_json)
+            if tree_data.get("truncated"):
+                raise RuntimeError(
+                    f"Recursive tree for {repo}@{sha} was truncated; "
+                    "refusing to request partial CODEOWNERS reviewers.")
+
+            entries = {}
+            for entry in tree_data["tree"]:
+                if entry["type"] == "tree":
+                    continue
+                entries[entry["path"]] = (
+                    entry.get("sha"), entry.get("mode"), entry.get("type"))
+            return entries
+
+        # Use the effective merge-result delta rather than GitHub's PR file
+        # list or a direct base -> head tree comparison. The PR file list is
+        # merge-base based, so it can include already-landed upstream changes
+        # brought in by a merge from the base branch. A direct base -> head
+        # comparison has the opposite problem when the PR branch is behind the
+        # base branch: it reports base-only changes as if the PR changed them.
+        # Comparing base -> test-merge tree matches the content that would land
+        # if this PR merged now, including real conflict-resolution edits.
+        base_tree = commit_tree(base_repo, base_sha)
+        merge_tree = commit_tree(base_repo, merge_sha)
+        files = sorted(path for path in set(base_tree) | set(merge_tree)
+                       if base_tree.get(path) != merge_tree.get(path))
+
+        print("Effective changed files:")
+        for path in files:
+            print(f"  {path}")
 
         owners = set()
         for path in files:
@@ -148,6 +209,9 @@ jobs:
         team_slugs = sorted(t.split("/", 1)[1] for t in owners if "/" in t)
         users = sorted(o for o in owners
                        if "/" not in o and o.lower() != author.lower())
+
+        print("Matched CODEOWNERS teams:", ", ".join(team_slugs) or "<none>")
+        print("Matched CODEOWNERS users:", ", ".join(users) or "<none>")
 
         if not (team_slugs or users):
             print("No CODEOWNERS-matched reviewers.")


### PR DESCRIPTION
## Summary
Update the CODEOWNERS reviewer request workflow to compute reviewers from the effective tree delta between the upstream PR base SHA and head SHA. This avoids requesting reviewers for already-landed upstream changes that appear only because a PR branch merged master, while still including real conflict-resolution edits that remain different at the branch head.

## Type of Change
- Bug fix

## Impact
CODEOWNERS reviewer requests should better match the actual current PR diff. Stale module reviewers should not be requested when their files are identical between the PR base tree and head tree.

## Verification
- [ ] I have verified that the local build succeeds (./etc/Build.sh).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

Checks run:
- ~/go/bin/actionlint .github/workflows/github-actions-on-label-create.yml
- YAML parse check with Python
- Embedded workflow Python compile check
- git diff --check -- .github/workflows/github-actions-on-label-create.yml
- API-only dry run against PR 10417 confirmed src/mpl/* is not in the effective diff and matched only openroad-dbsta, openroad-maintainers, and openroad-odb.

## Related Issues
N/A