### PR TITLE
drt: collapse frGuide to a single layer field

### DIFF
--- a/src/drt/src/db/obj/frGuide.h
+++ b/src/drt/src/db/obj/frGuide.h
@@ -17,11 +17,8 @@ class frNet;
 class frGuide : public frConnFig
 {
  public:
-  frGuide(const odb::Point& begin,
-          frLayerNum begin_layer,
-          const odb::Point& end,
-          frLayerNum end_layer)
-      : begin_(begin), end_(end), beginLayer_(begin_layer), endLayer_(end_layer)
+  frGuide(const odb::Point& begin, frLayerNum layer_num, const odb::Point& end)
+      : begin_(begin), end_(end), layerNum_(layer_num)
   {
   }
   frGuide(const frGuide& in) = delete;
@@ -31,8 +28,7 @@ class frGuide : public frConnFig
   const odb::Point& getBeginPoint() const { return begin_; }
   const odb::Point& getEndPoint() const { return end_; }
 
-  frLayerNum getBeginLayerNum() const { return beginLayer_; }
-  frLayerNum getEndLayerNum() const { return endLayer_; }
+  frLayerNum getLayerNum() const { return layerNum_; }
   bool hasRoutes() const { return !routeObj_.empty(); }
   const std::vector<std::unique_ptr<frConnFig>>& getRoutes() const
   {
@@ -76,8 +72,7 @@ class frGuide : public frConnFig
  private:
   odb::Point begin_;
   odb::Point end_;
-  frLayerNum beginLayer_;
-  frLayerNum endLayer_;
+  frLayerNum layerNum_;
   std::vector<std::unique_ptr<frConnFig>> routeObj_;
   frNet* net_{nullptr};
   int index_in_owner_{0};

--- a/src/drt/src/dr/FlexDR_init.cpp
+++ b/src/drt/src/dr/FlexDR_init.cpp
@@ -341,15 +341,10 @@ void FlexDRWorker::initNetObjs(
       odb::Point epIdx = design_->getTopBlock()->getGCellIdx(ep);
       odb::Rect bbox = design_->getTopBlock()->getGCellBox(bpIdx);
       odb::Rect ebox = design_->getTopBlock()->getGCellBox(epIdx);
-      frLayerNum bNum = guide->getBeginLayerNum();
-      frLayerNum eNum = guide->getEndLayerNum();
       frRect rect;
       rect.setBBox({bbox.xMin(), bbox.yMin(), ebox.xMax(), ebox.yMax()});
-      for (auto lNum = std::min(bNum, eNum); lNum <= std::max(bNum, eNum);
-           lNum += 2) {
-        rect.setLayerNum(lNum);
-        netGuides[guide->getNet()].push_back(rect);
-      }
+      rect.setLayerNum(guide->getLayerNum());
+      netGuides[guide->getNet()].push_back(rect);
     }
   }
 }

