### PR TITLE
github-actions-on-label-create.yml: use pull-requests scope for label removal

### DIFF
--- a/.github/workflows/github-actions-on-label-create.yml
+++ b/.github/workflows/github-actions-on-label-create.yml
@@ -17,8 +17,10 @@ jobs:
     permissions:
       # Read-only access so we don't accidentally try to push to *this* repository.
       contents: read
-      # Issues write so we can remove the label (labels live on the issues API).
-      issues: write
+      # Pull-requests write so we can remove the label (label endpoints on a
+      # PR require pull-requests scope, even though they live under the
+      # issues API).
+      pull-requests: write
       # Deployment write so link_pr can record the upstream PR.
       deployments: write
 


### PR DESCRIPTION
## Summary
- The `remove_label` step on the `Labelled Ready to Sync Public` workflow was failing with `403 Resource not accessible by integration`.
- Although the labels endpoint is under the issues REST API, when the target is a pull request GitHub requires `pull-requests: write` rather than `issues: write`. Swap the scope accordingly.
- No other step in this workflow needs `issues: write`, so we drop it entirely.

## Test plan
- [ ] Apply the `Ready To Sync Public` label to a PR and confirm the workflow removes it without a 403.