### PR TITLE
gui: fix power density heatmap not rendering after timing analysis (Closes: #10582)

### DIFF
--- a/src/gui/src/heatMapCore.cpp
+++ b/src/gui/src/heatMapCore.cpp
@@ -1211,15 +1211,20 @@ void PowerDensityDataSource::combineMapData(bool,
 
 sta::Scene* PowerDensityDataSource::getScene() const
 {
-  if (scene_.empty()) {
+  if (sta_ == nullptr) {
     return nullptr;
   }
-  for (auto* scene : sta_->scenes()) {
-    if (scene->name() == scene_) {
-      return scene;
+  if (!scene_.empty()) {
+    for (auto* scene : sta_->scenes()) {
+      if (scene->name() == scene_) {
+        return scene;
+      }
     }
   }
-  return nullptr;
+  // Fallback: use first available scene when none is explicitly selected
+  // or the named scene no longer exists (e.g. before timing analysis runs).
+  const auto& scenes = sta_->scenes();
+  return scenes.empty() ? nullptr : scenes[0];
 }
 
 HeatMapSourceRegistration::HeatMapSourceRegistration(std::string name,


### PR DESCRIPTION
## Summary

The power density map is not shown in the gui. This PR provides a bugfix.

PowerDensityDataSource::getScene() lost its fallback to scenes[0] when ca81a290b7 split heatMapCore.cpp from heatMap.cpp for web support. The constructor now initializes scene_ from sta_->scenes() at Gui::init() time, before timing analysis has run, so scene_ is empty.  With no fallback, getScene() returned nullptr and populateMap() bailed out early, leaving the map blank even after timing was performed.

Restore the original behaviour: if scene_ is unset or no longer names a valid scene, fall back to the first available scene at render time.

## Type of Change
- Bug fix

## Impact

The power density map is shown again

## Verification

I have build this via bazel on debian 13 and tested it in the gui in an OpenROAD-flow-scripts environment with the gcd design in the ihp technology. With the patch I can show the power density map. Without the patch I cannot show the map.

## Related Issues

Closes: #10582



