### PR TITLE
Fix mbff kmeans div by zero

### DIFF
--- a/src/gpl/BUILD
+++ b/src/gpl/BUILD
@@ -69,6 +69,7 @@ cc_library(
         "//src/rsz",
         "//src/sta:opensta_lib",
         "//src/utl",
+        "@abseil-cpp//absl/container:inlined_vector",
         "@boost.polygon",
         "@boost.stacktrace",
         "@boost.unordered",

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "AbstractGraphics.h"
+#include "absl/container/inlined_vector.h"
 #include "db_sta/dbNetwork.hh"
 #include "db_sta/dbSta.hh"
 #include "lemon/core.h"
@@ -1737,7 +1738,7 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
     }
 
     // find new center locations
-    std::vector<int> empty_clusters;
+    absl::InlinedVector<int, 4> empty_clusters;
     for (int i = 0; i < knn; i++) {
       const int cur_sz = clusters[i].size();
       if (cur_sz == 0) {
@@ -1758,7 +1759,7 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
     }
 
     if (!empty_clusters.empty()) {
-      std::set<int> used_flops;
+      absl::InlinedVector<int, 8> used_flops;
       for (int empty_idx : empty_clusters) {
         float max_dist = -1;
         Point best_pt = centers[empty_idx].pt;
@@ -1769,7 +1770,8 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
             continue;
           }
           for (const Flop& flop : clusters[j]) {
-            if (used_flops.count(flop.idx)) {
+            if (std::find(used_flops.begin(), used_flops.end(), flop.idx)
+                != used_flops.end()) {
               continue;
             }
             const float dist = GetDist(flop.pt, centers[j].pt);
@@ -1783,7 +1785,7 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
 
         if (best_idx != -1) {
           centers[empty_idx].pt = best_pt;
-          used_flops.insert(best_idx);
+          used_flops.push_back(best_idx);
         }
       }
     }

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -1737,8 +1737,13 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
     }
 
     // find new center locations
+    std::vector<int> empty_clusters;
     for (int i = 0; i < knn; i++) {
       const int cur_sz = clusters[i].size();
+      if (cur_sz == 0) {
+        empty_clusters.push_back(i);
+        continue;
+      }
       float cX = 0;
       float cY = 0;
 
@@ -1750,6 +1755,37 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
       const float new_x = cX / float(cur_sz);
       const float new_y = cY / float(cur_sz);
       centers[i].pt = Point{new_x, new_y};
+    }
+
+    if (!empty_clusters.empty()) {
+      std::set<int> used_flops;
+      for (int empty_idx : empty_clusters) {
+        float max_dist = -1;
+        Point best_pt = centers[empty_idx].pt;
+        int best_idx = -1;
+
+        for (int j = 0; j < knn; j++) {
+          if (clusters[j].empty()) {
+            continue;
+          }
+          for (const Flop& flop : clusters[j]) {
+            if (used_flops.count(flop.idx)) {
+              continue;
+            }
+            const float dist = GetDist(flop.pt, centers[j].pt);
+            if (dist > max_dist) {
+              max_dist = dist;
+              best_pt = flop.pt;
+              best_idx = flop.idx;
+            }
+          }
+        }
+
+        if (best_idx != -1) {
+          centers[empty_idx].pt = best_pt;
+          used_flops.insert(best_idx);
+        }
+      }
     }
 
     // get total displacement

--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -1759,10 +1759,14 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
     }
 
     if (!empty_clusters.empty()) {
+      // To revive empty clusters and avoid division by zero, we re-seed their
+      // centers with active flops that are currently furthest from their
+      // assigned cluster centers. We use an inlined vector to track chosen
+      // flops and prevent promoting the same flop to multiple empty clusters.
       absl::InlinedVector<int, 8> used_flops;
       for (int empty_idx : empty_clusters) {
         float max_dist = -1;
-        Point best_pt = centers[empty_idx].pt;
+        Point best_pt = centers[empty_idx].pt;  // Fallback to previous center
         int best_idx = -1;
 
         for (int j = 0; j < knn; j++) {
@@ -1774,6 +1778,8 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
                 != used_flops.end()) {
               continue;
             }
+            // Find the flop that has the worst-fit (largest displacement)
+            // to its currently assigned center.
             const float dist = GetDist(flop.pt, centers[j].pt);
             if (dist > max_dist) {
               max_dist = dist;
@@ -1784,6 +1790,10 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
         }
 
         if (best_idx != -1) {
+          // Re-seeding the center directly onto the flop's coordinate.
+          // This guarantees that in the next iteration, the distance from this
+          // flop to this center is 0.0, forcing it to be assigned to this
+          // cluster and keeping it active.
           centers[empty_idx].pt = best_pt;
           used_flops.push_back(best_idx);
         }


### PR DESCRIPTION
If a flop cluster in MBFF ends up empty we get a division by zero error.  Try to fix by alternative assignment of empty cluster centers.