### PR TITLE
odb: restructure code generator around a typed FieldType model

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7902,7 +7902,8 @@ class dbGDSARef : public dbObject
 
   // User Code Begin dbGDSARef
   dbGDSStructure* getStructure() const;
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSARef* create(dbGDSStructure* parent, dbGDSStructure* child);
   static void destroy(dbGDSARef* aref);
@@ -7926,7 +7927,8 @@ class dbGDSBoundary : public dbObject
 
   // User Code Begin dbGDSBoundary
   const std::vector<Point>& getXY();
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSBoundary* create(dbGDSStructure* structure);
   static void destroy(dbGDSBoundary* boundary);
@@ -7949,7 +7951,8 @@ class dbGDSBox : public dbObject
   Rect getBounds() const;
 
   // User Code Begin dbGDSBox
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSBox* create(dbGDSStructure* structure);
   static void destroy(dbGDSBox* box);
@@ -7981,7 +7984,8 @@ class dbGDSPath : public dbObject
 
   // User Code Begin dbGDSPath
   const std::vector<Point>& getXY();
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSPath* create(dbGDSStructure* structure);
   static void destroy(dbGDSPath* path);
@@ -8001,7 +8005,8 @@ class dbGDSSRef : public dbObject
 
   // User Code Begin dbGDSSRef
   dbGDSStructure* getStructure() const;
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSSRef* create(dbGDSStructure* parent, dbGDSStructure* child);
   static void destroy(dbGDSSRef* sref);
@@ -8063,7 +8068,8 @@ class dbGDSText : public dbObject
   std::string getText() const;
 
   // User Code Begin dbGDSText
-  std::vector<std::pair<std::int16_t, std::string>>& getPropattr();
+  const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
+  void addPropattr(std::int16_t type, const std::string& value);
 
   static dbGDSText* create(dbGDSStructure* structure);
   static void destroy(dbGDSText* text);

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7076,6 +7076,8 @@ class dbAccessPoint : public dbObject
 
   void setLayer(dbTechLayer* layer);
 
+  dbBPin* getBPin() const;
+
   // User Code Begin dbAccessPoint
   void setAccesses(const std::vector<dbDirection>& accesses);
 
@@ -7097,8 +7099,6 @@ class dbAccessPoint : public dbObject
   dbTechLayer* getLayer() const;
 
   dbMPin* getMPin() const;
-
-  dbBPin* getBPin() const;
 
   std::vector<std::vector<dbObject*>> getVias() const;
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7070,7 +7070,7 @@ class dbViaParams : private _dbViaParams
 class dbAccessPoint : public dbObject
 {
  public:
-  void setPoint(Point point);
+  void setPoint(const Point& point);
 
   Point getPoint() const;
 
@@ -7243,7 +7243,7 @@ class dbChip : public dbObject
 
   const char* getName() const;
 
-  void setOffset(Point offset);
+  void setOffset(const Point& offset);
 
   Point getOffset() const;
 
@@ -7876,15 +7876,15 @@ class dbGCellGrid : public dbObject
 class dbGDSARef : public dbObject
 {
  public:
-  void setOrigin(Point origin);
+  void setOrigin(const Point& origin);
 
   Point getOrigin() const;
 
-  void setLr(Point lr);
+  void setLr(const Point& lr);
 
   Point getLr() const;
 
-  void setUl(Point ul);
+  void setUl(const Point& ul);
 
   Point getUl() const;
 
@@ -7944,7 +7944,7 @@ class dbGDSBox : public dbObject
 
   int16_t getDatatype() const;
 
-  void setBounds(Rect bounds);
+  void setBounds(const Rect& bounds);
 
   Rect getBounds() const;
 
@@ -7991,7 +7991,7 @@ class dbGDSPath : public dbObject
 class dbGDSSRef : public dbObject
 {
  public:
-  void setOrigin(Point origin);
+  void setOrigin(const Point& origin);
 
   Point getOrigin() const;
 
@@ -8011,7 +8011,7 @@ class dbGDSSRef : public dbObject
 class dbGDSStructure : public dbObject
 {
  public:
-  char* getName() const;
+  const char* getName() const;
 
   dbSet<dbGDSBoundary> getGDSBoundaries() const;
 
@@ -8046,7 +8046,7 @@ class dbGDSText : public dbObject
 
   int16_t getDatatype() const;
 
-  void setOrigin(Point origin);
+  void setOrigin(const Point& origin);
 
   Point getOrigin() const;
 
@@ -9150,8 +9150,8 @@ class dbScanPin : public dbObject
   std::variant<dbBTerm*, dbITerm*> getPin() const;
   void setPin(dbBTerm* bterm);
   void setPin(dbITerm* iterm);
-  static dbId<dbScanPin> create(dbDft* dft, dbBTerm* bterm);
-  static dbId<dbScanPin> create(dbDft* dft, dbITerm* iterm);
+  static dbScanPin* create(dbDft* dft, dbBTerm* bterm);
+  static dbScanPin* create(dbDft* dft, dbITerm* iterm);
   // User Code End dbScanPin
 };
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7427,6 +7427,8 @@ class dbChipInst : public dbObject
  public:
   std::string getName() const;
 
+  void setOrient(dbOrientType3D orient);
+
   dbOrientType3D getOrient() const;
 
   dbChip* getMasterChip() const;
@@ -7436,8 +7438,6 @@ class dbChipInst : public dbObject
   // User Code Begin dbChipInst
 
   dbTransform getTransform() const;
-
-  void setOrient(dbOrientType3D orient);
 
   void setLoc(const Point3D& loc);
 
@@ -8198,13 +8198,23 @@ class dbIsolation : public dbObject
  public:
   const char* getName() const;
 
+  void setAppliesTo(const std::string& applies_to);
+
   std::string getAppliesTo() const;
+
+  void setClampValue(const std::string& clamp_value);
 
   std::string getClampValue() const;
 
+  void setIsolationSignal(const std::string& isolation_signal);
+
   std::string getIsolationSignal() const;
 
+  void setIsolationSense(const std::string& isolation_sense);
+
   std::string getIsolationSense() const;
+
+  void setLocation(const std::string& location);
 
   std::string getLocation() const;
 
@@ -8215,16 +8225,6 @@ class dbIsolation : public dbObject
   // User Code Begin dbIsolation
   static dbIsolation* create(dbBlock* block, const char* name);
   static void destroy(dbIsolation* iso);
-
-  void setAppliesTo(const std::string& applies_to);
-
-  void setClampValue(const std::string& clamp_value);
-
-  void setIsolationSignal(const std::string& isolation_signal);
-
-  void setIsolationSense(const std::string& isolation_sense);
-
-  void setLocation(const std::string& location);
 
   void addIsolationCell(const std::string& master);
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -7190,11 +7190,11 @@ class dbCellEdgeSpacing : public dbObject
  public:
   void setFirstEdgeType(const std::string& first_edge_type);
 
-  std::string getFirstEdgeType() const;
+  const std::string& getFirstEdgeType() const;
 
   void setSecondEdgeType(const std::string& second_edge_type);
 
-  std::string getSecondEdgeType() const;
+  const std::string& getSecondEdgeType() const;
 
   void setSpacing(int spacing);
 
@@ -7393,7 +7393,7 @@ class dbChipBumpInst : public dbObject
 class dbChipConn : public dbObject
 {
  public:
-  std::string getName() const;
+  const std::string& getName() const;
 
   void setThickness(int thickness);
 
@@ -7425,7 +7425,7 @@ class dbChipConn : public dbObject
 class dbChipInst : public dbObject
 {
  public:
-  std::string getName() const;
+  const std::string& getName() const;
 
   void setOrient(dbOrientType3D orient);
 
@@ -7464,7 +7464,7 @@ class dbChipInst : public dbObject
 class dbChipNet : public dbObject
 {
  public:
-  std::string getName() const;
+  const std::string& getName() const;
 
   // User Code Begin dbChipNet
   dbChip* getChip() const;
@@ -7522,7 +7522,7 @@ class dbChipRegion : public dbObject
     INTERNAL_EXT
   };
 
-  std::string getName() const;
+  const std::string& getName() const;
 
   void setBox(const Rect& box);
 
@@ -8065,7 +8065,7 @@ class dbGDSText : public dbObject
 
   void setText(const std::string& text);
 
-  std::string getText() const;
+  const std::string& getText() const;
 
   // User Code Begin dbGDSText
   const std::vector<std::pair<std::int16_t, std::string>>& getPropattr() const;
@@ -8083,9 +8083,9 @@ class dbGlobalConnect : public dbObject
 
   dbNet* getNet() const;
 
-  std::string getInstPattern() const;
+  const std::string& getInstPattern() const;
 
-  std::string getPinPattern() const;
+  const std::string& getPinPattern() const;
 
   // User Code Begin dbGlobalConnect
   std::vector<dbInst*> getInsts() const;
@@ -8206,23 +8206,23 @@ class dbIsolation : public dbObject
 
   void setAppliesTo(const std::string& applies_to);
 
-  std::string getAppliesTo() const;
+  const std::string& getAppliesTo() const;
 
   void setClampValue(const std::string& clamp_value);
 
-  std::string getClampValue() const;
+  const std::string& getClampValue() const;
 
   void setIsolationSignal(const std::string& isolation_signal);
 
-  std::string getIsolationSignal() const;
+  const std::string& getIsolationSignal() const;
 
   void setIsolationSense(const std::string& isolation_sense);
 
-  std::string getIsolationSense() const;
+  const std::string& getIsolationSense() const;
 
   void setLocation(const std::string& location);
 
-  std::string getLocation() const;
+  const std::string& getLocation() const;
 
   void setPowerDomain(dbPowerDomain* power_domain);
 
@@ -8250,11 +8250,11 @@ class dbLevelShifter : public dbObject
 
   void setSource(const std::string& source);
 
-  std::string getSource() const;
+  const std::string& getSource() const;
 
   void setSink(const std::string& sink);
 
-  std::string getSink() const;
+  const std::string& getSink() const;
 
   void setUseFunctionalEquivalence(bool use_functional_equivalence);
 
@@ -8262,15 +8262,15 @@ class dbLevelShifter : public dbObject
 
   void setAppliesTo(const std::string& applies_to);
 
-  std::string getAppliesTo() const;
+  const std::string& getAppliesTo() const;
 
   void setAppliesToBoundary(const std::string& applies_to_boundary);
 
-  std::string getAppliesToBoundary() const;
+  const std::string& getAppliesToBoundary() const;
 
   void setRule(const std::string& rule);
 
-  std::string getRule() const;
+  const std::string& getRule() const;
 
   void setThreshold(float threshold);
 
@@ -8286,39 +8286,39 @@ class dbLevelShifter : public dbObject
 
   void setLocation(const std::string& location);
 
-  std::string getLocation() const;
+  const std::string& getLocation() const;
 
   void setInputSupply(const std::string& input_supply);
 
-  std::string getInputSupply() const;
+  const std::string& getInputSupply() const;
 
   void setOutputSupply(const std::string& output_supply);
 
-  std::string getOutputSupply() const;
+  const std::string& getOutputSupply() const;
 
   void setInternalSupply(const std::string& internal_supply);
 
-  std::string getInternalSupply() const;
+  const std::string& getInternalSupply() const;
 
   void setNamePrefix(const std::string& name_prefix);
 
-  std::string getNamePrefix() const;
+  const std::string& getNamePrefix() const;
 
   void setNameSuffix(const std::string& name_suffix);
 
-  std::string getNameSuffix() const;
+  const std::string& getNameSuffix() const;
 
   void setCellName(const std::string& cell_name);
 
-  std::string getCellName() const;
+  const std::string& getCellName() const;
 
   void setCellInput(const std::string& cell_input);
 
-  std::string getCellInput() const;
+  const std::string& getCellInput() const;
 
   void setCellOutput(const std::string& cell_output);
 
-  std::string getCellOutput() const;
+  const std::string& getCellOutput() const;
 
   // User Code Begin dbLevelShifter
 
@@ -8341,7 +8341,7 @@ class dbLogicPort : public dbObject
  public:
   const char* getName() const;
 
-  std::string getDirection() const;
+  const std::string& getDirection() const;
 
   // User Code Begin dbLogicPort
   static dbLogicPort* create(dbBlock* block,
@@ -8356,7 +8356,7 @@ class dbMarker : public dbObject
  public:
   void setComment(const std::string& comment);
 
-  std::string getComment() const;
+  const std::string& getComment() const;
 
   void setLineNumber(int line_number);
 
@@ -8411,7 +8411,7 @@ class dbMarkerCategory : public dbObject
 
   void setDescription(const std::string& description);
 
-  std::string getDescription() const;
+  const std::string& getDescription() const;
 
   void setSource(const std::string& source);
 
@@ -8484,7 +8484,7 @@ class dbMasterEdgeType : public dbObject
 
   void setEdgeType(const std::string& edge_type);
 
-  std::string getEdgeType() const;
+  const std::string& getEdgeType() const;
 
   void setCellRow(int cell_row);
 
@@ -8541,7 +8541,7 @@ class dbMetalWidthViaMap : public dbObject
 
   void setViaName(const std::string& via_name);
 
-  std::string getViaName() const;
+  const std::string& getViaName() const;
 
   void setPgVia(bool pg_via);
 
@@ -8847,7 +8847,7 @@ class dbNetTrack : public dbObject
 class dbPolygon : public dbObject
 {
  public:
-  Polygon getPolygon() const;
+  const Polygon& getPolygon() const;
 
   int getDesignRuleWidth() const;
 
@@ -10569,7 +10569,7 @@ class dbTechLayerEolKeepOutRule : public dbObject
 
   void setClassName(const std::string& class_name);
 
-  std::string getClassName() const;
+  const std::string& getClassName() const;
 
   void setClassValid(bool class_valid);
 
@@ -10638,11 +10638,11 @@ class dbTechLayerKeepOutZoneRule : public dbObject
  public:
   void setFirstCutClass(const std::string& first_cut_class);
 
-  std::string getFirstCutClass() const;
+  const std::string& getFirstCutClass() const;
 
   void setSecondCutClass(const std::string& second_cut_class);
 
-  std::string getSecondCutClass() const;
+  const std::string& getSecondCutClass() const;
 
   void setAlignedSpacing(int aligned_spacing);
 
@@ -10710,7 +10710,7 @@ class dbTechLayerMaxSpacingRule : public dbObject
  public:
   void setCutClass(const std::string& cut_class);
 
-  std::string getCutClass() const;
+  const std::string& getCutClass() const;
 
   void setMaxSpacing(int max_spacing);
 
@@ -10733,7 +10733,7 @@ class dbTechLayerMinCutRule : public dbObject
 
   int getNumCuts() const;
 
-  std::map<std::string, int> getCutClassCutsMap() const;
+  const std::map<std::string, int>& getCutClassCutsMap() const;
 
   void setWidth(int width);
 

--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -9616,15 +9616,13 @@ class dbTechLayerAreaRule : public dbObject
 
   uint32_t getOverlap() const;
 
+  static dbTechLayerAreaRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerAreaRule* obj);
   // User Code Begin dbTechLayerAreaRule
-
-  static dbTechLayerAreaRule* create(dbTechLayer* _layer);
 
   void setTrimLayer(dbTechLayer* trim_layer);
 
   dbTechLayer* getTrimLayer() const;
-
-  static void destroy(dbTechLayerAreaRule* rule);
 
   // User Code End dbTechLayerAreaRule
 };
@@ -9666,6 +9664,8 @@ class dbTechLayerArraySpacingRule : public dbObject
 
   bool isWithinValid() const;
 
+  static dbTechLayerArraySpacingRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerArraySpacingRule* obj);
   // User Code Begin dbTechLayerArraySpacingRule
 
   void setCutsArraySpacing(int num_cuts, int spacing);
@@ -9674,13 +9674,9 @@ class dbTechLayerArraySpacingRule : public dbObject
 
   dbTechLayerCutClassRule* getCutClass() const;
 
-  static dbTechLayerArraySpacingRule* create(dbTechLayer* layer);
-
   static dbTechLayerArraySpacingRule* getTechLayerArraySpacingRule(
       dbTechLayer* inly,
       uint32_t dbid);
-
-  static void destroy(dbTechLayerArraySpacingRule* rule);
 
   // User Code End dbTechLayerArraySpacingRule
 };
@@ -9766,6 +9762,8 @@ class dbTechLayerCornerSpacingRule : public dbObject
 
   bool isCornerToCorner() const;
 
+  static dbTechLayerCornerSpacingRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerCornerSpacingRule* obj);
   // User Code Begin dbTechLayerCornerSpacingRule
   void setType(CornerType _type);
 
@@ -9777,12 +9775,9 @@ class dbTechLayerCornerSpacingRule : public dbObject
 
   void getWidthTable(std::vector<int>& tbl);
 
-  static dbTechLayerCornerSpacingRule* create(dbTechLayer* layer);
-
   static dbTechLayerCornerSpacingRule* getTechLayerCornerSpacingRule(
       dbTechLayer* inly,
       uint32_t dbid);
-  static void destroy(dbTechLayerCornerSpacingRule* rule);
   // User Code End dbTechLayerCornerSpacingRule
 };
 
@@ -10007,17 +10002,16 @@ class dbTechLayerCutEnclosureRule : public dbObject
 
   bool isConcaveCornersValid() const;
 
+  static dbTechLayerCutEnclosureRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerCutEnclosureRule* obj);
   // User Code Begin dbTechLayerCutEnclosureRule
   void setType(ENC_TYPE type);
 
   ENC_TYPE getType() const;
 
-  static dbTechLayerCutEnclosureRule* create(dbTechLayer* layer);
-
   static dbTechLayerCutEnclosureRule* getTechLayerCutEnclosureRule(
       dbTechLayer* inly,
       uint32_t dbid);
-  static void destroy(dbTechLayerCutEnclosureRule* rule);
   // User Code End dbTechLayerCutEnclosureRule
 };
 
@@ -10277,6 +10271,8 @@ class dbTechLayerCutSpacingRule : public dbObject
 
   bool isParWithinEnclosureValid() const;
 
+  static dbTechLayerCutSpacingRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerCutSpacingRule* obj);
   // User Code Begin dbTechLayerCutSpacingRule
   dbTechLayerCutClassRule* getCutClass() const;
 
@@ -10292,9 +10288,6 @@ class dbTechLayerCutSpacingRule : public dbObject
       dbTechLayer* inly,
       uint32_t dbid);
 
-  static dbTechLayerCutSpacingRule* create(dbTechLayer* _layer);
-
-  static void destroy(dbTechLayerCutSpacingRule* rule);
   // User Code End dbTechLayerCutSpacingRule
 };
 
@@ -10427,6 +10420,8 @@ class dbTechLayerCutSpacingTableDefRule : public dbObject
 
   bool isOppositeEnclosureResizeSpacingValid() const;
 
+  static dbTechLayerCutSpacingTableDefRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerCutSpacingTableDefRule* obj);
   // User Code Begin dbTechLayerCutSpacingTableDefRule
   void addPrlForAlignedCutEntry(const std::string& from, const std::string& to);
 
@@ -10487,12 +10482,9 @@ class dbTechLayerCutSpacingTableDefRule : public dbObject
 
   dbTechLayer* getTechLayer() const;
 
-  static dbTechLayerCutSpacingTableDefRule* create(dbTechLayer* parent);
-
   static dbTechLayerCutSpacingTableDefRule*
   getTechLayerCutSpacingTableDefSubRule(dbTechLayer* parent, uint32_t dbid);
 
-  static void destroy(dbTechLayerCutSpacingTableDefRule* rule);
   // User Code End dbTechLayerCutSpacingTableDefRule
 };
 
@@ -10501,15 +10493,14 @@ class dbTechLayerCutSpacingTableOrthRule : public dbObject
  public:
   void getSpacingTable(std::vector<std::pair<int, int>>& tbl) const;
 
+  static dbTechLayerCutSpacingTableOrthRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerCutSpacingTableOrthRule* obj);
   // User Code Begin dbTechLayerCutSpacingTableOrthRule
   void setSpacingTable(const std::vector<std::pair<int, int>>& tbl);
-
-  static dbTechLayerCutSpacingTableOrthRule* create(dbTechLayer* parent);
 
   static dbTechLayerCutSpacingTableOrthRule*
   getTechLayerCutSpacingTableOrthSubRule(dbTechLayer* parent, uint32_t dbid);
 
-  static void destroy(dbTechLayerCutSpacingTableOrthRule* rule);
   // User Code End dbTechLayerCutSpacingTableOrthRule
 };
 
@@ -10526,17 +10517,16 @@ class dbTechLayerEolExtensionRule : public dbObject
 
   bool isParallelOnly() const;
 
+  static dbTechLayerEolExtensionRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerEolExtensionRule* obj);
   // User Code Begin dbTechLayerEolExtensionRule
 
   void addEntry(int eol, int ext);
-
-  static dbTechLayerEolExtensionRule* create(dbTechLayer* layer);
 
   static dbTechLayerEolExtensionRule* getTechLayerEolExtensionRule(
       dbTechLayer* inly,
       uint32_t dbid);
 
-  static void destroy(dbTechLayerEolExtensionRule* rule);
   // User Code End dbTechLayerEolExtensionRule
 };
 
@@ -10583,13 +10573,13 @@ class dbTechLayerEolKeepOutRule : public dbObject
 
   bool isExceptWithin() const;
 
+  static dbTechLayerEolKeepOutRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerEolKeepOutRule* obj);
   // User Code Begin dbTechLayerEolKeepOutRule
-  static dbTechLayerEolKeepOutRule* create(dbTechLayer* layer);
 
   static dbTechLayerEolKeepOutRule* getTechLayerEolKeepOutRule(
       dbTechLayer* inly,
       uint32_t dbid);
-  static void destroy(dbTechLayerEolKeepOutRule* rule);
   // User Code End dbTechLayerEolKeepOutRule
 };
 
@@ -10696,11 +10686,9 @@ class dbTechLayerKeepOutZoneRule : public dbObject
 
   bool isExceptAlignedEnd() const;
 
+  static dbTechLayerKeepOutZoneRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerKeepOutZoneRule* obj);
   // User Code Begin dbTechLayerKeepOutZoneRule
-
-  static dbTechLayerKeepOutZoneRule* create(dbTechLayer* _layer);
-
-  static void destroy(dbTechLayerKeepOutZoneRule* rule);
 
   // User Code End dbTechLayerKeepOutZoneRule
 };
@@ -10716,12 +10704,10 @@ class dbTechLayerMaxSpacingRule : public dbObject
 
   int getMaxSpacing() const;
 
+  static dbTechLayerMaxSpacingRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerMaxSpacingRule* obj);
   // User Code Begin dbTechLayerMaxSpacingRule
   bool hasCutClass() const;
-
-  static dbTechLayerMaxSpacingRule* create(dbTechLayer* _layer);
-
-  static void destroy(dbTechLayerMaxSpacingRule* rule);
 
   // User Code End dbTechLayerMaxSpacingRule
 };
@@ -10795,16 +10781,14 @@ class dbTechLayerMinCutRule : public dbObject
 
   bool isFullyEnclosed() const;
 
+  static dbTechLayerMinCutRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerMinCutRule* obj);
   // User Code Begin dbTechLayerMinCutRule
 
   void setCutsPerCutClass(const std::string& cut_class, int num_cuts);
 
-  static dbTechLayerMinCutRule* create(dbTechLayer* layer);
-
   static dbTechLayerMinCutRule* getTechLayerMinCutRule(dbTechLayer* inly,
                                                        uint32_t dbid);
-
-  static void destroy(dbTechLayerMinCutRule* rule);
 
   // User Code End dbTechLayerMinCutRule
 };
@@ -10876,13 +10860,13 @@ class dbTechLayerMinStepRule : public dbObject
 
   bool isNoAdjacentEol() const;
 
+  static dbTechLayerMinStepRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerMinStepRule* obj);
   // User Code Begin dbTechLayerMinStepRule
-  static dbTechLayerMinStepRule* create(dbTechLayer* layer);
 
   static dbTechLayerMinStepRule* getTechLayerMinStepRule(dbTechLayer* inly,
                                                          uint32_t dbid);
 
-  static void destroy(dbTechLayerMinStepRule* rule);
   // User Code End dbTechLayerMinStepRule
 };
 
@@ -11185,14 +11169,14 @@ class dbTechLayerSpacingEolRule : public dbObject
 
   bool isToNotchLengthValid() const;
 
+  static dbTechLayerSpacingEolRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerSpacingEolRule* obj);
   // User Code Begin dbTechLayerSpacingEolRule
-  static dbTechLayerSpacingEolRule* create(dbTechLayer* layer);
 
   static dbTechLayerSpacingEolRule* getTechLayerSpacingEolRule(
       dbTechLayer* inly,
       uint32_t dbid);
 
-  static void destroy(dbTechLayerSpacingEolRule* rule);
   // User Code End dbTechLayerSpacingEolRule
 };
 
@@ -11215,14 +11199,12 @@ class dbTechLayerSpacingTablePrlRule : public dbObject
 
   bool isExceeptEol() const;
 
+  static dbTechLayerSpacingTablePrlRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerSpacingTablePrlRule* obj);
   // User Code Begin dbTechLayerSpacingTablePrlRule
   static dbTechLayerSpacingTablePrlRule* getTechLayerSpacingTablePrlRule(
       dbTechLayer* inly,
       uint32_t dbid);
-
-  static dbTechLayerSpacingTablePrlRule* create(dbTechLayer* _layer);
-
-  static void destroy(dbTechLayerSpacingTablePrlRule* rule);
 
   void setTable(const std::vector<int>& width_tbl,
                 const std::vector<int>& length_tbl,
@@ -11294,13 +11276,12 @@ class dbTechLayerVoltageSpacing : public dbObject
 
   bool isTocutBelow() const;
 
+  static dbTechLayerVoltageSpacing* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerVoltageSpacing* obj);
   // User Code Begin dbTechLayerVoltageSpacing
   const std::map<float, int>& getTable() const;
   void addEntry(float voltage, int spacing);
 
-  static dbTechLayerVoltageSpacing* create(dbTechLayer* layer);
-
-  static void destroy(dbTechLayerVoltageSpacing* rule);
   // User Code End dbTechLayerVoltageSpacing
 };
 
@@ -11358,14 +11339,14 @@ class dbTechLayerWrongDirSpacingRule : public dbObject
 
   bool isLengthValid() const;
 
+  static dbTechLayerWrongDirSpacingRule* create(dbTechLayer* parent);
+  static void destroy(dbTechLayerWrongDirSpacingRule* obj);
   // User Code Begin dbTechLayerWrongDirSpacingRule
-  static dbTechLayerWrongDirSpacingRule* create(dbTechLayer* layer);
 
   static dbTechLayerWrongDirSpacingRule* getTechLayerWrongDirSpacingRule(
       dbTechLayer* inly,
       uint32_t dbid);
 
-  static void destroy(dbTechLayerWrongDirSpacingRule* rule);
   // User Code End dbTechLayerWrongDirSpacingRule
 };
 

--- a/src/odb/src/codeGenerator/README.md
+++ b/src/odb/src/codeGenerator/README.md
@@ -1,9 +1,316 @@
-# Automatic Code Generator
+# ODB Code Generator
 
-This is an automatic code generation tool for OpenDB objects and Iterators. To test the tool you can use the following command
+This directory contains the code generator for OpenDB (`odb`) database objects.
+A large fraction of `odb`'s C++ — the public classes in `include/odb/db.h`, the
+private storage classes in `src/db/`, their serializers, comparators, memory
+accounting, and the object iterators — is generated from JSON schema files
+rather than written by hand. This document is for developers who maintain `odb`
+or the generator itself; it is **not** an end-user guide.
 
-``` shell
-python3 gen.py
+## Why a generator
+
+Every `odb` object follows the same boilerplate-heavy pattern:
+
+- a **public** class `dbFoo` (in `include/odb/db.h`) exposing getters/setters,
+- a **private** storage class `_dbFoo` (in `src/db/dbFoo.h`) holding the fields,
+- stream `operator>>` / `operator<<` for disk serialization,
+- `operator==` / `operator<` for diffing two databases,
+- `collectMemInfo()` for heap accounting,
+- constructor/destructor wiring for owned tables and `char*` strings,
+- registration in the `dbObjectType` enum and its hash maps,
+- one iterator class per parent→child table relationship.
+
+Writing this by hand is repetitive and easy to get subtly wrong (e.g. a field
+added to the struct but forgotten in the serializer, breaking on-disk
+compatibility). The generator derives all of it from a per-class description of
+the fields, so the only thing a developer writes by hand is the genuinely
+custom logic, kept in clearly marked **User Code** blocks (see
+[Section merging](#section-merging-user-code-vs-generated-code)).
+
+## Quick start
+
+```shell
+# Regenerate every odb file in place (writes into ../db and ../../include/odb):
+./generate          # wrapper for: python3 gen.py
+
+# Keep the intermediate rendered files for inspection:
+python3 gen.py --keep_generated   # leaves them in ./generated/
+
+# Preserve empty User Code blocks (see "Adding to an empty section" below):
+python3 gen.py --keep_empty
 ```
 
-Empty sections are removed by default from the output.  If you need to add someting to a section that is currently empty, you can run the generator with --keep_empty to preserve them.  Once the section is filled in, the flag can be dropped and the code regnerated to remove the remaining empty sections.
+The generator depends only on `jinja2` (CI pins `jinja2==3.1.6`) and
+`clang-format` (run on every generated C++ file). It must be run from this
+directory.
+
+> **CI invariant:** running `./generate` on a clean checkout must produce **no
+> git diff**. The workflow `.github/workflows/github-actions-are-odb-files-generated.yml`
+> fails the build otherwise. After editing any schema file, template, or the
+> generator itself, re-run `./generate` and commit the regenerated C++ alongside
+> your change.
+
+## Pipeline overview
+
+`gen.py` drives four stages:
+
+```
+load_schema()      read schema.json + every schema/**/*.json class file
+        │
+process_schema()   derive everything the templates need:
+        │            - expand relations into parent/child fields
+        │            - classify every field into a FieldType "kind"
+        │            - resolve accessor names, includes, forward decls
+        │            - pack bitfields into a flags_ struct
+        │            - compute operator==/< component lists
+        │            - assign each class a stable dbObjectType hash
+        │
+generate()         render Jinja templates into ./generated/
+        │
+_merge_files()     splice generated sections into the real source files,
+                   preserving hand-written User Code, then clang-format
+```
+
+## Files in this directory
+
+| File | Role |
+|------|------|
+| `gen.py` | Entry point and orchestration. Loads the schema, runs all the derivation passes (`process_schema`), renders templates, and merges output into the tree. |
+| `schema_models.py` | Dataclasses (`Schema`, `Class`, `Field`, `Struct`, `Enum`, `Relation`, `Iterator`) that the JSON deserializes into. `from_dict` rejects unknown keys so JSON typos fail loudly. |
+| `field_types.py` | The `FieldType` hierarchy — the single source of truth for how a field's C++ type is declared, serialized, compared, copied, and accessed. `make_field_type()` classifies a field into one kind. |
+| `helper.py` | Pure helper functions: type-string predicates (`is_ref`, `is_hash_table`, `is_set_by_ref`, …), name munging (pluralize, camel-case, table name), template-argument parsing, and the FNV-1a hash for object types. |
+| `parser.py` | The section merger. Knows how to find `Generator Code`/`User Code` regions in an existing file and splice new generated content in without losing hand-written code. |
+| `schema.json` | Top-level schema: `classes_dir`, the list of `iterators`, the list of `relations`, and `extern_enums`. |
+| `schema/**/*.json` | One file per database class (grouped into `chip/`, `tech/`, `gds/`, `scan/` subdirectories). |
+| `templates/*.jinja` | The Jinja2 templates that emit C++ / CMake. |
+| `test_*.py` | Unit tests (see [Testing](#testing)). |
+| `generate` | Thin shell wrapper: `python3 gen.py`. |
+
+## Schema format
+
+### Top-level `schema.json`
+
+```jsonc
+{
+  "classes_dir": "schema",          // directory scanned recursively for class files
+  "extern_enums": ["dbGDSSTrans"],  // enum types defined outside the generator;
+                                    //   treated as pass-by-value like other enums
+  "iterators": [ ... ],             // see "Iterators"
+  "relations": [ ... ]              // see "Relations"
+}
+```
+
+### Per-class file (`schema/**/dbFoo.json`)
+
+```jsonc
+{
+  "name": "dbAccessPoint",          // public class name; private class is _dbAccessPoint
+  "type": "dbObject",               // optional base class (default "dbObject")
+  "description": ["A line ...",     // optional doc-comment lines emitted above the
+                  "another line"],  //   public class in db.h
+  "fields": [ ... ],                // see "Fields"
+  "structs": [ ... ],               // optional nested structs (public or private)
+  "enums": [ ... ],                 // optional nested enums (public or private)
+  "h_includes":   ["dbVector.h"],   // extra headers for the generated .h
+  "cpp_includes": ["odb/dbTypes.h"],// extra headers for the generated .cpp
+  "do_not_generate_compare": false, // skip operator==/< (also drops the std::less<> in dbCompare.inc)
+  "hash": "0x1234ABCD",             // optional explicit object-type hash (default: FNV-1a of name)
+  "ostream_scope": false,           // wrap operator<< in a named dbOStreamScope
+  "assert_alignment_is_multiple_of": null  // emit a static_assert on alignof (pointer tagging)
+}
+```
+
+The set of accepted keys is exactly the dataclass fields in
+`schema_models.py`; an unknown key raises a `ValueError` naming the offending
+key. When adding a feature, add the key to the dataclass first.
+
+### Fields
+
+A field describes one member of the private `_dbFoo` storage class and the
+accessors generated for it. Common keys:
+
+| Key | Meaning |
+|-----|---------|
+| `name` | C++ member name, conventionally trailing-underscore (`point_`). The setter argument and accessor names are derived from it. |
+| `type` | C++ type string. May be a scalar, enum, `std::*`, `Point`/`Rect`/…, `dbId<_dbX>` (object reference), `dbVector<...>`, `dbHashTable<...>`, or the pseudo-type `"bit"` (→ `bool` 1-bit field). |
+| `flags` | List of behavior flags — see [Flags](#flags-reference). |
+| `bits` | Bitfield width. Fields with `bits` are packed into a generated `flags_` struct. |
+| `default` | Initializer emitted in the constructor. |
+| `parent` | For a `dbId<_dbX>` reference, the class that owns the table the id resolves against. Required for the getter to do a table lookup. |
+| `comment` / `public_comment` | Comment emitted next to the member / next to the public getter. |
+| `argument` | Override the setter's argument name (default: `name` without underscores). |
+| `setterFunctionName` / `getterFunctionName` | Override the derived accessor names (e.g. `getBPin`). |
+| `schema` | Guard serialization-in behind `isSchema(<token>)` for backward-compatible format upgrades. |
+| `table` / `page_size` / `dbSetGetter` | Set automatically for relation-generated table fields; not usually written by hand. |
+
+### Field kinds (`field_types.py`)
+
+`make_field_type()` classifies each field's `type` into exactly one `FieldType`,
+and the rest of the generator asks that object how to handle the field instead
+of re-parsing the type string. Classification precedence:
+
+| Kind | Matches | Accessor / behavior |
+|------|---------|---------------------|
+| `TableType` | a relation's owned `dbTable<_Child>*` | getter returns a `dbSet<Child>`; serialized/compared by dereference; constructed in the ctor, deleted in the dtor |
+| `RefType` | `dbId<_X>` **with** a `parent` | stores an OID; getter resolves it via the parent's owner table; setter takes `X*` |
+| `HashTableType` | `dbHashTable<_X>` | exposes a `findX(name)` getter; no setter |
+| `BoolType` | a width-1 bitfield | accessor type is `bool` (`isFoo()` getter) |
+| `VectorType` | `dbVector<...>` / `std::vector<...>` | getter is an out-parameter (`void getFoo(std::vector<...>&)`); exposed as `std::vector` |
+| `CharPtrType` | `char*` | deep-copied; getter returns `const char*`; `name_` is freed in the dtor |
+| `StringType` | `std::string` | scalar-like, but set by const ref |
+| `PairType` | `std::pair<...>` | scalar-like, but set by const ref |
+| `ScalarType` | everything else (PODs, enums, `std::` tail) | by-value getter/setter |
+
+The `Field` properties the templates read (`setterArgumentType`,
+`getterReturnType`, `member_decl`, `isSetByRef`, `refTable`, …) are all
+delegated to the field's `kind`. To change how a category of type is handled,
+edit the corresponding `FieldType` subclass rather than special-casing in the
+templates.
+
+### Flags reference
+
+| Flag | Effect |
+|------|--------|
+| `private` | No getter and no setter (implies `no-get` + `no-set`). |
+| `no-get` | Don't generate a getter. |
+| `no-set` | Don't generate a setter. |
+| `no-serial` | Exclude from `operator>>` / `operator<<`. |
+| `no-cmp` | Exclude from `operator==`. |
+| `cmpgt` | Include in `operator<` (the ordering comparison). |
+| `no-meminfo` | Exclude from generated `collectMemInfo()` accounting (handle it in the User Code block — e.g. a vector of strings that needs element-level accounting). |
+| `no-template` | Don't forward-declare the field's template arguments. |
+| `no-destruct` | Don't free a `char*` field in the destructor. |
+
+### Relations
+
+A relation declares a 1-to-many ownership: a `parent` class owns a table of
+`child` objects. From one entry the generator synthesizes, on the parent, an
+owned `dbTable<_Child>*` field with a `dbSet<Child>` getter (and, for `hash`
+relations, a `dbHashTable` plus a `next_entry_` link on the child).
+
+```jsonc
+{
+  "parent": "dbTechLayer",
+  "child":  "dbTechLayerCutClassRule",
+  "type":   "1_n",                       // only 1_n is supported
+  "tbl_name": "cut_class_rules_tbl_",     // the generated table member name
+  "hash":   true,                         // also generate a name→child hash table
+  "page_size": 1024,                      // optional dbTable page size
+  "schema": "kSchemaFoo",                 // gate serialization for format upgrades
+  "flags":  ["no-serial"],                // flags applied to the generated fields
+  "create": true,                         // generate Child::create(Parent*)
+  "destroy": true                         // generate Child::destroy(Child*)
+}
+```
+
+`create`/`destroy` emit the canonical owned-table factory methods on the child.
+Set them only when the hand-written `create`/`destroy` would do nothing more
+than allocate/free a table entry (and free properties on destroy); anything
+with extra logic must keep its hand-written versions in User Code.
+
+### Iterators
+
+Each iterator entry generates a `dbIterator` subclass that walks a parent's
+table:
+
+```jsonc
+{
+  "name": "dbModuleInstItr",
+  "parentObject": "dbInst",         // element type the iterator yields
+  "tableName": "inst_tbl",          // the table member it walks
+  "reversible": "true",
+  "orderReversed": "true",
+  "sequential": 0,
+  "customEnd": "true",              // emit a User Code end() instead of "return 0"
+  "tablePageSize": 1024,            // must match the table's page size
+  "flags": ["private"],
+  "includes": ["dbModule.h"]        // extra headers for the .cpp
+}
+```
+
+The `begin`, `next`, and (for `customEnd`) `end` bodies are left as User Code
+blocks for you to fill in — only the boilerplate around them is generated.
+
+## Generated output
+
+`generate()` renders, then `_merge_files()` writes:
+
+- **Per class:** `_dbFoo` private header and `.cpp` (`impl.h.jinja`,
+  `impl.cpp.jinja`) → `src/db/dbFoo.{h,cpp}`. The `.cpp` contains the
+  serializers (`serializer_in/out.cpp.jinja`), comparators, constructor,
+  destructor, `collectMemInfo`, and accessor definitions.
+- **Per iterator:** `dbFooItr.{h,cpp}` (`itr.h.jinja`, `itr.cpp.jinja`).
+- **Shared, schema-wide files:**
+  - `db.h.jinja` → public class declarations/definitions in `include/odb/db.h`.
+  - `dbObject.h.jinja` / `dbObject.cpp.jinja` → the `dbObjectType` enum entries
+    and the hash↔type maps.
+  - `dbCompare.inc.jinja` → deleted `std::less<dbFoo*>` specializations.
+  - `CMakeLists.txt.jinja` → the generated-source list in `src/CMakeLists.txt`.
+
+Each class is assigned a stable `dbObjectType` hash (explicit `hash` key, else
+FNV-1a of the name); a collision between two classes is a hard error.
+
+## Section merging (User Code vs generated code)
+
+Generated files are **not** wholesale-overwritten. Each managed file is divided
+into regions by paired comment markers:
+
+```cpp
+// Generator Code Begin Cpp
+   ... fully owned by the generator; replaced on every run ...
+   // User Code Begin Constructor
+      ... your hand-written code; preserved across runs ...
+   // User Code End Constructor
+// Generator Code End Cpp
+```
+
+`parser.py` (`Parser`) implements the merge:
+
+1. `parse_user_code()` — capture the current contents of every `User Code` block
+   from the existing file.
+2. `clean_code()` — strip the old generator-owned regions.
+3. `parse_source_code()` — read the freshly rendered generator regions.
+4. `write_in_file()` — splice the saved User Code back into the matching blocks
+   inside the new generated regions, then write the file.
+
+Key consequences for developers:
+
+- **Put custom logic only inside `User Code` blocks.** Anything outside them is
+  overwritten on the next `./generate`.
+- A `User Code` block whose name no longer exists in the regenerated output is a
+  **hard error** ("User tags … not used") — the generator refuses to silently
+  drop your code. If you rename/remove a field whose User Code you still need,
+  move that code first.
+- Empty `User Code` blocks are removed by default to keep files tidy. To add
+  code to a section that is currently emitted as empty, regenerate with
+  `--keep_empty`, fill in the block, then drop the flag and regenerate again.
+- `CMakeLists.txt` uses `#`-style markers; everything else uses `//`.
+- Files that don't yet exist are simply copied out; existing files are merged.
+
+## Testing
+
+```shell
+python3 -m unittest test_schema_validation   # schema typing: unknown-key rejection, bool coercion
+python3 -m unittest test_field_types          # every field in the real schema gets a valid kind
+python3 -m unittest test_generator_snapshot   # pins rendered output for one field of each kind
+```
+
+`test_field_types.py` and `test_generator_snapshot.py` load the **committed**
+schema and exercise `process_schema()` / template rendering, so they catch
+regressions in the derivation logic. The whole-tree guarantee — that
+`./generate` produces no diff — is enforced by CI, not these unit tests.
+
+## Adding a new database class — checklist
+
+1. Create `schema/<area>/dbFoo.json` with the class `name`, its `fields`, and
+   any `structs`/`enums`/includes.
+2. If the object is owned by another object, add a `relation` in `schema.json`
+   (parent → `dbFoo`). Add `create`/`destroy` if the trivial factories suffice.
+3. If clients iterate it, add an `iterator` entry in `schema.json`.
+4. Run `./generate`.
+5. Fill in the `User Code` blocks (e.g. iterator `begin`/`next`, custom
+   `create`/`destroy`, any methods declared in the `…PublicMethods` block).
+6. Re-run `./generate`, build, and run the tests. Commit the regenerated C++
+   together with the schema change so CI stays green.
+</content>
+</invoke>

