### PR TITLE
web: add multi-selection and inspector cycling with pulse animation

### DIFF
--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -50,6 +50,18 @@ const CLEAR_FOCUS_SVG =
     '<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>' +
     '</svg>';
 
+// Chevron left: Material "chevron_left"
+const CHEVRON_LEFT_SVG =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">' +
+    '<path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>' +
+    '</svg>';
+
+// Chevron right: Material "chevron_right"
+const CHEVRON_RIGHT_SVG =
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">' +
+    '<path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>' +
+    '</svg>';
+
 export function createInspectorPanel(app, redrawAllLayers) {
     let lastInspectData = null;
     let pendingInspectId = null;
@@ -216,6 +228,56 @@ export function createInspectorPanel(app, redrawAllLayers) {
         });
     }
 
+    function cycleSelection(direction) {
+        const reqType = direction > 0 ? 'select_next' : 'select_prev';
+        if (pendingInspectId !== null) {
+            app.websocketManager.cancel(pendingInspectId);
+            pendingInspectId = null;
+        }
+        showLoading();
+        const promise = app.websocketManager.request({ type: reqType });
+        pendingInspectId = promise.requestId;
+        promise
+            .then(data => {
+                pendingInspectId = null;
+                if (data.error) {
+                    console.error('Selection cycle error:', data.error);
+                    updateInspector(lastInspectData);
+                    return;
+                }
+                updateInspector(data);
+                // Keep schematic in sync when cycling to an instance.
+                if (data.type === 'Inst' && data.name) {
+                    app.selectedInstanceName = data.name;
+                    if (app.schematicWidget) {
+                        app.schematicWidget.refresh();
+                    }
+                }
+                if (app.map) {
+                    app.map.closePopup();
+                }
+                clearClientHoverHighlight();
+                if (app.highlightRect && app.map) {
+                    app.map.removeLayer(app.highlightRect);
+                    app.highlightRect = null;
+                }
+                if (data.bbox && app.map && app.designScale) {
+                    const [x1, y1, x2, y2] = data.bbox;
+                    if (data.type !== 'Inst') {
+                        highlightBBox(x1, y1, x2, y2);
+                    }
+                    pulseHighlight(data.bbox);
+                }
+                // Redraw tiles to restore selection-set highlights.
+                redrawAllLayers();
+            })
+            .catch(err => {
+                pendingInspectId = null;
+                console.error('Selection cycle failed:', err);
+                updateInspector(lastInspectData);
+            });
+    }
+
     function navigateInspector(selectId) {
         // Cancel previous in-flight inspect request
         if (pendingInspectId !== null) {
@@ -252,6 +314,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
                     if (data.type !== 'Inst') {
                         highlightBBox(x1, y1, x2, y2);
                     }
+                    pulseHighlight(data.bbox);
                 }
                 // Redraw tiles to update instance highlight
                 redrawAllLayers();
@@ -288,9 +351,12 @@ export function createInspectorPanel(app, redrawAllLayers) {
                     app.map.removeLayer(app.highlightRect);
                     app.highlightRect = null;
                 }
-                if (data.bbox && app.map && app.designScale && data.type !== 'Inst') {
-                    const [x1, y1, x2, y2] = data.bbox;
-                    highlightBBox(x1, y1, x2, y2);
+                if (data.bbox && app.map && app.designScale) {
+                    if (data.type !== 'Inst') {
+                        const [x1, y1, x2, y2] = data.bbox;
+                        highlightBBox(x1, y1, x2, y2);
+                    }
+                    pulseHighlight(data.bbox);
                 }
                 redrawAllLayers();
             })
