### PR TITLE
web: add Show DBU toggle to View menu

### DIFF
--- a/src/web/src/hierarchy-browser.js
+++ b/src/web/src/hierarchy-browser.js
@@ -339,7 +339,7 @@ export class HierarchyBrowser {
                 fmtInt(node.insts),
                 fmtInt(node.macros),
                 fmtInt(node.modules),
-                fmtArea(node.area),
+                this._fmtArea(node.area),
                 fmtInt(node.local_insts),
                 fmtInt(node.local_macros),
                 fmtInt(node.local_modules),
@@ -396,14 +396,19 @@ export class HierarchyBrowser {
         this._render();
         this._sendModuleColors();
     }
+
+    _fmtArea(v) {
+        if (v == null) return '';
+        if (this._app.showDbu) {
+            // Convert μm² back to DBU².
+            const dbu = this._app.getDbuPerMicron();
+            return String(Math.round(v * dbu * dbu));
+        }
+        if (v >= 1e6) return (v / 1e6).toFixed(3) + ' mm²';
+        return v.toFixed(3) + ' μm²';
+    }
 }
 
 function fmtInt(v) {
     return v != null ? String(v) : '';
-}
-
-function fmtArea(v) {
-    if (v == null) return '';
-    if (v >= 1e6) return (v / 1e6).toFixed(3) + ' mm²';
-    return v.toFixed(3) + ' μm²';
 }

--- a/src/web/src/inspector.js
+++ b/src/web/src/inspector.js
@@ -236,7 +236,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
             pendingInspectId = null;
         }
         showLoading();
-        const promise = app.websocketManager.request({ type: reqType });
+        const promise = app.websocketManager.request({ type: reqType, use_dbu: app.showDbu });
         pendingInspectId = promise.requestId;
         promise
             .then(data => {
@@ -290,7 +290,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
         showLoading();
 
         const promise = app.websocketManager.request(
-            { type: 'inspect', select_id: selectId });
+            { type: 'inspect', select_id: selectId, use_dbu: app.showDbu });
         pendingInspectId = promise.requestId;
 
         promise
@@ -334,7 +334,7 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
 
         showLoading();
 
-        const promise = app.websocketManager.request({ type: 'inspect_back' });
+        const promise = app.websocketManager.request({ type: 'inspect_back', use_dbu: app.showDbu });
         pendingInspectId = promise.requestId;
 
         promise
@@ -627,5 +627,20 @@ export function createInspectorPanel(app, redrawAllLayers, refreshOverlay) {
         updateInspector(null);
     }
 
-    return { createInspector, updateInspector, highlightBBox, pulseHighlight, navigateInspector };
+    // Re-request the currently inspected object from the server
+    // (e.g. after toggling show-DBU so property formatting changes).
+    // Rulers are client-side so we re-select instead of re-requesting.
+    function refreshInspector() {
+        if (!lastInspectData) return;
+        if (lastInspectData.type === 'Ruler') {
+            if (app.rulerManager && app.rulerManager._selectedRulerId !== null) {
+                app.rulerManager._selectRuler(app.rulerManager._selectedRulerId);
+            }
+            return;
+        }
+        if (!app.websocketManager) return;
+        navigateInspector(-1);
+    }
+
+    return { createInspector, updateInspector, highlightBBox, pulseHighlight, navigateInspector, refreshInspector };
 }

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -104,6 +104,7 @@ const app = {
     // "render every chiplet" (single-chip designs).
     visibleChiplets: null,
     useTrueZ: getCookie('or_use_true_z') === '1',
+    showDbu: getCookie('or_show_dbu') === '1',
     selectableLayers: new Set(),
     heatMapData: null,
     activeHeatMap: '',
@@ -113,6 +114,24 @@ const app = {
     rulerManager: null,
     getDbuPerMicron() {
         return this.techData?.dbu_per_micron || 1000;
+    },
+    // Format a DBU value as a display string, respecting the showDbu setting.
+    // Mirrors Qt GUI's MainWindow::convertDBUToString.
+    formatDbu(value, addUnits = false) {
+        if (this.showDbu) return String(Math.round(value));
+        const dbuPerUm = this.getDbuPerMicron();
+        const precision = Math.ceil(Math.log10(dbuPerUm));
+        const um = (value / dbuPerUm).toFixed(precision);
+        return addUnits ? um + ' \u00b5m' : um;
+    },
+    // Format a distance (always positive) with auto-scaling units.
+    formatDistance(dbuLength) {
+        if (this.showDbu) return String(Math.round(dbuLength));
+        const dbuPerUm = this.getDbuPerMicron();
+        const um = dbuLength / dbuPerUm;
+        if (um >= 1000) return (um / 1000).toFixed(3) + ' mm';
+        if (um >= 1) return um.toFixed(3) + ' um';
+        return (um * 1000).toFixed(1) + ' nm';
     },
 };
 
@@ -469,11 +488,7 @@ function createLayoutViewer(container) {
         const { dbuX, dbuY } = latLngToDbu(
             e.latlng.lat, e.latlng.lng, app.designScale, app.designMaxDXDY,
             app.designOriginX, app.designOriginY);
-        const dbuPerUm = app.getDbuPerMicron();
-        const precision = Math.ceil(Math.log10(dbuPerUm));
-        const xUm = (dbuX / dbuPerUm).toFixed(precision);
-        const yUm = (dbuY / dbuPerUm).toFixed(precision);
-        coordBar.textContent = `X: ${xUm}  Y: ${yUm}`;
+        coordBar.textContent = `X: ${app.formatDbu(dbuX)}  Y: ${app.formatDbu(dbuY)}`;
     });
     app.map.on('mouseout', () => { app.lastMouseLatLng = null; });
 
