### PR TITLE
bazel: add GUI icon to install for bazel

### DIFF
--- a/bazel/install.sh
+++ b/bazel/install.sh
@@ -3,20 +3,65 @@ set -e
 
 # Install binary and runfiles from bazel build
 
-TARFILE=$(cd $BUILD_WORKSPACE_DIRECTORY; bazelisk info bazel-bin)/packaging/openroad.tar
+BAZEL_BIN=$(cd "$BUILD_WORKSPACE_DIRECTORY"; bazel info bazel-bin)
+TARFILE="$BAZEL_BIN/packaging/openroad.tar"
 
-DEST_DIR=${1:-${BUILD_WORKSPACE_DIRECTORY}/../install/OpenROAD/bin}
+# The desktop entry is built into bazel-bin only for GUI builds
+# --//:platform=gui
+DESKTOP_SRC="$BAZEL_BIN/src/gui/openroad.desktop"
+ICON_SRC="$BUILD_WORKSPACE_DIRECTORY/src/gui/resources/icon.png"
 
-mkdir -p "$DEST_DIR"
-cp -f "$TARFILE" "$DEST_DIR"
-cd "$DEST_DIR"
-tar -xf openroad.tar
-rm -f openroad.tar
-
-# Remove useless files from pkg_tar from bazel
-if [ -e openroad.repo_mapping ]; then
-    chmod u+w openroad.repo_mapping
-    rm -rf openroad.repo_mapping
+INSTALL_DESKTOP=0
+if [ "${OPENROAD_INSTALL_GUI:-0}" = "1" ]; then
+    INSTALL_DESKTOP=1
 fi
 
-echo "OpenROAD binary installed to $(realpath "$DEST_DIR")"
+DEST_DIR=${1:-${BUILD_WORKSPACE_DIRECTORY}/../install/OpenROAD}
+
+mkdir -p "$DEST_DIR/bin"
+
+# Remove previous OpenROAD install artifacts.
+rm -f "$DEST_DIR/bin/openroad"
+rm -f "$DEST_DIR/bin/openroad.repo_mapping"
+rm -f "$DEST_DIR/bin/openroad.runfiles_manifest"
+rm -rf "$DEST_DIR/bin/openroad.runfiles"
+
+tar -xf "$TARFILE" -C "$DEST_DIR/bin"
+
+# Remove useless files from pkg_tar from bazel
+if [ -e "$DEST_DIR/bin/openroad.repo_mapping" ]; then
+    chmod u+w "$DEST_DIR/bin/openroad.repo_mapping"
+    rm -rf "$DEST_DIR/bin/openroad.repo_mapping"
+fi
+
+ABS_DEST="$(realpath "$DEST_DIR")"
+echo "OpenROAD binary installed to $ABS_DEST"
+
+# Remove any previously installed desktop entry and icon before (re)installing,
+# mirroring the binary artifact cleanup above. This runs unconditionally so a
+# prior GUI install is cleaned up even when the current install is not a GUI
+# build, avoiding a stale launcher/icon left pointing at an old prefix.
+APPS_DIR="${HOME}/.local/share/applications"
+rm -f "$ABS_DEST/share/openroad/gui/icon.png"
+rm -f "$APPS_DIR/openroad.desktop"
+
+# Install the desktop entry (menu launcher + icon) if Bazel built it, i.e.
+# this is a GUI build.
+if [ "$INSTALL_DESKTOP" = "1" ] && [ -f "$DESKTOP_SRC" ]; then
+    GUI_SHARE="$ABS_DEST/share/openroad/gui"
+    mkdir -p "$GUI_SHARE"
+    cp -f "$ICON_SRC" "$GUI_SHARE/icon.png"
+
+    mkdir -p "$APPS_DIR"
+    cp -f "$DESKTOP_SRC" "$APPS_DIR/openroad.desktop"
+    # Fill in the install prefix for the icon, and point Exec at the absolute
+    # binary so the launcher works without openroad being on PATH.
+    sed -i \
+        -e "s|@OPENROAD_PREFIX@|$ABS_DEST|g" \
+        -e "s|^Exec=openroad |Exec=$ABS_DEST/bin/openroad |" \
+        "$APPS_DIR/openroad.desktop"
+    if command -v update-desktop-database >/dev/null 2>&1; then
+        update-desktop-database "$APPS_DIR" >/dev/null 2>&1 || true
+    fi
+    echo "OpenROAD desktop entry installed to $APPS_DIR/openroad.desktop"
+fi

