### PR TITLE
Better document the private header included in test fixture.

### DIFF
--- a/src/drt/CMakeLists.txt
+++ b/src/drt/CMakeLists.txt
@@ -162,6 +162,7 @@ if(ENABLE_TESTS)
     PRIVATE
     ${FLEXROUTE_HOME}/src
     ${OPENROAD_HOME}/include
+    ${OPENROAD_HOME}
   )
 
   target_link_libraries(trTest

--- a/src/drt/test/BUILD
+++ b/src/drt/test/BUILD
@@ -167,7 +167,7 @@ cc_test(
         "../src",
     ],
     deps = [
-        "//src/drt",
+        "//src/drt",  # build_cleaner: keep for private headers
         "//src/drt:base_types",
         "//src/drt:db_hdrs",
         "//src/odb/src/db",

--- a/src/drt/test/fixture.cpp
+++ b/src/drt/test/fixture.cpp
@@ -25,9 +25,9 @@
 #include "frBaseTypes.h"
 #include "frDesign.h"
 #include "frRegionQuery.h"
-#include "global.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "src/drt/src/global.h"
 #include "utl/Logger.h"
 
 using odb::dbTechLayerDir;

--- a/src/drt/test/fixture.h
+++ b/src/drt/test/fixture.h
@@ -14,10 +14,10 @@
 #include "db/tech/frViaDef.h"
 #include "frBaseTypes.h"
 #include "frDesign.h"
-#include "global.h"
 #include "gtest/gtest.h"
 #include "odb/db.h"
 #include "odb/dbTypes.h"
+#include "src/drt/src/global.h"
 #include "utl/Logger.h"
 
 namespace odb {


### PR DESCRIPTION
Also, make it explicit starting from project root, otherwise it could be mistaken for the global.h provided in abc.
