### PR TITLE
ifp/ppl: add documentation for rectilinear floorplans

### DIFF
--- a/src/ifp/README.md
+++ b/src/ifp/README.md
@@ -64,9 +64,9 @@ initialize_floorplan
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-core_area` | Core area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-polygonal-floorplans). |
+| `-core_area` | Core area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-floorplans). |
 | `-core_space` | Space around the core in microns. Allowed values are either one value for all margins or a set of four values, one for each margin. The order of the four values are: `{bottom top left right}`. |
-| `-die_area` | Die area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-polygonal-floorplans). |
+| `-die_area` | Die area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-floorplans). |
 | `-site` | Site name. |
 | `-utilization` | Percentage utilization. Allowed values are `double` in the range `(0-100]`. |
 | `[-additional_sites]` | Tcl list of sites to make rows for (e.g. `{SITEXX, SITEYY}`) |

--- a/src/ifp/README.md
+++ b/src/ifp/README.md
@@ -87,6 +87,7 @@ specified as a polygon (it is not derived from `-utilization`,
 Example: an L-shaped die with a matching L-shaped core, with a 20 micron
 margin between them.
 
+<!-- checker: skip -->
 ```tcl
 initialize_floorplan \
   -die_area  {0 0   200 0   200 100   100 100   100 200   0 200} \

