### PR TITLE
odb: convert areas from double/int/uint to int64_t

### DIFF
--- a/src/dbSta/src/IpChecker.cc
+++ b/src/dbSta/src/IpChecker.cc
@@ -660,7 +660,6 @@ void IpChecker::checkPinMinDimensions(odb::dbMaster* master)
 void IpChecker::checkPinMinArea(odb::dbMaster* master)
 {
   std::string master_name = master->getName();
-  int dbu_per_micron = db_->getTech()->getDbUnitsPerMicron();
 
   for (odb::dbMTerm* mterm : master->getMTerms()) {
     for (odb::dbMPin* mpin : mterm->getMPins()) {
@@ -670,10 +669,8 @@ void IpChecker::checkPinMinArea(odb::dbMaster* master)
           continue;
         }
 
-        // getArea() returns microns^2, convert to DBU^2
-        double min_area_um2 = layer->getArea();
-        int64_t min_area_dbu2 = static_cast<int64_t>(
-            min_area_um2 * dbu_per_micron * dbu_per_micron);
+        // getArea() returns DBU^2
+        const int64_t min_area_dbu2 = layer->getArea();
 
         odb::Rect rect = box->getBox();
         int64_t shape_area

--- a/src/drt/src/io/io.cpp
+++ b/src/drt/src/io/io.cpp
@@ -2167,8 +2167,7 @@ void io::Parser::addRoutingLayer(odb::dbTechLayer* layer)
   setRoutingLayerProperties(layer, tmpLayer);
   // read minArea rule
   if (layer->hasArea()) {
-    frCoord minArea = frCoord(round(layer->getArea() * getTech()->getDBUPerUU()
-                                    * getTech()->getDBUPerUU()));
+    frCoord minArea = frCoord(layer->getArea());
     std::unique_ptr<frConstraint> uCon
         = std::make_unique<frAreaConstraint>(minArea);
     auto rptr = static_cast<frAreaConstraint*>(uCon.get());
@@ -2226,7 +2225,7 @@ void io::Parser::addRoutingLayer(odb::dbTechLayer* layer)
           "minEnclosedArea constraint with width is not supported, skipped.");
       continue;
     }
-    frUInt4 _minEnclosedArea;
+    int64_t _minEnclosedArea;
     rule->getEnclosure(_minEnclosedArea);
     frCoord minEnclosedArea = _minEnclosedArea;
     auto minEnclosedAreaConstraint

--- a/src/grt/src/cugr/src/Layers.cpp
+++ b/src/grt/src/cugr/src/Layers.cpp
@@ -26,8 +26,8 @@ MetalLayer::MetalLayer(odb::dbTechLayer* tech_layer,
 
   // Design rules not parsed thoroughly
   // Min area
-  const int min_area = tech_layer->getArea();
-  min_length_ = std::max(min_area / width_ - width_, 0);
+  const int64_t min_area = tech_layer->getArea();
+  min_length_ = std::max(static_cast<int>(min_area / width_) - width_, 0);
 
   // Parallel run spacing
   std::vector<std::vector<uint32_t>> spacing_table;

--- a/src/grt/src/cugr/src/Layers.cpp
+++ b/src/grt/src/cugr/src/Layers.cpp
@@ -26,8 +26,7 @@ MetalLayer::MetalLayer(odb::dbTechLayer* tech_layer,
 
   // Design rules not parsed thoroughly
   // Min area
-  const int database_unit = tech_layer->getTech()->getDbUnitsPerMicron();
-  const int min_area = tech_layer->getArea() * database_unit * database_unit;
+  const int min_area = tech_layer->getArea();
   min_length_ = std::max(min_area / width_ - width_, 0);
 
   // Parallel run spacing

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3035,8 +3035,9 @@ Descriptor::Properties DbTechLayerDescriptor::getDBProperties(
                        Property::convert_dbu(layer->getSpacing(), true));
   }
   if (layer->hasArea()) {
-    props.emplace_back("Minimum area",
-                       convertUnits(layer->getArea(), true) + "m²");
+    const double dbu_per_meter = db_->getDbuPerMicron() * 1e6;
+    const double area = layer->getArea() / (dbu_per_meter * dbu_per_meter);
+    props.emplace_back("Minimum area", convertUnits(area, true) + "m²");
   }
   if (layer->getResistance() != 0.0) {
     props.emplace_back("Resistance",

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3037,7 +3037,7 @@ Descriptor::Properties DbTechLayerDescriptor::getDBProperties(
   if (layer->hasArea()) {
     props.emplace_back(
         "Minimum area",
-        convertUnits(layer->getArea() * 1e-6 * 1e-6, true) + "m²");
+        convertUnits(layer->getArea(), true) + "m²");
   }
   if (layer->getResistance() != 0.0) {
     props.emplace_back("Resistance",

--- a/src/gui/src/dbDescriptors.cpp
+++ b/src/gui/src/dbDescriptors.cpp
@@ -3035,9 +3035,8 @@ Descriptor::Properties DbTechLayerDescriptor::getDBProperties(
                        Property::convert_dbu(layer->getSpacing(), true));
   }
   if (layer->hasArea()) {
-    props.emplace_back(
-        "Minimum area",
-        convertUnits(layer->getArea(), true) + "m²");
+    props.emplace_back("Minimum area",
+                       convertUnits(layer->getArea(), true) + "m²");
   }
   if (layer->getResistance() != 0.0) {
     props.emplace_back("Resistance",

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -6507,7 +6507,7 @@ class dbTechLayerSpacingRule : public dbObject
   bool getCutCenterToCenter() const;
   bool getCutSameNet() const;
   bool getCutParallelOverlap() const;
-  uint32_t getCutArea() const;
+  int64_t getCutArea() const;
 
   void setSameNetPgOnly(bool pgonly);
   bool getSameNetPgOnly();
@@ -6528,7 +6528,7 @@ class dbTechLayerSpacingRule : public dbObject
   void setCutCenterToCenter(bool c2c);
   void setCutSameNet(bool same_net);
   void setCutParallelOverlap(bool overlap);
-  void setCutArea(uint32_t area);
+  void setCutArea(int64_t area);
   void setEol(uint32_t width,
               uint32_t within,
               bool parallelEdge,
@@ -6591,8 +6591,8 @@ class dbTechMinCutRule : public dbObject
 class dbTechMinEncRule : public dbObject
 {
  public:
-  bool getEnclosure(uint32_t& area) const;
-  void setEnclosure(uint32_t area);
+  bool getEnclosure(int64_t& area) const;
+  void setEnclosure(int64_t area);
   bool getEnclosureWidth(uint32_t& width) const;
   void setEnclosureWidth(uint32_t width);
 
@@ -9431,8 +9431,8 @@ class dbTechLayer : public dbObject
   ///  reasonable default exists.
   ///
   bool hasArea() const;
-  double getArea() const;
-  void setArea(double area);
+  int64_t getArea() const;
+  void setArea(int64_t area);
 
   ///
   ///  Get/set MAXWIDTH parameter.  This interface is used when a
@@ -9570,9 +9570,9 @@ class dbTechLayer : public dbObject
 class dbTechLayerAreaRule : public dbObject
 {
  public:
-  void setArea(int area);
+  void setArea(int64_t area);
 
-  int getArea() const;
+  int64_t getArea() const;
 
   void setExceptMinWidth(int except_min_width);
 
@@ -10115,9 +10115,9 @@ class dbTechLayerCutSpacingRule : public dbObject
 
   uint32_t getParLength() const;
 
-  void setCutArea(int cut_area);
+  void setCutArea(int64_t cut_area);
 
-  int getCutArea() const;
+  int64_t getCutArea() const;
 
   void setCenterToCenter(bool center_to_center);
 
@@ -10745,9 +10745,9 @@ class dbTechLayerMinCutRule : public dbObject
 
   int getLengthWithinDist() const;
 
-  void setArea(int area);
+  void setArea(int64_t area);
 
-  int getArea() const;
+  int64_t getArea() const;
 
   void setAreaWithinDist(int area_within_dist);
 

--- a/src/odb/include/odb/dbStream.h
+++ b/src/odb/include/odb/dbStream.h
@@ -73,6 +73,12 @@ class dbOStream
     return *this;
   }
 
+  dbOStream& operator<<(int64_t c)
+  {
+    writeValueAsBytes(c);
+    return *this;
+  }
+
   dbOStream& operator<<(uint64_t c)
   {
     writeValueAsBytes(c);
@@ -311,6 +317,12 @@ class dbIStream
   }
 
   dbIStream& operator>>(int& c)
+  {
+    f_.read(reinterpret_cast<char*>(&c), sizeof(c));
+    return *this;
+  }
+
+  dbIStream& operator>>(int64_t& c)
   {
     f_.read(reinterpret_cast<char*>(&c), sizeof(c));
     return *this;

--- a/src/odb/include/odb/lefin.h
+++ b/src/odb/include/odb/lefin.h
@@ -225,7 +225,7 @@ class lefin
   // convert distance value to db-units
   int dbdist(double value);
 
-  // convert distance value to db-units
+  // convert area value to db-units^2
   int64_t dbarea(double value);
 
   // Create a technology from the tech-data of this LEF file.

--- a/src/odb/include/odb/lefin.h
+++ b/src/odb/include/odb/lefin.h
@@ -55,6 +55,9 @@ class lefinReader
   // convert distance value to db-units
   int dbdist(double value) { return lround(value * dist_factor_); }
 
+  // convert area value to squared db-units
+  int64_t dbarea(const double value) { return llround(value * area_factor_); }
+
   enum AntennaType
   {
     ANTENNA_INPUT_GATE_AREA,
@@ -172,9 +175,6 @@ class lefinReader
   void init();
   void setDBUPerMicron(int dbu);
 
-  // convert area value to squared db-units
-  int dbarea(const double value) { return lround(value * area_factor_); }
-
   bool readLefInner(const char* lef_file);
   bool readLef(const char* lef_file);
   bool addGeoms(dbObject* object,
@@ -224,6 +224,9 @@ class lefin
 
   // convert distance value to db-units
   int dbdist(double value);
+
+  // convert distance value to db-units
+  int64_t dbarea(double value);
 
   // Create a technology from the tech-data of this LEF file.
   dbTech* createTech(const char* name, const char* lef_file);

--- a/src/odb/include/odb/lefout.h
+++ b/src/odb/include/odb/lefout.h
@@ -46,7 +46,7 @@ class lefout
 {
  public:
   double lefdist(int value) { return value * dist_factor_; }
-  double lefarea(int value) { return value * area_factor_; }
+  double lefarea(int64_t value) { return value * area_factor_; }
 
   lefout(utl::Logger* logger, std::ostream& out) : _out(out)
   {

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -40,6 +40,7 @@ from schema_models import Field, Enum, Struct, Class, Schema
 STD_TYPE_HDR = {
     "int16_t": "cstdint",
     "uint32_t": "cstdint",
+    "int64_t": "cstdint",
     "pair": "utility",
 }
 

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -28,6 +28,7 @@ _comparable = {
     "string",
     "uint32_t",
     "uint8_t",
+    "int64_t",
 }
 
 std = {
@@ -48,6 +49,7 @@ std = {
     "string",
     "uint32_t",
     "uint8_t",
+    "int64_t",
 }
 
 _removable = {"const", "static", "unsigned"}

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayerAreaRule.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayerAreaRule.json
@@ -3,9 +3,12 @@
   "type": "dbObject",
   "fields": [
     {
-      "type": "int",
+      "type": "int64_t",
       "default": "0",
-      "name": "area_"
+      "name": "area_",
+      "flags": [
+        "custom-serial"
+      ]
     },
     {
       "type": "int",

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayerCutSpacingRule.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayerCutSpacingRule.json
@@ -284,9 +284,12 @@
       "default": 0
     },
     {
-      "type": "int",
+      "type": "int64_t",
       "name": "cut_area_",
-      "default": 0
+      "default": 0,
+      "flags": [
+        "custom-serial"
+      ]
     }
   ],
   "enums": [

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayerMinCutRule.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayerMinCutRule.json
@@ -57,9 +57,12 @@
       "name": "area_valid"
     },
     {
-      "type": "int",
+      "type": "int64_t",
       "name": "area_",
-      "default": 0
+      "default": 0,
+      "flags": [
+        "custom-serial"
+      ]
     },
     {
       "type": "bit",

--- a/src/odb/src/codeGenerator/templates/serializer_in.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/serializer_in.cpp.jinja
@@ -13,6 +13,9 @@
         stream >> {{field.name}}bit_field;
         static_assert(sizeof(obj.{{field.name}}) == sizeof({{field.name}}bit_field));
         std::memcpy(&obj.{{field.name}}, &{{field.name}}bit_field, sizeof({{field.name}}bit_field));
+      {% elif 'custom-serial' in field.flags %}
+        //User Code Begin >>{{ comment_tag }}{{ field.name }}
+        //User Code End >>{{ comment_tag }}{{ field.name }}
       {% else %}
         {% if 'no-serial' not in field.flags %}
           {% if field.schema %}

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -56,6 +56,11 @@
 #include "dbPropertyItr.h"
 #include "dbRSeg.h"
 #include "dbTech.h"
+#include "dbTechLayer.h"
+#include "dbTechLayerAreaRule.h"
+#include "dbTechLayerCutSpacingRule.h"
+#include "dbTechLayerMinCutRule.h"
+#include "dbTechLayerSpacingRule.h"
 #include "odb/dbBlockCallBackObj.h"
 #include "odb/dbDatabaseObserver.h"
 #include "odb/dbObject.h"
@@ -329,6 +334,49 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj)
     }
   }
 
+  dbDatabase* db = (dbDatabase*) &obj;
+  // Fix area scaling
+  if (!obj.isSchema(kSchemaStoreAreaAsInt64)) {
+    const int64_t dbu_per_micron = obj.dbu_per_micron_;
+    const int64_t single_dbu_scale = 20000 / dbu_per_micron;
+    const int64_t double_dbu_scaling
+        = (20000 * 20000) / (dbu_per_micron * dbu_per_micron);
+    // Fix techlayer area
+    for (dbTech* tech : db->getTechs()) {
+      for (dbTechLayer* layer : tech->getLayers()) {
+        _dbTechLayer* layer_impl = (_dbTechLayer*) layer;
+        layer_impl->area_ /= double_dbu_scaling;
+
+        for (dbTechLayerAreaRule* area_rule : layer->getTechLayerAreaRules()) {
+          _dbTechLayerAreaRule* area_rule_impl
+              = (_dbTechLayerAreaRule*) area_rule;
+          area_rule_impl->area_ /= single_dbu_scale;
+        }
+
+        for (dbTechLayerCutSpacingRule* cut_spacing_rule :
+             layer->getTechLayerCutSpacingRules()) {
+          _dbTechLayerCutSpacingRule* cut_spacing_rule_impl
+              = (_dbTechLayerCutSpacingRule*) cut_spacing_rule;
+          cut_spacing_rule_impl->cut_area_ /= single_dbu_scale;
+        }
+
+        for (dbTechLayerMinCutRule* min_cut_rule :
+             layer->getTechLayerMinCutRules()) {
+          _dbTechLayerMinCutRule* min_cut_rule_impl
+              = (_dbTechLayerMinCutRule*) min_cut_rule;
+          min_cut_rule_impl->area_ /= single_dbu_scale;
+        }
+
+        for (dbTechLayerSpacingRule* spacing_rule :
+             layer->getV54SpacingRules()) {
+          _dbTechLayerSpacingRule* spacing_rule_impl
+              = (_dbTechLayerSpacingRule*) spacing_rule;
+          spacing_rule_impl->cut_area_ /= single_dbu_scale;
+        }
+      }
+    }
+  }
+
   // Fix up the owner id of properties of this db, this value changes.
   const uint32_t oid = obj.getId();
 
@@ -341,7 +389,6 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj)
   obj.schema_minor_ = kSchemaMinor;
 
   // Set the chipinsts_map_ of the chip
-  dbDatabase* db = (dbDatabase*) &obj;
   for (const auto& inst : db->getChipInsts()) {
     _dbChip* parent_chip = (_dbChip*) inst->getParentChip();
     parent_chip->chipinsts_map_[inst->getName()] = inst->getId();
@@ -356,6 +403,7 @@ dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj)
     // Construct unfolded model only if there are multiple chips
     db->constructUnfoldedModel();
   }
+
   // User Code End >>
   return stream;
 }

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -355,7 +355,7 @@ class _dbDatabase : public _dbObject
   utl::Logger* logger_;
   std::set<dbDatabaseObserver*> observers_;
   UnfoldedModel* unfolded_model_;  // non-persistent object
-  // User Code End Fields
+                                   // User Code End Fields
 };
 dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj);
 dbOStream& operator<<(dbOStream& stream, const _dbDatabase& obj);

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,7 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 130;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 131;  // Current revision number
+
+// Revision where all areas in the are switched to be stored as int64_t
+inline constexpr uint32_t kSchemaStoreAreaAsInt64 = 131;
 
 // Revision where dbAlignmentMarkerRule was added
 inline constexpr uint32_t kSchemaChipAlignmentMarkerRule = 130;

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -355,7 +355,6 @@ class _dbDatabase : public _dbObject
   utl::Logger* logger_;
   std::set<dbDatabaseObserver*> observers_;
   UnfoldedModel* unfolded_model_;  // non-persistent object
-
   // User Code End Fields
 };
 dbIStream& operator>>(dbIStream& stream, _dbDatabase& obj);

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -608,7 +608,16 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayer& obj)
   stream >> obj.wire_extension_;
   stream >> obj.number_;
   stream >> obj.rlevel_;
-  stream >> obj.area_;
+  if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> obj.area_;
+  } else {
+    double area_double;
+    stream >> area_double;
+
+    dbDatabase* db = (dbDatabase*) obj.getDatabase();
+    const int64_t dbus = db->getDbuPerMicron();
+    obj.area_ = static_cast<int64_t>(std::round(area_double * dbus * dbus));
+  }
   stream >> obj.thickness_;
   stream >> obj.min_step_;
   stream >> obj.min_step_max_length_;
@@ -1857,18 +1866,17 @@ bool dbTechLayer::hasArea() const
   return (layer->flags_.has_area);
 }
 
-double  // Now denominated in squm
-dbTechLayer::getArea() const
+int64_t dbTechLayer::getArea() const
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
   if (layer->flags_.has_area) {
     return layer->area_;
   }
 
-  return 0.0;  // Default
+  return 0;  // Default
 }
 
-void dbTechLayer::setArea(double area)
+void dbTechLayer::setArea(int64_t area)
 {
   _dbTechLayer* layer = (_dbTechLayer*) this;
   layer->flags_.has_area = true;

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -37,6 +37,7 @@
 #include "odb/dbSet.h"
 // User Code Begin Includes
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <iterator>
 #include <ranges>

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -623,10 +623,7 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayer& obj)
   } else {
     double area_double;
     stream >> area_double;
-
-    dbDatabase* db = (dbDatabase*) obj.getDatabase();
-    const int64_t dbus = db->getDbuPerMicron();
-    obj.area_ = static_cast<int64_t>(std::round(area_double * dbus * dbus));
+    obj.area_ = static_cast<int64_t>(std::round(area_double * 20000 * 20000));
   }
   stream >> obj.thickness_;
   stream >> obj.min_step_;

--- a/src/odb/src/db/dbTechLayer.h
+++ b/src/odb/src/db/dbTechLayer.h
@@ -134,7 +134,7 @@ class _dbTechLayer : public _dbObject
   uint32_t wire_extension_;
   uint32_t number_;
   uint32_t rlevel_;
-  double area_;
+  int64_t area_;
   uint32_t thickness_;
   uint32_t max_width_;
   int min_width_;

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -69,7 +69,16 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerAreaRule& obj)
   stream >> flags_bit_field;
   static_assert(sizeof(obj.flags_) == sizeof(flags_bit_field));
   std::memcpy(&obj.flags_, &flags_bit_field, sizeof(flags_bit_field));
-  stream >> obj.area_;
+  // User Code Begin >>area_
+  if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> obj.area_;
+  } else {
+    dbDatabase* db = (dbDatabase*) obj.getDatabase();
+    int area;
+    stream >> area;
+    obj.area_ = area * db->getDbuPerMicron();
+  }
+  // User Code End >>area_
   stream >> obj.except_min_width_;
   stream >> obj.except_edge_length_;
   stream >> obj.except_edge_lengths_;
