### PR TITLE
rsz: drop stale STA search state after repair_timing (#10210)

### DIFF
--- a/src/dbSta/test/cpp/TestDbSta.cc
+++ b/src/dbSta/test/cpp/TestDbSta.cc
@@ -264,7 +264,8 @@ TEST_F(TestDbSta, ReassociateModITermPin)
   db_network_->checkAxioms();
 }
 
-// Regression for #10210 (stale Path* dereference in rsz).
+// Regression for #10210 (stale Path* dereference in rsz) and the rsz-side
+// resetSearchAfterRepair() mitigation.
 //
 // Topology (TestDbSta_StalePrevPath.v):
 //   clk -> b1(BUF) -> inv1(INV) -> nd1(NAND2) -> out1
@@ -277,6 +278,9 @@ TEST_F(TestDbSta, ReassociateModITermPin)
 //   4. Assert the captured Path's prev slot has been recycled: pin()
 //      decodes to data that belongs to a different instance than nd1's
 //      real input.
+//   5. Apply the rsz mitigation (Resizer::resetSearchAfterRepair) and assert a
+//      fresh worst-path lookup is clean -- every node's vertex resolves, so no
+//      recycled slot survives for CheckCrpr::findCrpr to walk.
 TEST_F(TestDbSta, StalePrevPath)
 {
   const auto* test_info = testing::UnitTest::GetInstance()->current_test_info();
@@ -329,6 +333,21 @@ TEST_F(TestDbSta, StalePrevPath)
   EXPECT_NE(pre_pin_name, post_pin_name)
       << "but slot content should differ after free+reuse. before="
       << pre_pin_name << " after=" << post_pin_name;
+
+  // 5. rsz's #10210 mitigation: repair_timing runs resetSearchAfterRepair() at
+  //    its end.  Dropping the interned search state must make a fresh
+  //    worst-path lookup clean again -- every node's vertex resolves, so no
+  //    recycled slot survives for CheckCrpr::findCrpr to walk.
+  resizer_.resetSearchAfterRepair();
+  Path* fixed_path = sta_->vertexWorstArrivalPath(
+      sta_->ensureGraph()->pinDrvrVertex(network->findPin(nd1, "ZN")),
+      MinMax::max());
+  ASSERT_NE(fixed_path, nullptr);
+  EXPECT_EQ(network->pathName(fixed_path->pin(sta_.get())), "nd1/ZN");
+  for (const Path* p = fixed_path; p != nullptr; p = p->prevPath()) {
+    EXPECT_NE(p->vertex(sta_.get()), nullptr)
+        << "reset left a stale path node for findCrpr to walk";
+  }
 }
 
 }  // namespace sta

--- a/src/rsz/include/rsz/Resizer.hh
+++ b/src/rsz/include/rsz/Resizer.hh
@@ -379,6 +379,11 @@ class Resizer : public sta::dbStaState, public sta::dbNetworkObserver
                   int max_passes);
   int holdBufferCount() const;
 
+  // Drop interned STA search state and recompute timing so a stale CRPR clock
+  // path left by incremental repairs is not walked later (#10210 workaround;
+  // graph/parasitics/delays kept). See the definition.
+  void resetSearchAfterRepair();
+
   ////////////////////////////////////////////////////////////////
   bool recoverPower(float recover_power_percent,
                     bool match_cell_footprint,

--- a/src/rsz/src/Resizer.cc
+++ b/src/rsz/src/Resizer.cc
@@ -5049,6 +5049,20 @@ int Resizer::holdBufferCount() const
   return repair_hold_->holdBufferCount();
 }
 
+void Resizer::resetSearchAfterRepair()
+{
+  // Workaround for #10210; the root fix belongs in OpenSTA. repair_timing's
+  // incremental updates recycle the per-vertex Path arena, but a CRPR clock
+  // path cached in an interned ClkInfo/Tag keeps a raw prev_path_ into the
+  // freed slot, so a later CheckCrpr::findCrpr (e.g. report_metrics) walks a
+  // dangling chain and aborts. Drop the interned search state so the next
+  // analysis rebuilds clean; graph/parasitics/delays are kept, only arrivals
+  // are recomputed. Proper fix: findCrpr should re-resolve clock-path nodes
+  // from stable graph ids, not raw prev_path_. TODO(#10210): remove when fixed.
+  search_->clear();
+  sta_->updateTiming(/*full=*/true);
+}
+
 ////////////////////////////////////////////////////////////////
 bool Resizer::recoverPower(float recover_power_percent,
                            bool match_cell_footprint,

--- a/src/rsz/src/Resizer.i
+++ b/src/rsz/src/Resizer.i
@@ -436,6 +436,14 @@ repair_hold_pin(Pin *end_pin,
                       max_buffer_percent, max_passes);
 }
 
+void
+reset_search_after_repair()
+{
+  ensureLinked();
+  Resizer *resizer = getResizer();
+  resizer->resetSearchAfterRepair();
+}
+
 int
 hold_buffer_count()
 {

--- a/src/rsz/src/Resizer.tcl
+++ b/src/rsz/src/Resizer.tcl
@@ -395,7 +395,14 @@ proc repair_timing { args } {
     }
   }
 
