### PR TITLE
web: group backside layers under a Backside category in the layer tree

### DIFF
--- a/src/web/src/display-controls.js
+++ b/src/web/src/display-controls.js
@@ -154,13 +154,18 @@ export function populateDisplayControls(app, visibility, selectability,
             });
         }
 
+        const nodeData = { name: hierarchyNode.name, isInstance: true };
+        // chipletPath is the canonical "top.wrapper_1.MEM_2" string the
+        // backend emits in layer_hierarchy; it matches ChipletNode::path
+        // exactly so toggling this node can drive app.visibleChiplets.
+        // Category nodes (e.g. "Backside") are pure UI folders — they have
+        // no chiplet path and must not participate in chiplet sync.
+        if (hierarchyNode.type !== 'category') {
+            nodeData.chipletPath = hierarchyNode.path;
+        }
         return {
             id: parentId,
-            // chipletPath is the canonical "top.wrapper_1.MEM_2" string the
-            // backend emits in layer_hierarchy; it matches ChipletNode::path
-            // exactly so toggling this node can drive app.visibleChiplets.
-            data: { name: hierarchyNode.name, isInstance: true,
-                    chipletPath: hierarchyNode.path },
+            data: nodeData,
             children: children,
         };
     }

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -3949,6 +3949,7 @@ boost::json::object buildLayerHierarchy(
   json_node["path"] = node.path;
 
   boost::json::array layers_arr;
+  boost::json::array backside_layers_arr;
   if (node.chip) {
     if (odb::dbTech* tech = node.chip->getTech()) {
       const auto& layer_colors = gen.getLayerColorMap(tech);
@@ -3965,7 +3966,11 @@ boost::json::object buildLayerHierarchy(
           layer_obj["color"] = boost::json::array{static_cast<int>(c.r),
                                                   static_cast<int>(c.g),
                                                   static_cast<int>(c.b)};
-          layers_arr.emplace_back(std::move(layer_obj));
+          if (layer->isBackside()) {
+            backside_layers_arr.emplace_back(std::move(layer_obj));
+          } else {
+            layers_arr.emplace_back(std::move(layer_obj));
+          }
         }
       }
     }
@@ -3979,6 +3984,14 @@ boost::json::object buildLayerHierarchy(
       instances_arr.emplace_back(
           buildLayerHierarchy(*child, children_by_parent, gen));
     }
+  }
+  if (!backside_layers_arr.empty()) {
+    boost::json::object backside_node;
+    backside_node["name"] = "Backside";
+    backside_node["type"] = "category";
+    backside_node["layers"] = std::move(backside_layers_arr);
+    backside_node["instances"] = boost::json::array{};
+    instances_arr.emplace_back(std::move(backside_node));
   }
   json_node["instances"] = std::move(instances_arr);
 

--- a/src/web/test/cpp/TestTileGenerator.cpp
+++ b/src/web/test/cpp/TestTileGenerator.cpp
@@ -1219,5 +1219,62 @@ TEST_F(TileGeneratorTest, SerializeTechResponseContainsBlockName)
       << "tech response missing block name value \"top\"; got: " << json;
 }
 
+TEST_F(TileGeneratorTest, LayerHierarchyBacksideCategory)
+{
+  odb::dbTech* tech = getDb()->getTech();
+
+  // Mark metal1 and via1 as backside.
+  tech->findLayer("metal1")->setBackside(true);
+  tech->findLayer("via1")->setBackside(true);
+
+  makeTileGen();
+  const auto resp = serializeTechResponse(*tile_gen_);
+  ASSERT_TRUE(resp.contains("layer_hierarchy"));
+  const auto& hier = resp.at("layer_hierarchy").as_object();
+
+  // Top-level layers should NOT contain the backside layers.
+  const auto& top_layers = hier.at("layers").as_array();
+  for (const auto& l : top_layers) {
+    const auto& name = l.as_object().at("name").as_string();
+    EXPECT_NE(name, "metal1") << "backside metal1 should not be at top level";
+    EXPECT_NE(name, "via1") << "backside via1 should not be at top level";
+  }
+
+  // A "Backside" category node should exist in instances.
+  const auto& instances = hier.at("instances").as_array();
+  const boost::json::object* backside_node = nullptr;
+  for (const auto& inst : instances) {
+    const auto& obj = inst.as_object();
+    if (obj.at("name").as_string() == "Backside") {
+      backside_node = &obj;
+      break;
+    }
+  }
+  ASSERT_NE(backside_node, nullptr)
+      << "layer_hierarchy missing Backside category node";
+  EXPECT_EQ(backside_node->at("type").as_string(), "category");
+
+  // The backside node should contain exactly metal1 and via1.
+  const auto& bs_layers = backside_node->at("layers").as_array();
+  std::set<std::string> bs_names;
+  for (const auto& l : bs_layers) {
+    bs_names.insert(std::string(l.as_object().at("name").as_string()));
+  }
+  EXPECT_EQ(bs_names, (std::set<std::string>{"metal1", "via1"}));
+}
+
+TEST_F(TileGeneratorTest, LayerHierarchyNoBacksideCategory)
+{
+  // No layers marked backside — there should be no Backside category.
+  makeTileGen();
+  const auto resp = serializeTechResponse(*tile_gen_);
+  const auto& hier = resp.at("layer_hierarchy").as_object();
+  const auto& instances = hier.at("instances").as_array();
+  for (const auto& inst : instances) {
+    EXPECT_NE(inst.as_object().at("name").as_string(), "Backside")
+        << "Backside category should not appear when no layers are backside";
+  }
+}
+
 }  // namespace
 }  // namespace web


### PR DESCRIPTION
Backside layers are split out of each chip node's layers array in the layer_hierarchy JSON and nested in a synthetic child node of type "category". The frontend skips chipletPath for category nodes so they do not participate in chiplet visibility sync.

<img width="178" height="538" alt="image" src="https://github.com/user-attachments/assets/9a1b5105-02ce-43dd-86f2-f1a094e67465" />
