### PR TITLE
gui: ensure QT5 and QT6 behave the same

### DIFF
--- a/src/gui/src/displayControls.cpp
+++ b/src/gui/src/displayControls.cpp
@@ -1251,8 +1251,13 @@ void DisplayControls::findControlsInItems(const std::string& path,
   collectControls(model_->invisibleRootItem(), column, controls);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  // NonPathWildcardConversion makes '*' match across '/' (like the old
+  // QRegExp::Wildcard); the default path mode would translate '*' to "[^/]*",
+  // so a bare '*' would fail to match any control path containing a separator.
   QString regexPattern = QRegularExpression::wildcardToRegularExpression(
-      QString::fromStdString(path));  // Defaults to exact match.
+      QString::fromStdString(path),
+      QRegularExpression::NonPathWildcardConversion);  // Defaults to exact
+                                                       // match.
 
   // Create the QRegularExpression object with the case-insensitive option.
   const QRegularExpression path_compare(


### PR DESCRIPTION
## Summary
Fix behavior of gui::set_display_controls

## Type of Change
- Bug fix

## Impact
In Qt5 `gui::set_display_controls "*" visible false` works and sets all elements to not visible
in Qt6 `gui::set_display_controls "*" visible false` matched nothing, this fixes it to match.

## Verification
- [X] I have verified that the local build succeeds (`./etc/Build.sh`).
- [X] I have run the relevant tests and they pass.
- [X] My code follows the repository's formatting guidelines.
- [X] **I have signed my commits (DCO).**
