### PR TITLE
rsz: skip ensureWireParasitic in repair_design hot path

### DIFF
--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -643,7 +643,8 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
   bool getCin(const sta::LibertyCell* cell, float& cin);
   // Resize drvr_pin instance to target slew.
   // Return 1 if resized.
-  int resizeToTargetSlew(const sta::Pin* drvr_pin);
+  int resizeToTargetSlew(const sta::Pin* drvr_pin,
+                         std::optional<float> load_cap_hint = std::nullopt);
 
   // Resize drvr_pin instance to target cap ratio.
   // Return 1 if resized.

--- a/src/rsz/src/RepairDesign.cc
+++ b/src/rsz/src/RepairDesign.cc
@@ -1604,6 +1604,10 @@ void RepairDesign::repairNetWire(
       double d = (length == 0) ? 0.0 : buf_dist / length;
       int buf_x = to_x + d * dx;
       int buf_y = to_y + d * dy;
+      // Buffer is inserted at buf_dist from to_pt, so it drives only the
+      // downstream wire (buf_dist long) + ref_cap, not the full Steiner edge.
+      const float buffer_load_cap
+          = static_cast<float>(buf_dist / (dbu_ * 1e+6) * wire_cap + ref_cap);
       float repeater_cap, repeater_fanout;
       if (!makeRepeater("wire",
                         odb::Point(buf_x, buf_y),
@@ -1613,7 +1617,8 @@ void RepairDesign::repairNetWire(
                         load_pins,
                         repeater_cap,
                         repeater_fanout,
-                        max_load_slew)) {
+                        max_load_slew,
+                        /* load_cap_hint= */ buffer_load_cap)) {
         debugPrint(logger_,
                    RSZ,
                    "repair_net",
@@ -1842,7 +1847,8 @@ void RepairDesign::repairNetJunc(
                  loads_left,
                  cap_left,
                  fanout_left,
-                 max_load_slew_left);
+                 max_load_slew_left,
+                 /* load_cap_hint= */ cap_left);
     wire_length_left = 0;
   }
   if (repeater_right) {
@@ -1854,7 +1860,8 @@ void RepairDesign::repairNetJunc(
                  loads_right,
                  cap_right,
                  fanout_right,
-                 max_load_slew_right);
+                 max_load_slew_right,
+                 /* load_cap_hint= */ cap_right);
     wire_length_right = 0;
   }
 
@@ -2167,7 +2174,8 @@ bool RepairDesign::makeRepeater(const char* reason,
                                 sta::PinSeq& load_pins,
                                 float& repeater_cap,
                                 float& repeater_fanout,
-                                float& repeater_max_slew)
+                                float& repeater_max_slew,
+                                std::optional<float> load_cap_hint)
 {
   sta::Net* out_net;
   sta::Pin *repeater_in_pin, *repeater_out_pin;
@@ -2183,7 +2191,8 @@ bool RepairDesign::makeRepeater(const char* reason,
                       repeater_max_slew,
                       out_net,
                       repeater_in_pin,
-                      repeater_out_pin);
+                      repeater_out_pin,
+                      load_cap_hint);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -2218,7 +2227,8 @@ bool RepairDesign::makeRepeater(
     float& repeater_max_slew,
     sta::Net*& out_net,
     sta::Pin*& repeater_in_pin,
-    sta::Pin*& repeater_out_pin)
+    sta::Pin*& repeater_out_pin,
+    std::optional<float> load_cap_hint)
 {
   debugPrint(logger_,
              RSZ,
@@ -2258,7 +2268,7 @@ bool RepairDesign::makeRepeater(
   // Resize repeater as we back up by levels.
   if (resize) {
     sta::Pin* buffer_out_pin = network_->findPin(buffer, buffer_output_port);
-    resizer_->resizeToTargetSlew(buffer_out_pin);
+    resizer_->resizeToTargetSlew(buffer_out_pin, load_cap_hint);
     buffer_cell = network_->libertyCell(buffer);
     buffer_cell->bufferPorts(buffer_input_port, buffer_output_port);
   }

--- a/src/rsz/src/RepairDesign.hh
+++ b/src/rsz/src/RepairDesign.hh
@@ -216,7 +216,8 @@ class RepairDesign : sta::dbStaState
                     sta::PinSeq& load_pins,
                     float& repeater_cap,
                     float& repeater_fanout,
-                    float& repeater_max_slew);
+                    float& repeater_max_slew,
+                    std::optional<float> load_cap_hint = std::nullopt);
   bool makeRepeater(const char* reason,
                     int x,
                     int y,
@@ -230,7 +231,8 @@ class RepairDesign : sta::dbStaState
                     float& repeater_max_slew,
                     sta::Net*& out_net,
                     sta::Pin*& repeater_in_pin,
-                    sta::Pin*& repeater_out_pin);
+                    sta::Pin*& repeater_out_pin,
+                    std::optional<float> load_cap_hint = std::nullopt);
   sta::LibertyCell* findBufferUnderSlew(float max_slew, float load_cap);
   bool hasInputPort(const sta::Net* net);
   double dbuToMeters(int dist) const;

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -2533,7 +2533,8 @@ VTCategory Resizer::cellVTType(dbMaster* master)
   return new_it->second;
 }
 