--- a/src/odb/src/codeGenerator/field_types.py
+++ b/src/odb/src/codeGenerator/field_types.py
@@ -46,6 +46,7 @@ class FieldType:
     table_base_type: Optional[str] = None
 
     def __init__(self, raw: str):
+        """Construct the kind from a raw C++ type string."""
         self.raw = raw
         # Whether the setter takes the value by const reference. Set by
         # make_field_type() since the rule needs the schema's enum names.
@@ -58,10 +59,12 @@ class FieldType:
     # ---- accessor signatures (setter argument type / getter return type) ----
     @property
     def setter_arg_type(self) -> str:
+        """C++ type the setter accepts (the raw type by default)."""
         return self.raw
 
     @property
     def getter_return_type(self) -> str:
+        """C++ type the getter returns (the raw type by default)."""
         return self.raw
 
     # ---- behavior ----
@@ -74,12 +77,15 @@ class FieldType:
         return arg
 
     def serialize_deref(self) -> bool:
+        """Whether the stream operators dereference the member."""
         return False
 
     def compare_deref(self) -> bool:
+        """Whether operator==/operator< dereference the member."""
         return False
 
     def needs_free(self, field_name: str) -> bool:
+        """Whether the named member must be freed in the destructor."""
         return False
 
 
@@ -100,10 +106,12 @@ class BoolType(FieldType):
 
     @property
     def setter_arg_type(self) -> str:
+        """Bitfields are set as bool."""
         return "bool"
 
     @property
     def getter_return_type(self) -> str:
+        """Bitfields are read as bool."""
         return "bool"
 
 
@@ -114,13 +122,16 @@ class CharPtrType(FieldType):
 
     @property
     def setter_arg_type(self) -> str:
+        """Setter takes a (non-const) char*."""
         return "char *"
 
     @property
     def getter_return_type(self) -> str:
+        """Getter returns a const char*."""
         return "const char *"
 
     def needs_free(self, field_name: str) -> bool:
+        """Only name_ owns its char* storage and is freed."""
         return field_name == "name_"
 
 
@@ -129,13 +140,16 @@ class VectorType(FieldType):
 
     @property
     def setter_arg_type(self) -> str:
+        """Exposed as std::vector (dbVector is an internal alias)."""
         return self.raw.replace("dbVector", "std::vector")
 
     @property
     def getter_return_type(self) -> str:
+        """Exposed as std::vector (dbVector is an internal alias)."""
         return self.raw.replace("dbVector", "std::vector")
 
     def getter_kind(self) -> str:
+        """Vector getter fills a std::vector out-parameter."""
         return "out_param"
 
 
@@ -143,22 +157,27 @@ class RefType(FieldType):
     """dbId<_X> object reference; getter resolves via the owner table."""
 
     def __init__(self, raw: str, ref_table: Optional[str]):
+        """Capture the referenced public pointer type and owner table name."""
         super().__init__(raw)
         self.ref_type = get_ref_type(raw)
         self.ref_table = ref_table
 
     @property
     def setter_arg_type(self) -> str:
+        """Setter takes the referenced object's pointer type."""
         return self.ref_type
 
     @property
     def getter_return_type(self) -> str:
+        """Getter returns the referenced object's pointer type."""
         return self.ref_type
 
     def getter_kind(self) -> str:
+        """Ref getter looks the id up in the owner table."""
         return "ref_lookup"
 
     def setter_assign_rhs(self, arg: str) -> str:
+        """Store the referenced object's OID rather than the pointer."""
         return f"{arg}->getImpl()->getOID()"
 
 
@@ -168,21 +187,26 @@ class HashTableType(FieldType):
     is_hash_table = True
 
     def __init__(self, raw: str):
+        """Capture the hashed value's pointer type from the dbHashTable<...>."""
         super().__init__(raw)
         self.hash_table_type = get_hash_table_type(raw)
 
     def _value_type(self) -> str:
+        """The hashed value's public pointer type (e.g. dbX*)."""
         return self.hash_table_type.replace("_", "") if self.hash_table_type else ""
 
     @property
     def setter_arg_type(self) -> str:
+        """Value pointer type (hash tables have no generated setter)."""
         return self._value_type()
 
     @property
     def getter_return_type(self) -> str:
+        """find() returns the value pointer type."""
         return self._value_type()
 
     def getter_kind(self) -> str:
+        """Hash-table getter is find(name)."""
         return "hash_find"
 
 
@@ -193,6 +217,7 @@ class TableType(FieldType):
     db_set_getter = True
 
     def __init__(self, base_type: str, page_size: Optional[int]):
+        """Owned table of `base_type` children with an optional page size."""
         # base_type is the child class name (e.g. "dbInst"); the stored member
         # type is the dbTable<_Child>* form returned by member_decl().
         super().__init__(base_type)
@@ -214,12 +239,15 @@ class TableType(FieldType):
         )
 
     def getter_kind(self) -> str:
+        """Owned tables expose a dbSet<> getter."""
         return "dbset"
 
     def serialize_deref(self) -> bool:
+        """Serialized by dereferencing the owned table pointer."""
         return True
 
     def compare_deref(self) -> bool:
+        """Compared by dereferencing the owned table pointer."""
         return True
 
 

--- a/src/odb/src/codeGenerator/field_types.py
+++ b/src/odb/src/codeGenerator/field_types.py
@@ -31,6 +31,7 @@ from helper import (
     is_pass_by_ref,
     is_ref,
     is_set_by_ref,
+    mem_info_accountable,
 )
 
 
@@ -91,6 +92,10 @@ class FieldType:
     def needs_free(self, field_name: str) -> bool:
         """Whether the named member must be freed in the destructor."""
         return False
+
+    def mem_info_account(self) -> bool:
+        """Whether collectMemInfo() accounts this member via a single add()."""
+        return mem_info_accountable(self.raw)
 
 
 class ScalarType(FieldType):
@@ -251,6 +256,10 @@ class TableType(FieldType):
     def compare_deref(self) -> bool:
         """Compared by dereferencing the owned table pointer."""
         return True
+
+    def mem_info_account(self) -> bool:
+        """Owned tables recurse via collectMemInfo(), not add()."""
+        return False
 
 
 def _resolve_ref_table(ref_type: str, parent: str | None, schema) -> str | None:

