### PR TITLE
gpl: parallelize updateGradients and nesterovUpdateCoordinates

### DIFF
--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -3139,7 +3139,11 @@ void NesterovBase::nesterovUpdateCoordinates(float coeff)
   }
 
   // fill in nextCoordinates with given stepLength_
-  for (size_t k = 0; k < nb_gcells_.size(); k++) {
+  // Independent writes to nextCoordi_[k] / nextSLPCoordi_[k] — trivially
+  // parallel, bit-identical to the serial version.
+  const size_t numGCells = nb_gcells_.size();
+#pragma omp parallel for num_threads(nbc_->getNumThreads())
+  for (size_t k = 0; k < numGCells; k++) {
     GCell* curGCell = nb_gcells_[k];
     if (curGCell->isLocked()) {
       nextCoordi_[k] = curCoordi_[k];

--- a/src/gpl/src/nesterovBase.cpp
+++ b/src/gpl/src/nesterovBase.cpp
@@ -2767,27 +2767,18 @@ void NesterovBase::updateGradients(std::vector<FloatPoint>& sumGrads,
   debugPrint(
       log_, GPL, "updateGrad", 1, "DensityPenalty: {:g}", densityPenalty_);
 
-  // TODO: This OpenMP parallel section is causing non-determinism. Consider
-  // revisiting this in the future to restore determinism.
-  // #pragma omp parallel for num_threads(nbc_->getNumThreads()) reduction(+ :
-  // wireLengthGradSum_, densityGradSum_, gradSum)
-  for (size_t i = 0; i < nb_gcells_.size(); i++) {
-    GCell* gCell = nb_gcells_.at(i);
+  // Two-phase: parallel per-cell compute, then deterministic serial reduce.
+  // The previous single-phase loop used `reduction(+: ...)`, whose combine
+  // order across threads is unspecified for floats, producing non-deterministic
+  // sums. Splitting the reduction out keeps results bit-identical regardless
+  // of thread count while still parallelizing the expensive gradient work.
+  const size_t numGCells = nb_gcells_.size();
+#pragma omp parallel for num_threads(nbc_->getNumThreads())
+  for (size_t i = 0; i < numGCells; i++) {
+    GCell* gCell = nb_gcells_[i];
     wireLengthGrads[i]
         = nbc_->getWireLengthGradientWA(gCell, wlCoeffX, wlCoeffY);
     densityGrads[i] = getDensityGradient(gCell);
-
-    // Different compiler has different results on the following formula.
-    // e.g. wireLengthGradSum_ += fabs(~~.x) + fabs(~~.y);
-    //
-    // To prevent instability problem,
-    // I partitioned the fabs(~~.x) + fabs(~~.y) as two terms.
-    //
-    wireLengthGradSum_ += std::fabs(wireLengthGrads[i].x);
-    wireLengthGradSum_ += std::fabs(wireLengthGrads[i].y);
-
-    densityGradSum_ += std::fabs(densityGrads[i].x);
-    densityGradSum_ += std::fabs(densityGrads[i].y);
 
     sumGrads[i].x = wireLengthGrads[i].x + densityPenalty_ * densityGrads[i].x;
     sumGrads[i].y = wireLengthGrads[i].y + densityPenalty_ * densityGrads[i].y;
@@ -2806,6 +2797,19 @@ void NesterovBase::updateGradients(std::vector<FloatPoint>& sumGrads,
 
     sumGrads[i].x /= sumPrecondi.x;
     sumGrads[i].y /= sumPrecondi.y;
+  }
+
+  // Different compiler has different results on the following formula.
+  // e.g. wireLengthGradSum_ += fabs(~~.x) + fabs(~~.y);
+  //
+  // To prevent instability problem,
+  // I partitioned the fabs(~~.x) + fabs(~~.y) as two terms.
+  for (size_t i = 0; i < numGCells; i++) {
+    wireLengthGradSum_ += std::fabs(wireLengthGrads[i].x);
+    wireLengthGradSum_ += std::fabs(wireLengthGrads[i].y);
+
+    densityGradSum_ += std::fabs(densityGrads[i].x);
+    densityGradSum_ += std::fabs(densityGrads[i].y);
 
     gradSum += std::fabs(sumGrads[i].x) + std::fabs(sumGrads[i].y);
   }


### PR DESCRIPTION
## Summary
Restores OpenMP parallelism to two hot per-iteration loops in `NesterovBase`, with bit-identical output preserved.

1. `updateGradients` (`nesterovBase.cpp`) — the OMP pragma had been disabled with a TODO explaining that `reduction(+: ...)` over floats produced non-deterministic sums. The serial loop has been the dominant per-iteration cost ever since. Replaced with a two-phase pattern: parallel per-cell write of gradients + preconditioner into the existing output vectors, then a serial in-order accumulation that preserves the original `sum += fabs(x); sum += fabs(y);` order. Result is bit-identical to the prior serial version regardless of thread count.
2. `nesterovUpdateCoordinates` (`nesterovBase.cpp`) — the per-cell axpy + layout-clamp loop was missing `#pragma omp parallel for` even though every iteration writes to distinct indices and uses only const helpers. Added the pragma. Bit-identical (independent writes, no reduction).

## Type of Change
- Refactoring

## Impact
2.0× wall-time speedup on `large01` (274,700 cells) at 64 threads. Placement output is unchanged: every gpl ctest passes against its committed golden DEF, and benchmark runs at 1 thread, 8 threads, and 64 threads all produce identical HPWL.

`large01.tcl`, 64 threads, 3 runs per condition:

| Stage | Run 1 (s) | Run 2 (s) | Run 3 (s) | Mean (s) | vs master |
|---|---:|---:|---:|---:|---:|
| master            | 139.61 | 138.91 | 137.69 | **138.74** | — |
| +grad OMP (#1)    | 76.51  | 77.95  | 72.90  | **75.79**  | **1.83× / −45.4%** |
| +coordi OMP (#2)  | 69.93  | 69.53  | 69.15  | **69.54**  | **2.00× / −49.9%** |

Final HPWL = 12,050,134,762 across all 9 runs — placement is bit-identical at every stage.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

Full `gpl` ctest suite: 62/62 passing. Each test diff-compares against a committed golden DEF, so the existing tests are themselves the bit-identical regression for this change. Additional ad-hoc determinism check: `convergence01.tcl` produces a DEF byte-for-byte identical to the committed golden at 1 thread and at 8 threads after each commit.

## Related Issues
None.