### PR TITLE
syn: fix static-library dependency cycle between syn_flow and syn_lib

### DIFF
--- a/src/syn/test/CMakeLists.txt
+++ b/src/syn/test/CMakeLists.txt
@@ -21,20 +21,20 @@ endforeach()
 
 foreach(_t opt_test bitblast_test)
   add_executable(${_t} ${_t}.cc)
-  target_link_libraries(${_t} ${_syn_test_libs} syn_flow syn_ir)
+  target_link_libraries(${_t} ${_syn_test_libs} syn_flow syn_lib syn_ir)
   gtest_discover_tests(${_t} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_dependencies(build_and_test ${_t})
 endforeach()
 
 add_executable(liveness_test liveness_test.cc)
 # No GTest::gtest_main: ABC ships its own main() that wins over gtest_main.
-target_link_libraries(liveness_test GTest::gtest syn_flow syn_ir utl_lib)
+target_link_libraries(liveness_test GTest::gtest syn_flow syn_lib syn_ir utl_lib)
 gtest_discover_tests(liveness_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_dependencies(build_and_test liveness_test)
 
 foreach(_t abc_test sm_test cm_test)
   add_executable(${_t} ${_t}.cc)
-  target_link_libraries(${_t} ${_syn_test_libs} syn_lib syn_flow syn_ir tst)
+  target_link_libraries(${_t} ${_syn_test_libs} syn_flow syn_lib syn_ir tst)
   gtest_discover_tests(${_t} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
   add_dependencies(build_and_test ${_t})
 endforeach()


### PR DESCRIPTION
libsyn_flow.a references Synthesis::dontUse(), defined in syn_lib. Add syn_lib to the link line to resolve it. Matches Bazel BUILD.

## Summary
This fixes build issues I have been facing.

## Type of Change
- Bug fix

## Impact
Succesfully build when using ORFS build script.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [ ] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