--- a/src/odb/src/codeGenerator/field_types.py
+++ b/src/odb/src/codeGenerator/field_types.py
@@ -26,6 +26,7 @@ from helper import (
     get_hash_table_type,
     get_ref_type,
     get_table_name,
+    is_get_by_ref,
     is_hash_table,
     is_pass_by_ref,
     is_ref,
@@ -64,7 +65,10 @@ class FieldType:
 
     @property
     def getter_return_type(self) -> str:
-        """C++ type the getter returns (the raw type by default)."""
+        """C++ type the getter returns: const ref for non-trivially-copyable
+        aggregates, otherwise the raw type by value."""
+        if is_get_by_ref(self.raw):
+            return f"const {self.raw}&"
         return self.raw
 
     # ---- behavior ----

--- a/src/odb/src/codeGenerator/field_types.py
+++ b/src/odb/src/codeGenerator/field_types.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, The OpenROAD Authors
+
+"""Typed model of a field's C++ storage kind.
+
+`make_field_type()` classifies a field's C++ type into one of the kinds below,
+and the resulting `FieldType` answers how to declare, serialize, compare, copy,
+and accessorize the field. This keeps the type classification in one place rather
+than re-sniffing the type string at each use site.
+
+Kinds, in classification precedence:
+  TableType      owned dbTable<_Child>*  (relation parent side; dbSet<> getter)
+  RefType        dbId<_X> object reference (resolved via owner table getPtr)
+  HashTableType  dbHashTable<_X>         (find(name) getter)
+  BoolType       a width-1 bitfield      (accessor type is bool)
+  VectorType     dbVector<>/std::vector<> (out-parameter getter)
+  CharPtrType    char* / char *          (deep-copied; getter returns const char*)
+  StringType     std::string             (set by const ref)
+  PairType       std::pair<>             (set by const ref)
+  ScalarType     everything else (PODs, enums, std:: tail)
+"""
+
+from typing import Optional
+
+from helper import (
+    get_hash_table_type,
+    get_ref_type,
+    get_table_name,
+    is_hash_table,
+    is_pass_by_ref,
+    is_ref,
+    is_set_by_ref,
+)
+
+
+class FieldType:
+    """Base kind: a scalar/POD/enum/pass-through C++ type."""
+
+    is_hash_table = False
+    is_table = False
+    db_set_getter = False
+
+    ref_type: Optional[str] = None
+    ref_table: Optional[str] = None
+    hash_table_type: Optional[str] = None
+    table_base_type: Optional[str] = None
+
+    def __init__(self, raw: str):
+        self.raw = raw
+        # Whether the setter takes the value by const reference. Set by
+        # make_field_type() since the rule needs the schema's enum names.
+        self.type_set_by_ref = False
+
+    def member_decl(self) -> str:
+        """The C++ type as declared for the stored member."""
+        return self.raw
+
+    # ---- accessor signatures (setter argument type / getter return type) ----
+    @property
+    def setter_arg_type(self) -> str:
+        return self.raw
+
+    @property
+    def getter_return_type(self) -> str:
+        return self.raw
+
+    # ---- behavior ----
+    def getter_kind(self) -> str:
+        """One of: value | out_param | ref_lookup | hash_find | dbset."""
+        return "value"
+
+    def setter_assign_rhs(self, arg: str) -> str:
+        """The right-hand side stored by the setter, given the argument name."""
+        return arg
+
+    def serialize_deref(self) -> bool:
+        return False
+
+    def compare_deref(self) -> bool:
+        return False
+
+    def needs_free(self, field_name: str) -> bool:
+        return False
+
+
+class ScalarType(FieldType):
+    pass
+
+
+class StringType(ScalarType):
+    """std::string — same accessor types as a scalar, but set by const ref."""
+
+
+class PairType(ScalarType):
+    """std::pair<...> — same accessor types as a scalar, but set by const ref."""
+
+
+class BoolType(FieldType):
+    """A width-1 bitfield; its accessor type is bool."""
+
+    @property
+    def setter_arg_type(self) -> str:
+        return "bool"
+
+    @property
+    def getter_return_type(self) -> str:
+        return "bool"
+
+
+class CharPtrType(FieldType):
+    """A char pointer (char* / char *): deep-copied, getter returns const char*."""
+
+    is_char_ptr = True
+
+    @property
+    def setter_arg_type(self) -> str:
+        return "char *"
+
+    @property
+    def getter_return_type(self) -> str:
+        return "const char *"
+
+    def needs_free(self, field_name: str) -> bool:
+        return field_name == "name_"
+
+
+class VectorType(FieldType):
+    """dbVector<...> / std::vector<...> — getter is an out-parameter."""
+
+    @property
+    def setter_arg_type(self) -> str:
+        return self.raw.replace("dbVector", "std::vector")
+
+    @property
+    def getter_return_type(self) -> str:
+        return self.raw.replace("dbVector", "std::vector")
+
+    def getter_kind(self) -> str:
+        return "out_param"
+
+
+class RefType(FieldType):
+    """dbId<_X> object reference; getter resolves via the owner table."""
+
+    def __init__(self, raw: str, ref_table: Optional[str]):
+        super().__init__(raw)
+        self.ref_type = get_ref_type(raw)
+        self.ref_table = ref_table
+
+    @property
+    def setter_arg_type(self) -> str:
+        return self.ref_type
+
+    @property
+    def getter_return_type(self) -> str:
+        return self.ref_type
+
+    def getter_kind(self) -> str:
+        return "ref_lookup"
+
+    def setter_assign_rhs(self, arg: str) -> str:
+        return f"{arg}->getImpl()->getOID()"
+
+
+class HashTableType(FieldType):
+    """dbHashTable<_X>; getter is find(name)."""
+
+    is_hash_table = True
+
+    def __init__(self, raw: str):
+        super().__init__(raw)
+        self.hash_table_type = get_hash_table_type(raw)
+
+    def _value_type(self) -> str:
+        return self.hash_table_type.replace("_", "") if self.hash_table_type else ""
+
+    @property
+    def setter_arg_type(self) -> str:
+        return self._value_type()
+
+    @property
+    def getter_return_type(self) -> str:
+        return self._value_type()
+
+    def getter_kind(self) -> str:
+        return "hash_find"
+
+
+class TableType(FieldType):
+    """An owned dbTable<_Child>* (the parent side of a 1_n relation)."""
+
+    is_table = True
+    db_set_getter = True
+
+    def __init__(self, base_type: str, page_size: Optional[int]):
+        # base_type is the child class name (e.g. "dbInst"); the stored member
+        # type is the dbTable<_Child>* form returned by member_decl().
+        super().__init__(base_type)
+        self.table_base_type = base_type
+        self.page_size = page_size
+
+    def member_decl(self) -> str:
+        """The stored C++ type: dbTable<_Child[, N]>*."""
+        size = f", {self.page_size}" if self.page_size else ""
+        return f"dbTable<_{self.table_base_type}{size}>*"
+
+    def default_expr(self, klass_name: str) -> str:
+        """The constructor initializer that allocates the owned table."""
+        this_or_db = "this" if klass_name == "dbDatabase" else "db"
+        # member_decl() without the trailing '*' is the dbTable<...> type.
+        return (
+            f"new {self.member_decl()[:-1]}({this_or_db}, this, "
+            f"(GetObjTbl_t) &_{klass_name}::getObjectTable, {self.table_base_type}Obj)"
+        )
+
+    def getter_kind(self) -> str:
+        return "dbset"
+
+    def serialize_deref(self) -> bool:
+        return True
+
+    def compare_deref(self) -> bool:
+        return True
+
+
+def _resolve_ref_table(ref_type: str, parent: Optional[str], schema) -> Optional[str]:
+    """Owner table the ref getter reads from, honoring any explicit relation."""
+    child = ref_type.replace("*", "")
+    table = get_table_name(child)
+    for relation in schema.relations:
+        if relation.parent == parent and relation.child == child:
+            table = relation.tbl_name
+    return table
+
+
+def make_field_type(field, schema) -> FieldType:
+    """Classify a field into its FieldType.
+
+    Requires the 'bit' pseudo-type to be resolved first (see _normalize_bits), and
+    expects field.type to hold the child class name for a table field.
+    """
+    raw = field.type
+    if field.table:
+        kind = TableType(raw, page_size=field.page_size)
+    elif field.parent is not None and is_ref(raw):
+        ref_type = get_ref_type(raw)
+        ref_table = (
+            _resolve_ref_table(ref_type, field.parent, schema) if ref_type else None
+        )
+        kind = RefType(raw, ref_table)
+    elif is_hash_table(raw):
+        kind = HashTableType(raw)
+    elif field.bits == 1:
+        kind = BoolType(raw)
+    elif is_pass_by_ref(raw):
+        kind = VectorType(raw)
+    elif raw.replace(" ", "") == "char*":
+        kind = CharPtrType(raw)
+    elif raw == "std::string":
+        kind = StringType(raw)
+    elif raw.startswith("std::pair"):
+        kind = PairType(raw)
+    else:
+        kind = ScalarType(raw)
+
+    kind.type_set_by_ref = is_set_by_ref(raw, schema.enum_type_names)
+    return kind

--- a/src/odb/src/codeGenerator/field_types.py
+++ b/src/odb/src/codeGenerator/field_types.py
@@ -20,7 +20,7 @@ Kinds, in classification precedence:
   ScalarType     everything else (PODs, enums, std:: tail)
 """
 
-from typing import Optional
+from __future__ import annotations
 
 from helper import (
     get_hash_table_type,
@@ -40,10 +40,10 @@ class FieldType:
     is_table = False
     db_set_getter = False
 
-    ref_type: Optional[str] = None
-    ref_table: Optional[str] = None
-    hash_table_type: Optional[str] = None
-    table_base_type: Optional[str] = None
+    ref_type: str | None = None
+    ref_table: str | None = None
+    hash_table_type: str | None = None
+    table_base_type: str | None = None
 
     def __init__(self, raw: str):
         """Construct the kind from a raw C++ type string."""
@@ -118,8 +118,6 @@ class BoolType(FieldType):
 class CharPtrType(FieldType):
     """A char pointer (char* / char *): deep-copied, getter returns const char*."""
 
-    is_char_ptr = True
-
     @property
     def setter_arg_type(self) -> str:
         """Setter takes a (non-const) char*."""
@@ -156,7 +154,7 @@ class VectorType(FieldType):
 class RefType(FieldType):
     """dbId<_X> object reference; getter resolves via the owner table."""
 
-    def __init__(self, raw: str, ref_table: Optional[str]):
+    def __init__(self, raw: str, ref_table: str | None):
         """Capture the referenced public pointer type and owner table name."""
         super().__init__(raw)
         self.ref_type = get_ref_type(raw)
@@ -216,7 +214,7 @@ class TableType(FieldType):
     is_table = True
     db_set_getter = True
 
-    def __init__(self, base_type: str, page_size: Optional[int]):
+    def __init__(self, base_type: str, page_size: int | None):
         """Owned table of `base_type` children with an optional page size."""
         # base_type is the child class name (e.g. "dbInst"); the stored member
         # type is the dbTable<_Child>* form returned by member_decl().
@@ -251,7 +249,7 @@ class TableType(FieldType):
         return True
 
 
-def _resolve_ref_table(ref_type: str, parent: Optional[str], schema) -> Optional[str]:
+def _resolve_ref_table(ref_type: str, parent: str | None, schema) -> str | None:
     """Owner table the ref getter reads from, honoring any explicit relation."""
     child = ref_type.replace("*", "")
     table = get_table_name(child)

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -10,31 +10,22 @@ import re
 import shutil
 from pathlib import Path
 from subprocess import call
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader
 
 from helper import (
-    add_once_to_dict,
     components,
     fnv1a_32,
-    get_class,
     get_functional_name,
-    get_hash_table_type,
     get_plural_name,
-    get_ref_type,
-    get_table_name,
     is_bit_fields,
-    is_hash_table,
-    is_pass_by_ref,
-    is_ref,
-    is_set_by_ref,
     is_template_type,
     get_template_types,
-    std,
 )
+from field_types import ScalarType, make_field_type
 from parser import Parser
-from schema_models import Field, Enum, Struct, Class, Schema
+from schema_models import Field, Enum, Struct, Class, Relation, Schema
 
 # map types to their header if it isn't equal to their name
 STD_TYPE_HDR = {
@@ -44,67 +35,73 @@ STD_TYPE_HDR = {
 }
 
 
+def make_environment(templates_dir) -> Environment:
+    """Build the Jinja environment with the generator's custom filters."""
+    env = Environment(loader=FileSystemLoader(str(templates_dir)), trim_blocks=True)
+    # Render Python booleans as C++ literals (e.g. iterator reversible() bodies).
+    env.filters["cpp_bool"] = lambda value: "true" if value else "false"
+    return env
+
+
 def get_json_files(directory: Path) -> List[Path]:
     """Return all json files under directory recursively."""
     return list(directory.rglob("*.json"))
 
 
-def make_parent_field(parent: Class, relation: Dict[str, Any]) -> Field:
+def make_parent_field(parent: Class, relation: Relation) -> Field:
     """Adds a table field to the parent of a relationship."""
     field = Field(
-        name=relation["tbl_name"],
-        type=relation["child"],
+        name=relation.tbl_name,
+        type=relation.child,
         table=True,
         dbSetGetter=True,
-        components=[relation["tbl_name"]],
-        flags=["no-set"] + relation.get("flags", []),
+        components=[relation.tbl_name],
+        flags=["no-set"] + relation.flags,
     )
-    if "page_size" in relation:
-        field.page_size = relation["page_size"]
-    if "schema" in relation:
-        field.schema = relation["schema"]
+    if relation.page_size is not None:
+        field.page_size = relation.page_size
+    if relation.schema is not None:
+        field.schema = relation.schema
 
     parent.fields.append(field)
-    if relation["parent"] != relation["child"]:
-        parent.cpp_includes.extend([f"{relation['child']}.h", "odb/dbSet.h"])
-    logging.debug(f"Add relation field {field.name} to {relation['parent']}")
+    if relation.parent != relation.child:
+        parent.cpp_includes.extend([f"{relation.child}.h", "odb/dbSet.h"])
+    logging.debug(f"Add relation field {field.name} to {relation.parent}")
     return field
 
 
 def make_parent_hash_field(
-    parent: Class, relation: Dict[str, Any], parent_field: Field
+    parent: Class, relation: Relation, parent_field: Field
 ) -> Field:
     """Adds a hash table field to the parent of a hashed relationship."""
-    page_size_part = f", {relation['page_size']}" if "page_size" in relation else ""
+    page_size_part = f", {relation.page_size}" if relation.page_size is not None else ""
     field = Field(
         name=parent_field.name[:-4] + "hash_",
-        type=f"dbHashTable<_{relation['child']}{page_size_part}>",
+        type=f"dbHashTable<_{relation.child}{page_size_part}>",
         components=[parent_field.name[:-4] + "hash_"],
         table_name=parent_field.name,
-        flags=["no-set"] + relation.get("flags", []),
+        flags=["no-set"] + relation.flags,
     )
     parent.fields.append(field)
     if "dbHashTable.h" not in parent.h_includes:
         parent.h_includes.append("dbHashTable.h")
-    logging.debug(f"Add hash field {field.name} to {relation['parent']}")
+    logging.debug(f"Add hash field {field.name} to {relation.parent}")
     return field
 
 
-def make_child_next_field(child: Class, relation: Dict[str, Any]) -> None:
+def make_child_next_field(child: Class, relation: Relation) -> None:
     """Adds a next entry field to the child of a hashed relationship."""
     field = Field(
         name="next_entry_",
-        type=f"dbId<_{relation['child']}>",
-        flags=["private"] + relation.get("flags", []),
+        type=f"dbId<_{relation.child}>",
+        flags=["private"] + relation.flags,
     )
     child.fields.append(field)
-    logging.debug(f"Add hash field {field.name} to {relation['child']}")
+    logging.debug(f"Add hash field {field.name} to {relation.child}")
 
 
-def add_field_attributes(
-    field: Field, klass: Class, flags_struct: Struct, schema: Schema
-) -> int:
-    """Adds various derived attributes to a field."""
+def _normalize_bits(field: Field, klass: Class, flags_struct: Struct) -> int:
+    """Resolve the 'bit' pseudo-type and register bitfields. Returns bit width."""
     flag_num_bits = 0
     if field.type == "bit":
         field.type = "bool"
@@ -115,7 +112,11 @@ def add_field_attributes(
         flag_num_bits = int(field.bits)
 
     field.bitFields = is_bit_fields(field, klass.structs)
+    return flag_num_bits
 
+
+def _add_type_includes(field: Field, klass: Class) -> None:
+    """Add system headers required by the field's std/cstdint type."""
     # Handle types from <cstdint> that are also in the global namespace (eg uint32_t)
     hdr = STD_TYPE_HDR.get(field.type)
     if hdr:
@@ -128,24 +129,9 @@ def add_field_attributes(
             klass.h_sys_includes.append(hdr)
             klass.cpp_sys_includes.append(hdr)
 
-    field.isRef = is_ref(field.type) if field.parent is not None else False
-    field.refType = get_ref_type(field.type)
 
-    # refTable is the table name from which the getter extracts the pointer to dbObject
-    if field.isRef and field.refType:
-        field.refTable = get_table_name(field.refType.replace("*", ""))
-        # checking if there is a defined relation between parent and refType for extracting table name
-        for relation in schema.relations:
-            if relation["parent"] == field.parent and relation[
-                "child"
-            ] == field.refType.replace("*", ""):
-                field.refTable = relation["tbl_name"]
-
-    field.isHashTable = is_hash_table(field.type)
-    field.hashTableType = get_hash_table_type(field.type)
-    field.isPassByRef = is_pass_by_ref(field.type)
-    field.isSetByRef = "set-const-ref" in field.flags or is_set_by_ref(field.type)
-
+def _apply_argument_and_visibility(field: Field) -> None:
+    """Default the setter argument name and expand the 'private' flag."""
     if not field.argument:
         field.argument = field.name.strip("_")
 
@@ -155,13 +141,13 @@ def add_field_attributes(
         if "no-get" not in field.flags:
             field.flags.append("no-get")
 
-    # Check if a class is being used inside a template definition to add
-    # to the list of forward declared classes
+
+def _collect_forward_decls(field: Field, klass: Class) -> None:
+    """Forward-declare db classes that appear as template arguments of this field."""
     if is_template_type(field.type):
         for template_class_name in get_template_types(field.type):
             name_check = (
                 template_class_name not in klass.declared_classes
-                and template_class_name not in std
                 and not template_class_name.isdigit()
                 and template_class_name not in {"true", "false"}
                 and "no-template" not in field.flags
@@ -172,6 +158,9 @@ def add_field_attributes(
             if name_check:
                 klass.declared_classes.append(template_class_name)
 
+
+def _assign_name_and_components(field: Field, klass: Class) -> None:
+    """Derive the functional name and the comparison components for the field."""
     if field.table:
         klass.hasTables = True
         field.functional_name = get_plural_name(
@@ -191,33 +180,28 @@ def add_field_attributes(
     if not field.getterFunctionName:
         field.getterFunctionName = f"{getter_prefix}{field.functional_name}"
 
-    if field.isRef:
-        field.setterArgumentType = field.getterReturnType = field.refType
-    elif field.isHashTable:
+
+def _finalize_hash_table(field: Field) -> None:
+    """Make hash-table fields read-only and give them a find()-style getter name.
+
+    The accessor argument/return types come from the field's kind (HashTableType).
+    """
+    if field.isHashTable:
         if "no-set" not in field.flags:
             field.flags.append("no-set")
-        field.setterArgumentType = field.getterReturnType = (
-            field.hashTableType.replace("_", "") if field.hashTableType else ""
-        )
+        # setterArgumentType is e.g. "dbTechLayerCutClassRule*"; [2:-1] drops the
+        # "db" prefix and the "*" suffix to form "findTechLayerCutClassRule".
         field.getterFunctionName = (
             f"find{field.setterArgumentType[2:-1]}" if field.setterArgumentType else ""
         )
-    elif field.bits == 1:
-        field.setterArgumentType = field.getterReturnType = "bool"
-    elif field.isPassByRef:
-        field.setterArgumentType = field.getterReturnType = field.type.replace(
-            "dbVector", "std::vector"
-        )
-    elif field.type == "char *":
-        field.setterArgumentType = field.type
-        field.getterReturnType = "const char *"
-    else:
-        field.setterArgumentType = field.getterReturnType = field.type
 
-    # For fields that we need to free/destroy in the destructor
+
+def _mark_destructor_needs(field: Field, klass: Class) -> None:
+    """Flag the class for a non-default destructor when a field needs freeing."""
+    # Char-pointer name_ fields are freed in the destructor (unless opted out).
     needs_free = (
-        field.name == "name_"
-        and field.type == "char *"
+        field.kind is not None
+        and field.kind.needs_free(field.name)
         and "no-destruct" not in field.flags
     )
 
@@ -226,6 +210,27 @@ def add_field_attributes(
         if needs_free:
             klass.cpp_sys_includes.append("cstdlib")
 
+
+def add_field_attributes(
+    field: Field, klass: Class, flags_struct: Struct, schema: Schema
+) -> int:
+    """Adds various derived attributes to a field.
+
+    The helpers below are ordered: side effects (flag mutation, include and
+    forward-declaration accumulation) and derived values depend on earlier steps,
+    so the call order must be preserved.
+    """
+    flag_num_bits = _normalize_bits(field, klass, flags_struct)
+    # Classify the field into its typed kind; the storage-kind properties on Field
+    # (setterArgumentType, getterReturnType, ...) derive from it. Requires field.bits
+    # resolved by _normalize_bits and reads the table/parent inputs.
+    field.kind = make_field_type(field, schema)
+    _add_type_includes(field, klass)
+    _apply_argument_and_visibility(field)
+    _collect_forward_decls(field, klass)
+    _assign_name_and_components(field, klass)
+    _finalize_hash_table(field)
+    _mark_destructor_needs(field, klass)
     return flag_num_bits
 
 
@@ -246,41 +251,44 @@ def add_bitfield_flags(klass: Class, flag_num_bits: int, flags_struct: Struct) -
             bits=spare_bits,
             flags=["no-cmp", "no-set", "no-get", "no-serial"],
         )
+        # Padding-only member; never accessed or serialized individually.
+        spare_bits_field.kind = ScalarType("uint32_t")
         total_num_bits += spare_bits
         flags_struct.fields.append(spare_bits_field)
 
     if flags_struct.fields:
         flags_struct.in_class_name = "flags_"
         klass.structs.insert(0, flags_struct)
-        klass.fields.insert(
-            0,
-            Field(
-                name="flags_",
-                type=flags_struct.name,
-                components=components(klass.structs, "flags_", flags_struct.name),
-                bitFields=True,
-                numBits=total_num_bits,
-                flags=["no-cmp", "no-set", "no-get", "no-serial"],
-            ),
+        flags_field = Field(
+            name="flags_",
+            type=flags_struct.name,
+            components=components(klass.structs, "flags_", flags_struct.name),
+            bitFields=True,
+            numBits=total_num_bits,
+            flags=["no-cmp", "no-set", "no-get", "no-serial"],
         )
+        # The aggregate flags struct is a plain stored member (no accessors); it is
+        # handled by the bitFields branches in the templates.
+        flags_field.kind = ScalarType(flags_struct.name)
+        klass.fields.insert(0, flags_field)
 
 
 def generate_relations(schema: Schema) -> None:
     """Generate the parent and child fields for all relationships."""
     for relation in schema.relations:
-        if relation["type"] != "1_n":
+        if relation.type != "1_n":
             raise KeyError("relation type is not supported, use 1_n")
 
-        parent = next(c for c in schema.classes if c.name == relation["parent"])
-        child = next(c for c in schema.classes if c.name == relation["child"])
+        parent = next(c for c in schema.classes if c.name == relation.parent)
+        child = next(c for c in schema.classes if c.name == relation.child)
 
         parent_field = make_parent_field(parent, relation)
-        child_type_name = f"_{relation['child']}"
+        child_type_name = f"_{relation.child}"
 
         if child_type_name not in parent.declared_classes:
             parent.declared_classes.append(child_type_name)
 
-        if relation.get("hash", False):
+        if relation.hash:
             make_parent_hash_field(parent, relation, parent_field)
             make_child_next_field(child, relation)
 
@@ -324,16 +332,12 @@ def preprocess_klass(klass: Class) -> None:
     add_include(klass, "dbObjectType", "odb/dbObject.h", cpp=True)
     add_include(klass, "tuple", "tuple", cpp=True, sys=True)
 
+    # Owned tables are constructed in the class constructor. The member type and
+    # table_base_type come from the field's TableType kind (field.member_decl /
+    # field.table_base_type); here we set the constructor initializer.
     for field in klass.fields:
         if field.table:
-            page_size_part = f", {field.page_size}" if field.page_size else ""
-            this_or_db = "this" if klass.name == "dbDatabase" else "db"
-            field.default = (
-                f"new dbTable<_{field.type}{page_size_part}>({this_or_db}, this, "
-                f"(GetObjTbl_t) &_{klass.name}::getObjectTable, {field.type}Obj)"
-            )
-            field.table_base_type = field.type
-            field.type = f"dbTable<_{field.type}{page_size_part}>*"
+            field.default = field.kind.default_expr(klass.name)
 
 
 class ODBGenerator:
@@ -364,6 +368,12 @@ class ODBGenerator:
     def process_schema(self, schema: Schema) -> None:
         generate_relations(schema)
 
+        # All enum type names (schema-declared + external) used to keep enums
+        # passed by value in is_set_by_ref().
+        schema.enum_type_names = set(schema.extern_enums) | {
+            e.name for klass in schema.classes for e in klass.enums
+        }
+
         hash_dict = {}
         for klass in schema.classes:
             flags_struct = Struct(
@@ -376,6 +386,13 @@ class ODBGenerator:
             )
 
             add_bitfield_flags(klass, flag_num_bits, flags_struct)
+
+            # Struct members (e.g. JSON-defined public structs) also need a kind so
+            # the templates can query it uniformly; they are never tables.
+            for struct in klass.structs:
+                for field in struct.fields:
+                    if field.kind is None:
+                        field.kind = make_field_type(field, schema)
 
             if any(s.public for s in klass.structs):
                 if "odb/db.h" not in klass.h_includes:
@@ -423,7 +440,7 @@ class ODBGenerator:
             else:
                 if "no-cmp" not in field.flags:
                     for comp in field.components:
-                        deref = "*" if field.table else ""
+                        deref = "*" if field.kind.compare_deref() else ""
                         klass.equal_fields.append(
                             {"left": f"{deref}{comp}", "right": f"{deref}rhs.{comp}"}
                         )
@@ -466,7 +483,7 @@ class ODBGenerator:
         for itr in schema.iterators:
             for template_base in ["itr.h", "itr.cpp"]:
                 template_file = f"{template_base}.jinja"
-                out_name = f"{itr['name']}.{template_base.split('.')[1]}"
+                out_name = f"{itr.name}.{template_base.split('.')[1]}"
                 self._render_to_file(template_file, out_name, itr=itr, schema=schema)
                 to_be_merged.append(out_name)
 
@@ -535,7 +552,7 @@ def main():
         shutil.rmtree(generated_dir)
     generated_dir.mkdir()
 
-    env = Environment(loader=FileSystemLoader(args.templates), trim_blocks=True)
+    env = make_environment(args.templates)
     generator = ODBGenerator(
         env, Path(args.include_dir), Path(args.src_dir), args.keep_empty
     )

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -3,14 +3,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021-2025, The OpenROAD Authors
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import re
 import shutil
+import subprocess
 from pathlib import Path
-from subprocess import call
-from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -43,7 +44,7 @@ def make_environment(templates_dir) -> Environment:
     return env
 
 
-def get_json_files(directory: Path) -> List[Path]:
+def get_json_files(directory: Path) -> list[Path]:
     """Return all json files under directory recursively."""
     return list(directory.rglob("*.json"))
 
@@ -353,17 +354,15 @@ class ODBGenerator:
 
     def load_schema(self, json_path: Path) -> Schema:
         """Load the top-level schema JSON and every per-class JSON it points to."""
-        with open(json_path, encoding="ascii") as f:
-            data = json.load(f)
+        data = json.loads(json_path.read_text(encoding="ascii"))
 
         schema = Schema.from_dict(data)
 
         classes_dir = Path(schema.classes_dir)
         for file_path in get_json_files(classes_dir):
-            with open(file_path, encoding="ascii") as f:
-                klass_data = json.load(f)
-                klass = Class.from_dict(klass_data)
-                schema.classes.append(klass)
+            klass_data = json.loads(file_path.read_text(encoding="ascii"))
+            klass = Class.from_dict(klass_data)
+            schema.classes.append(klass)
 
         return schema
 
@@ -507,10 +506,9 @@ class ODBGenerator:
         """Render a template and write it to out_name in the generated dir."""
         template = self.env.get_template(template_name)
         text = template.render(**kwargs)
-        with open(self.generated_dir / out_name, "w", encoding="ascii") as f:
-            f.write(text)
+        (self.generated_dir / out_name).write_text(text, encoding="ascii")
 
-    def _merge_files(self, file_names: List[str]) -> None:
+    def _merge_files(self, file_names: list[str]) -> None:
         """Merge generated sections into the target files, preserving user code,
         then run clang-format."""
         includes = {"db.h", "dbObject.h", "dbCompare.inc"}
@@ -531,7 +529,10 @@ class ODBGenerator:
                 shutil.copy(gen_path, target_path)
 
             if item != "CMakeLists.txt":
-                if call(["clang-format", "-i", str(target_path)]) != 0:
+                if (
+                    subprocess.run(["clang-format", "-i", str(target_path)]).returncode
+                    != 0
+                ):
                     print(f"Failed to format {target_path}")
             print(f"Generated: {target_path}")
 

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -344,6 +344,7 @@ class ODBGenerator:
     def __init__(
         self, env: Environment, include_dir: Path, src_dir: Path, keep_empty: bool
     ):
+        """Hold the Jinja env, output directories, and the keep_empty flag."""
         self.env = env
         self.include_dir = include_dir
         self.src_dir = src_dir
@@ -351,6 +352,7 @@ class ODBGenerator:
         self.generated_dir = Path("generated")
 
     def load_schema(self, json_path: Path) -> Schema:
+        """Load the top-level schema JSON and every per-class JSON it points to."""
         with open(json_path, encoding="ascii") as f:
             data = json.load(f)
 
@@ -366,6 +368,7 @@ class ODBGenerator:
         return schema
 
     def process_schema(self, schema: Schema) -> None:
+        """Derive all generated attributes on the schema's classes and fields."""
         generate_relations(schema)
 
         # All enum type names (schema-declared + external) used to keep enums
@@ -451,6 +454,7 @@ class ODBGenerator:
                         )
 
     def generate(self, schema: Schema) -> None:
+        """Render all class, iterator, and shared files, then merge and format."""
         print("###################Code Generation Begin###################")
         self.process_schema(schema)
 
@@ -500,12 +504,15 @@ class ODBGenerator:
         print("###################Code Generation End###################")
 
     def _render_to_file(self, template_name: str, out_name: str, **kwargs) -> None:
+        """Render a template and write it to out_name in the generated dir."""
         template = self.env.get_template(template_name)
         text = template.render(**kwargs)
         with open(self.generated_dir / out_name, "w", encoding="ascii") as f:
             f.write(text)
 
     def _merge_files(self, file_names: List[str]) -> None:
+        """Merge generated sections into the target files, preserving user code,
+        then run clang-format."""
         includes = {"db.h", "dbObject.h", "dbCompare.inc"}
         for item in file_names:
             target_dir = self.include_dir if item in includes else self.src_dir
@@ -530,6 +537,7 @@ class ODBGenerator:
 
 
 def main():
+    """Parse CLI args, load the schema, and run code generation."""
     parser = argparse.ArgumentParser(
         description="Code generator",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -293,6 +293,18 @@ def generate_relations(schema: Schema) -> None:
             make_parent_hash_field(parent, relation, parent_field)
             make_child_next_field(child, relation)
 
+        if relation.create or relation.destroy:
+            child.factory_parent = relation.parent
+            child.factory_table = relation.tbl_name
+            child.gen_create = relation.create
+            child.gen_destroy = relation.destroy
+            # create()/destroy() cast to the parent's internal type.
+            if f"{relation.parent}.h" not in child.cpp_includes:
+                child.cpp_includes.append(f"{relation.parent}.h")
+            # destroy() frees the entry's properties.
+            if relation.destroy and "dbProperty.h" not in child.cpp_includes:
+                child.cpp_includes.append("dbProperty.h")
+
 
 def add_include(
     klass: Class, key: str, include: str, cpp: bool = False, sys: bool = False

--- a/src/odb/src/codeGenerator/gen.py
+++ b/src/odb/src/codeGenerator/gen.py
@@ -174,6 +174,17 @@ def _assign_name_and_components(field: Field, klass: Class) -> None:
         field.functional_name = get_functional_name(field.name)
         field.components = components(klass.structs, field.name, field.type)
 
+    # A field flagged for ordering must resolve to at least one comparison
+    # component; otherwise its operator< term is silently dropped (see the
+    # dbAccessType::Value regression that motivated treating enums as leaves).
+    if "cmpgt" in field.flags and not field.components:
+        raise ValueError(
+            f"{klass.name}.{field.name} ({field.type}) is flagged 'cmpgt' but "
+            f"resolves to no comparison components; its operator< term would be "
+            f"silently dropped. Make the type a comparison leaf in "
+            f"helper.components() (see is_enum/_comparable)."
+        )
+
     if not field.setterFunctionName:
         field.setterFunctionName = f"set{field.functional_name}"
 

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -193,9 +193,7 @@ def is_set_by_ref(type_name: str, enum_names) -> bool:
         return False
     if type_name in enum_names:
         return False
-    # A bare scoped enum (e.g. "dbAccessType::Value"): has "::" but is neither a
-    # std:: type nor a template (those are aggregates passed by const ref).
-    if "::" in type_name and "<" not in type_name and not type_name.startswith("std::"):
+    if is_enum(type_name):
         return False
     return True
 

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -217,6 +217,36 @@ def is_get_by_ref(type_name: str) -> bool:
     return type_name.startswith(_GET_BY_REF_PREFIXES)
 
 
+# Type prefixes for which MemInfo::add() has an overload that accounts the
+# member's heap allocation in collectMemInfo(). Scalars, dbId, std::pair,
+# std::array, std::tuple, and the value structs have no overload (no heap to
+# account) and are skipped.
+_MEM_INFO_PREFIXES = (
+    "dbVector",
+    "std::vector",
+    "dbHashTable",
+    "dbIntHashTable",
+    "std::map",
+    "std::unordered_map",
+    "boost::container::flat_map",
+    "std::set",
+)
+
+
+def mem_info_accountable(type_name: str) -> bool:
+    """Whether collectMemInfo() accounts this member via a single add() call.
+
+    True for the heap-backed types MemInfo::add() overloads accept (std::string,
+    vectors, hash tables, maps, sets). Members whose elements themselves own heap
+    storage (e.g. a vector of strings, or a map of matrices) need element-level
+    accounting and opt out with the 'no-meminfo' flag, keeping that logic in the
+    collectMemInfo User Code block.
+    """
+    if type_name == "std::string":
+        return True
+    return type_name.startswith(_MEM_INFO_PREFIXES)
+
+
 def is_template_type(type_name: str) -> bool:
     """Whether the type has a <...> template argument list."""
     open_bracket = type_name.find("<")

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -189,6 +189,34 @@ def is_set_by_ref(type_name: str, enum_names) -> bool:
     return True
 
 
+# Heap std:: container prefixes whose value getter returns a const reference.
+# std::vector is excluded (it uses an out-parameter getter); std::array/pair are
+# trivially copyable when their elements are, so they are returned by value.
+_GET_BY_REF_PREFIXES = (
+    "std::map",
+    "std::multimap",
+    "std::unordered_map",
+    "std::set",
+    "std::multiset",
+    "std::unordered_set",
+    "std::list",
+    "std::deque",
+)
+
+
+def is_get_by_ref(type_name: str) -> bool:
+    """Whether a value getter returns a const reference rather than by value.
+
+    True for non-trivially-copyable value types: std::string, heap std::
+    containers, and Polygon (an odb geometry type holding a std::vector). Small
+    value structs (Point/Rect/Line/...) and trivially-copyable scalars/enums are
+    returned by value.
+    """
+    if type_name in ("std::string", "Polygon"):
+        return True
+    return type_name.startswith(_GET_BY_REF_PREFIXES)
+
+
 def is_template_type(type_name: str) -> bool:
     """Whether the type has a <...> template argument list."""
     open_bracket = type_name.find("<")

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -80,13 +80,24 @@ def _get_struct(name: str, structs: list[Struct]) -> Struct | None:
     return None
 
 
+def is_enum(type_name: str) -> bool:
+    """Whether the type is an odb-style scoped enum ("Foo::Value").
+
+    Such enums are comparison leaves: they support == and < directly and are
+    decomposed no further. Other scoped names (e.g. nested structs like
+    "dbPowerSwitch::UPFControlPort") are intentionally excluded -- only the
+    "::Value" convention used for odb enums is treated as a leaf.
+    """
+    return type_name.endswith("::Value")
+
+
 def components(structs: list[Struct], name: str, _type: str) -> list[str]:
     """Expand a field into its comparison sub-components.
 
-    A leaf/ref type yields itself; a struct type recurses into its members;
+    A leaf/ref/enum type yields itself; a struct type recurses into its members;
     anything else yields nothing (not compared).
     """
-    if _stem(_type) in _comparable or is_ref(_type):
+    if _stem(_type) in _comparable or is_ref(_type) or is_enum(_type):
         return [name]
     struct = _get_struct(_type.rstrip(" *"), structs)
     if struct is not None:

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -66,10 +66,12 @@ _removable = {"const", "static", "unsigned"}
 
 
 def _stem(s: str) -> str:
+    """Strip cv/`unsigned`/`static` qualifiers from a type string."""
     return " ".join(item for item in s.split() if item not in _removable)
 
 
 def _get_struct(name: str, structs: List[Struct]) -> Optional[Struct]:
+    """Return the Struct named `name` from `structs`, or None if absent."""
     for struct in structs:
         if struct.name == name:
             return struct
@@ -77,6 +79,11 @@ def _get_struct(name: str, structs: List[Struct]) -> Optional[Struct]:
 
 
 def components(structs: List[Struct], name: str, _type: str) -> List[str]:
+    """Expand a field into its comparison sub-components.
+
+    A leaf/ref type yields itself; a struct type recurses into its members;
+    anything else yields nothing (not compared).
+    """
     if _stem(_type) in _comparable or is_ref(_type):
         return [name]
     struct = _get_struct(_type.rstrip(" *"), structs)
@@ -92,6 +99,7 @@ def components(structs: List[Struct], name: str, _type: str) -> List[str]:
 
 
 def is_bit_fields(field: Field, structs: List[Struct]) -> bool:
+    """Whether the field (or any nested struct member) is a bitfield."""
     if field.bits:
         return True
     struct = _get_struct(field.type, structs)
@@ -101,6 +109,7 @@ def is_bit_fields(field: Field, structs: List[Struct]) -> bool:
 
 
 def get_plural_name(name: str) -> str:
+    """Pluralize a name (handles trailing 'y' and 's')."""
     if name.endswith("y"):
         return f"{name[:-1]}ies"
     if name.endswith("s"):
@@ -109,12 +118,14 @@ def get_plural_name(name: str) -> str:
 
 
 def get_functional_name(name: str) -> str:
+    """CamelCase accessor stem from a snake_case field name (tbl -> table)."""
     if name.islower():
         return "".join(n.capitalize() for n in name.replace("tbl", "table").split("_"))
     return name
 
 
 def get_table_name(name: str) -> str:
+    """Table member name for a db class (e.g. dbInst -> inst_tbl_)."""
     if name.startswith("db"):
         name = name[2:]
     return f"{name.lower()}_tbl_"
@@ -130,14 +141,17 @@ _DBHASHTABLE_PREFIX = "dbHashTable<"
 
 
 def is_ref(type_name: str) -> bool:
+    """Whether the type is a dbId<...> object reference."""
     return type_name.startswith("dbId<") and type_name.endswith(">")
 
 
 def is_hash_table(type_name: str) -> bool:
+    """Whether the type is a dbHashTable<...>."""
     return type_name.startswith("dbHashTable<") and type_name.endswith(">")
 
 
 def get_hash_table_type(type_name: str) -> Optional[str]:
+    """Value pointer type of a dbHashTable<_dbX[, N]> (e.g. dbX*), or None."""
     if not is_hash_table(type_name) or len(type_name) < 13:
         return None
     types = get_template_types(type_name[len(_DBHASHTABLE_PREFIX) : -1])
@@ -148,6 +162,7 @@ def get_hash_table_type(type_name: str) -> Optional[str]:
 
 
 def is_pass_by_ref(type_name: str) -> bool:
+    """Whether the type is a dbVector<...> or std::vector<...>."""
     return type_name.startswith(("dbVector", "std::vector"))
 
 
@@ -173,6 +188,7 @@ def is_set_by_ref(type_name: str, enum_names) -> bool:
 
 
 def is_template_type(type_name: str) -> bool:
+    """Whether the type has a <...> template argument list."""
     open_bracket = type_name.find("<")
     if open_bracket == -1:
         return False
@@ -198,6 +214,7 @@ def _split_top_level_commas(type_name: str) -> List[str]:
 
 
 def get_template_types(type_name: str) -> List[str]:
+    """Flatten a type into its constituent template argument type names."""
     # Check for top-level commas first (bracket-aware)
     parts = _split_top_level_commas(type_name)
     if len(parts) > 1:
@@ -214,6 +231,7 @@ def get_template_types(type_name: str) -> List[str]:
 
 
 def get_template_type(type_name: str) -> Optional[str]:
+    """The substring inside the outer <...> of a template type, or None."""
     if not is_template_type(type_name):
         return None
     num_brackets = 0
@@ -229,12 +247,14 @@ def get_template_type(type_name: str) -> Optional[str]:
 
 
 def get_ref_type(type_name: str) -> Optional[str]:
+    """Public pointer type for a dbId<_dbX> reference (e.g. dbX*), or None."""
     if not is_ref(type_name) or len(type_name) < 7:
         return None
     return f"{type_name[len(_DBID_PUBLIC_PREFIX) : -1]}*"
 
 
 def fnv1a_32(string: str) -> int:
+    """FNV-1a 32-bit hash of a string (used for stable dbObjectType hashes)."""
     FNV_prime = 0x01000193
     hash_value = 0x811C9DC5
     for c in string:

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021-2025, The OpenROAD Authors
 
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional
 import re
-from schema_models import Field, Struct, Class, Schema
+from schema_models import Field, Struct
 
-_comparable = {
-    "Point",
-    "Point3D",
-    "Rect",
-    "Polygon",
-    "Line",
+# Atomic leaf types: in components() these compare as a whole rather than being
+# decomposed into struct members. Includes scalars plus std::string and char*.
+_LEAF_TYPES = {
     "bool",
     "char *",
     "char",
-    "char*",
     "double",
     "float",
     "int",
@@ -25,29 +21,45 @@ _comparable = {
     "short",
     "int16_t",
     "std::string",
-    "string",
     "uint32_t",
     "uint8_t",
 }
 
-std = {
+# Value structs that are comparison leaves in components() but are not scalars.
+_VALUE_TYPES = {"Point", "Point3D", "Rect", "Polygon", "Line"}
+
+# Types treated as a single comparison leaf by components() (leaf types + value
+# structs); used in helper.py:components().
+_comparable = _LEAF_TYPES | _VALUE_TYPES
+
+# C++ fundamental / cstdint scalar types that are cheap to pass by value; used by
+# is_set_by_ref(). std::string is intentionally excluded (it is passed by ref).
+_BY_VALUE_SCALARS = {
     "bool",
-    "char *",
     "char",
-    "char*",
-    "double",
-    "float",
-    "int",
-    "int8_t",
-    "long double",
-    "long long",
-    "long",
+    "signed char",
+    "unsigned char",
     "short",
+    "unsigned short",
+    "int",
+    "unsigned",
+    "unsigned int",
+    "long",
+    "unsigned long",
+    "long long",
+    "unsigned long long",
+    "float",
+    "double",
+    "long double",
+    "int8_t",
     "int16_t",
-    "std::string",
-    "string",
-    "uint32_t",
+    "int32_t",
+    "int64_t",
     "uint8_t",
+    "uint16_t",
+    "uint32_t",
+    "uint64_t",
+    "size_t",
 }
 
 _removable = {"const", "static", "unsigned"}
@@ -79,15 +91,6 @@ def components(structs: List[Struct], name: str, _type: str) -> List[str]:
     return []
 
 
-def add_once_to_dict(src: List[str], target: Union[Dict[str, Any], Class]) -> None:
-    for obj in src:
-        if isinstance(target, dict):
-            target.setdefault(obj, [])
-        else:
-            if not getattr(target, obj, None):
-                setattr(target, obj, [])
-
-
 def is_bit_fields(field: Field, structs: List[Struct]) -> bool:
     if field.bits:
         return True
@@ -111,17 +114,19 @@ def get_functional_name(name: str) -> str:
     return name
 
 
-def get_class(schema: Schema, name: str) -> Class:
-    for klass in schema.classes:
-        if klass.name == name:
-            return klass
-    raise NameError(f"Class {name} in relations is not found")
-
-
 def get_table_name(name: str) -> str:
     if name.startswith("db"):
         name = name[2:]
     return f"{name.lower()}_tbl_"
+
+
+# get_ref_type() turns "dbId<_dbModule>" into the public pointer type "dbModule*"
+# by dropping this 6-char prefix (note the trailing "_": the private storage class
+# is "_dbModule" but the public type is "dbModule") and the closing ">".
+_DBID_PUBLIC_PREFIX = "dbId<_"
+
+# get_hash_table_type() strips this prefix off "dbHashTable<_dbX[, N]>".
+_DBHASHTABLE_PREFIX = "dbHashTable<"
 
 
 def is_ref(type_name: str) -> bool:
@@ -135,7 +140,7 @@ def is_hash_table(type_name: str) -> bool:
 def get_hash_table_type(type_name: str) -> Optional[str]:
     if not is_hash_table(type_name) or len(type_name) < 13:
         return None
-    types = get_template_types(type_name[12:-1])
+    types = get_template_types(type_name[len(_DBHASHTABLE_PREFIX) : -1])
     for t in types:
         if "db" in t:
             return f"{t}*"
@@ -146,12 +151,25 @@ def is_pass_by_ref(type_name: str) -> bool:
     return type_name.startswith(("dbVector", "std::vector"))
 
 
-def is_set_by_ref(type_name: str) -> bool:
-    return (
-        type_name == "std::string"
-        or type_name.startswith("std::pair")
-        or type_name.startswith("std::vector")
-    )
+def is_set_by_ref(type_name: str, enum_names) -> bool:
+    """Whether a setter takes the value by const reference rather than by value.
+
+    Trivially-copyable types are passed by value: fundamental scalars, pointers
+    and handles (char*, dbId<>, dbHashTable<>), and enums (scoped "X::Value" or
+    registered in enum_names). Everything else -- std::string, std:: containers,
+    dbVector, geometry/value structs, any class type -- is passed by const ref.
+    """
+    if type_name in _BY_VALUE_SCALARS:
+        return False
+    if type_name.endswith("*") or type_name.startswith(("dbId<", "dbHashTable<")):
+        return False
+    if type_name in enum_names:
+        return False
+    # A bare scoped enum (e.g. "dbAccessType::Value"): has "::" but is neither a
+    # std:: type nor a template (those are aggregates passed by const ref).
+    if "::" in type_name and "<" not in type_name and not type_name.startswith("std::"):
+        return False
+    return True
 
 
 def is_template_type(type_name: str) -> bool:
@@ -213,7 +231,7 @@ def get_template_type(type_name: str) -> Optional[str]:
 def get_ref_type(type_name: str) -> Optional[str]:
     if not is_ref(type_name) or len(type_name) < 7:
         return None
-    return f"{type_name[6:-1]}*"
+    return f"{type_name[len(_DBID_PUBLIC_PREFIX) : -1]}*"
 
 
 def fnv1a_32(string: str) -> int:

--- a/src/odb/src/codeGenerator/helper.py
+++ b/src/odb/src/codeGenerator/helper.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021-2025, The OpenROAD Authors
 
-from typing import List, Optional
+from __future__ import annotations
+
 import re
+
 from schema_models import Field, Struct
 
 # Atomic leaf types: in components() these compare as a whole rather than being
@@ -70,7 +72,7 @@ def _stem(s: str) -> str:
     return " ".join(item for item in s.split() if item not in _removable)
 
 
-def _get_struct(name: str, structs: List[Struct]) -> Optional[Struct]:
+def _get_struct(name: str, structs: list[Struct]) -> Struct | None:
     """Return the Struct named `name` from `structs`, or None if absent."""
     for struct in structs:
         if struct.name == name:
@@ -78,7 +80,7 @@ def _get_struct(name: str, structs: List[Struct]) -> Optional[Struct]:
     return None
 
 
-def components(structs: List[Struct], name: str, _type: str) -> List[str]:
+def components(structs: list[Struct], name: str, _type: str) -> list[str]:
     """Expand a field into its comparison sub-components.
 
     A leaf/ref type yields itself; a struct type recurses into its members;
@@ -98,7 +100,7 @@ def components(structs: List[Struct], name: str, _type: str) -> List[str]:
     return []
 
 
-def is_bit_fields(field: Field, structs: List[Struct]) -> bool:
+def is_bit_fields(field: Field, structs: list[Struct]) -> bool:
     """Whether the field (or any nested struct member) is a bitfield."""
     if field.bits:
         return True
@@ -150,7 +152,7 @@ def is_hash_table(type_name: str) -> bool:
     return type_name.startswith("dbHashTable<") and type_name.endswith(">")
 
 
-def get_hash_table_type(type_name: str) -> Optional[str]:
+def get_hash_table_type(type_name: str) -> str | None:
     """Value pointer type of a dbHashTable<_dbX[, N]> (e.g. dbX*), or None."""
     if not is_hash_table(type_name) or len(type_name) < 13:
         return None
@@ -196,7 +198,7 @@ def is_template_type(type_name: str) -> bool:
     return closed_bracket >= open_bracket
 
 
-def _split_top_level_commas(type_name: str) -> List[str]:
+def _split_top_level_commas(type_name: str) -> list[str]:
     """Split by commas at angle-bracket depth 0."""
     parts = []
     depth = 0
@@ -213,7 +215,7 @@ def _split_top_level_commas(type_name: str) -> List[str]:
     return [p for p in parts if p]
 
 
-def get_template_types(type_name: str) -> List[str]:
+def get_template_types(type_name: str) -> list[str]:
     """Flatten a type into its constituent template argument type names."""
     # Check for top-level commas first (bracket-aware)
     parts = _split_top_level_commas(type_name)
@@ -230,7 +232,7 @@ def get_template_types(type_name: str) -> List[str]:
     return [type_name]
 
 
-def get_template_type(type_name: str) -> Optional[str]:
+def get_template_type(type_name: str) -> str | None:
     """The substring inside the outer <...> of a template type, or None."""
     if not is_template_type(type_name):
         return None
@@ -246,7 +248,7 @@ def get_template_type(type_name: str) -> Optional[str]:
     return None
 
 
-def get_ref_type(type_name: str) -> Optional[str]:
+def get_ref_type(type_name: str) -> str | None:
     """Public pointer type for a dbId<_dbX> reference (e.g. dbX*), or None."""
     if not is_ref(type_name) or len(type_name) < 7:
         return None

--- a/src/odb/src/codeGenerator/parser.py
+++ b/src/odb/src/codeGenerator/parser.py
@@ -55,6 +55,7 @@ class Parser:
     """Parses a file looking for the sections delimited by the code_tags."""
 
     def __init__(self, file_name: str):
+        """Read `file_name` into lines and default to // section comments."""
         with open(file_name, "r", encoding="ascii") as file:
             self.lines = file.readlines()
         self.generator_code: Dict[str, List[str]] = {}

--- a/src/odb/src/codeGenerator/parser.py
+++ b/src/odb/src/codeGenerator/parser.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021-2025, The OpenROAD Authors
 
+from __future__ import annotations
+
 import re
-from typing import List, Dict, Optional
 
 
-def _find_index(lines: List[str], target: str, start_index: int = 0) -> int:
+def _find_index(lines: list[str], target: str, start_index: int = 0) -> int:
     """Find the index of target in lines[start_index:] ignoring white space"""
     for i in range(start_index, len(lines)):
         if lines[i].strip().replace(" ", "") == target:
@@ -14,9 +15,9 @@ def _find_index(lines: List[str], target: str, start_index: int = 0) -> int:
 
 
 def _get_sections(
-    lines: List[str],
+    lines: list[str],
     tag: str,
-    sections: Optional[Dict[str, List[str]]] = None,
+    sections: dict[str, list[str]] | None = None,
     remove: bool = False,
 ) -> None:
     """Find all sections delimeted by begin/end tags in lines.
@@ -58,8 +59,8 @@ class Parser:
         """Read `file_name` into lines and default to // section comments."""
         with open(file_name, "r", encoding="ascii") as file:
             self.lines = file.readlines()
-        self.generator_code: Dict[str, List[str]] = {}
-        self.user_code: Dict[str, List[str]] = {}
+        self.generator_code: dict[str, list[str]] = {}
+        self.user_code: dict[str, list[str]] = {}
         self.set_comment_str("//")
 
     def set_comment_str(self, comment: str) -> None:

--- a/src/odb/src/codeGenerator/schema.json
+++ b/src/odb/src/codeGenerator/schema.json
@@ -223,74 +223,98 @@
       "parent":"dbTechLayer",
       "child":"dbTechLayerSpacingEolRule",
       "type":"1_n",
-      "tbl_name":"spacing_eol_rules_tbl_"
+      "tbl_name":"spacing_eol_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerCutSpacingRule",
       "type":"1_n",
-      "tbl_name":"cut_spacing_rules_tbl_"
+      "tbl_name":"cut_spacing_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerMinStepRule",
       "type":"1_n",
-      "tbl_name":"minstep_rules_tbl_"
+      "tbl_name":"minstep_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerCornerSpacingRule",
       "type":"1_n",
-      "tbl_name":"corner_spacing_rules_tbl_"
+      "tbl_name":"corner_spacing_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerSpacingTablePrlRule",
       "type":"1_n",
-      "tbl_name":"spacing_table_prl_rules_tbl_"
+      "tbl_name":"spacing_table_prl_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerCutSpacingTableOrthRule",
       "type":"1_n",
-      "tbl_name":"cut_spacing_table_orth_tbl_"
+      "tbl_name":"cut_spacing_table_orth_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerCutSpacingTableDefRule",
       "type":"1_n",
-      "tbl_name":"cut_spacing_table_def_tbl_"
+      "tbl_name":"cut_spacing_table_def_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerCutEnclosureRule",
       "type":"1_n",
-      "tbl_name":"cut_enc_rules_tbl_"
+      "tbl_name":"cut_enc_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerEolExtensionRule",
       "type":"1_n",
-      "tbl_name":"eol_ext_rules_tbl_"
+      "tbl_name":"eol_ext_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerArraySpacingRule",
       "type":"1_n",
-      "tbl_name":"array_spacing_rules_tbl_"
+      "tbl_name":"array_spacing_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerEolKeepOutRule",
       "type":"1_n",
-      "tbl_name":"eol_keep_out_rules_tbl_"
+      "tbl_name":"eol_keep_out_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerMaxSpacingRule",
       "type":"1_n",
       "tbl_name":"max_spacing_rules_tbl_",
-      "schema":"kSchemaMaxSpacing"
+      "schema":"kSchemaMaxSpacing",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
@@ -302,13 +326,17 @@
       "parent":"dbTechLayer",
       "child":"dbTechLayerMinCutRule",
       "type":"1_n",
-      "tbl_name":"min_cuts_rules_tbl_"
+      "tbl_name":"min_cuts_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerAreaRule",
       "type":"1_n",
-      "tbl_name":"area_rules_tbl_"
+      "tbl_name":"area_rules_tbl_",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
@@ -322,14 +350,18 @@
       "child":"dbTechLayerKeepOutZoneRule",
       "type":"1_n",
       "tbl_name":"keepout_zone_rules_tbl_",
-      "schema":"kSchemaKeepoutZone"
+      "schema":"kSchemaKeepoutZone",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
       "child":"dbTechLayerWrongDirSpacingRule",
       "type":"1_n",
       "tbl_name":"wrongdir_spacing_rules_tbl_",
-      "schema":"kSchemaWrongdirSpacing"
+      "schema":"kSchemaWrongdirSpacing",
+      "create":true,
+      "destroy":true
     },
     {
       "parent":"dbTechLayer",
@@ -343,7 +375,9 @@
       "child":"dbTechLayerVoltageSpacing",
       "type":"1_n",
       "tbl_name":"voltage_spacing_rules_tbl_",
-      "schema":"kSchemaVoltageSpacingTables"
+      "schema":"kSchemaVoltageSpacingTables",
+      "create":true,
+      "destroy":true
     },
     {
       "parent": "dbDft",

--- a/src/odb/src/codeGenerator/schema.json
+++ b/src/odb/src/codeGenerator/schema.json
@@ -464,7 +464,6 @@
       "parent":"dbChip",
       "child":"dbChipRegion",
       "type":"1_n", 
-      "flags": [],
       "schema":"kSchemaChipRegion",
       "tbl_name":"chip_region_tbl_"
     },
@@ -472,7 +471,6 @@
       "parent":"dbChip",
       "child":"dbMarkerCategory",
       "type":"1_n",
-      "flags": [],
       "tbl_name":"marker_categories_tbl_",
       "schema":"kSchemaChipMarkerCategories"
     },
@@ -488,7 +486,6 @@
       "parent":"dbChipRegion",
       "child":"dbChipBump",
       "type":"1_n", 
-      "flags": [],
       "schema":"kSchemaChipBump",
       "tbl_name":"chip_bump_tbl_"
     },

--- a/src/odb/src/codeGenerator/schema.json
+++ b/src/odb/src/codeGenerator/schema.json
@@ -1,5 +1,6 @@
 {
     "classes_dir": "schema",
+    "extern_enums": ["dbGDSSTrans", "dbGDSTextPres", "dbOrientType3D"],
     "iterators":[
     {
         "name": "dbModulePortItr",

--- a/src/odb/src/codeGenerator/schema/chip/dbAccessPoint.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbAccessPoint.json
@@ -33,8 +33,9 @@
       {
         "type": "dbId<_dbBPin>",
         "name": "bpin_",
-        "flags":["private","cmpgt"],
-        "parent": "dbBPin"
+        "flags":["no-set","cmpgt"],
+        "parent": "dbBlock",
+        "getterFunctionName": "getBPin"
       },
       {
         "name": "accesses_",

--- a/src/odb/src/codeGenerator/schema/chip/dbAccessPoint.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbAccessPoint.json
@@ -64,7 +64,7 @@
         "name": "vias_",
         "type": "dbVector<dbVector<std::pair<dbObjectType,dbId<_dbObject>>>>",
         "comment" : "//list of vias by num of cuts",
-        "flags" : ["private"]
+        "flags" : ["private", "no-meminfo"]
       },
       {
         "name": "path_segs_",

--- a/src/odb/src/codeGenerator/schema/chip/dbChipConn.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbChipConn.json
@@ -3,7 +3,7 @@
   "type": "dbObject",
   "fields": [
     { "name": "name_", "type": "std::string", "flags": ["no-set"] },
-    { "name": "thickness_", "type": "int", "flags": [], "default": 0 },
+    { "name": "thickness_", "type": "int", "default": 0 },
     { "name": "chip_", "type": "dbId<_dbChip>", "flags": ["private"] },
     { "name": "chip_conn_next_", "type": "dbId<_dbChipConn>", "flags": ["private"] },
     { "name": "top_region_", "type": "dbId<_dbChipRegionInst>", "flags": ["private"] },

--- a/src/odb/src/codeGenerator/schema/chip/dbChipInst.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbChipInst.json
@@ -14,8 +14,7 @@
     },
     {
       "name": "orient_",
-      "type": "dbOrientType3D",
-      "flags": []
+      "type": "dbOrientType3D"
     },
     {
       "name": "master_chip_",
@@ -49,6 +48,5 @@
   "h_includes": [
     "odb/geom.h",
     "odb/dbTypes.h"
-  ],
-  "cpp_includes": []
+  ]
 }

--- a/src/odb/src/codeGenerator/schema/chip/dbChipInst.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbChipInst.json
@@ -15,7 +15,7 @@
     {
       "name": "orient_",
       "type": "dbOrientType3D",
-      "flags": ["no-set"]
+      "flags": []
     },
     {
       "name": "master_chip_",

--- a/src/odb/src/codeGenerator/schema/chip/dbChipRegion.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbChipRegion.json
@@ -13,7 +13,7 @@
     { "name": "name_", "type": "std::string", "flags": ["no-set"]},
     { "name": "side_", "type": "uint8_t", "flags": ["private"] , "default": "static_cast<uint8_t>(dbChipRegion::Side::FRONT)"},
     { "name": "layer_", "type": "dbId<_dbTechLayer>", "flags": ["private"] },
-    { "name": "box_", "type": "Rect", "flags": ["set-const-ref"]},
+    { "name": "box_", "type": "Rect"},
     { "name": "z_min_", "type": "int", "flags": ["private"] , "default": "0"},
     { "name": "z_max_", "type": "int", "flags": ["private"] , "default": "0"}
   ],

--- a/src/odb/src/codeGenerator/schema/chip/dbGCellGrid.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbGCellGrid.json
@@ -87,13 +87,11 @@
         {
           "name": "usage",
           "type": "float",
-          "flags": [],
           "default": 0
         },
         {
           "name": "capacity",
           "type": "float",
-          "flags": [],
           "default": 0
         }
       ],

--- a/src/odb/src/codeGenerator/schema/chip/dbGCellGrid.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbGCellGrid.json
@@ -77,8 +77,7 @@
       "flags": [
         "private",
         "no-serial",
-        "no-template"
-      ]
+        "no-template", "no-meminfo"]
     }
   ],
   "structs": [

--- a/src/odb/src/codeGenerator/schema/chip/dbIsolation.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbIsolation.json
@@ -15,28 +15,23 @@
     },
     {
       "name":"applies_to_",
-      "type":"std::string",
-      "flags":[]
+      "type":"std::string"
     },
     {
       "name":"clamp_value_",
-      "type":"std::string",
-      "flags":[]
+      "type":"std::string"
     },
     {
       "name":"isolation_signal_",
-      "type":"std::string",
-      "flags":[]
+      "type":"std::string"
     },
     {
       "name":"isolation_sense_",
-      "type":"std::string",
-      "flags":[]
+      "type":"std::string"
     },
     {
       "name":"location_",
-      "type":"std::string",
-      "flags":[]
+      "type":"std::string"
     },
     {
       "name": "isolation_cells_",
@@ -46,7 +41,6 @@
     {
       "name":"power_domain_",
       "type":"dbId<_dbPowerDomain>",
-      "flags":[],
       "parent":"dbBlock"
     }
   ],

--- a/src/odb/src/codeGenerator/schema/chip/dbIsolation.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbIsolation.json
@@ -16,27 +16,27 @@
     {
       "name":"applies_to_",
       "type":"std::string",
-      "flags":["no-set"]
+      "flags":[]
     },
     {
       "name":"clamp_value_",
       "type":"std::string",
-      "flags":["no-set"]
+      "flags":[]
     },
     {
       "name":"isolation_signal_",
       "type":"std::string",
-      "flags":["no-set"]
+      "flags":[]
     },
     {
       "name":"isolation_sense_",
       "type":"std::string",
-      "flags":["no-set"]
+      "flags":[]
     },
     {
       "name":"location_",
       "type":"std::string",
-      "flags":["no-set"]
+      "flags":[]
     },
     {
       "name": "isolation_cells_",

--- a/src/odb/src/codeGenerator/schema/chip/dbLevelShifter.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbLevelShifter.json
@@ -31,82 +31,67 @@
     },
     {
       "name": "source_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "sink_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "use_functional_equivalence_",
       "type": "bool",
-      "default": "false",
-      "flags": []
+      "default": "false"
     },
     {
       "name": "applies_to_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "applies_to_boundary_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "rule_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "threshold_",
       "type": "float",
-      "default": "0",
-      "flags": []
+      "default": "0"
     },
     {
       "name": "no_shift_",
       "type": "bool",
-      "default": "false",
-      "flags": []
+      "default": "false"
     },
     {
       "name": "force_shift_",
       "type": "bool",
-      "default": "false",
-      "flags": []
+      "default": "false"
     },
     {
       "name": "location_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "input_supply_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "output_supply_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "internal_supply_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "name_prefix_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "name_suffix_",
-      "type": "std::string",
-      "flags": []
+      "type": "std::string"
     },
     {
       "name": "instances_",

--- a/src/odb/src/codeGenerator/schema/chip/dbModInst.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbModInst.json
@@ -42,7 +42,7 @@
 	},
 	{
       	    "name":"moditerms_",
-	    "type":"dbId<_dbModITerm >",
+	    "type":"dbId<_dbModITerm>",
 	    "flags":["no-get","no-set","no-serial"],	
 	    "parent":"dbBlock"
 	}

--- a/src/odb/src/codeGenerator/schema/chip/dbPowerDomain.json
+++ b/src/odb/src/codeGenerator/schema/chip/dbPowerDomain.json
@@ -39,8 +39,7 @@
     {
       "name":"top_",
       "type":"bool",
-      "default": "false",
-      "flags":[]
+      "default": "false"
     },
     {
       "name": "parent_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSARef.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSARef.json
@@ -16,7 +16,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       },
       {
         "name":"transform_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSARef.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSARef.json
@@ -20,8 +20,7 @@
       },
       {
         "name":"transform_",
-        "type":"dbGDSSTrans",
-        "flags":[]
+        "type":"dbGDSSTrans"
       },
       {
         "name":"num_rows_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSBoundary.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSBoundary.json
@@ -21,7 +21,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       }
     ],
     "h_includes": [

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSBoundary.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSBoundary.json
@@ -4,14 +4,12 @@
       {
         "name":"layer_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"datatype_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"xy_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSBox.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSBox.json
@@ -4,14 +4,12 @@
       {
         "name":"layer_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"datatype_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"bounds_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSBox.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSBox.json
@@ -21,7 +21,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       }
     ],
     "h_includes": [

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSPath.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSPath.json
@@ -21,7 +21,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       },
       {
         "name":"width_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSPath.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSPath.json
@@ -4,14 +4,12 @@
       {
         "name":"layer_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"datatype_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"xy_",
@@ -26,14 +24,12 @@
       {
         "name":"width_",
         "default":"0",
-        "type":"int",
-        "flags":[]
+        "type":"int"
       },
       {
         "name":"path_type_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       }
     ],
     "h_includes": [

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSSRef.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSSRef.json
@@ -8,7 +8,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       },
       {
         "name":"transform_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSSRef.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSSRef.json
@@ -12,8 +12,7 @@
       },
       {
         "name":"transform_",
-        "type":"dbGDSSTrans",
-        "flags":[]
+        "type":"dbGDSSTrans"
       },
       {
         "name":"structure_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSStructure.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSStructure.json
@@ -3,7 +3,7 @@
     "fields":[
       {
         "name":"name_",
-        "type":"char*",
+        "type":"char *",
         "default":"nullptr",
         "flags":["no-set"]
       },

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSText.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSText.json
@@ -20,7 +20,7 @@
       {
         "name":"propattr_",
         "type":"std::vector<std::pair<std::int16_t, std::string>>",
-        "flags":["no-template", "no-get", "no-set"]
+        "flags":["no-template", "no-get", "no-set", "no-meminfo"]
       },
       {
         "name":"presentation_",

--- a/src/odb/src/codeGenerator/schema/gds/dbGDSText.json
+++ b/src/odb/src/codeGenerator/schema/gds/dbGDSText.json
@@ -4,14 +4,12 @@
       {
         "name":"layer_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"datatype_",
         "type":"int16_t",
-        "default":"0",
-        "flags":[]
+        "default":"0"
       },
       {
         "name":"origin_",
@@ -24,18 +22,15 @@
       },
       {
         "name":"presentation_",
-        "type":"dbGDSTextPres",
-        "flags":[]
+        "type":"dbGDSTextPres"
       },
       {
         "name":"transform_",
-        "type":"dbGDSSTrans",
-        "flags":[]
+        "type":"dbGDSSTrans"
       },
       {
         "name":"text_",
-        "type":"std::string",
-        "flags":[]
+        "type":"std::string"
       }
     ],
     "h_includes": [

--- a/src/odb/src/codeGenerator/schema/scan/dbScanChain.json
+++ b/src/odb/src/codeGenerator/schema/scan/dbScanChain.json
@@ -14,22 +14,22 @@
     },
     {
       "name": "scan_in_",
-      "type": "dbId<dbScanPin>",
+      "type": "dbId<_dbScanPin>",
       "flags": ["private"]
     },
     {
       "name": "scan_out_",
-      "type": "dbId<dbScanPin>",
+      "type": "dbId<_dbScanPin>",
       "flags": ["private"]
     },
     {
       "name": "scan_enable_",
-      "type": "dbId<dbScanPin>",
+      "type": "dbId<_dbScanPin>",
       "flags": ["private"]
     },
     {
       "name": "test_mode_",
-      "type": "dbId<dbScanPin>",
+      "type": "dbId<_dbScanPin>",
       "flags": ["private"]
     },
     {

--- a/src/odb/src/codeGenerator/schema/scan/dbScanInst.json
+++ b/src/odb/src/codeGenerator/schema/scan/dbScanInst.json
@@ -19,17 +19,17 @@
     },
     {
       "name": "access_pins_",
-      "type": "std::pair<dbId<dbScanPin>, dbId<dbScanPin>>",
+      "type": "std::pair<dbId<_dbScanPin>, dbId<_dbScanPin>>",
       "flags": ["private", "no-template"]
     },
     {
       "name": "scan_enable_",
-      "type": "dbId<dbScanPin>",
+      "type": "dbId<_dbScanPin>",
       "flags": ["private"]
     },
     {
       "name": "inst_",
-      "type": "dbId<dbInst>",
+      "type": "dbId<_dbInst>",
       "flags": ["private"]
     },
     {

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayer.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayer.json
@@ -96,23 +96,19 @@
     },
     {
       "name": "rect_only",
-      "type": "bit",
-      "flags": []
+      "type": "bit"
     },
     {
       "name": "right_way_on_grid_only",
-      "type": "bit",
-      "flags": []
+      "type": "bit"
     },
     {
       "name": "right_way_on_grid_only_check_mask",
-      "type": "bit",
-      "flags": []
+      "type": "bit"
     },
     {
       "type": "bit",
-      "name": "rect_only_except_non_core_pins",
-      "flags": []
+      "name": "rect_only_except_non_core_pins"
     },
     {
       "type": "uint32_t",

--- a/src/odb/src/codeGenerator/schema/tech/dbTechLayerSpacingTablePrlRule.json
+++ b/src/odb/src/codeGenerator/schema/tech/dbTechLayerSpacingTablePrlRule.json
@@ -40,8 +40,7 @@
       "name": "spacing_tbl_",
       "flags": [
         "no-set",
-        "no-get"
-      ]
+        "no-get", "no-meminfo"]
     },
     {
       "type": "dbVector<std::tuple<int,int,int>>",

--- a/src/odb/src/codeGenerator/schema_models.py
+++ b/src/odb/src/codeGenerator/schema_models.py
@@ -159,6 +159,13 @@ class Class:
     ostream_scope: bool = False
     equal_fields: list[dict[str, str]] = dataclass_field(default_factory=list)
     less_fields: list[dict[str, str]] = dataclass_field(default_factory=list)
+    # Generated factory methods, populated from an opted-in relation (see
+    # generate_relations): the owning parent class and its table member, plus
+    # whether to emit create()/destroy().
+    factory_parent: str | None = None
+    factory_table: str | None = None
+    gen_create: bool = False
+    gen_destroy: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Class:
@@ -224,6 +231,12 @@ class Relation:
     page_size: int | None = None
     schema: str | None = None
     flags: list[str] = dataclass_field(default_factory=list)
+    # Opt in to generating the child's trivial factory methods. 'create' emits
+    # Child::create(Parent*) and 'destroy' emits Child::destroy(Child*) using the
+    # canonical owned-table pattern; set only when the hand-written versions do
+    # nothing more than allocate/free the table entry (see generate_relations).
+    create: bool = False
+    destroy: bool = False
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> Relation:

--- a/src/odb/src/codeGenerator/schema_models.py
+++ b/src/odb/src/codeGenerator/schema_models.py
@@ -5,6 +5,17 @@ from dataclasses import dataclass, field as dataclass_field
 from typing import Any, Dict, List, Optional
 
 
+def _require_known_keys(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+    """Reject schema keys the dataclass does not declare (catches JSON typos).
+
+    Must be called after any key remapping (e.g. Class 'type'->'base_class').
+    """
+    unknown = set(data) - set(cls.__dataclass_fields__)
+    if unknown:
+        raise ValueError(f"{cls.__name__}: unknown schema key(s): {sorted(unknown)}")
+    return data
+
+
 @dataclass
 class Field:
     name: str = ""
@@ -19,28 +30,61 @@ class Field:
     functional_name: Optional[str] = None
     setterFunctionName: Optional[str] = None
     getterFunctionName: Optional[str] = None
-    setterArgumentType: Optional[str] = None
-    getterReturnType: Optional[str] = None
-    isRef: bool = False
-    refType: Optional[str] = None
-    refTable: Optional[str] = None
-    isHashTable: bool = False
-    hashTableType: Optional[str] = None
-    isPassByRef: bool = False
-    isSetByRef: bool = False
     bitFields: bool = False
     table: bool = False
     dbSetGetter: bool = False
-    table_base_type: Optional[str] = None
     table_name: Optional[str] = None
     page_size: Optional[int] = None
     schema: Optional[str] = None
     components: List[str] = dataclass_field(default_factory=list)
     numBits: Optional[int] = None
+    # Set during processing to a field_types.FieldType; not read from JSON. It is
+    # the single source of truth for the storage-kind properties below.
+    kind: Optional[Any] = None
+
+    # The following are derived from `kind`, which is the only place that classifies
+    # a C++ type. They are properties so the templates can read them by name.
+    @property
+    def refType(self) -> Optional[str]:
+        return self.kind.ref_type if self.kind else None
+
+    @property
+    def refTable(self) -> Optional[str]:
+        return self.kind.ref_table if self.kind else None
+
+    @property
+    def isHashTable(self) -> bool:
+        return self.kind.is_hash_table if self.kind else False
+
+    @property
+    def hashTableType(self) -> Optional[str]:
+        return self.kind.hash_table_type if self.kind else None
+
+    @property
+    def isSetByRef(self) -> bool:
+        return self.kind.type_set_by_ref if self.kind else False
+
+    @property
+    def setterArgumentType(self) -> Optional[str]:
+        return self.kind.setter_arg_type if self.kind else None
+
+    @property
+    def getterReturnType(self) -> Optional[str]:
+        return self.kind.getter_return_type if self.kind else None
+
+    @property
+    def table_base_type(self) -> Optional[str]:
+        return self.kind.table_base_type if self.kind else None
+
+    @property
+    def member_decl(self) -> str:
+        """The C++ type for the stored member declaration."""
+        return self.kind.member_decl() if self.kind else self.type
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Field":
-        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        _require_known_keys(cls, data)
+        return cls(**data)
 
 
 @dataclass
@@ -54,7 +98,8 @@ class Enum:
     def from_dict(cls, data: Dict[str, Any]) -> "Enum":
         if "class" in data:
             data["cls"] = data.pop("class")
-        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        _require_known_keys(cls, data)
+        return cls(**data)
 
 
 @dataclass
@@ -72,7 +117,8 @@ class Struct:
             for f in data.get("fields", [])
         ]
         data["fields"] = fields
-        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        _require_known_keys(cls, data)
+        return cls(**data)
 
 
 @dataclass
@@ -120,16 +166,73 @@ class Class:
             Struct.from_dict(s) if isinstance(s, dict) else s
             for s in data.get("structs", [])
         ]
-        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        _require_known_keys(cls, data)
+        return cls(**data)
+
+
+@dataclass
+class Iterator:
+    name: str
+    parentObject: str
+    tableName: str
+    reversible: bool = False
+    orderReversed: bool = False
+    customEnd: bool = False
+    sequential: int = 0
+    tablePageSize: Optional[int] = None
+    includes: List[str] = dataclass_field(default_factory=list)
+    flags: List[str] = dataclass_field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Iterator":
+        data = dict(data)
+        # The schema spells these as the JSON strings "true"/"false".
+        for key in ("reversible", "orderReversed", "customEnd"):
+            if isinstance(data.get(key), str):
+                data[key] = data[key].lower() == "true"
+        _require_known_keys(cls, data)
+        return cls(**data)
+
+
+@dataclass
+class Relation:
+    parent: str
+    child: str
+    type: str
+    tbl_name: str
+    hash: bool = False
+    page_size: Optional[int] = None
+    schema: Optional[str] = None
+    flags: List[str] = dataclass_field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Relation":
+        _require_known_keys(cls, data)
+        return cls(**data)
 
 
 @dataclass
 class Schema:
     classes_dir: str
     classes: List[Class] = dataclass_field(default_factory=list)
-    iterators: List[Dict[str, Any]] = dataclass_field(default_factory=list)
-    relations: List[Dict[str, Any]] = dataclass_field(default_factory=list)
+    iterators: List[Iterator] = dataclass_field(default_factory=list)
+    relations: List[Relation] = dataclass_field(default_factory=list)
+    # Names of enum types defined outside the generator (e.g. dbGDSSTrans). They
+    # are passed by value like other enums; see is_set_by_ref().
+    extern_enums: List[str] = dataclass_field(default_factory=list)
+    # Derived during processing: all enum type names (declared + external).
+    enum_type_names: set = dataclass_field(default_factory=set)
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Schema":
-        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+        data = dict(data)
+        data["iterators"] = [
+            Iterator.from_dict(i) if isinstance(i, dict) else i
+            for i in data.get("iterators", [])
+        ]
+        data["relations"] = [
+            Relation.from_dict(r) if isinstance(r, dict) else r
+            for r in data.get("relations", [])
+        ]
+        _require_known_keys(cls, data)
+        return cls(**data)

--- a/src/odb/src/codeGenerator/schema_models.py
+++ b/src/odb/src/codeGenerator/schema_models.py
@@ -1,11 +1,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021-2025, The OpenROAD Authors
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field as dataclass_field
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from field_types import FieldType
 
 
-def _require_known_keys(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+def _require_known_keys(cls, data: dict[str, Any]) -> dict[str, Any]:
     """Reject schema keys the dataclass does not declare (catches JSON typos).
 
     Must be called after any key remapping (e.g. Class 'type'->'base_class').
@@ -20,37 +25,37 @@ def _require_known_keys(cls, data: Dict[str, Any]) -> Dict[str, Any]:
 class Field:
     name: str = ""
     type: str = ""
-    flags: List[str] = dataclass_field(default_factory=list)
-    bits: Optional[int] = None
-    default: Optional[Any] = None
-    comment: Optional[str] = None
-    public_comment: Optional[str] = None
-    parent: Optional[str] = None
-    argument: Optional[str] = None
-    functional_name: Optional[str] = None
-    setterFunctionName: Optional[str] = None
-    getterFunctionName: Optional[str] = None
+    flags: list[str] = dataclass_field(default_factory=list)
+    bits: int | None = None
+    default: Any | None = None
+    comment: str | None = None
+    public_comment: str | None = None
+    parent: str | None = None
+    argument: str | None = None
+    functional_name: str | None = None
+    setterFunctionName: str | None = None
+    getterFunctionName: str | None = None
     bitFields: bool = False
     table: bool = False
     dbSetGetter: bool = False
-    table_name: Optional[str] = None
-    page_size: Optional[int] = None
-    schema: Optional[str] = None
-    components: List[str] = dataclass_field(default_factory=list)
-    numBits: Optional[int] = None
-    # Set during processing to a field_types.FieldType; not read from JSON. It is
-    # the single source of truth for the storage-kind properties below.
-    kind: Optional[Any] = None
+    table_name: str | None = None
+    page_size: int | None = None
+    schema: str | None = None
+    components: list[str] = dataclass_field(default_factory=list)
+    numBits: int | None = None
+    # Set during processing to a FieldType; not read from JSON. It is the single
+    # source of truth for the storage-kind properties below.
+    kind: FieldType | None = None
 
     # The following are derived from `kind`, which is the only place that classifies
     # a C++ type. They are properties so the templates can read them by name.
     @property
-    def refType(self) -> Optional[str]:
+    def refType(self) -> str | None:
         """Referenced object's pointer type, for a dbId<> field."""
         return self.kind.ref_type if self.kind else None
 
     @property
-    def refTable(self) -> Optional[str]:
+    def refTable(self) -> str | None:
         """Owner table a dbId<> getter reads from."""
         return self.kind.ref_table if self.kind else None
 
@@ -60,7 +65,7 @@ class Field:
         return self.kind.is_hash_table if self.kind else False
 
     @property
-    def hashTableType(self) -> Optional[str]:
+    def hashTableType(self) -> str | None:
         """Value pointer type of a dbHashTable<> field."""
         return self.kind.hash_table_type if self.kind else None
 
@@ -70,17 +75,17 @@ class Field:
         return self.kind.type_set_by_ref if self.kind else False
 
     @property
-    def setterArgumentType(self) -> Optional[str]:
+    def setterArgumentType(self) -> str | None:
         """C++ type the generated setter accepts."""
         return self.kind.setter_arg_type if self.kind else None
 
     @property
-    def getterReturnType(self) -> Optional[str]:
+    def getterReturnType(self) -> str | None:
         """C++ type the generated getter returns."""
         return self.kind.getter_return_type if self.kind else None
 
     @property
-    def table_base_type(self) -> Optional[str]:
+    def table_base_type(self) -> str | None:
         """Child class name of an owned-table field."""
         return self.kind.table_base_type if self.kind else None
 
@@ -90,7 +95,7 @@ class Field:
         return self.kind.member_decl() if self.kind else self.type
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Field":
+    def from_dict(cls, data: dict[str, Any]) -> Field:
         """Build a Field from its JSON object, rejecting unknown keys."""
         _require_known_keys(cls, data)
         return cls(**data)
@@ -99,12 +104,12 @@ class Field:
 @dataclass
 class Enum:
     name: str
-    values: List[str]
+    values: list[str]
     public: bool = False
     cls: bool = dataclass_field(default=False)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Enum":
+    def from_dict(cls, data: dict[str, Any]) -> Enum:
         """Build an Enum from JSON, mapping the reserved 'class' key to `cls`."""
         if "class" in data:
             data["cls"] = data.pop("class")
@@ -115,13 +120,13 @@ class Enum:
 @dataclass
 class Struct:
     name: str
-    fields: List[Field] = dataclass_field(default_factory=list)
+    fields: list[Field] = dataclass_field(default_factory=list)
     public: bool = False
-    flags: List[str] = dataclass_field(default_factory=list)
-    in_class_name: Optional[str] = None
+    flags: list[str] = dataclass_field(default_factory=list)
+    in_class_name: str | None = None
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Struct":
+    def from_dict(cls, data: dict[str, Any]) -> Struct:
         """Build a Struct from JSON, parsing its nested field list."""
         fields = [
             Field.from_dict(f) if isinstance(f, dict) else f
@@ -136,27 +141,27 @@ class Struct:
 class Class:
     name: str
     base_class: str = "dbObject"
-    fields: List[Field] = dataclass_field(default_factory=list)
-    enums: List[Enum] = dataclass_field(default_factory=list)
-    structs: List[Struct] = dataclass_field(default_factory=list)
-    h_includes: List[str] = dataclass_field(default_factory=list)
-    h_sys_includes: List[str] = dataclass_field(default_factory=list)
-    cpp_includes: List[str] = dataclass_field(default_factory=list)
-    cpp_sys_includes: List[str] = dataclass_field(default_factory=list)
-    declared_classes: List[str] = dataclass_field(default_factory=list)
-    description: List[str] = dataclass_field(default_factory=list)
+    fields: list[Field] = dataclass_field(default_factory=list)
+    enums: list[Enum] = dataclass_field(default_factory=list)
+    structs: list[Struct] = dataclass_field(default_factory=list)
+    h_includes: list[str] = dataclass_field(default_factory=list)
+    h_sys_includes: list[str] = dataclass_field(default_factory=list)
+    cpp_includes: list[str] = dataclass_field(default_factory=list)
+    cpp_sys_includes: list[str] = dataclass_field(default_factory=list)
+    declared_classes: list[str] = dataclass_field(default_factory=list)
+    description: list[str] = dataclass_field(default_factory=list)
     do_not_generate_compare: bool = False
-    hash: Optional[str] = None
+    hash: str | None = None
     hasTables: bool = False
     hasBitFields: bool = False
     needs_non_default_destructor: bool = False
-    assert_alignment_is_multiple_of: Optional[int] = None
+    assert_alignment_is_multiple_of: int | None = None
     ostream_scope: bool = False
-    equal_fields: List[Dict[str, str]] = dataclass_field(default_factory=list)
-    less_fields: List[Dict[str, str]] = dataclass_field(default_factory=list)
+    equal_fields: list[dict[str, str]] = dataclass_field(default_factory=list)
+    less_fields: list[dict[str, str]] = dataclass_field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Class":
+    def from_dict(cls, data: dict[str, Any]) -> Class:
         """Build a Class from JSON: the 'type' alias, do_not_generate_compare
         coercion, and the nested field/enum/struct lists."""
         if "do_not_generate_compare" in data and isinstance(
@@ -192,12 +197,12 @@ class Iterator:
     orderReversed: bool = False
     customEnd: bool = False
     sequential: int = 0
-    tablePageSize: Optional[int] = None
-    includes: List[str] = dataclass_field(default_factory=list)
-    flags: List[str] = dataclass_field(default_factory=list)
+    tablePageSize: int | None = None
+    includes: list[str] = dataclass_field(default_factory=list)
+    flags: list[str] = dataclass_field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Iterator":
+    def from_dict(cls, data: dict[str, Any]) -> Iterator:
         """Build an Iterator from JSON, coercing the 'true'/'false' string
         flags to bool."""
         data = dict(data)
@@ -216,12 +221,12 @@ class Relation:
     type: str
     tbl_name: str
     hash: bool = False
-    page_size: Optional[int] = None
-    schema: Optional[str] = None
-    flags: List[str] = dataclass_field(default_factory=list)
+    page_size: int | None = None
+    schema: str | None = None
+    flags: list[str] = dataclass_field(default_factory=list)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Relation":
+    def from_dict(cls, data: dict[str, Any]) -> Relation:
         """Build a Relation from its JSON object, rejecting unknown keys."""
         _require_known_keys(cls, data)
         return cls(**data)
@@ -230,17 +235,17 @@ class Relation:
 @dataclass
 class Schema:
     classes_dir: str
-    classes: List[Class] = dataclass_field(default_factory=list)
-    iterators: List[Iterator] = dataclass_field(default_factory=list)
-    relations: List[Relation] = dataclass_field(default_factory=list)
+    classes: list[Class] = dataclass_field(default_factory=list)
+    iterators: list[Iterator] = dataclass_field(default_factory=list)
+    relations: list[Relation] = dataclass_field(default_factory=list)
     # Names of enum types defined outside the generator (e.g. dbGDSSTrans). They
     # are passed by value like other enums; see is_set_by_ref().
-    extern_enums: List[str] = dataclass_field(default_factory=list)
+    extern_enums: list[str] = dataclass_field(default_factory=list)
     # Derived during processing: all enum type names (declared + external).
     enum_type_names: set = dataclass_field(default_factory=set)
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> "Schema":
+    def from_dict(cls, data: dict[str, Any]) -> Schema:
         """Build a Schema from JSON, parsing the iterator and relation lists."""
         data = dict(data)
         data["iterators"] = [

--- a/src/odb/src/codeGenerator/schema_models.py
+++ b/src/odb/src/codeGenerator/schema_models.py
@@ -46,34 +46,42 @@ class Field:
     # a C++ type. They are properties so the templates can read them by name.
     @property
     def refType(self) -> Optional[str]:
+        """Referenced object's pointer type, for a dbId<> field."""
         return self.kind.ref_type if self.kind else None
 
     @property
     def refTable(self) -> Optional[str]:
+        """Owner table a dbId<> getter reads from."""
         return self.kind.ref_table if self.kind else None
 
     @property
     def isHashTable(self) -> bool:
+        """Whether the field is a dbHashTable<>."""
         return self.kind.is_hash_table if self.kind else False
 
     @property
     def hashTableType(self) -> Optional[str]:
+        """Value pointer type of a dbHashTable<> field."""
         return self.kind.hash_table_type if self.kind else None
 
     @property
     def isSetByRef(self) -> bool:
+        """Whether the setter takes its argument by const reference."""
         return self.kind.type_set_by_ref if self.kind else False
 
     @property
     def setterArgumentType(self) -> Optional[str]:
+        """C++ type the generated setter accepts."""
         return self.kind.setter_arg_type if self.kind else None
 
     @property
     def getterReturnType(self) -> Optional[str]:
+        """C++ type the generated getter returns."""
         return self.kind.getter_return_type if self.kind else None
 
     @property
     def table_base_type(self) -> Optional[str]:
+        """Child class name of an owned-table field."""
         return self.kind.table_base_type if self.kind else None
 
     @property
@@ -83,6 +91,7 @@ class Field:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Field":
+        """Build a Field from its JSON object, rejecting unknown keys."""
         _require_known_keys(cls, data)
         return cls(**data)
 
@@ -96,6 +105,7 @@ class Enum:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Enum":
+        """Build an Enum from JSON, mapping the reserved 'class' key to `cls`."""
         if "class" in data:
             data["cls"] = data.pop("class")
         _require_known_keys(cls, data)
@@ -112,6 +122,7 @@ class Struct:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Struct":
+        """Build a Struct from JSON, parsing its nested field list."""
         fields = [
             Field.from_dict(f) if isinstance(f, dict) else f
             for f in data.get("fields", [])
@@ -146,6 +157,8 @@ class Class:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Class":
+        """Build a Class from JSON: the 'type' alias, do_not_generate_compare
+        coercion, and the nested field/enum/struct lists."""
         if "do_not_generate_compare" in data and isinstance(
             data["do_not_generate_compare"], str
         ):
@@ -185,6 +198,8 @@ class Iterator:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Iterator":
+        """Build an Iterator from JSON, coercing the 'true'/'false' string
+        flags to bool."""
         data = dict(data)
         # The schema spells these as the JSON strings "true"/"false".
         for key in ("reversible", "orderReversed", "customEnd"):
@@ -207,6 +222,7 @@ class Relation:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Relation":
+        """Build a Relation from its JSON object, rejecting unknown keys."""
         _require_known_keys(cls, data)
         return cls(**data)
 
@@ -225,6 +241,7 @@ class Schema:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Schema":
+        """Build a Schema from JSON, parsing the iterator and relation lists."""
         data = dict(data)
         data["iterators"] = [
             Iterator.from_dict(i) if isinstance(i, dict) else i

--- a/src/odb/src/codeGenerator/templates/db.h.jinja
+++ b/src/odb/src/codeGenerator/templates/db.h.jinja
@@ -57,6 +57,12 @@ class {{klass.name}} : public {{klass.base_class}}
       {% endfor %}
     {% endif %}
   {% endfor %}
+  {% if klass.gen_create %}
+  static {{klass.name}}* create({{klass.factory_parent}}* parent);
+  {% endif %}
+  {% if klass.gen_destroy %}
+  static void destroy({{klass.name}}* obj);
+  {% endif %}
   //User Code Begin {{klass.name}}
   //User Code End {{klass.name}}
 };

--- a/src/odb/src/codeGenerator/templates/impl.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/impl.cpp.jinja
@@ -105,8 +105,10 @@ namespace odb {
     info.size += sizeof(*this);
 
     {% for field in klass.fields %}
-      {% if field.table %} 
+      {% if field.table %}
         {{field.name}}->collectMemInfo(info.children["{{field.name}}"]);
+      {% elif field.kind.mem_info_account() and 'no-meminfo' not in field.flags %}
+        info.children["{{ field.name[:-1] if field.name.endswith('_') else field.name }}"].add({{field.name}});
       {% endif %}
     {% endfor %}
 

--- a/src/odb/src/codeGenerator/templates/impl.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/impl.cpp.jinja
@@ -212,6 +212,21 @@ namespace odb {
     {% endif %}
   {% endfor %}
 
+  {% if klass.gen_create %}
+  {{klass.name}}* {{klass.name}}::create({{klass.factory_parent}}* parent)
+  {
+    _{{klass.factory_parent}}* _parent = (_{{klass.factory_parent}}*) parent;
+    return ({{klass.name}}*) _parent->{{klass.factory_table}}->create();
+  }
+  {% endif %}
+  {% if klass.gen_destroy %}
+  void {{klass.name}}::destroy({{klass.name}}* obj)
+  {
+    _{{klass.factory_parent}}* _parent = (_{{klass.factory_parent}}*) obj->getImpl()->getOwner();
+    dbProperty::destroyProperties(obj);
+    _parent->{{klass.factory_table}}->destroy((_{{klass.name}}*) obj);
+  }
+  {% endif %}
   //User Code Begin {{klass.name}}PublicMethods
   //User Code End {{klass.name}}PublicMethods
 } // namespace odb

--- a/src/odb/src/codeGenerator/templates/impl.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/impl.cpp.jinja
@@ -118,7 +118,7 @@ namespace odb {
     _{{klass.name}}::~_{{klass.name}}()
     {
       {% for field in klass.fields %}
-        {% if field.name == 'name_' and field.type == "char *" %}
+        {% if field.kind.needs_free(field.name) %}
           if (name_) {
             free((void*) name_);
           }
@@ -147,41 +147,32 @@ namespace odb {
       {
     
         _{{klass.name}}* obj = (_{{klass.name}}*)this;
-    
-        {% if field.isRef %}
-    
-          obj->{{field.name}}={{field.argument}}->getImpl()->getOID();
-    
-        {% else %}
 
-          obj->{{field.name}}={{field.argument}};
-    
-        {% endif %}
+        obj->{{field.name}}={{field.kind.setter_assign_rhs(field.argument)}};
       }
     {% endif %}
   
     {% if 'no-get' not in field.flags %}
       {{- macros.getter_signature(field, klass) -}}
       {
-      {% if field.dbSetGetter %}
+      {% set getter_kind = field.kind.getter_kind() %}
+      {% if getter_kind == 'dbset' %}
           _{{klass.name}}* obj = (_{{klass.name}}*)this;
           return dbSet<{{field.table_base_type}}>(obj, obj->{{field.name}});
-      {% elif field.isPassByRef %}
+      {% elif getter_kind == 'out_param' %}
           _{{klass.name}}* obj = (_{{klass.name}}*)this;
           tbl = obj->{{field.name}};
-      {% elif field.isHashTable %}
+      {% elif getter_kind == 'hash_find' %}
           _{{klass.name}}* obj = (_{{klass.name}}*)this;
           return ({{field.getterReturnType}}) obj->{{field.name}}.find(name);
       {% else %}
           _{{klass.name}}* obj = (_{{klass.name}}*)this;
-          {% if field.isRef %}
+          {% if getter_kind == 'ref_lookup' %}
             if(obj->{{field.name}} == 0) {
               return nullptr;
             }
             _{{field.parent}}* par = (_{{field.parent}}*) obj->getOwner();
             return ({{field.refType}}) par->{{field.refTable}}->getPtr(obj->{{field.name}});
-          {% elif field.isHashTable %}
-            return {{field.getterReturnType}} obj->{{field.name}}.find(name);
           {% else %}
             return obj->{{field.name}};
           {% endif %}

--- a/src/odb/src/codeGenerator/templates/impl.h.jinja
+++ b/src/odb/src/codeGenerator/templates/impl.h.jinja
@@ -62,7 +62,7 @@ namespace odb {
       {% if field.comment %}
         {{field.comment}}
       {% endif %}
-      {{field.type}} {{field.name}};
+      {{field.member_decl}} {{field.name}};
     {% endfor %}
 
     // User Code Begin Fields

--- a/src/odb/src/codeGenerator/templates/itr.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/itr.cpp.jinja
@@ -24,12 +24,12 @@ namespace odb {
 
 bool {{itr.name}}::reversible() const
 {
-  return {{itr.reversible}};
+  return {{itr.reversible | cpp_bool}};
 }
 
 bool {{itr.name}}::orderReversed() const
 {
-  return {{itr.orderReversed}};
+  return {{itr.orderReversed | cpp_bool}};
 }
 
 void {{itr.name}}::reverse(dbObject* parent)

--- a/src/odb/src/codeGenerator/templates/macros.jinja
+++ b/src/odb/src/codeGenerator/templates/macros.jinja
@@ -21,7 +21,6 @@
        not is_public and not _enum.public %}
     enum {% if _enum.cls %} class {% endif %}
          {{ _enum.name }}
-         {% if _enum.type %} : {{ _enum.type }}{% endif %}
     {
       {% for value in _enum.values %}
         {% if not loop.first %},{%endif%} {{value}}
@@ -33,11 +32,12 @@
 
 {% macro getter_signature(field, klass=None) -%}
   {% if klass %}{% set prefix = klass.name + "::" %}{% endif %}
-  {% if field.dbSetGetter %}
+  {% set getter_kind = field.kind.getter_kind() %}
+  {% if getter_kind == 'dbset' %}
     dbSet<{{field.table_base_type}}> {{prefix}}get{{field.functional_name}}() const
-  {% elif field.isPassByRef %}
+  {% elif getter_kind == 'out_param' %}
     void {{prefix}}{{field.getterFunctionName}}({{field.getterReturnType}}& tbl) const
-  {% elif field.isHashTable %}
+  {% elif getter_kind == 'hash_find' %}
     {{field.getterReturnType}} {{prefix}}{{field.getterFunctionName}}(const char* name) const
   {% else %}
     {{field.getterReturnType}} {{prefix}}{{field.getterFunctionName}}() const

--- a/src/odb/src/codeGenerator/templates/serializer_in.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/serializer_in.cpp.jinja
@@ -18,7 +18,7 @@
           {% if field.schema %}
           if (obj.getDatabase()->isSchema({{field.schema}})) {
           {% endif %}
-          stream >> {% if field.table %}*{% endif %}obj.{{field.name}};
+          stream >> {% if field.kind.serialize_deref() %}*{% endif %}obj.{{field.name}};
           {% if field.schema %}
           }
           {% endif %}

--- a/src/odb/src/codeGenerator/templates/serializer_out.cpp.jinja
+++ b/src/odb/src/codeGenerator/templates/serializer_out.cpp.jinja
@@ -18,7 +18,7 @@
         stream << {{field.name}}bit_field;
       {% else %}
         {% if 'no-serial' not in field.flags %}
-          stream << {% if field.table %}*{% endif %}obj.{{field.name}};
+          stream << {% if field.kind.serialize_deref() %}*{% endif %}obj.{{field.name}};
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/src/odb/src/codeGenerator/test_field_types.py
+++ b/src/odb/src/codeGenerator/test_field_types.py
@@ -160,6 +160,11 @@ class SetByRefRuleTest(unittest.TestCase):
         ):
             self.assertFalse(is_set_by_ref(t, self.ENUMS), t)
 
+    def test_nested_struct_is_const_ref_not_by_value(self):
+        # A scoped name that is not a "::Value" enum (e.g. a nested struct) must
+        # be passed by const ref, not by value -- guards the is_enum() precision.
+        self.assertTrue(is_set_by_ref("dbPowerSwitch::UPFControlPort", self.ENUMS))
+
 
 class ComponentsRuleTest(unittest.TestCase):
     """components() decides which fields contribute to operator==/operator<."""

--- a/src/odb/src/codeGenerator/test_field_types.py
+++ b/src/odb/src/codeGenerator/test_field_types.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from field_types import CharPtrType, make_field_type
 from gen import ODBGenerator, make_environment
-from helper import is_set_by_ref
+from helper import is_set_by_ref, mem_info_accountable
 from schema_models import Field, Schema
 
 HERE = Path(os.path.dirname(__file__))
@@ -159,6 +159,39 @@ class SetByRefRuleTest(unittest.TestCase):
             "dbAccessType::Value",  # scoped enum
         ):
             self.assertFalse(is_set_by_ref(t, self.ENUMS), t)
+
+
+class MemInfoAccountableTest(unittest.TestCase):
+    """mem_info_accountable matches the heap types MemInfo::add() overloads accept."""
+
+    def test_accountable_heap_types(self):
+        for t in (
+            "std::string",
+            "std::vector<Point>",
+            "dbVector<int>",
+            "dbHashTable<_dbInst>",
+            "std::map<int,int>",
+            "std::unordered_map<std::string, dbId<_dbInst>>",
+            "std::set<int>",
+        ):
+            self.assertTrue(mem_info_accountable(t), t)
+
+    def test_not_accountable_inline_types(self):
+        # Scalars, refs, and small aggregates own no heap and have no overload.
+        for t in (
+            "int",
+            "bool",
+            "double",
+            "uint32_t",
+            "dbId<_dbNet>",
+            "std::pair<int,int>",
+            "std::array<bool, 6>",
+            "std::tuple<Rect, bool, bool>",
+            "char *",
+            "Point",
+            "Polygon",
+        ):
+            self.assertFalse(mem_info_accountable(t), t)
 
 
 if __name__ == "__main__":

--- a/src/odb/src/codeGenerator/test_field_types.py
+++ b/src/odb/src/codeGenerator/test_field_types.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, The OpenROAD Authors
+
+"""Validates the Field / FieldType contract against the real committed schema.
+
+Processes every field in the schema and checks that each carries a `kind`
+(field_types.FieldType) and that the Field accessor properties
+(setterArgumentType, refType, ...) resolve from that kind.
+
+Run with:  python3 -m unittest test_field_types
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from field_types import CharPtrType, make_field_type
+from gen import ODBGenerator, make_environment
+from helper import is_set_by_ref
+from schema_models import Field, Schema
+
+HERE = Path(os.path.dirname(__file__))
+
+
+def _all_fields():
+    env = make_environment(HERE / "templates")
+    gen = ODBGenerator(env, ".", ".", False)
+    schema = gen.load_schema(HERE / "schema.json")
+    gen.process_schema(schema)
+    for klass in schema.classes:
+        for field in klass.fields:
+            yield klass, field
+        # The in-class (flags_) struct members get accessors generated too, so
+        # they must carry a kind as well.
+        for struct in klass.structs:
+            if struct.in_class_name:
+                for field in struct.fields:
+                    yield klass, field
+
+
+class FieldKindContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fields = list(_all_fields())
+        assert cls.fields, "no fields processed"
+
+    def test_every_field_has_a_kind(self):
+        for klass, field in self.fields:
+            self.assertIsNotNone(field.kind, f"{klass.name}.{field.name} has no kind")
+
+    def test_field_properties_resolve_from_kind(self):
+        for klass, field in self.fields:
+            k = field.kind
+            ctx = f"{klass.name}.{field.name} (type={field.type!r})"
+
+            # classification booleans
+            self.assertEqual(k.is_hash_table, field.isHashTable, f"isHashTable {ctx}")
+            self.assertEqual(k.is_table, bool(field.table), f"table {ctx}")
+            self.assertEqual(
+                k.db_set_getter, bool(field.dbSetGetter), f"dbSetGetter {ctx}"
+            )
+
+            # isSetByRef is determined solely by the kind.
+            self.assertEqual(k.type_set_by_ref, field.isSetByRef, f"isSetByRef {ctx}")
+
+            # accessor signature types. The synthetic flags_ aggregate has no
+            # accessor types (no-get/no-set, handled by the bitFields branch).
+            if field.setterArgumentType is not None:
+                self.assertEqual(
+                    k.setter_arg_type, field.setterArgumentType, f"setterArgType {ctx}"
+                )
+            if field.getterReturnType is not None:
+                self.assertEqual(
+                    k.getter_return_type, field.getterReturnType, f"getterRetType {ctx}"
+                )
+
+            # type-dependent details, checked where they apply
+            if field.refType is not None:
+                self.assertEqual(k.ref_type, field.refType, f"refType {ctx}")
+                self.assertEqual(k.ref_table, field.refTable, f"refTable {ctx}")
+            if field.isHashTable:
+                self.assertEqual(
+                    k.hash_table_type, field.hashTableType, f"hashTableType {ctx}"
+                )
+            if field.table:
+                self.assertEqual(
+                    k.table_base_type, field.table_base_type, f"tableBaseType {ctx}"
+                )
+
+    def test_table_member_decl_is_owned_table_pointer(self):
+        """Owned-table members declare a dbTable<_Child[, N]>*; type is the child."""
+        for klass, field in self.fields:
+            if field.table:
+                ctx = f"{klass.name}.{field.name}"
+                decl = field.member_decl
+                self.assertTrue(
+                    decl.startswith(f"dbTable<_{field.table_base_type}")
+                    and decl.endswith(">*"),
+                    f"member_decl {ctx} = {decl!r}",
+                )
+                # field.type holds the child class name; member_decl adds the wrapper.
+                self.assertEqual(field.type, field.table_base_type, f"type {ctx}")
+
+
+class CharPtrSpellingTest(unittest.TestCase):
+    """Both "char *" and "char*" classify as CharPtrType (spacing-insensitive)."""
+
+    def _kind(self, type_str):
+        return make_field_type(Field(name="name_", type=type_str), Schema("."))
+
+    def test_both_spellings_are_charptr(self):
+        for spelling in ("char *", "char*"):
+            kind = self._kind(spelling)
+            self.assertIsInstance(kind, CharPtrType, spelling)
+            self.assertEqual(kind.getter_return_type, "const char *", spelling)
+            self.assertEqual(kind.setter_arg_type, "char *", spelling)
+            self.assertTrue(kind.needs_free("name_"), spelling)
+            self.assertFalse(kind.needs_free("other_"), spelling)
+
+    def test_member_decl_preserves_original_spelling(self):
+        # The stored member keeps the authored spelling; clang-format normalizes it.
+        self.assertEqual(self._kind("char *").member_decl(), "char *")
+        self.assertEqual(self._kind("char*").member_decl(), "char*")
+
+    def test_plain_char_is_not_a_pointer(self):
+        self.assertNotIsInstance(self._kind("char"), CharPtrType)
+
+
+class SetByRefRuleTest(unittest.TestCase):
+    """is_set_by_ref passes everything by const ref except scalars/pointers/enums."""
+
+    ENUMS = {"dbGDSSTrans", "dbOrientType3D"}
+
+    def test_const_ref_for_aggregates(self):
+        for t in (
+            "std::string",
+            "std::pair<int,int>",
+            "std::vector<Point>",
+            "std::map<int,int>",
+            "dbVector<int>",
+            "Rect",
+            "Point",
+            "Polygon",
+        ):
+            self.assertTrue(is_set_by_ref(t, self.ENUMS), t)
+
+    def test_by_value_for_pod_and_pointers_and_enums(self):
+        for t in (
+            "int",
+            "float",
+            "bool",
+            "uint32_t",
+            "int16_t",
+            "char *",
+            "char*",
+            "dbId<_dbNet>",
+            "dbHashTable<_dbInst>",
+            "dbGDSSTrans",  # registered external enum
+            "dbAccessType::Value",  # scoped enum
+        ):
+            self.assertFalse(is_set_by_ref(t, self.ENUMS), t)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odb/src/codeGenerator/test_field_types.py
+++ b/src/odb/src/codeGenerator/test_field_types.py
@@ -161,6 +161,39 @@ class SetByRefRuleTest(unittest.TestCase):
             self.assertFalse(is_set_by_ref(t, self.ENUMS), t)
 
 
+class FactoryGenerationTest(unittest.TestCase):
+    """An opted-in relation wires the child's generated create()/destroy()."""
+
+    @classmethod
+    def setUpClass(cls):
+        env = make_environment(HERE / "templates")
+        gen = ODBGenerator(env, ".", ".", False)
+        schema = gen.load_schema(HERE / "schema.json")
+        gen.process_schema(schema)
+        cls.by_name = {k.name: k for k in schema.classes}
+        cls.relations = schema.relations
+
+    def test_opted_in_relation_populates_child_factory(self):
+        rel = next((r for r in self.relations if r.create or r.destroy), None)
+        if rel is None:
+            self.skipTest("no relation opts into factory generation")
+        child = self.by_name[rel.child]
+        self.assertEqual(child.factory_parent, rel.parent)
+        self.assertEqual(child.factory_table, rel.tbl_name)
+        self.assertEqual(child.gen_create, rel.create)
+        self.assertEqual(child.gen_destroy, rel.destroy)
+        # The parent's internal header is pulled in for the owner cast.
+        self.assertIn(f"{rel.parent}.h", child.cpp_includes)
+
+    def test_non_factory_class_has_no_factory(self):
+        # dbCellEdgeSpacing has a hand-managed owner table (no relation), so it
+        # never opts into factory generation.
+        klass = self.by_name["dbCellEdgeSpacing"]
+        self.assertFalse(klass.gen_create)
+        self.assertFalse(klass.gen_destroy)
+        self.assertIsNone(klass.factory_parent)
+
+
 class MemInfoAccountableTest(unittest.TestCase):
     """mem_info_accountable matches the heap types MemInfo::add() overloads accept."""
 

--- a/src/odb/src/codeGenerator/test_field_types.py
+++ b/src/odb/src/codeGenerator/test_field_types.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from field_types import CharPtrType, make_field_type
 from gen import ODBGenerator, make_environment
-from helper import is_set_by_ref, mem_info_accountable
+from helper import components, is_enum, is_set_by_ref, mem_info_accountable
 from schema_models import Field, Schema
 
 HERE = Path(os.path.dirname(__file__))
@@ -159,6 +159,39 @@ class SetByRefRuleTest(unittest.TestCase):
             "dbAccessType::Value",  # scoped enum
         ):
             self.assertFalse(is_set_by_ref(t, self.ENUMS), t)
+
+
+class ComponentsRuleTest(unittest.TestCase):
+    """components() decides which fields contribute to operator==/operator<."""
+
+    def test_scoped_enum_is_a_comparison_leaf(self):
+        self.assertTrue(is_enum("dbAccessType::Value"))
+        self.assertEqual(
+            components([], "low_type_", "dbAccessType::Value"), ["low_type_"]
+        )
+
+    def test_non_value_scoped_name_is_not_an_enum(self):
+        # Nested structs share the "X::Y" shape but must not be treated as leaves.
+        self.assertFalse(is_enum("dbPowerSwitch::UPFControlPort"))
+        self.assertFalse(is_enum("std::string"))
+
+    def test_scalar_and_ref_remain_leaves(self):
+        self.assertEqual(components([], "x_", "int"), ["x_"])
+        self.assertEqual(components([], "net_", "dbId<_dbNet>"), ["net_"])
+
+    def test_uncompared_container_yields_nothing(self):
+        self.assertEqual(components([], "tbl_", "dbVector<int>"), [])
+
+    def test_cmpgt_field_with_empty_components_raises(self):
+        # A field flagged for ordering must resolve to a component; an unhandled
+        # type would otherwise drop its operator< term silently.
+        env = make_environment(HERE / "templates")
+        gen = ODBGenerator(env, ".", ".", False)
+        schema = gen.load_schema(HERE / "schema.json")
+        klass = schema.classes[0]
+        klass.fields = [Field(name="orphan_", type="dbVector<int>", flags=["cmpgt"])]
+        with self.assertRaises(ValueError):
+            gen.process_schema(schema)
 
 
 class FactoryGenerationTest(unittest.TestCase):

--- a/src/odb/src/codeGenerator/test_generator_snapshot.py
+++ b/src/odb/src/codeGenerator/test_generator_snapshot.py
@@ -110,6 +110,20 @@ class SnapshotTest(unittest.TestCase):
             "return (dbTechLayerCutClassRule*) obj->cut_class_rules_hash_.find(name);",
         )
 
+    # --- scoped enum ("Foo::Value") is a comparison leaf, not silently dropped ---
+    def test_enum_field_is_compared(self):
+        # cmpgt enums appear in both operator== and operator< (dbAccessType::Value).
+        self.assertLine(
+            "dbAccessPoint", "impl.cpp.jinja", "if (low_type_ != rhs.low_type_) {"
+        )
+        self.assertLine(
+            "dbAccessPoint", "impl.cpp.jinja", "if (low_type_ >= rhs.low_type_) {"
+        )
+        # enum bitfields compare via the packed flags_ member.
+        self.assertLine(
+            "dbTechLayer", "impl.cpp.jinja", "if (flags_.type != rhs.flags_.type) {"
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/odb/src/codeGenerator/test_generator_snapshot.py
+++ b/src/odb/src/codeGenerator/test_generator_snapshot.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, The OpenROAD Authors
+
+"""Fine-grained regression tests for the odb code generator.
+
+These render templates against the real committed schema and pin the rendered
+output for one representative field of every kind (scalar, char*, std::string,
+std::vector/dbVector pass-by-ref, dbId object ref, owned dbTable, dbHashTable).
+The whole-tree guard is `python3 gen.py` producing no git diff (enforced by CI in
+github-actions-are-odb-files-generated.yml).
+
+Run with:  python3 -m unittest test_generator_snapshot
+"""
+
+import os
+import unittest
+from pathlib import Path
+
+from gen import ODBGenerator, make_environment
+
+HERE = Path(os.path.dirname(__file__))
+
+
+def _processed_schema():
+    env = make_environment(HERE / "templates")
+    gen = ODBGenerator(env, ".", ".", False)
+    schema = gen.load_schema(HERE / "schema.json")
+    gen.process_schema(schema)
+    return env, schema, {k.name: k for k in schema.classes}
+
+
+class SnapshotTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.env, cls.schema, cls.by_name = _processed_schema()
+
+    def render(self, class_name, template):
+        return self.env.get_template(template).render(
+            klass=self.by_name[class_name], schema=self.schema
+        )
+
+    def assertLine(self, class_name, template, line):
+        """Assert an exact (stripped) line appears in the rendered template."""
+        rendered = self.render(class_name, template)
+        lines = {ln.strip() for ln in rendered.splitlines()}
+        self.assertIn(
+            line, lines, f"{line!r} not found in rendered {class_name}/{template}"
+        )
+
+    # --- char* name_ -> getter returns const char*, freed in destructor ---
+    def test_charptr_getter_and_destructor(self):
+        for klass in ("dbTechLayerCutClassRule", "dbGDSStructure"):
+            self.assertLine(
+                klass, "impl.cpp.jinja", f"const char * {klass}::getName() const"
+            )
+            self.assertLine(klass, "impl.cpp.jinja", "free((void*) name_);")
+
+    # --- std::string -> setter takes const std::string& (set-by-ref) ---
+    def test_string_setter_is_const_ref(self):
+        self.assertLine(
+            "dbGDSText",
+            "impl.cpp.jinja",
+            "void dbGDSText::setText( const std::string& text )",
+        )
+
+    # --- vector -> getter is an out-parameter by reference ---
+    def test_vector_getter_is_out_param(self):
+        self.assertLine(
+            "dbGDSPath",
+            "impl.cpp.jinja",
+            "void dbGDSPath::getXy(std::vector<Point>& tbl) const",
+        )
+
+    # --- value-struct setter passes by const ref; enum setter passes by value ---
+    def test_setter_by_ref_for_value_struct_by_value_for_enum(self):
+        self.assertLine(
+            "dbGDSBox",
+            "impl.cpp.jinja",
+            "void dbGDSBox::setBounds( const Rect& bounds )",
+        )
+        self.assertLine(
+            "dbGDSSRef",
+            "impl.cpp.jinja",
+            "void dbGDSSRef::setTransform( dbGDSSTrans transform )",
+        )
+
+    # --- dbId object ref -> getter resolves via owner table getPtr ---
+    def test_ref_getter_uses_getptr(self):
+        self.assertLine(
+            "dbGlobalConnect",
+            "impl.cpp.jinja",
+            "dbNet* dbGlobalConnect::getNet() const",
+        )
+        self.assertLine(
+            "dbGlobalConnect",
+            "impl.cpp.jinja",
+            "return (dbRegion*) par->region_tbl_->getPtr(obj->region_);",
+        )
+
+    # --- owned table -> dbSet<> getter; hashed child -> .find(name) ---
+    def test_table_dbset_and_hash_find(self):
+        self.assertLine(
+            "dbTechLayer",
+            "impl.cpp.jinja",
+            "dbSet<dbTechLayerCutClassRule> dbTechLayer::getTechLayerCutClassRules() const",
+        )
+        self.assertLine(
+            "dbTechLayer",
+            "impl.cpp.jinja",
+            "return (dbTechLayerCutClassRule*) obj->cut_class_rules_hash_.find(name);",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odb/src/codeGenerator/test_schema_validation.py
+++ b/src/odb/src/codeGenerator/test_schema_validation.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2025, The OpenROAD Authors
+
+"""Tests for schema input typing and validation (Stage E).
+
+Run with:  python3 -m unittest test_schema_validation
+"""
+
+import unittest
+
+from schema_models import Class, Field, Iterator, Relation
+
+
+class UnknownKeyRejectionTest(unittest.TestCase):
+    def test_field_rejects_unknown_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            Field.from_dict({"name": "x_", "type": "int", "typo": 1})
+        self.assertIn("typo", str(ctx.exception))
+
+    def test_class_rejects_unknown_key(self):
+        with self.assertRaises(ValueError) as ctx:
+            Class.from_dict({"name": "dbFoo", "bogus": True})
+        self.assertIn("bogus", str(ctx.exception))
+
+    def test_class_type_alias_is_accepted(self):
+        # "type" is remapped to base_class and must not be flagged as unknown.
+        klass = Class.from_dict({"name": "dbFoo", "type": "dbObject"})
+        self.assertEqual(klass.base_class, "dbObject")
+
+    def test_relation_rejects_unknown_key(self):
+        with self.assertRaises(ValueError):
+            Relation.from_dict(
+                {"parent": "a", "child": "b", "type": "1_n", "tbl_name": "t_", "x": 1}
+            )
+
+
+class IteratorTypingTest(unittest.TestCase):
+    def test_true_strings_become_bools(self):
+        it = Iterator.from_dict(
+            {
+                "name": "dbFooItr",
+                "parentObject": "dbFoo",
+                "tableName": "foo_tbl",
+                "reversible": "true",
+                "orderReversed": "true",
+                "sequential": 0,
+            }
+        )
+        self.assertIs(it.reversible, True)
+        self.assertIs(it.orderReversed, True)
+        self.assertIs(it.customEnd, False)  # absent -> default
+
+    def test_rejects_unknown_key(self):
+        with self.assertRaises(ValueError):
+            Iterator.from_dict(
+                {"name": "dbFooItr", "parentObject": "dbFoo", "tableName": "t", "z": 1}
+            )
+
+
+class RelationTypingTest(unittest.TestCase):
+    def test_defaults_and_fields(self):
+        rel = Relation.from_dict(
+            {"parent": "dbA", "child": "dbB", "type": "1_n", "tbl_name": "b_tbl_"}
+        )
+        self.assertEqual(rel.parent, "dbA")
+        self.assertFalse(rel.hash)
+        self.assertIsNone(rel.page_size)
+        self.assertEqual(rel.flags, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -57,6 +57,12 @@ bool _dbAccessPoint::operator==(const _dbAccessPoint& rhs) const
   if (bpin_ != rhs.bpin_) {
     return false;
   }
+  if (low_type_ != rhs.low_type_) {
+    return false;
+  }
+  if (high_type_ != rhs.high_type_) {
+    return false;
+  }
 
   return true;
   // NOLINTEND(readability-simplify-boolean-expr)
@@ -80,6 +86,12 @@ bool _dbAccessPoint::operator<(const _dbAccessPoint& rhs) const
     return false;
   }
   if (bpin_ >= rhs.bpin_) {
+    return false;
+  }
+  if (low_type_ >= rhs.low_type_) {
+    return false;
+  }
+  if (high_type_ >= rhs.high_type_) {
     return false;
   }
 

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -171,7 +171,7 @@ void _dbAccessPoint::setMPin(_dbMPin* mpin)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbAccessPoint::setPoint(Point point)
+void dbAccessPoint::setPoint(const Point& point)
 {
   _dbAccessPoint* obj = (_dbAccessPoint*) this;
 

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -191,6 +191,16 @@ void dbAccessPoint::setLayer(dbTechLayer* layer)
   obj->layer_ = layer->getImpl()->getOID();
 }
 
+dbBPin* dbAccessPoint::getBPin() const
+{
+  _dbAccessPoint* obj = (_dbAccessPoint*) this;
+  if (obj->bpin_ == 0) {
+    return nullptr;
+  }
+  _dbBlock* par = (_dbBlock*) obj->getOwner();
+  return (dbBPin*) par->bpin_tbl_->getPtr(obj->bpin_);
+}
+
 // User Code Begin dbAccessPointPublicMethods
 
 void dbAccessPoint::addSegment(const Rect& segment,
@@ -312,15 +322,6 @@ dbMPin* dbAccessPoint::getMPin() const
   return (dbMPin*) master->mpin_tbl_->getPtr(obj->mpin_);
 }
 
-dbBPin* dbAccessPoint::getBPin() const
-{
-  _dbAccessPoint* obj = (_dbAccessPoint*) this;
-  if (!obj->bpin_.isValid()) {
-    return nullptr;
-  }
-  _dbBlock* block = (_dbBlock*) obj->getOwner();
-  return (dbBPin*) block->bpin_tbl_->getPtr(obj->bpin_);
-}
 std::vector<std::vector<dbObject*>> dbAccessPoint::getVias() const
 {
   _dbAccessPoint* obj = (_dbAccessPoint*) this;

--- a/src/odb/src/db/dbAccessPoint.cpp
+++ b/src/odb/src/db/dbAccessPoint.cpp
@@ -143,13 +143,14 @@ void _dbAccessPoint::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["iterms"].add(iterms_);
+  info.children["path_segs"].add(path_segs_);
+
+  // User Code Begin collectMemInfo
   MemInfo& via_info = info.children["vias"];
   for (const auto& v : vias_) {
     via_info.add(v);
   }
-  info.children["path_segs"].add(path_segs_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbAlignmentMarkerRule.cpp
+++ b/src/odb/src/db/dbAlignmentMarkerRule.cpp
@@ -82,6 +82,8 @@ void _dbAlignmentMarkerRule::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["rel_orients"].add(rel_orients_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbCellEdgeSpacing.cpp
+++ b/src/odb/src/db/dbCellEdgeSpacing.cpp
@@ -89,10 +89,8 @@ void _dbCellEdgeSpacing::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["first_edge_type"].add(first_edge_type_);
   info.children["second_edge_type"].add(second_edge_type_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbCellEdgeSpacing.cpp
+++ b/src/odb/src/db/dbCellEdgeSpacing.cpp
@@ -108,7 +108,7 @@ void dbCellEdgeSpacing::setFirstEdgeType(const std::string& first_edge_type)
   obj->first_edge_type_ = first_edge_type;
 }
 
-std::string dbCellEdgeSpacing::getFirstEdgeType() const
+const std::string& dbCellEdgeSpacing::getFirstEdgeType() const
 {
   _dbCellEdgeSpacing* obj = (_dbCellEdgeSpacing*) this;
   return obj->first_edge_type_;
@@ -121,7 +121,7 @@ void dbCellEdgeSpacing::setSecondEdgeType(const std::string& second_edge_type)
   obj->second_edge_type_ = second_edge_type;
 }
 
-std::string dbCellEdgeSpacing::getSecondEdgeType() const
+const std::string& dbCellEdgeSpacing::getSecondEdgeType() const
 {
   _dbCellEdgeSpacing* obj = (_dbCellEdgeSpacing*) this;
   return obj->second_edge_type_;

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -395,7 +395,7 @@ const char* dbChip::getName() const
   return obj->name_;
 }
 
-void dbChip::setOffset(Point offset)
+void dbChip::setOffset(const Point& offset)
 {
   _dbChip* obj = (_dbChip*) this;
 

--- a/src/odb/src/db/dbChip.cpp
+++ b/src/odb/src/db/dbChip.cpp
@@ -346,14 +346,15 @@ void _dbChip::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["chipinsts_map"].add(chipinsts_map_);
+  info.children["chip_region_map"].add(chip_region_map_);
+  info.children["marker_categories_map"].add(marker_categories_map_);
   prop_tbl_->collectMemInfo(info.children["prop_tbl_"]);
-
   chip_region_tbl_->collectMemInfo(info.children["chip_region_tbl_"]);
-
   marker_categories_tbl_->collectMemInfo(
       info.children["marker_categories_tbl_"]);
-
   chip_path_tbl_->collectMemInfo(info.children["chip_path_tbl_"]);
+  info.children["chip_path_hash"].add(chip_path_hash_);
 
   // User Code Begin collectMemInfo
   block_tbl_->collectMemInfo(info.children["block"]);

--- a/src/odb/src/db/dbChipConn.cpp
+++ b/src/odb/src/db/dbChipConn.cpp
@@ -88,6 +88,10 @@ void _dbChipConn::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["name"].add(name_);
+  info.children["top_region_path"].add(top_region_path_);
+  info.children["bottom_region_path"].add(bottom_region_path_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbChipConn.cpp
+++ b/src/odb/src/db/dbChipConn.cpp
@@ -96,7 +96,7 @@ void _dbChipConn::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-std::string dbChipConn::getName() const
+const std::string& dbChipConn::getName() const
 {
   _dbChipConn* obj = (_dbChipConn*) this;
   return obj->name_;

--- a/src/odb/src/db/dbChipInst.cpp
+++ b/src/odb/src/db/dbChipInst.cpp
@@ -98,6 +98,9 @@ void _dbChipInst::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["name"].add(name_);
+  info.children["region_insts_map"].add(region_insts_map_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbChipInst.cpp
+++ b/src/odb/src/db/dbChipInst.cpp
@@ -106,7 +106,7 @@ void _dbChipInst::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-std::string dbChipInst::getName() const
+const std::string& dbChipInst::getName() const
 {
   _dbChipInst* obj = (_dbChipInst*) this;
   return obj->name_;

--- a/src/odb/src/db/dbChipInst.cpp
+++ b/src/odb/src/db/dbChipInst.cpp
@@ -112,6 +112,13 @@ std::string dbChipInst::getName() const
   return obj->name_;
 }
 
+void dbChipInst::setOrient(dbOrientType3D orient)
+{
+  _dbChipInst* obj = (_dbChipInst*) this;
+
+  obj->orient_ = orient;
+}
+
 dbOrientType3D dbChipInst::getOrient() const
 {
   _dbChipInst* obj = (_dbChipInst*) this;
@@ -144,13 +151,6 @@ dbTransform dbChipInst::getTransform() const
 {
   _dbChipInst* obj = (_dbChipInst*) this;
   return dbTransform(obj->orient_, obj->origin_);
-}
-
-void dbChipInst::setOrient(dbOrientType3D orient)
-{
-  _dbChipInst* obj = (_dbChipInst*) this;
-
-  obj->orient_ = orient;
 }
 
 void dbChipInst::setLoc(const Point3D& loc)

--- a/src/odb/src/db/dbChipNet.cpp
+++ b/src/odb/src/db/dbChipNet.cpp
@@ -79,7 +79,7 @@ void _dbChipNet::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-std::string dbChipNet::getName() const
+const std::string& dbChipNet::getName() const
 {
   _dbChipNet* obj = (_dbChipNet*) this;
   return obj->name_;

--- a/src/odb/src/db/dbChipNet.cpp
+++ b/src/odb/src/db/dbChipNet.cpp
@@ -71,6 +71,9 @@ void _dbChipNet::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["name"].add(name_);
+  info.children["bump_insts_paths"].add(bump_insts_paths_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbChipPath.cpp
+++ b/src/odb/src/db/dbChipPath.cpp
@@ -68,9 +68,10 @@ void _dbChipPath::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["entries"].add(entries_);
+
   // User Code Begin collectMemInfo
   info.children["name"].add(name_);
-  info.children["entries"].add(entries_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbChipRegion.cpp
+++ b/src/odb/src/db/dbChipRegion.cpp
@@ -111,6 +111,7 @@ void _dbChipRegion::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["name"].add(name_);
   chip_bump_tbl_->collectMemInfo(info.children["chip_bump_tbl_"]);
 }
 

--- a/src/odb/src/db/dbChipRegion.cpp
+++ b/src/odb/src/db/dbChipRegion.cpp
@@ -125,7 +125,7 @@ _dbChipRegion::~_dbChipRegion()
 //
 ////////////////////////////////////////////////////////////////////
 
-std::string dbChipRegion::getName() const
+const std::string& dbChipRegion::getName() const
 {
   _dbChipRegion* obj = (_dbChipRegion*) this;
   return obj->name_;

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -430,19 +430,13 @@ void _dbDatabase::collectMemInfo(MemInfo& info)
 
   alignment_marker_rule_tbl_->collectMemInfo(
       info.children["alignment_marker_rule_tbl_"]);
-
   chip_tbl_->collectMemInfo(info.children["chip_tbl_"]);
-
+  info.children["chip_hash"].add(chip_hash_);
   prop_tbl_->collectMemInfo(info.children["prop_tbl_"]);
-
   chip_inst_tbl_->collectMemInfo(info.children["chip_inst_tbl_"]);
-
   chip_region_inst_tbl_->collectMemInfo(info.children["chip_region_inst_tbl_"]);
-
   chip_conn_tbl_->collectMemInfo(info.children["chip_conn_tbl_"]);
-
   chip_bump_inst_tbl_->collectMemInfo(info.children["chip_bump_inst_tbl_"]);
-
   chip_net_tbl_->collectMemInfo(info.children["chip_net_tbl_"]);
 
   // User Code Begin collectMemInfo

--- a/src/odb/src/db/dbDft.cpp
+++ b/src/odb/src/db/dbDft.cpp
@@ -82,7 +82,6 @@ void _dbDft::collectMemInfo(MemInfo& info)
   info.size += sizeof(*this);
 
   scan_pins_->collectMemInfo(info.children["scan_pins_"]);
-
   scan_chains_->collectMemInfo(info.children["scan_chains_"]);
 }
 

--- a/src/odb/src/db/dbGCellGrid.cpp
+++ b/src/odb/src/db/dbGCellGrid.cpp
@@ -15,6 +15,7 @@
 #include "dbTechLayer.h"
 #include "odb/db.h"
 // User Code Begin Includes
+#include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <utility>
@@ -119,6 +120,7 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
     std::map<dbId<_dbTechLayer>, dbMatrix<OldGCellData>> old_format;
     stream >> old_format;
     for (const auto& [lid, cells] : old_format) {
+      auto& matrix = obj.get(lid);
       const uint32_t num_rows = cells.numRows();
       const uint32_t num_cols = cells.numCols();
       for (int row = 0; row < num_rows; ++row) {
@@ -126,7 +128,7 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
           auto& old = cells(row, col);
           const float usage = old.usage;
           const float capacity = old.capacity;
-          obj.setCell(lid, row, col, {.usage = usage, .capacity = capacity});
+          matrix(row, col) = {.usage = usage, .capacity = capacity};
         }
       }
     }
@@ -137,7 +139,7 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
     stream >> old_format;
     for (const auto& [lid, cells] : old_format) {
       for (const auto& [coord, data] : cells) {
-        obj.setCell(lid, coord.first, coord.second, data);
+        obj.get(lid)(coord.first, coord.second) = data;
       }
     }
   }
@@ -187,7 +189,6 @@ void _dbGCellGrid::collectMemInfo(MemInfo& info)
   info.children["y_grid"].add(y_grid_);
 
   // User Code Begin collectMemInfo
-
   MemInfo& congestion_info = info.children["congestion"];
   for (auto& [layer, data] : congestion_map_) {
     congestion_info.add(data);
@@ -223,45 +224,33 @@ dbIStream& operator>>(dbIStream& stream, dbGCellGrid::GCellData& obj)
   return stream;
 }
 
-void _dbGCellGrid::ensureMatrix(const dbId<_dbTechLayer>& lid)
+dbMatrix<dbGCellGrid::GCellData>& _dbGCellGrid::get(
+    const dbId<_dbTechLayer>& lid)
 {
-  if (congestion_map_.find(lid) != congestion_map_.end()) {
-    return;
-  }
-
-  uint32_t num_rows;
-  uint32_t num_cols;
   if (congestion_map_.empty()) {
     dbGCellGrid* pub_grid = (dbGCellGrid*) this;
     std::vector<int> grid;
     pub_grid->getGridX(grid);
-    num_rows = grid.size();
+    const uint32_t num_x = grid.size();
     pub_grid->getGridY(grid);
-    num_cols = grid.size();
-  } else {
-    const auto& existing = congestion_map_.begin()->second;
-    num_rows = existing.numRows();
-    num_cols = existing.numCols();
+    const uint32_t num_y = grid.size();
+
+    dbMatrix<dbGCellGrid::GCellData> data(num_x, num_y);
+    auto [iter, ins] = congestion_map_.emplace(lid, std::move(data));
+    return iter->second;
+  }
+  auto it = congestion_map_.find(lid);
+  if (it != congestion_map_.end()) {
+    return it->second;
   }
 
-  congestion_map_.emplace(lid,
-                          dbMatrix<dbGCellGrid::GCellData>(num_rows, num_cols));
-}
+  it = congestion_map_.begin();
+  const uint32_t num_rows = it->second.numRows();
+  const uint32_t num_cols = it->second.numCols();
 
-const dbMatrix<dbGCellGrid::GCellData>& _dbGCellGrid::get(
-    const dbId<_dbTechLayer>& lid)
-{
-  ensureMatrix(lid);
-  return congestion_map_.at(lid);
-}
-
-void _dbGCellGrid::setCell(const dbId<_dbTechLayer>& lid,
-                           uint32_t x,
-                           uint32_t y,
-                           const dbGCellGrid::GCellData& data)
-{
-  ensureMatrix(lid);
-  congestion_map_.at(lid)(x, y) = data;
+  dbMatrix<dbGCellGrid::GCellData> data(num_rows, num_cols);
+  auto [iter, ins] = congestion_map_.emplace(lid, std::move(data));
+  return iter->second;
 }
 
 dbTechLayer* _dbGCellGrid::getLayer(const dbId<_dbTechLayer>& lid) const
@@ -424,10 +413,10 @@ dbGCellGrid* dbGCellGrid::create(dbBlock* block_)
   return (dbGCellGrid*) grid;
 }
 
-dbGCellGrid* dbGCellGrid::getGCellGrid(dbBlock* block_, uint32_t oid)
+dbGCellGrid* dbGCellGrid::getGCellGrid(dbBlock* block_, uint32_t dbid_)
 {
   _dbBlock* block = (_dbBlock*) block_;
-  return (dbGCellGrid*) block->gcell_grid_tbl_->getPtr(oid);
+  return (dbGCellGrid*) block->gcell_grid_tbl_->getPtr(dbid_);
 }
 
 uint32_t dbGCellGrid::getXIdx(int x)
@@ -477,9 +466,7 @@ void dbGCellGrid::setCapacity(dbTechLayer* layer,
 {
   _dbGCellGrid* _grid = (_dbGCellGrid*) this;
   uint32_t lid = layer->getId();
-  GCellData data = _grid->get(lid)(x_idx, y_idx);
-  data.capacity = capacity;
-  _grid->setCell(lid, x_idx, y_idx, data);
+  _grid->get(lid)(x_idx, y_idx).capacity = capacity;
 }
 
 void dbGCellGrid::setUsage(dbTechLayer* layer,
@@ -489,9 +476,7 @@ void dbGCellGrid::setUsage(dbTechLayer* layer,
 {
   _dbGCellGrid* _grid = (_dbGCellGrid*) this;
   uint32_t lid = layer->getId();
-  GCellData data = _grid->get(lid)(x_idx, y_idx);
-  data.usage = use;
-  _grid->setCell(lid, x_idx, y_idx, data);
+  _grid->get(lid)(x_idx, y_idx).usage = use;
 }
 
 void dbGCellGrid::resetCongestionMap()

--- a/src/odb/src/db/dbGCellGrid.cpp
+++ b/src/odb/src/db/dbGCellGrid.cpp
@@ -120,7 +120,6 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
     std::map<dbId<_dbTechLayer>, dbMatrix<OldGCellData>> old_format;
     stream >> old_format;
     for (const auto& [lid, cells] : old_format) {
-      auto& matrix = obj.get(lid);
       const uint32_t num_rows = cells.numRows();
       const uint32_t num_cols = cells.numCols();
       for (int row = 0; row < num_rows; ++row) {
@@ -128,7 +127,7 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
           auto& old = cells(row, col);
           const float usage = old.usage;
           const float capacity = old.capacity;
-          matrix(row, col) = {.usage = usage, .capacity = capacity};
+          obj.setCell(lid, row, col, {.usage = usage, .capacity = capacity});
         }
       }
     }
@@ -139,7 +138,7 @@ dbIStream& operator>>(dbIStream& stream, _dbGCellGrid& obj)
     stream >> old_format;
     for (const auto& [lid, cells] : old_format) {
       for (const auto& [coord, data] : cells) {
-        obj.get(lid)(coord.first, coord.second) = data;
+        obj.setCell(lid, coord.first, coord.second, data);
       }
     }
   }
@@ -224,33 +223,45 @@ dbIStream& operator>>(dbIStream& stream, dbGCellGrid::GCellData& obj)
   return stream;
 }
 
-dbMatrix<dbGCellGrid::GCellData>& _dbGCellGrid::get(
-    const dbId<_dbTechLayer>& lid)
+void _dbGCellGrid::ensureMatrix(const dbId<_dbTechLayer>& lid)
 {
+  if (congestion_map_.find(lid) != congestion_map_.end()) {
+    return;
+  }
+
+  uint32_t num_rows;
+  uint32_t num_cols;
   if (congestion_map_.empty()) {
     dbGCellGrid* pub_grid = (dbGCellGrid*) this;
     std::vector<int> grid;
     pub_grid->getGridX(grid);
-    const uint32_t num_x = grid.size();
+    num_rows = grid.size();
     pub_grid->getGridY(grid);
-    const uint32_t num_y = grid.size();
-
-    dbMatrix<dbGCellGrid::GCellData> data(num_x, num_y);
-    auto [iter, ins] = congestion_map_.emplace(lid, std::move(data));
-    return iter->second;
-  }
-  auto it = congestion_map_.find(lid);
-  if (it != congestion_map_.end()) {
-    return it->second;
+    num_cols = grid.size();
+  } else {
+    const auto& existing = congestion_map_.begin()->second;
+    num_rows = existing.numRows();
+    num_cols = existing.numCols();
   }
 
-  it = congestion_map_.begin();
-  const uint32_t num_rows = it->second.numRows();
-  const uint32_t num_cols = it->second.numCols();
+  congestion_map_.emplace(lid,
+                          dbMatrix<dbGCellGrid::GCellData>(num_rows, num_cols));
+}
 
-  dbMatrix<dbGCellGrid::GCellData> data(num_rows, num_cols);
-  auto [iter, ins] = congestion_map_.emplace(lid, std::move(data));
-  return iter->second;
+const dbMatrix<dbGCellGrid::GCellData>& _dbGCellGrid::get(
+    const dbId<_dbTechLayer>& lid)
+{
+  ensureMatrix(lid);
+  return congestion_map_.at(lid);
+}
+
+void _dbGCellGrid::setCell(const dbId<_dbTechLayer>& lid,
+                           uint32_t x,
+                           uint32_t y,
+                           const dbGCellGrid::GCellData& data)
+{
+  ensureMatrix(lid);
+  congestion_map_.at(lid)(x, y) = data;
 }
 
 dbTechLayer* _dbGCellGrid::getLayer(const dbId<_dbTechLayer>& lid) const
@@ -466,7 +477,9 @@ void dbGCellGrid::setCapacity(dbTechLayer* layer,
 {
   _dbGCellGrid* _grid = (_dbGCellGrid*) this;
   uint32_t lid = layer->getId();
-  _grid->get(lid)(x_idx, y_idx).capacity = capacity;
+  GCellData data = _grid->get(lid)(x_idx, y_idx);
+  data.capacity = capacity;
+  _grid->setCell(lid, x_idx, y_idx, data);
 }
 
 void dbGCellGrid::setUsage(dbTechLayer* layer,
@@ -476,7 +489,9 @@ void dbGCellGrid::setUsage(dbTechLayer* layer,
 {
   _dbGCellGrid* _grid = (_dbGCellGrid*) this;
   uint32_t lid = layer->getId();
-  _grid->get(lid)(x_idx, y_idx).usage = use;
+  GCellData data = _grid->get(lid)(x_idx, y_idx);
+  data.usage = use;
+  _grid->setCell(lid, x_idx, y_idx, data);
 }
 
 void dbGCellGrid::resetCongestionMap()

--- a/src/odb/src/db/dbGCellGrid.cpp
+++ b/src/odb/src/db/dbGCellGrid.cpp
@@ -178,15 +178,16 @@ void _dbGCellGrid::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["x_origin"].add(x_origin_);
-  info.children["x_count_"].add(x_count_);
-  info.children["x_step_"].add(x_step_);
-  info.children["y_origin_"].add(y_origin_);
-  info.children["y_count_"].add(y_count_);
-  info.children["y_step_"].add(y_step_);
-  info.children["x_grid_"].add(x_grid_);
-  info.children["y_grid_"].add(y_grid_);
+  info.children["x_count"].add(x_count_);
+  info.children["x_step"].add(x_step_);
+  info.children["y_origin"].add(y_origin_);
+  info.children["y_count"].add(y_count_);
+  info.children["y_step"].add(y_step_);
+  info.children["x_grid"].add(x_grid_);
+  info.children["y_grid"].add(y_grid_);
+
+  // User Code Begin collectMemInfo
 
   MemInfo& congestion_info = info.children["congestion"];
   for (auto& [layer, data] : congestion_map_) {

--- a/src/odb/src/db/dbGCellGrid.cpp
+++ b/src/odb/src/db/dbGCellGrid.cpp
@@ -15,7 +15,6 @@
 #include "dbTechLayer.h"
 #include "odb/db.h"
 // User Code Begin Includes
-#include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <utility>
@@ -425,10 +424,10 @@ dbGCellGrid* dbGCellGrid::create(dbBlock* block_)
   return (dbGCellGrid*) grid;
 }
 
-dbGCellGrid* dbGCellGrid::getGCellGrid(dbBlock* block_, uint32_t dbid_)
+dbGCellGrid* dbGCellGrid::getGCellGrid(dbBlock* block_, uint32_t oid)
 {
   _dbBlock* block = (_dbBlock*) block_;
-  return (dbGCellGrid*) block->gcell_grid_tbl_->getPtr(dbid_);
+  return (dbGCellGrid*) block->gcell_grid_tbl_->getPtr(oid);
 }
 
 uint32_t dbGCellGrid::getXIdx(int x)

--- a/src/odb/src/db/dbGCellGrid.h
+++ b/src/odb/src/db/dbGCellGrid.h
@@ -41,13 +41,7 @@ class _dbGCellGrid : public _dbObject
   bool operator<(const _dbGCellGrid& rhs) const;
   void collectMemInfo(MemInfo& info);
   // User Code Begin Methods
-  // Lazily create the congestion matrix for a layer if it does not exist.
-  void ensureMatrix(const dbId<_dbTechLayer>& lid);
-  const dbMatrix<dbGCellGrid::GCellData>& get(const dbId<_dbTechLayer>& lid);
-  void setCell(const dbId<_dbTechLayer>& lid,
-               uint32_t x,
-               uint32_t y,
-               const dbGCellGrid::GCellData& data);
+  dbMatrix<dbGCellGrid::GCellData>& get(const dbId<_dbTechLayer>& lid);
   dbTechLayer* getLayer(const dbId<_dbTechLayer>& lid) const;
   // User Code End Methods
 

--- a/src/odb/src/db/dbGCellGrid.h
+++ b/src/odb/src/db/dbGCellGrid.h
@@ -41,7 +41,13 @@ class _dbGCellGrid : public _dbObject
   bool operator<(const _dbGCellGrid& rhs) const;
   void collectMemInfo(MemInfo& info);
   // User Code Begin Methods
-  dbMatrix<dbGCellGrid::GCellData>& get(const dbId<_dbTechLayer>& lid);
+  // Lazily create the congestion matrix for a layer if it does not exist.
+  void ensureMatrix(const dbId<_dbTechLayer>& lid);
+  const dbMatrix<dbGCellGrid::GCellData>& get(const dbId<_dbTechLayer>& lid);
+  void setCell(const dbId<_dbTechLayer>& lid,
+               uint32_t x,
+               uint32_t y,
+               const dbGCellGrid::GCellData& data);
   dbTechLayer* getLayer(const dbId<_dbTechLayer>& lid) const;
   // User Code End Methods
 

--- a/src/odb/src/db/dbGDSARef.cpp
+++ b/src/odb/src/db/dbGDSARef.cpp
@@ -103,7 +103,7 @@ void _dbGDSARef::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbGDSARef::setOrigin(Point origin)
+void dbGDSARef::setOrigin(const Point& origin)
 {
   _dbGDSARef* obj = (_dbGDSARef*) this;
 
@@ -116,7 +116,7 @@ Point dbGDSARef::getOrigin() const
   return obj->origin_;
 }
 
-void dbGDSARef::setLr(Point lr)
+void dbGDSARef::setLr(const Point& lr)
 {
   _dbGDSARef* obj = (_dbGDSARef*) this;
 
@@ -129,7 +129,7 @@ Point dbGDSARef::getLr() const
   return obj->lr_;
 }
 
-void dbGDSARef::setUl(Point ul)
+void dbGDSARef::setUl(const Point& ul)
 {
   _dbGDSARef* obj = (_dbGDSARef*) this;
 

--- a/src/odb/src/db/dbGDSARef.cpp
+++ b/src/odb/src/db/dbGDSARef.cpp
@@ -194,10 +194,17 @@ dbGDSStructure* dbGDSARef::getStructure() const
   return (dbGDSStructure*) lib->gdsstructure_tbl_->getPtr(obj->structure_);
 }
 
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSARef::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>&
+dbGDSARef::getPropattr() const
 {
   auto* obj = (_dbGDSARef*) this;
   return obj->propattr_;
+}
+
+void dbGDSARef::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSARef*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 dbGDSARef* dbGDSARef::create(dbGDSStructure* parent, dbGDSStructure* child)

--- a/src/odb/src/db/dbGDSBoundary.cpp
+++ b/src/odb/src/db/dbGDSBoundary.cpp
@@ -130,10 +130,17 @@ const std::vector<Point>& dbGDSBoundary::getXY()
   return obj->xy_;
 }
 
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSBoundary::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>&
+dbGDSBoundary::getPropattr() const
 {
   auto* obj = (_dbGDSBoundary*) this;
   return obj->propattr_;
+}
+
+void dbGDSBoundary::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSBoundary*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 dbGDSBoundary* dbGDSBoundary::create(dbGDSStructure* structure)

--- a/src/odb/src/db/dbGDSBoundary.cpp
+++ b/src/odb/src/db/dbGDSBoundary.cpp
@@ -69,8 +69,9 @@ void _dbGDSBoundary::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["xy"].add(xy_);
+
+  // User Code Begin collectMemInfo
   info.children["propattr"].add(propattr_);
   for (auto& [i, s] : propattr_) {
     info.children["propattr"].add(s);

--- a/src/odb/src/db/dbGDSBox.cpp
+++ b/src/odb/src/db/dbGDSBox.cpp
@@ -112,7 +112,7 @@ int16_t dbGDSBox::getDatatype() const
   return obj->datatype_;
 }
 
-void dbGDSBox::setBounds(Rect bounds)
+void dbGDSBox::setBounds(const Rect& bounds)
 {
   _dbGDSBox* obj = (_dbGDSBox*) this;
 

--- a/src/odb/src/db/dbGDSBox.cpp
+++ b/src/odb/src/db/dbGDSBox.cpp
@@ -126,10 +126,17 @@ Rect dbGDSBox::getBounds() const
 }
 
 // User Code Begin dbGDSBoxPublicMethods
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSBox::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>& dbGDSBox::getPropattr()
+    const
 {
   auto* obj = (_dbGDSBox*) this;
   return obj->propattr_;
+}
+
+void dbGDSBox::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSBox*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 dbGDSBox* dbGDSBox::create(dbGDSStructure* structure)

--- a/src/odb/src/db/dbGDSPath.cpp
+++ b/src/odb/src/db/dbGDSPath.cpp
@@ -162,10 +162,17 @@ int16_t dbGDSPath::getPathType() const
 }
 
 // User Code Begin dbGDSPathPublicMethods
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSPath::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>&
+dbGDSPath::getPropattr() const
 {
   auto* obj = (_dbGDSPath*) this;
   return obj->propattr_;
+}
+
+void dbGDSPath::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSPath*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 const std::vector<Point>& dbGDSPath::getXY()

--- a/src/odb/src/db/dbGDSPath.cpp
+++ b/src/odb/src/db/dbGDSPath.cpp
@@ -81,8 +81,9 @@ void _dbGDSPath::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["xy"].add(xy_);
+
+  // User Code Begin collectMemInfo
   info.children["propattr"].add(propattr_);
   for (auto& [i, s] : propattr_) {
     info.children["propattr"].add(s);

--- a/src/odb/src/db/dbGDSSRef.cpp
+++ b/src/odb/src/db/dbGDSSRef.cpp
@@ -81,7 +81,7 @@ void _dbGDSSRef::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-void dbGDSSRef::setOrigin(Point origin)
+void dbGDSSRef::setOrigin(const Point& origin)
 {
   _dbGDSSRef* obj = (_dbGDSSRef*) this;
 

--- a/src/odb/src/db/dbGDSSRef.cpp
+++ b/src/odb/src/db/dbGDSSRef.cpp
@@ -120,10 +120,17 @@ dbGDSStructure* dbGDSSRef::getStructure() const
   return (dbGDSStructure*) lib->gdsstructure_tbl_->getPtr(obj->structure_);
 }
 
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSSRef::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>&
+dbGDSSRef::getPropattr() const
 {
   auto* obj = (_dbGDSSRef*) this;
   return obj->propattr_;
+}
+
+void dbGDSSRef::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSSRef*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 dbGDSSRef* dbGDSSRef::create(dbGDSStructure* parent, dbGDSStructure* child)

--- a/src/odb/src/db/dbGDSStructure.cpp
+++ b/src/odb/src/db/dbGDSStructure.cpp
@@ -4,6 +4,8 @@
 // Generator Code Begin Cpp
 #include "dbGDSStructure.h"
 
+#include <cstdlib>
+
 #include "dbCore.h"
 #include "dbDatabase.h"
 #include "dbGDSARef.h"
@@ -152,6 +154,9 @@ void _dbGDSStructure::collectMemInfo(MemInfo& info)
 
 _dbGDSStructure::~_dbGDSStructure()
 {
+  if (name_) {
+    free((void*) name_);
+  }
   delete boundaries_;
   delete boxes_;
   delete paths_;
@@ -166,7 +171,7 @@ _dbGDSStructure::~_dbGDSStructure()
 //
 ////////////////////////////////////////////////////////////////////
 
-char* dbGDSStructure::getName() const
+const char* dbGDSStructure::getName() const
 {
   _dbGDSStructure* obj = (_dbGDSStructure*) this;
   return obj->name_;

--- a/src/odb/src/db/dbGDSStructure.cpp
+++ b/src/odb/src/db/dbGDSStructure.cpp
@@ -136,15 +136,10 @@ void _dbGDSStructure::collectMemInfo(MemInfo& info)
   info.size += sizeof(*this);
 
   boundaries_->collectMemInfo(info.children["boundaries_"]);
-
   boxes_->collectMemInfo(info.children["boxes_"]);
-
   paths_->collectMemInfo(info.children["paths_"]);
-
   srefs_->collectMemInfo(info.children["srefs_"]);
-
   arefs_->collectMemInfo(info.children["arefs_"]);
-
   texts_->collectMemInfo(info.children["texts_"]);
 
   // User Code Begin collectMemInfo

--- a/src/odb/src/db/dbGDSText.cpp
+++ b/src/odb/src/db/dbGDSText.cpp
@@ -81,12 +81,13 @@ void _dbGDSText::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["text"].add(text_);
+
   // User Code Begin collectMemInfo
   info.children["propattr"].add(propattr_);
   for (auto& [i, s] : propattr_) {
     info.children["propattr"].add(s);
   }
-  info.children["text"].add(text_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbGDSText.cpp
+++ b/src/odb/src/db/dbGDSText.cpp
@@ -175,10 +175,17 @@ std::string dbGDSText::getText() const
 }
 
 // User Code Begin dbGDSTextPublicMethods
-std::vector<std::pair<std::int16_t, std::string>>& dbGDSText::getPropattr()
+const std::vector<std::pair<std::int16_t, std::string>>&
+dbGDSText::getPropattr() const
 {
   auto* obj = (_dbGDSText*) this;
   return obj->propattr_;
+}
+
+void dbGDSText::addPropattr(std::int16_t type, const std::string& value)
+{
+  auto* obj = (_dbGDSText*) this;
+  obj->propattr_.emplace_back(type, value);
 }
 
 dbGDSText* dbGDSText::create(dbGDSStructure* structure)

--- a/src/odb/src/db/dbGDSText.cpp
+++ b/src/odb/src/db/dbGDSText.cpp
@@ -168,7 +168,7 @@ void dbGDSText::setText(const std::string& text)
   obj->text_ = text;
 }
 
-std::string dbGDSText::getText() const
+const std::string& dbGDSText::getText() const
 {
   _dbGDSText* obj = (_dbGDSText*) this;
   return obj->text_;

--- a/src/odb/src/db/dbGDSText.cpp
+++ b/src/odb/src/db/dbGDSText.cpp
@@ -122,7 +122,7 @@ int16_t dbGDSText::getDatatype() const
   return obj->datatype_;
 }
 
-void dbGDSText::setOrigin(Point origin)
+void dbGDSText::setOrigin(const Point& origin)
 {
   _dbGDSText* obj = (_dbGDSText*) this;
 

--- a/src/odb/src/db/dbGlobalConnect.cpp
+++ b/src/odb/src/db/dbGlobalConnect.cpp
@@ -129,13 +129,13 @@ dbNet* dbGlobalConnect::getNet() const
   return (dbNet*) par->net_tbl_->getPtr(obj->net_);
 }
 
-std::string dbGlobalConnect::getInstPattern() const
+const std::string& dbGlobalConnect::getInstPattern() const
 {
   _dbGlobalConnect* obj = (_dbGlobalConnect*) this;
   return obj->inst_pattern_;
 }
 
-std::string dbGlobalConnect::getPinPattern() const
+const std::string& dbGlobalConnect::getPinPattern() const
 {
   _dbGlobalConnect* obj = (_dbGlobalConnect*) this;
   return obj->pin_pattern_;

--- a/src/odb/src/db/dbGlobalConnect.cpp
+++ b/src/odb/src/db/dbGlobalConnect.cpp
@@ -97,10 +97,8 @@ void _dbGlobalConnect::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["inst_pattern"].add(inst_pattern_);
   info.children["pin_pattern"].add(pin_pattern_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbGroup.cpp
+++ b/src/odb/src/db/dbGroup.cpp
@@ -149,10 +149,11 @@ void _dbGroup::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
-  info.children["name"].add(name_);
   info.children["power_nets"].add(power_nets_);
   info.children["ground_nets"].add(ground_nets_);
+
+  // User Code Begin collectMemInfo
+  info.children["name"].add(name_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbIsolation.cpp
+++ b/src/odb/src/db/dbIsolation.cpp
@@ -100,14 +100,15 @@ void _dbIsolation::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
-  info.children["name"].add(name_);
   info.children["applies_to"].add(applies_to_);
   info.children["clamp_value"].add(clamp_value_);
   info.children["isolation_signal"].add(isolation_signal_);
   info.children["isolation_sense"].add(isolation_sense_);
   info.children["location"].add(location_);
   info.children["isolation_cells"].add(isolation_cells_);
+
+  // User Code Begin collectMemInfo
+  info.children["name"].add(name_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbIsolation.cpp
+++ b/src/odb/src/db/dbIsolation.cpp
@@ -137,7 +137,7 @@ void dbIsolation::setAppliesTo(const std::string& applies_to)
   obj->applies_to_ = applies_to;
 }
 
-std::string dbIsolation::getAppliesTo() const
+const std::string& dbIsolation::getAppliesTo() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->applies_to_;
@@ -150,7 +150,7 @@ void dbIsolation::setClampValue(const std::string& clamp_value)
   obj->clamp_value_ = clamp_value;
 }
 
-std::string dbIsolation::getClampValue() const
+const std::string& dbIsolation::getClampValue() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->clamp_value_;
@@ -163,7 +163,7 @@ void dbIsolation::setIsolationSignal(const std::string& isolation_signal)
   obj->isolation_signal_ = isolation_signal;
 }
 
-std::string dbIsolation::getIsolationSignal() const
+const std::string& dbIsolation::getIsolationSignal() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->isolation_signal_;
@@ -176,7 +176,7 @@ void dbIsolation::setIsolationSense(const std::string& isolation_sense)
   obj->isolation_sense_ = isolation_sense;
 }
 
-std::string dbIsolation::getIsolationSense() const
+const std::string& dbIsolation::getIsolationSense() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->isolation_sense_;
@@ -189,7 +189,7 @@ void dbIsolation::setLocation(const std::string& location)
   obj->location_ = location;
 }
 
-std::string dbIsolation::getLocation() const
+const std::string& dbIsolation::getLocation() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->location_;

--- a/src/odb/src/db/dbIsolation.cpp
+++ b/src/odb/src/db/dbIsolation.cpp
@@ -130,10 +130,24 @@ const char* dbIsolation::getName() const
   return obj->name_;
 }
 
+void dbIsolation::setAppliesTo(const std::string& applies_to)
+{
+  _dbIsolation* obj = (_dbIsolation*) this;
+
+  obj->applies_to_ = applies_to;
+}
+
 std::string dbIsolation::getAppliesTo() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->applies_to_;
+}
+
+void dbIsolation::setClampValue(const std::string& clamp_value)
+{
+  _dbIsolation* obj = (_dbIsolation*) this;
+
+  obj->clamp_value_ = clamp_value;
 }
 
 std::string dbIsolation::getClampValue() const
@@ -142,16 +156,37 @@ std::string dbIsolation::getClampValue() const
   return obj->clamp_value_;
 }
 
+void dbIsolation::setIsolationSignal(const std::string& isolation_signal)
+{
+  _dbIsolation* obj = (_dbIsolation*) this;
+
+  obj->isolation_signal_ = isolation_signal;
+}
+
 std::string dbIsolation::getIsolationSignal() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->isolation_signal_;
 }
 
+void dbIsolation::setIsolationSense(const std::string& isolation_sense)
+{
+  _dbIsolation* obj = (_dbIsolation*) this;
+
+  obj->isolation_sense_ = isolation_sense;
+}
+
 std::string dbIsolation::getIsolationSense() const
 {
   _dbIsolation* obj = (_dbIsolation*) this;
   return obj->isolation_sense_;
+}
+
+void dbIsolation::setLocation(const std::string& location)
+{
+  _dbIsolation* obj = (_dbIsolation*) this;
+
+  obj->location_ = location;
 }
 
 std::string dbIsolation::getLocation() const
@@ -194,36 +229,6 @@ dbIsolation* dbIsolation::create(dbBlock* block, const char* name)
 void dbIsolation::destroy(dbIsolation* iso)
 {
   // TODO
-}
-
-void dbIsolation::setAppliesTo(const std::string& applies_to)
-{
-  _dbIsolation* obj = (_dbIsolation*) this;
-  obj->applies_to_ = applies_to;
-}
-
-void dbIsolation::setClampValue(const std::string& clamp_value)
-{
-  _dbIsolation* obj = (_dbIsolation*) this;
-  obj->clamp_value_ = clamp_value;
-}
-
-void dbIsolation::setIsolationSignal(const std::string& isolation_signal)
-{
-  _dbIsolation* obj = (_dbIsolation*) this;
-  obj->isolation_signal_ = isolation_signal;
-}
-
-void dbIsolation::setIsolationSense(const std::string& isolation_sense)
-{
-  _dbIsolation* obj = (_dbIsolation*) this;
-  obj->isolation_sense_ = isolation_sense;
-}
-
-void dbIsolation::setLocation(const std::string& location)
-{
-  _dbIsolation* obj = (_dbIsolation*) this;
-  obj->location_ = location;
 }
 
 void dbIsolation::addIsolationCell(const std::string& master)

--- a/src/odb/src/db/dbLevelShifter.cpp
+++ b/src/odb/src/db/dbLevelShifter.cpp
@@ -179,25 +179,26 @@ void _dbLevelShifter::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["elements"].add(elements_);
+  info.children["exclude_elements"].add(exclude_elements_);
+  info.children["source"].add(source_);
+  info.children["sink"].add(sink_);
+  info.children["applies_to"].add(applies_to_);
+  info.children["applies_to_boundary"].add(applies_to_boundary_);
+  info.children["rule"].add(rule_);
+  info.children["location"].add(location_);
+  info.children["input_supply"].add(input_supply_);
+  info.children["output_supply"].add(output_supply_);
+  info.children["internal_supply"].add(internal_supply_);
+  info.children["name_prefix"].add(name_prefix_);
+  info.children["name_suffix"].add(name_suffix_);
+  info.children["instances"].add(instances_);
+  info.children["cell_name"].add(cell_name_);
+  info.children["cell_input"].add(cell_input_);
+  info.children["cell_output"].add(cell_output_);
+
   // User Code Begin collectMemInfo
   info.children["name"].add(name_);
-  info.children["_elements"].add(elements_);
-  info.children["_exclude_elements"].add(exclude_elements_);
-  info.children["_source"].add(source_);
-  info.children["_sink"].add(sink_);
-  info.children["_applies_to"].add(applies_to_);
-  info.children["_applies_to_boundary"].add(applies_to_boundary_);
-  info.children["_rule"].add(rule_);
-  info.children["_location"].add(location_);
-  info.children["_input_supply"].add(input_supply_);
-  info.children["_output_supply"].add(output_supply_);
-  info.children["_internal_supply"].add(internal_supply_);
-  info.children["_name_prefix"].add(name_prefix_);
-  info.children["_name_suffix"].add(name_suffix_);
-  info.children["_instances"].add(instances_);
-  info.children["_cell_name"].add(cell_name_);
-  info.children["_cell_input"].add(cell_input_);
-  info.children["_cell_output"].add(cell_output_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbLevelShifter.cpp
+++ b/src/odb/src/db/dbLevelShifter.cpp
@@ -237,7 +237,7 @@ void dbLevelShifter::setSource(const std::string& source)
   obj->source_ = source;
 }
 
-std::string dbLevelShifter::getSource() const
+const std::string& dbLevelShifter::getSource() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->source_;
@@ -250,7 +250,7 @@ void dbLevelShifter::setSink(const std::string& sink)
   obj->sink_ = sink;
 }
 
-std::string dbLevelShifter::getSink() const
+const std::string& dbLevelShifter::getSink() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->sink_;
@@ -277,7 +277,7 @@ void dbLevelShifter::setAppliesTo(const std::string& applies_to)
   obj->applies_to_ = applies_to;
 }
 
-std::string dbLevelShifter::getAppliesTo() const
+const std::string& dbLevelShifter::getAppliesTo() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->applies_to_;
@@ -291,7 +291,7 @@ void dbLevelShifter::setAppliesToBoundary(
   obj->applies_to_boundary_ = applies_to_boundary;
 }
 
-std::string dbLevelShifter::getAppliesToBoundary() const
+const std::string& dbLevelShifter::getAppliesToBoundary() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->applies_to_boundary_;
@@ -304,7 +304,7 @@ void dbLevelShifter::setRule(const std::string& rule)
   obj->rule_ = rule;
 }
 
-std::string dbLevelShifter::getRule() const
+const std::string& dbLevelShifter::getRule() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->rule_;
@@ -356,7 +356,7 @@ void dbLevelShifter::setLocation(const std::string& location)
   obj->location_ = location;
 }
 
-std::string dbLevelShifter::getLocation() const
+const std::string& dbLevelShifter::getLocation() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->location_;
@@ -369,7 +369,7 @@ void dbLevelShifter::setInputSupply(const std::string& input_supply)
   obj->input_supply_ = input_supply;
 }
 
-std::string dbLevelShifter::getInputSupply() const
+const std::string& dbLevelShifter::getInputSupply() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->input_supply_;
@@ -382,7 +382,7 @@ void dbLevelShifter::setOutputSupply(const std::string& output_supply)
   obj->output_supply_ = output_supply;
 }
 
-std::string dbLevelShifter::getOutputSupply() const
+const std::string& dbLevelShifter::getOutputSupply() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->output_supply_;
@@ -395,7 +395,7 @@ void dbLevelShifter::setInternalSupply(const std::string& internal_supply)
   obj->internal_supply_ = internal_supply;
 }
 
-std::string dbLevelShifter::getInternalSupply() const
+const std::string& dbLevelShifter::getInternalSupply() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->internal_supply_;
@@ -408,7 +408,7 @@ void dbLevelShifter::setNamePrefix(const std::string& name_prefix)
   obj->name_prefix_ = name_prefix;
 }
 
-std::string dbLevelShifter::getNamePrefix() const
+const std::string& dbLevelShifter::getNamePrefix() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->name_prefix_;
@@ -421,7 +421,7 @@ void dbLevelShifter::setNameSuffix(const std::string& name_suffix)
   obj->name_suffix_ = name_suffix;
 }
 
-std::string dbLevelShifter::getNameSuffix() const
+const std::string& dbLevelShifter::getNameSuffix() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->name_suffix_;
@@ -434,7 +434,7 @@ void dbLevelShifter::setCellName(const std::string& cell_name)
   obj->cell_name_ = cell_name;
 }
 
-std::string dbLevelShifter::getCellName() const
+const std::string& dbLevelShifter::getCellName() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->cell_name_;
@@ -447,7 +447,7 @@ void dbLevelShifter::setCellInput(const std::string& cell_input)
   obj->cell_input_ = cell_input;
 }
 
-std::string dbLevelShifter::getCellInput() const
+const std::string& dbLevelShifter::getCellInput() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->cell_input_;
@@ -460,7 +460,7 @@ void dbLevelShifter::setCellOutput(const std::string& cell_output)
   obj->cell_output_ = cell_output;
 }
 
-std::string dbLevelShifter::getCellOutput() const
+const std::string& dbLevelShifter::getCellOutput() const
 {
   _dbLevelShifter* obj = (_dbLevelShifter*) this;
   return obj->cell_output_;

--- a/src/odb/src/db/dbLogicPort.cpp
+++ b/src/odb/src/db/dbLogicPort.cpp
@@ -71,9 +71,10 @@ void _dbLogicPort::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["direction"].add(direction);
+
   // User Code Begin collectMemInfo
   info.children["name"].add(name_);
-  info.children["direction"].add(direction);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbLogicPort.cpp
+++ b/src/odb/src/db/dbLogicPort.cpp
@@ -96,7 +96,7 @@ const char* dbLogicPort::getName() const
   return obj->name_;
 }
 
-std::string dbLogicPort::getDirection() const
+const std::string& dbLogicPort::getDirection() const
 {
   _dbLogicPort* obj = (_dbLogicPort*) this;
   return obj->direction;

--- a/src/odb/src/db/dbMarker.cpp
+++ b/src/odb/src/db/dbMarker.cpp
@@ -208,8 +208,9 @@ void _dbMarker::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["comment"].add(comment_);
+
+  // User Code Begin collectMemInfo
   info.children["sources"].add(sources_);
   info.children["shapes"].add(shapes_);
   // User Code End collectMemInfo

--- a/src/odb/src/db/dbMarker.cpp
+++ b/src/odb/src/db/dbMarker.cpp
@@ -557,7 +557,7 @@ void dbMarker::setComment(const std::string& comment)
   obj->comment_ = comment;
 }
 
-std::string dbMarker::getComment() const
+const std::string& dbMarker::getComment() const
 {
   _dbMarker* obj = (_dbMarker*) this;
   return obj->comment_;

--- a/src/odb/src/db/dbMarkerCategory.cpp
+++ b/src/odb/src/db/dbMarkerCategory.cpp
@@ -127,13 +127,11 @@ void _dbMarkerCategory::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["description"].add(description_);
+  info.children["source"].add(source_);
   marker_tbl_->collectMemInfo(info.children["marker_tbl_"]);
-
   categories_tbl_->collectMemInfo(info.children["categories_tbl_"]);
-
-  // User Code Begin collectMemInfo
   info.children["categories_hash"].add(categories_hash_);
-  // User Code End collectMemInfo
 }
 
 _dbMarkerCategory::~_dbMarkerCategory()

--- a/src/odb/src/db/dbMarkerCategory.cpp
+++ b/src/odb/src/db/dbMarkerCategory.cpp
@@ -313,7 +313,7 @@ void dbMarkerCategory::setDescription(const std::string& description)
   obj->description_ = description;
 }
 
-std::string dbMarkerCategory::getDescription() const
+const std::string& dbMarkerCategory::getDescription() const
 {
   _dbMarkerCategory* obj = (_dbMarkerCategory*) this;
   return obj->description_;

--- a/src/odb/src/db/dbMasterEdgeType.cpp
+++ b/src/odb/src/db/dbMasterEdgeType.cpp
@@ -99,7 +99,7 @@ void dbMasterEdgeType::setEdgeType(const std::string& edge_type)
   obj->edge_type_ = edge_type;
 }
 
-std::string dbMasterEdgeType::getEdgeType() const
+const std::string& dbMasterEdgeType::getEdgeType() const
 {
   _dbMasterEdgeType* obj = (_dbMasterEdgeType*) this;
   return obj->edge_type_;

--- a/src/odb/src/db/dbMasterEdgeType.cpp
+++ b/src/odb/src/db/dbMasterEdgeType.cpp
@@ -81,9 +81,7 @@ void _dbMasterEdgeType::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["edge_type"].add(edge_type_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbMetalWidthViaMap.cpp
+++ b/src/odb/src/db/dbMetalWidthViaMap.cpp
@@ -97,9 +97,7 @@ void _dbMetalWidthViaMap::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["via_name"].add(via_name_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbMetalWidthViaMap.cpp
+++ b/src/odb/src/db/dbMetalWidthViaMap.cpp
@@ -187,7 +187,7 @@ void dbMetalWidthViaMap::setViaName(const std::string& via_name)
   obj->via_name_ = via_name;
 }
 
-std::string dbMetalWidthViaMap::getViaName() const
+const std::string& dbMetalWidthViaMap::getViaName() const
 {
   _dbMetalWidthViaMap* obj = (_dbMetalWidthViaMap*) this;
   return obj->via_name_;

--- a/src/odb/src/db/dbPolygon.cpp
+++ b/src/odb/src/db/dbPolygon.cpp
@@ -116,7 +116,7 @@ void _dbPolygon::collectMemInfo(MemInfo& info)
 //
 ////////////////////////////////////////////////////////////////////
 
-Polygon dbPolygon::getPolygon() const
+const Polygon& dbPolygon::getPolygon() const
 {
   _dbPolygon* obj = (_dbPolygon*) this;
   return obj->polygon_;

--- a/src/odb/src/db/dbPowerDomain.cpp
+++ b/src/odb/src/db/dbPowerDomain.cpp
@@ -118,12 +118,13 @@ void _dbPowerDomain::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
-  info.children["name"].add(name_);
   info.children["elements"].add(elements_);
   info.children["power_switch"].add(power_switch_);
   info.children["isolation"].add(isolation_);
   info.children["levelshifters"].add(levelshifters_);
+
+  // User Code Begin collectMemInfo
+  info.children["name"].add(name_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbPowerSwitch.cpp
+++ b/src/odb/src/db/dbPowerSwitch.cpp
@@ -194,13 +194,14 @@ void _dbPowerSwitch::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
-  info.children["name"].add(name_);
   info.children["in_supply_port"].add(in_supply_port_);
   info.children["control_port"].add(control_port_);
   info.children["acknowledge_port"].add(acknowledge_port_);
   info.children["on_state"].add(on_state_);
   info.children["port_map"].add(port_map_);
+
+  // User Code Begin collectMemInfo
+  info.children["name"].add(name_);
   // User Code End collectMemInfo
 }
 

--- a/src/odb/src/db/dbScanChain.cpp
+++ b/src/odb/src/db/dbScanChain.cpp
@@ -107,6 +107,8 @@ void _dbScanChain::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["name"].add(name_);
+  info.children["test_mode_name"].add(test_mode_name_);
   scan_partitions_->collectMemInfo(info.children["scan_partitions_"]);
 }
 

--- a/src/odb/src/db/dbScanChain.cpp
+++ b/src/odb/src/db/dbScanChain.cpp
@@ -142,23 +142,22 @@ void dbScanChain::setName(std::string_view name)
 }
 
 std::variant<dbBTerm*, dbITerm*> _dbScanChain::getPin(
-    const dbId<dbScanPin>& scan_pin_id)
+    const dbId<_dbScanPin>& scan_pin_id)
 {
   _dbDft* dft = (_dbDft*) getOwner();
-  return ((dbScanPin*) dft->scan_pins_->getPtr((dbId<_dbScanPin>) scan_pin_id))
-      ->getPin();
+  return ((dbScanPin*) dft->scan_pins_->getPtr(scan_pin_id))->getPin();
 }
 
-void _dbScanChain::setPin(dbId<dbScanPin> _dbScanChain::*field, dbBTerm* pin)
+void _dbScanChain::setPin(dbId<_dbScanPin> _dbScanChain::*field, dbBTerm* pin)
 {
   dbDft* dft = (dbDft*) getOwner();
-  this->*field = dbScanPin::create(dft, pin);
+  this->*field = dbScanPin::create(dft, pin)->getImpl()->getOID();
 }
 
-void _dbScanChain::setPin(dbId<dbScanPin> _dbScanChain::*field, dbITerm* pin)
+void _dbScanChain::setPin(dbId<_dbScanPin> _dbScanChain::*field, dbITerm* pin)
 {
   dbDft* dft = (dbDft*) getOwner();
-  this->*field = dbScanPin::create(dft, pin);
+  this->*field = dbScanPin::create(dft, pin)->getImpl()->getOID();
 }
 
 void dbScanChain::setScanIn(dbBTerm* scan_in)

--- a/src/odb/src/db/dbScanChain.h
+++ b/src/odb/src/db/dbScanChain.h
@@ -23,6 +23,7 @@ class dbIStream;
 class dbOStream;
 class _dbDatabase;
 class _dbScanPartition;
+class _dbScanPin;
 
 class _dbScanChain : public _dbObject
 {
@@ -37,16 +38,16 @@ class _dbScanChain : public _dbObject
   dbObjectTable* getObjectTable(dbObjectType type);
   void collectMemInfo(MemInfo& info);
   // User Code Begin Methods
-  std::variant<dbBTerm*, dbITerm*> getPin(const dbId<dbScanPin>& scan_pin_id);
-  void setPin(dbId<dbScanPin> _dbScanChain::*field, dbBTerm* pin);
-  void setPin(dbId<dbScanPin> _dbScanChain::*field, dbITerm* pin);
+  std::variant<dbBTerm*, dbITerm*> getPin(const dbId<_dbScanPin>& scan_pin_id);
+  void setPin(dbId<_dbScanPin> _dbScanChain::*field, dbBTerm* pin);
+  void setPin(dbId<_dbScanPin> _dbScanChain::*field, dbITerm* pin);
   // User Code End Methods
 
   std::string name_;
-  dbId<dbScanPin> scan_in_;
-  dbId<dbScanPin> scan_out_;
-  dbId<dbScanPin> scan_enable_;
-  dbId<dbScanPin> test_mode_;
+  dbId<_dbScanPin> scan_in_;
+  dbId<_dbScanPin> scan_out_;
+  dbId<_dbScanPin> scan_enable_;
+  dbId<_dbScanPin> test_mode_;
   std::string test_mode_name_;
   dbTable<_dbScanPartition>* scan_partitions_;
 };

--- a/src/odb/src/db/dbScanInst.cpp
+++ b/src/odb/src/db/dbScanInst.cpp
@@ -162,7 +162,8 @@ void dbScanInst::setScanEnable(dbBTerm* scan_enable)
   _dbScanInst* scan_inst = (_dbScanInst*) this;
   _dbBlock* block = (_dbBlock*) scan_inst->getOwner();
   dbDft* dft = (dbDft*) block->dft_tbl_->getPtr(block->dft_);
-  scan_inst->scan_enable_ = dbScanPin::create(dft, scan_enable);
+  scan_inst->scan_enable_
+      = dbScanPin::create(dft, scan_enable)->getImpl()->getOID();
 }
 
 void dbScanInst::setScanEnable(dbITerm* scan_enable)
@@ -170,7 +171,8 @@ void dbScanInst::setScanEnable(dbITerm* scan_enable)
   _dbScanInst* scan_inst = (_dbScanInst*) this;
   _dbBlock* block = (_dbBlock*) scan_inst->getOwner();
   dbDft* dft = (dbDft*) block->dft_tbl_->getPtr(block->dft_);
-  scan_inst->scan_enable_ = dbScanPin::create(dft, scan_enable);
+  scan_inst->scan_enable_
+      = dbScanPin::create(dft, scan_enable)->getImpl()->getOID();
 }
 
 std::variant<dbBTerm*, dbITerm*> dbScanInst::getScanEnable() const
@@ -178,8 +180,8 @@ std::variant<dbBTerm*, dbITerm*> dbScanInst::getScanEnable() const
   _dbScanInst* scan_inst = (_dbScanInst*) this;
   _dbBlock* block = (_dbBlock*) scan_inst->getOwner();
   _dbDft* dft = (_dbDft*) block->dft_tbl_->getPtr(block->dft_);
-  const dbScanPin* scan_enable = (dbScanPin*) dft->scan_pins_->getPtr(
-      (dbId<_dbScanPin>) scan_inst->scan_enable_);
+  const dbScanPin* scan_enable
+      = (dbScanPin*) dft->scan_pins_->getPtr(scan_inst->scan_enable_);
   return scan_enable->getPin();
 }
 
@@ -191,11 +193,12 @@ void dbScanInst::setAccessPins(const AccessPins& access_pins)
 
   std::visit(
       [&access_pins, scan_inst, dft](auto&& scan_in_pin) {
-        const dbId<dbScanPin> scan_in = dbScanPin::create(dft, scan_in_pin);
+        const dbId<_dbScanPin> scan_in
+            = dbScanPin::create(dft, scan_in_pin)->getImpl()->getOID();
         std::visit(
             [scan_inst, dft, &scan_in](auto&& scan_out_pin) {
-              const dbId<dbScanPin> scan_out
-                  = dbScanPin::create(dft, scan_out_pin);
+              const dbId<_dbScanPin> scan_out
+                  = dbScanPin::create(dft, scan_out_pin)->getImpl()->getOID();
               scan_inst->access_pins_ = std::make_pair(scan_in, scan_out);
             },
             access_pins.scan_out);
@@ -212,10 +215,8 @@ dbScanInst::AccessPins dbScanInst::getAccessPins() const
 
   const auto& [scan_in_id, scan_out_id] = scan_inst->access_pins_;
 
-  dbScanPin* scan_in
-      = (dbScanPin*) dft->scan_pins_->getPtr((dbId<_dbScanPin>) scan_in_id);
-  dbScanPin* scan_out
-      = (dbScanPin*) dft->scan_pins_->getPtr((dbId<_dbScanPin>) scan_out_id);
+  dbScanPin* scan_in = (dbScanPin*) dft->scan_pins_->getPtr(scan_in_id);
+  dbScanPin* scan_out = (dbScanPin*) dft->scan_pins_->getPtr(scan_out_id);
 
   access_pins.scan_in = scan_in->getPin();
   access_pins.scan_out = scan_out->getPin();
@@ -227,7 +228,7 @@ dbInst* dbScanInst::getInst() const
 {
   _dbScanInst* scan_inst = (_dbScanInst*) this;
   _dbBlock* block = (_dbBlock*) scan_inst->getOwner();
-  return (dbInst*) block->inst_tbl_->getPtr((dbId<_dbInst>) scan_inst->inst_);
+  return (dbInst*) block->inst_tbl_->getPtr(scan_inst->inst_);
 }
 
 void dbScanInst::insertAtFront(dbScanList* scan_list_)
@@ -255,7 +256,7 @@ dbScanInst* dbScanInst::create(dbScanList* scan_list, dbInst* inst)
   _dbBlock* block = (_dbBlock*) ((_dbInst*) inst)->getOwner();
   _dbScanInst* scan_inst = (_dbScanInst*) block->scan_inst_tbl_->create();
   uint32_t inst_id = ((_dbInst*) inst)->getId();
-  scan_inst->inst_ = (dbId<dbInst>) inst_id;
+  scan_inst->inst_ = inst_id;
   block->inst_scan_inst_map_[(dbId<_dbInst>) inst_id] = scan_inst->getId();
   return (dbScanInst*) scan_inst;
 }

--- a/src/odb/src/db/dbScanInst.cpp
+++ b/src/odb/src/db/dbScanInst.cpp
@@ -100,6 +100,8 @@ void _dbScanInst::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["scan_clock"].add(scan_clock_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbScanInst.h
+++ b/src/odb/src/db/dbScanInst.h
@@ -19,6 +19,8 @@ namespace odb {
 class dbIStream;
 class dbOStream;
 class _dbDatabase;
+class _dbScanPin;
+class _dbInst;
 
 class _dbScanInst : public _dbObject
 {
@@ -31,9 +33,9 @@ class _dbScanInst : public _dbObject
   void collectMemInfo(MemInfo& info);
 
   uint32_t bits_;
-  std::pair<dbId<dbScanPin>, dbId<dbScanPin>> access_pins_;
-  dbId<dbScanPin> scan_enable_;
-  dbId<dbInst> inst_;
+  std::pair<dbId<_dbScanPin>, dbId<_dbScanPin>> access_pins_;
+  dbId<_dbScanPin> scan_enable_;
+  dbId<_dbInst> inst_;
   std::string scan_clock_;
   uint32_t clock_edge_;
   dbId<_dbScanInst> next_list_scan_inst_;

--- a/src/odb/src/db/dbScanPartition.cpp
+++ b/src/odb/src/db/dbScanPartition.cpp
@@ -75,6 +75,7 @@ void _dbScanPartition::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["name"].add(name_);
   scan_lists_->collectMemInfo(info.children["scan_lists_"]);
 }
 

--- a/src/odb/src/db/dbScanPin.cpp
+++ b/src/odb/src/db/dbScanPin.cpp
@@ -111,20 +111,20 @@ void dbScanPin::setPin(dbITerm* iterm)
   scan_pin->pin_.emplace<dbId<_dbITerm>>(((_dbITerm*) iterm)->getId());
 }
 
-dbId<dbScanPin> dbScanPin::create(dbDft* dft, dbBTerm* bterm)
+dbScanPin* dbScanPin::create(dbDft* dft, dbBTerm* bterm)
 {
   _dbDft* obj = (_dbDft*) dft;
   _dbScanPin* scan_pin = (_dbScanPin*) obj->scan_pins_->create();
   ((dbScanPin*) scan_pin)->setPin(bterm);
-  return scan_pin->getId();
+  return (dbScanPin*) scan_pin;
 }
 
-dbId<dbScanPin> dbScanPin::create(dbDft* dft, dbITerm* iterm)
+dbScanPin* dbScanPin::create(dbDft* dft, dbITerm* iterm)
 {
   _dbDft* obj = (_dbDft*) dft;
   _dbScanPin* scan_pin = (_dbScanPin*) obj->scan_pins_->create();
   ((dbScanPin*) scan_pin)->setPin(iterm);
-  return scan_pin->getId();
+  return (dbScanPin*) scan_pin;
 }
 
 // User Code End dbScanPinPublicMethods

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -796,66 +796,46 @@ void _dbTechLayer::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
+  info.children["orth_spacing_tbl"].add(orth_spacing_tbl_);
   cut_class_rules_tbl_->collectMemInfo(info.children["cut_class_rules_tbl_"]);
-
+  info.children["cut_class_rules_hash"].add(cut_class_rules_hash_);
   spacing_eol_rules_tbl_->collectMemInfo(
       info.children["spacing_eol_rules_tbl_"]);
-
   cut_spacing_rules_tbl_->collectMemInfo(
       info.children["cut_spacing_rules_tbl_"]);
-
   minstep_rules_tbl_->collectMemInfo(info.children["minstep_rules_tbl_"]);
-
   corner_spacing_rules_tbl_->collectMemInfo(
       info.children["corner_spacing_rules_tbl_"]);
-
   spacing_table_prl_rules_tbl_->collectMemInfo(
       info.children["spacing_table_prl_rules_tbl_"]);
-
   cut_spacing_table_orth_tbl_->collectMemInfo(
       info.children["cut_spacing_table_orth_tbl_"]);
-
   cut_spacing_table_def_tbl_->collectMemInfo(
       info.children["cut_spacing_table_def_tbl_"]);
-
   cut_enc_rules_tbl_->collectMemInfo(info.children["cut_enc_rules_tbl_"]);
-
   eol_ext_rules_tbl_->collectMemInfo(info.children["eol_ext_rules_tbl_"]);
-
   array_spacing_rules_tbl_->collectMemInfo(
       info.children["array_spacing_rules_tbl_"]);
-
   eol_keep_out_rules_tbl_->collectMemInfo(
       info.children["eol_keep_out_rules_tbl_"]);
-
   max_spacing_rules_tbl_->collectMemInfo(
       info.children["max_spacing_rules_tbl_"]);
-
   width_table_rules_tbl_->collectMemInfo(
       info.children["width_table_rules_tbl_"]);
-
   min_cuts_rules_tbl_->collectMemInfo(info.children["min_cuts_rules_tbl_"]);
-
   area_rules_tbl_->collectMemInfo(info.children["area_rules_tbl_"]);
-
   forbidden_spacing_rules_tbl_->collectMemInfo(
       info.children["forbidden_spacing_rules_tbl_"]);
-
   keepout_zone_rules_tbl_->collectMemInfo(
       info.children["keepout_zone_rules_tbl_"]);
-
   wrongdir_spacing_rules_tbl_->collectMemInfo(
       info.children["wrongdir_spacing_rules_tbl_"]);
-
   two_wires_forbidden_spc_rules_tbl_->collectMemInfo(
       info.children["two_wires_forbidden_spc_rules_tbl_"]);
-
   voltage_spacing_rules_tbl_->collectMemInfo(
       info.children["voltage_spacing_rules_tbl_"]);
 
   // User Code Begin collectMemInfo
-  info.children["orth_spacing"].add(orth_spacing_tbl_);
-  info.children["cut_class_rules_hash"].add(cut_class_rules_hash_);
   info.children["name"].add(name_);
   info.children["alias"].add(alias_);
   spacing_rules_tbl_->collectMemInfo(info.children["spacing_rules_tbl"]);

--- a/src/odb/src/db/dbTechLayer.cpp
+++ b/src/odb/src/db/dbTechLayer.cpp
@@ -63,6 +63,15 @@ bool _dbTechLayer::operator==(const _dbTechLayer& rhs) const
   if (flags_.num_masks != rhs.flags_.num_masks) {
     return false;
   }
+  if (flags_.type != rhs.flags_.type) {
+    return false;
+  }
+  if (flags_.direction != rhs.flags_.direction) {
+    return false;
+  }
+  if (flags_.minstep_type != rhs.flags_.minstep_type) {
+    return false;
+  }
   if (flags_.has_max_width != rhs.flags_.has_max_width) {
     return false;
   }

--- a/src/odb/src/db/dbTechLayerAreaRule.cpp
+++ b/src/odb/src/db/dbTechLayerAreaRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -245,25 +246,18 @@ uint32_t dbTechLayerAreaRule::getOverlap() const
   return obj->flags_.overlap;
 }
 
-// User Code Begin dbTechLayerAreaRulePublicMethods
-
-dbTechLayerAreaRule* dbTechLayerAreaRule::create(dbTechLayer* _layer)
+dbTechLayerAreaRule* dbTechLayerAreaRule::create(dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerAreaRule* newrule = layer->area_rules_tbl_->create();
-  newrule->area_ = 0;
-  newrule->except_min_width_ = 0;
-  newrule->except_edge_length_ = 0;
-  newrule->except_edge_lengths_ = std::pair<int, int>(0, 0);
-  newrule->except_min_size_ = std::pair<int, int>(0, 0);
-  newrule->except_step_ = std::pair<int, int>(0, 0);
-  newrule->mask_ = 0;
-  newrule->rect_width_ = 0;
-  newrule->flags_.except_rectangle = false;
-  newrule->flags_.overlap = 0;
-  return ((dbTechLayerAreaRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerAreaRule*) _parent->area_rules_tbl_->create();
 }
-
+void dbTechLayerAreaRule::destroy(dbTechLayerAreaRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->area_rules_tbl_->destroy((_dbTechLayerAreaRule*) obj);
+}
+// User Code Begin dbTechLayerAreaRulePublicMethods
 void dbTechLayerAreaRule::setTrimLayer(dbTechLayer* trim_layer)
 {
   _dbTechLayerAreaRule* obj = (_dbTechLayerAreaRule*) this;
@@ -277,14 +271,6 @@ dbTechLayer* dbTechLayerAreaRule::getTrimLayer() const
   odb::dbTech* tech = getDb()->getTech();
   return odb::dbTechLayer::getTechLayer(tech, obj->trim_layer_);
 }
-
-void dbTechLayerAreaRule::destroy(dbTechLayerAreaRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->area_rules_tbl_->destroy((_dbTechLayerAreaRule*) rule);
-}
-
 // User Code End dbTechLayerAreaRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
@@ -104,9 +104,7 @@ void _dbTechLayerArraySpacingRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["array_spacing_map"].add(array_spacing_map_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerArraySpacingRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "dbTechLayerCutClassRule.h"
@@ -229,6 +230,20 @@ bool dbTechLayerArraySpacingRule::isWithinValid() const
   return obj->flags_.within_valid;
 }
 
+dbTechLayerArraySpacingRule* dbTechLayerArraySpacingRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerArraySpacingRule*)
+      _parent->array_spacing_rules_tbl_->create();
+}
+void dbTechLayerArraySpacingRule::destroy(dbTechLayerArraySpacingRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->array_spacing_rules_tbl_->destroy(
+      (_dbTechLayerArraySpacingRule*) obj);
+}
 // User Code Begin dbTechLayerArraySpacingRulePublicMethods
 
 void dbTechLayerArraySpacingRule::setCutsArraySpacing(int num_cuts, int spacing)
@@ -254,16 +269,6 @@ dbTechLayerCutClassRule* dbTechLayerArraySpacingRule::getCutClass() const
   return (dbTechLayerCutClassRule*) layer->cut_class_rules_tbl_->getPtr(
       obj->cut_class_);
 }
-
-dbTechLayerArraySpacingRule* dbTechLayerArraySpacingRule::create(
-    dbTechLayer* inly)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) inly;
-  _dbTechLayerArraySpacingRule* newrule
-      = layer->array_spacing_rules_tbl_->create();
-  return ((dbTechLayerArraySpacingRule*) newrule);
-}
-
 dbTechLayerArraySpacingRule*
 dbTechLayerArraySpacingRule::getTechLayerArraySpacingRule(dbTechLayer* inly,
                                                           uint32_t dbid)
@@ -272,15 +277,6 @@ dbTechLayerArraySpacingRule::getTechLayerArraySpacingRule(dbTechLayer* inly,
   return ((dbTechLayerArraySpacingRule*)
               layer->array_spacing_rules_tbl_->getPtr(dbid));
 }
-
-void dbTechLayerArraySpacingRule::destroy(dbTechLayerArraySpacingRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->array_spacing_rules_tbl_->destroy(
-      (_dbTechLayerArraySpacingRule*) rule);
-}
-
 // User Code End dbTechLayerArraySpacingRulePublicMethods
 }  // namespace odb
    // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCornerSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCornerSpacingRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -406,6 +407,20 @@ bool dbTechLayerCornerSpacingRule::isCornerToCorner() const
   return obj->flags_.corner_to_corner;
 }
 
+dbTechLayerCornerSpacingRule* dbTechLayerCornerSpacingRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerCornerSpacingRule*)
+      _parent->corner_spacing_rules_tbl_->create();
+}
+void dbTechLayerCornerSpacingRule::destroy(dbTechLayerCornerSpacingRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->corner_spacing_rules_tbl_->destroy(
+      (_dbTechLayerCornerSpacingRule*) obj);
+}
 // User Code Begin dbTechLayerCornerSpacingRulePublicMethods
 void dbTechLayerCornerSpacingRule::addSpacing(uint32_t width,
                                               uint32_t spacing1,
@@ -443,16 +458,6 @@ dbTechLayerCornerSpacingRule::CornerType dbTechLayerCornerSpacingRule::getType()
 
   return (dbTechLayerCornerSpacingRule::CornerType) obj->flags_.corner_type;
 }
-
-dbTechLayerCornerSpacingRule* dbTechLayerCornerSpacingRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerCornerSpacingRule* newrule
-      = layer->corner_spacing_rules_tbl_->create();
-  return ((dbTechLayerCornerSpacingRule*) newrule);
-}
-
 dbTechLayerCornerSpacingRule*
 dbTechLayerCornerSpacingRule::getTechLayerCornerSpacingRule(dbTechLayer* inly,
                                                             uint32_t dbid)
@@ -460,13 +465,6 @@ dbTechLayerCornerSpacingRule::getTechLayerCornerSpacingRule(dbTechLayer* inly,
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerCornerSpacingRule*)
       layer->corner_spacing_rules_tbl_->getPtr(dbid);
-}
-void dbTechLayerCornerSpacingRule::destroy(dbTechLayerCornerSpacingRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->corner_spacing_rules_tbl_->destroy(
-      (_dbTechLayerCornerSpacingRule*) rule);
 }
 // User Code End dbTechLayerCornerSpacingRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerCutEnclosureRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutEnclosureRule.cpp
@@ -9,6 +9,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "dbTechLayerCutClassRule.h"
@@ -813,6 +814,18 @@ bool dbTechLayerCutEnclosureRule::isConcaveCornersValid() const
   return obj->flags_.concave_corners_valid;
 }
 
+dbTechLayerCutEnclosureRule* dbTechLayerCutEnclosureRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerCutEnclosureRule*) _parent->cut_enc_rules_tbl_->create();
+}
+void dbTechLayerCutEnclosureRule::destroy(dbTechLayerCutEnclosureRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->cut_enc_rules_tbl_->destroy((_dbTechLayerCutEnclosureRule*) obj);
+}
 // User Code Begin dbTechLayerCutEnclosureRulePublicMethods
 void dbTechLayerCutEnclosureRule::setType(ENC_TYPE type)
 {
@@ -828,27 +841,12 @@ dbTechLayerCutEnclosureRule::ENC_TYPE dbTechLayerCutEnclosureRule::getType()
 
   return (dbTechLayerCutEnclosureRule::ENC_TYPE) obj->flags_.type;
 }
