### PR TITLE
Add a build-cleaner tool.

### DIFF
--- a/etc/run-build-cleaner.sh
+++ b/etc/run-build-cleaner.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025-2025, The OpenROAD Authors
+#
+# Run build cleaner to optimized the deps = [] in cc_libraries.
+
+set -u
+
+readonly BANT_EXIT_ON_DWYU_ISSUES=3
+
+BANT=$("$(dirname "$0")"/get-bant-path.sh)
+
+# Run depend-on-what-you-use build-cleaner.
+# Print buildifier commands to fix if needed.
+"${BANT}" dwyu --graph-augment="..." "$@"
+
+BANT_EXIT=$?
+if [ ${BANT_EXIT} -eq ${BANT_EXIT_ON_DWYU_ISSUES} ]; then
+  cat >&2 <<EOF
+------------------------------------------------------------------
+Build dependency issues found, the following one-liner will fix it.
+
+source <(etc/run-build-cleaner.sh $@)
+EOF
+fi
+
+exit $BANT_EXIT


### PR DESCRIPTION
This runs the depend-on-what-you-use command of bant https://github.com/hzeller/bant#dwyu--depend-on-what-you-use

It should be possible to make new cc_libraries(), add a bunch of `srcs=[]i` and i`hdrs=[]i` to it, and have bant figure out all the dependencies needed, emitting an edit script to make it happen.
