### PR TITLE
ord: fix a crash when link_design is called twice.

### DIFF
--- a/src/OpenRoad.cc
+++ b/src/OpenRoad.cc
@@ -624,6 +624,7 @@ void OpenRoad::linkDesign(const char* design_name,
   if (success) {
     delete verilog_reader_;
     verilog_reader_ = nullptr;
+    verilog_network_->setLinkFunc(nullptr);
   }
 
   if (hierarchy) {


### PR DESCRIPTION
## Summary
OpenROAD throws sigsegv when link_design is called twice due to the `sta::VerilogReader` being destructed but the openroad object retains the dangling pointer.

Repro:
```
read_lef test/sky130hd/sky130hd.tlef
read_lef test/sky130hd/sky130_fd_sc_hd.lef
read_liberty test/sky130hd/sky130hd_tt.lib
read_verilog test/gcd_sky130hd.v
link_design gcd

# allocate over the existing memory
report_wns

# crashes
link_design gcd
```

## Type of Change
- Bug fix

## Impact
STA will throw an error instead of crashing.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