-  return [expr $recovered_power || $repaired_setup || $repaired_hold]
+  set repaired [expr $recovered_power || $repaired_setup || $repaired_hold]
+  if { $repaired } {
+    # Workaround for #10210: incremental repairs can leave a stale CRPR clock
+    # path that crashes a later report; drop the search state so it rebuilds
+    # clean. Remove when fixed in OpenSTA. See Resizer::resetSearchAfterRepair.
+    rsz::reset_search_after_repair
+  }
+  return $repaired
 }
 
 ################################################################


### PR DESCRIPTION
## Summary

On some designs `repair_timing` makes a later `report_metrics` abort
deterministically (public issue #10210). Root cause is in **OpenSTA**: a CRPR
clock path cached in an interned `ClkInfo`/`Tag` keeps a **raw `prev_path_`**
into the per-vertex `Path` arena, which `repair_timing`'s incremental updates
free and recycle — leaving a dangling pointer that `CheckCrpr::findCrpr` later
walks and dereferences out of bounds. PR #3343 fixed four rsz *move* consumers
via `prevArc()`; CRPR walks the prev-path **chain**, so it is the remaining
unfixed consumer (the single-hop `prevArc` trick does not apply).

This PR is an **OpenROAD-side mitigation** — the root fix belongs in OpenSTA.
At the end of the `repair_timing` command, once a repair has run, it drops the
interned search state so nothing stale survives into the next analysis.
`TODO(#10210)` marks it for removal once OpenSTA stops dangling persisted CRPR
paths.

## Mechanism

A cached pointer outlives the memory slot it points at:

```mermaid
flowchart TD
    A["Step 1 — repair_timing caches a clock-path pointer to slot A (valid)"]
    B["Step 2 — repair frees slot A, then reuses it for a different path"]
    C["Step 3 — the cached pointer still points at slot A, now garbage (dangling)"]
    D["Step 4 — report_metrics follows the pointer, reads garbage, crashes"]
    A --> B --> C --> D
```

In code: the cached path lives in an interned `ClkInfo`/`Tag` that **persists**
across updates. During `repair_timing`, `Search::setVertexArrivals` calls
`Vertex::deletePaths()` + `makePaths()`, which frees and recycles the slot the
cached `prev_path_` points at — but `prev_path_` is never fixed up. A later
`CheckCrpr::findCrpr` walks that chain and `Path::vertex()` indexes
`ObjectTable<Edge>` out of bounds.

### Crash stack

```mermaid
flowchart TD
    A["report_metrics / report_checks"] --> B["Search::findPathEnds"]
    B --> C["latch endpoint → Latches::latchBorrowInfo"]
    C --> D["CheckCrpr::checkCrpr → findCrpr"]
    D -->|walk prev_path_ chain| E["Path::vertex()"]
    E --> F["graph edge(prev_edge_id_) — stale id"]
    F --> G["ObjectTable::pointer → blocks_[blk_idx]"]
    G -->|blk_idx out of range| H["abort (SIGABRT / SIGSEGV)"]
```

## Fix

`Resizer::resetSearchAfterRepair()` = `Search::clear()` (drop interned
tags / paths / path groups) + `updateTiming(full)`, called at the end of the
`repair_timing` command when a repair actually happened. Graph, parasitics and
arc delays are preserved; only arrivals are recomputed. rsz cannot surgically
purge just the stale clock paths, so it drops all interned search state and lets
the next analysis rebuild from scratch.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Impact

- Prevents a deterministic abort in `report_metrics`/`report_checks` after
  `repair_timing` on affected designs.
- No change to timing results: the reset rebuilds the same arrivals from the
  current netlist; it only discards stale interned search state.

### Runtime impact (measured)

The reset adds one from-scratch arrival recompute per `repair_timing`
invocation that actually repaired. `Search::clear()` itself is negligible; the
cost is arrival re-propagation — graph, parasitics and arc delays are preserved,
so delay calculation is **not** re-run. Measured on a customer design
(188,731 instances) at global route:

| measurement | time |
|---|---|
| `resetSearchAfterRepair()`, 2 trials | 1.21 s / 1.21 s |
| ref: cold `find_timing` (delays + arrivals) | 5 s |
| ref: `estimate_parasitics -global_routing` | 10 s |
| `repair_timing` command total (reset included) | 267 s |
| whole global-route step | 17.5 min |

So the reset is ~0.45% of the `repair_timing` command and ~0.1% of the
global-route step. It fired once here (recover_power was a no-op). Across a full
flow `repair_timing` runs at a few stages (post-place / CTS / global route), so
the cumulative cost is a handful of seconds — negligible against repair and
routing runtime. A clean with/without A/B is not possible: the unfixed binary
aborts in `report_metrics` before the step completes.

## Verification

- Reproduced the abort on a customer post-CTS design at global route
  (`report_metrics` after `repair_timing`); with this change the step completes
  cleanly — `findPathEnds` enumerates all endpoints with no crash.
- Unit test `TestDbSta.StalePrevPath` extended: it reproduces the free+recycle
  staleness and then asserts `resetSearchAfterRepair()` rebuilds a clean, fully
  walkable search (every prev-path node's vertex resolves).
- `rsz` regression suite: 85/85 pass.
- `clang-format` / `tclint` / `tclfmt` clean.

## Related Issues

- Public issue The-OpenROAD-Project/OpenROAD#10210
- Related (merged) PR #3343 — fixed the rsz move consumers via `prevArc()`
