### PR TITLE
gui/web: use random colors on backside layers to preserve color order on frontside metals

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -2134,29 +2134,33 @@ void DisplayControls::techInit(odb::dbTech* tech)
   for (dbTechLayer* layer : tech->getLayers()) {
     dbTechLayerType type = layer->getType();
     QColor color;
-    if (type == dbTechLayerType::ROUTING) {
-      if (metal < default_metal_colors.size()) {
-        color = default_metal_colors[metal++];
-      } else {
-        // pick a random color as we exceeded the built-in palette size
-        color = generate_next_color();
-      }
-    } else if (type == dbTechLayerType::CUT) {
-      if (via < default_cut_colors.size()) {
-        if (metal != 0) {
-          color = default_cut_colors[via++];
+    if (layer->isBackside()) {
+      color = generate_next_color();
+    } else {
+      if (type == dbTechLayerType::ROUTING) {
+        if (metal < default_metal_colors.size()) {
+          color = default_metal_colors[metal++];
         } else {
-          // via came first, so pick random color
+          // pick a random color as we exceeded the built-in palette size
+          color = generate_next_color();
+        }
+      } else if (type == dbTechLayerType::CUT) {
+        if (via < default_cut_colors.size()) {
+          if (metal != 0) {
+            color = default_cut_colors[via++];
+          } else {
+            // via came first, so pick random color
+            color = generate_next_color();
+          }
+        } else {
+          // pick a random color as we exceeded the built-in palette size
           color = generate_next_color();
         }
       } else {
-        // pick a random color as we exceeded the built-in palette size
+        // Do not draw from the existing palette so the metal layers can claim
+        // those colors.
         color = generate_next_color();
       }
-    } else {
-      // Do not draw from the existing palette so the metal layers can claim
-      // those colors.
-      color = generate_next_color();
     }
     color.setAlpha(180);
     layer_color_[layer] = std::move(color);

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -952,17 +952,21 @@ static odb::PtrMap<odb::dbTechLayer, Color> buildLayerColorMap(
   size_t via = 0;
   for (odb::dbTechLayer* layer : tech->getLayers()) {
     Color c;
-    const odb::dbTechLayerType type = layer->getType();
-    if (type == odb::dbTechLayerType::ROUTING) {
-      c = (metal < kMetalColors.size()) ? kMetalColors[metal++]
-                                        : random_color();
-    } else if (type == odb::dbTechLayerType::CUT) {
-      // GUI: a CUT layer that appears before any ROUTING layer gets a random
-      // color so cuts don't claim the metal palette slots.
-      c = (via < kCutColors.size() && metal != 0) ? kCutColors[via++]
-                                                  : random_color();
-    } else {
+    if (layer->isBackside()) {
       c = random_color();
+    } else {
+      const odb::dbTechLayerType type = layer->getType();
+      if (type == odb::dbTechLayerType::ROUTING) {
+        c = (metal < kMetalColors.size()) ? kMetalColors[metal++]
+                                          : random_color();
+      } else if (type == odb::dbTechLayerType::CUT) {
+        // GUI: a CUT layer that appears before any ROUTING layer gets a random
+        // color so cuts don't claim the metal palette slots.
+        c = (via < kCutColors.size() && metal != 0) ? kCutColors[via++]
+                                                    : random_color();
+      } else {
+        c = random_color();
+      }
     }
     colors[layer] = c;
   }

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -290,6 +290,85 @@ TEST_F(TileGeneratorTest, GetLayerColorMapMatchesGuiPalette)
   }
 }
 
+// Only frontside metals should consume the palette colors.
+TEST_F(TileGeneratorTest, GetLayerColorMapWithBacksideMetals)
+{
+  odb::dbTech* tech = getDb()->getTech();
+  ASSERT_NE(tech, nullptr);
+
+  // make metals 1 -> 3 backside
+  odb::dbTechLayer* layer = tech->findLayer("metal1");
+  layer->setBackside(true);
+  layer = tech->findLayer("via1");
+  layer->setBackside(true);
+  layer = tech->findLayer("metal2");
+  layer->setBackside(true);
+  layer = tech->findLayer("via2");
+  layer->setBackside(true);
+  layer = tech->findLayer("metal3");
+  layer->setBackside(true);
+  layer = tech->findLayer("via3");
+  layer->setBackside(true);
+
+  makeTileGen();
+  const auto& colors = tile_gen_->getLayerColorMap();
+
+  // Helper: assert a layer's color matches an expected RGB (alpha is always
+  // 180 in both the GUI and the web palette).
+  auto expectColor = [&](const char* name, int r, int g, int b) {
+    odb::dbTechLayer* layer = tech->findLayer(name);
+    ASSERT_NE(layer, nullptr) << "missing layer " << name;
+    const Color c = colors.at(layer);
+    EXPECT_EQ(c.r, r) << name << " red";
+    EXPECT_EQ(c.g, g) << name << " green";
+    EXPECT_EQ(c.b, b) << name << " blue";
+    EXPECT_EQ(c.a, 180) << name << " alpha";
+  };
+
+  struct LayerColor
+  {
+    const char* name;
+    int r;
+    int g;
+    int b;
+  };
+
+  // All 20 routing layers: metal1..metal14 are the seeded kMetalColors palette
+  // (#00F, #F00, #0D0, ...), metal15..metal20 are the mt19937(1) overflow.
+  const LayerColor kRouting[] = {// Backside
+                                 {"metal1", 209, 191, 141},
+                                 {"metal2", 63, 193, 166},
+                                 {"metal3", 200, 166, 92},
+                                 // Frontside
+                                 {"metal4", 0, 0, 254},
+                                 {"metal5", 254, 0, 0},
+                                 {"metal6", 9, 221, 0},
+                                 {"metal7", 190, 244, 81},
+                                 {"metal8", 222, 33, 96},
+                                 {"metal9", 32, 216, 253}};
+
+  // All 19 cut layers: via1..via14 are the seeded kCutColors palette,
+  // via15..via19 are the mt19937(1) overflow.
+  const LayerColor kCut[] = {// Backside
+                             {"via1", 99, 98, 82},
+                             {"via2", 171, 152, 190},
+                             {"via3", 54, 196, 143},
+                             // Frontside
+                             {"via4", 126, 126, 255},
+                             {"via5", 255, 126, 126},
+                             {"via6", 4, 110, 0},
+                             {"via7", 95, 122, 40},
+                             {"via8", 111, 17, 48},
+                             {"via9", 16, 108, 126}};
+
+  for (const LayerColor& lc : kRouting) {
+    expectColor(lc.name, lc.r, lc.g, lc.b);
+  }
+  for (const LayerColor& lc : kCut) {
+    expectColor(lc.name, lc.r, lc.g, lc.b);
+  }
+}
+
 TEST_F(TileGeneratorTest, GetLayerColorMapIsCached)
 {
   makeTileGen();

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -297,18 +297,12 @@ TEST_F(TileGeneratorTest, GetLayerColorMapWithBacksideMetals)
   ASSERT_NE(tech, nullptr);
 
   // make metals 1 -> 3 backside
-  odb::dbTechLayer* layer = tech->findLayer("metal1");
-  layer->setBackside(true);
-  layer = tech->findLayer("via1");
-  layer->setBackside(true);
-  layer = tech->findLayer("metal2");
-  layer->setBackside(true);
-  layer = tech->findLayer("via2");
-  layer->setBackside(true);
-  layer = tech->findLayer("metal3");
-  layer->setBackside(true);
-  layer = tech->findLayer("via3");
-  layer->setBackside(true);
+  for (const char* name :
+       {"metal1", "via1", "metal2", "via2", "metal3", "via3"}) {
+    odb::dbTechLayer* layer = tech->findLayer(name);
+    ASSERT_NE(layer, nullptr) << "missing layer " << name;
+    layer->setBackside(true);
+  }
 
   makeTileGen();
   const auto& colors = tile_gen_->getLayerColorMap();


### PR DESCRIPTION
## Summary
Ensures the color order for routing layers stays consistent for techs with backside metals.

## Type of Change
- Bug fix?

## Impact
No impact

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] I have included tests to prevent regressions.
- [X] **I have signed my commits (DCO).**