--- a/packaging/BUILD.bazel
+++ b/packaging/BUILD.bazel
@@ -7,7 +7,16 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 sh_binary(
     name = "install",
     srcs = ["//bazel:install.sh"],
-    data = [":tarfile"],
+    env = select({
+        "//:platform_gui": {"OPENROAD_INSTALL_GUI": "1"},
+        "//conditions:default": {},
+    }),
+    data = [":tarfile"] + select({
+        # Ship the desktop entry + icon only for GUI builds so install.sh
+        # can register a menu launcher (mirrors the CMake GUI install).
+        "//:platform_gui": ["//src/gui:desktop_files"],
+        "//conditions:default": [],
+    }),
     visibility = ["//visibility:public"],
 )
 

--- a/packaging/BUILD.bazel
+++ b/packaging/BUILD.bazel
@@ -7,15 +7,15 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 sh_binary(
     name = "install",
     srcs = ["//bazel:install.sh"],
-    env = select({
-        "//:platform_gui": {"OPENROAD_INSTALL_GUI": "1"},
-        "//conditions:default": {},
-    }),
     data = [":tarfile"] + select({
         # Ship the desktop entry + icon only for GUI builds so install.sh
         # can register a menu launcher (mirrors the CMake GUI install).
         "//:platform_gui": ["//src/gui:desktop_files"],
         "//conditions:default": [],
+    }),
+    env = select({
+        "//:platform_gui": {"OPENROAD_INSTALL_GUI": "1"},
+        "//conditions:default": {},
     }),
     visibility = ["//visibility:public"],
 )

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -4,8 +4,10 @@
 # This file only currently supports the gui disabled.  More work
 # is needed to handle Qt and build a working gui.
 
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
 load("@qt-bazel//:build_defs.bzl", "qt6_library", "qt6_resource_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 load("//bazel:tcl_encode_or.bzl", "tcl_encode")
 load("//bazel:tcl_wrap_cc.bzl", "tcl_wrap_cc")
 load("//test:regression.bzl", "messages_txt")
@@ -202,4 +204,33 @@ filegroup(
 
 messages_txt(
     visibility = ["//src/gui/test:__pkg__"],
+)
+
+# Desktop entry for GUI builds. Generated from the same template that the
+# CMake build configures (see src/gui/CMakeLists.txt). The install prefix is
+# not known at build time, so the icon path is left as a @OPENROAD_PREFIX@
+# placeholder that //bazel:install.sh substitutes at install time.
+expand_template(
+    name = "desktop_entry",
+    out = "openroad.desktop",
+    substitutions = {
+        "${OPENROAD_SHARE_GUI_DIR}": "@OPENROAD_PREFIX@/share/openroad/gui",
+    },
+    template = "resources/openroad.desktop.cmake",
+)
+
+# The desktop entry and its icon, laid out at the paths install.sh expects
+# inside the extracted tar. Pulled into //packaging:tarfile only when
+# --//:platform=gui is set.
+pkg_files(
+    name = "desktop_files",
+    srcs = [
+        ":openroad.desktop",
+        "resources/icon.png",
+    ],
+    renames = {
+        ":openroad.desktop": "share/applications/openroad.desktop",
+        "resources/icon.png": "share/openroad/gui/icon.png",
+    },
+    visibility = ["//packaging:__pkg__"],
 )

--- a/src/gui/BUILD
+++ b/src/gui/BUILD
@@ -225,8 +225,8 @@ expand_template(
 pkg_files(
     name = "desktop_files",
     srcs = [
-        ":openroad.desktop",
         "resources/icon.png",
+        ":openroad.desktop",
     ],
     renames = {
         ":openroad.desktop": "share/applications/openroad.desktop",

--- a/test/install/BUILD.bazel
+++ b/test/install/BUILD.bazel
@@ -6,7 +6,13 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 sh_test(
     name = "install_test",
     srcs = ["install_test.sh"],
-    args = ["$(rootpath //packaging:tarfile)"],
-    data = ["//packaging:tarfile"],
+    args = [
+        "$(rootpath //packaging:tarfile)",
+        "$(rootpath //bazel:install.sh)",
+    ],
+    data = [
+        "//bazel:install.sh",
+        "//packaging:tarfile",
+    ],
     tags = ["local"],
 )

--- a/test/install/README.md
+++ b/test/install/README.md
@@ -16,6 +16,12 @@ bazelisk test //test/install/...
 2. Launches the binary with a trivial Tcl script (`puts "install_test_ok"`).
 3. Asserts the expected output appears, proving Tcl initialised and the
    interpreter is functional.
+4. Runs the real `bazel/install.sh` inside a self-contained fake workspace
+   (fake `bazel info bazel-bin`, a minimal tarball, synthetic desktop/icon
+   sources) to verify its cleanup logic: stale binary runfiles are removed on
+   re-install, the GUI launcher + icon are installed and refreshed for a GUI
+   build, and the stale launcher + icon are removed when a later install is
+   not a GUI build.
 
 ## Background
 

--- a/test/install/install_test.sh
+++ b/test/install/install_test.sh
@@ -6,7 +6,10 @@
 # binary can start with cleared runfiles env vars.
 set -euo pipefail
 
-TARFILE="$1"
+# Resolve to absolute paths now: the script cd's into a temp dir below, after
+# which these runfiles-relative args would no longer resolve.
+TARFILE="$(realpath "$1")"
+INSTALL_SH="$(realpath "$2")"
 
 DEST_DIR=$(mktemp -d)
 WORK_DIR=$(mktemp -d)
@@ -71,3 +74,114 @@ else
     echo "Output was: $OUTPUT"
     exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# install.sh artifact cleanup test.
+#
+# Runs the real, unmodified bazel/install.sh inside a self-contained fake
+# workspace (a fake `bazel info bazel-bin`, a minimal tarball, and synthetic
+# desktop/icon sources) so no live bazel is needed. Verifies that install.sh:
+#   1. removes stale binary runfiles before re-extracting (existing cleanup);
+#   2. installs the GUI launcher + icon for a GUI build, with the
+#      @OPENROAD_PREFIX@/Exec placeholders substituted;
+#   3. refreshes (updates) those files on a subsequent GUI re-install;
+#   4. removes the stale launcher + icon when a later install is NOT a GUI
+#      build (the unconditional GUI cleanup).
+# ---------------------------------------------------------------------------
+SHIM_DIR=$(mktemp -d)     # holds the fake `bazel` on PATH
+WS=$(mktemp -d)           # BUILD_WORKSPACE_DIRECTORY (icon source lives here)
+BB=$(mktemp -d)           # fake bazel-bin (tarball + desktop entry live here)
+PREFIX=$(mktemp -d)       # install destination (DEST_DIR)
+FAKE_HOME=$(mktemp -d)    # controls APPS_DIR (~/.local/share/applications)
+trap 'rm -rf "$DEST_DIR" "$WORK_DIR" "$SHIM_DIR" "$WS" "$BB" "$PREFIX" "$FAKE_HOME"' EXIT
+
+# Fake `bazel`: install.sh only ever calls `bazel info bazel-bin`.
+cat > "$SHIM_DIR/bazel" <<EOF
+#!/usr/bin/env bash
+[ "\$1" = "info" ] && [ "\$2" = "bazel-bin" ] && { echo "$BB"; exit 0; }
+exit 1
+EOF
+chmod +x "$SHIM_DIR/bazel"
+
+# Minimal tarball: install.sh just extracts it into PREFIX/bin; the binary
+# itself is irrelevant to the cleanup logic, so a dummy file keeps this fast.
+mkdir -p "$BB/packaging" "$BB/src/gui" "$WS/src/gui/resources"
+TAR_SRC=$(mktemp -d)
+echo "dummy" > "$TAR_SRC/openroad"
+tar -cf "$BB/packaging/openroad.tar" -C "$TAR_SRC" .
+rm -rf "$TAR_SRC"
+
+# Synthetic icon + desktop template mirroring //src/gui:desktop_entry: the
+# template carries the @OPENROAD_PREFIX@ placeholder and an "Exec=openroad ..."
+# line, both rewritten by install.sh at install time.
+echo "icon-v1" > "$WS/src/gui/resources/icon.png"
+cat > "$BB/src/gui/openroad.desktop" <<'EOF'
+[Desktop Entry]
+Type=Application
+Name=OpenROAD
+Exec=openroad -gui
+Icon=@OPENROAD_PREFIX@/share/openroad/gui/icon.png
+Categories=Development;Electronics
+EOF
+
+# Run the real install.sh; arg $1 controls OPENROAD_INSTALL_GUI.
+run_install() {
+    env PATH="$SHIM_DIR:$PATH" \
+        HOME="$FAKE_HOME" \
+        BUILD_WORKSPACE_DIRECTORY="$WS" \
+        OPENROAD_INSTALL_GUI="$1" \
+        bash "$INSTALL_SH" "$PREFIX" > /dev/null
+}
+
+APPS_DIR="$FAKE_HOME/.local/share/applications"
+INSTALLED_DESKTOP="$APPS_DIR/openroad.desktop"
+INSTALLED_ICON="$PREFIX/share/openroad/gui/icon.png"
+
+# 1. GUI install: launcher + icon present, placeholders substituted.
+run_install 1
+if [ ! -f "$INSTALLED_DESKTOP" ] || [ ! -f "$INSTALLED_ICON" ]; then
+    echo "FAIL: GUI install did not create desktop entry and/or icon"
+    exit 1
+fi
+ABS_PREFIX="$(realpath "$PREFIX")"
+if grep -q "@OPENROAD_PREFIX@" "$INSTALLED_DESKTOP"; then
+    echo "FAIL: @OPENROAD_PREFIX@ placeholder not substituted in desktop entry"
+    exit 1
+fi
+if ! grep -q "^Exec=$ABS_PREFIX/bin/openroad " "$INSTALLED_DESKTOP"; then
+    echo "FAIL: Exec line not rewritten to absolute installed binary path"
+    exit 1
+fi
+echo "PASS: GUI install created launcher + icon with substituted paths"
+
+# 2. Binary cleanup: a stale runfiles tree must be removed on re-install.
+mkdir -p "$PREFIX/bin/openroad.runfiles/stale"
+touch "$PREFIX/bin/openroad.runfiles/stale/old_file"
+run_install 1
+if [ -e "$PREFIX/bin/openroad.runfiles/stale/old_file" ]; then
+    echo "FAIL: stale binary runfiles not removed on re-install"
+    exit 1
+fi
+echo "PASS: re-install removes stale binary runfiles"
+
+# 3. GUI re-install with changed sources: files are refreshed in place.
+echo "icon-v2" > "$WS/src/gui/resources/icon.png"
+run_install 1
+if ! grep -q "icon-v2" "$INSTALLED_ICON"; then
+    echo "FAIL: GUI re-install did not update the installed icon"
+    exit 1
+fi
+echo "PASS: GUI re-install updates previously installed artifacts"
+
+# 4. Non-GUI install: stale launcher + icon from the prior GUI install must be
+#    removed even though this install ships no desktop files.
+run_install 0
+if [ -f "$INSTALLED_DESKTOP" ]; then
+    echo "FAIL: stale desktop entry not removed on non-GUI re-install"
+    exit 1
+fi
+if [ -f "$INSTALLED_ICON" ]; then
+    echo "FAIL: stale icon not removed on non-GUI re-install"
+    exit 1
+fi
+echo "PASS: non-GUI re-install removes stale GUI artifacts"


### PR DESCRIPTION
## Summary
This adds the GUI Icon and desktop entry needed to provide a taskbar icon and shortcut, as we have in the CMake install.
This only installs when the gui is enabled in the build.
Also adds some cleanup of installs to avoid stale files from hanging around.

## Type of Change
- New feature

## Impact
Only installs are impacted and once CMake is dropped the template file can be updated to make it more bazel-ish, and then QT is dropped, we can update it to be -web instead of -gui.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**