-
-dbTechLayerCutEnclosureRule* dbTechLayerCutEnclosureRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerCutEnclosureRule* newrule = layer->cut_enc_rules_tbl_->create();
-  return ((dbTechLayerCutEnclosureRule*) newrule);
-}
-
 dbTechLayerCutEnclosureRule*
 dbTechLayerCutEnclosureRule::getTechLayerCutEnclosureRule(dbTechLayer* inly,
                                                           uint32_t dbid)
 {
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerCutEnclosureRule*) layer->cut_enc_rules_tbl_->getPtr(dbid);
-}
-void dbTechLayerCutEnclosureRule::destroy(dbTechLayerCutEnclosureRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->cut_enc_rules_tbl_->destroy((_dbTechLayerCutEnclosureRule*) rule);
 }
 // User Code End dbTechLayerCutEnclosureRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingRule.cpp
@@ -9,6 +9,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -1153,6 +1154,18 @@ bool dbTechLayerCutSpacingRule::isParWithinEnclosureValid() const
   return obj->flags_.par_within_enclosure_valid;
 }
 
+dbTechLayerCutSpacingRule* dbTechLayerCutSpacingRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerCutSpacingRule*) _parent->cut_spacing_rules_tbl_->create();
+}
+void dbTechLayerCutSpacingRule::destroy(dbTechLayerCutSpacingRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->cut_spacing_rules_tbl_->destroy((_dbTechLayerCutSpacingRule*) obj);
+}
 // User Code Begin dbTechLayerCutSpacingRulePublicMethods
 dbTechLayerCutClassRule* dbTechLayerCutSpacingRule::getCutClass() const
 {
@@ -1197,15 +1210,6 @@ dbTechLayerCutSpacingRule::CutSpacingType dbTechLayerCutSpacingRule::getType()
   return (dbTechLayerCutSpacingRule::CutSpacingType)
       obj->flags_.cut_spacing_type;
 }
