### PR TITLE
ram: auto-detect power and ground pin names

### DIFF
--- a/src/ram/README.md
+++ b/src/ram/README.md
@@ -41,8 +41,6 @@ generate_ram [-mask_size bits]
              [-storage_cell name]
              [-tristate_cell name]
              [-inv_cell name]
-             -power_pin name
-             -ground_pin name
              [-power_net_name name]
              [-ground_net_name name]
              -routing_layer config
@@ -66,8 +64,6 @@ generate_ram [-mask_size bits]
 | `-storage_cell` | Name of the master to use for the storage device (i.e. a flip-flop). Must be positive-edge triggered. Default: auto-select from the loaded cell library. |
 | `-tristate_cell` | Name of the master to use for the tristate device (i.e. a tristate inverter). It is currently assumed that the device is inverting. Default: auto-select from the loaded cell library. |
 | `-inv_cell` | Name of the master to use for inverters. Default: auto-select from the loaded cell library. |
-| `-power_pin` | Name of the power pin in each standard cell used. Only one name is currently supported. |
-| `-ground_pin` | Name of the ground pin in each standard cell used. Only one name is currently supported. |
 | `-routing_layer` | A list of the metal layer and metal width (in microns) for generating standard cell power tracks (followpins). Example: `{met1 0.48}`. |
 | `-power_net_name` | Name of the power net to create. Default: `VDD`. |
 | `-ground_net_name` | Name of the ground net to create. Default: `VSS`. |

--- a/src/ram/include/ram/ram.h
+++ b/src/ram/include/ram/ram.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -99,9 +100,7 @@ class RamGen
                 odb::dbMaster* tapcell,
                 int max_tap_dist);
 
-  void ramPdngen(const char* power_pin,
-                 const char* ground_pin,
-                 const char* power_net_name,
+  void ramPdngen(const char* power_net_name,
                  const char* ground_net_name,
                  const char* route_name,
                  int route_width,
@@ -202,6 +201,9 @@ class RamGen
   odb::dbMaster* aoi22_cell_{nullptr};
   odb::dbMaster* latch_cell_{nullptr};
   odb::dbMaster* tapcell_{nullptr};
+
+  std::set<std::string> power_pin_names_;
+  std::set<std::string> ground_pin_names_;
 
   std::map<PortRole, std::string> storage_ports_;
   std::map<PortRole, std::string> tristate_ports_;

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -928,6 +928,8 @@ void RamGen::ramPdngen(const char* power_net_name,
   }
 
   block_->globalConnect(false, false);
+  power_pin_names_.clear();
+  ground_pin_names_.clear();
 
   std::string grid_name = "ram_grid";
   pdngen_->setCoreDomain(power_net, nullptr, ground_net, {});

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -582,6 +582,14 @@ std::map<PortRole, std::string> RamGen::buildPortMap(dbMaster* master)
                    ground_count);
   }
 
+  for (auto& [role, name] : pin_map) {
+    if (role.type == PortRoleType::Power) {
+      power_pin_names_.insert(name);
+    } else if (role.type == PortRoleType::Ground) {
+      ground_pin_names_.insert(name);
+    }
+  }
+
   return pin_map;
 }
 
@@ -846,9 +854,7 @@ void RamGen::findMasters()
   }
 }
 
-void RamGen::ramPdngen(const char* power_pin,
-                       const char* ground_pin,
-                       const char* power_net_name,
+void RamGen::ramPdngen(const char* power_net_name,
                        const char* ground_net_name,
                        const char* route_name,
                        int route_width,
@@ -913,8 +919,13 @@ void RamGen::ramPdngen(const char* power_pin,
   ground_net->setSpecial();
   ground_net->setSigType(odb::dbSigType::GROUND);
 
-  block_->addGlobalConnect(nullptr, ".*", power_pin, power_net, true);
-  block_->addGlobalConnect(nullptr, ".*", ground_pin, ground_net, true);
+  for (const auto& pin_name : power_pin_names_) {
+    block_->addGlobalConnect(nullptr, ".*", pin_name.c_str(), power_net, true);
+  }
+
+  for (const auto& pin_name : ground_pin_names_) {
+    block_->addGlobalConnect(nullptr, ".*", pin_name.c_str(), ground_net, true);
+  }
 
   block_->globalConnect(false, false);
 

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -591,17 +591,31 @@ std::map<PortRole, std::string> RamGen::buildPortMap(dbMaster* master)
   }
 
   if (power_pin_names_.size() > 1) {
+    std::string names;
+    for (const auto& name : power_pin_names_) {
+      if (!names.empty()) {
+        names += ", ";
+      }
+      names += name;
+    }
     logger_->error(RAM,
                    42,
                    "Multiple primary power pin names detected across cells: {}",
-                   fmt::join(power_pin_names_, ", "));
+                   names);
   }
   if (ground_pin_names_.size() > 1) {
+    std::string names;
+    for (const auto& name : ground_pin_names_) {
+      if (!names.empty()) {
+        names += ", ";
+      }
+      names += name;
+    }
     logger_->error(
         RAM,
         43,
         "Multiple primary ground pin names detected across cells: {}",
-        fmt::join(ground_pin_names_, ", "));
+        names);
   }
 
   return pin_map;

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -590,34 +590,6 @@ std::map<PortRole, std::string> RamGen::buildPortMap(dbMaster* master)
     }
   }
 