@@ -111,14 +120,14 @@ void _dbTechLayerAreaRule::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbTechLayerAreaRule::setArea(int area)
+void dbTechLayerAreaRule::setArea(int64_t area)
 {
   _dbTechLayerAreaRule* obj = (_dbTechLayerAreaRule*) this;
 
   obj->area_ = area;
 }
 
-int dbTechLayerAreaRule::getArea() const
+int64_t dbTechLayerAreaRule::getArea() const
 {
   _dbTechLayerAreaRule* obj = (_dbTechLayerAreaRule*) this;
   return obj->area_;

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -74,10 +74,9 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerAreaRule& obj)
   if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> obj.area_;
   } else {
-    dbDatabase* db = (dbDatabase*) obj.getDatabase();
     int area;
     stream >> area;
-    obj.area_ = static_cast<int64_t>(area) * db->getDbuPerMicron();
+    obj.area_ = static_cast<int64_t>(area) * 20000;
   }
   // User Code End >>area_
   stream >> obj.except_min_width_;

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -76,7 +76,7 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerAreaRule& obj)
     dbDatabase* db = (dbDatabase*) obj.getDatabase();
     int area;
     stream >> area;
-    obj.area_ = area * db->getDbuPerMicron();
+    obj.area_ = static_cast<int64_t>(area) * db->getDbuPerMicron();
   }
   // User Code End >>area_
   stream >> obj.except_min_width_;

