### PR TITLE
odb: add inst-to-chip-bump back-reference

### DIFF
--- a/src/odb/include/odb/db.h
+++ b/src/odb/include/odb/db.h
@@ -3191,6 +3191,12 @@ class dbInst : public dbObject
   uint32_t getPinAccessIdx() const;
 
   ///
+  /// Get the chip bump associated with this instance.
+  /// Returns a pointer to the dbChipBump object if present, otherwise nullptr.
+  ///
+  dbChipBump* getChipBump() const;
+
+  ///
   /// Create a new instance.
   /// If physical_only is true, the instance can only be added to a top module.
   /// If false, it will be added to the parent module.

--- a/src/odb/src/db/dbBTerm.cpp
+++ b/src/odb/src/db/dbBTerm.cpp
@@ -820,6 +820,9 @@ void dbBTerm::destroy(dbBTerm* bterm_)
   if (bterm->net_) {
     bterm->disconnectNet(bterm, block);
   }
+  if (auto bump = (_dbChipBump*) (bterm_->getChipBump())) {
+    bump->bterm_ = 0;
+  }
   for (auto callback : block->callbacks_) {
     callback->inDbBTermDestroy(bterm_);
   }

--- a/src/odb/src/db/dbChipBump.cpp
+++ b/src/odb/src/db/dbChipBump.cpp
@@ -163,12 +163,21 @@ dbChipBump* dbChipBump::create(dbChipRegion* chip_region, dbInst* inst)
                   "as the chip region {}",
                   inst->getName(),
                   chip_region->getName());
-    return nullptr;
   }
+  if (inst->getChipBump() != nullptr) {
+    logger->error(
+        utl::ODB,
+        534,
+        "Cannot create chip bump. Inst {} already has an associated chip bump",
+        inst->getName());
+  }
+
   _dbChipBump* obj = _chip_region->chip_bump_tbl_->create();
   obj->inst_ = _inst->getOID();
   obj->chip_ = _chip->getOID();
   obj->chip_region_ = _chip_region->getOID();
+  _inst->chip_region_ = _chip_region->getOID();
+  _inst->bump_ = obj->getOID();
   return (dbChipBump*) obj;
 }
 

--- a/src/odb/src/db/dbDatabase.h
+++ b/src/odb/src/db/dbDatabase.h
@@ -50,8 +50,10 @@ namespace odb {
 inline constexpr uint32_t kSchemaMajor = 0;  // Not used...
 inline constexpr uint32_t kSchemaInitial = 57;
 
-inline constexpr uint32_t kSchemaMinor = 131;  // Current revision number
+inline constexpr uint32_t kSchemaMinor = 132;  // Current revision number
 
+// Revision where dbInst::bump_ was added
+inline constexpr uint32_t kSchemaInstBump = 132;
 // Revision where all areas in the are switched to be stored as int64_t
 inline constexpr uint32_t kSchemaStoreAreaAsInt64 = 131;
 

--- a/src/odb/src/db/dbInst.cpp
+++ b/src/odb/src/db/dbInst.cpp
@@ -16,6 +16,8 @@
 #include "dbBlock.h"
 #include "dbBox.h"
 #include "dbChip.h"
+#include "dbChipBump.h"
+#include "dbChipRegion.h"
 #include "dbCommon.h"
 #include "dbCore.h"
 #include "dbDatabase.h"
@@ -125,6 +127,8 @@ _dbInst::_dbInst(_dbDatabase*, const _dbInst& i)
       region_prev_(i.region_prev_),
       module_prev_(i.module_prev_),
       hierarchy_(i.hierarchy_),
+      chip_region_(i.chip_region_),
+      bump_(i.bump_),
       iterms_(i.iterms_),
       halo_(i.halo_),
       pin_access_idx_(i.pin_access_idx_)
@@ -161,6 +165,8 @@ dbOStream& operator<<(dbOStream& stream, const _dbInst& inst)
   stream << inst.region_prev_;
   stream << inst.module_prev_;
   stream << inst.hierarchy_;
+  stream << inst.chip_region_;
+  stream << inst.bump_;
   stream << inst.iterms_;
   stream << inst.halo_;
   stream << inst.pin_access_idx_;
@@ -187,6 +193,10 @@ dbIStream& operator>>(dbIStream& stream, _dbInst& inst)
   stream >> inst.region_prev_;
   stream >> inst.module_prev_;
   stream >> inst.hierarchy_;
+  if (inst.getDatabase()->isSchema(kSchemaInstBump)) {
+    stream >> inst.chip_region_;
+    stream >> inst.bump_;
+  }
   stream >> inst.iterms_;
   stream >> inst.halo_;
   stream >> inst.pin_access_idx_;
@@ -297,6 +307,14 @@ bool _dbInst::operator==(const _dbInst& rhs) const
   }
 
   if (hierarchy_ != rhs.hierarchy_) {
+    return false;
+  }
+
+  if (chip_region_ != rhs.chip_region_) {
+    return false;
+  }
+
+  if (bump_ != rhs.bump_) {
     return false;
   }
 