-
-dbTechLayerCutSpacingRule* dbTechLayerCutSpacingRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerCutSpacingRule* newrule = layer->cut_spacing_rules_tbl_->create();
-  return ((dbTechLayerCutSpacingRule*) newrule);
-}
-
 dbTechLayerCutSpacingRule*
 dbTechLayerCutSpacingRule::getTechLayerCutSpacingRule(dbTechLayer* inly,
                                                       uint32_t dbid)
@@ -1213,12 +1217,6 @@ dbTechLayerCutSpacingRule::getTechLayerCutSpacingRule(dbTechLayer* inly,
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerCutSpacingRule*) layer->cut_spacing_rules_tbl_->getPtr(
       dbid);
-}
-void dbTechLayerCutSpacingRule::destroy(dbTechLayerCutSpacingRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->cut_spacing_rules_tbl_->destroy((_dbTechLayerCutSpacingRule*) rule);
 }
 // User Code End dbTechLayerCutSpacingRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
@@ -12,6 +12,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -647,6 +648,21 @@ bool dbTechLayerCutSpacingTableDefRule::isOppositeEnclosureResizeSpacingValid()
   return obj->flags_.opposite_enclosure_resize_spacing_valid;
 }
 
+dbTechLayerCutSpacingTableDefRule* dbTechLayerCutSpacingTableDefRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerCutSpacingTableDefRule*)
+      _parent->cut_spacing_table_def_tbl_->create();
+}
+void dbTechLayerCutSpacingTableDefRule::destroy(
+    dbTechLayerCutSpacingTableDefRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->cut_spacing_table_def_tbl_->destroy(
+      (_dbTechLayerCutSpacingTableDefRule*) obj);
+}
 // User Code Begin dbTechLayerCutSpacingTableDefRulePublicMethods
 void dbTechLayerCutSpacingTableDefRule::addPrlForAlignedCutEntry(
     const std::string& from,
@@ -940,16 +956,6 @@ dbTechLayer* dbTechLayerCutSpacingTableDefRule::getTechLayer() const
       = (_dbTechLayerCutSpacingTableDefRule*) this;
   return (odb::dbTechLayer*) obj->getOwner();
 }
