### PR TITLE
dpl: make optimize_mirroring deterministic

### DIFF
--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -63,10 +63,14 @@ void OptimizeMirroring::run()
   }
 
   // Sort net boxes by net hpwl.
-  std::ranges::sort(sorted_boxes,
-                    [](NetBox* net_box1, NetBox* net_box2) -> bool {
-                      return net_box1->hpwl() > net_box2->hpwl();
-                    });
+  std::ranges::sort(
+      sorted_boxes, [](NetBox* net_box1, NetBox* net_box2) -> bool {
+        if (net_box1->hpwl() != net_box2->hpwl()) {
+          return net_box1->hpwl() > net_box2->hpwl();
+        }
+        // net_box_map_ is unordered; tie-break for stable output.
+        return net_box1->getNet()->getId() < net_box2->getNet()->getId();
+      });
 
   std::vector<odb::dbInst*> mirror_candidates
       = findMirrorCandidates(sorted_boxes);

--- a/src/dpl/src/OptMirror.cpp
+++ b/src/dpl/src/OptMirror.cpp
@@ -65,8 +65,10 @@ void OptimizeMirroring::run()
   // Sort net boxes by net hpwl.
   std::ranges::sort(
       sorted_boxes, [](NetBox* net_box1, NetBox* net_box2) -> bool {
-        if (net_box1->hpwl() != net_box2->hpwl()) {
-          return net_box1->hpwl() > net_box2->hpwl();
+        const int64_t hpwl1 = net_box1->hpwl();
+        const int64_t hpwl2 = net_box2->hpwl();
+        if (hpwl1 != hpwl2) {
+          return hpwl1 > hpwl2;
         }
         // net_box_map_ is unordered; tie-break for stable output.
         return net_box1->getNet()->getId() < net_box2->getNet()->getId();


### PR DESCRIPTION
`net_box_map_` is a `std::unordered_map<dbNet*, NetBox>`, so the
`sorted_boxes` vector built from it starts in heap-address order. The
comparator keys on `hpwl()` alone and `std::ranges::sort` is not stable,
so equal-hpwl boxes keep that non-deterministic order. The greedy
`mirrorCandidates()` then mutates boxes in that order, so the mirroring
result — and the written db — differs run to run.

Tie-break the sort by net id for a stable total order.

`src/dpl/test` mirror1/2/3 output is unchanged.