### PR TITLE
Clean-up old header behind ifdef, not needed anymore.

### DIFF
--- a/src/utl/BUILD
+++ b/src/utl/BUILD
@@ -84,7 +84,6 @@ cc_library(
         "src",
     ],
     deps = [
-        "//src/sta:opensta_lib",
         "@abseil-cpp//absl/synchronization",
         "@boost.algorithm",
         "@boost.asio",

--- a/src/utl/src/Logger.cpp
+++ b/src/utl/src/Logger.cpp
@@ -17,17 +17,12 @@
 #include <utility>
 
 #include "CommandLineProgress.h"
-#include "utl/Metrics.h"
-#if SPDLOG_VERSION < 10601
-#include "spdlog/details/pattern_formatter.h"
-#else
-#include "spdlog/pattern_formatter.h"
-#endif
 #include "spdlog/common.h"
+#include "spdlog/pattern_formatter.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/sinks/ostream_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
-#include "spdlog/spdlog.h"
+#include "utl/Metrics.h"
 #include "utl/Progress.h"
 #include "utl/prometheus/metrics_server.h"
 #include "utl/prometheus/registry.h"


### PR DESCRIPTION
That also made it possible to associate all headers with providing libraries and notice a non-needed dependency.