### PR TITLE
web: add selectability column to display controls

### DIFF
--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -52,7 +52,8 @@ const fallbackLayerPalette = [
 ];
 
 // Populate display controls with layer checkboxes and visibility tree.
-export function populateDisplayControls(app, visibility, WebSocketTileLayer,
+export function populateDisplayControls(app, visibility, selectability,
+                                         WebSocketTileLayer,
                                          techData, redrawAllLayers,
                                          HeatMapTileLayer) {
     if (!app.displayControlsEl) return;
@@ -93,11 +94,19 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
     // has more than one entry).
     let chipletModel = null;
 
-    // Restore saved hidden-layers set from previous session.
+    // Restore saved hidden-layers and non-selectable-layers sets.
     let savedHiddenLayers = new Set();
+    let savedNonSelectableLayers = new Set();
     try {
         const raw = getCookie('or_hidden_layers');
         if (raw) savedHiddenLayers = new Set(JSON.parse(decodeURIComponent(raw)));
+    } catch (_) { /* ignore */ }
+    try {
+        const raw = getCookie('or_nonselectable_layers');
+        if (raw) {
+            savedNonSelectableLayers
+                = new Set(JSON.parse(decodeURIComponent(raw)));
+        }
     } catch (_) { /* ignore */ }
 
     // Global counter so each layer (across the whole hierarchy) gets a unique
@@ -187,6 +196,26 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
         };
     }
 
+    // Parallel selectability model with the same node ids as layerSpec so
+    // syncLayerSelDom() and buildLayerDOM() can pair each visibility node
+    // with its selectability peer.
+    function mirrorForSelectability(node) {
+        if (!node.children || node.children.length === 0) {
+            const name = node.data && node.data.name;
+            const selectable = name ? !savedNonSelectableLayers.has(name) : true;
+            if (selectable && name) {
+                app.selectableLayers.add(name);
+            }
+            return { id: node.id, data: { name }, checked: selectable };
+        }
+        return {
+            id: node.id,
+            data: { name: node.data && node.data.name },
+            children: node.children.map(mirrorForSelectability),
+        };
+    }
+    const layerSelSpec = mirrorForSelectability(layerSpec);
+
     const layerModel = new CheckboxTreeModel(() => {
         // Single pass over the tree: rebuild visibleLayerNames in place
         // (the WebSocketTileLayer closure captured this Set by reference
@@ -250,7 +279,8 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
                 }
             }
         });
-
+        // Visibility off ⇒ selectability disabled — refresh selectability DOM.
+        syncLayerSelDom();
         // Refresh pins layer so it filters by the updated visible_layers.
         if (app.pinsLayer && app.map.hasLayer(app.pinsLayer)) {
             app.pinsLayer.refreshTiles();
@@ -295,6 +325,39 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
     app.layerModel = layerModel; // expose it so other rendering mechanism can use it
     layerModel.addFromSpec(layerSpec);
 
+    // Parallel selectability model — picks gate on this set on the server.
+    const layerSelModel = new CheckboxTreeModel(() => {
+        layerSelModel.forEach(node => {
+            if (!node.data) return;
+            if (node.data.name) {
+                if (node.checked) {
+                    app.selectableLayers.add(node.data.name);
+                } else {
+                    app.selectableLayers.delete(node.data.name);
+                }
+            }
+        });
+        syncLayerSelDom();
+        const nonSel
+            = techData.layers.filter(n => !app.selectableLayers.has(n));
+        setCookie('or_nonselectable_layers',
+                  encodeURIComponent(JSON.stringify(nonSel)));
+    });
+    layerSelModel.addFromSpec(layerSelSpec);
+
+    // Sync layer selectability DOM: visibility off disables the sel checkbox.
+    function syncLayerSelDom() {
+        layerSelModel.forEach(node => {
+            if (!node.selCb) return;
+            node.selCb.checked = node.checked;
+            node.selCb.indeterminate = node.indeterminate;
+            const visNode = layerModel.get(node.id);
+            const visOff
+                = visNode && !visNode.checked && !visNode.indeterminate;
+            node.selCb.disabled = visOff;
+        });
+    }
+
     // --- Layer context menu (right-click) ---
     const contextMenu = document.createElement('div');
     contextMenu.className = 'context-menu';
@@ -330,18 +393,33 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
     });
 
     function buildLayerDOM(node, isRoot = false) {
+        const selNode = layerSelModel.get(node.id);
         if (!node.children || node.children.length === 0) {
             // Leaf node (layer)
             const label = document.createElement('label');
 
             const checkbox = document.createElement('input');
             checkbox.type = 'checkbox';
+            checkbox.title = 'Visible';
             checkbox.checked = node.checked;
             node.cb = checkbox;
             checkbox.addEventListener('change', () => {
                 layerModel.check(node.id, checkbox.checked);
             });
             label.appendChild(checkbox);
+
+            if (selNode) {
+                const selCheckbox = document.createElement('input');
+                selCheckbox.type = 'checkbox';
+                selCheckbox.className = 'vis-sel-cb';
+                selCheckbox.title = 'Selectable';
+                selCheckbox.checked = selNode.checked;
+                selNode.selCb = selCheckbox;
+                selCheckbox.addEventListener('change', () => {
+                    layerSelModel.check(node.id, selCheckbox.checked);
+                });
+                label.appendChild(selCheckbox);
+            }
 
             const index = node.data.colorIndex;
             const name = node.data.name;
@@ -390,6 +468,7 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
 
             const cb = document.createElement('input');
             cb.type = 'checkbox';
+            cb.title = 'Visible';
             cb.checked = node.checked;
             cb.indeterminate = node.indeterminate;
             node.cb = cb;
@@ -397,6 +476,20 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
                 layerModel.check(node.id, cb.checked);
             });
             header.appendChild(cb);
+
+            if (selNode) {
+                const selCb = document.createElement('input');
+                selCb.type = 'checkbox';
+                selCb.className = 'vis-sel-cb';
+                selCb.title = 'Selectable';
+                selCb.checked = selNode.checked;
+                selCb.indeterminate = selNode.indeterminate;
+                selNode.selCb = selCb;
+                selCb.addEventListener('change', () => {
+                    layerSelModel.check(node.id, selCb.checked);
+                });
+                header.appendChild(selCb);
+            }
 
             const name = isRoot ? 'Layers' : (node.data.name || 'Group');
             header.appendChild(document.createTextNode(name));
@@ -428,6 +521,10 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
     const layerGroup = buildLayerDOM(parentNode, true);
 
     app.displayControlsEl.appendChild(layerGroup);
+
+    // Initial selectability DOM sync (esp. disabled state for layers whose
+    // visibility was restored as false).
+    syncLayerSelDom();
 
     // --- Chiplets group (multi-die / 3D-IC visibility) ---
     //
@@ -731,8 +828,10 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
     }
 
     // --- Visibility tree (ordered to match Qt GUI display controls) ---
