### PR TITLE
rsz: Honor dont_touch in legacy MT size-up

### DIFF
--- a/src/rsz/src/move/SizeUpMtGenerator.cc
+++ b/src/rsz/src/move/SizeUpMtGenerator.cc
@@ -29,7 +29,9 @@ SizeUpMtGenerator::SizeUpMtGenerator(const GeneratorContext& context)
 
 bool SizeUpMtGenerator::isApplicable(const Target& target) const
 {
-  return MoveGenerator::isApplicable(target) && target.inst(resizer_) != nullptr
+  sta::Instance* target_inst = target.inst(resizer_);
+  return MoveGenerator::isApplicable(target) && target_inst != nullptr
+         && !resizer_.dontTouch(target_inst)
          && target.isPrepared(kArcDelayStateCache);
 }
 

--- a/src/rsz/test/BUILD
+++ b/src/rsz/test/BUILD
@@ -135,6 +135,7 @@ TESTS = [
     "repair_setup_clone_high_fanout",
     "repair_setup_crit_vt_asap7",
     "repair_setup_default_nangate45",
+    "repair_setup_dont_touch_sizeup",
     "repair_setup_endpoint_fanin_only",
     "repair_setup_gcd",
     "repair_setup_invalid_phase",

--- a/src/rsz/test/CMakeLists.txt
+++ b/src/rsz/test/CMakeLists.txt
@@ -91,6 +91,7 @@ or_integration_tests(
     repair_setup_clone_high_fanout
     repair_setup_crit_vt_asap7
     repair_setup_default_nangate45
+    repair_setup_dont_touch_sizeup
     repair_setup_endpoint_fanin_only
     repair_setup_gcd
     repair_setup_invalid_phase

--- a/src/rsz/test/repair_setup_dont_touch_sizeup.def
+++ b/src/rsz/test/repair_setup_dont_touch_sizeup.def
@@ -1,0 +1,49 @@
+# 
+VERSION 5.8 ; 
+DIVIDERCHAR "/" ;
+BUSBITCHARS "[]" ;
+DESIGN reg1 ;
+UNITS DISTANCE MICRONS 1000 ;
+DIEAREA ( 0 0 ) ( 40000 1200000 ) ;
+
+COMPONENTS 14 ;
+- r1 DFF_X1 + PLACED   ( 10000 200000 ) N ;
+- u1 BUF_X8 + PLACED   ( 10000 300000 ) N ;
+- u2 BUF_X1 + PLACED   ( 10000 400000 ) N ;
+- u3 BUF_X1 + PLACED   ( 10000 500000 ) N ;
+- u4 BUF_X1 + PLACED   ( 10000 600000 ) N ;
+- u5 BUF_X1 + PLACED   ( 10000 700000 ) N ;
+- r2 DFF_X1 + PLACED   ( 20000 100000 ) N ;
+- r3 DFF_X2 + PLACED   ( 20000 200000 ) N ;
+- r4a BUF_X8 + PLACED   ( 20000 300000 ) N ;
+- r4 DFF_X2 + PLACED   ( 20000 300000 ) N ;
+- r5a BUF_X8 + PLACED   ( 20000 400000 ) N ;
+- r5 DFF_X2 + PLACED   ( 20000 400000 ) N ;
+- r6 DFF_X2 + PLACED   ( 20000 500000 ) N ;
+- r7 DFF_X2 + PLACED   ( 20000 600000 ) N ;
+END COMPONENTS
+
+PINS 1 ;
+    - clk + NET clk + DIRECTION INPUT + USE SIGNAL + FIXED ( 10000 3333 ) N + LAYER metal2 ( 0 0 ) ( 0 0 ) ;
+END PINS
+
+SPECIALNETS 2 ;
+- VSS  ( * VSS )
+  + USE GROUND ;
+- VDD  ( * VDD )
+  + USE POWER ;
+END SPECIALNETS
+
+NETS 9 ;
+- clk ( PIN clk ) ( r1 CK ) ( r2 CK ) ( r3 CK ) ( r4 CK ) ( r5 CK ) ( r6 CK ) ( r7 CK ) + USE SIGNAL ;
+- r1q ( r1 Q ) ( u1 A ) ( r4a A ) ( r5a A ) ( r3 D ) ( r6 D ) ( r7 D ) + USE SIGNAL ;
+- r1qb ( r4a Z ) ( r4 D ) + USE SIGNAL ;
+- r1qc ( r5a Z ) ( r5 D ) + USE SIGNAL ;
+- u1z ( u1 Z ) ( u2 A ) + USE SIGNAL ;
+- u2z ( u2 Z ) ( u3 A ) + USE SIGNAL ;
+- u3z ( u3 Z ) ( u4 A ) + USE SIGNAL ;
+- u4z ( u4 Z ) ( u5 A ) + USE SIGNAL ;
+- u5z ( u5 Z ) ( r2 D ) + USE SIGNAL ;
+END NETS
+
+END DESIGN

--- a/src/rsz/test/repair_setup_dont_touch_sizeup.ok
+++ b/src/rsz/test/repair_setup_dont_touch_sizeup.ok
@@ -1,0 +1,41 @@
+[INFO ODB-0227] LEF file: Nangate45/Nangate45.lef, created 22 layers, 27 vias, 135 library cells
+[INFO ODB-0128] Design: reg1
+[INFO ODB-0130]     Created 1 pins.
+[INFO ODB-0131]     Created 14 components and 70 component-terminals.
+[INFO ODB-0132]     Created 2 special nets and 28 connections.
+[INFO ODB-0133]     Created 9 nets and 28 connections.
+Dont-touch instances: 14
+Repair policy: LEGACY
+[INFO RSZ-0100] Repair move sequence: SizeUpMove 
+[INFO RSZ-0094] Found 1 endpoints with setup violations.
+[INFO RSZ-0099] Repairing 1 out of 1 (100.00%) violating endpoints...
+[INFO RSZ-0221] Using custom phase sequence: LEGACY
+   Iter   | Removed | Resized | Inserted | Cloned |  Pin  |   Area   |    WNS   |   StTNS    |   EnTNS    |  Viol  |  Worst  
+          | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |          |            |            | Endpts | St/EnPt 
+------------------------------------------------------------------------------------------------------------------------------
+       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+       1* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+       1* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+    final |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+------------------------------------------------------------------------------------------------------------------------------
+[WARNING RSZ-0062] Unable to repair all setup violations.
+All dont-touch instances preserved after LEGACY.
+Manual ECO: restored r1 to DFF_X1.
+Repair policy: LEGACY_MT
+[WARNING RSZ-2024] Experimental repair setup policy 'SetupLegacyMtPolicy' selected. Do not use this for production.
+[INFO RSZ-0100] Repair move sequence: SizeUpMove 
+[INFO RSZ-0094] Found 1 endpoints with setup violations.
+[INFO RSZ-0099] Repairing 1 out of 1 (100.00%) violating endpoints...
+[INFO RSZ-0221] Using custom phase sequence: LEGACY_MT
+   Iter   | Removed | Resized | Inserted | Cloned |  Pin  |   Area   |    WNS   |   StTNS    |   EnTNS    |  Viol  |  Worst  
+          | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |          |            |            | Endpts | St/EnPt 
+------------------------------------------------------------------------------------------------------------------------------
+       0* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+       1* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+       1* |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+    final |       0 |       0 |        0 |      0 |     0 |    +0.0% |   -0.230 |       -0.2 |       -0.2 |      1 | r2/D
+------------------------------------------------------------------------------------------------------------------------------
+[WARNING RSZ-0062] Unable to repair all setup violations.
+All dont-touch instances preserved after LEGACY_MT.
+worst slack max -0.23
+tns max -0.230

--- a/src/rsz/test/repair_setup_dont_touch_sizeup.tcl
+++ b/src/rsz/test/repair_setup_dont_touch_sizeup.tcl
@@ -1,0 +1,72 @@
+# Check LEGACY and LEGACY_MT setup size-up honor dont_touch instances.
+
+source "helpers.tcl"
+
+proc instance_refs { } {
+  set refs {}
+  foreach inst [get_cells *] {
+    dict set refs [get_full_name $inst] [get_property $inst ref_name]
+  }
+  return $refs
+}
+
+proc check_instance_refs { before_refs stage } {
+  set mismatches {}
+  foreach inst [get_cells *] {
+    set inst_name [get_full_name $inst]
+    set before_ref [dict get $before_refs $inst_name]
+    set after_ref [get_property $inst ref_name]
+    if { $before_ref ne $after_ref } {
+      lappend mismatches "$inst_name:$before_ref->$after_ref"
+    }
+  }
+  if { [llength $mismatches] != 0 } {
+    error "dont_touch instances changed after $stage: [join $mismatches {, }]"
+  }
+}
+
+proc run_sizeup_repair { repair_policy before_refs } {
+  puts "Repair policy: $repair_policy"
+  repair_timing -setup \
+    -policy $repair_policy \
+    -sequence "sizeup" \
+    -skip_last_gasp \
+    -skip_crit_vt_swap
+  check_instance_refs $before_refs $repair_policy
+  puts "All dont-touch instances preserved after $repair_policy."
+}
+
+read_liberty Nangate45/Nangate45_typ.lib
+read_lef Nangate45/Nangate45.lef
+read_def repair_setup_dont_touch_sizeup.def
+create_clock -period 0.35 clk
+set_load 1.0 [all_outputs]
+
+source Nangate45/Nangate45.rc
+set_wire_rc -layer metal3
+estimate_parasitics -placement
+
+# Mark every instance dont_touch before exercising repair setup.
+set before_refs [instance_refs]
+foreach inst [get_cells *] {
+  set_dont_touch $inst
+}
+puts "Dont-touch instances: [dict size $before_refs]"
+
+run_sizeup_repair "LEGACY" $before_refs
+
+# Restore the target cell through a manual ECO before testing LEGACY_MT.
+set target_inst r1
+set target_ref [dict get $before_refs $target_inst]
+set target_lib_cell "NangateOpenCellLibrary/$target_ref"
+unset_dont_touch $target_inst
+if { [replace_cell $target_inst $target_lib_cell] == 0 } {
+  error "failed to restore $target_inst to $target_lib_cell"
+}
+set_dont_touch $target_inst
+puts "Manual ECO: restored $target_inst to $target_ref."
+
+run_sizeup_repair "LEGACY_MT" $before_refs
+
+report_worst_slack -max
+report_tns -digits 3


### PR DESCRIPTION
- Skip LEGACY_MT size-up candidates for dont_touch instances.
- Add a focused LEGACY/LEGACY_MT regression with a manual ECO reset.
- Tested: ctest --output-on-failure -R 'rsz\\.repair_setup_dont_touch_sizeup\\.tcl'