### PR TITLE
grt: avoid using layers below min routing layer on CUGR

### DIFF
--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -1194,8 +1194,10 @@ void CUGR::saveCongestion()
 
   // Emit one marker per congested 3D edge, tagged with its routing
   // layer. Comment carries capacity/usage/congestion and the source of
-  // the congestion (wire segments, via stubs, or both).
-  for (int l = 0; l < num_layers; l++) {
+  // the congestion (wire segments, via stubs, or both). Skip sub-min
+  // layers: their 0-capacity edges carry only pin-access via demand and
+  // would otherwise emit false congestion markers.
+  for (int l = constants_.min_routing_layer; l < num_layers; l++) {
     const int direction = grid_graph_->getLayerDirection(l);
     odb::dbTechLayer* db_layer = tech->findRoutingLayer(l + 1);
     const int x_max = (direction == MetalLayer::H) ? x_size - 1 : x_size;

--- a/src/grt/src/cugr/src/CUGR.cpp
+++ b/src/grt/src/cugr/src/CUGR.cpp
@@ -898,7 +898,11 @@ void CUGR::updateDbCongestion()
   db_gcell->addGridPatternY(y_corner, y_size, gridline_size);
 
   odb::dbTech* db_tech = db_->getTech();
-  for (int layer = 0; layer < grid_graph_->getNumLayers(); layer++) {
+  // Skip sub-min layers: they hold no routing wire and their 0-capacity edges
+  // would otherwise export as fully-blocked cells.
+  for (int layer = constants_.min_routing_layer;
+       layer < grid_graph_->getNumLayers();
+       layer++) {
     odb::dbTechLayer* db_layer = db_tech->findRoutingLayer(layer + 1);
     if (db_layer == nullptr) {
       continue;

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -98,6 +98,11 @@ GridGraph::GridGraph(const Design* design,
       }
     }
 
+    // Layers below min_routing_layer are not routable; leave capacity 0.
+    if (layer_index < constants_.min_routing_layer) {
+      continue;
+    }
+
     // Initialize edges' capacity to the number of tracks
     if (direction == MetalLayer::V) {
       for (size_t x = 0; x < x_size_; x++) {
@@ -116,10 +121,13 @@ GridGraph::GridGraph(const Design* design,
     }
   }
 
-  // Deduct obstacles usage for layers EXCEPT Metal 1
+  // Deduct obstacles usage for routable layers (skip any layer below
+  // min_routing_layer, whose capacity is held at 0).
   std::vector<std::vector<BoxT>> obstacles(num_layers_);
   design->getAllObstacles(obstacles, true);
-  for (int layer_index = 1; layer_index < num_layers_; layer_index++) {
+  for (int layer_index = std::max(1, constants_.min_routing_layer);
+       layer_index < num_layers_;
+       layer_index++) {
     const MetalLayer& layer = design->getLayer(layer_index);
     const int direction = layer.getDirection();
     const int n_grids = gridlines_[1 - direction].size() - 1;
@@ -689,6 +697,14 @@ void GridGraph::commitWire(const int layer_index,
                            const bool rip_up,
                            const double net_factor)
 {
+  // Wire must never land below min_routing_layer.
+  if (layer_index < constants_.min_routing_layer) {
+    logger_->error(utl::GRT,
+                   307,
+                   "Wire committed on layer {} below min routing layer {}.",
+                   layer_names_[layer_index],
+                   layer_names_[constants_.min_routing_layer]);
+  }
   const int direction = layer_directions_[layer_index];
   const int edge_length = getEdgeLength(direction, lower[direction]);
   if (rip_up) {

--- a/src/grt/src/cugr/src/GridGraph.cpp
+++ b/src/grt/src/cugr/src/GridGraph.cpp
@@ -308,6 +308,12 @@ void GridGraph::computeCongestionInformation()
     CapacityT overflow_sum = 0;
     CapacityT max_overflow = 0;
 
+    // Sub-min layers hold no routing wire, only pin-access via demand on
+    // 0-capacity edges.
+    if (layer_index < constants_.min_routing_layer) {
+      continue;
+    }
+
     auto accumulate = [&](int x, int y) {
       const auto& edge = graph_edges_[layer_index][x][y];
       cap_sum += edge.capacity;

--- a/src/grt/test/clock_route_cugr.ok
+++ b/src/grt/test/clock_route_cugr.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555         27555          0.00%
 met2       Vertical        21571         21571          0.00%
 met3       Horizontal      14023         14023          0.00%
@@ -47,14 +47,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             3            0.01%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1             27555            74            0.27%             0 /  0 /  0
 met2             21571            63            0.29%             0 /  0 /  0
 met3             14023            25            0.18%             0 /  0 /  0
 met4             10804            13            0.12%             0 /  0 /  0
 met5              3108             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            98632           178            0.18%             0 /  0 /  0
+Total            77061           175            0.23%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/clock_route_cugr2.ok
+++ b/src/grt/test/clock_route_cugr2.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -47,14 +47,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             3            0.01%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            31            0.56%             0 /  0 /  0
 met2              6471            65            1.00%             0 /  0 /  0
 met3              7012            75            1.07%             0 /  0 /  0
 met4              5402            16            0.30%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           190            0.40%             0 /  0 /  0
+Total            25950           187            0.72%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/critical_nets_percentage_cugr.ok
+++ b/src/grt/test/critical_nets_percentage_cugr.ok
@@ -29,7 +29,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        25000         25000          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      30634          6127          80.00%
 met2       Vertical        25000          5000          80.00%
 met3       Horizontal      16240          3248          80.00%
@@ -56,14 +56,14 @@ Bottleneck:            (1, 24, 29)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              25000            39            0.16%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              6127          1012           16.52%             1 /  0 / 29
 met2              5000          1043           20.86%             0 /  1 / 19
 met3              3248           560           17.24%             1 /  0 / 21
 met4              2496           191            7.65%             0 /  1 /  1
 met5              1640             6            0.37%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            43511          2851            6.55%             2 /  2 / 70
+Total            18511          2812           15.19%             2 /  2 / 70
 
 [INFO GRT-0018] Total wirelength: 24148 um
 [INFO GRT-0014] Routed nets: 348

--- a/src/grt/test/cugr_adjustment1.ok
+++ b/src/grt/test/cugr_adjustment1.ok
@@ -32,7 +32,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480          4896          80.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918          5375          70.00%
 metal3     Horizontal      24480         12240          50.00%
 metal4     Vertical        12172          6086          50.00%
@@ -55,7 +55,7 @@ Bottleneck:            (8, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1            4896             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2            5375           538           10.01%             0 /  0 /  0
 metal3           12240          1260           10.29%             0 /  0 /  0
 metal4            6086           389            6.39%             0 /  0 /  0
@@ -66,7 +66,7 @@ metal8            2142             0            0.00%             0 /  0 /  0
 metal9            1190             0            0.00%             0 /  0 /  0
 metal10           1190             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47467          2445            5.15%             0 /  0 /  0
+Total            42571          2445            5.74%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/cugr_adjustment2.ok
+++ b/src/grt/test/cugr_adjustment2.ok
@@ -32,7 +32,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480          9792          60.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918          7167          60.00%
 metal3     Horizontal      24480          9792          60.00%
 metal4     Vertical        12172          4869          60.00%
@@ -55,7 +55,7 @@ Bottleneck:            (2, 16, 16)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1            9792             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2            7167          1099           15.33%             0 /  0 /  0
 metal3            9792          1251           12.78%             0 /  0 /  0
 metal4            4869            60            1.23%             0 /  0 /  0
@@ -66,7 +66,7 @@ metal8            1714             0            0.00%             0 /  0 /  0
 metal9            1190             0            0.00%             0 /  0 /  0
 metal10           1190             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47193          2445            5.18%             0 /  0 /  0
+Total            37401          2445            6.54%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/cugr_adjustment3.ok
+++ b/src/grt/test/cugr_adjustment3.ok
@@ -32,7 +32,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480          2448          90.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918          1792          90.00%
 metal3     Horizontal      24480          2448          90.00%
 metal4     Vertical        12172          1217          90.00%
@@ -63,7 +63,7 @@ Bottleneck:            (1, 9, 20)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1            2448             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2            1792           579           32.31%             0 /  0 /  8
 metal3            2448           808           33.01%             0 /  0 /  0
 metal4            1217           262           21.53%             0 /  0 /  0
@@ -74,7 +74,7 @@ metal8            1190           133           11.18%             0 /  0 /  0
 metal9            1190            65            5.46%             0 /  0 /  0
 metal10           1190            81            6.81%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            15106          2555           16.91%             0 /  0 /  8
+Total            12658          2555           20.18%             0 /  0 /  8
 
 [INFO GRT-0018] Total wirelength: 10764 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/est_rc_cugr1.ok
+++ b/src/grt/test/est_rc_cugr1.ok
@@ -31,7 +31,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480         24480          0.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918         17918          0.00%
 metal3     Horizontal      24480         24480          0.00%
 metal4     Vertical        12172         12172          0.00%
@@ -54,7 +54,7 @@ Bottleneck:            (8, 0, 4)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1           24480             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2           17918          1179            6.58%             0 /  0 /  0
 metal3           24480          1215            4.96%             0 /  0 /  0
 metal4           12172             0            0.00%             0 /  0 /  0
@@ -65,7 +65,7 @@ metal8            4284             0            0.00%             0 /  0 /  0
 metal9            2142             0            0.00%             0 /  0 /  0
 metal10           2142             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total           116314          2445            2.10%             0 /  0 /  0
+Total            91834          2445            2.66%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/gcd_cugr.ok
+++ b/src/grt/test/gcd_cugr.ok
@@ -32,7 +32,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480         24480          0.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918         17918          0.00%
 metal3     Horizontal      24480         24480          0.00%
 metal4     Vertical        12172         12172          0.00%
@@ -55,7 +55,7 @@ Bottleneck:            (8, 0, 4)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1           24480             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2           17918          1179            6.58%             0 /  0 /  0
 metal3           24480          1215            4.96%             0 /  0 /  0
 metal4           12172             0            0.00%             0 /  0 /  0
@@ -66,7 +66,7 @@ metal8            4284             0            0.00%             0 /  0 /  0
 metal9            2142             0            0.00%             0 /  0 /  0
 metal10           2142             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total           116314          2445            2.10%             0 /  0 /  0
+Total            91834          2445            2.66%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 10354 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/incremental_update_net.ok
+++ b/src/grt/test/incremental_update_net.ok
@@ -31,7 +31,7 @@ Routing layers:      8
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal       5712          5712          0.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical         4208           842          79.99%
 metal3     Horizontal       5712          1714          69.99%
 metal4     Vertical         2848          1424          50.00%
@@ -52,7 +52,7 @@ Bottleneck:            (6, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1            5712             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2             842             0            0.00%             0 /  0 /  0
 metal3            1714            27            1.58%             0 /  0 /  0
 metal4            1424            12            0.84%             0 /  0 /  0
@@ -61,7 +61,7 @@ metal6            1424             8            0.56%             0 /  0 /  0
 metal7             496             0            0.00%             0 /  0 /  0
 metal8             496             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            13540            47            0.35%             0 /  0 /  0
+Total             7828            47            0.60%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 319 um
 [INFO GRT-0014] Routed nets: 5

--- a/src/grt/test/ndr_1w_3s_cugr.ok
+++ b/src/grt/test/ndr_1w_3s_cugr.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -47,14 +47,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             4            0.02%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            42            0.76%             0 /  0 /  0
 met2              6471            73            1.13%             0 /  0 /  0
 met3              7012           116            1.65%             0 /  0 /  0
 met4              5402            19            0.35%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           254            0.53%             0 /  0 /  0
+Total            25950           250            0.96%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/ndr_2w_3s_cugr.ok
+++ b/src/grt/test/ndr_2w_3s_cugr.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -47,14 +47,14 @@ Bottleneck:            (1, 17, 27)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             4            0.02%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            46            0.83%             0 /  0 /  0
 met2              6471            81            1.25%             0 /  0 /  0
 met3              7012           129            1.84%             0 /  0 /  0
 met4              5402            21            0.39%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           281            0.59%             0 /  0 /  0
+Total            25950           277            1.07%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/ndr_multi_cugr.ok
+++ b/src/grt/test/ndr_multi_cugr.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -47,14 +47,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             3            0.01%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            39            0.71%             0 /  0 /  0
 met2              6471            71            1.10%             0 /  0 /  0
 met3              7012           109            1.55%             0 /  0 /  0
 met4              5402            18            0.33%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           240            0.51%             0 /  0 /  0
+Total            25950           237            0.91%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/ndr_rrr_cugr.ok
+++ b/src/grt/test/ndr_rrr_cugr.ok
@@ -37,7 +37,7 @@ Routing layers:      10
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-metal1     Horizontal      24480          2448          90.00%
+metal1     Horizontal          0             0          0.00%
 metal2     Vertical        17918          1792          90.00%
 metal3     Horizontal      24480          2448          90.00%
 metal4     Vertical        12172          1217          90.00%
@@ -70,7 +70,7 @@ Bottleneck:            (1, 9, 20)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-metal1            2448             0            0.00%             0 /  0 /  0
+metal1               0             0            0.00%             0 /  0 /  0
 metal2            1792           582           32.48%             0 /  0 /  5
 metal3            2448           825           33.70%             0 /  0 /  0
 metal4            1217           298           24.49%             0 /  0 /  0
@@ -81,7 +81,7 @@ metal8            1190           152           12.77%             0 /  0 /  0
 metal9            1190            27            2.27%             0 /  0 /  0
 metal10           1190            42            3.53%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            15106          2608           17.26%             0 /  0 /  5
+Total            12658          2608           20.60%             0 /  0 /  5
 
 [INFO GRT-0018] Total wirelength: 10921 um
 [INFO GRT-0014] Routed nets: 563

--- a/src/grt/test/ndr_upper_layers_cugr.ok
+++ b/src/grt/test/ndr_upper_layers_cugr.ok
@@ -31,7 +31,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -50,14 +50,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             3            0.01%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            55            1.00%             0 /  0 /  0
 met2              6471            66            1.02%             0 /  0 /  0
 met3              7012            78            1.11%             0 /  0 /  0
 met4              5402            18            0.33%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           220            0.46%             0 /  0 /  0
+Total            25950           217            0.84%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/pin_access1_cugr.ok
+++ b/src/grt/test/pin_access1_cugr.ok
@@ -61,7 +61,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555          5511          80.00%
 met2       Vertical        21571          6471          70.00%
 met3       Horizontal      14023          7012          50.00%
@@ -80,14 +80,14 @@ Bottleneck:            (5, 0, 0)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             3            0.01%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5511            22            0.40%             0 /  0 /  0
 met2              6471            71            1.10%             0 /  0 /  0
 met3              7012            74            1.06%             0 /  0 /  0
 met4              5402            15            0.28%             0 /  0 /  0
 met5              1554             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            47521           185            0.39%             0 /  0 /  0
+Total            25950           182            0.70%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1584 um
 [INFO GRT-0014] Routed nets: 15

--- a/src/grt/test/pin_access2_cugr.ok
+++ b/src/grt/test/pin_access2_cugr.ok
@@ -62,7 +62,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        25000         25000          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      25777          5155          80.00%
 met2       Vertical        24693          7408          70.00%
 met3       Horizontal      15984          7992          50.00%
@@ -83,14 +83,14 @@ Bottleneck:            (1, 19, 13)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              25000            47            0.19%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1              5155           686           13.31%             0 /  0 /  0
 met2              7408          1456           19.65%             0 /  0 /  0
 met3              7992          1286           16.09%             0 /  0 /  0
 met4              5849           276            4.72%             0 /  0 /  0
 met5              1800             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            53204          3751            7.05%             0 /  0 /  0
+Total            28204          3704           13.13%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 30672 um
 [INFO GRT-0014] Routed nets: 411

--- a/src/grt/test/soft_ndr_4w_6s_cugr.ok
+++ b/src/grt/test/soft_ndr_4w_6s_cugr.ok
@@ -28,7 +28,7 @@ Routing layers:      6
           Routing      Original      Derated      Resource
 Layer     Direction    Resources     Resources    Reduction (%)
 ---------------------------------------------------------------
-li1        Vertical        21571         21571          0.00%
+li1        Vertical            0             0          0.00%
 met1       Horizontal      27555         13777          50.00%
 met2       Vertical        21571         10786          50.00%
 met3       Horizontal      14023          4207          70.00%
@@ -53,14 +53,14 @@ Bottleneck:            (3, 15, 21)
 [INFO GRT-0096] Final congestion report:
 Layer         Resource        Demand        Usage (%)    Max H / Max V / Total Congestion
 ---------------------------------------------------------------------------------------
-li1              21571             6            0.03%             0 /  0 /  0
+li1                  0             0            0.00%             0 /  0 /  0
 met1             13777           199            1.44%             0 /  0 /  0
 met2             10786           129            1.20%             0 /  0 /  0
 met3              4207            25            0.59%             0 /  0 /  0
 met4              3241            13            0.40%             0 /  0 /  0
 met5              1413             0            0.00%             0 /  0 /  0
 ---------------------------------------------------------------------------------------
-Total            54995           372            0.68%             0 /  0 /  0
+Total            33424           366            1.10%             0 /  0 /  0
 
 [INFO GRT-0018] Total wirelength: 1641 um
 [INFO GRT-0014] Routed nets: 15


### PR DESCRIPTION
## Summary
Fixes CUGR treating layers below the min routing layer (M1/li1) as
routable. The GridGraph constructor handed sub-min layers full track
capacity and skipped their obstacle deduction, so the router saw them as
cheap, wide-open wiring on the most resistive layer while their usage was
invisible to overflow accounting.

Changes:
- Zero edge capacity for layers below min_routing_layer; gate obstacle
  deduction by min_routing_layer instead of the hardcoded "skip M1".
- Exclude sub-min layers from the GRT-0096 congestion report and from the
  dbGCellGrid export, matching FastRoute (those layers carry only
  pin-access via demand on 0-capacity edges).
- Add a guard (GRT-1254) that errors if wire is ever committed below the
  min routing layer, so the invariant is enforced rather than assumed.

## Type of Change
- Bug fix

## Impact
CUGR no longer routes wire on or reports capacity for layers below the
min routing layer. Congestion reports and the DRC/congestion viewer no
longer show sub-min layers. In-range layers, including their via usage,
are unaffected; routing guides are unchanged on all regression tests.

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass (all 18 grt cugr tests).
- [x] My code follows the repository's formatting guidelines.
- [x] I have included tests to prevent regressions (updated golden files
      for the affected CUGR tests).
- [x] I have signed my commits (DCO).

## Related Issues
N/A