### PR TITLE
ram: Enable optional user-provided name for power rails

### DIFF
--- a/src/ram/README.md
+++ b/src/ram/README.md
@@ -43,6 +43,8 @@ generate_ram [-mask_size bits]
              [-inv_cell name]
              -power_pin name
              -ground_pin name
+             [-power_net_name name]
+             [-ground_net_name name]
              -routing_layer config
              -ver_layer config
              -hor_layer config
@@ -67,6 +69,8 @@ generate_ram [-mask_size bits]
 | `-power_pin` | Name of the power pin in each standard cell used. Only one name is currently supported. |
 | `-ground_pin` | Name of the ground pin in each standard cell used. Only one name is currently supported. |
 | `-routing_layer` | A list of the metal layer and metal width (in microns) for generating standard cell power tracks (followpins). Example: `{met1 0.48}`. |
+| `-power_net_name` | Name of the power net to create. Default: `VDD`. |
+| `-ground_net_name` | Name of the ground net to create. Default: `VSS`. |
 | `-ver_layer` | A list of the metal layer, metal width (in microns), and metal pitch (in microns) for generating power grid stripes on the first vertical layer above the followpin layer. Example: `{met2 0.48 40}`. North/South I/O pins are also created in this layer. |
 | `-hor_layer` | A list of the metal layer, metal width (in microns), and metal pitch (in microns) for generating power grid stripes on the first horizontal layer above the followpin layer. Example: `{met3 0.48 40}`. East/West I/O pins are also created in this layer. |
 | `-filler_cells` | A list of filler cells to use. Example: `{FILL_X1 FILL_X2 FILL_X4}`. |

--- a/src/ram/include/ram/ram.h
+++ b/src/ram/include/ram/ram.h
@@ -101,6 +101,8 @@ class RamGen
 
   void ramPdngen(const char* power_pin,
                  const char* ground_pin,
+                 const char* power_net_name,
+                 const char* ground_net_name,
                  const char* route_name,
                  int route_width,
                  const char* ver_name,

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -891,8 +891,22 @@ void RamGen::ramPdngen(const char* power_pin,
         ver_pitch / dbu_per_um);
   }
 
-  auto power_net = dbNet::create(block_, power_net_name);
-  auto ground_net = dbNet::create(block_, ground_net_name);
+  auto power_net = block_->findNet(power_net_name);
+  if (!power_net) {
+    power_net = dbNet::create(block_, power_net_name);
+  }
+  if (!power_net) {
+    logger_->error(RAM, 38, "Failed to create power net '{}'", power_net_name);
+  }
+
+  auto ground_net = block_->findNet(ground_net_name);
+  if (!ground_net) {
+    ground_net = dbNet::create(block_, ground_net_name);
+  }
+  if (!ground_net) {
+    logger_->error(
+        RAM, 39, "Failed to create ground net '{}'", ground_net_name);
+  }
 
   power_net->setSpecial();
   power_net->setSigType(odb::dbSigType::POWER);

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -848,6 +848,8 @@ void RamGen::findMasters()
 
 void RamGen::ramPdngen(const char* power_pin,
                        const char* ground_pin,
+                       const char* power_net_name,
+                       const char* ground_net_name,
                        const char* route_name,
                        int route_width,
                        const char* ver_name,
@@ -889,10 +891,8 @@ void RamGen::ramPdngen(const char* power_pin,
         ver_pitch / dbu_per_um);
   }
 
-  // need parameters for power and ground nets
-  auto power_net = dbNet::create(block_, "VDD");
-  // need parameters for power and ground nets
-  auto ground_net = dbNet::create(block_, "VSS");
+  auto power_net = dbNet::create(block_, power_net_name);
+  auto ground_net = dbNet::create(block_, ground_net_name);
 
   power_net->setSpecial();
   power_net->setSigType(odb::dbSigType::POWER);

