### PR TITLE
dbSta: propagate clock signal type when Liberty loaded after LEF

### DIFF
--- a/src/dbSta/src/dbNetwork.cc
+++ b/src/dbSta/src/dbNetwork.cc
@@ -2425,6 +2425,20 @@ void dbNetwork::readLibertyAfter(LibertyLibrary* lib)
               if (lport) {
                 cport->setLibertyPort(lport);
                 lport->setExtPort(cport->extPort());
+                dbMTerm* mterm = staToDb(lport);
+                if (mterm && lport->isClock()
+                    && mterm->getSigType() != dbSigType::CLOCK) {
+                  debugPrint(
+                      logger_,
+                      utl::ORD,
+                      "dbNetwork",
+                      1,
+                      "Updating LEF pin {}/{} from {} to CLOCK from Liberty",
+                      mterm->getMaster()->getName(),
+                      mterm->getName(),
+                      mterm->getSigType().getString());
+                  mterm->setSigType(dbSigType::CLOCK);
+                }
               } else if (!cport->direction()->isPowerGround()
                          && !lcell->findPort(port_name)) {
                 logger_->warn(ORD,

--- a/src/gpl/test/mbff_test.cpp
+++ b/src/gpl/test/mbff_test.cpp
@@ -70,10 +70,10 @@ class MBFFTestFixture : public tst::Fixture
                                               opendp_.get(),
                                               estimate_parasitics_.get());
 
-    readLiberty(getFilePath("openroad/src/gpl/test/library/test/test0.lib"));
     loadTechAndLib("test0",
                    "test0",
                    getFilePath("openroad/src/gpl/test/library/test/test0.lef"));
+    readLiberty(getFilePath("openroad/src/gpl/test/library/test/test0.lib"));
 
     chip_ = odb::dbChip::create(db_.get(), db_->getTech());
     block_ = odb::dbBlock::create(chip_, "top");


### PR DESCRIPTION
Ensure that when Liberty timing libraries are loaded after LEF macro files, the OpenDB master terms (dbMTerm) correctly receive the CLOCK signal type. This aligns the LEF-first loading order behavior with the Liberty-first behavior.

## Summary
When Liberty timing libraries (.lib) are loaded *after* LEF files, the database master terms (`dbMTerm`s) were not updated to the `CLOCK` signal type (unlike when Liberty was loaded *before* LEF). This led to incorrect signal types in the database and caused downstream tools (like MBFF) that query `iterm->getSigType()` directly to fail to identify clock pins.

This PR updates `dbNetwork::readLibertyAfter` to inspect mapped ports and propagate the `CLOCK` signal type to the database master terms (`dbMTerm`) when the Liberty port `isClock()` is true.

## Type of Change
- Bug fix

## Impact
This change makes the loading order of LEF and Liberty files arbitrary and consistent, eliminating downstream placement and timing failures when LEF is read first.

## Verification
- [x] I have verified that the local build succeeds.
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
Closes #10464