### PR TITLE
web: render highlights in a separate overlay tile layer

### DIFF
--- a/src/web/src/clock-tree-widget.js
+++ b/src/web/src/clock-tree-widget.js
@@ -153,9 +153,10 @@ export function computeClockTreeLayout(clockData) {
 }
 
 export class ClockTreeWidget {
-    constructor(container, app, redrawAllLayers) {
+    constructor(container, app, redrawAllLayers, refreshOverlay) {
         this._app = app;
         this._redrawAllLayers = redrawAllLayers;
+        this._refreshOverlay = refreshOverlay || redrawAllLayers;
         this._clockData = [];
         this._selectedClockIdx = 0;
         this._selectedNodeId = -1;
@@ -671,7 +672,7 @@ export class ClockTreeWidget {
             this._app.websocketManager.request({
                 type: 'clock_tree_highlight',
                 inst_name: hit.name,
-            }).then(() => this._redrawAllLayers());
+            }).then(() => this._refreshOverlay());
         } else {
             if (this._selectedNodeId >= 0) {
                 this._selectedNodeId = -1;
@@ -679,7 +680,7 @@ export class ClockTreeWidget {
                 this._app.websocketManager.request({
                     type: 'clock_tree_highlight',
                     inst_name: '',
-                }).then(() => this._redrawAllLayers());
+                }).then(() => this._refreshOverlay());
             }
         }
     }