--- a/src/odb/src/db/dbTechLayerAreaRule.h
+++ b/src/odb/src/db/dbTechLayerAreaRule.h
@@ -37,7 +37,7 @@ class _dbTechLayerAreaRule : public _dbObject
   void collectMemInfo(MemInfo& info);
 
   dbTechLayerAreaRuleFlags flags_;
-  int area_;
+  int64_t area_;
   int except_min_width_;
   int except_edge_length_;
   std::pair<int, int> except_edge_lengths_;

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -283,10 +283,9 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerCutSpacingRule& obj)
   if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> obj.cut_area_;
   } else {
-    dbDatabase* db = (dbDatabase*) obj.getDatabase();
     uint32_t cut_area;
     stream >> cut_area;
-    obj.cut_area_ = static_cast<int64_t>(cut_area) * db->getDbuPerMicron();
+    obj.cut_area_ = static_cast<int64_t>(cut_area) * 20000;
   }
   // User Code End >>cut_area_
   return stream;

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -278,7 +278,15 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerCutSpacingRule& obj)
   stream >> obj.two_cuts_;
   stream >> obj.prl_;
   stream >> obj.par_length_;
-  stream >> obj.cut_area_;
+  // User Code Begin >>cut_area_
+  if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> obj.cut_area_;
+  } else {
+    int cut_area;
+    stream >> cut_area;
+    obj.cut_area_ = cut_area;
+  }
+  // User Code End >>cut_area_
   return stream;
 }
 
