### PR TITLE
grt,cts,est: backside-aware fixes (cross-side direction check, NDR creation, parasitic midpoint)

### DIFF
--- a/src/cts/src/TritonCTS.cpp
+++ b/src/cts/src/TritonCTS.cpp
@@ -1931,6 +1931,13 @@ void TritonCTS::writeClockNDRsToDb(TreeBuilder* builder)
   odb::dbTech* tech = db_->getTech();
   for (int i = 1; i <= tech->getRoutingLayerCount(); i++) {
     odb::dbTechLayer* layer = tech->findRoutingLayer(i);
+    // Backside routing layers (BPR, BM*, BRDL) are not clock-routing
+    // targets; clock trees live on the frontside. Skip them so we do
+    // not create NDR rules whose widths/spacings are derived from
+    // backside design rules and would never apply to a clock net.
+    if (layer->isBackside()) {
+      continue;
+    }
     odb::dbTechLayerRule* layerRule = clockNDR->getLayerRule(layer);
     if (!layerRule) {
       layerRule = odb::dbTechLayerRule::create(clockNDR, layer);

--- a/src/est/src/EstimateParasitics.cpp
+++ b/src/est/src/EstimateParasitics.cpp
@@ -914,7 +914,22 @@ double EstimateParasitics::computeAverageCutResistance(sta::Scene* scene)
   int max_layer = block_->getMaxRoutingLayer();
 
   if (max_layer < 0) {
-    max_layer = db_->getTech()->getRoutingLayerCount() / 2;
+    // Fall back to roughly the middle of the frontside routing stack.
+    // Halving the total routing-layer count picks the wrong stack when
+    // backside layers (BPR, BM*, BRDL) push the midpoint below the
+    // frontside boundary; counting only frontside levels keeps the
+    // heuristic on the side that hosts the signal routes whose cut
+    // resistance this function averages.
+    odb::dbTech* tech = db_->getTech();
+    const int total_levels = tech->getRoutingLayerCount();
+    odb::dbTechLayer* first_front = tech->firstFrontsideRoutingLayer();
+    if (first_front != nullptr) {
+      const int first_level = first_front->getRoutingLevel();
+      const int frontside_count = total_levels - first_level + 1;
+      max_layer = first_level - 1 + frontside_count / 2;
+    } else {
+      max_layer = total_levels / 2;
+    }
   }
 
   odb::dbTechLayer* min_tech_layer

--- a/src/grt/src/GlobalRouter.cpp
+++ b/src/grt/src/GlobalRouter.cpp
@@ -796,6 +796,13 @@ void GlobalRouter::checkAdjacentLayersDirection(int min_routing_layer,
   for (int l = min_routing_layer; l < max_routing_layer; l++) {
     odb::dbTechLayer* layer_a = tech->findRoutingLayer(l);
     odb::dbTechLayer* layer_b = tech->findRoutingLayer(l + 1);
+    // Backside and frontside routing layers sit on opposite sides of the
+    // substrate, so "adjacent routing level" across the side boundary is
+    // not a physical neighbor relationship and direction agreement there
+    // is not a misconfiguration.
+    if (layer_a->isBackside() != layer_b->isBackside()) {
+      continue;
+    }
     if (layer_a->getDirection() == layer_b->getDirection()) {
       logger_->error(
           GRT,


### PR DESCRIPTION
### Summary

Three small backside-aware fixes uncovered while bringing up the
gt2n BSPDN PDK in OpenROAD-flow-scripts. Each is independent and
sits as its own commit. The underlying theme is the same: routines
that walk `dbTech::findRoutingLayer(1..count)` without an
`isBackside()` guard misbehave on a tech whose routing-layer
enumeration interleaves a backside stack (BPR, BM*, BRDL) with the
familiar frontside stack (M0 .. RDL).

### Commits

1. **grt: skip cross-side pairs in checkAdjacentLayersDirection**
   GRT-126 is a hard error fired when two consecutive routing levels
   share a preferred direction. On a BSPDN tech the level-l /
   level-l+1 pair can straddle the backside boundary (e.g. BPR(H) and
   M0(H)). Those layers are not physical neighbors and direction
   agreement across the boundary is not a misconfiguration. Skip the
   pair when isBackside() differs.

2. **cts: skip backside layers in writeClockNDRsToDb**
   The default-NDR creation loop builds a dbTechLayerRule for every
   routing layer in the tech. Clock trees route on the frontside.
   The backside rules are derived from backside design rules and
   would never apply to a clock net, but still live in the
   dbTechNonDefaultRule and could leak through by-name lookups.

3. **est: keep cut-resistance fallback midpoint on the frontside stack**
   computeAverageCutResistance falls back to
   getRoutingLayerCount() / 2 when block max routing layer is unset.
   With backside layers in the count, that midpoint lands on the
   backside via stack instead of the signal-routing via stack the
   function is meant to characterize. Anchor the fallback at
   firstFrontsideRoutingLayer() and halve the frontside-only count.
   Legacy non-backside techs are unchanged.

### Why now / impact

The GRT-126 case is not theoretical. Lowering MIN_ROUTING_LAYER to
M0, a perfectly reasonable choice that @gadfort appears to have been
running when he flagged this, is enough to make the check walk the
BPR(H) / M0(H) pair and abort the flow with a hard error on a valid
BSPDN PDK. The default ORFS gt2n config sets MIN_ROUTING_LAYER=M2
today and so happens to skip over the boundary, which masks the bug;
any config that opens the bottom of the stack hits it immediately.

The CTS and EST cases are quieter. The bogus NDR rules on backside
layers never get applied to a clock net in practice, and the EST
fallback only fires when block max routing layer is unset. They are
the same underlying pattern and worth cleaning up at the same time.

### Test plan

- [x] Local incremental rebuild clean.
- [x] gt2n/gcd ORFS run through `5_1_grt` clean with the series
      applied (no GRT-126, no behavioral change vs. unpatched for
      that config since MIN_ROUTING_LAYER=M2 and block max is set).
- Existing GRT / CTS / EST regressions cover the no-backside path,
  which is what the legacy-equivalence arms of each patch preserve.

### Related

@gadfort flagged the GRT-126 case on a review comment elsewhere.
Filing the cluster of three together since they all share the same
underlying pattern.