### PR TITLE
gui: Add context menu to WebGUI

### DIFF
--- a/src/web/BUILD
+++ b/src/web/BUILD
@@ -41,6 +41,8 @@ genrule(
         "src/tcl-completer.js",
         "src/hierarchy-browser.js",
         "src/menu-bar.js",
+        "src/add-label-widget.js",
+        "src/context-menu.js",
         "src/title.js",
         "src/clock-tree-widget.js",
         "src/schematic-widget.js",
@@ -67,6 +69,8 @@ genrule(
           " $(location src/tcl-completer.js)" +
           " $(location src/hierarchy-browser.js)" +
           " $(location src/menu-bar.js)" +
+          " $(location src/add-label-widget.js)" +
+          " $(location src/context-menu.js)" +
           " $(location src/title.js)" +
           " $(location src/clock-tree-widget.js)" +
           " $(location src/schematic-widget.js)" +
@@ -94,6 +98,8 @@ _WEB_ASSET_FILES = [
     "src/tcl-completer.js",
     "src/hierarchy-browser.js",
     "src/menu-bar.js",
+    "src/add-label-widget.js",
+    "src/context-menu.js",
     "src/title.js",
     "src/clock-tree-widget.js",
     "src/schematic-widget.js",

--- a/src/web/CMakeLists.txt
+++ b/src/web/CMakeLists.txt
@@ -28,6 +28,8 @@ set(WEB_ASSET_FILES
     src/tcl-completer.js
     src/hierarchy-browser.js
     src/menu-bar.js
+    src/add-label-widget.js
+    src/context-menu.js
     src/title.js
     src/clock-tree-widget.js
     src/schematic-widget.js
@@ -63,6 +65,8 @@ add_custom_command(
         ${CMAKE_CURRENT_SOURCE_DIR}/src/tcl-completer.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/hierarchy-browser.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/menu-bar.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/add-label-widget.js
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/context-menu.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/title.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/clock-tree-widget.js
         ${CMAKE_CURRENT_SOURCE_DIR}/src/schematic-widget.js

--- a/src/web/src/add-label-widget.js
+++ b/src/web/src/add-label-widget.js
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+export class LabelManager {
+    constructor(app) {
+        this._app = app;
+        this._labels = [];
+    }
+
+    addLabelAt(text, color, size, latlng) {
+        if (!this._app.map) return;
+
+        // Escape user-supplied text — it is interpolated into innerHTML below.
+        const safeText = String(text)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+
+        const icon = L.divIcon({
+            className: 'custom-leaflet-label',
+            html: `<div style="color: ${color}; font-size: ${size}px; font-weight: bold; white-space: nowrap; text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;">${safeText}</div>`,
+            iconSize: null,
+        });
+
+        const marker = L.marker(latlng, {
+            icon,
+            draggable: true,
+        }).addTo(this._app.map);
+
+        marker.on('mousedown', (e) => {
+            if (e.originalEvent.button === 2) {
+                e.originalEvent.stopPropagation();
+            }
+        });
+
+        marker.on('contextmenu', (e) => {
+            // Prevent the layout viewer's right-click menu from opening.
+            e.originalEvent.preventDefault();
+            e.originalEvent.stopPropagation();
+            setTimeout(() => {
+                marker.remove();
+                this._labels = this._labels.filter(m => m !== marker);
+            }, 0);
+        });
+
+        this._labels.push(marker);
+    }
+
+    clearAll() {
+        this._labels.forEach(m => m.remove());
+        this._labels = [];
+    }
+}

--- a/src/web/src/context-menu.js
+++ b/src/web/src/context-menu.js
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Copyright (c) 2026, The OpenROAD Authors
+
+import { latLngToDbu } from './coordinates.js';
+
+// Mirrors kHighlightColors / kHighlightOverlayColors in the backend.
+const HIGHLIGHT_COLORS = [
+    { name: 'green',        hex: '#00ff00' },
+    { name: 'yellow',       hex: '#ffff00' },
+    { name: 'cyan',         hex: '#00ffff' },
+    { name: 'magenta',      hex: '#ff00ff' },
+    { name: 'red',          hex: '#ff0000' },
+    { name: 'dark_green',   hex: '#008000' },
+    { name: 'dark_magenta', hex: '#800080' },
+    { name: 'blue',         hex: '#0000ff' },
+    { name: 'orange',       hex: '#ffa500' },
+    { name: 'purple',       hex: '#800080' },
+    { name: 'lime',         hex: '#bfff00' },
+    { name: 'teal',         hex: '#008080' },
+    { name: 'pink',         hex: '#ffc0cb' },
+    { name: 'brown',        hex: '#8b4513' },
+    { name: 'indigo',       hex: '#4b0082' },
+    { name: 'turquoise',    hex: '#40e0d0' },
+];
+
+export class ContextMenu {
+    constructor(app) {
+        this._app = app;
+        this._el = document.createElement('div');
+        this._el.className = 'context-menu';
+        this._el.style.display = 'none';
+        this._el.style.zIndex = '10000';
+        document.body.appendChild(this._el);
+
+        this._bindEvents();
+    }
+
+    _bindEvents() {
+        // Hide menu when clicking (left or right) outside.
+        document.addEventListener('mousedown', (e) => {
+            if (!this._el.contains(e.target)) {
+                this.hide();
+            }
+        });
+
+        // Hide menu when map moves.
+        if (this._app.map) {
+            this._app.map.on('movestart', () => this.hide());
+        }
+    }
+
+    show(e, latlng) {
+        this._el.innerHTML = '';
+
+        const menuItems = [
+            { label: 'Add Label', action: () => this._showAddLabelDialog(latlng) },
+            { type: 'separator' },
+            { label: 'Select', subMenu: [
+                { label: 'Connected Insts', action: () => this._sendContextAction('select_connected_insts') },
+                { label: 'Output Nets', action: () => this._sendContextAction('select_connected_nets', { output: true, input: false }) },
+                { label: 'Input Nets', action: () => this._sendContextAction('select_connected_nets', { output: false, input: true }) },
+                { label: 'All Nets', action: () => this._sendContextAction('select_connected_nets', { output: true, input: true }) },
+                { label: 'All buffer trees', action: () => this._sendContextAction('select_connected_buffer_trees') },
+            ]},
+            { label: 'Highlight', subMenu: [
+                { label: 'Connected Insts', subMenu:
+                    this._buildColorSubmenu('highlight_connected_insts') },
+                { label: 'Output Nets', subMenu:
+                    this._buildColorSubmenu('highlight_connected_nets', { output: true, input: false }) },
+                { label: 'Input Nets', subMenu:
+                    this._buildColorSubmenu('highlight_connected_nets', { output: false, input: true }) },
+                { label: 'All Nets', subMenu:
+                    this._buildColorSubmenu('highlight_connected_nets', { output: true, input: true }) },
+                { label: 'All buffer trees', subMenu:
+                    this._buildColorSubmenu('highlight_connected_buffer_trees') },
+            ]},
+            { label: 'Clear', subMenu: [
+                { label: 'Selections', action: () => this._sendContextAction('clear_selections') },
+                { label: 'Highlights', action: () => this._sendContextAction('clear_highlights') },
+                { label: 'Rulers', action: () => { if (this._app.rulerManager) this._app.rulerManager.clearAllRulers(); } },
+                { label: 'Labels', action: () => { if (this._app.labelManager) this._app.labelManager.clearAll(); } },
+                { label: 'Focus nets', action: () => this._sendContextAction('clear_focus_nets') },
+                { label: 'Route Guides', action: () => this._sendContextAction('clear_route_guides') },
+                { label: 'Net Tracks', action: () => this._sendContextAction('clear_net_tracks') },
+                { label: 'All', action: () => {
+                    this._sendContextAction('clear_all');
+                    if (this._app.rulerManager) this._app.rulerManager.clearAllRulers();
+                    if (this._app.labelManager) this._app.labelManager.clearAll();
+                }},
+            ]},
+            { label: 'Save', subMenu: [
+                { label: 'Visible layout', action: () => {
+                    const bounds = this._app.map.getBounds();
+                    const sw = latLngToDbu(bounds.getSouthWest().lat, bounds.getSouthWest().lng, this._app.designScale, this._app.designMaxDXDY, this._app.designOriginX, this._app.designOriginY);
+                    const ne = latLngToDbu(bounds.getNorthEast().lat, bounds.getNorthEast().lng, this._app.designScale, this._app.designMaxDXDY, this._app.designOriginX, this._app.designOriginY);
+                    const bbox = [
+                        Math.min(sw.dbuX, ne.dbuX),
+                        Math.min(sw.dbuY, ne.dbuY),
+                        Math.max(sw.dbuX, ne.dbuX),
+                        Math.max(sw.dbuY, ne.dbuY),
+                    ];
+                    this._triggerImageDownload(true, bbox);
+                }},
+                { label: 'Entire layout', action: () => this._triggerImageDownload(false, null) },
+            ]},
+        ];
+
+        this._buildMenu(menuItems, this._el);
+
+        // Show first so we can measure, then clamp into the viewport so the
+        // menu (and its tall submenus) never spills off the right/bottom edge.
+        this._el.style.display = 'block';
+        const margin = 4;
+        const rect = this._el.getBoundingClientRect();
+        const maxLeft = window.innerWidth - rect.width - margin;
+        const maxTop = window.innerHeight - rect.height - margin;
+        const left = Math.max(margin,
+            Math.min(e.originalEvent.clientX, maxLeft));
+        const top = Math.max(margin,
+            Math.min(e.originalEvent.clientY, maxTop));
+        this._el.style.left = left + 'px';
+        this._el.style.top = top + 'px';
+    }
+
+    hide() {
+        this._el.style.display = 'none';
+    }
+
+    _buildMenu(items, container) {
+        items.forEach(item => {
+            if (item.type === 'separator') {
+                const sep = document.createElement('div');
+                sep.className = 'cm-separator';
+                container.appendChild(sep);
+                return;
+            }
+
+            const row = document.createElement('div');
+            row.className = 'cm-item';
+            if (item.swatch) {
+                const sw = document.createElement('span');
+                sw.className = 'cm-swatch';
+                sw.style.background = item.swatch;
+                row.appendChild(sw);
+            }
+            row.appendChild(document.createTextNode(item.label));
+
+            if (item.subMenu) {
+                row.classList.add('has-submenu');
+                const subContainer = document.createElement('div');
+                subContainer.className = 'cm-submenu';
+                this._buildMenu(item.subMenu, subContainer);
+                row.appendChild(subContainer);
+                // Flip the submenu to the left edge when it would overflow the
+                // viewport on the right (deep color submenus are 3 levels in).
+                row.addEventListener('mouseenter', () => {
+                    subContainer.classList.remove('flip-left');
+                    const sub = subContainer.getBoundingClientRect();
+                    if (sub.right > window.innerWidth) {
+                        subContainer.classList.add('flip-left');
+                    }
+                });
+            } else if (item.action) {
+                row.addEventListener('click', (ev) => {
+                    ev.stopPropagation();
+                    this.hide();
+                    try {
+                        item.action();
+                    } catch (err) {
+                        console.error('Context menu item action threw:',
+                                      item.label, err);
+                    }
+                });
+            }
+
+            container.appendChild(row);
+        });
+    }
+
+    _triggerImageDownload(visible, bbox) {
+        const filename = visible ? 'layout_visible.png' : 'layout_entire.png';
+        const params = new URLSearchParams();
+        params.set('type', visible ? 'visible' : 'entire');
+        params.set('filename', filename);
+        if (visible && bbox) {
+            params.set('bbox', bbox.join(','));
+        }
+        const url = `/download/image?${params.toString()}`;
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+    }
+
+    _buildColorSubmenu(action, baseArgs = {}) {
+        return HIGHLIGHT_COLORS.map(({ name, hex }, idx) => ({
+            label: name,
+            swatch: hex,
+            action: () => this._sendContextAction(action, { ...baseArgs, group: idx }),
+        }));
+    }
+
+    _showAddLabelDialog(latlng) {
+        const text = prompt('Enter label text:');
+        if (text && this._app.labelManager) {
+            this._app.labelManager.addLabelAt(text, 'yellow', 14, latlng);
+        }
+    }
+
+    _sendContextAction(action, args = {}) {
+        if (!this._app.websocketManager) {
+            return;
+        }
+        this._app.websocketManager
+            .request({ type: 'context_action', action, ...args })
+            .then(() => {
+                if (typeof this._app.redrawAllLayers === 'function') {
+                    this._app.redrawAllLayers();
+                }
+            })
+            .catch((err) => {
+                console.error('Context action failed:', action, err);
+            });
+    }
+}

--- a/src/web/src/main.js
+++ b/src/web/src/main.js
@@ -20,6 +20,8 @@ import { TclCompleter } from './tcl-completer.js';
 import { getCookie, setCookie, applyGLTheme } from './theme.js';
 import { updateDocumentTitle } from './title.js';
 import { ThreeDViewerWidget } from './3d-viewer-widget.js';
+import { ContextMenu } from './context-menu.js';
+import { LabelManager } from './add-label-widget.js';
 
 // ─── Status Indicator ───────────────────────────────────────────────────────
 
@@ -448,6 +450,10 @@ function scheduleRedrawAllLayers() {
         redrawAllLayers();
     });
 }
+
+// Expose so the context menu can refresh base + overlay tiles after a
+// server-side context_action (select / highlight / clear).
+app.redrawAllLayers = redrawAllLayers;
 
 function createLayoutViewer(container) {
     const mapDiv = document.createElement('div');
@@ -965,6 +971,9 @@ app.toggleShowDbu = function() {
 
 createMenuBar(app);
 
+app.labelManager = new LabelManager(app);
+app.contextMenu = new ContextMenu(app);
+
 // Debug-graphics pause affordance: appended lazily when the first
 // debug_paused push arrives.  Clicking "Continue" tells the server to
 // release the placer thread.
@@ -1194,6 +1203,15 @@ app.websocketManager.readyPromise.then(async () => {
 
             container.addEventListener('mousedown', (e) => {
                 if (e.button !== 2) return;
+                // Right-clicking a label only removes it (handled by the
+                // marker's own contextmenu listener).  Decide here, at
+                // mousedown — the first event of the right-click sequence —
+                // because mouseup (which opens the menu) fires before the
+                // marker's contextmenu, so a later guard can't suppress it.
+                if (e.target && e.target.closest
+                    && e.target.closest('.custom-leaflet-label')) {
+                    return;
+                }
                 rbStart = { x: e.clientX, y: e.clientY };
                 app.map.dragging.disable();
             });
@@ -1228,18 +1246,37 @@ app.websocketManager.readyPromise.then(async () => {
                 rbStart = null;
                 app.map.dragging.enable();
 
-                if (!wasShowing) return;
-
-                // Convert the two screen corners to lat/lng and zoom
                 const rect = container.getBoundingClientRect();
-                const p1 = app.map.containerPointToLatLng([
-                    start.x - rect.left, start.y - rect.top]);
-                const p2 = app.map.containerPointToLatLng([
+
+                if (wasShowing) {
+                    // Drag — rubber-band zoom.
+                    const p1 = app.map.containerPointToLatLng([
+                        start.x - rect.left, start.y - rect.top]);
+                    const p2 = app.map.containerPointToLatLng([
+                        e.clientX - rect.left, e.clientY - rect.top]);
+                    app.map.fitBounds([
+                        [Math.min(p1.lat, p2.lat), Math.min(p1.lng, p2.lng)],
+                        [Math.max(p1.lat, p2.lat), Math.max(p1.lng, p2.lng)],
+                    ]);
+                    return;
+                }
+
+                // Pure click — show context menu (only over the map container).
+                const overMap = e.clientX >= rect.left && e.clientX <= rect.right
+                             && e.clientY >= rect.top  && e.clientY <= rect.bottom;
+                if (!overMap) return;
+                if (app.rulerManager && app.rulerManager.isActive()) return;
+                if (!app.contextMenu) return;
+                // Right-clicking a label deletes it (handled by the marker's own
+                // contextmenu listener); don't also open the layout menu there.
+                if (e.target && e.target.closest
+                    && e.target.closest('.custom-leaflet-label')) {
+                    return;
+                }
+
+                const latlng = app.map.containerPointToLatLng([
                     e.clientX - rect.left, e.clientY - rect.top]);
-                app.map.fitBounds([
-                    [Math.min(p1.lat, p2.lat), Math.min(p1.lng, p2.lng)],
-                    [Math.max(p1.lat, p2.lat), Math.max(p1.lng, p2.lng)],
-                ]);
+                app.contextMenu.show({ originalEvent: e }, latlng);
             });
         }
 

--- a/src/web/src/request_handler.cpp
+++ b/src/web/src/request_handler.cpp
@@ -31,6 +31,8 @@
 #include "cli_completer.h"
 #include "clock_tree_report.h"
 #include "color.h"
+#include "db_sta/dbNetwork.hh"
+#include "db_sta/dbSta.hh"
 #include "gui/descriptor_registry.h"
 #include "gui/gui.h"
 #include "gui/heatMap.h"
@@ -41,6 +43,7 @@
 #include "odb/dbTypes.h"
 #include "odb/geom.h"
 #include "request_dispatcher.h"
+#include "sta/Liberty.hh"
 #include "tile_generator.h"
 #include "timing_report.h"
 #include "utl/Logger.h"
@@ -60,6 +63,7 @@ class ShapeCollector : public gui::Painter
 
   std::vector<odb::Rect> rects;
   std::vector<odb::Polygon> polys;
+  std::vector<std::pair<odb::Point, odb::Point>> lines;
 
   void drawRect(const odb::Rect& rect, int, int) override
   {
@@ -71,6 +75,14 @@ class ShapeCollector : public gui::Painter
   }
   void drawOctagon(const odb::Oct& oct) override { polys.emplace_back(oct); }
 
+  // Capture line segments (net flywires, route paths, guide lines) so net
+  // highlights are visible in the overlay.  All Painter::drawLine overloads
+  // funnel through this virtual.
+  void drawLine(const odb::Point& p1, const odb::Point& p2) override
+  {
+    lines.emplace_back(p1, p2);
+  }
+
   // No-ops
   Color getPenColor() override { return {}; }
   void setPen(odb::dbTechLayer*, bool) override {}
@@ -81,7 +93,6 @@ class ShapeCollector : public gui::Painter
   void setFont(const Font&) override {}
   void saveState() override {}
   void restoreState() override {}
-  void drawLine(const odb::Point&, const odb::Point&) override {}
   void drawCircle(int, int, int) override {}
   void drawX(int, int, int) override {}
   void drawPolygon(const std::vector<odb::Point>&) override {}
@@ -231,12 +242,15 @@ static boost::json::object serializeProperty(
   return o;
 }
 
-static void collectHighlightShapes(const gui::Selected& sel,
-                                   std::vector<odb::Rect>& rects,
-                                   std::vector<odb::Polygon>& polys)
+static void collectHighlightShapes(
+    const gui::Selected& sel,
+    std::vector<odb::Rect>& rects,
+    std::vector<odb::Polygon>& polys,
+    std::vector<std::pair<odb::Point, odb::Point>>& lines)
 {
   rects.clear();
   polys.clear();
+  lines.clear();
   if (!sel) {
     return;
   }
@@ -244,6 +258,7 @@ static void collectHighlightShapes(const gui::Selected& sel,
   sel.highlight(collector);
   rects = std::move(collector.rects);
   polys = std::move(collector.polys);
+  lines = std::move(collector.lines);
 }
 
 // Return the 0-based position of the iterator within the selection set,
@@ -259,12 +274,15 @@ static int selectionIteratorPosition(const gui::SelectionSet& set,
 }
 
 // Accumulate highlight shapes from all items in a selection set.
-static void collectMultiHighlightShapes(const gui::SelectionSet& selections,
-                                        std::vector<odb::Rect>& rects,
-                                        std::vector<odb::Polygon>& polys)
+static void collectMultiHighlightShapes(
+    const gui::SelectionSet& selections,
+    std::vector<odb::Rect>& rects,
+    std::vector<odb::Polygon>& polys,
+    std::vector<std::pair<odb::Point, odb::Point>>& lines)
 {
   rects.clear();
   polys.clear();
+  lines.clear();
   for (const auto& sel : selections) {
     if (!sel) {
       continue;
@@ -273,6 +291,7 @@ static void collectMultiHighlightShapes(const gui::SelectionSet& selections,
     sel.highlight(collector);
     rects.insert(rects.end(), collector.rects.begin(), collector.rects.end());
     polys.insert(polys.end(), collector.polys.begin(), collector.polys.end());
+    lines.insert(lines.end(), collector.lines.begin(), collector.lines.end());
   }
 }
 
@@ -546,6 +565,11 @@ void SelectHandler::registerRequests(RequestDispatcher& d)
         [this](const WebSocketRequest& req, SessionState&) {
           return handleGet3DData(req);
         });
+  d.add("context_action",
+        WebSocketRequest::kContextAction,
+        [this](const WebSocketRequest& req, SessionState& state) {
+          return handleContextAction(req, state);
+        });
 }
 
 WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
@@ -645,8 +669,10 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
       }
 
       // Highlight all items in the selection set.
-      collectMultiHighlightShapes(
-          state.selection_set, state.highlight_rects, state.highlight_polys);
+      collectMultiHighlightShapes(state.selection_set,
+                                  state.highlight_rects,
+                                  state.highlight_polys,
+                                  state.highlight_lines);
       state.current_inspected = inspected_sel;
 
       root["selection_count"]
@@ -655,6 +681,270 @@ WebSocketResponse SelectHandler::handleSelect(const WebSocketRequest& req,
           selectionIteratorPosition(state.selection_set, state.selection_itr));
     }
 
+    writePayload(resp, root);
+  } catch (const std::exception& e) {
+    resp.type = WebSocketResponse::kError;
+    const std::string err = std::string("server error: ") + e.what();
+    resp.payload.assign(err.begin(), err.end());
+  }
+  return resp;
+}
+
+// ── Context-menu actions (Select / Highlight / Clear) ─────────────────────
+//
+// Mirror the Qt GUI's LayoutViewer context menu, operating on the session's
+// current selection set.  Connected-object traversal replicates
+// MainWindow::selectHighlightConnected{Insts,Nets,BufferTrees}
+// (mainWindow.cpp).
+
+namespace {
+
+// True if `inst` is a buffer cell (per liberty), used to walk buffer trees.
+bool isBufferInst(odb::dbInst* inst, sta::dbSta* sta)
+{
+  if (inst == nullptr || sta == nullptr) {
+    return false;
+  }
+  sta::dbNetwork* network = sta->getDbNetwork();
+  sta::Cell* cell = network->dbToSta(inst->getMaster());
+  if (cell == nullptr) {
+    return false;
+  }
+  sta::LibertyCell* lib_cell = network->libertyCell(cell);
+  return lib_cell != nullptr && lib_cell->isBuffer();
+}
+
+// Walk the buffer tree rooted at `net`, collecting every net and buffer inst
+// reachable by passing through buffer cells.  Mirrors gui::BufferTree::populate
+// without depending on the gui module's private BufferTree type.
+void collectBufferTree(odb::dbNet* net,
+                       sta::dbSta* sta,
+                       odb::PtrSet<odb::dbNet>& nets,
+                       odb::PtrSet<odb::dbInst>& insts)
+{
+  if (net == nullptr || nets.contains(net)) {
+    return;
+  }
+  nets.insert(net);
+  for (auto* iterm : net->getITerms()) {
+    odb::dbInst* inst = iterm->getInst();
+    if (!isBufferInst(inst, sta)) {
+      continue;
+    }
+    insts.insert(inst);
+    for (auto* next : inst->getITerms()) {
+      if (!next->getSigType().isSupply()) {
+        collectBufferTree(next->getNet(), sta, nets, insts);
+      }
+    }
+  }
+}
+
+// Collect the objects connected to the current selection, per `action`.
+gui::SelectionSet computeConnectedSet(const std::string& action,
+                                      const gui::SelectionSet& selection,
+                                      const bool output,
+                                      const bool input,
+                                      sta::dbSta* sta)
+{
+  auto* registry = gui::DescriptorRegistry::instance();
+  gui::SelectionSet result;
+
+  const bool want_insts = action.find("insts") != std::string::npos;
+  const bool want_buffer_trees
+      = action.find("buffer_trees") != std::string::npos;
+  const bool want_nets
+      = !want_buffer_trees && action.find("nets") != std::string::npos;
+
+  for (const auto& sel : selection) {
+    if (!sel) {
+      continue;
+    }
+    if (want_insts && sel.isNet()) {
+      auto* net = std::any_cast<odb::dbNet*>(sel.getObject());
+      if (net == nullptr) {
+        continue;
+      }
+      // Select the owning instances of the net's terminals (deduped by the
+      // SelectionSet) so the connected instances are highlighted as bboxes,
+      // matching the "Connected Insts" label.
+      for (auto* iterm : net->getITerms()) {
+        odb::dbInst* inst = iterm->getInst();
+        if (inst != nullptr) {
+          result.insert(registry->makeSelected(inst));
+        }
+      }
+    } else if (want_nets && sel.isInst()) {
+      auto* inst = std::any_cast<odb::dbInst*>(sel.getObject());
+      if (inst == nullptr) {
+        continue;
+      }
+      for (auto* iterm : inst->getITerms()) {
+        odb::dbNet* net = iterm->getNet();
+        if (net == nullptr || net->getSigType() != odb::dbSigType::SIGNAL) {
+          continue;
+        }
+        const auto dir = iterm->getIoType();
+        if (output
+            && (dir == odb::dbIoType::OUTPUT || dir == odb::dbIoType::INOUT)) {
+          result.insert(registry->makeSelected(net));
+        }
+        if (input
+            && (dir == odb::dbIoType::INPUT || dir == odb::dbIoType::INOUT)) {
+          result.insert(registry->makeSelected(net));
+        }
+      }
+    } else if (want_buffer_trees && sel.isInst()) {
+      auto* inst = std::any_cast<odb::dbInst*>(sel.getObject());
+      if (inst == nullptr) {
+        continue;
+      }
+      odb::PtrSet<odb::dbNet> tree_nets;
+      odb::PtrSet<odb::dbInst> tree_insts;
+      for (auto* iterm : inst->getITerms()) {
+        const auto dir = iterm->getIoType();
+        if (iterm->getSigType().isSupply()
+            || (dir != odb::dbIoType::INPUT && dir != odb::dbIoType::OUTPUT
+                && dir != odb::dbIoType::INOUT)) {
+          continue;
+        }
+        odb::dbNet* net = iterm->getNet();
+        if (net == nullptr || net->getSigType() != odb::dbSigType::SIGNAL) {
+          continue;
+        }
+        collectBufferTree(net, sta, tree_nets, tree_insts);
+      }
+      // Highlight the tree's nets and buffer instances via their already
+      // registered dbNet/dbInst descriptors (no gui::BufferTree dependency).
+      for (auto* tree_net : tree_nets) {
+        result.insert(registry->makeSelected(tree_net));
+      }
+      for (auto* tree_inst : tree_insts) {
+        result.insert(registry->makeSelected(tree_inst));
+      }
+    }
+  }
+  return result;
+}
+
+// Map a highlight group index to its web RGBA color
+// (gui::Painter::kHighlightColors carries an alpha of 100 for the fill).
+Color toWebHighlightColor(const int group)
+{
+  const auto& colors = gui::Painter::kHighlightColors;
+  const int num_colors = static_cast<int>(colors.size());
+  if (num_colors == 0) {
+    return Color{.r = 0, .g = 0, .b = 0, .a = 255};
+  }
+  // Signed arithmetic so a negative group still maps into [0, num_colors).
+  const auto& c = colors[((group % num_colors) + num_colors) % num_colors];
+  return Color{.r = static_cast<unsigned char>(c.r),
+               .g = static_cast<unsigned char>(c.g),
+               .b = static_cast<unsigned char>(c.b),
+               .a = static_cast<unsigned char>(c.a)};
+}
+
+}  // namespace
+
+WebSocketResponse SelectHandler::handleContextAction(
+    const WebSocketRequest& req,
+    SessionState& state)
+{
+  WebSocketResponse resp;
+  resp.id = req.id;
+  resp.type = WebSocketResponse::kJson;
+  try {
+    const std::string action(req.json.at("action").as_string());
+    const bool output = jsonOr(req.json, "output", false);
+    const bool input = jsonOr(req.json, "input", false);
+    const int group = static_cast<int>(jsonOr(req.json, "group", int64_t{0}));
+
+    // STA traversal, makeSelected() and highlight() are not thread-safe;
+    // serialize with other STA callers (timing, clock tree, tcl eval).
+    std::lock_guard<std::mutex> sta_lock(tcl_eval_->mutex);
+    std::lock_guard<std::mutex> lock(state.selection_mutex);
+
+    if (action.starts_with("select_")) {
+      const gui::SelectionSet connected = computeConnectedSet(
+          action, state.selection_set, output, input, gen_->getSta());
+      for (const auto& s : connected) {
+        state.selection_set.insert(s);
+      }
+      state.selection_itr = state.selection_set.begin();
+      collectMultiHighlightShapes(state.selection_set,
+                                  state.highlight_rects,
+                                  state.highlight_polys,
+                                  state.highlight_lines);
+    } else if (action.starts_with("highlight_")) {
+      const gui::SelectionSet connected = computeConnectedSet(
+          action, state.selection_set, output, input, gen_->getSta());
+      const Color color = toWebHighlightColor(group);
+      for (const auto& s : connected) {
+        if (!s) {
+          continue;
+        }
+        ShapeCollector collector;
+        s.highlight(collector);
+        for (const auto& r : collector.rects) {
+          state.highlight_group_rects.push_back(ColoredRect{
+              .rect = r, .color = color, .layer = "", .filled = true});
+        }
+        for (const auto& p : collector.polys) {
+          state.highlight_group_polys.push_back(
+              ColoredPolygon{.poly = p, .color = color});
+        }
+        for (const auto& [p1, p2] : collector.lines) {
+          state.highlight_group_lines.push_back(
+              FlightLine{.p1 = p1, .p2 = p2, .color = color});
+        }
+      }
+    } else if (action == "clear_selections") {
+      state.selection_set.clear();
+      state.selection_itr = state.selection_set.end();
+      state.current_inspected = gui::Selected();
+      state.navigation_history.clear();
+      state.highlight_rects.clear();
+      state.highlight_polys.clear();
+      state.highlight_lines.clear();
+    } else if (action == "clear_highlights") {
+      state.highlight_group_rects.clear();
+      state.highlight_group_polys.clear();
+      state.highlight_group_lines.clear();
+    } else if (action == "clear_focus_nets") {
+      std::lock_guard<std::mutex> flock(state.focus_nets_mutex);
+      state.focus_net_ids.clear();
+    } else if (action == "clear_route_guides") {
+      std::lock_guard<std::mutex> rlock(state.route_guides_mutex);
+      state.route_guide_net_ids.clear();
+    } else if (action == "clear_net_tracks") {
+      // No server-side net-tracks state in the web viewer yet; no-op so the
+      // menu item still returns success.
+    } else if (action == "clear_all") {
+      state.selection_set.clear();
+      state.selection_itr = state.selection_set.end();
+      state.current_inspected = gui::Selected();
+      state.navigation_history.clear();
+      state.highlight_rects.clear();
+      state.highlight_polys.clear();
+      state.highlight_lines.clear();
+      state.highlight_group_rects.clear();
+      state.highlight_group_polys.clear();
+      state.highlight_group_lines.clear();
+      {
+        std::lock_guard<std::mutex> flock(state.focus_nets_mutex);
+        state.focus_net_ids.clear();
+      }
+      {
+        std::lock_guard<std::mutex> rlock(state.route_guides_mutex);
+        state.route_guide_net_ids.clear();
+      }
+    } else {
+      throw std::runtime_error("unknown context action: " + action);
+    }
+
+    boost::json::object root;
+    root["ok"] = true;
+    root["selection_count"] = static_cast<int64_t>(state.selection_set.size());
     writePayload(resp, root);
   } catch (const std::exception& e) {
     resp.type = WebSocketResponse::kError;
@@ -701,7 +991,10 @@ WebSocketResponse SelectHandler::handleInspect(const WebSocketRequest& req,
       state.hover_rects.clear();
       state.timing_rects.clear();
       state.timing_lines.clear();
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      collectHighlightShapes(sel,
+                             state.highlight_rects,
+                             state.highlight_polys,
+                             state.highlight_lines);
       if (sel) {
         if (state.current_inspected && state.current_inspected != sel) {
           state.navigation_history.push_back(state.current_inspected);
@@ -767,7 +1060,10 @@ WebSocketResponse SelectHandler::handleInspectBack(const WebSocketRequest& req,
         sel = state.current_inspected;
       }
 
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      collectHighlightShapes(sel,
+                             state.highlight_rects,
+                             state.highlight_polys,
+                             state.highlight_lines);
       can_navigate_back = !state.navigation_history.empty();
       sel_count = static_cast<int>(state.selection_set.size());
       sel_index
@@ -836,8 +1132,10 @@ static WebSocketResponse handleSelectionCycle(
         state.navigation_history.clear();
         // Restore selection-set highlights (handleInspect may have
         // replaced them with a single linked object's shapes).
-        collectMultiHighlightShapes(
-            state.selection_set, state.highlight_rects, state.highlight_polys);
+        collectMultiHighlightShapes(state.selection_set,
+                                    state.highlight_rects,
+                                    state.highlight_polys,
+                                    state.highlight_lines);
       }
       sel_index
           = selectionIteratorPosition(state.selection_set, state.selection_itr);
@@ -1463,7 +1761,10 @@ WebSocketResponse SelectHandler::handleSchematicInspect(
       state.hover_rects.clear();
       state.timing_rects.clear();
       state.timing_lines.clear();
-      collectHighlightShapes(sel, state.highlight_rects, state.highlight_polys);
+      collectHighlightShapes(sel,
+                             state.highlight_rects,
+                             state.highlight_polys,
+                             state.highlight_lines);
       state.current_inspected = sel;
       state.navigation_history.clear();
     }
@@ -1833,6 +2134,7 @@ WebSocketResponse ClockTreeHandler::handleClockTreeHighlight(
     std::lock_guard<std::mutex> lock(state.selection_mutex);
     state.highlight_rects.clear();
     state.highlight_polys.clear();
+    state.highlight_lines.clear();
     state.timing_rects.clear();
     state.timing_lines.clear();
 
@@ -2007,14 +2309,19 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
     if (state.current_inspected) {
       collectHighlightShapes(state.current_inspected,
                              state.highlight_rects,
-                             state.highlight_polys);
+                             state.highlight_polys,
+                             state.highlight_lines);
     }
   }
+
+  // Selection highlight color (yellow), matching drawHighlight's border.
+  constexpr Color kSelectionLine{.r = 255, .g = 255, .b = 0, .a = 255};
 
   // Snapshot current highlight state
   std::vector<odb::Rect> rects;
   std::vector<odb::Polygon> polys;
   std::vector<ColoredRect> colored;
+  std::vector<ColoredPolygon> colored_polys;
   std::vector<FlightLine> lines;
   {
     std::lock_guard<std::mutex> lock(state.selection_mutex);
@@ -2023,7 +2330,20 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
         rects.end(), state.hover_rects.begin(), state.hover_rects.end());
     polys = state.highlight_polys;
     colored = state.timing_rects;
+    // Context-menu "Highlight" group shapes carry their own group color.
+    colored.insert(colored.end(),
+                   state.highlight_group_rects.begin(),
+                   state.highlight_group_rects.end());
+    colored_polys = state.highlight_group_polys;
     lines = state.timing_lines;
+    // Net flywires / route paths from the selection highlight, drawn yellow.
+    for (const auto& [p1, p2] : state.highlight_lines) {
+      lines.push_back(FlightLine{.p1 = p1, .p2 = p2, .color = kSelectionLine});
+    }
+    // Context-menu "Highlight" group line segments (per-group color).
+    lines.insert(lines.end(),
+                 state.highlight_group_lines.begin(),
+                 state.highlight_group_lines.end());
   }
 
   // Merge DRC overlay shapes
@@ -2069,7 +2389,8 @@ WebSocketResponse TileHandler::handleOverlayTile(const WebSocketRequest& req,
                                   lines,
                                   route_guide_ptr,
                                   has_vis_layers,
-                                  vis_layers);
+                                  vis_layers,
+                                  colored_polys);
   return resp;
 }
 
@@ -2922,12 +3243,16 @@ WebSocketResponse DRCHandler::handleDRCHighlight(const WebSocketRequest& req,
           state.hover_rects.clear();
           state.timing_rects.clear();
           state.timing_lines.clear();
-          collectHighlightShapes(
-              sel, state.highlight_rects, state.highlight_polys);
+          collectHighlightShapes(sel,
+                                 state.highlight_rects,
+                                 state.highlight_polys,
+                                 state.highlight_lines);
           state.current_inspected = sel;
           state.navigation_history.clear();
         } else {
           state.highlight_rects.push_back(bbox);
+          state.highlight_polys.clear();
+          state.highlight_lines.clear();
         }
       }
 

--- a/src/web/src/request_handler.h
+++ b/src/web/src/request_handler.h
@@ -121,6 +121,7 @@ struct WebSocketRequest
     kDebugCharts,
     kGet3DData,
     kOverlayTile,
+    kContextAction,
     kUnknown
   };
 
@@ -162,6 +163,16 @@ struct SessionState
   std::mutex selection_mutex;
   std::vector<odb::Rect> highlight_rects;
   std::vector<odb::Polygon> highlight_polys;
+  // Selection highlight line segments (net flywires / route paths) — rendered
+  // in the selection color (yellow) via the overlay flight-line channel.
+  std::vector<std::pair<odb::Point, odb::Point>> highlight_lines;
+  // Context-menu "Highlight" groups: shapes carry the per-group color
+  // (gui::Painter::kHighlightColors[group]).  Rendered via the colored
+  // overlay path, independent of the single-style selection highlight
+  // above.  Guarded by selection_mutex.
+  std::vector<ColoredRect> highlight_group_rects;
+  std::vector<ColoredPolygon> highlight_group_polys;
+  std::vector<FlightLine> highlight_group_lines;
   std::vector<odb::Rect> hover_rects;
   std::vector<ColoredRect> timing_rects;
   std::vector<FlightLine> timing_lines;
@@ -243,6 +254,8 @@ class SelectHandler
   WebSocketResponse handleSchematicInspect(const WebSocketRequest& req,
                                            SessionState& state);
   WebSocketResponse handleGet3DData(const WebSocketRequest& req);
+  WebSocketResponse handleContextAction(const WebSocketRequest& req,
+                                        SessionState& state);
 
  private:
   std::shared_ptr<TileGenerator> gen_;

--- a/src/web/src/style.css
+++ b/src/web/src/style.css
@@ -727,6 +727,59 @@ html, body {
     background: var(--bg-hover);
     color: var(--fg-bright);
 }
+.cm-item {
+    position: relative;
+    padding: 5px 12px;
+    padding-right: 24px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.cm-item:hover {
+    background: var(--bg-hover);
+    color: var(--fg-bright);
+}
+.cm-item.has-submenu::after {
+    content: '▶';
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 10px;
+    opacity: 0.7;
+}
+.cm-submenu {
+    position: absolute;
+    left: 100%;
+    top: -5px;
+    display: none;
+    background: var(--bg-context);
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    min-width: 160px;
+    padding: 4px 0;
+    box-shadow: 0 2px 8px var(--shadow);
+}
+.cm-item.has-submenu:hover > .cm-submenu {
+    display: block;
+}
+.cm-submenu.flip-left {
+    left: auto;
+    right: 100%;
+}
+.cm-separator {
+    height: 1px;
+    background: var(--border-strong);
+    margin: 4px 0;
+}
+.cm-swatch {
+    display: inline-block;
+    width: 11px;
+    height: 11px;
+    margin-right: 8px;
+    border: 1px solid var(--border-strong);
+    vertical-align: middle;
+    flex-shrink: 0;
+}
 
 /* Tcl Console */
 .tcl-console {

--- a/src/web/src/tile_generator.cpp
+++ b/src/web/src/tile_generator.cpp
@@ -1393,7 +1393,8 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
     const std::vector<FlightLine>& flight_lines,
     const std::set<uint32_t>* route_guide_net_ids,
     const bool has_visible_layers,
-    const std::set<std::string>& visible_layers) const
+    const std::set<std::string>& visible_layers,
+    const std::vector<ColoredPolygon>& colored_polys) const
 {
   constexpr int kBufferSize = kTileSizeInPixel * kTileSizeInPixel * 4;
   std::vector<unsigned char> image(kBufferSize, 0);  // fully transparent
@@ -1407,7 +1408,7 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
 
   // Short-circuit: if there's nothing to draw, return a blank tile.
   if (highlight_rects.empty() && highlight_polys.empty()
-      && colored_rects.empty() && flight_lines.empty()
+      && colored_rects.empty() && colored_polys.empty() && flight_lines.empty()
       && (!route_guide_net_ids || route_guide_net_ids->empty())) {
     std::vector<unsigned char> png;
     lodepng::encode(png, image, kTileSizeInPixel, kTileSizeInPixel);
@@ -1439,6 +1440,9 @@ std::vector<unsigned char> TileGenerator::generateOverlayTile(
     // Pass empty layer name so all colored rects are drawn regardless of
     // their per-layer tag (the overlay sits above all base layers).
     drawColoredHighlight(image, colored_rects, "", dbu_tile, scale);
+  }
+  if (!colored_polys.empty()) {
+    drawColoredPolygons(image, colored_polys, dbu_tile, scale);
   }
   if (!flight_lines.empty()) {
     drawFlightLines(image, flight_lines, dbu_tile, scale);
@@ -2819,16 +2823,16 @@ static void compositePixel(unsigned char* dst, const unsigned char* src)
   dst[3] = out_a;
 }
 
-void TileGenerator::saveImage(const std::string& filename,
-                              const odb::Rect& region,
-                              const int width_px,
-                              const double dbu_per_pixel,
-                              const TileVisibility& vis) const
+std::vector<unsigned char> TileGenerator::renderImagePng(
+    const odb::Rect& region,
+    const int width_px,
+    const double dbu_per_pixel,
+    const TileVisibility& vis) const
 {
   odb::dbBlock* block = getBlock();
   if (!block) {
     logger_->error(utl::WEB, 20, "No design loaded.");
-    return;
+    return {};
   }
 
   // Determine rendering region (DBU).
@@ -2860,7 +2864,7 @@ void TileGenerator::saveImage(const std::string& filename,
 
   if (img_w <= 0 || img_h <= 0) {
     logger_->error(utl::WEB, 21, "Invalid image dimensions.");
-    return;
+    return {};
   }
 
   // Cap image size at 16k x 16k to prevent excessive memory usage.
@@ -2979,17 +2983,30 @@ void TileGenerator::saveImage(const std::string& filename,
     }
   }
 
-  // Encode to PNG and save.
+  // Encode to PNG.
   std::vector<unsigned char> png_data;
   const unsigned error = lodepng::encode(png_data, final_buf, final_w, final_h);
   if (error) {
     logger_->error(
         utl::WEB, 23, "PNG encode error: {}", lodepng_error_text(error));
+    return {};
+  }
+  return png_data;
+}
+
+void TileGenerator::saveImage(const std::string& filename,
+                              const odb::Rect& region,
+                              const int width_px,
+                              const double dbu_per_pixel,
+                              const TileVisibility& vis) const
+{
+  const std::vector<unsigned char> png_data
+      = renderImagePng(region, width_px, dbu_per_pixel, vis);
+  if (png_data.empty()) {
     return;
   }
   lodepng::save_file(png_data, filename);
-  logger_->info(
-      utl::WEB, 24, "Saved {}x{} image to {}", final_w, final_h, filename);
+  logger_->info(utl::WEB, 24, "Saved image to {}", filename);
 }
 
 std::vector<unsigned char> TileGenerator::renderOverlayPng(
@@ -3583,19 +3600,54 @@ void TileGenerator::drawHighlight(std::vector<unsigned char>& image,
     // Semi-transparent yellow fill
     fillPolygon(image, poly, dbu_tile, scale, fill, /*blend=*/true);
 
-    // Solid yellow border — draw each edge
+    // Solid yellow border — draw each edge, wrapping the last point back to
+    // the first so the outline is closed even if the point list is open.
     const auto& points = poly.getPoints();
     const int n = static_cast<int>(points.size());
-    for (int i = 0; i < n - 1; ++i) {
-      const int px0
-          = static_cast<int>((points[i].x() - dbu_tile.xMin()) * scale);
+    for (int i = 0; i < n; ++i) {
+      const odb::Point& p0 = points[i];
+      const odb::Point& p1 = points[(i + 1) % n];
+      const int px0 = static_cast<int>((p0.x() - dbu_tile.xMin()) * scale);
       const int py0
-          = 255 - static_cast<int>((points[i].y() - dbu_tile.yMin()) * scale);
-      const int px1
-          = static_cast<int>((points[i + 1].x() - dbu_tile.xMin()) * scale);
+          = 255 - static_cast<int>((p0.y() - dbu_tile.yMin()) * scale);
+      const int px1 = static_cast<int>((p1.x() - dbu_tile.xMin()) * scale);
       const int py1
-          = 255
-            - static_cast<int>((points[i + 1].y() - dbu_tile.yMin()) * scale);
+          = 255 - static_cast<int>((p1.y() - dbu_tile.yMin()) * scale);
+      drawLine(image, px0, py0, px1, py1, border);
+    }
+  }
+}
+
+void TileGenerator::drawColoredPolygons(
+    std::vector<unsigned char>& image,
+    const std::vector<ColoredPolygon>& polys,
+    const odb::Rect& dbu_tile,
+    const double scale) const
+{
+  for (const ColoredPolygon& cp : polys) {
+    const odb::Polygon& poly = cp.poly;
+    if (!dbu_tile.overlaps(poly.getEnclosingRect())) {
+      continue;
+    }
+    Color border = cp.color;
+    border.a = 255;
+
+    // Semi-transparent fill in the shape's color.
+    fillPolygon(image, poly, dbu_tile, scale, cp.color, /*blend=*/true);
+
+    // Solid outline — draw each edge, wrapping the last point back to the
+    // first so the outline is closed even if the point list is open.
+    const auto& points = poly.getPoints();
+    const int n = static_cast<int>(points.size());
+    for (int i = 0; i < n; ++i) {
+      const odb::Point& p0 = points[i];
+      const odb::Point& p1 = points[(i + 1) % n];
+      const int px0 = static_cast<int>((p0.x() - dbu_tile.xMin()) * scale);
+      const int py0
+          = 255 - static_cast<int>((p0.y() - dbu_tile.yMin()) * scale);
+      const int px1 = static_cast<int>((p1.x() - dbu_tile.xMin()) * scale);
+      const int py1
+          = 255 - static_cast<int>((p1.y() - dbu_tile.yMin()) * scale);
       drawLine(image, px0, py0, px1, py1, border);
     }
   }

--- a/src/web/src/tile_generator.h
+++ b/src/web/src/tile_generator.h
@@ -58,6 +58,12 @@ struct FlightLine
   Color color;
 };
 
+struct ColoredPolygon
+{
+  odb::Polygon poly;
+  Color color;
+};
+
 struct SelectionResult
 {
   std::any object;  // dbInst*, dbNet*, etc.
@@ -385,11 +391,20 @@ class TileGenerator
       const std::vector<FlightLine>& flight_lines = {},
       const std::set<uint32_t>* route_guide_net_ids = nullptr,
       bool has_visible_layers = false,
-      const std::set<std::string>& visible_layers = {}) const;
+      const std::set<std::string>& visible_layers = {},
+      const std::vector<ColoredPolygon>& colored_polys = {}) const;
   std::vector<unsigned char> generateHeatMapTile(gui::HeatMapDataSource& source,
                                                  int z,
                                                  int x,
                                                  int y) const;
+
+  // Render full design (or region) to PNG bytes.  Works without a running
+  // web server.  region in DBU; if zero-area, defaults to die + 5% margin.
+  // Returns an empty vector on error (no design / invalid dimensions).
+  std::vector<unsigned char> renderImagePng(const odb::Rect& region,
+                                            int width_px,
+                                            double dbu_per_pixel,
+                                            const TileVisibility& vis) const;
 
   // Render full design (or region) to a PNG file.  Works without a running
   // web server.  region in DBU; if zero-area, defaults to die + 5% margin.
@@ -490,6 +505,11 @@ class TileGenerator
                             const std::string& current_layer,
                             const odb::Rect& dbu_tile,
                             double scale) const;
+
+  void drawColoredPolygons(std::vector<unsigned char>& image,
+                           const std::vector<ColoredPolygon>& polys,
+                           const odb::Rect& dbu_tile,
+                           double scale) const;
 
   void drawFlightLines(std::vector<unsigned char>& image,
                        const std::vector<FlightLine>& lines,

--- a/src/web/src/web.cpp
+++ b/src/web/src/web.cpp
@@ -5,6 +5,7 @@
 
 #include <netinet/in.h>
 
+#include <algorithm>
 #include <csignal>
 #include <cstdint>
 #include <cstdlib>
@@ -80,11 +81,115 @@ static std::vector<unsigned char> serialize_response(
 }
 
 //------------------------------------------------------------------------------
-// HTTP request handler (serves embedded static assets)
+// HTTP request handler (serves embedded static assets + image downloads)
 //------------------------------------------------------------------------------
 
+namespace {
+
+// Parse the "k=v&k2=v2" query of a request target into a map.
+std::map<std::string, std::string> parseQuery(std::string_view target)
+{
+  std::map<std::string, std::string> params;
+  const auto qpos = target.find('?');
+  if (qpos == std::string_view::npos) {
+    return params;
+  }
+  const std::string_view qs = target.substr(qpos + 1);
+  std::size_t start = 0;
+  while (start < qs.size()) {
+    std::size_t amp = qs.find('&', start);
+    if (amp == std::string_view::npos) {
+      amp = qs.size();
+    }
+    const std::string_view kv = qs.substr(start, amp - start);
+    const std::size_t eq = kv.find('=');
+    if (eq != std::string_view::npos) {
+      params.emplace(std::string(kv.substr(0, eq)),
+                     std::string(kv.substr(eq + 1)));
+    }
+    start = amp + 1;
+  }
+  return params;
+}
+
+// Parse "x0,y0,x1,y1" (DBU) into a Rect.  Returns false on malformed input.
+bool parseBbox(const std::string& s, odb::Rect& out)
+{
+  int v[4];
+  int idx = 0;
+  std::size_t start = 0;
+  while (idx < 4) {
+    std::size_t comma = s.find(',', start);
+    const std::string tok = s.substr(
+        start, comma == std::string::npos ? std::string::npos : comma - start);
+    try {
+      v[idx++] = std::stoi(tok);
+    } catch (const std::exception&) {
+      return false;
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    start = comma + 1;
+  }
+  if (idx != 4) {
+    return false;
+  }
+  out = odb::Rect(std::min(v[0], v[2]),
+                  std::min(v[1], v[3]),
+                  std::max(v[0], v[2]),
+                  std::max(v[1], v[3]));
+  return true;
+}
+
+// Render the layout image requested by /download/image into `res`.
+void handleImageDownload(const std::shared_ptr<TileGenerator>& generator,
+                         std::string_view target,
+                         http::response<http::string_body>& res)
+{
+  if (!generator) {
+    res.result(http::status::not_found);
+    res.body() = "No design loaded.";
+    return;
+  }
+  const auto params = parseQuery(target);
+  const auto type_it = params.find("type");
+  const std::string type = type_it == params.end() ? "entire" : type_it->second;
+
+  odb::Rect region;  // zero-area => entire die (renderImagePng default)
+  if (type == "visible") {
+    const auto bbox_it = params.find("bbox");
+    if (bbox_it == params.end() || !parseBbox(bbox_it->second, region)) {
+      res.result(http::status::bad_request);
+      res.body() = "Missing or malformed bbox.";
+      return;
+    }
+  }
+
+  // The HTTP route has no access to the WebSocket session's layer
+  // visibility, so render with defaults (all layers visible).
+  const std::vector<unsigned char> png = generator->renderImagePng(
+      region, /*width_px=*/0, /*dbu_per_pixel=*/0, TileVisibility{});
+  if (png.empty()) {
+    res.result(http::status::internal_server_error);
+    res.body() = "Image render failed.";
+    return;
+  }
+
+  const auto fname_it = params.find("filename");
+  const std::string filename
+      = fname_it == params.end() ? "layout.png" : fname_it->second;
+  res.set(http::field::content_type, "image/png");
+  res.set(http::field::content_disposition,
+          "attachment; filename=\"" + filename + "\"");
+  res.body().assign(reinterpret_cast<const char*>(png.data()), png.size());
+}
+
+}  // namespace
+
 static http::response<http::string_body> handle_request(
-    http::request<http::string_body>&& req)
+    http::request<http::string_body>&& req,
+    const std::shared_ptr<TileGenerator>& generator)
 {
   http::response<http::string_body> res{http::status::ok, req.version()};
   res.set(http::field::server, "Boost.Beast Server (C++17)");
@@ -93,17 +198,27 @@ static http::response<http::string_body> handle_request(
   res.set(http::field::access_control_allow_origin, "*");
 
   if (req.method() == http::verb::get) {
-    std::string file_path(req.target());
-    if (file_path == "/") {
-      file_path = "/index.html";
+    std::string target(req.target());
+    // Strip any query string for route matching / asset lookup.
+    std::string path = target;
+    if (const auto qpos = path.find('?'); qpos != std::string::npos) {
+      path.resize(qpos);
     }
-    const auto* asset = findEmbeddedAsset(file_path);
-    if (asset) {
-      res.set(http::field::content_type, asset->content_type);
-      res.body() = std::string(asset->content());
+
+    if (path == "/download/image") {
+      handleImageDownload(generator, target, res);
     } else {
-      res.result(http::status::not_found);
-      res.body() = "Resource not found.";
+      if (path == "/") {
+        path = "/index.html";
+      }
+      const auto* asset = findEmbeddedAsset(path);
+      if (asset) {
+        res.set(http::field::content_type, asset->content_type);
+        res.body() = std::string(asset->content());
+      } else {
+        res.result(http::status::not_found);
+        res.body() = "Resource not found.";
+      }
     }
   } else {
     res.result(http::status::not_found);
@@ -636,10 +751,13 @@ class HttpSession : public std::enable_shared_from_this<HttpSession>
   beast::flat_buffer buffer_;
   std::shared_ptr<http::response<http::string_body>> res_;
   http::request<http::string_body> req_;
+  std::shared_ptr<TileGenerator> generator_;
   utl::Logger* logger_;
 
  public:
-  HttpSession(Tcp::socket&& socket, utl::Logger* logger);
+  HttpSession(Tcp::socket&& socket,
+              std::shared_ptr<TileGenerator> generator,
+              utl::Logger* logger);
 
   void run() { do_read(); }
 
@@ -654,8 +772,12 @@ class HttpSession : public std::enable_shared_from_this<HttpSession>
   void do_close();
 };
 
-HttpSession::HttpSession(Tcp::socket&& socket, utl::Logger* logger)
-    : stream_(std::move(socket)), logger_(logger)
+HttpSession::HttpSession(Tcp::socket&& socket,
+                         std::shared_ptr<TileGenerator> generator,
+                         utl::Logger* logger)
+    : stream_(std::move(socket)),
+      generator_(std::move(generator)),
+      logger_(logger)
 {
 }
 
@@ -692,7 +814,7 @@ void HttpSession::on_read(beast::error_code ec)
   }
 
   res_ = std::make_shared<http::response<http::string_body>>(
-      handle_request(std::move(req_)));
+      handle_request(std::move(req_), generator_));
   do_write();
 }
 
@@ -815,7 +937,8 @@ void DetectSession::on_read(beast::error_code ec)
     websocket_session->run(std::move(req_));
   } else {
     // Regular HTTP - hand off to session with already-read request
-    auto s = std::make_shared<HttpSession>(stream_.release_socket(), logger_);
+    auto s = std::make_shared<HttpSession>(
+        stream_.release_socket(), generator_, logger_);
     s->run_with_request(std::move(req_), std::move(buffer_));
   }
 }


### PR DESCRIPTION
Addresses a portion of https://github.com/The-OpenROAD-Project/OpenROAD/issues/10619

### 2.7 Right-click context menu (layout canvas)
| Feature | GUI | Web | Status |
|---|---|---|---|
| **Select →** Connected Insts / Output / Input / All Nets / All buffer trees | `layoutViewer` | — | ✅ |
| **Highlight →** same + 8-color submenu | yes | — |✅ |
| **Save →** Visible / Entire layout | yes | — | ✅ |
| **Clear →** Selections/Highlights/Rulers/Labels/Focus/Guides/Tracks/All | yes | partial (Clear Rulers in Tools) | ✅ |



### 2.12 Rulers & labels
| Feature | GUI | Web | Status |
|---|---|---|---|
| **Custom labels / text annotations** | `label.{h,cpp}`, `add_label` | — | ✅ |

