### PR TITLE
odb: add setter for wire type

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -3841,6 +3841,11 @@ class dbSWire : public dbObject
   dbWireType getWireType();
 
   ///
+  /// Set the wire-type.
+  ///
+  void setWireType(dbWireType type);
+
+  ///
   /// Returns the shield net if the wire-type is dbWireType::SHIELD
   ///
   dbNet* getShield();

--- a/src/odb/src/db/dbSWire.cpp
+++ b/src/odb/src/db/dbSWire.cpp
@@ -134,6 +134,12 @@ dbNet* dbSWire::getNet()
   return (dbNet*) block->net_tbl_->getPtr(wire->net_);
 }
 
+void dbSWire::setWireType(dbWireType type)
+{
+  _dbSWire* wire = (_dbSWire*) this;
+  wire->flags_.wire_type = type.getValue();
+}
+
 dbWireType dbSWire::getWireType()
 {
   _dbSWire* wire = (_dbSWire*) this;


### PR DESCRIPTION
## Summary
Adds missing setter for the SWire type

## Type of Change
- New feature

## Impact
No impact

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
N/A