@@ -600,14 +608,14 @@ uint32_t dbTechLayerCutSpacingRule::getParLength() const
   return obj->par_length_;
 }
 
-void dbTechLayerCutSpacingRule::setCutArea(int cut_area)
+void dbTechLayerCutSpacingRule::setCutArea(int64_t cut_area)
 {
   _dbTechLayerCutSpacingRule* obj = (_dbTechLayerCutSpacingRule*) this;
 
   obj->cut_area_ = cut_area;
 }
 
-int dbTechLayerCutSpacingRule::getCutArea() const
+int64_t dbTechLayerCutSpacingRule::getCutArea() const
 {
   _dbTechLayerCutSpacingRule* obj = (_dbTechLayerCutSpacingRule*) this;
   return obj->cut_area_;

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -282,7 +282,7 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerCutSpacingRule& obj)
   if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> obj.cut_area_;
   } else {
-    int cut_area;
+    uint32_t cut_area;
     stream >> cut_area;
     obj.cut_area_ = cut_area;
   }

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -282,9 +282,10 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerCutSpacingRule& obj)
   if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> obj.cut_area_;
   } else {
+    dbDatabase* db = (dbDatabase*) obj.getDatabase();
     uint32_t cut_area;
     stream >> cut_area;
-    obj.cut_area_ = cut_area;
+    obj.cut_area_ = static_cast<int64_t>(cut_area) * db->getDbuPerMicron();
   }
   // User Code End >>cut_area_
   return stream;

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.h
@@ -99,7 +99,7 @@ class _dbTechLayerCutSpacingRule : public _dbObject
   uint32_t two_cuts_;
   uint32_t prl_;
   uint32_t par_length_;