-
-dbTechLayerCutSpacingTableDefRule* dbTechLayerCutSpacingTableDefRule::create(
-    dbTechLayer* parent)
-{
-  _dbTechLayer* _parent = (_dbTechLayer*) parent;
-  _dbTechLayerCutSpacingTableDefRule* newrule
-      = _parent->cut_spacing_table_def_tbl_->create();
-  return ((dbTechLayerCutSpacingTableDefRule*) newrule);
-}
-
 dbTechLayerCutSpacingTableDefRule*
 dbTechLayerCutSpacingTableDefRule::getTechLayerCutSpacingTableDefSubRule(
     dbTechLayer* parent,
@@ -959,15 +965,6 @@ dbTechLayerCutSpacingTableDefRule::getTechLayerCutSpacingTableDefSubRule(
   return (dbTechLayerCutSpacingTableDefRule*)
       _parent->cut_spacing_table_def_tbl_->getPtr(dbid);
 }
-void dbTechLayerCutSpacingTableDefRule::destroy(
-    dbTechLayerCutSpacingTableDefRule* rule)
-{
-  _dbTechLayer* _parent = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  _parent->cut_spacing_table_def_tbl_->destroy(
-      (_dbTechLayerCutSpacingTableDefRule*) rule);
-}
-
 // User Code End dbTechLayerCutSpacingTableDefRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableDefRule.cpp
@@ -192,20 +192,18 @@ void _dbTechLayerCutSpacingTableDefRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
-  info.children["prl_for_aligned_cut_tbl_"].add(prl_for_aligned_cut_tbl_);
-  info.children["center_to_center_tbl_"].add(center_to_center_tbl_);
-  info.children["center_and_edge_tbl_"].add(center_and_edge_tbl_);
-  info.children["prl_tbl_"].add(prl_tbl_);
-  info.children["end_extension_tbl_"].add(end_extension_tbl_);
-  info.children["side_extension_tbl_"].add(side_extension_tbl_);
-  info.children["exact_aligned_spacing_tbl_"].add(exact_aligned_spacing_tbl_);
-  info.children["non_opp_enc_spacing_tbl_"].add(non_opp_enc_spacing_tbl_);
-  info.children["opp_enc_spacing_tbl_"].add(opp_enc_spacing_tbl_);
-  info.children["spacing_tbl_"].add(spacing_tbl_);
-  info.children["row_map_"].add(row_map_);
-  info.children["col_map_"].add(col_map_);
-  // User Code End collectMemInfo
+  info.children["prl_for_aligned_cut_tbl"].add(prl_for_aligned_cut_tbl_);
+  info.children["center_to_center_tbl"].add(center_to_center_tbl_);
+  info.children["center_and_edge_tbl"].add(center_and_edge_tbl_);
+  info.children["prl_tbl"].add(prl_tbl_);
+  info.children["end_extension_tbl"].add(end_extension_tbl_);
+  info.children["side_extension_tbl"].add(side_extension_tbl_);
+  info.children["exact_aligned_spacing_tbl"].add(exact_aligned_spacing_tbl_);
+  info.children["non_opp_enc_spacing_tbl"].add(non_opp_enc_spacing_tbl_);
+  info.children["opp_enc_spacing_tbl"].add(opp_enc_spacing_tbl_);
+  info.children["spacing_tbl"].add(spacing_tbl_);
+  info.children["row_map"].add(row_map_);
+  info.children["col_map"].add(col_map_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
@@ -58,9 +58,7 @@ void _dbTechLayerCutSpacingTableOrthRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["spacing_tbl"].add(spacing_tbl_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
+++ b/src/odb/src/db/dbTechLayerCutSpacingTableOrthRule.cpp
@@ -6,7 +6,9 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
+#include "dbTechLayer.h"
 #include "dbTechLayerCutSpacingRule.h"
 #include "odb/db.h"
 // User Code Begin Includes
@@ -75,6 +77,21 @@ void dbTechLayerCutSpacingTableOrthRule::getSpacingTable(
   tbl = obj->spacing_tbl_;
 }
 
+dbTechLayerCutSpacingTableOrthRule* dbTechLayerCutSpacingTableOrthRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerCutSpacingTableOrthRule*)
+      _parent->cut_spacing_table_orth_tbl_->create();
+}
+void dbTechLayerCutSpacingTableOrthRule::destroy(
+    dbTechLayerCutSpacingTableOrthRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->cut_spacing_table_orth_tbl_->destroy(
+      (_dbTechLayerCutSpacingTableOrthRule*) obj);
+}
 // User Code Begin dbTechLayerCutSpacingTableOrthRulePublicMethods
 void dbTechLayerCutSpacingTableOrthRule::setSpacingTable(
     const std::vector<std::pair<int, int>>& tbl)
@@ -83,16 +100,6 @@ void dbTechLayerCutSpacingTableOrthRule::setSpacingTable(
       = (_dbTechLayerCutSpacingTableOrthRule*) this;
   obj->spacing_tbl_ = tbl;
 }
-
-dbTechLayerCutSpacingTableOrthRule* dbTechLayerCutSpacingTableOrthRule::create(
-    dbTechLayer* parent)
-{
-  _dbTechLayer* _parent = (_dbTechLayer*) parent;
-  _dbTechLayerCutSpacingTableOrthRule* newrule
-      = _parent->cut_spacing_table_orth_tbl_->create();
-  return ((dbTechLayerCutSpacingTableOrthRule*) newrule);
-}
-
 dbTechLayerCutSpacingTableOrthRule*
 dbTechLayerCutSpacingTableOrthRule::getTechLayerCutSpacingTableOrthSubRule(
     dbTechLayer* parent,
@@ -102,15 +109,6 @@ dbTechLayerCutSpacingTableOrthRule::getTechLayerCutSpacingTableOrthSubRule(
   return (dbTechLayerCutSpacingTableOrthRule*)
       _parent->cut_spacing_table_orth_tbl_->getPtr(dbid);
 }
-void dbTechLayerCutSpacingTableOrthRule::destroy(
-    dbTechLayerCutSpacingTableOrthRule* rule)
-{
-  _dbTechLayer* _parent = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  _parent->cut_spacing_table_orth_tbl_->destroy(
-      (_dbTechLayerCutSpacingTableOrthRule*) rule);
-}
-
 // User Code End dbTechLayerCutSpacingTableOrthRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
@@ -9,6 +9,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -122,6 +123,18 @@ bool dbTechLayerEolExtensionRule::isParallelOnly() const
   return obj->flags_.parallel_only;
 }
 
+dbTechLayerEolExtensionRule* dbTechLayerEolExtensionRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerEolExtensionRule*) _parent->eol_ext_rules_tbl_->create();
+}
+void dbTechLayerEolExtensionRule::destroy(dbTechLayerEolExtensionRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->eol_ext_rules_tbl_->destroy((_dbTechLayerEolExtensionRule*) obj);
+}
 // User Code Begin dbTechLayerEolExtensionRulePublicMethods
 
 void dbTechLayerEolExtensionRule::addEntry(int eol, int ext)
