### PR TITLE
bazel: enable additional mem safety compiler checks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -50,6 +50,16 @@ build  --cxxopt=-fexceptions    --host_cxxopt=-fexceptions
 build --copt "-Wall"               --host_copt "-Wall"
 build --copt "-Wextra"             --host_copt "-Wextra"
 
+# Treat specific warnings as errors
+build --copt "-Werror=array-bounds"               --host_copt "-Werror=array-bounds"
+build --copt "-Werror=dangling"                   --host_copt "-Werror=dangling"
+build --copt "-Werror=dangling-assignment"        --host_copt "-Werror=dangling-assignment"
+build --copt "-Werror=dangling-assignment-gsl"    --host_copt "-Werror=dangling-assignment-gsl"
+build --copt "-Werror=dangling-field"             --host_copt "-Werror=dangling-field"
+build --copt "-Werror=dangling-gsl"               --host_copt "-Werror=dangling-gsl"
+build --copt "-Werror=fortify-source"             --host_copt "-Werror=fortify-source"
+build --copt "-Werror=return-stack-address"       --host_copt "-Werror=return-stack-address"
+
 # ... and disable the warnings we're not interested in.
 build --copt "-Wno-sign-compare"          --host_copt "-Wno-sign-compare"
 build --copt "-Wno-unused-parameter"      --host_copt "-Wno-unused-parameter"
@@ -73,7 +83,6 @@ build --copt "-Wno-cast-function-type-mismatch"  --host_copt "-Wno-cast-function
 build --copt "-Wno-unused-but-set-variable"  --host_copt "-Wno-unused-but-set-variable"
 build --cxxopt "-Wno-deprecated-copy"  --host_cxxopt "-Wno-deprecated-copy"
 build --cxxopt "-Wno-deprecated-copy-with-user-provided-copy"  --host_cxxopt "-Wno-deprecated-copy-with-user-provided-copy"
-build --cxxopt "-Wno-dangling"  --host_cxxopt "-Wno-dangling"
 
 # For 3rd party code: Disable warnings entirely.
 # They are not actionable and just create noise.

--- a/src/dbSta/src/dbSta.cc
+++ b/src/dbSta/src/dbSta.cc
@@ -1602,7 +1602,7 @@ void dbSta::dumpModInstGraphConnections(const char* mod_inst_name,
 
         bool is_external = false;
         if (from_pin) {
-          std::string_view pin_name = network()->name(from_pin);
+          std::string pin_name = network()->name(from_pin);
           std::string mod_prefix = db_mod_inst->getName();
           mod_prefix += "/";  // e.g., "_202_/"
           if (!pin_name.starts_with(mod_prefix)) {


### PR DESCRIPTION
## Type of Change
- New feature

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**

## Related Issues
[Link issues here]