-  int cut_area_;
+  int64_t cut_area_;
 };
 dbIStream& operator>>(dbIStream& stream, _dbTechLayerCutSpacingRule& obj);
 dbOStream& operator<<(dbOStream& stream, const _dbTechLayerCutSpacingRule& obj);

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -109,7 +109,7 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerMinCutRule& obj)
     dbDatabase* db = (dbDatabase*) obj.getDatabase();
     int area;
     stream >> area;
-    obj.area_ = area * db->getDbuPerMicron();
+    obj.area_ = static_cast<int64_t>(area) * db->getDbuPerMicron();
   }
   // User Code End >>area_
   stream >> obj.area_within_dist_;

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -102,7 +102,16 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerMinCutRule& obj)
   stream >> obj.within_cut_dist;
   stream >> obj.length_;
   stream >> obj.length_within_dist_;
-  stream >> obj.area_;
+  // User Code Begin >>area_
+  if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> obj.area_;
+  } else {
+    dbDatabase* db = (dbDatabase*) obj.getDatabase();
+    int area;
+    stream >> area;
+    obj.area_ = area * db->getDbuPerMicron();
+  }
+  // User Code End >>area_
   stream >> obj.area_within_dist_;
   return stream;
 }
@@ -211,14 +220,14 @@ int dbTechLayerMinCutRule::getLengthWithinDist() const
   return obj->length_within_dist_;
 }
 
-void dbTechLayerMinCutRule::setArea(int area)
+void dbTechLayerMinCutRule::setArea(int64_t area)
 {
   _dbTechLayerMinCutRule* obj = (_dbTechLayerMinCutRule*) this;
 
   obj->area_ = area;
 }
 
-int dbTechLayerMinCutRule::getArea() const
+int64_t dbTechLayerMinCutRule::getArea() const
 {
   _dbTechLayerMinCutRule* obj = (_dbTechLayerMinCutRule*) this;
   return obj->area_;

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -107,10 +107,9 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerMinCutRule& obj)
   if (obj.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> obj.area_;
   } else {
-    dbDatabase* db = (dbDatabase*) obj.getDatabase();
     int area;
     stream >> area;
-    obj.area_ = static_cast<int64_t>(area) * db->getDbuPerMicron();
+    obj.area_ = static_cast<int64_t>(area) * 20000;
   }
   // User Code End >>area_
   stream >> obj.area_within_dist_;

--- a/src/odb/src/db/dbTechLayerMinCutRule.h
+++ b/src/odb/src/db/dbTechLayerMinCutRule.h
@@ -49,7 +49,7 @@ class _dbTechLayerMinCutRule : public _dbObject
   int within_cut_dist;
   int length_;
   int length_within_dist_;
-  int area_;
+  int64_t area_;
   int area_within_dist_;
 };
 dbIStream& operator>>(dbIStream& stream, _dbTechLayerMinCutRule& obj);

--- a/src/odb/src/db/dbTechLayerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingRule.cpp
@@ -148,7 +148,14 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerSpacingRule& rule)
   stream >> rule.r1max_;
   stream >> rule.r2min_;
   stream >> rule.r2max_;
-  stream >> rule.cut_area_;
+  if (rule.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> rule.cut_area_;
+  } else {
+    dbDatabase* db = (dbDatabase*) rule.getDatabase();
+    uint32_t cut_area;
+    stream >> cut_area;
+    rule.cut_area_ = static_cast<int64_t>(cut_area) * db->getDbuPerMicron();
+  }
   stream >> rule.layer_;
   stream >> rule.cut_layer_below_;
 
@@ -244,13 +251,13 @@ void dbTechLayerSpacingRule::setCutParallelOverlap(bool overlap)
   _lsp->flags_.cut_parallel_overlap = overlap;
 }
 
-uint32_t dbTechLayerSpacingRule::getCutArea() const
+int64_t dbTechLayerSpacingRule::getCutArea() const
 {
   _dbTechLayerSpacingRule* _lsp = (_dbTechLayerSpacingRule*) this;
   return _lsp->cut_area_;
 }
 
-void dbTechLayerSpacingRule::setCutArea(uint32_t area)
+void dbTechLayerSpacingRule::setCutArea(int64_t area)
 {
   _dbTechLayerSpacingRule* _lsp = (_dbTechLayerSpacingRule*) this;
   _lsp->cut_area_ = area;

--- a/src/odb/src/db/dbTechLayerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingRule.cpp
@@ -151,10 +151,9 @@ dbIStream& operator>>(dbIStream& stream, _dbTechLayerSpacingRule& rule)
   if (rule.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
     stream >> rule.cut_area_;
   } else {
-    dbDatabase* db = (dbDatabase*) rule.getDatabase();
     uint32_t cut_area;
     stream >> cut_area;
-    rule.cut_area_ = static_cast<int64_t>(cut_area) * db->getDbuPerMicron();
+    rule.cut_area_ = static_cast<int64_t>(cut_area) * 20000;
   }
   stream >> rule.layer_;
   stream >> rule.cut_layer_below_;

--- a/src/odb/src/db/dbTechLayerSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerSpacingRule.h
@@ -67,7 +67,7 @@ class _dbTechLayerSpacingRule : public _dbObject
   uint32_t r1max_;
   uint32_t r2min_;
   uint32_t r2max_;
-  uint32_t cut_area_;
+  int64_t cut_area_;
   dbId<_dbTechLayer> layer_;
   dbId<_dbTechLayer> cut_layer_below_;
 };