@@ -308,6 +374,44 @@ export function createInspectorPanel(app, redrawAllLayers) {
         app.highlightRect = L.rectangle(bounds, {
             color: '#ff0', weight: 2, fill: false, dashArray: '6,4',
         }).addTo(app.map);
+    }
+
+    // Briefly pulse the object's bbox so the user can see which object
+    // the inspector is now showing — mirrors the Qt GUI's selection
+    // animation.  The pulse is a filled rectangle that fades in and out
+    // several times, then removes itself.
+    let pulseLayer = null;
+    function pulseHighlight(bbox) {
+        if (!bbox || !app.map || !app.designScale) return;
+        if (pulseLayer) {
+            app.map.removeLayer(pulseLayer);
+            pulseLayer = null;
+        }
+        const [x1, y1, x2, y2] = bbox;
+        const bounds = dbuRectToBounds(
+            x1, y1, x2, y2, app.designScale, app.designMaxDXDY,
+            app.designOriginX, app.designOriginY);
+        pulseLayer = L.rectangle(bounds, {
+            color: '#ff0',
+            weight: 3,
+            fill: true,
+            fillColor: '#ff0',
+            fillOpacity: 0.25,
+            opacity: 1,
+            interactive: false,
+            className: 'selection-pulse',
+            pane: app.hoverHighlightPane,
+        }).addTo(app.map);
+        // Remove after the animation finishes (3 cycles × 350ms = 1050ms).
+        const layerToRemove = pulseLayer;
+        setTimeout(() => {
+            if (layerToRemove && app.map && app.map.hasLayer(layerToRemove)) {
+                app.map.removeLayer(layerToRemove);
+            }
+            if (pulseLayer === layerToRemove) {
+                pulseLayer = null;
+            }
+        }, 1100);
     }
 
     function renderProperty(prop, data) {
@@ -477,6 +581,36 @@ export function createInspectorPanel(app, redrawAllLayers) {
             app.inspectorEl.appendChild(toolbar);
         }
 
+        // Selection navigation bar (visible when multiple objects selected)
+        const selCount = data.selection_count || 0;
+        const selIndex = typeof data.selection_index === 'number'
+            ? data.selection_index : -1;
+        if (selCount > 1 && selIndex >= 0) {
+            const nav = document.createElement('div');
+            nav.className = 'inspector-selection-nav';
+
+            const prevBtn = document.createElement('button');
+            prevBtn.className = 'inspector-btn';
+            prevBtn.title = 'Previous (Shift+click to multi-select)';
+            prevBtn.innerHTML = CHEVRON_LEFT_SVG;
+            prevBtn.addEventListener('click', () => cycleSelection(-1));
+
+            const label = document.createElement('span');
+            label.className = 'inspector-selection-label';
+            label.textContent = (selIndex + 1) + ' / ' + selCount;
+
+            const nextBtn = document.createElement('button');
+            nextBtn.className = 'inspector-btn';
+            nextBtn.title = 'Next';
+            nextBtn.innerHTML = CHEVRON_RIGHT_SVG;
+            nextBtn.addEventListener('click', () => cycleSelection(+1));
+
+            nav.appendChild(prevBtn);
+            nav.appendChild(label);
+            nav.appendChild(nextBtn);
+            app.inspectorEl.appendChild(nav);
+        }
+
         for (const prop of data.properties) {
             app.inspectorEl.appendChild(renderProperty(prop, data));
         }
@@ -492,5 +626,5 @@ export function createInspectorPanel(app, redrawAllLayers) {
         updateInspector(null);
     }
 
-    return { createInspector, updateInspector, highlightBBox, navigateInspector };
+    return { createInspector, updateInspector, highlightBBox, pulseHighlight, navigateInspector };
 }

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -629,6 +629,7 @@ const inspector = createInspectorPanel(app, redrawAllLayers);
 const createInspector = inspector.createInspector;
 const updateInspector = inspector.updateInspector;
 const highlightBBox = inspector.highlightBBox;
+const pulseHighlight = inspector.pulseHighlight;
 app.updateInspector = updateInspector;
 app.navigateInspector = inspector.navigateInspector;
 
