### PR TITLE
ci: route CODEOWNERS reviewers via three-dot compare

### DIFF
--- a/.github/workflows/github-actions-on-label-create.yml
+++ b/.github/workflows/github-actions-on-label-create.yml
@@ -101,43 +101,30 @@ jobs:
         python3 -m venv /tmp/codeowners-venv
         /tmp/codeowners-venv/bin/pip install --quiet pathspec
         /tmp/codeowners-venv/bin/python <<'PY'
-        import base64, json, os, subprocess, sys, time
+        import base64, json, os, subprocess, sys
         from pathspec import GitIgnoreSpec
 
         pr = os.environ["PR"]
         upstream = os.environ["UPSTREAM"]
 
-        # GitHub computes PR mergeability asynchronously, so `mergeable` and
-        # `merge_commit_sha` are often null on the first read after PR
-        # creation. Poll until the background job finishes.
-        attempts = 10
-        delay = 3
-        for attempt in range(1, attempts + 1):
-            pr_json = subprocess.check_output(
-                ["gh", "api", f"repos/{upstream}/pulls/{pr}"], text=True)
-            pr_data = json.loads(pr_json)
-            if pr_data.get("mergeable") is not None \
-                    and pr_data.get("merge_commit_sha"):
-                break
-            print(f"Mergeability not yet computed "
-                  f"(attempt {attempt}/{attempts}); sleeping {delay}s")
-            time.sleep(delay)
-        else:
-            raise RuntimeError(
-                "PR merge commit SHA is unavailable after polling; refusing "
-                "to request CODEOWNERS reviewers from an incomplete "
-                "effective diff.")
+        pr_json = subprocess.check_output(
+            ["gh", "api", f"repos/{upstream}/pulls/{pr}"], text=True)
+        pr_data = json.loads(pr_json)
 
         author = pr_data["user"]["login"]
         base_ref = pr_data["base"]["ref"]
-        base_repo = pr_data["base"]["repo"]["full_name"]
         base_sha = pr_data["base"]["sha"]
         head_repo = pr_data["head"]["repo"]["full_name"]
         head_sha = pr_data["head"]["sha"]
-        merge_sha = pr_data["merge_commit_sha"]
 
-        print(f"Computing effective PR merge diff: {base_repo}@{base_sha}.."
-              f"{base_repo}@{merge_sha} (head {head_repo}@{head_sha})")
+        # The compare endpoint accepts cross-fork heads as "{owner}:{sha}".
+        upstream_owner = upstream.split("/", 1)[0]
+        head_owner = head_repo.split("/", 1)[0]
+        head_ref = (head_sha if head_owner == upstream_owner
+                    else f"{head_owner}:{head_sha}")
+
+        print(f"Computing PR diff: {upstream}@{base_sha}..."
+              f"{head_repo}@{head_sha}")
 
         # Authoritative CODEOWNERS is the one on the PR base branch.
         raw = subprocess.check_output(
@@ -154,42 +141,39 @@ jobs:
             pattern, *rule_owners = line.split()
             rules.append((GitIgnoreSpec.from_lines([pattern]), rule_owners))
 
-        def commit_tree(repo, sha):
-            commit_json = subprocess.check_output(
-                ["gh", "api", f"repos/{repo}/git/commits/{sha}"],
-                text=True)
-            commit_data = json.loads(commit_json)
-            tree_sha = commit_data["tree"]["sha"]
-            tree_json = subprocess.check_output(
+        # Use the three-dot compare (merge_base(base, head)...head). This is
+        # what GitHub's "Files changed" tab shows and is a deterministic
+        # function of the two SHAs, so it does not race with master moving.
+        # Previously we diffed base.sha against merge_commit_sha, but the
+        # async-computed merge_commit_sha can lag behind base.sha, making
+        # files only touched on master after the PR was opened appear as
+        # PR-introduced changes and falsely route their CODEOWNERS teams.
+        files = []
+        page = 1
+        per_page = 100
+        while True:
+            cmp_json = subprocess.check_output(
                 ["gh", "api",
-                 f"repos/{repo}/git/trees/{tree_sha}?recursive=1"],
-                text=True)
-            tree_data = json.loads(tree_json)
-            if tree_data.get("truncated"):
+                 f"repos/{upstream}/compare/{base_sha}...{head_ref}"
+                 f"?per_page={per_page}&page={page}"], text=True)
+            cmp_data = json.loads(cmp_json)
+            page_files = cmp_data.get("files") or []
+            for f in page_files:
+                files.append(f["filename"])
+                # Renames carry the source in previous_filename; route to
+                # CODEOWNERS for both the old and new paths so moves out of
+                # an owned directory still notify the original owner.
+                if f.get("previous_filename"):
+                    files.append(f["previous_filename"])
+            if len(page_files) < per_page:
+                break
+            page += 1
+            if page > 30:
                 raise RuntimeError(
-                    f"Recursive tree for {repo}@{sha} was truncated; "
+                    "PR comparison exceeded pagination cap (>3000 files); "
                     "refusing to request partial CODEOWNERS reviewers.")
 
-            entries = {}
-            for entry in tree_data["tree"]:
-                if entry["type"] == "tree":
-                    continue
-                entries[entry["path"]] = (
-                    entry.get("sha"), entry.get("mode"), entry.get("type"))
-            return entries
-
-        # Use the effective merge-result delta rather than GitHub's PR file
-        # list or a direct base -> head tree comparison. The PR file list is
-        # merge-base based, so it can include already-landed upstream changes
-        # brought in by a merge from the base branch. A direct base -> head
-        # comparison has the opposite problem when the PR branch is behind the
-        # base branch: it reports base-only changes as if the PR changed them.
-        # Comparing base -> test-merge tree matches the content that would land
-        # if this PR merged now, including real conflict-resolution edits.
-        base_tree = commit_tree(base_repo, base_sha)
-        merge_tree = commit_tree(base_repo, merge_sha)
-        files = sorted(path for path in set(base_tree) | set(merge_tree)
-                       if base_tree.get(path) != merge_tree.get(path))
+        files = sorted(set(files))
 
         print("Effective changed files:")
         for path in files:


### PR DESCRIPTION
The CODEOWNERS reviewer-routing workflow previously diffed two trees fetched by SHA: base.sha and merge_commit_sha. Both fields come from the same /pulls/{n} response, but GitHub does not guarantee merge_commit_sha is a merge of head into the current base.sha -- the async-computed merge commit can lag behind base.sha by minutes after master advances. In that window, files only touched on master since the PR opened appear as PR-introduced changes, and their CODEOWNERS teams get falsely added as reviewers (e.g. #10458 picked up openroad-rsz and openroad-gpl despite touching neither).

Switch to GET /compare/{base_sha}...{head_ref}. The three-dot compare runs merge_base(base, head) server-side, is a deterministic function of two immutable SHAs, and matches what GitHub's "Files changed" tab shows. The mergeability poll loop and the recursive-tree fetch helper are no longer needed.

Renamed files are routed to CODEOWNERS for both the new and old paths (filename + previous_filename), preserving the prior tree-union behavior so moves out of an owned directory still notify the original owner. Cross-fork heads are addressed as "{owner}:{sha}" per the compare endpoint syntax, and pagination is capped at 3000 files.
