### PR TITLE
pad: add custom comparator for GridGraphEdge set to prevent non-determinism

### DIFF
--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -381,7 +381,7 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
   makeGraph();
 
   // Determine access points
-  std::unordered_map<odb::Point, std::set<GridGraphEdge>> remove_edges;
+  std::unordered_map<odb::Point, GridGraphEdgeSet> remove_edges;
   for (auto& [net, iterm_targets] : routing_targets_) {
     for (auto& [iterm, targets] : iterm_targets) {
       for (auto& target : targets) {
@@ -797,7 +797,7 @@ static odb::Point getValidGridPoint(
 }
 
 void RDLRouter::cleanupGraphEdges(
-    const std::unordered_map<odb::Point, std::set<GridGraphEdge>>& edges)
+    const std::unordered_map<odb::Point, GridGraphEdgeSet>& edges)
 {
   if (edges.empty()) {
     return;
@@ -824,7 +824,7 @@ void RDLRouter::cleanupGraphEdges(
 
 void RDLRouter::populateTerminalAccessPoints(
     RouteTarget& target,
-    std::unordered_map<odb::Point, std::set<GridGraphEdge>>& edges) const
+    std::unordered_map<odb::Point, GridGraphEdgeSet>& edges) const
 {
   // determine new access point in graph
   std::set<odb::Point> snap_pts;
@@ -1181,10 +1181,9 @@ bool RDLRouter::is45DegreeEdge(const odb::Point& pt0,
   return RDLRoute::is45DegreeEdge(pt0, pt1);
 }
 
-std::set<GridGraphEdge> RDLRouter::getVertexEdges(
-    const GridGraphVertex& vertex) const
+GridGraphEdgeSet RDLRouter::getVertexEdges(const GridGraphVertex& vertex) const
 {
-  std::set<GridGraphEdge> edges;
+  GridGraphEdgeSet edges;
 
   GridGraph::out_edge_iterator oit, oend;
   std::tie(oit, oend) = boost::out_edges(vertex, graph_);
@@ -1203,7 +1202,7 @@ std::set<GridGraphEdge> RDLRouter::getVertexEdges(
 std::vector<RDLRouter::GridEdge> RDLRouter::commitRoute(
     const std::vector<GridGraphVertex>& route)
 {
-  std::set<GridGraphEdge> edges;
+  GridGraphEdgeSet edges;
   for (const auto& v : route) {
     const auto v_edges = getVertexEdges(v);
     edges.insert(v_edges.begin(), v_edges.end());

--- a/src/pad/src/RDLRouter.cpp
+++ b/src/pad/src/RDLRouter.cpp
@@ -41,6 +41,17 @@ namespace pad {
 
 namespace {
 
+// Order routes by their source terminal id so ripup iteration (and the edge
+// re-add order it drives) is deterministic, not heap-address dependent.
+struct RDLRoutePtrLess
+{
+  bool operator()(const std::shared_ptr<RDLRoute>& lhs,
+                  const std::shared_ptr<RDLRoute>& rhs) const
+  {
+    return lhs->getTerminal()->getId() < rhs->getTerminal()->getId();
+  }
+};
+
 bool compareRouteTargets(const RouteTarget& lhs, const RouteTarget& rhs)
 {
   if (lhs.center.x() != rhs.center.x()) {
@@ -649,7 +660,7 @@ void RDLRouter::route(const std::vector<odb::dbNet*>& nets)
       }
 
       // find routes to ripup
-      std::set<RDLRoutePtr> ripup;
+      std::set<RDLRoutePtr, RDLRoutePtrLess> ripup;
       for (const auto& failed_route : failed) {
         for (const auto& route : routes_) {
           if (!route->isRouted()) {
@@ -1185,15 +1196,11 @@ GridGraphEdgeSet RDLRouter::getVertexEdges(const GridGraphVertex& vertex) const
 {
   GridGraphEdgeSet edges;
 
+  // The graph is undirected, so out_edges already yields every incident edge.
   GridGraph::out_edge_iterator oit, oend;
   std::tie(oit, oend) = boost::out_edges(vertex, graph_);
   for (; oit != oend; oit++) {
     edges.insert(*oit);
-  }
-  GridGraph::in_edge_iterator iit, iend;
-  std::tie(iit, iend) = boost::in_edges(vertex, graph_);
-  for (; iit != iend; iit++) {
-    edges.insert(*iit);
   }
 
   return edges;

--- a/src/pad/src/RDLRouter.h
+++ b/src/pad/src/RDLRouter.h
@@ -74,14 +74,8 @@ struct GridGraphEdgeLess
 {
   bool operator()(const GridGraphEdge& lhs, const GridGraphEdge& rhs) const
   {
-    const auto lhs_lo = std::min(lhs.m_source, lhs.m_target);
-    const auto lhs_hi = std::max(lhs.m_source, lhs.m_target);
-    const auto rhs_lo = std::min(rhs.m_source, rhs.m_target);
-    const auto rhs_hi = std::max(rhs.m_source, rhs.m_target);
-    if (lhs_lo != rhs_lo) {
-      return lhs_lo < rhs_lo;
-    }
-    return lhs_hi < rhs_hi;
+    return std::minmax(lhs.m_source, lhs.m_target)
+           < std::minmax(rhs.m_source, rhs.m_target);
   }
 };
 using GridGraphEdgeSet = std::set<GridGraphEdge, GridGraphEdgeLess>;

--- a/src/pad/src/RDLRouter.h
+++ b/src/pad/src/RDLRouter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <memory>
@@ -66,6 +67,24 @@ using GridWeightMap
     = boost::property_map<GridGraph, boost::edge_weight_t>::type;
 using GridGraphVertex = GridGraph::vertex_descriptor;
 using GridGraphEdge = GridGraph::edge_descriptor;
+
+// Order edges by (source, target) vertex indices; the descriptor's default
+// operator< compares a heap pointer, giving build-dependent iteration.
+struct GridGraphEdgeLess
+{
+  bool operator()(const GridGraphEdge& lhs, const GridGraphEdge& rhs) const
+  {
+    const auto lhs_lo = std::min(lhs.m_source, lhs.m_target);
+    const auto lhs_hi = std::max(lhs.m_source, lhs.m_target);
+    const auto rhs_lo = std::min(rhs.m_source, rhs.m_target);
+    const auto rhs_hi = std::max(rhs.m_source, rhs.m_target);
+    if (lhs_lo != rhs_lo) {
+      return lhs_lo < rhs_lo;
+    }
+    return lhs_hi < rhs_hi;
+  }
+};
+using GridGraphEdgeSet = std::set<GridGraphEdge, GridGraphEdgeLess>;
 
 struct RouteTarget
 {
@@ -213,11 +232,11 @@ class RDLRouter
 
   void populateTerminalAccessPoints(
       RouteTarget& target,
-      std::unordered_map<odb::Point, std::set<GridGraphEdge>>& edges) const;
+      std::unordered_map<odb::Point, GridGraphEdgeSet>& edges) const;
   void cleanupTerminalAccessPoints(odb::dbITerm* iterm,
                                    std::vector<RouteTarget>& targets) const;
   void cleanupGraphEdges(
-      const std::unordered_map<odb::Point, std::set<GridGraphEdge>>& edges);
+      const std::unordered_map<odb::Point, GridGraphEdgeSet>& edges);
   std::set<odb::Point> generateTerminalAccessPoints(const odb::Point& pt,
                                                     bool do_x) const;
   TerminalAccess insertTerminalAccess(const RouteTarget& target,
@@ -227,7 +246,7 @@ class RDLRouter
   odb::PtrMap<odb::dbITerm, std::vector<RouteTarget>> generateRoutingTargets(
       odb::dbNet* net) const;
   odb::dbTechLayer* getOtherLayer(odb::dbTechVia* via) const;
-  std::set<GridGraphEdge> getVertexEdges(const GridGraphVertex& vertex) const;
+  GridGraphEdgeSet getVertexEdges(const GridGraphVertex& vertex) const;
 
   void buildIntialRouteSet();
   int reportFailedRoutes(

--- a/src/pad/test/rdl_route_failed.ok
+++ b/src/pad/test/rdl_route_failed.ok
@@ -15,7 +15,7 @@
 [INFO PAD-0037] End of routing iteration 7: 89.5% complete
 [INFO PAD-0037] End of routing iteration 8: 89.0% complete
 [INFO PAD-0037] End of routing iteration 9: 88.8% complete
-[INFO PAD-0037] End of routing iteration 10: 88.8% complete
+[INFO PAD-0037] End of routing iteration 10: 88.4% complete
 [WARNING PAD-0006] Failed to route the following 17 nets:
   DVDD
     BUMP_11_3/PAD -> u_v18_6/DVDD, u_v18_7/DVDD, u_v18_5/DVDD, u_v18_4/DVDD, u_v18_8/DVDD, ... (67 possible terminals)
@@ -27,6 +27,7 @@
     BUMP_15_11/PAD -> u_vzz_15/DVSS, u_vzz_16/DVSS, u_vzz_14/DVSS, u_vzz_13/DVSS, u_vzz_12/DVSS, ... (67 possible terminals)
     BUMP_15_7/PAD -> u_vzz_12/DVSS, u_vzz_13/DVSS, u_vzz_11/DVSS, u_vzz_14/DVSS, u_vzz_10/DVSS, ... (67 possible terminals)
     BUMP_1_9/PAD -> u_vzz_29/DVSS, u_vzz_30/DVSS, u_vzz_28/DVSS, u_vzz_31/DVSS, u_vzz_27/DVSS, ... (67 possible terminals)
+    BUMP_8_15/PAD -> u_vzz_21/DVSS, u_vzz_22/DVSS, u_vzz_20/DVSS, u_vzz_23/DVSS, u_vzz_24/DVSS, ... (67 possible terminals)
   VSS
     BUMP_14_9/PAD -> u_vss_6/VSS, u_vss_5/VSS, u_vss_7/VSS, u_vss_4/VSS, u_vss_8/VSS, ... (33 possible terminals)
     BUMP_16_6/PAD -> u_vss_5/VSS, u_vss_6/VSS, u_vss_4/VSS, u_vss_7/VSS, u_vss_3/VSS, ... (33 possible terminals)

--- a/src/pad/test/rdl_route_failed.ok
+++ b/src/pad/test/rdl_route_failed.ok
@@ -10,54 +10,45 @@
 [INFO PAD-0037] End of routing iteration 2: 85.4% complete
 [INFO PAD-0037] End of routing iteration 3: 81.9% complete
 [INFO PAD-0037] End of routing iteration 4: 84.4% complete
-[INFO PAD-0037] End of routing iteration 5: 89.0% complete
-[INFO PAD-0037] End of routing iteration 6: 89.9% complete
-[INFO PAD-0037] End of routing iteration 7: 89.5% complete
-[INFO PAD-0037] End of routing iteration 8: 89.0% complete
-[INFO PAD-0037] End of routing iteration 9: 88.8% complete
-[INFO PAD-0037] End of routing iteration 10: 88.4% complete
-[WARNING PAD-0006] Failed to route the following 17 nets:
+[INFO PAD-0037] End of routing iteration 5: 89.2% complete
+[INFO PAD-0037] End of routing iteration 6: 90.1% complete
+[INFO PAD-0037] End of routing iteration 7: 90.3% complete
+[INFO PAD-0037] End of routing iteration 8: 90.3% complete
+[INFO PAD-0037] End of routing iteration 9: 89.2% complete
+[INFO PAD-0037] End of routing iteration 10: 90.3% complete
+[WARNING PAD-0006] Failed to route the following 13 nets:
   DVDD
     BUMP_11_3/PAD -> u_v18_6/DVDD, u_v18_7/DVDD, u_v18_5/DVDD, u_v18_4/DVDD, u_v18_8/DVDD, ... (67 possible terminals)
     BUMP_16_11/PAD -> u_v18_15/DVDD, u_v18_16/DVDD, u_v18_14/DVDD, u_v18_13/DVDD, u_v18_12/DVDD, ... (67 possible terminals)
     BUMP_1_13/PAD -> u_v18_26/DVDD, u_v18_27/DVDD, u_v18_28/DVDD, u_v18_25/DVDD, u_v18_29/DVDD, ... (67 possible terminals)
-    BUMP_4_1/PAD -> u_v18_1/DVDD, u_v18_2/DVDD, u_v18_0/DVDD, u_v18_3/DVDD, u_v18_4/DVDD, ... (67 possible terminals)
   DVSS
-    BUMP_0_8/PAD -> u_vzz_30/DVSS, u_vzz_29/DVSS, u_vzz_31/DVSS, u_vzz_32/DVSS, u_vzz_28/DVSS, ... (67 possible terminals)
     BUMP_15_11/PAD -> u_vzz_15/DVSS, u_vzz_16/DVSS, u_vzz_14/DVSS, u_vzz_13/DVSS, u_vzz_12/DVSS, ... (67 possible terminals)
     BUMP_15_7/PAD -> u_vzz_12/DVSS, u_vzz_13/DVSS, u_vzz_11/DVSS, u_vzz_14/DVSS, u_vzz_10/DVSS, ... (67 possible terminals)
     BUMP_1_9/PAD -> u_vzz_29/DVSS, u_vzz_30/DVSS, u_vzz_28/DVSS, u_vzz_31/DVSS, u_vzz_27/DVSS, ... (67 possible terminals)
-    BUMP_8_15/PAD -> u_vzz_21/DVSS, u_vzz_22/DVSS, u_vzz_20/DVSS, u_vzz_23/DVSS, u_vzz_24/DVSS, ... (67 possible terminals)
+  VDD
+    BUMP_11_12/PAD -> u_vdd_9/VDD, u_vdd_pll/VDD, u_vdd_8/VDD, u_vdd_7/VDD, u_vdd_10/VDD, ... (33 possible terminals)
+    BUMP_1_10/PAD -> u_vdd_13/VDD, u_vdd_14/VDD, u_vdd_12/VDD, u_vdd_15/VDD, u_vdd_11/VDD, ... (33 possible terminals)
   VSS
+    BUMP_0_10/PAD -> u_vss_13/VSS, u_vss_14/VSS, u_vss_12/VSS, u_vss_15/VSS, u_vss_11/VSS, ... (33 possible terminals)
     BUMP_14_9/PAD -> u_vss_6/VSS, u_vss_5/VSS, u_vss_7/VSS, u_vss_4/VSS, u_vss_8/VSS, ... (33 possible terminals)
     BUMP_16_6/PAD -> u_vss_5/VSS, u_vss_6/VSS, u_vss_4/VSS, u_vss_7/VSS, u_vss_3/VSS, ... (33 possible terminals)
+  p_bsg_tag_data_o
+    BUMP_2_10/PAD -> u_bsg_tag_data_o/PAD
   p_clk_A_i
     BUMP_7_13/PAD -> u_clk_A_i/PAD
-  p_clk_async_reset_i
-    BUMP_9_14/PAD -> u_clk_async_reset_i/PAD
   p_co2_v_o
     BUMP_0_13/PAD -> u_co2_v_o/PAD
-  p_ddr_addr_15_o
-    BUMP_4_0/PAD -> u_ddr_addr_15_o/PAD
   p_ddr_addr_2_o
     BUMP_8_2/PAD -> u_ddr_addr_2_o/PAD
-  p_ddr_addr_6_o
-    BUMP_7_0/PAD -> u_ddr_addr_6_o/PAD
-  p_ddr_addr_7_o
-    BUMP_7_1/PAD -> u_ddr_addr_7_o/PAD
+  p_ddr_addr_4_o
+    BUMP_7_4/PAD -> u_ddr_addr_4_o/PAD
   p_ddr_ck_n_o
     BUMP_11_4/PAD -> u_ddr_ck_n_o/PAD
-  p_ddr_dq_0_io
-    BUMP_3_7/PAD -> u_ddr_dq_0_io/PAD
-  p_ddr_dq_11_io
-    BUMP_4_5/PAD -> u_ddr_dq_11_io/PAD
-  p_ddr_dq_13_io
-    BUMP_3_5/PAD -> u_ddr_dq_13_io/PAD
-  p_ddr_dq_2_io
-    BUMP_1_8/PAD -> u_ddr_dq_2_io/PAD
+  p_ddr_dq_7_io
+    BUMP_4_10/PAD -> u_ddr_dq_7_io/PAD
   p_ddr_dq_8_io
     BUMP_0_4/PAD -> u_ddr_dq_8_io/PAD
   p_ddr_dq_9_io
     BUMP_1_4/PAD -> u_ddr_dq_9_io/PAD
-[ERROR PAD-0007] Failed to route 17 nets.
+[ERROR PAD-0007] Failed to route 13 nets.
 pass

--- a/src/pad/test/rdl_route_max_iterations.ok
+++ b/src/pad/test/rdl_route_max_iterations.ok
@@ -13,7 +13,6 @@
 [WARNING PAD-0006] Failed to route the following 18 nets:
   DVDD
     BUMP_11_13/PAD -> u_v18_19/DVDD, u_v18_20/DVDD, u_v18_18/DVDD, u_v18_21/DVDD, u_v18_17/DVDD, ... (67 possible terminals)
-    BUMP_7_3/PAD -> u_v18_3/DVDD, u_v18_4/DVDD, u_v18_2/DVDD, u_v18_5/DVDD, u_v18_1/DVDD, ... (67 possible terminals)
   VSS
     BUMP_0_7/PAD -> u_vss_14/VSS, u_vss_13/VSS, u_vss_15/VSS, u_vss_12/VSS, u_vss_0/VSS, ... (33 possible terminals)
     BUMP_10_13/PAD -> u_vss_9/VSS, u_vss_pll/VSS, u_vss_10/VSS, u_vss_8/VSS, u_vss_7/VSS, ... (33 possible terminals)


### PR DESCRIPTION
## Summary
RDL routing was nondeterministic across builds, causing `pad.rdl_route_failed.tcl`
to fail intermittently in CI (only the merge pipeline) while passing locally and
being stable within any single binary.

The router ordered graph data by heap addresses in two places:
- `std::set<GridGraphEdge>` — a boost `adjacency_list` edge descriptor's default
  `operator<` compares its internal edge-property pointer (a heap address).
- `std::set<RDLRoutePtr>` (the ripup set) — `std::shared_ptr` compares by pointer
  value.

Both orders drive the sequence in which edges are removed and re-added to the
graph (`commitRoute`/`uncommitRoute`/access-point teardown). Boost A* walks a
vertex's incident edges in adjacency-list (insertion) order, so the heap layout
— which varies by build (compiler, allocator, LTO, CI node) — changed A*
equal-cost tie-breaks and therefore the final set of unroutable nets. Within one
binary ASLR shifts all addresses equally, preserving relative order, which is
why it was stable locally but flaky across CI builds.

The fix orders both by stable integer keys:
- edges by their `(source, target)` vertex indices (`GridGraphEdgeLess` /
  `GridGraphEdgeSet`), and
- ripup routes by their source terminal id (`RDLRoutePtrLess`).

It also drops a redundant `in_edges` traversal in `getVertexEdges` (for an
undirected graph `out_edges` already yields every incident edge).

## Type of Change
- Bug fix

## Impact
This is a result-changing deterministic policy, not a no-op cleanup. It replaces
an arbitrary, build-dependent (heap-address) ordering with an arbitrary but
stable one, so routing converges on a single canonical result instead of a
layout-dependent one. As a consequence two congested-case goldens change
(`rdl_route_failed`: 17 -> 13 reported unroutable nets; `rdl_route_max_iterations`:
one fewer). The chosen ordering is deterministic but is not selected for routing
quality; the QoR shift is incidental. All geometry (`defok`) goldens are
unaffected.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass (full `pad` suite on gcc; both
      changed tests stable across repeated runs).
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

## Related Issues
N/A