@@ -1078,6 +1079,9 @@ app.websocketManager.readyPromise.then(async () => {
                 selectable_layers: [...app.selectableLayers],
                 ...vf,
             };
+            if (e.originalEvent && e.originalEvent.shiftKey) {
+                selectRequest.add_to_selection = true;
+            }
             if (app.visibleChiplets instanceof Set) {
                 selectRequest.visible_chiplets = [...app.visibleChiplets];
             }
@@ -1099,6 +1103,7 @@ app.websocketManager.readyPromise.then(async () => {
                         if (inst.bbox) {
                             highlightBBox(inst.bbox[0], inst.bbox[1],
                                           inst.bbox[2], inst.bbox[3]);
+                            pulseHighlight(inst.bbox);
                         }
                     } else {
                         updateInspector(null);

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -1105,7 +1105,10 @@ app.websocketManager.readyPromise.then(async () => {
                                           inst.bbox[2], inst.bbox[3]);
                             pulseHighlight(inst.bbox);
                         }
-                    } else {
+                    } else if (!selectRequest.add_to_selection) {
+                        // Shift+click on empty space preserves the existing
+                        // multi-selection on the server, so leave the
+                        // inspector/navigation controls and highlight intact.
                         updateInspector(null);
                         if (app.highlightRect) {
                             app.map.removeLayer(app.highlightRect);

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <exception>
 #include <filesystem>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <memory>
@@ -660,6 +661,12 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
           state.navigation_history.push_back(state.current_inspected);
         }
         state.current_inspected = sel;
+        // Realign the cycling iterator with the linked target so that
+        // selection_index reflects the object actually being rendered, and
+        // the next Next/Previous starts from this object. If the link goes
+        // outside the multi-selection, point the iterator at end() so the
+        // index serializes as -1 and the nav UI is suppressed.
+        state.selection_itr = state.selection_set.find(sel);
       }
       can_navigate_back = !state.navigation_history.empty();
       sel_count = static_cast<int>(state.selection_set.size());
@@ -772,6 +779,9 @@ static WebSocketResponse handleSelectionCycle(
         }
         sel = *state.selection_itr;
         state.current_inspected = sel;
+        state.hover_rects.clear();
+        state.timing_rects.clear();
+        state.timing_lines.clear();
         state.navigation_history.clear();
         // Restore selection-set highlights (handleInspect may have
         // replaced them with a single linked object's shapes).

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -209,6 +209,36 @@ static void collectHighlightShapes(const gui::Selected& sel,
   polys = std::move(collector.polys);
 }
 
+// Return the 0-based position of the iterator within the selection set,
+// or -1 if the set is empty.  Mirrors Qt GUI's
+// Inspector::getSelectedIteratorPosition().
+static int selectionIteratorPosition(const gui::SelectionSet& set,
+                                     gui::SelectionSet::const_iterator itr)
+{
+  if (set.empty() || itr == set.end()) {
+    return -1;
+  }
+  return static_cast<int>(std::distance(set.begin(), itr));
+}
+
+// Accumulate highlight shapes from all items in a selection set.
+static void collectMultiHighlightShapes(const gui::SelectionSet& selections,
+                                        std::vector<odb::Rect>& rects,
+                                        std::vector<odb::Polygon>& polys)
+{
+  rects.clear();
+  polys.clear();
+  for (const auto& sel : selections) {
+    if (!sel) {
+      continue;
+    }
+    ShapeCollector collector;
+    sel.highlight(collector);
+    rects.insert(rects.end(), collector.rects.begin(), collector.rects.end());
+    polys.insert(polys.end(), collector.polys.begin(), collector.polys.end());
+  }
+}
+
 static void writeInspectPayload(boost::json::object& o,
                                 const gui::Selected& sel,
                                 std::vector<gui::Selected>& new_selectables,
@@ -454,6 +484,16 @@ void SelectHandler::registerRequests(RequestDispatcher& d)
         [this](const WebSocketRequest& req, SessionState& state) {
           return handleSchematicInspect(req, state);
         });
+  d.add("select_next",
+        WebSocketRequest::kSelectNext,
+        [this](const WebSocketRequest& req, SessionState& state) {
+          return handleSelectNext(req, state);
+        });
+  d.add("select_prev",
+        WebSocketRequest::kSelectPrev,
+        [this](const WebSocketRequest& req, SessionState& state) {
+          return handleSelectPrev(req, state);
+        });
   d.add("set_focus_nets",
         WebSocketRequest::kSetFocusNets,
         [this](const WebSocketRequest& req, SessionState& state) {
@@ -490,6 +530,8 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
                          zoom,
                          vis,
                          arrayAsStringSet(req.json.at("visible_layers")));
+
+    const bool add_to_selection = jsonOr(req.json, "add_to_selection", false);
 
     // STA's highlight() and getProperties() are not thread-safe;
     // serialize with other STA callers (timing, clock tree, tcl eval).
@@ -546,10 +588,32 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
       state.hover_rects.clear();
       state.timing_rects.clear();
       state.timing_lines.clear();
-      collectHighlightShapes(
-          inspected_sel, state.highlight_rects, state.highlight_polys);
-      state.current_inspected = inspected_sel;
       state.navigation_history.clear();
+
+      if (add_to_selection) {
+        // Shift+click: add to existing selection set if we hit something;
+        // clicking empty space preserves the current selection.
+        if (inspected_sel) {
+          state.selection_itr = state.selection_set.insert(inspected_sel).first;
+        }
+      } else {
+        // Normal click: replace selection set.
+        state.selection_set.clear();
+        if (inspected_sel) {
+          state.selection_set.insert(inspected_sel);
+        }
+        state.selection_itr = state.selection_set.begin();
+      }
+
+      // Highlight all items in the selection set.
+      collectMultiHighlightShapes(
+          state.selection_set, state.highlight_rects, state.highlight_polys);
+      state.current_inspected = inspected_sel;
+
+      root["selection_count"]
+          = static_cast<int64_t>(state.selection_set.size());
+      root["selection_index"] = static_cast<int64_t>(
+          selectionIteratorPosition(state.selection_set, state.selection_itr));
     }
 
     writePayload(resp, root);
@@ -583,6 +647,8 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
 
     bool can_navigate_back = false;
+    int sel_count = 0;
+    int sel_index = -1;
     {
       std::lock_guard<std::mutex> lock(state.selection_mutex);
       state.hover_rects.clear();
@@ -596,12 +662,17 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
         state.current_inspected = sel;
       }
       can_navigate_back = !state.navigation_history.empty();
+      sel_count = static_cast<int>(state.selection_set.size());
+      sel_index
+          = selectionIteratorPosition(state.selection_set, state.selection_itr);
     }
 
     resp.type = WebSocketResponse::kJson;
     boost::json::object root;
     std::vector<gui::Selected> new_selectables;
     writeInspectPayload(root, sel, new_selectables, can_navigate_back);
+    root["selection_count"] = static_cast<int64_t>(sel_count);
+    root["selection_index"] = static_cast<int64_t>(sel_index);
     {
       std::lock_guard<std::mutex> lock(state.selectables_mutex);
       state.selectables = std::move(new_selectables);
@@ -625,6 +696,8 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
     bool can_navigate_back = false;
 
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    int sel_count = 0;
+    int sel_index = -1;
     {
       std::lock_guard<std::mutex> lock(state.selection_mutex);
       state.hover_rects.clear();
@@ -641,12 +714,17 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
 
       collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
       can_navigate_back = !state.navigation_history.empty();
+      sel_count = static_cast<int>(state.selection_set.size());
+      sel_index
+          = selectionIteratorPosition(state.selection_set, state.selection_itr);
     }
 
     resp.type = WebSocketResponse::kJson;
     boost::json::object root;
     std::vector<gui::Selected> new_selectables;
     writeInspectPayload(root, sel, new_selectables, can_navigate_back);
+    root["selection_count"] = static_cast<int64_t>(sel_count);
+    root["selection_index"] = static_cast<int64_t>(sel_index);
     {
       std::lock_guard<std::mutex> lock(state.selectables_mutex);
       state.selectables = std::move(new_selectables);
@@ -658,6 +736,82 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
     resp.payload.assign(err.begin(), err.end());
   }
   return resp;
+}
+
+// Cycle to the next/previous item in the multi-selection set.
+// Returns the inspect payload for the newly active item without
+// changing the highlight shapes (all selected items stay highlighted).
+static WebSocketResponse handleSelectionCycle(
+    const WebSocketRequest& req,
+    SessionState& state,
+    const int direction,
+    std::shared_ptr<TclEvaluator>& tcl_eval)
+{
+  WebSocketResponse resp;
+  resp.id = req.id;
+  try {
+    gui::Selected sel;
+
+    std::lock_guard<std::mutex> sta_lock(tcl_eval->mutex);
+    int sel_count = 0;
+    int sel_index = -1;
+    {
+      std::lock_guard<std::mutex> lock(state.selection_mutex);
+      sel_count = static_cast<int>(state.selection_set.size());
+      if (sel_count > 0) {
+        if (direction > 0) {
+          ++state.selection_itr;
+          if (state.selection_itr == state.selection_set.end()) {
+            state.selection_itr = state.selection_set.begin();
+          }
+        } else {
+          if (state.selection_itr == state.selection_set.begin()) {
+            state.selection_itr = state.selection_set.end();
+          }
+          --state.selection_itr;
+        }
+        sel = *state.selection_itr;
+        state.current_inspected = sel;
+        state.navigation_history.clear();
+        // Restore selection-set highlights (handleInspect may have
+        // replaced them with a single linked object's shapes).
+        collectMultiHighlightShapes(
+            state.selection_set, state.highlight_rects, state.highlight_polys);
+      }
+      sel_index
+          = selectionIteratorPosition(state.selection_set, state.selection_itr);
+    }
+
+    resp.type = WebSocketResponse::kJson;
+    boost::json::object root;
+    std::vector<gui::Selected> new_selectables;
+    const bool can_navigate_back = false;
+    writeInspectPayload(root, sel, new_selectables, can_navigate_back);
+    root["selection_count"] = static_cast<int64_t>(sel_count);
+    root["selection_index"] = static_cast<int64_t>(sel_index);
+    {
+      std::lock_guard<std::mutex> lock(state.selectables_mutex);
+      state.selectables = std::move(new_selectables);
+    }
+    writePayload(resp, root);
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  return resp;
+}
+
+WebSocketResponse SelectHandler::handleSelectNext(const WebSocketRequest& req,
+                                                  SessionState& state)
+{
+  return handleSelectionCycle(req, state, +1, tcl_eval_);
+}
+
+WebSocketResponse SelectHandler::handleSelectPrev(const WebSocketRequest& req,
+                                                  SessionState& state)
+{
+  return handleSelectionCycle(req, state, -1, tcl_eval_);
 }
 
 WebSocketResponse SelectHandler::handleHover(const WebSocketRequest& req,

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -115,6 +115,8 @@ struct WebSocketRequest
     kDrcUpdateMarker,
     kDrcUpdateCategoryVisibility,
     kDrcHighlight,
+    kSelectNext,
+    kSelectPrev,
     kDebugContinue,
     kDebugCharts,
     kGet3DData,
@@ -168,6 +170,10 @@ struct SessionState
 
   gui::Selected current_inspected;
   std::vector<gui::Selected> navigation_history;
+
+  // Multi-selection set and iterator position (mirrors Qt GUI's SelectionSet).
+  gui::SelectionSet selection_set;
+  gui::SelectionSet::const_iterator selection_itr = selection_set.end();
 
   std::mutex module_colors_mutex;
   std::map<uint32_t, Color> module_colors;  // odb module id → RGBA color
@@ -226,6 +232,10 @@ class SelectHandler
                                        SessionState& state);
   WebSocketResponse handleSetRouteGuides(const WebSocketRequest& req,
                                          SessionState& state);
+  WebSocketResponse handleSelectNext(const WebSocketRequest& req,
+                                     SessionState& state);
+  WebSocketResponse handleSelectPrev(const WebSocketRequest& req,
+                                     SessionState& state);
   WebSocketResponse handleSnap(const WebSocketRequest& req);
   WebSocketResponse handleSchematicCone(const WebSocketRequest& req);
   WebSocketResponse handleSchematicFull(const WebSocketRequest& req);

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -942,6 +942,20 @@ html, body {
     background: var(--bg-context);
     color: var(--fg-muted);
 }
+.inspector-selection-nav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 0 5px;
+    border-bottom: 1px solid var(--border-subtle);
+    margin-bottom: 4px;
+}
+.inspector-selection-label {
+    font-size: 11px;
+    color: var(--fg-muted);
+    min-width: 40px;
+    text-align: center;
+}
 
 /* Debug-graphics Continue button (fixed top-right, hidden until paused) */
 .debug-continue-btn {
@@ -987,6 +1001,18 @@ html, body {
         stroke-opacity: 0.95;
         fill-opacity: 0.14;
     }
+}
+
+/* Selection pulse: brief flash when the inspector changes its target */
+.selection-pulse {
+    pointer-events: none;
+    animation: selection-pulse 350ms ease-in-out 3;
+    animation-fill-mode: forwards;
+}
+@keyframes selection-pulse {
+    0%   { stroke-opacity: 0;   fill-opacity: 0; }
+    50%  { stroke-opacity: 1;   fill-opacity: 0.28; }
+    100% { stroke-opacity: 0;   fill-opacity: 0; }
 }
 
 /* ─── Timing Widget ────────────────────────────────────────────────────── */

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -802,6 +802,314 @@ TEST_F(SelectHandlerTest, TileHandlerSnapshotsFocusNets)
 }
 
 //------------------------------------------------------------------------------
