### PR TITLE
psm: handle empty networks gracefully

### DIFF
--- a/src/psm/src/ir_network.cpp
+++ b/src/psm/src/ir_network.cpp
@@ -77,6 +77,16 @@ odb::dbTech* IRNetwork::getTech() const
   return getBlock()->getTech();
 }
 
+bool IRNetwork::hasNodes() const
+{
+  for (const auto& [layer, nodes] : nodes_) {
+    if (!nodes.empty()) {
+      return true;
+    }
+  }
+  return !iterm_nodes_.empty() || !bpin_nodes_.empty();
+}
+
 void IRNetwork::reset()
 {
   shapes_.clear();
@@ -98,6 +108,12 @@ void IRNetwork::construct()
 
   generateRoutingLayerShapesAndNodes();
   generateCutLayerNodes();
+
+  if (!hasNodes()) {
+    logger_->warn(utl::PSM, 86, "Net {} is empty.", net_->getName());
+    return;
+  }
+
   generateTopLayerFillerNodes();
   sortNodes();
   if (logger_->debugCheck(utl::PSM, "dump", 2)) {

--- a/src/psm/src/ir_network.h
+++ b/src/psm/src/ir_network.h
@@ -111,6 +111,8 @@ class IRNetwork
   odb::PtrMap<odb::dbInst, Node::NodeSet> getInstanceNodeMapping() const;
   ShapeTree getShapeTree(odb::dbTechLayer* layer) const;
 
+  bool hasNodes() const;
+
   // For debug only
   void dumpNodes(const std::map<Node*, std::size_t>& node_map,
                  const std::string& name = "nodes") const;

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -125,18 +125,22 @@ bool IRSolver::check(bool check_bterms)
     return connected_.value();
   }
 
-  // set to true and unset if it failed
-  connected_ = true;
-  if (check_bterms && !checkBTerms()) {
-    reportMissingBTerm();
+  if (!network_->hasNodes()) {
     connected_ = false;
-  }
-  if (!checkOpen()) {
-    reportUnconnectedNodes();
-    connected_ = false;
-  }
-  if (!checkShort()) {
-    connected_ = false;
+  } else {
+    // set to true and unset if it failed
+    connected_ = true;
+    if (check_bterms && !checkBTerms()) {
+      reportMissingBTerm();
+      connected_ = false;
+    }
+    if (!checkOpen()) {
+      reportUnconnectedNodes();
+      connected_ = false;
+    }
+    if (!checkShort()) {
+      connected_ = false;
+    }
   }
 
   return connected_.value();
@@ -1000,6 +1004,10 @@ void IRSolver::solve(sta::Scene* corner,
   if (network_->isFloorplanningOnly()) {
     network_->setFloorplanning(false);
     network_->construct();
+  }
+
+  if (!network_->hasNodes()) {
+    return;
   }
 
   assertResistanceMap(corner);

--- a/src/psm/src/ir_solver.cpp
+++ b/src/psm/src/ir_solver.cpp
@@ -1007,6 +1007,10 @@ void IRSolver::solve(sta::Scene* corner,
   }
 
   if (!network_->hasNodes()) {
+    voltages_.erase(corner);
+    currents_.erase(corner);
+    solution_voltages_.erase(corner);
+    solution_power_.erase(corner);
     return;
   }
 

--- a/src/psm/test/BUILD
+++ b/src/psm/test/BUILD
@@ -18,6 +18,7 @@ COMPULSORY_TESTS = [
     "check_power_grid",
     "check_power_grid_disconnected",
     "check_power_grid_disconnected_macro",
+    "check_power_grid_empty_net",
     "check_power_grid_floorplanning",
     "check_power_grid_macros",
     "check_power_grid_ok_disconnected",

--- a/src/psm/test/CMakeLists.txt
+++ b/src/psm/test/CMakeLists.txt
@@ -11,6 +11,7 @@ or_integration_tests(
     check_power_grid
     check_power_grid_disconnected
     check_power_grid_disconnected_macro
+    check_power_grid_empty_net
     check_power_grid_floorplanning
     check_power_grid_macros
     check_power_grid_ok_disconnected

--- a/src/psm/test/check_power_grid_empty_net.ok
+++ b/src/psm/test/check_power_grid_empty_net.ok
@@ -1,0 +1,9 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: gcd
+[INFO ODB-0130]     Created 54 pins.
+[INFO ODB-0131]     Created 624 components and 2752 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 1248 connections.
+[INFO ODB-0133]     Created 581 nets and 1504 connections.
+[WARNING PSM-0086] Net VDDTest is empty.
+[ERROR PSM-0069] Check connectivity failed on VDDTest.
+PSM-0069

--- a/src/psm/test/check_power_grid_empty_net.tcl
+++ b/src/psm/test/check_power_grid_empty_net.tcl
@@ -1,0 +1,13 @@
+# Check that check_power_grid works when the net is empty
+source helpers.tcl
+
+read_lef Nangate45/Nangate45.lef
+read_def Nangate45_data/gcd.def
+
+set net [odb::dbNet_create [ord::get_db_block] VDDTest]
+$net setSigType POWER
+
+odb::dbBTerm_create $net "VDDTest"
+
+catch { [check_power_grid -net VDDTest] } err
+puts $err

--- a/src/psm/test/check_power_grid_empty_net.tcl
+++ b/src/psm/test/check_power_grid_empty_net.tcl
@@ -9,5 +9,5 @@ $net setSigType POWER
 
 odb::dbBTerm_create $net "VDDTest"
 
-catch { [check_power_grid -net VDDTest] } err
+catch { check_power_grid -net VDDTest } err
 puts $err


### PR DESCRIPTION
## Summary
When called on an empty net, PSM was segfaulting. This ensures we generate an error gracefully.

## Type of Change
- Bug fix

## Impact
Fix segfault

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**

## Related Issues
