### PR TITLE
Add includes that are needed to properly find includes in src/

### DIFF
--- a/src/dpl/src/util/color.cxx
+++ b/src/dpl/src/util/color.cxx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2021-2025, The OpenROAD Authors
 
-#include "color.h"
+#include "util/color.h"
 
 #include <algorithm>
 #include <vector>

--- a/src/grt/BUILD
+++ b/src/grt/BUILD
@@ -107,7 +107,9 @@ cc_library(
     ],
     includes = [
         "include",
+        "src",
         "src/cugr/include",
+        "src/cugr/src",
     ],
     deps = [
         ":groute",

--- a/src/pdn/BUILD
+++ b/src/pdn/BUILD
@@ -55,6 +55,7 @@ cc_library(
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//:ord",

--- a/src/psm/BUILD
+++ b/src/psm/BUILD
@@ -40,6 +40,7 @@ cc_library(
     ],
     includes = [
         "include",
+        "src",
     ],
     deps = [
         "//:ord",


### PR DESCRIPTION
Also, include a more specific `color.h` in `color.cxx`.