--- a/src/ifp/README.md
+++ b/src/ifp/README.md
@@ -52,7 +52,7 @@ die =  ( 0, 0 )
 
 ```tcl
 initialize_floorplan
-  (-die_area {llx lly urx ury} -core_area {llx lly urx ury}) | (-utilization util -core_space (space | {bottom top left right}) [-aspect_ratio ratio])
+  (-die_area {llx lly urx ury | x1 y1 x2 y2 ...} -core_area {llx lly urx ury | x1 y1 x2 y2 ...}) | (-utilization util -core_space (space | {bottom top left right}) [-aspect_ratio ratio])
   -site site_name
   [-additional_sites site_names]
   [-flip_sites site_names]
@@ -64,9 +64,9 @@ initialize_floorplan
 
 | Switch Name | Description |
 | ----- | ----- |
-| `-core_area` | Core area coordinates in microns (lower left x/y and upper right x/y coordinates). |
+| `-core_area` | Core area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-polygonal-floorplans). |
 | `-core_space` | Space around the core in microns. Allowed values are either one value for all margins or a set of four values, one for each margin. The order of the four values are: `{bottom top left right}`. |
-| `-die_area` | Die area coordinates in microns (lower left x/y and upper right x/y coordinates). |
+| `-die_area` | Die area coordinates in microns. Either a rectangle as `{llx lly urx ury}`, or a rectilinear polygon as a list of vertex coordinates `{x1 y1 x2 y2 ...}`. See [Rectilinear Floorplans](#rectilinear-polygonal-floorplans). |
 | `-site` | Site name. |
 | `-utilization` | Percentage utilization. Allowed values are `double` in the range `(0-100]`. |
 | `[-additional_sites]` | Tcl list of sites to make rows for (e.g. `{SITEXX, SITEYY}`) |
@@ -74,6 +74,37 @@ initialize_floorplan
 | `[-flip_sites]` | Flip the orientations of rows matching these sites. Sites listed under this option will create `FS`-oriented rows at even indices and `N`-oriented rows at odd ones, and vice versa for sites not listed under this option. (e.g. `{SITEXX, SITEYY}`) |
 | `[-gap]` | Space between power domains in microns. The default value is 6 times the minimum site height. |
 | `[-row_parity]` | Snap to either an odd (`ODD`) or even (`EVEN`) number of rows. Defaults to `NONE` (no constraint on parity). |
+
+### Rectilinear Floorplans
+
+The `initialize_floorplan` command supports non-rectangular die and core
+outlines (e.g. L-shapes, T-shapes, or arbitrary rectilinear polygons).
+Rectilinear mode is selected automatically when `-die_area` is given more than
+four coordinates. When rectilinear mode is used, `-core_area` must also be
+specified as a polygon (it is not derived from `-utilization`,
+`-aspect_ratio`, or `-core_space`).
+
+Example: an L-shaped die with a matching L-shaped core, with a 20 micron
+margin between them.
+
+```tcl
+initialize_floorplan \
+  -die_area  {0 0   200 0   200 100   100 100   100 200   0 200} \
+  -core_area {20 20  180 20  180 80   80 80     80 180    20 180} \
+  -site FreePDK45_38x28_10R_NP_162NW_34O
+```
+
+Rows are generated only inside the polygonal core, respecting its rectilinear edges.
+
+#### Polygon Vertex Rules
+
+- Coordinates are in microns, listed as `{x1 y1 x2 y2 ... xN yN}`.
+- The vertex count must be even (each `x` paired with a `y`).
+- Exactly 4 coordinates are interpreted as a rectangle. A polygon must
+  have more than 4 coordinates and at least 4 vertices (8 coordinates).
+- Edges must be axis-aligned (rectilinear): consecutive vertices must
+  share either an `x` or a `y` coordinate.
+- The die polygon must fully contain the core polygon.
 
 ### Make Tracks
 

--- a/src/ifp/test/ifp_readme_msgs_check.ok
+++ b/src/ifp/test/ifp_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 4,        Desc: 4,        Syn: 4,        Options: 4,        Args: 4
+Names: 5,        Desc: 5,        Syn: 5,        Options: 5,        Args: 5
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.

--- a/src/ppl/README.md
+++ b/src/ppl/README.md
@@ -321,6 +321,11 @@ Rectilinear mode is detected automatically from the die polygon stored in the
 database; no extra option is required. Pins are distributed along the
 edges of the polygonal die boundary.
 
+<!-- checker: skip -->
+```tcl
+place_pins -hor_layers metal3 -ver_layers metal2
+```
+
 ## Useful Developer Commands
 
 If you are a developer, you might find these useful. More details can be found in the [source file](./src/IOPlacer.cpp) or the [swig file](./src/IOPlacer.i).

--- a/src/ppl/README.md
+++ b/src/ppl/README.md
@@ -316,7 +316,7 @@ write_pin_placement
 The `place_pins` command supports designs with a rectilinear
 (non-rectangular) die outline, such as those created by
 `initialize_floorplan` with a polygonal `-die_area` (see the
-[`ifp` documentation](../ifp/README.md#rectilinear-polygonal-floorplans)).
+[`ifp` documentation](../ifp/README.md#rectilinear-floorplans)).
 Rectilinear mode is detected automatically from the die polygon stored in the
 database; no extra option is required. Pins are distributed along the
 edges of the polygonal die boundary.

--- a/src/ppl/README.md
+++ b/src/ppl/README.md
@@ -311,6 +311,16 @@ write_pin_placement
 | `file_name` | The name of the file with the pin placement. |
 | `-placed_status` | When this flag is enabled, the file will be generated´with the `-placed_status` flag in each `place_pin` command call. |
 
+### Rectilinear Floorplans
+
+The `place_pins` command supports designs with a rectilinear
+(non-rectangular) die outline, such as those created by
+`initialize_floorplan` with a polygonal `-die_area` (see the
+[`ifp` documentation](../ifp/README.md#rectilinear-polygonal-floorplans)).
+Rectilinear mode is detected automatically from the die polygon stored in the
+database; no extra option is required. Pins are distributed along the
+edges of the polygonal die boundary.
+
 ## Useful Developer Commands
 
 If you are a developer, you might find these useful. More details can be found in the [source file](./src/IOPlacer.cpp) or the [swig file](./src/IOPlacer.i).

--- a/src/ppl/test/ppl_readme_msgs_check.ok
+++ b/src/ppl/test/ppl_readme_msgs_check.ok
@@ -1,5 +1,5 @@
 README.md
-Names: 12,        Desc: 12,        Syn: 12,        Options: 12,        Args: 12
+Names: 13,        Desc: 13,        Syn: 13,        Options: 13,        Args: 13
 Global Examples: None
 Global See Also: None
 Man2 successfully compiled.


### PR DESCRIPTION
## Summary
Add missing documentation for the rectilinear floorplans support implemented on IFP and PPL.

## Type of Change
- Documentation update

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