--- a/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
+++ b/src/odb/src/db/dbTechMinCutOrAreaRule.cpp
@@ -129,7 +129,13 @@ dbIStream& operator>>(dbIStream& stream, _dbTechMinEncRule& rule)
 {
   uint32_t* bit_field = (uint32_t*) &rule.flags_;
   stream >> *bit_field;
-  stream >> rule.area_;
+  if (rule.getDatabase()->isSchema(kSchemaStoreAreaAsInt64)) {
+    stream >> rule.area_;
+  } else {
+    uint32_t area;
+    stream >> area;
+    rule.area_ = area;
+  }
   stream >> rule.width_;
   return stream;
 }
@@ -258,7 +264,7 @@ dbTechMinCutRule* dbTechMinCutRule::getMinCutRule(dbTechLayer* inly,
 //
 ////////////////////////////////////////////////////////////////////
 
-bool dbTechMinEncRule::getEnclosure(uint32_t& area) const
+bool dbTechMinEncRule::getEnclosure(int64_t& area) const
 {
   _dbTechMinEncRule* _lsm = (_dbTechMinEncRule*) this;
 
@@ -266,7 +272,7 @@ bool dbTechMinEncRule::getEnclosure(uint32_t& area) const
   return true;
 }
 
-void dbTechMinEncRule::setEnclosure(uint32_t area)
+void dbTechMinEncRule::setEnclosure(int64_t area)
 {
   _dbTechMinEncRule* _lsm = (_dbTechMinEncRule*) this;
 

--- a/src/odb/src/db/dbTechMinCutOrAreaRule.h
+++ b/src/odb/src/db/dbTechMinCutOrAreaRule.h
@@ -91,7 +91,7 @@ class _dbTechMinEncRule : public _dbObject
   };
 
   Flags flags_;
-  uint32_t area_;
+  int64_t area_;
   uint32_t width_;
 
   _dbTechMinEncRule(_dbDatabase* db);

--- a/src/odb/src/lefin/MinCutParser.cpp
+++ b/src/odb/src/lefin/MinCutParser.cpp
@@ -43,7 +43,7 @@ void MinCutParser::setLengthWithin(double within)
 
 void MinCutParser::setArea(double area)
 {
-  rule_->setArea(lefin_->dbdist(area));
+  rule_->setArea(lefin_->dbarea(area));
   rule_->setAreaValid(true);
 }
 

--- a/src/odb/src/lefin/lefLayerPropParser.h
+++ b/src/odb/src/lefin/lefLayerPropParser.h
@@ -185,9 +185,12 @@ class lefTechLayerAreaRuleParser
       const std::string&,
       odb::dbTechLayer* layer,
       std::vector<std::pair<odb::dbObject*, std::string>>& incomplete_props);
