### PR TITLE
IWYU: Fix some missing includes

### DIFF
--- a/src/gui/src/gui.cpp
+++ b/src/gui/src/gui.cpp
@@ -22,6 +22,7 @@
 #include <variant>
 
 #include "gui/descriptor_registry.h"
+#include "gui/heatMap.h"
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #include <QRegularExpression>
 #else

--- a/src/psm/src/pdnsim.cpp
+++ b/src/psm/src/pdnsim.cpp
@@ -13,6 +13,7 @@
 #include "debug_gui.h"
 #include "dpl/Opendp.h"
 #include "gui/gui.h"
+#include "gui/heatMap.h"
 #include "heatMap.h"
 #include "ir_network.h"
 #include "ir_solver.h"


### PR DESCRIPTION
Breakdown:

```
src/gui/src/gui.cpp:                     #include "gui/heatMap.h" for gui::registerBuiltinHeatMapSources
src/psm/src/pdnsim.cpp:                  #include "gui/heatMap.h" for gui::registerHeatMapSource
```