@@ -488,6 +503,16 @@ function createLayoutViewer(container) {
     scaleBarLabel.className = 'scale-bar-label';
     scaleBar.appendChild(scaleBarLabel);
 
+    // Round to the nearest 1/2/5 × 10^n value (e.g. 1, 2, 5, 10, 20, …).
+    function niceRound(value) {
+        const mag = Math.pow(10, Math.floor(Math.log10(value)));
+        const residual = value / mag;
+        if (residual < 1.5) return 1 * mag;
+        if (residual < 3.5) return 2 * mag;
+        if (residual < 7.5) return 5 * mag;
+        return 10 * mag;
+    }
+
     function updateScaleBar() {
         if (!app.designScale || !visibility.scale_bar) {
             scaleBar.style.display = 'none';
@@ -495,34 +520,32 @@ function createLayoutViewer(container) {
         }
         scaleBar.style.display = '';
 
-        const dbuPerUm = app.techData?.dbu_per_micron || 1000;
         // Pixels per DBU at current zoom: designScale * 2^zoom.
         const zoom = app.map.getZoom();
         const pxPerDbu = app.designScale * Math.pow(2, zoom);
-        const pxPerUm = pxPerDbu * dbuPerUm;
 
         // Target bar width: ~15% of the map container width.
         const containerWidth = app.map.getContainer().clientWidth || 400;
         const targetPx = containerWidth * 0.15;
-        const targetUm = targetPx / pxPerUm;
 
-        // Pick a nice round number: 1, 2, 5, 10, 20, 50, ...
-        const mag = Math.pow(10, Math.floor(Math.log10(targetUm)));
-        const residual = targetUm / mag;
-        let niceUm;
-        if (residual < 1.5) niceUm = 1 * mag;
-        else if (residual < 3.5) niceUm = 2 * mag;
-        else if (residual < 7.5) niceUm = 5 * mag;
-        else niceUm = 10 * mag;
+        let barPx, label;
+        if (app.showDbu) {
+            const niceDbu = Math.max(1, niceRound(targetPx / pxPerDbu));
+            barPx = Math.round(niceDbu * pxPerDbu);
+            label = String(Math.round(niceDbu));
+        } else {
+            const dbuPerUm = app.techData?.dbu_per_micron || 1000;
+            const pxPerUm = pxPerDbu * dbuPerUm;
+            const niceUm = niceRound(targetPx / pxPerUm);
 
-        const barPx = Math.round(niceUm * pxPerUm);
+            barPx = Math.round(niceUm * pxPerUm);
 
-        // Format with appropriate units.
-        let label;
-        if (niceUm >= 1000) label = (niceUm / 1000) + ' mm';
-        else if (niceUm >= 1) label = niceUm + ' \u00b5m';
-        else if (niceUm >= 0.001) label = (niceUm * 1000) + ' nm';
-        else label = (niceUm * 1e6) + ' pm';
+            // Format with appropriate units.
+            if (niceUm >= 1000) label = (niceUm / 1000) + ' mm';
+            else if (niceUm >= 1) label = niceUm + ' \u00b5m';
+            else if (niceUm >= 0.001) label = (niceUm * 1000) + ' nm';
+            else label = (niceUm * 1e6) + ' pm';
+        }
 
         scaleBarLine.style.width = barPx + 'px';
         scaleBarLabel.textContent = label;
@@ -654,6 +677,7 @@ const highlightBBox = inspector.highlightBBox;
 const pulseHighlight = inspector.pulseHighlight;
 app.updateInspector = updateInspector;
 app.navigateInspector = inspector.navigateInspector;
+app.refreshInspector = inspector.refreshInspector;
 
 function createBrowser(container) {
     new HierarchyBrowser(container, app, redrawAllLayers);
@@ -924,6 +948,19 @@ app.toggleTheme = function() {
     if (app.clockTreeWidget) app.clockTreeWidget.render();
 };
 
+app.toggleShowDbu = function() {
+    app.showDbu = !app.showDbu;
+    setCookie('or_show_dbu', app.showDbu ? '1' : '0');
+    // Re-render rulers so their labels update.
+    if (app.rulerManager) app.rulerManager._rerenderAll();
+    // Re-render hierarchy browser if present.
+    if (app.hierarchyBrowser) app.hierarchyBrowser._render();
+    // Update scale bar.
+    if (app.updateScaleBar) app.updateScaleBar();
+    // Re-request inspector properties with new formatting.
+    if (app.refreshInspector) app.refreshInspector();
+};
+
 // ─── Menu Bar ────────────────────────────────────────────────────────────────
 
 createMenuBar(app);
@@ -1099,6 +1136,7 @@ app.websocketManager.readyPromise.then(async () => {
                 zoom: Math.round(app.map.getZoom()),
                 visible_layers: [...app.visibleLayerNames],
                 selectable_layers: [...app.selectableLayers],
+                use_dbu: app.showDbu,
                 ...vf,
             };
             if (e.originalEvent && e.originalEvent.shiftKey) {

--- a/src/web/src/menu-bar.js
+++ b/src/web/src/menu-bar.js
@@ -16,6 +16,8 @@ export function createMenuBar(app) {
             { label: 'Zoom Out', shortcut: 'Shift+Z', action: () => app.map.zoomOut() },
             { type: 'separator' },
             { label: 'Toggle Theme', shortcut: 'T', action: () => app.toggleTheme() },
+            { label: 'Show DBU', action: () => app.toggleShowDbu(),
+              checked: () => app.showDbu },
             { type: 'separator' },
             { label: 'Find...', shortcut: 'Ctrl+F', disabled: true },
             { label: 'Go to Position...', shortcut: 'Shift+G', disabled: true },
@@ -76,6 +78,16 @@ export function createMenuBar(app) {
             // Track items with dynamic enabled state for refresh on open.
             if (item.enabledWhen) row._enabledWhen = item.enabledWhen;
 
+            // Checkmark indicator for toggle items.
+            let checkEl = null;
+            if (item.checked) {
+                checkEl = document.createElement('span');
+                checkEl.className = 'menu-check';
+                checkEl.textContent = item.checked() ? '\u2713' : '';
+                row.appendChild(checkEl);
+                row._checkedFn = item.checked;
+            }
+
             const text = document.createElement('span');
             text.textContent = item.label;
             row.appendChild(text);
@@ -105,6 +117,10 @@ export function createMenuBar(app) {
             for (const row of dropdown.querySelectorAll('.menu-item')) {
                 if (row._enabledWhen) {
                     row.classList.toggle('disabled', !row._enabledWhen());
+                }
+                if (row._checkedFn) {
+                    const check = row.querySelector('.menu-check');
+                    if (check) check.textContent = row._checkedFn() ? '\u2713' : '';
                 }
             }
         }

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -44,6 +44,7 @@
 #include "tile_generator.h"
 #include "timing_report.h"
 #include "utl/Logger.h"
+#include "utl/algorithms.h"
 
 namespace web {
 
@@ -126,6 +127,41 @@ void writePayload(WebSocketResponse& resp, const boost::json::value& v)
 }
 
 }  // namespace
+
+// RAII helper: temporarily sets Descriptor::Property::convert_dbu to a
+// micron-aware formatter (matching the Qt GUI's default) for the lifetime
+// of the scope.  When `use_dbu` is true the default identity formatter is
+// kept so that raw DBU integers are emitted.  Must be held while the
+// sta_lock mutex is held — the global static is not otherwise thread-safe.
+class [[nodiscard]] ScopedDbuFormat
+{
+ public:
+  ScopedDbuFormat(odb::dbBlock* block, bool use_dbu)
+      : saved_(gui::Descriptor::Property::convert_dbu)
+  {
+    if (use_dbu || !block) {
+      return;  // keep default (raw DBU)
+    }
+    const double dbu_per_micron = block->getDbUnitsPerMicron();
+    const int precision
+        = static_cast<int>(std::ceil(std::log10(dbu_per_micron)));
+    gui::Descriptor::Property::convert_dbu
+        = [dbu_per_micron, precision](int value, bool add_units) {
+            auto str = utl::to_numeric_string(
+                static_cast<double>(value) / dbu_per_micron, precision);
+            if (add_units) {
+              str += " \xC2\xB5m";  // UTF-8 µm
+            }
+            return str;
+          };
+  }
+  ~ScopedDbuFormat() { gui::Descriptor::Property::convert_dbu = saved_; }
+  ScopedDbuFormat(const ScopedDbuFormat&) = delete;
+  ScopedDbuFormat& operator=(const ScopedDbuFormat&) = delete;
+
+ private:
+  gui::DBUToString saved_;
+};
 
 // Store a Selected in the clickables vector and return its index.
 static int storeSelectable(std::vector<gui::Selected>& selectables,
@@ -537,6 +573,8 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
     // STA's highlight() and getProperties() are not thread-safe;
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
 
     resp.type = WebSocketResponse::kJson;
     boost::json::object root;
@@ -636,16 +674,24 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
     {
       const int select_id
           = static_cast<int>(req.json.at("select_id").as_int64());
-      std::lock_guard<std::mutex> lock(state.selectables_mutex);
-      if (select_id >= 0
-          && select_id < static_cast<int>(state.selectables.size())) {
-        sel = state.selectables[select_id];
+      if (select_id >= 0) {
+        std::lock_guard<std::mutex> lock(state.selectables_mutex);
+        if (select_id < static_cast<int>(state.selectables.size())) {
+          sel = state.selectables[select_id];
+        }
+      } else {
+        // select_id < 0: re-inspect the currently inspected object
+        // (used when toggling display-unit mode without changing selection).
+        std::lock_guard<std::mutex> lock(state.selection_mutex);
+        sel = state.current_inspected;
       }
     }
 
     // STA's highlight() and getProperties() are not thread-safe;
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
 
     bool can_navigate_back = false;
     int sel_count = 0;
@@ -703,6 +749,8 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
     bool can_navigate_back = false;
 
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(gen_->getBlock(), use_dbu);
     int sel_count = 0;
     int sel_index = -1;
     {
@@ -752,7 +800,8 @@ static WebSocketResponse handleSelectionCycle(
     const WebSocketRequest& req,
     SessionState& state,
     const int direction,
-    std::shared_ptr<TclEvaluator>& tcl_eval)
+    std::shared_ptr<TclEvaluator>& tcl_eval,
+    odb::dbBlock* block)
 {
   WebSocketResponse resp;
   resp.id = req.id;
@@ -760,6 +809,8 @@ static WebSocketResponse handleSelectionCycle(
     gui::Selected sel;
 
     std::lock_guard<std::mutex> sta_lock(tcl_eval->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(block, use_dbu);
     int sel_count = 0;
     int sel_index = -1;
     {
@@ -815,13 +866,13 @@ static WebSocketResponse handleSelectionCycle(
 WebSocketResponse SelectHandler::handleSelectNext(const WebSocketRequest& req,
                                                   SessionState& state)
 {
-  return handleSelectionCycle(req, state, +1, tcl_eval_);
+  return handleSelectionCycle(req, state, +1, tcl_eval_, gen_->getBlock());
 }
 
 WebSocketResponse SelectHandler::handleSelectPrev(const WebSocketRequest& req,
                                                   SessionState& state)
 {
-  return handleSelectionCycle(req, state, -1, tcl_eval_);
+  return handleSelectionCycle(req, state, -1, tcl_eval_, gen_->getBlock());
 }
 
 WebSocketResponse SelectHandler::handleHover(const WebSocketRequest& req,
@@ -1404,6 +1455,8 @@ WebSocketResponse SelectHandler::handleSchematicInspect(
     // STA's highlight() and getProperties() are not thread-safe;
     // serialize with other STA callers (timing, clock tree, tcl eval).
     std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    const bool use_dbu = jsonOr(req.json, "use_dbu", false);
+    ScopedDbuFormat dbu_fmt(block, use_dbu);
 
     {
       std::lock_guard<std::mutex> lock(state.selection_mutex);

--- a/src/web/src/ruler.js
+++ b/src/web/src/ruler.js
@@ -501,15 +501,12 @@ export class RulerManager {
             ? Math.sqrt(dx * dx + dy * dy)
             : dx + dy;
 
-        const fmt = (dbu) => {
-            const um = dbu / dbuPerUm;
-            return um.toFixed(3) + ' um';
-        };
+        const fmt = (dbu) => this._app.formatDbu(dbu, true);
 
         const parseDbu = (str) => {
-            // Parse "123.456 um" → DBU
             const num = parseFloat(str);
             if (isNaN(num)) return null;
+            if (this._app.showDbu) return Math.round(num);
             return Math.round(num * dbuPerUm);
         };
 
@@ -623,11 +620,7 @@ export class RulerManager {
     }
 
     _formatDistance(dbuLength) {
-        const dbuPerUm = this._app.techData?.dbu_per_micron || 1000;
-        const um = dbuLength / dbuPerUm;
-        if (um >= 1000) return (um / 1000).toFixed(3) + ' mm';
-        if (um >= 1) return um.toFixed(3) + ' um';
-        return (um * 1000).toFixed(1) + ' nm';
+        return this._app.formatDistance(dbuLength);
     }
 
     _setCursor(crosshair) {

--- a/src/web/src/schematic-widget.js
+++ b/src/web/src/schematic-widget.js
@@ -199,7 +199,7 @@ export class SchematicWidget {
         const wm = this.appState.websocketManager;
         if (!wm) return;
         console.log('[Schematic] inspect:', instName);
-        wm.request({ type: 'schematic_inspect', inst_name: instName })
+        wm.request({ type: 'schematic_inspect', inst_name: instName, use_dbu: this.appState.showDbu })
             .then(data => {
                 if (this.appState.updateInspector) {
                     this.appState.updateInspector(data);

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -199,9 +199,14 @@ html, body {
 #menu-bar .menu-item {
     display: flex;
     justify-content: space-between;
+    position: relative;
     padding: 4px 20px;
     cursor: default;
     white-space: nowrap;
+}
+#menu-bar .menu-check {
+    position: absolute;
+    left: 4px;
 }
 #menu-bar .menu-item:hover {
     background: var(--bg-selected);

--- a/src/web/test/cpp/TestRequestHandler.cpp
+++ b/src/web/test/cpp/TestRequestHandler.cpp
@@ -683,6 +683,42 @@ TEST_F(SelectHandlerTest, InspectBackWithoutHistoryKeepsCurrentObject)
   }
 }
 
+TEST_F(SelectHandlerTest, InspectRespectsDbuToggle)
+{
+  fake_current_.bbox = odb::Rect(2000, 4000, 6000, 8000);
+  const gui::Selected block_selected = makeFakeSelected(&fake_current_);
+
+  {
+    std::lock_guard<std::mutex> lock(state_.selectables_mutex);
+    state_.selectables = {block_selected};
+  }
+
+  // 1. inspect with use_dbu: true
+  WebSocketRequest inspect_req_dbu;
+  inspect_req_dbu.id = 21;
+  inspect_req_dbu.type = WebSocketRequest::kInspect;
+  inspect_req_dbu.json = parseObj(R"({"select_id":0,"use_dbu":true})");
+
+  auto resp_dbu = handler_->handleInspect(inspect_req_dbu, state_);
+  EXPECT_EQ(resp_dbu.type, WebSocketResponse::kJson);
+  std::string json_dbu = payloadStr(resp_dbu);
+  EXPECT_NE(json_dbu.find("\"value\":\"(2000, 4000), (6000, 8000)\""),
+            std::string::npos)
+      << json_dbu;
+
+  // 2. inspect with use_dbu: false, using select_id: -1 to re-inspect current
+  WebSocketRequest inspect_req_um;
+  inspect_req_um.id = 22;
+  inspect_req_um.type = WebSocketRequest::kInspect;
+  inspect_req_um.json = parseObj(R"({"select_id":-1,"use_dbu":false})");
+
+  auto resp_um = handler_->handleInspect(inspect_req_um, state_);
+  EXPECT_EQ(resp_um.type, WebSocketResponse::kJson);
+  std::string json_um = payloadStr(resp_um);
+  EXPECT_NE(json_um.find("\"value\":\"(1, 2), (3, 4)\""), std::string::npos)
+      << json_um;
+}
+
 //------------------------------------------------------------------------------
 // Focus nets tests
 //------------------------------------------------------------------------------

--- a/src/web/test/js/test-ruler.js
+++ b/src/web/test/js/test-ruler.js
@@ -52,7 +52,7 @@ function makeApp() {
         getBoundingClientRect() { return { left: 0, top: 0 }; },
     };
     const requests = [];
-    return {
+    const app = {
         map: {
             createPane() { return { style: {} }; },
             getContainer() { return container; },
@@ -63,6 +63,7 @@ function makeApp() {
         designScale: 1e-6,
         designMaxDXDY: 1000000,
         techData: { dbu_per_micron: 1000 },
+        showDbu: false,
         visibleLayers: new Set(['metal1']),
         websocketManager: {
             request(msg) {
@@ -71,10 +72,29 @@ function makeApp() {
             },
         },
         inspectorEl: null,
+        getDbuPerMicron() {
+            return this.techData?.dbu_per_micron || 1000;
+        },
+        formatDbu(value, addUnits = false) {
+            if (this.showDbu) return String(Math.round(value));
+            const dbuPerUm = this.getDbuPerMicron();
+            const precision = Math.ceil(Math.log10(dbuPerUm));
+            const um = (value / dbuPerUm).toFixed(precision);
+            return addUnits ? um + ' \u00b5m' : um;
+        },
+        formatDistance(dbuLength) {
+            if (this.showDbu) return String(Math.round(dbuLength));
+            const dbuPerUm = this.getDbuPerMicron();
+            const um = dbuLength / dbuPerUm;
+            if (um >= 1000) return (um / 1000).toFixed(3) + ' mm';
+            if (um >= 1) return um.toFixed(3) + ' um';
+            return (um * 1000).toFixed(1) + ' nm';
+        },
         _container: container,
         _classList: classList,
         _requests: requests,
     };
+    return app;
 }
 
 function makeManager(appOverrides = {}) {
@@ -395,14 +415,52 @@ describe('Ruler inspector data', () => {
             propMap[p.name] = p.value;
         }
         assert.equal(propMap['Name'], 'ruler0');
-        assert.equal(propMap['Point 0 - x'], '1.000 um');
-        assert.equal(propMap['Point 0 - y'], '2.000 um');
-        assert.equal(propMap['Point 1 - x'], '4.000 um');
-        assert.equal(propMap['Point 1 - y'], '6.000 um');
-        assert.equal(propMap['Delta x'], '3.000 um');
-        assert.equal(propMap['Delta y'], '4.000 um');
-        assert.equal(propMap['Length'], '5.000 um');
+        assert.equal(propMap['Point 0 - x'], '1.000 \u00b5m');
+        assert.equal(propMap['Point 0 - y'], '2.000 \u00b5m');
+        assert.equal(propMap['Point 1 - x'], '4.000 \u00b5m');
+        assert.equal(propMap['Point 1 - y'], '6.000 \u00b5m');
+        assert.equal(propMap['Delta x'], '3.000 \u00b5m');
+        assert.equal(propMap['Delta y'], '4.000 \u00b5m');
+        assert.equal(propMap['Length'], '5.000 \u00b5m');
         assert.equal(propMap['Euclidian'], 'true');
+    });
+
+    it('_selectRuler produces DBU values when showDbu is true', () => {
+        const { mgr, app, inspectorData } = makeManager();
+        app.showDbu = true;
+        mgr._createRuler({ x: 1000, y: 2000 }, { x: 4000, y: 6000 });
+        mgr._selectRuler(0);
+
+        const data = inspectorData[0];
+        const propMap = {};
+        for (const p of data.properties) {
+            propMap[p.name] = p.value;
+        }
+        assert.equal(propMap['Point 0 - x'], '1000');
+        assert.equal(propMap['Point 0 - y'], '2000');
+        assert.equal(propMap['Delta x'], '3000');
+        assert.equal(propMap['Length'], '5000');
+    });
+
+    it('re-selecting ruler after toggling showDbu updates values', () => {
+        const { mgr, app, inspectorData } = makeManager();
+        mgr._createRuler({ x: 1000, y: 2000 }, { x: 4000, y: 6000 });
+        mgr._selectRuler(0);
+
+        // Initially micron mode
+        const umProps = inspectorData.at(-1).properties;
+        const umMap = {};
+        for (const p of umProps) umMap[p.name] = p.value;
+        assert.equal(umMap['Point 0 - x'], '1.000 \u00b5m');
+
+        // Toggle to DBU and re-select
+        app.showDbu = true;
+        mgr._selectRuler(0);
+
+        const dbuProps = inspectorData.at(-1).properties;
+        const dbuMap = {};
+        for (const p of dbuProps) dbuMap[p.name] = p.value;
+        assert.equal(dbuMap['Point 0 - x'], '1000');
     });
 
     it('selection changes selectedRulerId', () => {


### PR DESCRIPTION
## Summary
- Add a "Show DBU" toggle to the web UI's View menu, mirroring the Qt GUI's Options > Show DBU. When enabled, coordinates and dimensions display as raw database units instead of microns.
- Setting defaults to off (microns), persists between sessions via cookie, and affects: coordinate bar, scale bar, ruler labels/properties, inspector BBox/Point properties, and hierarchy browser area column.
- Server-side `ScopedDbuFormat` RAII helper temporarily sets `Descriptor::Property::convert_dbu` to a micron-aware formatter for each inspect request, controlled by a `use_dbu` flag from the client.