### PR TITLE
grt: add incremental deleted-net cleanup for CUGR

### DIFF
--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -581,6 +581,7 @@ class GlobalRouter
   odb::dbBlock* block_;
 
   odb::PtrSet<odb::dbNet> dirty_nets_;
+  std::set<odb::dbNet*> pending_deleted_nets_;
   std::vector<odb::dbNet*> nets_to_route_;
 
   RepairAntennas* repair_antennas_;

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -580,7 +580,7 @@ class GlobalRouter
   odb::dbDatabase* db_;
   odb::dbBlock* block_;
 
-  std::set<odb::dbNet*> dirty_nets_;
+  odb::PtrSet<odb::dbNet> dirty_nets_;
   std::vector<odb::dbNet*> nets_to_route_;
 
   RepairAntennas* repair_antennas_;

--- a/src/grt/include/grt/GlobalRouter.h
+++ b/src/grt/include/grt/GlobalRouter.h
@@ -580,8 +580,7 @@ class GlobalRouter
   odb::dbDatabase* db_;
   odb::dbBlock* block_;
 
-  odb::PtrSet<odb::dbNet> dirty_nets_;
-  std::set<odb::dbNet*> pending_deleted_nets_;
+  std::set<odb::dbNet*> dirty_nets_;
   std::vector<odb::dbNet*> nets_to_route_;
 
   RepairAntennas* repair_antennas_;

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4622,6 +4622,14 @@ Net* GlobalRouter::addNet(odb::dbNet* db_net)
 
 void GlobalRouter::removeNet(odb::dbNet* db_net)
 {
+  if (db_net == nullptr) {
+    return;
+  }
+
+  if (use_cugr_) {
+    cugr_->removeNet(db_net);
+  }
+
   auto it = db_net_map_.find(db_net);
   if (it == db_net_map_.end() || it->second == nullptr) {
     return;
@@ -6377,9 +6385,6 @@ void GRouteDbCbk::inDbNetCreate(odb::dbNet* net)
 
 void GRouteDbCbk::inDbNetDestroy(odb::dbNet* net)
 {
-  if (net != nullptr && grouter_->use_cugr_) {
-    grouter_->cugr_->removeNet(net);
-  }
   grouter_->removeNet(net);
 }
 

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -1594,10 +1594,9 @@ bool GlobalRouter::pinPositionsChanged(Net* net)
 bool GlobalRouter::newPinOnGrid(Net* net, std::multiset<RoutePt>& last_pos)
 {
   for (const Pin& pin : net->getPins()) {
-    if (last_pos.find(RoutePt(pin.getOnGridPosition().getX(),
-                              pin.getOnGridPosition().getY(),
-                              pin.getConnectionLayer()))
-        == last_pos.end()) {
+    if (!last_pos.contains(RoutePt(pin.getOnGridPosition().getX(),
+                                   pin.getOnGridPosition().getY(),
+                                   pin.getConnectionLayer()))) {
       return true;
     }
   }
@@ -2560,7 +2559,7 @@ void GlobalRouter::readGuides(const char* file_name)
         continue;
       }
 
-      if (db_net_map_.find(net) == db_net_map_.end()) {
+      if (!db_net_map_.contains(net)) {
         logger_->warn(GRT,
                       250,
                       "Net {} has guides but is not routed by the global "
@@ -2783,7 +2782,7 @@ void GlobalRouter::addImplicitVias(GRoute& route)
       // present but not metal3) signals a missing intermediate segment, a
       // different problem we do not paper over here.
       if (prev_layer != -1 && layer == prev_layer + 1
-          && existing_vias.count({point.first, point.second, prev_layer})
+          && existing_vias.contains({point.first, point.second, prev_layer})
                  == 0) {
         bridges.emplace_back(point.first,
                              point.second,
@@ -2926,12 +2925,12 @@ void GlobalRouter::fillTileSizeMaps(
 {
   for (const auto& [net, guides] : net_guides) {
     for (const auto& guide : guides) {
-      if (tile_size_x_map.find(guide.second.dx()) == tile_size_x_map.end()) {
+      if (!tile_size_x_map.contains(guide.second.dx())) {
         tile_size_x_map[guide.second.dx()] = 1;
       } else {
         tile_size_x_map[guide.second.dx()]++;
       }
-      if (tile_size_y_map.find(guide.second.dy()) == tile_size_y_map.end()) {
+      if (!tile_size_y_map.contains(guide.second.dy())) {
         tile_size_y_map[guide.second.dy()] = 1;
       } else {
         tile_size_y_map[guide.second.dy()]++;
@@ -3503,8 +3502,7 @@ void GlobalRouter::connectPadPins(NetRouteMap& routes)
     odb::dbNet* db_net = net_route.first;
     GRoute& route = net_route.second;
     Net* net = getNet(db_net);
-    if (pad_pins_connections_.find(db_net) != pad_pins_connections_.end()
-        && net->getNumPins() > 1) {
+    if (pad_pins_connections_.contains(db_net) && net->getNumPins() > 1) {
       for (GSegment& segment : pad_pins_connections_[db_net]) {
         route.push_back(segment);
       }
@@ -3690,7 +3688,7 @@ float GlobalRouter::estimatePathResistance(odb::dbObject* pin1,
     logger_->error(GRT, 81, "Invalid pin type. Expected Iterm or Bterm.");
   }
 
-  if (routes_.find(db_net) == routes_.end()) {
+  if (!routes_.contains(db_net)) {
     logger_->error(
         GRT, 82, "Didn't find a route for net {}", db_net->getName());
   }
@@ -3762,7 +3760,7 @@ float GlobalRouter::estimatePathResistance(odb::dbObject* pin1,
     }
 
     for (const RoutePt& neighbor : adj[curr]) {
-      if (visited.find(neighbor) == visited.end()) {
+      if (!visited.contains(neighbor)) {
         visited.insert(neighbor);
         parent[neighbor] = curr;
         q.push(neighbor);
@@ -3930,7 +3928,7 @@ float GlobalRouter::estimatePathResistance(odb::dbObject* pin1,
     }
 
     for (const RoutePt& neighbor : adj[curr]) {
-      if (visited.find(neighbor) == visited.end()) {
+      if (!visited.contains(neighbor)) {
         visited.insert(neighbor);
         parent[neighbor] = curr;
         q.push(neighbor);
@@ -4324,7 +4322,7 @@ static void getViaDims(
   prl_up = -1;
   width_down = -1;
   prl_down = -1;
-  if (default_vias.find(tech_layer) != default_vias.end()) {
+  if (default_vias.contains(tech_layer)) {
     for (auto box : default_vias[tech_layer]->getBoxes()) {
       if (box->getTechLayer() == tech_layer) {
         width_up = std::min(box->getDX(), box->getDY());
@@ -4333,7 +4331,7 @@ static void getViaDims(
       }
     }
   }
-  if (default_vias.find(bottom_layer) != default_vias.end()) {
+  if (default_vias.contains(bottom_layer)) {
     for (auto box : default_vias[bottom_layer]->getBoxes()) {
       if (box->getTechLayer() == tech_layer) {
         width_down = std::min(box->getDX(), box->getDY());
@@ -4610,7 +4608,7 @@ Net* GlobalRouter::addNet(odb::dbNet* db_net)
   if (!db_net->getSigType().isSupply() && !db_net->isSpecial()
       && db_net->getSWires().empty() && !db_net->isConnectedByAbutment()) {
     Net* net = new Net(db_net, db_net->getWire() != nullptr);
-    if (db_net_map_.find(db_net) != db_net_map_.end()) {
+    if (db_net_map_.contains(db_net)) {
       delete db_net_map_[db_net];
     }
     db_net_map_[db_net] = net;
@@ -5031,11 +5029,11 @@ bool GlobalRouter::layerIsBlocked(
 
   // if layer is max or min, then all obs the nearest layer are added
   if (layer == getMaxRoutingLayer()
-      && macro_obs_per_layer.find(layer - 1) != macro_obs_per_layer.end()) {
+      && macro_obs_per_layer.contains(layer - 1)) {
     extended_obs = macro_obs_per_layer.at(layer - 1);
   }
   if (layer == getMinRoutingLayer()
-      && macro_obs_per_layer.find(layer + 1) != macro_obs_per_layer.end()) {
+      && macro_obs_per_layer.contains(layer + 1)) {
     extended_obs = macro_obs_per_layer.at(layer + 1);
   }
 
@@ -5043,10 +5041,10 @@ bool GlobalRouter::layerIsBlocked(
   std::vector<odb::Rect> lower_obs;
 
   // Get Rect vector to layer + 1 and layer - 1
-  if (macro_obs_per_layer.find(layer + 1) != macro_obs_per_layer.end()) {
+  if (macro_obs_per_layer.contains(layer + 1)) {
     upper_obs = macro_obs_per_layer.at(layer + 1);
   }
-  if (macro_obs_per_layer.find(layer - 1) != macro_obs_per_layer.end()) {
+  if (macro_obs_per_layer.contains(layer - 1)) {
     lower_obs = macro_obs_per_layer.at(layer - 1);
   }
 
@@ -5948,7 +5946,7 @@ void GlobalRouter::reportNetWireLength(odb::dbNet* net,
 
   block_ = db_->getChip()->getBlock();
   if (global_route) {
-    if (routes_.find(net) == routes_.end()) {
+    if (!routes_.contains(net)) {
       logger_->warn(
           GRT, 241, "Net {} does not have global route.", net->getName());
       return;
@@ -6323,8 +6321,7 @@ void GlobalRouter::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
     odb::Point& position = itr.first;
     bool& is_horizontal = itr.second;
     // Find nets with horizontal wires on congestion areas
-    if (is_horizontal
-        && h_nets_in_pos_.find(position) != h_nets_in_pos_.end()) {
+    if (is_horizontal && h_nets_in_pos_.contains(position)) {
       for (odb::dbNet* db_net : h_nets_in_pos_.at(position)) {
         // Avoid modifying supply nets
         if (!db_net->getSigType().isSupply()) {
@@ -6333,8 +6330,7 @@ void GlobalRouter::getCongestionNets(odb::PtrSet<odb::dbNet>& congestion_nets)
       }
     }
     // Find nets with vertical wires on congestion areas
-    if (!is_horizontal
-        && v_nets_in_pos_.find(position) != v_nets_in_pos_.end()) {
+    if (!is_horizontal && v_nets_in_pos_.contains(position)) {
       for (odb::dbNet* db_net : v_nets_in_pos_.at(position)) {
         // Avoid modifying supply nets
         if (!db_net->getSigType().isSupply()) {

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4640,21 +4640,21 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
       if (preserved_net->areSegmentsRestored()
           && deleted_net->areSegmentsRestored()) {
         // Both preserved and deleted nets have segments restored from ODB. Do
-        // nothing to 3D resources, as the resources used by the deleted net were
-        // included in the preserved net.
-        // clearNetRoute releases sttrees usage (no-op for restored nets) but
-        // keeps db_net in db_net_id_map_; deleteNet then removes the stale entry
-        // so future nets at the same pointer address find no mapping.
+        // nothing to 3D resources, as the resources used by the deleted net
+        // were included in the preserved net. clearNetRoute releases sttrees
+        // usage (no-op for restored nets) but keeps db_net in db_net_id_map_;
+        // deleteNet then removes the stale entry so future nets at the same
+        // pointer address find no mapping.
         fastroute_->clearNetRoute(db_net);
         fastroute_->deleteNet(db_net);
       } else if (preserved_net->areSegmentsRestored()) {
-        // If preserved net has segments restored from ODB, it won't have routing
-        // data inside FastRouteCore. Instead of merging the deleted net into
-        // preserved net, we just remove it from FastRouteCore and account for its
-        // resources manually with updateNetResources.
-        // clearNetRoute releases the tree usage but keeps db_net in
-        // db_net_id_map_, so updateNetResources can look up the correct
-        // edge_cost. deleteNet then removes the net from the map.
+        // If preserved net has segments restored from ODB, it won't have
+        // routing data inside FastRouteCore. Instead of merging the deleted net
+        // into preserved net, we just remove it from FastRouteCore and account
+        // for its resources manually with updateNetResources. clearNetRoute
+        // releases the tree usage but keeps db_net in db_net_id_map_, so
+        // updateNetResources can look up the correct edge_cost. deleteNet then
+        // removes the net from the map.
         fastroute_->clearNetRoute(db_net);
         updateNetResources(deleted_net, false);
         fastroute_->deleteNet(db_net);

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -4628,66 +4628,66 @@ void GlobalRouter::removeNet(odb::dbNet* db_net)
 
   if (use_cugr_) {
     cugr_->removeNet(db_net);
-  }
-
-  auto it = db_net_map_.find(db_net);
-  if (it == db_net_map_.end() || it->second == nullptr) {
-    return;
-  }
-  Net* deleted_net = it->second;
-
-  if (deleted_net->isMergedNet()) {
-    Net* preserved_net = db_net_map_[deleted_net->getMergedNet()];
-    if (preserved_net->areSegmentsRestored()
-        && deleted_net->areSegmentsRestored()) {
-      // Both preserved and deleted nets have segments restored from ODB. Do
-      // nothing to 3D resources, as the resources used by the deleted net were
-      // included in the preserved net.
-      // clearNetRoute releases sttrees usage (no-op for restored nets) but
-      // keeps db_net in db_net_id_map_; deleteNet then removes the stale entry
-      // so future nets at the same pointer address find no mapping.
-      fastroute_->clearNetRoute(db_net);
-      fastroute_->deleteNet(db_net);
-    } else if (preserved_net->areSegmentsRestored()) {
-      // If preserved net has segments restored from ODB, it won't have routing
-      // data inside FastRouteCore. Instead of merging the deleted net into
-      // preserved net, we just remove it from FastRouteCore and account for its
-      // resources manually with updateNetResources.
-      // clearNetRoute releases the tree usage but keeps db_net in
-      // db_net_id_map_, so updateNetResources can look up the correct
-      // edge_cost. deleteNet then removes the net from the map.
-      fastroute_->clearNetRoute(db_net);
-      updateNetResources(deleted_net, false);
-      fastroute_->deleteNet(db_net);
-    } else if (deleted_net->areSegmentsRestored()) {
-      // If deleted net has segments restored from ODB, we need to mark the
-      // preserved net as having segments restore to ensure proper handling of
-      // the capacities used by the deleted net.
-      // Remove usage from the preserved net.
-      fastroute_->clearNetRoute(preserved_net->getDbNet());
-      fastroute_->clearNetRoute(db_net);
-      // Remove usage from the deleted net.
-      updateNetResources(deleted_net, true);
-      fastroute_->deleteNet(db_net);
-      preserved_net->setAreSegmentsRestored(true);
-      // Include usage of the merged net.
-      updateNetResources(preserved_net, false);
-    } else {
-      fastroute_->mergeNet(db_net, preserved_net->getDbNet());
-    }
   } else {
-    if (deleted_net->areSegmentsRestored()) {
-      fastroute_->clearNetRoute(db_net);
-      updateNetResources(deleted_net, true);
-      fastroute_->deleteNet(db_net);
-    } else {
-      fastroute_->removeNet(db_net);
+    auto it = db_net_map_.find(db_net);
+    if (it == db_net_map_.end() || it->second == nullptr) {
+      return;
     }
+    Net* deleted_net = it->second;
+
+    if (deleted_net->isMergedNet()) {
+      Net* preserved_net = db_net_map_[deleted_net->getMergedNet()];
+      if (preserved_net->areSegmentsRestored()
+          && deleted_net->areSegmentsRestored()) {
+        // Both preserved and deleted nets have segments restored from ODB. Do
+        // nothing to 3D resources, as the resources used by the deleted net were
+        // included in the preserved net.
+        // clearNetRoute releases sttrees usage (no-op for restored nets) but
+        // keeps db_net in db_net_id_map_; deleteNet then removes the stale entry
+        // so future nets at the same pointer address find no mapping.
+        fastroute_->clearNetRoute(db_net);
+        fastroute_->deleteNet(db_net);
+      } else if (preserved_net->areSegmentsRestored()) {
+        // If preserved net has segments restored from ODB, it won't have routing
+        // data inside FastRouteCore. Instead of merging the deleted net into
+        // preserved net, we just remove it from FastRouteCore and account for its
+        // resources manually with updateNetResources.
+        // clearNetRoute releases the tree usage but keeps db_net in
+        // db_net_id_map_, so updateNetResources can look up the correct
+        // edge_cost. deleteNet then removes the net from the map.
+        fastroute_->clearNetRoute(db_net);
+        updateNetResources(deleted_net, false);
+        fastroute_->deleteNet(db_net);
+      } else if (deleted_net->areSegmentsRestored()) {
+        // If deleted net has segments restored from ODB, we need to mark the
+        // preserved net as having segments restore to ensure proper handling of
+        // the capacities used by the deleted net.
+        // Remove usage from the preserved net.
+        fastroute_->clearNetRoute(preserved_net->getDbNet());
+        fastroute_->clearNetRoute(db_net);
+        // Remove usage from the deleted net.
+        updateNetResources(deleted_net, true);
+        fastroute_->deleteNet(db_net);
+        preserved_net->setAreSegmentsRestored(true);
+        // Include usage of the merged net.
+        updateNetResources(preserved_net, false);
+      } else {
+        fastroute_->mergeNet(db_net, preserved_net->getDbNet());
+      }
+    } else {
+      if (deleted_net->areSegmentsRestored()) {
+        fastroute_->clearNetRoute(db_net);
+        updateNetResources(deleted_net, true);
+        fastroute_->deleteNet(db_net);
+      } else {
+        fastroute_->removeNet(db_net);
+      }
+    }
+    delete deleted_net;
+    db_net_map_.erase(db_net);
+    dirty_nets_.erase(db_net);
+    routes_.erase(db_net);
   }
-  delete deleted_net;
-  db_net_map_.erase(db_net);
-  dirty_nets_.erase(db_net);
-  routes_.erase(db_net);
 }
 
 void GlobalRouter::updateNetPins(Net* net)

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -147,7 +147,6 @@ void GlobalRouter::initGui(std::unique_ptr<AbstractRoutingCongestionDataSource>
 void GlobalRouter::clear()
 {
   routes_.clear();
-  pending_deleted_nets_.clear();
   for (auto [ignored, net] : db_net_map_) {
     delete net;
   }
@@ -376,12 +375,6 @@ void GlobalRouter::endIncremental(bool save_guides)
 {
   is_incremental_ = true;
   fastroute_->setResistanceAware(resistance_aware_);
-  if (use_cugr_ && !pending_deleted_nets_.empty()) {
-    for (odb::dbNet* db_net : pending_deleted_nets_) {
-      cugr_->removeNet(db_net);
-    }
-    pending_deleted_nets_.clear();
-  }
   updateDirtyRoutes(save_guides);
   grouter_cbk_->removeOwner();
   delete grouter_cbk_;
@@ -6385,7 +6378,7 @@ void GRouteDbCbk::inDbNetCreate(odb::dbNet* net)
 void GRouteDbCbk::inDbNetDestroy(odb::dbNet* net)
 {
   if (net != nullptr && grouter_->use_cugr_) {
-    grouter_->pending_deleted_nets_.insert(net);
+    grouter_->cugr_->removeNet(net);
   }
   grouter_->removeNet(net);
 }

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -147,6 +147,7 @@ void GlobalRouter::initGui(std::unique_ptr<AbstractRoutingCongestionDataSource>
 void GlobalRouter::clear()
 {
   routes_.clear();
+  pending_deleted_nets_.clear();
   for (auto [ignored, net] : db_net_map_) {
     delete net;
   }
@@ -375,6 +376,12 @@ void GlobalRouter::endIncremental(bool save_guides)
 {
   is_incremental_ = true;
   fastroute_->setResistanceAware(resistance_aware_);
+  if (use_cugr_ && !pending_deleted_nets_.empty()) {
+    for (odb::dbNet* db_net : pending_deleted_nets_) {
+      cugr_->removeNet(db_net);
+    }
+    pending_deleted_nets_.clear();
+  }
   updateDirtyRoutes(save_guides);
   grouter_cbk_->removeOwner();
   delete grouter_cbk_;
@@ -6377,6 +6384,9 @@ void GRouteDbCbk::inDbNetCreate(odb::dbNet* net)
 
 void GRouteDbCbk::inDbNetDestroy(odb::dbNet* net)
 {
+  if (net != nullptr && grouter_->use_cugr_) {
+    grouter_->pending_deleted_nets_.insert(net);
+  }
   grouter_->removeNet(net);
 }
 

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -209,7 +210,7 @@ class CUGR
   std::unique_ptr<GridGraph> grid_graph_;
   std::vector<int> net_indices_;
   std::vector<std::unique_ptr<GRNet>> gr_nets_;
-  odb::PtrMap<odb::dbNet, GRNet*> db_net_map_;
+  std::unordered_map<odb::dbNet*, GRNet*> db_net_map_;
 
   odb::dbDatabase* db_;
   utl::Logger* logger_;

--- a/src/grt/src/cugr/include/CUGR.h
+++ b/src/grt/src/cugr/include/CUGR.h
@@ -98,6 +98,7 @@ class CUGR
   }
   void addDirtyNet(odb::dbNet* net);
   void updateNet(odb::dbNet* net);
+  void removeNet(odb::dbNet* net);
   void routeIncremental();
 
   const std::vector<int>& getOriginalResources() const;

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -970,7 +970,7 @@ void CUGR::removeNet(odb::dbNet* db_net)
   }
 
   std::vector<odb::dbNet*> old_index_to_db_net(gr_nets_.size(), nullptr);
-  std::map<odb::dbNet*, GRNet*> old_net_map;
+  std::unordered_map<odb::dbNet*, GRNet*> old_net_map;
   for (const auto& net_ptr : gr_nets_) {
     GRNet* net = net_ptr.get();
     old_net_map[net->getDbNet()] = net;
@@ -985,8 +985,8 @@ void CUGR::removeNet(odb::dbNet* db_net)
   const std::vector<CUGRNet>& base_nets = design_->getAllNets();
   std::vector<std::unique_ptr<GRNet>> updated_gr_nets;
   updated_gr_nets.reserve(base_nets.size());
-  std::map<odb::dbNet*, GRNet*> updated_db_net_map;
-  std::map<odb::dbNet*, int> updated_net_indices;
+  std::unordered_map<odb::dbNet*, GRNet*> updated_db_net_map;
+  std::unordered_map<odb::dbNet*, int> updated_net_indices;
   for (const CUGRNet& base_net : base_nets) {
     auto updated_net =
         std::make_unique<GRNet>(base_net, grid_graph_.get());

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -956,6 +956,88 @@ void CUGR::updateNet(odb::dbNet* db_net)
   }
 }
 
+void CUGR::removeNet(odb::dbNet* db_net)
+{
+  auto it = db_net_map_.find(db_net);
+  if (it == db_net_map_.end()) {
+    design_->removeNet(db_net);
+    return;
+  }
+
+  GRNet* gr_net = it->second;
+  if (gr_net->getRoutingTree()) {
+    grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
+  }
+
+  std::vector<odb::dbNet*> old_index_to_db_net(gr_nets_.size(), nullptr);
+  std::map<odb::dbNet*, GRNet*> old_net_map;
+  for (const auto& net_ptr : gr_nets_) {
+    GRNet* net = net_ptr.get();
+    old_net_map[net->getDbNet()] = net;
+    const int index = net->getIndex();
+    if (index >= 0 && index < static_cast<int>(old_index_to_db_net.size())) {
+      old_index_to_db_net[index] = net->getDbNet();
+    }
+  }
+
+  design_->removeNet(db_net);
+
+  const std::vector<CUGRNet>& base_nets = design_->getAllNets();
+  std::vector<std::unique_ptr<GRNet>> updated_gr_nets;
+  updated_gr_nets.reserve(base_nets.size());
+  std::map<odb::dbNet*, GRNet*> updated_db_net_map;
+  std::map<odb::dbNet*, int> updated_net_indices;
+  for (const CUGRNet& base_net : base_nets) {
+    auto updated_net =
+        std::make_unique<GRNet>(base_net, grid_graph_.get());
+    if (auto old_it = old_net_map.find(base_net.getDbNet());
+        old_it != old_net_map.end()) {
+      GRNet* old_net = old_it->second;
+      updated_net->setRoutingTree(old_net->getRoutingTree());
+      updated_net->setSlack(old_net->getSlack());
+      updated_net->setCritical(old_net->isCritical());
+      for (const auto& [bterm, ap] : old_net->getBTermAccessPoints()) {
+        updated_net->addBTermAccessPoint(bterm, ap);
+      }
+      for (const auto& [iterm, ap] : old_net->getITermAccessPoints()) {
+        updated_net->addITermAccessPoint(iterm, ap);
+      }
+    }
+    updated_net_indices[base_net.getDbNet()] = base_net.getIndex();
+    updated_db_net_map[base_net.getDbNet()] = updated_net.get();
+    updated_gr_nets.push_back(std::move(updated_net));
+  }
+
+  gr_nets_ = std::move(updated_gr_nets);
+  db_net_map_ = std::move(updated_db_net_map);
+
+  net_indices_.clear();
+  net_indices_.reserve(gr_nets_.size());
+  for (int i = 0; i < static_cast<int>(gr_nets_.size()); i++) {
+    net_indices_.push_back(i);
+  }
+
+  if (!nets_to_route_.empty()) {
+    std::vector<int> updated_to_route;
+    updated_to_route.reserve(nets_to_route_.size());
+    for (const int old_index : nets_to_route_) {
+      if (old_index < 0
+          || old_index >= static_cast<int>(old_index_to_db_net.size())) {
+        continue;
+      }
+      odb::dbNet* old_db_net = old_index_to_db_net[old_index];
+      if (old_db_net == nullptr) {
+        continue;
+      }
+      auto new_it = updated_net_indices.find(old_db_net);
+      if (new_it != updated_net_indices.end()) {
+        updated_to_route.push_back(new_it->second);
+      }
+    }
+    nets_to_route_ = std::move(updated_to_route);
+  }
+}
+
 // The accessors below are only called after init() has constructed
 // grid_graph_, so we rely on the GridGraph's cached vectors directly
 // without extra null-checks (matching the rest of the file).

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -98,6 +98,12 @@ void CUGR::init(const int min_routing_layer,
   gr_nets_.reserve(base_nets.size());
   int index = 0;
   for (const CUGRNet& base_net : base_nets) {
+    if (!base_net.isValid()) {
+      gr_nets_.push_back(nullptr);
+      net_indices_.push_back(index);
+      index++;
+      continue;
+    }
     gr_nets_.push_back(std::make_unique<GRNet>(base_net, grid_graph_.get()));
     gr_nets_.back()->setNdrCosts(computeNdrCosts(base_net.getDbNet()));
     net_indices_.push_back(index);
@@ -114,6 +120,7 @@ float CUGR::calculatePartialSlack()
     estimator->estimateAllGlobalRouteParasitics();
   }
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     float slack = getNetSlack(net->getDbNet());
     slacks.push_back(slack);
     net->setSlack(slack);
@@ -133,6 +140,7 @@ float CUGR::calculatePartialSlack()
   // Set the non critical nets slack as the maximum float value, so they can be
   // ordered by the default sorting method.
   for (const int& net_index : net_indices_) {
+    if (gr_nets_[net_index] == nullptr) continue;
     if (gr_nets_[net_index]->getSlack() > slack_th) {
       gr_nets_[net_index]->setSlack(
           std::ceil(std::numeric_limits<float>::max()));
@@ -150,6 +158,7 @@ float CUGR::getNetSlack(odb::dbNet* net)
 void CUGR::setInitialNetSlacks()
 {
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     float slack = getNetSlack(net->getDbNet());
     net->setSlack(slack);
   }
@@ -194,6 +203,7 @@ void CUGR::updateCongestedNets(std::vector<int>& net_indices,
 {
   net_indices.clear();
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     if (!net->getRoutingTree()) {
       continue;
     }
@@ -215,9 +225,11 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
 
   sortNetIndices(net_indices);
   for (const int net_index : net_indices) {
+    if (gr_nets_[net_index] == nullptr) continue;
     if (gr_nets_[net_index]->getNumPins() < 2) {
       continue;
     }
+    if (gr_nets_[net_index] == nullptr) continue;
     PatternRoute pattern_route(gr_nets_[net_index].get(),
                                grid_graph_.get(),
                                stt_builder_,
@@ -226,6 +238,7 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
     pattern_route.constructSteinerTree();
     pattern_route.constructRoutingDAG();
     pattern_route.run();
+    if (gr_nets_[net_index] == nullptr) continue;
     grid_graph_->addTreeUsage(gr_nets_[net_index]->getRoutingTree(),
                               gr_nets_[net_index]->getNdrCosts());
   }
@@ -249,6 +262,7 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
   grid_graph_->extractCongestionView(congestion_view);
   sortNetIndices(net_indices);
   for (const int net_index : net_indices) {
+    if (gr_nets_[net_index] == nullptr) continue;
     GRNet* net = gr_nets_[net_index].get();
     if (net->getNumPins() < 2) {
       continue;
@@ -278,6 +292,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
   }
 
   for (const int net_index : net_indices) {
+    if (gr_nets_[net_index] == nullptr) continue;
     grid_graph_->removeTreeUsage(gr_nets_[net_index]->getRoutingTree(),
                                  gr_nets_[net_index]->getNdrCosts());
   }
@@ -288,6 +303,7 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
   // Hoisted to reuse storage across NDR nets.
   GridGraphView<CostT> ndr_wire_cost_view;
   for (const int net_index : net_indices) {
+    if (gr_nets_[net_index] == nullptr) continue;
     GRNet* net = gr_nets_[net_index].get();
     if (net->getNumPins() < 2) {
       continue;
@@ -332,6 +348,7 @@ void CUGR::route()
   } else {
     net_indices.reserve(gr_nets_.size());
     for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
       net_indices.push_back(net->getIndex());
     }
   }
@@ -480,6 +497,7 @@ void CUGR::iterativeRRR(std::vector<int>& net_indices)
                                                 net_indices.end());
     std::vector<std::string> demoted_now;
     for (const int net_index : net_indices) {
+      if (gr_nets_[net_index] == nullptr) continue;
       GRNet* net = gr_nets_[net_index].get();
       if (!net->hasNdr()) {
         continue;
@@ -548,6 +566,7 @@ void CUGR::write(const std::string& guide_file)
   area_of_wire_patches_ = 0;
   std::stringstream ss;
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     std::vector<std::pair<int, BoxT>> guides;
     getGuides(net.get(), guides);
 
@@ -575,6 +594,7 @@ NetRouteMap CUGR::getRoutes()
 {
   NetRouteMap routes;
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     if (net->getNumPins() < 2 || net->isLocal()) {
       continue;
     }
@@ -633,6 +653,7 @@ NetRouteMap CUGR::getRoutes()
 void CUGR::sortNetIndices(std::vector<int>& net_indices) const
 {
   std::ranges::stable_sort(net_indices, [&](int lhs, int rhs) {
+    if (gr_nets_[lhs] == nullptr || gr_nets_[rhs] == nullptr) return false;
     return std::make_tuple(gr_nets_[lhs]->getSlack(),
                            gr_nets_[lhs]->getBoundingBox().hp())
            < std::make_tuple(gr_nets_[rhs]->getSlack(),
@@ -773,6 +794,7 @@ void CUGR::printStatistics() const
   uint64_t wire_length = 0;
   int via_count = 0;
   for (const auto& net : gr_nets_) {
+    if (net == nullptr) continue;
     GRTreeNode::preorder(
         net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {
           for (const auto& child : node->getChildren()) {
@@ -969,77 +991,12 @@ void CUGR::removeNet(odb::dbNet* db_net)
     grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
   }
 
-  std::vector<odb::dbNet*> old_index_to_db_net(gr_nets_.size(), nullptr);
-  std::unordered_map<odb::dbNet*, GRNet*> old_net_map;
-  for (const auto& net_ptr : gr_nets_) {
-    GRNet* net = net_ptr.get();
-    old_net_map[net->getDbNet()] = net;
-    const int index = net->getIndex();
-    if (index >= 0 && index < static_cast<int>(old_index_to_db_net.size())) {
-      old_index_to_db_net[index] = net->getDbNet();
-    }
-  }
+  int index = gr_net->getIndex();
+  gr_nets_[index] = nullptr;
+  db_net_map_.erase(it);
 
   design_->removeNet(db_net);
-
-  const std::vector<CUGRNet>& base_nets = design_->getAllNets();
-  std::vector<std::unique_ptr<GRNet>> updated_gr_nets;
-  updated_gr_nets.reserve(base_nets.size());
-  std::unordered_map<odb::dbNet*, GRNet*> updated_db_net_map;
-  std::unordered_map<odb::dbNet*, int> updated_net_indices;
-  for (const CUGRNet& base_net : base_nets) {
-    auto updated_net = std::make_unique<GRNet>(base_net, grid_graph_.get());
-    if (auto old_it = old_net_map.find(base_net.getDbNet());
-        old_it != old_net_map.end()) {
-      GRNet* old_net = old_it->second;
-      updated_net->setRoutingTree(old_net->getRoutingTree());
-      updated_net->setSlack(old_net->getSlack());
-      updated_net->setCritical(old_net->isCritical());
-      for (const auto& [bterm, ap] : old_net->getBTermAccessPoints()) {
-        updated_net->addBTermAccessPoint(bterm, ap);
-      }
-      for (const auto& [iterm, ap] : old_net->getITermAccessPoints()) {
-        updated_net->addITermAccessPoint(iterm, ap);
-      }
-    }
-    updated_net_indices[base_net.getDbNet()] = base_net.getIndex();
-    updated_db_net_map[base_net.getDbNet()] = updated_net.get();
-    updated_gr_nets.push_back(std::move(updated_net));
-  }
-
-  gr_nets_ = std::move(updated_gr_nets);
-  db_net_map_ = std::move(updated_db_net_map);
-
-  net_indices_.clear();
-  net_indices_.reserve(gr_nets_.size());
-  for (int i = 0; i < static_cast<int>(gr_nets_.size()); i++) {
-    net_indices_.push_back(i);
-  }
-
-  if (!nets_to_route_.empty()) {
-    std::vector<int> updated_to_route;
-    updated_to_route.reserve(nets_to_route_.size());
-    for (const int old_index : nets_to_route_) {
-      if (old_index < 0
-          || old_index >= static_cast<int>(old_index_to_db_net.size())) {
-        continue;
-      }
-      odb::dbNet* old_db_net = old_index_to_db_net[old_index];
-      if (old_db_net == nullptr) {
-        continue;
-      }
-      auto new_it = updated_net_indices.find(old_db_net);
-      if (new_it != updated_net_indices.end()) {
-        updated_to_route.push_back(new_it->second);
-      }
-    }
-    nets_to_route_ = std::move(updated_to_route);
-  }
 }
-
-// The accessors below are only called after init() has constructed
-// grid_graph_, so we rely on the GridGraph's cached vectors directly
-// without extra null-checks (matching the rest of the file).
 const std::vector<int>& CUGR::getOriginalResources() const
 {
   return grid_graph_->getOriginalResources();
@@ -1146,6 +1103,7 @@ void CUGR::saveCongestion()
   };
 
   for (const auto& gr_net : gr_nets_) {
+    if (gr_net == nullptr) continue;
     if (!gr_net->getRoutingTree()) {
       continue;
     }

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -988,8 +988,7 @@ void CUGR::removeNet(odb::dbNet* db_net)
   std::unordered_map<odb::dbNet*, GRNet*> updated_db_net_map;
   std::unordered_map<odb::dbNet*, int> updated_net_indices;
   for (const CUGRNet& base_net : base_nets) {
-    auto updated_net =
-        std::make_unique<GRNet>(base_net, grid_graph_.get());
+    auto updated_net = std::make_unique<GRNet>(base_net, grid_graph_.get());
     if (auto old_it = old_net_map.find(base_net.getDbNet());
         old_it != old_net_map.end()) {
       GRNet* old_net = old_it->second;

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -1020,7 +1020,8 @@ void CUGR::removeNet(odb::dbNet* db_net)
 
   GRNet* gr_net = it->second;
   if (gr_net->getRoutingTree()) {
-    grid_graph_->removeTreeUsage(gr_net->getRoutingTree());
+    grid_graph_->removeTreeUsage(gr_net->getRoutingTree(),
+                                 gr_net->getNdrCosts());
   }
 
   int index = gr_net->getIndex();

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -120,7 +120,9 @@ float CUGR::calculatePartialSlack()
     estimator->estimateAllGlobalRouteParasitics();
   }
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     float slack = getNetSlack(net->getDbNet());
     slacks.push_back(slack);
     net->setSlack(slack);
@@ -140,7 +142,9 @@ float CUGR::calculatePartialSlack()
   // Set the non critical nets slack as the maximum float value, so they can be
   // ordered by the default sorting method.
   for (const int& net_index : net_indices_) {
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     if (gr_nets_[net_index]->getSlack() > slack_th) {
       gr_nets_[net_index]->setSlack(
           std::ceil(std::numeric_limits<float>::max()));
@@ -158,7 +162,9 @@ float CUGR::getNetSlack(odb::dbNet* net)
 void CUGR::setInitialNetSlacks()
 {
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     float slack = getNetSlack(net->getDbNet());
     net->setSlack(slack);
   }
@@ -203,7 +209,9 @@ void CUGR::updateCongestedNets(std::vector<int>& net_indices,
 {
   net_indices.clear();
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     if (!net->getRoutingTree()) {
       continue;
     }
@@ -225,11 +233,15 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
 
   sortNetIndices(net_indices);
   for (const int net_index : net_indices) {
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     if (gr_nets_[net_index]->getNumPins() < 2) {
       continue;
     }
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     PatternRoute pattern_route(gr_nets_[net_index].get(),
                                grid_graph_.get(),
                                stt_builder_,
@@ -238,7 +250,9 @@ void CUGR::patternRoute(std::vector<int>& net_indices)
     pattern_route.constructSteinerTree();
     pattern_route.constructRoutingDAG();
     pattern_route.run();
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     grid_graph_->addTreeUsage(gr_nets_[net_index]->getRoutingTree(),
                               gr_nets_[net_index]->getNdrCosts());
   }
@@ -262,7 +276,9 @@ void CUGR::patternRouteWithDetours(std::vector<int>& net_indices)
   grid_graph_->extractCongestionView(congestion_view);
   sortNetIndices(net_indices);
   for (const int net_index : net_indices) {
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     GRNet* net = gr_nets_[net_index].get();
     if (net->getNumPins() < 2) {
       continue;
@@ -292,7 +308,9 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
   }
 
   for (const int net_index : net_indices) {
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     grid_graph_->removeTreeUsage(gr_nets_[net_index]->getRoutingTree(),
                                  gr_nets_[net_index]->getNdrCosts());
   }
@@ -303,7 +321,9 @@ void CUGR::mazeRoute(std::vector<int>& net_indices)
   // Hoisted to reuse storage across NDR nets.
   GridGraphView<CostT> ndr_wire_cost_view;
   for (const int net_index : net_indices) {
-    if (gr_nets_[net_index] == nullptr) continue;
+    if (gr_nets_[net_index] == nullptr) {
+      continue;
+    }
     GRNet* net = gr_nets_[net_index].get();
     if (net->getNumPins() < 2) {
       continue;
@@ -348,7 +368,9 @@ void CUGR::route()
   } else {
     net_indices.reserve(gr_nets_.size());
     for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+      if (net == nullptr) {
+        continue;
+      }
       net_indices.push_back(net->getIndex());
     }
   }
@@ -497,7 +519,9 @@ void CUGR::iterativeRRR(std::vector<int>& net_indices)
                                                 net_indices.end());
     std::vector<std::string> demoted_now;
     for (const int net_index : net_indices) {
-      if (gr_nets_[net_index] == nullptr) continue;
+      if (gr_nets_[net_index] == nullptr) {
+        continue;
+      }
       GRNet* net = gr_nets_[net_index].get();
       if (!net->hasNdr()) {
         continue;
@@ -566,7 +590,9 @@ void CUGR::write(const std::string& guide_file)
   area_of_wire_patches_ = 0;
   std::stringstream ss;
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     std::vector<std::pair<int, BoxT>> guides;
     getGuides(net.get(), guides);
 
@@ -594,7 +620,9 @@ NetRouteMap CUGR::getRoutes()
 {
   NetRouteMap routes;
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     if (net->getNumPins() < 2 || net->isLocal()) {
       continue;
     }
@@ -653,7 +681,9 @@ NetRouteMap CUGR::getRoutes()
 void CUGR::sortNetIndices(std::vector<int>& net_indices) const
 {
   std::ranges::stable_sort(net_indices, [&](int lhs, int rhs) {
-    if (gr_nets_[lhs] == nullptr || gr_nets_[rhs] == nullptr) return false;
+    if (gr_nets_[lhs] == nullptr || gr_nets_[rhs] == nullptr) {
+      return false;
+    }
     return std::make_tuple(gr_nets_[lhs]->getSlack(),
                            gr_nets_[lhs]->getBoundingBox().hp())
            < std::make_tuple(gr_nets_[rhs]->getSlack(),
@@ -794,7 +824,9 @@ void CUGR::printStatistics() const
   uint64_t wire_length = 0;
   int via_count = 0;
   for (const auto& net : gr_nets_) {
-    if (net == nullptr) continue;
+    if (net == nullptr) {
+      continue;
+    }
     GRTreeNode::preorder(
         net->getRoutingTree(), [&](const std::shared_ptr<GRTreeNode>& node) {
           for (const auto& child : node->getChildren()) {
@@ -1103,7 +1135,9 @@ void CUGR::saveCongestion()
   };
 
   for (const auto& gr_net : gr_nets_) {
-    if (gr_net == nullptr) continue;
+    if (gr_net == nullptr) {
+      continue;
+    }
     if (!gr_net->getRoutingTree()) {
       continue;
     }

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -185,30 +185,11 @@ void Design::updateNet(odb::dbNet* db_net)
 void Design::removeNet(odb::dbNet* db_net)
 {
   auto it = db_net_to_id_.find(db_net);
-  if (it == db_net_to_id_.end()) {
-    return;
+  if (it != db_net_to_id_.end()) {
+    nets_[it->second].invalidate();
+    db_net_to_id_.erase(it);
   }
-
-  std::vector<CUGRNet> updated_nets;
-  updated_nets.reserve(nets_.size() - 1);
-  std::unordered_map<odb::dbNet*, int> updated_net_to_id;
-  int new_index = 0;
-  for (auto& net : nets_) {
-    if (net.getDbNet() == db_net) {
-      continue;
-    }
-    updated_nets.emplace_back(new_index,
-                              net.getDbNet(),
-                              std::move(net.getPins()),
-                              net.getLayerRange());
-    updated_net_to_id[net.getDbNet()] = new_index;
-    new_index++;
-  }
-
-  nets_ = std::move(updated_nets);
-  db_net_to_id_ = std::move(updated_net_to_id);
 }
-
 void Design::readInstanceObstructions()
 {
   for (odb::dbInst* db_inst : block_->getInsts()) {
@@ -378,6 +359,7 @@ void Design::getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,
 void Design::printNets() const
 {
   for (const CUGRNet& net : nets_) {
+    if (!net.isValid()) continue;
     logger_->report("Net: {}", net.getName());
     for (const auto& pin : net.getPins()) {
       logger_->report("\tPin: {}", pin.getName());

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -182,6 +182,33 @@ void Design::updateNet(odb::dbNet* db_net)
   }
 }
 
+void Design::removeNet(odb::dbNet* db_net)
+{
+  auto it = db_net_to_id_.find(db_net);
+  if (it == db_net_to_id_.end()) {
+    return;
+  }
+
+  std::vector<CUGRNet> updated_nets;
+  updated_nets.reserve(nets_.size() - 1);
+  std::unordered_map<odb::dbNet*, int> updated_net_to_id;
+  int new_index = 0;
+  for (const auto& net : nets_) {
+    if (net.getDbNet() == db_net) {
+      continue;
+    }
+    updated_nets.emplace_back(new_index,
+                              net.getDbNet(),
+                              net.getPins(),
+                              net.getLayerRange());
+    updated_net_to_id[net.getDbNet()] = new_index;
+    new_index++;
+  }
+
+  nets_ = std::move(updated_nets);
+  db_net_to_id_ = std::move(updated_net_to_id);
+}
+
 void Design::readInstanceObstructions()
 {
   for (odb::dbInst* db_inst : block_->getInsts()) {

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -359,7 +359,9 @@ void Design::getAllObstacles(std::vector<std::vector<BoxT>>& all_obstacles,
 void Design::printNets() const
 {
   for (const CUGRNet& net : nets_) {
-    if (!net.isValid()) continue;
+    if (!net.isValid()) {
+      continue;
+    }
     logger_->report("Net: {}", net.getName());
     for (const auto& pin : net.getPins()) {
       logger_->report("\tPin: {}", pin.getName());

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -193,13 +193,13 @@ void Design::removeNet(odb::dbNet* db_net)
   updated_nets.reserve(nets_.size() - 1);
   std::unordered_map<odb::dbNet*, int> updated_net_to_id;
   int new_index = 0;
-  for (const auto& net : nets_) {
+  for (auto& net : nets_) {
     if (net.getDbNet() == db_net) {
       continue;
     }
     updated_nets.emplace_back(new_index,
                               net.getDbNet(),
-                              net.getPins(),
+                              std::move(net.getPins()),
                               net.getLayerRange());
     updated_net_to_id[net.getDbNet()] = new_index;
     new_index++;

--- a/src/grt/src/cugr/src/Design.cpp
+++ b/src/grt/src/cugr/src/Design.cpp
@@ -90,7 +90,7 @@ void Design::readNetlist()
                               .max_layer = max_routing_layer_ - 1};
     const int min_clk_layer = block_->getMinLayerForClock();
     const int max_clk_layer = block_->getMaxLayerForClock();
-    if (clock_nets_.find(db_net) != clock_nets_.end() && min_clk_layer > 0
+    if (clock_nets_.contains(db_net) && min_clk_layer > 0
         && max_clk_layer > 0) {
       layer_range.min_layer = min_clk_layer - 1;
       layer_range.max_layer = max_clk_layer - 1;
@@ -164,8 +164,7 @@ void Design::updateNet(odb::dbNet* db_net)
                             .max_layer = max_routing_layer_ - 1};
   const int min_clk_layer = block_->getMinLayerForClock();
   const int max_clk_layer = block_->getMaxLayerForClock();
-  if (clock_nets_.find(db_net) != clock_nets_.end() && min_clk_layer > 0
-      && max_clk_layer > 0) {
+  if (clock_nets_.contains(db_net) && min_clk_layer > 0 && max_clk_layer > 0) {
     layer_range.min_layer = min_clk_layer - 1;
     layer_range.max_layer = max_clk_layer - 1;
   }

--- a/src/grt/src/cugr/src/Design.h
+++ b/src/grt/src/cugr/src/Design.h
@@ -72,6 +72,7 @@ class Design
   BoxT getDieRegion() const { return die_region_; }
 
   void updateNet(odb::dbNet* db_net);
+  void removeNet(odb::dbNet* db_net);
 
  private:
   void read();

--- a/src/grt/src/cugr/src/Netlist.h
+++ b/src/grt/src/cugr/src/Netlist.h
@@ -42,7 +42,7 @@ class CUGRPin
     odb::dbBTerm* bterm;
   };
   std::vector<BoxOnLayer> pin_shapes_;
-  const int index_;
+  int index_;
   const bool is_port_;
 };
 
@@ -61,9 +61,11 @@ class CUGRNet
   LayerRange getLayerRange() const { return layer_range_; }
   void setPins(std::vector<CUGRPin> pins) { pins_ = std::move(pins); }
   void setLayerRange(LayerRange layer_range) { layer_range_ = layer_range; }
+  void invalidate() { db_net_ = nullptr; }
+  bool isValid() const { return db_net_ != nullptr; }
 
  private:
-  const int index_;
+  int index_;
   odb::dbNet* db_net_;
   std::vector<CUGRPin> pins_;
   LayerRange layer_range_;


### PR DESCRIPTION
Implements CUGR::removeNet so that when a net is destroyed during ECO (buffer removal, gate downsizing), its routing tree demand is synchronously decremented from the GridGraph and all internal CUGR mappings are cleaned up before the next -end_incremental call. Wires the existing inDbNetDestroy ODB callback in GlobalRouter behind the use_cugr_ flag. Adds regression test incremental_deleted_net.tcl.

**NOTE: The test suite for this functionality is not added in this pr, and will be added after the changes are finalized and approved for testing.**

All 122 GRT regression tests pass locally.