### PR TITLE
gha: use commit sha instead of version/tag

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Run black
-        uses: psf/black@stable
+        uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # 26.5.1

--- a/.github/workflows/buildifier.yaml
+++ b/.github/workflows/buildifier.yaml
@@ -30,11 +30,11 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Cache buildifier
         id: cache-buildifier
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ./buildifier
           key: ${{ runner.os }}-buildifier-${{ env.BUILDIFIER_VERSION }}

--- a/.github/workflows/first-time-contributor.yml
+++ b/.github/workflows/first-time-contributor.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Greet First-Time Contributor
-        uses: actions/first-interaction@v1
+        uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7  # v1.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |

--- a/.github/workflows/github-actions-are-differences-found.yml
+++ b/.github/workflows/github-actions-are-differences-found.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Check ok files

--- a/.github/workflows/github-actions-are-odb-files-generated.yml
+++ b/.github/workflows/github-actions-are-odb-files-generated.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           submodules: 'recursive'

--- a/.github/workflows/github-actions-check-bazel-lock.yml
+++ b/.github/workflows/github-actions-check-bazel-lock.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Verify lock file is up to date
         run: bazelisk mod deps --lockfile_mode=error

--- a/.github/workflows/github-actions-clang-tidy-bazel-post.yml
+++ b/.github/workflows/github-actions-clang-tidy-bazel-post.yml
@@ -34,7 +34,7 @@ jobs:
       # a .git directory to operate against. No fork code involved — this
       # is the base repo at HEAD of its default branch.
       - name: Check out base repo for reviewdog .git requirement
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           # Default ref in workflow_run context is the base repo's default
@@ -43,7 +43,7 @@ jobs:
           # match the PR head.
 
       - name: Download clang-tidy artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           name: clang-tidy-bazel
           run-id: ${{ github.event.workflow_run.id }}
@@ -118,7 +118,7 @@ jobs:
           echo "event_path=${EVENT_PATH}" >> "$GITHUB_OUTPUT"
 
       - name: Set up reviewdog
-        uses: reviewdog/action-setup@v1
+        uses: reviewdog/action-setup@d8a7baabd7f3e8544ee4dbde3ee41d0011c3a93f  # v1.5.0
         with:
           reviewdog_version: latest
 

--- a/.github/workflows/github-actions-clang-tidy-bazel.yml
+++ b/.github/workflows/github-actions-clang-tidy-bazel.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: 'recursive'
           # Need full history so the post workflow's reviewdog can diff
@@ -30,7 +30,7 @@ jobs:
         # runners do not. Install it explicitly so the workflow works on
         # both runner types. bazel-contrib/setup-bazel's default uses a
         # pre-installed bazelisk; passing bazelisk-version forces install.
-        uses: bazel-contrib/setup-bazel@0.19.0
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86  # 0.19.0
         with:
           bazelisk-version: 1.x
           bazelisk-cache: true
@@ -102,7 +102,7 @@ jobs:
           } > pr-meta.txt
 
       - name: Upload clang-tidy artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: clang-tidy-bazel
           path: |

--- a/.github/workflows/github-actions-format-on-push.yml
+++ b/.github/workflows/github-actions-format-on-push.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v47
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
       - name: Check format of cpp changed files
         run: |
           clang-format --version

--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: 'recursive'
       - name: Install Dependencies

--- a/.github/workflows/github-actions-macos-bazel.yml
+++ b/.github/workflows/github-actions-macos-bazel.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Setup xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
           xcode-version: latest-stable
 
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: 'recursive'
 
       # 1. RESTORE: All jobs (PRs, manual runs, master) get to read the cache
       - name: Restore Bazel Disk Cache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/bazel-disk-cache
           key: ${{ runner.os }}-bazel-${{ github.sha }}
@@ -66,7 +66,7 @@ jobs:
       # 2. SAVE: Only executes if this is a push/merge directly to the master branch
       - name: Save Bazel Disk Cache
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ~/.cache/bazel-disk-cache
           key: ${{ runner.os }}-bazel-${{ github.sha }}

--- a/.github/workflows/github-actions-macos.yml
+++ b/.github/workflows/github-actions-macos.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Setup xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90  # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: 'recursive'
       - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
           rm -rf "${{ github.workspace }}"
           mkdir -p "${{ github.workspace }}"
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: 'recursive'
       - name: Build OpenROAD

--- a/.github/workflows/github-actions-on-master-push.yml
+++ b/.github/workflows/github-actions-on-master-push.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache buildifier
         id: cache-buildifier
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ./buildifier
           key: ${{ runner.os }}-buildifier-${{ env.BUILDIFIER_VERSION }}

--- a/.github/workflows/github-actions-on-push.yml
+++ b/.github/workflows/github-actions-on-push.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: run security_scan_on_push
         uses: The-OpenROAD-Project/actions/security_scan_on_push@main

--- a/.github/workflows/github-actions-quarterly-tag.yml
+++ b/.github/workflows/github-actions-quarterly-tag.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Determine tag name
         id: tag

--- a/.github/workflows/github-actions-repo-stats.yml
+++ b/.github/workflows/github-actions-repo-stats.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: run-ghrs
-        uses: jgehrcke/github-repo-stats@v1.4.2
+        uses: jgehrcke/github-repo-stats@306db38ad131cab2aa5f2cd3062bf6f8aa78c1aa  # v1.4.2
         with:
           databranch: repo-stats
           ghtoken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -18,7 +18,7 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:
           days-before-stale: 60
           days-before-close: 21

--- a/.github/workflows/github-actions-update-grammar-railroad-diagrams.yml
+++ b/.github/workflows/github-actions-update-grammar-railroad-diagrams.yml
@@ -17,16 +17,16 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4.8.0
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Cache railroad diagram tools
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         id: cache-tools
         with:
           path: src/odb/doc/tools
@@ -82,7 +82,7 @@ jobs:
 
       - name: Open PR if diagrams changed
         if: steps.diagram-changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676  # v7.0.11
         with:
           commit-message: "odb: regenerate LEF/DEF railroad diagram SVGs"
           branch: auto/grammar-railroad-diagrams

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,7 +11,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Label PR Size
-        uses: codelytv/pr-size-labeler@v1
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9  # v1.10.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/XS'


### PR DESCRIPTION
Using commit sha helps prevent chain attacks that have become common.