@@ -1292,6 +1310,18 @@ uint32_t dbInst::getPinAccessIdx() const
   return inst->pin_access_idx_;
 }
 
+dbChipBump* dbInst::getChipBump() const
+{
+  _dbInst* inst = (_dbInst*) this;
+  if (inst->bump_ == 0) {
+    return nullptr;
+  }
+  _dbChip* chip = (_dbChip*) getBlock()->getChip();
+  _dbChipRegion* chip_region
+      = (_dbChipRegion*) chip->chip_region_tbl_->getPtr(inst->chip_region_);
+  return (dbChipBump*) chip_region->chip_bump_tbl_->getPtr(inst->bump_);
+}
+
 dbInst* dbInst::create(dbBlock* block,
                        dbMaster* master,
                        const char* name,
@@ -1491,6 +1521,13 @@ void dbInst::destroy(dbInst* inst_)
                              362,
                              "Attempt to destroy dont_touch instance {}",
                              inst->name_);
+  }
+  if (inst->bump_.isValid()) {
+    inst->getLogger()->error(
+        utl::ODB,
+        546,
+        "Cannot destroy instance {} with an associated chip bump",
+        inst->name_);
   }
 
   dbScanInst* scan_inst = inst_->getScanInst();

--- a/src/odb/src/db/dbInst.h
+++ b/src/odb/src/db/dbInst.h
@@ -21,6 +21,8 @@ class _dbRegion;
 class _dbDatabase;
 class _dbModule;
 class _dbGroup;
+class _dbChipBump;
+class _dbChipRegion;
 class dbInst;
 class dbIStream;
 class dbOStream;
@@ -85,6 +87,8 @@ class _dbInst : public _dbObject
   dbId<_dbInst> region_prev_;
   dbId<_dbInst> module_prev_;
   dbId<_dbHier> hierarchy_;
+  dbId<_dbChipRegion> chip_region_;
+  dbId<_dbChipBump> bump_;
   dbVector<uint32_t> iterms_;
   dbId<_dbBox> halo_;
   uint32_t pin_access_idx_;

--- a/src/odb/test/cpp/TestChips.cpp
+++ b/src/odb/test/cpp/TestChips.cpp
@@ -367,6 +367,7 @@ TEST_F(ChipHierarchyFixture, test_chip_bumps)
   auto io_inst_region_r1_bump_inst
       = *io_inst_region_r1->getChipBumpInsts().begin();
   EXPECT_EQ(io_inst_region_r1_bump_inst->getChipBump(), io_bump);
+  EXPECT_EQ(io_bump->getInst()->getChipBump(), io_bump);
   EXPECT_EQ(io_inst_region_r1_bump_inst->getChipRegionInst(),
             io_inst_region_r1);
 


### PR DESCRIPTION
## Summary

Add `dbInst` → `dbChipBump` back-reference (`chip_region_`, `bump_`) and `dbInst::getChipBump()`. Enforce one bump per inst, block inst destroy when a bump exists, and clear `bump->bterm_` on bterm destroy. Schema bump to 132.

## Type of Change

- New feature

## Impact

Bump-backed insts can be looked up directly via `getChipBump()`.

## Verification

- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues

N/A