-  if (power_pin_names_.size() > 1) {
-    std::string names;
-    for (const auto& name : power_pin_names_) {
-      if (!names.empty()) {
-        names += ", ";
-      }
-      names += name;
-    }
-    logger_->error(RAM,
-                   42,
-                   "Multiple primary power pin names detected across cells: {}",
-                   names);
-  }
-  if (ground_pin_names_.size() > 1) {
-    std::string names;
-    for (const auto& name : ground_pin_names_) {
-      if (!names.empty()) {
-        names += ", ";
-      }
-      names += name;
-    }
-    logger_->error(
-        RAM,
-        43,
-        "Multiple primary ground pin names detected across cells: {}",
-        names);
-  }
-
   return pin_map;
 }
 

--- a/src/ram/src/ram.cpp
+++ b/src/ram/src/ram.cpp
@@ -590,6 +590,20 @@ std::map<PortRole, std::string> RamGen::buildPortMap(dbMaster* master)
     }
   }
 
+  if (power_pin_names_.size() > 1) {
+    logger_->error(RAM,
+                   42,
+                   "Multiple primary power pin names detected across cells: {}",
+                   fmt::join(power_pin_names_, ", "));
+  }
+  if (ground_pin_names_.size() > 1) {
+    logger_->error(
+        RAM,
+        43,
+        "Multiple primary ground pin names detected across cells: {}",
+        fmt::join(ground_pin_names_, ", "));
+  }
+
   return pin_map;
 }
 
@@ -928,8 +942,6 @@ void RamGen::ramPdngen(const char* power_net_name,
   }
 
   block_->globalConnect(false, false);
-  power_pin_names_.clear();
-  ground_pin_names_.clear();
 
   std::string grid_name = "ram_grid";
   pdngen_->setCoreDomain(power_net, nullptr, ground_net, {});

--- a/src/ram/src/ram.i
+++ b/src/ram/src/ram.i
@@ -94,14 +94,13 @@ generate_ram_netlist_cmd(int mask_size,
                     max_tap_dist);
 }
 