-int Resizer::resizeToTargetSlew(const sta::Pin* drvr_pin)
+int Resizer::resizeToTargetSlew(const sta::Pin* drvr_pin,
+                                std::optional<float> load_cap_hint)
 {
   sta::Instance* inst = network_->instance(drvr_pin);
   sta::LibertyCell* cell = network_->libertyCell(inst);
@@ -2550,10 +2551,19 @@ int Resizer::resizeToTargetSlew(const sta::Pin* drvr_pin)
                  revisiting_inst ? " - revisit" : "");
       resized_multi_output_insts_.insert(inst);
     }
-    estimate_parasitics_->ensureWireParasitic(drvr_pin);
-    // Includes net parasitic capacitance.
-    float load_cap
-        = graph_delay_calc_->loadCap(drvr_pin, tgt_slew_corner_, max_);
+    // Hint skips ensureWireParasitic, which triggers an incremental
+    // FastRoute per buffer in the repair_design.
+    // Only applies under global-routing parasitics;
+    // placement-based estimation is already cheap.
+    float load_cap;
+    if (load_cap_hint.has_value()
+        && estimate_parasitics_->getParasiticsSrc()
+               == est::ParasiticsSrc::kGlobalRouting) {
+      load_cap = *load_cap_hint;
+    } else {
+      estimate_parasitics_->ensureWireParasitic(drvr_pin);
+      load_cap = graph_delay_calc_->loadCap(drvr_pin, tgt_slew_corner_, max_);
+    }
     if (load_cap > 0.0) {
       sta::LibertyCell* target_cell
           = findTargetCell(cell, load_cap, revisiting_inst);


### PR DESCRIPTION
## Summary

- Pass a local load_cap from BufferedNet wire RC to \`resizeToTargetSlew\` as a hint, skipping the expensive \`ensureWireParasitic + STA loadCap\` query on the \`repair_design\` buffer-insertion hot path.
- \`repairNetWire\` hint reflects only the wire the buffer drives (\`buf_dist × wire_cap + ref_cap\`), not the full Steiner edge.
- \`repairNetJunc\` passes \`cap_left\`/\`cap_right\` since the buffer is placed at the junction location.
- Gate on \`parasitics_src_ == kGlobalRouting\` so the optimization applies only where the FastRoute incremental setup is the cost. Placement-mode \`repair_design\` (the bulk of OR's own test suite) keeps the existing path.

## Type

- [x] Performance optimization (no functional change at the API level; existing callers without a hint take the same code path)

## Impact

Profiled on a large customer design (497k inst) where \`ensureWireParasitic\` accounted for **96% of \`repair_design\` wall time** (5,860 calls × ~390ms FastRoute setup each).

Measured on the same design (same cts.odb, same OR commit, 5_1_grt step only re-run):

| Metric | Baseline | Fix | Δ |
|---|---:|---:|---:|
| \`repair_design\` wall | 1,570s | **312s** | **-79% (5× faster)** |
| Total GRT step (5_1_grt) | 3,996s | 2,842s | -29% |
| Buffers inserted in RD | 6,360 | 6,360 | exact match |
| Final Setup TNS | -343.7 | **-341.7** | better |
| Final Hold TNS | -0.0599 | **-0.0323** | **better (-46%)** |
| Final Hold viol count | 32 | **23** | better (-9) |
| Final Setup WS | -0.1444 | -0.1470 | -1.8% |

## Verification

- All 7 existing \`rsz.repair_design*\` and 11 \`rsz.repair_wire*\` regression tests pass.
- clang-format applied. Diff: 4 files in \`src/rsz/\`, +34 / -15.

## Related Issues

See private issue The-OpenROAD-Project-private/OpenROAD-flow-scripts#1676.

(Note: supersedes #3433 which had its head branch renamed.)