### PR TITLE
bazel: less ugly cruft while we wait for things to percolate into bazel bcr

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -225,24 +225,11 @@ orfs.default(
     yosys_plugins = ["@yosys-slang//src/yosys_plugin:slang.so"],
 )
 
-# --- External archives ---
-
-# Alias @slang -> @sv-lang//:libsvlang so submodule BUILD files that
-# reference @slang resolve without modification. OpenROAD source uses
-# @sv-lang directly; this alias only exists for the slang-elab submodule.
-new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
-
-new_local_repository(
-    name = "slang",
-    build_file_content = """\
-alias(
-    name = "slang",
-    actual = "@sv-lang//:libsvlang",
-    visibility = ["//visibility:public"],
-)
-""",
-    path = "bazel",
-)
+# @slang -> @sv-lang//:libsvlang for third-party/slang-elab/src/BUILD.
+# Drops when slang-elab moves to BCR (along with the yosys-slang
+# git_override above).
+slang_alias = use_extension("//bazel:slang_alias.bzl", "slang_alias")
+use_repo(slang_alias, "slang")
 
 # --- Overrides ---
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -834,6 +834,22 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "//bazel:slang_alias.bzl%slang_alias": {
+      "general": {
+        "bzlTransitiveDigest": "G9F5g546mLafkCbQ7PYxM8XMMPE354r9iMaRSVjp8pk=",
+        "usagesDigest": "FiHKHyF3ynFxjcXTD/YzjInHpxk2Iag3YLgUrFHWKkA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "slang": {
+            "repoRuleId": "@@//bazel:slang_alias.bzl%_slang_alias_repo",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@apple_rules_lint+//lint:extensions.bzl%linter": {
       "general": {
         "bzlTransitiveDigest": "g7izj5kLCmsajh8IospHh4ZQ35dyM0FIrA8D4HapAsM=",

--- a/bazel/slang_alias.bzl
+++ b/bazel/slang_alias.bzl
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026, The OpenROAD Authors
+
+"""@slang -> @sv-lang//:libsvlang alias repo.
+
+Standalone repo so the slang-elab submodule BUILD's bare @slang reference
+resolves without modification. Drop once slang-elab moves to BCR and
+references @sv-lang directly.
+"""
+
+_BUILD = """\
+alias(
+    name = "slang",
+    actual = "@sv-lang//:libsvlang",
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _slang_alias_repo_impl(rctx):
+    rctx.file("BUILD.bazel", _BUILD)
+
+_slang_alias_repo = repository_rule(implementation = _slang_alias_repo_impl)
+
+def _slang_alias_impl(_module_ctx):
+    _slang_alias_repo(name = "slang")
+
+slang_alias = module_extension(implementation = _slang_alias_impl)


### PR DESCRIPTION
Follow-up to #10500 — addresses https://github.com/The-OpenROAD-Project/OpenROAD/pull/10500#pullrequestreview-4373480022.

`new_local_repository(name = "slang", path = "bazel")` was satisfying a required attribute by pointing at the OpenROAD `bazel/` directory, which has its own `BUILD`. `@slang`'s source ended up mirroring `bazel/` entirely; `external/+_repo_rules+slang/BUILD` was a symlink to `bazel/BUILD`, and only the sibling `BUILD.bazel` (written by `build_file_content`) saved the build. Replaced with a `repository_rule` + `module_extension` that writes only `BUILD.bazel` containing the alias — no path, no mirroring.

Verification:

- `bazelisk cquery '@slang//:slang' --output=label_kind` → `alias rule @slang//:slang`
- `external/+slang_alias+slang/` contains only `BUILD.bazel` with the alias.
- `//:fmt_bzl_test`, `//:lint_bzl_test` pass.

Longer-term cleanup: drop the `@slang` alias, the `yosys-slang` `git_override` (MODULE.bazel:152), and the slang-elab submodule once slang-elab is published to BCR.