-void ram_pdngen(const char* power_pin, const char* ground_pin, 
-                const char* power_net_name, const char* ground_net_name,
+void ram_pdngen(const char* power_net_name, const char* ground_net_name,
                 const char* route_name, int route_width, 
                 const char* ver_name, int ver_width, int ver_pitch,
                 const char* hor_name, int hor_width, int hor_pitch)
 {
   RamGen* ram_gen = ord::getRamGen();
-  ram_gen->ramPdngen(power_pin, ground_pin, power_net_name, ground_net_name,
+  ram_gen->ramPdngen(power_net_name, ground_net_name,
                      route_name, route_width,
                      ver_name, ver_width, ver_pitch, 
                      hor_name, hor_width, hor_pitch);

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -118,8 +118,8 @@ proc generate_ram { args } {
   sta::parse_key_args "generate_ram" args \
     keys { -mask_size -word_size -num_words -column_mux_ratio
            -storage_cell -tristate_cell -inv_cell -read_ports -use_latch
-           -power_net_name -ground_net_name -routing_layer -ver_layer 
-           -hor_layer -filler_cells -tapcell -max_tap_dist 
+           -power_net_name -ground_net_name -routing_layer -ver_layer
+           -hor_layer -filler_cells -tapcell -max_tap_dist
            -write_behavioral_verilog } flags {}
 
   sta::check_argc_eq0 "generate_ram" $args

--- a/src/ram/src/ram.tcl
+++ b/src/ram/src/ram.tcl
@@ -101,8 +101,6 @@ sta::define_cmd_args "generate_ram" {[-mask_size bits]
                                      [-storage_cell name]
                                      [-tristate_cell name]
                                      [-inv_cell name]
-                                     -power_pin name
-                                     -ground_pin name
                                      [-power_net_name name]
                                      [-ground_net_name name]
                                      -routing_layer config
@@ -120,9 +118,9 @@ proc generate_ram { args } {
   sta::parse_key_args "generate_ram" args \
     keys { -mask_size -word_size -num_words -column_mux_ratio
            -storage_cell -tristate_cell -inv_cell -read_ports -use_latch
-           -power_pin -ground_pin -power_net_name -ground_net_name
-           -routing_layer -ver_layer -hor_layer -filler_cells
-           -tapcell -max_tap_dist -write_behavioral_verilog } flags {}
+           -power_net_name -ground_net_name -routing_layer -ver_layer 
+           -hor_layer -filler_cells -tapcell -max_tap_dist 
+           -write_behavioral_verilog } flags {}
 
   sta::check_argc_eq0 "generate_ram" $args
 
@@ -179,18 +177,6 @@ proc generate_ram { args } {
   generate_ram_netlist {*}$ram_netlist_args
 
   ord::design_created
-
-  if { [info exists keys(-power_pin)] } {
-    set power_pin $keys(-power_pin)
-  } else {
-    utl::error RAM 5 "The -power_pin argument must be specified."
-  }
-
-  if { [info exists keys(-ground_pin)] } {
-    set ground_pin $keys(-ground_pin)
-  } else {
-    utl::error RAM 6 "The -ground_pin argument must be specified."
-  }
 
   set power_net_name "VDD"
   if { [info exists keys(-power_net_name)] } {
@@ -259,7 +245,7 @@ proc generate_ram { args } {
     utl::error RAM 18 "The -filler_cells argument must be specified."
   }
 
-  ram::ram_pdngen $power_pin $ground_pin $power_net_name $ground_net_name \
+  ram::ram_pdngen $power_net_name $ground_net_name \
     $route_name $route_width \
     $ver_name $ver_width $ver_pitch $hor_name $hor_width $hor_pitch
 

--- a/src/ram/test/make_7x7_nangate45.tcl
+++ b/src/ram/test/make_7x7_nangate45.tcl
@@ -23,8 +23,6 @@ generate_ram \
   -num_words 7 \
   -read_ports 1 \
   -storage_cell DFF_X1 \
-  -power_pin VDD \
-  -ground_pin VSS \
   -routing_layer {metal1 0.08} \
   -ver_layer {metal4 0.14 9} \
   -hor_layer {metal3 0.08 8} \

--- a/src/ram/test/make_8x8_latch_sky130.tcl
+++ b/src/ram/test/make_8x8_latch_sky130.tcl
@@ -15,8 +15,6 @@ generate_ram \
   -num_words 8 \
   -read_ports 1 \
   -use_latch 1 \
-  -power_pin VPWR \
-  -ground_pin VGND \
   -routing_layer {met1 0.48} \
   -ver_layer {met2 0.48 40} \
   -hor_layer {met3 0.48 20} \

--- a/src/ram/test/make_8x8_mux2_sky130.tcl
+++ b/src/ram/test/make_8x8_mux2_sky130.tcl
@@ -11,8 +11,6 @@ generate_ram \
   -column_mux_ratio 2 \
   -read_ports 1 \
   -storage_cell sky130_fd_sc_hd__dfxtp_1 \
-  -power_pin VPWR \
-  -ground_pin VGND \
   -routing_layer {met1 0.48} \
   -ver_layer {met2 0.48 20} \
   -hor_layer {met3 0.48 10} \

--- a/src/ram/test/make_8x8_mux4_sky130.tcl
+++ b/src/ram/test/make_8x8_mux4_sky130.tcl
@@ -16,8 +16,6 @@ generate_ram \
   -column_mux_ratio 4 \
   -read_ports 1 \
   -storage_cell sky130_fd_sc_hd__dfxtp_1 \
-  -power_pin VPWR \
-  -ground_pin VGND \
   -routing_layer {met1 0.48} \
   -ver_layer {met2 0.48 10} \
   -hor_layer {met3 0.48 7} \

--- a/src/ram/test/make_8x8_sky130.tcl
+++ b/src/ram/test/make_8x8_sky130.tcl
@@ -15,8 +15,6 @@ generate_ram \
   -num_words 8 \
   -read_ports 1 \
   -storage_cell sky130_fd_sc_hd__dfxtp_1 \
-  -power_pin VPWR \
-  -ground_pin VGND \
   -routing_layer {met1 0.48} \
   -ver_layer {met2 0.48 40} \
   -hor_layer {met3 0.48 20} \


### PR DESCRIPTION
## Summary
Automatically detect power and ground pin names instead of requiring the user to manually specify using `-power_pin` and `-ground_pin`, then globally connect them. The RAM generator will only collect primary power/grounds. README.md and tcl files are updated to reflect this new change

## Type of Change
- New feature
- Documentation update

## Impact
User no longer need to manually specify power and ground names when using the tool

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**

## Related Issues
Fixes #10562 

@rovinski 