-  void setInt(double val,
-              odb::dbTechLayerAreaRule* rule,
-              void (odb::dbTechLayerAreaRule::*func)(int));
+  void setDist(double val,
+               odb::dbTechLayerAreaRule* rule,
+               void (odb::dbTechLayerAreaRule::*func)(int));
+  void setArea(double val,
+               odb::dbTechLayerAreaRule* rule,
+               void (odb::dbTechLayerAreaRule::*func)(int64_t));
   void setExceptEdgeLengths(const boost::fusion::vector<double, double>& params,
                             odb::dbTechLayerAreaRule* rule);
   void setExceptMinSize(const boost::fusion::vector<double, double>& params,

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2022-2025, The OpenROAD Authors
 
 // Parser for LEF58 area rules that define minimum area requirements for shapes
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -39,12 +39,20 @@ void lefTechLayerAreaRuleParser::parse(
 }
 
 // Helper function to set integer values (converts to database units)
-void lefTechLayerAreaRuleParser::setInt(
+void lefTechLayerAreaRuleParser::setDist(
     double val,
     odb::dbTechLayerAreaRule* rule,
     void (odb::dbTechLayerAreaRule::*func)(int))
 {
   (rule->*func)(lefin_->dbdist(val));
+}
+
+void lefTechLayerAreaRuleParser::setArea(
+    double val,
+    odb::dbTechLayerAreaRule* rule,
+    void (odb::dbTechLayerAreaRule::*func)(int64_t))
+{
+  (rule->*func)(lefin_->dbarea(val));
 }
 
 // Set edge length exception parameters
@@ -108,7 +116,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
       = ((lit("EXCEPTEDGELENGTH") >> double_ >> double_)[boost::bind(
              &lefTechLayerAreaRuleParser::setExceptEdgeLengths, this, _1, rule)]
          | lit("EXCEPTEDGELENGTH") >> double_[boost::bind(
-               &lefTechLayerAreaRuleParser::setInt,
+               &lefTechLayerAreaRuleParser::setDist,
                this,
                _1,
                rule,
@@ -134,7 +142,7 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
          >> int_[boost::bind(&odb::dbTechLayerAreaRule::setOverlap, rule, _1)]);
 
   qi::rule<std::string::const_iterator, space_type> area_rule
-      = (lit("AREA") >> double_[boost::bind(&lefTechLayerAreaRuleParser::setInt,
+      = (lit("AREA") >> double_[boost::bind(&lefTechLayerAreaRuleParser::setArea,
                                             this,
                                             _1,
                                             rule,
@@ -143,14 +151,14 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
              lit("MASK")
              >> int_[boost::bind(&odb::dbTechLayerAreaRule::setMask, rule, _1)])
          >> -(lit("EXCEPTMINWIDTH") >> double_[boost::bind(
-                  &lefTechLayerAreaRuleParser::setInt,
+                  &lefTechLayerAreaRuleParser::setDist,
                   this,
                   _1,
                   rule,
                   &odb::dbTechLayerAreaRule::setExceptMinWidth)])
          >> -except_edge_length >> -except_min_size >> -except_step
          >> -(lit("RECTWIDTH")
-              >> double_[boost::bind(&lefTechLayerAreaRuleParser::setInt,
+              >> double_[boost::bind(&lefTechLayerAreaRuleParser::setDist,
                                      this,
                                      _1,
                                      rule,

--- a/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerAreaRuleParser.cpp
@@ -142,11 +142,12 @@ bool lefTechLayerAreaRuleParser::parseSubRule(
          >> int_[boost::bind(&odb::dbTechLayerAreaRule::setOverlap, rule, _1)]);
 
   qi::rule<std::string::const_iterator, space_type> area_rule
-      = (lit("AREA") >> double_[boost::bind(&lefTechLayerAreaRuleParser::setArea,
-                                            this,
-                                            _1,
-                                            rule,
-                                            &odb::dbTechLayerAreaRule::setArea)]
+      = (lit("AREA")
+         >> double_[boost::bind(&lefTechLayerAreaRuleParser::setArea,
+                                this,
+                                _1,
+                                rule,
+                                &odb::dbTechLayerAreaRule::setArea)]
          >> -(
              lit("MASK")
              >> int_[boost::bind(&odb::dbTechLayerAreaRule::setMask, rule, _1)])

--- a/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
+++ b/src/odb/src/lefin/lefTechLayerCutSpacingParser.cpp
@@ -208,7 +208,7 @@ void addAreaSubRule(double value,
 {
   parser->curRule->setType(
       odb::dbTechLayerCutSpacingRule::CutSpacingType::AREA);
-  parser->curRule->setCutArea(lefinReader->dbdist(value));
+  parser->curRule->setCutArea(lefinReader->dbarea(value));
 }
 
 void setConcaveCornerWidth(

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -833,7 +833,7 @@ void lefinReader::layer(LefParser::lefiLayer* layer)
       cur_rule->setSpacingNotchLengthValid(layer->hasSpacingNotchLength(j));
 
       if (layer->hasSpacingArea(j)) {
-        cur_rule->setCutArea(dbdist(layer->spacingArea(j)));
+        cur_rule->setCutArea(dbarea(layer->spacingArea(j)));
       }
 
       if (layer->hasSpacingRange(j)) {
@@ -1125,7 +1125,7 @@ void lefinReader::layer(LefParser::lefiLayer* layer)
   }
 
   if (layer->hasArea()) {
-    l->setArea(layer->area());
+    l->setArea(dbarea(layer->area()));
   }
 
   if (layer->hasThickness()) {

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -2596,6 +2596,11 @@ int lefin::dbdist(double value)
   return reader_->dbdist(value);
 }
 
+int64_t lefin::dbarea(double value)
+{
+  return reader_->dbarea(value);
+}
+
 dbTech* lefin::createTech(const char* name, const char* lef_file)
 {
   absl::MutexLock lock(&lef_mutex_);

--- a/src/odb/src/lefin/lefin.cpp
+++ b/src/odb/src/lefin/lefin.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <cctype>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <sstream>

--- a/src/odb/src/lefout/lefout.cpp
+++ b/src/odb/src/lefout/lefout.cpp
@@ -1080,7 +1080,7 @@ void lefout::writeLayer(std::ostream& out, dbTechLayer* layer)
   }
 
   if (layer->hasArea()) {
-    fmt::print(out, "    AREA {:.11g} ;\n", layer->getArea());
+    fmt::print(out, "    AREA {:.11g} ;\n", lefarea(layer->getArea()));
   }
 
   uint32_t thickness;
@@ -1186,7 +1186,7 @@ void lefout::writeSpacingRuleLef(std::ostream& out,
   }
 
   if (rule->getCutArea() > 0) {
-    fmt::print(out, "    AREA {:g} ", lefdist(rule->getCutArea()));
+    fmt::print(out, "    AREA {:g} ", lefarea(rule->getCutArea()));
   }
 
   if (rule->getRange(rmin, rmax)) {
@@ -1310,7 +1310,8 @@ void lefout::writeMinCutRuleLef(std::ostream& out, dbTechMinCutRule* rule)
 
 void lefout::writeMinEncRuleLef(std::ostream& out, dbTechMinEncRule* rule)
 {
-  uint32_t enc_area, enc_width;
+  int64_t enc_area;
+  uint32_t enc_width;
   rule->getEnclosure(enc_area);
   fmt::print(out, "    MINENCLOSEDAREA {:g} ", lefarea(enc_area));
   if (rule->getEnclosureWidth(enc_width)) {

--- a/src/odb/src/swig/common/odb.i
+++ b/src/odb/src/swig/common/odb.i
@@ -39,6 +39,7 @@ using namespace odb;
 %typemap(in) (uint32_t) = (int);
 %typemap(out) (uint32_t) = (int);
 %typemap(out) (uint64) = (long);
+%typemap(in) (int64_t) = (long);
 %typemap(out) (int64_t) = (long);
 %apply int* OUTPUT {int* x, int* y, int& ext};
 

--- a/src/odb/test/cpp/TestLef58Properties.cpp
+++ b/src/odb/test/cpp/TestLef58Properties.cpp
@@ -77,6 +77,7 @@ TEST_F(Fixture, test_default)
 
   auto dbTech = db2->getTech();
   double distFactor = 2000;
+  double areaFactor = 2000 * 2000;
   auto layer = dbTech->findLayer("metal1");
   EXPECT_EQ(layer->getLef58Type(), odb::dbTechLayer::LEF58_TYPE::MIMCAP);
   auto rules = layer->getTechLayerSpacingEolRules();
@@ -228,7 +229,7 @@ TEST_F(Fixture, test_default)
   EXPECT_EQ(minCutRule->getNumCuts(), 2);
   EXPECT_EQ(minCutRule->getWithinCutDist(), 0.05 * distFactor);
   EXPECT_EQ(minCutRule->getWidth(), 0.09 * distFactor);
-  EXPECT_EQ(minCutRule->getArea(), 2.0 * distFactor);
+  EXPECT_EQ(minCutRule->getArea(), 2.0 * areaFactor);
 
   auto cutLayer = dbTech->findLayer("via1");
 
@@ -393,15 +394,15 @@ TEST_F(Fixture, test_default)
   int cnt = 0;
   for (odb::dbTechLayerAreaRule* subRule : areaRules) {
     if (cnt == 0) {
-      EXPECT_EQ(subRule->getArea(), 0.044 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 0.044 * areaFactor);
       EXPECT_EQ(subRule->getMask(), 2);
     }
     if (cnt == 1) {
-      EXPECT_EQ(subRule->getArea(), 0.34 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 0.34 * areaFactor);
       EXPECT_EQ(subRule->getRectWidth(), 0.12 * distFactor);
     }
     if (cnt == 2) {
-      EXPECT_EQ(subRule->getArea(), 1.01 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 1.01 * areaFactor);
       EXPECT_EQ(subRule->getExceptMinWidth(), 0.09 * distFactor);
       EXPECT_EQ(subRule->getExceptMinSize().first, 0.1 * distFactor);
       EXPECT_EQ(subRule->getExceptMinSize().second, 0.3 * distFactor);
@@ -410,16 +411,16 @@ TEST_F(Fixture, test_default)
       EXPECT_EQ(subRule->getExceptEdgeLength(), 0.8 * distFactor);
     }
     if (cnt == 3) {
-      EXPECT_EQ(subRule->getArea(), 0.101 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 0.101 * areaFactor);
       EXPECT_EQ(subRule->getTrimLayer()->getName(), "metal1");
       EXPECT_EQ(subRule->getOverlap(), 1);
     }
     if (cnt == 4) {
-      EXPECT_EQ(subRule->getArea(), 2.34 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 2.34 * areaFactor);
       EXPECT_TRUE(subRule->isExceptRectangle());
     }
     if (cnt == 5) {
-      EXPECT_EQ(subRule->getArea(), 0.78 * distFactor);
+      EXPECT_EQ(subRule->getArea(), 0.78 * areaFactor);
       EXPECT_EQ(subRule->getExceptEdgeLengths().first, 0.3 * distFactor);
       EXPECT_EQ(subRule->getExceptEdgeLengths().second, 0.7 * distFactor);
     }

--- a/src/pdn/src/techlayer.cpp
+++ b/src/pdn/src/techlayer.cpp
@@ -240,22 +240,20 @@ odb::Rect TechLayer::adjustToMinArea(
     return rect;
   }
 
-  const int dbu_per_micron = getLefUnits();
-  int min_area = 0;
+  int64_t min_area = 0;
   if (has_rules) {
     for (auto* rule : layer_->getTechLayerAreaRules()) {
-      const int layer_min_area = rule->getArea();
+      const int64_t layer_min_area = rule->getArea();
       if (layer_min_area == 0) {
         continue;
       }
       // TODO: Check width rules
       // TODO: Check length rules
       // TODO: Check except rules
-      min_area = std::max(min_area, layer_min_area * dbu_per_micron);
+      min_area = std::max(min_area, layer_min_area);
     }
   } else {
-    const double layer_min_area = layer_->getArea();
-    min_area = layer_min_area * dbu_per_micron * dbu_per_micron;
+    min_area = layer_->getArea();
   }
 
   if (min_area == 0) {

--- a/src/pdn/test/core_grid_with_M6_min_area.tcl
+++ b/src/pdn/test/core_grid_with_M6_min_area.tcl
@@ -5,7 +5,7 @@ read_lef Nangate45/Nangate45.lef
 read_def nangate_gcd/floorplan.def
 
 # Adjust techrules to set min area on metal6
-[[ord::get_db_tech] findLayer metal6] setArea 0.5898
+[[ord::get_db_tech] findLayer metal6] setArea 2359200
 
 add_global_connection -net VDD -pin_pattern VDD -power
 add_global_connection -net VSS -pin_pattern VSS -ground

--- a/src/ppl/src/IOPlacer.cpp
+++ b/src/ppl/src/IOPlacer.cpp
@@ -2579,8 +2579,7 @@ void IOPlacer::placePin(odb::dbBTerm* bterm,
                         bool placed_status)
 {
   if (width == 0 && height == 0) {
-    const int database_unit = getTech()->getDbUnitsPerMicron();
-    const double min_area = layer->getArea() * database_unit * database_unit;
+    const double min_area = layer->getArea();
     if (layer->getDirection() == odb::dbTechLayerDir::VERTICAL) {
       width = layer->getMinWidth();
       height
@@ -2853,7 +2852,7 @@ void IOPlacer::initCore(const std::set<int>& hor_layer_idxs,
           i, init_track_y[i], num_track_y[i], min_spacing_y[i]);
     }
 
-    min_area_y = hor_layer->getArea() * database_unit * database_unit;
+    min_area_y = hor_layer->getArea();
     min_width_y = hor_layer->getWidth();
 
     min_spacings_y[hor_layer_idx] = std::move(min_spacing_y);
@@ -2879,7 +2878,7 @@ void IOPlacer::initCore(const std::set<int>& hor_layer_idxs,
           i, init_track_x[i], num_track_x[i], min_spacing_x[i]);
     }
 
-    min_area_x = ver_layer->getArea() * database_unit * database_unit;
+    min_area_x = ver_layer->getArea();
     min_width_x = ver_layer->getWidth();
 
     min_spacings_x[ver_layer_idx] = std::move(min_spacing_x);


### PR DESCRIPTION
## Summary
In the database we were incorrectly storing areas as distances or as doubles.
This converts them to int64_t (atleast those I could find), I chose this since it's the return type of `Rect::area()` so trying to be consistent there.
I searched through the code to find the callers and adjust them (this should be checked carefully).
I added a custom-serial flag to the code generator since I couldn't see a way to change datatype changes nicely.

## Type of Change
- Bug fix
- Refactoring

## Impact
No change expected

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
N/A