+// Multi-selection tests
+//------------------------------------------------------------------------------
+
+// Helper: populate selection_set with two fake objects and point the
+// iterator at whichever position (0 = begin, 1 = second).
+// Because SelectionSet is std::set, iteration order is by operator<
+// (FakeDescriptor::lessThan compares pointer addresses).
+void populateSelectionSet(SessionState& st,
+                          const gui::Selected& a,
+                          const gui::Selected& b,
+                          int itr_pos)
+{
+  std::lock_guard<std::mutex> lock(st.selection_mutex);
+  st.selection_set.insert(a);
+  st.selection_set.insert(b);
+  st.selection_itr = st.selection_set.begin();
+  if (itr_pos > 0) {
+    std::advance(st.selection_itr, itr_pos);
+  }
+  st.current_inspected = *st.selection_itr;
+}
+
+// Verify that a select response always includes selection metadata.
+TEST_F(SelectHandlerTest, SelectResponseIncludesSelectionMetadata)
+{
+  WebSocketRequest req;
+  req.id = 30;
+  req.type = WebSocketRequest::kSelect;
+  req.json
+      = parseObj(R"({"dbu_x":1000,"dbu_y":1000,"zoom":0,"visible_layers":[]})");
+
+  auto resp = handler_->handleSelect(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kJson);
+
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\""), std::string::npos);
+  EXPECT_NE(json.find("\"selection_index\""), std::string::npos);
+}
+
+TEST_F(SelectHandlerTest, SelectEmptyAreaClearsSelectionSet)
+{
+  // Pre-populate selection set
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.selection_set.insert(makeFakeSelected(&fake_current_));
+    state_.selection_itr = state_.selection_set.begin();
+  }
+
+  WebSocketRequest req;
+  req.id = 31;
+  req.type = WebSocketRequest::kSelect;
+  req.json = parseObj(
+      R"({"dbu_x":99000,"dbu_y":99000,"zoom":10,"visible_layers":[]})");
+
+  auto resp = handler_->handleSelect(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kJson);
+
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\":0"), std::string::npos);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.selection_set.empty());
+}
+
+// Normal click (no add_to_selection) clears any pre-existing selection set.
+TEST_F(SelectHandlerTest, SelectNormalClickClearsPreviousSelectionSet)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       1);
+
+  // Normal click at empty area should clear the set
+  WebSocketRequest req;
+  req.id = 32;
+  req.type = WebSocketRequest::kSelect;
+  req.json = parseObj(
+      R"({"dbu_x":99000,"dbu_y":99000,"zoom":10,"visible_layers":[]})");
+
+  handler_->handleSelect(req, state_);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.selection_set.empty());
+}
+
+// Shift+click on empty space should preserve the existing selection set.
+TEST_F(SelectHandlerTest, AddToSelectionEmptyHitPreservesSet)
+{
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.selection_set.insert(makeFakeSelected(&fake_current_));
+    state_.selection_itr = state_.selection_set.begin();
+  }
+
+  WebSocketRequest req;
+  req.id = 33;
+  req.type = WebSocketRequest::kSelect;
+  req.json = parseObj(
+      R"({"dbu_x":99000,"dbu_y":99000,"zoom":10,"visible_layers":[],"add_to_selection":true})");
+
+  handler_->handleSelect(req, state_);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.selection_set.size(), 1u);
+}
+
+// Verify SelectionSet deduplicates (std::set property).
+TEST_F(SelectHandlerTest, SelectionSetDeduplicates)
+{
+  const auto sel = makeFakeSelected(&fake_current_);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.selection_set.insert(sel);
+    state_.selection_set.insert(sel);  // duplicate
+  }
+  EXPECT_EQ(state_.selection_set.size(), 1u);
+}
+
+TEST_F(SelectHandlerTest, SelectNextCyclesForward)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       0);
+
+  WebSocketRequest req;
+  req.id = 37;
+  req.type = WebSocketRequest::kSelectNext;
+
+  auto resp = handler_->handleSelectNext(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kJson);
+
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\":2"), std::string::npos);
+  EXPECT_NE(json.find("\"selection_index\":1"), std::string::npos);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  auto expected = std::next(state_.selection_set.begin());
+  EXPECT_EQ(state_.selection_itr, expected);
+}
+
+TEST_F(SelectHandlerTest, SelectNextWrapsAround)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       1);  // at the end
+
+  WebSocketRequest req;
+  req.id = 38;
+  req.type = WebSocketRequest::kSelectNext;
+
+  auto resp = handler_->handleSelectNext(req, state_);
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_index\":0"), std::string::npos);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.selection_itr, state_.selection_set.begin());
+}
+
+TEST_F(SelectHandlerTest, SelectPrevCyclesBackward)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       1);
+
+  WebSocketRequest req;
+  req.id = 39;
+  req.type = WebSocketRequest::kSelectPrev;
+
+  auto resp = handler_->handleSelectPrev(req, state_);
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_index\":0"), std::string::npos);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.selection_itr, state_.selection_set.begin());
+}
+
+TEST_F(SelectHandlerTest, SelectPrevWrapsAround)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       0);  // at the start
+
+  WebSocketRequest req;
+  req.id = 40;
+  req.type = WebSocketRequest::kSelectPrev;
+
+  auto resp = handler_->handleSelectPrev(req, state_);
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_index\":1"), std::string::npos);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.selection_itr, std::next(state_.selection_set.begin()));
+}
+
+TEST_F(SelectHandlerTest, SelectNextEmptySetReturnsError)
+{
+  WebSocketRequest req;
+  req.id = 41;
+  req.type = WebSocketRequest::kSelectNext;
+
+  auto resp = handler_->handleSelectNext(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kJson);
+
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\":0"), std::string::npos);
+  EXPECT_NE(json.find("\"error\""), std::string::npos);
+}
+
+TEST_F(SelectHandlerTest, SelectNextClearsNavigationHistory)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       0);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.navigation_history.push_back(makeFakeSelected(&fake_previous_));
+  }
+
+  WebSocketRequest req;
+  req.id = 42;
+  req.type = WebSocketRequest::kSelectNext;
+
+  handler_->handleSelectNext(req, state_);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_TRUE(state_.navigation_history.empty());
+}
+
+TEST_F(SelectHandlerTest, InspectResponseIncludesSelectionMetadata)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       0);
+  {
+    std::lock_guard<std::mutex> lock(state_.selectables_mutex);
+    state_.selectables = {makeFakeSelected(&fake_previous_)};
+  }
+
+  WebSocketRequest req;
+  req.id = 43;
+  req.type = WebSocketRequest::kInspect;
+  req.json = parseObj(R"({"select_id":0})");
+
+  auto resp = handler_->handleInspect(req, state_);
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\":2"), std::string::npos);
+  EXPECT_NE(json.find("\"selection_index\":0"), std::string::npos);
+}
+
+TEST_F(SelectHandlerTest, InspectBackResponseIncludesSelectionMetadata)
+{
+  populateSelectionSet(state_,
+                       makeFakeSelected(&fake_current_),
+                       makeFakeSelected(&fake_previous_),
+                       1);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.navigation_history.push_back(makeFakeSelected(&fake_current_));
+  }
+
+  WebSocketRequest req;
+  req.id = 44;
+  req.type = WebSocketRequest::kInspectBack;
+
+  auto resp = handler_->handleInspectBack(req, state_);
+  const std::string json = payloadStr(resp);
+  EXPECT_NE(json.find("\"selection_count\":2"), std::string::npos);
+}
+
+TEST_F(SelectHandlerTest, SelectNextRestoresSelectionSetHighlights)
+{
+  const auto sel_a = makeFakeSelected(&fake_current_);
+  const auto sel_b = makeFakeSelected(&fake_previous_);
+
+  populateSelectionSet(state_, sel_a, sel_b, 0);
+
+  const odb::Rect stale_rect(9999, 9999, 10000, 10000);
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects = {stale_rect};
+    state_.highlight_polys.clear();
+  }
+
+  WebSocketRequest req;
+  req.id = 50;
+  req.type = WebSocketRequest::kSelectNext;
+  handler_->handleSelectNext(req, state_);
+
+  std::lock_guard<std::mutex> lock(state_.selection_mutex);
+  EXPECT_EQ(state_.highlight_rects.size(), 2u);
+  bool found_current = false;
+  bool found_previous = false;
+  for (const auto& r : state_.highlight_rects) {
+    EXPECT_FALSE(r == stale_rect);
+    found_current |= r == fake_current_.bbox;
+    found_previous |= r == fake_previous_.bbox;
+  }
+  EXPECT_TRUE(found_current);
+  EXPECT_TRUE(found_previous);
+}
+
+//------------------------------------------------------------------------------
 // DRCHandler tests
 //------------------------------------------------------------------------------
 

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -1054,7 +1054,7 @@ TEST_F(SelectHandlerTest, InspectResponseIncludesSelectionMetadata)
   auto resp = handler_->handleInspect(req, state_);
   const std::string json = payloadStr(resp);
   EXPECT_NE(json.find("\"selection_count\":2"), std::string::npos);
