### PR TITLE
mbff: runtime optimizations for large designs

### DIFF
--- a/src/gpl/src/mbff.cpp
+++ b/src/gpl/src/mbff.cpp
@@ -1760,7 +1760,7 @@ void MBFF::KMeans(const std::vector<Flop>& flops,
       }
     }
 
-    if (tot_disp == prev) {
+    if (std::abs(tot_disp - prev) <= 0.01f * prev) {
       break;
     }
     prev = tot_disp;
@@ -2277,6 +2277,17 @@ float MBFF::getClockPeriod(odb::dbInst* ff_inst)
   return period;
 }
 
+std::vector<float> MBFF::precomputeClockPeriods(
+    const std::vector<std::vector<Flop>>& FFs)
+{
+  std::vector<float> clock_periods(FFs.size());
+  for (size_t i = 0; i < FFs.size(); i++) {
+    dbInst* ff_inst = insts_[FFs[i].back().idx];
+    clock_periods[i] = getClockPeriod(ff_inst);
+  }
+  return clock_periods;
+}
+
 void MBFF::SetVars(const std::vector<Flop>& flops)
 {
   // get min height and width
@@ -2419,6 +2430,7 @@ void MBFF::Run(const int mx_sz, const float alpha, const float beta)
 
   std::vector<std::vector<Flop>> FFs;
   SeparateFlops(FFs);
+  const std::vector<float> clock_periods = precomputeClockPeriods(FFs);
   const int num_chunks = FFs.size();
   float tot_ilp = 0;
   bool any_found = false;
@@ -2437,7 +2449,7 @@ void MBFF::Run(const int mx_sz, const float alpha, const float beta)
       continue;
     }
     any_found = true;
-    clock_period_ = getClockPeriod(ff_inst);
+    clock_period_ = clock_periods[i];
     SelectBestTrays(array_mask, clockActivity());
     SetVars(FFs[i]);
     SetRatios(array_mask);

--- a/src/gpl/src/mbff.h
+++ b/src/gpl/src/mbff.h
@@ -247,6 +247,8 @@ class MBFF
   float getInternalEnergy(odb::dbInst* inst);
   float clockActivity() const;
   float getClockPeriod(odb::dbInst* ff_inst);
+  std::vector<float> precomputeClockPeriods(
+      const std::vector<std::vector<Flop>>& FFs);
 
   // OpenROAD vars
   odb::dbDatabase* db_;


### PR DESCRIPTION
## Summary
Two separate runtime optimizations for `cluster_flops` for large designs:
- Pre-compute clock periods of each flop before making any graph edits, as the sta clock period lookup requires rebuilding the graph which is fully invalidated after editing sequential elements.
- The exit criteria for the Knn while(true) loop was equality checking of floats, which sometimes did not converge for a significant number of iterations. Now, the loop exits when the displacement is less than 1%. This did not incur PPA loss on our designs.

## Type of Change
- Refactoring

## Impact
For one of our designs, this is >2x speedup for MBFF (1hr -> 25m for 750k instances) 

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