@@ -129,15 +142,6 @@ void dbTechLayerEolExtensionRule::addEntry(int eol, int ext)
   _dbTechLayerEolExtensionRule* obj = (_dbTechLayerEolExtensionRule*) this;
   obj->extension_tbl_.push_back({eol, ext});
 }
-
-dbTechLayerEolExtensionRule* dbTechLayerEolExtensionRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerEolExtensionRule* newrule = layer->eol_ext_rules_tbl_->create();
-  return ((dbTechLayerEolExtensionRule*) newrule);
-}
-
 dbTechLayerEolExtensionRule*
 dbTechLayerEolExtensionRule::getTechLayerEolExtensionRule(dbTechLayer* inly,
                                                           uint32_t dbid)
@@ -145,13 +149,6 @@ dbTechLayerEolExtensionRule::getTechLayerEolExtensionRule(dbTechLayer* inly,
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerEolExtensionRule*) layer->eol_ext_rules_tbl_->getPtr(dbid);
 }
-void dbTechLayerEolExtensionRule::destroy(dbTechLayerEolExtensionRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->eol_ext_rules_tbl_->destroy((_dbTechLayerEolExtensionRule*) rule);
-}
-
 // User Code End dbTechLayerEolExtensionRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolExtensionRule.cpp
@@ -79,9 +79,7 @@ void _dbTechLayerEolExtensionRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["extension_tbl"].add(extension_tbl_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -252,17 +253,20 @@ bool dbTechLayerEolKeepOutRule::isExceptWithin() const
   return obj->flags_.except_within;
 }
 
