### PR TITLE
odb: dbNet::getFirstOutput don't skip clocked OUTPUTs (driver of clock net)

### DIFF
--- a/src/odb/src/db/dbNet.cpp
+++ b/src/odb/src/db/dbNet.cpp
@@ -1264,10 +1264,6 @@ dbITerm* dbNet::getFirstOutput() const
       continue;
     }
 
-    if (tr->isClocked()) {
-      continue;
-    }
-
     if (tr->getIoType() != dbIoType::OUTPUT) {
       continue;
     }


### PR DESCRIPTION
## Summary

`dbNet::getFirstOutput()` skipped iterms with `isClocked() == true`
unconditionally.  `isClocked()` returns true whenever the iterm's MTerm has
`SigType::CLOCK`, which is the correct flag for INPUT clock-sinks (flop
CLK pins) but also for OUTPUT clock-source pins like a macro's clock-out
(liberty `direction: output; clock: true;`) or a clock-buffer output.
The skip dropped the actual driver of any clock net whose source pin is
tagged `clock: true`, returning `nullptr`.

`src/cts/src/TritonCTS.cpp:1295` then falls into the bterm branch, fails
again (when the clock is driven by an internal macro pin rather than a
top-level port), and emits

```
[INFO CTS-0122] Clock net "<net>" is skipped for CTS because it is not
connected to any output instance pin or input block terminal.
```

even though the net IS driven by an OUTPUT instance pin — just one whose
MTerm SigType is `CLOCK`.  No clock tree gets built; the whole clock
domain is distributed only by placement + routing's natural wire delay.

This patch restricts the `isClocked()` skip to INPUT iterms (sinks).
Clocked OUTPUTs (macro clock-out, clock-buffer output, …) are drivers of
the clock net and should be returned.

```diff
-    if (tr->isClocked()) {
+    // Only skip clocked INPUTs (sinks like flop CLK pins).  Clocked
+    // OUTPUTs (a macro's clock-out pin or a clock-buffer output) ARE
+    // the driver of the clock net — don't skip them.
+    if (tr->isClocked() && tr->getIoType() == dbIoType::INPUT) {
       continue;
     }
```

## Type of Change

- Bug fix

## Impact

Clock nets whose driver is a `clock: true`-tagged macro output pin (PCIe
hard-IP `user_clk`, PLL clock-out, etc.) now get proper CTS tree synthesis
instead of being silently skipped.

On a real design where the system clock is sourced from a PCIe hard-IP
macro pin driving ~12,000 flops across the die, this fix changes
TritonCTS behavior from:

- **Before:** CTS-0122 fires, no tree built, ~9 ns of naked wire-delay
  clock skew, thousands of unfixable hold violations.
- **After:** TritonCTS recognizes the driver, builds a balanced clock
  tree (verified ~12,000 register sinks + a 41-sink macro subnet, max
  level 7), latency balancer completes cleanly, CTS finishes normally.

Designs that don't have macro-pin-sourced clocks are unaffected — for
ordinary clocks (driven by a top-level input port or a std-cell clock
buffer), `getDrivingITerm()` short-circuits before the loop, or the
existing direction check filters the (INPUT) sinks anyway.

## Verification

- [x] Local build succeeds (`./etc/Build.sh`)
- [x] Tested on a real design that previously hit CTS-0122; tree now
      builds correctly with the expected sink counts and the CTS latency
      balancer completes without crashing.
- [x] Code follows the repository's formatting guidelines.
- [ ] Unit test in tree — not yet included; happy to add a small
      C++/Python test exercising `dbNet::getFirstOutput()` on a synthetic
      net with a `CLOCK`-SigType OUTPUT iterm if a reviewer would like
      one in this PR vs. a follow-up.
- [x] DCO sign-off included on the commit.

A minimal self-contained reproducer (~50 lines of Verilog/LEF/LIB/SDC)
that triggers CTS-0122 reliably through any synth→FP→place→CTS flow can
be provided on request.

## Related Issues

(none filed yet — this PR is the first report)