### PR TITLE
syn: minimal Bazel repro for SIGSEGV in syn::map_combinationals (post-#10473)

### DIFF
--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -2,6 +2,27 @@
 # Copyright (c) 2026, The OpenROAD Authors
 
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
+# End-to-end repro for a SIGSEGV in syn::map_combinationals (the post-ABC
+# mapper introduced in #10473). Runs the openroad binary against a 2-input
+# AND Tcl repro and expects exit 0 with "OK" on stdout. Currently fails;
+# tagged manual so CI does not turn red on the unfixed bug.
+sh_test(
+    name = "synthesize_minimal_and_sigsegv_test",
+    srcs = ["run_openroad_repro.sh"],
+    args = [
+        "$(rootpath //:openroad)",
+        "$(rootpath synthesize_minimal_and.tcl)",
+    ],
+    data = [
+        "synthesize_minimal_and.sv",
+        "synthesize_minimal_and.tcl",
+        "//:openroad",
+        "//test:regression_resources",
+    ],
+    tags = ["manual"],
+)
 
 # No gtest_main on ir/graph/opt tests: ABC (via //src/syn/src/ir →
 # TritModel) ships its own main() that wins over gtest_main; each TU

--- a/src/syn/test/BUILD
+++ b/src/syn/test/BUILD
@@ -10,6 +10,7 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 # tagged manual so CI does not turn red on the unfixed bug.
 sh_test(
     name = "synthesize_minimal_and_sigsegv_test",
+    size = "small",
     srcs = ["run_openroad_repro.sh"],
     args = [
         "$(rootpath //:openroad)",

--- a/src/syn/test/run_openroad_repro.sh
+++ b/src/syn/test/run_openroad_repro.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 # Wrapper for sh_test targets that run the openroad binary against a Tcl
-# repro using workspace-root-relative paths.
+# repro.
 #
-# Test data (asap7 lib files, the .sv RTL) lives under the runfiles
-# workspace root (TEST_SRCDIR/TEST_WORKSPACE). cd-ing there before
-# invoking openroad lets the Tcl use "test/asap7/..." and
-# "src/syn/test/..." style paths.
+# Bazel's sh_test sets cwd to the runfiles workspace root before
+# invoking this script, so test data (asap7 lib files, the .sv RTL,
+# the openroad binary itself) is reachable via "./" relative paths
+# without any explicit cd or workspace-name detection.
 #
 # args:
 #   $1 - rootpath to the openroad binary
 #   $2 - rootpath to the Tcl script
-set -eu
+set -euo pipefail
 OPENROAD_BIN="$1"
 TCL="$2"
-cd "${TEST_SRCDIR}/${TEST_WORKSPACE:-_main}"
 exec "./${OPENROAD_BIN}" -no_splash -no_init -exit "./${TCL}"

--- a/src/syn/test/run_openroad_repro.sh
+++ b/src/syn/test/run_openroad_repro.sh
@@ -13,4 +13,8 @@
 set -euo pipefail
 OPENROAD_BIN="$1"
 TCL="$2"
-exec "./${OPENROAD_BIN}" -no_splash -no_init -exit "./${TCL}"
+# The "./" prefix on the binary is needed so exec resolves it relative
+# to cwd rather than PATH-searching; the Tcl script is just a file
+# argument and goes through openroad's own open(), which handles both
+# relative-to-cwd and absolute paths without it.
+exec "./${OPENROAD_BIN}" -no_splash -no_init -exit "${TCL}"

--- a/src/syn/test/run_openroad_repro.sh
+++ b/src/syn/test/run_openroad_repro.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wrapper for sh_test targets that run the openroad binary against a Tcl
+# repro using workspace-root-relative paths.
+#
+# Bazel sh_test cwd is the runfiles dir, but the test data (asap7 lib
+# files, the .sv RTL) is laid out under the runfiles workspace root
+# (TEST_SRCDIR/TEST_WORKSPACE), not the runfiles dir. cd-ing there before
+# invoking openroad lets the Tcl use "test/asap7/..." style paths.
+#
+# args:
+#   $1 - rootpath to the openroad binary
+#   $2 - rootpath to the Tcl script
+set -eu
+OPENROAD_BIN="$1"
+TCL="$2"
+WORKSPACE_ROOT="${TEST_SRCDIR}/${TEST_WORKSPACE:-_main}"
+exec "${WORKSPACE_ROOT}/${OPENROAD_BIN}" -no_splash -no_init -exit \
+    "${WORKSPACE_ROOT}/${TCL}"

--- a/src/syn/test/run_openroad_repro.sh
+++ b/src/syn/test/run_openroad_repro.sh
@@ -2,10 +2,10 @@
 # Wrapper for sh_test targets that run the openroad binary against a Tcl
 # repro using workspace-root-relative paths.
 #
-# Bazel sh_test cwd is the runfiles dir, but the test data (asap7 lib
-# files, the .sv RTL) is laid out under the runfiles workspace root
-# (TEST_SRCDIR/TEST_WORKSPACE), not the runfiles dir. cd-ing there before
-# invoking openroad lets the Tcl use "test/asap7/..." style paths.
+# Test data (asap7 lib files, the .sv RTL) lives under the runfiles
+# workspace root (TEST_SRCDIR/TEST_WORKSPACE). cd-ing there before
+# invoking openroad lets the Tcl use "test/asap7/..." and
+# "src/syn/test/..." style paths.
 #
 # args:
 #   $1 - rootpath to the openroad binary
@@ -13,6 +13,5 @@
 set -eu
 OPENROAD_BIN="$1"
 TCL="$2"
-WORKSPACE_ROOT="${TEST_SRCDIR}/${TEST_WORKSPACE:-_main}"
-exec "${WORKSPACE_ROOT}/${OPENROAD_BIN}" -no_splash -no_init -exit \
-    "${WORKSPACE_ROOT}/${TCL}"
+cd "${TEST_SRCDIR}/${TEST_WORKSPACE:-_main}"
+exec "./${OPENROAD_BIN}" -no_splash -no_init -exit "./${TCL}"

--- a/src/syn/test/synthesize_minimal_and.sv
+++ b/src/syn/test/synthesize_minimal_and.sv
@@ -1,0 +1,3 @@
+module synthesize_minimal_and (input wire a, input wire b, output wire q);
+    assign q = a & b;
+endmodule

--- a/src/syn/test/synthesize_minimal_and.tcl
+++ b/src/syn/test/synthesize_minimal_and.tcl
@@ -19,7 +19,7 @@ read_liberty test/asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
 read_liberty test/asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
 
 sv_elaborate -D SYNTHESIS --top synthesize_minimal_and --std=1364-2005 \
-    src/syn/test/synthesize_minimal_and.sv
+  src/syn/test/synthesize_minimal_and.sv
 syn::stats
 synthesize
 

--- a/src/syn/test/synthesize_minimal_and.tcl
+++ b/src/syn/test/synthesize_minimal_and.tcl
@@ -1,0 +1,26 @@
+# Minimal reproducer for a SIGSEGV in syn::map_combinationals (the post-ABC
+# mapper introduced in #10473). Any design with at least one AND node in
+# the post-ABC AIG crashes; a single 2-input AND is the smallest input
+# that triggers it.
+#
+# Expected behavior once fixed: synthesize completes and "OK" is printed.
+# Current behavior: SIGSEGV inside syn::map_combinationals immediately
+# after the "[INFO SYN-0023] abc_roundtrip: after ABC: 1 ANDs ..." log line.
+#
+# Paths are workspace-root-relative; the wrapper sh_test cd's into the
+# Bazel runfiles workspace before invoking openroad.
+
+read_lef test/asap7/asap7_tech_1x_201209.lef
+read_lef test/asap7/asap7sc7p5t_28_R_1x_220121a.lef
+read_liberty test/asap7/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
+read_liberty test/asap7/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
+read_liberty test/asap7/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
+read_liberty test/asap7/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
+read_liberty test/asap7/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
+
+sv_elaborate -D SYNTHESIS --top synthesize_minimal_and --std=1364-2005 \
+    src/syn/test/synthesize_minimal_and.sv
+syn::stats
+synthesize
+
+puts "OK"


### PR DESCRIPTION
## Summary

Adds a Bazel `sh_test` at `//src/syn/test:synthesize_minimal_and_sigsegv_test`
that reproduces a SIGSEGV introduced by #10473 (the integrated synth merge,
`edcc2e8d92`).

- **Input:** a 2-input AND gate (`module synthesize_minimal_and (input wire a, input wire b, output wire q); assign q = a & b; endmodule`).
- **Output:** the `openroad` binary crashes with `Signal 11` immediately after the `[INFO SYN-0023] abc_roundtrip: after ABC: 1 ANDs, 2 CIs, 1 COs` log line, inside `syn::map_combinationals`.

The crash is **not** in `abc_roundtrip`. `synthesize -reduce_name_loss`
(which skips both `abc_roundtrip` calls) also crashes, with no `SYN-0023`
line before the SIGSEGV. The bug is downstream of ABC roundtrip in the new
post-bitblast mapper.

### Bisection (all ASAP7, single-Vt RVT)

| Input | After-ABC AIG | Result |
|---|---|---|
| Wire passthrough (`q = a`) | 0 ANDs, 1 CI, 0 COs | `mapCombinationals: done` |
| Inverter (`q = ~a`) | 0 ANDs, 1 CI, 1 COs | `mapCombinationals: done` |
| 1 D-flop, no logic | 0 ANDs, 3 CIs, 0 COs | Clean `SYN-0027 no dbMaster` (not the crash) |
| **2-input AND** | **1 AND, 2 CIs, 1 COs** | **SIGSEGV** |
| 2:1 mux | 3 ANDs, 3 CIs, 1 COs | SIGSEGV |
| 4-input XOR | 9 ANDs, 4 CIs, 1 COs | SIGSEGV |
| 4-bit comb adder | 27 ANDs, 8 CIs, 5 COs | SIGSEGV |
| 8-bit registered adder | 59 ANDs, 25 CIs, 8 COs | SIGSEGV |

Threshold: any design with `>= 1` AND node post-ABC triggers the crash.

### Stack (`-c opt`, symbols stripped)

```
[INFO SYN-0023] abc_roundtrip: after ABC: 1 ANDs, 2 CIs, 1 COs
Signal 11 received
Stack trace:
 0# 0x0000000001F69945 in .../bazel-out/k8-opt/bin/openroad
 1# 0x0000000000045F60 in /lib/x86_64-linux-gnu/libc.so.6
 2# 0x0000000003E896B7 in .../bazel-out/k8-opt/bin/openroad
 3# 0x0000000003E89730 in .../bazel-out/k8-opt/bin/openroad
 4# 0x0000000003E898E3 in .../bazel-out/k8-opt/bin/openroad
 5# 0x0000000003E8B3D9 in .../bazel-out/k8-opt/bin/openroad
 6# 0x0000000003E6F168 in .../bazel-out/k8-opt/bin/openroad
 7# 0x0000000005739303 in .../bazel-out/k8-opt/bin/openroad
 ...
```

## Why the test is `tags = ["manual"]`

The test asserts the post-fix behavior: `synthesize` runs to completion and
prints `OK`. Today it SIGSEGVs, so the test fails. To keep CI green while
the underlying bug is unfixed, the test is tagged `manual` and excluded
from default `bazelisk test //...` runs. Run it explicitly with:

```
bazelisk test //src/syn/test:synthesize_minimal_and_sigsegv_test
```

Once the mapper bug is fixed, remove the `manual` tag and the test becomes
a permanent regression guard.

## Bazel-only by design

The repro is intentionally registered only in Bazel (`src/syn/test/BUILD`),
not in `src/syn/test/CMakeLists.txt`. The CMake `or_integration_tests`
helper does not currently expose `WILL_FAIL` semantics, so registering a
known-failing test there would just break `ctest` for everyone. Once the
bug is fixed and the test passes, CMake registration can be added in a
follow-up.

## Test plan

- [x] `bazelisk test //src/syn/test:synthesize_minimal_and_sigsegv_test` reproduces `Signal 11` after `SYN-0023` (see `test.log` excerpt above)
- [x] Default `bazelisk test //...` is unaffected (test is tagged `manual`)
- [x] No CMake registration; `ctest` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)