-// User Code Begin dbTechLayerEolKeepOutRulePublicMethods
-
 dbTechLayerEolKeepOutRule* dbTechLayerEolKeepOutRule::create(
-    dbTechLayer* _layer)
+    dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerEolKeepOutRule* newrule
-      = layer->eol_keep_out_rules_tbl_->create();
-  return ((dbTechLayerEolKeepOutRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerEolKeepOutRule*)
+      _parent->eol_keep_out_rules_tbl_->create();
 }
-
+void dbTechLayerEolKeepOutRule::destroy(dbTechLayerEolKeepOutRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->eol_keep_out_rules_tbl_->destroy((_dbTechLayerEolKeepOutRule*) obj);
+}
+// User Code Begin dbTechLayerEolKeepOutRulePublicMethods
 dbTechLayerEolKeepOutRule*
 dbTechLayerEolKeepOutRule::getTechLayerEolKeepOutRule(dbTechLayer* inly,
                                                       uint32_t dbid)
@@ -271,13 +275,6 @@ dbTechLayerEolKeepOutRule::getTechLayerEolKeepOutRule(dbTechLayer* inly,
   return (dbTechLayerEolKeepOutRule*) layer->eol_keep_out_rules_tbl_->getPtr(
       dbid);
 }
-void dbTechLayerEolKeepOutRule::destroy(dbTechLayerEolKeepOutRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->eol_keep_out_rules_tbl_->destroy((_dbTechLayerEolKeepOutRule*) rule);
-}
-
 // User Code End dbTechLayerEolKeepOutRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
@@ -110,9 +110,7 @@ void _dbTechLayerEolKeepOutRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["class_name"].add(class_name_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
+++ b/src/odb/src/db/dbTechLayerEolKeepOutRule.cpp
@@ -206,7 +206,7 @@ void dbTechLayerEolKeepOutRule::setClassName(const std::string& class_name)
   obj->class_name_ = class_name;
 }
 
-std::string dbTechLayerEolKeepOutRule::getClassName() const
+const std::string& dbTechLayerEolKeepOutRule::getClassName() const
 {
   _dbTechLayerEolKeepOutRule* obj = (_dbTechLayerEolKeepOutRule*) this;
   return obj->class_name_;

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
@@ -152,7 +152,7 @@ void dbTechLayerKeepOutZoneRule::setFirstCutClass(
   obj->first_cut_class_ = first_cut_class;
 }
 
-std::string dbTechLayerKeepOutZoneRule::getFirstCutClass() const
+const std::string& dbTechLayerKeepOutZoneRule::getFirstCutClass() const
 {
   _dbTechLayerKeepOutZoneRule* obj = (_dbTechLayerKeepOutZoneRule*) this;
   return obj->first_cut_class_;
@@ -166,7 +166,7 @@ void dbTechLayerKeepOutZoneRule::setSecondCutClass(
   obj->second_cut_class_ = second_cut_class;
 }
 
-std::string dbTechLayerKeepOutZoneRule::getSecondCutClass() const
+const std::string& dbTechLayerKeepOutZoneRule::getSecondCutClass() const
 {
   _dbTechLayerKeepOutZoneRule* obj = (_dbTechLayerKeepOutZoneRule*) this;
   return obj->second_cut_class_;

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -346,24 +347,18 @@ bool dbTechLayerKeepOutZoneRule::isExceptAlignedEnd() const
   return obj->flags_.except_aligned_end;
 }
 
-// User Code Begin dbTechLayerKeepOutZoneRulePublicMethods
-
 dbTechLayerKeepOutZoneRule* dbTechLayerKeepOutZoneRule::create(
-    dbTechLayer* _layer)
+    dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerKeepOutZoneRule* newrule
-      = layer->keepout_zone_rules_tbl_->create();
-  return ((dbTechLayerKeepOutZoneRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerKeepOutZoneRule*)
+      _parent->keepout_zone_rules_tbl_->create();
 }
-
-void dbTechLayerKeepOutZoneRule::destroy(dbTechLayerKeepOutZoneRule* rule)
+void dbTechLayerKeepOutZoneRule::destroy(dbTechLayerKeepOutZoneRule* obj)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->keepout_zone_rules_tbl_->destroy((_dbTechLayerKeepOutZoneRule*) rule);
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->keepout_zone_rules_tbl_->destroy((_dbTechLayerKeepOutZoneRule*) obj);
 }
-
-// User Code End dbTechLayerKeepOutZoneRulePublicMethods
 }  // namespace odb
    // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
+++ b/src/odb/src/db/dbTechLayerKeepOutZoneRule.cpp
@@ -132,10 +132,8 @@ void _dbTechLayerKeepOutZoneRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["first_cut_class"].add(first_cut_class_);
   info.children["second_cut_class"].add(second_cut_class_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
@@ -8,6 +8,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -94,26 +95,24 @@ int dbTechLayerMaxSpacingRule::getMaxSpacing() const
   return obj->max_spacing_;
 }
 
+dbTechLayerMaxSpacingRule* dbTechLayerMaxSpacingRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerMaxSpacingRule*) _parent->max_spacing_rules_tbl_->create();
+}
+void dbTechLayerMaxSpacingRule::destroy(dbTechLayerMaxSpacingRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->max_spacing_rules_tbl_->destroy((_dbTechLayerMaxSpacingRule*) obj);
+}
 // User Code Begin dbTechLayerMaxSpacingRulePublicMethods
 
 bool dbTechLayerMaxSpacingRule::hasCutClass() const
 {
   _dbTechLayerMaxSpacingRule* obj = (_dbTechLayerMaxSpacingRule*) this;
   return (!obj->cut_class_.empty());
-}
-dbTechLayerMaxSpacingRule* dbTechLayerMaxSpacingRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerMaxSpacingRule* newrule = layer->max_spacing_rules_tbl_->create();
-  return ((dbTechLayerMaxSpacingRule*) newrule);
-}
-
-void dbTechLayerMaxSpacingRule::destroy(dbTechLayerMaxSpacingRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->max_spacing_rules_tbl_->destroy((_dbTechLayerMaxSpacingRule*) rule);
 }
 // User Code End dbTechLayerMaxSpacingRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
@@ -77,7 +77,7 @@ void dbTechLayerMaxSpacingRule::setCutClass(const std::string& cut_class)
   obj->cut_class_ = cut_class;
 }
 
-std::string dbTechLayerMaxSpacingRule::getCutClass() const
+const std::string& dbTechLayerMaxSpacingRule::getCutClass() const
 {
   _dbTechLayerMaxSpacingRule* obj = (_dbTechLayerMaxSpacingRule*) this;
   return obj->cut_class_;

--- a/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerMaxSpacingRule.cpp
@@ -59,9 +59,7 @@ void _dbTechLayerMaxSpacingRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["cut_class"].add(cut_class_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -11,6 +11,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -362,6 +363,17 @@ bool dbTechLayerMinCutRule::isFullyEnclosed() const
   return obj->flags_.fully_enclosed;
 }
 
+dbTechLayerMinCutRule* dbTechLayerMinCutRule::create(dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerMinCutRule*) _parent->min_cuts_rules_tbl_->create();
+}
+void dbTechLayerMinCutRule::destroy(dbTechLayerMinCutRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->min_cuts_rules_tbl_->destroy((_dbTechLayerMinCutRule*) obj);
+}
 // User Code Begin dbTechLayerMinCutRulePublicMethods
 
 void dbTechLayerMinCutRule::setCutsPerCutClass(const std::string& cut_class,
@@ -370,14 +382,6 @@ void dbTechLayerMinCutRule::setCutsPerCutClass(const std::string& cut_class,
   _dbTechLayerMinCutRule* obj = (_dbTechLayerMinCutRule*) this;
   obj->cut_class_cuts_map_[cut_class] = num_cuts;
 }
-
-dbTechLayerMinCutRule* dbTechLayerMinCutRule::create(dbTechLayer* inly)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) inly;
-  _dbTechLayerMinCutRule* newrule = layer->min_cuts_rules_tbl_->create();
-  return ((dbTechLayerMinCutRule*) newrule);
-}
-
 dbTechLayerMinCutRule* dbTechLayerMinCutRule::getTechLayerMinCutRule(
     dbTechLayer* inly,
     uint32_t dbid)
@@ -385,14 +389,6 @@ dbTechLayerMinCutRule* dbTechLayerMinCutRule::getTechLayerMinCutRule(
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return ((dbTechLayerMinCutRule*) layer->min_cuts_rules_tbl_->getPtr(dbid));
 }
-
-void dbTechLayerMinCutRule::destroy(dbTechLayerMinCutRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->min_cuts_rules_tbl_->destroy((_dbTechLayerMinCutRule*) rule);
-}
-
 // User Code End dbTechLayerMinCutRulePublicMethods
 }  // namespace odb
    // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -129,9 +129,7 @@ void _dbTechLayerMinCutRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["cut_class_cuts_map"].add(cut_class_cuts_map_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerMinCutRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinCutRule.cpp
@@ -153,7 +153,8 @@ int dbTechLayerMinCutRule::getNumCuts() const
   return obj->num_cuts_;
 }
 
-std::map<std::string, int> dbTechLayerMinCutRule::getCutClassCutsMap() const
+const std::map<std::string, int>& dbTechLayerMinCutRule::getCutClassCutsMap()
+    const
 {
   _dbTechLayerMinCutRule* obj = (_dbTechLayerMinCutRule*) this;
   return obj->cut_class_cuts_map_;

--- a/src/odb/src/db/dbTechLayerMinStepRule.cpp
+++ b/src/odb/src/db/dbTechLayerMinStepRule.cpp
@@ -9,6 +9,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -350,26 +351,24 @@ bool dbTechLayerMinStepRule::isNoAdjacentEol() const
   return obj->flags_.no_adjacent_eol;
 }
 
-// User Code Begin dbTechLayerMinStepRulePublicMethods
-dbTechLayerMinStepRule* dbTechLayerMinStepRule::create(dbTechLayer* _layer)
+dbTechLayerMinStepRule* dbTechLayerMinStepRule::create(dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerMinStepRule* newrule = layer->minstep_rules_tbl_->create();
-  return ((dbTechLayerMinStepRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerMinStepRule*) _parent->minstep_rules_tbl_->create();
 }
-
+void dbTechLayerMinStepRule::destroy(dbTechLayerMinStepRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->minstep_rules_tbl_->destroy((_dbTechLayerMinStepRule*) obj);
+}
+// User Code Begin dbTechLayerMinStepRulePublicMethods
 dbTechLayerMinStepRule* dbTechLayerMinStepRule::getTechLayerMinStepRule(
     dbTechLayer* inly,
     uint32_t dbid)
 {
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerMinStepRule*) layer->minstep_rules_tbl_->getPtr(dbid);
-}
-void dbTechLayerMinStepRule::destroy(dbTechLayerMinStepRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->minstep_rules_tbl_->destroy((_dbTechLayerMinStepRule*) rule);
 }
 // User Code End dbTechLayerMinStepRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerSpacingEolRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingEolRule.cpp
@@ -9,7 +9,9 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
+#include "dbTechLayer.h"
 #include "odb/db.h"
 // User Code Begin Includes
 #include "dbTech.h"
@@ -1448,17 +1450,19 @@ bool dbTechLayerSpacingEolRule::isToNotchLengthValid() const
   return obj->flags_.to_notch_length_valid;
 }
 
-// User Code Begin dbTechLayerSpacingEolRulePublicMethods
 dbTechLayerSpacingEolRule* dbTechLayerSpacingEolRule::create(
-    dbTechLayer* _layer)
+    dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerSpacingEolRule* newrule = layer->spacing_eol_rules_tbl_->create();
-  newrule->layer_ = _layer->getImpl()->getOID();
-
-  return ((dbTechLayerSpacingEolRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerSpacingEolRule*) _parent->spacing_eol_rules_tbl_->create();
 }
-
+void dbTechLayerSpacingEolRule::destroy(dbTechLayerSpacingEolRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->spacing_eol_rules_tbl_->destroy((_dbTechLayerSpacingEolRule*) obj);
+}
+// User Code Begin dbTechLayerSpacingEolRulePublicMethods
 dbTechLayerSpacingEolRule*
 dbTechLayerSpacingEolRule::getTechLayerSpacingEolRule(dbTechLayer* inly,
                                                       uint32_t dbid)
@@ -1467,14 +1471,6 @@ dbTechLayerSpacingEolRule::getTechLayerSpacingEolRule(dbTechLayer* inly,
   return (dbTechLayerSpacingEolRule*) layer->spacing_eol_rules_tbl_->getPtr(
       dbid);
 }
-
-void dbTechLayerSpacingEolRule::destroy(dbTechLayerSpacingEolRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->spacing_eol_rules_tbl_->destroy((_dbTechLayerSpacingEolRule*) rule);
-}
-
 // User Code End dbTechLayerSpacingEolRulePublicMethods
 }  // namespace odb
 // Generator Code End Cpp

--- a/src/odb/src/db/dbTechLayerSpacingEolRule.h
+++ b/src/odb/src/db/dbTechLayerSpacingEolRule.h
@@ -7,17 +7,11 @@
 #include <cstdint>
 
 #include "dbCore.h"
-// User Code Begin Includes
-#include "odb/dbId.h"
-// User Code End Includes
 
 namespace odb {
 class dbIStream;
 class dbOStream;
 class _dbDatabase;
-// User Code Begin Classes
-class _dbTechLayer;
-// User Code End Classes
 
 struct dbTechLayerSpacingEolRuleFlags
 {
@@ -112,10 +106,6 @@ class _dbTechLayerSpacingEolRule : public _dbObject
   int min_adj_length1_;
   int min_adj_length2_;
   int notch_length_;
-
-  // User Code Begin Fields
-  dbId<_dbTechLayer> layer_;
-  // User Code End Fields
 };
 dbIStream& operator>>(dbIStream& stream, _dbTechLayerSpacingEolRule& obj);
 dbOStream& operator<<(dbOStream& stream, const _dbTechLayerSpacingEolRule& obj);

--- a/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
@@ -100,14 +100,15 @@ void _dbTechLayerSpacingTablePrlRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["length_tbl"].add(length_tbl_);
   info.children["width_tbl"].add(width_tbl_);
+  info.children["influence_tbl"].add(influence_tbl_);
+
+  // User Code Begin collectMemInfo
   MemInfo& spacing_info = info.children["spacing_tbl"];
   for (const auto& s : spacing_tbl_) {
     spacing_info.add(s);
   }
-  info.children["influence_tbl"].add(influence_tbl_);
   info.children["within_tbl"].add(_within_tbl_);
   // User Code End collectMemInfo
 }

--- a/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
+++ b/src/odb/src/db/dbTechLayerSpacingTablePrlRule.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -182,6 +183,21 @@ bool dbTechLayerSpacingTablePrlRule::isExceeptEol() const
   return obj->flags_.exceept_eol;
 }
 
+dbTechLayerSpacingTablePrlRule* dbTechLayerSpacingTablePrlRule::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerSpacingTablePrlRule*)
+      _parent->spacing_table_prl_rules_tbl_->create();
+}
+void dbTechLayerSpacingTablePrlRule::destroy(
+    dbTechLayerSpacingTablePrlRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->spacing_table_prl_rules_tbl_->destroy(
+      (_dbTechLayerSpacingTablePrlRule*) obj);
+}
 // User Code Begin dbTechLayerSpacingTablePrlRulePublicMethods
 
 uint32_t _dbTechLayerSpacingTablePrlRule::getWidthIdx(const int width) const
@@ -237,16 +253,6 @@ void dbTechLayerSpacingTablePrlRule::setSpacingTableInfluence(
       = (_dbTechLayerSpacingTablePrlRule*) this;
   obj->influence_tbl_ = influence_tbl;
 }
-
-dbTechLayerSpacingTablePrlRule* dbTechLayerSpacingTablePrlRule::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerSpacingTablePrlRule* newrule
-      = layer->spacing_table_prl_rules_tbl_->create();
-  return ((dbTechLayerSpacingTablePrlRule*) newrule);
-}
-
 dbTechLayerSpacingTablePrlRule*
 dbTechLayerSpacingTablePrlRule::getTechLayerSpacingTablePrlRule(
     dbTechLayer* inly,
@@ -256,16 +262,6 @@ dbTechLayerSpacingTablePrlRule::getTechLayerSpacingTablePrlRule(
   return (dbTechLayerSpacingTablePrlRule*)
       layer->spacing_table_prl_rules_tbl_->getPtr(dbid);
 }
-
-void dbTechLayerSpacingTablePrlRule::destroy(
-    dbTechLayerSpacingTablePrlRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->spacing_table_prl_rules_tbl_->destroy(
-      (_dbTechLayerSpacingTablePrlRule*) rule);
-}
-
 int dbTechLayerSpacingTablePrlRule::getSpacing(const int width,
                                                const int length) const
 {

--- a/src/odb/src/db/dbTechLayerVoltageSpacing.cpp
+++ b/src/odb/src/db/dbTechLayerVoltageSpacing.cpp
@@ -10,6 +10,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -122,6 +123,20 @@ bool dbTechLayerVoltageSpacing::isTocutBelow() const
   return obj->flags_.tocut_below;
 }
 
+dbTechLayerVoltageSpacing* dbTechLayerVoltageSpacing::create(
+    dbTechLayer* parent)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerVoltageSpacing*)
+      _parent->voltage_spacing_rules_tbl_->create();
+}
+void dbTechLayerVoltageSpacing::destroy(dbTechLayerVoltageSpacing* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->voltage_spacing_rules_tbl_->destroy(
+      (_dbTechLayerVoltageSpacing*) obj);
+}
 // User Code Begin dbTechLayerVoltageSpacingPublicMethods
 void dbTechLayerVoltageSpacing::addEntry(float voltage, int spacing)
 {
@@ -133,23 +148,6 @@ const std::map<float, int>& dbTechLayerVoltageSpacing::getTable() const
 {
   _dbTechLayerVoltageSpacing* obj = (_dbTechLayerVoltageSpacing*) this;
   return obj->table_;
-}
-
-dbTechLayerVoltageSpacing* dbTechLayerVoltageSpacing::create(
-    dbTechLayer* _layer)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerVoltageSpacing* newrule
-      = layer->voltage_spacing_rules_tbl_->create();
-  return ((dbTechLayerVoltageSpacing*) newrule);
-}
-
-void dbTechLayerVoltageSpacing::destroy(dbTechLayerVoltageSpacing* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->voltage_spacing_rules_tbl_->destroy(
-      (_dbTechLayerVoltageSpacing*) rule);
 }
 // User Code End dbTechLayerVoltageSpacingPublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerVoltageSpacing.cpp
+++ b/src/odb/src/db/dbTechLayerVoltageSpacing.cpp
@@ -84,6 +84,8 @@ void _dbTechLayerVoltageSpacing::collectMemInfo(MemInfo& info)
 {
   info.cnt++;
   info.size += sizeof(*this);
+
+  info.children["table"].add(table_);
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerWidthTableRule.cpp
+++ b/src/odb/src/db/dbTechLayerWidthTableRule.cpp
@@ -69,9 +69,7 @@ void _dbTechLayerWidthTableRule::collectMemInfo(MemInfo& info)
   info.cnt++;
   info.size += sizeof(*this);
 
-  // User Code Begin collectMemInfo
   info.children["width_tbl"].add(width_tbl_);
-  // User Code End collectMemInfo
 }
 
 ////////////////////////////////////////////////////////////////////

--- a/src/odb/src/db/dbTechLayerWrongDirSpacingRule.cpp
+++ b/src/odb/src/db/dbTechLayerWrongDirSpacingRule.cpp
@@ -9,6 +9,7 @@
 
 #include "dbCore.h"
 #include "dbDatabase.h"
+#include "dbProperty.h"
 #include "dbTable.h"
 #include "dbTechLayer.h"
 #include "odb/db.h"
@@ -189,18 +190,22 @@ bool dbTechLayerWrongDirSpacingRule::isLengthValid() const
   return obj->flags_.length_valid;
 }
 
-// User Code Begin dbTechLayerWrongDirSpacingRulePublicMethods
 dbTechLayerWrongDirSpacingRule* dbTechLayerWrongDirSpacingRule::create(
-    dbTechLayer* _layer)
+    dbTechLayer* parent)
 {
-  _dbTechLayer* layer = (_dbTechLayer*) _layer;
-  _dbTechLayerWrongDirSpacingRule* newrule
-      = layer->wrongdir_spacing_rules_tbl_->create();
-  newrule->layer_ = _layer->getImpl()->getOID();
-
-  return ((dbTechLayerWrongDirSpacingRule*) newrule);
+  _dbTechLayer* _parent = (_dbTechLayer*) parent;
+  return (dbTechLayerWrongDirSpacingRule*)
+      _parent->wrongdir_spacing_rules_tbl_->create();
 }
-
+void dbTechLayerWrongDirSpacingRule::destroy(
+    dbTechLayerWrongDirSpacingRule* obj)
+{
+  _dbTechLayer* _parent = (_dbTechLayer*) obj->getImpl()->getOwner();
+  dbProperty::destroyProperties(obj);
+  _parent->wrongdir_spacing_rules_tbl_->destroy(
+      (_dbTechLayerWrongDirSpacingRule*) obj);
+}
+// User Code Begin dbTechLayerWrongDirSpacingRulePublicMethods
 dbTechLayerWrongDirSpacingRule*
 dbTechLayerWrongDirSpacingRule::getTechLayerWrongDirSpacingRule(
     dbTechLayer* inly,
@@ -209,15 +214,6 @@ dbTechLayerWrongDirSpacingRule::getTechLayerWrongDirSpacingRule(
   _dbTechLayer* layer = (_dbTechLayer*) inly;
   return (dbTechLayerWrongDirSpacingRule*)
       layer->wrongdir_spacing_rules_tbl_->getPtr(dbid);
-}
-
-void dbTechLayerWrongDirSpacingRule::destroy(
-    dbTechLayerWrongDirSpacingRule* rule)
-{
-  _dbTechLayer* layer = (_dbTechLayer*) rule->getImpl()->getOwner();
-  dbProperty::destroyProperties(rule);
-  layer->wrongdir_spacing_rules_tbl_->destroy(
-      (_dbTechLayerWrongDirSpacingRule*) rule);
 }
 // User Code End dbTechLayerWrongDirSpacingRulePublicMethods
 }  // namespace odb

--- a/src/odb/src/db/dbTechLayerWrongDirSpacingRule.h
+++ b/src/odb/src/db/dbTechLayerWrongDirSpacingRule.h
@@ -7,17 +7,11 @@
 #include <cstdint>
 
 #include "dbCore.h"
-// User Code Begin Includes
-#include "odb/dbId.h"
-// User Code End Includes
 
 namespace odb {
 class dbIStream;
 class dbOStream;
 class _dbDatabase;
-// User Code Begin Classes
-class _dbTechLayer;
-// User Code End Classes
 
 struct dbTechLayerWrongDirSpacingRuleFlags
 {
@@ -44,10 +38,6 @@ class _dbTechLayerWrongDirSpacingRule : public _dbObject
   int noneol_width_;
   int length_;
   int prl_length_;
-
-  // User Code Begin Fields
-  dbId<_dbTechLayer> layer_;
-  // User Code End Fields
 };
 dbIStream& operator>>(dbIStream& stream, _dbTechLayerWrongDirSpacingRule& obj);
 dbOStream& operator<<(dbOStream& stream,

--- a/src/odb/src/gdsin/gdsin.cpp
+++ b/src/odb/src/gdsin/gdsin.cpp
@@ -237,7 +237,7 @@ void GDSReader::processPropAttr(T* elem)
     const std::string value = r_.data8;
 
     if (elem) {
-      elem->getPropattr().emplace_back(attr, value);
+      elem->addPropattr(attr, value);
     }
   }
 }

--- a/src/odb/src/gdsout/gdsout.cpp
+++ b/src/odb/src/gdsout/gdsout.cpp
@@ -247,7 +247,7 @@ void GDSWriter::writeStruct(dbGDSStructure* str)
 template <typename T>
 void GDSWriter::writePropAttr(T* el)
 {
-  auto& props = el->getPropattr();
+  const auto& props = el->getPropattr();
   for (const auto& pair : props) {
     record_t r;
     r.type = RecordType::PROPATTR;

--- a/src/odb/test/cpp/TestGDSIn.cpp
+++ b/src/odb/test/cpp/TestGDSIn.cpp
@@ -162,7 +162,7 @@ TEST_F(Fixture, edit)
   box->setDatatype(4);
   box->setBounds({0, 0, 1000, 1000});
 
-  box->getPropattr().emplace_back(12, "test");
+  box->addPropattr(12, "test");
 
   dbGDSSRef* sref = dbGDSSRef::create(str3, str1);
   sref->setTransform(dbGDSSTrans(false, 2.0, 90));


### PR DESCRIPTION
## Summary

Refactors the `src/odb/src/codeGenerator` ODB code generator around an explicit, typed `FieldType` model and moves more hand-written boilerplate under generator control. Each C++ type category (scalar, `char*`, `std::string`, `dbVector`, `dbId<>` ref, owned `dbTable`, `dbHashTable`, …) is now classified once into a `FieldType` that is the single source of truth for how the field is declared, serialized, compared, copied, and accessed — instead of re-sniffing the type string at each use site in the templates.

## What changed

- **Typed `FieldType` model** (`field_types.py`): centralizes type classification; `Field` accessor properties (`setterArgumentType`, `getterReturnType`, `member_decl`, `refTable`, …) now delegate to the field's `kind`.
- **Python modernization**: target 3.8+, dataclass-based schema models (`schema_models.py`) with unknown-key rejection, and docstrings across the generator modules.
- **More generated boilerplate**, previously hand-written in User Code:
  - trivial setters
  - `collectMemInfo()` heap accounting
  - trivial `create`/`destroy` factories derived from `1_n` relations
  - `dbAccessPoint::getBPin`
- **Accessor correctness**: non-trivially-copyable value getters now return `const &`; removed the old non-const-reference getters.
- **Developer documentation**: expands the `codeGenerator/README.md` into a full developer guide (pipeline, schema format, field kinds, flags, relations, iterators, the User-Code/Generator-Code section-merge mechanism, testing, and a new-class checklist).

## Testing

- New generator unit tests: `test_schema_validation.py`, `test_field_types.py`, `test_generator_snapshot.py`.
- The whole-tree invariant — `./generate` produces no git diff — remains enforced by `.github/workflows/github-actions-are-odb-files-generated.yml`. Regenerated C++ is committed alongside the generator changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)