### PR TITLE
The `BAZEL_BUILD` macro is used in source; explicitly define in BUILD

### DIFF
--- a/src/tst/BUILD
+++ b/src/tst/BUILD
@@ -41,6 +41,9 @@ cc_library(
     hdrs = [
         "include/tst/fixture.h",
     ],
+    defines = [
+        "BAZEL_BUILD",
+    ],
     includes = [
         "include",
     ],


### PR DESCRIPTION
Right now, this is only defined in the global `.bazelrc`, but that file is not inspected if OpenROAD is used as submodule or dependency. So we need to define all the relevant macros in the relevant BUILD rules.