--- a/src/web/src/drc-widget.js
+++ b/src/web/src/drc-widget.js
@@ -7,9 +7,10 @@
 import { dbuRectToBounds } from './coordinates.js';
 
 export class DrcWidget {
-    constructor(app, redrawAllLayers) {
+    constructor(app, redrawAllLayers, refreshOverlay) {
         this._app = app;
         this._redrawAllLayers = redrawAllLayers;
+        this._refreshOverlay = refreshOverlay || redrawAllLayers;
         this._categories = [];
         this._activeCategory = '';
         this._markerTree = null;  // server response for current category
@@ -117,7 +118,7 @@ export class DrcWidget {
             this._markerTree = null;
             this._treeContainer.innerHTML = '';
             this._infoBar.textContent = '';
-            this._redrawAllLayers();
+            this._refreshOverlay();
             return;
         }
 
@@ -129,7 +130,7 @@ export class DrcWidget {
         }).then(data => {
             this._markerTree = data;
             this._renderTree();
-            this._redrawAllLayers();
+            this._refreshOverlay();
         }).catch(err => {
             this._treeContainer.innerHTML = '';
             const errDiv = document.createElement('div');
@@ -344,7 +345,7 @@ export class DrcWidget {
                 if (row) row.classList.remove('drc-unvisited');
 
                 this._zoomToBBox(data.bbox);
-                this._redrawAllLayers();
+                this._refreshOverlay();
 
                 if (openInspector) {
                     if (data.select_id != null && this._app.navigateInspector) {
@@ -391,7 +392,7 @@ export class DrcWidget {
             field: field,
             value: !!value
         }).then(() => {
-            this._redrawAllLayers();
+            this._refreshOverlay();
             if (field === 'visible') {
                 this._update3DHighlights();
                 if (value) {
@@ -514,7 +515,7 @@ export class DrcWidget {
             category: category.name,
             visible: !!visible
         }).then(() => {
-            this._redrawAllLayers();
+            this._refreshOverlay();
             this._update3DHighlights();
             if (visible) {
                 this._flashHighlight();

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -50,7 +50,7 @@ const CLEAR_FOCUS_SVG =
     '<path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>' +
     '</svg>';
 
-export function createInspectorPanel(app, redrawAllLayers) {
+export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
     let lastInspectData = null;
     let pendingInspectId = null;
     let pendingHoverId = null;
@@ -106,7 +106,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
         } catch (err) {
             console.error('set_route_guides failed:', err);
         }
-        redrawAllLayers();
+        refreshOverlay();
         if (lastInspectData) updateInspector(lastInspectData);
     }
 
@@ -205,14 +205,14 @@ export function createInspectorPanel(app, redrawAllLayers) {
             promise.then(data => {
                 pendingHoverId = null;
                 renderHoverRects(data.rects || []);
-                redrawAllLayers();
+                refreshOverlay();
             }).catch(() => {
                 pendingHoverId = null;
             });
         });
         el.addEventListener('mouseleave', () => {
             clearHoverHighlight();
-            redrawAllLayers();
+            refreshOverlay();
         });
     }
 
@@ -253,8 +253,8 @@ export function createInspectorPanel(app, redrawAllLayers) {
                         highlightBBox(x1, y1, x2, y2);
                     }
                 }
-                // Redraw tiles to update instance highlight
-                redrawAllLayers();
+                // Refresh overlay to update instance highlight
+                refreshOverlay();
             })
             .catch(err => {
                 pendingInspectId = null;
@@ -292,7 +292,7 @@ export function createInspectorPanel(app, redrawAllLayers) {
                     const [x1, y1, x2, y2] = data.bbox;
                     highlightBBox(x1, y1, x2, y2);
                 }
-                redrawAllLayers();
+                refreshOverlay();
             })
             .catch(err => {
                 pendingInspectId = null;

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -51,6 +51,7 @@ const CLEAR_FOCUS_SVG =
     '</svg>';
 
 export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
+    refreshOverlay = refreshOverlay || redrawAllLayers;
     let lastInspectData = null;
     let pendingInspectId = null;
     let pendingHoverId = null;

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -4,7 +4,7 @@
 import { GoldenLayout, LayoutConfig } from 'https://esm.sh/golden-layout@2.6.0';
 import { latLngToDbu } from './coordinates.js';
 import { WebSocketManager } from './websocket-manager.js';
-import { createWebSocketTileLayer } from './websocket-tile-layer.js';
+import { createWebSocketTileLayer, createOverlayTileLayer } from './websocket-tile-layer.js';
 import { TimingWidget } from './timing-widget.js';
 import { ClockTreeWidget } from './clock-tree-widget.js';
 import { ChartsWidget } from './charts-widget.js';
@@ -359,6 +359,25 @@ function updateHeatMaps(data) {
 }
 app.updateHeatMaps = updateHeatMaps;
 
+// Refresh only the highlight overlay layer (selection, hover, timing,
+// DRC, route guides).  Much cheaper than redrawAllLayers because base
+// geometry tiles are not re-rendered.
+function refreshOverlay() {
+    if (app.overlayLayer) {
+        app.overlayLayer.refreshTiles();
+    }
+}
+app.refreshOverlay = refreshOverlay;
+
+let _overlayRAF = null;
+function scheduleRefreshOverlay() {
+    if (_overlayRAF !== null) return;
+    _overlayRAF = requestAnimationFrame(() => {
+        _overlayRAF = null;
+        refreshOverlay();
+    });
+}
+
 function redrawAllLayers() {
     // Persist visibility and selectability state to cookies so they survive
     // page reloads.
@@ -388,6 +407,9 @@ function redrawAllLayers() {
     if (app.heatMapLayer) {
         app.heatMapLayer.refreshTiles();
     }
+    // Overlay layer must also refresh on structural changes (e.g. design
+    // reload changes the coordinate space).
+    refreshOverlay();
     // Update ruler and scale bar visibility.
     if (app.rulerManager) {
         app.rulerManager.updateVisibility();
@@ -625,7 +647,7 @@ function createTclConsole(container) {
 
 // ─── Inspector Panel ────────────────────────────────────────────────────────
 
-const inspector = createInspectorPanel(app, redrawAllLayers);
+const inspector = createInspectorPanel(app, redrawAllLayers, refreshOverlay);
 const createInspector = inspector.createInspector;
 const updateInspector = inspector.updateInspector;
 const highlightBBox = inspector.highlightBBox;
@@ -637,17 +659,17 @@ function createBrowser(container) {
 }
 
 function createTimingWidget(container) {
-    app.timingWidget = new TimingWidget(app, redrawAllLayers);
+    app.timingWidget = new TimingWidget(app, redrawAllLayers, refreshOverlay);
     container.element.appendChild(app.timingWidget.element);
 }
 
 function createDRCWidget(container) {
-    app.drcWidget = new DrcWidget(app, redrawAllLayers);
+    app.drcWidget = new DrcWidget(app, redrawAllLayers, refreshOverlay);
     container.element.appendChild(app.drcWidget.element);
 }
 
 function createClockWidget(container) {
-    app.clockTreeWidget = new ClockTreeWidget(container, app, redrawAllLayers);
+    app.clockTreeWidget = new ClockTreeWidget(container, app, redrawAllLayers, refreshOverlay);
 }
 
 function createChartsWidget(container) {
@@ -1107,7 +1129,7 @@ app.websocketManager.readyPromise.then(async () => {
                             app.highlightRect = null;
                         }
                     }
-                    redrawAllLayers();
+                    refreshOverlay();
                 })
                 .catch(err => {
                     console.error('Select failed:', err);
@@ -1178,6 +1200,22 @@ app.websocketManager.readyPromise.then(async () => {
         populateDisplayControls(app, visibility, selectability,
                                 WebSocketTileLayer,
                                 techData, redrawAllLayers, HeatMapTileLayer);
+
+        // Create the highlight overlay layer — sits above all base/metal
+        // layers but below the heatmap.  Only carries selection, hover,
+        // timing, DRC, and route-guide shapes on a transparent background,
+        // so base tiles stay cached when highlights change.
+        // Skip in static mode: there is no WebSocket server to serve
+        // overlay_tile requests.
+        if (!app.overlayLayer && !staticCache) {
+            const OverlayTileLayer = createOverlayTileLayer(visibility, app);
+            app.overlayLayer = new OverlayTileLayer(app.websocketManager, {
+                zIndex: app.allLayers.length + 5,
+                opacity: 1,
+            });
+            app.overlayLayer.addTo(app.map);
+        }
+
         updateHeatMaps(heatMapData);
 
         // Only show the loading overlay if a design is loaded but shapes

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -367,7 +367,7 @@ function refreshOverlay() {
         app.overlayLayer.refreshTiles();
     }
 }
-app.refreshOverlay = refreshOverlay;
+app.refreshOverlay = scheduleRefreshOverlay;
 
 let _overlayRAF = null;
 function scheduleRefreshOverlay() {
@@ -647,7 +647,7 @@ function createTclConsole(container) {
 
 // ─── Inspector Panel ────────────────────────────────────────────────────────
 
-const inspector = createInspectorPanel(app, redrawAllLayers, refreshOverlay);
+const inspector = createInspectorPanel(app, redrawAllLayers, scheduleRefreshOverlay);
 const createInspector = inspector.createInspector;
 const updateInspector = inspector.updateInspector;
 const highlightBBox = inspector.highlightBBox;
@@ -659,17 +659,17 @@ function createBrowser(container) {
 }
 
 function createTimingWidget(container) {
-    app.timingWidget = new TimingWidget(app, redrawAllLayers, refreshOverlay);
+    app.timingWidget = new TimingWidget(app, redrawAllLayers, scheduleRefreshOverlay);
     container.element.appendChild(app.timingWidget.element);
 }
 
 function createDRCWidget(container) {
-    app.drcWidget = new DrcWidget(app, redrawAllLayers, refreshOverlay);
+    app.drcWidget = new DrcWidget(app, redrawAllLayers, scheduleRefreshOverlay);
     container.element.appendChild(app.drcWidget.element);
 }
 
 function createClockWidget(container) {
-    app.clockTreeWidget = new ClockTreeWidget(container, app, redrawAllLayers, refreshOverlay);
+    app.clockTreeWidget = new ClockTreeWidget(container, app, redrawAllLayers, scheduleRefreshOverlay);
 }
 
 function createChartsWidget(container) {

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1695,6 +1695,11 @@ void TileHandler::registerRequests(RequestDispatcher& d)
         [this](const WebSocketRequest& req, SessionState& state) {
           return handleHeatMapTile(req, state);
         });
+  d.add("overlay_tile",
+        WebSocketRequest::kOverlayTile,
+        [this](const WebSocketRequest& req, SessionState& state) {
+          return handleOverlayTile(req, state);
+        });
 }
 
 void TileHandler::initializeHeatMaps(SessionState& state)
@@ -1730,10 +1735,57 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
 
   TileVisibility vis;
   vis.parseFromJson(req.json);
+
+  // Snapshot module colors for _modules layer
+  std::map<uint32_t, Color> mod_colors;
+  {
+    std::lock_guard<std::mutex> lock(state.module_colors_mutex);
+    mod_colors = state.module_colors;
+  }
+  const std::map<uint32_t, Color>* mod_ptr
+      = mod_colors.empty() ? nullptr : &mod_colors;
+
+  // Snapshot focus nets
+  std::set<uint32_t> focus_nets;
+  {
+    std::lock_guard<std::mutex> lock(state.focus_nets_mutex);
+    focus_nets = state.focus_net_ids;
+  }
+  const std::set<uint32_t>* focus_ptr
+      = focus_nets.empty() ? nullptr : &focus_nets;
+
+  // Base tiles no longer carry highlights — those are rendered by the
+  // overlay tile layer.  Pass empty vectors so renderTileBuffer skips
+  // drawHighlight / drawColoredHighlight / drawFlightLines / drawRouteGuides.
+  static const std::vector<odb::Rect> no_rects;
+  static const std::vector<odb::Polygon> no_polys;
+  static const std::vector<ColoredRect> no_colored;
+  static const std::vector<FlightLine> no_lines;
+
+  return renderTile(req.id,
+                    std::string(req.json.at("layer").as_string()),
+                    static_cast<int>(req.json.at("z").as_int64()),
+                    static_cast<int>(req.json.at("x").as_int64()),
+                    static_cast<int>(req.json.at("y").as_int64()),
+                    vis,
+                    *gen_,
+                    no_rects,
+                    no_polys,
+                    no_colored,
+                    no_lines,
+                    mod_ptr,
+                    focus_ptr,
+                    nullptr);
+}
+
+WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
+                                                 SessionState& state)
+{
   // When debug renderers are active, instance positions change between
   // frames.  Re-derive highlight shapes from the current inspected
   // object so the selection tracks the moving instance.
-  if (vis.debug_renderers) {
+  const bool debug_renderers = jsonOr(req.json, "debug_renderers", false);
+  if (debug_renderers) {
     std::lock_guard<std::mutex> lock(state.selection_mutex);
     if (state.current_inspected) {
       collectHighlightShapes(state.current_inspected,
@@ -1765,24 +1817,6 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
     lines.insert(lines.end(), state.drc_lines.begin(), state.drc_lines.end());
   }
 
-  // Snapshot module colors for _modules layer
-  std::map<uint32_t, Color> mod_colors;
-  {
-    std::lock_guard<std::mutex> lock(state.module_colors_mutex);
-    mod_colors = state.module_colors;
-  }
-  const std::map<uint32_t, Color>* mod_ptr
-      = mod_colors.empty() ? nullptr : &mod_colors;
-
-  // Snapshot focus nets
-  std::set<uint32_t> focus_nets;
-  {
-    std::lock_guard<std::mutex> lock(state.focus_nets_mutex);
-    focus_nets = state.focus_net_ids;
-  }
-  const std::set<uint32_t>* focus_ptr
-      = focus_nets.empty() ? nullptr : &focus_nets;
-
   // Snapshot route guide nets
   std::set<uint32_t> route_guides;
   {
@@ -1792,20 +1826,34 @@ WebSocketResponse TileHandler::handleTile(const WebSocketRequest& req,
   const std::set<uint32_t>* route_guide_ptr
       = route_guides.empty() ? nullptr : &route_guides;
 
-  return renderTile(req.id,
-                    std::string(req.json.at("layer").as_string()),
-                    static_cast<int>(req.json.at("z").as_int64()),
-                    static_cast<int>(req.json.at("x").as_int64()),
-                    static_cast<int>(req.json.at("y").as_int64()),
-                    vis,
-                    *gen_,
-                    rects,
-                    polys,
-                    colored,
-                    lines,
-                    mod_ptr,
-                    focus_ptr,
-                    route_guide_ptr);
+  // Parse visible layers so route guides respect layer visibility.
+  // has_vis_layers=true means the field was present (even if empty,
+  // which means "all layers hidden" — matching pin-marker semantics).
+  bool has_vis_layers = false;
+  std::set<std::string> vis_layers;
+  if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
+    has_vis_layers = true;
+    const auto& arr = it->value().as_array();
+    for (size_t i = 0; i < arr.size(); ++i) {
+      vis_layers.emplace(arr[i].as_string());
+    }
+  }
+
+  WebSocketResponse resp;
+  resp.id = req.id;
+  resp.type = WebSocketResponse::kPng;
+  resp.payload
+      = gen_->generateOverlayTile(static_cast<int>(req.json.at("z").as_int64()),
+                                  static_cast<int>(req.json.at("x").as_int64()),
+                                  static_cast<int>(req.json.at("y").as_int64()),
+                                  rects,
+                                  polys,
+                                  colored,
+                                  lines,
+                                  route_guide_ptr,
+                                  has_vis_layers,
+                                  vis_layers);
+  return resp;
 }
 
 WebSocketResponse TileHandler::handleModuleHierarchy(

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -1834,8 +1834,8 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
   if (auto it = req.json.find("visible_layers"); it != req.json.end()) {
     has_vis_layers = true;
     const auto& arr = it->value().as_array();
-    for (size_t i = 0; i < arr.size(); ++i) {
-      vis_layers.emplace(arr[i].as_string());
+    for (const auto& elem : arr) {
+      vis_layers.emplace(elem.as_string());
     }
   }
 

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -118,6 +118,7 @@ struct WebSocketRequest
     kDebugContinue,
     kDebugCharts,
     kGet3DData,
+    kOverlayTile,
     kUnknown
   };
 
@@ -302,6 +303,8 @@ class TileHandler
   void initializeHeatMaps(SessionState& state);
   WebSocketResponse handleTile(const WebSocketRequest& req,
                                SessionState& state);
+  WebSocketResponse handleOverlayTile(const WebSocketRequest& req,
+                                      SessionState& state);
   WebSocketResponse handleModuleHierarchy(const WebSocketRequest& req);
   WebSocketResponse handleSetModuleColors(const WebSocketRequest& req,
                                           SessionState& state);

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -207,9 +207,9 @@ export class SchematicWidget {
                 if (this.appState.focusComponent) {
                     this.appState.focusComponent('Inspector');
                 }
-                // Redraw layout tiles to show instance highlight
-                if (this.appState.redrawAllLayers) {
-                    this.appState.redrawAllLayers();
+                // Refresh overlay tiles to show instance highlight
+                if (this.appState.refreshOverlay) {
+                    this.appState.refreshOverlay();
                 }
             })
             .catch(err => {

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -1383,6 +1383,95 @@ std::vector<unsigned char> TileGenerator::generateTile(
   return png_data;
 }
 
+std::vector<unsigned char> TileGenerator::generateOverlayTile(
+    const int z,
+    const int x,
+    int y,
+    const std::vector<odb::Rect>& highlight_rects,
+    const std::vector<odb::Polygon>& highlight_polys,
+    const std::vector<ColoredRect>& colored_rects,
+    const std::vector<FlightLine>& flight_lines,
+    const std::set<uint32_t>* route_guide_net_ids,
+    const bool has_visible_layers,
+    const std::set<std::string>& visible_layers) const
+{
+  constexpr int kBufferSize = kTileSizeInPixel * kTileSizeInPixel * 4;
+  std::vector<unsigned char> image(kBufferSize, 0);  // fully transparent
+
+  if (!getChip()) {
+    // No design — return blank transparent PNG.
+    std::vector<unsigned char> png;
+    lodepng::encode(png, image, kTileSizeInPixel, kTileSizeInPixel);
+    return png;
+  }
+
+  // Short-circuit: if there's nothing to draw, return a blank tile.
+  if (highlight_rects.empty() && highlight_polys.empty()
+      && colored_rects.empty() && flight_lines.empty()
+      && (!route_guide_net_ids || route_guide_net_ids->empty())) {
+    std::vector<unsigned char> png;
+    lodepng::encode(png, image, kTileSizeInPixel, kTileSizeInPixel);
+    return png;
+  }
+
+  // Compute tile bounding box in DBU (same math as renderTileBuffer).
+  const double num_tiles_at_zoom = pow(2, z);
+  y = num_tiles_at_zoom - 1 - y;  // flip Y
+  const odb::Rect full_bounds = getBounds();
+  if (full_bounds.maxDXDY() <= 0) {
+    std::vector<unsigned char> png;
+    lodepng::encode(png, image, kTileSizeInPixel, kTileSizeInPixel);
+    return png;
+  }
+  const double tile_dbu_size = full_bounds.maxDXDY() / num_tiles_at_zoom;
+  const int dbu_x_min = full_bounds.xMin() + x * tile_dbu_size;
+  const int dbu_y_min = full_bounds.yMin() + y * tile_dbu_size;
+  const int dbu_x_max = full_bounds.xMin() + std::ceil((x + 1) * tile_dbu_size);
+  const int dbu_y_max = full_bounds.yMin() + std::ceil((y + 1) * tile_dbu_size);
+  const odb::Rect dbu_tile(dbu_x_min, dbu_y_min, dbu_x_max, dbu_y_max);
+  const double scale = kTileSizeInPixel / tile_dbu_size;
+
+  // Draw highlight shapes onto transparent buffer.
+  if (!highlight_rects.empty() || !highlight_polys.empty()) {
+    drawHighlight(image, highlight_rects, highlight_polys, dbu_tile, scale);
+  }
+  if (!colored_rects.empty()) {
+    // Pass empty layer name so all colored rects are drawn regardless of
+    // their per-layer tag (the overlay sits above all base layers).
+    drawColoredHighlight(image, colored_rects, "", dbu_tile, scale);
+  }
+  if (!flight_lines.empty()) {
+    drawFlightLines(image, flight_lines, dbu_tile, scale);
+  }
+  if (route_guide_net_ids && !route_guide_net_ids->empty()) {
+    // Draw route guides only for visible tech layers.
+    for (odb::dbTech* tech : db_->getTechs()) {
+      const auto& colors = getLayerColorMap(tech);
+      for (odb::dbTechLayer* layer : tech->getLayers()) {
+        // Skip layers the user has hidden in Display Controls.
+        // has_visible_layers=true with an empty set means all hidden.
+        if (has_visible_layers && !visible_layers.contains(layer->getName())) {
+          continue;
+        }
+        const auto it = colors.find(layer);
+        if (it == colors.end()) {
+          continue;
+        }
+        drawRouteGuides(image,
+                        *route_guide_net_ids,
+                        layer->getName(),
+                        it->second,
+                        dbu_tile,
+                        scale);
+      }
+    }
+  }
+
+  std::vector<unsigned char> png;
+  lodepng::encode(png, image, kTileSizeInPixel, kTileSizeInPixel);
+  return png;
+}
+
 std::vector<unsigned char> TileGenerator::renderTileBuffer(
     const std::string& layer,
     const int z,
@@ -3518,10 +3607,11 @@ void TileGenerator::drawColoredHighlight(std::vector<unsigned char>& image,
                                          const odb::Rect& dbu_tile,
                                          const double scale) const
 {
-  const bool is_instances_layer = (current_layer == "_instances");
+  const bool draw_all = current_layer.empty() || current_layer == "_instances";
   for (const auto& cr : rects) {
-    // Layer filtering: draw on _instances (overview) or matching layer
-    if (!is_instances_layer && !cr.layer.empty() && cr.layer != current_layer) {
+    // Layer filtering: draw on _instances (overview), overlay (empty
+    // current_layer), or matching layer.
+    if (!draw_all && !cr.layer.empty() && cr.layer != current_layer) {
       continue;
     }
     if (!dbu_tile.overlaps(cr.rect)) {

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -370,6 +370,22 @@ class TileGenerator
       const std::map<uint32_t, Color>* module_colors = nullptr,
       const std::set<uint32_t>* focus_net_ids = nullptr,
       const std::set<uint32_t>* route_guide_net_ids = nullptr) const;
+
+  // Render only highlight/overlay shapes (selection, hover, timing, DRC,
+  // route guides, flight lines) on a fully transparent background.  Used
+  // by the overlay tile layer so base tiles can stay cached when only
+  // highlights change.
+  std::vector<unsigned char> generateOverlayTile(
+      int z,
+      int x,
+      int y,
+      const std::vector<odb::Rect>& highlight_rects = {},
+      const std::vector<odb::Polygon>& highlight_polys = {},
+      const std::vector<ColoredRect>& colored_rects = {},
+      const std::vector<FlightLine>& flight_lines = {},
+      const std::set<uint32_t>* route_guide_net_ids = nullptr,
+      bool has_visible_layers = false,
+      const std::set<std::string>& visible_layers = {}) const;
   std::vector<unsigned char> generateHeatMapTile(gui::HeatMapDataSource& source,
                                                  int z,
                                                  int x,

--- a/src/web/src/timing-widget.js
+++ b/src/web/src/timing-widget.js
@@ -6,9 +6,10 @@
 import { isStaticMode, makeResizableHeaders } from './ui-utils.js';
 
 export class TimingWidget {
-    constructor(app, redrawAllLayers) {
+    constructor(app, redrawAllLayers, refreshOverlay) {
         this._app = app;
         this._redrawAllLayers = redrawAllLayers;
+        this._refreshOverlay = refreshOverlay || redrawAllLayers;
 
         this._currentTab = 'setup';
         this._setupPaths = [];
@@ -207,7 +208,7 @@ export class TimingWidget {
 
     _clearTimingHighlight() {
         this._app.websocketManager.request({ type: 'timing_highlight', path_index: -1 })
-            .then(() => this._redrawAllLayers());
+            .then(() => this._refreshOverlay());
     }
 
     _selectPathRow(idx) {
@@ -227,7 +228,7 @@ export class TimingWidget {
             type: 'timing_highlight',
             path_index: highlightIdx,
             is_setup: this._currentTab === 'setup',
-        }).then(() => this._redrawAllLayers())
+        }).then(() => this._refreshOverlay())
           .catch(err => console.error('timing_highlight error:', err));
     }
 
@@ -327,7 +328,7 @@ export class TimingWidget {
             path_index: highlightIdx,
             is_setup: this._currentTab === 'setup',
             pin_name: nodes[idx].pin,
-        }).then(() => this._redrawAllLayers());
+        }).then(() => this._refreshOverlay());
     }
 
     _renderDetailTable() {

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -145,3 +145,111 @@ export function createWebSocketTileLayer(visibility, visibleLayers,
         }
     });
 }
+
+// Lightweight tile layer that renders only highlight/overlay shapes
+// (selection, hover, timing, DRC, route guides) on a transparent
+// background.  Separated from the base tile layers so that highlight
+// changes don't trigger a full re-render of all geometry tiles.
+export function createOverlayTileLayer(visibility, app) {
+    function buildOverlayRequest(coords) {
+        const req = {
+            type: 'overlay_tile',
+            z: coords.z,
+            x: coords.x,
+            y: coords.y,
+            debug_renderers: !!visibility.debug_renderers,
+        };
+        // Pass visible layers so route guides respect layer visibility.
+        if (app && app.visibleLayerNames) {
+            req.visible_layers = [...app.visibleLayerNames];
+        }
+        return req;
+    }
+    return L.GridLayer.extend({
+        initialize: function(websocketManager, options) {
+            this._websocketManager = websocketManager;
+            L.GridLayer.prototype.initialize.call(this, options);
+        },
+
+        createTile: function(coords, done) {
+            const tile = document.createElement('img');
+            tile.alt = '';
+            tile.setAttribute('role', 'presentation');
+
+            tile._tileDone = false;
+            tile.onload = () => {
+                if (tile.src && tile.src.startsWith('blob:')) {
+                    URL.revokeObjectURL(tile.src);
+                }
+                if (!tile._tileDone) {
+                    tile._tileDone = true;
+                    done(null, tile);
+                }
+            };
+            tile.onerror = () => {
+                if (!tile._tileDone) {
+                    tile._tileDone = true;
+                    done(new Error('overlay tile load error'), tile);
+                }
+            };
+
+            tile._websocketRequestId = this._websocketManager.nextId;
+
+            this._websocketManager.request(
+                buildOverlayRequest(coords)
+            ).then(data => {
+                if (typeof data === 'string') {
+                    tile.src = data;
+                } else {
+                    tile.src = URL.createObjectURL(data);
+                }
+            }).catch(() => {});
+
+            return tile;
+        },
+
+        refreshTiles: function() {
+            if (!this._map) return;
+
+            for (const key in this._tiles) {
+                const tileInfo = this._tiles[key];
+                if (!tileInfo || !tileInfo.el) continue;
+
+                const tile = tileInfo.el;
+                const coords = tileInfo.coords;
+
+                if (tile._websocketRequestId !== undefined) {
+                    this._websocketManager.cancel(tile._websocketRequestId);
+                }
+
+                tile._websocketRequestId = this._websocketManager.nextId;
+
+                this._websocketManager.request(
+                    buildOverlayRequest(coords)
+                ).then(data => {
+                    if (tile.src && tile.src.startsWith('blob:')) {
+                        URL.revokeObjectURL(tile.src);
+                    }
+                    if (typeof data === 'string') {
+                        tile.src = data;
+                    } else {
+                        tile.src = URL.createObjectURL(data);
+                    }
+                }).catch(() => {});
+            }
+        },
+
+        _removeTile: function(key) {
+            const tile = this._tiles[key];
+            if (tile && tile.el) {
+                if (tile.el._websocketRequestId !== undefined) {
+                    this._websocketManager.cancel(tile.el._websocketRequestId);
+                }
+                if (tile.el.src && tile.el.src.startsWith('blob:')) {
+                    URL.revokeObjectURL(tile.el.src);
+                }
+            }
+            L.GridLayer.prototype._removeTile.call(this, key);
+        }
+    });
+}

--- a/src/web/src/websocket-tile-layer.js
+++ b/src/web/src/websocket-tile-layer.js
@@ -193,11 +193,15 @@ export function createOverlayTileLayer(visibility, app) {
                 }
             };
 
-            tile._websocketRequestId = this._websocketManager.nextId;
+            const requestId = this._websocketManager.nextId;
+            tile._websocketRequestId = requestId;
 
             this._websocketManager.request(
                 buildOverlayRequest(coords)
             ).then(data => {
+                if (tile._websocketRequestId !== requestId) {
+                    return;  // stale response; a newer request superseded this one
+                }
                 if (typeof data === 'string') {
                     tile.src = data;
                 } else {
@@ -222,11 +226,15 @@ export function createOverlayTileLayer(visibility, app) {
                     this._websocketManager.cancel(tile._websocketRequestId);
                 }
 
-                tile._websocketRequestId = this._websocketManager.nextId;
+                const requestId = this._websocketManager.nextId;
+                tile._websocketRequestId = requestId;
 
                 this._websocketManager.request(
                     buildOverlayRequest(coords)
                 ).then(data => {
+                    if (tile._websocketRequestId !== requestId) {
+                        return;  // stale response superseded by a newer refresh
+                    }
                     if (tile.src && tile.src.startsWith('blob:')) {
                         URL.revokeObjectURL(tile.src);
                     }
@@ -244,6 +252,7 @@ export function createOverlayTileLayer(visibility, app) {
             if (tile && tile.el) {
                 if (tile.el._websocketRequestId !== undefined) {
                     this._websocketManager.cancel(tile.el._websocketRequestId);
+                    tile.el._websocketRequestId = undefined;
                 }
                 if (tile.el.src && tile.el.src.startsWith('blob:')) {
                     URL.revokeObjectURL(tile.el.src);

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -226,9 +226,9 @@ TEST_F(TileHandlerTest, EmptyTile)
   EXPECT_FALSE(resp.payload.empty());
 }
 
-TEST_F(TileHandlerTest, UsesHighlightState)
+TEST_F(TileHandlerTest, BaseTileExcludesHighlights)
 {
-  // Put a highlight rect in the state
+  // Put a highlight rect in the state — base tiles should NOT include it.
   {
     std::lock_guard<std::mutex> lock(state_.selection_mutex);
     state_.highlight_rects.emplace_back(0, 0, 50000, 50000);
@@ -240,8 +240,46 @@ TEST_F(TileHandlerTest, UsesHighlightState)
   req.json = parseObj(
       R"({"layer":"_instances","z":0,"x":0,"y":0,"visible_layers":[]})");
 
-  // Should not crash and should return valid PNG
+  // Should not crash and should return valid PNG (without highlights)
   auto resp = handler_->handleTile(req, state_);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  EXPECT_FALSE(resp.payload.empty());
+}
+
+TEST_F(TileHandlerTest, OverlayTileReturnsPng)
+{
+  WebSocketRequest req;
+  req.id = 10;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+
+  auto resp = handler_->handleOverlayTile(req, state_);
+  EXPECT_EQ(resp.id, 10u);
+  EXPECT_EQ(resp.type, WebSocketResponse::kPng);
+  EXPECT_FALSE(resp.payload.empty());
+  // PNG magic bytes
+  EXPECT_GE(resp.payload.size(), 8u);
+  EXPECT_EQ(resp.payload[0], 0x89);
+  EXPECT_EQ(resp.payload[1], 'P');
+  EXPECT_EQ(resp.payload[2], 'N');
+  EXPECT_EQ(resp.payload[3], 'G');
+}
+
+TEST_F(TileHandlerTest, OverlayTileUsesHighlightState)
+{
+  // Put a highlight rect in the state
+  {
+    std::lock_guard<std::mutex> lock(state_.selection_mutex);
+    state_.highlight_rects.emplace_back(0, 0, 50000, 50000);
+  }
+
+  WebSocketRequest req;
+  req.id = 11;
+  req.type = WebSocketRequest::kOverlayTile;
+  req.json = parseObj(R"({"z":0,"x":0,"y":0})");
+
+  // Should not crash and should return valid PNG with highlights
+  auto resp = handler_->handleOverlayTile(req, state_);
   EXPECT_EQ(resp.type, WebSocketResponse::kPng);
   EXPECT_FALSE(resp.payload.empty());
 }


### PR DESCRIPTION
## Summary
- Move selection, hover, timing, DRC, route-guide, and flight-line rendering out of base tiles into a dedicated transparent overlay tile layer
- When highlights change, only ~64 overlay tiles are re-requested instead of ~800+ base geometry tiles across all metal layers
- Base tiles stay cached and are only re-rendered on structural changes (visibility toggles, design reload, focus nets)

## Changes

**Backend:**
- `generateOverlayTile()` renders only overlay shapes on a transparent background
- New `"overlay_tile"` request type registered in `TileHandler`
- `handleTile()` no longer passes highlight data to base tiles
- `drawColoredHighlight()` draws all colored rects when `current_layer` is empty (overlay mode)

**Frontend:**
- `createOverlayTileLayer()` factory in `websocket-tile-layer.js`
- Overlay layer created above base layers, below heatmap
- `refreshOverlay()` / `scheduleRefreshOverlay()` for highlight-only updates
- Widgets (inspector, timing, DRC, clock-tree, schematic) call `refreshOverlay()` instead of `redrawAllLayers()` for highlight changes