--- a/src/ram/src/ram.i
+++ b/src/ram/src/ram.i
@@ -95,12 +95,13 @@ generate_ram_netlist_cmd(int mask_size,
 }
 
 void ram_pdngen(const char* power_pin, const char* ground_pin, 
+                const char* power_net_name, const char* ground_net_name,
                 const char* route_name, int route_width, 
                 const char* ver_name, int ver_width, int ver_pitch,
                 const char* hor_name, int hor_width, int hor_pitch)
 {
   RamGen* ram_gen = ord::getRamGen();
-  ram_gen->ramPdngen(power_pin, ground_pin, 
+  ram_gen->ramPdngen(power_pin, ground_pin, power_net_name, ground_net_name,
                      route_name, route_width,
                      ver_name, ver_width, ver_pitch, 
                      hor_name, hor_width, hor_pitch);

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -197,9 +197,19 @@ proc generate_ram { args } {
     set power_net_name $keys(-power_net_name)
   }
 
+  set power_net_name [string trim $power_net_name]
+  if { $power_net_name eq "" } {
+    utl::error RAM 40 "The -power_net_name argument cannot be empty."
+  }
+
   set ground_net_name "VSS"
   if { [info exists keys(-ground_net_name)] } {
     set ground_net_name $keys(-ground_net_name)
+  }
+  
+  set ground_net_name [string trim $ground_net_name]
+  if { $ground_net_name eq "" } {
+    utl::error RAM 41 "The -ground_net_name argument cannot be empty."
   }
 
   if { [info exists keys(-routing_layer)] } {

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -120,8 +120,9 @@ proc generate_ram { args } {
   sta::parse_key_args "generate_ram" args \
     keys { -mask_size -word_size -num_words -column_mux_ratio
            -storage_cell -tristate_cell -inv_cell -read_ports -use_latch
-      -power_pin -ground_pin -power_net_name -ground_net_name -routing_layer -ver_layer -hor_layer -filler_cells
-        -tapcell -max_tap_dist -write_behavioral_verilog } flags {}
+           -power_pin -ground_pin -power_net_name -ground_net_name
+           -routing_layer -ver_layer -hor_layer -filler_cells
+           -tapcell -max_tap_dist -write_behavioral_verilog } flags {}
 
   sta::check_argc_eq0 "generate_ram" $args
 

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -103,6 +103,8 @@ sta::define_cmd_args "generate_ram" {[-mask_size bits]
                                      [-inv_cell name]
                                      -power_pin name
                                      -ground_pin name
+                                     [-power_net_name name]
+                                     [-ground_net_name name]
                                      -routing_layer config
                                      -ver_layer config
                                      -hor_layer config
@@ -118,7 +120,7 @@ proc generate_ram { args } {
   sta::parse_key_args "generate_ram" args \
     keys { -mask_size -word_size -num_words -column_mux_ratio
            -storage_cell -tristate_cell -inv_cell -read_ports -use_latch
-      -power_pin -ground_pin -routing_layer -ver_layer -hor_layer -filler_cells
+      -power_pin -ground_pin -power_net_name -ground_net_name -routing_layer -ver_layer -hor_layer -filler_cells
         -tapcell -max_tap_dist -write_behavioral_verilog } flags {}
 
   sta::check_argc_eq0 "generate_ram" $args
@@ -189,6 +191,16 @@ proc generate_ram { args } {
     utl::error RAM 6 "The -ground_pin argument must be specified."
   }
 
+  set power_net_name "VDD"
+  if { [info exists keys(-power_net_name)] } {
+    set power_net_name $keys(-power_net_name)
+  }
+
+  set ground_net_name "VSS"
+  if { [info exists keys(-ground_net_name)] } {
+    set ground_net_name $keys(-ground_net_name)
+  }
+
   if { [info exists keys(-routing_layer)] } {
     set routing_layer $keys(-routing_layer)
   } else {
@@ -236,7 +248,8 @@ proc generate_ram { args } {
     utl::error RAM 18 "The -filler_cells argument must be specified."
   }
 
-  ram::ram_pdngen $power_pin $ground_pin $route_name $route_width \
+  ram::ram_pdngen $power_pin $ground_pin $power_net_name $ground_net_name \
+    $route_name $route_width \
     $ver_name $ver_width $ver_pitch $hor_name $hor_width $hor_pitch
 
   make_tracks -x_offset 0 -y_offset 0

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -206,7 +206,7 @@ proc generate_ram { args } {
   if { [info exists keys(-ground_net_name)] } {
     set ground_net_name $keys(-ground_net_name)
   }
-  
+
   set ground_net_name [string trim $ground_net_name]
   if { $ground_net_name eq "" } {
     utl::error RAM 41 "The -ground_net_name argument cannot be empty."


### PR DESCRIPTION
## Summary
Allow users to change the names of power rails or leave as default (`power_net=VDD`, `ground_net=VSS`). README.md is also updated to include information on this change

## Type of Change
<!-- Delete items that do not apply -->
- New feature
- Documentation update

## Impact
Allow user-defined name for power rails

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
Fixes #10563 

@rovinski 