### PR TITLE
est: check if delay calculator supports reduceParasitics

### DIFF
--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -721,9 +721,12 @@ void EstimateParasitics::makePadParasitic(const sta::Net* net,
     if (spef_writer) {
       spef_writer->writeNet(corner, net, parasitic, parasitics);
     }
-    arc_delay_calc_->reduceParasitic(
-        parasitic, net, corner, sta::MinMaxAll::all());
-    parasitics->deleteParasiticNetwork(net);
+
+    if (arc_delay_calc_->reduceSupported()) {
+      arc_delay_calc_->reduceParasitic(
+          parasitic, net, corner, sta::MinMaxAll::all());
+      parasitics->deleteParasiticNetwork(net);
+    }
   }
 }
 
@@ -855,9 +858,12 @@ void EstimateParasitics::estimateWireParasiticSteiner(
         if (spef_writer) {
           spef_writer->writeNet(corner, net, parasitic, parasitics);
         }
-        arc_delay_calc_->reduceParasitic(
-            parasitic, net, corner, sta::MinMaxAll::all());
-        parasitics->deleteParasiticNetwork(net);
+
+        if (arc_delay_calc_->reduceSupported()) {
+          arc_delay_calc_->reduceParasitic(
+              parasitic, net, corner, sta::MinMaxAll::all());
+          parasitics->deleteParasiticNetwork(net);
+        }
       }
       delete tree;
     }

--- a/src/est/src/MakeWireParasitics.cpp
+++ b/src/est/src/MakeWireParasitics.cpp
@@ -96,9 +96,11 @@ void MakeWireParasitics::estimateParasitics(odb::dbNet* net,
       spef_writer->writeNet(corner, sta_net, parasitic, parasitics);
     }
 
-    arc_delay_calc_->reduceParasitic(
-        parasitic, sta_net, corner, sta::MinMaxAll::all());
-    parasitics->deleteParasiticNetwork(sta_net);
+    if (arc_delay_calc_->reduceSupported()) {
+      arc_delay_calc_->reduceParasitic(
+          parasitic, sta_net, corner, sta::MinMaxAll::all());
+      parasitics->deleteParasiticNetwork(sta_net);
+    }
   }
 }
 
@@ -135,9 +137,11 @@ void MakeWireParasitics::estimateParasitics(odb::dbNet* net, grt::GRoute& route)
     makePartialParasiticsToPins(
         parasitics, pin_grid_locs, node_map, corner, parasitic, net);
 
-    arc_delay_calc_->reduceParasitic(
-        parasitic, sta_net, corner, sta::MinMaxAll::all());
-    parasitics->deleteParasiticNetwork(sta_net);
+    if (arc_delay_calc_->reduceSupported()) {
+      arc_delay_calc_->reduceParasitic(
+          parasitic, sta_net, corner, sta::MinMaxAll::all());
+      parasitics->deleteParasiticNetwork(sta_net);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Updated placement and routing parasitics estimation with checks for delay calculator support for reduce parasitics. This is especially important when using STA's `set_delay_calculator prima` and CCS libraries.

## Type of Change
<!-- Delete items that do not apply -->
- Bug fix

## Impact
Correct parasitics estimation for CCS designs.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