-    const visTree = new VisTree(visibility, redrawAllLayers);
-    visTree.add({ label: 'Nets', children: [
+    // Subtrees that opt into a second "selectable" checkbox column mirror
+    // the Qt GUI's selectability column (see displayControls.cpp).
+    const visTree = new VisTree(visibility, selectability, redrawAllLayers);
+    visTree.add({ label: 'Nets', addSelectable: true, children: [
         { key: 'net_signal', label: 'Signal' },
         { key: 'net_power', label: 'Power' },
         { key: 'net_ground', label: 'Ground' },
@@ -742,7 +841,7 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
         { key: 'net_scan', label: 'Scan' },
         { key: 'net_analog', label: 'Analog' },
     ]});
-    visTree.add({ label: 'Instances', children: [
+    visTree.add({ label: 'Instances', addSelectable: true, children: [
         { label: 'Std Cells', visKey: 'stdcells', disabled: !app.hasLiberty, children: [
             { label: 'Bufs/Invs', children: [
                 { key: 'std_bufinv_timing', label: 'Timing opt.' },
@@ -777,13 +876,13 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
             { key: 'phys_other', label: 'Other' },
         ]},
     ]});
-    visTree.add({ label: 'Blockages', children: [
+    visTree.add({ label: 'Blockages', addSelectable: true, children: [
         { key: 'placement_blockages', label: 'Placement' },
         { key: 'routing_obstructions', label: 'Routing' },
     ]});
     if (techData.sites && techData.sites.length > 0) {
-        visTree.add({ label: 'Rows', visKey: 'rows', children:
-            techData.sites.map(name => ({
+        visTree.add({ label: 'Rows', visKey: 'rows', addSelectable: true,
+            children: techData.sites.map(name => ({
                 key: 'site_' + name, label: name,
             })),
         });
@@ -801,13 +900,13 @@ export function populateDisplayControls(app, visibility, WebSocketTileLayer,
             { key: 'srouting_segments', label: 'Segments' },
             { key: 'srouting_vias', label: 'Vias' },
         ]},
-        { key: 'pins', label: 'Pins' },
+        { key: 'pins', label: 'Pins', selectable: true },
         { key: 'pin_names', label: 'Pin Names', disabledBy: 'pins' },
     ]});
     visTree.add({ label: 'Misc', children: [
         { label: 'Instances', children: [
             { key: 'inst_names', label: 'Names' },
-            { key: 'inst_pins', label: 'Pins' },
+            { key: 'inst_pins', label: 'Pins', selectable: true },
             { key: 'inst_pin_names', label: 'Pin Names', disabledBy: 'inst_pins' },
             { key: 'blockages', label: 'Blockages' },
         ]},

--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -327,14 +327,15 @@ export function populateDisplayControls(app, visibility, selectability,
 
     // Parallel selectability model — picks gate on this set on the server.
     const layerSelModel = new CheckboxTreeModel(() => {
+        // Rebuild from scratch so multi-chiplet/multi-tech subtrees that
+        // share a layer name don't fall into last-writer-wins (an unchecked
+        // M1 leaf in one subtree would otherwise delete the name even when
+        // another M1 leaf is still checked).  Mutate in place — the
+        // WebSocketTileLayer closure captured this Set by reference.
+        app.selectableLayers.clear();
         layerSelModel.forEach(node => {
-            if (!node.data) return;
-            if (node.data.name) {
-                if (node.checked) {
-                    app.selectableLayers.add(node.data.name);
-                } else {
-                    app.selectableLayers.delete(node.data.name);
-                }
+            if (node.checked && node.data && node.data.name) {
+                app.selectableLayers.add(node.data.name);
             }
         });
         syncLayerSelDom();

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -103,6 +103,7 @@ const app = {
     // "render every chiplet" (single-chip designs).
     visibleChiplets: null,
     useTrueZ: getCookie('or_use_true_z') === '1',
+    selectableLayers: new Set(),
     heatMapData: null,
     activeHeatMap: '',
     heatMapLayer: null,
@@ -194,11 +195,67 @@ try {
     // Ignore malformed cookie.
 }
 
+// Selectability mirrors the Qt GUI's display-controls "selectable" column.
+// Defaults to true (everything selectable), matching the Qt GUI.  Only
+// categories that the Qt GUI exposes a selectable checkbox for are listed
+// here; the server treats unspecified keys as selectable.
+const selectability = {
+    stdcells: true,
+    macros: true,
+    pad_input: true,
+    pad_output: true,
+    pad_inout: true,
+    pad_power: true,
+    pad_spacer: true,
+    pad_areaio: true,
+    pad_other: true,
+    phys_fill: true,
+    phys_endcap: true,
+    phys_welltap: true,
+    phys_tie: true,
+    phys_antenna: true,
+    phys_cover: true,
+    phys_bump: true,
+    phys_other: true,
+    std_bufinv: true,
+    std_bufinv_timing: true,
+    std_clock_bufinv: true,
+    std_clock_gate: true,
+    std_level_shift: true,
+    std_sequential: true,
+    std_combinational: true,
+    net_signal: true,
+    net_power: true,
+    net_ground: true,
+    net_clock: true,
+    net_reset: true,
+    net_tieoff: true,
+    net_scan: true,
+    net_analog: true,
+    pins: true,
+    inst_pins: true,
+    placement_blockages: true,
+    routing_obstructions: true,
+};
+
+try {
+    const saved = getCookie('or_selectability');
+    if (saved) {
+        const parsed = JSON.parse(decodeURIComponent(saved));
+        for (const [k, v] of Object.entries(parsed)) {
+            selectability[k] = !!v;
+        }
+    }
+} catch (_) {
+    // Ignore malformed cookie.
+}
+
 // `app` is forwarded so the tile layer can read app.visibleChiplets
 // lazily on every request — the field is populated by display-controls
 // once the server's tech metadata arrives.
-const WebSocketTileLayer
-    = createWebSocketTileLayer(visibility, app.visibleLayerNames, app);
+const WebSocketTileLayer = createWebSocketTileLayer(
+    visibility, app.visibleLayerNames, selectability, app.selectableLayers,
+    app);
 const BLANK_TILE
     = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
@@ -301,8 +358,11 @@ function updateHeatMaps(data) {
 app.updateHeatMaps = updateHeatMaps;
 
 function redrawAllLayers() {
-    // Persist visibility state to cookie so it survives page reloads.
+    // Persist visibility and selectability state to cookies so they survive
+    // page reloads.
     setCookie('or_visibility', encodeURIComponent(JSON.stringify(visibility)));
+    setCookie('or_selectability',
+              encodeURIComponent(JSON.stringify(selectability)));
 
     // Show/hide modules layer based on module_view visibility
     if (app.modulesLayer) {
@@ -987,12 +1047,18 @@ app.websocketManager.readyPromise.then(async () => {
             for (const [k, v] of Object.entries(visibility)) {
                 vf[k] = !!v;
             }
+            // Selectability is sent with `s_` prefix to mirror the flat
+            // visibility key scheme; the server parses both columns.
+            for (const [k, v] of Object.entries(selectability)) {
+                vf['s_' + k] = !!v;
+            }
             const selectRequest = {
                 type: 'select',
                 dbu_x,
                 dbu_y,
                 zoom: Math.round(app.map.getZoom()),
                 visible_layers: [...app.visibleLayerNames],
+                selectable_layers: [...app.selectableLayers],
                 ...vf,
             };
             if (app.visibleChiplets instanceof Set) {
@@ -1092,7 +1158,8 @@ app.websocketManager.readyPromise.then(async () => {
             });
         }
 
-        populateDisplayControls(app, visibility, WebSocketTileLayer,
+        populateDisplayControls(app, visibility, selectability,
+                                WebSocketTileLayer,
                                 techData, redrawAllLayers, HeatMapTileLayer);
         updateHeatMaps(heatMapData);
 

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -677,6 +677,29 @@ html, body {
     pointer-events: none;
 }
 
+/* Selectability checkbox (second column, next to the visibility checkbox).
+ * Small left margin gives a clear visual separation between the two columns;
+ * disabled state (visibility off) dims the checkbox. */
+.display-controls .vis-sel-cb {
+    margin-left: 2px;
+    margin-right: 2px;
+}
+.display-controls .vis-sel-cb.vis-sel-spacer {
+    /* Layout-only placeholder when a row has no selectability checkbox. */
+    display: inline-block;
+    width: 13px;
+    height: 13px;
+    visibility: hidden;
+}
+.display-controls .vis-sel-cb:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+.display-controls label.vis-sel-disabled {
+    /* Visually dim labels whose selectability is disabled by visibility. */
+    color: var(--fg-muted);
+}
+
 /* Layer context menu */
 .context-menu {
     position: fixed;

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -163,17 +163,78 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
     }
   }
 
+  // ── Selectability peers ──
+  // clang-format off
+  // NOLINTBEGIN(modernize-use-designated-initializers)
+  static const BoolField kSelectableFields[] = {
+    {"s_stdcells",             &TileVisibility::stdcells_selectable,             true},
+    {"s_macros",               &TileVisibility::macros_selectable,               true},
+    {"s_pad_input",            &TileVisibility::pad_input_selectable,            true},
+    {"s_pad_output",           &TileVisibility::pad_output_selectable,           true},
+    {"s_pad_inout",            &TileVisibility::pad_inout_selectable,            true},
+    {"s_pad_power",            &TileVisibility::pad_power_selectable,            true},
+    {"s_pad_spacer",           &TileVisibility::pad_spacer_selectable,           true},
+    {"s_pad_areaio",           &TileVisibility::pad_areaio_selectable,           true},
+    {"s_pad_other",            &TileVisibility::pad_other_selectable,            true},
+    {"s_phys_fill",            &TileVisibility::phys_fill_selectable,            true},
+    {"s_phys_endcap",          &TileVisibility::phys_endcap_selectable,          true},
+    {"s_phys_welltap",         &TileVisibility::phys_welltap_selectable,         true},
+    {"s_phys_tie",             &TileVisibility::phys_tie_selectable,             true},
+    {"s_phys_antenna",         &TileVisibility::phys_antenna_selectable,         true},
+    {"s_phys_cover",           &TileVisibility::phys_cover_selectable,           true},
+    {"s_phys_bump",            &TileVisibility::phys_bump_selectable,            true},
+    {"s_phys_other",           &TileVisibility::phys_other_selectable,           true},
+    {"s_std_bufinv",           &TileVisibility::std_bufinv_selectable,           true},
+    {"s_std_bufinv_timing",    &TileVisibility::std_bufinv_timing_selectable,    true},
+    {"s_std_clock_bufinv",     &TileVisibility::std_clock_bufinv_selectable,     true},
+    {"s_std_clock_gate",       &TileVisibility::std_clock_gate_selectable,       true},
+    {"s_std_level_shift",      &TileVisibility::std_level_shift_selectable,      true},
+    {"s_std_sequential",       &TileVisibility::std_sequential_selectable,       true},
+    {"s_std_combinational",    &TileVisibility::std_combinational_selectable,    true},
+    {"s_net_signal",           &TileVisibility::net_signal_selectable,           true},
+    {"s_net_power",            &TileVisibility::net_power_selectable,            true},
+    {"s_net_ground",           &TileVisibility::net_ground_selectable,           true},
+    {"s_net_clock",            &TileVisibility::net_clock_selectable,            true},
+    {"s_net_reset",            &TileVisibility::net_reset_selectable,            true},
+    {"s_net_tieoff",           &TileVisibility::net_tieoff_selectable,           true},
+    {"s_net_scan",             &TileVisibility::net_scan_selectable,             true},
+    {"s_net_analog",           &TileVisibility::net_analog_selectable,           true},
+    {"s_pins",                 &TileVisibility::pins_selectable,                 true},
+    {"s_inst_pins",            &TileVisibility::inst_pins_selectable,            true},
+    {"s_placement_blockages",  &TileVisibility::placement_blockages_selectable,  true},
+    {"s_routing_obstructions", &TileVisibility::routing_obstructions_selectable, true},
+  };
+  // NOLINTEND(modernize-use-designated-initializers)
+  // clang-format on
+  for (const auto& f : kSelectableFields) {
+    this->*(f.field) = jsonOr<bool>(json, f.key, f.default_val);
+  }
+
+  selectable_layers.clear();
+  has_selectable_layers = false;
+  if (auto it = json.find("selectable_layers"); it != json.end()) {
+    has_selectable_layers = true;
+    for (const auto& v : it->value().as_array()) {
+      selectable_layers.emplace(v.as_string());
+    }
+  }
+
   // Per-site flags are only consulted when rows are visible; skip the
   // full-object scan otherwise.
   sites.clear();
+  site_selectable.clear();
   if (rows) {
-    constexpr std::string_view kPrefix = "site_";
+    constexpr std::string_view kVisPrefix = "site_";
+    constexpr std::string_view kSelPrefix = "s_site_";
     for (const auto& [key, value] : json) {
       const std::string_view k(key.data(), key.size());
-      if (!k.starts_with(kPrefix)) {
-        continue;
+      if (k.starts_with(kSelPrefix)) {
+        site_selectable.emplace(std::string(k.substr(kSelPrefix.size())),
+                                value.as_bool());
+      } else if (k.starts_with(kVisPrefix)) {
+        sites.emplace(std::string(k.substr(kVisPrefix.size())),
+                      value.as_bool());
       }
-      sites.emplace(std::string(k.substr(kPrefix.size())), value.as_bool());
     }
   }
 }
@@ -218,7 +279,30 @@ bool TileVisibility::isNetVisible(odb::dbNet* net) const
   return true;
 }
 
-bool TileVisibility::isInstVisible(odb::dbInst* inst, sta::dbSta* sta) const
+bool TileVisibility::isNetSelectable(odb::dbNet* net) const
+{
+  switch (net->getSigType().getValue()) {
+    case odb::dbSigType::SIGNAL:
+      return net_signal_selectable;
+    case odb::dbSigType::POWER:
+      return net_power_selectable;
+    case odb::dbSigType::GROUND:
+      return net_ground_selectable;
+    case odb::dbSigType::CLOCK:
+      return net_clock_selectable;
+    case odb::dbSigType::RESET:
+      return net_reset_selectable;
+    case odb::dbSigType::TIEOFF:
+      return net_tieoff_selectable;
+    case odb::dbSigType::SCAN:
+      return net_scan_selectable;
+    case odb::dbSigType::ANALOG:
+      return net_analog_selectable;
+  }
+  return true;
+}
+
+InstCategory classifyInstance(odb::dbInst* inst, sta::dbSta* sta)
 {
   odb::dbMaster* master = inst->getMaster();
   const odb::dbMasterType mtype = master->getType();
@@ -227,114 +311,237 @@ bool TileVisibility::isInstVisible(odb::dbInst* inst, sta::dbSta* sta) const
     using IT = sta::dbSta::InstType;
     switch (sta->getInstanceType(inst)) {
       case IT::BLOCK:
-        return macros;
+        return InstCategory::kMacros;
       case IT::PAD_INPUT:
-        return pad_input;
+        return InstCategory::kPadInput;
       case IT::PAD_OUTPUT:
-        return pad_output;
+        return InstCategory::kPadOutput;
       case IT::PAD_INOUT:
-        return pad_inout;
+        return InstCategory::kPadInout;
       case IT::PAD_POWER:
-        return pad_power;
+        return InstCategory::kPadPower;
       case IT::PAD_SPACER:
-        return pad_spacer;
+        return InstCategory::kPadSpacer;
       case IT::PAD_AREAIO:
-        return pad_areaio;
+        return InstCategory::kPadAreaIO;
       case IT::PAD:
-        return pad_other;
+        return InstCategory::kPadOther;
       case IT::ENDCAP:
-        return phys_endcap;
+        return InstCategory::kPhysEndcap;
       case IT::FILL:
-        return phys_fill;
+        return InstCategory::kPhysFill;
       case IT::TAPCELL:
-        return phys_welltap;
+        return InstCategory::kPhysWelltap;
       case IT::TIE:
-        return phys_tie;
+        return InstCategory::kPhysTie;
       case IT::ANTENNA:
-        return phys_antenna;
+        return InstCategory::kPhysAntenna;
       case IT::COVER:
-        return phys_cover;
+        return InstCategory::kPhysCover;
       case IT::BUMP:
-        return phys_bump;
+        return InstCategory::kPhysBump;
       case IT::LEF_OTHER:
-        return phys_other;
+        return InstCategory::kPhysOther;
       case IT::STD_BUF:
       case IT::STD_INV:
-        return std_bufinv;
+        return InstCategory::kStdBufInv;
       case IT::STD_BUF_TIMING_REPAIR:
       case IT::STD_INV_TIMING_REPAIR:
-        return std_bufinv_timing;
+        return InstCategory::kStdBufInvTiming;
       case IT::STD_BUF_CLK_TREE:
       case IT::STD_INV_CLK_TREE:
-        return std_clock_bufinv;
+        return InstCategory::kStdClockBufInv;
       case IT::STD_CLOCK_GATE:
-        return std_clock_gate;
+        return InstCategory::kStdClockGate;
       case IT::STD_LEVEL_SHIFT:
-        return std_level_shift;
+        return InstCategory::kStdLevelShift;
       case IT::STD_SEQUENTIAL:
-        return std_sequential;
+        return InstCategory::kStdSequential;
       case IT::STD_COMBINATIONAL:
-        return std_combinational;
+        return InstCategory::kStdCombinational;
       case IT::STD_CELL:
       case IT::STD_PHYSICAL:
       case IT::STD_OTHER:
       default:
-        return stdcells;
+        return InstCategory::kStdCells;
     }
   }
 
   // Fallback: dbMasterType-only classification (no Liberty)
   if (mtype.isBlock()) {
-    return macros;
+    return InstCategory::kMacros;
   }
   if (mtype.isPad()) {
     if (mtype == odb::dbMasterType::PAD_INPUT) {
-      return pad_input;
+      return InstCategory::kPadInput;
     }
     if (mtype == odb::dbMasterType::PAD_OUTPUT) {
-      return pad_output;
+      return InstCategory::kPadOutput;
     }
     if (mtype == odb::dbMasterType::PAD_INOUT) {
-      return pad_inout;
+      return InstCategory::kPadInout;
     }
     if (mtype == odb::dbMasterType::PAD_POWER) {
-      return pad_power;
+      return InstCategory::kPadPower;
     }
     if (mtype == odb::dbMasterType::PAD_SPACER) {
-      return pad_spacer;
+      return InstCategory::kPadSpacer;
     }
     if (mtype == odb::dbMasterType::PAD_AREAIO) {
-      return pad_areaio;
+      return InstCategory::kPadAreaIO;
     }
-    return pad_other;
+    return InstCategory::kPadOther;
   }
   if (mtype.isEndCap()) {
-    return phys_endcap;
+    return InstCategory::kPhysEndcap;
   }
   if (master->isFiller()) {
-    return phys_fill;
+    return InstCategory::kPhysFill;
   }
   if (mtype == odb::dbMasterType::CORE_WELLTAP) {
-    return phys_welltap;
+    return InstCategory::kPhysWelltap;
   }
   if (mtype == odb::dbMasterType::CORE_TIEHIGH
       || mtype == odb::dbMasterType::CORE_TIELOW) {
-    return phys_tie;
+    return InstCategory::kPhysTie;
   }
   if (mtype == odb::dbMasterType::CORE_ANTENNACELL) {
-    return phys_antenna;
+    return InstCategory::kPhysAntenna;
   }
   if (mtype.isCover()) {
     if (mtype == odb::dbMasterType::COVER_BUMP) {
-      return phys_bump;
+      return InstCategory::kPhysBump;
     }
-    return phys_cover;
+    return InstCategory::kPhysCover;
   }
   if (mtype == odb::dbMasterType::CORE_SPACER
       || inst->getSourceType() == odb::dbSourceType::DIST) {
-    return phys_other;
+    return InstCategory::kPhysOther;
+  }
+  return InstCategory::kStdCells;
+}
+
+bool TileVisibility::isInstVisible(odb::dbInst* inst, sta::dbSta* sta) const
+{
+  switch (classifyInstance(inst, sta)) {
+    case InstCategory::kStdCells:
+      return stdcells;
+    case InstCategory::kMacros:
+      return macros;
+    case InstCategory::kPadInput:
+      return pad_input;
+    case InstCategory::kPadOutput:
+      return pad_output;
+    case InstCategory::kPadInout:
+      return pad_inout;
+    case InstCategory::kPadPower:
+      return pad_power;
+    case InstCategory::kPadSpacer:
+      return pad_spacer;
+    case InstCategory::kPadAreaIO:
+      return pad_areaio;
+    case InstCategory::kPadOther:
+      return pad_other;
+    case InstCategory::kPhysEndcap:
+      return phys_endcap;
+    case InstCategory::kPhysFill:
+      return phys_fill;
+    case InstCategory::kPhysWelltap:
+      return phys_welltap;
+    case InstCategory::kPhysTie:
+      return phys_tie;
+    case InstCategory::kPhysAntenna:
+      return phys_antenna;
+    case InstCategory::kPhysCover:
+      return phys_cover;
+    case InstCategory::kPhysBump:
+      return phys_bump;
+    case InstCategory::kPhysOther:
+      return phys_other;
+    case InstCategory::kStdBufInv:
+      return std_bufinv;
+    case InstCategory::kStdBufInvTiming:
+      return std_bufinv_timing;
+    case InstCategory::kStdClockBufInv:
+      return std_clock_bufinv;
+    case InstCategory::kStdClockGate:
+      return std_clock_gate;
+    case InstCategory::kStdLevelShift:
+      return std_level_shift;
+    case InstCategory::kStdSequential:
+      return std_sequential;
+    case InstCategory::kStdCombinational:
+      return std_combinational;
   }
   return stdcells;
+}
+
+bool TileVisibility::isInstSelectable(odb::dbInst* inst, sta::dbSta* sta) const
+{
+  switch (classifyInstance(inst, sta)) {
+    case InstCategory::kStdCells:
+      return stdcells_selectable;
+    case InstCategory::kMacros:
+      return macros_selectable;
+    case InstCategory::kPadInput:
+      return pad_input_selectable;
+    case InstCategory::kPadOutput:
+      return pad_output_selectable;
+    case InstCategory::kPadInout:
+      return pad_inout_selectable;
+    case InstCategory::kPadPower:
+      return pad_power_selectable;
+    case InstCategory::kPadSpacer:
+      return pad_spacer_selectable;
+    case InstCategory::kPadAreaIO:
+      return pad_areaio_selectable;
+    case InstCategory::kPadOther:
+      return pad_other_selectable;
+    case InstCategory::kPhysEndcap:
+      return phys_endcap_selectable;
+    case InstCategory::kPhysFill:
+      return phys_fill_selectable;
+    case InstCategory::kPhysWelltap:
+      return phys_welltap_selectable;
+    case InstCategory::kPhysTie:
+      return phys_tie_selectable;
+    case InstCategory::kPhysAntenna:
+      return phys_antenna_selectable;
+    case InstCategory::kPhysCover:
+      return phys_cover_selectable;
+    case InstCategory::kPhysBump:
+      return phys_bump_selectable;
+    case InstCategory::kPhysOther:
+      return phys_other_selectable;
+    case InstCategory::kStdBufInv:
+      return std_bufinv_selectable;
+    case InstCategory::kStdBufInvTiming:
+      return std_bufinv_timing_selectable;
+    case InstCategory::kStdClockBufInv:
+      return std_clock_bufinv_selectable;
+    case InstCategory::kStdClockGate:
+      return std_clock_gate_selectable;
+    case InstCategory::kStdLevelShift:
+      return std_level_shift_selectable;
+    case InstCategory::kStdSequential:
+      return std_sequential_selectable;
+    case InstCategory::kStdCombinational:
+      return std_combinational_selectable;
+  }
+  return stdcells_selectable;
+}
+
+bool TileVisibility::isSiteSelectable(const std::string& site_name) const
+{
+  auto it = site_selectable.find(site_name);
+  // Default: selectable when not explicitly listed.
+  return it == site_selectable.end() || it->second;
+}
+
+bool TileVisibility::isLayerSelectable(const std::string& layer_name) const
+{
+  // When the client doesn't transmit a list, treat all layers as selectable.
+  return !has_selectable_layers || selectable_layers.contains(layer_name);
 }
 
 //////////////////////////////////////////////////
@@ -891,11 +1098,13 @@ std::vector<SelectionResult> TileGenerator::selectAt(
       return r;
     };
 
-    // Search instances in this chiplet's block.
+    // Search instances in this chiplet's block — require both visible
+    // and selectable.
     for (odb::dbInst* inst :
          search_->searchInsts(block, x_lo, y_lo, x_hi, y_hi)) {
       const odb::Rect bbox = inst->getBBox()->getBox();
-      if (bbox.intersects(click_pt) && vis.isInstVisible(inst, sta_)) {
+      if (bbox.intersects(click_pt) && vis.isInstVisible(inst, sta_)
+          && vis.isInstSelectable(inst, sta_)) {
         std::string label = inst->getName();
         if (!node.path.empty() && node.inst != nullptr) {
           std::string prefixed = node.path;
@@ -917,13 +1126,21 @@ std::vector<SelectionResult> TileGenerator::selectAt(
           && !visible_layers.contains(layer->getName())) {
         continue;
       }
+      if (!vis.isLayerSelectable(layer->getName())) {
+        continue;
+      }
 
-      // Regular routing shapes (wires, vias) and BTerm shapes
+      // Regular routing shapes (wires, vias) and BTerm shapes.
+      // Picks require both visible and selectable: routing segments/vias
+      // have no dedicated selectable flag (Qt parity — clicks resolve
+      // through the net), so the net's own selectability gates the
+      // result.  BTerm picks gate on the dedicated `pins_selectable`
+      // flag.
       if (vis.routing || vis.pins) {
         for (const auto& shape :
              search_->searchBoxShapes(block, layer, x_lo, y_lo, x_hi, y_hi)) {
           const auto type = std::get<1>(shape);
-          if (type == Search::kBterm && !vis.pins) {
+          if (type == Search::kBterm && (!vis.pins || !vis.pins_selectable)) {
             continue;
           }
           if (type == Search::kWire && !(vis.routing && vis.routing_segments)) {
@@ -937,7 +1154,8 @@ std::vector<SelectionResult> TileGenerator::selectAt(
             continue;
           }
           const odb::Rect& box = std::get<0>(shape);
-          if (box.intersects(click_pt) && vis.isNetVisible(net)) {
+          if (box.intersects(click_pt) && vis.isNetVisible(net)
+              && vis.isNetSelectable(net)) {
             seen_nets.insert(net);
             results.push_back({net,
                                net->getName(),
@@ -957,7 +1175,8 @@ std::vector<SelectionResult> TileGenerator::selectAt(
             continue;
           }
           const odb::Rect box = std::get<0>(shape)->getBox();
-          if (box.intersects(click_pt) && vis.isNetVisible(net)) {
+          if (box.intersects(click_pt) && vis.isNetVisible(net)
+              && vis.isNetSelectable(net)) {
             seen_nets.insert(net);
             results.push_back({net,
                                net->getName(),
@@ -977,7 +1196,8 @@ std::vector<SelectionResult> TileGenerator::selectAt(
             continue;
           }
           const odb::Rect box = std::get<0>(shape)->getBox();
-          if (box.intersects(click_pt) && vis.isNetVisible(net)) {
+          if (box.intersects(click_pt) && vis.isNetVisible(net)
+              && vis.isNetSelectable(net)) {
             seen_nets.insert(net);
             results.push_back({net,
                                net->getName(),

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -214,8 +214,10 @@ void TileVisibility::parseFromJson(const boost::json::object& json)
   has_selectable_layers = false;
   if (auto it = json.find("selectable_layers"); it != json.end()) {
     has_selectable_layers = true;
-    for (const auto& v : it->value().as_array()) {
-      selectable_layers.emplace(v.as_string());
+    const auto& arr = it->value().as_array();
+    const size_t count = std::min(arr.size(), kMaxVisibilityEntries);
+    for (size_t i = 0; i < count; ++i) {
+      selectable_layers.emplace(arr[i].as_string());
     }
   }
 

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -95,6 +95,38 @@ struct ChipletNode
 // stable hierarchical paths so the web renderer can place each chiplet.
 std::vector<ChipletNode> collectChiplets(odb::dbChip* root);
 
+// Coarse instance category, derived once per inst and reused by both
+// isInstVisible and isInstSelectable so the two stay in lock-step.
+enum class InstCategory
+{
+  kStdCells,
+  kMacros,
+  kPadInput,
+  kPadOutput,
+  kPadInout,
+  kPadPower,
+  kPadSpacer,
+  kPadAreaIO,
+  kPadOther,
+  kPhysEndcap,
+  kPhysFill,
+  kPhysWelltap,
+  kPhysTie,
+  kPhysAntenna,
+  kPhysCover,
+  kPhysBump,
+  kPhysOther,
+  kStdBufInv,
+  kStdBufInvTiming,
+  kStdClockBufInv,
+  kStdClockGate,
+  kStdLevelShift,
+  kStdSequential,
+  kStdCombinational,
+};
+
+InstCategory classifyInstance(odb::dbInst* inst, sta::dbSta* sta);
+
 struct TileVisibility
 {
   bool stdcells = true;
@@ -198,10 +230,72 @@ struct TileVisibility
   bool has_visible_chiplets = false;
   bool isChipletVisible(const std::string& path) const;
 
+  // ── Selectability ──
+  // Parallel to the visibility flags above: when off, the corresponding
+  // class of object is still rendered but is not pickable by selectAt().
+  // Mirrors the Qt GUI's displayControls "selectable" column.
+  // Defaults are all true (everything selectable), matching the Qt GUI.
+  bool stdcells_selectable = true;
+  bool macros_selectable = true;
+
+  bool pad_input_selectable = true;
+  bool pad_output_selectable = true;
+  bool pad_inout_selectable = true;
+  bool pad_power_selectable = true;
+  bool pad_spacer_selectable = true;
+  bool pad_areaio_selectable = true;
+  bool pad_other_selectable = true;
+
+  bool phys_fill_selectable = true;
+  bool phys_endcap_selectable = true;
+  bool phys_welltap_selectable = true;
+  bool phys_tie_selectable = true;
+  bool phys_antenna_selectable = true;
+  bool phys_cover_selectable = true;
+  bool phys_bump_selectable = true;
+  bool phys_other_selectable = true;
+
+  bool std_bufinv_selectable = true;
+  bool std_bufinv_timing_selectable = true;
+  bool std_clock_bufinv_selectable = true;
+  bool std_clock_gate_selectable = true;
+  bool std_level_shift_selectable = true;
+  bool std_sequential_selectable = true;
+  bool std_combinational_selectable = true;
+
+  bool net_signal_selectable = true;
+  bool net_power_selectable = true;
+  bool net_ground_selectable = true;
+  bool net_clock_selectable = true;
+  bool net_reset_selectable = true;
+  bool net_tieoff_selectable = true;
+  bool net_scan_selectable = true;
+  bool net_analog_selectable = true;
+
+  bool pins_selectable = true;
+  bool inst_pins_selectable = true;
+
+  bool placement_blockages_selectable = true;
+  bool routing_obstructions_selectable = true;
+
+  // Per-site selectability (peer to `sites`).  Defaults to true when
+  // unspecified — checked only when the corresponding row is selectable.
+  std::unordered_map<std::string, bool> site_selectable;
+
+  // Per-metal-layer selectability.  When has_selectable_layers is true,
+  // selectAt() skips layers not in this set.
+  std::set<std::string> selectable_layers;
+  bool has_selectable_layers = false;
+
   void parseFromJson(const boost::json::object& json);
 
   bool isNetVisible(odb::dbNet* net) const;
   bool isInstVisible(odb::dbInst* inst, sta::dbSta* sta) const;
+
+  bool isNetSelectable(odb::dbNet* net) const;
+  bool isInstSelectable(odb::dbInst* inst, sta::dbSta* sta) const;
+  bool isSiteSelectable(const std::string& site_name) const;
+  bool isLayerSelectable(const std::string& layer_name) const;
 };
 
 class TileGenerator

--- a/src/web/src/vis-tree.js
+++ b/src/web/src/vis-tree.js
@@ -2,26 +2,39 @@
 // Copyright (c) 2026, The OpenROAD Authors
 
 // Data-model-driven checkbox tree (mirrors Qt's QStandardItemModel pattern).
-// State lives in CheckboxTreeModel; DOM is synced from model after every change.
+// State lives in CheckboxTreeModel; DOM is synced from model after every
+// change.
+//
+// Each row renders a visibility checkbox.  Rows that opt into selectability
+// (via `selectable: true` on a leaf, or `addSelectable: true` on a group that
+// then propagates to its descendants) also render a second checkbox in the
+// selectability column.  When visibility is unchecked, the selectability
+// checkbox is disabled — matching the Qt GUI's displayControls behavior.
 
 import { CheckboxTreeModel } from './checkbox-tree-model.js';
 
 export class VisTree {
-    constructor(visibility, onChange) {
+    constructor(visibility, selectability, onChange) {
         this.visibility = visibility;
+        this.selectability = selectability;
         this.onChange = onChange;
-        this.model = new CheckboxTreeModel(() => {
+        const notify = () => {
             this._syncAll();
             this.onChange();
-        });
+        };
+        this.model = new CheckboxTreeModel(notify);
+        this.selModel = new CheckboxTreeModel(notify);
     }
 
     // Add a tree from a declarative spec.
-    // Leaf:  { key, label }
-    // Group: { label, children: [...], visKey?, disabled? }
+    // Leaf:  { key, label, selectable?: bool }
+    // Group: { label, children: [...], visKey?, disabled?, addSelectable?: bool }
+    // `addSelectable: true` on a group makes its descendant leaves selectable
+    // unless they set `selectable: false` to opt out.  `selectable: true` on
+    // a leaf opts in even without an ancestor `addSelectable`.
     add(spec) {
-        const enriched = this._enrichSpec(spec);
-        this.model.addFromSpec(enriched);
+        this.model.addFromSpec(this._enrichSpec(spec, ''));
+        this.selModel.addFromSpec(this._enrichSelSpec(spec, '', false));
         return this;
     }
 
@@ -32,12 +45,21 @@ export class VisTree {
 
     // -- model helpers --
 
-    // Convert user spec to model spec, initializing checked from visibility.
-    _enrichSpec(spec) {
-        const id = spec.key || spec.label;
+    // Compute a path-qualified model id.  Without the parent prefix, two
+    // groups with the same label (e.g. top-level "Instances" and the
+    // "Misc / Instances" subgroup) would collide in CheckboxTreeModel's
+    // node map and make parent-level toggling pick the wrong subtree.
+    _nodeId(spec, parentId) {
+        const local = spec.key || spec.label;
+        return parentId ? parentId + '/' + local : local;
+    }
+
+    // Convert user spec to visibility model spec.
+    _enrichSpec(spec, parentId) {
+        const id = this._nodeId(spec, parentId);
         const result = { id, data: spec };
         if (spec.children) {
-            result.children = spec.children.map(c => this._enrichSpec(c));
+            result.children = spec.children.map(c => this._enrichSpec(c, id));
         } else if (spec.key) {
             result.checked = !!this.visibility[spec.key];
         }
@@ -45,7 +67,41 @@ export class VisTree {
         return result;
     }
 
+    // Convert user spec to selectability model spec.  Groups that don't have
+    // any selectable descendant collapse to `hasCheckbox: false` so the
+    // CheckboxTreeModel's tri-state propagation skips them naturally.
+    _enrichSelSpec(spec, parentId, scope) {
+        // A group can override the inherited "selectable scope" of its
+        // subtree via `addSelectable: true/false`.
+        const childScope = spec.addSelectable === true ? true
+            : spec.addSelectable === false ? false
+            : scope;
+        const id = this._nodeId(spec, parentId);
+        const node = { id, data: spec, hasCheckbox: false };
+        if (spec.children) {
+            node.children = spec.children.map(
+                c => this._enrichSelSpec(c, id, childScope));
+            // Group has a selectability checkbox iff at least one descendant
+            // has one.
+            const anyChild = (subtree) => subtree.some(
+                c => c.hasCheckbox || (c.children && anyChild(c.children)));
+            node.hasCheckbox = anyChild(node.children);
+            if (node.hasCheckbox) {
+                node.checked = true;
+            }
+        } else if (spec.key) {
+            const isSelectable = spec.selectable === true
+                || (spec.selectable !== false && scope);
+            node.hasCheckbox = isSelectable;
+            if (isSelectable) {
+                node.checked = this.selectability[spec.key] !== false;
+            }
+        }
+        return node;
+    }
+
     _syncAll() {
+        // Visibility column: refresh DOM and write back to `visibility`.
         this.model.forEach(node => {
             if (node.cb) {
                 node.cb.checked = node.checked;
@@ -55,6 +111,22 @@ export class VisTree {
             if (spec.key) this.visibility[spec.key] = node.checked;
             if (spec.visKey) {
                 this.visibility[spec.visKey] = node.checked || node.indeterminate;
+            }
+        });
+        // Selectability column: refresh DOM, write back to `selectability`,
+        // and disable when the corresponding visibility node is unchecked.
+        this.selModel.forEach(node => {
+            if (!node.hasCheckbox) return;
+            const spec = node.data;
+            if (spec.key) this.selectability[spec.key] = node.checked;
+            if (!node.selCb) return;
+            node.selCb.checked = node.checked;
+            node.selCb.indeterminate = node.indeterminate;
+            const visNode = this.model.get(node.id);
+            const visOff = visNode && !visNode.checked && !visNode.indeterminate;
+            node.selCb.disabled = visOff;
+            if (node.selLabel) {
+                node.selLabel.classList.toggle('vis-sel-disabled', visOff);
             }
         });
         // Apply disabledBy: gray out nodes whose controlling key is off.
@@ -69,22 +141,50 @@ export class VisTree {
 
     // -- DOM --
 
+    // Build a selectability checkbox for `node` (a visibility-model node),
+    // wired to the parallel sel-model node with the same id.  Returns null
+    // if this row doesn't expose selectability.
+    _buildSelCheckbox(node) {
+        const selNode = this.selModel.get(node.id);
+        if (!selNode || !selNode.hasCheckbox) return null;
+        const cb = document.createElement('input');
+        cb.type = 'checkbox';
+        cb.className = 'vis-sel-cb';
+        cb.title = 'Selectable';
+        cb.addEventListener('change', () => {
+            this.selModel.check(selNode.id, cb.checked);
+        });
+        selNode.selCb = cb;
+        return cb;
+    }
+
     _dom(node) {
         const spec = node.data;
 
         const cb = document.createElement('input');
         cb.type = 'checkbox';
+        cb.title = 'Visible';
         node.cb = cb;
         cb.addEventListener('change', () => this.model.check(node.id, cb.checked));
 
+        const selCb = this._buildSelCheckbox(node);
+
         if (!node.children.length) {
             const label = document.createElement('label');
+            label.className = 'vis-leaf';
             const spacer = document.createElement('span');
             spacer.className = 'vis-arrow';
             spacer.style.visibility = 'hidden';
-            spacer.textContent = '\u25B6';
+            spacer.textContent = '▶';
             label.appendChild(spacer);
             label.appendChild(cb);
+            if (selCb) {
+                label.appendChild(selCb);
+                const selNode = this.selModel.get(node.id);
+                if (selNode) selNode.selLabel = label;
+            } else {
+                label.appendChild(this._selSpacer());
+            }
             label.appendChild(document.createTextNode(spec.label));
             node.el = label;
             return label;
@@ -100,6 +200,13 @@ export class VisTree {
         arrow.textContent = '▶';
         header.appendChild(arrow);
         header.appendChild(cb);
+        if (selCb) {
+            header.appendChild(selCb);
+            const selNode = this.selModel.get(node.id);
+            if (selNode) selNode.selLabel = header;
+        } else {
+            header.appendChild(this._selSpacer());
+        }
         header.appendChild(document.createTextNode(spec.label));
         div.appendChild(header);
 
@@ -118,5 +225,13 @@ export class VisTree {
         });
 
         return div;
+    }
+
+    // Empty placeholder that keeps the selectability column aligned for rows
+    // that have no selectability checkbox.
+    _selSpacer() {
+        const span = document.createElement('span');
+        span.className = 'vis-sel-cb vis-sel-spacer';
+        return span;
     }
 }

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -3,21 +3,32 @@
 
 // Leaflet tile layer that fetches tiles via WebSocket.
 
-// `app` (third arg) is read lazily on every request so that
+// `app` (last arg) is read lazily on every request so that
 // app.visibleChiplets, populated by display-controls.js after the tech
 // metadata arrives, is reflected in tile requests without rebuilding
 // the layer.  When null or absent the field is omitted and the server
 // renders every chiplet (default).
-export function createWebSocketTileLayer(visibility, visibleLayers, app) {
+export function createWebSocketTileLayer(visibility, visibleLayers,
+                                         selectability, selectableLayers,
+                                         app) {
     // Single source of truth for the tile-request payload.  Both
     // createTile (initial load) and refreshTiles (visibility change)
     // call this so the wire format stays in sync — earlier copies of
     // this snippet drifted when fields like visible_chiplets were
     // added in only one place.
+    //
+    // Tiles don't actually use selectability for rendering, but we
+    // send it on every request so the wire schema stays uniform with
+    // selectAt requests.
     function buildTileRequest(coords, layerName) {
         const vf = {};
         for (const [k, v] of Object.entries(visibility)) {
             vf[k] = !!v;
+        }
+        if (selectability) {
+            for (const [k, v] of Object.entries(selectability)) {
+                vf['s_' + k] = !!v;
+            }
         }
         const req = {
             type: 'tile',
@@ -26,6 +37,7 @@ export function createWebSocketTileLayer(visibility, visibleLayers, app) {
             x: coords.x,
             y: coords.y,
             visible_layers: visibleLayers ? [...visibleLayers] : [],
+            selectable_layers: selectableLayers ? [...selectableLayers] : [],
             ...vf,
         };
         if (app && app.visibleChiplets instanceof Set) {

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -963,6 +963,119 @@ TEST_F(RowRenderingTest, RowsDefaultOff)
 // document title (techData.block_name).
 //------------------------------------------------------------------------------
 
+//------------------------------------------------------------------------------
+// Selectability — parallel column added to the display panel, mirroring the
+// Qt GUI's selectability column.  Picks (selectAt) require both visible AND
+// selectable, but rendering ignores the selectability flags.
+//------------------------------------------------------------------------------
+
+TEST_F(TileGeneratorTest, SelectableDefaultAllTrue)
+{
+  TileVisibility vis;
+  EXPECT_TRUE(vis.stdcells_selectable);
+  EXPECT_TRUE(vis.macros_selectable);
+  EXPECT_TRUE(vis.net_signal_selectable);
+  EXPECT_TRUE(vis.net_power_selectable);
+  EXPECT_TRUE(vis.net_clock_selectable);
+  EXPECT_TRUE(vis.pins_selectable);
+  EXPECT_TRUE(vis.inst_pins_selectable);
+  EXPECT_TRUE(vis.placement_blockages_selectable);
+  EXPECT_TRUE(vis.routing_obstructions_selectable);
+  EXPECT_FALSE(vis.has_selectable_layers);
+}
+
+TEST_F(TileGeneratorTest, ParseFromJsonReadsSelectableKeys)
+{
+  TileVisibility vis;
+  vis.parseFromJson(
+      parseObj(R"({"s_stdcells":false,"s_macros":true,"s_net_signal":false,)"
+               R"("s_pins":false,"s_inst_pins":false,)"
+               R"("selectable_layers":["metal1","metal2"]})"));
+  EXPECT_FALSE(vis.stdcells_selectable);
+  EXPECT_TRUE(vis.macros_selectable);
+  EXPECT_FALSE(vis.net_signal_selectable);
+  EXPECT_FALSE(vis.pins_selectable);
+  EXPECT_FALSE(vis.inst_pins_selectable);
+  EXPECT_TRUE(vis.has_selectable_layers);
+  EXPECT_TRUE(vis.isLayerSelectable("metal1"));
+  EXPECT_TRUE(vis.isLayerSelectable("metal2"));
+  EXPECT_FALSE(vis.isLayerSelectable("metal3"));
+}
+
+TEST_F(TileGeneratorTest, IsNetSelectableRespectsSignalType)
+{
+  odb::dbNet* sig_net = odb::dbNet::create(block_, "sig");
+  sig_net->setSigType(odb::dbSigType::SIGNAL);
+  odb::dbNet* pwr_net = odb::dbNet::create(block_, "vdd");
+  pwr_net->setSigType(odb::dbSigType::POWER);
+
+  TileVisibility vis;
+  EXPECT_TRUE(vis.isNetSelectable(sig_net));
+  EXPECT_TRUE(vis.isNetSelectable(pwr_net));
+
+  vis.net_signal_selectable = false;
+  EXPECT_FALSE(vis.isNetSelectable(sig_net));
+  EXPECT_TRUE(vis.isNetSelectable(pwr_net));
+}
+
+TEST_F(TileGeneratorTest, IsLayerSelectableDefaultsTrueWhenUnspecified)
+{
+  TileVisibility vis;
+  // No selectable_layers list ⇒ every layer is selectable.
+  EXPECT_TRUE(vis.isLayerSelectable("metal1"));
+  EXPECT_TRUE(vis.isLayerSelectable("anything"));
+}
+
+TEST_F(TileGeneratorTest, SelectAtGatesInstancesBySelectability)
+{
+  odb::dbInst* inst = placeInst("BUF_X16", "buf1", 10000, 10000);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  const odb::Rect bbox = inst->getBBox()->getBox();
+  const int cx = (bbox.xMin() + bbox.xMax()) / 2;
+  const int cy = (bbox.yMin() + bbox.yMax()) / 2;
+
+  // Default visibility + selectability ⇒ the inst is picked.
+  TileVisibility vis;
+  auto results = tile_gen_->selectAt(cx, cy, /*zoom=*/0, vis);
+  EXPECT_EQ(results.size(), 1u);
+
+  // Visible but not selectable ⇒ no pick.
+  TileVisibility vis_no_sel;
+  vis_no_sel.stdcells_selectable = false;
+  auto results_no_sel = tile_gen_->selectAt(cx, cy, /*zoom=*/0, vis_no_sel);
+  EXPECT_EQ(results_no_sel.size(), 0u);
+
+  // Confirm the path-through-parseFromJson works too.
+  TileVisibility vis_json;
+  vis_json.parseFromJson(parseObj(R"({"s_stdcells":false})"));
+  auto results_json = tile_gen_->selectAt(cx, cy, /*zoom=*/0, vis_json);
+  EXPECT_EQ(results_json.size(), 0u);
+}
+
+TEST_F(TileGeneratorTest, SelectAtGatesInstancesByLayerSelectability)
+{
+  // Layer selectability does NOT gate instance picks (insts aren't on a
+  // layer) — only routing-shape picks.  Confirm an inst still picks when
+  // the selectable_layers list is non-empty but doesn't list anything.
+  odb::dbInst* inst = placeInst("BUF_X16", "buf1", 10000, 10000);
+  makeTileGen();
+  tile_gen_->eagerInit();
+
+  const odb::Rect bbox = inst->getBBox()->getBox();
+  const int cx = (bbox.xMin() + bbox.xMax()) / 2;
+  const int cy = (bbox.yMin() + bbox.yMax()) / 2;
+
+  TileVisibility vis;
+  vis.parseFromJson(parseObj(R"({"selectable_layers":[]})"));
+  EXPECT_TRUE(vis.has_selectable_layers);
+  auto results = tile_gen_->selectAt(cx, cy, /*zoom=*/0, vis);
+  EXPECT_EQ(results.size(), 1u);
+}
+
+//------------------------------------------------------------------------------
+
 TEST_F(TileGeneratorTest, SerializeTechResponseContainsBlockName)
 {
   // Nangate45Fixture creates the block with name "top".

--- a/src/web/test/js/test-vis-tree.js
+++ b/src/web/test/js/test-vis-tree.js
@@ -12,12 +12,13 @@ globalThis.document = dom.window.document;
 const { VisTree } = await import('../../src/vis-tree.js');
 
 describe('VisTree', () => {
-    let visibility, changes, tree;
+    let visibility, selectability, changes, tree;
 
     beforeEach(() => {
         visibility = {};
+        selectability = {};
         changes = 0;
-        tree = new VisTree(visibility, () => { changes++; });
+        tree = new VisTree(visibility, selectability, () => { changes++; });
     });
 
     describe('leaf nodes', () => {
@@ -230,4 +231,166 @@ describe('VisTree', () => {
             assert.ok(pinNamesLabel.classList.contains('disabled'));
         });
     });
+
+    describe('selectability column', () => {
+        it('no second checkbox when addSelectable not set', () => {
+            visibility.a = true;
+            tree.add({ label: 'Group', children: [
+                { key: 'a', label: 'A' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            // Only visibility checkbox on the leaf (plus parent header cb).
+            const leafLabel = container.querySelector('.vis-group-children label');
+            assert.equal(leafLabel.querySelectorAll('input[type=checkbox]').length, 1);
+            // selectability state untouched for keys without selectable column.
+            assert.equal(selectability.a, undefined);
+        });
+
+        it('renders second checkbox on group when addSelectable is true', () => {
+            visibility.a = true;
+            tree.add({ label: 'Group', addSelectable: true, children: [
+                { key: 'a', label: 'A' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            const leafLabel = container.querySelector('.vis-group-children label');
+            const inputs = leafLabel.querySelectorAll('input[type=checkbox]');
+            assert.equal(inputs.length, 2);
+            // The header (group) also gets a selectability checkbox.
+            const headerInputs = container.querySelectorAll(
+                '.vis-group-header input[type=checkbox]');
+            assert.equal(headerInputs.length, 2);
+        });
+
+        it('toggling selectability checkbox updates selectability object', () => {
+            visibility.a = true;
+            selectability.a = true;
+            tree.add({ label: 'Group', addSelectable: true, children: [
+                { key: 'a', label: 'A' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            const leafLabel = container.querySelector('.vis-group-children label');
+            const [, selCb] = leafLabel.querySelectorAll('input[type=checkbox]');
+            selCb.checked = false;
+            selCb.dispatchEvent(new dom.window.Event('change'));
+            assert.equal(selectability.a, false);
+        });
+
+        it('parent selectability checkbox tri-states from children', () => {
+            visibility.a = true;
+            visibility.b = true;
+            selectability.a = true;
+            selectability.b = true;
+            tree.add({ label: 'Group', addSelectable: true, children: [
+                { key: 'a', label: 'A' },
+                { key: 'b', label: 'B' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            // Uncheck child A's selectability.
+            const leaves = container.querySelectorAll('.vis-group-children label');
+            const [, aSel] = leaves[0].querySelectorAll('input[type=checkbox]');
+            aSel.checked = false;
+            aSel.dispatchEvent(new dom.window.Event('change'));
+            // Parent header sel checkbox becomes indeterminate.
+            const headerInputs = container.querySelectorAll(
+                '.vis-group-header input[type=checkbox]');
+            const parentSel = headerInputs[1];
+            assert.equal(parentSel.indeterminate, true);
+        });
+
+        it('unchecking visibility disables selectability checkbox', () => {
+            visibility.a = true;
+            selectability.a = true;
+            tree.add({ label: 'Group', addSelectable: true, children: [
+                { key: 'a', label: 'A' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            const leafLabel = container.querySelector('.vis-group-children label');
+            const [visCb, selCb] = leafLabel.querySelectorAll(
+                'input[type=checkbox]');
+            assert.equal(selCb.disabled, false);
+            visCb.checked = false;
+            visCb.dispatchEvent(new dom.window.Event('change'));
+            assert.equal(selCb.disabled, true);
+        });
+
+        it('toggling parent propagates to all selectable descendants', () => {
+            visibility.a = true;
+            visibility.b = true;
+            visibility.c = true;
+            selectability.a = true;
+            selectability.b = true;
+            selectability.c = true;
+            tree.add({ label: 'Group', addSelectable: true, children: [
+                { label: 'Sub', children: [
+                    { key: 'a', label: 'A' },
+                    { key: 'b', label: 'B' },
+                ]},
+                { key: 'c', label: 'C' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            // The outer "Group" header has [vis, sel] checkboxes.
+            const headerInputs = container.querySelectorAll(
+                '.vis-group-header')[0].querySelectorAll(
+                'input[type=checkbox]');
+            const groupSel = headerInputs[1];
+            groupSel.checked = false;
+            groupSel.dispatchEvent(new dom.window.Event('change'));
+            assert.equal(selectability.a, false);
+            assert.equal(selectability.b, false);
+            assert.equal(selectability.c, false);
+        });
+
+        it('same-labeled groups under different parents stay independent', () => {
+            // Regression: two "Instances" groups (top-level and under Misc)
+            // used to collide on the model node id, so toggling the parent
+            // resolved to the wrong subtree.
+            visibility.a = true;
+            visibility.b = true;
+            selectability.a = true;
+            selectability.b = true;
+            tree.add({ label: 'Instances', addSelectable: true, children: [
+                { key: 'a', label: 'A' },
+            ]});
+            tree.add({ label: 'Misc', children: [
+                { label: 'Instances', children: [
+                    { key: 'b', label: 'B', selectable: true },
+                ]},
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            // The first '.vis-group-header' belongs to the top-level Instances.
+            const topHeader = container.querySelectorAll(
+                '.vis-group-header')[0];
+            const [, topSel] = topHeader.querySelectorAll(
+                'input[type=checkbox]');
+            topSel.checked = false;
+            topSel.dispatchEvent(new dom.window.Event('change'));
+            assert.equal(selectability.a, false);
+            // The unrelated Misc/Instances leaf should be untouched.
+            assert.equal(selectability.b, true);
+        });
+
+        it('leaf with selectable: true opts in without addSelectable', () => {
+            visibility.a = true;
+            selectability.a = true;
+            tree.add({ label: 'Group', children: [
+                { key: 'a', label: 'A', selectable: true },
+                { key: 'b', label: 'B' },
+            ]});
+            const container = document.createElement('div');
+            tree.render(container);
+            const leaves = container.querySelectorAll('.vis-group-children label');
+            assert.equal(
+                leaves[0].querySelectorAll('input[type=checkbox]').length, 2);
+            assert.equal(
+                leaves[1].querySelectorAll('input[type=checkbox]').length, 1);
+        });
+    });
+
 });


### PR DESCRIPTION
Mirrors the Qt GUI's display-controls "selectable" column in the web viewer: a second checkbox per row alongside the visibility checkbox. Picks (selectAt) require both visible AND selectable; rendering is unchanged.

- TileVisibility gains *_selectable peers for every Qt-parity flag, plus selectable_layers / site_selectable maps.  Instance classification is factored into a shared classifyInstance() so isInstVisible and the new isInstSelectable cannot drift.
- parseFromJson reads s_* keys, selectable_layers, and s_site_<name>.
- selectAt() gates instance picks by isInstSelectable, net picks by isNetSelectable, layer iteration by isLayerSelectable, and BTerm picks by pins_selectable.
- VisTree renders a second checkbox column when a leaf opts in with selectable:true or inherits addSelectable from an ancestor group. Visibility unchecked auto-disables the selectability checkbox. Node ids are path-qualified to avoid collisions between same-labeled subtrees (e.g. top-level Instances vs Misc / Instances).
- display-controls layer subtree gets a parallel layerSelModel and a second checkbox per layer, persisted to or_nonselectable_layers.
- main.js initializes a selectability object (Qt defaults true) and app.selectableLayers, persisted to or_selectability, and includes s_* + selectable_layers on every tile/select request.
- New JS tests cover the second column, tri-state propagation, visibility-off-disables-selectability, and the same-label-collision regression.  New C++ tests cover parseFromJson, the new helpers, and selectAt gating by instance and layer selectability.
