### PR TITLE
Add `includes = [ "../../include" ]` to libraries with includes level…

### DIFF
--- a/src/odb/src/3dblox/BUILD
+++ b/src/odb/src/3dblox/BUILD
@@ -15,6 +15,9 @@ cc_library(
         "*.h",
     ]),
     hdrs = ["//src/odb:include/odb/3dblox.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/odb/src/defin",

--- a/src/odb/src/cdl/BUILD
+++ b/src/odb/src/cdl/BUILD
@@ -12,6 +12,9 @@ cc_library(
     name = "cdl",
     srcs = glob(["*.cpp"]),
     hdrs = ["//src/odb:include/odb/cdl.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/utl",

--- a/src/odb/src/defin/BUILD
+++ b/src/odb/src/defin/BUILD
@@ -15,6 +15,9 @@ cc_library(
         "*.h",
     ]),
     hdrs = ["//src/odb:include/odb/defin.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/odb/src/def",

--- a/src/odb/src/defout/BUILD
+++ b/src/odb/src/defout/BUILD
@@ -15,6 +15,9 @@ cc_library(
         "*.h",
     ]),
     hdrs = ["//src/odb:include/odb/defout.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/utl",

--- a/src/odb/src/gdsin/BUILD
+++ b/src/odb/src/gdsin/BUILD
@@ -16,6 +16,9 @@ cc_library(
         "//src/odb:include/odb/gdsUtil.h",
         "//src/odb:include/odb/gdsin.h",
     ],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/utl",

--- a/src/odb/src/gdsout/BUILD
+++ b/src/odb/src/gdsout/BUILD
@@ -12,6 +12,9 @@ cc_library(
     name = "gdsout",
     srcs = glob(["*.cpp"]),
     hdrs = ["//src/odb:include/odb/gdsout.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/odb/src/gdsin",  # for gdsUtil.h

--- a/src/odb/src/lefin/BUILD
+++ b/src/odb/src/lefin/BUILD
@@ -15,6 +15,9 @@ cc_library(
         "*.h",
     ]),
     hdrs = ["//src/odb:include/odb/lefin.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/odb/src/lef",

--- a/src/odb/src/lefout/BUILD
+++ b/src/odb/src/lefout/BUILD
@@ -12,6 +12,9 @@ cc_library(
     name = "lefout",
     srcs = glob(["*.cpp"]),
     hdrs = ["//src/odb:include/odb/lefout.h"],
+    includes = [
+        "../../include",
+    ],
     deps = [
         "//src/odb/src/db",
         "//src/utl",


### PR DESCRIPTION
…s up.

Cleanup of all the libraries that recently went further into subdirectories while the headers are still at the original place.
