### PR TITLE
mpl: Fixes MPL-45 can't split cluster error

### DIFF
--- a/src/mpl/src/clusterEngine.cpp
+++ b/src/mpl/src/clusterEngine.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -1120,9 +1121,47 @@ void ClusteringEngine::breakLargeFlatCluster(Cluster* parent)
 
   std::vector<odb::dbInst*> insts;
   odb::PtrMap<odb::dbInst, int> inst_vertex_id_map;
+  // 1. Calculate areas to detect discrete macro domination
+  float max_macro_area = 0.0f;
+  float total_std_cell_area = 0.0f;
+
+  for (auto& macro : parent->getLeafMacros()) {
+    float area = block_->dbuAreaToMicrons(computeArea(macro));
+    max_macro_area = std::max(max_macro_area, area);
+  }
+
+  for (auto& std_cell : parent->getLeafStdCells()) {
+    float area = block_->dbuAreaToMicrons(computeArea(std_cell));
+    total_std_cell_area += area;
+  }
+
+  // At this point in the code we should have some standard cells, but set
+  // to 1.0 if not.
+  const size_t num_std_cells = parent->getLeafStdCells().size();
+  const float avg_std_cell_area
+      = (num_std_cells > 0) ? (total_std_cell_area / num_std_cells) : 1.0f;
+
+  // 2. The Rocks vs Sand Check
+  // If a single macro dwarfs the entire standard cell cloud, area-balancing
+  // is structurally impossible against a min-cut objective.
+  const bool discrete_macro_domination = (max_macro_area > total_std_cell_area);
+
+  if (discrete_macro_domination) {
+    debugPrint(logger_,
+               MPL,
+               "multilevel_autoclustering",
+               1,
+               "Graph is macro-dominated. Normalizing macro weights to avoid "
+               "knapsack partition failure.");
+  }
+
+  // 3. Populate vertex weights dynamically
   for (auto& macro : parent->getLeafMacros()) {
     inst_vertex_id_map[macro] = vertex_id++;
-    vertex_weight.push_back(block_->dbuAreaToMicrons(computeArea(macro)));
+    float weight = discrete_macro_domination
+                       ? avg_std_cell_area
+                       : block_->dbuAreaToMicrons(computeArea(macro));
+    vertex_weight.push_back(weight);
     insts.push_back(macro);
   }
   for (auto& std_cell : parent->getLeafStdCells()) {

--- a/src/mpl/test/BUILD
+++ b/src/mpl/test/BUILD
@@ -40,6 +40,7 @@ COMPULSORY_TESTS = [
     "macro_only",
     "macros_without_pins1",
     "mixed_ios1",
+    "mpl_dominated",
     "no_unfixed_macros",
     "orientation_improve1",
     "orientation_improve2",
@@ -205,6 +206,10 @@ filegroup(
                     "testcases/macro_only.lef",
                     "testcases/macro_only.lib",
                     "testcases/mixed_ios1.def",
+                ],
+                "mpl_dominated": [
+                    "testcases/mpl_dominated.def",
+                    "testcases/mpl_dominated.lef",
                 ],
                 "no_unfixed_macros": [
                     "testcases/macro_only.lef",

--- a/src/mpl/test/CMakeLists.txt
+++ b/src/mpl/test/CMakeLists.txt
@@ -35,6 +35,7 @@ or_integration_tests(
     halos2
     halos3
     halos4
+    mpl_dominated
 )
 
 

--- a/src/mpl/test/mpl_dominated.ok
+++ b/src/mpl/test/mpl_dominated.ok
@@ -1,0 +1,22 @@
+[INFO ODB-0227] LEF file: ./Nangate45/Nangate45_tech.lef, created 22 layers, 27 vias
+[INFO ODB-0227] LEF file: ./testcases/mpl_dominated.lef, created 2 library cells
+[INFO ODB-0128] Design: mpl_dominated
+[INFO ODB-0131]     Created 23 components and 53 component-terminals.
+[INFO ODB-0133]     Created 31 nets and 81 connections.
+Die Area: (0.00, 0.00) (30000.00, 30000.00),  Floorplan Area: (0.00, 0.00) (30000.00, 30000.00)
+	Number of std cell instances: 20
+	Area of std cell instances: 20.00
+	Number of macros: 3
+	Area of macros: 300000000.00
+	Base halo (L, B, R, T): (0.00, 0.00, 0.00, 0.00)
+	Area of macros with halos: 300000000.00
+	Area of std cell instances + Area of macros: 300000020.00
+	Floorplan area: 900000000.00
+	Design Utilization: 0.33
+	Floorplan Utilization: 0.00
+	Manufacturing Grid: 10
+
+[WARNING MPL-0026] Design has no IO pins!
+[WARNING MPL-0002] Could not align all pins of the macro macro1 to the track-grid. 2 out of 11 pins were aligned.
+[WARNING MPL-0002] Could not align all pins of the macro macro2 to the track-grid. 1 out of 11 pins were aligned.
+[WARNING MPL-0002] Could not align all pins of the macro macro3 to the track-grid. 2 out of 11 pins were aligned.

--- a/src/mpl/test/mpl_dominated.tcl
+++ b/src/mpl/test/mpl_dominated.tcl
@@ -1,0 +1,12 @@
+# Test if we handle macro-dominated partitions correctly
+source "helpers.tcl"
+
+read_lef "./Nangate45/Nangate45_tech.lef"
+read_lef "./testcases/mpl_dominated.lef"
+
+read_def "./testcases/mpl_dominated.def"
+
+set_thread_count 0
+rtl_macro_placer -max_num_macro 3 -min_num_macro 1 \
+  -max_num_inst 5 -min_num_inst 2 \
+  -report_directory [make_result_dir]

--- a/src/mpl/test/testcases/mpl_dominated.def
+++ b/src/mpl/test/testcases/mpl_dominated.def
@@ -1,0 +1,110 @@
+VERSION 5.8 ;
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN mpl_dominated ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 30000000 30000000 ) ;
+
+COMPONENTS 23 ;
+  - macro1 LARGE_MACRO_CELL ;
+  - macro2 LARGE_MACRO_CELL ;
+  - macro3 LARGE_MACRO_CELL ;
+  - sc0 SMALL_STDCELL_CELL ;
+  - sc1 SMALL_STDCELL_CELL ;
+  - sc2 SMALL_STDCELL_CELL ;
+  - sc3 SMALL_STDCELL_CELL ;
+  - sc4 SMALL_STDCELL_CELL ;
+  - sc5 SMALL_STDCELL_CELL ;
+  - sc6 SMALL_STDCELL_CELL ;
+  - sc7 SMALL_STDCELL_CELL ;
+  - sc8 SMALL_STDCELL_CELL ;
+  - sc9 SMALL_STDCELL_CELL ;
+  - sc10 SMALL_STDCELL_CELL ;
+  - sc11 SMALL_STDCELL_CELL ;
+  - sc12 SMALL_STDCELL_CELL ;
+  - sc13 SMALL_STDCELL_CELL ;
+  - sc14 SMALL_STDCELL_CELL ;
+  - sc15 SMALL_STDCELL_CELL ;
+  - sc16 SMALL_STDCELL_CELL ;
+  - sc17 SMALL_STDCELL_CELL ;
+  - sc18 SMALL_STDCELL_CELL ;
+  - sc19 SMALL_STDCELL_CELL ;
+END COMPONENTS
+
+TRACKS X 190 DO 2368 STEP 380 LAYER metal1 ;
+TRACKS Y 140 DO 3214 STEP 280 LAYER metal1 ;
+TRACKS X 190 DO 2368 STEP 380 LAYER metal2 ;
+TRACKS Y 140 DO 3214 STEP 280 LAYER metal2 ;
+TRACKS X 190 DO 2368 STEP 380 LAYER metal3 ;
+TRACKS Y 140 DO 3214 STEP 280 LAYER metal3 ;
+TRACKS X 190 DO 1607 STEP 560 LAYER metal4 ;
+TRACKS Y 140 DO 1607 STEP 560 LAYER metal4 ;
+TRACKS X 190 DO 1607 STEP 560 LAYER metal5 ;
+TRACKS Y 140 DO 1607 STEP 560 LAYER metal5 ;
+TRACKS X 190 DO 1607 STEP 560 LAYER metal6 ;
+TRACKS Y 140 DO 1607 STEP 560 LAYER metal6 ;
+TRACKS X 190 DO 563 STEP 1600 LAYER metal7 ;
+TRACKS Y 140 DO 563 STEP 1600 LAYER metal7 ;
+TRACKS X 190 DO 563 STEP 1600 LAYER metal8 ;
+TRACKS Y 140 DO 563 STEP 1600 LAYER metal8 ;
+TRACKS X 190 DO 282 STEP 3200 LAYER metal9 ;
+TRACKS Y 140 DO 282 STEP 3200 LAYER metal9 ;
+TRACKS X 190 DO 282 STEP 3200 LAYER metal10 ;
+TRACKS Y 140 DO 282 STEP 3200 LAYER metal10 ;
+
+NETS 31 ;
+  - net1
+    ( macro1 p )
+    ( sc0 a )
+    ( sc1 a )
+    ( sc2 a )
+    ( sc3 a )
+    ( sc4 a )
+    ( sc5 a )
+    ( sc6 a )
+    ( sc7 a )
+    ( sc8 a )
+    ( sc9 a )
+    ( sc10 a )
+    ( sc11 a )
+    ( sc12 a )
+    ( sc13 a )
+    ( sc14 a )
+    ( sc15 a )
+    ( sc16 a )
+    ( sc17 a )
+    ( sc18 a )
+    ( sc19 a ) ;
+  - net_m12_0 ( macro1 p0 ) ( macro2 p0 ) ;
+  - net_m12_1 ( macro1 p1 ) ( macro2 p1 ) ;
+  - net_m12_2 ( macro1 p2 ) ( macro2 p2 ) ;
+  - net_m12_3 ( macro1 p3 ) ( macro2 p3 ) ;
+  - net_m12_4 ( macro1 p4 ) ( macro2 p4 ) ;
+  - net_m12_5 ( macro1 p5 ) ( macro2 p5 ) ;
+  - net_m12_6 ( macro1 p6 ) ( macro2 p6 ) ;
+  - net_m12_7 ( macro1 p7 ) ( macro2 p7 ) ;
+  - net_m12_8 ( macro1 p8 ) ( macro2 p8 ) ;
+  - net_m12_9 ( macro1 p9 ) ( macro2 p9 ) ;
+  - net_m23_0 ( macro2 p0 ) ( macro3 p0 ) ;
+  - net_m23_1 ( macro2 p1 ) ( macro3 p1 ) ;
+  - net_m23_2 ( macro2 p2 ) ( macro3 p2 ) ;
+  - net_m23_3 ( macro2 p3 ) ( macro3 p3 ) ;
+  - net_m23_4 ( macro2 p4 ) ( macro3 p4 ) ;
+  - net_m23_5 ( macro2 p5 ) ( macro3 p5 ) ;
+  - net_m23_6 ( macro2 p6 ) ( macro3 p6 ) ;
+  - net_m23_7 ( macro2 p7 ) ( macro3 p7 ) ;
+  - net_m23_8 ( macro2 p8 ) ( macro3 p8 ) ;
+  - net_m23_9 ( macro2 p9 ) ( macro3 p9 ) ;
+  - net_m31_0 ( macro3 p0 ) ( macro1 p0 ) ;
+  - net_m31_1 ( macro3 p1 ) ( macro1 p1 ) ;
+  - net_m31_2 ( macro3 p2 ) ( macro1 p2 ) ;
+  - net_m31_3 ( macro3 p3 ) ( macro1 p3 ) ;
+  - net_m31_4 ( macro3 p4 ) ( macro1 p4 ) ;
+  - net_m31_5 ( macro3 p5 ) ( macro1 p5 ) ;
+  - net_m31_6 ( macro3 p6 ) ( macro1 p6 ) ;
+  - net_m31_7 ( macro3 p7 ) ( macro1 p7 ) ;
+  - net_m31_8 ( macro3 p8 ) ( macro1 p8 ) ;
+  - net_m31_9 ( macro3 p9 ) ( macro1 p9 ) ;
+END NETS
+
+END DESIGN

--- a/src/mpl/test/testcases/mpl_dominated.lef
+++ b/src/mpl/test/testcases/mpl_dominated.lef
@@ -1,0 +1,105 @@
+VERSION 5.6 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+MACRO LARGE_MACRO_CELL
+  CLASS BLOCK ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SIZE 10000 BY 10000 ;
+  PIN p
+    DIRECTION OUTPUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 0 10 10 ;
+    END
+  END p
+  PIN p0
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 20 10 30 ;
+    END
+  END p0
+  PIN p1
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 40 10 50 ;
+    END
+  END p1
+  PIN p2
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 60 10 70 ;
+    END
+  END p2
+  PIN p3
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 80 10 90 ;
+    END
+  END p3
+  PIN p4
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 100 10 110 ;
+    END
+  END p4
+  PIN p5
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 120 10 130 ;
+    END
+  END p5
+  PIN p6
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 140 10 150 ;
+    END
+  END p6
+  PIN p7
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 160 10 170 ;
+    END
+  END p7
+  PIN p8
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 180 10 190 ;
+    END
+  END p8
+  PIN p9
+    DIRECTION INOUT ;
+    PORT
+      LAYER metal3 ;
+        RECT 0 200 10 210 ;
+    END
+  END p9
+  OBS
+      LAYER metal3 ;
+        RECT 0 0 10000 10000 ;
+  END
+END LARGE_MACRO_CELL
+
+MACRO SMALL_STDCELL_CELL
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  SIZE 1 BY 1 ;
+  SYMMETRY X Y ;
+  PIN a
+    DIRECTION INPUT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 0 0.2 0.2 ;
+    END
+  END a
+END SMALL_STDCELL_CELL


### PR DESCRIPTION
This error seems to occur when you have a macro dominated block with just a few standard cells. Added a test case that I validated failed with HEAD and passes with my change.

## Verification
- [ x ] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ x ] I have run the relevant tests and they pass.
- [ x ] My code follows the repository's formatting guidelines.
- [ x ] I have included tests to prevent regressions.
- [ x ] **I have signed my commits (DCO).**