--- a/src/drt/src/frRegionQuery.cpp
+++ b/src/drt/src/frRegionQuery.cpp
@@ -470,9 +470,7 @@ void frRegionQuery::Impl::addGuide(frGuide* guide,
                                    ObjectsByLayer<frGuide>& allShapes)
 {
   odb::Rect frb = guide->getBBox();
-  for (int i = guide->getBeginLayerNum(); i <= guide->getEndLayerNum(); i++) {
-    allShapes.at(i).emplace_back(frb, guide);
-  }
+  allShapes.at(guide->getLayerNum()).emplace_back(frb, guide);
 }
 
 void frRegionQuery::Impl::addOrigGuide(frNet* net,

--- a/src/drt/src/global.cpp
+++ b/src/drt/src/global.cpp
@@ -200,8 +200,7 @@ std::ostream& operator<<(std::ostream& os, const frPathSeg& p)
 std::ostream& operator<<(std::ostream& os, const frGuide& p)
 {
   os << "frGuide: begin " << p.getBeginPoint() << " end " << p.getEndPoint()
-     << " begin LayerNum " << p.getBeginLayerNum() << " end layerNum "
-     << p.getEndLayerNum();
+     << " layerNum " << p.getLayerNum();
   return os;
 }
 

--- a/src/drt/src/io/GuideProcessor.cpp
+++ b/src/drt/src/io/GuideProcessor.cpp
@@ -1721,7 +1721,7 @@ GuidePathFinder::commitPathToGuides(
     const odb::Point begin
         = getDesign()->getTopBlock()->getGCellCenter(box.ll());
     const odb::Point end = getDesign()->getTopBlock()->getGCellCenter(box.ur());
-    auto guide = std::make_unique<frGuide>(begin, layer_num, end, layer_num);
+    auto guide = std::make_unique<frGuide>(begin, layer_num, end);
     net_->addGuide(std::move(guide));
   }
   return gr_pins;
@@ -1956,30 +1956,14 @@ void GuideProcessor::saveGuidesUpdates()
       odb::Point epIdx = getDesign()->getTopBlock()->getGCellIdx(ep);
       odb::Rect bbox = getDesign()->getTopBlock()->getGCellBox(bpIdx);
       odb::Rect ebox = getDesign()->getTopBlock()->getGCellBox(epIdx);
-      frLayerNum bNum = guide->getBeginLayerNum();
-      frLayerNum eNum = guide->getEndLayerNum();
-      if (bNum != eNum) {
-        for (auto lNum = std::min(bNum, eNum); lNum <= std::max(bNum, eNum);
-             lNum += 2) {
-          auto layer = getTech()->getLayer(lNum);
-          auto dbLayer = dbTech->findLayer(layer->getName().c_str());
-          odb::dbGuide::create(
-              dbNet,
-              dbLayer,
-              dbLayer,
-              {bbox.xMin(), bbox.yMin(), ebox.xMax(), ebox.yMax()},
-              false);
-        }
-      } else {
-        auto layerName = getTech()->getLayer(bNum)->getName();
-        auto dbLayer = dbTech->findLayer(layerName.c_str());
-        odb::dbGuide::create(
-            dbNet,
-            dbLayer,
-            dbLayer,
-            {bbox.xMin(), bbox.yMin(), ebox.xMax(), ebox.yMax()},
-            false);
-      }
+      const frLayerNum layer_num = guide->getLayerNum();
+      auto layerName = getTech()->getLayer(layer_num)->getName();
+      auto dbLayer = dbTech->findLayer(layerName.c_str());
+      odb::dbGuide::create(dbNet,
+                           dbLayer,
+                           dbLayer,
+                           {bbox.xMin(), bbox.yMin(), ebox.xMax(), ebox.yMax()},
+                           false);
     }
     auto dbGuides = dbNet->getGuides();
     if (dbGuides.orderReversed() && dbGuides.reversible()) {

--- a/src/drt/src/ta/FlexTA_assign.cpp
+++ b/src/drt/src/ta/FlexTA_assign.cpp
@@ -572,7 +572,7 @@ void FlexTAWorker::assignIroute_availTracks(taPin* iroute,
                                             int& idx1,
                                             int& idx2)
 {
-  lNum = iroute->getGuide()->getBeginLayerNum();
+  lNum = iroute->getGuide()->getLayerNum();
   auto [gbp, gep] = iroute->getGuide()->getPoints();
   odb::Point gIdx = getDesign()->getTopBlock()->getGCellIdx(gbp);
   odb::Rect gBox = getDesign()->getTopBlock()->getGCellBox(gIdx);
@@ -667,7 +667,7 @@ frUInt4 FlexTAWorker::assignIroute_getPinCost(taPin* iroute, frCoord trackLoc)
 
     // add cost to locations that will cause forbidden via spacing to
     // boundary pin
-    auto layerNum = iroute->getGuide()->getBeginLayerNum();
+    auto layerNum = iroute->getGuide()->getLayerNum();
     auto layer = getTech()->getLayer(layerNum);
 
     if (layer->isUnidirectional()) {
@@ -923,7 +923,7 @@ frUInt4 FlexTAWorker::assignIroute_getCost(taPin* iroute,
                                            frUInt4& outDrcCost)
 {
   frCoord irouteLayerPitch
-      = getTech()->getLayer(iroute->getGuide()->getBeginLayerNum())->getPitch();
+      = getTech()->getLayer(iroute->getGuide()->getLayerNum())->getPitch();
   outDrcCost = assignIroute_getDRCCost(iroute, trackLoc);
   int drcCost = (isInitTA()) ? (0.05 * outDrcCost)
                              : (router_cfg_->TADRCCOST * outDrcCost);

--- a/src/drt/src/ta/FlexTA_init.cpp
+++ b/src/drt/src/ta/FlexTA_init.cpp
@@ -143,7 +143,7 @@ bool FlexTAWorker::initIroute_helper_pin(frGuide* guide,
   }
 
   auto net = guide->getNet();
-  auto layerNum = guide->getBeginLayerNum();
+  auto layerNum = guide->getLayerNum();
   bool isH = (getDir() == dbTechLayerDir::HORIZONTAL);
   bool hasDown = false;
   bool hasUp = false;
@@ -376,7 +376,7 @@ void FlexTAWorker::initIroute_helper_generic(frGuide* guide,
                                              frCoord& pinCoord)
 {
   auto net = guide->getNet();
-  auto layerNum = guide->getBeginLayerNum();
+  auto layerNum = guide->getLayerNum();
   bool hasMinBegin = false;
   bool hasMaxEnd = false;
   minBegin = std::numeric_limits<frCoord>::max();
@@ -415,7 +415,7 @@ void FlexTAWorker::initIroute_helper_generic(frGuide* guide,
         auto [nbrBp, nbrEp] = nbrGuide->getPoints();
         if (!nbrGuide->hasRoutes()) {
           // via location assumed in center
-          auto psLNum = nbrGuide->getBeginLayerNum();
+          auto psLNum = nbrGuide->getLayerNum();
           if (psLNum == layerNum - 2) {
             downViaCoordSet.insert((isH ? nbrBp.x() : nbrBp.y()));
           } else {
@@ -477,7 +477,7 @@ void FlexTAWorker::initIroute(frGuide* guide)
   auto iroute = std::make_unique<taPin>();
   iroute->setGuide(guide);
   odb::Rect guideBox = guide->getBBox();
-  auto layerNum = guide->getBeginLayerNum();
+  auto layerNum = guide->getLayerNum();
   bool isExt = !(getRouteBox().contains(guideBox));
   if (isExt) {
     // extIroute empty, skip
@@ -608,7 +608,7 @@ void FlexTAWorker::initCosts()
     for (auto& iroute : iroutes_) {
       auto pitch = getDesign()
                        ->getTech()
-                       ->getLayer(iroute->getGuide()->getBeginLayerNum())
+                       ->getLayer(iroute->getGuide()->getLayerNum())
                        ->getPitch();
       for (auto& uPinFig : iroute->getFigs()) {
         if (uPinFig->typeId() == tacPathSeg) {

--- a/src/drt/test/taTest.cpp
+++ b/src/drt/test/taTest.cpp
@@ -73,7 +73,7 @@ struct TAFixture : public Fixture
                      const odb::Point& begin,
                      const odb::Point& end)
   {
-    auto guide = std::make_unique<frGuide>(begin, layer_num, end, layer_num);
+    auto guide = std::make_unique<frGuide>(begin, layer_num, end);
     auto* ptr = guide.get();
     net->addGuide(std::move(guide));
     return ptr;


### PR DESCRIPTION
## Description

Replace `frGuide`'s `beginLayer_`/`endLayer_` pair with a single `layerNum_` field. The two-layer design was never used: the sole constructor call (`GuideProcessor.cpp`) always passed the same `layer_num` for both begin and end, and `odb::dbGuide` is inherently single-layer.

## Changes

- **frGuide.h**: Remove `beginLayerNum_`/`endLayerNum_`, add `layerNum_`; simplify constructor from 4 args to 3 `(begin, layer_num, end)`.
- Replace all `getBeginLayerNum()`/`getEndLayerNum()` calls with `getLayerNum()` across `FlexDR_init`, `FlexTA_assign`, `FlexTA_init`, `frRegionQuery`, `GuideProcessor`, and `global.cpp`.
- Eliminate multi-layer guide expansion loops in `FlexDR_init` and `GuideProcessor::saveGuidesUpdates()` that were dead code (the loop always executed exactly once since `bNum == eNum`).
- Update `taTest.cpp` to use the new 3-arg `frGuide` constructor.

## Testing

- All 19/19 DRT integration tests pass (the 1 failure in `drt.cpp_tests.tcl` is a pre-existing path configuration issue unrelated to this change).
- `taTest` unit test passes.

Closes #10481