### PR TITLE
odb: initialize all tables in _dbDatabase::clear() constructor

### DIFF
--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -609,7 +609,6 @@ _dbDatabase::_dbDatabase(_dbDatabase* /* unused: db */, int id)
   schema_major_ = kSchemaMajor;
   schema_minor_ = kSchemaMinor;
   master_id_ = 0;
-  logger_ = nullptr;
   unique_id_ = id;
   dbu_per_micron_ = 0;
   hierarchy_ = false;

--- a/src/odb/src/db/dbDatabase.cpp
+++ b/src/odb/src/db/dbDatabase.cpp
@@ -614,8 +614,57 @@ _dbDatabase::_dbDatabase(_dbDatabase* /* unused: db */, int id)
   dbu_per_micron_ = 0;
   hierarchy_ = false;
 
+  alignment_marker_rule_tbl_ = new dbTable<_dbAlignmentMarkerRule>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbAlignmentMarkerRuleObj);
   chip_tbl_ = new dbTable<_dbChip, 2>(
       this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbChipObj);
+  chip_hash_.setTable(chip_tbl_);
+  prop_tbl_ = new dbTable<_dbProperty>(
+      this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbPropertyObj);
+  chip_inst_tbl_ = new dbTable<_dbChipInst>(
+      this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbChipInstObj);
+  chip_region_inst_tbl_ = new dbTable<_dbChipRegionInst>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbChipRegionInstObj);
+  chip_conn_tbl_ = new dbTable<_dbChipConn>(
+      this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbChipConnObj);
+  chip_bump_inst_tbl_
+      = new dbTable<_dbChipBumpInst>(this,
+                                     this,
+                                     (GetObjTbl_t) &_dbDatabase::getObjectTable,
+                                     dbChipBumpInstObj);
+  chip_net_tbl_ = new dbTable<_dbChipNet>(
+      this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbChipNetObj);
+  unfolded_chip_inst_tbl_ = new dbTable<_dbUnfoldedChipInst>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbUnfoldedChipInstObj);
+  unfolded_chip_region_inst_tbl_ = new dbTable<_dbUnfoldedChipRegionInst>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbUnfoldedChipRegionInstObj);
+  unfolded_chip_bump_inst_tbl_ = new dbTable<_dbUnfoldedChipBumpInst>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbUnfoldedChipBumpInstObj);
+  unfolded_chip_conn_tbl_ = new dbTable<_dbUnfoldedChipConn>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbUnfoldedChipConnObj);
+  unfolded_chip_net_tbl_ = new dbTable<_dbUnfoldedChipNet>(
+      this,
+      this,
+      (GetObjTbl_t) &_dbDatabase::getObjectTable,
+      dbUnfoldedChipNetObj);
 
   gds_lib_tbl_ = new dbTable<_dbGDSLib, 2>(
       this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbGdsLibObj);
@@ -625,9 +674,6 @@ _dbDatabase::_dbDatabase(_dbDatabase* /* unused: db */, int id)
 
   lib_tbl_ = new dbTable<_dbLib>(
       this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbLibObj);
-
-  prop_tbl_ = new dbTable<_dbProperty>(
-      this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable, dbPropertyObj);
 
   name_cache_ = new _dbNameCache(
       this, this, (GetObjTbl_t) &_dbDatabase::getObjectTable);


### PR DESCRIPTION
## Summary
Fixes a latent bug in `_dbDatabase::_dbDatabase(_dbDatabase*, int id)` — the placement-new constructor used by `dbDatabase::clear()` — that only allocated a subset of the tables that `~_dbDatabase` deletes. After `clear()`, the remaining table pointers held dangling values from the just-destructed object, and any iterator built against them (`chip_inst_itr_`, `chip_region_inst_itr_`, `chip_conn_itr_`, `chip_bump_inst_itr_`, `chip_net_itr_`, `unfolded_region_itr_`, `unfolded_bump_itr_`) dereferenced uninitialized memory.


## Type of Change
- Bug fix

## Impact
- `dbDatabase::clear()` is now safe to call: after the destructor runs and the placement-new constructor reconstructs the object, all tables the destructor expects are allocated, and all iterator pointers reference live tables.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [x] **I have signed my commits (DCO).**