-  EXPECT_NE(json.find("\"selection_index\":0"), std::string::npos);
+  EXPECT_NE(json.find("\"selection_index\":1"), std::string::npos);
 }
 
 TEST_F(SelectHandlerTest, InspectBackResponseIncludesSelectionMetadata)

--- a/src/web/test/js/test-inspector.js
+++ b/src/web/test/js/test-inspector.js
@@ -176,6 +176,108 @@ describe('Inspector focus nets', () => {
         });
     });
 
+    describe('selection navigation bar', () => {
+        it('does not show nav bar for single selection', () => {
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 1,
+                selection_index: 0,
+            });
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            assert.equal(nav, null, 'nav bar should not be shown for single selection');
+        });
+
+        it('shows nav bar when selection_count > 1', () => {
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 3,
+                selection_index: 1,
+            });
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            assert.ok(nav, 'nav bar should be present');
+            const label = nav.querySelector('.inspector-selection-label');
+            assert.equal(label.textContent, '2 / 3');
+        });
+
+        it('does not show nav bar without selection metadata', () => {
+            panel.updateInspector(instData('buf1'));
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            assert.equal(nav, null);
+        });
+
+        it('prev button sends select_prev request', () => {
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 2,
+                selection_index: 1,
+            });
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            const prevBtn = nav.querySelectorAll('.inspector-btn')[0];
+            prevBtn.click();
+            assert.equal(app._requests.length, 1);
+            assert.equal(app._requests[0].type, 'select_prev');
+        });
+
+        it('next button sends select_next request', () => {
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 2,
+                selection_index: 0,
+            });
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            const btns = nav.querySelectorAll('.inspector-btn');
+            const nextBtn = btns[btns.length - 1];
+            nextBtn.click();
+            assert.equal(app._requests.length, 1);
+            assert.equal(app._requests[0].type, 'select_next');
+        });
+
+        it('next button refreshes schematic selection for cycled Inst', async () => {
+            let schematicRefreshes = 0;
+            app.map = { closePopup() {} };
+            app.schematicWidget = {
+                refresh() { schematicRefreshes++; },
+            };
+            app.selectedInstanceName = 'buf1';
+            app.websocketManager.request = msg => {
+                app._requests.push(msg);
+                const p = Promise.resolve({
+                    ...instData('buf2'),
+                    selection_count: 2,
+                    selection_index: 1,
+                });
+                p.requestId = 1;
+                return p;
+            };
+
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 2,
+                selection_index: 0,
+            });
+            const nav = app.inspectorEl.querySelector('.inspector-selection-nav');
+            const btns = nav.querySelectorAll('.inspector-btn');
+            btns[btns.length - 1].click();
+
+            await new Promise(r => setTimeout(r, 0));
+
+            assert.equal(app._requests[0].type, 'select_next');
+            assert.equal(app.selectedInstanceName, 'buf2');
+            assert.equal(schematicRefreshes, 1);
+            assert.equal(redraws, 1);
+        });
+
+        it('label shows correct 1-indexed position', () => {
+            panel.updateInspector({
+                ...instData('buf1'),
+                selection_count: 5,
+                selection_index: 3,
+            });
+            const label = app.inspectorEl.querySelector('.inspector-selection-label');
+            assert.equal(label.textContent, '4 / 5');
+        });
+    });
+
     describe('properties rendering', () => {
         it('renders leaf properties', () => {
             panel.updateInspector({


### PR DESCRIPTION
## Summary
- Shift+click adds objects to a `SelectionSet` (mirroring the Qt GUI), with all selected objects highlighted simultaneously on the layout tiles
- Inspector shows Previous/Next buttons and a "2 / 5" position label when multiple objects are selected, cycling through the set
- Each selection change triggers a brief pulse animation on the object's bounding box so the user can see which object the inspector is now showing

## Details

**Backend:** `SessionState` gains a `gui::SelectionSet` and iterator. `handleSelect` reads an optional `add_to_selection` flag. New `select_next`/`select_prev` request types advance the iterator with wrap-around. All inspect responses include `selection_count` and `selection_index` metadata.

**Frontend:** `main.js` detects `shiftKey` and sets `add_to_selection`. `inspector.js` adds `cycleSelection()`, the nav bar UI, and `pulseHighlight()`. `style.css` adds the `selection-pulse` keyframe animation.

## Test plan
- [x] C++ tests: 14 new tests in `TestRequestHandler.cpp` covering selection set population, next/prev cycling, wrap-around, empty set, navigation history clearing, and metadata in inspect/inspect_back responses
- [x] JS tests: 6 new tests in `test-inspector.js` covering nav bar visibility, label formatting, and button request wiring
- [x] All existing web tests pass (`ctest -R web`, `bun test`)
- [ ] Manual: load a design, click an object, Shift+click another, verify both highlighted and Next/Prev cycle works